### PR TITLE
fix(homelab): finalize root releases across sync waves

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1543,10 +1543,12 @@ steps:
       # before children can depend on them, without starting child operations.
       bun --no-install packages/homelab/scripts/argocd.ts stage-root-release apps --revision "$$apps_revision" --timeout 300
       bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300
-      # Restore the exact child auto-sync policies and prune the exact root
-      # tree only after child operations finish. Keep the Buildkite identity
-      # through apply and termination so retries adopt only this revision.
-      bun --no-install packages/homelab/scripts/argocd.ts sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300
+      # Restore the exact tree in isolated sync waves while the self-managed
+      # root stays suspended, then restore it and prune after every other
+      # desired resource has applied-result proof. Keep the Buildkite identity
+      # through batches and termination so retries adopt only this revision
+      # and phase.
+      bun --no-install packages/homelab/scripts/argocd.ts finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300
       # The scoped release health below remains authoritative for this release.
       bun --no-install packages/homelab/scripts/argocd.ts release-health-wait argocd-release-expected.json --timeout 300
     retry: *retry

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -8,7 +8,7 @@ const stagedRootRelease = argocdCommand(
   'stage-root-release apps --revision "$$apps_revision" --timeout 300',
 );
 const atomicRootSync = argocdCommand(
-  'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
+  'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
 );
 const deferredReleaseHealth = argocdCommand(
   "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300",
@@ -61,6 +61,21 @@ describe("atomic ArgoCD root sync pipeline contract", () => {
         ),
       ),
     ).toThrow(
+      "argocd-sync must contain exactly one atomic identity-bound root sync",
+    );
+  });
+
+  test("rejects the full-source final sync that can stall before later waves", () => {
+    const legacyFinalSync = [
+      stagedRootRelease,
+      deferredReleaseHealth,
+      argocdCommand(
+        'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
+      ),
+      scopedReleaseHealth,
+    ].join("\n");
+
+    expect(() => validateAtomicRootSyncLifecycle(legacyFinalSync)).toThrow(
       "argocd-sync must contain exactly one atomic identity-bound root sync",
     );
   });

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -23,7 +23,7 @@ const ARGOCD_COMMAND_PREFIX =
 const STAGED_ROOT_RELEASE_SUBCOMMAND =
   'stage-root-release apps --revision "$$apps_revision" --timeout 300';
 const ATOMIC_ROOT_SYNC_SUBCOMMAND =
-  'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
+  'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
 const DEFERRED_RELEASE_HEALTH_SUBCOMMAND =
   "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300";
 const SCOPED_RELEASE_HEALTH_SUBCOMMAND =
@@ -47,7 +47,7 @@ export function validateAtomicRootSyncLifecycle(
         .map((command) => command.trim()),
     );
   const rootSyncCommands = executableCommands.filter((line) =>
-    /^sync\s+apps(?:\s|$)/.test(line),
+    /^(?:sync|finalize-root-release)\s+apps(?:\s|$)/.test(line),
   );
   const hasAsyncRootSync = rootSyncCommands.some((line) =>
     /(?:^|\s)--async(?:\s|$)/.test(line),
@@ -166,6 +166,7 @@ function validateReleaseSteps({
         'artifact download "argocd-release-expected.json"',
         'stage-root-release apps --revision "$$apps_revision"',
         "reconcile-release argocd-release-expected.json --skip-health-wait",
+        'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID"',
         "release-health-wait argocd-release-expected.json",
       ],
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,18 @@ resources finalizer. Do not classify candidates from `OutOfSync` or
 `requiresPruning` alone: the selective manifest-override sync temporarily
 marks unselected retained children as requiring prune.
 
+Main release finalization must use `argocd.ts finalize-root-release` with the
+exact apps revision and Buildkite request UUID. It reapplies every desired
+sync wave through bounded manifest overrides before the full-source prune, so
+an unhealthy earlier Application cannot hide an unapplied later wave. Only the
+self-managed root Application remains auto-sync suspended across those batches
+so it cannot start an unowned operation between them. The final prune restores
+that policy and must report the root Application plus every validated prune
+candidate. Every operation carries an explicit `batch` or `prune` phase marker;
+retry adoption requires that marker and the expected prune mode as well as the
+request UUID, revision, and batch selection. Generic atomic syncs still require
+every rendered identity.
+
 ## Code Review Rules
 
 These rules steer the automated PR code-review provider (Codex by default; the

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -61,9 +61,26 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   Argo omits `operation.sync.revision` for manifest-override operations; when
   both representations exist, require them to agree.
   Reconcile children with aggregate health deferred, then atomically restore
-  and prune the exact root tree before one scoped release-health gate. Reject
-  the old split lifecycle, child-only staging, eager duplicate gates,
-  shell-wrapped commands, and unsafe ordering in pipeline validation.
+  and prune the exact root tree before one scoped release-health gate. The
+  finalizer reapplies the exact desired tree in the same isolated wave batches
+  before starting the full-source prune, except that the self-managed root
+  Application stays auto-sync suspended across every batch. Restoring it early
+  could start an unowned full-source operation between batches. The final prune
+  restores that policy and therefore still requires the root Application's
+  applied result alongside every validated prune candidate. The separate batch
+  proof is necessary
+  because Argo can withhold later-wave results forever while a self-referential
+  or degraded ordinary Application remains unhealthy in an earlier wave. Once
+  every desired batch is applied, the prune operation needs to prove every
+  validated prune candidate rather than repeat desired-resource coverage that
+  Argo cannot publish across the blocked wave. A retry adopts only the exact
+  active desired batch or final prune selected by the same request and revision
+  and carrying the finalizer's explicit `batch` or `prune` operation marker.
+  Prune adoption also requires `operation.sync.prune: true`; a matching but
+  unmarked full-source operation is not evidence that the desired batches ran.
+  Reject the old full-source final sync, split lifecycle, child-only staging,
+  eager duplicate gates, shell-wrapped commands, and unsafe ordering in
+  pipeline validation.
   Serialize every desired automated sync policy with an explicit `enabled`
   boolean. Restoring `enabled: false` to an empty object makes Argo's patch
   encode `automated: null`, which the Application CRD rejects; validate the
@@ -73,8 +90,8 @@ only an exact retry; and keep the scoped release-health gate authoritative.
 
 - Cover delayed visibility, stale state, exact retry adoption, identity and
   revision mismatches, natural success, failed phases, timeouts, applied-result
-  termination, partial sync and prune waves, legacy recovery,
-  post-termination waiting, and interference.
+  termination, partial sync and prune waves, active desired-batch and final
+  prune adoption, legacy recovery, post-termination waiting, and interference.
 - Exercise the live result shape: 255 synced resources, two pruned resources,
   and five child Applications still in a running health phase.
 - Run focused Bun tests, homelab typecheck and lint, pipeline validation, staged

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -62,9 +62,23 @@ release command also persists the exact revision in the operation info list
 beside its request and operation UUIDs. Either representation can prove the
 revision, but disagreement between them is a hard identity failure.
 
-After explicit child reconciliation completes, the full root apply restores
-the exact auto-sync policies and performs verified pruning. Aggregate child
-health is deferred until both the child and final root applies have completed.
+After explicit child reconciliation completes, the
+[root finalizer](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)
+reapplies the exact desired tree in isolated wave batches. This restores every
+child auto-sync policy without letting an unhealthy earlier wave hide a later
+one. The self-managed root Application stays suspended so it cannot launch an
+unowned full-source operation between batches. Only then does the owned
+full-source operation restore the root policy and perform verified pruning.
+That final operation must report the root Application and every prune
+candidate; other desired-resource coverage comes from the completed batches.
+Aggregate child health remains deferred to the scoped release gate.
+
+This split proof is deliberate. The root chart contains its own Application,
+and ordinary child Applications can be degraded. Argo waits for their health
+before exposing later waves, even after the current wave and all prunes apply.
+Weakening generic sync completeness would risk skipping a genuinely unapplied
+later wave. Proving each desired wave first keeps that safety boundary intact.
+
 Every desired automated policy includes an explicit `enabled` boolean. The
 [release policy](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/application-release-policy.ts)
 stages repository charts with `enabled: false`. An empty object also means
@@ -123,12 +137,16 @@ So the [main release pipeline](https://github.com/shepherdjerred/monorepo/blob/m
 separates root application from release-scoped health. One
 [atomic Argo command](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)
 retains the exact Buildkite request identity while ArgoCD applies the root
-revision. It terminates the aggregate health wait only after the complete sync
-result is applied. The command compares reported group, kind, and name
-identities with every resource rendered from the exact revision. An applied
-early sync wave cannot hide later-wave work that ArgoCD has not reported yet.
-It also carries the validated prune candidates into this boundary and requires
-each candidate to appear as `Pruned` before termination.
+revision. It sends every desired wave as bounded manifest-override batches,
+compares each batch's reported group, kind, and name identities with its exact
+selection, and terminates that batch only after all selected resources apply.
+The self-managed root is the deliberate exception: its batch override keeps
+auto-sync disabled. Only after all desired batches complete does the finalizer
+start a full-source prune. That operation must report the restored root and
+carries the independently validated candidates into its completion boundary,
+requiring each candidate to appear as `Pruned` before termination.
+The generic atomic sync path remains stricter: without prior desired-batch
+proof, it still requires every rendered desired identity in the same result.
 
 The identity boundary matters because ArgoCD publishes operation state
 asynchronously. A second process can read before the accepted operation appears.
@@ -138,14 +156,19 @@ gap and distinguish stale state from its own operation.
 Buildkite retries reuse the build UUID. The
 [operation identity implementation](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)
 adopts only the same request ID and revision. It refuses any unrelated active
-operation. A generated per-operation UUID binds the top-level live operation
-to its completed status. This lets a retry accept a stable, fully applied
-result while rejecting stale status from an earlier POST with the same
-Buildkite identity. The standalone finalizer remains a recovery tool, not part
-of the normal release path. It recognizes the retired client's pre-UUID
-operation only when both live and completed state share the exact request ID
-and revision. Both must omit an operation UUID. Atomic operations never use
-that compatibility case.
+operation. For the root workflow, the active resource selection must also equal
+one exact desired batch or the unselected final prune. Each owned operation
+also persists a `batch` or `prune` phase marker. An unselected operation is
+adoptable as the final prune only when that marker says `prune` and Argo's prune
+flag is true, so an older full-source operation cannot borrow prior-batch proof.
+A generated per-operation UUID binds the top-level live operation to its
+completed status. This lets a retry accept a stable, fully applied result while
+rejecting stale status from an earlier POST with the same Buildkite identity.
+The standalone finalizer remains a recovery tool, not part of the normal
+release path. It recognizes the retired client's pre-UUID operation only when
+both live and completed state share the exact request ID and revision. Both
+must omit an operation UUID. Atomic operations never use that compatibility
+case.
 
 After termination, the top-level live operation is authoritative. Its absence
 means the health wait is gone even if `status.operationState` still says

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -26,11 +26,14 @@ Stage 3 is deliberately separate from stage 5. New child-level safety settings
 must exist before those children sync, but enabling floating auto-sync before
 every chart is published could expose a partially published release.
 
-Stage 3 also applies root-owned prerequisites such as admission policies, but
-keeps every child Application's auto-sync disabled. This lets stage 4 explicitly own
-child operations without racing ArgoCD. Stage 5 restores the exact auto-sync
-policies and prunes only after reconciliation. Stage 6 is the single
-authoritative scoped health gate.
+Stage 3 also applies root-owned prerequisites such as admission policies. It
+keeps every child Application's auto-sync disabled, so stage 4 owns child
+operations without racing ArgoCD. In stage 5, the
+[root finalizer](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)
+reapplies every exact sync wave before running the verified prune. It keeps the
+self-managed root Application's auto-sync disabled between batches; the final
+prune restores that one policy. Stage 6 is the single authoritative scoped
+health gate.
 
 The
 [release policy](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/application-release-policy.ts)
@@ -85,18 +88,25 @@ pin.
 ## If the release will not start
 
 A previous root operation stuck in `Running` blocks the next ordered release.
-Stage 5 prevents that in the normal pipeline. One process submits the sync,
-waits for its exact request ID and revision, verifies the complete applied
-result, terminates the aggregate health wait, and waits for termination.
-Completeness means every resource in the exact rendered root revision has a
-successful result and every validated prune candidate has a `Pruned` result; a
-fully applied early sync or prune wave is not enough.
+Stage 5 prevents that in the normal pipeline. One process owns every desired
+wave and the final prune. It waits for the exact request ID, revision, and
+per-operation UUID; verifies each selected batch; terminates its aggregate
+health wait; and waits for termination before starting the next operation.
+After every resource in the exact rendered revision has a successful batch
+result, except for the intentionally suspended root auto-sync policy, the
+full-source operation must report the restored root Application as `Synced` and
+every validated prune candidate as `Pruned`. A fully applied early batch or
+prune wave is not enough.
 
-Buildkite retries reuse the build UUID. The command adopts the operation only
-when both UUID and revision match. An unrelated active operation remains a hard
-failure. Each POST also receives an internal operation UUID; adoption requires
-the live operation and its status to share that UUID before a stable applied
-result can be finalized.
+Buildkite retries reuse the build UUID. The command adopts an operation only
+when the UUID and revision match and its selected resources are exactly one
+desired batch, or when it is the unselected final prune. An unrelated active
+operation or an unexpected selection remains a hard failure. The operation must
+also carry the finalizer's explicit `batch` or `prune` marker; prune adoption
+requires Argo's prune flag. This prevents an interrupted legacy full-source sync
+from impersonating the post-batch prune. Each POST also receives an internal
+operation UUID; adoption requires the live operation and its status to share
+that UUID before a stable applied result can be finalized.
 
 For manifest-override staging operations, inspect the
 `ci.sjer.red/revision` operation-info entry. Argo does not retain

--- a/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
@@ -22,6 +22,28 @@ description: |
 
 This agent helps you work with ArgoCD for GitOps-based Kubernetes deployments, application synchronization, and declarative configuration management.
 
+## shepherdjerred monorepo root releases
+
+The main Buildkite release owns the root `apps` lifecycle. It stages the exact
+chart with child auto-sync disabled, reconciles selected children, then runs:
+
+```bash
+bun packages/homelab/scripts/argocd.ts finalize-root-release apps \
+  --revision "$apps_revision" \
+  --request-id "$BUILDKITE_BUILD_ID" \
+  --timeout 300
+```
+
+The finalizer reapplies every exact sync wave before pruning, while keeping the
+self-managed root Application auto-sync suspended between batches. The final
+full-source operation restores that policy and proves both the root result and
+validated prunes. Do not replace it with one full-source
+`sync --prune --terminate-after-applied`: an unhealthy earlier wave can prevent
+ArgoCD from ever reporting later desired resources. Recovery may adopt only the
+exact request ID, revision, resource selection, and `batch` or `prune` phase
+marker; prune adoption also requires Argo's prune flag. Never terminate a root
+operation by revision alone.
+
 ## Auto-Approved Commands
 
 Safe read-only commands that don't require confirmation:

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -81,6 +81,24 @@ describe("manifest override batching", () => {
     ).toHaveLength(2);
   });
 
+  test("counts the root finalizer phase marker in revisioned requests", () => {
+    const overrides = [override("one", 400), override("two", 400)];
+
+    expect(
+      batchManifestOverrides(overrides, {
+        maxRequestBytes: 1470,
+        revision: "2.0.0-42",
+      }),
+    ).toHaveLength(1);
+    expect(
+      batchManifestOverrides(overrides, {
+        maxRequestBytes: 1470,
+        revision: "2.0.0-42",
+        rootFinalizerPhase: "batch",
+      }),
+    ).toHaveLength(2);
+  });
+
   test("leaves room for Argo's duplicated operation-state envelope", () => {
     const batches = batchManifestOverrides([
       override("one", 500_000),

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -10,6 +10,8 @@ const SYNC_WAVE_PATTERN = /^[+-]?\d+$/;
 export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
 export const SYNC_REVISION_INFO_NAME = "ci.sjer.red/revision";
+export const ROOT_FINALIZER_PHASE_INFO_NAME =
+  "ci.sjer.red/root-finalizer-phase";
 
 const ApplicationOperationSchema = z.object({
   operation: z.record(z.string(), z.unknown()).optional(),
@@ -74,6 +76,7 @@ export type ManifestOverrideBatch = {
 function serializedRequestBytes(
   batch: ManifestOverrideBatch,
   revision: string | undefined,
+  rootFinalizerPhase: "batch" | "prune" | undefined,
 ): number {
   return new TextEncoder().encode(
     JSON.stringify({
@@ -90,6 +93,14 @@ function serializedRequestBytes(
         ...(revision === undefined
           ? []
           : [{ name: SYNC_REVISION_INFO_NAME, value: revision }]),
+        ...(rootFinalizerPhase === undefined
+          ? []
+          : [
+              {
+                name: ROOT_FINALIZER_PHASE_INFO_NAME,
+                value: rootFinalizerPhase,
+              },
+            ]),
       ],
       ...(revision === undefined ? {} : { revision }),
       manifests: batch.manifests,
@@ -130,13 +141,17 @@ function batchSingleSyncWave(
   overrides: readonly ManifestOverride[],
   maxRequestBytes: number,
   revision: string | undefined,
+  rootFinalizerPhase: "batch" | "prune" | undefined,
 ): ManifestOverrideBatch[] {
   const batches: ManifestOverrideBatch[] = [];
   let current: ManifestOverrideBatch = { manifests: [], resources: [] };
 
   for (const override of overrides) {
     const candidate = appendOverride(current, override);
-    if (serializedRequestBytes(candidate, revision) <= maxRequestBytes) {
+    if (
+      serializedRequestBytes(candidate, revision, rootFinalizerPhase) <=
+      maxRequestBytes
+    ) {
       current = candidate;
       continue;
     }
@@ -146,7 +161,10 @@ function batchSingleSyncWave(
     } else {
       current = candidate;
     }
-    if (serializedRequestBytes(current, revision) > maxRequestBytes) {
+    if (
+      serializedRequestBytes(current, revision, rootFinalizerPhase) >
+      maxRequestBytes
+    ) {
       throw new Error(
         `manifest override for ${override.resource.kind}/${override.resource.name} exceeds the request budget`,
       );
@@ -176,6 +194,7 @@ export function batchManifestOverrides(
   options: {
     readonly maxRequestBytes?: number;
     readonly revision?: string;
+    readonly rootFinalizerPhase?: "batch" | "prune";
   } = {},
 ): ManifestOverrideBatch[] {
   const maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
@@ -193,7 +212,12 @@ export function batchManifestOverrides(
   return [...overridesBySyncWave.entries()]
     .sort(([leftWave], [rightWave]) => leftWave - rightWave)
     .flatMap(([, waveOverrides]) =>
-      batchSingleSyncWave(waveOverrides, maxRequestBytes, options.revision),
+      batchSingleSyncWave(
+        waveOverrides,
+        maxRequestBytes,
+        options.revision,
+        options.rootFinalizerPhase,
+      ),
     );
 }
 

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -22,6 +22,8 @@
  *       [--revision <v>] [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts stage-root-release <root-app> \
  *       --revision <v> [--timeout <s>] [--dry-run]
+ *   bun packages/homelab/scripts/argocd.ts finalize-root-release apps \
+ *       --revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts wait-deletion <app> \
  *       --group <g> --version <v> --kind <k> --namespace <ns> \
  *       [--timeout <s>] [--dry-run]
@@ -52,6 +54,7 @@ import {
   completedOperationId,
   completedOperationRequestId,
   operationRevision,
+  ROOT_FINALIZER_PHASE_INFO_NAME,
   requestedOperationId,
   requestedOperationRequestId,
   requestedOperationRevision,
@@ -77,8 +80,11 @@ const CHARTMUSEUM_RETRY_BASE_DELAY_MS = 100;
 const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
 const SyncRequestIdSchema = z.uuid();
 const SyncOperationIdSchema = z.uuid();
+const RootFinalizerPhaseSchema = z.enum(["batch", "prune"]);
 const OperationStartedAtSchema = z.iso.datetime({ offset: true }).optional();
 const PollIntervalSchema = z.coerce.number().int().positive();
+
+type RootFinalizerPhase = z.infer<typeof RootFinalizerPhaseSchema>;
 
 const ExpectedApplicationsSchema = z.array(
   z.object({
@@ -126,6 +132,18 @@ const RenderedResourceSchema = z.object({
     })
     .passthrough(),
 });
+
+const ActiveOperationResourceSchema = z.object({
+  group: z.string().optional(),
+  kind: z.string().min(1),
+  name: z.string().min(1),
+});
+
+const OperationInfoEntriesSchema = z
+  .object({
+    info: z.array(z.object({ name: z.string(), value: z.string() })).optional(),
+  })
+  .loose();
 
 const RootDeploymentHistorySchema = z.object({
   status: z.object({
@@ -267,6 +285,99 @@ function renderedResourceIdentities(
   return unique;
 }
 
+function operationResourceIdentities(
+  resources: readonly SyncOperationResource[],
+): ReadonlySet<string> {
+  const identities = resources.map(({ group, kind, name }) =>
+    resourceIdentity(group, kind, name),
+  );
+  const unique = new Set(identities);
+  if (unique.size !== identities.length) {
+    throw new Error(
+      "Sync operation contains duplicate group/kind/name identities",
+    );
+  }
+  return unique;
+}
+
+function activeOperationResourceIdentities(
+  app: Record<string, unknown>,
+): ReadonlySet<string> | null {
+  const operation = app["operation"];
+  if (!isRecord(operation)) {
+    throw new Error("Cannot inspect resources for a missing live operation");
+  }
+  const sync = operation["sync"];
+  if (!isRecord(sync)) {
+    throw new Error("Active Argo operation is missing its sync request");
+  }
+  const resources = sync["resources"];
+  if (resources === undefined) {
+    return null;
+  }
+  const parsedResources = z
+    .array(ActiveOperationResourceSchema)
+    .parse(resources);
+  if (parsedResources.length === 0) {
+    return null;
+  }
+  return operationResourceIdentities(
+    parsedResources.map(({ group, kind, name }) => ({
+      group: group ?? "",
+      kind,
+      name,
+    })),
+  );
+}
+
+function operationRootFinalizerPhase(
+  operation: Record<string, unknown>,
+): RootFinalizerPhase | undefined {
+  const matches = (OperationInfoEntriesSchema.parse(operation).info ?? [])
+    .filter(({ name }) => name === ROOT_FINALIZER_PHASE_INFO_NAME)
+    .map(({ value }) => value);
+  if (matches.length > 1) {
+    throw new Error("Argo operation has multiple root finalizer phases");
+  }
+  const phase = matches[0];
+  return phase === undefined
+    ? undefined
+    : RootFinalizerPhaseSchema.parse(phase);
+}
+
+function activeOperationPrunes(app: Record<string, unknown>): boolean {
+  const operation = app["operation"];
+  if (!isRecord(operation)) {
+    throw new Error("Cannot inspect pruning for a missing live operation");
+  }
+  const sync = operation["sync"];
+  if (!isRecord(sync)) {
+    throw new Error("Active Argo operation is missing its sync request");
+  }
+  return sync["prune"] === true;
+}
+
+function requestedOperationRootFinalizerPhase(
+  application: unknown,
+): RootFinalizerPhase | undefined {
+  const parsed = z.record(z.string(), z.unknown()).parse(application);
+  const operation = parsed["operation"];
+  if (!isRecord(operation)) {
+    throw new Error("Argo sync response is missing the requested operation");
+  }
+  return operationRootFinalizerPhase(operation);
+}
+
+function resourceIdentitySetsEqual(
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>,
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every((identity) => right.has(identity))
+  );
+}
+
 async function getRenderedResourceIdentities(
   appName: string,
   revision: string,
@@ -298,25 +409,47 @@ type PreparedManifestOverride = {
   readonly suspendedApplication: string | null;
 };
 
+type PreparedFinalRootManifest = {
+  readonly deferredDesiredIdentity: string | null;
+  readonly override: ManifestOverride;
+};
+
+type ParsedRootManifest = {
+  readonly parsed: unknown;
+  readonly override: ManifestOverride;
+};
+
+function parseRootManifest(manifestSource: string): ParsedRootManifest {
+  const parsed: unknown = JSON.parse(manifestSource);
+  const renderedResource = RenderedResourceSchema.parse(parsed);
+  const separator = renderedResource.apiVersion.indexOf("/");
+  return {
+    parsed,
+    override: {
+      manifest: manifestSource,
+      resource: {
+        group:
+          separator === -1
+            ? ""
+            : renderedResource.apiVersion.slice(0, separator),
+        kind: renderedResource.kind,
+        name: renderedResource.metadata.name,
+        ...(renderedResource.metadata.namespace === undefined
+          ? {}
+          : { namespace: renderedResource.metadata.namespace }),
+      },
+    },
+  };
+}
+
 function prepareRootManifestOverride(
   manifestSource: string,
   suspendAllApplications: boolean,
 ): PreparedManifestOverride {
-  const parsed: unknown = JSON.parse(manifestSource);
-  const renderedResource = RenderedResourceSchema.parse(parsed);
-  const separator = renderedResource.apiVersion.indexOf("/");
-  const resource: SyncOperationResource = {
-    group:
-      separator === -1 ? "" : renderedResource.apiVersion.slice(0, separator),
-    kind: renderedResource.kind,
-    name: renderedResource.metadata.name,
-    ...(renderedResource.metadata.namespace === undefined
-      ? {}
-      : { namespace: renderedResource.metadata.namespace }),
-  };
-  if (renderedResource.kind !== "Application") {
+  const { parsed, override } = parseRootManifest(manifestSource);
+  if (override.resource.kind !== "Application") {
     return {
-      override: { manifest: manifestSource, resource },
+      override,
       suspendedApplication: null,
     };
   }
@@ -326,7 +459,7 @@ function prepareRootManifestOverride(
     !Object.hasOwn(application.spec.syncPolicy, "automated")
   ) {
     return {
-      override: { manifest: manifestSource, resource },
+      override,
       suspendedApplication: null,
     };
   }
@@ -335,14 +468,14 @@ function prepareRootManifestOverride(
     REPOSITORY_CHART_URLS.has(application.spec.source.repoURL);
   if (!suspendAllApplications && !isRepositoryApplication) {
     return {
-      override: { manifest: manifestSource, resource },
+      override,
       suspendedApplication: null,
     };
   }
   const automated = application.spec.syncPolicy["automated"];
   if (!isRecord(automated)) {
     return {
-      override: { manifest: manifestSource, resource },
+      override,
       suspendedApplication: null,
     };
   }
@@ -358,9 +491,38 @@ function prepareRootManifestOverride(
           },
         },
       }),
-      resource,
+      resource: override.resource,
     },
     suspendedApplication: application.metadata.name,
+  };
+}
+
+function prepareFinalRootManifestOverride(
+  manifestSource: string,
+  rootAppName: string,
+): PreparedFinalRootManifest {
+  const parsed = parseRootManifest(manifestSource);
+  if (
+    parsed.override.resource.group !== "argoproj.io" ||
+    parsed.override.resource.kind !== "Application" ||
+    parsed.override.resource.name !== rootAppName
+  ) {
+    return {
+      deferredDesiredIdentity: null,
+      override: parsed.override,
+    };
+  }
+  const prepared = prepareRootManifestOverride(manifestSource, true);
+  return {
+    deferredDesiredIdentity:
+      prepared.suspendedApplication === null
+        ? null
+        : resourceIdentity(
+            prepared.override.resource.group,
+            prepared.override.resource.kind,
+            prepared.override.resource.name,
+          ),
+    override: prepared.override,
   };
 }
 
@@ -464,6 +626,167 @@ async function stageRootRelease(
       resources: batch.resources,
     });
   }
+}
+
+async function finalizeRootRelease(
+  rootAppName: string,
+  revision: string,
+  requestId: string,
+  timeoutSeconds: number,
+  dryRun: boolean,
+): Promise<void> {
+  const exactRevision = BuildRevisionSchema.parse(revision);
+  const exactRequestId = SyncRequestIdSchema.parse(requestId);
+  if (rootAppName !== "apps") {
+    throw new Error("finalize-root-release only supports the apps root");
+  }
+  console.log(
+    `--- argocd finalize-root-release: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
+  );
+  if (dryRun) {
+    return;
+  }
+  await assertExpectedAppsRevisionIsLatest(exactRevision, timeoutSeconds);
+  const token = requireEnv("ARGOCD_TOKEN");
+  const manifests = await getApplicationManifests(
+    rootAppName,
+    exactRevision,
+    token,
+  );
+  if (manifests.length === 0) {
+    throw new Error("Rendered root release contains no resources");
+  }
+  const preparedManifests = manifests.map((manifestSource) =>
+    prepareFinalRootManifestOverride(manifestSource, rootAppName),
+  );
+  const allDesiredIdentities = operationResourceIdentities(
+    preparedManifests.map(({ override }) => override.resource),
+  );
+  const deferredDesiredIdentities = new Set(
+    preparedManifests.flatMap(({ deferredDesiredIdentity }) =>
+      deferredDesiredIdentity === null ? [] : [deferredDesiredIdentity],
+    ),
+  );
+  const verifiedRootDesiredIdentities = new Set(
+    [...allDesiredIdentities].filter(
+      (identity) => !deferredDesiredIdentities.has(identity),
+    ),
+  );
+  const batches = batchManifestOverrides(
+    preparedManifests.map(({ override }) => override),
+    { revision: exactRevision, rootFinalizerPhase: "batch" },
+  );
+
+  let nextBatchIndex = 0;
+  const initialApplication = await getApplication(rootAppName, token);
+  const initialOperation = observeOperation(initialApplication);
+  assertMatchingRevision(
+    initialOperation,
+    exactRequestId,
+    exactRevision,
+    rootAppName,
+  );
+  assertMatchingLiveRevision(
+    initialOperation,
+    exactRequestId,
+    exactRevision,
+    rootAppName,
+  );
+  if (initialOperation.hasLiveOperation) {
+    if (
+      !liveOperationMatches(initialOperation, exactRequestId, exactRevision)
+    ) {
+      throw new Error(
+        `Refusing to replace active ${rootAppName} operation ${liveOperationDescription(initialOperation)}; expected request ${exactRequestId}`,
+      );
+    }
+    const activeResources =
+      activeOperationResourceIdentities(initialApplication);
+    if (activeResources === null) {
+      if (
+        initialOperation.liveRootFinalizerPhase !== "prune" ||
+        !activeOperationPrunes(initialApplication)
+      ) {
+        throw new Error(
+          `Active ${rootAppName} full-source operation is not the marked final root prune`,
+        );
+      }
+      console.log(`adopting active final root prune: ${rootAppName}`);
+      await sync(rootAppName, timeoutSeconds, false, {
+        prune: true,
+        requestId: exactRequestId,
+        revision: exactRevision,
+        rootFinalizerPhase: "prune",
+        terminateAfterApplied: true,
+        verifiedRootDesiredIdentities,
+      });
+      return;
+    }
+    if (
+      initialOperation.liveRootFinalizerPhase !== "batch" ||
+      activeOperationPrunes(initialApplication)
+    ) {
+      throw new Error(
+        `Active ${rootAppName} selective operation is not a marked root batch`,
+      );
+    }
+    const activeBatchIndex = batches.findIndex((batch) =>
+      resourceIdentitySetsEqual(
+        activeResources,
+        operationResourceIdentities(batch.resources),
+      ),
+    );
+    if (activeBatchIndex === -1) {
+      throw new Error(
+        `Active ${rootAppName} operation for request ${exactRequestId} does not match an exact root batch`,
+      );
+    }
+    const activeBatch = batches[activeBatchIndex];
+    if (activeBatch === undefined) {
+      throw new Error("Matched root batch is missing");
+    }
+    console.log(
+      `adopting exact root batch ${(activeBatchIndex + 1).toString()}/${batches.length.toString()} (${activeBatch.manifests.length.toString()} resources)`,
+    );
+    await sync(rootAppName, timeoutSeconds, false, {
+      prune: false,
+      manifests: activeBatch.manifests,
+      requestId: exactRequestId,
+      resources: activeBatch.resources,
+      revision: exactRevision,
+      rootFinalizerPhase: "batch",
+      terminateAfterApplied: true,
+    });
+    nextBatchIndex = activeBatchIndex + 1;
+  }
+
+  for (let index = nextBatchIndex; index < batches.length; index += 1) {
+    const batch = batches[index];
+    if (batch === undefined) {
+      throw new Error(`Exact root batch ${index.toString()} is missing`);
+    }
+    console.log(
+      `syncing exact root batch ${(index + 1).toString()}/${batches.length.toString()} (${batch.manifests.length.toString()} resources)`,
+    );
+    await sync(rootAppName, timeoutSeconds, false, {
+      prune: false,
+      manifests: batch.manifests,
+      requestId: exactRequestId,
+      resources: batch.resources,
+      revision: exactRevision,
+      rootFinalizerPhase: "batch",
+      terminateAfterApplied: true,
+    });
+  }
+
+  await sync(rootAppName, timeoutSeconds, false, {
+    prune: true,
+    requestId: exactRequestId,
+    revision: exactRevision,
+    rootFinalizerPhase: "prune",
+    terminateAfterApplied: true,
+    verifiedRootDesiredIdentities,
+  });
 }
 
 function latestSuccessfulRevision(
@@ -633,7 +956,9 @@ async function assertRootPruneSafe(
 type SyncOptions = {
   prune: boolean;
   requestId?: string;
+  rootFinalizerPhase?: RootFinalizerPhase;
   terminateAfterApplied?: boolean;
+  verifiedRootDesiredIdentities?: ReadonlySet<string>;
   waitForCompletion?: boolean;
   revision?: string;
   manifests?: readonly string[];
@@ -656,6 +981,30 @@ async function sync(
     return;
   }
   const token = requireEnv("ARGOCD_TOKEN");
+  const verifiedRootDesiredIdentities = options.verifiedRootDesiredIdentities;
+  if (
+    options.rootFinalizerPhase !== undefined &&
+    (appName !== "apps" ||
+      options.requestId === undefined ||
+      options.revision === undefined ||
+      options.terminateAfterApplied !== true ||
+      (options.rootFinalizerPhase === "prune") !== options.prune)
+  ) {
+    throw new Error(
+      "Root finalizer phases require an identity-bound atomic apps batch or prune",
+    );
+  }
+  if (
+    verifiedRootDesiredIdentities !== undefined &&
+    (appName !== "apps" ||
+      !options.prune ||
+      options.rootFinalizerPhase !== "prune" ||
+      options.terminateAfterApplied !== true)
+  ) {
+    throw new Error(
+      "Verified root desired state can only narrow an applied-result boundary for atomic apps pruning",
+    );
+  }
   let expectedResourceIdentities: ExpectedSyncResultIdentities | undefined;
   if (appName === "apps" && options.prune) {
     if (options.revision === undefined) {
@@ -663,10 +1012,29 @@ async function sync(
         "Root Application pruning requires an exact --revision so prune candidates can be verified against the rendered source",
       );
     }
-    expectedResourceIdentities = await assertRootPruneSafe(
+    const rootExpectedResourceIdentities = await assertRootPruneSafe(
       token,
       options.revision,
     );
+    if (verifiedRootDesiredIdentities === undefined) {
+      expectedResourceIdentities = rootExpectedResourceIdentities;
+    } else {
+      for (const identity of verifiedRootDesiredIdentities) {
+        if (!rootExpectedResourceIdentities.desired.has(identity)) {
+          throw new Error(
+            `Verified root desired identity ${identity} is absent from the exact rendered revision`,
+          );
+        }
+      }
+      expectedResourceIdentities = {
+        desired: new Set(
+          [...rootExpectedResourceIdentities.desired].filter(
+            (identity) => !verifiedRootDesiredIdentities.has(identity),
+          ),
+        ),
+        pruned: rootExpectedResourceIdentities.pruned,
+      };
+    }
   }
   if (
     options.terminateAfterApplied === true &&
@@ -720,7 +1088,15 @@ async function sync(
     assertMatchingRevision(baseline, requestId, options.revision, appName);
     assertMatchingLiveRevision(baseline, requestId, options.revision, appName);
     if (baseline.hasLiveOperation) {
-      if (!liveOperationMatches(baseline, requestId, options.revision)) {
+      if (
+        !liveOperationMatches(
+          baseline,
+          requestId,
+          options.revision,
+          undefined,
+          options.rootFinalizerPhase,
+        )
+      ) {
         throw new Error(
           `Refusing to replace active ${appName} operation ${liveOperationDescription(baseline)}; expected request ${requestId}`,
         );
@@ -731,6 +1107,7 @@ async function sync(
         requestId,
         options.revision,
         operationId,
+        options.rootFinalizerPhase,
       );
       if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
@@ -779,6 +1156,14 @@ async function sync(
           ...(options.revision === undefined
             ? []
             : [{ name: SYNC_REVISION_INFO_NAME, value: options.revision }]),
+          ...(options.rootFinalizerPhase === undefined
+            ? []
+            : [
+                {
+                  name: ROOT_FINALIZER_PHASE_INFO_NAME,
+                  value: options.rootFinalizerPhase,
+                },
+              ]),
         ],
         ...(options.revision === undefined
           ? {}
@@ -818,6 +1203,14 @@ async function sync(
         `Argo sync response returned a different CI revision; expected ${options.revision}`,
       );
     }
+    if (
+      requestedOperationRootFinalizerPhase(responseBody) !==
+      options.rootFinalizerPhase
+    ) {
+      throw new Error(
+        `Argo sync response returned a different root finalizer phase; expected ${options.rootFinalizerPhase ?? "none"}`,
+      );
+    }
     console.log(`sync operation started: ${appName}`);
   }
   if (options.waitForCompletion === false) {
@@ -828,6 +1221,7 @@ async function sync(
     token,
     requestId,
     operationId,
+    rootFinalizerPhase: options.rootFinalizerPhase,
     expectedResourceIdentities,
     revision: options.revision,
     timeoutSeconds,
@@ -845,10 +1239,12 @@ type OperationObservation = {
   readonly liveOperationId: string | null;
   readonly liveRequestId: string | null;
   readonly liveRevision: string | undefined;
+  readonly liveRootFinalizerPhase: RootFinalizerPhase | undefined;
   readonly operationId: string | null;
   readonly phase: string;
   readonly requestId: string | null;
   readonly revision: string | undefined;
+  readonly rootFinalizerPhase: RootFinalizerPhase | undefined;
   readonly startedAt: string | undefined;
   readonly state: Record<string, unknown>;
 };
@@ -872,6 +1268,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
       liveOperation === undefined
         ? undefined
         : operationRevision(liveOperation),
+    liveRootFinalizerPhase:
+      liveOperation === undefined
+        ? undefined
+        : operationRootFinalizerPhase(liveOperation),
     phase: typeof phase === "string" ? phase : "",
     operationId: completedOperationId(app),
     requestId: completedOperationRequestId(app),
@@ -879,6 +1279,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
       completedOperation === undefined
         ? undefined
         : operationRevision(completedOperation),
+    rootFinalizerPhase:
+      completedOperation === undefined
+        ? undefined
+        : operationRootFinalizerPhase(completedOperation),
     startedAt: OperationStartedAtSchema.parse(state["startedAt"]),
     state,
   };
@@ -889,12 +1293,15 @@ function liveOperationMatches(
   requestId: string,
   revision: string | undefined,
   operationId?: string | null,
+  rootFinalizerPhase?: RootFinalizerPhase,
 ): boolean {
   return (
     operation.hasLiveOperation &&
     operation.liveRequestId === requestId &&
     (revision === undefined || operation.liveRevision === revision) &&
-    (operationId === undefined || operation.liveOperationId === operationId)
+    (operationId === undefined || operation.liveOperationId === operationId) &&
+    (rootFinalizerPhase === undefined ||
+      operation.liveRootFinalizerPhase === rootFinalizerPhase)
   );
 }
 
@@ -903,11 +1310,14 @@ function operationMatches(
   requestId: string,
   revision: string | undefined,
   operationId?: string | null,
+  rootFinalizerPhase?: RootFinalizerPhase,
 ): boolean {
   return (
     operation.requestId === requestId &&
     (revision === undefined || operation.revision === revision) &&
-    (operationId === undefined || operation.operationId === operationId)
+    (operationId === undefined || operation.operationId === operationId) &&
+    (rootFinalizerPhase === undefined ||
+      operation.rootFinalizerPhase === rootFinalizerPhase)
   );
 }
 
@@ -1084,6 +1494,7 @@ type WaitForIdentifiedOperationOptions = {
   readonly operationId: string;
   readonly requestId: string;
   readonly revision: string | undefined;
+  readonly rootFinalizerPhase: RootFinalizerPhase | undefined;
   readonly terminateAfterApplied: boolean;
   readonly timeoutSeconds: number;
   readonly token: string;
@@ -1095,6 +1506,7 @@ async function waitForIdentifiedOperation({
   operationId,
   requestId,
   revision,
+  rootFinalizerPhase,
   terminateAfterApplied,
   timeoutSeconds,
   token,
@@ -1110,12 +1522,14 @@ async function waitForIdentifiedOperation({
       requestId,
       revision,
       operationId,
+      rootFinalizerPhase,
     );
     const isExpectedLiveOperation = liveOperationMatches(
       current,
       requestId,
       revision,
       operationId,
+      rootFinalizerPhase,
     );
     if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
@@ -1749,6 +2163,8 @@ function usage(): never {
       "[--revision <v>] [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts stage-root-release <root-app> " +
       "--revision <v> [--timeout <s>] [--dry-run]\n" +
+      "  bun packages/homelab/scripts/argocd.ts finalize-root-release apps " +
+      "--revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts wait-deletion <app> " +
       "--group <g> --version <v> --kind <k> --namespace <ns> " +
       "[--timeout <s>] [--dry-run]",
@@ -1919,6 +2335,24 @@ async function main(): Promise<void> {
       await stageRootRelease(
         app,
         revision,
+        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
+        dryRun,
+      );
+      return;
+    }
+    case "finalize-root-release": {
+      const revision = flag(argv, "revision");
+      const requestId = flag(argv, "request-id");
+      if (revision === undefined || requestId === undefined) {
+        console.error(
+          "--revision and --request-id are required for finalize-root-release.",
+        );
+        usage();
+      }
+      await finalizeRootRelease(
+        app,
+        revision,
+        requestId,
         timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
         dryRun,
       );

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -1,0 +1,710 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+import { z } from "zod";
+
+const RELEASE_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
+const RELEASE_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
+const BATCH_PHASE_INFO = {
+  name: "ci.sjer.red/root-finalizer-phase",
+  value: "batch",
+} as const;
+const PRUNE_PHASE_INFO = {
+  name: "ci.sjer.red/root-finalizer-phase",
+  value: "prune",
+} as const;
+
+const SyncInfoEntrySchema = z.discriminatedUnion("name", [
+  z.object({
+    name: z.literal("ci.sjer.red/request-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/operation-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/revision"),
+    value: z.string(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/root-finalizer-phase"),
+    value: z.enum(["batch", "prune"]),
+  }),
+]);
+
+const SyncRequestSchema = z.object({
+  infos: z.array(SyncInfoEntrySchema),
+  manifests: z.array(z.string()),
+  revision: z.string().optional(),
+  resources: z.array(
+    z.object({
+      group: z.string(),
+      kind: z.string(),
+      name: z.string(),
+    }),
+  ),
+});
+
+const RootSyncRequestSchema = z.object({
+  infos: z.array(SyncInfoEntrySchema),
+  prune: z.boolean(),
+  revision: z.string().optional(),
+});
+
+function operationForRootSyncRequest(
+  request: unknown,
+): Record<string, unknown> {
+  const syncRequest = RootSyncRequestSchema.parse(request);
+  return {
+    info: syncRequest.infos,
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      prune: syncRequest.prune,
+      ...(syncRequest.revision === undefined
+        ? {}
+        : { revision: syncRequest.revision }),
+    },
+  };
+}
+
+const WorkerApplicationResource = {
+  group: "argoproj.io",
+  kind: "Application",
+  name: "worker",
+};
+
+const RootApplicationResource = {
+  group: "argoproj.io",
+  kind: "Application",
+  name: "apps",
+};
+
+const StagedRootApplication = JSON.stringify({
+  apiVersion: "argoproj.io/v1alpha1",
+  kind: "Application",
+  metadata: { name: "apps" },
+  spec: {
+    source: {
+      repoURL: "https://chartmuseum.sjer.red",
+      chart: "apps",
+      targetRevision: "2.0.0-43",
+    },
+    syncPolicy: {
+      automated: { enabled: true, prune: true, selfHeal: true },
+    },
+  },
+});
+
+const StagedRepositoryApplication = JSON.stringify({
+  apiVersion: "argoproj.io/v1alpha1",
+  kind: "Application",
+  metadata: { name: "worker" },
+  spec: {
+    source: {
+      repoURL: "https://chartmuseum.sjer.red",
+      chart: "worker",
+      targetRevision: "2.0.0-43",
+    },
+    syncPolicy: {
+      automated: { enabled: false, prune: true, selfHeal: true },
+    },
+  },
+});
+
+const StagedAdmissionPolicy = JSON.stringify({
+  apiVersion: "admissionregistration.k8s.io/v1",
+  kind: "ValidatingAdmissionPolicy",
+  metadata: {
+    name: "pvc-backup-policy.sjer.red",
+    annotations: { "argocd.argoproj.io/sync-wave": "1" },
+  },
+  spec: { failurePolicy: "Fail" },
+});
+
+const StagedExternalApplication = JSON.stringify({
+  apiVersion: "argoproj.io/v1alpha1",
+  kind: "Application",
+  metadata: { name: "external" },
+  spec: {
+    source: {
+      repoURL: "https://charts.example.com",
+      chart: "external",
+      targetRevision: "1.0.0",
+    },
+    syncPolicy: { automated: { enabled: true } },
+  },
+});
+
+function finalPruneResources(
+  removedApplication: string,
+  includeRoot: boolean,
+): Record<string, unknown>[] {
+  return [
+    ...(includeRoot ? [{ ...RootApplicationResource, status: "Synced" }] : []),
+    { ...WorkerApplicationResource, status: "Synced" },
+    {
+      group: "argoproj.io",
+      kind: "Application",
+      name: removedApplication,
+      status: "Pruned",
+    },
+  ];
+}
+
+function operationForSyncRequest(request: unknown): Record<string, unknown> {
+  const syncRequest = SyncRequestSchema.parse(request);
+  return {
+    info: syncRequest.infos,
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      manifests: syncRequest.manifests,
+      resources: syncRequest.resources,
+    },
+  };
+}
+
+function releaseOperationInfo(phase: "batch" | "prune") {
+  return [
+    { name: "ci.sjer.red/request-id", value: RELEASE_REQUEST_ID },
+    { name: "ci.sjer.red/operation-id", value: RELEASE_OPERATION_ID },
+    { name: "ci.sjer.red/revision", value: "2.0.0-43" },
+    { name: "ci.sjer.red/root-finalizer-phase", value: phase },
+  ];
+}
+
+test("root release finalization requires exact revision and request identity", async () => {
+  const process = Bun.spawn(
+    [
+      "bun",
+      "--no-install",
+      "scripts/argocd.ts",
+      "finalize-root-release",
+      "apps",
+      "--revision",
+      "2.0.0-43",
+      "--dry-run",
+    ],
+    {
+      cwd: path.resolve(import.meta.dir, "../../.."),
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain(
+    "--revision and --request-id are required for finalize-root-release",
+  );
+});
+
+test("root release finalization applies every exact wave before accepting a partial-wave prune result", async () => {
+  const syncBodies: unknown[] = [];
+  let activeRequest: unknown;
+  let requestedOperation: Record<string, unknown> | undefined;
+  let deleteRequests = 0;
+  let finalPruneReads = 0;
+  const removedApplication = "removed-worker";
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/charts/apps") {
+        return Response.json([
+          {
+            version: "2.0.0-43",
+            urls: ["charts/apps-2.0.0-43.tgz"],
+            digest: "a".repeat(64),
+          },
+        ]);
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        expect(url.searchParams.get("revision")).toBe("2.0.0-43");
+        return Response.json({
+          manifests: [
+            StagedRootApplication,
+            StagedRepositoryApplication,
+            StagedExternalApplication,
+            StagedAdmissionPolicy,
+          ],
+        });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === `/api/v1/applications/${removedApplication}`
+      ) {
+        return Response.json({
+          metadata: {
+            annotations: {
+              "ci.sjer.red/application-lifecycle": "cascade",
+            },
+            finalizers: ["resources-finalizer.argocd.argoproj.io"],
+          },
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/apps/sync"
+      ) {
+        activeRequest = await request.json();
+        syncBodies.push(activeRequest);
+        const manifestRequest = SyncRequestSchema.safeParse(activeRequest);
+        requestedOperation = manifestRequest.success
+          ? operationForSyncRequest(activeRequest)
+          : operationForRootSyncRequest(activeRequest);
+        return Response.json({ operation: requestedOperation });
+      }
+      if (
+        request.method === "DELETE" &&
+        url.pathname === "/api/v1/applications/apps/operation"
+      ) {
+        deleteRequests += 1;
+        activeRequest = undefined;
+        requestedOperation = undefined;
+        return Response.json({});
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps"
+      ) {
+        if (activeRequest === undefined || requestedOperation === undefined) {
+          return Response.json({
+            status: {
+              resources: [
+                {
+                  group: "argoproj.io",
+                  kind: "Application",
+                  name: removedApplication,
+                },
+              ],
+            },
+          });
+        }
+        const manifestRequest = SyncRequestSchema.safeParse(activeRequest);
+        if (!manifestRequest.success) {
+          finalPruneReads += 1;
+        }
+        const resources = manifestRequest.success
+          ? manifestRequest.data.resources.map((resource) => ({
+              ...resource,
+              status: "Synced",
+            }))
+          : finalPruneResources(removedApplication, finalPruneReads > 1);
+        return Response.json({
+          operation: requestedOperation,
+          status: {
+            operationState: {
+              phase: "Running",
+              startedAt: new Date().toISOString(),
+              operation: requestedOperation,
+              syncResult: {
+                revision: "2.0.0-43",
+                resources,
+              },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "finalize-root-release",
+        "apps",
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_POLL_INTERVAL_MS: "5",
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("finalize-root-release: apps at 2.0.0-43");
+    expect(stdout).toContain("syncing exact root batch 1/2 (3 resources)");
+    expect(stdout).toContain("syncing exact root batch 2/2 (1 resources)");
+    expect(syncBodies).toHaveLength(3);
+    expect(deleteRequests).toBe(3);
+    expect(finalPruneReads).toBeGreaterThanOrEqual(2);
+
+    const applicationRequest = SyncRequestSchema.parse(syncBodies[0]);
+    expect(applicationRequest.revision).toBe("2.0.0-43");
+    expect(applicationRequest.infos).toContainEqual(BATCH_PHASE_INFO);
+    expect(applicationRequest.resources).toEqual([
+      RootApplicationResource,
+      WorkerApplicationResource,
+      {
+        group: "argoproj.io",
+        kind: "Application",
+        name: "external",
+      },
+    ]);
+    expect(JSON.parse(applicationRequest.manifests[0] ?? "")).toMatchObject({
+      spec: { syncPolicy: { automated: { enabled: false } } },
+    });
+    expect(JSON.parse(applicationRequest.manifests[1] ?? "")).toMatchObject({
+      spec: { syncPolicy: { automated: { enabled: false } } },
+    });
+    expect(JSON.parse(applicationRequest.manifests[2] ?? "")).toMatchObject({
+      spec: { syncPolicy: { automated: { enabled: true } } },
+    });
+
+    const policyRequest = SyncRequestSchema.parse(syncBodies[1]);
+    expect(policyRequest.resources).toEqual([
+      {
+        group: "admissionregistration.k8s.io",
+        kind: "ValidatingAdmissionPolicy",
+        name: "pvc-backup-policy.sjer.red",
+      },
+    ]);
+    const pruneRequest = RootSyncRequestSchema.parse(syncBodies[2]);
+    expect(pruneRequest.prune).toBe(true);
+    expect(pruneRequest.infos).toContainEqual(PRUNE_PHASE_INFO);
+    const rawPruneRequest = z
+      .record(z.string(), z.unknown())
+      .parse(syncBodies[2]);
+    expect(rawPruneRequest["resources"]).toBeUndefined();
+    expect(rawPruneRequest["manifests"]).toBeUndefined();
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("root release finalization adopts the exact active batch without replaying prior waves", async () => {
+  const policyResource = {
+    group: "admissionregistration.k8s.io",
+    kind: "ValidatingAdmissionPolicy",
+    name: "pvc-backup-policy.sjer.red",
+  };
+  const activeBatchRequest = {
+    infos: releaseOperationInfo("batch"),
+    manifests: [StagedAdmissionPolicy],
+    prune: false,
+    resources: [policyResource],
+    revision: "2.0.0-43",
+  };
+  let activeRequest: unknown = activeBatchRequest;
+  let requestedOperation: Record<string, unknown> | undefined =
+    operationForSyncRequest(activeBatchRequest);
+  let deleteRequests = 0;
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/charts/apps") {
+        return Response.json([
+          {
+            version: "2.0.0-43",
+            urls: ["charts/apps-2.0.0-43.tgz"],
+            digest: "a".repeat(64),
+          },
+        ]);
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        return Response.json({
+          manifests: [
+            StagedRootApplication,
+            StagedRepositoryApplication,
+            StagedExternalApplication,
+            StagedAdmissionPolicy,
+          ],
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/apps/sync"
+      ) {
+        syncPosts += 1;
+        activeRequest = await request.json();
+        requestedOperation = operationForRootSyncRequest(activeRequest);
+        return Response.json({ operation: requestedOperation });
+      }
+      if (
+        request.method === "DELETE" &&
+        url.pathname === "/api/v1/applications/apps/operation"
+      ) {
+        deleteRequests += 1;
+        activeRequest = undefined;
+        requestedOperation = undefined;
+        return Response.json({});
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps"
+      ) {
+        if (activeRequest === undefined || requestedOperation === undefined) {
+          return Response.json({ status: { resources: [] } });
+        }
+        const manifestRequest = SyncRequestSchema.safeParse(activeRequest);
+        return Response.json({
+          operation: requestedOperation,
+          status: {
+            resources: [],
+            operationState: {
+              phase: "Running",
+              startedAt: new Date().toISOString(),
+              operation: requestedOperation,
+              syncResult: {
+                revision: "2.0.0-43",
+                resources: manifestRequest.success
+                  ? manifestRequest.data.resources.map((resource) => ({
+                      ...resource,
+                      status: "Synced",
+                    }))
+                  : [
+                      { ...RootApplicationResource, status: "Synced" },
+                      { ...WorkerApplicationResource, status: "Synced" },
+                    ],
+              },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "finalize-root-release",
+        "apps",
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_POLL_INTERVAL_MS: "5",
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("adopting exact root batch 2/2 (1 resources)");
+    expect(stdout).not.toContain("syncing exact root batch 1/2");
+    expect(syncPosts).toBe(1);
+    expect(deleteRequests).toBe(2);
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("root release finalization adopts the exact active prune without another POST", async () => {
+  const activeOperation = operationForRootSyncRequest({
+    infos: releaseOperationInfo("prune"),
+    prune: true,
+    revision: "2.0.0-43",
+  });
+  const unmarkedOperation = operationForRootSyncRequest({
+    infos: releaseOperationInfo("prune").filter(
+      ({ name }) => name !== "ci.sjer.red/root-finalizer-phase",
+    ),
+    prune: true,
+    revision: "2.0.0-43",
+  });
+  let marked = false;
+  let live = true;
+  let deleteRequests = 0;
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/charts/apps") {
+        return Response.json([
+          {
+            version: "2.0.0-43",
+            urls: ["charts/apps-2.0.0-43.tgz"],
+            digest: "a".repeat(64),
+          },
+        ]);
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        return Response.json({ manifests: [StagedRootApplication] });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/apps/sync"
+      ) {
+        syncPosts += 1;
+        return Response.json({});
+      }
+      if (
+        request.method === "DELETE" &&
+        url.pathname === "/api/v1/applications/apps/operation"
+      ) {
+        deleteRequests += 1;
+        live = false;
+        return Response.json({});
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps"
+      ) {
+        if (!live) {
+          return Response.json({ status: { resources: [] } });
+        }
+        const currentOperation = marked ? activeOperation : unmarkedOperation;
+        return Response.json({
+          operation: currentOperation,
+          status: {
+            resources: [],
+            operationState: {
+              phase: "Running",
+              startedAt: new Date().toISOString(),
+              operation: currentOperation,
+              syncResult: {
+                revision: "2.0.0-43",
+                resources: [{ ...RootApplicationResource, status: "Synced" }],
+              },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const unmarkedProcess = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "finalize-root-release",
+        "apps",
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_POLL_INTERVAL_MS: "5",
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [unmarkedExitCode, unmarkedStderr] = await Promise.all([
+      unmarkedProcess.exited,
+      new Response(unmarkedProcess.stderr).text(),
+    ]);
+    expect(unmarkedExitCode).not.toBe(0);
+    expect(unmarkedStderr).toContain(
+      "full-source operation is not the marked final root prune",
+    );
+    expect(syncPosts).toBe(0);
+    expect(deleteRequests).toBe(0);
+
+    marked = true;
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "finalize-root-release",
+        "apps",
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_POLL_INTERVAL_MS: "5",
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("adopting active final root prune: apps");
+    expect(syncPosts).toBe(0);
+    expect(deleteRequests).toBe(1);
+  } finally {
+    await server.stop(true);
+  }
+});

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -82,7 +82,9 @@ const StagedRepositoryApplication = JSON.stringify({
       chart: "worker",
       targetRevision: "2.0.0-43",
     },
-    syncPolicy: { automated: { prune: true, selfHeal: true } },
+    syncPolicy: {
+      automated: { enabled: false, prune: true, selfHeal: true },
+    },
   },
 });
 
@@ -106,7 +108,7 @@ const StagedExternalApplication = JSON.stringify({
       chart: "external",
       targetRevision: "1.0.0",
     },
-    syncPolicy: { automated: {} },
+    syncPolicy: { automated: { enabled: true } },
   },
 });
 
@@ -346,6 +348,9 @@ test("Argo CD CLI usage documents atomic sync and recovery identity", async () =
   );
   expect(stderr).toContain(
     "stage-root-release <root-app> --revision <v> [--timeout <s>]",
+  );
+  expect(stderr).toContain(
+    "finalize-root-release apps --revision <v> --request-id <uuid>",
   );
   expect(stderr).toContain(
     "finalize-async-sync <app> --revision <v> --request-id <uuid>",


### PR DESCRIPTION
## Why

Buildkite main build #9024 applied 257 root resources and both validated prunes, then stalled before nine later-wave resources appeared. The full-source operation contained the self-referential root Application and degraded ordinary child Applications in wave zero, so ArgoCD waited for their health before exposing later waves. The generic completeness fence correctly refused to terminate that partial result.

## What

- Add `finalize-root-release`, which renders the exact published apps revision, reapplies every desired sync wave in bounded manifest-override batches, and starts the verified full-source prune only after all desired batches have applied. The self-managed root remains auto-sync suspended between batches; the final prune must restore and report it.
- Reuse the Buildkite request UUID across the lifecycle while assigning a distinct internal operation UUID to every POST. Mark each owned operation as `batch` or `prune`; retries also require the expected prune mode and adopt only an exact active batch or the marked unselected final prune with matching request and revision. Unmarked full-source operations, unrelated identities, and unexpected resource selections fail closed.
- Keep generic atomic sync completeness strict. Only the final apps prune may use prior exact-batch proof to narrow its completion boundary to validated prune candidates.
- Replace the pipeline's stalling full-source final sync, strengthen its regression validator, and document the workflow and identity-bound recovery boundary in operator guidance, repository instructions, and the ArgoCD skill.

## Verification

- `cd packages/homelab/src/cdk8s && bun test src/argocd-script.test.ts src/argocd-root-finalization.test.ts src/argocd-atomic-sync.test.ts` - 51 passed
- `cd packages/homelab/src/cdk8s && bun test ../../scripts/argocd-manifest-overrides.test.ts` - 21 passed
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s` - passed
- `bun test ./.buildkite/scripts/validate-pipeline-release.test.ts` - 14 passed
- `bun .buildkite/scripts/validate-pipeline-release.ts` - passed
- `bunx turbo run typecheck lint test build --filter=@shepherdjerred/docs-wiki` - passed
- `cd packages/docs/wiki && bun run test:e2e` - 7 passed
- `bun run markdownlint` and `bun run check-todos` - passed
- `bunx lefthook run pre-commit` - passed
- `bun run verify` - 247/248 tasks passed; the only local failure was the resume build because `xelatex` is not installed on this machine. Buildkite provides TeX Live and remains the authoritative full gate.
- Live recovery revalidated build #9024 request `019ff00f-3b9e-4cef-93c0-9a2468280602` at revision `2.0.0-9024`, adopted its fully applied final prune without a second POST, and waited until the root operation cleared.

## Rollout

Merge only after the exact PR head passes Buildkite and current-head review is clean. Then require a passed Buildkite build for the current remote `main` SHA, a green scoped release-health gate, and no lingering root ArgoCD operation.
