### PR TITLE
feat(homelab): deploy scout-evals behind a tailnet-only ingress

### DIFF
--- a/packages/docs/plans/2026-08-02_host-scout-evals.md
+++ b/packages/docs/plans/2026-08-02_host-scout-evals.md
@@ -88,6 +88,45 @@ On-cluster (after layer 2 merges):
 - E2E: push a real draft over the tailnet, rate a case in the hosted UI, re-push an extended draft, confirm merge.
 - Confirm next Velero run includes the PVC.
 
+## Session Log — 2026-08-02
+
+### Done
+
+- **Part A** (commit 36c8b5c56, PR #1955): `--host`/`SCOUT_EVAL_HOSTNAME` bind option; draft
+  transfer schemas + checksum machinery; `draft-transfer-store.ts` (additive-merge
+  `pushDraftIntoDatabase`, draft-only `exportDraftFromDatabase`); `datasets.pushDraft` tRPC
+  mutation; `dataset:push` CLI; freshness invalidation on pushed generations; 8 new tests +
+  API test; README + scout AGENTS.md docs. Live-verified over real HTTP against a second
+  server bound 0.0.0.0 (push → extend → additive re-push → idempotent re-push).
+- **Part B** (commit 43ec3e15a, PR #1955): evals Dockerfile (prod-deps/build/runtime/smoke/
+  image stages; scout's own tsconfig.base.json, not the root one, is the required extend);
+  bake target + selector + smoke-harness wiring; placeholder versions.ts pin; package
+  `docker:build`/`smoke` scripts; `.dockerignore` guard for the local eval DB. Image builds
+  (538 MB, `/app/packages` 4.2 MB — no data package leak) and container smoke passes.
+  `.buildkite` tests 155/155 (twisted-patch fixture now expects both scout images).
+- **Part C** (commit ff4f07502, PR #1956): scout-evals chart (recreate, uid 1000, 1 GiB
+  ZFS PVC at /data with backup enabled, TailscaleIngress `scout-evals`, /health probes,
+  DNS-only egress) + helm dir + ArgoCD app + registrations. Homelab suite 316 pass.
+- Published native GitHub stack #1957: PR #1955 (app + image) → PR #1956 (homelab).
+
+### Remaining
+
+- Merge PR #1955; wait for the main build's version commit-back PR to replace the
+  placeholder `shepherdjerred/scout-evals` pin; then merge PR #1956.
+- On-cluster verification after ArgoCD sync: pod Running / PVC Bound, tailnet
+  `curl https://scout-evals.<tailnet>.ts.net/health`, DB starts empty, push a real draft
+  over the tailnet + rate it in the hosted UI, confirm unreachable off-tailnet, confirm
+  the next Velero run includes the `scout-evals-data` PVC.
+
+### Caveats
+
+- PR #1956 must NOT merge before the real image pin lands — ArgoCD would deploy the
+  placeholder digest (ImagePullBackOff until the next commit-back; self-heals but avoidable).
+- `readOnlyRootFilesystem: false` initially (Bun writes caches under HOME); tightening is a
+  possible follow-up.
+- The draft-push CLI talks to the hosted server over the tailnet with no auth by design;
+  anyone on the tailnet can rate/push. Accepted decision.
+
 ## Risks
 
 - `.buildkite` fixture edits not fully enumerated — test failures will name them.

--- a/packages/docs/wiki/astro.config.ts
+++ b/packages/docs/wiki/astro.config.ts
@@ -70,6 +70,10 @@ export default defineConfig({
               label: "qBittorrent VPN webseed relay",
               link: "/homelab/qbittorrent-vpn-webseed-relay/",
             },
+            {
+              label: "Scout evals tailnet boundary",
+              link: "/homelab/scout-evals-tailnet-boundary/",
+            },
           ],
           label: "Homelab",
         },

--- a/packages/docs/wiki/src/content/docs/homelab/scout-evals-tailnet-boundary.md
+++ b/packages/docs/wiki/src/content/docs/homelab/scout-evals-tailnet-boundary.md
@@ -1,0 +1,58 @@
+---
+title: Scout evals tailnet trust boundary
+description: Scout review evals is an unauthenticated app whose only authorization boundary is a tailnet-only Tailscale ingress; the tailnet is the auth layer, its ZFS PVC owns the data, and it must never be exposed via Funnel.
+---
+
+Scout review evals — the post-match review calibration app in
+`packages/scout-for-lol/packages/evals` — has **no application-level auth by
+design**. It is a single Bun process that serves its built client and a tRPC API
+over one WAL-mode SQLite file. Its entire authorization boundary is the
+**tailnet-only Tailscale ingress** in front of it: only devices on the tailnet
+can reach `https://scout-evals.<tailnet>.ts.net`, and the tailnet membership
+_is_ the login. There is no second gate behind it.
+
+## Trust boundary
+
+```mermaid
+flowchart LR
+  accTitle: Scout evals tailnet trust boundary
+  accDescr: Only tailnet-member devices can reach the Scout evals ingress. The ingress is the sole authorization boundary because the app has no auth. Behind it a single Bun pod serves the client and tRPC API and writes to a read-write-once ZFS PVC holding the SQLite database. Funnel, which would expose the service to the public internet, is never configured.
+
+  Dev[Tailnet member device] -->|MagicDNS over tailnet| ING[TailscaleIngress<br/>scout-evals]
+  Public((Public internet)) -.->|no Funnel — blocked| ING
+  ING --> POD[scout-evals Bun pod<br/>no app auth]
+  POD -->|single-writer SQLite| PVC[(ZFS RWO PVC<br/>/data)]
+```
+
+## Why it is shaped this way
+
+- **Tailnet is the auth layer.** The app binds `0.0.0.0` inside the cluster
+  (`SCOUT_EVAL_HOSTNAME`), which is only safe because nothing but the tailnet
+  ingress can route to it. Anyone off the tailnet cannot reach it at all, so the
+  app itself carries no password, session, or token logic. Removing the tailnet
+  boundary would expose an unauthenticated admin surface — never do it.
+- **Never Funnel.** Funnel would publish the service to the public internet,
+  which would defeat the entire boundary. The ingress is tailnet-only on
+  purpose; the call site in `scout-evals.ts` and the app README both call this
+  out explicitly.
+- **The PVC owns the data.** All datasets — raw source artifacts, processed
+  match context, prompts, model settings, generations, and human ratings — live
+  in one SQLite file on a read-write-once ZFS NVMe volume mounted at `/data`.
+  Because it is single-writer, the Deployment uses the `Recreate` strategy so an
+  old and new pod never run concurrently and corrupt the WAL.
+- **Read-only root filesystem.** The container runs non-root (uid/gid 1000) with
+  a read-only root filesystem and no privilege escalation. Bun's runtime caches
+  need a writable `$HOME`, so `HOME` points at a small writable `emptyDir` at
+  `/tmp`; durable data still lives only on the `/data` PVC. If this
+  unauthenticated service is ever compromised, the attacker cannot rewrite the
+  container image contents.
+
+## Operating it
+
+- **Reach it** from any tailnet device at `https://scout-evals.<tailnet>.ts.net`.
+  No credentials are prompted — being on the tailnet is the access grant.
+- **Guard tailnet membership** the way you would guard a login. Anyone you add to
+  the tailnet with routing to this service can read and write every eval dataset.
+- **Populate datasets** with the evals CLI (`sync-beta`, `discover`, and the
+  ingest commands) as documented in the package README; the hosted instance is
+  the durable home for the resulting SQLite database.

--- a/packages/homelab/src/cdk8s/helm/scout-evals/Chart.yaml
+++ b/packages/homelab/src/cdk8s/helm/scout-evals/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: scout-evals
+description: Scout post-match review evals calibration app (tailnet-only)
+type: application
+version: "$version"
+appVersion: "$appVersion"

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
@@ -384,6 +384,12 @@
     "reason": "Replicated Syncthing bulk data"
   },
   {
+    "namespace": "scout-evals",
+    "name": "scout-evals-data",
+    "backup": "enabled",
+    "reason": "Scout review evals SQLite — human ratings live only here"
+  },
+  {
     "namespace": "tasknotes",
     "name": "tasknotes-vault-pvc",
     "backup": "enabled",

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -65,15 +65,15 @@ afterEach(async () => {
 });
 
 describe("PVC backup policy", () => {
-  it("classifies 45 included and 23 excluded PVCs without duplicates", () => {
+  it("classifies 46 included and 23 excluded PVCs without duplicates", () => {
     const keys = PVC_BACKUP_POLICY.map((entry) =>
       pvcBackupPolicyKey(entry.namespace, entry.name),
     );
-    expect(keys).toHaveLength(68);
-    expect(new Set(keys).size).toBe(68);
+    expect(keys).toHaveLength(69);
+    expect(new Set(keys).size).toBe(69);
     expect(
       PVC_BACKUP_POLICY.filter((entry) => entry.backup === "enabled"),
-    ).toHaveLength(45);
+    ).toHaveLength(46);
     expect(
       PVC_BACKUP_POLICY.filter((entry) => entry.backup === "disabled"),
     ).toHaveLength(23);

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -33,6 +33,7 @@ import { createAllGrafanaDashboards } from "@shepherdjerred/homelab/cdk8s/src/re
 import { createDdnsApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/ddns.ts";
 import { createAppsApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/apps.ts";
 import { createScoutBetaApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/scout-beta.ts";
+import { createScoutEvalsApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/scout-evals.ts";
 import { createScoutProdApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/scout-prod.ts";
 import { createStarlightKarmaBotBetaApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/starlight-karma-bot-beta.ts";
 import { createStarlightKarmaBotProdApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/starlight-karma-bot-prod.ts";
@@ -133,6 +134,7 @@ export async function createAppsChart(app: App) {
   // Per-service ArgoCD apps
   createDdnsApp(chart);
   createScoutBetaApp(chart);
+  createScoutEvalsApp(chart);
   createScoutProdApp(chart);
   createStarlightKarmaBotBetaApp(chart);
   createStarlightKarmaBotProdApp(chart);

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout-evals.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout-evals.ts
@@ -1,0 +1,80 @@
+import type { App } from "cdk8s";
+import { Chart } from "cdk8s";
+import { Namespace } from "cdk8s-plus-31";
+import {
+  KubeNetworkPolicy,
+  IntOrString,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import { createScoutEvalsDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/scout-evals.ts";
+
+export function createScoutEvalsChart(app: App) {
+  const chart = new Chart(app, "scout-evals", {
+    namespace: "scout-evals",
+    disableResourceNameHashes: true,
+  });
+
+  new Namespace(chart, "scout-evals-namespace", {
+    metadata: {
+      name: "scout-evals",
+    },
+  });
+
+  createScoutEvalsDeployment(chart);
+
+  // NetworkPolicy: allow ingress from Tailscale only (the app has no auth —
+  // the tailnet is the trust boundary), plus the blackbox health probe.
+  new KubeNetworkPolicy(chart, "scout-evals-ingress-netpol", {
+    metadata: { name: "scout-evals-ingress-netpol" },
+    spec: {
+      podSelector: {},
+      policyTypes: ["Ingress"],
+      ingress: [
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "tailscale" },
+              },
+            },
+          ],
+        },
+        // Allow blackbox-exporter's in-cluster health probe (http service port
+        // only — not every port on the pod)
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(7341), protocol: "TCP" }],
+        },
+      ],
+    },
+  });
+
+  // NetworkPolicy: DNS-only egress — the server reads/writes local SQLite and
+  // makes no outbound calls (materialization runs on operator machines).
+  new KubeNetworkPolicy(chart, "scout-evals-egress-netpol", {
+    metadata: { name: "scout-evals-egress-netpol" },
+    spec: {
+      podSelector: {},
+      policyTypes: ["Egress"],
+      egress: [
+        {
+          to: [
+            {
+              namespaceSelector: {},
+              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+            },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(53), protocol: "UDP" },
+            { port: IntOrString.fromNumber(53), protocol: "TCP" },
+          ],
+        },
+      ],
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-evals.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-evals.ts
@@ -1,0 +1,27 @@
+import type { Chart } from "cdk8s";
+import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
+
+export function createScoutEvalsApp(chart: Chart) {
+  return new Application(chart, "scout-evals-app", {
+    metadata: {
+      name: "scout-evals",
+    },
+    spec: {
+      revisionHistoryLimit: 5,
+      project: "default",
+      source: {
+        repoUrl: "https://chartmuseum.tailnet-1a49.ts.net",
+        targetRevision: "~2.0.0-0",
+        chart: "scout-evals",
+      },
+      destination: {
+        server: "https://kubernetes.default.svc",
+        namespace: "scout-evals",
+      },
+      syncPolicy: {
+        automated: {},
+        syncOptions: ["CreateNamespace=true"],
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/scout-evals.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout-evals.ts
@@ -1,0 +1,119 @@
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  EnvValue,
+  Probe,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import {
+  withCommonProps,
+  setRevisionHistoryLimit,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+
+// Scout review evals: the post-match review calibration app
+// (packages/scout-for-lol/packages/evals). Single Bun process serving the
+// built client + tRPC API over one WAL-mode SQLite file on a PVC. The app has
+// NO auth by design — the tailnet-only TailscaleIngress is the entire trust
+// boundary. Never expose it via Funnel.
+export function createScoutEvalsDeployment(chart: Chart) {
+  const deployment = new Deployment(chart, "scout-evals", {
+    replicas: 1,
+    // Single-writer SQLite on an RWO ZFS volume: never run old and new pods
+    // concurrently.
+    strategy: DeploymentStrategy.recreate(),
+    securityContext: {
+      fsGroup: 1000,
+    },
+    metadata: {
+      annotations: {
+        "ignore-check.kube-linter.io/no-read-only-root-fs":
+          "Bun writes runtime caches under HOME; app data lives on the PVC",
+      },
+    },
+  });
+
+  const dataVolume = new ZfsNvmeVolume(chart, "scout-evals-data", {
+    storage: Size.gibibytes(1),
+  });
+
+  deployment.addContainer(
+    withCommonProps({
+      name: "scout-evals",
+      image: `ghcr.io/shepherdjerred/scout-evals:${versions["shepherdjerred/scout-evals"]}`,
+      securityContext: {
+        user: 1000,
+        group: 1000,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: false,
+      },
+      ports: [{ number: 7341, name: "http" }],
+      resources: {
+        cpu: {
+          request: Cpu.millis(50),
+          limit: Cpu.millis(500),
+        },
+        memory: {
+          request: Size.mebibytes(128),
+          limit: Size.mebibytes(512),
+        },
+      },
+      startup: Probe.fromHttpGet("/health", {
+        port: 7341,
+        periodSeconds: Duration.seconds(5),
+        failureThreshold: 12,
+      }),
+      liveness: Probe.fromHttpGet("/health", {
+        port: 7341,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      readiness: Probe.fromHttpGet("/health", {
+        port: 7341,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 3,
+      }),
+      volumeMounts: [
+        {
+          path: "/data",
+          volume: Volume.fromPersistentVolumeClaim(
+            chart,
+            "scout-evals-data-volume",
+            dataVolume.claim,
+          ),
+        },
+      ],
+      envVariables: {
+        SCOUT_EVAL_HOSTNAME: EnvValue.fromValue("0.0.0.0"),
+        SCOUT_EVAL_DATABASE_PATH: EnvValue.fromValue(
+          "/data/scout-review-evals.sqlite",
+        ),
+      },
+    }),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "scout-evals-service", {
+    metadata: {
+      labels: {
+        app: "scout-evals",
+      },
+    },
+    selector: deployment,
+    ports: [{ port: 7341, name: "http" }],
+  });
+
+  // Tailnet-only ingress — this IS the trust boundary (no app auth).
+  new TailscaleIngress(chart, "scout-evals-ingress", {
+    service,
+    host: "scout-evals",
+    probePath: "/health",
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/scout-evals.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout-evals.ts
@@ -31,12 +31,6 @@ export function createScoutEvalsDeployment(chart: Chart) {
     securityContext: {
       fsGroup: 1000,
     },
-    metadata: {
-      annotations: {
-        "ignore-check.kube-linter.io/no-read-only-root-fs":
-          "Bun writes runtime caches under HOME; app data lives on the PVC",
-      },
-    },
   });
 
   const dataVolume = new ZfsNvmeVolume(chart, "scout-evals-data", {
@@ -51,7 +45,8 @@ export function createScoutEvalsDeployment(chart: Chart) {
         user: 1000,
         group: 1000,
         ensureNonRoot: true,
-        readOnlyRootFilesystem: false,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
       },
       ports: [{ number: 7341, name: "http" }],
       resources: {
@@ -88,8 +83,16 @@ export function createScoutEvalsDeployment(chart: Chart) {
             dataVolume.claim,
           ),
         },
+        // Bun writes runtime caches under $HOME; keep the root filesystem
+        // read-only by pointing HOME at a writable emptyDir (app data still
+        // lives on the /data PVC).
+        {
+          path: "/tmp",
+          volume: Volume.fromEmptyDir(chart, "scout-evals-tmp", "tmp"),
+        },
       ],
       envVariables: {
+        HOME: EnvValue.fromValue("/tmp"),
         SCOUT_EVAL_HOSTNAME: EnvValue.fromValue("0.0.0.0"),
         SCOUT_EVAL_DATABASE_PATH: EnvValue.fromValue(
           "/data/scout-review-evals.sqlite",

--- a/packages/homelab/src/cdk8s/src/setup-charts.ts
+++ b/packages/homelab/src/cdk8s/src/setup-charts.ts
@@ -21,6 +21,7 @@ import { createGrafanaDbChart } from "./cdk8s-charts/grafana-db.ts";
 import { createS3StaticSitesChart } from "./cdk8s-charts/s3-static-sites.ts";
 import { createMcpGatewayChart } from "./cdk8s-charts/mcp-gateway.ts";
 import { createBugsinkChart } from "./cdk8s-charts/bugsink.ts";
+import { createScoutEvalsChart } from "./cdk8s-charts/scout-evals.ts";
 import { createTasknotesChart } from "./cdk8s-charts/tasknotes.ts";
 import { createRelayChart } from "./cdk8s-charts/relay.ts";
 import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
@@ -72,6 +73,7 @@ export async function setupCharts(app: App): Promise<void> {
   createGrafanaDbChart(app);
   await createMcpGatewayChart(app);
   createBugsinkChart(app);
+  createScoutEvalsChart(app);
   createTasknotesChart(app);
   createRelayChart(app);
   createTemporalChart(app);


### PR DESCRIPTION
Layer 2 of the scout-evals hosting stack (on top of #1955): the homelab deployment.

- New `scout-evals` chart: single-replica **recreate** deployment (single-writer SQLite on an RWO volume), running as uid 1000 with `fsGroup: 1000`.
- 1 GiB `ZfsNvmeVolume` mounted at `/data` (`SCOUT_EVAL_DATABASE_PATH=/data/scout-review-evals.sqlite`), **Velero backup enabled** — human ratings live only here.
- Tailnet-only `TailscaleIngress` at `scout-evals` with `/health` probe. The app has no auth by design; the tailnet is the entire trust boundary. Never Funnel.
- NetworkPolicies: ingress from the tailscale namespace + prometheus blackbox on 7341 only; DNS-only egress (the server makes no outbound calls).
- Standard helm chart dir + ArgoCD Application, registered in `setup-charts.ts` / `apps.ts`; backup-policy entry + count fixture.

## Merge ordering

**Merge #1955 first and wait for its main build's version commit-back PR to land** — that replaces the placeholder `shepherdjerred/scout-evals` pin with a real tag@digest. Merging this PR before then would have ArgoCD deploy an unpullable image (self-heals after commit-back, but avoidable).

## Verification

- Homelab cdk8s: build + typecheck + lint clean, full suite 316 pass / 0 fail (helm render, PVC backup policy, container resources).
- Post-merge: `argocd app get scout-evals` Healthy → `curl https://scout-evals.<tailnet>.ts.net/health` → rate a pushed draft in the hosted UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbcP3C5RVs59k5EY4BsKfN