### PR TITLE
fix(homelab): mount the generated Alert Dashboard database secret

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { App } from "cdk8s";
+import { z } from "zod";
+import { createAlertDashboardChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/alert-dashboard.ts";
+
+const DeploymentSchema = z.object({
+  kind: z.literal("Deployment"),
+  metadata: z.object({ name: z.literal("alert-dashboard") }).loose(),
+  spec: z.object({
+    template: z.object({
+      spec: z.object({
+        volumes: z.array(
+          z
+            .object({
+              name: z.string(),
+              secret: z.object({ secretName: z.string() }).loose().optional(),
+            })
+            .loose(),
+        ),
+      }),
+    }),
+  }),
+});
+
+describe("Alert Dashboard deployment", () => {
+  test("mounts the Zalando-normalized database user secret", () => {
+    const app = new App();
+    createAlertDashboardChart(app);
+    const manifests = z.array(z.unknown()).parse(app.charts.at(0)?.toJson());
+    const deployment = manifests
+      .map((manifest) => DeploymentSchema.safeParse(manifest))
+      .find((result) => result.success)?.data;
+    if (deployment === undefined) {
+      throw new Error("Missing Deployment/alert-dashboard manifest");
+    }
+    const postgresSecret = deployment.spec.template.spec.volumes.find(
+      (volume) => volume.name === "pg-secret",
+    )?.secret?.secretName;
+
+    expect(postgresSecret).toBe(
+      "alert-dashboard.alert-dashboard-postgresql.credentials.postgresql.acid.zalan.do",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.ts
@@ -43,7 +43,7 @@ export function createAlertDashboardDeployment(chart: Chart) {
   const postgresSecret = Secret.fromSecretName(
     chart,
     "alert-dashboard-postgres-secret",
-    "alert_dashboard.alert-dashboard-postgresql.credentials.postgresql.acid.zalan.do",
+    "alert-dashboard.alert-dashboard-postgresql.credentials.postgresql.acid.zalan.do",
   );
   const pgSecretVolume = Volume.fromSecret(
     chart,


### PR DESCRIPTION
## Why

The Alert Dashboard PostgreSQL database recovered after the root admission policy was staged, but the application pod remained `Pending`. The deployment mounted `alert_dashboard.alert-dashboard-postgresql.credentials.postgresql.acid.zalan.do`; the Zalando operator normalizes the username and created `alert-dashboard.alert-dashboard-postgresql.credentials.postgresql.acid.zalan.do` instead.

## What

- Mount the exact operator-generated database credential Secret.
- Add a synthesized-manifest regression test for the `pg-secret` volume so the live Secret name cannot drift silently again.

## Verification

- `cd packages/homelab/src/cdk8s && bun test src/resources/alert-dashboard/index.test.ts src/alert-dashboard-network-policy.test.ts` (5 passed)
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`
- Synthesized `alert-dashboard.k8s.yaml` contains the exact live Secret name
- Full root verify: pending exact-head Buildkite PR CI

## Live evidence

- `pgdata-alert-dashboard-postgresql-0` is `Bound` at 16 GiB and `alert-dashboard-postgresql-0` is running.
- The operator-created database user Secret uses the hyphenated `alert-dashboard` prefix.
- The application pod reports `FailedMount` only for the underscore-prefixed Secret referenced by the current chart.