### PR TITLE
fix(dotfiles): disable three-finger drag so Middle can middle-click

### DIFF
--- a/packages/dotfiles/private_dot_config/macos-defaults/NSGlobalDomain.current-host.yaml
+++ b/packages/dotfiles/private_dot_config/macos-defaults/NSGlobalDomain.current-host.yaml
@@ -16,7 +16,8 @@ data:
     com.apple.trackpad.pinchGesture: true
     com.apple.trackpad.rotateGesture: true
     com.apple.trackpad.scrollBehavior: 2
-    com.apple.trackpad.threeFingerDragGesture: true
+    # Off — see com.apple.AppleMultitouchTrackpad.yaml (conflicts with Middle).
+    com.apple.trackpad.threeFingerDragGesture: false
     com.apple.trackpad.threeFingerHorizSwipeGesture: 2
     com.apple.trackpad.threeFingerTapGesture: 0
     com.apple.trackpad.threeFingerVertSwipeGesture: 2

--- a/packages/dotfiles/private_dot_config/macos-defaults/com.apple.AppleMultitouchTrackpad.yaml
+++ b/packages/dotfiles/private_dot_config/macos-defaults/com.apple.AppleMultitouchTrackpad.yaml
@@ -24,7 +24,9 @@ data:
     TrackpadRightClick: true
     TrackpadRotate: 1
     TrackpadScroll: true
-    TrackpadThreeFingerDrag: true
+    # Off: three-finger drag makes macOS synthesize a left click on every
+    # three-finger touch, which preempts Middle's three-finger middle click.
+    TrackpadThreeFingerDrag: false
     TrackpadThreeFingerHorizSwipeGesture: 2
     TrackpadThreeFingerTapGesture: 0
     TrackpadThreeFingerVertSwipeGesture: 2

--- a/packages/dotfiles/private_dot_config/macos-defaults/com.knollsoft.Middle.yaml
+++ b/packages/dotfiles/private_dot_config/macos-defaults/com.knollsoft.Middle.yaml
@@ -7,6 +7,6 @@ data:
     launchOnLogin: true
     mouseThreeClick: false
     mouseThreeTap: true
-    trackpadThreeClick: false
+    trackpadThreeClick: true
     trackpadThreeTap: true
     wideOneCenterClick: 1


### PR DESCRIPTION
macOS three-finger drag makes the trackpad driver synthesize a left
mouse-down when three fingers land and a left mouse-up when they lift.
That full left click is emitted before Middle sees the gesture, so a
three-finger tap on a link navigated the current tab instead of opening
a background one. Middle's developer confirmed a third party cannot
distinguish the two (rxhanson/Middle-Community#52).

The stray click is usually harmless (clicking a browser tab just selects
it), which is why this only looked broken on links in Safari.

Disable the gesture in both the device domain and the hardware-scoped
current-host domain, and enable Middle's three-finger physical click,
which was off so only tap was mapped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>