### PR TITLE
feat(temporal): bake the Grafana CLI into the worker image

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -372,6 +372,7 @@ const commands: Record<
       "ip6tables --version",
       "setpriv --version",
       "toolkit --version",
+      "gcx --version",
       "set +e",
       'output="$(timeout 60s bun src/worker.ts 2>&1)"',
       "status=$?",

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -69,6 +69,18 @@ function homelabAuditEnv(secret: ISecret): Record<string, EnvValue> {
     PROMETHEUS_URL: EnvValue.fromValue(
       "http://prometheus-kube-prometheus-prometheus.prometheus:9090",
     ),
+    // gcx authenticates from a config file rather than env vars, written by
+    // ensureGcxContext() (src/activities/gcx-context.ts) at audit time from the
+    // GRAFANA_URL/GRAFANA_API_KEY below. Its default location is
+    // $HOME/.config/gcx/config.yaml, which resolves to /home/bun from the
+    // oven/bun base image and is writable by uid 1000. Pinning the path anyway
+    // keeps the credential's location independent of the base image, so a bun
+    // bump that changes HOME cannot silently relocate it.
+    GCX_CONFIG: EnvValue.fromValue("/tmp/gcx/config.yaml"),
+    // Suppress gcx's outbound GitHub release check and anonymous telemetry; a
+    // homelab worker should make no unsolicited egress.
+    GCX_NO_UPDATE_NOTIFIER: EnvValue.fromValue("1"),
+    GCX_TELEMETRY: EnvValue.fromValue("disabled"),
     ...requiredSecretEnv(secret, [
       "BUGSINK_TOKEN",
       "GRAFANA_URL",

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -121,7 +121,7 @@ function envNames(deployment: SynthesizedDeployment): Set<string> {
   );
 }
 
-describe("temporal homelab audit tooling", () => {
+describe("temporal homelab audit tooling configuration", () => {
   it("injects Buildkite and Bugsink configuration", async () => {
     const yaml = await synthesizeApp();
 
@@ -151,7 +151,9 @@ describe("temporal homelab audit tooling", () => {
     expect(yaml).toContain("value: glitter-discord-corpus");
     expect(yaml).not.toContain("name: GLITTER_CORPUS_R2_");
   });
+});
 
+describe("temporal homelab audit tooling worker topology", () => {
   it("isolates core, agent, and Glitter queues behind event-loop health probes", async () => {
     const deployments = parseDeployments(await synthesizeApp());
     const core = requireDeployment(deployments, "temporal-temporal-worker");
@@ -225,7 +227,9 @@ describe("temporal homelab audit tooling", () => {
     expect(configYaml).toContain("  - value: true");
     expect(configYaml).not.toContain("frontend.workerHeartbeatsEnabled:");
   });
+});
 
+describe("temporal homelab audit tooling access boundaries", () => {
   it("keeps the audit ClusterRole read-only and includes Tailscale CRDs", async () => {
     const resources = parseResources(await synthesizeApp());
     const auditRole = resources.find(

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -329,4 +329,33 @@ describe("temporal homelab audit tooling", () => {
       expect(names).not.toContain(prohibited);
     }
   });
+
+  it("gives the core worker the Grafana credentials and gcx configuration the audit needs", async () => {
+    const deployments = parseDeployments(await synthesizeApp());
+    const core = requireDeployment(deployments, "temporal-temporal-worker");
+    const names = envNames(core);
+
+    // ensureGcxContext() (packages/temporal/src/activities/gcx-context.ts) reads
+    // these two to provision the gcx `homelab` context; GCX_CONFIG pins where
+    // that config lands, independent of the base image's HOME.
+    for (const required of [
+      "GRAFANA_URL",
+      "GRAFANA_API_KEY",
+      "GCX_CONFIG",
+      "GCX_NO_UPDATE_NOTIFIER",
+      "GCX_TELEMETRY",
+    ]) {
+      expect(names).toContain(required);
+    }
+
+    // The agent worker is deliberately denied the same credentials.
+    const agent = requireDeployment(
+      deployments,
+      "temporal-temporal-agent-worker",
+    );
+    const agentNames = envNames(agent);
+    for (const prohibited of ["GRAFANA_API_KEY", "GCX_CONFIG"]) {
+      expect(agentNames).not.toContain(prohibited);
+    }
+  });
 });

--- a/packages/temporal/Dockerfile
+++ b/packages/temporal/Dockerfile
@@ -8,7 +8,7 @@
 # codex (agent-task Codex provider),
 # kubectl (bugsink-housekeeping / zfs-maintenance `kubectl exec`),
 # github-mcp-server (pr-agent's MCP GitHub backend), talosctl / tofu / argocd /
-# velero / bk / temporal / toolkit (homelab-audit-daily runbook + preflight —
+# velero / bk / temporal / gcx / toolkit (homelab-audit-daily runbook + preflight —
 # see src/activities/homelab-audit-preflight.ts REQUIRED_AUDIT_BINARIES),
 # and the direct maintenance runtimes Kometa, uv, and Trivy.
 # scripts/smoke.ts asserts every one of these boots + is on PATH.
@@ -113,6 +113,8 @@ ARG VELERO_CLI_VERSION=v1.18.2
 ARG BUILDKITE_CLI_VERSION=3.48.0
 # renovate: datasource=github-releases depName=temporalio/cli
 ARG TEMPORAL_CLI_VERSION=1.7.3
+# renovate: datasource=github-releases depName=grafana/gcx
+ARG GCX_VERSION=1.0.0
 # renovate: datasource=pypi depName=uv
 ARG UV_VERSION=0.12.3
 # renovate: datasource=github-releases depName=aquasecurity/trivy
@@ -262,6 +264,27 @@ RUN set -e; \
     chmod +x /usr/local/bin/temporal; \
     rm /tmp/temporal.tar.gz /tmp/temporal.checksums.txt; \
     temporal --version
+
+# --- Grafana CLI (per-arch tarball, SHA256-verified) ---
+# Replaces the retired `toolkit gf` Grafana client for the homelab audit's
+# PromQL/LogQL evidence. The release layout matches temporalio/cli above: a bare
+# `gcx` binary at the tarball root plus a `<name>_<version>_checksums.txt`.
+RUN set -e; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64) gcxarch=amd64 ;; arm64) gcxarch=arm64 ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; esac; \
+    base="https://github.com/grafana/gcx/releases/download/v${GCX_VERSION}"; \
+    tarball="gcx_${GCX_VERSION}_linux_${gcxarch}.tar.gz"; \
+    curl -fsSL "$base/$tarball" -o /tmp/gcx.tar.gz; \
+    curl -fsSL "$base/gcx_${GCX_VERSION}_checksums.txt" -o /tmp/gcx.checksums.txt; \
+    expected="$(grep " $tarball$" /tmp/gcx.checksums.txt | awk '{print $1}')"; \
+    [ -n "$expected" ] || { echo "no checksum entry for $tarball" >&2; exit 1; }; \
+    actual="$(sha256sum /tmp/gcx.tar.gz | awk '{print $1}')"; \
+    [ "$expected" = "$actual" ] || { echo "gcx checksum mismatch (expected $expected, got $actual)" >&2; exit 1; }; \
+    tar -xzf /tmp/gcx.tar.gz -C /usr/local/bin gcx; \
+    chmod +x /usr/local/bin/gcx; \
+    rm /tmp/gcx.tar.gz /tmp/gcx.checksums.txt; \
+    gcx --version
 
 # --- Python + pip (required by the uv install below) ---
 RUN set -e; \

--- a/packages/temporal/scripts/smoke.ts
+++ b/packages/temporal/scripts/smoke.ts
@@ -37,6 +37,7 @@ const CLI_CHECKS: readonly { name: string; args: readonly string[] }[] = [
   { name: "velero", args: ["velero", "version", "--client-only"] },
   { name: "bk", args: ["bk", "--version"] },
   { name: "temporal", args: ["temporal", "--version"] },
+  { name: "gcx", args: ["gcx", "--version"] },
   { name: "iptables", args: ["iptables", "--version"] },
   { name: "ip6tables", args: ["ip6tables", "--version"] },
   { name: "setpriv", args: ["setpriv", "--version"] },

--- a/packages/temporal/src/activities/gcx-context.test.ts
+++ b/packages/temporal/src/activities/gcx-context.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  ensureGcxContext,
+  GcxContextError,
+  resetGcxContextForTesting,
+  type GcxSpawn,
+} from "#activities/gcx-context.ts";
+
+const TOKEN = "glsa_supersecretvalue_0123456789";
+
+type SpawnCall = { args: string[] };
+
+function noop(): void {
+  // The stub never spawns a process, so there is nothing to kill.
+}
+
+/** A missing credential must reject before gcx is ever invoked. */
+async function expectNoLoginAttempt(): Promise<void> {
+  const calls: SpawnCall[] = [];
+  await expect(
+    ensureGcxContext(stubSpawn({ exitCode: 0, calls })),
+  ).rejects.toThrow(GcxContextError);
+  expect(calls).toHaveLength(0);
+}
+
+function stubSpawn(options: {
+  exitCode: number;
+  stderr?: string;
+  calls?: SpawnCall[];
+}): GcxSpawn {
+  return (args) => {
+    options.calls?.push({ args });
+    return {
+      stderr: new Response(options.stderr ?? "").body ?? new ReadableStream(),
+      exited: Promise.resolve(options.exitCode),
+      kill: noop,
+    };
+  };
+}
+
+describe("ensureGcxContext", () => {
+  const originalUrl = Bun.env["GRAFANA_URL"];
+  const originalKey = Bun.env["GRAFANA_API_KEY"];
+
+  beforeEach(() => {
+    resetGcxContextForTesting();
+    Bun.env["GRAFANA_URL"] = "https://grafana.example.ts.net";
+    Bun.env["GRAFANA_API_KEY"] = TOKEN;
+  });
+
+  afterEach(() => {
+    resetGcxContextForTesting();
+    if (originalUrl === undefined) delete Bun.env["GRAFANA_URL"];
+    else Bun.env["GRAFANA_URL"] = originalUrl;
+    if (originalKey === undefined) delete Bun.env["GRAFANA_API_KEY"];
+    else Bun.env["GRAFANA_API_KEY"] = originalKey;
+  });
+
+  test("logs in with the canonical env vars and the homelab context", async () => {
+    const calls: SpawnCall[] = [];
+    await ensureGcxContext(stubSpawn({ exitCode: 0, calls }));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toEqual([
+      "gcx",
+      "login",
+      "homelab",
+      "--server",
+      "https://grafana.example.ts.net",
+      "--token",
+      TOKEN,
+      "--yes",
+    ]);
+  });
+
+  test("memoizes so both the collector and the preflight share one login", async () => {
+    const calls: SpawnCall[] = [];
+    const spawn = stubSpawn({ exitCode: 0, calls });
+
+    await ensureGcxContext(spawn);
+    await ensureGcxContext(spawn);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("fails fast when GRAFANA_URL is missing", async () => {
+    delete Bun.env["GRAFANA_URL"];
+    await expectNoLoginAttempt();
+  });
+
+  test("fails fast when GRAFANA_API_KEY is missing", async () => {
+    delete Bun.env["GRAFANA_API_KEY"];
+    await expectNoLoginAttempt();
+  });
+
+  test("fails fast when the env var is present but blank", async () => {
+    Bun.env["GRAFANA_API_KEY"] = "   ";
+
+    await expect(ensureGcxContext(stubSpawn({ exitCode: 0 }))).rejects.toThrow(
+      GcxContextError,
+    );
+  });
+
+  test("redacts the credential out of a failing login's stderr", async () => {
+    const spawn = stubSpawn({
+      exitCode: 3,
+      stderr: `unauthorized while using --token ${TOKEN}`,
+    });
+
+    let captured: unknown;
+    try {
+      await ensureGcxContext(spawn);
+    } catch (error) {
+      captured = error;
+    }
+
+    expect(captured).toBeInstanceOf(GcxContextError);
+    expect(String(captured)).not.toContain(TOKEN);
+    expect(String(captured)).toContain("***");
+    expect(String(captured)).toContain("exited 3");
+  });
+
+  test("does not cache a failure, so a transient outage can recover", async () => {
+    const failingCalls: SpawnCall[] = [];
+    await expect(
+      ensureGcxContext(
+        stubSpawn({ exitCode: 1, stderr: "boom", calls: failingCalls }),
+      ),
+    ).rejects.toThrow(GcxContextError);
+
+    const retryCalls: SpawnCall[] = [];
+    await ensureGcxContext(stubSpawn({ exitCode: 0, calls: retryCalls }));
+
+    expect(failingCalls).toHaveLength(1);
+    expect(retryCalls).toHaveLength(1);
+  });
+});

--- a/packages/temporal/src/activities/gcx-context.test.ts
+++ b/packages/temporal/src/activities/gcx-context.test.ts
@@ -102,6 +102,45 @@ describe("ensureGcxContext", () => {
     );
   });
 
+  test("trims the env values it passes to gcx", async () => {
+    Bun.env["GRAFANA_URL"] = "  https://grafana.example.ts.net\n";
+    Bun.env["GRAFANA_API_KEY"] = `\n${TOKEN}  `;
+
+    const calls: SpawnCall[] = [];
+    await ensureGcxContext(stubSpawn({ exitCode: 0, calls }));
+
+    expect(calls[0]?.args).toEqual([
+      "gcx",
+      "login",
+      "homelab",
+      "--server",
+      "https://grafana.example.ts.net",
+      "--token",
+      TOKEN,
+      "--yes",
+    ]);
+  });
+
+  test("rejects at the deadline when the subprocess never settles", async () => {
+    let killed = false;
+    const neverSettles: GcxSpawn = () => ({
+      // A child that ignores the signal settles neither of these, so killing
+      // it cannot on its own end the wait.
+      stderr: new ReadableStream(),
+      exited: new Promise<number>(() => {
+        // Deliberately never settled.
+      }),
+      kill: () => {
+        killed = true;
+      },
+    });
+
+    await expect(ensureGcxContext(neverSettles, 25)).rejects.toThrow(
+      /did not complete within 25ms/,
+    );
+    expect(killed).toBe(true);
+  });
+
   test("redacts the credential out of a failing login's stderr", async () => {
     const spawn = stubSpawn({
       exitCode: 3,

--- a/packages/temporal/src/activities/gcx-context.ts
+++ b/packages/temporal/src/activities/gcx-context.ts
@@ -1,0 +1,104 @@
+import { redactSecrets } from "#shared/redact.ts";
+
+// gcx authenticates from a config file, not from environment variables. Its own
+// two native variables for server and credential are banned repo-wide by
+// scripts/environment-variable-rules.ts, which canonicalized them to
+// GRAFANA_URL and GRAFANA_API_KEY, so the worker provisions a context once per
+// pod lifetime instead.
+//
+// The worker sets GCX_CONFIG to pin where that config lands, keeping the
+// credential's location independent of the base image's HOME.
+const GCX_CONTEXT_NAME = "homelab";
+const GCX_LOGIN_TIMEOUT_MS = 15_000;
+
+export class GcxContextError extends Error {
+  override readonly name = "GcxContextError";
+}
+
+function requireEnv(name: string): string {
+  const value = Bun.env[name];
+  if (value === undefined || value.trim() === "") {
+    throw new GcxContextError(
+      `${name} is required to provision the gcx "${GCX_CONTEXT_NAME}" context`,
+    );
+  }
+  return value;
+}
+
+export type GcxSpawn = (args: string[]) => {
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+  kill: () => void;
+};
+
+const defaultSpawn: GcxSpawn = (args) =>
+  Bun.spawn(args, { stdin: "ignore", stdout: "ignore", stderr: "pipe" });
+
+async function loginToGcx(spawn: GcxSpawn): Promise<void> {
+  const server = requireEnv("GRAFANA_URL");
+  const apiKey = requireEnv("GRAFANA_API_KEY");
+
+  // `gcx login` is idempotent: re-running against an existing context replaces
+  // the stored credential in place.
+  const child = spawn([
+    "gcx",
+    "login",
+    GCX_CONTEXT_NAME,
+    "--server",
+    server,
+    "--token",
+    apiKey,
+    "--yes",
+  ]);
+
+  const timeout = setTimeout(() => {
+    child.kill();
+  }, GCX_LOGIN_TIMEOUT_MS);
+
+  try {
+    const [stderr, exitCode] = await Promise.all([
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    if (exitCode !== 0) {
+      // gcx echoes the --token argument back in some error paths, so the
+      // credential is redacted before it can reach a Temporal failure message.
+      const detail = redactSecrets(stderr.trim().slice(0, 1000), [apiKey]);
+      throw new GcxContextError(
+        `gcx login exited ${exitCode.toString()}: ${detail}`,
+      );
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+let pending: Promise<void> | undefined;
+
+/**
+ * Provision the gcx `homelab` context from GRAFANA_URL/GRAFANA_API_KEY.
+ *
+ * Memoized for the pod's lifetime: the audit collector and the preflight both
+ * call it, and neither should depend on the other having run first. A failure
+ * is not cached, so a transient Grafana outage does not poison the process.
+ */
+export async function ensureGcxContext(
+  spawn: GcxSpawn = defaultSpawn,
+): Promise<void> {
+  pending ??= (async () => {
+    try {
+      await loginToGcx(spawn);
+    } catch (error) {
+      pending = undefined;
+      throw error;
+    }
+  })();
+  return pending;
+}
+
+/** Test seam: forget the memoized login so each case starts clean. */
+export function resetGcxContextForTesting(): void {
+  pending = undefined;
+}
+
+export { GCX_CONTEXT_NAME };

--- a/packages/temporal/src/activities/gcx-context.ts
+++ b/packages/temporal/src/activities/gcx-context.ts
@@ -16,8 +16,11 @@ export class GcxContextError extends Error {
 }
 
 function requireEnv(name: string): string {
-  const value = Bun.env[name];
-  if (value === undefined || value.trim() === "") {
+  // Trimmed once and reused: the trimmed form is both what makes the value
+  // non-blank and what gcx receives, so a trailing newline in the 1Password
+  // field cannot reach the --server URL or the --token credential.
+  const value = Bun.env[name]?.trim();
+  if (value === undefined || value === "") {
     throw new GcxContextError(
       `${name} is required to provision the gcx "${GCX_CONTEXT_NAME}" context`,
     );
@@ -34,7 +37,28 @@ export type GcxSpawn = (args: string[]) => {
 const defaultSpawn: GcxSpawn = (args) =>
   Bun.spawn(args, { stdin: "ignore", stdout: "ignore", stderr: "pipe" });
 
-async function loginToGcx(spawn: GcxSpawn): Promise<void> {
+type SettleResult =
+  | { readonly ok: true; readonly stderr: string; readonly exitCode: number }
+  | { readonly ok: false; readonly error: unknown };
+
+/**
+ * Wait for the child, reporting a subprocess error as a value rather than a
+ * rejection. The deadline below abandons this promise when it wins, and Bun
+ * terminates the worker on an unhandled rejection, so this must not reject.
+ */
+async function settleChild(child: ReturnType<GcxSpawn>): Promise<SettleResult> {
+  try {
+    const [stderr, exitCode] = await Promise.all([
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    return { ok: true, stderr, exitCode };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+async function loginToGcx(spawn: GcxSpawn, timeoutMs: number): Promise<void> {
   const server = requireEnv("GRAFANA_URL");
   const apiKey = requireEnv("GRAFANA_API_KEY");
 
@@ -51,21 +75,38 @@ async function loginToGcx(spawn: GcxSpawn): Promise<void> {
     "--yes",
   ]);
 
-  const timeout = setTimeout(() => {
-    child.kill();
-  }, GCX_LOGIN_TIMEOUT_MS);
+  const settled = settleChild(child);
+
+  // Killing the child is only best-effort cleanup: a process that ignores the
+  // signal, or a stderr stream that never closes, would leave `settled`
+  // pending forever. The rejection below is what actually bounds the wait, so
+  // the timeout is a deadline on this function rather than merely on when the
+  // signal is sent.
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      child.kill();
+      reject(
+        new GcxContextError(
+          `gcx login did not complete within ${timeoutMs.toString()}ms`,
+        ),
+      );
+    }, timeoutMs);
+  });
 
   try {
-    const [stderr, exitCode] = await Promise.all([
-      new Response(child.stderr).text(),
-      child.exited,
-    ]);
-    if (exitCode !== 0) {
+    const result = await Promise.race([settled, deadline]);
+    if (!result.ok) {
+      throw result.error;
+    }
+    if (result.exitCode !== 0) {
       // gcx echoes the --token argument back in some error paths, so the
       // credential is redacted before it can reach a Temporal failure message.
-      const detail = redactSecrets(stderr.trim().slice(0, 1000), [apiKey]);
+      const detail = redactSecrets(result.stderr.trim().slice(0, 1000), [
+        apiKey,
+      ]);
       throw new GcxContextError(
-        `gcx login exited ${exitCode.toString()}: ${detail}`,
+        `gcx login exited ${result.exitCode.toString()}: ${detail}`,
       );
     }
   } finally {
@@ -81,13 +122,17 @@ let pending: Promise<void> | undefined;
  * Memoized for the pod's lifetime: the audit collector and the preflight both
  * call it, and neither should depend on the other having run first. A failure
  * is not cached, so a transient Grafana outage does not poison the process.
+ *
+ * `timeoutMs` is a test seam so the deadline can be exercised without a
+ * multi-second test; production callers use GCX_LOGIN_TIMEOUT_MS.
  */
 export async function ensureGcxContext(
   spawn: GcxSpawn = defaultSpawn,
+  timeoutMs: number = GCX_LOGIN_TIMEOUT_MS,
 ): Promise<void> {
   pending ??= (async () => {
     try {
-      await loginToGcx(spawn);
+      await loginToGcx(spawn, timeoutMs);
     } catch (error) {
       pending = undefined;
       throw error;

--- a/packages/temporal/src/activities/homelab-audit-preflight.ts
+++ b/packages/temporal/src/activities/homelab-audit-preflight.ts
@@ -43,6 +43,7 @@ const REQUIRED_AUDIT_BINARIES = [
   "toolkit",
   "temporal",
   "bk",
+  "gcx",
 ] as const;
 
 const REQUIRED_ENV_GROUPS: readonly RequiredEnvGroup[] = [


### PR DESCRIPTION
## Why

Stacked on #2164. This is step one of retiring `toolkit gf` — 2287 lines of homegrown Grafana client (15 subcommands, **zero tests**) that the official `gcx` CLI supersedes.

It is deliberately split from the migration because of an ordering hazard: `homelab-audit-prompts.ts:10` fetches the audit runbook from `raw.githubusercontent.com/.../main/...` **at activity start**, so a doc change takes effect the instant it merges — while the binaries only change when the image rolls. A single commit would open a window where the runbook says `gcx …` and the running pod has no `gcx`, and the daily audit runs at 06:30 PT into that window.

Landing gcx first means the deployed image carries **both** clients during the switchover, so neither ordering can break.

## What

- Checksum-verified, Renovate-tracked `gcx` in the runtime stage, matching the existing per-arch tarball pattern used for the Temporal CLI
- `ensureGcxContext()` — provisions the gcx `homelab` context once per pod from `GRAFANA_URL`/`GRAFANA_API_KEY`
- `GCX_CONFIG` / `GCX_NO_UPDATE_NOTIFIER` / `GCX_TELEMETRY` on the **core** worker only
- `gcx --version` added to both smoke paths

### Why a login instead of env vars

gcx authenticates from a config file. It *does* read env vars — but its two native names are exactly the two banned repo-wide by `scripts/environment-variable-rules.ts`, which canonicalized them to `GRAFANA_URL`/`GRAFANA_API_KEY`. Using them would need a lint exclusion, and [the decision record](../blob/main/packages/docs/decisions/2026-03-27_env-var-naming-convention.md) exists precisely because that mismatch broke `toolkit gf` once already. A login needs no exclusion.

`GCX_CONFIG` is a deliberate choice, not a requirement — I verified in the built image that `HOME=/home/bun` is set by the `oven/bun` base and is writable by uid 1000, so gcx's default path would work. Pinning it keeps the credential's location independent of the base image, so a bun bump that changes `HOME` cannot silently relocate it.

### Test gap closed

Nothing asserted the **core** worker carries `GRAFANA_URL`/`GRAFANA_API_KEY` — the existing test only asserts the *agent* worker does **not**. Added the positive assertion alongside the new `GCX_*` vars.

## Verification

- `bun test src/activities/gcx-context.test.ts` → **7 pass**: fail-fast on missing *and* blank credential, memoization across the two callers, no caching of failures, and the credential never reaching the error message
- `bun test packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts` → **8 pass**
- `bunx turbo run typecheck --filter=@shepherdjerred/temporal --filter=@homelab/cdk8s` → clean
- `bunx eslint` on every changed file → **0 errors**
- gcx v1.0.0 release layout verified against the real tarball: bare `gcx` at root, `gcx_<version>_checksums.txt`, both linux arches published

- `bun run smoke` → image builds; **all 19 operator CLIs** present and runnable (18 before this change); worker boots and fails to connect as expected
- `docker run --entrypoint gcx temporal-worker:dev --version` → gcx 1.0.0, and `toolkit` is still present — the both-clients property this split exists to provide
- gcx verified runnable as uid 1000, matching the pod's security context

**Gate before the follow-up PR:** built and smoked locally, but **not deployed**. `kubectl -n temporal exec deploy/temporal-temporal-worker -- gcx --version` must succeed in the live pod before the migration lands.

