### PR TITLE
docs(root): improve Git Spice metadata guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,31 @@ Buildkite step). They apply repo-wide; per-package `AGENTS.md` files add more.
 - **Severity discipline.** Only flag genuine issues (P0–P2); skip nits and anything
   a linter would catch. A clean diff should get a clean review.
 
+## Commit and PR Metadata
+
+Before creating or updating a feature PR, apply this checklist to the complete
+branch diff:
+
+- Every commit subject uses `type(scope): outcome`, names the behavior or result,
+  and avoids placeholders such as `update`, `changes`, `fix stuff`, `WIP`, or
+  `address feedback` without saying what changed.
+- The primary commit for a branch has a useful body with `Why`, `What`, and
+  `Verification` sections. Verification names exact commands and states any
+  live or production checks that were not run.
+- A PR title describes the complete branch outcome, not merely its first file,
+  commit, or implementation step.
+- A PR body is synthesized from the complete `base...branch` diff and contains
+  `Why`, `What`, and `Verification`. Add rollout notes or follow-up boundaries
+  when they affect reviewer acceptance.
+- Use `git-spice --fill` only as an optional draft or diagnostic. Inspect the
+  full branch diff and submit reviewed metadata explicitly with
+  `git-spice branch submit --title ... --body ...`.
+- After review changes, keep the PR narrative stable and use
+  `git-spice ... submit --update-only`; do not regenerate it blindly from
+  follow-up commits.
+- For user-visible changes, attach the required screenshot, GIF, video, or
+  other lightest artifact that proves the behavior.
+
 ## Documentation Discipline
 
 Do not create per-session journals or append session summaries to repository

--- a/packages/docs/plans/2026-08-09_git-spice-metadata-quality.md
+++ b/packages/docs/plans/2026-08-09_git-spice-metadata-quality.md
@@ -1,0 +1,43 @@
+---
+id: git-spice-metadata-quality-2026-08-09
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Improve Git Spice Commit and PR Metadata
+
+## Summary
+
+Define a clear metadata contract so every commit is meaningful and every PR
+accurately describes the complete branch diff. Agents compose PR titles and
+bodies explicitly instead of blindly relying on `git-spice --fill`.
+
+## Implementation
+
+- Update `AGENTS.md` with an objective pre-submit checklist for commit subjects,
+  primary commit bodies, PR titles, PR bodies, verification evidence, and visual
+  artifacts.
+- Update the tracked Git Spice skill and worked workflows to make the complete
+  branch diff the source for PR metadata, document multi-commit branches, and
+  show explicit title/body submission with a dry-run inspection.
+- Treat `--fill` as an optional draft or diagnostic. Use `--update-only` after
+  review changes so follow-up commits do not overwrite the narrative PR body.
+- Keep the commit hook and automated validation unchanged; enforcement is the
+  deterministic agent checklist and explicit submit workflow.
+
+## Verification
+
+- Confirm no guidance presents `git-spice --fill` as sufficient final metadata.
+- Run focused Prettier/Markdown checks and the staged pre-commit hook.
+- Exercise Git Spice dry-run and explicit title/body command forms without
+  publishing a PR.
+- Verify single-commit, multi-commit, stacked, and review-follow-up workflows
+  are all covered.
+
+## Remaining
+
+- [ ] Publish the guidance changes through a Git Spice PR and verify the workflow
+      with a real submission.

--- a/packages/dotfiles/dot_agents/skills/git-spice-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/git-spice-helper/SKILL.md
@@ -63,6 +63,39 @@ originals even across force-pushes. Squash-merging each PR still yields a clean,
 atomic trunk history. Do **not** try to make one PR per commit — that's a
 different tool's model.
 
+## Commit and PR metadata contract
+
+The commit hook checks Conventional Commit shape and scope, but it cannot judge
+whether a message explains the change. Agents must do that review before
+submitting:
+
+- Every commit subject uses `type(scope): outcome`, describes behavior or a
+  result, and avoids placeholders such as `update`, `changes`, `fix stuff`,
+  `WIP`, or an unexplained `address feedback`.
+- The primary commit for each branch carries the branch narrative in a body with
+  `Why`, `What`, and `Verification` sections. Verification lists exact commands
+  and clearly labels live or production checks that were not run.
+- A branch may contain multiple meaningful commits. The PR title and body are
+  authored from the complete `base...branch` diff, not copied from whichever
+  commit happens to be first or latest.
+- PR bodies contain `Why`, `What`, and `Verification`; add rollout notes when
+  they affect acceptance. User-visible changes include the appropriate media
+  evidence.
+- `--fill` is an optional draft or diagnostic. It is never a substitute for
+  reviewing the full diff and composing final PR metadata explicitly.
+
+Good metadata describes the outcome:
+
+```text
+fix(homelab): keep Buildkite agents awake during host idle periods
+```
+
+Weak metadata describes activity without an outcome:
+
+```text
+chore(root): update stuff
+```
+
 ## This repo's setup (shepherdjerred/monorepo)
 
 | Thing | Value |
@@ -106,11 +139,11 @@ checks staged files only; Buildkite runs the exhaustive whole-repo gate.
 # To add a branch ON TOP of the current one:
 git-spice branch create feature/auth-api      # no commit (commit=false); name required
 git add packages/…                            # stage the change
-git-spice commit create -m "feat(scout): auth api"   # commit + auto-restack upstack
+git-spice commit create -m "feat(scout): expose authenticated report API"   # commit + auto-restack upstack
 # repeat to keep stacking:
 git-spice branch create feature/auth-ui
 git add …
-git-spice commit create -m "feat(scout): auth ui"
+git-spice commit create -m "feat(scout): render authenticated report controls"
 ```
 
 `git-spice log short` (`gs ls`) shows the stack; add `-a` for every tracked branch.
@@ -126,22 +159,37 @@ git-spice branch checkout feature/auth-api   # jump to a specific branch
 ### 3. Submit the stack of PRs
 
 ```bash
-git-spice stack submit --fill        # open/update a PR per branch; titles/bodies from commits
+# Review each complete base...branch diff and compose its final title/body.
+git-spice branch submit --dry-run \
+  --title "feat(scout): add authenticated match reports" \
+  --body "Why: ... What: ... Verification: ..."
+git-spice branch submit \
+  --title "feat(scout): add authenticated match reports" \
+  --body "Why: ... What: ... Verification: ..."
+
+# For an existing, already-described stack, update branches without replacing
+# their narrative bodies from commit messages.
+git-spice stack submit --update-only
 # scope variants: git-spice branch submit | upstack submit | downstack submit
 ```
 
 Each PR targets its parent branch as base; git-spice posts a navigation comment
 showing the stack. Use `--dry-run` first to preview, `--draft` for drafts,
-`-r user,org/team` for reviewers.
+`-r user,org/team` for reviewers. `--fill` may be useful to draft or compare
+metadata, but do not publish it without checking the complete branch diff.
 
 ### 4. Address review feedback
 
 ```bash
 git-spice down                       # go to the branch under review
 git add …                            # make the fix
-git-spice commit amend               # or: git-spice commit create -m "…"  — both auto-restack the upstack
-git-spice stack submit --update-only # force-push updates to existing PRs only
+git-spice commit amend               # or: git-spice commit create -m "fix(scout): reject expired sessions"
+git-spice stack submit --update-only # force-push updates; preserves PR narratives
 ```
+
+Review-fix commits still need specific subjects. Do not replace the PR body
+with `--fill` after review; update the code and commits while keeping the
+branch-level `Why`/`What`/`Verification` narrative accurate.
 
 ### 5. Sync after a PR merges
 
@@ -185,9 +233,12 @@ git-spice rebase abort               # (gs rba) revert to the pre-rebase state
   own `buildkite/monorepo/pr` run, and every restack re-pushes → re-runs CI on
   the affected PRs. The **root of the stack must be independently landable**;
   feature-flag anything that would break a lower PR's CI on its own.
-- **Verify before every submit:** run focused package checks and commit through
-  the staged-file pre-commit hook. Do not run the root verification graph
-  locally by default; Buildkite runs it exhaustively for every PR.
+- **Verify before every submit:** inspect the complete base-to-branch diff,
+  confirm every commit has a meaningful subject, confirm the primary commit
+  body and PR body have `Why`/`What`/`Verification`, run focused package checks,
+  and commit through the staged-file pre-commit hook. Do not run the root
+  verification graph locally by default; Buildkite runs it exhaustively for
+  every PR.
 - **`repo sync` / `repo restack` are repo-global.** They act on all tracked
   branches; know what other stacks exist before running them.
 - **Stack state is local and never pushed.** A fresh clone / CI / a teammate has

--- a/packages/dotfiles/dot_agents/skills/git-spice-helper/references/command-reference.md
+++ b/packages/dotfiles/dot_agents/skills/git-spice-helper/references/command-reference.md
@@ -84,13 +84,16 @@ Global flags on every command: `-h/--help`, `--version`, `-v/--verbose`,
 
 ## Submit flags (branch/stack/upstack/downstack submit)
 
-`-n/--dry-run` · `-c/--fill` (title+body from commits) · `--[no-]draft` ·
+`-n/--dry-run` · `-c/--fill` (optional title/body draft from commits) · `--[no-]draft` ·
 `--[no-]publish` (`--no-publish` = push without opening a PR) · `-w/--web` ·
 `--nav-comment=true|false|multiple` · `--force` · `--no-verify` ·
 `-u/--[no-]update-only` (only update existing PRs) · `-l/--label=…` ·
 `-r/--reviewer=…` (`user` or `org/team`) · `-a/--assign=…`.
 
 Submission is idempotent — creates the PR if absent, updates it if present.
+For this repository, inspect the complete branch diff and provide final
+metadata explicitly with `--title` and `--body`; do not treat `--fill` as an
+unreviewed final.
 
 ## Auth
 

--- a/packages/dotfiles/dot_agents/skills/git-spice-helper/references/workflows.md
+++ b/packages/dotfiles/dot_agents/skills/git-spice-helper/references/workflows.md
@@ -3,6 +3,23 @@
 All examples use `git-spice` (agent/script-safe). Interactively, `gs` is the
 abbreviation. Run them from the checkout that manages the stack.
 
+## Metadata gate
+
+Before submitting a branch, inspect the complete `base...branch` diff and
+answer these questions:
+
+- Does every commit subject name a concrete behavior or result rather than an
+  activity or placeholder?
+- Does the primary commit explain `Why`, `What`, and `Verification`?
+- Does the PR title describe the complete branch outcome?
+- Does the PR body explain `Why`, `What`, and `Verification`, with exact checks
+  and explicit live-test boundaries?
+- Are required screenshots or recordings attached for user-visible changes?
+
+`git-spice --fill` can provide a draft or comparison point, but it is not final
+metadata. Compose the final title and body from the complete branch diff and
+submit them explicitly.
+
 ## 0. One-time per clone
 
 ```bash
@@ -17,9 +34,14 @@ This is the common case and matches the pre-git-spice flow.
 ```bash
 # Start on feature/<slug> off origin/main.
 git add packages/foo/…
-git-spice commit create -m "fix(foo): correct the thing"
+git-spice commit create -m "fix(foo): reject invalid match data"
 bun run verify -- --affected
-git-spice branch submit --fill        # opens ONE PR targeting main
+git-spice branch submit --dry-run \
+  --title "fix(foo): reject invalid match data" \
+  --body "Why: ... What: ... Verification: ..."
+git-spice branch submit \
+  --title "fix(foo): reject invalid match data" \
+  --body "Why: ... What: ... Verification: ..."
 ```
 
 ## 2. Build and submit a stack
@@ -27,18 +49,19 @@ git-spice branch submit --fill        # opens ONE PR targeting main
 ```bash
 # Bottom branch (feature/<slug>) already exists.
 git add packages/scout/schema/…
-git-spice commit create -m "feat(scout-for-lol): auth schema"
+git-spice commit create -m "feat(scout-for-lol): add authenticated report schema"
 
 git-spice branch create feature/auth-api      # no commit (commit=false), name required
 git add packages/scout/api/…
-git-spice commit create -m "feat(scout-for-lol): auth api"
+git-spice commit create -m "feat(scout-for-lol): expose authenticated report API"
 
 git-spice branch create feature/auth-ui
 git add packages/scout/web/…
-git-spice commit create -m "feat(scout-for-lol): auth ui"
+git-spice commit create -m "feat(scout-for-lol): render authenticated report controls"
 
 git-spice log short          # visualise: main → auth-schema → auth-api → auth-ui
-git-spice stack submit --fill   # 3 PRs; each targets the one below; nav comment added
+# Repeat the explicit dry-run and submit commands from the single-PR workflow
+# for each branch, using that branch's complete base...branch diff.
 ```
 
 ## 3. Review loop — amend a lower branch, propagate up
@@ -47,10 +70,10 @@ git-spice stack submit --fill   # 3 PRs; each targets the one below; nav comment
 git-spice down                       # or: git-spice branch checkout feature/auth-api
 git add packages/scout/api/…         # apply reviewer's fix
 git-spice commit amend               # auto-restacks auth-ui onto the new auth-api
-# (git-spice commit create -m "fix(scout-for-lol): review nits" also works and keeps
-#  the feedback as its own commit — often nicer for reviewers)
+# (git-spice commit create -m "fix(scout-for-lol): reject expired auth sessions"
+#  also works and keeps the feedback as its own meaningful commit)
 bun run verify -- --affected
-git-spice stack submit --update-only # force-pushes updates to the existing PRs
+git-spice stack submit --update-only # force-pushes updates without --fill
 ```
 
 ## 4. Land the stack bottom-up


### PR DESCRIPTION
## Why

Agents were publishing weak commit and PR metadata because Git Spice could copy incomplete commit messages into PRs without a quality contract.

## What

- Adds a repo-wide checklist for outcome-oriented commit subjects and `Why`/`What`/`Verification` narratives.
- Makes the complete branch diff the source for PR titles and bodies, including multi-commit stacks.
- Documents explicit Git Spice title/body submission, dry-run review, and `--update-only` follow-ups.
- Adds a durable implementation plan.

## Verification

- `bunx prettier --check` passed for all changed Markdown files.
- `bunx markdownlint-cli2` passed for the applicable changed documents.
- `bun run check-todos` passed.
- `bunx lefthook run pre-commit` passed, including Prettier, suppressions, and Gitleaks.
- An isolated Git Spice `branch submit --dry-run` reported it would create a CR with explicit title/body metadata.

No commit-hook, validator, or Conductor settings changes are included.