### PR TITLE
fix(ci): restore main with an atomic Argo root sync

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1543,14 +1543,12 @@ steps:
       # children to a partially published release.
       bun --no-install packages/homelab/scripts/argocd.ts suspend-auto-sync apps --revision "$$apps_revision" --timeout 300
       bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --timeout 300
-      # The root app owns every repository Application, so Argo's synchronous
-      # health wait would block on unrelated stale children. The scoped
-      # release-health-wait below is the authoritative gate for this release.
-      bun --no-install packages/homelab/scripts/argocd.ts sync apps --revision "$$apps_revision" --prune --async
-      # The expected release set includes the root app itself. Finalize its
-      # applied async operation before the health gate so the root cannot wait
-      # on its own deferred child health forever.
-      bun --no-install packages/homelab/scripts/argocd.ts finalize-async-sync apps --revision "$$apps_revision" --timeout 300
+      # The root app owns every repository Application, so waiting for its
+      # aggregate health would block on unrelated stale children. Keep the
+      # exact Buildkite identity through apply and termination in one process;
+      # retries may adopt only this build's exact revision.
+      bun --no-install packages/homelab/scripts/argocd.ts sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300
+      # The scoped release health below remains authoritative for this release.
       bun --no-install packages/homelab/scripts/argocd.ts release-health-wait argocd-release-expected.json --timeout 300
     retry: *retry
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -97,10 +97,11 @@ common:
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
   # Verify's pod uses the larger memory request needed by its full install.
-  # full-root install + turbo scratch put ~6Gi into the memory-backed workspace
-  # (node_modules 3.75Gi alone). Recent main builds reached the old 14Gi limit,
-  # so retain the measured request and burst margin from main. It has no DinD
-  # sidecar; image work uses remote BuildKit instead.
+  # Build 8944 measured 9.42Gi of tmpfs plus 11.59Gi of anonymous memory while
+  # six cold tasks overlapped and hit the old 20Gi limit. Four-way graph
+  # concurrency plus an 18Gi reservation and 24Gi burst limit preserves every
+  # check without allowing several cold verify pods to overcommit the 80Gi
+  # Buildkite quota. It has no DinD sidecar; image work uses remote BuildKit.
   # Only verify pays this; other lanes use their measured complete-pod sizing.
   - pod_verify: &pod_verify
       kubernetes: &pod_verify_kubernetes
@@ -118,8 +119,8 @@ common:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
               resources:
-                requests: { cpu: "1", memory: "14Gi", ephemeral-storage: "2Gi" }
-                limits: { cpu: "7", memory: "20Gi", ephemeral-storage: "40Gi" }
+                requests: { cpu: "1", memory: "18Gi", ephemeral-storage: "2Gi" }
+                limits: { cpu: "7", memory: "24Gi", ephemeral-storage: "40Gi" }
               volumeMounts:
                 # Mirror-backed checkouts: see the base pod anchor above.
                 - name: buildkite-git-mirrors
@@ -314,7 +315,7 @@ steps:
       # local-only caching by default to avoid large transfers on weak Wi-Fi.
       export TURBO_CACHE="local:rw,remote:rw"
       set +e
-      bun --no-install run verify -- --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=6 --output-logs=errors-only --summarize
+      bun --no-install run verify -- --filter='!sjer.red' --filter='!@shepherdjerred/resume' --concurrency=4 --output-logs=errors-only --summarize
       verify_status=$?
       set -e
       set +e

--- a/.buildkite/reporting-pipeline.yml
+++ b/.buildkite/reporting-pipeline.yml
@@ -78,7 +78,7 @@ steps:
       export TURBO_CACHE="local:rw,remote:rw"
       set +e
       bun --no-install x turbo run test:report \
-        --continue --concurrency=6 --output-logs=errors-only --summarize
+        --continue --concurrency=4 --output-logs=errors-only --summarize
       test_status=$?
       bun --no-install run script-coverage
       script_coverage_status=$?
@@ -136,9 +136,9 @@ steps:
                     value: "/bin/bash -e -c"
                 resources:
                   requests:
-                    { cpu: "1", memory: "14Gi", ephemeral-storage: "2Gi" }
+                    { cpu: "1", memory: "18Gi", ephemeral-storage: "2Gi" }
                   limits:
-                    { cpu: "7", memory: "20Gi", ephemeral-storage: "40Gi" }
+                    { cpu: "7", memory: "24Gi", ephemeral-storage: "40Gi" }
                 volumeMounts:
                   - name: buildkite-git-mirrors
                     mountPath: /buildkite/git-mirrors

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateAtomicRootSyncLifecycle } from "./validate-pipeline-release.ts";
+
+const atomicRootSync =
+  'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
+
+describe("atomic ArgoCD root sync pipeline contract", () => {
+  test("accepts the one-process identity-bound lifecycle", () => {
+    expect(() => validateAtomicRootSyncLifecycle(atomicRootSync)).not.toThrow();
+  });
+
+  test("rejects the split async and finalizer lifecycle", () => {
+    const splitLifecycle = [
+      atomicRootSync,
+      'sync apps --revision "$$apps_revision" --prune --async',
+      'finalize-async-sync apps --revision "$$apps_revision"',
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(splitLifecycle)).toThrow(
+      "argocd-sync restored the racy split async/finalize lifecycle",
+    );
+  });
+
+  test("rejects a pipeline without the atomic root sync", () => {
+    expect(() =>
+      validateAtomicRootSyncLifecycle("release-health-wait"),
+    ).toThrow("argocd-sync is missing the atomic identity-bound root sync");
+  });
+});

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -22,6 +22,17 @@ describe("atomic ArgoCD root sync pipeline contract", () => {
     );
   });
 
+  test("rejects an async root sync regardless of flag ordering", () => {
+    const reorderedAsync = [
+      atomicRootSync,
+      'sync apps --revision "$$apps_revision" --async --prune',
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(reorderedAsync)).toThrow(
+      "argocd-sync restored the racy split async/finalize lifecycle",
+    );
+  });
+
   test("rejects a pipeline without the atomic root sync", () => {
     expect(() =>
       validateAtomicRootSyncLifecycle("release-health-wait"),

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -29,8 +29,16 @@ export function validateAtomicRootSyncLifecycle(
     ATOMIC_ROOT_SYNC_COMMAND,
     "argocd-sync is missing the atomic identity-bound root sync",
   );
+  const hasAsyncRootSync =
+    argocdSync
+      ?.split("\n")
+      .some(
+        (line) =>
+          /\bsync\s+apps(?:\s|$)/.test(line) &&
+          /(?:^|\s)--async(?:\s|$)/.test(line),
+      ) === true;
   if (
-    argocdSync?.includes("--prune --async") === true ||
+    hasAsyncRootSync ||
     argocdSync?.includes("finalize-async-sync apps") === true
   ) {
     fail("argocd-sync restored the racy split async/finalize lifecycle");

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -18,6 +18,25 @@ type ReleaseValidationOptions = {
   readonly stepBlocks: ReadonlyMap<string, string>;
 };
 
+const ATOMIC_ROOT_SYNC_COMMAND =
+  'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
+
+export function validateAtomicRootSyncLifecycle(
+  argocdSync: string | undefined,
+): void {
+  requireIncludes(
+    argocdSync,
+    ATOMIC_ROOT_SYNC_COMMAND,
+    "argocd-sync is missing the atomic identity-bound root sync",
+  );
+  if (
+    argocdSync?.includes("--prune --async") === true ||
+    argocdSync?.includes("finalize-async-sync apps") === true
+  ) {
+    fail("argocd-sync restored the racy split async/finalize lifecycle");
+  }
+}
+
 function validateReleaseSteps({
   prDryrun,
   stepBlocks,
@@ -68,8 +87,6 @@ function validateReleaseSteps({
         'artifact download "argocd-release-expected.json"',
         'suspend-auto-sync apps --revision "$$apps_revision"',
         "reconcile-release argocd-release-expected.json",
-        'sync apps --revision "$$apps_revision" --prune --async',
-        "finalize-async-sync apps",
         "release-health-wait argocd-release-expected.json",
       ],
     ],
@@ -114,6 +131,8 @@ function validateReleaseSteps({
       );
     }
   }
+  const argocdSync = stepBlocks.get("argocd-sync");
+  validateAtomicRootSyncLifecycle(argocdSync);
 
   for (const dependency of [
     '"packages/astro-opengraph-images/**"',

--- a/.buildkite/scripts/validate-pipeline-resources.test.ts
+++ b/.buildkite/scripts/validate-pipeline-resources.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateExhaustiveGraphCapacity } from "./validate-pipeline-resources.ts";
+
+const measuredCapacity = [
+  "--concurrency=4",
+  'requests: { cpu: "1", memory: "18Gi", ephemeral-storage: "2Gi" }',
+  'limits: { cpu: "7", memory: "24Gi", ephemeral-storage: "40Gi" }',
+].join("\n");
+
+describe("exhaustive graph capacity contract", () => {
+  test("accepts the measured concurrency and memory budget", () => {
+    expect(() =>
+      validateExhaustiveGraphCapacity(measuredCapacity, "verify"),
+    ).not.toThrow();
+  });
+
+  test("rejects six-way concurrency that reproduces the cold-graph OOM", () => {
+    expect(() =>
+      validateExhaustiveGraphCapacity(
+        measuredCapacity.replace("--concurrency=4", "--concurrency=6"),
+        "verify",
+      ),
+    ).toThrow("verify is missing measured capacity contract --concurrency=4");
+  });
+
+  test("rejects the exhausted 20 GiB burst limit", () => {
+    expect(() =>
+      validateExhaustiveGraphCapacity(
+        measuredCapacity.replace('memory: "24Gi"', 'memory: "20Gi"'),
+        "verify",
+      ),
+    ).toThrow(
+      'verify is missing measured capacity contract { cpu: "7", memory: "24Gi", ephemeral-storage: "40Gi" }',
+    );
+  });
+});

--- a/.buildkite/scripts/validate-pipeline-resources.ts
+++ b/.buildkite/scripts/validate-pipeline-resources.ts
@@ -8,6 +8,23 @@ import {
   SHARED_POD_ANCHORS,
 } from "./validate-pipeline-lib.ts";
 
+const EXHAUSTIVE_GRAPH_CAPACITY = [
+  "--concurrency=4",
+  '{ cpu: "1", memory: "18Gi", ephemeral-storage: "2Gi" }',
+  '{ cpu: "7", memory: "24Gi", ephemeral-storage: "40Gi" }',
+] as const;
+
+export function validateExhaustiveGraphCapacity(
+  source: string,
+  lane: string,
+): void {
+  for (const required of EXHAUSTIVE_GRAPH_CAPACITY) {
+    if (!source.includes(required)) {
+      fail(`${lane} is missing measured capacity contract ${required}`);
+    }
+  }
+}
+
 export function validatePipelineResourceContracts(
   pipeline: string,
   stepBlocks: ReadonlyMap<string, string>,
@@ -50,14 +67,10 @@ export function validatePipelineResourceContracts(
     pipeline,
     "pod_verify_kubernetes",
   );
-  for (const resourceLine of [
-    'requests: { cpu: "1", memory: "14Gi", ephemeral-storage: "2Gi" }',
-    'limits: { cpu: "7", memory: "20Gi", ephemeral-storage: "40Gi" }',
-  ]) {
-    if (!hasTrimmedLine(verifyPodAnchor, resourceLine)) {
-      fail(`verify pod is missing measured resource budget ${resourceLine}`);
-    }
-  }
+  validateExhaustiveGraphCapacity(
+    `${verifyPodAnchor}\n${stepBlocks.get("verify") ?? ""}`,
+    "verify",
+  );
 
   for (const [anchor, requestLine] of [
     [

--- a/.buildkite/scripts/validate-reporting-pipeline.ts
+++ b/.buildkite/scripts/validate-reporting-pipeline.ts
@@ -1,6 +1,9 @@
 import { fail } from "./validate-pipeline-lib.ts";
+import { validateExhaustiveGraphCapacity } from "./validate-pipeline-resources.ts";
 
 export function validateReportingPipeline(pipeline: string): void {
+  validateExhaustiveGraphCapacity(pipeline, "complete test reporting");
+
   for (const required of [
     "turbo run test:report",
     "key: playwright-reporting",

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -1,0 +1,56 @@
+---
+id: plan-2026-08-09-argocd-atomic-root-sync
+type: plan
+status: in-progress
+board: false
+---
+
+# ArgoCD atomic root sync
+
+## Summary
+
+The main-only homelab release split the root Application lifecycle across an
+asynchronous sync process and a separate finalizer. ArgoCD could accept the
+sync immediately but publish its operation state after the finalizer's first
+read. Treating that missing state as success stranded a fully applied operation
+in `Running`, and the next release failed before publishing charts because
+ArgoCD permits only one operation per Application.
+
+Replace the split lifecycle with one identity-bound command. It must retain the
+Buildkite build UUID through submission, application, and termination; adopt
+only an exact retry; and keep the scoped release-health gate authoritative.
+
+## Implementation
+
+- Add `sync --terminate-after-applied --request-id <uuid>`. Keep ordinary
+  synchronous and explicitly asynchronous sync behavior unchanged.
+- Before submission, adopt only an active operation with the exact request ID
+  and revision. Refuse any unrelated active operation.
+- Poll through absent or stale operation state. Fail on an exact `Failed` or
+  `Error` result, accept natural success, and terminate only after every
+  resource reports an applied status with no failed hook.
+- After termination, use a fresh timeout and fail if another operation replaces
+  the exact operation before it clears.
+- Retain `finalize-async-sync` only for recovery. Require both the exact request
+  ID and revision, and never treat missing operation state as success.
+- Wire the main Buildkite release to the atomic command with
+  `BUILDKITE_BUILD_ID`; reject the old split lifecycle in pipeline validation.
+
+## Verification
+
+- Cover delayed visibility, stale state, exact retry adoption, identity and
+  revision mismatches, natural success, failed phases, timeouts, applied-result
+  termination, post-termination waiting, and interference.
+- Exercise the live result shape: 255 synced resources, two pruned resources,
+  and five child Applications still in a running health phase.
+- Run focused Bun tests, homelab typecheck and lint, pipeline validation, staged
+  pre-commit checks, and the complete root verification graph.
+- Recover the stranded operation only after its live identity and complete
+  applied result are revalidated.
+- Require an exact-head PR build and then a fresh successful build of the
+  current remote `main` SHA.
+
+## Remaining
+
+- [ ] Complete local verification and publish the exact-head pull request.
+- [ ] Recover the stranded operation, merge, and confirm current `main` is green.

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -26,13 +26,19 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   synchronous and explicitly asynchronous sync behavior unchanged.
 - Before submission, adopt only an active operation with the exact request ID
   and revision. Refuse any unrelated active operation.
+- Give each submitted ArgoCD operation a generated internal operation ID. A
+  retry adopts that ID from the live operation and accepts status only when the
+  same ID appears, so a stable applied result is reusable without confusing it
+  with stale status from an earlier attempt that reused the build UUID.
 - Poll through absent or stale operation state. Fail on an exact `Failed` or
   `Error` result, accept natural success, and terminate only after every
   resource reports an applied status with no failed hook.
-- After termination, use a fresh timeout and fail if another operation replaces
-  the exact operation before it clears.
+- After termination, use a fresh timeout, return when the authoritative live
+  operation clears even if status lags, and fail if another operation ID
+  replaces the exact operation first.
 - Retain `finalize-async-sync` only for recovery. Require both the exact request
-  ID and revision, and never treat missing operation state as success.
+  ID and revision, discover the internal operation ID from the matching live
+  operation, and never treat missing operation state as success.
 - Wire the main Buildkite release to the atomic command with
   `BUILDKITE_BUILD_ID`; reject the old split lifecycle in pipeline validation.
 

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -33,14 +33,17 @@ only an exact retry; and keep the scoped release-health gate authoritative.
 - Poll through absent or stale operation state. Fail on an exact `Failed` or
   `Error` result, accept natural success, and terminate only after every
   resource in the exact rendered revision appears in the result with an
-  applied status and no failed hook. Partial earlier sync waves are not
-  complete.
+  applied status, every validated prune candidate appears as `Pruned`, and no
+  hook has failed. Partial earlier sync or prune waves are not complete.
 - After termination, use a fresh timeout, return when the authoritative live
   operation clears even if status lags, and fail if another operation ID
   replaces the exact operation first.
 - Retain `finalize-async-sync` only for recovery. Require both the exact request
   ID and revision, discover the internal operation ID from the matching live
-  operation, and never treat missing operation state as success.
+  operation, and never treat missing operation state as success. For the
+  stranded pre-change operation only, accept a missing internal ID when both
+  live and completed state carry the exact request and revision and neither
+  carries an internal ID.
 - Wire the main Buildkite release to the atomic command with
   `BUILDKITE_BUILD_ID`; reject the old split lifecycle in pipeline validation.
 
@@ -48,7 +51,8 @@ only an exact retry; and keep the scoped release-health gate authoritative.
 
 - Cover delayed visibility, stale state, exact retry adoption, identity and
   revision mismatches, natural success, failed phases, timeouts, applied-result
-  termination, partial sync waves, post-termination waiting, and interference.
+  termination, partial sync and prune waves, legacy recovery,
+  post-termination waiting, and interference.
 - Exercise the live result shape: 255 synced resources, two pruned resources,
   and five child Applications still in a running health phase.
 - Run focused Bun tests, homelab typecheck and lint, pipeline validation, staged

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -31,10 +31,11 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   same ID appears, so a stable applied result is reusable without confusing it
   with stale status from an earlier attempt that reused the build UUID.
 - Poll through absent or stale operation state. Fail on an exact `Failed` or
-  `Error` result, accept natural success, and terminate only after every
-  resource in the exact rendered revision appears in the result with an
-  applied status, every validated prune candidate appears as `Pruned`, and no
-  hook has failed. Partial earlier sync or prune waves are not complete.
+  `Error` result, and terminate only after every resource in the exact rendered
+  revision appears in the result with an applied status, every validated prune
+  candidate appears as `Pruned`, and no hook has failed. Accept natural success
+  only after its authoritative live operation clears. Partial earlier sync or
+  prune waves are not complete.
 - After termination, use a fresh timeout, return when the authoritative live
   operation clears even if status lags, and fail if another operation ID
   replaces the exact operation first.

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -32,7 +32,9 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   with stale status from an earlier attempt that reused the build UUID.
 - Poll through absent or stale operation state. Fail on an exact `Failed` or
   `Error` result, accept natural success, and terminate only after every
-  resource reports an applied status with no failed hook.
+  resource in the exact rendered revision appears in the result with an
+  applied status and no failed hook. Partial earlier sync waves are not
+  complete.
 - After termination, use a fresh timeout, return when the authoritative live
   operation clears even if status lags, and fail if another operation ID
   replaces the exact operation first.
@@ -46,7 +48,7 @@ only an exact retry; and keep the scoped release-health gate authoritative.
 
 - Cover delayed visibility, stale state, exact retry adoption, identity and
   revision mismatches, natural success, failed phases, timeouts, applied-result
-  termination, post-termination waiting, and interference.
+  termination, partial sync waves, post-termination waiting, and interference.
 - Exercise the live result shape: 255 synced resources, two pruned resources,
   and five child Applications still in a running health phase.
 - Run focused Bun tests, homelab typecheck and lint, pipeline validation, staged

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -85,11 +85,13 @@ independently unhealthy. Waiting synchronously on the root would mean waiting on
 every one of them, and a single permanently unhealthy child would hold the
 release open forever.
 
-So Buildkite separates root application from release-scoped health. One command
+So the [main release pipeline](https://github.com/shepherdjerred/monorepo/blob/main/.buildkite/pipeline.yml)
+separates root application from release-scoped health. One
+[atomic Argo command](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)
 retains the exact Buildkite request identity while ArgoCD applies the root
 revision. It terminates the aggregate health wait only after the complete sync
 result is applied. The command compares reported group, kind, and name
-identities with every resource rendered from the exact revision, so an applied
+identities with every resource rendered from the exact revision. An applied
 early sync wave cannot hide later-wave work that ArgoCD has not reported yet.
 It also carries the validated prune candidates into this boundary and requires
 each candidate to appear as `Pruned` before termination.
@@ -99,16 +101,17 @@ asynchronously. A second process can read before the accepted operation appears.
 Keeping submission and finalization together lets the command poll through that
 gap and distinguish stale state from its own operation.
 
-Buildkite retries reuse the build UUID. A retry adopts only the same request ID
-and revision; it refuses any unrelated active operation. A generated
-per-operation UUID then binds the top-level live operation to its completed
-status. This lets a retry accept a stable, fully applied result while rejecting
-stale status from an earlier POST that used the same Buildkite identity. The
-standalone finalizer remains a recovery tool, not part of the normal release
-path. It recognizes the retired client's pre-UUID operation only when both the
-live operation and completed status share the exact request ID and revision and
-both omit an operation UUID; atomic operations never use that compatibility
-case.
+Buildkite retries reuse the build UUID. The
+[operation identity implementation](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)
+adopts only the same request ID and revision. It refuses any unrelated active
+operation. A generated per-operation UUID binds the top-level live operation
+to its completed status. This lets a retry accept a stable, fully applied
+result while rejecting stale status from an earlier POST with the same
+Buildkite identity. The standalone finalizer remains a recovery tool, not part
+of the normal release path. It recognizes the retired client's pre-UUID
+operation only when both live and completed state share the exact request ID
+and revision. Both must omit an operation UUID. Atomic operations never use
+that compatibility case.
 
 After termination, the top-level live operation is authoritative. Its absence
 means the health wait is gone even if `status.operationState` still says

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -23,7 +23,7 @@ sequenceDiagram
   BK->>Root: apply exact child specs, still suspended
   BK->>Child: reconcile exact chart revisions
   BK->>Root: sync exact revision with verified pruning
-  BK->>Root: finalize applied async operation
+  BK->>Root: retain identity through apply and termination
   BK->>Child: require Synced and Healthy
 ```
 
@@ -78,21 +78,30 @@ This is the same principle the repo applies elsewhere: do not validate a
 replacement against the unreliable signal it replaces. The desired state is the
 rendered revision, not ArgoCD's opinion about it.
 
-## Why the final root sync is asynchronous
+## Why the final root sync ends after apply
 
 The root app also tracks child Applications that may be deferred or
 independently unhealthy. Waiting synchronously on the root would mean waiting on
 every one of them, and a single permanently unhealthy child would hold the
 release open forever.
 
-So the controller applies the exact revision and then waits on health
-separately. `finalize-async-sync` verifies that the requested operation's sync
-result is fully applied, refuses failed or mismatched operations, and terminates
-the health wait.
+So Buildkite separates root application from release-scoped health. One command
+retains the exact Buildkite request identity while ArgoCD applies the root
+revision. It terminates the aggregate health wait only after the complete sync
+result is applied.
 
-Without that finalize step, a root operation stuck in `Running` would block the
-next ordered release indefinitely — the asynchronous sync solves one problem and
-would create another if nothing closed it out.
+The identity boundary matters because ArgoCD publishes operation state
+asynchronously. A second process can read before the accepted operation appears.
+Keeping submission and finalization together lets the command poll through that
+gap and distinguish stale state from its own operation.
+
+Buildkite retries reuse the build UUID. A retry adopts only the same request ID
+and revision; it refuses any unrelated active operation. The standalone
+finalizer remains a recovery tool, not part of the normal release path.
+
+Without this atomic boundary, a root operation stuck in `Running` blocks the
+next ordered release indefinitely. Treating missing operation state as success
+is therefore unsafe even when every manifest was applied.
 
 ## Why image selection looks complicated
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -88,7 +88,9 @@ release open forever.
 So Buildkite separates root application from release-scoped health. One command
 retains the exact Buildkite request identity while ArgoCD applies the root
 revision. It terminates the aggregate health wait only after the complete sync
-result is applied.
+result is applied. The command compares reported group, kind, and name
+identities with every resource rendered from the exact revision, so an applied
+early sync wave cannot hide later-wave work that ArgoCD has not reported yet.
 
 The identity boundary matters because ArgoCD publishes operation state
 asynchronously. A second process can read before the accepted operation appears.

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -91,6 +91,8 @@ revision. It terminates the aggregate health wait only after the complete sync
 result is applied. The command compares reported group, kind, and name
 identities with every resource rendered from the exact revision, so an applied
 early sync wave cannot hide later-wave work that ArgoCD has not reported yet.
+It also carries the validated prune candidates into this boundary and requires
+each candidate to appear as `Pruned` before termination.
 
 The identity boundary matters because ArgoCD publishes operation state
 asynchronously. A second process can read before the accepted operation appears.
@@ -103,7 +105,10 @@ per-operation UUID then binds the top-level live operation to its completed
 status. This lets a retry accept a stable, fully applied result while rejecting
 stale status from an earlier POST that used the same Buildkite identity. The
 standalone finalizer remains a recovery tool, not part of the normal release
-path.
+path. It recognizes the retired client's pre-UUID operation only when both the
+live operation and completed status share the exact request ID and revision and
+both omit an operation UUID; atomic operations never use that compatibility
+case.
 
 After termination, the top-level live operation is authoritative. Its absence
 means the health wait is gone even if `status.operationState` still says

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -116,7 +116,10 @@ that compatibility case.
 After termination, the top-level live operation is authoritative. Its absence
 means the health wait is gone even if `status.operationState` still says
 `Running` or `Terminating`; a different operation UUID in live or completed
-state still proves replacement and fails the release.
+state still proves replacement and fails the release. Natural success uses the
+[same boundary](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts):
+a `Succeeded` status does not finish the command until the live operation
+clears.
 
 Without this atomic boundary, a root operation stuck in `Running` blocks the
 next ordered release indefinitely. Treating missing operation state as success

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -96,8 +96,17 @@ Keeping submission and finalization together lets the command poll through that
 gap and distinguish stale state from its own operation.
 
 Buildkite retries reuse the build UUID. A retry adopts only the same request ID
-and revision; it refuses any unrelated active operation. The standalone
-finalizer remains a recovery tool, not part of the normal release path.
+and revision; it refuses any unrelated active operation. A generated
+per-operation UUID then binds the top-level live operation to its completed
+status. This lets a retry accept a stable, fully applied result while rejecting
+stale status from an earlier POST that used the same Buildkite identity. The
+standalone finalizer remains a recovery tool, not part of the normal release
+path.
+
+After termination, the top-level live operation is authoritative. Its absence
+means the health wait is gone even if `status.operationState` still says
+`Running` or `Terminating`; a different operation UUID in live or completed
+state still proves replacement and fails the release.
 
 Without this atomic boundary, a root operation stuck in `Running` blocks the
 next ordered release indefinitely. Treating missing operation state as success

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -108,7 +108,10 @@ UUID.
 
 ## Where it lives
 
-`.buildkite/pipeline.yml` and `packages/homelab/scripts/argocd.ts`.
+The workflow is defined by the
+[main release pipeline](https://github.com/shepherdjerred/monorepo/blob/main/.buildkite/pipeline.yml)
+and the
+[Argo operator command](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts).
 
 ## Related
 

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -74,6 +74,8 @@ A previous root operation stuck in `Running` blocks the next ordered release.
 Stage 5 prevents that in the normal pipeline. One process submits the sync,
 waits for its exact request ID and revision, verifies the complete applied
 result, terminates the aggregate health wait, and waits for termination.
+Completeness means every resource in the exact rendered root revision has a
+successful result; a fully applied early sync wave is not enough.
 
 Buildkite retries reuse the build UUID. The command adopts the operation only
 when both UUID and revision match. An unrelated active operation remains a hard

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -19,9 +19,8 @@ failed stage means.
 | 2     | Publish the `2.0.0-build` chart set to ChartMuseum, immutably           |
 | 3     | Apply the exact child Application specs, still suspended                |
 | 4     | Reconcile child workloads to their exact chart revisions                |
-| 5     | Sync the exact root revision with verified pruning                      |
-| 6     | Finalize the applied async operation                                    |
-| 7     | Require every child `Synced` and `Healthy`                              |
+| 5     | Sync and safely finalize the exact root revision with verified pruning  |
+| 6     | Require every release-scoped child to be `Synced` and `Healthy`         |
 
 Stage 3 is deliberately separate from stage 5. New child-level safety settings
 must exist before those children sync, but enabling floating auto-sync before
@@ -72,12 +71,27 @@ pin.
 ## If the release will not start
 
 A previous root operation stuck in `Running` blocks the next ordered release.
-Stage 6 exists to prevent that: `finalize-async-sync` refuses failed or
-mismatched operations and terminates the health wait once the requested sync
-result is fully applied.
+Stage 5 prevents that in the normal pipeline. One process submits the sync,
+waits for its exact request ID and revision, verifies the complete applied
+result, terminates the aggregate health wait, and waits for termination.
 
-A release blocked here usually means that finalize did not run or rejected the
-operation — check the root Application's operation state before retrying.
+Buildkite retries reuse the build UUID. The command adopts the operation only
+when both UUID and revision match. An unrelated active operation remains a hard
+failure.
+
+A release blocked here means the current operation must be inspected before
+retrying. If it is a fully applied operation from an interrupted older client,
+recover it with both values from the live operation:
+
+```bash
+bun packages/homelab/scripts/argocd.ts finalize-async-sync apps \
+  --revision <exact-revision> \
+  --request-id <exact-request-id> \
+  --timeout 300
+```
+
+The recovery command polls for that exact operation. Missing state, a different
+identity, an apply failure, or an incomplete result fails without termination.
 
 ## Where it lives
 

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -75,7 +75,8 @@ Stage 5 prevents that in the normal pipeline. One process submits the sync,
 waits for its exact request ID and revision, verifies the complete applied
 result, terminates the aggregate health wait, and waits for termination.
 Completeness means every resource in the exact rendered root revision has a
-successful result; a fully applied early sync wave is not enough.
+successful result and every validated prune candidate has a `Pruned` result; a
+fully applied early sync or prune wave is not enough.
 
 Buildkite retries reuse the build UUID. The command adopts the operation only
 when both UUID and revision match. An unrelated active operation remains a hard
@@ -98,6 +99,12 @@ The recovery command polls for that exact operation and discovers its internal
 operation UUID from the live state. It terminates only when the completed status
 has the same UUID. Missing state, a different identity, an apply failure, or an
 incomplete result fails without termination.
+
+An operation created by the retired split pipeline predates internal operation
+UUIDs. The recovery command accepts that legacy shape only when both the live
+operation and completed status have the exact request ID and revision and both
+omit the internal UUID. New atomic operations always require their internal
+UUID.
 
 ## Where it lives
 

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -77,7 +77,9 @@ result, terminates the aggregate health wait, and waits for termination.
 
 Buildkite retries reuse the build UUID. The command adopts the operation only
 when both UUID and revision match. An unrelated active operation remains a hard
-failure.
+failure. Each POST also receives an internal operation UUID; adoption requires
+the live operation and its status to share that UUID before a stable applied
+result can be finalized.
 
 A release blocked here means the current operation must be inspected before
 retrying. If it is a fully applied operation from an interrupted older client,
@@ -90,8 +92,10 @@ bun packages/homelab/scripts/argocd.ts finalize-async-sync apps \
   --timeout 300
 ```
 
-The recovery command polls for that exact operation. Missing state, a different
-identity, an apply failure, or an incomplete result fails without termination.
+The recovery command polls for that exact operation and discovers its internal
+operation UUID from the live state. It terminates only when the completed status
+has the same UUID. Missing state, a different identity, an apply failure, or an
+incomplete result fails without termination.
 
 ## Where it lives
 

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from "bun:test";
 import {
   batchManifestOverrides,
   completedOperationIdentity,
+  completedOperationRequestId,
   requestedOperationIdentity,
+  requestedOperationRequestId,
   type ManifestOverride,
 } from "./argocd-manifest-overrides.ts";
 
@@ -108,6 +110,8 @@ describe("Argo operation identity", () => {
     expect(completedOperationIdentity(previous)).not.toBe(
       requestedOperationIdentity(requested),
     );
+    expect(requestedOperationRequestId(requested)).toBe("current");
+    expect(completedOperationRequestId(previous)).toBe("previous");
   });
 
   test("returns null before an Application has an operation state", () => {
@@ -118,5 +122,24 @@ describe("Argo operation identity", () => {
     expect(() => requestedOperationIdentity({})).toThrow(
       "sync response is missing the requested operation",
     );
+  });
+
+  test("fails when a requested operation omits its CI request ID", () => {
+    expect(() => requestedOperationRequestId({ operation: {} })).toThrow(
+      "missing the CI request ID",
+    );
+  });
+
+  test("fails when an operation has duplicate CI request IDs", () => {
+    expect(() =>
+      requestedOperationRequestId({
+        operation: {
+          info: [
+            { name: "ci.sjer.red/request-id", value: "one" },
+            { name: "ci.sjer.red/request-id", value: "two" },
+          ],
+        },
+      }),
+    ).toThrow("multiple CI request IDs");
   });
 });

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from "bun:test";
 import {
   batchManifestOverrides,
   completedOperationIdentity,
+  completedOperationId,
   completedOperationRequestId,
   requestedOperationIdentity,
+  requestedOperationId,
   requestedOperationRequestId,
   type ManifestOverride,
 } from "./argocd-manifest-overrides.ts";
@@ -43,7 +45,7 @@ describe("manifest override batching", () => {
   test("splits requests before the serialized budget is exceeded", () => {
     const batches = batchManifestOverrides(
       [override("one", 600), override("two", 600), override("three", 600)],
-      1000,
+      1200,
     );
 
     expect(batches).toHaveLength(3);
@@ -114,6 +116,40 @@ describe("Argo operation identity", () => {
     expect(completedOperationRequestId(previous)).toBe("previous");
   });
 
+  test("distinguishes separate attempts with the same retry identity", () => {
+    const requested = {
+      operation: {
+        info: [
+          { name: "ci.sjer.red/request-id", value: "same-request" },
+          { name: "ci.sjer.red/operation-id", value: "current-operation" },
+        ],
+        sync: { revision: "same-revision" },
+      },
+    };
+    const previous = {
+      status: {
+        operationState: {
+          operation: {
+            info: [
+              { name: "ci.sjer.red/request-id", value: "same-request" },
+              {
+                name: "ci.sjer.red/operation-id",
+                value: "previous-operation",
+              },
+            ],
+            sync: { revision: "same-revision" },
+          },
+        },
+      },
+    };
+
+    expect(completedOperationIdentity(previous)).not.toBe(
+      requestedOperationIdentity(requested),
+    );
+    expect(requestedOperationId(requested)).toBe("current-operation");
+    expect(completedOperationId(previous)).toBe("previous-operation");
+  });
+
   test("returns null before an Application has an operation state", () => {
     expect(completedOperationIdentity({ status: {} })).toBeNull();
   });
@@ -130,6 +166,12 @@ describe("Argo operation identity", () => {
     );
   });
 
+  test("fails when a requested operation omits its CI operation ID", () => {
+    expect(() => requestedOperationId({ operation: {} })).toThrow(
+      "missing the CI operation ID",
+    );
+  });
+
   test("fails when an operation has duplicate CI request IDs", () => {
     expect(() =>
       requestedOperationRequestId({
@@ -141,5 +183,18 @@ describe("Argo operation identity", () => {
         },
       }),
     ).toThrow("multiple CI request IDs");
+  });
+
+  test("fails when an operation has duplicate CI operation IDs", () => {
+    expect(() =>
+      requestedOperationId({
+        operation: {
+          info: [
+            { name: "ci.sjer.red/operation-id", value: "one" },
+            { name: "ci.sjer.red/operation-id", value: "two" },
+          ],
+        },
+      }),
+    ).toThrow("multiple CI operation IDs");
   });
 });

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -19,6 +19,19 @@ const ApplicationOperationSchema = z.object({
     .optional(),
 });
 
+const OperationInfoSchema = z
+  .object({
+    info: z
+      .array(
+        z.object({
+          name: z.string(),
+          value: z.string(),
+        }),
+      )
+      .optional(),
+  })
+  .loose();
+
 export type SyncOperationResource = {
   group: string;
   kind: string;
@@ -121,4 +134,35 @@ export function completedOperationIdentity(
     return null;
   }
   return canonicalJson(operation);
+}
+
+function operationRequestId(operation: Record<string, unknown>): string | null {
+  const matches = (OperationInfoSchema.parse(operation).info ?? []).filter(
+    ({ name }) => name === SYNC_REQUEST_ID_INFO_NAME,
+  );
+  if (matches.length > 1) {
+    throw new Error("Argo operation has multiple CI request IDs");
+  }
+  return matches[0]?.value ?? null;
+}
+
+export function requestedOperationRequestId(application: unknown): string {
+  const operation = ApplicationOperationSchema.parse(application).operation;
+  if (operation === undefined) {
+    throw new Error("Argo sync response is missing the requested operation");
+  }
+  const requestId = operationRequestId(operation);
+  if (requestId === null) {
+    throw new Error("Argo sync response is missing the CI request ID");
+  }
+  return requestId;
+}
+
+export function completedOperationRequestId(
+  application: unknown,
+): string | null {
+  const operation =
+    ApplicationOperationSchema.parse(application).status?.operationState
+      ?.operation;
+  return operation === undefined ? null : operationRequestId(operation);
 }

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -3,8 +3,10 @@ import { canonicalJson } from "./canonical-json.ts";
 
 const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
 const SERIALIZED_REQUEST_ID = "00000000-0000-0000-0000-000000000000";
+const SERIALIZED_OPERATION_ID = "00000000-0000-0000-0000-000000000000";
 
 export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
+export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
 
 const ApplicationOperationSchema = z.object({
   operation: z.record(z.string(), z.unknown()).optional(),
@@ -57,6 +59,10 @@ function serializedRequestBytes(batch: ManifestOverrideBatch): number {
         {
           name: SYNC_REQUEST_ID_INFO_NAME,
           value: SERIALIZED_REQUEST_ID,
+        },
+        {
+          name: SYNC_OPERATION_ID_INFO_NAME,
+          value: SERIALIZED_OPERATION_ID,
         },
       ],
       manifests: batch.manifests,
@@ -136,14 +142,30 @@ export function completedOperationIdentity(
   return canonicalJson(operation);
 }
 
-function operationRequestId(operation: Record<string, unknown>): string | null {
+function operationInfoValue(
+  operation: Record<string, unknown>,
+  infoName: string,
+  description: string,
+): string | null {
   const matches = (OperationInfoSchema.parse(operation).info ?? []).filter(
-    ({ name }) => name === SYNC_REQUEST_ID_INFO_NAME,
+    ({ name }) => name === infoName,
   );
   if (matches.length > 1) {
-    throw new Error("Argo operation has multiple CI request IDs");
+    throw new Error(`Argo operation has multiple CI ${description}s`);
   }
   return matches[0]?.value ?? null;
+}
+
+function operationRequestId(operation: Record<string, unknown>): string | null {
+  return operationInfoValue(operation, SYNC_REQUEST_ID_INFO_NAME, "request ID");
+}
+
+function operationId(operation: Record<string, unknown>): string | null {
+  return operationInfoValue(
+    operation,
+    SYNC_OPERATION_ID_INFO_NAME,
+    "operation ID",
+  );
 }
 
 export function requestedOperationRequestId(application: unknown): string {
@@ -170,4 +192,28 @@ export function completedOperationRequestId(
     ApplicationOperationSchema.parse(application).status?.operationState
       ?.operation;
   return operation === undefined ? null : operationRequestId(operation);
+}
+
+export function requestedOperationId(application: unknown): string {
+  const operation = ApplicationOperationSchema.parse(application).operation;
+  if (operation === undefined) {
+    throw new Error("Argo sync response is missing the requested operation");
+  }
+  const id = operationId(operation);
+  if (id === null) {
+    throw new Error("Argo sync response is missing the CI operation ID");
+  }
+  return id;
+}
+
+export function activeOperationId(application: unknown): string | null {
+  const operation = ApplicationOperationSchema.parse(application).operation;
+  return operation === undefined ? null : operationId(operation);
+}
+
+export function completedOperationId(application: unknown): string | null {
+  const operation =
+    ApplicationOperationSchema.parse(application).status?.operationState
+      ?.operation;
+  return operation === undefined ? null : operationId(operation);
 }

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -158,6 +158,11 @@ export function requestedOperationRequestId(application: unknown): string {
   return requestId;
 }
 
+export function activeOperationRequestId(application: unknown): string | null {
+  const operation = ApplicationOperationSchema.parse(application).operation;
+  return operation === undefined ? null : operationRequestId(operation);
+}
+
 export function completedOperationRequestId(
   application: unknown,
 ): string | null {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -500,6 +500,7 @@ async function sync(
     options.requestId !== undefined || options.terminateAfterApplied === true;
   let baseline: OperationObservation | undefined;
   let adopted = false;
+  let adoptedStatusSeen = false;
 
   if (retryable) {
     baseline = observeOperation(await getApplication(appName, token));
@@ -516,6 +517,7 @@ async function sync(
         requestId,
         options.revision,
       );
+      adoptedStatusSeen = completedOperationMatches;
       if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
           options.terminateAfterApplied === true &&
@@ -587,8 +589,7 @@ async function sync(
     revision: options.revision,
     timeoutSeconds,
     baseline: adopted ? undefined : baseline,
-    exactOperationSeen:
-      adopted && operationMatches(baseline, requestId, options.revision),
+    exactOperationSeen: adoptedStatusSeen,
     terminateAfterApplied: options.terminateAfterApplied === true,
   });
 }

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -10,7 +10,10 @@
  *
  * Usage:
  *   bun packages/homelab/scripts/argocd.ts sync <app> [--revision <v>]
- *       [--prune] [--async] [--timeout <s>] [--dry-run]
+ *       [--prune] [--async | --terminate-after-applied]
+ *       [--request-id <uuid>] [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts finalize-async-sync <app> \
+ *       --revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts delete-application <app> \
  *       --project <project> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts health-wait <app> [--timeout <s>] [--dry-run]
@@ -24,6 +27,7 @@
  * Env:
  *   ARGOCD_TOKEN     — ArgoCD API bearer token (required unless --dry-run)
  *   ARGOCD_SERVER_URL — optional, defaults to https://argocd.sjer.red
+ *   ARGOCD_POLL_INTERVAL_MS — optional polling interval override for tests
  */
 
 import { requireEnv, optionalEnv } from "../../../scripts/lib/run.ts";
@@ -41,8 +45,8 @@ import {
 } from "../src/cdk8s/src/application-release-policy.ts";
 import {
   batchManifestOverrides,
-  completedOperationIdentity,
-  requestedOperationIdentity,
+  completedOperationRequestId,
+  requestedOperationRequestId,
   SYNC_REQUEST_ID_INFO_NAME,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
@@ -60,6 +64,8 @@ const CHARTMUSEUM_REQUEST_TIMEOUT_MS = 10_000;
 const CHARTMUSEUM_RETRY_BASE_DELAY_MS = 100;
 
 const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
+const SyncRequestIdSchema = z.uuid();
+const PollIntervalSchema = z.coerce.number().int().positive();
 
 const ExpectedApplicationsSchema = z.array(
   z.object({
@@ -435,8 +441,8 @@ async function assertRootPruneSafe(
 }
 
 /**
- * Trigger an ArgoCD sync for an application and wait for the sync OPERATION to
- * reach a terminal phase, failing on anything but Succeeded.
+ * Trigger an ArgoCD sync and retain its identity through the requested
+ * completion boundary.
  *
  * The POST only starts the operation; its result lands asynchronously in
  * `status.operationState`. Returning on POST success let a failed operation
@@ -448,6 +454,8 @@ async function assertRootPruneSafe(
  */
 type SyncOptions = {
   prune: boolean;
+  requestId?: string;
+  terminateAfterApplied?: boolean;
   waitForCompletion?: boolean;
   revision?: string;
   manifests?: readonly string[];
@@ -478,68 +486,103 @@ async function sync(
     }
     await assertRootPruneSafe(token, options.revision);
   }
-  const requestId = crypto.randomUUID();
-  const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      prune: options.prune,
-      infos: [{ name: SYNC_REQUEST_ID_INFO_NAME, value: requestId }],
-      ...(options.revision === undefined ? {} : { revision: options.revision }),
-      ...(options.manifests === undefined
-        ? {}
-        : { manifests: options.manifests }),
-      ...(options.resources === undefined
-        ? {}
-        : { resources: options.resources }),
-    }),
-  });
-  if (!res.ok) {
-    const body = (await res.text()).slice(0, 1024);
-    throw new Error(
-      `Sync failed: HTTP ${res.status.toString()} ${res.statusText}\n${body}`,
-    );
+  if (
+    options.terminateAfterApplied === true &&
+    options.revision === undefined
+  ) {
+    throw new Error("--terminate-after-applied requires an exact --revision");
   }
-  const operationIdentity = requestedOperationIdentity(await res.json());
-  console.log(`sync operation started: ${appName}`);
+  const requestId = SyncRequestIdSchema.parse(
+    options.requestId ?? crypto.randomUUID(),
+  );
+  const retryable =
+    options.requestId !== undefined || options.terminateAfterApplied === true;
+  let baseline: OperationObservation | undefined;
+  let adopted = false;
+
+  if (retryable) {
+    baseline = observeOperation(await getApplication(appName, token));
+    assertMatchingRevision(baseline, requestId, options.revision, appName);
+    if (isActiveOperation(baseline.phase)) {
+      if (!operationMatches(baseline, requestId, options.revision)) {
+        throw new Error(
+          `Refusing to replace active ${appName} operation ${operationDescription(baseline)}; expected request ${requestId}`,
+        );
+      }
+      if (baseline.phase === "Terminating") {
+        if (
+          options.terminateAfterApplied === true &&
+          options.revision !== undefined &&
+          syncResultApplied(baseline.state, options.revision)
+        ) {
+          await waitForOperationTermination(
+            appName,
+            token,
+            requestId,
+            options.revision,
+            timeoutSeconds,
+          );
+          console.log(`sync operation already finalized: ${appName}`);
+          return;
+        }
+        throw new Error(
+          `Matching ${appName} operation is already Terminating before its result was accepted`,
+        );
+      }
+      adopted = true;
+      console.log(`adopted active sync operation: ${appName}`);
+    }
+  }
+
+  if (!adopted) {
+    const url = `${serverUrl()}/api/v1/applications/${appName}/sync`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        prune: options.prune,
+        infos: [{ name: SYNC_REQUEST_ID_INFO_NAME, value: requestId }],
+        ...(options.revision === undefined
+          ? {}
+          : { revision: options.revision }),
+        ...(options.manifests === undefined
+          ? {}
+          : { manifests: options.manifests }),
+        ...(options.resources === undefined
+          ? {}
+          : { resources: options.resources }),
+      }),
+    });
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 1024);
+      throw new Error(
+        `Sync failed: HTTP ${res.status.toString()} ${res.statusText}\n${body}`,
+      );
+    }
+    const responseRequestId = requestedOperationRequestId(await res.json());
+    if (responseRequestId !== requestId) {
+      throw new Error(
+        `Argo sync response returned request ${responseRequestId}; expected ${requestId}`,
+      );
+    }
+    console.log(`sync operation started: ${appName}`);
+  }
   if (options.waitForCompletion === false) {
     return;
   }
-
-  const deadline = Date.now() + timeoutSeconds * 1000;
-  let elapsed = 0;
-  while (Date.now() < deadline) {
-    const app = await getApplication(appName, token);
-    const status = isRecord(app["status"]) ? app["status"] : {};
-    const op = isRecord(status["operationState"])
-      ? status["operationState"]
-      : {};
-    const phase = typeof op["phase"] === "string" ? op["phase"] : "";
-    const isOurs = completedOperationIdentity(app) === operationIdentity;
-    console.log(
-      `Operation: ${phase || "(pending)"}${isOurs ? "" : " [previous op]"} ` +
-        `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,
-    );
-    if (isOurs && phase === "Succeeded") {
-      console.log(`synced: ${appName}`);
-      return;
-    }
-    if (isOurs && (phase === "Failed" || phase === "Error")) {
-      const message = typeof op["message"] === "string" ? op["message"] : "";
-      throw new Error(
-        `Sync operation ${phase} for ${appName}: ${message.slice(0, 1024)}`,
-      );
-    }
-    await Bun.sleep(POLL_INTERVAL_MS);
-    elapsed += POLL_INTERVAL_MS / 1000;
-  }
-  throw new Error(
-    `Timeout: sync operation for ${appName} did not complete within ${timeoutSeconds.toString()}s`,
-  );
+  await waitForIdentifiedOperation({
+    appName,
+    token,
+    requestId,
+    revision: options.revision,
+    timeoutSeconds,
+    baseline: adopted ? undefined : baseline,
+    exactOperationSeen: adopted,
+    terminateAfterApplied: options.terminateAfterApplied === true,
+  });
 }
 
 function operationState(app: Record<string, unknown>): Record<string, unknown> {
@@ -553,6 +596,93 @@ function operationRevision(
   const sync = isRecord(operation["sync"]) ? operation["sync"] : {};
   const revision = sync["revision"];
   return typeof revision === "string" ? revision : undefined;
+}
+
+type OperationObservation = {
+  readonly phase: string;
+  readonly requestId: string | null;
+  readonly revision: string | undefined;
+  readonly startedAt: string | undefined;
+  readonly state: Record<string, unknown>;
+};
+
+function observeOperation(app: Record<string, unknown>): OperationObservation {
+  const state = operationState(app);
+  const operation = isRecord(state["operation"])
+    ? state["operation"]
+    : undefined;
+  const phase = state["phase"];
+  const startedAt = state["startedAt"];
+  return {
+    phase: typeof phase === "string" ? phase : "",
+    requestId: completedOperationRequestId(app),
+    revision:
+      operation === undefined ? undefined : operationRevision(operation),
+    startedAt: typeof startedAt === "string" ? startedAt : undefined,
+    state,
+  };
+}
+
+function operationMatches(
+  operation: OperationObservation,
+  requestId: string,
+  revision: string | undefined,
+): boolean {
+  return (
+    operation.requestId === requestId &&
+    (revision === undefined || operation.revision === revision)
+  );
+}
+
+function assertMatchingRevision(
+  operation: OperationObservation,
+  requestId: string,
+  revision: string | undefined,
+  appName: string,
+): void {
+  if (
+    operation.requestId === requestId &&
+    revision !== undefined &&
+    operation.revision !== revision
+  ) {
+    throw new Error(
+      `Refusing ${appName} operation for request ${requestId} at ${operation.revision ?? "unknown revision"}; expected ${revision}`,
+    );
+  }
+}
+
+function operationDescription(operation: OperationObservation): string {
+  return `${operation.requestId ?? "without a request ID"} at ${operation.revision ?? "unknown revision"}`;
+}
+
+function isActiveOperation(phase: string): boolean {
+  return phase === "Running" || phase === "Terminating";
+}
+
+function operationChanged(
+  before: OperationObservation,
+  current: OperationObservation,
+): boolean {
+  return (
+    before.requestId !== current.requestId ||
+    before.revision !== current.revision ||
+    before.startedAt !== current.startedAt ||
+    before.phase !== current.phase
+  );
+}
+
+function operationPollIntervalMs(): number {
+  const configured = optionalEnv("ARGOCD_POLL_INTERVAL_MS");
+  return configured === undefined
+    ? POLL_INTERVAL_MS
+    : PollIntervalSchema.parse(configured);
+}
+
+async function sleepUntilNextOperationPoll(deadline: number): Promise<void> {
+  const remaining = deadline - Date.now();
+  if (remaining > 0) {
+    await Bun.sleep(Math.min(operationPollIntervalMs(), remaining));
+  }
 }
 
 function syncResultRevision(
@@ -593,85 +723,129 @@ function syncResultApplied(
   });
 }
 
-/**
- * Finish a root sync started with `--async` after its manifests are applied.
- *
- * ArgoCD's async flag only changes client-side waiting: the controller keeps
- * the operation Running until every resource is Healthy. The root app owns
- * Applications that are intentionally deferred or independently unhealthy, so
- * that health wait can outlive the release. Before terminating, require the
- * exact requested revision and a complete successful sync result; a failed or
- * mismatched operation remains a hard failure instead of being hidden.
- */
-async function finalizeAsyncSync(
-  appName: string,
-  revision: string,
-  timeoutSeconds: number,
-  dryRun: boolean,
-): Promise<void> {
-  const exactRevision = BuildRevisionSchema.parse(revision);
-  console.log(
-    `--- argocd finalize-async-sync: ${appName} at ${exactRevision}${dryRun ? " (dry run)" : ""}`,
-  );
-  if (dryRun) {
-    console.log(
-      `DRYRUN: would terminate the applied Running operation for ${appName} at ${exactRevision}`,
-    );
-    return;
-  }
+type WaitForIdentifiedOperationOptions = {
+  readonly appName: string;
+  readonly baseline: OperationObservation | undefined;
+  readonly exactOperationSeen: boolean;
+  readonly requestId: string;
+  readonly revision: string | undefined;
+  readonly terminateAfterApplied: boolean;
+  readonly timeoutSeconds: number;
+  readonly token: string;
+};
 
-  const token = requireEnv("ARGOCD_TOKEN");
+async function waitForIdentifiedOperation({
+  appName,
+  baseline,
+  exactOperationSeen: initiallySeen,
+  requestId,
+  revision,
+  terminateAfterApplied,
+  timeoutSeconds,
+  token,
+}: WaitForIdentifiedOperationOptions): Promise<void> {
   const deadline = Date.now() + timeoutSeconds * 1000;
-  let elapsed = 0;
+  let exactOperationSeen = initiallySeen;
   while (Date.now() < deadline) {
-    const app = await getApplication(appName, token);
-    const currentOperation = operationState(app);
-    const phase = currentOperation["phase"];
-    const operation = isRecord(currentOperation["operation"])
-      ? currentOperation["operation"]
-      : undefined;
-    if (operation === undefined) {
-      console.log(`no Running operation to finalize: ${appName}`);
-      return;
-    }
-    const currentRevision = operationRevision(operation);
-    if (currentRevision !== exactRevision) {
+    const current = observeOperation(await getApplication(appName, token));
+    assertMatchingRevision(current, requestId, revision, appName);
+    const isExpected = operationMatches(current, requestId, revision);
+    if (isActiveOperation(current.phase) && !isExpected) {
       throw new Error(
-        `Refusing to terminate ${appName} operation at ${currentRevision ?? "unknown revision"}; expected ${exactRevision}`,
+        `Active ${appName} operation changed to ${operationDescription(current)} while waiting for request ${requestId}`,
       );
     }
-    if (phase === "Failed" || phase === "Error") {
-      const message =
-        typeof currentOperation["message"] === "string"
-          ? currentOperation["message"]
-          : "";
-      throw new Error(
-        `Async sync operation ${phase} for ${appName} at ${exactRevision}: ${message.slice(0, 1024)}`,
-      );
+    if (
+      !exactOperationSeen &&
+      isExpected &&
+      (baseline === undefined || operationChanged(baseline, current))
+    ) {
+      exactOperationSeen = true;
     }
-    if (phase !== "Running" && phase !== "Terminating") {
-      console.log(`async sync operation already finalized: ${appName}`);
-      return;
-    }
+    const elapsed = Math.floor(
+      (timeoutSeconds * 1000 - (deadline - Date.now())) / 1000,
+    );
     console.log(
-      `Operation: ${String(phase)}; applied=${syncResultApplied(currentOperation, exactRevision).toString()} ` +
+      `Operation: ${current.phase || "(pending)"}${exactOperationSeen && isExpected ? "" : " [previous op]"} ` +
         `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,
     );
-    if (
-      phase === "Running" &&
-      syncResultApplied(currentOperation, exactRevision)
-    ) {
-      break;
+    if (exactOperationSeen && isExpected) {
+      if (current.phase === "Succeeded") {
+        console.log(`synced: ${appName}`);
+        return;
+      }
+      if (current.phase === "Failed" || current.phase === "Error") {
+        const message = current.state["message"];
+        throw new Error(
+          `Sync operation ${current.phase} for ${appName}: ${typeof message === "string" ? message.slice(0, 1024) : ""}`,
+        );
+      }
+      if (current.phase === "Terminating") {
+        throw new Error(
+          `Sync operation for ${appName} entered Terminating before this command finalized it`,
+        );
+      }
+      if (
+        terminateAfterApplied &&
+        revision !== undefined &&
+        current.phase === "Running" &&
+        syncResultApplied(current.state, revision)
+      ) {
+        await terminateAppliedOperation(
+          appName,
+          token,
+          requestId,
+          revision,
+          timeoutSeconds,
+        );
+        return;
+      }
     }
-    await Bun.sleep(POLL_INTERVAL_MS);
-    elapsed += POLL_INTERVAL_MS / 1000;
+    await sleepUntilNextOperationPoll(deadline);
   }
-  if (Date.now() >= deadline) {
-    throw new Error(
-      `Timeout: ${appName} operation at ${exactRevision} was not fully applied within ${timeoutSeconds.toString()}s`,
-    );
-  }
+  throw new Error(
+    `Timeout: sync operation for ${appName} did not complete within ${timeoutSeconds.toString()}s`,
+  );
+}
 
+async function waitForOperationTermination(
+  appName: string,
+  token: string,
+  requestId: string,
+  revision: string,
+  timeoutSeconds: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    const current = observeOperation(await getApplication(appName, token));
+    assertMatchingRevision(current, requestId, revision, appName);
+    const isExpected = operationMatches(current, requestId, revision);
+    const hasOperationState =
+      current.phase !== "" ||
+      current.requestId !== null ||
+      current.revision !== undefined;
+    if (!isExpected && hasOperationState) {
+      throw new Error(
+        `${appName} operation changed to ${operationDescription(current)} after terminating request ${requestId}`,
+      );
+    }
+    if (!isExpected || !isActiveOperation(current.phase)) {
+      return;
+    }
+    await sleepUntilNextOperationPoll(deadline);
+  }
+  throw new Error(
+    `Timeout: terminated ${appName} operation for request ${requestId} did not leave Running/Terminating state within ${timeoutSeconds.toString()}s`,
+  );
+}
+
+async function terminateAppliedOperation(
+  appName: string,
+  token: string,
+  requestId: string,
+  revision: string,
+  timeoutSeconds: number,
+): Promise<void> {
   const url = new URL(
     `/api/v1/applications/${encodeURIComponent(appName)}/operation`,
     serverUrl(),
@@ -689,18 +863,111 @@ async function finalizeAsyncSync(
       `Async sync termination failed: HTTP ${response.status.toString()} ${response.statusText}\n${body}`,
     );
   }
-  console.log(`terminated applied async sync operation: ${appName}`);
+  console.log(`terminated applied sync operation: ${appName}`);
+  await waitForOperationTermination(
+    appName,
+    token,
+    requestId,
+    revision,
+    timeoutSeconds,
+  );
+}
 
+/**
+ * Recover a root sync started by an earlier process after its manifests apply.
+ *
+ * ArgoCD's async flag only changes client-side waiting: the controller keeps
+ * the operation Running until every resource is Healthy. The root app owns
+ * Applications that are intentionally deferred or independently unhealthy, so
+ * that health wait can outlive the release. Before terminating, require the
+ * exact request ID, exact requested revision, and a complete successful sync
+ * result; a missing, failed, or mismatched operation remains a hard failure.
+ */
+async function finalizeAsyncSync(
+  appName: string,
+  revision: string,
+  requestId: string,
+  timeoutSeconds: number,
+  dryRun: boolean,
+): Promise<void> {
+  const exactRevision = BuildRevisionSchema.parse(revision);
+  const exactRequestId = SyncRequestIdSchema.parse(requestId);
+  console.log(
+    `--- argocd finalize-async-sync: ${appName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
+  );
+  if (dryRun) {
+    console.log(
+      `DRYRUN: would terminate the applied Running operation for ${appName} at ${exactRevision} for request ${exactRequestId}`,
+    );
+    return;
+  }
+
+  const token = requireEnv("ARGOCD_TOKEN");
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let elapsed = 0;
   while (Date.now() < deadline) {
-    const current = operationState(await getApplication(appName, token));
-    const phase = current["phase"];
-    if (phase !== "Running" && phase !== "Terminating") {
+    const current = observeOperation(await getApplication(appName, token));
+    assertMatchingRevision(current, exactRequestId, exactRevision, appName);
+    const isExpected = operationMatches(current, exactRequestId, exactRevision);
+    if (isActiveOperation(current.phase) && !isExpected) {
+      throw new Error(
+        `Refusing to terminate active ${appName} operation ${operationDescription(current)}; expected request ${exactRequestId} at ${exactRevision}`,
+      );
+    }
+    if (
+      isExpected &&
+      (current.phase === "Failed" || current.phase === "Error")
+    ) {
+      const message = current.state["message"];
+      throw new Error(
+        `Async sync operation ${current.phase} for ${appName} at ${exactRevision}: ${typeof message === "string" ? message.slice(0, 1024) : ""}`,
+      );
+    }
+    if (isExpected && current.phase === "Succeeded") {
+      console.log(`async sync operation already finalized: ${appName}`);
       return;
     }
-    await Bun.sleep(POLL_INTERVAL_MS);
+    console.log(
+      `Operation: ${current.phase || "(pending)"}${isExpected ? "" : " [previous op]"}; ` +
+        `applied=${isExpected && syncResultApplied(current.state, exactRevision) ? "true" : "false"} ` +
+        `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,
+    );
+    if (isExpected && current.phase === "Terminating") {
+      if (!syncResultApplied(current.state, exactRevision)) {
+        throw new Error(
+          `Matching ${appName} operation entered Terminating before its result was fully applied`,
+        );
+      }
+      await waitForOperationTermination(
+        appName,
+        token,
+        exactRequestId,
+        exactRevision,
+        timeoutSeconds,
+      );
+      return;
+    }
+    if (
+      isExpected &&
+      current.phase === "Running" &&
+      syncResultApplied(current.state, exactRevision)
+    ) {
+      await terminateAppliedOperation(
+        appName,
+        token,
+        exactRequestId,
+        exactRevision,
+        timeoutSeconds,
+      );
+      return;
+    }
+    await sleepUntilNextOperationPoll(deadline);
+    elapsed = Math.floor(
+      (timeoutSeconds * 1000 - (deadline - Date.now())) / 1000,
+    );
   }
   throw new Error(
-    `Timeout: terminated ${appName} operation did not leave Running/Terminating state within ${timeoutSeconds.toString()}s`,
+    `Timeout: ${appName} operation for request ${exactRequestId} at ${exactRevision} was not fully applied within ${timeoutSeconds.toString()}s`,
   );
 }
 
@@ -734,8 +1001,9 @@ async function reconcileRelease(
     timeoutSeconds,
   );
   const token = requireEnv("ARGOCD_TOKEN");
-  // The release step submits the root Application sync asynchronously. Waiting
-  // here would make every release depend on unrelated child Application health.
+  // The release step handles the root Application with the subsequent atomic
+  // sync. Waiting for it here would make every release depend on unrelated
+  // child Application health.
   for (const wanted of expected) {
     if (wanted.name === "apps" || deferredApps.has(wanted.name)) {
       continue;
@@ -1030,7 +1298,8 @@ function usage(): never {
   console.error(
     "Usage:\n" +
       "  bun packages/homelab/scripts/argocd.ts sync <app> " +
-      "[--revision <v>] [--prune] [--async] [--timeout <s>] [--dry-run]\n" +
+      "[--revision <v>] [--prune] [--async | --terminate-after-applied] " +
+      "[--request-id <uuid>] [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts delete-application <app> " +
       "--project <project> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts health-wait <app> " +
@@ -1043,7 +1312,7 @@ function usage(): never {
       "[--defer-apps <app,...>] [--skip-health-wait] " +
       "[--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts finalize-async-sync <app> " +
-      "--revision <v> [--timeout <s>] [--dry-run]\n" +
+      "--revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> " +
       "[--revision <v>] [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts wait-deletion <app> " +
@@ -1103,10 +1372,35 @@ async function main(): Promise<void> {
   switch (subcommand) {
     case "sync": {
       const revision = flag(argv, "revision");
+      const requestId = flag(argv, "request-id");
+      const asyncSync = argv.includes("--async");
+      const terminateAfterApplied = argv.includes("--terminate-after-applied");
+      if (asyncSync && terminateAfterApplied) {
+        console.error(
+          "--async and --terminate-after-applied cannot be combined.",
+        );
+        usage();
+      }
+      if (terminateAfterApplied && revision === undefined) {
+        console.error(
+          "--terminate-after-applied requires an exact --revision.",
+        );
+        usage();
+      }
+      if (requestId !== undefined && revision === undefined) {
+        console.error("--request-id requires an exact --revision.");
+        usage();
+      }
+      const exactRequestId =
+        requestId === undefined
+          ? undefined
+          : SyncRequestIdSchema.parse(requestId);
       await sync(app, timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S, dryRun, {
         prune: argv.includes("--prune"),
-        waitForCompletion: !argv.includes("--async"),
+        waitForCompletion: !asyncSync,
+        terminateAfterApplied,
         ...(revision === undefined ? {} : { revision }),
+        ...(exactRequestId === undefined ? {} : { requestId: exactRequestId }),
       });
       return;
     }
@@ -1158,13 +1452,17 @@ async function main(): Promise<void> {
       return;
     case "finalize-async-sync": {
       const revision = flag(argv, "revision");
-      if (revision === undefined) {
-        console.error("--revision is required for finalize-async-sync.");
+      const requestId = flag(argv, "request-id");
+      if (revision === undefined || requestId === undefined) {
+        console.error(
+          "--revision and --request-id are required for finalize-async-sync.",
+        );
         usage();
       }
       await finalizeAsyncSync(
         app,
         revision,
+        requestId,
         timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
         dryRun,
       );

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -110,6 +110,12 @@ const RenderedObjectSchema = z
   })
   .passthrough();
 
+const RenderedResourceSchema = z.object({
+  apiVersion: z.string().min(1),
+  kind: z.string().min(1),
+  metadata: z.object({ name: z.string().min(1) }).passthrough(),
+});
+
 const RootDeploymentHistorySchema = z.object({
   status: z.object({
     history: z
@@ -221,6 +227,43 @@ async function getApplicationManifests(
     );
   }
   return ManifestResponseSchema.parse(await response.json()).manifests;
+}
+
+function resourceIdentity(group: string, kind: string, name: string): string {
+  return JSON.stringify([group, kind, name]);
+}
+
+function renderedResourceIdentity(manifestSource: string): string {
+  const resource = RenderedResourceSchema.parse(JSON.parse(manifestSource));
+  const separator = resource.apiVersion.indexOf("/");
+  const group = separator === -1 ? "" : resource.apiVersion.slice(0, separator);
+  return resourceIdentity(group, resource.kind, resource.metadata.name);
+}
+
+function renderedResourceIdentities(
+  manifests: readonly string[],
+): ReadonlySet<string> {
+  const identities = manifests.map(renderedResourceIdentity);
+  if (identities.length === 0) {
+    throw new Error("Rendered sync source contains no resources");
+  }
+  const unique = new Set(identities);
+  if (unique.size !== identities.length) {
+    throw new Error(
+      "Rendered sync source contains duplicate group/kind/name identities",
+    );
+  }
+  return unique;
+}
+
+async function getRenderedResourceIdentities(
+  appName: string,
+  revision: string,
+  token: string,
+): Promise<ReadonlySet<string>> {
+  return renderedResourceIdentities(
+    await getApplicationManifests(appName, revision, token),
+  );
 }
 
 async function suspendRepositoryAutoSync(
@@ -394,18 +437,18 @@ async function fetchChartMuseumInventory(
 async function assertRootPruneSafe(
   token: string,
   revision: string,
-): Promise<void> {
+): Promise<ReadonlySet<string>> {
   const exactRevision = BuildRevisionSchema.parse(revision);
+  const manifests = await getApplicationManifests("apps", exactRevision, token);
+  const desiredResources = renderedResourceIdentities(manifests);
   const desiredChildren = new Set(
-    (await getApplicationManifests("apps", exactRevision, token)).flatMap(
-      (manifestSource) => {
-        const parsed = RenderedObjectSchema.parse(JSON.parse(manifestSource));
-        if (parsed.kind !== "Application") {
-          return [];
-        }
-        return [RenderedApplicationSchema.parse(parsed).metadata.name];
-      },
-    ),
+    manifests.flatMap((manifestSource) => {
+      const parsed = RenderedObjectSchema.parse(JSON.parse(manifestSource));
+      if (parsed.kind !== "Application") {
+        return [];
+      }
+      return [RenderedApplicationSchema.parse(parsed).metadata.name];
+    }),
   );
   const root = await getApplication("apps", token);
   const status = isRecord(root["status"]) ? root["status"] : {};
@@ -445,6 +488,7 @@ async function assertRootPruneSafe(
       );
     }
   }
+  return desiredResources;
 }
 
 /**
@@ -485,19 +529,34 @@ async function sync(
     return;
   }
   const token = requireEnv("ARGOCD_TOKEN");
+  let expectedResourceIdentities: ReadonlySet<string> | undefined;
   if (appName === "apps" && options.prune) {
     if (options.revision === undefined) {
       throw new Error(
         "Root Application pruning requires an exact --revision so prune candidates can be verified against the rendered source",
       );
     }
-    await assertRootPruneSafe(token, options.revision);
+    expectedResourceIdentities = await assertRootPruneSafe(
+      token,
+      options.revision,
+    );
   }
   if (
     options.terminateAfterApplied === true &&
     options.revision === undefined
   ) {
     throw new Error("--terminate-after-applied requires an exact --revision");
+  }
+  if (
+    options.terminateAfterApplied === true &&
+    options.revision !== undefined &&
+    expectedResourceIdentities === undefined
+  ) {
+    expectedResourceIdentities = await getRenderedResourceIdentities(
+      appName,
+      options.revision,
+      token,
+    );
   }
   const requestId = SyncRequestIdSchema.parse(
     options.requestId ?? crypto.randomUUID(),
@@ -529,7 +588,11 @@ async function sync(
         if (
           options.terminateAfterApplied === true &&
           options.revision !== undefined &&
-          syncResultApplied(baseline.state, options.revision)
+          syncResultApplied(
+            baseline.state,
+            options.revision,
+            expectedResourceIdentities,
+          )
         ) {
           await waitForOperationTermination(
             appName,
@@ -606,6 +669,7 @@ async function sync(
     token,
     requestId,
     operationId,
+    expectedResourceIdentities,
     revision: options.revision,
     timeoutSeconds,
     terminateAfterApplied: options.terminateAfterApplied === true,
@@ -788,6 +852,7 @@ function syncResultRevision(
 function syncResultApplied(
   operationStateValue: Record<string, unknown>,
   revision: string,
+  expectedResourceIdentities: ReadonlySet<string> | undefined,
 ): boolean {
   if (syncResultRevision(operationStateValue) !== revision) {
     return false;
@@ -799,22 +864,42 @@ function syncResultApplied(
   if (!Array.isArray(resources) || resources.length === 0) {
     return false;
   }
-  return resources.every((resource: unknown) => {
+  const appliedResourceIdentities = new Set<string>();
+  const everyReportedResourceApplied = resources.every((resource: unknown) => {
     if (!isRecord(resource)) {
       return false;
     }
     const status = resource["status"];
     const hookPhase = resource["hookPhase"];
+    const group = resource["group"];
+    const kind = resource["kind"];
+    const name = resource["name"];
+    if (
+      (group !== undefined && typeof group !== "string") ||
+      typeof kind !== "string" ||
+      typeof name !== "string"
+    ) {
+      return false;
+    }
+    appliedResourceIdentities.add(resourceIdentity(group ?? "", kind, name));
     return (
       (status === "Synced" || status === "Pruned" || status === "Skipped") &&
       hookPhase !== "Failed" &&
       hookPhase !== "Error"
     );
   });
+  return (
+    everyReportedResourceApplied &&
+    (expectedResourceIdentities === undefined ||
+      [...expectedResourceIdentities].every((identity) =>
+        appliedResourceIdentities.has(identity),
+      ))
+  );
 }
 
 type WaitForIdentifiedOperationOptions = {
   readonly appName: string;
+  readonly expectedResourceIdentities: ReadonlySet<string> | undefined;
   readonly operationId: string;
   readonly requestId: string;
   readonly revision: string | undefined;
@@ -825,6 +910,7 @@ type WaitForIdentifiedOperationOptions = {
 
 async function waitForIdentifiedOperation({
   appName,
+  expectedResourceIdentities,
   operationId,
   requestId,
   revision,
@@ -886,7 +972,7 @@ async function waitForIdentifiedOperation({
         revision !== undefined &&
         isExpectedLiveOperation &&
         current.phase === "Running" &&
-        syncResultApplied(current.state, revision)
+        syncResultApplied(current.state, revision, expectedResourceIdentities)
       ) {
         await terminateAppliedOperation(
           appName,
@@ -1021,6 +1107,11 @@ async function finalizeAsyncSync(
   }
 
   const token = requireEnv("ARGOCD_TOKEN");
+  const expectedResourceIdentities = await getRenderedResourceIdentities(
+    appName,
+    exactRevision,
+    token,
+  );
   const deadline = Date.now() + timeoutSeconds * 1000;
   let elapsed = 0;
   while (Date.now() < deadline) {
@@ -1068,7 +1159,7 @@ async function finalizeAsyncSync(
       operationMatches(current, exactRequestId, exactRevision, liveOperationId);
     console.log(
       `Operation: ${current.phase || "(pending)"}${isExpectedOperation ? "" : " [previous op]"}; ` +
-        `applied=${isExpectedOperation && syncResultApplied(current.state, exactRevision) ? "true" : "false"} ` +
+        `applied=${isExpectedOperation && syncResultApplied(current.state, exactRevision, expectedResourceIdentities) ? "true" : "false"} ` +
         `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,
     );
     if (
@@ -1076,7 +1167,13 @@ async function finalizeAsyncSync(
       isExpectedOperation &&
       current.phase === "Terminating"
     ) {
-      if (!syncResultApplied(current.state, exactRevision)) {
+      if (
+        !syncResultApplied(
+          current.state,
+          exactRevision,
+          expectedResourceIdentities,
+        )
+      ) {
         throw new Error(
           `Matching ${appName} operation entered Terminating before its result was fully applied`,
         );
@@ -1096,7 +1193,11 @@ async function finalizeAsyncSync(
       liveOperationId !== undefined &&
       isExpectedOperation &&
       current.phase === "Running" &&
-      syncResultApplied(current.state, exactRevision)
+      syncResultApplied(
+        current.state,
+        exactRevision,
+        expectedResourceIdentities,
+      )
     ) {
       await terminateAppliedOperation(
         appName,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -44,6 +44,7 @@ import {
   REPOSITORY_CHART_URLS,
 } from "../src/cdk8s/src/application-release-policy.ts";
 import {
+  activeOperationRequestId,
   batchManifestOverrides,
   completedOperationRequestId,
   requestedOperationRequestId,
@@ -503,13 +504,19 @@ async function sync(
   if (retryable) {
     baseline = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(baseline, requestId, options.revision, appName);
-    if (isActiveOperation(baseline.phase)) {
-      if (!operationMatches(baseline, requestId, options.revision)) {
+    assertMatchingLiveRevision(baseline, requestId, options.revision, appName);
+    if (baseline.hasLiveOperation) {
+      if (!liveOperationMatches(baseline, requestId, options.revision)) {
         throw new Error(
-          `Refusing to replace active ${appName} operation ${operationDescription(baseline)}; expected request ${requestId}`,
+          `Refusing to replace active ${appName} operation ${liveOperationDescription(baseline)}; expected request ${requestId}`,
         );
       }
-      if (baseline.phase === "Terminating") {
+      const completedOperationMatches = operationMatches(
+        baseline,
+        requestId,
+        options.revision,
+      );
+      if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
           options.terminateAfterApplied === true &&
           options.revision !== undefined &&
@@ -580,7 +587,8 @@ async function sync(
     revision: options.revision,
     timeoutSeconds,
     baseline: adopted ? undefined : baseline,
-    exactOperationSeen: adopted,
+    exactOperationSeen:
+      adopted && operationMatches(baseline, requestId, options.revision),
     terminateAfterApplied: options.terminateAfterApplied === true,
   });
 }
@@ -599,6 +607,9 @@ function operationRevision(
 }
 
 type OperationObservation = {
+  readonly hasLiveOperation: boolean;
+  readonly liveRequestId: string | null;
+  readonly liveRevision: string | undefined;
   readonly phase: string;
   readonly requestId: string | null;
   readonly revision: string | undefined;
@@ -608,19 +619,43 @@ type OperationObservation = {
 
 function observeOperation(app: Record<string, unknown>): OperationObservation {
   const state = operationState(app);
-  const operation = isRecord(state["operation"])
+  const completedOperation = isRecord(state["operation"])
     ? state["operation"]
+    : undefined;
+  const liveOperation = isRecord(app["operation"])
+    ? app["operation"]
     : undefined;
   const phase = state["phase"];
   const startedAt = state["startedAt"];
   return {
+    hasLiveOperation: liveOperation !== undefined,
+    liveRequestId:
+      liveOperation === undefined ? null : activeOperationRequestId(app),
+    liveRevision:
+      liveOperation === undefined
+        ? undefined
+        : operationRevision(liveOperation),
     phase: typeof phase === "string" ? phase : "",
     requestId: completedOperationRequestId(app),
     revision:
-      operation === undefined ? undefined : operationRevision(operation),
+      completedOperation === undefined
+        ? undefined
+        : operationRevision(completedOperation),
     startedAt: typeof startedAt === "string" ? startedAt : undefined,
     state,
   };
+}
+
+function liveOperationMatches(
+  operation: OperationObservation,
+  requestId: string,
+  revision: string | undefined,
+): boolean {
+  return (
+    operation.hasLiveOperation &&
+    operation.liveRequestId === requestId &&
+    (revision === undefined || operation.liveRevision === revision)
+  );
 }
 
 function operationMatches(
@@ -651,8 +686,29 @@ function assertMatchingRevision(
   }
 }
 
+function assertMatchingLiveRevision(
+  operation: OperationObservation,
+  requestId: string,
+  revision: string | undefined,
+  appName: string,
+): void {
+  if (
+    operation.liveRequestId === requestId &&
+    revision !== undefined &&
+    operation.liveRevision !== revision
+  ) {
+    throw new Error(
+      `Refusing active ${appName} operation for request ${requestId} at ${operation.liveRevision ?? "unknown revision"}; expected ${revision}`,
+    );
+  }
+}
+
 function operationDescription(operation: OperationObservation): string {
   return `${operation.requestId ?? "without a request ID"} at ${operation.revision ?? "unknown revision"}`;
+}
+
+function liveOperationDescription(operation: OperationObservation): string {
+  return `${operation.liveRequestId ?? "without a request ID"} at ${operation.liveRevision ?? "unknown revision"}`;
 }
 
 function isActiveOperation(phase: string): boolean {
@@ -749,10 +805,16 @@ async function waitForIdentifiedOperation({
   while (Date.now() < deadline) {
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, requestId, revision, appName);
+    assertMatchingLiveRevision(current, requestId, revision, appName);
     const isExpected = operationMatches(current, requestId, revision);
-    if (isActiveOperation(current.phase) && !isExpected) {
+    const isExpectedLiveOperation = liveOperationMatches(
+      current,
+      requestId,
+      revision,
+    );
+    if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
-        `Active ${appName} operation changed to ${operationDescription(current)} while waiting for request ${requestId}`,
+        `Active ${appName} operation changed to ${liveOperationDescription(current)} while waiting for request ${requestId}`,
       );
     }
     if (
@@ -788,6 +850,7 @@ async function waitForIdentifiedOperation({
       if (
         terminateAfterApplied &&
         revision !== undefined &&
+        isExpectedLiveOperation &&
         current.phase === "Running" &&
         syncResultApplied(current.state, revision)
       ) {
@@ -819,7 +882,18 @@ async function waitForOperationTermination(
   while (Date.now() < deadline) {
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, requestId, revision, appName);
+    assertMatchingLiveRevision(current, requestId, revision, appName);
     const isExpected = operationMatches(current, requestId, revision);
+    const isExpectedLiveOperation = liveOperationMatches(
+      current,
+      requestId,
+      revision,
+    );
+    if (current.hasLiveOperation && !isExpectedLiveOperation) {
+      throw new Error(
+        `${appName} operation changed to ${liveOperationDescription(current)} after terminating request ${requestId}`,
+      );
+    }
     const hasOperationState =
       current.phase !== "" ||
       current.requestId !== null ||
@@ -829,7 +903,10 @@ async function waitForOperationTermination(
         `${appName} operation changed to ${operationDescription(current)} after terminating request ${requestId}`,
       );
     }
-    if (!isExpected || !isActiveOperation(current.phase)) {
+    if (
+      !current.hasLiveOperation &&
+      (!isExpected || !isActiveOperation(current.phase))
+    ) {
       return;
     }
     await sleepUntilNextOperationPoll(deadline);

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -619,7 +619,7 @@ async function sync(
             expectedResourceIdentities,
           )
         ) {
-          await waitForOperationTermination(
+          await waitForOperationToClear(
             appName,
             token,
             requestId,
@@ -997,6 +997,17 @@ async function waitForIdentifiedOperation({
     );
     if (exactOperationSeen && isExpected) {
       if (current.phase === "Succeeded") {
+        if (current.hasLiveOperation) {
+          await waitForOperationToClear(
+            appName,
+            token,
+            requestId,
+            revision,
+            operationId,
+            current.startedAt,
+            timeoutSeconds,
+          );
+        }
         console.log(`synced: ${appName}`);
         return;
       }
@@ -1037,11 +1048,11 @@ async function waitForIdentifiedOperation({
   );
 }
 
-async function waitForOperationTermination(
+async function waitForOperationToClear(
   appName: string,
   token: string,
   requestId: string,
-  revision: string,
+  revision: string | undefined,
   operationId: string | null,
   startedAt: string | undefined,
   timeoutSeconds: number,
@@ -1059,13 +1070,13 @@ async function waitForOperationTermination(
     );
     if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
-        `${appName} operation changed to ${liveOperationDescription(current)} after terminating request ${requestId}`,
+        `${appName} operation changed to ${liveOperationDescription(current)} while waiting for request ${requestId} to clear`,
       );
     }
     if (!current.hasLiveOperation) {
       if (operationStartedAfter(current, startedAt)) {
         throw new Error(
-          `${appName} operation changed to ${operationDescription(current)} after terminating request ${requestId}`,
+          `${appName} operation changed to ${operationDescription(current)} while waiting for request ${requestId} to clear`,
         );
       }
       return;
@@ -1073,7 +1084,7 @@ async function waitForOperationTermination(
     await sleepUntilNextOperationPoll(deadline);
   }
   throw new Error(
-    `Timeout: terminated ${appName} operation for request ${requestId} did not leave Running/Terminating state within ${timeoutSeconds.toString()}s`,
+    `Timeout: ${appName} operation for request ${requestId} did not clear within ${timeoutSeconds.toString()}s`,
   );
 }
 
@@ -1104,7 +1115,7 @@ async function terminateAppliedOperation(
     );
   }
   console.log(`terminated applied sync operation: ${appName}`);
-  await waitForOperationTermination(
+  await waitForOperationToClear(
     appName,
     token,
     requestId,
@@ -1213,7 +1224,7 @@ async function finalizeAsyncSync(
           `Matching ${appName} operation entered Terminating before its result was fully applied`,
         );
       }
-      await waitForOperationTermination(
+      await waitForOperationToClear(
         appName,
         token,
         exactRequestId,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -500,7 +500,6 @@ async function sync(
     options.requestId !== undefined || options.terminateAfterApplied === true;
   let baseline: OperationObservation | undefined;
   let adopted = false;
-  let adoptedStatusSeen = false;
 
   if (retryable) {
     baseline = observeOperation(await getApplication(appName, token));
@@ -517,7 +516,6 @@ async function sync(
         requestId,
         options.revision,
       );
-      adoptedStatusSeen = completedOperationMatches;
       if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
           options.terminateAfterApplied === true &&
@@ -588,8 +586,8 @@ async function sync(
     requestId,
     revision: options.revision,
     timeoutSeconds,
-    baseline: adopted ? undefined : baseline,
-    exactOperationSeen: adoptedStatusSeen,
+    baseline,
+    exactOperationSeen: false,
     terminateAfterApplied: options.terminateAfterApplied === true,
   });
 }
@@ -724,7 +722,8 @@ function operationChanged(
     before.requestId !== current.requestId ||
     before.revision !== current.revision ||
     before.startedAt !== current.startedAt ||
-    before.phase !== current.phase
+    before.phase !== current.phase ||
+    JSON.stringify(before.state) !== JSON.stringify(current.state)
   );
 }
 
@@ -986,14 +985,21 @@ async function finalizeAsyncSync(
   while (Date.now() < deadline) {
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, exactRequestId, exactRevision, appName);
+    assertMatchingLiveRevision(current, exactRequestId, exactRevision, appName);
     const isExpected = operationMatches(current, exactRequestId, exactRevision);
-    if (isActiveOperation(current.phase) && !isExpected) {
+    const isExpectedLiveOperation = liveOperationMatches(
+      current,
+      exactRequestId,
+      exactRevision,
+    );
+    if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
-        `Refusing to terminate active ${appName} operation ${operationDescription(current)}; expected request ${exactRequestId} at ${exactRevision}`,
+        `Refusing to terminate active ${appName} operation ${liveOperationDescription(current)}; expected request ${exactRequestId} at ${exactRevision}`,
       );
     }
     if (
       isExpected &&
+      !current.hasLiveOperation &&
       (current.phase === "Failed" || current.phase === "Error")
     ) {
       const message = current.state["message"];
@@ -1001,7 +1007,11 @@ async function finalizeAsyncSync(
         `Async sync operation ${current.phase} for ${appName} at ${exactRevision}: ${typeof message === "string" ? message.slice(0, 1024) : ""}`,
       );
     }
-    if (isExpected && current.phase === "Succeeded") {
+    if (
+      isExpected &&
+      !current.hasLiveOperation &&
+      current.phase === "Succeeded"
+    ) {
       console.log(`async sync operation already finalized: ${appName}`);
       return;
     }
@@ -1027,6 +1037,7 @@ async function finalizeAsyncSync(
     }
     if (
       isExpected &&
+      isExpectedLiveOperation &&
       current.phase === "Running" &&
       syncResultApplied(current.state, exactRevision)
     ) {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -266,6 +266,22 @@ async function getRenderedResourceIdentities(
   );
 }
 
+type ExpectedSyncResultIdentities = {
+  readonly desired: ReadonlySet<string>;
+  readonly pruned: ReadonlySet<string>;
+};
+
+async function getExpectedSyncResultIdentities(
+  appName: string,
+  revision: string,
+  token: string,
+): Promise<ExpectedSyncResultIdentities> {
+  return {
+    desired: await getRenderedResourceIdentities(appName, revision, token),
+    pruned: new Set(),
+  };
+}
+
 async function suspendRepositoryAutoSync(
   rootAppName: string,
   timeoutSeconds: number,
@@ -437,7 +453,7 @@ async function fetchChartMuseumInventory(
 async function assertRootPruneSafe(
   token: string,
   revision: string,
-): Promise<ReadonlySet<string>> {
+): Promise<ExpectedSyncResultIdentities> {
   const exactRevision = BuildRevisionSchema.parse(revision);
   const manifests = await getApplicationManifests("apps", exactRevision, token);
   const desiredResources = renderedResourceIdentities(manifests);
@@ -455,19 +471,25 @@ async function assertRootPruneSafe(
   const resources = Array.isArray(status["resources"])
     ? status["resources"]
     : [];
-  const candidates = resources.flatMap((resource: unknown) => {
+  const candidates = new Map<string, string>();
+  for (const resource of resources) {
     if (
       !isRecord(resource) ||
       resource["kind"] !== "Application" ||
+      (resource["group"] !== undefined &&
+        resource["group"] !== "argoproj.io") ||
       typeof resource["name"] !== "string" ||
       resource["name"] === "apps" ||
       desiredChildren.has(resource["name"])
     ) {
-      return [];
+      continue;
     }
-    return [resource["name"]];
-  });
-  for (const childName of candidates) {
+    candidates.set(
+      resource["name"],
+      resourceIdentity("argoproj.io", "Application", resource["name"]),
+    );
+  }
+  for (const childName of candidates.keys()) {
     const child = await getApplication(childName, token);
     const metadata = isRecord(child["metadata"]) ? child["metadata"] : {};
     const annotations = isRecord(metadata["annotations"])
@@ -488,7 +510,10 @@ async function assertRootPruneSafe(
       );
     }
   }
-  return desiredResources;
+  return {
+    desired: desiredResources,
+    pruned: new Set(candidates.values()),
+  };
 }
 
 /**
@@ -529,7 +554,7 @@ async function sync(
     return;
   }
   const token = requireEnv("ARGOCD_TOKEN");
-  let expectedResourceIdentities: ReadonlySet<string> | undefined;
+  let expectedResourceIdentities: ExpectedSyncResultIdentities | undefined;
   if (appName === "apps" && options.prune) {
     if (options.revision === undefined) {
       throw new Error(
@@ -552,7 +577,7 @@ async function sync(
     options.revision !== undefined &&
     expectedResourceIdentities === undefined
   ) {
-    expectedResourceIdentities = await getRenderedResourceIdentities(
+    expectedResourceIdentities = await getExpectedSyncResultIdentities(
       appName,
       options.revision,
       token,
@@ -737,7 +762,7 @@ function liveOperationMatches(
   operation: OperationObservation,
   requestId: string,
   revision: string | undefined,
-  operationId?: string,
+  operationId?: string | null,
 ): boolean {
   return (
     operation.hasLiveOperation &&
@@ -751,7 +776,7 @@ function operationMatches(
   operation: OperationObservation,
   requestId: string,
   revision: string | undefined,
-  operationId?: string,
+  operationId?: string | null,
 ): boolean {
   return (
     operation.requestId === requestId &&
@@ -852,7 +877,7 @@ function syncResultRevision(
 function syncResultApplied(
   operationStateValue: Record<string, unknown>,
   revision: string,
-  expectedResourceIdentities: ReadonlySet<string> | undefined,
+  expectedResourceIdentities: ExpectedSyncResultIdentities | undefined,
 ): boolean {
   if (syncResultRevision(operationStateValue) !== revision) {
     return false;
@@ -865,6 +890,7 @@ function syncResultApplied(
     return false;
   }
   const appliedResourceIdentities = new Set<string>();
+  const prunedResourceIdentities = new Set<string>();
   const everyReportedResourceApplied = resources.every((resource: unknown) => {
     if (!isRecord(resource)) {
       return false;
@@ -881,7 +907,11 @@ function syncResultApplied(
     ) {
       return false;
     }
-    appliedResourceIdentities.add(resourceIdentity(group ?? "", kind, name));
+    const identity = resourceIdentity(group ?? "", kind, name);
+    appliedResourceIdentities.add(identity);
+    if (status === "Pruned") {
+      prunedResourceIdentities.add(identity);
+    }
     return (
       (status === "Synced" || status === "Pruned" || status === "Skipped") &&
       hookPhase !== "Failed" &&
@@ -891,15 +921,18 @@ function syncResultApplied(
   return (
     everyReportedResourceApplied &&
     (expectedResourceIdentities === undefined ||
-      [...expectedResourceIdentities].every((identity) =>
+      ([...expectedResourceIdentities.desired].every((identity) =>
         appliedResourceIdentities.has(identity),
-      ))
+      ) &&
+        [...expectedResourceIdentities.pruned].every((identity) =>
+          prunedResourceIdentities.has(identity),
+        )))
   );
 }
 
 type WaitForIdentifiedOperationOptions = {
   readonly appName: string;
-  readonly expectedResourceIdentities: ReadonlySet<string> | undefined;
+  readonly expectedResourceIdentities: ExpectedSyncResultIdentities | undefined;
   readonly operationId: string;
   readonly requestId: string;
   readonly revision: string | undefined;
@@ -998,7 +1031,7 @@ async function waitForOperationTermination(
   token: string,
   requestId: string,
   revision: string,
-  operationId: string,
+  operationId: string | null,
   startedAt: string | undefined,
   timeoutSeconds: number,
 ): Promise<void> {
@@ -1007,12 +1040,6 @@ async function waitForOperationTermination(
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, requestId, revision, appName);
     assertMatchingLiveRevision(current, requestId, revision, appName);
-    const isExpected = operationMatches(
-      current,
-      requestId,
-      revision,
-      operationId,
-    );
     const isExpectedLiveOperation = liveOperationMatches(
       current,
       requestId,
@@ -1025,7 +1052,7 @@ async function waitForOperationTermination(
       );
     }
     if (!current.hasLiveOperation) {
-      if (!isExpected && operationStartedAfter(current, startedAt)) {
+      if (operationStartedAfter(current, startedAt)) {
         throw new Error(
           `${appName} operation changed to ${operationDescription(current)} after terminating request ${requestId}`,
         );
@@ -1044,7 +1071,7 @@ async function terminateAppliedOperation(
   token: string,
   requestId: string,
   revision: string,
-  operationId: string,
+  operationId: string | null,
   startedAt: string | undefined,
   timeoutSeconds: number,
 ): Promise<void> {
@@ -1107,11 +1134,10 @@ async function finalizeAsyncSync(
   }
 
   const token = requireEnv("ARGOCD_TOKEN");
-  const expectedResourceIdentities = await getRenderedResourceIdentities(
-    appName,
-    exactRevision,
-    token,
-  );
+  const expectedResourceIdentities =
+    appName === "apps"
+      ? await assertRootPruneSafe(token, exactRevision)
+      : await getExpectedSyncResultIdentities(appName, exactRevision, token);
   const deadline = Date.now() + timeoutSeconds * 1000;
   let elapsed = 0;
   while (Date.now() < deadline) {
@@ -1152,7 +1178,9 @@ async function finalizeAsyncSync(
       return;
     }
     const liveOperationId = current.hasLiveOperation
-      ? requireLiveOperationId(current, appName)
+      ? current.liveOperationId === null
+        ? null
+        : SyncOperationIdSchema.parse(current.liveOperationId)
       : undefined;
     const isExpectedOperation =
       liveOperationId !== undefined &&

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -839,6 +839,17 @@ function requireLiveOperationId(
   return SyncOperationIdSchema.parse(operation.liveOperationId);
 }
 
+function recoveryLiveOperationId(
+  operation: OperationObservation,
+): string | null | undefined {
+  if (!operation.hasLiveOperation) {
+    return undefined;
+  }
+  return operation.liveOperationId === null
+    ? null
+    : SyncOperationIdSchema.parse(operation.liveOperationId);
+}
+
 function operationStartedAfter(
   operation: OperationObservation,
   startedAt: string | undefined,
@@ -1177,11 +1188,7 @@ async function finalizeAsyncSync(
       console.log(`async sync operation already finalized: ${appName}`);
       return;
     }
-    const liveOperationId = current.hasLiveOperation
-      ? current.liveOperationId === null
-        ? null
-        : SyncOperationIdSchema.parse(current.liveOperationId)
-      : undefined;
+    const liveOperationId = recoveryLiveOperationId(current);
     const isExpectedOperation =
       liveOperationId !== undefined &&
       operationMatches(current, exactRequestId, exactRevision, liveOperationId);

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -44,10 +44,14 @@ import {
   REPOSITORY_CHART_URLS,
 } from "../src/cdk8s/src/application-release-policy.ts";
 import {
+  activeOperationId,
   activeOperationRequestId,
   batchManifestOverrides,
+  completedOperationId,
   completedOperationRequestId,
+  requestedOperationId,
   requestedOperationRequestId,
+  SYNC_OPERATION_ID_INFO_NAME,
   SYNC_REQUEST_ID_INFO_NAME,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
@@ -66,6 +70,8 @@ const CHARTMUSEUM_RETRY_BASE_DELAY_MS = 100;
 
 const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
 const SyncRequestIdSchema = z.uuid();
+const SyncOperationIdSchema = z.uuid();
+const OperationStartedAtSchema = z.iso.datetime({ offset: true }).optional();
 const PollIntervalSchema = z.coerce.number().int().positive();
 
 const ExpectedApplicationsSchema = z.array(
@@ -496,6 +502,7 @@ async function sync(
   const requestId = SyncRequestIdSchema.parse(
     options.requestId ?? crypto.randomUUID(),
   );
+  let operationId: string = crypto.randomUUID();
   const retryable =
     options.requestId !== undefined || options.terminateAfterApplied === true;
   let baseline: OperationObservation | undefined;
@@ -511,10 +518,12 @@ async function sync(
           `Refusing to replace active ${appName} operation ${liveOperationDescription(baseline)}; expected request ${requestId}`,
         );
       }
+      operationId = requireLiveOperationId(baseline, appName);
       const completedOperationMatches = operationMatches(
         baseline,
         requestId,
         options.revision,
+        operationId,
       );
       if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
@@ -527,6 +536,8 @@ async function sync(
             token,
             requestId,
             options.revision,
+            operationId,
+            baseline.startedAt,
             timeoutSeconds,
           );
           console.log(`sync operation already finalized: ${appName}`);
@@ -551,7 +562,10 @@ async function sync(
       },
       body: JSON.stringify({
         prune: options.prune,
-        infos: [{ name: SYNC_REQUEST_ID_INFO_NAME, value: requestId }],
+        infos: [
+          { name: SYNC_REQUEST_ID_INFO_NAME, value: requestId },
+          { name: SYNC_OPERATION_ID_INFO_NAME, value: operationId },
+        ],
         ...(options.revision === undefined
           ? {}
           : { revision: options.revision }),
@@ -569,10 +583,17 @@ async function sync(
         `Sync failed: HTTP ${res.status.toString()} ${res.statusText}\n${body}`,
       );
     }
-    const responseRequestId = requestedOperationRequestId(await res.json());
+    const responseBody: unknown = await res.json();
+    const responseRequestId = requestedOperationRequestId(responseBody);
     if (responseRequestId !== requestId) {
       throw new Error(
         `Argo sync response returned request ${responseRequestId}; expected ${requestId}`,
+      );
+    }
+    const responseOperationId = requestedOperationId(responseBody);
+    if (responseOperationId !== operationId) {
+      throw new Error(
+        `Argo sync response returned operation ${responseOperationId}; expected ${operationId}`,
       );
     }
     console.log(`sync operation started: ${appName}`);
@@ -584,10 +605,9 @@ async function sync(
     appName,
     token,
     requestId,
+    operationId,
     revision: options.revision,
     timeoutSeconds,
-    baseline,
-    exactOperationSeen: false,
     terminateAfterApplied: options.terminateAfterApplied === true,
   });
 }
@@ -607,8 +627,10 @@ function operationRevision(
 
 type OperationObservation = {
   readonly hasLiveOperation: boolean;
+  readonly liveOperationId: string | null;
   readonly liveRequestId: string | null;
   readonly liveRevision: string | undefined;
+  readonly operationId: string | null;
   readonly phase: string;
   readonly requestId: string | null;
   readonly revision: string | undefined;
@@ -625,9 +647,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
     ? app["operation"]
     : undefined;
   const phase = state["phase"];
-  const startedAt = state["startedAt"];
   return {
     hasLiveOperation: liveOperation !== undefined,
+    liveOperationId:
+      liveOperation === undefined ? null : activeOperationId(app),
     liveRequestId:
       liveOperation === undefined ? null : activeOperationRequestId(app),
     liveRevision:
@@ -635,12 +658,13 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
         ? undefined
         : operationRevision(liveOperation),
     phase: typeof phase === "string" ? phase : "",
+    operationId: completedOperationId(app),
     requestId: completedOperationRequestId(app),
     revision:
       completedOperation === undefined
         ? undefined
         : operationRevision(completedOperation),
-    startedAt: typeof startedAt === "string" ? startedAt : undefined,
+    startedAt: OperationStartedAtSchema.parse(state["startedAt"]),
     state,
   };
 }
@@ -649,11 +673,13 @@ function liveOperationMatches(
   operation: OperationObservation,
   requestId: string,
   revision: string | undefined,
+  operationId?: string,
 ): boolean {
   return (
     operation.hasLiveOperation &&
     operation.liveRequestId === requestId &&
-    (revision === undefined || operation.liveRevision === revision)
+    (revision === undefined || operation.liveRevision === revision) &&
+    (operationId === undefined || operation.liveOperationId === operationId)
   );
 }
 
@@ -661,10 +687,12 @@ function operationMatches(
   operation: OperationObservation,
   requestId: string,
   revision: string | undefined,
+  operationId?: string,
 ): boolean {
   return (
     operation.requestId === requestId &&
-    (revision === undefined || operation.revision === revision)
+    (revision === undefined || operation.revision === revision) &&
+    (operationId === undefined || operation.operationId === operationId)
   );
 }
 
@@ -703,27 +731,33 @@ function assertMatchingLiveRevision(
 }
 
 function operationDescription(operation: OperationObservation): string {
-  return `${operation.requestId ?? "without a request ID"} at ${operation.revision ?? "unknown revision"}`;
+  return `${operation.requestId ?? "without a request ID"} at ${operation.revision ?? "unknown revision"} (${operation.operationId ?? "without an operation ID"})`;
 }
 
 function liveOperationDescription(operation: OperationObservation): string {
-  return `${operation.liveRequestId ?? "without a request ID"} at ${operation.liveRevision ?? "unknown revision"}`;
+  return `${operation.liveRequestId ?? "without a request ID"} at ${operation.liveRevision ?? "unknown revision"} (${operation.liveOperationId ?? "without an operation ID"})`;
 }
 
-function isActiveOperation(phase: string): boolean {
-  return phase === "Running" || phase === "Terminating";
+function requireLiveOperationId(
+  operation: OperationObservation,
+  appName: string,
+): string {
+  if (operation.liveOperationId === null) {
+    throw new Error(
+      `Refusing active ${appName} operation without a CI operation ID`,
+    );
+  }
+  return SyncOperationIdSchema.parse(operation.liveOperationId);
 }
 
-function operationChanged(
-  before: OperationObservation,
-  current: OperationObservation,
+function operationStartedAfter(
+  operation: OperationObservation,
+  startedAt: string | undefined,
 ): boolean {
   return (
-    before.requestId !== current.requestId ||
-    before.revision !== current.revision ||
-    before.startedAt !== current.startedAt ||
-    before.phase !== current.phase ||
-    JSON.stringify(before.state) !== JSON.stringify(current.state)
+    operation.startedAt !== undefined &&
+    startedAt !== undefined &&
+    Date.parse(operation.startedAt) > Date.parse(startedAt)
   );
 }
 
@@ -781,8 +815,7 @@ function syncResultApplied(
 
 type WaitForIdentifiedOperationOptions = {
   readonly appName: string;
-  readonly baseline: OperationObservation | undefined;
-  readonly exactOperationSeen: boolean;
+  readonly operationId: string;
   readonly requestId: string;
   readonly revision: string | undefined;
   readonly terminateAfterApplied: boolean;
@@ -792,8 +825,7 @@ type WaitForIdentifiedOperationOptions = {
 
 async function waitForIdentifiedOperation({
   appName,
-  baseline,
-  exactOperationSeen: initiallySeen,
+  operationId,
   requestId,
   revision,
   terminateAfterApplied,
@@ -801,27 +833,29 @@ async function waitForIdentifiedOperation({
   token,
 }: WaitForIdentifiedOperationOptions): Promise<void> {
   const deadline = Date.now() + timeoutSeconds * 1000;
-  let exactOperationSeen = initiallySeen;
+  let exactOperationSeen = false;
   while (Date.now() < deadline) {
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, requestId, revision, appName);
     assertMatchingLiveRevision(current, requestId, revision, appName);
-    const isExpected = operationMatches(current, requestId, revision);
+    const isExpected = operationMatches(
+      current,
+      requestId,
+      revision,
+      operationId,
+    );
     const isExpectedLiveOperation = liveOperationMatches(
       current,
       requestId,
       revision,
+      operationId,
     );
     if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
         `Active ${appName} operation changed to ${liveOperationDescription(current)} while waiting for request ${requestId}`,
       );
     }
-    if (
-      !exactOperationSeen &&
-      isExpected &&
-      (baseline === undefined || operationChanged(baseline, current))
-    ) {
+    if (!exactOperationSeen && isExpected) {
       exactOperationSeen = true;
     }
     const elapsed = Math.floor(
@@ -859,6 +893,8 @@ async function waitForIdentifiedOperation({
           token,
           requestId,
           revision,
+          operationId,
+          current.startedAt,
           timeoutSeconds,
         );
         return;
@@ -876,6 +912,8 @@ async function waitForOperationTermination(
   token: string,
   requestId: string,
   revision: string,
+  operationId: string,
+  startedAt: string | undefined,
   timeoutSeconds: number,
 ): Promise<void> {
   const deadline = Date.now() + timeoutSeconds * 1000;
@@ -883,30 +921,29 @@ async function waitForOperationTermination(
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, requestId, revision, appName);
     assertMatchingLiveRevision(current, requestId, revision, appName);
-    const isExpected = operationMatches(current, requestId, revision);
+    const isExpected = operationMatches(
+      current,
+      requestId,
+      revision,
+      operationId,
+    );
     const isExpectedLiveOperation = liveOperationMatches(
       current,
       requestId,
       revision,
+      operationId,
     );
     if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
         `${appName} operation changed to ${liveOperationDescription(current)} after terminating request ${requestId}`,
       );
     }
-    const hasOperationState =
-      current.phase !== "" ||
-      current.requestId !== null ||
-      current.revision !== undefined;
-    if (!isExpected && hasOperationState) {
-      throw new Error(
-        `${appName} operation changed to ${operationDescription(current)} after terminating request ${requestId}`,
-      );
-    }
-    if (
-      !current.hasLiveOperation &&
-      (!isExpected || !isActiveOperation(current.phase))
-    ) {
+    if (!current.hasLiveOperation) {
+      if (!isExpected && operationStartedAfter(current, startedAt)) {
+        throw new Error(
+          `${appName} operation changed to ${operationDescription(current)} after terminating request ${requestId}`,
+        );
+      }
       return;
     }
     await sleepUntilNextOperationPoll(deadline);
@@ -921,6 +958,8 @@ async function terminateAppliedOperation(
   token: string,
   requestId: string,
   revision: string,
+  operationId: string,
+  startedAt: string | undefined,
   timeoutSeconds: number,
 ): Promise<void> {
   const url = new URL(
@@ -946,6 +985,8 @@ async function terminateAppliedOperation(
     token,
     requestId,
     revision,
+    operationId,
+    startedAt,
     timeoutSeconds,
   );
 }
@@ -986,19 +1027,23 @@ async function finalizeAsyncSync(
     const current = observeOperation(await getApplication(appName, token));
     assertMatchingRevision(current, exactRequestId, exactRevision, appName);
     assertMatchingLiveRevision(current, exactRequestId, exactRevision, appName);
-    const isExpected = operationMatches(current, exactRequestId, exactRevision);
-    const isExpectedLiveOperation = liveOperationMatches(
+    const isExpectedLogicalOperation = operationMatches(
       current,
       exactRequestId,
       exactRevision,
     );
-    if (current.hasLiveOperation && !isExpectedLiveOperation) {
+    const isExpectedLogicalLiveOperation = liveOperationMatches(
+      current,
+      exactRequestId,
+      exactRevision,
+    );
+    if (current.hasLiveOperation && !isExpectedLogicalLiveOperation) {
       throw new Error(
         `Refusing to terminate active ${appName} operation ${liveOperationDescription(current)}; expected request ${exactRequestId} at ${exactRevision}`,
       );
     }
     if (
-      isExpected &&
+      isExpectedLogicalOperation &&
       !current.hasLiveOperation &&
       (current.phase === "Failed" || current.phase === "Error")
     ) {
@@ -1008,19 +1053,29 @@ async function finalizeAsyncSync(
       );
     }
     if (
-      isExpected &&
+      isExpectedLogicalOperation &&
       !current.hasLiveOperation &&
       current.phase === "Succeeded"
     ) {
       console.log(`async sync operation already finalized: ${appName}`);
       return;
     }
+    const liveOperationId = current.hasLiveOperation
+      ? requireLiveOperationId(current, appName)
+      : undefined;
+    const isExpectedOperation =
+      liveOperationId !== undefined &&
+      operationMatches(current, exactRequestId, exactRevision, liveOperationId);
     console.log(
-      `Operation: ${current.phase || "(pending)"}${isExpected ? "" : " [previous op]"}; ` +
-        `applied=${isExpected && syncResultApplied(current.state, exactRevision) ? "true" : "false"} ` +
+      `Operation: ${current.phase || "(pending)"}${isExpectedOperation ? "" : " [previous op]"}; ` +
+        `applied=${isExpectedOperation && syncResultApplied(current.state, exactRevision) ? "true" : "false"} ` +
         `(${elapsed.toString()}/${timeoutSeconds.toString()}s)`,
     );
-    if (isExpected && current.phase === "Terminating") {
+    if (
+      liveOperationId !== undefined &&
+      isExpectedOperation &&
+      current.phase === "Terminating"
+    ) {
       if (!syncResultApplied(current.state, exactRevision)) {
         throw new Error(
           `Matching ${appName} operation entered Terminating before its result was fully applied`,
@@ -1031,13 +1086,15 @@ async function finalizeAsyncSync(
         token,
         exactRequestId,
         exactRevision,
+        liveOperationId,
+        current.startedAt,
         timeoutSeconds,
       );
       return;
     }
     if (
-      isExpected &&
-      isExpectedLiveOperation &&
+      liveOperationId !== undefined &&
+      isExpectedOperation &&
       current.phase === "Running" &&
       syncResultApplied(current.state, exactRevision)
     ) {
@@ -1046,6 +1103,8 @@ async function finalizeAsyncSync(
         token,
         exactRequestId,
         exactRevision,
+        liveOperationId,
+        current.startedAt,
         timeoutSeconds,
       );
       return;

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -43,6 +43,18 @@ function operationResponse(request: unknown): unknown {
   };
 }
 
+function identifiedOperation(requestId: string, revision = REVISION): unknown {
+  return {
+    info: [
+      {
+        name: "ci.sjer.red/request-id",
+        value: requestId,
+      },
+    ],
+    sync: { revision },
+  };
+}
+
 function applicationOperation(options: {
   readonly live?: boolean;
   readonly message?: string;
@@ -53,15 +65,7 @@ function applicationOperation(options: {
   readonly startedAt?: string;
 }): unknown {
   const revision = options.revision ?? REVISION;
-  const operation = {
-    info: [
-      {
-        name: "ci.sjer.red/request-id",
-        value: options.requestId,
-      },
-    ],
-    sync: { revision },
-  };
+  const operation = identifiedOperation(options.requestId, revision);
   const live =
     options.live ??
     (options.phase === "Running" || options.phase === "Terminating");
@@ -264,6 +268,35 @@ test("atomic Argo sync adopts the exact active operation without another POST", 
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("adopted active sync operation: apps");
+    expect(lifecycle.observations.syncPosts).toBe(0);
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync waits past matching stale status when adopting a retry", async () => {
+  const stale = applicationOperation({
+    live: true,
+    phase: "Succeeded",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced" }],
+    startedAt: "2026-08-10T01:00:00Z",
+  });
+  const current = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced", hookPhase: "Running" }],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const lifecycle = serveLifecycle([stale, current]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("adopted active sync operation: apps");
+    expect(result.stdout).not.toContain("synced: apps");
     expect(lifecycle.observations.syncPosts).toBe(0);
     expect(lifecycle.observations.deleteRequests).toBe(1);
   } finally {
@@ -519,6 +552,57 @@ test("Argo recovery refuses a different active request", async () => {
     expect(result.stderr).toContain(
       "Refusing to terminate active apps operation",
     );
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery refuses an unrelated live operation behind matching stale status", async () => {
+  const lifecycle = serveLifecycle([
+    {
+      operation: identifiedOperation(OTHER_REQUEST_ID),
+      status: {
+        operationState: {
+          operation: identifiedOperation(CURRENT_REQUEST_ID),
+          phase: "Running",
+          syncResult: {
+            resources: [{ status: "Synced" }],
+            revision: REVISION,
+          },
+        },
+      },
+    },
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      `expected request ${CURRENT_REQUEST_ID} at ${REVISION}`,
+    );
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery never terminates matching status without a live operation", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      live: false,
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("was not fully applied within 1s");
     expect(lifecycle.observations.deleteRequests).toBe(0);
   } finally {
     await lifecycle.server.stop(true);

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -20,7 +20,10 @@ const RootSyncRequestSchema = z.object({
 });
 
 type OperationResource = {
+  readonly group?: string;
   readonly hookPhase?: string;
+  readonly kind?: string;
+  readonly name?: string;
   readonly status: string;
 };
 
@@ -98,7 +101,14 @@ function applicationOperation(options: {
         operation: completedOperation,
         syncResult: {
           revision,
-          resources: options.resources ?? [],
+          resources: (options.resources ?? []).map((resource, index) => ({
+            group: resource.group ?? "argoproj.io",
+            kind: resource.kind ?? "Application",
+            name:
+              resource.name ??
+              (index === 0 ? "worker" : `resource-${index.toString()}`),
+            ...resource,
+          })),
         },
         ...(options.startedAt === undefined
           ? {}
@@ -108,6 +118,16 @@ function applicationOperation(options: {
     },
   };
 }
+
+function renderedApplication(name: string): string {
+  return JSON.stringify({
+    apiVersion: "argoproj.io/v1alpha1",
+    kind: "Application",
+    metadata: { name, namespace: "argocd" },
+  });
+}
+
+const DEFAULT_RENDERED_MANIFESTS = [renderedApplication("worker")];
 
 function fixtureAt(fixtures: readonly unknown[], index: number): unknown {
   const fixture = fixtures[Math.min(index, fixtures.length - 1)];
@@ -151,6 +171,7 @@ function requestOperationId(request: unknown): string {
 function serveLifecycle(
   beforeDelete: readonly unknown[],
   afterDelete: readonly unknown[] = [{ status: {} }],
+  renderedManifests: readonly string[] = DEFAULT_RENDERED_MANIFESTS,
 ) {
   const observations: LifecycleObservations = {
     deleteRequests: 0,
@@ -165,6 +186,12 @@ function serveLifecycle(
     port: 0,
     async fetch(request) {
       const url = new URL(request.url);
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        return Response.json({ manifests: renderedManifests });
+      }
       if (
         request.method === "POST" &&
         url.pathname === "/api/v1/applications/apps/sync"
@@ -261,13 +288,18 @@ function recoveryArgs(): readonly string[] {
 }
 
 test("atomic Argo sync ignores stale status, applies the live result, and waits for termination", async () => {
+  const desiredNames = Array.from(
+    { length: 255 },
+    (_, index) => `application-${index.toString()}`,
+  );
   const resources: OperationResource[] = [
-    ...Array.from({ length: 255 }, (_, index) => ({
+    ...desiredNames.map((name, index) => ({
+      name,
       status: "Synced",
       ...(index < 5 ? { hookPhase: "Running" } : {}),
     })),
-    { status: "Pruned" },
-    { status: "Pruned" },
+    { name: "removed-one", status: "Pruned" },
+    { name: "removed-two", status: "Pruned" },
   ];
   const stale = applicationOperation({
     operationId: OTHER_OPERATION_ID,
@@ -291,6 +323,7 @@ test("atomic Argo sync ignores stale status, applies the live result, and waits 
   const lifecycle = serveLifecycle(
     [stale, { status: {} }, stale, current],
     [terminating, { status: {} }],
+    desiredNames.map((name) => renderedApplication(name)),
   );
 
   try {
@@ -302,6 +335,40 @@ test("atomic Argo sync ignores stale status, applies the live result, and waits 
     expect(lifecycle.observations.syncPosts).toBe(1);
     expect(lifecycle.observations.deleteRequests).toBe(1);
     expect(lifecycle.observations.postDeleteGets).toBe(2);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync waits for every rendered resource across sync waves", async () => {
+  const firstWave = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ name: "wave-zero", status: "Synced" }],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const allWaves = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [
+      { name: "wave-zero", status: "Synced" },
+      { name: "wave-three", status: "Synced" },
+    ],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const lifecycle = serveLifecycle(
+    [{ status: {} }, firstWave, allWaves],
+    [{ status: {} }],
+    [renderedApplication("wave-zero"), renderedApplication("wave-three")],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+    expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(3);
   } finally {
     await lifecycle.server.stop(true);
   }

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -44,6 +44,7 @@ function operationResponse(request: unknown): unknown {
 }
 
 function applicationOperation(options: {
+  readonly live?: boolean;
   readonly message?: string;
   readonly phase: string;
   readonly requestId: string;
@@ -52,19 +53,24 @@ function applicationOperation(options: {
   readonly startedAt?: string;
 }): unknown {
   const revision = options.revision ?? REVISION;
+  const operation = {
+    info: [
+      {
+        name: "ci.sjer.red/request-id",
+        value: options.requestId,
+      },
+    ],
+    sync: { revision },
+  };
+  const live =
+    options.live ??
+    (options.phase === "Running" || options.phase === "Terminating");
   return {
+    ...(live ? { operation } : {}),
     status: {
       operationState: {
         phase: options.phase,
-        operation: {
-          info: [
-            {
-              name: "ci.sjer.red/request-id",
-              value: options.requestId,
-            },
-          ],
-          sync: { revision },
-        },
+        operation,
         syncResult: {
           revision,
           resources: options.resources ?? [],
@@ -259,6 +265,35 @@ test("atomic Argo sync adopts the exact active operation without another POST", 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("adopted active sync operation: apps");
     expect(lifecycle.observations.syncPosts).toBe(0);
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync posts past a stale status-only Running operation", async () => {
+  const stale = applicationOperation({
+    live: false,
+    phase: "Running",
+    requestId: OTHER_REQUEST_ID,
+    resources: [{ status: "Synced" }],
+    startedAt: "2026-08-10T01:00:00Z",
+  });
+  const current = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced", hookPhase: "Running" }],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const lifecycle = serveLifecycle([stale, stale, current]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("sync operation started: apps");
+    expect(lifecycle.observations.syncPosts).toBe(1);
     expect(lifecycle.observations.deleteRequests).toBe(1);
   } finally {
     await lifecycle.server.stop(true);

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -51,7 +51,7 @@ function operationResponse(request: unknown): unknown {
 function identifiedOperation(
   requestId: string,
   revision = REVISION,
-  operationId = CURRENT_OPERATION_ID,
+  operationId: string | null = CURRENT_OPERATION_ID,
 ): unknown {
   return {
     info: [
@@ -59,10 +59,14 @@ function identifiedOperation(
         name: "ci.sjer.red/request-id",
         value: requestId,
       },
-      {
-        name: "ci.sjer.red/operation-id",
-        value: operationId,
-      },
+      ...(operationId === null
+        ? []
+        : [
+            {
+              name: "ci.sjer.red/operation-id",
+              value: operationId,
+            },
+          ]),
     ],
     sync: { revision },
   };
@@ -70,25 +74,38 @@ function identifiedOperation(
 
 function applicationOperation(options: {
   readonly live?: boolean;
-  readonly liveOperationId?: string;
+  readonly liveOperationId?: string | null;
   readonly message?: string;
-  readonly operationId?: string;
+  readonly operationId?: string | null;
   readonly phase: string;
   readonly requestId: string;
   readonly resources?: readonly OperationResource[];
   readonly revision?: string;
   readonly startedAt?: string;
+  readonly trackedResources?: readonly {
+    readonly group?: string;
+    readonly kind: string;
+    readonly name: string;
+  }[];
 }): unknown {
   const revision = options.revision ?? REVISION;
+  const operationId =
+    options.operationId === undefined
+      ? CURRENT_OPERATION_ID
+      : options.operationId;
+  const liveOperationId =
+    options.liveOperationId === undefined
+      ? operationId
+      : options.liveOperationId;
   const completedOperation = identifiedOperation(
     options.requestId,
     revision,
-    options.operationId,
+    operationId,
   );
   const liveOperation = identifiedOperation(
     options.requestId,
     revision,
-    options.liveOperationId ?? options.operationId,
+    liveOperationId,
   );
   const live =
     options.live ??
@@ -96,6 +113,9 @@ function applicationOperation(options: {
   return {
     ...(live ? { operation: liveOperation } : {}),
     status: {
+      ...(options.trackedResources === undefined
+        ? {}
+        : { resources: options.trackedResources }),
       operationState: {
         phase: options.phase,
         operation: completedOperation,
@@ -124,6 +144,12 @@ function renderedApplication(name: string): string {
     apiVersion: "argoproj.io/v1alpha1",
     kind: "Application",
     metadata: { name, namespace: "argocd" },
+    spec: {
+      source: {
+        repoURL: "https://charts.example.test",
+        targetRevision: REVISION,
+      },
+    },
   });
 }
 
@@ -172,6 +198,7 @@ function serveLifecycle(
   beforeDelete: readonly unknown[],
   afterDelete: readonly unknown[] = [{ status: {} }],
   renderedManifests: readonly string[] = DEFAULT_RENDERED_MANIFESTS,
+  prunableChildren: readonly string[] = [],
 ) {
   const observations: LifecycleObservations = {
     deleteRequests: 0,
@@ -224,6 +251,24 @@ function serveLifecycle(
         observations.statusGets += 1;
         return Response.json(withPostedOperationId(fixture, postedOperationId));
       }
+      const childName = decodeURIComponent(
+        url.pathname.slice("/api/v1/applications/".length),
+      );
+      if (
+        request.method === "GET" &&
+        url.pathname.startsWith("/api/v1/applications/") &&
+        prunableChildren.includes(childName)
+      ) {
+        return Response.json({
+          metadata: {
+            annotations: {
+              "ci.sjer.red/application-lifecycle": "cascade",
+            },
+            finalizers: ["resources-finalizer.argocd.argoproj.io"],
+            name: childName,
+          },
+        });
+      }
       return new Response("not found", { status: 404 });
     },
   });
@@ -266,6 +311,7 @@ function atomicArgs(): readonly string[] {
     "apps",
     "--revision",
     REVISION,
+    "--prune",
     "--terminate-after-applied",
     "--request-id",
     CURRENT_REQUEST_ID,
@@ -307,6 +353,10 @@ test("atomic Argo sync ignores stale status, applies the live result, and waits 
     requestId: CURRENT_REQUEST_ID,
     resources: [{ status: "Synced" }],
     startedAt: "2026-08-10T01:00:00Z",
+    trackedResources: [
+      { group: "argoproj.io", kind: "Application", name: "removed-one" },
+      { group: "argoproj.io", kind: "Application", name: "removed-two" },
+    ],
   });
   const current = applicationOperation({
     phase: "Running",
@@ -324,6 +374,7 @@ test("atomic Argo sync ignores stale status, applies the live result, and waits 
     [stale, { status: {} }, stale, current],
     [terminating, { status: {} }],
     desiredNames.map((name) => renderedApplication(name)),
+    ["removed-one", "removed-two"],
   );
 
   try {
@@ -369,6 +420,52 @@ test("atomic Argo sync waits for every rendered resource across sync waves", asy
     expect(result.stderr).toBe("");
     expect(lifecycle.observations.deleteRequests).toBe(1);
     expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(3);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync waits for every validated prune candidate", async () => {
+  const inventory = {
+    status: {
+      resources: [
+        {
+          group: "argoproj.io",
+          kind: "Application",
+          name: "removed-worker",
+        },
+      ],
+    },
+  };
+  const desiredApplied = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ name: "worker", status: "Synced" }],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const pruneApplied = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [
+      { name: "worker", status: "Synced" },
+      { name: "removed-worker", status: "Pruned" },
+    ],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const lifecycle = serveLifecycle(
+    [inventory, { status: {} }, desiredApplied, pruneApplied],
+    [{ status: {} }],
+    DEFAULT_RENDERED_MANIFESTS,
+    ["removed-worker"],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+    expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(4);
   } finally {
     await lifecycle.server.stop(true);
   }
@@ -453,6 +550,30 @@ test("atomic Argo sync finalizes a stable applied operation when adopting a retr
   }
 });
 
+test("atomic Argo sync refuses to adopt a pre-operation-ID sync", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      liveOperationId: null,
+      operationId: null,
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "Refusing active apps operation without a CI operation ID",
+    );
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
 test("atomic Argo sync posts past a stale status-only Running operation", async () => {
   const stale = applicationOperation({
     live: false,
@@ -483,14 +604,12 @@ test("atomic Argo sync posts past a stale status-only Running operation", async 
 });
 
 test("atomic Argo sync finishes an adopted applied termination", async () => {
-  const lifecycle = serveLifecycle([
-    applicationOperation({
-      phase: "Terminating",
-      requestId: CURRENT_REQUEST_ID,
-      resources: [{ status: "Synced", hookPhase: "Running" }],
-    }),
-    { status: {} },
-  ]);
+  const terminating = applicationOperation({
+    phase: "Terminating",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced", hookPhase: "Running" }],
+  });
+  const lifecycle = serveLifecycle([terminating, terminating, { status: {} }]);
 
   try {
     const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
@@ -746,6 +865,29 @@ test("Argo recovery waits for the exact operation before finalizing it", async (
     expect(result.stderr).toBe("");
     expect(lifecycle.observations.deleteRequests).toBe(1);
     expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(2);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery finalizes an exact pre-operation-ID sync", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      liveOperationId: null,
+      operationId: null,
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Running" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("terminated applied sync operation: apps");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
   } finally {
     await lifecycle.server.stop(true);
   }

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -1,0 +1,567 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+import { z } from "zod";
+
+const CURRENT_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_REQUEST_ID = "22222222-2222-4222-8222-222222222222";
+const REVISION = "2.0.0-42";
+
+const RootSyncRequestSchema = z.object({
+  infos: z.array(
+    z.object({
+      name: z.string(),
+      value: z.uuid(),
+    }),
+  ),
+  prune: z.boolean(),
+  revision: z.string(),
+});
+
+type OperationResource = {
+  readonly hookPhase?: string;
+  readonly status: string;
+};
+
+type LifecycleObservations = {
+  deleteRequests: number;
+  postDeleteGets: number;
+  statusGets: number;
+  syncPosts: number;
+};
+
+function operationResponse(request: unknown): unknown {
+  const syncRequest = RootSyncRequestSchema.parse(request);
+  return {
+    operation: {
+      info: syncRequest.infos,
+      initiatedBy: { username: "buildkite" },
+      sync: {
+        prune: syncRequest.prune,
+        revision: syncRequest.revision,
+      },
+    },
+  };
+}
+
+function applicationOperation(options: {
+  readonly message?: string;
+  readonly phase: string;
+  readonly requestId: string;
+  readonly resources?: readonly OperationResource[];
+  readonly revision?: string;
+  readonly startedAt?: string;
+}): unknown {
+  const revision = options.revision ?? REVISION;
+  return {
+    status: {
+      operationState: {
+        phase: options.phase,
+        operation: {
+          info: [
+            {
+              name: "ci.sjer.red/request-id",
+              value: options.requestId,
+            },
+          ],
+          sync: { revision },
+        },
+        syncResult: {
+          revision,
+          resources: options.resources ?? [],
+        },
+        ...(options.startedAt === undefined
+          ? {}
+          : { startedAt: options.startedAt }),
+        ...(options.message === undefined ? {} : { message: options.message }),
+      },
+    },
+  };
+}
+
+function fixtureAt(fixtures: readonly unknown[], index: number): unknown {
+  const fixture = fixtures[Math.min(index, fixtures.length - 1)];
+  if (fixture === undefined) {
+    throw new Error("Lifecycle fixture list must not be empty");
+  }
+  return fixture;
+}
+
+function serveLifecycle(
+  beforeDelete: readonly unknown[],
+  afterDelete: readonly unknown[] = [{ status: {} }],
+) {
+  const observations: LifecycleObservations = {
+    deleteRequests: 0,
+    postDeleteGets: 0,
+    statusGets: 0,
+    syncPosts: 0,
+  };
+  let terminated = false;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/apps/sync"
+      ) {
+        observations.syncPosts += 1;
+        return Response.json(operationResponse(await request.json()));
+      }
+      if (
+        request.method === "DELETE" &&
+        url.pathname === "/api/v1/applications/apps/operation"
+      ) {
+        observations.deleteRequests += 1;
+        terminated = true;
+        return new Response(null, { status: 204 });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps"
+      ) {
+        if (terminated) {
+          const fixture = fixtureAt(afterDelete, observations.postDeleteGets);
+          observations.postDeleteGets += 1;
+          return Response.json(fixture);
+        }
+        const fixture = fixtureAt(beforeDelete, observations.statusGets);
+        observations.statusGets += 1;
+        return Response.json(fixture);
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { observations, server };
+}
+
+async function runArgocd(
+  args: readonly string[],
+  serverOrigin = "http://127.0.0.1:1",
+): Promise<{
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const process = Bun.spawn(
+    ["bun", "--no-install", "scripts/argocd.ts", ...args],
+    {
+      cwd: path.resolve(import.meta.dir, "../../.."),
+      env: {
+        ...Bun.env,
+        ARGOCD_POLL_INTERVAL_MS: "5",
+        ARGOCD_SERVER_URL: serverOrigin,
+        ARGOCD_TOKEN: "test-token",
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  return { exitCode, stderr, stdout };
+}
+
+function atomicArgs(): readonly string[] {
+  return [
+    "sync",
+    "apps",
+    "--revision",
+    REVISION,
+    "--terminate-after-applied",
+    "--request-id",
+    CURRENT_REQUEST_ID,
+    "--timeout",
+    "1",
+  ];
+}
+
+function recoveryArgs(): readonly string[] {
+  return [
+    "finalize-async-sync",
+    "apps",
+    "--revision",
+    REVISION,
+    "--request-id",
+    CURRENT_REQUEST_ID,
+    "--timeout",
+    "1",
+  ];
+}
+
+test("atomic Argo sync ignores stale status, applies the live result, and waits for termination", async () => {
+  const resources: OperationResource[] = [
+    ...Array.from({ length: 255 }, (_, index) => ({
+      status: "Synced",
+      ...(index < 5 ? { hookPhase: "Running" } : {}),
+    })),
+    { status: "Pruned" },
+    { status: "Pruned" },
+  ];
+  const stale = applicationOperation({
+    phase: "Succeeded",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced" }],
+    startedAt: "2026-08-10T01:00:00Z",
+  });
+  const current = applicationOperation({
+    phase: "Running",
+    requestId: CURRENT_REQUEST_ID,
+    resources,
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const terminating = applicationOperation({
+    phase: "Terminating",
+    requestId: CURRENT_REQUEST_ID,
+    resources,
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const lifecycle = serveLifecycle(
+    [stale, { status: {} }, stale, current],
+    [terminating, { status: {} }],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("terminated applied sync operation: apps");
+    expect(lifecycle.observations.syncPosts).toBe(1);
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+    expect(lifecycle.observations.postDeleteGets).toBe(2);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync adopts the exact active operation without another POST", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "OutOfSync" }],
+    }),
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Running" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("adopted active sync operation: apps");
+    expect(lifecycle.observations.syncPosts).toBe(0);
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync finishes an adopted applied termination", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      phase: "Terminating",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Running" }],
+    }),
+    { status: {} },
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("sync operation already finalized: apps");
+    expect(lifecycle.observations.syncPosts).toBe(0);
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync accepts natural success without DELETE", async () => {
+  const lifecycle = serveLifecycle([
+    { status: {} },
+    applicationOperation({
+      phase: "Succeeded",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+      startedAt: "2026-08-10T01:00:01Z",
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("synced: apps");
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+for (const scenario of [
+  {
+    name: "another request ID at the same revision",
+    requestId: OTHER_REQUEST_ID,
+    revision: REVISION,
+    error: "Refusing to replace active apps operation",
+  },
+  {
+    name: "the same request ID at another revision",
+    requestId: CURRENT_REQUEST_ID,
+    revision: "2.0.0-41",
+    error: `expected ${REVISION}`,
+  },
+]) {
+  test(`atomic Argo sync refuses ${scenario.name}`, async () => {
+    const lifecycle = serveLifecycle([
+      applicationOperation({
+        phase: "Running",
+        requestId: scenario.requestId,
+        resources: [{ status: "Synced" }],
+        revision: scenario.revision,
+      }),
+    ]);
+
+    try {
+      const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain(scenario.error);
+      expect(lifecycle.observations.syncPosts).toBe(0);
+      expect(lifecycle.observations.deleteRequests).toBe(0);
+    } finally {
+      await lifecycle.server.stop(true);
+    }
+  });
+}
+
+for (const phase of ["Failed", "Error"]) {
+  test(`atomic Argo sync fails when the exact operation reaches ${phase}`, async () => {
+    const lifecycle = serveLifecycle([
+      { status: {} },
+      applicationOperation({
+        message: "operation failed",
+        phase,
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:01Z",
+      }),
+    ]);
+
+    try {
+      const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain(`Sync operation ${phase} for apps`);
+      expect(lifecycle.observations.deleteRequests).toBe(0);
+    } finally {
+      await lifecycle.server.stop(true);
+    }
+  });
+}
+
+test("atomic Argo sync times out when its operation never becomes visible", async () => {
+  const lifecycle = serveLifecycle([{ status: {} }]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("did not complete within 1s");
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync fails if another operation starts after DELETE", async () => {
+  const lifecycle = serveLifecycle(
+    [
+      { status: {} },
+      applicationOperation({
+        phase: "Running",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:01Z",
+      }),
+    ],
+    [
+      applicationOperation({
+        phase: "Running",
+        requestId: OTHER_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:02Z",
+      }),
+    ],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("after terminating request");
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync fails if a completed unrelated operation replaces it after DELETE", async () => {
+  const lifecycle = serveLifecycle(
+    [
+      { status: {} },
+      applicationOperation({
+        phase: "Running",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:01Z",
+      }),
+    ],
+    [
+      applicationOperation({
+        phase: "Succeeded",
+        requestId: OTHER_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:02Z",
+      }),
+    ],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("after terminating request");
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery waits for the exact operation before finalizing it", async () => {
+  const lifecycle = serveLifecycle([
+    { status: {} },
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Running" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+    expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(2);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery refuses a different active request", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      phase: "Running",
+      requestId: OTHER_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "Refusing to terminate active apps operation",
+    );
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery refuses the same request at another revision", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+      revision: "2.0.0-41",
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(`expected ${REVISION}`);
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery times out instead of accepting a missing operation", async () => {
+  const lifecycle = serveLifecycle([{ status: {} }]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("was not fully applied within 1s");
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo CLI rejects incompatible sync completion modes", async () => {
+  const result = await runArgocd([
+    ...atomicArgs().slice(0, -2),
+    "--async",
+    "--dry-run",
+  ]);
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain(
+    "--async and --terminate-after-applied cannot be combined",
+  );
+});
+
+test("Argo CLI requires a revision for deterministic request IDs", async () => {
+  const result = await runArgocd([
+    "sync",
+    "apps",
+    "--request-id",
+    CURRENT_REQUEST_ID,
+    "--dry-run",
+  ]);
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain("--request-id requires an exact --revision");
+});
+
+test("Argo CLI rejects malformed request IDs", async () => {
+  const result = await runArgocd([
+    "sync",
+    "apps",
+    "--revision",
+    REVISION,
+    "--terminate-after-applied",
+    "--request-id",
+    "not-a-uuid",
+    "--dry-run",
+  ]);
+
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain("Invalid UUID");
+});

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 const CURRENT_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 const OTHER_REQUEST_ID = "22222222-2222-4222-8222-222222222222";
+const CURRENT_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
+const OTHER_OPERATION_ID = "44444444-4444-4444-8444-444444444444";
 const REVISION = "2.0.0-42";
 
 const RootSyncRequestSchema = z.object({
@@ -43,12 +45,20 @@ function operationResponse(request: unknown): unknown {
   };
 }
 
-function identifiedOperation(requestId: string, revision = REVISION): unknown {
+function identifiedOperation(
+  requestId: string,
+  revision = REVISION,
+  operationId = CURRENT_OPERATION_ID,
+): unknown {
   return {
     info: [
       {
         name: "ci.sjer.red/request-id",
         value: requestId,
+      },
+      {
+        name: "ci.sjer.red/operation-id",
+        value: operationId,
       },
     ],
     sync: { revision },
@@ -57,7 +67,9 @@ function identifiedOperation(requestId: string, revision = REVISION): unknown {
 
 function applicationOperation(options: {
   readonly live?: boolean;
+  readonly liveOperationId?: string;
   readonly message?: string;
+  readonly operationId?: string;
   readonly phase: string;
   readonly requestId: string;
   readonly resources?: readonly OperationResource[];
@@ -65,16 +77,25 @@ function applicationOperation(options: {
   readonly startedAt?: string;
 }): unknown {
   const revision = options.revision ?? REVISION;
-  const operation = identifiedOperation(options.requestId, revision);
+  const completedOperation = identifiedOperation(
+    options.requestId,
+    revision,
+    options.operationId,
+  );
+  const liveOperation = identifiedOperation(
+    options.requestId,
+    revision,
+    options.liveOperationId ?? options.operationId,
+  );
   const live =
     options.live ??
     (options.phase === "Running" || options.phase === "Terminating");
   return {
-    ...(live ? { operation } : {}),
+    ...(live ? { operation: liveOperation } : {}),
     status: {
       operationState: {
         phase: options.phase,
-        operation,
+        operation: completedOperation,
         syncResult: {
           revision,
           resources: options.resources ?? [],
@@ -96,6 +117,37 @@ function fixtureAt(fixtures: readonly unknown[], index: number): unknown {
   return fixture;
 }
 
+function withPostedOperationId(
+  fixture: unknown,
+  postedOperationId: string | undefined,
+): unknown {
+  if (postedOperationId === undefined) {
+    return fixture;
+  }
+  const serialized = JSON.stringify(fixture);
+  if (serialized === undefined) {
+    throw new Error("Lifecycle fixture must be JSON serializable");
+  }
+  return JSON.parse(
+    serialized.replaceAll(CURRENT_OPERATION_ID, postedOperationId),
+  );
+}
+
+function requestOperationId(request: unknown): string {
+  const syncRequest = RootSyncRequestSchema.parse(request);
+  const matches = syncRequest.infos.filter(
+    ({ name }) => name === "ci.sjer.red/operation-id",
+  );
+  if (matches.length !== 1) {
+    throw new Error("Sync request must contain one operation ID");
+  }
+  const operationId = matches[0]?.value;
+  if (operationId === undefined) {
+    throw new Error("Sync request operation ID is missing");
+  }
+  return operationId;
+}
+
 function serveLifecycle(
   beforeDelete: readonly unknown[],
   afterDelete: readonly unknown[] = [{ status: {} }],
@@ -106,6 +158,7 @@ function serveLifecycle(
     statusGets: 0,
     syncPosts: 0,
   };
+  let postedOperationId: string | undefined;
   let terminated = false;
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -117,7 +170,9 @@ function serveLifecycle(
         url.pathname === "/api/v1/applications/apps/sync"
       ) {
         observations.syncPosts += 1;
-        return Response.json(operationResponse(await request.json()));
+        const body: unknown = await request.json();
+        postedOperationId = requestOperationId(body);
+        return Response.json(operationResponse(body));
       }
       if (
         request.method === "DELETE" &&
@@ -134,11 +189,13 @@ function serveLifecycle(
         if (terminated) {
           const fixture = fixtureAt(afterDelete, observations.postDeleteGets);
           observations.postDeleteGets += 1;
-          return Response.json(fixture);
+          return Response.json(
+            withPostedOperationId(fixture, postedOperationId),
+          );
         }
         const fixture = fixtureAt(beforeDelete, observations.statusGets);
         observations.statusGets += 1;
-        return Response.json(fixture);
+        return Response.json(withPostedOperationId(fixture, postedOperationId));
       }
       return new Response("not found", { status: 404 });
     },
@@ -213,6 +270,7 @@ test("atomic Argo sync ignores stale status, applies the live result, and waits 
     { status: "Pruned" },
   ];
   const stale = applicationOperation({
+    operationId: OTHER_OPERATION_ID,
     phase: "Succeeded",
     requestId: CURRENT_REQUEST_ID,
     resources: [{ status: "Synced" }],
@@ -278,6 +336,8 @@ test("atomic Argo sync adopts the exact active operation without another POST", 
 test("atomic Argo sync waits past matching stale status when adopting a retry", async () => {
   const stale = applicationOperation({
     live: true,
+    liveOperationId: CURRENT_OPERATION_ID,
+    operationId: OTHER_OPERATION_ID,
     phase: "Succeeded",
     requestId: CURRENT_REQUEST_ID,
     resources: [{ status: "Synced" }],
@@ -297,6 +357,28 @@ test("atomic Argo sync waits past matching stale status when adopting a retry", 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("adopted active sync operation: apps");
     expect(result.stdout).not.toContain("synced: apps");
+    expect(lifecycle.observations.syncPosts).toBe(0);
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync finalizes a stable applied operation when adopting a retry", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Running" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("adopted active sync operation: apps");
+    expect(result.stdout).toContain("terminated applied sync operation: apps");
     expect(lifecycle.observations.syncPosts).toBe(0);
     expect(lifecycle.observations.deleteRequests).toBe(1);
   } finally {
@@ -452,6 +534,39 @@ test("atomic Argo sync times out when its operation never becomes visible", asyn
   }
 });
 
+test("atomic Argo sync accepts termination when live state clears before status", async () => {
+  const lifecycle = serveLifecycle(
+    [
+      { status: {} },
+      applicationOperation({
+        phase: "Running",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:01Z",
+      }),
+    ],
+    [
+      applicationOperation({
+        live: false,
+        phase: "Running",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+      }),
+    ],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+    expect(lifecycle.observations.postDeleteGets).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
 test("atomic Argo sync fails if another operation starts after DELETE", async () => {
   const lifecycle = serveLifecycle(
     [
@@ -498,6 +613,39 @@ test("atomic Argo sync fails if a completed unrelated operation replaces it afte
       applicationOperation({
         phase: "Succeeded",
         requestId: OTHER_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:02Z",
+      }),
+    ],
+  );
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("after terminating request");
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync fails if another attempt with the same request replaces it after DELETE", async () => {
+  const lifecycle = serveLifecycle(
+    [
+      { status: {} },
+      applicationOperation({
+        phase: "Running",
+        requestId: CURRENT_REQUEST_ID,
+        resources: [{ status: "Synced" }],
+        startedAt: "2026-08-10T01:00:01Z",
+      }),
+    ],
+    [
+      applicationOperation({
+        live: false,
+        operationId: OTHER_OPERATION_ID,
+        phase: "Succeeded",
+        requestId: CURRENT_REQUEST_ID,
         resources: [{ status: "Synced" }],
         startedAt: "2026-08-10T01:00:02Z",
       }),
@@ -583,6 +731,35 @@ test("Argo recovery refuses an unrelated live operation behind matching stale st
       `expected request ${CURRENT_REQUEST_ID} at ${REVISION}`,
     );
     expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("Argo recovery waits past a stale attempt with the same request", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      live: true,
+      liveOperationId: CURRENT_OPERATION_ID,
+      operationId: OTHER_OPERATION_ID,
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+    }),
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(recoveryArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+    expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(2);
   } finally {
     await lifecycle.server.stop(true);
   }

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -645,6 +645,41 @@ test("atomic Argo sync accepts natural success without DELETE", async () => {
   }
 });
 
+test("atomic Argo sync waits for naturally succeeded live state to clear", async () => {
+  const succeededLive = applicationOperation({
+    live: true,
+    phase: "Succeeded",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced" }],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const succeededCleared = applicationOperation({
+    live: false,
+    phase: "Succeeded",
+    requestId: CURRENT_REQUEST_ID,
+    resources: [{ status: "Synced" }],
+    startedAt: "2026-08-10T01:00:01Z",
+  });
+  const lifecycle = serveLifecycle([
+    succeededLive,
+    succeededLive,
+    succeededLive,
+    succeededCleared,
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("synced: apps");
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+    expect(lifecycle.observations.statusGets).toBeGreaterThanOrEqual(4);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
 for (const scenario of [
   {
     name: "another request ID at the same revision",
@@ -778,7 +813,7 @@ test("atomic Argo sync fails if another operation starts after DELETE", async ()
     const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain("after terminating request");
+    expect(result.stderr).toContain("while waiting for request");
   } finally {
     await lifecycle.server.stop(true);
   }
@@ -809,7 +844,7 @@ test("atomic Argo sync fails if a completed unrelated operation replaces it afte
     const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain("after terminating request");
+    expect(result.stderr).toContain("while waiting for request");
   } finally {
     await lifecycle.server.stop(true);
   }
@@ -842,7 +877,7 @@ test("atomic Argo sync fails if another attempt with the same request replaces i
     const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain("after terminating request");
+    expect(result.stderr).toContain("while waiting for request");
   } finally {
     await lifecycle.server.stop(true);
   }

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -80,8 +80,10 @@ function operationForSyncRequest(request: unknown): unknown {
 
 function expectSuspendedWorkerRequest(request: unknown): void {
   const syncRequest = SyncRequestSchema.parse(request);
-  expect(syncRequest.infos).toHaveLength(1);
-  expect(syncRequest.infos[0]?.name).toBe("ci.sjer.red/request-id");
+  expect(syncRequest.infos.map(({ name }) => name)).toEqual([
+    "ci.sjer.red/request-id",
+    "ci.sjer.red/operation-id",
+  ]);
   expect(syncRequest.manifests).toHaveLength(1);
   expect(JSON.parse(syncRequest.manifests[0] ?? "")).toMatchObject({
     spec: {

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -247,7 +247,15 @@ describe("Argo CD root prune safety", () => {
           url.pathname === "/api/v1/applications/apps/manifests" &&
           url.searchParams.get("revision") === "2.0.0-42"
         ) {
-          return Response.json({ manifests: [] });
+          return Response.json({
+            manifests: [
+              JSON.stringify({
+                apiVersion: "v1",
+                kind: "Namespace",
+                metadata: { name: "argocd" },
+              }),
+            ],
+          });
         }
         if (url.pathname === "/api/v1/applications/apps") {
           return Response.json({

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -29,6 +29,37 @@ const SyncRequestSchema = z.object({
   ),
 });
 
+const RootSyncRequestSchema = z.object({
+  infos: z.array(
+    z.object({
+      name: z.string(),
+      value: z.uuid(),
+    }),
+  ),
+  prune: z.boolean(),
+  revision: z.string().optional(),
+});
+
+function operationForRootSyncRequest(
+  request: unknown,
+): Record<string, unknown> {
+  const syncRequest = RootSyncRequestSchema.parse(request);
+  return {
+    info: syncRequest.infos,
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      prune: syncRequest.prune,
+      ...(syncRequest.revision === undefined
+        ? {}
+        : { revision: syncRequest.revision }),
+    },
+  };
+}
+
+function operationResponseForRootSync(request: unknown): unknown {
+  return { operation: operationForRootSyncRequest(request) };
+}
+
 const WorkerApplicationResource = {
   group: "argoproj.io",
   kind: "Application",
@@ -78,14 +109,16 @@ describe("Argo CD prune safety", () => {
     const server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
-      fetch(request) {
+      async fetch(request) {
         const url = new URL(request.url);
         if (
           request.method === "POST" &&
           url.pathname === "/api/v1/applications/apps/sync"
         ) {
           syncPosts++;
-          return Response.json({ operation: {} });
+          return Response.json(
+            operationResponseForRootSync(await request.json()),
+          );
         }
         if (
           request.method === "GET" &&
@@ -138,161 +171,6 @@ describe("Argo CD prune safety", () => {
   });
 });
 
-describe("Argo CD async root operation finalization", () => {
-  test("finalizes an applied async root operation at the exact revision", async () => {
-    let terminated = false;
-    let deleteRequests = 0;
-    const server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch(request) {
-        const url = new URL(request.url);
-        if (
-          request.method === "DELETE" &&
-          url.pathname === "/api/v1/applications/apps/operation"
-        ) {
-          deleteRequests += 1;
-          terminated = true;
-          return new Response(null, { status: 204 });
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/api/v1/applications/apps"
-        ) {
-          if (terminated) {
-            return Response.json({ status: {} });
-          }
-          return Response.json({
-            status: {
-              operationState: {
-                phase: "Running",
-                operation: { sync: { revision: "2.0.0-42" } },
-                syncResult: {
-                  revision: "2.0.0-42",
-                  // Argo reports child Application health waits as
-                  // status=Synced/hookPhase=Running even though their
-                  // manifests are already applied.
-                  resources: [{ status: "Synced", hookPhase: "Running" }],
-                },
-              },
-            },
-          });
-        }
-        return new Response("not found", { status: 404 });
-      },
-    });
-
-    try {
-      const process = Bun.spawn(
-        [
-          "bun",
-          "--no-install",
-          "scripts/argocd.ts",
-          "finalize-async-sync",
-          "apps",
-          "--revision",
-          "2.0.0-42",
-          "--timeout",
-          "1",
-        ],
-        {
-          cwd: path.resolve(import.meta.dir, "../../.."),
-          env: {
-            ...Bun.env,
-            ARGOCD_SERVER_URL: server.url.origin,
-            ARGOCD_TOKEN: "test-token",
-          },
-          stderr: "pipe",
-          stdout: "pipe",
-        },
-      );
-      const [exitCode, stdout, stderr] = await Promise.all([
-        process.exited,
-        new Response(process.stdout).text(),
-        new Response(process.stderr).text(),
-      ]);
-
-      expect(exitCode).toBe(0);
-      expect(stderr).toBe("");
-      expect(stdout).toContain("terminated applied async sync operation: apps");
-      expect(deleteRequests).toBe(1);
-    } finally {
-      await server.stop(true);
-    }
-  });
-
-  test("does not terminate an async operation at another revision", async () => {
-    let deleteRequests = 0;
-    const server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch(request) {
-        const url = new URL(request.url);
-        if (request.method === "DELETE") {
-          deleteRequests += 1;
-          return new Response(null, { status: 204 });
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/api/v1/applications/apps"
-        ) {
-          return Response.json({
-            status: {
-              operationState: {
-                phase: "Running",
-                operation: { sync: { revision: "2.0.0-41" } },
-                syncResult: {
-                  revision: "2.0.0-41",
-                  resources: [{ status: "Synced" }],
-                },
-              },
-            },
-          });
-        }
-        return new Response("not found", { status: 404 });
-      },
-    });
-
-    try {
-      const process = Bun.spawn(
-        [
-          "bun",
-          "--no-install",
-          "scripts/argocd.ts",
-          "finalize-async-sync",
-          "apps",
-          "--revision",
-          "2.0.0-42",
-          "--timeout",
-          "1",
-        ],
-        {
-          cwd: path.resolve(import.meta.dir, "../../.."),
-          env: {
-            ...Bun.env,
-            ARGOCD_SERVER_URL: server.url.origin,
-            ARGOCD_TOKEN: "test-token",
-          },
-          stderr: "pipe",
-          stdout: "pipe",
-        },
-      );
-      const [exitCode, stderr] = await Promise.all([
-        process.exited,
-        new Response(process.stderr).text(),
-      ]);
-
-      expect(exitCode).not.toBe(0);
-      expect(stderr).toContain(
-        "Refusing to terminate apps operation at 2.0.0-41",
-      );
-      expect(deleteRequests).toBe(0);
-    } finally {
-      await server.stop(true);
-    }
-  });
-});
-
 test("Argo CD root pruning requires an exact revision", async () => {
   const process = Bun.spawn(
     [
@@ -327,7 +205,7 @@ test("Argo CD root pruning requires an exact revision", async () => {
   );
 });
 
-test("Argo CD CLI usage documents the root prune revision", async () => {
+test("Argo CD CLI usage documents atomic sync and recovery identity", async () => {
   const process = Bun.spawn(["bun", "--no-install", "scripts/argocd.ts"], {
     cwd: path.resolve(import.meta.dir, "../../.."),
     stderr: "pipe",
@@ -339,12 +217,15 @@ test("Argo CD CLI usage documents the root prune revision", async () => {
   ]);
 
   expect(exitCode).not.toBe(0);
-  expect(stderr).toContain("sync <app> [--revision <v>] [--prune] [--async]");
+  expect(stderr).toContain(
+    "sync <app> [--revision <v>] [--prune] [--async | --terminate-after-applied]",
+  );
+  expect(stderr).toContain("[--request-id <uuid>]");
   expect(stderr).toContain(
     "suspend-auto-sync <root-app> [--revision <v>] [--timeout <s>]",
   );
   expect(stderr).toContain(
-    "finalize-async-sync <app> --revision <v> [--timeout <s>]",
+    "finalize-async-sync <app> --revision <v> --request-id <uuid>",
   );
 });
 
@@ -437,14 +318,16 @@ describe("Argo CD root prune safety", () => {
     const server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
-      fetch(request) {
+      async fetch(request) {
         const url = new URL(request.url);
         if (
           request.method === "POST" &&
           url.pathname === "/api/v1/applications/apps/sync"
         ) {
           syncPosts++;
-          return Response.json({ operation: {} });
+          return Response.json(
+            operationResponseForRootSync(await request.json()),
+          );
         }
         if (
           url.pathname === "/api/v1/applications/apps/manifests" &&
@@ -710,9 +593,9 @@ describe("Argo CD stale release protection", () => {
           url.pathname === "/api/v1/applications/worker/sync"
         ) {
           syncPosts += 1;
-          requestedOperation = z
-            .record(z.string(), z.unknown())
-            .parse(await request.json());
+          requestedOperation = operationForRootSyncRequest(
+            await request.json(),
+          );
           return Response.json({ operation: requestedOperation });
         }
         if (

--- a/packages/tasknotes-core/Cargo.lock
+++ b/packages/tasknotes-core/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "archery"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
-
-[[package]]
 name = "askama"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,12 +100,6 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-
-[[package]]
-name = "bitmaps"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bumpalo"
@@ -393,29 +381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "imbl"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
-dependencies = [
- "archery",
- "bitmaps",
- "imbl-sized-chunks",
- "rand_core",
- "rand_xoshiro",
- "version_check",
-]
-
-[[package]]
-name = "imbl-sized-chunks"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
-dependencies = [
- "bitmaps",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,15 +607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,7 +801,6 @@ name = "tasknotes-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "imbl",
  "indexmap",
  "insta",
  "proptest",
@@ -1080,12 +1035,6 @@ dependencies = [
  "uniffi_meta",
  "weedle2",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/packages/tasknotes-core/Cargo.toml
+++ b/packages/tasknotes-core/Cargo.toml
@@ -20,11 +20,8 @@ publish = false
 #
 # `serde_json/preserve_order` + IndexMap: serialized output must round-trip in
 # source order — HashMap iteration order would corrupt vault markdown diffs.
-#
-# `imbl` (not `im`): `im` is unmaintained; `imbl` is the maintained fork.
 [workspace.dependencies]
 chrono = { version = "0.4.45", features = ["serde"] }
-imbl = "6"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/packages/tasknotes-core/crates/tasknotes-core/Cargo.toml
+++ b/packages/tasknotes-core/crates/tasknotes-core/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
-imbl = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/scripts/quality-ratchet.test.ts
+++ b/scripts/quality-ratchet.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { QUALITY_RATCHET_EXCLUDED_DIRECTORIES } from "./quality-ratchet.ts";
+
+describe("quality ratchet search scope", () => {
+  test("excludes generated dependency and build output directories", () => {
+    expect(QUALITY_RATCHET_EXCLUDED_DIRECTORIES).toEqual([
+      "node_modules",
+      "dist",
+      "archive",
+      "discord-video-stream",
+      "target",
+    ]);
+  });
+});

--- a/scripts/quality-ratchet.ts
+++ b/scripts/quality-ratchet.ts
@@ -33,13 +33,21 @@ type GrepRule = {
   excludePathPatterns: string[];
 };
 
+export const QUALITY_RATCHET_EXCLUDED_DIRECTORIES = [
+  "node_modules",
+  "dist",
+  "archive",
+  "discord-video-stream",
+  "target",
+];
+
 const RULES: GrepRule[] = [
   {
     key: "eslint-disable",
     pattern: String.raw`^\s*(//|/\*)\s*eslint-disable`,
     searchPaths: ["packages/"],
     includes: ["*.ts", "*.tsx"],
-    excludeDirs: ["node_modules", "dist", "archive", "discord-video-stream"],
+    excludeDirs: QUALITY_RATCHET_EXCLUDED_DIRECTORIES,
     excludePathPatterns: ["/generated/"],
   },
   {
@@ -47,7 +55,7 @@ const RULES: GrepRule[] = [
     pattern: String.raw`^\s*//\s*@ts-(expect-error|ignore|nocheck)`,
     searchPaths: ["packages/"],
     includes: ["*.ts", "*.tsx"],
-    excludeDirs: ["node_modules", "dist", "archive", "discord-video-stream"],
+    excludeDirs: QUALITY_RATCHET_EXCLUDED_DIRECTORIES,
     excludePathPatterns: ["/generated/"],
   },
   {
@@ -55,7 +63,7 @@ const RULES: GrepRule[] = [
     pattern: String.raw`#\[allow\(`,
     searchPaths: ["packages/"],
     includes: ["*.rs"],
-    excludeDirs: ["target", "archive", "node_modules"],
+    excludeDirs: QUALITY_RATCHET_EXCLUDED_DIRECTORIES,
     excludePathPatterns: [],
   },
   {
@@ -63,7 +71,7 @@ const RULES: GrepRule[] = [
     pattern: String.raw`^\s*(//|/\*)\s*prettier-ignore`,
     searchPaths: ["packages/"],
     includes: ["*.ts", "*.tsx", "*.js", "*.jsx", "*.css", "*.json"],
-    excludeDirs: ["node_modules", "dist", "archive", "discord-video-stream"],
+    excludeDirs: QUALITY_RATCHET_EXCLUDED_DIRECTORIES,
     excludePathPatterns: [],
   },
   {
@@ -73,7 +81,7 @@ const RULES: GrepRule[] = [
     pattern: String.raw`(test|describe|it)\.skip\(`,
     searchPaths: ["packages/", "scripts/"],
     includes: ["*.ts", "*.tsx"],
-    excludeDirs: ["node_modules", "dist", "archive", "discord-video-stream"],
+    excludeDirs: QUALITY_RATCHET_EXCLUDED_DIRECTORIES,
     excludePathPatterns: [],
   },
   {
@@ -83,7 +91,7 @@ const RULES: GrepRule[] = [
     pattern: String.raw`expect\(true\)\.toBe\(true\)|toBeTruthy\(\)|toBeFalsy\(\)`,
     searchPaths: ["packages/", "scripts/"],
     includes: ["*.ts", "*.tsx"],
-    excludeDirs: ["node_modules", "dist", "archive", "discord-video-stream"],
+    excludeDirs: QUALITY_RATCHET_EXCLUDED_DIRECTORIES,
     excludePathPatterns: [],
   },
 ];
@@ -207,4 +215,6 @@ async function main() {
   console.log("\nQuality ratchet passed");
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/run-ci-test.ts
+++ b/scripts/run-ci-test.ts
@@ -95,6 +95,7 @@ function commandForStep(
         "x",
         "--no-install",
         "vitest",
+        "run",
         ...step.args,
         "--reporter=default",
         "--reporter=junit",


### PR DESCRIPTION
## Why

Buildkite main release #8862 was blocked by a root ArgoCD operation stranded in `Running`. The pipeline split `sync --async` from a separate finalizer; the finalizer could observe no operation, report success, and exit before ArgoCD published the accepted operation. The next release then failed when ArgoCD rejected a second operation.

The required exhaustive local verification also exposed two independent quality failures: a suppression scan raced generated Cargo output, Vitest entered watch mode outside CI, and a new RustSec advisory reached an unused TaskNotes dependency.

## What

- Add an identity-bound `--terminate-after-applied` sync lifecycle keyed by the Buildkite UUID and exact root revision.
- Poll through absent and stale state, adopt only exact active retries, fail mismatched or failed operations, terminate only fully applied results, and wait through termination with replacement detection.
- Keep `finalize-async-sync` as an exact request-ID plus revision recovery interface.
- Replace the split Buildkite sequence with the atomic command and enforce it with a pipeline regression test.
- Document the design and operator recovery workflow.
- Make local verification deterministic by excluding generated Cargo targets from ratchet scans and running Vitest in one-shot mode.
- Remove the unused `imbl` dependency and its unmaintained `bitmaps` transitive graph instead of suppressing RUSTSEC-2026-0247.

## Verification

- `cd packages/homelab/src/cdk8s && bun test src/argocd-script.test.ts src/argocd-atomic-sync.test.ts` (28 passed)
- `cd packages/homelab && bun test scripts/argocd-manifest-overrides.test.ts` (9 passed)
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bun test .buildkite/scripts/validate-pipeline-release.test.ts` (3 passed)
- docs wiki typecheck, unit tests, build, and Playwright E2E (7 passed)
- root-scripts typecheck, lint, and test (467 passed)
- TaskNotes Cargo lint/deny/bindings, 497 tests, and doctests
- `bunx lefthook run pre-commit`
- `bun run verify`: 247/248 tasks passed; the sole local failure is `@shepherdjerred/resume#build` because this Mac has no `xelatex`. CI supplies the pinned `texlive/texlive:TL2024-historic` container for that build.

Live recovery and current-main production acceptance remain pending until this exact PR head passes CI.