### PR TITLE
Roll Temporal agents when admission policy changes

### DIFF
--- a/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
+++ b/packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md
@@ -116,6 +116,11 @@ only an exact retry; and keep the scoped release-health gate authoritative.
   fixes that regression. Keep the Alert Dashboard CA non-renewing and repair
   the controller rather than weakening the deliberate CA trust-migration
   boundary.
+- Carry the Temporal agent worker's Namespace Pod Security enforcement value
+  on its Deployment pod template as well. A release that changes the admission
+  contract then creates a fresh ReplicaSet after the Namespace is updated,
+  instead of letting Argo inherit a `ProgressDeadlineExceeded` condition from
+  pods rejected under the previous policy.
 - Treat anonymous image access as part of the release handoff. Every
   application image links its GHCR package to the public monorepo through the
   OCI source label. A new package still requires an explicit one-time public
@@ -148,6 +153,8 @@ only an exact retry; and keep the scoped release-health gate authoritative.
 - Cover the cert-manager health override in the synthesized ArgoCD Application
   and prove initial Secret issuance is distinct from terminal Certificate
   failure.
+- Prove the Temporal agent Namespace enforcement label and pod-template rollout
+  annotation carry the same value.
 - Recover the stranded operation only after its live identity and complete
   applied result are revalidated.
 - Require an exact-head PR build and then a fresh successful build of the

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
@@ -74,7 +74,10 @@ labels for every workload. This does not make the containers privileged: their
 security contexts still drop all capabilities and add only the two named above,
 with privilege escalation disabled. The synthesized namespace labels and both
 container capability sets are tested together so the admission contract cannot
-drift away from the runtime boundary.
+drift away from the runtime boundary. The enforcement value is also copied to
+the agent Deployment's pod-template annotation. Changing that admission
+contract therefore starts a fresh ReplicaSet after the Namespace update rather
+than retaining a rollout failure created under the old policy.
 
 So local filesystem writes are still possible. A sufficiently confused or
 prompt-injected run can corrupt only its disposable workdir; it does not receive

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -12,6 +12,7 @@ import { createTemporalUiDeployment } from "@shepherdjerred/homelab/cdk8s/src/re
 import { createTemporalNamespaceInitJob } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/namespace-init.ts";
 import { createTemporalWorkerDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker.ts";
 import { createTemporalAgentWorkerNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker-network-policy.ts";
+import { TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker.ts";
 
 export function createTemporalChart(app: App) {
   const chart = new Chart(app, "temporal", {
@@ -29,7 +30,8 @@ export function createTemporalChart(app: App) {
         // pod-scoped exception, so enforcement must permit those explicit
         // capabilities at the namespace boundary while audit/warn retain the
         // baseline signal for every workload.
-        "pod-security.kubernetes.io/enforce": "privileged",
+        "pod-security.kubernetes.io/enforce":
+          TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT,
         "pod-security.kubernetes.io/audit": "baseline",
         "pod-security.kubernetes.io/warn": "baseline",
       },

--- a/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
@@ -26,6 +26,8 @@ type CreateTemporalAgentWorkerProps = {
 const AGENT_WORKER_UID = 1000;
 const AGENT_PROVIDER_UID = 1001;
 
+export const TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT = "privileged";
+
 /**
  * Run provider-controlled report-only subprocesses outside the core worker.
  *
@@ -57,6 +59,10 @@ export function createTemporalAgentWorker(
       fsGroup: AGENT_WORKER_UID,
     },
     podMetadata: {
+      annotations: {
+        "ci.sjer.red/pod-security-enforcement":
+          TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT,
+      },
       labels: {
         app: "temporal-agent-worker",
         component: "agent-worker",

--- a/packages/homelab/src/cdk8s/src/temporal-agent-network-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-agent-network-boundary.test.ts
@@ -25,7 +25,10 @@ const DeploymentSchema = z.object({
   metadata: z.object({ name: z.string() }),
   spec: z.object({
     template: z.object({
-      metadata: z.object({ labels: z.record(z.string(), z.string()) }),
+      metadata: z.object({
+        annotations: z.record(z.string(), z.string()),
+        labels: z.record(z.string(), z.string()),
+      }),
       spec: z.object({
         containers: z.array(ContainerSchema),
         initContainers: z.array(ContainerSchema),
@@ -95,6 +98,34 @@ describe("Temporal agent provider network boundary", () => {
       "pod-security.kubernetes.io/audit": "baseline",
       "pod-security.kubernetes.io/warn": "baseline",
     });
+  });
+
+  test("rolls the agent worker when its admission contract changes", () => {
+    const synthesized = resources();
+    const namespace = synthesized.flatMap((resource) => {
+      const parsed = NamespaceSchema.safeParse(resource);
+      return parsed.success && parsed.data.metadata.name === "temporal"
+        ? [parsed.data]
+        : [];
+    })[0];
+    const deployment = synthesized.flatMap((resource) => {
+      const parsed = DeploymentSchema.safeParse(resource);
+      return parsed.success &&
+        parsed.data.metadata.name === "temporal-temporal-agent-worker"
+        ? [parsed.data]
+        : [];
+    })[0];
+    if (namespace === undefined || deployment === undefined) {
+      throw new Error(
+        "Temporal Namespace and agent worker Deployment must be synthesized",
+      );
+    }
+
+    expect(
+      deployment.spec.template.metadata.annotations[
+        "ci.sjer.red/pod-security-enforcement"
+      ],
+    ).toBe(namespace.metadata.labels["pod-security.kubernetes.io/enforce"]);
   });
 
   test("runs provider commands under a firewalled uid distinct from the poller", () => {


### PR DESCRIPTION
## Why

Buildkite main #9174 applied the corrected Temporal Namespace policy, but the agent worker Deployment kept the same pod template that had already failed under the old policy. Kubernetes retained the ReplicaSet failure and `ProgressDeadlineExceeded` condition, so Argo failed the release immediately instead of waiting for an admission retry.

## What

- Source the Temporal Namespace Pod Security enforcement label from one admission-contract value.
- Carry that same value on the agent worker pod template so an enforcement change necessarily creates a fresh ReplicaSet.
- Test the synthesized Namespace-to-Deployment coupling.
- Record the rollout invariant in the atomic-release plan and Temporal security-boundary explanation.

## Verification

- `bunx turbo run typecheck lint test --filter=@homelab/cdk8s --output-logs=errors-only`
- `bunx turbo run build test --filter=@shepherdjerred/docs-wiki --output-logs=errors-only`
- `bun run markdownlint packages/docs/plans/2026-08-09_argocd-atomic-root-sync.md packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md`
- `bunx lefthook run pre-commit`
- Buildkite #9175 passed on exact head `99c58422d19dfbe761603308fe667c31dddbbc53`: verify, Playwright, Semgrep, deploy/drift dry-run, and Codex review gate.
- Codex and Qodo reported no material issues on the exact head.
- Live recovery: the unavailable Deployment was restarted after the Namespace policy landed; its firewall init completed with exit 0, the worker became Ready with zero restarts, an identity-bound sync of Temporal `2.0.0-9174` succeeded, the temporary restart marker was removed, and Argo reports `Synced/Healthy` with no active operation.