### PR TITLE
fix(root): accept a clean Qodo review that carries the daily-tip footer

### DIFF
--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -113,6 +113,58 @@ describe("qodoProvider", () => {
     ).toEqual([]);
   });
 
+  // Qodo closes EVERY review with this block, so a fixture without it does not
+  // model a real comment. Observed on PR #2177, the first genuinely clean review
+  // this repository saw: the tip's `<details>` made the clean-review check
+  // conclude the comment must be rendering findings, and the gate rejected a PR
+  // Qodo had passed.
+  const DAILY_TIP = `<!-- qodo-daily-tip:start -->
+
+<details>
+<summary> Tip of the day</summary>
+
+<br/>
+
+<pre>💡 Did you know, you can turn on the rule miner</pre>
+
+<a href="https://docs.qodo.ai/tips-and-tricks">More tips ↗</a>
+
+</details>
+
+<img src="https://example/divider.svg" alt="Grey Divider">
+<!-- qodo-daily-tip:end -->`;
+
+  test("accepts a clean review carrying Qodo's daily-tip footer", () => {
+    expect(
+      parseQodoIssueComment({
+        ...comment,
+        body: `
+<h3>Code Review by Qodo</h3>
+<code>🐞 Bugs (0)</code> <code>📘 Rule violations (0)</code> <code>📎 Requirement gaps (0)</code>
+<img src="https://example/divider.svg" alt="Grey Divider">
+<img src="https://example/anteater.svg" width="20%">
+<h3>Great, no issues found!</h3>
+Qodo reviewed your code and found no material issues that require review
+<img src="https://example/divider.svg" alt="Grey Divider">
+${DAILY_TIP}
+`,
+      }),
+    ).toEqual([]);
+  });
+
+  test("still parses findings when the daily-tip footer follows them", () => {
+    // The tip rides along on finding-bearing reviews too, so stripping it must
+    // not disturb the findings rendered above it.
+    expect(
+      parseQodoIssueComment({
+        ...comment,
+        body: `${comment.body}
+${DAILY_TIP}
+`,
+      }),
+    ).toHaveLength(3);
+  });
+
   test("treats categories Qodo omits from the header as zero", () => {
     expect(
       parseQodoIssueComment({

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -368,13 +368,33 @@ function assertSectionsAreModelled(reviewBody: string): void {
   }
 }
 
+/**
+ * The review Qodo rendered, from its first divider on and without the daily tip.
+ *
+ * Qodo closes every review with a "Tip of the day" block fenced by its own HTML
+ * comments. That block is product chrome rather than review content, and it is
+ * wrapped in `<details>` — which the clean-review check reads as proof the
+ * comment renders findings. Left in, a review that genuinely found nothing looks
+ * like one whose findings failed to parse, and the gate rejects the comment
+ * instead of passing the PR. Removed before every layout check so the checks see
+ * only what Qodo reviewed.
+ */
+const QODO_DAILY_TIP =
+  /<!-- qodo-daily-tip:start -->[\s\S]*?<!-- qodo-daily-tip:end -->/giu;
+
+function reviewBodyOf(body: string): string {
+  return body
+    .slice(body.indexOf(QODO_DIVIDER_ALT))
+    .replaceAll(QODO_DAILY_TIP, "");
+}
+
 function assertParsedLayout(input: {
   body: string;
   expectedFindings: number;
   findings: readonly ReviewThread[];
   severitySections: number;
 }): void {
-  const reviewBody = input.body.slice(input.body.indexOf(QODO_DIVIDER_ALT));
+  const reviewBody = reviewBodyOf(input.body);
   assertSectionsAreModelled(reviewBody);
   if (
     input.findings.length === 0 &&
@@ -420,10 +440,7 @@ export function parseQodoIssueComment(
     severitySections,
   });
   assertContiguousNumbering(rendered);
-  assertNoFindingBeyondParsed(
-    comment.body.slice(comment.body.indexOf(QODO_DIVIDER_ALT)),
-    rendered,
-  );
+  assertNoFindingBeyondParsed(reviewBodyOf(comment.body), rendered);
 
   return dedupeRenderedFindings(rendered);
 }


### PR DESCRIPTION
## Why

Qodo closes **every** review with a "Tip of the day" block fenced by `<!-- qodo-daily-tip:start -->` / `<!-- qodo-daily-tip:end -->`, and that block is wrapped in `<details>`. `assertParsedLayout` builds its review body by slicing from the first divider to the end of the comment, so the tip was always inside it — and the clean-review branch reads a `<details>` anywhere in that body as proof the comment renders findings:

```ts
input.findings.length === 0 &&
  (input.expectedFindings !== 0 ||
    input.severitySections !== 0 ||
    /<details>/iu.test(reviewBody))
```

On a review **with** findings this never mattered: `findings.length === 0` short-circuits first. On a review with **none**, the guard concluded the comment must be rendering findings the parser had failed to reach, and threw. A PR Qodo had actually passed was rejected by our own parser, and the required gate failed in ~4 minutes with `Qodo review comment did not match the finding or clean-review layout`.

Surfaced on #2177 — the first genuinely clean review this repository has seen. This is not latent: it would reject **every** clean review from here on.

## What

- Remove the fenced daily-tip block when building the review body, via one shared `reviewBodyOf` helper now used by both `assertParsedLayout` and `assertNoFindingBeyondParsed` (which had each been slicing the body independently).

Deliberately scoped to the layout checks: `declaredFindingCount` reads the header *above* the first divider, and the severity-section split ignores the tip because its only `alt` is the divider — neither needed changing.

## Verification

- **Reproduced against #2177's real comment**: `parseQodoIssueComment` threw the exact gate error before the fix, returns **0 findings** after.
- **Isolated the guard**: `/<details>/` is `true` on that review body and `false` once the fenced block is removed — the tip is the whole cause.
- **Verified rather than assumed** the two neighbouring checks are unaffected: the loose finding-opener regex matches **nothing** in the tip block (0 matches), and the only `alt` inside it is `"Grey Divider"`, which is not a severity section.
- Confirmed the clean-review test **fails without** the strip and **passes with** it. The findings-plus-tip test passes either way *by design* — it's a control that the strip doesn't disturb findings rendered above it, not a second reproducer.
- `bunx turbo run typecheck lint test --filter=@shepherdjerred/code-review --force` → 4/4 tasks, 23 tests, 0 fail.
- Consumers: `root-scripts` and `pr-fleet-controller` test tasks green.

Not run: no live gate execution from this branch — the real-comment reproduction above is the evidence.

## Note on fixtures

Every pre-existing fixture in `qodo.test.ts` omits the daily tip, so none of them modelled a real Qodo comment. The two cases added here carry it.