### PR TITLE
feat(discord-plays-mario-kart): measure real press-to-glass input lag

### DIFF
--- a/packages/docs/plans/2026-08-03_mk64-latency-full-surface.md
+++ b/packages/docs/plans/2026-08-03_mk64-latency-full-surface.md
@@ -438,3 +438,52 @@ running`). Every subsequent `/play` then replies "Starting Mario Kart 64 in
   unrecoverable client state, and `/play` reporting success when it cannot
   stream (a fail-fast violation — it should surface the dead gateway). Not
   fixed here; filed as `packages/docs/todos/mk64-stop-bricks-stream-account.md`.
+
+## Session Log — 2026-08-03 (press-to-glass)
+
+### Done
+
+- Built and validated a real input-lag ruler after establishing that every
+  prior measurement in this plan was video-path only, not input lag.
+  `packages/discord-plays-mario-kart/packages/backend/scripts/e2e-press-to-glass.ts`
+  (input half) plus a `requestVideoFrameCallback` HUD decoder that samples every
+  presented frame (analysis harness in the session scratchpad).
+- Measured press-to-glass, single player, in Discord: **~172 ms settled,
+  ~500 ms on a fresh stream**, decomposed into input path / pod→browser /
+  client buffer / vsync. Charted the decay (attached to PR #1973).
+- Validated the measurement: exact glyph decode, single-frame rise gate, NTP
+  round-trip clock skew (18.54 ± 0.54 ms, re-verified), vsync quantisation of
+  `expectedDisplayTime`, and concurrent getStats corroboration of the client leg.
+- Ruled out clock drift, retransmission, ffmpeg input backpressure, and
+  sub-realtime encode as causes of the decaying pod→browser leg.
+- Shipped `video_playout_delay_max_ms` (fork opt-in + mario-kart config),
+  defaulting to the historical 100 ms so no consumer changes behavior.
+- Filed `packages/docs/todos/mk64-stop-bricks-stream-account.md`.
+- PR #1973 (draft, git-spice, off the new main after #1965 merged mid-session).
+
+### Remaining
+
+- **A/B `video_playout_delay_max_ms` 100 → 30 at matched stream age.** This is
+  the first change the new ruler can properly evaluate, and the client buffer
+  is ~92 ms of a ~172 ms settled budget. Requires a candidate image, deploy by
+  digest, and two runs started at the same stream age.
+- **Phase 3 metric repair is now the blocker for the biggest unexplained term.**
+  `stream_packet_ready_delay_ms` is pinned at its top bucket, so ~200 ms of
+  fresh-stream pod→browser latency cannot be localised to encode, packetize,
+  pacer, or SFU.
+- Understand and fix the startup decay itself — a player who `/play`s and races
+  immediately gets 2-3x the settled lag.
+- Phase 4 freeze attribution, Phase 5 4P gate (unchanged).
+
+### Caveats
+
+- The settled figure (~172 ms) comes from runs that had not finished decaying;
+  the true floor may be lower. Runs were 4 minutes.
+- `press → HUD digit lit` deliberately excludes MK64's own internal reaction
+  (~66-133 ms). It measures the part of the budget this system controls; felt
+  lag is higher.
+- `/stop` bricks the stream account, so every session cycle in this work used
+  a pod restart instead. `scratchpad/start_stream.sh` encodes that.
+- The A/B in the earlier Comment Log entries was measured with the video-path
+  ruler. Those numbers are not wrong, but they are not input lag, and the
+  stream-age confound means their confidence intervals understate uncertainty.


### PR DESCRIPTION
feat(discord-plays-mario-kart): measure real press-to-glass input lag

Every existing ruler in this repo measures the video path — how long a frame
takes to reach a viewer. That is not input lag, and the distinction turned out
to matter: press-to-glass is dominated by segments the video-only numbers do
not separate.

Adds the input half of a real ruler. `e2e-press-to-glass.ts` claims a seat over
the production socket path and issues press/release edges with the epoch-ms of
each emit; the burned-in HUD supplies the other half, since it lights seat N's
digit on the first frame the emulator rendered while holding that input and
also carries the pod's capture timestamp. Decoding the HUD on every presented
frame (requestVideoFrameCallback, so the transition frame is never missed) and
joining against the emit log yields press -> on screen, with both ends read off
one machine's clock so no skew correction is needed.

First results, single player, in Discord (n=120/run, exact glyph decode, clock
skew pinned to 18.5 +/- 0.5 ms by NTP-style round trip and re-verified stable):

  input path (press -> emulator renders the frame)   ~35 ms, flat
  pod -> last packet at browser                      80-250 ms, decays
  browser jitter buffer + decode                    ~100-120 ms
  wait for a vsync                                   ~17-29 ms

Two findings follow. The input path is already fast and is not worth further
optimisation. And press-to-glass is 2-3x worse on a freshly started stream
(~500 ms) than a settled one (~170 ms), decaying over 4+ minutes, so any A/B
that does not match stream age measures the age, not the change.

Also makes the receiver's jitter-buffer ceiling configurable. The fork
advertises playout-delay max = 100 ms and Chrome sits at that ceiling (92 ms
measured via getStats) despite zero packet loss and one 198 ms freeze in five
minutes, so the cap is close to a floor on client-side delay. The option is
opt-in and defaults to the historical 100 ms, so streambot and pokemon are
unaffected; mario-kart exposes it as `video_playout_delay_max_ms`, still
defaulted to 100 pending a matched-age A/B.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S5ADc4WWQRJRPDui3LKciS

docs(discord-plays-mario-kart): record press-to-glass results and the /stop bug

Writes up what the real input-lag ruler found, including the two results that
change the plan's priorities: the input path is ~35 ms and flat (nothing left
to win there), and stream age moves press-to-glass by 2-3x, which makes it both
a confound for every A/B and a lever in its own right.

Also files the /stop bug hit while cycling sessions: the stream account's
selfbot client fails to tear down, the emulator worker is left stopped, and
every later /play reports success without going live until the pod restarts.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S5ADc4WWQRJRPDui3LKciS

docs(discord-plays-mario-kart): add press-to-glass session log

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S5ADc4WWQRJRPDui3LKciS