### PR TITLE
feature/host scout evals

### DIFF
--- a/.buildkite/scripts/image-targets.ts
+++ b/.buildkite/scripts/image-targets.ts
@@ -6,6 +6,7 @@ export const IMAGE_TARGET_OWNERS: Readonly<Record<string, string>> = {
   "temporal-worker": "@shepherdjerred/temporal",
   "trmnl-dashboard": "@shepherdjerred/trmnl-dashboard",
   "scout-for-lol": "@scout-for-lol/backend",
+  "scout-evals": "@scout-for-lol/evals",
   "discord-plays-pokemon": "@discord-plays-pokemon/backend",
   "discord-plays-mario-kart": "@discord-plays-mario-kart/backend",
 };

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -8,6 +8,7 @@ const applicationTargets = [
   "temporal-worker",
   "trmnl-dashboard",
   "scout-for-lol",
+  "scout-evals",
   "discord-plays-pokemon",
   "discord-plays-mario-kart",
 ] as const;

--- a/.buildkite/scripts/select-image-targets.test.ts
+++ b/.buildkite/scripts/select-image-targets.test.ts
@@ -135,9 +135,11 @@ describe("selectImageTargets", () => {
     expect(await select(["packages/birmel/package.json"])).toEqual(["birmel"]);
   });
 
-  test("selects Scout for its shared base TypeScript config", async () => {
+  test("selects both Scout images for its shared base TypeScript config", async () => {
+    // The evals image build copies this file and its runtime tsconfig extends
+    // it, so a change to it must rebuild scout-evals alongside scout-for-lol.
     expect(await select(["packages/scout-for-lol/tsconfig.base.json"])).toEqual(
-      ["scout-for-lol"],
+      ["scout-evals", "scout-for-lol"],
     );
   });
 

--- a/.buildkite/scripts/select-image-targets.test.ts
+++ b/.buildkite/scripts/select-image-targets.test.ts
@@ -391,12 +391,14 @@ describe("patch attribution", () => {
     ).toEqual(["birmel"]);
   });
 
-  test("a patch resolved through several scout packages selects only scout", async () => {
+  test("a patch resolved through several scout packages selects only scout images", async () => {
     // twisted@1.82.0 is the live resolution across scout's closure (backend,
-    // data), so its patch attributes to exactly the scout image. (Stale
-    // patches — keys no closure resolves — can no longer exist:
+    // data), so its patch attributes to exactly the images whose closures
+    // resolve it: the backend and the evals app (via @scout-for-lol/data).
+    // (Stale patches — keys no closure resolves — can no longer exist:
     // scripts/check-patched-deps.ts fails verify on them.)
     expect(await select(["patches/twisted@1.82.0.patch"])).toEqual([
+      "scout-evals",
       "scout-for-lol",
     ]);
   });

--- a/.buildkite/scripts/select-image-targets.ts
+++ b/.buildkite/scripts/select-image-targets.ts
@@ -81,6 +81,11 @@ const TARGET_PATH_PREFIXES: Readonly<Record<string, readonly string[]>> = {
     "packages/scout-for-lol/scripts/contract-hash.ts",
     "packages/scout-for-lol/tsconfig.base.json",
   ],
+  // The evals image build copies packages/scout-for-lol/tsconfig.base.json and
+  // its runtime tsconfig extends it, but that file sits above every workspace
+  // package dir, so the closure walk never attributes it. Rebuild scout-evals
+  // when it changes so the image never pins stale compiler configuration.
+  "scout-evals": ["packages/scout-for-lol/tsconfig.base.json"],
   // Temporal compiles toolkit into the worker image as an embedded CLI, but
   // toolkit is deliberately not a runtime workspace dependency.
   "temporal-worker": ["packages/toolkit/"],

--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -260,6 +260,29 @@ const commands: Record<
       VIDEOS_DIR: "/tmp/videos",
     },
   },
+  "scout-evals": {
+    command: [
+      "set -eu",
+      "cd /app/packages/scout-for-lol/packages/evals",
+      "test -f dist/client/index.html",
+      "bun src/server/index.ts >/tmp/scout-evals-smoke.log 2>&1 &",
+      "pid=$!",
+      "trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT",
+      "for _ in $(seq 1 30); do",
+      "  if grep -Fq 'Scout review evals:' /tmp/scout-evals-smoke.log; then exit 0; fi",
+      "  if ! kill -0 $pid; then cat /tmp/scout-evals-smoke.log; exit 1; fi",
+      "  sleep 1",
+      "done",
+      "cat /tmp/scout-evals-smoke.log",
+      "exit 1",
+    ].join("\n"),
+    // Proves the server boots as uid 1000 and creates its WAL-mode SQLite
+    // (plus sidecar files) at a fresh path — the exact K8s deployment shape.
+    env: {
+      SCOUT_EVAL_DATABASE_PATH: "/tmp/scout-evals-smoke.sqlite",
+      SCOUT_EVAL_HOSTNAME: "127.0.0.1",
+    },
+  },
   "tasknotes-server": {
     command: [
       "set -eu",

--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,7 @@ packages/docs/wiki/*
 # context AND out of scoped runtime source COPYs (e.g. scout's report package).
 **/__snapshots__
 packages/sjer.red/src/content
+# The operator's local eval SQLite databases (ratings + Beta corpus snapshot)
+# must never reach an image: the scout-evals runtime COPYs this package's
+# whole source tree.
+packages/scout-for-lol/packages/evals/data

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -81,6 +81,7 @@ group "app" {
     "temporal-worker",
     "trmnl-dashboard",
     "scout-for-lol",
+    "scout-evals",
     "discord-plays-pokemon",
     "discord-plays-mario-kart",
   ]
@@ -109,6 +110,14 @@ target "tasknotes-server" {
   tags       = imagetags("tasknotes-server")
   cache-from = cachefrom("tasknotes-server")
   cache-to   = cacheto("tasknotes-server")
+}
+
+target "scout-evals" {
+  inherits   = ["_app"]
+  dockerfile = "packages/scout-for-lol/packages/evals/Dockerfile"
+  tags       = imagetags("scout-evals")
+  cache-from = cachefrom("scout-evals")
+  cache-to   = cacheto("scout-evals")
 }
 
 target "starlight-karma-bot" {

--- a/packages/docs/plans/2026-08-02_host-scout-evals.md
+++ b/packages/docs/plans/2026-08-02_host-scout-evals.md
@@ -1,0 +1,96 @@
+---
+id: plan-2026-08-02-host-scout-evals
+type: plan
+status: in-progress
+board: false
+---
+
+# Host the Scout Review Evals app on the homelab
+
+## Context
+
+`@scout-for-lol/evals` (packages/scout-for-lol/packages/evals) is a loopback-only Bun app
+(Hono/tRPC + built Vite client + one WAL-mode SQLite file) for rating post-match review
+datasets. Hosting it makes rating reachable from any tailnet device and gives the DB a durable,
+Velero-backed home. Name everywhere: **`scout-evals`** (image, chart, namespace, tailnet host —
+verified no conflicts).
+
+## Decisions (user-confirmed)
+
+| Decision       | Choice                                                                                                                                              |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trust boundary | Tailscale only (TailscaleIngress, no app auth, never Funnel)                                                                                        |
+| Durability     | PVC (`ZfsNvmeVolume`, 1 GiB, backup **enabled**)                                                                                                    |
+| Image          | Built/pushed by the standard Buildkite bake flow, digest-pinned via commit-back                                                                     |
+| Draft flow     | **Remote push over tailnet**: new draft transfer format + `datasets.pushDraft` tRPC mutation + `dataset:push` CLI; materialization/creds stay local |
+| Seed data      | Hosted DB starts empty                                                                                                                              |
+
+Draft-push semantics: drafts carry metadata + cases + generations (no ratings); re-push is an
+**additive merge** (insert missing case/generation ids, canonical-JSON-verify existing ones,
+hard-reject content drift or a finalized target). Reuses `dataset-transfer.ts` sha256 machinery.
+Verified: generation `sequence` is `INTEGER PRIMARY KEY AUTOINCREMENT` (migrations.ts:79) so
+appended generations order correctly; existing finalized export/import stays untouched.
+
+## Part A — Evals app (packages/scout-for-lol/packages/evals)
+
+- `src/server/index.ts` — add `host` option: `--host` ?? `SCOUT_EVAL_HOSTNAME` env ?? `"127.0.0.1"`; pass to `Bun.serve`. dev.ts/e2e untouched.
+- `src/shared/schema.ts` — add `DraftTransferMetadataSchema` (status literal `"draft"`), `DraftTransferCaseSchema` (no ratings), `DatasetDraftTransferPayloadSchema` + checksummed `DatasetDraftTransferSchema`; extract shared case-dedup superRefine helper (file must stay <500 lines).
+- `src/server/dataset-transfer.ts` — parameterize checksum helpers; add `createDraftTransfer` / `validateDraftTransfer`.
+- NEW `src/server/draft-transfer-store.ts` — `exportDraftFromDatabase` (draft-only snapshot in one transaction) + `pushDraftIntoDatabase` (additive merge per semantics above), mirroring `dataset-transfer-store.ts` structure.
+- `src/server/store.ts` — `exportDraft` / `pushDraft` methods; mirror on the in-memory e2e test store.
+- `src/server/trpc.ts` — `datasets.pushDraft` mutation (input `DatasetDraftTransferSchema`, output `DatasetSummarySchema`).
+- NEW `src/scripts/push-dataset.ts` — open local store, `exportDraft`, `createTRPCClient<AppRouter>` + `httpBatchLink({ url: <server>/trpc })`, `datasets.pushDraft.mutate(...)`. Flags: `--dataset`, `--server` (?? `SCOUT_EVAL_REMOTE_URL`), `--database`.
+- `package.json` — `"dataset:push"` script. Docs: `README.md` + workflow table in `packages/scout-for-lol/CLAUDE.md`.
+- Tests: NEW `src/server/draft-transfer-store.test.ts` (round-trip, tamper reject, finalized-collision reject, additive re-push, content-drift reject, ratings survive re-push); extend `src/server/dataset-transfer-api.test.ts` with pushDraft over `app.request`.
+
+## Part B — Image + CI
+
+- NEW `packages/scout-for-lol/packages/evals/Dockerfile` (repo-root context, modeled on `packages/tasknotes-server/Dockerfile`): `prod-deps` (manifest-only COPY, `bun install --frozen-lockfile --production --filter '@scout-for-lol/evals'`) → **`build`** (dev-deps install + `vite build` → `dist/client`) → `runtime` (prod-deps tree + evals sources + built `dist/client`; `WORKDIR /app/packages/scout-for-lol/packages/evals` so cwd-relative `./dist/client` serving works; `CMD ["bun", "src/server/index.ts"]`; EXPOSE 7341) → `smoke` (uid 1000, `smoke-app-in-image.ts`) → empty `image` stage. Verified: server/client import graph never touches `@scout-for-lol/data` (materialization-only) — the 82 MB data package stays out of the image.
+- `.buildkite/scripts/image-targets.ts` — `"scout-evals": "@scout-for-lol/evals"`.
+- `.buildkite/scripts/migration-core.ts` — add to `applicationTargets`.
+- `docker-bake.hcl` — `scout-evals` target block + `group "app"`.
+- `.buildkite/scripts/smoke-app-in-image.ts` — `scout-evals` entry (boot with `SCOUT_EVAL_DATABASE_PATH=/tmp/...`, poll for `Scout review evals:` ready line — also proves uid-1000 WAL DB creation).
+- `packages/homelab/src/cdk8s/src/versions.ts` — pin key `"shepherdjerred/scout-evals"` with placeholder `0.0.0@sha256:<64 zeros>` + `// not managed by renovate`; first main build's commit-back lane PRs the real tag@digest.
+- Evals `package.json`: `docker:build` + `smoke` scripts; NEW `scripts/smoke.ts` (clone tasknotes'). Turbo needs no changes.
+- Fix `.buildkite` test fixtures that enumerate targets (`select-image-targets.test.ts`, `bake-images.test.ts`, `application-image-inputs.test.ts`, `ci-lane-coverage.test.ts` — failures will name each spot).
+
+## Part C — Homelab (packages/homelab/src/cdk8s)
+
+- NEW `src/cdk8s-charts/scout-evals.ts` — Chart + Namespace `scout-evals`, NetworkPolicies (ingress from `tailscale` ns + prometheus:7341; egress DNS only — server makes no outbound calls).
+- NEW `src/resources/scout-evals.ts` — `createScoutEvalsDeployment`: replicas 1, `DeploymentStrategy.recreate()` (RWO PVC + single-writer SQLite), `fsGroup: 1000`; container via `withCommonProps` — image from versions pin, port 7341, env `SCOUT_EVAL_HOSTNAME=0.0.0.0` + `SCOUT_EVAL_DATABASE_PATH=/data/scout-review-evals.sqlite`, securityContext user/group 1000 + `ensureNonRoot`, resources 50m/500m CPU + 128Mi/512Mi mem, startup/liveness/readiness probes on `/health`; `ZfsNvmeVolume` "scout-evals-data" (1 GiB) mounted at `/data`; Service; `TailscaleIngress { host: "scout-evals", probePath: "/health" }`. No secrets.
+- `src/backup-policy/pvc-backup-policy.json` — `scout-evals/scout-evals-data` **enabled** ("human ratings live only here"; name must match construct id or synth throws).
+- NEW `helm/scout-evals/Chart.yaml` (clone tasknotes template).
+- NEW `src/resources/argo-applications/scout-evals.ts` + wire into `src/cdk8s-charts/apps.ts`.
+- `src/setup-charts.ts` — `createScoutEvalsChart(app)` before `createServiceProbesChart`.
+
+## PR strategy
+
+Worktree + one native gh-stack, two layers (real sequencing reason: ArgoCD must not deploy the
+placeholder pin):
+
+1. **Layer 1: Parts A + B** — app changes, Dockerfile, CI wiring, placeholder pin. On merge,
+   main builds/pushes the image and commit-back auto-PRs the real tag@digest.
+2. **Layer 2: Part C** — homelab chart + ArgoCD app. Merge after the commit-back pin lands.
+
+## Verification
+
+Local:
+
+- `bunx turbo run typecheck test lint --filter=@scout-for-lol/evals`; `bunx turbo run test:e2e --filter=@scout-for-lol/evals`.
+- Draft-push loop against a second local server: `SCOUT_EVAL_DATABASE_PATH=/tmp/remote.sqlite bun run start -- --port 7345`; `dataset:push --dataset <id> --server http://127.0.0.1:7345`; extend draft via materialize spec `datasetId`, re-push, confirm additive merge + surviving ratings in the 7345 UI.
+- Image: `bun run --filter=@scout-for-lol/evals docker:build` + `bunx turbo run smoke --filter=@scout-for-lol/evals`; sanity-check image size (no data package).
+- `cd .buildkite && bun test` (target-enumeration fixtures); `cd packages/homelab/src/cdk8s && bun run build && bun run test` (helm render, backup policy, resources checks pick the chart up automatically).
+
+On-cluster (after layer 2 merges):
+
+- Commit-back PR pinned real digest; ArgoCD `scout-evals` Healthy; pod Running, PVC Bound.
+- Tailnet: `curl https://scout-evals.<tailnet>.ts.net/health` → `{"status":"ok"}`; UI loads; DB empty. Confirm unreachable off-tailnet.
+- E2E: push a real draft over the tailnet, rate a case in the hosted UI, re-push an extended draft, confirm merge.
+- Confirm next Velero run includes the PVC.
+
+## Risks
+
+- `.buildkite` fixture edits not fully enumerated — test failures will name them.
+- `readOnlyRootFilesystem: false` initially (Bun may write under `$HOME`); tightening is a follow-up.
+- Large drafts ship as one JSON POST — fine on tailnet; chunking only if ever needed.
+- No app auth by design: anyone on the tailnet can rate/push. Accepted.

--- a/packages/docs/plans/2026-08-02_host-scout-evals.md
+++ b/packages/docs/plans/2026-08-02_host-scout-evals.md
@@ -94,3 +94,42 @@ On-cluster (after layer 2 merges):
 - `readOnlyRootFilesystem: false` initially (Bun may write under `$HOME`); tightening is a follow-up.
 - Large drafts ship as one JSON POST — fine on tailnet; chunking only if ever needed.
 - No app auth by design: anyone on the tailnet can rate/push. Accepted.
+
+## Session Log — 2026-08-03
+
+### Done
+
+- Layer 1 (PR #1955, `feature/host-scout-evals`): shipped the app + image layer.
+  - Hosted-mode app support: additive draft transfer over the tailnet
+    (`src/server/dataset-transfer.ts`, `src/server/draft-transfer-store.ts` and
+    tests, `src/scripts/push-dataset.ts`, schema and store wiring), documented in
+    `packages/scout-for-lol/packages/evals/README.md` ("Push A Draft To The
+    Hosted Instance").
+  - Image build: `packages/scout-for-lol/packages/evals/Dockerfile`, smoke
+    (`scripts/smoke.ts`, `.buildkite/scripts/smoke-app-in-image.ts`),
+    `docker-bake.hcl`, `.dockerignore`, and image-target wiring
+    (`scout-evals` in `.buildkite/scripts/image-targets.ts`).
+  - Placeholder image pin in `packages/homelab/src/cdk8s/src/versions.ts`
+    (commit-back replaces it with the real tag@digest after merge).
+- CI selector correctness: `.buildkite/scripts/select-image-targets.ts` now
+  rebuilds `scout-evals` when `packages/scout-for-lol/tsconfig.base.json`
+  changes (the evals Dockerfile copies that file and its runtime tsconfig
+  extends it), with the assertion updated in `select-image-targets.test.ts`.
+
+### Remaining
+
+- Layer 2 (PR #1956, `feature/scout-evals-homelab`, stacked on this): homelab
+  chart + ArgoCD app + `TailscaleIngress`. Merge after this PR's commit-back
+  pin lands. The human-facing wiki page for the hosted service and its tailnet
+  trust boundary belongs with that layer, where the deployment actually exists.
+- On-cluster verification (post layer-2 merge): ArgoCD `scout-evals` Healthy,
+  PVC Bound, tailnet health check, off-tailnet unreachable, Velero includes the
+  PVC. See the Verification section above.
+
+### Caveats
+
+- `readOnlyRootFilesystem: false` initially (Bun may write under `$HOME`);
+  tightening is a follow-up.
+- No app auth by design: anyone on the tailnet can rate/push. Accepted.
+- Draft transfers are additive merges that reject drift/checksum mismatch;
+  server-authored ratings always survive re-pushes.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -174,6 +174,10 @@ const versions = {
   // not managed by renovate
   "shepherdjerred/birmel":
     "2.0.0-7749@sha256:2afc31cb39cf67e37571644535ac93417fb5da79c401de318f3801b557c9c2ff",
+  // not managed by renovate — placeholder digest; CI version-commit-back fills
+  // the real digest after the first successful scout-evals image push.
+  "shepherdjerred/scout-evals":
+    "0.0.0-0@sha256:0000000000000000000000000000000000000000000000000000000000000000",
   // not managed by renovate
   "shepherdjerred/discord-plays-pokemon":
     "2.0.0-7794@sha256:bbad9108923e3512673a1ad110a1c385aeb2742fb6e2fa8db25817e285cd46e1",

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -166,6 +166,7 @@ The full operator workflow (flags and examples in `packages/evals/README.md`):
 | `bun run --filter=@scout-for-lol/evals sync-beta`                                        | Snapshot a sanitized Beta profile corpus into the local SQLite snapshot used by discovery/materialization. |
 | `AWS_PROFILE=seaweedfs bun run --filter=@scout-for-lol/evals discover -- …`              | Discover candidate matches from the `scout-beta` bucket against the snapshot.                              |
 | `bun run --filter=@scout-for-lol/evals materialize -- --spec <file>`                     | Materialize a new draft — or extend an existing draft via the spec's `datasetId` — with S3/model cases.    |
+| `bun run --filter=@scout-for-lol/evals dataset:push -- --dataset <id> --server <url>`    | Push a locally-materialized draft to the hosted instance over the tailnet (additive, never overwrites).    |
 | `bun run --filter=@scout-for-lol/evals dataset:export -- --dataset <id> --output <file>` | Export a finalized dataset to a checksummed, generation-set-bound transfer file.                           |
 | `bun run --filter=@scout-for-lol/evals dataset:import -- --input <file>`                 | Import a transfer file into another eval database (rejects tampered checksums or freshness bindings).      |
 

--- a/packages/scout-for-lol/packages/evals/Dockerfile
+++ b/packages/scout-for-lol/packages/evals/Dockerfile
@@ -1,0 +1,91 @@
+# syntax=docker/dockerfile:1-labs@sha256:7d49dad25a050e14338ba7028b0460243f9d911dedc160a8fe20c34738fef3af
+# scout-evals image. Build context is the REPO ROOT (single Bun workspace, one
+# root bun.lock, isolated linker). Built via `bun run docker:build` in this
+# package (which passes `-f Dockerfile ../../../..`).
+#
+# Multi-stage: prod-deps installs the production-only dependency closure from
+# the workspace manifests; build installs dev deps and runs `vite build` for
+# the client bundle; runtime COPYs the prod tree, this package's source, and
+# the built client — it never runs `bun install`. The @scout-for-lol/data
+# package (82 MB of splash assets) is deliberately NOT copied: only the
+# local-only materialization/discovery scripts import it, never the server or
+# client, so its dangling workspace symlink is never resolved at runtime.
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS base
+WORKDIR /app
+
+# ── prod-deps: production-only node_modules, cached on manifests ────────────
+# Copying just the workspace package.json files (plus the lockfile, bunfig, and
+# patches) means this filtered install only invalidates when a
+# manifest/lockfile/patch changes — not on every source edit. `--frozen-lockfile`
+# requires every workspace member's package.json present, so the globs below
+# enumerate every member. The root .dockerignore keeps node_modules/dist/.git
+# and this package's local data/ SQLite out of context.
+FROM base AS prod-deps
+COPY --parents \
+  package.json bun.lock bunfig.toml patches/ scripts/package.json \
+  packages/*/package.json packages/*/packages/*/package.json \
+  packages/docs/wiki/package.json \
+  packages/homelab/src/cdk8s/package.json \
+  packages/homelab/src/helm-types/package.json \
+  packages/scout-for-lol/packages/desktop/src-tauri/package.json \
+  ./
+RUN bun install --frozen-lockfile --production --filter '@scout-for-lol/evals'
+
+# ── build: dev deps + vite build for the client bundle ──────────────────────
+FROM base AS build
+COPY --parents \
+  package.json bun.lock bunfig.toml patches/ scripts/package.json \
+  packages/*/package.json packages/*/packages/*/package.json \
+  packages/docs/wiki/package.json \
+  packages/homelab/src/cdk8s/package.json \
+  packages/homelab/src/helm-types/package.json \
+  packages/scout-for-lol/packages/desktop/src-tauri/package.json \
+  ./
+RUN bun install --frozen-lockfile --filter '@scout-for-lol/evals'
+# The evals tsconfig extends scout's own tsconfig.base.json (not the root one).
+COPY --parents \
+  packages/scout-for-lol/tsconfig.base.json \
+  packages/scout-for-lol/packages/evals \
+  ./
+RUN cd packages/scout-for-lol/packages/evals && bun run build
+
+# ── runtime: COPY-only — no install, no build tooling, no network ───────────
+FROM base AS runtime
+# The isolated-linker tree uses relative symlinks (store at node_modules/.bun),
+# so copying the whole install root between same-rooted stages is safe. Kept
+# BEFORE the source COPY so a source edit doesn't re-push this layer.
+COPY --from=prod-deps /app/ /app/
+COPY --parents \
+  packages/scout-for-lol/tsconfig.base.json \
+  packages/scout-for-lol/packages/evals \
+  ./
+COPY --from=build \
+  /app/packages/scout-for-lol/packages/evals/dist/client \
+  /app/packages/scout-for-lol/packages/evals/dist/client
+
+ENV NODE_ENV=production
+
+# app.ts serves ./dist/client cwd-relative, so the workdir must be the package.
+WORKDIR /app/packages/scout-for-lol/packages/evals
+
+# No auth by design: the deployment fronts this with a tailnet-only Tailscale
+# ingress. SCOUT_EVAL_HOSTNAME / SCOUT_EVAL_DATABASE_PATH configure the bind
+# and the PVC-backed SQLite path; both default to local-dev values.
+EXPOSE 7341
+
+CMD ["bun", "src/server/index.ts"]
+
+FROM runtime AS smoke
+# The smoke harness ships in CI context only — the scoped source COPY
+# excludes .buildkite, so stage it here (never in the pushed image stage).
+COPY .buildkite/scripts/smoke-app-in-image.ts /app/.buildkite/scripts/smoke-app-in-image.ts
+ARG SMOKE_TARGET=scout-evals
+ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+# Smoke runs as the non-root deploy uid (1000), never root: it must prove the
+# server can create its WAL-mode SQLite (and sidecar files) as uid 1000, the
+# same uid the K8s deployment runs with. HOME points at /tmp for tool caches.
+USER 1000:1000
+ENV HOME=/tmp
+RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
+
+FROM runtime AS image

--- a/packages/scout-for-lol/packages/evals/README.md
+++ b/packages/scout-for-lol/packages/evals/README.md
@@ -1,6 +1,6 @@
 # Scout Review Evals
 
-Local calibration app for immutable post-match review datasets. It stores raw
+Calibration app for immutable post-match review datasets. It stores raw
 source artifacts, processed match context, exact prompts, model settings,
 generations, human ratings, and style-batch freshness ratings in SQLite.
 
@@ -12,6 +12,13 @@ bun run --filter=@scout-for-lol/evals dev
 
 The API binds to `127.0.0.1:7341`; Vite binds to `127.0.0.1:7342`.
 `SCOUT_EVAL_DATABASE_PATH` overrides the default database under `data/`.
+
+The production server (`bun run start`) binds loopback by default; `--host` or
+`SCOUT_EVAL_HOSTNAME` widens the bind. The app has no auth, so any non-loopback
+bind must sit behind a real trust boundary — the hosted instance runs on the
+homelab behind a tailnet-only Tailscale ingress at
+`https://scout-evals.<tailnet>.ts.net`, where the tailnet is the auth layer.
+Never expose it publicly (no Funnel).
 
 ## Discover Candidates
 
@@ -67,6 +74,31 @@ Raw S3 objects do not identify Scout aliases or tracked-player membership. The
 sanitized Beta snapshot supplies that mapping and materialization fails if the
 target is absent. API keys remain server-side and are never included in the
 Vite bundle.
+
+## Push A Draft To The Hosted Instance
+
+Materialization stays local (it needs `OPENAI_API_KEY`, AWS credentials, and
+the Beta corpus snapshot), but rating happens on the hosted app. Move a
+locally-materialized draft over the tailnet with:
+
+```bash
+bun run --filter=@scout-for-lol/evals dataset:push -- \
+  --dataset <dataset-id> \
+  --server https://scout-evals.<tailnet>.ts.net
+```
+
+`SCOUT_EVAL_REMOTE_URL` supplies the server when `--server` is omitted;
+`--database` / `SCOUT_EVAL_DATABASE_PATH` select the local source database.
+
+Draft transfers carry dataset metadata, frozen case artifacts, and generations
+— never human or freshness ratings, which are authored on the receiving
+instance. Pushes are additive merges: re-pushing after extending the draft
+(`materialize` with the spec's `datasetId`) inserts only the missing cases and
+generations, verifies existing records are byte-identical (canonical-JSON), and
+rejects any drift, checksum mismatch, or finalized target instead of
+overwriting. A push that adds a generation to a style invalidates that style's
+freshness rating on the server, exactly like recording a generation locally.
+Ratings authored on the server always survive re-pushes.
 
 ## Transfer A Finalized Dataset
 

--- a/packages/scout-for-lol/packages/evals/package.json
+++ b/packages/scout-for-lol/packages/evals/package.json
@@ -10,6 +10,8 @@
     "dataset:export": "bun run src/scripts/export-dataset.ts",
     "dataset:import": "bun run src/scripts/import-dataset.ts",
     "dataset:push": "bun run src/scripts/push-dataset.ts",
+    "docker:build": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/scout-evals:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t scout-evals:dev -f Dockerfile ../../../..",
+    "smoke": "bun scripts/smoke.ts",
     "launch": "bun run build && bun run src/server/index.ts --open",
     "materialize": "bun run src/scripts/materialize-dataset.ts",
     "start": "bun run src/server/index.ts",

--- a/packages/scout-for-lol/packages/evals/package.json
+++ b/packages/scout-for-lol/packages/evals/package.json
@@ -9,6 +9,7 @@
     "discover": "bun run src/scripts/discover-candidates.ts",
     "dataset:export": "bun run src/scripts/export-dataset.ts",
     "dataset:import": "bun run src/scripts/import-dataset.ts",
+    "dataset:push": "bun run src/scripts/push-dataset.ts",
     "launch": "bun run build && bun run src/server/index.ts --open",
     "materialize": "bun run src/scripts/materialize-dataset.ts",
     "start": "bun run src/server/index.ts",

--- a/packages/scout-for-lol/packages/evals/scripts/smoke.ts
+++ b/packages/scout-for-lol/packages/evals/scripts/smoke.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+/**
+ * Smoke test for the scout-evals image.
+ *
+ * The server starts fully with defaults (SQLite is created on demand and there
+ * is no external auth), so success is a clean boot — the server reaching its
+ * ready log line. We run the container detached and poll its logs for that
+ * line, then tear the container down.
+ *
+ * Dependency-free: Bun.spawn only. Exits non-zero on failure and always removes
+ * the container (even on failure).
+ */
+const IMAGE = "scout-evals:dev";
+const CONTAINER = `smoke-scout-evals-${String(process.pid)}`;
+const READY_LOG = "Scout review evals:";
+const TIMEOUT_MS = 30_000;
+
+async function sh(cmd: string[]): Promise<{ code: number; stdout: string }> {
+  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  return { code, stdout: `${stdout}${stderr}` };
+}
+
+async function removeContainer(): Promise<void> {
+  await sh(["docker", "rm", "-f", CONTAINER]);
+}
+
+async function main(): Promise<void> {
+  await removeContainer();
+
+  const run = await sh([
+    "docker",
+    "run",
+    "-d",
+    "--name",
+    CONTAINER,
+    "-e",
+    "SCOUT_EVAL_DATABASE_PATH=/tmp/smoke-evals.sqlite",
+    "-e",
+    "SCOUT_EVAL_HOSTNAME=127.0.0.1",
+    IMAGE,
+  ]);
+  if (run.code !== 0) {
+    throw new Error(
+      `docker run failed (exit ${String(run.code)}):\n${run.stdout}`,
+    );
+  }
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const logs = await sh(["docker", "logs", CONTAINER]);
+    if (logs.stdout.includes(READY_LOG)) {
+      console.log("Smoke test passed: server reached its ready log line.");
+      return;
+    }
+    // If the container died before becoming ready, fail fast with its logs.
+    const state = await sh([
+      "docker",
+      "inspect",
+      "-f",
+      "{{.State.Running}}",
+      CONTAINER,
+    ]);
+    if (state.stdout.trim() === "false") {
+      throw new Error(
+        `Smoke test failed: container exited before becoming ready.\n\nLogs:\n${logs.stdout}`,
+      );
+    }
+    await Bun.sleep(1000);
+  }
+
+  const logs = await sh(["docker", "logs", CONTAINER]);
+  throw new Error(
+    `Smoke test failed: "${READY_LOG}" not seen within ${String(
+      TIMEOUT_MS / 1000,
+    )}s.\n\nLogs:\n${logs.stdout}`,
+  );
+}
+
+// Async IIFE instead of top-level await: these package tsconfigs
+// (CommonJS/Node16 module) reject TLA (same pattern as tasknotes-server).
+void (async () => {
+  try {
+    await main();
+  } finally {
+    await removeContainer();
+  }
+})();

--- a/packages/scout-for-lol/packages/evals/src/scripts/push-dataset.ts
+++ b/packages/scout-for-lol/packages/evals/src/scripts/push-dataset.ts
@@ -1,0 +1,36 @@
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { z } from "zod";
+
+import { argumentValue, evalDatabasePath } from "#lib/cli.ts";
+import { createEvalStore } from "#server/store.ts";
+import type { AppRouter } from "#server/trpc.ts";
+
+const OptionsSchema = z.strictObject({
+  databasePath: z.string().min(1),
+  datasetId: z.string().min(1),
+  serverUrl: z.url(),
+});
+
+const options = OptionsSchema.parse({
+  databasePath: evalDatabasePath(),
+  datasetId: argumentValue("--dataset"),
+  serverUrl: argumentValue("--server") ?? Bun.env["SCOUT_EVAL_REMOTE_URL"],
+});
+
+const store = createEvalStore(options.databasePath);
+try {
+  const transfer = store.exportDraft(options.datasetId);
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({ url: new URL("/trpc", options.serverUrl).toString() }),
+    ],
+  });
+  const summary = await client.datasets.pushDraft.mutate(transfer);
+  console.warn(
+    `Pushed draft ${summary.key} v${String(summary.version)} ` +
+      `(${summary.id}) to ${options.serverUrl}: ` +
+      `${String(summary.caseCount)} cases now on the server`,
+  );
+} finally {
+  store.close();
+}

--- a/packages/scout-for-lol/packages/evals/src/server/dataset-transfer-api.test.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/dataset-transfer-api.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { createEvalStore } from "#server/store.ts";
 import { appRouter } from "#server/trpc.ts";
-import { makeFinalizedRatedDataset } from "#testing/eval-fixtures.ts";
+import {
+  makeDraftDataset,
+  makeFinalizedRatedDataset,
+} from "#testing/eval-fixtures.ts";
 
 describe("dataset transfer tRPC API", () => {
   test("exports and imports through validated procedures", async () => {
@@ -32,6 +35,35 @@ describe("dataset transfer tRPC API", () => {
           sha256: "0".repeat(64),
         }),
       ).rejects.toThrow("Dataset export checksum mismatch");
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+
+  test("pushes drafts through the validated pushDraft procedure", async () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "api-draft-push");
+      const targetCaller = appRouter.createCaller({ store: target });
+
+      const transfer = source.exportDraft(fixture.datasetId);
+      const pushed = await targetCaller.datasets.pushDraft(transfer);
+      expect(pushed).toMatchObject({
+        id: fixture.datasetId,
+        key: "api-draft-push",
+        status: "draft",
+        caseCount: 1,
+      });
+      expect(target.exportDraft(fixture.datasetId)).toEqual(transfer);
+
+      await expect(
+        targetCaller.datasets.pushDraft({
+          ...transfer,
+          sha256: "0".repeat(64),
+        }),
+      ).rejects.toThrow("Draft transfer checksum mismatch");
     } finally {
       source.close();
       target.close();

--- a/packages/scout-for-lol/packages/evals/src/server/dataset-transfer.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/dataset-transfer.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 
 import {
+  DatasetDraftTransferPayloadSchema,
+  DatasetDraftTransferSchema,
   DatasetExportPayloadSchema,
   DatasetExportSchema,
+  type DatasetDraftTransfer,
+  type DatasetDraftTransferPayload,
   type DatasetExport,
   type DatasetExportPayload,
 } from "#shared/schema.ts";
@@ -36,7 +40,7 @@ function sortJsonValue(value: unknown): unknown {
   throw new TypeError(`Cannot serialize JSON value of type ${typeof value}`);
 }
 
-function canonicalJson(value: unknown): string {
+export function canonicalJson(value: unknown): string {
   return JSON.stringify(sortJsonValue(value));
 }
 
@@ -49,7 +53,7 @@ function payloadFromExport(datasetExport: DatasetExport): DatasetExportPayload {
   });
 }
 
-function payloadSha256(payload: DatasetExportPayload): string {
+function payloadSha256(payload: unknown): string {
   return new Bun.CryptoHasher("sha256")
     .update(canonicalJson(payload))
     .digest("hex");
@@ -93,4 +97,35 @@ export function parseDatasetExport(serialized: string): DatasetExport {
 export function serializeDatasetExport(value: unknown): string {
   const datasetExport = validateDatasetExport(value);
   return `${JSON.stringify(sortJsonValue(datasetExport), null, 2)}\n`;
+}
+
+function draftPayloadFromTransfer(
+  transfer: DatasetDraftTransfer,
+): DatasetDraftTransferPayload {
+  return DatasetDraftTransferPayloadSchema.parse({
+    schemaVersion: transfer.schemaVersion,
+    dataset: transfer.dataset,
+    cases: transfer.cases,
+  });
+}
+
+export function createDraftTransfer(
+  payload: DatasetDraftTransferPayload,
+): DatasetDraftTransfer {
+  const parsedPayload = DatasetDraftTransferPayloadSchema.parse(payload);
+  return DatasetDraftTransferSchema.parse({
+    ...parsedPayload,
+    sha256: payloadSha256(parsedPayload),
+  });
+}
+
+export function validateDraftTransfer(value: unknown): DatasetDraftTransfer {
+  const transfer = DatasetDraftTransferSchema.parse(value);
+  const actual = payloadSha256(draftPayloadFromTransfer(transfer));
+  if (actual !== transfer.sha256) {
+    throw new Error(
+      `Draft transfer checksum mismatch: expected ${transfer.sha256}, calculated ${actual}`,
+    );
+  }
+  return transfer;
 }

--- a/packages/scout-for-lol/packages/evals/src/server/draft-transfer-store.test.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/draft-transfer-store.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, test } from "bun:test";
+
+import { createDraftTransfer } from "#server/dataset-transfer.ts";
+import { createEvalStore, type EvalStore } from "#server/store.ts";
+import { DatasetDraftTransferPayloadSchema } from "#shared/schema.ts";
+import {
+  makeCaseArtifact,
+  makeDraftDataset,
+  makeFinalizedRatedDataset,
+} from "#testing/eval-fixtures.ts";
+
+function extendDraft(store: EvalStore, datasetId: string, suffix: string) {
+  const artifact = makeCaseArtifact({
+    matchId: `NA1_extension_${suffix}`,
+    playerName: "Aaron",
+    puuid: `puuid-extension-${suffix}`,
+    championName: "Teemo",
+    performanceSlice: "terrible",
+    styleKey: "nekoryan",
+  });
+  const evalCase = store.addMaterializedCase({ datasetId, artifact });
+  const generation = store.recordGeneration({
+    caseId: evalCase.id,
+    outputText: `Extension output ${suffix}.`,
+    model: "test-model",
+    promptRevision: "baseline-v1",
+    renderedPrompts: artifact.context.renderedPrompts,
+    durationMs: null,
+    inputTokens: null,
+    outputTokens: null,
+  });
+  return { evalCase, generation };
+}
+
+describe("draft transfer store", () => {
+  test("round-trips a draft and re-exports it byte-identically", () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-roundtrip");
+      const transfer = source.exportDraft(fixture.datasetId);
+
+      const summary = target.pushDraft(transfer);
+      expect(summary).toMatchObject({
+        id: fixture.datasetId,
+        key: "draft-roundtrip",
+        version: 1,
+        status: "draft",
+        caseCount: 1,
+        ratedCaseCount: 0,
+      });
+      expect(target.exportDraft(fixture.datasetId)).toEqual(transfer);
+      expect(
+        target.getCaseDetail(fixture.datasetId, fixture.caseId).generation,
+      ).toEqual(fixture.generation);
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+
+  test("re-push is idempotent and additive", () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-additive");
+      target.pushDraft(source.exportDraft(fixture.datasetId));
+
+      // Identical re-push changes nothing.
+      expect(
+        target.pushDraft(source.exportDraft(fixture.datasetId)),
+      ).toMatchObject({ caseCount: 1 });
+
+      // A rating authored on the target survives later pushes.
+      target.upsertHumanRating({
+        generationId: fixture.generation.id,
+        rating: {
+          anchoredness: 3,
+          entertainment: 2,
+          styleRecognizability: 3,
+          note: "Rated on the hosted instance.",
+        },
+      });
+
+      const extension = extendDraft(source, fixture.datasetId, "one");
+      const extended = target.pushDraft(source.exportDraft(fixture.datasetId));
+      expect(extended).toMatchObject({ caseCount: 2, ratedCaseCount: 1 });
+      expect(
+        target.getCaseDetail(fixture.datasetId, extension.evalCase.id)
+          .generation,
+      ).toEqual(extension.generation);
+      expect(
+        target.getCaseDetail(fixture.datasetId, fixture.caseId).rating,
+      ).toMatchObject({ note: "Rated on the hosted instance." });
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+
+  test("a new generation invalidates the target freshness rating for its style", () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-freshness");
+      target.pushDraft(source.exportDraft(fixture.datasetId));
+
+      // Freshness unlocks only after every generated case has its own rating.
+      target.upsertHumanRating({
+        generationId: fixture.generation.id,
+        rating: {
+          anchoredness: 3,
+          entertainment: 3,
+          styleRecognizability: 3,
+          note: "Baseline rating.",
+        },
+      });
+      const batch = target.listStyleBatch(fixture.datasetId, "aaron");
+      target.upsertFreshnessRating({
+        datasetId: fixture.datasetId,
+        styleKey: "aaron",
+        generationSetRevision: batch.generationSetRevision,
+        rating: { score: 3, note: "Fresh enough." },
+      });
+
+      // Pushing a new generation for the rated style drops the stale rating.
+      const secondGeneration = source.recordGeneration({
+        caseId: fixture.caseId,
+        outputText: "Second local generation.",
+        model: "test-model",
+        promptRevision: "candidate-v2",
+        renderedPrompts: fixture.generation.renderedPrompts,
+        durationMs: null,
+        inputTokens: null,
+        outputTokens: null,
+      });
+      target.pushDraft(source.exportDraft(fixture.datasetId));
+      // Rate the newly pushed latest generation so freshness unlocks again,
+      // then confirm the pre-push freshness rating was invalidated.
+      target.upsertHumanRating({
+        generationId: secondGeneration.id,
+        rating: {
+          anchoredness: 2,
+          entertainment: 2,
+          styleRecognizability: 2,
+          note: "Rating the pushed generation.",
+        },
+      });
+      expect(target.listStyleBatch(fixture.datasetId, "aaron").rating).toBe(
+        null,
+      );
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+});
+
+describe("draft transfer store rejections", () => {
+  test("rejects tampered checksums and payload mutations", () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-tamper");
+      const transfer = source.exportDraft(fixture.datasetId);
+      expect(() => {
+        target.pushDraft({ ...transfer, sha256: "0".repeat(64) });
+      }).toThrow("Draft transfer checksum mismatch");
+      expect(() => {
+        target.pushDraft({
+          ...transfer,
+          dataset: { ...transfer.dataset, name: "Renamed" },
+        });
+      }).toThrow("Draft transfer checksum mismatch");
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+
+  test("rejects pushes onto a finalized dataset", () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-finalized");
+      const transfer = source.exportDraft(fixture.datasetId);
+      target.pushDraft(transfer);
+      target.finalizeDataset(fixture.datasetId, 1);
+      expect(() => target.pushDraft(transfer)).toThrow(
+        `Dataset ${fixture.datasetId} is finalized and cannot accept draft pushes`,
+      );
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+
+  test("rejects content drift on existing records instead of overwriting", () => {
+    const source = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-drift");
+      const transfer = source.exportDraft(fixture.datasetId);
+      target.pushDraft(transfer);
+
+      const [onlyCase] = transfer.cases;
+      if (onlyCase === undefined) throw new Error("Fixture case missing");
+      const [onlyGeneration] = onlyCase.generations;
+      if (onlyGeneration === undefined) {
+        throw new Error("Fixture generation missing");
+      }
+
+      const driftedGeneration = createDraftTransfer(
+        DatasetDraftTransferPayloadSchema.parse({
+          schemaVersion: 1,
+          dataset: transfer.dataset,
+          cases: [
+            {
+              ...onlyCase,
+              generations: [
+                { ...onlyGeneration, outputText: "Rewritten output." },
+              ],
+            },
+          ],
+        }),
+      );
+      expect(() => target.pushDraft(driftedGeneration)).toThrow(
+        `Generation ${onlyGeneration.id} already exists with different content`,
+      );
+
+      const driftedMetadata = createDraftTransfer(
+        DatasetDraftTransferPayloadSchema.parse({
+          schemaVersion: 1,
+          dataset: { ...transfer.dataset, description: "Rewritten" },
+          cases: transfer.cases,
+        }),
+      );
+      expect(() => target.pushDraft(driftedMetadata)).toThrow(
+        `Dataset ${transfer.dataset.id} already exists with different metadata`,
+      );
+    } finally {
+      source.close();
+      target.close();
+    }
+  });
+
+  test("rejects id collisions across datasets and key/version collisions", () => {
+    const source = createEvalStore(":memory:");
+    const other = createEvalStore(":memory:");
+    const target = createEvalStore(":memory:");
+    try {
+      const fixture = makeDraftDataset(source, "draft-collision");
+      const transfer = source.exportDraft(fixture.datasetId);
+      target.pushDraft(transfer);
+
+      // Same case id under a different dataset id.
+      const otherFixture = makeDraftDataset(other, "draft-collision-other");
+      const otherTransfer = other.exportDraft(otherFixture.datasetId);
+      const [stolenCase] = transfer.cases;
+      if (stolenCase === undefined) throw new Error("Fixture case missing");
+      const caseCollision = createDraftTransfer(
+        DatasetDraftTransferPayloadSchema.parse({
+          schemaVersion: 1,
+          dataset: otherTransfer.dataset,
+          cases: [{ ...stolenCase, generations: [] }],
+        }),
+      );
+      expect(() => target.pushDraft(caseCollision)).toThrow(
+        `Case ${stolenCase.id} already belongs to dataset ${fixture.datasetId}`,
+      );
+
+      // Same key+version under a different dataset id.
+      const keyCollision = createDraftTransfer(
+        DatasetDraftTransferPayloadSchema.parse({
+          schemaVersion: 1,
+          dataset: { ...otherTransfer.dataset, key: "draft-collision" },
+          cases: otherTransfer.cases,
+        }),
+      );
+      expect(() => target.pushDraft(keyCollision)).toThrow(
+        "Dataset draft-collision version 1 already exists as " +
+          fixture.datasetId,
+      );
+    } finally {
+      source.close();
+      other.close();
+      target.close();
+    }
+  });
+
+  test("only exports drafts with cases", () => {
+    const store = createEvalStore(":memory:");
+    try {
+      const finalized = makeFinalizedRatedDataset(store, "draft-export-guard");
+      expect(() => store.exportDraft(finalized.dataset.id)).toThrow(
+        `Dataset ${finalized.dataset.id} must be a draft to transfer drafts`,
+      );
+
+      const empty = store.createDataset({
+        key: "draft-empty",
+        name: "Empty draft",
+      });
+      expect(() => store.exportDraft(empty.id)).toThrow(
+        `Draft dataset ${empty.id} has no cases to transfer`,
+      );
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/evals/src/server/draft-transfer-store.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/draft-transfer-store.ts
@@ -1,0 +1,360 @@
+import type { Database } from "bun:sqlite";
+import { z } from "zod";
+
+import {
+  canonicalJson,
+  createDraftTransfer,
+  validateDraftTransfer,
+} from "#server/dataset-transfer.ts";
+import {
+  INSERT_GENERATION_SQL,
+  parseGenerationRow,
+  SELECT_GENERATION_SQL,
+} from "#server/generation.ts";
+import { DATASET_SUMMARY_SQL } from "#server/store-queries.ts";
+import {
+  CaseArtifactSchema,
+  CaseIdSchema,
+  DatasetIdSchema,
+  DatasetStatusSchema,
+  DatasetSummarySchema,
+  DraftTransferMetadataSchema,
+  type DatasetDraftTransfer,
+  type DatasetSummary,
+} from "#shared/schema.ts";
+
+const DraftDatasetRowSchema = DraftTransferMetadataSchema.extend({
+  status: DatasetStatusSchema,
+});
+
+const DraftCaseRowSchema = z.strictObject({
+  id: CaseIdSchema,
+  ordinal: z.number().int().nonnegative(),
+  artifactJson: z.string().min(1),
+});
+
+const ExistingCaseRowSchema = z.strictObject({
+  datasetId: DatasetIdSchema,
+  ordinal: z.number().int().nonnegative(),
+  artifactJson: z.string().min(1),
+});
+
+const ExistingIdRowSchema = z.strictObject({ id: z.string().min(1) });
+
+const GenerationCaseRowSchema = z.strictObject({ caseId: CaseIdSchema });
+
+function readDraftMetadata(
+  database: Database,
+  datasetId: string,
+): z.infer<typeof DraftTransferMetadataSchema> {
+  const metadata = DraftDatasetRowSchema.parse(
+    database
+      .query(
+        `SELECT
+           id,
+           dataset_key AS key,
+           version,
+           name,
+           description,
+           status,
+           created_at AS createdAt
+         FROM datasets
+         WHERE id = ?`,
+      )
+      .get(datasetId),
+  );
+  if (metadata.status !== "draft") {
+    throw new Error(`Dataset ${datasetId} must be a draft to transfer drafts`);
+  }
+  return DraftTransferMetadataSchema.parse(metadata);
+}
+
+function readDraftSnapshot(
+  database: Database,
+  id: string,
+): DatasetDraftTransfer {
+  if (!database.inTransaction) {
+    throw new Error("Draft export requires an active SQLite transaction");
+  }
+  const dataset = readDraftMetadata(database, id);
+  const caseRows = z.array(DraftCaseRowSchema).parse(
+    database
+      .query(
+        `SELECT id, ordinal, artifact_json AS artifactJson
+         FROM dataset_cases
+         WHERE dataset_id = ?
+         ORDER BY ordinal`,
+      )
+      .all(id),
+  );
+  if (caseRows.length === 0) {
+    throw new Error(`Draft dataset ${id} has no cases to transfer`);
+  }
+  return createDraftTransfer({
+    schemaVersion: 1,
+    dataset,
+    cases: caseRows.map((row) => ({
+      id: row.id,
+      ordinal: row.ordinal,
+      artifact: CaseArtifactSchema.parse(JSON.parse(row.artifactJson)),
+      generations: database
+        .query(
+          `SELECT
+             id,
+             output_text AS outputText,
+             model,
+             prompt_revision AS promptRevision,
+             rendered_prompts_json AS renderedPromptsJson,
+             duration_ms AS durationMs,
+             input_tokens AS inputTokens,
+             output_tokens AS outputTokens
+           FROM generations
+           WHERE case_id = ?
+           ORDER BY sequence`,
+        )
+        .all(row.id)
+        .map((generationRow) => parseGenerationRow(generationRow)),
+    })),
+  });
+}
+
+export function exportDraftFromDatabase(
+  database: Database,
+  datasetId: string,
+): DatasetDraftTransfer {
+  const id = DatasetIdSchema.parse(datasetId);
+  return database.transaction(() => readDraftSnapshot(database, id)).deferred();
+}
+
+function ensureTargetDataset(
+  database: Database,
+  dataset: DatasetDraftTransfer["dataset"],
+): void {
+  const existing = DraftDatasetRowSchema.nullable().parse(
+    database
+      .query(
+        `SELECT
+           id,
+           dataset_key AS key,
+           version,
+           name,
+           description,
+           status,
+           created_at AS createdAt
+         FROM datasets
+         WHERE id = ?`,
+      )
+      .get(dataset.id),
+  );
+  if (existing !== null) {
+    if (existing.status === "finalized") {
+      throw new Error(
+        `Dataset ${dataset.id} is finalized and cannot accept draft pushes`,
+      );
+    }
+    const incoming = { ...dataset, status: existing.status };
+    if (canonicalJson(existing) !== canonicalJson(incoming)) {
+      throw new Error(
+        `Dataset ${dataset.id} already exists with different metadata; ` +
+          "draft pushes never overwrite existing records",
+      );
+    }
+    return;
+  }
+
+  const versionCollision = ExistingIdRowSchema.nullable().parse(
+    database
+      .query(
+        `SELECT id FROM datasets
+         WHERE dataset_key = ? AND version = ?`,
+      )
+      .get(dataset.key, dataset.version),
+  );
+  if (versionCollision !== null) {
+    throw new Error(
+      `Dataset ${dataset.key} version ${String(dataset.version)} already ` +
+        `exists as ${versionCollision.id}`,
+    );
+  }
+
+  database
+    .query(
+      `INSERT INTO datasets (
+         id, dataset_key, version, name, description, status, created_at
+       ) VALUES (?, ?, ?, ?, ?, 'draft', ?)`,
+    )
+    .run(
+      dataset.id,
+      dataset.key,
+      dataset.version,
+      dataset.name,
+      dataset.description,
+      dataset.createdAt,
+    );
+}
+
+function ensureCase(
+  database: Database,
+  datasetId: string,
+  evalCase: DatasetDraftTransfer["cases"][number],
+  receivedAt: string,
+): void {
+  const existing = ExistingCaseRowSchema.nullable().parse(
+    database
+      .query(
+        `SELECT dataset_id AS datasetId, ordinal, artifact_json AS artifactJson
+         FROM dataset_cases
+         WHERE id = ?`,
+      )
+      .get(evalCase.id),
+  );
+  if (existing !== null) {
+    if (existing.datasetId !== datasetId) {
+      throw new Error(
+        `Case ${evalCase.id} already belongs to dataset ${existing.datasetId}`,
+      );
+    }
+    if (existing.ordinal !== evalCase.ordinal) {
+      throw new Error(
+        `Case ${evalCase.id} already exists at ordinal ` +
+          `${String(existing.ordinal)}, not ${String(evalCase.ordinal)}`,
+      );
+    }
+    const existingArtifact = CaseArtifactSchema.parse(
+      JSON.parse(existing.artifactJson),
+    );
+    if (canonicalJson(existingArtifact) !== canonicalJson(evalCase.artifact)) {
+      throw new Error(
+        `Case ${evalCase.id} already exists with a different artifact; ` +
+          "draft pushes never overwrite existing records",
+      );
+    }
+    return;
+  }
+
+  const ordinalCollision = ExistingIdRowSchema.nullable().parse(
+    database
+      .query(
+        `SELECT id FROM dataset_cases
+         WHERE dataset_id = ? AND ordinal = ?`,
+      )
+      .get(datasetId, evalCase.ordinal),
+  );
+  if (ordinalCollision !== null) {
+    throw new Error(
+      `Dataset ${datasetId} already has case ${ordinalCollision.id} at ` +
+        `ordinal ${String(evalCase.ordinal)}`,
+    );
+  }
+
+  const { artifact } = evalCase;
+  database
+    .query(
+      `INSERT INTO dataset_cases (
+         id, dataset_id, ordinal, match_id, target_player_name,
+         target_player_puuid, champion_name, performance_slice, style_key,
+         artifact_json, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      evalCase.id,
+      datasetId,
+      evalCase.ordinal,
+      artifact.matchId,
+      artifact.targetPlayerName,
+      artifact.targetPlayerPuuid,
+      artifact.championName,
+      artifact.performanceSlice,
+      artifact.styleKey,
+      JSON.stringify(artifact),
+      receivedAt,
+    );
+}
+
+function ensureGeneration(
+  database: Database,
+  caseId: string,
+  generation: DatasetDraftTransfer["cases"][number]["generations"][number],
+  receivedAt: string,
+): boolean {
+  const owner = GenerationCaseRowSchema.nullable().parse(
+    database
+      .query("SELECT case_id AS caseId FROM generations WHERE id = ?")
+      .get(generation.id),
+  );
+  if (owner !== null) {
+    if (owner.caseId !== caseId) {
+      throw new Error(
+        `Generation ${generation.id} already belongs to case ${owner.caseId}`,
+      );
+    }
+    const existing = parseGenerationRow(
+      database.query(SELECT_GENERATION_SQL).get(generation.id),
+    );
+    if (canonicalJson(existing) !== canonicalJson(generation)) {
+      throw new Error(
+        `Generation ${generation.id} already exists with different content; ` +
+          "draft pushes never overwrite existing records",
+      );
+    }
+    return false;
+  }
+
+  database
+    .query(INSERT_GENERATION_SQL)
+    .run(
+      generation.id,
+      caseId,
+      generation.outputText,
+      generation.model,
+      generation.promptRevision,
+      JSON.stringify(generation.renderedPrompts),
+      generation.durationMs,
+      generation.inputTokens,
+      generation.outputTokens,
+      receivedAt,
+    );
+  return true;
+}
+
+export function pushDraftIntoDatabase(
+  database: Database,
+  value: unknown,
+): DatasetSummary {
+  const transfer = validateDraftTransfer(value);
+  const receivedAt = new Date().toISOString();
+  return database.transaction(() => {
+    ensureTargetDataset(database, transfer.dataset);
+
+    // A pushed generation extends a style batch, so any freshness rating for
+    // that style no longer describes the current generation set. Mirror
+    // EvalStore.recordGeneration and drop it; existing human ratings attach to
+    // untouched generations and survive every push.
+    const staleStyles = new Set<string>();
+    for (const evalCase of transfer.cases) {
+      ensureCase(database, transfer.dataset.id, evalCase, receivedAt);
+      for (const generation of evalCase.generations) {
+        if (ensureGeneration(database, evalCase.id, generation, receivedAt)) {
+          staleStyles.add(evalCase.artifact.styleKey);
+        }
+      }
+    }
+    for (const styleKey of staleStyles) {
+      database
+        .query(
+          "DELETE FROM freshness_ratings WHERE dataset_id = ? AND style_key = ?",
+        )
+        .run(transfer.dataset.id, styleKey);
+    }
+
+    return DatasetSummarySchema.parse(
+      database
+        .query(
+          `${DATASET_SUMMARY_SQL}
+           WHERE d.id = ?
+           GROUP BY d.id`,
+        )
+        .get(transfer.dataset.id),
+    );
+  })();
+}

--- a/packages/scout-for-lol/packages/evals/src/server/index.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/index.ts
@@ -6,6 +6,10 @@ import { createEvalStore } from "#server/store.ts";
 
 const OptionsSchema = z.strictObject({
   databasePath: z.string().min(1),
+  // Loopback by default: the app has no auth, so any wider bind must be an
+  // explicit deployment decision (the hosted container sets 0.0.0.0 and relies
+  // on the tailnet as its trust boundary).
+  host: z.string().min(1).default("127.0.0.1"),
   open: z.boolean(),
   port: z.coerce.number().int().min(1).max(65_535).default(7341),
 });
@@ -15,6 +19,7 @@ const options = OptionsSchema.parse({
     argumentValue("--database") ??
     Bun.env["SCOUT_EVAL_DATABASE_PATH"] ??
     new URL("../../data/scout-review-evals.sqlite", import.meta.url).pathname,
+  host: argumentValue("--host") ?? Bun.env["SCOUT_EVAL_HOSTNAME"],
   open: Bun.argv.includes("--open"),
   port: argumentValue("--port"),
 });
@@ -23,7 +28,7 @@ const store = createEvalStore(options.databasePath);
 const app = createApp(store);
 const server = Bun.serve({
   fetch: app.fetch,
-  hostname: "127.0.0.1",
+  hostname: options.host,
   port: options.port,
 });
 const hostname = server.hostname;

--- a/packages/scout-for-lol/packages/evals/src/server/store.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/store.ts
@@ -7,6 +7,10 @@ import {
   importDatasetIntoDatabase,
 } from "#server/dataset-transfer-store.ts";
 import {
+  exportDraftFromDatabase,
+  pushDraftIntoDatabase,
+} from "#server/draft-transfer-store.ts";
+import {
   generationSetRevision,
   requireCurrentGenerationSet,
   requireFreshnessAvailable,
@@ -37,6 +41,7 @@ import {
   type CaseSummary,
   CreateDatasetInputSchema,
   DatasetIdSchema,
+  type DatasetDraftTransfer,
   type DatasetExport,
   type DatasetSummary,
   DatasetSummarySchema,
@@ -186,6 +191,14 @@ export class EvalStore {
 
   public importDataset(value: unknown): DatasetSummary {
     return importDatasetIntoDatabase(this.#database, value);
+  }
+
+  public exportDraft(datasetId: string): DatasetDraftTransfer {
+    return exportDraftFromDatabase(this.#database, datasetId);
+  }
+
+  public pushDraft(value: unknown): DatasetSummary {
+    return pushDraftIntoDatabase(this.#database, value);
   }
 
   public addMaterializedCase(input: AddMaterializedCaseInput): CaseSummary {

--- a/packages/scout-for-lol/packages/evals/src/server/trpc.ts
+++ b/packages/scout-for-lol/packages/evals/src/server/trpc.ts
@@ -29,6 +29,10 @@ const datasetsRouter = t.router({
     .input(EvalSchema.DatasetExportSchema)
     .output(EvalSchema.DatasetSummarySchema)
     .mutation(({ ctx, input }) => ctx.store.importDataset(input)),
+  pushDraft: t.procedure
+    .input(EvalSchema.DatasetDraftTransferSchema)
+    .output(EvalSchema.DatasetSummarySchema)
+    .mutation(({ ctx, input }) => ctx.store.pushDraft(input)),
 });
 
 const casesRouter = t.router({

--- a/packages/scout-for-lol/packages/evals/src/shared/schema.ts
+++ b/packages/scout-for-lol/packages/evals/src/shared/schema.ts
@@ -270,6 +270,82 @@ export const DatasetExportFreshnessRatingSchema = z.strictObject({
   rating: FreshnessRatingSchema,
 });
 
+type TransferCaseIssue = { message: string; path: (string | number)[] };
+
+type TransferCaseView = {
+  id: string;
+  ordinal: number;
+  artifact: { matchId: string; targetPlayerPuuid: string; styleKey: string };
+  generationIds: readonly string[];
+};
+
+function collectTransferCaseIssues(
+  cases: readonly TransferCaseView[],
+  generationIdPath: (
+    casePosition: number,
+    generationPosition: number,
+  ) => (string | number)[],
+): {
+  issues: TransferCaseIssue[];
+  styles: Set<string>;
+  generatedStyles: Set<string>;
+} {
+  const issues: TransferCaseIssue[] = [];
+  const caseIds = new Set<string>();
+  const generationIds = new Set<string>();
+  const memberships = new Set<string>();
+  const styles = new Set<string>();
+  const generatedStyles = new Set<string>();
+
+  for (const [position, evalCase] of cases.entries()) {
+    if (evalCase.ordinal !== position) {
+      issues.push({
+        message: `Case ordinal ${String(evalCase.ordinal)} must match its array position ${String(position)}`,
+        path: ["cases", position, "ordinal"],
+      });
+    }
+    if (caseIds.has(evalCase.id)) {
+      issues.push({
+        message: `Duplicate case id ${evalCase.id}`,
+        path: ["cases", position, "id"],
+      });
+    }
+    caseIds.add(evalCase.id);
+
+    const membership = [
+      evalCase.artifact.matchId,
+      evalCase.artifact.targetPlayerPuuid,
+      evalCase.artifact.styleKey,
+    ].join("\0");
+    if (memberships.has(membership)) {
+      issues.push({
+        message: "Duplicate match-player-style case membership",
+        path: ["cases", position, "artifact"],
+      });
+    }
+    memberships.add(membership);
+    styles.add(evalCase.artifact.styleKey);
+    if (evalCase.generationIds.length > 0) {
+      generatedStyles.add(evalCase.artifact.styleKey);
+    }
+
+    for (const [
+      generationPosition,
+      generationId,
+    ] of evalCase.generationIds.entries()) {
+      if (generationIds.has(generationId)) {
+        issues.push({
+          message: `Duplicate generation id ${generationId}`,
+          path: generationIdPath(position, generationPosition),
+        });
+      }
+      generationIds.add(generationId);
+    }
+  }
+
+  return { issues, styles, generatedStyles };
+}
+
 export const DatasetExportPayloadSchema = z
   .strictObject({
     schemaVersion: z.literal(1),
@@ -278,67 +354,26 @@ export const DatasetExportPayloadSchema = z
     freshnessRatings: z.array(DatasetExportFreshnessRatingSchema),
   })
   .superRefine((payload, context) => {
-    const caseIds = new Set<string>();
-    const generationIds = new Set<string>();
-    const memberships = new Set<string>();
-    const styles = new Set<string>();
-    const generatedStyles = new Set<string>();
-
-    for (const [position, evalCase] of payload.cases.entries()) {
-      if (evalCase.ordinal !== position) {
-        context.addIssue({
-          code: "custom",
-          message: `Case ordinal ${String(evalCase.ordinal)} must match its array position ${String(position)}`,
-          path: ["cases", position, "ordinal"],
-        });
-      }
-      if (caseIds.has(evalCase.id)) {
-        context.addIssue({
-          code: "custom",
-          message: `Duplicate case id ${evalCase.id}`,
-          path: ["cases", position, "id"],
-        });
-      }
-      caseIds.add(evalCase.id);
-
-      const membership = [
-        evalCase.artifact.matchId,
-        evalCase.artifact.targetPlayerPuuid,
-        evalCase.artifact.styleKey,
-      ].join("\0");
-      if (memberships.has(membership)) {
-        context.addIssue({
-          code: "custom",
-          message: "Duplicate match-player-style case membership",
-          path: ["cases", position, "artifact"],
-        });
-      }
-      memberships.add(membership);
-      styles.add(evalCase.artifact.styleKey);
-      if (evalCase.generations.length > 0) {
-        generatedStyles.add(evalCase.artifact.styleKey);
-      }
-
-      for (const [
+    const { issues, styles, generatedStyles } = collectTransferCaseIssues(
+      payload.cases.map((evalCase) => ({
+        id: evalCase.id,
+        ordinal: evalCase.ordinal,
+        artifact: evalCase.artifact,
+        generationIds: evalCase.generations.map(
+          (record) => record.generation.id,
+        ),
+      })),
+      (casePosition, generationPosition) => [
+        "cases",
+        casePosition,
+        "generations",
         generationPosition,
-        record,
-      ] of evalCase.generations.entries()) {
-        if (generationIds.has(record.generation.id)) {
-          context.addIssue({
-            code: "custom",
-            message: `Duplicate generation id ${record.generation.id}`,
-            path: [
-              "cases",
-              position,
-              "generations",
-              generationPosition,
-              "generation",
-              "id",
-            ],
-          });
-        }
-        generationIds.add(record.generation.id);
-      }
+        "generation",
+        "id",
+      ],
+    );
+    for (const issue of issues) {
+      context.addIssue({ code: "custom", ...issue });
     }
 
     let previousStyleKey: string | undefined;
@@ -375,6 +410,61 @@ export const DatasetExportSchema = DatasetExportPayloadSchema.safeExtend({
   sha256: z.string().regex(/^[\da-f]{64}$/),
 });
 
+// Draft transfers move a locally-materialized draft onto another eval server
+// (the hosted instance) before any human rating exists. They deliberately carry
+// only dataset metadata, frozen case artifacts, and generations — never human
+// or freshness ratings, which are authored on the receiving instance. The
+// finalized export above remains the full-fidelity archival format.
+export const DraftTransferMetadataSchema = DatasetSummarySchema.pick({
+  id: true,
+  key: true,
+  version: true,
+  name: true,
+  description: true,
+  createdAt: true,
+}).extend({
+  status: z.literal("draft"),
+});
+
+export const DraftTransferCaseSchema = z.strictObject({
+  id: CaseIdSchema,
+  ordinal: z.number().int().nonnegative(),
+  artifact: CaseArtifactSchema,
+  generations: z.array(GenerationSchema),
+});
+
+export const DatasetDraftTransferPayloadSchema = z
+  .strictObject({
+    schemaVersion: z.literal(1),
+    dataset: DraftTransferMetadataSchema,
+    cases: z.array(DraftTransferCaseSchema).min(1),
+  })
+  .superRefine((payload, context) => {
+    const { issues } = collectTransferCaseIssues(
+      payload.cases.map((evalCase) => ({
+        id: evalCase.id,
+        ordinal: evalCase.ordinal,
+        artifact: evalCase.artifact,
+        generationIds: evalCase.generations.map((generation) => generation.id),
+      })),
+      (casePosition, generationPosition) => [
+        "cases",
+        casePosition,
+        "generations",
+        generationPosition,
+        "id",
+      ],
+    );
+    for (const issue of issues) {
+      context.addIssue({ code: "custom", ...issue });
+    }
+  });
+
+export const DatasetDraftTransferSchema =
+  DatasetDraftTransferPayloadSchema.safeExtend({
+    sha256: z.string().regex(/^[\da-f]{64}$/),
+  });
+
 export type DatasetSummary = z.infer<typeof DatasetSummarySchema>;
 export type CaseSummary = z.infer<typeof CaseSummarySchema>;
 export type CaseArtifact = z.infer<typeof CaseArtifactSchema>;
@@ -383,3 +473,7 @@ export type HumanRating = z.infer<typeof HumanRatingSchema>;
 export type EvalScore = z.infer<typeof EvalScoreSchema>;
 export type DatasetExportPayload = z.infer<typeof DatasetExportPayloadSchema>;
 export type DatasetExport = z.infer<typeof DatasetExportSchema>;
+export type DatasetDraftTransferPayload = z.infer<
+  typeof DatasetDraftTransferPayloadSchema
+>;
+export type DatasetDraftTransfer = z.infer<typeof DatasetDraftTransferSchema>;

--- a/packages/scout-for-lol/packages/evals/src/testing/eval-fixtures.ts
+++ b/packages/scout-for-lol/packages/evals/src/testing/eval-fixtures.ts
@@ -105,18 +105,14 @@ export function makeCaseArtifact(overrides: {
   });
 }
 
-export function makeFinalizedRatedDataset(
+export function makeDraftDataset(
   store: EvalStore,
   key: string,
-): {
-  dataset: DatasetSummary;
-  caseId: string;
-  generations: readonly [Generation, Generation];
-} {
+): { datasetId: string; caseId: string; generation: Generation } {
   const draft = store.createDataset({
     key,
     name: `${key} calibration`,
-    description: "Transfer fixture",
+    description: "Draft transfer fixture",
   });
   const artifact = makeCaseArtifact({
     matchId: `NA1_${key}`,
@@ -130,9 +126,9 @@ export function makeFinalizedRatedDataset(
     datasetId: draft.id,
     artifact,
   });
-  const firstGeneration = store.recordGeneration({
+  const generation = store.recordGeneration({
     caseId: evalCase.id,
-    outputText: "First frozen output.",
+    outputText: "Draft baseline output.",
     model: "test-model",
     promptRevision: "baseline-v1",
     renderedPrompts: artifact.context.renderedPrompts,
@@ -140,6 +136,19 @@ export function makeFinalizedRatedDataset(
     inputTokens: 200,
     outputTokens: 20,
   });
+  return { datasetId: draft.id, caseId: evalCase.id, generation };
+}
+
+export function makeFinalizedRatedDataset(
+  store: EvalStore,
+  key: string,
+): {
+  dataset: DatasetSummary;
+  caseId: string;
+  generations: readonly [Generation, Generation];
+} {
+  const draft = makeDraftDataset(store, key);
+  const firstGeneration = draft.generation;
   store.upsertHumanRating({
     generationId: firstGeneration.id,
     rating: {
@@ -150,11 +159,11 @@ export function makeFinalizedRatedDataset(
     },
   });
   const secondGeneration = store.recordGeneration({
-    caseId: evalCase.id,
+    caseId: draft.caseId,
     outputText: "Second frozen output.",
     model: "test-model",
     promptRevision: "candidate-v2",
-    renderedPrompts: artifact.context.renderedPrompts,
+    renderedPrompts: firstGeneration.renderedPrompts,
     durationMs: null,
     inputTokens: null,
     outputTokens: null,
@@ -168,17 +177,17 @@ export function makeFinalizedRatedDataset(
       note: "More entertaining.",
     },
   });
-  const batch = store.listStyleBatch(draft.id, "aaron");
+  const batch = store.listStyleBatch(draft.datasetId, "aaron");
   store.upsertFreshnessRating({
-    datasetId: draft.id,
+    datasetId: draft.datasetId,
     styleKey: "aaron",
     generationSetRevision: batch.generationSetRevision,
     rating: { score: 3, note: "Varied enough." },
   });
 
   return {
-    dataset: store.finalizeDataset(draft.id, 1),
-    caseId: evalCase.id,
+    dataset: store.finalizeDataset(draft.datasetId, 1),
+    caseId: draft.caseId,
     generations: [firstGeneration, secondGeneration],
   };
 }

--- a/packages/scout-for-lol/packages/evals/tsconfig.json
+++ b/packages/scout-for-lol/packages/evals/tsconfig.json
@@ -7,6 +7,12 @@
     "jsxImportSource": "react",
     "noEmit": true
   },
-  "include": ["src/**/*", "e2e/**/*", "playwright.config.ts", "vite.config.ts"],
+  "include": [
+    "src/**/*",
+    "e2e/**/*",
+    "scripts/**/*",
+    "playwright.config.ts",
+    "vite.config.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Hosts the Scout Review Evals app on the homelab (layer 1 of 2): prepares the app for remote use and adds the CI-built image. The homelab chart lands in the next PR in this stack (#1956).

## App changes

- Server bind hostname is now configurable via `--host` / `SCOUT_EVAL_HOSTNAME` (default stays `127.0.0.1`; the container sets `0.0.0.0` and relies on the tailnet as the trust boundary).
- New **remote draft push**: `bun run --filter=@scout-for-lol/evals dataset:push -- --dataset <id> --server <url>` exports a checksummed draft transfer (metadata + frozen case artifacts + generations — never ratings) from the local SQLite and pushes it to a remote server via a new `datasets.pushDraft` tRPC mutation. Pushes are additive merges: existing records must be canonical-JSON identical, finalized targets and any content drift are rejected, and a pushed generation invalidates that style's freshness rating exactly like recording one locally. Ratings authored on the server survive re-pushes. Materialization (OpenAI/AWS creds, Beta snapshot) stays local.

## Image + CI

- `packages/scout-for-lol/packages/evals/Dockerfile`: filtered prod install → vite client build → COPY-only runtime (cwd = package dir for the cwd-relative `./dist/client` serving) → uid-1000 smoke stage. The 82 MB `@scout-for-lol/data` package is deliberately excluded — only local-only materialization imports it (verified: image `/app/packages` is 4.2 MB).
- Bake target + selector wiring (`image-targets.ts`, `migration-core.ts`, `docker-bake.hcl`), smoke-harness entry (proves WAL SQLite creation as uid 1000), package `docker:build`/`smoke` scripts.
- Placeholder `shepherdjerred/scout-evals` pin in versions.ts; the first main build's version commit-back fills the real tag@digest.
- `.dockerignore` now excludes the evals `data/` dir so a local operator database can never reach an image.

## Verification

- 71 unit tests + Playwright e2e green; typecheck + eslint clean; `.buildkite` suite 155/155 (one fixture correctly now expects the `twisted` patch to select both scout images).
- Live loop: seeded a local draft, booted a second server on `:7345` bound `0.0.0.0`, pushed over real HTTP, extended the draft, re-pushed (additive 1→2 cases), re-pushed identically (no-op), verified via `/trpc/datasets.list`.
- `docker:build` + container smoke pass locally (image 538 MB, mostly base + deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbcP3C5RVs59k5EY4BsKfN