### PR TITLE
fix(homelab): make memory and ZFS alerts durable

### DIFF
--- a/packages/docs/guides/2026-04-04_homelab-audit-runbook.md
+++ b/packages/docs/guides/2026-04-04_homelab-audit-runbook.md
@@ -115,6 +115,33 @@ toolkit gf query 'zfs_zpool_capacity_used_ratio'           # Pool utilization
 toolkit gf query 'node_zfs_arc_hits / (node_zfs_arc_hits + node_zfs_arc_misses)'   # ARC hit rate
 ```
 
+### ZFS maintenance workflow
+
+The weekly `zfs-maintenance-weekly` Temporal schedule discovers the managed
+`zfspv-pool-*` pools on each node's `zfs-zpool-collector` pod. Do not use
+`kubectl exec daemonset/...` for verification: the DaemonSet spans nodes with
+different pool inventories.
+
+```bash
+temporal schedule describe --schedule-id zfs-maintenance-weekly
+temporal workflow list --query "WorkflowType='runZfsMaintenanceWorkflow'"
+kubectl -n prometheus get pods -l app=zfs-zpool-collector -o wide
+toolkit gf query 'zfs_zpool_last_scrub_completion_timestamp'
+```
+
+For a failed or overdue run, select the Ready collector pod for the relevant
+node and inspect each pool it reports:
+
+```bash
+temporal workflow describe --workflow-id <WORKFLOW_ID>
+kubectl -n prometheus exec <COLLECTOR_POD> -c zfs-zpool-collector -- zpool list -H -o name
+kubectl -n prometheus exec <COLLECTOR_POD> -c zfs-zpool-collector -- zpool status <POOL>
+```
+
+An `ONLINE` pool with no known data errors is healthy but can still need a
+scrub. A zero `zfs_zpool_last_scrub_completion_timestamp` means no completed
+scrub has been recorded and is intentionally alertable.
+
 ### Velero Backups
 
 ```bash

--- a/packages/docs/plans/2026-08-08_memory-and-zfs-alert-remediation.md
+++ b/packages/docs/plans/2026-08-08_memory-and-zfs-alert-remediation.md
@@ -1,0 +1,45 @@
+---
+id: plan-2026-08-08-memory-and-zfs-alert-remediation
+type: plan
+status: in-progress
+board: false
+---
+
+# Durable memory and ZFS alert remediation
+
+## Context
+
+The `MemoryLeakSuspected` PagerDuty incident on `liskov` was a false positive:
+the PromQL `offset 24h` modifier applied only to the historical ZFS ARC selector,
+so a large ARC drop looked like non-ARC memory growth. The corrected expression
+must offset total memory, available memory, and ARC together.
+
+The weekly `runZfsMaintenanceWorkflow` failed on 2026-08-02 after selecting the
+`liskov` `zfs-zpool-collector` pod through `kubectl exec daemonset/...`. The
+activity assumed that pod also contained `zfspv-pool-hdd`, but that pool exists
+only on `torvalds`; the failure occurred before either node reached the scrub
+loop. The maintenance activity now discovers one Ready collector pod per node
+and only operates on that node's managed `zfspv-pool-*` inventory.
+
+## Changes
+
+- Correct and regression-test the memory alert expression.
+- Make ZFS maintenance pod- and pool-aware, with fail-fast errors carrying node,
+  pod, pool, and command context.
+- Treat a zero scrub timestamp as an alert condition so never-scrubbed pools are
+  visible instead of silently excluded.
+- Document per-node verification and the Temporal workflow failure mode in the
+  homelab runbook.
+
+## Verification
+
+- Focused Temporal and CDK8s tests and lint pass; CDK8s typecheck passes.
+- The Temporal package-wide typecheck remains blocked by pre-existing missing
+  `@shepherdjerred/glitter-context/schema` and `@shepherdjerred/llm-models`
+  workspace artifacts plus dependent Glitter errors; no changed-file errors
+  were reported.
+- Rendered Prometheus rules contain the corrected memory and ZFS expressions.
+- After the GitOps rollout, run the weekly workflow once, verify each node's
+  managed pools have current scrub timestamps and no ZFS errors, then wait for
+  Prometheus/Alertmanager to clear the incidents. This operator step is not part
+  of the repository-only implementation.

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts
@@ -91,3 +91,26 @@ describe("crypto-mining alerts", () => {
     expect(alert.labels?.["severity"]).toBe("critical");
   });
 });
+
+describe("memory leak alerts", () => {
+  it("applies the 24-hour offset to every historical memory and ARC selector", () => {
+    const groups = getResourceMonitoringRuleGroups();
+    const memoryGroup = groups.find(
+      (group) => group.name === "resource-memory-monitoring",
+    );
+    if (memoryGroup?.rules === undefined) {
+      throw new Error("expected resource-memory-monitoring rules");
+    }
+
+    const alert = memoryGroup.rules.find(
+      (rule) => rule.alert === "MemoryLeakSuspected",
+    );
+    if (alert === undefined) {
+      throw new Error("expected MemoryLeakSuspected alert");
+    }
+
+    expect(alert.expr.value).toBe(
+      "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes offset 24h - node_memory_MemAvailable_bytes offset 24h) - on(instance) group_left node_zfs_arc_size offset 24h) > 8589934592",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.test.ts
@@ -110,7 +110,12 @@ describe("memory leak alerts", () => {
     }
 
     expect(alert.expr.value).toBe(
-      "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes offset 24h - node_memory_MemAvailable_bytes offset 24h) - on(instance) group_left node_zfs_arc_size offset 24h) > 8589934592",
+      [
+        "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) ",
+        "group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes offset 24h - ",
+        "node_memory_MemAvailable_bytes offset 24h) - on(instance) group_left ",
+        "node_zfs_arc_size offset 24h) > 8589934592",
+      ].join(""),
     );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts
@@ -90,7 +90,7 @@ export function getResourceMonitoringRuleGroups(): PrometheusRuleSpecGroups[] {
             summary: "Potential memory leak detected",
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) group_left node_zfs_arc_size offset 24h) > 8589934592", // 8GB increase over 24h, excluding ZFS ARC cache
+            "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes offset 24h - node_memory_MemAvailable_bytes offset 24h) - on(instance) group_left node_zfs_arc_size offset 24h) > 8589934592", // 8GB increase over 24h, excluding ZFS ARC cache
           ),
           for: "4h",
           labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/resource-monitoring.ts
@@ -12,6 +12,13 @@ const NOT_CI_NODE = `node!="${CI_NODE_HOSTNAME}"`;
 // watch it (crypto-mining), we scope to it explicitly.
 const CI_NODE_ONLY = `node="${CI_NODE_HOSTNAME}"`;
 
+const memoryLeakExpression = [
+  "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) ",
+  "group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes offset 24h - ",
+  "node_memory_MemAvailable_bytes offset 24h) - on(instance) group_left ",
+  "node_zfs_arc_size offset 24h) > 8589934592",
+].join("");
+
 export function getResourceMonitoringRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     // CPU monitoring
@@ -89,8 +96,9 @@ export function getResourceMonitoringRuleGroups(): PrometheusRuleSpecGroups[] {
             ),
             summary: "Potential memory leak detected",
           },
+          // 8GB increase over 24h, excluding ZFS ARC cache.
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "((node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) - on(instance) group_left node_zfs_arc_size) - ((node_memory_MemTotal_bytes offset 24h - node_memory_MemAvailable_bytes offset 24h) - on(instance) group_left node_zfs_arc_size offset 24h) > 8589934592", // 8GB increase over 24h, excluding ZFS ARC cache
+            memoryLeakExpression,
           ),
           for: "4h",
           labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
@@ -18,7 +18,7 @@ describe("ZfsScrubOverdue", () => {
     expect(alert.expr.value).toBe(
       [
         "(time() - zfs_zpool_last_scrub_completion_timestamp > 777600) and ",
-        "on(zpool_name) (zfs_zpool_scan_state != 1)",
+        "on(instance, zpool_name) (zfs_zpool_scan_state != 1)",
       ].join(""),
     );
   });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { getZfsMaintenanceRuleGroups } from "./zfs-maintenance.ts";
+
+describe("ZfsScrubOverdue", () => {
+  it("fires for pools that have never recorded a completed scrub or are overdue", () => {
+    const group = getZfsMaintenanceRuleGroups().find(
+      (candidate) => candidate.name === "zfs-maintenance",
+    );
+    if (group?.rules === undefined) {
+      throw new Error("expected zfs-maintenance rules");
+    }
+
+    const alert = group.rules.find((rule) => rule.alert === "ZfsScrubOverdue");
+    if (alert === undefined) {
+      throw new Error("expected ZfsScrubOverdue alert");
+    }
+
+    expect(alert.expr.value).toBe(
+      "zfs_zpool_last_scrub_completion_timestamp == 0 or (time() - zfs_zpool_last_scrub_completion_timestamp) > 777600",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
@@ -16,7 +16,10 @@ describe("ZfsScrubOverdue", () => {
     }
 
     expect(alert.expr.value).toBe(
-      "time() - zfs_zpool_last_scrub_completion_timestamp > 777600",
+      [
+        "(time() - zfs_zpool_last_scrub_completion_timestamp > 777600) and ",
+        "on(zpool_name) (zfs_zpool_scan_state != 1)",
+      ].join(""),
     );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.test.ts
@@ -16,7 +16,7 @@ describe("ZfsScrubOverdue", () => {
     }
 
     expect(alert.expr.value).toBe(
-      "zfs_zpool_last_scrub_completion_timestamp == 0 or (time() - zfs_zpool_last_scrub_completion_timestamp) > 777600",
+      "time() - zfs_zpool_last_scrub_completion_timestamp > 777600",
     );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
@@ -56,11 +56,11 @@ export function getZfsMaintenanceRuleGroups(): PrometheusRuleSpecGroups[] {
               "ZFS scrub overdue on {{ $labels.zpool_name }}",
             ),
             description: escapePrometheusTemplate(
-              "ZFS pool {{ $labels.zpool_name }} has not been scrubbed in over 9 days. The weekly Temporal maintenance workflow may have failed.",
+              "ZFS pool {{ $labels.zpool_name }} has never completed a scrub or has not been scrubbed in over 9 days. The weekly Temporal maintenance workflow may have failed.",
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "zfs_zpool_last_scrub_completion_timestamp > 0 and (time() - zfs_zpool_last_scrub_completion_timestamp) > 777600",
+            "zfs_zpool_last_scrub_completion_timestamp == 0 or (time() - zfs_zpool_last_scrub_completion_timestamp) > 777600",
           ),
           for: "1h",
           labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
@@ -4,7 +4,7 @@ import { escapePrometheusTemplate } from "./shared.ts";
 
 const zfsScrubOverdueExpression = [
   "(time() - zfs_zpool_last_scrub_completion_timestamp > 777600) and ",
-  "on(zpool_name) (zfs_zpool_scan_state != 1)",
+  "on(instance, zpool_name) (zfs_zpool_scan_state != 1)",
 ].join("");
 
 export function getZfsMaintenanceRuleGroups(): PrometheusRuleSpecGroups[] {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
@@ -60,7 +60,7 @@ export function getZfsMaintenanceRuleGroups(): PrometheusRuleSpecGroups[] {
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "zfs_zpool_last_scrub_completion_timestamp == 0 or (time() - zfs_zpool_last_scrub_completion_timestamp) > 777600",
+            "time() - zfs_zpool_last_scrub_completion_timestamp > 777600",
           ),
           for: "1h",
           labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/zfs-maintenance.ts
@@ -2,6 +2,11 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
 
+const zfsScrubOverdueExpression = [
+  "(time() - zfs_zpool_last_scrub_completion_timestamp > 777600) and ",
+  "on(zpool_name) (zfs_zpool_scan_state != 1)",
+].join("");
+
 export function getZfsMaintenanceRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     {
@@ -60,7 +65,7 @@ export function getZfsMaintenanceRuleGroups(): PrometheusRuleSpecGroups[] {
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            "time() - zfs_zpool_last_scrub_completion_timestamp > 777600",
+            zfsScrubOverdueExpression,
           ),
           for: "1h",
           labels: {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/zfs-zpool.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/zfs-zpool.ts
@@ -66,6 +66,11 @@ export async function createZfsZpoolMonitoring(chart: Chart) {
       },
     },
     serviceAccount,
+    podMetadata: {
+      labels: {
+        app: "zfs-zpool-collector",
+      },
+    },
     securityContext: {
       ensureNonRoot: false,
       fsGroup: 0,

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -122,10 +122,9 @@ function createTemporalWorkerMaintenanceRbac(
   chart: Chart,
   serviceAccount: ServiceAccount,
 ) {
-  // Namespace-scoped RBAC for the ZFS maintenance workflow, which execs into
-  // the zfs-zpool-collector DaemonSet pod in the prometheus namespace.
-  // `kubectl exec daemonset/<name>` resolves the daemonset → pod via a
-  // GET on daemonsets.apps before opening the exec stream.
+  // Namespace-scoped RBAC for the ZFS maintenance workflow, which lists the
+  // zfs-zpool-collector pods and execs into one Running and Ready pod per node
+  // in the prometheus namespace.
   new KubeRole(chart, "temporal-worker-zfs-exec", {
     metadata: { name: "temporal-worker-zfs-exec", namespace: "prometheus" },
     rules: [
@@ -138,11 +137,6 @@ function createTemporalWorkerMaintenanceRbac(
         apiGroups: [""],
         resources: ["pods"],
         verbs: ["get", "list"],
-      },
-      {
-        apiGroups: ["apps"],
-        resources: ["daemonsets"],
-        verbs: ["get"],
       },
     ],
   });

--- a/packages/temporal/src/activities/bugsink.ts
+++ b/packages/temporal/src/activities/bugsink.ts
@@ -1,5 +1,6 @@
 import { Context } from "@temporalio/activity";
 import * as k8s from "@kubernetes/client-node";
+import { kubectlExecInPod } from "#shared/kubectl-exec.ts";
 
 const NAMESPACE = "bugsink";
 const CONTAINER = "bugsink";
@@ -35,7 +36,12 @@ export const bugsinkHousekeepingActivities = {
       // heartbeatTimeout: "90 seconds" in workflows/bugsink.ts. SDK
       // throttles transmission to 80% of timeout automatically.
       Context.current().heartbeat({ command: command.join(" ") });
-      const out = await kubectlExec(podName, command);
+      const out = await kubectlExecInPod({
+        namespace: NAMESPACE,
+        container: CONTAINER,
+        pod: podName,
+        command,
+      });
       const trimmed = out.trim();
       results.push(`${command.join(" ")}: ${trimmed === "" ? "ok" : trimmed}`);
     }
@@ -61,36 +67,3 @@ async function findRunningBugsinkPod(): Promise<string> {
 // ErrorEvent objects under Bun (the library targets Node's `ws` shim, which
 // Bun doesn't replicate exactly). Pod discovery via the HTTP API still works
 // and is kept above.
-async function kubectlExec(
-  podName: string,
-  command: string[],
-): Promise<string> {
-  const args = [
-    "kubectl",
-    "exec",
-    "--namespace",
-    NAMESPACE,
-    "--container",
-    CONTAINER,
-    podName,
-    "--",
-    ...command,
-  ];
-  const proc = Bun.spawn(args, {
-    stdin: "ignore",
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  if (exitCode !== 0) {
-    const detail = stderr.trim() || stdout.trim() || "(no output)";
-    throw new Error(
-      `kubectl exec [${command.join(" ")}] in ${NAMESPACE}/${podName} exited ${String(exitCode)}: ${detail}`,
-    );
-  }
-  return stdout;
-}

--- a/packages/temporal/src/activities/velero-orphan-audit.ts
+++ b/packages/temporal/src/activities/velero-orphan-audit.ts
@@ -11,6 +11,12 @@ import {
   veleroOrphanLocalSnapshotsTotal,
   zfsDatasetSnapshotCount,
 } from "#observability/metrics.ts";
+import {
+  selectRunningReadyNodePods,
+  type KubernetesNodePod,
+  type KubernetesNodePodCandidate,
+} from "#shared/kubernetes-node-pods.ts";
+import { kubectlExecInPod } from "#shared/kubectl-exec.ts";
 
 // The audit detects ZFS snapshots on PVC datasets whose name does not match
 // any live `velero.io/v1/Backup` CR. Such snapshots are orphans from a prior
@@ -39,26 +45,7 @@ export type VeleroOrphanDataset = {
   liveCount: number;
 };
 
-type ZfsNodePod = {
-  node: string;
-  pod: string;
-};
-
-type ZfsNodePodCandidate = {
-  metadata?: {
-    name?: string;
-  };
-  spec?: {
-    nodeName?: string;
-  };
-  status?: {
-    phase?: string;
-    conditions?: {
-      type: string;
-      status: string;
-    }[];
-  };
-};
+type ZfsNodePod = KubernetesNodePod;
 
 export type VeleroOrphanAuditResult = {
   liveBackupCount: number;
@@ -191,39 +178,13 @@ async function findZfsNodePods(): Promise<ZfsNodePod[]> {
 }
 
 export function selectZfsNodePods(
-  pods: readonly ZfsNodePodCandidate[],
+  pods: readonly KubernetesNodePodCandidate[],
 ): ZfsNodePod[] {
-  const nodePods = new Map<string, string>();
-  for (const pod of pods) {
-    const isReady = pod.status?.conditions?.some(
-      (condition) => condition.type === "Ready" && condition.status === "True",
-    );
-    if (isReady !== true || pod.status?.phase !== "Running") {
-      continue;
-    }
-    const name = pod.metadata?.name;
-    const node = pod.spec?.nodeName;
-    if (name === undefined || node === undefined) {
-      throw new Error(
-        "Running and Ready openebs-zfs-localpv-node pod is missing metadata.name or spec.nodeName",
-      );
-    }
-    const existingPod = nodePods.get(node);
-    if (existingPod !== undefined) {
-      throw new Error(
-        `Multiple Running and Ready openebs-zfs-localpv-node pods found for node ${node}: ${existingPod}, ${name}`,
-      );
-    }
-    nodePods.set(node, name);
-  }
-  if (nodePods.size === 0) {
-    throw new Error(
-      `No Running and Ready openebs-zfs-localpv-node pods found in ${NAMESPACE_OPENEBS} (label selector: ${ZFS_NODE_LABEL})`,
-    );
-  }
-  return [...nodePods.entries()]
-    .map(([node, pod]) => ({ node, pod }))
-    .toSorted((left, right) => left.node.localeCompare(right.node));
+  return selectRunningReadyNodePods(pods, {
+    namespace: NAMESPACE_OPENEBS,
+    labelSelector: ZFS_NODE_LABEL,
+    resourceDescription: "openebs-zfs-localpv-node",
+  });
 }
 
 async function listZfsOrphanSnapshots(
@@ -372,34 +333,10 @@ export function parseZfsInventory(
 }
 
 async function execInPod(podName: string, command: string): Promise<string> {
-  const args = [
-    "kubectl",
-    "exec",
-    "-n",
-    NAMESPACE_OPENEBS,
-    "-c",
-    ZFS_NODE_CONTAINER,
-    podName,
-    "--",
-    "sh",
-    "-c",
+  return kubectlExecInPod({
+    namespace: NAMESPACE_OPENEBS,
+    container: ZFS_NODE_CONTAINER,
+    pod: podName,
     command,
-  ];
-  const proc = Bun.spawn(args, {
-    stdin: "ignore",
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  if (exitCode !== 0) {
-    const detail = stderr.trim() || stdout.trim() || "(no output)";
-    throw new Error(
-      `kubectl exec [${command}] in ${NAMESPACE_OPENEBS}/${podName} exited ${String(exitCode)}: ${detail}`,
-    );
-  }
-  return stdout;
 }

--- a/packages/temporal/src/activities/zfs-maintenance.test.ts
+++ b/packages/temporal/src/activities/zfs-maintenance.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "bun:test";
+import {
+  parseManagedZfsPools,
+  runZfsMaintenanceWithDependencies,
+  selectZfsCollectorPods,
+  type ZfsCollectorPodCandidate,
+  type ZfsMaintenanceDependencies,
+} from "./zfs-maintenance.ts";
+
+function readyPod(node: string, pod: string): ZfsCollectorPodCandidate {
+  return {
+    metadata: { name: pod },
+    spec: { nodeName: node },
+    status: {
+      phase: "Running",
+      conditions: [{ type: "Ready", status: "True" }],
+    },
+  };
+}
+
+function dependenciesFor(
+  pods: readonly ZfsCollectorPodCandidate[],
+  execute: ZfsMaintenanceDependencies["execInPod"],
+  heartbeat: ZfsMaintenanceDependencies["heartbeat"] = (details) => {
+    expect(details.phase).toBeDefined();
+  },
+): ZfsMaintenanceDependencies {
+  return {
+    listCollectorPods: async () => pods,
+    execInPod: execute,
+    heartbeat,
+  };
+}
+
+describe("selectZfsCollectorPods", () => {
+  it("returns one Running and Ready collector per node in stable order", () => {
+    expect(
+      selectZfsCollectorPods([
+        readyPod("torvalds", "zfs-torvalds"),
+        readyPod("liskov", "zfs-liskov"),
+        {
+          metadata: { name: "zfs-pending" },
+          spec: { nodeName: "ignored" },
+          status: {
+            phase: "Pending",
+            conditions: [{ type: "Ready", status: "False" }],
+          },
+        },
+      ]),
+    ).toEqual([
+      { node: "liskov", pod: "zfs-liskov" },
+      { node: "torvalds", pod: "zfs-torvalds" },
+    ]);
+  });
+
+  it("fails on duplicate Ready collectors for one node", () => {
+    expect(() =>
+      selectZfsCollectorPods([
+        readyPod("torvalds", "zfs-a"),
+        readyPod("torvalds", "zfs-b"),
+      ]),
+    ).toThrow("Multiple Running and Ready");
+  });
+
+  it("fails when no collector is Running and Ready", () => {
+    expect(() => selectZfsCollectorPods([])).toThrow(
+      "No Running and Ready zfs-zpool-collector pods",
+    );
+  });
+
+  it("fails when a Ready collector lacks node identity", () => {
+    expect(() =>
+      selectZfsCollectorPods([
+        {
+          metadata: { name: "zfs-collector" },
+          status: {
+            phase: "Running",
+            conditions: [{ type: "Ready", status: "True" }],
+          },
+        },
+      ]),
+    ).toThrow("missing metadata.name or spec.nodeName");
+  });
+});
+
+describe("parseManagedZfsPools", () => {
+  it("filters unmanaged pools and sorts managed pools", () => {
+    expect(
+      parseManagedZfsPools("zfspv-pool-nvme\nrpool\nzfspv-pool-hdd\n", {
+        node: "torvalds",
+        pod: "zfs-torvalds",
+      }),
+    ).toEqual(["zfspv-pool-hdd", "zfspv-pool-nvme"]);
+  });
+
+  it("fails when a node has no managed pools", () => {
+    expect(() =>
+      parseManagedZfsPools("rpool\n", { node: "liskov", pod: "zfs-liskov" }),
+    ).toThrow("No managed ZFS pools");
+  });
+
+  it("rejects pool names that cannot safely be passed to the shell", () => {
+    expect(() =>
+      parseManagedZfsPools("zfspv-pool-nvme; rm -rf /\n", {
+        node: "torvalds",
+        pod: "zfs-torvalds",
+      }),
+    ).toThrow("Invalid ZFS pool name");
+  });
+});
+
+describe("runZfsMaintenanceWithDependencies", () => {
+  it("includes node and pool details in heartbeats and results", async () => {
+    const heartbeats: Parameters<ZfsMaintenanceDependencies["heartbeat"]>[0][] =
+      [];
+    const deps = dependenciesFor(
+      [readyPod("liskov", "zfs-liskov")],
+      async (_pod, command) => {
+        if (command === "zpool list -H -o name") {
+          return "zfspv-pool-nvme\n";
+        }
+        if (command.startsWith("zpool status")) {
+          return "state: ONLINE\n";
+        }
+        return "";
+      },
+      (details) => {
+        heartbeats.push(details);
+      },
+    );
+
+    const result = await runZfsMaintenanceWithDependencies(deps);
+
+    expect(heartbeats).toContainEqual({
+      phase: "autotrim",
+      node: "liskov",
+      pod: "zfs-liskov",
+      pool: "zfspv-pool-nvme",
+    });
+    expect(result).toContain("liskov/zfspv-pool-nvme");
+  });
+
+  it("routes each node's discovered pools to its own collector pod", async () => {
+    const calls: { node: string; command: string }[] = [];
+    const deps = dependenciesFor(
+      [readyPod("torvalds", "zfs-torvalds"), readyPod("liskov", "zfs-liskov")],
+      async (pod, command) => {
+        calls.push({ node: pod.node, command });
+        if (command === "zpool list -H -o name") {
+          return pod.node === "liskov"
+            ? "zfspv-pool-nvme\n"
+            : "zfspv-pool-hdd\nzfspv-pool-nvme\n";
+        }
+        if (command.startsWith("zpool status")) {
+          return "state: ONLINE\n";
+        }
+        return "";
+      },
+    );
+
+    const result = await runZfsMaintenanceWithDependencies(deps);
+
+    expect(result).toContain("liskov/zfspv-pool-nvme");
+    expect(result).toContain("torvalds/zfspv-pool-hdd");
+    expect(result).toContain("torvalds/zfspv-pool-nvme");
+    expect(
+      calls.filter(
+        ({ node, command }) =>
+          node === "liskov" && command.includes("zfspv-pool-hdd"),
+      ),
+    ).toEqual([]);
+    expect(
+      calls.filter(
+        ({ node, command }) =>
+          node === "torvalds" && command.includes("zfspv-pool-hdd"),
+      ).length,
+    ).toBe(3);
+  });
+
+  it("does not start a scrub that is already in progress", async () => {
+    const commands: string[] = [];
+    const deps = dependenciesFor(
+      [readyPod("torvalds", "zfs-torvalds")],
+      async (_pod, command) => {
+        commands.push(command);
+        if (command === "zpool list -H -o name") {
+          return "zfspv-pool-nvme\n";
+        }
+        if (command.startsWith("zpool status")) {
+          return "scan: scrub in progress\n";
+        }
+        return "";
+      },
+    );
+
+    const result = await runZfsMaintenanceWithDependencies(deps);
+
+    expect(result).toContain("already in progress, skipped");
+    expect(commands).not.toContain("zpool scrub zfspv-pool-nvme");
+  });
+
+  it("includes node, pool, and command context when a command fails", async () => {
+    const deps = dependenciesFor(
+      [readyPod("torvalds", "zfs-torvalds")],
+      async (_pod, command) => {
+        if (command === "zpool list -H -o name") {
+          return "zfspv-pool-nvme\n";
+        }
+        throw new Error("permission denied");
+      },
+    );
+
+    await expect(runZfsMaintenanceWithDependencies(deps)).rejects.toThrow(
+      "ZFS maintenance command failed: node=torvalds, pod=zfs-torvalds, pool=zfspv-pool-nvme, command=zpool set autotrim=on zfspv-pool-nvme",
+    );
+  });
+});

--- a/packages/temporal/src/activities/zfs-maintenance.test.ts
+++ b/packages/temporal/src/activities/zfs-maintenance.test.ts
@@ -24,8 +24,12 @@ function dependenciesFor(
   heartbeat: ZfsMaintenanceDependencies["heartbeat"] = (details) => {
     expect(details.phase).toBeDefined();
   },
+  nodes: readonly string[] = pods.flatMap((pod) =>
+    pod.spec?.nodeName === undefined ? [] : [pod.spec.nodeName],
+  ),
 ): ZfsMaintenanceDependencies {
   return {
+    listClusterNodes: async () => nodes,
     listCollectorPods: async () => pods,
     execInPod: execute,
     heartbeat,
@@ -74,6 +78,19 @@ describe("selectZfsCollectorPods", () => {
         },
       ]),
     ).toThrow("exactly one Running and Ready");
+  });
+
+  it("fails when a collector pod is absent for a cluster node", async () => {
+    const deps = dependenciesFor(
+      [readyPod("torvalds", "zfs-torvalds")],
+      async () => "",
+      undefined,
+      ["torvalds", "liskov"],
+    );
+
+    await expect(runZfsMaintenanceWithDependencies(deps)).rejects.toThrow(
+      "node liskov",
+    );
   });
 
   it("fails when a Ready collector lacks node identity", () => {

--- a/packages/temporal/src/activities/zfs-maintenance.test.ts
+++ b/packages/temporal/src/activities/zfs-maintenance.test.ts
@@ -38,14 +38,6 @@ describe("selectZfsCollectorPods", () => {
       selectZfsCollectorPods([
         readyPod("torvalds", "zfs-torvalds"),
         readyPod("liskov", "zfs-liskov"),
-        {
-          metadata: { name: "zfs-pending" },
-          spec: { nodeName: "ignored" },
-          status: {
-            phase: "Pending",
-            conditions: [{ type: "Ready", status: "False" }],
-          },
-        },
       ]),
     ).toEqual([
       { node: "liskov", pod: "zfs-liskov" },
@@ -66,6 +58,22 @@ describe("selectZfsCollectorPods", () => {
     expect(() => selectZfsCollectorPods([])).toThrow(
       "No Running and Ready zfs-zpool-collector pods",
     );
+  });
+
+  it("fails when a collector node has no Ready pod", () => {
+    expect(() =>
+      selectZfsCollectorPods([
+        readyPod("torvalds", "zfs-torvalds"),
+        {
+          metadata: { name: "zfs-pending" },
+          spec: { nodeName: "liskov" },
+          status: {
+            phase: "Pending",
+            conditions: [{ type: "Ready", status: "False" }],
+          },
+        },
+      ]),
+    ).toThrow("exactly one Running and Ready");
   });
 
   it("fails when a Ready collector lacks node identity", () => {
@@ -211,7 +219,10 @@ describe("runZfsMaintenanceWithDependencies", () => {
     );
 
     await expect(runZfsMaintenanceWithDependencies(deps)).rejects.toThrow(
-      "ZFS maintenance command failed: node=torvalds, pod=zfs-torvalds, pool=zfspv-pool-nvme, command=zpool set autotrim=on zfspv-pool-nvme",
+      [
+        "ZFS maintenance command failed: node=torvalds, pod=zfs-torvalds, ",
+        "pool=zfspv-pool-nvme, command=zpool set autotrim=on zfspv-pool-nvme",
+      ].join(""),
     );
   });
 });

--- a/packages/temporal/src/activities/zfs-maintenance.ts
+++ b/packages/temporal/src/activities/zfs-maintenance.ts
@@ -1,74 +1,214 @@
 import { Context } from "@temporalio/activity";
+import * as k8s from "@kubernetes/client-node";
+import { selectRunningReadyNodePods } from "#shared/kubernetes-node-pods.ts";
+import { kubectlExecInPod } from "#shared/kubectl-exec.ts";
 
-// Daemonset name in the prometheus namespace. The pod has only cdk8s-generated
-// labels (cdk8s.io/metadata.addr=apps-zfs-zpool-collector-<hash>), so we cannot
-// select by `app=zfs-zpool-collector`. `kubectl exec daemonset/<name>` resolves
-// to the daemonset's pod directly and is stable across pod-template-generation
-// rollouts.
 const NAMESPACE = "prometheus";
-const TARGET = "daemonset/zfs-zpool-collector";
-const POOLS = ["zfspv-pool-nvme", "zfspv-pool-hdd"] as const;
+const ZFS_COLLECTOR_LABEL = "app=zfs-zpool-collector";
+const ZFS_COLLECTOR_CONTAINER = "zfs-zpool-collector";
+const MANAGED_POOL_PREFIX = "zfspv-pool-";
+
+export type ZfsCollectorPod = {
+  node: string;
+  pod: string;
+};
+
+export type ZfsCollectorPodCandidate = {
+  metadata?: { name?: string };
+  spec?: { nodeName?: string };
+  status?: {
+    phase?: string;
+    conditions?: { type?: string; status?: string }[];
+  };
+};
+
+type ZfsMaintenancePhase = "discover" | "autotrim" | "scrub";
+
+type ZfsMaintenanceHeartbeat = (details: {
+  phase: ZfsMaintenancePhase;
+  node: string;
+  pod: string;
+  pool?: string;
+}) => void;
+
+export type ZfsMaintenanceDependencies = {
+  listCollectorPods: () => Promise<readonly ZfsCollectorPodCandidate[]>;
+  execInPod: (pod: ZfsCollectorPod, command: string) => Promise<string>;
+  heartbeat: ZfsMaintenanceHeartbeat;
+};
 
 export type ZfsMaintenanceActivities = typeof zfsMaintenanceActivities;
 
 export const zfsMaintenanceActivities = {
   async runZfsMaintenance(): Promise<string> {
-    const results: string[] = [];
-
-    // Enable autotrim (idempotent; NVMe supports TRIM, HDD setting is a no-op)
-    for (const pool of POOLS) {
-      Context.current().heartbeat({ phase: "autotrim", pool });
-      const out = await execInPod(`zpool set autotrim=on ${pool}`);
-      results.push(
-        `autotrim ${pool}: ${out.trim() === "" ? "ok" : out.trim()}`,
-      );
-    }
-
-    // Start scrub only if one is not already in progress
-    for (const pool of POOLS) {
-      Context.current().heartbeat({ phase: "scrub", pool });
-      const status = await execInPod(`zpool status ${pool}`);
-      if (status.includes("scrub in progress")) {
-        results.push(`scrub ${pool}: already in progress, skipped`);
-      } else {
-        const out = await execInPod(`zpool scrub ${pool}`);
-        results.push(
-          `scrub ${pool}: initiated (${out.trim() === "" ? "ok" : out.trim()})`,
-        );
-      }
-    }
-
-    return results.join("\n");
+    return runZfsMaintenanceWithDependencies({
+      listCollectorPods: findZfsCollectorPods,
+      execInPod: (pod, command) =>
+        kubectlExecInPod({
+          namespace: NAMESPACE,
+          container: ZFS_COLLECTOR_CONTAINER,
+          pod: pod.pod,
+          command,
+        }),
+      heartbeat: (details) => {
+        Context.current().heartbeat(details);
+      },
+    });
   },
 };
 
-async function execInPod(command: string): Promise<string> {
-  const args = [
-    "kubectl",
-    "exec",
-    "-n",
-    NAMESPACE,
-    TARGET,
-    "--",
-    "sh",
-    "-c",
-    command,
-  ];
-  const proc = Bun.spawn(args, {
-    stdin: "ignore",
-    stdout: "pipe",
-    stderr: "pipe",
+export async function runZfsMaintenanceWithDependencies(
+  dependencies: ZfsMaintenanceDependencies,
+): Promise<string> {
+  const candidates = await dependencies.listCollectorPods();
+  const nodePods = selectZfsCollectorPods(candidates);
+  const results: string[] = [];
+
+  for (const nodePod of nodePods) {
+    dependencies.heartbeat({
+      phase: "discover",
+      node: nodePod.node,
+      pod: nodePod.pod,
+    });
+    const inventory = await runCommand(
+      dependencies,
+      nodePod,
+      "zpool list -H -o name",
+    );
+    const pools = parseManagedZfsPools(inventory, nodePod);
+
+    for (const pool of pools) {
+      dependencies.heartbeat({
+        phase: "autotrim",
+        node: nodePod.node,
+        pod: nodePod.pod,
+        pool,
+      });
+      const autotrimOutput = await runCommand(
+        dependencies,
+        nodePod,
+        `zpool set autotrim=on ${pool}`,
+        pool,
+      );
+
+      dependencies.heartbeat({
+        phase: "scrub",
+        node: nodePod.node,
+        pod: nodePod.pod,
+        pool,
+      });
+      const status = await runCommand(
+        dependencies,
+        nodePod,
+        `zpool status ${pool}`,
+        pool,
+      );
+      let scrubOutput: string;
+      if (status.includes("scrub in progress")) {
+        scrubOutput = "already in progress, skipped";
+      } else {
+        const scrubCommandOutput = await runCommand(
+          dependencies,
+          nodePod,
+          `zpool scrub ${pool}`,
+          pool,
+        );
+        scrubOutput = `initiated (${scrubCommandOutput.trim() || "ok"})`;
+      }
+      results.push(
+        `${nodePod.node}/${pool}: autotrim ${autotrimOutput.trim() || "ok"}; scrub ${scrubOutput}`,
+      );
+    }
+  }
+
+  return results.join("\n");
+}
+
+export function selectZfsCollectorPods(
+  pods: readonly ZfsCollectorPodCandidate[],
+): ZfsCollectorPod[] {
+  return selectRunningReadyNodePods(pods, {
+    namespace: NAMESPACE,
+    labelSelector: ZFS_COLLECTOR_LABEL,
+    resourceDescription: "zfs-zpool-collector",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  if (exitCode !== 0) {
-    const detail = stderr.trim() || stdout.trim() || "(no output)";
+}
+
+export function parseManagedZfsPools(
+  inventory: string,
+  nodePod: ZfsCollectorPod,
+): string[] {
+  const pools = inventory
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const managedPools = pools.filter((pool) =>
+    pool.startsWith(MANAGED_POOL_PREFIX),
+  );
+  for (const pool of managedPools) {
+    if (!/^\w[\w.-]*$/.test(pool)) {
+      throw new Error(
+        `Invalid ZFS pool name from ${nodePod.node}/${nodePod.pod}: ${pool}`,
+      );
+    }
+  }
+
+  if (managedPools.length === 0) {
     throw new Error(
-      `zfs command "${command}" exited ${String(exitCode)}: ${detail}`,
+      `No managed ZFS pools (${MANAGED_POOL_PREFIX}*) found on ${nodePod.node}/${nodePod.pod}`,
     );
   }
-  return stdout;
+  return managedPools.toSorted();
+}
+
+async function findZfsCollectorPods(): Promise<ZfsCollectorPodCandidate[]> {
+  const kc = new k8s.KubeConfig();
+  kc.loadFromCluster();
+  const response = await kc.makeApiClient(k8s.CoreV1Api).listNamespacedPod({
+    namespace: NAMESPACE,
+    labelSelector: ZFS_COLLECTOR_LABEL,
+  });
+  return response.items.map((pod) => {
+    const candidate: ZfsCollectorPodCandidate = {};
+    if (pod.metadata?.name !== undefined) {
+      candidate.metadata = { name: pod.metadata.name };
+    }
+    if (pod.spec?.nodeName !== undefined) {
+      candidate.spec = { nodeName: pod.spec.nodeName };
+    }
+    if (pod.status !== undefined) {
+      candidate.status = {};
+      if (pod.status.phase !== undefined) {
+        candidate.status.phase = pod.status.phase;
+      }
+      if (pod.status.conditions !== undefined) {
+        candidate.status.conditions = pod.status.conditions.map(
+          ({ type, status }) => ({
+            type,
+            status,
+          }),
+        );
+      }
+    }
+    return candidate;
+  });
+}
+
+async function runCommand(
+  dependencies: ZfsMaintenanceDependencies,
+  nodePod: ZfsCollectorPod,
+  command: string,
+  pool?: string,
+): Promise<string> {
+  try {
+    return await dependencies.execInPod(nodePod, command);
+  } catch (error) {
+    throw new Error(
+      `ZFS maintenance command failed: node=${nodePod.node}, pod=${nodePod.pod}, pool=${pool ?? "unknown"}, command=${command}`,
+      {
+        cause: error,
+      },
+    );
+  }
 }

--- a/packages/temporal/src/activities/zfs-maintenance.ts
+++ b/packages/temporal/src/activities/zfs-maintenance.ts
@@ -32,6 +32,7 @@ type ZfsMaintenanceHeartbeat = (details: {
 }) => void;
 
 export type ZfsMaintenanceDependencies = {
+  listClusterNodes: () => Promise<readonly string[]>;
   listCollectorPods: () => Promise<readonly ZfsCollectorPodCandidate[]>;
   execInPod: (pod: ZfsCollectorPod, command: string) => Promise<string>;
   heartbeat: ZfsMaintenanceHeartbeat;
@@ -42,6 +43,7 @@ export type ZfsMaintenanceActivities = typeof zfsMaintenanceActivities;
 export const zfsMaintenanceActivities = {
   async runZfsMaintenance(): Promise<string> {
     return runZfsMaintenanceWithDependencies({
+      listClusterNodes: findKubernetesNodes,
       listCollectorPods: findZfsCollectorPods,
       execInPod: (pod, command) =>
         kubectlExecInPod({
@@ -60,8 +62,9 @@ export const zfsMaintenanceActivities = {
 export async function runZfsMaintenanceWithDependencies(
   dependencies: ZfsMaintenanceDependencies,
 ): Promise<string> {
+  const nodes = await dependencies.listClusterNodes();
   const candidates = await dependencies.listCollectorPods();
-  const nodePods = selectZfsCollectorPods(candidates);
+  const nodePods = selectZfsCollectorPods(candidates, nodes);
   const results: string[] = [];
 
   for (const nodePod of nodePods) {
@@ -126,13 +129,18 @@ export async function runZfsMaintenanceWithDependencies(
 
 export function selectZfsCollectorPods(
   pods: readonly ZfsCollectorPodCandidate[],
+  expectedNodes?: readonly string[],
 ): ZfsCollectorPod[] {
-  return selectRunningReadyNodePods(pods, {
+  const context = {
     namespace: NAMESPACE,
     labelSelector: ZFS_COLLECTOR_LABEL,
     resourceDescription: "zfs-zpool-collector",
     requireExactlyOneReadyPodPerNode: true,
-  });
+  };
+  if (expectedNodes !== undefined) {
+    return selectRunningReadyNodePods(pods, { ...context, expectedNodes });
+  }
+  return selectRunningReadyNodePods(pods, context);
 }
 
 export function parseManagedZfsPools(
@@ -194,6 +202,23 @@ async function findZfsCollectorPods(): Promise<ZfsCollectorPodCandidate[]> {
     }
     return candidate;
   });
+}
+
+async function findKubernetesNodes(): Promise<string[]> {
+  const kc = new k8s.KubeConfig();
+  kc.loadFromCluster();
+  const response = await kc.makeApiClient(k8s.CoreV1Api).listNode();
+  const nodes: string[] = [];
+  for (const node of response.items) {
+    const name = node.metadata?.name;
+    if (name === undefined) {
+      throw new Error(
+        "Kubernetes node inventory contains a node without metadata.name",
+      );
+    }
+    nodes.push(name);
+  }
+  return nodes.toSorted();
 }
 
 async function runCommand(

--- a/packages/temporal/src/activities/zfs-maintenance.ts
+++ b/packages/temporal/src/activities/zfs-maintenance.ts
@@ -131,6 +131,7 @@ export function selectZfsCollectorPods(
     namespace: NAMESPACE,
     labelSelector: ZFS_COLLECTOR_LABEL,
     resourceDescription: "zfs-zpool-collector",
+    requireExactlyOneReadyPodPerNode: true,
   });
 }
 
@@ -204,11 +205,14 @@ async function runCommand(
   try {
     return await dependencies.execInPod(nodePod, command);
   } catch (error) {
-    throw new Error(
-      `ZFS maintenance command failed: node=${nodePod.node}, pod=${nodePod.pod}, pool=${pool ?? "unknown"}, command=${command}`,
-      {
-        cause: error,
-      },
-    );
+    const context = [
+      `node=${nodePod.node}`,
+      `pod=${nodePod.pod}`,
+      `pool=${pool ?? "unknown"}`,
+      `command=${command}`,
+    ].join(", ");
+    throw new Error(`ZFS maintenance command failed: ${context}`, {
+      cause: error,
+    });
   }
 }

--- a/packages/temporal/src/shared/kubectl-exec.ts
+++ b/packages/temporal/src/shared/kubectl-exec.ts
@@ -1,0 +1,39 @@
+export async function kubectlExecInPod(input: {
+  namespace: string;
+  container: string;
+  pod: string;
+  command: string | readonly string[];
+}): Promise<string> {
+  const command =
+    typeof input.command === "string"
+      ? { args: ["sh", "-c", input.command], label: input.command }
+      : { args: [...input.command], label: input.command.join(" ") };
+  const args = [
+    "kubectl",
+    "exec",
+    "--namespace",
+    input.namespace,
+    "--container",
+    input.container,
+    input.pod,
+    "--",
+    ...command.args,
+  ];
+  const proc = Bun.spawn(args, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    const detail = stderr.trim() || stdout.trim() || "(no output)";
+    throw new Error(
+      `kubectl exec [${command.label}] in ${input.namespace}/${input.pod} exited ${String(exitCode)}: ${detail}`,
+    );
+  }
+  return stdout;
+}

--- a/packages/temporal/src/shared/kubernetes-node-pods.ts
+++ b/packages/temporal/src/shared/kubernetes-node-pods.ts
@@ -25,29 +25,39 @@ export function selectRunningReadyNodePods(
     namespace: string;
     labelSelector: string;
     resourceDescription: string;
+    requireExactlyOneReadyPodPerNode?: boolean;
   },
 ): KubernetesNodePod[] {
   const nodePods = new Map<string, string>();
+  const candidateCountsByNode = new Map<string, number>();
+  const requireExactlyOneReadyPodPerNode =
+    context.requireExactlyOneReadyPodPerNode === true;
   for (const pod of pods) {
-    const isReady = pod.status?.conditions?.some(
-      (condition) => condition.type === "Ready" && condition.status === "True",
-    );
-    if (isReady !== true || pod.status?.phase !== "Running") {
+    const node = pod.spec?.nodeName;
+    validateNodeIdentity(node, context, requireExactlyOneReadyPodPerNode);
+    if (node !== undefined) {
+      candidateCountsByNode.set(
+        node,
+        (candidateCountsByNode.get(node) ?? 0) + 1,
+      );
+    }
+
+    if (!isRunningReady(pod)) {
       continue;
     }
 
-    const name = pod.metadata?.name;
-    const node = pod.spec?.nodeName;
-    if (name === undefined || node === undefined) {
+    if (node === undefined) {
       throw new Error(
         `Running and Ready ${context.resourceDescription} pod is missing metadata.name or spec.nodeName`,
       );
     }
+    const name = getReadyPodName(pod, context);
 
     const existingPod = nodePods.get(node);
     if (existingPod !== undefined) {
       throw new Error(
-        `Multiple Running and Ready ${context.resourceDescription} pods found for node ${node}: ${existingPod}, ${name}`,
+        `Multiple Running and Ready ${context.resourceDescription} pods found for node ${node}: ` +
+          `${existingPod}, ${name}`,
       );
     }
     nodePods.set(node, name);
@@ -55,11 +65,70 @@ export function selectRunningReadyNodePods(
 
   if (nodePods.size === 0) {
     throw new Error(
-      `No Running and Ready ${context.resourceDescription} pods found in ${context.namespace} (label selector: ${context.labelSelector})`,
+      `No Running and Ready ${context.resourceDescription} pods found in ${context.namespace} ` +
+        `(label selector: ${context.labelSelector})`,
+    );
+  }
+
+  if (requireExactlyOneReadyPodPerNode) {
+    validateExactlyOneReadyPodPerNode(
+      candidateCountsByNode,
+      nodePods,
+      context.resourceDescription,
     );
   }
 
   return [...nodePods.entries()]
     .map(([node, pod]) => ({ node, pod }))
     .toSorted((left, right) => left.node.localeCompare(right.node));
+}
+
+function validateNodeIdentity(
+  node: string | undefined,
+  context: { resourceDescription: string },
+  requireNode: boolean,
+): void {
+  if (node === undefined && requireNode) {
+    throw new Error(
+      `Running and Ready ${context.resourceDescription} pod is missing metadata.name or spec.nodeName`,
+    );
+  }
+}
+
+function isRunningReady(pod: KubernetesNodePodCandidate): boolean {
+  return (
+    pod.status?.phase === "Running" &&
+    pod.status.conditions?.some(
+      (condition) => condition.type === "Ready" && condition.status === "True",
+    ) === true
+  );
+}
+
+function getReadyPodName(
+  pod: KubernetesNodePodCandidate,
+  context: { resourceDescription: string },
+): string {
+  const name = pod.metadata?.name;
+  if (name === undefined) {
+    throw new Error(
+      `Running and Ready ${context.resourceDescription} pod is missing metadata.name or spec.nodeName`,
+    );
+  }
+  return name;
+}
+
+function validateExactlyOneReadyPodPerNode(
+  candidateCountsByNode: ReadonlyMap<string, number>,
+  nodePods: ReadonlyMap<string, string>,
+  resourceDescription: string,
+): void {
+  for (const [node, candidateCount] of candidateCountsByNode) {
+    if (candidateCount !== 1 || !nodePods.has(node)) {
+      const readyState = nodePods.has(node) ? "one Ready pod" : "no Ready pod";
+      throw new Error(
+        `Expected exactly one Running and Ready ${resourceDescription} pod for node ${node}; ` +
+          `found ${String(candidateCount)} candidate(s) and ${readyState}`,
+      );
+    }
+  }
 }

--- a/packages/temporal/src/shared/kubernetes-node-pods.ts
+++ b/packages/temporal/src/shared/kubernetes-node-pods.ts
@@ -26,6 +26,7 @@ export function selectRunningReadyNodePods(
     labelSelector: string;
     resourceDescription: string;
     requireExactlyOneReadyPodPerNode?: boolean;
+    expectedNodes?: readonly string[];
   },
 ): KubernetesNodePod[] {
   const nodePods = new Map<string, string>();
@@ -75,6 +76,7 @@ export function selectRunningReadyNodePods(
       candidateCountsByNode,
       nodePods,
       context.resourceDescription,
+      context.expectedNodes,
     );
   }
 
@@ -121,8 +123,14 @@ function validateExactlyOneReadyPodPerNode(
   candidateCountsByNode: ReadonlyMap<string, number>,
   nodePods: ReadonlyMap<string, string>,
   resourceDescription: string,
+  expectedNodes: readonly string[] | undefined,
 ): void {
-  for (const [node, candidateCount] of candidateCountsByNode) {
+  const nodes = new Set([
+    ...candidateCountsByNode.keys(),
+    ...(expectedNodes ?? []),
+  ]);
+  for (const node of nodes) {
+    const candidateCount = candidateCountsByNode.get(node) ?? 0;
     if (candidateCount !== 1 || !nodePods.has(node)) {
       const readyState = nodePods.has(node) ? "one Ready pod" : "no Ready pod";
       throw new Error(

--- a/packages/temporal/src/shared/kubernetes-node-pods.ts
+++ b/packages/temporal/src/shared/kubernetes-node-pods.ts
@@ -1,0 +1,65 @@
+export type KubernetesNodePod = {
+  node: string;
+  pod: string;
+};
+
+export type KubernetesNodePodCandidate = {
+  metadata?: {
+    name?: string;
+  };
+  spec?: {
+    nodeName?: string;
+  };
+  status?: {
+    phase?: string;
+    conditions?: {
+      type?: string;
+      status?: string;
+    }[];
+  };
+};
+
+export function selectRunningReadyNodePods(
+  pods: readonly KubernetesNodePodCandidate[],
+  context: {
+    namespace: string;
+    labelSelector: string;
+    resourceDescription: string;
+  },
+): KubernetesNodePod[] {
+  const nodePods = new Map<string, string>();
+  for (const pod of pods) {
+    const isReady = pod.status?.conditions?.some(
+      (condition) => condition.type === "Ready" && condition.status === "True",
+    );
+    if (isReady !== true || pod.status?.phase !== "Running") {
+      continue;
+    }
+
+    const name = pod.metadata?.name;
+    const node = pod.spec?.nodeName;
+    if (name === undefined || node === undefined) {
+      throw new Error(
+        `Running and Ready ${context.resourceDescription} pod is missing metadata.name or spec.nodeName`,
+      );
+    }
+
+    const existingPod = nodePods.get(node);
+    if (existingPod !== undefined) {
+      throw new Error(
+        `Multiple Running and Ready ${context.resourceDescription} pods found for node ${node}: ${existingPod}, ${name}`,
+      );
+    }
+    nodePods.set(node, name);
+  }
+
+  if (nodePods.size === 0) {
+    throw new Error(
+      `No Running and Ready ${context.resourceDescription} pods found in ${context.namespace} (label selector: ${context.labelSelector})`,
+    );
+  }
+
+  return [...nodePods.entries()]
+    .map(([node, pod]) => ({ node, pod }))
+    .toSorted((left, right) => left.node.localeCompare(right.node));
+}


### PR DESCRIPTION
## Summary

- Correct the 24-hour memory comparison so historical memory and ARC selectors are all offset together.
- Discover ZFS collector pods and managed pools per node, route commands to the owning pod, and fail with actionable context.
- Alert on never-scrubbed pools, remove obsolete DaemonSet RBAC, and document operator verification.

## Verification

- CDK8s focused tests, typecheck, lint, and manifest build pass.
- Temporal focused tests and changed-file lint pass.
- Temporal package-wide typecheck remains blocked by pre-existing missing Glitter workspace artifacts.

No live deployment, scrub, or PagerDuty mutation was performed.