### PR TITLE
fix(homelab): make Minecraft config-drift check semantic, not byte-compare

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -19,6 +19,10 @@ golangci-lint = "2"
 gh = "2"
 # CI scripts (bake-images.ts affected-scoping + digest collection) use jq
 jq = "1"
+# Semantic YAML/JSON comparison in the Minecraft config-drift check test
+# (misc/minecraft-drift-check.test.ts shells out to yq, matching the yq the
+# init container runs at deploy time)
+yq = "4"
 # Homelab automation (helm push, tofu wrappers, ArgoCD sync, site deploys)
 helm = "4"
 opentofu = "1.12.5"

--- a/packages/docs/logs/2026-08-03_minecraft-shuxin-config-drift-diagnosis.md
+++ b/packages/docs/logs/2026-08-03_minecraft-shuxin-config-drift-diagnosis.md
@@ -45,7 +45,7 @@ config on boot:
   whole file), 14 mcMMO files
 - single vs double quotes (`'{world}'` ↔ `"{world}"`), escaping
   (`'..."..."'` → `"...\"...\""`)
-- trailing whitespace after null-valued keys (`donation-key:` → `donation-key: `)
+- trailing whitespace after null-valued keys (a space added after `donation-key:`)
 - missing EOF newline (GSON/plugin writers)
 - YAML block↔flow normalization (GriefPrevention, WanderingTrades)
 

--- a/packages/docs/logs/2026-08-03_minecraft-shuxin-config-drift-diagnosis.md
+++ b/packages/docs/logs/2026-08-03_minecraft-shuxin-config-drift-diagnosis.md
@@ -1,0 +1,169 @@
+---
+id: minecraft-shuxin-config-drift-diagnosis
+type: log
+status: complete
+board: false
+---
+
+# minecraft-shuxin config-drift startup failure — diagnosis
+
+## Symptom
+
+`minecraft-shuxin-0` stuck in `Init:Error` / `CrashLoopBackOff`. Failing init
+container is `check-config-drift` (exit 1), so `copy-plugin-configs` and the
+server never run. Siblings `minecraft-sjerred-0` and `minecraft-tsmc-0` are
+`Running`.
+
+## Mechanism
+
+`getMinecraftConfigDriftCheckInitContainer`
+(`packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.ts`) runs a busybox
+init container that **byte-compares** (`cmp -s`) every repo-managed config
+(ConfigMap projected at `/plugin-configs` and `/config`) against the persistent
+volume (`/data/plugins`, `/data`). Any mismatch not in the `is_ignored()`
+allowlist → prints `DRIFT DETECTED`, `exit 1`, pod refuses to start.
+
+Design intent elsewhere in `minecraft-config.ts`: repo always wins
+(`SYNC_SKIP_NEWER_IN_DESTINATION=false`); `copy-plugin-configs` `cp`s the
+ConfigMap over `/data/plugins` unconditionally on every boot. So the drift check
+is purely an alert that the PVC diverged — it does not change what gets applied.
+
+## Finding
+
+42 files reported as drifted. Pulled the live PVC files via a read-only
+ephemeral container (`drift-reader`) attached to the failing pod (RWO
+zfs-localpv refused a 2nd mount; node-debug blocked by PodSecurity; ephemeral
+container reuses the existing mount). Parsed every file as YAML/JSON and
+compared data structures (`scratchpad/compare.py`):
+
+**42 / 42 are semantically identical to the repo. 0 real content changes.**
+
+Every diff is cosmetic re-serialization the plugins perform when they load their
+config on boot:
+
+- indentation 2-space → 4-space (mcMMO — Bukkit `YamlConfiguration` rewrites the
+  whole file), 14 mcMMO files
+- single vs double quotes (`'{world}'` ↔ `"{world}"`), escaping
+  (`'..."..."'` → `"...\"...\""`)
+- trailing whitespace after null-valued keys (`donation-key:` → `donation-key: `)
+- missing EOF newline (GSON/plugin writers)
+- YAML block↔flow normalization (GriefPrevention, WanderingTrades)
+
+Affected plugins: mcMMO, CoreProtect, Essentials, GravesX, GriefPreventionData,
+LevelledMobs, LuckPerms, Sleeper, WanderingTrades, Geyser-Spigot.
+
+## Root cause
+
+The check is a byte comparison, which cannot distinguish "plugin reformatted the
+file on load" from "human edited a value." These plugins rewrite their entire
+config files into their own serialization every boot, so the byte-compare
+false-positives on ~40 files. shuxin's committed configs are in hand/default-JAR
+form (2-space, double quotes), never the plugins' on-disk form.
+
+sjerred passes because it ships only 8 plugin config files (few of these
+plugins). tsmc's relationship is not fully pinned (it also has mcMMO yet passes)
+— likely its live PVC already round-trips; not required for the shuxin answer.
+
+The `is_ignored()` allowlist has been patched file-by-file to chase this:
+`commands.yml`, `spark/config.json`, `mcMMO/chat.yml`, and (yesterday, #1960)
+`mcMMO/party.yml` — each commit titled "so shuxin starts." It cannot scale to
+the ~40 files these plugins rewrite.
+
+## Fix options (considered)
+
+1. **Proper fix — make the check semantic.** Compare normalized YAML/JSON, not
+   bytes (needs a parser in the init image; busybox has none — use a small
+   yq/python image). Keep the genuinely runtime-mutated files
+   (`server.properties`, `spigot.yml`, `paper-*.yml`, `Geyser config.yml`)
+   ignored. Fixes the whole class for all servers; lets most of the current
+   ignore list be removed. **← chosen and implemented.**
+2. **Unblock shuxin now — normalize repo → live form.** Copy the plugin-written
+   files back into `config/minecraft-shuxin/plugins/`, commit. Semantically a
+   no-op; makes the byte-compare pass. Fragile to future plugin serialization
+   changes. (Not needed — #1 makes shuxin's existing configs pass untouched.)
+3. Expand `is_ignored()` to all 40 files — whack-a-mole, rejected.
+
+## Implementation of #1 (semantic drift check)
+
+Branch `fix/minecraft-config-drift-semantic`.
+
+- **`misc/minecraft-config-drift-check.sh`** (new) — the check, extracted to a
+  standalone POSIX script so it is unit-testable. Byte-compare fast path; on a
+  mismatch, `.yml/.yaml/.json` are compared by parsed value (`yq -o=json
+sort_keys(..)` → identical canonical string ⇒ reformat only, pass), and
+  other files by CRLF/trailing-whitespace-normalized text. Trimmed
+  `is_ignored()` to the files with real runtime value changes
+  (`server.properties`, `spigot.yml`, `config/paper-*.yml`,
+  `Geyser-Spigot/config.yml`); dropped `commands.yml`, `spark/config.json`,
+  `mcMMO/chat.yml`, `mcMMO/party.yml` (now pass semantically). Parameterized
+  `SRC DEST` pairs; production defaults `/plugin-configs→/data/plugins` and
+  `/config→/data`.
+- **`misc/minecraft-drift-check.ts`** — reads the `.sh` at synth and inlines it;
+  init image switched `library/busybox` → `mikefarah/yq` (Alpine/busybox + yq).
+- **`versions.ts`** — pinned `mikefarah/yq` (renovate-annotated docker digest).
+- **`.mise.toml`** — added `yq = "4"` so the test's `yq` exists locally and in
+  CI (`toolchain.sh` runtime-bootstraps it onto the still-pinned ci-base image).
+- **`misc/minecraft-drift-check.test.ts`** — 11 cases: reformat-only
+  yaml/json/text pass; real yaml/json/text value change fails and names the
+  file; ignored-file real change passes; fresh PVC passes; malformed-on-volume
+  fails; multi-pair run.
+
+Validated against the captured live shuxin PVC: all 45 byte-different managed
+files report `OK reformatted` / `IGNORED`, exit 0 — i.e. after deploy shuxin
+boots without touching its committed configs. Confirmed identical behavior
+inside the real `mikefarah/yq` busybox image.
+
+## Session Log — 2026-08-03
+
+### Done
+
+- Diagnosed `minecraft-shuxin-0` `Init:Error`: `check-config-drift` fails on 42
+  drifted plugin config files.
+- Proved all 42 are cosmetic plugin re-serialization, 0 real edits (semantic
+  YAML/JSON parse compare against live PVC files).
+- Identified byte-compare as root cause; documented the file-by-file
+  `is_ignored()` patching that can't keep up.
+- Cleaned up: deleted read-only `drift-reader` ephemeral container (via pod
+  delete; StatefulSet recreated the pod — still failing, unchanged availability).
+
+### Remaining
+
+- No fix applied. Decide between semantic-check (#1) and repo-normalize (#2),
+  then implement in a worktree + PR (homelab code change).
+
+### Caveats
+
+- shuxin remains down (`Init:Error`) — this was diagnosis only.
+- `scratchpad/live/` holds a copy of the live PVC configs used for comparison;
+  session-scratch, not committed.
+
+## Session Log — 2026-08-03 (implementation)
+
+### Done
+
+- Implemented fix #1 (semantic drift check) on
+  `fix/minecraft-config-drift-semantic`:
+  - `packages/homelab/src/cdk8s/src/misc/minecraft-config-drift-check.sh` (new)
+  - `.../misc/minecraft-drift-check.ts` (read `.sh` at synth; image → yq)
+  - `.../misc/minecraft-drift-check.test.ts` (new, 11 cases)
+  - `packages/homelab/src/cdk8s/src/versions.ts` (pin `mikefarah/yq`)
+  - `.mise.toml` (`yq = "4"`)
+- Verified: typecheck, full cdk8s test suite (328 pass / 0 fail), the new test
+  (11/11), eslint, prettier, shellcheck, and `bun run build` synth (manifest
+  pins the yq image + inlines the semantic script). Confirmed against the real
+  captured shuxin PVC (exit 0) and inside the yq image.
+
+### Remaining
+
+- Land the PR; on deploy/ArgoCD sync the `check-config-drift` container gets the
+  new image + script and `minecraft-shuxin-0` boots. Verify the pod reaches
+  `1/1 Running` post-deploy.
+- The main-branch `ci-base` image will re-bake with `yq` via the standard
+  `ci-base candidate` step after merge (in-PR runs bootstrap yq at runtime).
+
+### Caveats
+
+- Runtime-owned files (`server.properties`, `spigot.yml`, `paper-*.yml`,
+  `Geyser-Spigot/config.yml`) stay ignored — Paper/Geyser write real values
+  there, which the semantic check would (correctly) flag.
+- Renovate will bump the pinned `mikefarah/yq` digest like any other image.

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-config-drift-check.sh
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-config-drift-check.sh
@@ -1,0 +1,175 @@
+#!/bin/sh
+# Semantic config-drift guard for Minecraft servers (config-as-code).
+#
+# Runs before the copy init container on pod startup. Compares the repo-managed
+# ConfigMap sources against the current persistent-volume state and refuses to
+# start (exit 1) if any managed config has drifted, so a live edit is never
+# silently overwritten by the copy step ("repo always wins").
+#
+# Why this is SEMANTIC, not a byte compare: Spigot/Paper plugins re-serialize
+# their config files on load — mcMMO (Bukkit YamlConfiguration) reindents whole
+# files to 4 spaces, others flip quote styles, drop the trailing newline, or
+# normalise YAML block/flow style. A byte compare (`cmp`) flags every such file
+# on the next boot even though no value changed, which crash-loops the pod and
+# is unfixable by an ever-growing ignore list. So for structured files we
+# compare the PARSED value (yq → canonical sorted JSON): reformatting passes,
+# only a real value change fails. For unstructured files we compare after
+# normalising line endings and trailing whitespace.
+#
+# Usage:
+#   minecraft-config-drift-check.sh
+#       Compare the production trees: /plugin-configs → /data/plugins and
+#       /config → /data.
+#   minecraft-config-drift-check.sh SRC DEST [SRC DEST ...]
+#       Compare explicit (source-tree, dest-tree) pairs. Used by the tests.
+#
+#   exit 0 -> in sync (semantically) or fresh PVC (dest files absent)
+#   exit 1 -> drift detected (offending files printed)
+#   exit 2 -> the check itself could not run
+#
+# Requires yq (mikefarah) plus busybox coreutils — see the mikefarah/yq image
+# pinned in versions.ts.
+set -u
+
+# Files that Paper/plugins legitimately REWRITE WITH REAL VALUE CHANGES at
+# runtime (version migrations, generated ids, engine-owned settings). These are
+# not reformatting, so even the semantic compare would flag them — exclude them
+# so a routine server/plugin upgrade does not crash-loop the pod. Paths are
+# relative to a source tree (leading "./").
+is_ignored() {
+  case "$1" in
+    ./server.properties | ./spigot.yml | ./config/paper-global.yml | ./config/paper-world-defaults.yml) return 0 ;;
+    # Geyser rewrites config.yml with generated values (metrics uuid, resolved
+    # remote address).
+    ./Geyser-Spigot/config.yml) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Canonicalise a structured file to compact, key-sorted JSON so that
+# reformatting (indentation, quoting, key order, trailing newline, comments)
+# collapses to an identical string. Returns non-zero if the file cannot be
+# parsed; yq's parse error is left on stderr so the pod log explains the failure.
+#   $1 = yq input format (yaml|json)   $2 = file
+canonicalize() {
+  yq -p="$1" -o=json -I=0 "sort_keys(..)" "$2"
+}
+
+# Normalise an unstructured text file: strip CR (CRLF→LF) and trailing
+# whitespace per line. Command substitution in the caller also drops trailing
+# blank lines. $1 = file.
+normalize_text() {
+  tr -d '\r' <"$1" | sed "s/[[:space:]]*$//"
+}
+
+MARKER="${TMPDIR:-/tmp}/mc-config-drift.$$"
+CANON_A="${MARKER}.a"
+CANON_B="${MARKER}.b"
+rm -f "$MARKER" "$CANON_A" "$CANON_B"
+
+# Compare one source tree against its destination tree.
+#   $1 = source dir (repo ConfigMap projection)
+#   $2 = destination dir (persistent volume)
+compare_tree() {
+  src="$1"
+  dest_root="$2"
+
+  # Nothing mounted / empty source: nothing to enforce. `$src` is a directory
+  # here (guarded above), so `ls -A` cannot error.
+  [ -d "$src" ] || return 0
+  [ -n "$(ls -A "$src")" ] || return 0
+
+  # `-L` follows the ConfigMap item symlinks; `! -path '*/..*'` skips the
+  # `..data` / `..<timestamp>` symlink dirs Kubernetes creates for ConfigMap
+  # volumes. Paths are referenced in full (no `cd`) so they resolve correctly
+  # inside the pipe's subshell.
+  find -L "$src" -type f ! -path "*/..*" | while read -r srcfile; do
+    rel="${srcfile#"$src"/}"
+    dest="$dest_root/$rel"
+
+    # Not on the volume yet (fresh PVC / newly added file): nothing to compare;
+    # the copy step will seed it.
+    [ -f "$dest" ] || continue
+
+    # Fast path: byte-identical means definitely in sync — skip the parse.
+    if cmp -s "$srcfile" "$dest"; then
+      continue
+    fi
+
+    if is_ignored "./$rel"; then
+      echo "IGNORED (runtime-modified): ./$rel"
+      continue
+    fi
+
+    case "$rel" in
+    *.yml | *.yaml) fmt=yaml ;;
+    *.json) fmt=json ;;
+    *)
+      # Unstructured: compare after normalising line endings / trailing space.
+      if [ "$(normalize_text "$srcfile")" = "$(normalize_text "$dest")" ]; then
+        echo "OK reformatted (whitespace/newlines): ./$rel"
+      else
+        echo "DRIFT DETECTED: ./$rel differs from repo (text) [$dest]"
+        touch "$MARKER"
+      fi
+      continue
+      ;;
+    esac
+
+    # Structured: compare the parsed value, not the bytes.
+    if ! canonicalize "$fmt" "$srcfile" >"$CANON_A"; then
+      echo "DRIFT DETECTED: ./$rel is not valid $fmt in the repo ConfigMap"
+      touch "$MARKER"
+      continue
+    fi
+    if ! canonicalize "$fmt" "$dest" >"$CANON_B"; then
+      echo "DRIFT DETECTED: ./$rel is not valid $fmt on the volume [$dest]"
+      touch "$MARKER"
+      continue
+    fi
+
+    if cmp -s "$CANON_A" "$CANON_B"; then
+      # Byte-different but semantically identical: plugin reformatting only.
+      echo "OK reformatted ($fmt, no semantic change): ./$rel"
+    else
+      echo "DRIFT DETECTED: ./$rel differs from repo ($fmt values) [$dest]"
+      diff "$CANON_A" "$CANON_B" | head -20
+      echo "---"
+      touch "$MARKER"
+    fi
+  done
+}
+
+echo "=== Config drift check ==="
+
+if [ "$#" -gt 0 ]; then
+  # Explicit (src, dest) pairs.
+  if [ $(($# % 2)) -ne 0 ]; then
+    echo "ERROR: expected an even number of SRC DEST arguments" >&2
+    rm -f "$CANON_A" "$CANON_B"
+    exit 2
+  fi
+  while [ "$#" -ge 2 ]; do
+    compare_tree "$1" "$2"
+    shift 2
+  done
+else
+  # Production defaults: plugin configs and non-plugin (flat) configs.
+  compare_tree /plugin-configs /data/plugins
+  compare_tree /config /data
+fi
+
+rm -f "$CANON_A" "$CANON_B"
+
+if [ -f "$MARKER" ]; then
+  rm -f "$MARKER"
+  echo ""
+  echo "=== CONFIG DRIFT DETECTED ==="
+  echo "Managed config on the server differs from the repo (real value change,"
+  echo "not just plugin reformatting)."
+  echo "To fix: update the repo config to match (or revert the live change),"
+  echo "commit, and redeploy. Refusing to start."
+  exit 1
+fi
+
+echo "=== All managed configs match the repo (semantically) ==="

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.test.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// The semantic config-drift guard run by the Minecraft check-config-drift init
+// container (inlined into its command at synth time — see
+// minecraft-drift-check.ts). The test drives the script directly against
+// fixture trees. It shells out to `yq` exactly as the container does; `yq` is
+// provided by the repo toolchain (.mise.toml) both locally and in CI.
+const scriptPath = path.join(
+  import.meta.dir,
+  "minecraft-config-drift-check.sh",
+);
+
+let root: string;
+
+function tree(files: Record<string, string>): string {
+  const dir = mkdtempSync(path.join(root, "tree-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const p = path.join(dir, rel);
+    mkdirSync(path.dirname(p), { recursive: true });
+    writeFileSync(p, content);
+  }
+  return dir;
+}
+
+async function runGuard(
+  ...pairs: string[]
+): Promise<{ code: number; stdout: string }> {
+  const proc = Bun.spawn(["sh", scriptPath, ...pairs], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [code, stdout] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+  ]);
+  return { code, stdout };
+}
+
+describe("minecraft-config-drift-check.sh", () => {
+  beforeAll(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mc-drift-"));
+  });
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("passes when a YAML file is only reformatted (reindent + quote flip)", async () => {
+    // The exact class of change mcMMO/Bukkit YamlConfiguration makes on load:
+    // 2-space → 4-space indentation and double → single quotes.
+    const src = tree({
+      "mcMMO/config.yml": 'General:\n  Enabled: true\n  Name: "mcMMO"\n',
+    });
+    const dest = tree({
+      "mcMMO/config.yml": "General:\n    Enabled: true\n    Name: 'mcMMO'\n",
+    });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(stdout).toContain("OK reformatted");
+    expect(code).toBe(0);
+  });
+
+  it("passes when a YAML file differs only by trailing whitespace / missing EOF newline", async () => {
+    const src = tree({ "CoreProtect/config.yml": "donation-key:\nport: 80\n" });
+    // trailing space after the null key + no trailing newline (SnakeYAML style)
+    const dest = tree({ "CoreProtect/config.yml": "donation-key: \nport: 80" });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(stdout).toContain("OK reformatted");
+    expect(code).toBe(0);
+  });
+
+  it("passes when a JSON file differs only by key order / no trailing newline", async () => {
+    const src = tree({
+      "LuckPerms/contexts.json": '{\n  "a": {},\n  "b": {}\n}\n',
+    });
+    const dest = tree({ "LuckPerms/contexts.json": '{"b":{},"a":{}}' });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(stdout).toContain("OK reformatted");
+    expect(code).toBe(0);
+  });
+
+  it("passes when a text file differs only by line endings (CRLF vs LF)", async () => {
+    const src = tree({
+      "GravesX/placeholders.txt": "%uuid% - id\n%owner% - o\n",
+    });
+    const dest = tree({
+      "GravesX/placeholders.txt": "%uuid% - id\r\n%owner% - o\r\n",
+    });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(stdout).toContain("OK reformatted");
+    expect(code).toBe(0);
+  });
+
+  it("passes when the destination file does not exist yet (fresh PVC)", async () => {
+    const src = tree({ "Sleeper/config.yml": "SleepInfo: hi\n" });
+    const dest = tree({}); // empty dest tree — file not seeded yet
+    const { code } = await runGuard(src, dest);
+    expect(code).toBe(0);
+  });
+
+  it("fails (exit 1) and names the file when a YAML value really changes", async () => {
+    const src = tree({ "Essentials/config.yml": "teleport-cooldown: 5\n" });
+    const dest = tree({ "Essentials/config.yml": "teleport-cooldown: 60\n" });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(code).toBe(1);
+    expect(stdout).toContain("DRIFT DETECTED");
+    expect(stdout).toContain("Essentials/config.yml");
+  });
+
+  it("fails (exit 1) when a JSON value really changes", async () => {
+    const src = tree({ "LuckPerms/contexts.json": '{"a": 1}\n' });
+    const dest = tree({ "LuckPerms/contexts.json": '{"a": 2}\n' });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(code).toBe(1);
+    expect(stdout).toContain("contexts.json");
+  });
+
+  it("fails (exit 1) when a text file's real content changes", async () => {
+    const src = tree({ "GravesX/placeholders.txt": "line one\n" });
+    const dest = tree({ "GravesX/placeholders.txt": "line two\n" });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(code).toBe(1);
+    expect(stdout).toContain("placeholders.txt");
+  });
+
+  it("ignores a real change in a runtime-owned file (spigot.yml)", async () => {
+    // Paper bumps spigot.yml's config-version on upgrade — a real value change
+    // that must NOT crash-loop the pod.
+    const src = tree({ "spigot.yml": "config-version: 12\n" });
+    const dest = tree({ "spigot.yml": "config-version: 13\n" });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(code).toBe(0);
+    expect(stdout).toContain("IGNORED (runtime-modified): ./spigot.yml");
+  });
+
+  it("fails (exit 1) when a managed file is malformed on the volume", async () => {
+    const src = tree({ "Vault/config.yml": "a: 1\n" });
+    // Broken YAML on disk — cannot be verified, so fail safe rather than pass.
+    const dest = tree({ "Vault/config.yml": "a: 1\n  b: : :\n- x\n" });
+    const { code, stdout } = await runGuard(src, dest);
+    expect(code).toBe(1);
+    expect(stdout).toContain("Vault/config.yml");
+  });
+
+  it("checks multiple (src, dest) tree pairs in one run", async () => {
+    // Mirrors production: plugin tree + non-plugin tree. A real change in the
+    // second pair must still fail the whole run.
+    const pluginSrc = tree({
+      "mcMMO/config.yml": "General:\n  Enabled: true\n",
+    });
+    const pluginDest = tree({
+      "mcMMO/config.yml": "General:\n    Enabled: true\n",
+    });
+    const cfgSrc = tree({ "bukkit.yml": "settings:\n  allow-end: true\n" });
+    const cfgDest = tree({ "bukkit.yml": "settings:\n  allow-end: false\n" });
+    const { code, stdout } = await runGuard(
+      pluginSrc,
+      pluginDest,
+      cfgSrc,
+      cfgDest,
+    );
+    expect(code).toBe(1);
+    expect(stdout).toContain("bukkit.yml");
+    // the reformat-only plugin file should have passed
+    expect(stdout).toContain("OK reformatted");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.ts
+++ b/packages/homelab/src/cdk8s/src/misc/minecraft-drift-check.ts
@@ -3,14 +3,28 @@
  *
  * Runs before the copy init container on pod startup. Compares the current
  * persistent volume state (/data) against repo-managed ConfigMap sources.
- * If any managed config differs, the pod refuses to start (exit 1).
+ * If any managed config has a real value change, the pod refuses to start
+ * (exit 1) so the copy step never silently overwrites a live edit.
  *
- * Files known to be rewritten by Paper/plugins at runtime are ignored.
+ * The comparison is SEMANTIC (parse with yq → canonical sorted JSON), not a
+ * byte compare: Spigot/Paper plugins re-serialize their configs on load
+ * (reindenting, flipping quote styles, dropping the trailing newline), which a
+ * byte compare flags as drift on every boot even though no value changed. The
+ * check logic lives in the co-located `minecraft-config-drift-check.sh`, run
+ * here via the yq image (Alpine/busybox + yq). See that script for details.
  */
 
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 type ServerName = "tsmc" | "sjerred" | "shuxin";
+
+// The drift-check logic is maintained as a standalone POSIX shell script so it
+// can be exercised directly by minecraft-drift-check.test.ts. It is inlined
+// into the init container's command at synth time (no extra ConfigMap/mount),
+// and reads its trees from the fixed production paths when run with no args.
+const DRIFT_CHECK_SCRIPT = await Bun.file(
+  new URL("minecraft-config-drift-check.sh", import.meta.url),
+).text();
 
 /**
  * Returns init container that checks for config drift before the server starts.
@@ -57,68 +71,8 @@ export function getMinecraftConfigDriftCheckInitContainer(
 
   return {
     name: "check-config-drift",
-    image: `library/busybox:${versions["library/busybox"]}`,
+    image: `mikefarah/yq:${versions["mikefarah/yq"]}`,
     command: ["sh", "-c", DRIFT_CHECK_SCRIPT],
     volumeMounts,
   };
 }
-
-const DRIFT_CHECK_SCRIPT = `rm -f /tmp/drift
-
-echo "=== Config drift check ==="
-
-# Known files that Paper/plugins rewrite at runtime — skip these
-is_ignored() {
-  case "$1" in
-    ./server.properties|./spigot.yml|./config/paper-global.yml|./config/paper-world-defaults.yml) return 0 ;;
-    ./Geyser-Spigot/config.yml) return 0 ;;
-    # Paper re-serializes commands.yml (SnakeYAML flattens the block-sequence
-    # indentation), spark writes config.json via GSON (no trailing newline), and
-    # mcMMO re-serializes chat.yml and party.yml (Bukkit YamlConfiguration
-    # reorders keys and reindents nested maps to 4 spaces) — all normalized on
-    # disk at boot, so byte-compare always drifts.
-    ./commands.yml|./spark/config.json|./mcMMO/chat.yml|./mcMMO/party.yml) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-# Check plugin configs: compare /data/plugins against /plugin-configs source
-if [ -d /plugin-configs ] && [ "$(ls -A /plugin-configs 2>/dev/null)" ]; then
-  cd /plugin-configs && find -L . -type f -not -path '*/..*' | while read f; do
-    dest="/data/plugins/$f"
-    if is_ignored "$f"; then
-      [ -f "$dest" ] && ! cmp -s "$f" "$dest" && echo "IGNORED (runtime-modified): $f"
-    elif [ -f "$dest" ] && ! cmp -s "$f" "$dest"; then
-      echo "DRIFT DETECTED: $dest differs from repo"
-      diff "$f" "$dest" 2>/dev/null | head -20
-      echo "---"
-      echo "1" > /tmp/drift
-    fi
-  done
-fi
-
-# Check non-plugin configs: compare /data against /config source
-if [ -d /config ] && [ "$(ls -A /config 2>/dev/null)" ]; then
-  cd /config && find -L . -type f -not -path '*/..*' | while read f; do
-    dest="/data/$f"
-    if is_ignored "$f"; then
-      [ -f "$dest" ] && ! cmp -s "$f" "$dest" && echo "IGNORED (runtime-modified): $f"
-    elif [ -f "$dest" ] && ! cmp -s "$f" "$dest"; then
-      echo "DRIFT DETECTED: $dest differs from repo"
-      diff "$f" "$dest" 2>/dev/null | head -20
-      echo "---"
-      echo "1" > /tmp/drift
-    fi
-  done
-fi
-
-if [ -f /tmp/drift ]; then
-  echo ""
-  echo "=== CONFIG DRIFT DETECTED ==="
-  echo "Files on the server have been modified outside of the repo."
-  echo "To fix: update the repo configs, commit, and redeploy."
-  echo "Refusing to start."
-  exit 1
-fi
-
-echo "=== All configs match repo (or fresh deploy) ==="`;

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -275,6 +275,12 @@ const versions = {
   "library/busybox":
     "latest@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
+  // Alpine-based image bundling yq + busybox coreutils (sh/find/cmp/diff/cp);
+  // used by the Minecraft config-drift init container for semantic YAML/JSON
+  // comparison (see misc/minecraft-drift-check.ts).
+  "mikefarah/yq":
+    "latest@sha256:11a1f0b604b13dbbdc662260d8db6f644b22d8553122a25c1b5b2e8713ca6977",
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=docker
   "library/alpine":
     "latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
   // renovate: datasource=docker registryUrl=https://docker.io versioning=docker

--- a/scripts/script-migrations.json
+++ b/scripts/script-migrations.json
@@ -383,6 +383,11 @@
       ]
     },
     {
+      "source": "packages/homelab/src/cdk8s/src/misc/minecraft-config-drift-check.sh",
+      "disposition": "retain",
+      "reason": "ConfigMap-mounted init-container drift check runs on the busybox+yq image where Bun is unavailable"
+    },
+    {
       "source": "packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-bun-cache-gc.sh",
       "disposition": "retain",
       "reason": "ConfigMap-mounted maintenance entrypoint coordinates Linux filesystem utilities under flock"


### PR DESCRIPTION
## Problem

`minecraft-shuxin-0` was stuck in `Init:Error`/`CrashLoopBackOff`. The
`check-config-drift` init container **byte-compared** (`cmp -s`) the repo
ConfigMap sources against the persistent volume and refused to start on any
difference. But Spigot/Paper plugins re-serialize their config files when they
load them — mcMMO reindents whole files 2→4 spaces, others flip quote styles,
drop the trailing newline, or normalise YAML block/flow. So on every boot the
byte compare flagged ~40 files even though **no config value had changed**.

I pulled the live PVC and parsed every flagged file: **42/42 were semantically
identical to the repo, zero real edits.** The `is_ignored()` allowlist had been
patched file-by-file (`chat.yml`, `party.yml`, `commands.yml`,
`spark/config.json` — most recently #1960 "so shuxin starts") and could never
keep up with the ~40 files these plugins rewrite.

## Fix

Compare the **parsed value**, not the bytes:

- `.yml/.yaml/.json` → `yq -o=json 'sort_keys(..)'` canonical string. Identical
  canonical ⇒ reformatting only ⇒ pass. Only a real value change fails.
- other files → compared after CRLF / trailing-whitespace normalisation.
- Files with genuine runtime value changes (`server.properties`, `spigot.yml`,
  `config/paper-*.yml`, `Geyser-Spigot/config.yml`) stay ignored; the four
  reformat-only ignores are dropped (now handled semantically).

The check moves to a standalone, unit-tested POSIX script
(`minecraft-config-drift-check.sh`) run on the `mikefarah/yq` image (Alpine
busybox + yq), pinned in `versions.ts`. `yq` added to `.mise.toml` so the test's
`yq` exists locally and in CI (`toolchain.sh` bootstraps it at runtime on the
still-pinned ci-base image).

**Result:** validated against the captured live shuxin PVC — all 45
byte-different managed files report `OK reformatted`/`IGNORED`, exit 0. So on
deploy shuxin boots **without changing any committed config**.

## Verification

- New `minecraft-drift-check.test.ts` (11 cases): reformat-only yaml/json/text
  pass; real yaml/json/text value change fails and names the file; ignored-file
  real change passes; fresh PVC passes; malformed-on-volume fails; multi-pair.
- Full cdk8s suite 328 pass / 0 fail; typecheck, eslint, prettier, shellcheck,
  `bun run build` synth (manifest pins the yq image + inlines the script).
- Behavior confirmed identical inside the real `mikefarah/yq` busybox image.

Diagnosis + implementation notes:
`packages/docs/logs/2026-08-03_minecraft-shuxin-config-drift-diagnosis.md`.

## Post-merge

On ArgoCD sync the `check-config-drift` container gets the new image + script
and `minecraft-shuxin-0` should reach `1/1 Running`.