### PR TITLE
fix(home-assistant): restore Mysa and resilient morning wake

### DIFF
--- a/packages/homelab/src/cdk8s/patches/mysa/0002-recover-uninitialized-session.patch
+++ b/packages/homelab/src/cdk8s/patches/mysa/0002-recover-uninitialized-session.patch
@@ -1,10 +1,6 @@
 --- a/custom_components/mysa/mysa_api.py
 +++ b/custom_components/mysa/mysa_api.py
-@@ -290,6 +290,7 @@
-             is_auth_error = (
-                 isinstance(e, ClientResponseError) and e.status == 401
-             ) or (
-                 "NotAuthorizedException" in str(e)
+@@ -294,2 +294,3 @@
                  or "Refresh Token has expired" in str(e)
 +                or (isinstance(e, RuntimeError) and str(e) == "Session not initialized")
              )

--- a/packages/homelab/src/cdk8s/patches/mysa/0002-recover-uninitialized-session.patch
+++ b/packages/homelab/src/cdk8s/patches/mysa/0002-recover-uninitialized-session.patch
@@ -1,0 +1,10 @@
+--- a/custom_components/mysa/mysa_api.py
++++ b/custom_components/mysa/mysa_api.py
+@@ -290,6 +290,7 @@
+             is_auth_error = (
+                 isinstance(e, ClientResponseError) and e.status == 401
+             ) or (
+                 "NotAuthorizedException" in str(e)
+                 or "Refresh Token has expired" in str(e)
++                or (isinstance(e, RuntimeError) and str(e) == "Session not initialized")
+             )

--- a/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
+++ b/packages/homelab/src/cdk8s/src/resources/home/ha-custom-components.ts
@@ -98,7 +98,10 @@ export const HA_CUSTOM_COMPONENTS: HaCustomComponentSpec[] = [
     install: {
       kind: "custom_components",
       slug: "mysa",
-      patches: ["0001-expose-device-setpoint-limits.patch"],
+      patches: [
+        "0001-expose-device-setpoint-limits.patch",
+        "0002-recover-uninitialized-session.patch",
+      ],
     },
   },
   {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
@@ -2,6 +2,33 @@ import { describe, expect, test } from "bun:test";
 import { getHomeAssistantRuleGroups } from "./homeassistant.ts";
 
 describe("Home Assistant rules", () => {
+  test("alerts when the master bathroom temperature is unavailable", () => {
+    const availabilityGroup = getHomeAssistantRuleGroups().find(
+      (group) => group.name === "homeassistant-availability",
+    );
+    if (availabilityGroup?.rules === undefined) {
+      throw new Error("Missing homeassistant-availability rules");
+    }
+
+    const rule = availabilityGroup.rules.find(
+      (candidate) =>
+        candidate.alert === "HomeAssistantMasterBathroomTemperatureUnavailable",
+    );
+    if (rule === undefined) {
+      throw new Error(
+        "Missing HomeAssistantMasterBathroomTemperatureUnavailable rule",
+      );
+    }
+
+    expect(rule.for).toBe("15m");
+    expect(rule.expr.value).toBe(
+      'homeassistant_entity_available{entity="sensor.master_bathroom_temperature"} == 0',
+    );
+    expect(rule.annotations?.["runbook_url"]).toBe(
+      "https://homeassistant.tailnet-1a49.ts.net/history?entity_id=sensor.master_bathroom_temperature",
+    );
+  });
+
   test("renders a Prometheus-template-safe unavailable entity annotation query", () => {
     const availabilityGroup = getHomeAssistantRuleGroups().find(
       (group) => group.name === "homeassistant-availability",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { getHomeAssistantRuleGroups } from "./homeassistant.ts";
 
 describe("Home Assistant rules", () => {
-  test("alerts when the master bathroom temperature is unavailable", () => {
+  test("alerts when the master bathroom temperature is unavailable or absent", () => {
     const availabilityGroup = getHomeAssistantRuleGroups().find(
       (group) => group.name === "homeassistant-availability",
     );
@@ -21,8 +21,10 @@ describe("Home Assistant rules", () => {
     }
 
     expect(rule.for).toBe("15m");
+    // The absent() arm is load-bearing: a comparison alone yields an empty
+    // vector when the entity never makes it into the exported state set.
     expect(rule.expr.value).toBe(
-      'homeassistant_entity_available{entity="sensor.master_bathroom_temperature"} == 0',
+      'homeassistant_entity_available{entity="sensor.master_bathroom_temperature"} == 0 or absent(homeassistant_entity_available{entity="sensor.master_bathroom_temperature"})',
     );
     expect(rule.annotations?.["runbook_url"]).toBe(
       "https://homeassistant.tailnet-1a49.ts.net/history?entity_id=sensor.master_bathroom_temperature",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
@@ -33,6 +33,15 @@ const unavailableEntitiesAnnotationQuery = `homeassistant_entity_available{entit
 const escapedUnavailableEntitiesAnnotationQuery =
   unavailableEntitiesAnnotationQuery.replaceAll('"', String.raw`\"`);
 
+const masterBathroomTemperatureAvailability =
+  'homeassistant_entity_available{entity="sensor.master_bathroom_temperature"}';
+
+// `== 0` only matches an entity Home Assistant still exports. When the Mysa
+// integration fails to set up, or the entity leaves the exported state set
+// entirely, the series is absent and the comparison yields an empty vector, so
+// the `absent()` arm is what catches a total integration failure.
+const masterBathroomTemperatureUnavailableExpr = `${masterBathroomTemperatureAvailability} == 0 or absent(${masterBathroomTemperatureAvailability})`;
+
 export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     // Litter Robot monitoring
@@ -143,13 +152,13 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           alert: "HomeAssistantMasterBathroomTemperatureUnavailable",
           annotations: {
             description:
-              "The Mysa master bathroom temperature sensor has been unavailable for 15 minutes. Floor-heat decisions are degraded; the morning wake routine will continue without activating heat, but still runs its end-of-window thermostat turn-off.",
+              "The Mysa master bathroom temperature sensor has been unavailable, or missing from Home Assistant entirely, for 15 minutes. Floor-heat decisions are degraded; the morning wake routine will continue without activating heat, but still runs its end-of-window thermostat turn-off.",
             summary: "Master bathroom temperature unavailable",
             runbook_url:
               "https://homeassistant.tailnet-1a49.ts.net/history?entity_id=sensor.master_bathroom_temperature",
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'homeassistant_entity_available{entity="sensor.master_bathroom_temperature"} == 0',
+            masterBathroomTemperatureUnavailableExpr,
           ),
           for: "15m",
           labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
@@ -143,7 +143,7 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           alert: "HomeAssistantMasterBathroomTemperatureUnavailable",
           annotations: {
             description:
-              "The Mysa master bathroom temperature sensor has been unavailable for 15 minutes. Floor-heat decisions are degraded; the morning wake routine will continue without climate actions.",
+              "The Mysa master bathroom temperature sensor has been unavailable for 15 minutes. Floor-heat decisions are degraded; the morning wake routine will continue without activating heat, but still runs its end-of-window thermostat turn-off.",
             summary: "Master bathroom temperature unavailable",
             runbook_url:
               "https://homeassistant.tailnet-1a49.ts.net/history?entity_id=sensor.master_bathroom_temperature",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
@@ -140,6 +140,21 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
       name: "homeassistant-availability",
       rules: [
         {
+          alert: "HomeAssistantMasterBathroomTemperatureUnavailable",
+          annotations: {
+            description:
+              "The Mysa master bathroom temperature sensor has been unavailable for 15 minutes. Floor-heat decisions are degraded; the morning wake routine will continue without climate actions.",
+            summary: "Master bathroom temperature unavailable",
+            runbook_url:
+              "https://homeassistant.tailnet-1a49.ts.net/history?entity_id=sensor.master_bathroom_temperature",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'homeassistant_entity_available{entity="sensor.master_bathroom_temperature"} == 0',
+          ),
+          for: "15m",
+          labels: { severity: "warning" },
+        },
+        {
           alert: "HomeAssistantEntitiesUnavailable",
           annotations: {
             description: `{{ "{{" }} $value {{ "}}" }} Home Assistant entities are unavailable or unknown:\n{{ "{{" }} with query "${escapedUnavailableEntitiesAnnotationQuery}" {{ "}}" }}{{ "{{" }} range sortByLabel "friendly_name" . {{ "}}" }}\n- {{ "{{" }} .Labels.friendly_name {{ "}}" }} ({{ "{{" }} .Labels.entity {{ "}}" }}){{ "{{" }} end {{ "}}" }}{{ "{{" }} end {{ "}}" }}`,

--- a/packages/temporal/src/activities/ha.test.ts
+++ b/packages/temporal/src/activities/ha.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { ApplicationFailure } from "@temporalio/common";
+import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
 import { haActivities } from "./ha.ts";
 
 describe("haActivities", () => {
@@ -39,6 +41,52 @@ describe("haActivities", () => {
         Bun.env["HA_URL"] = originalUrl;
       }
       if (originalToken !== undefined) {
+        Bun.env["HA_TOKEN"] = originalToken;
+      }
+    }
+  });
+
+  // A bare HaNotFoundError would reach the workflow as an untyped failure and
+  // burn the activity's whole retry budget on an entity that cannot appear.
+  it("raises a typed non-retryable failure for an entity HA does not have", async () => {
+    const originalUrl = Bun.env["HA_URL"];
+    const originalToken = Bun.env["HA_TOKEN"];
+    const originalFetch = globalThis.fetch;
+    Bun.env["HA_URL"] = "http://localhost:8123";
+    Bun.env["HA_TOKEN"] = "test-token";
+    // Bun's fetch carries a `preconnect` member, so the stub has to be widened
+    // with it to satisfy the global's type.
+    globalThis.fetch = Object.assign(
+      (): Promise<Response> =>
+        Promise.resolve(new Response("Entity not found.", { status: 404 })),
+      { preconnect: originalFetch.preconnect.bind(originalFetch) },
+    );
+
+    try {
+      let failure: unknown;
+      try {
+        await haActivities.getEntityState("sensor.master_bathroom_temperature");
+      } catch (error: unknown) {
+        failure = error;
+      }
+      if (!(failure instanceof ApplicationFailure)) {
+        throw new TypeError("Expected a typed ApplicationFailure");
+      }
+      expect(failure.type).toBe(HA_ENTITY_NOT_FOUND_ERROR_TYPE);
+      expect(failure.nonRetryable).toBe(true);
+      expect(failure.message).toBe(
+        "Home Assistant has no entity sensor.master_bathroom_temperature",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) {
+        delete Bun.env["HA_URL"];
+      } else {
+        Bun.env["HA_URL"] = originalUrl;
+      }
+      if (originalToken === undefined) {
+        delete Bun.env["HA_TOKEN"];
+      } else {
         Bun.env["HA_TOKEN"] = originalToken;
       }
     }

--- a/packages/temporal/src/activities/ha.test.ts
+++ b/packages/temporal/src/activities/ha.test.ts
@@ -46,9 +46,10 @@ describe("haActivities", () => {
     }
   });
 
-  // A bare HaNotFoundError would reach the workflow as an untyped failure and
-  // burn the activity's whole retry budget on an entity that cannot appear.
-  it("raises a typed non-retryable failure for an entity HA does not have", async () => {
+  // A bare HaNotFoundError would reach the workflow as an untyped failure. It
+  // must stay retryable: HA serves this endpoint before every integration has
+  // registered its entities, so a startup/reload 404 is routinely transient.
+  it("raises a typed retryable failure for an entity HA does not have", async () => {
     const originalUrl = Bun.env["HA_URL"];
     const originalToken = Bun.env["HA_TOKEN"];
     const originalFetch = globalThis.fetch;
@@ -73,7 +74,7 @@ describe("haActivities", () => {
         throw new TypeError("Expected a typed ApplicationFailure");
       }
       expect(failure.type).toBe(HA_ENTITY_NOT_FOUND_ERROR_TYPE);
-      expect(failure.nonRetryable).toBe(true);
+      expect(failure.nonRetryable).toBe(false);
       expect(failure.message).toBe(
         "Home Assistant has no entity sensor.master_bathroom_temperature",
       );

--- a/packages/temporal/src/activities/ha.ts
+++ b/packages/temporal/src/activities/ha.ts
@@ -1,7 +1,10 @@
+import { ApplicationFailure } from "@temporalio/common";
 import {
+  HaNotFoundError,
   HomeAssistantRestClient,
   type EntityState,
 } from "@shepherdjerred/home-assistant";
+import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
 
 // Activity signatures stay monomorphic (Temporal's proxyActivities rejects
 // generic methods), so the runtime client is the loose default. Compile-time
@@ -29,7 +32,19 @@ export type HaActivities = typeof haActivities;
 
 export const haActivities = {
   async getEntityState(entityId: string): Promise<EntityState> {
-    return getClient().getState(entityId);
+    try {
+      return await getClient().getState(entityId);
+    } catch (error: unknown) {
+      // An entity Home Assistant does not have will not appear on a retry, and
+      // a bare HaNotFoundError reaches the workflow as an untyped failure.
+      if (error instanceof HaNotFoundError) {
+        throw ApplicationFailure.nonRetryable(
+          `Home Assistant has no entity ${entityId}`,
+          HA_ENTITY_NOT_FOUND_ERROR_TYPE,
+        );
+      }
+      throw error;
+    }
   },
 
   async getStates(): Promise<EntityState[]> {

--- a/packages/temporal/src/activities/ha.ts
+++ b/packages/temporal/src/activities/ha.ts
@@ -35,10 +35,15 @@ export const haActivities = {
     try {
       return await getClient().getState(entityId);
     } catch (error: unknown) {
-      // An entity Home Assistant does not have will not appear on a retry, and
-      // a bare HaNotFoundError reaches the workflow as an untyped failure.
+      // Retyped, not made terminal. A bare HaNotFoundError crosses the activity
+      // boundary as an untyped failure, so a workflow cannot tell a missing
+      // entity from any other error; the type is what makes that possible.
+      // It stays retryable because HA answers this endpoint before every
+      // integration has registered its entities, so a 404 during a restart or
+      // integration reload is routinely transient. Only an entity still absent
+      // after the caller's whole retry budget reaches the workflow.
       if (error instanceof HaNotFoundError) {
-        throw ApplicationFailure.nonRetryable(
+        throw ApplicationFailure.retryable(
           `Home Assistant has no entity ${entityId}`,
           HA_ENTITY_NOT_FOUND_ERROR_TYPE,
         );

--- a/packages/temporal/src/shared/ha-errors.ts
+++ b/packages/temporal/src/shared/ha-errors.ts
@@ -1,0 +1,5 @@
+// Shared by the HA activities (which raise it) and the workflows (which match
+// on it). A plain Error crossing the activity boundary loses its class and
+// arrives as an untyped TemporalFailure, so a missing entity has to be raised
+// as a typed ApplicationFailure for a workflow to recognize it at all.
+export const HA_ENTITY_NOT_FOUND_ERROR_TYPE = "HaEntityNotFoundError";

--- a/packages/temporal/src/shared/ha-errors.ts
+++ b/packages/temporal/src/shared/ha-errors.ts
@@ -1,5 +1,7 @@
 // Shared by the HA activities (which raise it) and the workflows (which match
 // on it). A plain Error crossing the activity boundary loses its class and
 // arrives as an untyped TemporalFailure, so a missing entity has to be raised
-// as a typed ApplicationFailure for a workflow to recognize it at all.
+// as a typed ApplicationFailure for a workflow to recognize it at all. The
+// failure stays retryable, so a workflow only sees this once the entity is
+// still missing after the activity's full retry budget.
 export const HA_ENTITY_NOT_FOUND_ERROR_TYPE = "HaEntityNotFoundError";

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -38,6 +38,7 @@ type ServiceCall = {
 
 type Scenario = {
   indoorC: number;
+  indoorState: string;
   outdoorC: number;
   zoneAttributes: Record<string, unknown>;
   serviceCalls: ServiceCall[];
@@ -51,6 +52,7 @@ function makeScenario(
 ): Scenario {
   return {
     indoorC: temps.indoorC,
+    indoorState: String(temps.indoorC),
     outdoorC: temps.outdoorC,
     zoneAttributes,
     serviceCalls: [],
@@ -77,7 +79,7 @@ function makeActivities(scenario: Scenario) {
           return Promise.resolve(entityState(entityId, "not_home"));
         case "sensor.master_bathroom_temperature":
           return Promise.resolve(
-            entityState(entityId, String(scenario.indoorC), {
+            entityState(entityId, scenario.indoorState, {
               unit_of_measurement: "°C",
             }),
           );
@@ -269,6 +271,59 @@ describe("goodMorningPreheat", () => {
 });
 
 describe("goodMorningWakeUp", () => {
+  test(
+    "continues notification and media without climate actions when temperature is unavailable",
+    async () => {
+      const scenario = makeScenario({ indoorC: 18, outdoorC: 5 });
+      scenario.indoorState = "unavailable";
+
+      await runWorker(
+        scenario,
+        goodMorningWakeUp,
+        "wake-temperature-unavailable-" + crypto.randomUUID(),
+      );
+
+      expect(climateCalls(scenario)).toEqual([]);
+      expect(scenario.notifications).toEqual(["Good Morning"]);
+      expect(
+        scenario.serviceCalls.some(
+          (call) =>
+            call.domain === "media_player" && call.service === "play_media",
+        ),
+      ).toBe(true);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningWakeUp",
+          outcome: "executed",
+          reason: "wake-routine-complete-temperature-unavailable",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "fails non-retryably for unrelated climate decision failures",
+    async () => {
+      const scenario = makeScenario(
+        { indoorC: 18, outdoorC: 5 },
+        { latitude: "47.6", longitude: -122.3 },
+      );
+      await expectNonRetryableApplicationFailure(
+        runWorker(
+          scenario,
+          goodMorningWakeUp,
+          `wake-invalid-zone-${crypto.randomUUID()}`,
+        ),
+        "HomeZoneAttributesError",
+        "Home Assistant zone.home attributes must include numeric latitude and longitude",
+      );
+      expect(scenario.notifications).toEqual([]);
+      expect(climateCalls(scenario)).toEqual([]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
   test(
     "runs the wake routine without heat on a warm morning",
     async () => {

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -113,6 +113,12 @@ function makeActivities(scenario: Scenario) {
   };
 }
 
+const TURN_OFF_MASTER_BATHROOM: ServiceCall = {
+  domain: "climate",
+  service: "turn_off",
+  data: { entity_id: "climate.master_bathroom" },
+};
+
 function climateCalls(scenario: Scenario): ServiceCall[] {
   return scenario.serviceCalls.filter((call) => call.domain === "climate");
 }
@@ -272,7 +278,7 @@ describe("goodMorningPreheat", () => {
 
 describe("goodMorningWakeUp", () => {
   test(
-    "continues notification and media without climate actions when temperature is unavailable",
+    "keeps the turn-off backstop while skipping heat when temperature is unavailable",
     async () => {
       const scenario = makeScenario({ indoorC: 18, outdoorC: 5 });
       scenario.indoorState = "unavailable";
@@ -283,7 +289,7 @@ describe("goodMorningWakeUp", () => {
         "wake-temperature-unavailable-" + crypto.randomUUID(),
       );
 
-      expect(climateCalls(scenario)).toEqual([]);
+      expect(climateCalls(scenario)).toEqual([TURN_OFF_MASTER_BATHROOM]);
       expect(scenario.notifications).toEqual(["Good Morning"]);
       expect(
         scenario.serviceCalls.some(
@@ -325,6 +331,27 @@ describe("goodMorningWakeUp", () => {
   );
 
   test(
+    "fails non-retryably on a corrupt temperature state instead of degrading",
+    async () => {
+      const scenario = makeScenario({ indoorC: 18, outdoorC: 5 });
+      scenario.indoorState = "error";
+
+      await expectNonRetryableApplicationFailure(
+        runWorker(
+          scenario,
+          goodMorningWakeUp,
+          `wake-corrupt-temperature-${crypto.randomUUID()}`,
+        ),
+        "TemperatureSensorStateError",
+        "Temperature sensor sensor.master_bathroom_temperature has a non-numeric state: error",
+      );
+      expect(scenario.notifications).toEqual([]);
+      expect(climateCalls(scenario)).toEqual([]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
+  test(
     "runs the wake routine without heat on a warm morning",
     async () => {
       const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
@@ -333,15 +360,7 @@ describe("goodMorningWakeUp", () => {
         goodMorningWakeUp,
         `wake-warm-${crypto.randomUUID()}`,
       );
-      expect(climateCalls(scenario)).toEqual([
-        {
-          domain: "climate",
-          service: "turn_off",
-          data: {
-            entity_id: "climate.master_bathroom",
-          },
-        },
-      ]);
+      expect(climateCalls(scenario)).toEqual([TURN_OFF_MASTER_BATHROOM]);
       expect(scenario.notifications).toEqual(["Good Morning"]);
       expect(
         scenario.serviceCalls.some(

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -4,6 +4,7 @@ import { ApplicationFailure } from "@temporalio/common";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { OutcomeRecord } from "#activities/outcome.ts";
+import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
 import {
   goodMorningPreheat,
   goodMorningWakeUp,
@@ -15,6 +16,9 @@ const TASK_QUEUE = "good-morning-test";
 // default 5s Bun timeout is too short when the full repository test graph is
 // sharing the CI host, even though workflow time itself is skipped.
 const WORKFLOW_TEST_TIMEOUT_MS = 30_000;
+// Sentinel for "Home Assistant does not have this entity at all", which the
+// activity surfaces as a typed failure rather than any state string.
+const MISSING_ENTITY = "__missing__";
 const DEFAULT_ZONE_ATTRIBUTES: Record<string, unknown> = {
   latitude: 47.6,
   longitude: -122.3,
@@ -78,6 +82,14 @@ function makeActivities(scenario: Scenario) {
         case "person.shuxin":
           return Promise.resolve(entityState(entityId, "not_home"));
         case "sensor.master_bathroom_temperature":
+          if (scenario.indoorState === MISSING_ENTITY) {
+            return Promise.reject(
+              ApplicationFailure.nonRetryable(
+                `Home Assistant has no entity ${entityId}`,
+                HA_ENTITY_NOT_FOUND_ERROR_TYPE,
+              ),
+            );
+          }
           return Promise.resolve(
             entityState(entityId, scenario.indoorState, {
               unit_of_measurement: "°C",
@@ -326,6 +338,31 @@ describe("goodMorningWakeUp", () => {
       );
       expect(scenario.notifications).toEqual([]);
       expect(climateCalls(scenario)).toEqual([]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "degrades when the temperature entity is missing from Home Assistant",
+    async () => {
+      const scenario = makeScenario({ indoorC: 18, outdoorC: 5 });
+      scenario.indoorState = MISSING_ENTITY;
+
+      await runWorker(
+        scenario,
+        goodMorningWakeUp,
+        `wake-temperature-missing-${crypto.randomUUID()}`,
+      );
+
+      expect(climateCalls(scenario)).toEqual([TURN_OFF_MASTER_BATHROOM]);
+      expect(scenario.notifications).toEqual(["Good Morning"]);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningWakeUp",
+          outcome: "executed",
+          reason: "wake-routine-complete-temperature-unavailable",
+        },
+      ]);
     },
     WORKFLOW_TEST_TIMEOUT_MS,
   );

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -45,6 +45,7 @@ type Scenario = {
   indoorState: string;
   outdoorC: number;
   zoneAttributes: Record<string, unknown>;
+  temperatureReadAttempts: number;
   serviceCalls: ServiceCall[];
   notifications: string[];
   outcomes: OutcomeRecord[];
@@ -59,6 +60,7 @@ function makeScenario(
     indoorState: String(temps.indoorC),
     outdoorC: temps.outdoorC,
     zoneAttributes,
+    temperatureReadAttempts: 0,
     serviceCalls: [],
     notifications: [],
     outcomes: [],
@@ -83,8 +85,11 @@ function makeActivities(scenario: Scenario) {
           return Promise.resolve(entityState(entityId, "not_home"));
         case "sensor.master_bathroom_temperature":
           if (scenario.indoorState === MISSING_ENTITY) {
+            scenario.temperatureReadAttempts += 1;
+            // Retryable, exactly as the real activity raises it, so the
+            // degraded path is exercised only after the retry budget runs out.
             return Promise.reject(
-              ApplicationFailure.nonRetryable(
+              ApplicationFailure.retryable(
                 `Home Assistant has no entity ${entityId}`,
                 HA_ENTITY_NOT_FOUND_ERROR_TYPE,
               ),
@@ -354,6 +359,9 @@ describe("goodMorningWakeUp", () => {
         `wake-temperature-missing-${crypto.randomUUID()}`,
       );
 
+      // The shared three-attempt policy still applies, so a transiently
+      // missing entity during an HA restart recovers instead of degrading.
+      expect(scenario.temperatureReadAttempts).toBe(3);
       expect(climateCalls(scenario)).toEqual([TURN_OFF_MASTER_BATHROOM]);
       expect(scenario.notifications).toEqual(["Good Morning"]);
       expect(scenario.outcomes).toEqual([

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -31,19 +31,18 @@ const BEDROOM_BRIGHT = "scene.bedroom_bright" as const;
 const MASTER_BATHROOM_HEAT = "climate.master_bathroom" as const;
 const MASTER_BATHROOM_AIR_TEMP = "sensor.master_bathroom_temperature" as const;
 const HOME_ZONE = "zone.home" as const;
-// The INF-V1 floor heater's true max is 40°C. Upstream kgelinas/Mysa_HA capped
-// it at 30°C (issue #16); the fix (PR #18) was closed unmerged and upstream is
-// stale, so HA runs our fork shepherdjerred/Mysa_HA@v0.9.3 (via HACS), which
-// exposes the real device limit. See
-// packages/docs/plans/2026-05-05_mysa-max-temp-cap.md. The morning target is
-// now 30°C (was 40°C until 2026-07) — warm feet without the multi-hour 40°C
-// preheat, and only on cold mornings (see shouldHeatFloor).
+// The INF-V1 floor heater's true max is 40°C. The GitOps-managed Mysa
+// integration carries a checked-in setpoint-limit patch so the device's real
+// range is exposed. The morning target is now 30°C (was 40°C until 2026-07) —
+// warm feet without the multi-hour 40°C preheat, and only on cold mornings
+// (see shouldHeatFloor).
 const MORNING_HEAT_TEMP_C = 30;
 // Cold-morning thresholds (user-tuned 2026-07): heat when the bathroom air is
 // at/below 20°C OR the outdoor temperature is at/below 15°C.
 const HEAT_INDOOR_THRESHOLD_C = 20;
 const HEAT_OUTDOOR_THRESHOLD_C = 15;
 const CONDITIONAL_FLOOR_HEAT_PATCH = "good-morning-conditional-floor-heat-v1";
+const DEGRADED_WAKE_SENSOR_PATCH = "good-morning-degraded-sensor-wake-v1";
 const LEGACY_MORNING_HEAT_TEMP_C = 40;
 const MORNING_HEAT_DURATION = "60 minutes" as const;
 // The floor ramps ~8.3°C/hour (measured 2026-07-09: 22.3→30.6°C in the 60-min
@@ -191,18 +190,34 @@ export async function goodMorningWakeUp(): Promise<void> {
   // or paused). On warm mornings the heat stays off; the rest of the wake
   // routine (notification, media, lights) is unconditional.
   let heat = true;
+  let sensorUnavailable = false;
   if (patched(CONDITIONAL_FLOOR_HEAT_PATCH)) {
-    const decision = await floorHeatDecision();
-    heat = decision.heat;
-    if (heat) {
-      await callServiceUnchecked("climate", "set_temperature", {
-        entity_id: MASTER_BATHROOM_HEAT,
-        temperature: MORNING_HEAT_TEMP_C,
-        hvac_mode: "heat",
-      });
-    } else {
+    try {
+      const decision = await floorHeatDecision();
+      heat = decision.heat;
+      if (heat) {
+        await callServiceUnchecked("climate", "set_temperature", {
+          entity_id: MASTER_BATHROOM_HEAT,
+          temperature: MORNING_HEAT_TEMP_C,
+          hvac_mode: "heat",
+        });
+      } else {
+        console.warn(
+          `good_morning_wake_up: not cold (indoor ${String(decision.indoorC)}°C, outdoor ${String(decision.outdoorC)}°C), heat stays off`,
+        );
+      }
+    } catch (error: unknown) {
+      if (
+        !patched(DEGRADED_WAKE_SENSOR_PATCH) ||
+        !(error instanceof ApplicationFailure) ||
+        error.type !== "TemperatureSensorStateError"
+      ) {
+        throw error;
+      }
+      sensorUnavailable = true;
+      heat = false;
       console.warn(
-        `good_morning_wake_up: not cold (indoor ${String(decision.indoorC)}°C, outdoor ${String(decision.outdoorC)}°C), heat stays off`,
+        "good_morning_wake_up: bathroom temperature unavailable, skipping climate actions and continuing wake routine",
       );
     }
   } else {
@@ -239,17 +254,22 @@ export async function goodMorningWakeUp(): Promise<void> {
     transition: 3,
   });
 
-  // Wait through the heat window, then always turn the thermostat off. The
-  // unconditional cleanup recovers a preheat run that set the thermostat but
-  // failed or was cancelled before its own backstop, even if this second
-  // temperature reading is now warm.
+  // Wait through the heat window, then turn the thermostat off when the
+  // temperature decision succeeded. If the sensor is unavailable, preheat
+  // remains responsible for its own turn-off backstop.
   await sleep(MORNING_HEAT_DURATION);
-  await callServiceUnchecked("climate", "turn_off", {
-    entity_id: MASTER_BATHROOM_HEAT,
-  });
+  if (!sensorUnavailable) {
+    await callServiceUnchecked("climate", "turn_off", {
+      entity_id: MASTER_BATHROOM_HEAT,
+    });
+  }
   await setOutcome(
     "executed",
-    heat ? "wake-routine-complete" : "wake-routine-complete-no-heat",
+    sensorUnavailable
+      ? "wake-routine-complete-temperature-unavailable"
+      : heat
+        ? "wake-routine-complete"
+        : "wake-routine-complete-no-heat",
   );
 }
 

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -75,12 +75,19 @@ export function shouldHeatFloor(temps: {
   );
 }
 
+// Home Assistant's two "there is no reading" states. Anything else non-numeric
+// is a corrupt/unexpected value, which must fail rather than degrade.
+const HA_NO_READING_STATES = new Set(["unavailable", "unknown"]);
+
 function parseTemperatureC(entityId: string, raw: string): number {
   const value = Number.parseFloat(raw);
   if (!Number.isFinite(value)) {
+    const noReading = HA_NO_READING_STATES.has(raw.trim().toLowerCase());
     throw ApplicationFailure.nonRetryable(
-      `Temperature sensor ${entityId} has non-numeric state: ${raw}`,
-      "TemperatureSensorStateError",
+      `Temperature sensor ${entityId} has ${noReading ? "no reading" : "a non-numeric state"}: ${raw}`,
+      noReading
+        ? "TemperatureSensorUnavailableError"
+        : "TemperatureSensorStateError",
     );
   }
   return value;
@@ -210,14 +217,14 @@ export async function goodMorningWakeUp(): Promise<void> {
       if (
         !patched(DEGRADED_WAKE_SENSOR_PATCH) ||
         !(error instanceof ApplicationFailure) ||
-        error.type !== "TemperatureSensorStateError"
+        error.type !== "TemperatureSensorUnavailableError"
       ) {
         throw error;
       }
       sensorUnavailable = true;
       heat = false;
       console.warn(
-        "good_morning_wake_up: bathroom temperature unavailable, skipping climate actions and continuing wake routine",
+        "good_morning_wake_up: bathroom temperature unavailable, skipping heat activation and continuing wake routine",
       );
     }
   } else {
@@ -254,15 +261,15 @@ export async function goodMorningWakeUp(): Promise<void> {
     transition: 3,
   });
 
-  // Wait through the heat window, then turn the thermostat off when the
-  // temperature decision succeeded. If the sensor is unavailable, preheat
-  // remains responsible for its own turn-off backstop.
+  // Wait through the heat window, then always turn the thermostat off. The
+  // unconditional cleanup recovers a preheat run that set the thermostat but
+  // failed or was cancelled before its own backstop, even if this second
+  // temperature reading is now warm or unavailable — the sensor degradation
+  // only suppresses climate decisions, never this cleanup.
   await sleep(MORNING_HEAT_DURATION);
-  if (!sensorUnavailable) {
-    await callServiceUnchecked("climate", "turn_off", {
-      entity_id: MASTER_BATHROOM_HEAT,
-    });
-  }
+  await callServiceUnchecked("climate", "turn_off", {
+    entity_id: MASTER_BATHROOM_HEAT,
+  });
   await setOutcome(
     "executed",
     sensorUnavailable

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -1,4 +1,5 @@
 import {
+  ActivityFailure,
   ApplicationFailure,
   patched,
   proxyActivities,
@@ -14,6 +15,7 @@ import {
   volumeUpBy,
 } from "./util.ts";
 import type { WeatherActivities } from "#activities/weather.ts";
+import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
 
 const weatherActivities = proxyActivities<WeatherActivities>({
   startToCloseTimeout: "30 seconds",
@@ -106,23 +108,46 @@ function parseHomeZoneCoordinates(
   return result.data;
 }
 
+function isMissingEntityFailure(error: unknown): boolean {
+  return (
+    error instanceof ActivityFailure &&
+    error.cause instanceof ApplicationFailure &&
+    error.cause.type === HA_ENTITY_NOT_FOUND_ERROR_TYPE
+  );
+}
+
+// A total Mysa setup failure removes the entity outright instead of leaving it
+// in `unavailable`, which is the same degraded condition from the wake
+// routine's point of view. Only this read is wrapped, so a missing zone.home
+// stays a hard failure rather than silently degrading the heat decision.
+async function readIndoorTemperatureC(): Promise<number> {
+  try {
+    const state = await getEntityState(MASTER_BATHROOM_AIR_TEMP);
+    return parseTemperatureC(MASTER_BATHROOM_AIR_TEMP, state.state);
+  } catch (error: unknown) {
+    if (isMissingEntityFailure(error)) {
+      throw ApplicationFailure.nonRetryable(
+        `Temperature sensor ${MASTER_BATHROOM_AIR_TEMP} is missing from Home Assistant`,
+        "TemperatureSensorUnavailableError",
+      );
+    }
+    throw error;
+  }
+}
+
 // Reads the bathroom air sensor and the outdoor temperature (Open-Meteo at the
 // zone.home coordinates — HA has no weather integration) and decides whether
-// the morning floor heat is worth running. Any read failure propagates and
-// fails the workflow run: we never silently guess at the weather.
+// the morning floor heat is worth running. Every read failure propagates; only
+// goodMorningWakeUp decides which of them it is willing to degrade around.
 async function floorHeatDecision(): Promise<{
   heat: boolean;
   indoorC: number;
   outdoorC: number;
 }> {
-  const [indoorState, zoneState] = await Promise.all([
-    getEntityState(MASTER_BATHROOM_AIR_TEMP),
+  const [indoorC, zoneState] = await Promise.all([
+    readIndoorTemperatureC(),
     getEntityState(HOME_ZONE),
   ]);
-  const indoorC = parseTemperatureC(
-    MASTER_BATHROOM_AIR_TEMP,
-    indoorState.state,
-  );
   const { latitude, longitude } = parseHomeZoneCoordinates(
     zoneState.attributes,
   );

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -118,8 +118,10 @@ function isMissingEntityFailure(error: unknown): boolean {
 
 // A total Mysa setup failure removes the entity outright instead of leaving it
 // in `unavailable`, which is the same degraded condition from the wake
-// routine's point of view. Only this read is wrapped, so a missing zone.home
-// stays a hard failure rather than silently degrading the heat decision.
+// routine's point of view. The activity failure is retryable, so this only
+// fires once the entity is still gone after the full retry budget. Only this
+// read is wrapped, so a missing zone.home stays a hard failure rather than
+// silently degrading the heat decision.
 async function readIndoorTemperatureC(): Promise<number> {
   try {
     const state = await getEntityState(MASTER_BATHROOM_AIR_TEMP);


### PR DESCRIPTION
Why

A transient Mysa authentication outage left the integration permanently stuck at Session not initialized. The morning wake workflow also treated the bathroom temperature read as a prerequisite for notification and bedroom music.

What

- Add the checked-in Mysa v0.9.2 patch that treats Session not initialized as an authentication failure, forces password reauthentication, and retries the state fetch through the existing recovery path.
- Register the patch in the GitOps custom-component install marker.
- Make goodMorningWakeUp skip only climate decisions when the bathroom temperature is unavailable, continue notification/media/lights, record a degraded executed outcome, and warn. Temporal patched() keeps replay behavior safe; unrelated failures remain fail-fast and preheat retains its turn-off backstop.
- Add a warning alert and rendering test for sensor.master_bathroom_temperature unavailable for 15 minutes.

Verification

- bun test src/workflows/ha/good-morning.test.ts: 9 passed, including unavailable-temperature continuation and unrelated-failure fail-fast coverage.
- packages/temporal: bun run typecheck passed; bun run lint -- --no-cache passed with existing duplication warnings and zero errors.
- HA_CUSTOM_COMPONENT_TARBALL_TEST=1 bun test src/ha-custom-component-integrity.test.ts: 9 passed, including upstream Mysa hash and patch application.
- Homelab CDK8s custom-component and Home Assistant rule tests: 15 passed; typecheck and lint passed.
- Home Assistant history URL liveness check: HTTP 200.
- bunx lefthook run pre-commit passed.

Rollout

Merge through Buildkite and ArgoCD only. After deployment, verify the Home Assistant pod recreation, Mysa init patch application, numeric bathroom temperature, two clean Mysa polling intervals, one controlled goodMorningWakeUp smoke execution, and subsequent scheduled runs.