### PR TITLE
fix(scout-for-lol): require a minimum window age before auto-closing a queue

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -593,16 +593,25 @@ Limited-time queue availability lives in
 `queue-windows.schema.ts`; loaded by `queue-availability.ts` — end dates are
 inclusive through the whole UTC day). The `scout-queue-windows-daily` Temporal
 schedule (06:45 PT, `packages/temporal/src/activities/scout-queue-windows.ts`)
-scans the `scout-prod` match lake for a 21-day lookback and proposes edits via
+scans the `scout-prod` match lake for a 28-day lookback and proposes edits via
 the pure drift engine (`queue-window-drift.ts`): window opens/reopens auto-merge;
 window closes open a plain PR for human confirmation against patch notes;
 warnings-only runs (unknown queue ids, sparse modes) send an email.
+
+A close is gated on the window being at least `CLOSE_MIN_WINDOW_AGE_DAYS` (21)
+old, and its volume baseline is only counted from observations still inside the
+lookback — so the lookback is what decides how many consecutive daily runs
+re-propose the same close. Because the job closes its proposal PR as soon as a
+run produces no drift, a lookback equal to the minimum age would give a human
+exactly one day to review before the proposal vanished for good. The engine
+rejects any `lookbackDays` below `MIN_DRIFT_LOOKBACK_DAYS`; keep the schedule's
+`LOOKBACK_DAYS` and the CLI's default in step.
 
 Local dry-run (no writes):
 
 ```bash
 cd packages/backend
-AWS_PROFILE=seaweedfs bun run update-queue-windows -- --bucket scout-prod --lookback-days 21 --dry-run
+AWS_PROFILE=seaweedfs bun run update-queue-windows -- --bucket scout-prod --lookback-days 28 --dry-run
 ```
 
 New modes with unmapped queue ids surface as "new mode?" warnings — add the

--- a/packages/scout-for-lol/packages/backend/scripts/update-queue-windows.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/update-queue-windows.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  MIN_DRIFT_LOOKBACK_DAYS,
   proposeQueueWindowEdits,
   QueueWindowsFileSchema,
   type QueueWindowEdit,
@@ -12,6 +13,13 @@ import { collectQueueActivity } from "./queue-activity-s3.ts";
 import { fetchPatches } from "../../data/scripts/riot-patch.ts";
 
 const RawArgsSchema = z.array(z.string());
+
+/**
+ * Four weeks, one day above `MIN_DRIFT_LOOKBACK_DAYS`. Keep this in step with
+ * `LOOKBACK_DAYS` in `packages/temporal/src/activities/scout-queue-windows.ts`
+ * so a dry run reproduces what the scheduled watcher proposes.
+ */
+const DEFAULT_LOOKBACK_DAYS = 28;
 
 // The committed source of truth, resolved relative to this script so the CLI
 // works regardless of cwd (Temporal runs it from packages/scout-for-lol).
@@ -45,7 +53,9 @@ function requiredFlagValue(args: readonly string[], flag: string): string {
 
 const CliConfigSchema = z.strictObject({
   bucket: z.string().min(1),
-  lookbackDays: z.number().int().positive(),
+  // Rejected here rather than deep inside the drift engine so an operator
+  // learns the lookback is too short before the S3 scan, not after it.
+  lookbackDays: z.number().int().min(MIN_DRIFT_LOOKBACK_DAYS),
   dryRun: z.boolean(),
   reportPath: z.string().min(1).optional(),
   awsProfile: z.string().min(1).optional(),
@@ -59,7 +69,8 @@ function parseCliConfig(): CliConfig {
   const lookbackRaw = optionalFlagValue(args, "--lookback-days");
   return CliConfigSchema.parse({
     bucket: requiredFlagValue(args, "--bucket"),
-    lookbackDays: lookbackRaw === undefined ? 21 : Number(lookbackRaw),
+    lookbackDays:
+      lookbackRaw === undefined ? DEFAULT_LOOKBACK_DAYS : Number(lookbackRaw),
     dryRun: args.includes("--dry-run"),
     reportPath: optionalFlagValue(args, "--report"),
     awsProfile: optionalFlagValue(args, "--aws-profile"),

--- a/packages/scout-for-lol/packages/data/src/model/queue-window-drift.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-window-drift.test.ts
@@ -234,3 +234,64 @@ describe("proposeQueueWindowEdits", () => {
     expect(warnings).toHaveLength(0);
   });
 });
+
+describe("proposeQueueWindowEdits close guards", () => {
+  test("refuses to close a launch-week window even with a full volume baseline (PR #2100 replay)", () => {
+    // The real false positive: `classic aram mayhem` opened 2026-07-29 — the
+    // start of Ranked Season 3 — took 20+ matches over its first two days, then
+    // went quiet. On 2026-08-10 the watcher proposed retiring it while ARAM:
+    // Mayhem was still receiving balance changes in the current patch.
+    //
+    // Every pre-existing close condition is satisfied here: no trailing
+    // matches, and earlierTotal (24) clears CLOSE_MIN_VOLUME_BASELINE. Only the
+    // window's age stops it.
+    const file = makeFile({ "classic aram mayhem": [["2026-07-29", null]] });
+    const { edits, warnings, next } = proposeQueueWindowEdits({
+      file,
+      counts: { "2450": { "2026-07-29": 14, "2026-07-30": 10 } },
+      today: "2026-08-10",
+      lookbackDays: LOOKBACK,
+    });
+
+    expect(edits).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.kind).toBe("window-too-young");
+    expect(warnings[0]?.total).toBe(24);
+    expect(warnings[0]?.message).toContain("12 day(s) old");
+    // The window must remain open-ended, or the queue disappears from the
+    // subscription picker.
+    expect(next.queues["classic aram mayhem"]?.at(-1)?.end).toBeNull();
+  });
+
+  test("closes once the window clears the minimum age with the same evidence shape", () => {
+    // Identical evidence to the replay above, just an older window: a burst at
+    // the start, then nothing. At 30 days old the close is trusted.
+    const file = makeFile({ "classic aram mayhem": [["2026-07-11", null]] });
+    const { edits, warnings } = proposeQueueWindowEdits({
+      file,
+      counts: { "2450": { "2026-07-24": 14, "2026-07-25": 10 } },
+      today: "2026-08-10",
+      lookbackDays: LOOKBACK,
+    });
+
+    expect(warnings).toHaveLength(0);
+    expect(edits).toHaveLength(1);
+    expect(edits[0]?.kind).toBe("close");
+    expect(edits[0]?.date).toBe("2026-07-25");
+  });
+
+  test("stays silent about a young window that is still being played", () => {
+    // The age gate must not turn every fresh mode into a daily warning email —
+    // it only speaks once the mode has actually gone quiet.
+    const file = makeFile({ "classic aram mayhem": [["2026-07-29", null]] });
+    const { edits, warnings } = proposeQueueWindowEdits({
+      file,
+      counts: { "2450": { "2026-08-08": 3, "2026-08-09": 4 } },
+      today: "2026-08-10",
+      lookbackDays: LOOKBACK,
+    });
+
+    expect(edits).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/queue-window-drift.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-window-drift.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { proposeQueueWindowEdits } from "#src/model/queue-window-drift.ts";
+import {
+  MIN_DRIFT_LOOKBACK_DAYS,
+  proposeQueueWindowEdits,
+} from "#src/model/queue-window-drift.ts";
 import {
   QueueWindowsFileSchema,
   type QueueWindowsFile,
 } from "#src/model/queue-windows.schema.ts";
 
 const TODAY = "2026-07-26";
-const LOOKBACK = 21;
+/** What the scheduled watcher and the CLI default to. */
+const LOOKBACK = 28;
 
 function makeFile(
   queues: Record<string, [start: string, end: string | null][]>,
@@ -293,5 +297,71 @@ describe("proposeQueueWindowEdits close guards", () => {
 
     expect(edits).toHaveLength(0);
     expect(warnings).toHaveLength(0);
+  });
+});
+
+function addDaysUtc(date: string, days: number): string {
+  const ms = Date.parse(`${date}T00:00:00.000Z`) + days * 86_400_000;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+describe("proposeQueueWindowEdits close eligibility span", () => {
+  const WINDOW_START = "2026-07-01";
+
+  /** Outcome of the daily run that sees `WINDOW_START` as `age` days ago. */
+  function runAtAge(age: number) {
+    return proposeQueueWindowEdits({
+      file: makeFile({ "classic aram mayhem": [[WINDOW_START, null]] }),
+      // Worst case for eligibility: the entire volume baseline lands on the
+      // window's first day, so it is the first evidence to fall out of the
+      // lookback. This is the launch-burst shape the age gate exists for.
+      counts: { "2450": { [WINDOW_START]: 24 } },
+      today: addDaysUtc(WINDOW_START, age),
+      lookbackDays: LOOKBACK,
+    });
+  }
+
+  test("re-proposes the same close on every run of a week-long review window", () => {
+    // The close is not applied automatically — it opens a PR, and the watcher
+    // closes that PR as soon as a run produces no drift. So the close has to be
+    // re-derivable across enough consecutive runs for a human to review it. With
+    // lookbackDays equal to the minimum age this band was a single day: the next
+    // morning the burst aged out of the lookback, the baseline collapsed, and
+    // the unreviewed proposal was closed for good.
+    const closingAges: number[] = [];
+    for (let age = 1; age <= 40; age++) {
+      const { edits } = runAtAge(age);
+      if (edits.some((edit) => edit.kind === "close")) {
+        closingAges.push(age);
+      }
+    }
+
+    expect(closingAges).toEqual([21, 22, 23, 24, 25, 26, 27, 28]);
+    expect(closingAges.length).toBeGreaterThanOrEqual(7);
+  });
+
+  test("withholds the close below the minimum age and loses the baseline past the lookback", () => {
+    // The two ends of the band above, and how each is reported: too young while
+    // the evidence is still visible, then no evidence at all once the burst has
+    // fallen outside the lookback.
+    const tooYoung = runAtAge(20);
+    expect(tooYoung.edits).toHaveLength(0);
+    expect(tooYoung.warnings[0]?.kind).toBe("window-too-young");
+    expect(tooYoung.warnings[0]?.total).toBe(24);
+
+    const agedOut = runAtAge(29);
+    expect(agedOut.edits).toHaveLength(0);
+    expect(agedOut.warnings[0]?.kind).toBe("sparse-no-close");
+  });
+
+  test("rejects a lookback that collapses close eligibility to a single run", () => {
+    expect(() =>
+      proposeQueueWindowEdits({
+        file: makeFile({ "classic aram mayhem": [[WINDOW_START, null]] }),
+        counts: {},
+        today: TODAY,
+        lookbackDays: MIN_DRIFT_LOOKBACK_DAYS - 1,
+      }),
+    ).toThrow(/lookbackDays must be at least/);
   });
 });

--- a/packages/scout-for-lol/packages/data/src/model/queue-window-drift.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-window-drift.ts
@@ -30,6 +30,22 @@ const REOPEN_MAX_GAP_DAYS = 7;
 const CLOSE_TRAILING_EMPTY_DAYS = 10;
 /** Earlier-in-window match volume required to trust an auto-close. */
 const CLOSE_MIN_VOLUME_BASELINE = 20;
+/**
+ * A window must be at least this old before an auto-close is trusted.
+ *
+ * The volume baseline proves a mode WAS live; it says nothing about whether it
+ * stopped being live. A launch-week burst followed by quiet satisfies it
+ * perfectly, and that is the exact shape of a false positive: our evidence is
+ * biased to Scout's tracked players, so "nobody played it for 10 days" and
+ * "Riot turned it off" are indistinguishable.
+ *
+ * This fired for real. `classic aram mayhem` opened 2026-07-29 — the start of
+ * Ranked Season 3 — took 20+ matches over its first two days, then went quiet;
+ * on 2026-08-10 the watcher proposed retiring it (PR #2100) while ARAM: Mayhem
+ * was still receiving balance changes in the current patch. Twelve days is not
+ * enough evidence to retire a mode.
+ */
+const CLOSE_MIN_WINDOW_AGE_DAYS = 21;
 
 export type QueueWindowEditKind = "open" | "reopen" | "close";
 
@@ -44,6 +60,7 @@ export type QueueWindowEdit = {
 export type QueueWindowWarningKind =
   | "sparse-no-close"
   | "no-volume-baseline"
+  | "window-too-young"
   | "unknown-queue-id";
 
 export type QueueWindowWarning = {
@@ -317,8 +334,10 @@ type CloseOutcome =
   | { type: "close"; change: UnitChange }
   | {
       type: "warning";
-      kind: "sparse-no-close" | "no-volume-baseline";
+      kind: "sparse-no-close" | "no-volume-baseline" | "window-too-young";
       total: number;
+      /** Why the close was withheld, spliced into the operator-facing text. */
+      reason: string;
     };
 
 function tryClose(
@@ -366,6 +385,23 @@ function tryClose(
       : undefined;
 
   if (closeEnd !== undefined) {
+    // Final veto on an otherwise-valid close. Deliberately last: it must mean
+    // "every other signal said close, but the window is too new to trust", not
+    // pre-empt the volume-baseline check — otherwise a young window with
+    // trivial volume would be reported as too-young rather than as having no
+    // baseline, and the more specific diagnosis would be lost.
+    const windowAgeDays = Math.floor(
+      (todayMs - parseUtcDate(windowStart)) / DAY_MS,
+    );
+    if (windowAgeDays < CLOSE_MIN_WINDOW_AGE_DAYS) {
+      return {
+        type: "warning",
+        kind: "window-too-young",
+        total: earlierTotal,
+        reason: `the window is only ${windowAgeDays.toString()} day(s) old (minimum ${CLOSE_MIN_WINDOW_AGE_DAYS.toString()} before an auto-close is trusted)`,
+      };
+    }
+
     const nextWindows = windows.map((window, index) =>
       index === windows.length - 1 ? { ...window, end: closeEnd } : window,
     );
@@ -382,9 +418,19 @@ function tryClose(
   }
 
   if (earlierTotal > 0) {
-    return { type: "warning", kind: "no-volume-baseline", total: earlierTotal };
+    return {
+      type: "warning",
+      kind: "no-volume-baseline",
+      total: earlierTotal,
+      reason: `volume baseline is below threshold (${earlierTotal.toString()} < ${CLOSE_MIN_VOLUME_BASELINE.toString()})`,
+    };
   }
-  return { type: "warning", kind: "sparse-no-close", total: 0 };
+  return {
+    type: "warning",
+    kind: "sparse-no-close",
+    total: 0,
+    reason: "the mode is sparse (no matches observed in the window at all)",
+  };
 }
 
 export function proposeQueueWindowEdits(
@@ -459,7 +505,7 @@ export function proposeQueueWindowEdits(
             kind: closeOutcome.kind,
             queue: primaryKey,
             total: closeOutcome.total,
-            message: `${unit.keys.join("/")}: open-ended window has no recent matches but ${closeOutcome.kind === "sparse-no-close" ? "the mode is sparse" : "volume baseline is below threshold"}; not auto-closing`,
+            message: `${unit.keys.join("/")}: open-ended window has no recent matches but ${closeOutcome.reason}; not auto-closing`,
           });
         }
       }

--- a/packages/scout-for-lol/packages/data/src/model/queue-window-drift.ts
+++ b/packages/scout-for-lol/packages/data/src/model/queue-window-drift.ts
@@ -44,8 +44,37 @@ const CLOSE_MIN_VOLUME_BASELINE = 20;
  * on 2026-08-10 the watcher proposed retiring it (PR #2100) while ARAM: Mayhem
  * was still receiving balance changes in the current patch. Twelve days is not
  * enough evidence to retire a mode.
+ *
+ * This value is coupled to the caller's `lookbackDays` — see
+ * `MIN_DRIFT_LOOKBACK_DAYS`.
  */
 const CLOSE_MIN_WINDOW_AGE_DAYS = 21;
+/**
+ * Daily runs on which an otherwise-valid close must stay proposable.
+ *
+ * A close is not applied automatically: it opens a PR for a human to confirm
+ * against patch notes, and the watcher closes that PR as soon as a later run
+ * produces no drift. So the close must survive re-derivation across enough
+ * consecutive runs for someone to actually review it — a week.
+ */
+const CLOSE_MIN_ELIGIBLE_RUNS = 7;
+/**
+ * Smallest observation lookback that gives closes a usable review window.
+ *
+ * The two gates pull against each other. `CLOSE_MIN_WINDOW_AGE_DAYS` sets the
+ * earliest age at which a close may be proposed; `lookbackDays` sets the latest,
+ * because the volume baseline is only counted from observations still inside the
+ * lookback. In the worst case — every baseline match on the window's first day,
+ * which is exactly the launch-burst shape the age gate exists for — the close is
+ * proposable only while `CLOSE_MIN_WINDOW_AGE_DAYS <= age <= lookbackDays`.
+ *
+ * A lookback equal to the minimum age therefore collapses that band to a single
+ * run: the day after, the burst falls out of the lookback, the baseline drops
+ * below threshold, the run reports no drift, and the watcher closes the
+ * unreviewed proposal PR permanently.
+ */
+export const MIN_DRIFT_LOOKBACK_DAYS =
+  CLOSE_MIN_WINDOW_AGE_DAYS + CLOSE_MIN_ELIGIBLE_RUNS - 1;
 
 export type QueueWindowEditKind = "open" | "reopen" | "close";
 
@@ -440,6 +469,11 @@ export function proposeQueueWindowEdits(
   const todayMs = parseUtcDate(today);
   if (Number.isNaN(todayMs)) {
     throw new TypeError(`invalid today date: ${today}`);
+  }
+  if (lookbackDays < MIN_DRIFT_LOOKBACK_DAYS) {
+    throw new RangeError(
+      `lookbackDays must be at least ${MIN_DRIFT_LOOKBACK_DAYS.toString()} (got ${lookbackDays.toString()}): a close is only proposable while the window is between ${CLOSE_MIN_WINDOW_AGE_DAYS.toString()} and lookbackDays days old, and that band must span at least ${CLOSE_MIN_ELIGIBLE_RUNS.toString()} daily runs for the proposal PR to be reviewable`,
+    );
   }
   const obsStartMs = todayMs - lookbackDays * DAY_MS;
   const obsEndMs = todayMs - DAY_MS;

--- a/packages/temporal/src/activities/scout-queue-windows.ts
+++ b/packages/temporal/src/activities/scout-queue-windows.ts
@@ -19,7 +19,11 @@ const QUEUE_WINDOWS_PATH = `${SCOUT_ROOT}/packages/data/src/model/queue-windows.
 // The ONLY path this job is allowed to stage.
 const GENERATED_PATHS = [QUEUE_WINDOWS_PATH];
 const BUCKET = "scout-prod";
-const LOOKBACK_DAYS = 21;
+// Must stay above the drift engine's MIN_DRIFT_LOOKBACK_DAYS: the lookback is
+// what bounds how many consecutive runs re-derive a close proposal, and this
+// job closes the proposal PR the moment a run produces no drift. See
+// CLOSE_MIN_ELIGIBLE_RUNS in queue-window-drift.ts.
+const LOOKBACK_DAYS = 28;
 const PROPOSAL_BRANCH = "chore/scout-queue-windows";
 const AutoMergeStateSchema = z.enum(["true", "false"]);
 

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -247,7 +247,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutQueueWindowsWatch",
     args: [],
     // 06:45 PT — staggered after the 06:00 data-dragon version check. Scans
-    // the scout-prod match lake (21-day lookback) for limited-queue window
+    // the scout-prod match lake (28-day lookback) for limited-queue window
     // drift; opens an auto-merging PR for window opens/reopens, a plain PR
     // for closes (a human confirms against patch notes), and emails
     // warnings-only runs. Steady state is a silent no-diff.

--- a/packages/temporal/src/workflows/scout-queue-windows.ts
+++ b/packages/temporal/src/workflows/scout-queue-windows.ts
@@ -7,7 +7,7 @@ import type {
 const { refreshScoutQueueWindows } =
   proxyActivities<ScoutQueueWindowsActivities>({
     // Clones the monorepo, does the root + scout workspace installs, scans
-    // the scout-prod match lake for the 21-day lookback, and opens a PR on
+    // the scout-prod match lake for the 28-day lookback, and opens a PR on
     // window drift (auto-merge for open/reopen edits only). Heartbeats fire
     // every 10s in the activity, so worker death surfaces in <60s. 30 min
     // leaves room for a retry inside the 45-min workflowExecutionTimeout.


### PR DESCRIPTION
## Why

The watcher proposed retiring `classic aram mayhem` on 2026-08-10 (#2100). That window opened **2026-07-29 — the start of Ranked Season 3** — took 20+ matches over its first two days, then went quiet. ARAM: Mayhem was still receiving balance changes in patch 26.15, and no patch from 26.11–26.15 announced an end.

Every existing close condition was satisfied: no trailing matches, and the earlier-in-window volume cleared `CLOSE_MIN_VOLUME_BASELINE`. But that baseline proves a mode **was** live; nothing in the rule proves it **stopped being** live. Our evidence is biased to Scout's tracked players, so "nobody played it for 10 days" and "Riot turned it off" are indistinguishable — and a launch-week burst followed by quiet is exactly the false-positive shape.

**A wrong close is not cosmetic.** `subscription-filter-fields.tsx:144-150` hides unavailable, unselected queues behind a `Show unavailable queues` toggle, so closing a live window removes it from the subscription picker by default. Recovery is only partial: `REOPEN_MAX_GAP_DAYS` reopens the same window only if play resumes within 7 days; past that a *new* window is appended and the false gap persists permanently.

Structurally this is rare — with `CLOSE_TRAILING_EMPTY_DAYS = 10`, the "earlier" band is only `lookbackDays - 10` days wide, so `tryClose` almost always warns rather than closes. #2100 is the pathological case where a launch burst happened to clear the bar.

### The age gate is coupled to the lookback (review finding)

The first version of this PR set the minimum age to 21, the same value as the observation lookback, which left **exactly one** daily run where a close could be proposed.

The two gates bound the same band from opposite sides. The age gate sets the earliest age a close may be proposed; the lookback sets the latest, because the volume baseline is only counted from observations still inside it. In the launch-burst shape the age gate exists for — the whole baseline on the window's first day — a close is proposable only while `CLOSE_MIN_WINDOW_AGE_DAYS <= age <= lookbackDays`. Equal values collapse that band to a single day.

That single day is not survivable. A close is not applied automatically: it opens a PR for a human to confirm against patch notes, and `scout-queue-windows.ts` closes that PR as soon as a later run produces no drift. The morning after the one eligible run, the burst falls out of the lookback, the baseline drops below threshold, the run reports no drift, and the unreviewed proposal is closed for good.

## What

- Add `CLOSE_MIN_WINDOW_AGE_DAYS` (21) as a **final veto** on an otherwise-valid close, plus a `window-too-young` warning kind so the withheld close is still reported rather than silently dropped.
- **Order matters.** The age check runs *last*, after the volume baseline. Checking it earlier would report a young window with trivial volume as too-young instead of as having no baseline, losing the more specific diagnosis — the existing `does not close a fresh window from a prior run's pre-window volume` test caught exactly that when I first placed it too early.
- Give each close-warning outcome an explicit `reason` string instead of growing a ternary at the call site as warning kinds are added.
- **Widen the observation lookback 21 → 28 days** (the `scout-queue-windows-daily` schedule and the `update-queue-windows` CLI default), leaving the minimum age at 21. The launch-burst close now stays proposable across ages 21–28 — eight consecutive daily runs. Fixing this by *lowering* the age gate instead would have bought margin by giving up the point of the gate: 12 days of quiet is not evidence a mode was retired, and 14 is not meaningfully better.
- Add `MIN_DRIFT_LOOKBACK_DAYS` (`CLOSE_MIN_WINDOW_AGE_DAYS + CLOSE_MIN_ELIGIBLE_RUNS - 1` = 27) and **reject any shorter `lookbackDays` in the drift engine**, so the coupling cannot silently collapse again. The CLI validates `--lookback-days` against the same constant at argument parsing, so a bad value fails before the S3 scan rather than after it.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@shepherdjerred/temporal` — all green, 0 fail
- `bunx lefthook run pre-commit`, `bunx markdownlint-cli2 packages/scout-for-lol/AGENTS.md`
- `close guards` describe:
  - **PR #2100 replay** — window start `2026-07-29`, 24 matches across 07-29/07-30, `today = 2026-08-10`. Asserts no edits, a `window-too-young` warning, and that the window **stays open-ended** (the property that keeps the queue in the picker).
  - **Same evidence shape, older window** — still closes, so the guard is an age gate and not a blanket disable.
  - **Young window still being played** — stays silent, so the gate does not turn every fresh mode into a daily warning email.
- `close eligibility span` describe:
  - **Week-long review window** — sweeps window ages 1–40 against the worst-case evidence shape (the entire baseline on the window's first day) and asserts the close is re-proposed on exactly ages 21–28. This is the regression test for the single-day band.
  - **Both ends of the band** — `window-too-young` at age 20, `sparse-no-close` at age 29 once the burst has fallen outside the lookback.
  - **Lookback invariant** — a `lookbackDays` below the minimum throws.
- Not run: the scheduled watcher against the live `scout-prod` lake.

## Rollout note

The daily watcher scans 28 days of the `scout-prod` match lake instead of 21 — a third more objects per run, on a job that runs once a day at 06:45 PT.

## Follow-ups (not in this PR)

Tracked from the same investigation, deliberately separated:

- The drift engine reaches `QueueType` via `parseQueueType` alone, while the rest of the system uses `resolveQueueTypeFromGame` — which is durable across Riot's documented queue-ID churn (Arena has moved 1700 → 1750 → 1740). `queue-activity-s3.ts` already has `gameMode` in hand and discards it.
- No independent liveness oracle. The CommunityDragon `rcp-be-lol-game-data` queue catalog (already a dependency of the data-dragon refresh) carries per-queue enabled flags and would let a close be gated on something other than our own players' behaviour.

Non-visual change (pure drift-engine logic and a scan-window constant), so no screenshots.
