### PR TITLE
fix(homelab): classify alert dashboard database backup

### DIFF
--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.json
@@ -1,5 +1,11 @@
 [
   {
+    "namespace": "alert-dashboard",
+    "name": "pgdata-alert-dashboard-postgresql-0",
+    "backup": "enabled",
+    "reason": "Alert dashboard PostgreSQL database"
+  },
+  {
     "namespace": "birmel",
     "name": "birmel-pvc",
     "backup": "enabled",

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -28,6 +28,17 @@ const ManifestSchema = z.object({
   }),
 });
 
+const OperatorPostgresqlSchema = z.object({
+  kind: z.literal("postgresql"),
+  metadata: z.object({
+    name: z.string(),
+    namespace: z.string(),
+  }),
+  spec: z.object({
+    numberOfInstances: z.number().int().positive(),
+  }),
+});
+
 const MutatingAdmissionPolicySchema = z.object({
   kind: z.literal("MutatingAdmissionPolicy"),
   spec: z.object({
@@ -65,21 +76,21 @@ afterEach(async () => {
 });
 
 describe("PVC backup policy", () => {
-  it("classifies 46 included and 23 excluded PVCs without duplicates", () => {
+  it("classifies 47 included and 23 excluded PVCs without duplicates", () => {
     const keys = PVC_BACKUP_POLICY.map((entry) =>
       pvcBackupPolicyKey(entry.namespace, entry.name),
     );
-    expect(keys).toHaveLength(69);
-    expect(new Set(keys).size).toBe(69);
+    expect(keys).toHaveLength(70);
+    expect(new Set(keys).size).toBe(70);
     expect(
       PVC_BACKUP_POLICY.filter((entry) => entry.backup === "enabled"),
-    ).toHaveLength(46);
+    ).toHaveLength(47);
     expect(
       PVC_BACKUP_POLICY.filter((entry) => entry.backup === "disabled"),
     ).toHaveLength(23);
   });
 
-  it("classifies and labels every synthesized PVC", async () => {
+  it("classifies every synthesized and operator-managed PVC", async () => {
     const outdir = await mkdtemp(
       path.join(tmpdir(), "pvc-backup-policy-synth-"),
     );
@@ -89,6 +100,7 @@ describe("PVC backup policy", () => {
     app.synth();
 
     let pvcCount = 0;
+    let operatorManagedPvcCount = 0;
     const admissionKinds = new Map<string, number>();
     for (const filename of await readdir(outdir)) {
       if (!filename.endsWith(".yaml")) {
@@ -96,7 +108,8 @@ describe("PVC backup policy", () => {
       }
       const rendered = await Bun.file(path.join(outdir, filename)).text();
       for (const document of parseAllDocuments(rendered)) {
-        const parsed = ManifestSchema.safeParse(document.toJS());
+        const manifest = document.toJS();
+        const parsed = ManifestSchema.safeParse(manifest);
         if (!parsed.success) {
           continue;
         }
@@ -104,13 +117,25 @@ describe("PVC backup policy", () => {
         admissionKinds.set(parsed.data.kind, currentCount + 1);
         if (parsed.data.kind === "MutatingAdmissionPolicy") {
           expect(
-            MutatingAdmissionPolicySchema.parse(document.toJS()).spec
-              .matchConstraints,
+            MutatingAdmissionPolicySchema.parse(manifest).spec.matchConstraints,
           ).toEqual({
             matchPolicy: "Equivalent",
             namespaceSelector: {},
             objectSelector: {},
           });
+        }
+        const operatorPostgresql = OperatorPostgresqlSchema.safeParse(manifest);
+        if (operatorPostgresql.success) {
+          const { metadata, spec } = operatorPostgresql.data;
+          for (let index = 0; index < spec.numberOfInstances; index += 1) {
+            const name = `pgdata-${metadata.name}-${index.toString()}`;
+            const policy = getPvcBackupPolicy(metadata.namespace, name);
+            expect(policy).toMatchObject({
+              namespace: metadata.namespace,
+              name,
+            });
+            operatorManagedPvcCount += 1;
+          }
         }
         if (parsed.data.kind !== "PersistentVolumeClaim") {
           continue;
@@ -130,6 +155,7 @@ describe("PVC backup policy", () => {
     }
 
     expect(pvcCount).toBeGreaterThan(0);
+    expect(operatorManagedPvcCount).toBeGreaterThan(0);
     expect(admissionKinds.get("MutatingAdmissionPolicy")).toBe(2);
     expect(admissionKinds.get("MutatingAdmissionPolicyBinding")).toBe(2);
     expect(admissionKinds.get("ValidatingAdmissionPolicy")).toBe(1);


### PR DESCRIPTION
Why

Main build #8971 reached the scoped release health gate, but `alert-dashboard` could not start because the fail-closed PVC admission policy denied the operator-created `pgdata-alert-dashboard-postgresql-0` claim. The existing completeness test covered synthesized PVC manifests, not claims derived at runtime from Zalando PostgreSQL resources.

What

- Classify the 16 GiB alert-dashboard PostgreSQL claim as backup-enabled.
- Derive every Zalando PostgreSQL PVC name from synthesized resources and require each one in the explicit policy.
- Update policy counts while retaining duplicate and label validation.

Verification

- `cd packages/homelab/src/cdk8s && bun test src/backup-policy/pvc-backup-policy.test.ts` (5 passed)
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`
- Live read-only evidence: `alert-dashboard-postgresql` repeatedly fails PVC creation only because `pvc-backup-policy.sjer.red` lacks this exact claim