### PR TITLE
Upgrade cert-manager to stop Disabled-renewal panics

### DIFF
--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -96,6 +96,13 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   timeout as the upper bound. This lets certificate sync waves wait for actual
   readiness without ignoring their health or weakening terminal failure
   handling.
+- Pin cert-manager v1.21.1. Version 1.21.0 has a
+  [controller panic](https://github.com/cert-manager/cert-manager/issues/9031)
+  when a Certificate uses `renewal.policy: Disabled`; the
+  [v1.21.1 patch release](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.1)
+  fixes that regression. Keep the Alert Dashboard CA non-renewing and repair
+  the controller rather than weakening the deliberate CA trust-migration
+  boundary.
 - Treat anonymous image access as part of the release handoff. Every
   application image links its GHCR package to the public monorepo through the
   OCI source label. A new package still requires an explicit one-time public

--- a/packages/homelab/src/cdk8s/src/version-catalog.json
+++ b/packages/homelab/src/cdk8s/src/version-catalog.json
@@ -60,7 +60,7 @@
         "registryUrl": "https://charts.jetstack.io",
         "versioning": "semver-coerced"
       },
-      "value": "v1.21.0"
+      "value": "v1.21.1"
     },
     {
       "name": "intel-device-plugins-operator",


### PR DESCRIPTION
## Why

Main build #9157 completed every root staging wave, then the Alert Dashboard child sync stalled because cert-manager v1.21.0 crash-looped. The live stack is the exact upstream regression in cert-manager issue #9031: a Certificate with renewal.policy Disabled dereferences a nil renewal time. The CA Issuer therefore never becomes Ready.

## What

- Pin the cert-manager chart to v1.21.1, whose release notes explicitly fix the v1.21.0 panic.
- Keep the Alert Dashboard root CA non-renewing; replacing that safety policy with automatic CA rotation would weaken the trust-migration boundary.
- Record the newly exposed runtime root cause in the atomic release plan.
- Regenerate all 25 committed Helm type sources; v1.21.1 produces no type drift from v1.21.0.

## Verification

- bun run generate-helm-types
- bun run generate-helm-types --check
- bunx turbo run build typecheck lint test --filter=@homelab/cdk8s --output-logs=errors-only
- bunx markdownlint-cli2 packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
- bunx lefthook run pre-commit
- Upstream issue and v1.21.1 release links returned HTTP 200.

Live rollout and current-main Buildkite acceptance are pending this exact head.