### PR TITLE
chore(homelab): promote beta images to prod

### DIFF
--- a/packages/docs/logs/2026-08-03_promote-beta-images-to-prod.md
+++ b/packages/docs/logs/2026-08-03_promote-beta-images-to-prod.md
@@ -1,5 +1,5 @@
 ---
-id: 2026-08-03_promote-beta-images-to-prod
+id: 2026-08-03-promote-beta-images-to-prod
 type: log
 status: complete
 board: false

--- a/packages/docs/logs/2026-08-03_promote-beta-images-to-prod.md
+++ b/packages/docs/logs/2026-08-03_promote-beta-images-to-prod.md
@@ -1,0 +1,82 @@
+---
+id: 2026-08-03_promote-beta-images-to-prod
+type: log
+status: complete
+board: false
+---
+
+# Promote beta images to prod
+
+## Task
+
+Promote all first-party beta image pins to prod in
+`packages/homelab/src/cdk8s/src/versions.ts`.
+
+## Scope
+
+Two first-party apps carry `/beta` and `/prod` deployment-stage pins:
+
+- `shepherdjerred/scout-for-lol`
+- `shepherdjerred/starlight-karma-bot`
+
+(`shepherdjerred/birmel` and `shepherdjerred/scout-evals` have no `/prod`
+stage, so nothing to promote there.)
+
+## Mechanism (per version-management / scout AGENTS.md)
+
+Prod promotion = pinning the `/prod` entry to a **minted** `2.0.0-<n>`
+tag@digest. Every main build both archives the prod-flavored site artifact to
+`s3://scout-site-releases/2.0.0-<n>/` and mints
+`ghcr.io/shepherdjerred/scout-for-lol:2.0.0-<n>` pointing at the backend digest
+beta serves — so a minted tag's existence in GHCR guarantees its paired prod
+site artifact exists. `scout-prod-reconcile` derives the prod site version from
+the pin's tag portion (no separate site pin). Only ever pin a minted tag@digest.
+
+No standing Renovate promotion PR was open, so the promotion was done by
+hand-editing the pins (doc-sanctioned).
+
+## Changes
+
+| Pin                        | Before                        | After                         |
+| -------------------------- | ----------------------------- | ----------------------------- |
+| `scout-for-lol/prod`       | `2.0.0-7074@sha256:f5e6add3…` | `2.0.0-7926@sha256:026d26b2…` |
+| `starlight-karma-bot/prod` | `2.0.0-6673@sha256:4e0aaa2b…` | `2.0.0-7909@sha256:7e904d05…` |
+
+### Verification of targets (before editing)
+
+- `scout` beta pin's cosmetic tag `2.0.0-7924` does **not** exist as a real
+  GHCR tag (it's a label on `:latest`). The latest **minted** scout tag is
+  `2.0.0-7926`, whose digest `026d26b2…` is **identical** to the beta pin's
+  digest — i.e. `-7926` is the minted release tag for the exact backend beta
+  serves. Pinned prod to `2.0.0-7926@sha256:026d26b2…`.
+- `starlight-karma-bot` beta pin `2.0.0-7909@sha256:7e904d05…` **is** a real
+  minted GHCR tag (verified `crane digest` matches). It is also the latest
+  karma-bot tag. Pinned prod to the same value.
+
+`crane digest` / `crane ls` used to confirm every tag+digest before editing.
+
+## Session Log — 2026-08-03
+
+### Done
+
+- Edited `packages/homelab/src/cdk8s/src/versions.ts`: promoted
+  `scout-for-lol/prod` → `2.0.0-7926@sha256:026d26b2…` and
+  `starlight-karma-bot/prod` → `2.0.0-7909@sha256:7e904d05…`.
+- Verified both target tags/digests exist in GHCR and match the backend digest
+  beta serves.
+- `bunx turbo run typecheck --filter=homelab` — passes.
+
+### Remaining
+
+- Open the PR and let it merge; on merge to main, ArgoCD rolls the prod
+  backends and `scout-prod-reconcile` syncs the prod site bucket from the
+  archived `2.0.0-7926` artifact.
+- Post-merge, confirm prod serves the promoted versions:
+  `curl https://scout-for-lol.com/.release-version` should report `7926`.
+
+### Caveats
+
+- This is a production deploy of both apps. Rollback = revert the promotion
+  commit, or hand-edit a pin back to an older minted tag@digest.
+- Scout prod site version is derived from the pin's tag portion (`-7926`); do
+  not hand-pair a tag with a mismatched digest.

--- a/packages/docs/logs/2026-08-03_promote-beta-images-to-prod.md
+++ b/packages/docs/logs/2026-08-03_promote-beta-images-to-prod.md
@@ -25,12 +25,20 @@ stage, so nothing to promote there.)
 ## Mechanism (per version-management / scout AGENTS.md)
 
 Prod promotion = pinning the `/prod` entry to a **minted** `2.0.0-<n>`
-tag@digest. Every main build both archives the prod-flavored site artifact to
-`s3://scout-site-releases/2.0.0-<n>/` and mints
+tag@digest. On an **eligible Scout release build** — a main build that produces
+a `shepherdjerred/scout-for-lol/beta` image candidate or a `site-scout` source
+change (the `scout-beta-release`/`scout-tag-release` steps in
+`.buildkite/pipeline.yml` short-circuit with `exit 0` otherwise) — the release
+pipeline both immutably archives the prod-flavored site artifact and mints
 `ghcr.io/shepherdjerred/scout-for-lol:2.0.0-<n>` pointing at the backend digest
-beta serves — so a minted tag's existence in GHCR guarantees its paired prod
-site artifact exists. `scout-prod-reconcile` derives the prod site version from
-the pin's tag portion (no separate site pin). Only ever pin a minted tag@digest.
+beta serves, so a minted tag's existence in GHCR guarantees its paired prod
+site artifact exists. The artifact is **content-addressed**: `archiveFlavor`
+stores it under `s3://scout-site-releases/<releaseInputDigest>/prod/`
+(`scripts/lib/scout-site-storage.ts`); `versions/2.0.0-<n>.json` is only a
+lookup record mapping the tag to that release state, **not** the artifact path.
+`scout-prod-reconcile` resolves the pinned tag to its release state and
+reconciles prod to that immutable archive (no separate site pin). Only ever pin
+a minted tag@digest.
 
 No standing Renovate promotion PR was open, so the promotion was done by
 hand-editing the pins (doc-sanctioned).
@@ -70,13 +78,17 @@ hand-editing the pins (doc-sanctioned).
 
 - Open the PR and let it merge; on merge to main, ArgoCD rolls the prod
   backends and `scout-prod-reconcile` syncs the prod site bucket from the
-  archived `2.0.0-7926` artifact.
-- Post-merge, confirm prod serves the promoted versions:
-  `curl https://scout-for-lol.com/.release-version` should report `7926`.
+  immutable content-addressed archive for the pinned `2.0.0-7926` release state.
+- Post-merge, confirm prod serves the promoted site: the prod bucket's
+  `.release-version` marker (`curl https://scout-for-lol.com/.release-version`)
+  should read `scout-site@<releaseInputDigest>` — the content identity
+  `siteReleaseIdentity` writes (`scripts/lib/scout-release-state.ts`), not the
+  bare `7926` tag number.
 
 ### Caveats
 
 - This is a production deploy of both apps. Rollback = revert the promotion
   commit, or hand-edit a pin back to an older minted tag@digest.
-- Scout prod site version is derived from the pin's tag portion (`-7926`); do
-  not hand-pair a tag with a mismatched digest.
+- The prod site identity is the release's content digest (`releaseInputDigest`),
+  resolved from the pinned tag's release state — not the `-7926` tag portion
+  itself; do not hand-pair a tag with a mismatched digest.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -164,13 +164,13 @@ const versions = {
   // base moves off 2.0.0-, this pin needs one manual edit).
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
-    "2.0.0-7074@sha256:f5e6add31cb08c1919c667dff6216318aca82d2918758f6bc742552a2ff3e024",
+    "2.0.0-7926@sha256:026d26b2304c9b629c4b6f59628eccea7457d370c9f9b57ae396afcefc46048b",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
     "2.0.0-7909@sha256:7e904d0538a6e0456271b50fe58c520e18159440f3b68b6073a307d7862c4972",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/starlight-karma-bot
   "shepherdjerred/starlight-karma-bot/prod":
-    "2.0.0-6673@sha256:4e0aaa2bc818f4e98c67462bfe95c722ea470a266b6c95f6861b7dc6a5da240f",
+    "2.0.0-7909@sha256:7e904d0538a6e0456271b50fe58c520e18159440f3b68b6073a307d7862c4972",
   // not managed by renovate
   "shepherdjerred/birmel":
     "2.0.0-7924@sha256:f71e5ad3c8be9a8b91a758cba6f7cc137ac9381c6c592368a85b2f82e8c87b5c",


### PR DESCRIPTION
Promotes all first-party `/prod` image pins in `versions.ts` to the current beta releases.

## Changes

| Pin | Before | After |
| --- | --- | --- |
| `shepherdjerred/scout-for-lol/prod` | `2.0.0-7074@f5e6add3` | `2.0.0-7926@026d26b2` |
| `shepherdjerred/starlight-karma-bot/prod` | `2.0.0-6673@4e0aaa2b` | `2.0.0-7909@7e904d05` |

(`birmel` and `scout-evals` have no `/prod` stage — nothing to promote.)

## Why these tags

Per version-management + `scout-for-lol/AGENTS.md`, prod promotion = pinning `/prod` to a **minted** `2.0.0-<n>` tag@digest (never a hand-paired tag/digest). Verified with `crane` before editing:

- **scout:** beta's cosmetic label `2.0.0-7924` is not a real GHCR tag (it sits on `:latest`). The latest **minted** scout tag `2.0.0-7926` has digest `026d26b2…` — **identical** to the beta pin's digest, i.e. the minted release tag for exactly the backend beta serves. `scout-prod-reconcile` derives the prod site version from this tag portion.
- **starlight-karma-bot:** `2.0.0-7909@7e904d05` is a real minted tag and the latest; its `crane digest` matches beta.

No standing Renovate promotion PR was open, so this hand-edit is the doc-sanctioned promotion path.

## Impact

Production deploy of both apps on merge (ArgoCD rolls scout + karma-bot backends; `scout-prod-reconcile` syncs the prod site bucket from the archived `2.0.0-7926` artifact). Rollback = revert this commit or pin back to an older minted tag@digest.

## Verification

- `bunx turbo run typecheck --filter=homelab` — passes.
- Post-merge: `curl https://scout-for-lol.com/.release-version` should report `7926`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016R8r6MQuF5EvNHwPf1jwrV
