### PR TITLE
fix(temporal): isolate Glitter workers

### DIFF
--- a/packages/docs/logs/2026-08-03_temporal-outage-diagnosis.md
+++ b/packages/docs/logs/2026-08-03_temporal-outage-diagnosis.md
@@ -1,0 +1,162 @@
+---
+id: log-2026-08-03-temporal-outage-diagnosis
+type: log
+status: in-progress
+board: false
+---
+
+# Temporal Outage Diagnosis
+
+## Question
+
+Why is the production Temporal service down?
+
+## Investigation
+
+Temporal itself is serving. The production failure is a wedged TypeScript SDK
+worker process: it is alive according to Kubernetes, but it is no longer polling
+the `default` workflow task queue.
+
+### Healthy control plane and dependencies
+
+- Both Talos nodes are `Ready`; the Temporal namespace has no warning events.
+- PostgreSQL, Temporal server, Temporal UI, and the worker pod are all
+  `Running` with zero restarts. The PVC is bound, and service endpoint slices
+  are populated.
+- ArgoCD reports the `temporal` application `Synced` and `Healthy` at worker
+  image `ghcr.io/shepherdjerred/temporal-worker:2.0.0-7749`.
+- The Temporal gRPC health service reports `SERVING`; the UI and its namespace
+  API both return HTTP 200.
+
+### Failed worker path
+
+- The `default` queue has 10 workflow tasks with an approximately 1 hour 29
+  minute oldest-task age and a dispatch rate of zero. It has an activity poller
+  but no workflow poller.
+- The worker pod remains Kubernetes-ready with zero restarts, while consuming
+  approximately 0.9-1.0 CPU core and 2.34 GiB of memory. It has no
+  liveness/readiness probe that tests workflow-task polling, so Kubernetes only
+  knows that the container process exists.
+- Sampling `/proc/1/task` showed one unnamed Bun/JavaScriptCore thread consuming
+  a full core while the main thread and the named Temporal Core workflow threads
+  were sleeping. The pod permissions do not permit reading that thread's native
+  stack, so its exact runtime function is not proven.
+- Workflows on the `default` queue repeatedly time out their 10-second workflow
+  tasks. The `good-morning` workflow is one affected workflow, but its failure
+  began after the worker stopped making progress; its bounded preheat loop is
+  not the trigger.
+
+### Trigger and timeline
+
+Prometheus shows the worker changing from approximately 0.06 CPU core to a
+continuous full core between `2026-08-03T13:07:30Z` and `13:08:00Z`. Memory
+simultaneously peaked at approximately 2.67 GB before settling near 2.45 GB.
+There were no restarts.
+
+That transition coincides exactly with completion of the unusually large
+`glitter-corpus-daily-workflow-2026-08-03T11:15:00Z` run:
+
+- The parent ran for 1 hour 52 minutes, produced 212,683 messages, and reached
+  2,426 history events. Its 267 full-backfill children scheduled 5,115
+  activities and produced approximately 67.5 MB of history JSON in aggregate.
+- Two consecutive channel children were unusually large: 7,085 events / 58,873
+  messages and 10,013 events / 83,242 messages. The larger child alone scheduled
+  1,668 activities and produced approximately 23.8 MB of history JSON.
+- The final child completed at `13:06:59Z`; snapshot finalization and the parent
+  completed at `13:07:39Z`, within the same metrics interval in which the
+  worker thread pinned a core.
+
+The strongest supported diagnosis is therefore: the full Glitter refresh
+coincided with a nondeterministic stall in the shared Bun worker process,
+leaving an unnamed thread spinning and the JavaScript event loop unable to make
+progress. The live evidence proves the process-level failure but does not prove
+whether its low-level origin is Bun, the Temporal SDK, application code, or an
+interaction among them. Temporal still tracks
+[full Bun support as an open feature request](https://github.com/temporalio/sdk-typescript/issues/2273),
+which makes that compatibility boundary relevant, but the successful replays
+and stress tests do not justify identifying Bun itself as the root cause.
+
+All four queue workers are created inside one Bun process in
+`packages/temporal/src/worker.ts`, so separate Temporal task queues do not
+provide process/runtime fault isolation. The per-channel corpus workflow also
+accumulated 10,013 history events without continuing as new.
+
+### Further reproduction and exclusions
+
+- The successful August 2 parent had effectively the same 2,426-event parent
+  history and final payload sizes, and reached a higher memory peak than the
+  failed August 3 process before recovering. A simple parent-size or memory
+  threshold therefore does not explain the incident.
+- Exact August 2 and August 3 parent histories and the 10,013-event child replay
+  successfully under Bun. The full sequence of all 267 recorded child histories
+  plus the parent also replays successfully in the exact production image.
+- A real local Temporal worker running the exact production image completed two
+  consecutive mocked children matching the large production activity/message
+  counts, then completed a cleanup workflow.
+- A final controlled run exercised the complete 267-channel weekly-refresh
+  shape under the production 6 GiB / 1.5 CPU limits. It stayed responsive for
+  8.5 minutes, processed activities continuously, and recovered through repeated
+  garbage-collection cycles; it was stopped to avoid extending the diagnosis.
+
+These negative tests rule out deterministic workflow nondeterminism, recorded
+history replay, the two large child workflows alone, and a simple memory limit
+as sufficient causes. They do not rule out a timing-sensitive runtime defect or
+an interaction with the other queue workers that share the production process.
+
+After the initial event-loop stall, the `default` worker accumulated occupied
+workflow slots until all 40 SDK-default slots were full. Its workflow pollers
+then fell to zero and the task backlog grew. The missing poller was therefore a
+downstream cascade from the process stall, not the initiating failure.
+
+## Recovery boundary
+
+No restart or other live mutation was performed. Restarting the worker would
+probably restore polling, but it can interrupt the active `agent-task` work and
+release delayed time-sensitive workflows. Recovery should account for those
+effects before restarting the pod.
+
+The durable remediation keeps Bun while isolating the Glitter queues into a
+separate deployment/process and probing an event-loop-backed health endpoint.
+That contains a recurrence to one role and lets Kubernetes restart a process
+that exists but cannot service HTTP. Missing-poller and backlog alerts remain a
+useful additional detection layer; history rollover should be evaluated
+separately because the recorded histories replayed successfully.
+
+## Session Log — 2026-08-03
+
+### Done
+
+- Verified live Kubernetes, ArgoCD, Temporal gRPC/UI, PostgreSQL, queue, workflow
+  history, process-thread, and Prometheus evidence.
+- Identified the immediate failure as a spinning Bun/JavaScriptCore thread,
+  followed by workflow-slot saturation and loss of the `default` poller.
+- Correlated the failure onset to finalization of the weekly Glitter full
+  refresh and quantified its 267 children, 5,115 activities, and two largest
+  histories.
+- Replayed the exact histories and exercised equivalent real-worker workloads
+  in the production image without reproducing the wedge, excluding deterministic
+  workflow, history, and simple memory-threshold explanations.
+- Cross-checked Temporal's current experimental Bun-support status and narrowed
+  the remaining uncertainty without claiming that Bun itself caused the stall.
+- Added explicit `core`, `glitter`, and backward-compatible `all` Bun worker
+  roles with strict environment parsing and regression tests.
+- Split Glitter into a separate Kubernetes Deployment with independent SDK and
+  application metrics Services and event-loop-backed startup, readiness, and
+  liveness probes on `/healthz`.
+- Added synthesized-manifest regression coverage for the role split, probe
+  configuration, and exposed ports.
+
+### Remaining
+
+- Update the Temporal operator and architecture documentation.
+- Complete focused verification, publish the native-stack draft PR, and inspect
+  its exact-current-head Buildkite result.
+
+### Caveats
+
+- No live recovery action has been authorized or performed.
+- The trigger correlation is strong, but the exact low-level defect remains
+  unproven. Capturing it requires an invasive live native stack or a future
+  recurrence with CPU profiling enabled.
+- Restarting now may interrupt active agent work and cause delayed schedules to
+  execute late.

--- a/packages/homelab/src/cdk8s/src/resources/temporal/glitter-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/glitter-worker.ts
@@ -1,0 +1,112 @@
+import type { Chart } from "cdk8s";
+import { Size } from "cdk8s";
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  type EnvValue,
+  Service,
+  type ServiceAccount,
+  Volume,
+} from "cdk8s-plus-31";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import { temporalWorkerHealthProbes } from "./worker-health.ts";
+
+type CreateTemporalGlitterWorkerProps = {
+  serviceAccount: ServiceAccount;
+  envVariables: Record<string, EnvValue>;
+};
+
+export function createTemporalGlitterWorker(
+  chart: Chart,
+  props: CreateTemporalGlitterWorkerProps,
+): Deployment {
+  const deployment = new Deployment(chart, "temporal-glitter-worker", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    serviceAccount: props.serviceAccount,
+    automountServiceAccountToken: true,
+    securityContext: {
+      fsGroup: 1000,
+    },
+    podMetadata: {
+      labels: {
+        app: "temporal-worker",
+        component: "glitter-worker",
+      },
+    },
+  });
+
+  setRevisionHistoryLimit(deployment, 5);
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      name: "temporal-glitter-worker",
+      image: `ghcr.io/shepherdjerred/temporal-worker:${versions["shepherdjerred/temporal-worker"]}`,
+      ports: [
+        { number: 9464, name: "metrics" },
+        { number: 9465, name: "app-metrics" },
+      ],
+      securityContext: {
+        user: 1000,
+        group: 1000,
+        readOnlyRootFilesystem: false,
+      },
+      resources: {
+        cpu: {
+          request: Cpu.millis(500),
+          limit: Cpu.millis(1500),
+        },
+        memory: {
+          request: Size.gibibytes(2),
+          limit: Size.gibibytes(6),
+        },
+      },
+      ...temporalWorkerHealthProbes(),
+      envVariables: props.envVariables,
+    }),
+  );
+
+  const tmpVolume = Volume.fromEmptyDir(
+    chart,
+    "temporal-glitter-worker-tmp",
+    "glitter-tmp",
+  );
+  container.mount("/tmp", tmpVolume);
+
+  new Service(chart, "temporal-glitter-worker-metrics-service", {
+    selector: deployment,
+    metadata: {
+      labels: { app: "temporal-glitter-worker-metrics" },
+    },
+    ports: [{ port: 9464, name: "metrics" }],
+  });
+
+  createServiceMonitor(chart, {
+    name: "temporal-glitter-worker-metrics",
+    matchLabels: { app: "temporal-glitter-worker-metrics" },
+  });
+
+  new Service(chart, "temporal-glitter-worker-app-metrics-service", {
+    metadata: {
+      name: "temporal-glitter-worker-app-metrics",
+      labels: { app: "temporal-glitter-worker-app-metrics" },
+    },
+    selector: deployment,
+    ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
+  });
+
+  createServiceMonitor(chart, {
+    name: "temporal-glitter-worker-app-metrics",
+    port: "app-metrics",
+    interval: "30s",
+    matchLabels: { app: "temporal-glitter-worker-app-metrics" },
+  });
+
+  return deployment;
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-health.ts
@@ -1,0 +1,24 @@
+import { Duration } from "cdk8s";
+import { Probe } from "cdk8s-plus-31";
+
+const HEALTH_PORT = 9465;
+
+export function temporalWorkerHealthProbes() {
+  return {
+    startup: Probe.fromHttpGet("/healthz", {
+      port: HEALTH_PORT,
+      periodSeconds: Duration.seconds(10),
+      failureThreshold: 30,
+    }),
+    liveness: Probe.fromHttpGet("/healthz", {
+      port: HEALTH_PORT,
+      periodSeconds: Duration.seconds(30),
+      failureThreshold: 3,
+    }),
+    readiness: Probe.fromHttpGet("/healthz", {
+      port: HEALTH_PORT,
+      periodSeconds: Duration.seconds(10),
+      failureThreshold: 3,
+    }),
+  };
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -34,6 +34,8 @@ import {
   createXcodeCloudWebhookService,
 } from "./http-services.ts";
 import { glitterCorpusEnv } from "./glitter-corpus-env.ts";
+import { createTemporalGlitterWorker } from "./glitter-worker.ts";
+import { temporalWorkerHealthProbes } from "./worker-health.ts";
 
 export type CreateTemporalWorkerDeploymentProps = {
   serverServiceName: string;
@@ -270,7 +272,6 @@ export function createTemporalWorkerDeployment(
   props: CreateTemporalWorkerDeploymentProps,
 ) {
   const UID = 1000;
-  const GID = 1000;
 
   const onePasswordItem = new OnePasswordItem(chart, "temporal-worker-1p", {
     spec: {
@@ -314,7 +315,7 @@ export function createTemporalWorkerDeployment(
     serviceAccount,
     automountServiceAccountToken: true,
     securityContext: {
-      fsGroup: GID,
+      fsGroup: UID,
     },
     podMetadata: {
       labels: {
@@ -349,7 +350,7 @@ export function createTemporalWorkerDeployment(
       ],
       securityContext: {
         user: UID,
-        group: GID,
+        group: UID,
         readOnlyRootFilesystem: false,
       },
       // Sized for in-process claude -p invocations. The pr-agent activity
@@ -368,9 +369,11 @@ export function createTemporalWorkerDeployment(
           limit: Size.gibibytes(6),
         },
       },
+      ...temporalWorkerHealthProbes(),
       envVariables: {
         TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
         TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+        TEMPORAL_WORKER_ROLE: EnvValue.fromValue("core"),
         ENVIRONMENT: EnvValue.fromValue("production"),
         // Headless hygiene for the `claude -p` agent subprocesses: don't let
         // startup block on statsig/telemetry fetches or an auto-update check.
@@ -536,6 +539,18 @@ export function createTemporalWorkerDeployment(
   const tmpVolume = Volume.fromEmptyDir(chart, "temporal-worker-tmp", "tmp");
   container.mount("/tmp", tmpVolume);
 
+  // Glitter's corpus and context-refresh queues perform the heaviest Bun-side
+  // work. Keep them in a separate process and pod so a runtime wedge or
+  // resource spike cannot stop schedules, webhooks, or the general queues.
+  const glitterDeployment = createTemporalGlitterWorker(chart, {
+    serviceAccount,
+    envVariables: {
+      ...container.env.variables,
+      TEMPORAL_WORKER_ROLE: EnvValue.fromValue("glitter"),
+      TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-glitter-worker"),
+    },
+  });
+
   // Project the talosconfig YAML from 1Password into a file at
   // /etc/talos/config. The homelab-audit-daily workflow's §1 commands
   // (`talosctl health`, `talosctl get members`, `talosctl dmesg`) need it —
@@ -593,5 +608,5 @@ export function createTemporalWorkerDeployment(
   createAgentTaskApiService(chart, deployment);
   createXcodeCloudWebhookService(chart, deployment);
 
-  return { deployment };
+  return { deployment, glitterDeployment };
 }

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -17,6 +17,40 @@ const ResourceSchema = z.object({
   rules: z.array(RuleSchema).optional(),
 });
 
+const HttpProbeSchema = z.object({
+  failureThreshold: z.number(),
+  httpGet: z.object({
+    path: z.string(),
+    port: z.union([z.string(), z.number()]),
+  }),
+  periodSeconds: z.number(),
+});
+
+const DeploymentSchema = z.object({
+  kind: z.literal("Deployment"),
+  metadata: z.object({ name: z.string() }),
+  spec: z.object({
+    template: z.object({
+      spec: z.object({
+        containers: z.array(
+          z.object({
+            env: z.array(
+              z.object({ name: z.string(), value: z.string().optional() }),
+            ),
+            livenessProbe: HttpProbeSchema,
+            name: z.string(),
+            ports: z.array(z.object({ containerPort: z.number() })),
+            readinessProbe: HttpProbeSchema,
+            startupProbe: HttpProbeSchema,
+          }),
+        ),
+      }),
+    }),
+  }),
+});
+
+type SynthesizedDeployment = z.infer<typeof DeploymentSchema>;
+
 async function synthesizeApp(): Promise<string> {
   const app = new App({ outdir: ".test-synth" });
   await setupCharts(app);
@@ -32,6 +66,39 @@ function parseResources(yaml: string): z.infer<typeof ResourceSchema>[] {
     }
   }
   return resources;
+}
+
+function parseDeployments(yaml: string): SynthesizedDeployment[] {
+  const deployments: SynthesizedDeployment[] = [];
+  for (const document of parseAllDocuments(yaml)) {
+    const parsed = DeploymentSchema.safeParse(document.toJSON());
+    if (parsed.success) {
+      deployments.push(parsed.data);
+    }
+  }
+  return deployments;
+}
+
+function requireDeployment(
+  deployments: SynthesizedDeployment[],
+  name: string,
+): SynthesizedDeployment {
+  const deployment = deployments.find(
+    (candidate) => candidate.metadata.name === name,
+  );
+  if (deployment === undefined) {
+    throw new Error(`Missing synthesized Deployment ${name}`);
+  }
+  return deployment;
+}
+
+function envValue(
+  deployment: SynthesizedDeployment,
+  name: string,
+): string | undefined {
+  return deployment.spec.template.spec.containers[0]?.env.find(
+    (variable) => variable.name === name,
+  )?.value;
 }
 
 describe("temporal homelab audit tooling", () => {
@@ -63,6 +130,42 @@ describe("temporal homelab audit tooling", () => {
     expect(yaml).toContain("name: GLITTER_CORPUS_S3_BUCKET");
     expect(yaml).toContain("value: glitter-discord-corpus");
     expect(yaml).not.toContain("name: GLITTER_CORPUS_R2_");
+  });
+
+  it("isolates core and Glitter queues behind event-loop health probes", async () => {
+    const deployments = parseDeployments(await synthesizeApp());
+    const core = requireDeployment(deployments, "temporal-temporal-worker");
+    const glitter = requireDeployment(
+      deployments,
+      "temporal-temporal-glitter-worker",
+    );
+
+    expect(envValue(core, "TEMPORAL_WORKER_ROLE")).toBe("core");
+    expect(envValue(glitter, "TEMPORAL_WORKER_ROLE")).toBe("glitter");
+
+    const coreContainer = core.spec.template.spec.containers[0];
+    const glitterContainer = glitter.spec.template.spec.containers[0];
+    if (coreContainer === undefined || glitterContainer === undefined) {
+      throw new Error("Temporal worker Deployments require one container");
+    }
+
+    for (const probe of [
+      coreContainer.startupProbe,
+      coreContainer.livenessProbe,
+      coreContainer.readinessProbe,
+      glitterContainer.startupProbe,
+      glitterContainer.livenessProbe,
+      glitterContainer.readinessProbe,
+    ]) {
+      expect(probe.httpGet).toEqual({ path: "/healthz", port: 9465 });
+    }
+
+    expect(coreContainer.ports.map((port) => port.containerPort)).toEqual([
+      9464, 9465, 9466, 9467, 9468,
+    ]);
+    expect(glitterContainer.ports.map((port) => port.containerPort)).toEqual([
+      9464, 9465,
+    ]);
   });
 
   it("enables Temporal worker observability dynamic config with v1.29 key casing", async () => {

--- a/packages/temporal/src/shared/worker-role.test.ts
+++ b/packages/temporal/src/shared/worker-role.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import {
+  parseWorkerRole,
+  workerRoleRunsCore,
+  workerRoleRunsGlitter,
+} from "./worker-role.ts";
+
+describe("Temporal worker role", () => {
+  it("defaults to the backward-compatible all role", () => {
+    expect(parseWorkerRole(undefined)).toBe("all");
+  });
+
+  it.each(["all", "core", "glitter"])("accepts the %s role", (role) => {
+    expect(parseWorkerRole(role)).toBe(role);
+  });
+
+  it("fails fast for an unknown role", () => {
+    expect(() => parseWorkerRole("unknown")).toThrow();
+  });
+
+  it("maps roles to their isolated worker groups", () => {
+    expect(workerRoleRunsCore("all")).toBe(true);
+    expect(workerRoleRunsGlitter("all")).toBe(true);
+    expect(workerRoleRunsCore("core")).toBe(true);
+    expect(workerRoleRunsGlitter("core")).toBe(false);
+    expect(workerRoleRunsCore("glitter")).toBe(false);
+    expect(workerRoleRunsGlitter("glitter")).toBe(true);
+  });
+});

--- a/packages/temporal/src/shared/worker-role.ts
+++ b/packages/temporal/src/shared/worker-role.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const WorkerRoleSchema = z.enum(["all", "core", "glitter"]);
+
+export type WorkerRole = z.infer<typeof WorkerRoleSchema>;
+
+export function parseWorkerRole(value: string | undefined): WorkerRole {
+  return WorkerRoleSchema.parse(value ?? "all");
+}
+
+export function workerRoleRunsCore(role: WorkerRole): boolean {
+  return role === "all" || role === "core";
+}
+
+export function workerRoleRunsGlitter(role: WorkerRole): boolean {
+  return role === "all" || role === "glitter";
+}

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -19,13 +19,19 @@ import {
 import { createStructuredLogger } from "./observability/logging.ts";
 import { restoreGlitterCorpusSnapshotMetrics } from "./activities/glitter-corpus-snapshot.ts";
 import { WORKFLOW_TASK_POLLER_BEHAVIOR } from "./shared/worker-options.ts";
+import {
+  parseWorkerRole,
+  workerRoleRunsCore,
+  workerRoleRunsGlitter,
+  type WorkerRole,
+} from "./shared/worker-role.ts";
 
 const DEFAULT_ADDRESS = "temporal-server.temporal.svc.cluster.local:7233";
 const DEFAULT_METRICS_ADDRESS = "0.0.0.0:9464";
 
 const jsonLog = createStructuredLogger();
 
-function installRuntime(): void {
+function installRuntime(role: WorkerRole): void {
   const metricsAddress =
     Bun.env["TEMPORAL_METRICS_ADDRESS"] ?? DEFAULT_METRICS_ADDRESS;
 
@@ -40,7 +46,8 @@ function installRuntime(): void {
         // scrape target reports `up=0`. Keep globalTags to labels the SDK
         // does NOT emit on its own.
         globalTags: {
-          worker: "temporal-worker",
+          worker: `temporal-worker-${role}`,
+          worker_role: role,
         },
         prometheus: {
           bindAddress: metricsAddress,
@@ -204,13 +211,13 @@ function startEventBridgeSupervisor(client: Client): EventBridgeHandle {
 }
 
 async function main(): Promise<void> {
-  installRuntime();
+  const role = parseWorkerRole(Bun.env["TEMPORAL_WORKER_ROLE"]);
+  installRuntime(role);
   initSentry();
   initializeTracing();
-  startMetricsServer();
 
   const address = Bun.env["TEMPORAL_ADDRESS"] ?? DEFAULT_ADDRESS;
-  jsonLog("info", "Connecting to Temporal server", { address });
+  jsonLog("info", "Connecting to Temporal server", { address, role });
 
   const connection = await NativeConnection.connect({ address });
 
@@ -223,59 +230,71 @@ async function main(): Promise<void> {
     workflowTaskPollerBehavior: WORKFLOW_TASK_POLLER_BEHAVIOR,
   };
 
-  const worker = await Worker.create({
-    ...commonWorkerOptions,
-    taskQueue: TASK_QUEUES.DEFAULT,
-  });
+  const workers: Worker[] = [];
+  let httpServers: EventBridgeHandle | undefined;
+  let eventBridge: EventBridgeHandle | undefined;
 
-  jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.DEFAULT });
+  if (workerRoleRunsCore(role)) {
+    const worker = await Worker.create({
+      ...commonWorkerOptions,
+      taskQueue: TASK_QUEUES.DEFAULT,
+    });
+    workers.push(worker);
+    jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.DEFAULT });
 
-  // Dedicated queue for delayed/recurring report-only Claude/Codex tasks.
-  // These can run for tens of minutes and must not head-of-line block HA,
-  // schedule registration, PR summaries, or PR review specialist traffic.
-  const agentTaskWorker = await Worker.create({
-    ...commonWorkerOptions,
-    taskQueue: TASK_QUEUES.AGENT_TASK,
-  });
+    // Dedicated queue for delayed/recurring report-only Claude/Codex tasks.
+    // These can run for tens of minutes and must not head-of-line block HA,
+    // schedule registration, PR summaries, or PR review specialist traffic.
+    const agentTaskWorker = await Worker.create({
+      ...commonWorkerOptions,
+      taskQueue: TASK_QUEUES.AGENT_TASK,
+    });
+    workers.push(agentTaskWorker);
+    jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.AGENT_TASK });
 
-  jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.AGENT_TASK });
+    const clientConnection = await Connection.connect({ address });
+    const client = new Client({ connection: clientConnection });
+    await registerSchedules(client);
+    jsonLog("info", "Schedules registered");
 
-  // Activity concurrency stays 1 (serial long work). Workflow-task concurrency
-  // must be ≥2 when sticky cache is on — Core rejects max_cached_workflows>0
-  // with a single workflow-task poller/slot (see WORKFLOW_TASK_POLLER_BEHAVIOR).
-  const glitterCorpusWorker = await Worker.create({
-    ...commonWorkerOptions,
-    taskQueue: TASK_QUEUES.GLITTER_CORPUS,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  });
+    httpServers = startHttpServers(client);
+    eventBridge = startEventBridgeSupervisor(client);
+  }
 
-  jsonLog("info", "Worker created", {
-    taskQueue: TASK_QUEUES.GLITTER_CORPUS,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  });
+  if (workerRoleRunsGlitter(role)) {
+    // Activity concurrency stays 1 (serial long work). Workflow-task
+    // concurrency must be ≥2 when sticky cache is on — Core rejects
+    // max_cached_workflows>0 with a single workflow-task poller/slot.
+    const glitterCorpusWorker = await Worker.create({
+      ...commonWorkerOptions,
+      taskQueue: TASK_QUEUES.GLITTER_CORPUS,
+      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentWorkflowTaskExecutions: 2,
+    });
+    workers.push(glitterCorpusWorker);
+    jsonLog("info", "Worker created", {
+      taskQueue: TASK_QUEUES.GLITTER_CORPUS,
+      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentWorkflowTaskExecutions: 2,
+    });
 
-  const glitterContextWorker = await Worker.create({
-    ...commonWorkerOptions,
-    taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  });
+    const glitterContextWorker = await Worker.create({
+      ...commonWorkerOptions,
+      taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
+      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentWorkflowTaskExecutions: 2,
+    });
+    workers.push(glitterContextWorker);
+    jsonLog("info", "Worker created", {
+      taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
+      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentWorkflowTaskExecutions: 2,
+    });
+  }
 
-  jsonLog("info", "Worker created", {
-    taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  });
-
-  const clientConnection = await Connection.connect({ address });
-  const client = new Client({ connection: clientConnection });
-  await registerSchedules(client);
-  jsonLog("info", "Schedules registered");
-
-  const httpServers = startHttpServers(client);
-  const eventBridge = startEventBridgeSupervisor(client);
+  // The event-loop-backed health endpoint starts only after every worker in
+  // this role has been created and all role-specific startup has completed.
+  startMetricsServer();
 
   // Guard against double-shutdown. Kubernetes may deliver SIGTERM more than
   // once during pod termination, and the Temporal SDK throws
@@ -294,43 +313,21 @@ async function main(): Promise<void> {
     }
     shutdownStarted = true;
     jsonLog("info", "Shutting down worker", { signal });
-    await httpServers.close();
-    await eventBridge.close();
-    const workerState = worker.getState();
-    if (workerState === "RUNNING") {
-      worker.shutdown();
-    } else {
-      jsonLog("info", "Worker not RUNNING, skipping worker.shutdown()", {
-        state: workerState,
-      });
+    if (httpServers !== undefined) {
+      await httpServers.close();
     }
-    const agentTaskState = agentTaskWorker.getState();
-    if (agentTaskState === "RUNNING") {
-      agentTaskWorker.shutdown();
-    } else {
-      jsonLog("info", "agent-task worker not RUNNING, skipping shutdown()", {
-        state: agentTaskState,
-      });
+    if (eventBridge !== undefined) {
+      await eventBridge.close();
     }
-    const glitterCorpusState = glitterCorpusWorker.getState();
-    if (glitterCorpusState === "RUNNING") {
-      glitterCorpusWorker.shutdown();
-    } else {
-      jsonLog(
-        "info",
-        "glitter-corpus worker not RUNNING, skipping shutdown()",
-        { state: glitterCorpusState },
-      );
-    }
-    const glitterContextState = glitterContextWorker.getState();
-    if (glitterContextState === "RUNNING") {
-      glitterContextWorker.shutdown();
-    } else {
-      jsonLog(
-        "info",
-        "glitter-context worker not RUNNING, skipping shutdown()",
-        { state: glitterContextState },
-      );
+    for (const roleWorker of workers) {
+      const state = roleWorker.getState();
+      if (state === "RUNNING") {
+        roleWorker.shutdown();
+      } else {
+        jsonLog("info", "Worker not RUNNING, skipping shutdown()", {
+          state,
+        });
+      }
     }
     await stopMetricsServer();
     await shutdownTracing();
@@ -343,13 +340,10 @@ async function main(): Promise<void> {
     void shutdown("SIGINT");
   });
 
-  const workerRuns = [
-    worker.run(),
-    agentTaskWorker.run(),
-    glitterCorpusWorker.run(),
-    glitterContextWorker.run(),
-  ];
-  void restoreGlitterCorpusMetricsAfterWorkerStart();
+  const workerRuns = workers.map((roleWorker) => roleWorker.run());
+  if (workerRoleRunsGlitter(role)) {
+    void restoreGlitterCorpusMetricsAfterWorkerStart();
+  }
   await Promise.all(workerRuns);
 }
 


### PR DESCRIPTION
## Summary

- Keep Bun and split the worker into strict `core`, `glitter`, and backward-compatible `all` process roles.
- Run Glitter corpus/context queues in an independent Kubernetes Deployment so a runtime wedge cannot stop core schedules, webhooks, Home Assistant, or agent tasks.
- Probe the Bun event loop through `/healthz` for startup, readiness, and liveness, with independent SDK and application metrics per role.
- Add role-parsing and synthesized-manifest regression coverage.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal` — 481 tests passed.
- `bunx turbo run typecheck lint test --filter=@homelab/cdk8s` — 317 tests passed; 14 repository-declared integration skips.
- `bunx turbo run smoke --filter=@shepherdjerred/temporal` — Bun image built, all 13 operator CLIs passed, and worker boot behavior passed.
- `bun run check-todos` — 1,119 documents passed.
- Buildkite main #7903 exhaustive verify passed; its publish tail was superseded by a newer main build, so deployment provenance is being followed through the latest descendant main build.

## Incident boundary

The live evidence proved a stall in the shared Bun process but did not prove Bun itself was the low-level cause. This change contains and recovers the failure while retaining Bun.