### PR TITLE
feat(dotfiles): wire the cf CLI to its own Cloudflare credential

### DIFF
--- a/packages/dotfiles/private_dot_config/private_fish/config.fish.tmpl
+++ b/packages/dotfiles/private_dot_config/private_fish/config.fish.tmpl
@@ -71,6 +71,11 @@ set -gx LINEAR_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/iixe
 # stored under. Deliberately shares the MCP gateway's project-scoped key.
 set -gx POSTHOG_CLI_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/iixelnobjabehkgxhl3ekacdy4/POSTHOG_API_KEY" }}'
 set -gx POSTHOG_CLI_PROJECT_ID '549883'
+# Deliberately NOT named CLOUDFLARE_API_TOKEN. src/tofu/cloudflare authenticates
+# from that name ambiently, so exporting it globally would let a bare `tofu apply`
+# with no `op run` authenticate and apply instead of failing closed. ~/.local/bin/cf
+# maps this to CLOUDFLARE_API_TOKEN for its own process only.
+set -gx CF_API_TOKEN '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/vp4l6tpe2cly6q4w5aremgvnbe/credential" }}'
 # Loki and Prometheus are tailnet-only with no auth (loki runs auth_enabled:
 # false), so logcli and promtool need an address but no credential.
 set -gx LOKI_ADDR 'https://loki.tailnet-1a49.ts.net'


### PR DESCRIPTION
Follow-up to #2164, which landed the `cf` wrapper but left it without a credential — so it correctly failed closed and none of the Cloudflare surface was reachable.

## What

Points `CF_API_TOKEN` at a new read/write API Credential item in the homelab vault.

The variable is **deliberately not named `CLOUDFLARE_API_TOKEN`**. `src/tofu/cloudflare` authenticates from that name ambiently, so exporting it globally would let a bare `tofu -chdir=cloudflare apply` with no `op run` authenticate and apply against production instead of failing closed on a missing credential. `~/.local/bin/cf` maps the name for its own process only.

## Verification

| Check | Result |
| --- | --- |
| `GET /user/tokens/verify` | success, status `active` |
| `cf zones list` | 10 zones |
| `cf accounts list` | the homelab account |
| `cf r2 buckets list` | `glitter-discord-corpus`, `homelab`, `sjerred` |
| `env \| grep -c '^CLOUDFLARE_API_TOKEN='` | **0** — the Tofu guardrail still holds |
| gitleaks + full pre-commit | pass |

The tracked file contains only the `op://` reference; the literal token appears nowhere in the tree (verified with a repo-wide search including untracked and ignored files).

All five Cloudflare capabilities originally asked for — access keys, R2 buckets, domains, DNS, analytics — are now reachable read-side through `cf`, with the mutating `cf dns`/`zones`/`registrar` subcommands denied in `managed-settings.json` because those records are OpenTofu-owned.