### PR TITLE
Restore explicit Argo auto-sync policies

### DIFF
--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -64,6 +64,10 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   and prune the exact root tree before one scoped release-health gate. Reject
   the old split lifecycle, child-only staging, eager duplicate gates,
   shell-wrapped commands, and unsafe ordering in pipeline validation.
+  Serialize every desired automated sync policy with an explicit `enabled`
+  boolean. Restoring `enabled: false` to an empty object makes Argo's patch
+  encode `automated: null`, which the Application CRD rejects; validate the
+  synthesized chart corpus so that implicit policy cannot return.
 
 ## Verification
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -65,6 +65,13 @@ revision, but disagreement between them is a hard identity failure.
 After explicit child reconciliation completes, the full root apply restores
 the exact auto-sync policies and performs verified pruning. Aggregate child
 health is deferred until both the child and final root applies have completed.
+Every desired automated policy includes an explicit `enabled` boolean. The
+[release policy](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/application-release-policy.ts)
+stages repository charts with `enabled: false`. An empty object also means
+enabled to Argo, but restoring that staged object to `{}` can produce an
+`automated: null` patch that the Application CRD rejects. The
+[artifact-level chart test](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/helm-template.test.ts)
+checks every synthesized Application so the release restores a concrete object.
 
 ## Why immutable chart revisions
 

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -32,6 +32,14 @@ child operations without racing ArgoCD. Stage 5 restores the exact auto-sync
 policies and prunes only after reconciliation. Stage 6 is the single
 authoritative scoped health gate.
 
+The
+[release policy](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/application-release-policy.ts)
+stages repository-chart Applications with explicit auto-sync state. The
+[artifact-level chart test](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/helm-template.test.ts)
+requires every published automated policy to have a boolean `enabled`. If the
+final root apply reports that `spec.syncPolicy.automated` became invalid
+`null`, do not retry. Regenerate the chart with explicit state.
+
 ## If a child stays out of sync
 
 Child reconciliation retries a failed operation recorded against the current

--- a/packages/homelab/src/cdk8s/src/apps/1password.ts
+++ b/packages/homelab/src/cdk8s/src/apps/1password.ts
@@ -41,7 +41,7 @@ export function createOnePasswordApp(chart: Chart) {
         namespace: "1password",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/apps/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/apps/argocd.ts
@@ -118,7 +118,7 @@ export function createArgoCdApp(chart: Chart) {
         namespace: "argocd",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/helm-template.test.ts
+++ b/packages/homelab/src/cdk8s/src/helm-template.test.ts
@@ -3,6 +3,8 @@ import { Glob } from "bun";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
 
 /**
  * Helm Template Rendering Tests
@@ -28,6 +30,112 @@ const DIST_DIR = path.join(import.meta.dir, "../dist");
 // call but never got the same timeout bump. Shared here so both describe
 // blocks stay consistent.
 const HELM_TEMPLATE_TIMEOUT_MS = 60_000;
+
+const ApplicationAutoSyncSchema = z
+  .object({
+    kind: z.literal("Application"),
+    metadata: z.object({ name: z.string() }).loose(),
+    spec: z
+      .object({
+        syncPolicy: z
+          .object({
+            automated: z
+              .object({ enabled: z.boolean().optional() })
+              .loose()
+              .optional(),
+          })
+          .loose()
+          .optional(),
+      })
+      .loose(),
+  })
+  .loose();
+
+const KubernetesResourceSchema = z
+  .object({ kind: z.string().optional() })
+  .loose();
+
+const KubernetesListSchema = z
+  .object({
+    kind: z.literal("List"),
+    items: z.array(z.unknown()).optional(),
+  })
+  .loose();
+
+function resourceObjects(manifest: unknown, source: string): unknown[] {
+  if (
+    manifest === null ||
+    typeof manifest !== "object" ||
+    Array.isArray(manifest)
+  ) {
+    return [];
+  }
+  const resourceResult = KubernetesResourceSchema.safeParse(manifest);
+  if (!resourceResult.success) {
+    throw new Error(
+      `Could not inspect ${source}: ${z.prettifyError(resourceResult.error)}`,
+    );
+  }
+  if (resourceResult.data.kind !== "List") {
+    return [manifest];
+  }
+  const listResult = KubernetesListSchema.safeParse(manifest);
+  if (!listResult.success) {
+    throw new Error(
+      `Could not inspect ${source}: ${z.prettifyError(listResult.error)}`,
+    );
+  }
+  return listResult.data.items ?? [];
+}
+
+function implicitAutoSyncApplications(content: string, entry: string) {
+  const implicitAutoSync: string[] = [];
+  for (const [documentIndex, document] of parseAllDocuments(
+    content,
+  ).entries()) {
+    if (document.errors.length > 0) {
+      throw new Error(
+        `Could not parse ${entry} document ${documentIndex.toString()}: ${document.errors
+          .map((error) => error.message)
+          .join("; ")}`,
+      );
+    }
+    const source = `${entry} document ${documentIndex.toString()}`;
+    for (const [resourceIndex, manifest] of resourceObjects(
+      document.toJS(),
+      source,
+    ).entries()) {
+      if (
+        manifest === null ||
+        typeof manifest !== "object" ||
+        Array.isArray(manifest)
+      ) {
+        continue;
+      }
+      const resourceResult = KubernetesResourceSchema.safeParse(manifest);
+      if (!resourceResult.success) {
+        throw new Error(
+          `Could not inspect ${source} resource ${resourceIndex.toString()}: ${z.prettifyError(resourceResult.error)}`,
+        );
+      }
+      if (resourceResult.data.kind !== "Application") {
+        continue;
+      }
+      const applicationResult = ApplicationAutoSyncSchema.safeParse(manifest);
+      if (!applicationResult.success) {
+        throw new Error(
+          `Could not inspect ${source} resource ${resourceIndex.toString()}: ${z.prettifyError(applicationResult.error)}`,
+        );
+      }
+      const application = applicationResult.data;
+      const automated = application.spec.syncPolicy?.automated;
+      if (automated !== undefined && automated.enabled === undefined) {
+        implicitAutoSync.push(`${entry}:${application.metadata.name}`);
+      }
+    }
+  }
+  return implicitAutoSync;
+}
 
 /**
  * Check that no unescaped {{ sequences exist in YAML content.
@@ -136,6 +244,45 @@ describe("Helm Escaping - Denylist Check (dist/)", () => {
     ).text();
     const escapedCount = (appsContent.match(/\{\{ "\{\{" \}\}/g) ?? []).length;
     expect(escapedCount).toBeGreaterThan(0);
+  });
+
+  it("declares automated sync state explicitly for every Application", async () => {
+    const implicitAutoSync: string[] = [];
+    const glob = new Glob("*.k8s.yaml");
+    for await (const entry of glob.scan(DIST_DIR)) {
+      const content = await Bun.file(path.join(DIST_DIR, entry)).text();
+      implicitAutoSync.push(...implicitAutoSyncApplications(content, entry));
+    }
+
+    expect(implicitAutoSync).toEqual([]);
+  });
+
+  it("inspects Applications nested in Kubernetes Lists", () => {
+    const content = `---
+scalar document
+---
+- array document
+---
+kind: List
+items:
+  - kind: Application
+    metadata:
+      name: implicit-list-application
+    spec:
+      syncPolicy:
+        automated: {}
+  - kind: Application
+    metadata:
+      name: explicit-list-application
+    spec:
+      syncPolicy:
+        automated:
+          enabled: true
+`;
+
+    expect(implicitAutoSyncApplications(content, "fixture.k8s.yaml")).toEqual([
+      "fixture.k8s.yaml:implicit-list-application",
+    ]);
   });
 });
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/1password.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/1password.ts
@@ -59,7 +59,7 @@ export function createOnePasswordApp(chart: Chart) {
         namespace: "1password",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/alert-dashboard.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/alert-dashboard.ts
@@ -18,7 +18,10 @@ export function createAlertDashboardApp(chart: Chart) {
         server: "https://kubernetes.default.svc",
         namespace: "alert-dashboard",
       },
-      syncPolicy: { automated: {}, syncOptions: ["CreateNamespace=true"] },
+      syncPolicy: {
+        automated: { enabled: true },
+        syncOptions: ["CreateNamespace=true"],
+      },
     },
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/alloy.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/alloy.ts
@@ -146,7 +146,7 @@ export function createAlloyApp(chart: Chart) {
         namespace: "alloy",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/apps.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/apps.ts
@@ -37,7 +37,7 @@ export function createAppsApp(chart: Chart) {
         },
       ],
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -264,7 +264,7 @@ return hs`,
         namespace: "argocd",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/birmel.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/birmel.ts
@@ -19,7 +19,7 @@ export function createBirmelApp(chart: Chart) {
         namespace: "birmel",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/blackbox-exporter.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/blackbox-exporter.ts
@@ -31,7 +31,7 @@ export function createBlackboxExporterApp(chart: Chart) {
         namespace: "prometheus",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/bugsink.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/bugsink.ts
@@ -19,7 +19,7 @@ export function createBugsinkApp(chart: Chart) {
         namespace: "bugsink",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkitd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkitd.ts
@@ -19,7 +19,7 @@ export function createBuildkitdApp(chart: Chart) {
         namespace: "buildkitd",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -470,7 +470,7 @@ overrides:
         namespace: "buildkite",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/cert-manager.ts
@@ -75,7 +75,7 @@ export function createCertManagerApp(chart: Chart) {
         namespace: "cert-manager",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/chartmuseum.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/chartmuseum.ts
@@ -73,7 +73,7 @@ export function createChartMuseumApp(chart: Chart) {
         namespace: "chartmuseum",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/cloudflare-operator.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/cloudflare-operator.ts
@@ -42,7 +42,7 @@ export function createCloudflareOperatorApp(chart: Chart) {
         namespace: "cloudflare-operator-system",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/cloudflare-tunnel.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/cloudflare-tunnel.ts
@@ -19,7 +19,7 @@ export function createCloudflareTunnelApp(chart: Chart) {
         namespace: "cloudflare-tunnel",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/ddns.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/ddns.ts
@@ -29,7 +29,7 @@ export function createDdnsApp(chart: Chart) {
         namespace: "ddns",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/discord-apps.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/discord-apps.test.ts
@@ -31,7 +31,9 @@ describe("Discord Applications", () => {
 
     expect(applications).toHaveLength(2);
     for (const application of applications) {
-      expect(application.spec.syncPolicy).toEqual({ automated: {} });
+      expect(application.spec.syncPolicy).toEqual({
+        automated: { enabled: true },
+      });
     }
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/freshrss.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/freshrss.ts
@@ -19,7 +19,7 @@ export function createFreshrssApp(chart: Chart) {
         namespace: "freshrss",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/gickup.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/gickup.ts
@@ -19,7 +19,7 @@ export function createGickupApp(chart: Chart) {
         namespace: "gickup",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/golink.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/golink.ts
@@ -31,7 +31,7 @@ export function createGolinkApp(chart: Chart) {
         },
       ],
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: [
           "ApplyOutOfSyncOnly=true",
           "RespectIgnoreDifferences=true",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana-db.ts
@@ -19,7 +19,7 @@ export function createGrafanaDbApp(chart: Chart) {
         namespace: "prometheus",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/grafana.ts
@@ -38,7 +38,7 @@ export function createGrafanaApp(chart: Chart) {
         namespace: "prometheus",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/home.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/home.ts
@@ -19,7 +19,7 @@ export function createHomeApp(chart: Chart) {
         namespace: "home",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/intel-device-plugin-operator.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/intel-device-plugin-operator.ts
@@ -31,7 +31,7 @@ export function createIntelDevicePluginOperatorApp(chart: Chart) {
         namespace: "intel-device-plugin-operator",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/intel-gpu-device-plugin.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/intel-gpu-device-plugin.ts
@@ -30,7 +30,7 @@ export function createIntelGpuDevicePluginApp(chart: Chart) {
         namespace: "intel-device-plugin-operator",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/kueue.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/kueue.ts
@@ -148,7 +148,7 @@ export function createKueueApp(chart: Chart) {
         namespace: "kueue-system",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/loki.ts
@@ -389,7 +389,7 @@ export function createLokiApp(chart: Chart) {
         },
       ],
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: [
           "CreateNamespace=true",
           "ServerSideApply=true",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/mario-kart.ts
@@ -18,7 +18,7 @@ export function createMarioKartApp(chart: Chart) {
         server: "https://kubernetes.default.svc",
         namespace: "mario-kart",
       },
-      syncPolicy: { automated: {} },
+      syncPolicy: { automated: { enabled: true } },
     },
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/mc-router.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/mc-router.ts
@@ -76,7 +76,7 @@ export function createMcRouterApp(chart: Chart) {
         namespace: "mc-router",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/mcp-gateway.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/mcp-gateway.ts
@@ -19,7 +19,7 @@ export function createMcpGatewayApp(chart: Chart) {
         namespace: "mcp-gateway",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "Replace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/media.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/media.ts
@@ -19,7 +19,7 @@ export function createMediaApp(chart: Chart) {
         namespace: "media",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-shuxin.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-shuxin.ts
@@ -234,7 +234,7 @@ export function createMinecraftShuxinApp(chart: Chart) {
         },
       ],
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: [
           "CreateNamespace=true",
           "ServerSideApply=true",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-sjerred.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-sjerred.ts
@@ -219,7 +219,7 @@ export function createMinecraftSjerredApp(chart: Chart) {
         },
       ],
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: [
           "CreateNamespace=true",
           "ServerSideApply=true",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-tsmc.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-tsmc.ts
@@ -238,7 +238,7 @@ export function createMinecraftTsmcApp(chart: Chart) {
         },
       ],
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         // ServerSideApply needed to avoid "annotation exceeds 262KB limit" error
         syncOptions: [
           "CreateNamespace=true",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/nfd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/nfd.ts
@@ -44,7 +44,7 @@ export function createNfdApp(chart: Chart) {
         namespace: "node-feature-discovery",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/openebs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/openebs.ts
@@ -79,7 +79,7 @@ export function createOpenEBSApp(chart: Chart) {
         namespace: "openebs",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/pinchtab.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/pinchtab.ts
@@ -19,7 +19,7 @@ export function createPinchtabApp(chart: Chart) {
         namespace: "pinchtab",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/pokemon.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/pokemon.ts
@@ -18,7 +18,7 @@ export function createPokemonApp(chart: Chart) {
         server: "https://kubernetes.default.svc",
         namespace: "pokemon",
       },
-      syncPolicy: { automated: {} },
+      syncPolicy: { automated: { enabled: true } },
     },
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/postal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/postal.ts
@@ -19,7 +19,7 @@ export function createPostalApp(chart: Chart) {
         namespace: "postal",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/postgres-operator.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/postgres-operator.ts
@@ -88,7 +88,7 @@ export function createPostgresOperatorApp(chart: Chart) {
         namespace: "postgres-operator",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
       ignoreDifferences: [

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus-adapter.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus-adapter.ts
@@ -79,7 +79,7 @@ export function createPrometheusAdapterApp(chart: Chart) {
         namespace: "prometheus",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -469,7 +469,7 @@ export async function createPrometheusApp(chart: Chart) {
         namespace: "prometheus",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
       ignoreDifferences: [

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/promtail.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/promtail.ts
@@ -57,7 +57,7 @@ export function createPromtailApp(chart: Chart) {
         namespace: "promtail",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/pyroscope.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/pyroscope.ts
@@ -65,7 +65,7 @@ export function createPyroscopeApp(chart: Chart) {
         namespace: "pyroscope",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/redlib.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/redlib.ts
@@ -19,7 +19,7 @@ export function createRedlibApp(chart: Chart) {
         namespace: "redlib",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/relay.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/relay.ts
@@ -19,7 +19,7 @@ export function createRelayApp(chart: Chart) {
         namespace: "relay",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/s3-static-sites.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/s3-static-sites.ts
@@ -19,7 +19,7 @@ export function createS3StaticSitesApp(chart: Chart) {
         namespace: "s3-static-sites",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-beta.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-beta.ts
@@ -19,7 +19,7 @@ export function createScoutBetaApp(chart: Chart) {
         namespace: "scout-beta",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-evals.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-evals.ts
@@ -19,7 +19,7 @@ export function createScoutEvalsApp(chart: Chart) {
         namespace: "scout-evals",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-prod.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/scout-prod.ts
@@ -19,7 +19,7 @@ export function createScoutProdApp(chart: Chart) {
         namespace: "scout-prod",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
@@ -239,6 +239,7 @@ export function createSeaweedfsApp(chart: Chart) {
       },
       syncPolicy: {
         automated: {
+          enabled: true,
           prune: true,
           selfHeal: true,
         },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/service-probes.ts
@@ -31,7 +31,7 @@ export function createServiceProbesApp(chart: Chart) {
         // Probe CRs regenerated from the service registry — the worst a prune can do is delete a probe, and a
         // stale Probe is actively harmful: it keeps probing a deregistered service, adding alert noise or
         // masking ServiceProbeAbsent (the exact failure this PR fixes).
-        automated: { prune: true },
+        automated: { enabled: true, prune: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/starlight-karma-bot-beta.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/starlight-karma-bot-beta.ts
@@ -19,7 +19,7 @@ export function createStarlightKarmaBotBetaApp(chart: Chart) {
         namespace: "starlight-karma-bot-beta",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/starlight-karma-bot-prod.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/starlight-karma-bot-prod.ts
@@ -19,7 +19,7 @@ export function createStarlightKarmaBotProdApp(chart: Chart) {
         namespace: "starlight-karma-bot-prod",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/syncthing.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/syncthing.ts
@@ -19,7 +19,7 @@ export function createSyncthingApp(chart: Chart) {
         namespace: "syncthing",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tailscale.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tailscale.ts
@@ -78,7 +78,7 @@ export function createTailscaleApp(chart: Chart) {
         namespace: "tailscale",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tasknotes.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tasknotes.ts
@@ -19,7 +19,7 @@ export function createTasknotesApp(chart: Chart) {
         namespace: "tasknotes",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
@@ -113,7 +113,7 @@ export function createTempoApp(chart: Chart) {
         namespace: "tempo",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true", "Replace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/temporal.ts
@@ -19,7 +19,7 @@ export function createTemporalApp(chart: Chart) {
         namespace: "temporal",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tracker-tracker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tracker-tracker.ts
@@ -19,7 +19,7 @@ export function createTrackerTrackerApp(chart: Chart) {
         namespace: "tracker-tracker",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/trmnl-dashboard.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/trmnl-dashboard.ts
@@ -19,7 +19,7 @@ export function createTrmnlDashboardApp(chart: Chart) {
         namespace: "trmnl-dashboard",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/turbo-cache.ts
@@ -27,7 +27,7 @@ export function createTurboCacheApp(chart: Chart) {
         // dropped by the write-reduction cutover) orphans forever: the app
         // reports OutOfSync on every reconcile and the argocd-sync step's
         // tree-health-wait times out on every main build (build 6322).
-        automated: { prune: true },
+        automated: { enabled: true, prune: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/velero.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/velero.ts
@@ -184,6 +184,7 @@ export function createVeleroApp(chart: Chart) {
       },
       syncPolicy: {
         automated: {
+          enabled: true,
           prune: true,
           selfHeal: true,
         },

--- a/packages/homelab/src/cdk8s/src/resources/common/redis.ts
+++ b/packages/homelab/src/cdk8s/src/resources/common/redis.ts
@@ -62,7 +62,7 @@ export class Redis extends Construct {
           namespace: props.namespace,
         },
         syncPolicy: {
-          automated: {},
+          automated: { enabled: true },
         },
       },
     });

--- a/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/postal-mariadb.ts
@@ -156,7 +156,7 @@ collation-server = utf8mb4_unicode_ci
           namespace: props.namespace,
         },
         syncPolicy: {
-          automated: {},
+          automated: { enabled: true },
           syncOptions: ["CreateNamespace=true"],
         },
       },


### PR DESCRIPTION
## Why

Main Buildkite build #9015 reached the final exact-revision root prune after all eight staged batches and targeted child reconciliations passed. Argo then rejected 23 external-chart Applications because restoring their staged `{ enabled: false }` policy to the historical empty `{}` policy produced an `automated: null` patch, which the Application CRD rejects. The root operation remained Running after the client timeout, so it was fingerprinted by request UUID, operation UUID, revision, initiator, phase, and failure corpus before exact termination. Argo now has no active root operation.

## What

- make every intended automated-sync policy explicit with `enabled: true`
- preserve the existing prune and self-heal settings on policies that already carry them
- add an artifact-level test across every synthesized chart requiring each Application automated policy to contain a boolean `enabled` field
- document why the staged false-to-desired transition cannot use an implicit empty object

The synthesized corpus now contains 28 explicitly enabled policies, 33 explicitly disabled release policies, and zero implicit automated policies.

## Verification

- `bunx turbo run build --filter=@homelab/cdk8s` — passed
- `bunx turbo run test typecheck lint --filter=@homelab/cdk8s` — passed; 424 tests plus the GPU-resource gate
- synthesized chart audit — 28 enabled, 33 disabled, 0 implicit
- `bunx turbo run typecheck test build --filter=@shepherdjerred/docs-wiki` — passed
- `cd packages/docs/wiki && bun run test:e2e` — 7 passed
- staged pre-commit checks — passed
- desktop and mobile renders of both changed wiki pages — inspected, no horizontal overflow

The whole-repo local `bun run verify` was not repeated; the prior run reached 247/248 with only the independently reproduced missing local `xelatex` tool in the separately selected resume package. Exact-head Buildkite is the full-repository acceptance gate.

## Rollout

Merge only the exact reviewed head after PR Buildkite passes. The next current-main release must publish a new apps revision, complete `verify`, `helm-push`, and `argocd-sync`, restore the root tree, pass scoped release health, and leave no root operation. Any version commit-back SHA supersedes this build and requires its own passing main build.