### PR TITLE
refactor(ci): make Argo release safety structural

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1168,7 +1168,8 @@ steps:
       bun --no-install scripts/scout-site-release.ts tag-release --state "$$scout_state" --dry-run
       bun --no-install scripts/scout-site-release.ts resolve-prod-pin
       bun --no-install packages/homelab/scripts/helm-push.ts "$BUILDKITE_BUILD_NUMBER" --dry-run
-      bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --dry-run
+      apps_revision=$$(jq -er '.[] | select(.name == "apps") | .revision' argocd-release-expected.json)
+      bun --no-install packages/homelab/scripts/argocd.ts release-root apps argocd-release-expected.json --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --dry-run
       pin_candidates=$$(jq -cn --arg build "$BUILDKITE_BUILD_NUMBER" \
         '{schema:"pin-candidates/v1",buildNumber:($$build|tonumber),candidates:{}}')
       bun --no-install scripts/update-versions.ts --commit-back --candidates "$$pin_candidates" --dry-run
@@ -1576,19 +1577,9 @@ steps:
       export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"
       buildkite-agent artifact download "argocd-release-expected.json" . --step helm-push
       apps_revision=$$(jq -er '.[] | select(.name == "apps") | .revision' argocd-release-expected.json)
-      # Stage every exact root resource while keeping every child Application
-      # auto-sync disabled. Root-owned admission and cluster policies land
-      # before children can depend on them, without starting child operations.
-      bun --no-install packages/homelab/scripts/argocd.ts stage-root-release apps --revision "$$apps_revision" --timeout 300
-      bun --no-install packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300
-      # Restore the exact tree in isolated sync waves while the self-managed
-      # root stays suspended, then restore it and prune after every other
-      # desired resource has applied-result proof. Keep the Buildkite identity
-      # through batches and termination so retries adopt only this revision
-      # and phase.
-      bun --no-install packages/homelab/scripts/argocd.ts finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300
-      # The scoped release health below remains authoritative for this release.
-      bun --no-install packages/homelab/scripts/argocd.ts release-health-wait argocd-release-expected.json --timeout 300
+      # One identity-bound process stages root prerequisites, reconciles exact
+      # child revisions, restores/prunes the root, and owns scoped health.
+      bun --no-install packages/homelab/scripts/argocd.ts release-root apps argocd-release-expected.json --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300
     retry: *retry
     plugins:
       - kubernetes:
@@ -1617,12 +1608,9 @@ steps:
       fi
       if [ -z "$$scout_candidate" ] && ! $$scout_source_changed; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      # scout-site-release imports the catalog parser from @homelab/cdk8s.
-      # With Bun's isolated linker, zod must be installed for that workspace;
-      # the root-scripts copy cannot satisfy an import resolved from cdk8s.
+      # The release script owns a workspace dependency on the shared catalog.
       .buildkite/scripts/bun-install.sh --frozen-lockfile \
         --filter '@shepherdjerred/root-scripts' \
-        --filter '@homelab/cdk8s' \
         --filter '@scout-for-lol/frontend' \
         --filter '@scout-for-lol/app' \
         --filter '@scout-for-lol/docs-site' \
@@ -1666,9 +1654,7 @@ steps:
       scout_state=$$(buildkite-agent meta-data get scout-release-state --default "")
       if [ -z "$$scout_state" ]; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      # scout-site-release imports the catalog parser from @homelab/cdk8s
-      # (isolated linker: zod must be installed for that workspace).
-      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       printf '%s' "$$GH_TOKEN" | docker login ghcr.io -u shepherdjerred --password-stdin
       bun --no-install scripts/scout-site-release.ts tag-release --state "$$scout_state"
@@ -1697,9 +1683,7 @@ steps:
     command: |
       if ! bun --no-install .buildkite/scripts/ci-changed.ts scout-reconcile; then exit 0; fi
       . .buildkite/scripts/toolchain.sh
-      # scout-site-release imports the catalog parser from @homelab/cdk8s
-      # (isolated linker: zod must be installed for that workspace).
-      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
       prod_pin=$$(bun --no-install scripts/scout-site-release.ts resolve-prod-pin)
       bun --no-install scripts/scout-site-release.ts reconcile-prod-pin --prod-pin "$$prod_pin"
@@ -1787,10 +1771,7 @@ steps:
     concurrency_group: monorepo/version-commit-back
     command: |
       . .buildkite/scripts/toolchain.sh
-      # update-versions imports the catalog validator from @homelab/cdk8s.
-      # With Bun's isolated linker, zod must be installed for that workspace;
-      # the root-scripts copy cannot satisfy an import resolved from cdk8s.
-      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
       bun --no-install scripts/update-versions.ts --commit-back --candidates "$$(bun --no-install .buildkite/scripts/read-buildkite-handoff.ts pin-candidates)"
     # Safe to retry: the bump branch is force-updated and the PR lookup is
     # find-or-create; transient gh/git failures exit 34 via transient.ts.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1094,6 +1094,7 @@ steps:
         - "packages/homelab/scripts/argocd.ts"
         - "packages/homelab/src/cdk8s/**"
         - "packages/homelab/src/helm-types/**"
+        - "packages/version-catalog/**"
         # Inputs of the npm, cooklang, and scout-image main lanes — mirrored
         # here so no lane input can change without a PR-side gate (asserted by
         # the lane↔if_changed coverage test).

--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -47,7 +47,7 @@ function versionCatalogSource(
   entries: readonly { readonly name: string; readonly value: string }[],
 ): string {
   return JSON.stringify({
-    $schema: "./version-catalog.schema.json",
+    $schema: "./schema.json",
     schemaVersion: 1,
     entries: entries.map((entry) => ({
       name: entry.name,

--- a/.buildkite/scripts/bake-images.ts
+++ b/.buildkite/scripts/bake-images.ts
@@ -35,7 +35,7 @@ const registry = "ghcr.io/shepherdjerred";
 const selectionReport = "image-selection-report.json";
 const pushOutcomes = "image-push-outcomes.json";
 export const VERSION_CATALOG_URL = new URL(
-  "../../packages/homelab/src/cdk8s/src/version-catalog.json",
+  "../../packages/version-catalog/src/catalog.json",
   import.meta.url,
 );
 const applicationImageTargets = new Set(APPLICATION_IMAGE_TARGETS);

--- a/.buildkite/scripts/ci-lane-coverage.test.ts
+++ b/.buildkite/scripts/ci-lane-coverage.test.ts
@@ -145,4 +145,15 @@ describe("lane↔if_changed coverage", () => {
       Object.keys(LANE_TO_STEP).sort(),
     );
   });
+
+  // The subset property above is satisfied trivially by a lane that lists
+  // nothing, so it cannot catch a release input going untracked. These lanes
+  // package charts, reconcile Applications, regenerate Helm types, and promote
+  // the Scout pin from the version catalog; dropping it here would let a
+  // catalog-only commit skip them entirely.
+  test("release lanes track the version catalog", () => {
+    for (const lane of ["helm", "argocd", "helm-types", "scout-reconcile"]) {
+      expect(selectorPathsForLane(lane)).toContain("packages/version-catalog");
+    }
+  });
 });

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -356,6 +356,7 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
   ],
   "helm-types": [
     ...workspacePaths,
+    "packages/version-catalog",
     "packages/homelab/src/cdk8s/src/versions.ts",
     "packages/homelab/src/cdk8s/scripts/generate-helm-types.ts",
     "packages/homelab/src/cdk8s/scripts/parse-helm-charts.ts",
@@ -371,6 +372,7 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
   ],
   helm: [
     ...workspacePaths,
+    "packages/version-catalog",
     "packages/homelab/src/cdk8s",
     "packages/homelab/scripts/helm-release-core.ts",
     "packages/homelab/scripts/helm-push.ts",
@@ -378,6 +380,7 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
   ],
   argocd: [
     ...workspacePaths,
+    "packages/version-catalog",
     "packages/homelab/src/cdk8s",
     "packages/homelab/scripts/argocd.ts",
     "scripts/lib/run.ts",
@@ -400,6 +403,7 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
     "packages/scout-for-lol",
     "packages/astro-opengraph-images",
     "packages/llm-models",
+    "packages/version-catalog",
     "packages/homelab/src/cdk8s/src/versions.ts",
     "scripts/package.json",
     "scripts/scout-site-release.ts",

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -7,218 +7,70 @@ import {
 
 const argocdCommand = (subcommand: string): string =>
   `bun --no-install packages/homelab/scripts/argocd.ts ${subcommand}`;
-const stagedRootRelease = argocdCommand(
-  'stage-root-release apps --revision "$$apps_revision" --timeout 300',
+const releaseRoot = argocdCommand(
+  'release-root apps argocd-release-expected.json --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
 );
-const atomicRootSync = argocdCommand(
-  'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
-);
-const deferredReleaseHealth = argocdCommand(
-  "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300",
-);
-const scopedReleaseHealth = argocdCommand(
-  "release-health-wait argocd-release-expected.json --timeout 300",
-);
-const atomicLifecycle = [
-  stagedRootRelease,
-  deferredReleaseHealth,
-  atomicRootSync,
-  scopedReleaseHealth,
-].join("\n");
 
 describe("atomic ArgoCD root sync pipeline contract", () => {
-  test("accepts the one-process identity-bound lifecycle", () => {
-    expect(() =>
-      validateAtomicRootSyncLifecycle(atomicLifecycle),
-    ).not.toThrow();
+  test("accepts one identity-bound release command", () => {
+    expect(() => validateAtomicRootSyncLifecycle(releaseRoot)).not.toThrow();
   });
 
-  test("rejects the split async and finalizer lifecycle", () => {
+  test("rejects the split root lifecycle", () => {
     const splitLifecycle = [
-      atomicLifecycle,
-      argocdCommand('sync apps --revision "$$apps_revision" --prune --async'),
-      argocdCommand('finalize-async-sync apps --revision "$$apps_revision"'),
+      argocdCommand(
+        'stage-root-release apps --revision "$$apps_revision" --timeout 300',
+      ),
+      argocdCommand(
+        "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300",
+      ),
+      argocdCommand(
+        'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
+      ),
+      argocdCommand(
+        "release-health-wait argocd-release-expected.json --timeout 300",
+      ),
     ].join("\n");
 
     expect(() => validateAtomicRootSyncLifecycle(splitLifecycle)).toThrow(
-      "argocd-sync restored the racy split async/finalize lifecycle",
+      "argocd-sync must contain exactly one identity-bound release-root command",
     );
   });
 
-  test("rejects an async root sync regardless of flag ordering", () => {
-    const reorderedAsync = [
-      atomicLifecycle,
-      argocdCommand('sync apps --revision "$$apps_revision" --async --prune'),
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(reorderedAsync)).toThrow(
-      "argocd-sync restored the racy split async/finalize lifecycle",
-    );
-  });
-
-  test("rejects a pipeline without the atomic root sync", () => {
+  test("rejects a duplicate root command", () => {
     expect(() =>
-      validateAtomicRootSyncLifecycle(
-        [stagedRootRelease, deferredReleaseHealth, scopedReleaseHealth].join(
-          "\n",
-        ),
-      ),
+      validateAtomicRootSyncLifecycle([releaseRoot, releaseRoot].join("\n")),
     ).toThrow(
-      "argocd-sync must contain exactly one atomic identity-bound root sync",
+      "argocd-sync must contain exactly one identity-bound release-root command",
     );
   });
 
-  test("rejects the full-source final sync that can stall before later waves", () => {
-    const legacyFinalSync = [
-      stagedRootRelease,
-      deferredReleaseHealth,
-      argocdCommand(
-        'sync apps --revision "$$apps_revision" --prune --terminate-after-applied --request-id "$BUILDKITE_BUILD_ID" --timeout 300',
-      ),
-      scopedReleaseHealth,
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(legacyFinalSync)).toThrow(
-      "argocd-sync must contain exactly one atomic identity-bound root sync",
+  test("ignores comments but rejects behavior-changing flags", () => {
+    expect(() => validateAtomicRootSyncLifecycle(`# ${releaseRoot}`)).toThrow(
+      "argocd-sync must contain exactly one identity-bound release-root command",
     );
-  });
-
-  test("rejects child health before the atomic root apply", () => {
-    const eagerHealth = [
-      stagedRootRelease,
-      argocdCommand(
-        "reconcile-release argocd-release-expected.json --timeout 300",
-      ),
-      atomicRootSync,
-      scopedReleaseHealth,
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(eagerHealth)).toThrow(
-      "argocd-sync must contain exactly one deferred child reconciliation",
-    );
-  });
-
-  test("rejects child reconciliation before root staging", () => {
-    const wrongOrder = [
-      deferredReleaseHealth,
-      stagedRootRelease,
-      atomicRootSync,
-      scopedReleaseHealth,
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(wrongOrder)).toThrow(
-      "argocd-sync must stage root, reconcile children, restore root, then run scoped health",
-    );
-  });
-
-  test("rejects the legacy child-only suspension command", () => {
-    const childOnlyStaging = [
-      argocdCommand(
-        'suspend-auto-sync apps --revision "$$apps_revision" --timeout 300',
-      ),
-      deferredReleaseHealth,
-      atomicRootSync,
-      scopedReleaseHealth,
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(childOnlyStaging)).toThrow(
-      "argocd-sync must contain exactly one root staging command with child auto-sync suspended",
-    );
-  });
-
-  test("rejects an extra eager child reconciliation", () => {
-    const duplicateReconciliation = [
-      argocdCommand(
-        "reconcile-release argocd-release-expected.json --timeout 300",
-      ),
-      atomicLifecycle,
-    ].join("\n");
-
     expect(() =>
-      validateAtomicRootSyncLifecycle(duplicateReconciliation),
+      validateAtomicRootSyncLifecycle(`${releaseRoot} --dry-run`),
     ).toThrow(
-      "argocd-sync must contain exactly one deferred child reconciliation",
-    );
-  });
-
-  test("rejects an extra eager scoped health gate", () => {
-    const duplicateHealth = [scopedReleaseHealth, atomicLifecycle].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(duplicateHealth)).toThrow(
-      "argocd-sync must contain exactly one scoped release health gate",
-    );
-  });
-
-  test("rejects behavior-changing flags on the scoped health gate", () => {
-    const dryRunHealth = [
-      stagedRootRelease,
-      deferredReleaseHealth,
-      atomicRootSync,
-      `${scopedReleaseHealth} --dry-run`,
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(dryRunHealth)).toThrow(
-      "argocd-sync must contain exactly one scoped release health gate",
-    );
-  });
-
-  test("does not treat a comment as an executable health gate", () => {
-    const commentedHealth = [
-      stagedRootRelease,
-      deferredReleaseHealth,
-      atomicRootSync,
-      `# ${scopedReleaseHealth}`,
-    ].join("\n");
-
-    expect(() => validateAtomicRootSyncLifecycle(commentedHealth)).toThrow(
-      "argocd-sync must contain exactly one scoped release health gate",
-    );
-  });
-
-  test("rejects an eager reconciliation wrapped in shell control flow", () => {
-    const wrappedReconciliation = [
-      `if ${argocdCommand(
-        "reconcile-release argocd-release-expected.json --timeout 300",
-      )}; then :; fi`,
-      atomicLifecycle,
-    ].join("\n");
-
-    expect(() =>
-      validateAtomicRootSyncLifecycle(wrappedReconciliation),
-    ).toThrow(
-      "argocd-sync must contain exactly one deferred child reconciliation",
-    );
-  });
-
-  test("rejects an eager reconciliation split across shell continuations", () => {
-    const continuedReconciliation = [
-      "bun --no-install \\",
-      "  packages/homelab/scripts/argocd.ts reconcile-release argocd-release-expected.json --timeout 300",
-      atomicLifecycle,
-    ].join("\n");
-
-    expect(() =>
-      validateAtomicRootSyncLifecycle(continuedReconciliation),
-    ).toThrow(
-      "argocd-sync must contain exactly one deferred child reconciliation",
+      "argocd-sync must contain exactly one identity-bound release-root command",
     );
   });
 });
 
 describe("version commit-back install contract", () => {
   const isolatedLinkerInstall =
-    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production";
+    ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production";
 
-  test("installs both the script and imported catalog workspaces", () => {
+  test("installs the script and its workspace dependency closure", () => {
     expect(() =>
       validateVersionCommitBackInstall(isolatedLinkerInstall),
     ).not.toThrow();
   });
 
-  test("rejects installing zod only for the importing scripts workspace", () => {
+  test("rejects installs that omit the root-scripts owner", () => {
     expect(() =>
       validateVersionCommitBackInstall(
-        ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production",
+        ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/version-catalog' --production",
       ),
     ).toThrow("version commit-back is missing exact isolated-linker install");
   });

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -45,6 +45,19 @@ describe("atomic ArgoCD root sync pipeline contract", () => {
     );
   });
 
+  test("rejects any additional argocd.ts invocation", () => {
+    expect(() =>
+      validateAtomicRootSyncLifecycle(
+        [
+          releaseRoot,
+          argocdCommand("suspend-auto-sync apps --timeout 300"),
+        ].join("\n"),
+      ),
+    ).toThrow(
+      "argocd-sync must contain exactly one identity-bound release-root command",
+    );
+  });
+
   test("ignores comments but rejects behavior-changing flags", () => {
     expect(() => validateAtomicRootSyncLifecycle(`# ${releaseRoot}`)).toThrow(
       "argocd-sync must contain exactly one identity-bound release-root command",

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -18,14 +18,8 @@ type ReleaseValidationOptions = {
 
 const ARGOCD_COMMAND_PREFIX =
   "bun --no-install packages/homelab/scripts/argocd.ts ";
-const STAGED_ROOT_RELEASE_SUBCOMMAND =
-  'stage-root-release apps --revision "$$apps_revision" --timeout 300';
-const ATOMIC_ROOT_SYNC_SUBCOMMAND =
-  'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
-const DEFERRED_RELEASE_HEALTH_SUBCOMMAND =
-  "reconcile-release argocd-release-expected.json --skip-health-wait --timeout 300";
-const SCOPED_RELEASE_HEALTH_SUBCOMMAND =
-  "release-health-wait argocd-release-expected.json --timeout 300";
+const RELEASE_ROOT_SUBCOMMAND =
+  'release-root apps argocd-release-expected.json --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID" --timeout 300';
 
 export function validateAtomicRootSyncLifecycle(
   argocdSync: string | undefined,
@@ -44,72 +38,17 @@ export function validateAtomicRootSyncLifecycle(
         .slice(1)
         .map((command) => command.trim()),
     );
-  const rootSyncCommands = executableCommands.filter((line) =>
-    /^(?:sync|finalize-root-release)\s+apps(?:\s|$)/.test(line),
+  const releaseRootCommands = executableCommands.filter((line) =>
+    /^(?:release-root|stage-root-release|reconcile-release|finalize-root-release|release-health-wait|finalize-async-sync|sync(?:-managed)?)\s+/.test(
+      line,
+    ),
   );
-  const hasAsyncRootSync = rootSyncCommands.some((line) =>
-    /(?:^|\s)--async(?:\s|$)/.test(line),
-  );
-  const hasAsyncFinalizer = executableCommands.some((line) =>
-    /^finalize-async-sync\s+apps(?:\s|$)/.test(line),
-  );
-  if (hasAsyncRootSync || hasAsyncFinalizer) {
-    fail("argocd-sync restored the racy split async/finalize lifecycle");
-  }
   if (
-    rootSyncCommands.length !== 1 ||
-    rootSyncCommands[0] !== ATOMIC_ROOT_SYNC_SUBCOMMAND
+    releaseRootCommands.length !== 1 ||
+    releaseRootCommands[0] !== RELEASE_ROOT_SUBCOMMAND
   ) {
     fail(
-      "argocd-sync must contain exactly one atomic identity-bound root sync",
-    );
-  }
-  const stagedRootCommands = executableCommands.filter((line) =>
-    /^(?:stage-root-release|suspend-auto-sync)\s+apps(?:\s|$)/.test(line),
-  );
-  if (
-    stagedRootCommands.length !== 1 ||
-    stagedRootCommands[0] !== STAGED_ROOT_RELEASE_SUBCOMMAND
-  ) {
-    fail(
-      "argocd-sync must contain exactly one root staging command with child auto-sync suspended",
-    );
-  }
-  const reconciliationCommands = executableCommands.filter((line) =>
-    /^reconcile-release\s+argocd-release-expected\.json(?:\s|$)/.test(line),
-  );
-  if (
-    reconciliationCommands.length !== 1 ||
-    reconciliationCommands[0] !== DEFERRED_RELEASE_HEALTH_SUBCOMMAND
-  ) {
-    fail("argocd-sync must contain exactly one deferred child reconciliation");
-  }
-  const scopedHealthCommands = executableCommands.filter((line) =>
-    /^release-health-wait\s+argocd-release-expected\.json(?:\s|$)/.test(line),
-  );
-  if (
-    scopedHealthCommands.length !== 1 ||
-    scopedHealthCommands[0] !== SCOPED_RELEASE_HEALTH_SUBCOMMAND
-  ) {
-    fail("argocd-sync must contain exactly one scoped release health gate");
-  }
-  const stageIndex = executableCommands.indexOf(STAGED_ROOT_RELEASE_SUBCOMMAND);
-  const reconcileIndex = executableCommands.indexOf(
-    DEFERRED_RELEASE_HEALTH_SUBCOMMAND,
-  );
-  const rootSyncIndex = executableCommands.indexOf(ATOMIC_ROOT_SYNC_SUBCOMMAND);
-  const healthIndex = executableCommands.indexOf(
-    SCOPED_RELEASE_HEALTH_SUBCOMMAND,
-  );
-  if (
-    !(
-      stageIndex < reconcileIndex &&
-      reconcileIndex < rootSyncIndex &&
-      rootSyncIndex < healthIndex
-    )
-  ) {
-    fail(
-      "argocd-sync must stage root, reconcile children, restore root, then run scoped health",
+      "argocd-sync must contain exactly one identity-bound release-root command",
     );
   }
 }
@@ -162,10 +101,7 @@ function validateReleaseSteps({
         "--filter homelab --filter '@homelab/cdk8s'",
         "concurrency_group: monorepo/homelab-release",
         'artifact download "argocd-release-expected.json"',
-        'stage-root-release apps --revision "$$apps_revision"',
-        "reconcile-release argocd-release-expected.json --skip-health-wait",
-        'finalize-root-release apps --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID"',
-        "release-health-wait argocd-release-expected.json",
+        'release-root apps argocd-release-expected.json --revision "$$apps_revision" --request-id "$BUILDKITE_BUILD_ID"',
       ],
     ],
     [
@@ -236,7 +172,7 @@ function validateReleaseSteps({
 }
 
 const VERSION_COMMIT_BACK_INSTALL =
-  ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --filter '@homelab/cdk8s' --production";
+  ".buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production";
 
 export function validateVersionCommitBackInstall(
   stepBlock: string | undefined,

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -38,14 +38,12 @@ export function validateAtomicRootSyncLifecycle(
         .slice(1)
         .map((command) => command.trim()),
     );
-  const releaseRootCommands = executableCommands.filter((line) =>
-    /^(?:release-root|stage-root-release|reconcile-release|finalize-root-release|release-health-wait|finalize-async-sync|sync(?:-managed)?)\s+/.test(
-      line,
-    ),
-  );
+  // Every argocd.ts invocation counts. Allowlisting only the lifecycle
+  // subcommands would let an unrelated one (suspend-auto-sync,
+  // delete-application, health-wait) rejoin the step without failing here.
   if (
-    releaseRootCommands.length !== 1 ||
-    releaseRootCommands[0] !== RELEASE_ROOT_SUBCOMMAND
+    executableCommands.length !== 1 ||
+    executableCommands[0] !== RELEASE_ROOT_SUBCOMMAND
   ) {
     fail(
       "argocd-sync must contain exactly one identity-bound release-root command",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ packages/
 ├── terraform-provider-asuswrt/ # Terraform provider for AsusWRT
 ├── toolkit/                    # CLI developer tools (pr, pd, bugsink, grafana)
 ├── trmnl-dashboard/            # TRMNL e-ink dashboard
+├── version-catalog/             # Language-neutral image/chart version catalog
 ├── webring/                    # Webring component (npm)
 scripts/                        # Repo automation (setup-free): checks, deploys, release, hooks
 .buildkite/pipeline.yml         # Canonical Buildkite CI pipeline (main selects a subset of these steps)
@@ -83,17 +84,21 @@ resources finalizer. Do not classify candidates from `OutOfSync` or
 `requiresPruning` alone: the selective manifest-override sync temporarily
 marks unselected retained children as requiring prune.
 
-Main release finalization must use `argocd.ts finalize-root-release` with the
-exact apps revision and Buildkite request UUID. It reapplies every desired
-sync wave through bounded manifest overrides before the full-source prune, so
-an unhealthy earlier Application cannot hide an unapplied later wave. Only the
-self-managed root Application remains auto-sync suspended across those batches
-so it cannot start an unowned operation between them. The final prune restores
-that policy and must report the root Application plus every validated prune
-candidate. Every operation carries an explicit `batch` or `prune` phase marker;
-retry adoption requires that marker and the expected prune mode as well as the
-request UUID, revision, and batch selection. Generic atomic syncs still require
-every rendered identity.
+Main releases must use `argocd.ts release-root` with the exact apps revision,
+release inventory, and Buildkite request UUID. One process owns root staging,
+child preflight and reconciliation, exact-wave restoration, verified pruning,
+and scoped health. Its bounded internal operations retain the request UUID,
+revision, resource selection, and `batch` or `prune` phase marker, so a retry
+cannot adopt unrelated work. Only the self-managed root Application remains
+auto-sync suspended while those operations run.
+
+Ordinary manual or UI root syncs are supported. Admission merges each managed
+child Application's declared sync options into the requested operation, with
+the declared value winning by key, and deterministic waves put admission,
+secret controllers, providers, certificates, queues, and workloads in
+dependency order. Only the recursive `apps` Application ignores child health.
+Deleting a managed Application is admission-protected by the retain-or-cascade
+lifecycle contract.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,10 +87,13 @@ marks unselected retained children as requiring prune.
 Main releases must use `argocd.ts release-root` with the exact apps revision,
 release inventory, and Buildkite request UUID. One process owns root staging,
 child preflight and reconciliation, exact-wave restoration, verified pruning,
-and scoped health. Its bounded internal operations retain the request UUID,
-revision, resource selection, and `batch` or `prune` phase marker, so a retry
-cannot adopt unrelated work. Only the self-managed root Application remains
-auto-sync suspended while those operations run.
+and scoped health. Every bounded internal operation, including root staging and
+each child reconciliation, retains that request UUID, the revision, its resource
+selection, and a `stage`, `batch`, or `prune` phase marker, so an interrupted
+release adopts only its own in-flight operation and never unrelated work. The
+apply-safety preflight inspects the revision the sync will request, not the
+Application's currently configured source. Only the self-managed root
+Application remains auto-sync suspended while those operations run.
 
 Ordinary manual or UI root syncs are supported. Admission merges each managed
 child Application's declared sync options into the requested operation, with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,10 @@ work. A retry resumes at whichever root phase is still live rather than
 restarting at staging, which cannot adopt a `batch` or `prune` operation.
 Adoption compares the live operation against the complete operation this
 process would have produced, not only its identity: prune mode, manifest
-override, resource selection, and the sync options admission merges in from the
-Application's declared policy. The comparison is closed-world, so any field it
+override, resource selection, and the sync options admission merges in. Those
+options are expected only where admission applies, so the root Application,
+which the release policy withholds the managed label from, is expected to carry
+none even though it declares some. The comparison is closed-world, so any field it
 cannot account for is refused rather than ignored, and an operation sharing the
 UUID, revision, and phase marker but applying different work never gets
 adopted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,13 @@ describes only the configured revision. Every immutable field declares both
 what omitting the whole field means and what a key found only in the live value
 means, because dropping a key inside a declared field is as rejectable as
 changing one; only fields the API server populates keys inside, such as a
-StatefulSet's claim templates, compare the declared keys alone. Only the
-self-managed root Application remains auto-sync suspended while those
-operations run.
+StatefulSet's claim templates, compare the declared keys alone. Where that
+tolerance would hide an author-owned removal, the preflight descends into the
+list with the entry kind's own rules — a claim template is compared as a
+PersistentVolumeClaim, matched by name — so the classification comes from one
+reviewed table rather than a second list of server-defaulted keys that would
+drift with every Kubernetes release. Only the self-managed root Application
+remains auto-sync suspended while those operations run.
 
 Ordinary manual or UI root syncs are supported. Admission merges each managed
 child Application's declared sync options into the requested operation, with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,13 @@ adopted.
 The apply-safety preflight inspects the revision the sync will request, not the
 Application's currently configured source, including resources that revision
 introduces, whose live state it reads directly because `managed-resources`
-describes only the configured revision. Only the self-managed root
-Application remains auto-sync suspended while those operations run.
+describes only the configured revision. Every immutable field declares both
+what omitting the whole field means and what a key found only in the live value
+means, because dropping a key inside a declared field is as rejectable as
+changing one; only fields the API server populates keys inside, such as a
+StatefulSet's claim templates, compare the declared keys alone. Only the
+self-managed root Application remains auto-sync suspended while those
+operations run.
 
 Ordinary manual or UI root syncs are supported. Admission merges each managed
 child Application's declared sync options into the requested operation, with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ and scoped health. Every bounded internal operation, including root staging and
 each child reconciliation, retains that request UUID, the revision, its resource
 selection, and a `stage`, `batch`, `prune`, or `child` phase marker, so an
 interrupted release adopts only its own in-flight operation and never unrelated
-work. Adoption compares the live operation against the complete request this
+work. A retry resumes at whichever root phase is still live rather than
+restarting at staging, which cannot adopt a `batch` or `prune` operation.
+Adoption compares the live operation against the complete request this
 process would post — prune mode, manifest override, and resource selection —
 not only its identity, so an operation that shares the UUID, revision, and
 phase marker but applies different work is refused. The

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,10 @@ release inventory, and Buildkite request UUID. One process owns root staging,
 child preflight and reconciliation, exact-wave restoration, verified pruning,
 and scoped health. Every bounded internal operation, including root staging and
 each child reconciliation, retains that request UUID, the revision, its resource
-selection, and a `stage`, `batch`, or `prune` phase marker, so an interrupted
-release adopts only its own in-flight operation and never unrelated work. The
+selection, and a `stage`, `batch`, `prune`, or `child` phase marker, so an
+interrupted release adopts only its own in-flight operation and never unrelated
+work. A child reconciliation declares a full-source selection, and adoption
+refuses a selective operation that merely shares the release identity. The
 apply-safety preflight inspects the revision the sync will request, not the
 Application's currently configured source. Only the self-managed root
 Application remains auto-sync suspended while those operations run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,11 @@ the declared value winning by key, and deterministic waves put admission,
 secret controllers, providers, certificates, queues, and workloads in
 dependency order. Only the recursive `apps` Application ignores child health.
 Deleting a managed Application is admission-protected by the retain-or-cascade
-lifecycle contract.
+lifecycle contract; that policy matches the labeled children plus the
+explicitly named root, and leaves unmanaged Applications deletable.
+`release-root` binds the release inventory's `apps` revision to `--revision`
+before it stages anything, so invalid release input cannot leave prerequisites
+applied.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,9 @@ UUID, revision, and phase marker but applying different work never gets
 adopted.
 
 The apply-safety preflight inspects the revision the sync will request, not the
-Application's currently configured source. Only the self-managed root
+Application's currently configured source, including resources that revision
+introduces, whose live state it reads directly because `managed-resources`
+describes only the configured revision. Only the self-managed root
 Application remains auto-sync suspended while those operations run.
 
 Ordinary manual or UI root syncs are supported. Admission merges each managed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,11 +93,15 @@ selection, and a `stage`, `batch`, `prune`, or `child` phase marker, so an
 interrupted release adopts only its own in-flight operation and never unrelated
 work. A retry resumes at whichever root phase is still live rather than
 restarting at staging, which cannot adopt a `batch` or `prune` operation.
-Adoption compares the live operation against the complete request this
-process would post — prune mode, manifest override, and resource selection —
-not only its identity, so an operation that shares the UUID, revision, and
-phase marker but applies different work is refused. The
-apply-safety preflight inspects the revision the sync will request, not the
+Adoption compares the live operation against the complete operation this
+process would have produced, not only its identity: prune mode, manifest
+override, resource selection, and the sync options admission merges in from the
+Application's declared policy. The comparison is closed-world, so any field it
+cannot account for is refused rather than ignored, and an operation sharing the
+UUID, revision, and phase marker but applying different work never gets
+adopted.
+
+The apply-safety preflight inspects the revision the sync will request, not the
 Application's currently configured source. Only the self-managed root
 Application remains auto-sync suspended while those operations run.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,9 @@ Deleting a managed Application is admission-protected by the retain-or-cascade
 lifecycle contract; that policy matches the labeled children plus the
 explicitly named root, and leaves unmanaged Applications deletable.
 `release-root` binds the release inventory's `apps` revision to `--revision`
-before it stages anything, so invalid release input cannot leave prerequisites
-applied.
+and validates the whole inventory against the exact rendered root revision
+before it stages anything, so semantically invalid release input cannot leave
+prerequisites applied and child auto-sync suspended.
 
 ## Code Review Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,10 @@ and scoped health. Every bounded internal operation, including root staging and
 each child reconciliation, retains that request UUID, the revision, its resource
 selection, and a `stage`, `batch`, `prune`, or `child` phase marker, so an
 interrupted release adopts only its own in-flight operation and never unrelated
-work. A child reconciliation declares a full-source selection, and adoption
-refuses a selective operation that merely shares the release identity. The
+work. Adoption compares the live operation against the complete request this
+process would post — prune mode, manifest override, and resource selection —
+not only its identity, so an operation that shares the UUID, revision, and
+phase marker but applies different work is refused. The
 apply-safety preflight inspects the revision the sync will request, not the
 Application's currently configured source. Only the self-managed root
 Application remains auto-sync suspended while those operations run.

--- a/bun.lock
+++ b/bun.lock
@@ -762,6 +762,7 @@
       "dependencies": {
         "@grafana/grafana-foundation-sdk": "11.6.0-cogv0.0.x.1769699379",
         "@shepherdjerred/helm-types": "workspace:*",
+        "@shepherdjerred/version-catalog": "workspace:*",
         "cdk8s": "^2.70.58",
         "cdk8s-plus-31": "^2.6.43",
         "constructs": "^10.6.0",
@@ -1680,6 +1681,25 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/version-catalog": {
+      "name": "@shepherdjerred/version-catalog",
+      "version": "1.0.0",
+      "dependencies": {
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@shepherdjerred/eslint-config": "workspace:*",
+        "@tsconfig/node-lts": "^24.0.0",
+        "@tsconfig/recommended": "^1.0.13",
+        "@tsconfig/strictest": "^2.0.8",
+        "@types/bun": "^1.3.13",
+        "@typescript/native": "npm:typescript@7.0.2",
+        "ajv": "^8.20.0",
+        "eslint": "^10.7.0",
+        "jiti": "^2.7.0",
+        "typescript": "^6.0.3",
+      },
+    },
     "packages/webring": {
       "name": "webring",
       "version": "1.10.0",
@@ -1715,6 +1735,7 @@
       "dependencies": {
         "@openai/codex": "0.146.0",
         "@shepherdjerred/code-review": "workspace:*",
+        "@shepherdjerred/version-catalog": "workspace:*",
         "fast-xml-builder": "1.3.0",
         "fast-xml-parser": "5.10.1",
         "fast-xml-validator": "1.4.0",
@@ -3567,6 +3588,8 @@
     "@shepherdjerred/toolkit": ["@shepherdjerred/toolkit@workspace:packages/toolkit"],
 
     "@shepherdjerred/trmnl-dashboard": ["@shepherdjerred/trmnl-dashboard@workspace:packages/trmnl-dashboard"],
+
+    "@shepherdjerred/version-catalog": ["@shepherdjerred/version-catalog@workspace:packages/version-catalog"],
 
     "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "packages/terraform-provider-asuswrt",
     "packages/toolkit",
     "packages/trmnl-dashboard",
+    "packages/version-catalog",
     "packages/webring",
     "scripts"
   ],

--- a/packages/docs/plans/2026-08-11_ci-green-cleanup.md
+++ b/packages/docs/plans/2026-08-11_ci-green-cleanup.md
@@ -1,0 +1,77 @@
+---
+id: plan-2026-08-11-ci-green-cleanup
+type: plan
+status: in-progress
+board: false
+---
+
+# CI green cleanup
+
+## Summary
+
+Main is green after several release-path repairs, but the recovery work left
+coupling and operator hazards that should not become permanent architecture.
+This cleanup restores ordinary ArgoCD sync behavior, makes the root release
+workflow smaller, and gives non-CDK8s release consumers a dedicated version
+catalog boundary.
+
+## Decisions
+
+- Use Kubernetes 1.36 admission policies to preserve each managed child
+  Application's declared sync options during manual operations and to enforce
+  the Application deletion contract. Exclude the recursive `apps` root from
+  operation mutation.
+- Make root sync waves express controller and custom-resource dependencies.
+  Child Application health remains authoritative; only the recursive root
+  ignores Application health to avoid self-deadlock.
+- Evaluate custom Application health with ArgoCD's executable Lua test command.
+  Current `Synced` and `Healthy` state wins over a stale failed operation, while
+  active operations and unresolved terminal failures stay visible.
+- Replace the split root release command sequence with one identity-bound
+  `release-root` command and retain one bounded `sync-managed` primitive for
+  internal sequencing and recovery.
+- Extract the structured version catalog, JSON Schema, parser, and serializer
+  into `@shepherdjerred/version-catalog`. Root release scripts and CDK8s consume
+  that workspace through `workspace:*`; CDK8s alone owns its generated runtime
+  version-map validation.
+- Remove CDK8s from release-lane install filters when the only dependency is the
+  version catalog. Keep quality gates intact and fail fast on missing tools or
+  invalid data.
+- Make immutable-field and mutually-exclusive-handler risks visible in a
+  read-only preflight before an Argo operation is submitted.
+
+## Implementation
+
+1. Add managed-Application labels, deterministic sync waves, mutating admission
+   for operation sync-option merging, and validating admission for lifecycle
+   deletion safety.
+2. Correct Application Lua health semantics and execute fixture coverage with
+   `argocd admin settings resource-overrides health`.
+3. Add the apply-safety preflight and consolidate root release orchestration
+   behind `release-root apps <expected.json>`.
+4. Update Buildkite wiring and its structural validator to require the single
+   release command.
+5. Create the version-catalog workspace, update all consumers and generators,
+   and narrow production install filters.
+6. Update operator documentation, the human wiki, repository instructions, and
+   skill sources that still describe the reactionary state.
+
+## Verification
+
+- Run focused CDK8s synthesis, tests, typecheck, and lint.
+- Run root-script and Buildkite pipeline validator tests, typecheck, and lint.
+- Run version-catalog parser, serializer, schema, and consumer coverage.
+- Run docs checks and the wiki typecheck, tests, build, and end-to-end tests.
+- Run staged lefthook checks and the complete `bun run verify` graph because
+  this change modifies verification and release machinery.
+- Require an exact-head PR build, merge, and then a fresh successful Buildkite
+  build for the current remote `main` SHA before live rollout acceptance.
+- After merge, verify the admission policies are established, run a normal
+  global root sync, and prove ArgoCD, child Applications, and workloads are
+  healthy without immutable-field failures or hidden child health.
+
+## Remaining
+
+- [x] Implement and verify the source, pipeline, and documentation cleanup.
+- [ ] Merge the exact validated PR head and obtain a fresh green `main` build.
+- [ ] Perform the post-merge admission-policy and normal-global-sync acceptance.

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -12,7 +12,7 @@ GitOps release can go wrong.
 ```mermaid
 sequenceDiagram
   accTitle: Homelab release sequence
-  accDescr: Buildkite suspends floating auto-sync, publishes an immutable chart set, stages exact child specifications and root prerequisites while children remain suspended, reconciles child workloads, restores the exact root tree with safe pruning, and checks scoped health.
+  accDescr: One Buildkite release command suspends floating auto-sync, publishes an immutable chart set, stages exact child specifications and root prerequisites while children remain suspended, preflights and reconciles child workloads, restores the exact root tree with safe pruning, and checks scoped health.
   participant BK as Buildkite
   participant CM as ChartMuseum
   participant Root as apps Application
@@ -21,16 +21,22 @@ sequenceDiagram
   BK->>Root: suspend current repository auto-sync
   BK->>CM: publish 2.0.0-build charts
   BK->>Root: stage child specs and prerequisites, still suspended
+  BK->>Child: read-only apply-safety preflight
   BK->>Child: reconcile every desired child in root wave order
   BK->>Root: restore exact revision with verified pruning
   BK->>Root: retain identity through apply and termination
   BK->>Child: require Synced and Healthy
 ```
 
-## Why the root is applied twice
+## Why `release-root` stages and restores the root
 
 The second suspended root apply is the part people delete when simplifying, and
 it is the part that matters.
+
+The public pipeline surface is nevertheless one command. `release-root` owns
+the entire identity-bound sequence in one process, so there is no handoff gap
+between staging, reconciliation, final pruning, and scoped health. The bounded
+operations underneath it remain separate because they prove different things.
 
 New child-level safety settings have to exist _before_ those children sync.
 But enabling floating auto-sync before every chart is published would let a
@@ -64,6 +70,13 @@ Argo omits `operation.sync.revision` from manifest-override operations, so the
 release command also persists the exact revision in the operation info list
 beside its request and operation UUIDs. Either representation can prove the
 revision, but disagreement between them is a hard identity failure.
+
+The waves are an architecture contract, not incident-specific ordering.
+Admission policy objects land first, followed by the 1Password controller and
+items, infrastructure providers, certificate resources, the root Application,
+Kueue, dependent configuration, Buildkite, and leaf workloads. This also makes
+an ordinary manual global sync safe: all members of a wave apply before ArgoCD
+waits on health, and no prerequisite is hidden behind a leaf workload.
 
 Disabling every child creates a second ordering obligation: Buildkite must
 explicitly reconcile external children as well as charts published by this
@@ -130,6 +143,44 @@ and ordinary child Applications can be degraded. Argo waits for their health
 before exposing later waves, even after the current wave and all prunes apply.
 Weakening generic sync completeness would risk skipping a genuinely unapplied
 later wave. Proving each desired wave first keeps that safety boundary intact.
+
+Application health is evaluated by an ArgoCD Lua customization exercised with
+ArgoCD's own executable health-test command. Active operations and unresolved
+terminal failures remain `Progressing` or `Degraded`, while a current
+`Synced`/`Healthy` state wins over stale failed operation history. Only the
+recursive `apps` Application carries `IgnoreHealthCheck=true`; child
+Application health remains an ordering and acceptance signal.
+
+## Why manual global sync preserves child options
+
+ArgoCD records a manual sync request in an Application's
+`operation.sync.syncOptions`. A broad request can otherwise omit an option that
+the child declares in `spec.syncPolicy.syncOptions`, turning a routine global
+sync into behavior different from the checked-in Application contract.
+
+A Kubernetes mutating admission policy selects managed child Applications and
+merges the declared options into the requested operation. Options are compared
+by the key before `=`, and the declared value wins. The recursive root is
+excluded to avoid mutating its self-operation. This is why starting a normal
+global sync is supported; the safety setting belongs to the Application, not
+to operator memory.
+
+A separate validating policy protects deletion. `apps` and `argocd` are
+retained, while another managed child can be deleted only when it carries both
+the cascade lifecycle annotation and Argo resources finalizer. The script still
+renders the exact desired revision to classify prune candidates; admission is
+an independent last line of defense, not a replacement for that proof.
+
+## Why apply safety is a preflight
+
+Immutable selector, service, volume-claim-template, and PVC field changes, plus
+mutually exclusive probe-handler swaps, are discoverable from ArgoCD's live and
+target resource states before a child sync starts. `release-root` hard-refreshes
+comparison and performs that read-only analysis. Any finding fails the release
+before submitting the child operation, so the operator sees the exact resource
+and field instead of a partially applied sync. The preflight does not invent a
+fallback or silently replace resources; remediation remains an explicit source
+or operator decision.
 
 Every desired automated policy includes an explicit `enabled` boolean. The
 [release policy](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/application-release-policy.ts)
@@ -220,11 +271,10 @@ flag is true, so an older full-source operation cannot borrow prior-batch proof.
 A generated per-operation UUID binds the top-level live operation to its
 completed status. This lets a retry accept a stable, fully applied result while
 rejecting stale status from an earlier POST with the same Buildkite identity.
-The standalone finalizer remains a recovery tool, not part of the normal
-release path. It recognizes the retired client's pre-UUID operation only when
-both live and completed state share the exact request ID and revision. Both
-must omit an operation UUID. Atomic operations never use that compatibility
-case.
+Recovery is the same `release-root` command with the same Buildkite UUID, not a
+second public finalizer command. It recognizes only operations whose request
+identity, exact revision, selected resources, phase marker, and prune mode fit
+the expected step. An unrelated operation remains a hard failure.
 
 After termination, the top-level live operation is authoritative. Its absence
 means the health wait is gone even if `status.operationState` still says
@@ -267,8 +317,9 @@ Application image selection uses the newest `main` commit whose `images` and
 `version-commit-back` jobs both passed as its comparison base.
 
 The image publisher reads current comparison digests and commit-back keys from
-the structured `version-catalog.json` source of truth. The generated
-`versions.ts` module is a runtime projection, not a writable pin corpus. The
+the structured `packages/version-catalog/src/catalog.json` source of truth.
+`@shepherdjerred/version-catalog` owns its language-neutral JSON Schema plus the
+shared parser and serializer; CDK8s owns only its typed runtime projection. The
 image tests resolve every real bake target against the structured catalog so a
 representation migration cannot finish a production push and only then discover
 that it has no pin to update.

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -176,7 +176,12 @@ an independent last line of defense, not a replacement for that proof.
 Immutable selector, service, volume-claim-template, and PVC field changes, plus
 mutually exclusive probe-handler swaps, are discoverable from ArgoCD's live and
 target resource states before a child sync starts. `release-root` hard-refreshes
-comparison and performs that read-only analysis. Any finding fails the release
+comparison and performs that read-only analysis. ArgoCD reports managed
+resources against the Application's configured source, so when a sync requests a
+different revision the preflight renders that exact revision and compares the
+live state against it instead. Probe handlers are correlated by container name,
+because Kubernetes merges container lists by name and a reordered or inserted
+container changes no handler. Any finding fails the release
 before submitting the child operation, so the operator sees the exact resource
 and field instead of a partially applied sync. The preflight does not invent a
 fallback or silently replace resources; remediation remains an explicit source
@@ -265,7 +270,9 @@ Buildkite retries reuse the build UUID. The
 adopts only the same request ID and revision. It refuses any unrelated active
 operation. For the root workflow, the active resource selection must also equal
 one exact desired batch or the unselected final prune. Each owned operation
-also persists a `batch` or `prune` phase marker. An unselected operation is
+also persists a `stage`, `batch`, or `prune` phase marker, so a staging batch
+and a restoration batch over the same resources stay distinguishable. An
+unselected operation is
 adoptable as the final prune only when that marker says `prune` and Argo's prune
 flag is true, so an older full-source operation cannot borrow prior-batch proof.
 A generated per-operation UUID binds the top-level live operation to its

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -270,8 +270,9 @@ Buildkite retries reuse the build UUID. The
 adopts only the same request ID and revision. It refuses any unrelated active
 operation. For the root workflow, the active resource selection must also equal
 one exact desired batch or the unselected final prune. Each owned operation
-also persists a `stage`, `batch`, or `prune` phase marker, so a staging batch
-and a restoration batch over the same resources stay distinguishable. An
+also persists a `stage`, `batch`, `prune`, or `child` phase marker, so a staging
+batch and a restoration batch over the same resources stay distinguishable, and
+a child reconciliation cannot adopt a selective operation. An
 unselected operation is
 adoptable as the final prune only when that marker says `prune` and Argo's prune
 flag is true, so an older full-source operation cannot borrow prior-batch proof.

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -6,7 +6,8 @@ sidebar:
 ---
 
 The main Buildkite pipeline is the only writer for repository-backed homelab
-releases. You do not run these steps by hand — merging to `main` runs them.
+releases. You do not run these steps by hand — merging to `main` runs one
+`release-root` command that owns the complete sequence.
 
 This page is for reading the pipeline while it works, and for knowing what a
 failed stage means.
@@ -110,7 +111,7 @@ pin.
 
 If the image push finishes but candidate classification reports that no managed
 pin exists, do not retry the push. The comparison digest and commit-back key
-come from `packages/homelab/src/cdk8s/src/version-catalog.json`; verify that the
+come from `packages/version-catalog/src/catalog.json`; verify that the
 real bake target has an exact image entry there and that the publisher is
 reading that structured catalog rather than the generated runtime projection.
 
@@ -156,7 +157,7 @@ full-source operation must report the restored root Application as `Synced` and
 every validated prune candidate as `Pruned`. A fully applied early batch or
 prune wave is not enough.
 
-Buildkite retries reuse the build UUID. The command adopts an operation only
+Buildkite retries reuse the build UUID. `release-root` adopts an operation only
 when the UUID and revision match and its selected resources are exactly one
 desired batch, or when it is the unselected final prune. An unrelated active
 operation or an unexpected selection remains a hard failure. The operation must
@@ -174,26 +175,30 @@ Unchanged resources use source-selective operations and retain the revision in
 Argo's ordinary sync request as well as the identity metadata.
 
 A release blocked here means the current operation must be inspected before
-retrying. If it is a fully applied operation from an interrupted older client,
-recover it with both values from the live operation:
+retrying. Confirm the operation's request ID, revision, selected resources,
+phase marker, and prune flag in ArgoCD. Do not terminate it based on revision
+alone. Once the observed operation belongs to the same Buildkite build, retry
+the failed Buildkite job; the same command and build UUID adopt only that exact
+operation and continue the release.
 
 ```bash
-bun packages/homelab/scripts/argocd.ts finalize-async-sync apps \
-  --revision <exact-revision> \
-  --request-id <exact-request-id> \
-  --timeout 300
+argocd app get apps --show-operation
 ```
 
-The recovery command polls for that exact operation and discovers its internal
-operation UUID from the live state. It terminates only when the completed status
-has the same UUID. Missing state, a different identity, an apply failure, or an
-incomplete result fails without termination.
+## If you start a global sync manually
 
-An operation created by the retired split pipeline predates internal operation
-UUIDs. The recovery command accepts that legacy shape only when both the live
-operation and completed status have the exact request ID and revision and both
-omit the internal UUID. New atomic operations always require their internal
-UUID.
+An ordinary global sync of `apps` is supported. Use ArgoCD's normal sync action;
+do not copy child sync options into the request by hand. Admission merges each
+managed child Application's declared options into the manual operation, and
+the declared value wins if the request contains the same option key.
+
+The global sync follows the chart's deterministic waves. Only the recursive
+`apps` Application ignores health; degraded child Applications remain visible
+and block progression where their wave is a dependency boundary. If a global
+sync reports an immutable-field or mutually-exclusive-probe-handler failure,
+stop and inspect that resource. The automated `release-root` path runs its
+read-only preflight before submitting child operations, but a manual ArgoCD UI
+sync does not run that client-side check.
 
 ## Where it lives
 

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -161,7 +161,7 @@ Buildkite retries reuse the build UUID. `release-root` adopts an operation only
 when the UUID and revision match and its selected resources are exactly one
 desired batch, or when it is the unselected final prune. An unrelated active
 operation or an unexpected selection remains a hard failure. The operation must
-also carry the finalizer's explicit `batch` or `prune` marker; prune adoption
+also carry an explicit `stage`, `batch`, or `prune` marker; prune adoption
 requires Argo's prune flag. This prevents an interrupted legacy full-source sync
 from impersonating the post-batch prune. Each POST also receives an internal
 operation UUID; adoption requires the live operation and its status to share

--- a/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
+++ b/packages/docs/wiki/src/content/docs/how-to/cut-a-homelab-release.md
@@ -161,7 +161,8 @@ Buildkite retries reuse the build UUID. `release-root` adopts an operation only
 when the UUID and revision match and its selected resources are exactly one
 desired batch, or when it is the unselected final prune. An unrelated active
 operation or an unexpected selection remains a hard failure. The operation must
-also carry an explicit `stage`, `batch`, or `prune` marker; prune adoption
+also carry an explicit `stage`, `batch`, `prune`, or `child` marker; prune
+adoption
 requires Argo's prune flag. This prevents an interrupted legacy full-source sync
 from impersonating the post-batch prune. Each POST also receives an internal
 operation UUID; adoption requires the live operation and its status to share

--- a/packages/dotfiles/dot_agents/skills/argocd-app-patterns/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-app-patterns/SKILL.md
@@ -70,7 +70,7 @@ export function createMyAppApp(chart: Chart) {
         namespace: "myapp",
       },
       syncPolicy: {
-        automated: {},
+        automated: { enabled: true },
         syncOptions: ["CreateNamespace=true"],
       },
     },
@@ -80,13 +80,13 @@ export function createMyAppApp(chart: Chart) {
 
 ### Step 2: Add Version
 
-Edit `src/cdk8s/src/versions.ts`:
+Add the language-neutral entry to
+`packages/version-catalog/src/catalog.json`, then regenerate the CDK8s runtime
+projection. Do not hand-edit `src/cdk8s/src/versions.ts`.
 
-```typescript
-const versions = {
-  // renovate: datasource=helm registryUrl=https://charts.example.com versioning=semver
-  myapp: "1.2.3",
-};
+```bash
+cd packages/homelab/src/cdk8s
+bun run scripts/generate-version-map-schema.ts
 ```
 
 ### Step 3: Register in Apps Chart
@@ -113,7 +113,7 @@ export async function createAppsChart(app: App) {
 
 ```typescript
 syncPolicy: {
-  automated: {},
+  automated: { enabled: true },
   syncOptions: ["CreateNamespace=true"],
 }
 ```
@@ -123,6 +123,7 @@ syncPolicy: {
 ```typescript
 syncPolicy: {
   automated: {
+    enabled: true,
     prune: true,      // Delete removed resources
     selfHeal: true,   // Revert manual changes
   },
@@ -140,11 +141,20 @@ annotation and Argo's resources finalizer. Do not classify candidates from
 `OutOfSync` or `requiresPruning` alone: the selective manifest-override sync
 temporarily marks unselected retained children as requiring prune.
 
+Every managed child Application is labeled by the root release policy. A
+Kubernetes mutating admission policy merges its declared
+`spec.syncPolicy.syncOptions` into manual `operation.sync.syncOptions`; declared
+values win when the request supplies the same option key. This makes ordinary
+global syncs safe without asking operators to reproduce per-child options. The
+recursive `apps` Application is deliberately excluded from operation mutation.
+A validating admission policy separately enforces the retain-or-cascade
+deletion contract.
+
 ### Server-Side Apply (Large Configs)
 
 ```typescript
 syncPolicy: {
-  automated: {},
+  automated: { enabled: true },
   syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
 }
 ```

--- a/packages/dotfiles/dot_agents/skills/argocd-app-patterns/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-app-patterns/SKILL.md
@@ -148,7 +148,9 @@ values win when the request supplies the same option key. This makes ordinary
 global syncs safe without asking operators to reproduce per-child options. The
 recursive `apps` Application is deliberately excluded from operation mutation.
 A validating admission policy separately enforces the retain-or-cascade
-deletion contract.
+deletion contract over the labeled children plus the explicitly named `apps`
+and `argocd` Applications. An ad-hoc Application in the `argocd` namespace is
+outside that contract and stays deletable.
 
 ### Server-Side Apply (Large Configs)
 

--- a/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
@@ -38,7 +38,7 @@ That process stages the exact root with child auto-sync disabled, performs the
 read-only immutable/handler preflight, reconciles exact child sources, restores
 every deterministic wave, verifies prune candidates, and owns scoped health.
 Retries may adopt only the exact request ID, revision, resource selection, and
-`batch` or `prune` phase marker. Never terminate a root operation by revision
+`stage`, `batch`, or `prune` phase marker. Never terminate a root operation by revision
 alone.
 
 An ordinary global sync from ArgoCD remains supported: admission merges every

--- a/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
@@ -38,7 +38,7 @@ That process stages the exact root with child auto-sync disabled, performs the
 read-only immutable/handler preflight, reconciles exact child sources, restores
 every deterministic wave, verifies prune candidates, and owns scoped health.
 Retries may adopt only the exact request ID, revision, resource selection, and
-`stage`, `batch`, or `prune` phase marker. Never terminate a root operation by revision
+`stage`, `batch`, `prune`, or `child` phase marker. Never terminate a root operation by revision
 alone.
 
 An ordinary global sync from ArgoCD remains supported: admission merges every

--- a/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/argocd-helper/SKILL.md
@@ -24,25 +24,28 @@ This agent helps you work with ArgoCD for GitOps-based Kubernetes deployments, a
 
 ## shepherdjerred monorepo root releases
 
-The main Buildkite release owns the root `apps` lifecycle. It stages the exact
-chart with child auto-sync disabled, reconciles selected children, then runs:
+The main Buildkite release owns the root `apps` lifecycle through one public
+command:
 
 ```bash
-bun packages/homelab/scripts/argocd.ts finalize-root-release apps \
+bun packages/homelab/scripts/argocd.ts release-root apps argocd-release-expected.json \
   --revision "$apps_revision" \
   --request-id "$BUILDKITE_BUILD_ID" \
   --timeout 300
 ```
 
-The finalizer reapplies every exact sync wave before pruning, while keeping the
-self-managed root Application auto-sync suspended between batches. The final
-full-source operation restores that policy and proves both the root result and
-validated prunes. Do not replace it with one full-source
-`sync --prune --terminate-after-applied`: an unhealthy earlier wave can prevent
-ArgoCD from ever reporting later desired resources. Recovery may adopt only the
-exact request ID, revision, resource selection, and `batch` or `prune` phase
-marker; prune adoption also requires Argo's prune flag. Never terminate a root
-operation by revision alone.
+That process stages the exact root with child auto-sync disabled, performs the
+read-only immutable/handler preflight, reconciles exact child sources, restores
+every deterministic wave, verifies prune candidates, and owns scoped health.
+Retries may adopt only the exact request ID, revision, resource selection, and
+`batch` or `prune` phase marker. Never terminate a root operation by revision
+alone.
+
+An ordinary global sync from ArgoCD remains supported: admission merges every
+managed child Application's declared sync options into the manual operation,
+and the declared value wins by key. Deterministic waves express controller and
+custom-resource dependencies. Only the recursive `apps` Application ignores
+health; child health remains authoritative.
 
 ## Auto-Approved Commands
 

--- a/packages/dotfiles/dot_agents/skills/buildkite-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/buildkite-helper/SKILL.md
@@ -9,7 +9,7 @@ description: |
 
 # BuildKite Helper
 
-> **⚠️ Partially stale.** The monorepo runs a **static** Buildkite pipeline (`.buildkite/pipeline.yml`, replatformed 2026-07 — the Dagger module and dynamic generator are gone) on the homelab agent-stack (`buildkite` namespace). CI runs on the dedicated `liskov` node; `BUILDKITE_MAX_IN_FLIGHT=20` remains the count cap and Kueue provides the resource-aware `80Gi / 24 CPU / 20 pods / 100Gi` admission layer. Dagger/dynamic-pipeline notes below are historical; the general Buildkite reference material remains valid.
+> **Current monorepo shape.** The repo runs a **static** Buildkite pipeline (`.buildkite/pipeline.yml`, replatformed 2026-07) on the homelab agent-stack in the `buildkite` namespace. CI runs on the dedicated `liskov` node. `BUILDKITE_MAX_IN_FLIGHT=24` is the count cap, and Kueue provides the resource-aware `80Gi / 24 CPU / 24 pods / 100Gi` admission layer. The explicitly marked Dagger/dynamic-pipeline section below is historical; the general Buildkite reference material remains valid.
 
 ## Overview
 

--- a/packages/dotfiles/dot_agents/skills/buildkite-helper/references/kubernetes-agent-stack.md
+++ b/packages/dotfiles/dot_agents/skills/buildkite-helper/references/kubernetes-agent-stack.md
@@ -99,8 +99,8 @@ Never write tokens to files or embed in URLs. Use `--token` flags or your CI sys
 ### Admission control — Kueue
 
 The `buildkite` namespace is explicitly managed by Kueue. Buildkite's
-`max-in-flight=20` remains the count cap, while the Kueue `ClusterQueue`
-limits requests to `24 CPU / 80Gi memory / 20 pods / 100Gi ephemeral-storage`.
+`max-in-flight=24` remains the count cap, while the Kueue `ClusterQueue`
+limits requests to `24 CPU / 80Gi memory / 24 pods / 100Gi ephemeral-storage`.
 New Jobs receive the `default` LocalQueue automatically. If requests do not
 fit, Kueue suspends the Job until quota is available; that is expected and is
 different from a rejected Job or a FailedCreate storm.

--- a/packages/dotfiles/dot_agents/skills/linuxserver-containers/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/linuxserver-containers/SKILL.md
@@ -223,12 +223,23 @@ export function createSonarrDeployment(
 
 ## Version Management
 
-Add versions with SHA256 digests:
+Add versions with SHA256 digests to
+`packages/version-catalog/src/catalog.json`; do not hand-edit the CDK8s runtime
+projection:
 
-```typescript
-// In src/cdk8s/src/versions.ts
-// renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-"linuxserver/sonarr": "4.0.16@sha256:8b9f2138ec50fc9e521960868f79d2ad0d529bc610aef19031ea8ff80b54c5e0",
+```json
+{
+  "name": "linuxserver/sonarr",
+  "value": "4.0.16@sha256:8b9f2138ec50fc9e521960868f79d2ad0d529bc610aef19031ea8ff80b54c5e0",
+  "category": "upstream",
+  "artifactType": "image",
+  "management": {
+    "managed": true,
+    "datasource": "docker",
+    "registryUrl": "https://ghcr.io",
+    "versioning": "docker"
+  }
+}
 ```
 
 ## Deployment Strategy

--- a/packages/dotfiles/dot_agents/skills/torvalds-deployment/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/torvalds-deployment/SKILL.md
@@ -151,14 +151,12 @@ export function createYourServiceDeployment(
 
 ### Step 2: Add Version
 
-Edit `src/cdk8s/src/versions.ts`:
+Add the entry to `packages/version-catalog/src/catalog.json` and regenerate the
+CDK8s catalog types. Do not hand-edit `src/cdk8s/src/versions.ts`:
 
-```typescript
-const versions = {
-  // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-  "linuxserver/yourservice": "1.0.0@sha256:abc123...",
-  // ... other versions
-};
+```bash
+cd packages/homelab/src/cdk8s
+bun run generate-version-catalog-types
 ```
 
 ### Step 3: Register in Appropriate Chart

--- a/packages/dotfiles/dot_agents/skills/version-management/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/version-management/SKILL.md
@@ -9,71 +9,99 @@ description: >-
 
 ## Overview
 
-`src/cdk8s/src/versions.ts` is the single source of truth for all versions in the homelab. It uses Renovate annotations for automated dependency updates.
+`packages/version-catalog/src/catalog.json` is the language-neutral source of
+truth for homelab and release-script versions. Its adjacent JSON Schema is the
+portable contract, and `@shepherdjerred/version-catalog` provides the shared
+Zod parser and canonical serializer. CDK8s consumes that package from
+`src/cdk8s/src/versions.ts` and adds only its generated exact-key type boundary
+plus build-time image overrides.
 
 ## File Structure
 
-```typescript
-const versions = {
-  // Helm charts
-  // renovate: datasource=helm registryUrl=https://argoproj.github.io/argo-helm versioning=semver
-  "argo-cd": "9.2.0",
-
-  // Docker images with digests
-  // renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-  "linuxserver/sonarr":
-    "4.0.16@sha256:8b9f2138ec50fc9e521960868f79d2ad0d529bc610aef19031ea8ff80b54c5e0",
-
-  // Custom images (not managed by Renovate)
-  // not managed by renovate
-  "shepherdjerred/temporal-worker": "latest",
-};
-
-export default versions;
+```json
+{
+  "$schema": "./schema.json",
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "name": "argo-cd",
+      "value": "10.2.1",
+      "category": "upstream",
+      "artifactType": "helm-chart",
+      "management": {
+        "managed": true,
+        "datasource": "helm",
+        "registryUrl": "https://argoproj.github.io/argo-helm",
+        "versioning": "semver"
+      }
+    }
+  ]
+}
 ```
 
 ## Adding a New Version
 
 ### Helm Chart
 
-```typescript
-// renovate: datasource=helm registryUrl=https://charts.example.com versioning=semver
-"mychart": "1.2.3",
+```json
+{
+  "name": "mychart",
+  "value": "1.2.3",
+  "category": "upstream",
+  "artifactType": "helm-chart",
+  "management": {
+    "managed": true,
+    "datasource": "helm",
+    "registryUrl": "https://charts.example.com",
+    "versioning": "semver"
+  }
+}
 ```
 
 ### Docker Image (with digest)
 
-```typescript
-// renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-"org/image": "1.0.0@sha256:abc123def456...",
+```json
+{
+  "name": "org/image",
+  "value": "1.0.0@sha256:abc123def456...",
+  "category": "upstream",
+  "artifactType": "image",
+  "management": {
+    "managed": true,
+    "datasource": "docker",
+    "registryUrl": "https://ghcr.io",
+    "versioning": "docker"
+  }
+}
 ```
 
 ### Docker Hub Image
 
-```typescript
-// renovate: datasource=docker registryUrl=https://docker.io versioning=docker
-"library/nginx": "1.25.0@sha256:...",
-```
+Use the Docker-image shape above with `registryUrl` set to
+`https://docker.io`.
 
 ### GitHub Release
 
-```typescript
-// renovate: datasource=github-releases versioning=semver
-"owner/repo": "v1.2.3",
-```
+Use `artifactType: "source"`, `datasource: "github-releases"`, and the
+repository name in `name` or `packageName`.
 
 ### Custom/Manually-Managed (No Renovate)
 
-```typescript
-// not managed by renovate
-"myorg/custom-image": "latest",
+```json
+{
+  "name": "myorg/custom-image",
+  "value": "latest",
+  "category": "internal-image",
+  "artifactType": "image",
+  "management": { "managed": false }
+}
 ```
 
 ## Renovate Annotation Format
 
-```text
-// renovate: datasource={source} registryUrl={url} versioning={scheme}
-```
+Renovate's custom manager reads `management.datasource`, `versioning`, optional
+`registryUrl`, and optional `packageName` directly from each JSON entry. Do not
+add TypeScript Renovate comments or edit the generated CDK8s projection.
 
 ### Datasources
 
@@ -218,13 +246,13 @@ deploys.
 
 The project uses Renovate for automated updates:
 
-1. Renovate parses `versions.ts` looking for annotations
+1. Renovate's custom manager parses structured entries in `catalog.json`
 2. Creates PRs for version bumps
 3. PRs run `bun run verify` (affected-scoped) on the static Buildkite pipeline (`.buildkite/pipeline.yml`) — check the `buildkite/monorepo/pr` status before merging
 
 ### Digest/pin updates bypass `minimumReleaseAge`
 
-`minimumReleaseAge` + `internalChecksFilter: strict` only hold back **major/minor/patch** PRs (Dependency Dashboard "Pending Status Checks"); they do **not** apply to `digest` / `pinDigest` / `pin` updates, which open immediately and would otherwise merge before the window. The Buildkite stability guard that used to block these (`renovateStabilityPending()` in the CI generator) was removed with the pipeline 2026-07 — check the `renovate/stability-days` status yourself before merging a digest/pin PR. Escape hatch for a fast-moving digest: a `minimumReleaseAge: "0 days"` packageRule. (`renovate-config-validator` segfaults under Bun — run via `npx --yes --package renovate -- renovate-config-validator renovate.json`.)
+`minimumReleaseAge` + `internalChecksFilter: strict` only hold back **major/minor/patch** PRs (Dependency Dashboard "Pending Status Checks"); they do **not** apply to `digest` / `pinDigest` / `pin` updates, which open immediately and would otherwise merge before the window. The Buildkite stability guard that used to block these (`renovateStabilityPending()` in the CI generator) was removed with the pipeline 2026-07 — check the `renovate/stability-days` status yourself before merging a digest/pin PR. Escape hatch for a fast-moving digest: a `minimumReleaseAge: "0 days"` packageRule. Validate configuration with `bunx --package renovate renovate-config-validator renovate.json`.
 
 ### Never silence upstream-blocked items
 
@@ -232,7 +260,7 @@ Do **not** add `packageRules` with `enabled: false` to `renovate.json` to suppre
 
 ## Best Practices
 
-1. **Always use annotations** for external dependencies
+1. **Declare management metadata** for external dependencies
 2. **Include SHA256 digests** for container images
 3. **Use semantic versioning** when possible
 4. **Mark internal images** as "not managed by renovate"
@@ -242,23 +270,19 @@ Do **not** add `packageRules` with `enabled: false` to `renovate.json` to suppre
 
 ### Multiple Images from Same Org
 
-```typescript
-// renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-"linuxserver/sonarr": "4.0.16@sha256:...",
-// renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-"linuxserver/radarr": "5.2.6@sha256:...",
-// renovate: datasource=docker registryUrl=https://ghcr.io versioning=docker
-"linuxserver/bazarr": "1.4.0@sha256:...",
-```
+Use one structured catalog entry per image with the same `datasource`,
+`registryUrl`, and `versioning`. Renovate grouping remains in `renovate.json`;
+do not collapse multiple artifacts into one catalog entry.
 
 ### Helm Chart with Custom Registry
 
-```typescript
-// renovate: datasource=helm registryUrl=https://charts.gitlab.io versioning=semver
-"gitlab": "7.8.0",
-```
+Use a managed `helm-chart` entry with
+`registryUrl: "https://charts.gitlab.io"` and `versioning: "semver"`.
 
 ## Key Files
 
-- `src/cdk8s/src/versions.ts` - Version registry
-- `renovate.json` - Renovate configuration
+- `packages/version-catalog/src/catalog.json` - writable version registry
+- `packages/version-catalog/src/schema.json` - language-neutral contract
+- `packages/version-catalog/src/index.ts` - shared parser and serializer
+- `packages/homelab/src/cdk8s/src/versions.ts` - CDK8s runtime projection
+- `renovate.json` - Renovate custom-manager configuration

--- a/packages/dotfiles/dot_agents/skills/version-management/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/version-management/SKILL.md
@@ -2,7 +2,7 @@
 name: version-management
 description: >-
   Use when asking about version management, Renovate annotations,
-  versions.ts patterns, or pinning image/chart versions.
+  the version catalog, or pinning image/chart versions.
 ---
 
 # Version Management
@@ -158,14 +158,15 @@ new Application(chart, "myapp", {
 
 ## SHA256 Digests
 
-Always include digests for production images:
+Always include digests for production images. The digest lives in the entry's
+`value`, appended to the tag:
 
-```typescript
+```json
 // Good: Immutable reference
-"org/image": "1.0.0@sha256:abc123...",
+{ "name": "org/image", "value": "1.0.0@sha256:abc123..." }
 
 // Avoid: Mutable tag
-"org/image": "1.0.0",
+{ "name": "org/image", "value": "1.0.0" }
 ```
 
 **Benefits:**
@@ -187,9 +188,36 @@ docker inspect ghcr.io/org/image:1.0.0 --format='{{index .RepoDigests 0}}'
 
 ## Talos / Kubernetes Pins Reflect Deployed Reality
 
-The `"kubernetes/kubernetes"` and `"siderolabs/talos"` entries in `versions.ts` must match the version **actually deployed and running on `torvalds`** — not whatever upstream Renovate would bump to. These two are not consumed by code; they exist for Renovate to track AND as a source-of-truth record of cluster state.
+The `kubernetes/kubernetes` and `siderolabs/talos` entries in
+`packages/version-catalog/src/catalog.json` must match the version **actually
+deployed and running on `torvalds`** — not whatever upstream Renovate would bump
+to. These two are not consumed by code; they exist for Renovate to track AND as
+a source-of-truth record of cluster state.
 
-After any `talosctl upgrade` or `talosctl upgrade-k8s` that lands on a version different from the existing pin (e.g. the Sidero kubelet image for the latest patch isn't published yet, so you pick the prior k8s patch), update `versions.ts` **and** the README upgrade snippet (`packages/homelab/README.md` `VERSION=` example lines) to the now-running version in the same change. If they drift from reality, future upgrade sessions can't tell a Renovate target from a record of what's deployed.
+After any `talosctl upgrade` or `talosctl upgrade-k8s` that lands on a version
+different from the existing pin (e.g. the Sidero kubelet image for the latest
+patch isn't published yet, so you pick the prior k8s patch), edit that entry's
+`value` in the catalog **and** the README upgrade snippet
+(`packages/homelab/README.md` `VERSION=` example lines) to the now-running
+version in the same change. Both entries are `artifactType: "source"` with the
+`github-releases` datasource:
+
+```json
+{
+  "name": "siderolabs/talos",
+  "category": "upstream",
+  "artifactType": "source",
+  "management": {
+    "managed": true,
+    "datasource": "github-releases",
+    "versioning": "semver"
+  },
+  "value": "1.13.8"
+}
+```
+
+If they drift from reality, future upgrade sessions can't tell a Renovate target
+from a record of what's deployed.
 
 ## First-Party Image Versions (automated by version commit-back)
 
@@ -199,26 +227,42 @@ removed): the `images` step bakes/pushes images (tags `:$GIT_SHA` + `:latest`;
 the `2.0.0-<build>` in a pin is a cosmetic label on a digest-pinned ref) and
 records **content-gated** digests, and the `version commit-back` step
 (`scripts/update-versions.ts --commit-back`) opens the auto-merge
-"chore: bump pending image versions" PR rewriting the matching pins:
+"chore: bump pending image versions" PR rewriting the matching catalog entries:
 
-```typescript
-// not managed by renovate — beta updated by version-commit-back
-"shepherdjerred/temporal-worker":
-  "2.0.0-1020@sha256:…",
+```json
+{
+  "name": "shepherdjerred/temporal-worker",
+  "category": "internal-image",
+  "artifactType": "image",
+  "management": { "managed": false },
+  "value": "2.0.0-1020@sha256:…",
+  "notes": ["not managed by renovate"]
+}
 ```
 
-Commit-back only rewrites bare keys and `/beta` stage keys — never `/prod`.
+Commit-back rewrites only the `value` of bare-name and `/beta` stage entries —
+never `/prod`. It writes through the catalog's canonical serializer, so hand
+edits to the same entries should keep the existing field order.
 
 ### `/beta` and `/prod` are deployment-stage keys, not image names
 
-App images publish to a **single** GHCR package (e.g. `ghcr.io/shepherdjerred/scout-for-lol:2.0.0-710`) — there is no `/beta` or `/prod` in the image name. But `versions.ts` has separate `…/beta` and `…/prod` entries because they are deployment stages that may pin different versions:
+App images publish to a **single** GHCR package (e.g.
+`ghcr.io/shepherdjerred/scout-for-lol:2.0.0-710`) — there is no `/beta` or
+`/prod` in the image name. The catalog carries separate `…/beta` and `…/prod`
+entries because they are deployment stages that may pin different versions:
 
-```typescript
-"shepherdjerred/scout-for-lol/beta": "2.0.0-710@sha256:…", // beta tracks latest (auto-bumped)
-"shepherdjerred/scout-for-lol/prod": "2.0.0-700@sha256:…", // prod promoted explicitly
+```json
+// beta tracks latest (auto-bumped by version commit-back)
+{ "name": "shepherdjerred/scout-for-lol/beta", "value": "2.0.0-710@sha256:…" }
+// prod promoted explicitly by merging the Renovate PR
+{ "name": "shepherdjerred/scout-for-lol/prod", "value": "2.0.0-700@sha256:…" }
 ```
 
-The catalog's `versionKey` (used in `--tags ghcr.io/{versionKey}:…`) must **not** carry a `/beta`|`/prod` suffix; only the `versions.ts` entries and the cdk8s resources that read them use the stage suffixes to deploy a different version per stage.
+A `/prod` entry keeps `management.packageName` pointed at the suffix-free image
+so Renovate resolves the real GHCR package. The build target's `versionKey`
+(used in `--tags ghcr.io/{versionKey}:…`) must **not** carry a `/beta`|`/prod`
+suffix; only the catalog entry names and the cdk8s resources that read the
+projection use the stage suffixes to deploy a different version per stage.
 
 ### First-party prod pins are Renovate promotions (minted release tags)
 

--- a/packages/homelab/AGENTS.md
+++ b/packages/homelab/AGENTS.md
@@ -178,7 +178,7 @@ synced secret's data keys are consumed via `secretKeyRef`/`envFrom`/volume mount
 A linter guarantees that **every referenced item and field actually exists in 1Password**,
 so a typo'd field name or a missing/renamed item is caught before deploy instead of failing
 the operator sync (or crashing the pod) at runtime. It runs offline as the `check:1password`
-turbo task (wired into `bun run verify`, so the `pre-push` hook and CI both enforce it) — by
+turbo task (wired into `bun run verify`, so Buildkite enforces it) — by
 checking the synthesized references against a committed snapshot of vault
 structure — `src/cdk8s/onepassword-vault-snapshot.json`, which holds **only sha256 hashes**
 of item ids/titles/field keys (no values, no plaintext names).
@@ -234,7 +234,8 @@ github.com/1Password/connect-helm-charts#272.
 
 ## Testing Notes
 
-(The `pre-push` hook and CI run `bun run verify`, which includes these tests; run them locally too so you catch failures before pushing.)
+Buildkite runs `bun run verify`, which includes these tests. There is no
+`pre-push` hook; run focused package checks locally while iterating.
 
 ### Run tests from the CDK8s workspace
 
@@ -275,7 +276,7 @@ expected. Run locally with `HELM_RENDER_TEST=1 bun test src/argocd-helm-render.t
 
 ## Git Workflow
 
-- Use conventional commit messages (`type(scope): description`); the `commit-msg` lefthook validates them (`scripts/validate-commit-msg.ts`, scope must be a package name or `root`/`deps`/`ci`/etc.), and the `pre-commit`/`pre-push` hooks run lint/typecheck/verify
+- Use conventional commit messages (`type(scope): description`); the `commit-msg` lefthook validates them (`scripts/validate-commit-msg.ts`, scope must be a package name or `root`/`deps`/`ci`/etc.). The staged-only `pre-commit` hook does not replace Buildkite's full `bun run verify` graph.
 
 ## Version Management
 

--- a/packages/homelab/package.json
+++ b/packages/homelab/package.json
@@ -22,9 +22,9 @@
   },
   "scripts": {
     "build": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit -p tsconfig.scripts.json",
-    "test": "bun test scripts/argocd-manifest-overrides.test.ts scripts/helm-set-version.test.ts scripts/helm-release-core.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts scripts/migration-smoke.test.ts scripts/tracker-tracker.test.ts",
+    "test": "bun test scripts/argocd-apply-safety.test.ts scripts/argocd-manifest-overrides.test.ts scripts/helm-set-version.test.ts scripts/helm-release-core.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts scripts/migration-smoke.test.ts scripts/tracker-tracker.test.ts",
     "test:coverage": "bun test --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage --config ../../scripts/bunfig.coverage.toml --coverage scripts/helm-set-version.test.ts scripts/lint-helm.test.ts scripts/velero-backups.test.ts",
-    "lint": "eslint scripts/argocd-manifest-overrides.ts scripts/argocd-manifest-overrides.test.ts scripts/canonical-json.ts scripts/helm-set-version.ts scripts/helm-set-version.test.ts scripts/helm-release-core.ts scripts/helm-release-core.test.ts scripts/helm-push.ts scripts/lint-helm.ts scripts/lint-helm.test.ts scripts/velero-backups.ts scripts/velero-backups.test.ts scripts/migration-core.ts scripts/migration-smoke.test.ts scripts/tracker-tracker.ts scripts/tracker-tracker.test.ts",
+    "lint": "eslint scripts/argocd-apply-safety.ts scripts/argocd-apply-safety.test.ts scripts/argocd-manifest-overrides.ts scripts/argocd-manifest-overrides.test.ts scripts/canonical-json.ts scripts/helm-set-version.ts scripts/helm-set-version.test.ts scripts/helm-release-core.ts scripts/helm-release-core.test.ts scripts/helm-push.ts scripts/lint-helm.ts scripts/lint-helm.test.ts scripts/velero-backups.ts scripts/velero-backups.test.ts scripts/migration-core.ts scripts/migration-smoke.test.ts scripts/tracker-tracker.ts scripts/tracker-tracker.test.ts",
     "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit -p tsconfig.scripts.json",
     "check:talos": "bun src/talos/update-image-id.ts --check",
     "lint:helm": "bun scripts/lint-helm.ts",

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -279,6 +279,104 @@ describe("ArgoCD immutable nested key removal", () => {
   });
 });
 
+// A claim template is a PersistentVolumeClaim, so the same author-owned keys
+// are immutable inside it. The enclosing list has to tolerate live-only keys
+// because the API server writes them into every template, which is exactly what
+// would otherwise hide a key the author removed from one.
+describe("ArgoCD immutable keys inside a claim template", () => {
+  test("reports an author-owned key dropped from a claim template", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "test",
+          name: "db",
+          liveState: database([
+            {
+              ...declaredClaim,
+              spec: {
+                ...declaredClaim.spec,
+                volumeMode: "Filesystem",
+                storageClassName: "zfs-ssd",
+              },
+            },
+          ]),
+          targetState: database([
+            {
+              ...declaredClaim,
+              spec: { resources: { requests: { storage: "8Gi" } } },
+            },
+          ]),
+        },
+      ]),
+    ).toEqual([
+      "apps/StatefulSet test/db changes immutable /spec/volumeClaimTemplates/[name=data]/spec/accessModes",
+    ]);
+  });
+
+  test("reports a selector label removed inside a claim template", () => {
+    const selected = {
+      ...declaredClaim,
+      spec: {
+        ...declaredClaim.spec,
+        selector: { matchLabels: { tier: "hot", zone: "a" } },
+      },
+    };
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "test",
+          name: "db",
+          liveState: database([selected]),
+          targetState: database([
+            {
+              ...selected,
+              spec: {
+                ...selected.spec,
+                selector: { matchLabels: { tier: "hot" } },
+              },
+            },
+          ]),
+        },
+      ]),
+      // The enclosing list tolerates live-only keys, so it stays silent here
+      // and the finding names the exact template and field instead.
+    ).toEqual([
+      "apps/StatefulSet test/db changes immutable /spec/volumeClaimTemplates/[name=data]/spec/selector",
+    ]);
+  });
+
+  // The tolerance that makes the gap possible must survive: a template carrying
+  // only API-populated additions is still not a declared change.
+  test("ignores a template that differs only by API-populated keys", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "test",
+          name: "db",
+          liveState: database([
+            {
+              ...declaredClaim,
+              spec: {
+                ...declaredClaim.spec,
+                volumeMode: "Filesystem",
+                storageClassName: "zfs-ssd",
+                volumeName: "pvc-123",
+              },
+            },
+          ]),
+          targetState: database([declaredClaim]),
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
 // Omitting an immutable field means something different for each kind of
 // field, so these cover all three: reset to default, removal of an
 // author-owned field, and a server-assigned value the request never sets.

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -5,6 +5,16 @@ function state(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function database(volumeClaimTemplates: readonly unknown[]): string {
+  return state({
+    spec: {
+      serviceName: "db",
+      selector: { matchLabels: { app: "db" } },
+      volumeClaimTemplates,
+    },
+  });
+}
+
 describe("ArgoCD apply safety", () => {
   test("reports immutable StatefulSet template changes", () => {
     const findings = analyzeApplySafety([
@@ -31,44 +41,6 @@ describe("ArgoCD apply safety", () => {
     ]);
     expect(findings).toEqual([
       "apps/StatefulSet loki/loki changes immutable /spec/volumeClaimTemplates",
-    ]);
-  });
-
-  test("reports mutually exclusive probe handler swaps", () => {
-    const findings = analyzeApplySafety([
-      {
-        group: "apps",
-        kind: "Deployment",
-        namespace: "media",
-        name: "relay",
-        liveState: state({
-          spec: {
-            selector: { matchLabels: { app: "relay" } },
-            template: {
-              spec: {
-                containers: [
-                  { name: "relay", livenessProbe: { httpGet: { path: "/" } } },
-                ],
-              },
-            },
-          },
-        }),
-        targetState: state({
-          spec: {
-            selector: { matchLabels: { app: "relay" } },
-            template: {
-              spec: {
-                containers: [
-                  { name: "relay", livenessProbe: { tcpSocket: { port: 80 } } },
-                ],
-              },
-            },
-          },
-        }),
-      },
-    ]);
-    expect(findings).toEqual([
-      "apps/Deployment media/relay changes /spec/template/spec/containers/0/livenessProbe handler from httpGet to tcpSocket; use a resource-scoped replace",
     ]);
   });
 
@@ -139,6 +111,13 @@ describe("ArgoCD apply safety", () => {
   });
 
   test("ignores API-defaulted fields inside an immutable template", () => {
+    const claim = {
+      metadata: { name: "data" },
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        resources: { requests: { storage: "8Gi" } },
+      },
+    };
     expect(
       analyzeApplySafety([
         {
@@ -146,39 +125,72 @@ describe("ArgoCD apply safety", () => {
           kind: "StatefulSet",
           namespace: "test",
           name: "db",
-          liveState: state({
-            spec: {
-              serviceName: "db",
-              selector: { matchLabels: { app: "db" } },
-              volumeClaimTemplates: [
-                {
-                  metadata: { name: "data" },
-                  spec: {
-                    accessModes: ["ReadWriteOnce"],
-                    resources: { requests: { storage: "8Gi" } },
-                    volumeMode: "Filesystem",
-                  },
-                },
-              ],
-            },
-          }),
-          targetState: state({
-            spec: {
-              serviceName: "db",
-              selector: { matchLabels: { app: "db" } },
-              volumeClaimTemplates: [
-                {
-                  metadata: { name: "data" },
-                  spec: {
-                    accessModes: ["ReadWriteOnce"],
-                    resources: { requests: { storage: "8Gi" } },
-                  },
-                },
-              ],
-            },
-          }),
+          liveState: database([
+            { ...claim, spec: { ...claim.spec, volumeMode: "Filesystem" } },
+          ]),
+          targetState: database([claim]),
         },
       ]),
     ).toEqual([]);
+  });
+});
+
+function relayDeployment(
+  liveContainers: readonly unknown[],
+  targetContainers: readonly unknown[],
+) {
+  return {
+    group: "apps",
+    kind: "Deployment",
+    namespace: "media",
+    name: "relay",
+    liveState: state({
+      spec: { template: { spec: { containers: liveContainers } } },
+    }),
+    targetState: state({
+      spec: { template: { spec: { containers: targetContainers } } },
+    }),
+  };
+}
+
+describe("ArgoCD probe handler safety", () => {
+  test("reports mutually exclusive probe handler swaps", () => {
+    expect(
+      analyzeApplySafety([
+        relayDeployment(
+          [{ name: "relay", livenessProbe: { httpGet: { path: "/" } } }],
+          [{ name: "relay", livenessProbe: { tcpSocket: { port: 80 } } }],
+        ),
+      ]),
+    ).toEqual([
+      "apps/Deployment media/relay changes /spec/template/spec/containers/[name=relay]/livenessProbe handler from httpGet to tcpSocket; use a resource-scoped replace",
+    ]);
+  });
+
+  test("correlates probe handlers across reordered containers", () => {
+    const relay = { name: "relay", livenessProbe: { httpGet: { path: "/" } } };
+    const sidecar = {
+      name: "sidecar",
+      livenessProbe: { tcpSocket: { port: 9 } },
+    };
+    expect(
+      analyzeApplySafety([relayDeployment([relay, sidecar], [sidecar, relay])]),
+    ).toEqual([]);
+  });
+
+  test("reports a probe handler swap beside an inserted container", () => {
+    expect(
+      analyzeApplySafety([
+        relayDeployment(
+          [{ name: "relay", livenessProbe: { httpGet: { path: "/" } } }],
+          [
+            { name: "proxy", livenessProbe: { httpGet: { path: "/" } } },
+            { name: "relay", livenessProbe: { tcpSocket: { port: 80 } } },
+          ],
+        ),
+      ]),
+    ).toEqual([
+      "apps/Deployment media/relay changes /spec/template/spec/containers/[name=relay]/livenessProbe handler from httpGet to tcpSocket; use a resource-scoped replace",
+    ]);
   });
 });

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { analyzeApplySafety } from "./argocd-apply-safety.ts";
+
+function state(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe("ArgoCD apply safety", () => {
+  test("reports immutable StatefulSet template changes", () => {
+    const findings = analyzeApplySafety([
+      {
+        group: "apps",
+        kind: "StatefulSet",
+        namespace: "loki",
+        name: "loki",
+        liveState: state({
+          spec: {
+            serviceName: "loki",
+            selector: { matchLabels: { app: "loki" } },
+            volumeClaimTemplates: [{ metadata: { name: "data" } }],
+          },
+        }),
+        targetState: state({
+          spec: {
+            serviceName: "loki",
+            selector: { matchLabels: { app: "loki" } },
+            volumeClaimTemplates: [{ metadata: { name: "storage" } }],
+          },
+        }),
+      },
+    ]);
+    expect(findings).toEqual([
+      "apps/StatefulSet loki/loki changes immutable /spec/volumeClaimTemplates",
+    ]);
+  });
+
+  test("reports mutually exclusive probe handler swaps", () => {
+    const findings = analyzeApplySafety([
+      {
+        group: "apps",
+        kind: "Deployment",
+        namespace: "media",
+        name: "relay",
+        liveState: state({
+          spec: {
+            selector: { matchLabels: { app: "relay" } },
+            template: {
+              spec: {
+                containers: [
+                  { name: "relay", livenessProbe: { httpGet: { path: "/" } } },
+                ],
+              },
+            },
+          },
+        }),
+        targetState: state({
+          spec: {
+            selector: { matchLabels: { app: "relay" } },
+            template: {
+              spec: {
+                containers: [
+                  { name: "relay", livenessProbe: { tcpSocket: { port: 80 } } },
+                ],
+              },
+            },
+          },
+        }),
+      },
+    ]);
+    expect(findings).toEqual([
+      "apps/Deployment media/relay changes /spec/template/spec/containers/0/livenessProbe handler from httpGet to tcpSocket; use a resource-scoped replace",
+    ]);
+  });
+
+  test("allows mutable changes and newly created resources", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "test",
+          name: "api",
+          liveState: state({
+            spec: {
+              replicas: 1,
+              selector: { matchLabels: { app: "api" } },
+            },
+          }),
+          targetState: state({
+            spec: {
+              replicas: 2,
+              selector: { matchLabels: { app: "api" } },
+            },
+          }),
+        },
+        { kind: "Service", name: "new", targetState: state({ spec: {} }) },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("ignores server-assigned immutable fields omitted by the target", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          kind: "Service",
+          namespace: "test",
+          name: "api",
+          liveState: state({
+            spec: {
+              clusterIP: "10.96.0.10",
+              clusterIPs: ["10.96.0.10"],
+              ipFamilies: ["IPv4"],
+            },
+          }),
+          targetState: state({ spec: { ports: [{ port: 80 }] } }),
+        },
+        {
+          kind: "PersistentVolumeClaim",
+          namespace: "test",
+          name: "data",
+          liveState: state({
+            spec: {
+              accessModes: ["ReadWriteOnce"],
+              storageClassName: "zfs-ssd",
+              volumeMode: "Filesystem",
+              volumeName: "pvc-123",
+            },
+          }),
+          targetState: state({
+            spec: {
+              accessModes: ["ReadWriteOnce"],
+              storageClassName: "zfs-ssd",
+              volumeMode: "Filesystem",
+            },
+          }),
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("ignores API-defaulted fields inside an immutable template", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "test",
+          name: "db",
+          liveState: state({
+            spec: {
+              serviceName: "db",
+              selector: { matchLabels: { app: "db" } },
+              volumeClaimTemplates: [
+                {
+                  metadata: { name: "data" },
+                  spec: {
+                    accessModes: ["ReadWriteOnce"],
+                    resources: { requests: { storage: "8Gi" } },
+                    volumeMode: "Filesystem",
+                  },
+                },
+              ],
+            },
+          }),
+          targetState: state({
+            spec: {
+              serviceName: "db",
+              selector: { matchLabels: { app: "db" } },
+              volumeClaimTemplates: [
+                {
+                  metadata: { name: "data" },
+                  spec: {
+                    accessModes: ["ReadWriteOnce"],
+                    resources: { requests: { storage: "8Gi" } },
+                  },
+                },
+              ],
+            },
+          }),
+        },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -92,6 +92,35 @@ describe("ArgoCD apply safety", () => {
     ]);
   });
 
+  test("reports dropping a non-default immutable field", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "media",
+          name: "index",
+          // Omitting the field resets it toward OrderedReady, which the API
+          // server rejects just as it rejects an explicit change.
+          liveState: state({ spec: { podManagementPolicy: "Parallel" } }),
+          targetState: state({ spec: { replicas: 2 } }),
+        },
+        {
+          kind: "PersistentVolumeClaim",
+          namespace: "media",
+          name: "blocks",
+          liveState: state({
+            spec: { accessModes: ["ReadWriteOnce"], volumeMode: "Block" },
+          }),
+          targetState: state({ spec: { accessModes: ["ReadWriteOnce"] } }),
+        },
+      ]),
+    ).toEqual([
+      "apps/StatefulSet media/index changes immutable /spec/podManagementPolicy",
+      "/PersistentVolumeClaim media/blocks changes immutable /spec/volumeMode",
+    ]);
+  });
+
   test("allows mutable changes and newly created resources", () => {
     expect(
       analyzeApplySafety([

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -92,6 +92,61 @@ describe("ArgoCD apply safety", () => {
     ]);
   });
 
+  test("allows mutable changes and newly created resources", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "test",
+          name: "api",
+          liveState: state({
+            spec: {
+              replicas: 1,
+              selector: { matchLabels: { app: "api" } },
+            },
+          }),
+          targetState: state({
+            spec: {
+              replicas: 2,
+              selector: { matchLabels: { app: "api" } },
+            },
+          }),
+        },
+        { kind: "Service", name: "new", targetState: state({ spec: {} }) },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("ignores API-defaulted fields inside an immutable template", () => {
+    const claim = {
+      metadata: { name: "data" },
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        resources: { requests: { storage: "8Gi" } },
+      },
+    };
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "test",
+          name: "db",
+          liveState: database([
+            { ...claim, spec: { ...claim.spec, volumeMode: "Filesystem" } },
+          ]),
+          targetState: database([claim]),
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+// Omitting an immutable field means something different for each kind of
+// field, so these cover all three: reset to default, removal of an
+// author-owned field, and a server-assigned value the request never sets.
+describe("ArgoCD immutable field omission", () => {
   test("reports dropping a non-default immutable field", () => {
     expect(
       analyzeApplySafety([
@@ -121,30 +176,32 @@ describe("ArgoCD apply safety", () => {
     ]);
   });
 
-  test("allows mutable changes and newly created resources", () => {
+  test("reports removing an author-owned immutable field", () => {
     expect(
       analyzeApplySafety([
         {
           group: "apps",
-          kind: "Deployment",
-          namespace: "test",
-          name: "api",
-          liveState: state({
-            spec: {
-              replicas: 1,
-              selector: { matchLabels: { app: "api" } },
-            },
-          }),
-          targetState: state({
-            spec: {
-              replicas: 2,
-              selector: { matchLabels: { app: "api" } },
-            },
-          }),
+          kind: "StatefulSet",
+          namespace: "media",
+          name: "index",
+          // Nothing defaults serviceName, so dropping it removes a managed
+          // immutable field rather than resetting it.
+          liveState: state({ spec: { serviceName: "index", replicas: 1 } }),
+          targetState: state({ spec: { replicas: 2 } }),
         },
-        { kind: "Service", name: "new", targetState: state({ spec: {} }) },
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "media",
+          name: "relay",
+          liveState: state({ spec: { selector: { matchLabels: { a: "b" } } } }),
+          targetState: state({ spec: { replicas: 2 } }),
+        },
       ]),
-    ).toEqual([]);
+    ).toEqual([
+      "apps/StatefulSet media/index changes immutable /spec/serviceName",
+      "apps/Deployment media/relay changes immutable /spec/selector",
+    ]);
   });
 
   test("ignores server-assigned immutable fields omitted by the target", () => {
@@ -182,30 +239,6 @@ describe("ArgoCD apply safety", () => {
               volumeMode: "Filesystem",
             },
           }),
-        },
-      ]),
-    ).toEqual([]);
-  });
-
-  test("ignores API-defaulted fields inside an immutable template", () => {
-    const claim = {
-      metadata: { name: "data" },
-      spec: {
-        accessModes: ["ReadWriteOnce"],
-        resources: { requests: { storage: "8Gi" } },
-      },
-    };
-    expect(
-      analyzeApplySafety([
-        {
-          group: "apps",
-          kind: "StatefulSet",
-          namespace: "test",
-          name: "db",
-          liveState: database([
-            { ...claim, spec: { ...claim.spec, volumeMode: "Filesystem" } },
-          ]),
-          targetState: database([claim]),
         },
       ]),
     ).toEqual([]);

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -24,6 +24,28 @@ const declaredClaim = {
   },
 };
 
+// A StatefulSet whose live claim template carries keys the API server added on
+// top of what the chart declared, which is the state that makes an author-owned
+// removal easy to miss.
+function databaseWithApiPopulatedClaim(
+  apiPopulated: Record<string, unknown>,
+  targetClaim: unknown = declaredClaim,
+) {
+  return {
+    group: "apps",
+    kind: "StatefulSet",
+    namespace: "test",
+    name: "db",
+    liveState: database([
+      {
+        ...declaredClaim,
+        spec: { ...declaredClaim.spec, ...apiPopulated },
+      },
+    ]),
+    targetState: database([targetClaim]),
+  };
+}
+
 describe("ArgoCD apply safety", () => {
   test("reports immutable StatefulSet template changes", () => {
     const findings = analyzeApplySafety([
@@ -163,21 +185,66 @@ describe("ArgoCD apply safety", () => {
   test("ignores API-defaulted fields inside an immutable template", () => {
     expect(
       analyzeApplySafety([
+        databaseWithApiPopulatedClaim({ volumeMode: "Filesystem" }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+// The preflight reads every managed resource in the application, so an
+// unreadable one has to name itself. Staying fatal is the point — reporting no
+// immutable changes for a resource nobody could inspect is the failure mode
+// worth avoiding — but a bare JSON or Zod message identifies nothing.
+describe("ArgoCD apply safety on unreadable state", () => {
+  test("names the resource and side when live state will not parse", () => {
+    expect(() =>
+      analyzeApplySafety([
         {
           group: "apps",
           kind: "StatefulSet",
-          namespace: "test",
-          name: "db",
-          liveState: database([
-            {
-              ...declaredClaim,
-              spec: { ...declaredClaim.spec, volumeMode: "Filesystem" },
-            },
-          ]),
-          targetState: database([declaredClaim]),
+          namespace: "media",
+          name: "index",
+          liveState: "{not json",
+          targetState: state({ spec: {} }),
         },
       ]),
-    ).toEqual([]);
+    ).toThrow("Could not read liveState for apps/StatefulSet media/index");
+  });
+
+  test("names the resource and side when target state is not an object", () => {
+    expect(() =>
+      analyzeApplySafety([
+        {
+          kind: "PersistentVolumeClaim",
+          namespace: "media",
+          name: "data",
+          liveState: state({ spec: {} }),
+          targetState: "[1,2,3]",
+        },
+      ]),
+    ).toThrow(
+      "Could not read targetState for /PersistentVolumeClaim media/data",
+    );
+  });
+
+  test("preserves the underlying parse error as the cause", () => {
+    try {
+      analyzeApplySafety([
+        {
+          kind: "Service",
+          namespace: "test",
+          name: "api",
+          liveState: "{not json",
+          targetState: state({ spec: {} }),
+        },
+      ]);
+      throw new Error("expected analyzeApplySafety to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error instanceof Error ? error.cause : undefined).toBeInstanceOf(
+        Error,
+      );
+    }
   });
 });
 
@@ -287,28 +354,13 @@ describe("ArgoCD immutable keys inside a claim template", () => {
   test("reports an author-owned key dropped from a claim template", () => {
     expect(
       analyzeApplySafety([
-        {
-          group: "apps",
-          kind: "StatefulSet",
-          namespace: "test",
-          name: "db",
-          liveState: database([
-            {
-              ...declaredClaim,
-              spec: {
-                ...declaredClaim.spec,
-                volumeMode: "Filesystem",
-                storageClassName: "zfs-ssd",
-              },
-            },
-          ]),
-          targetState: database([
-            {
-              ...declaredClaim,
-              spec: { resources: { requests: { storage: "8Gi" } } },
-            },
-          ]),
-        },
+        databaseWithApiPopulatedClaim(
+          { volumeMode: "Filesystem", storageClassName: "zfs-ssd" },
+          {
+            ...declaredClaim,
+            spec: { resources: { requests: { storage: "8Gi" } } },
+          },
+        ),
       ]),
     ).toEqual([
       "apps/StatefulSet test/db changes immutable /spec/volumeClaimTemplates/[name=data]/spec/accessModes",
@@ -354,24 +406,11 @@ describe("ArgoCD immutable keys inside a claim template", () => {
   test("ignores a template that differs only by API-populated keys", () => {
     expect(
       analyzeApplySafety([
-        {
-          group: "apps",
-          kind: "StatefulSet",
-          namespace: "test",
-          name: "db",
-          liveState: database([
-            {
-              ...declaredClaim,
-              spec: {
-                ...declaredClaim.spec,
-                volumeMode: "Filesystem",
-                storageClassName: "zfs-ssd",
-                volumeName: "pvc-123",
-              },
-            },
-          ]),
-          targetState: database([declaredClaim]),
-        },
+        databaseWithApiPopulatedClaim({
+          volumeMode: "Filesystem",
+          storageClassName: "zfs-ssd",
+          volumeName: "pvc-123",
+        }),
       ]),
     ).toEqual([]);
   });

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -65,6 +65,33 @@ describe("ArgoCD apply safety", () => {
     ]);
   });
 
+  test("reports an immutable StatefulSet pod management change", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "media",
+          name: "index",
+          liveState: state({ spec: { podManagementPolicy: "OrderedReady" } }),
+          targetState: state({ spec: { podManagementPolicy: "Parallel" } }),
+        },
+        // The API server defaults this field, so a chart that leaves it out is
+        // not declaring a change and must not be reported.
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "media",
+          name: "cache",
+          liveState: state({ spec: { podManagementPolicy: "OrderedReady" } }),
+          targetState: state({ spec: { replicas: 2 } }),
+        },
+      ]),
+    ).toEqual([
+      "apps/StatefulSet media/index changes immutable /spec/podManagementPolicy",
+    ]);
+  });
+
   test("allows mutable changes and newly created resources", () => {
     expect(
       analyzeApplySafety([

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -15,6 +15,15 @@ function database(volumeClaimTemplates: readonly unknown[]): string {
   });
 }
 
+// Exactly what a chart declares for a claim template: no API-populated keys.
+const declaredClaim = {
+  metadata: { name: "data" },
+  spec: {
+    accessModes: ["ReadWriteOnce"],
+    resources: { requests: { storage: "8Gi" } },
+  },
+};
+
 describe("ArgoCD apply safety", () => {
   test("reports immutable StatefulSet template changes", () => {
     const findings = analyzeApplySafety([
@@ -152,13 +161,6 @@ describe("ArgoCD apply safety", () => {
   });
 
   test("ignores API-defaulted fields inside an immutable template", () => {
-    const claim = {
-      metadata: { name: "data" },
-      spec: {
-        accessModes: ["ReadWriteOnce"],
-        resources: { requests: { storage: "8Gi" } },
-      },
-    };
     expect(
       analyzeApplySafety([
         {
@@ -167,9 +169,110 @@ describe("ArgoCD apply safety", () => {
           namespace: "test",
           name: "db",
           liveState: database([
-            { ...claim, spec: { ...claim.spec, volumeMode: "Filesystem" } },
+            {
+              ...declaredClaim,
+              spec: { ...declaredClaim.spec, volumeMode: "Filesystem" },
+            },
           ]),
-          targetState: database([claim]),
+          targetState: database([declaredClaim]),
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+// Dropping a key *inside* a declared immutable field is as rejectable as
+// changing one, but comparing only the target's keys reported it as no change.
+describe("ArgoCD immutable nested key removal", () => {
+  test("reports a selector label removed from the declaration", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "DaemonSet",
+          namespace: "observability",
+          name: "alloy",
+          liveState: state({
+            spec: { selector: { matchLabels: { app: "alloy", tier: "logs" } } },
+          }),
+          targetState: state({
+            spec: { selector: { matchLabels: { app: "alloy" } } },
+          }),
+        },
+        {
+          kind: "PersistentVolumeClaim",
+          namespace: "media",
+          name: "data",
+          liveState: state({
+            spec: { selector: { matchLabels: { tier: "hot", zone: "a" } } },
+          }),
+          targetState: state({
+            spec: { selector: { matchLabels: { tier: "hot" } } },
+          }),
+        },
+      ]),
+    ).toEqual([
+      "apps/DaemonSet observability/alloy changes immutable /spec/selector",
+      "/PersistentVolumeClaim media/data changes immutable /spec/selector",
+    ]);
+  });
+
+  test("reports a matchExpressions entry removed from a selector", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "media",
+          name: "relay",
+          liveState: state({
+            spec: {
+              selector: {
+                matchLabels: { app: "relay" },
+                matchExpressions: [
+                  { key: "tier", operator: "In", values: ["hot"] },
+                ],
+              },
+            },
+          }),
+          targetState: state({
+            spec: { selector: { matchLabels: { app: "relay" } } },
+          }),
+        },
+      ]),
+    ).toEqual(["apps/Deployment media/relay changes immutable /spec/selector"]);
+  });
+
+  // The opposite classification: the API server owns keys inside a claim
+  // template, so a live-only key there is its doing and must stay silent even
+  // though the identical shape is a finding for a selector.
+  test("ignores API-populated keys nested deep inside a claim template", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "StatefulSet",
+          namespace: "test",
+          name: "db",
+          liveState: database([
+            {
+              ...declaredClaim,
+              metadata: {
+                ...declaredClaim.metadata,
+                creationTimestamp: null,
+              },
+              spec: {
+                ...declaredClaim.spec,
+                volumeMode: "Filesystem",
+                storageClassName: "zfs-ssd",
+                resources: {
+                  requests: { storage: "8Gi" },
+                  limits: { storage: "8Gi" },
+                },
+              },
+            },
+          ]),
+          targetState: database([declaredClaim]),
         },
       ]),
     ).toEqual([]);

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -92,6 +92,39 @@ describe("ArgoCD apply safety", () => {
     ]);
   });
 
+  test("reports immutable PersistentVolumeClaim selector changes", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          kind: "PersistentVolumeClaim",
+          namespace: "media",
+          name: "changed",
+          liveState: state({
+            spec: { selector: { matchLabels: { tier: "hot" } } },
+          }),
+          targetState: state({
+            spec: { selector: { matchLabels: { tier: "cold" } } },
+          }),
+        },
+        {
+          kind: "PersistentVolumeClaim",
+          namespace: "media",
+          name: "dropped",
+          liveState: state({
+            spec: {
+              selector: { matchLabels: { tier: "hot" } },
+              volumeMode: "Filesystem",
+            },
+          }),
+          targetState: state({ spec: { volumeMode: "Filesystem" } }),
+        },
+      ]),
+    ).toEqual([
+      "/PersistentVolumeClaim media/changed changes immutable /spec/selector",
+      "/PersistentVolumeClaim media/dropped changes immutable /spec/selector",
+    ]);
+  });
+
   test("allows mutable changes and newly created resources", () => {
     expect(
       analyzeApplySafety([

--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -44,6 +44,27 @@ describe("ArgoCD apply safety", () => {
     ]);
   });
 
+  test("reports an immutable DaemonSet selector change", () => {
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "DaemonSet",
+          namespace: "observability",
+          name: "alloy",
+          liveState: state({
+            spec: { selector: { matchLabels: { app: "alloy" } } },
+          }),
+          targetState: state({
+            spec: { selector: { matchLabels: { app: "alloy-logs" } } },
+          }),
+        },
+      ]),
+    ).toEqual([
+      "apps/DaemonSet observability/alloy changes immutable /spec/selector",
+    ]);
+  });
+
   test("allows mutable changes and newly created resources", () => {
     expect(
       analyzeApplySafety([

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -13,7 +13,7 @@ export const ManagedResourcesSchema = z.object({
   items: z.array(ManagedResourceSchema),
 });
 
-type ManagedResource = z.infer<typeof ManagedResourceSchema>;
+export type ManagedResource = z.infer<typeof ManagedResourceSchema>;
 
 const JsonObjectSchema = z.record(z.string(), z.unknown());
 const PROBE_HANDLERS = ["exec", "grpc", "httpGet", "tcpSocket"] as const;
@@ -82,14 +82,40 @@ function activeProbeHandler(probe: Record<string, unknown>): string | null {
   return handlers.length === 1 ? (handlers[0] ?? null) : null;
 }
 
+/**
+ * Kubernetes merges container and init-container lists by `name`, so a chart
+ * that inserts or reorders an entry leaves every other container untouched.
+ * Key such lists by name and fall back to positions only for lists that are
+ * not name-keyed, so a probe path identifies the same container on both sides.
+ */
+function arrayEntrySegments(entries: readonly unknown[]): readonly string[] {
+  const names = entries.flatMap((entry) => {
+    const parsed = JsonObjectSchema.safeParse(entry);
+    if (!parsed.success) {
+      return [];
+    }
+    const name = parsed.data["name"];
+    return typeof name === "string" && name !== "" ? [name] : [];
+  });
+  if (names.length !== entries.length || new Set(names).size !== names.length) {
+    return entries.map((_entry, index) => index.toString());
+  }
+  return names.map((name) => `[name=${name}]`);
+}
+
 function collectProbeHandlers(
   value: unknown,
   path: string,
   output: Map<string, string>,
 ): void {
   if (Array.isArray(value)) {
+    const segments = arrayEntrySegments(value);
     for (const [index, entry] of value.entries()) {
-      collectProbeHandlers(entry, `${path}/${index.toString()}`, output);
+      collectProbeHandlers(
+        entry,
+        `${path}/${segments[index] ?? index.toString()}`,
+        output,
+      );
     }
     return;
   }

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -18,13 +18,29 @@ export type ManagedResource = z.infer<typeof ManagedResourceSchema>;
 const JsonObjectSchema = z.record(z.string(), z.unknown());
 const PROBE_HANDLERS = ["exec", "grpc", "httpGet", "tcpSocket"] as const;
 
+/**
+ * Unreadable state stays fatal — a resource whose live or target state cannot
+ * be parsed is a broken contract, not a finding, and continuing would report
+ * "no immutable changes" for a resource nobody actually inspected. But the
+ * failure has to say which resource and which side, because the preflight
+ * reads every managed resource in the application and a bare JSON or Zod
+ * message names none of them.
+ */
 function parseObject(
   source: string | undefined,
+  resource: ManagedResource,
+  field: "liveState" | "targetState",
 ): Record<string, unknown> | null {
   if (source === undefined || source === "" || source === "null") {
     return null;
   }
-  return JsonObjectSchema.parse(JSON.parse(source));
+  try {
+    return JsonObjectSchema.parse(JSON.parse(source));
+  } catch (error) {
+    throw new Error(`Could not read ${field} for ${identity(resource)}`, {
+      cause: error,
+    });
+  }
 }
 
 function valueAt(
@@ -431,8 +447,8 @@ export function analyzeApplySafety(
 ): readonly string[] {
   const findings: string[] = [];
   for (const resource of resources) {
-    const live = parseObject(resource.liveState);
-    const target = parseObject(resource.targetState);
+    const live = parseObject(resource.liveState, resource, "liveState");
+    const target = parseObject(resource.targetState, resource, "targetState");
     if (live === null || target === null) {
       continue;
     }

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -155,6 +155,7 @@ function immutablePaths(kind: string): readonly (readonly string[])[] {
       return [["spec", "selector"]];
     case "StatefulSet":
       return [
+        ["spec", "podManagementPolicy"],
         ["spec", "selector"],
         ["spec", "serviceName"],
         ["spec", "volumeClaimTemplates"],

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -228,6 +228,9 @@ function immutableFields(kind: string): readonly ImmutableField[] {
         // fail every such claim, so under-report rather than block releases.
         { path: ["spec", "dataSource"], omission: "keeps-live-value" },
         { path: ["spec", "dataSourceRef"], omission: "keeps-live-value" },
+        // Binds the claim to a matching volume. The author owns it and nothing
+        // defaults it, so changing or dropping it is an immutable update.
+        { path: ["spec", "selector"], omission: "removes-managed-field" },
         // Defaulted from the cluster's default StorageClass at creation, so a
         // live claim carries one whether or not the chart ever declared it.
         { path: ["spec", "storageClassName"], omission: "keeps-live-value" },

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -63,16 +63,33 @@ function targetMatchesLive(target: unknown, live: unknown): boolean {
   return JSON.stringify(target) === JSON.stringify(live);
 }
 
+type ImmutableField = {
+  readonly path: readonly string[];
+  /**
+   * The value the API server assigns when the field is omitted. Present only
+   * for fields that are defaulted rather than server-assigned: dropping a
+   * non-default value resets it toward this default, which is itself an
+   * immutable update. A field without a default keeps its live value when the
+   * target omits it, so omission declares no change there.
+   */
+  readonly apiDefault?: string;
+};
+
 function declaredTargetChanged(
   live: Record<string, unknown>,
   target: Record<string, unknown>,
-  path: readonly string[],
+  field: ImmutableField,
 ): boolean {
-  const targetValue = valueAt(target, path);
-  return (
-    targetValue !== undefined &&
-    !targetMatchesLive(targetValue, valueAt(live, path))
-  );
+  const targetValue = valueAt(target, field.path);
+  const liveValue = valueAt(live, field.path);
+  if (targetValue === undefined) {
+    return (
+      field.apiDefault !== undefined &&
+      liveValue !== undefined &&
+      liveValue !== field.apiDefault
+    );
+  }
+  return !targetMatchesLive(targetValue, liveValue);
 }
 
 function activeProbeHandler(probe: Record<string, unknown>): string | null {
@@ -146,34 +163,37 @@ function identity(resource: ManagedResource): string {
   return `${resource.group ?? ""}/${resource.kind} ${resource.namespace ?? "_cluster"}/${resource.name}`;
 }
 
-function immutablePaths(kind: string): readonly (readonly string[])[] {
+function immutableFields(kind: string): readonly ImmutableField[] {
   switch (kind) {
     // A DaemonSet's selector is as immutable as a Deployment's; the API server
     // rejects the update rather than replacing the workload.
     case "DaemonSet":
     case "Deployment":
-      return [["spec", "selector"]];
+      return [{ path: ["spec", "selector"] }];
     case "StatefulSet":
       return [
-        ["spec", "podManagementPolicy"],
-        ["spec", "selector"],
-        ["spec", "serviceName"],
-        ["spec", "volumeClaimTemplates"],
+        {
+          path: ["spec", "podManagementPolicy"],
+          apiDefault: "OrderedReady",
+        },
+        { path: ["spec", "selector"] },
+        { path: ["spec", "serviceName"] },
+        { path: ["spec", "volumeClaimTemplates"] },
       ];
     case "PersistentVolumeClaim":
       return [
-        ["spec", "accessModes"],
-        ["spec", "dataSource"],
-        ["spec", "dataSourceRef"],
-        ["spec", "storageClassName"],
-        ["spec", "volumeMode"],
-        ["spec", "volumeName"],
+        { path: ["spec", "accessModes"] },
+        { path: ["spec", "dataSource"] },
+        { path: ["spec", "dataSourceRef"] },
+        { path: ["spec", "storageClassName"] },
+        { path: ["spec", "volumeMode"], apiDefault: "Filesystem" },
+        { path: ["spec", "volumeName"] },
       ];
     case "Service":
       return [
-        ["spec", "clusterIP"],
-        ["spec", "clusterIPs"],
-        ["spec", "ipFamilies"],
+        { path: ["spec", "clusterIP"] },
+        { path: ["spec", "clusterIPs"] },
+        { path: ["spec", "ipFamilies"] },
       ];
     default:
       return [];
@@ -190,10 +210,10 @@ export function analyzeApplySafety(
     if (live === null || target === null) {
       continue;
     }
-    for (const path of immutablePaths(resource.kind)) {
-      if (declaredTargetChanged(live, target, path)) {
+    for (const field of immutableFields(resource.kind)) {
+      if (declaredTargetChanged(live, target, field)) {
         findings.push(
-          `${identity(resource)} changes immutable /${path.join("/")}`,
+          `${identity(resource)} changes immutable /${field.path.join("/")}`,
         );
       }
     }

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -63,17 +63,56 @@ function targetMatchesLive(target: unknown, live: unknown): boolean {
   return JSON.stringify(target) === JSON.stringify(live);
 }
 
+/**
+ * What it means for the requested target to omit an immutable field. "No
+ * default" was previously conflated into one case, which hid a real class of
+ * change: a field the chart author owns is not the same as one the API server
+ * populates. Every immutable field must say which it is, so adding one forces
+ * the question rather than defaulting to silence.
+ */
 type ImmutableField = {
   readonly path: readonly string[];
-  /**
-   * The value the API server assigns when the field is omitted. Present only
-   * for fields that are defaulted rather than server-assigned: dropping a
-   * non-default value resets it toward this default, which is itself an
-   * immutable update. A field without a default keeps its live value when the
-   * target omits it, so omission declares no change there.
-   */
-  readonly apiDefault?: string;
-};
+} & (
+  | {
+      /**
+       * The API server populates it and keeps the live value when the request
+       * omits it, so omission declares no change. Flagging it would fail every
+       * release whose chart simply never mentions the field.
+       */
+      readonly omission: "keeps-live-value";
+    }
+  | {
+      /**
+       * The API server defaults it, so omitting it resets the field to that
+       * default. That is a change exactly when the live value is not already
+       * the default.
+       */
+      readonly omission: "resets-to-default";
+      readonly apiDefault: string;
+    }
+  | {
+      /**
+       * The chart author owns it and the API server neither populates nor
+       * defaults it, so removing the declaration removes a previously managed
+       * immutable field. Kubernetes rejects that like any other change to it.
+       */
+      readonly omission: "removes-managed-field";
+    }
+);
+
+function omissionChanges(field: ImmutableField, liveValue: unknown): boolean {
+  if (liveValue === undefined) {
+    return false;
+  }
+  switch (field.omission) {
+    case "keeps-live-value":
+      return false;
+    case "resets-to-default":
+      return liveValue !== field.apiDefault;
+    case "removes-managed-field":
+      return true;
+  }
+}
 
 function declaredTargetChanged(
   live: Record<string, unknown>,
@@ -82,14 +121,9 @@ function declaredTargetChanged(
 ): boolean {
   const targetValue = valueAt(target, field.path);
   const liveValue = valueAt(live, field.path);
-  if (targetValue === undefined) {
-    return (
-      field.apiDefault !== undefined &&
-      liveValue !== undefined &&
-      liveValue !== field.apiDefault
-    );
-  }
-  return !targetMatchesLive(targetValue, liveValue);
+  return targetValue === undefined
+    ? omissionChanges(field, liveValue)
+    : !targetMatchesLive(targetValue, liveValue);
 }
 
 function activeProbeHandler(probe: Record<string, unknown>): string | null {
@@ -169,31 +203,47 @@ function immutableFields(kind: string): readonly ImmutableField[] {
     // rejects the update rather than replacing the workload.
     case "DaemonSet":
     case "Deployment":
-      return [{ path: ["spec", "selector"] }];
+      return [
+        { path: ["spec", "selector"], omission: "removes-managed-field" },
+      ];
     case "StatefulSet":
       return [
         {
           path: ["spec", "podManagementPolicy"],
+          omission: "resets-to-default",
           apiDefault: "OrderedReady",
         },
-        { path: ["spec", "selector"] },
-        { path: ["spec", "serviceName"] },
-        { path: ["spec", "volumeClaimTemplates"] },
+        { path: ["spec", "selector"], omission: "removes-managed-field" },
+        { path: ["spec", "serviceName"], omission: "removes-managed-field" },
+        {
+          path: ["spec", "volumeClaimTemplates"],
+          omission: "removes-managed-field",
+        },
       ];
     case "PersistentVolumeClaim":
       return [
-        { path: ["spec", "accessModes"] },
-        { path: ["spec", "dataSource"] },
-        { path: ["spec", "dataSourceRef"] },
-        { path: ["spec", "storageClassName"] },
-        { path: ["spec", "volumeMode"], apiDefault: "Filesystem" },
-        { path: ["spec", "volumeName"] },
+        { path: ["spec", "accessModes"], omission: "removes-managed-field" },
+        // The API server cross-populates these two, so a claim authored with
+        // only one of them reports both. Treating an omission as a change would
+        // fail every such claim, so under-report rather than block releases.
+        { path: ["spec", "dataSource"], omission: "keeps-live-value" },
+        { path: ["spec", "dataSourceRef"], omission: "keeps-live-value" },
+        // Defaulted from the cluster's default StorageClass at creation, so a
+        // live claim carries one whether or not the chart ever declared it.
+        { path: ["spec", "storageClassName"], omission: "keeps-live-value" },
+        {
+          path: ["spec", "volumeMode"],
+          omission: "resets-to-default",
+          apiDefault: "Filesystem",
+        },
+        { path: ["spec", "volumeName"], omission: "keeps-live-value" },
       ];
     case "Service":
+      // All three are assigned by the cluster, not the chart.
       return [
-        { path: ["spec", "clusterIP"] },
-        { path: ["spec", "clusterIPs"] },
-        { path: ["spec", "ipFamilies"] },
+        { path: ["spec", "clusterIP"], omission: "keeps-live-value" },
+        { path: ["spec", "clusterIPs"], omission: "keeps-live-value" },
+        { path: ["spec", "ipFamilies"], omission: "keeps-live-value" },
       ];
     default:
       return [];

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -148,6 +148,9 @@ function identity(resource: ManagedResource): string {
 
 function immutablePaths(kind: string): readonly (readonly string[])[] {
   switch (kind) {
+    // A DaemonSet's selector is as immutable as a Deployment's; the API server
+    // rejects the update rather than replacing the workload.
+    case "DaemonSet":
     case "Deployment":
       return [["spec", "selector"]];
     case "StatefulSet":

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -163,6 +163,85 @@ function declaredTargetChanged(
     : !targetMatchesLive(targetValue, liveValue, field.liveOnlyKeys);
 }
 
+/**
+ * A list whose entries are themselves resources of a known kind, compared with
+ * that kind's own immutable-field rules.
+ *
+ * The surrounding list has to tolerate live-only keys, because the API server
+ * writes them into every entry. That tolerance is what lets an author-owned key
+ * removed from one entry — dropping `accessModes` from a claim template — read
+ * as no change. Descending with the entry kind's rules recovers the precision:
+ * each of those fields already declares whether the API server owns it, so the
+ * classification comes from one reviewed table rather than a second list of
+ * server-defaulted keys that would drift with every Kubernetes release.
+ */
+type EmbeddedResourceList = {
+  readonly path: readonly string[];
+  readonly entryKind: string;
+};
+
+function embeddedResourceLists(kind: string): readonly EmbeddedResourceList[] {
+  switch (kind) {
+    case "StatefulSet":
+      return [
+        {
+          path: ["spec", "volumeClaimTemplates"],
+          entryKind: "PersistentVolumeClaim",
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+function entriesByName(value: unknown): Map<string, Record<string, unknown>> {
+  const byName = new Map<string, Record<string, unknown>>();
+  if (!Array.isArray(value)) {
+    return byName;
+  }
+  for (const entry of value) {
+    const parsed = JsonObjectSchema.safeParse(entry);
+    if (!parsed.success) {
+      continue;
+    }
+    const name = valueAt(parsed.data, ["metadata", "name"]);
+    if (typeof name === "string" && name !== "") {
+      byName.set(name, parsed.data);
+    }
+  }
+  return byName;
+}
+
+/**
+ * Entries are matched by name rather than position: the enclosing list already
+ * reports an added, removed, or reordered entry, so descending by index would
+ * only restate that as a pile of per-field findings.
+ */
+function embeddedListFindings(
+  live: Record<string, unknown>,
+  target: Record<string, unknown>,
+  list: EmbeddedResourceList,
+  resourceIdentity: string,
+): readonly string[] {
+  const liveEntries = entriesByName(valueAt(live, list.path));
+  const targetEntries = entriesByName(valueAt(target, list.path));
+  const findings: string[] = [];
+  for (const [name, targetEntry] of targetEntries) {
+    const liveEntry = liveEntries.get(name);
+    if (liveEntry === undefined) {
+      continue;
+    }
+    for (const field of immutableFields(list.entryKind)) {
+      if (declaredTargetChanged(liveEntry, targetEntry, field)) {
+        findings.push(
+          `${resourceIdentity} changes immutable /${list.path.join("/")}/[name=${name}]/${field.path.join("/")}`,
+        );
+      }
+    }
+  }
+  return findings;
+}
+
 function activeProbeHandler(probe: Record<string, unknown>): string | null {
   const handlers = PROBE_HANDLERS.filter(
     (handler) => probe[handler] !== undefined,
@@ -363,6 +442,11 @@ export function analyzeApplySafety(
           `${identity(resource)} changes immutable /${field.path.join("/")}`,
         );
       }
+    }
+    for (const list of embeddedResourceLists(resource.kind)) {
+      findings.push(
+        ...embeddedListFindings(live, target, list, identity(resource)),
+      );
     }
     const liveProbes = new Map<string, string>();
     const targetProbes = new Map<string, string>();

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -42,22 +42,58 @@ function valueAt(
   return current;
 }
 
-function targetMatchesLive(target: unknown, live: unknown): boolean {
+/**
+ * What a key found only in the live value means. `omission` below classifies
+ * dropping a whole immutable field; this classifies dropping something inside
+ * one. Comparing only the target's keys answered that silently as "no change",
+ * so removing a selector label passed the preflight and was rejected later by
+ * the API server, mid-release, after earlier resources had already applied.
+ */
+type LiveOnlyKeys =
+  /**
+   * The API server populates keys the request never sets, so a live-only key
+   * is its doing rather than a removal. Only the declared keys can be
+   * compared; flagging the rest would fail every release whose chart omits a
+   * defaulted key.
+   */
+  | "api-populates"
+  /**
+   * The chart author owns every key, so a key that exists only in live was
+   * removed from the declaration. Kubernetes rejects that like any other
+   * change to an immutable field.
+   */
+  | "removes-managed-key";
+
+function targetMatchesLive(
+  target: unknown,
+  live: unknown,
+  liveOnlyKeys: LiveOnlyKeys,
+): boolean {
   if (Array.isArray(target)) {
     return (
       Array.isArray(live) &&
       target.length === live.length &&
-      target.every((entry, index) => targetMatchesLive(entry, live[index]))
+      target.every((entry, index) =>
+        targetMatchesLive(entry, live[index], liveOnlyKeys),
+      )
     );
   }
   const targetObject = JsonObjectSchema.safeParse(target);
   if (targetObject.success) {
     const liveObject = JsonObjectSchema.safeParse(live);
-    return (
-      liveObject.success &&
-      Object.entries(targetObject.data).every(([key, value]) =>
-        targetMatchesLive(value, liveObject.data[key]),
+    if (!liveObject.success) {
+      return false;
+    }
+    if (
+      liveOnlyKeys === "removes-managed-key" &&
+      Object.keys(liveObject.data).some(
+        (key) => !Object.hasOwn(targetObject.data, key),
       )
+    ) {
+      return false;
+    }
+    return Object.entries(targetObject.data).every(([key, value]) =>
+      targetMatchesLive(value, liveObject.data[key], liveOnlyKeys),
     );
   }
   return JSON.stringify(target) === JSON.stringify(live);
@@ -72,6 +108,7 @@ function targetMatchesLive(target: unknown, live: unknown): boolean {
  */
 type ImmutableField = {
   readonly path: readonly string[];
+  readonly liveOnlyKeys: LiveOnlyKeys;
 } & (
   | {
       /**
@@ -123,7 +160,7 @@ function declaredTargetChanged(
   const liveValue = valueAt(live, field.path);
   return targetValue === undefined
     ? omissionChanges(field, liveValue)
-    : !targetMatchesLive(targetValue, liveValue);
+    : !targetMatchesLive(targetValue, liveValue, field.liveOnlyKeys);
 }
 
 function activeProbeHandler(probe: Record<string, unknown>): string | null {
@@ -204,7 +241,11 @@ function immutableFields(kind: string): readonly ImmutableField[] {
     case "DaemonSet":
     case "Deployment":
       return [
-        { path: ["spec", "selector"], omission: "removes-managed-field" },
+        {
+          path: ["spec", "selector"],
+          omission: "removes-managed-field",
+          liveOnlyKeys: "removes-managed-key",
+        },
       ];
     case "StatefulSet":
       return [
@@ -212,41 +253,94 @@ function immutableFields(kind: string): readonly ImmutableField[] {
           path: ["spec", "podManagementPolicy"],
           omission: "resets-to-default",
           apiDefault: "OrderedReady",
+          liveOnlyKeys: "removes-managed-key",
         },
-        { path: ["spec", "selector"], omission: "removes-managed-field" },
-        { path: ["spec", "serviceName"], omission: "removes-managed-field" },
+        {
+          path: ["spec", "selector"],
+          omission: "removes-managed-field",
+          liveOnlyKeys: "removes-managed-key",
+        },
+        {
+          path: ["spec", "serviceName"],
+          omission: "removes-managed-field",
+          liveOnlyKeys: "removes-managed-key",
+        },
         {
           path: ["spec", "volumeClaimTemplates"],
           omission: "removes-managed-field",
+          // Each template is a claim the API server defaults like any other:
+          // volumeMode, storageClassName, and status appear on the live copy
+          // whether or not the chart wrote them.
+          liveOnlyKeys: "api-populates",
         },
       ];
     case "PersistentVolumeClaim":
       return [
-        { path: ["spec", "accessModes"], omission: "removes-managed-field" },
+        {
+          path: ["spec", "accessModes"],
+          omission: "removes-managed-field",
+          liveOnlyKeys: "removes-managed-key",
+        },
         // The API server cross-populates these two, so a claim authored with
         // only one of them reports both. Treating an omission as a change would
         // fail every such claim, so under-report rather than block releases.
-        { path: ["spec", "dataSource"], omission: "keeps-live-value" },
-        { path: ["spec", "dataSourceRef"], omission: "keeps-live-value" },
+        // The same cross-population adds keys inside them.
+        {
+          path: ["spec", "dataSource"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "api-populates",
+        },
+        {
+          path: ["spec", "dataSourceRef"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "api-populates",
+        },
         // Binds the claim to a matching volume. The author owns it and nothing
         // defaults it, so changing or dropping it is an immutable update.
-        { path: ["spec", "selector"], omission: "removes-managed-field" },
+        {
+          path: ["spec", "selector"],
+          omission: "removes-managed-field",
+          liveOnlyKeys: "removes-managed-key",
+        },
         // Defaulted from the cluster's default StorageClass at creation, so a
         // live claim carries one whether or not the chart ever declared it.
-        { path: ["spec", "storageClassName"], omission: "keeps-live-value" },
+        {
+          path: ["spec", "storageClassName"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "removes-managed-key",
+        },
         {
           path: ["spec", "volumeMode"],
           omission: "resets-to-default",
           apiDefault: "Filesystem",
+          liveOnlyKeys: "removes-managed-key",
         },
-        { path: ["spec", "volumeName"], omission: "keeps-live-value" },
+        {
+          path: ["spec", "volumeName"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "removes-managed-key",
+        },
       ];
     case "Service":
-      // All three are assigned by the cluster, not the chart.
+      // All three are assigned by the cluster, not the chart. Each holds a
+      // string or a list of strings, so there is no key inside for the API
+      // server to populate.
       return [
-        { path: ["spec", "clusterIP"], omission: "keeps-live-value" },
-        { path: ["spec", "clusterIPs"], omission: "keeps-live-value" },
-        { path: ["spec", "ipFamilies"], omission: "keeps-live-value" },
+        {
+          path: ["spec", "clusterIP"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "removes-managed-key",
+        },
+        {
+          path: ["spec", "clusterIPs"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "removes-managed-key",
+        },
+        {
+          path: ["spec", "ipFamilies"],
+          omission: "keeps-live-value",
+          liveOnlyKeys: "removes-managed-key",
+        },
       ];
     default:
       return [];

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -1,0 +1,184 @@
+import { z } from "zod";
+
+export const ManagedResourceSchema = z.object({
+  group: z.string().optional(),
+  kind: z.string(),
+  name: z.string(),
+  namespace: z.string().optional(),
+  liveState: z.string().optional(),
+  targetState: z.string().optional(),
+});
+
+export const ManagedResourcesSchema = z.object({
+  items: z.array(ManagedResourceSchema),
+});
+
+type ManagedResource = z.infer<typeof ManagedResourceSchema>;
+
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+const PROBE_HANDLERS = ["exec", "grpc", "httpGet", "tcpSocket"] as const;
+
+function parseObject(
+  source: string | undefined,
+): Record<string, unknown> | null {
+  if (source === undefined || source === "" || source === "null") {
+    return null;
+  }
+  return JsonObjectSchema.parse(JSON.parse(source));
+}
+
+function valueAt(
+  object: Record<string, unknown>,
+  path: readonly string[],
+): unknown {
+  let current: unknown = object;
+  for (const segment of path) {
+    const parsed = JsonObjectSchema.safeParse(current);
+    if (!parsed.success) {
+      return undefined;
+    }
+    current = parsed.data[segment];
+  }
+  return current;
+}
+
+function targetMatchesLive(target: unknown, live: unknown): boolean {
+  if (Array.isArray(target)) {
+    return (
+      Array.isArray(live) &&
+      target.length === live.length &&
+      target.every((entry, index) => targetMatchesLive(entry, live[index]))
+    );
+  }
+  const targetObject = JsonObjectSchema.safeParse(target);
+  if (targetObject.success) {
+    const liveObject = JsonObjectSchema.safeParse(live);
+    return (
+      liveObject.success &&
+      Object.entries(targetObject.data).every(([key, value]) =>
+        targetMatchesLive(value, liveObject.data[key]),
+      )
+    );
+  }
+  return JSON.stringify(target) === JSON.stringify(live);
+}
+
+function declaredTargetChanged(
+  live: Record<string, unknown>,
+  target: Record<string, unknown>,
+  path: readonly string[],
+): boolean {
+  const targetValue = valueAt(target, path);
+  return (
+    targetValue !== undefined &&
+    !targetMatchesLive(targetValue, valueAt(live, path))
+  );
+}
+
+function activeProbeHandler(probe: Record<string, unknown>): string | null {
+  const handlers = PROBE_HANDLERS.filter(
+    (handler) => probe[handler] !== undefined,
+  );
+  return handlers.length === 1 ? (handlers[0] ?? null) : null;
+}
+
+function collectProbeHandlers(
+  value: unknown,
+  path: string,
+  output: Map<string, string>,
+): void {
+  if (Array.isArray(value)) {
+    for (const [index, entry] of value.entries()) {
+      collectProbeHandlers(entry, `${path}/${index.toString()}`, output);
+    }
+    return;
+  }
+  const parsed = JsonObjectSchema.safeParse(value);
+  if (!parsed.success) {
+    return;
+  }
+  for (const [key, entry] of Object.entries(parsed.data)) {
+    const entryPath = `${path}/${key}`;
+    if (
+      key === "livenessProbe" ||
+      key === "readinessProbe" ||
+      key === "startupProbe"
+    ) {
+      const probe = JsonObjectSchema.safeParse(entry);
+      if (probe.success) {
+        const handler = activeProbeHandler(probe.data);
+        if (handler !== null) {
+          output.set(entryPath, handler);
+        }
+      }
+    }
+    collectProbeHandlers(entry, entryPath, output);
+  }
+}
+
+function identity(resource: ManagedResource): string {
+  return `${resource.group ?? ""}/${resource.kind} ${resource.namespace ?? "_cluster"}/${resource.name}`;
+}
+
+function immutablePaths(kind: string): readonly (readonly string[])[] {
+  switch (kind) {
+    case "Deployment":
+      return [["spec", "selector"]];
+    case "StatefulSet":
+      return [
+        ["spec", "selector"],
+        ["spec", "serviceName"],
+        ["spec", "volumeClaimTemplates"],
+      ];
+    case "PersistentVolumeClaim":
+      return [
+        ["spec", "accessModes"],
+        ["spec", "dataSource"],
+        ["spec", "dataSourceRef"],
+        ["spec", "storageClassName"],
+        ["spec", "volumeMode"],
+        ["spec", "volumeName"],
+      ];
+    case "Service":
+      return [
+        ["spec", "clusterIP"],
+        ["spec", "clusterIPs"],
+        ["spec", "ipFamilies"],
+      ];
+    default:
+      return [];
+  }
+}
+
+export function analyzeApplySafety(
+  resources: readonly ManagedResource[],
+): readonly string[] {
+  const findings: string[] = [];
+  for (const resource of resources) {
+    const live = parseObject(resource.liveState);
+    const target = parseObject(resource.targetState);
+    if (live === null || target === null) {
+      continue;
+    }
+    for (const path of immutablePaths(resource.kind)) {
+      if (declaredTargetChanged(live, target, path)) {
+        findings.push(
+          `${identity(resource)} changes immutable /${path.join("/")}`,
+        );
+      }
+    }
+    const liveProbes = new Map<string, string>();
+    const targetProbes = new Map<string, string>();
+    collectProbeHandlers(live, "", liveProbes);
+    collectProbeHandlers(target, "", targetProbes);
+    for (const [path, liveHandler] of liveProbes) {
+      const targetHandler = targetProbes.get(path);
+      if (targetHandler !== undefined && targetHandler !== liveHandler) {
+        findings.push(
+          `${identity(resource)} changes ${path} handler from ${liveHandler} to ${targetHandler}; use a resource-scoped replace`,
+        );
+      }
+    }
+  }
+  return findings;
+}

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -94,7 +94,7 @@ describe("manifest override batching", () => {
       batchManifestOverrides(overrides, {
         maxRequestBytes: 1470,
         revision: "2.0.0-42",
-        rootReleasePhase: "batch",
+        releasePhase: "batch",
       }),
     ).toHaveLength(2);
   });

--- a/packages/homelab/scripts/argocd-manifest-overrides.test.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.test.ts
@@ -81,7 +81,7 @@ describe("manifest override batching", () => {
     ).toHaveLength(2);
   });
 
-  test("counts the root finalizer phase marker in revisioned requests", () => {
+  test("counts the root release phase marker in revisioned requests", () => {
     const overrides = [override("one", 400), override("two", 400)];
 
     expect(
@@ -94,7 +94,7 @@ describe("manifest override batching", () => {
       batchManifestOverrides(overrides, {
         maxRequestBytes: 1470,
         revision: "2.0.0-42",
-        rootFinalizerPhase: "batch",
+        rootReleasePhase: "batch",
       }),
     ).toHaveLength(2);
   });

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -10,9 +10,10 @@ const SYNC_WAVE_PATTERN = /^[+-]?\d+$/;
 export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
 export const SYNC_REVISION_INFO_NAME = "ci.sjer.red/revision";
-export const ROOT_RELEASE_PHASE_INFO_NAME = "ci.sjer.red/root-release-phase";
+export const RELEASE_PHASE_INFO_NAME = "ci.sjer.red/release-phase";
 
-export type RootReleasePhase = "stage" | "batch" | "prune";
+export type ReleasePhase = "stage" | "batch" | "prune" | "child";
+export type RootReleasePhase = Exclude<ReleasePhase, "child">;
 
 const ApplicationOperationSchema = z.object({
   operation: z.record(z.string(), z.unknown()).optional(),
@@ -77,7 +78,7 @@ export type ManifestOverrideBatch = {
 function serializedRequestBytes(
   batch: ManifestOverrideBatch,
   revision: string | undefined,
-  rootReleasePhase: RootReleasePhase | undefined,
+  releasePhase: ReleasePhase | undefined,
 ): number {
   return new TextEncoder().encode(
     JSON.stringify({
@@ -94,12 +95,12 @@ function serializedRequestBytes(
         ...(revision === undefined
           ? []
           : [{ name: SYNC_REVISION_INFO_NAME, value: revision }]),
-        ...(rootReleasePhase === undefined
+        ...(releasePhase === undefined
           ? []
           : [
               {
-                name: ROOT_RELEASE_PHASE_INFO_NAME,
-                value: rootReleasePhase,
+                name: RELEASE_PHASE_INFO_NAME,
+                value: releasePhase,
               },
             ]),
       ],
@@ -142,7 +143,7 @@ function batchSingleSyncWave(
   overrides: readonly ManifestOverride[],
   maxRequestBytes: number,
   revision: string | undefined,
-  rootReleasePhase: RootReleasePhase | undefined,
+  releasePhase: ReleasePhase | undefined,
 ): ManifestOverrideBatch[] {
   const batches: ManifestOverrideBatch[] = [];
   let current: ManifestOverrideBatch = { manifests: [], resources: [] };
@@ -150,7 +151,7 @@ function batchSingleSyncWave(
   for (const override of overrides) {
     const candidate = appendOverride(current, override);
     if (
-      serializedRequestBytes(candidate, revision, rootReleasePhase) <=
+      serializedRequestBytes(candidate, revision, releasePhase) <=
       maxRequestBytes
     ) {
       current = candidate;
@@ -163,8 +164,7 @@ function batchSingleSyncWave(
       current = candidate;
     }
     if (
-      serializedRequestBytes(current, revision, rootReleasePhase) >
-      maxRequestBytes
+      serializedRequestBytes(current, revision, releasePhase) > maxRequestBytes
     ) {
       throw new Error(
         `manifest override for ${override.resource.kind}/${override.resource.name} exceeds the request budget`,
@@ -195,7 +195,7 @@ export function batchManifestOverrides(
   options: {
     readonly maxRequestBytes?: number;
     readonly revision?: string;
-    readonly rootReleasePhase?: RootReleasePhase;
+    readonly releasePhase?: ReleasePhase;
   } = {},
 ): ManifestOverrideBatch[] {
   const maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
@@ -217,7 +217,7 @@ export function batchManifestOverrides(
         waveOverrides,
         maxRequestBytes,
         options.revision,
-        options.rootReleasePhase,
+        options.releasePhase,
       ),
     );
 }

--- a/packages/homelab/scripts/argocd-manifest-overrides.ts
+++ b/packages/homelab/scripts/argocd-manifest-overrides.ts
@@ -10,8 +10,9 @@ const SYNC_WAVE_PATTERN = /^[+-]?\d+$/;
 export const SYNC_REQUEST_ID_INFO_NAME = "ci.sjer.red/request-id";
 export const SYNC_OPERATION_ID_INFO_NAME = "ci.sjer.red/operation-id";
 export const SYNC_REVISION_INFO_NAME = "ci.sjer.red/revision";
-export const ROOT_FINALIZER_PHASE_INFO_NAME =
-  "ci.sjer.red/root-finalizer-phase";
+export const ROOT_RELEASE_PHASE_INFO_NAME = "ci.sjer.red/root-release-phase";
+
+export type RootReleasePhase = "stage" | "batch" | "prune";
 
 const ApplicationOperationSchema = z.object({
   operation: z.record(z.string(), z.unknown()).optional(),
@@ -76,7 +77,7 @@ export type ManifestOverrideBatch = {
 function serializedRequestBytes(
   batch: ManifestOverrideBatch,
   revision: string | undefined,
-  rootFinalizerPhase: "batch" | "prune" | undefined,
+  rootReleasePhase: RootReleasePhase | undefined,
 ): number {
   return new TextEncoder().encode(
     JSON.stringify({
@@ -93,12 +94,12 @@ function serializedRequestBytes(
         ...(revision === undefined
           ? []
           : [{ name: SYNC_REVISION_INFO_NAME, value: revision }]),
-        ...(rootFinalizerPhase === undefined
+        ...(rootReleasePhase === undefined
           ? []
           : [
               {
-                name: ROOT_FINALIZER_PHASE_INFO_NAME,
-                value: rootFinalizerPhase,
+                name: ROOT_RELEASE_PHASE_INFO_NAME,
+                value: rootReleasePhase,
               },
             ]),
       ],
@@ -141,7 +142,7 @@ function batchSingleSyncWave(
   overrides: readonly ManifestOverride[],
   maxRequestBytes: number,
   revision: string | undefined,
-  rootFinalizerPhase: "batch" | "prune" | undefined,
+  rootReleasePhase: RootReleasePhase | undefined,
 ): ManifestOverrideBatch[] {
   const batches: ManifestOverrideBatch[] = [];
   let current: ManifestOverrideBatch = { manifests: [], resources: [] };
@@ -149,7 +150,7 @@ function batchSingleSyncWave(
   for (const override of overrides) {
     const candidate = appendOverride(current, override);
     if (
-      serializedRequestBytes(candidate, revision, rootFinalizerPhase) <=
+      serializedRequestBytes(candidate, revision, rootReleasePhase) <=
       maxRequestBytes
     ) {
       current = candidate;
@@ -162,7 +163,7 @@ function batchSingleSyncWave(
       current = candidate;
     }
     if (
-      serializedRequestBytes(current, revision, rootFinalizerPhase) >
+      serializedRequestBytes(current, revision, rootReleasePhase) >
       maxRequestBytes
     ) {
       throw new Error(
@@ -194,7 +195,7 @@ export function batchManifestOverrides(
   options: {
     readonly maxRequestBytes?: number;
     readonly revision?: string;
-    readonly rootFinalizerPhase?: "batch" | "prune";
+    readonly rootReleasePhase?: RootReleasePhase;
   } = {},
 ): ManifestOverrideBatch[] {
   const maxRequestBytes = options.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
@@ -216,7 +217,7 @@ export function batchManifestOverrides(
         waveOverrides,
         maxRequestBytes,
         options.revision,
-        options.rootFinalizerPhase,
+        options.rootReleasePhase,
       ),
     );
 }

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -500,6 +500,71 @@ function operationReleasePhase(
   return phase === undefined ? undefined : ReleasePhaseSchema.parse(phase);
 }
 
+const ActiveSyncRequestSchema = z.object({
+  manifests: z.array(z.string()).optional(),
+  prune: z.boolean().optional(),
+});
+
+/**
+ * Adoption must accept only the operation this call would itself have posted.
+ * Compare every field of the request this process controls rather than
+ * spot-checking one of them: a live operation can share the request UUID,
+ * revision, and phase marker while applying a manifest override, a different
+ * resource selection, or a different prune mode. Any option added to
+ * `SyncOptions` that changes the posted body belongs here too, so a retry can
+ * never adopt work that is not the exact request. Revision and identity stay
+ * with the operation observation, which reads them from the CI info entries.
+ */
+function activeOperationRequestMismatch(
+  app: Record<string, unknown>,
+  options: SyncOptions,
+): string | null {
+  const operation = app["operation"];
+  if (!isRecord(operation)) {
+    throw new Error(
+      "Cannot inspect the sync request for a missing live operation",
+    );
+  }
+  const sync = operation["sync"];
+  if (!isRecord(sync)) {
+    throw new Error("Active Argo operation is missing its sync request");
+  }
+  const active = ActiveSyncRequestSchema.parse(sync);
+  if ((active.prune ?? false) !== options.prune) {
+    return `prune ${(active.prune ?? false).toString()}`;
+  }
+  if ((active.manifests === undefined) !== (options.manifests === undefined)) {
+    return active.manifests === undefined
+      ? "no manifest override"
+      : "a manifest override";
+  }
+  if (
+    active.manifests !== undefined &&
+    options.manifests !== undefined &&
+    canonicalJson(active.manifests) !== canonicalJson(options.manifests)
+  ) {
+    return "a different manifest override";
+  }
+  const activeResources = activeOperationResourceIdentities(app);
+  const requestedResources =
+    options.resources === undefined
+      ? null
+      : operationResourceIdentities(options.resources);
+  if ((activeResources === null) !== (requestedResources === null)) {
+    return activeResources === null
+      ? "the full rendered source"
+      : "a resource selection";
+  }
+  if (
+    activeResources !== null &&
+    requestedResources !== null &&
+    !resourceIdentitySetsEqual(activeResources, requestedResources)
+  ) {
+    return "a different resource selection";
+  }
+  return null;
+}
+
 function activeOperationPrunes(app: Record<string, unknown>): boolean {
   const operation = app["operation"];
   if (!isRecord(operation)) {
@@ -1417,12 +1482,13 @@ async function sync(
           `Refusing to replace active ${appName} operation ${liveOperationDescription(baseline)}; expected request ${requestId}`,
         );
       }
-      if (
-        options.releasePhase === "child" &&
-        activeOperationResourceIdentities(baselineApplication) !== null
-      ) {
+      const mismatch = activeOperationRequestMismatch(
+        baselineApplication,
+        options,
+      );
+      if (mismatch !== null) {
         throw new Error(
-          `Refusing to adopt a selective ${appName} operation for request ${requestId}; expected the full-source child reconciliation`,
+          `Refusing to adopt the active ${appName} operation for request ${requestId}; it applies ${mismatch}`,
         );
       }
       operationId = requireLiveOperationId(baseline, appName);

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -2488,6 +2488,30 @@ async function releaseHealthWait(
   );
 }
 
+/**
+ * A Buildkite retry restarts `release-root` from the top, but the interrupted
+ * attempt may have died with a later root phase still live. Staging cannot
+ * adopt a `batch` or `prune` operation, so it would reject an operation this
+ * release legitimately owns and no retry could ever recover. Resume at the
+ * finalizer instead. Earlier phases need no routing: staging re-applies the
+ * same suspension, and child reconciliation skips children that already carry
+ * the expected release, so replaying them is idempotent.
+ */
+async function activeRootReleasePhase(
+  rootAppName: string,
+  requestId: string,
+  revision: string,
+  token: string,
+): Promise<ReleasePhase | null> {
+  const observation = observeOperation(
+    await getApplication(rootAppName, token),
+  );
+  if (!liveOperationMatches(observation, requestId, revision)) {
+    return null;
+  }
+  return observation.liveReleasePhase ?? null;
+}
+
 async function releaseRoot(
   rootAppName: string,
   expectedPath: string,
@@ -2511,29 +2535,44 @@ async function releaseRoot(
   console.log(
     `--- argocd release-root: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
   );
-  if (!dryRun) {
-    await assertReleaseInventoryIsComplete(
+  const resumePhase = dryRun
+    ? null
+    : await (async (): Promise<ReleasePhase | null> => {
+        const token = requireEnv("ARGOCD_TOKEN");
+        await assertReleaseInventoryIsComplete(
+          rootAppName,
+          expected,
+          exactRevision,
+          token,
+        );
+        return activeRootReleasePhase(
+          rootAppName,
+          exactRequestId,
+          exactRevision,
+          token,
+        );
+      })();
+  if (resumePhase === "batch" || resumePhase === "prune") {
+    console.log(
+      `resuming ${rootAppName} release at the ${resumePhase} phase for request ${exactRequestId}`,
+    );
+  } else {
+    await stageRootRelease(
       rootAppName,
-      expected,
       exactRevision,
-      requireEnv("ARGOCD_TOKEN"),
+      exactRequestId,
+      timeoutSeconds,
+      dryRun,
+    );
+    await reconcileRelease(
+      expectedPath,
+      timeoutSeconds,
+      dryRun,
+      new Set(),
+      false,
+      exactRequestId,
     );
   }
-  await stageRootRelease(
-    rootAppName,
-    exactRevision,
-    exactRequestId,
-    timeoutSeconds,
-    dryRun,
-  );
-  await reconcileRelease(
-    expectedPath,
-    timeoutSeconds,
-    dryRun,
-    new Set(),
-    false,
-    exactRequestId,
-  );
   await finalizeRootRelease(
     rootAppName,
     exactRevision,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -391,9 +391,17 @@ async function liveResourceState(
 }
 
 /**
- * A rendered manifest may omit the namespace an Application's destination
- * supplies, so an unnamespaced rendering matches a live namespaced resource.
- * Anything more ambiguous than that would silently preflight the wrong target.
+ * Either side may omit the namespace for the same object: a rendered manifest
+ * leaves it to the Application's destination, and `managed-resources` omits it
+ * for a cluster-scoped resource whose chart still stamps `metadata.namespace`
+ * (harmless — the API server ignores it). So a missing namespace on either side
+ * is a wildcard, and only two *concrete, different* namespaces are a mismatch.
+ *
+ * That mismatch is fatal rather than silent. Returning no manifest leaves the
+ * resource without a `targetState`, and `analyzeApplySafety` skips a resource
+ * that has no target — so a namespace disagreement used to mean the immutable
+ * checks simply never ran for it. Failing an ambiguous match loudly while
+ * quietly failing an impossible one was the wrong way round.
  */
 function renderedTargetState(
   targets: ReadonlyMap<string, readonly RenderedTarget[]>,
@@ -408,11 +416,21 @@ function renderedTargetState(
   const candidates = targets.get(identity) ?? [];
   const matches = candidates.filter(
     ({ namespace }) =>
-      namespace === undefined || namespace === resource.namespace,
+      namespace === undefined ||
+      resource.namespace === undefined ||
+      namespace === resource.namespace,
   );
   if (matches.length > 1) {
     throw new Error(
       `Apply-safety preflight for ${appName} matched ${identity} to ${matches.length.toString()} rendered manifests`,
+    );
+  }
+  if (matches.length === 0 && candidates.length > 0) {
+    const rendered = candidates
+      .map(({ namespace }) => namespace ?? "<none>")
+      .join(", ");
+    throw new Error(
+      `Apply-safety preflight for ${appName} found ${identity} in namespace ${resource.namespace ?? "<none>"} but rendered it in ${rendered}`,
     );
   }
   return matches[0]?.manifest;

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -147,6 +147,7 @@ const ActiveOperationResourceSchema = z.object({
   group: z.string().optional(),
   kind: z.string().min(1),
   name: z.string().min(1),
+  namespace: z.string().min(1).optional(),
 });
 
 const OperationInfoEntriesSchema = z
@@ -297,7 +298,11 @@ async function getApplicationManifests(
 }
 
 type RenderedTarget = {
+  readonly apiVersion: string;
+  readonly group: string;
+  readonly kind: string;
   readonly manifest: string;
+  readonly name: string;
   readonly namespace: string | undefined;
 };
 
@@ -308,19 +313,71 @@ function renderedTargetsByIdentity(
   for (const manifestSource of manifests) {
     const resource = RenderedResourceSchema.parse(JSON.parse(manifestSource));
     const separator = resource.apiVersion.indexOf("/");
+    const group =
+      separator === -1 ? "" : resource.apiVersion.slice(0, separator);
     const identity = resourceIdentity(
-      separator === -1 ? "" : resource.apiVersion.slice(0, separator),
+      group,
       resource.kind,
       resource.metadata.name,
     );
     const rendered = targets.get(identity) ?? [];
     rendered.push({
+      apiVersion: resource.apiVersion,
+      group,
+      kind: resource.kind,
       manifest: manifestSource,
+      name: resource.metadata.name,
       namespace: resource.metadata.namespace,
     });
     targets.set(identity, rendered);
   }
   return targets;
+}
+
+const ResourceManifestResponseSchema = z.object({ manifest: z.string() });
+
+/**
+ * Read one live object through the Application's resource endpoint. A resource
+ * the requested revision introduces has no entry in `managed-resources`, which
+ * only describes the configured revision, so its live state has to be fetched
+ * directly. A missing object is a creation and needs no immutable-field check.
+ */
+async function liveResourceState(
+  appName: string,
+  target: RenderedTarget,
+  token: string,
+): Promise<string | undefined> {
+  const separator = target.apiVersion.indexOf("/");
+  const url = new URL(
+    `/api/v1/applications/${encodeURIComponent(appName)}/resource`,
+    serverUrl(),
+  );
+  url.searchParams.set("resourceName", target.name);
+  url.searchParams.set("kind", target.kind);
+  url.searchParams.set("group", target.group);
+  url.searchParams.set(
+    "version",
+    separator === -1
+      ? target.apiVersion
+      : target.apiVersion.slice(separator + 1),
+  );
+  if (target.namespace !== undefined) {
+    url.searchParams.set("namespace", target.namespace);
+  }
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (response.status === 404) {
+    return undefined;
+  }
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 1024);
+    throw new Error(
+      `Could not read live ${target.kind} ${target.name} for ${appName}: ` +
+        `HTTP ${response.status.toString()} ${response.statusText}\n${body}`,
+    );
+  }
+  return ResourceManifestResponseSchema.parse(await response.json()).manifest;
 }
 
 /**
@@ -366,8 +423,12 @@ async function revisionScopedResources(
   const targets = renderedTargetsByIdentity(
     await getApplicationManifests(appName, revision, token),
   );
-  return resources.map((resource) => {
+  const matched = new Set<string>();
+  const scoped = resources.map((resource) => {
     const manifest = renderedTargetState(targets, resource, appName);
+    if (manifest !== undefined) {
+      matched.add(manifest);
+    }
     return {
       kind: resource.kind,
       name: resource.name,
@@ -381,6 +442,33 @@ async function revisionScopedResources(
       ...(manifest === undefined ? {} : { targetState: manifest }),
     };
   });
+  // A resource the requested revision adds is absent from `managed-resources`,
+  // so it never appears above. It still collides with any live object of the
+  // same identity, which is exactly the immutable-field case this gate exists
+  // to catch, so read those live states directly.
+  const introduced: ManagedResource[] = [];
+  for (const candidates of targets.values()) {
+    for (const target of candidates) {
+      if (matched.has(target.manifest)) {
+        continue;
+      }
+      const liveState = await liveResourceState(appName, target, token);
+      if (liveState === undefined) {
+        continue;
+      }
+      introduced.push({
+        kind: target.kind,
+        name: target.name,
+        group: target.group,
+        ...(target.namespace === undefined
+          ? {}
+          : { namespace: target.namespace }),
+        liveState,
+        targetState: target.manifest,
+      });
+    }
+  }
+  return [...scoped, ...introduced];
 }
 
 async function assertApplySafe(
@@ -442,6 +530,28 @@ function renderedResourceIdentities(
   return unique;
 }
 
+/**
+ * Two sync selectors are only the same target when their namespace agrees, so
+ * comparing one live operation's selection against another's must keep it.
+ * This is deliberately not `resourceIdentity`: that one compares selections
+ * against rendered manifests and Argo sync results, whose namespaces are
+ * populated inconsistently, so it stays namespace-agnostic on purpose.
+ */
+function operationSelectorIdentities(
+  resources: readonly SyncOperationResource[],
+): ReadonlySet<string> {
+  const identities = resources.map(({ group, kind, name, namespace }) =>
+    JSON.stringify([group, kind, name, namespace ?? ""]),
+  );
+  const unique = new Set(identities);
+  if (unique.size !== identities.length) {
+    throw new Error(
+      "Sync operation contains duplicate group/kind/namespace/name identities",
+    );
+  }
+  return unique;
+}
+
 function operationResourceIdentities(
   resources: readonly SyncOperationResource[],
 ): ReadonlySet<string> {
@@ -478,11 +588,12 @@ function activeOperationResourceIdentities(
   if (parsedResources.length === 0) {
     return null;
   }
-  return operationResourceIdentities(
-    parsedResources.map(({ group, kind, name }) => ({
+  return operationSelectorIdentities(
+    parsedResources.map(({ group, kind, name, namespace }) => ({
       group: group ?? "",
       kind,
       name,
+      ...(namespace === undefined ? {} : { namespace }),
     })),
   );
 }
@@ -603,7 +714,7 @@ function activeOperationRequestMismatch(
   const requestedResources =
     options.resources === undefined
       ? null
-      : operationResourceIdentities(options.resources);
+      : operationSelectorIdentities(options.resources);
   if ((activeResources === null) !== (requestedResources === null)) {
     return activeResources === null
       ? "the full rendered source"
@@ -980,7 +1091,7 @@ async function syncRootReleaseBatches(
     const activeBatchIndex = batches.findIndex((batch) =>
       resourceIdentitySetsEqual(
         activeResources,
-        operationResourceIdentities(batch.resources),
+        operationSelectorIdentities(batch.resources),
       ),
     );
     if (activeBatchIndex === -1) {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -9,10 +9,10 @@
  * timeouts are preserved.
  *
  * Usage:
- *   bun packages/homelab/scripts/argocd.ts sync <app> [--revision <v>]
- *       [--prune] [--async | --terminate-after-applied]
+ *   bun packages/homelab/scripts/argocd.ts sync-managed <app> [--revision <v>]
+ *       [--prune] [--terminate-after-applied]
  *       [--request-id <uuid>] [--timeout <s>] [--dry-run]
- *   bun packages/homelab/scripts/argocd.ts finalize-async-sync <app> \
+ *   bun packages/homelab/scripts/argocd.ts release-root apps <expected.json> \
  *       --revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts delete-application <app> \
  *       --project <project> [--timeout <s>] [--dry-run]
@@ -20,10 +20,6 @@
  *   bun packages/homelab/scripts/argocd.ts tree-health-wait <app> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> \
  *       [--revision <v>] [--timeout <s>] [--dry-run]
- *   bun packages/homelab/scripts/argocd.ts stage-root-release <root-app> \
- *       --revision <v> [--timeout <s>] [--dry-run]
- *   bun packages/homelab/scripts/argocd.ts finalize-root-release apps \
- *       --revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]
  *   bun packages/homelab/scripts/argocd.ts wait-deletion <app> \
  *       --group <g> --version <v> --kind <k> --namespace <ns> \
  *       [--timeout <s>] [--dry-run]
@@ -66,6 +62,10 @@ import {
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
+import {
+  analyzeApplySafety,
+  ManagedResourcesSchema,
+} from "./argocd-apply-safety.ts";
 import { z } from "zod";
 
 const DEFAULT_SERVER_URL = "https://argocd.sjer.red";
@@ -230,8 +230,15 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 async function getApplication(
   appName: string,
   token: string,
+  refresh?: "hard",
 ): Promise<Record<string, unknown>> {
-  const url = `${serverUrl()}/api/v1/applications/${appName}`;
+  const url = new URL(
+    `/api/v1/applications/${encodeURIComponent(appName)}`,
+    serverUrl(),
+  );
+  if (refresh !== undefined) {
+    url.searchParams.set("refresh", refresh);
+  }
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
     redirect: "follow",
@@ -239,13 +246,13 @@ async function getApplication(
   if (res.status !== 200) {
     const body = (await res.text()).slice(0, 1024);
     throw new Error(
-      `ERROR: ${url} returned HTTP ${res.status.toString()}\n` +
+      `ERROR: ${url.toString()} returned HTTP ${res.status.toString()}\n` +
         `Response body (first 1KB): ${body}`,
     );
   }
   const data: unknown = await res.json();
   if (!isRecord(data)) {
-    throw new Error(`${url} returned a non-object body`);
+    throw new Error(`${url.toString()} returned a non-object body`);
   }
   return data;
 }
@@ -287,6 +294,31 @@ async function getApplicationManifests(
     );
   }
   return ManifestResponseSchema.parse(await response.json()).manifests;
+}
+
+async function assertApplySafe(appName: string, token: string): Promise<void> {
+  await getApplication(appName, token, "hard");
+  const url = new URL(
+    `/api/v1/applications/${encodeURIComponent(appName)}/managed-resources`,
+    serverUrl(),
+  );
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 1024);
+    throw new Error(
+      `Could not inspect apply safety for ${appName}: HTTP ${response.status.toString()} ${response.statusText}\n${body}`,
+    );
+  }
+  const findings = analyzeApplySafety(
+    ManagedResourcesSchema.parse(await response.json()).items,
+  );
+  if (findings.length > 0) {
+    throw new Error(
+      `Refusing ${appName} sync because the read-only apply-safety preflight found:\n${findings.map((finding) => `- ${finding}`).join("\n")}`,
+    );
+  }
 }
 
 function resourceIdentity(group: string, kind: string, name: string): string {
@@ -2118,6 +2150,7 @@ async function reconcileRelease(
     if (deployedExpectedRepositoryRelease || deployedExpectedExternalSource) {
       continue;
     }
+    await assertApplySafe(wanted.name, token);
     await sync(wanted.name, timeoutSeconds, false, {
       prune: wanted.prune,
       revision: wanted.revision,
@@ -2163,6 +2196,40 @@ async function releaseHealthWait(
   throw new Error(
     `Release tree did not become ready: ${latestFailures.join("; ")}`,
   );
+}
+
+async function releaseRoot(
+  rootAppName: string,
+  expectedPath: string,
+  revision: string,
+  requestId: string,
+  timeoutSeconds: number,
+  dryRun: boolean,
+): Promise<void> {
+  if (rootAppName !== "apps") {
+    throw new Error("release-root only supports the apps root");
+  }
+  const exactRevision = BuildRevisionSchema.parse(revision);
+  const exactRequestId = SyncRequestIdSchema.parse(requestId);
+  console.log(
+    `--- argocd release-root: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
+  );
+  await stageRootRelease(rootAppName, exactRevision, timeoutSeconds, dryRun);
+  await reconcileRelease(
+    expectedPath,
+    timeoutSeconds,
+    dryRun,
+    new Set(),
+    false,
+  );
+  await finalizeRootRelease(
+    rootAppName,
+    exactRevision,
+    exactRequestId,
+    timeoutSeconds,
+    dryRun,
+  );
+  await releaseHealthWait(expectedPath, timeoutSeconds, dryRun);
 }
 
 /**
@@ -2389,28 +2456,19 @@ async function waitDeletion(opts: {
 function usage(): never {
   console.error(
     "Usage:\n" +
-      "  bun packages/homelab/scripts/argocd.ts sync <app> " +
-      "[--revision <v>] [--prune] [--async | --terminate-after-applied] " +
+      "  bun packages/homelab/scripts/argocd.ts sync-managed <app> " +
+      "[--revision <v>] [--prune] [--terminate-after-applied] " +
       "[--request-id <uuid>] [--timeout <s>] [--dry-run]\n" +
+      "  bun packages/homelab/scripts/argocd.ts release-root apps <expected.json> " +
+      "--revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts delete-application <app> " +
       "--project <project> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts health-wait <app> " +
       "[--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts tree-health-wait <app> " +
       "[--timeout <s>] [--dry-run]\n" +
-      "  bun packages/homelab/scripts/argocd.ts release-health-wait <expected.json> " +
-      "[--timeout <s>] [--dry-run]\n" +
-      "  bun packages/homelab/scripts/argocd.ts reconcile-release <expected.json> " +
-      "[--defer-apps <app,...>] [--skip-health-wait] " +
-      "[--timeout <s>] [--dry-run]\n" +
-      "  bun packages/homelab/scripts/argocd.ts finalize-async-sync <app> " +
-      "--revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts suspend-auto-sync <root-app> " +
       "[--revision <v>] [--timeout <s>] [--dry-run]\n" +
-      "  bun packages/homelab/scripts/argocd.ts stage-root-release <root-app> " +
-      "--revision <v> [--timeout <s>] [--dry-run]\n" +
-      "  bun packages/homelab/scripts/argocd.ts finalize-root-release apps " +
-      "--revision <v> --request-id <uuid> [--timeout <s>] [--dry-run]\n" +
       "  bun packages/homelab/scripts/argocd.ts wait-deletion <app> " +
       "--group <g> --version <v> --kind <k> --namespace <ns> " +
       "[--timeout <s>] [--dry-run]",
@@ -2430,18 +2488,6 @@ function flag(argv: string[], name: string): string | undefined {
     usage();
   }
   return v;
-}
-
-function appList(raw: string | undefined): ReadonlySet<string> {
-  if (raw === undefined) {
-    return new Set();
-  }
-  const apps = raw.split(",").map((app) => app.trim());
-  if (apps.some((app) => app.length === 0)) {
-    console.error("--defer-apps must contain only comma-separated names");
-    usage();
-  }
-  return new Set(apps);
 }
 
 async function main(): Promise<void> {
@@ -2466,6 +2512,43 @@ async function main(): Promise<void> {
   }
 
   switch (subcommand) {
+    case "sync-managed": {
+      const revision = flag(argv, "revision");
+      const requestId = flag(argv, "request-id");
+      const terminateAfterApplied = argv.includes("--terminate-after-applied");
+      if (argv.includes("--async")) {
+        console.error("sync-managed is bounded and does not support --async.");
+        usage();
+      }
+      if (terminateAfterApplied && revision === undefined) {
+        console.error(
+          "--terminate-after-applied requires an exact --revision.",
+        );
+        usage();
+      }
+      if (requestId !== undefined && revision === undefined) {
+        console.error("--request-id requires an exact --revision.");
+        usage();
+      }
+      const exactRequestId =
+        requestId === undefined
+          ? undefined
+          : SyncRequestIdSchema.parse(requestId);
+      if (!dryRun) {
+        await assertApplySafe(app, requireEnv("ARGOCD_TOKEN"));
+      }
+      await sync(app, timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S, dryRun, {
+        prune: argv.includes("--prune"),
+        waitForCompletion: true,
+        terminateAfterApplied,
+        ...(revision === undefined ? {} : { revision }),
+        ...(exactRequestId === undefined ? {} : { requestId: exactRequestId }),
+      });
+      return;
+    }
+    // Internal compatibility primitives keep the detailed lifecycle tests and
+    // exact-operation recovery path executable. Buildkite and operator docs
+    // expose only release-root and sync-managed.
     case "sync": {
       const revision = flag(argv, "revision");
       const requestId = flag(argv, "request-id");
@@ -2530,11 +2613,12 @@ async function main(): Promise<void> {
         true,
       );
       return;
-    case "release-health-wait":
-      await releaseHealthWait(
+    case "suspend-auto-sync":
+      await suspendRepositoryAutoSync(
         app,
-        timeoutOverride ?? DEFAULT_HEALTH_TIMEOUT_S,
+        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
         dryRun,
+        flag(argv, "revision"),
       );
       return;
     case "reconcile-release":
@@ -2542,34 +2626,8 @@ async function main(): Promise<void> {
         app,
         timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
         dryRun,
-        appList(flag(argv, "defer-apps")),
+        new Set(),
         !argv.includes("--skip-health-wait"),
-      );
-      return;
-    case "finalize-async-sync": {
-      const revision = flag(argv, "revision");
-      const requestId = flag(argv, "request-id");
-      if (revision === undefined || requestId === undefined) {
-        console.error(
-          "--revision and --request-id are required for finalize-async-sync.",
-        );
-        usage();
-      }
-      await finalizeAsyncSync(
-        app,
-        revision,
-        requestId,
-        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
-        dryRun,
-      );
-      return;
-    }
-    case "suspend-auto-sync":
-      await suspendRepositoryAutoSync(
-        app,
-        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
-        dryRun,
-        flag(argv, "revision"),
       );
       return;
     case "stage-root-release": {
@@ -2597,6 +2655,49 @@ async function main(): Promise<void> {
       }
       await finalizeRootRelease(
         app,
+        revision,
+        requestId,
+        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
+        dryRun,
+      );
+      return;
+    }
+    case "finalize-async-sync": {
+      const revision = flag(argv, "revision");
+      const requestId = flag(argv, "request-id");
+      if (revision === undefined || requestId === undefined) {
+        console.error(
+          "--revision and --request-id are required for finalize-async-sync.",
+        );
+        usage();
+      }
+      await finalizeAsyncSync(
+        app,
+        revision,
+        requestId,
+        timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
+        dryRun,
+      );
+      return;
+    }
+    case "release-root": {
+      const expectedPath = argv[2];
+      const revision = flag(argv, "revision");
+      const requestId = flag(argv, "request-id");
+      if (
+        expectedPath === undefined ||
+        expectedPath.startsWith("--") ||
+        revision === undefined ||
+        requestId === undefined
+      ) {
+        console.error(
+          "release-root requires <expected.json>, --revision, and --request-id.",
+        );
+        usage();
+      }
+      await releaseRoot(
+        app,
+        expectedPath,
         revision,
         requestId,
         timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -735,6 +735,14 @@ function splitRootSyncBatches(
   });
 }
 
+/**
+ * Deliberately carries no release identity, unlike every phase of
+ * `release-root`. This runs in `helm-push`, before the release exists, and only
+ * rewrites each child's auto-sync policy to the same suspended value, so a
+ * Buildkite retry can re-apply it blindly. Identity binding exists to decide
+ * between adopting and restarting an in-flight operation; there is nothing to
+ * decide when repeating the operation is the correct outcome either way.
+ */
 async function suspendRepositoryAutoSync(
   rootAppName: string,
   timeoutSeconds: number,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -2254,6 +2254,26 @@ function expectedAppsRelease(
   return appsRelease;
 }
 
+/**
+ * `releaseReconciliationTargets` is the only complete oracle for the release
+ * inventory: it rejects duplicate children, a missing repository child, and any
+ * Application absent from the exact rendered root. Running it before staging
+ * keeps semantically invalid input from applying root prerequisites and
+ * suspending child auto-sync first.
+ */
+async function assertReleaseInventoryIsComplete(
+  rootAppName: string,
+  expected: readonly ExpectedApplication[],
+  revision: string,
+  token: string,
+): Promise<void> {
+  releaseReconciliationTargets(
+    await getApplicationManifests(rootAppName, revision, token),
+    expected,
+    rootAppName,
+  );
+}
+
 async function reconcileRelease(
   expectedPath: string,
   timeoutSeconds: number,
@@ -2383,9 +2403,8 @@ async function releaseRoot(
   }
   const exactRevision = BuildRevisionSchema.parse(revision);
   const exactRequestId = SyncRequestIdSchema.parse(requestId);
-  const appsRelease = expectedAppsRelease(
-    await readExpectedApplications(expectedPath),
-  );
+  const expected = await readExpectedApplications(expectedPath);
+  const appsRelease = expectedAppsRelease(expected);
   if (appsRelease.revision !== exactRevision) {
     throw new Error(
       `Release inventory declares apps ${appsRelease.revision}; expected ${exactRevision}`,
@@ -2394,6 +2413,14 @@ async function releaseRoot(
   console.log(
     `--- argocd release-root: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
   );
+  if (!dryRun) {
+    await assertReleaseInventoryIsComplete(
+      rootAppName,
+      expected,
+      exactRevision,
+      requireEnv("ARGOCD_TOKEN"),
+    );
+  }
   await stageRootRelease(
     rootAppName,
     exactRevision,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -503,17 +503,59 @@ function operationReleasePhase(
 const ActiveSyncRequestSchema = z.object({
   manifests: z.array(z.string()).optional(),
   prune: z.boolean().optional(),
+  syncOptions: z.array(z.string()).optional(),
+});
+
+const DeclaredSyncOptionsSchema = z.object({
+  spec: z
+    .object({
+      syncPolicy: z
+        .object({ syncOptions: z.array(z.string()).optional() })
+        .loose()
+        .optional(),
+    })
+    .loose()
+    .optional(),
 });
 
 /**
- * Adoption must accept only the operation this call would itself have posted.
- * Compare every field of the request this process controls rather than
- * spot-checking one of them: a live operation can share the request UUID,
- * revision, and phase marker while applying a manifest override, a different
- * resource selection, or a different prune mode. Any option added to
- * `SyncOptions` that changes the posted body belongs here too, so a retry can
- * never adopt work that is not the exact request. Revision and identity stay
- * with the operation observation, which reads them from the CI info entries.
+ * Every key this process can account for in a live `operation.sync`. `revision`,
+ * `prune`, `manifests`, and `resources` are the request's own fields;
+ * `syncOptions` is absent from the request and injected by the sync-option
+ * admission policy from the Application's declared policy.
+ */
+const ACCOUNTED_SYNC_KEYS = new Set([
+  "manifests",
+  "prune",
+  "resources",
+  "revision",
+  "syncOptions",
+]);
+
+function declaredSyncOptions(app: Record<string, unknown>): readonly string[] {
+  return (
+    DeclaredSyncOptionsSchema.parse(app).spec?.syncPolicy?.syncOptions ?? []
+  );
+}
+
+/**
+ * Adoption must accept only the operation this call would itself have produced.
+ * That is not the same as the request this call posts: admission merges the
+ * Application's declared sync options into the operation server-side, so the
+ * live operation legitimately carries a field the request never sent.
+ *
+ * The comparison is therefore closed-world. Every key in the live sync request
+ * must be one this process can account for and must equal the value it would
+ * have produced, and any key it cannot account for is a refusal rather than
+ * something ignored. An operation sharing the request UUID, revision, and phase
+ * marker can otherwise apply materially different semantics — `Force=true` or
+ * `Replace=true` sync options, a manifest override, a different resource
+ * selection, or a different prune mode.
+ *
+ * A future Argo release that always serializes a new `operation.sync` field
+ * will surface here as a refusal on retry rather than a silent adoption. That
+ * is the intended direction to fail: add the field to `ACCOUNTED_SYNC_KEYS`
+ * with its expected value once its semantics are known.
  */
 function activeOperationRequestMismatch(
   app: Record<string, unknown>,
@@ -529,9 +571,21 @@ function activeOperationRequestMismatch(
   if (!isRecord(sync)) {
     throw new Error("Active Argo operation is missing its sync request");
   }
+  for (const key of Object.keys(sync)) {
+    if (!ACCOUNTED_SYNC_KEYS.has(key)) {
+      return `an unaccounted ${key} field`;
+    }
+  }
   const active = ActiveSyncRequestSchema.parse(sync);
   if ((active.prune ?? false) !== options.prune) {
     return `prune ${(active.prune ?? false).toString()}`;
+  }
+  // The request never sends sync options, so admission's merge leaves exactly
+  // the Application's declared set. Anything else was added by someone else.
+  const admittedOptions = [...(active.syncOptions ?? [])].sort();
+  const expectedOptions = [...declaredSyncOptions(app)].sort();
+  if (canonicalJson(admittedOptions) !== canonicalJson(expectedOptions)) {
+    return `sync options ${JSON.stringify(admittedOptions)}`;
   }
   if ((active.manifests === undefined) !== (options.manifests === undefined)) {
     return active.manifests === undefined

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -50,7 +50,7 @@ import {
   completedOperationId,
   completedOperationRequestId,
   operationRevision,
-  ROOT_RELEASE_PHASE_INFO_NAME,
+  RELEASE_PHASE_INFO_NAME,
   requestedOperationId,
   requestedOperationRequestId,
   requestedOperationRevision,
@@ -59,7 +59,7 @@ import {
   SYNC_REVISION_INFO_NAME,
   type ManifestOverride,
   type ManifestOverrideBatch,
-  type RootReleasePhase,
+  type ReleasePhase,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
@@ -83,7 +83,7 @@ const CHARTMUSEUM_RETRY_BASE_DELAY_MS = 100;
 const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
 const SyncRequestIdSchema = z.uuid();
 const SyncOperationIdSchema = z.uuid();
-const RootReleasePhaseSchema = z.enum(["stage", "batch", "prune"]);
+const ReleasePhaseSchema = z.enum(["stage", "batch", "prune", "child"]);
 const OperationStartedAtSchema = z.iso.datetime({ offset: true }).optional();
 const PollIntervalSchema = z.coerce.number().int().positive();
 
@@ -487,17 +487,17 @@ function activeOperationResourceIdentities(
   );
 }
 
-function operationRootReleasePhase(
+function operationReleasePhase(
   operation: Record<string, unknown>,
-): RootReleasePhase | undefined {
+): ReleasePhase | undefined {
   const matches = (OperationInfoEntriesSchema.parse(operation).info ?? [])
-    .filter(({ name }) => name === ROOT_RELEASE_PHASE_INFO_NAME)
+    .filter(({ name }) => name === RELEASE_PHASE_INFO_NAME)
     .map(({ value }) => value);
   if (matches.length > 1) {
     throw new Error("Argo operation has multiple root release phases");
   }
   const phase = matches[0];
-  return phase === undefined ? undefined : RootReleasePhaseSchema.parse(phase);
+  return phase === undefined ? undefined : ReleasePhaseSchema.parse(phase);
 }
 
 function activeOperationPrunes(app: Record<string, unknown>): boolean {
@@ -512,15 +512,15 @@ function activeOperationPrunes(app: Record<string, unknown>): boolean {
   return sync["prune"] === true;
 }
 
-function requestedOperationRootReleasePhase(
+function requestedOperationReleasePhase(
   application: unknown,
-): RootReleasePhase | undefined {
+): ReleasePhase | undefined {
   const parsed = z.record(z.string(), z.unknown()).parse(application);
   const operation = parsed["operation"];
   if (!isRecord(operation)) {
     throw new Error("Argo sync response is missing the requested operation");
   }
-  return operationRootReleasePhase(operation);
+  return operationReleasePhase(operation);
 }
 
 function resourceIdentitySetsEqual(
@@ -806,7 +806,7 @@ async function syncRootReleaseBatch(
     requestId,
     resources: batch.resources,
     revision,
-    rootReleasePhase: phase,
+    releasePhase: phase,
     terminateAfterApplied: true,
     ...(batch.manifests === undefined ? {} : { manifests: batch.manifests }),
   });
@@ -843,7 +843,7 @@ async function syncRootReleaseBatches(
     const activeResources = activeOperationResourceIdentities(application);
     if (
       activeResources === null ||
-      observation.liveRootReleasePhase !== phase ||
+      observation.liveReleasePhase !== phase ||
       activeOperationPrunes(application)
     ) {
       throw new Error(
@@ -946,7 +946,7 @@ async function stageRootRelease(
   const batches = splitRootSyncBatches(
     batchManifestOverrides(
       staged.map(({ override }) => override),
-      { revision: exactRevision, rootReleasePhase: "stage" },
+      { revision: exactRevision, releasePhase: "stage" },
     ),
     manifestOverrideIdentities,
   );
@@ -1008,7 +1008,7 @@ async function finalizeRootRelease(
   const batches = splitRootSyncBatches(
     batchManifestOverrides(
       preparedManifests.map(({ override }) => override),
-      { revision: exactRevision, rootReleasePhase: "batch" },
+      { revision: exactRevision, releasePhase: "batch" },
     ),
     deferredDesiredIdentities,
   );
@@ -1039,7 +1039,7 @@ async function finalizeRootRelease(
       );
     }
     if (
-      initialOperation.liveRootReleasePhase !== "prune" ||
+      initialOperation.liveReleasePhase !== "prune" ||
       !activeOperationPrunes(initialApplication)
     ) {
       throw new Error(
@@ -1051,7 +1051,7 @@ async function finalizeRootRelease(
       prune: true,
       requestId: exactRequestId,
       revision: exactRevision,
-      rootReleasePhase: "prune",
+      releasePhase: "prune",
       terminateAfterApplied: true,
       verifiedRootDesiredIdentities,
     });
@@ -1072,7 +1072,7 @@ async function finalizeRootRelease(
     prune: true,
     requestId: exactRequestId,
     revision: exactRevision,
-    rootReleasePhase: "prune",
+    releasePhase: "prune",
     terminateAfterApplied: true,
     verifiedRootDesiredIdentities,
   });
@@ -1245,7 +1245,7 @@ async function assertRootPruneSafe(
 type SyncOptions = {
   prune: boolean;
   requestId?: string;
-  rootReleasePhase?: RootReleasePhase;
+  releasePhase?: ReleasePhase;
   terminateAfterApplied?: boolean;
   verifiedRootDesiredIdentities?: ReadonlySet<string>;
   waitForCompletion?: boolean;
@@ -1272,22 +1272,40 @@ async function sync(
   const token = requireEnv("ARGOCD_TOKEN");
   const verifiedRootDesiredIdentities = options.verifiedRootDesiredIdentities;
   if (
-    options.rootReleasePhase !== undefined &&
+    options.releasePhase !== undefined &&
+    (options.requestId === undefined || options.revision === undefined)
+  ) {
+    throw new Error("Release phases require an exact request and revision");
+  }
+  if (
+    options.releasePhase !== undefined &&
+    options.releasePhase !== "child" &&
     (appName !== "apps" ||
-      options.requestId === undefined ||
-      options.revision === undefined ||
       options.terminateAfterApplied !== true ||
-      (options.rootReleasePhase === "prune") !== options.prune)
+      (options.releasePhase === "prune") !== options.prune)
   ) {
     throw new Error(
       "Root release phases require an identity-bound atomic apps batch or prune",
+    );
+  }
+  // A child reconciliation always applies the child's complete rendered source.
+  // Declaring that here is what lets adoption reject a selective operation that
+  // merely shares the release identity.
+  if (
+    options.releasePhase === "child" &&
+    (appName === "apps" ||
+      options.manifests !== undefined ||
+      options.resources !== undefined)
+  ) {
+    throw new Error(
+      "Child release phases require a full-source sync of a managed Application",
     );
   }
   if (
     verifiedRootDesiredIdentities !== undefined &&
     (appName !== "apps" ||
       !options.prune ||
-      options.rootReleasePhase !== "prune" ||
+      options.releasePhase !== "prune" ||
       options.terminateAfterApplied !== true)
   ) {
     throw new Error(
@@ -1373,7 +1391,8 @@ async function sync(
   let adopted = false;
 
   if (retryable) {
-    baseline = observeOperation(await getApplication(appName, token));
+    const baselineApplication = await getApplication(appName, token);
+    baseline = observeOperation(baselineApplication);
     assertMatchingRevision(baseline, requestId, options.revision, appName);
     assertMatchingLiveRevision(baseline, requestId, options.revision, appName);
     if (baseline.hasLiveOperation) {
@@ -1383,11 +1402,19 @@ async function sync(
           requestId,
           options.revision,
           undefined,
-          options.rootReleasePhase,
+          options.releasePhase,
         )
       ) {
         throw new Error(
           `Refusing to replace active ${appName} operation ${liveOperationDescription(baseline)}; expected request ${requestId}`,
+        );
+      }
+      if (
+        options.releasePhase === "child" &&
+        activeOperationResourceIdentities(baselineApplication) !== null
+      ) {
+        throw new Error(
+          `Refusing to adopt a selective ${appName} operation for request ${requestId}; expected the full-source child reconciliation`,
         );
       }
       operationId = requireLiveOperationId(baseline, appName);
@@ -1396,7 +1423,7 @@ async function sync(
         requestId,
         options.revision,
         operationId,
-        options.rootReleasePhase,
+        options.releasePhase,
       );
       if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
@@ -1445,12 +1472,12 @@ async function sync(
           ...(options.revision === undefined
             ? []
             : [{ name: SYNC_REVISION_INFO_NAME, value: options.revision }]),
-          ...(options.rootReleasePhase === undefined
+          ...(options.releasePhase === undefined
             ? []
             : [
                 {
-                  name: ROOT_RELEASE_PHASE_INFO_NAME,
-                  value: options.rootReleasePhase,
+                  name: RELEASE_PHASE_INFO_NAME,
+                  value: options.releasePhase,
                 },
               ]),
         ],
@@ -1492,12 +1519,9 @@ async function sync(
         `Argo sync response returned a different CI revision; expected ${options.revision}`,
       );
     }
-    if (
-      requestedOperationRootReleasePhase(responseBody) !==
-      options.rootReleasePhase
-    ) {
+    if (requestedOperationReleasePhase(responseBody) !== options.releasePhase) {
       throw new Error(
-        `Argo sync response returned a different root release phase; expected ${options.rootReleasePhase ?? "none"}`,
+        `Argo sync response returned a different root release phase; expected ${options.releasePhase ?? "none"}`,
       );
     }
     console.log(`sync operation started: ${appName}`);
@@ -1510,7 +1534,7 @@ async function sync(
     token,
     requestId,
     operationId,
-    rootReleasePhase: options.rootReleasePhase,
+    releasePhase: options.releasePhase,
     expectedResourceIdentities,
     revision: options.revision,
     timeoutSeconds,
@@ -1528,12 +1552,12 @@ type OperationObservation = {
   readonly liveOperationId: string | null;
   readonly liveRequestId: string | null;
   readonly liveRevision: string | undefined;
-  readonly liveRootReleasePhase: RootReleasePhase | undefined;
+  readonly liveReleasePhase: ReleasePhase | undefined;
   readonly operationId: string | null;
   readonly phase: string;
   readonly requestId: string | null;
   readonly revision: string | undefined;
-  readonly rootReleasePhase: RootReleasePhase | undefined;
+  readonly releasePhase: ReleasePhase | undefined;
   readonly startedAt: string | undefined;
   readonly state: Record<string, unknown>;
 };
@@ -1557,10 +1581,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
       liveOperation === undefined
         ? undefined
         : operationRevision(liveOperation),
-    liveRootReleasePhase:
+    liveReleasePhase:
       liveOperation === undefined
         ? undefined
-        : operationRootReleasePhase(liveOperation),
+        : operationReleasePhase(liveOperation),
     phase: typeof phase === "string" ? phase : "",
     operationId: completedOperationId(app),
     requestId: completedOperationRequestId(app),
@@ -1568,10 +1592,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
       completedOperation === undefined
         ? undefined
         : operationRevision(completedOperation),
-    rootReleasePhase:
+    releasePhase:
       completedOperation === undefined
         ? undefined
-        : operationRootReleasePhase(completedOperation),
+        : operationReleasePhase(completedOperation),
     startedAt: OperationStartedAtSchema.parse(state["startedAt"]),
     state,
   };
@@ -1582,15 +1606,14 @@ function liveOperationMatches(
   requestId: string,
   revision: string | undefined,
   operationId?: string | null,
-  rootReleasePhase?: RootReleasePhase,
+  releasePhase?: ReleasePhase,
 ): boolean {
   return (
     operation.hasLiveOperation &&
     operation.liveRequestId === requestId &&
     (revision === undefined || operation.liveRevision === revision) &&
     (operationId === undefined || operation.liveOperationId === operationId) &&
-    (rootReleasePhase === undefined ||
-      operation.liveRootReleasePhase === rootReleasePhase)
+    (releasePhase === undefined || operation.liveReleasePhase === releasePhase)
   );
 }
 
@@ -1599,14 +1622,13 @@ function operationMatches(
   requestId: string,
   revision: string | undefined,
   operationId?: string | null,
-  rootReleasePhase?: RootReleasePhase,
+  releasePhase?: ReleasePhase,
 ): boolean {
   return (
     operation.requestId === requestId &&
     (revision === undefined || operation.revision === revision) &&
     (operationId === undefined || operation.operationId === operationId) &&
-    (rootReleasePhase === undefined ||
-      operation.rootReleasePhase === rootReleasePhase)
+    (releasePhase === undefined || operation.releasePhase === releasePhase)
   );
 }
 
@@ -1783,7 +1805,7 @@ type WaitForIdentifiedOperationOptions = {
   readonly operationId: string;
   readonly requestId: string;
   readonly revision: string | undefined;
-  readonly rootReleasePhase: RootReleasePhase | undefined;
+  readonly releasePhase: ReleasePhase | undefined;
   readonly terminateAfterApplied: boolean;
   readonly timeoutSeconds: number;
   readonly token: string;
@@ -1795,7 +1817,7 @@ async function waitForIdentifiedOperation({
   operationId,
   requestId,
   revision,
-  rootReleasePhase,
+  releasePhase,
   terminateAfterApplied,
   timeoutSeconds,
   token,
@@ -1811,14 +1833,14 @@ async function waitForIdentifiedOperation({
       requestId,
       revision,
       operationId,
-      rootReleasePhase,
+      releasePhase,
     );
     const isExpectedLiveOperation = liveOperationMatches(
       current,
       requestId,
       revision,
       operationId,
-      rootReleasePhase,
+      releasePhase,
     );
     if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
@@ -2347,7 +2369,9 @@ async function reconcileRelease(
     await sync(wanted.name, timeoutSeconds, false, {
       prune: wanted.prune,
       revision: wanted.revision,
-      ...(exactRequestId === undefined ? {} : { requestId: exactRequestId }),
+      ...(exactRequestId === undefined
+        ? {}
+        : { requestId: exactRequestId, releasePhase: "child" }),
     });
   }
   if (waitForHealth) {

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -144,11 +144,20 @@ const RenderedResourceSchema = z.object({
     .passthrough(),
 });
 
+/**
+ * A live operation's selector as Argo reports it. `namespace` accepts an empty
+ * string on purpose: a cluster-scoped target has two valid spellings on the
+ * wire, omitted or empty, and this identity model already treats them as one —
+ * `group` is normalised with `?? ""` and `operationSelectorIdentities` does the
+ * same for `namespace`. Requiring a non-empty namespace made the parse reject a
+ * selector the comparison would then have matched, aborting batch adoption
+ * before it could read the operation at all.
+ */
 const ActiveOperationResourceSchema = z.object({
   group: z.string().optional(),
   kind: z.string().min(1),
   name: z.string().min(1),
-  namespace: z.string().min(1).optional(),
+  namespace: z.string().optional(),
 });
 
 const OperationInfoEntriesSchema = z

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -41,6 +41,7 @@ import {
 import {
   APPLICATION_LIFECYCLE_ANNOTATION,
   APPLICATION_RESOURCES_FINALIZER,
+  MANAGED_APPLICATION_LABEL,
   REPOSITORY_CHART_URLS,
 } from "../src/cdk8s/src/application-release-policy.ts";
 import {
@@ -618,6 +619,10 @@ const ActiveSyncRequestSchema = z.object({
 });
 
 const DeclaredSyncOptionsSchema = z.object({
+  metadata: z
+    .object({ labels: z.record(z.string(), z.string()).optional() })
+    .loose()
+    .optional(),
   spec: z
     .object({
       syncPolicy: z
@@ -643,10 +648,19 @@ const ACCOUNTED_SYNC_KEYS = new Set([
   "syncOptions",
 ]);
 
-function declaredSyncOptions(app: Record<string, unknown>): readonly string[] {
-  return (
-    DeclaredSyncOptionsSchema.parse(app).spec?.syncPolicy?.syncOptions ?? []
-  );
+/**
+ * The sync options an operation on this Application is expected to carry. The
+ * request never sends any, so they can only come from the sync-option admission
+ * policy, which matches on the managed label. The release policy withholds that
+ * label from the root `apps` Application precisely so its operations are not
+ * mutated, so the root legitimately carries none even though it declares some.
+ * Reading the declaration alone would reject every root retry.
+ */
+function expectedSyncOptions(app: Record<string, unknown>): readonly string[] {
+  const parsed = DeclaredSyncOptionsSchema.parse(app);
+  const admitted =
+    parsed.metadata?.labels?.[MANAGED_APPLICATION_LABEL] === "true";
+  return admitted ? (parsed.spec?.syncPolicy?.syncOptions ?? []) : [];
 }
 
 /**
@@ -692,9 +706,9 @@ function activeOperationRequestMismatch(
     return `prune ${(active.prune ?? false).toString()}`;
   }
   // The request never sends sync options, so admission's merge leaves exactly
-  // the Application's declared set. Anything else was added by someone else.
+  // the set it injects. Anything else was added by someone else.
   const admittedOptions = [...(active.syncOptions ?? [])].sort();
-  const expectedOptions = [...declaredSyncOptions(app)].sort();
+  const expectedOptions = [...expectedSyncOptions(app)].sort();
   if (canonicalJson(admittedOptions) !== canonicalJson(expectedOptions)) {
     return `sync options ${JSON.stringify(admittedOptions)}`;
   }

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -50,7 +50,7 @@ import {
   completedOperationId,
   completedOperationRequestId,
   operationRevision,
-  ROOT_FINALIZER_PHASE_INFO_NAME,
+  ROOT_RELEASE_PHASE_INFO_NAME,
   requestedOperationId,
   requestedOperationRequestId,
   requestedOperationRevision,
@@ -59,12 +59,14 @@ import {
   SYNC_REVISION_INFO_NAME,
   type ManifestOverride,
   type ManifestOverrideBatch,
+  type RootReleasePhase,
   type SyncOperationResource,
 } from "./argocd-manifest-overrides.ts";
 import { latestPublishedVersion } from "./helm-release-core.ts";
 import {
   analyzeApplySafety,
   ManagedResourcesSchema,
+  type ManagedResource,
 } from "./argocd-apply-safety.ts";
 import { z } from "zod";
 
@@ -81,11 +83,9 @@ const CHARTMUSEUM_RETRY_BASE_DELAY_MS = 100;
 const BuildRevisionSchema = z.string().regex(/^2\.0\.0-\d+$/);
 const SyncRequestIdSchema = z.uuid();
 const SyncOperationIdSchema = z.uuid();
-const RootFinalizerPhaseSchema = z.enum(["batch", "prune"]);
+const RootReleasePhaseSchema = z.enum(["stage", "batch", "prune"]);
 const OperationStartedAtSchema = z.iso.datetime({ offset: true }).optional();
 const PollIntervalSchema = z.coerce.number().int().positive();
-
-type RootFinalizerPhase = z.infer<typeof RootFinalizerPhaseSchema>;
 
 const ExpectedApplicationsSchema = z.array(
   z.object({
@@ -296,7 +296,98 @@ async function getApplicationManifests(
   return ManifestResponseSchema.parse(await response.json()).manifests;
 }
 
-async function assertApplySafe(appName: string, token: string): Promise<void> {
+type RenderedTarget = {
+  readonly manifest: string;
+  readonly namespace: string | undefined;
+};
+
+function renderedTargetsByIdentity(
+  manifests: readonly string[],
+): ReadonlyMap<string, readonly RenderedTarget[]> {
+  const targets = new Map<string, RenderedTarget[]>();
+  for (const manifestSource of manifests) {
+    const resource = RenderedResourceSchema.parse(JSON.parse(manifestSource));
+    const separator = resource.apiVersion.indexOf("/");
+    const identity = resourceIdentity(
+      separator === -1 ? "" : resource.apiVersion.slice(0, separator),
+      resource.kind,
+      resource.metadata.name,
+    );
+    const rendered = targets.get(identity) ?? [];
+    rendered.push({
+      manifest: manifestSource,
+      namespace: resource.metadata.namespace,
+    });
+    targets.set(identity, rendered);
+  }
+  return targets;
+}
+
+/**
+ * A rendered manifest may omit the namespace an Application's destination
+ * supplies, so an unnamespaced rendering matches a live namespaced resource.
+ * Anything more ambiguous than that would silently preflight the wrong target.
+ */
+function renderedTargetState(
+  targets: ReadonlyMap<string, readonly RenderedTarget[]>,
+  resource: ManagedResource,
+  appName: string,
+): string | undefined {
+  const identity = resourceIdentity(
+    resource.group ?? "",
+    resource.kind,
+    resource.name,
+  );
+  const candidates = targets.get(identity) ?? [];
+  const matches = candidates.filter(
+    ({ namespace }) =>
+      namespace === undefined || namespace === resource.namespace,
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Apply-safety preflight for ${appName} matched ${identity} to ${matches.length.toString()} rendered manifests`,
+    );
+  }
+  return matches[0]?.manifest;
+}
+
+/**
+ * `managed-resources` reports the target state of the Application's configured
+ * revision, so a sync that requests a different revision must be preflighted
+ * against that revision's rendered manifests instead. A resource the requested
+ * revision no longer declares is a prune, not an apply, so it carries no target.
+ */
+async function revisionScopedResources(
+  appName: string,
+  revision: string,
+  token: string,
+  resources: readonly ManagedResource[],
+): Promise<readonly ManagedResource[]> {
+  const targets = renderedTargetsByIdentity(
+    await getApplicationManifests(appName, revision, token),
+  );
+  return resources.map((resource) => {
+    const manifest = renderedTargetState(targets, resource, appName);
+    return {
+      kind: resource.kind,
+      name: resource.name,
+      ...(resource.group === undefined ? {} : { group: resource.group }),
+      ...(resource.namespace === undefined
+        ? {}
+        : { namespace: resource.namespace }),
+      ...(resource.liveState === undefined
+        ? {}
+        : { liveState: resource.liveState }),
+      ...(manifest === undefined ? {} : { targetState: manifest }),
+    };
+  });
+}
+
+async function assertApplySafe(
+  appName: string,
+  token: string,
+  revision: string | undefined,
+): Promise<void> {
   await getApplication(appName, token, "hard");
   const url = new URL(
     `/api/v1/applications/${encodeURIComponent(appName)}/managed-resources`,
@@ -311,8 +402,11 @@ async function assertApplySafe(appName: string, token: string): Promise<void> {
       `Could not inspect apply safety for ${appName}: HTTP ${response.status.toString()} ${response.statusText}\n${body}`,
     );
   }
+  const managed = ManagedResourcesSchema.parse(await response.json()).items;
   const findings = analyzeApplySafety(
-    ManagedResourcesSchema.parse(await response.json()).items,
+    revision === undefined
+      ? managed
+      : await revisionScopedResources(appName, revision, token, managed),
   );
   if (findings.length > 0) {
     throw new Error(
@@ -393,19 +487,17 @@ function activeOperationResourceIdentities(
   );
 }
 
-function operationRootFinalizerPhase(
+function operationRootReleasePhase(
   operation: Record<string, unknown>,
-): RootFinalizerPhase | undefined {
+): RootReleasePhase | undefined {
   const matches = (OperationInfoEntriesSchema.parse(operation).info ?? [])
-    .filter(({ name }) => name === ROOT_FINALIZER_PHASE_INFO_NAME)
+    .filter(({ name }) => name === ROOT_RELEASE_PHASE_INFO_NAME)
     .map(({ value }) => value);
   if (matches.length > 1) {
-    throw new Error("Argo operation has multiple root finalizer phases");
+    throw new Error("Argo operation has multiple root release phases");
   }
   const phase = matches[0];
-  return phase === undefined
-    ? undefined
-    : RootFinalizerPhaseSchema.parse(phase);
+  return phase === undefined ? undefined : RootReleasePhaseSchema.parse(phase);
 }
 
 function activeOperationPrunes(app: Record<string, unknown>): boolean {
@@ -420,15 +512,15 @@ function activeOperationPrunes(app: Record<string, unknown>): boolean {
   return sync["prune"] === true;
 }
 
-function requestedOperationRootFinalizerPhase(
+function requestedOperationRootReleasePhase(
   application: unknown,
-): RootFinalizerPhase | undefined {
+): RootReleasePhase | undefined {
   const parsed = z.record(z.string(), z.unknown()).parse(application);
   const operation = parsed["operation"];
   if (!isRecord(operation)) {
     throw new Error("Argo sync response is missing the requested operation");
   }
-  return operationRootFinalizerPhase(operation);
+  return operationRootReleasePhase(operation);
 }
 
 function resourceIdentitySetsEqual(
@@ -696,15 +788,126 @@ async function suspendRepositoryAutoSync(
   }
 }
 
+const ROOT_BATCH_LABELS = {
+  batch: "exact root batch",
+  stage: "staged root batch",
+} as const;
+
+async function syncRootReleaseBatch(
+  rootAppName: string,
+  batch: RootSyncBatch,
+  phase: "stage" | "batch",
+  requestId: string,
+  revision: string,
+  timeoutSeconds: number,
+): Promise<void> {
+  await sync(rootAppName, timeoutSeconds, false, {
+    prune: false,
+    requestId,
+    resources: batch.resources,
+    revision,
+    rootReleasePhase: phase,
+    terminateAfterApplied: true,
+    ...(batch.manifests === undefined ? {} : { manifests: batch.manifests }),
+  });
+}
+
+/**
+ * Every batch of a release phase carries the same request UUID, revision, and
+ * phase marker, so an interrupted process can identify its own in-flight batch
+ * on retry. The live operation's exact resource selection decides which batch
+ * it is; anything that does not match one of this phase's batches belongs to
+ * different work and must not be adopted.
+ */
+async function syncRootReleaseBatches(
+  rootAppName: string,
+  batches: readonly RootSyncBatch[],
+  phase: "stage" | "batch",
+  requestId: string,
+  revision: string,
+  timeoutSeconds: number,
+  token: string,
+): Promise<void> {
+  const label = ROOT_BATCH_LABELS[phase];
+  let nextBatchIndex = 0;
+  const application = await getApplication(rootAppName, token);
+  const observation = observeOperation(application);
+  assertMatchingRevision(observation, requestId, revision, rootAppName);
+  assertMatchingLiveRevision(observation, requestId, revision, rootAppName);
+  if (observation.hasLiveOperation) {
+    if (!liveOperationMatches(observation, requestId, revision)) {
+      throw new Error(
+        `Refusing to replace active ${rootAppName} operation ${liveOperationDescription(observation)}; expected request ${requestId}`,
+      );
+    }
+    const activeResources = activeOperationResourceIdentities(application);
+    if (
+      activeResources === null ||
+      observation.liveRootReleasePhase !== phase ||
+      activeOperationPrunes(application)
+    ) {
+      throw new Error(
+        `Active ${rootAppName} selective operation is not a marked ${label}`,
+      );
+    }
+    const activeBatchIndex = batches.findIndex((batch) =>
+      resourceIdentitySetsEqual(
+        activeResources,
+        operationResourceIdentities(batch.resources),
+      ),
+    );
+    if (activeBatchIndex === -1) {
+      throw new Error(
+        `Active ${rootAppName} operation for request ${requestId} does not match an ${label}`,
+      );
+    }
+    const activeBatch = batches[activeBatchIndex];
+    if (activeBatch === undefined) {
+      throw new Error("Matched root batch is missing");
+    }
+    console.log(
+      `adopting ${label} ${(activeBatchIndex + 1).toString()}/${batches.length.toString()} (${activeBatch.resources.length.toString()} resources)`,
+    );
+    await syncRootReleaseBatch(
+      rootAppName,
+      activeBatch,
+      phase,
+      requestId,
+      revision,
+      timeoutSeconds,
+    );
+    nextBatchIndex = activeBatchIndex + 1;
+  }
+  for (let index = nextBatchIndex; index < batches.length; index += 1) {
+    const batch = batches[index];
+    if (batch === undefined) {
+      throw new Error(`${label} ${index.toString()} is missing`);
+    }
+    console.log(
+      `syncing ${label} ${(index + 1).toString()}/${batches.length.toString()} (${batch.resources.length.toString()} resources)`,
+    );
+    await syncRootReleaseBatch(
+      rootAppName,
+      batch,
+      phase,
+      requestId,
+      revision,
+      timeoutSeconds,
+    );
+  }
+}
+
 async function stageRootRelease(
   rootAppName: string,
   revision: string,
+  requestId: string,
   timeoutSeconds: number,
   dryRun: boolean,
 ): Promise<void> {
   const exactRevision = BuildRevisionSchema.parse(revision);
+  const exactRequestId = SyncRequestIdSchema.parse(requestId);
   console.log(
-    `--- argocd stage-root-release: ${rootAppName} at ${exactRevision}${dryRun ? " (dry run)" : ""}`,
+    `--- argocd stage-root-release: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
   );
   if (dryRun) {
     return;
@@ -743,22 +946,19 @@ async function stageRootRelease(
   const batches = splitRootSyncBatches(
     batchManifestOverrides(
       staged.map(({ override }) => override),
-      { revision: exactRevision },
+      { revision: exactRevision, rootReleasePhase: "stage" },
     ),
     manifestOverrideIdentities,
   );
-  for (const [index, batch] of batches.entries()) {
-    console.log(
-      `syncing staged root batch ${(index + 1).toString()}/${batches.length.toString()} (${batch.resources.length.toString()} resources)`,
-    );
-    await sync(rootAppName, timeoutSeconds, false, {
-      prune: false,
-      revision: exactRevision,
-      terminateAfterApplied: true,
-      resources: batch.resources,
-      ...(batch.manifests === undefined ? {} : { manifests: batch.manifests }),
-    });
-  }
+  await syncRootReleaseBatches(
+    rootAppName,
+    batches,
+    "stage",
+    exactRequestId,
+    exactRevision,
+    timeoutSeconds,
+    token,
+  );
 }
 
 async function finalizeRootRelease(
@@ -808,12 +1008,11 @@ async function finalizeRootRelease(
   const batches = splitRootSyncBatches(
     batchManifestOverrides(
       preparedManifests.map(({ override }) => override),
-      { revision: exactRevision, rootFinalizerPhase: "batch" },
+      { revision: exactRevision, rootReleasePhase: "batch" },
     ),
     deferredDesiredIdentities,
   );
 
-  let nextBatchIndex = 0;
   const initialApplication = await getApplication(rootAppName, token);
   const initialOperation = observeOperation(initialApplication);
   assertMatchingRevision(
@@ -828,7 +1027,10 @@ async function finalizeRootRelease(
     exactRevision,
     rootAppName,
   );
-  if (initialOperation.hasLiveOperation) {
+  if (
+    initialOperation.hasLiveOperation &&
+    activeOperationResourceIdentities(initialApplication) === null
+  ) {
     if (
       !liveOperationMatches(initialOperation, exactRequestId, exactRevision)
     ) {
@@ -836,92 +1038,41 @@ async function finalizeRootRelease(
         `Refusing to replace active ${rootAppName} operation ${liveOperationDescription(initialOperation)}; expected request ${exactRequestId}`,
       );
     }
-    const activeResources =
-      activeOperationResourceIdentities(initialApplication);
-    if (activeResources === null) {
-      if (
-        initialOperation.liveRootFinalizerPhase !== "prune" ||
-        !activeOperationPrunes(initialApplication)
-      ) {
-        throw new Error(
-          `Active ${rootAppName} full-source operation is not the marked final root prune`,
-        );
-      }
-      console.log(`adopting active final root prune: ${rootAppName}`);
-      await sync(rootAppName, timeoutSeconds, false, {
-        prune: true,
-        requestId: exactRequestId,
-        revision: exactRevision,
-        rootFinalizerPhase: "prune",
-        terminateAfterApplied: true,
-        verifiedRootDesiredIdentities,
-      });
-      return;
-    }
     if (
-      initialOperation.liveRootFinalizerPhase !== "batch" ||
-      activeOperationPrunes(initialApplication)
+      initialOperation.liveRootReleasePhase !== "prune" ||
+      !activeOperationPrunes(initialApplication)
     ) {
       throw new Error(
-        `Active ${rootAppName} selective operation is not a marked root batch`,
+        `Active ${rootAppName} full-source operation is not the marked final root prune`,
       );
     }
-    const activeBatchIndex = batches.findIndex((batch) =>
-      resourceIdentitySetsEqual(
-        activeResources,
-        operationResourceIdentities(batch.resources),
-      ),
-    );
-    if (activeBatchIndex === -1) {
-      throw new Error(
-        `Active ${rootAppName} operation for request ${exactRequestId} does not match an exact root batch`,
-      );
-    }
-    const activeBatch = batches[activeBatchIndex];
-    if (activeBatch === undefined) {
-      throw new Error("Matched root batch is missing");
-    }
-    console.log(
-      `adopting exact root batch ${(activeBatchIndex + 1).toString()}/${batches.length.toString()} (${activeBatch.resources.length.toString()} resources)`,
-    );
+    console.log(`adopting active final root prune: ${rootAppName}`);
     await sync(rootAppName, timeoutSeconds, false, {
-      prune: false,
+      prune: true,
       requestId: exactRequestId,
-      resources: activeBatch.resources,
       revision: exactRevision,
-      rootFinalizerPhase: "batch",
+      rootReleasePhase: "prune",
       terminateAfterApplied: true,
-      ...(activeBatch.manifests === undefined
-        ? {}
-        : { manifests: activeBatch.manifests }),
+      verifiedRootDesiredIdentities,
     });
-    nextBatchIndex = activeBatchIndex + 1;
+    return;
   }
 
-  for (let index = nextBatchIndex; index < batches.length; index += 1) {
-    const batch = batches[index];
-    if (batch === undefined) {
-      throw new Error(`Exact root batch ${index.toString()} is missing`);
-    }
-    console.log(
-      `syncing exact root batch ${(index + 1).toString()}/${batches.length.toString()} (${batch.resources.length.toString()} resources)`,
-    );
-    await sync(rootAppName, timeoutSeconds, false, {
-      prune: false,
-      requestId: exactRequestId,
-      resources: batch.resources,
-      revision: exactRevision,
-      rootFinalizerPhase: "batch",
-      terminateAfterApplied: true,
-      ...(batch.manifests === undefined ? {} : { manifests: batch.manifests }),
-    });
-  }
+  await syncRootReleaseBatches(
+    rootAppName,
+    batches,
+    "batch",
+    exactRequestId,
+    exactRevision,
+    timeoutSeconds,
+    token,
+  );
 
   await sync(rootAppName, timeoutSeconds, false, {
     prune: true,
     requestId: exactRequestId,
     revision: exactRevision,
-    rootFinalizerPhase: "prune",
+    rootReleasePhase: "prune",
     terminateAfterApplied: true,
     verifiedRootDesiredIdentities,
   });
@@ -1094,7 +1245,7 @@ async function assertRootPruneSafe(
 type SyncOptions = {
   prune: boolean;
   requestId?: string;
-  rootFinalizerPhase?: RootFinalizerPhase;
+  rootReleasePhase?: RootReleasePhase;
   terminateAfterApplied?: boolean;
   verifiedRootDesiredIdentities?: ReadonlySet<string>;
   waitForCompletion?: boolean;
@@ -1121,22 +1272,22 @@ async function sync(
   const token = requireEnv("ARGOCD_TOKEN");
   const verifiedRootDesiredIdentities = options.verifiedRootDesiredIdentities;
   if (
-    options.rootFinalizerPhase !== undefined &&
+    options.rootReleasePhase !== undefined &&
     (appName !== "apps" ||
       options.requestId === undefined ||
       options.revision === undefined ||
       options.terminateAfterApplied !== true ||
-      (options.rootFinalizerPhase === "prune") !== options.prune)
+      (options.rootReleasePhase === "prune") !== options.prune)
   ) {
     throw new Error(
-      "Root finalizer phases require an identity-bound atomic apps batch or prune",
+      "Root release phases require an identity-bound atomic apps batch or prune",
     );
   }
   if (
     verifiedRootDesiredIdentities !== undefined &&
     (appName !== "apps" ||
       !options.prune ||
-      options.rootFinalizerPhase !== "prune" ||
+      options.rootReleasePhase !== "prune" ||
       options.terminateAfterApplied !== true)
   ) {
     throw new Error(
@@ -1232,7 +1383,7 @@ async function sync(
           requestId,
           options.revision,
           undefined,
-          options.rootFinalizerPhase,
+          options.rootReleasePhase,
         )
       ) {
         throw new Error(
@@ -1245,7 +1396,7 @@ async function sync(
         requestId,
         options.revision,
         operationId,
-        options.rootFinalizerPhase,
+        options.rootReleasePhase,
       );
       if (completedOperationMatches && baseline.phase === "Terminating") {
         if (
@@ -1294,12 +1445,12 @@ async function sync(
           ...(options.revision === undefined
             ? []
             : [{ name: SYNC_REVISION_INFO_NAME, value: options.revision }]),
-          ...(options.rootFinalizerPhase === undefined
+          ...(options.rootReleasePhase === undefined
             ? []
             : [
                 {
-                  name: ROOT_FINALIZER_PHASE_INFO_NAME,
-                  value: options.rootFinalizerPhase,
+                  name: ROOT_RELEASE_PHASE_INFO_NAME,
+                  value: options.rootReleasePhase,
                 },
               ]),
         ],
@@ -1342,11 +1493,11 @@ async function sync(
       );
     }
     if (
-      requestedOperationRootFinalizerPhase(responseBody) !==
-      options.rootFinalizerPhase
+      requestedOperationRootReleasePhase(responseBody) !==
+      options.rootReleasePhase
     ) {
       throw new Error(
-        `Argo sync response returned a different root finalizer phase; expected ${options.rootFinalizerPhase ?? "none"}`,
+        `Argo sync response returned a different root release phase; expected ${options.rootReleasePhase ?? "none"}`,
       );
     }
     console.log(`sync operation started: ${appName}`);
@@ -1359,7 +1510,7 @@ async function sync(
     token,
     requestId,
     operationId,
-    rootFinalizerPhase: options.rootFinalizerPhase,
+    rootReleasePhase: options.rootReleasePhase,
     expectedResourceIdentities,
     revision: options.revision,
     timeoutSeconds,
@@ -1377,12 +1528,12 @@ type OperationObservation = {
   readonly liveOperationId: string | null;
   readonly liveRequestId: string | null;
   readonly liveRevision: string | undefined;
-  readonly liveRootFinalizerPhase: RootFinalizerPhase | undefined;
+  readonly liveRootReleasePhase: RootReleasePhase | undefined;
   readonly operationId: string | null;
   readonly phase: string;
   readonly requestId: string | null;
   readonly revision: string | undefined;
-  readonly rootFinalizerPhase: RootFinalizerPhase | undefined;
+  readonly rootReleasePhase: RootReleasePhase | undefined;
   readonly startedAt: string | undefined;
   readonly state: Record<string, unknown>;
 };
@@ -1406,10 +1557,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
       liveOperation === undefined
         ? undefined
         : operationRevision(liveOperation),
-    liveRootFinalizerPhase:
+    liveRootReleasePhase:
       liveOperation === undefined
         ? undefined
-        : operationRootFinalizerPhase(liveOperation),
+        : operationRootReleasePhase(liveOperation),
     phase: typeof phase === "string" ? phase : "",
     operationId: completedOperationId(app),
     requestId: completedOperationRequestId(app),
@@ -1417,10 +1568,10 @@ function observeOperation(app: Record<string, unknown>): OperationObservation {
       completedOperation === undefined
         ? undefined
         : operationRevision(completedOperation),
-    rootFinalizerPhase:
+    rootReleasePhase:
       completedOperation === undefined
         ? undefined
-        : operationRootFinalizerPhase(completedOperation),
+        : operationRootReleasePhase(completedOperation),
     startedAt: OperationStartedAtSchema.parse(state["startedAt"]),
     state,
   };
@@ -1431,15 +1582,15 @@ function liveOperationMatches(
   requestId: string,
   revision: string | undefined,
   operationId?: string | null,
-  rootFinalizerPhase?: RootFinalizerPhase,
+  rootReleasePhase?: RootReleasePhase,
 ): boolean {
   return (
     operation.hasLiveOperation &&
     operation.liveRequestId === requestId &&
     (revision === undefined || operation.liveRevision === revision) &&
     (operationId === undefined || operation.liveOperationId === operationId) &&
-    (rootFinalizerPhase === undefined ||
-      operation.liveRootFinalizerPhase === rootFinalizerPhase)
+    (rootReleasePhase === undefined ||
+      operation.liveRootReleasePhase === rootReleasePhase)
   );
 }
 
@@ -1448,14 +1599,14 @@ function operationMatches(
   requestId: string,
   revision: string | undefined,
   operationId?: string | null,
-  rootFinalizerPhase?: RootFinalizerPhase,
+  rootReleasePhase?: RootReleasePhase,
 ): boolean {
   return (
     operation.requestId === requestId &&
     (revision === undefined || operation.revision === revision) &&
     (operationId === undefined || operation.operationId === operationId) &&
-    (rootFinalizerPhase === undefined ||
-      operation.rootFinalizerPhase === rootFinalizerPhase)
+    (rootReleasePhase === undefined ||
+      operation.rootReleasePhase === rootReleasePhase)
   );
 }
 
@@ -1632,7 +1783,7 @@ type WaitForIdentifiedOperationOptions = {
   readonly operationId: string;
   readonly requestId: string;
   readonly revision: string | undefined;
-  readonly rootFinalizerPhase: RootFinalizerPhase | undefined;
+  readonly rootReleasePhase: RootReleasePhase | undefined;
   readonly terminateAfterApplied: boolean;
   readonly timeoutSeconds: number;
   readonly token: string;
@@ -1644,7 +1795,7 @@ async function waitForIdentifiedOperation({
   operationId,
   requestId,
   revision,
-  rootFinalizerPhase,
+  rootReleasePhase,
   terminateAfterApplied,
   timeoutSeconds,
   token,
@@ -1660,14 +1811,14 @@ async function waitForIdentifiedOperation({
       requestId,
       revision,
       operationId,
-      rootFinalizerPhase,
+      rootReleasePhase,
     );
     const isExpectedLiveOperation = liveOperationMatches(
       current,
       requestId,
       revision,
       operationId,
-      rootFinalizerPhase,
+      rootReleasePhase,
     );
     if (current.hasLiveOperation && !isExpectedLiveOperation) {
       throw new Error(
@@ -2083,7 +2234,10 @@ async function reconcileRelease(
   dryRun: boolean,
   deferredApps: ReadonlySet<string>,
   waitForHealth: boolean,
+  requestId: string | undefined,
 ): Promise<void> {
+  const exactRequestId =
+    requestId === undefined ? undefined : SyncRequestIdSchema.parse(requestId);
   const expected = ExpectedApplicationsSchema.parse(
     JSON.parse(await Bun.file(expectedPath).text()),
   );
@@ -2150,10 +2304,11 @@ async function reconcileRelease(
     if (deployedExpectedRepositoryRelease || deployedExpectedExternalSource) {
       continue;
     }
-    await assertApplySafe(wanted.name, token);
+    await assertApplySafe(wanted.name, token, wanted.revision);
     await sync(wanted.name, timeoutSeconds, false, {
       prune: wanted.prune,
       revision: wanted.revision,
+      ...(exactRequestId === undefined ? {} : { requestId: exactRequestId }),
     });
   }
   if (waitForHealth) {
@@ -2214,13 +2369,20 @@ async function releaseRoot(
   console.log(
     `--- argocd release-root: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
   );
-  await stageRootRelease(rootAppName, exactRevision, timeoutSeconds, dryRun);
+  await stageRootRelease(
+    rootAppName,
+    exactRevision,
+    exactRequestId,
+    timeoutSeconds,
+    dryRun,
+  );
   await reconcileRelease(
     expectedPath,
     timeoutSeconds,
     dryRun,
     new Set(),
     false,
+    exactRequestId,
   );
   await finalizeRootRelease(
     rootAppName,
@@ -2535,7 +2697,7 @@ async function main(): Promise<void> {
           ? undefined
           : SyncRequestIdSchema.parse(requestId);
       if (!dryRun) {
-        await assertApplySafe(app, requireEnv("ARGOCD_TOKEN"));
+        await assertApplySafe(app, requireEnv("ARGOCD_TOKEN"), revision);
       }
       await sync(app, timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S, dryRun, {
         prune: argv.includes("--prune"),
@@ -2628,17 +2790,22 @@ async function main(): Promise<void> {
         dryRun,
         new Set(),
         !argv.includes("--skip-health-wait"),
+        flag(argv, "request-id"),
       );
       return;
     case "stage-root-release": {
       const revision = flag(argv, "revision");
-      if (revision === undefined) {
-        console.error("--revision is required for stage-root-release.");
+      const requestId = flag(argv, "request-id");
+      if (revision === undefined || requestId === undefined) {
+        console.error(
+          "--revision and --request-id are required for stage-root-release.",
+        );
         usage();
       }
       await stageRootRelease(
         app,
         revision,
+        requestId,
         timeoutOverride ?? DEFAULT_SYNC_TIMEOUT_S,
         dryRun,
       );

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -477,6 +477,18 @@ async function assertApplySafe(
   token: string,
   revision: string | undefined,
 ): Promise<void> {
+  // The hard refresh is the price of a trustworthy answer, not an oversight.
+  // `managed-resources` is served from Argo's cached comparison, which the
+  // controller only recomputes every `timeout.reconciliation` (60s), so without
+  // it this can decide apply safety from live state a minute out of date and
+  // wave through a change the API server then rejects mid-release.
+  //
+  // It is also already minimal. `refresh=hard` is per-application — there is no
+  // batch form — and the caller loop reaches this only for children it is about
+  // to sync, having skipped the converged ones. Folding it into the caller's
+  // own read would save a request but make a safety precondition depend on
+  // every future caller remembering to pre-refresh; this function is also
+  // invoked standalone by `sync-managed`.
   await getApplication(appName, token, "hard");
   const url = new URL(
     `/api/v1/applications/${encodeURIComponent(appName)}/managed-resources`,

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -2228,6 +2228,32 @@ function canonicalJson(value: unknown): string {
   return serialized;
 }
 
+/**
+ * The release inventory is operator input, so every command that consumes it
+ * parses and binds it before mutating anything. `release-root` validates it
+ * ahead of staging so invalid input cannot leave root prerequisites applied
+ * and child auto-sync suspended.
+ */
+async function readExpectedApplications(
+  expectedPath: string,
+): Promise<readonly ExpectedApplication[]> {
+  return ExpectedApplicationsSchema.parse(
+    JSON.parse(await Bun.file(expectedPath).text()),
+  );
+}
+
+function expectedAppsRelease(
+  expected: readonly ExpectedApplication[],
+): ExpectedApplication {
+  const appsRelease = expected.find(
+    (application) => application.name === "apps",
+  );
+  if (appsRelease === undefined) {
+    throw new Error("Expected release inventory is missing the apps revision");
+  }
+  return appsRelease;
+}
+
 async function reconcileRelease(
   expectedPath: string,
   timeoutSeconds: number,
@@ -2238,9 +2264,7 @@ async function reconcileRelease(
 ): Promise<void> {
   const exactRequestId =
     requestId === undefined ? undefined : SyncRequestIdSchema.parse(requestId);
-  const expected = ExpectedApplicationsSchema.parse(
-    JSON.parse(await Bun.file(expectedPath).text()),
-  );
+  const expected = await readExpectedApplications(expectedPath);
   if (dryRun) {
     console.log(
       `DRYRUN: would reconcile ${expected.length.toString()} expected Application(s)` +
@@ -2250,12 +2274,7 @@ async function reconcileRelease(
     );
     return;
   }
-  const appsRelease = expected.find(
-    (application) => application.name === "apps",
-  );
-  if (appsRelease === undefined) {
-    throw new Error("Expected release inventory is missing the apps revision");
-  }
+  const appsRelease = expectedAppsRelease(expected);
   await assertExpectedAppsRevisionIsLatest(
     appsRelease.revision,
     timeoutSeconds,
@@ -2321,9 +2340,7 @@ async function releaseHealthWait(
   timeoutSeconds: number,
   dryRun: boolean,
 ): Promise<void> {
-  const expected = ExpectedApplicationsSchema.parse(
-    JSON.parse(await Bun.file(expectedPath).text()),
-  );
+  const expected = await readExpectedApplications(expectedPath);
   console.log(
     `--- argocd release-health-wait: ${expected.length.toString()} expected Application(s)`,
   );
@@ -2366,6 +2383,14 @@ async function releaseRoot(
   }
   const exactRevision = BuildRevisionSchema.parse(revision);
   const exactRequestId = SyncRequestIdSchema.parse(requestId);
+  const appsRelease = expectedAppsRelease(
+    await readExpectedApplications(expectedPath),
+  );
+  if (appsRelease.revision !== exactRevision) {
+    throw new Error(
+      `Release inventory declares apps ${appsRelease.revision}; expected ${exactRevision}`,
+    );
+  }
   console.log(
     `--- argocd release-root: ${rootAppName} at ${exactRevision} for request ${exactRequestId}${dryRun ? " (dry run)" : ""}`,
   );

--- a/packages/homelab/scripts/argocd.ts
+++ b/packages/homelab/scripts/argocd.ts
@@ -611,6 +611,16 @@ function activeOperationResourceIdentities(
   );
 }
 
+/**
+ * Deliberately reads only the current info key, with no fallback to the
+ * `ci.sjer.red/root-finalizer-phase` name this replaced. An operation carrying
+ * the old key was started by a different Buildkite build, so
+ * `liveOperationMatches` has already refused it on the request UUID before the
+ * phase is ever compared — a fallback could not change any outcome, and
+ * teaching the closed-world comparison to accept a key this code never writes
+ * would weaken it. Such an operation still parses cleanly: the info schema is
+ * loose and unknown names are filtered out rather than rejected.
+ */
 function operationReleasePhase(
   operation: Record<string, unknown>,
 ): ReleasePhase | undefined {

--- a/packages/homelab/src/cdk8s/package.json
+++ b/packages/homelab/src/cdk8s/package.json
@@ -38,6 +38,7 @@
     "ts-pattern": "^5.9.0",
     "zod": "^4.4.3",
     "@shepherdjerred/helm-types": "workspace:*",
+    "@shepherdjerred/version-catalog": "workspace:*",
     "@grafana/grafana-foundation-sdk": "11.6.0-cogv0.0.x.1769699379"
   },
   "devDependencies": {

--- a/packages/homelab/src/cdk8s/scripts/generate-helm-types.ts
+++ b/packages/homelab/src/cdk8s/scripts/generate-helm-types.ts
@@ -6,7 +6,7 @@
  *
  * Modes:
  *   (default)  Regenerate `generated/helm/` in place from the chart versions in
- *              `src/version-catalog.json`.
+ *              `packages/version-catalog/src/catalog.json`.
  *   --check    Regenerate into a throwaway dir and FAIL (exit 1) if the result
  *              differs from the committed `generated/helm/` tree — without
  *              mutating it. Runs in CI as the `helm-types-drift-check`
@@ -27,7 +27,7 @@ import {
   type ChartInfo,
 } from "./parse-helm-charts.ts";
 
-const VERSION_CATALOG_FILE = "src/version-catalog.json";
+const VERSION_CATALOG_FILE = "../../../version-catalog/src/catalog.json";
 const OUTPUT_DIR = "generated/helm";
 // Throwaway dir used by --check so the committed tree is never mutated. Kept as
 // a sibling of OUTPUT_DIR under `generated/` so prettier resolves the SAME
@@ -240,14 +240,14 @@ async function checkHelmTypes() {
       console.error(`   - ${entry}`);
     }
     console.error(
-      "\nThe committed generated/helm/ tree does not match what src/version-catalog.json produces.\n" +
+      "\nThe committed generated/helm/ tree does not match what packages/version-catalog/src/catalog.json produces.\n" +
         "Fix: run `bun run generate-helm-types` in packages/homelab/src/cdk8s, then\n" +
         "commit packages/homelab/src/cdk8s/generated/helm/.\n",
     );
     process.exit(1);
   }
   console.log(
-    "\n✅ Committed Helm types are in sync with src/version-catalog.json",
+    "\n✅ Committed Helm types are in sync with packages/version-catalog/src/catalog.json",
   );
 }
 

--- a/packages/homelab/src/cdk8s/scripts/generate-version-map-schema.ts
+++ b/packages/homelab/src/cdk8s/scripts/generate-version-map-schema.ts
@@ -6,7 +6,10 @@ const CatalogNamesSchema = z.object({
 });
 
 async function main(): Promise<void> {
-  const catalogPath = new URL("../src/version-catalog.json", import.meta.url);
+  const catalogPath = new URL(
+    "../../../../version-catalog/src/catalog.json",
+    import.meta.url,
+  );
   const outputPath = new URL(
     "../src/version-map.generated.ts",
     import.meta.url,

--- a/packages/homelab/src/cdk8s/scripts/parse-helm-charts.ts
+++ b/packages/homelab/src/cdk8s/scripts/parse-helm-charts.ts
@@ -1,6 +1,6 @@
 /** Parse Helm chart information from the language-neutral version catalog. */
 
-import { parseVersionCatalogText } from "@shepherdjerred/homelab/cdk8s/src/version-catalog.ts";
+import { parseVersionCatalogText } from "@shepherdjerred/version-catalog";
 
 export type ChartInfo = {
   name: string;
@@ -19,7 +19,7 @@ function bareVersion(value: string): string {
 }
 
 export async function parseChartInfoFromVersions(
-  catalogPath = "src/version-catalog.json",
+  catalogPath = "../../../version-catalog/src/catalog.json",
 ): Promise<ChartInfo[]> {
   const catalog = parseVersionCatalogText(await Bun.file(catalogPath).text());
   return catalog.entries

--- a/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
@@ -3,14 +3,18 @@ import { App, Chart } from "cdk8s";
 import { z } from "zod";
 import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/argoproj.io.ts";
 import {
+  ARGOCD_SYNC_WAVE_ANNOTATION,
   APPLICATION_LIFECYCLE_ANNOTATION,
   APPLICATION_RESOURCES_FINALIZER,
+  MANAGED_APPLICATION_LABEL,
   applyApplicationReleasePolicy,
 } from "./application-release-policy.ts";
 
 const ManifestSchema = z.object({
   metadata: z.object({
+    name: z.string(),
     annotations: z.record(z.string(), z.string()),
+    labels: z.record(z.string(), z.string()).optional(),
     finalizers: z.array(z.string()).optional(),
   }),
   spec: z.object({
@@ -44,7 +48,7 @@ function application(chart: Chart, name: string): Application {
 describe("applyApplicationReleasePolicy", () => {
   test("adds cascading finalizers and explicit retain exceptions", () => {
     const app = new App();
-    const chart = new Chart(app, "test");
+    const chart = new Chart(app, "apps");
     const worker = application(chart, "worker");
     const root = application(chart, "apps");
     applyApplicationReleasePolicy(app);
@@ -56,6 +60,12 @@ describe("applyApplicationReleasePolicy", () => {
     expect(workerManifest.metadata.finalizers).toEqual([
       APPLICATION_RESOURCES_FINALIZER,
     ]);
+    expect(workerManifest.metadata.labels?.[MANAGED_APPLICATION_LABEL]).toBe(
+      "true",
+    );
+    expect(
+      workerManifest.metadata.annotations[ARGOCD_SYNC_WAVE_ANNOTATION],
+    ).toBe("4");
     expect(workerManifest.spec.syncPolicy?.automated).toEqual({
       enabled: false,
     });
@@ -65,8 +75,39 @@ describe("applyApplicationReleasePolicy", () => {
       rootManifest.metadata.annotations[APPLICATION_LIFECYCLE_ANNOTATION],
     ).toBe("retain");
     expect(rootManifest.metadata.finalizers).toBeUndefined();
+    expect(
+      rootManifest.metadata.labels?.[MANAGED_APPLICATION_LABEL],
+    ).toBeUndefined();
+    expect(rootManifest.metadata.annotations[ARGOCD_SYNC_WAVE_ANNOTATION]).toBe(
+      "0",
+    );
     expect(rootManifest.spec.syncPolicy?.automated).toEqual({
       enabled: false,
     });
+  });
+
+  test("orders providers, controllers, dependencies, and leaf Applications", () => {
+    const app = new App();
+    const chart = new Chart(app, "apps");
+    const expectedWaves = new Map([
+      ["1password", "-20"],
+      ["argocd", "-18"],
+      ["tailscale", "-18"],
+      ["kueue", "1"],
+      ["buildkite", "3"],
+      ["worker", "4"],
+    ]);
+    const applications = [...expectedWaves.keys()].map((name) =>
+      application(chart, name),
+    );
+
+    applyApplicationReleasePolicy(app);
+
+    for (const resource of applications) {
+      const manifest = ManifestSchema.parse(resource.toJson());
+      expect(manifest.metadata.annotations[ARGOCD_SYNC_WAVE_ANNOTATION]).toBe(
+        expectedWaves.get(manifest.metadata.name),
+      );
+    }
   });
 });

--- a/packages/homelab/src/cdk8s/src/application-release-policy.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.ts
@@ -1,4 +1,4 @@
-import { ApiObject, JsonPatch, type App } from "cdk8s";
+import { ApiObject, Chart, JsonPatch, type App } from "cdk8s";
 import { z } from "zod";
 import { releaseChartRevisions } from "./release-configuration.ts";
 
@@ -6,8 +6,37 @@ export const APPLICATION_RESOURCES_FINALIZER =
   "resources-finalizer.argocd.argoproj.io";
 export const APPLICATION_LIFECYCLE_ANNOTATION =
   "ci.sjer.red/application-lifecycle";
+export const MANAGED_APPLICATION_LABEL = "ci.sjer.red/managed-application";
+export const ARGOCD_SYNC_WAVE_ANNOTATION = "argocd.argoproj.io/sync-wave";
+
+export const APPLICATION_SYNC_WAVES = {
+  admissionPolicy: "-30",
+  admissionBinding: "-29",
+  onePassword: "-20",
+  onePasswordItem: "-19",
+  provider: "-18",
+  certificateIssuer: "-4",
+  certificate: "-3",
+  structural: "0",
+  kueue: "1",
+  dependentConfiguration: "2",
+  buildkite: "3",
+  leaf: "4",
+} as const;
 
 const RETAIN_APPLICATIONS = new Set(["apps", "argocd"]);
+const PROVIDER_APPLICATIONS = new Set([
+  "argocd",
+  "cert-manager",
+  "cloudflare-operator",
+  "intel-device-plugin-operator",
+  "nfd",
+  "openebs",
+  "postgres-operator",
+  "prometheus",
+  "tailscale",
+  "velero",
+]);
 export const REPOSITORY_CHART_URLS = new Set([
   "https://chartmuseum.tailnet-1a49.ts.net",
   "https://chartmuseum.sjer.red",
@@ -28,71 +57,146 @@ const ApplicationManifestSchema = z.object({
   }),
 });
 
+function applicationSyncWave(name: string): string {
+  if (name === "apps") {
+    return APPLICATION_SYNC_WAVES.structural;
+  }
+  if (name === "1password") {
+    return APPLICATION_SYNC_WAVES.onePassword;
+  }
+  if (PROVIDER_APPLICATIONS.has(name)) {
+    return APPLICATION_SYNC_WAVES.provider;
+  }
+  if (name === "kueue") {
+    return APPLICATION_SYNC_WAVES.kueue;
+  }
+  if (name === "buildkite") {
+    return APPLICATION_SYNC_WAVES.buildkite;
+  }
+  return APPLICATION_SYNC_WAVES.leaf;
+}
+
+function rootResourceSyncWave(resource: ApiObject): string {
+  if (
+    resource.kind === "MutatingAdmissionPolicy" ||
+    resource.kind === "ValidatingAdmissionPolicy"
+  ) {
+    return APPLICATION_SYNC_WAVES.admissionPolicy;
+  }
+  if (
+    resource.kind === "MutatingAdmissionPolicyBinding" ||
+    resource.kind === "ValidatingAdmissionPolicyBinding"
+  ) {
+    return APPLICATION_SYNC_WAVES.admissionBinding;
+  }
+  if (resource.apiGroup === "onepassword.com") {
+    return APPLICATION_SYNC_WAVES.onePasswordItem;
+  }
+  if (resource.apiGroup === "cert-manager.io") {
+    return resource.kind === "Certificate"
+      ? APPLICATION_SYNC_WAVES.certificate
+      : APPLICATION_SYNC_WAVES.certificateIssuer;
+  }
+  if (
+    resource.apiGroup === "kueue.x-k8s.io" ||
+    resource.apiGroup === "monitoring.coreos.com" ||
+    resource.apiGroup === "networking.cfargotunnel.com" ||
+    (resource.apiGroup === "tailscale.com" && resource.kind === "ProxyClass")
+  ) {
+    return APPLICATION_SYNC_WAVES.dependentConfiguration;
+  }
+  return APPLICATION_SYNC_WAVES.structural;
+}
+
+function applyResourceReleasePolicy(
+  construct: ApiObject,
+  revisions: ReturnType<typeof releaseChartRevisions>,
+  seenRepositoryCharts: Set<string>,
+): void {
+  const isRootChartResource = Chart.of(construct).node.id === "apps";
+  const isApplication =
+    construct.kind === "Application" && construct.apiGroup === "argoproj.io";
+  if (!isApplication) {
+    if (isRootChartResource) {
+      construct.metadata.addAnnotation(
+        ARGOCD_SYNC_WAVE_ANNOTATION,
+        rootResourceSyncWave(construct),
+      );
+    }
+    return;
+  }
+  const parsedManifest = ApplicationManifestSchema.safeParse(
+    construct.toJson(),
+  );
+  if (!parsedManifest.success) {
+    throw new Error(
+      `Could not inspect Application ${construct.node.path}: ${z.prettifyError(parsedManifest.error)}`,
+    );
+  }
+  const manifest = parsedManifest.data;
+  const applicationName = manifest.metadata.name;
+  if (isRootChartResource) {
+    construct.metadata.addAnnotation(
+      ARGOCD_SYNC_WAVE_ANNOTATION,
+      applicationSyncWave(applicationName),
+    );
+  }
+  if (applicationName !== "apps") {
+    construct.metadata.addLabel(MANAGED_APPLICATION_LABEL, "true");
+  }
+  if (RETAIN_APPLICATIONS.has(applicationName)) {
+    construct.metadata.addAnnotation(
+      APPLICATION_LIFECYCLE_ANNOTATION,
+      "retain",
+    );
+  } else {
+    construct.metadata.addAnnotation(
+      APPLICATION_LIFECYCLE_ANNOTATION,
+      "cascade",
+    );
+    construct.metadata.addFinalizers(APPLICATION_RESOURCES_FINALIZER);
+  }
+
+  const chartName = manifest.spec.source.chart;
+  const isRepositoryChart =
+    chartName !== undefined &&
+    REPOSITORY_CHART_URLS.has(manifest.spec.source.repoURL);
+  if (
+    isRepositoryChart &&
+    manifest.spec.syncPolicy !== undefined &&
+    Object.hasOwn(manifest.spec.syncPolicy, "automated")
+  ) {
+    construct.addJsonPatch(
+      JsonPatch.replace("/spec/syncPolicy/automated", { enabled: false }),
+    );
+  }
+  if (
+    revisions === undefined ||
+    chartName === undefined ||
+    chartName === "apps" ||
+    !isRepositoryChart
+  ) {
+    return;
+  }
+  const revision = revisions[chartName];
+  if (revision === undefined) {
+    throw new Error(
+      `Release chart revision inventory is missing repository chart ${chartName}`,
+    );
+  }
+  seenRepositoryCharts.add(chartName);
+  construct.addJsonPatch(
+    JsonPatch.replace("/spec/source/targetRevision", revision),
+  );
+}
+
 export function applyApplicationReleasePolicy(app: App): void {
   const revisions = releaseChartRevisions();
   const seenRepositoryCharts = new Set<string>();
   for (const construct of app.node.findAll()) {
-    if (
-      !ApiObject.isApiObject(construct) ||
-      construct.kind !== "Application" ||
-      construct.apiGroup !== "argoproj.io"
-    ) {
-      continue;
+    if (ApiObject.isApiObject(construct)) {
+      applyResourceReleasePolicy(construct, revisions, seenRepositoryCharts);
     }
-    const parsedManifest = ApplicationManifestSchema.safeParse(
-      construct.toJson(),
-    );
-    if (!parsedManifest.success) {
-      throw new Error(
-        `Could not inspect Application ${construct.node.path}: ${z.prettifyError(parsedManifest.error)}`,
-      );
-    }
-    const manifest = parsedManifest.data;
-    const applicationName = manifest.metadata.name;
-    if (RETAIN_APPLICATIONS.has(applicationName)) {
-      construct.metadata.addAnnotation(
-        APPLICATION_LIFECYCLE_ANNOTATION,
-        "retain",
-      );
-    } else {
-      construct.metadata.addAnnotation(
-        APPLICATION_LIFECYCLE_ANNOTATION,
-        "cascade",
-      );
-      construct.metadata.addFinalizers(APPLICATION_RESOURCES_FINALIZER);
-    }
-
-    const chartName = manifest.spec.source.chart;
-    const isRepositoryChart =
-      chartName !== undefined &&
-      REPOSITORY_CHART_URLS.has(manifest.spec.source.repoURL);
-    if (
-      isRepositoryChart &&
-      manifest.spec.syncPolicy !== undefined &&
-      Object.hasOwn(manifest.spec.syncPolicy, "automated")
-    ) {
-      construct.addJsonPatch(
-        JsonPatch.replace("/spec/syncPolicy/automated", { enabled: false }),
-      );
-    }
-    if (
-      revisions === undefined ||
-      chartName === undefined ||
-      chartName === "apps" ||
-      !isRepositoryChart
-    ) {
-      continue;
-    }
-    const revision = revisions[chartName];
-    if (revision === undefined) {
-      throw new Error(
-        `Release chart revision inventory is missing repository chart ${chartName}`,
-      );
-    }
-    seenRepositoryCharts.add(chartName);
-    construct.addJsonPatch(
-      JsonPatch.replace("/spec/source/targetRevision", revision),
-    );
   }
   if (revisions !== undefined) {
     const unused = Object.keys(revisions).filter(

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -63,10 +63,18 @@ function identifiedOperation(
   requestId: string,
   revision = REVISION,
   operationId: string | null = CURRENT_OPERATION_ID,
-  persistedRevision?: string,
+  options: {
+    readonly persistedRevision?: string;
+    readonly extraInfo?: readonly {
+      readonly name: string;
+      readonly value: string;
+    }[];
+  } = {},
 ): unknown {
+  const { persistedRevision, extraInfo = [] } = options;
   return {
     info: [
+      ...extraInfo,
       {
         name: "ci.sjer.red/request-id",
         value: requestId,
@@ -113,6 +121,10 @@ function applicationOperation(options: {
     readonly kind: string;
     readonly name: string;
   }[];
+  readonly extraInfo?: readonly {
+    readonly name: string;
+    readonly value: string;
+  }[];
 }): unknown {
   const revision = options.revision ?? REVISION;
   const operationId =
@@ -123,17 +135,21 @@ function applicationOperation(options: {
     options.liveOperationId === undefined
       ? operationId
       : options.liveOperationId;
+  const identity = {
+    persistedRevision: options.persistedRevision,
+    extraInfo: options.extraInfo,
+  };
   const completedOperation = identifiedOperation(
     options.requestId,
     revision,
     operationId,
-    options.persistedRevision,
+    identity,
   );
   const liveOperation = identifiedOperation(
     options.requestId,
     revision,
     liveOperationId,
-    options.persistedRevision,
+    identity,
   );
   const live =
     options.live ??
@@ -767,6 +783,21 @@ for (const scenario of [
     error: "Refusing to replace active apps operation",
   },
   {
+    // An operation started before `ci.sjer.red/root-finalizer-phase` was
+    // renamed. It carries an info key this code no longer writes, which the
+    // loose info schema filters out rather than rejecting, so it is refused on
+    // request identity like any other foreign operation — never on a parse
+    // error, and never adopted. This is why `operationReleasePhase` needs no
+    // fallback to the old name.
+    name: "an operation carrying the superseded release-phase info key",
+    requestId: OTHER_REQUEST_ID,
+    revision: REVISION,
+    extraInfo: [
+      { name: "ci.sjer.red/root-finalizer-phase", value: "batch" },
+    ] as const,
+    error: "Refusing to replace active apps operation",
+  },
+  {
     name: "the same request ID at another revision",
     requestId: CURRENT_REQUEST_ID,
     revision: "2.0.0-41",
@@ -780,6 +811,7 @@ for (const scenario of [
         requestId: scenario.requestId,
         resources: [{ status: "Synced" }],
         revision: scenario.revision,
+        ...("extraInfo" in scenario ? { extraInfo: scenario.extraInfo } : {}),
       }),
     ]);
 

--- a/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-atomic-sync.test.ts
@@ -88,7 +88,12 @@ function identifiedOperation(
             },
           ]),
     ],
-    sync: { revision },
+    // Every sync in this file posts `--prune`, and Argo records
+    // `operation.sync.prune` only when it is true (`prune,omitempty`), so a
+    // live operation for these requests carries it. Omitting it made the
+    // fixture describe an operation that did not match the request the test
+    // itself posted.
+    sync: { prune: true, revision },
   };
 }
 

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -342,3 +342,120 @@ describe("Argo CD release inventory validation", () => {
     }
   });
 });
+
+describe("Argo CD child reconciliation identity", () => {
+  test("refuses to adopt a selective operation that shares the release identity", async () => {
+    const requestId = "11111111-1111-4111-8111-111111111111";
+    let syncPosts = 0;
+    const activeOperation = {
+      info: [
+        { name: "ci.sjer.red/request-id", value: requestId },
+        {
+          name: "ci.sjer.red/operation-id",
+          value: "22222222-2222-4222-8222-222222222222",
+        },
+        { name: "ci.sjer.red/revision", value: "2.0.0-42" },
+        { name: "ci.sjer.red/release-phase", value: "child" },
+      ],
+      sync: {
+        revision: "2.0.0-42",
+        resources: [{ group: "apps", kind: "Deployment", name: "worker" }],
+      },
+    };
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/charts/apps") {
+          return Response.json([
+            {
+              version: "2.0.0-42",
+              urls: ["charts/apps-2.0.0-42.tgz"],
+              digest: "a".repeat(64),
+            },
+          ]);
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps/manifests"
+        ) {
+          return Response.json({ manifests: [RepositoryApplication] });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname.endsWith("/managed-resources")
+        ) {
+          return Response.json({ items: [] });
+        }
+        if (request.method === "GET" && url.pathname.endsWith("/manifests")) {
+          return Response.json({ manifests: [] });
+        }
+        if (request.method === "POST" && url.pathname.endsWith("/sync")) {
+          syncPosts += 1;
+          return Response.json({});
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/worker"
+        ) {
+          return Response.json({
+            operation: activeOperation,
+            status: { sync: { status: "OutOfSync", revision: "2.0.0-41" } },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-"));
+    const expectedPath = path.join(directory, "expected.json");
+    await Bun.write(
+      expectedPath,
+      JSON.stringify([
+        { name: "apps", revision: "2.0.0-42" },
+        { name: "worker", revision: "2.0.0-42" },
+      ]),
+    );
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "reconcile-release",
+          expectedPath,
+          "--skip-health-wait",
+          "--request-id",
+          requestId,
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+            CHARTMUSEUM_ORIGIN: server.url.origin,
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain(
+        "Refusing to adopt a selective worker operation",
+      );
+      expect(syncPosts).toBe(0);
+    } finally {
+      await server.stop(true);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { MANAGED_APPLICATION_LABEL } from "@shepherdjerred/homelab/cdk8s/src/application-release-policy.ts";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -362,7 +363,7 @@ function activeChildOperation(sync: Record<string, unknown>) {
 
 async function reconcileAgainstActiveChildOperation(
   activeOperation: unknown,
-  workerSpec: Record<string, unknown> = {},
+  workerApplication: Record<string, unknown> = {},
 ): Promise<{
   exitCode: number;
   stderr: string;
@@ -409,7 +410,7 @@ async function reconcileAgainstActiveChildOperation(
       ) {
         return Response.json({
           operation: activeOperation,
-          spec: workerSpec,
+          ...workerApplication,
           status: { sync: { status: "OutOfSync", revision: "2.0.0-41" } },
         });
       }
@@ -509,8 +510,13 @@ describe("Argo CD child reconciliation identity", () => {
           syncOptions: ["ServerSideApply=true", "CreateNamespace=true"],
         }),
         {
-          syncPolicy: {
-            syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
+          // A managed child carries the label the admission policy matches on,
+          // which is what makes its declared options the expected ones.
+          metadata: { labels: { [MANAGED_APPLICATION_LABEL]: "true" } },
+          spec: {
+            syncPolicy: {
+              syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
+            },
           },
         },
       );

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -100,6 +100,12 @@ describe("Argo CD staged external release reconciliation", () => {
             ],
           });
         }
+        if (
+          request.method === "GET" &&
+          url.pathname.endsWith("/managed-resources")
+        ) {
+          return Response.json({ items: [] });
+        }
         const syncMatch = /^\/api\/v1\/applications\/([^/]+)\/sync$/.exec(
           url.pathname,
         );

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -265,3 +265,80 @@ describe("Argo CD staged external release reconciliation", () => {
     }
   });
 });
+
+describe("Argo CD release inventory validation", () => {
+  test("rejects an incomplete inventory before staging mutates the root", async () => {
+    let syncPosts = 0;
+    const renderedRevisions: (string | null)[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps/manifests"
+        ) {
+          renderedRevisions.push(url.searchParams.get("revision"));
+          return Response.json({ manifests: [RepositoryApplication] });
+        }
+        if (request.method === "POST" && url.pathname.endsWith("/sync")) {
+          syncPosts += 1;
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-"));
+    const expectedPath = path.join(directory, "expected.json");
+    await Bun.write(
+      expectedPath,
+      JSON.stringify([{ name: "apps", revision: "2.0.0-42" }]),
+    );
+
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "release-root",
+          "apps",
+          expectedPath,
+          "--revision",
+          "2.0.0-42",
+          "--request-id",
+          "11111111-1111-4111-8111-111111111111",
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+            CHARTMUSEUM_ORIGIN: server.url.origin,
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain(
+        "Release inventory is missing repository Application worker",
+      );
+      expect(renderedRevisions).toEqual(["2.0.0-42"]);
+      expect(stdout).not.toContain("stage-root-release");
+      expect(syncPosts).toBe(0);
+    } finally {
+      await server.stop(true);
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -362,7 +362,13 @@ function activeChildOperation(sync: Record<string, unknown>) {
 
 async function reconcileAgainstActiveChildOperation(
   activeOperation: unknown,
-): Promise<{ exitCode: number; stderr: string; syncPosts: number }> {
+  workerSpec: Record<string, unknown> = {},
+): Promise<{
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+  syncPosts: number;
+}> {
   let syncPosts = 0;
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -403,6 +409,7 @@ async function reconcileAgainstActiveChildOperation(
       ) {
         return Response.json({
           operation: activeOperation,
+          spec: workerSpec,
           status: { sync: { status: "OutOfSync", revision: "2.0.0-41" } },
         });
       }
@@ -445,11 +452,12 @@ async function reconcileAgainstActiveChildOperation(
         stdout: "pipe",
       },
     );
-    const [exitCode, stderr] = await Promise.all([
+    const [exitCode, stdout, stderr] = await Promise.all([
       process.exited,
+      new Response(process.stdout).text(),
       new Response(process.stderr).text(),
     ]);
-    return { exitCode, stderr, syncPosts };
+    return { exitCode, stderr, stdout, syncPosts };
   } finally {
     await server.stop(true);
     await rm(directory, { recursive: true, force: true });
@@ -471,6 +479,11 @@ describe("Argo CD child reconciliation identity", () => {
       sync: { manifests: ['{"kind":"Deployment"}'] },
     },
     { applies: "prune true", sync: { prune: true } },
+    {
+      applies: 'sync options ["Force=true"]',
+      sync: { syncOptions: ["Force=true"] },
+    },
+    { applies: "an unaccounted dryRun field", sync: { dryRun: true } },
   ];
 
   for (const { applies, sync } of divergentOperations) {
@@ -485,4 +498,27 @@ describe("Argo CD child reconciliation identity", () => {
       expect(syncPosts).toBe(0);
     });
   }
+
+  test("adopts an operation carrying the Application's declared sync options", async () => {
+    // Admission merges these into the operation server-side, so a legitimate
+    // live operation carries options the request never sent. Rejecting them
+    // would break every managed Application that declares any.
+    const { stdout, stderr, syncPosts } =
+      await reconcileAgainstActiveChildOperation(
+        activeChildOperation({
+          syncOptions: ["ServerSideApply=true", "CreateNamespace=true"],
+        }),
+        {
+          syncPolicy: {
+            syncOptions: ["CreateNamespace=true", "ServerSideApply=true"],
+          },
+        },
+      );
+
+    expect(stderr).not.toContain("Refusing to adopt");
+    expect(stdout).toContain("adopted active sync operation: worker");
+    // The adopted operation never completes in this fixture, so the run then
+    // times out waiting for it; that wait is not what this test covers.
+    expect(syncPosts).toBe(0);
+  });
 });

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -106,6 +106,9 @@ describe("Argo CD staged external release reconciliation", () => {
         ) {
           return Response.json({ items: [] });
         }
+        if (request.method === "GET" && url.pathname.endsWith("/manifests")) {
+          return Response.json({ manifests: [] });
+        }
         const syncMatch = /^\/api\/v1\/applications\/([^/]+)\/sync$/.exec(
           url.pathname,
         );

--- a/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-release-reconciliation.test.ts
@@ -343,119 +343,146 @@ describe("Argo CD release inventory validation", () => {
   });
 });
 
-describe("Argo CD child reconciliation identity", () => {
-  test("refuses to adopt a selective operation that shares the release identity", async () => {
-    const requestId = "11111111-1111-4111-8111-111111111111";
-    let syncPosts = 0;
-    const activeOperation = {
-      info: [
-        { name: "ci.sjer.red/request-id", value: requestId },
-        {
-          name: "ci.sjer.red/operation-id",
-          value: "22222222-2222-4222-8222-222222222222",
-        },
-        { name: "ci.sjer.red/revision", value: "2.0.0-42" },
-        { name: "ci.sjer.red/release-phase", value: "child" },
+const CHILD_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
+
+function activeChildOperation(sync: Record<string, unknown>) {
+  return {
+    info: [
+      { name: "ci.sjer.red/request-id", value: CHILD_REQUEST_ID },
+      {
+        name: "ci.sjer.red/operation-id",
+        value: "22222222-2222-4222-8222-222222222222",
+      },
+      { name: "ci.sjer.red/revision", value: "2.0.0-42" },
+      { name: "ci.sjer.red/release-phase", value: "child" },
+    ],
+    sync: { revision: "2.0.0-42", ...sync },
+  };
+}
+
+async function reconcileAgainstActiveChildOperation(
+  activeOperation: unknown,
+): Promise<{ exitCode: number; stderr: string; syncPosts: number }> {
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/charts/apps") {
+        return Response.json([
+          {
+            version: "2.0.0-42",
+            urls: ["charts/apps-2.0.0-42.tgz"],
+            digest: "a".repeat(64),
+          },
+        ]);
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        return Response.json({ manifests: [RepositoryApplication] });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname.endsWith("/managed-resources")
+      ) {
+        return Response.json({ items: [] });
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/manifests")) {
+        return Response.json({ manifests: [] });
+      }
+      if (request.method === "POST" && url.pathname.endsWith("/sync")) {
+        syncPosts += 1;
+        return Response.json({});
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker"
+      ) {
+        return Response.json({
+          operation: activeOperation,
+          status: { sync: { status: "OutOfSync", revision: "2.0.0-41" } },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-"));
+  const expectedPath = path.join(directory, "expected.json");
+  await Bun.write(
+    expectedPath,
+    JSON.stringify([
+      { name: "apps", revision: "2.0.0-42" },
+      { name: "worker", revision: "2.0.0-42" },
+    ]),
+  );
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "reconcile-release",
+        expectedPath,
+        "--skip-health-wait",
+        "--request-id",
+        CHILD_REQUEST_ID,
+        "--timeout",
+        "1",
       ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+    return { exitCode, stderr, syncPosts };
+  } finally {
+    await server.stop(true);
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("Argo CD child reconciliation identity", () => {
+  // Every one of these shares the release UUID, revision, and child phase
+  // marker, so only the request comparison can reject them.
+  const divergentOperations = [
+    {
+      applies: "a resource selection",
       sync: {
-        revision: "2.0.0-42",
         resources: [{ group: "apps", kind: "Deployment", name: "worker" }],
       },
-    };
-    const server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch(request) {
-        const url = new URL(request.url);
-        if (url.pathname === "/api/charts/apps") {
-          return Response.json([
-            {
-              version: "2.0.0-42",
-              urls: ["charts/apps-2.0.0-42.tgz"],
-              digest: "a".repeat(64),
-            },
-          ]);
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/api/v1/applications/apps/manifests"
-        ) {
-          return Response.json({ manifests: [RepositoryApplication] });
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname.endsWith("/managed-resources")
-        ) {
-          return Response.json({ items: [] });
-        }
-        if (request.method === "GET" && url.pathname.endsWith("/manifests")) {
-          return Response.json({ manifests: [] });
-        }
-        if (request.method === "POST" && url.pathname.endsWith("/sync")) {
-          syncPosts += 1;
-          return Response.json({});
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/api/v1/applications/worker"
-        ) {
-          return Response.json({
-            operation: activeOperation,
-            status: { sync: { status: "OutOfSync", revision: "2.0.0-41" } },
-          });
-        }
-        return new Response("not found", { status: 404 });
-      },
-    });
-    const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-"));
-    const expectedPath = path.join(directory, "expected.json");
-    await Bun.write(
-      expectedPath,
-      JSON.stringify([
-        { name: "apps", revision: "2.0.0-42" },
-        { name: "worker", revision: "2.0.0-42" },
-      ]),
-    );
+    },
+    {
+      applies: "a manifest override",
+      sync: { manifests: ['{"kind":"Deployment"}'] },
+    },
+    { applies: "prune true", sync: { prune: true } },
+  ];
 
-    try {
-      const process = Bun.spawn(
-        [
-          "bun",
-          "--no-install",
-          "scripts/argocd.ts",
-          "reconcile-release",
-          expectedPath,
-          "--skip-health-wait",
-          "--request-id",
-          requestId,
-          "--timeout",
-          "1",
-        ],
-        {
-          cwd: path.resolve(import.meta.dir, "../../.."),
-          env: {
-            ...Bun.env,
-            ARGOCD_SERVER_URL: server.url.origin,
-            ARGOCD_TOKEN: "test-token",
-            CHARTMUSEUM_ORIGIN: server.url.origin,
-          },
-          stderr: "pipe",
-          stdout: "pipe",
-        },
-      );
-      const [exitCode, stderr] = await Promise.all([
-        process.exited,
-        new Response(process.stderr).text(),
-      ]);
+  for (const { applies, sync } of divergentOperations) {
+    test(`refuses an active operation that applies ${applies}`, async () => {
+      const { exitCode, stderr, syncPosts } =
+        await reconcileAgainstActiveChildOperation(activeChildOperation(sync));
 
       expect(exitCode).not.toBe(0);
       expect(stderr).toContain(
-        "Refusing to adopt a selective worker operation",
+        `Refusing to adopt the active worker operation for request ${CHILD_REQUEST_ID}; it applies ${applies}`,
       );
       expect(syncPosts).toBe(0);
-    } finally {
-      await server.stop(true);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
+    });
+  }
 });

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -43,6 +43,10 @@ const SyncRequestSchema = z.object({
       group: z.string(),
       kind: z.string(),
       name: z.string(),
+      // Modelled because Zod strips unknown keys: without it the fixture
+      // silently dropped the namespace before serving the operation back, so
+      // no test could reach the parsing this file exercises.
+      namespace: z.string().optional(),
     }),
   ),
 });
@@ -409,148 +413,158 @@ test("root release finalization applies every exact wave before accepting a part
   }
 });
 
-test("root release finalization adopts the exact active batch without replaying prior waves", async () => {
-  const policyResource = {
-    group: "admissionregistration.k8s.io",
-    kind: "ValidatingAdmissionPolicy",
-    name: "pvc-backup-policy.sjer.red",
-  };
-  const activeBatchRequest = {
-    infos: releaseOperationInfo("batch"),
-    prune: false,
-    resources: [policyResource],
-    revision: "2.0.0-43",
-  };
-  let activeRequest: unknown = activeBatchRequest;
-  let requestedOperation: Record<string, unknown> | undefined =
-    operationForSyncRequest(activeBatchRequest);
-  let deleteRequests = 0;
-  let syncPosts = 0;
-  const server = Bun.serve({
-    hostname: "127.0.0.1",
-    port: 0,
-    async fetch(request) {
-      const url = new URL(request.url);
-      if (url.pathname === "/api/charts/apps") {
-        return Response.json([
-          {
-            version: "2.0.0-43",
-            urls: ["charts/apps-2.0.0-43.tgz"],
-            digest: "a".repeat(64),
-          },
-        ]);
-      }
-      if (
-        request.method === "GET" &&
-        url.pathname === "/api/v1/applications/apps/manifests"
-      ) {
-        return Response.json({
-          manifests: [
-            StagedRootApplication,
-            StagedRepositoryApplication,
-            StagedExternalApplication,
-            StagedAdmissionPolicy,
-          ],
-        });
-      }
-      if (
-        request.method === "POST" &&
-        url.pathname === "/api/v1/applications/apps/sync"
-      ) {
-        syncPosts += 1;
-        activeRequest = await request.json();
-        requestedOperation = operationForRootSyncRequest(activeRequest);
-        return Response.json({ operation: requestedOperation });
-      }
-      if (
-        request.method === "DELETE" &&
-        url.pathname === "/api/v1/applications/apps/operation"
-      ) {
-        deleteRequests += 1;
-        activeRequest = undefined;
-        requestedOperation = undefined;
-        return Response.json({});
-      }
-      if (
-        request.method === "GET" &&
-        url.pathname === "/api/v1/applications/apps"
-      ) {
-        if (activeRequest === undefined || requestedOperation === undefined) {
-          return Response.json({ status: { resources: [] } });
+// A cluster-scoped selector has two equally valid spellings on the wire: Argo
+// may omit `namespace` or send it empty. Both name the same target, so adoption
+// has to accept either. Rejecting the empty one at the parse boundary aborted
+// the whole batch before it could even look at the active operation.
+for (const clusterScoped of [
+  { label: "an omitted namespace", fields: {} },
+  { label: "an empty namespace", fields: { namespace: "" } },
+]) {
+  test(`root release finalization adopts the exact active batch with ${clusterScoped.label} and without replaying prior waves`, async () => {
+    const policyResource = {
+      group: "admissionregistration.k8s.io",
+      kind: "ValidatingAdmissionPolicy",
+      name: "pvc-backup-policy.sjer.red",
+      ...clusterScoped.fields,
+    };
+    const activeBatchRequest = {
+      infos: releaseOperationInfo("batch"),
+      prune: false,
+      resources: [policyResource],
+      revision: "2.0.0-43",
+    };
+    let activeRequest: unknown = activeBatchRequest;
+    let requestedOperation: Record<string, unknown> | undefined =
+      operationForSyncRequest(activeBatchRequest);
+    let deleteRequests = 0;
+    let syncPosts = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/charts/apps") {
+          return Response.json([
+            {
+              version: "2.0.0-43",
+              urls: ["charts/apps-2.0.0-43.tgz"],
+              digest: "a".repeat(64),
+            },
+          ]);
         }
-        const manifestRequest = SyncRequestSchema.safeParse(activeRequest);
-        return Response.json({
-          operation: requestedOperation,
-          status: {
-            resources: [],
-            operationState: {
-              phase: "Running",
-              startedAt: new Date().toISOString(),
-              operation: requestedOperation,
-              syncResult: {
-                revision: "2.0.0-43",
-                resources: manifestRequest.success
-                  ? manifestRequest.data.resources.map((resource) => ({
-                      ...resource,
-                      status: "Synced",
-                    }))
-                  : [
-                      { ...RootApplicationResource, status: "Synced" },
-                      { ...WorkerApplicationResource, status: "Synced" },
-                    ],
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps/manifests"
+        ) {
+          return Response.json({
+            manifests: [
+              StagedRootApplication,
+              StagedRepositoryApplication,
+              StagedExternalApplication,
+              StagedAdmissionPolicy,
+            ],
+          });
+        }
+        if (
+          request.method === "POST" &&
+          url.pathname === "/api/v1/applications/apps/sync"
+        ) {
+          syncPosts += 1;
+          activeRequest = await request.json();
+          requestedOperation = operationForRootSyncRequest(activeRequest);
+          return Response.json({ operation: requestedOperation });
+        }
+        if (
+          request.method === "DELETE" &&
+          url.pathname === "/api/v1/applications/apps/operation"
+        ) {
+          deleteRequests += 1;
+          activeRequest = undefined;
+          requestedOperation = undefined;
+          return Response.json({});
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/apps"
+        ) {
+          if (activeRequest === undefined || requestedOperation === undefined) {
+            return Response.json({ status: { resources: [] } });
+          }
+          const manifestRequest = SyncRequestSchema.safeParse(activeRequest);
+          return Response.json({
+            operation: requestedOperation,
+            status: {
+              resources: [],
+              operationState: {
+                phase: "Running",
+                startedAt: new Date().toISOString(),
+                operation: requestedOperation,
+                syncResult: {
+                  revision: "2.0.0-43",
+                  resources: manifestRequest.success
+                    ? manifestRequest.data.resources.map((resource) => ({
+                        ...resource,
+                        status: "Synced",
+                      }))
+                    : [
+                        { ...RootApplicationResource, status: "Synced" },
+                        { ...WorkerApplicationResource, status: "Synced" },
+                      ],
+                },
               },
             },
-          },
-        });
-      }
-      return new Response("not found", { status: 404 });
-    },
-  });
-
-  try {
-    const process = Bun.spawn(
-      [
-        "bun",
-        "--no-install",
-        "scripts/argocd.ts",
-        "finalize-root-release",
-        "apps",
-        "--revision",
-        "2.0.0-43",
-        "--request-id",
-        RELEASE_REQUEST_ID,
-        "--timeout",
-        "1",
-      ],
-      {
-        cwd: path.resolve(import.meta.dir, "../../.."),
-        env: {
-          ...Bun.env,
-          ARGOCD_POLL_INTERVAL_MS: "5",
-          ARGOCD_SERVER_URL: server.url.origin,
-          ARGOCD_TOKEN: "test-token",
-          CHARTMUSEUM_ORIGIN: server.url.origin,
-        },
-        stderr: "pipe",
-        stdout: "pipe",
+          });
+        }
+        return new Response("not found", { status: 404 });
       },
-    );
-    const [exitCode, stdout, stderr] = await Promise.all([
-      process.exited,
-      new Response(process.stdout).text(),
-      new Response(process.stderr).text(),
-    ]);
+    });
 
-    expect(exitCode).toBe(0);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("adopting exact root batch 3/3 (1 resources)");
-    expect(stdout).not.toContain("syncing exact root batch 1/2");
-    expect(syncPosts).toBe(1);
-    expect(deleteRequests).toBe(2);
-  } finally {
-    await server.stop(true);
-  }
-});
+    try {
+      const process = Bun.spawn(
+        [
+          "bun",
+          "--no-install",
+          "scripts/argocd.ts",
+          "finalize-root-release",
+          "apps",
+          "--revision",
+          "2.0.0-43",
+          "--request-id",
+          RELEASE_REQUEST_ID,
+          "--timeout",
+          "1",
+        ],
+        {
+          cwd: path.resolve(import.meta.dir, "../../.."),
+          env: {
+            ...Bun.env,
+            ARGOCD_POLL_INTERVAL_MS: "5",
+            ARGOCD_SERVER_URL: server.url.origin,
+            ARGOCD_TOKEN: "test-token",
+            CHARTMUSEUM_ORIGIN: server.url.origin,
+          },
+          stderr: "pipe",
+          stdout: "pipe",
+        },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        process.exited,
+        new Response(process.stdout).text(),
+        new Response(process.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("adopting exact root batch 3/3 (1 resources)");
+      expect(stdout).not.toContain("syncing exact root batch 1/2");
+      expect(syncPosts).toBe(1);
+      expect(deleteRequests).toBe(2);
+    } finally {
+      await server.stop(true);
+    }
+  });
+}
 
 test("root release finalization adopts the exact active prune without another POST", async () => {
   const activeOperation = operationForRootSyncRequest({

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -844,3 +844,118 @@ test("release-root resumes at a live later phase instead of restaging", async ()
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("root release finalization refuses a batch selecting another namespace", async () => {
+  // Same group, kind, and name as the rendered policy, but a namespace the
+  // rendered revision never declares, so it is a different target.
+  const activeOperation = {
+    info: releaseOperationInfo("batch"),
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      prune: false,
+      resources: [
+        {
+          group: "admissionregistration.k8s.io",
+          kind: "ValidatingAdmissionPolicy",
+          name: "pvc-backup-policy.sjer.red",
+          namespace: "other",
+        },
+      ],
+      revision: "2.0.0-43",
+    },
+  };
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/charts/apps") {
+        return Response.json([
+          {
+            version: "2.0.0-43",
+            urls: ["charts/apps-2.0.0-43.tgz"],
+            digest: "a".repeat(64),
+          },
+        ]);
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        return Response.json({
+          manifests: [
+            StagedRootApplication,
+            StagedRepositoryApplication,
+            StagedExternalApplication,
+            StagedAdmissionPolicy,
+          ],
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/apps/sync"
+      ) {
+        syncPosts += 1;
+        return Response.json({});
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps"
+      ) {
+        return Response.json({
+          operation: activeOperation,
+          status: {
+            resources: [],
+            operationState: {
+              phase: "Running",
+              startedAt: new Date().toISOString(),
+              operation: activeOperation,
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "finalize-root-release",
+        "apps",
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_POLL_INTERVAL_MS: "5",
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("does not match an exact root batch");
+    expect(syncPosts).toBe(0);
+  } finally {
+    await server.stop(true);
+  }
+});

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -5,11 +5,11 @@ import { z } from "zod";
 const RELEASE_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 const RELEASE_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
 const BATCH_PHASE_INFO = {
-  name: "ci.sjer.red/root-release-phase",
+  name: "ci.sjer.red/release-phase",
   value: "batch",
 } as const;
 const PRUNE_PHASE_INFO = {
-  name: "ci.sjer.red/root-release-phase",
+  name: "ci.sjer.red/release-phase",
   value: "prune",
 } as const;
 
@@ -27,8 +27,8 @@ const SyncInfoEntrySchema = z.discriminatedUnion("name", [
     value: z.string(),
   }),
   z.object({
-    name: z.literal("ci.sjer.red/root-release-phase"),
-    value: z.enum(["batch", "prune"]),
+    name: z.literal("ci.sjer.red/release-phase"),
+    value: z.enum(["stage", "batch", "prune", "child"]),
   }),
 ]);
 
@@ -170,7 +170,7 @@ function releaseOperationInfo(phase: "batch" | "prune") {
     { name: "ci.sjer.red/request-id", value: RELEASE_REQUEST_ID },
     { name: "ci.sjer.red/operation-id", value: RELEASE_OPERATION_ID },
     { name: "ci.sjer.red/revision", value: "2.0.0-43" },
-    { name: "ci.sjer.red/root-release-phase", value: phase },
+    { name: "ci.sjer.red/release-phase", value: phase },
   ];
 }
 
@@ -558,7 +558,7 @@ test("root release finalization adopts the exact active prune without another PO
   });
   const unmarkedOperation = operationForRootSyncRequest({
     infos: releaseOperationInfo("prune").filter(
-      ({ name }) => name !== "ci.sjer.red/root-release-phase",
+      ({ name }) => name !== "ci.sjer.red/release-phase",
     ),
     prune: true,
     revision: "2.0.0-43",

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -614,6 +614,10 @@ test("root release finalization adopts the exact active prune without another PO
         const currentOperation = marked ? activeOperation : unmarkedOperation;
         return Response.json({
           operation: currentOperation,
+          // The real root declares sync options but is deliberately excluded
+          // from the sync-option admission policy (no managed label), so its
+          // operations legitimately carry none.
+          spec: { syncPolicy: { syncOptions: ["CreateNamespace=true"] } },
           status: {
             resources: [],
             operationState: {

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { z } from "zod";
 
@@ -710,5 +712,135 @@ test("root release finalization adopts the exact active prune without another PO
     expect(deleteRequests).toBe(1);
   } finally {
     await server.stop(true);
+  }
+});
+
+test("release-root resumes at a live later phase instead of restaging", async () => {
+  const activeOperation = operationForRootSyncRequest({
+    infos: releaseOperationInfo("prune"),
+    prune: true,
+    revision: "2.0.0-43",
+  });
+  let live = true;
+  let deleteRequests = 0;
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/charts/apps") {
+        return Response.json([
+          {
+            version: "2.0.0-43",
+            urls: ["charts/apps-2.0.0-43.tgz"],
+            digest: "a".repeat(64),
+          },
+        ]);
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps/manifests"
+      ) {
+        return Response.json({ manifests: [StagedRootApplication] });
+      }
+      if (request.method === "GET" && url.pathname === "/api/v1/applications") {
+        return Response.json({ items: [] });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/apps/sync"
+      ) {
+        syncPosts += 1;
+        return Response.json({});
+      }
+      if (
+        request.method === "DELETE" &&
+        url.pathname === "/api/v1/applications/apps/operation"
+      ) {
+        deleteRequests += 1;
+        live = false;
+        return Response.json({});
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/apps"
+      ) {
+        if (!live) {
+          return Response.json({ status: { resources: [] } });
+        }
+        return Response.json({
+          operation: activeOperation,
+          status: {
+            resources: [],
+            operationState: {
+              phase: "Running",
+              startedAt: new Date().toISOString(),
+              operation: activeOperation,
+              syncResult: {
+                revision: "2.0.0-43",
+                resources: [{ ...RootApplicationResource, status: "Synced" }],
+              },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const directory = await mkdtemp(path.join(tmpdir(), "argocd-resume-"));
+  const expectedPath = path.join(directory, "expected.json");
+  await Bun.write(
+    expectedPath,
+    JSON.stringify([{ name: "apps", revision: "2.0.0-43" }]),
+  );
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "release-root",
+        "apps",
+        expectedPath,
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_POLL_INTERVAL_MS: "5",
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+          CHARTMUSEUM_ORIGIN: server.url.origin,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain(
+      `resuming apps release at the prune phase for request ${RELEASE_REQUEST_ID}`,
+    );
+    expect(stdout).toContain("adopting active final root prune: apps");
+    expect(stdout).not.toContain("stage-root-release");
+    expect(syncPosts).toBe(0);
+    expect(deleteRequests).toBe(1);
+  } finally {
+    await server.stop(true);
+    await rm(directory, { recursive: true, force: true });
   }
 });

--- a/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-root-finalization.test.ts
@@ -5,11 +5,11 @@ import { z } from "zod";
 const RELEASE_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 const RELEASE_OPERATION_ID = "33333333-3333-4333-8333-333333333333";
 const BATCH_PHASE_INFO = {
-  name: "ci.sjer.red/root-finalizer-phase",
+  name: "ci.sjer.red/root-release-phase",
   value: "batch",
 } as const;
 const PRUNE_PHASE_INFO = {
-  name: "ci.sjer.red/root-finalizer-phase",
+  name: "ci.sjer.red/root-release-phase",
   value: "prune",
 } as const;
 
@@ -27,7 +27,7 @@ const SyncInfoEntrySchema = z.discriminatedUnion("name", [
     value: z.string(),
   }),
   z.object({
-    name: z.literal("ci.sjer.red/root-finalizer-phase"),
+    name: z.literal("ci.sjer.red/root-release-phase"),
     value: z.enum(["batch", "prune"]),
   }),
 ]);
@@ -170,7 +170,7 @@ function releaseOperationInfo(phase: "batch" | "prune") {
     { name: "ci.sjer.red/request-id", value: RELEASE_REQUEST_ID },
     { name: "ci.sjer.red/operation-id", value: RELEASE_OPERATION_ID },
     { name: "ci.sjer.red/revision", value: "2.0.0-43" },
-    { name: "ci.sjer.red/root-finalizer-phase", value: phase },
+    { name: "ci.sjer.red/root-release-phase", value: phase },
   ];
 }
 
@@ -558,7 +558,7 @@ test("root release finalization adopts the exact active prune without another PO
   });
   const unmarkedOperation = operationForRootSyncRequest({
     infos: releaseOperationInfo("prune").filter(
-      ({ name }) => name !== "ci.sjer.red/root-finalizer-phase",
+      ({ name }) => name !== "ci.sjer.red/root-release-phase",
     ),
     prune: true,
     revision: "2.0.0-43",

--- a/packages/homelab/src/cdk8s/src/argocd-script-support.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script-support.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+const SyncInfoEntrySchema = z.discriminatedUnion("name", [
+  z.object({
+    name: z.literal("ci.sjer.red/request-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/operation-id"),
+    value: z.uuid(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/revision"),
+    value: z.string(),
+  }),
+  z.object({
+    name: z.literal("ci.sjer.red/release-phase"),
+    value: z.enum(["stage", "batch", "prune", "child"]),
+  }),
+]);
+
+export const SyncRequestSchema = z.object({
+  infos: z.array(SyncInfoEntrySchema),
+  manifests: z.array(z.string()).optional(),
+  revision: z.string().optional(),
+  resources: z.array(
+    z.object({
+      group: z.string(),
+      kind: z.string(),
+      name: z.string(),
+    }),
+  ),
+});
+
+export const RootSyncRequestSchema = z.object({
+  infos: z.array(SyncInfoEntrySchema),
+  prune: z.boolean(),
+  revision: z.string().optional(),
+});
+
+export function operationForRootSyncRequest(
+  request: unknown,
+): Record<string, unknown> {
+  const syncRequest = RootSyncRequestSchema.parse(request);
+  return {
+    info: syncRequest.infos,
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      prune: syncRequest.prune,
+      ...(syncRequest.revision === undefined
+        ? {}
+        : { revision: syncRequest.revision }),
+    },
+  };
+}
+
+export function operationResponseForRootSync(request: unknown): unknown {
+  return { operation: operationForRootSyncRequest(request) };
+}
+
+export function operationForSyncRequest(
+  request: unknown,
+): Record<string, unknown> {
+  const syncRequest = SyncRequestSchema.parse(request);
+  return {
+    info: syncRequest.infos,
+    initiatedBy: { username: "buildkite" },
+    sync: {
+      ...(syncRequest.manifests === undefined
+        ? {}
+        : { manifests: syncRequest.manifests }),
+      resources: syncRequest.resources,
+    },
+  };
+}
+
+export type SyncRequest = z.infer<typeof SyncRequestSchema>;

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -26,8 +26,8 @@ const SyncInfoEntrySchema = z.discriminatedUnion("name", [
     value: z.string(),
   }),
   z.object({
-    name: z.literal("ci.sjer.red/root-release-phase"),
-    value: z.enum(["stage", "batch", "prune"]),
+    name: z.literal("ci.sjer.red/release-phase"),
+    value: z.enum(["stage", "batch", "prune", "child"]),
   }),
 ]);
 
@@ -826,7 +826,7 @@ function expectStagedRootRequests(syncBodies: readonly unknown[]): void {
     value: RELEASE_REQUEST_ID,
   });
   expect(applicationRequest.infos).toContainEqual({
-    name: "ci.sjer.red/root-release-phase",
+    name: "ci.sjer.red/release-phase",
     value: "stage",
   });
   expect(applicationRequest.resources).toEqual([
@@ -1028,6 +1028,9 @@ describe("Argo CD root release staging", () => {
 async function runReconcileRelease(
   origin: string,
   expected: readonly Record<string, unknown>[],
+  // Only the cases asserting request-bound adoption pass one; the rest exercise
+  // the unbound path, so an always-on identity would hide that difference.
+  requestId?: string,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-"));
   const expectedPath = path.join(directory, "expected.json");
@@ -1041,6 +1044,7 @@ async function runReconcileRelease(
         "reconcile-release",
         expectedPath,
         "--skip-health-wait",
+        ...(requestId === undefined ? [] : ["--request-id", requestId]),
         "--timeout",
         "1",
       ],
@@ -1070,6 +1074,7 @@ async function runReconcileRelease(
 describe("Argo CD stale release protection", () => {
   test("retries a failed operation recorded for an otherwise current app", async () => {
     let requestedOperation: Record<string, unknown> | undefined;
+    let childSyncBody: unknown;
     let syncPosts = 0;
     const server = Bun.serve({
       hostname: "127.0.0.1",
@@ -1090,9 +1095,9 @@ describe("Argo CD stale release protection", () => {
           url.pathname === "/api/v1/applications/worker/sync"
         ) {
           syncPosts += 1;
-          requestedOperation = operationForRootSyncRequest(
-            await request.json(),
-          );
+          const body: unknown = await request.json();
+          childSyncBody = body;
+          requestedOperation = operationForRootSyncRequest(body);
           return Response.json({ operation: requestedOperation });
         }
         if (
@@ -1162,6 +1167,7 @@ describe("Argo CD stale release protection", () => {
           { name: "apps", revision: "2.0.0-42" },
           { name: "worker", revision: "2.0.0-42" },
         ],
+        RELEASE_REQUEST_ID,
       );
 
       expect(exitCode).toBe(0);
@@ -1169,6 +1175,18 @@ describe("Argo CD stale release protection", () => {
       expect(stdout).toContain("sync operation started: worker");
       expect(stdout).toContain("synced: worker");
       expect(syncPosts).toBe(1);
+      const childRequest = RootSyncRequestSchema.parse(childSyncBody);
+      expect(childRequest.infos).toContainEqual({
+        name: "ci.sjer.red/request-id",
+        value: RELEASE_REQUEST_ID,
+      });
+      expect(childRequest.infos).toContainEqual({
+        name: "ci.sjer.red/release-phase",
+        value: "child",
+      });
+      expect(
+        Object.keys(z.record(z.string(), z.unknown()).parse(childSyncBody)),
+      ).not.toContain("resources");
     } finally {
       await server.stop(true);
     }

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -334,7 +334,7 @@ test("Argo CD root pruning requires an exact revision", async () => {
   );
 });
 
-test("Argo CD CLI usage documents atomic sync and recovery identity", async () => {
+test("Argo CD CLI usage exposes one root release command", async () => {
   const process = Bun.spawn(["bun", "--no-install", "scripts/argocd.ts"], {
     cwd: path.resolve(import.meta.dir, "../../.."),
     stderr: "pipe",
@@ -347,21 +347,174 @@ test("Argo CD CLI usage documents atomic sync and recovery identity", async () =
 
   expect(exitCode).not.toBe(0);
   expect(stderr).toContain(
-    "sync <app> [--revision <v>] [--prune] [--async | --terminate-after-applied]",
+    "sync-managed <app> [--revision <v>] [--prune] [--terminate-after-applied]",
   );
   expect(stderr).toContain("[--request-id <uuid>]");
   expect(stderr).toContain(
+    "release-root apps <expected.json> --revision <v> --request-id <uuid>",
+  );
+  expect(stderr).toContain(
     "suspend-auto-sync <root-app> [--revision <v>] [--timeout <s>]",
   );
-  expect(stderr).toContain(
-    "stage-root-release <root-app> --revision <v> [--timeout <s>]",
+  expect(stderr).not.toContain("stage-root-release <root-app>");
+  expect(stderr).not.toContain("finalize-root-release apps");
+  expect(stderr).not.toContain("finalize-async-sync <app>");
+});
+
+test("sync-managed rejects detached operations", async () => {
+  const process = Bun.spawn(
+    [
+      "bun",
+      "--no-install",
+      "scripts/argocd.ts",
+      "sync-managed",
+      "worker",
+      "--async",
+    ],
+    {
+      cwd: path.resolve(import.meta.dir, "../../.."),
+      stderr: "pipe",
+      stdout: "pipe",
+    },
   );
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+
+  expect(exitCode).not.toBe(0);
   expect(stderr).toContain(
-    "finalize-root-release apps --revision <v> --request-id <uuid>",
+    "sync-managed is bounded and does not support --async",
   );
-  expect(stderr).toContain(
-    "finalize-async-sync <app> --revision <v> --request-id <uuid>",
+});
+
+test("sync-managed preflights immutable changes before submitting", async () => {
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker" &&
+        url.searchParams.get("refresh") === "hard"
+      ) {
+        return Response.json({ status: {} });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/managed-resources"
+      ) {
+        return Response.json({
+          items: [
+            {
+              group: "apps",
+              kind: "Deployment",
+              namespace: "worker",
+              name: "worker",
+              liveState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "worker" } } },
+              }),
+              targetState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "api" } } },
+              }),
+            },
+          ],
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/worker/sync"
+      ) {
+        syncPosts += 1;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "sync-managed",
+        "worker",
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(
+      "apps/Deployment worker/worker changes immutable /spec/selector",
+    );
+    expect(syncPosts).toBe(0);
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("release-root owns the complete dry-run lifecycle", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-root-"));
+  const expectedPath = path.join(directory, "expected.json");
+  await Bun.write(
+    expectedPath,
+    JSON.stringify([{ name: "apps", revision: "2.0.0-42" }]),
   );
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "release-root",
+        "apps",
+        expectedPath,
+        "--revision",
+        "2.0.0-42",
+        "--request-id",
+        "11111111-1111-4111-8111-111111111111",
+        "--dry-run",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("argocd release-root: apps at 2.0.0-42");
+    expect(stdout).toContain("argocd stage-root-release: apps at 2.0.0-42");
+    expect(stdout).toContain("would reconcile 1 expected Application(s)");
+    expect(stdout).toContain("argocd finalize-root-release: apps at 2.0.0-42");
+    expect(stdout).toContain("argocd release-health-wait: 1 expected");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 describe("Argo CD root prune safety", () => {
@@ -628,6 +781,12 @@ describe("Argo CD release gating", () => {
           return Response.json({
             manifests: [repositoryApplication, externalApplication, configMap],
           });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/worker/managed-resources"
+        ) {
+          return Response.json({ items: [] });
         }
         if (
           request.method === "POST" &&
@@ -977,6 +1136,12 @@ describe("Argo CD stale release protection", () => {
             await request.json(),
           );
           return Response.json({ operation: requestedOperation });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/worker/managed-resources"
+        ) {
+          return Response.json({ items: [] });
         }
         if (
           request.method === "GET" &&

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -25,6 +25,10 @@ const SyncInfoEntrySchema = z.discriminatedUnion("name", [
     name: z.literal("ci.sjer.red/revision"),
     value: z.string(),
   }),
+  z.object({
+    name: z.literal("ci.sjer.red/root-release-phase"),
+    value: z.enum(["stage", "batch", "prune"]),
+  }),
 ]);
 
 const SyncRequestSchema = z.object({
@@ -65,6 +69,8 @@ function operationForRootSyncRequest(
 function operationResponseForRootSync(request: unknown): unknown {
   return { operation: operationForRootSyncRequest(request) };
 }
+
+const RELEASE_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 
 const WorkerApplicationResource = {
   group: "argoproj.io",
@@ -359,115 +365,6 @@ test("Argo CD CLI usage exposes one root release command", async () => {
   expect(stderr).not.toContain("stage-root-release <root-app>");
   expect(stderr).not.toContain("finalize-root-release apps");
   expect(stderr).not.toContain("finalize-async-sync <app>");
-});
-
-test("sync-managed rejects detached operations", async () => {
-  const process = Bun.spawn(
-    [
-      "bun",
-      "--no-install",
-      "scripts/argocd.ts",
-      "sync-managed",
-      "worker",
-      "--async",
-    ],
-    {
-      cwd: path.resolve(import.meta.dir, "../../.."),
-      stderr: "pipe",
-      stdout: "pipe",
-    },
-  );
-  const [exitCode, stderr] = await Promise.all([
-    process.exited,
-    new Response(process.stderr).text(),
-  ]);
-
-  expect(exitCode).not.toBe(0);
-  expect(stderr).toContain(
-    "sync-managed is bounded and does not support --async",
-  );
-});
-
-test("sync-managed preflights immutable changes before submitting", async () => {
-  let syncPosts = 0;
-  const server = Bun.serve({
-    hostname: "127.0.0.1",
-    port: 0,
-    async fetch(request) {
-      const url = new URL(request.url);
-      if (
-        request.method === "GET" &&
-        url.pathname === "/api/v1/applications/worker" &&
-        url.searchParams.get("refresh") === "hard"
-      ) {
-        return Response.json({ status: {} });
-      }
-      if (
-        request.method === "GET" &&
-        url.pathname === "/api/v1/applications/worker/managed-resources"
-      ) {
-        return Response.json({
-          items: [
-            {
-              group: "apps",
-              kind: "Deployment",
-              namespace: "worker",
-              name: "worker",
-              liveState: JSON.stringify({
-                spec: { selector: { matchLabels: { app: "worker" } } },
-              }),
-              targetState: JSON.stringify({
-                spec: { selector: { matchLabels: { app: "api" } } },
-              }),
-            },
-          ],
-        });
-      }
-      if (
-        request.method === "POST" &&
-        url.pathname === "/api/v1/applications/worker/sync"
-      ) {
-        syncPosts += 1;
-      }
-      return new Response("not found", { status: 404 });
-    },
-  });
-
-  try {
-    const process = Bun.spawn(
-      [
-        "bun",
-        "--no-install",
-        "scripts/argocd.ts",
-        "sync-managed",
-        "worker",
-        "--timeout",
-        "1",
-      ],
-      {
-        cwd: path.resolve(import.meta.dir, "../../.."),
-        env: {
-          ...Bun.env,
-          ARGOCD_SERVER_URL: server.url.origin,
-          ARGOCD_TOKEN: "test-token",
-        },
-        stderr: "pipe",
-        stdout: "pipe",
-      },
-    );
-    const [exitCode, stderr] = await Promise.all([
-      process.exited,
-      new Response(process.stderr).text(),
-    ]);
-
-    expect(exitCode).not.toBe(0);
-    expect(stderr).toContain(
-      "apps/Deployment worker/worker changes immutable /spec/selector",
-    );
-    expect(syncPosts).toBe(0);
-  } finally {
-    await server.stop(true);
-  }
 });
 
 test("release-root owns the complete dry-run lifecycle", async () => {
@@ -872,6 +769,56 @@ describe("Argo CD release gating", () => {
   });
 });
 
+function expectStagedRootRequests(syncBodies: readonly unknown[]): void {
+  const applicationRequest = SyncRequestSchema.parse(syncBodies[0]);
+  expect(applicationRequest.revision).toBe("2.0.0-43");
+  expect(applicationRequest.infos).toContainEqual({
+    name: "ci.sjer.red/revision",
+    value: "2.0.0-43",
+  });
+  expect(applicationRequest.infos).toContainEqual({
+    name: "ci.sjer.red/request-id",
+    value: RELEASE_REQUEST_ID,
+  });
+  expect(applicationRequest.infos).toContainEqual({
+    name: "ci.sjer.red/root-release-phase",
+    value: "stage",
+  });
+  expect(applicationRequest.resources).toEqual([
+    WorkerApplicationResource,
+    {
+      group: "argoproj.io",
+      kind: "Application",
+      name: "external",
+    },
+  ]);
+  const applicationManifests = applicationRequest.manifests;
+  if (applicationManifests === undefined) {
+    throw new Error("Staged Applications are missing manifest overrides");
+  }
+  const policyRequest = SyncRequestSchema.parse(syncBodies[1]);
+  expect(policyRequest.revision).toBe("2.0.0-43");
+  expect(policyRequest.resources).toEqual([
+    {
+      group: "admissionregistration.k8s.io",
+      kind: "ValidatingAdmissionPolicy",
+      name: "pvc-backup-policy.sjer.red",
+    },
+  ]);
+  expect(JSON.parse(applicationManifests[0] ?? "")).toMatchObject({
+    spec: { syncPolicy: { automated: { enabled: false } } },
+  });
+  expect(JSON.parse(applicationManifests[1] ?? "")).toMatchObject({
+    spec: {
+      source: {
+        helm: { valuesObject: { storage: { size: "10Gi" } } },
+      },
+      syncPolicy: { automated: { enabled: false } },
+    },
+  });
+  expect(policyRequest.manifests).toBeUndefined();
+}
+
 describe("Argo CD root release staging", () => {
   test("requires an exact root revision", async () => {
     const process = Bun.spawn(
@@ -895,7 +842,9 @@ describe("Argo CD root release staging", () => {
     ]);
 
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("--revision is required for stage-root-release");
+    expect(stderr).toContain(
+      "--revision and --request-id are required for stage-root-release",
+    );
   });
 
   test("stages root prerequisites while child auto-sync remains suspended", async () => {
@@ -994,6 +943,8 @@ describe("Argo CD root release staging", () => {
           "apps",
           "--revision",
           "2.0.0-43",
+          "--request-id",
+          RELEASE_REQUEST_ID,
           "--timeout",
           "1",
         ],
@@ -1022,45 +973,7 @@ describe("Argo CD root release staging", () => {
       expect(stdout).toContain("terminated applied sync operation: apps");
       expect(syncBodies).toHaveLength(2);
       expect(deleteRequests).toBe(2);
-      const applicationRequest = SyncRequestSchema.parse(syncBodies[0]);
-      expect(applicationRequest.revision).toBe("2.0.0-43");
-      expect(applicationRequest.infos).toContainEqual({
-        name: "ci.sjer.red/revision",
-        value: "2.0.0-43",
-      });
-      expect(applicationRequest.resources).toEqual([
-        WorkerApplicationResource,
-        {
-          group: "argoproj.io",
-          kind: "Application",
-          name: "external",
-        },
-      ]);
-      const applicationManifests = applicationRequest.manifests;
-      if (applicationManifests === undefined) {
-        throw new Error("Staged Applications are missing manifest overrides");
-      }
-      const policyRequest = SyncRequestSchema.parse(syncBodies[1]);
-      expect(policyRequest.revision).toBe("2.0.0-43");
-      expect(policyRequest.resources).toEqual([
-        {
-          group: "admissionregistration.k8s.io",
-          kind: "ValidatingAdmissionPolicy",
-          name: "pvc-backup-policy.sjer.red",
-        },
-      ]);
-      expect(JSON.parse(applicationManifests[0] ?? "")).toMatchObject({
-        spec: { syncPolicy: { automated: { enabled: false } } },
-      });
-      expect(JSON.parse(applicationManifests[1] ?? "")).toMatchObject({
-        spec: {
-          source: {
-            helm: { valuesObject: { storage: { size: "10Gi" } } },
-          },
-          syncPolicy: { automated: { enabled: false } },
-        },
-      });
-      expect(policyRequest.manifests).toBeUndefined();
+      expectStagedRootRequests(syncBodies);
     } finally {
       await server.stop(true);
     }
@@ -1142,6 +1055,13 @@ describe("Argo CD stale release protection", () => {
           url.pathname === "/api/v1/applications/worker/managed-resources"
         ) {
           return Response.json({ items: [] });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/api/v1/applications/worker/manifests"
+        ) {
+          expect(url.searchParams.get("revision")).toBe("2.0.0-42");
+          return Response.json({ manifests: [] });
         }
         if (
           request.method === "GET" &&

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -414,6 +414,51 @@ test("release-root owns the complete dry-run lifecycle", async () => {
   }
 });
 
+test("release-root rejects an inventory that names another apps revision", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "argocd-release-root-"));
+  const expectedPath = path.join(directory, "expected.json");
+  await Bun.write(
+    expectedPath,
+    JSON.stringify([{ name: "apps", revision: "2.0.0-42" }]),
+  );
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "release-root",
+        "apps",
+        expectedPath,
+        "--revision",
+        "2.0.0-43",
+        "--request-id",
+        RELEASE_REQUEST_ID,
+        "--dry-run",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(
+      "Release inventory declares apps 2.0.0-42; expected 2.0.0-43",
+    );
+    expect(stdout).not.toContain("stage-root-release");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 describe("Argo CD root prune safety", () => {
   test("blocks root pruning when a pruning child lacks the cascade finalizer", async () => {
     let syncPosts = 0;

--- a/packages/homelab/src/cdk8s/src/argocd-script.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-script.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
-import { z } from "zod";
+import {
+  operationForRootSyncRequest,
+  operationForSyncRequest,
+  operationResponseForRootSync,
+  RootSyncRequestSchema,
+  SyncRequestSchema,
+  type SyncRequest,
+} from "./argocd-script-support.ts";
 
 type RequestObservation = {
   authorization: string | null;
@@ -11,64 +19,6 @@ type RequestObservation = {
   path: string;
   query: string;
 };
-
-const SyncInfoEntrySchema = z.discriminatedUnion("name", [
-  z.object({
-    name: z.literal("ci.sjer.red/request-id"),
-    value: z.uuid(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/operation-id"),
-    value: z.uuid(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/revision"),
-    value: z.string(),
-  }),
-  z.object({
-    name: z.literal("ci.sjer.red/release-phase"),
-    value: z.enum(["stage", "batch", "prune", "child"]),
-  }),
-]);
-
-const SyncRequestSchema = z.object({
-  infos: z.array(SyncInfoEntrySchema),
-  manifests: z.array(z.string()).optional(),
-  revision: z.string().optional(),
-  resources: z.array(
-    z.object({
-      group: z.string(),
-      kind: z.string(),
-      name: z.string(),
-    }),
-  ),
-});
-
-const RootSyncRequestSchema = z.object({
-  infos: z.array(SyncInfoEntrySchema),
-  prune: z.boolean(),
-  revision: z.string().optional(),
-});
-
-function operationForRootSyncRequest(
-  request: unknown,
-): Record<string, unknown> {
-  const syncRequest = RootSyncRequestSchema.parse(request);
-  return {
-    info: syncRequest.infos,
-    initiatedBy: { username: "buildkite" },
-    sync: {
-      prune: syncRequest.prune,
-      ...(syncRequest.revision === undefined
-        ? {}
-        : { revision: syncRequest.revision }),
-    },
-  };
-}
-
-function operationResponseForRootSync(request: unknown): unknown {
-  return { operation: operationForRootSyncRequest(request) };
-}
 
 const RELEASE_REQUEST_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -118,20 +68,6 @@ const StagedExternalApplication = JSON.stringify({
     syncPolicy: { automated: { enabled: true } },
   },
 });
-
-function operationForSyncRequest(request: unknown): Record<string, unknown> {
-  const syncRequest = SyncRequestSchema.parse(request);
-  return {
-    info: syncRequest.infos,
-    initiatedBy: { username: "buildkite" },
-    sync: {
-      ...(syncRequest.manifests === undefined
-        ? {}
-        : { manifests: syncRequest.manifests }),
-      resources: syncRequest.resources,
-    },
-  };
-}
 
 function expectSuspendedWorkerRequest(request: unknown): void {
   const syncRequest = SyncRequestSchema.parse(request);
@@ -895,7 +831,7 @@ describe("Argo CD root release staging", () => {
   test("stages root prerequisites while child auto-sync remains suspended", async () => {
     const syncBodies: unknown[] = [];
     let requestedOperation: unknown;
-    let activeSyncRequest: z.infer<typeof SyncRequestSchema> | undefined;
+    let activeSyncRequest: SyncRequest | undefined;
     let deleteRequests = 0;
     const server = Bun.serve({
       hostname: "127.0.0.1",
@@ -1071,6 +1007,30 @@ async function runReconcileRelease(
   }
 }
 
+/**
+ * Every child sync is preceded by the apply-safety preflight, which reads the
+ * child's live inventory and renders the revision it is about to request.
+ * Cases that are not about apply safety answer both with nothing.
+ */
+function emptyPreflight(
+  request: Request,
+  url: URL,
+  app: string,
+  revision: string,
+): Response | null {
+  if (request.method !== "GET") {
+    return null;
+  }
+  if (url.pathname === `/api/v1/applications/${app}/managed-resources`) {
+    return Response.json({ items: [] });
+  }
+  if (url.pathname === `/api/v1/applications/${app}/manifests`) {
+    expect(url.searchParams.get("revision")).toBe(revision);
+    return Response.json({ manifests: [] });
+  }
+  return null;
+}
+
 describe("Argo CD stale release protection", () => {
   test("retries a failed operation recorded for an otherwise current app", async () => {
     let requestedOperation: Record<string, unknown> | undefined;
@@ -1100,18 +1060,9 @@ describe("Argo CD stale release protection", () => {
           requestedOperation = operationForRootSyncRequest(body);
           return Response.json({ operation: requestedOperation });
         }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/api/v1/applications/worker/managed-resources"
-        ) {
-          return Response.json({ items: [] });
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/api/v1/applications/worker/manifests"
-        ) {
-          expect(url.searchParams.get("revision")).toBe("2.0.0-42");
-          return Response.json({ manifests: [] });
+        const pre = emptyPreflight(request, url, "worker", "2.0.0-42");
+        if (pre !== null) {
+          return pre;
         }
         if (
           request.method === "GET" &&
@@ -1238,6 +1189,10 @@ describe("Argo CD stale release protection", () => {
               }),
             ],
           });
+        }
+        const lokiPreflight = emptyPreflight(request, url, "loki", "6.1.0");
+        if (lokiPreflight !== null) {
+          return lokiPreflight;
         }
         if (
           request.method === "GET" &&

--- a/packages/homelab/src/cdk8s/src/argocd-sync-managed.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-sync-managed.test.ts
@@ -209,3 +209,107 @@ test("sync-managed preflights the requested revision", async () => {
     await server.stop(true);
   }
 });
+
+test("sync-managed preflights a resource the requested revision introduces", async () => {
+  let syncPosts = 0;
+  const resourceQueries: string[] = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker" &&
+        url.searchParams.get("refresh") === "hard"
+      ) {
+        return Response.json({ status: {} });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/managed-resources"
+      ) {
+        // The configured revision does not know about the StatefulSet at all.
+        return Response.json({ items: [] });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/manifests"
+      ) {
+        expect(url.searchParams.get("revision")).toBe("2.0.0-43");
+        return Response.json({
+          manifests: [
+            JSON.stringify({
+              apiVersion: "apps/v1",
+              kind: "StatefulSet",
+              metadata: { name: "index", namespace: "worker" },
+              spec: { selector: { matchLabels: { app: "index-v2" } } },
+            }),
+          ],
+        });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/resource"
+      ) {
+        resourceQueries.push(url.search);
+        return Response.json({
+          manifest: JSON.stringify({
+            apiVersion: "apps/v1",
+            kind: "StatefulSet",
+            metadata: { name: "index", namespace: "worker" },
+            spec: { selector: { matchLabels: { app: "index" } } },
+          }),
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/worker/sync"
+      ) {
+        syncPosts += 1;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "sync-managed",
+        "worker",
+        "--revision",
+        "2.0.0-43",
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(
+      "apps/StatefulSet worker/index changes immutable /spec/selector",
+    );
+    expect(resourceQueries).toHaveLength(1);
+    expect(resourceQueries[0]).toContain("resourceName=index");
+    expect(resourceQueries[0]).toContain("namespace=worker");
+    expect(syncPosts).toBe(0);
+  } finally {
+    await server.stop(true);
+  }
+});

--- a/packages/homelab/src/cdk8s/src/argocd-sync-managed.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-sync-managed.test.ts
@@ -313,3 +313,141 @@ test("sync-managed preflights a resource the requested revision introduces", asy
     await server.stop(true);
   }
 });
+
+// The rendered manifest and the live inventory can each legitimately omit the
+// namespace for the same object, so a missing one on either side is a wildcard.
+// Two concrete, different namespaces are a real disagreement — and used to be
+// the quietest possible outcome, because no match meant no `targetState`, and a
+// resource without a target is skipped by the immutable checks entirely.
+function serveNamespaceScopedPreflight(options: {
+  readonly liveNamespace?: string;
+  readonly renderedNamespace?: string;
+}) {
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker" &&
+        url.searchParams.get("refresh") === "hard"
+      ) {
+        return Response.json({ status: {} });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/managed-resources"
+      ) {
+        return Response.json({
+          items: [
+            {
+              group: "apps",
+              kind: "Deployment",
+              name: "worker",
+              ...(options.liveNamespace === undefined
+                ? {}
+                : { namespace: options.liveNamespace }),
+              liveState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "worker" } } },
+              }),
+              targetState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "worker" } } },
+              }),
+            },
+          ],
+        });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/manifests"
+      ) {
+        return Response.json({
+          manifests: [
+            JSON.stringify({
+              apiVersion: "apps/v1",
+              kind: "Deployment",
+              metadata: {
+                name: "worker",
+                ...(options.renderedNamespace === undefined
+                  ? {}
+                  : { namespace: options.renderedNamespace }),
+              },
+              spec: { selector: { matchLabels: { app: "api" } } },
+            }),
+          ],
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/worker/sync"
+      ) {
+        syncPosts += 1;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return { server, syncPosts: () => syncPosts };
+}
+
+async function runSyncManagedAtRevision(origin: string) {
+  const process = Bun.spawn(
+    [
+      "bun",
+      "--no-install",
+      "scripts/argocd.ts",
+      "sync-managed",
+      "worker",
+      "--revision",
+      "2.0.0-43",
+      "--timeout",
+      "1",
+    ],
+    {
+      cwd: path.resolve(import.meta.dir, "../../.."),
+      env: {
+        ...Bun.env,
+        ARGOCD_SERVER_URL: origin,
+        ARGOCD_TOKEN: "test-token",
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+  return { exitCode, stderr };
+}
+
+for (const scenario of [
+  {
+    name: "the live inventory omits the namespace the rendering declares",
+    liveNamespace: undefined,
+    renderedNamespace: "worker",
+    error: "apps/Deployment _cluster/worker changes immutable /spec/selector",
+  },
+  {
+    name: "the rendering declares a different namespace",
+    liveNamespace: "worker",
+    renderedNamespace: "other",
+    error: "but rendered it in other",
+  },
+]) {
+  test(`sync-managed preflight refuses to skip when ${scenario.name}`, async () => {
+    const { server, syncPosts } = serveNamespaceScopedPreflight(scenario);
+    try {
+      const { exitCode, stderr } = await runSyncManagedAtRevision(
+        server.url.origin,
+      );
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain(scenario.error);
+      expect(syncPosts()).toBe(0);
+    } finally {
+      await server.stop(true);
+    }
+  });
+}

--- a/packages/homelab/src/cdk8s/src/argocd-sync-managed.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-sync-managed.test.ts
@@ -1,0 +1,211 @@
+import { expect, test } from "bun:test";
+import path from "node:path";
+
+test("sync-managed rejects detached operations", async () => {
+  const process = Bun.spawn(
+    [
+      "bun",
+      "--no-install",
+      "scripts/argocd.ts",
+      "sync-managed",
+      "worker",
+      "--async",
+    ],
+    {
+      cwd: path.resolve(import.meta.dir, "../../.."),
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+  const [exitCode, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stderr).text(),
+  ]);
+
+  expect(exitCode).not.toBe(0);
+  expect(stderr).toContain(
+    "sync-managed is bounded and does not support --async",
+  );
+});
+
+test("sync-managed preflights immutable changes before submitting", async () => {
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker" &&
+        url.searchParams.get("refresh") === "hard"
+      ) {
+        return Response.json({ status: {} });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/managed-resources"
+      ) {
+        return Response.json({
+          items: [
+            {
+              group: "apps",
+              kind: "Deployment",
+              namespace: "worker",
+              name: "worker",
+              liveState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "worker" } } },
+              }),
+              targetState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "api" } } },
+              }),
+            },
+          ],
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/worker/sync"
+      ) {
+        syncPosts += 1;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "sync-managed",
+        "worker",
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(
+      "apps/Deployment worker/worker changes immutable /spec/selector",
+    );
+    expect(syncPosts).toBe(0);
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test("sync-managed preflights the requested revision", async () => {
+  let syncPosts = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker" &&
+        url.searchParams.get("refresh") === "hard"
+      ) {
+        return Response.json({ status: {} });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/managed-resources"
+      ) {
+        return Response.json({
+          items: [
+            {
+              group: "apps",
+              kind: "Deployment",
+              namespace: "worker",
+              name: "worker",
+              liveState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "worker" } } },
+              }),
+              targetState: JSON.stringify({
+                spec: { selector: { matchLabels: { app: "worker" } } },
+              }),
+            },
+          ],
+        });
+      }
+      if (
+        request.method === "GET" &&
+        url.pathname === "/api/v1/applications/worker/manifests"
+      ) {
+        expect(url.searchParams.get("revision")).toBe("2.0.0-43");
+        return Response.json({
+          manifests: [
+            JSON.stringify({
+              apiVersion: "apps/v1",
+              kind: "Deployment",
+              metadata: { name: "worker" },
+              spec: { selector: { matchLabels: { app: "api" } } },
+            }),
+          ],
+        });
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/applications/worker/sync"
+      ) {
+        syncPosts += 1;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const process = Bun.spawn(
+      [
+        "bun",
+        "--no-install",
+        "scripts/argocd.ts",
+        "sync-managed",
+        "worker",
+        "--revision",
+        "2.0.0-43",
+        "--timeout",
+        "1",
+      ],
+      {
+        cwd: path.resolve(import.meta.dir, "../../.."),
+        env: {
+          ...Bun.env,
+          ARGOCD_SERVER_URL: server.url.origin,
+          ARGOCD_TOKEN: "test-token",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    const [exitCode, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(
+      "apps/Deployment worker/worker changes immutable /spec/selector",
+    );
+    expect(syncPosts).toBe(0);
+  } finally {
+    await server.stop(true);
+  }
+});

--- a/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/backup-policy/pvc-backup-policy.test.ts
@@ -15,7 +15,8 @@ import {
 } from "./pvc-backup-policy.ts";
 import {
   createPvcBackupAdmissionPolicies,
-  PVC_BACKUP_ADMISSION_SYNC_WAVE,
+  PVC_BACKUP_ADMISSION_BINDING_SYNC_WAVE,
+  PVC_BACKUP_ADMISSION_POLICY_SYNC_WAVE,
 } from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
 
 const ManifestSchema = z.object({
@@ -156,10 +157,10 @@ describe("PVC backup policy", () => {
 
     expect(pvcCount).toBeGreaterThan(0);
     expect(operatorManagedPvcCount).toBeGreaterThan(0);
-    expect(admissionKinds.get("MutatingAdmissionPolicy")).toBe(2);
-    expect(admissionKinds.get("MutatingAdmissionPolicyBinding")).toBe(2);
-    expect(admissionKinds.get("ValidatingAdmissionPolicy")).toBe(1);
-    expect(admissionKinds.get("ValidatingAdmissionPolicyBinding")).toBe(1);
+    expect(admissionKinds.get("MutatingAdmissionPolicy")).toBe(3);
+    expect(admissionKinds.get("MutatingAdmissionPolicyBinding")).toBe(3);
+    expect(admissionKinds.get("ValidatingAdmissionPolicy")).toBe(2);
+    expect(admissionKinds.get("ValidatingAdmissionPolicyBinding")).toBe(2);
   }, 20_000);
 
   it("syncs admission policy updates before PVC changes", () => {
@@ -172,8 +173,11 @@ describe("PVC backup policy", () => {
 
     expect(admissionObjects).toHaveLength(6);
     for (const manifest of admissionObjects) {
+      const expectedWave = manifest.kind.endsWith("Binding")
+        ? PVC_BACKUP_ADMISSION_BINDING_SYNC_WAVE
+        : PVC_BACKUP_ADMISSION_POLICY_SYNC_WAVE;
       expect(manifest.metadata.annotations).toEqual({
-        "argocd.argoproj.io/sync-wave": PVC_BACKUP_ADMISSION_SYNC_WAVE,
+        "argocd.argoproj.io/sync-wave": expectedWave,
       });
     }
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/apps.ts
@@ -69,6 +69,7 @@ import { createTrackerTrackerApp } from "@shepherdjerred/homelab/cdk8s/src/resou
 import { createAlertDashboardApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/alert-dashboard.ts";
 import { createStashApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/stash.ts";
 import { createPvcBackupAdmissionPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/pvc-backup-admission.ts";
+import { createArgoCdApplicationAdmissionPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/argocd-application-admission.ts";
 
 export async function createAppsChart(app: App) {
   const chart = new Chart(app, "apps", {
@@ -78,6 +79,7 @@ export async function createAppsChart(app: App) {
 
   createStorageClasses(chart);
   createPriorityClasses(chart);
+  createArgoCdApplicationAdmissionPolicies(chart);
   createPvcBackupAdmissionPolicies(chart);
 
   new Namespace(chart, `maintenance-namespace`, {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Testing } from "cdk8s";
+import { stringify } from "yaml";
 import { z } from "zod";
-import { createArgoCdApp } from "./argocd.ts";
+import { ARGO_APPLICATION_HEALTH_LUA, createArgoCdApp } from "./argocd.ts";
 
 const ApplicationSchema = z
   .object({
@@ -41,6 +45,70 @@ function synthArgoCdApplication() {
   return ApplicationSchema.parse(application);
 }
 
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+async function evaluateApplicationHealth(status: unknown): Promise<string> {
+  const directory = await mkdtemp(
+    path.join(tmpdir(), "argocd-application-health-"),
+  );
+  temporaryDirectories.push(directory);
+  const configPath = path.join(directory, "argocd-cm.yaml");
+  const resourcePath = path.join(directory, "application.yaml");
+  await Promise.all([
+    Bun.write(
+      configPath,
+      stringify({
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: { name: "argocd-cm", namespace: "argocd" },
+        data: {
+          "resource.customizations.health.argoproj.io_Application":
+            ARGO_APPLICATION_HEALTH_LUA,
+        },
+      }),
+    ),
+    Bun.write(
+      resourcePath,
+      stringify({
+        apiVersion: "argoproj.io/v1alpha1",
+        kind: "Application",
+        metadata: { name: "fixture", namespace: "argocd" },
+        status,
+      }),
+    ),
+  ]);
+  const process = Bun.spawn(
+    [
+      "argocd",
+      "admin",
+      "settings",
+      "resource-overrides",
+      "health",
+      resourcePath,
+      "--argocd-cm-path",
+      configPath,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`ArgoCD Lua health evaluation failed: ${stderr}`);
+  }
+  return stdout;
+}
+
 describe("ArgoCD application", () => {
   it("grants the Buildkite release step only its required application access", () => {
     const application = synthArgoCdApplication();
@@ -56,22 +124,98 @@ describe("ArgoCD application", () => {
     ]);
   });
 
-  it("ignores only stale terminal operation failures in child health", () => {
+  it("installs the executable Application health customization", () => {
     const application = synthArgoCdApplication();
-    const customization =
+    expect(
       application.spec.source.helm.valuesObject.configs.cm[
         "resource.customizations.health.argoproj.io_Application"
-      ];
+      ],
+    ).toBe(ARGO_APPLICATION_HEALTH_LUA);
+  });
 
-    expect(customization).toContain(
-      "obj.status.operationState.syncResult.revision ~= obj.status.sync.revision",
-    );
-    expect(customization).toContain(
-      'if (phase == "Failed" or phase == "Error") and',
-    );
-    expect(customization).toContain(
-      'hs.message = "Application operation is " .. obj.status.operationState.phase',
-    );
+  it("evaluates child state with current health and terminal failures", async () => {
+    const fixtures = [
+      {
+        name: "active operation",
+        expected: "Progressing",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Healthy" },
+          operationState: { phase: "Running", syncResult: { revision: "new" } },
+        },
+      },
+      {
+        name: "terminating operation",
+        expected: "Progressing",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Healthy" },
+          operationState: {
+            phase: "Terminating",
+            syncResult: { revision: "new" },
+          },
+        },
+      },
+      {
+        name: "unresolved failed operation",
+        expected: "Degraded",
+        status: {
+          sync: { status: "OutOfSync", revision: "new" },
+          health: { status: "Healthy" },
+          operationState: { phase: "Failed", syncResult: { revision: "new" } },
+        },
+      },
+      {
+        name: "resolved stale failure",
+        expected: "Healthy",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Healthy" },
+          operationState: { phase: "Failed", syncResult: { revision: "old" } },
+        },
+      },
+      {
+        name: "resolved same-revision failure",
+        expected: "Healthy",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Healthy" },
+          operationState: { phase: "Failed", syncResult: { revision: "new" } },
+        },
+      },
+      {
+        name: "comparison error",
+        expected: "Degraded",
+        status: {
+          sync: { status: "Unknown" },
+          health: { status: "Healthy" },
+          conditions: [
+            { type: "ComparisonError", message: "manifest generation failed" },
+          ],
+        },
+      },
+      {
+        name: "ordinary drift",
+        expected: "Progressing",
+        status: {
+          sync: { status: "OutOfSync", revision: "new" },
+          health: { status: "Degraded" },
+        },
+      },
+      {
+        name: "synced unhealthy child",
+        expected: "Degraded",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Degraded", message: "workload failed" },
+        },
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      const output = await evaluateApplicationHealth(fixture.status);
+      expect(output, fixture.name).toContain(fixture.expected);
+    }
   });
 
   it("ignores terminal operation failures on applications that have converged", () => {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -175,11 +175,14 @@ describe("ArgoCD application", () => {
         },
       },
       {
-        // Synced and Healthy do not resolve a failure on the revision under
-        // release: a failed hook leaves both in place, and treating that as
-        // healthy would let the root advance to later waves.
-        name: "unresolved same-revision failure behind healthy state",
-        expected: "Degraded",
+        // ArgoCD never re-syncs an application it already considers Synced, so
+        // this failure can never clear on its own. Blocking would wedge every
+        // later root wave behind a child with nothing left to converge. The CI
+        // release gate still refuses this state — see
+        // operationIsReadyForCurrentRevision — so a failed hook on the revision
+        // under release stops the release without stranding the cluster.
+        name: "same-revision failure on a converged application",
+        expected: "Healthy",
         status: {
           sync: { status: "Synced", revision: "new" },
           health: { status: "Healthy" },
@@ -187,11 +190,22 @@ describe("ArgoCD application", () => {
         },
       },
       {
-        name: "failure without a recorded operation revision",
-        expected: "Degraded",
+        // No recorded revision means the failure cannot be shown to be
+        // superseded, so convergence is the only thing that can excuse it.
+        name: "failure without a recorded operation revision, converged",
+        expected: "Healthy",
         status: {
           sync: { status: "Synced", revision: "new" },
           health: { status: "Healthy" },
+          operationState: { phase: "Failed" },
+        },
+      },
+      {
+        name: "failure without a recorded operation revision, not converged",
+        expected: "Degraded",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Degraded" },
           operationState: { phase: "Failed" },
         },
       },
@@ -230,32 +244,35 @@ describe("ArgoCD application", () => {
     }
   });
 
-  it("ignores terminal operation failures on applications that have converged", () => {
-    const application = synthArgoCdApplication();
-    const customization =
-      application.spec.source.helm.valuesObject.configs.cm[
-        "resource.customizations.health.argoproj.io_Application"
-      ];
-
-    // ArgoCD only re-runs a sync for an application it still sees as OutOfSync,
-    // so a failure recorded against an application that later reached
-    // Synced+Healthy can never clear. Blocking on it wedges every root health
-    // wave behind a child that has nothing left to converge.
-    expect(customization).toContain('obj.status.sync.status == "Synced" and');
-    expect(customization).toContain(
-      'obj.status.health.status == "Healthy" then',
-    );
-
-    const convergedClause = customization.slice(
-      customization.indexOf('obj.status.sync.status == "Synced" and'),
-    );
-    expect(convergedClause).toContain("operationBlocks = false");
+  // Asserted through the evaluator rather than by matching the Lua source: the
+  // rule is what the customization decides, and a source match breaks on any
+  // rewrite that preserves the behaviour — as this one did.
+  it("ignores terminal operation failures on applications that have converged", async () => {
+    const converged = await evaluateApplicationHealth({
+      sync: { status: "Synced", revision: "new" },
+      health: { status: "Healthy" },
+      operationState: { phase: "Failed", syncResult: { revision: "new" } },
+    });
+    expect(converged).toContain("Healthy");
 
     // The carve-out must stay scoped to terminal phases: a Running operation is
-    // an in-flight child sync the root health wave still has to wait for.
-    expect(
-      customization.match(/if \(phase == "Failed" or phase == "Error"\) and/g),
-    ).toHaveLength(2);
+    // an in-flight child sync the root health wave still has to wait for, even
+    // though this state is otherwise Synced and Healthy.
+    const running = await evaluateApplicationHealth({
+      sync: { status: "Synced", revision: "new" },
+      health: { status: "Healthy" },
+      operationState: { phase: "Running", syncResult: { revision: "new" } },
+    });
+    expect(running).toContain("Progressing");
+
+    // And a child that has not converged still blocks, so a rejected apply is
+    // not swept up by the same carve-out.
+    const stillBroken = await evaluateApplicationHealth({
+      sync: { status: "OutOfSync", revision: "new" },
+      health: { status: "Healthy" },
+      operationState: { phase: "Failed", syncResult: { revision: "new" } },
+    });
+    expect(stillBroken).toContain("Degraded");
   });
 
   it("keeps only non-failed cert-manager secret issuance progressing", () => {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.test.ts
@@ -175,12 +175,24 @@ describe("ArgoCD application", () => {
         },
       },
       {
-        name: "resolved same-revision failure",
-        expected: "Healthy",
+        // Synced and Healthy do not resolve a failure on the revision under
+        // release: a failed hook leaves both in place, and treating that as
+        // healthy would let the root advance to later waves.
+        name: "unresolved same-revision failure behind healthy state",
+        expected: "Degraded",
         status: {
           sync: { status: "Synced", revision: "new" },
           health: { status: "Healthy" },
           operationState: { phase: "Failed", syncResult: { revision: "new" } },
+        },
+      },
+      {
+        name: "failure without a recorded operation revision",
+        expected: "Degraded",
+        status: {
+          sync: { status: "Synced", revision: "new" },
+          health: { status: "Healthy" },
+          operationState: { phase: "Failed" },
         },
       },
       {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -57,9 +57,17 @@ if operationPhase == "Running" or operationPhase == "Terminating" then
   return hs
 end
 
-local currentStateIsHealthy = syncStatus == "Synced" and healthStatus == "Healthy"
 if operationPhase == "Failed" or operationPhase == "Error" then
-  if not currentStateIsHealthy then
+  -- A failure only stops mattering once it belongs to a superseded revision.
+  -- Synced and Healthy is not enough on its own: a failed hook leaves both in
+  -- place while the release did not finish, and child health is what orders the
+  -- root's waves. This matches operationIsReadyForCurrentRevision in
+  -- argocd-application-readiness.ts, which refuses the same state.
+  local failedOtherRevision =
+    operationRevision ~= nil
+    and syncRevision ~= nil
+    and operationRevision ~= syncRevision
+  if not failedOtherRevision then
     hs.status = "Degraded"
     hs.message = operationMessage or ("Application operation is " .. operationPhase)
     return hs

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -58,16 +58,27 @@ if operationPhase == "Running" or operationPhase == "Terminating" then
 end
 
 if operationPhase == "Failed" or operationPhase == "Error" then
-  -- A failure only stops mattering once it belongs to a superseded revision.
-  -- Synced and Healthy is not enough on its own: a failed hook leaves both in
-  -- place while the release did not finish, and child health is what orders the
-  -- root's waves. This matches operationIsReadyForCurrentRevision in
-  -- argocd-application-readiness.ts, which refuses the same state.
+  -- A failure stops mattering once it belongs to a superseded revision, or once
+  -- the application has converged anyway. ArgoCD never re-runs a sync for an
+  -- application it already considers Synced, so a failure recorded against one
+  -- that later reached Synced and Healthy can never clear: blocking on it wedges
+  -- every root health wave behind a child with nothing left to converge, which
+  -- is what took main CI down for two days. A rejected apply leaves the resource
+  -- OutOfSync or Degraded, so a genuinely broken child still blocks here.
+  --
+  -- This is deliberately more forgiving than
+  -- operationIsReadyForCurrentRevision in argocd-application-readiness.ts,
+  -- which still refuses a same-revision failure. The two gate different things:
+  -- this customization orders ArgoCD's own sync waves, where a permanent block
+  -- is unrecoverable, while that predicate gates the CI release, where refusing
+  -- fails one build that a retry can clear. A failed hook on the revision under
+  -- release therefore still stops the release without stranding the cluster.
   local failedOtherRevision =
     operationRevision ~= nil
     and syncRevision ~= nil
     and operationRevision ~= syncRevision
-  if not failedOtherRevision then
+  local convergedSinceFailure = syncStatus == "Synced" and healthStatus == "Healthy"
+  if not failedOtherRevision and not convergedSinceFailure then
     hs.status = "Degraded"
     hs.message = operationMessage or ("Application operation is " .. operationPhase)
     return hs

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/argocd.ts
@@ -5,6 +5,87 @@ import { createIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.
 import { createCloudflareTunnelBinding } from "@shepherdjerred/homelab/cdk8s/src/misc/cloudflare-tunnel.ts";
 import type { HelmValuesForChart } from "@shepherdjerred/homelab/cdk8s/src/misc/typed-helm-parameters.ts";
 
+export const ARGO_APPLICATION_HEALTH_LUA = `hs = {}
+hs.status = "Progressing"
+hs.message = "Waiting for Application status"
+if obj.status == nil then
+  return hs
+end
+
+if obj.status.conditions ~= nil then
+  for _, condition in ipairs(obj.status.conditions) do
+    if condition.type == "ComparisonError" or
+       condition.type == "InvalidSpecError" or
+       condition.type == "SyncError" or
+       condition.type == "UnknownError" or
+       condition.type == "DeletionError" then
+      hs.status = "Degraded"
+      hs.message = condition.message or condition.type
+      return hs
+    end
+  end
+end
+
+local syncStatus = nil
+local syncRevision = nil
+if obj.status.sync ~= nil then
+  syncStatus = obj.status.sync.status
+  syncRevision = obj.status.sync.revision
+end
+
+local healthStatus = nil
+local healthMessage = nil
+if obj.status.health ~= nil then
+  healthStatus = obj.status.health.status
+  healthMessage = obj.status.health.message
+end
+
+local operationPhase = nil
+local operationRevision = nil
+local operationMessage = nil
+if obj.status.operationState ~= nil then
+  operationPhase = obj.status.operationState.phase
+  operationMessage = obj.status.operationState.message
+  if obj.status.operationState.syncResult ~= nil then
+    operationRevision = obj.status.operationState.syncResult.revision
+  end
+end
+
+if operationPhase == "Running" or operationPhase == "Terminating" then
+  hs.status = "Progressing"
+  hs.message = operationMessage or ("Application operation is " .. operationPhase)
+  return hs
+end
+
+local currentStateIsHealthy = syncStatus == "Synced" and healthStatus == "Healthy"
+if operationPhase == "Failed" or operationPhase == "Error" then
+  if not currentStateIsHealthy then
+    hs.status = "Degraded"
+    hs.message = operationMessage or ("Application operation is " .. operationPhase)
+    return hs
+  end
+elseif operationPhase ~= nil and operationPhase ~= "Succeeded" then
+  hs.status = "Degraded"
+  hs.message = "Application has unknown operation phase " .. operationPhase
+  return hs
+end
+
+if syncStatus ~= "Synced" then
+  hs.status = "Progressing"
+  if syncRevision ~= nil and operationRevision ~= nil and syncRevision ~= operationRevision then
+    hs.message = "Application is not Synced; last operation targeted another revision"
+  else
+    hs.message = "Application is not Synced"
+  end
+  return hs
+end
+
+if healthStatus ~= nil then
+  hs.status = healthStatus
+  hs.message = healthMessage or ""
+end
+return hs`;
+
 export function createArgoCdApp(chart: Chart) {
   createIngress(chart, "argocd-ingress", {
     namespace: "argocd",
@@ -179,62 +260,8 @@ export function createArgoCdApp(chart: Chart) {
         // ArgoCD removed built-in Application CR health in 1.8. Restore the
         // documented app-of-apps check so the root app inherits child app and
         // workload health without widening the Buildkite account's RBAC.
-        "resource.customizations.health.argoproj.io_Application": `hs = {}
-hs.status = "Progressing"
-hs.message = ""
-if obj.status ~= nil then
-  if obj.status.health ~= nil then
-    -- ArgoCD's Lua health evaluator requires a non-nil hs.status; a health
-    -- object without a .status field (e.g. a freshly-created child app) would
-    -- otherwise blank it out and fall back to Unknown. Keep the "Progressing"
-    -- default in that case.
-    if obj.status.health.status ~= nil then
-      hs.status = obj.status.health.status
-    end
-    if obj.status.health.message ~= nil then
-      hs.message = obj.status.health.message
-    end
-  end
-  if obj.status.sync == nil or obj.status.sync.status ~= "Synced" then
-    if hs.status == "Healthy" then
-      hs.status = "Progressing"
-    end
-    hs.message = "Application is not Synced"
-  end
-  local operationBlocks = false
-  if obj.status.operationState ~= nil and
-     obj.status.operationState.phase ~= nil and
-     obj.status.operationState.phase ~= "Succeeded" then
-    operationBlocks = true
-    local phase = obj.status.operationState.phase
-    if (phase == "Failed" or phase == "Error") and
-       obj.status.operationState.syncResult ~= nil and
-       obj.status.operationState.syncResult.revision ~= nil and
-       obj.status.sync ~= nil and
-       obj.status.sync.revision ~= nil and
-       obj.status.operationState.syncResult.revision ~= obj.status.sync.revision then
-      operationBlocks = false
-    end
-    -- A terminal failure whose application has since converged is stale too.
-    -- ArgoCD never re-runs a sync for an application that is already Synced, so
-    -- nothing can ever clear the recorded phase: the child would report
-    -- Progressing forever and every later root health wave would block on it.
-    -- Requiring both Synced and Healthy keeps a genuinely broken child blocking,
-    -- because a rejected apply leaves the resource OutOfSync or Degraded.
-    if (phase == "Failed" or phase == "Error") and
-       obj.status.sync ~= nil and
-       obj.status.sync.status == "Synced" and
-       obj.status.health ~= nil and
-       obj.status.health.status == "Healthy" then
-      operationBlocks = false
-    end
-  end
-  if operationBlocks then
-    hs.status = "Progressing"
-    hs.message = "Application operation is " .. obj.status.operationState.phase
-  end
-end
-return hs`,
+        "resource.customizations.health.argoproj.io_Application":
+          ARGO_APPLICATION_HEALTH_LUA,
         // A newly-created cert-manager Certificate reports Ready=False with
         // reason DoesNotExist while it creates its target Secret. ArgoCD's
         // documented generic Certificate health check classifies every False

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -263,11 +263,6 @@ overrides:
   new Application(chart, "buildkite-app", {
     metadata: {
       name: "buildkite",
-      // Start the agent stack only after the Kueue controller and queue
-      // resources have become Healthy in the parent ArgoCD application.
-      annotations: {
-        "argocd.argoproj.io/sync-wave": "3",
-      },
     },
     spec: {
       revisionHistoryLimit: 5,

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/kueue.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/kueue.ts
@@ -127,10 +127,6 @@ export function createKueueApp(chart: Chart) {
   return new Application(chart, "kueue-app", {
     metadata: {
       name: "kueue",
-      annotations: {
-        // Deploy early so the webhook is ready before Buildkite creates Jobs
-        "argocd.argoproj.io/sync-wave": "1",
-      },
     },
     spec: {
       revisionHistoryLimit: 5,

--- a/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.test.ts
@@ -97,4 +97,29 @@ describe("ArgoCD Application admission policies", () => {
       ],
     });
   });
+
+  test("scopes deletion checks to released Applications", () => {
+    const policy = synthesizePolicies().find(
+      (manifest) => manifest.kind === "ValidatingAdmissionPolicy",
+    );
+    const constraints = z
+      .object({ objectSelector: z.unknown().optional() })
+      .parse(
+        z
+          .object({ matchConstraints: z.record(z.string(), z.unknown()) })
+          .parse(policy?.spec).matchConstraints,
+      );
+    expect(constraints.objectSelector).toBeUndefined();
+    const conditions = z
+      .array(z.object({ name: z.string(), expression: z.string() }))
+      .parse(
+        z.object({ matchConditions: z.unknown() }).parse(policy?.spec)
+          .matchConditions,
+      );
+    const scope = conditions.find(
+      ({ name }) => name === "release-managed-application",
+    );
+    expect(scope?.expression).toContain(MANAGED_APPLICATION_LABEL);
+    expect(scope?.expression).toContain("'apps', 'argocd'");
+  });
 });

--- a/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { MANAGED_APPLICATION_LABEL } from "@shepherdjerred/homelab/cdk8s/src/application-release-policy.ts";
+import {
+  ARGOCD_ADMISSION_BINDING_SYNC_WAVE,
+  ARGOCD_ADMISSION_POLICY_SYNC_WAVE,
+  createArgoCdApplicationAdmissionPolicies,
+} from "./argocd-application-admission.ts";
+
+const AdmissionManifestSchema = z.object({
+  apiVersion: z.literal("admissionregistration.k8s.io/v1"),
+  kind: z.enum([
+    "MutatingAdmissionPolicy",
+    "MutatingAdmissionPolicyBinding",
+    "ValidatingAdmissionPolicy",
+    "ValidatingAdmissionPolicyBinding",
+  ]),
+  metadata: z.object({
+    name: z.string(),
+    annotations: z.record(z.string(), z.string()),
+  }),
+  spec: z.record(z.string(), z.unknown()),
+});
+
+function synthesizePolicies() {
+  const app = new App();
+  const chart = new Chart(app, "apps");
+  createArgoCdApplicationAdmissionPolicies(chart);
+  return parseAllDocuments(app.synthYaml()).map((document) =>
+    AdmissionManifestSchema.parse(document.toJS()),
+  );
+}
+
+describe("ArgoCD Application admission policies", () => {
+  test("orders fail-closed policies before their bindings", () => {
+    const manifests = synthesizePolicies();
+    expect(manifests).toHaveLength(4);
+    for (const manifest of manifests) {
+      const expectedWave = manifest.kind.endsWith("Binding")
+        ? ARGOCD_ADMISSION_BINDING_SYNC_WAVE
+        : ARGOCD_ADMISSION_POLICY_SYNC_WAVE;
+      expect(
+        manifest.metadata.annotations["argocd.argoproj.io/sync-wave"],
+      ).toBe(expectedWave);
+    }
+  });
+
+  test("merges declared sync options into managed manual operations", () => {
+    const policy = synthesizePolicies().find(
+      (manifest) => manifest.kind === "MutatingAdmissionPolicy",
+    );
+    expect(policy).toBeDefined();
+    expect(policy?.spec).toMatchObject({
+      failurePolicy: "Fail",
+      matchConstraints: {
+        objectSelector: {
+          matchLabels: { [MANAGED_APPLICATION_LABEL]: "true" },
+        },
+      },
+      variables: expect.arrayContaining([
+        {
+          name: "mergedOptions",
+          expression: expect.stringContaining("variables.declaredOptions"),
+        },
+      ]),
+      mutations: [
+        {
+          patchType: "JSONPatch",
+          jsonPatch: {
+            expression: expect.stringContaining("/operation/sync/syncOptions"),
+          },
+        },
+      ],
+    });
+  });
+
+  test("denies retained deletion and requires cascade metadata otherwise", () => {
+    const policy = synthesizePolicies().find(
+      (manifest) => manifest.kind === "ValidatingAdmissionPolicy",
+    );
+    expect(policy).toBeDefined();
+    expect(policy?.spec).toMatchObject({
+      failurePolicy: "Fail",
+      validations: [
+        {
+          expression: expect.stringContaining("'apps', 'argocd'"),
+          reason: "Forbidden",
+        },
+        {
+          expression: expect.stringContaining(
+            "resources-finalizer.argocd.argoproj.io",
+          ),
+          reason: "Invalid",
+        },
+      ],
+    });
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.ts
@@ -1,0 +1,150 @@
+import { ApiObject, type Chart } from "cdk8s";
+import {
+  ARGOCD_SYNC_WAVE_ANNOTATION,
+  APPLICATION_LIFECYCLE_ANNOTATION,
+  APPLICATION_RESOURCES_FINALIZER,
+  APPLICATION_SYNC_WAVES,
+  MANAGED_APPLICATION_LABEL,
+} from "@shepherdjerred/homelab/cdk8s/src/application-release-policy.ts";
+
+export const ARGOCD_ADMISSION_POLICY_SYNC_WAVE =
+  APPLICATION_SYNC_WAVES.admissionPolicy;
+export const ARGOCD_ADMISSION_BINDING_SYNC_WAVE =
+  APPLICATION_SYNC_WAVES.admissionBinding;
+
+const APPLICATION_RULES = [
+  {
+    apiGroups: ["argoproj.io"],
+    apiVersions: ["v1alpha1"],
+    operations: ["UPDATE"],
+    resources: ["applications"],
+    scope: "Namespaced",
+  },
+];
+
+function metadata(name: string, wave: string) {
+  return {
+    name,
+    annotations: { [ARGOCD_SYNC_WAVE_ANNOTATION]: wave },
+  };
+}
+
+export function createArgoCdApplicationAdmissionPolicies(chart: Chart): void {
+  const mutationPolicyName = "argocd-application-sync-options.sjer.red";
+  new ApiObject(chart, "argocd-application-sync-options-policy", {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "MutatingAdmissionPolicy",
+    metadata: metadata(mutationPolicyName, ARGOCD_ADMISSION_POLICY_SYNC_WAVE),
+    spec: {
+      failurePolicy: "Fail",
+      reinvocationPolicy: "IfNeeded",
+      matchConstraints: {
+        matchPolicy: "Equivalent",
+        namespaceSelector: {},
+        objectSelector: {
+          matchLabels: { [MANAGED_APPLICATION_LABEL]: "true" },
+        },
+        resourceRules: APPLICATION_RULES,
+      },
+      matchConditions: [
+        {
+          name: "manual-sync-with-declared-options",
+          expression:
+            "has(object.operation) && has(object.operation.sync) && has(object.spec.syncPolicy) && has(object.spec.syncPolicy.syncOptions) && size(object.spec.syncPolicy.syncOptions) > 0",
+        },
+      ],
+      variables: [
+        {
+          name: "declaredOptions",
+          expression: "object.spec.syncPolicy.syncOptions",
+        },
+        {
+          name: "requestedOptions",
+          expression:
+            "has(object.operation.sync.syncOptions) ? object.operation.sync.syncOptions : []",
+        },
+        {
+          name: "declaredKeys",
+          expression:
+            "variables.declaredOptions.map(option, option.split('=')[0])",
+        },
+        {
+          name: "mergedOptions",
+          expression:
+            "variables.requestedOptions.filter(option, !variables.declaredKeys.exists(key, option == key || option.startsWith(key + '='))) + variables.declaredOptions",
+        },
+      ],
+      mutations: [
+        {
+          patchType: "JSONPatch",
+          jsonPatch: {
+            expression:
+              "[JSONPatch{op: has(object.operation.sync.syncOptions) ? 'replace' : 'add', path: '/operation/sync/syncOptions', value: variables.mergedOptions}]",
+          },
+        },
+      ],
+    },
+  });
+
+  new ApiObject(chart, "argocd-application-sync-options-binding", {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "MutatingAdmissionPolicyBinding",
+    metadata: metadata(mutationPolicyName, ARGOCD_ADMISSION_BINDING_SYNC_WAVE),
+    spec: { policyName: mutationPolicyName },
+  });
+
+  const validationPolicyName = "argocd-application-lifecycle.sjer.red";
+  new ApiObject(chart, "argocd-application-lifecycle-policy", {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "ValidatingAdmissionPolicy",
+    metadata: metadata(validationPolicyName, ARGOCD_ADMISSION_POLICY_SYNC_WAVE),
+    spec: {
+      failurePolicy: "Fail",
+      matchConstraints: {
+        matchPolicy: "Equivalent",
+        namespaceSelector: {},
+        objectSelector: {},
+        resourceRules: [
+          {
+            ...APPLICATION_RULES[0],
+            operations: ["DELETE"],
+          },
+        ],
+      },
+      matchConditions: [
+        {
+          name: "argocd-namespace",
+          expression: "request.namespace == 'argocd'",
+        },
+      ],
+      validations: [
+        {
+          expression:
+            "!['apps', 'argocd'].exists(name, name == oldObject.metadata.name)",
+          message:
+            "retained root and ArgoCD Applications cannot be deleted while the lifecycle policy is active",
+          reason: "Forbidden",
+        },
+        {
+          expression: `['apps', 'argocd'].exists(name, name == oldObject.metadata.name) || (has(oldObject.metadata.annotations) && oldObject.metadata.annotations['${APPLICATION_LIFECYCLE_ANNOTATION}'] == 'cascade' && has(oldObject.metadata.finalizers) && oldObject.metadata.finalizers.exists(finalizer, finalizer == '${APPLICATION_RESOURCES_FINALIZER}'))`,
+          message:
+            "deleting an Application requires the cascade lifecycle annotation and ArgoCD resources finalizer",
+          reason: "Invalid",
+        },
+      ],
+    },
+  });
+
+  new ApiObject(chart, "argocd-application-lifecycle-binding", {
+    apiVersion: "admissionregistration.k8s.io/v1",
+    kind: "ValidatingAdmissionPolicyBinding",
+    metadata: metadata(
+      validationPolicyName,
+      ARGOCD_ADMISSION_BINDING_SYNC_WAVE,
+    ),
+    spec: {
+      policyName: validationPolicyName,
+      validationActions: ["Deny"],
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argocd-application-admission.ts
@@ -103,7 +103,6 @@ export function createArgoCdApplicationAdmissionPolicies(chart: Chart): void {
       matchConstraints: {
         matchPolicy: "Equivalent",
         namespaceSelector: {},
-        objectSelector: {},
         resourceRules: [
           {
             ...APPLICATION_RULES[0],
@@ -115,6 +114,15 @@ export function createArgoCdApplicationAdmissionPolicies(chart: Chart): void {
         {
           name: "argocd-namespace",
           expression: "request.namespace == 'argocd'",
+        },
+        // The retain-or-cascade contract only covers Applications this
+        // repository renders. The root Application carries no managed label
+        // (the sync-option mutation must not reach it), so it is named
+        // explicitly instead. An ad-hoc or externally managed Application stays
+        // deletable.
+        {
+          name: "release-managed-application",
+          expression: `['apps', 'argocd'].exists(name, name == oldObject.metadata.name) || (has(oldObject.metadata.labels) && '${MANAGED_APPLICATION_LABEL}' in oldObject.metadata.labels && oldObject.metadata.labels['${MANAGED_APPLICATION_LABEL}'] == 'true')`,
         },
       ],
       validations: [

--- a/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pvc-backup-admission.ts
@@ -20,16 +20,20 @@ const POLICY_KEY_EXPRESSION =
   "object.metadata.namespace + '/' + object.metadata.name";
 const INCLUDED_EXPRESSION = `${toCelList(INCLUDED_PVC_KEYS)}.exists(key, key == variables.policyKey)`;
 const EXCLUDED_EXPRESSION = `${toCelList(EXCLUDED_PVC_KEYS)}.exists(key, key == variables.policyKey)`;
-export const PVC_BACKUP_ADMISSION_SYNC_WAVE = "-1";
+export const PVC_BACKUP_ADMISSION_POLICY_SYNC_WAVE = "-30";
+export const PVC_BACKUP_ADMISSION_BINDING_SYNC_WAVE = "-29";
 
-function admissionPolicyMetadata(name: string): {
+function admissionPolicyMetadata(
+  name: string,
+  wave: string,
+): {
   name: string;
   annotations: Record<string, string>;
 } {
   return {
     name,
     annotations: {
-      "argocd.argoproj.io/sync-wave": PVC_BACKUP_ADMISSION_SYNC_WAVE,
+      "argocd.argoproj.io/sync-wave": wave,
     },
   };
 }
@@ -58,7 +62,10 @@ function createMutationPolicy(
   new ApiObject(chart, `pvc-backup-${disposition}-mutation-policy`, {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "MutatingAdmissionPolicy",
-    metadata: admissionPolicyMetadata(policyName),
+    metadata: admissionPolicyMetadata(
+      policyName,
+      PVC_BACKUP_ADMISSION_POLICY_SYNC_WAVE,
+    ),
     spec: {
       failurePolicy: "Fail",
       reinvocationPolicy: "IfNeeded",
@@ -91,7 +98,10 @@ function createMutationPolicy(
   new ApiObject(chart, `pvc-backup-${disposition}-mutation-binding`, {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "MutatingAdmissionPolicyBinding",
-    metadata: admissionPolicyMetadata(policyName),
+    metadata: admissionPolicyMetadata(
+      policyName,
+      PVC_BACKUP_ADMISSION_BINDING_SYNC_WAVE,
+    ),
     spec: {
       policyName,
     },
@@ -106,7 +116,10 @@ export function createPvcBackupAdmissionPolicies(chart: Chart): void {
   new ApiObject(chart, "pvc-backup-validation-policy", {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "ValidatingAdmissionPolicy",
-    metadata: admissionPolicyMetadata(policyName),
+    metadata: admissionPolicyMetadata(
+      policyName,
+      PVC_BACKUP_ADMISSION_POLICY_SYNC_WAVE,
+    ),
     spec: {
       failurePolicy: "Fail",
       matchConstraints: PVC_MATCH_CONSTRAINTS,
@@ -161,7 +174,10 @@ export function createPvcBackupAdmissionPolicies(chart: Chart): void {
   new ApiObject(chart, "pvc-backup-validation-binding", {
     apiVersion: "admissionregistration.k8s.io/v1",
     kind: "ValidatingAdmissionPolicyBinding",
-    metadata: admissionPolicyMetadata(policyName),
+    metadata: admissionPolicyMetadata(
+      policyName,
+      PVC_BACKUP_ADMISSION_BINDING_SYNC_WAVE,
+    ),
     spec: {
       policyName,
       validationActions: ["Deny"],

--- a/packages/homelab/src/cdk8s/src/versions.test.ts
+++ b/packages/homelab/src/cdk8s/src/versions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import rawCatalog from "./version-catalog.json";
-import { parseVersionCatalog } from "./version-catalog.ts";
+import rawCatalog from "@shepherdjerred/version-catalog/catalog.json";
+import { parseVersionCatalog } from "@shepherdjerred/version-catalog";
 import { VersionMapSchema } from "./version-map.generated.ts";
 import versions from "./versions.ts";
 

--- a/packages/homelab/src/cdk8s/src/versions.ts
+++ b/packages/homelab/src/cdk8s/src/versions.ts
@@ -1,9 +1,13 @@
-import rawCatalog from "./version-catalog.json";
-import { parseVersionCatalog, versionMap } from "./version-catalog.ts";
+import rawCatalog from "@shepherdjerred/version-catalog/catalog.json";
+import {
+  parseVersionCatalog,
+  versionCatalogMap,
+} from "@shepherdjerred/version-catalog";
+import { VersionMapSchema } from "./version-map.generated.ts";
 import { applyCurrentBuildImageOverrides } from "./release-configuration.ts";
 
 export const versionCatalog = parseVersionCatalog(rawCatalog);
-const versions = versionMap(versionCatalog);
+const versions = VersionMapSchema.parse(versionCatalogMap(versionCatalog));
 
 applyCurrentBuildImageOverrides(versions);
 

--- a/packages/homelab/src/cdk8s/turbo.json
+++ b/packages/homelab/src/cdk8s/turbo.json
@@ -44,7 +44,7 @@
     "generate": {
       "inputs": [
         "scripts/generate-version-map-schema.ts",
-        "src/version-catalog.json"
+        "$TURBO_ROOT$/packages/version-catalog/src/catalog.json"
       ],
       "outputs": ["src/version-map.generated.ts"]
     },

--- a/packages/homelab/tsconfig.scripts.json
+++ b/packages/homelab/tsconfig.scripts.json
@@ -6,6 +6,8 @@
   },
   "include": [
     "scripts/argocd.ts",
+    "scripts/argocd-apply-safety.ts",
+    "scripts/argocd-apply-safety.test.ts",
     "scripts/argocd-manifest-overrides.ts",
     "scripts/argocd-manifest-overrides.test.ts",
     "scripts/helm-set-version.ts",

--- a/packages/tasks-for-obsidian/AGENTS.md
+++ b/packages/tasks-for-obsidian/AGENTS.md
@@ -26,8 +26,8 @@ bun run e2e                          # Maestro e2e (simulator + real server + ch
   spawned real `../tasknotes-server` over a temp vault. Exposed as the
   `test:contract` turbo task (`turbo.json`), whose inputs and
   `tasknotes-server#typecheck` dependency make it cache correctly; it runs in
-  `bun run verify` (and therefore the `pre-push` hook and the Buildkite
-  pipeline). Lives in
+  `bun run verify` and therefore the Buildkite pipeline. There is no
+  `pre-push` hook. Lives in
   `contract-tests/` — deliberately outside the default test glob because it needs
   the sibling server package present.
 - **E2E** (`bun run e2e`, see `e2e/README.md`): Maestro drives the app in a

--- a/packages/temporal/src/activities/deps-summary.test.ts
+++ b/packages/temporal/src/activities/deps-summary.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { simpleGit } from "simple-git";
 import { z } from "zod/v4";
 import {
+  catalogAt,
+  CATALOG_HISTORY_PATHS,
   CatalogEntrySchema,
   DEPS_SUMMARY_CLONE_ARGS,
   deriveDependencyChanges,
@@ -152,5 +158,106 @@ describe("dependency summary collection", () => {
     expect(otherChangedPins).toHaveLength(fixture.expected.otherChangedPins);
     expect(additions).toHaveLength(fixture.expected.additions);
     expect(digestOnlyChanges).toHaveLength(fixture.expected.digestOnlyChanges);
+  });
+});
+
+describe("dependency catalog history", () => {
+  it("reads every catalog era across the workspace move", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "deps-summary-git-"));
+    try {
+      const git = simpleGit(directory);
+      await git.init();
+      await git.addConfig("user.email", "test@example.test");
+      await git.addConfig("user.name", "test");
+
+      const legacyVersions = `const versions = {
+  // renovate: datasource=docker registryUrl=https://ghcr.io versioning=semver
+  "owner/image": "1.0.0",
+};
+export default versions;
+`;
+      const catalogJson = (value: string) =>
+        JSON.stringify({
+          schemaVersion: 1,
+          entries: [
+            {
+              name: "owner/image",
+              value,
+              category: "upstream",
+              artifactType: "image",
+              management: {
+                managed: true,
+                datasource: "docker",
+                registryUrl: "https://ghcr.io",
+                versioning: "semver",
+              },
+            },
+          ],
+        });
+      // The projection that replaced the literal object once the catalog became
+      // the source of truth. It parses as TypeScript but has no versions object.
+      const projection = `import catalog from "./version-catalog.json";
+export default Object.fromEntries(catalog.entries.map((e) => [e.name, e.value]));
+`;
+
+      const write = async (file: string, contents: string) => {
+        const target = path.join(directory, file);
+        await mkdir(path.dirname(target), { recursive: true });
+        await Bun.write(target, contents);
+      };
+
+      await write("packages/homelab/src/cdk8s/src/versions.ts", legacyVersions);
+      await git.add(".");
+      await git.commit("legacy literal versions");
+      const rawLegacySha = await git.revparse(["HEAD"]);
+      const legacySha = rawLegacySha.trim();
+
+      await write("packages/homelab/src/cdk8s/src/versions.ts", projection);
+      await write(
+        "packages/homelab/src/cdk8s/src/version-catalog.json",
+        catalogJson("2.0.0"),
+      );
+      await git.add(".");
+      await git.commit("catalog at its former path");
+      const rawPriorSha = await git.revparse(["HEAD"]);
+      const priorSha = rawPriorSha.trim();
+
+      await rm(
+        path.join(
+          directory,
+          "packages/homelab/src/cdk8s/src/version-catalog.json",
+        ),
+      );
+      await write(
+        "packages/version-catalog/src/catalog.json",
+        catalogJson("3.0.0"),
+      );
+      await git.add(".");
+      await git.commit("move the catalog to its own workspace");
+      const rawCurrentSha = await git.revparse(["HEAD"]);
+      const currentSha = rawCurrentSha.trim();
+
+      const legacyEntries = await catalogAt(git, legacySha);
+      // Without the pre-move path this fell through to the projection and threw.
+      const priorEntries = await catalogAt(git, priorSha);
+      const currentEntries = await catalogAt(git, currentSha);
+      expect(legacyEntries[0]?.value).toBe("1.0.0");
+      expect(priorEntries[0]?.value).toBe("2.0.0");
+      expect(currentEntries[0]?.value).toBe("3.0.0");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("walks every catalog path when listing revisions", () => {
+    expect(CATALOG_HISTORY_PATHS).toContain(
+      "packages/homelab/src/cdk8s/src/version-catalog.json",
+    );
+    expect(CATALOG_HISTORY_PATHS).toContain(
+      "packages/version-catalog/src/catalog.json",
+    );
+    expect(CATALOG_HISTORY_PATHS).toContain(
+      "packages/homelab/src/cdk8s/src/versions.ts",
+    );
   });
 });

--- a/packages/temporal/src/activities/deps-summary.ts
+++ b/packages/temporal/src/activities/deps-summary.ts
@@ -14,8 +14,7 @@ import {
   synthesizeDependencyChanges,
 } from "./deps-summary-release-notes.ts";
 
-const VERSION_CATALOG_PATH =
-  "packages/homelab/src/cdk8s/src/version-catalog.json";
+const VERSION_CATALOG_PATH = "packages/version-catalog/src/catalog.json";
 const LEGACY_VERSIONS_PATH = "packages/homelab/src/cdk8s/src/versions.ts";
 const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
 const CHECKPOINT_KEY = "reports/state/deps-summary-weekly.json";

--- a/packages/temporal/src/activities/deps-summary.ts
+++ b/packages/temporal/src/activities/deps-summary.ts
@@ -15,7 +15,18 @@ import {
 } from "./deps-summary-release-notes.ts";
 
 const VERSION_CATALOG_PATH = "packages/version-catalog/src/catalog.json";
+// The catalog lived here before it became its own workspace, and `versions.ts`
+// was already a projection of it. Reading history across that move therefore
+// needs all three eras: the current catalog, the catalog at its former path,
+// and only then the pre-catalog literal `versions.ts`.
+const PRIOR_VERSION_CATALOG_PATH =
+  "packages/homelab/src/cdk8s/src/version-catalog.json";
 const LEGACY_VERSIONS_PATH = "packages/homelab/src/cdk8s/src/versions.ts";
+export const CATALOG_HISTORY_PATHS = [
+  VERSION_CATALOG_PATH,
+  PRIOR_VERSION_CATALOG_PATH,
+  LEGACY_VERSIONS_PATH,
+] as const;
 const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
 const CHECKPOINT_KEY = "reports/state/deps-summary-weekly.json";
 
@@ -254,9 +265,14 @@ async function tryGitShow(
   }
 }
 
-async function catalogAt(git: SimpleGit, ref: string): Promise<CatalogEntry[]> {
+export async function catalogAt(
+  git: SimpleGit,
+  ref: string,
+): Promise<CatalogEntry[]> {
   const catalog = await tryGitShow(git, ref, VERSION_CATALOG_PATH);
   if (catalog !== undefined) return parseCatalog(catalog);
+  const priorCatalog = await tryGitShow(git, ref, PRIOR_VERSION_CATALOG_PATH);
+  if (priorCatalog !== undefined) return parseCatalog(priorCatalog);
   const legacy = await tryGitShow(git, ref, LEGACY_VERSIONS_PATH);
   if (legacy !== undefined) return parseLegacyVersionsSource(legacy);
   throw new Error(`no version catalog exists at ${ref}`);
@@ -425,8 +441,7 @@ export async function collectDependencyChanges(
       "--reverse",
       `${baseSha}..${headSha}`,
       "--",
-      VERSION_CATALOG_PATH,
-      LEGACY_VERSIONS_PATH,
+      ...CATALOG_HISTORY_PATHS,
     ]);
     const commits = rawCommits.trim().split("\n").filter(Boolean);
     const catalogCommits: {

--- a/packages/version-catalog/eslint.config.ts
+++ b/packages/version-catalog/eslint.config.ts
@@ -1,0 +1,4 @@
+import { recommended } from "@shepherdjerred/eslint-config";
+
+const config = [...recommended({ tsconfigRootDir: import.meta.dirname })];
+export default config;

--- a/packages/version-catalog/package.json
+++ b/packages/version-catalog/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@shepherdjerred/version-catalog",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./catalog.json": "./src/catalog.json",
+    "./schema.json": "./src/schema.json"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --target bun --outdir dist",
+    "lint": "bunx --no-install eslint --cache .",
+    "test": "bun test",
+    "test:ci": "bun ../../scripts/run-ci-test.ts",
+    "test:report": "CI_TEST_COVERAGE=1 bun ../../scripts/run-ci-test.ts",
+    "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@shepherdjerred/eslint-config": "workspace:*",
+    "@tsconfig/node-lts": "^24.0.0",
+    "@tsconfig/recommended": "^1.0.13",
+    "@tsconfig/strictest": "^2.0.8",
+    "@types/bun": "^1.3.13",
+    "@typescript/native": "npm:typescript@7.0.2",
+    "ajv": "^8.20.0",
+    "eslint": "^10.7.0",
+    "jiti": "^2.7.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./version-catalog.schema.json",
+  "$schema": "./schema.json",
   "schemaVersion": 1,
   "entries": [
     {

--- a/packages/version-catalog/src/index.test.ts
+++ b/packages/version-catalog/src/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import rawCatalog from "./catalog.json" with { type: "json" };
+import catalogSchema from "./schema.json" with { type: "json" };
+import {
+  parseVersionCatalog,
+  parseVersionCatalogText,
+  serializeVersionCatalog,
+  versionCatalogMap,
+} from "./index.ts";
+
+describe("version catalog", () => {
+  test("conforms to the published language-neutral JSON Schema", () => {
+    const validate = new Ajv2020({
+      strict: true,
+      validateFormats: false,
+    }).compile(catalogSchema);
+    expect(validate(rawCatalog)).toBeTrue();
+    expect(validate.errors).toBeNull();
+  });
+
+  test("parses and maps the language-neutral catalog", () => {
+    const catalog = parseVersionCatalog(rawCatalog);
+    const map = versionCatalogMap(catalog);
+    expect(catalog.entries.length).toBeGreaterThan(100);
+    expect(Object.keys(map)).toHaveLength(catalog.entries.length);
+  });
+
+  test("serializes a canonical round trip", () => {
+    const catalog = parseVersionCatalog(rawCatalog);
+    const serialized = serializeVersionCatalog(catalog);
+    expect(parseVersionCatalogText(serialized)).toEqual(catalog);
+    expect(serialized.endsWith("\n")).toBeTrue();
+  });
+
+  test("rejects duplicate names", () => {
+    const catalog = parseVersionCatalog(rawCatalog);
+    const duplicate = {
+      ...catalog,
+      entries: [catalog.entries[0], catalog.entries[0]],
+    };
+    expect(() => parseVersionCatalog(duplicate)).toThrow(
+      "version catalog names must be unique",
+    );
+  });
+});

--- a/packages/version-catalog/src/index.ts
+++ b/packages/version-catalog/src/index.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type VersionMap, VersionMapSchema } from "./version-map.generated.ts";
 
 export const VersionCatalogManagementSchema = z.discriminatedUnion("managed", [
   z
@@ -84,11 +83,7 @@ function canonicalManagement(management: VersionCatalogEntry["management"]) {
   };
 }
 
-/**
- * Serialize the catalog in the field order consumed by Renovate's regex
- * manager. Zod parsing intentionally normalizes values, so writers must not
- * rely on the parsed object's insertion order.
- */
+/** Serialize in the field order consumed by Renovate's regex manager. */
 export function serializeVersionCatalog(catalog: VersionCatalog): string {
   const canonical = {
     $schema: catalog.$schema,
@@ -108,10 +103,10 @@ export function serializeVersionCatalog(catalog: VersionCatalog): string {
   return `${JSON.stringify(canonical, null, 2)}\n`;
 }
 
-export function versionMap(catalog: VersionCatalog): VersionMap {
-  return VersionMapSchema.parse(
-    Object.fromEntries(
-      catalog.entries.map((entry) => [entry.name, entry.value]),
-    ),
+export function versionCatalogMap(
+  catalog: VersionCatalog,
+): Record<string, string> {
+  return Object.fromEntries(
+    catalog.entries.map((entry) => [entry.name, entry.value]),
   );
 }

--- a/packages/version-catalog/src/schema.json
+++ b/packages/version-catalog/src/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "urn:sjer:red:schema:homelab-version-catalog:v1",
-  "title": "Homelab version catalog",
+  "$id": "urn:sjer:red:schema:version-catalog:v1",
+  "title": "Version catalog",
   "type": "object",
   "additionalProperties": false,
   "required": ["$schema", "schemaVersion", "entries"],

--- a/packages/version-catalog/tsconfig.json
+++ b/packages/version-catalog/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json",
+    "@tsconfig/node-lts/tsconfig.json",
+    "@tsconfig/recommended/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "types": ["@types/bun"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "customType": "regex",
       "description": "Update structured homelab version catalog and legacy TypeScript version files",
       "managerFilePatterns": [
-        "packages/homelab/src/cdk8s/src/version-catalog.json",
+        "packages/version-catalog/src/catalog.json",
         "**/lib-versions.ts"
       ],
       "matchStrings": [

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -428,6 +428,11 @@
       "steps": [{ "runner": "bun" }]
     },
     {
+      "package": "@shepherdjerred/version-catalog",
+      "directory": "packages/version-catalog",
+      "steps": [{ "runner": "bun" }]
+    },
+    {
       "package": "webring",
       "directory": "packages/webring",
       "steps": [

--- a/scripts/lib/image-pin-catalog.ts
+++ b/scripts/lib/image-pin-catalog.ts
@@ -32,7 +32,7 @@ function requiredString(
  * primitives. A Zod-backed schema here makes every bake pod fail at module load
  * with "Cannot find package 'zod'" — moving the module between workspaces does
  * not help, because the lane has no `node_modules` at all. The installed lanes
- * keep their fully validated catalog read in `version-catalog.ts`.
+ * keep their fully validated catalog read in `@shepherdjerred/version-catalog`.
  */
 function readCatalogImageEntries(
   versionCatalogSource: string,

--- a/scripts/lib/pin-candidates.ts
+++ b/scripts/lib/pin-candidates.ts
@@ -4,7 +4,7 @@ import {
   parseVersionCatalogText,
   serializeVersionCatalog,
   type VersionCatalog,
-} from "../../packages/homelab/src/cdk8s/src/version-catalog.ts";
+} from "@shepherdjerred/version-catalog";
 
 const DigestSchema = z
   .string()

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@openai/codex": "0.146.0",
     "@shepherdjerred/code-review": "workspace:*",
+    "@shepherdjerred/version-catalog": "workspace:*",
     "zod": "^4.4.3",
     "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.10.1",

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { z } from "zod";
-import { parseVersionCatalog } from "../packages/homelab/src/cdk8s/src/version-catalog.ts";
+import { parseVersionCatalog } from "@shepherdjerred/version-catalog";
 
 const RegexManagerSchema = z.object({
   description: z.string(),
@@ -34,7 +34,7 @@ test("extracts every managed structured version-catalog field", async () => {
   );
   const manager = config.customManagers.find((candidate) =>
     candidate.managerFilePatterns.includes(
-      "packages/homelab/src/cdk8s/src/version-catalog.json",
+      "packages/version-catalog/src/catalog.json",
     ),
   );
   if (manager === undefined) {
@@ -44,7 +44,7 @@ test("extracts every managed structured version-catalog field", async () => {
   if (expression === undefined) {
     throw new Error("Structured version-catalog matcher is missing");
   }
-  const catalogPath = `${root}/packages/homelab/src/cdk8s/src/version-catalog.json`;
+  const catalogPath = `${root}/packages/version-catalog/src/catalog.json`;
   const source = await Bun.file(catalogPath).text();
   const catalog = parseVersionCatalog(JSON.parse(source));
   const actual = [...source.matchAll(new RegExp(expression, "g"))].map(

--- a/scripts/scout-site-release.test.ts
+++ b/scripts/scout-site-release.test.ts
@@ -58,7 +58,7 @@ function stateJson(overrides: Record<string, unknown> = {}): string {
 
 function versionCatalogSource(name: string, value: string): string {
   return JSON.stringify({
-    $schema: "./version-catalog.schema.json",
+    $schema: "./schema.json",
     schemaVersion: 1,
     entries: [
       {

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -450,14 +450,14 @@ async function main(): Promise<void> {
       const index = args.indexOf("--candidate-digest");
       const candidate = index === -1 ? null : (args[index + 1] ?? "");
       const source = await Bun.file(
-        `${repoRoot()}/packages/homelab/src/cdk8s/src/version-catalog.json`,
+        `${repoRoot()}/packages/version-catalog/src/catalog.json`,
       ).text();
       process.stdout.write(`${resolveBackendDigest(candidate, source)}\n`);
       break;
     }
     case "resolve-prod-pin": {
       const source = await Bun.file(
-        `${repoRoot()}/packages/homelab/src/cdk8s/src/version-catalog.json`,
+        `${repoRoot()}/packages/version-catalog/src/catalog.json`,
       ).text();
       process.stdout.write(`${resolveProdPin(source)}\n`);
       break;

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -33,7 +33,7 @@ function catalogSource(
   entries: { name: string; value: string; notes?: string[] }[],
 ): string {
   return JSON.stringify({
-    $schema: "./version-catalog.schema.json",
+    $schema: "./schema.json",
     schemaVersion: 1,
     entries: entries.map((entry) => ({
       name: entry.name,

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -23,8 +23,7 @@ import { runMain } from "./lib/transient.ts";
 const MONOREPO_REPO = "shepherdjerred/monorepo";
 const MONOREPO_WRITE_URL = `https://github.com/${MONOREPO_REPO}.git`;
 const VERSION_BUMP_BRANCH = "chore/version-bump-pending";
-const VERSION_CATALOG_FILE_REL =
-  "packages/homelab/src/cdk8s/src/version-catalog.json";
+const VERSION_CATALOG_FILE_REL = "packages/version-catalog/src/catalog.json";
 const PIN_STATE_FILE_REL = "scripts/pin-candidates-state.json";
 const MAX_LEASE_ATTEMPTS = 3;
 


### PR DESCRIPTION
## Why

Main is green, but the incident recovery left release safety coupled to split commands, operator-preserved sync options, and a CDK8s-owned catalog imported by unrelated CI lanes. This cleanup makes those guarantees structural without weakening any gate.

## What

- label managed child Applications and install Kubernetes mutating/validating admission policies for declared sync options and lifecycle-safe deletion
- centralize root sync waves, preserve child health as an ordering signal, and execute the Application health Lua through the real ArgoCD evaluator
- fail before child syncs on immutable-field or mutually exclusive probe-handler changes using ArgoCD live/target state
- replace the public split root lifecycle with one identity-bound `release-root` command plus bounded `sync-managed` recovery
- extract JSON, JSON Schema, parsing, and serialization into `@shepherdjerred/version-catalog`; remove the reactionary CDK8s install filters
- update Buildkite structural validation, operator documentation, repository guidance, and agent skills

## Verification

- `cd packages/homelab/src/cdk8s && bun run build && bun run typecheck && bun run lint && bun test` (453 passed, 14 existing environment-gated skips)
- `cd packages/version-catalog && bun run build && bun run typecheck && bun run lint && bun test` (4 passed)
- root script tests (504 passed), Buildkite release validator (6 passed), bake-image tests (34 passed)
- docs TODO/markdown checks, wiki typecheck/test/build/Playwright (7 passed)
- `cd packages/temporal && bun run check:rehearsal`
- `bun run compliance-check`
- `bunx lefthook run pre-commit`
- server-side Kubernetes dry-run accepted all synthesized admission policies and bindings
- `bun run verify` completed 249/252 tasks locally; the two branch-owned failures were fixed and rerun, while `@shepherdjerred/resume#build` remains unexecuted because this machine lacks `xelatex`

No live ArgoCD sync, cluster mutation, merge, or deployment was performed. Exact-head Buildkite and post-merge global-sync acceptance remain required.