### PR TITLE
feat(homelab): enable Stash Intel GPU transcoding

### DIFF
--- a/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
+++ b/packages/docs/plans/2026-08-10_stash-tailnet-deployment.md
@@ -56,8 +56,9 @@ Excluded:
   deployment acceptance.
 - Public internet exposure, Tailscale Funnel, a `stash.sjer.red` hostname, or a
   Cloudflare tunnel binding.
-- Intel GPU allocation and hardware transcoding. Add it only after the initial
-  deployment is stable and workload evidence justifies it.
+- Intel GPU allocation and hardware transcoding for the initial deployment;
+  this follow-up is tracked in
+  [`2026-08-11_stash-gpu-acceleration.md`](2026-08-11_stash-gpu-acceleration.md).
 
 ### Public terminology and disclosure
 

--- a/packages/docs/plans/2026-08-11_stash-gpu-acceleration.md
+++ b/packages/docs/plans/2026-08-11_stash-gpu-acceleration.md
@@ -1,0 +1,51 @@
+---
+id: plan-2026-08-11-stash-gpu-acceleration
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Stash Intel GPU Acceleration
+
+## Goal
+
+Give the existing private Stash deployment one shared Intel iGPU slot through
+the cluster's Intel device plugin and enable VAAPI hardware encoding without
+changing its storage, authentication, ingress, or security boundaries.
+
+## Changes
+
+- Request `gpu.intel.com/i915: 1` on the Stash container using the existing
+  cdk8s JSON-patch convention.
+- Set `STASH_HW_DRI_DEVICE` explicitly to `/dev/dri/renderD128`.
+- Extend the Stash synth test and the repository GPU-resource test to prevent
+  the resource from disappearing in a later manifest change.
+- Enable Stash's persisted `FFmpeg hardware encoding` setting through its
+  authenticated UI during rollout. The setting is application state, not a
+  `config.yml` field, so it is not managed by the authentication init
+  container.
+
+## Verification
+
+- Focused CDK8s tests, GPU-resource checks, typecheck, lint, and synthesized
+  manifest inspection pass.
+- The ArgoCD `stash` Application is Synced and Healthy after the chart is
+  published and reconciled.
+- The running pod has the GPU limit, runs on `torvalds`, and exposes a readable
+  `/dev/dri/renderD128`.
+- Stash startup logs report supported hardware codecs after the persisted
+  setting is enabled.
+- The container's FFmpeg completes a short `h264_vaapi` smoke encode.
+
+## Remaining
+
+- [ ] Merge and publish the GitOps change.
+- [ ] Enable the Stash hardware-encoding setting and complete live acceptance.
+
+## Comment Log
+
+- 2026-08-11: The cluster GPU device plugin and Stash image were verified live;
+  Stash was CPU-only because its pod requested no GPU resource and had no
+  `/dev/dri` device.

--- a/packages/docs/plans/2026-08-11_stash-gpu-acceleration.md
+++ b/packages/docs/plans/2026-08-11_stash-gpu-acceleration.md
@@ -22,10 +22,11 @@ changing its storage, authentication, ingress, or security boundaries.
 - Set `STASH_HW_DRI_DEVICE` explicitly to `/dev/dri/renderD128`.
 - Extend the Stash synth test and the repository GPU-resource test to prevent
   the resource from disappearing in a later manifest change.
-- Enable Stash's persisted `FFmpeg hardware encoding` setting through its
-  authenticated UI during rollout. The setting is application state, not a
-  `config.yml` field, so it is not managed by the authentication init
-  container.
+
+Stash's persisted `FFmpeg hardware encoding` setting is application state rather
+than a `config.yml` field, so enabling it needs the authenticated UI and is out
+of scope here. It is tracked as operator-blocked work in
+`packages/docs/todos/stash-hardware-encoding-setting.md`.
 
 ## Verification
 
@@ -35,17 +36,25 @@ changing its storage, authentication, ingress, or security boundaries.
   published and reconciled.
 - The running pod has the GPU limit, runs on `torvalds`, and exposes a readable
   `/dev/dri/renderD128`.
-- Stash startup logs report supported hardware codecs after the persisted
-  setting is enabled.
 - The container's FFmpeg completes a short `h264_vaapi` smoke encode.
+
+Stash reporting its supported hardware codecs at startup depends on the
+operator-only setting and is verified in
+`packages/docs/todos/stash-hardware-encoding-setting.md`.
 
 ## Remaining
 
 - [ ] Merge and publish the GitOps change.
-- [ ] Enable the Stash hardware-encoding setting and complete live acceptance.
+- [ ] Confirm the ArgoCD `stash` Application is Synced and Healthy, and that the
+      running pod carries the `gpu.intel.com/i915` limit on `torvalds` with a
+      readable `/dev/dri/renderD128`.
+- [ ] Run a short `h264_vaapi` FFmpeg smoke encode inside the container.
 
 ## Comment Log
 
 - 2026-08-11: The cluster GPU device plugin and Stash image were verified live;
   Stash was CPU-only because its pod requested no GPU resource and had no
   `/dev/dri` device.
+- 2026-08-13: Split the authenticated-UI hardware-encoding enablement into
+  `stash-hardware-encoding-setting` so this item stays genuinely agent-operable;
+  the remaining checks here are all deterministic and do not need that setting.

--- a/packages/docs/todos/stash-hardware-encoding-setting.md
+++ b/packages/docs/todos/stash-hardware-encoding-setting.md
@@ -1,0 +1,29 @@
+---
+id: stash-hardware-encoding-setting
+type: todo
+status: planned
+board: true
+verification: operator
+disposition: blocked
+source_marker: false
+---
+
+# Enable the Stash FFmpeg hardware-encoding setting
+
+## Remaining
+
+- [ ] Sign in to the private Stash UI and enable the persisted
+      `FFmpeg hardware encoding` setting. It is application state rather than a
+      `config.yml` field, so neither the authentication init container nor the
+      GitOps chart can set it.
+- [ ] Once the setting is persisted, confirm Stash startup logs report the
+      supported hardware codecs.
+
+## Comment Log
+
+- 2026-08-13 — Split out of the Stash Intel GPU acceleration plan. Changing
+  persisted application state through an authenticated UI is a privileged
+  operator action, so it must not sit on the board as active agent work. The
+  deterministic post-deployment checks (GPU limit, `/dev/dri/renderD128`
+  readability, and the direct `h264_vaapi` FFmpeg smoke encode) stay
+  agent-owned in that plan and do not depend on this setting.

--- a/packages/homelab/src/cdk8s/scripts/patch.ts
+++ b/packages/homelab/src/cdk8s/scripts/patch.ts
@@ -5,6 +5,7 @@ const filesToPatch = [
   "dist/media.k8s.yaml",
   "dist/pokemon.k8s.yaml",
   "dist/mario-kart.k8s.yaml",
+  "dist/stash.k8s.yaml",
 ];
 
 console.log("🔧 Applying Intel GPU resource patches...");

--- a/packages/homelab/src/cdk8s/scripts/test-gpu-resources.ts
+++ b/packages/homelab/src/cdk8s/scripts/test-gpu-resources.ts
@@ -5,6 +5,7 @@ const EXPECTED_VALUE = 1;
 // Services that should have Intel GPU resources, mapped to their chart files
 const GPU_SERVICES: Record<string, string> = {
   plex: "dist/media.k8s.yaml",
+  stash: "dist/stash.k8s.yaml",
 };
 
 async function testGpuResources() {

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
@@ -14,6 +14,17 @@ const ManifestSchema = z
   .loose();
 
 const VALID_HASH = `$2a$10$${"a".repeat(53)}`;
+const EXPECTED_STASH_ENV = {
+  TZ: "America/Los_Angeles",
+  STASH_CONFIG_FILE: "/state/config.yml",
+  STASH_STASH: "/data/",
+  STASH_METADATA: "/state/metadata/",
+  STASH_BLOBS: "/state/blobs/",
+  STASH_GENERATED: "/generated/",
+  STASH_CACHE: "/cache/",
+  STASH_PORT: "9999",
+  STASH_HW_DRI_DEVICE: "/dev/dri/renderD128",
+};
 
 // Runs the real init script so the credential guards are proven, not just matched
 // as text. Every case here fails before the script reaches /state, so no test
@@ -206,16 +217,7 @@ describe("Stash chart", () => {
       Object.fromEntries(
         appContainer.env.map(({ name, value }) => [name, value]),
       ),
-    ).toEqual({
-      TZ: "America/Los_Angeles",
-      STASH_CONFIG_FILE: "/state/config.yml",
-      STASH_STASH: "/data/",
-      STASH_METADATA: "/state/metadata/",
-      STASH_BLOBS: "/state/blobs/",
-      STASH_GENERATED: "/generated/",
-      STASH_CACHE: "/cache/",
-      STASH_PORT: "9999",
-    });
+    ).toEqual(EXPECTED_STASH_ENV);
     const ProbeSchema = z.object({
       failureThreshold: z.number(),
       periodSeconds: z.number(),
@@ -236,8 +238,14 @@ describe("Stash chart", () => {
       periodSeconds: 30,
       httpGet: { path: "/healthz", port: 9999 },
     });
+    // The CDK8s JSON patch materializes the extended-resource value during the
+    // post-synthesis patch step; the GPU manifest guard asserts the final 1.
     expect(appContainer.resources).toEqual({
-      limits: { cpu: "4", memory: "4096Mi" },
+      limits: {
+        cpu: "4",
+        memory: "4096Mi",
+        "gpu.intel.com/i915": undefined,
+      },
       requests: { cpu: "250m", memory: "512Mi" },
     });
   });

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.test.ts
@@ -238,16 +238,24 @@ describe("Stash chart", () => {
       periodSeconds: 30,
       httpGet: { path: "/healthz", port: 9999 },
     });
-    // The CDK8s JSON patch materializes the extended-resource value during the
-    // post-synthesis patch step; the GPU manifest guard asserts the final 1.
-    expect(appContainer.resources).toEqual({
-      limits: {
-        cpu: "4",
-        memory: "4096Mi",
-        "gpu.intel.com/i915": undefined,
-      },
-      requests: { cpu: "250m", memory: "512Mi" },
-    });
+    // cdk8s drops the JSON-patched extended-resource value during synthesis, so
+    // the manifest carries a bare `gpu.intel.com/i915: null` placeholder that
+    // scripts/patch.ts rewrites to 1 and scripts/test-gpu-resources.ts asserts.
+    // Losing the key here would leave that patch step nothing to rewrite.
+    const resources = z
+      .object({
+        limits: z
+          .object({ cpu: z.literal("4"), memory: z.literal("4096Mi") })
+          .loose(),
+        requests: z.object({
+          cpu: z.literal("250m"),
+          memory: z.literal("512Mi"),
+        }),
+      })
+      .parse(appContainer.resources);
+    expect(new Set(Object.keys(resources.limits))).toEqual(
+      new Set(["cpu", "memory", "gpu.intel.com/i915"]),
+    );
   });
 
   it.each([

--- a/packages/homelab/src/cdk8s/src/resources/stash/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/stash/index.ts
@@ -1,5 +1,5 @@
 import type { Chart } from "cdk8s";
-import { Duration, Size } from "cdk8s";
+import { ApiObject, Duration, JsonPatch, Size } from "cdk8s";
 import {
   Capability,
   Cpu,
@@ -198,6 +198,7 @@ export function createStashDeployment(chart: Chart) {
         STASH_GENERATED: EnvValue.fromValue("/generated/"),
         STASH_CACHE: EnvValue.fromValue("/cache/"),
         STASH_PORT: EnvValue.fromValue(String(PORT)),
+        STASH_HW_DRI_DEVICE: EnvValue.fromValue("/dev/dri/renderD128"),
       },
       securityContext: {
         ensureNonRoot: false,
@@ -218,6 +219,16 @@ export function createStashDeployment(chart: Chart) {
   );
 
   setRevisionHistoryLimit(deployment);
+
+  // Request one shared Intel iGPU slot so the device plugin injects /dev/dri.
+  // cdk8s-plus does not expose extended GPU resources directly, so patch the
+  // generated limits using the same pattern as the other VAAPI workloads.
+  ApiObject.of(deployment).addJsonPatch(
+    JsonPatch.add(
+      "/spec/template/spec/containers/0/resources/limits/gpu.intel.com~1i915",
+      1,
+    ),
+  );
 
   const service = new Service(chart, "stash-service", {
     metadata: { labels: LABELS },


### PR DESCRIPTION
## Why

Stash currently runs CPU-only because its pod requests no Intel GPU resource and has no /dev/dri device, even though torvalds and the Intel device plugin already support shared GPU workloads.

## What

- Request one shared gpu.intel.com/i915 slot for the Stash container.
- Set STASH_HW_DRI_DEVICE=/dev/dri/renderD128 for explicit VAAPI device selection.
- Register Stash with the post-build GPU patcher and GPU-resource regression test.
- Add focused manifest assertions and a durable follow-up deployment plan.
- Keep the existing non-privileged security context, storage, authentication, ingress, and ArgoCD ownership unchanged.

## Verification

- bun test src/resources/stash/index.test.ts — 9 passed.
- bun run test:gpu-resources — Plex and Stash GPU resources rendered as 1.
- bun run typecheck — passed.
- bunx eslint src/resources/stash/index.ts src/resources/stash/index.test.ts scripts/test-gpu-resources.ts scripts/patch.ts — passed.
- bun run check-todos — 666 Markdown documents valid.
- bunx prettier --check relevant files — passed.
- bunx lefthook run pre-commit — passed.

## Rollout

After merge and chart publication, ArgoCD should reconcile the Stash Deployment. Enable Stash's persisted FFmpeg hardware encoding setting through its authenticated UI, then verify the pod has /dev/dri/renderD128, reports supported hardware codecs, and completes a short h264_vaapi smoke encode.