### PR TITLE
fix(scout-for-lol): make showcase bucket pins real and the pipeline docs accurate

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -648,6 +648,9 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
   from the run's `--bucket` and silently revert the pin. The pin has to carry
   the whole entry, not just the `bucket` field: a freshly discovered key came
   from the run bucket and generally does not exist in the pinned one.
+  Untouchable is not unconditional, though: `discover` verifies every pinned
+  entry's source keys in its own bucket up front, and a missing one is a hard
+  error rather than a silent rebuild — see the NoSuchKey recovery below.
 - **Player names are pseudonymous in the charts.** `showcase/anonymize.ts` maps
   a player to a curated handle by hashing `${stableKey}|${realName}`, where the
   stable key is a non-display identity (`playerId` / `puuid`). The weekly job
@@ -692,6 +695,17 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
   post-match objects), ARAM Mayhem has no such survey, so it is deliberately
   **not** declared `states: ["prematch"]` — the scan keeps looking. Run that
   survey before narrowing the spec.
+- **Recovering a dead pinned source.** `discover` verifies each pinned entry's
+  keys before scanning, so a deleted source stops the run in seconds with the
+  entry id, the bucket, and the missing key — instead of letting `generate`
+  fail on NoSuchKey again. Repointing a hand-curated source is a decision, so
+  the fix is explicit, not inferred. Either re-pin the entry by hand to a live
+  object in the same bucket, or discard the pin with
+  `--refresh-pinned <entry-id>` (comma-separate ids, or `all`) to rebuild it
+  from the run bucket. Unknown ids fail rather than silently refreshing
+  nothing. Prefer re-pinning for the competition graph: refreshing it moves the
+  chart back to prod's three-player leaderboard, which renders fine and is not
+  what anyone chose.
 - **Adding or renaming a variant** touches four places: the spec in
   `discover-marketing-showcase.ts`, `REQUIRED_SHOWCASE_VARIANT_IDS` in
   `src/showcase/manifest.ts`, `showcasePreviews` in the frontend's

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -633,7 +633,33 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
 - **GC protection**: `scout-image-gc-daily` exempts every key the manifest
   references (it fetches the manifest from `main` before pruning), so curated
   sources outlive the 30-day image window. Consequence: manifest edits on a
-  branch don't protect new keys until merged.
+  branch don't protect new keys until merged. It only prunes `.png`/`.svg`
+  under `games/` and `prematch/`, so `leaderboards/**` snapshots are never
+  collected and need no exemption.
+- **Per-entry `bucket` override**: an entry may pin its own source bucket.
+  Both buckets sit behind one SeaweedFS endpoint, so only the bucket name
+  swaps, not the client. The competition graph uses it to source `scout-beta`,
+  whose competitions have ~28 players against prod's richest at 3. `discover`
+  treats an entry carrying an explicit `bucket` as pinned and leaves it alone —
+  without that it would rebuild the entry from the run's `--bucket` and
+  silently revert the pin.
+- **Player names are pseudonymous in the charts.** `showcase/anonymize.ts` maps
+  a stable non-display identity (`playerId` / `puuid`) to a curated handle,
+  deterministically — the weekly job commits these PNGs, so a pseudonym that
+  moved between runs would open a junk PR every Monday. Assign handles to the
+  players you will actually render (slice, then anonymize): the report graph
+  aggregates ~120 participants but draws ten, and anonymizing before the slice
+  exhausts the pool into a numbered fallback. **Known gap:** `s3-image` and
+  `discord-screenshot` entries are byte copies of prod-rendered PNGs, so the
+  names in those are baked into the pixels and are still real.
+- **Discovery finds rare modes.** `wantedCombos` is derived from the full
+  `variantSpecs()` set, split by state, and is the scan's loop terminator —
+  it was once hard-coded to `{solo:1, flex:1}`, which stopped the walk after a
+  few dozen objects and left every rarer variant carried forward from `--prev`
+  indefinitely. Combos verified absent (flex 4/5) are excluded so the loop can
+  still terminate early. A mode with no post-match payload (League Classic —
+  Riot exposes none) declares `states: ["prematch"]` rather than emitting a
+  variant that can only ever resolve to a miss.
 - **Re-curation runbook** (after a renderer redesign, or if the weekly job
   fails NoSuchKey): from `packages/backend`,
   `AWS_PROFILE=seaweedfs bun run scripts/discover-marketing-showcase.ts
@@ -641,6 +667,18 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
 --prev ../../showcase/marketing-showcase.manifest.json`, then run
   `scripts/generate-marketing-showcase.ts` with the standard flags (see the
   Temporal activity for the exact invocation) and commit manifest + outputs.
+  Let the `seaweedfs` AWS profile supply the endpoint; passing `--endpoint-url`
+  by hand overrides it. Expect roughly 30s — the post-match scan uses its full
+  head budget because ARAM Mayhem has no post-match object to find.
+- **Adding or renaming a variant** touches four places: the spec in
+  `discover-marketing-showcase.ts`, `REQUIRED_SHOWCASE_VARIANT_IDS` in
+  `src/showcase/manifest.ts`, `showcasePreviews` in the frontend's
+  `index.astro` (`requireShowcaseAsset` **throws** on a missing id, so a stale
+  reference breaks the marketing build), and the committed PNGs. The
+  `discord-screenshot` templates in `src/showcase/discord-templates.ts` are an
+  independent `(queue, playerCount)` lookup — leaving one at a player count the
+  bucket no longer produces pins it to a stale object while everything else
+  refreshes.
 
 ## Pre-commit gates
 

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -652,11 +652,13 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
   a player to a curated handle by hashing `${stableKey}|${realName}`, where the
   stable key is a non-display identity (`playerId` / `puuid`). The weekly job
   commits these PNGs, so a pseudonym that moved between runs would open a junk
-  PR every Monday. The display name is in the seed only as a same-key
-  disambiguator, but it is still in the seed: within one run a rename cannot
-  move a handle (the per-run cache is keyed on the stable key alone), while
-  **across** runs a renamed player can draw a different pseudonym. That is a
-  one-off image diff to eyeball, not drift. Assign handles to the
+  PR every Monday. What is guaranteed is **reproducibility, not a fixed
+  key→handle mapping**: a handle depends on the whole call sequence, because
+  the seed includes the display name and collisions probe past the handles
+  already taken. Re-running the same manifest over the same rosters reproduces
+  the same PNGs; a re-curation, a rename, or a change to how many players an
+  entry renders can move handles, including for players who did not change.
+  Read that as a one-off image diff to eyeball, not drift. Assign handles to the
   players you will actually render (slice, then anonymize): the report graph
   aggregates ~120 participants but draws ten, and anonymizing before the slice
   exhausts the pool into a numbered fallback. **Known gap:** `s3-image` and

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -633,20 +633,30 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
 - **GC protection**: `scout-image-gc-daily` exempts every key the manifest
   references (it fetches the manifest from `main` before pruning), so curated
   sources outlive the 30-day image window. Consequence: manifest edits on a
-  branch don't protect new keys until merged. It only prunes `.png`/`.svg`
-  under `games/` and `prematch/`, so `leaderboards/**` snapshots are never
-  collected and need no exemption.
+  branch don't protect new keys until merged. It prunes **both** `scout-prod`
+  and `scout-beta`, so the exemption list is grouped by the bucket each entry
+  actually reads (`bucket` if pinned, else `scout-prod`) — a flat list applied
+  to prod alone would leave a beta-pinned source unprotected. It only prunes
+  `.png`/`.svg` under `games/` and `prematch/`, so `leaderboards/**` snapshots
+  are never collected and need no exemption.
 - **Per-entry `bucket` override**: an entry may pin its own source bucket.
   Both buckets sit behind one SeaweedFS endpoint, so only the bucket name
   swaps, not the client. The competition graph uses it to source `scout-beta`,
   whose competitions have ~28 players against prod's richest at 3. `discover`
-  treats an entry carrying an explicit `bucket` as pinned and leaves it alone —
-  without that it would rebuild the entry from the run's `--bucket` and
-  silently revert the pin.
+  treats any entry carrying an explicit `bucket` as pinned and returns it
+  untouched, for every entry kind — without that it would rebuild the entry
+  from the run's `--bucket` and silently revert the pin. The pin has to carry
+  the whole entry, not just the `bucket` field: a freshly discovered key came
+  from the run bucket and generally does not exist in the pinned one.
 - **Player names are pseudonymous in the charts.** `showcase/anonymize.ts` maps
-  a stable non-display identity (`playerId` / `puuid`) to a curated handle,
-  deterministically — the weekly job commits these PNGs, so a pseudonym that
-  moved between runs would open a junk PR every Monday. Assign handles to the
+  a player to a curated handle by hashing `${stableKey}|${realName}`, where the
+  stable key is a non-display identity (`playerId` / `puuid`). The weekly job
+  commits these PNGs, so a pseudonym that moved between runs would open a junk
+  PR every Monday. The display name is in the seed only as a same-key
+  disambiguator, but it is still in the seed: within one run a rename cannot
+  move a handle (the per-run cache is keyed on the stable key alone), while
+  **across** runs a renamed player can draw a different pseudonym. That is a
+  one-off image diff to eyeball, not drift. Assign handles to the
   players you will actually render (slice, then anonymize): the report graph
   aggregates ~120 participants but draws ten, and anonymizing before the slice
   exhausts the pool into a numbered fallback. **Known gap:** `s3-image` and
@@ -667,9 +677,19 @@ real objects in the `scout-prod` bucket. Never hand-edit the outputs.
 --prev ../../showcase/marketing-showcase.manifest.json`, then run
   `scripts/generate-marketing-showcase.ts` with the standard flags (see the
   Temporal activity for the exact invocation) and commit manifest + outputs.
-  Let the `seaweedfs` AWS profile supply the endpoint; passing `--endpoint-url`
-  by hand overrides it. Expect roughly 30s — the post-match scan uses its full
-  head budget because ARAM Mayhem has no post-match object to find.
+  Both scripts validate their flag names against a closed `z.enum`, so there is
+  **no** endpoint flag and an unknown `--…` fails CLI parsing rather than being
+  ignored. `createS3Client()` sets no endpoint, region, or credentials, so all
+  three come from standard AWS resolution — that is what `AWS_PROFILE=seaweedfs`
+  (its `endpoint_url` in `~/.aws/config`) is doing above; point the run
+  somewhere else by selecting a different profile. Expect roughly 30s: the
+  post-match scan runs to its full head budget whenever a wanted combo is never
+  satisfied, and today `aram mayhem` post-match is that combo — the manifest has
+  carried it as unsupported since the generator landed. Unlike League Classic,
+  whose absence was verified against prod (zero `classic` reports across 1,078
+  post-match objects), ARAM Mayhem has no such survey, so it is deliberately
+  **not** declared `states: ["prematch"]` — the scan keeps looking. Run that
+  survey before narrowing the spec.
 - **Adding or renaming a variant** touches four places: the spec in
   `discover-marketing-showcase.ts`, `REQUIRED_SHOWCASE_VARIANT_IDS` in
   `src/showcase/manifest.ts`, `showcasePreviews` in the frontend's

--- a/packages/scout-for-lol/packages/backend/scripts/discover-marketing-showcase.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/discover-marketing-showcase.ts
@@ -1,8 +1,11 @@
 import {
   GetObjectCommand,
   ListObjectsV2Command,
+  NoSuchKey,
+  NotFound,
   type S3Client,
 } from "@aws-sdk/client-s3";
+import { match, P } from "ts-pattern";
 import { z } from "zod";
 import { QueueTypeSchema, type QueueType } from "@scout-for-lol/data";
 import { createS3Client } from "#src/storage/s3-client.ts";
@@ -25,6 +28,7 @@ const CliFlagNameSchema = z.enum([
   "out",
   "prev",
   "max-head",
+  "refresh-pinned",
 ]);
 
 const CliValuesSchema = z.strictObject({
@@ -35,6 +39,9 @@ const CliValuesSchema = z.strictObject({
   out: z.string().optional(),
   prev: z.string().optional(),
   "max-head": z.string().optional(),
+  // Comma-separated entry ids (or `all`) to rebuild from the run bucket,
+  // discarding their pin. See `resolvePinnedEntries`.
+  "refresh-pinned": z.string().optional(),
 });
 
 /** Safety cap on metadata reads per prefix if a wanted combo is unexpectedly scarce. */
@@ -270,28 +277,145 @@ function s3Entry(params: {
   };
 }
 
+/** Every S3 object an entry's renderer will read. */
+function entrySourceKeys(entry: ShowcaseEntry): string[] {
+  return match(entry)
+    .with({ kind: "unsupported" }, () => [])
+    .with({ kind: "competition-graph" }, (graph) => graph.snapshotKeys)
+    .with({ kind: "report-graph" }, (graph) => graph.matchKeys)
+    .with(
+      { kind: P.union("s3-image", "discord-screenshot") },
+      (image): string[] =>
+        image.dataKey === undefined
+          ? [image.imageKey]
+          : [image.imageKey, image.dataKey],
+    )
+    .exhaustive();
+}
+
+async function objectExists(params: {
+  client: S3Client;
+  bucket: string;
+  key: string;
+}): Promise<boolean> {
+  try {
+    await objectMetadata(params);
+    return true;
+  } catch (error) {
+    // Narrow: a missing object is the answer to the question being asked, but a
+    // credential, endpoint, or permission failure is not — those must surface
+    // rather than be reported as "the pin is stale".
+    if (error instanceof NoSuchKey || error instanceof NotFound) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 /**
+ * Resolve which previous entries are still usable as pins.
+ *
  * An entry that pins its own `bucket` was curated by hand against a source this
  * scan cannot even see — discover only ever lists the run's `--bucket`. Without
  * treating it as untouchable, a re-curation silently reverts that choice: the
  * fresh entry is built from scratch with no `bucket` field, so generate falls
  * back to the run bucket and renders a different object (or fails on
- * NoSuchKey). The `--prev` fallback below cannot save it either, because it is
- * only reached when nothing fresh was found at all.
+ * NoSuchKey). The `--prev` fallback in `withFallback` cannot save it either,
+ * because it is only reached when nothing fresh was found at all. Carrying only
+ * the `bucket` field onto a fresh candidate would be worse than useless: that
+ * candidate's key was discovered in the run bucket and generally does not exist
+ * in the pinned one.
  *
- * Carrying only the `bucket` field onto a fresh candidate would be worse than
- * useless: that candidate's key was discovered in the run bucket and generally
- * does not exist in the pinned one.
+ * But "untouchable" cannot mean "unconditional", or the NoSuchKey runbook
+ * cannot recover: if a pinned source is deleted, re-running with `--prev`
+ * reloads the same dead entry, returns it before considering any replacement,
+ * and generate fails on the same key forever. So every pinned entry's source
+ * keys are verified in its own bucket first, and a missing one is a hard error
+ * naming the remedy. Repointing a hand-curated source is a decision, not
+ * something to infer: silently rebuilding it from the run bucket would swap the
+ * competition graph back to prod's three-player leaderboard and render a chart
+ * that looks fine and is not what anyone chose. `--refresh-pinned` is how an
+ * operator says to do it anyway.
  */
-function pinnedEntry(
-  prevById: Map<string, ShowcaseEntry>,
-  id: string,
-): ShowcaseEntry | undefined {
-  const prev = prevById.get(id);
-  if (prev === undefined || prev.kind === "unsupported") {
-    return undefined;
+async function resolvePinnedEntries(params: {
+  client: S3Client;
+  prevById: Map<string, ShowcaseEntry>;
+  refreshIds: ReadonlySet<string>;
+}): Promise<Map<string, ShowcaseEntry>> {
+  const pinned = new Map<string, ShowcaseEntry>();
+
+  for (const entry of params.prevById.values()) {
+    if (entry.kind === "unsupported" || entry.bucket === undefined) {
+      continue;
+    }
+    if (params.refreshIds.has(entry.id) || params.refreshIds.has("all")) {
+      process.stderr.write(
+        `Refreshing pinned entry ${entry.id}: rebuilding from the run bucket, dropping its ${entry.bucket} pin.\n`,
+      );
+      continue;
+    }
+
+    for (const key of entrySourceKeys(entry)) {
+      if (
+        !(await objectExists({
+          client: params.client,
+          bucket: entry.bucket,
+          key,
+        }))
+      ) {
+        throw new Error(
+          `Pinned showcase entry '${entry.id}' references ${entry.bucket}/${key}, which no longer exists. ` +
+            `Re-pin it by hand to a live object in ${entry.bucket}, or rerun with --refresh-pinned ${entry.id} ` +
+            `to discard the pin and rebuild the entry from the run bucket.`,
+        );
+      }
+    }
+    pinned.set(entry.id, entry);
   }
-  return prev.bucket === undefined ? undefined : prev;
+
+  return pinned;
+}
+
+/**
+ * Ids named by `--refresh-pinned`, validated against the entries that are
+ * actually pinned so a typo fails here rather than silently refreshing nothing.
+ */
+function parseRefreshIds(
+  raw: string | undefined,
+  prevById: Map<string, ShowcaseEntry>,
+): ReadonlySet<string> {
+  if (raw === undefined) {
+    return new Set<string>();
+  }
+
+  const ids = new Set(
+    raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+  );
+  if (ids.size === 0) {
+    throw new Error("--refresh-pinned needs at least one entry id, or 'all'");
+  }
+  if (ids.has("all")) {
+    return ids;
+  }
+
+  const pinnedIds = new Set(
+    [...prevById.values()]
+      .filter(
+        (entry) => entry.kind !== "unsupported" && entry.bucket !== undefined,
+      )
+      .map((entry) => entry.id),
+  );
+  for (const id of ids) {
+    if (!pinnedIds.has(id)) {
+      throw new Error(
+        `--refresh-pinned '${id}' is not a pinned entry in --prev (pinned: ${[...pinnedIds].join(", ") || "none"})`,
+      );
+    }
+  }
+  return ids;
 }
 
 /**
@@ -313,9 +437,10 @@ function buildEntries(params: {
   prematchCandidates: ImageCandidate[];
   postmatchCandidates: ImageCandidate[];
   prevById: Map<string, ShowcaseEntry>;
+  pinnedById: Map<string, ShowcaseEntry>;
 }): ShowcaseEntry[] {
   return params.specs.map((spec) => {
-    const pinned = pinnedEntry(params.prevById, spec.id);
+    const pinned = params.pinnedById.get(spec.id);
     if (pinned !== undefined) {
       return pinned;
     }
@@ -365,9 +490,10 @@ function buildEntries(params: {
 function discordEntries(
   postmatchCandidates: ImageCandidate[],
   prevById: Map<string, ShowcaseEntry>,
+  pinnedById: Map<string, ShowcaseEntry>,
 ): ShowcaseEntry[] {
   return DISCORD_SHOWCASE_TEMPLATES.map((template) => {
-    const pinned = pinnedEntry(prevById, template.id);
+    const pinned = pinnedById.get(template.id);
     if (pinned !== undefined) {
       return pinned;
     }
@@ -540,10 +666,9 @@ function variantSpecs(): VariantSpec[] {
 function leaderboardSnapshotGroups(keys: string[]): Map<string, string[]> {
   const groups = new Map<string, string[]>();
   for (const key of keys) {
-    const match = /^leaderboards\/competition-\d+\/snapshots\/.+\.json$/.exec(
-      key,
-    );
-    if (match === null) {
+    const snapshotMatch =
+      /^leaderboards\/competition-\d+\/snapshots\/.+\.json$/.exec(key);
+    if (snapshotMatch === null) {
       continue;
     }
     const competitionKey = key.split("/snapshots/")[0];
@@ -594,9 +719,10 @@ async function competitionGraphEntry(params: {
   bucket: string;
   keys: string[];
   prevById: Map<string, ShowcaseEntry>;
+  pinnedById: Map<string, ShowcaseEntry>;
 }): Promise<ShowcaseEntry> {
   // Checked before the snapshot scan below, which is the expensive part.
-  const pinned = pinnedEntry(params.prevById, "competition-graph");
+  const pinned = params.pinnedById.get("competition-graph");
   if (pinned !== undefined) {
     return pinned;
   }
@@ -649,8 +775,9 @@ async function competitionGraphEntry(params: {
 function reportGraphEntry(
   postmatchCandidates: ImageCandidate[],
   prevById: Map<string, ShowcaseEntry>,
+  pinnedById: Map<string, ShowcaseEntry>,
 ): ShowcaseEntry {
-  const pinned = pinnedEntry(prevById, "report-graph");
+  const pinned = pinnedById.get("report-graph");
   if (pinned !== undefined) {
     return pinned;
   }
@@ -739,6 +866,14 @@ function wantedCombosForState(state: "prematch" | "postmatch"): Set<string> {
 
 const prevById = await loadPrevEntries(values.prev);
 
+// Resolved before the scans so a dead pin fails in seconds rather than after a
+// full head budget of metadata reads.
+const pinnedById = await resolvePinnedEntries({
+  client,
+  prevById,
+  refreshIds: parseRefreshIds(values["refresh-pinned"], prevById),
+});
+
 const [postmatch, prematch, leaderboardKeys] = await Promise.all([
   discoverImageCandidates({
     client,
@@ -768,6 +903,7 @@ const competitionEntry = await competitionGraphEntry({
   bucket,
   keys: leaderboardKeys,
   prevById,
+  pinnedById,
 });
 
 const manifest = ShowcaseManifestSchema.parse({
@@ -778,10 +914,11 @@ const manifest = ShowcaseManifestSchema.parse({
       prematchCandidates: prematch.candidates,
       postmatchCandidates: postmatch.candidates,
       prevById,
+      pinnedById,
     }),
-    ...discordEntries(postmatch.candidates, prevById),
+    ...discordEntries(postmatch.candidates, prevById, pinnedById),
     competitionEntry,
-    reportGraphEntry(postmatch.candidates, prevById),
+    reportGraphEntry(postmatch.candidates, prevById, pinnedById),
   ],
 });
 

--- a/packages/scout-for-lol/packages/backend/scripts/discover-marketing-showcase.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/discover-marketing-showcase.ts
@@ -271,6 +271,30 @@ function s3Entry(params: {
 }
 
 /**
+ * An entry that pins its own `bucket` was curated by hand against a source this
+ * scan cannot even see — discover only ever lists the run's `--bucket`. Without
+ * treating it as untouchable, a re-curation silently reverts that choice: the
+ * fresh entry is built from scratch with no `bucket` field, so generate falls
+ * back to the run bucket and renders a different object (or fails on
+ * NoSuchKey). The `--prev` fallback below cannot save it either, because it is
+ * only reached when nothing fresh was found at all.
+ *
+ * Carrying only the `bucket` field onto a fresh candidate would be worse than
+ * useless: that candidate's key was discovered in the run bucket and generally
+ * does not exist in the pinned one.
+ */
+function pinnedEntry(
+  prevById: Map<string, ShowcaseEntry>,
+  id: string,
+): ShowcaseEntry | undefined {
+  const prev = prevById.get(id);
+  if (prev === undefined || prev.kind === "unsupported") {
+    return undefined;
+  }
+  return prev.bucket === undefined ? undefined : prev;
+}
+
+/**
  * Use a freshly-found entry if available, else fall back to the previous
  * manifest's entry (preserving an older-but-valid image so required coverage
  * never regresses), else mark unsupported.
@@ -291,6 +315,11 @@ function buildEntries(params: {
   prevById: Map<string, ShowcaseEntry>;
 }): ShowcaseEntry[] {
   return params.specs.map((spec) => {
+    const pinned = pinnedEntry(params.prevById, spec.id);
+    if (pinned !== undefined) {
+      return pinned;
+    }
+
     // These two short-circuit before the candidate lookup and before the
     // `--prev` fallback, so they are permanent rather than budget-dependent.
     // Say so: the generic miss reason below means "not found within the head
@@ -338,6 +367,11 @@ function discordEntries(
   prevById: Map<string, ShowcaseEntry>,
 ): ShowcaseEntry[] {
   return DISCORD_SHOWCASE_TEMPLATES.map((template) => {
+    const pinned = pinnedEntry(prevById, template.id);
+    if (pinned !== undefined) {
+      return pinned;
+    }
+
     const candidate = findCandidate(
       postmatchCandidates,
       template.queue,
@@ -561,18 +595,10 @@ async function competitionGraphEntry(params: {
   keys: string[];
   prevById: Map<string, ShowcaseEntry>;
 }): Promise<ShowcaseEntry> {
-  // An entry that pins its own `bucket` was curated by hand against a source
-  // this scan cannot even see — discover only ever lists the run's `--bucket`.
-  // Without this, a re-curation silently reverts that choice: the fresh entry
-  // below is built from scratch with no `bucket` field, so generate would fall
-  // back to the run bucket and render a different competition (or fail on
-  // NoSuchKey). The `--prev` fallback at the bottom cannot save it either,
-  // because it is only reached when NO competition in the run bucket qualifies.
-  const pinned = params.prevById.get("competition-graph");
-  if (pinned !== undefined && pinned.kind !== "unsupported") {
-    if (pinned.bucket !== undefined) {
-      return pinned;
-    }
+  // Checked before the snapshot scan below, which is the expensive part.
+  const pinned = pinnedEntry(params.prevById, "competition-graph");
+  if (pinned !== undefined) {
+    return pinned;
   }
 
   // Prefer the competition with the most snapshots whose *latest* snapshot is
@@ -624,6 +650,11 @@ function reportGraphEntry(
   postmatchCandidates: ImageCandidate[],
   prevById: Map<string, ShowcaseEntry>,
 ): ShowcaseEntry {
+  const pinned = pinnedEntry(prevById, "report-graph");
+  if (pinned !== undefined) {
+    return pinned;
+  }
+
   const matchKeys = postmatchCandidates
     .map((candidate) => candidate.dataKey)
     .slice(0, 12);

--- a/packages/scout-for-lol/packages/backend/scripts/discover-marketing-showcase.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/discover-marketing-showcase.ts
@@ -312,6 +312,16 @@ async function objectExists(params: {
   }
 }
 
+type ResolvedPins = {
+  /** Verified pins, returned untouched by every entry generator. */
+  pinned: Map<string, ShowcaseEntry>;
+  /**
+   * Previous entries still usable as a stale-but-valid fallback when a fresh
+   * scan finds nothing. Excludes anything `--refresh-pinned` discarded.
+   */
+  fallback: Map<string, ShowcaseEntry>;
+};
+
 /**
  * Resolve which previous entries are still usable as pins.
  *
@@ -336,19 +346,29 @@ async function objectExists(params: {
  * competition graph back to prod's three-player leaderboard and render a chart
  * that looks fine and is not what anyone chose. `--refresh-pinned` is how an
  * operator says to do it anyway.
+ *
+ * Refreshing has to drop the entry from BOTH maps. Omitting it only from
+ * `pinned` still leaves it in the fallback, and the fallback is reached exactly
+ * when the run bucket produced no candidate within the head budget — so the
+ * dead entry an operator asked to discard would come straight back, and
+ * generate would fail on the same missing key. Discarded means discarded; a
+ * refreshed entry with no replacement becomes `unsupported`, which is honest
+ * about the coverage gap.
  */
 async function resolvePinnedEntries(params: {
   client: S3Client;
   prevById: Map<string, ShowcaseEntry>;
   refreshIds: ReadonlySet<string>;
-}): Promise<Map<string, ShowcaseEntry>> {
+}): Promise<ResolvedPins> {
   const pinned = new Map<string, ShowcaseEntry>();
+  const fallback = new Map(params.prevById);
 
   for (const entry of params.prevById.values()) {
     if (entry.kind === "unsupported" || entry.bucket === undefined) {
       continue;
     }
     if (params.refreshIds.has(entry.id) || params.refreshIds.has("all")) {
+      fallback.delete(entry.id);
       process.stderr.write(
         `Refreshing pinned entry ${entry.id}: rebuilding from the run bucket, dropping its ${entry.bucket} pin.\n`,
       );
@@ -373,7 +393,7 @@ async function resolvePinnedEntries(params: {
     pinned.set(entry.id, entry);
   }
 
-  return pinned;
+  return { pinned, fallback };
 }
 
 /**
@@ -426,17 +446,17 @@ function parseRefreshIds(
 function withFallback(
   id: string,
   fresh: ShowcaseEntry | undefined,
-  prevById: Map<string, ShowcaseEntry>,
+  fallbackById: Map<string, ShowcaseEntry>,
   unsupported: ShowcaseEntry,
 ): ShowcaseEntry {
-  return fresh ?? prevById.get(id) ?? unsupported;
+  return fresh ?? fallbackById.get(id) ?? unsupported;
 }
 
 function buildEntries(params: {
   specs: VariantSpec[];
   prematchCandidates: ImageCandidate[];
   postmatchCandidates: ImageCandidate[];
-  prevById: Map<string, ShowcaseEntry>;
+  fallbackById: Map<string, ShowcaseEntry>;
   pinnedById: Map<string, ShowcaseEntry>;
 }): ShowcaseEntry[] {
   return params.specs.map((spec) => {
@@ -473,7 +493,7 @@ function buildEntries(params: {
     return withFallback(
       spec.id,
       candidate === undefined ? undefined : s3Entry({ spec, candidate }),
-      params.prevById,
+      params.fallbackById,
       unsupportedEntry(
         spec,
         `No recent ${spec.queue} ${spec.state} report was found within the head budget for ${spec.playerCount.toString()} tracked player(s).`,
@@ -489,7 +509,7 @@ function buildEntries(params: {
  */
 function discordEntries(
   postmatchCandidates: ImageCandidate[],
-  prevById: Map<string, ShowcaseEntry>,
+  fallbackById: Map<string, ShowcaseEntry>,
   pinnedById: Map<string, ShowcaseEntry>,
 ): ShowcaseEntry[] {
   return DISCORD_SHOWCASE_TEMPLATES.map((template) => {
@@ -511,7 +531,7 @@ function discordEntries(
             imageKey: candidate.key,
             dataKey: candidate.dataKey,
           }),
-      prevById,
+      fallbackById,
       {
         kind: "unsupported",
         id: template.id,
@@ -718,7 +738,7 @@ async function competitionGraphEntry(params: {
   client: S3Client;
   bucket: string;
   keys: string[];
-  prevById: Map<string, ShowcaseEntry>;
+  fallbackById: Map<string, ShowcaseEntry>;
   pinnedById: Map<string, ShowcaseEntry>;
 }): Promise<ShowcaseEntry> {
   // Checked before the snapshot scan below, which is the expensive part.
@@ -762,7 +782,7 @@ async function competitionGraphEntry(params: {
   }
 
   return (
-    params.prevById.get("competition-graph") ?? {
+    params.fallbackById.get("competition-graph") ?? {
       kind: "unsupported",
       id: "competition-graph",
       title: "Competition Graph",
@@ -774,7 +794,7 @@ async function competitionGraphEntry(params: {
 
 function reportGraphEntry(
   postmatchCandidates: ImageCandidate[],
-  prevById: Map<string, ShowcaseEntry>,
+  fallbackById: Map<string, ShowcaseEntry>,
   pinnedById: Map<string, ShowcaseEntry>,
 ): ShowcaseEntry {
   const pinned = pinnedById.get("report-graph");
@@ -788,7 +808,7 @@ function reportGraphEntry(
 
   if (matchKeys.length === 0) {
     return (
-      prevById.get("report-graph") ?? {
+      fallbackById.get("report-graph") ?? {
         kind: "unsupported",
         id: "report-graph",
         title: "Report Graph",
@@ -868,11 +888,12 @@ const prevById = await loadPrevEntries(values.prev);
 
 // Resolved before the scans so a dead pin fails in seconds rather than after a
 // full head budget of metadata reads.
-const pinnedById = await resolvePinnedEntries({
-  client,
-  prevById,
-  refreshIds: parseRefreshIds(values["refresh-pinned"], prevById),
-});
+const { pinned: pinnedById, fallback: fallbackById } =
+  await resolvePinnedEntries({
+    client,
+    prevById,
+    refreshIds: parseRefreshIds(values["refresh-pinned"], prevById),
+  });
 
 const [postmatch, prematch, leaderboardKeys] = await Promise.all([
   discoverImageCandidates({
@@ -902,7 +923,7 @@ const competitionEntry = await competitionGraphEntry({
   client,
   bucket,
   keys: leaderboardKeys,
-  prevById,
+  fallbackById,
   pinnedById,
 });
 
@@ -913,12 +934,12 @@ const manifest = ShowcaseManifestSchema.parse({
       specs: variantSpecs(),
       prematchCandidates: prematch.candidates,
       postmatchCandidates: postmatch.candidates,
-      prevById,
+      fallbackById,
       pinnedById,
     }),
-    ...discordEntries(postmatch.candidates, prevById, pinnedById),
+    ...discordEntries(postmatch.candidates, fallbackById, pinnedById),
     competitionEntry,
-    reportGraphEntry(postmatch.candidates, prevById, pinnedById),
+    reportGraphEntry(postmatch.candidates, fallbackById, pinnedById),
   ],
 });
 

--- a/packages/scout-for-lol/packages/backend/src/showcase/anonymize.ts
+++ b/packages/scout-for-lol/packages/backend/src/showcase/anonymize.ts
@@ -114,8 +114,11 @@ export function createPlayerAnonymizer(): PlayerAnonymizer {
     // Mix the real name into the hash so two players who somehow share a stable
     // key still separate. The cache above is keyed on the stable key alone, so
     // within a run a rename cannot move a handle; across runs it can, because
-    // the seed changes. That is a one-time image diff on the Monday PR, not
-    // per-run churn — a player who does not rename is stable forever.
+    // the seed changes. A rename is not the only thing that can move a handle,
+    // though — the probe below reads `taken`, so who was assigned earlier in
+    // the run matters too. Both are one-off image diffs on the Monday PR rather
+    // than per-run churn, because an unchanged manifest replays an unchanged
+    // call sequence.
     const seed = fnv1a(`${stableKey}|${realName}`);
     for (let probe = 0; probe < HANDLE_POOL.length; probe += 1) {
       const candidate = HANDLE_POOL[(seed + probe) % HANDLE_POOL.length];

--- a/packages/scout-for-lol/packages/backend/src/showcase/anonymize.ts
+++ b/packages/scout-for-lol/packages/backend/src/showcase/anonymize.ts
@@ -19,7 +19,8 @@ import { fnv1a } from "@scout-for-lol/report";
  * The hard requirement is determinism. The showcase regenerates weekly and
  * commits the PNGs; a pseudonym that moved between runs would produce an image
  * diff and a junk PR every Monday. Every output is therefore a pure function of
- * the caller's stable key.
+ * the caller's inputs — the stable key and the display name, in that call
+ * order. Same inputs, same handle, forever.
  */
 
 // Invented handles in the same register as the hand-authored Discord chrome in
@@ -97,8 +98,10 @@ export function createPlayerAnonymizer(): PlayerAnonymizer {
     }
 
     // Mix the real name into the hash so two players who somehow share a stable
-    // key still separate, while a rename alone (same key) cannot move the
-    // handle — the cache above already returned for that case.
+    // key still separate. The cache above is keyed on the stable key alone, so
+    // within a run a rename cannot move a handle; across runs it can, because
+    // the seed changes. That is a one-time image diff on the Monday PR, not
+    // per-run churn — a player who does not rename is stable forever.
     const seed = fnv1a(`${stableKey}|${realName}`);
     for (let probe = 0; probe < HANDLE_POOL.length; probe += 1) {
       const candidate = HANDLE_POOL[(seed + probe) % HANDLE_POOL.length];

--- a/packages/scout-for-lol/packages/backend/src/showcase/anonymize.ts
+++ b/packages/scout-for-lol/packages/backend/src/showcase/anonymize.ts
@@ -18,9 +18,19 @@ import { fnv1a } from "@scout-for-lol/report";
  *
  * The hard requirement is determinism. The showcase regenerates weekly and
  * commits the PNGs; a pseudonym that moved between runs would produce an image
- * diff and a junk PR every Monday. Every output is therefore a pure function of
- * the caller's inputs — the stable key and the display name, in that call
- * order. Same inputs, same handle, forever.
+ * diff and a junk PR every Monday.
+ *
+ * What that buys is narrower than "this player always draws this handle". A
+ * handle is a function of the whole call sequence, not of one call's arguments:
+ * the seed is `${stableKey}|${realName}`, and collisions are resolved by
+ * probing past the handles already taken (see `createPlayerAnonymizer`). So the
+ * guarantee is reproducibility — the same manifest, rendering the same rosters
+ * in the same order, yields the same handles, run after run, which is what
+ * keeps the committed PNGs stable. Anything that changes the inputs to that
+ * sequence — a re-curation pointing an entry at a different object, a player
+ * renaming, a change to how many players an entry renders — can move handles,
+ * including for players who themselves did not change. That is a one-off image
+ * diff to review on the Monday PR, not per-run churn.
  */
 
 // Invented handles in the same register as the hand-authored Discord chrome in
@@ -80,10 +90,14 @@ export type PlayerAnonymizer = (stableKey: string, realName: string) => string;
  *
  * `realName` is used only as a last-resort disambiguator; it is never emitted.
  *
- * Collisions are resolved by linear probing over the pool. That makes the result
- * order-dependent *within* a run, which is safe because the manifest fixes entry
- * order and entries are generated serially — two runs over the same manifest see
- * identical key order. It is bounded: once the pool is exhausted, fall back to a
+ * Collisions are resolved by linear probing over the pool, so an assignment
+ * depends on which handles earlier calls took, not just on this call's seed.
+ * Two runs over the same manifest still agree, because the manifest fixes entry
+ * order, entries are generated serially, and each entry pins exact S3 object
+ * keys — the roster behind an entry cannot move until a re-curation swaps that
+ * key. That is the precondition, not an inherent property: change the roster or
+ * the order and a player whose own seed did not change can still land on a
+ * different handle. It is bounded: once the pool is exhausted, fall back to a
  * numbered handle rather than emitting a duplicate, because a duplicate would
  * silently merge two people in a legend.
  */

--- a/packages/scout-for-lol/packages/backend/src/showcase/manifest.ts
+++ b/packages/scout-for-lol/packages/backend/src/showcase/manifest.ts
@@ -19,10 +19,11 @@ const BaseEntrySchema = z.strictObject({
   // behind the same SeaweedFS endpoint, so this swaps the bucket name only, not
   // the client. Needed because prod's competitions are thin (the best one has 3
   // players across its whole range) while beta has competitions with 28 — and a
-  // leaderboard chart is only interesting with real players on it. Safe for
-  // leaderboards specifically: scout-image-gc only prunes .png/.svg under
-  // games/ and prematch/, so `leaderboards/**` snapshots are never collected in
-  // either bucket and need no manifest exemption to survive.
+  // leaderboard chart is only interesting with real players on it.
+  // `leaderboards/**` is outside scout-image-gc's prune prefixes entirely, and
+  // a pinned `games/`/`prematch/` source is exempted in the bucket named here
+  // (the GC groups its manifest exemptions by this field), so a pin survives
+  // retention in either bucket.
   bucket: z.string().min(1).optional(),
 });
 

--- a/packages/temporal/src/activities/scout-image-gc.test.ts
+++ b/packages/temporal/src/activities/scout-image-gc.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { isPrunableImage } from "./scout-image-gc.ts";
+import {
+  isPrunableImage,
+  showcaseExemptKeysByBucket,
+} from "./scout-image-gc.ts";
 
 describe("isPrunableImage", () => {
   const cutoff = new Date("2026-06-03T00:00:00Z");
@@ -81,5 +84,70 @@ describe("isPrunableImage", () => {
         exemptKeys,
       }),
     ).toBe(true);
+  });
+});
+
+describe("showcaseExemptKeysByBucket", () => {
+  test("assigns keys without an explicit bucket to scout-prod", () => {
+    const byBucket = showcaseExemptKeysByBucket({
+      entries: [
+        {
+          imageKey: "games/2026/05/01/M1/report.png",
+          dataKey: "games/2026/05/01/M1/match.json",
+        },
+      ],
+    });
+
+    expect(byBucket.get("scout-prod")).toEqual(
+      new Set([
+        "games/2026/05/01/M1/report.png",
+        "games/2026/05/01/M1/match.json",
+      ]),
+    );
+    expect(byBucket.has("scout-beta")).toBe(false);
+  });
+
+  test("exempts a pinned entry's keys in the bucket it pins, not the default", () => {
+    const byBucket = showcaseExemptKeysByBucket({
+      entries: [
+        { bucket: "scout-beta", imageKey: "games/2026/05/01/B1/report.png" },
+        { imageKey: "games/2026/05/01/P1/report.png" },
+      ],
+    });
+
+    expect(byBucket.get("scout-beta")).toEqual(
+      new Set(["games/2026/05/01/B1/report.png"]),
+    );
+    expect(byBucket.get("scout-prod")).toEqual(
+      new Set(["games/2026/05/01/P1/report.png"]),
+    );
+  });
+
+  test("keeps a pinned key alive in its own bucket and prunable in the other", () => {
+    const cutoff = new Date("2026-06-03T00:00:00Z");
+    const old = new Date("2026-05-01T00:00:00Z");
+    const key = "prematch/2026/05/01/B1/loading-screen.png";
+    const byBucket = showcaseExemptKeysByBucket({
+      entries: [{ bucket: "scout-beta", imageKey: key }],
+    });
+
+    expect(
+      isPrunableImage(key, old, cutoff, {
+        exemptKeys: byBucket.get("scout-beta") ?? new Set<string>(),
+      }),
+    ).toBe(false);
+    expect(
+      isPrunableImage(key, old, cutoff, {
+        exemptKeys: byBucket.get("scout-prod") ?? new Set<string>(),
+      }),
+    ).toBe(true);
+  });
+
+  test("entries with no keys (competition graph) contribute no exemptions", () => {
+    const byBucket = showcaseExemptKeysByBucket({
+      entries: [{ bucket: "scout-beta" }],
+    });
+
+    expect(byBucket.get("scout-beta")).toEqual(new Set<string>());
   });
 });

--- a/packages/temporal/src/activities/scout-image-gc.ts
+++ b/packages/temporal/src/activities/scout-image-gc.ts
@@ -27,41 +27,64 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 // pruning them breaks the refresh permanently (rare queue types may never
 // produce a replacement; learned 2026-07-19 when a month of GC had eaten 60%
 // of the manifest's sources). Fetch the manifest from main and exempt every
-// referenced key. Scoped to scout-prod — the manifest is curated against prod.
+// referenced key in the bucket that entry actually reads.
 const SHOWCASE_MANIFEST_URL =
   "https://raw.githubusercontent.com/shepherdjerred/monorepo/main/packages/scout-for-lol/showcase/marketing-showcase.manifest.json";
-const SHOWCASE_EXEMPT_BUCKET = "scout-prod";
+
+// A manifest entry without an explicit `bucket` is read from the generator's
+// run bucket, which is prod for the committed showcase.
+const SHOWCASE_DEFAULT_BUCKET = "scout-prod";
 
 const ShowcaseManifestKeysSchema = z.object({
   entries: z.array(
     z.looseObject({
+      bucket: z.string().optional(),
       imageKey: z.string().optional(),
       dataKey: z.string().optional(),
     }),
   ),
 });
+type ShowcaseManifestKeys = z.infer<typeof ShowcaseManifestKeysSchema>;
 
 /**
- * Fetch the showcase manifest and return every S3 key it references. Fails
- * loudly (activity failure → Temporal retry) rather than pruning without the
- * exemption list — a GC run that can't see the manifest must not delete.
+ * Group every key the manifest references by the bucket the showcase generator
+ * reads it from. An entry may pin its own `bucket`, so a single flat key set
+ * applied to prod alone would leave a pinned `games/`/`prematch/` source in the
+ * other bucket unprotected — it would survive curation and then vanish after
+ * the retention window, breaking the weekly refresh.
+ */
+export function showcaseExemptKeysByBucket(
+  manifest: ShowcaseManifestKeys,
+): Map<string, Set<string>> {
+  const byBucket = new Map<string, Set<string>>();
+  for (const entry of manifest.entries) {
+    const bucket = entry.bucket ?? SHOWCASE_DEFAULT_BUCKET;
+    const keys = byBucket.get(bucket) ?? new Set<string>();
+    if (entry.imageKey !== undefined) keys.add(entry.imageKey);
+    if (entry.dataKey !== undefined) keys.add(entry.dataKey);
+    byBucket.set(bucket, keys);
+  }
+  return byBucket;
+}
+
+/**
+ * Fetch the showcase manifest and return every S3 key it references, keyed by
+ * source bucket. Fails loudly (activity failure → Temporal retry) rather than
+ * pruning without the exemption list — a GC run that can't see the manifest
+ * must not delete.
  */
 export async function fetchShowcaseExemptKeys(
   url: string = SHOWCASE_MANIFEST_URL,
-): Promise<Set<string>> {
+): Promise<Map<string, Set<string>>> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(
       `[scout-image-gc] failed to fetch showcase manifest (${String(response.status)}) — refusing to prune without the exemption list`,
     );
   }
-  const manifest = ShowcaseManifestKeysSchema.parse(await response.json());
-  const keys = new Set<string>();
-  for (const entry of manifest.entries) {
-    if (entry.imageKey !== undefined) keys.add(entry.imageKey);
-    if (entry.dataKey !== undefined) keys.add(entry.dataKey);
-  }
-  return keys;
+  return showcaseExemptKeysByBucket(
+    ShowcaseManifestKeysSchema.parse(await response.json()),
+  );
 }
 
 const InputSchema = z.object({
@@ -267,10 +290,7 @@ export const scoutImageGcActivities = {
 
     const buckets: BucketPruneResult[] = [];
     for (const bucket of BUCKETS) {
-      const exemptKeys =
-        bucket === SHOWCASE_EXEMPT_BUCKET
-          ? showcaseExemptKeys
-          : new Set<string>();
+      const exemptKeys = showcaseExemptKeys.get(bucket) ?? new Set<string>();
       const result = await pruneBucket({
         client,
         bucket,


### PR DESCRIPTION
## Why

Four PRs changed showcase behaviour (#2140 anonymization + per-entry bucket, #2142 discovery coverage) and the package guide still described the pipeline as it was before them. It said assets are generated "against real objects in the `scout-prod` bucket" — the competition graph now sources beta — and said nothing about pseudonymous chart labels, the pinned-bucket convention, or why discovery stopped scanning after a few dozen objects for months.

The repo rule is that docs move with the code. I skipped it in those PRs; this catches up.

Writing it down surfaced three places where the convention I was documenting did not actually exist in the code, so the branch now fixes those too rather than narrowing the docs around them.

## What

**Docs (`packages/scout-for-lol/AGENTS.md`)**

- **The per-entry `bucket` override** — why the competition graph uses it, and that `discover` treats a pinned entry as untouchable. Without that, a re-curation rebuilds the entry from the run's `--bucket` and silently reverts the pin.
- **Chart labels are pseudonymous** and must stay deterministic, because the weekly job commits the PNGs. Records the **slice-then-anonymize ordering**, which is easy to get backwards — the report graph aggregates ~120 participants but renders ten, so anonymizing first exhausts the handle pool into a numbered fallback. (I made exactly that mistake in #2140 and only caught it by looking at the image.) The seed is `${stableKey}|${realName}`, so the guarantee is stated precisely: stable within a run regardless of renames, and stable across runs for anyone who doesn't rename.
- **The known gap**, stated plainly: `s3-image` and `discord-screenshot` entries are byte copies of prod-rendered PNGs, so those names are still real pixels.
- **Why `wantedCombos` is derived from the spec set** rather than hard-coded — it is the scan's loop terminator, and the reason the manifest rotted for months while appearing maintained.
- **GC never touches `leaderboards/**`**, and its manifest exemptions are per-source-bucket.
- **The re-curation runbook** documents the real endpoint configuration. Neither script accepts `--endpoint-url`; both validate flag names against a closed `z.enum`, so passing it fails CLI parsing. `createS3Client()` sets no endpoint/region/credentials, so all three come from the `seaweedfs` AWS profile.
- **ARAM Mayhem** is no longer described as having no post-match object. Unlike League Classic — whose absence was surveyed against prod — that was never established, which is exactly why the spec deliberately does not declare `states: ["prematch"]` for it.
- **The four places a variant id must change together**, including that `requireShowcaseAsset` *throws* and breaks the marketing build, and that the Discord templates are an independent `(queue, playerCount)` lookup that pins itself to a stale object if left at a count the bucket no longer produces.

**Code — make the documented pin convention real**

- `discover-marketing-showcase.ts` checked the previous entry's `bucket` only for `competition-graph`; an `s3-image` or `discord-screenshot` pin was silently reverted to the run's `--bucket` on the next re-curation. A shared `pinnedEntry()` now runs in every entry generator, ahead of the hard-coded flex-4/5 short-circuits. The pin returns the whole entry, because carrying only the `bucket` field onto a freshly discovered key would point the pinned bucket at a key that exists only in the run bucket.
- `scout-image-gc.ts` prunes both `scout-prod` and `scout-beta` but applied the manifest exemption list to prod only — so a pinned beta `games/`/`prematch/` source would survive curation and then vanish after 30 days, breaking the weekly generator with NoSuchKey. Exemptions are now grouped by the bucket each entry actually reads, via a pure, unit-tested `showcaseExemptKeysByBucket()`.
- Same two overstatements corrected in the `anonymize.ts` and `manifest.ts` source comments.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal` — 756 pass, 0 fail
- `bunx turbo run typecheck test lint --filter=@scout-for-lol/backend` — 1244 pass, 0 fail
- `bunx markdownlint-cli2 packages/scout-for-lol/AGENTS.md` — 0 issues
- `bunx prettier --check` on every touched file — clean
- Every claim re-read against the merged code rather than written from memory
- **Not run:** a live re-curation against SeaweedFS and a real `scout-image-gc` pass. `discover-marketing-showcase.ts` parses CLI args at module scope, so its helpers aren't importable and the pin path has no unit test; the GC change is covered by new tests.

No user-visible surface, so no screenshots.
