### PR TITLE
Persist Argo manifest-sync revision identity

### DIFF
--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -57,6 +57,9 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   Terminate each exact staged wave after all selected resources apply; a
   degraded ordinary resource is deferred to the scoped health gate, while a
   failed resource carrying an actual Argo hook type remains a hard failure.
+  Persist the exact revision in operation info alongside both UUIDs because
+  Argo omits `operation.sync.revision` for manifest-override operations; when
+  both representations exist, require them to agree.
   Reconcile children with aggregate health deferred, then atomically restore
   and prune the exact root tree before one scoped release-health gate. Reject
   the old split lifecycle, child-only staging, eager duplicate gates,

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -57,6 +57,10 @@ Once every selected resource in a staged wave is applied, the release command
 terminates that exact operation instead of waiting for aggregate health. A
 failed resource with an actual Argo hook type still blocks termination; health
 for ordinary child Applications remains the final scoped release gate's job.
+Argo omits `operation.sync.revision` from manifest-override operations, so the
+release command also persists the exact revision in the operation info list
+beside its request and operation UUIDs. Either representation can prove the
+revision, but disagreement between them is a hard identity failure.
 
 After explicit child reconciliation completes, the full root apply restores
 the exact auto-sync policies and performs verified pruning. Aggregate child

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -90,6 +90,11 @@ failure. Each POST also receives an internal operation UUID; adoption requires
 the live operation and its status to share that UUID before a stable applied
 result can be finalized.
 
+For manifest-override staging operations, inspect the
+`ci.sjer.red/revision` operation-info entry. Argo does not retain
+`operation.sync.revision` for that request shape, so CI persists the same exact
+revision beside both UUIDs and rejects any disagreement when both forms exist.
+
 A release blocked here means the current operation must be inspected before
 retrying. If it is a fully applied operation from an interrupted older client,
 recover it with both values from the live operation:

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -5,9 +5,11 @@ import {
   completedOperationIdentity,
   completedOperationId,
   completedOperationRequestId,
+  operationInfoRevision,
   requestedOperationIdentity,
   requestedOperationId,
   requestedOperationRequestId,
+  requestedOperationRevision,
   type ManifestOverride,
 } from "./argocd-manifest-overrides.ts";
 
@@ -40,7 +42,7 @@ describe("manifest override batching", () => {
   test("keeps matching manifests and resource selectors together", () => {
     const batches = batchManifestOverrides(
       [override("one", 400), override("two", 400)],
-      1500,
+      { maxRequestBytes: 1500 },
     );
 
     expect(batches).toHaveLength(1);
@@ -54,7 +56,7 @@ describe("manifest override batching", () => {
   test("splits requests before the serialized budget is exceeded", () => {
     const batches = batchManifestOverrides(
       [override("one", 600), override("two", 600), override("three", 600)],
-      1200,
+      { maxRequestBytes: 1200 },
     );
 
     expect(batches).toHaveLength(3);
@@ -63,6 +65,20 @@ describe("manifest override batching", () => {
       "two",
       "three",
     ]);
+  });
+
+  test("counts revision identity only for revisioned requests", () => {
+    const overrides = [override("one", 400), override("two", 400)];
+
+    expect(
+      batchManifestOverrides(overrides, { maxRequestBytes: 1400 }),
+    ).toHaveLength(1);
+    expect(
+      batchManifestOverrides(overrides, {
+        maxRequestBytes: 1400,
+        revision: "2.0.0-42",
+      }),
+    ).toHaveLength(2);
   });
 
   test("leaves room for Argo's duplicated operation-state envelope", () => {
@@ -86,7 +102,7 @@ describe("manifest override batching", () => {
         override("earlier", 100, "-2"),
         override("default-two", 100, "0"),
       ],
-      5000,
+      { maxRequestBytes: 5000 },
     );
 
     expect(
@@ -101,9 +117,11 @@ describe("manifest override batching", () => {
   });
 
   test("fails when one manifest cannot fit", () => {
-    expect(() => batchManifestOverrides([override("huge", 2000)], 500)).toThrow(
-      "Application/huge exceeds the request budget",
-    );
+    expect(() =>
+      batchManifestOverrides([override("huge", 2000)], {
+        maxRequestBytes: 500,
+      }),
+    ).toThrow("Application/huge exceeds the request budget");
   });
 });
 
@@ -194,6 +212,36 @@ describe("Argo operation identity", () => {
     expect(completedOperationId(previous)).toBe("previous-operation");
   });
 
+  test("reads the revision persisted in operation info", () => {
+    const operation = {
+      operation: {
+        info: [{ name: "ci.sjer.red/revision", value: "2.0.0-42" }],
+      },
+    };
+
+    expect(requestedOperationRevision(operation)).toBe("2.0.0-42");
+    expect(operationInfoRevision(operation.operation)).toBe("2.0.0-42");
+  });
+
+  test("rejects a direct revision without persisted CI identity", () => {
+    expect(() =>
+      requestedOperationRevision({
+        operation: { sync: { revision: "2.0.0-42" } },
+      }),
+    ).toThrow("missing the CI revision");
+  });
+
+  test("rejects disagreement with the direct revision", () => {
+    expect(() =>
+      requestedOperationRevision({
+        operation: {
+          info: [{ name: "ci.sjer.red/revision", value: "2.0.0-42" }],
+          sync: { revision: "2.0.0-43" },
+        },
+      }),
+    ).toThrow("Argo operation revision mismatch");
+  });
+
   test("returns null before an Application has an operation state", () => {
     expect(completedOperationIdentity({ status: {} })).toBeNull();
   });
@@ -240,5 +288,16 @@ describe("Argo operation identity", () => {
         },
       }),
     ).toThrow("multiple CI operation IDs");
+  });
+
+  test("fails when an operation has duplicate CI revisions", () => {
+    expect(() =>
+      operationInfoRevision({
+        info: [
+          { name: "ci.sjer.red/revision", value: "2.0.0-41" },
+          { name: "ci.sjer.red/revision", value: "2.0.0-42" },
+        ],
+      }),
+    ).toThrow("multiple CI revisions");
   });
 });

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -9,6 +9,7 @@ const SYNC_WAVE_PATTERN = /^[+-]?\d+$/;
 
 export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
+export const SYNC_REVISION_INFO_NAME = "ci.sjer.red/revision";
 
 const ApplicationOperationSchema = z.object({
   operation: z.record(z.string(), z.unknown()).optional(),
@@ -36,6 +37,17 @@ const OperationInfoSchema = z
   })
   .loose();
 
+const OperationSyncRevisionSchema = z
+  .object({
+    sync: z
+      .object({
+        revision: z.string().optional(),
+      })
+      .loose()
+      .optional(),
+  })
+  .loose();
+
 const SyncWaveManifestSchema = z.object({
   metadata: z.object({
     annotations: z.record(z.string(), z.string()).optional(),
@@ -59,7 +71,10 @@ export type ManifestOverrideBatch = {
   resources: SyncOperationResource[];
 };
 
-function serializedRequestBytes(batch: ManifestOverrideBatch): number {
+function serializedRequestBytes(
+  batch: ManifestOverrideBatch,
+  revision: string | undefined,
+): number {
   return new TextEncoder().encode(
     JSON.stringify({
       prune: false,
@@ -72,7 +87,11 @@ function serializedRequestBytes(batch: ManifestOverrideBatch): number {
           name: SYNC_OPERATION_ID_INFO_NAME,
           value: SERIALIZED_OPERATION_ID,
         },
+        ...(revision === undefined
+          ? []
+          : [{ name: SYNC_REVISION_INFO_NAME, value: revision }]),
       ],
+      ...(revision === undefined ? {} : { revision }),
       manifests: batch.manifests,
       resources: batch.resources,
     }),
@@ -110,13 +129,14 @@ function manifestSyncWave(override: ManifestOverride): number {
 function batchSingleSyncWave(
   overrides: readonly ManifestOverride[],
   maxRequestBytes: number,
+  revision: string | undefined,
 ): ManifestOverrideBatch[] {
   const batches: ManifestOverrideBatch[] = [];
   let current: ManifestOverrideBatch = { manifests: [], resources: [] };
 
   for (const override of overrides) {
     const candidate = appendOverride(current, override);
-    if (serializedRequestBytes(candidate) <= maxRequestBytes) {
+    if (serializedRequestBytes(candidate, revision) <= maxRequestBytes) {
       current = candidate;
       continue;
     }
@@ -126,7 +146,7 @@ function batchSingleSyncWave(
     } else {
       current = candidate;
     }
-    if (serializedRequestBytes(current) > maxRequestBytes) {
+    if (serializedRequestBytes(current, revision) > maxRequestBytes) {
       throw new Error(
         `manifest override for ${override.resource.kind}/${override.resource.name} exceeds the request budget`,
       );
@@ -153,8 +173,12 @@ function batchSingleSyncWave(
  */
 export function batchManifestOverrides(
   overrides: readonly ManifestOverride[],
-  maxRequestBytes = DEFAULT_MAX_REQUEST_BYTES,
+  options: {
+    readonly maxRequestBytes?: number;
+    readonly revision?: string;
+  } = {},
 ): ManifestOverrideBatch[] {
+  const maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
   if (!Number.isSafeInteger(maxRequestBytes) || maxRequestBytes <= 0) {
     throw new Error("maxRequestBytes must be a positive safe integer");
   }
@@ -169,7 +193,7 @@ export function batchManifestOverrides(
   return [...overridesBySyncWave.entries()]
     .sort(([leftWave], [rightWave]) => leftWave - rightWave)
     .flatMap(([, waveOverrides]) =>
-      batchSingleSyncWave(waveOverrides, maxRequestBytes),
+      batchSingleSyncWave(waveOverrides, maxRequestBytes, options.revision),
     );
 }
 
@@ -219,6 +243,30 @@ function operationId(operation: Record<string, unknown>): string | null {
   );
 }
 
+export function operationInfoRevision(
+  operation: Record<string, unknown>,
+): string | null {
+  return operationInfoValue(operation, SYNC_REVISION_INFO_NAME, "revision");
+}
+
+export function operationRevision(
+  operation: Record<string, unknown>,
+): string | undefined {
+  const directRevision =
+    OperationSyncRevisionSchema.parse(operation).sync?.revision;
+  const persistedRevision = operationInfoRevision(operation) ?? undefined;
+  if (
+    directRevision !== undefined &&
+    persistedRevision !== undefined &&
+    directRevision !== persistedRevision
+  ) {
+    throw new Error(
+      `Argo operation revision mismatch: sync revision ${directRevision} does not match CI revision ${persistedRevision}`,
+    );
+  }
+  return directRevision ?? persistedRevision;
+}
+
 export function requestedOperationRequestId(application: unknown): string {
   const operation = ApplicationOperationSchema.parse(application).operation;
   if (operation === undefined) {
@@ -229,6 +277,19 @@ export function requestedOperationRequestId(application: unknown): string {
     throw new Error("Argo sync response is missing the CI request ID");
   }
   return requestId;
+}
+
+export function requestedOperationRevision(application: unknown): string {
+  const operation = ApplicationOperationSchema.parse(application).operation;
+  if (operation === undefined) {
+    throw new Error("Argo sync response is missing the requested operation");
+  }
+  const persistedRevision = operationInfoRevision(operation);
+  if (persistedRevision === null) {
+    throw new Error("Argo sync response is missing the CI revision");
+  }
+  operationRevision(operation);
+  return persistedRevision;
 }
 
 export function activeOperationRequestId(application: unknown): string | null {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -51,10 +51,13 @@ import {
   batchManifestOverrides,
   completedOperationId,
   completedOperationRequestId,
+  operationRevision,
   requestedOperationId,
   requestedOperationRequestId,
+  requestedOperationRevision,
   SYNC_OPERATION_ID_INFO_NAME,
   SYNC_REQUEST_ID_INFO_NAME,
+  SYNC_REVISION_INFO_NAME,
   type ManifestOverride,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
@@ -447,6 +450,7 @@ async function stageRootRelease(
   }
   const batches = batchManifestOverrides(
     staged.map(({ override }) => override),
+    { revision: exactRevision },
   );
   for (const [index, batch] of batches.entries()) {
     console.log(
@@ -772,6 +776,9 @@ async function sync(
         infos: [
           { name: SYNC_REQUEST_ID_INFO_NAME, value: requestId },
           { name: SYNC_OPERATION_ID_INFO_NAME, value: operationId },
+          ...(options.revision === undefined
+            ? []
+            : [{ name: SYNC_REVISION_INFO_NAME, value: options.revision }]),
         ],
         ...(options.revision === undefined
           ? {}
@@ -803,6 +810,14 @@ async function sync(
         `Argo sync response returned operation ${responseOperationId}; expected ${operationId}`,
       );
     }
+    if (
+      options.revision !== undefined &&
+      requestedOperationRevision(responseBody) !== options.revision
+    ) {
+      throw new Error(
+        `Argo sync response returned a different CI revision; expected ${options.revision}`,
+      );
+    }
     console.log(`sync operation started: ${appName}`);
   }
   if (options.waitForCompletion === false) {
@@ -823,14 +838,6 @@ async function sync(
 function operationState(app: Record<string, unknown>): Record<string, unknown> {
   const status = isRecord(app["status"]) ? app["status"] : {};
   return isRecord(status["operationState"]) ? status["operationState"] : {};
-}
-
-function operationRevision(
-  operation: Record<string, unknown>,
-): string | undefined {
-  const sync = isRecord(operation["sync"]) ? operation["sync"] : {};
-  const revision = sync["revision"];
-  return typeof revision === "string" ? revision : undefined;
 }
 
 type OperationObservation = {

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -8,13 +8,23 @@ const CURRENT_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
 const OTHER_OPERATION_ID = "44444444-4444-4444-8444-444444444444";
 const REVISION = "2.0.0-42";
 
+const SyncInfoEntrySchema = z.discriminatedUnion("name", [
+  z.object({
+    name: z.literal("ci.sjer.red/request-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/operation-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/revision"),
+    value: z.string(),
+  }),
+]);
+
 const RootSyncRequestSchema = z.object({
-  infos: z.array(
-    z.object({
-      name: z.string(),
-      value: z.uuid(),
-    }),
-  ),
+  infos: z.array(SyncInfoEntrySchema),
   prune: z.boolean(),
   revision: z.string(),
 });
@@ -53,6 +63,7 @@ function identifiedOperation(
   requestId: string,
   revision = REVISION,
   operationId: string | null = CURRENT_OPERATION_ID,
+  persistedRevision?: string,
 ): unknown {
   return {
     info: [
@@ -68,6 +79,14 @@ function identifiedOperation(
               value: operationId,
             },
           ]),
+      ...(persistedRevision === undefined
+        ? []
+        : [
+            {
+              name: "ci.sjer.red/revision",
+              value: persistedRevision,
+            },
+          ]),
     ],
     sync: { revision },
   };
@@ -78,6 +97,7 @@ function applicationOperation(options: {
   readonly liveOperationId?: string | null;
   readonly message?: string;
   readonly operationId?: string | null;
+  readonly persistedRevision?: string;
   readonly phase: string;
   readonly requestId: string;
   readonly resources?: readonly OperationResource[];
@@ -102,11 +122,13 @@ function applicationOperation(options: {
     options.requestId,
     revision,
     operationId,
+    options.persistedRevision,
   );
   const liveOperation = identifiedOperation(
     options.requestId,
     revision,
     liveOperationId,
+    options.persistedRevision,
   );
   const live =
     options.live ??
@@ -768,6 +790,27 @@ for (const scenario of [
     }
   });
 }
+
+test("atomic Argo sync rejects disagreement between direct and persisted revisions", async () => {
+  const lifecycle = serveLifecycle([
+    applicationOperation({
+      persistedRevision: "2.0.0-43",
+      phase: "Running",
+      requestId: CURRENT_REQUEST_ID,
+      resources: [{ status: "Synced" }],
+    }),
+  ]);
+
+  try {
+    const result = await runArgocd(atomicArgs(), lifecycle.server.url.origin);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Argo operation revision mismatch");
+    expect(lifecycle.observations.deleteRequests).toBe(0);
+  } finally {
+    await lifecycle.server.stop(true);
+  }
+});
 
 for (const phase of ["Failed", "Error"]) {
   test(`atomic Argo sync fails when the exact operation reaches ${phase}`, async () => {

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -12,13 +12,23 @@ type RequestObservation = {
   query: string;
 };
 
+const SyncInfoEntrySchema = z.discriminatedUnion("name", [
+  z.object({
+    name: z.literal("ci.sjer.red/request-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/operation-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/revision"),
+    value: z.string(),
+  }),
+]);
+
 const SyncRequestSchema = z.object({
-  infos: z.array(
-    z.object({
-      name: z.string(),
-      value: z.uuid(),
-    }),
-  ),
+  infos: z.array(SyncInfoEntrySchema),
   manifests: z.array(z.string()),
   revision: z.string().optional(),
   resources: z.array(
@@ -31,12 +41,7 @@ const SyncRequestSchema = z.object({
 });
 
 const RootSyncRequestSchema = z.object({
-  infos: z.array(
-    z.object({
-      name: z.string(),
-      value: z.uuid(),
-    }),
-  ),
+  infos: z.array(SyncInfoEntrySchema),
   prune: z.boolean(),
   revision: z.string().optional(),
 });
@@ -113,9 +118,6 @@ function operationForSyncRequest(request: unknown): Record<string, unknown> {
     sync: {
       manifests: syncRequest.manifests,
       resources: syncRequest.resources,
-      ...(syncRequest.revision === undefined
-        ? {}
-        : { revision: syncRequest.revision }),
     },
   };
 }
@@ -209,6 +211,80 @@ describe("Argo CD prune safety", () => {
       expect(stdout).toContain("sync operation started: apps");
       expect(syncPosts).toBe(1);
       expect(statusGets).toBe(0);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("rejects contradictory revision identity in an asynchronous sync response", async () => {
+    let syncPosts = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (
+          request.method === "POST" &&
+          url.pathname === "/api/v1/applications/apps/sync"
+        ) {
+          syncPosts++;
+          const syncRequest = RootSyncRequestSchema.parse(await request.json());
+          return Response.json({
+            operation: {
+              info: syncRequest.infos,
+              initiatedBy: { username: "buildkite" },
+              sync: {
+                prune: syncRequest.prune,
+                revision: "2.0.0-44",
+              },
+            },
+          });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps"
+        ) {
+          return Response.json({});
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "sync",
+          "apps",
+          "--revision",
+          "2.0.0-42",
+          "--request-id",
+          "11111111-1111-4111-8111-111111111111",
+          "--async",
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("Argo operation revision mismatch");
+      expect(syncPosts).toBe(1);
     } finally {
       await server.stop(true);
     }
@@ -777,6 +853,10 @@ describe("Argo CD root release staging", () => {
       expect(deleteRequests).toBe(2);
       const applicationRequest = SyncRequestSchema.parse(syncBodies[0]);
       expect(applicationRequest.revision).toBe("2.0.0-43");
+      expect(applicationRequest.infos).toContainEqual({
+        name: "ci.sjer.red/revision",
+        value: "2.0.0-43",
+      });
       expect(applicationRequest.resources).toEqual([
         WorkerApplicationResource,
         {


### PR DESCRIPTION
## Why

Main Buildkite build #9008 proved that ArgoCD omits `operation.sync.revision` for manifest-override operations. The staged root sync therefore rejected its own operation as an unknown revision even though its request ID and operation UUID matched. The operation completed naturally, but the release correctly remained failed rather than weakening identity checks.

## What

- persist the exact chart revision in `ci.sjer.red/revision` operation info beside the request and operation UUIDs
- validate that revision in the POST response and use it as the fallback identity for live and completed operations
- fail closed when a direct Argo revision and the persisted CI revision disagree
- account for the added info field in manifest request-size batching
- cover Argo's live response shape and conflicting identity cases in tests
- document the identity model and operator inspection procedure in the durable plan and release wiki

## Verification

- `cd packages/homelab/src/cdk8s && bun test src/argocd-script.test.ts src/argocd-atomic-sync.test.ts ../../scripts/argocd-manifest-overrides.test.ts` — 63 passed
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s` — passed
- `bunx turbo run typecheck test build --filter=@shepherdjerred/docs-wiki` — passed
- `cd packages/docs/wiki && bun run test:e2e` — 7 passed
- staged pre-commit checks — passed
- desktop and mobile renders of both changed wiki pages — inspected, no horizontal overflow

The whole-repo local `bun run verify` was not repeated on this follow-up; the preceding wave-safe PR reached 247/248 locally with only the independently reproduced missing `xelatex` tool in the separately selected resume package. Exact-head Buildkite CI is the full-repository acceptance gate.

## Rollout

After exact-head PR checks and review are clean, merge this head and observe a fresh build on the then-current remote `main`. Acceptance requires `verify`, `helm-push`, and `argocd-sync` to pass, no lingering root operation, and the scoped release-health gate to succeed. A later version commit-back supersedes the earlier build and must receive its own passing build.