### PR TITLE
docs(docs): close out main-ci-green session (build #7807 green)

### DIFF
--- a/packages/docs/logs/2026-08-02_main-ci-green-session.md
+++ b/packages/docs/logs/2026-08-02_main-ci-green-session.md
@@ -183,6 +183,17 @@ config.yml: Operation not permitted`. The file was **root-owned** on the PVC
   }
   -->
 
+  **Not yet registered.** Per root `AGENTS.md` § Temporal Agent Follow-ups,
+  this block documents the follow-up; it does not itself create the schedule.
+  An operator with local Temporal access must run it once to activate the
+  monthly recheck:
+
+  ```bash
+  cd packages/temporal
+  TEMPORAL_ADDRESS=localhost:7233 bun run scripts/schedule-agent-task.ts \
+    --from-doc ../../packages/docs/logs/2026-08-02_main-ci-green-session.md
+  ```
+
 ### Caveats
 
 - Several fixes were operational (live-cluster), not code: golink/loki stale-op

--- a/packages/docs/logs/2026-08-02_main-ci-green-session.md
+++ b/packages/docs/logs/2026-08-02_main-ci-green-session.md
@@ -185,14 +185,9 @@ config.yml: Operation not permitted`. The file was **root-owned** on the PVC
 
   **Not yet registered.** Per root `AGENTS.md` § Temporal Agent Follow-ups,
   this block documents the follow-up; it does not itself create the schedule.
-  An operator with local Temporal access must run it once to activate the
-  monthly recheck:
-
-  ```bash
-  cd packages/temporal
-  TEMPORAL_ADDRESS=localhost:7233 bun run scripts/schedule-agent-task.ts \
-    --from-doc ../../packages/docs/logs/2026-08-02_main-ci-green-session.md
-  ```
+  Tracked as a blocked operator todo —
+  [`scout-paper-26-2-schedule-registration`](../todos/scout-paper-26-2-schedule-registration.md) —
+  so registering it survives this log closing as `complete` / `board: false`.
 
 ### Caveats
 

--- a/packages/docs/logs/2026-08-02_main-ci-green-session.md
+++ b/packages/docs/logs/2026-08-02_main-ci-green-session.md
@@ -160,12 +160,28 @@ config.yml: Operation not permitted`. The file was **root-owned** on the PVC
   write the archive + input-state record atomically, or have `archiveFlavor`
   reconcile an orphaned record whose `inputs/<id>.json` is missing instead of
   failing closed. This changes the deliberately fail-closed release semantics, so
-  it needs owner sign-off before implementing.
+  it needs owner sign-off before implementing. Tracked in
+  [`scout-release-orphan-atomic-archive`](../todos/scout-release-orphan-atomic-archive.md).
 - **Paper 26.2 bump (held).** Smoke-tested live: Paper 26.2 boots but EssentialsX
   (core) and LevelledMobs fail — their version parsers reject the `26.x` scheme,
   and no 26.2-aware plugin releases exist yet. Revisit when the plugin ecosystem
   catches up; also fix the Renovate `customDatasources.papermc` mapping (returns
   version families, so Renovate can't surface the bump).
+
+  <!-- temporal-agent-task
+  {
+    "title": "Recheck Paper 26.2 plugin compatibility (EssentialsX, LevelledMobs)",
+    "provider": "claude",
+    "mode": "report-only",
+    "cron": "0 9 1 * *",
+    "scheduleId": "scout-paper-26-2-plugin-recheck",
+    "repo": { "fullName": "shepherdjerred/monorepo", "ref": "main" },
+    "source": {
+      "docPath": "packages/docs/logs/2026-08-02_main-ci-green-session.md"
+    },
+    "prompt": "Check whether EssentialsX (core) and LevelledMobs have shipped releases compatible with Paper 26.2's version scheme, and whether the Renovate customDatasources.papermc mapping now surfaces the 26.2 bump instead of collapsing it into a version family. Email whether the held Paper 26.2 upgrade is unblocked, with links/evidence (plugin release notes, Renovate PR if any). If both plugins are compatible, recommend proceeding with the bump and note that this recurring schedule should be paused."
+  }
+  -->
 
 ### Caveats
 

--- a/packages/docs/logs/2026-08-02_main-ci-green-session.md
+++ b/packages/docs/logs/2026-08-02_main-ci-green-session.md
@@ -1,7 +1,7 @@
 ---
 id: main-ci-green-session-2026-08-02
 type: log
-status: in-progress
+status: complete
 board: false
 ---
 
@@ -132,26 +132,53 @@ config.yml: Operation not permitted`. The file was **root-owned** on the PVC
   (+ the stale artifact dirs) via a uid-1000 debug pod; itzg recreates it as
   uid 1000. tsmc then reached `1/1 Running`. No code change needed — durable
   because itzg runs as uid 1000.
+- PR #1960 (merged): the shuxin drift-check fix. Rolled all three servers onto the
+  fix + java25; all reached Healthy (they then hibernated to replicas 0 = Healthy).
+- Cleared **loki**'s stale ArgoCD `Operation=Failed` (same bound-PVC `volumeName`
+  class as golink). This was the real reason the root `apps` app stayed
+  `Progressing` even with every child Healthy — the app-of-apps health check
+  treats a child with a failed operation as Progressing. After clearing it, `apps`
+  → Healthy. (Restarting the argocd-application-controller did NOT clear it; the
+  child-op sync did.)
+- Cleared a **scout release orphan**: build #7794 (canceled on dotfiles commit
+  `694fc85d5`, which doesn't touch scout) archived `<releaseInputDigest>/prod.json`
+  then was canceled before writing `inputs/<id>.json`. Because scout content-
+  addresses by `releaseInputDigest` (excludes the full commit sha) but
+  `sameScoutReleaseContent` compares `sourceCommit`, the next build collided with
+  the orphan and failed `immutable prod archive record does not match state`.
+  Verified it was a true orphan (no input record, not in `versions/`, not the prod
+  pin) and deleted only that identity prefix from `s3://scout-site-releases/`.
+- **Main CI green confirmed: build #7807 (`25cd0cff2`) PASSED** — 22 jobs passed,
+  0 failed; `argo: sync + wait` and `scout beta release` both green. First fully
+  green main build in 30+ builds.
 
 ### Remaining
 
-- Merge the shuxin drift-check PR; after it deploys, delete `minecraft-shuxin-0`
-  so it rolls onto the new drift-check + java25, and confirm it reaches Healthy
-  (watch for the same DiscordSRV root-owned-config cruft on shuxin's PVC — clean
-  it the same way if present).
-- With all three Healthy, `apps` returns to Healthy → confirm a `main` build
-  completes the `argo: sync + wait` gate green (needs a quiet window — rapid
-  merges keep canceling in-flight main builds mid-argo).
+- **Durable scout orphan fix (recommended follow-up).** The rapid-merge
+  cancellation pattern will recreate scout release orphans (archive prod → build
+  canceled before the input record). Make the scout release step resilient — e.g.
+  write the archive + input-state record atomically, or have `archiveFlavor`
+  reconcile an orphaned record whose `inputs/<id>.json` is missing instead of
+  failing closed. This changes the deliberately fail-closed release semantics, so
+  it needs owner sign-off before implementing.
+- **Paper 26.2 bump (held).** Smoke-tested live: Paper 26.2 boots but EssentialsX
+  (core) and LevelledMobs fail — their version parsers reject the `26.x` scheme,
+  and no 26.2-aware plugin releases exist yet. Revisit when the plugin ecosystem
+  catches up; also fix the Renovate `customDatasources.papermc` mapping (returns
+  version families, so Renovate can't surface the bump).
 
 ### Caveats
 
-- The tsmc DiscordSRV fix was operational (PVC state), not code. Root cause of the
-  original root-ownership is historical (likely a past root-running deployment or
-  a ConfigMap once mounted onto the PVC path); the current manifest mounts the
-  config at `/plugins/...` correctly. If root-owned plugin files reappear, a
-  durable init-container safeguard would be warranted.
+- Several fixes were operational (live-cluster), not code: golink/loki stale-op
+  clears, the tsmc DiscordSRV PVC cleanup, the shuxin pod roll, and the scout
+  orphan deletion. They are durable for the fixed condition but not re-applied by
+  code; the scout orphan specifically WILL recur without the durable fix above.
+- The systemic bound-PVC `volumeName` immutable-patch (golink, loki, minecraft)
+  leaves stale `Operation=Failed` artifacts on otherwise-healthy apps. A global
+  ArgoCD `ignoreDifferences` for PVC `/spec/volumeName` would stop them recurring.
 - Minecraft servers hibernate at replicas 0 (mc-router); they only block the argo
   gate while woken+crashing. Something (likely the bluemap ingress) kept them
   woken through this session.
 - Rapid successive merges to main cancel in-flight builds before the ~15-min
-  deploy+argo train finishes; a fully-green main build needs a quiet window.
+  deploy+argo train finishes; a fully-green main build needs a quiet window (#7807
+  got one).

--- a/packages/docs/todos/scout-paper-26-2-schedule-registration.md
+++ b/packages/docs/todos/scout-paper-26-2-schedule-registration.md
@@ -1,0 +1,53 @@
+---
+id: scout-paper-26-2-schedule-registration
+type: todo
+status: planned
+board: true
+verification: operator
+disposition: blocked
+origin: packages/docs/logs/2026-08-02_main-ci-green-session.md
+source_marker: false
+---
+
+# Register the Scout Paper 26.2 plugin-compatibility recheck schedule
+
+## Problem
+
+[`2026-08-02_main-ci-green-session.md`](../logs/2026-08-02_main-ci-green-session.md)
+documents a held Paper 26.2 bump (EssentialsX core and LevelledMobs reject the
+`26.x` version scheme) and carries a `temporal-agent-task` HTML block
+(report-only, monthly cron, `scheduleId: scout-paper-26-2-plugin-recheck`)
+meant to recheck plugin compatibility over time.
+
+Per root `AGENTS.md` § Temporal Agent Follow-ups, that block only documents
+the follow-up — `packages/temporal/scripts/schedule-agent-task.ts` has no
+document watcher and only calls `startOrScheduleAgentTask` when an operator
+invokes it directly. Registering the schedule therefore requires a local
+operator with access to a live Temporal server (`TEMPORAL_ADDRESS=
+localhost:7233`), which is out of scope for a docs-only PR to run. Without
+this todo, the log closing as `status: complete` / `board: false` would leave
+that operator prerequisite with no active workboard record, and the monthly
+recheck would never actually run.
+
+## Remaining
+
+- [ ] Run, as an operator with local Temporal access:
+
+  ```bash
+  cd packages/temporal
+  TEMPORAL_ADDRESS=localhost:7233 bun run scripts/schedule-agent-task.ts \
+    --from-doc ../../packages/docs/logs/2026-08-02_main-ci-green-session.md
+  ```
+
+- [ ] Confirm the schedule was created (Temporal Web UI, or
+      `temporal schedule describe --schedule-id scout-paper-26-2-plugin-recheck`)
+      and record the confirmation here.
+- [ ] Archive this todo once the schedule is confirmed live and running.
+
+## Comment Log
+
+- 2026-08-03 — Filed from PR #1966 review feedback (chatgpt-codex-connector,
+  P2): a prior revision added a "not yet registered" note directly in the log,
+  but Codex correctly pointed out that a `status: complete` / `board: false`
+  log gives that operator prerequisite no active workboard record. This todo
+  is the tracked item that owns actually registering the schedule.

--- a/packages/docs/todos/scout-release-orphan-atomic-archive.md
+++ b/packages/docs/todos/scout-release-orphan-atomic-archive.md
@@ -66,12 +66,30 @@ keeping the manual-cleanup runbook):
    (`scripts/lib/scout-site-storage.ts:285-299`) validating a local source
    directory that was never produced — a silent "release is done" pointer with
    no reachable site behind it. Concretely: only ever write
-   `inputs/<digest>.json` after both flavor archives are confirmed present (as
-   today), and make a retried job for the same digest resumable — check
-   whether `prod.json`/`beta.json` already exist before rebuilding, and if so
-   skip straight to writing the input pointer using those existing archives'
-   recorded digests rather than a freshly recomputed (and likely mismatched)
-   state.
+   `inputs/<digest>.json` after both flavor archives are confirmed present.
+
+   This must also handle the **partial-archive case that actually occurred**:
+   build #7794 was canceled immediately after `prod.json` committed but before
+   `beta.json` or the input record, so `beta.json` never existed for that
+   digest. A retry that only resumes when _both_ flavor records already exist
+   does not recover this case — it still rebuilds `prod` under the new
+   `sourceCommit`, colliding with the immutable, already-archived `prod.json`
+   from the old commit, and there is no local `beta` archive to adopt in its
+   place. Any incomplete identity (one flavor archived, no input pointer) must
+   be handled explicitly, e.g.:
+   - **Delete-and-rebuild** — since no `inputs/<digest>.json` references this
+     identity, nothing depends on the lone `prod.json` being preserved; delete
+     it (and any other partial flavor records for that identity) before doing
+     a full fresh build under the current commit, then archive both flavors
+     and write the input pointer as normal. This mirrors the manual cleanup
+     already performed for build #7794's orphan.
+   - **Rebuild at the recorded commit** — alternatively, check out the
+     `sourceCommit` recorded in the existing `prod.json` in a scratch clone,
+     rebuild `beta` there so its digest matches what a same-commit build would
+     have produced, then archive `beta` and write the input pointer. More
+     complex than delete-and-rebuild; only worth it if losing the already-spent
+     `prod` build time matters.
+
 2. **Reconcile on read** — have `archiveFlavor`, on finding an existing
    `<digest>/<flavor>.json` with no matching `inputs/<digest>.json`, treat it
    as an orphan and adopt its recorded content (rather than a freshly
@@ -80,14 +98,26 @@ keeping the manual-cleanup runbook):
    `--if-none-match "*"` immutability guarantee only for the read path, not the
    write path (the archive bytes themselves are never overwritten).
 
+   This still needs the same partial-archive handling as approach 1: adopting
+   `prod.json`'s recorded state fixes what `beta`'s digest is _supposed_ to
+   be, but `beta`'s bytes were never uploaded, so `beta` must still be rebuilt
+   to match that adopted digest — which only happens if it's rebuilt at the
+   adopted `sourceCommit` (see "rebuild at the recorded commit" above), not the
+   current checkout's commit. If rebuilding at an old commit isn't worth the
+   complexity, reconciliation should fall back to delete-and-rebuild for that
+   identity rather than silently adopting a state it can't actually complete.
+
 ## Remaining
 
 - [ ] Get explicit owner sign-off on approach 1, approach 2, or "keep manual
       cleanup" before implementing.
 - [ ] If approved, implement the chosen fix in `scout-site-storage.ts` /
       `scout-release-state.ts` / `scout-site-release.ts`.
-- [ ] Add a regression test reproducing the cancel-between-writes race
-      (archive written, input record missing) and asserting the new behavior.
+- [ ] Add regression tests reproducing both cancel-between-writes shapes: all
+      flavors archived with no input record, and (matching the actual #7794
+      incident) only one flavor archived with no input record — assert the
+      chosen recovery (delete-and-rebuild or rebuild-at-recorded-commit) in
+      each case.
 - [ ] If "keep manual cleanup" is chosen instead, document the cleanup runbook
       (verify true orphan: no input record, not in `versions/`, not the prod
       pin, then delete only that identity prefix) here or in `guides/` and
@@ -98,3 +128,9 @@ keeping the manual-cleanup runbook):
 - 2026-08-02 — Filed from PR #1966 review feedback (chatgpt-codex-connector,
   P2) after the 2026-08-02 main-CI-green session cleared one live orphan
   operationally but left no durable fix or tracked follow-up.
+- 2026-08-03 — Corrected an unsafe input-first ordering in approach 1
+  (chatgpt-codex-connector, P2).
+- 2026-08-03 — Extended both approaches to explicitly cover the
+  partial-archive case (only `prod.json` written, matching the actual #7794
+  incident), which the prior revision's "resume when both flavors exist"
+  wording did not recover (chatgpt-codex-connector, P2).

--- a/packages/docs/todos/scout-release-orphan-atomic-archive.md
+++ b/packages/docs/todos/scout-release-orphan-atomic-archive.md
@@ -1,0 +1,84 @@
+---
+id: scout-release-orphan-atomic-archive
+type: todo
+status: planned
+board: true
+verification: agent
+disposition: blocked
+origin: packages/docs/logs/2026-08-02_main-ci-green-session.md
+source_marker: false
+---
+
+# Scout release: make flavor-archive + input-record writes atomic (or reconcile orphans)
+
+## Problem
+
+`archiveScout` (`scripts/lib/scout-site-storage.ts`) commits
+each flavor's immutable archive record before it commits the input record:
+
+- `archiveFlavor("prod", …)` / `archiveFlavor("beta", …)` in
+  `scripts/lib/scout-site-storage.ts` (`archiveFlavor` at lines 276-325,
+  `archiveScout` at lines 327-345) each `putImmutableObject` a
+  `<releaseInputDigest>/<flavor>.json` record (line 321) using
+  `--if-none-match "*"` — permanent once written.
+- Only afterward does `archiveScout` write `versions/<version>.json` (line 338)
+  and `inputs/<releaseInputDigest>.json` (lines 340-344).
+
+If the Buildkite step is canceled between those writes (the rapid-merge
+cancellation pattern documented in
+[`2026-08-02_main-ci-green-session.md`](../logs/2026-08-02_main-ci-green-session.md)),
+the flavor archive is left orphaned: present in S3 with no matching
+`inputs/<digest>.json` pointer.
+
+`prepareState` (`scripts/scout-site-release.ts`, lines 167-240) dedupes via
+`readScoutStateByInput` (lines 203-214) — if `inputs/<digest>.json` is
+missing it silently rebuilds instead of reusing the existing archive. Because
+`buildSite` (lines 116-152) bakes `sourceCommit` into `VITE_GIT_SHA` /
+`PUBLIC_GIT_SHA` (lines 133-134), a rebuild with the same `RELEASE_INPUT_PATHS`
+selection (same `releaseInputDigest`) but a different `sourceCommit` produces a
+different `siteArchiveDigest`. `archiveFlavor`'s existing-record check then
+calls `assertArchiveRecordMatchesState`
+(`scripts/lib/scout-release-state.ts`, lines 138-153), which compares via
+`sameScoutReleaseContent` (lines 110-121) and throws `"immutable ${flavor}
+archive record does not match state"` — a hard, permanently-unrecoverable
+failure for that digest until someone manually deletes the orphaned prefix
+from `s3://scout-site-releases/` (done once, operationally, on 2026-08-02 for
+digest `<releaseInputDigest>` under build #7794 — see the origin log).
+
+No comment in `scout-site-storage.ts`, `scout-release-state.ts`, or
+`scout-site-release.ts` currently acknowledges this race.
+
+## Why this needs sign-off
+
+Two fix shapes change deliberately fail-closed release semantics and the
+repository owner should choose between them (or reject both in favor of
+keeping the manual-cleanup runbook):
+
+1. **Atomic write** — write the flavor archive record(s) and the
+   `inputs/<digest>.json` pointer as a single logical commit (e.g. write the
+   input record first and have `archiveFlavor` require it to already exist,
+   or use a two-phase marker) so a cancellation between them can't happen.
+2. **Reconcile on read** — have `archiveFlavor`, on finding an existing
+   `<digest>/<flavor>.json` with no matching `inputs/<digest>.json`, treat it
+   as an orphan and overwrite/reclaim it (loosens the current
+   `--if-none-match "*"` immutability guarantee for that narrow case) rather
+   than failing closed.
+
+## Remaining
+
+- [ ] Get explicit owner sign-off on approach 1, approach 2, or "keep manual
+      cleanup" before implementing.
+- [ ] If approved, implement the chosen fix in `scout-site-storage.ts` /
+      `scout-release-state.ts` / `scout-site-release.ts`.
+- [ ] Add a regression test reproducing the cancel-between-writes race
+      (archive written, input record missing) and asserting the new behavior.
+- [ ] If "keep manual cleanup" is chosen instead, document the cleanup runbook
+      (verify true orphan: no input record, not in `versions/`, not the prod
+      pin, then delete only that identity prefix) here or in `guides/` and
+      close this todo as won't-fix.
+
+## Comment Log
+
+- 2026-08-02 — Filed from PR #1966 review feedback (chatgpt-codex-connector,
+  P2) after the 2026-08-02 main-CI-green session cleared one live orphan
+  operationally but left no durable fix or tracked follow-up.

--- a/packages/docs/todos/scout-release-orphan-atomic-archive.md
+++ b/packages/docs/todos/scout-release-orphan-atomic-archive.md
@@ -82,13 +82,36 @@ keeping the manual-cleanup runbook):
      it (and any other partial flavor records for that identity) before doing
      a full fresh build under the current commit, then archive both flavors
      and write the input pointer as normal. This mirrors the manual cleanup
-     already performed for build #7794's orphan.
+     already performed for build #7794's orphan. **This is only safe before
+     `archiveScout` reaches the `versions/<version>.json` write
+     (`scripts/lib/scout-site-storage.ts:338`)** — see the version-linked case
+     below for why deletion is unsafe once that record exists.
    - **Rebuild at the recorded commit** — alternatively, check out the
      `sourceCommit` recorded in the existing `prod.json` in a scratch clone,
      rebuild `beta` there so its digest matches what a same-commit build would
      have produced, then archive `beta` and write the input pointer. More
      complex than delete-and-rebuild; only worth it if losing the already-spent
      `prod` build time matters.
+
+   **Version-linked cancellation is a separate, narrower case that
+   delete-and-rebuild must not touch.** `archiveScout` (lines 327-345) only
+   reaches the `versions/<version>.json` write (line 338) _after_ **both**
+   `archiveFlavor("prod", …)` and `archiveFlavor("beta", …)` have already
+   succeeded — so by the time that record exists, both flavor archives are
+   already complete and mutually consistent (produced from the same in-memory
+   `state`). A cancellation in the narrow window after line 338 but before the
+   `inputs/<digest>.json` write (lines 340-344) therefore never has a partial
+   (single-flavor) archive — it always has a complete, matching pair, plus an
+   immutable `versions/<version>.json` that already pins those exact digests.
+   Deleting and rebuilding under a new commit here would silently invalidate
+   that version record (later reads/deploys of that version number would find
+   digests that no longer match anything in S3). The only safe recovery once
+   `versions/<version>.json` exists is to **reuse the existing archives
+   verbatim** — read them back, confirm they still match the version record,
+   and finish only the missing `inputs/<digest>.json` write; never delete or
+   rebuild in this case. Any implementation must check for
+   `versions/<version>.json` first and route to this reuse-only path before
+   ever considering deletion.
 
 2. **Reconcile on read** — have `archiveFlavor`, on finding an existing
    `<digest>/<flavor>.json` with no matching `inputs/<digest>.json`, treat it
@@ -113,11 +136,14 @@ keeping the manual-cleanup runbook):
       cleanup" before implementing.
 - [ ] If approved, implement the chosen fix in `scout-site-storage.ts` /
       `scout-release-state.ts` / `scout-site-release.ts`.
-- [ ] Add regression tests reproducing both cancel-between-writes shapes: all
-      flavors archived with no input record, and (matching the actual #7794
-      incident) only one flavor archived with no input record — assert the
-      chosen recovery (delete-and-rebuild or rebuild-at-recorded-commit) in
-      each case.
+- [ ] Add regression tests reproducing all three cancel-between-writes shapes:
+      (1) only one flavor archived, no `versions/<version>.json`, no input
+      record (matching the actual #7794 incident) — assert delete-and-rebuild
+      or rebuild-at-recorded-commit; (2) both flavors archived but no
+      `versions/<version>.json` yet — safe to delete-and-rebuild or reuse; and
+      (3) both flavors archived **and** `versions/<version>.json` already
+      written, only the input record missing — assert the recovery reuses the
+      existing archives verbatim and never deletes/rebuilds.
 - [ ] If "keep manual cleanup" is chosen instead, document the cleanup runbook
       (verify true orphan: no input record, not in `versions/`, not the prod
       pin, then delete only that identity prefix) here or in `guides/` and
@@ -134,3 +160,9 @@ keeping the manual-cleanup runbook):
   partial-archive case (only `prod.json` written, matching the actual #7794
   incident), which the prior revision's "resume when both flavors exist"
   wording did not recover (chatgpt-codex-connector, P2).
+- 2026-08-03 — Split the "both flavors archived" recovery further: once
+  `versions/<version>.json` is also written (which — per `archiveScout`'s
+  order — only happens after both flavors are already complete and mutually
+  consistent), delete-and-rebuild would invalidate that immutable version
+  record; the only safe recovery there is reuse-existing-archives-verbatim,
+  never delete/rebuild (chatgpt-codex-connector, P2).

--- a/packages/docs/todos/scout-release-orphan-atomic-archive.md
+++ b/packages/docs/todos/scout-release-orphan-atomic-archive.md
@@ -54,15 +54,31 @@ Two fix shapes change deliberately fail-closed release semantics and the
 repository owner should choose between them (or reject both in favor of
 keeping the manual-cleanup runbook):
 
-1. **Atomic write** — write the flavor archive record(s) and the
-   `inputs/<digest>.json` pointer as a single logical commit (e.g. write the
-   input record first and have `archiveFlavor` require it to already exist,
-   or use a two-phase marker) so a cancellation between them can't happen.
+1. **Atomic write** — commit the flavor archive record(s) and the
+   `inputs/<digest>.json` pointer as a single logical unit that can never
+   leave the pointer visible without its archives. **Keep the existing
+   archive-then-input order** — do not flip it. Writing `inputs/<digest>.json`
+   before its archives exist would open a _worse_ orphan class: `prepareState`
+   treats a present input record as "already built" and returns early without
+   rebuilding `.scout-release/{prod,beta}`
+   (`scripts/scout-site-release.ts:203-214`), so a subsequent `archiveFlavor`
+   call would fail at `assertStaticSiteComplete`
+   (`scripts/lib/scout-site-storage.ts:285-299`) validating a local source
+   directory that was never produced — a silent "release is done" pointer with
+   no reachable site behind it. Concretely: only ever write
+   `inputs/<digest>.json` after both flavor archives are confirmed present (as
+   today), and make a retried job for the same digest resumable — check
+   whether `prod.json`/`beta.json` already exist before rebuilding, and if so
+   skip straight to writing the input pointer using those existing archives'
+   recorded digests rather than a freshly recomputed (and likely mismatched)
+   state.
 2. **Reconcile on read** — have `archiveFlavor`, on finding an existing
    `<digest>/<flavor>.json` with no matching `inputs/<digest>.json`, treat it
-   as an orphan and overwrite/reclaim it (loosens the current
-   `--if-none-match "*"` immutability guarantee for that narrow case) rather
-   than failing closed.
+   as an orphan and adopt its recorded content (rather than a freshly
+   recomputed state) to finish writing `inputs/<digest>.json`, instead of
+   failing closed on a digest mismatch. This loosens the current
+   `--if-none-match "*"` immutability guarantee only for the read path, not the
+   write path (the archive bytes themselves are never overwritten).
 
 ## Remaining
 


### PR DESCRIPTION
Mark the session log complete and record the final steps: loki stale-op clear
(the real apps-Progressing cause), the scout release orphan cleanup, and the
confirmed green main build #7807. Capture the two durable follow-ups (scout
orphan resilience; the held Paper 26.2 bump).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>