### PR TITLE
fix(tasks-for-obsidian): preserve row divider contrast

### DIFF
--- a/packages/tasks-for-obsidian/e2e/README.md
+++ b/packages/tasks-for-obsidian/e2e/README.md
@@ -57,7 +57,7 @@ The chaos proxy is toggled from flows via `runScript` (GraalJS `http.post`)
 against `/__chaos/offline` and `/__chaos/online` on the proxy port itself;
 control endpoints keep working while "offline".
 
-## Current status (2026-08-07)
+## Current status
 
 The harness is **functional end-to-end**: it builds the app, boots the
 simulator, delivers config via the deep link, syncs the seeded vault, and

--- a/packages/tasks-for-obsidian/src/components/task/TaskRow.tsx
+++ b/packages/tasks-for-obsidian/src/components/task/TaskRow.tsx
@@ -83,7 +83,7 @@ export const TaskRow = React.memo(function TaskRowComponent({
         styles.row,
         {
           backgroundColor: colors.surface,
-          borderBottomColor: colors.borderLight,
+          borderBottomColor: colors.divider,
         },
       ]}
       onPress={onPress}


### PR DESCRIPTION
## Summary

- preserve task-row separator contrast after making rows opaque
- remove the timestamp from the stable E2E status heading

## Context

Follow-up to #2002 for two actionable post-merge review findings. The dark theme's `borderLight` token equals `surface`, so the divider disappeared once rows gained an opaque surface. The semantic `divider` token contrasts correctly in both themes.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run test` (306 passed)
- Prettier and `git diff --check`
- `bunx lefthook run pre-commit`
