### PR TITLE
feat(homelab): deploy media service

### DIFF
--- a/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
+++ b/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
@@ -1,0 +1,512 @@
+---
+id: plan-2026-08-10-stash-tailnet-deployment
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Dedicated Stash Tailnet Deployment
+
+## Goal
+
+Deploy Stash as an isolated homelab service at the MagicDNS host
+`stash.tailnet-1a49.ts.net`. Bootstrap the exact synthesized workload directly
+with Kubernetes before opening the PR, then make ArgoCD the durable owner after
+the PR merges and its internal chart is published. Access must remain private to
+the Tailscale tailnet, and Stash's built-in single-user username/password
+authentication must be active before the workload becomes Ready.
+
+This first phase proves deployment, persistence, private HTTPS, built-in
+authentication, and backup coverage. It knowingly uses the current unencrypted
+local storage and backup path temporarily; that accepted risk does not block
+personal media use after runtime acceptance.
+
+## Scope
+
+Included:
+
+- A dedicated `stash` namespace, internal Helm chart, and ArgoCD Application.
+- The official Stash container pinned to the current stable `v0.31.1` tag and
+  immutable multi-architecture digest
+  `sha256:df744af5a0c976e2ec671052ecc1f8a9aa757fa12b8f9930b59910b7295f0da6`.
+- A private Tailscale Layer 7 ingress with operator-managed HTTPS and no Funnel
+  or Cloudflare public route.
+- Built-in Stash authentication bootstrapped from 1Password before readiness.
+- Dedicated state, generated-content, and library storage with explicit backup
+  policy classifications.
+- All three persistent volumes included in the existing Velero/OpenEBS backup
+  schedules and Cloudflare R2 destination from their first populated state.
+- A bounded out-of-band bootstrap using only the synthesized Stash workload
+  manifest, followed immediately by a git-spice PR and explicit ArgoCD ownership
+  handoff.
+- Default-deny network policy, health probes, focused synth tests, and runtime
+  acceptance checks.
+
+Excluded:
+
+- SSO, an external authentication proxy, multi-user authorization, or
+  identity-aware Tailscale headers.
+- Encryption at rest for OpenEBS/ZFS volumes or client-side encrypted backups.
+- Automated ingestion, scraper credentials, plugins, metadata-provider
+  configuration, API keys, downloader automation, or integrations with the
+  existing media chart. Manual library setup remains an operator activity after
+  deployment acceptance.
+- Public internet exposure, Tailscale Funnel, a `stash.sjer.red` hostname, or a
+  Cloudflare tunnel binding.
+- Intel GPU allocation and hardware transcoding. Add it only after the initial
+  deployment is stable and workload evidence justifies it.
+
+### Public terminology and disclosure
+
+Describe Stash neutrally as a private media organizer and its collection as a
+private or personal media library. Do not name, characterize, imply, or provide
+examples of the library's content category in any artifact that may leave the
+private working context.
+
+This rule applies to source comments, identifiers where a neutral name is
+possible, test fixtures, logs, error messages, documentation, commit subjects
+and bodies, PR titles and descriptions, review replies, release notes,
+screenshots, captions, and demo artifacts. Use synthetic, category-neutral
+filenames and metadata in tests. Runtime evidence must use the empty library or
+fully neutral synthetic data and must not capture real thumbnails, filenames,
+performer metadata, tags, or scan paths.
+
+Before publication, review the complete `origin/main...HEAD` diff together with
+all commit and PR metadata for this disclosure boundary. Keep upstream links
+limited to technical documentation needed to review or operate the deployment;
+do not quote or reproduce upstream marketing copy.
+
+## Decisions
+
+### Isolation
+
+Stash will not join the broad `media` namespace or reuse the Plex, movie,
+television, or qBittorrent PVCs. It gets its own namespace, Application,
+NetworkPolicies, secret, and volumes. This keeps a private workload outside
+the existing media service trust and storage boundaries.
+
+The only user-facing path is:
+
+```text
+tailnet browser
+  -> Tailscale HTTPS ingress (stash.tailnet-1a49.ts.net)
+  -> stash Service:9999
+  -> Stash pod:9999
+```
+
+The current tailnet ACL already allows members to operator-managed `tag:k8s`
+web ingresses on TCP 443 and grants no Funnel capability. No Tailscale policy
+change is required for this phase. Stash's password is defense in depth inside
+that private connectivity boundary.
+
+### Out-of-band bootstrap and ownership handoff
+
+The operator explicitly authorizes a one-time direct Kubernetes bootstrap
+before the PR is opened. This is a deployment-order exception, not a second
+configuration path:
+
+- Finish the repository implementation first, commit it locally, and synthesize
+  from that clean commit.
+- Apply only `packages/homelab/src/cdk8s/dist/stash.k8s.yaml`. Do not apply
+  `apps.k8s.yaml`, `service-probes.k8s.yaml`, a whole `dist/` directory, or any
+  other chart out of band.
+- Do not hand-author, edit, or retain a second manifest. Record the source commit
+  and SHA-256 of the exact synthesized file used for dry-run, diff, and apply.
+- Use server-side apply with the dedicated field manager `stash-bootstrap` and
+  never use `--force-conflicts`.
+- Open the git-spice PR immediately after the direct workload reaches its
+  initial acceptance boundary. The period before ArgoCD adoption is expected
+  drift and must remain short and visible in the PR.
+- After merge, chart publication, and ArgoCD adoption, stop using the bootstrap
+  field manager. Every later change goes through Git and ArgoCD.
+
+The direct manifest creates the namespace and workload resources, including the
+`OnePasswordItem`, PVCs, Deployment, Service, Tailscale Ingress, and
+NetworkPolicies. The PR adds the durable internal chart, ArgoCD Application, and
+shared service-probe registration. Existing cluster-wide Velero schedules will
+select the backup-enabled PVCs as soon as they exist; they do not require the
+new ArgoCD Application to start protecting them.
+
+If the committed source changes during review in a way that changes
+`stash.k8s.yaml`, regenerate, re-run focused checks, inspect the new diff, apply
+that exact revision with the same field manager, and update the manifest hash
+and live verification in the PR. Documentation-only or PR-metadata changes do
+not require a live reapply.
+
+### Authentication bootstrap
+
+Stash v0.31.1 stores `username` and a bcrypt password hash in `config.yml`.
+Its supported `STASH_` environment overrides intentionally do not include
+credentials, so directly injecting `STASH_USERNAME` and `STASH_PASSWORD` into
+the main container would not enable authentication.
+
+Create a 1Password Login item named `stash` with these fields:
+
+- `username`: a simple value limited to ASCII letters, digits, `.`, `_`, and
+  `-`.
+- `password`: the generated plaintext used by the operator to sign in; never
+  mounted into the Stash container.
+- `password_hash`: a bcrypt cost-10 hash of that same password.
+
+Generate the hash interactively so the plaintext does not appear in shell
+history or process arguments. Stash uses Go's bcrypt verifier; accept only a
+cost-10 `$2a$`, `$2b$`, or `$2y$` hash. Reference the item by immutable item ID
+through `vaultItemPath(...)`, then refresh the committed vault-structure
+snapshot. The snapshot contains only hashes of item metadata and field names,
+not secret values.
+
+An init container based on the repository's already-pinned BusyBox image will:
+
+1. Read only `username` and `password_hash` from the operator-created Secret.
+2. Fail if either value is absent or does not match the expected format.
+3. Remove only existing top-level `username:` and `password:` entries from the
+   persistent configuration, append the desired values, and atomically replace
+   `config.yml` with mode `0600`.
+4. Exit before the Stash container starts.
+
+Run the init container on every pod start so 1Password remains authoritative.
+Changing a password only in the Stash UI is therefore not durable; rotation is
+a coordinated update of both 1Password fields followed by a controlled
+deployment restart. Never log either credential field. The main Stash
+container must not receive the plaintext password or mount the Kubernetes
+Secret.
+
+This ordering removes the first-boot unauthenticated window. Stash must not be
+marked Ready unless its persistent configuration already contains both auth
+fields.
+
+### Runtime and health
+
+Run one replica with `Recreate` strategy because Stash uses SQLite and its state
+PVC is ReadWriteOnce. Expose only container port 9999 through a ClusterIP
+Service. Use the upstream `/healthz` heartbeat for startup, readiness, liveness,
+and the registered blackbox probe; upstream installs that heartbeat before its
+authentication middleware, so probes do not need credentials.
+
+Use `withCommonProps`, explicit resource requests and limits, a medium Tailscale
+proxy class, no host networking, no host ports, no privileged mode, no
+privilege escalation, and no service-account token. Start with:
+
+- CPU: 250m request, 4 cores limit.
+- Memory: 512 MiB request, 4 GiB limit.
+- Startup: `/healthz` every 5 seconds, allowing up to 5 minutes for first-run
+  database initialization.
+- Readiness: `/healthz` every 10 seconds.
+- Liveness: `/healthz` every 30 seconds.
+
+The upstream image runs as root. Keep that explicit and add only the required
+kube-linter exception. Attempt a read-only root filesystem with writable mounts
+for `/state`, `/generated`, `/cache`, and `/tmp`; if upstream behavior writes
+elsewhere, identify and mount the exact path instead of making the whole root
+filesystem writable without evidence.
+
+Configure these supported paths:
+
+- `STASH_CONFIG_FILE=/state/config.yml`
+- `STASH_STASH=/data/`
+- `STASH_METADATA=/state/metadata/`
+- `STASH_BLOBS=/state/blobs/`
+- `STASH_GENERATED=/generated/`
+- `STASH_CACHE=/cache/`
+- `STASH_PORT=9999`
+
+Pass `--nobrowser` to the Stash entrypoint. Keep cache and `/tmp` on bounded
+`emptyDir` volumes; do not persist disposable cache data.
+
+### Storage and backup boundary
+
+Create three dedicated thin-provisioned ReadWriteOnce PVCs:
+
+| PVC               | Class    | Initial size | Contents                                                    | Phase-one backup policy                                                |
+| ----------------- | -------- | -----------: | ----------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `stash-state`     | ZFS NVMe |       64 GiB | Config, SQLite database, metadata, plugins, scrapers, blobs | Enabled: application configuration, database, and curated metadata     |
+| `stash-generated` | ZFS SATA |      256 GiB | Screenshots, previews, sprites, and transcodes              | Enabled: preserve generated assets and avoid a full regeneration cycle |
+| `stash-media`     | ZFS SATA |        1 TiB | Source library mounted at `/data`                           | Enabled: preserve the personal media library                           |
+
+Use an 8 GiB disk-backed `emptyDir` for `/cache` and a 2 GiB disk-backed
+`emptyDir` for `/tmp`. The PVC requests establish initial ceilings, not a claim
+that the physical data already exists.
+
+Add all three PVCs to `pvc-backup-policy.json` as `enabled`; synthesis must fail
+if any is unclassified. Their labels must opt into both the six-hourly recovery
+points and the daily, weekly, and monthly retention schedules already generated
+from the repository's Velero configuration.
+
+This temporarily accepts two facts: the local ZFS datasets are not encrypted at
+rest, and the OpenEBS ZFS data stream sent to R2 is not client-side encrypted by
+this deployment. Recoverability is preferred over waiting for that hardening.
+The follow-up encryption design must cover local datasets, backup data, key
+custody, recovery, and a migration path that does not discard these backups.
+
+The first backup can transfer up to the populated size of the three volumes;
+later backups use the existing incremental ZFS path. Confirm capacity and
+completion from actual R2 objects rather than assuming a Velero phase alone
+proves that the volume streams arrived.
+
+### Network policy
+
+Select the Stash pod with a stable `app: stash` label and apply ingress and
+egress policy together:
+
+- Permit TCP 9999 ingress only from the `tailscale` namespace and from the
+  Prometheus namespace used by the registered blackbox probe.
+- Permit TCP/UDP 53 egress only to kube-dns.
+- Permit TCP 80 and 443 egress to the internet for release checks, scraper
+  catalogs, plugins, and future metadata providers.
+- Permit no ingress from the `media`, `cloudflare-tunnel`, or default namespace.
+- Do not add DLNA, multicast, host networking, downloader, or cross-namespace
+  media rules in this phase.
+
+### Documentation
+
+Add a focused explanation page at
+`packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md`
+when implementing the deployment. It should explain the isolation, two-layer
+tailnet-plus-password access model, credential bootstrap, and the explicit
+temporary encryption risk. Keep operating steps in the plan/PR or a separate
+how-to page rather than mixing them into the explanation.
+
+## Implementation Changes
+
+### Image and secret prerequisites
+
+- Add the Renovate-managed `stashapp/stash` v0.31.1 tag and digest to
+  `packages/homelab/src/cdk8s/src/versions.ts`.
+- Create the 1Password item and record its immutable item ID.
+- Refresh
+  `packages/homelab/src/cdk8s/onepassword-vault-snapshot.json` with
+  `bun run scripts/snapshot-1password-vault.ts` from the CDK8s package.
+
+### Workload chart
+
+- Add `packages/homelab/src/cdk8s/src/resources/stash/index.ts` for the
+  OnePasswordItem, PVCs, init container, Deployment, Service,
+  `TailscaleIngress`, probes, and NetworkPolicies.
+- Add `packages/homelab/src/cdk8s/src/cdk8s-charts/stash.ts` for the dedicated
+  namespace and workload.
+- Register `createStashChart` in
+  `packages/homelab/src/cdk8s/src/setup-charts.ts` before the service-probes
+  chart, which must remain last.
+- Add the three explicit entries to
+  `packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json`.
+
+### GitOps publication
+
+- Add `packages/homelab/src/cdk8s/helm/stash/Chart.yaml` and `values.yaml`, using
+  the repository's `$version`/`$appVersion` internal chart convention.
+- Add
+  `packages/homelab/src/cdk8s/src/resources/argo-applications/stash.ts` with
+  chart `stash`, destination namespace `stash`, ChartMuseum source, automated
+  sync, `CreateNamespace=true`, and the standard `~2.0.0-0` target revision.
+- Register `createStashApp` in
+  `packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts`.
+- Do not add a Cloudflare binding, Funnel annotation, public DNS record, or
+  permanent direct-apply script. The bootstrap uses the generated workload
+  artifact only and is not committed as a parallel deployment mechanism.
+- Assert that the application release policy adds the standard lifecycle
+  annotation and resources finalizer needed by the root app's prune safety
+  model.
+
+### Tests
+
+Add a focused Stash synth test that validates the emitted manifests, including:
+
+- Exactly one Stash replica with `Recreate` strategy and the pinned image.
+- The auth init container consumes only `username` and `password_hash`, rejects
+  malformed values, updates the config atomically, and runs before Stash.
+- The main container receives no plaintext password or secret volume.
+- All supported Stash path variables, volume mounts, storage classes, sizes,
+  resource bounds, and `/healthz` probes are exact.
+- The ingress uses class `tailscale`, host `stash`, TLS, medium proxy class, and
+  no Funnel/public annotations.
+- NetworkPolicy admits only the intended ingress and egress paths.
+- All three PVCs have explicit backup-enabled labels and policy entries.
+- The Argo Application and both chart registration points are present.
+
+## Verification
+
+### Source and manifest validation
+
+From `packages/homelab/src/cdk8s`:
+
+```bash
+bun run build
+bun test src/resources/stash/index.test.ts
+bun run typecheck
+bun run lint
+bun run check:1password
+HELM_RENDER_TEST=1 bun test src/argocd-helm-render.test.ts
+```
+
+From the repository root, validate the plan and all changed documentation with
+the focused Prettier and TODO checks. Do not substitute a whole-repository
+`bun run verify` for these implementation checks; Buildkite remains the
+exhaustive gate.
+
+Before touching the cluster, restack the branch on current `origin/main` with
+git-spice if needed, create the reviewed local commit, and require a clean
+worktree. Synthesize from that exact commit. Inspect
+`dist/stash.k8s.yaml` to confirm it contains only the dedicated Namespace,
+OnePasswordItem, PVCs, Deployment, Service, Ingress, and NetworkPolicies. Record
+both `git rev-parse HEAD` and `shasum -a 256 dist/stash.k8s.yaml` for the PR.
+
+### Direct Kubernetes bootstrap
+
+First prove the current kube context resolves to the production `torvalds` node.
+Inventory any existing `stash` namespace or same-named resources. A missing
+namespace is the expected first-deploy state; if anything already exists, stop
+and reconcile ownership and data before applying.
+
+Run server validation and inspect the full diff before the one authorized
+mutation:
+
+```bash
+kubectl config current-context
+kubectl get node torvalds
+kubectl apply --server-side --field-manager=stash-bootstrap --dry-run=server -f dist/stash.k8s.yaml
+kubectl diff --server-side --field-manager=stash-bootstrap -f dist/stash.k8s.yaml
+kubectl apply --server-side --field-manager=stash-bootstrap -f dist/stash.k8s.yaml
+```
+
+`kubectl diff` exits 1 when it finds the expected create diff; inspect that diff
+rather than treating the status as an infrastructure failure. Do not pass
+`--force-conflicts`, apply a directory, or broaden the target after dry-run.
+
+After the apply:
+
+1. Confirm the namespace exists, the `OnePasswordItem` reconciles, all three
+   PVCs are Bound with backup-enabled labels, and the Deployment rollout
+   completes.
+2. Confirm the auth init container exits successfully and neither its output nor
+   the Stash logs contain secret values.
+3. Confirm the Tailscale ingress receives its MagicDNS address and valid TLS
+   certificate, and that the service is unreachable with Tailscale disabled.
+4. Confirm `/healthz` returns success without credentials while `/` redirects
+   to `/login` for a new session.
+5. Confirm an incorrect password is rejected, the 1Password password succeeds,
+   logout removes access, and a fresh browser session requires login.
+6. Confirm no Cloudflare tunnel, Funnel annotation, public DNS record, real
+   library data, scan path, or scraper credential was introduced by the
+   bootstrap manifest.
+7. Create or await a backup. Confirm it attempts all three ZFS volume snapshots
+   and that R2 contains a non-empty data stream plus its metadata object for each
+   PVC. Record exact object names, sizes, and the backup revision without
+   exposing library metadata.
+
+Open the draft PR immediately after steps 1 through 6. Backup verification may
+finish while the draft and Buildkite checks run, but it must be added to the PR
+before the PR is marked ready.
+
+### PR publication and GitOps adoption
+
+Use git-spice for the stack-of-one PR. Preview the submission first and provide
+explicit metadata synthesized from the complete `origin/main...HEAD` diff. The
+neutral title should be `feat(homelab): deploy private Stash media service`.
+The body must use `Why`, `What`, and `Verification` sections and include:
+
+- The direct-bootstrap source commit and manifest SHA-256.
+- The fact that the live workload temporarily precedes ArgoCD ownership.
+- Tailnet, authentication, PVC, and backup evidence using neutral terminology.
+- Exact focused commands, Buildkite status, and any still-pending backup or
+  post-merge adoption check.
+
+After merge and internal-chart publication:
+
+1. Confirm the exact published chart revision is the one the root `apps`
+   Application reconciles and that it creates the `stash` Application.
+2. Confirm the `stash` Application adopts the existing resources without PVC or
+   namespace replacement, then reaches Synced and Healthy.
+3. Confirm `argocd app diff stash` is empty and ArgoCD resource tracking covers
+   every object emitted by the Stash chart.
+4. Confirm the shared service-probes chart now contains the Stash blackbox probe
+   and remains Healthy.
+5. Restart the pod through GitOps and confirm built-in authentication,
+   application state, PVC identity, and backup labels persist.
+6. Recheck that scheduled backups continue after ownership transfer. Update the
+   PR's final verification boundary with the exact deployed chart revision and
+   live ArgoCD state.
+
+Runtime success establishes an authenticated Stash instance and observed backup
+coverage for all three PVCs. It does not establish encryption at rest,
+client-side backup encryption, restoreability, or GPU transcoding. Library
+population may proceed as a separate operator activity under the accepted
+temporary encryption risk.
+
+## Rollout and Rollback
+
+The rollout has two explicit ownership states:
+
+1. **Bootstrap:** the committed and hashed Stash manifest is applied directly
+   with field manager `stash-bootstrap`; no ArgoCD Application exists yet.
+2. **Steady state:** the merged internal chart and root app create the Stash
+   Application, which adopts the exact resources; Git and ArgoCD become the only
+   mutation path.
+
+The first certificate request can be slow while the Tailscale operator obtains
+the certificate, so distinguish that known startup condition from a failing
+workload. Do not create the PR until the direct workload itself is Ready and
+authentication works, but do not wait for the first scheduled backup before
+opening the draft.
+
+Before ArgoCD adoption, an application regression may be contained by scaling
+the Stash Deployment to zero. Preserve the namespace, PVCs, and 1Password item.
+Record any imperative containment in the PR and make the committed desired state
+match before resuming. Do not delete stateful resources as routine rollback.
+
+After ArgoCD adoption, roll back the image or configuration through Git and let
+ArgoCD reconcile it. Never return to `stash-bootstrap` direct apply. If the PR is
+delayed or rejected, explicitly choose whether to keep the documented temporary
+deployment or scale it to zero; do not leave its unmanaged status unstated. Any
+resource or data deletion requires a fresh exact inventory and explicit
+destructive approval.
+
+## Remaining
+
+- [x] Create the Stash 1Password Login item with matching plaintext password
+      and cost-10 bcrypt hash, then refresh the safe vault snapshot.
+- [x] Add the pinned Stash version, dedicated chart, namespace, workload,
+      volumes, probes, auth init container, and restrictive NetworkPolicies.
+- [x] Add and register the internal Helm chart and ArgoCD Application.
+- [x] Classify all Stash PVCs as backup-enabled and add manifest-level tests
+      for the security and storage invariants.
+- [x] Add the focused human wiki explanation of the Stash security boundary.
+- [x] Run focused CDK8s, 1Password, Helm render, and docs validation.
+- [ ] Confirm Buildkite is green for the published PR head.
+- [ ] Commit and hash the exact synthesized Stash manifest, validate the
+      production context, inspect the server-side diff, and apply only that
+      manifest with the `stash-bootstrap` field manager.
+- [ ] Complete direct-deployment authentication and storage acceptance, then
+      immediately submit the neutral-language draft PR with git-spice.
+- [ ] Verify non-empty R2 data streams for all three PVCs and promote the PR only
+      after focused checks and Buildkite are green.
+- [ ] After merge and chart publication, prove the Stash Application adopted
+      every live resource with an empty ArgoCD diff, then retire direct apply.
+- [ ] Plan encryption at rest, client-side backup encryption, restore testing,
+      and key recovery as follow-up hardening without blocking initial use.
+
+## References
+
+- [Stash Docker installation](https://docs.stashapp.cc/installation/docker/)
+- [Stash authentication configuration](https://docs.stashapp.cc/in-app-manual/configuration/)
+- [Stash v0.31.1 source](https://github.com/stashapp/stash/tree/v0.31.1)
+- [Tailscale Kubernetes ingress](https://tailscale.com/docs/kubernetes-operator/ingress)
+
+## Comment Log
+
+- 2026-08-10 — Initial plan. The requested first phase is a dedicated Stash
+  deployment on Tailscale with Stash's built-in authentication. External auth,
+  encryption at rest, encrypted backups, and library use were initially treated
+  as follow-up gates; the backup and initial-use boundary is superseded below.
+- 2026-08-10 — Backup posture revised by operator direction: enable the existing
+  Velero/OpenEBS-to-R2 path for every persistent Stash volume immediately.
+  Unencrypted local and backup storage is an accepted temporary risk and no
+  longer blocks initial library use.
+- 2026-08-10 — Rollout order revised by operator direction: deploy the exact
+  committed and synthesized Stash workload directly first, then immediately
+  submit the PR that publishes the chart and transfers ownership to ArgoCD. The
+  direct apply is a bounded bootstrap exception, not a durable second path.
+- 2026-08-10 — Source implementation completed. The generated credential and
+  cost-10 hash match, the safe vault snapshot is current, all 405 CDK8s tests
+  pass (391 active and 14 integration skips), and all 34 internal charts render.

--- a/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
+++ b/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
@@ -474,13 +474,13 @@ destructive approval.
 - [x] Add the focused human wiki explanation of the Stash security boundary.
 - [x] Run focused CDK8s, 1Password, Helm render, and docs validation.
 - [ ] Confirm Buildkite is green for the published PR head.
-- [ ] Commit and hash the exact synthesized Stash manifest, validate the
+- [x] Commit and hash the exact synthesized Stash manifest, validate the
       production context, inspect the server-side diff, and apply only that
       manifest with the `stash-bootstrap` field manager.
-- [ ] Complete direct-deployment authentication and storage acceptance, then
+- [x] Complete direct-deployment authentication and storage acceptance, then
       immediately submit the neutral-language draft PR with git-spice.
-- [ ] Verify non-empty R2 data streams for all three PVCs and promote the PR only
-      after focused checks and Buildkite are green.
+- [x] Verify non-empty R2 data streams for all three PVCs.
+- [ ] Promote the PR only after focused checks and Buildkite are green.
 - [ ] After merge and chart publication, prove the Stash Application adopted
       every live resource with an empty ArgoCD diff, then retire direct apply.
 - [ ] Plan encryption at rest, client-side backup encryption, restore testing,
@@ -508,5 +508,40 @@ destructive approval.
   submit the PR that publishes the chart and transfers ownership to ArgoCD. The
   direct apply is a bounded bootstrap exception, not a durable second path.
 - 2026-08-10 — Source implementation completed. The generated credential and
-  cost-10 hash match, the safe vault snapshot is current, all 405 CDK8s tests
-  pass (391 active and 14 integration skips), and all 34 internal charts render.
+  cost-10 hash match, the safe vault snapshot is current, all 406 CDK8s tests
+  pass (392 active and 14 intentional integration skips), and all 34 internal
+  charts render.
+- 2026-08-10 — The exact workload synthesized from source commit
+  `782f49caf7f1732fdd1e0206559ad4414f12187c` was applied with manifest SHA-256
+  `c8c22e3cf0b1c24eb455494a38cdcd63ad5cc9fb88b08021b8988904fc497918`.
+  Runtime acceptance found that the image required an explicit `stash` command;
+  that correction was committed, re-synthesized, and re-applied before the pod
+  reached Ready with the auth init container complete and zero restarts.
+- 2026-08-10 — The live cluster's backup admission policy and `medium`
+  Tailscale ProxyClass lagged the already-committed global desired state. The
+  bootstrap applied only those two exact resources extracted from the committed
+  `apps.k8s.yaml`, without a broad apps apply or forced conflicts, before
+  retrying the exact Stash workload manifest. The backup policy reached observed
+  generation 16 before all three PVCs were admitted.
+- 2026-08-10 — On-demand backup `stash-bootstrap-20260811-0225` completed at
+  `2026-08-11T02:25:59Z` with 9 of 9 Kubernetes items, three of three ZFS
+  snapshots, zero errors, and one known plugin interruption warning. R2 contains
+  a non-empty metadata object and data stream for each volume: state (1,437 and
+  888,400 bytes), generated (1,437 and 58,184 bytes), and media (1,438 and
+  45,776 bytes). This proves transfer of the new empty-volume recovery points,
+  not application restoreability.
+- 2026-08-10 — Tailnet acceptance completed at the exact MagicDNS hostname.
+  Tailscale's first certificate attempts validated before its DNS update had
+  propagated, so a temporary exact-version proxy extended only that issuance
+  window. After staging proved the timing diagnosis, production issuance
+  succeeded with the propagated record. The temporary proxy classes, loader
+  pod, and node-local image tags were removed; the durable `medium` ProxyClass
+  now runs the standard pinned Tailscale image and serves the trusted certificate.
+  A normal MagicDNS request returns 200 from `/healthz`, while an unauthenticated
+  request to `/` returns 302 to `/login`.
+- 2026-08-10 — Draft PR #2109 was published with the complete neutral-language
+  diff narrative. Buildkite #8963 passed the PR Playwright and Semgrep lanes,
+  but exhaustive verify hit the same `tasknotes-core` transitive-dependency
+  advisory already failing current-main build #8941. The dependent review and
+  deployment-dry-run jobs were canceled, so the PR remains draft pending the
+  independent main-branch repair and a fresh green build.

--- a/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
+++ b/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
@@ -12,11 +12,13 @@ disposition: active
 ## Goal
 
 Deploy Stash as an isolated homelab service at the MagicDNS host
-`stash.tailnet-1a49.ts.net`. Bootstrap the exact synthesized workload directly
-with Kubernetes before opening the PR, then make ArgoCD the durable owner after
-the PR merges and its internal chart is published. Access must remain private to
-the Tailscale tailnet, and Stash's built-in single-user username/password
-authentication must be active before the workload becomes Ready.
+`stash.tailnet-1a49.ts.net`, owned by ArgoCD. The internal Helm chart and `stash`
+Application committed in this change are the deployment mechanism: when the PR
+merges and the chart is published, the root `apps` Application reconciles that
+revision and ArgoCD creates and owns every Stash resource. Access must remain
+private to the Tailscale tailnet, and Stash's built-in single-user
+username/password authentication must be active before the workload becomes
+Ready.
 
 This first phase proves deployment, persistence, private HTTPS, built-in
 authentication, and backup coverage. It knowingly uses the current unencrypted
@@ -38,9 +40,8 @@ Included:
   policy classifications.
 - All three persistent volumes included in the existing Velero/OpenEBS backup
   schedules and Cloudflare R2 destination from their first populated state.
-- A bounded out-of-band bootstrap using only the synthesized Stash workload
-  manifest, followed immediately by a git-spice PR and explicit ArgoCD ownership
-  handoff.
+- A single completed out-of-band bootstrap of the synthesized Stash workload
+  manifest, closed by ArgoCD adoption of those exact resources.
 - Default-deny network policy, health probes, focused synth tests, and runtime
   acceptance checks.
 
@@ -101,39 +102,39 @@ web ingresses on TCP 443 and grants no Funnel capability. No Tailscale policy
 change is required for this phase. Stash's password is defense in depth inside
 that private connectivity boundary.
 
-### Out-of-band bootstrap and ownership handoff
+### ArgoCD ownership and the closed bootstrap exception
 
-The operator explicitly authorizes a one-time direct Kubernetes bootstrap
-before the PR is opened. This is a deployment-order exception, not a second
-configuration path:
+ArgoCD is the deployment mechanism and the only ownership path. This change
+commits the internal chart, the `stash` Application, and the shared
+service-probe registration. On merge and chart publication the root `apps`
+Application reconciles that revision, creates the `stash` Application, and
+ArgoCD owns the namespace, `OnePasswordItem`, PVCs, Deployment, Service,
+Tailscale Ingress, and NetworkPolicies. Existing cluster-wide Velero schedules
+select the backup-enabled PVCs from their labels alone, so backup coverage does
+not depend on the Application either.
 
-- Finish the repository implementation first, commit it locally, and synthesize
-  from that clean commit.
-- Apply only `packages/homelab/src/cdk8s/dist/stash.k8s.yaml`. Do not apply
-  `apps.k8s.yaml`, `service-probes.k8s.yaml`, a whole `dist/` directory, or any
-  other chart out of band.
-- Do not hand-author, edit, or retain a second manifest. Record the source commit
-  and SHA-256 of the exact synthesized file used for dry-run, diff, and apply.
-- Use server-side apply with the dedicated field manager `stash-bootstrap` and
-  never use `--force-conflicts`.
-- Open the git-spice PR immediately after the direct workload reaches its
-  initial acceptance boundary. The period before ArgoCD adoption is expected
-  drift and must remain short and visible in the PR.
-- After merge, chart publication, and ArgoCD adoption, stop using the bootstrap
-  field manager. Every later change goes through Git and ArgoCD.
+One direct Kubernetes apply preceded this PR under explicit operator
+authorization so private access and authentication could be accepted on real
+hardware. It was a one-time deployment-order exception rather than a second
+configuration path, and it is closed. It stayed inside these bounds, which are
+what let ArgoCD adopt the result instead of fighting it:
 
-The direct manifest creates the namespace and workload resources, including the
-`OnePasswordItem`, PVCs, Deployment, Service, Tailscale Ingress, and
-NetworkPolicies. The PR adds the durable internal chart, ArgoCD Application, and
-shared service-probe registration. Existing cluster-wide Velero schedules will
-select the backup-enabled PVCs as soon as they exist; they do not require the
-new ArgoCD Application to start protecting them.
+- Only `packages/homelab/src/cdk8s/dist/stash.k8s.yaml`, synthesized from a
+  clean committed revision, was applied — never `apps.k8s.yaml`,
+  `service-probes.k8s.yaml`, a whole `dist/` directory, or a hand-authored
+  manifest.
+- Server-side apply used the dedicated field manager `stash-bootstrap` without
+  `--force-conflicts`, leaving field ownership adoptable on the first sync.
+- No direct-apply script, task, or runbook step was committed, so the bootstrap
+  left behind no reusable imperative path.
 
-If the committed source changes during review in a way that changes
-`stash.k8s.yaml`, regenerate, re-run focused checks, inspect the new diff, apply
-that exact revision with the same field manager, and update the manifest hash
-and live verification in the PR. Documentation-only or PR-metadata changes do
-not require a live reapply.
+The bootstrap is not repeated for review changes. If the committed source
+changes while this PR is open, regenerate, re-run the focused checks, and
+inspect the new manifest diff, but do not reapply it: the merged chart and
+ArgoCD deliver the change. Until adoption the live workload is known drift from
+the desired state, which the PR states plainly. A delayed or rejected PR is
+resolved by deciding whether to keep or scale down that unmanaged workload, not
+by further imperative production mutation.
 
 ### Authentication bootstrap
 
@@ -266,7 +267,10 @@ Add a focused explanation page at
 when implementing the deployment. It should explain the isolation, two-layer
 tailnet-plus-password access model, credential bootstrap, and the explicit
 temporary encryption risk. Keep operating steps in the plan/PR or a separate
-how-to page rather than mixing them into the explanation.
+how-to page rather than mixing them into the explanation. Rollout state — the
+one-time bootstrap and its pending ArgoCD adoption — stays in this plan; it is
+workflow history that would go stale on the published page as soon as adoption
+completes.
 
 ## Implementation Changes
 
@@ -345,59 +349,41 @@ the focused Prettier and TODO checks. Do not substitute a whole-repository
 `bun run verify` for these implementation checks; Buildkite remains the
 exhaustive gate.
 
-Before touching the cluster, restack the branch on current `origin/main` with
-git-spice if needed, create the reviewed local commit, and require a clean
-worktree. Synthesize from that exact commit. Inspect
-`dist/stash.k8s.yaml` to confirm it contains only the dedicated Namespace,
-OnePasswordItem, PVCs, Deployment, Service, Ingress, and NetworkPolicies. Record
-both `git rev-parse HEAD` and `shasum -a 256 dist/stash.k8s.yaml` for the PR.
+Inspect `dist/stash.k8s.yaml` to confirm it contains only the dedicated
+Namespace, OnePasswordItem, PVCs, Deployment, Service, Ingress, and
+NetworkPolicies, and no Cloudflare binding, Funnel annotation, public DNS
+record, real library data, scan path, or scraper credential.
 
-### Direct Kubernetes bootstrap
+### Completed bootstrap acceptance
 
-First prove the current kube context resolves to the production `torvalds` node.
-Inventory any existing `stash` namespace or same-named resources. A missing
-namespace is the expected first-deploy state; if anything already exists, stop
-and reconcile ownership and data before applying.
+This records the closed one-time bootstrap described under
+[ArgoCD ownership and the closed bootstrap exception](#argocd-ownership-and-the-closed-bootstrap-exception).
+It is evidence, not a procedure to repeat: reproducing it would create a second
+unmanaged workload outside reconciliation.
 
-Run server validation and inspect the full diff before the one authorized
-mutation:
+The operator confirmed the kube context resolved to the production `torvalds`
+node and that no prior `stash` namespace or same-named resources existed, then
+ran a server-side dry run and reviewed the full create diff before the single
+authorized apply. The exact source commit and manifest SHA-256 are recorded in
+the Comment Log and the PR body.
 
-```bash
-kubectl config current-context
-kubectl get node torvalds
-kubectl apply --server-side --field-manager=stash-bootstrap --dry-run=server -f dist/stash.k8s.yaml
-kubectl diff --server-side --field-manager=stash-bootstrap -f dist/stash.k8s.yaml
-kubectl apply --server-side --field-manager=stash-bootstrap -f dist/stash.k8s.yaml
-```
+Runtime acceptance of that workload confirmed:
 
-`kubectl diff` exits 1 when it finds the expected create diff; inspect that diff
-rather than treating the status as an infrastructure failure. Do not pass
-`--force-conflicts`, apply a directory, or broaden the target after dry-run.
-
-After the apply:
-
-1. Confirm the namespace exists, the `OnePasswordItem` reconciles, all three
-   PVCs are Bound with backup-enabled labels, and the Deployment rollout
-   completes.
-2. Confirm the auth init container exits successfully and neither its output nor
-   the Stash logs contain secret values.
-3. Confirm the Tailscale ingress receives its MagicDNS address and valid TLS
-   certificate, and that the service is unreachable with Tailscale disabled.
-4. Confirm `/healthz` returns success without credentials while `/` redirects
-   to `/login` for a new session.
-5. Confirm an incorrect password is rejected, the 1Password password succeeds,
-   logout removes access, and a fresh browser session requires login.
-6. Confirm no Cloudflare tunnel, Funnel annotation, public DNS record, real
-   library data, scan path, or scraper credential was introduced by the
-   bootstrap manifest.
-7. Create or await a backup. Confirm it attempts all three ZFS volume snapshots
-   and that R2 contains a non-empty data stream plus its metadata object for each
-   PVC. Record exact object names, sizes, and the backup revision without
-   exposing library metadata.
-
-Open the draft PR immediately after steps 1 through 6. Backup verification may
-finish while the draft and Buildkite checks run, but it must be added to the PR
-before the PR is marked ready.
+1. The namespace exists, the `OnePasswordItem` reconciled, all three PVCs are
+   Bound with backup-enabled labels, and the Deployment rollout completed.
+2. The auth init container exited successfully, and neither its output nor the
+   Stash logs contain secret values.
+3. The Tailscale ingress received its MagicDNS address and a valid TLS
+   certificate, and the service is unreachable with Tailscale disabled.
+4. `/healthz` returns success without credentials while `/` redirects to
+   `/login` for a new session.
+5. An incorrect password is rejected, the 1Password password succeeds, logout
+   removes access, and a fresh browser session requires login.
+6. No Cloudflare tunnel, Funnel annotation, public DNS record, real library
+   data, scan path, or scraper credential reached the cluster.
+7. A backup attempted all three ZFS volume snapshots, and R2 holds a non-empty
+   data stream plus its metadata object for each PVC. Exact object names, sizes,
+   and the backup revision are recorded without library metadata.
 
 ### PR publication and GitOps adoption
 
@@ -436,31 +422,27 @@ temporary encryption risk.
 
 ## Rollout and Rollback
 
-The rollout has two explicit ownership states:
+Steady state is the only durable rollout mechanism: the merged internal chart
+and root `apps` Application create the `stash` Application, it adopts the exact
+existing resources, and Git plus ArgoCD become the only mutation path. Roll back
+the image or configuration through Git and let ArgoCD reconcile it. Never return
+to `stash-bootstrap` direct apply.
 
-1. **Bootstrap:** the committed and hashed Stash manifest is applied directly
-   with field manager `stash-bootstrap`; no ArgoCD Application exists yet.
-2. **Steady state:** the merged internal chart and root app create the Stash
-   Application, which adopts the exact resources; Git and ArgoCD become the only
-   mutation path.
+The closed bootstrap left the cluster in a transitional state that adoption
+resolves. It is a state to exit, not a rollout mode to re-enter.
 
 The first certificate request can be slow while the Tailscale operator obtains
 the certificate, so distinguish that known startup condition from a failing
-workload. Do not create the PR until the direct workload itself is Ready and
-authentication works, but do not wait for the first scheduled backup before
-opening the draft.
+workload.
 
-Before ArgoCD adoption, an application regression may be contained by scaling
-the Stash Deployment to zero. Preserve the namespace, PVCs, and 1Password item.
-Record any imperative containment in the PR and make the committed desired state
-match before resuming. Do not delete stateful resources as routine rollback.
-
-After ArgoCD adoption, roll back the image or configuration through Git and let
-ArgoCD reconcile it. Never return to `stash-bootstrap` direct apply. If the PR is
-delayed or rejected, explicitly choose whether to keep the documented temporary
-deployment or scale it to zero; do not leave its unmanaged status unstated. Any
-resource or data deletion requires a fresh exact inventory and explicit
-destructive approval.
+Until adoption completes, an application regression may be contained by scaling
+the Stash Deployment to zero. Preserve the namespace, PVCs, and 1Password item,
+record any imperative containment in the PR, and make the committed desired
+state match before resuming. If this PR is delayed or rejected, explicitly
+choose whether to keep the documented temporary deployment or scale it to zero;
+do not leave its unmanaged status unstated. Do not delete stateful resources as
+routine rollback — any resource or data deletion requires a fresh exact
+inventory and explicit destructive approval.
 
 ## Remaining
 
@@ -545,3 +527,11 @@ destructive approval.
   advisory already failing current-main build #8941. The dependent review and
   deployment-dry-run jobs were canceled, so the PR remains draft pending the
   independent main-branch repair and a fresh green build.
+- 2026-08-11 — Review findings on PR #2109 addressed. The plan now presents
+  ArgoCD reconciliation of the committed chart and Application as the deployment
+  mechanism, and the one-time direct apply as a closed exception recorded for
+  evidence. The instruction to reapply `stash.k8s.yaml` directly when review
+  changes the manifest was removed; review changes now reach the cluster only
+  through merge and ArgoCD. The wiki explanation page lost its rollout-state
+  section, which was workflow history rather than enduring security rationale,
+  and that material lives here instead.

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
@@ -28,13 +28,20 @@ flowchart LR
 Tailscale limits network reachability to enrolled devices. It does not prove
 that the person using an unlocked device should see this service.
 
-Stash's credentials add an application session boundary. They are written into
-the persistent configuration before the app starts, so there is no first-run
-window without authentication.
+Stash's credentials add an application session boundary. An
+[init container](https://github.com/shepherdjerred/monorepo/blob/308f68a33ce0e6afe26606c5d2fb13c1b82ef1f2/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L33-L45)
+writes the username and bcrypt hash into `/state/config.yml` before Stash
+starts, so there is no first-run window without authentication.
 
-The plaintext password remains in 1Password for operator access. The workload
-receives only the username and bcrypt hash through an init container. The main
-container receives neither credential field.
+The [Stash container](https://github.com/shepherdjerred/monorepo/blob/308f68a33ce0e6afe26606c5d2fb13c1b82ef1f2/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L182-L205)
+mounts that same `/state` volume and points `STASH_CONFIG_FILE` at that file. It
+therefore reads both credential fields; it must, to verify a login.
+
+What it never receives is the plaintext password or the Kubernetes Secret. The
+plaintext stays in 1Password for operator access and is never written to disk.
+Only the init container reads the Secret, and only its `username` and
+`password_hash` fields. A cost-10 bcrypt hash is not a reusable credential, so
+its presence on the state volume is a far weaker exposure than the password.
 
 ## Why storage is isolated
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
@@ -29,20 +29,20 @@ Tailscale limits network reachability to enrolled devices. It does not prove
 that the person using an unlocked device should see this service.
 
 Stash's credentials add an application session boundary. An
-[init container](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L36-L56)
+[init container](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L36-L56)
 writes the username and bcrypt hash into `/state/config.yml` before Stash
 starts, so there is no first-run window without authentication.
 
-The [Stash container](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L193-L216)
+The [Stash container](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L193-L216)
 mounts that same `/state` volume and points `STASH_CONFIG_FILE` at that file. It
 therefore reads both credential fields; it must, to verify a login.
 
 Neither container receives the plaintext password, but it is not confined to
 1Password. The
-[`OnePasswordItem`](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L74-L83)
+[`OnePasswordItem`](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L74-L83)
 syncs the whole Login item into a Kubernetes Secret, so the plaintext lands in
 cluster state and, by default, in etcd. The two
-[`secretKeyRef`s](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L138-L147)
+[`secretKeyRef`s](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L138-L147)
 only narrow what the init container reads: `username` and `password_hash`.
 
 So the boundary is that no container reads the plaintext into its environment or
@@ -57,8 +57,16 @@ The service does not reuse the broad media namespace or its shared claims.
 Configuration, generated assets, and the personal library have distinct volume
 lifecycles and capacity profiles.
 
-All three claims are listed explicitly in the backup inventory. This makes
-missing coverage a synthesis failure instead of an operational assumption.
+All three claims are listed explicitly in the
+[backup inventory](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json#L356-L373).
+The two ZFS volume constructs,
+[NVMe](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/misc/zfs-nvme-volume.ts#L33)
+and
+[SATA](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/misc/zfs-sata-volume.ts#L33),
+look their claim up as the chart is built. That lookup
+[throws on an unlisted claim](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.ts#L41-L54).
+Missing coverage is therefore a synthesis failure, not an operational
+assumption.
 
 Phase one protects recoverability, not confidentiality at rest. The local ZFS
 datasets and backup stream retain the homelab's existing unencrypted posture.
@@ -67,7 +75,7 @@ key-recovery design that preserves the initial recovery points.
 
 ## Where to look
 
-- Workload boundary: `src/cdk8s/src/resources/stash/`
-- ArgoCD ownership: `src/cdk8s/src/resources/argo-applications/stash.ts`
-- Backup inventory: `src/cdk8s/src/backup-policy/pvc-backup-policy.json`
-- Deployment decisions: `packages/docs/plans/2026-08-10_stash-tailnet-deployment.md`
+- [Workload boundary](https://github.com/shepherdjerred/monorepo/tree/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/resources/stash)
+- [ArgoCD ownership](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/resources/argo-applications/stash.ts)
+- [Backup policy and its enforcement](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.ts)
+- [Deployment decisions](https://github.com/shepherdjerred/monorepo/blob/808643e192b14d4c9ec14b3c664f099407c07fd1/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md)

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
@@ -1,0 +1,67 @@
+---
+title: Why Stash has two access barriers
+description: Stash combines a tailnet-only route with built-in credentials because network identity and application authentication cover different failures.
+---
+
+Stash is a private media organizer with two independent access barriers. The
+tailnet controls who can reach it, while built-in credentials control who can
+open the application.
+
+```mermaid
+flowchart LR
+  accTitle: Stash access and persistence boundaries
+  accDescr: A tailnet member reaches the private Tailscale ingress over HTTPS, then signs in through Stash's built-in authentication. Stash keeps durable state, generated assets, and the personal media library on three isolated ZFS volumes. Velero protects each volume.
+
+  USER[Tailnet member] -->|private HTTPS| TS[Tailscale ingress]
+  TS --> AUTH[Built-in authentication]
+  AUTH --> APP[Stash]
+  APP --> STATE[(State)]
+  APP --> GEN[(Generated assets)]
+  APP --> MEDIA[(Personal media library)]
+  STATE --> BACKUP[Velero backups]
+  GEN --> BACKUP
+  MEDIA --> BACKUP
+```
+
+## Why the barriers are separate
+
+Tailscale limits network reachability to enrolled devices. It does not prove
+that the person using an unlocked device should see this service.
+
+Stash's credentials add an application session boundary. They are written into
+the persistent configuration before the app starts, so there is no first-run
+window without authentication.
+
+The plaintext password remains in 1Password for operator access. The workload
+receives only the username and bcrypt hash through an init container. The main
+container receives neither credential field.
+
+## Why storage is isolated
+
+The service does not reuse the broad media namespace or its shared claims.
+Configuration, generated assets, and the personal library have distinct volume
+lifecycles and capacity profiles.
+
+All three claims are listed explicitly in the backup inventory. This makes
+missing coverage a synthesis failure instead of an operational assumption.
+
+Phase one protects recoverability, not confidentiality at rest. The local ZFS
+datasets and backup stream retain the homelab's existing unencrypted posture.
+That risk is temporary and explicit; encryption needs a separate migration and
+key-recovery design that preserves the initial recovery points.
+
+## Why the first deployment is exceptional
+
+The workload is bootstrapped once from the exact synthesized chart manifest so
+its private access and authentication can be accepted before review. The same
+change also defines the internal chart and ArgoCD Application.
+
+After the chart is published and ArgoCD adopts the resources, direct apply is
+no longer an ownership path. Later changes use the normal release flow.
+
+## Where to look
+
+- Workload boundary: `src/cdk8s/src/resources/stash/`
+- ArgoCD ownership: `src/cdk8s/src/resources/argo-applications/stash.ts`
+- Backup inventory: `src/cdk8s/src/backup-policy/pvc-backup-policy.json`
+- Deployment decisions: `packages/docs/plans/2026-08-10_stash-tailnet-deployment.md`

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
@@ -50,15 +50,6 @@ datasets and backup stream retain the homelab's existing unencrypted posture.
 That risk is temporary and explicit; encryption needs a separate migration and
 key-recovery design that preserves the initial recovery points.
 
-## Why the first deployment is exceptional
-
-The workload is bootstrapped once from the exact synthesized chart manifest so
-its private access and authentication can be accepted before review. The same
-change also defines the internal chart and ArgoCD Application.
-
-After the chart is published and ArgoCD adopts the resources, direct apply is
-no longer an ownership path. Later changes use the normal release flow.
-
 ## Where to look
 
 - Workload boundary: `src/cdk8s/src/resources/stash/`

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/stash-security-boundary.md
@@ -29,19 +29,27 @@ Tailscale limits network reachability to enrolled devices. It does not prove
 that the person using an unlocked device should see this service.
 
 Stash's credentials add an application session boundary. An
-[init container](https://github.com/shepherdjerred/monorepo/blob/308f68a33ce0e6afe26606c5d2fb13c1b82ef1f2/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L33-L45)
+[init container](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L36-L56)
 writes the username and bcrypt hash into `/state/config.yml` before Stash
 starts, so there is no first-run window without authentication.
 
-The [Stash container](https://github.com/shepherdjerred/monorepo/blob/308f68a33ce0e6afe26606c5d2fb13c1b82ef1f2/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L182-L205)
+The [Stash container](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L193-L216)
 mounts that same `/state` volume and points `STASH_CONFIG_FILE` at that file. It
 therefore reads both credential fields; it must, to verify a login.
 
-What it never receives is the plaintext password or the Kubernetes Secret. The
-plaintext stays in 1Password for operator access and is never written to disk.
-Only the init container reads the Secret, and only its `username` and
-`password_hash` fields. A cost-10 bcrypt hash is not a reusable credential, so
-its presence on the state volume is a far weaker exposure than the password.
+Neither container receives the plaintext password, but it is not confined to
+1Password. The
+[`OnePasswordItem`](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L74-L83)
+syncs the whole Login item into a Kubernetes Secret, so the plaintext lands in
+cluster state and, by default, in etcd. The two
+[`secretKeyRef`s](https://github.com/shepherdjerred/monorepo/blob/1411519de79ea54045b15146892a24a1d461490b/packages/homelab/src/cdk8s/src/resources/stash/index.ts#L138-L147)
+only narrow what the init container reads: `username` and `password_hash`.
+
+So the boundary is that no container reads the plaintext into its environment or
+filesystem, not that the plaintext never left 1Password. Anything able to read
+Secrets in the `stash` namespace can still recover it. A cost-10 bcrypt hash is
+not a reusable credential, so the hash on the state volume stays a far weaker
+exposure.
 
 ## Why storage is isolated
 

--- a/packages/homelab/src/cdk8s/helm/stash/Chart.yaml
+++ b/packages/homelab/src/cdk8s/helm/stash/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: stash
+description: Private media organizer deployed from the homelab CDK8s chart.
+type: application
+version: "$version"
+appVersion: "$appVersion"

--- a/packages/homelab/src/cdk8s/helm/stash/values.yaml
+++ b/packages/homelab/src/cdk8s/helm/stash/values.yaml
@@ -1,0 +1,1 @@
+# Defaults are emitted by CDK8s.

--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-10T03:05:08.972Z",
+  "generatedAt": "2026-08-11T02:11:02.518Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -288,6 +288,18 @@
         "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
         "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
       ]
+    },
+    {
+      "ref": "4b182eb238fb3d517ea2531e1cff821235903c243d2a96fac5a7587b1ad1ae93",
+      "title": "2c70237f50de15d265e68ea22d398935fc1efe72f1c8d15824fa9a2f69a12c0b",
+      "fields": [
+        "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
+        "9184f6c1db63dd3d386e26969a485b31a80c0bc1d1d59663dfc3cefd0a61074d",
+        "f810b7c679ab40b8641090751481092a328543ff54d33cb5840ede24ba64f02c"
+      ],
+      "blankFields": []
     },
     {
       "ref": "4dabe017357def248053bef95eb93afcad5027750a6d766d83f3dfca92854fc4",

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
@@ -354,6 +354,24 @@
     "reason": "SeaweedFS data is intentionally outside Velero volume backup"
   },
   {
+    "namespace": "stash",
+    "name": "stash-generated",
+    "backup": "enabled",
+    "reason": "Stash generated media assets"
+  },
+  {
+    "namespace": "stash",
+    "name": "stash-media",
+    "backup": "enabled",
+    "reason": "Personal media library"
+  },
+  {
+    "namespace": "stash",
+    "name": "stash-state",
+    "backup": "enabled",
+    "reason": "Stash configuration, database, and metadata"
+  },
+  {
     "namespace": "starlight-karma-bot-beta",
     "name": "starlight-karma-bot-storage-claim",
     "backup": "enabled",

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -76,15 +76,15 @@ afterEach(async () => {
 });
 
 describe("PVC backup policy", () => {
-  it("classifies 47 included and 23 excluded PVCs without duplicates", () => {
+  it("classifies 50 included and 23 excluded PVCs without duplicates", () => {
     const keys = PVC_BACKUP_POLICY.map((entry) =>
       pvcBackupPolicyKey(entry.namespace, entry.name),
     );
-    expect(keys).toHaveLength(70);
-    expect(new Set(keys).size).toBe(70);
+    expect(keys).toHaveLength(73);
+    expect(new Set(keys).size).toBe(73);
     expect(
       PVC_BACKUP_POLICY.filter((entry) => entry.backup === "enabled"),
-    ).toHaveLength(47);
+    ).toHaveLength(50);
     expect(
       PVC_BACKUP_POLICY.filter((entry) => entry.backup === "disabled"),
     ).toHaveLength(23);

--- a/packages/homelab/src/cdk8s/src/capacity-remediation.test.ts
+++ b/packages/homelab/src/cdk8s/src/capacity-remediation.test.ts
@@ -305,6 +305,7 @@ function assertTailscaleSizing(documents: readonly unknown[]): void {
     "media/media-bindery-tailscale-ingress-ingress": "medium",
     "pinchtab/pinchtab-pinchtab-tailscale-ingress-ingress": "medium",
     "mcp-gateway/mcp-gateway-mcp-gateway-ingress-ingress": "medium",
+    "stash/stash-stash-ingress-ingress": "medium",
     "turbo-cache/turbo-cache-turbo-cache-tailscale-ingress-ingress": "medium",
   });
 }

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -67,6 +67,7 @@ import { createTurboCacheApp } from "@shepherdjerred/homelab/cdk8s/src/resources
 import { createBuildkitdApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/buildkitd.ts";
 import { createTrackerTrackerApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/tracker-tracker.ts";
 import { createAlertDashboardApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/alert-dashboard.ts";
+import { createStashApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/stash.ts";
 import { createPvcBackupAdmissionPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
 
 export async function createAppsChart(app: App) {
@@ -177,6 +178,7 @@ export async function createAppsChart(app: App) {
   createBuildkitdApp(chart);
   createTrackerTrackerApp(chart);
   createAlertDashboardApp(chart);
+  createStashApp(chart);
 
   // ArgoCD AppProject
   createProject(chart);

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/stash.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/stash.ts
@@ -1,0 +1,17 @@
+import type { App } from "cdk8s";
+import { Chart } from "cdk8s";
+import { Namespace } from "cdk8s-plus-31";
+import { createStashDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/stash/index.ts";
+
+export function createStashChart(app: App) {
+  const chart = new Chart(app, "stash", {
+    namespace: "stash",
+    disableResourceNameHashes: true,
+  });
+
+  new Namespace(chart, "stash-namespace", {
+    metadata: { name: "stash" },
+  });
+
+  createStashDeployment(chart);
+}

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/stash.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/stash.ts
@@ -1,0 +1,25 @@
+import type { Chart } from "cdk8s";
+import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
+
+export function createStashApp(chart: Chart) {
+  return new Application(chart, "stash-app", {
+    metadata: { name: "stash" },
+    spec: {
+      revisionHistoryLimit: 5,
+      project: "default",
+      source: {
+        repoUrl: "https://chartmuseum.tailnet-1a49.ts.net",
+        targetRevision: "~2.0.0-0",
+        chart: "stash",
+      },
+      destination: {
+        server: "https://kubernetes.default.svc",
+        namespace: "stash",
+      },
+      syncPolicy: {
+        automated: {},
+        syncOptions: ["CreateNamespace=true"],
+      },
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
@@ -52,6 +52,7 @@ const ContainerSchema = z
   .object({
     name: z.string(),
     image: z.string(),
+    command: z.array(z.string()).optional(),
     args: z.array(z.string()).optional(),
     env: z.array(EnvSchema),
     startupProbe: z.unknown().optional(),
@@ -63,6 +64,8 @@ const ContainerSchema = z
         allowPrivilegeEscalation: z.literal(false),
         privileged: z.literal(false),
         readOnlyRootFilesystem: z.literal(true),
+        capabilities: z.object({ drop: z.tuple([z.literal("ALL")]) }),
+        seccompProfile: z.object({ type: z.literal("RuntimeDefault") }),
       })
       .loose(),
     volumeMounts: z.array(
@@ -171,6 +174,7 @@ describe("Stash chart", () => {
     expect(appContainer.image).toBe(
       "stashapp/stash:v0.31.1@sha256:df744af5a0c976e2ec671052ecc1f8a9aa757fa12b8f9930b59910b7295f0da6",
     );
+    expect(appContainer.command).toEqual(["stash"]);
     expect(appContainer.args).toEqual(["--nobrowser"]);
     expect(
       appContainer.env.every(({ valueFrom }) => valueFrom === undefined),

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
@@ -13,6 +13,26 @@ const ManifestSchema = z
   })
   .loose();
 
+const VALID_HASH = `$2a$10$${"a".repeat(53)}`;
+
+// Runs the real init script so the credential guards are proven, not just matched
+// as text. Every case here fails before the script reaches /state, so no test
+// touches the filesystem.
+async function runAuthInitScript(
+  env: Record<string, string>,
+): Promise<{ exitCode: number; stderr: string }> {
+  const proc = Bun.spawn(["sh", "-c", STASH_AUTH_INIT_SCRIPT], {
+    env: { PATH: Bun.env["PATH"] ?? "", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stderr).text(),
+  ]);
+  return { exitCode, stderr };
+}
+
 function synthesize(): unknown[] {
   const app = new App();
   createStashChart(app);
@@ -221,6 +241,28 @@ describe("Stash chart", () => {
       requests: { cpu: "250m", memory: "512Mi" },
     });
   });
+
+  it.each([
+    ["username holding a newline", "admin\nevil_key: injected", VALID_HASH],
+    [
+      "username smuggling a closing quote",
+      'admin\n": 1\nevil_key: "x',
+      VALID_HASH,
+    ],
+    ["username holding a carriage return", "admin\radmin2", VALID_HASH],
+    ["username holding a tab", "ad\tmin", VALID_HASH],
+    ["hash holding a newline", "admin", `${VALID_HASH}\nevil_key: injected`],
+  ])(
+    "refuses to write config.yml when the %s",
+    async (_case, username, passwordHash) => {
+      const { exitCode, stderr } = await runAuthInitScript({
+        STASH_USERNAME: username,
+        STASH_PASSWORD_HASH: passwordHash,
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("must not contain control characters");
+    },
+  );
 
   it("keeps ingress on Tailscale and restricts traffic to required paths", () => {
     const manifests = synthesize();

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { z } from "zod";
+import { createStashChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/stash.ts";
+import { STASH_AUTH_INIT_SCRIPT } from "@shepherdjerred/homelab/cdk8s/src/resources/stash/index.ts";
+import { createStashApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/stash.ts";
+import { applyApplicationReleasePolicy } from "@shepherdjerred/homelab/cdk8s/src/application-release-policy.ts";
+
+const ManifestSchema = z
+  .object({
+    kind: z.string(),
+    metadata: z.object({ name: z.string() }).loose(),
+  })
+  .loose();
+
+function synthesize(): unknown[] {
+  const app = new App();
+  createStashChart(app);
+  return z.array(z.unknown()).parse(app.charts.at(0)?.toJson());
+}
+
+function findManifest(
+  manifests: unknown[],
+  kind: string,
+  name: string,
+): unknown {
+  const manifest = manifests.find((candidate) => {
+    const parsed = ManifestSchema.safeParse(candidate);
+    return (
+      parsed.success &&
+      parsed.data.kind === kind &&
+      parsed.data.metadata.name === name
+    );
+  });
+  if (manifest === undefined)
+    throw new Error(`Missing ${kind}/${name} manifest`);
+  return manifest;
+}
+
+const EnvSchema = z.object({
+  name: z.string(),
+  value: z.string().optional(),
+  valueFrom: z
+    .object({
+      secretKeyRef: z.object({ name: z.string(), key: z.string() }).loose(),
+    })
+    .loose()
+    .optional(),
+});
+
+const ContainerSchema = z
+  .object({
+    name: z.string(),
+    image: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.array(EnvSchema),
+    startupProbe: z.unknown().optional(),
+    readinessProbe: z.unknown().optional(),
+    livenessProbe: z.unknown().optional(),
+    resources: z.unknown(),
+    securityContext: z
+      .object({
+        allowPrivilegeEscalation: z.literal(false),
+        privileged: z.literal(false),
+        readOnlyRootFilesystem: z.literal(true),
+      })
+      .loose(),
+    volumeMounts: z.array(
+      z.object({ mountPath: z.string(), name: z.string() }).loose(),
+    ),
+  })
+  .loose();
+
+describe("Stash chart", () => {
+  it("emits the isolated service and three backup-enabled PVCs", () => {
+    const manifests = synthesize();
+    const names = new Set(
+      manifests.map((manifest) => {
+        const parsed = ManifestSchema.parse(manifest);
+        return `${parsed.kind}/${parsed.metadata.name}`;
+      }),
+    );
+
+    expect(names).toEqual(
+      new Set([
+        "Namespace/stash",
+        "OnePasswordItem/stash-stash-credentials",
+        "PersistentVolumeClaim/stash-state",
+        "PersistentVolumeClaim/stash-generated",
+        "PersistentVolumeClaim/stash-media",
+        "Deployment/stash",
+        "Service/stash-stash-service",
+        "Ingress/stash-stash-ingress-ingress",
+        "NetworkPolicy/stash-network-policy",
+      ]),
+    );
+
+    const expectedClaims = new Map<string, [string, string]>([
+      ["stash-state", ["64Gi", "zfs-ssd"]],
+      ["stash-generated", ["256Gi", "zfs-hdd"]],
+      ["stash-media", ["1024Gi", "zfs-hdd"]],
+    ]);
+    for (const [name, [storage, storageClassName]] of expectedClaims) {
+      const pvc = z
+        .object({
+          metadata: z.object({
+            labels: z
+              .object({
+                "velero.io/backup": z.literal("enabled"),
+                "velero.io/exclude-from-backup": z.literal("false"),
+              })
+              .loose(),
+          }),
+          spec: z.object({
+            storageClassName: z.string(),
+            resources: z.object({
+              requests: z.object({ storage: z.string() }),
+            }),
+          }),
+        })
+        .parse(findManifest(manifests, "PersistentVolumeClaim", name));
+      expect(pvc.spec.resources.requests.storage).toBe(storage);
+      expect(pvc.spec.storageClassName).toBe(storageClassName);
+    }
+  });
+
+  it("configures built-in authentication before starting the app", () => {
+    const deployment = z
+      .object({
+        spec: z.object({
+          strategy: z.object({ type: z.literal("Recreate") }),
+          template: z.object({
+            spec: z.object({
+              automountServiceAccountToken: z.literal(false),
+              initContainers: z.array(ContainerSchema),
+              containers: z.array(ContainerSchema),
+            }),
+          }),
+        }),
+      })
+      .parse(findManifest(synthesize(), "Deployment", "stash"));
+
+    const initContainer = deployment.spec.template.spec.initContainers.at(0);
+    if (initContainer === undefined)
+      throw new Error("Missing authentication init container");
+    expect(initContainer.name).toBe("configure-auth");
+    expect(initContainer.args).toEqual([STASH_AUTH_INIT_SCRIPT]);
+    expect(STASH_AUTH_INIT_SCRIPT).toContain(
+      "grep -Eq '^[$]2[aby][$]10[$][./A-Za-z0-9]{53}$'",
+    );
+    expect(STASH_AUTH_INIT_SCRIPT).toContain("awk '!/^(username|password):/'");
+    expect(STASH_AUTH_INIT_SCRIPT).toContain(
+      "mv /state/config.yml.next /state/config.yml",
+    );
+    expect(
+      initContainer.env.map(({ name, valueFrom }) => ({
+        name,
+        secretKey: valueFrom?.secretKeyRef.key,
+      })),
+    ).toEqual([
+      { name: "TZ", secretKey: undefined },
+      { name: "STASH_USERNAME", secretKey: "username" },
+      { name: "STASH_PASSWORD_HASH", secretKey: "password_hash" },
+    ]);
+    expect(
+      initContainer.volumeMounts.map(({ mountPath }) => mountPath),
+    ).toEqual(["/state"]);
+
+    const appContainer = deployment.spec.template.spec.containers.at(0);
+    if (appContainer === undefined) throw new Error("Missing app container");
+    expect(appContainer.image).toBe(
+      "stashapp/stash:v0.31.1@sha256:df744af5a0c976e2ec671052ecc1f8a9aa757fa12b8f9930b59910b7295f0da6",
+    );
+    expect(appContainer.args).toEqual(["--nobrowser"]);
+    expect(
+      appContainer.env.every(({ valueFrom }) => valueFrom === undefined),
+    ).toBe(true);
+    expect(appContainer.volumeMounts.map(({ mountPath }) => mountPath)).toEqual(
+      ["/state", "/generated", "/data", "/cache", "/tmp"],
+    );
+    expect(
+      Object.fromEntries(
+        appContainer.env.map(({ name, value }) => [name, value]),
+      ),
+    ).toEqual({
+      TZ: "America/Los_Angeles",
+      STASH_CONFIG_FILE: "/state/config.yml",
+      STASH_STASH: "/data/",
+      STASH_METADATA: "/state/metadata/",
+      STASH_BLOBS: "/state/blobs/",
+      STASH_GENERATED: "/generated/",
+      STASH_CACHE: "/cache/",
+      STASH_PORT: "9999",
+    });
+    const ProbeSchema = z.object({
+      failureThreshold: z.number(),
+      periodSeconds: z.number(),
+      httpGet: z.object({ path: z.literal("/healthz"), port: z.literal(9999) }),
+    });
+    expect(ProbeSchema.parse(appContainer.startupProbe)).toEqual({
+      failureThreshold: 60,
+      periodSeconds: 5,
+      httpGet: { path: "/healthz", port: 9999 },
+    });
+    expect(ProbeSchema.parse(appContainer.readinessProbe)).toEqual({
+      failureThreshold: 3,
+      periodSeconds: 10,
+      httpGet: { path: "/healthz", port: 9999 },
+    });
+    expect(ProbeSchema.parse(appContainer.livenessProbe)).toEqual({
+      failureThreshold: 3,
+      periodSeconds: 30,
+      httpGet: { path: "/healthz", port: 9999 },
+    });
+    expect(appContainer.resources).toEqual({
+      limits: { cpu: "4", memory: "4096Mi" },
+      requests: { cpu: "250m", memory: "512Mi" },
+    });
+  });
+
+  it("keeps ingress on Tailscale and restricts traffic to required paths", () => {
+    const manifests = synthesize();
+    const ingress = z
+      .object({
+        metadata: z.object({
+          labels: z.object({
+            "tailscale.com/proxy-class": z.literal("medium"),
+          }),
+        }),
+        spec: z.object({
+          ingressClassName: z.literal("tailscale"),
+          tls: z.array(
+            z.object({ hosts: z.array(z.literal("stash")) }).loose(),
+          ),
+        }),
+      })
+      .parse(findManifest(manifests, "Ingress", "stash-stash-ingress-ingress"));
+    expect(ingress.spec.tls).toHaveLength(1);
+
+    const policy = z
+      .object({
+        spec: z.object({
+          podSelector: z.object({
+            matchLabels: z.object({ app: z.literal("stash") }),
+          }),
+          policyTypes: z.tuple([z.literal("Ingress"), z.literal("Egress")]),
+          ingress: z.array(z.unknown()),
+          egress: z.array(z.unknown()),
+        }),
+      })
+      .parse(findManifest(manifests, "NetworkPolicy", "stash-network-policy"));
+    expect(policy.spec.ingress).toHaveLength(1);
+    expect(policy.spec.egress).toHaveLength(2);
+  });
+});
+
+describe("Stash ArgoCD application", () => {
+  it("defines durable ownership with prune-safe lifecycle metadata", () => {
+    const app = new App();
+    const chart = new Chart(app, "apps", {
+      namespace: "argocd",
+      disableResourceNameHashes: true,
+    });
+    createStashApp(chart);
+    applyApplicationReleasePolicy(app);
+
+    const application = z
+      .object({
+        metadata: z.object({
+          name: z.literal("stash"),
+          annotations: z.object({
+            "ci.sjer.red/application-lifecycle": z.literal("cascade"),
+          }),
+          finalizers: z.tuple([
+            z.literal("resources-finalizer.argocd.argoproj.io"),
+          ]),
+        }),
+        spec: z.object({
+          destination: z.object({
+            namespace: z.literal("stash"),
+            server: z.literal("https://kubernetes.default.svc"),
+          }),
+          source: z.object({
+            chart: z.literal("stash"),
+            repoURL: z.literal("https://chartmuseum.tailnet-1a49.ts.net"),
+            targetRevision: z.literal("~2.0.0-0"),
+          }),
+          syncPolicy: z.object({
+            syncOptions: z.tuple([z.literal("CreateNamespace=true")]),
+          }),
+        }),
+      })
+      .parse(findManifest(chart.toJson(), "Application", "stash"));
+    expect(application.metadata.name).toBe("stash");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.ts
@@ -30,8 +30,19 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 const PORT = 9999;
 const LABELS = { app: "stash" };
 
+// grep is line-oriented, so an anchored pattern matches when any single line of a
+// multiline value matches. Reject control characters first, or the unvalidated
+// remainder of such a value is interpolated straight into config.yml as YAML.
 export const STASH_AUTH_INIT_SCRIPT = String.raw`set -eu
 umask 077
+reject_control_chars() {
+  if test "$(printf '%s' "$2" | tr -cd '[:cntrl:]' | wc -c)" -ne 0; then
+    echo "stash auth: $1 must not contain control characters" >&2
+    exit 1
+  fi
+}
+reject_control_chars STASH_USERNAME "$STASH_USERNAME"
+reject_control_chars STASH_PASSWORD_HASH "$STASH_PASSWORD_HASH"
 printf '%s\n' "$STASH_USERNAME" | grep -Eq '^[A-Za-z0-9._-]+$'
 printf '%s\n' "$STASH_PASSWORD_HASH" | grep -Eq '^[$]2[aby][$]10[$][./A-Za-z0-9]{53}$'
 mkdir -p /state

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.ts
@@ -1,11 +1,13 @@
 import type { Chart } from "cdk8s";
 import { Duration, Size } from "cdk8s";
 import {
+  Capability,
   Cpu,
   Deployment,
   DeploymentStrategy,
   EnvValue,
   Probe,
+  SeccompProfileType,
   Secret,
   Service,
   Volume,
@@ -141,6 +143,8 @@ export function createStashDeployment(chart: Chart) {
         readOnlyRootFilesystem: true,
         allowPrivilegeEscalation: false,
         privileged: false,
+        capabilities: { drop: [Capability.ALL] },
+        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
       },
       volumeMounts: [{ path: "/state", volume: stateVolume }],
     }),
@@ -150,6 +154,7 @@ export function createStashDeployment(chart: Chart) {
     withCommonProps({
       name: "stash",
       image: `stashapp/stash:${versions["stashapp/stash"]}`,
+      command: ["stash"],
       args: ["--nobrowser"],
       ports: [{ number: PORT, name: "http" }],
       startup: Probe.fromHttpGet("/healthz", {
@@ -188,6 +193,8 @@ export function createStashDeployment(chart: Chart) {
         readOnlyRootFilesystem: true,
         allowPrivilegeEscalation: false,
         privileged: false,
+        capabilities: { drop: [Capability.ALL] },
+        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
       },
       volumeMounts: [
         { path: "/state", volume: stateVolume },

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.ts
@@ -1,0 +1,253 @@
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  EnvValue,
+  Probe,
+  Secret,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import {
+  IntOrString,
+  KubeNetworkPolicy,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
+import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
+import { ZfsSataVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-sata-volume.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+const PORT = 9999;
+const LABELS = { app: "stash" };
+
+export const STASH_AUTH_INIT_SCRIPT = String.raw`set -eu
+umask 077
+printf '%s\n' "$STASH_USERNAME" | grep -Eq '^[A-Za-z0-9._-]+$'
+printf '%s\n' "$STASH_PASSWORD_HASH" | grep -Eq '^[$]2[aby][$]10[$][./A-Za-z0-9]{53}$'
+mkdir -p /state
+if test -f /state/config.yml; then
+  awk '!/^(username|password):/' /state/config.yml > /state/config.yml.next
+else
+  : > /state/config.yml.next
+fi
+printf 'username: "%s"\npassword: "%s"\n' "$STASH_USERNAME" "$STASH_PASSWORD_HASH" >> /state/config.yml.next
+mv /state/config.yml.next /state/config.yml
+chmod 600 /state/config.yml`;
+
+function createDnsEgress() {
+  return {
+    to: [
+      {
+        namespaceSelector: {},
+        podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+      },
+    ],
+    ports: [
+      { port: IntOrString.fromNumber(53), protocol: "UDP" },
+      { port: IntOrString.fromNumber(53), protocol: "TCP" },
+    ],
+  };
+}
+
+export function createStashDeployment(chart: Chart) {
+  const credentialsItem = new OnePasswordItem(chart, "stash-credentials", {
+    spec: {
+      itemPath: vaultItemPath("yo6duoxqos4sktcs5ogj54vbdu"),
+    },
+  });
+  const credentials = Secret.fromSecretName(
+    chart,
+    "stash-credentials-secret",
+    credentialsItem.name,
+  );
+
+  const stateClaim = new ZfsNvmeVolume(chart, "stash-state", {
+    storage: Size.gibibytes(64),
+  });
+  const generatedClaim = new ZfsSataVolume(chart, "stash-generated", {
+    storage: Size.gibibytes(256),
+  });
+  const mediaClaim = new ZfsSataVolume(chart, "stash-media", {
+    storage: Size.tebibytes(1),
+  });
+
+  const stateVolume = Volume.fromPersistentVolumeClaim(
+    chart,
+    "stash-state-volume",
+    stateClaim.claim,
+  );
+  const generatedVolume = Volume.fromPersistentVolumeClaim(
+    chart,
+    "stash-generated-volume",
+    generatedClaim.claim,
+  );
+  const mediaVolume = Volume.fromPersistentVolumeClaim(
+    chart,
+    "stash-media-volume",
+    mediaClaim.claim,
+  );
+  const cacheVolume = Volume.fromEmptyDir(chart, "stash-cache", "cache", {
+    sizeLimit: Size.gibibytes(8),
+  });
+  const tmpVolume = Volume.fromEmptyDir(chart, "stash-tmp", "tmp", {
+    sizeLimit: Size.gibibytes(2),
+  });
+
+  const deployment = new Deployment(chart, "stash", {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    automountServiceAccountToken: false,
+    securityContext: { ensureNonRoot: false },
+    metadata: {
+      labels: LABELS,
+      annotations: {
+        "ignore-check.kube-linter.io/run-as-non-root":
+          "The upstream image runs as root; privileges and filesystem writes remain constrained.",
+      },
+    },
+    podMetadata: { labels: LABELS },
+  });
+
+  deployment.addInitContainer(
+    withCommonProps({
+      name: "configure-auth",
+      image: `library/busybox:${versions["library/busybox"]}`,
+      command: ["/bin/sh", "-c"],
+      args: [STASH_AUTH_INIT_SCRIPT],
+      envVariables: {
+        STASH_USERNAME: EnvValue.fromSecretValue({
+          secret: credentials,
+          key: "username",
+        }),
+        STASH_PASSWORD_HASH: EnvValue.fromSecretValue({
+          secret: credentials,
+          key: "password_hash",
+        }),
+      },
+      resources: {
+        cpu: { request: Cpu.millis(5), limit: Cpu.millis(50) },
+        memory: { request: Size.mebibytes(8), limit: Size.mebibytes(32) },
+      },
+      securityContext: {
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
+        privileged: false,
+      },
+      volumeMounts: [{ path: "/state", volume: stateVolume }],
+    }),
+  );
+
+  deployment.addContainer(
+    withCommonProps({
+      name: "stash",
+      image: `stashapp/stash:${versions["stashapp/stash"]}`,
+      args: ["--nobrowser"],
+      ports: [{ number: PORT, name: "http" }],
+      startup: Probe.fromHttpGet("/healthz", {
+        port: PORT,
+        periodSeconds: Duration.seconds(5),
+        failureThreshold: 60,
+      }),
+      readiness: Probe.fromHttpGet("/healthz", {
+        port: PORT,
+        periodSeconds: Duration.seconds(10),
+        failureThreshold: 3,
+      }),
+      liveness: Probe.fromHttpGet("/healthz", {
+        port: PORT,
+        periodSeconds: Duration.seconds(30),
+        failureThreshold: 3,
+      }),
+      resources: {
+        cpu: { request: Cpu.millis(250), limit: Cpu.units(4) },
+        memory: {
+          request: Size.mebibytes(512),
+          limit: Size.gibibytes(4),
+        },
+      },
+      envVariables: {
+        STASH_CONFIG_FILE: EnvValue.fromValue("/state/config.yml"),
+        STASH_STASH: EnvValue.fromValue("/data/"),
+        STASH_METADATA: EnvValue.fromValue("/state/metadata/"),
+        STASH_BLOBS: EnvValue.fromValue("/state/blobs/"),
+        STASH_GENERATED: EnvValue.fromValue("/generated/"),
+        STASH_CACHE: EnvValue.fromValue("/cache/"),
+        STASH_PORT: EnvValue.fromValue(String(PORT)),
+      },
+      securityContext: {
+        ensureNonRoot: false,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
+        privileged: false,
+      },
+      volumeMounts: [
+        { path: "/state", volume: stateVolume },
+        { path: "/generated", volume: generatedVolume },
+        { path: "/data", volume: mediaVolume },
+        { path: "/cache", volume: cacheVolume },
+        { path: "/tmp", volume: tmpVolume },
+      ],
+    }),
+  );
+
+  setRevisionHistoryLimit(deployment);
+
+  const service = new Service(chart, "stash-service", {
+    metadata: { labels: LABELS },
+    selector: deployment,
+    ports: [{ port: PORT, name: "http" }],
+  });
+
+  new TailscaleIngress(chart, "stash-ingress", {
+    service,
+    host: "stash",
+    proxyClass: "medium",
+    probePath: "/healthz",
+  });
+
+  new KubeNetworkPolicy(chart, "stash-network-policy", {
+    metadata: { name: "stash-network-policy" },
+    spec: {
+      podSelector: { matchLabels: LABELS },
+      policyTypes: ["Ingress", "Egress"],
+      ingress: [
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "tailscale" },
+              },
+            },
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "prometheus" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(PORT), protocol: "TCP" }],
+        },
+      ],
+      egress: [
+        createDnsEgress(),
+        {
+          to: [{ ipBlock: { cidr: "0.0.0.0/0" } }],
+          ports: [
+            { port: IntOrString.fromNumber(80), protocol: "TCP" },
+            { port: IntOrString.fromNumber(443), protocol: "TCP" },
+          ],
+        },
+      ],
+    },
+  });
+
+  return { deployment, service };
+}

--- a/packages/homelab/src/cdk8s/src/setup-charts.ts
+++ b/packages/homelab/src/cdk8s/src/setup-charts.ts
@@ -29,6 +29,7 @@ import { createTurboCacheChart } from "./cdk8s-charts/turbo-cache.ts";
 import { createBuildkitdChart } from "./cdk8s-charts/buildkitd.ts";
 import { createTrackerTrackerChart } from "./cdk8s-charts/tracker-tracker.ts";
 import { createAlertDashboardChart } from "./cdk8s-charts/alert-dashboard.ts";
+import { createStashChart } from "./cdk8s-charts/stash.ts";
 import { createServiceProbesChart } from "./resources/monitoring/service-probes-chart.ts";
 import { resetProbeRegistry } from "./misc/probe-registry.ts";
 import { applyApplicationReleasePolicy } from "./application-release-policy.ts";
@@ -82,6 +83,7 @@ export async function setupCharts(app: App): Promise<void> {
   createTurboCacheChart(app);
   createBuildkitdChart(app);
   createTrackerTrackerChart(app);
+  createStashChart(app);
 
   // Must run last: reads the probe registry populated by every
   // TailscaleIngress/createIngress/createCloudflareTunnelBinding call above.

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -1,6 +1,9 @@
 import { applyCurrentBuildImageOverrides } from "./release-configuration.ts";
 
 const versions = {
+  // renovate: datasource=docker registryUrl=https://docker.io versioning=semver
+  "stashapp/stash":
+    "v0.31.1@sha256:df744af5a0c976e2ec671052ecc1f8a9aa757fa12b8f9930b59910b7295f0da6",
   // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
   "jordanlambrecht/tracker-tracker":
     "2.8.9@sha256:27b93eb839812c7ccaf03b1024f31d23b5981f8fcc13257447e2082100b7a71c",


### PR DESCRIPTION
## Why

Provide a dedicated private media organizer with application credentials, Tailnet-only access, isolated storage, and explicit recovery coverage.

## What

- Add the pinned Stash workload in its own namespace with three dedicated PVCs, resource limits, health probes, restrictive network policy, and a Tailscale HTTPS ingress.
- Bootstrap Stash's built-in credentials from 1Password before startup without exposing the plaintext password to the main container.
- Add the internal Helm chart, ArgoCD Application, shared service probe, backup inventory, focused synthesis tests, and an operator-facing security-boundary explanation.
- Enable the existing Velero/OpenEBS backup path for state, generated assets, and the private media library.

## Verification

- `cd packages/homelab/src/cdk8s && bun test` — 392 passed, 14 intentional integration skips.
- `cd packages/homelab/src/cdk8s && bun run typecheck`
- `cd packages/homelab/src/cdk8s && bunx eslint .`
- `cd packages/homelab/src/cdk8s && bun run check:1password` — 54 item references and 145 field references validated against the safe snapshot.
- `cd packages/homelab/src/cdk8s && HELM_RENDER_TEST=1 bun run render` — all 34 charts rendered.
- `cd packages/docs/wiki && bun run typecheck && bun run test && bun run build` — 15 tests passed and 45 pages built.
- `bun run check-todos` — 660 documents validated.
- Direct bootstrap source commit: `782f49caf7f1732fdd1e0206559ad4414f12187c`.
- Applied workload manifest SHA-256: `c8c22e3cf0b1c24eb455494a38cdcd63ad5cc9fb88b08021b8988904fc497918`.
- Live on `admin@torvalds`: the pod is Ready with zero restarts, the auth init container completed successfully, `/healthz` returns 200 without a session, a new root request redirects to login, an incorrect password returns 401, the 1Password credential signs in, and logout clears the browser session.
- `https://stash.tailnet-1a49.ts.net` resolves through MagicDNS and serves a trusted Let's Encrypt certificate from the standard pinned Tailscale v1.98.9 proxy. `/healthz` returns 200 and an unauthenticated `/` returns 302 to `/login`; all temporary certificate-issuance resources and node-local image tags were removed afterward.
- The three Bound volumes are `stash-state` (64 GiB, `zfs-ssd`), `stash-generated` (256 GiB, `zfs-hdd`), and `stash-media` (1 TiB, `zfs-hdd`), all labeled for backup and not excluded.
- Velero backup `stash-bootstrap-20260811-0225` completed 9/9 items and 3/3 ZFS snapshots with zero errors. R2 contains non-empty metadata and stream objects for state (1,437 and 888,400 bytes), generated (1,437 and 58,184 bytes), and media (1,438 and 45,776 bytes).
- Buildkite #8964 (current head): the PR Playwright and Semgrep lanes passed. Exhaustive verify is blocked by the same `tasknotes-core` transitive-dependency advisory already failing current-main build #8941; the review gate and deployment dry-run were consequently canceled, so this PR remains draft.

The live workload temporarily precedes ArgoCD ownership. The cluster's backup admission catalog and `medium` Tailscale ProxyClass lagged the already-committed global desired state, so bootstrap applied only those two exact committed resources before retrying the exact workload manifest; it did not apply the complete apps manifest or force field conflicts. ArgoCD adoption and an empty post-merge diff remain post-merge verification. Encryption at rest, client-side backup encryption, and restore testing remain explicit follow-up hardening.
