### PR TITLE
fix(ci): bind Scout release identity to the source commit

### DIFF
--- a/packages/docs/plans/2026-08-03_scout-minecraft-followups.md
+++ b/packages/docs/plans/2026-08-03_scout-minecraft-followups.md
@@ -1,0 +1,101 @@
+---
+id: scout-minecraft-followups-2026-08-03
+type: plan
+status: in-progress
+board: false
+---
+
+# Scout release resilience + Paper 26.2 upgrade
+
+Two durable follow-ups from the 2026-08-02 "get main CI green" session
+(`logs/2026-08-02_main-ci-green-session.md`): make Scout releases resilient to
+canceled builds, and lay out the (partly upstream-blocked) Paper 26.2 upgrade.
+
+## Part 1 — Scout release orphans (implementing now)
+
+### Problem
+
+The Scout archive is content-addressed by `releaseInputDigest`
+(`scripts/scout-site-release.ts`), which **excluded** `sourceCommit`. But
+`buildSite` bakes the commit into the deployable bytes via
+`VITE_GIT_SHA` / `PUBLIC_GIT_SHA`, so `siteArchiveDigest` is commit-dependent.
+Two commits with identical Scout inputs therefore shared an archive identity but
+produced different bytes. When a build archived `<id>/prod.json` then got
+canceled (the frequent rapid-merge cancellation) before writing
+`inputs/<id>.json`, the orphaned record collided with the next same-inputs build
+and failed `immutable prod archive record does not match state` — wedging every
+subsequent `scout beta release` until the orphan was deleted by hand (done once
+this session; it would recur).
+
+### Fix — Option A: bind the identity to the commit
+
+Add `sourceCommit` to the `releaseInputDigest` input hash (bumped
+`scout-release-input/v1` → `/v2`). Each commit now gets a **unique** archive
+identity, so a canceled build's orphan can never collide with another commit's
+build; a re-run of the _same_ commit reproduces the identity and self-heals
+idempotently. Extracted the hash into a testable
+`computeReleaseInputDigest(...)` with a unit test asserting the commit binding.
+
+**Why Option A over the planned Option B (make the build reproducible + drop
+`sourceCommit` from the comparison):** implementation showed `VITE_GIT_SHA` is
+not just a debug value — it renders a GitHub commit link in _both_ frontends'
+footers (`frontend/src/components/Footer.astro`,
+`app/src/components/version-info.tsx`). (The version-mismatch banner correctly
+keys on `contractHash`, not the git sha — `app/src/lib/build-info.ts`.) So
+Option B would delete a real footer feature across ~7 files, while Option A is a
+one-line hashing change that keeps it. Trade-offs accepted: cross-commit dedup
+no longer fires (it was semantically wrong anyway, since the bytes depend on the
+commit), and canceled builds leave harmless orphaned partials at dead identities
+(bucket lifecycle reaps them).
+
+### Compatibility
+
+Existing prod is unaffected: `versions/<version>.json` records and their
+archives keep their old identities, and `reconcile-prod-pin` resolves prod via
+the version record, so the pin and its archive still verify. Only _new_ releases
+compute the new identity.
+
+### Files / verification
+
+- `scripts/scout-site-release.ts` (add `computeReleaseInputDigest`, call it in
+  `prepareState`), `scripts/scout-site-release.test.ts` (commit-binding test).
+- `bun test scripts/scout-site-release.test.ts scripts/lib/scout-site-storage.test.ts`
+  green; `turbo run typecheck lint --filter=@shepherdjerred/root-scripts` clean.
+- CI dry-run of the scout release subcommands exercises the path end-to-end;
+  post-merge, confirm `scout beta release` passes across a later image-bump
+  commit without a manual orphan cleanup.
+
+## Part 2 — Paper 26.2 (Minecraft): blocked upstream + Renovate fix
+
+A live smoke test this session showed Paper **26.2 boots but breaks plugins** on
+the current pins: EssentialsX 2.21.0 (`26.2.build.92-stable is not in valid
+version format`), LevelledMobs 4.5.1 (`No enum constant …V26_2`), Lunamatic
+("Unsupported server version… Expected 1.21"). The actual bump **cannot
+complete** until those plugins ship `26.x`-aware releases (java25 from PR #1958
+already satisfies 26.x's Java requirement).
+
+### Actionable now (separate PR)
+
+Fix the Renovate `papermc` custom datasource (`renovate.json`), which emits
+version **families** (`26.2`, `26.1`) rather than full pins like `26.1.2`, so
+Renovate can't compute a bump against `versions.paper`. Resolve the latest full
+build per family (v3 builds endpoint) or repin to a family + build. Validate with
+`renovate-config-validator` under `node`.
+
+### Checklist for the bump (when plugin releases land)
+
+1. Confirm `26.x`-compatible releases for EssentialsX, LevelledMobs, Lunamatic
+   (re-verify the rest); JAR URLs live in
+   `packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-{sjerred,tsmc,shuxin}.ts`.
+2. Bump `versions.paper` → `26.2.x` in `packages/homelab/src/cdk8s/src/versions.ts`
+   and the incompatible plugin JAR versions.
+3. Live smoke test one server (disable auto-sync, `kubectl set env … VERSION=26.2.x`,
+   delete pod, confirm all plugins enable), then restore auto-sync.
+4. PR (versions.ts + plugins), verify, merge, roll the three pods.
+
+## Deferred (noted; not in this plan)
+
+- ArgoCD global `resource.customizations.ignoreDifferences.PersistentVolumeClaim`
+  (`/spec/volumeName`) in `argo-applications/argocd.ts` to stop the stale
+  `Operation=Failed` on ZFS-PVC apps (golink/loki/minecraft) recurring.
+- A privileged repair step for historically root-owned plugin config files.

--- a/packages/docs/plans/2026-08-03_scout-minecraft-followups.md
+++ b/packages/docs/plans/2026-08-03_scout-minecraft-followups.md
@@ -99,3 +99,36 @@ build per family (v3 builds endpoint) or repin to a family + build. Validate wit
   (`/spec/volumeName`) in `argo-applications/argocd.ts` to stop the stale
   `Operation=Failed` on ZFS-PVC apps (golink/loki/minecraft) recurring.
 - A privileged repair step for historically root-owned plugin config files.
+
+## Session Log — 2026-08-03
+
+### Done
+
+- **Part 1 (Scout orphan resilience) — implemented (PR #1967).** Bound the Scout
+  archive identity to `sourceCommit`: extracted `computeReleaseInputDigest()` in
+  `scripts/scout-site-release.ts` (input schema v1 → v2) and added a
+  commit-binding unit test. Chose Option A over the planned Option B after
+  finding `VITE_GIT_SHA` renders a used commit-link footer in both frontends.
+  Verified: 20 tests pass, typecheck + lint clean.
+- **Part 2 (Renovate `papermc` datasource) — implemented (PR #1968).** Corrected
+  the diagnosis (the transform already emits full versions; strict `semver`
+  dropped 2-part `26.2`): switched to `versioning=semver-coerced` and filtered
+  pre-releases from the transform. Verified against the live papermc API (54
+  stable releases, `26.2` in, `26.2-rc-2` out) and `renovate-config-validator`.
+
+### Remaining
+
+- **Paper 26.2 bump is upstream-blocked.** EssentialsX, LevelledMobs, and
+  Lunamatic reject the `26.x` version scheme (live smoke test). Take the bump
+  only once `26.x`-aware plugin releases land, following the Part 2 checklist.
+- The two Deferred items above (ArgoCD PVC `volumeName` `ignoreDifferences`;
+  root-owned-config safeguard) remain unaddressed by design (not selected).
+
+### Caveats
+
+- The Renovate fix's end-to-end behavior (Renovate actually opening the `26.2`
+  PR) can't be verified without the hosted runner; only the datasource output
+  and config syntax were verified locally.
+- Option A leaves harmless orphaned partial archives at dead identities from
+  canceled builds; the bucket lifecycle reaps them. Existing prod is unaffected
+  (old identities and their archives remain valid for `reconcile-prod-pin`).

--- a/scripts/scout-site-release.test.ts
+++ b/scripts/scout-site-release.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  computeReleaseInputDigest,
   hashReleaseInputFiles,
   writeScoutReleaseState,
 } from "./scout-site-release.ts";
@@ -147,6 +148,33 @@ test("release source digest changes only with selected input content", async () 
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("release input digest binds to the source commit", () => {
+  const base = {
+    sourceCommit: "0123456789012345678901234567890123456789",
+    backendImageDigest: DIGEST,
+    sourceInputsDigest: DIGEST,
+    contractHash: "contract-abc",
+    pinterestTagId: "pin-1",
+    redditPixelId: "reddit-1",
+  };
+  const digest = computeReleaseInputDigest(base);
+  // Deterministic for identical inputs.
+  expect(computeReleaseInputDigest(base)).toBe(digest);
+  // A different commit must produce a different identity, even when every other
+  // input is unchanged — the site bytes bake in the commit, so the archive must
+  // not collide across commits.
+  expect(
+    computeReleaseInputDigest({
+      ...base,
+      sourceCommit: "fedcba9876543210fedcba9876543210fedcba98",
+    }),
+  ).not.toBe(digest);
+  // A non-commit input change still changes the identity.
+  expect(
+    computeReleaseInputDigest({ ...base, backendImageDigest: `${DIGEST}0` }),
+  ).not.toBe(digest);
 });
 
 test("release state output creates its parent directory", async () => {

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -91,6 +91,41 @@ export async function hashReleaseInputFiles(
   return `sha256:${hasher.digest("hex")}`;
 }
 
+/**
+ * Content-address a Scout release by its build inputs. `sourceCommit` is part
+ * of the identity on purpose: the site build bakes the commit into the
+ * deployable bytes (`VITE_GIT_SHA` / `PUBLIC_GIT_SHA` in `buildSite`), so the
+ * bytes are commit-dependent. Leaving the commit out let two commits with
+ * otherwise-identical inputs share an archive identity yet produce different
+ * bytes, tripping the immutable-archive guard — and, once a build was canceled
+ * mid-archive, the orphaned record wedged every later release. Binding the
+ * identity to the commit keeps content-addressing honest: same identity ⇒ same
+ * bytes.
+ */
+export function computeReleaseInputDigest(inputs: {
+  sourceCommit: string;
+  backendImageDigest: string;
+  sourceInputsDigest: string;
+  contractHash: string;
+  pinterestTagId: string;
+  redditPixelId: string;
+}): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(
+    JSON.stringify({
+      schema: "scout-release-input/v2",
+      sourceCommit: inputs.sourceCommit,
+      backendImageDigest: inputs.backendImageDigest,
+      sourceInputsDigest: inputs.sourceInputsDigest,
+      contractHash: inputs.contractHash,
+      plausibleDomains: PLAUSIBLE_DOMAIN_BY_FLAVOR,
+      pinterestTagId: inputs.pinterestTagId,
+      redditPixelId: inputs.redditPixelId,
+    }),
+  );
+  return `sha256:${hasher.digest("hex")}`;
+}
+
 export async function writeScoutReleaseState(
   output: string,
   state: ScoutReleaseState,
@@ -178,18 +213,14 @@ async function prepareState(args: string[], dryRun: boolean): Promise<void> {
   if (!/^[0-9a-f]{40}$/.test(sourceCommit)) {
     throw new Error(`source commit is not canonical: ${sourceCommit}`);
   }
-  const inputHasher = new Bun.CryptoHasher("sha256");
-  inputHasher.update(
-    JSON.stringify({
-      schema: "scout-release-input/v1",
-      backendImageDigest,
-      sourceInputsDigest: await releaseSourceDigest(),
-      contractHash: await contractHash(),
-      plausibleDomains: PLAUSIBLE_DOMAIN_BY_FLAVOR,
-      pinterestTagId: requireEnv("PUBLIC_PINTEREST_TAG_ID"),
-      redditPixelId: requireEnv("PUBLIC_REDDIT_PIXEL_ID"),
-    }),
-  );
+  const releaseInputDigest = computeReleaseInputDigest({
+    sourceCommit,
+    backendImageDigest,
+    sourceInputsDigest: await releaseSourceDigest(),
+    contractHash: await contractHash(),
+    pinterestTagId: requireEnv("PUBLIC_PINTEREST_TAG_ID"),
+    redditPixelId: requireEnv("PUBLIC_REDDIT_PIXEL_ID"),
+  });
   const provisional = ScoutReleaseStateSchema.parse({
     schema: "scout-release-state/v1",
     buildNumber,
@@ -198,7 +229,7 @@ async function prepareState(args: string[], dryRun: boolean): Promise<void> {
     backendImageDigest,
     siteArchiveDigest: PLACEHOLDER_DIGEST,
     betaSiteArchiveDigest: PLACEHOLDER_DIGEST,
-    releaseInputDigest: `sha256:${inputHasher.digest("hex")}`,
+    releaseInputDigest,
   });
   if (!dryRun) {
     const existing = await readScoutStateByInput(


### PR DESCRIPTION
## Problem

The Scout release archive is content-addressed by `releaseInputDigest`, which **excluded** `sourceCommit`. But `buildSite` bakes the commit into the deployable bytes (`VITE_GIT_SHA` / `PUBLIC_GIT_SHA`), so `siteArchiveDigest` is commit-dependent. Two commits with identical Scout inputs therefore shared an archive identity but produced **different bytes**.

When a build archived `<id>/prod.json` then got **canceled** (the frequent rapid-merge cancellation) before writing `inputs/<id>.json`, the orphaned record collided with the next same-inputs build and failed `immutable prod archive record does not match state` — wedging every subsequent `scout beta release` until the orphan was deleted by hand (done once during the 2026-08-02 main-green session; it would recur).

## Fix (Option A — bind identity to the commit)

Add `sourceCommit` to the `releaseInputDigest` input hash (`scout-release-input` v1 → v2). Each commit now gets a **unique** archive identity, so a canceled build's orphan can never collide with another commit's build; a same-commit re-run reproduces the identity and self-heals idempotently. Extracted the hashing into a testable `computeReleaseInputDigest()` with a unit test asserting the commit binding.

**Why not the alternative** (make the build reproducible + drop `sourceCommit` from the comparison): `VITE_GIT_SHA` renders a real GitHub commit-link footer in *both* frontends (marketing `Footer.astro` and app `version-info.tsx`). The version-mismatch banner correctly keys on `contractHash`, not the git sha (`app/src/lib/build-info.ts`). So that option would delete a used feature across ~7 files; this is a one-line hashing change that keeps it.

## Compatibility

Existing prod is unaffected — `versions/<v>.json` records keep their old identities and `reconcile-prod-pin` still verifies them. Only *new* releases compute the new identity. Trade-offs accepted: cross-commit dedup no longer fires (it was semantically wrong anyway, since bytes depend on the commit), and canceled builds leave harmless orphaned partials at dead identities (bucket lifecycle reaps them).

## Verification

- `bun test scripts/scout-site-release.test.ts scripts/lib/scout-site-storage.test.ts` → 20 pass.
- `turbo run typecheck lint --filter=@shepherdjerred/root-scripts` clean.
- New test proves different commits → different identity; other input changes still change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)