### PR TITLE
fix(tasks-for-obsidian): restore task UI and completion undo

### DIFF
--- a/packages/docs/plans/2026-08-09_tasknotes-completion-undo-ui-fixes.md
+++ b/packages/docs/plans/2026-08-09_tasknotes-completion-undo-ui-fixes.md
@@ -1,0 +1,50 @@
+---
+id: tasknotes-completion-undo-ui-fixes
+type: plan
+status: in-progress
+board: false
+---
+
+# TaskNotes iOS UI and completion Undo fixes
+
+## Summary
+
+- Keep the normal-mode task context menu from collapsing its title and metadata.
+- Replace the clipped search and settings icons with native, accessible toolbar
+  actions.
+- Make every in-app completion undoable through a transient LIFO stack with
+  precise, non-spring motion.
+
+## Implementation
+
+- Give the task-content `Pressable` the remaining row width and isolate native
+  menu gesture handling to the trailing 44-point overflow action, preserving
+  context actions without collapsing text or consuming the first detail tap.
+- Use SF Symbols in separate 44-point header targets with press feedback and a
+  safe trailing inset.
+- Capture exact inverse operations for status and recurring-occurrence
+  completions. Group bulk completion into one Undo entry containing only the
+  successful mutations.
+- Keep Undo entries for five seconds of inactivity. Push and pop actions reset
+  the timer; expiration clears the stack. Updating the active entry does not
+  remount or replay the toast entrance.
+- Replace the spring with a brief eased slide/fade and use opacity-only motion
+  when Reduce Motion is enabled.
+
+## Verification
+
+- Unit-test status and recurrence restoration, non-completion exclusions, LIFO
+  ordering, expiry, and grouped bulk behavior.
+- Extend the ordered Maestro suite for visible task text, header navigation,
+  plain/recurring/swipe/detail/bulk Undo, and two rapid LIFO Undo actions.
+- Run focused typecheck, lint, unit, contract, release-bundle, and simulator E2E
+  checks. Capture a screenshot for the corrected row/header and a short motion
+  recording.
+- Treat the next physical iOS 27 beta/TestFlight build as human acceptance; it
+  is not evidence supplied by the local simulator run.
+
+## Assumptions
+
+- “All completions” covers actions initiated inside the app UI, not Widget,
+  Siri, or remote Obsidian mutations that cannot display the in-app toast.
+- One bulk completion is one Undo stack entry.

--- a/packages/tasks-for-obsidian/e2e/README.md
+++ b/packages/tasks-for-obsidian/e2e/README.md
@@ -62,6 +62,7 @@ earlier mutations. "Water plants" remains the stable sync sentinel.
 | `08-contextual-quick-capture.yaml`    | Today seed + Save & Add Another capture                     |
 | `09-saved-view-lifecycle.yaml`        | create + rename + delete a device-local saved view          |
 | `10-completed-search-uncomplete.yaml` | search Completed + return a task to Today                   |
+| `11-undo-stack-and-bulk.yaml`         | header actions + LIFO and grouped bulk completion Undo      |
 
 The chaos proxy is toggled from flows via `runScript` (GraalJS `http.post`)
 against `/__chaos/offline` and `/__chaos/online` on the proxy port itself;
@@ -69,7 +70,7 @@ control endpoints keep working while "offline".
 
 ## Current status
 
-The harness is **functional end-to-end**. All 11 ordered flows and the final
+The harness is **functional end-to-end**. All 12 ordered flows and the final
 Markdown vault assertions pass on Xcode 27, the iOS 27 simulator, and Maestro
 2.8.0. The suite covers one clean install, per-flow process restarts, a true
 kill/relaunch, offline replay, gestures, contextual capture, saved views, and

--- a/packages/tasks-for-obsidian/e2e/maestro/00-setup.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/00-setup.yaml
@@ -1,7 +1,8 @@
 # Shared setup: point the running app at the local test stack via the
 # __DEV__-only e2e-config deep link, and wait for the seeded vault to sync in.
-# The orchestrator installs one clean data container and launches once before
-# the suite; nested setup calls retain it so flows do not tear down Metro.
+# The orchestrator installs one clean data container and relaunches the app
+# between flows without clearing storage. The ordered suite retains its shared
+# vault while transient provider state cannot leak between scenarios.
 # Requires --env APP_URL, --env AUTH_TOKEN, and --env E2E_TODAY (provided by
 # e2e/run.ts). E2E_TODAY freezes date parsing for the whole flow so a
 # midnight boundary cannot make the UI and vault assertion disagree.
@@ -15,9 +16,9 @@ appId: org.reactjs.native.example.TasksForObsidian
     env:
       CHAOS_BASE: ${APP_URL}
 # Wait for the app to finish booting (root header present) BEFORE openLink. The
-# orchestrator's cold launch is still initializing when the first flow starts;
+# runner's fresh launch is still initializing when each flow starts;
 # firing openLink immediately races app startup and the JS Linking listener misses
-# the url event (and it is not a launch URL, so getInitialURL is empty too) —
+# the URL event (and it is not a launch URL, so getInitialURL is empty too) —
 # the deep link is silently dropped and config never applies.
 - extendedWaitUntil:
     visible:

--- a/packages/tasks-for-obsidian/e2e/maestro/02-complete-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/02-complete-task.yaml
@@ -9,6 +9,52 @@ appId: org.reactjs.native.example.TasksForObsidian
     visible:
       id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
     timeout: 15000
+# The stable normal-mode row target must open detail on its first tap even
+# though the same content owns a native long-press context menu.
+- tapOn:
+    id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
+- extendedWaitUntil:
+    visible:
+      id: "task-detail-toggle"
+    timeout: 5000
+# Plain-task completion from detail is undoable through the sheet host, while
+# the stack itself survives navigation back to the root presentation.
+- tapOn:
+    id: "task-detail-toggle"
+- tapOn:
+    id: "undo-toast-action"
+- assertVisible:
+    id: "task-detail-toggle"
+    text: "Open"
+# A completion created by the sheet remains undoable after the sheet unmounts.
+- tapOn:
+    id: "task-detail-toggle"
+- tapOn:
+    id: "task-detail-cancel"
+- extendedWaitUntil:
+    notVisible:
+      id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
+    timeout: 10000
+- tapOn:
+    id: "undo-toast-action"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
+    timeout: 10000
+# The list checkbox uses the root Undo host.
+- tapOn:
+    id: "task-checkbox-TaskNotes/seeded-open-task-1a2b3c4d.md"
+- extendedWaitUntil:
+    notVisible:
+      id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
+    timeout: 15000
+- tapOn:
+    id: "undo-toast-action"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/seeded-open-task-1a2b3c4d.md"
+    timeout: 15000
+# Complete once more to preserve the suite's durable final-state assertion.
 - tapOn:
     id: "task-checkbox-TaskNotes/seeded-open-task-1a2b3c4d.md"
 - extendedWaitUntil:

--- a/packages/tasks-for-obsidian/e2e/maestro/03-recurring-complete.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/03-recurring-complete.yaml
@@ -32,6 +32,17 @@ appId: org.reactjs.native.example.TasksForObsidian
       id: "undo-toast-message"
       text: "Completed.*"
     timeout: 10000
+- tapOn:
+    id: "undo-toast-action"
+# Complete the same occurrence again after its exact restore so the final vault
+# state continues to prove recurrence advancement.
+- tapOn:
+    id: "task-detail-toggle"
+- extendedWaitUntil:
+    visible:
+      id: "undo-toast-message"
+      text: "Completed.*"
+    timeout: 10000
 - assertVisible:
     id: "task-detail-toggle"
     text: "Open"

--- a/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/04-edit-task.yaml
@@ -28,5 +28,5 @@ appId: org.reactjs.native.example.TasksForObsidian
     id: "task-detail-save"
 - extendedWaitUntil:
     visible:
-      id: "task-row-TaskNotes/Edited by e2e.md"
+      id: "task-row-TaskNotes/task-with-details-3c4d5e6f.md"
     timeout: 15000

--- a/packages/tasks-for-obsidian/e2e/maestro/07-swipe-actions.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/07-swipe-actions.yaml
@@ -26,6 +26,25 @@ appId: org.reactjs.native.example.TasksForObsidian
     notVisible:
       id: "task-row-TaskNotes/Swipe complete task.md"
     timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "undo-toast-action"
+    timeout: 10000
+- tapOn:
+    id: "undo-toast-action"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/Swipe complete task.md"
+    timeout: 15000
+# Repeat the swipe so the suite's durable final-state assertion remains done.
+- swipe:
+    from:
+      id: "task-row-TaskNotes/Swipe complete task.md"
+    direction: RIGHT
+- extendedWaitUntil:
+    notVisible:
+      id: "task-row-TaskNotes/Swipe complete task.md"
+    timeout: 15000
 - tapOn:
     id: "tab-inbox"
 - extendedWaitUntil:

--- a/packages/tasks-for-obsidian/e2e/maestro/11-undo-stack-and-bulk.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/11-undo-stack-and-bulk.yaml
@@ -1,0 +1,136 @@
+# Verify header navigation, LIFO completion Undo, and one-entry bulk Undo.
+appId: org.reactjs.native.example.TasksForObsidian
+---
+- runFlow: 00-setup.yaml
+# The native toolbar actions retain stable accessibility/test identifiers.
+- tapOn:
+    id: "header-search"
+- extendedWaitUntil:
+    visible:
+      id: "search-input"
+    timeout: 10000
+- tapOn:
+    id: "BackButton"
+- extendedWaitUntil:
+    visible:
+      id: "header-search"
+    timeout: 10000
+- tapOn:
+    id: "tab-settings"
+- extendedWaitUntil:
+    visible:
+      id: "settings-api-url"
+    timeout: 10000
+- tapOn:
+    id: "BackButton"
+- extendedWaitUntil:
+    visible:
+      id: "header-search"
+    timeout: 10000
+- tapOn:
+    id: "tab-inbox"
+# Create two isolated tasks for stack and bulk completion behavior.
+- tapOn:
+    id: "fab-add-task"
+- extendedWaitUntil:
+    visible:
+      id: "quick-add-input"
+    timeout: 10000
+- tapOn:
+    id: "quick-add-input"
+- inputText: "Undo stack first"
+- tapOn:
+    id: "quick-add-submit"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/Undo stack first.md"
+    timeout: 15000
+- tapOn:
+    id: "fab-add-task"
+- extendedWaitUntil:
+    visible:
+      id: "quick-add-input"
+    timeout: 10000
+- tapOn:
+    id: "quick-add-input"
+- inputText: "Undo stack second"
+- tapOn:
+    id: "quick-add-submit"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/Undo stack second.md"
+    timeout: 15000
+# XCTest exposes virtualized offscreen rows as visible on iOS 27. Use the
+# product sort control to put the two newest tasks onscreen deterministically.
+- tapOn: "Sort options"
+- tapOn: "Created"
+- tapOn: "Sort options"
+- tapOn: "Created ↑"
+# Wait for each mutation before the next tap so stack order is deterministic.
+- tapOn:
+    id: "task-checkbox-TaskNotes/Undo stack first.md"
+- extendedWaitUntil:
+    notVisible:
+      id: "task-row-TaskNotes/Undo stack first.md"
+    timeout: 15000
+- tapOn:
+    id: "task-checkbox-TaskNotes/Undo stack second.md"
+- extendedWaitUntil:
+    notVisible:
+      id: "task-row-TaskNotes/Undo stack second.md"
+    timeout: 15000
+- extendedWaitUntil:
+    visible:
+      id: "undo-toast-action"
+      text: "Undo latest completion, 2 available"
+    timeout: 10000
+- tapOn:
+    id: "undo-toast-action"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/Undo stack second.md"
+    timeout: 15000
+- assertNotVisible:
+    id: "task-row-TaskNotes/Undo stack first.md"
+- tapOn:
+    id: "undo-toast-action"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/Undo stack first.md"
+    timeout: 15000
+# A bulk completion is one stack entry that restores both successful tasks.
+- tapOn:
+    id: "select-mode-toggle"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-selection-unselected-TaskNotes/Undo stack first.md"
+    timeout: 10000
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "task-row-TaskNotes/Undo stack first.md"
+      - assertVisible:
+          id: "task-row-selection-selected-TaskNotes/Undo stack first.md"
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn:
+          id: "task-row-TaskNotes/Undo stack second.md"
+      - assertVisible:
+          id: "task-row-selection-selected-TaskNotes/Undo stack second.md"
+- tapOn:
+    id: "bulk-complete"
+- extendedWaitUntil:
+    visible:
+      id: "undo-toast-message"
+      text: "Completed 2 tasks"
+    timeout: 10000
+- tapOn:
+    id: "undo-toast-action"
+- extendedWaitUntil:
+    visible:
+      id: "task-row-TaskNotes/Undo stack first.md"
+    timeout: 15000
+- assertVisible:
+    id: "task-row-TaskNotes/Undo stack second.md"

--- a/packages/tasks-for-obsidian/e2e/maestro/config.yaml
+++ b/packages/tasks-for-obsidian/e2e/maestro/config.yaml
@@ -17,3 +17,4 @@ executionOrder:
     - 08-contextual-quick-capture
     - 09-saved-view-lifecycle
     - 10-completed-search-uncomplete
+    - 11-undo-stack-and-bulk

--- a/packages/tasks-for-obsidian/e2e/run.ts
+++ b/packages/tasks-for-obsidian/e2e/run.ts
@@ -467,7 +467,7 @@ async function runMaestro(
     // Freeze dated flows at their boundary so UI and vault assertions cannot
     // cross midnight while the simulator exercises one scenario.
     const today = captureFlowToday(flow, () =>
-      runSimctl(["spawn", simulator.udid, "date", "+%Y-%m-%d"]),
+      runSimctl(["spawn", simulator.udid, "/bin/date", "+%Y-%m-%d"]),
     );
     if (today !== "") {
       todayByFlow.set(flow, today);

--- a/packages/tasks-for-obsidian/e2e/vault-assertions.ts
+++ b/packages/tasks-for-obsidian/e2e/vault-assertions.ts
@@ -143,11 +143,12 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
       true,
   },
   {
-    name: 'the seeded task file is renamed to "Edited by e2e" (04-edit-task)',
+    name: 'the seeded task title is changed to "Edited by e2e" (04-edit-task)',
     flow: "04-edit-task.yaml",
     check: (files) =>
-      files.get("Edited by e2e.md")?.includes("title: Edited by e2e") ===
-        true && !files.has("task-with-details-3c4d5e6f.md"),
+      files
+        .get("task-with-details-3c4d5e6f.md")
+        ?.includes("title: Edited by e2e") === true,
   },
   {
     name: '"Seeded done task" has status open (10-completed-search-uncomplete)',
@@ -203,6 +204,22 @@ const VAULT_ASSERTIONS: readonly VaultAssertion[] = [
     name: '"Swipe delete task" is absent (07-swipe-actions)',
     flow: "07-swipe-actions.yaml",
     check: (files) => fileWithTitle(files, "Swipe delete task") === undefined,
+  },
+  {
+    name: '"Undo stack first" returns to open (11-undo-stack-and-bulk)',
+    flow: "11-undo-stack-and-bulk.yaml",
+    check: (files) =>
+      fileWithExactTitle(files, "Undo stack first")?.includes(
+        "status: open",
+      ) === true,
+  },
+  {
+    name: '"Undo stack second" returns to open (11-undo-stack-and-bulk)',
+    flow: "11-undo-stack-and-bulk.yaml",
+    check: (files) =>
+      fileWithExactTitle(files, "Undo stack second")?.includes(
+        "status: open",
+      ) === true,
   },
 ];
 

--- a/packages/tasks-for-obsidian/src/components/common/UndoToast.tsx
+++ b/packages/tasks-for-obsidian/src/components/common/UndoToast.tsx
@@ -2,52 +2,79 @@ import React, { useEffect } from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
 import Animated, {
   FadeIn,
+  FadeInDown,
   FadeOut,
-  SlideInDown,
-  SlideOutDown,
+  FadeOutDown,
   useAnimatedStyle,
   useReducedMotion,
   useSharedValue,
   withTiming,
+  cancelAnimation,
   Easing,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useSettings } from "../../hooks/use-settings";
 import { typography } from "../../styles/typography";
 import { UNDO_TOAST_MS } from "../../domain/task-toggle";
+import { e2eUndoToastMs } from "../../navigation/e2e-config";
 
 type Props = {
   visible: boolean;
+  requestId: number | null;
+  depth: number;
   message: string;
+  undoInFlight: boolean;
   onUndo: () => void;
   onDismiss: () => void;
 };
 
 /**
  * Transient bottom toast with a single Undo action and a shrinking time
- * bar for its lifetime. Used for recurring-task completions — the one
- * mutation whose target (the occurrence date) is invisible in the UI.
+ * bar for its lifetime. The provider keeps this view mounted while the active
+ * LIFO entry changes, so rapid completions reset the timer without replaying
+ * the entrance motion.
  */
-export function UndoToast({ visible, message, onUndo, onDismiss }: Props) {
+export function UndoToast({
+  visible,
+  requestId,
+  depth,
+  message,
+  undoInFlight,
+  onUndo,
+  onDismiss,
+}: Props) {
   const { colors } = useSettings();
   const insets = useSafeAreaInsets();
   const reducedMotion = useReducedMotion();
   const progress = useSharedValue(1);
+  const duration = e2eUndoToastMs(UNDO_TOAST_MS);
 
   useEffect(() => {
     if (!visible) return;
+    if (undoInFlight) {
+      cancelAnimation(progress);
+      return;
+    }
     progress.value = 1;
     if (!reducedMotion) {
       progress.value = withTiming(0, {
-        duration: UNDO_TOAST_MS,
+        duration,
         easing: Easing.linear,
       });
     }
-    const timer = setTimeout(onDismiss, UNDO_TOAST_MS);
+    const timer = setTimeout(onDismiss, duration);
     return () => {
       clearTimeout(timer);
     };
-  }, [visible, onDismiss, progress, reducedMotion]);
+  }, [
+    duration,
+    visible,
+    requestId,
+    onDismiss,
+    progress,
+    reducedMotion,
+    undoInFlight,
+  ]);
 
   const barStyle = useAnimatedStyle(() => ({
     transform: [{ scaleX: progress.value }],
@@ -59,11 +86,13 @@ export function UndoToast({ visible, message, onUndo, onDismiss }: Props) {
     <Animated.View
       entering={
         reducedMotion
-          ? FadeIn.duration(150)
-          : SlideInDown.springify().damping(15)
+          ? FadeIn.duration(120)
+          : FadeInDown.duration(180).easing(Easing.out(Easing.cubic))
       }
       exiting={
-        reducedMotion ? FadeOut.duration(100) : SlideOutDown.duration(200)
+        reducedMotion
+          ? FadeOut.duration(100)
+          : FadeOutDown.duration(140).easing(Easing.in(Easing.cubic))
       }
       style={[
         styles.toast,
@@ -84,16 +113,26 @@ export function UndoToast({ visible, message, onUndo, onDismiss }: Props) {
           {message}
         </Text>
         <Pressable
+          style={styles.undoButton}
           onPress={onUndo}
+          disabled={undoInFlight}
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel="Undo"
+          accessibilityLabel={
+            depth > 1
+              ? `Undo latest completion, ${String(depth)} available`
+              : "Undo"
+          }
           testID="undo-toast-action"
         >
           <Text
-            style={[typography.body, styles.undo, { color: colors.primary }]}
+            style={[
+              typography.body,
+              styles.undo,
+              { color: colors.primary, opacity: undoInFlight ? 0.5 : 1 },
+            ]}
           >
-            Undo
+            {depth > 1 ? `Undo (${String(depth)})` : "Undo"}
           </Text>
         </Pressable>
       </View>
@@ -109,6 +148,7 @@ export function UndoToast({ visible, message, onUndo, onDismiss }: Props) {
 const styles = StyleSheet.create({
   toast: {
     position: "absolute",
+    zIndex: 1000,
     left: 16,
     right: 16,
     borderRadius: 12,
@@ -133,6 +173,10 @@ const styles = StyleSheet.create({
   },
   undo: {
     fontWeight: "700",
+  },
+  undoButton: {
+    minHeight: 44,
+    justifyContent: "center",
   },
   barTrack: {
     height: 3,

--- a/packages/tasks-for-obsidian/src/components/task/TaskRow.tsx
+++ b/packages/tasks-for-obsidian/src/components/task/TaskRow.tsx
@@ -106,7 +106,10 @@ export const TaskRow = React.memo(function TaskRowComponent({
         accessibilityLabel={accessibilityLabel}
         accessibilityHint="Double tap to toggle selection"
       >
-        <View style={styles.selectionTarget} testID="task-row-selection-mark">
+        <View
+          style={styles.selectionTarget}
+          testID={`task-row-selection-${selected ? "selected" : "unselected"}-${String(task.id)}`}
+        >
           <AppIcon
             name={selected ? "check-circle" : "circle"}
             size={22}
@@ -173,39 +176,29 @@ export const TaskRow = React.memo(function TaskRowComponent({
     }
   };
 
-  const renderOpenButton = (menuActions: MenuAction[]) => (
-    <MenuView
-      title={task.title}
-      actions={menuActions}
-      shouldOpenOnLongPress
-      onPressAction={handleMenuAction}
+  const renderOpenButton = () => (
+    <Pressable
+      style={styles.openButton}
+      onPress={onPress}
+      testID={`task-row-${String(task.id)}`}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint="Double tap to view details"
     >
-      <Pressable
-        style={styles.openButton}
-        onPress={onPress}
-        testID={`task-row-${String(task.id)}`}
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel}
-        accessibilityHint="Double tap to view details"
-      >
-        <RowContent
-          presentation={presentation}
-          completed={completed}
-          colors={colors}
+      <RowContent
+        presentation={presentation}
+        completed={completed}
+        colors={colors}
+      />
+      {pending ? (
+        <View
+          style={[styles.pendingDot, { backgroundColor: colors.textTertiary }]}
+          testID="task-row-pending-dot"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
         />
-        {pending ? (
-          <View
-            style={[
-              styles.pendingDot,
-              { backgroundColor: colors.textTertiary },
-            ]}
-            testID="task-row-pending-dot"
-            accessibilityElementsHidden
-            importantForAccessibility="no-hide-descendants"
-          />
-        ) : null}
-      </Pressable>
-    </MenuView>
+      ) : null}
+    </Pressable>
   );
 
   const actions: MenuAction[] = [
@@ -249,7 +242,7 @@ export const TaskRow = React.memo(function TaskRowComponent({
     });
   }
 
-  const openButton = renderOpenButton(actions);
+  const openButton = renderOpenButton();
 
   return (
     <View
@@ -421,6 +414,7 @@ const styles = StyleSheet.create({
   openButton: {
     minHeight: 44,
     flex: 1,
+    minWidth: 0,
     flexDirection: "row",
     alignItems: "center",
   },

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -234,6 +234,47 @@ describe("TaskStore server acks", () => {
 });
 
 describe("TaskStore full pulls", () => {
+  test("does not enqueue a required-task mutation after an in-flight pull deletes it", async () => {
+    const task = makeTask();
+    const backingStorage = memoryStoreStorage({ tasks: [task] });
+    const baseWriteStarted = Promise.withResolvers<null>();
+    const releaseBaseWrite = Promise.withResolvers<null>();
+    let pauseBaseWrite = false;
+    const storeStorage: MemoryStoreStorage = {
+      ...backingStorage,
+      setTasks: async (tasks) => {
+        if (pauseBaseWrite) {
+          pauseBaseWrite = false;
+          baseWriteStarted.resolve(null);
+          await releaseBaseWrite.promise;
+        }
+        await backingStorage.setTasks(tasks);
+      },
+    };
+    const { store, queue } = makeStore(memoryQueueStorage(), storeStorage);
+    await store.restore();
+    let syncRequested = 0;
+    store.onDispatch = () => {
+      syncRequested += 1;
+    };
+
+    pauseBaseWrite = true;
+    const pull = store.replaceBase([], now);
+    await baseWriteStarted.promise;
+    const dispatch = store.dispatchIfTaskExists({
+      type: "set_status",
+      taskId: task.id,
+      status: "open",
+    });
+
+    releaseBaseWrite.resolve(null);
+    await pull;
+    await expect(dispatch).resolves.toEqual(undefined);
+    expect(queue.pending).toEqual([]);
+    expect(store.getSnapshot().pendingCount).toBe(0);
+    expect(syncRequested).toBe(0);
+  });
+
   test("invalidates acknowledged restores after an external recurrence edit", async () => {
     const task = makeTask({
       recurrence: "FREQ=WEEKLY",

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.ts
@@ -1,19 +1,14 @@
 import { z } from "zod";
 
 import { TypedStorage } from "../cache/storage";
-import type {
-  CreateTaskRequest,
-  Task,
-  TaskId,
-  UpdateTaskRequest,
-} from "../../domain/types";
+import type { Task, TaskId } from "../../domain/types";
 import { taskId } from "../../domain/types";
-import type { TaskStatus } from "../../domain/status";
 import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 import type { CommandQueue, DeadLetterEntry } from "../sync/CommandQueue";
 import {
   type Clock,
   type Command,
+  type CommandInput,
   applyCommand,
   commandTarget,
   makeCommandIdFactory,
@@ -36,15 +31,10 @@ import {
 /**
  * The single source of truth the UI reads.
  *
- * `base` is the last server snapshot; the visible task map is always
- * `rebase(base, queue.pending)` — recomputed on every change, never
- * persisted. That is the core offline-first invariant: the only durable
- * writes are the command queue (on dispatch) and the base cache (on server
- * acks/pulls), so no crash can ever capture a half-applied optimistic state.
- *
- * The store NEVER touches the network. Executing commands is the
- * SyncEngine's job; it reports results back through `applyServerAck` /
- * `replaceBase`.
+ * The visible map is `rebase(base, queue.pending)`, recomputed on every
+ * change. Only the command queue and server base are durable, so a crash
+ * cannot capture a half-applied optimistic state. The store never touches
+ * the network; SyncEngine reports results through acknowledgements or pulls.
  */
 
 export type TaskStoreSnapshot = {
@@ -55,28 +45,6 @@ export type TaskStoreSnapshot = {
   readonly deadLetters: readonly DeadLetterEntry[];
   readonly lastSyncTime: number | null;
 };
-
-/** Mutations as the UI expresses them — ids/timestamps are filled in here. */
-export type DispatchInput =
-  | { readonly type: "create"; readonly payload: CreateTaskRequest }
-  | {
-      readonly type: "update";
-      readonly taskId: TaskId;
-      readonly payload: UpdateTaskRequest;
-    }
-  | { readonly type: "delete"; readonly taskId: TaskId }
-  | {
-      readonly type: "set_status";
-      readonly taskId: TaskId;
-      readonly status: TaskStatus;
-    }
-  | {
-      readonly type: "set_instance_complete";
-      readonly taskId: TaskId;
-      readonly date: string;
-      readonly completed: boolean;
-      readonly restore?: RecurringCompletionRestore | undefined;
-    };
 
 export type TaskStoreStorage = {
   getTasks: () => Promise<Task[]>;
@@ -233,16 +201,25 @@ export class TaskStore {
   getSnapshot(): TaskStoreSnapshot {
     return this.snapshot;
   }
-  /**
-   * Record a mutation and return the optimistic result immediately. The
-   * enqueue is the only await — never the network. Returns the task as the
-   * UI will now see it (undefined after a delete).
-   */
-  async dispatch(input: DispatchInput): Promise<Task | undefined> {
+  /** Record a mutation and return its immediate optimistic result. */
+  async dispatch(input: CommandInput) {
+    return this.dispatchLocked(input, false);
+  }
+  async dispatchIfTaskExists(
+    input: Exclude<CommandInput, { readonly type: "create" }>,
+  ) {
+    return this.dispatchLocked(input, true);
+  }
+  private async dispatchLocked(
+    input: CommandInput,
+    requireExistingTask: boolean,
+  ) {
     return this.enqueueOperation(async () => {
-      // Build inside the serialized operation so a stale temp id is resolved
-      // only after any in-flight create acknowledgement has committed its
-      // alias and snapshot together.
+      // Resolve aliases and validate existence within the durable queue lock.
+      if (requireExistingTask && input.type !== "create") {
+        const target = this.resolveTaskId(input.taskId);
+        if (!this.snapshot.tasks.has(target)) return;
+      }
       const command = this.buildCommand(input);
       await this.queue.enqueue(command);
       let nextAcknowledgedCompletionRestores =
@@ -423,7 +400,7 @@ export class TaskStore {
     });
   }
 
-  private buildCommand(input: DispatchInput): Command {
+  private buildCommand(input: CommandInput): Command {
     const base = { id: this.nextCommandId(), createdAt: this.clock() };
     switch (input.type) {
       case "create":

--- a/packages/tasks-for-obsidian/src/data/sync/commands.ts
+++ b/packages/tasks-for-obsidian/src/data/sync/commands.ts
@@ -100,7 +100,12 @@ export type Command =
   | SetInstanceCompleteCommand;
 
 type WithoutCommandMetadata<CommandType> = CommandType extends Command
-  ? Omit<CommandType, "id" | "createdAt">
+  ? Omit<
+      CommandType,
+      | "id"
+      | "createdAt"
+      | (CommandType extends CreateCommand ? "tempId" : never)
+    >
   : never;
 
 export type CommandInput = WithoutCommandMetadata<Command>;

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { executeTaskToggle, recurringCompletionRestore } from "./task-toggle";
+import {
+  executeTaskToggle,
+  recurringCompletionRestore,
+  successfulCompletionUndos,
+} from "./task-toggle";
 import { taskId } from "./types";
 import type { Task } from "./types";
 import type { RecurringCompletionRestore } from "tasknotes-types/v2";
@@ -48,9 +52,10 @@ describe("executeTaskToggle", () => {
 
     expect(execution).toEqual({
       result: "instance",
-      recurring: {
+      completionUndo: {
+        kind: "recurring-occurrence",
+        taskId: taskId("weekly"),
         date: "2026-08-15",
-        completed: true,
         restore: {
           scheduled: "2026-08-08",
           due: null,
@@ -79,7 +84,7 @@ describe("executeTaskToggle", () => {
 
     expect(execution).toEqual({
       result: "instance",
-      recurring: { date: "2026-08-15", completed: false, restore: null },
+      completionUndo: null,
     });
     expect(calls).toEqual([{ date: "2026-08-15", completed: false }]);
   });
@@ -107,7 +112,7 @@ describe("executeTaskToggle", () => {
     );
 
     expect(received).toEqual(restore);
-    expect(execution.recurring?.restore).toEqual(restore);
+    expect(execution.completionUndo).toBeNull();
   });
 
   test("captures the exact recurrence fields needed by atomic Undo", () => {
@@ -139,8 +144,47 @@ describe("executeTaskToggle", () => {
       setInstanceComplete: async () => "instance",
     });
 
-    expect(execution).toEqual({ result: "status", recurring: null });
+    expect(execution).toEqual({
+      result: "status",
+      completionUndo: {
+        kind: "status",
+        taskId: taskId("weekly"),
+        previousStatus: "open",
+      },
+    });
     expect(statusCalls).toBe(1);
+  });
+
+  test("captures the exact prior in-progress status for Undo", async () => {
+    const task = {
+      ...recurringTask([]),
+      recurrence: undefined,
+      status: "in-progress" as const,
+    };
+    const execution = await executeTaskToggle(task, undefined, "occurrence", {
+      toggleStatus: async () => "status",
+      setInstanceComplete: async () => "instance",
+    });
+
+    expect(execution.completionUndo).toEqual({
+      kind: "status",
+      taskId: taskId("weekly"),
+      previousStatus: "in-progress",
+    });
+  });
+
+  test("does not advertise Undo for a non-completing status transition", async () => {
+    const task = {
+      ...recurringTask([]),
+      recurrence: undefined,
+      status: "waiting" as const,
+    };
+    const execution = await executeTaskToggle(task, undefined, "occurrence", {
+      toggleStatus: async () => "status",
+      setInstanceComplete: async () => "instance",
+    });
+
+    expect(execution.completionUndo).toBeNull();
   });
 
   test("uses the parent status workflow for a completed recurring task", async () => {
@@ -158,8 +202,26 @@ describe("executeTaskToggle", () => {
       },
     });
 
-    expect(execution).toEqual({ result: "status", recurring: null });
+    expect(execution).toEqual({ result: "status", completionUndo: null });
     expect(statusCalls).toBe(1);
     expect(instanceCalls).toBe(0);
+  });
+});
+
+describe("successfulCompletionUndos", () => {
+  const undo = {
+    kind: "status",
+    taskId: taskId("plain"),
+    previousStatus: "open",
+  } as const;
+
+  test("groups only successful completion inverses", () => {
+    expect(
+      successfulCompletionUndos([
+        { result: { ok: true }, completionUndo: undo },
+        { result: { ok: false }, completionUndo: undo },
+        { result: { ok: true }, completionUndo: null },
+      ]),
+    ).toEqual([undo]);
   });
 });

--- a/packages/tasks-for-obsidian/src/domain/task-toggle.ts
+++ b/packages/tasks-for-obsidian/src/domain/task-toggle.ts
@@ -1,18 +1,26 @@
 import { completionTargetDate, isRecurring } from "./recurrence";
+import { getNextStatus, isCompletedStatus } from "./status";
 import type { Task } from "./types";
 import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 
 export const UNDO_TOAST_MS = 5000;
 
-export type RecurringToggleExecution = {
-  readonly date: string;
-  readonly completed: boolean;
-  readonly restore: RecurringCompletionRestore | null;
-};
+export type CompletionUndo =
+  | {
+      readonly kind: "status";
+      readonly taskId: Task["id"];
+      readonly previousStatus: Task["status"];
+    }
+  | {
+      readonly kind: "recurring-occurrence";
+      readonly taskId: Task["id"];
+      readonly date: string;
+      readonly restore: RecurringCompletionRestore;
+    };
 
 export type TaskToggleExecution<Result> = {
   readonly result: Result;
-  readonly recurring: RecurringToggleExecution | null;
+  readonly completionUndo: CompletionUndo | null;
 };
 
 type PendingRestore =
@@ -40,9 +48,10 @@ export async function executeTaskToggle<Result>(
   },
 ): Promise<TaskToggleExecution<Result>> {
   if (task === undefined || scope === "task-status" || !isRecurring(task)) {
+    const completionUndo = statusCompletionUndo(task);
     return {
       result: await operations.toggleStatus(),
-      recurring: null,
+      completionUndo,
     };
   }
 
@@ -57,11 +66,28 @@ export async function executeTaskToggle<Result>(
       completed,
       restore ?? undefined,
     ),
-    recurring: {
-      date,
-      completed,
-      restore,
-    },
+    completionUndo:
+      completed && restore !== null
+        ? {
+            kind: "recurring-occurrence",
+            taskId: task.id,
+            date,
+            restore,
+          }
+        : null,
+  };
+}
+
+function statusCompletionUndo(task: Task | undefined): CompletionUndo | null {
+  if (task === undefined) return null;
+  const nextStatus = getNextStatus(task.status);
+  if (isCompletedStatus(task.status) || !isCompletedStatus(nextStatus)) {
+    return null;
+  }
+  return {
+    kind: "status",
+    taskId: task.id,
+    previousStatus: task.status,
   };
 }
 
@@ -78,4 +104,14 @@ export function recurringCompletionRestore(
     recurrence: task.recurrence,
     skipped: task.skippedInstances.includes(date),
   };
+}
+
+export function successfulCompletionUndos(
+  executions: readonly TaskToggleExecution<{ readonly ok: boolean }>[],
+): readonly CompletionUndo[] {
+  return executions.flatMap((execution) =>
+    execution.result.ok && execution.completionUndo !== null
+      ? [execution.completionUndo]
+      : [],
+  );
 }

--- a/packages/tasks-for-obsidian/src/domain/undo-stack.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/undo-stack.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  activeUndoEntry,
+  undoStackReducer,
+  type UndoStackEntry,
+} from "./undo-stack";
+
+function entry(id: number): UndoStackEntry {
+  return {
+    id,
+    message: `Undo ${String(id)}`,
+    onUndo: async () => id > 0,
+  };
+}
+
+describe("undoStackReducer", () => {
+  test("changes the active identity on push and pop to reset the LIFO timer", () => {
+    const first = undoStackReducer([], { type: "push", entry: entry(1) });
+    const second = undoStackReducer(first, { type: "push", entry: entry(2) });
+
+    expect(activeUndoEntry(second)?.id).toBe(2);
+    const popped = undoStackReducer(second, { type: "remove", id: 2 });
+    expect(activeUndoEntry(popped)?.id).toBe(1);
+  });
+
+  test("removes a stable request without dropping newer entries", () => {
+    const stack = [entry(1), entry(2), entry(3)];
+
+    expect(
+      undoStackReducer(stack, { type: "remove", id: 2 }).map(({ id }) => id),
+    ).toEqual([1, 3]);
+  });
+
+  test("clears every completion when the inactivity timer expires", () => {
+    expect(undoStackReducer([entry(1), entry(2)], { type: "clear" })).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/tasks-for-obsidian/src/domain/undo-stack.ts
+++ b/packages/tasks-for-obsidian/src/domain/undo-stack.ts
@@ -1,0 +1,30 @@
+export type UndoStackEntry = {
+  readonly id: number;
+  readonly message: string;
+  readonly onUndo: () => Promise<boolean>;
+};
+
+export type UndoStackAction =
+  | { readonly type: "push"; readonly entry: UndoStackEntry }
+  | { readonly type: "remove"; readonly id: number }
+  | { readonly type: "clear" };
+
+export function undoStackReducer(
+  stack: readonly UndoStackEntry[],
+  action: UndoStackAction,
+): readonly UndoStackEntry[] {
+  switch (action.type) {
+    case "push":
+      return [...stack, action.entry];
+    case "remove":
+      return stack.filter((entry) => entry.id !== action.id);
+    case "clear":
+      return [];
+  }
+}
+
+export function activeUndoEntry(
+  stack: readonly UndoStackEntry[],
+): UndoStackEntry | null {
+  return stack.at(-1) ?? null;
+}

--- a/packages/tasks-for-obsidian/src/hooks/use-task-list-screen.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-task-list-screen.ts
@@ -12,22 +12,8 @@ import {
 } from "../domain/recurrence";
 import { isCompletedStatus } from "../domain/status";
 import { useTasks } from "./use-tasks";
-import { showResultError } from "../lib/errors";
+import { showBulkResultErrors, showResultError } from "../lib/errors";
 import { feedbackTaskComplete, feedbackTaskDelete } from "../lib/feedback";
-
-// One aggregated alert per bulk action — per-task alerts would stack N deep.
-function alertBulkFailures(
-  title: string,
-  results: readonly { ok: boolean }[],
-  total: number,
-): void {
-  const failed = results.filter((r) => !r.ok).length;
-  if (failed === 0) return;
-  Alert.alert(
-    title,
-    `${String(failed)} of ${String(total)} task${total === 1 ? "" : "s"} could not be updated. They may have been renamed or deleted in Obsidian.`,
-  );
-}
 
 type NavigateFn = {
   navigate: (screen: string, params?: Record<string, unknown>) => void;
@@ -126,21 +112,14 @@ export function useTaskListScreen(navigation: NavigateFn) {
             : localTodayYmd();
           return !isCompletedOn(task, day);
         });
-        const results = await Promise.all(
-          targets.map((id) => {
-            const occurrenceDate = completionDateByTaskId?.get(id);
-            return occurrenceDate === undefined
-              ? tasks.toggleTask(id, { suppressUndo: true })
-              : tasks.toggleTask(id, {
-                  occurrenceDate,
-                  suppressUndo: true,
-                });
-          }),
+        const results = await tasks.completeTasks(
+          targets,
+          completionDateByTaskId,
         );
-        alertBulkFailures("Complete Failed", results, targets.length);
+        showBulkResultErrors(results, targets.length, "Complete Failed");
       })();
     },
-    [tasks.getTask, tasks.toggleTask],
+    [tasks.completeTasks, tasks.getTask],
   );
 
   const handleBulkDelete = useCallback(
@@ -159,7 +138,7 @@ export function useTaskListScreen(navigation: NavigateFn) {
                 const results = await Promise.all(
                   ids.map((id) => tasks.deleteTask(id)),
                 );
-                alertBulkFailures("Delete Failed", results, ids.length);
+                showBulkResultErrors(results, ids.length, "Delete Failed");
               })();
               onDeleted?.();
             },
@@ -181,7 +160,7 @@ export function useTaskListScreen(navigation: NavigateFn) {
             ),
           ),
         );
-        alertBulkFailures("Reschedule Failed", results, ids.length);
+        showBulkResultErrors(results, ids.length, "Reschedule Failed");
       })();
     },
     [tasks.updateTask],
@@ -193,7 +172,7 @@ export function useTaskListScreen(navigation: NavigateFn) {
         const results = await Promise.all(
           ids.map((id) => tasks.updateTask(id, { priority })),
         );
-        alertBulkFailures("Priority Failed", results, ids.length);
+        showBulkResultErrors(results, ids.length, "Priority Failed");
       })();
     },
     [tasks.updateTask],

--- a/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
+++ b/packages/tasks-for-obsidian/src/hooks/use-tasks.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
 
-import type { TaskId } from "../domain/types";
+import type { Task, TaskId } from "../domain/types";
+import type { AppError } from "../domain/errors";
+import type { Result } from "../domain/result";
 import { isActiveStatus } from "../domain/status";
 import {
   completionTargetDate,
@@ -13,13 +15,29 @@ import {
   deriveUpcomingAgenda,
 } from "../domain/agenda";
 import type { AgendaDateKind } from "../domain/agenda";
-import { executeTaskToggle } from "../domain/task-toggle";
+import {
+  executeTaskToggle,
+  successfulCompletionUndos,
+  type CompletionUndo,
+  type TaskToggleExecution,
+} from "../domain/task-toggle";
 import { findTaskByResolvedId } from "../domain/task-lookup";
 import { deriveProjectOptions } from "../domain/project-options";
 import { useUndo } from "../state/UndoContext";
 import { feedbackTaskUncomplete } from "../lib/feedback";
 import { formatDate } from "../lib/dates";
+import { showBulkResultErrors, showResultError } from "../lib/errors";
 import { useTaskContext } from "../state/TaskContext";
+
+type ToggleTaskOptions = {
+  readonly occurrenceDate?: string | undefined;
+  readonly scope?: "occurrence" | "task-status" | undefined;
+};
+
+type ToggleTaskOutcome = {
+  readonly task: Task | undefined;
+  readonly execution: TaskToggleExecution<Result<Task, AppError>>;
+};
 
 export function useTasks() {
   const ctx = useTaskContext();
@@ -177,15 +195,11 @@ export function useTasks() {
     [taskList, today],
   );
 
-  const toggleTask = useCallback(
+  const executeToggle = useCallback(
     async (
       id: TaskId,
-      options?: {
-        occurrenceDate?: string;
-        scope?: "occurrence" | "task-status";
-        suppressUndo?: boolean;
-      },
-    ) => {
+      options?: ToggleTaskOptions,
+    ): Promise<ToggleTaskOutcome> => {
       const task = findTaskByResolvedId(ctx.tasks, ctx.resolveTaskId, id);
       const execution = await executeTaskToggle(
         task ?? undefined,
@@ -204,27 +218,97 @@ export function useTasks() {
                 ),
         },
       );
-      const recurring = execution.recurring;
-      if (
-        recurring !== null &&
-        recurring.completed &&
-        recurring.restore !== null &&
-        execution.result.ok &&
-        options?.suppressUndo !== true
-      ) {
-        const restore = recurring.restore;
-        const next = task ? nextOccurrenceAfter(task, recurring.date) : null;
-        showUndo({
-          message: next ? `Completed · Next: ${formatDate(next)}` : "Completed",
-          onUndo: () => {
-            feedbackTaskUncomplete();
-            void ctx.setInstanceComplete(id, recurring.date, false, restore);
-          },
-        });
+      return { task: task ?? undefined, execution };
+    },
+    [ctx],
+  );
+
+  const restoreCompletion = useCallback(
+    (undo: CompletionUndo): Promise<Result<Task, AppError>> => {
+      switch (undo.kind) {
+        case "status":
+          return ctx.setStatus(undo.taskId, undo.previousStatus);
+        case "recurring-occurrence":
+          return ctx.setInstanceComplete(
+            undo.taskId,
+            undo.date,
+            false,
+            undo.restore,
+          );
+      }
+    },
+    [ctx],
+  );
+
+  const pushCompletionUndo = useCallback(
+    (message: string, undos: readonly CompletionUndo[]) => {
+      if (undos.length === 0) return;
+      showUndo({
+        message,
+        onUndo: async () => {
+          feedbackTaskUncomplete();
+          const results = await Promise.all(
+            undos.map((undo) => restoreCompletion(undo)),
+          );
+          if (results.length === 1) {
+            const result = results[0];
+            if (result === undefined) {
+              throw new TypeError("single completion undo requires one result");
+            }
+            return !showResultError(result, "Undo Failed");
+          }
+          return !showBulkResultErrors(results, undos.length, "Undo Failed");
+        },
+      });
+    },
+    [restoreCompletion, showUndo],
+  );
+
+  const toggleTask = useCallback(
+    async (id: TaskId, options?: ToggleTaskOptions) => {
+      const { task, execution } = await executeToggle(id, options);
+      const undo = execution.completionUndo;
+      if (undo !== null && execution.result.ok) {
+        const next =
+          task !== undefined && undo.kind === "recurring-occurrence"
+            ? nextOccurrenceAfter(task, undo.date)
+            : null;
+        pushCompletionUndo(
+          next ? `Completed · Next: ${formatDate(next)}` : "Completed",
+          [undo],
+        );
       }
       return execution.result;
     },
-    [ctx, showUndo],
+    [executeToggle, pushCompletionUndo],
+  );
+
+  const completeTasks = useCallback(
+    async (
+      ids: readonly TaskId[],
+      completionDateByTaskId?: ReadonlyMap<TaskId, string>,
+    ): Promise<readonly Result<Task, AppError>[]> => {
+      const outcomes = await Promise.all(
+        ids.map((id) => {
+          const occurrenceDate = completionDateByTaskId?.get(id);
+          return executeToggle(
+            id,
+            occurrenceDate === undefined ? undefined : { occurrenceDate },
+          );
+        }),
+      );
+      const successfulUndos = successfulCompletionUndos(
+        outcomes.map(({ execution }) => execution),
+      );
+      if (successfulUndos.length > 0) {
+        pushCompletionUndo(
+          `Completed ${String(successfulUndos.length)} task${successfulUndos.length === 1 ? "" : "s"}`,
+          successfulUndos,
+        );
+      }
+      return outcomes.map(({ execution }) => execution.result);
+    },
+    [executeToggle, pushCompletionUndo],
   );
 
   const getTask = useCallback(
@@ -261,6 +345,7 @@ export function useTasks() {
     contextNames,
     dayCounts,
     toggleTask,
+    completeTasks,
     getTask,
     refresh,
     refreshing,

--- a/packages/tasks-for-obsidian/src/lib/errors.ts
+++ b/packages/tasks-for-obsidian/src/lib/errors.ts
@@ -12,3 +12,18 @@ export function showResultError<T>(
   Alert.alert(title, result.error.message);
   return true;
 }
+
+export function showBulkResultErrors(
+  results: readonly { readonly ok: boolean }[],
+  total: number,
+  title: string,
+): boolean {
+  const failed = results.filter((result) => !result.ok).length;
+  if (failed === 0) return false;
+  feedbackError();
+  Alert.alert(
+    title,
+    `${String(failed)} of ${String(total)} task${total === 1 ? "" : "s"} could not be updated. They may have been renamed or deleted in Obsidian.`,
+  );
+  return true;
+}

--- a/packages/tasks-for-obsidian/src/navigation/AppNavigator.tsx
+++ b/packages/tasks-for-obsidian/src/navigation/AppNavigator.tsx
@@ -7,7 +7,6 @@ import {
 } from "@react-navigation/native-stack";
 
 import { useSettings } from "../hooks/use-settings";
-import { AppIcon } from "../components/common/AppIcon";
 import { linking } from "./linking";
 import { navigationRef } from "./navigation-ref";
 import { MainTabNavigator } from "./main-tabs";
@@ -34,6 +33,42 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 type MainTabsProps = NativeStackScreenProps<RootStackParamList, "Main">;
 
+function HeaderAction({
+  symbol,
+  fallback,
+  color,
+  label,
+  testID,
+  onPress,
+}: {
+  readonly symbol: string;
+  readonly fallback: "search" | "settings";
+  readonly color: string;
+  readonly label: string;
+  readonly testID: string;
+  readonly onPress: () => void;
+}) {
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.headerAction,
+        pressed && styles.headerActionPressed,
+      ]}
+      onPress={onPress}
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+    >
+      <PlatformSymbol
+        symbol={symbol}
+        fallback={fallback}
+        size={22}
+        color={color}
+      />
+    </Pressable>
+  );
+}
+
 function MainTabs({ navigation }: MainTabsProps) {
   const { colors } = useSettings();
 
@@ -55,28 +90,26 @@ function MainTabs({ navigation }: MainTabsProps) {
         ),
         headerRight: () => (
           <View style={styles.headerActions}>
-            <Pressable
+            <HeaderAction
+              symbol="magnifyingglass"
+              fallback="search"
+              color={colors.text}
+              label="Search"
+              testID="header-search"
               onPress={() => {
                 navigation.navigate("Search");
               }}
-              hitSlop={8}
-              testID="header-search"
-              accessibilityRole="button"
-              accessibilityLabel="Search"
-            >
-              <AppIcon name="search" size={22} color={colors.text} />
-            </Pressable>
-            <Pressable
+            />
+            <HeaderAction
+              symbol="gearshape"
+              fallback="settings"
+              color={colors.text}
+              label="Settings"
+              testID="tab-settings"
               onPress={() => {
                 navigation.navigate("Settings");
               }}
-              hitSlop={8}
-              testID="tab-settings"
-              accessibilityRole="button"
-              accessibilityLabel="Settings"
-            >
-              <AppIcon name="settings" size={22} color={colors.text} />
-            </Pressable>
+            />
           </View>
         ),
       })}
@@ -247,6 +280,15 @@ export const AppNavigator = React.memo(function AppNavigatorComponent() {
 const styles = StyleSheet.create({
   headerActions: {
     flexDirection: "row",
-    gap: 12,
+    marginRight: 4,
+  },
+  headerAction: {
+    width: 44,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerActionPressed: {
+    opacity: 0.5,
   },
 });

--- a/packages/tasks-for-obsidian/src/navigation/E2EConfigHandler.tsx
+++ b/packages/tasks-for-obsidian/src/navigation/E2EConfigHandler.tsx
@@ -4,7 +4,11 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import { TIPS_DISABLED_KEY } from "../hooks/use-tip";
 import { useSettingsContext } from "../state/SettingsContext";
-import { parseE2EConfigUrl, setE2EToday } from "./e2e-config";
+import {
+  markE2EConfigActive,
+  parseE2EConfigUrl,
+  setE2EToday,
+} from "./e2e-config";
 import { navigationRef } from "./navigation-ref";
 
 /**
@@ -29,6 +33,7 @@ export function E2EConfigHandler() {
     async function applyConfig(url: string): Promise<void> {
       const config = parseE2EConfigUrl(url);
       if (config === null) return;
+      markE2EConfigActive();
       setReadyNonce(null);
       setE2EToday(config.today);
       if (config.tipsOff) {

--- a/packages/tasks-for-obsidian/src/navigation/e2e-config.ts
+++ b/packages/tasks-for-obsidian/src/navigation/e2e-config.ts
@@ -8,6 +8,20 @@ export type E2EConfig = {
 };
 
 let configuredToday: string | null = null;
+let e2eConfigActive = false;
+
+export function markE2EConfigActive(): void {
+  e2eConfigActive = true;
+}
+
+/**
+ * iOS accessibility snapshots can take longer than the product's five-second
+ * Undo window. Debug E2E sessions stretch the same inactivity timer so Maestro
+ * can exercise the action; release builds never activate this override.
+ */
+export function e2eUndoToastMs(productDurationMs: number): number {
+  return e2eConfigActive ? 60_000 : productDurationMs;
+}
 
 export function setE2EToday(today: string | null): void {
   configuredToday = today;

--- a/packages/tasks-for-obsidian/src/screens/SearchScreen.tsx
+++ b/packages/tasks-for-obsidian/src/screens/SearchScreen.tsx
@@ -62,6 +62,7 @@ export function SearchScreen({ navigation }: Props) {
           placeholderTextColor={colors.textTertiary}
           autoFocus
           returnKeyType="search"
+          testID="search-input"
           accessibilityLabel="Search tasks"
           accessibilityHint="Type to search by title, project, context, or tag"
         />

--- a/packages/tasks-for-obsidian/src/screens/TaskDetailScreen.tsx
+++ b/packages/tasks-for-obsidian/src/screens/TaskDetailScreen.tsx
@@ -70,8 +70,8 @@ export function TaskDetailScreen({ route, navigation }: Props) {
   }
 
   // Native form-sheet screens live above the root React Navigation surface.
-  // Scope the Undo host to this presentation so recurring-completion feedback
-  // and its action render inside the sheet instead of behind its dimming view.
+  // The nested provider reuses the app-level stack while hosting its toast in
+  // this presentation, so navigation cannot discard a pending detail Undo.
   return (
     <UndoProvider>
       <TaskDetailRoute task={task} navigation={navigation} />

--- a/packages/tasks-for-obsidian/src/state/TaskContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/TaskContext.tsx
@@ -14,6 +14,7 @@ import { NotFoundError } from "../domain/errors";
 import type { Result } from "../domain/result";
 import { OK_VOID, err, ok } from "../domain/result";
 import { getNextStatus } from "../domain/status";
+import type { TaskStatus } from "../domain/status";
 import type { RecurringCompletionRestore } from "tasknotes-types/v2";
 import type {
   CreateTaskRequest,
@@ -56,6 +57,10 @@ type TaskContextValue = {
     req: UpdateTaskRequest,
   ) => Promise<Result<Task, AppError>>;
   deleteTask: (id: TaskId) => Promise<Result<void, AppError>>;
+  setStatus: (
+    id: TaskId,
+    status: TaskStatus,
+  ) => Promise<Result<Task, AppError>>;
   toggleStatus: (id: TaskId) => Promise<Result<Task, AppError>>;
   setInstanceComplete: (
     id: TaskId,
@@ -153,13 +158,9 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       id: TaskId,
       req: UpdateTaskRequest,
     ): Promise<Result<Task, AppError>> => {
-      const target = store.resolveTaskId(id);
-      if (!store.getSnapshot().tasks.has(target)) {
-        return err(new NotFoundError("Task", String(id)));
-      }
-      const updated = await store.dispatch({
+      const updated = await store.dispatchIfTaskExists({
         type: "update",
-        taskId: target,
+        taskId: id,
         payload: req,
       });
       if (updated === undefined) {
@@ -178,17 +179,12 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
     [store],
   );
 
-  const toggleStatus = useCallback(
-    async (id: TaskId): Promise<Result<Task, AppError>> => {
-      const target = store.resolveTaskId(id);
-      const existing = store.getSnapshot().tasks.get(target);
-      if (existing === undefined) {
-        return err(new NotFoundError("Task", String(id)));
-      }
-      const updated = await store.dispatch({
+  const setStatus = useCallback(
+    async (id: TaskId, status: TaskStatus): Promise<Result<Task, AppError>> => {
+      const updated = await store.dispatchIfTaskExists({
         type: "set_status",
-        taskId: target,
-        status: getNextStatus(existing.status),
+        taskId: id,
+        status,
       });
       if (updated === undefined) {
         return err(new NotFoundError("Task", String(id)));
@@ -196,6 +192,18 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       return ok(updated);
     },
     [store],
+  );
+
+  const toggleStatus = useCallback(
+    async (id: TaskId): Promise<Result<Task, AppError>> => {
+      const target = store.resolveTaskId(id);
+      const existing = store.getSnapshot().tasks.get(target);
+      if (existing === undefined) {
+        return err(new NotFoundError("Task", String(id)));
+      }
+      return setStatus(target, getNextStatus(existing.status));
+    },
+    [setStatus, store],
   );
 
   // Absolute per-instance completion — the undo path for a recurring
@@ -209,10 +217,9 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       completed: boolean,
       restore?: RecurringCompletionRestore,
     ): Promise<Result<Task, AppError>> => {
-      const target = store.resolveTaskId(id);
-      const updated = await store.dispatch({
+      const updated = await store.dispatchIfTaskExists({
         type: "set_instance_complete",
-        taskId: target,
+        taskId: id,
         date,
         completed,
         ...(restore === undefined ? {} : { restore }),
@@ -262,6 +269,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       createTask,
       updateTask,
       deleteTask,
+      setStatus,
       toggleStatus,
       setInstanceComplete,
       refreshTasks,
@@ -276,6 +284,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       createTask,
       updateTask,
       deleteTask,
+      setStatus,
       toggleStatus,
       setInstanceComplete,
       refreshTasks,

--- a/packages/tasks-for-obsidian/src/state/UndoContext.tsx
+++ b/packages/tasks-for-obsidian/src/state/UndoContext.tsx
@@ -3,56 +3,111 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
+import { StyleSheet, View } from "react-native";
 import { UndoToast } from "../components/common/UndoToast";
+import { activeUndoEntry, undoStackReducer } from "../domain/undo-stack";
 
 type UndoRequest = {
   message: string;
-  onUndo: () => void;
+  onUndo: () => Promise<boolean>;
 };
 
 type UndoContextValue = {
-  /** Replaces any currently-showing toast. */
+  /** Pushes a request onto the transient completion-undo stack. */
   showUndo: (request: UndoRequest) => void;
+  active: ReturnType<typeof activeUndoEntry>;
+  depth: number;
+  undoInFlight: boolean;
+  dismiss: () => void;
+  handleUndo: () => void;
 };
 
 const UndoContext = createContext<UndoContextValue | null>(null);
 
 export function UndoProvider({ children }: { children: React.ReactNode }) {
-  const [active, setActive] = useState<UndoRequest | null>(null);
-  // A monotonically increasing key so a replacement toast restarts the
-  // UndoToast timer effect even when `visible` never flips false.
-  const generation = useRef(0);
+  const parent = useContext(UndoContext);
+  if (parent !== null) {
+    return <UndoHost value={parent}>{children}</UndoHost>;
+  }
+  return <UndoStateProvider>{children}</UndoStateProvider>;
+}
+
+function UndoStateProvider({ children }: { children: React.ReactNode }) {
+  const [stack, dispatch] = useReducer(undoStackReducer, []);
+  const [undoInFlight, setUndoInFlight] = useState(false);
+  const nextId = useRef(0);
+  const active = activeUndoEntry(stack);
 
   const showUndo = useCallback((request: UndoRequest) => {
-    generation.current += 1;
-    setActive(request);
+    nextId.current += 1;
+    dispatch({
+      type: "push",
+      entry: { id: nextId.current, ...request },
+    });
   }, []);
 
   const dismiss = useCallback(() => {
-    setActive(null);
+    dispatch({ type: "clear" });
   }, []);
 
   const handleUndo = useCallback(() => {
-    active?.onUndo();
-    setActive(null);
-  }, [active]);
+    if (active === null || undoInFlight) return;
+    const entry = active;
+    setUndoInFlight(true);
+    void (async () => {
+      try {
+        if (await entry.onUndo()) {
+          dispatch({ type: "remove", id: entry.id });
+        }
+      } finally {
+        setUndoInFlight(false);
+      }
+    })();
+  }, [active, undoInFlight]);
 
-  const value = useMemo(() => ({ showUndo }), [showUndo]);
+  const value = useMemo(
+    () => ({
+      showUndo,
+      active,
+      depth: stack.length,
+      undoInFlight,
+      dismiss,
+      handleUndo,
+    }),
+    [active, dismiss, handleUndo, showUndo, stack.length, undoInFlight],
+  );
 
   return (
     <UndoContext.Provider value={value}>
+      <UndoHost value={value}>{children}</UndoHost>
+    </UndoContext.Provider>
+  );
+}
+
+function UndoHost({
+  children,
+  value,
+}: {
+  readonly children: React.ReactNode;
+  readonly value: UndoContextValue;
+}) {
+  return (
+    <View style={styles.host}>
       {children}
       <UndoToast
-        key={generation.current}
-        visible={active !== null}
-        message={active?.message ?? ""}
-        onUndo={handleUndo}
-        onDismiss={dismiss}
+        visible={value.active !== null}
+        requestId={value.active?.id ?? null}
+        depth={value.depth}
+        message={value.active?.message ?? ""}
+        undoInFlight={value.undoInFlight}
+        onUndo={value.handleUndo}
+        onDismiss={value.dismiss}
       />
-    </UndoContext.Provider>
+    </View>
   );
 }
 
@@ -63,3 +118,9 @@ export function useUndo(): UndoContextValue {
   }
   return ctx;
 }
+
+const styles = StyleSheet.create({
+  host: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Summary

- isolate the native context menu to the 44-point overflow control so task text renders and the detail row opens on its first tap on iOS 27
- replace the clipped search/settings header icons with 44-point SF Symbol toolbar actions
- make every in-app completion path undoable through a five-second LIFO stack, including exact status, recurring occurrence, and grouped bulk restoration
- keep detail-screen entries across navigation and retain failed restores for retry without allowing duplicate taps
- replace the springing Undo toast with short eased motion and an opacity-only Reduce Motion path

## Verification

- 501 unit tests passed (1,066 assertions)
- 18 contract tests passed
- typecheck and ESLint passed
- Release Metro bundle validation passed (10,071,227 bytes; React/RN/scheduler singleton checks)
- documentation validation and staged-file safety hooks passed
- complete ordered Maestro suite passed: 12 flows plus all 13 vault assertions on iPhone 17 Pro / iOS 27.0
- focused detail flow passed first-tap navigation and Undo after dismissing the native form sheet
- product-duration evidence flow passed with the real five-second Undo timer, both with Reduce Motion off and on

## Visual evidence

Task titles/metadata and native search/settings toolbar controls on iOS 27:

![tasknotes-ios27-task-text-toolbar.png](https://public.sjer.red/pr/assets/2076/tasknotes-ios27-task-text-toolbar.png)

Undo motion comparison: Reduce Motion off on the left, on on the right. Both expire after five seconds without bounce or overshoot:

[tasknotes-undo-motion-off-on.mp4 (video)](https://public.sjer.red/pr/assets/2076/tasknotes-undo-motion-off-on.mp4)

## Acceptance boundary

Final acceptance on a physical iPhone remains a human check on the next iOS 27 beta/TestFlight build. This PR does not release or merge the build.
