### PR TITLE
fix(alert-dashboard): bake Prisma engines before startup

### DIFF
--- a/packages/alert-dashboard/Dockerfile
+++ b/packages/alert-dashboard/Dockerfile
@@ -31,6 +31,12 @@ RUN bun install --frozen-lockfile --production --filter '@shepherdjerred/alert-d
 FROM base AS runtime
 COPY --from=prod-deps /app/ /app/
 COPY --from=build /app/packages/alert-dashboard /app/packages/alert-dashboard
+# Bake Prisma's migration engines into the production dependency tree. Bun's
+# production install omits lifecycle scripts, so the CLI would otherwise
+# download engines on first use. Runtime executes as uid 1000 over root-owned
+# node_modules, which correctly prevents that startup write. Generating once as
+# root here keeps `prisma migrate deploy` read-only at runtime.
+RUN cd packages/alert-dashboard && bunx --no-install --trust prisma generate
 ENV NODE_ENV=production HOME=/tmp
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"
 EXPOSE 7341
@@ -41,6 +47,9 @@ FROM runtime AS smoke
 COPY .buildkite/scripts/smoke-app-in-image.ts /app/.buildkite/scripts/smoke-app-in-image.ts
 ARG SMOKE_TARGET=alert-dashboard
 ENV CI_IMAGE_SMOKE_TARGET=${SMOKE_TARGET}
+# Exercise Prisma as the deployed non-root user so a missing baked engine fails
+# the image gate instead of crash-looping the migration init container.
+RUN cd /app/packages/alert-dashboard && bunx --no-install prisma --version
 RUN bun /app/.buildkite/scripts/smoke-app-in-image.ts
 
 FROM runtime AS image


### PR DESCRIPTION
## Why

Making the alert-dashboard GHCR package public allowed Kubernetes to pull the exact pinned image, which exposed the next release-health blocker. The `prisma-migrate` init container runs as uid 1000 over root-owned `/app/node_modules`; because Bun production installs omit Prisma lifecycle scripts, Prisma tried to download its schema engine at startup and failed with EACCES.

## What

- Run `prisma generate` as root in the runtime image so the exact production dependency tree already contains its schema engine.
- Run `prisma --version` in the smoke stage after the image switches to uid 1000, turning this production-only permission failure into an image-build failure.
- Keep the runtime non-root and its dependency tree read-only; no permission broadening or health-gate bypass is introduced.

## Verification

- `docker buildx build --platform linux/amd64 --target smoke --load -t alert-dashboard:prisma-engines -f packages/alert-dashboard/Dockerfile .` — passed; non-root smoke resolved `schema-engine-debian-openssl-3.0.x`.
- `bunx turbo run typecheck lint test --filter=@shepherdjerred/alert-dashboard` — passed (25 tests).
- `bunx lefthook run pre-commit` — passed.
- `bun run verify` — 247/248 tasks passed; the unrelated resume build could not run locally because this Mac does not have `xelatex`. The dedicated Buildkite resume lane remains required.

## Rollout

The main image lane must publish and anonymously verify the replacement digest, the image pin commit-back must reach the alert-dashboard chart, and the release is not accepted until the deployment is Ready and the scoped Argo health gate passes.