### PR TITLE
chore(homelab): promote Scout PostHog release

### DIFF
--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -167,7 +167,7 @@ const versions = {
   // base moves off 2.0.0-, this pin needs one manual edit).
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver packageName=shepherdjerred/scout-for-lol
   "shepherdjerred/scout-for-lol/prod":
-    "2.0.0-8772@sha256:eb774526ea834293d0e0e02fb11a5cc6b3dcb3a22cef802da29bf31bb2867115",
+    "2.0.0-8810@sha256:d0783d718761e852b2f5798a234170e6f720be921aa59ee37cc86b1b8e53c6a2",
   // not managed by renovate — beta updated by version-commit-back
   "shepherdjerred/starlight-karma-bot/beta":
     "2.0.0-8807@sha256:b41149da60ed7ae398d84b35e72345b9392df7737b1b9fad21ea98d6f739ead1",


### PR DESCRIPTION
## Why

The PostHog cutover shipped to Scout beta as immutable release `2.0.0-8810`, but production remains pinned to `2.0.0-8772` and is still serving the retired Matomo bootstrap.

## What

Promote the existing `2.0.0-8810` backend/site pair by updating the production pin to its verified GHCR digest. Main CI will deploy the paired backend first and then reconcile the archived production site.

## Verification

- `docker buildx imagetools inspect ghcr.io/shepherdjerred/scout-for-lol:2.0.0-8810` resolves to the pinned digest
- `bun test packages/homelab/src/cdk8s/src/release-configuration.test.ts packages/homelab/src/cdk8s/src/versions.test.ts scripts/scout-site-release.test.ts` (28 passed)
- `bunx lefthook run pre-commit`

## Production acceptance

After merge, verify `scout-for-lol.com` serves `posthog-bootstrap.js`, emits PostHog events/replay, and makes no Matomo/Plausible requests before purging retired storage and vault items.