### PR TITLE
fix(temporal): raise Glitter synthesis token cap and retry on truncation

### DIFF
--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -260,23 +260,3 @@ verifiable evidence`, an earlier-attempt-has-evidence case still completes, and
   40k ceiling when the provider reports `finish_reason=length`. The preflight
   estimate and budget authorization use the actual base/retry caps. This is a
   probe for the observed `gpt-5.6-sol` reasoning-token drift.
-
-## Session Log — 2026-08-08
-
-### Done
-
-- Updated `packages/temporal/src/activities/glitter-context-refresh-style-generation.ts`
-  so the cached synthesis request identity includes the 40k truncation-retry
-  ceiling as well as the initial 28k completion-token cap.
-- Persisted the billable truncated attempt as its own artifact and budget entry
-  before issuing the distinct 40k retry artifact.
-- Updated the preflight estimate to include both calls when truncation occurs.
-
-### Remaining
-
-- Re-run focused Temporal verification and obtain a current-head Codex review.
-
-### Caveats
-
-- Worktree setup could not rebuild mise shims because the sandbox lacks
-  permission to write the shared mise cache and shim directories.

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -255,3 +255,8 @@ verifiable evidence`, an earlier-attempt-has-evidence case still completes, and
   Next: land + deploy, then re-run Phase 1 (cached good chunks, incl.
   `2024-10-0000`, reuse for free; `2023-03-0000` now sanitizes to its verifiable
   subset).
+- 2026-08-04 (truncation fix): `fix/glitter-synthesis-truncation` raises
+  `SYNTHESIS_MAX_OUTPUT_TOKENS` 15k→28k and retries a synthesis call once at a
+  40k ceiling when the provider reports `finish_reason=length`. The preflight
+  estimate and budget authorization use the actual base/retry caps. This is a
+  probe for the observed `gpt-5.6-sol` reasoning-token drift.

--- a/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
+++ b/packages/docs/plans/2026-07-29_glitter-style-card-v2.md
@@ -260,3 +260,23 @@ verifiable evidence`, an earlier-attempt-has-evidence case still completes, and
   40k ceiling when the provider reports `finish_reason=length`. The preflight
   estimate and budget authorization use the actual base/retry caps. This is a
   probe for the observed `gpt-5.6-sol` reasoning-token drift.
+
+## Session Log — 2026-08-08
+
+### Done
+
+- Updated `packages/temporal/src/activities/glitter-context-refresh-style-generation.ts`
+  so the cached synthesis request identity includes the 40k truncation-retry
+  ceiling as well as the initial 28k completion-token cap.
+- Persisted the billable truncated attempt as its own artifact and budget entry
+  before issuing the distinct 40k retry artifact.
+- Updated the preflight estimate to include both calls when truncation occurs.
+
+### Remaining
+
+- Re-run focused Temporal verification and obtain a current-head Codex review.
+
+### Caveats
+
+- Worktree setup could not rebuild mise shims because the sandbox lacks
+  permission to write the shared mise cache and shim directories.

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -12,6 +12,7 @@ import {
   StyleSynthesisSchema,
 } from "./glitter-context-refresh-style-schemas.ts";
 import * as glitterOpenai from "./glitter-context-refresh-openai.ts";
+import { LengthFinishReasonError } from "openai/core/error";
 import {
   sanitizeChunkSummary,
   validateChunkSummary,
@@ -310,10 +311,17 @@ const mockUsage = { prompt_tokens: 100, completion_tokens: 50 };
 let chunkResponder: (call: number) => unknown = () => goodChunkSummary;
 let chunkCallCount = 0;
 let recordedSeeds: number[] = [];
+// Synthesis calls whose max_completion_tokens is below this threshold reject with
+// a length-truncation error (0 = never truncate).
+let synthesisTruncateBelowTokens = 0;
+let recordedSynthesisMaxTokens: number[] = [];
 
 await mock.module("./glitter-context-refresh-openai.ts", () => ({
   ...glitterOpenai,
-  parseGlitterCompletion: (callSite: string, params: { seed: number }) => {
+  parseGlitterCompletion: (
+    callSite: string,
+    params: { seed: number; max_completion_tokens: number },
+  ) => {
     if (callSite.startsWith("glitter-style-chunk")) {
       recordedSeeds.push(params.seed);
       const parsed = chunkResponder(chunkCallCount);
@@ -322,6 +330,10 @@ await mock.module("./glitter-context-refresh-openai.ts", () => ({
         choices: [{ message: { parsed, content: null } }],
         usage: mockUsage,
       });
+    }
+    recordedSynthesisMaxTokens.push(params.max_completion_tokens);
+    if (params.max_completion_tokens < synthesisTruncateBelowTokens) {
+      return Promise.reject(new LengthFinishReasonError());
     }
     return Promise.resolve({
       choices: [{ message: { parsed: synthesis, content: null } }],
@@ -411,6 +423,24 @@ describe("Glitter extraction repair loop", () => {
 
     expect(result.schemaVersion).toBe(2);
     expect(recordedSeeds).toEqual([0, 1, 2]);
+  });
+});
+
+describe("Glitter synthesis truncation retry", () => {
+  test("retries synthesis at a higher token cap on a length truncation", async () => {
+    recordedSynthesisMaxTokens = [];
+    // The base 28k call rejects with a length truncation; only the 40k retry
+    // ceiling succeeds.
+    synthesisTruncateBelowTokens = 40_000;
+    try {
+      const result = await generateWithStubbedModel(() => goodChunkSummary);
+      expect(result.schemaVersion).toBe(2);
+      // Base call at the 28k cap truncated, then the run retried at the ceiling.
+      expect(recordedSynthesisMaxTokens).toContain(28_000);
+      expect(recordedSynthesisMaxTokens).toContain(40_000);
+    } finally {
+      synthesisTruncateBelowTokens = 0;
+    }
   });
 });
 

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -12,7 +12,6 @@ import {
   StyleSynthesisSchema,
 } from "./glitter-context-refresh-style-schemas.ts";
 import * as glitterOpenai from "./glitter-context-refresh-openai.ts";
-import { LengthFinishReasonError } from "openai/core/error";
 import {
   sanitizeChunkSummary,
   validateChunkSummary,
@@ -311,10 +310,11 @@ const mockUsage = { prompt_tokens: 100, completion_tokens: 50 };
 let chunkResponder: (call: number) => unknown = () => goodChunkSummary;
 let chunkCallCount = 0;
 let recordedSeeds: number[] = [];
-// Synthesis calls whose max_completion_tokens is below this threshold reject with
-// a length-truncation error (0 = never truncate).
+// Synthesis calls whose max_completion_tokens is below this threshold report a
+// length truncation (0 = never truncate).
 let synthesisTruncateBelowTokens = 0;
 let recordedSynthesisMaxTokens: number[] = [];
+let lastGenerationBudget: GenerationBudget | undefined;
 
 await mock.module("./glitter-context-refresh-openai.ts", () => ({
   ...glitterOpenai,
@@ -333,7 +333,15 @@ await mock.module("./glitter-context-refresh-openai.ts", () => ({
     }
     recordedSynthesisMaxTokens.push(params.max_completion_tokens);
     if (params.max_completion_tokens < synthesisTruncateBelowTokens) {
-      return Promise.reject(new LengthFinishReasonError());
+      return Promise.resolve({
+        choices: [
+          {
+            finish_reason: "length",
+            message: { parsed: null, content: "truncated" },
+          },
+        ],
+        usage: mockUsage,
+      });
     }
     return Promise.resolve({
       choices: [{ message: { parsed: synthesis, content: null } }],
@@ -361,12 +369,14 @@ function generateWithStubbedModel(responder: (call: number) => unknown) {
   chunkCallCount = 0;
   recordedSeeds = [];
   chunkResponder = responder;
+  const budget = new GenerationBudget(100);
+  lastGenerationBudget = budget;
   return generateStyleCard({
     candidate,
     existingCard,
     sourceSnapshotSha256: "a".repeat(64),
     artifactStore: memoryStore(),
-    budget: new GenerationBudget(100),
+    budget,
   });
 }
 
@@ -429,8 +439,8 @@ describe("Glitter extraction repair loop", () => {
 describe("Glitter synthesis truncation retry", () => {
   test("retries synthesis at a higher token cap on a length truncation", async () => {
     recordedSynthesisMaxTokens = [];
-    // The base 28k call rejects with a length truncation; only the 40k retry
-    // ceiling succeeds.
+    // The base 28k call reports a length truncation; only the 40k retry ceiling
+    // succeeds.
     synthesisTruncateBelowTokens = 40_000;
     try {
       const result = await generateWithStubbedModel(() => goodChunkSummary);
@@ -438,6 +448,10 @@ describe("Glitter synthesis truncation retry", () => {
       // Base call at the 28k cap truncated, then the run retried at the ceiling.
       expect(recordedSynthesisMaxTokens).toContain(28_000);
       expect(recordedSynthesisMaxTokens).toContain(40_000);
+      const synthesisArtifactKeys = lastGenerationBudget
+        ?.summary()
+        .artifactKeys.filter((key) => key.includes("glitter-style-synthesis"));
+      expect(synthesisArtifactKeys).toHaveLength(2);
     } finally {
       synthesisTruncateBelowTokens = 0;
     }

--- a/packages/temporal/src/activities/glitter-context-refresh-openai.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-openai.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import { parseChatCompletion } from "openai/lib/parser";
 import { z } from "zod/v4";
 import {
   traceOpenAi,
@@ -54,7 +55,39 @@ export async function parseGlitterCompletion<
       callSite,
       request: params,
     },
-    async () => client().chat.completions.parse(params),
+    async () => {
+      const completion = await client().chat.completions.create(params);
+      const completionForParsing = {
+        ...completion,
+        choices: completion.choices.map((choice) =>
+          choice.finish_reason === "length"
+            ? {
+                ...choice,
+                finish_reason: "stop" as const,
+                message: { ...choice.message, content: null },
+              }
+            : choice,
+        ),
+      };
+      const parsedCompletion = parseChatCompletion(
+        completionForParsing,
+        params,
+      );
+      return {
+        ...parsedCompletion,
+        choices: parsedCompletion.choices.map((choice, index) => ({
+          ...choice,
+          finish_reason:
+            completion.choices[index]?.finish_reason ?? choice.finish_reason,
+          message: {
+            ...choice.message,
+            content:
+              completion.choices[index]?.message.content ??
+              choice.message.content,
+          },
+        })),
+      };
+    },
   );
 }
 
@@ -129,6 +162,7 @@ export function glitterCompletionArtifact<Response>(input: {
   parsed: Response | null | undefined;
   rawContent: string | null;
   usage: OpenAI.Completions.CompletionUsage | undefined;
+  failureError?: string;
   missingParsedError: string;
 }): {
   response: GlitterCompletionArtifact<Response>;
@@ -143,7 +177,7 @@ export function glitterCompletionArtifact<Response>(input: {
       input.parsed === null || input.parsed === undefined
         ? {
             outcome: "failure",
-            error: input.missingParsedError,
+            error: input.failureError ?? input.missingParsedError,
             rawContent: input.rawContent,
           }
         : { outcome: "success", value: input.parsed },

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -1,0 +1,116 @@
+import type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+import {
+  estimatedCallCostUsd,
+  inputTokenUpperBound,
+} from "./glitter-context-refresh-budget.ts";
+import {
+  buildStyleEvidenceChunks,
+  type StyleEvidenceChunk,
+} from "./glitter-context-refresh-chunks.ts";
+import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import {
+  type StyleChunkSummary,
+  type StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+
+export const EXTRACTION_MODEL = "gpt-5.6-luna";
+export const SYNTHESIS_MODEL = "gpt-5.6-sol";
+export const EXTRACTION_MAX_OUTPUT_TOKENS = 2000;
+export const SYNTHESIS_MAX_OUTPUT_TOKENS = 28_000;
+export const SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 40_000;
+export const MAX_EXTRACTION_REPAIR_ATTEMPTS = 2;
+export const MAX_SYNTHESIS_REPAIR_ATTEMPTS = 3;
+
+export type SummarizedChunk = {
+  key: string;
+  month: string;
+  summary: StyleChunkSummary;
+};
+
+type StyleSynthesisPromptInput = {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  repair: {
+    previous: StyleSynthesis;
+    error: string;
+  } | null;
+};
+
+type StyleCostPromptBuilders = {
+  chunkPrompt: (input: {
+    candidate: StyleRefreshCandidate;
+    chunk: StyleEvidenceChunk;
+  }) => string;
+  synthesisPrompt: (input: StyleSynthesisPromptInput) => string;
+};
+
+export function estimateStyleGenerationCost(
+  input: {
+    candidate: StyleRefreshCandidate;
+    existingCard: StyleCard;
+  },
+  prompts: StyleCostPromptBuilders,
+): number {
+  const chunks = buildStyleEvidenceChunks(input.candidate.safeMessages);
+  const extractionCost = chunks.reduce((total, chunk) => {
+    const prompt = prompts.chunkPrompt({ candidate: input.candidate, chunk });
+    const initialInputTokens = inputTokenUpperBound(prompt);
+    const initialCall = estimatedCallCostUsd({
+      model: EXTRACTION_MODEL,
+      inputTokenUpperBound: initialInputTokens,
+      outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+    });
+    // Every repair attempt also serializes the prior summary (bounded by the
+    // output cap) and the validation error back into its request, so its input
+    // is larger than the initial call's.
+    const repairCall = estimatedCallCostUsd({
+      model: EXTRACTION_MODEL,
+      inputTokenUpperBound: initialInputTokens + EXTRACTION_MAX_OUTPUT_TOKENS,
+      outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+    });
+    return total + initialCall + repairCall * MAX_EXTRACTION_REPAIR_ATTEMPTS;
+  }, 0);
+  const synthesisBase = prompts.synthesisPrompt({
+    candidate: input.candidate,
+    existingCard: input.existingCard,
+    chunks: [],
+    repair: null,
+  });
+  const synthesisInputUpperBound =
+    inputTokenUpperBound(synthesisBase) +
+    chunks.length * EXTRACTION_MAX_OUTPUT_TOKENS;
+  // A truncated synthesis is billed as two separate calls: the base cap and
+  // one retry at the higher ceiling. Include both in the preflight estimate.
+  const synthesisInitialCall =
+    estimatedCallCostUsd({
+      model: SYNTHESIS_MODEL,
+      inputTokenUpperBound: synthesisInputUpperBound,
+      outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+    }) +
+    estimatedCallCostUsd({
+      model: SYNTHESIS_MODEL,
+      inputTokenUpperBound: synthesisInputUpperBound,
+      outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    });
+  // A synthesis repair likewise serializes the prior synthesis (bounded by the
+  // base cap) plus the error into its request, and may incur the same retry.
+  const synthesisRepairInput =
+    synthesisInputUpperBound + SYNTHESIS_MAX_OUTPUT_TOKENS;
+  const synthesisRepairCall =
+    estimatedCallCostUsd({
+      model: SYNTHESIS_MODEL,
+      inputTokenUpperBound: synthesisRepairInput,
+      outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+    }) +
+    estimatedCallCostUsd({
+      model: SYNTHESIS_MODEL,
+      inputTokenUpperBound: synthesisRepairInput,
+      outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    });
+  return (
+    extractionCost +
+    synthesisInitialCall +
+    synthesisRepairCall * MAX_SYNTHESIS_REPAIR_ATTEMPTS
+  );
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -94,9 +94,9 @@ export function estimateStyleGenerationCost(
       outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
     });
   // A synthesis repair likewise serializes the prior synthesis (bounded by the
-  // base cap) plus the error into its request, and may incur the same retry.
+  // retry ceiling) plus the error into its request, and may incur the same retry.
   const synthesisRepairInput =
-    synthesisInputUpperBound + SYNTHESIS_MAX_OUTPUT_TOKENS;
+    synthesisInputUpperBound + SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS;
   const synthesisRepairCall =
     estimatedCallCostUsd({
       model: SYNTHESIS_MODEL,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -1,5 +1,4 @@
 import { zodResponseFormat } from "openai/helpers/zod";
-import { LengthFinishReasonError } from "openai/core/error";
 import { z } from "zod/v4";
 import {
   type StyleCard,
@@ -28,6 +27,17 @@ import {
 } from "./glitter-context-refresh-openai.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
 import {
+  estimateStyleGenerationCost as estimateStyleGenerationCostInternal,
+  EXTRACTION_MAX_OUTPUT_TOKENS,
+  EXTRACTION_MODEL,
+  MAX_EXTRACTION_REPAIR_ATTEMPTS,
+  MAX_SYNTHESIS_REPAIR_ATTEMPTS,
+  SYNTHESIS_MAX_OUTPUT_TOKENS,
+  SYNTHESIS_MODEL,
+  SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+  type SummarizedChunk,
+} from "./glitter-context-refresh-style-generation-cost.ts";
+import {
   sanitizeChunkSummary,
   validateChunkSummary,
 } from "./glitter-context-refresh-style-validation.ts";
@@ -43,44 +53,23 @@ import {
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
 
-const EXTRACTION_MODEL = "gpt-5.6-luna";
-const SYNTHESIS_MODEL = "gpt-5.6-sol";
-const EXTRACTION_MAX_OUTPUT_TOKENS = 2000;
 // gpt-5.6-sol is a reasoning model at `reasoning_effort: "medium"`, so its
 // hidden reasoning tokens share `max_completion_tokens` with the (large) style
 // synthesis output. Observed live: reasoning + output crossed the former 15k cap
-// and truncated (finish_reason=length → unparseable → LengthFinishReasonError).
+// and truncated (finish_reason=length → unparseable).
 // 28k gives comfortable headroom over the observed ~15k usage; if a call still
 // truncates, it is retried once at the ceiling below.
-const SYNTHESIS_MAX_OUTPUT_TOKENS = 28_000;
-const SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 40_000;
+const SYNTHESIS_TRUNCATION_ERROR =
+  "GPT-5.6 Sol synthesis reached the completion-token limit";
 const DETERMINISTIC_SEED = 0;
 
-// gpt-5.6 sometimes emits an observation citing a message ID outside its
-// supplied evidence set. Because every completion is cached (immutably, keyed by
-// request hash) *before* validation, a fixed-seed retry re-reads the same
-// poisoned artifact and fails identically forever, so each repair attempt uses a
-// distinct seed (`DETERMINISTIC_SEED + attempt`) — a genuinely fresh,
-// cache-distinct model call, deterministic by attempt index (a re-run reuses the
-// first attempt that passed). Attempt 0 is the initial call (seed 0, stable
-// cache key); attempts 1..N are repairs.
+// Completions are cached before validation, so repairs use distinct seeds
+// (`DETERMINISTIC_SEED + attempt`) and cache keys. Attempt 0 is the initial call;
+// attempts 1..N are repairs, and a rerun reuses the first passing attempt.
 //
-// Repairs alone are not enough: for some chunks the model *deterministically*
-// cites an ID that appears inside message content (a reply/link/quote) but is
-// not a top-level chunk message, so every seed re-cites it. `sanitizeChunkSummary`
-// is the convergence guarantee — after the (few) repair attempts, unverifiable
-// evidence is dropped rather than failing the whole run (treating model output
-// as untrusted boundary input). Because sanitization guarantees a valid result,
-// the repair budget is kept small to bound spend on systematically-failing chunks.
-const MAX_EXTRACTION_REPAIR_ATTEMPTS = 2;
-const MAX_SYNTHESIS_REPAIR_ATTEMPTS = 3;
-
-type SummarizedChunk = {
-  key: string;
-  month: string;
-  summary: StyleChunkSummary;
-};
-
+// Sanitization is the convergence guarantee when a model repeatedly cites an ID
+// found inside content but not in the top-level chunk: unverifiable evidence is
+// dropped at the boundary instead of failing the run.
 function messageEvidence(message: CurrentMessage): {
   messageId: string;
   timestamp: string;
@@ -368,110 +357,83 @@ async function runSynthesis(input: {
   };
   const CompletionArtifactSchema =
     glitterCompletionArtifactSchema(StyleSynthesisSchema);
-  const artifact = await readOrCreateGenerationArtifact({
-    store: input.artifactStore,
-    model: SYNTHESIS_MODEL,
-    callSite,
-    request: {
-      schemaVersion: 3,
+  const createArtifact = async (
+    inputParams: typeof params,
+    inputCallSite: string,
+  ) =>
+    readOrCreateGenerationArtifact({
+      store: input.artifactStore,
       model: SYNTHESIS_MODEL,
-      messages,
-      maxCompletionTokens: params.max_completion_tokens,
-      reasoningEffort: params.reasoning_effort,
-      seed: params.seed,
-      responseSchema: "style-card-synthesis-v2",
-    },
-    responseSchema: CompletionArtifactSchema,
-    generate: async () => {
-      input.budget.authorizeUncachedCall(
-        estimatedCallCostUsd({
-          model: SYNTHESIS_MODEL,
-          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(params)),
-          outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-        }),
-      );
-      // Reasoning + output can still truncate at the base cap; retry once with a
-      // higher `max_completion_tokens` on a length finish before giving up.
-      const completion = await (async () => {
-        try {
-          return await parseGlitterCompletion(callSite, params);
-        } catch (error: unknown) {
-          if (!(error instanceof LengthFinishReasonError)) {
-            throw error;
-          }
-          return await parseGlitterCompletion(callSite, {
-            ...params,
-            max_completion_tokens: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-          });
-        }
-      })();
-      const message = completion.choices[0]?.message;
-      return glitterCompletionArtifact({
+      callSite: inputCallSite,
+      request: {
+        schemaVersion: 3,
         model: SYNTHESIS_MODEL,
-        parsed: message?.parsed,
-        rawContent: message?.content ?? null,
-        usage: completion.usage,
-        missingParsedError: `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
-      });
-    },
-  });
-  return useGlitterCompletionArtifact({
-    artifact,
-    budget: input.budget,
-  });
+        messages: inputParams.messages,
+        maxCompletionTokens: inputParams.max_completion_tokens,
+        truncationRetryMaxCompletionTokens:
+          SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+        reasoningEffort: inputParams.reasoning_effort,
+        seed: inputParams.seed,
+        responseSchema: "style-card-synthesis-v2",
+      },
+      responseSchema: CompletionArtifactSchema,
+      generate: async () => {
+        input.budget.authorizeUncachedCall(
+          estimatedCallCostUsd({
+            model: SYNTHESIS_MODEL,
+            inputTokenUpperBound: inputTokenUpperBound(
+              JSON.stringify(inputParams),
+            ),
+            outputTokenUpperBound: inputParams.max_completion_tokens,
+          }),
+        );
+        const completion = await parseGlitterCompletion(
+          inputCallSite,
+          inputParams,
+        );
+        const message = completion.choices[0]?.message;
+        return glitterCompletionArtifact({
+          model: SYNTHESIS_MODEL,
+          parsed: message?.parsed,
+          rawContent: message?.content ?? null,
+          usage: completion.usage,
+          ...(completion.choices[0]?.finish_reason === "length"
+            ? { failureError: SYNTHESIS_TRUNCATION_ERROR }
+            : {}),
+          missingParsedError: `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
+        });
+      },
+    });
+  const artifact = await createArtifact(params, callSite);
+  if (
+    artifact.response.outcome === "failure" &&
+    artifact.response.error === SYNTHESIS_TRUNCATION_ERROR
+  ) {
+    input.budget.record(artifact);
+    const retryParams = {
+      ...params,
+      max_completion_tokens: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    };
+    const retryArtifact = await createArtifact(
+      retryParams,
+      `${callSite}-truncation-retry`,
+    );
+    return useGlitterCompletionArtifact({
+      artifact: retryArtifact,
+      budget: input.budget,
+    });
+  }
+  return useGlitterCompletionArtifact({ artifact, budget: input.budget });
 }
 
 export function estimateStyleGenerationCost(input: {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
 }): number {
-  const chunks = buildStyleEvidenceChunks(input.candidate.safeMessages);
-  const extractionCost = chunks.reduce((total, chunk) => {
-    const prompt = chunkPrompt({ candidate: input.candidate, chunk });
-    const initialInputTokens = inputTokenUpperBound(prompt);
-    const initialCall = estimatedCallCostUsd({
-      model: EXTRACTION_MODEL,
-      inputTokenUpperBound: initialInputTokens,
-      outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
-    });
-    // Every repair attempt also serializes the prior summary (bounded by the
-    // output cap) and the validation error back into its request, so its input
-    // is larger than the initial call's.
-    const repairCall = estimatedCallCostUsd({
-      model: EXTRACTION_MODEL,
-      inputTokenUpperBound: initialInputTokens + EXTRACTION_MAX_OUTPUT_TOKENS,
-      outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
-    });
-    return total + initialCall + repairCall * MAX_EXTRACTION_REPAIR_ATTEMPTS;
-  }, 0);
-  const synthesisBase = synthesisPrompt({
-    candidate: input.candidate,
-    existingCard: input.existingCard,
-    chunks: [],
-    repair: null,
+  return estimateStyleGenerationCostInternal(input, {
+    chunkPrompt,
+    synthesisPrompt,
   });
-  const synthesisInputUpperBound =
-    inputTokenUpperBound(synthesisBase) +
-    chunks.length * EXTRACTION_MAX_OUTPUT_TOKENS;
-  // Worst-case output is the truncation-retry ceiling, not the base cap.
-  const synthesisInitialCall = estimatedCallCostUsd({
-    model: SYNTHESIS_MODEL,
-    inputTokenUpperBound: synthesisInputUpperBound,
-    outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-  });
-  // A synthesis repair likewise serializes the prior synthesis (bounded by the
-  // output ceiling) plus the error into its request.
-  const synthesisRepairCall = estimatedCallCostUsd({
-    model: SYNTHESIS_MODEL,
-    inputTokenUpperBound:
-      synthesisInputUpperBound + SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-    outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-  });
-  return (
-    extractionCost +
-    synthesisInitialCall +
-    synthesisRepairCall * MAX_SYNTHESIS_REPAIR_ATTEMPTS
-  );
 }
 
 export async function generateStyleCard(input: {

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -1,4 +1,5 @@
 import { zodResponseFormat } from "openai/helpers/zod";
+import { LengthFinishReasonError } from "openai/core/error";
 import { z } from "zod/v4";
 import {
   type StyleCard,
@@ -45,7 +46,14 @@ import {
 const EXTRACTION_MODEL = "gpt-5.6-luna";
 const SYNTHESIS_MODEL = "gpt-5.6-sol";
 const EXTRACTION_MAX_OUTPUT_TOKENS = 2000;
-const SYNTHESIS_MAX_OUTPUT_TOKENS = 15_000;
+// gpt-5.6-sol is a reasoning model at `reasoning_effort: "medium"`, so its
+// hidden reasoning tokens share `max_completion_tokens` with the (large) style
+// synthesis output. Observed live: reasoning + output crossed the former 15k cap
+// and truncated (finish_reason=length → unparseable → LengthFinishReasonError).
+// 28k gives comfortable headroom over the observed ~15k usage; if a call still
+// truncates, it is retried once at the ceiling below.
+const SYNTHESIS_MAX_OUTPUT_TOKENS = 28_000;
+const SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 40_000;
 const DETERMINISTIC_SEED = 0;
 
 // gpt-5.6 sometimes emits an observation citing a message ID outside its
@@ -379,10 +387,24 @@ async function runSynthesis(input: {
         estimatedCallCostUsd({
           model: SYNTHESIS_MODEL,
           inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(params)),
-          outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+          outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
         }),
       );
-      const completion = await parseGlitterCompletion(callSite, params);
+      // Reasoning + output can still truncate at the base cap; retry once with a
+      // higher `max_completion_tokens` on a length finish before giving up.
+      const completion = await (async () => {
+        try {
+          return await parseGlitterCompletion(callSite, params);
+        } catch (error: unknown) {
+          if (!(error instanceof LengthFinishReasonError)) {
+            throw error;
+          }
+          return await parseGlitterCompletion(callSite, {
+            ...params,
+            max_completion_tokens: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+          });
+        }
+      })();
       const message = completion.choices[0]?.message;
       return glitterCompletionArtifact({
         model: SYNTHESIS_MODEL,
@@ -431,18 +453,19 @@ export function estimateStyleGenerationCost(input: {
   const synthesisInputUpperBound =
     inputTokenUpperBound(synthesisBase) +
     chunks.length * EXTRACTION_MAX_OUTPUT_TOKENS;
+  // Worst-case output is the truncation-retry ceiling, not the base cap.
   const synthesisInitialCall = estimatedCallCostUsd({
     model: SYNTHESIS_MODEL,
     inputTokenUpperBound: synthesisInputUpperBound,
-    outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+    outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
   });
   // A synthesis repair likewise serializes the prior synthesis (bounded by the
-  // output cap) plus the error into its request.
+  // output ceiling) plus the error into its request.
   const synthesisRepairCall = estimatedCallCostUsd({
     model: SYNTHESIS_MODEL,
     inputTokenUpperBound:
-      synthesisInputUpperBound + SYNTHESIS_MAX_OUTPUT_TOKENS,
-    outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+      synthesisInputUpperBound + SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    outputTokenUpperBound: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
   });
   return (
     extractionCost +


### PR DESCRIPTION
## Why

With the extraction fixes (#1982 repair-loop, #1988 sanitize) deployed, a pinned
Glitter generation clears **all extraction** cleanly (zero citation errors) and
now dies in **synthesis** with `LengthFinishReasonError` (`finish_reason: length`
→ unparseable structured output).

LLM traces (`llm-archive`) confirm the cause: `gpt-5.6-sol` synthesis runs
**80–86k input tokens**, 4.7–7.6k output, at `reasoning_effort: "medium"`. Its
hidden **reasoning tokens + output share the 15k `max_completion_tokens` cap**,
and one attempt crossed it. The **same pinned snapshot + code succeeded on
2026-07-29**, so this is `sol` model drift since the cache was populated.

## What

- Raise `SYNTHESIS_MAX_OUTPUT_TOKENS` **15k → 28k** (comfortable headroom over the
  observed ~15k reasoning+output).
- Retry a synthesis call **once at a 40k ceiling** on `LengthFinishReasonError`
  (imported from `openai/core/error`).
- The preflight estimator and `budget.authorizeUncachedCall` use the 40k ceiling
  as the honest worst-case output bound.
- Test: a synthesis call that truncates at 28k succeeds on the 40k retry and the
  run completes.

## Probe note

This is deliberately a **probe** (per plan `2026-07-29_glitter-style-card-v2.md`).
The traces also show `glitter-style-synthesis-repair` calls — synthesis output is
*also* failing `finalizeStyleSynthesis` (the exact 20-quote/30-sample/18-example
contract) and going into repair loops. If, after this fix, synthesis converges
within finalize validation, Phase 1 completes. If it still fails the exact-count
contract, that confirms a deeper `sol` re-tune is needed (contract counts can't be
sanitized by dropping, unlike extraction evidence).

## Testing

- typecheck + lint clean; 10/10 generate tests, glitter cache/workflow/budget +
  workflow-bundle smoke all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
