### PR TITLE
fix(scout-for-lol): surface the queue-window signals the watcher was discarding

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/subscription-filter-fields.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/subscription-filter-fields.tsx
@@ -3,7 +3,6 @@ import {
   DOOM_BOTS_QUEUES,
   isQueueCurrentlyAvailable,
   QueueTypeSchema,
-  queueAvailabilityNote,
   queueTypeToDisplayString,
   subscriptionFilterQueues,
   describeSubscriptionFilters,
@@ -74,9 +73,20 @@ function entryAvailable(entry: PickerEntry): boolean {
   return entry.queues.some((queue) => isQueueCurrentlyAvailable(queue));
 }
 
+/**
+ * The "not currently live" note, derived from the SAME predicate that decides
+ * whether the entry is shown at all.
+ *
+ * These two used to disagree by construction: availability was `.some()` across
+ * the group while the note read only `queues[0]`. The only multi-queue entry is
+ * the Doom Bots trio, which the drift engine keeps in lockstep, so it was
+ * latent — but a divergent trio would have rendered as selectable-and-visible
+ * while still captioned "not currently live", or the reverse.
+ */
 function entryNote(entry: PickerEntry): string | undefined {
-  const first = entry.queues[0];
-  return first === undefined ? undefined : queueAvailabilityNote(first);
+  return entryAvailable(entry)
+    ? undefined
+    : "Limited-time mode — not currently live";
 }
 
 function EntryRow(props: {

--- a/packages/scout-for-lol/packages/backend/scripts/queue-activity-s3.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/queue-activity-s3.ts
@@ -116,6 +116,28 @@ export function matchDateString(match: RawMatch): string {
 }
 
 /**
+ * Fold one match into the running counts.
+ *
+ * This is the single classification rule, shared by the pure aggregator and the
+ * live S3 walk. They used to be two copies of the same loop, and only the pure
+ * one had tests — so every assertion about custom-game exclusion and UTC date
+ * derivation was made against code that never runs in production.
+ */
+function accumulateMatch(counts: QueueActivityCounts, match: RawMatch): void {
+  // Custom lobbies reuse queue ids from real modes (observed: queueId 3130
+  // with gameType CUSTOM_GAME) — they say nothing about a mode being live,
+  // so they must not feed availability windows.
+  if (match.info.gameType.toUpperCase().startsWith("CUSTOM")) {
+    return;
+  }
+  const queueId = match.info.queueId.toString();
+  const date = matchDateString(match);
+  const byDate = counts[queueId] ?? {};
+  byDate[date] = (byDate[date] ?? 0) + 1;
+  counts[queueId] = byDate;
+}
+
+/**
  * Pure aggregation of RawMatch records into per-queue, per-day counts. Split
  * from the S3 walk so it can be unit-tested against fixtures with no live S3.
  */
@@ -124,17 +146,7 @@ export function aggregateQueueActivity(
 ): QueueActivityCounts {
   const counts: QueueActivityCounts = {};
   for (const match of matches) {
-    // Custom lobbies reuse queue ids from real modes (observed: queueId 3130
-    // with gameType CUSTOM_GAME) — they say nothing about a mode being live,
-    // so they must not feed availability windows.
-    if (match.info.gameType.toUpperCase().startsWith("CUSTOM")) {
-      continue;
-    }
-    const queueId = match.info.queueId.toString();
-    const date = matchDateString(match);
-    const byDate = counts[queueId] ?? {};
-    byDate[date] = (byDate[date] ?? 0) + 1;
-    counts[queueId] = byDate;
+    accumulateMatch(counts, match);
   }
   return counts;
 }
@@ -154,15 +166,11 @@ export async function collectQueueActivity(
   for (const prefix of datePrefixes(config.startDate, config.endDate)) {
     const keys = await listMatchKeysForPrefix(client, config.bucket, prefix);
     for (const key of keys) {
-      const match = await fetchMatch(client, config.bucket, key);
-      if (match.info.gameType.toUpperCase().startsWith("CUSTOM")) {
-        continue;
-      }
-      const queueId = match.info.queueId.toString();
-      const date = matchDateString(match);
-      const byDate = counts[queueId] ?? {};
-      byDate[date] = (byDate[date] ?? 0) + 1;
-      counts[queueId] = byDate;
+      // Streamed one at a time rather than collected and handed to
+      // `aggregateQueueActivity`: a 28-day lookback is tens of thousands of
+      // matches and buffering them all just to fold them is pointless. The
+      // classification itself is shared, which is the part that must not drift.
+      accumulateMatch(counts, await fetchMatch(client, config.bucket, key));
     }
   }
 

--- a/packages/temporal/src/activities/scout-queue-windows-pr-body.test.ts
+++ b/packages/temporal/src/activities/scout-queue-windows-pr-body.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildPrBody,
+  canAutoMerge,
+} from "#activities/scout-queue-windows-pr-body.ts";
+
+const NO_PATCH_NOTES = { titles: [] };
+
+function report(overrides: {
+  edits?: {
+    queue: string;
+    kind: "open" | "reopen" | "close";
+    date: string;
+    message: string;
+  }[];
+  warnings?: { kind: string; message: string }[];
+  unknownQueueIds?: { queueId: string; total: number }[];
+}) {
+  return {
+    edits: overrides.edits ?? [],
+    warnings: overrides.warnings ?? [],
+    unknownQueueIds: overrides.unknownQueueIds ?? [],
+    patchNotes: NO_PATCH_NOTES,
+  };
+}
+
+describe("canAutoMerge", () => {
+  test("allows additive-only edits", () => {
+    expect(
+      canAutoMerge([
+        { queue: "urf", kind: "open", date: "2026-07-12", message: "m" },
+        { queue: "arena", kind: "reopen", date: "2026-07-01", message: "m" },
+      ]),
+    ).toBe(true);
+  });
+
+  test("refuses when any edit closes a window", () => {
+    // A close retires a live mode; it must be confirmed against patch notes.
+    expect(
+      canAutoMerge([
+        { queue: "urf", kind: "open", date: "2026-07-12", message: "m" },
+        { queue: "arena", kind: "close", date: "2026-07-08", message: "m" },
+      ]),
+    ).toBe(false);
+  });
+
+  test("refuses an empty edit list", () => {
+    expect(canAutoMerge([])).toBe(false);
+  });
+});
+
+describe("buildPrBody markdown safety", () => {
+  test("escapes a pipe in a queue name so the table survives", () => {
+    // The Doom Bots trio renders as a `/`-joined name today, but any engine
+    // message containing a `|` would silently break every row after it.
+    const body = buildPrBody(
+      report({
+        edits: [
+          {
+            queue: "easy doom bots",
+            kind: "open",
+            date: "2026-07-06",
+            message: "opened window | with a pipe",
+          },
+        ],
+      }),
+      true,
+    );
+
+    const row = body.split("\n").find((line) => line.includes("opened window"));
+    expect(row).toBeDefined();
+    expect(row).toContain(String.raw`\|`);
+    // Four cells means five delimiters; an unescaped pipe would make six.
+    expect(row?.split(/(?<!\\)\|/).length).toBe(6);
+  });
+
+  test("flattens a newline in a message onto one row", () => {
+    const body = buildPrBody(
+      report({
+        edits: [
+          {
+            queue: "urf",
+            kind: "close",
+            date: "2026-07-08",
+            message: "line one\nline two",
+          },
+        ],
+      }),
+      false,
+    );
+    expect(body).toContain("line one line two");
+    expect(body).not.toContain("line one\nline two");
+  });
+});
+
+describe("buildPrBody surfaces unmapped queue ids", () => {
+  test("renders the ids the watcher could not classify", () => {
+    // These were parsed off the report and then dropped on the floor — the
+    // "new mode?" signal never reached the human reading the PR.
+    const body = buildPrBody(
+      report({
+        edits: [
+          { queue: "urf", kind: "open", date: "2026-07-12", message: "m" },
+        ],
+        unknownQueueIds: [
+          { queueId: "4200", total: 12 },
+          { queueId: "999999", total: 4 },
+        ],
+      }),
+      true,
+    );
+
+    expect(body).toContain("## Unmapped queue ids");
+    expect(body).toContain("| 4200 | 12 |");
+    expect(body).toContain("| 999999 | 4 |");
+  });
+
+  test("omits the section entirely when every id mapped", () => {
+    const body = buildPrBody(
+      report({
+        edits: [
+          { queue: "urf", kind: "open", date: "2026-07-12", message: "m" },
+        ],
+      }),
+      true,
+    );
+    expect(body).not.toContain("## Unmapped queue ids");
+  });
+});

--- a/packages/temporal/src/activities/scout-queue-windows-pr-body.ts
+++ b/packages/temporal/src/activities/scout-queue-windows-pr-body.ts
@@ -1,0 +1,104 @@
+import { SCOUT_QUEUE_WINDOWS_LOOKBACK_DAYS } from "#shared/scout-queue-windows-lookback.ts";
+import {
+  BUCKET,
+  type QueueWindowsReport,
+} from "#activities/scout-queue-windows-report.ts";
+
+/**
+ * PR body + auto-merge policy for the queue-windows watcher.
+ *
+ * Split out of the activity: it sits at the repo's max-lines cap, and these are
+ * pure string builders that deserve tests without dragging the activity's S3,
+ * GitHub, and Temporal imports into the test process.
+ */
+
+/** Auto-merge is safe only when every edit merely opens/reopens a window. A
+ * close retires a live mode and must be confirmed against patch notes. */
+export function canAutoMerge(
+  edits: readonly QueueWindowsReport["edits"][number][],
+): boolean {
+  return edits.length > 0 && edits.every((edit) => edit.kind !== "close");
+}
+
+/**
+ * Make a value safe to place in a markdown table cell.
+ *
+ * Drift messages are engine-authored prose that can legitimately contain a
+ * queue name with a `/` separator (the Doom Bots trio renders as
+ * `easy doom bots/normal doom bots/hard doom bots`) and, in future, anything a
+ * new warning kind wants to say. A bare `|` or newline silently breaks the
+ * table for every row after it.
+ */
+function tableCell(value: string): string {
+  return value.replaceAll("|", String.raw`\|`).replaceAll(/\r?\n/g, " ");
+}
+
+export function buildPrBody(
+  report: QueueWindowsReport,
+  autoMerge: boolean,
+): string {
+  const lines: string[] = [
+    "Automated queue-windows update from Temporal (`scout-queue-windows-daily`).",
+    "",
+    "Proposed from real match volume in the last",
+    `${SCOUT_QUEUE_WINDOWS_LOOKBACK_DAYS.toString()} days against the ${BUCKET} bucket.`,
+    "",
+    "## Edits",
+    "",
+    "| Queue | Kind | Date | Detail |",
+    "| --- | --- | --- | --- |",
+    ...report.edits.map(
+      (edit) =>
+        `| ${tableCell(edit.queue)} | ${edit.kind} | ${edit.date} | ${tableCell(edit.message)} |`,
+    ),
+  ];
+
+  if (report.warnings.length > 0) {
+    lines.push("", "## Warnings", "");
+    for (const warning of report.warnings) {
+      lines.push(`- **${warning.kind}**: ${warning.message}`);
+    }
+  }
+
+  if (report.unknownQueueIds.length > 0) {
+    lines.push(
+      "",
+      "## Unmapped queue ids",
+      "",
+      "Observed in the match lake with no `parseQueueType` mapping. A new mode",
+      "shows up here first — add the QueueType enum value and the mapping, then",
+      "the watcher maintains its windows.",
+      "",
+      "| Queue id | Matches |",
+      "| --- | --- |",
+      ...report.unknownQueueIds.map(
+        (unknown) =>
+          `| ${tableCell(unknown.queueId)} | ${unknown.total.toString()} |`,
+      ),
+    );
+  }
+
+  lines.push("", "## Patch notes", "");
+  if ("error" in report.patchNotes) {
+    lines.push(`- Patch notes unavailable: ${report.patchNotes.error}`);
+  } else if (report.patchNotes.titles.length === 0) {
+    lines.push("- No recent patch notes found.");
+  } else {
+    for (const note of report.patchNotes.titles) {
+      lines.push(`- [${note.title}](${note.url})`);
+    }
+  }
+
+  lines.push("");
+  if (autoMerge) {
+    lines.push(
+      "Auto-merge enabled: every edit only opens/reopens a window (additive, reversible).",
+    );
+  } else {
+    lines.push(
+      "Auto-merge NOT enabled: this PR closes a window (retires a live mode).",
+      "A human must confirm the close against the patch notes above before merging.",
+    );
+  }
+  return lines.join("\n");
+}

--- a/packages/temporal/src/activities/scout-queue-windows-report.ts
+++ b/packages/temporal/src/activities/scout-queue-windows-report.ts
@@ -1,0 +1,48 @@
+import { z } from "zod/v4";
+
+/**
+ * The report contract between Scout's `update-queue-windows.ts` CLI and the
+ * queue-windows activity.
+ *
+ * Split out so the pure PR-body builder can share the type without importing
+ * the activity, which drags in S3, GitHub, and Temporal.
+ */
+
+/** The match lake the watcher observes. */
+export const BUCKET = "scout-prod";
+
+const ReportEditSchema = z.object({
+  queue: z.string(),
+  kind: z.enum(["open", "reopen", "close"]),
+  date: z.string(),
+  message: z.string(),
+});
+
+const ReportWarningSchema = z.object({
+  kind: z.string(),
+  message: z.string(),
+  // The drift engine emits these three; the schema used to drop them, so the
+  // volume behind a warning was discarded here — as was `unknownQueueIds`,
+  // which was parsed and then never read by anything.
+  queue: z.string().optional(),
+  queueId: z.string().optional(),
+  total: z.number().optional(),
+});
+
+const ReportPatchNotesSchema = z.union([
+  z.object({
+    titles: z.array(z.object({ title: z.string(), url: z.string() })),
+  }),
+  z.object({ error: z.string() }),
+]);
+
+export const QueueWindowsReportSchema = z.object({
+  edits: z.array(ReportEditSchema),
+  warnings: z.array(ReportWarningSchema),
+  unknownQueueIds: z.array(
+    z.object({ queueId: z.string(), total: z.number() }),
+  ),
+  patchNotes: ReportPatchNotesSchema,
+});
+
+export type QueueWindowsReport = z.infer<typeof QueueWindowsReportSchema>;

--- a/packages/temporal/src/activities/scout-queue-windows.ts
+++ b/packages/temporal/src/activities/scout-queue-windows.ts
@@ -12,6 +12,12 @@ import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
 import { SCOUT_QUEUE_WINDOWS_LOOKBACK_DAYS } from "#shared/scout-queue-windows-lookback.ts";
 import { installScoutWorkspace } from "./bot-clone.ts";
 import {
+  BUCKET,
+  QueueWindowsReportSchema,
+  type QueueWindowsReport,
+} from "./scout-queue-windows-report.ts";
+import { buildPrBody, canAutoMerge } from "./scout-queue-windows-pr-body.ts";
+import {
   changedFilesInPaths,
   closeSeasonRefreshPr,
   openSeasonRefreshPr,
@@ -25,37 +31,11 @@ const SCOUT_ROOT = "packages/scout-for-lol";
 const QUEUE_WINDOWS_PATH = `${SCOUT_ROOT}/packages/data/src/model/queue-windows.json`;
 // The ONLY path this job is allowed to stage.
 const GENERATED_PATHS = [QUEUE_WINDOWS_PATH];
-const BUCKET = "scout-prod";
 const LOOKBACK_DAYS = SCOUT_QUEUE_WINDOWS_LOOKBACK_DAYS;
 const PROPOSAL_BRANCH = "chore/scout-queue-windows";
 const WARNING_STATE_KEY = "reports/state/scout-queue-windows.json";
 const AutoMergeStateSchema = z.enum(["true", "false"]);
 
-const ReportEditSchema = z.object({
-  queue: z.string(),
-  kind: z.enum(["open", "reopen", "close"]),
-  date: z.string(),
-  message: z.string(),
-});
-const ReportWarningSchema = z.object({
-  kind: z.string(),
-  message: z.string(),
-});
-const ReportPatchNotesSchema = z.union([
-  z.object({
-    titles: z.array(z.object({ title: z.string(), url: z.string() })),
-  }),
-  z.object({ error: z.string() }),
-]);
-const ReportSchema = z.object({
-  edits: z.array(ReportEditSchema),
-  warnings: z.array(ReportWarningSchema),
-  unknownQueueIds: z.array(
-    z.object({ queueId: z.string(), total: z.number() }),
-  ),
-  patchNotes: ReportPatchNotesSchema,
-});
-type Report = z.infer<typeof ReportSchema>;
 const WarningStateSchema = z.object({
   schemaVersion: z.literal(1),
   fingerprint: z
@@ -91,61 +71,6 @@ function resolveS3Region(): string {
     Bun.env["S3_REGION"] ??
     "us-east-1"
   );
-}
-
-/** Auto-merge is safe only when every edit merely opens/reopens a window. A
- * close retires a live mode and must be confirmed against patch notes. */
-function canAutoMerge(edits: readonly Report["edits"][number][]): boolean {
-  return edits.length > 0 && edits.every((edit) => edit.kind !== "close");
-}
-
-function buildPrBody(report: Report, autoMerge: boolean): string {
-  const lines: string[] = [
-    "Automated queue-windows update from Temporal (`scout-queue-windows-daily`).",
-    "",
-    "Proposed from real match volume in the last",
-    `${LOOKBACK_DAYS.toString()} days against the ${BUCKET} bucket.`,
-    "",
-    "## Edits",
-    "",
-    "| Queue | Kind | Date | Detail |",
-    "| --- | --- | --- | --- |",
-    ...report.edits.map(
-      (edit) =>
-        `| ${edit.queue} | ${edit.kind} | ${edit.date} | ${edit.message} |`,
-    ),
-  ];
-
-  if (report.warnings.length > 0) {
-    lines.push("", "## Warnings", "");
-    for (const warning of report.warnings) {
-      lines.push(`- **${warning.kind}**: ${warning.message}`);
-    }
-  }
-
-  lines.push("", "## Patch notes", "");
-  if ("error" in report.patchNotes) {
-    lines.push(`- Patch notes unavailable: ${report.patchNotes.error}`);
-  } else if (report.patchNotes.titles.length === 0) {
-    lines.push("- No recent patch notes found.");
-  } else {
-    for (const note of report.patchNotes.titles) {
-      lines.push(`- [${note.title}](${note.url})`);
-    }
-  }
-
-  lines.push("");
-  if (autoMerge) {
-    lines.push(
-      "Auto-merge enabled: every edit only opens/reopens a window (additive, reversible).",
-    );
-  } else {
-    lines.push(
-      "Auto-merge NOT enabled: this PR closes a window (retires a live mode).",
-      "A human must confirm the close against the patch notes above before merging.",
-    );
-  }
-  return lines.join("\n");
 }
 
 function warningStateStore(
@@ -212,7 +137,7 @@ export function nextWarningState(
 }
 
 async function warningFingerprint(
-  warnings: Report["warnings"],
+  warnings: QueueWindowsReport["warnings"],
 ): Promise<string | undefined> {
   if (warnings.length === 0) return undefined;
   const canonical = warnings
@@ -231,7 +156,7 @@ async function warningFingerprint(
 async function updateWarningState(
   endpoint: string,
   region: string,
-  warnings: Report["warnings"],
+  warnings: QueueWindowsReport["warnings"],
 ): Promise<{ fingerprint: string | undefined; consecutiveRuns: number }> {
   const store = warningStateStore(endpoint, region);
   const [prior, fingerprint] = await Promise.all([
@@ -258,7 +183,7 @@ async function updateWarningState(
 }
 
 function resultDetails(
-  report: Report,
+  report: QueueWindowsReport,
   warningState: { fingerprint: string | undefined; consecutiveRuns: number },
 ): Pick<
   ScoutQueueWindowsResult,
@@ -358,7 +283,7 @@ export const scoutQueueWindowsActivities = {
       );
 
       const rawReport: unknown = await Bun.file(reportPath).json();
-      const report = ReportSchema.parse(rawReport);
+      const report = QueueWindowsReportSchema.parse(rawReport);
       const warningState = await updateWarningState(
         s3Endpoint,
         region,


### PR DESCRIPTION
## Why

Three signals the queue-windows watcher already computed never reached anyone, and one test suite was covering code that does not run.

**The "new mode?" signal was dropped on the floor.** `report.unknownQueueIds` was parsed off the CLI report and then never read by anything. That is the one thing that tells a human to add a `QueueType` mapping when Riot ships a new queue id. The warning schema also discarded `queue`/`queueId`/`total`, which the drift engine does emit — so the volume behind a warning was lost twice over.

**The PR body could break its own table.** `edit.message` is engine-authored prose interpolated straight into a markdown row; a `|` or newline silently breaks the table for every row after it.

**The tests were testing the wrong function.** `aggregateQueueActivity` is a test-only duplicate of the S3 walk's inline loop — all four of its tests (custom-game exclusion, UTC date derivation) asserted against code production never executes, while `collectQueueActivity`, the function `update-queue-windows.ts` actually calls, had **zero coverage**.

**Two picker predicates disagreed by construction.** `entryAvailable` was `.some()` across a group while `entryNote` read only `queues[0]`. Latent today because the drift engine keeps the Doom Bots trio in lockstep — but a divergent trio would render as visible-and-selectable while captioned "not currently live".

## What

- **One `accumulateMatch`** shared by the pure aggregator and the live S3 walk, so the existing tests now cover the path that runs. The walk still streams one match at a time (a 28-day lookback is tens of thousands of matches; buffering them all just to fold them is pointless) — but the *classification* can no longer drift between the two.
- **Escape `|` and flatten newlines** in table cells.
- **Render an "Unmapped queue ids" section** in the PR body, and keep the warning fields the engine emits.
- **Derive `entryNote` from `entryAvailable`** so one predicate decides both.
- **Extract the PR body and report contract** into two modules — the activity hit 513 lines against a 500 cap after these additions, and these are pure string builders that deserve tests without dragging S3, GitHub, and Temporal into the test process.

## Two things I deliberately did not do

**The `now = new Date()` default is not a timezone bug.** I went in planning to "fix" it and then read it properly: `new Date(window.start)` parses to a UTC *instant* and `new Date()` is an instant, so comparing them is correct in every zone. Changing it to local-date semantics would make availability differ per viewer, which is worse than the thing I was going to fix.

**No CommunityDragon liveness oracle.** I'd previously recommended one; I checked the live endpoint and its `queues.json` has **no** enabled/visibility field at all. The real per-platform flag exists only on the LCU endpoint, which needs a running game client. The static proxies fail in the direction that matters — `gameSelectPriority` marks **Arena as dead** while `queue-windows.json` has it open-ended and demonstrably live.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal --filter=@scout-for-lol/backend --filter=@scout-for-lol/app --filter=@scout-for-lol/data` — 19/19 tasks
- Workflow-bundle smoke test passes after the module split
- Seven new PR-body tests: auto-merge policy, pipe escaping (asserted by counting *unescaped* delimiters, so an over-eager escape fails too), newline flattening, and the unmapped-id section both appearing and being omitted

Non-visual change, so no screenshots.