### PR TITLE
fix(pr-fleet-controller): harden worker lifecycle

### DIFF
--- a/packages/docs/plans/2026-08-02_pr-fleet-observability-replay.md
+++ b/packages/docs/plans/2026-08-02_pr-fleet-observability-replay.md
@@ -1,0 +1,146 @@
+---
+id: pr-fleet-observability-replay
+type: plan
+status: in-progress
+board: false
+---
+
+# PR Fleet Observability and Replay
+
+## Goal
+
+Make `pr:fleet` produce a complete, locally inspectable, redacted record of
+each controller run so future evaluation work can use real evidence. This work
+collects data and provides deterministic control-plane replay; it does not add
+datasets, scorers, model judges, experiments, or evaluation gates.
+
+## Stack
+
+Two native GitHub stack layers keep runtime hardening independently reviewable:
+
+1. `fix/pr-fleet-runtime-safety`
+2. `feat/pr-fleet-observability`
+
+Both layers use the same isolated worktree and remain draft until focused
+verification is complete.
+
+## Runtime safety layer
+
+- Terminate command process groups on timeout so descendants cannot survive.
+- Remove controller-managed persistent `mise trust`; setup uses Mise paranoid
+  mode plus invocation-scoped trust for the exact assigned `.mise.toml` inside
+  the credential-scrubbed setup sandbox.
+- Validate changed and deleted publication paths without requiring a deleted
+  parent directory to still exist.
+- Rearm heartbeat scheduling after a failed tick.
+- Shut the controller down cleanly when terminal input reaches EOF.
+- Cover each repaired failure mode with focused Bun tests.
+
+## Collection layer
+
+### Mandatory local run bundle
+
+Every controller start creates a private run directory below
+`${XDG_STATE_HOME:-~/.local/state}/pr-fleet-controller`, or below the explicit
+`--state-dir` path. Startup fails before model access or repository mutation if
+the directory cannot be created with safe permissions.
+
+Each run stores:
+
+- `manifest.json` — immutable run identity, versions, model, repository, and
+  capture contract.
+- `events.jsonl` — schema-versioned, monotonically sequenced, hash-chained,
+  redacted events.
+- `summary.json` — completion state and aggregate counts/durations.
+- `mastra.db` — local Mastra storage.
+- `observability.duckdb` — local Mastra trace and metric storage.
+
+Run directories use mode `0700`; persisted files use mode `0600`. Runs are
+retained indefinitely in v1. There is no automatic pruning.
+
+### Event contract
+
+Events carry `schemaVersion: 1`, a sequence number, timestamp, previous hash,
+event hash, event kind, and correlation fields where applicable: run, trace,
+causation, tick, PR number, head SHA, generation, model turn, tool call, and
+command.
+
+Capture includes:
+
+- startup, operator input, shutdown, cancellation, and errors;
+- tick lifecycle, fleet snapshots, state transitions, dispatch decisions, and
+  final state;
+- worker lifecycle, retry attempts, model input/output, step/tool activity,
+  and structured worker results;
+- command arguments, working directory, output, exit status, duration, and
+  timeout state;
+- patches, publication attempts/results, review results, and controller
+  steering.
+
+All payloads pass through the repository redactor before any persistence.
+Credential values and authorization material must never be written.
+
+### Mastra observability
+
+Register master and worker agents with one run-scoped Mastra instance. Use
+run-scoped local storage and observability exporters so model spans, tool spans,
+token usage, cost, and durations are retained alongside the event stream.
+Keep exporter construction behind a seam suitable for a future OTLP exporter;
+v1 does not add central Tempo, Loki, or Prometheus infrastructure.
+
+## Inspection and replay
+
+Add two root commands:
+
+```bash
+bun run pr:fleet:inspect --run <id-or-path> [--state-dir <path>] [--pr <number>] [--show-bodies] [--json]
+bun run pr:fleet:replay --run <id-or-path> [--state-dir <path>] [--allow-version-mismatch] [--json]
+```
+
+Inspection verifies the hash chain and renders the exact correlated timeline,
+with bodies hidden unless explicitly requested.
+
+Replay verifies the bundle, rejects incompatible versions by default, and
+re-executes controller decisions against recorded environment and worker
+responses. Replay must not resolve a model, read credentials, access the
+network, spawn commands, or write to repository checkouts. It compares state
+transitions, dispatch decisions, snapshots, and final state with the recording
+and exits nonzero on divergence.
+
+## Verification
+
+- Focused package tests for safety fixes, secure bundle creation, redaction,
+  event ordering/hash integrity, failure finalization, inspection filters, and
+  offline replay equivalence/divergence.
+- Package typecheck, test, lint, and build tasks.
+- Staged-file Lefthook checks and root docs validation.
+- A zero-open-PR Terra smoke run to prove capture without branch mutation.
+- Synthetic worker scenarios to exercise retries, failures, publication
+  records, and replay without touching a real PR.
+- An asciinema recording of real inspect/replay output attached to the upper
+  draft PR.
+- Exact-current-head Buildkite and hosted review verification for both stack
+  layers. No merge without explicit authorization.
+
+## Non-goals
+
+- No evaluation dataset or corpus materialization.
+- No scorers, grading, model judges, experiments, or benchmark runner.
+- No CI evaluation gate.
+- No retention pruning or remote upload.
+- No live mutating PR-fleet canary without separate authorization.
+
+## Session Log — 2026-08-02
+
+### Done
+
+- Approved the collection-only design and two-layer native stack boundary.
+
+### Remaining
+
+- Implement, verify, publish, and drive both draft PRs to green.
+
+### Caveats
+
+- Live mutating controller acceptance remains prohibited unless separately
+  authorized; verification uses zero-PR and synthetic scenarios.

--- a/packages/pr-fleet-controller/README.md
+++ b/packages/pr-fleet-controller/README.md
@@ -38,8 +38,8 @@ Interactive input:
 - `/status` prints the deterministic fleet snapshot.
 - `/tick` requests an immediate complete reconciliation.
 - `/help` prints command help.
-- `/stop` aborts active model turns, preserves worktrees, waits for workers to
-  settle, and exits.
+- `/stop` or terminal EOF aborts active model turns, preserves worktrees, waits
+  for workers to settle, and exits.
 - Any other line is queued as conversational steering. Input remains available
   while the master is answering; queued messages are handled by the next
   serialized master turn.
@@ -77,6 +77,14 @@ denied, and a credential-scrubbed environment so tool output cannot exfiltrate
 host secrets. Only read-only script and task forms are accepted. Publication,
 worktree creation, current-head verification, review-request deduplication, and
 timers remain deterministic controller operations.
+
+Worktree setup never runs `mise trust`: the controller does not persist trust
+for configuration supplied by a pull request. Setup enables Mise paranoid mode
+and grants invocation-scoped trust to only the assigned worktree's exact
+`.mise.toml` while it runs inside the credential-scrubbed setup sandbox. Command
+timeouts, cancellation, and shutdown terminate the command's complete POSIX
+process group so descendant processes cannot outlive the worker that spawned
+them.
 
 The controller never merges, closes, or approves a pull request.
 

--- a/packages/pr-fleet-controller/src/cli.ts
+++ b/packages/pr-fleet-controller/src/cli.ts
@@ -12,6 +12,7 @@ import { CommandFleetEnvironment } from "./environment.ts";
 import type { FleetObserver } from "./ports.ts";
 import { FleetControllerConfigSchema, type FleetSnapshot } from "./schemas.ts";
 import { FleetStore } from "./state.ts";
+import { consumeTerminalLines } from "./terminal-loop.ts";
 
 const HELP = `Usage:
   bun run pr:fleet --model <provider>/<model> [options]
@@ -227,35 +228,39 @@ async function main(): Promise<void> {
   await controller.start();
   terminal.setPrompt("fleet> ");
   terminal.prompt();
-  for await (const rawLine of terminal) {
-    const line = rawLine.trim();
-    if (line === "/stop") {
-      await stop();
-      break;
-    }
-    switch (line) {
-      case "/status": {
-        observer.onSnapshot(controller.snapshot());
-
-        break;
+  await consumeTerminalLines(
+    terminal,
+    async (rawLine) => {
+      const line = rawLine.trim();
+      if (line === "/stop") {
+        return "stop";
       }
-      case "/tick": {
-        await controller.tick("user");
+      switch (line) {
+        case "/status": {
+          observer.onSnapshot(controller.snapshot());
 
-        break;
-      }
-      case "/help": {
-        process.stdout.write(`${HELP}\n`);
-
-        break;
-      }
-      default:
-        if (line.length > 0) {
-          master.send(line);
+          break;
         }
-    }
-    terminal.prompt();
-  }
+        case "/tick": {
+          await controller.tick("user");
+
+          break;
+        }
+        case "/help": {
+          process.stdout.write(`${HELP}\n`);
+
+          break;
+        }
+        default:
+          if (line.length > 0) {
+            master.send(line);
+          }
+      }
+      terminal.prompt();
+      return "continue";
+    },
+    stop,
+  );
 }
 
 try {

--- a/packages/pr-fleet-controller/src/controller.ts
+++ b/packages/pr-fleet-controller/src/controller.ts
@@ -2,6 +2,7 @@ import type {
   FleetControllerDependencies,
   FleetEnvironment,
   FleetObserver,
+  FleetScheduler,
   WorkerRunner,
 } from "./ports.ts";
 import {
@@ -29,9 +30,10 @@ export class FleetController implements MasterControllerTools {
   readonly #environment: FleetEnvironment;
   readonly #workerRunner: WorkerRunner;
   readonly #observer: FleetObserver;
+  readonly #scheduler: FleetScheduler;
   readonly #workflow;
   readonly store: FleetStore;
-  #heartbeat: ReturnType<typeof setTimeout> | null = null;
+  #heartbeat: (() => void) | null = null;
   #tickRunning = false;
   #tickDue = false;
 
@@ -41,6 +43,16 @@ export class FleetController implements MasterControllerTools {
     this.#environment = environment;
     this.#workerRunner = workerRunner;
     this.#observer = observer;
+    this.#scheduler =
+      dependencies.scheduler ??
+      ({
+        schedule: (callback, delayMs) => {
+          const timer = setTimeout(callback, delayMs);
+          return () => {
+            clearTimeout(timer);
+          };
+        },
+      } satisfies FleetScheduler);
     this.store = dependencies.store ?? new FleetStore(config.maxWorkers);
     this.#workflow = createFleetTickWorkflow((trigger) =>
       this.#executeTick(trigger),
@@ -392,9 +404,9 @@ export class FleetController implements MasterControllerTools {
       return;
     }
     if (this.#heartbeat !== null) {
-      clearTimeout(this.#heartbeat);
+      this.#heartbeat();
     }
-    this.#heartbeat = setTimeout(() => {
+    this.#heartbeat = this.#scheduler.schedule(() => {
       this.#heartbeat = null;
       void this.#runTickSafely("heartbeat", "heartbeat");
     }, seconds * 1000);
@@ -406,6 +418,12 @@ export class FleetController implements MasterControllerTools {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.#observer.onChange(`${label} failed: ${message}`);
+      // A heartbeat clears its handle before starting the tick. If that tick
+      // fails, rearm it so one transient external outage does not permanently
+      // stop fleet reconciliation. Other tick triggers retain their timer.
+      if (!this.store.stopping && this.#heartbeat === null) {
+        this.#armHeartbeat(300);
+      }
     }
   }
 
@@ -475,7 +493,7 @@ export class FleetController implements MasterControllerTools {
   async stop(): Promise<FleetSnapshot> {
     this.store.stopping = true;
     if (this.#heartbeat !== null) {
-      clearTimeout(this.#heartbeat);
+      this.#heartbeat();
       this.#heartbeat = null;
     }
     for (const controller of this.store.workerControllers.values()) {

--- a/packages/pr-fleet-controller/src/environment.ts
+++ b/packages/pr-fleet-controller/src/environment.ts
@@ -22,6 +22,7 @@ import type {
   CommandResult,
   FleetEnvironment,
 } from "./ports.ts";
+import { runCommand } from "./process-runner.ts";
 import type {
   CheckEvidence,
   PrIdentity,
@@ -64,32 +65,7 @@ export class CommandFleetEnvironment implements FleetEnvironment {
   }
 
   async runLocalCommand(request: CommandRequest): Promise<CommandResult> {
-    const baseOptions = {
-      cwd: request.cwd,
-      stdout: "pipe" as const,
-      stderr: "pipe" as const,
-      env: request.env ?? Bun.env,
-    };
-    const subprocess =
-      request.signal === undefined
-        ? Bun.spawn([request.executable, ...request.args], baseOptions)
-        : Bun.spawn([request.executable, ...request.args], {
-            ...baseOptions,
-            signal: request.signal,
-          });
-    const timer = setTimeout(() => {
-      subprocess.kill();
-    }, request.timeoutMs);
-    try {
-      const [exitCode, stdout, stderr] = await Promise.all([
-        subprocess.exited,
-        new Response(subprocess.stdout).text(),
-        new Response(subprocess.stderr).text(),
-      ]);
-      return { exitCode, stdout, stderr };
-    } finally {
-      clearTimeout(timer);
-    }
+    return runCommand(request);
   }
 
   async #mustRun(

--- a/packages/pr-fleet-controller/src/git-operations.ts
+++ b/packages/pr-fleet-controller/src/git-operations.ts
@@ -1,6 +1,7 @@
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import type { ReviewProvider } from "@shepherdjerred/code-review";
+import { z } from "zod";
 import { parseHeadSha, splitRepo } from "./evidence-parsers.ts";
 import type { CommandRequest, CommandResult } from "./ports.ts";
 import type { PrState } from "./schemas.ts";
@@ -16,6 +17,33 @@ type GitOperationsDependencies = {
     options?: { timeoutMs?: number; signal?: AbortSignal | undefined },
   ) => Promise<string>;
 };
+
+const SystemErrorSchema = z.object({ code: z.string() });
+
+function isMissingPath(error: unknown): boolean {
+  const parsed = SystemErrorSchema.safeParse(error);
+  return parsed.success && parsed.data.code === "ENOENT";
+}
+
+async function nearestExistingAncestor(target: string): Promise<string> {
+  try {
+    await stat(target);
+    return target;
+  } catch (error) {
+    if (!isMissingPath(error)) {
+      throw error instanceof Error
+        ? error
+        : new Error("Failed to inspect publication path", { cause: error });
+    }
+    const parent = path.dirname(target);
+    if (parent === target) {
+      throw new Error(`No existing ancestor for publication path: ${target}`, {
+        cause: error,
+      });
+    }
+    return nearestExistingAncestor(parent);
+  }
+}
 
 export class GitOperations {
   readonly #repo: string;
@@ -41,9 +69,18 @@ export class GitOperations {
         throw new Error(`Unsafe publication path: ${requestedPath}`);
       }
       const absolute = path.resolve(canonicalRoot, requestedPath);
-      const canonicalParent = await realpath(path.dirname(absolute));
-      const relativeParent = path.relative(canonicalRoot, canonicalParent);
-      if (relativeParent.startsWith("..") || path.isAbsolute(relativeParent)) {
+      // A deletion may remove its whole parent directory. Resolve the nearest
+      // ancestor that still exists, which supports that legitimate pathspec
+      // while still detecting a surviving symlink that escapes the worktree.
+      const existingAncestor = await nearestExistingAncestor(
+        path.dirname(absolute),
+      );
+      const canonicalAncestor = await realpath(existingAncestor);
+      const relativeAncestor = path.relative(canonicalRoot, canonicalAncestor);
+      if (
+        relativeAncestor.startsWith("..") ||
+        path.isAbsolute(relativeAncestor)
+      ) {
         throw new Error(`Publication path escapes worktree: ${requestedPath}`);
       }
       // Reject directory pathspecs. `git add -- .` or a package directory would
@@ -53,11 +90,7 @@ export class GitOperations {
       // (an explicit deletion). A path resolving to an existing directory — or
       // any other non-regular-file — is rejected.
       const stats = await stat(absolute).catch((error: unknown) => {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          error.code === "ENOENT"
-        ) {
+        if (isMissingPath(error)) {
           // Missing path: an explicit file deletion is a valid publication entry.
           return null;
         }

--- a/packages/pr-fleet-controller/src/ports.ts
+++ b/packages/pr-fleet-controller/src/ports.ts
@@ -63,10 +63,15 @@ export type FleetObserver = {
   onMasterText: (text: string) => void;
 };
 
+export type FleetScheduler = {
+  schedule: (callback: () => void, delayMs: number) => () => void;
+};
+
 export type FleetControllerDependencies = {
   config: FleetControllerConfig;
   environment: FleetEnvironment;
   workerRunner: WorkerRunner;
   observer: FleetObserver;
   store?: FleetStore;
+  scheduler?: FleetScheduler;
 };

--- a/packages/pr-fleet-controller/src/process-runner.ts
+++ b/packages/pr-fleet-controller/src/process-runner.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import type { CommandRequest, CommandResult } from "./ports.ts";
+
+const SystemErrorSchema = z.object({ code: z.string() });
+
+function errorHasCode(error: unknown, code: string): boolean {
+  const parsed = SystemErrorSchema.safeParse(error);
+  return parsed.success && parsed.data.code === code;
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error("Non-Error command termination failure", { cause: error });
+}
+
+function killProcessGroup(pid: number): void {
+  if (process.platform === "win32") {
+    throw new Error("PR fleet process-group termination requires POSIX");
+  }
+  try {
+    // A detached Bun subprocess leads a new POSIX process group. A negative
+    // PID targets the complete group, including grandchildren.
+    process.kill(-pid, "SIGKILL");
+  } catch (error) {
+    if (!errorHasCode(error, "ESRCH")) {
+      throw normalizeError(error);
+    }
+  }
+}
+
+export async function runCommand(
+  request: CommandRequest,
+): Promise<CommandResult> {
+  if (request.signal?.aborted === true) {
+    throw new Error(`Command aborted before start: ${request.executable}`);
+  }
+  const subprocess = Bun.spawn([request.executable, ...request.args], {
+    cwd: request.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: request.env ?? Bun.env,
+    detached: true,
+  });
+  const terminationFailure = Promise.withResolvers<never>();
+  const terminate = (): void => {
+    try {
+      killProcessGroup(subprocess.pid);
+    } catch (error) {
+      // Keep the direct-child safety net if group signaling itself fails.
+      // The captured error rejects the command after the child is killed.
+      subprocess.kill("SIGKILL");
+      terminationFailure.reject(normalizeError(error));
+    }
+  };
+  const timer = setTimeout(() => {
+    terminate();
+  }, request.timeoutMs);
+  request.signal?.addEventListener("abort", terminate, { once: true });
+  try {
+    const [exitCode, stdout, stderr] = await Promise.race([
+      Promise.all([
+        subprocess.exited,
+        new Response(subprocess.stdout).text(),
+        new Response(subprocess.stderr).text(),
+      ]),
+      terminationFailure.promise,
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timer);
+    request.signal?.removeEventListener("abort", terminate);
+  }
+}

--- a/packages/pr-fleet-controller/src/sandbox.ts
+++ b/packages/pr-fleet-controller/src/sandbox.ts
@@ -52,8 +52,10 @@ const READABLE_HOME_SUBPATHS = [
 // otherwise replace a toolchain binary the operator later runs OUTSIDE the
 // sandbox with normal credentials.
 //
-// `bun install --frozen-lockfile` writes only its module cache; `mise trust`
-// writes its trust state; `mise` reads (not writes) already-installed runtimes.
+// `bun install --frozen-lockfile` writes only its module cache; `mise` reads
+// (not writes) already-installed runtimes. Setup grants invocation-scoped trust
+// to the exact worktree config through its environment, with paranoid mode
+// disabling inherited/cross-worktree trust; it never persists a trust decision.
 // `mise install` for a NOT-yet-installed pinned runtime would need to write the
 // install dir and thus fails fast here — an acceptable, documented trade-off:
 // the fleet runs on the operator's machine where the pinned toolchain is already
@@ -289,10 +291,17 @@ export function sanitizedEnvironment(
 // git from chasing machine-specific config `include`s under the sandbox-denied
 // $HOME.
 export function setupEnvironment(
-  extraSecretNames: readonly string[] = [],
+  extraSecretNames: readonly string[],
+  miseConfigPath: string,
 ): Record<string, string | undefined> {
   const environment = sanitizedEnvironment(extraSecretNames);
   environment["GIT_CONFIG_GLOBAL"] = "/dev/null";
   environment["GIT_CONFIG_SYSTEM"] = "/dev/null";
+  // The setup command intentionally evaluates this PR's tool configuration
+  // inside the credential-scrubbed sandbox. Trust exactly that file for this
+  // subprocess tree, while paranoid mode disables persisted and repository-wide
+  // worktree trust. No `mise trust` mutation reaches the operator's machine.
+  environment["MISE_PARANOID"] = "1";
+  environment["MISE_TRUSTED_CONFIG_PATHS"] = miseConfigPath;
   return environment;
 }

--- a/packages/pr-fleet-controller/src/terminal-loop.ts
+++ b/packages/pr-fleet-controller/src/terminal-loop.ts
@@ -1,0 +1,20 @@
+export type TerminalLineResult = "continue" | "stop";
+
+export async function consumeTerminalLines(
+  lines: AsyncIterable<string>,
+  onLine: (line: string) => Promise<TerminalLineResult>,
+  onEnd: () => Promise<void>,
+): Promise<void> {
+  try {
+    for await (const line of lines) {
+      if ((await onLine(line)) === "stop") {
+        return;
+      }
+    }
+  } finally {
+    // EOF, an input failure, and an explicit stop all converge on the same
+    // idempotent shutdown path, so workers and model turns cannot outlive the
+    // terminal that owned them.
+    await onEnd();
+  }
+}

--- a/packages/pr-fleet-controller/src/tools.ts
+++ b/packages/pr-fleet-controller/src/tools.ts
@@ -14,6 +14,13 @@ import {
 import { LeaseKindSchema, PrStateSchema, type PrState } from "./schemas.ts";
 import type { FleetStore } from "./state.ts";
 
+export const SETUP_COMMANDS = [
+  { executable: "mise", args: ["install"] },
+  { executable: "bun", args: ["install", "--frozen-lockfile"] },
+  { executable: "bunx", args: ["turbo", "run", "generate"] },
+  { executable: "bunx", args: ["lefthook", "install"] },
+] satisfies { executable: string; args: string[] }[];
+
 async function containedPath(
   root: string,
   requestedPath: string,
@@ -247,27 +254,26 @@ export function createWorkerTools(
           store.releaseLease(pr.identity.number, "setup", pr.stackId);
           throw new Error("Heavy lease is not available for generation");
         }
-        const commands: { executable: string; args: string[] }[] = [
-          { executable: "mise", args: ["trust", "-y", "--all"] },
-          { executable: "mise", args: ["install"] },
-          { executable: "bun", args: ["install", "--frozen-lockfile"] },
-          { executable: "bunx", args: ["turbo", "run", "generate"] },
-          { executable: "bunx", args: ["lefthook", "install"] },
-        ];
         const completed: string[] = [];
         try {
           // These commands execute PR-controlled code (dependency lifecycle
-          // scripts, `turbo` generators, `.mise.toml`). Run each under the setup
-          // sandbox profile with scrubbed credentials so a malicious PR cannot
-          // read or exfiltrate the operator's credentials before validation.
+          // scripts, `turbo` generators, `.mise.toml`). The worker never
+          // persists trust for PR-controlled configuration: setup grants the
+          // exact worktree config invocation-scoped trust in paranoid mode.
+          // Run each command under the setup sandbox profile with scrubbed
+          // credentials so a malicious PR cannot read or exfiltrate operator
+          // credentials before validation.
           const directories = await resolveSetupDirectories(
             worktree,
             environment,
             signal,
           );
           const profile = setupSandboxProfile(worktree, directories);
-          const commandEnvironment = setupEnvironment(extraSecretNames);
-          for (const command of commands) {
+          const commandEnvironment = setupEnvironment(
+            extraSecretNames,
+            path.join(worktree, ".mise.toml"),
+          );
+          for (const command of SETUP_COMMANDS) {
             const result = await environment.runLocalCommand({
               executable: "sandbox-exec",
               args: ["-p", profile, command.executable, ...command.args],

--- a/packages/pr-fleet-controller/test/controller.test.ts
+++ b/packages/pr-fleet-controller/test/controller.test.ts
@@ -4,6 +4,7 @@ import type {
   CommandRequest,
   FleetEnvironment,
   FleetObserver,
+  FleetScheduler,
   WorkerRunner,
 } from "@shepherdjerred/pr-fleet-controller/src/ports.ts";
 import type {
@@ -188,6 +189,38 @@ class RecordingObserver implements FleetObserver {
   }
 }
 
+class RecordingScheduler implements FleetScheduler {
+  readonly callbacks = new Set<() => void>();
+
+  schedule(callback: () => void): () => void {
+    this.callbacks.add(callback);
+    return () => {
+      this.callbacks.delete(callback);
+    };
+  }
+
+  fireNext(): void {
+    for (const callback of this.callbacks) {
+      this.callbacks.delete(callback);
+      callback();
+      return;
+    }
+    throw new Error("No scheduled heartbeat");
+  }
+}
+
+class OneFailureEnvironment extends FakeEnvironment {
+  failNextList = false;
+
+  override listOpenPrs(): Promise<PrIdentity[]> {
+    if (this.failNextList) {
+      this.failNextList = false;
+      return Promise.reject(new Error("transient GitHub failure"));
+    }
+    return super.listOpenPrs();
+  }
+}
+
 test("a fleet tick classifies every PR and queues excess actionable work", async () => {
   const first = identity(1);
   const second = identity(2);
@@ -226,6 +259,39 @@ test("a fleet tick classifies every PR and queues excess actionable work", async
   expect(report.snapshot.queued).toBe(1);
   expect(observer.snapshots).toHaveLength(1);
   await controller.stop();
+});
+
+test("a failed heartbeat rearms reconciliation", async () => {
+  const environment = new OneFailureEnvironment([], new Map());
+  const observer = new RecordingObserver();
+  const scheduler = new RecordingScheduler();
+  const controller = new FleetController({
+    config: {
+      model: "openai/gpt-5",
+      repo: "shepherdjerred/monorepo",
+      checkout: "/tmp/repo",
+      worktreeRoot: "/tmp/worktrees",
+      maxWorkers: 1,
+    },
+    environment,
+    workerRunner: new BlockingRunner(),
+    observer,
+    store: new FleetStore(1),
+    scheduler,
+  });
+
+  await controller.start();
+  expect(scheduler.callbacks.size).toBe(1);
+  environment.failNextList = true;
+  scheduler.fireNext();
+  await flushMicrotasks();
+
+  expect(
+    observer.changes.some((change) => change.startsWith("heartbeat failed:")),
+  ).toBe(true);
+  expect(scheduler.callbacks.size).toBe(1);
+  await controller.stop();
+  expect(scheduler.callbacks.size).toBe(0);
 });
 
 test("aborts a worker whose assigned head changes and does not pause it", async () => {

--- a/packages/pr-fleet-controller/test/environment.test.ts
+++ b/packages/pr-fleet-controller/test/environment.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { codexProvider } from "@shepherdjerred/code-review";
+import { CommandFleetEnvironment } from "@shepherdjerred/pr-fleet-controller/src/environment.ts";
+
+describe("command process-group termination", () => {
+  let directory: string;
+
+  beforeAll(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "pr-fleet-process-group-"));
+  });
+
+  afterAll(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  const environment = new CommandFleetEnvironment(
+    "shepherdjerred/monorepo",
+    "/tmp/repo",
+    "/tmp/worktrees",
+    codexProvider,
+  );
+
+  async function runDescendant(output: string, signal?: AbortSignal) {
+    const bun = Bun.which("bun");
+    if (bun === null) {
+      throw new Error("bun is required for process-group tests");
+    }
+    const script = `
+      const output = Bun.argv.at(-1);
+      if (output === undefined) throw new Error("missing output path");
+      const child = Bun.spawn([
+        "sh",
+        "-c",
+        'sleep 0.25; printf survived > "$1"',
+        "child",
+        output,
+      ]);
+      await child.exited;
+    `;
+    return environment.runLocalCommand({
+      executable: bun,
+      args: ["-e", script, output],
+      cwd: directory,
+      timeoutMs: signal === undefined ? 50 : 5000,
+      signal,
+    });
+  }
+
+  test("a timeout kills grandchildren before they can outlive the command", async () => {
+    const output = path.join(directory, "timeout-survivor.txt");
+    const result = await runDescendant(output);
+    expect(result.exitCode).not.toBe(0);
+    await Bun.sleep(400);
+    expect(await Bun.file(output).exists()).toBe(false);
+  });
+
+  test("an abort kills the same complete process group", async () => {
+    const output = path.join(directory, "abort-survivor.txt");
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort();
+    }, 50);
+    try {
+      const result = await runDescendant(output, controller.signal);
+      expect(result.exitCode).not.toBe(0);
+    } finally {
+      clearTimeout(timer);
+    }
+    await Bun.sleep(400);
+    expect(await Bun.file(output).exists()).toBe(false);
+  });
+});

--- a/packages/pr-fleet-controller/test/git-operations.test.ts
+++ b/packages/pr-fleet-controller/test/git-operations.test.ts
@@ -149,6 +149,22 @@ describe("validatePaths rejects directory pathspecs", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  test("accepts a deletion whose parent directory was also removed", async () => {
+    const fake = fakeGit(0);
+    const result = await operations(fake).continueRestack(prAt(worktree), [
+      "removed-parent/nested/gone.ts",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(
+      fake.mustCalls.some(
+        (call) =>
+          call[0] === "git" &&
+          call[1] === "add" &&
+          call.includes("removed-parent/nested/gone.ts"),
+      ),
+    ).toBe(true);
+  });
+
   test("rejects a directory pathspec and never stages it", async () => {
     const fake = fakeGit(0);
     await expect(

--- a/packages/pr-fleet-controller/test/sandbox.test.ts
+++ b/packages/pr-fleet-controller/test/sandbox.test.ts
@@ -5,6 +5,7 @@ import {
   setupEnvironment,
   setupSandboxProfile,
 } from "@shepherdjerred/pr-fleet-controller/src/sandbox.ts";
+import { SETUP_COMMANDS } from "@shepherdjerred/pr-fleet-controller/src/tools.ts";
 
 describe("validation sandbox profile", () => {
   const worktree = "/tmp/pr-fleet-worktree";
@@ -65,9 +66,12 @@ describe("credential env scrubbing", () => {
 
     // Passing the configured name removes it from validation and setup envs.
     expect(sanitizedEnvironment(["LLM_ACCESS"])["LLM_ACCESS"]).toBeUndefined();
-    const setup = setupEnvironment(["LLM_ACCESS"]);
+    const miseConfig = "/tmp/pr-fleet-worktree/.mise.toml";
+    const setup = setupEnvironment(["LLM_ACCESS"], miseConfig);
     expect(setup["LLM_ACCESS"]).toBeUndefined();
     expect(setup["GIT_CONFIG_GLOBAL"]).toBe("/dev/null");
+    expect(setup["MISE_PARANOID"]).toBe("1");
+    expect(setup["MISE_TRUSTED_CONFIG_PATHS"]).toBe(miseConfig);
   });
 });
 
@@ -99,5 +103,14 @@ describe("setup sandbox write scope", () => {
   test("still permits network and denies the operator's credential stores", () => {
     expect(profile).toContain("(allow network*)");
     expect(profile).toContain(`(deny file-read* (subpath "${home}"))`);
+  });
+
+  test("never runs persistent trust for PR-controlled mise configuration", () => {
+    expect(
+      SETUP_COMMANDS.some(
+        (command) =>
+          command.executable === "mise" && command.args.includes("trust"),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/pr-fleet-controller/test/terminal-loop.test.ts
+++ b/packages/pr-fleet-controller/test/terminal-loop.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { consumeTerminalLines } from "@shepherdjerred/pr-fleet-controller/src/terminal-loop.ts";
+
+function noLines(): AsyncIterable<string> {
+  return {
+    [Symbol.asyncIterator]: () => ({
+      next: () => Promise.resolve({ done: true, value: undefined }),
+    }),
+  };
+}
+
+async function* oneLine(): AsyncGenerator<string> {
+  yield "/stop";
+}
+
+test("terminal EOF invokes controller shutdown", async () => {
+  let stops = 0;
+  await consumeTerminalLines(
+    noLines(),
+    () => Promise.reject(new Error("EOF must not dispatch a line")),
+    () => {
+      stops += 1;
+      return Promise.resolve();
+    },
+  );
+  expect(stops).toBe(1);
+});
+
+test("explicit stop uses the same idempotent end path", async () => {
+  let lines = 0;
+  let stops = 0;
+  await consumeTerminalLines(
+    oneLine(),
+    () => {
+      lines += 1;
+      return Promise.resolve("stop");
+    },
+    () => {
+      stops += 1;
+      return Promise.resolve();
+    },
+  );
+  expect(lines).toBe(1);
+  expect(stops).toBe(1);
+});


### PR DESCRIPTION
## Summary

- terminate full subprocess groups on timeout and abort so worker descendants cannot escape
- remove persistent worker-controlled `mise trust`; setup uses `MISE_PARANOID=1` plus invocation-scoped trust for only the assigned worktree `.mise.toml`
- preserve explicit-path publication for deleted parent directories and rearm heartbeat reconciliation after failures
- make terminal EOF and explicit stop share an idempotent shutdown path that awaits active master/worker work

## Verification

- `bunx turbo run typecheck test lint build --filter=@shepherdjerred/pr-fleet-controller`
- 55 controller tests passed at this layer, including process-group, heartbeat, deletion, setup-trust, and EOF regressions
- fresh linked-worktree probe: untrusted under Mise paranoid mode, trusted only when the exact config was supplied through `MISE_TRUSTED_CONFIG_PATHS`, and `mise install --dry-run` succeeded
- docs validation, Markdown lint, and pre-commit safety checks passed

## Stack

- Base layer of the PR fleet observability stack
- Follow-up: #1963