### PR TITLE
fix(root): use replaceAll for the argocd-sync regex substitution

### DIFF
--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -36,7 +36,7 @@ export function validateAtomicRootSyncLifecycle(
     fail("argocd-sync is missing the atomic identity-bound root sync");
   }
   const executableCommands = argocdSync
-    .replace(/\\\r?\n[\t ]*/g, "")
+    .replaceAll(/\\\r?\n[\t ]*/g, "")
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => !line.startsWith("#"))


### PR DESCRIPTION
## Why
`main` currently fails `@shepherdjerred/root-scripts#lint` (`unicorn/prefer-string-replace-all`) on `.buildkite/scripts/validate-pipeline-release.ts:39`, blocking `turborepo-verify` on every open PR whose branch picks up current main. Confirmed via a clean `origin/main` worktree (`bunx turbo run lint --filter=@shepherdjerred/root-scripts`), independent of any specific PR's changes.

## What
Change `.replace(/\\\r?\n[\t ]*/g, "")` to `.replaceAll(...)` in `validateAtomicRootSyncLifecycle`. The regex already carries the `g` flag, so this is behavior-neutral — `.replaceAll()` is simply the explicit form the lint rule requires.

## Verification
- `bunx turbo run lint typecheck test --filter=@shepherdjerred/root-scripts` — all pass (480 tests, 0 failures) in a clean `origin/main` worktree.
- Confirmed the failure reproduces on unmodified `origin/main` (6284a032c) before the fix, and clears after it.