### PR TITLE
test(tasks-for-obsidian): expand product experience e2e

### DIFF
--- a/packages/docs/archive/completed/tasks-for-obsidian-context-menu-rn85.md
+++ b/packages/docs/archive/completed/tasks-for-obsidian-context-menu-rn85.md
@@ -26,11 +26,11 @@ menu and iOS's native `UIMenu` without the old compatibility packages.
 
 ## Completed
 
-- [x] Replace every Zeego context/dropdown menu call site.
-- [x] Remove `zeego`, `react-native-ios-context-menu`, and
-      `react-native-ios-utilities` from the app and Bun lockfile.
-- [x] Remove the obsolete Bun patch and Podfile deployment-target workaround.
-- [x] Regenerate the CocoaPods lockfile and verify native dependency discovery.
+- Replace every Zeego context/dropdown menu call site.
+- Remove `zeego`, `react-native-ios-context-menu`, and
+  `react-native-ios-utilities` from the app and Bun lockfile.
+- Remove the obsolete Bun patch and Podfile deployment-target workaround.
+- Regenerate the CocoaPods lockfile and verify native dependency discovery.
 
 ## Evidence
 

--- a/packages/docs/archive/completed/tasks-for-obsidian-context-menu-rn85.md
+++ b/packages/docs/archive/completed/tasks-for-obsidian-context-menu-rn85.md
@@ -3,6 +3,8 @@ id: tasks-for-obsidian-context-menu-rn85
 type: todo
 status: complete
 board: false
+verification: agent
+disposition: active
 origin: packages/docs/archive/completed/2026-07-03_tasknotes-first-in-class.md
 source_marker: false
 ---
@@ -22,7 +24,7 @@ Task and card menus preserve long-press activation and nested actions; bulk
 priority remains a tap menu. The replacement supports Android's native popup
 menu and iOS's native `UIMenu` without the old compatibility packages.
 
-## Remaining
+## Completed
 
 - [x] Replace every Zeego context/dropdown menu call site.
 - [x] Remove `zeego`, `react-native-ios-context-menu`, and

--- a/packages/docs/plans/2026-08-07_tasknotes-native-product-experience.md
+++ b/packages/docs/plans/2026-08-07_tasknotes-native-product-experience.md
@@ -306,81 +306,64 @@ verify the corresponding Markdown in the vault.
 - Pixel parity across Android in this wave; shared logic and functional fallback
   remain required.
 
+## Completed
+
+- Spike native bottom tabs and reject the experimental host after reproducible
+  iOS 27 runtime crashes.
+- Define and test task presentation, agenda/date precedence, capture seed,
+  display configuration, and saved-view schemas.
+- Ship the stable tab shell, native sheets, shared task rows, direct task-detail
+  editing, keyboard-first capture, reversible parser chips, and shared capture
+  routing.
+- Replace Zeego's remaining call sites and add semantic System/Light/Dark
+  appearance colors.
+- Correct Today/Upcoming grouping, add overdue rescheduling, the week strip,
+  and recurrence-aware day-load indicators.
+- Persist editable saved views, rebuild Browse, bind the Job Search board to its
+  saved-view query, and add saved-view/completed-search flows.
+
 ## Remaining
 
 ### Phase 0 — Native feasibility and contracts
 
 - [ ] Record seeded before-state screenshots and performance/accessibility
       baselines for Inbox, Today, Upcoming, Browse, Quick Add, and task detail.
-- [x] Spike native bottom tabs and record the adopt/reject result: reject the
-      experimental host for this wave after reproducible iOS 27 runtime crashes;
-      ship one stable tab navigator on every supported OS version.
 - [ ] Validate native stack form sheets against restoration, accessibility,
       keyboard behavior, and an older runtime compatible with the deployment
       target.
-- [x] Define and test `TaskPresentation`, agenda/date precedence, capture seed,
-      display configuration, and versioned saved-view schemas.
 - [ ] Define the semantic color, Dynamic Type, spacing, motion, and haptic tokens.
 
 ### Phase 1 — Native shell
 
-- [x] Give the single stable tab shell real SF Symbol icons, per-tab titles,
-      contextual toolbar actions, native Quick Add/task-detail sheets, and the
-      existing deep-link contract.
 - [ ] Introduce per-tab native stacks and finish large-title behavior without
       creating a second runtime navigation implementation.
 - [ ] Convert display/sort/filter and overflow actions to native sheets/menus.
-- [x] Replace Zeego's remaining task/project call sites, remove its patches and
-      dependency, and archive the RN 0.85 context-menu TODO.
-- [x] Add System/Light/Dark appearance and semantic platform colors.
 
 ### Phase 2 — Tasks and details
 
-- [x] Ship the shared task-row presentation and section-header behavior across
-      every current task collection.
-- [x] Replace the read/edit detail screen with the task-detail sheet and direct,
-      offline-safe field editing.
 - [ ] Add configurable swipe actions and keep menu, swipe, and bulk semantics in
       sync.
 
 ### Phase 3 — Capture
 
-- [x] Ship the keyboard-first capture sheet, contextual seeds, structured
-      project selection, Create Another, and optimistic dismissal.
 - [ ] Add structured planned-date, deadline, and priority controls to the
       capture action row; keep the deterministic text path available.
-- [x] Make parser chips editable and reversible, with complete autocomplete and
-      accessibility coverage.
-- [x] Route in-app, deep-link, Home Screen, Siri/Shortcuts, and widget capture
-      through the same seed and creation command.
 - [ ] Hold the explicit AI product checkpoint; proceed without AI unless the
       user chooses a separately evaluated capture use case.
 
 ### Phase 4 — Daily planning
 
-- [x] Correct Today and Upcoming inclusion/grouping around scheduled versus due,
-      recurrence, overdue state, and deduplication.
-- [x] Add explicit overdue bulk rescheduling through the shared scheduling
-      sheet.
 - [ ] Add the deterministic Plan My Day sheet.
-- [x] Add Upcoming's selectable week strip and recurrence-aware reusable
-      day-load indicators.
 - [ ] Make the week strip collapsible, then add the expandable month calendar
       and list-scroll synchronization.
 
 ### Phase 5 — Views and organization
 
-- [x] Persist and migrate editable saved views with query and sort choices.
 - [ ] Add the remaining per-view layout, grouping, density, visibility, and
       date-range choices.
-- [x] Rebuild Browse around favorites, saved views, organizational dimensions,
-      completed history, reports, and settings.
 - [ ] Persist user-defined Browse section ordering.
 - [ ] Replace the hard-coded Job Search board with generic list, board, and
       calendar collection renderers.
-- [x] Bind the transitional Job Search board to its editable saved-view query,
-      shared task presentation, and explicit safe move actions.
-- [x] Add saved-view lifecycle and completed search/uncomplete flows.
 - [ ] Add distinct completed-history filter controls.
 
 ### Phase 6 — Acceptance and closeout

--- a/packages/docs/plans/2026-08-07_tasknotes-native-product-experience.md
+++ b/packages/docs/plans/2026-08-07_tasknotes-native-product-experience.md
@@ -1,0 +1,436 @@
+---
+id: plan-2026-08-07-tasknotes-native-product-experience
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# TaskNotes Native Product Experience
+
+## Outcome
+
+Make Tasks for Obsidian feel like a first-class iPhone task manager: as fast and
+legible as Todoist for capture, review, and daily planning, while keeping
+TaskNotes Markdown in Obsidian as the task source of truth and retaining the
+app's stronger offline behavior, recurrence handling, time tracking, and data
+ownership.
+
+This is an iOS-first product pass, not a pixel-for-pixel Todoist clone. Android
+must remain functional, but iPhone is the visual and interaction acceptance
+target for this wave.
+
+## Baseline
+
+The 2026-08-07 Todoist reference walkthrough exposed six connected gaps:
+
+| Area              | Current app                                                                                            | Target experience                                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| Native polish     | One global header, JavaScript tabs without real icons, custom modal surfaces, manually themed controls | Per-tab native navigation, SF Symbols, system materials and colors, native sheets and menus, Dynamic Type            |
+| Task presentation | Title plus sparse badges; scheduled and deadline meaning is not consistently visible                   | Scannable rows with stable date semantics, project/context cues, priority, recurrence, blocked state, and sync state |
+| Quick capture     | Full-screen form with parser tokens and a final create button                                          | Keyboard-first bottom composer with editable metadata chips, contextual defaults, and one-tap creation               |
+| Views             | Hard-coded saved views and a one-off Job Search board                                                  | User-defined saved views with shared list, board, and calendar presentations                                         |
+| Organization      | Browse is a segmented flat list                                                                        | A browse hub for favorites, views, projects, contexts, tags, completed work, reports, and settings                   |
+| Daily planning    | Today is due-date based; Upcoming is a plain grouped list                                              | Scheduled-vs-deadline-aware Today sections, overdue planning, and an interactive upcoming calendar                   |
+
+The reliability and ergonomics work already completed in
+`../archive/completed/2026-07-03_tasknotes-first-in-class.md` and
+`../archive/completed/2026-07-22_todoist-ergonomics-wave.md` remains the
+foundation. This plan supersedes only the future-gap list in
+`../guides/2026-07-22_todoist-feature-comparison.md`; it must not reimplement
+schedule editing, recurring undo, bulk actions, autocomplete, or offline sync.
+
+## Product decisions
+
+### Native without ornamental imitation
+
+- Use system navigation, presentation, color, typography, haptics, and
+  accessibility behavior wherever React Native exposes them.
+- Let iOS provide Liquid Glass on supported releases. Do not draw fake glass
+  backgrounds or put glass behind task content; use materials only for
+  navigation and floating controls.
+- Keep hierarchy shallow: each tab owns a native stack and large title; editors
+  and pickers are native stack sheet routes above those stacks.
+- Use one visual vocabulary for buttons, task metadata, empty states, banners,
+  and destructive actions. Remove generic pill controls when a toolbar item,
+  menu, segmented control, or sheet is the native equivalent.
+
+### Preserve TaskNotes meaning
+
+- `scheduled` means the day the user intends to work on a task.
+- `due` means a hard deadline. The UI labels it as a deadline whenever both
+  fields could otherwise be confused.
+- Task fields continue to round-trip through the existing TaskNotes server and
+  Markdown contract. Presentation preferences must not invent new task
+  frontmatter.
+- Saved views, layout choices, favorite order, and swipe configuration are
+  app preferences. Persist them locally as versioned, Zod-validated JSON. A
+  future cross-device preference contract is separate work; do not silently
+  write this state into arbitrary notes or TaskNotes plugin settings.
+- Migrate the two current built-in saved views into editable persisted views on
+  first load, then remove their hard-coded behavior so no personal project is a
+  permanent product concept.
+
+### AI is not on the critical path
+
+No model integration is required for this plan. Navigation, row presentation,
+deterministic natural-language parsing, filtering, and planning can all be
+excellent without network latency, cost, or privacy tradeoffs.
+
+After the deterministic quick-capture work is accepted, pause for an explicit
+product decision with the user. Candidate model-backed features are limited to
+high-value capture boundaries such as rambling voice-to-structured-task or
+photo-to-task extraction. If one is chosen, write a separate decision and
+evaluation plan before implementation. It must include structured preview and
+explicit confirmation, never silently create or mutate tasks, preserve a fully
+functional offline path, disclose what leaves the device, and measure quality,
+latency, and cost against a pinned corpus before choosing a provider or model.
+
+## Experience architecture
+
+### Navigation and presentation
+
+- Replace the single root `Tasks` header with a native stack inside Inbox,
+  Today, Upcoming, and Browse. Preserve the existing route names and deep links.
+- Spike the React Navigation 7 native bottom-tab API already available through
+  the installed dependency. Wrap its experimental import in one local adapter
+  so the rest of the app depends on a stable internal interface.
+- Accept native tabs only if tab restoration, deep links, VoiceOver labels,
+  keyboard/sheet interaction, and the iOS 15.1 deployment target all work. If
+  the spike fails, keep the stable JavaScript navigator for this wave but give
+  it native SF Symbol icons and system styling; do not ship two runtime tab
+  implementations.
+- Use the existing native SF Symbol bridge for content controls and the native
+  tab API's symbol support for tabs. Remove placeholder tab glyphs.
+- Present Quick Add, task detail, scheduling, and display/filter configuration
+  as native stack sheets with appropriate detents and grabbers. Route params
+  remain serializable: sheets receive task/view IDs or initial values and
+  commit through domain hooks rather than callback params.
+- Convert project/task overflow actions to the maintained native menu path and
+  resolve `../todos/tasks-for-obsidian-context-menu-rn85.md`; remove Zeego and
+  its compatibility patches once no call sites remain.
+
+### System design layer
+
+- Replace hard-coded iOS surface colors with semantic `PlatformColor` values;
+  retain explicit Android tokens. Change appearance to System, Light, or Dark,
+  with System as the default.
+- Map text roles to Dynamic Type ramps and verify layouts at accessibility
+  sizes. Do not disable font scaling or truncate essential metadata.
+- Centralize spacing, corner radii, minimum hit targets, separator behavior,
+  motion, and haptic intent. Honor Reduce Motion, Reduce Transparency, Bold
+  Text, increased contrast, and sound/haptic preferences.
+- Keep content backgrounds quiet and opaque. Reserve the accent color for
+  selection, capture, and high-value state rather than coloring every control.
+
+### Shared task-collection model
+
+Inbox, Today, Upcoming, projects, contexts, tags, completed history, and saved
+views should render through one collection pipeline:
+
+1. Select candidate tasks from the local offline store.
+2. Apply a pure, tested filter predicate.
+3. Derive each task's presentation date and state.
+4. Sort and group through a single configuration.
+5. Render the same result as list, board, or calendar.
+
+Define a versioned `SavedViewSchema` around:
+
+- identity: ID, name, SF Symbol, tint, favorite, and order;
+- query: projects, contexts, tags, statuses, priorities, text, completed state,
+  missing-field predicates, and relative scheduled/deadline ranges;
+- presentation: layout, sort, group, density, and completed visibility.
+
+Keep this schema app-local while the preference is app-local. Reuse the server's
+TaskNotes query vocabulary where it matches, but do not force view-only layout
+fields into `tasknotes-types`.
+
+## Target flows
+
+### Task rows and detail
+
+- Give every row a clear completion target, a one- or two-line title, and a
+  consistent secondary line. The secondary line prioritizes planned date,
+  deadline, project, then one useful context/tag; recurrence, blocked state,
+  estimate/tracked time, and queued sync use compact accessible indicators.
+- Derive row copy and color in a pure `TaskPresentation` function so list,
+  board, widget, VoiceOver, and tests agree. Never let individual screens infer
+  date meaning independently.
+- Color the completion control by priority without making color the only signal.
+  Use concise relative dates for near-term work and an unambiguous absolute date
+  outside that window.
+- Make section headers useful: count, collapse state, and contextual actions such
+  as Reschedule overdue. Preserve stable scroll position while rows complete,
+  move, or sync.
+- Open task detail as a native form sheet. Title and Markdown details use local
+  drafts committed on Done, blur, or dismissal; metadata changes use the
+  existing optimistic command queue. Present project, planned date, deadline,
+  priority, recurrence, contexts, tags, estimate, time tracking, and blocking
+  state as direct rows or chips instead of a read/edit mode switch.
+- Keep context menu, overflow menu, and swipe actions consistent. Add explicit
+  left/right swipe preferences for Complete, Schedule, Priority, and Delete;
+  destructive full swipes still require the existing safe confirmation/undo
+  behavior.
+
+### Quick capture
+
+- Open a compact native sheet focused directly in the title field, above the
+  keyboard. Expand it only when the user asks for details or more metadata.
+- Keep the deterministic parser and autocomplete, but render parsed date,
+  recurrence, project, context, tag, and priority as editable chips. Tapping a
+  parsed chip returns its source text to the title so parsing is reversible.
+- Put planned date, deadline, project, and priority in the primary action row;
+  contexts, tags, recurrence, estimate, and Markdown details live in a More
+  menu or expanded detent. Do not show unsupported Todoist affordances such as
+  attachments, location, comments, or assignees.
+- Seed capture from its source: a project adds that project, Today schedules
+  today, a selected Upcoming day schedules that day, and Inbox adds no project.
+  The user can clear every seed before creating.
+- Keep creation optimistic and offline-first. Successful creation dismisses
+  immediately with haptic feedback; queue failure remains visible through the
+  existing sync/dead-letter UX. Support Create and Create Another without
+  waiting for a network round trip.
+- Preserve Home Screen, deep-link, Siri/Shortcuts, widget, and in-app entry
+  points. All entry points construct the same serializable capture seed and use
+  the same domain command.
+
+### Views and organization
+
+- Rebuild Browse as a vertically scannable hub: Search, Favorites, Saved Views,
+  Projects, Contexts, Tags, Completed, Reports, and Settings. Show useful active
+  counts and make section ordering persistent.
+- Add create/edit/duplicate/delete/reorder flows for saved views. Editing uses
+  the same display sheet as built-in collections rather than a parallel filter
+  UI.
+- Replace `JobSearchKanbanScreen` with a generic board renderer. Status,
+  priority, and planned-date lanes may update their single underlying field;
+  project/context/tag lanes use explicit Move/Add/Remove actions so dragging
+  never has ambiguous array semantics.
+- Add a generic calendar renderer for views whose meaningful axis is planned
+  date or deadline. Use different accessible markers for each field and never
+  merge them into one unlabeled date.
+- Add completed history with search/filter and uncomplete. Completed tasks stay
+  hidden by default in active collections unless a view opts in.
+
+### Daily planning
+
+- Replace the current due-only Today selector with a pure, recurrence-aware
+  agenda derivation. Each task appears once using this precedence:
+  Overdue, Scheduled Today, Due Today, then an optional view-specific group.
+  A future-scheduled task whose deadline is today belongs in Due Today; a task
+  scheduled today and due today stays in Scheduled Today and shows its deadline
+  on the row.
+- Add a prominent Reschedule action to Overdue. It opens the existing bulk
+  scheduling calendar with Tomorrow, Later This Week, Next Week, and custom date
+  options; nothing moves until the user confirms.
+- Add a Plan My Day sheet that shows overdue tasks and deterministic candidates
+  from Inbox/no-date work. The user selects tasks and assigns a planned day;
+  there is no opaque automatic prioritization.
+- Give Upcoming a collapsible week strip and expandable month calendar with
+  per-day counts, a Today shortcut, date selection, and list scroll
+  synchronization. Group future tasks by their next relevant planned date or
+  deadline and label which one is being shown.
+- Reuse the calendar and agenda derivation in Schedule, Today, Upcoming, saved
+  views, and widgets so counts and inclusion rules cannot drift.
+
+## Delivery strategy
+
+Ship this as a git-spice stack of reviewable changes, with each slice remaining
+usable on its own:
+
+1. Native foundation and the shared design layer.
+2. Navigation shell, native sheets/menus, and context-menu dependency cleanup.
+3. Task presentation and task-detail sheet.
+4. Quick-capture composer and reversible parser chips.
+5. Date semantics, Today planning, and Upcoming calendar.
+6. Persisted saved views, Browse information architecture, board/calendar
+   layouts, and completed history.
+7. Accessibility, performance, E2E expansion, and visual acceptance.
+
+Do not combine the full redesign into one feature branch. Each slice gets a
+simulator screenshot or short interaction recording when visual behavior
+changes, focused tests, and a draft PR before the next dependent slice begins.
+
+## Verification
+
+### Deterministic gates
+
+- Unit-test `TaskPresentation`, date precedence, recurring occurrences, relative
+  date copy, filter/group/sort behavior, saved-view parsing/migration, capture
+  seeds, and tap-to-unparse round trips.
+- Extend the sync harness for offline quick creation, detail edits, bulk
+  rescheduling, uncomplete, and board moves; assert the resulting Markdown/API
+  commands, not only rendered state.
+- Extend Maestro with create-from-each-context, Today planning, Upcoming date
+  selection, saved-view lifecycle, board move, completed/uncomplete, deep-link
+  routing, and an offline capture/relaunch scenario.
+- For every slice run focused `typecheck`, `test`, and `lint` through Turbo. Run
+  `test:contract`, `check:release-bundle`, `check:ios-native-deps`, an iOS
+  simulator build, and the full Maestro suite before the final slice is marked
+  ready. Buildkite remains the exhaustive repository gate; Xcode Cloud remains
+  the Archive/TestFlight gate.
+- Assert no duplicate task IDs in any grouped result and no TaskNotes fields are
+  lost after edit/create/complete/uncomplete round trips.
+
+### Human acceptance matrix
+
+Before completion, capture the same seeded vault on a current iPhone simulator
+in light and dark appearance and review:
+
+- system and accessibility Dynamic Type, Bold Text, Reduce Motion, Reduce
+  Transparency, and increased contrast;
+- VoiceOver order, labels, values, hints, adjustable controls, and menu actions;
+- long titles, long project/context names, empty sections, hundreds of tasks,
+  offline/pending/error states, recurring tasks, and tasks with both dates;
+- native navigation and sheet behavior on the newest iOS runtime plus one older
+  installed runtime compatible with the 15.1 deployment target;
+- capture-to-visible-row latency, list scroll smoothness, and no keyboard or tab
+  bar collisions.
+
+The final acceptance scenarios are: capture an Inbox task without leaving the
+keyboard; plan it for today; distinguish its planned date from its deadline;
+reschedule overdue work; build and use a saved board view; find and uncomplete a
+completed task; kill/relaunch offline and observe the same state; reconnect and
+verify the corresponding Markdown in the vault.
+
+## Non-goals
+
+- Team collaboration, assignees, comments, Karma, templates, and Todoist account
+  compatibility.
+- New TaskNotes file fields solely to imitate Todoist.
+- Subtasks, sections, attachments, location, or reminder UX until their upstream
+  TaskNotes format and round-trip behavior are explicitly designed.
+- A React Navigation 8 alpha upgrade as a prerequisite for visual quality.
+- An AI assistant, automatic prioritizer, or model-dependent core capture flow.
+- Pixel parity across Android in this wave; shared logic and functional fallback
+  remain required.
+
+## Remaining
+
+### Phase 0 — Native feasibility and contracts
+
+- [ ] Record seeded before-state screenshots and performance/accessibility
+      baselines for Inbox, Today, Upcoming, Browse, Quick Add, and task detail.
+- [x] Spike native bottom tabs and record the adopt/reject result: reject the
+      experimental host for this wave after reproducible iOS 27 runtime crashes;
+      ship one stable tab navigator on every supported OS version.
+- [ ] Validate native stack form sheets against restoration, accessibility,
+      keyboard behavior, and an older runtime compatible with the deployment
+      target.
+- [x] Define and test `TaskPresentation`, agenda/date precedence, capture seed,
+      display configuration, and versioned saved-view schemas.
+- [ ] Define the semantic color, Dynamic Type, spacing, motion, and haptic tokens.
+
+### Phase 1 — Native shell
+
+- [x] Give the single stable tab shell real SF Symbol icons, per-tab titles,
+      contextual toolbar actions, native Quick Add/task-detail sheets, and the
+      existing deep-link contract.
+- [ ] Introduce per-tab native stacks and finish large-title behavior without
+      creating a second runtime navigation implementation.
+- [ ] Convert display/sort/filter and overflow actions to native sheets/menus.
+- [x] Replace Zeego's remaining task/project call sites, remove its patches and
+      dependency, and archive the RN 0.85 context-menu TODO.
+- [x] Add System/Light/Dark appearance and semantic platform colors.
+
+### Phase 2 — Tasks and details
+
+- [x] Ship the shared task-row presentation and section-header behavior across
+      every current task collection.
+- [x] Replace the read/edit detail screen with the task-detail sheet and direct,
+      offline-safe field editing.
+- [ ] Add configurable swipe actions and keep menu, swipe, and bulk semantics in
+      sync.
+
+### Phase 3 — Capture
+
+- [x] Ship the keyboard-first capture sheet, contextual seeds, structured
+      project selection, Create Another, and optimistic dismissal.
+- [ ] Add structured planned-date, deadline, and priority controls to the
+      capture action row; keep the deterministic text path available.
+- [x] Make parser chips editable and reversible, with complete autocomplete and
+      accessibility coverage.
+- [x] Route in-app, deep-link, Home Screen, Siri/Shortcuts, and widget capture
+      through the same seed and creation command.
+- [ ] Hold the explicit AI product checkpoint; proceed without AI unless the
+      user chooses a separately evaluated capture use case.
+
+### Phase 4 — Daily planning
+
+- [x] Correct Today and Upcoming inclusion/grouping around scheduled versus due,
+      recurrence, overdue state, and deduplication.
+- [x] Add explicit overdue bulk rescheduling through the shared scheduling
+      sheet.
+- [ ] Add the deterministic Plan My Day sheet.
+- [x] Add Upcoming's selectable week strip and recurrence-aware reusable
+      day-load indicators.
+- [ ] Make the week strip collapsible, then add the expandable month calendar
+      and list-scroll synchronization.
+
+### Phase 5 — Views and organization
+
+- [x] Persist and migrate editable saved views with query and sort choices.
+- [ ] Add the remaining per-view layout, grouping, density, visibility, and
+      date-range choices.
+- [x] Rebuild Browse around favorites, saved views, organizational dimensions,
+      completed history, reports, and settings.
+- [ ] Persist user-defined Browse section ordering.
+- [ ] Replace the hard-coded Job Search board with generic list, board, and
+      calendar collection renderers.
+- [x] Bind the transitional Job Search board to its editable saved-view query,
+      shared task presentation, and explicit safe move actions.
+- [x] Add saved-view lifecycle and completed search/uncomplete flows.
+- [ ] Add distinct completed-history filter controls.
+
+### Phase 6 — Acceptance and closeout
+
+- [ ] Complete the deterministic verification and human acceptance matrix,
+      including a real offline-to-Markdown round trip.
+- [ ] Attach the lightest visual evidence to each UI PR and a short end-to-end
+      recording for each final acceptance scenario.
+- [ ] Update the feature comparison guide to the shipped state, move this plan
+      to `../archive/completed/`, and leave any deliberately deferred product
+      decision as a focused TODO rather than an open-ended backlog.
+
+## Comment Log
+
+- 2026-08-07: Plan derived from the current simulator build and the Todoist iOS
+  reference walkthrough. Core UX is deterministic and local-first; AI is an
+  explicit post-capture decision rather than a prerequisite.
+- 2026-08-07: Implementation started with one integration owner and three
+  file-disjoint lanes: native navigation feasibility, task-presentation
+  contracts, and saved-view persistence. Date/agenda contracts, baseline
+  evidence, and integration remain with the root lane.
+- 2026-08-07: Reject the experimental React Navigation native bottom-tab host
+  for this wave after reproducing iOS 27 AnimationKit/UISheet crashes during
+  ordinary task mutations. The production path now uses one stable tab
+  navigator on every OS, retains native SF Symbols on iOS, and keeps the
+  contextual floating capture action. Native stack sheets remain in the root
+  stack; older-runtime acceptance is still open because this machine currently
+  has only the iOS 27 runtime.
+- 2026-08-07: The shared agenda, task-presentation, and saved-view
+  schema/migration contracts are integrated with 37 focused tests. Today now
+  uses Overdue, Today, and Due Today precedence; Upcoming groups each task once
+  by its next planned date, deadline, or recurring occurrence.
+- 2026-08-07: A second three-lane wave started for keyboard-first capture,
+  direct task-detail editing, and persisted Browse/saved-view UI while the root
+  lane integrates and verifies the shared collection surfaces.
+- 2026-08-07: The first integrated product wave now includes a single polished
+  iOS tab shell, semantic appearance, shared task rows, direct task detail,
+  contextual quick capture, recurrence-aware Today/Upcoming, persisted saved
+  views, the Browse hub, and searchable completed history. Generic board/month
+  calendar, configurable swipes, Plan My Day, richer view presentation,
+  older-runtime acceptance, and the explicit AI checkpoint remain open and are
+  not implied by the completed items above.
+- 2026-08-07: Recurring completion Undo now captures and restores scheduled,
+  deadline, recurrence, completion, and skipped-instance state through one
+  idempotent server mutation. The app, shared contract, and server suites cover
+  offline replay and date-only behavior in positive and negative UTC offsets.
+  Completed history currently represents completed task parents; a distinct
+  per-occurrence recurring-history product remains deferred.
+- 2026-08-07: The ordered 11-flow Maestro run and its five selected Markdown
+  assertions pass on Xcode 27, iOS 27, and Maestro 2.8.0. Integration review
+  additionally closed deterministic recurrence advancement across time zones,
+  the acknowledged-command crash window, exact same-basename project identity,
+  recurrence-aware calendar counts, and Job Search move consistency.

--- a/packages/tasks-for-obsidian/AGENTS.md
+++ b/packages/tasks-for-obsidian/AGENTS.md
@@ -12,7 +12,7 @@ bun run ios --simulator="iPhone 16 Pro"  # Specific simulator
 bun run start                        # Start Metro bundler (separate terminal)
 bun run typecheck                    # Type check
 bunx eslint . --max-warnings=0       # Lint
-bun run test                         # Unit tests (src + scripts only)
+bun run test                         # Unit tests (src, scripts, and deterministic E2E date tests)
 bun run test:contract                # Wire-contract suite vs a real spawned tasknotes-server
 bun run e2e                          # Maestro e2e (simulator + real server + chaos proxy)
 ```

--- a/packages/tasks-for-obsidian/e2e/README.md
+++ b/packages/tasks-for-obsidian/e2e/README.md
@@ -15,7 +15,9 @@ PRs** — run it locally before merging changes to `packages/tasks-for-obsidian`
 
 ```bash
 bun run e2e                 # full run: build + install + test
-E2E_SKIP_BUILD=1 bun run e2e  # skip `bun run ios` if the app is already installed
+E2E_SKIP_BUILD=1 bun run e2e  # reuse the existing xcodebuild product
+E2E_SKIP_BUILD=1 E2E_FLOW=03-recurring-complete.yaml bun run e2e
+                            # focused UI flow; skips suite-wide vault assertions
 ```
 
 The orchestrator (`e2e/run.ts`):
@@ -25,33 +27,41 @@ The orchestrator (`e2e/run.ts`):
    for `/api/health`
 3. Spawns the chaos proxy (`e2e/chaos-proxy.ts`) on `127.0.0.1:18902 → 18901`
 4. Ensures a booted iPhone simulator (boots the newest available if needed)
-5. Ensures Metro is running, then `bun run ios --simulator "<name>"`
-   (skipped with `E2E_SKIP_BUILD=1`)
-6. Runs `maestro test e2e/maestro` with `APP_URL` (the proxy) and `AUTH_TOKEN`
-7. Asserts the vault markdown files reflect the flows (created / completed /
-   recurring-instance) and prints PASS/FAIL per assertion
-8. Tears everything down and removes the temp vault (always)
+5. Starts Metro, builds the Debug app with `xcodebuild`, installs one clean app
+   data container, and waits until Metro can serve the JS bundle
+   (`xcodebuild` is skipped with `E2E_SKIP_BUILD=1`)
+6. Runs each configured Maestro flow in its own process with `APP_URL` (the
+   proxy) and `AUTH_TOKEN`, terminating and relaunching the app between flows
+   while preserving app data and the shared vault
+7. Asserts selected durable mutations from create, complete, recurring, and
+   swipe scenarios in the vault Markdown and prints PASS/FAIL per assertion
+8. Tears down child processes; removes the temp vault after a pass and preserves
+   it with a printed path after a failure for post-mortem inspection
 
 ## How the flows are structured
 
-Every flow starts with `runFlow: 00-setup.yaml`, which launches the app with
-cleared state and configures it via the `__DEV__`-only deep link
-`tasknotes://e2e-config?apiUrl=…&token=…` (handled by
-`src/navigation/E2EConfigHandler.tsx`; a no-op in production builds). Flows
-run in filename order and share the same server/vault, so later flows must not
-depend on state that earlier flows mutate (the stable sentinel task is
-"Water plants", which is never renamed or closed).
+Every scenario flow starts with `runFlow: 00-setup.yaml`, which configures the
+already-running app via the `__DEV__`-only deep link
+`tasknotes://e2e-config?apiUrl=…&token=…&nonce=…` (handled by
+`src/navigation/E2EConfigHandler.tsx`; a no-op in production builds). The nonce
+is a transaction boundary: a flow proceeds only after its exact settings write,
+refresh, and Today navigation complete. Flows run in configured order and share
+the same app data and server vault, so later scenarios intentionally observe
+earlier mutations. "Water plants" remains the stable sync sentinel.
 
-| Flow                           | Scenario                                                    |
-| ------------------------------ | ----------------------------------------------------------- |
-| `00-setup.yaml`                | launch + e2e-config deep link + first sync                  |
-| `01-create-task.yaml`          | FAB → Quick Add → task visible                              |
-| `02-complete-task.yaml`        | complete the seeded open task (via detail toggle)           |
-| `03-recurring-complete.yaml`   | complete today's instance of the recurring task             |
-| `04-edit-task.yaml`            | rename "Task with details" via the edit form                |
-| `05-offline-queue.yaml`        | chaos-proxy offline → create → optimistic → online → replay |
-| `06-offline-crash-replay.yaml` | like 05 but with a kill/relaunch before going back online   |
-| `07-swipe-actions.yaml`        | left-swipe completion + right-swipe deletion                |
+| Flow                                  | Scenario                                                    |
+| ------------------------------------- | ----------------------------------------------------------- |
+| `00-setup.yaml`                       | launch + e2e-config deep link + first sync                  |
+| `01-create-task.yaml`                 | Quick Add → task visible                                    |
+| `02-complete-task.yaml`               | complete the seeded open task from its row checkbox         |
+| `03-recurring-complete.yaml`          | complete an occurrence and advance the recurring task       |
+| `04-edit-task.yaml`                   | rename "Task with details" in the direct editor             |
+| `05-offline-queue.yaml`               | chaos-proxy offline → create → optimistic → online → replay |
+| `06-offline-crash-replay.yaml`        | like 05 but with a kill/relaunch before going back online   |
+| `07-swipe-actions.yaml`               | right-swipe completion + left-swipe deletion                |
+| `08-contextual-quick-capture.yaml`    | Today seed + Save & Add Another capture                     |
+| `09-saved-view-lifecycle.yaml`        | create + rename + delete a device-local saved view          |
+| `10-completed-search-uncomplete.yaml` | search Completed + return a task to Today                   |
 
 The chaos proxy is toggled from flows via `runScript` (GraalJS `http.post`)
 against `/__chaos/offline` and `/__chaos/online` on the proxy port itself;
@@ -59,25 +69,19 @@ control endpoints keep working while "offline".
 
 ## Current status
 
-The harness is **functional end-to-end**: it builds the app, boots the
-simulator, delivers config via the deep link, syncs the seeded vault, and
-drives real UI. The complete ordered suite (`00`–`07`) and its final vault
-assertions pass on Xcode 27, the iOS 27 simulator, and Maestro 2.8.0.
-
-One known limitation:
-
-- **Timing flakiness** — mobile e2e is inherently timing-sensitive; the
-  first cold sync and the on-screen keyboard occasionally race an assertion.
-  When a flow flakes it is almost always at the `00-setup` sync sentinel or a
-  post-input button tap. Re-running usually passes.
+The harness is **functional end-to-end**. All 11 ordered flows and the final
+Markdown vault assertions pass on Xcode 27, the iOS 27 simulator, and Maestro
+2.8.0. The suite covers one clean install, per-flow process restarts, a true
+kill/relaunch, offline replay, gestures, contextual capture, saved views, and
+completed-task recovery.
 
 ## Notes
 
 - The app must be a **Debug** build: the e2e-config deep link only works when
   `__DEV__` is true, and Debug builds need Metro (the orchestrator starts it).
-- `00-setup` waits for the app's tab bar before firing the deep link: a
-  `clearState` relaunch is still booting, and an immediate `openLink` races
-  app startup so the JS `Linking` listener misses the `url` event.
+- `00-setup` waits for the root header before firing the deep link: an immediate
+  `openLink` can race app startup so the JS `Linking` listener misses the `url`
+  event.
 - Seed fixtures use fixed dates: "Water plants" is intentionally overdue so it
   always appears on the Today tab; "Seeded open task" is due in the future so
   it lives on the Inbox tab.

--- a/packages/tasks-for-obsidian/e2e/README.md
+++ b/packages/tasks-for-obsidian/e2e/README.md
@@ -85,5 +85,7 @@ completed-task recovery.
 - Seed fixtures use fixed dates: "Water plants" is intentionally overdue so it
   always appears on the Today tab; "Seeded open task" is due in the future so
   it lives on the Inbox tab.
-- These files are excluded from `bun test` (no `*.test.ts` here) and from the
-  app's `tsc` project; they are linted via ESLint's `allowDefaultProject`.
+- The device-backed flows in this directory are excluded from `bun test` and
+  from the app's `tsc` project; the deterministic
+  `e2e/simulator-date.test.ts` helper test is included in `bun run test`.
+  E2E files are linted via ESLint's `allowDefaultProject`.

--- a/packages/tasks-for-obsidian/e2e/fixtures/seed-vault/TaskNotes/seeded-open-task-1a2b3c4d.md
+++ b/packages/tasks-for-obsidian/e2e/fixtures/seed-vault/TaskNotes/seeded-open-task-1a2b3c4d.md
@@ -3,7 +3,7 @@ id: 1a2b3c4d
 title: Seeded open task
 status: open
 priority: normal
-due: "2026-07-10"
+due: "2099-07-10"
 tags:
   - seeded
   - task

--- a/packages/tasks-for-obsidian/e2e/fixtures/seed-vault/TaskNotes/swipe-delete-task-5e6f7a8b.md
+++ b/packages/tasks-for-obsidian/e2e/fixtures/seed-vault/TaskNotes/swipe-delete-task-5e6f7a8b.md
@@ -1,0 +1,11 @@
+---
+id: 5e6f7a8b
+title: Swipe delete task
+status: open
+priority: normal
+tags:
+  - seeded
+  - task
+dateCreated: "2026-07-01T09:00:00.000Z"
+dateModified: "2026-07-01T09:00:00.000Z"
+---

--- a/packages/tasks-for-obsidian/e2e/maestro/00-setup.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/00-setup.yaml
@@ -1,5 +1,7 @@
-# Shared setup: clean app state, point the app at the local test stack via the
+# Shared setup: point the running app at the local test stack via the
 # __DEV__-only e2e-config deep link, and wait for the seeded vault to sync in.
+# The orchestrator installs one clean data container and launches once before
+# the suite; nested setup calls retain it so flows do not tear down Metro.
 # Requires --env APP_URL and --env AUTH_TOKEN (provided by e2e/run.ts).
 appId: org.reactjs.native.example.TasksForObsidian
 ---
@@ -10,18 +12,16 @@ appId: org.reactjs.native.example.TasksForObsidian
     file: scripts/chaos-online.js
     env:
       CHAOS_BASE: ${APP_URL}
-- launchApp:
-    clearState: true
-# Wait for the app to finish booting (tab bar present) BEFORE openLink. A
-# clearState relaunch is still initializing when the flow continues; firing
-# openLink immediately races app startup and the JS Linking listener misses
+# Wait for the app to finish booting (root header present) BEFORE openLink. The
+# orchestrator's cold launch is still initializing when the first flow starts;
+# firing openLink immediately races app startup and the JS Linking listener misses
 # the url event (and it is not a launch URL, so getInitialURL is empty too) —
 # the deep link is silently dropped and config never applies.
 - extendedWaitUntil:
     visible:
-      id: "tab-inbox"
+      id: "header-search"
     timeout: 60000
-- openLink: "tasknotes://e2e-config?apiUrl=${APP_URL}&token=${AUTH_TOKEN}&tips=off"
+- openLink: "tasknotes://e2e-config?apiUrl=${APP_URL}&token=${AUTH_TOKEN}&tips=off&nonce=${MAESTRO_FILENAME}"
 # If SpringBoard shows an "Open in <app>?" confirmation for the custom scheme,
 # dismiss it. runFlow's `when` only taps if the button is actually present, so
 # the common direct-delivery path (app already frontmost) is unaffected.
@@ -32,6 +32,13 @@ appId: org.reactjs.native.example.TasksForObsidian
     commands:
       - tapOn:
           text: "Open"
+# A cached task can already be visible before AsyncStorage/keychain writes and
+# the final navigation complete. The flow-specific nonce prevents a previous
+# setup's UI from satisfying this transaction boundary.
+- extendedWaitUntil:
+    visible:
+      id: "e2e-config-ready-${MAESTRO_FILENAME}"
+    timeout: 15000
 # The config handler applies apiUrl+token and navigates to Today. Applying the
 # apiUrl rebuilds the API client, which triggers an automatic refreshTasks — so
 # the seeded vault syncs in without any manual pull. "Water plants" (recurring,
@@ -39,5 +46,7 @@ appId: org.reactjs.native.example.TasksForObsidian
 # and sync succeeded. Generous timeout because it's the first cold sync.
 - extendedWaitUntil:
     visible:
-      text: ".*Water plants.*"
+      id: "task-row-TaskNotes/water-plants-4d5e6f7a.md"
     timeout: 45000
+- waitForAnimationToEnd:
+    timeout: 5000

--- a/packages/tasks-for-obsidian/e2e/maestro/00-setup.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/00-setup.yaml
@@ -2,7 +2,9 @@
 # __DEV__-only e2e-config deep link, and wait for the seeded vault to sync in.
 # The orchestrator installs one clean data container and launches once before
 # the suite; nested setup calls retain it so flows do not tear down Metro.
-# Requires --env APP_URL and --env AUTH_TOKEN (provided by e2e/run.ts).
+# Requires --env APP_URL, --env AUTH_TOKEN, and --env E2E_TODAY (provided by
+# e2e/run.ts). E2E_TODAY freezes date parsing for the whole flow so a
+# midnight boundary cannot make the UI and vault assertion disagree.
 appId: org.reactjs.native.example.TasksForObsidian
 ---
 # Self-healing: force the chaos proxy back online before every flow. If an
@@ -21,7 +23,7 @@ appId: org.reactjs.native.example.TasksForObsidian
     visible:
       id: "header-search"
     timeout: 60000
-- openLink: "tasknotes://e2e-config?apiUrl=${APP_URL}&token=${AUTH_TOKEN}&tips=off&nonce=${MAESTRO_FILENAME}"
+- openLink: "tasknotes://e2e-config?apiUrl=${APP_URL}&token=${AUTH_TOKEN}&today=${E2E_TODAY}&tips=off&nonce=${MAESTRO_FILENAME}"
 # If SpringBoard shows an "Open in <app>?" confirmation for the custom scheme,
 # dismiss it. runFlow's `when` only taps if the button is actually present, so
 # the common direct-delivery path (app already frontmost) is unaffected.

--- a/packages/tasks-for-obsidian/e2e/maestro/01-create-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/01-create-task.yaml
@@ -1,4 +1,4 @@
-# Create a task through the FAB + Quick Add flow and see it in the Today list.
+# Create a task through the contextual quick-capture FAB and see it in Today.
 appId: org.reactjs.native.example.TasksForObsidian
 ---
 - runFlow: 00-setup.yaml

--- a/packages/tasks-for-obsidian/e2e/maestro/02-complete-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/02-complete-task.yaml
@@ -1,8 +1,5 @@
-# Complete the seeded open task and assert it reads as completed.
+# Complete the seeded open task and assert the active Inbox removes it.
 # The task is due in the future, so it lives on the Inbox tab (no project).
-# Completion is toggled from the detail screen: the inline checkbox is nested
-# inside the row's accessible Pressable, which iOS collapses into a single
-# accessibility element, making the checkbox untappable for XCUITest/Maestro.
 appId: org.reactjs.native.example.TasksForObsidian
 ---
 - runFlow: 00-setup.yaml
@@ -10,18 +7,11 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "tab-inbox"
 - extendedWaitUntil:
     visible:
-      text: ".*Seeded open task.*"
+      id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
     timeout: 15000
 - tapOn:
-    text: ".*Seeded open task.*"
+    id: "task-checkbox-TaskNotes/seeded-open-task-1a2b3c4d.md"
 - extendedWaitUntil:
-    visible:
-      id: "task-detail-toggle"
-    timeout: 10000
-- tapOn:
-    id: "task-detail-toggle"
-# The Status meta row flips to "Done" — the visual completion signal.
-- extendedWaitUntil:
-    visible:
-      text: "Done"
+    notVisible:
+      id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
     timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/03-recurring-complete.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/03-recurring-complete.yaml
@@ -5,19 +5,41 @@
 appId: org.reactjs.native.example.TasksForObsidian
 ---
 - runFlow: 00-setup.yaml
-- tapOn:
-    text: ".*Water plants.*"
-- extendedWaitUntil:
-    visible:
-      id: "task-detail-toggle"
-    timeout: 10000
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "task-row-TaskNotes/water-plants-4d5e6f7a.md"
+          retryTapIfNoChange: true
+      - extendedWaitUntil:
+          visible:
+            id: "task-detail-toggle"
+          timeout: 5000
 # Sanity: this really is the recurring task.
-- assertVisible: "FREQ=DAILY"
+- assertVisible:
+    id: "task-detail-recurrence-menu"
+# Do not use retryTapIfNoChange here: a recurring completion advances to the
+# next occurrence, so this control intentionally returns to its Open state.
+# The toast and durable vault assertion are the independent completion signal.
 - tapOn:
     id: "task-detail-toggle"
-# Recurring semantics: the task itself must stay Open (not flip to Done).
+# Recurring semantics: the represented occurrence is recorded as complete,
+# then the same task advances to its next open occurrence. The suite's vault
+# assertion verifies the completed instance persisted; the toast proves this
+# tap completed rather than merely observing the already-open next instance.
 - extendedWaitUntil:
     visible:
-      text: "Open"
+      id: "undo-toast-message"
+      text: "Completed.*"
     timeout: 10000
-- assertVisible: ".*Water plants.*"
+- assertVisible:
+    id: "task-detail-toggle"
+    text: "Open"
+- assertVisible:
+    id: "task-detail-title-input"
+- tapOn:
+    id: "task-detail-cancel"
+- extendedWaitUntil:
+    visible:
+      text: "^Today$"
+    timeout: 10000

--- a/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
@@ -1,4 +1,4 @@
-# Edit the seeded "Task with details": rename it via the detail edit form.
+# Edit the seeded "Task with details": rename it directly in task detail.
 appId: org.reactjs.native.example.TasksForObsidian
 ---
 - runFlow: 00-setup.yaml
@@ -6,32 +6,27 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "tab-inbox"
 - extendedWaitUntil:
     visible:
-      text: ".*Task with details.*"
+      id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
     timeout: 15000
-- tapOn:
-    text: ".*Task with details.*"
-- extendedWaitUntil:
-    visible:
-      id: "task-detail-edit"
-    timeout: 10000
-- tapOn:
-    id: "task-detail-edit"
-- extendedWaitUntil:
-    visible:
-      id: "task-detail-title-input"
-    timeout: 10000
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
+          retryTapIfNoChange: true
+      - extendedWaitUntil:
+          visible:
+            id: "task-detail-title-input"
+          timeout: 5000
 - tapOn:
     id: "task-detail-title-input"
 - eraseText: 50
 - inputText: "Edited by e2e"
-# Dismiss the keyboard first: with it up, the Save button is half-covered and
-# the tap lands on the keyboard. Tapping the PRIORITY section label is a
-# side-effect-free way to blur the input (labels aren't tappable controls).
-- tapOn:
-    text: "Priority"
+# Dismiss the keyboard before using the native editor's Save button.
+- hideKeyboard
 - tapOn:
     id: "task-detail-save"
 - extendedWaitUntil:
     visible:
-      text: "Edited by e2e"
+      id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
     timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
@@ -6,7 +6,7 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "tab-inbox"
 - extendedWaitUntil:
     visible:
-      id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
+      id: "task-row-TaskNotes/Edited by e2e.md"
     timeout: 15000
 - retry:
     maxRetries: 2

--- a/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
@@ -6,7 +6,7 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "tab-inbox"
 - extendedWaitUntil:
     visible:
-      id: "task-row-TaskNotes/Edited by e2e.md"
+      id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
     timeout: 15000
 - retry:
     maxRetries: 2
@@ -28,5 +28,5 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "task-detail-save"
 - extendedWaitUntil:
     visible:
-      id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
+      id: "task-row-TaskNotes/Edited by e2e.md"
     timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/06-offline-crash-replay.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/06-offline-crash-replay.yaml
@@ -34,9 +34,9 @@ appId: org.reactjs.native.example.TasksForObsidian
 # races app startup and the config deep link is dropped (see 00-setup).
 - extendedWaitUntil:
     visible:
-      id: "tab-inbox"
+      id: "header-search"
     timeout: 60000
-- openLink: "tasknotes://e2e-config?apiUrl=${APP_URL}&token=${AUTH_TOKEN}&tips=off"
+- openLink: "tasknotes://e2e-config?apiUrl=${APP_URL}&token=${AUTH_TOKEN}&tips=off&nonce=${MAESTRO_FILENAME}-relaunch"
 - runFlow:
     when:
       visible:
@@ -44,6 +44,10 @@ appId: org.reactjs.native.example.TasksForObsidian
     commands:
       - tapOn:
           text: "Open"
+- extendedWaitUntil:
+    visible:
+      id: "e2e-config-ready-${MAESTRO_FILENAME}-relaunch"
+    timeout: 15000
 - runScript:
     file: scripts/chaos-online.js
     env:

--- a/packages/tasks-for-obsidian/e2e/maestro/07-swipe-actions.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/07-swipe-actions.yaml
@@ -1,5 +1,5 @@
 # Exercise both task-row swipe actions after the Gesture Handler 3 upgrade.
-# A left swipe completes a task; a right swipe deletes a task.
+# A right swipe reveals Complete; a left swipe reveals Delete.
 appId: org.reactjs.native.example.TasksForObsidian
 ---
 - runFlow: 00-setup.yaml
@@ -16,15 +16,15 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "quick-add-submit"
 - extendedWaitUntil:
     visible:
-      text: ".*Swipe complete task.*"
+      id: "task-row-TaskNotes/Swipe complete task.md"
     timeout: 20000
 - swipe:
     from:
-      text: ".*Swipe complete task.*"
-    direction: LEFT
+      id: "task-row-TaskNotes/Swipe complete task.md"
+    direction: RIGHT
 - extendedWaitUntil:
     notVisible:
-      text: ".*Swipe complete task.*"
+      id: "task-row-TaskNotes/Swipe complete task.md"
     timeout: 15000
 - tapOn:
     id: "fab-add-task"
@@ -39,12 +39,12 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "quick-add-submit"
 - extendedWaitUntil:
     visible:
-      text: ".*Swipe delete task.*"
+      id: "task-row-TaskNotes/Swipe delete task.md"
     timeout: 20000
 - swipe:
     from:
-      text: ".*Swipe delete task.*"
-    direction: RIGHT
+      id: "task-row-TaskNotes/Swipe delete task.md"
+    direction: LEFT
 - extendedWaitUntil:
     visible:
       text: "Delete Task"
@@ -53,5 +53,5 @@ appId: org.reactjs.native.example.TasksForObsidian
     text: "Delete"
 - extendedWaitUntil:
     notVisible:
-      text: ".*Swipe delete task.*"
+      id: "task-row-TaskNotes/Swipe delete task.md"
     timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/07-swipe-actions.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/07-swipe-actions.yaml
@@ -27,23 +27,14 @@ appId: org.reactjs.native.example.TasksForObsidian
       id: "task-row-TaskNotes/Swipe complete task.md"
     timeout: 15000
 - tapOn:
-    id: "fab-add-task"
+    id: "tab-inbox"
 - extendedWaitUntil:
     visible:
-      id: "quick-add-input"
-    timeout: 10000
-- tapOn:
-    id: "quick-add-input"
-- inputText: "Swipe delete task today"
-- tapOn:
-    id: "quick-add-submit"
-- extendedWaitUntil:
-    visible:
-      id: "task-row-TaskNotes/Swipe delete task.md"
+      id: "task-row-TaskNotes/swipe-delete-task-5e6f7a8b.md"
     timeout: 20000
 - swipe:
     from:
-      id: "task-row-TaskNotes/Swipe delete task.md"
+      id: "task-row-TaskNotes/swipe-delete-task-5e6f7a8b.md"
     direction: LEFT
 - extendedWaitUntil:
     visible:
@@ -53,5 +44,5 @@ appId: org.reactjs.native.example.TasksForObsidian
     text: "Delete"
 - extendedWaitUntil:
     notVisible:
-      id: "task-row-TaskNotes/Swipe delete task.md"
+      id: "task-row-TaskNotes/swipe-delete-task-5e6f7a8b.md"
     timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/08-contextual-quick-capture.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/08-contextual-quick-capture.yaml
@@ -1,0 +1,48 @@
+# Today quick capture preserves its planned-for-today source default across
+# Save & Add Another, then creates both tasks in the Today agenda.
+appId: org.reactjs.native.example.TasksForObsidian
+---
+- runFlow: 00-setup.yaml
+- tapOn:
+    id: "fab-add-task"
+- extendedWaitUntil:
+    visible:
+      id: "quick-add-input"
+    timeout: 10000
+# This stable selector proves the Today entry point supplied a planned date
+# without coupling the flow to a calendar date.
+- assertVisible:
+    id: "quick-add-seed-scheduled"
+- tapOn:
+    id: "quick-add-input"
+- inputText: "Context capture alpha"
+- tapOn:
+    id: "quick-add-save-another"
+# Save & Add Another clears the title, re-enables capture, and retains source
+# defaults. Waiting for disabled Save avoids racing the async create.
+- extendedWaitUntil:
+    visible:
+      id: "quick-add-submit"
+      enabled: false
+    timeout: 20000
+- assertVisible:
+    id: "quick-add-seed-scheduled"
+- tapOn:
+    id: "quick-add-input"
+- inputText: "Context capture beta"
+- tapOn:
+    id: "quick-add-submit"
+- scrollUntilVisible:
+    element:
+      text: ".*Context capture alpha.*"
+    direction: DOWN
+    timeout: 20000
+    speed: 40
+    visibilityPercentage: 90
+- scrollUntilVisible:
+    element:
+      text: ".*Context capture beta.*"
+    direction: DOWN
+    timeout: 20000
+    speed: 40
+    visibilityPercentage: 90

--- a/packages/tasks-for-obsidian/e2e/maestro/08-contextual-quick-capture.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/08-contextual-quick-capture.yaml
@@ -19,11 +19,10 @@ appId: org.reactjs.native.example.TasksForObsidian
 - tapOn:
     id: "quick-add-save-another"
 # Save & Add Another clears the title, re-enables capture, and retains source
-# defaults. Waiting for disabled Save avoids racing the async create.
+# defaults. The ready marker appears only after the async create resets input.
 - extendedWaitUntil:
     visible:
-      id: "quick-add-submit"
-      enabled: false
+      id: "quick-add-ready"
     timeout: 20000
 - assertVisible:
     id: "quick-add-seed-scheduled"

--- a/packages/tasks-for-obsidian/e2e/maestro/09-saved-view-lifecycle.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/09-saved-view-lifecycle.yaml
@@ -1,0 +1,76 @@
+# Create, rename, and delete a device-local saved view through Browse.
+appId: org.reactjs.native.example.TasksForObsidian
+---
+- runFlow: 00-setup.yaml
+- tapOn:
+    id: "tab-browse"
+- scrollUntilVisible:
+    element:
+      id: "create-saved-view"
+    direction: DOWN
+    timeout: 15000
+    speed: 40
+    visibilityPercentage: 90
+- tapOn:
+    id: "create-saved-view"
+- extendedWaitUntil:
+    visible:
+      id: "saved-view-name"
+    timeout: 10000
+- tapOn:
+    id: "saved-view-name"
+- inputText: "Maestro saved view"
+- tapOn:
+    id: "saved-view-editor-save"
+- extendedWaitUntil:
+    visible:
+      id: "saved-view-maestro-saved-view"
+    timeout: 15000
+# Resolve the row before invoking its native menu so virtualized-section
+# position never becomes an implicit assumption.
+- scrollUntilVisible:
+    element:
+      id: "saved-view-menu-maestro-saved-view"
+    direction: UP
+    timeout: 15000
+    speed: 40
+    visibilityPercentage: 90
+- tapOn:
+    id: "saved-view-menu-maestro-saved-view"
+- tapOn:
+    text: "Edit View"
+- extendedWaitUntil:
+    visible:
+      id: "saved-view-name"
+    timeout: 10000
+- tapOn:
+    id: "saved-view-name"
+- eraseText: 100
+- inputText: "Maestro renamed view"
+- tapOn:
+    id: "saved-view-editor-save"
+- extendedWaitUntil:
+    visible:
+      id: "saved-view-maestro-saved-view"
+    timeout: 15000
+- scrollUntilVisible:
+    element:
+      id: "saved-view-menu-maestro-saved-view"
+    direction: UP
+    timeout: 15000
+    speed: 40
+    visibilityPercentage: 90
+- tapOn:
+    id: "saved-view-menu-maestro-saved-view"
+- tapOn:
+    text: "Delete View"
+- extendedWaitUntil:
+    visible:
+      text: "Delete “Maestro renamed view”?"
+    timeout: 10000
+- tapOn:
+    text: "Delete"
+- extendedWaitUntil:
+    notVisible:
+      id: "saved-view-maestro-saved-view"
+    timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/10-completed-search-uncomplete.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/10-completed-search-uncomplete.yaml
@@ -1,0 +1,52 @@
+# Find a seeded completed task, uncomplete it from the row's native menu, and
+# confirm it returns to the Today agenda.
+appId: org.reactjs.native.example.TasksForObsidian
+---
+- runFlow: 00-setup.yaml
+- tapOn:
+    id: "tab-browse"
+- scrollUntilVisible:
+    element:
+      id: "browse-completed"
+    direction: DOWN
+    timeout: 15000
+    speed: 40
+    visibilityPercentage: 90
+- tapOn:
+    id: "browse-completed"
+- extendedWaitUntil:
+    visible:
+      id: "completed-tasks-search"
+    timeout: 10000
+- tapOn:
+    id: "completed-tasks-search"
+- inputText: "Seeded done task"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/seeded-done-task-2b3c4d5e.md"
+    timeout: 10000
+# Scroll resolution is explicit before the row's native actions menu.
+- scrollUntilVisible:
+    element:
+      id: "task-row-menu-TaskNotes/seeded-done-task-2b3c4d5e.md"
+    direction: DOWN
+    timeout: 10000
+    speed: 40
+    visibilityPercentage: 90
+- tapOn:
+    id: "task-row-menu-TaskNotes/seeded-done-task-2b3c4d5e.md"
+- tapOn:
+    text: "Uncomplete"
+- extendedWaitUntil:
+    notVisible:
+      id: "task-row-TaskNotes/seeded-done-task-2b3c4d5e.md"
+    timeout: 15000
+- assertVisible: "No results"
+- tapOn:
+    id: "completed-tasks-close"
+- tapOn:
+    id: "tab-today"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/seeded-done-task-2b3c4d5e.md"
+    timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/config.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/config.yaml
@@ -5,7 +5,6 @@
 # 02 completes the seeded open task). Without flowsOrder, Maestro picks its
 # own order and any state-sensitive assertion becomes a coin flip.
 executionOrder:
-  continueOnFailure: true
   flowsOrder:
     - 00-setup
     - 01-create-task
@@ -15,3 +14,6 @@ executionOrder:
     - 05-offline-queue
     - 06-offline-crash-replay
     - 07-swipe-actions
+    - 08-contextual-quick-capture
+    - 09-saved-view-lifecycle
+    - 10-completed-search-uncomplete

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -91,10 +91,19 @@ const SimListSchema = z.object({
 });
 type SimDevice = z.infer<typeof SimDeviceSchema>;
 
-function runSimctl(args: string[]): string {
+function runSimctl(args: string[], allowAlreadyStopped = false): string {
   const proc = spawnSync("xcrun", ["simctl", ...args], { encoding: "utf8" });
   if (proc.status !== 0) {
-    fail(`xcrun simctl ${args.join(" ")} failed:\n${proc.stderr}`);
+    const stderr = proc.stderr.trim();
+    if (
+      allowAlreadyStopped &&
+      (stderr.includes("No such process") ||
+        /application .* is not running/i.test(stderr))
+    ) {
+      log(`${APP_ID} was already stopped`);
+      return "";
+    }
+    fail(`xcrun simctl ${args.join(" ")} failed:\n${stderr}`);
   }
   return proc.stdout;
 }
@@ -413,7 +422,7 @@ function launchApp(simulator: SimDevice): void {
 
 function restartApp(simulator: SimDevice, flow: string): void {
   log(`restarting ${APP_ID} before ${flow}`);
-  runSimctl(["terminate", simulator.udid, APP_ID]);
+  runSimctl(["terminate", simulator.udid, APP_ID], true);
   launchApp(simulator);
 }
 

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -7,27 +7,30 @@
  *   2. tasknotes-server on 127.0.0.1:18901 over that vault
  *   3. chaos proxy on 127.0.0.1:18902 -> 18901 (offline/online control)
  *   4. booted iPhone simulator (boots the newest available one if needed)
- *   5. Metro + `bun run ios` debug build (skippable with E2E_SKIP_BUILD=1)
- *   6. `maestro test e2e/maestro` pointing the app at the proxy
+ *   5. Metro + xcodebuild debug build (skippable with E2E_SKIP_BUILD=1)
+ *   6. each ordered Maestro flow in a fresh process, pointing at the proxy
  *   7. vault-state assertions against the real markdown files
- *   8. teardown (always): kill children, remove the temp vault
+ *   8. teardown: kill children; remove a passing vault, preserve a failed one
  *
  * (node:child_process rather than Bun.spawn so the file typechecks against
  * the repo-pinned @types/node — Bun implements node:child_process natively.)
  */
 
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { cp, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { access, cp, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
+
+import { assertVaultState } from "./vault-assertions";
 
 const SERVER_PORT = 18_901;
 const CHAOS_PORT = 18_902;
 const AUTH_TOKEN = "e2e-test-token";
 const TASKS_DIR = "TaskNotes";
 const METRO_PORT = 8081;
+const APP_ID = "org.reactjs.native.example.TasksForObsidian";
 
 const packageDir = fileURLToPath(new URL("..", import.meta.url));
 const serverDir = fileURLToPath(
@@ -94,6 +97,21 @@ function runSimctl(args: string[]): string {
     fail(`xcrun simctl ${args.join(" ")} failed:\n${proc.stderr}`);
   }
   return proc.stdout;
+}
+
+function isAppInstalled(simulator: SimDevice): boolean {
+  const proc = spawnSync(
+    "xcrun",
+    ["simctl", "get_app_container", simulator.udid, APP_ID, "data"],
+    { encoding: "utf8" },
+  );
+  if (proc.status === 0) return true;
+  if (proc.status === 2 && proc.stderr.includes("No such file or directory")) {
+    return false;
+  }
+  fail(
+    `could not determine whether ${APP_ID} is installed on ${simulator.name}:\n${proc.stderr}`,
+  );
 }
 
 function simctlList(filter: string): Map<string, SimDevice[]> {
@@ -350,6 +368,16 @@ async function buildAndInstallApp(simulator: SimDevice): Promise<void> {
     }
   }
 
+  // Start each suite with one clean data container. Clearing the app from every
+  // nested Maestro setup flow repeatedly tears down the React Native debug
+  // runtime; on newer simulators that can strand the app at "Downloading 100%"
+  // and turn a 60-second assertion into a many-minute XCTest timeout. The
+  // flows already intentionally share one server vault, so relaunching the same
+  // clean install between flows is the matching local-state model.
+  if (isAppInstalled(simulator)) {
+    log(`uninstalling existing ${APP_ID} data container`);
+    runSimctl(["uninstall", simulator.udid, APP_ID]);
+  }
   log(`installing ${appPath}`);
   runSimctl(["install", simulator.udid, appPath]);
 }
@@ -379,110 +407,86 @@ async function waitForJsBundle(): Promise<void> {
   log("Metro bundle ready");
 }
 
+function launchApp(simulator: SimDevice): void {
+  runSimctl(["launch", simulator.udid, APP_ID]);
+}
+
+function restartApp(simulator: SimDevice, flow: string): void {
+  log(`restarting ${APP_ID} before ${flow}`);
+  runSimctl(["terminate", simulator.udid, APP_ID]);
+  launchApp(simulator);
+}
+
 // ---------------------------------------------------------------------------
 // Maestro
 // ---------------------------------------------------------------------------
 
-async function runMaestro(simulator: SimDevice): Promise<void> {
+const MaestroConfigSchema = z.object({
+  executionOrder: z.object({
+    flowsOrder: z.array(z.string().regex(/^\d{2}-[a-z0-9-]+$/)).min(1),
+  }),
+});
+
+async function orderedFlowFiles(): Promise<readonly string[]> {
+  const configPath = path.join(packageDir, "e2e", "maestro", "config.yaml");
+  const source = await readFile(configPath, "utf8");
+  const config = MaestroConfigSchema.parse(Bun.YAML.parse(source));
+  return config.executionOrder.flowsOrder.map((flow) => `${flow}.yaml`);
+}
+
+async function runMaestro(
+  simulator: SimDevice,
+  focusedFlow: string | null,
+): Promise<void> {
   const which = spawnSync("which", ["maestro"], { encoding: "utf8" });
   if (which.status !== 0) {
     fail(
       "maestro CLI not found — install it: brew install mobile-dev-inc/tap/maestro",
     );
   }
-  // Pin the device: maestro aborts with "Multiple devices connected" if any
-  // other simulator (or a paired watch/host) is also up.
-  const proc = spawn(
-    "maestro",
-    [
-      "--device",
-      simulator.udid,
-      "test",
-      path.join("e2e", "maestro"),
-      "--env",
-      `APP_URL=http://127.0.0.1:${String(CHAOS_PORT)}`,
-      "--env",
-      `AUTH_TOKEN=${AUTH_TOKEN}`,
-    ],
-    { cwd: packageDir, stdio: "inherit" },
-  );
-  const exitCode = await waitForExit(proc);
-  if (exitCode !== 0) {
-    fail(`maestro test failed with exit code ${String(exitCode)}`);
+  const flows = focusedFlow === null ? await orderedFlowFiles() : [focusedFlow];
+  for (const [index, flow] of flows.entries()) {
+    if (index > 0) restartApp(simulator, flow);
+    const target = path.join(packageDir, "e2e", "maestro", flow);
+    try {
+      await access(target);
+    } catch {
+      fail(`requested Maestro flow does not exist: ${target}`);
+    }
+
+    log(`Maestro flow ${String(index + 1)}/${String(flows.length)}: ${flow}`);
+    // Pin the device: maestro aborts with "Multiple devices connected" if any
+    // other simulator (or a paired watch/host) is also up.
+    const proc = spawn(
+      "maestro",
+      [
+        "--device",
+        simulator.udid,
+        "test",
+        target,
+        "--env",
+        `APP_URL=http://127.0.0.1:${String(CHAOS_PORT)}`,
+        "--env",
+        `AUTH_TOKEN=${AUTH_TOKEN}`,
+      ],
+      { cwd: packageDir, stdio: "inherit" },
+    );
+    const exitCode = await waitForExit(proc);
+    if (exitCode !== 0) {
+      fail(`${flow} failed with exit code ${String(exitCode)}`);
+    }
   }
 }
 
-// ---------------------------------------------------------------------------
-// Vault-state assertions
-// ---------------------------------------------------------------------------
-
-type VaultAssertion = {
-  name: string;
-  check: (files: Map<string, string>) => boolean;
-};
-
-function fileWithTitle(
-  files: Map<string, string>,
-  title: string,
-): string | undefined {
-  for (const content of files.values()) {
-    if (content.includes(`title: ${title}`)) return content;
+function requestedFlow(): string | null {
+  const value = process.env["E2E_FLOW"];
+  if (value === undefined || value === "") return null;
+  if (!/^\d{2}-[a-z0-9-]+\.yaml$/.test(value)) {
+    fail(
+      "E2E_FLOW must be a Maestro filename such as 03-recurring-complete.yaml",
+    );
   }
-  return undefined;
-}
-
-const VAULT_ASSERTIONS: VaultAssertion[] = [
-  {
-    name: 'a task file containing "Created by e2e" exists (01-create-task)',
-    check: (files) => fileWithTitle(files, "Created by e2e") !== undefined,
-  },
-  {
-    name: '"Seeded open task" has status done (02-complete-task)',
-    check: (files) =>
-      fileWithTitle(files, "Seeded open task")?.includes("status: done") ===
-      true,
-  },
-  {
-    name: '"Water plants" has a complete_instances entry (03-recurring-complete)',
-    check: (files) => {
-      const content = fileWithTitle(files, "Water plants");
-      if (content === undefined) return false;
-      // Server writes block-style YAML: "complete_instances:\n  - '2026-…'"
-      return /complete_instances:\n\s+- /.test(content);
-    },
-  },
-  {
-    name: '"Swipe complete task" has status done (07-swipe-actions)',
-    check: (files) =>
-      fileWithTitle(files, "Swipe complete task")?.includes("status: done") ===
-      true,
-  },
-  {
-    name: '"Swipe delete task" is absent (07-swipe-actions)',
-    check: (files) => fileWithTitle(files, "Swipe delete task") === undefined,
-  },
-];
-
-async function assertVaultState(vaultDir: string): Promise<void> {
-  const tasksDir = path.join(vaultDir, TASKS_DIR);
-  const files = new Map<string, string>();
-  for (const entry of await readdir(tasksDir)) {
-    if (!entry.endsWith(".md")) continue;
-    files.set(entry, await readFile(path.join(tasksDir, entry), "utf8"));
-  }
-  log(
-    `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
-  );
-
-  let failures = 0;
-  for (const assertion of VAULT_ASSERTIONS) {
-    const passed = assertion.check(files);
-    console.log(`[e2e] ${passed ? "PASS" : "FAIL"} — ${assertion.name}`);
-    if (!passed) failures += 1;
-  }
-  if (failures > 0) {
-    fail(`${String(failures)} vault assertion(s) failed`);
-  }
+  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -503,6 +507,7 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
 async function main(): Promise<void> {
   let vaultDir: string | null = null;
   let passed = false;
+  const focusedFlow = requestedFlow();
   try {
     // (1) temp vault seeded with fixtures
     vaultDir = await mkdtemp(path.join(tmpdir(), "tasknotes-e2e-"));
@@ -521,12 +526,18 @@ async function main(): Promise<void> {
     if (metro !== null) children.push(metro);
     await buildAndInstallApp(simulator);
     await waitForJsBundle();
+    log(`launching ${APP_ID} for the first flow`);
+    launchApp(simulator);
 
     // (6) Maestro flows
-    await runMaestro(simulator);
+    await runMaestro(simulator, focusedFlow);
 
     // (7) vault-state assertions
-    await assertVaultState(vaultDir);
+    if (focusedFlow === null) {
+      await assertVaultState(vaultDir, log);
+    } else {
+      log(`focused flow passed: ${focusedFlow}`);
+    }
 
     log("e2e suite passed");
     passed = true;

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -541,12 +541,10 @@ async function main(): Promise<void> {
     // (6) Maestro flows
     await runMaestro(simulator, focusedFlow);
 
-    // (7) vault-state assertions
-    if (focusedFlow === null) {
-      await assertVaultState(vaultDir, log);
-    } else {
-      log(`focused flow passed: ${focusedFlow}`);
-    }
+    // (7) vault-state assertions. Focused runs still verify the selected
+    // flow's authoritative Markdown mutation, rather than relying only on
+    // optimistic UI state.
+    await assertVaultState(vaultDir, log, focusedFlow);
 
     log("e2e suite passed");
     passed = true;

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -23,7 +23,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
 
-import { parseSimulatorToday } from "./simulator-date";
+import { captureFlowToday } from "./simulator-date";
 import { assertVaultState } from "./vault-assertions";
 
 const SERVER_PORT = 18_901;
@@ -464,12 +464,13 @@ async function runMaestro(
     } catch {
       fail(`requested Maestro flow does not exist: ${target}`);
     }
-    if (
-      flow === "01-create-task.yaml" ||
-      flow === "08-contextual-quick-capture.yaml"
-    ) {
-      const today = runSimctl(["spawn", simulator.udid, "date", "+%Y-%m-%d"]);
-      todayByFlow.set(flow, parseSimulatorToday(today));
+    // Freeze dated flows at their boundary so UI and vault assertions cannot
+    // cross midnight while the simulator exercises one scenario.
+    const today = captureFlowToday(flow, () =>
+      runSimctl(["spawn", simulator.udid, "date", "+%Y-%m-%d"]),
+    );
+    if (today !== "") {
+      todayByFlow.set(flow, today);
     }
 
     log(`Maestro flow ${String(index + 1)}/${String(flows.length)}: ${flow}`);
@@ -486,6 +487,8 @@ async function runMaestro(
         `APP_URL=http://127.0.0.1:${String(CHAOS_PORT)}`,
         "--env",
         `AUTH_TOKEN=${AUTH_TOKEN}`,
+        "--env",
+        `E2E_TODAY=${today}`,
       ],
       { cwd: packageDir, stdio: "inherit" },
     );

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -23,6 +23,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { z } from "zod";
 
+import { parseSimulatorToday } from "./simulator-date";
 import { assertVaultState } from "./vault-assertions";
 
 const SERVER_PORT = 18_901;
@@ -446,7 +447,7 @@ async function orderedFlowFiles(): Promise<readonly string[]> {
 async function runMaestro(
   simulator: SimDevice,
   focusedFlow: string | null,
-): Promise<void> {
+): Promise<ReadonlyMap<string, string>> {
   const which = spawnSync("which", ["maestro"], { encoding: "utf8" });
   if (which.status !== 0) {
     fail(
@@ -454,6 +455,7 @@ async function runMaestro(
     );
   }
   const flows = focusedFlow === null ? await orderedFlowFiles() : [focusedFlow];
+  const todayByFlow = new Map<string, string>();
   for (const [index, flow] of flows.entries()) {
     if (index > 0) restartApp(simulator, flow);
     const target = path.join(packageDir, "e2e", "maestro", flow);
@@ -461,6 +463,13 @@ async function runMaestro(
       await access(target);
     } catch {
       fail(`requested Maestro flow does not exist: ${target}`);
+    }
+    if (
+      flow === "01-create-task.yaml" ||
+      flow === "08-contextual-quick-capture.yaml"
+    ) {
+      const today = runSimctl(["spawn", simulator.udid, "date", "+%Y-%m-%d"]);
+      todayByFlow.set(flow, parseSimulatorToday(today));
     }
 
     log(`Maestro flow ${String(index + 1)}/${String(flows.length)}: ${flow}`);
@@ -485,6 +494,7 @@ async function runMaestro(
       fail(`${flow} failed with exit code ${String(exitCode)}`);
     }
   }
+  return todayByFlow;
 }
 
 function requestedFlow(): string | null {
@@ -539,21 +549,12 @@ async function main(): Promise<void> {
     launchApp(simulator);
 
     // (6) Maestro flows
-    await runMaestro(simulator, focusedFlow);
+    const todayByFlow = await runMaestro(simulator, focusedFlow);
 
     // (7) vault-state assertions. Focused runs still verify the selected
     // flow's authoritative Markdown mutation, rather than relying only on
     // optimistic UI state.
-    const simulatorToday = runSimctl([
-      "spawn",
-      simulator.udid,
-      "date",
-      "+%Y-%m-%d",
-    ]).trim();
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(simulatorToday)) {
-      fail(`simulator returned an invalid date: ${simulatorToday}`);
-    }
-    await assertVaultState(vaultDir, log, focusedFlow, simulatorToday);
+    await assertVaultState(vaultDir, log, focusedFlow, todayByFlow);
 
     log("e2e suite passed");
     passed = true;

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -544,7 +544,16 @@ async function main(): Promise<void> {
     // (7) vault-state assertions. Focused runs still verify the selected
     // flow's authoritative Markdown mutation, rather than relying only on
     // optimistic UI state.
-    await assertVaultState(vaultDir, log, focusedFlow);
+    const simulatorToday = runSimctl([
+      "spawn",
+      simulator.udid,
+      "date",
+      "+%Y-%m-%d",
+    ]).trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(simulatorToday)) {
+      fail(`simulator returned an invalid date: ${simulatorToday}`);
+    }
+    await assertVaultState(vaultDir, log, focusedFlow, simulatorToday);
 
     log("e2e suite passed");
     passed = true;

--- a/packages/tasks-for-obsidian/e2e/simulator-date.test.ts
+++ b/packages/tasks-for-obsidian/e2e/simulator-date.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { parseSimulatorToday } from "./simulator-date";
+import { captureFlowToday, parseSimulatorToday } from "./simulator-date";
+
+const readToday = (): string => "2026-08-08\n";
 
 describe("parseSimulatorToday", () => {
   test("accepts a simulator-local calendar date", () => {
@@ -10,5 +12,17 @@ describe("parseSimulatorToday", () => {
     expect(() => parseSimulatorToday("Sat Aug 8")).toThrow(
       "simulator returned an invalid date",
     );
+  });
+});
+
+describe("captureFlowToday", () => {
+  test("captures only the dated flows at their boundary", () => {
+    expect(captureFlowToday("01-create-task.yaml", readToday)).toBe(
+      "2026-08-08",
+    );
+    expect(
+      captureFlowToday("08-contextual-quick-capture.yaml", readToday),
+    ).toBe("2026-08-08");
+    expect(captureFlowToday("03-recurring-complete.yaml", readToday)).toBe("");
   });
 });

--- a/packages/tasks-for-obsidian/e2e/simulator-date.test.ts
+++ b/packages/tasks-for-obsidian/e2e/simulator-date.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { parseSimulatorToday } from "./simulator-date";
+
+describe("parseSimulatorToday", () => {
+  test("accepts a simulator-local calendar date", () => {
+    expect(parseSimulatorToday("2026-08-08\n")).toBe("2026-08-08");
+  });
+
+  test("rejects malformed simulator output", () => {
+    expect(() => parseSimulatorToday("Sat Aug 8")).toThrow(
+      "simulator returned an invalid date",
+    );
+  });
+});

--- a/packages/tasks-for-obsidian/e2e/simulator-date.ts
+++ b/packages/tasks-for-obsidian/e2e/simulator-date.ts
@@ -5,3 +5,16 @@ export function parseSimulatorToday(output: string): string {
   }
   return today;
 }
+
+export function captureFlowToday(
+  flow: string,
+  readToday: () => string,
+): string {
+  if (
+    flow !== "01-create-task.yaml" &&
+    flow !== "08-contextual-quick-capture.yaml"
+  ) {
+    return "";
+  }
+  return parseSimulatorToday(readToday());
+}

--- a/packages/tasks-for-obsidian/e2e/simulator-date.ts
+++ b/packages/tasks-for-obsidian/e2e/simulator-date.ts
@@ -1,0 +1,7 @@
+export function parseSimulatorToday(output: string): string {
+  const today = output.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(today)) {
+    throw new Error(`simulator returned an invalid date: ${today}`);
+  }
+  return today;
+}

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -1,0 +1,78 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const TASKS_DIR = "TaskNotes";
+
+type VaultAssertion = {
+  readonly name: string;
+  readonly check: (files: Map<string, string>) => boolean;
+};
+
+function fileWithTitle(
+  files: Map<string, string>,
+  title: string,
+): string | undefined {
+  for (const content of files.values()) {
+    if (content.includes(`title: ${title}`)) return content;
+  }
+  return undefined;
+}
+
+const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
+  {
+    name: 'a task file containing "Created by e2e" exists (01-create-task)',
+    check: (files) => fileWithTitle(files, "Created by e2e") !== undefined,
+  },
+  {
+    name: '"Seeded open task" has status done (02-complete-task)',
+    check: (files) =>
+      fileWithTitle(files, "Seeded open task")?.includes("status: done") ===
+      true,
+  },
+  {
+    name: '"Water plants" stays open and gains a complete_instances entry (03-recurring-complete)',
+    check: (files) => {
+      const content = fileWithTitle(files, "Water plants");
+      if (content === undefined) return false;
+      return (
+        content.includes("status: open") &&
+        /complete_instances:\n\s+- /.test(content)
+      );
+    },
+  },
+  {
+    name: '"Swipe complete task" has status done (07-swipe-actions)',
+    check: (files) =>
+      fileWithTitle(files, "Swipe complete task")?.includes("status: done") ===
+      true,
+  },
+  {
+    name: '"Swipe delete task" is absent (07-swipe-actions)',
+    check: (files) => fileWithTitle(files, "Swipe delete task") === undefined,
+  },
+];
+
+export async function assertVaultState(
+  vaultDir: string,
+  log: (message: string) => void,
+): Promise<void> {
+  const tasksDir = path.join(vaultDir, TASKS_DIR);
+  const files = new Map<string, string>();
+  for (const entry of await readdir(tasksDir)) {
+    if (!entry.endsWith(".md")) continue;
+    files.set(entry, await readFile(path.join(tasksDir, entry), "utf8"));
+  }
+  log(
+    `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
+  );
+
+  let failures = 0;
+  for (const assertion of VAULT_ASSERTIONS) {
+    const passed = assertion.check(files);
+    console.log(`[e2e] ${passed ? "PASS" : "FAIL"} — ${assertion.name}`);
+    if (!passed) failures += 1;
+  }
+  if (failures > 0) {
+    throw new Error(`${String(failures)} vault assertion(s) failed`);
+  }
+}

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -30,6 +30,10 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
       true,
   },
   {
+    name: 'a task file containing "Edited by e2e" exists (04-edit-task)',
+    check: (files) => fileWithTitle(files, "Edited by e2e") !== undefined,
+  },
+  {
     name: '"Seeded done task" has status open (10-completed-search-uncomplete)',
     check: (files) =>
       fileWithTitle(files, "Seeded done task")?.includes("status: open") ===

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -36,6 +36,20 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
       true,
   },
   {
+    name: '"Context capture alpha" is persisted with a scheduled date (08-contextual-quick-capture)',
+    check: (files) => {
+      const content = fileWithTitle(files, "Context capture alpha");
+      return content !== undefined && /^scheduled:/m.test(content);
+    },
+  },
+  {
+    name: '"Context capture beta" is persisted with a scheduled date (08-contextual-quick-capture)',
+    check: (files) => {
+      const content = fileWithTitle(files, "Context capture beta");
+      return content !== undefined && /^scheduled:/m.test(content);
+    },
+  },
+  {
     name: '"Water plants" stays open and gains a complete_instances entry (03-recurring-complete)',
     check: (files) => {
       const content = fileWithTitle(files, "Water plants");

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -30,6 +30,12 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
       true,
   },
   {
+    name: '"Seeded done task" has status open (10-completed-search-uncomplete)',
+    check: (files) =>
+      fileWithTitle(files, "Seeded done task")?.includes("status: open") ===
+      true,
+  },
+  {
     name: '"Water plants" stays open and gains a complete_instances entry (03-recurring-complete)',
     check: (files) => {
       const content = fileWithTitle(files, "Water plants");

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -110,7 +110,9 @@ export async function assertVaultState(
       ? VAULT_ASSERTIONS
       : VAULT_ASSERTIONS.filter((assertion) => assertion.flow === focusedFlow);
   if (assertions.length === 0) {
-    throw new Error(`no vault assertions registered for ${focusedFlow}`);
+    throw new Error(
+      `no vault assertions registered for ${String(focusedFlow)}`,
+    );
   }
   for (const assertion of assertions) {
     const passed = assertion.check(files);

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -5,6 +5,7 @@ const TASKS_DIR = "TaskNotes";
 
 type VaultAssertion = {
   readonly name: string;
+  readonly flow: string;
   readonly check: (files: Map<string, string>) => boolean;
 };
 
@@ -21,26 +22,34 @@ function fileWithTitle(
 const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   {
     name: 'a task file containing "Created by e2e" exists (01-create-task)',
+    flow: "01-create-task.yaml",
     check: (files) => fileWithTitle(files, "Created by e2e") !== undefined,
   },
   {
     name: '"Seeded open task" has status done (02-complete-task)',
+    flow: "02-complete-task.yaml",
     check: (files) =>
       fileWithTitle(files, "Seeded open task")?.includes("status: done") ===
       true,
   },
   {
-    name: 'a task file containing "Edited by e2e" exists (04-edit-task)',
-    check: (files) => fileWithTitle(files, "Edited by e2e") !== undefined,
+    name: 'the seeded task file is renamed to "Edited by e2e" (04-edit-task)',
+    flow: "04-edit-task.yaml",
+    check: (files) =>
+      files
+        .get("task-with-details-3c4d5e6f.md")
+        ?.includes("title: Edited by e2e") === true,
   },
   {
     name: '"Seeded done task" has status open (10-completed-search-uncomplete)',
+    flow: "10-completed-search-uncomplete.yaml",
     check: (files) =>
       fileWithTitle(files, "Seeded done task")?.includes("status: open") ===
       true,
   },
   {
     name: '"Context capture alpha" is persisted with a scheduled date (08-contextual-quick-capture)',
+    flow: "08-contextual-quick-capture.yaml",
     check: (files) => {
       const content = fileWithTitle(files, "Context capture alpha");
       return content !== undefined && /^scheduled:/m.test(content);
@@ -48,6 +57,7 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   },
   {
     name: '"Context capture beta" is persisted with a scheduled date (08-contextual-quick-capture)',
+    flow: "08-contextual-quick-capture.yaml",
     check: (files) => {
       const content = fileWithTitle(files, "Context capture beta");
       return content !== undefined && /^scheduled:/m.test(content);
@@ -55,6 +65,7 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   },
   {
     name: '"Water plants" stays open and gains a complete_instances entry (03-recurring-complete)',
+    flow: "03-recurring-complete.yaml",
     check: (files) => {
       const content = fileWithTitle(files, "Water plants");
       if (content === undefined) return false;
@@ -66,12 +77,14 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   },
   {
     name: '"Swipe complete task" has status done (07-swipe-actions)',
+    flow: "07-swipe-actions.yaml",
     check: (files) =>
       fileWithTitle(files, "Swipe complete task")?.includes("status: done") ===
       true,
   },
   {
     name: '"Swipe delete task" is absent (07-swipe-actions)',
+    flow: "07-swipe-actions.yaml",
     check: (files) => fileWithTitle(files, "Swipe delete task") === undefined,
   },
 ];
@@ -79,6 +92,7 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
 export async function assertVaultState(
   vaultDir: string,
   log: (message: string) => void,
+  focusedFlow: string | null = null,
 ): Promise<void> {
   const tasksDir = path.join(vaultDir, TASKS_DIR);
   const files = new Map<string, string>();
@@ -91,7 +105,14 @@ export async function assertVaultState(
   );
 
   let failures = 0;
-  for (const assertion of VAULT_ASSERTIONS) {
+  const assertions =
+    focusedFlow === null
+      ? VAULT_ASSERTIONS
+      : VAULT_ASSERTIONS.filter((assertion) => assertion.flow === focusedFlow);
+  if (assertions.length === 0) {
+    throw new Error(`no vault assertions registered for ${focusedFlow}`);
+  }
+  for (const assertion of assertions) {
     const passed = assertion.check(files);
     console.log(`[e2e] ${passed ? "PASS" : "FAIL"} — ${assertion.name}`);
     if (!passed) failures += 1;

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -26,6 +26,17 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     check: (files) => fileWithTitle(files, "Created by e2e") !== undefined,
   },
   {
+    name: '"Offline created task" is persisted (05-offline-queue)',
+    flow: "05-offline-queue.yaml",
+    check: (files) =>
+      fileWithTitle(files, "Offline created task") !== undefined,
+  },
+  {
+    name: '"Offline crash task" is persisted after relaunch (06-offline-crash-replay)',
+    flow: "06-offline-crash-replay.yaml",
+    check: (files) => fileWithTitle(files, "Offline crash task") !== undefined,
+  },
+  {
     name: '"Seeded open task" has status done (02-complete-task)',
     flow: "02-complete-task.yaml",
     check: (files) =>
@@ -110,6 +121,13 @@ export async function assertVaultState(
       ? VAULT_ASSERTIONS
       : VAULT_ASSERTIONS.filter((assertion) => assertion.flow === focusedFlow);
   if (assertions.length === 0) {
+    if (
+      focusedFlow === "00-setup.yaml" ||
+      focusedFlow === "09-saved-view-lifecycle.yaml"
+    ) {
+      log(`focused flow passed without vault mutation: ${focusedFlow}`);
+      return;
+    }
     throw new Error(
       `no vault assertions registered for ${String(focusedFlow)}`,
     );

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -6,7 +6,14 @@ const TASKS_DIR = "TaskNotes";
 type VaultAssertion = {
   readonly name: string;
   readonly flow: string;
-  readonly check: (files: Map<string, string>) => boolean;
+  readonly check: (
+    files: Map<string, string>,
+    context: VaultAssertionContext,
+  ) => boolean;
+};
+
+export type VaultAssertionContext = {
+  readonly today: string;
 };
 
 function fileWithTitle(
@@ -17,15 +24,6 @@ function fileWithTitle(
     if (content.includes(`title: ${title}`)) return content;
   }
   return undefined;
-}
-
-function localTodayYmd(): string {
-  const now = new Date();
-  return [
-    String(now.getFullYear()),
-    String(now.getMonth() + 1).padStart(2, "0"),
-    String(now.getDate()).padStart(2, "0"),
-  ].join("-");
 }
 
 function scheduledDate(content: string): string | undefined {
@@ -56,6 +54,7 @@ async function readVaultFiles(
 async function waitForVaultAssertions(
   vaultDir: string,
   assertions: readonly VaultAssertion[],
+  context: VaultAssertionContext,
 ): Promise<Map<string, string>> {
   const deadline = Date.now() + 30_000;
   for (;;) {
@@ -67,7 +66,9 @@ async function waitForVaultAssertions(
       await new Promise((resolve) => setTimeout(resolve, 250));
       continue;
     }
-    const failures = assertions.filter((assertion) => !assertion.check(files));
+    const failures = assertions.filter(
+      (assertion) => !assertion.check(files, context),
+    );
     if (failures.length === 0) return files;
     if (Date.now() >= deadline) {
       throw new Error(`${String(failures.length)} vault assertion(s) failed`);
@@ -117,21 +118,17 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   {
     name: '"Context capture alpha" is persisted with a scheduled date (08-contextual-quick-capture)',
     flow: "08-contextual-quick-capture.yaml",
-    check: (files) => {
+    check: (files, context) => {
       const content = fileWithTitle(files, "Context capture alpha");
-      return (
-        content !== undefined && scheduledDate(content) === localTodayYmd()
-      );
+      return content !== undefined && scheduledDate(content) === context.today;
     },
   },
   {
     name: '"Context capture beta" is persisted with a scheduled date (08-contextual-quick-capture)',
     flow: "08-contextual-quick-capture.yaml",
-    check: (files) => {
+    check: (files, context) => {
       const content = fileWithTitle(files, "Context capture beta");
-      return (
-        content !== undefined && scheduledDate(content) === localTodayYmd()
-      );
+      return content !== undefined && scheduledDate(content) === context.today;
     },
   },
   {
@@ -164,6 +161,7 @@ export async function assertVaultState(
   vaultDir: string,
   log: (message: string) => void,
   focusedFlow: string | null = null,
+  today: string,
 ): Promise<void> {
   const assertions =
     focusedFlow === null
@@ -182,7 +180,7 @@ export async function assertVaultState(
     );
   }
 
-  const files = await waitForVaultAssertions(vaultDir, assertions);
+  const files = await waitForVaultAssertions(vaultDir, assertions, { today });
   log(
     `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
   );

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -49,6 +49,22 @@ function dueDate(content: string): string | undefined {
   return /^due:\s*(\d{4}-\d{2}-\d{2})\s*$/m.exec(content)?.[1];
 }
 
+function completeInstanceDates(content: string): readonly string[] {
+  const lines = content.split(/\r?\n/);
+  const headerIndex = lines.findIndex(
+    (line) => line.trim() === "complete_instances:",
+  );
+  if (headerIndex === -1) return [];
+  const dates: string[] = [];
+  for (const line of lines.slice(headerIndex + 1)) {
+    if (!line.trimStart().startsWith("- ")) break;
+    dates.push(
+      line.trim().slice(2).trim().replaceAll('"', "").replaceAll("'", ""),
+    );
+  }
+  return dates;
+}
+
 function isMissingFileError(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
@@ -172,7 +188,7 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
       if (content === undefined) return false;
       return (
         content.includes("status: open") &&
-        /complete_instances:\n\s+- /.test(content)
+        completeInstanceDates(content).includes("2026-07-01")
       );
     },
   },

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -26,6 +26,21 @@ function fileWithTitle(
   return undefined;
 }
 
+function frontmatterTitle(content: string): string | undefined {
+  const match = /^title: ([^\r\n]*)$/m.exec(content);
+  return match?.[1].trim();
+}
+
+function fileWithExactTitle(
+  files: Map<string, string>,
+  title: string,
+): string | undefined {
+  for (const content of files.values()) {
+    if (frontmatterTitle(content) === title) return content;
+  }
+  return undefined;
+}
+
 function scheduledDate(content: string): string | undefined {
   return /^scheduled:\s*(\d{4}-\d{2}-\d{2})\s*$/m.exec(content)?.[1];
 }
@@ -119,7 +134,7 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     name: '"Context capture alpha" is persisted with a scheduled date (08-contextual-quick-capture)',
     flow: "08-contextual-quick-capture.yaml",
     check: (files, context) => {
-      const content = fileWithTitle(files, "Context capture alpha");
+      const content = fileWithExactTitle(files, "Context capture alpha");
       return content !== undefined && scheduledDate(content) === context.today;
     },
   },
@@ -127,7 +142,7 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     name: '"Context capture beta" is persisted with a scheduled date (08-contextual-quick-capture)',
     flow: "08-contextual-quick-capture.yaml",
     check: (files, context) => {
-      const content = fileWithTitle(files, "Context capture beta");
+      const content = fileWithExactTitle(files, "Context capture beta");
       return content !== undefined && scheduledDate(content) === context.today;
     },
   },

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -19,6 +19,19 @@ function fileWithTitle(
   return undefined;
 }
 
+function localTodayYmd(): string {
+  const now = new Date();
+  return [
+    String(now.getFullYear()),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function scheduledDate(content: string): string | undefined {
+  return /^scheduled:\s*(\d{4}-\d{2}-\d{2})\s*$/m.exec(content)?.[1];
+}
+
 async function readVaultFiles(vaultDir: string): Promise<Map<string, string>> {
   const tasksDir = path.join(vaultDir, TASKS_DIR);
   const files = new Map<string, string>();
@@ -72,7 +85,9 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     flow: "08-contextual-quick-capture.yaml",
     check: (files) => {
       const content = fileWithTitle(files, "Context capture alpha");
-      return content !== undefined && /^scheduled:/m.test(content);
+      return (
+        content !== undefined && scheduledDate(content) === localTodayYmd()
+      );
     },
   },
   {
@@ -80,7 +95,9 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     flow: "08-contextual-quick-capture.yaml",
     check: (files) => {
       const content = fileWithTitle(files, "Context capture beta");
-      return content !== undefined && /^scheduled:/m.test(content);
+      return (
+        content !== undefined && scheduledDate(content) === localTodayYmd()
+      );
     },
   },
   {

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -32,14 +32,48 @@ function scheduledDate(content: string): string | undefined {
   return /^scheduled:\s*(\d{4}-\d{2}-\d{2})\s*$/m.exec(content)?.[1];
 }
 
-async function readVaultFiles(vaultDir: string): Promise<Map<string, string>> {
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+async function readVaultFiles(
+  vaultDir: string,
+): Promise<Map<string, string> | undefined> {
   const tasksDir = path.join(vaultDir, TASKS_DIR);
-  const files = new Map<string, string>();
-  for (const entry of await readdir(tasksDir)) {
-    if (!entry.endsWith(".md")) continue;
-    files.set(entry, await readFile(path.join(tasksDir, entry), "utf8"));
+  try {
+    const files = new Map<string, string>();
+    for (const entry of await readdir(tasksDir)) {
+      if (!entry.endsWith(".md")) continue;
+      files.set(entry, await readFile(path.join(tasksDir, entry), "utf8"));
+    }
+    return files;
+  } catch (error) {
+    if (isMissingFileError(error)) return undefined;
+    throw error;
   }
-  return files;
+}
+
+async function waitForVaultAssertions(
+  vaultDir: string,
+  assertions: readonly VaultAssertion[],
+): Promise<Map<string, string>> {
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const files = await readVaultFiles(vaultDir);
+    if (files === undefined) {
+      if (Date.now() >= deadline) {
+        throw new Error("vault changed while reading assertions");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      continue;
+    }
+    const failures = assertions.filter((assertion) => !assertion.check(files));
+    if (failures.length === 0) return files;
+    if (Date.now() >= deadline) {
+      throw new Error(`${String(failures.length)} vault assertion(s) failed`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
 }
 
 const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
@@ -148,18 +182,7 @@ export async function assertVaultState(
     );
   }
 
-  const deadline = Date.now() + 30_000;
-  let files = await readVaultFiles(vaultDir);
-  for (;;) {
-    const failures = assertions.filter((assertion) => !assertion.check(files));
-    if (failures.length === 0) break;
-    if (Date.now() >= deadline) {
-      throw new Error(`${String(failures.length)} vault assertion(s) failed`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    files = await readVaultFiles(vaultDir);
-  }
-
+  const files = await waitForVaultAssertions(vaultDir, assertions);
   log(
     `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
   );

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -13,7 +13,7 @@ type VaultAssertion = {
 };
 
 export type VaultAssertionContext = {
-  readonly today: string;
+  readonly todayByFlow: ReadonlyMap<string, string>;
 };
 
 function fileWithTitle(
@@ -43,6 +43,10 @@ function fileWithExactTitle(
 
 function scheduledDate(content: string): string | undefined {
   return /^scheduled:\s*(\d{4}-\d{2}-\d{2})\s*$/m.exec(content)?.[1];
+}
+
+function dueDate(content: string): string | undefined {
+  return /^due:\s*(\d{4}-\d{2}-\d{2})\s*$/m.exec(content)?.[1];
 }
 
 function isMissingFileError(error: unknown): boolean {
@@ -94,9 +98,15 @@ async function waitForVaultAssertions(
 
 const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   {
-    name: 'a task file containing "Created by e2e" exists (01-create-task)',
+    name: '"Created by e2e" is persisted with today as its deadline (01-create-task)',
     flow: "01-create-task.yaml",
-    check: (files) => fileWithTitle(files, "Created by e2e") !== undefined,
+    check: (files, context) => {
+      const content = fileWithExactTitle(files, "Created by e2e");
+      return (
+        content !== undefined &&
+        dueDate(content) === context.todayByFlow.get("01-create-task.yaml")
+      );
+    },
   },
   {
     name: '"Offline created task" is persisted (05-offline-queue)',
@@ -135,7 +145,11 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     flow: "08-contextual-quick-capture.yaml",
     check: (files, context) => {
       const content = fileWithExactTitle(files, "Context capture alpha");
-      return content !== undefined && scheduledDate(content) === context.today;
+      return (
+        content !== undefined &&
+        scheduledDate(content) ===
+          context.todayByFlow.get("08-contextual-quick-capture.yaml")
+      );
     },
   },
   {
@@ -143,7 +157,11 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     flow: "08-contextual-quick-capture.yaml",
     check: (files, context) => {
       const content = fileWithExactTitle(files, "Context capture beta");
-      return content !== undefined && scheduledDate(content) === context.today;
+      return (
+        content !== undefined &&
+        scheduledDate(content) ===
+          context.todayByFlow.get("08-contextual-quick-capture.yaml")
+      );
     },
   },
   {
@@ -176,7 +194,7 @@ export async function assertVaultState(
   vaultDir: string,
   log: (message: string) => void,
   focusedFlow: string | null = null,
-  today: string,
+  todayByFlow: ReadonlyMap<string, string>,
 ): Promise<void> {
   const assertions =
     focusedFlow === null
@@ -195,7 +213,9 @@ export async function assertVaultState(
     );
   }
 
-  const files = await waitForVaultAssertions(vaultDir, assertions, { today });
+  const files = await waitForVaultAssertions(vaultDir, assertions, {
+    todayByFlow,
+  });
   log(
     `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
   );

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -19,6 +19,16 @@ function fileWithTitle(
   return undefined;
 }
 
+async function readVaultFiles(vaultDir: string): Promise<Map<string, string>> {
+  const tasksDir = path.join(vaultDir, TASKS_DIR);
+  const files = new Map<string, string>();
+  for (const entry of await readdir(tasksDir)) {
+    if (!entry.endsWith(".md")) continue;
+    files.set(entry, await readFile(path.join(tasksDir, entry), "utf8"));
+  }
+  return files;
+}
+
 const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
   {
     name: 'a task file containing "Created by e2e" exists (01-create-task)',
@@ -47,9 +57,8 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     name: 'the seeded task file is renamed to "Edited by e2e" (04-edit-task)',
     flow: "04-edit-task.yaml",
     check: (files) =>
-      files
-        .get("task-with-details-3c4d5e6f.md")
-        ?.includes("title: Edited by e2e") === true,
+      files.get("Edited by e2e.md")?.includes("title: Edited by e2e") ===
+        true && !files.has("task-with-details-3c4d5e6f.md"),
   },
   {
     name: '"Seeded done task" has status open (10-completed-search-uncomplete)',
@@ -105,17 +114,6 @@ export async function assertVaultState(
   log: (message: string) => void,
   focusedFlow: string | null = null,
 ): Promise<void> {
-  const tasksDir = path.join(vaultDir, TASKS_DIR);
-  const files = new Map<string, string>();
-  for (const entry of await readdir(tasksDir)) {
-    if (!entry.endsWith(".md")) continue;
-    files.set(entry, await readFile(path.join(tasksDir, entry), "utf8"));
-  }
-  log(
-    `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
-  );
-
-  let failures = 0;
   const assertions =
     focusedFlow === null
       ? VAULT_ASSERTIONS
@@ -132,12 +130,23 @@ export async function assertVaultState(
       `no vault assertions registered for ${String(focusedFlow)}`,
     );
   }
-  for (const assertion of assertions) {
-    const passed = assertion.check(files);
-    console.log(`[e2e] ${passed ? "PASS" : "FAIL"} — ${assertion.name}`);
-    if (!passed) failures += 1;
+
+  const deadline = Date.now() + 30_000;
+  let files = await readVaultFiles(vaultDir);
+  for (;;) {
+    const failures = assertions.filter((assertion) => !assertion.check(files));
+    if (failures.length === 0) break;
+    if (Date.now() >= deadline) {
+      throw new Error(`${String(failures.length)} vault assertion(s) failed`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    files = await readVaultFiles(vaultDir);
   }
-  if (failures > 0) {
-    throw new Error(`${String(failures)} vault assertion(s) failed`);
+
+  log(
+    `vault contains ${String(files.size)} task file(s): ${[...files.keys()].join(", ")}`,
+  );
+  for (const assertion of assertions) {
+    console.log(`[e2e] PASS — ${assertion.name}`);
   }
 }

--- a/packages/tasks-for-obsidian/package.json
+++ b/packages/tasks-for-obsidian/package.json
@@ -6,7 +6,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "test": "bun test src scripts",
+    "test": "bun test src scripts e2e/simulator-date.test.ts",
     "test:coverage": "bun test --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage --config ../../scripts/bunfig.coverage.toml --coverage scripts/clean-ios.test.ts scripts/ios-logs.test.ts",
     "test:contract": "bun test contract-tests --timeout 20000",
     "e2e": "bun run e2e/run.ts",

--- a/packages/tasks-for-obsidian/src/components/input/QuickCaptureComposer.tsx
+++ b/packages/tasks-for-obsidian/src/components/input/QuickCaptureComposer.tsx
@@ -83,6 +83,7 @@ export function QuickCaptureComposer({
       keyboardDismissMode="interactive"
     >
       <View
+        testID={!saving && value.length === 0 ? "quick-add-ready" : undefined}
         style={[
           styles.composer,
           {

--- a/packages/tasks-for-obsidian/src/screens/TodayScreen.tsx
+++ b/packages/tasks-for-obsidian/src/screens/TodayScreen.tsx
@@ -5,6 +5,7 @@ import type { CompositeScreenProps } from "@react-navigation/native";
 import type { Task, TaskId } from "../domain/types";
 import { createCaptureSeed } from "../domain/quick-capture-seed";
 import { localTodayYmd } from "../domain/recurrence";
+import { e2eNow } from "../navigation/e2e-config";
 import type { RootStackParamList } from "../navigation/types";
 import type { MainTabScreenProps } from "../navigation/main-tabs";
 import {
@@ -212,7 +213,7 @@ export function TodayScreen({ navigation }: Props) {
           onPress={() => {
             navigation.navigate(
               "QuickAdd",
-              createCaptureSeed({ scheduled: localTodayYmd() }),
+              createCaptureSeed({ scheduled: localTodayYmd(e2eNow()) }),
             );
           }}
         />

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -299,7 +299,12 @@
     {
       "package": "tasks-for-obsidian",
       "directory": "packages/tasks-for-obsidian",
-      "steps": [{ "runner": "bun", "args": ["src", "scripts"] }],
+      "steps": [
+        {
+          "runner": "bun",
+          "args": ["src", "scripts", "e2e/simulator-date.test.ts"]
+        }
+      ],
       "excludedSuites": [
         {
           "path": "contract-tests/contract.test.ts",


### PR DESCRIPTION
## Summary

- expand the iOS Maestro suite from seven to eleven ordered product flows
- cover contextual quick capture, saved-view lifecycle, completed-task search/uncomplete, recurring completion, offline queue/crash replay, editing, and swipe actions
- assert selected durable outcomes directly against the real Obsidian Markdown vault
- record the decision-complete product plan and keep unfinished work visibly marked as in progress

## Device evidence

- the final byte-for-byte 11-flow suite passed together on Xcode 27, iOS 27, and Maestro 2.8.0
- focused recurring completion also passed after moving Undo feedback inside the native Task Detail sheet
- the runner builds a fresh seeded vault, starts the real TaskNotes server and chaos proxy, drives the simulator, checks selected Markdown outcomes, and preserves failed vaults for diagnosis

## Verification

- tasks-for-obsidian lint and both application/script TypeScript checks passed
- docs contract passed with 621 Markdown documents
- staged pre-commit and commit-message hooks passed

## Remaining acceptance

The plan intentionally remains in progress. Human review is still needed for Todoist-reference parity, Dynamic Type, VoiceOver, Reduce Motion, contrast, older supported runtimes, widget/Siri behavior, and final native feel. Larger roadmap items are not claimed by this stack.

## Stack

This is 3 of 3, based on product PR #2013 and reliability PR #2012.
