### PR TITLE
docs(tasks-for-obsidian): track physical iOS acceptance

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -258,10 +258,10 @@ const commands: Record<
       // only far enough to fail Discord auth would not touch the database at
       // all, so an image that cannot create or query its schema used to pass.
       "bun scripts/migrate.ts",
-      String.raw`bun -e 'import { prisma, disconnectPrisma } from "#src/db/index.ts";` +
-        String.raw` const n = await prisma.karma.count();` +
-        String.raw` if (n !== 0) { throw new Error("expected an empty smoke database, got " + String(n)); }` +
-        String.raw` console.log("smoke: prisma query ok"); await disconnectPrisma();'`,
+      `bun -e 'import { prisma, disconnectPrisma } from "#src/db/index.ts";` +
+        ` const n = await prisma.karma.count();` +
+        ` if (n !== 0) { throw new Error("expected an empty smoke database, got " + String(n)); }` +
+        ` console.log("smoke: prisma query ok"); await disconnectPrisma();'`,
       "set +e",
       'output="$(timeout 30s bun scripts/start.ts 2>&1)"',
       "status=$?",

--- a/packages/docs/plans/2026-08-09_tasknotes-completion-undo-ui-fixes.md
+++ b/packages/docs/plans/2026-08-09_tasknotes-completion-undo-ui-fixes.md
@@ -1,8 +1,10 @@
 ---
 id: tasknotes-completion-undo-ui-fixes
 type: plan
-status: in-progress
-board: false
+status: awaiting-human
+board: true
+verification: human
+disposition: active
 ---
 
 # TaskNotes iOS UI and completion Undo fixes
@@ -40,8 +42,18 @@ board: false
 - Run focused typecheck, lint, unit, contract, release-bundle, and simulator E2E
   checks. Capture a screenshot for the corrected row/header and a short motion
   recording.
-- Treat the next physical iOS 27 beta/TestFlight build as human acceptance; it
-  is not evidence supplied by the local simulator run.
+
+## Human Verification
+
+- On the next physical iPhone build using the iOS 27 beta, confirm task titles
+  and metadata remain visible in normal mode and the Search and Settings header
+  actions are aligned and tappable.
+- Complete tasks from the list, detail, swipe, and bulk surfaces. Confirm Undo
+  stays visible for about five seconds, restores each task in LIFO order, and
+  enters and exits without repeated vertical bouncing with Reduce Motion both
+  off and on.
+- Accept the change only if those behaviors match the simulator evidence; on
+  failure, record the device model, iOS build, app build, and affected surface.
 
 ## Assumptions
 


### PR DESCRIPTION
Why

PR #2076 shipped the automated TaskNotes iOS UI and completion Undo implementation, but physical iOS 27 beta/TestFlight acceptance remains outstanding. The first exhaustive follow-up run also surfaced four current-main lint failures in the image smoke script.

What

- Keep the TaskNotes plan active as awaiting-human with explicit physical-device acceptance criteria.
- Replace four unnecessary String.raw templates so the repository lint gate can run cleanly.

Verification

- bun run check-todos
- bunx markdownlint-cli2 packages/docs/plans/2026-08-09_tasknotes-completion-undo-ui-fixes.md
- bunx prettier --check .buildkite/scripts/smoke-app-in-image.ts packages/docs/plans/2026-08-09_tasknotes-completion-undo-ui-fixes.md
- cd scripts && bun lint-buildkite.ts
- bunx lefthook run pre-commit