### PR TITLE
fix(homelab): honor default Argo poll interval

### DIFF
--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -863,7 +863,7 @@ function operationStartedAfter(
 
 function operationPollIntervalMs(): number {
   const configured = optionalEnv("ARGOCD_POLL_INTERVAL_MS");
-  return configured === undefined
+  return configured === null
     ? POLL_INTERVAL_MS
     : PollIntervalSchema.parse(configured);
 }

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -278,21 +278,29 @@ function serveLifecycle(
 async function runArgocd(
   args: readonly string[],
   serverOrigin = "http://127.0.0.1:1",
+  options: { readonly pollIntervalMs?: string | null } = {},
 ): Promise<{
   readonly exitCode: number;
   readonly stderr: string;
   readonly stdout: string;
 }> {
+  const env = {
+    ...Object.fromEntries(
+      Object.entries(Bun.env).filter(
+        ([name]) => name !== "ARGOCD_POLL_INTERVAL_MS",
+      ),
+    ),
+    ...(options.pollIntervalMs === null
+      ? {}
+      : { ARGOCD_POLL_INTERVAL_MS: options.pollIntervalMs ?? "5" }),
+    ARGOCD_SERVER_URL: serverOrigin,
+    ARGOCD_TOKEN: "test-token",
+  };
   const process = Bun.spawn(
     ["bun", "--no-install", "scripts/argocd.ts", ...args],
     {
       cwd: path.resolve(import.meta.dir, "../../.."),
-      env: {
-        ...Bun.env,
-        ARGOCD_POLL_INTERVAL_MS: "5",
-        ARGOCD_SERVER_URL: serverOrigin,
-        ARGOCD_TOKEN: "test-token",
-      },
+      env,
       stderr: "pipe",
       stdout: "pipe",
     },
@@ -742,14 +750,18 @@ for (const phase of ["Failed", "Error"]) {
   });
 }
 
-test("atomic Argo sync times out when its operation never becomes visible", async () => {
+test("atomic Argo sync uses the default poll interval when its operation never becomes visible", async () => {
   const lifecycle = serveLifecycle([{ status: {} }]);
 
   try {
-    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin, {
+      pollIntervalMs: null,
+    });
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("did not complete within 1s");
+    expect(result.stderr).not.toContain("ZodError");
+    expect(lifecycle.observations.syncPosts).toBe(1);
   } finally {
     await lifecycle.server.stop(true);
   }


### PR DESCRIPTION
Why

Main build #8967 reached the new atomic root sync and started the exact Argo operation, but the first delayed-visibility poll crashed. The shared optional-env helper returns `null` when the test-only poll override is absent; the polling helper treated only `undefined` as absent, so Zod coerced `null` to zero and rejected it.

What

- Treat a `null` `ARGOCD_POLL_INTERVAL_MS` as absent and use the production 10-second default.
- Run the existing never-visible operation regression without the override.
- Assert the command reaches its normal timeout, posts exactly once, and does not emit a Zod error.

Verification

- `cd packages/homelab/src/cdk8s && bun test src/argocd-script.test.ts src/argocd-manifest-overrides.test.ts src/argocd-atomic-sync.test.ts` (41 passed)
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `bunx turbo run typecheck build lint --filter=homelab`
- `bunx lefthook run pre-commit`
- Live read-only Argo check: build #8967 operation succeeded and root `apps` has no active top-level operation