### PR TITLE
fix(homelab): reconcile live release health

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1478,12 +1478,17 @@ steps:
       buildkite-agent artifact download "helm-release-plan.json" . --step helm-push
       buildkite-agent artifact download "argocd-release-expected.json" . --step helm-push
       deferred_discord_apps=$$(jq -r '[.selected[] | select(.name == "pokemon" or .name == "mario-kart") | .name] | join(",")' helm-release-plan.json)
+      apps_revision=$$(jq -er '.[] | select(.name == "apps") | .revision' argocd-release-expected.json)
+      # Apply the exact published child Application specs while keeping their
+      # repository auto-sync disabled. This makes new sync options and diff
+      # rules effective before child charts are reconciled, without exposing
+      # children to a partially published release.
+      bun --no-install packages/homelab/scripts/argocd.ts suspend-auto-sync apps --revision "$$apps_revision" --timeout 300
       if [ -n "$$deferred_discord_apps" ]; then
         bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --defer-apps "$$deferred_discord_apps" --skip-health-wait --timeout 300
       else
         bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --timeout 300
       fi
-      apps_revision=$$(jq -er '.[] | select(.name == "apps") | .revision' argocd-release-expected.json)
       # The root app owns every repository Application, so Argo's synchronous
       # health wait would block on unrelated stale children. The scoped
       # release-health-wait above is the authoritative gate for this release.

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -65,6 +65,7 @@ function validateReleaseSteps({
         "--filter homelab --filter '@homelab/cdk8s'",
         "concurrency_group: monorepo/homelab-release",
         'artifact download "argocd-release-expected.json"',
+        'suspend-auto-sync apps --revision "$$apps_revision"',
         "reconcile-release argocd-release-expected.json",
         'sync apps --revision "$$apps_revision" --prune --async',
       ],

--- a/packages/docs/wiki/astro.config.ts
+++ b/packages/docs/wiki/astro.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
         {
           items: [
             {
+              label: "Release pipeline",
+              link: "/homelab/releases/",
+            },
+            {
               label: "Plane issue tracker",
               link: "/homelab/plane/",
             },

--- a/packages/docs/wiki/src/content/docs/homelab/matomo.md
+++ b/packages/docs/wiki/src/content/docs/homelab/matomo.md
@@ -26,11 +26,15 @@ the site-release lane to deploy tracker changes.
 The archive sidecar disables browser-triggered archiving, configures the
 Cloudflare client-IP header, and runs `core:archive` every five minutes. A
 failed archive exits the sidecar so Kubernetes reports the pod as unhealthy.
+The official Matomo image keeps its root entrypoint so it can initialize the
+shared application volume, with privilege escalation disabled; the nginx
+public gate runs as its numeric non-root user.
 
 ## Audit checks
 
 - `argocd app get matomo` is `Synced` and `Healthy`.
-- Both Matomo containers and MariaDB are ready, with no restart loop.
+- The Matomo process, archive sidecar, public gate, and MariaDB are ready, with
+  no restart loop.
 - `curl -fsS https://matomo.sjer.red/matomo.js` succeeds after the marker is created.
 - The archive sidecar logs successful `core:archive` runs.
 - Matomo privacy settings keep IP anonymization, DNT support, no User IDs,

--- a/packages/docs/wiki/src/content/docs/homelab/plane.md
+++ b/packages/docs/wiki/src/content/docs/homelab/plane.md
@@ -27,7 +27,9 @@ flowchart LR
 
 - **Tailnet-only access.** The vendor chart's own ingress stays disabled because
   the cluster's Tailscale ingress supplies the private access boundary. It
-  routes Plane's path-based services without creating a public endpoint.
+  routes Plane's path-based services without creating a public endpoint. The
+  vendor services are headless, so the local chart provides narrow ClusterIP
+  adapters for the Tailscale operator rather than changing the vendor chart.
 - **State has two recovery paths.** PostgreSQL, Redis, RabbitMQ, and monitor
   state live on ZFS persistent volumes and are explicitly included in the
   Velero inventory. Attachments instead live in the private `plane-attachments`

--- a/packages/docs/wiki/src/content/docs/homelab/releases.md
+++ b/packages/docs/wiki/src/content/docs/homelab/releases.md
@@ -1,0 +1,40 @@
+---
+title: Homelab release pipeline
+description: Buildkite publishes immutable Helm revisions, reconciles child Applications while auto-sync is suspended, then restores the ArgoCD app tree through an exact root revision.
+---
+
+The main Buildkite pipeline is the only writer for repository-backed homelab
+releases. It publishes one immutable chart revision, applies that exact child
+Application inventory with auto-sync still disabled, and only then reconciles
+workloads and restores the root app tree.
+
+```mermaid
+sequenceDiagram
+  accTitle: Homelab release sequence
+  accDescr: Buildkite suspends floating auto-sync, publishes an immutable chart set, applies the exact child specifications while suspended, reconciles child workloads, and finally restores the exact root tree with safe pruning.
+  participant BK as Buildkite
+  participant CM as ChartMuseum
+  participant Root as apps Application
+  participant Child as child Applications
+
+  BK->>Root: suspend current repository auto-sync
+  BK->>CM: publish 2.0.0-build charts
+  BK->>Root: apply exact child specs, still suspended
+  BK->>Child: reconcile exact chart revisions
+  BK->>Root: sync exact revision with verified pruning
+  BK->>Child: require Synced and Healthy
+```
+
+The second suspended root apply is deliberate. New child-level safety settings
+must exist before those children sync, but enabling floating auto-sync before
+every chart is published could expose a partially published release.
+
+Root pruning does not trust ArgoCD's cached `OutOfSync` or `requiresPruning`
+flags. Selective manifest overrides can make those flags temporarily describe
+the override rather than the published tree. The release script renders the
+exact `apps` revision and treats only live child Applications absent from that
+rendered set as prune candidates; each candidate must still opt into cascading
+deletion and carry the Argo resources finalizer.
+
+The implementation lives in `.buildkite/pipeline.yml` and
+`packages/homelab/scripts/argocd.ts`.

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -15,6 +15,8 @@
  *       --project <project> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts health-wait <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts tree-health-wait <app> [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> \
+ *       [--revision <v>] [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts wait-deletion <app> \
  *       --group <g> --version <v> --kind <k> --namespace <ns> \
  *       [--timeout <s>] [--dry-run]
@@ -25,6 +27,7 @@
  */
 
 import { requireEnv, optionalEnv } from "../../../scripts/lib/run.ts";
+import { TransientError } from "../../../scripts/lib/transient-error.ts";
 import { runMain } from "../../../scripts/lib/transient.ts";
 import {
   applicationReadiness,
@@ -52,6 +55,9 @@ const DEFAULT_HEALTH_TIMEOUT_S = 300;
 const DEFAULT_SYNC_TIMEOUT_S = 300;
 const DEFAULT_DELETION_TIMEOUT_S = 120;
 const POLL_INTERVAL_MS = 10_000;
+const CHARTMUSEUM_MAX_ATTEMPTS = 3;
+const CHARTMUSEUM_REQUEST_TIMEOUT_MS = 10_000;
+const CHARTMUSEUM_RETRY_BASE_DELAY_MS = 100;
 
 const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
 
@@ -202,29 +208,32 @@ async function suspendRepositoryAutoSync(
   rootAppName: string,
   timeoutSeconds: number,
   dryRun: boolean,
+  revision: string | undefined,
 ): Promise<void> {
+  const exactRevision =
+    revision === undefined ? undefined : BuildRevisionSchema.parse(revision);
   console.log(
     `--- argocd suspend-auto-sync: repository Applications under ${rootAppName}${dryRun ? " (dry run)" : ""}`,
   );
   if (dryRun) {
     return;
   }
-  const token = requireEnv("ARGOCD_TOKEN");
-  const rootApplication = RootDeploymentHistorySchema.parse(
-    await getApplication(rootAppName, token),
-  );
-  const [firstDeployment, ...remainingDeployments] =
-    rootApplication.status.history;
-  if (firstDeployment === undefined) {
-    throw new Error(`${rootAppName} has no successful deployment history`);
+  if (exactRevision !== undefined) {
+    await assertExpectedAppsRevisionIsLatest(exactRevision, timeoutSeconds);
   }
-  const latestDeployment = remainingDeployments.reduce(
-    (latest, candidate) => (candidate.id > latest.id ? candidate : latest),
-    firstDeployment,
-  );
+  const token = requireEnv("ARGOCD_TOKEN");
+  const renderedRevision =
+    exactRevision === undefined
+      ? latestSuccessfulRevision(
+          rootAppName,
+          RootDeploymentHistorySchema.parse(
+            await getApplication(rootAppName, token),
+          ),
+        )
+      : exactRevision;
   const manifests = await getApplicationManifests(
     rootAppName,
-    latestDeployment.revision,
+    renderedRevision,
     token,
   );
   const suspended = manifests.flatMap((manifestSource) => {
@@ -277,17 +286,27 @@ async function suspendRepositoryAutoSync(
   }
 }
 
+function latestSuccessfulRevision(
+  rootAppName: string,
+  rootApplication: z.infer<typeof RootDeploymentHistorySchema>,
+): string {
+  const [firstDeployment, ...remainingDeployments] =
+    rootApplication.status.history;
+  if (firstDeployment === undefined) {
+    throw new Error(`${rootAppName} has no successful deployment history`);
+  }
+  return remainingDeployments.reduce(
+    (latest, candidate) => (candidate.id > latest.id ? candidate : latest),
+    firstDeployment,
+  ).revision;
+}
+
 async function assertExpectedAppsRevisionIsLatest(
   expectedRevision: string,
+  timeoutSeconds: number,
 ): Promise<void> {
   const url = `${chartMuseumOrigin()}/api/charts/apps`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    const body = (await response.text()).slice(0, 1024);
-    throw new Error(
-      `ChartMuseum inventory failed for apps: HTTP ${response.status.toString()}\n${body}`,
-    );
-  }
+  const response = await fetchChartMuseumInventory(url, timeoutSeconds);
   const latest = latestPublishedVersion(await response.json());
   if (latest === undefined) {
     throw new Error("ChartMuseum has no published apps release");
@@ -297,6 +316,60 @@ async function assertExpectedAppsRevisionIsLatest(
       `Refusing stale Argo release ${expectedRevision}: newest published apps revision is ${latest.version}`,
     );
   }
+}
+
+async function fetchChartMuseumInventory(
+  url: string,
+  timeoutSeconds: number,
+): Promise<Response> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let lastFailure = "request deadline expired";
+  let lastCause: unknown;
+  for (let attempt = 1; attempt <= CHARTMUSEUM_MAX_ATTEMPTS; attempt += 1) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    let response: Response | undefined;
+    try {
+      response = await fetch(url, {
+        signal: AbortSignal.timeout(
+          Math.min(CHARTMUSEUM_REQUEST_TIMEOUT_MS, remainingMs),
+        ),
+      });
+    } catch (error) {
+      lastCause = error;
+      lastFailure = error instanceof Error ? error.message : String(error);
+    }
+    if (response !== undefined) {
+      if (response.ok) {
+        return response;
+      }
+      const body = (await response.text()).slice(0, 1024);
+      lastFailure = `HTTP ${response.status.toString()}\n${body}`;
+      if (response.status !== 429 && response.status < 500) {
+        throw new Error(
+          `ChartMuseum inventory failed for apps: ${lastFailure}`,
+        );
+      }
+    }
+    if (attempt < CHARTMUSEUM_MAX_ATTEMPTS) {
+      const delayMs = Math.min(
+        CHARTMUSEUM_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+        Math.max(0, deadline - Date.now()),
+      );
+      if (delayMs > 0) {
+        console.warn(
+          `ChartMuseum inventory attempt ${attempt.toString()} failed; retrying in ${delayMs.toString()}ms`,
+        );
+        await Bun.sleep(delayMs);
+      }
+    }
+  }
+  throw new TransientError(
+    `ChartMuseum inventory failed for apps after ${CHARTMUSEUM_MAX_ATTEMPTS.toString()} attempts: ${lastFailure}`,
+    { cause: lastCause },
+  );
 }
 
 async function assertRootPruneSafe(
@@ -488,7 +561,10 @@ async function reconcileRelease(
   if (appsRelease === undefined) {
     throw new Error("Expected release inventory is missing the apps revision");
   }
-  await assertExpectedAppsRevisionIsLatest(appsRelease.revision);
+  await assertExpectedAppsRevisionIsLatest(
+    appsRelease.revision,
+    timeoutSeconds,
+  );
   const token = requireEnv("ARGOCD_TOKEN");
   // The release step submits the root Application sync asynchronously. Waiting
   // here would make every release depend on unrelated child Application health.
@@ -792,7 +868,7 @@ function usage(): never {
       "[--defer-apps <app,...>] [--skip-health-wait] " +
       "[--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> " +
-      "[--dry-run]\n" +
+      "[--revision <v>] [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts wait-deletion <app> " +
       "--group <g> --version <v> --kind <k> --namespace <ns> " +
       "[--timeout <s>] [--dry-run]",
@@ -908,6 +984,7 @@ async function main(): Promise<void> {
         app,
         timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
         dryRun,
+        flag(argv, "revision"),
       );
       return;
     case "wait-deletion": {

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -185,6 +185,9 @@ test("Argo CD CLI usage documents the root prune revision", async () => {
 
   expect(exitCode).not.toBe(0);
   expect(stderr).toContain("sync <app> [--revision <v>] [--prune] [--async]");
+  expect(stderr).toContain(
+    "suspend-auto-sync <root-app> [--revision <v>] [--timeout <s>]",
+  );
 });
 
 describe("Argo CD root prune safety", () => {
@@ -367,10 +370,11 @@ describe("Argo CD root prune safety", () => {
 });
 
 describe("Argo CD release gating", () => {
-  test("suspends repository auto-sync through an explicit root manifest sync", async () => {
+  test("suspends the exact published root revision before child reconciliation", async () => {
     const syncBodies: unknown[] = [];
     let requestedOperation: unknown;
     const renderedRevisions: (string | null)[] = [];
+    let chartMuseumRequests = 0;
     const repositoryApplication = JSON.stringify({
       apiVersion: "argoproj.io/v1alpha1",
       kind: "Application",
@@ -419,6 +423,19 @@ describe("Argo CD release gating", () => {
       port: 0,
       async fetch(request) {
         const url = new URL(request.url);
+        if (url.pathname === "/api/charts/apps") {
+          chartMuseumRequests += 1;
+          if (chartMuseumRequests < 3) {
+            return new Response("temporary upstream failure", { status: 503 });
+          }
+          return Response.json([
+            {
+              version: "2.0.0-43",
+              urls: ["charts/apps-2.0.0-43.tgz"],
+              digest: "a".repeat(64),
+            },
+          ]);
+        }
         if (
           request.method === "GET" &&
           url.pathname === "/api/v1/applications/apps/manifests"
@@ -471,6 +488,8 @@ describe("Argo CD release gating", () => {
           "scripts/argocd.ts",
           "suspend-auto-sync",
           "apps",
+          "--revision",
+          "2.0.0-43",
           "--timeout",
           "1",
         ],
@@ -480,6 +499,7 @@ describe("Argo CD release gating", () => {
             ...Bun.env,
             ARGOCD_SERVER_URL: server.url.origin,
             ARGOCD_TOKEN: "test-token",
+            CHARTMUSEUM_ORIGIN: server.url.origin,
           },
           stderr: "pipe",
           stdout: "pipe",
@@ -492,16 +512,24 @@ describe("Argo CD release gating", () => {
       ]);
 
       expect(exitCode).toBe(0);
-      expect(stderr).toBe("");
+      expect(stderr).toContain(
+        "ChartMuseum inventory attempt 1 failed; retrying in 100ms",
+      );
+      expect(stderr).toContain(
+        "ChartMuseum inventory attempt 2 failed; retrying in 200ms",
+      );
       expect(stdout).toContain("suspending auto-sync: worker");
-      expect(renderedRevisions).toEqual(["2.0.0-42"]);
+      expect(chartMuseumRequests).toBe(3);
+      expect(renderedRevisions).toEqual(["2.0.0-43"]);
       expect(syncBodies).toHaveLength(1);
       expectSuspendedWorkerRequest(syncBodies[0]);
     } finally {
       await server.stop(true);
     }
   });
+});
 
+describe("Argo CD stale release protection", () => {
   test("rejects an Argo reconcile after a newer apps chart is published", async () => {
     let argoRequests = 0;
     const server = Bun.serve({

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/plane.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/plane.ts
@@ -1,7 +1,10 @@
 import type { App } from "cdk8s";
 import { Chart } from "cdk8s";
 import { Namespace } from "cdk8s-plus-31";
-import { KubeIngress } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import {
+  KubeIngress,
+  KubeService,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import { registerBackendProbe } from "@shepherdjerred/homelab/cdk8s/src/misc/probe-registry.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
@@ -10,6 +13,38 @@ const PLANE_NAMESPACE = "plane";
 const PLANE_HOST = "plane";
 const PLANE_SECRET_NAME = "plane-secrets";
 const PLANE_ONEPASSWORD_ITEM = "plane-commercial-secrets";
+const planeIngressBackends = {
+  admin: {
+    serviceName: "plane-ingress-admin",
+    selector: "plane-plane-admin",
+    port: 3000,
+  },
+  api: {
+    serviceName: "plane-ingress-api",
+    selector: "plane-plane-api",
+    port: 8000,
+  },
+  live: {
+    serviceName: "plane-ingress-live",
+    selector: "plane-plane-live",
+    port: 3000,
+  },
+  silo: {
+    serviceName: "plane-ingress-silo",
+    selector: "plane-plane-silo",
+    port: 3000,
+  },
+  space: {
+    serviceName: "plane-ingress-space",
+    selector: "plane-plane-space",
+    port: 3000,
+  },
+  web: {
+    serviceName: "plane-ingress-web",
+    selector: "plane-plane-web",
+    port: 3000,
+  },
+} as const;
 
 export function createPlaneChart(app: App) {
   const chart = new Chart(app, "plane", {
@@ -41,6 +76,22 @@ export function createPlaneChart(app: App) {
     },
   });
 
+  // Plane's vendor chart exposes its HTTP workloads through headless Services.
+  // The Tailscale operator rejects headless backends, so give the ingress
+  // stable ClusterIP adapters while retaining the vendor selectors and ports.
+  for (const backend of Object.values(planeIngressBackends)) {
+    new KubeService(chart, `${backend.serviceName}-service`, {
+      metadata: {
+        name: backend.serviceName,
+        namespace: PLANE_NAMESPACE,
+      },
+      spec: {
+        selector: { "app.name": backend.selector },
+        ports: [{ port: backend.port }],
+      },
+    });
+  }
+
   // Plane's vendor chart only supports Traefik or nginx ingress. Route its
   // path-based services through the cluster's private Tailscale ingress
   // instead; the operator provisions HTTPS for the short hostname 'plane'.
@@ -60,63 +111,90 @@ export function createPlaneChart(app: App) {
                 path: "/spaces/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-space", port: { number: 3000 } },
+                  service: {
+                    name: planeIngressBackends.space.serviceName,
+                    port: { number: planeIngressBackends.space.port },
+                  },
                 },
               },
               {
                 path: "/god-mode/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-admin", port: { number: 3000 } },
+                  service: {
+                    name: planeIngressBackends.admin.serviceName,
+                    port: { number: planeIngressBackends.admin.port },
+                  },
                 },
               },
               {
                 path: "/api/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-api", port: { number: 8000 } },
+                  service: {
+                    name: planeIngressBackends.api.serviceName,
+                    port: { number: planeIngressBackends.api.port },
+                  },
                 },
               },
               {
                 path: "/auth/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-api", port: { number: 8000 } },
+                  service: {
+                    name: planeIngressBackends.api.serviceName,
+                    port: { number: planeIngressBackends.api.port },
+                  },
                 },
               },
               {
                 path: "/graphql/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-api", port: { number: 8000 } },
+                  service: {
+                    name: planeIngressBackends.api.serviceName,
+                    port: { number: planeIngressBackends.api.port },
+                  },
                 },
               },
               {
                 path: "/marketplace/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-api", port: { number: 8000 } },
+                  service: {
+                    name: planeIngressBackends.api.serviceName,
+                    port: { number: planeIngressBackends.api.port },
+                  },
                 },
               },
               {
                 path: "/live/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-live", port: { number: 3000 } },
+                  service: {
+                    name: planeIngressBackends.live.serviceName,
+                    port: { number: planeIngressBackends.live.port },
+                  },
                 },
               },
               {
                 path: "/silo/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-silo", port: { number: 3000 } },
+                  service: {
+                    name: planeIngressBackends.silo.serviceName,
+                    port: { number: planeIngressBackends.silo.port },
+                  },
                 },
               },
               {
                 path: "/",
                 pathType: "Prefix",
                 backend: {
-                  service: { name: "plane-web", port: { number: 3000 } },
+                  service: {
+                    name: planeIngressBackends.web.serviceName,
+                    port: { number: planeIngressBackends.web.port },
+                  },
                 },
               },
             ],

--- a/packages/homelab/src/cdk8s/src/resources/analytics/matomo.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/matomo.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { App } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { createMatomoChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/matomo.ts";
+
+const MatomoDeploymentSchema = z.object({
+  kind: z.literal("Deployment"),
+  metadata: z.object({
+    name: z.literal("matomo"),
+    annotations: z.object({
+      "ignore-check.kube-linter.io/run-as-non-root": z.string(),
+    }),
+  }),
+  spec: z.object({
+    template: z.object({
+      spec: z.object({
+        containers: z.array(
+          z.object({
+            name: z.string(),
+            securityContext: z.object({
+              runAsNonRoot: z.boolean(),
+              runAsUser: z.number().optional(),
+              runAsGroup: z.number().optional(),
+              allowPrivilegeEscalation: z.literal(false),
+            }),
+          }),
+        ),
+      }),
+    }),
+  }),
+});
+
+const PublicGateConfigSchema = z.object({
+  kind: z.literal("ConfigMap"),
+  metadata: z.object({ name: z.literal("matomo-matomo-public-gate-config") }),
+  data: z.object({ "nginx.conf": z.string() }),
+});
+
+describe("Matomo deployment", () => {
+  it("uses image-compatible identities without allowing privilege escalation", () => {
+    const app = new App();
+    createMatomoChart(app);
+    const documents = parseAllDocuments(app.synthYaml()).map((document) =>
+      document.toJS(),
+    );
+    const deployment = documents
+      .map((document) => MatomoDeploymentSchema.safeParse(document))
+      .find((result) => result.success);
+    const config = documents
+      .map((document) => PublicGateConfigSchema.safeParse(document))
+      .find((result) => result.success);
+    if (!deployment?.success || !config?.success) {
+      throw new Error("Matomo resources were not synthesized");
+    }
+
+    const securityContexts = Object.fromEntries(
+      deployment.data.spec.template.spec.containers.map((container) => [
+        container.name,
+        container.securityContext,
+      ]),
+    );
+    expect(securityContexts).toMatchObject({
+      matomo: { runAsNonRoot: false, allowPrivilegeEscalation: false },
+      "matomo-archive": {
+        runAsNonRoot: false,
+        allowPrivilegeEscalation: false,
+      },
+      "matomo-public-gate": {
+        runAsNonRoot: true,
+        runAsUser: 101,
+        runAsGroup: 101,
+        allowPrivilegeEscalation: false,
+      },
+    });
+    const nginxConfig = config.data.data["nginx.conf"];
+    expect(nginxConfig).toStartWith("pid /tmp/nginx.pid;");
+    for (const temporaryPath of [
+      "client_body_temp_path /tmp/client-body;",
+      "proxy_temp_path /tmp/proxy;",
+      "fastcgi_temp_path /tmp/fastcgi;",
+      "uwsgi_temp_path /tmp/uwsgi;",
+      "scgi_temp_path /tmp/scgi;",
+    ]) {
+      expect(nginxConfig).toContain(temporaryPath);
+    }
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/analytics/matomo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/matomo.ts
@@ -77,6 +77,8 @@ export function createMatomoDeployment(
     },
     metadata: {
       annotations: {
+        "ignore-check.kube-linter.io/run-as-non-root":
+          "The official Matomo Apache image requires its root entrypoint to initialize the shared application volume",
         "ignore-check.kube-linter.io/no-read-only-root-fs":
           "Matomo requires a writable application volume for config and plugins",
       },
@@ -106,8 +108,14 @@ export function createMatomoDeployment(
   );
   const publicGateConfig = new ConfigMap(chart, "matomo-public-gate-config", {
     data: {
-      "nginx.conf": `events {}
+      "nginx.conf": `pid /tmp/nginx.pid;
+events {}
 http {
+  client_body_temp_path /tmp/client-body;
+  proxy_temp_path /tmp/proxy;
+  fastcgi_temp_path /tmp/fastcgi;
+  uwsgi_temp_path /tmp/uwsgi;
+  scgi_temp_path /tmp/scgi;
   server {
     listen 8080;
     location / {
@@ -138,6 +146,11 @@ http {
       ports: [{ name: "http", number: 80 }],
       envVariables: sharedEnv,
       volumeMounts: [{ path: "/var/www/html", volume: dataVolume }],
+      securityContext: {
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+        allowPrivilegeEscalation: false,
+      },
       resources: {
         cpu: {
           request: Cpu.millis(100),
@@ -177,6 +190,11 @@ http {
       args: [archiveCommand],
       envVariables: sharedEnv,
       volumeMounts: [{ path: "/var/www/html", volume: dataVolume }],
+      securityContext: {
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: false,
+        allowPrivilegeEscalation: false,
+      },
       resources: {
         cpu: {
           request: Cpu.millis(50),
@@ -205,6 +223,13 @@ http {
         { path: "/etc/nginx", volume: publicGateConfigVolume },
         { path: "/var/www/html", volume: dataVolume, readOnly: true },
       ],
+      securityContext: {
+        user: 101,
+        group: 101,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: false,
+        allowPrivilegeEscalation: false,
+      },
       resources: {
         cpu: {
           request: Cpu.millis(10),

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/golink.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/golink.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { createGolinkApp } from "./golink.ts";
+
+const GolinkApplicationSchema = z.object({
+  kind: z.literal("Application"),
+  metadata: z.object({ name: z.literal("golink") }),
+  spec: z.object({
+    ignoreDifferences: z.array(
+      z.object({
+        group: z.literal(""),
+        kind: z.literal("PersistentVolumeClaim"),
+        name: z.literal("golink-pvc"),
+        namespace: z.literal("golink"),
+        jsonPointers: z.array(z.string()),
+      }),
+    ),
+    syncPolicy: z.object({ syncOptions: z.array(z.string()) }),
+  }),
+});
+
+describe("Golink Argo CD application", () => {
+  it("preserves the Kubernetes-assigned PVC volume name", () => {
+    const app = new App();
+    const chart = new Chart(app, "test");
+    createGolinkApp(chart);
+    const manifest = parseAllDocuments(app.synthYaml())
+      .map((document) => GolinkApplicationSchema.safeParse(document.toJS()))
+      .find((result) => result.success);
+    if (!manifest?.success) {
+      throw new Error("Golink Application was not synthesized");
+    }
+
+    expect(manifest.data.spec.ignoreDifferences).toEqual([
+      {
+        group: "",
+        kind: "PersistentVolumeClaim",
+        name: "golink-pvc",
+        namespace: "golink",
+        jsonPointers: ["/spec/volumeName"],
+      },
+    ]);
+    expect(manifest.data.spec.syncPolicy.syncOptions).toContain(
+      "RespectIgnoreDifferences=true",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/golink.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/golink.ts
@@ -18,9 +18,24 @@ export function createGolinkApp(chart: Chart) {
         server: "https://kubernetes.default.svc",
         namespace: "golink",
       },
+      // Kubernetes assigns spec.volumeName after binding the generated PVC.
+      // Argo's typed normalization otherwise tries to clear that immutable
+      // field on later syncs, leaving the current revision Operation=Failed.
+      ignoreDifferences: [
+        {
+          group: "",
+          kind: "PersistentVolumeClaim",
+          name: "golink-pvc",
+          namespace: "golink",
+          jsonPointers: ["/spec/volumeName"],
+        },
+      ],
       syncPolicy: {
         automated: {},
-        syncOptions: ["ApplyOutOfSyncOnly=true"],
+        syncOptions: [
+          "ApplyOutOfSyncOnly=true",
+          "RespectIgnoreDifferences=true",
+        ],
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/plane.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/plane.test.ts
@@ -115,6 +115,7 @@ const IngressSchema = z.object({
     tls: z.array(z.object({ hosts: z.array(z.literal("plane")) })),
     rules: z.array(
       z.object({
+        host: z.undefined().optional(),
         http: z.object({
           paths: z.array(
             z.object({
@@ -130,6 +131,26 @@ const IngressSchema = z.object({
         }),
       }),
     ),
+  }),
+});
+
+const PlaneIngressServiceSchema = z.object({
+  kind: z.literal("Service"),
+  metadata: z.object({
+    name: z.enum([
+      "plane-ingress-admin",
+      "plane-ingress-api",
+      "plane-ingress-live",
+      "plane-ingress-silo",
+      "plane-ingress-space",
+      "plane-ingress-web",
+    ]),
+    namespace: z.literal("plane"),
+  }),
+  spec: z.object({
+    clusterIP: z.undefined().optional(),
+    selector: z.object({ "app.name": z.string() }),
+    ports: z.array(z.object({ port: z.number() })).length(1),
   }),
 });
 
@@ -182,6 +203,10 @@ describe("Plane Commercial deployment", () => {
     const ingress = documents
       .map((document) => IngressSchema.safeParse(document))
       .find((result) => result.success);
+    const ingressServices = documents.flatMap((document) => {
+      const result = PlaneIngressServiceSchema.safeParse(document);
+      return result.success ? [result.data] : [];
+    });
     if (!secret?.success || !namespace?.success || !ingress?.success) {
       throw new Error("Plane infrastructure resources were not synthesized");
     }
@@ -192,6 +217,26 @@ describe("Plane Commercial deployment", () => {
       "pod-security.kubernetes.io/audit": "restricted",
       "pod-security.kubernetes.io/warn": "restricted",
     });
+    expect(ingressServices).toHaveLength(6);
+    expect(
+      Object.fromEntries(
+        ingressServices.map((service) => [
+          service.metadata.name,
+          {
+            selector: service.spec.selector["app.name"],
+            port: service.spec.ports[0]?.port,
+          },
+        ]),
+      ),
+    ).toEqual({
+      "plane-ingress-admin": { selector: "plane-plane-admin", port: 3000 },
+      "plane-ingress-api": { selector: "plane-plane-api", port: 8000 },
+      "plane-ingress-live": { selector: "plane-plane-live", port: 3000 },
+      "plane-ingress-silo": { selector: "plane-plane-silo", port: 3000 },
+      "plane-ingress-space": { selector: "plane-plane-space", port: 3000 },
+      "plane-ingress-web": { selector: "plane-plane-web", port: 3000 },
+    });
+    expect(ingress.data.spec.rules[0]?.host).toBeUndefined();
     expect(
       ingress.data.spec.rules[0]?.http.paths.map((path) => path.path),
     ).toEqual([
@@ -211,7 +256,7 @@ describe("Plane Commercial deployment", () => {
           path: "/api/",
           backend: expect.objectContaining({
             service: expect.objectContaining({
-              name: "plane-api",
+              name: "plane-ingress-api",
               port: { number: 8000 },
             }),
           }),
@@ -220,7 +265,7 @@ describe("Plane Commercial deployment", () => {
           path: "/",
           backend: expect.objectContaining({
             service: expect.objectContaining({
-              name: "plane-web",
+              name: "plane-ingress-web",
               port: { number: 3000 },
             }),
           }),

--- a/packages/tasks-for-obsidian/contract-tests/contract.test.ts
+++ b/packages/tasks-for-obsidian/contract-tests/contract.test.ts
@@ -76,6 +76,7 @@ beforeAll(async () => {
     cwd: serverDir,
     env: {
       ...process.env,
+      TZ: "UTC",
       VAULT_PATH: vaultDir,
       TASKS_DIR: "TaskNotes",
       AUTH_TOKEN,
@@ -203,15 +204,21 @@ describe("recurring completion (current contract: server-today TOGGLE)", () => {
         recurrence: "FREQ=DAILY",
       }),
     );
-    const today = localTodayYmd();
-
+    const beforeDate = new Date().toISOString().slice(0, 10);
     const first = unwrap(await client.completeRecurringInstance(recurring.id));
-    expect(first.completeInstances.map(String)).toContain(today);
+    const afterDate = new Date().toISOString().slice(0, 10);
+    const completedDates = first.completeInstances.map(String);
+    expect(completedDates).toHaveLength(1);
+    const completedDate = completedDates[0];
+    if (completedDate === undefined) {
+      throw new Error("Expected the server to select one completion date");
+    }
+    expect(new Set([beforeDate, afterDate])).toContain(completedDate);
 
     // Second call un-completes — this is the toggle behavior the P1 patch
     // extends with explicit {date, completed} set-semantics.
     const second = unwrap(await client.completeRecurringInstance(recurring.id));
-    expect(second.completeInstances.map(String)).not.toContain(today);
+    expect(second.completeInstances.map(String)).not.toContain(completedDate);
 
     await client.deleteTask(recurring.id);
   });


### PR DESCRIPTION
## Summary

- apply the exact published child `Application` specs while repository auto-sync remains suspended, and reject stale release revisions before any Argo mutation with a deadline-bounded, transient-retrying ChartMuseum preflight
- clear the live deployment blockers: preserve Golink's bound PVC field, run Matomo's official entrypoints with image-compatible identities, and route Plane through ClusterIP adapters for its headless vendor services
- make the recurring-completion wire contract assert the server-selected calendar date instead of comparing clocks across processes
- document the two-phase homelab release sequence and the workload-specific operating constraints

## Root cause

The root app's new safety settings were only applied after child reconciliation, so current children could sync before their updated diff and sync policies existed. That exposed three independent live health failures: Argo attempted to clear Golink's immutable bound `volumeName`, Matomo's root-declared images were rejected by `runAsNonRoot`, and Tailscale rejected Plane's headless ingress backends.

## Verification

- `bunx turbo run typecheck lint test --filter=homelab --filter=@homelab/cdk8s` (401 passed, 14 expected external-chart skips)
- `bun run test:contract` in `packages/tasks-for-obsidian` (18 passed)
- ChartMuseum integration coverage proves two transient 503 retries before a successful exact-revision apply
- Tasks typecheck and strict lint for the changed contract test
- docs wiki typecheck, unit tests, production build, and Playwright E2E (11 unit + 5 browser tests)
- `.buildkite/scripts/validate-pipeline.ts` and `bun run check-todos`
- desktop and mobile visual inspection of the new wiki page
- server-side dry-run accepted the new Plane Services and reached only expected field-manager conflicts on existing Argo-owned resources
- generated nginx config validated and remained running as UID/GID 101 in the exact pinned `nginx:1.29.1-alpine` image
- `bunx lefthook run pre-commit`
- full `bun run verify` reached 229/231 tasks before the contract repair; the repaired contract then passed directly. The remaining local boundary is `@shepherdjerred/resume#build`, because this machine does not have optional `xelatex`; Buildkite provides the release toolchain and is the authoritative full gate.

## Visual evidence

The new public wiki page makes the suspended two-phase release sequence and exact root restore visible to operators.

![homelab-releases-desktop.png](https://public.sjer.red/pr/assets/2055/homelab-releases-desktop.png)
