### PR TITLE
fix(ci): keep Argo staging below the controller message limit

### DIFF
--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -47,13 +47,15 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   carries an internal ID.
 - Wire the main Buildkite release to the atomic command with
   `BUILDKITE_BUILD_ID`. First stage every rendered root resource through
-  manifest overrides that keep every child Application's auto-sync disabled. This makes
-  root-owned prerequisites available before child reconciliation without
-  racing an automatic child operation. Reconcile children with aggregate
-  health deferred, then atomically restore and prune the exact root tree before
-  one scoped release-health gate. Reject the old split lifecycle, child-only
-  staging, eager duplicate gates, shell-wrapped commands, and unsafe ordering
-  in pipeline validation.
+  manifest overrides that keep every child Application's auto-sync disabled.
+  This makes root-owned prerequisites available before child reconciliation
+  without racing an automatic child operation. Bound each override request to
+  750 kB because ArgoCD's operation-state update carries both the requested and
+  completed operation inside its 2 MiB controller message ceiling. Reconcile
+  children with aggregate health deferred, then atomically restore and prune
+  the exact root tree before one scoped release-health gate. Reject the old
+  split lifecycle, child-only staging, eager duplicate gates, shell-wrapped
+  commands, and unsafe ordering in pipeline validation.
 
 ## Verification
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -41,7 +41,14 @@ overrides. Child Applications are the only resources changed: their auto-sync
 remains disabled regardless of whether their source is internal or external.
 Child settings and root-owned prerequisites such as admission policies
 therefore land before reconciliation without starting an automatic child
-operation.
+operation. The
+[manifest-override batcher](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd-manifest-overrides.ts)
+splits those requests at 750 kB. ArgoCD v3.4.5's
+[operation-state constructor](https://github.com/argoproj/argo-cd/blob/564b94973b284b8de98da7cee6eeade2cb941e46/controller/sync.go#L76-L81)
+copies the original request into status. In this cluster, a request near the
+observed 2 MiB controller message ceiling can therefore be accepted but never
+acquire visible operation state, matching
+[upstream reports of oversized operation-state patches](https://github.com/argoproj/argo-cd/issues/14224#issuecomment-1636337124).
 
 After explicit child reconciliation completes, the full root apply restores
 the exact auto-sync policies and performs verified pruning. Aggregate child

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -56,6 +56,19 @@ describe("manifest override batching", () => {
     ]);
   });
 
+  test("leaves room for Argo's duplicated operation-state envelope", () => {
+    const batches = batchManifestOverrides([
+      override("one", 500_000),
+      override("two", 500_000),
+    ]);
+
+    expect(batches).toHaveLength(2);
+    expect(batches.map(({ resources }) => resources[0]?.name)).toEqual([
+      "one",
+      "two",
+    ]);
+  });
+
   test("fails when one manifest cannot fit", () => {
     expect(() => batchManifestOverrides([override("huge", 2000)], 500)).toThrow(
       "Application/huge exceeds the request budget",

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { canonicalJson } from "./canonical-json.ts";
 
-const DEFAULT_MAX_REQUEST_BYTES = 1_500_000;
+const DEFAULT_MAX_REQUEST_BYTES = 750_000;
 const SERIALIZED_REQUEST_ID = "00000000-0000-0000-0000-000000000000";
 const SERIALIZED_OPERATION_ID = "00000000-0000-0000-0000-000000000000";
 
@@ -83,8 +83,12 @@ function appendOverride(
 
 /**
  * Keep manifest-override operations comfortably below Argo CD's 2 MiB gRPC
- * message ceiling. The request is measured after JSON serialization so
- * escaping and resource selectors are included instead of estimated.
+ * message ceiling. The application-controller's operation-state update
+ * includes both the requested and completed operation, so the manifest
+ * payload can appear twice in that message. A 750 kB request budget leaves
+ * almost 600 kB for the rest of the Application while staying below 2 MiB.
+ * The request is measured after JSON serialization so escaping and resource
+ * selectors are included instead of estimated.
  */
 export function batchManifestOverrides(
   overrides: readonly ManifestOverride[],


### PR DESCRIPTION
## Why

Main build #8980 exposed a second boundary after the staged-root release fix: ArgoCD accepted a 1.5 MB manifest-override request, but the application controller then duplicated the requested operation into status and could not persist the resulting 2.89 MiB message through its 2 MiB gRPC ceiling. The operation remained visible without operation state, and the retry-safe client correctly kept polling instead of reporting success.

## What

- Reduce the default manifest-override request budget from 1.5 MB to 750 kB, leaving almost 600 kB for Application metadata and status after the operation payload is duplicated.
- Add a regression test that requires two 500 kB manifests to be split under the default budget.
- Record the controller-envelope constraint in the atomic root-sync plan and release-safety explanation.

## Verification

- `bun test packages/homelab/scripts/argocd-manifest-overrides.test.ts packages/homelab/src/cdk8s/src/argocd-script.test.ts` (25 passed)
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `cd packages/docs/wiki && bun run typecheck && bun run test && bun run build && bun run test:e2e` (15 unit and 7 E2E passed)
- `bunx lefthook run pre-commit`
- Desktop 1440x1000 and mobile 390x844 wiki render inspection
- Full root verify: pending exact-head Buildkite PR CI

## Live evidence

Build #8980's staging operation contains 76 resources and a 1.42 MB operation object. The ArgoCD application-controller repeatedly reports `ResourceExhausted: trying to send message larger than max (2888452 vs. 2097152)`. No operation state was published, so no staged resources were accepted as complete.

## Visual

The release-safety explanation renders the new controller-envelope constraint without disturbing the existing workflow diagram or page structure.

![argocd-batching-desktop.png](https://public.sjer.red/pr/assets/2118/argocd-batching-desktop.png)
