### PR TITLE
Prevent staged Argo releases from blocking across sync waves

### DIFF
--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -51,11 +51,16 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   This makes root-owned prerequisites available before child reconciliation
   without racing an automatic child operation. Bound each override request to
   750 kB because ArgoCD's operation-state update carries both the requested and
-  completed operation inside its 2 MiB controller message ceiling. Reconcile
-  children with aggregate health deferred, then atomically restore and prune
-  the exact root tree before one scoped release-health gate. Reject the old
-  split lifecycle, child-only staging, eager duplicate gates, shell-wrapped
-  commands, and unsafe ordering in pipeline validation.
+  completed operation inside its 2 MiB controller message ceiling. Keep each
+  request within one numeric Argo sync wave and submit waves in ascending order,
+  so health waiting in one wave cannot leave later-wave prerequisites unapplied.
+  Terminate each exact staged wave after all selected resources apply; a
+  degraded ordinary resource is deferred to the scoped health gate, while a
+  failed resource carrying an actual Argo hook type remains a hard failure.
+  Reconcile children with aggregate health deferred, then atomically restore
+  and prune the exact root tree before one scoped release-health gate. Reject
+  the old split lifecycle, child-only staging, eager duplicate gates,
+  shell-wrapped commands, and unsafe ordering in pipeline validation.
 
 ## Verification
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -49,6 +49,14 @@ copies the original request into status. In this cluster, a request near the
 observed 2 MiB controller message ceiling can therefore be accepted but never
 acquire visible operation state, matching
 [upstream reports of oversized operation-state patches](https://github.com/argoproj/argo-cd/issues/14224#issuecomment-1636337124).
+The batcher also keeps each request within one numeric Argo sync wave and sends
+waves in ascending order. Argo applies all targets in a wave before waiting for
+their health; separating waves prevents a degraded child Application in an
+earlier wave from leaving root-owned prerequisites in a later wave unapplied.
+Once every selected resource in a staged wave is applied, the release command
+terminates that exact operation instead of waiting for aggregate health. A
+failed resource with an actual Argo hook type still blocks termination; health
+for ordinary child Applications remains the final scoped release gate's job.
 
 After explicit child reconciliation completes, the full root apply restores
 the exact auto-sync policies and performs verified pruning. Aggregate child

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -11,12 +11,21 @@ import {
   type ManifestOverride,
 } from "./argocd-manifest-overrides.ts";
 
-function override(name: string, payloadLength: number): ManifestOverride {
+function override(
+  name: string,
+  payloadLength: number,
+  syncWave?: string,
+): ManifestOverride {
   return {
     manifest: JSON.stringify({
       apiVersion: "argoproj.io/v1alpha1",
       kind: "Application",
-      metadata: { name },
+      metadata: {
+        name,
+        ...(syncWave === undefined
+          ? {}
+          : { annotations: { "argocd.argoproj.io/sync-wave": syncWave } }),
+      },
       spec: { payload: "x".repeat(payloadLength) },
     }),
     resource: {
@@ -67,6 +76,28 @@ describe("manifest override batching", () => {
       "one",
       "two",
     ]);
+  });
+
+  test("keeps sync waves in separate requests and Argo application order", () => {
+    const batches = batchManifestOverrides(
+      [
+        override("later", 100, "3"),
+        override("default-one", 100),
+        override("earlier", 100, "-2"),
+        override("default-two", 100, "0"),
+      ],
+      5000,
+    );
+
+    expect(
+      batches.map(({ resources }) => resources.map(({ name }) => name)),
+    ).toEqual([["earlier"], ["default-one", "default-two"], ["later"]]);
+  });
+
+  test("fails loudly for an invalid sync wave", () => {
+    expect(() =>
+      batchManifestOverrides([override("bad", 100, "next")]),
+    ).toThrow('Application/bad has invalid Argo CD sync wave "next"');
   });
 
   test("fails when one manifest cannot fit", () => {

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -4,6 +4,8 @@ import { canonicalJson } from "./canonical-json.ts";
 const DEFAULT_MAX_REQUEST_BYTES = 750_000;
 const SERIALIZED_REQUEST_ID = "00000000-0000-0000-0000-000000000000";
 const SERIALIZED_OPERATION_ID = "00000000-0000-0000-0000-000000000000";
+const SYNC_WAVE_ANNOTATION = "argocd.argoproj.io/sync-wave";
+const SYNC_WAVE_PATTERN = /^[+-]?\d+$/;
 
 export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
@@ -33,6 +35,12 @@ const OperationInfoSchema = z
       .optional(),
   })
   .loose();
+
+const SyncWaveManifestSchema = z.object({
+  metadata: z.object({
+    annotations: z.record(z.string(), z.string()).optional(),
+  }),
+});
 
 export type SyncOperationResource = {
   group: string;
@@ -81,23 +89,28 @@ function appendOverride(
   };
 }
 
-/**
- * Keep manifest-override operations comfortably below Argo CD's 2 MiB gRPC
- * message ceiling. The application-controller's operation-state update
- * includes both the requested and completed operation, so the manifest
- * payload can appear twice in that message. A 750 kB request budget leaves
- * almost 600 kB for the rest of the Application while staying below 2 MiB.
- * The request is measured after JSON serialization so escaping and resource
- * selectors are included instead of estimated.
- */
-export function batchManifestOverrides(
-  overrides: readonly ManifestOverride[],
-  maxRequestBytes = DEFAULT_MAX_REQUEST_BYTES,
-): ManifestOverrideBatch[] {
-  if (!Number.isSafeInteger(maxRequestBytes) || maxRequestBytes <= 0) {
-    throw new Error("maxRequestBytes must be a positive safe integer");
+function manifestSyncWave(override: ManifestOverride): number {
+  const parsed: unknown = JSON.parse(override.manifest);
+  const annotation =
+    SyncWaveManifestSchema.parse(parsed).metadata.annotations?.[
+      SYNC_WAVE_ANNOTATION
+    ];
+  if (annotation === undefined) {
+    return 0;
   }
+  const wave = Number(annotation);
+  if (!SYNC_WAVE_PATTERN.test(annotation) || !Number.isSafeInteger(wave)) {
+    throw new Error(
+      `manifest override for ${override.resource.kind}/${override.resource.name} has invalid Argo CD sync wave ${JSON.stringify(annotation)}`,
+    );
+  }
+  return wave;
+}
 
+function batchSingleSyncWave(
+  overrides: readonly ManifestOverride[],
+  maxRequestBytes: number,
+): ManifestOverrideBatch[] {
   const batches: ManifestOverrideBatch[] = [];
   let current: ManifestOverrideBatch = { manifests: [], resources: [] };
 
@@ -124,6 +137,40 @@ export function batchManifestOverrides(
     batches.push(current);
   }
   return batches;
+}
+
+/**
+ * Keep manifest-override operations comfortably below Argo CD's 2 MiB gRPC
+ * message ceiling. The application-controller's operation-state update
+ * includes both the requested and completed operation, so the manifest
+ * payload can appear twice in that message. A 750 kB request budget leaves
+ * almost 600 kB for the rest of the Application while staying below 2 MiB.
+ * The request is measured after JSON serialization so escaping and resource
+ * selectors are included instead of estimated. Each request also contains
+ * exactly one Argo CD sync wave. Argo applies every target in a wave before it
+ * waits for health, so a degraded resource cannot strand later-wave targets
+ * inside the same manifest-override operation.
+ */
+export function batchManifestOverrides(
+  overrides: readonly ManifestOverride[],
+  maxRequestBytes = DEFAULT_MAX_REQUEST_BYTES,
+): ManifestOverrideBatch[] {
+  if (!Number.isSafeInteger(maxRequestBytes) || maxRequestBytes <= 0) {
+    throw new Error("maxRequestBytes must be a positive safe integer");
+  }
+
+  const overridesBySyncWave = new Map<number, ManifestOverride[]>();
+  for (const override of overrides) {
+    const wave = manifestSyncWave(override);
+    const waveOverrides = overridesBySyncWave.get(wave) ?? [];
+    waveOverrides.push(override);
+    overridesBySyncWave.set(wave, waveOverrides);
+  }
+  return [...overridesBySyncWave.entries()]
+    .sort(([leftWave], [rightWave]) => leftWave - rightWave)
+    .flatMap(([, waveOverrides]) =>
+      batchSingleSyncWave(waveOverrides, maxRequestBytes),
+    );
 }
 
 export function requestedOperationIdentity(application: unknown): string {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -454,6 +454,8 @@ async function stageRootRelease(
     );
     await sync(rootAppName, timeoutSeconds, false, {
       prune: false,
+      revision: exactRevision,
+      terminateAfterApplied: true,
       manifests: batch.manifests,
       resources: batch.resources,
     });
@@ -673,11 +675,32 @@ async function sync(
     options.revision !== undefined &&
     expectedResourceIdentities === undefined
   ) {
-    expectedResourceIdentities = await getExpectedSyncResultIdentities(
-      appName,
-      options.revision,
-      token,
-    );
+    if (options.resources === undefined) {
+      expectedResourceIdentities = await getExpectedSyncResultIdentities(
+        appName,
+        options.revision,
+        token,
+      );
+    } else {
+      const identities = options.resources.map(({ group, kind, name }) =>
+        resourceIdentity(group, kind, name),
+      );
+      if (identities.length === 0) {
+        throw new Error(
+          "Manifest-override termination requires at least one selected resource",
+        );
+      }
+      const unique = new Set(identities);
+      if (unique.size !== identities.length) {
+        throw new Error(
+          "Manifest-override termination received duplicate group/kind/name identities",
+        );
+      }
+      expectedResourceIdentities = {
+        desired: unique,
+        pruned: new Set(),
+      };
+    }
   }
   const requestId = SyncRequestIdSchema.parse(
     options.requestId ?? crypto.randomUUID(),
@@ -1003,6 +1026,7 @@ function syncResultApplied(
       return false;
     }
     const status = resource["status"];
+    const hookType = resource["hookType"];
     const hookPhase = resource["hookPhase"];
     const group = resource["group"];
     const kind = resource["kind"];
@@ -1014,6 +1038,13 @@ function syncResultApplied(
     ) {
       return false;
     }
+    if (
+      hookType !== undefined &&
+      hookType !== null &&
+      typeof hookType !== "string"
+    ) {
+      return false;
+    }
     const identity = resourceIdentity(group ?? "", kind, name);
     appliedResourceIdentities.add(identity);
     if (status === "Pruned") {
@@ -1021,8 +1052,11 @@ function syncResultApplied(
     }
     return (
       (status === "Synced" || status === "Pruned" || status === "Skipped") &&
-      hookPhase !== "Failed" &&
-      hookPhase !== "Error"
+      !(
+        hookType !== undefined &&
+        hookType !== null &&
+        (hookPhase === "Failed" || hookPhase === "Error")
+      )
     );
   });
   return (

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -22,6 +22,7 @@ const RootSyncRequestSchema = z.object({
 type OperationResource = {
   readonly group?: string;
   readonly hookPhase?: string;
+  readonly hookType?: string;
   readonly kind?: string;
   readonly name?: string;
   readonly status: string;
@@ -500,6 +501,49 @@ test("atomic Argo sync adopts the exact active operation without another POST", 
     expect(result.stdout).toContain("adopted active sync operation: apps");
     expect(lifecycle.observations.syncPosts).toBe(0);
     expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync can finalize an applied degraded non-hook resource", async () => {
+  const lifecycle = serveLifecycle([
+    { status: {} },
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Failed" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("terminated applied sync operation: apps");
+    expect(lifecycle.observations.deleteRequests).toBe(1);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
+
+test("atomic Argo sync never finalizes a failed Argo hook", async () => {
+  const lifecycle = serveLifecycle([
+    { status: {} },
+    applicationOperation({
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced", hookPhase: "Failed", hookType: "Sync" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("did not complete within 1s");
+    expect(lifecycle.observations.deleteRequests).toBe(0);
   } finally {
     await lifecycle.server.stop(true);
   }

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -20,6 +20,7 @@ const SyncRequestSchema = z.object({
     }),
   ),
   manifests: z.array(z.string()),
+  revision: z.string().optional(),
   resources: z.array(
     z.object({
       group: z.string(),
@@ -66,7 +67,45 @@ const WorkerApplicationResource = {
   name: "worker",
 };
 
-function operationForSyncRequest(request: unknown): unknown {
+const StagedRepositoryApplication = JSON.stringify({
+  apiVersion: "argoproj.io/v1alpha1",
+  kind: "Application",
+  metadata: { name: "worker" },
+  spec: {
+    source: {
+      repoURL: "https://chartmuseum.sjer.red",
+      chart: "worker",
+      targetRevision: "2.0.0-43",
+    },
+    syncPolicy: { automated: { prune: true, selfHeal: true } },
+  },
+});
+
+const StagedAdmissionPolicy = JSON.stringify({
+  apiVersion: "admissionregistration.k8s.io/v1",
+  kind: "ValidatingAdmissionPolicy",
+  metadata: {
+    name: "pvc-backup-policy.sjer.red",
+    annotations: { "argocd.argoproj.io/sync-wave": "1" },
+  },
+  spec: { failurePolicy: "Fail" },
+});
+
+const StagedExternalApplication = JSON.stringify({
+  apiVersion: "argoproj.io/v1alpha1",
+  kind: "Application",
+  metadata: { name: "external" },
+  spec: {
+    source: {
+      repoURL: "https://charts.example.com",
+      chart: "external",
+      targetRevision: "1.0.0",
+    },
+    syncPolicy: { automated: {} },
+  },
+});
+
+function operationForSyncRequest(request: unknown): Record<string, unknown> {
   const syncRequest = SyncRequestSchema.parse(request);
   return {
     info: syncRequest.infos,
@@ -74,6 +113,9 @@ function operationForSyncRequest(request: unknown): unknown {
     sync: {
       manifests: syncRequest.manifests,
       resources: syncRequest.resources,
+      ...(syncRequest.revision === undefined
+        ? {}
+        : { revision: syncRequest.revision }),
     },
   };
 }
@@ -612,40 +654,8 @@ describe("Argo CD root release staging", () => {
   test("stages root prerequisites while child auto-sync remains suspended", async () => {
     const syncBodies: unknown[] = [];
     let requestedOperation: unknown;
-    const repositoryApplication = JSON.stringify({
-      apiVersion: "argoproj.io/v1alpha1",
-      kind: "Application",
-      metadata: { name: "worker" },
-      spec: {
-        source: {
-          repoURL: "https://chartmuseum.sjer.red",
-          chart: "worker",
-          targetRevision: "2.0.0-43",
-        },
-        syncPolicy: {
-          automated: { prune: true, selfHeal: true },
-        },
-      },
-    });
-    const admissionPolicy = JSON.stringify({
-      apiVersion: "admissionregistration.k8s.io/v1",
-      kind: "ValidatingAdmissionPolicy",
-      metadata: { name: "pvc-backup-policy.sjer.red" },
-      spec: { failurePolicy: "Fail" },
-    });
-    const externalApplication = JSON.stringify({
-      apiVersion: "argoproj.io/v1alpha1",
-      kind: "Application",
-      metadata: { name: "external" },
-      spec: {
-        source: {
-          repoURL: "https://charts.example.com",
-          chart: "external",
-          targetRevision: "1.0.0",
-        },
-        syncPolicy: { automated: {} },
-      },
-    });
+    let activeSyncRequest: z.infer<typeof SyncRequestSchema> | undefined;
+    let deleteRequests = 0;
     const server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
@@ -667,9 +677,9 @@ describe("Argo CD root release staging", () => {
           expect(url.searchParams.get("revision")).toBe("2.0.0-43");
           return Response.json({
             manifests: [
-              repositoryApplication,
-              externalApplication,
-              admissionPolicy,
+              StagedRepositoryApplication,
+              StagedExternalApplication,
+              StagedAdmissionPolicy,
             ],
           });
         }
@@ -679,6 +689,7 @@ describe("Argo CD root release staging", () => {
         ) {
           const body = await request.json();
           syncBodies.push(body);
+          activeSyncRequest = SyncRequestSchema.parse(body);
           requestedOperation = operationForSyncRequest(body);
           return Response.json({ operation: requestedOperation });
         }
@@ -686,15 +697,41 @@ describe("Argo CD root release staging", () => {
           request.method === "GET" &&
           url.pathname === "/api/v1/applications/apps"
         ) {
+          if (
+            requestedOperation === undefined ||
+            activeSyncRequest === undefined
+          ) {
+            return Response.json({ status: {} });
+          }
           return Response.json({
+            operation: requestedOperation,
             status: {
               operationState: {
-                phase: "Succeeded",
+                phase: "Running",
                 startedAt: new Date().toISOString(),
                 operation: requestedOperation,
+                syncResult: {
+                  revision: activeSyncRequest.revision,
+                  resources: activeSyncRequest.resources.map((resource) => ({
+                    ...resource,
+                    status: "Synced",
+                    ...(resource.name === "worker"
+                      ? { hookPhase: "Failed" }
+                      : {}),
+                  })),
+                },
               },
             },
           });
+        }
+        if (
+          request.method === "DELETE" &&
+          url.pathname === "/api/v1/applications/apps/operation"
+        ) {
+          deleteRequests++;
+          requestedOperation = undefined;
+          activeSyncRequest = undefined;
+          return Response.json({});
         }
         return new Response("not found", { status: 404 });
       },
@@ -735,28 +772,35 @@ describe("Argo CD root release staging", () => {
       expect(stderr).toBe("");
       expect(stdout).toContain("stage-root-release: apps at 2.0.0-43");
       expect(stdout).toContain("suspending auto-sync: worker");
-      expect(syncBodies).toHaveLength(1);
-      const stagedRequest = SyncRequestSchema.parse(syncBodies[0]);
-      expect(stagedRequest.resources).toEqual([
+      expect(stdout).toContain("terminated applied sync operation: apps");
+      expect(syncBodies).toHaveLength(2);
+      expect(deleteRequests).toBe(2);
+      const applicationRequest = SyncRequestSchema.parse(syncBodies[0]);
+      expect(applicationRequest.revision).toBe("2.0.0-43");
+      expect(applicationRequest.resources).toEqual([
         WorkerApplicationResource,
         {
           group: "argoproj.io",
           kind: "Application",
           name: "external",
         },
+      ]);
+      const policyRequest = SyncRequestSchema.parse(syncBodies[1]);
+      expect(policyRequest.revision).toBe("2.0.0-43");
+      expect(policyRequest.resources).toEqual([
         {
           group: "admissionregistration.k8s.io",
           kind: "ValidatingAdmissionPolicy",
           name: "pvc-backup-policy.sjer.red",
         },
       ]);
-      expect(JSON.parse(stagedRequest.manifests[0] ?? "")).toMatchObject({
+      expect(JSON.parse(applicationRequest.manifests[0] ?? "")).toMatchObject({
         spec: { syncPolicy: { automated: { enabled: false } } },
       });
-      expect(JSON.parse(stagedRequest.manifests[1] ?? "")).toMatchObject({
+      expect(JSON.parse(applicationRequest.manifests[1] ?? "")).toMatchObject({
         spec: { syncPolicy: { automated: { enabled: false } } },
       });
-      expect(stagedRequest.manifests[2]).toBe(admissionPolicy);
+      expect(policyRequest.manifests[0]).toBe(StagedAdmissionPolicy);
     } finally {
       await server.stop(true);
     }


### PR DESCRIPTION
## Why

Buildkite main build #9001 proved that request-size batching alone is insufficient for staged root releases. Its fourth manifest-override request crossed Argo sync waves; the already-degraded `alert-dashboard` child held wave 0 open, so 21 later-wave root prerequisites were never applied and the job timed out after 300 seconds.

## What

- Group manifest overrides by numeric `argocd.argoproj.io/sync-wave`, submit waves in Argo order, and retain the 750 kB serialized request budget within each wave.
- Run each staged batch at the exact chart revision and terminate only after every selected resource reports `Synced`, `Pruned`, or `Skipped`.
- Distinguish failed real Argo hooks (`hookType` present) from an ordinary resource whose health-derived `hookPhase` is failed, leaving aggregate child health to the scoped release gate.
- Add regressions for wave ordering, invalid annotations, degraded non-hook resources, failed hooks, selected-resource completeness, and post-termination progression.
- Update the durable atomic-sync plan and release-safety explanation.

## Verification

- `cd packages/homelab/src/cdk8s && bun test src/argocd-script.test.ts src/argocd-atomic-sync.test.ts ../../scripts/argocd-manifest-overrides.test.ts` — 60 passed.
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s` — passed.
- `bunx turbo run typecheck test build --filter=@shepherdjerred/docs-wiki` — passed.
- `cd packages/docs/wiki && bun run test:e2e` — 7 passed.
- Desktop and 390 px mobile documentation renders inspected; no overflow and the new operator boundary is present.
- `bunx lefthook run pre-commit` — passed.
- `bun run verify` — 247/248 tasks passed locally; the only failure was the independently reproduced missing local `xelatex` executable in the unrelated resume build. CI selects the resume build separately only when its paths change, so this unrelated local gate is explicitly unrun rather than reported as passed.
- Exact-head Buildkite #9006: `verify`, Playwright, Semgrep, and the deploy/drift dry-run passed.
- Live `2.0.0-9001` rendering produces eight single-wave requests (waves -1, 0, 1, 2, 3), all below 750 kB.

## Rollout

The failed #9001 operation was revalidated as the exact Buildkite-owned request `6a391064-45df-4de0-b357-b83566a83d19` / operation `114d5278-3585-40c6-8260-6360ca665dcd` and cleared through ArgoCD after the job failed. This cleanup is not acceptance evidence. Merge requires clean exact-head review and Buildkite checks; main acceptance still requires `verify`, `helm-push`, `argocd-sync`, scoped release health, and no lingering root operation.