### PR TITLE
fix(homelab): ignore mcMMO party.yml drift so shuxin starts

### DIFF
--- a/packages/docs/logs/2026-08-02_main-ci-green-session.md
+++ b/packages/docs/logs/2026-08-02_main-ci-green-session.md
@@ -117,24 +117,39 @@ may hit server-specific plugin/config issues) — see Remaining.
 - PR #1952 (merged): route `config/*` off itzg's `/config` sync via `/config-subdir`
   - init `cp`-seed; `set -e`; `${CFG_*}` guard. Validated live: no more
     `DirectoryNotEmptyException`.
-- PR #1958 (open): bump itzg image to java25 to match Paper 26.1.2. Smoke-tested
-  live: sjerred reached `1/1 Running`.
+- PR #1958 (merged): bump itzg image to java25 to match Paper 26.1.2. Deployed
+  and validated live — **sjerred and tsmc both reach `1/1 Running`** on java25.
+- **shuxin** had a second issue: its `check-config-drift` init container (from
+  #1927) refused to start on `mcMMO/party.yml` drift (mcMMO reindents nested maps
+  2→4 spaces on boot, same class as the already-ignored `chat.yml`). PR
+  (fix/minecraft-shuxin-drift): add `./mcMMO/party.yml` to the drift-check
+  `is_ignored()` allow-list.
+- **tsmc** had a third issue: `FileSystemException: /data/plugins/DiscordSRV/
+config.yml: Operation not permitted`. The file was **root-owned** on the PVC
+  (historical cruft, alongside dozens of stale ConfigMap `..timestamp` artifact
+  dirs), so itzg (uid 1000) could not overwrite it. Manifest is correct (same as
+  sjerred). Fix was a one-time PVC cleanup: deleted the root-owned `config.yml`
+  (+ the stale artifact dirs) via a uid-1000 debug pod; itzg recreates it as
+  uid 1000. tsmc then reached `1/1 Running`. No code change needed — durable
+  because itzg runs as uid 1000.
 
 ### Remaining
 
-- Merge #1958 after CI + review gate pass.
-- After #1958 deploys, confirm all three servers reach Healthy and `apps` returns
-  to Healthy (delete the crash-looping pods so RollingUpdate applies the new
-  revision — a not-Ready pod blocks the roll otherwise).
-- Confirm a `main` build then completes the `argo: sync + wait` gate green (needs
-  a quiet window — rapid merges keep canceling in-flight main builds mid-argo).
+- Merge the shuxin drift-check PR; after it deploys, delete `minecraft-shuxin-0`
+  so it rolls onto the new drift-check + java25, and confirm it reaches Healthy
+  (watch for the same DiscordSRV root-owned-config cruft on shuxin's PVC — clean
+  it the same way if present).
+- With all three Healthy, `apps` returns to Healthy → confirm a `main` build
+  completes the `argo: sync + wait` gate green (needs a quiet window — rapid
+  merges keep canceling in-flight main builds mid-argo).
 
 ### Caveats
 
-- The minecraft fix is verified at the manifest level and by root-cause analysis,
-  but itzg's runtime ordering (whether it preserves the init-seeded paper config
-  vs. regenerating it) is only fully confirmable post-deploy. The crash is
-  eliminated either way; only _which_ paper config wins needs the live check.
+- The tsmc DiscordSRV fix was operational (PVC state), not code. Root cause of the
+  original root-ownership is historical (likely a past root-running deployment or
+  a ConfigMap once mounted onto the PVC path); the current manifest mounts the
+  config at `/plugins/...` correctly. If root-owned plugin files reappear, a
+  durable init-container safeguard would be warranted.
 - Minecraft servers hibernate at replicas 0 (mc-router); they only block the argo
   gate while woken+crashing. Something (likely the bluemap ingress) kept them
   woken through this session.

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.ts
@@ -74,9 +74,10 @@ is_ignored() {
     ./Geyser-Spigot/config.yml) return 0 ;;
     # Paper re-serializes commands.yml (SnakeYAML flattens the block-sequence
     # indentation), spark writes config.json via GSON (no trailing newline), and
-    # mcMMO re-serializes chat.yml (Bukkit YamlConfiguration reorders keys) — all
-    # normalized on disk at boot, so byte-compare always drifts.
-    ./commands.yml|./spark/config.json|./mcMMO/chat.yml) return 0 ;;
+    # mcMMO re-serializes chat.yml and party.yml (Bukkit YamlConfiguration
+    # reorders keys and reindents nested maps to 4 spaces) — all normalized on
+    # disk at boot, so byte-compare always drifts.
+    ./commands.yml|./spark/config.json|./mcMMO/chat.yml|./mcMMO/party.yml) return 0 ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
shuxin's check-config-drift init container refuses to start on
'DRIFT DETECTED: mcMMO/party.yml differs from repo' — mcMMO reindents the
nested Party map (2->4 spaces) on every boot, the same normalization class
already ignored for chat.yml, commands.yml and spark/config.json. Add
./mcMMO/party.yml to the is_ignored() allow-list.

Also records the shuxin + tsmc per-server fixes in the session log (tsmc's
root-owned DiscordSRV config.yml was a one-time PVC cleanup; sjerred and tsmc
now run 1/1 on java25).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011YURVLggWRQXjaG1Er5eY1

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>