### PR TITLE
fix(deps): let Renovate surface Paper 26.x bumps

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -227,7 +227,11 @@ const versions = {
     "3.6.0@sha256:9ea3331d891e436a7239e37e68ca4c8888500cb122be7cdc9d8400f345555c76",
   // renovate: datasource=github-releases versioning=semver
   "kubernetes/kubernetes": "v1.36.3",
-  // renovate: datasource=custom.papermc versioning=semver
+  // The papermc datasource lists both 2-part families (e.g. "26.2") and 3-part
+  // builds (e.g. "26.1.2"); strict semver drops the 2-part ones, so it never
+  // surfaced "26.2". semver-coerced compares them all, and the datasource
+  // transform now filters pre-releases (-rc/-pre) so only stable builds appear.
+  // renovate: datasource=custom.papermc versioning=semver-coerced
   paper: "26.1.2",
   // renovate: datasource=docker registryUrl=https://ghcr.io/recyclarr versioning=docker
   recyclarr:

--- a/renovate.json
+++ b/renovate.json
@@ -150,7 +150,7 @@
       "defaultRegistryUrlTemplate": "https://fill.papermc.io/v3/projects/paper",
       "format": "json",
       "transformTemplates": [
-        "{\"releases\": $map($reduce($each(versions, function($v) { $v }), $append, []), function($v) { {\"version\": $v} }), \"sourceUrl\": \"https://github.com/PaperMC/Paper\", \"homepage\": \"https://papermc.io\"}"
+        "{\"releases\": $map($filter($reduce($each(versions, function($v) { $v }), $append, []), function($v) { $not($contains($v, \"-\")) }), function($v) { {\"version\": $v} }), \"sourceUrl\": \"https://github.com/PaperMC/Paper\", \"homepage\": \"https://papermc.io\"}"
       ]
     }
   },


### PR DESCRIPTION
## Problem

Renovate never surfaces Paper bumps. The `papermc` custom datasource
(`renovate.json`) already flattens the `fill.papermc.io/v3` per-family version
lists into full versions (`26.2`, `26.1.2`, `1.21.11`, …), but the pin was tagged
`versioning=semver`, which **drops the 2-part families like `26.2`** as invalid
semver — so `26.1.2` stayed the max and no bump was offered.

## Fix

- `versions.ts`: `versioning=semver` → **`versioning=semver-coerced`** (compares 2-
  and 3-part versions alike).
- `renovate.json`: filter pre-releases (`-rc`/`-pre`) out of the datasource
  transform, so `semver-coerced` (which would otherwise coerce `26.2-rc-2` to a
  `26.2.0` "stable") only ever sees real builds.

## Verification

Tested the transform against the **live** `fill.papermc.io/v3` response: it now
yields **54 stable releases including `26.2`** and excluding `26.2-rc-2`.
`renovate-config-validator` passes. End-to-end (Renovate actually opening the PR)
can't be verified without the hosted runner, but the datasource output and config
are correct.

## Note

The actual Paper **26.2 bump is still blocked** — a live smoke test showed it
breaks EssentialsX (core) and LevelledMobs, which don't support the `26.x` scheme
yet. This PR only ensures Renovate *surfaces* the bump when compatible plugins
land. Full context + checklist: `docs/plans/2026-08-03_scout-minecraft-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)