### PR TITLE
fix(homelab): verify root prune against exact revision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,12 +71,14 @@ sandbox/                        # Personal scratch (not shipped, excluded from m
 
 ### ArgoCD root prune safety
 
-The homelab CI reconcile script must validate every root `apps` child that
-ArgoCD reports with `requiresPruning: true` before running a pruned sync. The
-child must use the `ci.sjer.red/application-lifecycle: cascade` annotation and
-the Argo resources finalizer. An `OutOfSync` child without
-`requiresPruning: true` may be retained intentionally and is not itself a
-prune candidate.
+The homelab CI reconcile script must require an exact root `apps` chart
+revision and render that revision before running a pruned sync. Compare the
+root's tracked `Application` resources to that rendered source; every live
+child absent from the exact desired revision is a prune candidate and must use
+the `ci.sjer.red/application-lifecycle: cascade` annotation plus the Argo
+resources finalizer. Do not classify candidates from `OutOfSync` or
+`requiresPruning` alone: the selective manifest-override sync temporarily
+marks unselected retained children as requiring prune.
 
 ## Code Review Rules
 

--- a/packages/docs/todos/post-merge-prune-jellyfin-minecraft.md
+++ b/packages/docs/todos/post-merge-prune-jellyfin-minecraft.md
@@ -13,13 +13,14 @@ origin: log-2026-07-27-homelab-cleanup-floor-heat
 PR #1747 removed Jellyfin and the five modded Minecraft servers
 (allthemons, stoneblock4, bettermc, allofcreate, ftbskies2) from cdk8s and
 OpenTofu. Auto-deletion on merge covers only the DNS records (CI `tofu apply`)
-and any remaining app-of-apps resources (`argocd.ts sync apps --prune`). The
-Minecraft Applications, workloads, PVCs, secrets, and ZFS datasets were
-deleted live on 2026-07-28. The merge-time app-of-apps prune removed the five
-empty namespaces. The five remaining `Released` PV API objects were deleted
-later that day; no retired Minecraft storage objects remain in Kubernetes.
-The Jellyfin workload, Service, ingress/proxy, binding, and PVC objects are also
-gone. Two Released PV records and their Ready OpenEBS ZFSVolume datasets remain.
+and any remaining app-of-apps resources
+(`argocd.ts sync apps --revision <exact-build-revision> --prune`). The Minecraft
+Applications, workloads, PVCs, secrets, and ZFS datasets were deleted live on
+2026-07-28. The merge-time app-of-apps prune removed the five empty namespaces.
+The five remaining `Released` PV API objects were deleted later that day; no
+retired Minecraft storage objects remain in Kubernetes. The Jellyfin workload,
+Service, ingress/proxy, binding, and PVC objects are also gone. Two Released PV
+records and their Ready OpenEBS ZFSVolume datasets remain.
 
 ## Remaining
 

--- a/packages/dotfiles/dot_agents/skills/argocd-app-patterns/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-app-patterns/SKILL.md
@@ -132,13 +132,13 @@ syncPolicy: {
 
 ### Root Application Prune Safety
 
-The homelab CI reconcile script validates the root `apps` Application before
-using prune. ArgoCD identifies a removed child with `requiresPruning: true`,
-even when its resource status is `OutOfSync`; status alone is not a prune
-signal. Every such child must have the
-`ci.sjer.red/application-lifecycle: cascade` annotation and Argo's resources
-finalizer. Retained children may remain `OutOfSync` without being treated as
-prune candidates.
+The homelab CI reconcile script requires an exact root `apps` chart revision
+and renders that revision before using prune. It compares the root's tracked
+`Application` resources to the exact desired manifest set. Every live child
+absent from that set must have the `ci.sjer.red/application-lifecycle: cascade`
+annotation and Argo's resources finalizer. Do not classify candidates from
+`OutOfSync` or `requiresPruning` alone: the selective manifest-override sync
+temporarily marks unselected retained children as requiring prune.
 
 ### Server-Side Apply (Large Configs)
 

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -9,7 +9,8 @@
  * timeouts are preserved.
  *
  * Usage:
- *   bun packages/homelab/scripts/argocd.ts sync <app> [--revision <v>] [--prune] [--async] [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts sync <app> [--revision <v>]
+ *       [--prune] [--async] [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts delete-application <app> \
  *       --project <project> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts health-wait <app> [--timeout <s>] [--dry-run]
@@ -190,7 +191,8 @@ async function getApplicationManifests(
   if (!response.ok) {
     const body = (await response.text()).slice(0, 1024);
     throw new Error(
-      `Could not render ${appName} from ${manifestsUrl.toString()}: HTTP ${response.status.toString()}\n${body}`,
+      `Could not render ${appName} from ${manifestsUrl.toString()}: ` +
+        `HTTP ${response.status.toString()}\n${body}`,
     );
   }
   return ManifestResponseSchema.parse(await response.json()).manifests;
@@ -777,7 +779,7 @@ function usage(): never {
   console.error(
     "Usage:\n" +
       "  bun packages/homelab/scripts/argocd.ts sync <app> " +
-      "[--prune] [--async] [--timeout <s>] [--dry-run]\n" +
+      "[--revision <v>] [--prune] [--async] [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts delete-application <app> " +
       "--project <project> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts health-wait <app> " +

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -9,7 +9,7 @@
  * timeouts are preserved.
  *
  * Usage:
- *   bun packages/homelab/scripts/argocd.ts sync <app> [--prune] [--async] [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts sync <app> [--revision <v>] [--prune] [--async] [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts delete-application <app> \
  *       --project <project> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts health-wait <app> [--timeout <s>] [--dry-run]
@@ -52,10 +52,12 @@ const DEFAULT_SYNC_TIMEOUT_S = 300;
 const DEFAULT_DELETION_TIMEOUT_S = 120;
 const POLL_INTERVAL_MS = 10_000;
 
+const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
+
 const ExpectedApplicationsSchema = z.array(
   z.object({
     name: z.string().min(1),
-    revision: z.string().regex(/^2\.0\.0-\d+$/),
+    revision: BuildRevisionSchema,
     prune: z.boolean().default(false),
   }),
 );
@@ -171,6 +173,29 @@ async function getApplications(token: string): Promise<unknown> {
   return response.json();
 }
 
+async function getApplicationManifests(
+  appName: string,
+  revision: string,
+  token: string,
+): Promise<readonly string[]> {
+  const manifestsUrl = new URL(
+    `/api/v1/applications/${encodeURIComponent(appName)}/manifests`,
+    serverUrl(),
+  );
+  manifestsUrl.searchParams.set("revision", revision);
+  const response = await fetch(manifestsUrl, {
+    headers: { Authorization: `Bearer ${token}` },
+    redirect: "follow",
+  });
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 1024);
+    throw new Error(
+      `Could not render ${appName} from ${manifestsUrl.toString()}: HTTP ${response.status.toString()}\n${body}`,
+    );
+  }
+  return ManifestResponseSchema.parse(await response.json()).manifests;
+}
+
 async function suspendRepositoryAutoSync(
   rootAppName: string,
   timeoutSeconds: number,
@@ -195,23 +220,12 @@ async function suspendRepositoryAutoSync(
     (latest, candidate) => (candidate.id > latest.id ? candidate : latest),
     firstDeployment,
   );
-  const manifestsUrl = new URL(
-    `/api/v1/applications/${encodeURIComponent(rootAppName)}/manifests`,
-    serverUrl(),
+  const manifests = await getApplicationManifests(
+    rootAppName,
+    latestDeployment.revision,
+    token,
   );
-  manifestsUrl.searchParams.set("revision", latestDeployment.revision);
-  const manifestsResponse = await fetch(manifestsUrl, {
-    headers: { Authorization: `Bearer ${token}` },
-    redirect: "follow",
-  });
-  if (!manifestsResponse.ok) {
-    const body = (await manifestsResponse.text()).slice(0, 1024);
-    throw new Error(
-      `Could not render ${rootAppName} from ${manifestsUrl.toString()}: HTTP ${manifestsResponse.status.toString()}\n${body}`,
-    );
-  }
-  const rendered = ManifestResponseSchema.parse(await manifestsResponse.json());
-  const suspended = rendered.manifests.flatMap((manifestSource) => {
+  const suspended = manifests.flatMap((manifestSource) => {
     const parsed = RenderedObjectSchema.parse(JSON.parse(manifestSource));
     if (parsed.kind !== "Application") {
       return [];
@@ -283,7 +297,22 @@ async function assertExpectedAppsRevisionIsLatest(
   }
 }
 
-async function assertRootPruneSafe(token: string): Promise<void> {
+async function assertRootPruneSafe(
+  token: string,
+  revision: string,
+): Promise<void> {
+  const exactRevision = BuildRevisionSchema.parse(revision);
+  const desiredChildren = new Set(
+    (await getApplicationManifests("apps", exactRevision, token)).flatMap(
+      (manifestSource) => {
+        const parsed = RenderedObjectSchema.parse(JSON.parse(manifestSource));
+        if (parsed.kind !== "Application") {
+          return [];
+        }
+        return [RenderedApplicationSchema.parse(parsed).metadata.name];
+      },
+    ),
+  );
   const root = await getApplication("apps", token);
   const status = isRecord(root["status"]) ? root["status"] : {};
   const resources = Array.isArray(status["resources"])
@@ -293,9 +322,9 @@ async function assertRootPruneSafe(token: string): Promise<void> {
     if (
       !isRecord(resource) ||
       resource["kind"] !== "Application" ||
-      resource["requiresPruning"] !== true ||
       typeof resource["name"] !== "string" ||
-      resource["name"] === "apps"
+      resource["name"] === "apps" ||
+      desiredChildren.has(resource["name"])
     ) {
       return [];
     }
@@ -361,7 +390,12 @@ async function sync(
   }
   const token = requireEnv("ARGOCD_TOKEN");
   if (appName === "apps" && options.prune) {
-    await assertRootPruneSafe(token);
+    if (options.revision === undefined) {
+      throw new Error(
+        "Root Application pruning requires an exact --revision so prune candidates can be verified against the rendered source",
+      );
+    }
+    await assertRootPruneSafe(token, options.revision);
   }
   const requestId = crypto.randomUUID();
   const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -172,6 +172,21 @@ test("Argo CD root pruning requires an exact revision", async () => {
   );
 });
 
+test("Argo CD CLI usage documents the root prune revision", async () => {
+  const process = Bun.spawn(["bun", "--no-install", "scripts/argocd.ts"], {
+    cwd: path.resolve(import.meta.dir, "../../.."),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain("sync <app> [--revision <v>] [--prune] [--async]");
+});
+
 describe("Argo CD root prune safety", () => {
   test("blocks root pruning when a pruning child lacks the cascade finalizer", async () => {
     let syncPosts = 0;

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -138,6 +138,40 @@ describe("Argo CD prune safety", () => {
   });
 });
 
+test("Argo CD root pruning requires an exact revision", async () => {
+  const process = Bun.spawn(
+    [
+      "bun",
+      "--no-install",
+      "scripts/argocd.ts",
+      "sync",
+      "apps",
+      "--prune",
+      "--timeout",
+      "1",
+    ],
+    {
+      cwd: path.resolve(import.meta.dir, "../../.."),
+      env: {
+        ...Bun.env,
+        ARGOCD_SERVER_URL: "http://127.0.0.1:1",
+        ARGOCD_TOKEN: "test-token",
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain(
+    "Root Application pruning requires an exact --revision",
+  );
+});
+
 describe("Argo CD root prune safety", () => {
   test("blocks root pruning when a pruning child lacks the cascade finalizer", async () => {
     let syncPosts = 0;
@@ -149,6 +183,12 @@ describe("Argo CD root prune safety", () => {
         if (request.method === "POST") {
           syncPosts++;
           return Response.json({});
+        }
+        if (
+          url.pathname === "/api/v1/applications/apps/manifests" &&
+          url.searchParams.get("revision") === "2.0.0-42"
+        ) {
+          return Response.json({ manifests: [] });
         }
         if (url.pathname === "/api/v1/applications/apps") {
           return Response.json({
@@ -186,6 +226,8 @@ describe("Argo CD root prune safety", () => {
           "scripts/argocd.ts",
           "sync",
           "apps",
+          "--revision",
+          "2.0.0-42",
           "--prune",
           "--timeout",
           "1",
@@ -214,7 +256,7 @@ describe("Argo CD root prune safety", () => {
     }
   });
 
-  test("ignores out-of-sync retained children when checking root pruning", async () => {
+  test("ignores stale prune signals for children present in the exact root revision", async () => {
     let syncPosts = 0;
     const server = Bun.serve({
       hostname: "127.0.0.1",
@@ -228,6 +270,27 @@ describe("Argo CD root prune safety", () => {
           syncPosts++;
           return Response.json({ operation: {} });
         }
+        if (
+          url.pathname === "/api/v1/applications/apps/manifests" &&
+          url.searchParams.get("revision") === "2.0.0-42"
+        ) {
+          return Response.json({
+            manifests: [
+              JSON.stringify({
+                apiVersion: "argoproj.io/v1alpha1",
+                kind: "Application",
+                metadata: { name: "argocd" },
+                spec: {
+                  source: {
+                    repoURL: "https://argoproj.github.io/argo-helm/",
+                    chart: "argo-cd",
+                    targetRevision: "9.0.0",
+                  },
+                },
+              }),
+            ],
+          });
+        }
         if (url.pathname === "/api/v1/applications/apps") {
           return Response.json({
             status: {
@@ -236,7 +299,7 @@ describe("Argo CD root prune safety", () => {
                   kind: "Application",
                   name: "argocd",
                   status: "OutOfSync",
-                  requiresPruning: false,
+                  requiresPruning: true,
                 },
               ],
             },
@@ -254,6 +317,8 @@ describe("Argo CD root prune safety", () => {
           "scripts/argocd.ts",
           "sync",
           "apps",
+          "--revision",
+          "2.0.0-42",
           "--prune",
           "--async",
           "--timeout",


### PR DESCRIPTION
## Summary

- require an exact `apps` chart revision before root pruning
- compare live tracked Applications with the rendered exact revision instead of ArgoCD's stale prune flags
- keep cascade annotation and finalizer checks for every genuine prune candidate
- document the invariant in the repository instructions and ArgoCD skill

## Root cause

The release workflow first performs a selective manifest-override sync to suspend repository-backed child Applications. ArgoCD retains that partial comparison and temporarily reports every unselected child as `requiresPruning: true`, including retained control-plane Applications. Main build 8584 reproduced 30 reported prune flags while the exact published `2.0.0-8584` source contained every live child, leaving zero actual prune candidates.

## Verification

- `bunx turbo run typecheck lint test --filter=homelab --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`
- read-only live comparison: 30 reported prune flags, 0 tracked children absent from exact revision `2.0.0-8584`
