### PR TITLE
Restore version commit-back under Bun's isolated linker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1738,7 +1738,10 @@ steps:
     concurrency_group: monorepo/version-commit-back
     command: |
       . .buildkite/scripts/toolchain.sh
-      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
+      # update-versions imports the catalog validator from @homelab/cdk8s.
+      # With Bun's isolated linker, zod must be installed for that workspace;
+      # the root-scripts copy cannot satisfy an import resolved from cdk8s.
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production
       bun --no-install scripts/update-versions.ts --commit-back --candidates "$$(buildkite-agent meta-data get pin-candidates)"
     # Safe to retry: the bump branch is force-updated and the PR lookup is
     # find-or-create; transient gh/git failures exit 34 via transient.ts.

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { validateAtomicRootSyncLifecycle } from "./validate-pipeline-release.ts";
+import {
+  validateAtomicRootSyncLifecycle,
+  validateVersionCommitBackInstall,
+} from "./validate-pipeline-release.ts";
 
 const argocdCommand = (subcommand: string): string =>
   `bun --no-install packages/homelab/scripts/argocd.ts ${subcommand}`;
@@ -199,5 +202,24 @@ describe("atomic ArgoCD root sync pipeline contract", () => {
     ).toThrow(
       "argocd-sync must contain exactly one deferred child reconciliation",
     );
+  });
+});
+
+describe("version commit-back install contract", () => {
+  const isolatedLinkerInstall =
+    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production";
+
+  test("installs both the script and imported catalog workspaces", () => {
+    expect(() =>
+      validateVersionCommitBackInstall(isolatedLinkerInstall),
+    ).not.toThrow();
+  });
+
+  test("rejects installing zod only for the importing scripts workspace", () => {
+    expect(() =>
+      validateVersionCommitBackInstall(
+        ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production",
+      ),
+    ).toThrow("version commit-back is missing exact isolated-linker install");
   });
 });

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -237,6 +237,19 @@ function validateReleaseSteps({
   }
 }
 
+const VERSION_COMMIT_BACK_INSTALL =
+  ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production";
+
+export function validateVersionCommitBackInstall(
+  stepBlock: string | undefined,
+): void {
+  if (!hasTrimmedLine(stepBlock, VERSION_COMMIT_BACK_INSTALL)) {
+    fail(
+      `version commit-back is missing exact isolated-linker install ${VERSION_COMMIT_BACK_INSTALL}`,
+    );
+  }
+}
+
 function validatePublishing(stepBlocks: ReadonlyMap<string, string>): void {
   const publish = stepBlocks.get("publish");
   if (
@@ -260,11 +273,7 @@ function validatePublishing(stepBlocks: ReadonlyMap<string, string>): void {
     );
   }
 
-  requireIncludes(
-    stepBlocks.get("version-commit-back"),
-    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production",
-    "version commit-back is missing its Zod-owning filtered install",
-  );
+  validateVersionCommitBackInstall(stepBlocks.get("version-commit-back"));
 }
 
 async function validateSelectorAndUpload({


### PR DESCRIPTION
Why

Main Buildkite #9141 passed verify, the full image publisher, and Helm publication, then failed in version-commit-back before ArgoCD. The lane installed only @shepherdjerred/root-scripts, but update-versions.ts imports the Zod-backed catalog validator from @homelab/cdk8s. Bun's isolated linker resolves zod from the source module's workspace, so the scripts workspace dependency cannot satisfy that import.

What

- Install both @shepherdjerred/root-scripts and @homelab/cdk8s in the production commit-back lane.
- Require that exact isolated-linker install in pipeline validation.
- Add a negative regression proving the scripts-only install shape from #9141 is rejected.

Verification

- bun --no-install test ./.buildkite/scripts/ ./scripts/lib/ — 322 pass
- bunx turbo run typecheck lint --filter=@shepherdjerred/root-scripts --output-logs=errors-only
- bun --no-install .buildkite/scripts/validate-pipeline.ts
- bunx lefthook run pre-commit
- Clean temporary checkout: filtered production install completed with 148 packages and bun --no-install resolved scripts/lib/pin-candidates.ts

Live Buildkite and ArgoCD acceptance are pending this PR.