### PR TITLE
fix(temporal): retry Glitter extraction/synthesis with per-attempt seeds

### DIFF
--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -114,14 +114,110 @@ weekly production schedule.
 
 ## Remaining
 
-- [ ] Complete the production generation, review, deployment, and schedule
-      activation gates.
+Verified live state on 2026-08-03 (Temporal UI + `main`): the workflow code is
+merged/deployed (#1846), the isolated `glitter` worker is up and polling
+`glitter-context` + `glitter-corpus`, and `glitter-corpus-daily` is healthy. But
+`main` still holds **legacy V1** cards (old `coverage` shape, no `schemaVersion`,
+no 18 situational examples; `generation-state.json` is an empty scaffold), the
+2026-07-29 real-run proposal branch has been deleted, and no V2 data PR is open.
+The schedule remains paused. The ordered checklist to finish:
+
+### Phase 0 — Preflight (no spend) — COMPLETE
+
+- [x] `OPENAI_API_KEY` (Homelab vault `temporal-worker-secrets`) verified healthy
+      2026-08-03: `GET /v1/models` → 200, both `gpt-5.6-luna` and `gpt-5.6-sol`
+      available, live `/v1/responses` call on luna → 200 (quota OK, not the 429
+      the 2026-07-29 runs hit).
+- [x] `costForTextUsage` pricing present: luna $1/$6 per M in/out, sol $5/$30.
+- [x] Confirm the `glitter` worker is polling `glitter-context` (verified
+      2026-08-03 19:47, poller `temporal-temporal-glitter-worker-…`).
+- [ ] Decide the source snapshot: reuse the proven pinned snapshot
+      (`dbb59f00-3f6b-4cab-a87c-6d8a65e21d62`,
+      sha `e4253d20…`, cached artifacts → near-free deterministic reproduction of
+      `proposalSha256=9f558af0…`) or regenerate against the newer corpus
+      (full spend). Trigger:
+      `bun run glitter:operate context-refresh --dry-run=… --max-estimated-cost-usd=… [--snapshot-id=… --snapshot-sha256=…]`
+      via `kubectl port-forward svc/temporal-temporal-server-service 7233:7233 -n temporal`.
+
+### Phase 1 — Regenerate the V2 proposal
+
+- [ ] Run two pinned deterministic dry runs ($50 ceiling); confirm byte-identical
+      `proposalSha256`.
+- [ ] Run the real run reusing those cached artifacts → outcome `pr-created`
+      (re-emits the 13–14 V2 cards + `generation-state.json`, opens a fresh PR).
+
+### Phase 2 — Review & merge the data
+
+- [ ] Human-review the V2 data PR: spot-check 20 quotes / 30 samples / 18
+      situational examples / `coverage` + `schemaVersion` present per card.
+- [ ] Merge → `main` flips V1 → V2; confirm `@shepherdjerred/glitter-context`
+      rebuilds `dist/` with the new data for consumers.
+
+### Phase 3 — Consumer smoke tests (production)
+
+- [ ] Birmel: supervisor, subagents, and should-respond classifier receive the
+      full thick `StylePromptContext` for V2 cards.
+- [ ] Scout: frontend + backend built-ins serialize the full shared context.
+- [ ] Confirm deployed digests / ArgoCD health for Birmel + Scout picked up the
+      new data.
+
+### Phase 4 — Go live
+
+- [ ] Un-pause `glitter-context-refresh-weekly` in the Temporal UI (Schedules).
+- [ ] Confirm the next scheduled action (Mon 11:00 PT) under the $10 weekly
+      ceiling.
+
+### Phase 5 — Close out
+
+- [x] Close PR #1834 as superseded (already CLOSED).
+- [ ] Set this plan `status: complete` and move it to `archive/completed/`.
 
 ## Comment Log
 
 - 2026-07-29: Approved design selects Luna extraction, Sol synthesis,
   field-level preservation, exact 20/30/18 content counts, and thick Birmel and
   Scout contexts.
+- 2026-08-03 (execution attempt): Phase 0 passed. Ran a pinned dry run
+  (snapshot `dbb59f00…`) expecting cached-artifact reuse. Instead the 2026-07-29
+  SeaweedFS artifacts are **expired/cold**, so it regenerated from scratch and
+  **FAILED** (`glitter-context-refresh-manual-70d55356…`, 20:02→20:12, both
+  activity attempts): `chunk 2024-10-0000 observation cites unknown message IDs:
+1296836613842944112`. Root-caused read-only: `chunkPrompt` shows the model only
+  the sub-chunk's messages and `validateChunkSummary` builds `knownIds` from that
+  same set (consistent — not a code mismatch); `gpt-5.6-luna` simply emitted a
+  citation outside its supplied set, the single repair attempt also missed, and
+  both outputs are cached pre-validation (`readOrCreateGenerationArtifact`,
+  key `guilds/<id>/derived/glitter-context/generation-artifacts/…`, request hash
+  includes a fixed `DETERMINISTIC_SEED`) → the chunk is now **poison-cached** and
+  fails deterministically on retry. This is the same stochastic
+  extraction-compliance failure that killed 3 runs on 2026-07-29; those passed by
+  eventually landing a clean pass whose artifacts got cached, and that cache has
+  since expired. Net: the "reuse pinned cache → near-free" path is no longer
+  available; getting to green now requires either lucky clear-and-retry (risky —
+  the fixed seed may reproduce the bad output) or a code fix hardening extraction
+  reliability. Escalated to the operator for a path decision. Spend bounded (early
+  failure, well under the $50 ceiling; exact receipt not surfaced in logs).
+- 2026-08-03: Live status audit. Workflow proven working on 2026-07-29 (two dry
+  runs matched `proposalSha256=9f558af0…`; real run `outcome=pr-created`), but
+  that branch/PR was never merged and is now deleted, so `main` is still V1 and
+  the schedule stays paused. The isolated glitter worker (#1972, merged
+  2026-08-03) is up and polling both glitter queues. Rewrote `## Remaining` as an
+  ordered Phase 0–5 checklist; the blocking work is regenerating and merging a
+  fresh V2 data PR (Phase 1–2), everything else is downstream of it.
+- 2026-08-03 (fix): Operator chose to harden extraction rather than gamble on
+  clear-and-retry. `fix/glitter-extraction-repair-loop` converts the single
+  chunk-extraction and synthesis repair steps into bounded loops
+  (`MAX_EXTRACTION_REPAIR_ATTEMPTS=4`, `MAX_SYNTHESIS_REPAIR_ATTEMPTS=3`) where
+  each attempt uses `DETERMINISTIC_SEED + attempt`. Attempt 0 keeps seed 0 (its
+  cache key is unchanged, so valid prior artifacts still reuse), and each repair
+  gets a distinct seed → a genuinely fresh, cache-distinct model call that a
+  fixed-seed retry could not produce, while staying deterministic by attempt
+  index (a re-run reuses the first attempt that passed). No loosening of the
+  evidence validator. Added two loop tests to
+  `glitter-context-refresh-generate.test.ts` (poisoned→clean succeeds with seeds
+  `[0,1]`; persistent failure throws after seeds `[0,1,2,3,4]`). Next: land +
+  deploy the worker, then re-run Phase 1 (the poisoned `2024-10-0000` artifact
+  stays cached but now just triggers the repair loop instead of failing).
 
 ## Session Log — 2026-07-29
 

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { zodResponseFormat } from "openai/helpers/zod";
 import {
   PersonSchema,
@@ -11,6 +11,9 @@ import {
   StyleChunkSummarySchema,
   StyleSynthesisSchema,
 } from "./glitter-context-refresh-style-schemas.ts";
+import * as glitterOpenai from "./glitter-context-refresh-openai.ts";
+import { GenerationBudget } from "./glitter-context-refresh-budget.ts";
+import type { GenerationArtifactStore } from "./glitter-context-refresh-cache.ts";
 
 const person = PersonSchema.parse({
   id: "ryan",
@@ -242,5 +245,121 @@ describe("Glitter generated style-card schemas", () => {
     ).toThrow(
       "style synthesis did not decide every prior summary observation exactly once",
     );
+  });
+});
+
+// The extraction/synthesis repair loop: gpt-5.6 occasionally cites a message ID
+// outside its supplied evidence set, and because completions are cached before
+// validation a fixed-seed retry would re-read the same poisoned artifact and
+// fail forever. Each repair attempt must use a distinct seed so it is a fresh,
+// cache-distinct call — a re-run then reuses the first attempt that passed.
+const firstMessage = CurrentMessageSchema.parse(messages[0]);
+
+const goodChunkSummary = {
+  observations: [
+    {
+      field: "voice" as const,
+      claim: "Writes concise, direct sentences.",
+      confidence: 0.9,
+      evidenceMessageIds: [firstMessage.messageId],
+    },
+  ],
+  representativeMessages: [
+    { messageId: firstMessage.messageId, content: firstMessage.content },
+  ],
+};
+
+const badChunkSummary = {
+  observations: [
+    {
+      field: "voice" as const,
+      claim: "Cites a message from outside the supplied chunk.",
+      confidence: 0.9,
+      evidenceMessageIds: ["99999999999999999"],
+    },
+  ],
+  representativeMessages: [],
+};
+
+const mockUsage = { prompt_tokens: 100, completion_tokens: 50 };
+
+let chunkResponder: (call: number) => unknown = () => goodChunkSummary;
+let chunkCallCount = 0;
+let recordedSeeds: number[] = [];
+
+await mock.module("./glitter-context-refresh-openai.ts", () => ({
+  ...glitterOpenai,
+  parseGlitterCompletion: (callSite: string, params: { seed: number }) => {
+    if (callSite.startsWith("glitter-style-chunk")) {
+      recordedSeeds.push(params.seed);
+      const parsed = chunkResponder(chunkCallCount);
+      chunkCallCount += 1;
+      return Promise.resolve({
+        choices: [{ message: { parsed, content: null } }],
+        usage: mockUsage,
+      });
+    }
+    return Promise.resolve({
+      choices: [{ message: { parsed: synthesis, content: null } }],
+      usage: mockUsage,
+    });
+  },
+}));
+
+const { generateStyleCard } =
+  await import("./glitter-context-refresh-style-generation.ts");
+
+function memoryStore(): GenerationArtifactStore {
+  const values = new Map<string, unknown>();
+  return {
+    ownerRunId: "11111111-1111-4111-8111-111111111111",
+    read: (key) => Promise.resolve(values.get(key)),
+    create: (key, value) => {
+      values.set(key, value);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("Glitter extraction repair loop", () => {
+  test("retries a poisoned chunk with a fresh seed and succeeds", async () => {
+    chunkCallCount = 0;
+    recordedSeeds = [];
+    // Attempt 0 (seed 0) cites an unknown ID; the repair (seed 1) is clean.
+    chunkResponder = (call) =>
+      call === 0 ? badChunkSummary : goodChunkSummary;
+
+    const result = await generateStyleCard({
+      candidate,
+      existingCard,
+      sourceSnapshotSha256: "a".repeat(64),
+      artifactStore: memoryStore(),
+      budget: new GenerationBudget(100),
+    });
+
+    expect(result.schemaVersion).toBe(2);
+    // Initial attempt seed 0, one repair at seed 1 — distinct seeds, so the
+    // repair is a genuinely fresh (cache-distinct) model call.
+    expect(recordedSeeds).toEqual([0, 1]);
+  });
+
+  test("throws after exhausting the bounded repair attempts", async () => {
+    chunkCallCount = 0;
+    recordedSeeds = [];
+    chunkResponder = () => badChunkSummary;
+
+    await expect(
+      generateStyleCard({
+        candidate,
+        existingCard,
+        sourceSnapshotSha256: "a".repeat(64),
+        artifactStore: memoryStore(),
+        budget: new GenerationBudget(100),
+      }),
+    ).rejects.toThrow("cites unknown message IDs");
+
+    // Initial attempt (seed 0) plus MAX_EXTRACTION_REPAIR_ATTEMPTS repairs,
+    // each with a distinct escalating seed.
+    expect(recordedSeeds).toEqual([0, 1, 2, 3, 4]);
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -45,6 +45,18 @@ const EXTRACTION_MAX_OUTPUT_TOKENS = 2000;
 const SYNTHESIS_MAX_OUTPUT_TOKENS = 15_000;
 const DETERMINISTIC_SEED = 0;
 
+// A single repair attempt is not enough: gpt-5.6 occasionally emits an
+// observation/quote/sample citing a message ID outside its supplied evidence
+// set, and because every completion is cached (immutably, keyed by request
+// hash) *before* validation, a fixed-seed retry re-reads the same poisoned
+// artifact and fails identically forever. Each repair attempt therefore uses a
+// distinct seed (`DETERMINISTIC_SEED + attempt`) so it is a genuinely fresh,
+// cache-distinct model call while staying deterministic by attempt index — a
+// re-run reuses the first attempt that passed. Attempt 0 is the initial call
+// (unchanged seed 0, so its cache key is stable); attempts 1..N are repairs.
+const MAX_EXTRACTION_REPAIR_ATTEMPTS = 4;
+const MAX_SYNTHESIS_REPAIR_ATTEMPTS = 3;
+
 type SummarizedChunk = {
   key: string;
   month: string;
@@ -128,6 +140,7 @@ async function runChunkExtraction(input: {
   chunk: StyleEvidenceChunk;
   artifactStore: GenerationArtifactStore;
   budget: GenerationBudget;
+  attempt: number;
   repair: {
     previous: StyleChunkSummary;
     error: string;
@@ -156,7 +169,7 @@ async function runChunkExtraction(input: {
     messages,
     max_completion_tokens: EXTRACTION_MAX_OUTPUT_TOKENS,
     reasoning_effort: "none" as const,
-    seed: DETERMINISTIC_SEED,
+    seed: DETERMINISTIC_SEED + input.attempt,
     response_format: zodResponseFormat(
       StyleChunkSummarySchema,
       "style_chunk_summary",
@@ -210,19 +223,33 @@ async function summarizeChunk(input: {
   artifactStore: GenerationArtifactStore;
   budget: GenerationBudget;
 }): Promise<StyleChunkSummary> {
-  const initial = await runChunkExtraction({ ...input, repair: null });
+  let previous = await runChunkExtraction({
+    ...input,
+    attempt: 0,
+    repair: null,
+  });
+  let lastError: Error;
   try {
-    validateChunkSummary(input.chunk, initial);
-    return initial;
+    validateChunkSummary(input.chunk, previous);
+    return previous;
   } catch (error: unknown) {
-    const parsedError = z.instanceof(Error).parse(error);
+    lastError = z.instanceof(Error).parse(error);
+  }
+  for (let attempt = 1; attempt <= MAX_EXTRACTION_REPAIR_ATTEMPTS; attempt++) {
     const repaired = await runChunkExtraction({
       ...input,
-      repair: { previous: initial, error: parsedError.message },
+      attempt,
+      repair: { previous, error: lastError.message },
     });
-    validateChunkSummary(input.chunk, repaired);
-    return repaired;
+    try {
+      validateChunkSummary(input.chunk, repaired);
+      return repaired;
+    } catch (error: unknown) {
+      lastError = z.instanceof(Error).parse(error);
+      previous = repaired;
+    }
   }
+  throw lastError;
 }
 
 function synthesisPrompt(input: {
@@ -295,6 +322,7 @@ async function runSynthesis(input: {
   chunks: readonly SummarizedChunk[];
   artifactStore: GenerationArtifactStore;
   budget: GenerationBudget;
+  attempt: number;
   repair: {
     previous: StyleSynthesis;
     error: string;
@@ -314,7 +342,7 @@ async function runSynthesis(input: {
     messages,
     max_completion_tokens: SYNTHESIS_MAX_OUTPUT_TOKENS,
     reasoning_effort: "medium" as const,
-    seed: DETERMINISTIC_SEED,
+    seed: DETERMINISTIC_SEED + input.attempt,
     response_format: zodResponseFormat(
       StyleSynthesisSchema,
       "style_card_synthesis",
@@ -368,12 +396,21 @@ export function estimateStyleGenerationCost(input: {
   const chunks = buildStyleEvidenceChunks(input.candidate.safeMessages);
   const extractionCost = chunks.reduce((total, chunk) => {
     const prompt = chunkPrompt({ candidate: input.candidate, chunk });
-    const oneAttempt = estimatedCallCostUsd({
+    const initialInputTokens = inputTokenUpperBound(prompt);
+    const initialCall = estimatedCallCostUsd({
       model: EXTRACTION_MODEL,
-      inputTokenUpperBound: inputTokenUpperBound(prompt),
+      inputTokenUpperBound: initialInputTokens,
       outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
     });
-    return total + oneAttempt * 2;
+    // Every repair attempt also serializes the prior summary (bounded by the
+    // output cap) and the validation error back into its request, so its input
+    // is larger than the initial call's.
+    const repairCall = estimatedCallCostUsd({
+      model: EXTRACTION_MODEL,
+      inputTokenUpperBound: initialInputTokens + EXTRACTION_MAX_OUTPUT_TOKENS,
+      outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+    });
+    return total + initialCall + repairCall * MAX_EXTRACTION_REPAIR_ATTEMPTS;
   }, 0);
   const synthesisBase = synthesisPrompt({
     candidate: input.candidate,
@@ -384,12 +421,24 @@ export function estimateStyleGenerationCost(input: {
   const synthesisInputUpperBound =
     inputTokenUpperBound(synthesisBase) +
     chunks.length * EXTRACTION_MAX_OUTPUT_TOKENS;
-  const synthesisCost = estimatedCallCostUsd({
+  const synthesisInitialCall = estimatedCallCostUsd({
     model: SYNTHESIS_MODEL,
     inputTokenUpperBound: synthesisInputUpperBound,
     outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
   });
-  return extractionCost + synthesisCost * 2;
+  // A synthesis repair likewise serializes the prior synthesis (bounded by the
+  // output cap) plus the error into its request.
+  const synthesisRepairCall = estimatedCallCostUsd({
+    model: SYNTHESIS_MODEL,
+    inputTokenUpperBound:
+      synthesisInputUpperBound + SYNTHESIS_MAX_OUTPUT_TOKENS,
+    outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+  });
+  return (
+    extractionCost +
+    synthesisInitialCall +
+    synthesisRepairCall * MAX_SYNTHESIS_REPAIR_ATTEMPTS
+  );
 }
 
 export async function generateStyleCard(input: {
@@ -413,28 +462,39 @@ export async function generateStyleCard(input: {
       }),
     });
   }
-  const initial = await runSynthesis({
+  let previous = await runSynthesis({
     ...input,
     chunks: summarizedChunks,
+    attempt: 0,
     repair: null,
   });
+  let lastError: Error;
   try {
     return finalizeStyleSynthesis({
       ...input,
       chunkCount: chunks.length,
-      synthesis: initial,
+      synthesis: previous,
     });
   } catch (error: unknown) {
-    const parsedError = z.instanceof(Error).parse(error);
+    lastError = z.instanceof(Error).parse(error);
+  }
+  for (let attempt = 1; attempt <= MAX_SYNTHESIS_REPAIR_ATTEMPTS; attempt++) {
     const repaired = await runSynthesis({
       ...input,
       chunks: summarizedChunks,
-      repair: { previous: initial, error: parsedError.message },
+      attempt,
+      repair: { previous, error: lastError.message },
     });
-    return finalizeStyleSynthesis({
-      ...input,
-      chunkCount: chunks.length,
-      synthesis: repaired,
-    });
+    try {
+      return finalizeStyleSynthesis({
+        ...input,
+        chunkCount: chunks.length,
+        synthesis: repaired,
+      });
+    } catch (error: unknown) {
+      lastError = z.instanceof(Error).parse(error);
+      previous = repaired;
+    }
   }
+  throw lastError;
 }


### PR DESCRIPTION
## Why

A cold-cache production run of `runGlitterContextRefresh` (the Glitter style-card
generator) **failed deterministically** on chunk `2024-10-0000`:

```
chunk 2024-10-0000 observation cites unknown message IDs: 1296836613842944112
```

Root cause (not a validation-vs-prompt mismatch — those are consistent):

- `gpt-5.6-luna` occasionally emits an observation/quote/sample citing a message
  ID outside its supplied evidence set. The evidence validator correctly rejects it.
- Every completion is cached immutably (`readOrCreateGenerationArtifact`, keyed by
  a request hash that includes a **fixed** `DETERMINISTIC_SEED`) **before**
  validation. So a bad extraction is written to the cache, and the single repair
  attempt — same seed — re-reads/re-produces the same poisoned output. Retries and
  re-runs then fail **identically forever**.

This is the same stochastic failure that killed 3 runs on 2026-07-29; those only
went green by luck (eventually landing a clean pass whose artifacts got cached),
and that cache has since expired.

## What

Convert both the chunk-extraction and synthesis single-repair steps into **bounded
repair loops** with a **per-attempt seed** (`DETERMINISTIC_SEED + attempt`):

- `MAX_EXTRACTION_REPAIR_ATTEMPTS = 4`, `MAX_SYNTHESIS_REPAIR_ATTEMPTS = 3`.
- Attempt 0 keeps seed 0, so its cache key is unchanged and any valid prior
  artifact still reuses (determinism + dry-run→real promotion preserved).
- Each repair uses a distinct seed → a genuinely fresh, **cache-distinct** model
  call that a fixed-seed retry could not produce, while staying deterministic by
  attempt index (a re-run reuses the first attempt that passed).
- **No loosening of the evidence validator** — it still fails closed after the
  bounded attempts are exhausted.

## Testing

- `bunx turbo run typecheck lint --filter=@shepherdjerred/temporal` — clean.
- New loop tests in `glitter-context-refresh-generate.test.ts`:
  - poisoned attempt (seed 0) → clean repair (seed 1) succeeds, asserting seeds `[0,1]`.
  - persistent failure throws after exhausting seeds `[0,1,2,3,4]`.
- Existing glitter cache/generate/workflow tests pass (15/15).

## Rollout context

Part of the paused Glitter V2 rollout (`packages/docs/plans/2026-07-29_glitter-style-card-v2.md`).
After this merges + the `glitter` worker redeploys, the poisoned `2024-10-0000`
artifact stays cached but now just triggers the repair loop instead of wedging the
run — unblocking Phase 1 (regenerate + open the V2 data PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
