### PR TITLE
fix(root): dedupe Qodo findings across blockquote-marker reflow

### DIFF
--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isProviderAuthor } from "../identity.ts";
+import type { ReviewThread } from "../types.ts";
 import { qodoProvider, parseQodoIssueComment } from "./qodo.ts";
 
 const comment = {
@@ -244,6 +245,52 @@ describe("qodo layout guards", () => {
   });
 });
 
+/**
+ * One finding rendered twice, as a re-review leaves it: the first copy struck
+ * and resolved, the second re-appended unstruck against the previous head.
+ * Only the Issue Context quoting differs, which is what each case varies.
+ */
+function quotedCopy(
+  number: number,
+  summary: string,
+  context: string,
+  sha: string,
+): string {
+  return `<details>
+<summary>  ${String(number)}. ${summary}</summary>
+<code>[src/priors.ts[R10-12]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc)</code>
+>Existence does not prove this run wrote it.
+${context}
+>The intent is to assert the landing.
+>[src/priors.ts[10-12]](https://github.com/shepherdjerred/monorepo/blob/${sha}/src/priors.ts/#L10-L12)
+></details>
+
+<hr/>
+</details>`;
+}
+
+function reviewWithQuotedContext(
+  firstContext: string,
+  secondContext: string,
+): string {
+  return `
+<h3>Code Review by Qodo</h3>
+<code>🐞 Bugs (1)</code> <code>📘 Rule violations (0)</code>
+<img src="https://example/divider.svg" alt="Grey Divider">
+<img src="https://example/action-required.png" alt="Action required">
+${quotedCopy(1, "<s>Stale artifact</s> <code>✓ Resolved</code> <code>🐞 Bug</code>", firstContext, "f4c0d5a390d7aa2ad7713f0da3de349b8e66d421")}
+${quotedCopy(2, "Stale artifact <code>🐞 Bug</code>", secondContext, "52d176391dc9015d5b3a070ea025081cdd1fad85")}
+`;
+}
+
+function soleFinding(body: string): ReviewThread {
+  const findings = parseQodoIssueComment({ ...comment, body });
+  expect(findings).toHaveLength(1);
+  const finding = findings[0];
+  if (finding === undefined) throw new Error("expected one finding");
+  return finding;
+}
+
 describe("qodo re-review copies", () => {
   test("collapses the copies Qodo re-appends on each re-review", () => {
     // Qodo re-appends every finding on re-review and reflows the copy's
@@ -304,44 +351,27 @@ describe("qodo re-review copies", () => {
     // Collapsing whitespace leaves the marker itself behind, so the two copies
     // read as different findings and the gate blocked on the unstruck duplicate
     // of a finding Qodo had already marked resolved.
-    const blankQuoteLine = `
-<h3>Code Review by Qodo</h3>
-<code>🐞 Bugs (1)</code> <code>📘 Rule violations (0)</code>
-<img src="https://example/divider.svg" alt="Grey Divider">
-<img src="https://example/action-required.png" alt="Action required">
-<details>
-<summary>  1. <s>Stale artifact</s> <code>✓ Resolved</code> <code>🐞 Bug</code></summary>
-<code>[src/priors.ts[R10-12]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc)</code>
->Existence does not prove this run wrote it.
->## Issue Context
->The intent is to assert the landing.
->[src/priors.ts[10-12]](https://github.com/shepherdjerred/monorepo/blob/f4c0d5a390d7aa2ad7713f0da3de349b8e66d421/src/priors.ts/#L10-L12)
-></details>
+    const finding = soleFinding(
+      reviewWithQuotedContext(">## Issue Context", ">\n>## Issue Context"),
+    );
 
-<hr/>
-</details>
-<details>
-<summary>  2. Stale artifact <code>🐞 Bug</code></summary>
-<code>[src/priors.ts[R10-12]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc)</code>
->Existence does not prove this run wrote it.
->
->## Issue Context
->The intent is to assert the landing.
->[src/priors.ts[10-12]](https://github.com/shepherdjerred/monorepo/blob/52d176391dc9015d5b3a070ea025081cdd1fad85/src/priors.ts/#L10-L12)
-></details>
-
-<hr/>
-</details>
-`;
-    const findings = parseQodoIssueComment({
-      ...comment,
-      body: blankQuoteLine,
-    });
-
-    expect(findings).toHaveLength(1);
     // Qodo's own verdict on the finding, not on the copy it happened to strike.
-    expect(findings[0]?.isResolved).toBe(true);
-    expect(findings[0]?.title).toBe("Stale artifact");
+    expect(finding.isResolved).toBe(true);
+    expect(finding.title).toBe("Stale artifact");
+  });
+
+  test("collapses copies whose quoting differs only in nesting depth", () => {
+    // Nesting is conventionally written `> >`, so a marker matched as a run of
+    // `>` characters stops at the space between the levels and leaves the inner
+    // one behind — the same failure the blank-line case produces, one level
+    // down. Not seen in a live comment yet; it is the shape the identity claims
+    // to normalize, so it is pinned rather than left to be discovered.
+    const finding = soleFinding(
+      reviewWithQuotedContext(">## Issue Context", "> > ## Issue Context"),
+    );
+
+    expect(finding.isResolved).toBe(true);
+    expect(finding.title).toBe("Stale artifact");
   });
 
   test("keeps same-titled findings apart when their bodies differ", () => {

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -297,6 +297,53 @@ describe("qodo re-review copies", () => {
     ]);
   });
 
+  test("collapses copies separated only by a blank blockquote line", () => {
+    // Observed on PR #2174. Qodo resolved the finding and re-appended an
+    // unstruck copy whose Issue Context carried one extra blank `>`
+    // continuation line — invisible when rendered, and no part of the finding.
+    // Collapsing whitespace leaves the marker itself behind, so the two copies
+    // read as different findings and the gate blocked on the unstruck duplicate
+    // of a finding Qodo had already marked resolved.
+    const blankQuoteLine = `
+<h3>Code Review by Qodo</h3>
+<code>🐞 Bugs (1)</code> <code>📘 Rule violations (0)</code>
+<img src="https://example/divider.svg" alt="Grey Divider">
+<img src="https://example/action-required.png" alt="Action required">
+<details>
+<summary>  1. <s>Stale artifact</s> <code>✓ Resolved</code> <code>🐞 Bug</code></summary>
+<code>[src/priors.ts[R10-12]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc)</code>
+>Existence does not prove this run wrote it.
+>## Issue Context
+>The intent is to assert the landing.
+>[src/priors.ts[10-12]](https://github.com/shepherdjerred/monorepo/blob/f4c0d5a390d7aa2ad7713f0da3de349b8e66d421/src/priors.ts/#L10-L12)
+></details>
+
+<hr/>
+</details>
+<details>
+<summary>  2. Stale artifact <code>🐞 Bug</code></summary>
+<code>[src/priors.ts[R10-12]](https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc)</code>
+>Existence does not prove this run wrote it.
+>
+>## Issue Context
+>The intent is to assert the landing.
+>[src/priors.ts[10-12]](https://github.com/shepherdjerred/monorepo/blob/52d176391dc9015d5b3a070ea025081cdd1fad85/src/priors.ts/#L10-L12)
+></details>
+
+<hr/>
+</details>
+`;
+    const findings = parseQodoIssueComment({
+      ...comment,
+      body: blankQuoteLine,
+    });
+
+    expect(findings).toHaveLength(1);
+    // Qodo's own verdict on the finding, not on the copy it happened to strike.
+    expect(findings[0]?.isResolved).toBe(true);
+    expect(findings[0]?.title).toBe("Stale artifact");
+  });
+
   test("keeps same-titled findings apart when their bodies differ", () => {
     const findings = parseQodoIssueComment({
       ...comment,

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -106,6 +106,13 @@ type RenderedFinding = {
 };
 
 /**
+ * Blockquote markers opening a line, including the nested `> >` form and the
+ * single space a marker conventionally takes. Horizontal whitespace only, so a
+ * line's own marker is matched without reaching into the line before it.
+ */
+const BLOCKQUOTE_MARKER = /^[^\S\n]*>+[^\S\n]?/gmu;
+
+/**
  * Canonical form of a rendered finding, used to recognize the copies Qodo
  * re-appends. Qodo reflows the blockquote indentation of a finding's agent
  * prompt between copies, so whitespace carries no meaning here; everything
@@ -124,6 +131,14 @@ function identityOf(summary: string, findingBody: string): string {
       // count on an unchanged PR — the exact accumulation this identity exists
       // to collapse.
       .replaceAll(/\b[0-9a-f]{40}\b/giu, "<commit>")
+      // Blockquote markers are reflow, not content. Collapsing whitespace alone
+      // leaves them behind, so one copy gaining a blank `>` continuation line —
+      // which renders identically and says nothing — made the two copies
+      // different findings, and the gate blocked on an unstruck duplicate of a
+      // finding Qodo had already resolved. Stripped BEFORE the whitespace
+      // collapse, which is the step that would otherwise weld a marker to the
+      // text after it.
+      .replaceAll(BLOCKQUOTE_MARKER, "")
       .replaceAll(/\s+/gu, "")
   );
 }

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -106,11 +106,17 @@ type RenderedFinding = {
 };
 
 /**
- * Blockquote markers opening a line, including the nested `> >` form and the
- * single space a marker conventionally takes. Horizontal whitespace only, so a
- * line's own marker is matched without reaching into the line before it.
+ * Blockquote markers opening a line, however deeply nested.
+ *
+ * Repeats the whole `>`-plus-optional-space unit rather than matching a run of
+ * `>` characters: nesting is conventionally written `> >`, and a `>+` run stops
+ * at the space between the levels, leaving the inner marker in the identity —
+ * which is the very difference this exists to erase, one level down.
+ *
+ * Horizontal whitespace only, so a line's own marker is matched without
+ * reaching into the line before it.
  */
-const BLOCKQUOTE_MARKER = /^[^\S\n]*>+[^\S\n]?/gmu;
+const BLOCKQUOTE_MARKER = /^(?:[^\S\n]*>[^\S\n]?)+/gmu;
 
 /**
  * Canonical form of a rendered finding, used to recognize the copies Qodo


### PR DESCRIPTION
## Why

`identityOf` in `packages/code-review/src/providers/qodo.ts` collapses whitespace and normalizes the evidence commit SHA so the copies Qodo re-appends on each re-review recognize each other. It does **not** strip markdown blockquote `>` markers, and the whitespace collapse leaves them in the identity — so a copy that gains a single blank `>` continuation line, which renders identically and carries no content, reads as a different finding.

The consequence is a required gate that blocks on work already done. Observed on #2174: Qodo re-reviewed, correctly struck the finding as resolved, and re-appended an unstruck copy whose Issue Context carried one extra marker. The two failed to collapse, `isBlocking` counted the unstruck copy, and `review-gate` failed a PR whose finding the same comment reported as resolved.

This is the "stale Qodo finding that will not clear" symptom hit repeatedly across recent PRs and previously written off as a Qodo tooling quirk. It is ours.

## What

- Strip blockquote markers in `identityOf`, **before** the whitespace collapse. The pattern covers the nested `> >` form and the single space a marker conventionally takes, and uses horizontal-whitespace classes so a line's own marker is matched without reaching into the line before it.
- Regression test built from the real #2174 shape: two copies of one finding differing only by evidence SHA and one blank `>` line, expected to collapse to a single resolved finding.

Ordering is load-bearing: the whitespace collapse is what would otherwise weld a marker onto the text after it, so the strip has to precede it.

## Verification

- **Reproduced end to end against the live #2174 comment** through the exported `parseQodoIssueComment`: **2 findings before** (one resolved, one not) → **1 after** (resolved). The gate-blocking duplicate is gone.
- Diffed the two renderings' identity strings directly: the sole divergence is one `>` character, and stripping makes them byte-identical.
- Confirmed **no line-start `>` in that comment follows an unterminated tag**, so stripping cannot merge an HTML tag split across lines into its neighbour.
- Confirmed the new test **fails without the strip and passes with it**, while all 19 pre-existing tests in the file pass either way — so the test isolates this behavior rather than the fixture.
- `bunx turbo run typecheck lint test --filter=@shepherdjerred/code-review --force` → 4/4 tasks, 106 tests, 0 fail.
- Consumers checked: `root-scripts` and `pr-fleet-controller` test tasks green (249 pass in the controller); temporal's review-signal tests green.

Not run: no live re-review was triggered to observe the gate flip green in CI from this branch — the live-comment reproduction above is the evidence.

## Rollout

Once this lands on `main`, PRs hitting the same symptom (currently #2174, potentially #2172/#2173) can rebase onto it to benefit. No behavior change for comments that do not carry reflowed markers.