### PR TITLE
fix(ci): make release recovery self-healing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1161,7 +1161,7 @@ steps:
         # (should-never-happen) case that write didn't happen.
         jq -n '[]' > image-push-outcomes.json
         if [ ! -f image-selection-report.json ]; then
-          jq -n '{base: null, changedPaths: [], mode: "selected", globalReason: "no image-owning packages changed since last green main build", targets: {}}' > image-selection-report.json
+          jq -n '{base: null, changedPaths: [], mode: "selected", globalReason: "no image-owning packages changed since last completed main image release", targets: {}}' > image-selection-report.json
         fi
         if ! bun --no-install .buildkite/scripts/annotate-image-summary.ts --report image-selection-report.json --outcomes image-push-outcomes.json; then
           echo "WARN: image summary annotation failed (non-fatal)" >&2

--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -3,7 +3,7 @@ import {
   annotate,
   ensureBuilder,
   execute,
-  lastGreenCommit,
+  lastSuccessfulImageReleaseCommit,
   manifestDigest,
   pushImages,
   runSmoke,
@@ -26,6 +26,7 @@ import {
   knownImageTargets,
   parseBakeArguments,
   parseBuildkiteCommits,
+  parseLastPassedStepsCommit,
   parseImageSelection,
   parseStringArray,
 } from "./migration-core.ts";
@@ -173,6 +174,33 @@ test("validates external JSON arrays", () => {
   );
   expect(() => parseBuildkiteCommits({})).toThrow("array");
   expect(() => parseBuildkiteCommits([{}])).toThrow("contain a commit");
+  expect(
+    parseLastPassedStepsCommit(
+      [
+        {
+          commit: "current",
+          jobs: [
+            { step_key: "images", state: "passed" },
+            { step_key: "version-commit-back", state: "running" },
+          ],
+        },
+        {
+          commit: "previous",
+          jobs: [
+            { step_key: "images", state: "passed" },
+            { step_key: "version-commit-back", state: "passed" },
+          ],
+        },
+      ],
+      ["images", "version-commit-back"],
+    ),
+  ).toBe("previous");
+  expect(
+    parseLastPassedStepsCommit([{ commit: "current", jobs: [] }], ["images"]),
+  ).toBeUndefined();
+  expect(() =>
+    parseLastPassedStepsCommit([{ commit: "current" }], ["images"]),
+  ).toThrow("contain jobs");
 });
 
 test("fails open when image selection output is malformed", () => {
@@ -222,9 +250,28 @@ test("annotates with the expected report arguments", async () => {
   ]);
 });
 
-test("resolves the newest green Buildkite commit, including the current head", async () => {
+test("resolves the newest main commit whose image release jobs passed", async () => {
   const fetcher = Object.assign(
-    async () => Response.json([{ commit: "green-commit" }], { status: 200 }),
+    async () =>
+      Response.json(
+        [
+          {
+            commit: "current",
+            jobs: [
+              { step_key: "images", state: "passed" },
+              { step_key: "version-commit-back", state: "running" },
+            ],
+          },
+          {
+            commit: "image-green-commit",
+            jobs: [
+              { step_key: "images", state: "passed" },
+              { step_key: "version-commit-back", state: "passed" },
+            ],
+          },
+        ],
+        { status: 200 },
+      ),
     { preconnect: fetch.preconnect },
   );
   const commands: string[][] = [];
@@ -234,21 +281,17 @@ test("resolves the newest green Buildkite commit, including the current head", a
   };
 
   expect(
-    await lastGreenCommit("current", fetcher, executor, {
+    await lastSuccessfulImageReleaseCommit("current", fetcher, executor, {
       BUILDKITE_API_TOKEN: "token",
     }),
-  ).toBe("green-commit");
+  ).toBe("image-green-commit");
   expect(commands).toEqual([
-    ["git", "cat-file", "-e", "green-commit^{commit}"],
+    ["git", "cat-file", "-e", "image-green-commit^{commit}"],
+    ["git", "merge-base", "--is-ancestor", "image-green-commit", "current"],
   ]);
   expect(
-    await lastGreenCommit("current", fetcher, executor, {}),
+    await lastSuccessfulImageReleaseCommit("current", fetcher, executor, {}),
   ).toBeUndefined();
-  expect(
-    await lastGreenCommit("green-commit", fetcher, executor, {
-      BUILDKITE_API_TOKEN: "token",
-    }),
-  ).toBe("green-commit");
 });
 
 test("selects affected image targets from the merge base", async () => {
@@ -301,7 +344,7 @@ test("falls back to all images when target selection fails", async () => {
   });
 });
 
-test("uses the last green commit for scoped pushes", async () => {
+test("uses the last completed image-release commit for scoped pushes", async () => {
   expect(
     await selectedTargets(
       { affected: false, push: true },

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -16,7 +16,7 @@ import {
   findManagedImagePin,
   knownImageTargets,
   parseBakeArguments,
-  parseBuildkiteCommits,
+  parseLastPassedStepsCommit,
   parseImageSelection,
 } from "./migration-core.ts";
 import { APPLICATION_IMAGE_TARGETS } from "./image-targets.ts";
@@ -68,8 +68,14 @@ export async function annotate(
   }
 }
 
-export async function lastGreenCommit(
-  _currentCommit: string,
+/**
+ * Resolve the newest main commit with completed image and pin-handoff evidence.
+ * The overall build may be canceled after version commit-back advances main;
+ * these two passed jobs still prove that the selected closures were built,
+ * smoked, pushed, and handed to the durable pin workflow successfully.
+ */
+export async function lastSuccessfulImageReleaseCommit(
+  currentCommit: string,
   fetcher: typeof fetch = fetch,
   executor: CommandExecutor = execute,
   environment: Readonly<Record<string, string | undefined>> = Bun.env,
@@ -77,23 +83,26 @@ export async function lastGreenCommit(
   const token = environment["BUILDKITE_API_TOKEN"];
   if (token === undefined) return undefined;
   const response = await fetcher(
-    "https://api.buildkite.com/v2/organizations/sjerred/pipelines/monorepo/builds?branch=main&state=passed&per_page=1",
+    "https://api.buildkite.com/v2/organizations/sjerred/pipelines/monorepo/builds?branch=main&per_page=20&include_retried_jobs=true",
     {
       headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(20_000),
     },
   ).catch(() => null);
   if (response?.ok !== true) return undefined;
-  const commits = parseBuildkiteCommits(await response.json());
-  const commit = commits[0];
-  if (commit === undefined) return undefined;
-  const exists = await executor([
-    "git",
-    "cat-file",
-    "-e",
-    `${commit}^{commit}`,
+  const commit = parseLastPassedStepsCommit(await response.json(), [
+    "images",
+    "version-commit-back",
   ]);
-  return exists.exitCode === 0 ? commit : undefined;
+  if (commit === undefined) return undefined;
+  for (const command of [
+    ["git", "cat-file", "-e", `${commit}^{commit}`],
+    ["git", "merge-base", "--is-ancestor", commit, currentCommit],
+  ]) {
+    const validation = await executor(command);
+    if (validation.exitCode !== 0) return undefined;
+  }
+  return commit;
 }
 
 export async function selectedTargets(
@@ -104,9 +113,9 @@ export async function selectedTargets(
   },
   commit: string,
   executor: CommandExecutor = execute,
-  greenCommit: (
+  imageBaseCommit: (
     currentCommit: string,
-  ) => Promise<string | undefined> = lastGreenCommit,
+  ) => Promise<string | undefined> = lastSuccessfulImageReleaseCommit,
 ): Promise<{ readonly targets: string[]; readonly fallbackReason: string }> {
   if (fixedCorpusMode(options.environment ?? Bun.env)) {
     return {
@@ -121,9 +130,9 @@ export async function selectedTargets(
     if (result.exitCode === 0) base = result.stdout.trim();
     else fallbackReason = "could not resolve merge-base with origin/main";
   } else if (options.push) {
-    base = await greenCommit(commit);
+    base = await imageBaseCommit(commit);
     if (base === undefined)
-      fallbackReason = "could not resolve last green main build";
+      fallbackReason = "could not resolve last completed main image release";
   }
   if (base === undefined) return { targets: knownImageTargets, fallbackReason };
 

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -165,6 +165,37 @@ export function parseBuildkiteCommits(value: unknown): string[] {
   return commits;
 }
 
+export function parseLastPassedStepsCommit(
+  value: unknown,
+  stepKeys: readonly string[],
+): string | undefined {
+  if (!Array.isArray(value)) {
+    throw new TypeError("Buildkite response must be an array");
+  }
+  for (const item of value) {
+    const build = asRecord(item);
+    const commit = build?.["commit"];
+    const jobs = build?.["jobs"];
+    if (typeof commit !== "string" || commit.length === 0) {
+      throw new TypeError("Buildkite build must contain a commit");
+    }
+    if (!Array.isArray(jobs)) {
+      throw new TypeError("Buildkite build must contain jobs");
+    }
+    const passedStepKeys = new Set(
+      jobs.flatMap((job) => {
+        const record = asRecord(job);
+        const stepKey = record?.["step_key"];
+        return typeof stepKey === "string" && record?.["state"] === "passed"
+          ? [stepKey]
+          : [];
+      }),
+    );
+    if (stepKeys.every((stepKey) => passedStepKeys.has(stepKey))) return commit;
+  }
+  return undefined;
+}
+
 export const summarySteps = [
   "verify",
   "playwright-e2e-main",

--- a/packages/docs/wiki/src/content/docs/homelab/matomo.md
+++ b/packages/docs/wiki/src/content/docs/homelab/matomo.md
@@ -23,12 +23,13 @@ Only after that marker exists does the public gate proxy requests to Matomo.
 Verify `https://matomo.sjer.red/matomo.js` and the API endpoint before allowing
 the site-release lane to deploy tracker changes.
 
-The archive sidecar disables browser-triggered archiving, configures the
-Cloudflare client-IP header, and runs `core:archive` every five minutes. A
-failed archive exits the sidecar so Kubernetes reports the pod as unhealthy.
-The official Matomo image keeps its root entrypoint so it can initialize the
-shared application volume, with privilege escalation disabled; the nginx
-public gate runs as its numeric non-root user.
+The archive sidecar waits for the installer to write the database section,
+then disables browser-triggered archiving, configures the Cloudflare client-IP
+header, and runs `core:archive` every five minutes. A failed archive exits the
+sidecar so Kubernetes reports the pod as unhealthy. The official Matomo image
+keeps its root entrypoint so it can initialize the shared application volume,
+with privilege escalation disabled; the nginx public gate runs as its numeric
+non-root user.
 
 ## Audit checks
 

--- a/packages/docs/wiki/src/content/docs/homelab/releases.md
+++ b/packages/docs/wiki/src/content/docs/homelab/releases.md
@@ -29,12 +29,25 @@ The second suspended root apply is deliberate. New child-level safety settings
 must exist before those children sync, but enabling floating auto-sync before
 every chart is published could expose a partially published release.
 
+Child reconciliation also retries a failed operation recorded against the
+current chart revision, even when ArgoCD already reports the application as
+Synced and Healthy. That clears a failed apply after a new child-level safety
+setting makes the same immutable chart revision safe to retry.
+
 Root pruning does not trust ArgoCD's cached `OutOfSync` or `requiresPruning`
 flags. Selective manifest overrides can make those flags temporarily describe
 the override rather than the published tree. The release script renders the
 exact `apps` revision and treats only live child Applications absent from that
 rendered set as prune candidates; each candidate must still opt into cascading
 deletion and carry the Argo resources finalizer.
+
+Application image selection uses the newest main commit whose `images` and
+`version-commit-back` jobs both passed as its comparison base. A later
+version-pin commit can cancel the rest of that build without invalidating its
+completed image build, smoke-test, and durable pin-handoff evidence. Changes
+after that image-release commit still rebuild their affected closures, while
+an unchanged pin-only successor does not rebuild and repin the same application
+forever.
 
 The implementation lives in `.buildkite/pipeline.yml` and
 `packages/homelab/scripts/argocd.ts`.

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -119,6 +119,12 @@ const ReconcileApplicationSchema = z.object({
           revision: z.string().optional(),
         })
         .optional(),
+      operationState: z
+        .object({
+          phase: z.string(),
+          syncResult: z.object({ revision: z.string().optional() }).optional(),
+        })
+        .optional(),
     })
     .optional(),
 });
@@ -577,9 +583,16 @@ async function reconcileRelease(
     );
     const syncStatus = current.status?.sync?.status;
     const revision = current.status?.sync?.revision;
+    const operationPhase = current.status?.operationState?.phase;
+    const operationRevision =
+      current.status?.operationState?.syncResult?.revision;
+    const failedCurrentOperation =
+      (operationPhase === "Failed" || operationPhase === "Error") &&
+      (operationRevision === undefined || operationRevision === revision);
     if (
       syncStatus === "Synced" &&
-      (wanted.revision === undefined || revision === wanted.revision)
+      (wanted.revision === undefined || revision === wanted.revision) &&
+      !failedCurrentOperation
     ) {
       continue;
     }

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -530,6 +530,109 @@ describe("Argo CD release gating", () => {
 });
 
 describe("Argo CD stale release protection", () => {
+  test("retries a failed operation recorded for an otherwise current app", async () => {
+    let requestedOperation: Record<string, unknown> | undefined;
+    let syncPosts = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/charts/apps") {
+          return Response.json([
+            {
+              version: "2.0.0-42",
+              urls: ["charts/apps-2.0.0-42.tgz"],
+              digest: "a".repeat(64),
+            },
+          ]);
+        }
+        if (
+          request.method === "POST" &&
+          url.pathname === "/api/v1/applications/worker/sync"
+        ) {
+          syncPosts += 1;
+          requestedOperation = z
+            .record(z.string(), z.unknown())
+            .parse(await request.json());
+          return Response.json({ operation: requestedOperation });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/worker"
+        ) {
+          return Response.json({
+            status: {
+              sync: { status: "Synced", revision: "2.0.0-42" },
+              health: { status: "Healthy" },
+              operationState:
+                requestedOperation === undefined
+                  ? {
+                      phase: "Failed",
+                      syncResult: { revision: "2.0.0-42" },
+                    }
+                  : {
+                      phase: "Succeeded",
+                      operation: requestedOperation,
+                      syncResult: { revision: "2.0.0-42" },
+                    },
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-"));
+    const expectedPath = path.join(directory, "expected.json");
+    await Bun.write(
+      expectedPath,
+      JSON.stringify([
+        { name: "apps", revision: "2.0.0-42" },
+        { name: "worker", revision: "2.0.0-42" },
+      ]),
+    );
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "reconcile-release",
+          expectedPath,
+          "--skip-health-wait",
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+            CHARTMUSEUM_ORIGIN: server.url.origin,
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("sync operation started: worker");
+      expect(stdout).toContain("synced: worker");
+      expect(syncPosts).toBe(1);
+    } finally {
+      await server.stop(true);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   test("rejects an Argo reconcile after a newer apps chart is published", async () => {
     let argoRequests = 0;
     const server = Bun.serve({

--- a/packages/homelab/src/cdk8s/src/resources/analytics/matomo.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/matomo.test.ts
@@ -18,6 +18,8 @@ const MatomoDeploymentSchema = z.object({
         containers: z.array(
           z.object({
             name: z.string(),
+            command: z.array(z.string()).optional(),
+            args: z.array(z.string()).optional(),
             securityContext: z.object({
               runAsNonRoot: z.boolean(),
               runAsUser: z.number().optional(),
@@ -73,6 +75,15 @@ describe("Matomo deployment", () => {
         allowPrivilegeEscalation: false,
       },
     });
+    const archiveContainer = deployment.data.spec.template.spec.containers.find(
+      (container) => container.name === "matomo-archive",
+    );
+    if (archiveContainer?.args === undefined) {
+      throw new Error("Matomo archive container command was not synthesized");
+    }
+    expect(archiveContainer.args.join(" ")).toContain(
+      "grep -Fqx '[database]' /var/www/html/config/config.ini.php",
+    );
     const nginxConfig = config.data.data["nginx.conf"];
     expect(nginxConfig).toStartWith("pid /tmp/nginx.pid;");
     for (const temporaryPath of [

--- a/packages/homelab/src/cdk8s/src/resources/analytics/matomo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/analytics/matomo.ts
@@ -27,7 +27,7 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 const archiveCommand = [
   "set -e;",
-  "until test -f /var/www/html/config/config.ini.php; do sleep 30; done;",
+  "until test -f /var/www/html/config/config.ini.php && grep -Fqx '[database]' /var/www/html/config/config.ini.php; do sleep 30; done;",
   "php /var/www/html/console config:set",
   "'General.enable_browser_archiving_triggering=0'",
   "'General.browser_archiving_disabled_enforce=1'",

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -37,11 +37,11 @@ type ResetGitRunner = (args: string[]) => Promise<unknown>;
 /**
  * Reconstruct the generated bump branch from current main.
  *
- * Main image builds are scoped from the last green main build, and a failed
- * commit-back prevents that baseline from advancing. The current candidate
- * state therefore contains every still-pending image change. Starting from
- * main is both cumulative and immune to conflicts from a closed or superseded
- * generated PR.
+ * Main image builds are scoped from the last main commit whose image and
+ * version commit-back lanes both passed, while generated PRs may overlap or be
+ * superseded. The current candidate state therefore contains every
+ * still-pending image change. Starting from main is both cumulative and immune
+ * to conflicts from a closed or superseded generated PR.
  */
 export async function resetVersionBumpBranch(
   git: ResetGitRunner,


### PR DESCRIPTION
## Summary

- base main image selection on the newest main commit whose `images` and `version-commit-back` jobs both passed, even when the resulting pin commit later canceled the overall build
- retry current-revision Argo CD operations that are terminally failed instead of skipping them solely because the app is already Synced
- keep Matomo's archive sidecar healthy and idle until the manual first-run installer writes its database configuration
- document the release recovery guarantees and Matomo initialization boundary in the human wiki

## Root cause

Main had no recent fully passed build, so every pin-only successor compared image inputs against the same old green commit. Birmel rebuilt, produced a new pin commit, and canceled its parent build repeatedly. Completed image and version commit-back jobs in the same build are independent evidence that the selected closures were built, smoked, pushed, and handed to the durable pin workflow; requiring both prevents a failed commit-back from stranding an unpinned image.

Separately, Golink became Synced/Healthy after its PVC difference was ignored, but its failed operation remained attached to the unchanged chart revision. The release health gate correctly rejected that state while reconciliation skipped it. Reconciliation now retries that exact condition and preserves the existing treatment of failures recorded for older revisions.

Matomo's archive sidecar treated the existence of `config.ini.php` as proof that first-run initialization was complete. On a fresh deployment it created a partial `[General]` configuration before the installer had written `[database]`, then `core:archive` failed with a local-socket database error and left the pod in CrashLoopBackOff. The sidecar now waits for the installer's database section; post-install archive failures still exit loudly.

## Verification

- `bunx turbo run typecheck lint test --filter=@shepherdjerred/root-scripts --filter=@homelab/cdk8s`
- `bun run .buildkite/scripts/validate-pipeline.ts`
- docs wiki: typecheck, unit tests, production build, and 5 Playwright tests
- staged pre-commit and commit-message hooks

No demo artifact: this changes release orchestration and test contracts, not a visual surface.
