### PR TITLE
feat(pr-fleet-controller): reuse operator worktrees + reliable edit tools

### DIFF
--- a/packages/docs/plans/2026-08-03_pr-fleet-worktree-reuse-edit-tools.md
+++ b/packages/docs/plans/2026-08-03_pr-fleet-worktree-reuse-edit-tools.md
@@ -1,0 +1,145 @@
+---
+id: pr-fleet-worktree-reuse-edit-tools-2026-08-03
+type: plan
+status: in-progress
+board: false
+---
+
+# PR fleet controller — make workers able to make progress
+
+A `bun run pr:fleet --model openai/gpt-5.6-luna` run stalled at
+`open=5 green=1 active=0 paused=4` with no work advancing. Post-mortem of the
+run bundle
+(`~/.local/state/pr-fleet-controller/2026-08-03T23-23-53.638Z-410b59ec-…`)
+found two independent root causes, both fleet-side (the model is Sonnet/Opus
+class, so tool brittleness — not model capability — is the fault).
+
+## Root cause 1 — worktree/branch conflict pauses workable PRs
+
+PR #1981 (`feature/dpp-save-goals`) and #1983 (`feature/promote-beta-prod`)
+paused immediately:
+
+```
+git worktree add …/stack-pr-1981 feature/dpp-save-goals failed (128):
+fatal: 'feature/dpp-save-goals' is already used by worktree at '…/dpp-save-goals'
+```
+
+Both branches are already checked out in the operator's own worktrees. Git
+forbids the same branch in two worktrees, so `provisionWorktree`
+(`worktree.ts:245`) fails and the PR parks for the whole run. Both branches are
+**native/unstacked** (not git-spice) and both operator worktrees are **clean**.
+
+**Fix (operator chose "reuse operator worktree in place"):** let the fleet reuse
+the operator's existing worktree for that branch rather than provisioning a
+second one.
+
+- `WorktreeManager.findWorktree` today filters to fleet-owned paths via
+  `#isFleetWorktree` so a `reset --hard` cannot clobber operator edits. Relax it
+  to also return a non-fleet worktree that has the branch checked out.
+- Add a safety guard in `assignWorktreeBranch`: when the worktree is **not**
+  fleet-owned **and** dirty, throw (→ clean pause with an actionable message)
+  rather than `reset --hard`-ing the operator's uncommitted work. Clean operator
+  worktrees are reused in place; the worker's commit publishes via the existing
+  native force-push path (`git-operations.ts:283`).
+
+## Root cause 2 — brittle `apply_patch` burns the whole cycle
+
+For #1655 the worker issued 24 `apply_patch` calls, almost all rejected:
+
+- `"Patch has no explicit repository paths"` (17× across #1655 + #1389) —
+  `tools.ts:238-247` requires patch header lines to start with **exactly**
+  `--- a/` / `+++ b/` and `.slice(6)`. A valid unified diff without `a/`/`b/`
+  prefixes yields zero paths and is rejected.
+- `"corrupt patch at <stdin>:15"` — `git apply --whitespace=error-all`
+  (`tools.ts:253`) rejects on whitespace nits and slightly-off hunk counts.
+
+A capable model produces correct-but-differently-formatted patches, gets
+rejected, exhausts `maxSteps: 20`, and never emits a final result.
+
+**Fix (operator chose "add an Edit-style tool"):** add reliable edit tools that
+don't depend on hand-crafted unified-diff formatting.
+
+- `str_replace` — `{ path, old_string, new_string, replace_all? }`. Reads the
+  contained file, requires `old_string` to occur (uniquely unless
+  `replace_all`), replaces, writes back.
+- `write_file` — `{ path, content }`. Writes a full file (create or overwrite)
+  within the worktree.
+- Both gated on the stack-write lease exactly like `apply_patch`, both routed
+  through `containedPath`. `apply_patch` stays as a fallback.
+- Steer `WORKER_INSTRUCTIONS` toward the edit tools.
+
+## Root cause 2b — cryptic crash when the model emits no structured result
+
+When `apply_patch` thrashing consumes every step, `agent.generate` returns with
+`result.object === undefined`, and `WorkerResultSchema.parse(undefined)`
+(`agents.ts:171`) throws a raw Zod v4 `ZodError` whose `.message` is a JSON
+issues array — surfaced to the operator as the unreadable
+`expected object, received undefined` dump.
+
+**Fix:** detect `undefined`/non-object before parsing and throw a clear,
+actionable error including the model's final text, so the failure is legible.
+
+## Verification
+
+- `bunx turbo run typecheck test lint --filter=pr-fleet-controller`
+- Unit coverage for: reuse of a clean non-fleet worktree; refusal on a dirty
+  non-fleet worktree; `str_replace` unique/replace-all/miss; `write_file`
+  create+overwrite + path containment; empty-structured-output error message.
+
+## Workflow
+
+- Worktree + draft PR via gh-stack (new work).
+- Operator's current uncommitted `environment.ts` / `evidence-parsers.ts` /
+  `worktree.ts` changes are related robustness fixes and the `worktree.ts` edits
+  layer on them, so they are carried into the worktree as the base commit and
+  noted in the PR. They remain untouched in the main checkout.
+
+## Session Log — 2026-08-03
+
+### Done
+
+- Diagnosed a stalled `pr:fleet` run (`open=5 green=1 active=0 paused=4`) from
+  its run bundle; root causes were fleet-side, not model capability.
+- Root cause 1 — reuse operator worktree in place
+  (`packages/pr-fleet-controller/src/worktree.ts`): `findWorktree` now falls back
+  to an operator worktree holding the branch (fleet worktree still preferred);
+  `assignWorktreeBranch` refuses reuse of a **dirty** non-fleet worktree with an
+  actionable message instead of `reset --hard`-ing operator edits.
+- Root cause 2 — Edit-style tools
+  (`packages/pr-fleet-controller/src/worker-file-edits.ts`, new): `str_replace`
+  (exact-match, literal `$`-safe) and `write_file` (full file), both
+  path-contained via `containedPath` and gated on the stack-write lease;
+  `apply_patch` kept as a fallback. `WORKER_INSTRUCTIONS` steers to the edit
+  tools. Extracted `containedPath` + `createFileEditTools` into the new module to
+  stay under the `max-lines` / `max-lines-per-function` limits.
+- Root cause 2b — `agents.ts` `coerceWorkerResult` (extracted, exported): detects
+  `result.object === undefined` and throws a legible error (with the model's
+  final text) instead of a raw Zod "expected object, received undefined" dump.
+- Fixed the carried-in `environment.ts` `#withGitLock` mutex to async/await
+  (was `.then` chaining — tripped `prefer-async-await` / `no-useless-undefined`).
+- Tests: `test/worker-edit-tools.test.ts` (str_replace/write_file semantics +
+  containment), `test/worktree.test.ts` (operator-worktree fallback + dirty
+  guard), `test/agents.test.ts` (`coerceWorkerResult`). Package `typecheck`,
+  `lint`, `test` all green — 167 tests pass.
+- Updated `packages/pr-fleet-controller/README.md` worker tool-boundary section.
+
+### Remaining
+
+- Open the draft PR from this worktree; promote to ready after CI.
+- Re-run `bun run pr:fleet --model openai/gpt-5.6-luna` and confirm #1981/#1983
+  are now worked in place (operator worktrees `dpp-save-goals` /
+  `promote-beta-prod` are clean) and that workers land edits via the new tools.
+
+### Caveats
+
+- "Reuse operator worktree in place" means the fleet runs setup, commits, and
+  force-pushes **inside the operator's checkout**. It is guarded to refuse when
+  that worktree is dirty, but it will advance the operator's local branch to the
+  fleet's commit. This was the explicitly chosen option.
+- The base commit bundles the operator's prior uncommitted
+  `environment.ts` / `evidence-parsers.ts` / `worktree.ts` fixes; those files
+  remain uncommitted in the main checkout and can be discarded there once this
+  merges.
+- `git-spice`-owned branches held by an operator worktree still can't be worked
+  in place cleanly (git-spice submit/restack need the branch attached); this
+  change targets the native/unstacked case (which is what #1981/#1983 are).

--- a/packages/docs/wiki/src/content/docs/pr-fleet-controller.md
+++ b/packages/docs/wiki/src/content/docs/pr-fleet-controller.md
@@ -45,6 +45,20 @@ prompt instructions — the worker's tools simply do not expose those actions.
 - **One worker per stack.** Each git-spice stack shares a single worktree, and
   only one worker holds it at a time; siblings queue. A worker is dispatched
   against a specific PR head, and its worktree is synced to that head first.
+- **Operator-owned checkouts are reused only when safe.** The controller
+  provisions its own disposable worktree per stack, but Git forbids the same
+  branch in two worktrees, so if you already have a PR's branch checked out in
+  your own worktree the fleet reuses that checkout in place — otherwise the PR
+  would be parked for the whole run. That reuse is fenced: an operator checkout
+  is reused only when it holds the **exact** PR being worked (never a sibling
+  branch that would get switched and hard-reset under you), and only when it is
+  clean **and** its `HEAD` already sits at the PR's fetched head. If it has
+  uncommitted changes or committed-but-unpushed commits, the fleet refuses and
+  pauses the PR with an actionable message instead of discarding your edits or
+  force-pushing your local commits. Worker file edits are likewise confined to
+  the worktree and cannot touch Git metadata (`.git`, config, hooks), even via a
+  symlink. To hand a PR to the fleet cleanly, commit and push (or remove) your
+  local work, or just delete your worktree for that branch.
 - **Leases** serialize the expensive/dangerous steps — setup (dependency
   install + codegen), heavy commands, and the stack-write that publishing needs.
   Leases are released only after a worker actually settles, so a cancelled or

--- a/packages/pr-fleet-controller/README.md
+++ b/packages/pr-fleet-controller/README.md
@@ -69,8 +69,11 @@ The master receives:
 Each worker receives:
 
 - normalized current-head PR, Buildkite, merge-tree, and review evidence;
-- worktree-scoped UTF-8 reads, ripgrep, Git status, Git diff, and unified patch
-  application;
+- worktree-scoped UTF-8 reads, ripgrep, Git status, and Git diff;
+- worktree-scoped edits: `str_replace` (exact-match substring replacement) and
+  `write_file` (full-file create/overwrite) are the preferred edit surface, with
+  `apply_patch` (unified diff) retained as a fallback — all path-contained and
+  gated on the stack-write lease;
 - serial worktree setup;
 - setup, heavy-command, and stack-write lease requests;
 - an allowlisted validation command surface;
@@ -93,6 +96,14 @@ and grants invocation-scoped trust to only the assigned worktree's exact
 timeouts, cancellation, and shutdown terminate the command's complete POSIX
 process group so descendant processes cannot outlive the worker that spawned
 them.
+
+Each stack gets one worktree. A fleet-owned worktree is always preferred, but
+when a branch is already checked out in an operator's own worktree — git forbids
+the same branch in two worktrees, so the fleet cannot provision its own — the
+fleet reuses that operator worktree in place so the PR can still make progress.
+That reuse is refused while the operator worktree holds uncommitted changes, so
+operator edits are never `reset --hard`-ed away; the PR pauses with an actionable
+message instead.
 
 The controller never merges, closes, or approves a pull request.
 

--- a/packages/pr-fleet-controller/src/agents.ts
+++ b/packages/pr-fleet-controller/src/agents.ts
@@ -32,9 +32,34 @@ or request a tick. Never weaken readiness, merge, close, or approve a PR.`;
 
 const WORKER_INSTRUCTIONS = `You own one focused fix cycle for exactly one PR.
 Refresh evidence first, choose one actionable blocker, preserve the PR's intent, and
-use only the assigned worktree tools. Never merge, close, approve, suppress a gate,
-use blanket staging, or bypass hooks. Return the required structured result after one
+use only the assigned worktree tools. Edit files with str_replace (exact-match, the
+default) or write_file (full contents); apply_patch is a fallback that requires a
+correctly formatted unified diff. Never merge, close, approve, suppress a gate, use
+blanket staging, or bypass hooks. Return the required structured result after one
 cycle; do not poll or sleep.`;
+
+// Turn a Mastra `generate` result into a validated WorkerResult. Mastra leaves
+// `object` undefined when the model ends a turn without emitting the structured
+// result — e.g. it exhausted `maxSteps` mid-edit. Parsing `undefined` against
+// the object schema throws a bare Zod "expected object, received undefined"
+// whose message is an opaque issues array; detect that case first and throw a
+// legible, actionable error (with the model's final text) instead.
+export function coerceWorkerResult(result: {
+  object?: unknown;
+  text?: string;
+}): WorkerResult {
+  if (result.object === undefined) {
+    const finalText = result.text?.trim();
+    throw new Error(
+      `Worker produced no structured result (the model ended its turn without emitting a WorkerResult, likely after exhausting its step budget)${
+        finalText === undefined || finalText.length === 0
+          ? ""
+          : `. Final model text: ${finalText.slice(0, 500)}`
+      }`,
+    );
+  }
+  return WorkerResultSchema.parse(result.object);
+}
 
 const NOOP_TELEMETRY: FleetTelemetry = {
   runId: "unrecorded-test-run",
@@ -168,7 +193,7 @@ Additional user guidance: ${guidance.length === 0 ? "none" : guidance.join("\n")
                   tags: ["pr-fleet", "worker"],
                 },
               });
-              return WorkerResultSchema.parse(result.object);
+              return coerceWorkerResult(result);
             },
           });
           if (outcome.status === "completed") {

--- a/packages/pr-fleet-controller/src/controller-correlation.ts
+++ b/packages/pr-fleet-controller/src/controller-correlation.ts
@@ -43,6 +43,7 @@ export async function assignFleetWorktree(
       (await environment.findWorktree(
         siblingBranches,
         candidate.identity.headRefName,
+        !candidate.identity.crossRepository,
       )) ??
       (await environment.provisionWorktree(
         candidate.identity,

--- a/packages/pr-fleet-controller/src/controller-correlation.ts
+++ b/packages/pr-fleet-controller/src/controller-correlation.ts
@@ -40,7 +40,10 @@ export async function assignFleetWorktree(
       .filter((pr) => pr.stackId === candidate.stackId)
       .map((pr) => pr.identity.headRefName);
     const worktree =
-      (await environment.findWorktree(siblingBranches)) ??
+      (await environment.findWorktree(
+        siblingBranches,
+        candidate.identity.headRefName,
+      )) ??
       (await environment.provisionWorktree(
         candidate.identity,
         candidate.stackId,

--- a/packages/pr-fleet-controller/src/environment.ts
+++ b/packages/pr-fleet-controller/src/environment.ts
@@ -482,8 +482,13 @@ export class CommandFleetEnvironment implements FleetEnvironment {
   findWorktree(
     fleetBranches: string[],
     candidateBranch: string,
+    allowOperatorFallback: boolean,
   ): Promise<string | null> {
-    return this.#worktreeManager.findWorktree(fleetBranches, candidateBranch);
+    return this.#worktreeManager.findWorktree(
+      fleetBranches,
+      candidateBranch,
+      allowOperatorFallback,
+    );
   }
 
   assignWorktreeBranch(worktree: string, pr: PrIdentity): Promise<void> {

--- a/packages/pr-fleet-controller/src/environment.ts
+++ b/packages/pr-fleet-controller/src/environment.ts
@@ -479,8 +479,11 @@ export class CommandFleetEnvironment implements FleetEnvironment {
     return evidence;
   }
 
-  findWorktree(branches: string[]): Promise<string | null> {
-    return this.#worktreeManager.findWorktree(branches);
+  findWorktree(
+    fleetBranches: string[],
+    candidateBranch: string,
+  ): Promise<string | null> {
+    return this.#worktreeManager.findWorktree(fleetBranches, candidateBranch);
   }
 
   assignWorktreeBranch(worktree: string, pr: PrIdentity): Promise<void> {

--- a/packages/pr-fleet-controller/src/environment.ts
+++ b/packages/pr-fleet-controller/src/environment.ts
@@ -73,6 +73,29 @@ export class CommandFleetEnvironment implements FleetEnvironment {
     });
   }
 
+  // The reconcile fan-out refreshes evidence for up to five PRs concurrently
+  // (`mapBounded(identities, 5, …)`), and each PR's `#conflict()` runs a
+  // sequence of git commands against the single checkout's shared ref store.
+  // Git cannot tolerate ANY concurrent ref access there: two `git fetch`
+  // invocations race on the ref-lock / packed-refs transaction, and even a
+  // read (`git rev-parse`) can miss a loose ref while another PR's fetch is
+  // consolidating loose refs into `packed-refs`. Either way a ref reads back
+  // missing and the tick aborts. Every PR's whole git critical section is
+  // therefore run atomically through this promise-mutex, while the network
+  // evidence calls (`gh`, `bk`) stay fully parallel across the fan-out.
+  #gitQueue: Promise<unknown> = Promise.resolve();
+
+  #withGitLock<T>(operation: () => Promise<T>): Promise<T> {
+    // Chain onto the tail regardless of whether the prior section fulfilled or
+    // rejected, so one failed section cannot wedge the queue for later waiters.
+    const result = this.#gitQueue.then(operation, operation);
+    this.#gitQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
   async runLocalCommand(request: CommandRequest): Promise<CommandResult> {
     return runRecordedCommand(request, this.#telemetry);
   }
@@ -239,44 +262,54 @@ export class CommandFleetEnvironment implements FleetEnvironment {
   }
 
   async #conflict(pr: PrIdentity): Promise<boolean> {
-    await this.#mustRun("git", [
-      "fetch",
-      "origin",
-      `refs/heads/${pr.baseRefName}:refs/remotes/origin/${pr.baseRefName}`,
-    ]);
-    await this.#mustRun("git", [
-      "fetch",
-      "origin",
-      `pull/${String(pr.number)}/head:refs/remotes/pull/${String(pr.number)}/head`,
-    ]);
-    const fetchedHeadOutput = await this.#mustRun("git", [
-      "rev-parse",
-      `refs/remotes/pull/${String(pr.number)}/head`,
-    ]);
-    const fetchedHead = fetchedHeadOutput.trim();
-    if (fetchedHead !== pr.headSha) {
-      throw new Error(
-        `PR #${String(pr.number)} changed during conflict inspection (${pr.headSha} -> ${fetchedHead})`,
-      );
-    }
-    const result = await this.runLocalCommand({
-      executable: "git",
-      args: [
-        "merge-tree",
-        "--write-tree",
-        "--quiet",
-        `refs/remotes/origin/${pr.baseRefName}`,
+    // Run the whole fetch → rev-parse → merge-tree sequence as one critical
+    // section so no other PR's git ref access overlaps it (see #withGitLock).
+    return this.#withGitLock(async () => {
+      await this.#mustRun("git", [
+        "fetch",
+        "origin",
+        `refs/heads/${pr.baseRefName}:refs/remotes/origin/${pr.baseRefName}`,
+      ]);
+      await this.#mustRun("git", [
+        "fetch",
+        "origin",
+        // The source MUST be fully qualified (`refs/pull/N/head`). With the
+        // unqualified `pull/N/head`, once `refs/remotes/pull/N/head` exists its
+        // abbreviated name is also `pull/N/head`, so git resolves the source to
+        // that local ref, finds no matching remote ref, and prunes the
+        // destination ("- [deleted] (none)") while still exiting 0 — the next
+        // `rev-parse` then fails and the whole tick aborts.
+        `refs/pull/${String(pr.number)}/head:refs/remotes/pull/${String(pr.number)}/head`,
+      ]);
+      const fetchedHeadOutput = await this.#mustRun("git", [
+        "rev-parse",
         `refs/remotes/pull/${String(pr.number)}/head`,
-      ],
-      cwd: this.#checkout,
-      timeoutMs: 120_000,
+      ]);
+      const fetchedHead = fetchedHeadOutput.trim();
+      if (fetchedHead !== pr.headSha) {
+        throw new Error(
+          `PR #${String(pr.number)} changed during conflict inspection (${pr.headSha} -> ${fetchedHead})`,
+        );
+      }
+      const result = await this.runLocalCommand({
+        executable: "git",
+        args: [
+          "merge-tree",
+          "--write-tree",
+          "--quiet",
+          `refs/remotes/origin/${pr.baseRefName}`,
+          `refs/remotes/pull/${String(pr.number)}/head`,
+        ],
+        cwd: this.#checkout,
+        timeoutMs: 120_000,
+      });
+      if (result.exitCode !== 0 && result.exitCode !== 1) {
+        throw new Error(
+          `merge-tree failed for PR #${String(pr.number)}: ${result.stderr.trim()}`,
+        );
+      }
+      return result.exitCode === 1;
     });
-    if (result.exitCode !== 0 && result.exitCode !== 1) {
-      throw new Error(
-        `merge-tree failed for PR #${String(pr.number)}: ${result.stderr.trim()}`,
-      );
-    }
-    return result.exitCode === 1;
   }
 
   async #buildkiteEvidence(

--- a/packages/pr-fleet-controller/src/environment.ts
+++ b/packages/pr-fleet-controller/src/environment.ts
@@ -86,13 +86,27 @@ export class CommandFleetEnvironment implements FleetEnvironment {
   #gitQueue: Promise<unknown> = Promise.resolve();
 
   #withGitLock<T>(operation: () => Promise<T>): Promise<T> {
-    // Chain onto the tail regardless of whether the prior section fulfilled or
-    // rejected, so one failed section cannot wedge the queue for later waiters.
-    const result = this.#gitQueue.then(operation, operation);
-    this.#gitQueue = result.then(
-      () => undefined,
-      () => undefined,
-    );
+    const priorTail = this.#gitQueue;
+    const result = (async (): Promise<T> => {
+      // Await the tail regardless of whether the prior section fulfilled or
+      // rejected, so one failed section cannot wedge the queue for later
+      // waiters; its rejection was already surfaced to its own caller.
+      try {
+        await priorTail;
+      } catch {
+        // Prior section already reported this to its caller.
+      }
+      return operation();
+    })();
+    // Advance the queue only after this section settles, swallowing its outcome
+    // so the next waiter is not affected by a rejection here.
+    this.#gitQueue = (async (): Promise<void> => {
+      try {
+        await result;
+      } catch {
+        // Surfaced to this section's caller via the returned promise.
+      }
+    })();
     return result;
   }
 

--- a/packages/pr-fleet-controller/src/evidence-parsers.ts
+++ b/packages/pr-fleet-controller/src/evidence-parsers.ts
@@ -29,7 +29,10 @@ const GhCheckSchema = z.object({
   name: z.string(),
   state: z.string(),
   bucket: z.string(),
-  link: z.url().optional(),
+  // `gh pr checks` emits `link: ""` (not a valid URL) for checks that carry no
+  // details URL — e.g. a queued/pending status — so an empty string is
+  // accepted here and normalized to null in `parseChecks`.
+  link: z.union([z.url(), z.literal("")]).optional(),
 });
 
 const ReviewPageSchema = z.object({
@@ -120,7 +123,7 @@ export function parseChecks(text: string): RawCheck[] {
       name: check.name,
       state: check.state,
       bucket: check.bucket,
-      link: check.link ?? null,
+      link: check.link === undefined || check.link === "" ? null : check.link,
     }));
 }
 

--- a/packages/pr-fleet-controller/src/ports.ts
+++ b/packages/pr-fleet-controller/src/ports.ts
@@ -40,6 +40,7 @@ export type FleetEnvironment = {
   findWorktree: (
     fleetBranches: string[],
     candidateBranch: string,
+    allowOperatorFallback: boolean,
   ) => Promise<string | null>;
   provisionWorktree: (pr: PrIdentity, stackId: string) => Promise<string>;
   assignWorktreeBranch: (worktree: string, pr: PrIdentity) => Promise<void>;

--- a/packages/pr-fleet-controller/src/ports.ts
+++ b/packages/pr-fleet-controller/src/ports.ts
@@ -37,7 +37,10 @@ export type CommandResult = {
 export type FleetEnvironment = {
   listOpenPrs: () => Promise<PrIdentity[]>;
   refreshEvidence: (pr: PrIdentity) => Promise<ReadinessEvidence>;
-  findWorktree: (branches: string[]) => Promise<string | null>;
+  findWorktree: (
+    fleetBranches: string[],
+    candidateBranch: string,
+  ) => Promise<string | null>;
   provisionWorktree: (pr: PrIdentity, stackId: string) => Promise<string>;
   assignWorktreeBranch: (worktree: string, pr: PrIdentity) => Promise<void>;
   runLocalCommand: (request: CommandRequest) => Promise<CommandResult>;

--- a/packages/pr-fleet-controller/src/tools.ts
+++ b/packages/pr-fleet-controller/src/tools.ts
@@ -1,4 +1,3 @@
-import { realpath } from "node:fs/promises";
 import path from "node:path";
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
@@ -16,6 +15,7 @@ import {
 } from "./sandbox.ts";
 import { LeaseKindSchema, PrStateSchema, type PrState } from "./schemas.ts";
 import type { FleetStore } from "./state.ts";
+import { containedPath, createFileEditTools } from "./worker-file-edits.ts";
 
 export const SETUP_COMMANDS = [
   { executable: "mise", args: ["install"] },
@@ -23,29 +23,6 @@ export const SETUP_COMMANDS = [
   { executable: "bunx", args: ["turbo", "run", "generate"] },
   { executable: "bunx", args: ["lefthook", "install"] },
 ] satisfies { executable: string; args: string[] }[];
-
-async function containedPath(
-  root: string,
-  requestedPath: string,
-): Promise<string> {
-  if (
-    path.isAbsolute(requestedPath) ||
-    requestedPath.split("/").includes("..")
-  ) {
-    throw new Error(`Unsafe worktree path: ${requestedPath}`);
-  }
-  const canonicalRoot = await realpath(root);
-  const absolute = path.resolve(canonicalRoot, requestedPath);
-  const targetExists = await Bun.file(absolute).exists();
-  const canonicalTarget = await realpath(
-    targetExists ? absolute : path.dirname(absolute),
-  );
-  const fromRoot = path.relative(canonicalRoot, canonicalTarget);
-  if (fromRoot.startsWith("..") || path.isAbsolute(fromRoot)) {
-    throw new Error(`Path escapes assigned worktree: ${requestedPath}`);
-  }
-  return absolute;
-}
 
 // Resolve the git directories and outer checkout root that the setup sandbox
 // profile needs. A linked worktree's git store lives outside the worktree tree,
@@ -261,6 +238,14 @@ export function createWorkerTools(
           }
           return { applied: true, stderr: result.stderr };
         }),
+    }),
+    // Reliable exact-match / full-file edit tools (see worker-file-edits.ts).
+    ...createFileEditTools({
+      worktree,
+      store,
+      pr,
+      record: (tool, input, run) =>
+        runRecordedTool(tool, input, toolContext, run),
     }),
     request_lease: createTool({
       id: "request_lease",

--- a/packages/pr-fleet-controller/src/worker-file-edits.ts
+++ b/packages/pr-fleet-controller/src/worker-file-edits.ts
@@ -37,6 +37,17 @@ export async function containedPath(
   if (fromRoot.startsWith("..") || path.isAbsolute(fromRoot)) {
     throw new Error(`Path escapes assigned worktree: ${requestedPath}`);
   }
+  // A symlink whose real target resolves into the checkout's own Git directory
+  // (`.git`, `.git/config`, `.git/hooks/...`) stays beneath the root and so
+  // passes the escape check above, yet `Bun.write` would follow it and corrupt
+  // the checkout or mutate remotes/hooks. The raw-segment guard above cannot see
+  // it because the requested segment is the innocuous link name, so check the
+  // resolved canonical path too.
+  if (
+    fromRoot.split(path.sep).some((segment) => segment.toLowerCase() === ".git")
+  ) {
+    throw new Error(`Refusing to edit Git metadata path: ${requestedPath}`);
+  }
   return absolute;
 }
 

--- a/packages/pr-fleet-controller/src/worker-file-edits.ts
+++ b/packages/pr-fleet-controller/src/worker-file-edits.ts
@@ -1,0 +1,160 @@
+import { realpath } from "node:fs/promises";
+import path from "node:path";
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import type { PrState } from "./schemas.ts";
+import type { FleetStore } from "./state.ts";
+
+// Resolve a worktree-relative path to an absolute one, refusing anything that
+// escapes the assigned worktree (absolute inputs, `..` segments, or a symlink
+// whose real target is outside the tree). Shared by every worker tool that
+// touches the filesystem.
+export async function containedPath(
+  root: string,
+  requestedPath: string,
+): Promise<string> {
+  if (
+    path.isAbsolute(requestedPath) ||
+    requestedPath.split("/").includes("..")
+  ) {
+    throw new Error(`Unsafe worktree path: ${requestedPath}`);
+  }
+  const canonicalRoot = await realpath(root);
+  const absolute = path.resolve(canonicalRoot, requestedPath);
+  const targetExists = await Bun.file(absolute).exists();
+  const canonicalTarget = await realpath(
+    targetExists ? absolute : path.dirname(absolute),
+  );
+  const fromRoot = path.relative(canonicalRoot, canonicalTarget);
+  if (fromRoot.startsWith("..") || path.isAbsolute(fromRoot)) {
+    throw new Error(`Path escapes assigned worktree: ${requestedPath}`);
+  }
+  return absolute;
+}
+
+// Replace an exact substring in a worktree file. `old_string` must match
+// verbatim and be unique unless `replace_all` is set. Literal (non-regex)
+// substring semantics throughout: count with split and replace via slice /
+// split-join so a `$`-bearing `new_string` is never interpreted as a
+// String.replace replacement pattern.
+export async function applyStrReplace(
+  worktree: string,
+  input: {
+    path: string;
+    old_string: string;
+    new_string: string;
+    replace_all: boolean;
+  },
+): Promise<{ path: string; replacements: number }> {
+  if (input.old_string === input.new_string) {
+    throw new Error(
+      "old_string and new_string are identical; nothing to replace",
+    );
+  }
+  const absolute = await containedPath(worktree, input.path);
+  const file = Bun.file(absolute);
+  if (!(await file.exists())) {
+    throw new Error(
+      `File does not exist: ${input.path} (use write_file to create it)`,
+    );
+  }
+  const content = await file.text();
+  const occurrences = content.split(input.old_string).length - 1;
+  if (occurrences === 0) {
+    throw new Error(
+      `old_string not found in ${input.path}; it must match the file exactly, including whitespace and indentation`,
+    );
+  }
+  if (occurrences > 1 && !input.replace_all) {
+    throw new Error(
+      `old_string occurs ${String(occurrences)} times in ${input.path}; add surrounding context to make it unique, or pass replace_all to replace every occurrence`,
+    );
+  }
+  const firstIndex = content.indexOf(input.old_string);
+  const updated = input.replace_all
+    ? content.split(input.old_string).join(input.new_string)
+    : content.slice(0, firstIndex) +
+      input.new_string +
+      content.slice(firstIndex + input.old_string.length);
+  await Bun.write(absolute, updated);
+  return {
+    path: input.path,
+    replacements: input.replace_all ? occurrences : 1,
+  };
+}
+
+// Create or overwrite a worktree file with the given full contents.
+export async function writeWorktreeFile(
+  worktree: string,
+  input: { path: string; content: string },
+): Promise<{ path: string; bytes: number }> {
+  const absolute = await containedPath(worktree, input.path);
+  const bytes = await Bun.write(absolute, input.content);
+  return { path: input.path, bytes };
+}
+
+// Runs a tool body inside the shared telemetry-recording wrapper, already bound
+// to the calling worker's correlation context.
+type RecordTool = <T>(
+  tool: string,
+  input: unknown,
+  run: () => Promise<T>,
+) => Promise<T>;
+
+type FileEditToolDeps = {
+  worktree: string;
+  store: FleetStore;
+  pr: PrState;
+  record: RecordTool;
+};
+
+function holdsWriteLease(store: FleetStore, pr: PrState): void {
+  if (store.stackWriteOwners.get(pr.stackId) !== pr.identity.number) {
+    throw new Error("Worker does not hold the stack write lease");
+  }
+}
+
+// The reliable worker edit surface: exact-match `str_replace` and full-file
+// `write_file`. A capable model produces these consistently, where a
+// hand-authored unified diff for `apply_patch` frequently fails format or
+// whitespace checks and burns the whole cycle.
+export function createFileEditTools(deps: FileEditToolDeps) {
+  const { worktree, store, pr, record } = deps;
+  return {
+    str_replace: createTool({
+      id: "str_replace",
+      description:
+        "Replace an exact substring in a file beneath the assigned worktree. `old_string` must match the file verbatim (including whitespace and indentation) and be unique unless `replace_all` is set. This is the preferred way to edit an existing file — reach for it before apply_patch, which needs a correctly formatted unified diff.",
+      inputSchema: z.object({
+        path: z.string().min(1),
+        old_string: z.string().min(1),
+        new_string: z.string(),
+        replace_all: z.boolean().default(false),
+      }),
+      outputSchema: z.object({
+        path: z.string(),
+        replacements: z.number().int(),
+      }),
+      execute: (input) =>
+        record("str_replace", input, async () => {
+          holdsWriteLease(store, pr);
+          return applyStrReplace(worktree, input);
+        }),
+    }),
+    write_file: createTool({
+      id: "write_file",
+      description:
+        "Create or overwrite a UTF-8 file beneath the assigned worktree with the given full contents. Use for new files or a full rewrite; prefer str_replace for a targeted edit to an existing file.",
+      inputSchema: z.object({
+        path: z.string().min(1),
+        content: z.string(),
+      }),
+      outputSchema: z.object({ path: z.string(), bytes: z.number().int() }),
+      execute: (input) =>
+        record("write_file", input, async () => {
+          holdsWriteLease(store, pr);
+          return writeWorktreeFile(worktree, input);
+        }),
+    }),
+  };
+}

--- a/packages/pr-fleet-controller/src/worker-file-edits.ts
+++ b/packages/pr-fleet-controller/src/worker-file-edits.ts
@@ -44,16 +44,20 @@ export async function containedPath(
   }
   const canonicalRoot = await realpath(root);
   const absolute = path.resolve(canonicalRoot, requestedPath);
-  // Refuse to write through a symlink at the target itself. `Bun.write` follows
-  // it, and a DANGLING link (missing target) evades the canonicalization below:
-  // `Bun.file(absolute).exists()` is false, so only the in-tree parent gets
-  // resolved and the link passes — then the write follows it to an arbitrary
-  // operator-accessible path outside the checkout. Checked no-follow via lstat so
-  // it catches the link regardless of whether its target exists.
-  if (await isSymlink(absolute)) {
-    throw new Error(`Refusing to write through a symlink: ${requestedPath}`);
-  }
   const targetExists = await Bun.file(absolute).exists();
+  // Reject only a DANGLING symlink at the target (its link resolves to nothing).
+  // Such a link can't be canonicalized — `exists()` is false, so the branch
+  // below would resolve only the in-tree parent and let the link pass, then
+  // `Bun.write` would follow it to an arbitrary, possibly external path. An
+  // EXISTING symlink is deliberately allowed through: the canonical containment
+  // and `.git` checks below resolve its real target and reject it only if it
+  // escapes the tree or reaches Git metadata, so a safe in-tree link (e.g. this
+  // repo's `CLAUDE.md` -> `AGENTS.md`) can still be read and edited.
+  if (!targetExists && (await isSymlink(absolute))) {
+    throw new Error(
+      `Refusing to write through a dangling symlink: ${requestedPath}`,
+    );
+  }
   const canonicalTarget = await realpath(
     targetExists ? absolute : path.dirname(absolute),
   );

--- a/packages/pr-fleet-controller/src/worker-file-edits.ts
+++ b/packages/pr-fleet-controller/src/worker-file-edits.ts
@@ -1,9 +1,24 @@
-import { realpath } from "node:fs/promises";
+import { lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import type { PrState } from "./schemas.ts";
 import type { FleetStore } from "./state.ts";
+
+// Is `candidate` itself a symlink? Uses `lstat` (no-follow) so it reports the
+// link, not its target — and treats a wholly missing path as "not a symlink"
+// (the normal write_file-creates-a-new-file case). Any other error propagates.
+async function isSymlink(candidate: string): Promise<boolean> {
+  try {
+    const stats = await lstat(candidate);
+    return stats.isSymbolicLink();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
 
 // Resolve a worktree-relative path to an absolute one, refusing anything that
 // escapes the assigned worktree (absolute inputs, `..` segments, or a symlink
@@ -29,6 +44,15 @@ export async function containedPath(
   }
   const canonicalRoot = await realpath(root);
   const absolute = path.resolve(canonicalRoot, requestedPath);
+  // Refuse to write through a symlink at the target itself. `Bun.write` follows
+  // it, and a DANGLING link (missing target) evades the canonicalization below:
+  // `Bun.file(absolute).exists()` is false, so only the in-tree parent gets
+  // resolved and the link passes — then the write follows it to an arbitrary
+  // operator-accessible path outside the checkout. Checked no-follow via lstat so
+  // it catches the link regardless of whether its target exists.
+  if (await isSymlink(absolute)) {
+    throw new Error(`Refusing to write through a symlink: ${requestedPath}`);
+  }
   const targetExists = await Bun.file(absolute).exists();
   const canonicalTarget = await realpath(
     targetExists ? absolute : path.dirname(absolute),

--- a/packages/pr-fleet-controller/src/worker-file-edits.ts
+++ b/packages/pr-fleet-controller/src/worker-file-edits.ts
@@ -7,16 +7,24 @@ import type { FleetStore } from "./state.ts";
 
 // Resolve a worktree-relative path to an absolute one, refusing anything that
 // escapes the assigned worktree (absolute inputs, `..` segments, or a symlink
-// whose real target is outside the tree). Shared by every worker tool that
-// touches the filesystem.
+// whose real target is outside the tree) or reaches into Git's own metadata.
+// Shared by every worker tool that touches the filesystem.
 export async function containedPath(
   root: string,
   requestedPath: string,
 ): Promise<string> {
-  if (
-    path.isAbsolute(requestedPath) ||
-    requestedPath.split("/").includes("..")
-  ) {
+  const segments = requestedPath.split("/");
+  // A `.git` segment is off-limits regardless of where it sits: in a linked
+  // worktree `.git` is a file whose contents point at the real Git directory
+  // (overwriting it detaches the worktree), and when a primary checkout is
+  // reused `.git/config`, `.git/hooks/...`, etc. resolve inside the tree and so
+  // would pass the containment check below. A mistaken or prompt-injected worker
+  // edit must never corrupt the checkout or mutate remotes/hooks. Case-folded
+  // because Git treats `.git` case-insensitively on macOS/Windows.
+  if (segments.some((segment) => segment.toLowerCase() === ".git")) {
+    throw new Error(`Refusing to edit Git metadata path: ${requestedPath}`);
+  }
+  if (path.isAbsolute(requestedPath) || segments.includes("..")) {
     throw new Error(`Unsafe worktree path: ${requestedPath}`);
   }
   const canonicalRoot = await realpath(root);

--- a/packages/pr-fleet-controller/src/worktree.ts
+++ b/packages/pr-fleet-controller/src/worktree.ts
@@ -150,7 +150,11 @@ export class WorktreeManager {
     await this.#mustRun("git", [
       "fetch",
       "origin",
-      `pull/${n}/head:${pullRef}`,
+      // Source fully qualified (`refs/pull/N/head`) on purpose: the unqualified
+      // `pull/N/head` resolves to the existing local `pullRef` once it exists,
+      // so git prunes the destination ("- [deleted] (none)") at exit 0 and the
+      // following rev-parse fails. See the matching note in environment.ts.
+      `refs/pull/${n}/head:${pullRef}`,
     ]);
     const fetchedOutput = await this.#mustRun(
       "git",

--- a/packages/pr-fleet-controller/src/worktree.ts
+++ b/packages/pr-fleet-controller/src/worktree.ts
@@ -33,11 +33,12 @@ export class WorktreeManager {
     this.#mustRun = dependencies.mustRun;
   }
 
-  // Only a worktree UNDER `#worktreeRoot` is a fleet-managed worktree. The
-  // operator may have the same PR branch checked out in their own normal
-  // worktree elsewhere; returning that would let `assignWorktreeBranch`
-  // `reset --hard` the operator's real edits. Restrict the search to
-  // fleet-owned paths so only disposable fleet worktrees are ever reused.
+  // A worktree UNDER `#worktreeRoot` is a fleet-managed, disposable worktree.
+  // The operator may have the same PR branch checked out in their own normal
+  // worktree elsewhere; `findWorktree` prefers a fleet worktree but falls back
+  // to reusing an operator worktree in place (see its note), and
+  // `assignWorktreeBranch` guards that reuse so the operator's uncommitted work
+  // is never `reset --hard`-ed away.
   #isFleetWorktree(worktreePath: string): boolean {
     const relative = path.relative(this.#worktreeRoot, worktreePath);
     return (
@@ -46,6 +47,13 @@ export class WorktreeManager {
     );
   }
 
+  // Find a worktree that already has one of `branches` checked out. Git forbids
+  // the same branch in two worktrees, so a `git worktree add` for a branch the
+  // operator already holds fails and parks the PR for the whole run. To let the
+  // fleet make progress on such a PR, reuse that existing checkout in place: a
+  // fleet-owned worktree is always preferred (disposable, safe to hard-reset),
+  // and an operator worktree is returned only as a fallback — `assignWorktreeBranch`
+  // refuses to reuse it while it is dirty, so operator edits are never lost.
   async findWorktree(branches: string[]): Promise<string | null> {
     const output = await this.#mustRun("git", [
       "worktree",
@@ -53,22 +61,22 @@ export class WorktreeManager {
       "--porcelain",
     ]);
     let currentPath: string | null = null;
+    let operatorFallback: string | null = null;
     for (const line of output.split("\n")) {
       if (line.startsWith("worktree ")) {
         currentPath = line.slice("worktree ".length);
       }
       if (line.startsWith("branch refs/heads/")) {
         const branch = line.slice("branch refs/heads/".length);
-        if (
-          currentPath !== null &&
-          branches.includes(branch) &&
-          this.#isFleetWorktree(currentPath)
-        ) {
-          return currentPath;
+        if (currentPath !== null && branches.includes(branch)) {
+          if (this.#isFleetWorktree(currentPath)) {
+            return currentPath;
+          }
+          operatorFallback ??= currentPath;
         }
       }
     }
-    return null;
+    return operatorFallback;
   }
 
   // Is a worktree registered at exactly this path, regardless of what (if any)
@@ -123,6 +131,26 @@ export class WorktreeManager {
       worktree,
     );
     const onBranch = currentBranchOutput.trim() === branch;
+    // Reusing an operator-owned worktree in place: `findWorktree` falls back to
+    // the operator's own checkout when they already hold this PR's branch (git
+    // forbids the same branch in two worktrees, so the fleet cannot provision
+    // its own). That checkout is `onBranch` by definition, so the switch guard
+    // below never fires for it — yet the sync further down `reset --hard`s the
+    // working tree. Refuse while the operator worktree carries uncommitted work
+    // so their edits are never discarded; the PR pauses with an actionable
+    // message instead of silently losing local changes.
+    if (!this.#isFleetWorktree(worktree)) {
+      const dirtyOutput = await this.#mustRun(
+        "git",
+        ["status", "--porcelain"],
+        worktree,
+      );
+      if (dirtyOutput.trim().length > 0) {
+        throw new Error(
+          `Operator worktree ${worktree} has uncommitted changes; refusing to reuse it for PR #${n}. Commit or stash them, or remove the worktree, to let the fleet work this PR.`,
+        );
+      }
+    }
     // Refuse to carry another PR's uncommitted work across a branch switch. A
     // prior worker that ended blocked/failed on a DIFFERENT branch may have left
     // dirty edits; `git checkout` preserves non-conflicting modifications, so

--- a/packages/pr-fleet-controller/src/worktree.ts
+++ b/packages/pr-fleet-controller/src/worktree.ts
@@ -275,6 +275,17 @@ export class WorktreeManager {
         return;
       }
     }
+    // Operator worktree that reached here is, by the guards above, clean and
+    // already exactly at the fetched PR head (a non-fleet worktree whose local
+    // head differs threw above). There is nothing to sync, so DON'T `reset
+    // --hard`: the cleanliness check and the reset are not atomic, and a live
+    // operator edit landing in that window would be silently destroyed by the
+    // reset. Skipping it means the fleet never runs a destructive Git command
+    // against an operator's own checkout — it only reads and then hands it to the
+    // worker. (Fleet worktrees are disposable and still get aligned below.)
+    if (!this.#isFleetWorktree(worktree)) {
+      return;
+    }
     // Local ref is at, behind, or diverged from the confirmed PR head: align to
     // the remote head, discarding prior failed-attempt working-tree edits.
     await this.#mustRun("git", ["reset", "--hard", fetchedHead], worktree);

--- a/packages/pr-fleet-controller/src/worktree.ts
+++ b/packages/pr-fleet-controller/src/worktree.ts
@@ -57,18 +57,25 @@ export class WorktreeManager {
   // is reused when it holds ANY of `fleetBranches` — the whole stack shares one
   // fleet worktree, so a sibling's checkout is fair game and is always preferred.
   //
-  // An operator worktree is reused only as a fallback and only when it holds the
-  // EXACT `candidateBranch`. Matching a mere sibling would let the caller switch
-  // the operator's checkout to a different branch and hard-reset it — changing
-  // their checkout and deleting committed-but-unpushed work on the sibling, whose
-  // divergence the assign-time guard cannot catch because that guard only runs
-  // when the worktree was already on the candidate branch. On the candidate
-  // branch itself, `assignWorktreeBranch` still refuses reuse while the worktree
-  // is dirty or its HEAD has diverged, so operator edits are never lost or
-  // force-pushed.
+  // An operator worktree is reused only as a fallback and only when
+  // `allowOperatorFallback` is set and it holds the EXACT `candidateBranch`.
+  // Matching a mere sibling would let the caller switch the operator's checkout
+  // to a different branch and hard-reset it — changing their checkout and
+  // deleting committed-but-unpushed work on the sibling, whose divergence the
+  // assign-time guard cannot catch because that guard only runs when the worktree
+  // was already on the candidate branch. On the candidate branch itself,
+  // `assignWorktreeBranch` still refuses reuse while the worktree is dirty or its
+  // HEAD has diverged, so operator edits are never lost or force-pushed.
+  //
+  // `allowOperatorFallback` is false for cross-repository (fork) PRs: the fleet
+  // can never publish a fork branch, so reusing an operator's fork checkout would
+  // only leave an orphan repair commit in it before `#submitBranch` rejects the
+  // push. Those PRs must fall through to `provisionWorktree`, which rejects them
+  // with an actionable cross-repository message instead of dispatching a worker.
   async findWorktree(
     fleetBranches: string[],
     candidateBranch: string,
+    allowOperatorFallback: boolean,
   ): Promise<string | null> {
     const output = await this.#mustRun("git", [
       "worktree",
@@ -91,6 +98,7 @@ export class WorktreeManager {
             return currentPath;
           }
           if (
+            allowOperatorFallback &&
             branch === candidateBranch &&
             !this.#isFleetWorktree(currentPath)
           ) {
@@ -280,7 +288,11 @@ export class WorktreeManager {
     }
     await mkdir(this.#worktreeRoot, { recursive: true });
     const worktreePath = path.join(this.#worktreeRoot, `stack-${stackId}`);
-    const existing = await this.findWorktree([pr.headRefName], pr.headRefName);
+    const existing = await this.findWorktree(
+      [pr.headRefName],
+      pr.headRefName,
+      !pr.crossRepository,
+    );
     if (existing !== null) {
       return existing;
     }

--- a/packages/pr-fleet-controller/src/worktree.ts
+++ b/packages/pr-fleet-controller/src/worktree.ts
@@ -48,15 +48,28 @@ export class WorktreeManager {
     );
   }
 
-  // Find a worktree that already has one of `branches` checked out. Git forbids
-  // the same branch in two worktrees, so a `git worktree add` for a branch the
-  // operator already holds fails and parks the PR for the whole run. To let the
-  // fleet make progress on such a PR, reuse that existing checkout in place: a
-  // fleet-owned worktree is always preferred (disposable, safe to hard-reset),
-  // and an operator worktree is returned only as a fallback — `assignWorktreeBranch`
-  // refuses to reuse it while it is dirty or when its HEAD has diverged from the
-  // PR head, so operator edits are never lost and never force-pushed.
-  async findWorktree(branches: string[]): Promise<string | null> {
+  // Find a worktree already holding a relevant branch. Git forbids the same
+  // branch in two worktrees, so a `git worktree add` for a branch that is
+  // already checked out fails and parks the PR for the whole run. To let the
+  // fleet make progress, reuse an existing checkout in place.
+  //
+  // A fleet-owned worktree (disposable, safe to hard-reset onto the candidate)
+  // is reused when it holds ANY of `fleetBranches` — the whole stack shares one
+  // fleet worktree, so a sibling's checkout is fair game and is always preferred.
+  //
+  // An operator worktree is reused only as a fallback and only when it holds the
+  // EXACT `candidateBranch`. Matching a mere sibling would let the caller switch
+  // the operator's checkout to a different branch and hard-reset it — changing
+  // their checkout and deleting committed-but-unpushed work on the sibling, whose
+  // divergence the assign-time guard cannot catch because that guard only runs
+  // when the worktree was already on the candidate branch. On the candidate
+  // branch itself, `assignWorktreeBranch` still refuses reuse while the worktree
+  // is dirty or its HEAD has diverged, so operator edits are never lost or
+  // force-pushed.
+  async findWorktree(
+    fleetBranches: string[],
+    candidateBranch: string,
+  ): Promise<string | null> {
     const output = await this.#mustRun("git", [
       "worktree",
       "list",
@@ -70,11 +83,19 @@ export class WorktreeManager {
       }
       if (line.startsWith("branch refs/heads/")) {
         const branch = line.slice("branch refs/heads/".length);
-        if (currentPath !== null && branches.includes(branch)) {
-          if (this.#isFleetWorktree(currentPath)) {
+        if (currentPath !== null) {
+          if (
+            fleetBranches.includes(branch) &&
+            this.#isFleetWorktree(currentPath)
+          ) {
             return currentPath;
           }
-          operatorFallback ??= currentPath;
+          if (
+            branch === candidateBranch &&
+            !this.#isFleetWorktree(currentPath)
+          ) {
+            operatorFallback ??= currentPath;
+          }
         }
       }
     }
@@ -259,7 +280,7 @@ export class WorktreeManager {
     }
     await mkdir(this.#worktreeRoot, { recursive: true });
     const worktreePath = path.join(this.#worktreeRoot, `stack-${stackId}`);
-    const existing = await this.findWorktree([pr.headRefName]);
+    const existing = await this.findWorktree([pr.headRefName], pr.headRefName);
     if (existing !== null) {
       return existing;
     }

--- a/packages/pr-fleet-controller/src/worktree.ts
+++ b/packages/pr-fleet-controller/src/worktree.ts
@@ -38,7 +38,8 @@ export class WorktreeManager {
   // worktree elsewhere; `findWorktree` prefers a fleet worktree but falls back
   // to reusing an operator worktree in place (see its note), and
   // `assignWorktreeBranch` guards that reuse so the operator's uncommitted work
-  // is never `reset --hard`-ed away.
+  // is never `reset --hard`-ed away and their committed-but-unpushed work is
+  // never force-pushed under the fleet's PR.
   #isFleetWorktree(worktreePath: string): boolean {
     const relative = path.relative(this.#worktreeRoot, worktreePath);
     return (
@@ -53,7 +54,8 @@ export class WorktreeManager {
   // fleet make progress on such a PR, reuse that existing checkout in place: a
   // fleet-owned worktree is always preferred (disposable, safe to hard-reset),
   // and an operator worktree is returned only as a fallback — `assignWorktreeBranch`
-  // refuses to reuse it while it is dirty, so operator edits are never lost.
+  // refuses to reuse it while it is dirty or when its HEAD has diverged from the
+  // PR head, so operator edits are never lost and never force-pushed.
   async findWorktree(branches: string[]): Promise<string | null> {
     const output = await this.#mustRun("git", [
       "worktree",
@@ -216,6 +218,20 @@ export class WorktreeManager {
     );
     const localHead = localHeadOutput.trim();
     if (localHead !== fetchedHead) {
+      // An operator-owned worktree must sit exactly at the fetched PR head.
+      // Working-tree cleanliness is not enough: a clean checkout can still hold
+      // committed-but-unpushed operator work (WIP, an unrelated branch tip), and
+      // the ahead-of-remote branch below would preserve that local HEAD, which
+      // `GitOperations.#submitBranch` later force-pushes — silently publishing
+      // the operator's commits under this PR. Only a fleet-owned worktree may
+      // carry an unpublished fix forward (it authored the commit); refuse an
+      // operator worktree that has diverged so the PR pauses with an actionable
+      // message instead.
+      if (!this.#isFleetWorktree(worktree)) {
+        throw new Error(
+          `Operator worktree ${worktree} is at ${localHead}, not PR #${n} head ${fetchedHead}; refusing to reuse it because publishing would force-push the operator's local commits. Push or remove them, or remove the worktree, to let the fleet work this PR.`,
+        );
+      }
       const aheadOfRemote = await this.#run({
         executable: "git",
         args: ["merge-base", "--is-ancestor", fetchedHead, localHead],

--- a/packages/pr-fleet-controller/test/agents.test.ts
+++ b/packages/pr-fleet-controller/test/agents.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { MastraMaster } from "@shepherdjerred/pr-fleet-controller/src/agents.ts";
+import {
+  coerceWorkerResult,
+  MastraMaster,
+} from "@shepherdjerred/pr-fleet-controller/src/agents.ts";
+import type { WorkerResult } from "@shepherdjerred/pr-fleet-controller/src/schemas.ts";
 import type { MasterControllerTools } from "@shepherdjerred/pr-fleet-controller/src/master-tools.ts";
 import type {
   FleetObserver,
@@ -167,6 +171,53 @@ class KindFailingTelemetry extends RecordingTelemetry {
 
 const flush = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 5));
+
+describe("coerceWorkerResult", () => {
+  const validResult: WorkerResult = {
+    pr: 42,
+    state: "waiting-ci",
+    headShaBefore: "a".repeat(40),
+    headShaAfter: null,
+    hardFailures: [],
+    reviewFindings: [],
+    conflict: false,
+    validation: [],
+    lastAction: "observed CI",
+    blockers: [],
+    worktree: "/tmp/pr-fleet-42",
+    worktreeDirty: false,
+    setupLeaseReleased: true,
+    heavyLeaseReleased: true,
+    writeLeaseReleased: true,
+  };
+
+  test("returns the validated object when present", () => {
+    expect(coerceWorkerResult({ object: validResult })).toEqual(validResult);
+  });
+
+  test("throws a legible error (not a raw Zod dump) when object is undefined", () => {
+    expect(() =>
+      coerceWorkerResult({ object: undefined, text: "  ran out of steps  " }),
+    ).toThrow(
+      /Worker produced no structured result.*Final model text: ran out of steps/s,
+    );
+  });
+
+  test("omits the final-text clause when there is no model text", () => {
+    let message = "";
+    try {
+      coerceWorkerResult({ object: undefined });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("Worker produced no structured result");
+    expect(message).not.toContain("Final model text");
+  });
+
+  test("still rejects a present-but-invalid object", () => {
+    expect(() => coerceWorkerResult({ object: { pr: 1 } })).toThrow();
+  });
+});
 
 describe("master shutdown", () => {
   test("aborts and awaits the in-flight master turn before resolving", async () => {

--- a/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
+++ b/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
@@ -119,6 +119,19 @@ describe("applyStrReplace", () => {
       }),
     ).rejects.toThrow(/Unsafe worktree path/);
   });
+
+  test("refuses a path reaching into Git metadata", async () => {
+    for (const gitPath of [".git", ".git/config", ".git/hooks/pre-commit"]) {
+      await expect(
+        applyStrReplace(worktree, {
+          path: gitPath,
+          old_string: "x",
+          new_string: "y",
+          replace_all: false,
+        }),
+      ).rejects.toThrow(/Git metadata path/);
+    }
+  });
 });
 
 describe("writeWorktreeFile", () => {
@@ -144,5 +157,11 @@ describe("writeWorktreeFile", () => {
     await expect(
       writeWorktreeFile(worktree, { path: "/etc/x", content: "y" }),
     ).rejects.toThrow(/Unsafe worktree path/);
+  });
+
+  test("refuses writing into the Git directory", async () => {
+    await expect(
+      writeWorktreeFile(worktree, { path: ".git/config", content: "y" }),
+    ).rejects.toThrow(/Git metadata path/);
   });
 });

--- a/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
+++ b/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  applyStrReplace,
+  writeWorktreeFile,
+} from "@shepherdjerred/pr-fleet-controller/src/worker-file-edits.ts";
+
+let worktree: string;
+
+beforeEach(async () => {
+  worktree = await mkdtemp(path.join(tmpdir(), "pr-fleet-edit-"));
+});
+
+afterEach(async () => {
+  await rm(worktree, { recursive: true, force: true });
+});
+
+describe("applyStrReplace", () => {
+  test("replaces a unique substring in place", async () => {
+    await writeFile(
+      path.join(worktree, "a.ts"),
+      "const x = 1;\nconst y = 2;\n",
+    );
+    const result = await applyStrReplace(worktree, {
+      path: "a.ts",
+      old_string: "const x = 1;",
+      new_string: "const x = 99;",
+      replace_all: false,
+    });
+    expect(result).toEqual({ path: "a.ts", replacements: 1 });
+    expect(await readFile(path.join(worktree, "a.ts"), "utf8")).toBe(
+      "const x = 99;\nconst y = 2;\n",
+    );
+  });
+
+  test("treats new_string literally (no $ replacement patterns)", async () => {
+    await writeFile(path.join(worktree, "a.ts"), "const price = OLD;\n");
+    await applyStrReplace(worktree, {
+      path: "a.ts",
+      old_string: "OLD",
+      new_string: "$1$&cost",
+      replace_all: false,
+    });
+    expect(await readFile(path.join(worktree, "a.ts"), "utf8")).toBe(
+      "const price = $1$&cost;\n",
+    );
+  });
+
+  test("replaces every occurrence with replace_all", async () => {
+    await writeFile(path.join(worktree, "a.ts"), "a a a\n");
+    const result = await applyStrReplace(worktree, {
+      path: "a.ts",
+      old_string: "a",
+      new_string: "b",
+      replace_all: true,
+    });
+    expect(result).toEqual({ path: "a.ts", replacements: 3 });
+    expect(await readFile(path.join(worktree, "a.ts"), "utf8")).toBe("b b b\n");
+  });
+
+  test("rejects a non-unique old_string without replace_all", async () => {
+    await writeFile(path.join(worktree, "a.ts"), "a a\n");
+    await expect(
+      applyStrReplace(worktree, {
+        path: "a.ts",
+        old_string: "a",
+        new_string: "b",
+        replace_all: false,
+      }),
+    ).rejects.toThrow(/occurs 2 times/);
+    // Left untouched on rejection.
+    expect(await readFile(path.join(worktree, "a.ts"), "utf8")).toBe("a a\n");
+  });
+
+  test("rejects an old_string that is not present", async () => {
+    await writeFile(path.join(worktree, "a.ts"), "hello\n");
+    await expect(
+      applyStrReplace(worktree, {
+        path: "a.ts",
+        old_string: "goodbye",
+        new_string: "x",
+        replace_all: false,
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  test("rejects when old_string and new_string are identical", async () => {
+    await writeFile(path.join(worktree, "a.ts"), "same\n");
+    await expect(
+      applyStrReplace(worktree, {
+        path: "a.ts",
+        old_string: "same",
+        new_string: "same",
+        replace_all: false,
+      }),
+    ).rejects.toThrow(/identical/);
+  });
+
+  test("rejects editing a file that does not exist", async () => {
+    await expect(
+      applyStrReplace(worktree, {
+        path: "missing.ts",
+        old_string: "x",
+        new_string: "y",
+        replace_all: false,
+      }),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  test("refuses a path that escapes the worktree", async () => {
+    await expect(
+      applyStrReplace(worktree, {
+        path: "../escape.ts",
+        old_string: "x",
+        new_string: "y",
+        replace_all: false,
+      }),
+    ).rejects.toThrow(/Unsafe worktree path/);
+  });
+});
+
+describe("writeWorktreeFile", () => {
+  test("creates a new file", async () => {
+    const result = await writeWorktreeFile(worktree, {
+      path: "new.ts",
+      content: "export const z = 3;\n",
+    });
+    expect(result.path).toBe("new.ts");
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(await readFile(path.join(worktree, "new.ts"), "utf8")).toBe(
+      "export const z = 3;\n",
+    );
+  });
+
+  test("overwrites an existing file", async () => {
+    await writeFile(path.join(worktree, "e.ts"), "old\n");
+    await writeWorktreeFile(worktree, { path: "e.ts", content: "new\n" });
+    expect(await readFile(path.join(worktree, "e.ts"), "utf8")).toBe("new\n");
+  });
+
+  test("refuses an absolute path outside the worktree", async () => {
+    await expect(
+      writeWorktreeFile(worktree, { path: "/etc/x", content: "y" }),
+    ).rejects.toThrow(/Unsafe worktree path/);
+  });
+});

--- a/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
+++ b/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -163,5 +170,24 @@ describe("writeWorktreeFile", () => {
     await expect(
       writeWorktreeFile(worktree, { path: ".git/config", content: "y" }),
     ).rejects.toThrow(/Git metadata path/);
+  });
+
+  test("refuses a symlink that resolves into the Git directory", async () => {
+    // A tracked symlink whose real target is `.git` (or a path inside it) passes
+    // the raw-segment check under its innocuous link name; the canonical-path
+    // guard must still reject it before Bun.write follows it.
+    await mkdir(path.join(worktree, ".git"));
+    await writeFile(path.join(worktree, ".git", "config"), "[core]\n");
+    await symlink(path.join(worktree, ".git"), path.join(worktree, "gitlink"));
+    await expect(
+      writeWorktreeFile(worktree, {
+        path: "gitlink/config",
+        content: "pwned",
+      }),
+    ).rejects.toThrow(/Git metadata path/);
+    // The real config file is untouched.
+    expect(await readFile(path.join(worktree, ".git", "config"), "utf8")).toBe(
+      "[core]\n",
+    );
   });
 });

--- a/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
+++ b/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
@@ -183,8 +183,27 @@ describe("writeWorktreeFile", () => {
     await symlink(outside, path.join(worktree, "dangling"));
     await expect(
       writeWorktreeFile(worktree, { path: "dangling", content: "escaped" }),
-    ).rejects.toThrow(/write through a symlink/);
+    ).rejects.toThrow(/dangling symlink/);
     expect(await Bun.file(outside).exists()).toBe(false);
+  });
+
+  test("allows editing through a safe in-tree symlink", async () => {
+    // A tracked symlink whose real target is a normal in-tree file (like this
+    // repo's CLAUDE.md -> AGENTS.md) must remain editable: the canonical
+    // containment check resolves the real target and confirms it is in-tree.
+    await writeFile(path.join(worktree, "AGENTS.md"), "# real\n");
+    await symlink(
+      path.join(worktree, "AGENTS.md"),
+      path.join(worktree, "CLAUDE.md"),
+    );
+    await writeWorktreeFile(worktree, {
+      path: "CLAUDE.md",
+      content: "# edited\n",
+    });
+    // The write followed the link and updated the real target.
+    expect(await readFile(path.join(worktree, "AGENTS.md"), "utf8")).toBe(
+      "# edited\n",
+    );
   });
 
   test("refuses a symlink that resolves into the Git directory", async () => {

--- a/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
+++ b/packages/pr-fleet-controller/test/worker-edit-tools.test.ts
@@ -172,6 +172,21 @@ describe("writeWorktreeFile", () => {
     ).rejects.toThrow(/Git metadata path/);
   });
 
+  test("refuses a dangling symlink pointing outside the worktree", async () => {
+    // The link target does not exist, so exists() is false and only the in-tree
+    // parent would be canonicalized; without the no-follow lstat guard, Bun.write
+    // would follow the link and create a file at the external target.
+    const outside = path.join(
+      tmpdir(),
+      `pr-fleet-escape-${String(Date.now())}.txt`,
+    );
+    await symlink(outside, path.join(worktree, "dangling"));
+    await expect(
+      writeWorktreeFile(worktree, { path: "dangling", content: "escaped" }),
+    ).rejects.toThrow(/write through a symlink/);
+    expect(await Bun.file(outside).exists()).toBe(false);
+  });
+
   test("refuses a symlink that resolves into the Git directory", async () => {
     // A tracked symlink whose real target is `.git` (or a path inside it) passes
     // the raw-segment check under its innocuous link name; the canonical-path

--- a/packages/pr-fleet-controller/test/worktree.test.ts
+++ b/packages/pr-fleet-controller/test/worktree.test.ts
@@ -139,24 +139,59 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       "branch refs/heads/feature/x",
       "",
     ].join("\n");
-    expect(await managerWith(porcelain).findWorktree(["feature/x"])).toBe(
-      "/tmp/pr-fleet/stack-7",
-    );
+    expect(
+      await managerWith(porcelain).findWorktree(["feature/x"], "feature/x"),
+    ).toBe("/tmp/pr-fleet/stack-7");
   });
 
-  test("falls back to the operator worktree so the fleet can reuse it in place", async () => {
-    // Only the operator holds the branch; git forbids a second checkout of it,
-    // so reusing the operator worktree is the only way to make progress. The
-    // dirty guard in assignWorktreeBranch keeps that reuse safe.
+  test("reuses a fleet worktree checked out on a sibling branch", async () => {
+    // The stack shares one fleet worktree; a sibling's checkout is disposable
+    // and will be reset onto the candidate, so matching any fleet branch is fine.
+    const porcelain = [
+      "worktree /tmp/pr-fleet/stack-7",
+      `HEAD ${"b".repeat(40)}`,
+      "branch refs/heads/feature/sibling",
+      "",
+    ].join("\n");
+    expect(
+      await managerWith(porcelain).findWorktree(
+        ["feature/sibling", "feature/candidate"],
+        "feature/candidate",
+      ),
+    ).toBe("/tmp/pr-fleet/stack-7");
+  });
+
+  test("falls back to the operator worktree when it holds the candidate branch", async () => {
+    // Only the operator holds the candidate branch; git forbids a second
+    // checkout of it, so reusing the operator worktree is the only way to make
+    // progress. The dirty/divergence guards in assignWorktreeBranch keep it safe.
     const porcelain = [
       "worktree /home/user/monorepo",
       `HEAD ${"a".repeat(40)}`,
       "branch refs/heads/feature/x",
       "",
     ].join("\n");
-    expect(await managerWith(porcelain).findWorktree(["feature/x"])).toBe(
-      "/home/user/monorepo",
-    );
+    expect(
+      await managerWith(porcelain).findWorktree(["feature/x"], "feature/x"),
+    ).toBe("/home/user/monorepo");
+  });
+
+  test("never reuses an operator worktree that only holds a sibling branch", async () => {
+    // The operator holds sibling A while candidate B is dispatched. Reusing A's
+    // checkout would switch and hard-reset it to B, changing the operator's
+    // checkout and deleting unpushed work on A — so it must NOT be returned.
+    const porcelain = [
+      "worktree /home/user/monorepo",
+      `HEAD ${"a".repeat(40)}`,
+      "branch refs/heads/feature/sibling",
+      "",
+    ].join("\n");
+    expect(
+      await managerWith(porcelain).findWorktree(
+        ["feature/sibling", "feature/candidate"],
+        "feature/candidate",
+      ),
+    ).toBeNull();
   });
 
   test("returns null when no worktree has the branch", async () => {
@@ -166,7 +201,9 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       "branch refs/heads/main",
       "",
     ].join("\n");
-    expect(await managerWith(porcelain).findWorktree(["feature/x"])).toBeNull();
+    expect(
+      await managerWith(porcelain).findWorktree(["feature/x"], "feature/x"),
+    ).toBeNull();
   });
 });
 

--- a/packages/pr-fleet-controller/test/worktree.test.ts
+++ b/packages/pr-fleet-controller/test/worktree.test.ts
@@ -286,12 +286,14 @@ describe("assignWorktreeBranch guards operator worktree reuse", () => {
     expect(script.resets).toEqual([]);
   });
 
-  test("reuses a clean operator worktree in place", async () => {
+  test("reuses a clean operator worktree without resetting it", async () => {
     const pr = identity(15);
     const script = scriptOperatorWorktree(pr, "");
     await script.manager.assignWorktreeBranch("/home/user/monorepo", pr);
-    // Clean and already at the PR head: aligned to it, no operator work lost.
-    expect(script.resets).toEqual([pr.headSha]);
+    // Clean and already at the PR head: nothing to sync, so the fleet must run
+    // NO destructive `reset --hard` against the operator's checkout — that would
+    // race a concurrent operator edit landing after the cleanliness check.
+    expect(script.resets).toEqual([]);
   });
 
   test("refuses a clean operator worktree whose HEAD holds unpushed commits", async () => {

--- a/packages/pr-fleet-controller/test/worktree.test.ts
+++ b/packages/pr-fleet-controller/test/worktree.test.ts
@@ -126,10 +126,10 @@ function managerWith(porcelain: string): WorktreeManager {
   });
 }
 
-describe("findWorktree is scoped to fleet-owned worktrees", () => {
-  test("returns the fleet worktree, not the operator's own checkout of the branch", async () => {
+describe("findWorktree prefers a fleet worktree, falls back to the operator's", () => {
+  test("prefers the fleet worktree even when the operator also has the branch", async () => {
     const porcelain = [
-      // The operator's own checkout is listed first and must be skipped.
+      // The operator's own checkout is listed first but the fleet worktree wins.
       "worktree /home/user/monorepo",
       `HEAD ${"a".repeat(40)}`,
       "branch refs/heads/feature/x",
@@ -144,14 +144,83 @@ describe("findWorktree is scoped to fleet-owned worktrees", () => {
     );
   });
 
-  test("returns null when only a non-fleet worktree has the branch", async () => {
+  test("falls back to the operator worktree so the fleet can reuse it in place", async () => {
+    // Only the operator holds the branch; git forbids a second checkout of it,
+    // so reusing the operator worktree is the only way to make progress. The
+    // dirty guard in assignWorktreeBranch keeps that reuse safe.
     const porcelain = [
       "worktree /home/user/monorepo",
       `HEAD ${"a".repeat(40)}`,
       "branch refs/heads/feature/x",
       "",
     ].join("\n");
+    expect(await managerWith(porcelain).findWorktree(["feature/x"])).toBe(
+      "/home/user/monorepo",
+    );
+  });
+
+  test("returns null when no worktree has the branch", async () => {
+    const porcelain = [
+      "worktree /home/user/monorepo",
+      `HEAD ${"a".repeat(40)}`,
+      "branch refs/heads/main",
+      "",
+    ].join("\n");
     expect(await managerWith(porcelain).findWorktree(["feature/x"])).toBeNull();
+  });
+});
+
+// Reuse of an operator-owned worktree (outside the fleet root) must never
+// `reset --hard` uncommitted operator edits. Script the branch-check, the
+// pull-ref fetch/rev-parse, and a `status --porcelain` whose output signals
+// whether the operator worktree is dirty.
+function scriptOperatorWorktree(pr: PrIdentity, porcelainStatus: string) {
+  const pullRef = `refs/remotes/pull/${String(pr.number)}/head`;
+  const resets: string[] = [];
+  const mustRun = (executable: string, args: string[]): Promise<string> => {
+    if (executable === "git" && args[0] === "rev-parse") {
+      if (args[1] === "--abbrev-ref") {
+        return Promise.resolve(`${pr.headRefName}\n`);
+      }
+      if (args[1] === pullRef || args[1] === "HEAD") {
+        return Promise.resolve(`${pr.headSha}\n`);
+      }
+    }
+    if (executable === "git" && args[0] === "status") {
+      return Promise.resolve(porcelainStatus);
+    }
+    if (executable === "git" && args[0] === "reset") {
+      resets.push(args[2] ?? "");
+    }
+    return Promise.resolve("");
+  };
+  const manager = new WorktreeManager({
+    checkout: "/tmp/checkout",
+    worktreeRoot: "/tmp/pr-fleet",
+    run: okRun,
+    mustRun,
+  });
+  return { manager, resets };
+}
+
+describe("assignWorktreeBranch guards operator worktree reuse", () => {
+  test("refuses a dirty operator worktree instead of discarding its edits", async () => {
+    const pr = identity(14);
+    const script = scriptOperatorWorktree(pr, " M packages/x/file.ts\n");
+    await expect(
+      // Operator worktree lives outside the fleet root.
+      script.manager.assignWorktreeBranch("/home/user/monorepo", pr),
+    ).rejects.toThrow(/uncommitted changes; refusing to reuse/);
+    // Never touch the working tree while it is dirty.
+    expect(script.resets).toEqual([]);
+  });
+
+  test("reuses a clean operator worktree in place", async () => {
+    const pr = identity(15);
+    const script = scriptOperatorWorktree(pr, "");
+    await script.manager.assignWorktreeBranch("/home/user/monorepo", pr);
+    // Clean and already at the PR head: aligned to it, no operator work lost.
+    expect(script.resets).toEqual([pr.headSha]);
   });
 });
 

--- a/packages/pr-fleet-controller/test/worktree.test.ts
+++ b/packages/pr-fleet-controller/test/worktree.test.ts
@@ -140,7 +140,11 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       "",
     ].join("\n");
     expect(
-      await managerWith(porcelain).findWorktree(["feature/x"], "feature/x"),
+      await managerWith(porcelain).findWorktree(
+        ["feature/x"],
+        "feature/x",
+        true,
+      ),
     ).toBe("/tmp/pr-fleet/stack-7");
   });
 
@@ -157,6 +161,7 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       await managerWith(porcelain).findWorktree(
         ["feature/sibling", "feature/candidate"],
         "feature/candidate",
+        true,
       ),
     ).toBe("/tmp/pr-fleet/stack-7");
   });
@@ -172,7 +177,11 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       "",
     ].join("\n");
     expect(
-      await managerWith(porcelain).findWorktree(["feature/x"], "feature/x"),
+      await managerWith(porcelain).findWorktree(
+        ["feature/x"],
+        "feature/x",
+        true,
+      ),
     ).toBe("/home/user/monorepo");
   });
 
@@ -190,6 +199,27 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       await managerWith(porcelain).findWorktree(
         ["feature/sibling", "feature/candidate"],
         "feature/candidate",
+        true,
+      ),
+    ).toBeNull();
+  });
+
+  test("never reuses an operator worktree when operator fallback is disallowed", async () => {
+    // Cross-repository (fork) PRs pass allowOperatorFallback=false: the fleet
+    // can never publish a fork branch, so an operator's fork checkout must not be
+    // reused (it would only leave an orphan commit). The PR falls through to
+    // provisionWorktree, which rejects it with a cross-repository message.
+    const porcelain = [
+      "worktree /home/user/monorepo",
+      `HEAD ${"a".repeat(40)}`,
+      "branch refs/heads/feature/x",
+      "",
+    ].join("\n");
+    expect(
+      await managerWith(porcelain).findWorktree(
+        ["feature/x"],
+        "feature/x",
+        false,
       ),
     ).toBeNull();
   });
@@ -202,7 +232,11 @@ describe("findWorktree prefers a fleet worktree, falls back to the operator's", 
       "",
     ].join("\n");
     expect(
-      await managerWith(porcelain).findWorktree(["feature/x"], "feature/x"),
+      await managerWith(porcelain).findWorktree(
+        ["feature/x"],
+        "feature/x",
+        true,
+      ),
     ).toBeNull();
   });
 });

--- a/packages/pr-fleet-controller/test/worktree.test.ts
+++ b/packages/pr-fleet-controller/test/worktree.test.ts
@@ -222,6 +222,47 @@ describe("assignWorktreeBranch guards operator worktree reuse", () => {
     // Clean and already at the PR head: aligned to it, no operator work lost.
     expect(script.resets).toEqual([pr.headSha]);
   });
+
+  test("refuses a clean operator worktree whose HEAD holds unpushed commits", async () => {
+    const pr = identity(16);
+    // Clean working tree, but the operator's local HEAD is ahead of the PR head
+    // with committed-but-unpushed work. Reusing it would let #submitBranch
+    // force-push those commits under the fleet's PR.
+    const localHead = "e".repeat(40);
+    const pullRef = `refs/remotes/pull/${String(pr.number)}/head`;
+    const resets: string[] = [];
+    const mustRun = (executable: string, args: string[]): Promise<string> => {
+      if (executable === "git" && args[0] === "rev-parse") {
+        if (args[1] === "--abbrev-ref") {
+          return Promise.resolve(`${pr.headRefName}\n`);
+        }
+        if (args[1] === pullRef) {
+          return Promise.resolve(`${pr.headSha}\n`);
+        }
+        if (args[1] === "HEAD") {
+          return Promise.resolve(`${localHead}\n`);
+        }
+      }
+      if (executable === "git" && args[0] === "status") {
+        return Promise.resolve("");
+      }
+      if (executable === "git" && args[0] === "reset") {
+        resets.push(args[2] ?? "");
+      }
+      return Promise.resolve("");
+    };
+    const manager = new WorktreeManager({
+      checkout: "/tmp/checkout",
+      worktreeRoot: "/tmp/pr-fleet",
+      run: okRun,
+      mustRun,
+    });
+    await expect(
+      manager.assignWorktreeBranch("/home/user/monorepo", pr),
+    ).rejects.toThrow(/refusing to reuse it because publishing would/);
+    // Never reset an operator worktree we are refusing to reuse.
+    expect(resets).toEqual([]);
+  });
 });
 
 // Provisioning must recognize its own stack worktree even when a restack halted


### PR DESCRIPTION
## Why

A `bun run pr:fleet --model openai/gpt-5.6-luna` run stalled with no work advancing (`open=5 green=1 active=0 paused=4`). Post-mortem of the run bundle found **two fleet-side root causes** — GPT-5.6-luna is Sonnet/Opus class, so the tooling was failing a capable model, not the reverse.

1. **Worktree conflict** — PRs whose branch is already checked out in an operator's own worktree paused immediately: `git worktree add <branch>` refuses a branch checked out elsewhere.
2. **Brittle `apply_patch`** — it required patch headers to be *exactly* `--- a/` / `+++ b/` and applied with `--whitespace=error-all`. Correct-but-differently-formatted diffs were rejected 17× across two PRs; the worker burned its 20-step budget, emitted no structured result, and crashed on `WorkerResultSchema.parse(undefined)` with an opaque Zod dump.

## What

- **Reuse operator worktrees in place** (`worktree.ts`): `findWorktree` falls back to an operator worktree that holds the branch (fleet worktree still preferred). `assignWorktreeBranch` refuses to reuse a **dirty** non-fleet worktree with an actionable message rather than `reset --hard`-ing operator edits. Clean operator worktrees are worked in place; commits publish via the existing native force-push path.
- **Reliable edit tools** (`worker-file-edits.ts`, new): `str_replace` (exact-match, literal `$`-safe) and `write_file` (full file), both path-contained via `containedPath` and gated on the stack-write lease. `apply_patch` kept as a fallback. `WORKER_INSTRUCTIONS` steers to the edit tools.
- **Legible empty-output failure** (`agents.ts`): extracted `coerceWorkerResult` — throws a readable error (with the model's final text) when the model emits no structured result, instead of the raw Zod `expected object, received undefined` dump.
- **Housekeeping**: refactored the carried-in `#withGitLock` mutex to async/await (lint); extracted `containedPath` + `createFileEditTools` into the new module to stay under `max-lines` limits; README worker tool-boundary section updated.

## Base commit

The first commit carries the operator's prior uncommitted `environment.ts` / `evidence-parsers.ts` / `worktree.ts` robustness fixes (git ref-lock mutex, `refs/pull/N/head` fetch fix, gh empty-check-link normalization) — the `worktree.ts` change here layers on them. Those files remain uncommitted in the main checkout and can be discarded there once this merges.

## Verification

- `bunx turbo run typecheck lint test --filter=@shepherdjerred/pr-fleet-controller` — all green, **167 tests pass**.
- New tests: `str_replace`/`write_file` semantics + path containment, operator-worktree fallback + dirty guard, `coerceWorkerResult`.

## Caveats

- "Reuse in place" runs setup, commits, and force-pushes **inside the operator's checkout**, advancing their local branch to the fleet's commit (guarded to refuse a dirty worktree). This was the explicitly chosen option.
- Targets native/unstacked branches (what the two stuck PRs, #1981/#1983, are). A git-spice-owned branch held by an operator worktree still can't be worked in place cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkqpNXr4KYHzswGE5gpyJn