### PR TITLE
fix(pr-fleet-controller): close review races

### DIFF
--- a/packages/pr-fleet-controller/src/controller-operator-questions.ts
+++ b/packages/pr-fleet-controller/src/controller-operator-questions.ts
@@ -6,6 +6,7 @@ import {
   type FleetTickReport,
   type OperatorInputAnswer,
   type OperatorInputRequest,
+  type PrState,
 } from "./schemas.ts";
 import type { FleetStore } from "./state.ts";
 
@@ -19,6 +20,28 @@ type OperatorQuestionDependencies = {
   ) => Promise<string | null>;
   queueReconciliation: () => void;
 };
+
+function requireCurrentAnswerState(
+  store: FleetStore,
+  request: OperatorInputRequest,
+  remoteHead: string | null,
+): PrState {
+  if (store.isStopping()) {
+    throw new Error("Controller is stopping; operator answer was not accepted");
+  }
+  const currentRequest = store.operatorRequests.get(request.pr);
+  const currentState = store.prs.get(request.pr);
+  if (
+    currentState === undefined ||
+    currentState.status === "closed" ||
+    currentRequest?.id !== request.id ||
+    remoteHead !== request.headSha ||
+    currentState.identity.headSha !== request.headSha
+  ) {
+    throw new Error(`Operator request ${request.id} is stale`);
+  }
+  return currentState;
+}
 
 export async function lookupCurrentPrHead(
   environment: FleetEnvironment,
@@ -100,17 +123,7 @@ export async function acceptOperatorAnswer(
     );
   }
   const remoteHead = await currentPrHead(request.pr, request.headSha);
-  const currentRequest = store.operatorRequests.get(request.pr);
-  const currentState = store.prs.get(request.pr);
-  if (
-    currentState === undefined ||
-    currentState.status === "closed" ||
-    currentRequest?.id !== request.id ||
-    remoteHead !== request.headSha ||
-    currentState.identity.headSha !== request.headSha
-  ) {
-    throw new Error(`Operator request ${request.id} is stale`);
-  }
+  const currentState = requireCurrentAnswerState(store, request, remoteHead);
   const guidance = answerGuidance(request, answer);
   telemetry.operatorQuestionAnswered(request, answer);
   store.operatorRequests.delete(request.pr);

--- a/packages/pr-fleet-controller/src/controller-reconciliation.ts
+++ b/packages/pr-fleet-controller/src/controller-reconciliation.ts
@@ -21,6 +21,7 @@ export function closeMissingPrStates(
       store.operatorRequests.delete(number);
     }
     store.completedRestacks.delete(number);
+    store.activeRestacks.delete(number);
     store.prs.set(number, {
       ...previous,
       status: "closed",
@@ -76,6 +77,7 @@ export function reconcilePrStates(
       previous.identity.headSha !== reconciled.state.identity.headSha;
     if (headChanged || reconciled.state.classification === "green") {
       store.completedRestacks.delete(item.identity.number);
+      store.activeRestacks.delete(item.identity.number);
     }
     if (
       (headChanged || reconciled.state.classification === "green") &&

--- a/packages/pr-fleet-controller/src/inherited-wip.ts
+++ b/packages/pr-fleet-controller/src/inherited-wip.ts
@@ -199,7 +199,14 @@ export function requireMatchingInheritedWipInspection(
   if (context?.ownership !== "operator") {
     return;
   }
-  if (live.localHeadSha !== context.localHeadSha) {
+  const inspection = store.inheritedWipInspections.get(pr.identity.number);
+  const expectedLocalHead = store.activeRestacks.has(pr.identity.number)
+    ? inspection?.localHeadSha
+    : context.localHeadSha;
+  if (
+    expectedLocalHead === undefined ||
+    live.localHeadSha !== expectedLocalHead
+  ) {
     throw new Error(
       "Operator worktree HEAD changed after assignment; inspect again or ask the operator",
     );
@@ -207,7 +214,6 @@ export function requireMatchingInheritedWipInspection(
   if (!live.hasWip && !context.dirty) {
     return;
   }
-  const inspection = store.inheritedWipInspections.get(pr.identity.number);
   if (
     inspection === undefined ||
     !inspection.complete ||

--- a/packages/pr-fleet-controller/src/inherited-wip.ts
+++ b/packages/pr-fleet-controller/src/inherited-wip.ts
@@ -200,9 +200,13 @@ export function requireMatchingInheritedWipInspection(
     return;
   }
   const inspection = store.inheritedWipInspections.get(pr.identity.number);
-  const expectedLocalHead = store.activeRestacks.has(pr.identity.number)
-    ? inspection?.localHeadSha
-    : context.localHeadSha;
+  const activeRestack = store.activeRestacks.get(pr.identity.number);
+  const expectedLocalHead =
+    activeRestack === undefined
+      ? context.localHeadSha
+      : activeRestack.remoteHeadSha === context.remoteHeadSha
+        ? activeRestack.localHeadSha
+        : undefined;
   if (
     expectedLocalHead === undefined ||
     live.localHeadSha !== expectedLocalHead
@@ -211,7 +215,7 @@ export function requireMatchingInheritedWipInspection(
       "Operator worktree HEAD changed after assignment; inspect again or ask the operator",
     );
   }
-  if (!live.hasWip && !context.dirty) {
+  if (activeRestack === undefined && !live.hasWip && !context.dirty) {
     return;
   }
   if (

--- a/packages/pr-fleet-controller/src/state.ts
+++ b/packages/pr-fleet-controller/src/state.ts
@@ -51,6 +51,7 @@ export class FleetStore {
     number,
     { remoteHeadSha: string; localHeadSha: string }
   >();
+  readonly activeRestacks = new Set<number>();
   readonly stackWriteOwners = new Map<string, number>();
   setupOwner: number | null = null;
   readonly heavyOwners = new Set<number>();

--- a/packages/pr-fleet-controller/src/state.ts
+++ b/packages/pr-fleet-controller/src/state.ts
@@ -51,7 +51,10 @@ export class FleetStore {
     number,
     { remoteHeadSha: string; localHeadSha: string }
   >();
-  readonly activeRestacks = new Set<number>();
+  readonly activeRestacks = new Map<
+    number,
+    { remoteHeadSha: string; localHeadSha: string }
+  >();
   readonly stackWriteOwners = new Map<string, number>();
   setupOwner: number | null = null;
   readonly heavyOwners = new Set<number>();

--- a/packages/pr-fleet-controller/src/worker-restack-tools.ts
+++ b/packages/pr-fleet-controller/src/worker-restack-tools.ts
@@ -55,6 +55,7 @@ async function requireCurrentCompletedRestack(
   );
   const live = await collectInheritedWipEvidence(options);
   if (
+    options.store.activeRestacks.has(options.pr.identity.number) ||
     expected?.remoteHeadSha !== options.pr.identity.headSha ||
     expected.localHeadSha !== live.localHeadSha
   ) {
@@ -94,15 +95,20 @@ export function createWorkerRestackTools(options: RestackToolOptions) {
             throw new Error("Stack write lease is not available");
           }
           await requireCurrentInheritedWipInspection(options);
-          invalidateInheritedWipInspection({ store, pr });
+          invalidateInheritedWipInspection(options);
           store.completedRestacks.delete(pr.identity.number);
+          store.activeRestacks.add(pr.identity.number);
           const result = await environment.startRestack(pr, signal);
           const output = `${result.stdout}\n${result.stderr}`.trim();
           if (result.exitCode !== 0 && !/conflict/i.test(output)) {
+            store.activeRestacks.delete(pr.identity.number);
             store.releaseLease(pr.identity.number, "stack-write", pr.stackId);
             throw new Error(`git-spice restack failed: ${output}`);
           }
-          if (result.exitCode === 0) await recordCompletedRestack(options);
+          if (result.exitCode === 0) {
+            store.activeRestacks.delete(pr.identity.number);
+            await recordCompletedRestack(options);
+          }
           return { completed: result.exitCode === 0, output };
         }),
     }),
@@ -123,7 +129,8 @@ export function createWorkerRestackTools(options: RestackToolOptions) {
           if (store.stackWriteOwners.get(pr.stackId) !== pr.identity.number) {
             throw new Error("Worker does not hold the stack write lease");
           }
-          invalidateInheritedWipInspection({ store, pr });
+          await requireCurrentInheritedWipInspection(options);
+          invalidateInheritedWipInspection(options);
           store.completedRestacks.delete(pr.identity.number);
           const result = await environment.continueRestack(
             pr,
@@ -132,9 +139,13 @@ export function createWorkerRestackTools(options: RestackToolOptions) {
           );
           const output = `${result.stdout}\n${result.stderr}`.trim();
           if (result.exitCode !== 0 && !/conflict/i.test(output)) {
+            store.activeRestacks.delete(pr.identity.number);
             throw new Error(`git-spice rebase continue failed: ${output}`);
           }
-          if (result.exitCode === 0) await recordCompletedRestack(options);
+          if (result.exitCode === 0) {
+            store.activeRestacks.delete(pr.identity.number);
+            await recordCompletedRestack(options);
+          }
           return { completed: result.exitCode === 0, output };
         }),
     }),

--- a/packages/pr-fleet-controller/src/worker-restack-tools.ts
+++ b/packages/pr-fleet-controller/src/worker-restack-tools.ts
@@ -62,17 +62,42 @@ async function recordCompletedRestack(
 async function isRebaseInProgress(
   options: RestackToolOptions,
 ): Promise<boolean> {
-  const result = await options.environment.runLocalCommand({
-    executable: "git",
-    args: ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"],
-    cwd: options.worktree,
-    timeoutMs: 30_000,
-    signal: options.signal,
-    maxOutputBytes: 1024,
-  });
-  if (result.exitCode === 0) return true;
-  if (result.exitCode === 1) return false;
-  throw new Error(`Failed to inspect active rebase state: ${result.stderr}`);
+  for (const controlDirectory of ["rebase-merge", "rebase-apply"]) {
+    const pathResult = await options.environment.runLocalCommand({
+      executable: "git",
+      args: ["rev-parse", "--git-path", controlDirectory],
+      cwd: options.worktree,
+      timeoutMs: 30_000,
+      signal: options.signal,
+      maxOutputBytes: 1024,
+    });
+    if (pathResult.exitCode !== 0 || pathResult.stdoutTruncated === true) {
+      throw new Error(
+        `Failed to resolve ${controlDirectory} rebase control path: ${pathResult.stderr}`,
+      );
+    }
+    const controlPath = pathResult.stdout.trim();
+    if (controlPath.length === 0) {
+      throw new Error(
+        `Git returned an empty ${controlDirectory} rebase control path`,
+      );
+    }
+    const directoryResult = await options.environment.runLocalCommand({
+      executable: "test",
+      args: ["-d", controlPath],
+      cwd: options.worktree,
+      timeoutMs: 30_000,
+      signal: options.signal,
+      maxOutputBytes: 1024,
+    });
+    if (directoryResult.exitCode === 0) return true;
+    if (directoryResult.exitCode !== 1) {
+      throw new Error(
+        `Failed to inspect ${controlDirectory} rebase control state: ${directoryResult.stderr}`,
+      );
+    }
+  }
+  return false;
 }
 
 async function requireCurrentCompletedRestack(

--- a/packages/pr-fleet-controller/src/worker-restack-tools.ts
+++ b/packages/pr-fleet-controller/src/worker-restack-tools.ts
@@ -98,18 +98,22 @@ export function createWorkerRestackTools(options: RestackToolOptions) {
           invalidateInheritedWipInspection(options);
           store.completedRestacks.delete(pr.identity.number);
           store.activeRestacks.add(pr.identity.number);
-          const result = await environment.startRestack(pr, signal);
-          const output = `${result.stdout}\n${result.stderr}`.trim();
-          if (result.exitCode !== 0 && !/conflict/i.test(output)) {
+          try {
+            const result = await environment.startRestack(pr, signal);
+            const output = `${result.stdout}\n${result.stderr}`.trim();
+            if (result.exitCode !== 0 && !/conflict/i.test(output)) {
+              throw new Error(`git-spice restack failed: ${output}`);
+            }
+            if (result.exitCode === 0) {
+              store.activeRestacks.delete(pr.identity.number);
+              await recordCompletedRestack(options);
+            }
+            return { completed: result.exitCode === 0, output };
+          } catch (error) {
             store.activeRestacks.delete(pr.identity.number);
             store.releaseLease(pr.identity.number, "stack-write", pr.stackId);
-            throw new Error(`git-spice restack failed: ${output}`);
+            throw error;
           }
-          if (result.exitCode === 0) {
-            store.activeRestacks.delete(pr.identity.number);
-            await recordCompletedRestack(options);
-          }
-          return { completed: result.exitCode === 0, output };
         }),
     }),
     continue_restack: createTool({

--- a/packages/pr-fleet-controller/src/worker-restack-tools.ts
+++ b/packages/pr-fleet-controller/src/worker-restack-tools.ts
@@ -5,7 +5,7 @@ import {
   invalidateInheritedWipInspection,
   requireCurrentInheritedWipInspection,
 } from "./inherited-wip.ts";
-import type { FleetEnvironment } from "./ports.ts";
+import type { CommandResult, FleetEnvironment } from "./ports.ts";
 import type { PrState } from "./schemas.ts";
 import type { FleetStore } from "./state.ts";
 
@@ -25,9 +25,10 @@ type RestackToolOptions = {
   assertNotWaitingForAnswer: () => void;
 };
 
-async function recordCompletedRestack(
+async function captureLocalHead(
   options: RestackToolOptions,
-): Promise<void> {
+  purpose: string,
+): Promise<string> {
   const result = await options.environment.runLocalCommand({
     executable: "git",
     args: ["rev-parse", "HEAD"],
@@ -37,14 +38,41 @@ async function recordCompletedRestack(
     maxOutputBytes: 1024,
   });
   if (result.exitCode !== 0 || result.stdoutTruncated === true) {
-    throw new Error(
-      `Failed to capture completed restack HEAD: ${result.stderr}`,
-    );
+    throw new Error(`Failed to capture ${purpose} HEAD: ${result.stderr}`);
   }
+  return result.stdout.trim();
+}
+
+async function recordActiveRestack(options: RestackToolOptions): Promise<void> {
+  options.store.activeRestacks.set(options.pr.identity.number, {
+    remoteHeadSha: options.pr.identity.headSha,
+    localHeadSha: await captureLocalHead(options, "active restack"),
+  });
+}
+
+async function recordCompletedRestack(
+  options: RestackToolOptions,
+): Promise<void> {
   options.store.completedRestacks.set(options.pr.identity.number, {
     remoteHeadSha: options.pr.identity.headSha,
-    localHeadSha: result.stdout.trim(),
+    localHeadSha: await captureLocalHead(options, "completed restack"),
   });
+}
+
+async function isRebaseInProgress(
+  options: RestackToolOptions,
+): Promise<boolean> {
+  const result = await options.environment.runLocalCommand({
+    executable: "git",
+    args: ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"],
+    cwd: options.worktree,
+    timeoutMs: 30_000,
+    signal: options.signal,
+    maxOutputBytes: 1024,
+  });
+  if (result.exitCode === 0) return true;
+  if (result.exitCode === 1) return false;
+  throw new Error(`Failed to inspect active rebase state: ${result.stderr}`);
 }
 
 async function requireCurrentCompletedRestack(
@@ -97,23 +125,30 @@ export function createWorkerRestackTools(options: RestackToolOptions) {
           await requireCurrentInheritedWipInspection(options);
           invalidateInheritedWipInspection(options);
           store.completedRestacks.delete(pr.identity.number);
-          store.activeRestacks.add(pr.identity.number);
+          await recordActiveRestack(options);
+          let result: CommandResult;
           try {
-            const result = await environment.startRestack(pr, signal);
-            const output = `${result.stdout}\n${result.stderr}`.trim();
-            if (result.exitCode !== 0 && !/conflict/i.test(output)) {
-              throw new Error(`git-spice restack failed: ${output}`);
-            }
-            if (result.exitCode === 0) {
-              store.activeRestacks.delete(pr.identity.number);
-              await recordCompletedRestack(options);
-            }
-            return { completed: result.exitCode === 0, output };
+            result = await environment.startRestack(pr, signal);
           } catch (error) {
             store.activeRestacks.delete(pr.identity.number);
             store.releaseLease(pr.identity.number, "stack-write", pr.stackId);
             throw error;
           }
+          const output = `${result.stdout}\n${result.stderr}`.trim();
+          if (await isRebaseInProgress(options)) {
+            await recordActiveRestack(options);
+            if (result.exitCode !== 0 && !/conflict/i.test(output)) {
+              throw new Error(`git-spice restack failed: ${output}`);
+            }
+            return { completed: false, output };
+          }
+          store.activeRestacks.delete(pr.identity.number);
+          if (result.exitCode !== 0) {
+            store.releaseLease(pr.identity.number, "stack-write", pr.stackId);
+            throw new Error(`git-spice restack failed: ${output}`);
+          }
+          await recordCompletedRestack(options);
+          return { completed: true, output };
         }),
     }),
     continue_restack: createTool({
@@ -142,15 +177,19 @@ export function createWorkerRestackTools(options: RestackToolOptions) {
             signal,
           );
           const output = `${result.stdout}\n${result.stderr}`.trim();
-          if (result.exitCode !== 0 && !/conflict/i.test(output)) {
-            store.activeRestacks.delete(pr.identity.number);
+          if (await isRebaseInProgress(options)) {
+            await recordActiveRestack(options);
+            if (result.exitCode !== 0 && !/conflict/i.test(output)) {
+              throw new Error(`git-spice rebase continue failed: ${output}`);
+            }
+            return { completed: false, output };
+          }
+          store.activeRestacks.delete(pr.identity.number);
+          if (result.exitCode !== 0) {
             throw new Error(`git-spice rebase continue failed: ${output}`);
           }
-          if (result.exitCode === 0) {
-            store.activeRestacks.delete(pr.identity.number);
-            await recordCompletedRestack(options);
-          }
-          return { completed: result.exitCode === 0, output };
+          await recordCompletedRestack(options);
+          return { completed: true, output };
         }),
     }),
     publish_restack: createTool({

--- a/packages/pr-fleet-controller/src/worker-wip-tools.ts
+++ b/packages/pr-fleet-controller/src/worker-wip-tools.ts
@@ -218,12 +218,24 @@ export function createWorkerWipTools(options: {
           let localCommits = "No ahead-of-remote inherited commits.";
           let localCommitEvidenceComplete = true;
           const context = pr.worktreeContext;
-          if (context !== null && wip.localHeadSha !== context.localHeadSha) {
+          const restackInProgress = store.activeRestacks.has(
+            pr.identity.number,
+          );
+          if (
+            !restackInProgress &&
+            context !== null &&
+            wip.localHeadSha !== context.localHeadSha
+          ) {
             throw new Error(
               "Local HEAD changed after inherited work was captured; inspect again",
             );
           }
-          if (context?.relation === "ahead") {
+          if (restackInProgress) {
+            localCommits =
+              "Restack in progress; inherited commit publication is disabled until it completes.";
+            localCommitEvidenceComplete = false;
+            store.inheritedCommitInspections.delete(pr.identity.number);
+          } else if (context?.relation === "ahead") {
             const inheritedRange = `${pr.identity.headSha}..HEAD`;
             const commitLog = await runGit(environment, worktree, signal, [
               "log",

--- a/packages/pr-fleet-controller/test/environment.test.ts
+++ b/packages/pr-fleet-controller/test/environment.test.ts
@@ -98,6 +98,22 @@ class CapturingCommandFleetEnvironment extends StubCommandFleetEnvironment {
 
 class RestackPublishingEnvironment extends CommandFleetEnvironment {
   published = false;
+  continued = false;
+
+  override continueRestack(): Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    termination: "exit";
+  }> {
+    this.continued = true;
+    return Promise.resolve({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      termination: "exit",
+    });
+  }
 
   override publishRestack(pr: PrState): Promise<{ headSha: string }> {
     this.published = true;
@@ -475,8 +491,12 @@ test("restack publication revalidates its captured head and clean worktree", asy
       assertNotWaitingForAnswer: () => null,
     });
     const publishRestack = tools.publish_restack.execute;
+    const continueRestack = tools.continue_restack.execute;
     if (publishRestack === undefined) {
       throw new Error("publish restack tool has no executor");
+    }
+    if (continueRestack === undefined) {
+      throw new Error("continue restack tool has no executor");
     }
     const armPublication = () => {
       store.requestLease(pr, "stack-write");
@@ -485,6 +505,33 @@ test("restack publication revalidates its captured head and clean worktree", asy
         localHeadSha: headSha,
       });
     };
+
+    store.requestLease(pr, "stack-write");
+    store.activeRestacks.add(pr.identity.number);
+    await expect(
+      continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve }),
+    ).rejects.toThrow(/inspect again/);
+    expect(environment.continued).toBe(false);
+    const inspected = await collectInheritedWipEvidence({
+      environment,
+      worktree: directory,
+      signal: new AbortController().signal,
+    });
+    store.inheritedWipInspections.set(pr.identity.number, {
+      remoteHeadSha: headSha,
+      localHeadSha: inspected.localHeadSha,
+      fingerprint: inspected.fingerprint,
+      complete: true,
+    });
+    await Bun.write(path.join(directory, "tracked.txt"), "late edit\n");
+    await expect(
+      continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve }),
+    ).rejects.toThrow(/differs from the complete inspection/);
+    expect(environment.continued).toBe(false);
+    await Bun.write(path.join(directory, "tracked.txt"), "base\n");
+    await continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve });
+    expect(environment.continued).toBe(true);
+    expect(store.activeRestacks.has(pr.identity.number)).toBe(false);
 
     armPublication();
     await publishRestack({}, { observe: noopObserve });

--- a/packages/pr-fleet-controller/test/environment.test.ts
+++ b/packages/pr-fleet-controller/test/environment.test.ts
@@ -15,6 +15,7 @@ import { settleEvidenceParts } from "@shepherdjerred/pr-fleet-controller/src/env
 import { collectInheritedWipEvidence } from "@shepherdjerred/pr-fleet-controller/src/inherited-wip.ts";
 import type {
   CommandRequest,
+  CommandResult,
   FleetTelemetry,
 } from "@shepherdjerred/pr-fleet-controller/src/ports.ts";
 import type {
@@ -98,32 +99,66 @@ class CapturingCommandFleetEnvironment extends StubCommandFleetEnvironment {
 
 class RestackPublishingEnvironment extends CommandFleetEnvironment {
   readonly startFailure = new Error("restack startup failed");
+  startResult: CommandResult | null = null;
+  continueResult: CommandResult = commandResult(0, "");
+  rebaseInProgress = false;
   published = false;
   continued = false;
 
-  override startRestack(): Promise<never> {
-    return Promise.reject(this.startFailure);
+  override runLocalCommand(request: CommandRequest): Promise<CommandResult> {
+    if (
+      request.executable === "git" &&
+      request.args.join("\0") ===
+        ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"].join("\0")
+    ) {
+      return Promise.resolve({
+        exitCode: this.rebaseInProgress ? 0 : 1,
+        stdout: "",
+        stderr: "",
+        termination: "exit",
+      });
+    }
+    return super.runLocalCommand(request);
   }
 
-  override continueRestack(): Promise<{
-    exitCode: number;
-    stdout: string;
-    stderr: string;
-    termination: "exit";
-  }> {
+  override startRestack(): Promise<CommandResult> {
+    return this.startResult === null
+      ? Promise.reject(this.startFailure)
+      : Promise.resolve(this.startResult);
+  }
+
+  override continueRestack(): Promise<CommandResult> {
     this.continued = true;
-    return Promise.resolve({
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      termination: "exit",
-    });
+    return Promise.resolve(this.continueResult);
   }
 
   override publishRestack(pr: PrState): Promise<{ headSha: string }> {
     this.published = true;
     return Promise.resolve({ headSha: pr.identity.headSha });
   }
+}
+
+function commandResult(exitCode: number, stderr: string): CommandResult {
+  return { exitCode, stdout: "", stderr, termination: "exit" };
+}
+
+async function recordCompleteInheritedWipInspection(options: {
+  store: FleetStore;
+  pr: PrState;
+  environment: RestackPublishingEnvironment;
+  worktree: string;
+}): Promise<void> {
+  const inspected = await collectInheritedWipEvidence({
+    environment: options.environment,
+    worktree: options.worktree,
+    signal: new AbortController().signal,
+  });
+  options.store.inheritedWipInspections.set(options.pr.identity.number, {
+    remoteHeadSha: options.pr.identity.headSha,
+    localHeadSha: inspected.localHeadSha,
+    fingerprint: inspected.fingerprint,
+    complete: true,
+  });
 }
 
 test("environment result persistence failures use the fatal capture boundary", async () => {
@@ -521,22 +556,64 @@ test("restack lifecycle cleans startup failures and revalidates publication", as
     expect(store.activeRestacks.has(pr.identity.number)).toBe(false);
     expect(store.stackWriteOwners.has(pr.stackId)).toBe(false);
 
-    store.requestLease(pr, "stack-write");
-    store.activeRestacks.add(pr.identity.number);
+    environment.startResult = commandResult(1, "CONFLICT in tracked.txt");
+    environment.rebaseInProgress = true;
+    await expect(startRestack({}, { observe: noopObserve })).resolves.toEqual({
+      completed: false,
+      output: "CONFLICT in tracked.txt",
+    });
+    expect(store.activeRestacks.get(pr.identity.number)).toEqual({
+      remoteHeadSha: headSha,
+      localHeadSha: headSha,
+    });
+
+    await runGit([
+      "-c",
+      "user.name=Test Operator",
+      "-c",
+      "user.email=operator@example.com",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "test: concurrent rebase head change",
+    ]);
+    await recordCompleteInheritedWipInspection({
+      store,
+      pr,
+      environment,
+      worktree: directory,
+    });
+    await expect(
+      continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve }),
+    ).rejects.toThrow(/HEAD changed after assignment/);
+    expect(environment.continued).toBe(false);
+
+    await runGit(["reset", "--hard", headSha]);
+    await recordCompleteInheritedWipInspection({
+      store,
+      pr,
+      environment,
+      worktree: directory,
+    });
+    environment.continueResult = commandResult(1, "commit hook failed");
+    await expect(
+      continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve }),
+    ).rejects.toThrow(/commit hook failed/);
+    expect(store.activeRestacks.get(pr.identity.number)).toEqual({
+      remoteHeadSha: headSha,
+      localHeadSha: headSha,
+    });
+
+    environment.continued = false;
     await expect(
       continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve }),
     ).rejects.toThrow(/inspect again/);
     expect(environment.continued).toBe(false);
-    const inspected = await collectInheritedWipEvidence({
+    await recordCompleteInheritedWipInspection({
+      store,
+      pr,
       environment,
       worktree: directory,
-      signal: new AbortController().signal,
-    });
-    store.inheritedWipInspections.set(pr.identity.number, {
-      remoteHeadSha: headSha,
-      localHeadSha: inspected.localHeadSha,
-      fingerprint: inspected.fingerprint,
-      complete: true,
     });
     await Bun.write(path.join(directory, "tracked.txt"), "late edit\n");
     await expect(
@@ -544,6 +621,8 @@ test("restack lifecycle cleans startup failures and revalidates publication", as
     ).rejects.toThrow(/differs from the complete inspection/);
     expect(environment.continued).toBe(false);
     await Bun.write(path.join(directory, "tracked.txt"), "base\n");
+    environment.continueResult = commandResult(0, "");
+    environment.rebaseInProgress = false;
     await continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve });
     expect(environment.continued).toBe(true);
     expect(store.activeRestacks.has(pr.identity.number)).toBe(false);

--- a/packages/pr-fleet-controller/test/environment.test.ts
+++ b/packages/pr-fleet-controller/test/environment.test.ts
@@ -102,6 +102,7 @@ class RestackPublishingEnvironment extends CommandFleetEnvironment {
   startResult: CommandResult | null = null;
   continueResult: CommandResult = commandResult(0, "");
   rebaseInProgress = false;
+  rebaseHeadExists = false;
   published = false;
   continued = false;
 
@@ -110,6 +111,18 @@ class RestackPublishingEnvironment extends CommandFleetEnvironment {
       request.executable === "git" &&
       request.args.join("\0") ===
         ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"].join("\0")
+    ) {
+      return Promise.resolve({
+        exitCode: this.rebaseHeadExists ? 0 : 1,
+        stdout: "",
+        stderr: "",
+        termination: "exit",
+      });
+    }
+    if (
+      request.executable === "test" &&
+      request.args[0] === "-d" &&
+      request.args[1]?.endsWith("rebase-merge")
     ) {
       return Promise.resolve({
         exitCode: this.rebaseInProgress ? 0 : 1,
@@ -558,6 +571,7 @@ test("restack lifecycle cleans startup failures and revalidates publication", as
 
     environment.startResult = commandResult(1, "CONFLICT in tracked.txt");
     environment.rebaseInProgress = true;
+    environment.rebaseHeadExists = true;
     await expect(startRestack({}, { observe: noopObserve })).resolves.toEqual({
       completed: false,
       output: "CONFLICT in tracked.txt",
@@ -623,7 +637,11 @@ test("restack lifecycle cleans startup failures and revalidates publication", as
     await Bun.write(path.join(directory, "tracked.txt"), "base\n");
     environment.continueResult = commandResult(0, "");
     environment.rebaseInProgress = false;
-    await continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve });
+    // Git can retain REBASE_HEAD after the control directory is removed.
+    environment.rebaseHeadExists = true;
+    await expect(
+      continueRestack({ paths: ["tracked.txt"] }, { observe: noopObserve }),
+    ).resolves.toEqual({ completed: true, output: "" });
     expect(environment.continued).toBe(true);
     expect(store.activeRestacks.has(pr.identity.number)).toBe(false);
 

--- a/packages/pr-fleet-controller/test/environment.test.ts
+++ b/packages/pr-fleet-controller/test/environment.test.ts
@@ -97,8 +97,13 @@ class CapturingCommandFleetEnvironment extends StubCommandFleetEnvironment {
 }
 
 class RestackPublishingEnvironment extends CommandFleetEnvironment {
+  readonly startFailure = new Error("restack startup failed");
   published = false;
   continued = false;
+
+  override startRestack(): Promise<never> {
+    return Promise.reject(this.startFailure);
+  }
 
   override continueRestack(): Promise<{
     exitCode: number;
@@ -417,7 +422,7 @@ test("inherited WIP keeps untracked contents out of evidence and bounds diffs", 
   }
 });
 
-test("restack publication revalidates its captured head and clean worktree", async () => {
+test("restack lifecycle cleans startup failures and revalidates publication", async () => {
   const directory = await mkdtemp(path.join(tmpdir(), "pr-fleet-restack-"));
   const runGit = async (args: string[]): Promise<string> => {
     const process = Bun.spawn(["git", ...args], {
@@ -490,8 +495,12 @@ test("restack publication revalidates its captured head and clean worktree", asy
       record: (_tool, _input, run) => run(),
       assertNotWaitingForAnswer: () => null,
     });
+    const startRestack = tools.start_restack.execute;
     const publishRestack = tools.publish_restack.execute;
     const continueRestack = tools.continue_restack.execute;
+    if (startRestack === undefined) {
+      throw new Error("start restack tool has no executor");
+    }
     if (publishRestack === undefined) {
       throw new Error("publish restack tool has no executor");
     }
@@ -505,6 +514,12 @@ test("restack publication revalidates its captured head and clean worktree", asy
         localHeadSha: headSha,
       });
     };
+
+    await expect(startRestack({}, { observe: noopObserve })).rejects.toBe(
+      environment.startFailure,
+    );
+    expect(store.activeRestacks.has(pr.identity.number)).toBe(false);
+    expect(store.stackWriteOwners.has(pr.stackId)).toBe(false);
 
     store.requestLease(pr, "stack-write");
     store.activeRestacks.add(pr.identity.number);

--- a/packages/pr-fleet-controller/test/operator-head-races.test.ts
+++ b/packages/pr-fleet-controller/test/operator-head-races.test.ts
@@ -44,6 +44,38 @@ function waitingState(prNumber: number) {
   return { pr, state };
 }
 
+function waitingRequest(prNumber: number, headSha: string, generation: number) {
+  return OperatorInputRequestSchema.parse({
+    id: `question-${String(prNumber)}`,
+    pr: prNumber,
+    headSha,
+    generation,
+    context: "The current head needs an ownership decision.",
+    questions: [
+      {
+        id: "ownership",
+        header: "Ownership",
+        question: "Should this change be included?",
+        options: [
+          {
+            id: "include",
+            label: "Include it",
+            description: "It matches the PR head.",
+            recommended: true,
+          },
+          {
+            id: "exclude",
+            label: "Exclude it",
+            description: "It belongs elsewhere.",
+            recommended: false,
+          },
+        ],
+      },
+    ],
+    createdAt: "2026-08-08T20:00:00.000Z",
+  });
+}
+
 test("a mid-refresh head move makes stale state non-dispatchable and cancels its worker", () => {
   const { pr, state } = waitingState(74);
   const actionable = {
@@ -74,35 +106,7 @@ test("a mid-refresh head move makes stale state non-dispatchable and cancels its
 
 test("an answer is rejected when the remote head moved before reconciliation", async () => {
   const { pr, state } = waitingState(75);
-  const request = OperatorInputRequestSchema.parse({
-    id: "question-75",
-    pr: pr.number,
-    headSha: pr.headSha,
-    generation: state.agentGeneration,
-    context: "The old head needs an ownership decision.",
-    questions: [
-      {
-        id: "ownership",
-        header: "Ownership",
-        question: "Should the old-head change be included?",
-        options: [
-          {
-            id: "include",
-            label: "Include it",
-            description: "It matches the old PR head.",
-            recommended: true,
-          },
-          {
-            id: "exclude",
-            label: "Exclude it",
-            description: "It belongs elsewhere.",
-            recommended: false,
-          },
-        ],
-      },
-    ],
-    createdAt: "2026-08-08T20:00:00.000Z",
-  });
+  const request = waitingRequest(pr.number, pr.headSha, state.agentGeneration);
   const store = new FleetStore(1);
   store.prs.set(pr.number, { ...state, operatorRequest: request });
   store.operatorRequests.set(pr.number, request);
@@ -134,5 +138,44 @@ test("an answer is rejected when the remote head moved before reconciliation", a
 
   expect(store.operatorRequests.get(pr.number)?.id).toBe(request.id);
   expect(store.workerGuidance.has(pr.number)).toBe(false);
+  expect(reconciliationQueued).toBe(false);
+});
+
+test("an answer finishing after shutdown begins cannot mutate operator state", async () => {
+  const { pr, state } = waitingState(76);
+  const request = waitingRequest(pr.number, pr.headSha, state.agentGeneration);
+  const store = new FleetStore(1);
+  store.prs.set(pr.number, { ...state, operatorRequest: request });
+  store.operatorRequests.set(pr.number, request);
+  const headLookup = Promise.withResolvers<string | null>();
+  let reconciliationQueued = false;
+  const acceptance = acceptOperatorAnswer(
+    {
+      requestId: request.id,
+      answers: [
+        {
+          questionId: "ownership",
+          optionId: "include",
+          freeText: null,
+        },
+      ],
+    },
+    {
+      store,
+      telemetry: new ControllerTelemetry(),
+      observer,
+      currentPrHead: () => headLookup.promise,
+      queueReconciliation: () => {
+        reconciliationQueued = true;
+      },
+    },
+  );
+  store.stopping = true;
+  headLookup.resolve(pr.headSha);
+
+  await expect(acceptance).rejects.toThrow(/stopping/);
+  expect(store.operatorRequests.get(pr.number)?.id).toBe(request.id);
+  expect(store.workerGuidance.has(pr.number)).toBe(false);
+  expect(store.prs.get(pr.number)?.operatorRequest?.id).toBe(request.id);
   expect(reconciliationQueued).toBe(false);
 });


### PR DESCRIPTION
## Summary

- revalidate inherited conflict work immediately before continuing a restack
- track active restacks so publication cannot use incomplete conflict state
- reject operator answers that finish after controller shutdown begins

Follow-up to #2028, which was merged before its final two hosted-review findings were published.

## Verification

- `bunx turbo run build typecheck test lint --filter=@shepherdjerred/pr-fleet-controller --filter=@shepherdjerred/pr-fleet-web --force`
- 247 controller tests passed
- 7 dashboard tests passed
- staged pre-commit checks passed