### PR TITLE
fix(tasks-for-obsidian): make recurring mutations crash-safe

### DIFF
--- a/packages/tasknotes-server/AGENTS.md
+++ b/packages/tasknotes-server/AGENTS.md
@@ -79,10 +79,14 @@ contract. The interim `/legacy/api/*` camelCase adapter was removed in P6.
 
 ### Complete-instance body (optional)
 
-`POST /api/tasks/:id/complete-instance` accepts `{date?: "YYYY-MM-DD", completed?: boolean}`:
-no body = legacy toggle of server-local today (upstream plugin parity); `date` targets the
+`POST /api/tasks/:id/complete-instance` accepts `{date?: "YYYY-MM-DD", completed?: boolean,
+restore?: {scheduled: string | null, due: string | null, recurrence: string,
+skipped: boolean}}`: no body =
+legacy toggle of server-local today (upstream plugin parity); `date` targets the
 device-captured instance; `completed` gives idempotent SET semantics (required for safe
-offline-queue replay). Non-recurring tasks are a 400 (upstream parity).
+offline-queue replay). `restore` is valid only with `completed: false` and atomically restores
+the schedule snapshot from before a completion advanced it. Non-recurring tasks are a 400
+(upstream parity).
 
 ### Idempotent mutations
 

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -190,8 +190,7 @@ describe("status workflow + archive", () => {
   });
 });
 
-describe("recurring instance completion", () => {
-  const RECURRING = `---
+const RECURRING = `---
 title: Water plants
 status: open
 priority: normal
@@ -202,6 +201,7 @@ tags:
 ---
 `;
 
+describe("recurring instance completion", () => {
   test("explicit date is honored (not server-today)", async () => {
     await seed("TaskNotes/water.md", RECURRING);
     await repo.scan();
@@ -397,6 +397,65 @@ tags:
 
     const updated = await edgeRepo.completeInstance("TaskNotes/water.md");
     expect(updated.complete_instances).toEqual([ymdOf(edgeNow)]);
+  });
+});
+
+describe("recurring completion safeguards", () => {
+  test("rejects an Undo snapshot after the server schedule changed", async () => {
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+priority: normal
+scheduled: 2026-09-01
+recurrence: FREQ=WEEKLY
+complete_instances:
+  - 2026-08-01
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    await expect(
+      repo.completeInstance("TaskNotes/weekly.md", {
+        date: "2026-08-01",
+        completed: false,
+        restore: {
+          scheduled: "2026-08-01",
+          due: null,
+          recurrence: "FREQ=WEEKLY",
+          skipped: false,
+        },
+      }),
+    ).rejects.toThrow("restore");
+    expect(
+      repo.list().find((task) => task.path === "TaskNotes/weekly.md")
+        ?.scheduled,
+    ).toBe("2026-09-01");
+  });
+
+  test("bodyless call samples the clock once", async () => {
+    let calls = 0;
+    await seed("TaskNotes/water.md", RECURRING);
+    const edgeRepo = new TaskRepository(
+      vault,
+      "TaskNotes",
+      resolveModelConfig(),
+      () => {
+        calls += 1;
+        return new Date(
+          calls === 1 ? "2026-07-03T01:00:00.000Z" : "2026-07-04T01:00:00.000Z",
+        );
+      },
+    );
+    await edgeRepo.scan();
+
+    const updated = await edgeRepo.completeInstance("TaskNotes/water.md");
+    expect(updated.complete_instances).toEqual(["2026-07-03"]);
+    expect(calls).toBe(1);
   });
 });
 

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -437,6 +437,38 @@ tags:
     ).toBe("2026-09-01");
   });
 
+  test("rejects an Undo snapshot after a nullable due date was added", async () => {
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+scheduled: 2026-09-01
+due: 2026-09-02
+recurrence: FREQ=WEEKLY
+complete_instances:
+  - 2026-08-01
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    await expect(
+      repo.completeInstance("TaskNotes/weekly.md", {
+        date: "2026-08-01",
+        completed: false,
+        restore: {
+          scheduled: null,
+          due: null,
+          recurrence: "FREQ=WEEKLY",
+          skipped: false,
+        },
+      }),
+    ).rejects.toThrow("restore");
+  });
+
   test("bodyless call samples the clock once", async () => {
     let calls = 0;
     await seed("TaskNotes/water.md", RECURRING);

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -366,6 +366,9 @@ tags:
     expect(restored.recurrence).toBe("FREQ=WEEKLY");
     expect(restored.skipped_instances).toEqual(["2026-07-25", "2026-08-01"]);
 
+    const beforeReplay = await Bun.file(
+      path.join(vault, "TaskNotes/weekly.md"),
+    ).text();
     const replay = await repo.completeInstance("TaskNotes/weekly.md", {
       date: "2026-08-01",
       completed: false,
@@ -378,6 +381,9 @@ tags:
     });
     expect(replay.complete_instances ?? []).toEqual([]);
     expect(replay.skipped_instances).toEqual(["2026-07-25", "2026-08-01"]);
+    expect(await Bun.file(path.join(vault, "TaskNotes/weekly.md")).text()).toBe(
+      beforeReplay,
+    );
   });
 
   test("bodyless call toggles (upstream parity); non-recurring throws", async () => {

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -347,6 +347,7 @@ tags:
     expect(on.complete_instances).toEqual([ymdOf(NOW)]);
     const off = await repo.completeInstance("TaskNotes/water.md");
     expect(off.complete_instances ?? []).toEqual([]);
+    expect(off.scheduled).toBe(on.scheduled);
     await expect(repo.completeInstance("TaskNotes/plain.md")).rejects.toThrow(
       NotRecurringError,
     );

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -417,6 +417,34 @@ tags:
 });
 
 describe("matching-state restore safeguards", () => {
+  test("rejects a matching-state restore after a DTSTART-only recurrence edit", async () => {
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+recurrence: DTSTART:20260901;FREQ=WEEKLY
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    await expect(
+      repo.completeInstance("TaskNotes/weekly.md", {
+        date: "2026-08-01",
+        completed: false,
+        restore: {
+          scheduled: null,
+          due: null,
+          recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+          skipped: false,
+        },
+      }),
+    ).rejects.toThrow("restore");
+  });
+
   test("rejects a matching-state restore after an unrelated recurrence edit", async () => {
     await seed(
       "TaskNotes/weekly.md",

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -226,6 +226,119 @@ tags:
     expect(replay.complete_instances).toEqual(["2026-07-01"]);
   });
 
+  test("uncomplete atomically restores the pre-completion recurrence snapshot", async () => {
+    const recurrence = "FREQ=WEEKLY";
+    const scheduled = "2026-08-01";
+    const due = "2026-08-03";
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+priority: normal
+scheduled: ${scheduled}
+due: ${due}
+recurrence: ${recurrence}
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    const completed = await repo.completeInstance("TaskNotes/weekly.md", {
+      date: scheduled,
+      completed: true,
+    });
+    expect(completed.complete_instances).toEqual([scheduled]);
+    expect(completed.scheduled).toBe("2026-08-08");
+    expect(completed.due).toBe("2026-08-10");
+
+    const restored = await repo.completeInstance("TaskNotes/weekly.md", {
+      date: scheduled,
+      completed: false,
+      restore: { scheduled, due, recurrence, skipped: false },
+    });
+    expect(restored.complete_instances).toEqual([]);
+    expect(restored.scheduled).toBe(scheduled);
+    expect(restored.due).toBe(due);
+    expect(restored.recurrence).toBe(recurrence);
+  });
+
+  test("a restore snapshot deletes nullable schedule fields", async () => {
+    await seed("TaskNotes/weekly.md", RECURRING);
+    await repo.scan();
+    await repo.completeInstance("TaskNotes/weekly.md", {
+      date: "2026-07-01",
+      completed: true,
+    });
+
+    const restored = await repo.completeInstance("TaskNotes/weekly.md", {
+      date: "2026-07-01",
+      completed: false,
+      restore: {
+        scheduled: null,
+        due: null,
+        recurrence: "FREQ=DAILY",
+        skipped: false,
+      },
+    });
+    expect(restored.scheduled).toBeUndefined();
+    expect(restored.due).toBeUndefined();
+    const raw = await Bun.file(path.join(vault, "TaskNotes/weekly.md")).text();
+    expect(raw).not.toContain("scheduled:");
+    expect(raw).not.toContain("due:");
+  });
+
+  test("restore repairs schedule and skipped membership when completion is already clear", async () => {
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+priority: normal
+scheduled: 2026-08-08
+due: 2026-08-10
+recurrence: FREQ=DAILY
+skipped_instances:
+  - 2026-07-25
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    const restored = await repo.completeInstance("TaskNotes/weekly.md", {
+      date: "2026-08-01",
+      completed: false,
+      restore: {
+        scheduled: "2026-08-01",
+        due: "2026-08-03",
+        recurrence: "FREQ=WEEKLY",
+        skipped: true,
+      },
+    });
+    expect(restored.complete_instances ?? []).toEqual([]);
+    expect(restored.scheduled).toBe("2026-08-01");
+    expect(restored.due).toBe("2026-08-03");
+    expect(restored.recurrence).toBe("FREQ=WEEKLY");
+    expect(restored.skipped_instances).toEqual(["2026-07-25", "2026-08-01"]);
+
+    const replay = await repo.completeInstance("TaskNotes/weekly.md", {
+      date: "2026-08-01",
+      completed: false,
+      restore: {
+        scheduled: "2026-08-01",
+        due: "2026-08-03",
+        recurrence: "FREQ=WEEKLY",
+        skipped: true,
+      },
+    });
+    expect(replay.complete_instances ?? []).toEqual([]);
+    expect(replay.skipped_instances).toEqual(["2026-07-25", "2026-08-01"]);
+  });
+
   test("bodyless call toggles (upstream parity); non-recurring throws", async () => {
     await seed("TaskNotes/water.md", RECURRING);
     await seed("TaskNotes/plain.md", PLUGIN_AUTHORED);
@@ -237,6 +350,21 @@ tags:
     await expect(repo.completeInstance("TaskNotes/plain.md")).rejects.toThrow(
       NotRecurringError,
     );
+  });
+
+  test("bodyless call targets the server-local day across a UTC boundary", async () => {
+    const edgeNow = new Date("2026-07-03T01:00:00.000Z");
+    await seed("TaskNotes/water.md", RECURRING);
+    const edgeRepo = new TaskRepository(
+      vault,
+      "TaskNotes",
+      resolveModelConfig(),
+      () => edgeNow,
+    );
+    await edgeRepo.scan();
+
+    const updated = await edgeRepo.completeInstance("TaskNotes/water.md");
+    expect(updated.complete_instances).toEqual([ymdOf(edgeNow)]);
   });
 });
 

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -416,6 +416,42 @@ tags:
   });
 });
 
+describe("due-only recurring completion", () => {
+  test("uncomplete restores a due-only recurrence snapshot", async () => {
+    const due = "2026-08-03";
+    const recurrence = "FREQ=WEEKLY";
+    await seed(
+      "TaskNotes/due-only.md",
+      `---
+title: Due-only review
+status: open
+priority: normal
+due: ${due}
+recurrence: ${recurrence}
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    await repo.completeInstance("TaskNotes/due-only.md", {
+      date: due,
+      completed: true,
+    });
+    const restored = await repo.completeInstance("TaskNotes/due-only.md", {
+      date: due,
+      completed: false,
+      restore: { scheduled: null, due, recurrence, skipped: false },
+    });
+
+    expect(restored.complete_instances).toEqual([]);
+    expect(restored.scheduled).toBeUndefined();
+    expect(restored.due).toBe(due);
+    expect(restored.recurrence).toBe(recurrence);
+  });
+});
+
 describe("matching-state restore safeguards", () => {
   test("rejects a matching-state restore after a DTSTART-only recurrence edit", async () => {
     await seed(

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -330,7 +330,7 @@ status: open
 priority: normal
 scheduled: 2026-08-08
 due: 2026-08-10
-recurrence: FREQ=DAILY
+recurrence: DTSTART:20260801;FREQ=WEEKLY
 skipped_instances:
   - 2026-07-25
 tags:
@@ -397,6 +397,38 @@ tags:
 
     const updated = await edgeRepo.completeInstance("TaskNotes/water.md");
     expect(updated.complete_instances).toEqual([ymdOf(edgeNow)]);
+  });
+});
+
+describe("matching-state restore safeguards", () => {
+  test("rejects a matching-state restore after an unrelated recurrence edit", async () => {
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+scheduled: 2026-08-08
+due: 2026-08-10
+recurrence: FREQ=DAILY
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    await expect(
+      repo.completeInstance("TaskNotes/weekly.md", {
+        date: "2026-08-01",
+        completed: false,
+        restore: {
+          scheduled: "2026-08-01",
+          due: "2026-08-03",
+          recurrence: "FREQ=WEEKLY",
+          skipped: false,
+        },
+      }),
+    ).rejects.toThrow("restore");
   });
 });
 

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -297,7 +297,17 @@ tags:
   });
 
   test("a restore snapshot deletes nullable schedule fields", async () => {
-    await seed("TaskNotes/weekly.md", RECURRING);
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+recurrence: FREQ=DAILY
+tags:
+  - task
+---
+`,
+    );
     await repo.scan();
     await repo.completeInstance("TaskNotes/weekly.md", {
       date: "2026-07-01",
@@ -486,6 +496,38 @@ tags:
 `,
     );
     await repo.scan();
+
+    await expect(
+      repo.completeInstance("TaskNotes/weekly.md", {
+        date: "2026-08-01",
+        completed: false,
+        restore: {
+          scheduled: null,
+          due: null,
+          recurrence: "FREQ=WEEKLY",
+          skipped: false,
+        },
+      }),
+    ).rejects.toThrow("restore");
+  });
+
+  test("rejects an Undo snapshot after a nullable scheduled date was added", async () => {
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+recurrence: FREQ=WEEKLY
+complete_instances:
+  - 2026-08-01
+tags:
+  - task
+---
+`,
+    );
+    await repo.scan();
+
+    await repo.update("TaskNotes/weekly.md", { scheduled: "2026-09-01" });
 
     await expect(
       repo.completeInstance("TaskNotes/weekly.md", {

--- a/packages/tasknotes-server/src/__tests__/task-repository.test.ts
+++ b/packages/tasknotes-server/src/__tests__/task-repository.test.ts
@@ -212,6 +212,37 @@ tags:
     expect(updated.complete_instances).toEqual(["2026-07-01"]);
   });
 
+  test("explicit completion date anchors the next occurrence", async () => {
+    const edgeNow = new Date("2026-08-03T12:00:00.000Z");
+    await seed(
+      "TaskNotes/weekly.md",
+      `---
+title: Weekly review
+status: open
+priority: normal
+scheduled: 2026-08-01
+recurrence: FREQ=WEEKLY
+tags:
+  - task
+---
+`,
+    );
+    const edgeRepo = new TaskRepository(
+      vault,
+      "TaskNotes",
+      resolveModelConfig(),
+      () => edgeNow,
+    );
+    await edgeRepo.scan();
+
+    const updated = await edgeRepo.completeInstance("TaskNotes/weekly.md", {
+      date: "2026-08-01",
+      completed: true,
+    });
+
+    expect(updated.scheduled).toBe("2026-08-08");
+  });
+
   test("set-semantics: matching state is a no-op, not a toggle", async () => {
     await seed("TaskNotes/water.md", RECURRING);
     await repo.scan();

--- a/packages/tasknotes-server/src/__tests__/v2-routes.test.ts
+++ b/packages/tasknotes-server/src/__tests__/v2-routes.test.ts
@@ -301,6 +301,39 @@ describe("complete-instance restore", () => {
     );
     expect(invalid.status).toBe(400);
 
+    const edited = await app.request(`/api/tasks/${weeklyId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scheduled: "2026-08-15", due: "2026-08-17" }),
+    });
+    expect(edited.status).toBe(200);
+
+    const stale = await app.request(
+      `/api/tasks/${weeklyId}/complete-instance`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          date: "2026-08-01",
+          completed: false,
+          restore: {
+            scheduled: "2026-08-01",
+            due: "2026-08-03",
+            recurrence: "FREQ=WEEKLY",
+            skipped: false,
+          },
+        }),
+      },
+    );
+    expect(stale.status).toBe(409);
+
+    const reset = await app.request(`/api/tasks/${weeklyId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scheduled: "2026-08-08", due: "2026-08-10" }),
+    });
+    expect(reset.status).toBe(200);
+
     const restored = await app.request(
       `/api/tasks/${weeklyId}/complete-instance`,
       {

--- a/packages/tasknotes-server/src/__tests__/v2-routes.test.ts
+++ b/packages/tasknotes-server/src/__tests__/v2-routes.test.ts
@@ -253,6 +253,80 @@ describe("v2 task routes", () => {
   });
 });
 
+describe("complete-instance restore", () => {
+  test("restores a weekly task and validates restore direction", async () => {
+    const created = await app.request("/api/tasks", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Weekly review",
+        scheduled: "2026-08-01",
+        due: "2026-08-03",
+        recurrence: "FREQ=WEEKLY",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const weeklyId = encodeURIComponent("TaskNotes/Weekly review.md");
+
+    const completed = await app.request(
+      `/api/tasks/${weeklyId}/complete-instance`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ date: "2026-08-01", completed: true }),
+      },
+    );
+    expect(completed.status).toBe(200);
+    const advanced = await unwrap(completed);
+    expect(advanced["complete_instances"]).toEqual(["2026-08-01"]);
+    expect(advanced["scheduled"]).toBe("2026-08-08");
+    expect(advanced["due"]).toBe("2026-08-10");
+
+    const invalid = await app.request(
+      `/api/tasks/${weeklyId}/complete-instance`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          date: "2026-08-01",
+          completed: true,
+          restore: {
+            scheduled: "2026-08-01",
+            due: "2026-08-03",
+            recurrence: "FREQ=WEEKLY",
+            skipped: false,
+          },
+        }),
+      },
+    );
+    expect(invalid.status).toBe(400);
+
+    const restored = await app.request(
+      `/api/tasks/${weeklyId}/complete-instance`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          date: "2026-08-01",
+          completed: false,
+          restore: {
+            scheduled: "2026-08-01",
+            due: "2026-08-03",
+            recurrence: "FREQ=WEEKLY",
+            skipped: false,
+          },
+        }),
+      },
+    );
+    expect(restored.status).toBe(200);
+    const task = await unwrap(restored);
+    expect(task["complete_instances"]).toEqual([]);
+    expect(task["scheduled"]).toBe("2026-08-01");
+    expect(task["due"]).toBe("2026-08-03");
+    expect(task["recurrence"]).toBe("FREQ=WEEKLY");
+  });
+});
+
 describe("v2 NLP + calendars", () => {
   test("nlp/parse returns {parsed, taskData}; nlp/create returns {task, parsed} at 201", async () => {
     const parsedRes = await app.request("/api/nlp/parse", {

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -22,6 +22,15 @@ export type RestoreValidationInput = {
   readonly maintainDueDateOffset: boolean;
 };
 
+export class RecurringRestoreConflictError extends Error {
+  constructor(path: string) {
+    super(
+      `recurring restore for ${path} is stale; refusing to overwrite newer task state`,
+    );
+    this.name = "RecurringRestoreConflictError";
+  }
+}
+
 function restoreScheduleSource(
   task: TaskInfo,
   restore: RecurringCompletionRestore,
@@ -79,12 +88,10 @@ export function assertRecurringRestoreIsCurrent({
   if (
     !targetIsNotSkipped ||
     !recurrenceMatches ||
-    (restore.scheduled !== null && task.scheduled !== expectedScheduled) ||
+    task.scheduled !== expectedScheduled ||
     (restore.due === null ? task.due !== undefined : task.due !== expectedDue)
   ) {
-    throw new Error(
-      `recurring restore for ${task.path} is stale; refusing to overwrite newer task state`,
-    );
+    throw new RecurringRestoreConflictError(task.path);
   }
 }
 

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -71,6 +71,7 @@ export function assertRecurringRestoreIsCurrent({
     addDTSTARTToRecurrenceRule({
       recurrence: restore.recurrence,
       ...(restore.scheduled === null ? {} : { scheduled: restore.scheduled }),
+      ...(restore.due === null ? {} : { due: restore.due }),
       ...(task.dateCreated === undefined
         ? {}
         : { dateCreated: task.dateCreated }),

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -76,7 +76,7 @@ export function assertRecurringRestoreIsCurrent({
   if (
     !recurrenceMatches ||
     (restore.scheduled !== null && task.scheduled !== expectedScheduled) ||
-    (restore.due !== null && task.due !== expectedDue)
+    (restore.due === null ? task.due !== undefined : task.due !== expectedDue)
   ) {
     throw new Error(
       `recurring restore for ${task.path} is stale; refusing to overwrite newer task state`,

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -10,10 +10,6 @@ import type {
   TaskPatchOperation,
 } from "tasknotes-types/v2";
 
-function recurrenceRuleWithoutStart(recurrence: string): string {
-  return recurrence.replace(/^DTSTART:[^;]+;/, "");
-}
-
 export type RestoreValidationInput = {
   readonly task: TaskInfo;
   readonly restore: RecurringCompletionRestore;
@@ -79,11 +75,7 @@ export function assertRecurringRestoreIsCurrent({
         ? {}
         : { dateCreated: task.dateCreated }),
     }) ?? restore.recurrence;
-  const recurrenceMatches =
-    restore.scheduled === null
-      ? recurrenceRuleWithoutStart(task.recurrence ?? "") ===
-        recurrenceRuleWithoutStart(restore.recurrence)
-      : task.recurrence === expectedRecurrence;
+  const recurrenceMatches = task.recurrence === expectedRecurrence;
   const targetIsNotSkipped = !(task.skipped_instances ?? []).includes(date);
   if (
     !targetIsNotSkipped ||

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -1,4 +1,7 @@
-import { updateToNextScheduledOccurrence } from "tasknotes-types/v2";
+import {
+  addDTSTARTToRecurrenceRule,
+  updateToNextScheduledOccurrence,
+} from "tasknotes-types/v2";
 import type {
   FieldMapping,
   RecurringCompletionRestore,
@@ -6,6 +9,80 @@ import type {
   TaskInfo,
   TaskPatchOperation,
 } from "tasknotes-types/v2";
+
+function recurrenceRuleWithoutStart(recurrence: string): string {
+  return recurrence.replace(/^DTSTART:[^;]+;/, "");
+}
+
+export type RestoreValidationInput = {
+  readonly task: TaskInfo;
+  readonly restore: RecurringCompletionRestore;
+  readonly date: string;
+  readonly today: string;
+  readonly maintainDueDateOffset: boolean;
+};
+
+function restoreScheduleSource(
+  task: TaskInfo,
+  restore: RecurringCompletionRestore,
+  date: string,
+) {
+  return {
+    title: task.title,
+    recurrence: restore.recurrence,
+    ...(restore.scheduled === null ? {} : { scheduled: restore.scheduled }),
+    ...(restore.due === null ? {} : { due: restore.due }),
+    ...(task.dateCreated === undefined
+      ? {}
+      : { dateCreated: task.dateCreated }),
+    ...(task.recurrence_anchor === undefined
+      ? {}
+      : { recurrence_anchor: task.recurrence_anchor }),
+    complete_instances: task.complete_instances ?? [],
+    skipped_instances: (task.skipped_instances ?? []).filter(
+      (entry) => entry !== date,
+    ),
+  };
+}
+
+export function assertRecurringRestoreIsCurrent({
+  task,
+  restore,
+  date,
+  today,
+  maintainDueDateOffset,
+}: RestoreValidationInput): void {
+  const scheduleSource = restoreScheduleSource(task, restore, date);
+  const next = updateToNextScheduledOccurrence(
+    scheduleSource,
+    maintainDueDateOffset,
+    { today },
+  );
+  const expectedScheduled = next.scheduled ?? restore.scheduled ?? undefined;
+  const expectedDue = next.due ?? restore.due ?? undefined;
+  const expectedRecurrence =
+    addDTSTARTToRecurrenceRule({
+      recurrence: restore.recurrence,
+      ...(restore.scheduled === null ? {} : { scheduled: restore.scheduled }),
+      ...(task.dateCreated === undefined
+        ? {}
+        : { dateCreated: task.dateCreated }),
+    }) ?? restore.recurrence;
+  const recurrenceMatches =
+    restore.scheduled === null
+      ? recurrenceRuleWithoutStart(task.recurrence ?? "") ===
+        recurrenceRuleWithoutStart(restore.recurrence)
+      : task.recurrence === expectedRecurrence;
+  if (
+    !recurrenceMatches ||
+    (restore.scheduled !== null && task.scheduled !== expectedScheduled) ||
+    (restore.due !== null && task.due !== expectedDue)
+  ) {
+    throw new Error(
+      `recurring restore for ${task.path} is stale; refusing to overwrite newer task state`,
+    );
+  }
+}
 
 function withInstanceMembership(
   instances: readonly string[] | undefined,

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -1,0 +1,87 @@
+import { updateToNextScheduledOccurrence } from "tasknotes-types/v2";
+import type {
+  FieldMapping,
+  RecurringCompletionRestore,
+  RecurringTaskCompletePlan,
+  TaskInfo,
+  TaskPatchOperation,
+} from "tasknotes-types/v2";
+
+function withInstanceMembership(
+  instances: readonly string[] | undefined,
+  date: string,
+  included: boolean,
+): string[] {
+  const withoutTarget = (instances ?? []).filter((entry) => entry !== date);
+  return included ? [...withoutTarget, date] : withoutTarget;
+}
+
+export function recurringCompletionRestorePatch(
+  restore: RecurringCompletionRestore,
+  date: string,
+  skippedInstances: readonly string[] | undefined,
+  fieldMapping: FieldMapping,
+): TaskPatchOperation[] {
+  return [
+    {
+      op: "set",
+      field: fieldMapping.recurrence,
+      value: restore.recurrence,
+    },
+    restore.scheduled === null
+      ? { op: "delete", field: fieldMapping.scheduled }
+      : {
+          op: "set",
+          field: fieldMapping.scheduled,
+          value: restore.scheduled,
+        },
+    restore.due === null
+      ? { op: "delete", field: fieldMapping.due }
+      : { op: "set", field: fieldMapping.due, value: restore.due },
+    {
+      op: "set",
+      field: fieldMapping.skippedInstances,
+      value: withInstanceMembership(skippedInstances, date, restore.skipped),
+    },
+  ];
+}
+
+function setTaskDate(
+  task: TaskInfo,
+  field: "scheduled" | "due",
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(task, field);
+  } else if (field === "scheduled") {
+    task.scheduled = value;
+  } else {
+    task.due = value;
+  }
+}
+
+export function useDeterministicRecurringSchedule(
+  plan: RecurringTaskCompletePlan,
+  original: TaskInfo,
+  today: string,
+  maintainDueDateOffset: boolean,
+): void {
+  const scheduleSource: TaskInfo = { ...plan.updatedTask };
+  setTaskDate(scheduleSource, "scheduled", original.scheduled);
+  setTaskDate(scheduleSource, "due", original.due);
+  const next = updateToNextScheduledOccurrence(
+    scheduleSource,
+    maintainDueDateOffset,
+    { today },
+  );
+
+  // Match the model plan's behavior when no future occurrence exists: retain
+  // the original value. The only difference is that its implicit wall-clock
+  // `today` is replaced with the repository's injected clock.
+  setTaskDate(
+    plan.updatedTask,
+    "scheduled",
+    next.scheduled ?? original.scheduled,
+  );
+  setTaskDate(plan.updatedTask, "due", next.due ?? original.due);
+}

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -66,6 +66,15 @@ export function useDeterministicRecurringSchedule(
   today: string,
   maintainDueDateOffset: boolean,
 ): void {
+  // Uncompleting clears the targeted instance but must not advance the
+  // already-advanced schedule. This also covers bodyless toggles and older
+  // clients that send completed:false without a restore snapshot.
+  if (!plan.newComplete) {
+    setTaskDate(plan.updatedTask, "scheduled", original.scheduled);
+    setTaskDate(plan.updatedTask, "due", original.due);
+    return;
+  }
+
   const scheduleSource: TaskInfo = { ...plan.updatedTask };
   setTaskDate(scheduleSource, "scheduled", original.scheduled);
   setTaskDate(scheduleSource, "due", original.due);

--- a/packages/tasknotes-server/src/engine/recurring-completion.ts
+++ b/packages/tasknotes-server/src/engine/recurring-completion.ts
@@ -38,7 +38,9 @@ function restoreScheduleSource(
     ...(task.recurrence_anchor === undefined
       ? {}
       : { recurrence_anchor: task.recurrence_anchor }),
-    complete_instances: task.complete_instances ?? [],
+    complete_instances: (task.complete_instances ?? []).includes(date)
+      ? (task.complete_instances ?? [])
+      : [...(task.complete_instances ?? []), date],
     skipped_instances: (task.skipped_instances ?? []).filter(
       (entry) => entry !== date,
     ),
@@ -73,7 +75,9 @@ export function assertRecurringRestoreIsCurrent({
       ? recurrenceRuleWithoutStart(task.recurrence ?? "") ===
         recurrenceRuleWithoutStart(restore.recurrence)
       : task.recurrence === expectedRecurrence;
+  const targetIsNotSkipped = !(task.skipped_instances ?? []).includes(date);
   if (
+    !targetIsNotSkipped ||
     !recurrenceMatches ||
     (restore.scheduled !== null && task.scheduled !== expectedScheduled) ||
     (restore.due === null ? task.due !== undefined : task.due !== expectedDue)
@@ -82,6 +86,25 @@ export function assertRecurringRestoreIsCurrent({
       `recurring restore for ${task.path} is stale; refusing to overwrite newer task state`,
     );
   }
+}
+
+export function recurringRestoreMatchesCurrent(
+  task: TaskInfo,
+  restore: RecurringCompletionRestore,
+  date: string,
+): boolean {
+  return (
+    task.recurrence === restore.recurrence &&
+    (restore.scheduled === null
+      ? task.scheduled === undefined
+      : task.scheduled === restore.scheduled) &&
+    (restore.due === null
+      ? task.due === undefined
+      : task.due === restore.due) &&
+    (restore.skipped
+      ? (task.skipped_instances ?? []).includes(date)
+      : !(task.skipped_instances ?? []).includes(date))
+  );
 }
 
 function withInstanceMembership(

--- a/packages/tasknotes-server/src/engine/task-repository.ts
+++ b/packages/tasknotes-server/src/engine/task-repository.ts
@@ -16,9 +16,11 @@ import {
   taskInfoUpdatesToFrontmatterPatch,
 } from "tasknotes-types/v2";
 import type {
+  CompleteInstanceRequest,
   TaskCreationRequest,
   TaskInfo,
   TaskNotesModelConfig,
+  TaskPatchOperation,
   TaskUpdateInput,
   TaskUpdateRequest,
 } from "tasknotes-types/v2";
@@ -31,6 +33,10 @@ import {
 } from "./vault-files.ts";
 import { newTaskPath } from "./filename.ts";
 import { ymd } from "./date.ts";
+import {
+  recurringCompletionRestorePatch,
+  useDeterministicRecurringSchedule,
+} from "./recurring-completion.ts";
 import {
   tasksCreatedTotal,
   tasksDeletedTotal,
@@ -301,10 +307,7 @@ export class TaskRepository {
    */
   async completeInstance(
     id: string,
-    options: {
-      date?: string | undefined;
-      completed?: boolean | undefined;
-    } = {},
+    options: CompleteInstanceRequest = {},
   ): Promise<TaskInfo> {
     const fresh = await this.readFresh(id);
     const recurrence = fresh.task.recurrence;
@@ -312,24 +315,65 @@ export class TaskRepository {
       // Upstream 400s on non-recurring; route layer translates this.
       throw new NotRecurringError(id);
     }
-    const targetDate =
-      options.date === undefined ? this.clock() : new Date(options.date);
-    const dateStr = ymd(targetDate);
+    const dateStr = options.date ?? ymd(this.clock());
+    // Date-only request values are calendar days, not instants. Construct the
+    // model target at UTC midnight so its UTC formatter preserves the exact
+    // requested day in every server timezone. Bodyless legacy calls first
+    // resolve the server-local day, then use the same model representation.
+    const targetDate = new Date(`${dateStr}T00:00:00.000Z`);
     const already = (fresh.task.complete_instances ?? []).includes(dateStr);
     if (options.completed !== undefined && options.completed === already) {
-      return fresh.task; // set-semantics no-op
+      if (options.restore === undefined) {
+        return fresh.task; // set-semantics no-op
+      }
+      const patch: TaskPatchOperation[] = [
+        {
+          op: "set",
+          field: this.config.fieldMapping.completeInstances,
+          value: fresh.task.complete_instances ?? [],
+        },
+        {
+          op: "set",
+          field: this.config.fieldMapping.dateModified,
+          value: this.clock().toISOString(),
+        },
+        ...recurringCompletionRestorePatch(
+          options.restore,
+          dateStr,
+          fresh.task.skipped_instances,
+          this.config.fieldMapping,
+        ),
+      ];
+      return this.applyPlanPatch(id, fresh, patch, {});
     }
+    const now = this.clock();
+    const maintainDueDateOffset = this.config.recurrence.maintainDueDateOffset;
     const plan = buildRecurringTaskCompletePlan({
       freshTask: fresh.task,
       targetDate,
-      currentTimestamp: this.clock().toISOString(),
-      maintainDueDateOffsetInRecurring:
-        this.config.recurrence.maintainDueDateOffset,
+      currentTimestamp: now.toISOString(),
+      maintainDueDateOffsetInRecurring: maintainDueDateOffset,
     });
+    useDeterministicRecurringSchedule(
+      plan,
+      fresh.task,
+      ymd(now),
+      maintainDueDateOffset,
+    );
     const patch = recurringCompletePlanToFrontmatterPatch(
       plan,
       this.config.fieldMapping,
     );
+    if (options.restore !== undefined) {
+      patch.push(
+        ...recurringCompletionRestorePatch(
+          options.restore,
+          dateStr,
+          plan.updatedTask.skipped_instances,
+          this.config.fieldMapping,
+        ),
+      );
+    }
     return this.applyPlanPatch(id, fresh, patch, {});
   }
 

--- a/packages/tasknotes-server/src/engine/task-repository.ts
+++ b/packages/tasknotes-server/src/engine/task-repository.ts
@@ -329,10 +329,12 @@ export class TaskRepository {
       if (options.restore === undefined) {
         return fresh.task; // set-semantics no-op
       }
-      if (
-        !options.completed &&
-        !recurringRestoreMatchesCurrent(fresh.task, options.restore, dateStr)
-      ) {
+      if (!options.completed) {
+        if (
+          recurringRestoreMatchesCurrent(fresh.task, options.restore, dateStr)
+        ) {
+          return fresh.task;
+        }
         assertRecurringRestoreIsCurrent({
           task: fresh.task,
           restore: options.restore,

--- a/packages/tasknotes-server/src/engine/task-repository.ts
+++ b/packages/tasknotes-server/src/engine/task-repository.ts
@@ -36,6 +36,7 @@ import { ymd } from "./date.ts";
 import {
   assertRecurringRestoreIsCurrent,
   recurringCompletionRestorePatch,
+  recurringRestoreMatchesCurrent,
   useDeterministicRecurringSchedule,
 } from "./recurring-completion.ts";
 import {
@@ -327,6 +328,18 @@ export class TaskRepository {
     if (options.completed !== undefined && options.completed === already) {
       if (options.restore === undefined) {
         return fresh.task; // set-semantics no-op
+      }
+      if (
+        !options.completed &&
+        !recurringRestoreMatchesCurrent(fresh.task, options.restore, dateStr)
+      ) {
+        assertRecurringRestoreIsCurrent({
+          task: fresh.task,
+          restore: options.restore,
+          date: dateStr,
+          today: options.date === undefined ? ymd(now) : dateStr,
+          maintainDueDateOffset: this.config.recurrence.maintainDueDateOffset,
+        });
       }
       const patch: TaskPatchOperation[] = [
         {

--- a/packages/tasknotes-server/src/engine/task-repository.ts
+++ b/packages/tasknotes-server/src/engine/task-repository.ts
@@ -357,7 +357,7 @@ export class TaskRepository {
     useDeterministicRecurringSchedule(
       plan,
       fresh.task,
-      ymd(now),
+      options.date === undefined ? ymd(now) : dateStr,
       maintainDueDateOffset,
     );
     const patch = recurringCompletePlanToFrontmatterPatch(

--- a/packages/tasknotes-server/src/engine/task-repository.ts
+++ b/packages/tasknotes-server/src/engine/task-repository.ts
@@ -34,6 +34,7 @@ import {
 import { newTaskPath } from "./filename.ts";
 import { ymd } from "./date.ts";
 import {
+  assertRecurringRestoreIsCurrent,
   recurringCompletionRestorePatch,
   useDeterministicRecurringSchedule,
 } from "./recurring-completion.ts";
@@ -315,7 +316,8 @@ export class TaskRepository {
       // Upstream 400s on non-recurring; route layer translates this.
       throw new NotRecurringError(id);
     }
-    const dateStr = options.date ?? ymd(this.clock());
+    const now = this.clock();
+    const dateStr = options.date ?? ymd(now);
     // Date-only request values are calendar days, not instants. Construct the
     // model target at UTC midnight so its UTC formatter preserves the exact
     // requested day in every server timezone. Bodyless legacy calls first
@@ -335,7 +337,7 @@ export class TaskRepository {
         {
           op: "set",
           field: this.config.fieldMapping.dateModified,
-          value: this.clock().toISOString(),
+          value: now.toISOString(),
         },
         ...recurringCompletionRestorePatch(
           options.restore,
@@ -346,7 +348,6 @@ export class TaskRepository {
       ];
       return this.applyPlanPatch(id, fresh, patch, {});
     }
-    const now = this.clock();
     const maintainDueDateOffset = this.config.recurrence.maintainDueDateOffset;
     const plan = buildRecurringTaskCompletePlan({
       freshTask: fresh.task,
@@ -365,6 +366,15 @@ export class TaskRepository {
       this.config.fieldMapping,
     );
     if (options.restore !== undefined) {
+      if (options.completed === false) {
+        assertRecurringRestoreIsCurrent({
+          task: fresh.task,
+          restore: options.restore,
+          date: dateStr,
+          today: options.date === undefined ? ymd(now) : dateStr,
+          maintainDueDateOffset,
+        });
+      }
       patch.push(
         ...recurringCompletionRestorePatch(
           options.restore,

--- a/packages/tasknotes-server/src/v2/routes.ts
+++ b/packages/tasknotes-server/src/v2/routes.ts
@@ -18,6 +18,7 @@ import {
   type Clock,
   type TaskRepository,
 } from "../engine/task-repository.ts";
+import { RecurringRestoreConflictError } from "../engine/recurring-completion.ts";
 import { FilterQuerySchema, evaluateQuery } from "../engine/query.ts";
 import { ymd } from "../engine/date.ts";
 import { parseTaskInput } from "../nlp/parser.ts";
@@ -41,8 +42,9 @@ export type V2Dependencies = {
   clock?: Clock;
 };
 
-function errorStatus(error: unknown): 400 | 404 | 500 {
+function errorStatus(error: unknown): 400 | 404 | 409 | 500 {
   if (error instanceof TaskNotFoundError) return 404;
+  if (error instanceof RecurringRestoreConflictError) return 409;
   if (error instanceof NotRecurringError) return 400;
   if (error instanceof TimeTrackingError) return 400;
   if (error instanceof z.ZodError) return 400;

--- a/packages/tasknotes-types/src/v2.test.ts
+++ b/packages/tasknotes-types/src/v2.test.ts
@@ -7,7 +7,9 @@ import {
 import { z } from "zod";
 
 import {
+  CompleteInstanceRequestSchema,
   PriorityConfigV2Schema,
+  RecurringCompletionRestoreSchema,
   StatusConfigV2Schema,
   TaskInfoV2Schema,
   projectDisplayName,
@@ -111,6 +113,36 @@ describe("v2 wire schemas mirror @tasknotes/model", () => {
   });
 });
 
+describe("complete-instance request", () => {
+  const restore = {
+    scheduled: "2026-08-01",
+    due: null,
+    recurrence: "FREQ=WEEKLY",
+    skipped: false,
+  };
+
+  test("accepts a recurring completion snapshot only while uncompleting", () => {
+    expect(RecurringCompletionRestoreSchema.parse(restore)).toEqual(restore);
+    expect(
+      CompleteInstanceRequestSchema.parse({
+        date: "2026-08-01",
+        completed: false,
+        restore,
+      }),
+    ).toEqual({ date: "2026-08-01", completed: false, restore });
+  });
+
+  test("rejects restore for completion or legacy toggle requests", () => {
+    expect(
+      CompleteInstanceRequestSchema.safeParse({ completed: true, restore })
+        .success,
+    ).toBe(false);
+    expect(CompleteInstanceRequestSchema.safeParse({ restore }).success).toBe(
+      false,
+    );
+  });
+});
+
 describe("wikilink project helpers", () => {
   test("projectPath and projectDisplayName cover all spellings", () => {
     expect(projectPath("[[Projects/Big Launch|Launch]]")).toBe(
@@ -132,5 +164,11 @@ describe("wikilink project helpers", () => {
     expect(projectMatches(link, "Other")).toBe(false);
     expect(projectMatches("Foo", "Foo")).toBe(true);
     expect(projectMatches("Foo", "Bar")).toBe(false);
+  });
+
+  test("projectMatches preserves distinct qualified paths with one basename", () => {
+    expect(projectMatches("[[Areas/Work]]", "[[Projects/Work]]")).toBe(false);
+    expect(projectMatches("Areas/Work", "Projects/Work")).toBe(false);
+    expect(projectMatches("[[Areas/Work]]", "Work")).toBe(true);
   });
 });

--- a/packages/tasknotes-types/src/v2.ts
+++ b/packages/tasknotes-types/src/v2.ts
@@ -168,15 +168,39 @@ export type TaskUpdateRequest = z.infer<typeof TaskUpdateRequestSchema>;
  * POST /api/tasks/:id/complete-instance — upstream takes `{date?}` and
  * TOGGLES that instance. `completed` is this server's set-semantics
  * extension (P1): when present, the instance is set absolutely, which is
- * what makes the app's offline replay idempotent.
+ * what makes the app's offline replay idempotent. `restore` is accepted only
+ * while clearing a completed instance and restores the recurring schedule
+ * snapshot that existed before completion advanced it.
  */
-export const CompleteInstanceRequestSchema = z.object({
-  // z.iso.date() rejects malformed dates (e.g. "not-a-date") at the schema
-  // boundary with a 400, instead of letting `new Date(...)` produce an
-  // Invalid Date that later throws RangeError out of `ymd(...).toISOString()`.
-  date: z.iso.date().optional(),
-  completed: z.boolean().optional(),
+export const RecurringCompletionRestoreSchema = z.object({
+  scheduled: z.string().nullable(),
+  due: z.string().nullable(),
+  recurrence: z.string(),
+  skipped: z.boolean(),
 });
+
+export type RecurringCompletionRestore = z.infer<
+  typeof RecurringCompletionRestoreSchema
+>;
+
+export const CompleteInstanceRequestSchema = z
+  .object({
+    // z.iso.date() rejects malformed dates (e.g. "not-a-date") at the schema
+    // boundary with a 400, instead of letting `new Date(...)` produce an
+    // Invalid Date that later throws RangeError out of `ymd(...).toISOString()`.
+    date: z.iso.date().optional(),
+    completed: z.boolean().optional(),
+    restore: RecurringCompletionRestoreSchema.optional(),
+  })
+  .superRefine((request, context) => {
+    if (request.restore !== undefined && request.completed !== false) {
+      context.addIssue({
+        code: "custom",
+        path: ["restore"],
+        message: "restore is allowed only when completed is false",
+      });
+    }
+  });
 
 export type CompleteInstanceRequest = z.infer<
   typeof CompleteInstanceRequestSchema
@@ -399,8 +423,9 @@ export function projectDisplayName(value: string): string {
 
 /**
  * Whether two project values refer to the same project, tolerant of the
- * wikilink/bare-name duality: full paths, basenames, and aliases all count
- * (case-insensitive).
+ * wikilink/bare-name duality. Two path-qualified values only match when their
+ * canonical vault paths match; this keeps projects such as `Areas/Work` and
+ * `Projects/Work` distinct even though they share a display basename.
  */
 function projectKeys(value: string): Set<string> {
   const path = projectPath(value).toLowerCase();
@@ -414,6 +439,11 @@ function projectKeys(value: string): Set<string> {
 }
 
 export function projectMatches(a: string, b: string): boolean {
+  const pathA = projectPath(a).toLowerCase();
+  const pathB = projectPath(b).toLowerCase();
+  if (pathA === pathB) return true;
+  if (pathA.includes("/") && pathB.includes("/")) return false;
+
   const ka = projectKeys(a);
   return [...projectKeys(b)].some((k) => ka.has(k));
 }

--- a/packages/tasks-for-obsidian/src/components/common/UndoToast.tsx
+++ b/packages/tasks-for-obsidian/src/components/common/UndoToast.tsx
@@ -14,8 +14,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useSettings } from "../../hooks/use-settings";
 import { typography } from "../../styles/typography";
-
-export const UNDO_TOAST_MS = 5000;
+import { UNDO_TOAST_MS } from "../../domain/task-toggle";
 
 type Props = {
   visible: boolean;

--- a/packages/tasks-for-obsidian/src/data/api/TaskNotesClient.ts
+++ b/packages/tasks-for-obsidian/src/data/api/TaskNotesClient.ts
@@ -45,6 +45,7 @@ import {
   wireNlpParseSchema,
 } from "../../domain/wire";
 import { PATHS } from "./endpoints";
+import type { CompleteInstanceRequest } from "tasknotes-types/v2";
 
 export type TaskNotesClientConfig = {
   baseUrl: string;
@@ -230,7 +231,7 @@ export class TaskNotesClient {
    */
   async completeRecurringInstance(
     id: TaskId,
-    instance?: { date: string; completed: boolean },
+    instance?: CompleteInstanceRequest,
     options?: MutationOptions,
   ): Promise<Result<Task, AppError>> {
     return this.request(

--- a/packages/tasks-for-obsidian/src/data/cache/storage.ts
+++ b/packages/tasks-for-obsidian/src/data/cache/storage.ts
@@ -11,6 +11,7 @@ const KEYS = {
   QUEUE_V2: "mutation_queue_v2",
   DEAD_LETTER: "dead_letter",
   ID_ALIASES: "id_aliases",
+  ACKNOWLEDGED_COMPLETION_RESTORES: "acknowledged_completion_restores",
   SCHEMA_VERSION: "storage_schema_version",
   LAST_SYNC: "last_sync_time",
 } as const;
@@ -106,6 +107,14 @@ export const TypedStorage = {
 
   async setIdAliases(data: string): Promise<void> {
     await AsyncStorage.setItem(KEYS.ID_ALIASES, data);
+  },
+
+  async getAcknowledgedCompletionRestores(): Promise<string | null> {
+    return AsyncStorage.getItem(KEYS.ACKNOWLEDGED_COMPLETION_RESTORES);
+  },
+
+  async setAcknowledgedCompletionRestores(data: string): Promise<void> {
+    await AsyncStorage.setItem(KEYS.ACKNOWLEDGED_COMPLETION_RESTORES, data);
   },
 
   async getSchemaVersion(): Promise<number> {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -414,6 +414,24 @@ describe("TaskStore restore validation", () => {
 
     await expect(store.restore()).rejects.toThrow();
   });
+
+  test("surfaces malformed persisted restore keys", async () => {
+    const storeStorage = memoryStoreStorage({
+      acknowledgedCompletionRestores: JSON.stringify({
+        "TaskNotes/test.md": {
+          restore: {
+            scheduled: "2026-08-08",
+            due: null,
+            recurrence: "FREQ=WEEKLY",
+            skipped: false,
+          },
+        },
+      }),
+    });
+    const { store } = makeStore(memoryQueueStorage(), storeStorage);
+
+    await expect(store.restore()).rejects.toThrow();
+  });
 });
 
 describe("TaskStore restore ordering", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -233,6 +233,55 @@ describe("TaskStore server acks", () => {
   });
 });
 
+describe("TaskStore full pulls", () => {
+  test("invalidates acknowledged restores after an external recurrence edit", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore: {
+        scheduled: "2026-08-08",
+        due: null,
+        recurrence: "FREQ=WEEKLY",
+        skipped: false,
+      },
+    });
+    const command = queue.head();
+    if (command?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(command, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    await store.replaceBase(
+      [
+        {
+          ...task,
+          recurrence: "FREQ=MONTHLY",
+          completeInstances: ["2026-08-08"],
+        },
+      ],
+      now,
+    );
+
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(undefined);
+  });
+});
+
 describe("TaskStore pending restores", () => {
   test("reads a pending restore after an in-flight create remaps its id", async () => {
     const backingStorage = memoryStoreStorage();

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -281,6 +281,66 @@ describe("TaskStore pending restores", () => {
     await ack;
     await expect(pendingRestore).resolves.toEqual(restore);
   });
+
+  test("retains a restore while its completion acknowledgement is settling", async () => {
+    const backingStorage = memoryStoreStorage();
+    const ackWriteStarted = Promise.withResolvers<null>();
+    const releaseAckWrite = Promise.withResolvers<null>();
+    let pauseAckWrite = false;
+    const storeStorage: MemoryStoreStorage = {
+      ...backingStorage,
+      setTasks: async (tasks) => {
+        if (pauseAckWrite) {
+          pauseAckWrite = false;
+          ackWriteStarted.resolve(null);
+          await releaseAckWrite.promise;
+        }
+        await backingStorage.setTasks(tasks);
+      },
+    };
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    const storeWithPausedAck = new TaskStore(queue, storeStorage, clock);
+    await storeWithPausedAck.restore();
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await storeWithPausedAck.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const command = queue.head();
+    if (command?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+
+    pauseAckWrite = true;
+    const ack = storeWithPausedAck.applyServerAck(command, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+    await ackWriteStarted.promise;
+    const pendingRestore = storeWithPausedAck.getPendingCompletionRestore(
+      task.id,
+      "2026-08-08",
+    );
+    releaseAckWrite.resolve(null);
+
+    await ack;
+    await expect(pendingRestore).resolves.toEqual(restore);
+  });
 });
 
 describe("TaskStore server acks", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { ApiError } from "../../domain/errors";
 import type { Task, TaskId } from "../../domain/types";
 import { taskId } from "../../domain/types";
+import { UNDO_TOAST_MS } from "../../domain/task-toggle";
 import { CommandQueue } from "../sync/CommandQueue";
 import {
   type MemoryQueueStorage,
@@ -423,6 +424,9 @@ describe("TaskStore pending restores", () => {
       taskId: task.id,
       payload: { recurrence: "FREQ=MONTHLY" },
     });
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(undefined);
     const updateCommand = queue.head();
     if (updateCommand?.type !== "update") {
       throw new Error("expected update command");
@@ -436,6 +440,47 @@ describe("TaskStore pending restores", () => {
     await expect(
       store.getPendingCompletionRestore(task.id, "2026-08-08"),
     ).resolves.toEqual(undefined);
+  });
+});
+
+describe("TaskStore restore expiry", () => {
+  test("expires acknowledged restores after the undo window", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue, storeStorage } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const command = queue.head();
+    if (command?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(command, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+    now += UNDO_TOAST_MS + 1;
+
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(undefined);
+    expect(await storeStorage.getAcknowledgedCompletionRestores()).toBe("{}");
   });
 });
 

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -327,6 +327,68 @@ describe("TaskStore full pulls", () => {
       store.getPendingCompletionRestore(task.id, "2026-08-08"),
     ).resolves.toEqual(undefined);
   });
+
+  test("persists restore invalidation before a pulled base write", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const backingStorage = memoryStoreStorage({ tasks: [task] });
+    let failBaseWrite = false;
+    const storeStorage = {
+      ...backingStorage,
+      setTasks: async (tasks: Task[]) => {
+        if (failBaseWrite) throw new Error("base pull interrupted");
+        await backingStorage.setTasks(tasks);
+      },
+    };
+    const { store, queue } = makeStore(memoryQueueStorage(), storeStorage);
+    await store.restore();
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const command = queue.head();
+    if (command?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(command, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    failBaseWrite = true;
+    await expect(
+      store.replaceBase(
+        [
+          {
+            ...task,
+            recurrence: "FREQ=MONTHLY",
+            completeInstances: ["2026-08-08"],
+          },
+        ],
+        now,
+      ),
+    ).rejects.toThrow("base pull interrupted");
+
+    const relaunched = makeStore(
+      memoryQueueStorage(),
+      backingStorage.clone(),
+    ).store;
+    await relaunched.restore();
+    await expect(
+      relaunched.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(undefined);
+  });
 });
 
 describe("TaskStore restore validation", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -453,6 +453,54 @@ describe("TaskStore restore ordering", () => {
   });
 });
 
+describe("TaskStore restore retention", () => {
+  test("retains a restore when a later occurrence edit is dead-lettered", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const completion = queue.head();
+    if (completion?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(completion, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { recurrence: "FREQ=MONTHLY" },
+    });
+    const edit = queue.head();
+    if (edit?.type !== "update") throw new Error("expected edit command");
+    await store.deadLetterCommand(edit.id, new ApiError("invalid", 422));
+
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+  });
+});
+
 describe("TaskStore pending restores", () => {
   test("reads a pending restore after an in-flight create remaps its id", async () => {
     const backingStorage = memoryStoreStorage();

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -341,6 +341,50 @@ describe("TaskStore pending restores", () => {
     await ack;
     await expect(pendingRestore).resolves.toEqual(restore);
   });
+
+  test("persists an acknowledged restore across relaunch", async () => {
+    const queueStorage = memoryQueueStorage();
+    const storeStorage = memoryStoreStorage();
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(queueStorage, storeStorage);
+    await store.restore();
+    await store.replaceBase([task], now);
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const command = queue.head();
+    if (command?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(command, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    const relaunchedQueue = new CommandQueue(queueStorage.clone(), clock);
+    const relaunched = new TaskStore(
+      relaunchedQueue,
+      storeStorage.clone(),
+      clock,
+    );
+    await relaunched.restore();
+    await expect(
+      relaunched.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+  });
 });
 
 describe("TaskStore server acks", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -181,6 +181,57 @@ describe("TaskStore server acks", () => {
     expect(store.getSnapshot().tasks.get(real.id)?.status).toBe("done");
   });
 
+  test("serializes a stale-id dispatch across an in-flight create ack", async () => {
+    const backingStorage = memoryStoreStorage();
+    const aliasWriteStarted = Promise.withResolvers<null>();
+    const releaseAliasWrite = Promise.withResolvers<null>();
+    let pauseAliasWrite = false;
+    const storeStorage: MemoryStoreStorage = {
+      ...backingStorage,
+      setIdAliases: async (data) => {
+        if (pauseAliasWrite) {
+          pauseAliasWrite = false;
+          aliasWriteStarted.resolve(null);
+          await releaseAliasWrite.promise;
+        }
+        await backingStorage.setIdAliases(data);
+      },
+    };
+    const { store, queue } = makeStore(memoryQueueStorage(), storeStorage);
+    await store.restore();
+    const optimistic = await store.dispatch({
+      type: "create",
+      payload: { title: "New" },
+    });
+    if (optimistic === undefined) throw new Error("expected optimistic task");
+    const createCmd = queue.head();
+    if (createCmd?.type !== "create") throw new Error("expected create head");
+    const real = makeTask({ id: taskId("TaskNotes/New.md"), title: "New" });
+
+    pauseAliasWrite = true;
+    const ack = store.applyServerAck(createCmd, real);
+    await aliasWriteStarted.promise;
+
+    // While persistence is paused, readers still observe the prior alias and
+    // snapshot together. The queued dispatch waits and resolves its stale id
+    // only after the acknowledgement publishes the real task.
+    expect(store.resolveTaskId(optimistic.id)).toBe(optimistic.id);
+    expect(store.getSnapshot().tasks.has(optimistic.id)).toBe(true);
+    const dispatch = store.dispatch({
+      type: "set_status",
+      taskId: optimistic.id,
+      status: "done",
+    });
+
+    releaseAliasWrite.resolve(null);
+    await ack;
+    const updated = await dispatch;
+    expect(updated?.id).toBe(real.id);
+    expect(updated?.status).toBe("done");
+    const pending = queue.head();
+    expect(pending?.type === "set_status" && pending.taskId).toBe(real.id);
+  });
+
   test("delete ack removes from base; update ack merges the server task", async () => {
     const seeded = makeTask();
     const other = makeTask({
@@ -214,6 +265,40 @@ describe("TaskStore server acks", () => {
     await store.applyServerAck(deleteCmd, null);
     expect(store.getSnapshot().tasks.has(other.id)).toBe(false);
     expect(store.getSnapshot().pendingCount).toBe(0);
+  });
+
+  test("keeps an acknowledged command durable until its base write succeeds", async () => {
+    const seeded = makeTask();
+    const queueStorage = memoryQueueStorage();
+    const backingStorage = memoryStoreStorage({ tasks: [seeded] });
+    const storeStorage: MemoryStoreStorage = {
+      ...backingStorage,
+      setTasks: () => Promise.reject(new Error("base write interrupted")),
+    };
+    const { store, queue } = makeStore(queueStorage, storeStorage);
+    await store.restore();
+    await store.dispatch({
+      type: "update",
+      taskId: seeded.id,
+      payload: { title: "Durable rename" },
+    });
+    const command = queue.head();
+    if (command === undefined) throw new Error("expected queued update");
+
+    await expect(
+      store.applyServerAck(command, { ...seeded, title: "Durable rename" }),
+    ).rejects.toThrow("base write interrupted");
+    expect(queue.pending.map((pending) => pending.id)).toEqual([command.id]);
+
+    const relaunched = makeStore(
+      queueStorage.clone(),
+      backingStorage.clone(),
+    ).store;
+    await relaunched.restore();
+    expect(relaunched.getSnapshot().pendingCount).toBe(1);
+    expect(relaunched.getSnapshot().tasks.get(seeded.id)?.title).toBe(
+      "Durable rename",
+    );
   });
 });
 

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -469,6 +469,45 @@ describe("TaskStore restore ordering", () => {
       store.getPendingCompletionRestore(task.id, "2026-08-08"),
     ).resolves.toEqual(restore);
   });
+
+  test("classifies later edits against the state at completion", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const restore = {
+      scheduled: "2026-08-15",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { scheduled: "2026-08-15" },
+    });
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { title: "Renamed", scheduled: "2026-08-15" },
+    });
+
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+  });
 });
 
 describe("TaskStore restore retention", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -280,6 +280,78 @@ describe("TaskStore full pulls", () => {
       store.getPendingCompletionRestore(task.id, "2026-08-08"),
     ).resolves.toEqual(undefined);
   });
+
+  test("invalidates acknowledged restores after an external skip edit", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore: {
+        scheduled: "2026-08-08",
+        due: null,
+        recurrence: "FREQ=WEEKLY",
+        skipped: false,
+      },
+    });
+    const command = queue.head();
+    if (command?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(command, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    await store.replaceBase(
+      [
+        {
+          ...task,
+          completeInstances: ["2026-08-08"],
+          skippedInstances: ["2026-08-08"],
+        },
+      ],
+      now,
+    );
+
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(undefined);
+  });
+});
+
+describe("TaskStore restore validation", () => {
+  test("surfaces malformed persisted restore JSON", async () => {
+    const storeStorage = memoryStoreStorage({
+      acknowledgedCompletionRestores: "not-json",
+    });
+    const { store } = makeStore(memoryQueueStorage(), storeStorage);
+
+    await expect(store.restore()).rejects.toThrow();
+    expect(await storeStorage.getAcknowledgedCompletionRestores()).toBe(
+      "not-json",
+    );
+  });
+
+  test("surfaces incompatible persisted restore shapes", async () => {
+    const storeStorage = memoryStoreStorage({
+      acknowledgedCompletionRestores: JSON.stringify({
+        "TaskNotes/test.md\u{0}2026-08-08": { restore: { recurrence: 42 } },
+      }),
+    });
+    const { store } = makeStore(memoryQueueStorage(), storeStorage);
+
+    await expect(store.restore()).rejects.toThrow();
+  });
 });
 
 describe("TaskStore pending restores", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -231,7 +231,59 @@ describe("TaskStore server acks", () => {
     const pending = queue.head();
     expect(pending?.type === "set_status" && pending.taskId).toBe(real.id);
   });
+});
 
+describe("TaskStore pending restores", () => {
+  test("reads a pending restore after an in-flight create remaps its id", async () => {
+    const backingStorage = memoryStoreStorage();
+    const aliasWriteStarted = Promise.withResolvers<null>();
+    const releaseAliasWrite = Promise.withResolvers<null>();
+    const storeStorage: MemoryStoreStorage = {
+      ...backingStorage,
+      setIdAliases: async (data) => {
+        aliasWriteStarted.resolve(null);
+        await releaseAliasWrite.promise;
+        await backingStorage.setIdAliases(data);
+      },
+    };
+    const { store, queue } = makeStore(memoryQueueStorage(), storeStorage);
+    await store.restore();
+    const optimistic = await store.dispatch({
+      type: "create",
+      payload: { title: "New" },
+    });
+    if (optimistic === undefined) throw new Error("expected optimistic task");
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: optimistic.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const createCmd = queue.head();
+    if (createCmd?.type !== "create") throw new Error("expected create head");
+    const real = makeTask({ id: taskId("TaskNotes/New.md"), title: "New" });
+
+    const ack = store.applyServerAck(createCmd, real);
+    await aliasWriteStarted.promise;
+    const pendingRestore = store.getPendingCompletionRestore(
+      optimistic.id,
+      "2026-08-08",
+    );
+    releaseAliasWrite.resolve(null);
+
+    await ack;
+    await expect(pendingRestore).resolves.toEqual(restore);
+  });
+});
+
+describe("TaskStore server acks", () => {
   test("delete ack removes from base; update ack merges the server task", async () => {
     const seeded = makeTask();
     const other = makeTask({

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -385,6 +385,58 @@ describe("TaskStore pending restores", () => {
       relaunched.getPendingCompletionRestore(task.id, "2026-08-08"),
     ).resolves.toEqual(restore);
   });
+
+  test("invalidates an acknowledged restore after recurrence edits", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const completionCommand = queue.head();
+    if (completionCommand?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(completionCommand, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { recurrence: "FREQ=MONTHLY" },
+    });
+    const updateCommand = queue.head();
+    if (updateCommand?.type !== "update") {
+      throw new Error("expected update command");
+    }
+    await store.applyServerAck(updateCommand, {
+      ...task,
+      recurrence: "FREQ=MONTHLY",
+      completeInstances: [],
+    });
+
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(undefined);
+  });
 });
 
 describe("TaskStore server acks", () => {

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { ApiError } from "../../domain/errors";
 import type { Task, TaskId } from "../../domain/types";
 import { taskId } from "../../domain/types";
-import { UNDO_TOAST_MS } from "../../domain/task-toggle";
 import { CommandQueue } from "../sync/CommandQueue";
 import {
   type MemoryQueueStorage,
@@ -444,7 +443,7 @@ describe("TaskStore pending restores", () => {
 });
 
 describe("TaskStore restore expiry", () => {
-  test("expires acknowledged restores after the undo window", async () => {
+  test("prunes acknowledged restores after their occurrence day", async () => {
     const task = makeTask({
       recurrence: "FREQ=WEEKLY",
       scheduled: "2026-08-08",
@@ -475,7 +474,7 @@ describe("TaskStore restore expiry", () => {
       ...task,
       completeInstances: ["2026-08-08"],
     });
-    now += UNDO_TOAST_MS + 1;
+    now = Date.parse("2026-08-09T12:00:00.000Z");
 
     await expect(
       store.getPendingCompletionRestore(task.id, "2026-08-08"),

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -525,6 +525,52 @@ describe("TaskStore restore retention", () => {
     ).resolves.toEqual(restore);
   });
 
+  test("treats null and undefined schedule fields as unchanged", async () => {
+    const task = makeTask({ recurrence: "FREQ=WEEKLY" });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const restore = {
+      scheduled: null,
+      due: null,
+      recurrence: "FREQ=WEEKLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const completion = queue.head();
+    if (completion?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(completion, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { title: "Renamed", due: null, scheduled: null },
+    });
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+
+    const edit = queue.head();
+    if (edit?.type !== "update") throw new Error("expected edit command");
+    await store.applyServerAck(edit, { ...task, title: "Renamed" });
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+  });
+
   test("retains a restore when a later occurrence edit is dead-lettered", async () => {
     const task = makeTask({
       recurrence: "FREQ=WEEKLY",

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -354,6 +354,43 @@ describe("TaskStore restore validation", () => {
   });
 });
 
+describe("TaskStore restore ordering", () => {
+  test("keeps a restore captured after an earlier queued occurrence edit", async () => {
+    const task = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "FREQ=MONTHLY",
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { recurrence: "FREQ=MONTHLY" },
+    });
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+
+    expect(queue.pending).toHaveLength(2);
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+  });
+});
+
 describe("TaskStore pending restores", () => {
   test("reads a pending restore after an in-flight create remaps its id", async () => {
     const backingStorage = memoryStoreStorage();

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -472,6 +472,59 @@ describe("TaskStore restore ordering", () => {
 });
 
 describe("TaskStore restore retention", () => {
+  test("retains a restore for an update with unchanged schedule fields", async () => {
+    const task = makeTask({
+      due: "2026-08-10",
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+    });
+    const { store, queue } = makeStore(
+      memoryQueueStorage(),
+      memoryStoreStorage({ tasks: [task] }),
+    );
+    await store.restore();
+    const scheduled = task.scheduled ?? null;
+    const due = task.due ?? null;
+    const recurrence = task.recurrence ?? "";
+    const restore = {
+      scheduled,
+      due,
+      recurrence,
+      skipped: false,
+    };
+    await store.dispatch({
+      type: "set_instance_complete",
+      taskId: task.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    const completion = queue.head();
+    if (completion?.type !== "set_instance_complete") {
+      throw new Error("expected completion command");
+    }
+    await store.applyServerAck(completion, {
+      ...task,
+      completeInstances: ["2026-08-08"],
+    });
+
+    await store.dispatch({
+      type: "update",
+      taskId: task.id,
+      payload: { title: "Renamed", due, scheduled },
+    });
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+
+    const edit = queue.head();
+    if (edit?.type !== "update") throw new Error("expected edit command");
+    await store.applyServerAck(edit, { ...task, title: "Renamed" });
+    await expect(
+      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+    ).resolves.toEqual(restore);
+  });
+
   test("retains a restore when a later occurrence edit is dead-lettered", async () => {
     const task = makeTask({
       recurrence: "FREQ=WEEKLY",

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -391,8 +391,6 @@ export class TaskStore {
       for (const [tempId, realId] of nextAliases) {
         if (!nextBase.has(realId)) nextAliases.delete(tempId);
       }
-      await this.persistBase(nextBase);
-      await this.persistAliases(nextAliases);
       const prunedAcknowledgedCompletionRestores = pruneCompletionRestores(
         this.acknowledgedCompletionRestores,
         localTodayYmd(new Date(this.clock())),
@@ -409,6 +407,8 @@ export class TaskStore {
           nextAcknowledgedCompletionRestores,
         ),
       );
+      await this.persistBase(nextBase);
+      await this.persistAliases(nextAliases);
       await this.storage.setLastSyncTime(syncedAt);
 
       this.base = nextBase;

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../domain/types";
 import { taskId } from "../../domain/types";
 import type { TaskStatus } from "../../domain/status";
+import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 import type { CommandQueue, DeadLetterEntry } from "../sync/CommandQueue";
 import {
   type Clock,
@@ -61,6 +62,7 @@ export type DispatchInput =
       readonly taskId: TaskId;
       readonly date: string;
       readonly completed: boolean;
+      readonly restore?: RecurringCompletionRestore | undefined;
     };
 
 export type TaskStoreStorage = {
@@ -90,6 +92,8 @@ export class TaskStore {
   private snapshot: TaskStoreSnapshot;
   private readonly listeners = new Set<() => void>();
   private readonly nextCommandId: () => string;
+  private operationLocked = false;
+  private readonly operationWaiters: (() => void)[] = [];
 
   /** Wired to SyncEngine.requestSync — fired after every dispatch. */
   onDispatch: (() => void) | null = null;
@@ -105,16 +109,18 @@ export class TaskStore {
 
   /** Load queue + cached base + aliases. Call once at startup, after migrations. */
   async restore(): Promise<void> {
-    await this.queue.restore();
-    const [tasks, rawAliases, lastSync] = await Promise.all([
-      this.storage.getTasks(),
-      this.storage.getIdAliases(),
-      this.storage.getLastSyncTime(),
-    ]);
-    this.base = new Map(tasks.map((t) => [t.id, t]));
-    this.aliases = parseAliases(rawAliases);
-    this.lastSyncTime = lastSync;
-    this.recompute();
+    await this.enqueueOperation(async () => {
+      await this.queue.restore();
+      const [tasks, rawAliases, lastSync] = await Promise.all([
+        this.storage.getTasks(),
+        this.storage.getIdAliases(),
+        this.storage.getLastSyncTime(),
+      ]);
+      this.base = new Map(tasks.map((t) => [t.id, t]));
+      this.aliases = parseAliases(rawAliases);
+      this.lastSyncTime = lastSync;
+      this.recompute();
+    });
   }
 
   subscribe(listener: () => void): () => void {
@@ -134,12 +140,18 @@ export class TaskStore {
    * UI will now see it (undefined after a delete).
    */
   async dispatch(input: DispatchInput): Promise<Task | undefined> {
-    const command = this.buildCommand(input);
-    await this.queue.enqueue(command);
-    this.recompute();
-    this.onDispatch?.();
-    const target = command.type === "create" ? command.tempId : command.taskId;
-    return this.snapshot.tasks.get(target);
+    return this.enqueueOperation(async () => {
+      // Build inside the serialized operation so a stale temp id is resolved
+      // only after any in-flight create acknowledgement has committed its
+      // alias and snapshot together.
+      const command = this.buildCommand(input);
+      await this.queue.enqueue(command);
+      this.recompute();
+      this.onDispatch?.();
+      const target =
+        command.type === "create" ? command.tempId : command.taskId;
+      return this.snapshot.tasks.get(target);
+    });
   }
 
   /**
@@ -160,51 +172,78 @@ export class TaskStore {
     command: Command,
     serverTask: Task | null,
   ): Promise<void> {
-    if (serverTask !== null && command.type === "create") {
-      this.aliases.set(command.tempId, serverTask.id);
-      await this.queue.remapTaskId(command.tempId, serverTask.id);
-      await this.persistAliases();
-    }
-    if (command.type === "delete") {
-      this.base.delete(command.taskId);
-    } else if (serverTask !== null) {
-      this.base.set(serverTask.id, serverTask);
-    }
-    await this.queue.ack(command.id);
-    await this.persistBase();
-    this.recompute();
+    await this.enqueueOperation(async () => {
+      let nextAliases = this.aliases;
+      if (serverTask !== null && command.type === "create") {
+        nextAliases = new Map(this.aliases);
+        nextAliases.set(command.tempId, serverTask.id);
+        await this.queue.remapTaskId(command.tempId, serverTask.id);
+        await this.persistAliases(nextAliases);
+      }
+
+      const nextBase = new Map(this.base);
+      if (command.type === "delete") {
+        nextBase.delete(command.taskId);
+      } else if (serverTask !== null) {
+        nextBase.set(serverTask.id, serverTask);
+      }
+      // Persist the authoritative base before removing the durable command.
+      // If the process dies between these writes, idempotent mutation replay
+      // is safe; the reverse order could lose the accepted mutation offline.
+      await this.persistBase(nextBase);
+      await this.queue.ack(command.id);
+
+      // Publish the alias/base/snapshot as one synchronous state transition.
+      // Readers can therefore never observe a real-id alias paired with the
+      // preceding temp-id snapshot while persistence is in flight.
+      this.aliases = nextAliases;
+      this.base = nextBase;
+      this.recompute();
+    });
   }
 
   /** A command failed permanently — park it and roll back its optimistic effect. */
   async deadLetterCommand(
     ...args: Parameters<CommandQueue["deadLetter"]>
   ): Promise<void> {
-    await this.queue.deadLetter(...args);
-    this.recompute();
+    await this.enqueueOperation(async () => {
+      await this.queue.deadLetter(...args);
+      this.recompute();
+    });
   }
 
   async retryDeadLetter(id: string): Promise<void> {
-    await this.queue.retryDeadLetter(id);
-    this.recompute();
-    this.onDispatch?.();
+    await this.enqueueOperation(async () => {
+      await this.queue.retryDeadLetter(id);
+      this.recompute();
+      this.onDispatch?.();
+    });
   }
 
   async discardDeadLetter(id: string): Promise<void> {
-    await this.queue.discardDeadLetter(id);
-    this.recompute();
+    await this.enqueueOperation(async () => {
+      await this.queue.discardDeadLetter(id);
+      this.recompute();
+    });
   }
 
   /** Replace the base with a fresh full pull and prune stale aliases. */
   async replaceBase(tasks: Task[], syncedAt: number): Promise<void> {
-    this.base = new Map(tasks.map((t) => [t.id, t]));
-    for (const [tempId, realId] of this.aliases) {
-      if (!this.base.has(realId)) this.aliases.delete(tempId);
-    }
-    this.lastSyncTime = syncedAt;
-    await this.persistBase();
-    await this.persistAliases();
-    await this.storage.setLastSyncTime(syncedAt);
-    this.recompute();
+    await this.enqueueOperation(async () => {
+      const nextBase = new Map(tasks.map((t) => [t.id, t]));
+      const nextAliases = new Map(this.aliases);
+      for (const [tempId, realId] of nextAliases) {
+        if (!nextBase.has(realId)) nextAliases.delete(tempId);
+      }
+      await this.persistBase(nextBase);
+      await this.persistAliases(nextAliases);
+      await this.storage.setLastSyncTime(syncedAt);
+
+      this.base = nextBase;
+      this.aliases = nextAliases;
+      this.lastSyncTime = syncedAt;
+      this.recompute();
+    });
   }
 
   private buildCommand(input: DispatchInput): Command {
@@ -215,12 +254,31 @@ export class TaskStore {
       case "update":
       case "delete":
       case "set_status":
-      case "set_instance_complete":
         return {
           ...base,
           ...input,
           taskId: this.resolveTaskId(input.taskId),
         };
+      case "set_instance_complete": {
+        const resolvedTaskId = this.resolveTaskId(input.taskId);
+        if (input.completed) {
+          return {
+            ...base,
+            type: input.type,
+            taskId: resolvedTaskId,
+            date: input.date,
+            completed: true,
+          };
+        }
+        return {
+          ...base,
+          type: input.type,
+          taskId: resolvedTaskId,
+          date: input.date,
+          completed: false,
+          ...(input.restore === undefined ? {} : { restore: input.restore }),
+        };
+      }
     }
   }
 
@@ -245,16 +303,48 @@ export class TaskStore {
     };
   }
 
-  private async persistBase(): Promise<void> {
-    await this.storage.setTasks([...this.base.values()]);
+  private async persistBase(base: ReadonlyMap<TaskId, Task>): Promise<void> {
+    await this.storage.setTasks([...base.values()]);
   }
 
-  private async persistAliases(): Promise<void> {
+  private async persistAliases(
+    aliases: ReadonlyMap<TaskId, TaskId>,
+  ): Promise<void> {
     const record: Record<string, string> = {};
-    for (const [from, to] of this.aliases) {
+    for (const [from, to] of aliases) {
       record[String(from)] = String(to);
     }
     await this.storage.setIdAliases(JSON.stringify(record));
+  }
+
+  private async enqueueOperation<Value>(
+    operation: () => Promise<Value>,
+  ): Promise<Value> {
+    await this.acquireOperationLock();
+    try {
+      return await operation();
+    } finally {
+      this.releaseOperationLock();
+    }
+  }
+
+  private async acquireOperationLock(): Promise<void> {
+    if (!this.operationLocked) {
+      this.operationLocked = true;
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      this.operationWaiters.push(resolve);
+    });
+  }
+
+  private releaseOperationLock(): void {
+    const next = this.operationWaiters.shift();
+    if (next === undefined) {
+      this.operationLocked = false;
+      return;
+    }
+    next();
   }
 }
 

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -85,9 +85,17 @@ const defaultStorage: TaskStoreStorage = {
 
 const AliasesSchema = z.record(z.string(), z.string());
 
+function completionRestoreKey(id: TaskId, date: string): string {
+  return `${String(id)}\u{0}${date}`;
+}
+
 export class TaskStore {
   private base = new Map<TaskId, Task>();
   private aliases = new Map<TaskId, TaskId>();
+  private acknowledgedCompletionRestores = new Map<
+    string,
+    RecurringCompletionRestore
+  >();
   private lastSyncTime: number | null = null;
   private snapshot: TaskStoreSnapshot;
   private readonly listeners = new Set<() => void>();
@@ -117,7 +125,14 @@ export class TaskStore {
           break;
         }
       }
-      return Promise.resolve(pendingRestore);
+      if (pendingRestore !== undefined) {
+        return Promise.resolve(pendingRestore);
+      }
+      return Promise.resolve(
+        this.acknowledgedCompletionRestores.get(
+          completionRestoreKey(target, date),
+        ),
+      );
     });
   }
 
@@ -169,6 +184,15 @@ export class TaskStore {
       // alias and snapshot together.
       const command = this.buildCommand(input);
       await this.queue.enqueue(command);
+      if (
+        command.type === "set_instance_complete" &&
+        !command.completed &&
+        command.restore !== undefined
+      ) {
+        this.acknowledgedCompletionRestores.delete(
+          completionRestoreKey(command.taskId, command.date),
+        );
+      }
       this.recompute();
       this.onDispatch?.();
       const target =
@@ -197,6 +221,8 @@ export class TaskStore {
   ): Promise<void> {
     await this.enqueueOperation(async () => {
       let nextAliases = this.aliases;
+      let nextAcknowledgedCompletionRestores =
+        this.acknowledgedCompletionRestores;
       if (serverTask !== null && command.type === "create") {
         nextAliases = new Map(this.aliases);
         nextAliases.set(command.tempId, serverTask.id);
@@ -210,6 +236,19 @@ export class TaskStore {
       } else if (serverTask !== null) {
         nextBase.set(serverTask.id, serverTask);
       }
+      if (
+        command.type === "set_instance_complete" &&
+        command.completed &&
+        command.restore !== undefined
+      ) {
+        nextAcknowledgedCompletionRestores = new Map(
+          this.acknowledgedCompletionRestores,
+        );
+        nextAcknowledgedCompletionRestores.set(
+          completionRestoreKey(command.taskId, command.date),
+          command.restore,
+        );
+      }
       // Persist the authoritative base before removing the durable command.
       // If the process dies between these writes, idempotent mutation replay
       // is safe; the reverse order could lose the accepted mutation offline.
@@ -221,6 +260,7 @@ export class TaskStore {
       // preceding temp-id snapshot while persistence is in flight.
       this.aliases = nextAliases;
       this.base = nextBase;
+      this.acknowledgedCompletionRestores = nextAcknowledgedCompletionRestores;
       this.recompute();
     });
   }

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -101,20 +101,24 @@ export class TaskStore {
   getPendingCompletionRestore(
     id: TaskId,
     date: string,
-  ): RecurringCompletionRestore | undefined {
-    const target = this.resolveTaskId(id);
-    for (const command of [...this.queue.pending].reverse()) {
-      if (
-        command.type === "set_instance_complete" &&
-        command.taskId === target &&
-        command.date === date &&
-        command.completed &&
-        command.restore !== undefined
-      ) {
-        return command.restore;
+  ): Promise<RecurringCompletionRestore | undefined> {
+    return this.enqueueOperation(() => {
+      const target = this.resolveTaskId(id);
+      let pendingRestore: RecurringCompletionRestore | undefined;
+      for (const command of [...this.queue.pending].reverse()) {
+        if (
+          command.type === "set_instance_complete" &&
+          command.taskId === target &&
+          command.date === date &&
+          command.completed &&
+          command.restore !== undefined
+        ) {
+          pendingRestore = command.restore;
+          break;
+        }
       }
-    }
-    return undefined;
+      return Promise.resolve(pendingRestore);
+    });
   }
 
   constructor(

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -30,6 +30,7 @@ import {
   parseAcknowledgedCompletionRestores,
   pruneCompletionRestores,
   serializeAcknowledgedCompletionRestores,
+  taskAfterCommands,
 } from "./acknowledged-completion-restores";
 
 /**
@@ -119,7 +120,6 @@ export class TaskStore {
 
   /** Wired to SyncEngine.requestSync — fired after every dispatch. */
   onDispatch: (() => void) | null = null;
-
   getPendingCompletionRestore(
     id: TaskId,
     date: string,
@@ -145,11 +145,17 @@ export class TaskStore {
         }
       }
       if (pendingRestore !== undefined) {
+        const taskAtCompletion = taskAfterCommands(
+          this.base,
+          pending,
+          completionIndex,
+          target,
+        );
         if (
           pending
             .slice(completionIndex + 1)
             .some((command) =>
-              isTaskOccurrenceEdit(command, target, this.base.get(target)),
+              isTaskOccurrenceEdit(command, target, taskAtCompletion),
             )
         ) {
           return;
@@ -182,7 +188,6 @@ export class TaskStore {
       return stored.restore;
     });
   }
-
   constructor(
     private readonly queue: CommandQueue,
     private readonly storage: TaskStoreStorage = defaultStorage,
@@ -191,7 +196,6 @@ export class TaskStore {
     this.nextCommandId = makeCommandIdFactory(clock);
     this.snapshot = this.buildSnapshot();
   }
-
   /** Load queue + cached base + aliases. Call once at startup, after migrations. */
   async restore(): Promise<void> {
     await this.enqueueOperation(async () => {
@@ -220,18 +224,15 @@ export class TaskStore {
       this.recompute();
     });
   }
-
   subscribe(listener: () => void): () => void {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
     };
   }
-
   getSnapshot(): TaskStoreSnapshot {
     return this.snapshot;
   }
-
   /**
    * Record a mutation and return the optimistic result immediately. The
    * enqueue is the only await — never the network. Returns the task as the

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -23,6 +23,7 @@ import { localTodayYmd } from "../../domain/recurrence";
 import {
   type StoredCompletionRestore,
   completionRestoreKey,
+  invalidateChangedCompletionRestores,
   invalidateCompletionRestores,
   isOccurrenceEdit,
   parseAcknowledgedCompletionRestores,
@@ -386,11 +387,17 @@ export class TaskStore {
       }
       await this.persistBase(nextBase);
       await this.persistAliases(nextAliases);
-      const nextAcknowledgedCompletionRestores = pruneCompletionRestores(
+      const prunedAcknowledgedCompletionRestores = pruneCompletionRestores(
         this.acknowledgedCompletionRestores,
         localTodayYmd(new Date(this.clock())),
         nextBase,
       );
+      const nextAcknowledgedCompletionRestores =
+        invalidateChangedCompletionRestores(
+          prunedAcknowledgedCompletionRestores,
+          this.base,
+          nextBase,
+        );
       await this.storage.setAcknowledgedCompletionRestores(
         serializeAcknowledgedCompletionRestores(
           nextAcknowledgedCompletionRestores,

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -19,7 +19,7 @@ import {
   makeCommandIdFactory,
   makeTempId,
 } from "../sync/commands";
-import { UNDO_TOAST_MS } from "../../domain/task-toggle";
+import { localTodayYmd } from "../../domain/recurrence";
 import {
   type StoredCompletionRestore,
   completionRestoreKey,
@@ -152,7 +152,10 @@ export class TaskStore {
       }
       const key = completionRestoreKey(target, date);
       const stored = this.acknowledgedCompletionRestores.get(key);
-      if (stored === undefined || stored.expiresAt <= this.clock()) {
+      if (
+        stored === undefined ||
+        date < localTodayYmd(new Date(this.clock()))
+      ) {
         if (stored !== undefined) {
           const next = new Map(this.acknowledgedCompletionRestores);
           next.delete(key);
@@ -191,7 +194,7 @@ export class TaskStore {
       this.aliases = parseAliases(rawAliases);
       const nextAcknowledgedCompletionRestores = pruneCompletionRestores(
         parseAcknowledgedCompletionRestores(rawAcknowledgedRestores),
-        this.clock(),
+        localTodayYmd(new Date(this.clock())),
         this.base,
       );
       await this.storage.setAcknowledgedCompletionRestores(
@@ -305,7 +308,7 @@ export class TaskStore {
       }
       nextAcknowledgedCompletionRestores = pruneCompletionRestores(
         nextAcknowledgedCompletionRestores,
-        this.clock(),
+        localTodayYmd(new Date(this.clock())),
         nextBase,
       );
       if (isOccurrenceEdit(command) && command.type === "update") {
@@ -319,16 +322,13 @@ export class TaskStore {
         command.completed &&
         command.restore !== undefined
       ) {
-        const expiresAt = command.createdAt + UNDO_TOAST_MS;
-        if (expiresAt > this.clock()) {
-          nextAcknowledgedCompletionRestores = new Map(
-            nextAcknowledgedCompletionRestores,
-          );
-          nextAcknowledgedCompletionRestores.set(
-            completionRestoreKey(command.taskId, command.date),
-            { restore: command.restore, expiresAt },
-          );
-        }
+        nextAcknowledgedCompletionRestores = new Map(
+          nextAcknowledgedCompletionRestores,
+        );
+        nextAcknowledgedCompletionRestores.set(
+          completionRestoreKey(command.taskId, command.date),
+          { restore: command.restore },
+        );
       }
       // Persist the authoritative base before removing the durable command.
       // If the process dies between these writes, idempotent mutation replay
@@ -388,7 +388,7 @@ export class TaskStore {
       await this.persistAliases(nextAliases);
       const nextAcknowledgedCompletionRestores = pruneCompletionRestores(
         this.acknowledgedCompletionRestores,
-        this.clock(),
+        localTodayYmd(new Date(this.clock())),
         nextBase,
       );
       await this.storage.setAcknowledgedCompletionRestores(

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -148,13 +148,19 @@ export class TaskStore {
         if (
           pending
             .slice(completionIndex + 1)
-            .some((command) => isTaskOccurrenceEdit(command, target))
+            .some((command) =>
+              isTaskOccurrenceEdit(command, target, this.base.get(target)),
+            )
         ) {
           return;
         }
         return pendingRestore;
       }
-      if (pending.some((command) => isTaskOccurrenceEdit(command, target))) {
+      if (
+        pending.some((command) =>
+          isTaskOccurrenceEdit(command, target, this.base.get(target)),
+        )
+      ) {
         return;
       }
       const key = completionRestoreKey(target, date);
@@ -312,7 +318,10 @@ export class TaskStore {
         localTodayYmd(new Date(this.clock())),
         nextBase,
       );
-      if (isOccurrenceEdit(command) && command.type === "update") {
+      if (
+        command.type === "update" &&
+        isOccurrenceEdit(command, this.base.get(command.taskId))
+      ) {
         nextAcknowledgedCompletionRestores = invalidateCompletionRestores(
           nextAcknowledgedCompletionRestores,
           command.taskId,

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -70,6 +70,8 @@ export type TaskStoreStorage = {
   setTasks: (tasks: Task[]) => Promise<void>;
   getIdAliases: () => Promise<string | null>;
   setIdAliases: (data: string) => Promise<void>;
+  getAcknowledgedCompletionRestores: () => Promise<string | null>;
+  setAcknowledgedCompletionRestores: (data: string) => Promise<void>;
   getLastSyncTime: () => Promise<number | null>;
   setLastSyncTime: (time: number) => Promise<void>;
 };
@@ -79,11 +81,50 @@ const defaultStorage: TaskStoreStorage = {
   setTasks: (tasks) => TypedStorage.setTasks(tasks),
   getIdAliases: () => TypedStorage.getIdAliases(),
   setIdAliases: (data) => TypedStorage.setIdAliases(data),
+  getAcknowledgedCompletionRestores: () =>
+    TypedStorage.getAcknowledgedCompletionRestores(),
+  setAcknowledgedCompletionRestores: (data) =>
+    TypedStorage.setAcknowledgedCompletionRestores(data),
   getLastSyncTime: () => TypedStorage.getLastSyncTime(),
   setLastSyncTime: (time) => TypedStorage.setLastSyncTime(time),
 };
 
 const AliasesSchema = z.record(z.string(), z.string());
+const CompletionRestoreSchema = z.object({
+  scheduled: z.string().nullable(),
+  due: z.string().nullable(),
+  recurrence: z.string(),
+  skipped: z.boolean(),
+});
+const AcknowledgedCompletionRestoresSchema = z.record(
+  z.string(),
+  CompletionRestoreSchema,
+);
+
+function parseAcknowledgedCompletionRestores(
+  raw: string | null,
+): Map<string, RecurringCompletionRestore> {
+  if (raw === null) return new Map();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new Map();
+  }
+  const result = AcknowledgedCompletionRestoresSchema.safeParse(parsed);
+  if (!result.success) return new Map();
+  const restores = new Map<string, RecurringCompletionRestore>();
+  for (const [key, value] of Object.entries(result.data)) {
+    restores.set(key, value);
+  }
+  return restores;
+}
+
+function serializeAcknowledgedCompletionRestores(
+  restores: ReadonlyMap<string, RecurringCompletionRestore>,
+): string {
+  return JSON.stringify(Object.fromEntries(restores));
+}
 
 function completionRestoreKey(id: TaskId, date: string): string {
   return `${String(id)}\u{0}${date}`;
@@ -149,13 +190,18 @@ export class TaskStore {
   async restore(): Promise<void> {
     await this.enqueueOperation(async () => {
       await this.queue.restore();
-      const [tasks, rawAliases, lastSync] = await Promise.all([
-        this.storage.getTasks(),
-        this.storage.getIdAliases(),
-        this.storage.getLastSyncTime(),
-      ]);
+      const [tasks, rawAliases, rawAcknowledgedRestores, lastSync] =
+        await Promise.all([
+          this.storage.getTasks(),
+          this.storage.getIdAliases(),
+          this.storage.getAcknowledgedCompletionRestores(),
+          this.storage.getLastSyncTime(),
+        ]);
       this.base = new Map(tasks.map((t) => [t.id, t]));
       this.aliases = parseAliases(rawAliases);
+      this.acknowledgedCompletionRestores = parseAcknowledgedCompletionRestores(
+        rawAcknowledgedRestores,
+      );
       this.lastSyncTime = lastSync;
       this.recompute();
     });
@@ -189,9 +235,19 @@ export class TaskStore {
         !command.completed &&
         command.restore !== undefined
       ) {
-        this.acknowledgedCompletionRestores.delete(
+        const nextAcknowledgedCompletionRestores = new Map(
+          this.acknowledgedCompletionRestores,
+        );
+        nextAcknowledgedCompletionRestores.delete(
           completionRestoreKey(command.taskId, command.date),
         );
+        await this.storage.setAcknowledgedCompletionRestores(
+          serializeAcknowledgedCompletionRestores(
+            nextAcknowledgedCompletionRestores,
+          ),
+        );
+        this.acknowledgedCompletionRestores =
+          nextAcknowledgedCompletionRestores;
       }
       this.recompute();
       this.onDispatch?.();
@@ -253,6 +309,11 @@ export class TaskStore {
       // If the process dies between these writes, idempotent mutation replay
       // is safe; the reverse order could lose the accepted mutation offline.
       await this.persistBase(nextBase);
+      await this.storage.setAcknowledgedCompletionRestores(
+        serializeAcknowledgedCompletionRestores(
+          nextAcknowledgedCompletionRestores,
+        ),
+      );
       await this.queue.ack(command.id);
 
       // Publish the alias/base/snapshot as one synchronous state transition.

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -240,12 +240,6 @@ export class TaskStore {
       await this.queue.enqueue(command);
       let nextAcknowledgedCompletionRestores =
         this.acknowledgedCompletionRestores;
-      if (isOccurrenceEdit(command) && command.type === "update") {
-        nextAcknowledgedCompletionRestores = invalidateCompletionRestores(
-          nextAcknowledgedCompletionRestores,
-          command.taskId,
-        );
-      }
       if (
         command.type === "set_instance_complete" &&
         !command.completed &&

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -293,6 +293,22 @@ export class TaskStore {
         nextBase.set(serverTask.id, serverTask);
       }
       if (
+        command.type === "update" &&
+        (command.payload.recurrence !== undefined ||
+          command.payload.scheduled !== undefined ||
+          command.payload.due !== undefined)
+      ) {
+        nextAcknowledgedCompletionRestores = new Map(
+          this.acknowledgedCompletionRestores,
+        );
+        const keyPrefix = `${String(command.taskId)}\u{0}`;
+        for (const key of nextAcknowledgedCompletionRestores.keys()) {
+          if (key.startsWith(keyPrefix)) {
+            nextAcknowledgedCompletionRestores.delete(key);
+          }
+        }
+      }
+      if (
         command.type === "set_instance_complete" &&
         command.completed &&
         command.restore !== undefined

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -19,6 +19,16 @@ import {
   makeCommandIdFactory,
   makeTempId,
 } from "../sync/commands";
+import { UNDO_TOAST_MS } from "../../domain/task-toggle";
+import {
+  type StoredCompletionRestore,
+  completionRestoreKey,
+  invalidateCompletionRestores,
+  isOccurrenceEdit,
+  parseAcknowledgedCompletionRestores,
+  pruneCompletionRestores,
+  serializeAcknowledgedCompletionRestores,
+} from "./acknowledged-completion-restores";
 
 /**
  * The single source of truth the UI reads.
@@ -90,52 +100,13 @@ const defaultStorage: TaskStoreStorage = {
 };
 
 const AliasesSchema = z.record(z.string(), z.string());
-const CompletionRestoreSchema = z.object({
-  scheduled: z.string().nullable(),
-  due: z.string().nullable(),
-  recurrence: z.string(),
-  skipped: z.boolean(),
-});
-const AcknowledgedCompletionRestoresSchema = z.record(
-  z.string(),
-  CompletionRestoreSchema,
-);
-
-function parseAcknowledgedCompletionRestores(
-  raw: string | null,
-): Map<string, RecurringCompletionRestore> {
-  if (raw === null) return new Map();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return new Map();
-  }
-  const result = AcknowledgedCompletionRestoresSchema.safeParse(parsed);
-  if (!result.success) return new Map();
-  const restores = new Map<string, RecurringCompletionRestore>();
-  for (const [key, value] of Object.entries(result.data)) {
-    restores.set(key, value);
-  }
-  return restores;
-}
-
-function serializeAcknowledgedCompletionRestores(
-  restores: ReadonlyMap<string, RecurringCompletionRestore>,
-): string {
-  return JSON.stringify(Object.fromEntries(restores));
-}
-
-function completionRestoreKey(id: TaskId, date: string): string {
-  return `${String(id)}\u{0}${date}`;
-}
 
 export class TaskStore {
   private base = new Map<TaskId, Task>();
   private aliases = new Map<TaskId, TaskId>();
   private acknowledgedCompletionRestores = new Map<
     string,
-    RecurringCompletionRestore
+    StoredCompletionRestore
   >();
   private lastSyncTime: number | null = null;
   private snapshot: TaskStoreSnapshot;
@@ -151,8 +122,18 @@ export class TaskStore {
     id: TaskId,
     date: string,
   ): Promise<RecurringCompletionRestore | undefined> {
-    return this.enqueueOperation(() => {
+    return this.enqueueOperation(async () => {
       const target = this.resolveTaskId(id);
+      if (
+        this.queue.pending.some(
+          (command) =>
+            isOccurrenceEdit(command) &&
+            command.type === "update" &&
+            command.taskId === target,
+        )
+      ) {
+        return;
+      }
       let pendingRestore: RecurringCompletionRestore | undefined;
       for (const command of [...this.queue.pending].reverse()) {
         if (
@@ -167,13 +148,22 @@ export class TaskStore {
         }
       }
       if (pendingRestore !== undefined) {
-        return Promise.resolve(pendingRestore);
+        return pendingRestore;
       }
-      return Promise.resolve(
-        this.acknowledgedCompletionRestores.get(
-          completionRestoreKey(target, date),
-        ),
-      );
+      const key = completionRestoreKey(target, date);
+      const stored = this.acknowledgedCompletionRestores.get(key);
+      if (stored === undefined || stored.expiresAt <= this.clock()) {
+        if (stored !== undefined) {
+          const next = new Map(this.acknowledgedCompletionRestores);
+          next.delete(key);
+          await this.storage.setAcknowledgedCompletionRestores(
+            serializeAcknowledgedCompletionRestores(next),
+          );
+          this.acknowledgedCompletionRestores = next;
+        }
+        return;
+      }
+      return stored.restore;
     });
   }
 
@@ -199,9 +189,17 @@ export class TaskStore {
         ]);
       this.base = new Map(tasks.map((t) => [t.id, t]));
       this.aliases = parseAliases(rawAliases);
-      this.acknowledgedCompletionRestores = parseAcknowledgedCompletionRestores(
-        rawAcknowledgedRestores,
+      const nextAcknowledgedCompletionRestores = pruneCompletionRestores(
+        parseAcknowledgedCompletionRestores(rawAcknowledgedRestores),
+        this.clock(),
+        this.base,
       );
+      await this.storage.setAcknowledgedCompletionRestores(
+        serializeAcknowledgedCompletionRestores(
+          nextAcknowledgedCompletionRestores,
+        ),
+      );
+      this.acknowledgedCompletionRestores = nextAcknowledgedCompletionRestores;
       this.lastSyncTime = lastSync;
       this.recompute();
     });
@@ -230,17 +228,30 @@ export class TaskStore {
       // alias and snapshot together.
       const command = this.buildCommand(input);
       await this.queue.enqueue(command);
+      let nextAcknowledgedCompletionRestores =
+        this.acknowledgedCompletionRestores;
+      if (isOccurrenceEdit(command) && command.type === "update") {
+        nextAcknowledgedCompletionRestores = invalidateCompletionRestores(
+          nextAcknowledgedCompletionRestores,
+          command.taskId,
+        );
+      }
       if (
         command.type === "set_instance_complete" &&
         !command.completed &&
         command.restore !== undefined
       ) {
-        const nextAcknowledgedCompletionRestores = new Map(
-          this.acknowledgedCompletionRestores,
+        nextAcknowledgedCompletionRestores = new Map(
+          nextAcknowledgedCompletionRestores,
         );
         nextAcknowledgedCompletionRestores.delete(
           completionRestoreKey(command.taskId, command.date),
         );
+      }
+      if (
+        nextAcknowledgedCompletionRestores !==
+        this.acknowledgedCompletionRestores
+      ) {
         await this.storage.setAcknowledgedCompletionRestores(
           serializeAcknowledgedCompletionRestores(
             nextAcknowledgedCompletionRestores,
@@ -292,34 +303,32 @@ export class TaskStore {
       } else if (serverTask !== null) {
         nextBase.set(serverTask.id, serverTask);
       }
-      if (
-        command.type === "update" &&
-        (command.payload.recurrence !== undefined ||
-          command.payload.scheduled !== undefined ||
-          command.payload.due !== undefined)
-      ) {
-        nextAcknowledgedCompletionRestores = new Map(
-          this.acknowledgedCompletionRestores,
+      nextAcknowledgedCompletionRestores = pruneCompletionRestores(
+        nextAcknowledgedCompletionRestores,
+        this.clock(),
+        nextBase,
+      );
+      if (isOccurrenceEdit(command) && command.type === "update") {
+        nextAcknowledgedCompletionRestores = invalidateCompletionRestores(
+          nextAcknowledgedCompletionRestores,
+          command.taskId,
         );
-        const keyPrefix = `${String(command.taskId)}\u{0}`;
-        for (const key of nextAcknowledgedCompletionRestores.keys()) {
-          if (key.startsWith(keyPrefix)) {
-            nextAcknowledgedCompletionRestores.delete(key);
-          }
-        }
       }
       if (
         command.type === "set_instance_complete" &&
         command.completed &&
         command.restore !== undefined
       ) {
-        nextAcknowledgedCompletionRestores = new Map(
-          this.acknowledgedCompletionRestores,
-        );
-        nextAcknowledgedCompletionRestores.set(
-          completionRestoreKey(command.taskId, command.date),
-          command.restore,
-        );
+        const expiresAt = command.createdAt + UNDO_TOAST_MS;
+        if (expiresAt > this.clock()) {
+          nextAcknowledgedCompletionRestores = new Map(
+            nextAcknowledgedCompletionRestores,
+          );
+          nextAcknowledgedCompletionRestores.set(
+            completionRestoreKey(command.taskId, command.date),
+            { restore: command.restore, expiresAt },
+          );
+        }
       }
       // Persist the authoritative base before removing the durable command.
       // If the process dies between these writes, idempotent mutation replay
@@ -377,10 +386,21 @@ export class TaskStore {
       }
       await this.persistBase(nextBase);
       await this.persistAliases(nextAliases);
+      const nextAcknowledgedCompletionRestores = pruneCompletionRestores(
+        this.acknowledgedCompletionRestores,
+        this.clock(),
+        nextBase,
+      );
+      await this.storage.setAcknowledgedCompletionRestores(
+        serializeAcknowledgedCompletionRestores(
+          nextAcknowledgedCompletionRestores,
+        ),
+      );
       await this.storage.setLastSyncTime(syncedAt);
 
       this.base = nextBase;
       this.aliases = nextAliases;
+      this.acknowledgedCompletionRestores = nextAcknowledgedCompletionRestores;
       this.lastSyncTime = syncedAt;
       this.recompute();
     });

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -26,6 +26,7 @@ import {
   invalidateChangedCompletionRestores,
   invalidateCompletionRestores,
   isOccurrenceEdit,
+  isTaskOccurrenceEdit,
   parseAcknowledgedCompletionRestores,
   pruneCompletionRestores,
   serializeAcknowledgedCompletionRestores,
@@ -125,18 +126,12 @@ export class TaskStore {
   ): Promise<RecurringCompletionRestore | undefined> {
     return this.enqueueOperation(async () => {
       const target = this.resolveTaskId(id);
-      if (
-        this.queue.pending.some(
-          (command) =>
-            isOccurrenceEdit(command) &&
-            command.type === "update" &&
-            command.taskId === target,
-        )
-      ) {
-        return;
-      }
+      const pending = this.queue.pending;
       let pendingRestore: RecurringCompletionRestore | undefined;
-      for (const command of [...this.queue.pending].reverse()) {
+      let completionIndex = -1;
+      for (let index = pending.length - 1; index >= 0; index -= 1) {
+        const command = pending[index];
+        if (command === undefined) continue;
         if (
           command.type === "set_instance_complete" &&
           command.taskId === target &&
@@ -145,11 +140,22 @@ export class TaskStore {
           command.restore !== undefined
         ) {
           pendingRestore = command.restore;
+          completionIndex = index;
           break;
         }
       }
       if (pendingRestore !== undefined) {
+        if (
+          pending
+            .slice(completionIndex + 1)
+            .some((command) => isTaskOccurrenceEdit(command, target))
+        ) {
+          return;
+        }
         return pendingRestore;
+      }
+      if (pending.some((command) => isTaskOccurrenceEdit(command, target))) {
+        return;
       }
       const key = completionRestoreKey(target, date);
       const stored = this.acknowledgedCompletionRestores.get(key);

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -98,6 +98,25 @@ export class TaskStore {
   /** Wired to SyncEngine.requestSync — fired after every dispatch. */
   onDispatch: (() => void) | null = null;
 
+  getPendingCompletionRestore(
+    id: TaskId,
+    date: string,
+  ): RecurringCompletionRestore | undefined {
+    const target = this.resolveTaskId(id);
+    for (const command of [...this.queue.pending].reverse()) {
+      if (
+        command.type === "set_instance_complete" &&
+        command.taskId === target &&
+        command.date === date &&
+        command.completed &&
+        command.restore !== undefined
+      ) {
+        return command.restore;
+      }
+    }
+    return undefined;
+  }
+
   constructor(
     private readonly queue: CommandQueue,
     private readonly storage: TaskStoreStorage = defaultStorage,
@@ -268,6 +287,7 @@ export class TaskStore {
             taskId: resolvedTaskId,
             date: input.date,
             completed: true,
+            ...(input.restore === undefined ? {} : { restore: input.restore }),
           };
         }
         return {

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -12,7 +12,6 @@ const CompletionRestoreSchema = z.object({
 });
 const StoredCompletionRestoreSchema = z.object({
   restore: CompletionRestoreSchema,
-  expiresAt: z.number(),
 });
 const AcknowledgedCompletionRestoresSchema = z.record(
   z.string(),
@@ -21,7 +20,6 @@ const AcknowledgedCompletionRestoresSchema = z.record(
 
 export type StoredCompletionRestore = {
   readonly restore: RecurringCompletionRestore;
-  readonly expiresAt: number;
 };
 
 export function parseAcknowledgedCompletionRestores(
@@ -76,13 +74,13 @@ export function invalidateCompletionRestores(
 
 export function pruneCompletionRestores(
   restores: ReadonlyMap<string, StoredCompletionRestore>,
-  now: number,
+  today: string,
   tasks: ReadonlyMap<TaskId, Task>,
 ): Map<string, StoredCompletionRestore> {
   const next = new Map<string, StoredCompletionRestore>();
   for (const [key, value] of restores) {
     const separator = key.indexOf("\u{0}");
-    if (separator === -1 || value.expiresAt <= now) continue;
+    if (separator === -1 || key.slice(separator + 1) < today) continue;
     if (!tasks.has(taskId(key.slice(0, separator)))) continue;
     next.set(key, value);
   }

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -26,16 +26,10 @@ export function parseAcknowledgedCompletionRestores(
   raw: string | null,
 ): Map<string, StoredCompletionRestore> {
   if (raw === null) return new Map();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return new Map();
-  }
-  const result = AcknowledgedCompletionRestoresSchema.safeParse(parsed);
-  if (!result.success) return new Map();
+  const parsed: unknown = JSON.parse(raw);
+  const result = AcknowledgedCompletionRestoresSchema.parse(parsed);
   const restores = new Map<string, StoredCompletionRestore>();
-  for (const [key, value] of Object.entries(result.data)) {
+  for (const [key, value] of Object.entries(result)) {
     restores.set(key, value);
   }
   return restores;
@@ -97,6 +91,7 @@ export function invalidateChangedCompletionRestores(
     const separator = key.indexOf("\u{0}");
     if (separator === -1) continue;
     const id = taskId(key.slice(0, separator));
+    const date = key.slice(separator + 1);
     const previous = previousTasks.get(id);
     const current = nextTasks.get(id);
     if (
@@ -104,7 +99,9 @@ export function invalidateChangedCompletionRestores(
       current !== undefined &&
       (previous.recurrence !== current.recurrence ||
         previous.scheduled !== current.scheduled ||
-        previous.due !== current.due)
+        previous.due !== current.due ||
+        previous.skippedInstances.includes(date) !==
+          current.skippedInstances.includes(date))
     ) {
       next.delete(key);
     }

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -54,6 +54,17 @@ export function isOccurrenceEdit(command: Command): boolean {
   );
 }
 
+export function isTaskOccurrenceEdit(
+  command: Command,
+  targetId: TaskId,
+): boolean {
+  return (
+    isOccurrenceEdit(command) &&
+    command.type === "update" &&
+    command.taskId === targetId
+  );
+}
+
 export function invalidateCompletionRestores(
   restores: ReadonlyMap<string, StoredCompletionRestore>,
   id: TaskId,

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -59,21 +59,29 @@ export function completionRestoreKey(id: TaskId, date: string): string {
   return `${String(id)}\u{0}${date}`;
 }
 
-export function isOccurrenceEdit(command: Command): boolean {
+export function isOccurrenceEdit(
+  command: Command,
+  currentTask: Task | undefined,
+): boolean {
   return (
     command.type === "update" &&
-    (command.payload.recurrence !== undefined ||
-      command.payload.scheduled !== undefined ||
-      command.payload.due !== undefined)
+    (currentTask === undefined ||
+      (command.payload.recurrence !== undefined &&
+        command.payload.recurrence !== currentTask.recurrence) ||
+      (command.payload.scheduled !== undefined &&
+        command.payload.scheduled !== currentTask.scheduled) ||
+      (command.payload.due !== undefined &&
+        command.payload.due !== currentTask.due))
   );
 }
 
 export function isTaskOccurrenceEdit(
   command: Command,
   targetId: TaskId,
+  currentTask: Task | undefined,
 ): boolean {
   return (
-    isOccurrenceEdit(command) &&
+    isOccurrenceEdit(command, currentTask) &&
     command.type === "update" &&
     command.taskId === targetId
   );

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -13,8 +13,22 @@ const CompletionRestoreSchema = z.object({
 const StoredCompletionRestoreSchema = z.object({
   restore: CompletionRestoreSchema,
 });
+const CompletionRestoreKeySchema = z.string().superRefine((key, context) => {
+  const separator = key.indexOf("\u{0}");
+  const date = key.slice(separator + 1);
+  if (
+    separator <= 0 ||
+    key.includes("\u{0}", separator + 1) ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(date)
+  ) {
+    context.addIssue({
+      code: "custom",
+      message: "Expected a task ID and ISO date separated by NUL",
+    });
+  }
+});
 const AcknowledgedCompletionRestoresSchema = z.record(
-  z.string(),
+  CompletionRestoreKeySchema,
   StoredCompletionRestoreSchema,
 );
 

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -86,3 +86,28 @@ export function pruneCompletionRestores(
   }
   return next;
 }
+
+export function invalidateChangedCompletionRestores(
+  restores: ReadonlyMap<string, StoredCompletionRestore>,
+  previousTasks: ReadonlyMap<TaskId, Task>,
+  nextTasks: ReadonlyMap<TaskId, Task>,
+): Map<string, StoredCompletionRestore> {
+  const next = new Map(restores);
+  for (const key of next.keys()) {
+    const separator = key.indexOf("\u{0}");
+    if (separator === -1) continue;
+    const id = taskId(key.slice(0, separator));
+    const previous = previousTasks.get(id);
+    const current = nextTasks.get(id);
+    if (
+      previous !== undefined &&
+      current !== undefined &&
+      (previous.recurrence !== current.recurrence ||
+        previous.scheduled !== current.scheduled ||
+        previous.due !== current.due)
+    ) {
+      next.delete(key);
+    }
+  }
+  return next;
+}

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -59,6 +59,13 @@ export function completionRestoreKey(id: TaskId, date: string): string {
   return `${String(id)}\u{0}${date}`;
 }
 
+function sameOptionalString(
+  left: string | null | undefined,
+  right: string | undefined,
+): boolean {
+  return (left ?? undefined) === right;
+}
+
 export function isOccurrenceEdit(
   command: Command,
   currentTask: Task | undefined,
@@ -67,11 +74,17 @@ export function isOccurrenceEdit(
     command.type === "update" &&
     (currentTask === undefined ||
       (command.payload.recurrence !== undefined &&
-        command.payload.recurrence !== currentTask.recurrence) ||
+        !sameOptionalString(
+          command.payload.recurrence,
+          currentTask.recurrence,
+        )) ||
       (command.payload.scheduled !== undefined &&
-        command.payload.scheduled !== currentTask.scheduled) ||
+        !sameOptionalString(
+          command.payload.scheduled,
+          currentTask.scheduled,
+        )) ||
       (command.payload.due !== undefined &&
-        command.payload.due !== currentTask.due))
+        !sameOptionalString(command.payload.due, currentTask.due)))
   );
 }
 

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+import { taskId, type Task, type TaskId } from "../../domain/types";
+import type { RecurringCompletionRestore } from "tasknotes-types/v2";
+import type { Command } from "../sync/commands";
+
+const CompletionRestoreSchema = z.object({
+  scheduled: z.string().nullable(),
+  due: z.string().nullable(),
+  recurrence: z.string(),
+  skipped: z.boolean(),
+});
+const StoredCompletionRestoreSchema = z.object({
+  restore: CompletionRestoreSchema,
+  expiresAt: z.number(),
+});
+const AcknowledgedCompletionRestoresSchema = z.record(
+  z.string(),
+  StoredCompletionRestoreSchema,
+);
+
+export type StoredCompletionRestore = {
+  readonly restore: RecurringCompletionRestore;
+  readonly expiresAt: number;
+};
+
+export function parseAcknowledgedCompletionRestores(
+  raw: string | null,
+): Map<string, StoredCompletionRestore> {
+  if (raw === null) return new Map();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new Map();
+  }
+  const result = AcknowledgedCompletionRestoresSchema.safeParse(parsed);
+  if (!result.success) return new Map();
+  const restores = new Map<string, StoredCompletionRestore>();
+  for (const [key, value] of Object.entries(result.data)) {
+    restores.set(key, value);
+  }
+  return restores;
+}
+
+export function serializeAcknowledgedCompletionRestores(
+  restores: ReadonlyMap<string, StoredCompletionRestore>,
+): string {
+  return JSON.stringify(Object.fromEntries(restores));
+}
+
+export function completionRestoreKey(id: TaskId, date: string): string {
+  return `${String(id)}\u{0}${date}`;
+}
+
+export function isOccurrenceEdit(command: Command): boolean {
+  return (
+    command.type === "update" &&
+    (command.payload.recurrence !== undefined ||
+      command.payload.scheduled !== undefined ||
+      command.payload.due !== undefined)
+  );
+}
+
+export function invalidateCompletionRestores(
+  restores: ReadonlyMap<string, StoredCompletionRestore>,
+  id: TaskId,
+): Map<string, StoredCompletionRestore> {
+  const next = new Map(restores);
+  const keyPrefix = `${String(id)}\u{0}`;
+  for (const key of next.keys()) {
+    if (key.startsWith(keyPrefix)) next.delete(key);
+  }
+  return next;
+}
+
+export function pruneCompletionRestores(
+  restores: ReadonlyMap<string, StoredCompletionRestore>,
+  now: number,
+  tasks: ReadonlyMap<TaskId, Task>,
+): Map<string, StoredCompletionRestore> {
+  const next = new Map<string, StoredCompletionRestore>();
+  for (const [key, value] of restores) {
+    const separator = key.indexOf("\u{0}");
+    if (separator === -1 || value.expiresAt <= now) continue;
+    if (!tasks.has(taskId(key.slice(0, separator)))) continue;
+    next.set(key, value);
+  }
+  return next;
+}

--- a/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
+++ b/packages/tasks-for-obsidian/src/data/store/acknowledged-completion-restores.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { taskId, type Task, type TaskId } from "../../domain/types";
 import type { RecurringCompletionRestore } from "tasknotes-types/v2";
-import type { Command } from "../sync/commands";
+import { applyCommand, type Command } from "../sync/commands";
 
 const CompletionRestoreSchema = z.object({
   scheduled: z.string().nullable(),
@@ -57,6 +57,18 @@ export function serializeAcknowledgedCompletionRestores(
 
 export function completionRestoreKey(id: TaskId, date: string): string {
   return `${String(id)}\u{0}${date}`;
+}
+
+export function taskAfterCommands(
+  base: ReadonlyMap<TaskId, Task>,
+  commands: readonly Command[],
+  endExclusive: number,
+  target: TaskId,
+): Task | undefined {
+  return commands
+    .slice(0, endExclusive)
+    .reduce((tasks, command) => applyCommand(command, tasks), new Map(base))
+    .get(target);
 }
 
 function sameOptionalString(

--- a/packages/tasks-for-obsidian/src/data/sync/SyncEngine.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/SyncEngine.ts
@@ -262,7 +262,7 @@ export class SyncEngine {
           {
             date: command.date,
             completed: command.completed,
-            ...(command.restore === undefined
+            ...(command.completed || command.restore === undefined
               ? {}
               : { restore: command.restore }),
           },

--- a/packages/tasks-for-obsidian/src/data/sync/SyncEngine.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/SyncEngine.ts
@@ -8,6 +8,7 @@ import type {
   UpdateTaskRequest,
 } from "../../domain/types";
 import type { TaskStatus } from "../../domain/status";
+import type { CompleteInstanceRequest } from "tasknotes-types/v2";
 import type { TaskStore } from "../store/TaskStore";
 import type { CommandQueue } from "./CommandQueue";
 import { type Clock, type Command, classify } from "./commands";
@@ -58,7 +59,7 @@ export type CommandClient = {
   ) => Promise<Result<Task, AppError>>;
   completeRecurringInstance: (
     id: TaskId,
-    instance?: { date: string; completed: boolean },
+    instance?: CompleteInstanceRequest,
     options?: MutationOptions,
   ) => Promise<Result<Task, AppError>>;
 };
@@ -258,7 +259,13 @@ export class SyncEngine {
       case "set_instance_complete":
         return client.completeRecurringInstance(
           command.taskId,
-          { date: command.date, completed: command.completed },
+          {
+            date: command.date,
+            completed: command.completed,
+            ...(command.restore === undefined
+              ? {}
+              : { restore: command.restore }),
+          },
           options,
         );
     }

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -1,0 +1,56 @@
+import type { CompleteInstanceRequest } from "tasknotes-types/v2";
+
+import type { Task } from "../../../domain/types";
+
+function localDay(timestamp: number): string {
+  const date = new Date(timestamp);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${String(date.getFullYear())}-${month}-${day}`;
+}
+
+export function applyFakeRecurringCompletion(
+  existing: Task,
+  instance: CompleteInstanceRequest | undefined,
+  timestamp: number,
+): Task {
+  const targetDate = instance?.date ?? localDay(timestamp);
+  const has = existing.completeInstances.includes(targetDate);
+  const completed = instance?.completed ?? !has;
+  if (completed === has && instance?.restore === undefined) {
+    return { ...existing };
+  }
+  const completeInstances = completed
+    ? has
+      ? [...existing.completeInstances]
+      : [...existing.completeInstances, targetDate]
+    : existing.completeInstances.filter((date) => date !== targetDate);
+  const updated: Task = {
+    ...existing,
+    completeInstances,
+    skippedInstances: completed
+      ? existing.skippedInstances.filter((date) => date !== targetDate)
+      : existing.skippedInstances,
+  };
+  const restore = instance?.restore;
+  if (restore === undefined) return updated;
+
+  updated.recurrence = restore.recurrence;
+  if (restore.scheduled === null) {
+    Reflect.deleteProperty(updated, "scheduled");
+  } else {
+    updated.scheduled = restore.scheduled;
+  }
+  if (restore.due === null) {
+    Reflect.deleteProperty(updated, "due");
+  } else {
+    updated.due = restore.due;
+  }
+  const withoutSkippedTarget = existing.skippedInstances.filter(
+    (date) => date !== targetDate,
+  );
+  updated.skippedInstances = restore.skipped
+    ? [...withoutSkippedTarget, targetDate]
+    : withoutSkippedTarget;
+  return updated;
+}

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -1,4 +1,7 @@
-import type { CompleteInstanceRequest } from "tasknotes-types/v2";
+import {
+  updateToNextScheduledOccurrence,
+  type CompleteInstanceRequest,
+} from "tasknotes-types/v2";
 
 import type { Task } from "../../../domain/types";
 
@@ -32,6 +35,36 @@ export function applyFakeRecurringCompletion(
       ? existing.skippedInstances.filter((date) => date !== targetDate)
       : existing.skippedInstances,
   };
+  if (completed) {
+    const recurrence = existing.recurrence;
+    if (recurrence === undefined) {
+      throw new Error("recurring completion fake requires a recurrence");
+    }
+    const next = updateToNextScheduledOccurrence(
+      {
+        title: existing.title,
+        recurrence,
+        scheduled: existing.scheduled,
+        due: existing.due,
+        dateCreated: existing.dateCreated,
+        recurrence_anchor: existing.recurrenceAnchor,
+        complete_instances: updated.completeInstances,
+        skipped_instances: updated.skippedInstances,
+      },
+      true,
+      { today: localDay(timestamp) },
+    );
+    if (next.scheduled === null) {
+      Reflect.deleteProperty(updated, "scheduled");
+    } else {
+      updated.scheduled = next.scheduled;
+    }
+    if (next.due === null) {
+      Reflect.deleteProperty(updated, "due");
+    } else {
+      updated.due = next.due;
+    }
+  }
   const restore = instance?.restore;
   if (restore === undefined) return updated;
 

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -40,15 +40,17 @@ function advanceSchedule(
   const next = updateToNextScheduledOccurrence(scheduleSource, true, {
     today: completionDate,
   });
-  if (next.scheduled === null) {
+  const scheduled = next.scheduled ?? existing.scheduled;
+  if (scheduled === undefined) {
     Reflect.deleteProperty(updated, "scheduled");
   } else {
-    updated.scheduled = next.scheduled;
+    updated.scheduled = scheduled;
   }
-  if (next.due === null) {
+  const due = next.due ?? existing.due;
+  if (due === undefined) {
     Reflect.deleteProperty(updated, "due");
   } else {
-    updated.due = next.due;
+    updated.due = due;
   }
 }
 

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -40,20 +40,25 @@ export function applyFakeRecurringCompletion(
     if (recurrence === undefined) {
       throw new Error("recurring completion fake requires a recurrence");
     }
-    const next = updateToNextScheduledOccurrence(
-      {
-        title: existing.title,
-        recurrence,
-        scheduled: existing.scheduled,
-        due: existing.due,
-        dateCreated: existing.dateCreated,
-        recurrence_anchor: existing.recurrenceAnchor,
-        complete_instances: updated.completeInstances,
-        skipped_instances: updated.skippedInstances,
-      },
-      true,
-      { today: localDay(timestamp) },
-    );
+    const scheduleSource = {
+      title: existing.title,
+      recurrence,
+      ...(existing.scheduled === undefined
+        ? {}
+        : { scheduled: existing.scheduled }),
+      ...(existing.due === undefined ? {} : { due: existing.due }),
+      ...(existing.dateCreated === undefined
+        ? {}
+        : { dateCreated: existing.dateCreated }),
+      ...(existing.recurrenceAnchor === undefined
+        ? {}
+        : { recurrence_anchor: existing.recurrenceAnchor }),
+      complete_instances: updated.completeInstances,
+      skipped_instances: updated.skippedInstances,
+    };
+    const next = updateToNextScheduledOccurrence(scheduleSource, true, {
+      today: localDay(timestamp),
+    });
     if (next.scheduled === null) {
       Reflect.deleteProperty(updated, "scheduled");
     } else {

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -57,11 +57,27 @@ function advanceSchedule(
   }
 }
 
+function fakeRestoredStateMatchesCurrent(
+  task: Task,
+  restore: RecurringCompletionRestore,
+  date: string,
+): boolean {
+  return (
+    !task.completeInstances.includes(date) &&
+    task.recurrence === restore.recurrence &&
+    task.scheduled === (restore.scheduled ?? undefined) &&
+    task.due === (restore.due ?? undefined) &&
+    task.skippedInstances.includes(date) === restore.skipped
+  );
+}
+
 export function fakeRecurringRestoreMatchesCurrent(
   task: Task,
   restore: RecurringCompletionRestore,
   date: string,
 ): boolean {
+  if (fakeRestoredStateMatchesCurrent(task, restore, date)) return true;
+
   const scheduleSource = {
     title: task.title,
     recurrence: restore.recurrence,

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -15,7 +15,7 @@ function localDay(timestamp: number): string {
 function advanceSchedule(
   existing: Task,
   updated: Task,
-  timestamp: number,
+  completionDate: string,
 ): void {
   const recurrence = existing.recurrence;
   if (recurrence === undefined) {
@@ -38,7 +38,7 @@ function advanceSchedule(
     skipped_instances: updated.skippedInstances,
   };
   const next = updateToNextScheduledOccurrence(scheduleSource, true, {
-    today: localDay(timestamp),
+    today: completionDate,
   });
   if (next.scheduled === null) {
     Reflect.deleteProperty(updated, "scheduled");
@@ -76,7 +76,7 @@ export function applyFakeRecurringCompletion(
       : existing.skippedInstances,
   };
   if (completed) {
-    advanceSchedule(existing, updated, timestamp);
+    advanceSchedule(existing, updated, targetDate);
   }
   const restore = instance?.restore;
   if (restore === undefined) return updated;

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -12,6 +12,46 @@ function localDay(timestamp: number): string {
   return `${String(date.getFullYear())}-${month}-${day}`;
 }
 
+function advanceSchedule(
+  existing: Task,
+  updated: Task,
+  timestamp: number,
+): void {
+  const recurrence = existing.recurrence;
+  if (recurrence === undefined) {
+    throw new Error("recurring completion fake requires a recurrence");
+  }
+  const scheduleSource = {
+    title: existing.title,
+    recurrence,
+    ...(existing.scheduled === undefined
+      ? {}
+      : { scheduled: existing.scheduled }),
+    ...(existing.due === undefined ? {} : { due: existing.due }),
+    ...(existing.dateCreated === undefined
+      ? {}
+      : { dateCreated: existing.dateCreated }),
+    ...(existing.recurrenceAnchor === undefined
+      ? {}
+      : { recurrence_anchor: existing.recurrenceAnchor }),
+    complete_instances: updated.completeInstances,
+    skipped_instances: updated.skippedInstances,
+  };
+  const next = updateToNextScheduledOccurrence(scheduleSource, true, {
+    today: localDay(timestamp),
+  });
+  if (next.scheduled === null) {
+    Reflect.deleteProperty(updated, "scheduled");
+  } else {
+    updated.scheduled = next.scheduled;
+  }
+  if (next.due === null) {
+    Reflect.deleteProperty(updated, "due");
+  } else {
+    updated.due = next.due;
+  }
+}
+
 export function applyFakeRecurringCompletion(
   existing: Task,
   instance: CompleteInstanceRequest | undefined,
@@ -36,39 +76,7 @@ export function applyFakeRecurringCompletion(
       : existing.skippedInstances,
   };
   if (completed) {
-    const recurrence = existing.recurrence;
-    if (recurrence === undefined) {
-      throw new Error("recurring completion fake requires a recurrence");
-    }
-    const scheduleSource = {
-      title: existing.title,
-      recurrence,
-      ...(existing.scheduled === undefined
-        ? {}
-        : { scheduled: existing.scheduled }),
-      ...(existing.due === undefined ? {} : { due: existing.due }),
-      ...(existing.dateCreated === undefined
-        ? {}
-        : { dateCreated: existing.dateCreated }),
-      ...(existing.recurrenceAnchor === undefined
-        ? {}
-        : { recurrence_anchor: existing.recurrenceAnchor }),
-      complete_instances: updated.completeInstances,
-      skipped_instances: updated.skippedInstances,
-    };
-    const next = updateToNextScheduledOccurrence(scheduleSource, true, {
-      today: localDay(timestamp),
-    });
-    if (next.scheduled === null) {
-      Reflect.deleteProperty(updated, "scheduled");
-    } else {
-      updated.scheduled = next.scheduled;
-    }
-    if (next.due === null) {
-      Reflect.deleteProperty(updated, "due");
-    } else {
-      updated.due = next.due;
-    }
+    advanceSchedule(existing, updated, timestamp);
   }
   const restore = instance?.restore;
   if (restore === undefined) return updated;

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/fake-recurring-completion.ts
@@ -1,11 +1,14 @@
 import {
+  addDTSTARTToRecurrenceRule,
   updateToNextScheduledOccurrence,
   type CompleteInstanceRequest,
+  type RecurringCompletionRestore,
 } from "tasknotes-types/v2";
 
 import type { Task } from "../../../domain/types";
+import { ApiError } from "../../../domain/errors";
 
-function localDay(timestamp: number): string {
+export function localDay(timestamp: number): string {
   const date = new Date(timestamp);
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
@@ -52,6 +55,61 @@ function advanceSchedule(
   } else {
     updated.due = due;
   }
+}
+
+export function fakeRecurringRestoreMatchesCurrent(
+  task: Task,
+  restore: RecurringCompletionRestore,
+  date: string,
+): boolean {
+  const scheduleSource = {
+    title: task.title,
+    recurrence: restore.recurrence,
+    ...(restore.scheduled === null ? {} : { scheduled: restore.scheduled }),
+    ...(restore.due === null ? {} : { due: restore.due }),
+    ...(task.dateCreated === undefined
+      ? {}
+      : { dateCreated: task.dateCreated }),
+    ...(task.recurrenceAnchor === undefined
+      ? {}
+      : { recurrence_anchor: task.recurrenceAnchor }),
+    complete_instances: task.completeInstances.includes(date)
+      ? task.completeInstances
+      : [...task.completeInstances, date],
+    skipped_instances: task.skippedInstances.filter((entry) => entry !== date),
+  };
+  const next = updateToNextScheduledOccurrence(scheduleSource, true, {
+    today: date,
+  });
+  const expectedScheduled = next.scheduled ?? restore.scheduled ?? undefined;
+  const expectedDue = next.due ?? restore.due ?? undefined;
+  const expectedRecurrence =
+    addDTSTARTToRecurrenceRule({
+      recurrence: restore.recurrence,
+      ...(restore.scheduled === null ? {} : { scheduled: restore.scheduled }),
+      ...(restore.due === null ? {} : { due: restore.due }),
+      ...(task.dateCreated === undefined
+        ? {}
+        : { dateCreated: task.dateCreated }),
+    }) ?? restore.recurrence;
+  return (
+    task.recurrence === expectedRecurrence &&
+    !task.skippedInstances.includes(date) &&
+    task.scheduled === expectedScheduled &&
+    (restore.due === null ? task.due === undefined : task.due === expectedDue)
+  );
+}
+
+export function restoreErrorFor(
+  task: Task,
+  instance: CompleteInstanceRequest | undefined,
+  timestamp: number,
+): ApiError | undefined {
+  if (instance?.restore === undefined) return undefined;
+  const date = instance.date ?? localDay(timestamp);
+  return fakeRecurringRestoreMatchesCurrent(task, instance.restore, date)
+    ? undefined
+    : new ApiError("Recurring restore is stale", 409);
 }
 
 export function applyFakeRecurringCompletion(

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { NetworkError } from "../../../domain/errors";
+import { ApiError, NetworkError } from "../../../domain/errors";
 import { taskId } from "../../../domain/types";
 import { CommandQueue } from "../CommandQueue";
 import { FakeServer, makeClock, makeHarness, makeTask } from "./harness";
@@ -101,6 +101,40 @@ describe("FakeServer", () => {
     });
     expect(unset.ok).toBe(true);
     if (unset.ok) expect(unset.value.completeInstances).toEqual([]);
+  });
+
+  test("stale recurring restores return a conflict without overwriting edits", async () => {
+    const server = new FakeServer(makeClock());
+    const recurring = makeTask({
+      recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+      due: "2026-08-10",
+      completeInstances: ["2026-08-01"],
+    });
+    server.seed(recurring);
+    server.injectServerEdit(recurring.id, {
+      scheduled: "2026-08-15",
+      due: "2026-08-17",
+    });
+
+    const result = await server.completeRecurringInstance(recurring.id, {
+      date: "2026-08-01",
+      completed: false,
+      restore: {
+        recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+        scheduled: "2026-08-08",
+        due: "2026-08-10",
+        skipped: false,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(ApiError);
+    if (!result.ok && result.error instanceof ApiError) {
+      expect(result.error.statusCode).toBe(409);
+    }
+    expect(server.tasks.get(recurring.id)?.scheduled).toBe("2026-08-15");
+    expect(server.tasks.get(recurring.id)?.due).toBe("2026-08-17");
   });
 
   test("a replayed X-Mutation-Id returns the stored response without re-applying", async () => {

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.test.ts
@@ -137,6 +137,34 @@ describe("FakeServer", () => {
     expect(server.tasks.get(recurring.id)?.due).toBe("2026-08-17");
   });
 
+  test("already-restored recurring state is idempotent", async () => {
+    const server = new FakeServer(makeClock());
+    const recurring = makeTask({
+      recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+      due: "2026-08-10",
+    });
+    server.seed(recurring);
+
+    const result = await server.completeRecurringInstance(recurring.id, {
+      date: "2026-08-01",
+      completed: false,
+      restore: {
+        recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+        scheduled: "2026-08-08",
+        due: "2026-08-10",
+        skipped: false,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.scheduled).toBe("2026-08-08");
+      expect(result.value.due).toBe("2026-08-10");
+      expect(result.value.completeInstances).toEqual([]);
+    }
+  });
+
   test("a replayed X-Mutation-Id returns the stored response without re-applying", async () => {
     const server = new FakeServer(makeClock());
     const first = await server.createTask(

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts
@@ -79,11 +79,14 @@ export function memoryStoreStorage(
   initial: {
     tasks?: Task[];
     aliases?: string | null;
+    acknowledgedCompletionRestores?: string | null;
     lastSync?: number | null;
   } = {},
 ): MemoryStoreStorage {
   let tasks = initial.tasks ?? [];
   let aliases = initial.aliases ?? null;
+  let acknowledgedCompletionRestores =
+    initial.acknowledgedCompletionRestores ?? null;
   let lastSync = initial.lastSync ?? null;
   return {
     getTasks: () => Promise.resolve(tasks),
@@ -96,12 +99,24 @@ export function memoryStoreStorage(
       aliases = d;
       return Promise.resolve();
     },
+    getAcknowledgedCompletionRestores: () =>
+      Promise.resolve(acknowledgedCompletionRestores),
+    setAcknowledgedCompletionRestores: (d) => {
+      acknowledgedCompletionRestores = d;
+      return Promise.resolve();
+    },
     getLastSyncTime: () => Promise.resolve(lastSync),
     setLastSyncTime: (t) => {
       lastSync = t;
       return Promise.resolve();
     },
-    clone: () => memoryStoreStorage({ tasks, aliases, lastSync }),
+    clone: () =>
+      memoryStoreStorage({
+        tasks,
+        aliases,
+        acknowledgedCompletionRestores,
+        lastSync,
+      }),
   };
 }
 

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts
@@ -15,7 +15,10 @@ import type { CommandClient, MutationOptions, SyncStatus } from "../SyncEngine";
 import { SyncEngine } from "../SyncEngine";
 import { TaskStore, type TaskStoreStorage } from "../../store/TaskStore";
 import type { CompleteInstanceRequest } from "tasknotes-types/v2";
-import { applyFakeRecurringCompletion } from "./fake-recurring-completion";
+import {
+  applyFakeRecurringCompletion,
+  restoreErrorFor,
+} from "./fake-recurring-completion";
 
 /**
  * Deterministic simulation harness for the offline-first sync stack.
@@ -450,6 +453,8 @@ export class FakeServer implements CommandClient {
     if (existing === undefined) {
       return Promise.resolve(err(new NotFoundError("Task", String(id))));
     }
+    const restoreError = restoreErrorFor(existing, instance, this.clock.now());
+    if (restoreError !== undefined) return Promise.resolve(err(restoreError));
     const updated = applyFakeRecurringCompletion(
       existing,
       instance,

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts
@@ -14,6 +14,8 @@ import { CommandQueue, type CommandQueueStorage } from "../CommandQueue";
 import type { CommandClient, MutationOptions, SyncStatus } from "../SyncEngine";
 import { SyncEngine } from "../SyncEngine";
 import { TaskStore, type TaskStoreStorage } from "../../store/TaskStore";
+import type { CompleteInstanceRequest } from "tasknotes-types/v2";
+import { applyFakeRecurringCompletion } from "./fake-recurring-completion";
 
 /**
  * Deterministic simulation harness for the offline-first sync stack.
@@ -43,13 +45,6 @@ export function makeClock(startMs = 1_750_000_000_000): ManualClock {
       current = ms;
     },
   };
-}
-
-function ymdOf(ms: number): string {
-  const d = new Date(ms);
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${String(d.getFullYear())}-${month}-${day}`;
 }
 
 export type MemoryQueueStorage = CommandQueueStorage & {
@@ -417,7 +412,7 @@ export class FakeServer implements CommandClient {
 
   completeRecurringInstance(
     id: TaskId,
-    instance?: { date: string; completed: boolean },
+    instance?: CompleteInstanceRequest,
     options?: MutationOptions,
   ): Promise<Result<Task, AppError>> {
     const mutationId = options?.mutationId ?? null;
@@ -440,28 +435,11 @@ export class FakeServer implements CommandClient {
     if (existing === undefined) {
       return Promise.resolve(err(new NotFoundError("Task", String(id))));
     }
-    let completeInstances: string[];
-    if (instance === undefined) {
-      // Legacy fallback: toggle "server today".
-      const today = ymdOf(this.clock.now());
-      const has = existing.completeInstances.includes(today);
-      completeInstances = has
-        ? existing.completeInstances.filter((d) => d !== today)
-        : [...existing.completeInstances, today];
-    } else {
-      // P1 set-semantics: absolute state at the app-provided date.
-      const has = existing.completeInstances.includes(instance.date);
-      if (instance.completed === has) {
-        completeInstances = [...existing.completeInstances];
-      } else if (instance.completed) {
-        completeInstances = [...existing.completeInstances, instance.date];
-      } else {
-        completeInstances = existing.completeInstances.filter(
-          (d) => d !== instance.date,
-        );
-      }
-    }
-    const updated: Task = { ...existing, completeInstances };
+    const updated = applyFakeRecurringCompletion(
+      existing,
+      instance,
+      this.clock.now(),
+    );
     this.tasks.set(id, updated);
     this.remember(mutationId, { kind: "task", task: updated });
     return Promise.resolve(ok({ ...updated }));

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
@@ -452,7 +452,8 @@ describe("recurring completion captures the tapped day", () => {
       due: "2026-08-10",
     });
     harness.server.seed(recurring);
-    expect((await harness.engine.syncNow()).ok).toBe(true);
+    const initialSync = await harness.engine.syncNow();
+    expect(initialSync.ok).toBe(true);
     harness.server.goOffline();
 
     const restore = {
@@ -477,7 +478,8 @@ describe("recurring completion captures the tapped day", () => {
     });
 
     harness.server.goOnline();
-    expect((await harness.engine.syncNow()).ok).toBe(true);
+    const syncResult = await harness.engine.syncNow();
+    expect(syncResult.ok).toBe(true);
     const completionCalls = harness.server.calls.filter(
       (call) => call.method === "completeRecurringInstance",
     );

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
@@ -376,6 +376,47 @@ describe("recurring completion captures the tapped day", () => {
     const server = harness.server.tasks.get(recurring.id);
     expect(server?.completeInstances).toEqual(["2026-07-01"]); // not 07-02
   });
+
+  test("atomic Undo survives an offline replay with the original schedule", async () => {
+    const harness = makeHarness();
+    await harness.store.restore();
+    const recurring = makeTask({
+      recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+      due: "2026-08-10",
+      completeInstances: ["2026-08-01"],
+    });
+    harness.server.seed(recurring);
+    const initialSync = await harness.engine.syncNow();
+    expect(initialSync.ok).toBe(true);
+    harness.server.goOffline();
+
+    await harness.store.dispatch({
+      type: "set_instance_complete",
+      taskId: recurring.id,
+      date: "2026-08-01",
+      completed: false,
+      restore: {
+        recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+        scheduled: "2026-08-01",
+        due: null,
+        skipped: false,
+      },
+    });
+
+    const optimistic = harness.store.getSnapshot().tasks.get(recurring.id);
+    expect(optimistic?.completeInstances).toEqual([]);
+    expect(optimistic?.scheduled).toBe("2026-08-01");
+    expect(optimistic?.due).toBeUndefined();
+
+    harness.server.goOnline();
+    const syncResult = await harness.engine.syncNow();
+    expect(syncResult.ok).toBe(true);
+    const server = harness.server.tasks.get(recurring.id);
+    expect(server?.completeInstances).toEqual([]);
+    expect(server?.scheduled).toBe("2026-08-01");
+    expect(server?.due).toBeUndefined();
+  });
 });
 
 describe("engine disposal (API client swapped in Settings)", () => {

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
@@ -350,6 +350,31 @@ describe("retry classification", () => {
 });
 
 describe("recurring completion captures the tapped day", () => {
+  test("offline completion advances the projected schedule", async () => {
+    const harness = makeHarness();
+    harness.clock.set(new Date("2026-08-03T12:00:00.000Z").getTime());
+    await harness.store.restore();
+    const recurring = makeTask({
+      recurrence: "FREQ=WEEKLY",
+      scheduled: "2026-08-01",
+    });
+    harness.server.seed(recurring);
+    await harness.engine.syncNow();
+
+    await harness.store.dispatch({
+      type: "set_instance_complete",
+      taskId: recurring.id,
+      date: "2026-08-01",
+      completed: true,
+    });
+    const result = await harness.engine.syncNow();
+
+    expect(result.ok).toBe(true);
+    expect(harness.server.tasks.get(recurring.id)?.scheduled).toBe(
+      "2026-08-08",
+    );
+  });
+
   test("a 23:59 tap replayed after midnight still completes the tapped date", async () => {
     const tappedAt = new Date("2026-07-01T23:59:00").getTime();
     const harness = makeHarness();

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
@@ -442,6 +442,59 @@ describe("recurring completion captures the tapped day", () => {
     expect(server?.scheduled).toBe("2026-08-01");
     expect(server?.due).toBeUndefined();
   });
+
+  test("offline re-toggle preserves the pending completion restore", async () => {
+    const harness = makeHarness();
+    await harness.store.restore();
+    const recurring = makeTask({
+      recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+      due: "2026-08-10",
+    });
+    harness.server.seed(recurring);
+    expect((await harness.engine.syncNow()).ok).toBe(true);
+    harness.server.goOffline();
+
+    const restore = {
+      recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+      scheduled: "2026-08-08",
+      due: "2026-08-10",
+      skipped: false,
+    };
+    await harness.store.dispatch({
+      type: "set_instance_complete",
+      taskId: recurring.id,
+      date: "2026-08-08",
+      completed: true,
+      restore,
+    });
+    await harness.store.dispatch({
+      type: "set_instance_complete",
+      taskId: recurring.id,
+      date: "2026-08-08",
+      completed: false,
+      restore,
+    });
+
+    harness.server.goOnline();
+    expect((await harness.engine.syncNow()).ok).toBe(true);
+    const completionCalls = harness.server.calls.filter(
+      (call) => call.method === "completeRecurringInstance",
+    );
+    expect(completionCalls).toHaveLength(2);
+    expect(completionCalls[0]?.payload).toEqual({
+      date: "2026-08-08",
+      completed: true,
+    });
+    expect(completionCalls[1]?.payload).toEqual({
+      date: "2026-08-08",
+      completed: false,
+      restore,
+    });
+    expect(harness.server.tasks.get(recurring.id)?.scheduled).toBe(
+      "2026-08-08",
+    );
+  });
 });
 
 describe("engine disposal (API client swapped in Settings)", () => {

--- a/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/__tests__/offline-scenarios.test.ts
@@ -408,7 +408,6 @@ describe("recurring completion captures the tapped day", () => {
     const recurring = makeTask({
       recurrence: "DTSTART:20260801;FREQ=WEEKLY",
       scheduled: "2026-08-08",
-      due: "2026-08-10",
       completeInstances: ["2026-08-01"],
     });
     harness.server.seed(recurring);

--- a/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
@@ -308,6 +308,32 @@ describe("applyCommand — idempotent absolute-state semantics", () => {
   });
 });
 
+test("uncompleting without restore preserves a skipped instance", () => {
+  const id = taskId("TaskNotes/a.md");
+  const tasks = new Map<TaskId, Task>([
+    [
+      id,
+      makeTask({
+        recurrence: "FREQ=WEEKLY",
+        completeInstances: ["2026-08-01"],
+        skippedInstances: ["2026-08-01"],
+      }),
+    ],
+  ]);
+  const uncomplete: Command = {
+    id: "uncomplete-skipped",
+    createdAt: 0,
+    type: "set_instance_complete",
+    taskId: id,
+    date: "2026-08-01",
+    completed: false,
+  };
+
+  expect(applyCommand(uncomplete, tasks).get(id)?.skippedInstances).toEqual([
+    "2026-08-01",
+  ]);
+});
+
 describe("remapTaskId / commandTarget", () => {
   const from = taskId("tmp-1");
   const to = taskId("TaskNotes/real.md");

--- a/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
@@ -10,6 +10,7 @@ import {
 import { taskId, type Task, type TaskId } from "../../domain/types";
 import {
   type Command,
+  CommandSchema,
   type CreateCommand,
   applyCommand,
   classify,
@@ -140,6 +141,120 @@ describe("applyCommand — idempotent absolute-state semantics", () => {
     const d = applyCommand(uncomplete, c);
     expect(c.get(id)?.completeInstances).toEqual([]);
     expect(d.get(id)?.completeInstances).toEqual([]);
+  });
+
+  test("rejects a recurrence restore while completing", () => {
+    expect(
+      CommandSchema.safeParse({
+        id: "invalid-restore",
+        createdAt: 0,
+        type: "set_instance_complete",
+        taskId: id,
+        date: "2026-07-03",
+        completed: true,
+        restore: {
+          recurrence: "FREQ=DAILY",
+          scheduled: "2026-07-03",
+          due: null,
+          skipped: false,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("recurring Undo restores the pre-completion schedule atomically", () => {
+    const tasks = new Map<TaskId, Task>([
+      [
+        id,
+        makeTask({
+          recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+          scheduled: "2026-08-08",
+          due: "2026-08-10",
+          completeInstances: ["2026-08-01"],
+        }),
+      ],
+    ]);
+    const undo: Command = {
+      id: "undo-1",
+      createdAt: 0,
+      type: "set_instance_complete",
+      taskId: id,
+      date: "2026-08-01",
+      completed: false,
+      restore: {
+        recurrence: "DTSTART:20260801;FREQ=WEEKLY",
+        scheduled: "2026-08-01",
+        due: null,
+        skipped: false,
+      },
+    };
+
+    const restored = applyCommand(undo, tasks).get(id);
+    expect(restored?.completeInstances).toEqual([]);
+    expect(restored?.scheduled).toBe("2026-08-01");
+    expect(restored?.due).toBeUndefined();
+    expect(applyCommand(undo, applyCommand(undo, tasks)).get(id)).toEqual(
+      restored,
+    );
+  });
+
+  test("recurring Undo restores prior skipped membership", () => {
+    const tasks = new Map<TaskId, Task>([
+      [
+        id,
+        makeTask({
+          recurrence: "FREQ=WEEKLY",
+          completeInstances: ["2026-08-01"],
+          skippedInstances: [],
+        }),
+      ],
+    ]);
+    const restored = applyCommand(
+      {
+        id: "undo-skipped",
+        createdAt: 0,
+        type: "set_instance_complete",
+        taskId: id,
+        date: "2026-08-01",
+        completed: false,
+        restore: {
+          recurrence: "FREQ=WEEKLY",
+          scheduled: null,
+          due: null,
+          skipped: true,
+        },
+      },
+      tasks,
+    ).get(id);
+
+    expect(restored?.completeInstances).toEqual([]);
+    expect(restored?.skippedInstances).toEqual(["2026-08-01"]);
+  });
+
+  test("set_status uncompletes a recurring parent without touching instances", () => {
+    const tasks = new Map<TaskId, Task>([
+      [
+        id,
+        makeTask({
+          status: "done",
+          recurrence: "FREQ=WEEKLY",
+          completeInstances: ["2026-08-01"],
+        }),
+      ],
+    ]);
+    const restored = applyCommand(
+      {
+        id: "status-1",
+        createdAt: 0,
+        type: "set_status",
+        taskId: id,
+        status: "open",
+      },
+      tasks,
+    ).get(id);
+
+    expect(restored?.status).toBe("open");
+    expect(restored?.completeInstances).toEqual(["2026-08-01"]);
   });
 
   test("update merges only defined fields; missing target is a no-op", () => {

--- a/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
@@ -318,6 +318,65 @@ describe("applyCommand — idempotent absolute-state semantics", () => {
   });
 });
 
+test("replaying a completed command with restore metadata is idempotent", () => {
+  const id = taskId("TaskNotes/a.md");
+  const original = makeTask({
+    recurrence: "FREQ=DAILY",
+    completeInstances: ["2026-07-03"],
+  });
+  const command: Command = {
+    id: "replay-complete",
+    createdAt: 0,
+    type: "set_instance_complete",
+    taskId: id,
+    date: "2026-07-03",
+    completed: true,
+    restore: {
+      recurrence: "FREQ=DAILY",
+      scheduled: null,
+      due: null,
+      skipped: false,
+    },
+  };
+
+  expect(applyCommand(command, new Map([[id, original]])).get(id)).toBe(
+    original,
+  );
+});
+
+test("forward completion clears a skipped instance even with restore metadata", () => {
+  const id = taskId("TaskNotes/a.md");
+  const command: Command = {
+    id: "complete-skipped",
+    createdAt: 0,
+    type: "set_instance_complete",
+    taskId: id,
+    date: "2026-07-03",
+    completed: true,
+    restore: {
+      recurrence: "FREQ=DAILY",
+      scheduled: null,
+      due: null,
+      skipped: true,
+    },
+  };
+
+  const applied = applyCommand(
+    command,
+    new Map([
+      [
+        id,
+        makeTask({
+          recurrence: "FREQ=DAILY",
+          skippedInstances: ["2026-07-03"],
+        }),
+      ],
+    ]),
+  ).get(id);
+  expect(applied?.completeInstances).toEqual(["2026-07-03"]);
+  expect(applied?.skippedInstances).toEqual([]);
+});
+
 test("uncompleting without restore preserves a skipped instance", () => {
   const id = taskId("TaskNotes/a.md");
   const tasks = new Map<TaskId, Task>([

--- a/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.test.ts
@@ -143,23 +143,33 @@ describe("applyCommand — idempotent absolute-state semantics", () => {
     expect(d.get(id)?.completeInstances).toEqual([]);
   });
 
-  test("rejects a recurrence restore while completing", () => {
-    expect(
-      CommandSchema.safeParse({
-        id: "invalid-restore",
-        createdAt: 0,
-        type: "set_instance_complete",
-        taskId: id,
-        date: "2026-07-03",
-        completed: true,
-        restore: {
-          recurrence: "FREQ=DAILY",
-          scheduled: "2026-07-03",
-          due: null,
-          skipped: false,
-        },
-      }).success,
-    ).toBe(false);
+  test("retains completion restore metadata without applying it optimistically", () => {
+    const parsed = CommandSchema.safeParse({
+      id: "invalid-restore",
+      createdAt: 0,
+      type: "set_instance_complete",
+      taskId: id,
+      date: "2026-07-03",
+      completed: true,
+      restore: {
+        recurrence: "FREQ=DAILY",
+        scheduled: "2026-07-03",
+        due: null,
+        skipped: false,
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    const original = makeTask({
+      recurrence: "FREQ=DAILY",
+      scheduled: "2026-07-03",
+    });
+    const applied = applyCommand(parsed.data, new Map([[id, original]])).get(
+      id,
+    );
+    expect(applied?.completeInstances).toEqual(["2026-07-03"]);
+    expect(applied?.scheduled).toBe("2026-07-03");
   });
 
   test("recurring Undo restores the pre-completion schedule atomically", () => {

--- a/packages/tasks-for-obsidian/src/data/sync/commands.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.ts
@@ -276,7 +276,8 @@ function applyInstanceCompletion(
   cmd: SetInstanceCompleteCommand,
 ): Task {
   const has = existing.completeInstances.includes(cmd.date);
-  if (cmd.completed === has && cmd.restore === undefined) return existing;
+  if (has && cmd.completed) return existing;
+  if (!has && !cmd.completed && cmd.restore === undefined) return existing;
 
   const completeInstances = cmd.completed
     ? [...existing.completeInstances, cmd.date]
@@ -287,12 +288,12 @@ function applyInstanceCompletion(
   const updated: Task = {
     ...existing,
     completeInstances,
-    skippedInstances: cmd.restore
-      ? cmd.restore.skipped
-        ? [...withoutSkippedTarget, cmd.date]
-        : withoutSkippedTarget
-      : cmd.completed
-        ? withoutSkippedTarget
+    skippedInstances: cmd.completed
+      ? withoutSkippedTarget
+      : cmd.restore
+        ? cmd.restore.skipped
+          ? [...withoutSkippedTarget, cmd.date]
+          : withoutSkippedTarget
         : existing.skippedInstances,
   };
   if (cmd.restore === undefined || cmd.completed) return updated;

--- a/packages/tasks-for-obsidian/src/data/sync/commands.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.ts
@@ -20,6 +20,10 @@ import {
 } from "../../domain/types";
 import type { TaskStatus } from "../../domain/status";
 import { TaskStatusSchema } from "../../domain/schemas";
+import {
+  RecurringCompletionRestoreSchema,
+  type RecurringCompletionRestore,
+} from "tasknotes-types/v2";
 
 /**
  * Offline-first sync commands.
@@ -69,12 +73,24 @@ export type SetStatusCommand = CommandBase & {
   readonly status: TaskStatus;
 };
 
-export type SetInstanceCompleteCommand = CommandBase & {
+type SetInstanceCompleteTarget = {
   readonly type: "set_instance_complete";
   readonly taskId: TaskId;
   readonly date: string;
-  readonly completed: boolean;
 };
+
+export type SetInstanceCompleteCommand = CommandBase &
+  SetInstanceCompleteTarget &
+  (
+    | {
+        readonly completed: true;
+        readonly restore?: undefined;
+      }
+    | {
+        readonly completed: false;
+        readonly restore?: RecurringCompletionRestore | undefined;
+      }
+  );
 
 export type Command =
   | CreateCommand
@@ -83,14 +99,13 @@ export type Command =
   | SetStatusCommand
   | SetInstanceCompleteCommand;
 
-export type CommandInput =
-  | Omit<CreateCommand, "id" | "createdAt">
-  | Omit<UpdateCommand, "id" | "createdAt">
-  | Omit<DeleteCommand, "id" | "createdAt">
-  | Omit<SetStatusCommand, "id" | "createdAt">
-  | Omit<SetInstanceCompleteCommand, "id" | "createdAt">;
+type WithoutCommandMetadata<CommandType> = CommandType extends Command
+  ? Omit<CommandType, "id" | "createdAt">
+  : never;
 
-export const CommandSchema = z.discriminatedUnion("type", [
+export type CommandInput = WithoutCommandMetadata<Command>;
+
+const StandardCommandSchema = z.discriminatedUnion("type", [
   z.object({
     id: z.string(),
     createdAt: z.number(),
@@ -118,13 +133,25 @@ export const CommandSchema = z.discriminatedUnion("type", [
     taskId: TaskIdSchema,
     status: TaskStatusSchema,
   }),
-  z.object({
-    id: z.string(),
-    createdAt: z.number(),
-    type: z.literal("set_instance_complete"),
-    taskId: TaskIdSchema,
-    date: z.string(),
-    completed: z.boolean(),
+]);
+
+const SetInstanceCompleteBaseSchema = z.object({
+  id: z.string(),
+  createdAt: z.number(),
+  type: z.literal("set_instance_complete"),
+  taskId: TaskIdSchema,
+  date: z.string(),
+});
+
+export const CommandSchema = z.union([
+  StandardCommandSchema,
+  SetInstanceCompleteBaseSchema.extend({
+    completed: z.literal(true),
+    restore: z.undefined().optional(),
+  }),
+  SetInstanceCompleteBaseSchema.extend({
+    completed: z.literal(false),
+    restore: RecurringCompletionRestoreSchema.optional(),
   }),
 ]);
 
@@ -238,15 +265,47 @@ export function applyCommand(
     case "set_instance_complete": {
       const existing = next.get(cmd.taskId);
       if (existing === undefined) return next;
-      const has = existing.completeInstances.includes(cmd.date);
-      if (cmd.completed === has) return next;
-      const completeInstances = cmd.completed
-        ? [...existing.completeInstances, cmd.date]
-        : existing.completeInstances.filter((d) => d !== cmd.date);
-      next.set(cmd.taskId, { ...existing, completeInstances });
+      next.set(cmd.taskId, applyInstanceCompletion(existing, cmd));
       return next;
     }
   }
+}
+
+function applyInstanceCompletion(
+  existing: Task,
+  cmd: SetInstanceCompleteCommand,
+): Task {
+  const has = existing.completeInstances.includes(cmd.date);
+  if (cmd.completed === has && cmd.restore === undefined) return existing;
+
+  const completeInstances = cmd.completed
+    ? [...existing.completeInstances, cmd.date]
+    : existing.completeInstances.filter((date) => date !== cmd.date);
+  const withoutSkippedTarget = existing.skippedInstances.filter(
+    (date) => date !== cmd.date,
+  );
+  const updated: Task = {
+    ...existing,
+    completeInstances,
+    skippedInstances:
+      cmd.restore?.skipped === true
+        ? [...withoutSkippedTarget, cmd.date]
+        : withoutSkippedTarget,
+  };
+  if (cmd.restore === undefined) return updated;
+
+  updated.recurrence = cmd.restore.recurrence;
+  if (cmd.restore.scheduled === null) {
+    Reflect.deleteProperty(updated, "scheduled");
+  } else {
+    updated.scheduled = cmd.restore.scheduled;
+  }
+  if (cmd.restore.due === null) {
+    Reflect.deleteProperty(updated, "due");
+  } else {
+    updated.due = cmd.restore.due;
+  }
+  return updated;
 }
 
 /** Rewrite a command's task reference from a temp id to the real server id. */

--- a/packages/tasks-for-obsidian/src/data/sync/commands.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.ts
@@ -287,10 +287,13 @@ function applyInstanceCompletion(
   const updated: Task = {
     ...existing,
     completeInstances,
-    skippedInstances:
-      cmd.restore?.skipped === true
+    skippedInstances: cmd.restore
+      ? cmd.restore.skipped
         ? [...withoutSkippedTarget, cmd.date]
-        : withoutSkippedTarget,
+        : withoutSkippedTarget
+      : cmd.completed
+        ? withoutSkippedTarget
+        : existing.skippedInstances,
   };
   if (cmd.restore === undefined) return updated;
 

--- a/packages/tasks-for-obsidian/src/data/sync/commands.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.ts
@@ -84,7 +84,7 @@ export type SetInstanceCompleteCommand = CommandBase &
   (
     | {
         readonly completed: true;
-        readonly restore?: undefined;
+        readonly restore?: RecurringCompletionRestore | undefined;
       }
     | {
         readonly completed: false;
@@ -147,7 +147,7 @@ export const CommandSchema = z.union([
   StandardCommandSchema,
   SetInstanceCompleteBaseSchema.extend({
     completed: z.literal(true),
-    restore: z.undefined().optional(),
+    restore: RecurringCompletionRestoreSchema.optional(),
   }),
   SetInstanceCompleteBaseSchema.extend({
     completed: z.literal(false),
@@ -295,7 +295,7 @@ function applyInstanceCompletion(
         ? withoutSkippedTarget
         : existing.skippedInstances,
   };
-  if (cmd.restore === undefined) return updated;
+  if (cmd.restore === undefined || cmd.completed) return updated;
 
   updated.recurrence = cmd.restore.recurrence;
   if (cmd.restore.scheduled === null) {

--- a/packages/tasks-for-obsidian/src/domain/recurrence.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/recurrence.test.ts
@@ -231,6 +231,16 @@ describe("nextOccurrenceAfter", () => {
     expect(nextOccurrenceAfter(task, "2026-08-01")).toBe("2026-09-01");
   });
 
+  test("skips already completed and skipped future occurrences", () => {
+    const task = makeTask({
+      recurrence: "DTSTART:20260808;FREQ=DAILY",
+      completeInstances: ["2026-08-08"],
+      skippedInstances: ["2026-08-09"],
+    });
+
+    expect(nextOccurrenceAfter(task, "2026-08-07")).toBe("2026-08-10");
+  });
+
   test("non-recurring tasks have no next occurrence", () => {
     expect(nextOccurrenceAfter(makeTask(), "2026-07-24")).toBeUndefined();
   });

--- a/packages/tasks-for-obsidian/src/domain/recurrence.ts
+++ b/packages/tasks-for-obsidian/src/domain/recurrence.ts
@@ -65,8 +65,11 @@ export function isRecurring(task: Task): boolean {
  *
  * Only meaningful for recurring tasks; callers gate on `isRecurring`.
  */
-export function completionTargetDate(task: Task): string {
-  if (task.recurrenceAnchor === "completion") return localTodayYmd();
+export function completionTargetDate(
+  task: Task,
+  today: string = localTodayYmd(),
+): string {
+  if (task.recurrenceAnchor === "completion") return today;
   return resolveOperationTargetDate(undefined, task.scheduled, task.due);
 }
 
@@ -100,7 +103,7 @@ export function isCompletedOn(task: Task, day: string): boolean {
   if (!isRecurring(task)) return isCompletedStatus(task.status);
   const effective = getEffectiveTaskStatus(
     toRecurringLike(task),
-    localDate(day),
+    modelCalendarDate(day),
     "done",
   );
   return effective === "done";
@@ -114,26 +117,47 @@ export function isCompletedOn(task: Task, day: string): boolean {
  */
 export function occursOn(task: Task, day: string): boolean {
   if (!isRecurring(task)) return false;
-  return shouldShowRecurringTaskOnDate(toRecurringLike(task), localDate(day));
-}
-
-/** Parse a YYYY-MM-DD string as a LOCAL date (never UTC midnight). */
-function localDate(day: string): Date {
-  const parts = day.split("-");
-  const y = Number(parts[0]);
-  const m = Number(parts[1]);
-  const d = Number(parts[2]);
-  // `??` only guards null/undefined; a malformed segment yields NaN, which
-  // would silently flow into an invalid Date. Fail fast instead.
-  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
-    throw new TypeError(`localDate: invalid YYYY-MM-DD string "${day}"`);
-  }
-  return new Date(y, m - 1, d);
+  return shouldShowRecurringTaskOnDate(
+    toRecurringLike(task),
+    modelCalendarDate(day),
+  );
 }
 
 /**
- * The next occurrence STRICTLY AFTER `afterYmd`, scanning up to
- * `horizonDays` ahead. Used for the "Completed · Next: <date>" undo toast.
+ * The TaskNotes model reads Date arguments with UTC calendar getters. Feed it
+ * UTC midnight so a local positive or negative offset cannot shift the task
+ * occurrence into an adjacent day. UI-only date parsing remains local.
+ */
+function modelCalendarDate(day: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day);
+  if (match === null) {
+    throw new TypeError(`localDate: invalid YYYY-MM-DD string "${day}"`);
+  }
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  if (
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() !== m - 1 ||
+    date.getUTCDate() !== d
+  ) {
+    throw new TypeError(`localDate: invalid YYYY-MM-DD string "${day}"`);
+  }
+  return date;
+}
+
+function utcCalendarDay(date: Date): string {
+  const y = String(date.getUTCFullYear());
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * The next uncompleted and unskipped occurrence STRICTLY AFTER `afterYmd`,
+ * scanning up to `horizonDays` ahead. Used by Upcoming and the completion
+ * undo toast, which must never advertise a processed date.
  */
 export function nextOccurrenceAfter(
   task: Task,
@@ -141,12 +165,16 @@ export function nextOccurrenceAfter(
   horizonDays = 366,
 ): string | undefined {
   if (!isRecurring(task)) return undefined;
-  const start = localDate(afterYmd);
+  const start = modelCalendarDate(afterYmd);
+  const processed = new Set([
+    ...task.completeInstances,
+    ...task.skippedInstances,
+  ]);
   for (let i = 1; i <= horizonDays; i += 1) {
     const d = new Date(start);
-    d.setDate(d.getDate() + i);
-    const ymd = localTodayYmd(d);
-    if (occursOn(task, ymd)) return ymd;
+    d.setUTCDate(d.getUTCDate() + i);
+    const ymd = utcCalendarDay(d);
+    if (occursOn(task, ymd) && !processed.has(ymd)) return ymd;
   }
   return undefined;
 }

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { executeTaskToggle, recurringCompletionRestore } from "./task-toggle";
 import { taskId } from "./types";
 import type { Task } from "./types";
+import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 
 function recurringTask(completeInstances: readonly string[]): Task {
   return {
@@ -81,6 +82,32 @@ describe("executeTaskToggle", () => {
       recurring: { date: "2026-08-15", completed: false, restore: null },
     });
     expect(calls).toEqual([{ date: "2026-08-15", completed: false }]);
+  });
+
+  test("passes a pending completion restore when unchecking offline", async () => {
+    const restore = {
+      scheduled: "2026-08-08",
+      due: null,
+      recurrence: "DTSTART:20260808;FREQ=WEEKLY",
+      skipped: false,
+    };
+    let received: RecurringCompletionRestore | undefined;
+    const execution = await executeTaskToggle(
+      recurringTask(["2026-08-15"]),
+      "2026-08-15",
+      "occurrence",
+      {
+        toggleStatus: async () => "status",
+        setInstanceComplete: async (_date, _completed, pendingRestore) => {
+          received = pendingRestore;
+          return "instance";
+        },
+        pendingRestore: restore,
+      },
+    );
+
+    expect(received).toEqual(restore);
+    expect(execution.recurring?.restore).toEqual(restore);
   });
 
   test("captures the exact recurrence fields needed by atomic Undo", () => {

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+
+import { executeTaskToggle, recurringCompletionRestore } from "./task-toggle";
+import { taskId } from "./types";
+import type { Task } from "./types";
+
+function recurringTask(completeInstances: readonly string[]): Task {
+  return {
+    id: taskId("weekly"),
+    path: "tasks/weekly.md",
+    title: "Weekly",
+    status: "open",
+    priority: "normal",
+    contexts: [],
+    projects: [],
+    tags: [],
+    recurrence: "DTSTART:20260808;FREQ=WEEKLY",
+    scheduled: "2026-08-08",
+    completeInstances: [...completeInstances],
+    skippedInstances: [],
+    timeEntries: [],
+    blockedBy: [],
+    reminders: [],
+    archived: false,
+    totalTrackedTime: 0,
+    isBlocked: false,
+    isBlocking: false,
+    extraFields: {},
+  };
+}
+
+describe("executeTaskToggle", () => {
+  test("completes the explicit occurrence represented by an unchecked row", async () => {
+    const calls: { readonly date: string; readonly completed: boolean }[] = [];
+    const execution = await executeTaskToggle(
+      recurringTask([]),
+      "2026-08-15",
+      "occurrence",
+      {
+        toggleStatus: async () => "status",
+        setInstanceComplete: async (date, completed) => {
+          calls.push({ date, completed });
+          return "instance";
+        },
+      },
+    );
+
+    expect(execution).toEqual({
+      result: "instance",
+      recurring: {
+        date: "2026-08-15",
+        completed: true,
+        restore: {
+          scheduled: "2026-08-08",
+          due: null,
+          recurrence: "DTSTART:20260808;FREQ=WEEKLY",
+          skipped: false,
+        },
+      },
+    });
+    expect(calls).toEqual([{ date: "2026-08-15", completed: true }]);
+  });
+
+  test("uncompletes the same explicit occurrence represented by a checked row", async () => {
+    const calls: { readonly date: string; readonly completed: boolean }[] = [];
+    const execution = await executeTaskToggle(
+      recurringTask(["2026-08-15"]),
+      "2026-08-15",
+      "occurrence",
+      {
+        toggleStatus: async () => "status",
+        setInstanceComplete: async (date, completed) => {
+          calls.push({ date, completed });
+          return "instance";
+        },
+      },
+    );
+
+    expect(execution).toEqual({
+      result: "instance",
+      recurring: { date: "2026-08-15", completed: false, restore: null },
+    });
+    expect(calls).toEqual([{ date: "2026-08-15", completed: false }]);
+  });
+
+  test("captures the exact recurrence fields needed by atomic Undo", () => {
+    expect(
+      recurringCompletionRestore(
+        {
+          ...recurringTask([]),
+          due: "2026-08-10",
+          skippedInstances: ["2026-08-08"],
+        },
+        "2026-08-08",
+      ),
+    ).toEqual({
+      scheduled: "2026-08-08",
+      due: "2026-08-10",
+      recurrence: "DTSTART:20260808;FREQ=WEEKLY",
+      skipped: true,
+    });
+  });
+
+  test("uses the status workflow for a plain task", async () => {
+    const task = { ...recurringTask([]), recurrence: undefined };
+    let statusCalls = 0;
+    const execution = await executeTaskToggle(task, undefined, "occurrence", {
+      toggleStatus: async () => {
+        statusCalls += 1;
+        return "status";
+      },
+      setInstanceComplete: async () => "instance",
+    });
+
+    expect(execution).toEqual({ result: "status", recurring: null });
+    expect(statusCalls).toBe(1);
+  });
+
+  test("uses the parent status workflow for a completed recurring task", async () => {
+    const task = { ...recurringTask([]), status: "done" as const };
+    let statusCalls = 0;
+    let instanceCalls = 0;
+    const execution = await executeTaskToggle(task, undefined, "task-status", {
+      toggleStatus: async () => {
+        statusCalls += 1;
+        return "status";
+      },
+      setInstanceComplete: async () => {
+        instanceCalls += 1;
+        return "instance";
+      },
+    });
+
+    expect(execution).toEqual({ result: "status", recurring: null });
+    expect(statusCalls).toBe(1);
+    expect(instanceCalls).toBe(0);
+  });
+});

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.ts
@@ -13,6 +13,11 @@ export type TaskToggleExecution<Result> = {
   readonly recurring: RecurringToggleExecution | null;
 };
 
+type PendingRestore =
+  | RecurringCompletionRestore
+  | Promise<RecurringCompletionRestore | undefined>
+  | undefined;
+
 /**
  * Executes the one toggle intent computed at tap time. Keeping the target date
  * and absolute completion state together prevents an offline replay from
@@ -29,7 +34,7 @@ export async function executeTaskToggle<Result>(
       completed: boolean,
       restore?: RecurringCompletionRestore,
     ) => Promise<Result>;
-    readonly pendingRestore?: RecurringCompletionRestore | undefined;
+    readonly pendingRestore?: PendingRestore;
   },
 ): Promise<TaskToggleExecution<Result>> {
   if (task === undefined || scope === "task-status" || !isRecurring(task)) {
@@ -43,7 +48,7 @@ export async function executeTaskToggle<Result>(
   const completed = !task.completeInstances.includes(date);
   const restore = completed
     ? recurringCompletionRestore(task, date)
-    : (operations.pendingRestore ?? null);
+    : ((await operations.pendingRestore) ?? null);
   return {
     result: await operations.setInstanceComplete(
       date,

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.ts
@@ -27,7 +27,9 @@ export async function executeTaskToggle<Result>(
     readonly setInstanceComplete: (
       date: string,
       completed: boolean,
+      restore?: RecurringCompletionRestore,
     ) => Promise<Result>;
+    readonly pendingRestore?: RecurringCompletionRestore | undefined;
   },
 ): Promise<TaskToggleExecution<Result>> {
   if (task === undefined || scope === "task-status" || !isRecurring(task)) {
@@ -39,12 +41,19 @@ export async function executeTaskToggle<Result>(
 
   const date = occurrenceDate ?? completionTargetDate(task);
   const completed = !task.completeInstances.includes(date);
+  const restore = completed
+    ? recurringCompletionRestore(task, date)
+    : (operations.pendingRestore ?? null);
   return {
-    result: await operations.setInstanceComplete(date, completed),
+    result: await operations.setInstanceComplete(
+      date,
+      completed,
+      restore ?? undefined,
+    ),
     recurring: {
       date,
       completed,
-      restore: completed ? recurringCompletionRestore(task, date) : null,
+      restore,
     },
   };
 }

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.ts
@@ -2,6 +2,8 @@ import { completionTargetDate, isRecurring } from "./recurrence";
 import type { Task } from "./types";
 import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 
+export const UNDO_TOAST_MS = 5000;
+
 export type RecurringToggleExecution = {
   readonly date: string;
   readonly completed: boolean;

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.ts
@@ -1,0 +1,65 @@
+import { completionTargetDate, isRecurring } from "./recurrence";
+import type { Task } from "./types";
+import type { RecurringCompletionRestore } from "tasknotes-types/v2";
+
+export type RecurringToggleExecution = {
+  readonly date: string;
+  readonly completed: boolean;
+  readonly restore: RecurringCompletionRestore | null;
+};
+
+export type TaskToggleExecution<Result> = {
+  readonly result: Result;
+  readonly recurring: RecurringToggleExecution | null;
+};
+
+/**
+ * Executes the one toggle intent computed at tap time. Keeping the target date
+ * and absolute completion state together prevents an offline replay from
+ * toggling a different recurring occurrence after the server advances it.
+ */
+export async function executeTaskToggle<Result>(
+  task: Task | undefined,
+  occurrenceDate: string | undefined,
+  scope: "occurrence" | "task-status",
+  operations: {
+    readonly toggleStatus: () => Promise<Result>;
+    readonly setInstanceComplete: (
+      date: string,
+      completed: boolean,
+    ) => Promise<Result>;
+  },
+): Promise<TaskToggleExecution<Result>> {
+  if (task === undefined || scope === "task-status" || !isRecurring(task)) {
+    return {
+      result: await operations.toggleStatus(),
+      recurring: null,
+    };
+  }
+
+  const date = occurrenceDate ?? completionTargetDate(task);
+  const completed = !task.completeInstances.includes(date);
+  return {
+    result: await operations.setInstanceComplete(date, completed),
+    recurring: {
+      date,
+      completed,
+      restore: completed ? recurringCompletionRestore(task, date) : null,
+    },
+  };
+}
+
+export function recurringCompletionRestore(
+  task: Task,
+  date: string,
+): RecurringCompletionRestore {
+  if (!isRecurring(task) || task.recurrence === undefined) {
+    throw new TypeError("recurring completion restore requires a recurrence");
+  }
+  return {
+    scheduled: task.scheduled ?? null,
+    due: task.due ?? null,
+    recurrence: task.recurrence,
+    skipped: task.skippedInstances.includes(date),
+  };
+}

--- a/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { TaskId } from "../domain/types";
 import { isActiveStatus } from "../domain/status";
 import {
+  completionTargetDate,
   isRecurring,
   localTodayYmd,
   nextOccurrenceAfter,
@@ -149,8 +150,15 @@ export function useTasks() {
         options?.scope ?? "occurrence",
         {
           toggleStatus: () => ctx.toggleStatus(id),
-          setInstanceComplete: (date, completed) =>
-            ctx.setInstanceComplete(id, date, completed),
+          setInstanceComplete: (date, completed, restore) =>
+            ctx.setInstanceComplete(id, date, completed, restore),
+          pendingRestore:
+            task?.recurrence === undefined
+              ? undefined
+              : ctx.getPendingCompletionRestore(
+                  id,
+                  options?.occurrenceDate ?? completionTargetDate(task),
+                ),
         },
       );
       const recurring = execution.recurring;

--- a/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
@@ -3,13 +3,12 @@ import { useCallback, useMemo, useState } from "react";
 import type { TaskId } from "../domain/types";
 import { isActiveStatus } from "../domain/status";
 import {
-  completionTargetDate,
-  isCompletedOn,
   isRecurring,
   localTodayYmd,
   nextOccurrenceAfter,
   occursOn,
 } from "../domain/recurrence";
+import { executeTaskToggle } from "../domain/task-toggle";
 import { useUndo } from "../state/UndoContext";
 import { feedbackTaskUncomplete } from "../lib/feedback";
 import { formatDate } from "../lib/dates";
@@ -135,35 +134,50 @@ export function useTasks() {
   // one toast per task would overwrite each other, leaving N-1 completions
   // silently un-undoable while implying otherwise.
   const toggleTask = useCallback(
-    async (id: TaskId, options?: { suppressUndo?: boolean }) => {
+    async (
+      id: TaskId,
+      options?: {
+        occurrenceDate?: string;
+        scope?: "occurrence" | "task-status";
+        suppressUndo?: boolean;
+      },
+    ) => {
       const task = ctx.tasks.get(ctx.resolveTaskId(id));
-      const date =
-        task !== undefined && isRecurring(task)
-          ? completionTargetDate(task)
-          : undefined;
-      const completing =
-        task !== undefined && date !== undefined && !isCompletedOn(task, date);
-      const result =
-        task !== undefined && date !== undefined
-          ? await ctx.setInstanceComplete(id, date, completing)
-          : await ctx.toggleStatus(id);
+      const execution = await executeTaskToggle(
+        task,
+        options?.occurrenceDate,
+        options?.scope ?? "occurrence",
+        {
+          toggleStatus: () => ctx.toggleStatus(id),
+          setInstanceComplete: (date, completed) =>
+            ctx.setInstanceComplete(id, date, completed),
+        },
+      );
+      const recurring = execution.recurring;
       if (
-        task !== undefined &&
-        date !== undefined &&
-        completing &&
-        result.ok &&
+        recurring !== null &&
+        recurring.completed &&
+        recurring.restore !== null &&
+        execution.result.ok &&
         options?.suppressUndo !== true
       ) {
-        const next = nextOccurrenceAfter(task, date);
+        const next = task
+          ? nextOccurrenceAfter(task, recurring.date)
+          : undefined;
         showUndo({
           message: next ? `Completed · Next: ${formatDate(next)}` : "Completed",
           onUndo: () => {
             feedbackTaskUncomplete();
-            void ctx.setInstanceComplete(id, date, false);
+            void ctx.setInstanceComplete(
+              id,
+              recurring.date,
+              false,
+              recurring.restore ?? undefined,
+            );
           },
         });
       }
-      return result;
+      return execution.result;
     },
     [ctx, showUndo],
   );

--- a/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
@@ -4,6 +4,7 @@ import type { TaskId } from "../domain/types";
 import { isActiveStatus } from "../domain/status";
 import {
   completionTargetDate,
+  isCompletedOn,
   isRecurring,
   localTodayYmd,
   nextOccurrenceAfter,
@@ -141,10 +142,11 @@ export function useTasks() {
           ? completionTargetDate(task)
           : undefined;
       const completing =
-        task !== undefined &&
-        date !== undefined &&
-        !task.completeInstances.includes(date);
-      const result = await ctx.toggleStatus(id);
+        task !== undefined && date !== undefined && !isCompletedOn(task, date);
+      const result =
+        task !== undefined && date !== undefined
+          ? await ctx.setInstanceComplete(id, date, completing)
+          : await ctx.toggleStatus(id);
       if (
         task !== undefined &&
         date !== undefined &&

--- a/packages/tasks-for-obsidian/src/screens/TaskDetailScreen.tsx
+++ b/packages/tasks-for-obsidian/src/screens/TaskDetailScreen.tsx
@@ -204,7 +204,11 @@ export function TaskDetailScreen({ route, navigation }: Props) {
               } else {
                 feedbackTaskComplete();
               }
-              void toggleTask(taskId);
+              void toggleTask(taskId, {
+                scope: isCompletedStatus(task.status)
+                  ? "task-status"
+                  : "occurrence",
+              });
             }}
             accessibilityRole="button"
             accessibilityLabel={

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -49,7 +49,7 @@ type TaskContextValue = {
   getPendingCompletionRestore: (
     id: TaskId,
     date: string,
-  ) => RecurringCompletionRestore | undefined;
+  ) => Promise<RecurringCompletionRestore | undefined>;
   createTask: (req: CreateTaskRequest) => Promise<Result<Task, AppError>>;
   updateTask: (
     id: TaskId,

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -46,6 +46,10 @@ type TaskContextValue = {
   syncStatus: SyncStatus;
   lastSyncTime: number | null;
   resolveTaskId: (id: TaskId) => TaskId;
+  getPendingCompletionRestore: (
+    id: TaskId,
+    date: string,
+  ) => RecurringCompletionRestore | undefined;
   createTask: (req: CreateTaskRequest) => Promise<Result<Task, AppError>>;
   updateTask: (
     id: TaskId,
@@ -238,6 +242,11 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
     [store],
   );
 
+  const getPendingCompletionRestore = useCallback(
+    (id: TaskId, date: string) => store.getPendingCompletionRestore(id, date),
+    [store],
+  );
+
   const value = useMemo<TaskContextValue>(
     () => ({
       tasks: snapshot.tasks,
@@ -249,6 +258,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       syncStatus,
       lastSyncTime: snapshot.lastSyncTime,
       resolveTaskId,
+      getPendingCompletionRestore,
       createTask,
       updateTask,
       deleteTask,
@@ -262,6 +272,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       snapshot,
       syncStatus,
       resolveTaskId,
+      getPendingCompletionRestore,
       createTask,
       updateTask,
       deleteTask,

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -14,7 +14,7 @@ import { NotFoundError } from "../domain/errors";
 import type { Result } from "../domain/result";
 import { OK_VOID, err, ok } from "../domain/result";
 import { getNextStatus } from "../domain/status";
-import { completionTargetDate, isRecurring } from "../domain/recurrence";
+import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 import type {
   CreateTaskRequest,
   Task,
@@ -57,6 +57,7 @@ type TaskContextValue = {
     id: TaskId,
     date: string,
     completed: boolean,
+    restore?: RecurringCompletionRestore,
   ) => Promise<Result<Task, AppError>>;
   refreshTasks: () => Promise<Result<void, AppError>>;
   retryDeadLetter: (commandId: string) => Promise<void>;
@@ -180,26 +181,11 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       if (existing === undefined) {
         return err(new NotFoundError("Task", String(id)));
       }
-      // Absolute target state, computed once at tap time — replaying the
-      // command later (even after midnight) applies exactly this intent.
-      // Recurring completion targets the SCHEDULED occurrence (plugin parity via
-      // completionTargetDate), not the literal tap day — otherwise a tap on a
-      // non-occurrence day records an orphaned date the model never reads as
-      // done. Capture the date once so `date` and `completed` can't straddle a
-      // midnight boundary (object properties evaluate left-to-right).
-      const instanceDate = completionTargetDate(existing);
-      const updated = isRecurring(existing)
-        ? await store.dispatch({
-            type: "set_instance_complete",
-            taskId: target,
-            date: instanceDate,
-            completed: !existing.completeInstances.includes(instanceDate),
-          })
-        : await store.dispatch({
-            type: "set_status",
-            taskId: target,
-            status: getNextStatus(existing.status),
-          });
+      const updated = await store.dispatch({
+        type: "set_status",
+        taskId: target,
+        status: getNextStatus(existing.status),
+      });
       if (updated === undefined) {
         return err(new NotFoundError("Task", String(id)));
       }
@@ -217,6 +203,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       id: TaskId,
       date: string,
       completed: boolean,
+      restore?: RecurringCompletionRestore,
     ): Promise<Result<Task, AppError>> => {
       const target = store.resolveTaskId(id);
       const updated = await store.dispatch({
@@ -224,6 +211,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
         taskId: target,
         date,
         completed,
+        ...(restore === undefined ? {} : { restore }),
       });
       if (updated === undefined) {
         return err(new NotFoundError("Task", String(id)));


### PR DESCRIPTION
## Summary

- make recurring completion an absolute-state, date-captured mutation so retries and offline replay cannot complete the wrong day
- make Undo restore the original recurring-instance snapshot atomically across the app, shared wire types, and server
- serialize TaskStore mutations and persist the authoritative server base before acknowledging a durable queue command
- preserve exact project identities, including two qualified projects with the same basename

## Why

Recurring completion previously depended on replay-time state, which made midnight boundaries and retries unsafe. The client also acknowledged queue work before its authoritative base write was guaranteed durable. This branch establishes the reliability contract used by the product UI above it.

## Verification

- isolated branch: 319 app tests, 154 server tests, and 9 shared-type tests passed
- focused test, lint, typecheck, and build Turbo tasks passed for tasks-for-obsidian, tasknotes-server, and tasknotes-types
- recurring timezone, offline replay, atomic Undo, project identity, and interrupted base-write regressions are covered
- staged pre-commit and commit-message hooks passed

## Stack

This is 1 of 3. The product UI is #2013 and its end-to-end evidence/roadmap is #2014.
