### PR TITLE
fix(ci): scope Argo release health to published apps (#2039)

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
@@ -177,3 +177,38 @@ describe("Scout web alert thresholds suit production volume", () => {
     expect(expression).toContain(">= 3");
   });
 });
+
+describe("Scout web alert holds are shorter than their lookback", () => {
+  const web = getScoutRuleGroups().find((group) => group.name === "scout-web");
+
+  // A `for` equal to the lookback can never fire on a burst: the oldest events
+  // age out of the window before the pending alert satisfies its hold. The hold
+  // must be a fraction of the observation window.
+  const holdSeconds: Record<string, number> = {
+    "5m": 300,
+    "15m": 900,
+    "30m": 1800,
+    "1h": 3600,
+    "6h": 21_600,
+  };
+
+  test.each([
+    "ScoutWeb5xxRateHigh",
+    "ScoutDiscordUpstreamFailures",
+    "ScoutTrpcErrorRateHigh",
+    "ScoutWebSigninFailureRate",
+  ])("%s holds for less than its lookback window", (alertName) => {
+    const rule = web?.rules?.find((candidate) => candidate.alert === alertName);
+    if (rule === undefined) {
+      throw new Error(`Missing ${alertName} rule`);
+    }
+    const expression = JSON.stringify(rule.expr);
+    const windows = [...expression.matchAll(/\[(\d+[mh])\]/g)].map(
+      (match) => holdSeconds[match[1] ?? ""] ?? 0,
+    );
+    const shortestWindow = Math.min(...windows);
+    const hold = holdSeconds[rule.for ?? ""] ?? 0;
+    expect(hold).toBeGreaterThan(0);
+    expect(hold).toBeLessThan(shortestWindow);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -326,13 +326,13 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
           annotations: {
             summary: "Scout web backend is returning server errors",
             message: escapePrometheusTemplate(
-              "Scout {{ $labels.environment }} is serving {{ $value | humanize }} 5xx responses in 15m on route {{ $labels.route }}. These are backend faults, not client mistakes.",
+              "Scout {{ $labels.environment }} is serving {{ $value | humanize }} 5xx responses in 30m on route {{ $labels.route }}. These are backend faults, not client mistakes.",
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'sum by (environment, route) (increase(scout_http_requests_total{status_class="5xx"}[15m])) > 5',
+            'sum by (environment, route) (increase(scout_http_requests_total{status_class="5xx"}[30m])) > 5',
           ),
-          for: "10m",
+          for: "5m",
           labels: {
             severity: "critical",
           },
@@ -345,13 +345,13 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
           annotations: {
             summary: "Scout cannot reach Discord to resolve user guilds",
             message: escapePrometheusTemplate(
-              "Scout {{ $labels.environment }} is failing to fetch user guilds from Discord ({{ $labels.reason }}) saw {{ $value | humanize }} failures in 15m. Web users will see 'Couldn't reach Discord' and cannot manage their servers.",
+              "Scout {{ $labels.environment }} is failing to fetch user guilds from Discord ({{ $labels.reason }}) saw {{ $value | humanize }} failures in 30m. Web users will see 'Couldn't reach Discord' and cannot manage their servers.",
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'sum by (environment, reason) (increase(scout_discord_user_guilds_failures_total{reason!="token_refresh_failed"}[15m])) > 3',
+            'sum by (environment, reason) (increase(scout_discord_user_guilds_failures_total{reason!="token_refresh_failed"}[30m])) > 3',
           ),
-          for: "15m",
+          for: "5m",
           labels: {
             severity: "warning",
           },
@@ -370,7 +370,7 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             `sum by (environment, procedure, code) (increase(scout_trpc_calls_total{code!~"${TRPC_NON_FAULT_CODES.join("|")}"}[30m])) > 5`,
           ),
-          for: "15m",
+          for: "5m",
           labels: {
             severity: "warning",
           },

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.ts
@@ -13,6 +13,8 @@
 import type { DiscordGuildId } from "@scout-for-lol/data";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 import { guildDataCleanupTotal } from "#src/metrics/index.ts";
+import { getErrorMessage } from "#src/utils/errors.ts";
+import { recordConversionIfAny } from "#src/league/tasks/outreach/conversions.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("cleanup-removed-guild");
@@ -55,6 +57,25 @@ export async function cleanupRemovedGuild(
     where: { serverId },
     data: { removedAt: new Date() },
   });
+
+  // Materialize any pending conversion before the deletions below destroy the
+  // evidence. The nightly job only polls once a day, so a guild that converted
+  // and then removed Scout the same day would otherwise vanish from the
+  // experiment entirely. Best-effort: cleanup must not be blocked by analytics.
+  try {
+    const install = await db.guildInstall.findUnique({
+      where: { serverId },
+      select: { installedAt: true },
+    });
+    if (install !== null) {
+      await recordConversionIfAny(db, serverId, install.installedAt);
+    }
+  } catch (error) {
+    logger.error(
+      `[RemoveGuild] Failed to materialize conversion for ${serverId}:`,
+      getErrorMessage(error),
+    );
+  }
 
   const summary = await db.$transaction(
     async (tx): Promise<RemovedGuildCleanupSummary> => {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/outreach/conversions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/outreach/conversions.test.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { recordConversionIfAny } from "#src/league/tasks/outreach/conversions.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("outreach-conversions-test");
+
+const SERVER_ID = testGuildId("111000000000000091");
+const RECIPIENT_ID = testAccountId("111000000000000092");
+const CHANNEL_ID = testChannelId("111000000000000093");
+const INSTALLED_AT = new Date("2026-08-01T00:00:00.000Z");
+const DELIVERED_AT = new Date("2026-08-02T00:00:00.000Z");
+const CONVERTED_AT = new Date("2026-08-03T00:00:00.000Z");
+
+beforeEach(async () => {
+  await prisma.outreachConversion.deleteMany();
+  await prisma.subscription.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.dmAuditLog.deleteMany();
+
+  const player = await prisma.player.create({
+    data: {
+      alias: "conversion-test-player",
+      serverId: SERVER_ID,
+      creatorDiscordId: RECIPIENT_ID,
+      createdTime: CONVERTED_AT,
+      updatedTime: CONVERTED_AT,
+    },
+  });
+  await prisma.subscription.create({
+    data: {
+      playerId: player.id,
+      channelId: CHANNEL_ID,
+      serverId: SERVER_ID,
+      creatorDiscordId: RECIPIENT_ID,
+      createdTime: CONVERTED_AT,
+      updatedTime: CONVERTED_AT,
+    },
+  });
+  await prisma.dmAuditLog.create({
+    data: {
+      recipientId: RECIPIENT_ID,
+      guildId: SERVER_ID,
+      kind: "outreach_nudge",
+      content: "Message 1 of 3",
+      deliveryStatus: "sent",
+      ladderStage: 1,
+      createdAt: DELIVERED_AT,
+    },
+  });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("recordConversionIfAny", () => {
+  test("is idempotent when concurrent writers record the same install", async () => {
+    await Promise.all(
+      Array.from({ length: 8 }, async () =>
+        recordConversionIfAny(prisma, SERVER_ID, INSTALLED_AT),
+      ),
+    );
+
+    const conversions = await prisma.outreachConversion.findMany({
+      select: {
+        serverId: true,
+        installedAt: true,
+        ladderStage: true,
+      },
+    });
+    expect(conversions).toEqual([
+      {
+        serverId: SERVER_ID,
+        installedAt: INSTALLED_AT,
+        ladderStage: 1,
+      },
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/outreach/conversions.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/outreach/conversions.ts
@@ -13,7 +13,8 @@
  */
 
 import { DiscordGuildIdSchema } from "@scout-for-lol/data";
-import { prisma } from "#src/database/index.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import type { DiscordGuildId } from "@scout-for-lol/data";
 import { readOutreachState } from "#src/discord/utils/outreach-state.ts";
 import {
   outreachBudgetExhausted,
@@ -35,6 +36,61 @@ const OUTREACH_KINDS = [
   "outreach_14d",
   "outreach_30d",
 ];
+
+/**
+ * Record a conversion for one guild if its first subscription of the current
+ * installation landed inside the attribution window after a delivered message.
+ *
+ * Exported so `cleanupRemovedGuild` can materialize a pending conversion BEFORE
+ * deleting the guild's subscriptions. The nightly job alone was not enough: a
+ * guild that converted and then removed Scout the same day lost the evidence
+ * before the job ever looked, so short-lived activations vanished from the
+ * experiment.
+ */
+export async function recordConversionIfAny(
+  db: ExtendedPrismaClient,
+  serverId: DiscordGuildId,
+  installedAt: Date,
+): Promise<boolean> {
+  const existing = await db.outreachConversion.findUnique({
+    where: { serverId_installedAt: { serverId, installedAt } },
+  });
+  if (existing !== null) return false;
+
+  const delivered = await db.dmAuditLog.findMany({
+    where: {
+      guildId: serverId,
+      deliveryStatus: "sent",
+      kind: { in: OUTREACH_KINDS },
+      createdAt: { gte: installedAt },
+    },
+    select: { createdAt: true, ladderStage: true },
+    orderBy: { createdAt: "asc" },
+  });
+  if (delivered.length === 0) return false;
+
+  const firstSub = await db.subscription.findFirst({
+    where: { serverId, createdTime: { gte: installedAt } },
+    select: { createdTime: true },
+    orderBy: { createdTime: "asc" },
+  });
+  if (firstSub === null) return false;
+
+  for (const row of delivered) {
+    const stage = row.ladderStage;
+    if (stage === null) continue;
+    if (
+      firstSub.createdTime > row.createdAt &&
+      firstSub.createdTime.getTime() < row.createdAt.getTime() + WINDOW_MS
+    ) {
+      await db.outreachConversion.create({
+        data: { serverId, installedAt, ladderStage: stage },
+      });
+      return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Recompute conversion and ladder-distribution gauges from the audit log.

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/outreach/conversions.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/outreach/conversions.ts
@@ -37,6 +37,22 @@ const OUTREACH_KINDS = [
   "outreach_30d",
 ];
 
+async function persistConversion(
+  db: ExtendedPrismaClient,
+  serverId: DiscordGuildId,
+  installedAt: Date,
+  ladderStage: number,
+): Promise<void> {
+  await db.outreachConversion.upsert({
+    where: { serverId_installedAt: { serverId, installedAt } },
+    create: { serverId, installedAt, ladderStage },
+    // Conversion rows are immutable historical facts. The no-op update makes
+    // concurrent cleanup and nightly writers idempotent without rewriting the
+    // stage or convertedAt timestamp selected by the first writer.
+    update: {},
+  });
+}
+
 /**
  * Record a conversion for one guild if its first subscription of the current
  * installation landed inside the attribution window after a delivered message.
@@ -83,9 +99,7 @@ export async function recordConversionIfAny(
       firstSub.createdTime > row.createdAt &&
       firstSub.createdTime.getTime() < row.createdAt.getTime() + WINDOW_MS
     ) {
-      await db.outreachConversion.create({
-        data: { serverId, installedAt, ladderStage: stage },
-      });
+      await persistConversion(db, serverId, installedAt, stage);
       return true;
     }
   }
@@ -161,13 +175,12 @@ export async function updateOutreachConversionMetrics(): Promise<void> {
     }
 
     alreadyRecorded.add(key);
-    await prisma.outreachConversion.create({
-      data: {
-        serverId: DiscordGuildIdSchema.parse(guildId),
-        installedAt,
-        ladderStage: stage,
-      },
-    });
+    await persistConversion(
+      prisma,
+      DiscordGuildIdSchema.parse(guildId),
+      installedAt,
+      stage,
+    );
   }
 
   const recorded = await prisma.outreachConversion.groupBy({


### PR DESCRIPTION
Follow-up to #2023, which was merged before these two review findings were addressed. Both are real and both are already visible on `main`.

## What's wrong on `main` today

**`ScoutDiscordUpstreamFailures` can never fire.** It uses a 15-minute lookback with a 15-minute `for` hold, so a burst of failures ages out of the observation window before the pending alert can satisfy the hold. The threshold is irrelevant — the rule is structurally unable to alert. `ScoutWeb5xxRateHigh` and `ScoutTrpcErrorRateHigh` have the same shape to a lesser degree.

This is the second time an alert I added couldn't fire (the first was reading `> 0.05` as "5%" when it's an absolute per-second rate), so this PR adds a test asserting `hold < lookback` for all four web rules.

**Short-lived conversions are lost.** The nightly conversion job polls live subscriptions once a day, but `cleanupRemovedGuild` deletes them. A guild that converted and then removed Scout the same day disappears from the experiment entirely — the persisted-conversion table added in #2023 only helps if something writes to it before the evidence is destroyed.

## Changes

- Conversion detection factored into `recordConversionIfAny`, called from `cleanupRemovedGuild` **before** the deletions. Same chokepoint pattern as `removedAt`: do it in the one function every removal path calls.
- Web alert observation windows widened to 30m and holds shortened to 5m, so a hold is a fraction of its window rather than equal to it.
- Test asserting hold < lookback for all four `scout-web` rules.

## Verification

`bun run verify` with CI's exact filters: **227/227**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
