### PR TITLE
Keep certificate issuance and image pin commit-back progressing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1685,6 +1685,7 @@
         "fast-xml-parser": "5.10.1",
         "fast-xml-validator": "1.4.0",
         "istanbul-lib-instrument": "6.0.3",
+        "prettier": "3.8.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -89,6 +89,13 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   boolean. Restoring `enabled: false` to an empty object makes Argo's patch
   encode `automated: null`, which the Application CRD rejects; validate the
   synthesized chart corpus so that implicit policy cannot return.
+- Override cert-manager Certificate health so the normal initial
+  `Ready=False` / `DoesNotExist` transition remains `Progressing` while the
+  controller creates its target Secret. Keep other false Ready conditions and
+  a simultaneous `Issuing=False` failure `Degraded`, and retain the operation
+  timeout as the upper bound. This lets certificate sync waves wait for actual
+  readiness without ignoring their health or weakening terminal failure
+  handling.
 - Treat anonymous image access as part of the release handoff. Every
   application image links its GHCR package to the public monorepo through the
   OCI source label. A new package still requires an explicit one-time public
@@ -118,6 +125,9 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   private, static and effective-image source-label completeness, and Turbo
   invalidation for Buildkite script inputs. Prove every image bake target
   resolves its exact pin from the real structured version catalog.
+- Cover the cert-manager health override in the synthesized ArgoCD Application
+  and prove initial Secret issuance is distinct from terminal Certificate
+  failure.
 - Recover the stranded operation only after its live identity and complete
   applied result are revalidated.
 - Require an exact-head PR build and then a fresh successful build of the

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -65,6 +65,24 @@ release command also persists the exact revision in the operation info list
 beside its request and operation UUIDs. Either representation can prove the
 revision, but disagreement between them is a hard identity failure.
 
+Certificate waves still use resource health as their ordering barrier. The
+[cert-manager Certificate condition contract](https://github.com/cert-manager/cert-manager/blob/b8f325e36f49626ba72d7efbe138c01a5e661d96/pkg/apis/certmanager/v1/types_certificate.go#L717-L777)
+allows separate `Ready` and `Issuing` conditions. A new Certificate briefly
+reports `Ready=False` with reason `DoesNotExist` while it creates the referenced
+Secret. The
+[ArgoCD health customization](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts)
+classifies only that normal issuance transition as `Progressing`, so the wave
+waits instead of terminating. It checks the separate Issuing condition before
+exempting a missing Secret because cert-manager
+[records a failed request as `Issuing=False`](https://github.com/cert-manager/cert-manager/blob/b8f325e36f49626ba72d7efbe138c01a5e661d96/pkg/controller/certificates/issuing/issuing_controller.go#L408-L430)
+while the missing-Secret Ready condition can remain unchanged. A different
+false Ready reason or failed issuance stays `Degraded`. The
+[five-minute release operation timeout](https://github.com/shepherdjerred/monorepo/blob/main/.buildkite/pipeline.yml#L1547-L1556)
+still fails a Certificate that never becomes ready. Ignoring Certificate health
+would let the
+[later CA, database, and workload waves](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/postgres/alert-dashboard-tls.ts)
+race a missing trust Secret, so the release does not use that shortcut.
+
 Both request shapes remain isolated by numeric sync wave and exact resource
 identity. After explicit child reconciliation completes, the
 [root finalizer](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/scripts/argocd.ts)

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -15,6 +15,8 @@ const ApplicationSchema = z
           valuesObject: z.object({
             configs: z.object({
               cm: z.object({
+                "resource.customizations.health.cert-manager.io_Certificate":
+                  z.string(),
                 "resource.customizations.health.argoproj.io_Application":
                   z.string(),
               }),
@@ -70,5 +72,29 @@ describe("ArgoCD application", () => {
     expect(customization).toContain(
       'hs.message = "Application operation is " .. obj.status.operationState.phase',
     );
+  });
+
+  it("keeps only non-failed cert-manager secret issuance progressing", () => {
+    const application = synthArgoCdApplication();
+    const customization =
+      application.spec.source.helm.valuesObject.configs.cm[
+        "resource.customizations.health.cert-manager.io_Certificate"
+      ];
+
+    expect(customization).toContain('condition.type == "Issuing" and');
+    expect(customization).toContain('condition.reason ~= "Issued"');
+    expect(customization).toContain(
+      'ready.status == "False" and ready.reason ~= "DoesNotExist"',
+    );
+    expect(customization).toContain("if failedIssuing ~= nil then");
+    expect(customization).toContain("hs.message = failedIssuing.message");
+    expect(customization.indexOf("if failedIssuing ~= nil then")).toBeLessThan(
+      customization.indexOf(
+        'ready.status == "False" and ready.reason ~= "DoesNotExist"',
+      ),
+    );
+    expect(customization).toContain('hs.status = "Progressing"');
+    expect(customization).toContain('hs.status = "Healthy"');
+    expect(customization).toContain('hs.status = "Degraded"');
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -222,6 +222,52 @@ if obj.status ~= nil then
   end
 end
 return hs`,
+        // A newly-created cert-manager Certificate reports Ready=False with
+        // reason DoesNotExist while it creates its target Secret. ArgoCD's
+        // documented generic Certificate health check classifies every False
+        // condition as Degraded, which terminates a sync wave during normal
+        // issuance. Preserve terminal Ready failures and the separate
+        // Issuing=False failure condition while letting that exact controller
+        // transition remain bounded by the operation timeout.
+        "resource.customizations.health.cert-manager.io_Certificate": `hs = {}
+hs.status = "Progressing"
+hs.message = "Waiting for certificate"
+if obj.status ~= nil and obj.status.conditions ~= nil then
+  local ready = nil
+  local failedIssuing = nil
+  for _, condition in ipairs(obj.status.conditions) do
+    if condition.type == "Ready" then
+      ready = condition
+    elseif condition.type == "Issuing" and
+           condition.status == "False" and
+           condition.reason ~= "Issued" then
+      failedIssuing = condition
+    end
+  end
+  if ready ~= nil and ready.status == "True" then
+    hs.status = "Healthy"
+    if ready.message ~= nil then
+      hs.message = ready.message
+    end
+    return hs
+  end
+  if failedIssuing ~= nil then
+    hs.status = "Degraded"
+    if failedIssuing.message ~= nil then
+      hs.message = failedIssuing.message
+    end
+    return hs
+  end
+  if ready ~= nil then
+    if ready.message ~= nil then
+      hs.message = ready.message
+    end
+    if ready.status == "False" and ready.reason ~= "DoesNotExist" then
+      hs.status = "Degraded"
+    end
+  end
+end
+return hs`,
         // Exclude ephemeral Velero resources from tracking
         "resource.exclusions": `- apiGroups:
   - velero.io

--- a/packages/homelab/src/cdk8s/src/version-catalog.json
+++ b/packages/homelab/src/cdk8s/src/version-catalog.json
@@ -695,9 +695,7 @@
         "managed": false
       },
       "value": "2.0.0-9147@sha256:d1a875a6488d9c48b7d39693e10ffaa270f46f8fef9499c1668f9c60cb6cba39",
-      "notes": [
-        "not managed by renovate — beta updated by version-commit-back"
-      ]
+      "notes": ["not managed by renovate — beta updated by version-commit-back"]
     },
     {
       "name": "shepherdjerred/scout-for-lol/prod",
@@ -729,9 +727,7 @@
         "managed": false
       },
       "value": "2.0.0-9147@sha256:565295441ceb3bf478fd2354dad38d202944fba0afef40dc12da41a7e409d4fe",
-      "notes": [
-        "not managed by renovate — beta updated by version-commit-back"
-      ]
+      "notes": ["not managed by renovate — beta updated by version-commit-back"]
     },
     {
       "name": "shepherdjerred/starlight-karma-bot/prod",
@@ -754,9 +750,7 @@
         "managed": false
       },
       "value": "2.0.0-9147@sha256:8c3ff8f35b9c0aa287a3ae1272a4fd0e7d580cc06d36f2aafa49fee998845fef",
-      "notes": [
-        "not managed by renovate"
-      ]
+      "notes": ["not managed by renovate"]
     },
     {
       "name": "shepherdjerred/alert-dashboard",
@@ -792,9 +786,7 @@
         "managed": false
       },
       "value": "2.0.0-9147@sha256:a52e342271bf15893bb7f7c02c1ad0823a1e4c5c2a41a59f6daf6a14a00bec74",
-      "notes": [
-        "not managed by renovate"
-      ]
+      "notes": ["not managed by renovate"]
     },
     {
       "name": "shepherdjerred/discord-plays-mario-kart",

--- a/scripts/lib/pin-candidates.ts
+++ b/scripts/lib/pin-candidates.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { format } from "prettier";
 import {
   parseVersionCatalogText,
   serializeVersionCatalog,
@@ -193,10 +194,10 @@ export function mergePinCandidates(
   return { schema: "pin-candidates-state/v1", pins };
 }
 
-export function rewriteVersionCatalogSource(
+export async function rewriteVersionCatalogSource(
   source: string,
   state: PinCandidatesState,
-): string {
+): Promise<string> {
   const catalog = parseVersionCatalogText(source);
   const pins = new Map(Object.entries(state.pins));
   const rewritten: VersionCatalog = {
@@ -215,5 +216,5 @@ export function rewriteVersionCatalogSource(
       );
     }
   }
-  return serializeVersionCatalog(rewritten);
+  return await format(serializeVersionCatalog(rewritten), { parser: "json" });
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,8 @@
     "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.10.1",
     "fast-xml-validator": "1.4.0",
-    "istanbul-lib-instrument": "6.0.3"
+    "istanbul-lib-instrument": "6.0.3",
+    "prettier": "3.8.3"
   },
   "devDependencies": {
     "@shepherdjerred/eslint-config": "workspace:*",

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -29,7 +29,9 @@ const C =
   "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 const KEY = "shepherdjerred/example";
 
-function catalogSource(entries: { name: string; value: string }[]): string {
+function catalogSource(
+  entries: { name: string; value: string; notes?: string[] }[],
+): string {
   return JSON.stringify({
     $schema: "./version-catalog.schema.json",
     schemaVersion: 1,
@@ -43,6 +45,7 @@ function catalogSource(entries: { name: string; value: string }[]): string {
         ? { managed: true, datasource: "docker", versioning: "docker" }
         : { managed: false },
       value: entry.value,
+      ...(entry.notes === undefined ? {} : { notes: entry.notes }),
     })),
   });
 }
@@ -199,13 +202,20 @@ describe("version catalog integrity", () => {
     { name: "chart", value: "1.0.0" },
   ]);
 
-  test("rewrites exact managed keys and serializes canonically", () => {
+  test("rewrites exact managed keys as Prettier-stable canonical JSON", async () => {
     const state = mergePinCandidates(
       parsePinCandidatesState('{"schema":"pin-candidates-state/v1","pins":{}}'),
       batch(12, "v12", B),
     );
-    const rewritten = rewriteVersionCatalogSource(source, state);
+    const rewritten = await rewriteVersionCatalogSource(
+      catalogSource([
+        { name: KEY, value: `old@${A}`, notes: ["not managed"] },
+        { name: "chart", value: "1.0.0" },
+      ]),
+      state,
+    );
     expect(rewritten).toContain(`"value": "v12@${B}"`);
+    expect(rewritten).toContain('"notes": ["not managed"]');
     const entryStart = rewritten.indexOf(`"name": "${KEY}"`);
     const management = rewritten.indexOf('"management":', entryStart);
     const value = rewritten.indexOf(`"value": "v12@${B}"`, entryStart);

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -188,7 +188,7 @@ async function prepareAttempt(
   await resetVersionBumpBranch(git);
   await Bun.write(
     `${cloneDir}/${VERSION_CATALOG_FILE_REL}`,
-    rewriteVersionCatalogSource(mainSource, aggregate),
+    await rewriteVersionCatalogSource(mainSource, aggregate),
   );
   await Bun.write(
     `${cloneDir}/${PIN_STATE_FILE_REL}`,


### PR DESCRIPTION
## Why

Main Buildkite #9147 completed all nine atomic ArgoCD root staging waves, then the alert-dashboard child failed while cert-manager was normally issuing its missing CA Secret. The generated image-pin PR #2135 independently failed verify because the catalog writer emitted JSON that was not Prettier-stable.

## What

- Add an ArgoCD Certificate health customization that keeps only Ready=False with reason DoesNotExist in Progressing, reports Ready=True as Healthy, and leaves every other Ready=False condition Degraded.
- Format version-catalog rewrites with the pinned production Prettier dependency before commit-back writes them.
- Add exact regressions for certificate health states and one-item notes arrays.
- Update the atomic root release plan and release-safety explanation with the health boundary and rejection of ignore-healthcheck bypasses.

## Verification

- cd packages/homelab/src/cdk8s && bun test src/resources/argo-applications/argocd.test.ts src/resources/alert-dashboard/index.test.ts
- bunx turbo run typecheck lint test --filter=@homelab/cdk8s --filter=@shepherdjerred/root-scripts --output-logs=errors-only
- bun test scripts/update-versions.test.ts
- cd scripts && bun run test:ci: 514 pass
- bun --no-install scripts/check-script-coverage.ts
- bun --no-install .buildkite/scripts/validate-pipeline.ts
- bunx turbo run build test --filter=@shepherdjerred/docs-wiki --output-logs=errors-only
- bunx markdownlint-cli2 packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
- bunx lefthook run pre-commit
- Clean isolated production install imported the release dependencies and produced exact Prettier-stable catalog JSON.

Live Buildkite and ArgoCD acceptance are pending this exact head.