### PR TITLE
fix(ci): apply Argo root before release health

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1538,16 +1538,14 @@ steps:
       export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       buildkite-agent artifact download "argocd-release-expected.json" . --step helm-push
       apps_revision=$$(jq -er '.[] | select(.name == "apps") | .revision' argocd-release-expected.json)
-      # Apply the exact published child Application specs while keeping their
-      # repository auto-sync disabled. This makes new sync options and diff
-      # rules effective before child charts are reconciled, without exposing
-      # children to a partially published release.
-      bun --no-install packages/homelab/scripts/argocd.ts suspend-auto-sync apps --revision "$$apps_revision" --timeout 300
-      bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --timeout 300
-      # The root app owns every repository Application, so waiting for its
-      # aggregate health would block on unrelated stale children. Keep the
-      # exact Buildkite identity through apply and termination in one process;
-      # retries may adopt only this build's exact revision.
+      # Stage every exact root resource while keeping every child Application
+      # auto-sync disabled. Root-owned admission and cluster policies land
+      # before children can depend on them, without starting child operations.
+      bun --no-install packages/homelab/scripts/argocd.ts stage-root-release apps --revision "$$apps_revision" --timeout 300
+      bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300
+      # Restore the exact child auto-sync policies and prune the exact root
+      # tree only after child operations finish. Keep the Buildkite identity
+      # through apply and termination so retries adopt only this revision.
       bun --no-install packages/homelab/scripts/argocd.ts sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300
       # The scoped release health below remains authoritative for this release.
       bun --no-install packages/homelab/scripts/argocd.ts release-health-wait argocd-release-expected.json --timeout 300

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -2,19 +2,39 @@ import { describe, expect, test } from "bun:test";
 
 import { validateAtomicRootSyncLifecycle } from "./validate-pipeline-release.ts";
 
-const atomicRootSync =
-  'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
+const argocdCommand = (subcommand: string): string =>
+  `bun --no-install packages/homelab/scripts/argocd.ts ${subcommand}`;
+const stagedRootRelease = argocdCommand(
+  'stage-root-release apps --revision "$$apps_revision" --timeout 300',
+);
+const atomicRootSync = argocdCommand(
+  'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
+);
+const deferredReleaseHealth = argocdCommand(
+  "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300",
+);
+const scopedReleaseHealth = argocdCommand(
+  "release-health-wait argocd-release-expected.json --timeout 300",
+);
+const atomicLifecycle = [
+  stagedRootRelease,
+  deferredReleaseHealth,
+  atomicRootSync,
+  scopedReleaseHealth,
+].join("\n");
 
 describe("atomic ArgoCD root sync pipeline contract", () => {
   test("accepts the one-process identity-bound lifecycle", () => {
-    expect(() => validateAtomicRootSyncLifecycle(atomicRootSync)).not.toThrow();
+    expect(() =>
+      validateAtomicRootSyncLifecycle(atomicLifecycle),
+    ).not.toThrow();
   });
 
   test("rejects the split async and finalizer lifecycle", () => {
     const splitLifecycle = [
-      atomicRootSync,
-      'sync apps --revision "$$apps_revision" --prune --async',
-      'finalize-async-sync apps --revision "$$apps_revision"',
+      atomicLifecycle,
+      argocdCommand('sync apps --revision "$$apps_revision" --prune --async'),
+      argocdCommand('finalize-async-sync apps --revision "$$apps_revision"'),
     ].join("\n");
 
     expect(() => validateAtomicRootSyncLifecycle(splitLifecycle)).toThrow(
@@ -24,8 +44,8 @@ describe("atomic ArgoCD root sync pipeline contract", () => {
 
   test("rejects an async root sync regardless of flag ordering", () => {
     const reorderedAsync = [
-      atomicRootSync,
-      'sync apps --revision "$$apps_revision" --async --prune',
+      atomicLifecycle,
+      argocdCommand('sync apps --revision "$$apps_revision" --async --prune'),
     ].join("\n");
 
     expect(() => validateAtomicRootSyncLifecycle(reorderedAsync)).toThrow(
@@ -35,7 +55,134 @@ describe("atomic ArgoCD root sync pipeline contract", () => {
 
   test("rejects a pipeline without the atomic root sync", () => {
     expect(() =>
-      validateAtomicRootSyncLifecycle("release-health-wait"),
-    ).toThrow("argocd-sync is missing the atomic identity-bound root sync");
+      validateAtomicRootSyncLifecycle(
+        [stagedRootRelease, deferredReleaseHealth, scopedReleaseHealth].join(
+          "\n",
+        ),
+      ),
+    ).toThrow(
+      "argocd-sync must contain exactly one atomic identity-bound root sync",
+    );
+  });
+
+  test("rejects child health before the atomic root apply", () => {
+    const eagerHealth = [
+      stagedRootRelease,
+      argocdCommand(
+        "reconcile-release argocd-release-expected.json --timeout 300",
+      ),
+      atomicRootSync,
+      scopedReleaseHealth,
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(eagerHealth)).toThrow(
+      "argocd-sync must contain exactly one deferred child reconciliation",
+    );
+  });
+
+  test("rejects child reconciliation before root staging", () => {
+    const wrongOrder = [
+      deferredReleaseHealth,
+      stagedRootRelease,
+      atomicRootSync,
+      scopedReleaseHealth,
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(wrongOrder)).toThrow(
+      "argocd-sync must stage root, reconcile children, restore root, then run scoped health",
+    );
+  });
+
+  test("rejects the legacy child-only suspension command", () => {
+    const childOnlyStaging = [
+      argocdCommand(
+        'suspend-auto-sync apps --revision "$$apps_revision" --timeout 300',
+      ),
+      deferredReleaseHealth,
+      atomicRootSync,
+      scopedReleaseHealth,
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(childOnlyStaging)).toThrow(
+      "argocd-sync must contain exactly one root staging command with child auto-sync suspended",
+    );
+  });
+
+  test("rejects an extra eager child reconciliation", () => {
+    const duplicateReconciliation = [
+      argocdCommand(
+        "reconcile-release argocd-release-expected.json --timeout 300",
+      ),
+      atomicLifecycle,
+    ].join("\n");
+
+    expect(() =>
+      validateAtomicRootSyncLifecycle(duplicateReconciliation),
+    ).toThrow(
+      "argocd-sync must contain exactly one deferred child reconciliation",
+    );
+  });
+
+  test("rejects an extra eager scoped health gate", () => {
+    const duplicateHealth = [scopedReleaseHealth, atomicLifecycle].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(duplicateHealth)).toThrow(
+      "argocd-sync must contain exactly one scoped release health gate",
+    );
+  });
+
+  test("rejects behavior-changing flags on the scoped health gate", () => {
+    const dryRunHealth = [
+      stagedRootRelease,
+      deferredReleaseHealth,
+      atomicRootSync,
+      `${scopedReleaseHealth} --dry-run`,
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(dryRunHealth)).toThrow(
+      "argocd-sync must contain exactly one scoped release health gate",
+    );
+  });
+
+  test("does not treat a comment as an executable health gate", () => {
+    const commentedHealth = [
+      stagedRootRelease,
+      deferredReleaseHealth,
+      atomicRootSync,
+      `# ${scopedReleaseHealth}`,
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(commentedHealth)).toThrow(
+      "argocd-sync must contain exactly one scoped release health gate",
+    );
+  });
+
+  test("rejects an eager reconciliation wrapped in shell control flow", () => {
+    const wrappedReconciliation = [
+      `if ${argocdCommand(
+        "reconcile-release argocd-release-expected.json --timeout 300",
+      )}; then :; fi`,
+      atomicLifecycle,
+    ].join("\n");
+
+    expect(() =>
+      validateAtomicRootSyncLifecycle(wrappedReconciliation),
+    ).toThrow(
+      "argocd-sync must contain exactly one deferred child reconciliation",
+    );
+  });
+
+  test("rejects an eager reconciliation split across shell continuations", () => {
+    const continuedReconciliation = [
+      "bun --no-install \\",
+      "  packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --timeout 300",
+      atomicLifecycle,
+    ].join("\n");
+
+    expect(() =>
+      validateAtomicRootSyncLifecycle(continuedReconciliation),
+    ).toThrow(
+      "argocd-sync must contain exactly one deferred child reconciliation",
+    );
   });
 });

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -18,30 +18,101 @@ type ReleaseValidationOptions = {
   readonly stepBlocks: ReadonlyMap<string, string>;
 };
 
-const ATOMIC_ROOT_SYNC_COMMAND =
+const ARGOCD_COMMAND_PREFIX =
+  "bun --no-install packages/homelab/scripts/argocd.ts ";
+const STAGED_ROOT_RELEASE_SUBCOMMAND =
+  'stage-root-release apps --revision "$$apps_revision" --timeout 300';
+const ATOMIC_ROOT_SYNC_SUBCOMMAND =
   'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
+const DEFERRED_RELEASE_HEALTH_SUBCOMMAND =
+  "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300";
+const SCOPED_RELEASE_HEALTH_SUBCOMMAND =
+  "release-health-wait argocd-release-expected.json --timeout 300";
 
 export function validateAtomicRootSyncLifecycle(
   argocdSync: string | undefined,
 ): void {
-  requireIncludes(
-    argocdSync,
-    ATOMIC_ROOT_SYNC_COMMAND,
-    "argocd-sync is missing the atomic identity-bound root sync",
+  if (argocdSync === undefined) {
+    fail("argocd-sync is missing the atomic identity-bound root sync");
+  }
+  const executableCommands = argocdSync
+    .replace(/\\\r?\n[\t ]*/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => !line.startsWith("#"))
+    .flatMap((line) =>
+      line
+        .split(ARGOCD_COMMAND_PREFIX)
+        .slice(1)
+        .map((command) => command.trim()),
+    );
+  const rootSyncCommands = executableCommands.filter((line) =>
+    /^sync\s+apps(?:\s|$)/.test(line),
   );
-  const hasAsyncRootSync =
-    argocdSync
-      ?.split("\n")
-      .some(
-        (line) =>
-          /\bsync\s+apps(?:\s|$)/.test(line) &&
-          /(?:^|\s)--async(?:\s|$)/.test(line),
-      ) === true;
-  if (
-    hasAsyncRootSync ||
-    argocdSync?.includes("finalize-async-sync apps") === true
-  ) {
+  const hasAsyncRootSync = rootSyncCommands.some((line) =>
+    /(?:^|\s)--async(?:\s|$)/.test(line),
+  );
+  const hasAsyncFinalizer = executableCommands.some((line) =>
+    /^finalize-async-sync\s+apps(?:\s|$)/.test(line),
+  );
+  if (hasAsyncRootSync || hasAsyncFinalizer) {
     fail("argocd-sync restored the racy split async/finalize lifecycle");
+  }
+  if (
+    rootSyncCommands.length !== 1 ||
+    rootSyncCommands[0] !== ATOMIC_ROOT_SYNC_SUBCOMMAND
+  ) {
+    fail(
+      "argocd-sync must contain exactly one atomic identity-bound root sync",
+    );
+  }
+  const stagedRootCommands = executableCommands.filter((line) =>
+    /^(?:stage-root-release|suspend-auto-sync)\s+apps(?:\s|$)/.test(line),
+  );
+  if (
+    stagedRootCommands.length !== 1 ||
+    stagedRootCommands[0] !== STAGED_ROOT_RELEASE_SUBCOMMAND
+  ) {
+    fail(
+      "argocd-sync must contain exactly one root staging command with child auto-sync suspended",
+    );
+  }
+  const reconciliationCommands = executableCommands.filter((line) =>
+    /^reconcile-release\s+argocd-release-expected\.json(?:\s|$)/.test(line),
+  );
+  if (
+    reconciliationCommands.length !== 1 ||
+    reconciliationCommands[0] !== DEFERRED_RELEASE_HEALTH_SUBCOMMAND
+  ) {
+    fail("argocd-sync must contain exactly one deferred child reconciliation");
+  }
+  const scopedHealthCommands = executableCommands.filter((line) =>
+    /^release-health-wait\s+argocd-release-expected\.json(?:\s|$)/.test(line),
+  );
+  if (
+    scopedHealthCommands.length !== 1 ||
+    scopedHealthCommands[0] !== SCOPED_RELEASE_HEALTH_SUBCOMMAND
+  ) {
+    fail("argocd-sync must contain exactly one scoped release health gate");
+  }
+  const stageIndex = executableCommands.indexOf(STAGED_ROOT_RELEASE_SUBCOMMAND);
+  const reconcileIndex = executableCommands.indexOf(
+    DEFERRED_RELEASE_HEALTH_SUBCOMMAND,
+  );
+  const rootSyncIndex = executableCommands.indexOf(ATOMIC_ROOT_SYNC_SUBCOMMAND);
+  const healthIndex = executableCommands.indexOf(
+    SCOPED_RELEASE_HEALTH_SUBCOMMAND,
+  );
+  if (
+    !(
+      stageIndex < reconcileIndex &&
+      reconcileIndex < rootSyncIndex &&
+      rootSyncIndex < healthIndex
+    )
+  ) {
+    fail(
+      "argocd-sync must stage root, reconcile children, restore root, then run scoped health",
+    );
   }
 }
 
@@ -93,8 +164,8 @@ function validateReleaseSteps({
         "--filter homelab --filter '@homelab/cdk8s'",
         "concurrency_group: monorepo/homelab-release",
         'artifact download "argocd-release-expected.json"',
-        'suspend-auto-sync apps --revision "$$apps_revision"',
-        "reconcile-release argocd-release-expected.json",
+        'stage-root-release apps --revision "$$apps_revision"',
+        "reconcile-release argocd-release-expected.json --skip-health-wait",
         "release-health-wait argocd-release-expected.json",
       ],
     ],

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -46,7 +46,14 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   live and completed state carry the exact request and revision and neither
   carries an internal ID.
 - Wire the main Buildkite release to the atomic command with
-  `BUILDKITE_BUILD_ID`; reject the old split lifecycle in pipeline validation.
+  `BUILDKITE_BUILD_ID`. First stage every rendered root resource through
+  manifest overrides that keep every child Application's auto-sync disabled. This makes
+  root-owned prerequisites available before child reconciliation without
+  racing an automatic child operation. Reconcile children with aggregate
+  health deferred, then atomically restore and prune the exact root tree before
+  one scoped release-health gate. Reject the old split lifecycle, child-only
+  staging, eager duplicate gates, shell-wrapped commands, and unsafe ordering
+  in pipeline validation.
 
 ## Verification
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -12,7 +12,7 @@ GitOps release can go wrong.
 ```mermaid
 sequenceDiagram
   accTitle: Homelab release sequence
-  accDescr: Buildkite suspends floating auto-sync, publishes an immutable chart set, applies the exact child specifications while suspended, reconciles child workloads, and finally restores the exact root tree with safe pruning.
+  accDescr: Buildkite suspends floating auto-sync, publishes an immutable chart set, stages exact child specifications and root prerequisites while children remain suspended, reconciles child workloads, restores the exact root tree with safe pruning, and checks scoped health.
   participant BK as Buildkite
   participant CM as ChartMuseum
   participant Root as apps Application
@@ -20,9 +20,9 @@ sequenceDiagram
 
   BK->>Root: suspend current repository auto-sync
   BK->>CM: publish 2.0.0-build charts
-  BK->>Root: apply exact child specs, still suspended
+  BK->>Root: stage child specs and prerequisites, still suspended
   BK->>Child: reconcile exact chart revisions
-  BK->>Root: sync exact revision with verified pruning
+  BK->>Root: restore exact revision with verified pruning
   BK->>Root: retain identity through apply and termination
   BK->>Child: require Synced and Healthy
 ```
@@ -36,8 +36,16 @@ New child-level safety settings have to exist _before_ those children sync.
 But enabling floating auto-sync before every chart is published would let a
 child pick up a partially published release.
 
-Applying the exact child specs while still suspended satisfies both: the
-settings land, and nothing syncs on them until the chart set is complete.
+The staged root release applies every exact rendered resource through manifest
+overrides. Child Applications are the only resources changed: their auto-sync
+remains disabled regardless of whether their source is internal or external.
+Child settings and root-owned prerequisites such as admission policies
+therefore land before reconciliation without starting an automatic child
+operation.
+
+After explicit child reconciliation completes, the full root apply restores
+the exact auto-sync policies and performs verified pruning. Aggregate child
+health is deferred until both the child and final root applies have completed.
 
 ## Why immutable chart revisions
 

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -13,18 +13,24 @@ failed stage means.
 
 ## The sequence
 
-| Stage | What happens                                                            |
-| ----- | ----------------------------------------------------------------------- |
-| 1     | Suspend the current repository auto-sync on the root `apps` Application |
-| 2     | Publish the `2.0.0-build` chart set to ChartMuseum, immutably           |
-| 3     | Apply the exact child Application specs, still suspended                |
-| 4     | Reconcile child workloads to their exact chart revisions                |
-| 5     | Sync and safely finalize the exact root revision with verified pruning  |
-| 6     | Require every release-scoped child to be `Synced` and `Healthy`         |
+| Stage | What happens                                                              |
+| ----- | ------------------------------------------------------------------------- |
+| 1     | Suspend the current repository auto-sync on the root `apps` Application   |
+| 2     | Publish the `2.0.0-build` chart set to ChartMuseum, immutably             |
+| 3     | Stage exact child specs and root prerequisites, with children suspended   |
+| 4     | Reconcile child workloads to their exact chart revisions                  |
+| 5     | Restore and safely finalize the exact root revision with verified pruning |
+| 6     | Require every release-scoped child to be `Synced` and `Healthy`           |
 
 Stage 3 is deliberately separate from stage 5. New child-level safety settings
 must exist before those children sync, but enabling floating auto-sync before
 every chart is published could expose a partially published release.
+
+Stage 3 also applies root-owned prerequisites such as admission policies, but
+keeps every child Application's auto-sync disabled. This lets stage 4 explicitly own
+child operations without racing ArgoCD. Stage 5 restores the exact auto-sync
+policies and prunes only after reconciliation. Stage 6 is the single
+authoritative scoped health gate.
 
 ## If a child stays out of sync
 

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -20,6 +20,8 @@
  *   bun packages/homelab/scripts/argocd.ts tree-health-wait <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> \
  *       [--revision <v>] [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts stage-root-release <root-app> \
+ *       --revision <v> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts wait-deletion <app> \
  *       --group <g> --version <v> --kind <k> --namespace <ns> \
  *       [--timeout <s>] [--dry-run]
@@ -53,6 +55,7 @@ import {
   requestedOperationRequestId,
   SYNC_OPERATION_ID_INFO_NAME,
   SYNC_REQUEST_ID_INFO_NAME,
+  type ManifestOverride,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
@@ -113,7 +116,12 @@ const RenderedObjectSchema = z
 const RenderedResourceSchema = z.object({
   apiVersion: z.string().min(1),
   kind: z.string().min(1),
-  metadata: z.object({ name: z.string().min(1) }).passthrough(),
+  metadata: z
+    .object({
+      name: z.string().min(1),
+      namespace: z.string().min(1).optional(),
+    })
+    .passthrough(),
 });
 
 const RootDeploymentHistorySchema = z.object({
@@ -282,6 +290,77 @@ async function getExpectedSyncResultIdentities(
   };
 }
 
+type PreparedManifestOverride = {
+  readonly override: ManifestOverride;
+  readonly suspendedApplication: string | null;
+};
+
+function prepareRootManifestOverride(
+  manifestSource: string,
+  suspendAllApplications: boolean,
+): PreparedManifestOverride {
+  const parsed: unknown = JSON.parse(manifestSource);
+  const renderedResource = RenderedResourceSchema.parse(parsed);
+  const separator = renderedResource.apiVersion.indexOf("/");
+  const resource: SyncOperationResource = {
+    group:
+      separator === -1 ? "" : renderedResource.apiVersion.slice(0, separator),
+    kind: renderedResource.kind,
+    name: renderedResource.metadata.name,
+    ...(renderedResource.metadata.namespace === undefined
+      ? {}
+      : { namespace: renderedResource.metadata.namespace }),
+  };
+  if (renderedResource.kind !== "Application") {
+    return {
+      override: { manifest: manifestSource, resource },
+      suspendedApplication: null,
+    };
+  }
+  const application = RenderedApplicationSchema.parse(parsed);
+  if (
+    application.spec.syncPolicy === undefined ||
+    !Object.hasOwn(application.spec.syncPolicy, "automated")
+  ) {
+    return {
+      override: { manifest: manifestSource, resource },
+      suspendedApplication: null,
+    };
+  }
+  const isRepositoryApplication =
+    application.spec.source.chart !== undefined &&
+    REPOSITORY_CHART_URLS.has(application.spec.source.repoURL);
+  if (!suspendAllApplications && !isRepositoryApplication) {
+    return {
+      override: { manifest: manifestSource, resource },
+      suspendedApplication: null,
+    };
+  }
+  const automated = application.spec.syncPolicy["automated"];
+  if (!isRecord(automated)) {
+    return {
+      override: { manifest: manifestSource, resource },
+      suspendedApplication: null,
+    };
+  }
+  return {
+    override: {
+      manifest: JSON.stringify({
+        ...application,
+        spec: {
+          ...application.spec,
+          syncPolicy: {
+            ...application.spec.syncPolicy,
+            automated: { ...automated, enabled: false },
+          },
+        },
+      }),
+      resource,
+    },
+    suspendedApplication: application.metadata.name,
+  };
+}
+
 async function suspendRepositoryAutoSync(
   rootAppName: string,
   timeoutSeconds: number,
@@ -315,46 +394,63 @@ async function suspendRepositoryAutoSync(
     token,
   );
   const suspended = manifests.flatMap((manifestSource) => {
-    const parsed = RenderedObjectSchema.parse(JSON.parse(manifestSource));
-    if (parsed.kind !== "Application") {
+    const prepared = prepareRootManifestOverride(manifestSource, false);
+    if (prepared.suspendedApplication === null) {
       return [];
     }
-    const application = RenderedApplicationSchema.parse(parsed);
-    if (
-      application.spec.source.chart === undefined ||
-      !REPOSITORY_CHART_URLS.has(application.spec.source.repoURL) ||
-      application.spec.syncPolicy === undefined ||
-      !Object.hasOwn(application.spec.syncPolicy, "automated")
-    ) {
-      return [];
-    }
-    const automated = application.spec.syncPolicy["automated"];
-    if (!isRecord(automated)) {
-      return [];
-    }
-    const syncPolicy = {
-      ...application.spec.syncPolicy,
-      automated: { ...automated, enabled: false },
-    };
-    console.log(`suspending auto-sync: ${application.metadata.name}`);
-    return [
-      {
-        manifest: JSON.stringify({
-          ...application,
-          spec: { ...application.spec, syncPolicy },
-        }),
-        resource: {
-          group: "argoproj.io",
-          kind: "Application",
-          name: application.metadata.name,
-        },
-      },
-    ];
+    console.log(`suspending auto-sync: ${prepared.suspendedApplication}`);
+    return [prepared.override];
   });
   const batches = batchManifestOverrides(suspended);
   for (const [index, batch] of batches.entries()) {
     console.log(
       `syncing suspended Application batch ${(index + 1).toString()}/${batches.length.toString()} (${batch.manifests.length.toString()} resources)`,
+    );
+    await sync(rootAppName, timeoutSeconds, false, {
+      prune: false,
+      manifests: batch.manifests,
+      resources: batch.resources,
+    });
+  }
+}
+
+async function stageRootRelease(
+  rootAppName: string,
+  revision: string,
+  timeoutSeconds: number,
+  dryRun: boolean,
+): Promise<void> {
+  const exactRevision = BuildRevisionSchema.parse(revision);
+  console.log(
+    `--- argocd stage-root-release: ${rootAppName} at ${exactRevision}${dryRun ? " (dry run)" : ""}`,
+  );
+  if (dryRun) {
+    return;
+  }
+  await assertExpectedAppsRevisionIsLatest(exactRevision, timeoutSeconds);
+  const token = requireEnv("ARGOCD_TOKEN");
+  const manifests = await getApplicationManifests(
+    rootAppName,
+    exactRevision,
+    token,
+  );
+  if (manifests.length === 0) {
+    throw new Error("Rendered root release contains no resources");
+  }
+  const staged = manifests.map((manifestSource) =>
+    prepareRootManifestOverride(manifestSource, true),
+  );
+  for (const prepared of staged) {
+    if (prepared.suspendedApplication !== null) {
+      console.log(`suspending auto-sync: ${prepared.suspendedApplication}`);
+    }
+  }
+  const batches = batchManifestOverrides(
+    staged.map(({ override }) => override),
+  );
+  for (const [index, batch] of batches.entries()) {
+    console.log(
+      `syncing staged root batch ${(index + 1).toString()}/${batches.length.toString()} (${batch.manifests.length.toString()} resources)`,
     );
     await sync(rootAppName, timeoutSeconds, false, {
       prune: false,
@@ -1610,6 +1706,8 @@ function usage(): never {
       "--revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> " +
       "[--revision <v>] [--timeout <s>] [--dry-run]\n" +
+      "  bun packages/homelab/scripts/argocd.ts stage-root-release <root-app> " +
+      "--revision <v> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts wait-deletion <app> " +
       "--group <g> --version <v> --kind <k> --namespace <ns> " +
       "[--timeout <s>] [--dry-run]",
@@ -1771,6 +1869,20 @@ async function main(): Promise<void> {
         flag(argv, "revision"),
       );
       return;
+    case "stage-root-release": {
+      const revision = flag(argv, "revision");
+      if (revision === undefined) {
+        console.error("--revision is required for stage-root-release.");
+        usage();
+      }
+      await stageRootRelease(
+        app,
+        revision,
+        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
+        dryRun,
+      );
+      return;
+    }
     case "wait-deletion": {
       const group = flag(argv, "group");
       const version = flag(argv, "version");

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -227,6 +227,9 @@ test("Argo CD CLI usage documents atomic sync and recovery identity", async () =
     "suspend-auto-sync <root-app> [--revision <v>] [--timeout <s>]",
   );
   expect(stderr).toContain(
+    "stage-root-release <root-app> --revision <v> [--timeout <s>]",
+  );
+  expect(stderr).toContain(
     "finalize-async-sync <app> --revision <v> --request-id <uuid>",
   );
 });
@@ -574,6 +577,186 @@ describe("Argo CD release gating", () => {
       expect(renderedRevisions).toEqual(["2.0.0-43"]);
       expect(syncBodies).toHaveLength(1);
       expectSuspendedWorkerRequest(syncBodies[0]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+
+describe("Argo CD root release staging", () => {
+  test("requires an exact root revision", async () => {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "stage-root-release",
+        "apps",
+        "--dry-run",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--revision is required for stage-root-release");
+  });
+
+  test("stages root prerequisites while child auto-sync remains suspended", async () => {
+    const syncBodies: unknown[] = [];
+    let requestedOperation: unknown;
+    const repositoryApplication = JSON.stringify({
+      apiVersion: "argoproj.io/v1alpha1",
+      kind: "Application",
+      metadata: { name: "worker" },
+      spec: {
+        source: {
+          repoURL: "https://chartmuseum.sjer.red",
+          chart: "worker",
+          targetRevision: "2.0.0-43",
+        },
+        syncPolicy: {
+          automated: { prune: true, selfHeal: true },
+        },
+      },
+    });
+    const admissionPolicy = JSON.stringify({
+      apiVersion: "admissionregistration.k8s.io/v1",
+      kind: "ValidatingAdmissionPolicy",
+      metadata: { name: "pvc-backup-policy.sjer.red" },
+      spec: { failurePolicy: "Fail" },
+    });
+    const externalApplication = JSON.stringify({
+      apiVersion: "argoproj.io/v1alpha1",
+      kind: "Application",
+      metadata: { name: "external" },
+      spec: {
+        source: {
+          repoURL: "https://charts.example.com",
+          chart: "external",
+          targetRevision: "1.0.0",
+        },
+        syncPolicy: { automated: {} },
+      },
+    });
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/charts/apps") {
+          return Response.json([
+            {
+              version: "2.0.0-43",
+              urls: ["charts/apps-2.0.0-43.tgz"],
+              digest: "a".repeat(64),
+            },
+          ]);
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps/manifests"
+        ) {
+          expect(url.searchParams.get("revision")).toBe("2.0.0-43");
+          return Response.json({
+            manifests: [
+              repositoryApplication,
+              externalApplication,
+              admissionPolicy,
+            ],
+          });
+        }
+        if (
+          request.method === "POST" &&
+          url.pathname === "/api/v1/applications/apps/sync"
+        ) {
+          const body = await request.json();
+          syncBodies.push(body);
+          requestedOperation = operationForSyncRequest(body);
+          return Response.json({ operation: requestedOperation });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps"
+        ) {
+          return Response.json({
+            status: {
+              operationState: {
+                phase: "Succeeded",
+                startedAt: new Date().toISOString(),
+                operation: requestedOperation,
+              },
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "stage-root-release",
+          "apps",
+          "--revision",
+          "2.0.0-43",
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+            CHARTMUSEUM_ORIGIN: server.url.origin,
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("stage-root-release: apps at 2.0.0-43");
+      expect(stdout).toContain("suspending auto-sync: worker");
+      expect(syncBodies).toHaveLength(1);
+      const stagedRequest = SyncRequestSchema.parse(syncBodies[0]);
+      expect(stagedRequest.resources).toEqual([
+        WorkerApplicationResource,
+        {
+          group: "argoproj.io",
+          kind: "Application",
+          name: "external",
+        },
+        {
+          group: "admissionregistration.k8s.io",
+          kind: "ValidatingAdmissionPolicy",
+          name: "pvc-backup-policy.sjer.red",
+        },
+      ]);
+      expect(JSON.parse(stagedRequest.manifests[0] ?? "")).toMatchObject({
+        spec: { syncPolicy: { automated: { enabled: false } } },
+      });
+      expect(JSON.parse(stagedRequest.manifests[1] ?? "")).toMatchObject({
+        spec: { syncPolicy: { automated: { enabled: false } } },
+      });
+      expect(stagedRequest.manifests[2]).toBe(admissionPolicy);
     } finally {
       await server.stop(true);
     }


### PR DESCRIPTION
Why

Main build #8973 published apps chart `2.0.0-8973` with the corrected PVC admission policy, but never reached the atomic root sync. `reconcile-release` entered its built-in health wait first, leaving `alert-dashboard` Degraded on a root-owned policy and making the later root apply unreachable.

What

- Pass `--skip-health-wait` during child reconciliation.
- Preserve one explicit scoped health gate after the atomic root apply.
- Require reconcile -> atomic root -> scoped health ordering in executable pipeline validation.
- Add regressions for eager health and a reordered explicit health gate.
- Record the ordering constraint in the durable atomic-sync plan.

Verification

- `bun test ./.buildkite/scripts/validate-pipeline-release.test.ts` (6 passed)
- `bun run ./.buildkite/scripts/validate-pipeline-release.ts`
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `bunx turbo run typecheck lint test --filter=@shepherdjerred/root-scripts` (473 tests)
- `bunx lefthook run pre-commit`
- Live read-only evidence: published apps chart `2.0.0-8973` contains the admission key, while #8973 logs enter `release-health-wait` immediately after only the suspended manifest batch sync