### PR TITLE
fix(ci): raise the review-gate budget toward real Qodo latency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1022,9 +1022,12 @@ steps:
   # Qodo is the only active provider in the registry; its persistent issue
   # comment is bound to the head timestamp and its Action required/Remediation
   # recommended findings are included in the same gate.
+  # This budget stays above wait-for-review.ts's own deadline plus its install,
+  # so the script always reports which provider and head it gave up on rather
+  # than Buildkite killing the pod first.
   - label: ":robot_face: Qodo review gate (required)"
     key: review-gate
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
     cancel_on_build_failing: true
     command: |
@@ -1422,7 +1425,7 @@ steps:
   # a finally, so a failed dev publish can't leak -dev.N into a later prod run).
   - label: ":npm: publish packages + cooklang plugin"
     key: publish
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: verify
     cancel_on_build_failing: true
@@ -1466,7 +1469,7 @@ steps:
   # ── Main-only: homelab release track ─────────────────────────────────────
   - label: ":helm: helm push"
     key: helm-push
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     # Wait for this build's remote solves before suspending the currently
     # floating repository Applications and publishing their immutable charts.
@@ -1502,7 +1505,7 @@ steps:
 
   - label: ":terraform: OpenTofu apply — infra state stacks"
     key: tofu-apply
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: [verify, helm-push]
     cancel_on_build_failing: true
@@ -1527,7 +1530,7 @@ steps:
 
   - label: ":terraform: OpenTofu apply — GitHub state"
     key: tofu-github
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: verify
     cancel_on_build_failing: true
@@ -1553,7 +1556,7 @@ steps:
 
   - label: ":argo: sync + wait"
     key: argocd-sync
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: [images, helm-push, tofu-apply]
     concurrency: 1
@@ -1710,7 +1713,7 @@ steps:
 
   - label: ":terraform: OpenTofu apply — Cloudflare after tunnel gate"
     key: tofu-cloudflare
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: argocd-sync
     cancel_on_build_failing: true
@@ -1750,7 +1753,7 @@ steps:
   # pushed image digests — is its own step below, gated on images.
   - label: ":package: release-please"
     key: release-please
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: verify
     cancel_on_build_failing: true
@@ -1776,7 +1779,7 @@ steps:
   # merge redeploys nothing.
   - label: ":package: version commit-back"
     key: version-commit-back
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: images
     cancel_on_build_failing: true

--- a/scripts/wait-for-review.test.ts
+++ b/scripts/wait-for-review.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { resolveReviewGateProvider } from "./wait-for-review.ts";
+import {
+  DEFAULT_TIMEOUT_SECONDS,
+  resolveReviewGateProvider,
+} from "./wait-for-review.ts";
 
 describe("resolveReviewGateProvider", () => {
   test("pins the required CI gate to Qodo", () => {
@@ -15,5 +18,96 @@ describe("resolveReviewGateProvider", () => {
     expect(() => resolveReviewGateProvider("greptile")).toThrow(
       "CI review gate requires Qodo",
     );
+  });
+});
+
+/**
+ * The step's own timeout, read from its block alone.
+ *
+ * Slicing to end-of-file and taking the first match would find a *later*
+ * step's timeout whenever review-gate loses its own, which is exactly the
+ * regression this budget test exists to catch — the assertion would keep
+ * passing against an unrelated number.
+ */
+export function reviewGateStepTimeoutSeconds(pipeline: string): number {
+  const lines = pipeline.split("\n");
+  const starts = lines.flatMap((line, index) =>
+    line.startsWith("  - label:") ? [index] : [],
+  );
+  for (const [position, start] of starts.entries()) {
+    const block = lines.slice(start, starts[position + 1] ?? lines.length);
+    if (!block.some((line) => line.trim() === "key: review-gate")) {
+      continue;
+    }
+    const declared = block.flatMap((line) => {
+      const match = /^\s+timeout_in_minutes:\s*(\d+)\s*$/.exec(line);
+      return match?.[1] === undefined ? [] : [Number.parseInt(match[1], 10)];
+    });
+    if (declared.length !== 1) {
+      throw new Error(
+        `review-gate declares ${declared.length.toString()} timeout_in_minutes, expected exactly 1`,
+      );
+    }
+    return (declared[0] ?? 0) * 60;
+  }
+  throw new Error("pipeline.yml has no review-gate step");
+}
+
+/**
+ * How long the step spends on `toolchain.sh` and the filtered install before
+ * wait-for-review.ts starts counting. Nothing bounds that preamble — a cold or
+ * stale image pays for mise bootstrap and network downloads — so the margin is
+ * deliberately generous. Getting it wrong reinstates the anonymous Buildkite
+ * kill this whole change exists to prevent.
+ */
+const PREAMBLE_MARGIN_SECONDS = 20 * 60;
+
+// Two timeouts govern this gate and only one of them explains itself. If
+// Buildkite's is the smaller, the job dies with an anonymous step timeout and
+// the operator cannot tell a slow provider from a broken one, so the ordering
+// is part of the gate's contract rather than a coincidence of two constants.
+describe("review gate timeout budget", () => {
+  test("expires before the Buildkite step that runs it", async () => {
+    // Resolved from this file: the suite runs with scripts/ as the cwd.
+    const pipeline = await Bun.file(
+      `${import.meta.dir}/../.buildkite/pipeline.yml`,
+    ).text();
+    expect(reviewGateStepTimeoutSeconds(pipeline)).toBeGreaterThanOrEqual(
+      DEFAULT_TIMEOUT_SECONDS + PREAMBLE_MARGIN_SECONDS,
+    );
+  });
+
+  test("reads review-gate's own timeout, not a later step's", () => {
+    const withoutItsOwn = [
+      '  - label: ":robot_face: Qodo review gate (required)"',
+      "    key: review-gate",
+      "    command: |",
+      "      bun --no-install scripts/wait-for-review.ts",
+      '  - label: ":microscope: pr dry-run"',
+      "    key: pr-dryrun",
+      "    timeout_in_minutes: 30",
+      "",
+    ].join("\n");
+    expect(() => reviewGateStepTimeoutSeconds(withoutItsOwn)).toThrow(
+      "review-gate declares 0 timeout_in_minutes",
+    );
+
+    const withItsOwn = withoutItsOwn.replace(
+      "    key: review-gate\n",
+      "    key: review-gate\n    timeout_in_minutes: 60\n",
+    );
+    expect(reviewGateStepTimeoutSeconds(withItsOwn)).toBe(60 * 60);
+  });
+
+  // A floor, not a sufficiency proof. A 2400s budget expired on a ~51-line PR
+  // whose review was still running, so no constant here can promise every
+  // review finishes inside the build. What this does guarantee is that the
+  // budget never regresses below a latency we have actually watched a review
+  // survive, which is the mistake the 1200s default made.
+  test("does not regress below the slowest completed review", () => {
+    // Both measured on PR #2152, on reviews that completed normally only after
+    // the 1200s budget had already failed the gate.
+    const slowestCompleted = 1834;
+    expect(DEFAULT_TIMEOUT_SECONDS).toBeGreaterThan(slowestCompleted);
   });
 });

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -41,7 +41,33 @@ import {
 } from "@shepherdjerred/code-review/github";
 
 const DEFAULT_REPO = "shepherdjerred/monorepo";
-const DEFAULT_TIMEOUT_SECONDS = 20 * 60;
+/**
+ * Qodo routinely needs longer than this gate used to allow. Two completed
+ * reviews were measured at 1637s and 1834s while the budget was 1200s, so the
+ * gate reported `timed_out` on reviews that were progressing normally and the
+ * PR went red for a reason unrelated to its diff.
+ *
+ * This value is an empirical ceiling over those samples plus margin. It is
+ * explicitly **not** a proof of sufficiency: a ~51-line PR was still reviewing
+ * when a 2400s budget expired, so latency does not scale with diff size and
+ * behaves more like provider-side queue depth, which no constant bounds. Treat
+ * this as raising the share of reviews that finish inside the build, not as a
+ * guarantee that they all will. Overshooting costs idle polling in a light pod;
+ * undershooting costs a false red on a healthy PR, so the asymmetry favours
+ * headroom.
+ *
+ * The durable fix is ordering rather than duration — not starting the gate
+ * until the review exists — but that is a CI-architecture change, not a
+ * constant.
+ *
+ * The `review-gate` step allows longer still — by a margin sized for its
+ * unbounded `toolchain.sh` and install preamble, not a token few minutes — so
+ * this deadline is always the binding one and the timeout message names the
+ * provider and head commit instead of Buildkite killing the pod anonymously.
+ * `wait-for-review.test.ts` asserts that ordering against the pipeline,
+ * reading the step's own declared timeout rather than the first one it finds.
+ */
+export const DEFAULT_TIMEOUT_SECONDS = 40 * 60;
 const DEFAULT_INTERVAL_SECONDS = 30;
 
 export function resolveReviewGateProvider(
@@ -155,7 +181,7 @@ function errorCode(error: unknown): string | null {
  * than failing the gate. Retry ONLY recognized transient failures — a 5xx
  * response, or a transport-level failure (socket closed/refused, DNS error,
  * timeout — by message OR error code). Everything else fails fast so the step
- * doesn't hold a Buildkite agent until the 20-minute deadline: a 4xx (bad token
+ * doesn't hold a Buildkite agent until the gate deadline: a 4xx (bad token
  * / missing permission), a GraphQL application-error payload (HTTP 200 +
  * `errors`), and — critically — an unexpected-shape / invariant error thrown by
  * our own parsers (e.g. `parseThreadPage` when `reviewThreads` is missing) all


### PR DESCRIPTION
## Why

The `review-gate` step allowed **1200s** for a provider review. Two reviews of
#2152 that completed normally were measured at **1637s** and **1834s** — the
gate had already given up at 1201s with `timed_out: true, decision: null`.
**Six** such timeouts hit #2148, #2152, and #2154 in a single evening, so PRs
went red for a reason unrelated to their diffs. The gate's own log makes the
shape obvious: every poll reports `review_state: "reviewing"` with
`blocking_count: 0`, right up to the deadline.

`REVIEW_WAIT_TIMEOUT_SECONDS` already exists as an override, but it only
reaches a build an operator constructs by hand. The pipeline's
`branch_configuration` is `main`, so `bk build create --branch <feature>` is
filtered out with `422 Branch does not match the pipeline's branch filtering
rules`; it works only via a direct REST call supplying `pull_request_id` and
the rest of the PR linkage. **Ordinary PR builds come from the GitHub webhook
and carry no custom env**, so every contributor and every push gets the default.

## What this does *not* claim

An earlier revision of this PR justified the value by diff size and argued
2400s cleared observed latency with margin. **That was false, and this branch
disproved it.** Build 9349 ran this gate against *this PR* — ~51 lines across 3
files — with `timeout=2400s` in effect:

```
Review gate: ... pr=#2162, head=b6293e5e3, timeout=2400s
... "gate_wait_s":2403,"timed_out":true
Timed out after 2400s
```

A diff two orders of magnitude smaller than #2152's took **longer**. Latency
does not scale with diff size; it behaves like provider-side queue depth, which
no constant bounds.

So this is a **mitigation, not a fix** — it raises the share of reviews that
finish inside the build. The durable fix is ordering rather than duration: not
starting the gate until the review exists, so a slow provider reads as "hasn't
run yet" instead of "failed". That is a CI-architecture change (most likely a
webhook-triggered build/job retry when Qodo posts) and is deliberately **out of
scope here**.

## What

- Raise `DEFAULT_TIMEOUT_SECONDS` to **2400s** — an empirical ceiling over the
  two completed samples plus margin, explicitly not a sufficiency proof.
  Overshooting costs idle polling in a light pod; undershooting costs a false
  red on a healthy PR, so the asymmetry favours headroom.
- Raise the `review-gate` step to **45 minutes**. At an equal budget the *step*
  would expire first, because the script only starts counting after the
  toolchain and filtered install — Buildkite would kill the pod and the operator
  would lose the message naming the provider and head commit. The script must
  stay the binding deadline; only one of these two timeouts explains itself.
- Pin that ordering in `wait-for-review.test.ts`, which reads the step's
  declared `timeout_in_minutes` out of `pipeline.yml` so the two constants
  cannot drift apart silently. Its companion test is a **regression floor** —
  the budget must never drop back below a latency a review has been watched to
  survive — and says in the test itself that it is not a sufficiency proof.

## Verification

- `cd scripts && bun test wait-for-review.test.ts` — 4 pass, 0 fail
- The ordering test was confirmed to fail when the step timeout is not far
  enough above the script's deadline. That check is what caught the step bump as
  necessary rather than cosmetic.
- `cd scripts && bun test . ../.buildkite/scripts` — 545 pass, 0 fail
- `bun --no-install .buildkite/scripts/validate-pipeline.ts` — 29 command steps
  valid; `cd scripts && bun lint-buildkite.ts` clean
- `bunx turbo run typecheck lint --filter=@shepherdjerred/root-scripts` — 3/3,
  0 errors. The 5 `strict-boolean-expressions` warnings are present on
  unmodified `main` too, verified by stashing this change and re-running.
- `bunx prettier --check` on all three files

**Not run:** no webhook-created PR build exercises the new *default* yet. A
hand-built REST build can carry the override — that proves the override works,
not the default. No screenshot applies; this is CI timing configuration with no
visible output.