### PR TITLE
docs(temporal): explain worker isolation

### DIFF
--- a/packages/docs/logs/2026-08-03_temporal-outage-diagnosis.md
+++ b/packages/docs/logs/2026-08-03_temporal-outage-diagnosis.md
@@ -145,12 +145,22 @@ separately because the recorded histories replayed successfully.
   liveness probes on `/healthz`.
 - Added synthesized-manifest regression coverage for the role split, probe
   configuration, and exposed ports.
+- Updated the package operator reference and human Temporal architecture page
+  to document the two Bun process roles and their failure boundary.
+- Merged the durable implementation in PR #1972 at feature commit
+  `e90062752c868027a97118fff97301609be49c57`; exact-head focused checks and the
+  exhaustive Buildkite verify graph passed.
+- Published the documentation follow-up as PR #1976 with a rendered system-map
+  screenshot; its exact-head verify, Playwright, deploy-path drift, and
+  Temporal image build/smoke jobs passed.
 
 ### Remaining
 
-- Update the Temporal operator and architecture documentation.
-- Complete focused verification, publish the native-stack draft PR, and inspect
-  its exact-current-head Buildkite result.
+- Verify that a main build publishes the feature-bearing Temporal image and
+  that GitOps rolls out two healthy worker Deployments with the expected
+  `core` and `glitter` roles.
+- Get a clean hosted review at the amended PR #1976 head; leave merging that
+  documentation follow-up to the normal human review workflow.
 
 ### Caveats
 
@@ -160,3 +170,21 @@ separately because the recorded histories replayed successfully.
   recurrence with CPU profiling enabled.
 - Restarting now may interrupt active agent work and cause delayed schedules to
   execute late.
+- The wiki's Bun unit tests pass, but local Astro 7/Vite 8 typecheck and build
+  fail during content-config loading with
+  `Tsconfig not found /tsconfig.base.json` in this nested worktree. A minimal
+  Astro config failed at the same content-sync boundary, and attempted config
+  and tsconfig-path workarounds were removed. Exact-head Buildkite remains the
+  independent verification for the rendered page.
+
+## Workflow Friction
+
+- `packages/docs/wiki` cannot currently run its required Astro render checks
+  from a nested `.claude/worktrees/` checkout because Vite 8 resolves an
+  inherited config as `/tsconfig.base.json`. The wiki needs a documented,
+  reproducible worktree-safe config-loading fix so visual documentation changes
+  can be rendered and captured before publication.
+- `gh stack submit --auto` unexpectedly converted both submitted branches from
+  draft state, and PR #1972 then auto-merged before the requested verification
+  was complete. The native-stack workflow needs a reliable noninteractive way
+  to preserve draft state until the agent explicitly promotes a PR.

--- a/packages/docs/wiki/src/content/docs/temporal/index.md
+++ b/packages/docs/wiki/src/content/docs/temporal/index.md
@@ -1,28 +1,28 @@
 ---
 title: Temporal worker
-description: One Bun process on the homelab runs every cron job, PR bot, and home-automation routine as durable Temporal workflows.
+description: Two fault-isolated Bun worker processes run the homelab's cron jobs, PR bots, Glitter pipeline, and home automation as durable Temporal workflows.
 ---
 
-`packages/temporal` is the monorepo's automation hub: a single Bun process
-running a fleet of Temporal workers on the homelab cluster. Every recurring
-job, PR bot, scheduled agent, and home-automation routine executes here as a
-durable workflow.
+`packages/temporal` is the monorepo's automation hub: one Bun image runs as two
+fault-isolated worker roles on the homelab cluster. Every
+recurring job, PR bot, scheduled agent, Glitter refresh, and home-automation
+routine executes here as a durable workflow.
 
 ```mermaid
 flowchart LR
   accTitle: Temporal worker system map
-  accDescr: Cron schedules, GitHub webhooks, Home Assistant events, the agent-task API, and the Xcode Cloud webhook all feed one worker process, which produces monorepo PRs, GitHub commit statuses, emailed reports, Home Assistant service calls, and Prometheus metrics.
+  accDescr: The Temporal server dispatches general and agent work to the core Bun worker and Glitter corpus and context work to a separate Bun worker. Webhooks, APIs, and Home Assistant events enter through the core worker. Both workers expose independent health and metrics endpoints.
 
-  S[Cron schedules] --> W[Worker process]
-  G[GitHub PR webhooks] --> W
-  H[Home Assistant events] --> W
-  A[Agent-task API] --> W
-  X[Xcode Cloud webhook] --> W
-  W --> P[Monorepo PRs]
-  W --> C[GitHub commit statuses]
-  W --> E[Emailed reports]
-  W --> HA[Home Assistant actions]
-  W --> M[Prometheus metrics]
+  S[Cron schedules] --> T[Temporal server]
+  T --> C[Core Bun worker<br/>default + agent-task]
+  T --> G[Glitter Bun worker<br/>corpus + context]
+  W[GitHub and Xcode webhooks] --> C
+  H[Home Assistant events] --> C
+  A[Agent-task API] --> C
+  C --> O[PRs, reports, HA actions]
+  G --> D[Discord corpus and context PRs]
+  C --> M[Health and metrics]
+  G --> M
 ```
 
 ## Shape
@@ -31,11 +31,15 @@ flowchart LR
   runtime: it consumes workspace libraries, clones the monorepo to open PRs,
   and receives webhooks. The rest of the repo talks to it only through its
   surfaces.
-- **One process, four queues.** A single deployment (1 replica, `Recreate`)
-  runs one worker per task queue — `default`, `agent-task`, `glitter-corpus`,
-  `glitter-context` — all sharing one workflow bundle. Queues exist to
-  isolate concurrency: long agent subprocesses and rate-limited Discord jobs
-  cannot starve fast home-automation workflows.
+- **Two Bun processes, four queues.** The core deployment owns `default` and
+  `agent-task`; a separate Glitter deployment owns `glitter-corpus` and
+  `glitter-context`. Both run the same image and workflow bundle, selected by
+  a strict process role. Queues isolate concurrency; processes isolate runtime
+  and resource failures.
+- **Self-healing failure boundary.** Each process serves `/healthz` from Bun's
+  event loop only after its workers finish startup. Independent startup,
+  readiness, and liveness probes restart a wedged role without taking down the
+  other one. SDK and application metrics are scraped separately per role.
 - **Runs on the homelab.** The `temporal` namespace holds the Temporal server
   (own Postgres), the worker, and a Tailscale-gated instance of the Temporal
   Web UI — the place to inspect runs and pause schedules. All of it is deployed

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -6,6 +6,13 @@ Temporal workflow worker for the monorepo. Consolidates ad-hoc scheduling (K8s C
 
 Runs under **Bun**. The Temporal TypeScript SDK supports Bun for workers, workflows, activities, and client.
 
+Production uses the same Bun image in two Kubernetes Deployments selected by
+`TEMPORAL_WORKER_ROLE`: `core` owns the `default` and `agent-task` queues plus
+schedules and HTTP/event surfaces; `glitter` owns `glitter-corpus` and
+`glitter-context`. The default `all` role preserves the single-process local
+development behavior. Keep new queue ownership explicit in `worker.ts` so a
+heavy Glitter failure cannot take down core automation.
+
 ## Structure
 
 ```
@@ -14,6 +21,7 @@ src/
   client.ts              # Shared Temporal client factory (reusable by other packages)
   shared/
     task-queues.ts       # Task queue name constants
+    worker-role.ts       # Strict process-role parsing and queue ownership
     schemas.ts           # Zod schemas for workflow inputs
   workflows/             # Temporal workflow definitions (deterministic, no I/O)
   activities/            # Temporal activity implementations (actual work: API calls, DB, etc.)
@@ -141,6 +149,7 @@ Workflow:
 ## Environment Variables
 
 - `TEMPORAL_ADDRESS` — Temporal server gRPC address (default: `temporal-server.temporal.svc.cluster.local:7233`)
+- `TEMPORAL_WORKER_ROLE` — process role: `all` (default/local), `core`, or `glitter`. Invalid values fail startup.
 - `HA_URL` — Home Assistant URL
 - `HA_TOKEN` — Home Assistant long-lived access token
 - `GOLINK_URL` — Golink service URL


### PR DESCRIPTION
## Summary

- Document the production `core` and `glitter` Bun worker roles in the package operator reference.
- Update the human Temporal architecture page and system diagram to show the process-level failure boundary.
- Correct the incident log so it does not claim that Bun itself was proven as the root cause.

## Verification

- `bun run check-todos` — 1,119 documents passed.
- Wiki Bun unit tests — 11 passed.
- Exact-head Buildkite #7907: exhaustive verify, Playwright, deploy-path drift check, and Temporal image build/smoke passed; hosted review pending.

## Visual verification

Updated system map: the same Bun image runs as separate core and Glitter processes, each with independent health and metrics.

![temporal-worker-isolation.png](https://public.sjer.red/pr/assets/1976/temporal-worker-isolation.png)

Local Astro 7/Vite 8 content sync fails in nested worktrees with `Tsconfig not found /tsconfig.base.json`; attempted configuration workarounds were removed rather than masking the failure. Exact-head hosted verification passes.