### PR TITLE
fix(ci): remove redundant raw template tags

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -258,10 +258,10 @@ const commands: Record<
       // only far enough to fail Discord auth would not touch the database at
       // all, so an image that cannot create or query its schema used to pass.
       "bun scripts/migrate.ts",
-      String.raw`bun -e 'import { prisma, disconnectPrisma } from "#src/db/index.ts";` +
-        String.raw` const n = await prisma.karma.count();` +
-        String.raw` if (n !== 0) { throw new Error("expected an empty smoke database, got " + String(n)); }` +
-        String.raw` console.log("smoke: prisma query ok"); await disconnectPrisma();'`,
+      `bun -e 'import { prisma, disconnectPrisma } from "#src/db/index.ts";` +
+        ` const n = await prisma.karma.count();` +
+        ` if (n !== 0) { throw new Error("expected an empty smoke database, got " + String(n)); }` +
+        ` console.log("smoke: prisma query ok"); await disconnectPrisma();'`,
       "set +e",
       'output="$(timeout 30s bun scripts/start.ts 2>&1)"',
       "status=$?",


### PR DESCRIPTION
Why: Buildkite main verify failed because four String.raw wrappers in the image smoke command contained no escape sequences and violated unicorn/prefer-string-raw.\n\nWhat: Replace only those wrappers with ordinary template literals; generated shell text is unchanged.\n\nVerification: bun --no-install run lint from scripts; bun --no-install test . ../.buildkite/scripts (461 passed); bun --no-install run verify -- --filter=!sjer.red --filter=!@shepherdjerred/resume --concurrency=6 --output-logs=errors-only --summarize. All passed.