### PR TITLE
feat(scout-for-lol): overhaul explore turn lifecycle, routing, sharing, and a11y

### DIFF
--- a/packages/docs/plans/2026-08-14_scout-explore-fix-batch.md
+++ b/packages/docs/plans/2026-08-14_scout-explore-fix-batch.md
@@ -292,3 +292,23 @@ src/router-analytics-identity.test.ts src/components/explore-transcript.test.tsx
   the pure `explore-turn-state.ts` layer.
 - react-router v8 optional-segment assumption pinned by router.test.ts with a
   named two-route fallback.
+
+## Remaining
+
+- [ ] Run the live `dev-web` end-to-end pass with `EXPLORE_GUILD_ALLOWLIST`
+      set (eyeball list in Verification above) from an environment with
+      1Password + Discord OAuth.
+- [ ] Capture and attach PR media: GIF of edit-root forking and
+      Stop-preserves-answer, screenshot of share/revoke header states
+      (`toolkit pr asset 2179 …`).
+- [ ] Promote [PR #2179](https://github.com/shepherdjerred/monorepo/pull/2179)
+      from draft once the two items above are done.
+- [ ] After merge: mark this plan `complete` and move it to
+      `packages/docs/archive/completed/`.
+
+## Comment Log
+
+- 2026-08-14: Implementation landed on `claude/lol-frontend-app-a6d9aa`
+  (contract + backend salvage, turn lifecycle, routing, sharing, a11y,
+  perf/reuse); draft PR #2179 opened. Local verification complete; live
+  checks and media pending an authenticated environment.

--- a/packages/docs/plans/2026-08-14_scout-explore-fix-batch.md
+++ b/packages/docs/plans/2026-08-14_scout-explore-fix-batch.md
@@ -1,0 +1,294 @@
+---
+id: plan-2026-08-14-scout-explore-fix-batch
+type: plan
+status: in-progress
+board: true
+verification: agent
+disposition: active
+---
+
+# Explore UI — Fix Review Findings & Fill Feature Gaps
+
+## Context
+
+A high-effort multi-angle code review of the Scout Explore chat surface
+(`packages/scout-for-lol/packages/app`) confirmed 10 correctness findings and
+surfaced feature, accessibility, and perf/reuse gaps. Full scope was chosen:
+all findings, the missing chat features (share revoke, URL-addressed
+conversations, timestamps, Escape-to-stop, clipboard timing), accessibility,
+and perf/reuse cleanups — including a breaking wire-contract change (safe:
+only app+backend consume the contract, and stage deploys are lockstep).
+
+Verified findings being fixed (file:line citations validated):
+
+1. Turn teardown loses answers — `finally` clears pending state before
+   `refresh()` lands (explore.tsx:163-169); non-abort errors persist nothing
+   (`persistPartialAnswer` refuses `!aborted`, http-route.ts:433-435); Stop
+   races the post-disconnect salvage; failed questions unrecoverable.
+2. Editing the root question can't fork — `parentMessageId: null` means
+   "attach at current leaf" (store.ts:302-304) and the root's parentId IS null.
+3. Pending stream state not conversation-keyed — switching/deleting mid-stream
+   renders the stream under the wrong conversation (explore.tsx:227, 404-415).
+4. Failed `explore.status` renders as access denial (explore.tsx:190-204).
+5. Enter-to-send lacks the IME `isComposing` guard (explore.tsx:353-358).
+6. Export table emits an empty mislabeled label column + raw values
+   (explore-export.ts:41-49) and never escapes `|`/newlines.
+7. setLeaf/rename/delete rejections unhandled; dialogs stick open; `isPending`
+   unused (explore.tsx:305-313, 387-396, 404-415).
+8. `/explore` + `/explore/s/:token` missing from `normalizePath`'s allowlist →
+   all Explore pageviews tracked as `/not-found` (analytics.ts:445-447).
+9. Per-token smooth `scrollIntoView` with no pinned-to-bottom guard
+   (explore.tsx:97-99).
+10. First question renders twice while a new conversation streams (persisted
+    question + pendingQuestion, no dedup; explore.tsx:469-471).
+
+Key verified facts the design leans on: `tree.ts` already treats
+`parentId === null` messages as root siblings (versionPosition/siblingsOf);
+`startExploreTurn`'s ownership check already permits a null parent; the `final`
+stream event already carries the full persisted assistant message; the app's
+test harness is SSR-only (`renderToStaticMarkup`, no effects/DOM); explore.tsx
+sits at 499/500 ESLint max-lines and must be split; react-router `^8.3.0`;
+`ReportResultTable` is structurally compatible with the explore preview
+(`formatCell` handles `key === "label"` via `row.label`).
+
+`PKG` = `packages/scout-for-lol/packages` below.
+
+## Design decisions
+
+- **Attach-point union replaces `parentMessageId`.** `ExploreTurnRequest`
+  gains `attach: {kind:"leaf"} | {kind:"root"} | {kind:"message", messageId}`
+  (default `{kind:"leaf"}`), because null currently means two different things
+  and "fork at root" is inexpressible. Matches the repo's discriminated-union
+  preference (LakeQueryScope precedent; `z.discriminatedUnion` already used in
+  explore.ts:196). Breaking change; both sides land in one release
+  (lockstep deploys). Stale tabs get a 400 until reload — accepted.
+- **`started` event gains `questionMessageId`** — the freshly persisted
+  question's id (existing question id for regenerate). Enables exact
+  duplicate-question suppression and stop catch-up detection.
+- **Salvage widens to non-abort errors.** `persistPartialAnswer` refuses only
+  empty text; caveat distinguishes stopped vs interrupted via two new
+  constants in `@scout-for-lol/data` (`EXPLORE_STOPPED_CAVEAT`,
+  `EXPLORE_INTERRUPTED_CAVEAT`). After successful salvage on error, emit
+  `final` only (single terminal event); log + Sentry-capture the swallowed
+  error server-side. Function is exported with an explicit prisma client
+  param as the test seam.
+- **Pure turn-state module + hook.** All turn logic leaves explore.tsx:
+  - `app/src/lib/explore-turn-state.ts` (pure, SSR-testable):
+    `ExplorePendingTurn` (conversation-keyed: conversationId,
+    questionMessageId, question, answer, activity, leafIdAtStart,
+    finalMessageId, phase), `createPendingTurn`, `applyStreamEvent` (reducer;
+    `final` replaces streamed text with the persisted message content),
+    `markStopping`, `turnHasLanded(turn, messages)` (finalMessageId present,
+    or last message is an assistant under `questionMessageId` with
+    id ≠ leafIdAtStart — detects stop-salvage rows), `visiblePending(turn,
+displayedConversationId, messages)` (all-null when conversation doesn't
+    match; question suppressed once messages contain `questionMessageId`;
+    answer suppressed once landed).
+  - `app/src/hooks/use-explore-turn.ts`: owns pendingTurn/error/abortRef;
+    `runTurn`, `stop`, `abortForNavigation`. Teardown order fixed: **await
+    targeted refresh first, then clear pendingTurn**. Stop catch-up: bounded
+    re-poll (refresh → check `turnHasLanded` → 600ms → refresh → 1500ms →
+    refresh, ~2.1s cap), then clear. Pre-`started` failures call
+    `restoreQuestion(text)` so the composer gets the draft back; post-started
+    failures don't (question already persisted). `abortForNavigation` aborts
+    (the backend allows one active run per user — backgrounding would silently
+    block the next question), clears pending, schedules one delayed refresh.
+- **URL is the source of truth for the active conversation.** Single route
+  `explore/:conversationId?` (optional segment — avoids remounting `Explore`
+  when the `started` event navigates `/explore` → `/explore/:id`;
+  `router.test.ts` pins v8 optional-segment support; fallback = two sibling
+  routes sharing the element). `explore/s/:shareToken` stays put. Params via
+  `useExploreParams()` in route-params.ts (uuid-validated,
+  `RouteParameterError` on garbage); non-blocking `exploreLoader` prefetches
+  status/list/get. Sidebar select/new navigate; `started` navigates
+  `replace: true`; deleting the active conversation navigates `/explore`
+  `replace: true` and `removeQueries` the dead transcript.
+- **Analytics**: two `.replace` templating rules (token first:
+  `/^\/explore\/s\/[^/]+/` → `/explore/s/:shareToken`, then
+  `/^\/explore\/(?!s(?:\/|$))[^/]+/` → `/explore/:conversationId`) + knownRoute
+  alternation `\/explore(?:\/(?::conversationId|s\/:shareToken))?`. Token is
+  templated before the knownRoute test, so it can never reach PostHog.
+  `analyticsContextRoute` deliberately unchanged (no guild property).
+- **Share flow**: `shareLink` derived from
+  `transcript.data.conversation.shareToken` (kills stale-after-delete);
+  `showShareLink` boolean reset on conversation change; clipboard write
+  immediately after mint (before invalidation, preserving user activation),
+  `typeof navigator.clipboard?.writeText === "function"` guard, refused
+  clipboard = "copy manually" hint, never an error. Revoke: small ghost icon
+  button (`Link2Off`, aria-label "Stop sharing") in the header when shared,
+  calling existing `explore.revokeShare`.
+- **Reuse swaps**: transcript preview → `ReportResultTable` (guard empty rows
+  at the call site to keep null-on-empty; accept left-aligned metrics);
+  query/trace disclosures → Radix `Collapsible` (free aria-expanded; triggers
+  move onto their own rows); loading → `SectionSkeleton`; rollout denial →
+  `ForbiddenPanel`; shared `httpErrorMessage` moves to a new
+  `lib/stream-http-error.ts` parsing a tolerant `z.looseObject({error})`
+  (the two strict schemas differ only in quota snapshot type).
+- **Error-state fix**: `status.isError` renders an inline retry panel calling
+  `status.refetch()` (narrower than RouteErrorPanel's resetQueries+navigate).
+- **Composer extracted** to `explore-composer.tsx` owning `question` state:
+  IME guard (`event.nativeEvent.isComposing` — combobox.tsx precedent),
+  Escape-to-stop via window listener gated on active turn +
+  `!event.defaultPrevented` (textarea is disabled mid-turn and can't hear
+  keys; guard defers to Radix dialogs), focus returned to the textarea on
+  active→idle, draft restore only into an empty box, JS autosize kept
+  (Firefox lacks `field-sizing`) with the 200px constant hoisted.
+- **Perf**: memoized `UserTurn`/`AssistantTurn`/`ExploreSidebar`
+  (`export const X = memo(XView)` convention); single memoized
+  `actions` object prop; pending stream rendering isolated in a memoized
+  `PendingTurn` leaf with `aria-live="polite"` (always mounted) so deltas
+  re-render only it; transcript root gets `role="log"`; pinned auto-scroll via
+  `use-pinned-scroll.ts` (window is the scroll container — verified; passive
+  scroll listener, 120px threshold, `block:"end"` auto behavior, never yanks a
+  scrolled-up reader); targeted invalidation
+  (`get.queryKey({conversationId})` + list; delete uses removeQueries);
+  ECharts init/dispose effect split from a `setOption(..., {notMerge:true})`
+  effect keyed on the snapshot.
+- **Timestamps**: assistant turns only — `<time dateTime>` with short
+  `Intl.DateTimeFormat` text and full-format `title`, no date library.
+- **Export**: label column heads the table (`labelColumn?.label ?? "Row"`),
+  metric values through `formatReportDisplayValue`, `escapeCell` (`\|`,
+  newlines→space) on headers/cells, heading newline collapse for title and
+  questions, `exportFilename` slices before stripping hyphens,
+  `downloadMarkdown` appends the anchor to the DOM and revokes the object URL
+  on a 0-ms timeout.
+
+## Implementation phases
+
+Single git-spice stack from this worktree branch; draft PR after phase 1's
+first coherent commit. Mirror this plan to
+`packages/docs/plans/2026-08-14_scout-explore-fix-batch.md` (canonical
+frontmatter) in the first commit.
+
+### Phase 1 — Contract + backend (PKG/data, PKG/backend)
+
+1. `data/src/model/explore.ts`: add `ExploreAttachPointSchema` +
+   `ExploreAttachPoint`; rewrite `ExploreTurnRequestSchema` (drop
+   `parentMessageId`, add `attach`, update the semantics docblock table:
+   Ask=leaf, Edit non-root=message(parent), Edit root=root,
+   Regenerate=message(question)); add `questionMessageId: z.uuid()` to the
+   `started` event; add the two caveat constants.
+2. `backend/src/explore/store.ts` `startExploreTurn`: input takes
+   `attach: ExploreAttachPoint`; existing-conversation branch resolves
+   parentId via the 3-way kind switch; `kind:"message"` ids must exist in the
+   conversation (`ExploreNotFoundError`); new-conversation branch ignores
+   attach. No tree.ts changes needed.
+3. `backend/src/explore/http-route.ts`: `resolveTurnTarget` — regenerate
+   requires `attach.kind === "message"` (else `ExploreInvalidTurnError`
+   "Answering again needs an existing question."); pass `attach` through;
+   `started` emit gains `questionMessageId: started.messageId`;
+   `persistPartialAnswer` exported with explicit prisma param, refuses only
+   empty text, caveat by `input.aborted`; log + `Sentry.captureException` the
+   non-abort error in the catch.
+4. Tests: adapt `store.integration.test.ts` `askAndAnswer` to `attach`; new
+   "editing the opening question forks a second root" (two roots,
+   versionCount 2, siblingIds, setLeaf restores the original path, nothing
+   deleted); `http-route.e2e.test.ts` — drop stale `parentMessageId: null`
+   bodies, new "a regenerate that names no message is rejected as invalid",
+   new "explore salvage" describe driving exported `persistPartialAnswer`
+   (stopped-with-text → stop caveat; errored-with-text → interrupted caveat +
+   currentLeafId moves; errored-empty → null, nothing written). No
+   `streamExploreAgent` mock (emit-ordering residue accepted; documented).
+5. Docs: AGENTS.md Explore bullets — attach-point semantics + salvage-on-error.
+
+### Phase 2 — Turn lifecycle + URL routing (PKG/app)
+
+1. New `src/lib/explore-turn-state.ts` (pure module above) + full test file
+   `explore-turn-state.test.ts` (10 cases from the design: reducer, landed
+   predicate incl. regenerate/leafIdAtStart, visiblePending suppressions,
+   null↔null conversation match). Fixtures via `ExploreMessageSchema.parse`.
+2. New `src/hooks/use-explore-turn.ts` (behavior above; targeted refresh:
+   invalidate `get.queryKey({conversationId})` + `list.queryKey()`).
+3. Routing: `router.tsx` route becomes
+   `{ path: "explore/:conversationId?", element: <Explore/>, loader:
+exploreLoader, errorElement: <RouteErrorPanel/> }`; `route-params.ts` gains
+   `ExploreParamsSchema`/`useExploreParams`; `route-loaders.ts` gains
+   `exploreLoader` (prefetch status/list/get, safeParse id);
+   `router.test.ts` KNOWN_URLS += `/explore`, `/explore/<uuid>`,
+   `/explore/s/some-share-token`.
+4. `routes/explore.tsx` rewrite (lands well under 500 lines): conversationId
+   from `useExploreParams()` (hook takes `conversationId ?? null`);
+   `onConversationStarted: navigate(`/explore/${id}`, {replace:true})`;
+   sidebar handlers `abortForNavigation()` + navigate; delete handler aborts
+   if streaming, navigates `/explore` replace, `removeQueries` the dead get
+   key; ask/edit/regenerate call sites send `attach` ({kind:"leaf"} /
+   parentId===null ? root : message / message(parentId)); `visiblePending`
+   feeds the transcript; status branches: `SectionSkeleton` → isError retry
+   panel (`status.refetch()`) → `ForbiddenPanel` rollout copy; named
+   `handleSelectVersion`/`handleRename`/`handleDelete` useCallbacks with
+   try/catch → setError, dialogs close on success only,
+   `pending={mutation.isPending}` wired; memoized `transcriptActions`.
+
+### Phase 3 — Components, share, export, analytics, perf (PKG/app)
+
+1. `explore-transcript.tsx`: props take `actions?: ExploreTranscriptActions`
+   (module-level `EMPTY_ACTIONS` fallback); `role="log"` container; memoized
+   `PendingTurn` live-region leaf; memoized UserTurn/AssistantTurn;
+   `ReportResultTable` swap (delete `PreviewTable` + unused imports; empty-rows
+   guard at call site); Collapsible disclosures for query + steps
+   (ChevronDown rotate pattern); `<time>` on assistant action rows. New SSR
+   test `explore-transcript.test.tsx` (6 cases from the design: log+live
+   region always mounted, streaming content in region, time element,
+   dimension-label header + formatted metrics, empty-preview omission,
+   aria-expanded false).
+2. New `src/components/explore-composer.tsx` (IME guard, Escape listener,
+   focus return, draft restore, autosize constant). New
+   `src/hooks/use-pinned-scroll.ts`; page effect replaces the old
+   scrollIntoView effect.
+3. Share: new `src/hooks/use-explore-share.ts` (derived link, copy-first,
+   revoke) + `src/components/explore-share.tsx` (link row + copied/manual
+   hint); `explore-header.tsx` actions gain `revoking`/`onRevoke` + Link2Off
+   button.
+4. New `src/lib/stream-http-error.ts`; `report-ai-stream.ts` and
+   `explore-stream.ts` consume it (delete both private copies; explore's
+   `attach`-carrying request type flows from the data package unchanged).
+5. `explore-export.ts` fixes + new `explore-export.test.ts` (6 cases from the
+   design). `explore-shared.tsx` swaps loading text for `SectionSkeleton`.
+6. `analytics.ts` replace-chain + knownRoute edits (verbatim regexes in the
+   design); `analytics.test.ts` two new cases ("templates explore conversation
+   ids", "never lets a share token reach PostHog").
+   `router-analytics-identity.test.ts` must pass untouched.
+7. `interactive-visualization.tsx` effect split (`notMerge: true`; Zod parse
+   stays in the option effect). `explore-sidebar.tsx` wrapped in `memo`.
+
+## Verification
+
+- Per-package while iterating:
+  `bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/app`
+- Focused suites: backend `bun test src/explore/` (store integration needs the
+  test DB harness); app `bun test src/lib/explore-turn-state.test.ts
+src/lib/explore-export.test.ts src/lib/analytics.test.ts src/router.test.ts
+src/router-analytics-identity.test.ts src/components/explore-transcript.test.tsx`.
+  `router.test.ts` is the canary for react-router v8 optional segments.
+- Root `bun run knip` (moved/deleted exports, new modules).
+- Manual end-to-end (SSR tests can't run effects):
+  `EXPLORE_GUILD_ALLOWLIST=<guild id> bun run --filter='./packages/scout-for-lol' dev:web`,
+  then `toolkit screenshot scout-app /app/explore --discord-id <allowlisted id>`
+  and `/app/explore/<conversation uuid>`. Eyeball: URL updates on
+  select/new/started + Back behaves; deep link renders; edit the OPENING
+  question → version arrows `‹1/2›` appear on turn 1; Stop mid-answer → prose
+  survives with the stopped caveat; kill the backend mid-answer → prose
+  survives with the interrupted caveat + composer regains the draft on
+  pre-start failure; share → link row + Copied ack; revoke flips back to
+  Share; export downloads a correct, escaped table; chart survives turn
+  refetches without flicker; Escape stops; focus returns to composer;
+  scrolled-up reading is never yanked; timestamps render; disclosures
+  animate with chevron + aria-expanded. IME Enter needs a real CJK input
+  source — manual spot check.
+- PR artifacts (repo rule for user-visible changes): short GIF of
+  edit-root forking + Stop-preserves-answer; screenshot of the share/revoke
+  header states. Upload via `toolkit pr asset`.
+- After merge: re-report the review findings with outcomes (ReportFindings).
+
+## Risks
+
+- Breaking wire change: stale SPA tabs 400 until reload (lockstep deploys;
+  accepted; no dual-read shim unless reports surface).
+- Salvage now keeps possibly-mid-sentence prose on errors — mitigated by the
+  interrupted caveat; deliberate trade against losing the answer.
+- Stop catch-up is bounded (~2.1s); a slower salvage appears on the next
+  natural refetch.
+- Hook async behavior isn't SSR-testable — that's why every decision lives in
+  the pure `explore-turn-state.ts` layer.
+- react-router v8 optional-segment assumption pinned by router.test.ts with a
+  named two-route fallback.

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -574,6 +574,15 @@ Two sources **refuse** global scope rather than answering wrongly:
   question), while editing forks the **question**. That is why the version
   arrows land where a reader expects them, and why messages carry `siblingIds`
   rather than only a count — a count cannot say which message "previous" is.
+  Turn requests carry an `attach` point (`leaf`/`root`/`message`) rather than
+  a nullable parent id: editing the _opening_ question forks a sibling
+  **root**, and the root's parent is null, so a nullable field cannot say
+  "fork at root" without colliding with "continue at the leaf".
+- A stopped **or errored** turn keeps whatever prose it had already streamed
+  as a caveated partial answer (`EXPLORE_STOPPED_CAVEAT` /
+  `EXPLORE_INTERRUPTED_CAVEAT` in `@scout-for-lol/data`); only a turn that
+  said nothing salvages nothing. The raw error behind an interrupted turn
+  goes to logs and Sentry, not the transcript.
 - The full ScoutQL registry is exposed as-is; there is no restricted dialect.
   Adding one properly needs a registry projection _plus_ a compile-time
   rejection path, because hiding an item from `get_report_language` alone would

--- a/packages/scout-for-lol/packages/app/src/components/explore-composer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-composer.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import { Square } from "lucide-react";
+import { Button } from "#src/components/ui/button.tsx";
+import { Textarea } from "#src/components/ui/textarea.tsx";
+
+/**
+ * Keep in step with the `max-h-[200px]` class below — Tailwind cannot
+ * interpolate a constant into a class name, so the ceiling lives twice.
+ */
+const MAX_COMPOSER_HEIGHT_PX = 200;
+
+/**
+ * The ask box. Owns its own draft so keystrokes re-render this leaf, not the
+ * page (and with it the whole transcript).
+ */
+export function ExploreComposer(props: {
+  /** True while a turn is streaming — disables input, swaps Ask for Stop. */
+  active: boolean;
+  /** Question handed back by a failed turn, adopted into an empty box. */
+  restoredDraft: string | null;
+  onAsk: (question: string) => void;
+  onStop: () => void;
+}) {
+  const { active, restoredDraft, onAsk, onStop } = props;
+  const [question, setQuestion] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const wasActiveRef = useRef(false);
+
+  const submit = (): void => {
+    const trimmed = question.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    setQuestion("");
+    onAsk(trimmed);
+  };
+
+  // Grow the composer with its content instead of scrolling a fixed box.
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea === null) {
+      return;
+    }
+    textarea.style.height = "auto";
+    textarea.style.height = `${String(
+      Math.min(textarea.scrollHeight, MAX_COMPOSER_HEIGHT_PX),
+    )}px`;
+  }, [question]);
+
+  // Escape stops the turn. Window-level because the textarea is disabled
+  // while a turn runs and a disabled control receives no keydown; the
+  // `defaultPrevented` guard defers to Radix dialogs, whose own Escape
+  // closes the dialog without also killing the turn.
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (event.key === "Escape") {
+        onStop();
+      }
+    };
+    globalThis.addEventListener("keydown", onKeyDown);
+    return () => {
+      globalThis.removeEventListener("keydown", onKeyDown);
+    };
+  }, [active, onStop]);
+
+  // Disabling the textarea when a turn starts blurs it to the document body;
+  // hand focus back when the turn ends so the next question needs no mouse.
+  useEffect(() => {
+    if (active) {
+      wasActiveRef.current = true;
+      return;
+    }
+    if (wasActiveRef.current) {
+      wasActiveRef.current = false;
+      textareaRef.current?.focus();
+    }
+  }, [active]);
+
+  // Adopt a restored draft only into an empty box — a user who already
+  // started retyping is never clobbered.
+  useEffect(() => {
+    if (restoredDraft === null) {
+      return;
+    }
+    setQuestion((current) => (current.length === 0 ? restoredDraft : current));
+  }, [restoredDraft]);
+
+  return (
+    <form
+      className="flex items-end gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <Textarea
+        ref={textareaRef}
+        value={question}
+        rows={1}
+        className="max-h-[200px] min-h-[42px] resize-none"
+        onChange={(event) => {
+          setQuestion(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          // Committing an IME candidate fires Enter with isComposing set;
+          // sending then would submit half-converted text.
+          if (event.nativeEvent.isComposing) {
+            return;
+          }
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            submit();
+          }
+        }}
+        placeholder="Ask a question about match data…"
+        disabled={active}
+      />
+      {active ? (
+        <Button
+          type="button"
+          variant="outline"
+          className="gap-1.5"
+          title="Stop (Esc)"
+          onClick={onStop}
+        >
+          <Square className="size-3.5" />
+          Stop
+        </Button>
+      ) : (
+        <Button type="submit" disabled={question.trim().length === 0}>
+          Ask
+        </Button>
+      )}
+    </form>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/explore-header.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-header.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Download, Menu, Share2 } from "lucide-react";
+import { Download, Link2Off, Menu, Share2 } from "lucide-react";
 import { Button } from "#src/components/ui/button.tsx";
 import {
   Sheet,
@@ -21,8 +21,10 @@ export function ExploreHeader(props: {
   actions?: {
     shared: boolean;
     sharing: boolean;
+    revoking: boolean;
     onExport: () => void;
     onShare: () => void;
+    onRevoke: () => void;
   };
 }) {
   return (
@@ -71,6 +73,19 @@ export function ExploreHeader(props: {
             <Share2 className="size-4" />
             {props.actions.shared ? "Copy link" : "Share"}
           </Button>
+          {props.actions.shared && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="size-8 p-0"
+              aria-label="Stop sharing"
+              title="Stop sharing"
+              disabled={props.actions.revoking}
+              onClick={props.actions.onRevoke}
+            >
+              <Link2Off className="size-4" />
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/packages/scout-for-lol/packages/app/src/components/explore-share.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-share.tsx
@@ -1,0 +1,26 @@
+/**
+ * The share-link row: a readonly, select-on-focus input plus a one-line ack.
+ * The app has no toast; the hint is the acknowledgement.
+ */
+export function ExploreShareRow(props: { shareLink: string; copied: boolean }) {
+  return (
+    <div className="space-y-1">
+      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        Share link
+        <input
+          readOnly
+          value={props.shareLink}
+          onFocus={(event) => {
+            event.target.select();
+          }}
+          className="min-w-0 flex-1 rounded-md border bg-muted px-2 py-1 font-mono text-xs"
+        />
+      </label>
+      <p className="text-xs text-muted-foreground" role="status">
+        {props.copied
+          ? "Copied to clipboard."
+          : "Copy the link manually — clipboard access was unavailable."}
+      </p>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/explore-sidebar.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { MoreHorizontal, Plus, Search } from "lucide-react";
 import type { ExploreConversation } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
@@ -14,9 +14,11 @@ import {
  * The conversation list.
  *
  * Rendered twice — as a fixed column on desktop and inside a drawer on mobile
- * — so it takes its state from the page rather than owning any.
+ * — so it takes its state from the page rather than owning any. Memoized so
+ * composer keystrokes and streamed tokens don't re-render every row's
+ * dropdown; the page passes stable callbacks to keep that effective.
  */
-export function ExploreSidebar(props: {
+export const ExploreSidebar = memo(function ExploreSidebarView(props: {
   conversations: ExploreConversation[];
   activeId: string | null;
   onSelect: (conversationId: string) => void;
@@ -121,7 +123,7 @@ export function ExploreSidebar(props: {
       </div>
     </div>
   );
-}
+});
 
 function filterByTitle(
   conversations: ExploreConversation[],

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ExploreMessageSchema, type ExploreMessage } from "@scout-for-lol/data";
+import { ExploreTranscript } from "#src/components/explore-transcript.tsx";
+
+const QUESTION_ID = "33333333-3333-4333-8333-333333333333";
+const ANSWER_ID = "44444444-4444-4444-8444-444444444444";
+
+function assistantMessage(overrides: Record<string, unknown>): ExploreMessage {
+  return ExploreMessageSchema.parse({
+    id: ANSWER_ID,
+    role: "assistant",
+    parentId: QUESTION_ID,
+    content: "Jinx, narrowly.",
+    createdAt: "2026-08-14T12:00:30.000Z",
+    ...overrides,
+  });
+}
+
+describe("ExploreTranscript", () => {
+  test("marks the transcript as a log with an always-mounted polite live region", () => {
+    // The live region must exist before content arrives — screen readers
+    // only announce additions to a region they already registered.
+    const markup = renderToStaticMarkup(<ExploreTranscript messages={[]} />);
+    expect(markup).toContain('role="log"');
+    expect(markup).toContain('aria-live="polite"');
+  });
+
+  test("renders the streaming answer and activity inside the live region", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[]}
+        pendingQuestion="Who wins?"
+        pendingAnswer="Jinx so far"
+        activity="Running the query…"
+      />,
+    );
+    expect(markup).toContain("Who wins?");
+    expect(markup).toContain("Jinx so far");
+    expect(markup).toContain("Running the query…");
+  });
+
+  test("renders assistant timestamps as <time> with an absolute title", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript messages={[assistantMessage({})]} />,
+    );
+    // Structure, not formatted text — the rendered string depends on the
+    // machine's timezone.
+    expect(markup).toContain("<time");
+    expect(markup).toContain('dateTime="2026-08-14T12:00:30.000Z"');
+  });
+
+  test("heads the preview table with its dimension label and no stray column", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[
+          assistantMessage({
+            preview: {
+              columns: [
+                { key: "label", label: "Player", format: "text" },
+                { key: "win_rate", label: "Win rate", format: "percent" },
+              ],
+              rows: [
+                {
+                  label: "Faker",
+                  values: [{ column: "win_rate", value: 0.5833 }],
+                },
+              ],
+              rowsScanned: 12,
+              renderKind: "TABLE",
+            },
+          }),
+        ]}
+      />,
+    );
+    expect(markup).toContain("Player");
+    expect(markup).toContain("Faker");
+    expect(markup).toContain("58.3%");
+    expect(markup).not.toContain(">Row<");
+  });
+
+  test("omits the preview table when the preview has no rows", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[
+          assistantMessage({
+            preview: {
+              columns: [{ key: "label", label: "Player", format: "text" }],
+              rows: [],
+              rowsScanned: 0,
+              renderKind: "TABLE",
+            },
+          }),
+        ]}
+      />,
+    );
+    expect(markup).not.toContain("No rows matched");
+    expect(markup).not.toContain("<table");
+  });
+
+  test("renders query and steps disclosures closed with aria-expanded false", () => {
+    const markup = renderToStaticMarkup(
+      <ExploreTranscript
+        messages={[
+          assistantMessage({
+            queryText: "FROM matches SELECT games",
+            trace: [
+              { toolName: "run_report_query", message: "Ran it.", ok: true },
+            ],
+          }),
+        ]}
+      />,
+    );
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain("ScoutQL query");
+    expect(markup).toContain("Steps (1)");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-transcript.tsx
@@ -1,25 +1,28 @@
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import {
   Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Copy,
   Pencil,
   RefreshCw,
 } from "lucide-react";
-import {
-  formatReportDisplayValue,
-  REPORT_RENDER_KINDS,
-} from "@scout-for-lol/data";
+import { REPORT_RENDER_KINDS } from "@scout-for-lol/data";
 import type {
   ExploreMessage,
-  ReportAiPreviewSummary,
   VisualizationSnapshot,
 } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "#src/components/ui/collapsible.tsx";
 import { Textarea } from "#src/components/ui/textarea.tsx";
 import { InteractiveVisualization } from "#src/components/interactive-visualization.tsx";
 import { MarkdownAnswer } from "#src/components/markdown-answer.tsx";
+import { ReportResultTable } from "#src/components/report-result-table.tsx";
 
 /**
  * Renders one path through an explore conversation.
@@ -30,7 +33,9 @@ import { MarkdownAnswer } from "#src/components/markdown-answer.tsx";
  * evidence, collapsed by default so they do not compete with the answer.
  *
  * Actions are opt-in per callback, so the shared view gets the same rendering
- * with none of the controls simply by passing none of them.
+ * with none of the controls simply by passing none of them. The turns are
+ * memoized and the streaming turn renders in its own leaf, so a token
+ * arriving re-renders one small component rather than every prior message.
  */
 export type ExploreTranscriptActions = {
   onFollowUp?: (question: string) => void;
@@ -39,35 +44,57 @@ export type ExploreTranscriptActions = {
   onSelectVersion?: (messageId: string) => void;
 };
 
-export function ExploreTranscript(
-  props: {
-    messages: ExploreMessage[];
-    /** Prose streaming in for a turn that has not been persisted yet. */
-    pendingAnswer?: string | null;
-    pendingQuestion?: string | null;
-    activity?: string | null;
-  } & ExploreTranscriptActions,
-) {
+/** Stable identity so memoized turns don't re-render on the shared page. */
+const EMPTY_ACTIONS: ExploreTranscriptActions = {};
+
+export function ExploreTranscript(props: {
+  messages: ExploreMessage[];
+  /** Prose streaming in for a turn that has not been persisted yet. */
+  pendingAnswer?: string | null;
+  pendingQuestion?: string | null;
+  activity?: string | null;
+  actions?: ExploreTranscriptActions;
+}) {
+  const actions = props.actions ?? EMPTY_ACTIONS;
   return (
-    <div className="space-y-6">
+    <div role="log" aria-label="Conversation" className="space-y-6">
       {props.messages.map((message) =>
         message.role === "user" ? (
-          <UserTurn key={message.id} message={message} actions={props} />
+          <UserTurn key={message.id} message={message} actions={actions} />
         ) : (
-          <AssistantTurn key={message.id} message={message} actions={props} />
+          <AssistantTurn key={message.id} message={message} actions={actions} />
         ),
       )}
 
-      {props.pendingQuestion !== undefined &&
-        props.pendingQuestion !== null && (
-          <UserBubble content={props.pendingQuestion} />
-        )}
+      <PendingTurn
+        pendingQuestion={props.pendingQuestion ?? null}
+        pendingAnswer={props.pendingAnswer ?? null}
+        activity={props.activity ?? null}
+      />
+    </div>
+  );
+}
 
-      {props.pendingAnswer !== undefined && props.pendingAnswer !== null && (
+/**
+ * The streaming turn. Its own memoized leaf so per-token updates re-render
+ * only this, and a live region so assistive tech announces the answer as it
+ * arrives — the region stays mounted even when idle, because screen readers
+ * only announce additions to a region they registered before content came.
+ */
+const PendingTurn = memo(function PendingTurnView(props: {
+  pendingQuestion: string | null;
+  pendingAnswer: string | null;
+  activity: string | null;
+}) {
+  return (
+    <div aria-live="polite" className="space-y-6">
+      {props.pendingQuestion !== null && (
+        <UserBubble content={props.pendingQuestion} />
+      )}
+      {props.pendingAnswer !== null && (
         <MarkdownAnswer>{props.pendingAnswer}</MarkdownAnswer>
       )}
-
-      {props.activity !== undefined && props.activity !== null && (
+      {props.activity !== null && (
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
           <span className="inline-block size-2 animate-pulse rounded-full bg-current" />
           {props.activity}
@@ -75,7 +102,7 @@ export function ExploreTranscript(
       )}
     </div>
   );
-}
+});
 
 function UserBubble(props: { content: string }) {
   return (
@@ -87,7 +114,7 @@ function UserBubble(props: { content: string }) {
   );
 }
 
-function UserTurn(props: {
+const UserTurn = memo(function UserTurnView(props: {
   message: ExploreMessage;
   actions: ExploreTranscriptActions;
 }) {
@@ -154,15 +181,13 @@ function UserTurn(props: {
       </div>
     </div>
   );
-}
+});
 
-function AssistantTurn(props: {
+const AssistantTurn = memo(function AssistantTurnView(props: {
   message: ExploreMessage;
   actions: ExploreTranscriptActions;
 }) {
   const { message, actions } = props;
-  const [showQuery, setShowQuery] = useState(false);
-  const [showTrace, setShowTrace] = useState(false);
   const chart = chartableSnapshot(message.visualization);
 
   return (
@@ -177,9 +202,16 @@ function AssistantTurn(props: {
         <InteractiveVisualization snapshot={chart} />
       )}
 
-      {chart === null && message.preview !== null && (
-        <PreviewTable preview={message.preview} />
-      )}
+      {chart === null &&
+        message.preview !== null &&
+        message.preview.rows.length > 0 && (
+          // Empty previews render nothing at all — the prose already says "no
+          // rows", and the shared table's empty-state box would restate it.
+          <ReportResultTable
+            columns={message.preview.columns}
+            rows={message.preview.rows}
+          />
+        )}
 
       {message.caveats.length > 0 && (
         <ul className="space-y-1 text-xs text-muted-foreground">
@@ -202,50 +234,37 @@ function AssistantTurn(props: {
             <RefreshCw className="size-3.5" />
           </IconButton>
         )}
-        {message.queryText !== null && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setShowQuery(!showQuery);
-            }}
-          >
-            {showQuery ? "Hide the query" : "Show the query"}
-          </Button>
-        )}
-        {message.trace.length > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setShowTrace(!showTrace);
-            }}
-          >
-            {showTrace
-              ? "Hide the steps"
-              : `Steps (${String(message.trace.length)})`}
-          </Button>
-        )}
+        <time
+          dateTime={message.createdAt}
+          title={TIME_FULL.format(new Date(message.createdAt))}
+          className="ml-auto text-xs text-muted-foreground"
+        >
+          {TIME_SHORT.format(new Date(message.createdAt))}
+        </time>
       </div>
 
-      {showQuery && message.queryText !== null && (
-        <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
-          <code>{message.queryText}</code>
-        </pre>
+      {message.queryText !== null && (
+        <Disclosure label="ScoutQL query">
+          <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+            <code>{message.queryText}</code>
+          </pre>
+        </Disclosure>
       )}
 
-      {showTrace && (
-        <ol className="space-y-1 rounded-md border p-3 text-xs text-muted-foreground">
-          {message.trace.map((entry, index) => (
-            <li key={`${entry.toolName}-${String(index)}`}>
-              <span className={entry.ok ? "" : "text-destructive"}>
-                {entry.ok ? "✓" : "✕"}
-              </span>{" "}
-              <span className="font-medium">{entry.toolName}</span> —{" "}
-              {entry.message}
-            </li>
-          ))}
-        </ol>
+      {message.trace.length > 0 && (
+        <Disclosure label={`Steps (${String(message.trace.length)})`}>
+          <ol className="space-y-1 rounded-md border p-3 text-xs text-muted-foreground">
+            {message.trace.map((entry, index) => (
+              <li key={`${entry.toolName}-${String(index)}`}>
+                <span className={entry.ok ? "" : "text-destructive"}>
+                  {entry.ok ? "✓" : "✕"}
+                </span>{" "}
+                <span className="font-medium">{entry.toolName}</span> —{" "}
+                {entry.message}
+              </li>
+            ))}
+          </ol>
+        </Disclosure>
       )}
 
       {actions.onFollowUp !== undefined && message.followUps.length > 0 && (
@@ -265,6 +284,40 @@ function AssistantTurn(props: {
         </div>
       )}
     </div>
+  );
+});
+
+// Assistant turns show when each exchange happened; one stamp per exchange,
+// since the question sits directly above its answer. Hover for the full date.
+const TIME_FULL = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+const TIME_SHORT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+/**
+ * Collapsed-by-default evidence. Radix supplies `aria-expanded`/`aria-controls`
+ * on the trigger, which the old hand-rolled show/hide buttons never had.
+ */
+function Disclosure(props: { label: string; children: React.ReactNode }) {
+  return (
+    <Collapsible className="space-y-2">
+      <CollapsibleTrigger asChild>
+        <Button variant="ghost" size="sm" className="group gap-1">
+          {props.label}
+          <ChevronDown
+            className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+            aria-hidden="true"
+          />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>{props.children}</CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -379,58 +432,4 @@ function chartableSnapshot(
   }
   const kind = REPORT_RENDER_KINDS.find((entry) => entry.id === snapshot.kind);
   return kind?.isChart === true ? snapshot : null;
-}
-
-/**
- * Fallback table for answers whose render kind produced no chart (a plain
- * table or leaderboard). Bounded to what the preview carries.
- */
-function PreviewTable(props: { preview: ReportAiPreviewSummary }) {
-  const { preview } = props;
-  if (preview.rows.length === 0) {
-    return null;
-  }
-  // The first column describes the grouping dimension ("Player", "Champion"),
-  // and its value is the row label rather than an entry in `values` — so it
-  // heads the label cell instead of becoming a column of its own. Rendering it
-  // as a normal column produced a stray "Player" column of em-dashes.
-  const [labelColumn, ...metricColumns] = preview.columns;
-
-  return (
-    <div className="overflow-x-auto rounded-lg border">
-      <table className="w-full text-sm">
-        <thead className="bg-muted/50">
-          <tr>
-            <th className="px-3 py-2 text-left font-medium">
-              {labelColumn?.label ?? "Row"}
-            </th>
-            {metricColumns.map((column) => (
-              <th key={column.key} className="px-3 py-2 text-right font-medium">
-                {column.label}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {preview.rows.map((row) => (
-            <tr key={row.label} className="border-t">
-              <td className="px-3 py-2">{row.label}</td>
-              {metricColumns.map((column) => {
-                const value = row.values.find(
-                  (entry) => entry.column === column.key,
-                )?.value;
-                return (
-                  <td key={column.key} className="px-3 py-2 text-right">
-                    {value === undefined || value === null
-                      ? "—"
-                      : formatReportDisplayValue(column, value)}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
 }

--- a/packages/scout-for-lol/packages/app/src/components/interactive-visualization.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/interactive-visualization.tsx
@@ -11,13 +11,17 @@ export function InteractiveVisualization(props: {
   compact?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<echarts.ECharts | null>(null);
 
+  // Init once: canvas + ResizeObserver + dispose. Re-initialising per
+  // snapshot rebuilt every on-screen chart from scratch each time a turn's
+  // refetch produced fresh message objects — a visible flicker right when a
+  // new answer lands.
   useEffect(() => {
     const container = containerRef.current;
     if (container === null) return;
-    const snapshot = VisualizationSnapshotSchema.parse(props.snapshot);
     const chart = echarts.init(container, undefined, { renderer: "canvas" });
-    chart.setOption(visualizationSnapshotToOption(snapshot, "interactive"));
+    chartRef.current = chart;
     const observer = new ResizeObserver(() => {
       chart.resize();
     });
@@ -25,7 +29,23 @@ export function InteractiveVisualization(props: {
     return () => {
       observer.disconnect();
       chart.dispose();
+      chartRef.current = null;
     };
+  }, []);
+
+  // Apply options per snapshot. `notMerge` replaces the previous option
+  // outright — the old dispose+init had replace semantics, and a merge would
+  // keep stale series when a new snapshot has fewer. The Zod parse stays: it
+  // is the wire-data guard, and it runs once per distinct snapshot, not per
+  // streamed token.
+  useEffect(() => {
+    chartRef.current?.setOption(
+      visualizationSnapshotToOption(
+        VisualizationSnapshotSchema.parse(props.snapshot),
+        "interactive",
+      ),
+      { notMerge: true },
+    );
   }, [props.snapshot]);
 
   return (

--- a/packages/scout-for-lol/packages/app/src/hooks/use-explore-share.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-explore-share.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+/**
+ * TS types `navigator.clipboard` as always present, but insecure origins and
+ * some embedded webviews ship without it; the function boundary keeps the
+ * declared `| undefined` from being narrowed away at the use site.
+ */
+function clipboardOrUndefined(): Clipboard | undefined {
+  return navigator.clipboard;
+}
+
+/**
+ * Sharing and revoking the active conversation.
+ *
+ * The link is derived from the transcript's `shareToken` rather than stored:
+ * deleting, revoking, or switching conversations kills it through the query
+ * cache, so there is no stale copy to forget to clear. `showShareLink` is the
+ * one piece of real state — the link row appears only after an explicit share
+ * click on *this* conversation.
+ */
+export function useExploreShare(params: {
+  conversationId: string | null;
+  /** `transcript.data.conversation.shareToken` — the only source of truth. */
+  shareToken: string | null;
+}): {
+  shareLink: string | null;
+  showShareLink: boolean;
+  copied: boolean;
+  sharing: boolean;
+  revoking: boolean;
+  error: string | null;
+  share: () => void;
+  revoke: () => void;
+} {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [showShareLink, setShowShareLink] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const shareMutation = useMutation(trpc.explore.share.mutationOptions());
+  const revokeMutation = useMutation(
+    trpc.explore.revokeShare.mutationOptions(),
+  );
+
+  useEffect(() => {
+    setShowShareLink(false);
+    setCopied(false);
+    setError(null);
+  }, [params.conversationId]);
+
+  const refresh = useCallback(
+    async (conversationId: string): Promise<void> => {
+      await queryClient.invalidateQueries({
+        queryKey: trpc.explore.get.queryKey({ conversationId }),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: trpc.explore.list.queryKey(),
+      });
+    },
+    [queryClient, trpc.explore.get, trpc.explore.list],
+  );
+
+  const share = useCallback((): void => {
+    const conversationId = params.conversationId;
+    if (conversationId === null) {
+      return;
+    }
+    void (async () => {
+      setError(null);
+      try {
+        const result = await shareMutation.mutateAsync({ conversationId });
+        const link = `${globalThis.location.origin}/app/explore/s/${result.shareToken}`;
+        // Copy before any invalidation round trip: browsers tie clipboard
+        // writes to recent user activation, and awaiting refetches first is
+        // how a successful share gets reported as a failure. A refused
+        // clipboard is not a failed share — the link row says "copy
+        // manually" instead. TS types `navigator.clipboard` as always
+        // present, but insecure origins and some embedded webviews ship
+        // without it, hence the widened read.
+        let didCopy = false;
+        const clipboard = clipboardOrUndefined();
+        if (clipboard !== undefined) {
+          try {
+            await clipboard.writeText(link);
+            didCopy = true;
+          } catch {
+            didCopy = false;
+          }
+        }
+        setCopied(didCopy);
+        setShowShareLink(true);
+        await refresh(conversationId);
+      } catch (shareError) {
+        setError(
+          shareError instanceof Error ? shareError.message : String(shareError),
+        );
+      }
+    })();
+  }, [params.conversationId, refresh, shareMutation]);
+
+  const revoke = useCallback((): void => {
+    const conversationId = params.conversationId;
+    if (conversationId === null) {
+      return;
+    }
+    void (async () => {
+      setError(null);
+      try {
+        await revokeMutation.mutateAsync({ conversationId });
+        setShowShareLink(false);
+        setCopied(false);
+        await refresh(conversationId);
+      } catch (revokeError) {
+        setError(
+          revokeError instanceof Error
+            ? revokeError.message
+            : String(revokeError),
+        );
+      }
+    })();
+  }, [params.conversationId, refresh, revokeMutation]);
+
+  return {
+    shareLink:
+      params.shareToken === null
+        ? null
+        : `${globalThis.location.origin}/app/explore/s/${params.shareToken}`,
+    showShareLink,
+    copied,
+    sharing: shareMutation.isPending,
+    revoking: revokeMutation.isPending,
+    error,
+    share,
+    revoke,
+  };
+}

--- a/packages/scout-for-lol/packages/app/src/hooks/use-explore-share.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-explore-share.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  exploreShareLink,
+  mintedAfterPersisted,
+  resolveShareToken,
+} from "#src/lib/explore-share-link.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
 
 /**
@@ -19,6 +24,12 @@ function clipboardOrUndefined(): Clipboard | undefined {
  * cache, so there is no stale copy to forget to clear. `showShareLink` is the
  * one piece of real state — the link row appears only after an explicit share
  * click on *this* conversation.
+ *
+ * The token the share mutation just minted is held only until the invalidated
+ * query reports it back, because the read-back is a network round trip the user
+ * would otherwise wait through with nothing on screen — and one that can fail,
+ * stranding a share that succeeded. `explore-share-link.ts` holds both rules;
+ * this hook only applies them.
  */
 export function useExploreShare(params: {
   conversationId: string | null;
@@ -39,6 +50,7 @@ export function useExploreShare(params: {
   const [showShareLink, setShowShareLink] = useState(false);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [mintedToken, setMintedToken] = useState<string | null>(null);
   const shareMutation = useMutation(trpc.explore.share.mutationOptions());
   const revokeMutation = useMutation(
     trpc.explore.revokeShare.mutationOptions(),
@@ -48,7 +60,16 @@ export function useExploreShare(params: {
     setShowShareLink(false);
     setCopied(false);
     setError(null);
+    setMintedToken(null);
   }, [params.conversationId]);
+
+  // Drop the bridge as soon as the query catches up, so the persisted value is
+  // the only thing keeping the link alive from then on.
+  useEffect(() => {
+    setMintedToken((minted) =>
+      mintedAfterPersisted({ minted, persisted: params.shareToken }),
+    );
+  }, [params.shareToken]);
 
   const refresh = useCallback(
     async (conversationId: string): Promise<void> => {
@@ -90,6 +111,7 @@ export function useExploreShare(params: {
           }
         }
         setCopied(didCopy);
+        setMintedToken(result.shareToken);
         setShowShareLink(true);
         await refresh(conversationId);
       } catch (shareError) {
@@ -111,6 +133,7 @@ export function useExploreShare(params: {
         await revokeMutation.mutateAsync({ conversationId });
         setShowShareLink(false);
         setCopied(false);
+        setMintedToken(null);
         await refresh(conversationId);
       } catch (revokeError) {
         setError(
@@ -123,10 +146,10 @@ export function useExploreShare(params: {
   }, [params.conversationId, refresh, revokeMutation]);
 
   return {
-    shareLink:
-      params.shareToken === null
-        ? null
-        : `${globalThis.location.origin}/app/explore/s/${params.shareToken}`,
+    shareLink: exploreShareLink(
+      globalThis.location.origin,
+      resolveShareToken({ persisted: params.shareToken, minted: mintedToken }),
+    ),
     showShareLink,
     copied,
     sharing: shareMutation.isPending,

--- a/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn.ts
@@ -162,6 +162,16 @@ export function useExploreTurn(params: {
           },
           signal: controller.signal,
           onEvent: (event) => {
+            // The same ownership question the finally block asks, and for the
+            // same reason. `abortForNavigation` clears `turnRef` synchronously,
+            // so a newer turn can be underway while this stream is still
+            // draining: one `reader.read()` can carry several SSE blocks and
+            // dispatches them with no abort checkpoint between them. Without
+            // this, those leftovers edit the new turn's state and can announce
+            // the abandoned run's conversation.
+            if (readSeq(seqRef) !== seq) {
+              return;
+            }
             const current = turnRef.current;
             if (current === null) {
               return;

--- a/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn.ts
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type {
+  ExploreAttachPoint,
+  ExploreTranscript,
+} from "@scout-for-lol/data";
+import { streamExploreTurn } from "#src/lib/explore-stream.ts";
+import {
+  applyStreamEvent,
+  createPendingTurn,
+  markStopping,
+  turnHasLanded,
+  type ExplorePendingTurn,
+} from "#src/lib/explore-turn-state.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+/**
+ * Read the ref through a function boundary: inside `runTurn`, control-flow
+ * narrowing pins `turnRef.current` to the `null` the early-return guard saw,
+ * but stream events reassign it between the guard and the catch/finally.
+ */
+function readTurn(ref: {
+  current: ExplorePendingTurn | null;
+}): ExplorePendingTurn | null {
+  return ref.current;
+}
+
+/** Same narrowing-defeat as {@link readTurn}, for the run-sequence counter. */
+function readSeq(ref: { current: number }): number {
+  return ref.current;
+}
+
+/**
+ * Owns one in-flight explore turn: the streaming request, the pending-turn
+ * state the transcript renders from, and the teardown that keeps the answer
+ * on screen until the persisted transcript actually contains it.
+ *
+ * The decisions live in `explore-turn-state.ts` as pure functions; this hook
+ * only drives the network and applies them.
+ */
+export function useExploreTurn(params: {
+  conversationId: string | null;
+  /** Fired on the stream's `started` event for a brand-new conversation. */
+  onConversationStarted: (conversationId: string) => void;
+  /** Refill the composer when a turn fails before its question persisted. */
+  restoreQuestion: (text: string) => void;
+}): {
+  pendingTurn: ExplorePendingTurn | null;
+  error: string | null;
+  clearError: () => void;
+  runTurn: (input: {
+    question: string | null;
+    attach: ExploreAttachPoint;
+    displayQuestion: string | null;
+    leafIdAtStart: string | null;
+  }) => Promise<void>;
+  stop: () => void;
+  abortForNavigation: () => void;
+} {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [pendingTurn, setPendingTurn] = useState<ExplorePendingTurn | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  // A synchronous mirror of `pendingTurn`: stream events arrive faster than
+  // React state settles, and the reducer must fold each event into the result
+  // of the previous one, not into a stale render's snapshot.
+  const turnRef = useRef<ExplorePendingTurn | null>(null);
+  const seqRef = useRef(0);
+
+  const applyTurn = useCallback((turn: ExplorePendingTurn | null): void => {
+    turnRef.current = turn;
+    setPendingTurn(turn);
+  }, []);
+
+  const refreshList = useCallback(async (): Promise<void> => {
+    await queryClient.invalidateQueries({
+      queryKey: trpc.explore.list.queryKey(),
+    });
+  }, [queryClient, trpc.explore.list]);
+
+  const refreshConversation = useCallback(
+    async (conversationId: string): Promise<void> => {
+      await queryClient.invalidateQueries({
+        queryKey: trpc.explore.get.queryKey({ conversationId }),
+      });
+      await refreshList();
+    },
+    [queryClient, refreshList, trpc.explore.get],
+  );
+
+  const cachedMessages = useCallback(
+    (conversationId: string) => {
+      const transcript: ExploreTranscript | undefined =
+        queryClient.getQueryData(trpc.explore.get.queryKey({ conversationId }));
+      return transcript?.messages ?? [];
+    },
+    [queryClient, trpc.explore.get],
+  );
+
+  /**
+   * A stop aborts the HTTP request, so the server's salvage write races the
+   * refetch. Poll a couple of times, bounded (~2.1s): a salvage slower than
+   * that shows up on the next natural refetch instead.
+   */
+  const awaitSalvage = useCallback(
+    async (turn: ExplorePendingTurn): Promise<void> => {
+      const conversationId = turn.conversationId;
+      if (conversationId === null || turn.questionMessageId === null) {
+        return;
+      }
+      applyTurn(markStopping(turn));
+      const delays = [0, 600, 1500];
+      for (const delay of delays) {
+        if (delay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+        await refreshConversation(conversationId);
+        if (turnHasLanded(turn, cachedMessages(conversationId))) {
+          return;
+        }
+      }
+    },
+    [applyTurn, cachedMessages, refreshConversation],
+  );
+
+  const runTurn = useCallback(
+    async (input: {
+      question: string | null;
+      attach: ExploreAttachPoint;
+      displayQuestion: string | null;
+      leafIdAtStart: string | null;
+    }): Promise<void> => {
+      if (turnRef.current !== null) {
+        return;
+      }
+      // Identifies this run: after `abortForNavigation`, a newer turn may
+      // already own the refs by the time this one's finally block fires, and
+      // tearing down the newer turn's state would kill it mid-stream.
+      const seq = seqRef.current + 1;
+      seqRef.current = seq;
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setError(null);
+      applyTurn(
+        createPendingTurn({
+          conversationId: params.conversationId,
+          question: input.displayQuestion,
+          leafIdAtStart: input.leafIdAtStart,
+        }),
+      );
+
+      try {
+        await streamExploreTurn({
+          input: {
+            conversationId: params.conversationId,
+            question: input.question,
+            attach: input.attach,
+          },
+          signal: controller.signal,
+          onEvent: (event) => {
+            const current = turnRef.current;
+            if (current === null) {
+              return;
+            }
+            if (event.type === "error") {
+              setError(event.message);
+              return;
+            }
+            const next = applyStreamEvent(current, event);
+            if (event.type === "started" && current.conversationId === null) {
+              params.onConversationStarted(event.conversationId);
+            }
+            applyTurn(next);
+          },
+        });
+      } catch (streamError) {
+        if (!controller.signal.aborted) {
+          setError(
+            streamError instanceof Error
+              ? streamError.message
+              : String(streamError),
+          );
+          // The question never reached the server, so it exists nowhere but
+          // here — hand it back. Once `started` arrived it is persisted, and
+          // restoring it would duplicate it.
+          const failed = readTurn(turnRef);
+          if (failed?.questionMessageId === null && input.question !== null) {
+            params.restoreQuestion(input.question);
+          }
+        }
+      } finally {
+        // Only tear down what this run still owns — see `seq` above.
+        if (readSeq(seqRef) === seq) {
+          abortRef.current = null;
+          // Null here also means `abortForNavigation` abandoned the turn —
+          // its conversation left the screen, so no salvage catch-up either.
+          const turn = readTurn(turnRef);
+          if (turn !== null) {
+            if (controller.signal.aborted) {
+              await awaitSalvage(turn);
+            } else if (turn.conversationId !== null) {
+              // Refetch before clearing, so there is no frame where the
+              // answer is neither pending nor fetched.
+              await refreshConversation(turn.conversationId);
+            }
+          }
+          applyTurn(null);
+        }
+      }
+    },
+    [applyTurn, awaitSalvage, params, refreshConversation],
+  );
+
+  const stop = useCallback((): void => {
+    abortRef.current?.abort();
+  }, []);
+
+  /**
+   * Abandon the turn because its conversation is leaving the screen — a
+   * sidebar switch, "new conversation", or deleting the streaming
+   * conversation. Aborting (rather than letting it run in the background) is
+   * deliberate: the backend allows one active run per user, so a backgrounded
+   * run would silently block the next question. The server salvages what was
+   * streamed; one delayed refresh makes it visible if the user returns.
+   */
+  const abortForNavigation = useCallback((): void => {
+    const turn = turnRef.current;
+    if (turn === null) {
+      return;
+    }
+    abortRef.current?.abort();
+    applyTurn(null);
+    const conversationId = turn.conversationId;
+    if (conversationId !== null) {
+      setTimeout(() => {
+        void refreshConversation(conversationId);
+      }, 1000);
+    }
+  }, [applyTurn, refreshConversation]);
+
+  // Abandon an in-flight turn if the page unmounts.
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    [],
+  );
+
+  const clearError = useCallback((): void => {
+    setError(null);
+  }, []);
+
+  return { pendingTurn, error, clearError, runTurn, stop, abortForNavigation };
+}

--- a/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn.ts
@@ -9,6 +9,7 @@ import {
   applyStreamEvent,
   createPendingTurn,
   markStopping,
+  salvageRefreshDelays,
   turnHasLanded,
   type ExplorePendingTurn,
 } from "#src/lib/explore-turn-state.ts";
@@ -102,17 +103,17 @@ export function useExploreTurn(params: {
 
   /**
    * A stop aborts the HTTP request, so the server's salvage write races the
-   * refetch. Poll a couple of times, bounded (~2.1s): a salvage slower than
-   * that shows up on the next natural refetch instead.
+   * refetch. `salvageRefreshDelays` decides how many reads this stop needs and
+   * whether it needs any at all.
    */
   const awaitSalvage = useCallback(
     async (turn: ExplorePendingTurn): Promise<void> => {
-      const conversationId = turn.conversationId;
-      if (conversationId === null || turn.questionMessageId === null) {
+      const plan = salvageRefreshDelays(turn);
+      if (plan === null) {
         return;
       }
+      const { conversationId, delays } = plan;
       applyTurn(markStopping(turn));
-      const delays = [0, 600, 1500];
       for (const delay of delays) {
         if (delay > 0) {
           await new Promise((resolve) => setTimeout(resolve, delay));

--- a/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+
+/**
+ * Follow the bottom of the page only while the reader is already there.
+ *
+ * The page body is the scroll container — RootLayout stacks min-h-screen flex
+ * columns with no overflow of their own — so pinning is measured against the
+ * window. A reader who scrolls up to re-read is never yanked back down by the
+ * next streamed token; scrolling back to the bottom re-pins.
+ */
+export function usePinnedScroll(): {
+  bottomRef: RefObject<HTMLDivElement | null>;
+  scrollIfPinned: () => void;
+} {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const pinnedRef = useRef(true);
+
+  useEffect(() => {
+    const onScroll = (): void => {
+      pinnedRef.current =
+        window.innerHeight + window.scrollY >=
+        document.documentElement.scrollHeight - 120;
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  const scrollIfPinned = useCallback((): void => {
+    if (pinnedRef.current) {
+      // `auto`, not `smooth`: per-token smooth scrolling restarts the
+      // animation on every delta and janks the whole stream.
+      bottomRef.current?.scrollIntoView({ block: "end" });
+    }
+  }, []);
+
+  return { bottomRef, scrollIfPinned };
+}

--- a/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-pinned-scroll.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, type RefObject } from "react";
+import { isScrolledToBottom } from "#src/lib/pinned-scroll.ts";
 
 /**
  * Follow the bottom of the page only while the reader is already there.
@@ -13,17 +14,25 @@ export function usePinnedScroll(): {
   scrollIfPinned: () => void;
 } {
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  // Optimistic only until the effect below measures; a reader who mounted
+  // part-way up is un-pinned before anything can scroll them.
   const pinnedRef = useRef(true);
 
   useEffect(() => {
-    const onScroll = (): void => {
-      pinnedRef.current =
-        window.innerHeight + window.scrollY >=
-        document.documentElement.scrollHeight - 120;
+    const measure = (): void => {
+      pinnedRef.current = isScrolledToBottom({
+        innerHeight: window.innerHeight,
+        scrollY: window.scrollY,
+        scrollHeight: document.documentElement.scrollHeight,
+      });
     };
-    window.addEventListener("scroll", onScroll, { passive: true });
+    // Measure once on mount: the ref's initial value is a guess, and a scroll
+    // event may never come. Browser scroll restoration and links into the
+    // middle of a conversation both land here already scrolled away.
+    measure();
+    window.addEventListener("scroll", measure, { passive: true });
     return () => {
-      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("scroll", measure);
     };
   }, []);
 

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
@@ -175,6 +175,21 @@ describe("normalizePath", () => {
     expect(normalizePath("/login")).toBe("/login");
     expect(normalizePath("/something/private")).toBe("/not-found");
   });
+
+  test("templates explore conversation ids", () => {
+    expect(normalizePath("/explore")).toBe("/explore");
+    expect(normalizePath("/explore/1b4e28ba-2fa1-41d2-883f-0016d3cca427")).toBe(
+      "/explore/:conversationId",
+    );
+  });
+
+  test("never lets a share token reach PostHog", () => {
+    // The token is the share credential; only the template may leave the app.
+    expect(normalizePath("/explore/s/8fb2f83f6a4e4f0f9d9c1c2d3e4f5a6b")).toBe(
+      "/explore/s/:shareToken",
+    );
+    expect(normalizePath("/explore/s")).toBe("/not-found");
+  });
 });
 
 describe("privacy settings", () => {

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.ts
@@ -441,9 +441,14 @@ export function normalizePath(pathname: string): string {
     .replace(
       /\/reports\/(?!new(?:\/|$)|help(?:\/|$))[^/]+/,
       "/reports/:reportId",
-    );
+    )
+    // Share token first, so the conversation rule's lookahead then sees the
+    // already-templated `s` segment. The token is the share credential — it
+    // is templated away before anything reaches PostHog.
+    .replace(/^\/explore\/s\/[^/]+/, "/explore/s/:shareToken")
+    .replace(/^\/explore\/(?!s(?:\/|$))[^/]+/, "/explore/:conversationId");
   const knownRoute =
-    /^(?:\/|\/(?:login|welcome|installed)|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
+    /^(?:\/|\/(?:login|welcome|installed)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
   return knownRoute.test(normalized) ? normalized : "/not-found";
 }
 

--- a/packages/scout-for-lol/packages/app/src/lib/explore-export.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-export.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { ExploreMessageSchema, type ExploreMessage } from "@scout-for-lol/data";
+import {
+  conversationToMarkdown,
+  exportFilename,
+} from "#src/lib/explore-export.ts";
+
+const QUESTION_ID = "33333333-3333-4333-8333-333333333333";
+const ANSWER_ID = "44444444-4444-4444-8444-444444444444";
+
+function answerWithPreview(preview: unknown): ExploreMessage[] {
+  return [
+    ExploreMessageSchema.parse({
+      id: QUESTION_ID,
+      role: "user",
+      content: "Which champion wins most?",
+      createdAt: "2026-08-14T12:00:00.000Z",
+    }),
+    ExploreMessageSchema.parse({
+      id: ANSWER_ID,
+      role: "assistant",
+      parentId: QUESTION_ID,
+      content: "Jinx, narrowly.",
+      preview,
+      createdAt: "2026-08-14T12:00:30.000Z",
+    }),
+  ];
+}
+
+const PREVIEW = {
+  columns: [
+    { key: "label", label: "Player", format: "text" },
+    { key: "games", label: "Games", format: "integer" },
+    { key: "win_rate", label: "Win rate", format: "percent" },
+  ],
+  rows: [
+    {
+      label: "Faker",
+      values: [
+        { column: "games", value: 12 },
+        { column: "win_rate", value: 0.5833 },
+      ],
+    },
+  ],
+  rowsScanned: 12,
+  renderKind: "TABLE",
+};
+
+describe("conversationToMarkdown", () => {
+  test("heads the table with the preview's label column instead of a stray Row column", () => {
+    const markdown = conversationToMarkdown("Wins", answerWithPreview(PREVIEW));
+    expect(markdown).toContain("| Player | Games | Win rate |");
+    expect(markdown).not.toContain("| Row |");
+    // The label lands once, in the label column — not beside an empty cell.
+    expect(markdown).toContain("| Faker | 12 |");
+  });
+
+  test("formats metric values through the display formatter", () => {
+    const markdown = conversationToMarkdown("Wins", answerWithPreview(PREVIEW));
+    expect(markdown).toContain("58.3%");
+    expect(markdown).not.toContain("0.5833");
+  });
+
+  test("escapes pipes and flattens newlines in cells and headers", () => {
+    const preview = {
+      ...PREVIEW,
+      columns: [
+        { key: "label", label: "Riot ID", format: "text" },
+        { key: "games", label: "Games", format: "integer" },
+      ],
+      rows: [
+        {
+          label: "foo|bar\nbaz",
+          values: [{ column: "games", value: 3 }],
+        },
+      ],
+    };
+    const markdown = conversationToMarkdown("Wins", answerWithPreview(preview));
+    expect(markdown).toContain(String.raw`| foo\|bar baz | 3 |`);
+  });
+
+  test("collapses newlines in the title and question headings", () => {
+    const markdown = conversationToMarkdown(
+      "Two\nlines",
+      answerWithPreview(null),
+    );
+    expect(markdown.startsWith("# Two lines\n")).toBe(true);
+  });
+});
+
+describe("exportFilename", () => {
+  test("drops hyphens introduced by truncation", () => {
+    // 60 characters in, the cut lands on a separator.
+    const title = `${"a".repeat(59)} ${"b".repeat(20)}`;
+    expect(exportFilename(title).endsWith("-.md")).toBe(false);
+  });
+
+  test("falls back for symbol-only titles", () => {
+    expect(exportFilename("???")).toBe("conversation.md");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/explore-export.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-export.ts
@@ -1,3 +1,4 @@
+import { formatReportDisplayValue } from "@scout-for-lol/data";
 import type { ExploreMessage } from "@scout-for-lol/data";
 
 /**
@@ -11,14 +12,15 @@ export function conversationToMarkdown(
   title: string,
   messages: ExploreMessage[],
 ): string {
-  const lines: string[] = [`# ${title}`, ""];
+  const lines: string[] = [`# ${headingText(title)}`, ""];
 
   for (const message of messages) {
     if (message.role === "user") {
-      lines.push(`## ${message.content}`, "");
+      lines.push(`## ${headingText(message.content)}`, "");
       continue;
     }
 
+    // Assistant prose stays verbatim — it *is* markdown.
     lines.push(message.content, "");
 
     if (message.preview !== null && message.preview.rows.length > 0) {
@@ -35,17 +37,40 @@ export function conversationToMarkdown(
   return lines.join("\n").trimEnd() + "\n";
 }
 
+/** Markdown-table-safe cell text: `|` escaped, newlines flattened. */
+function escapeCell(value: string): string {
+  return value.replaceAll("|", String.raw`\|`).replaceAll(/\r?\n/g, " ");
+}
+
+/** Heading-safe text: newlines collapsed so a multi-line question stays one heading. */
+function headingText(value: string): string {
+  return value.replaceAll(/\s*\n\s*/g, " ").trim();
+}
+
+/**
+ * The preview's first column is the grouping dimension ("Player",
+ * "Champion"), whose per-row value lives in `row.label` rather than in
+ * `row.values` — so it heads the label cells instead of becoming a column of
+ * its own, and values render exactly as the on-screen table formats them.
+ */
 function previewTable(
   preview: NonNullable<ExploreMessage["preview"]>,
 ): string[] {
-  const headers = ["Row", ...preview.columns.map((column) => column.label)];
+  const [labelColumn, ...metricColumns] = preview.columns;
+  const headers = [
+    labelColumn?.label ?? "Row",
+    ...metricColumns.map((column) => column.label),
+  ].map((header) => escapeCell(header));
   const rows = preview.rows.map((row) => [
-    row.label,
-    ...preview.columns.map((column) =>
-      String(
-        row.values.find((value) => value.column === column.key)?.value ?? "",
-      ),
-    ),
+    escapeCell(row.label),
+    ...metricColumns.map((column) => {
+      const value = row.values.find(
+        (entry) => entry.column === column.key,
+      )?.value;
+      return value === undefined || value === null
+        ? ""
+        : escapeCell(formatReportDisplayValue(column, value));
+    }),
   ]);
   return [
     `| ${headers.join(" | ")} |`,
@@ -62,16 +87,24 @@ export function downloadMarkdown(filename: string, contents: string): void {
   const anchor = document.createElement("a");
   anchor.href = url;
   anchor.download = filename;
+  // In the document, not detached — some browsers ignore a synthetic click on
+  // a detached anchor — and the URL is revoked a tick later so revocation
+  // cannot race the browser's fetch of the blob.
+  document.body.append(anchor);
   anchor.click();
-  URL.revokeObjectURL(url);
+  anchor.remove();
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 0);
 }
 
 /** A filesystem-safe name derived from the conversation title. */
 export function exportFilename(title: string): string {
+  // Slice before stripping, so truncation cannot reintroduce an edge hyphen.
   const slug = title
     .toLowerCase()
     .replaceAll(/[^a-z0-9]+/g, "-")
-    .replaceAll(/^-|-$/g, "")
-    .slice(0, 60);
+    .slice(0, 60)
+    .replaceAll(/^-+|-+$/g, "");
   return `${slug.length > 0 ? slug : "conversation"}.md`;
 }

--- a/packages/scout-for-lol/packages/app/src/lib/explore-share-link.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-share-link.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  exploreShareLink,
+  mintedAfterPersisted,
+  resolveShareToken,
+} from "#src/lib/explore-share-link.ts";
+
+const ORIGIN = "https://scout-for-lol.com";
+const PERSISTED = "persisted-token";
+const MINTED = "minted-token";
+
+describe("resolveShareToken", () => {
+  test("shows the token the share just minted before the query reports it", () => {
+    // The regression: sharing invalidates the transcript query and reads the
+    // token back over the network. Deriving the link from the read-back alone
+    // renders nothing until that lands — and nothing at all if it fails, so a
+    // share that succeeded shows no link and no clipboard acknowledgement.
+    expect(resolveShareToken({ persisted: null, minted: MINTED })).toBe(MINTED);
+  });
+
+  test("prefers the persisted token once the query reports one", () => {
+    // Not cosmetic: the persisted value is what a revocation elsewhere clears,
+    // so it has to win wherever both exist.
+    expect(resolveShareToken({ persisted: PERSISTED, minted: MINTED })).toBe(
+      PERSISTED,
+    );
+  });
+
+  test("shows nothing when the conversation has never been shared", () => {
+    expect(resolveShareToken({ persisted: null, minted: null })).toBeNull();
+  });
+});
+
+describe("mintedAfterPersisted", () => {
+  test("drops the bridge once the query reports the token", () => {
+    expect(
+      mintedAfterPersisted({ minted: MINTED, persisted: PERSISTED }),
+    ).toBeNull();
+  });
+
+  test("keeps the bridge while the query still reports nothing", () => {
+    expect(mintedAfterPersisted({ minted: MINTED, persisted: null })).toBe(
+      MINTED,
+    );
+  });
+
+  // Together with the drop above, this is what stops the bridge outliving a
+  // revocation: by the time a share can be revoked the query has reported it,
+  // so the bridge is already gone and `persisted` turning null clears the link.
+  test("a revoked share leaves no link once the bridge has been dropped", () => {
+    const afterReadBack = mintedAfterPersisted({
+      minted: MINTED,
+      persisted: PERSISTED,
+    });
+    expect(
+      resolveShareToken({ persisted: null, minted: afterReadBack }),
+    ).toBeNull();
+  });
+});
+
+describe("exploreShareLink", () => {
+  test("builds the shared-conversation URL for a token", () => {
+    expect(exploreShareLink(ORIGIN, PERSISTED)).toBe(
+      `${ORIGIN}/app/explore/s/${PERSISTED}`,
+    );
+  });
+
+  test("has no link without a token", () => {
+    expect(exploreShareLink(ORIGIN, null)).toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/explore-share-link.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-share-link.ts
@@ -1,0 +1,48 @@
+/**
+ * Which share link the explore page shows, and how long a freshly minted token
+ * stands in for the persisted one.
+ *
+ * Sharing mints a token server-side, then invalidates the transcript query to
+ * read it back. Deriving the link from the read-back value alone means the link
+ * row cannot render until that round trip lands — and never renders if the
+ * refetch fails, leaving a share that genuinely succeeded with nothing on
+ * screen to show for it. The mutation already knows the token, so it bridges
+ * the gap.
+ *
+ * The bridge is deliberately short-lived: the persisted value wins whenever it
+ * exists, and the bridge is dropped the moment the query reports a token. That
+ * keeps the original property that a share revoked in another tab, a deleted
+ * conversation, or a switch away all clear the link through the query cache,
+ * with no stored copy to go stale.
+ */
+
+/** The token to render a link for, or null when there is nothing to show. */
+export function resolveShareToken(input: {
+  /** `conversation.shareToken` from the transcript query. Authoritative. */
+  persisted: string | null;
+  /** Minted by this session's share, awaiting read-back. */
+  minted: string | null;
+}): string | null {
+  return input.persisted ?? input.minted;
+}
+
+/**
+ * The bridge token after the query has reported `persisted`.
+ *
+ * Once the read-back arrives the bridge has done its job, and holding it any
+ * longer is what would let a later revocation leave a stale link on screen.
+ */
+export function mintedAfterPersisted(input: {
+  minted: string | null;
+  persisted: string | null;
+}): string | null {
+  return input.persisted === null ? input.minted : null;
+}
+
+/** The absolute share URL for a token. */
+export function exploreShareLink(
+  origin: string,
+  token: string | null,
+): string | null {
+  return token === null ? null : `${origin}/app/explore/s/${token}`;
+}

--- a/packages/scout-for-lol/packages/app/src/lib/explore-stream.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-stream.ts
@@ -1,5 +1,4 @@
 import {
-  ExploreHttpErrorSchema,
   ExploreStreamEventSchema,
   ExploreTranscriptSchema,
   ExploreTurnRequestSchema,
@@ -8,6 +7,7 @@ import {
   type ExploreTurnRequest,
 } from "@scout-for-lol/data";
 import { postEventStream } from "#src/lib/sse-stream.ts";
+import { httpErrorMessage } from "#src/lib/stream-http-error.ts";
 import { readCsrfCookie } from "#src/lib/trpc.ts";
 
 export async function streamExploreTurn(params: {
@@ -22,27 +22,10 @@ export async function streamExploreTurn(params: {
     csrfToken: readCsrfCookie(),
     parseEvent: (raw) => ExploreStreamEventSchema.parse(raw),
     onEvent: params.onEvent,
-    httpErrorMessage: (response, text) => exploreErrorMessage(response, text),
+    httpErrorMessage: (response, text) =>
+      httpErrorMessage(response, text, "Explore request failed"),
     corruptedMessage: "The answer stream was corrupted. Please try again.",
   });
-}
-
-function exploreErrorMessage(response: Response, text: string): string {
-  if (text.length === 0) {
-    return `Explore request failed (${response.status.toString()}).`;
-  }
-  try {
-    const raw: unknown = JSON.parse(text);
-    const parsed = ExploreHttpErrorSchema.safeParse(raw);
-    if (parsed.success) {
-      return parsed.data.error;
-    }
-  } catch (error) {
-    if (!(error instanceof SyntaxError)) {
-      throw error;
-    }
-  }
-  return text;
 }
 
 /**

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -4,6 +4,7 @@ import {
   applyStreamEvent,
   createPendingTurn,
   markStopping,
+  pendingTurnLeftTheScreen,
   salvageRefreshDelays,
   turnHasLanded,
   visiblePending,
@@ -238,5 +239,54 @@ describe("salvageRefreshDelays", () => {
     });
 
     expect(salvageRefreshDelays(turn)).toBeNull();
+  });
+});
+
+describe("pendingTurnLeftTheScreen", () => {
+  test("abandons a turn whose conversation is no longer routed to", () => {
+    // The regression: only two callbacks abandon a turn, and Back/Forward goes
+    // through neither — leaving a run holding the one active run per user.
+    expect(
+      pendingTurnLeftTheScreen({
+        pendingConversationId: CONVERSATION,
+        routeConversationId: OTHER_CONVERSATION,
+      }),
+    ).toBe(true);
+  });
+
+  test("abandons a turn when the route goes back to the list", () => {
+    expect(
+      pendingTurnLeftTheScreen({
+        pendingConversationId: CONVERSATION,
+        routeConversationId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps a turn on the conversation still on screen", () => {
+    expect(
+      pendingTurnLeftTheScreen({
+        pendingConversationId: CONVERSATION,
+        routeConversationId: CONVERSATION,
+      }),
+    ).toBe(false);
+  });
+
+  // The case that makes this a comparison rather than a plain inequality: a new
+  // conversation has no id until `started`, and the navigation that assigns one
+  // would otherwise look like navigating away from the turn itself.
+  test("never abandons a turn that has not been placed yet", () => {
+    expect(
+      pendingTurnLeftTheScreen({
+        pendingConversationId: null,
+        routeConversationId: CONVERSATION,
+      }),
+    ).toBe(false);
+    expect(
+      pendingTurnLeftTheScreen({
+        pendingConversationId: null,
+        routeConversationId: null,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -4,6 +4,7 @@ import {
   applyStreamEvent,
   createPendingTurn,
   markStopping,
+  salvageRefreshDelays,
   turnHasLanded,
   visiblePending,
 } from "#src/lib/explore-turn-state.ts";
@@ -182,5 +183,60 @@ describe("turnHasLanded", () => {
     expect(
       turnHasLanded(turn, [message({ id: QUESTION_ID, role: "user" })]),
     ).toBe(false);
+  });
+});
+
+describe("salvageRefreshDelays", () => {
+  test("still reads once when the stop beat the started event", () => {
+    // The regression. The server persists the question before it opens the
+    // stream, so a stop this early leaves that row on disk while the only copy
+    // on screen is the pending turn's, which is cleared as the turn ends.
+    // Skipping the read drops the question the user just asked.
+    const turn = createPendingTurn({
+      conversationId: CONVERSATION,
+      question: "Who wins?",
+      leafIdAtStart: null,
+    });
+
+    expect(turn.questionMessageId).toBeNull();
+    expect(salvageRefreshDelays(turn)).toEqual({
+      conversationId: CONVERSATION,
+      delays: [0],
+    });
+  });
+
+  test("polls a bounded few times once the turn has a question id", () => {
+    // Only then can a partial answer be mid-write, and only then can
+    // `turnHasLanded` judge whether it arrived.
+    const turn = applyStreamEvent(
+      createPendingTurn({
+        conversationId: CONVERSATION,
+        question: "Who wins?",
+        leafIdAtStart: null,
+      }),
+      {
+        type: "started",
+        runId: RUN_ID,
+        conversationId: CONVERSATION,
+        questionMessageId: QUESTION_ID,
+      },
+    );
+
+    expect(salvageRefreshDelays(turn)).toEqual({
+      conversationId: CONVERSATION,
+      delays: [0, 600, 1500],
+    });
+  });
+
+  test("reads nothing when the conversation was never created", () => {
+    // A brand-new conversation stopped before `started`: there is no id to
+    // query, so there is nothing to read rather than something being skipped.
+    const turn = createPendingTurn({
+      conversationId: null,
+      question: "Who wins?",
+      leafIdAtStart: null,
+    });
+
+    expect(salvageRefreshDelays(turn)).toBeNull();
   });
 });

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import { ExploreMessageSchema, type ExploreMessage } from "@scout-for-lol/data";
+import {
+  applyStreamEvent,
+  createPendingTurn,
+  markStopping,
+  turnHasLanded,
+  visiblePending,
+} from "#src/lib/explore-turn-state.ts";
+
+const CONVERSATION = "11111111-1111-4111-8111-111111111111";
+const OTHER_CONVERSATION = "22222222-2222-4222-8222-222222222222";
+const QUESTION_ID = "33333333-3333-4333-8333-333333333333";
+const ANSWER_ID = "44444444-4444-4444-8444-444444444444";
+const OLD_ANSWER_ID = "55555555-5555-4555-8555-555555555555";
+const RUN_ID = "66666666-6666-4666-8666-666666666666";
+
+function message(input: {
+  id: string;
+  role: "user" | "assistant";
+  parentId?: string | null;
+}): ExploreMessage {
+  return ExploreMessageSchema.parse({
+    id: input.id,
+    role: input.role,
+    parentId: input.parentId ?? null,
+    content: input.role === "user" ? "Who wins?" : "Jinx.",
+    createdAt: "2026-08-14T12:00:00.000Z",
+  });
+}
+
+function startedTurn(question: string | null = "Who wins?") {
+  return applyStreamEvent(
+    createPendingTurn({
+      conversationId: CONVERSATION,
+      question,
+      leafIdAtStart: null,
+    }),
+    {
+      type: "started",
+      runId: RUN_ID,
+      conversationId: CONVERSATION,
+      questionMessageId: QUESTION_ID,
+    },
+  );
+}
+
+describe("applyStreamEvent", () => {
+  test("started fills the conversation and question ids", () => {
+    const turn = createPendingTurn({
+      conversationId: null,
+      question: "Who wins?",
+      leafIdAtStart: null,
+    });
+    const after = applyStreamEvent(turn, {
+      type: "started",
+      runId: RUN_ID,
+      conversationId: CONVERSATION,
+      questionMessageId: QUESTION_ID,
+    });
+    expect(after.conversationId).toBe(CONVERSATION);
+    expect(after.questionMessageId).toBe(QUESTION_ID);
+  });
+
+  test("answer deltas accumulate in order", () => {
+    let turn = startedTurn();
+    turn = applyStreamEvent(turn, { type: "answer_delta", text: "Jinx " });
+    turn = applyStreamEvent(turn, { type: "answer_delta", text: "wins." });
+    expect(turn.answer).toBe("Jinx wins.");
+  });
+
+  test("final pins the persisted message and replaces the streamed text", () => {
+    let turn = startedTurn();
+    turn = applyStreamEvent(turn, { type: "answer_delta", text: "Jin" });
+    turn = applyStreamEvent(turn, {
+      type: "final",
+      message: message({
+        id: ANSWER_ID,
+        role: "assistant",
+        parentId: QUESTION_ID,
+      }),
+      title: "Who wins?",
+      quota: [],
+    });
+    expect(turn.finalMessageId).toBe(ANSWER_ID);
+    expect(turn.answer).toBe("Jinx.");
+    expect(turn.activity).toBeNull();
+  });
+});
+
+describe("visiblePending", () => {
+  test("hides everything for another conversation", () => {
+    const turn = startedTurn();
+    expect(visiblePending(turn, OTHER_CONVERSATION, [])).toEqual({
+      pendingQuestion: null,
+      pendingAnswer: null,
+      activity: null,
+    });
+  });
+
+  test("matches a not-yet-created conversation to the new view", () => {
+    const turn = createPendingTurn({
+      conversationId: null,
+      question: "Who wins?",
+      leafIdAtStart: null,
+    });
+    expect(visiblePending(turn, null, []).pendingQuestion).toBe("Who wins?");
+  });
+
+  test("drops the question once the transcript contains it", () => {
+    const turn = startedTurn();
+    const persisted = [message({ id: QUESTION_ID, role: "user" })];
+    const visible = visiblePending(turn, CONVERSATION, persisted);
+    expect(visible.pendingQuestion).toBeNull();
+    // The streamed answer still renders — only the question deduplicates.
+    expect(visible.activity).not.toBeNull();
+  });
+
+  test("drops the answer once the turn has landed", () => {
+    let turn = startedTurn();
+    turn = applyStreamEvent(turn, { type: "answer_delta", text: "Jinx." });
+    turn = applyStreamEvent(turn, {
+      type: "final",
+      message: message({
+        id: ANSWER_ID,
+        role: "assistant",
+        parentId: QUESTION_ID,
+      }),
+      title: "Who wins?",
+      quota: [],
+    });
+    const persisted = [
+      message({ id: QUESTION_ID, role: "user" }),
+      message({ id: ANSWER_ID, role: "assistant", parentId: QUESTION_ID }),
+    ];
+    expect(visiblePending(turn, CONVERSATION, persisted)).toEqual({
+      pendingQuestion: null,
+      pendingAnswer: null,
+      activity: null,
+    });
+  });
+});
+
+describe("turnHasLanded", () => {
+  test("sees a salvage row under the question", () => {
+    // A stop never gets `final`, so landing is recognised structurally.
+    const turn = markStopping(
+      applyStreamEvent(startedTurn(), { type: "answer_delta", text: "Jin" }),
+    );
+    const persisted = [
+      message({ id: QUESTION_ID, role: "user" }),
+      message({ id: ANSWER_ID, role: "assistant", parentId: QUESTION_ID }),
+    ];
+    expect(turnHasLanded(turn, persisted)).toBe(true);
+  });
+
+  test("ignores the pre-existing answer during a regenerate", () => {
+    // Regenerating starts with the old answer already on the path; that row
+    // must not read as the new turn having landed.
+    const started = applyStreamEvent(
+      createPendingTurn({
+        conversationId: CONVERSATION,
+        question: null,
+        leafIdAtStart: OLD_ANSWER_ID,
+      }),
+      {
+        type: "started",
+        runId: RUN_ID,
+        conversationId: CONVERSATION,
+        questionMessageId: QUESTION_ID,
+      },
+    );
+    const persisted = [
+      message({ id: QUESTION_ID, role: "user" }),
+      message({ id: OLD_ANSWER_ID, role: "assistant", parentId: QUESTION_ID }),
+    ];
+    expect(turnHasLanded(started, persisted)).toBe(false);
+  });
+
+  test("is false while only the question is persisted", () => {
+    const turn = startedTurn();
+    expect(
+      turnHasLanded(turn, [message({ id: QUESTION_ID, role: "user" })]),
+    ).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -1,0 +1,171 @@
+import type { ExploreMessage, ExploreStreamEvent } from "@scout-for-lol/data";
+
+/**
+ * Pure state for one in-flight explore turn.
+ *
+ * Everything the page needs to render a streaming turn — and to decide when
+ * the persisted transcript has caught up with it — lives here as plain data
+ * and pure functions, so the tricky decisions (which conversation the stream
+ * belongs to, when the optimistic copies disappear) are testable without a
+ * DOM. The hook that drives the network holds one of these and applies the
+ * reducers; it decides nothing itself.
+ */
+export type ExplorePendingTurn = {
+  /** Null until `started` arrives for a brand-new conversation. */
+  conversationId: string | null;
+  /** From the `started` event; null until it arrives. */
+  questionMessageId: string | null;
+  /** Optimistic question text; null for a regenerate. */
+  question: string | null;
+  /** Streamed prose so far; replaced by the final message's content. */
+  answer: string | null;
+  activity: string | null;
+  /**
+   * The on-screen leaf id when the turn began — how a stop tells a fresh
+   * salvage row apart from the answer that was already there.
+   */
+  leafIdAtStart: string | null;
+  /** The persisted answer's id once `final` arrives. */
+  finalMessageId: string | null;
+  phase: "streaming" | "stopping";
+};
+
+export function createPendingTurn(input: {
+  conversationId: string | null;
+  question: string | null;
+  leafIdAtStart: string | null;
+}): ExplorePendingTurn {
+  return {
+    conversationId: input.conversationId,
+    questionMessageId: null,
+    question: input.question,
+    answer: null,
+    activity: "Thinking…",
+    leafIdAtStart: input.leafIdAtStart,
+    finalMessageId: null,
+    phase: "streaming",
+  };
+}
+
+/**
+ * Fold one stream event into the turn.
+ *
+ * `final` replaces the streamed prose with the persisted message's content —
+ * the two can differ by whatever the last delta had not delivered yet, and
+ * the persisted text is what the refetch will show. `error` is deliberately
+ * not folded here: an error message is page state (it outlives the turn), so
+ * the hook handles it.
+ */
+export function applyStreamEvent(
+  turn: ExplorePendingTurn,
+  event: ExploreStreamEvent,
+): ExplorePendingTurn {
+  switch (event.type) {
+    case "started": {
+      return {
+        ...turn,
+        conversationId: event.conversationId,
+        questionMessageId: event.questionMessageId,
+      };
+    }
+    case "tool_call": {
+      return { ...turn, activity: event.message };
+    }
+    case "answer_delta": {
+      return { ...turn, answer: (turn.answer ?? "") + event.text };
+    }
+    case "final": {
+      return {
+        ...turn,
+        answer: event.message.content,
+        finalMessageId: event.message.id,
+        activity: null,
+      };
+    }
+    case "preview":
+    case "tool_result":
+    case "error":
+    case "done": {
+      return turn;
+    }
+  }
+}
+
+/** Mark a deliberate stop while the salvage catch-up runs. */
+export function markStopping(turn: ExplorePendingTurn): ExplorePendingTurn {
+  return {
+    ...turn,
+    phase: "stopping",
+    activity:
+      turn.answer === null ? null : "Stopped — saving the partial answer…",
+  };
+}
+
+/**
+ * Has the persisted transcript caught up with this turn?
+ *
+ * True once the refetched messages contain the `final` message, or — for a
+ * stop, which never gets a `final` — once the path ends in a fresh assistant
+ * answer under this turn's question. `leafIdAtStart` excludes the answer that
+ * was already on screen when a regenerate began; a persisted question with no
+ * answer under it is deliberately not enough.
+ */
+export function turnHasLanded(
+  turn: ExplorePendingTurn,
+  messages: ExploreMessage[],
+): boolean {
+  if (
+    turn.finalMessageId !== null &&
+    messages.some((message) => message.id === turn.finalMessageId)
+  ) {
+    return true;
+  }
+  const last = messages.at(-1);
+  return (
+    last?.role === "assistant" &&
+    turn.questionMessageId !== null &&
+    last.parentId === turn.questionMessageId &&
+    last.id !== turn.leafIdAtStart
+  );
+}
+
+/**
+ * What the transcript should render for this turn, given which conversation
+ * is on screen and what the persisted transcript already contains.
+ *
+ * All-null when the turn belongs to a different conversation — that is the
+ * whole fix for a stream bleeding into whichever conversation the user
+ * switched to. A null turn-conversation matches only the not-yet-created
+ * view (`displayedConversationId === null`), so a first turn renders while
+ * `started` is still in flight.
+ *
+ * The optimistic question disappears the moment the fetched messages contain
+ * it (the duplicate-first-question fix), and the streamed answer disappears
+ * once the turn has landed — so there is never a frame showing both copies,
+ * and never a frame showing neither.
+ */
+export function visiblePending(
+  turn: ExplorePendingTurn | null,
+  displayedConversationId: string | null,
+  messages: ExploreMessage[],
+): {
+  pendingQuestion: string | null;
+  pendingAnswer: string | null;
+  activity: string | null;
+} {
+  if (turn === null) {
+    return { pendingQuestion: null, pendingAnswer: null, activity: null };
+  }
+  if (turn.conversationId !== displayedConversationId) {
+    return { pendingQuestion: null, pendingAnswer: null, activity: null };
+  }
+  const questionPersisted =
+    turn.questionMessageId !== null &&
+    messages.some((message) => message.id === turn.questionMessageId);
+  const landed = turnHasLanded(turn, messages);
+  return {
+    pendingQuestion: questionPersisted ? null : turn.question,
+    pendingAnswer: landed ? null : turn.answer,
+    activity: landed ? null : turn.activity,
+  };
+}

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -111,6 +111,28 @@ export function markStopping(turn: ExplorePendingTurn): ExplorePendingTurn {
  * answer under it is deliberately not enough.
  */
 /**
+ * Whether the conversation a pending turn belongs to has left the screen.
+ *
+ * The two explicit callbacks that abandon a turn — picking another conversation
+ * and deleting this one — cannot see every way the route changes. Browser Back
+ * and Forward move it directly, and a run left going keeps holding the one
+ * active run the backend allows per user, blocking the next question.
+ *
+ * A turn whose conversation id is still null is never abandoned here: that is a
+ * brand-new conversation waiting for `started`, and the navigation that assigns
+ * its id would otherwise read as having navigated away from itself.
+ */
+export function pendingTurnLeftTheScreen(input: {
+  pendingConversationId: string | null;
+  routeConversationId: string | null;
+}): boolean {
+  return (
+    input.pendingConversationId !== null &&
+    input.pendingConversationId !== input.routeConversationId
+  );
+}
+
+/**
  * When to re-read the transcript after a stop, or null when there is nothing
  * to read: the conversation was never created, so no row exists to fetch.
  *

--- a/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-turn-state.ts
@@ -110,6 +110,34 @@ export function markStopping(turn: ExplorePendingTurn): ExplorePendingTurn {
  * was already on screen when a regenerate began; a persisted question with no
  * answer under it is deliberately not enough.
  */
+/**
+ * When to re-read the transcript after a stop, or null when there is nothing
+ * to read: the conversation was never created, so no row exists to fetch.
+ *
+ * A stop before `started` arrives still needs one read. The server persists the
+ * question before it opens the stream, so by the time a stop is possible that
+ * row exists — while the copy on screen is the pending turn's optimistic one,
+ * which is cleared the moment the turn ends. Skipping the read there drops the
+ * question the user just asked until some unrelated refetch happens to run.
+ *
+ * That case needs only the one read: nothing streamed, so there is no salvage
+ * write to race, and `turnHasLanded` cannot judge arrival without a question id
+ * anyway. Once `started` has arrived a partial answer may still be being
+ * written, so those stops keep the bounded poll (~2.1s) — a salvage slower than
+ * that shows up on the next natural refetch instead.
+ */
+export function salvageRefreshDelays(
+  turn: ExplorePendingTurn,
+): { conversationId: string; delays: number[] } | null {
+  if (turn.conversationId === null) {
+    return null;
+  }
+  return {
+    conversationId: turn.conversationId,
+    delays: turn.questionMessageId === null ? [0] : [0, 600, 1500],
+  };
+}
+
 export function turnHasLanded(
   turn: ExplorePendingTurn,
   messages: ExploreMessage[],

--- a/packages/scout-for-lol/packages/app/src/lib/pinned-scroll.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/pinned-scroll.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isScrolledToBottom,
+  PINNED_BOTTOM_SLACK_PX,
+} from "#src/lib/pinned-scroll.ts";
+
+const VIEWPORT = 800;
+const DOCUMENT = 5000;
+
+describe("isScrolledToBottom", () => {
+  test("a page mounted part-way up is not pinned", () => {
+    // The regression this exists for: the hook assumed pinned until a scroll
+    // event proved otherwise, so a restored scroll position or a link into the
+    // middle of a conversation was yanked to the bottom on the first token.
+    expect(
+      isScrolledToBottom({
+        innerHeight: VIEWPORT,
+        scrollY: 0,
+        scrollHeight: DOCUMENT,
+      }),
+    ).toBe(false);
+  });
+
+  test("a page scrolled to the bottom is pinned", () => {
+    expect(
+      isScrolledToBottom({
+        innerHeight: VIEWPORT,
+        scrollY: DOCUMENT - VIEWPORT,
+        scrollHeight: DOCUMENT,
+      }),
+    ).toBe(true);
+  });
+
+  test("within the slack still counts as the bottom", () => {
+    // Following a stream should survive the last line or two of new content
+    // arriving between the scroll event and the measurement.
+    expect(
+      isScrolledToBottom({
+        innerHeight: VIEWPORT,
+        scrollY: DOCUMENT - VIEWPORT - (PINNED_BOTTOM_SLACK_PX - 1),
+        scrollHeight: DOCUMENT,
+      }),
+    ).toBe(true);
+  });
+
+  test("just beyond the slack does not", () => {
+    expect(
+      isScrolledToBottom({
+        innerHeight: VIEWPORT,
+        scrollY: DOCUMENT - VIEWPORT - (PINNED_BOTTOM_SLACK_PX + 1),
+        scrollHeight: DOCUMENT,
+      }),
+    ).toBe(false);
+  });
+
+  test("a document shorter than the viewport is pinned", () => {
+    // A conversation with one short answer never scrolls; it must still follow.
+    expect(
+      isScrolledToBottom({
+        innerHeight: VIEWPORT,
+        scrollY: 0,
+        scrollHeight: 200,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/pinned-scroll.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/pinned-scroll.ts
@@ -1,0 +1,21 @@
+/**
+ * Whether the window is scrolled to (or near) the bottom of the document.
+ *
+ * The page body is the scroll container, so this is measured against the
+ * window rather than an element. Pulled out of the hook so the initial state
+ * and the scroll handler cannot answer it differently: assuming pinned on mount
+ * is what yanks a reader who landed part-way up a conversation — a restored
+ * scroll position, or a link into the middle of one — down to the bottom on the
+ * first streamed token, before they have scrolled at all.
+ */
+export const PINNED_BOTTOM_SLACK_PX = 120;
+
+export function isScrolledToBottom(input: {
+  innerHeight: number;
+  scrollY: number;
+  scrollHeight: number;
+  slackPx?: number;
+}): boolean {
+  const slack = input.slackPx ?? PINNED_BOTTOM_SLACK_PX;
+  return input.innerHeight + input.scrollY >= input.scrollHeight - slack;
+}

--- a/packages/scout-for-lol/packages/app/src/lib/report-ai-stream.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/report-ai-stream.ts
@@ -1,11 +1,11 @@
 import {
   ReportAiEditRequestSchema,
-  ReportAiHttpErrorSchema,
   ReportAiStreamEventSchema,
   type ReportAiEditRequest,
   type ReportAiStreamEvent,
 } from "@scout-for-lol/data";
 import { postEventStream } from "#src/lib/sse-stream.ts";
+import { httpErrorMessage } from "#src/lib/stream-http-error.ts";
 import { readCsrfCookie } from "#src/lib/trpc.ts";
 
 export async function streamReportAiEdit(params: {
@@ -24,30 +24,4 @@ export async function streamReportAiEdit(params: {
       httpErrorMessage(response, text, "AI report request failed"),
     corruptedMessage: "The AI report stream was corrupted. Please try again.",
   });
-}
-
-/**
- * Prefer the server's structured error message, falling back to the raw body
- * and then to the status code.
- */
-export function httpErrorMessage(
-  response: Response,
-  text: string,
-  fallbackPrefix: string,
-): string {
-  if (text.length === 0) {
-    return `${fallbackPrefix} (${response.status.toString()}).`;
-  }
-  try {
-    const raw: unknown = JSON.parse(text);
-    const parsed = ReportAiHttpErrorSchema.safeParse(raw);
-    if (parsed.success) {
-      return parsed.data.error;
-    }
-  } catch (error) {
-    if (!(error instanceof SyntaxError)) {
-      throw error;
-    }
-  }
-  return text;
 }

--- a/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
@@ -1,5 +1,9 @@
 import type { LoaderFunctionArgs } from "react-router";
-import { CompetitionIdSchema, ReportIdSchema } from "@scout-for-lol/data";
+import {
+  CompetitionIdSchema,
+  ExploreConversationIdSchema,
+  ReportIdSchema,
+} from "@scout-for-lol/data";
 import { queryClient } from "#src/lib/query-client.ts";
 import { trpcOptions } from "#src/lib/trpc-options.ts";
 import { STALE_TIME_SLOW_LIST } from "#src/lib/stale-times.ts";
@@ -125,6 +129,19 @@ export function reportDetailLoader({ params }: LoaderFunctionArgs): null {
   if (!parsed.success) return null;
   void queryClient.prefetchQuery(
     trpcOptions.report.get.queryOptions({ guildId, reportId: parsed.data }),
+  );
+  return null;
+}
+
+export function exploreLoader({ params }: LoaderFunctionArgs): null {
+  void queryClient.prefetchQuery(trpcOptions.explore.status.queryOptions());
+  void queryClient.prefetchQuery(trpcOptions.explore.list.queryOptions());
+  const { conversationId } = params;
+  if (conversationId === undefined) return null;
+  const parsed = ExploreConversationIdSchema.safeParse(conversationId);
+  if (!parsed.success) return null;
+  void queryClient.prefetchQuery(
+    trpcOptions.explore.get.queryOptions({ conversationId: parsed.data }),
   );
   return null;
 }

--- a/packages/scout-for-lol/packages/app/src/lib/route-params.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-params.ts
@@ -1,6 +1,10 @@
 import { useParams } from "react-router";
 import { z } from "zod";
-import { CompetitionIdSchema, ReportIdSchema } from "@scout-for-lol/data";
+import {
+  CompetitionIdSchema,
+  ExploreConversationIdSchema,
+  ReportIdSchema,
+} from "@scout-for-lol/data";
 
 /**
  * Zod schemas for the router-matched path params, plus hooks that
@@ -25,6 +29,11 @@ export const CompetitionParamsSchema = z.object({
 export const ReportParamsSchema = z.object({
   guildId: z.string().min(1),
   reportId: z.coerce.number().pipe(ReportIdSchema),
+});
+
+/** The segment is optional — `/explore` is the not-yet-created conversation. */
+export const ExploreParamsSchema = z.object({
+  conversationId: ExploreConversationIdSchema.optional(),
 });
 
 /**
@@ -66,4 +75,8 @@ export function useCompetitionParams(): z.infer<
 
 export function useReportParams(): z.infer<typeof ReportParamsSchema> {
   return parseRouteParams(ReportParamsSchema, useParams());
+}
+
+export function useExploreParams(): z.infer<typeof ExploreParamsSchema> {
+  return parseRouteParams(ExploreParamsSchema, useParams());
 }

--- a/packages/scout-for-lol/packages/app/src/lib/stream-http-error.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/stream-http-error.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+/**
+ * Both stream endpoints answer errors as `{ error, retryAfterSeconds, quota }`
+ * (`ReportAiHttpErrorSchema` / `ExploreHttpErrorSchema` — the same shape, each
+ * `.strict()` against its own quota snapshot type). Only `error` is read here,
+ * so the common field is parsed tolerantly instead of binding this helper to
+ * either strict schema — quota drift on one endpoint cannot break the other's
+ * error messages.
+ */
+const StreamHttpErrorBodySchema = z.looseObject({
+  error: z.string().trim().min(1),
+});
+
+/** A readable message from a non-OK streaming response. */
+export function httpErrorMessage(
+  response: Response,
+  text: string,
+  fallbackPrefix: string,
+): string {
+  if (text.length === 0) {
+    return `${fallbackPrefix} (${response.status.toString()}).`;
+  }
+  try {
+    const raw: unknown = JSON.parse(text);
+    const parsed = StreamHttpErrorBodySchema.safeParse(raw);
+    if (parsed.success) {
+      return parsed.data.error;
+    }
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      throw error;
+    }
+  }
+  return text;
+}

--- a/packages/scout-for-lol/packages/app/src/router.test.ts
+++ b/packages/scout-for-lol/packages/app/src/router.test.ts
@@ -13,6 +13,11 @@ const KNOWN_URLS = [
   "/",
   "/welcome",
   "/installed",
+  // The pair pins react-router's optional-segment support (`:conversationId?`)
+  // — if an upgrade drops it, these fail before any user hits a blank page.
+  "/explore",
+  "/explore/1b4e28ba-2fa1-41d2-883f-0016d3cca427",
+  "/explore/s/some-share-token",
   "/g/1/subscriptions",
   "/g/1/players",
   "/g/1/players/Alias",

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -31,6 +31,7 @@ import {
   auditLoader,
   competitionDetailLoader,
   competitionsLoader,
+  exploreLoader,
   guildLoader,
   playerDetailLoader,
   playersLoader,
@@ -167,7 +168,15 @@ export const routes: RouteObject[] = [
         errorElement: <RouteErrorPanel />,
         children: [
           { index: true, element: <GuildPicker /> },
-          { path: "explore", element: <Explore /> },
+          // One route with an optional segment, not two siblings: navigating
+          // `/explore` → `/explore/:id` when the stream's `started` event
+          // mints a conversation must not remount Explore mid-turn.
+          {
+            path: "explore/:conversationId?",
+            element: <Explore />,
+            loader: exploreLoader,
+            errorElement: <RouteErrorPanel />,
+          },
           { path: "welcome", element: <OnboardingWizard /> },
           { path: "installed", element: <InstallLanding /> },
           {

--- a/packages/scout-for-lol/packages/app/src/routes/explore-shared.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore-shared.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from "react-router";
 import type { ExploreTranscript as Transcript } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
 import { ExploreTranscript } from "#src/components/explore-transcript.tsx";
+import { SectionSkeleton } from "#src/components/section-skeleton.tsx";
 import { fetchSharedTranscript } from "#src/lib/explore-stream.ts";
 
 /**
@@ -67,7 +68,9 @@ export function ExploreShared() {
 
   if (transcript === null) {
     return (
-      <p className="p-6 text-sm text-muted-foreground">Loading conversation…</p>
+      <div className="p-6">
+        <SectionSkeleton />
+      </div>
     );
   }
 

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -20,7 +20,10 @@ import {
   downloadMarkdown,
   exportFilename,
 } from "#src/lib/explore-export.ts";
-import { visiblePending } from "#src/lib/explore-turn-state.ts";
+import {
+  pendingTurnLeftTheScreen,
+  visiblePending,
+} from "#src/lib/explore-turn-state.ts";
 import { useExploreParams } from "#src/lib/route-params.ts";
 import { useExploreShare } from "#src/hooks/use-explore-share.ts";
 import { useExploreTurn } from "#src/hooks/use-explore-turn.ts";
@@ -234,6 +237,22 @@ export function Explore() {
     conversationId,
     messages,
   );
+
+  // The backstop for every route change the explicit callbacks cannot see —
+  // Back and Forward above all, which move the param without passing through
+  // `openConversation` or `handleDelete`. Those callbacks stay: they abandon
+  // the turn synchronously before navigating, which is a frame earlier than a
+  // re-render can, and deleting a conversation must abort before the delete.
+  useEffect(() => {
+    if (
+      pendingTurnLeftTheScreen({
+        pendingConversationId: turn.pendingTurn?.conversationId ?? null,
+        routeConversationId: conversationId,
+      })
+    ) {
+      turn.abortForNavigation();
+    }
+  }, [conversationId, turn]);
 
   const { bottomRef, scrollIfPinned } = usePinnedScroll();
   useEffect(() => {

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -1,23 +1,30 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Square } from "lucide-react";
-import type {
-  ExploreConversation,
-  ExploreStreamEvent,
-} from "@scout-for-lol/data";
+import { useNavigate } from "react-router";
+import type { ExploreConversation, ExploreMessage } from "@scout-for-lol/data";
 import { Button } from "#src/components/ui/button.tsx";
-import { Textarea } from "#src/components/ui/textarea.tsx";
+import { ExploreComposer } from "#src/components/explore-composer.tsx";
 import { ExploreHeader } from "#src/components/explore-header.tsx";
+import { ExploreShareRow } from "#src/components/explore-share.tsx";
 import { ExploreSidebar } from "#src/components/explore-sidebar.tsx";
-import { ExploreTranscript } from "#src/components/explore-transcript.tsx";
+import {
+  ExploreTranscript,
+  type ExploreTranscriptActions,
+} from "#src/components/explore-transcript.tsx";
 import { ConfirmDeleteDialog } from "#src/components/confirm-delete-dialog.tsx";
+import { ForbiddenPanel } from "#src/components/forbidden-panel.tsx";
 import { RenameConversationDialog } from "#src/components/rename-conversation-dialog.tsx";
-import { streamExploreTurn } from "#src/lib/explore-stream.ts";
+import { SectionSkeleton } from "#src/components/section-skeleton.tsx";
 import {
   conversationToMarkdown,
   downloadMarkdown,
   exportFilename,
 } from "#src/lib/explore-export.ts";
+import { visiblePending } from "#src/lib/explore-turn-state.ts";
+import { useExploreParams } from "#src/lib/route-params.ts";
+import { useExploreShare } from "#src/hooks/use-explore-share.ts";
+import { useExploreTurn } from "#src/hooks/use-explore-turn.ts";
+import { usePinnedScroll } from "#src/hooks/use-pinned-scroll.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
 
 /**
@@ -25,27 +32,22 @@ import { useTRPC } from "#src/lib/trpc.ts";
  *
  * Turns stream over SSE while conversation management goes through tRPC, so
  * the transcript is authoritative on the server and this page only mirrors
- * it. After a turn finishes the conversation is refetched rather than patched
- * locally — the server owns ordering, ids, and which branch is current, and
- * duplicating that here is how a transcript drifts from what a share link
- * would show.
+ * it. The active conversation lives in the URL (`/explore/:conversationId`),
+ * so refresh, Back, and deep links keep their place; the in-flight turn's
+ * state lives in {@link useExploreTurn} and is keyed by conversation, so a
+ * stream never renders under a conversation it does not belong to.
  */
 export function Explore() {
+  const { conversationId: routeConversationId } = useExploreParams();
+  const conversationId = routeConversationId ?? null;
+  const navigate = useNavigate();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const [conversationId, setConversationId] = useState<string | null>(null);
-  const [question, setQuestion] = useState("");
-  const [pendingQuestion, setPendingQuestion] = useState<string | null>(null);
-  const [pendingAnswer, setPendingAnswer] = useState<string | null>(null);
-  const [activity, setActivity] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [shareLink, setShareLink] = useState<string | null>(null);
+  const [restoredDraft, setRestoredDraft] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [renaming, setRenaming] = useState<ExploreConversation | null>(null);
   const [deleting, setDeleting] = useState<ExploreConversation | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
-  const bottomRef = useRef<HTMLDivElement | null>(null);
-  const composerRef = useRef<HTMLTextAreaElement | null>(null);
 
   const {
     status,
@@ -57,166 +59,244 @@ export function Explore() {
     shared,
   } = useExploreConversation(conversationId);
 
-  const shareMutation = useMutation(trpc.explore.share.mutationOptions());
+  const turn = useExploreTurn({
+    conversationId,
+    onConversationStarted: (id) => {
+      // Replace, not push: the transient blank `/explore` should not be a
+      // Back stop in the middle of a conversation.
+      void navigate(`/explore/${id}`, { replace: true });
+    },
+    restoreQuestion: setRestoredDraft,
+  });
+
+  const share = useExploreShare({ conversationId, shareToken: shared });
+
+  const setLeafMutation = useMutation(trpc.explore.setLeaf.mutationOptions());
   const deleteMutation = useMutation(trpc.explore.delete.mutationOptions());
   const renameMutation = useMutation(trpc.explore.rename.mutationOptions());
-  const setLeafMutation = useMutation(trpc.explore.setLeaf.mutationOptions());
 
-  const refresh = useCallback(async () => {
+  const refreshList = useCallback(async (): Promise<void> => {
     await queryClient.invalidateQueries({
       queryKey: trpc.explore.list.queryKey(),
     });
-    await queryClient.invalidateQueries({
-      queryKey: trpc.explore.get.queryKey(),
-    });
-  }, [queryClient, trpc.explore.get, trpc.explore.list]);
+  }, [queryClient, trpc.explore.list]);
 
-  // Sharing is two steps that can each fail — mint the token, then hand the
-  // link to the clipboard, which a browser may refuse over permissions or not
-  // implement at all. The link is shown as soon as it exists, so a refused
-  // clipboard write costs the copy and not the share; failing silently would
-  // look exactly like a copy that worked.
-  const share = useCallback(
-    async (id: string) => {
-      setError(null);
-      try {
-        const result = await shareMutation.mutateAsync({ conversationId: id });
-        const link = `${globalThis.location.origin}/app/explore/s/${result.shareToken}`;
-        setShareLink(link);
-        await refresh();
-        await navigator.clipboard.writeText(link);
-      } catch (shareError) {
-        setError(
-          shareError instanceof Error ? shareError.message : String(shareError),
-        );
-      }
+  const refreshConversation = useCallback(
+    async (id: string): Promise<void> => {
+      await queryClient.invalidateQueries({
+        queryKey: trpc.explore.get.queryKey({ conversationId: id }),
+      });
+      await refreshList();
     },
-    [refresh, shareMutation],
-  );
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [transcript.data, pendingAnswer]);
-
-  // Grow the composer with its content instead of scrolling a fixed box.
-  useEffect(() => {
-    const textarea = composerRef.current;
-    if (textarea === null) {
-      return;
-    }
-    textarea.style.height = "auto";
-    textarea.style.height = `${String(Math.min(textarea.scrollHeight, 200))}px`;
-  }, [question]);
-
-  // Abandon an in-flight turn if the page unmounts.
-  useEffect(
-    () => () => {
-      abortRef.current?.abort();
-    },
-    [],
-  );
-
-  const runTurn = useCallback(
-    async (input: {
-      question: string | null;
-      parentMessageId: string | null;
-      displayQuestion: string | null;
-    }) => {
-      if (activity !== null) {
-        return;
-      }
-      const controller = new AbortController();
-      abortRef.current = controller;
-      setError(null);
-      setPendingQuestion(input.displayQuestion);
-      setPendingAnswer(null);
-      setActivity("Thinking…");
-
-      let answered: string | null = null;
-      try {
-        await streamExploreTurn({
-          input: {
-            conversationId,
-            question: input.question,
-            parentMessageId: input.parentMessageId,
-          },
-          signal: controller.signal,
-          onEvent: (event) => {
-            answered = applyStreamEvent(event, answered, {
-              setConversationId,
-              setActivity,
-              setPendingAnswer,
-              setError,
-            });
-          },
-        });
-      } catch (streamError) {
-        // A deliberate stop is not a failure — the server keeps whatever the
-        // answer had reached, so there is nothing to apologise for.
-        if (!controller.signal.aborted) {
-          setError(
-            streamError instanceof Error
-              ? streamError.message
-              : String(streamError),
-          );
-        }
-      } finally {
-        abortRef.current = null;
-        setActivity(null);
-        setPendingAnswer(null);
-        setPendingQuestion(null);
-        await refresh();
-      }
-    },
-    [activity, conversationId, refresh],
+    [queryClient, refreshList, trpc.explore.get],
   );
 
   const ask = useCallback(
     (text: string) => {
-      const trimmed = text.trim();
-      if (trimmed.length === 0) {
-        return;
-      }
-      setQuestion("");
-      void runTurn({
-        question: trimmed,
-        parentMessageId: null,
-        displayQuestion: trimmed,
+      setRestoredDraft(null);
+      void turn.runTurn({
+        question: text,
+        attach: { kind: "leaf" },
+        displayQuestion: text,
+        leafIdAtStart: messages.at(-1)?.id ?? null,
       });
     },
-    [runTurn],
+    [messages, turn],
   );
 
+  const handleEdit = useCallback(
+    (message: ExploreMessage, edited: string) => {
+      // Editing forks the question: a sibling under the same parent, or a
+      // new root when the edited question *is* the root — the fork a parent
+      // id cannot name, which is why `attach` exists.
+      void turn.runTurn({
+        question: edited,
+        attach:
+          message.parentId === null
+            ? { kind: "root" }
+            : { kind: "message", messageId: message.parentId },
+        displayQuestion: edited,
+        leafIdAtStart: messages.at(-1)?.id ?? null,
+      });
+    },
+    [messages, turn],
+  );
+
+  const handleRegenerate = useCallback(
+    (message: ExploreMessage) => {
+      // The parent of an answer is the question it belongs to.
+      if (message.parentId === null) {
+        return;
+      }
+      void turn.runTurn({
+        question: null,
+        attach: { kind: "message", messageId: message.parentId },
+        displayQuestion: null,
+        leafIdAtStart: messages.at(-1)?.id ?? null,
+      });
+    },
+    [messages, turn],
+  );
+
+  const handleSelectVersion = useCallback(
+    async (messageId: string): Promise<void> => {
+      if (conversationId === null) {
+        return;
+      }
+      setError(null);
+      try {
+        await setLeafMutation.mutateAsync({ conversationId, messageId });
+        await refreshConversation(conversationId);
+      } catch (mutationError) {
+        setError(errorText(mutationError));
+      }
+    },
+    [conversationId, refreshConversation, setLeafMutation],
+  );
+
+  const handleRename = useCallback(
+    async (conversation: ExploreConversation, nextTitle: string) => {
+      setError(null);
+      try {
+        await renameMutation.mutateAsync({
+          conversationId: conversation.id,
+          title: nextTitle,
+        });
+        // Close only on success — a stuck-open dialog with an error banner
+        // beats one that swallowed the failure.
+        setRenaming(null);
+        await refreshConversation(conversation.id);
+      } catch (mutationError) {
+        setError(errorText(mutationError));
+      }
+    },
+    [refreshConversation, renameMutation],
+  );
+
+  const handleDelete = useCallback(
+    async (conversation: ExploreConversation) => {
+      setError(null);
+      if (turn.pendingTurn?.conversationId === conversation.id) {
+        turn.abortForNavigation();
+      }
+      try {
+        await deleteMutation.mutateAsync({ conversationId: conversation.id });
+        setDeleting(null);
+        queryClient.removeQueries({
+          queryKey: trpc.explore.get.queryKey({
+            conversationId: conversation.id,
+          }),
+        });
+        if (conversation.id === conversationId) {
+          void navigate("/explore", { replace: true });
+        }
+        await refreshList();
+      } catch (mutationError) {
+        setError(errorText(mutationError));
+      }
+    },
+    [
+      conversationId,
+      deleteMutation,
+      navigate,
+      queryClient,
+      refreshList,
+      trpc.explore.get,
+      turn,
+    ],
+  );
+
+  const openConversation = useCallback(
+    (id: string | null) => {
+      if (turn.pendingTurn !== null) {
+        turn.abortForNavigation();
+      }
+      void navigate(id === null ? "/explore" : `/explore/${id}`);
+      setDrawerOpen(false);
+    },
+    [navigate, turn],
+  );
+
+  const transcriptActions = useMemo<ExploreTranscriptActions>(
+    () => ({
+      onFollowUp: ask,
+      onEdit: handleEdit,
+      onRegenerate: handleRegenerate,
+      onSelectVersion: (messageId) => {
+        void handleSelectVersion(messageId);
+      },
+    }),
+    [ask, handleEdit, handleRegenerate, handleSelectVersion],
+  );
+
+  const { pendingQuestion, pendingAnswer, activity } = visiblePending(
+    turn.pendingTurn,
+    conversationId,
+    messages,
+  );
+
+  const { bottomRef, scrollIfPinned } = usePinnedScroll();
+  useEffect(() => {
+    scrollIfPinned();
+  }, [transcript.data, pendingAnswer, activity, scrollIfPinned]);
+
   if (status.isLoading) {
-    return <p className="text-sm text-muted-foreground">Loading…</p>;
+    return <SectionSkeleton />;
+  }
+
+  if (status.isError) {
+    // A failed availability check is not a denial — say so, and offer the
+    // narrow retry (just this query) rather than a whole-page reload.
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-card p-8 text-center">
+        <h2 className="text-base font-semibold text-destructive">
+          Explore couldn&apos;t load
+        </h2>
+        <p className="mx-auto mt-2 max-w-sm text-sm text-muted-foreground">
+          Checking your access failed. You can try again — if it keeps
+          happening, reload the page.
+        </p>
+        <div className="mt-4 flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void status.refetch();
+            }}
+          >
+            Try again
+          </Button>
+        </div>
+      </div>
+    );
   }
 
   if (!enabled) {
     return (
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold tracking-tight">Explore</h2>
-        <p className="text-sm text-muted-foreground">
-          Explore is in a limited rollout and is not available on your account
-          yet.
-        </p>
-      </div>
+      <ForbiddenPanel
+        title="Explore isn't available yet"
+        message="Explore is in a limited rollout and is not available on your account yet."
+      />
     );
   }
+
+  const pageError = error ?? turn.error ?? share.error;
 
   const headerActions =
     conversationId !== null && messages.length > 0
       ? {
           shared: shared !== null,
+          sharing: share.sharing,
+          revoking: share.revoking,
           onExport: () => {
             downloadMarkdown(
               exportFilename(title),
               conversationToMarkdown(title, messages),
             );
           },
-          sharing: shareMutation.isPending,
-          onShare: () => {
-            void share(conversationId);
-          },
+          onShare: share.share,
+          onRevoke: share.revoke,
         }
       : undefined;
 
@@ -224,15 +304,9 @@ export function Explore() {
     <ExploreSidebar
       conversations={conversations.data ?? []}
       activeId={conversationId}
-      onSelect={(id) => {
-        setConversationId(id);
-        setShareLink(null);
-        setDrawerOpen(false);
-      }}
+      onSelect={openConversation}
       onNew={() => {
-        setConversationId(null);
-        setShareLink(null);
-        setDrawerOpen(false);
+        openConversation(null);
       }}
       onRename={setRenaming}
       onDelete={setDeleting}
@@ -284,138 +358,56 @@ export function Explore() {
           pendingQuestion={pendingQuestion}
           pendingAnswer={pendingAnswer}
           activity={activity}
-          onFollowUp={ask}
-          onEdit={(message, edited) => {
-            // Attach the new question beside the old one, so both survive.
-            void runTurn({
-              question: edited,
-              parentMessageId: message.parentId,
-              displayQuestion: edited,
-            });
-          }}
-          onRegenerate={(message) => {
-            // A null question means "answer this one again"; the parent of an
-            // answer is the question it belongs to.
-            void runTurn({
-              question: null,
-              parentMessageId: message.parentId,
-              displayQuestion: null,
-            });
-          }}
-          onSelectVersion={(messageId) => {
-            if (conversationId === null) {
-              return;
-            }
-            void (async () => {
-              await setLeafMutation.mutateAsync({ conversationId, messageId });
-              await refresh();
-            })();
-          }}
+          actions={transcriptActions}
         />
 
-        {error !== null && (
+        {pageError !== null && (
           <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm">
-            {error}
+            {pageError}
           </p>
         )}
 
-        {shareLink !== null && (
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
-            Share link
-            <input
-              readOnly
-              value={shareLink}
-              onFocus={(event) => {
-                event.target.select();
-              }}
-              className="min-w-0 flex-1 rounded-md border bg-muted px-2 py-1 font-mono text-xs"
-            />
-          </label>
+        {share.showShareLink && share.shareLink !== null && (
+          <ExploreShareRow shareLink={share.shareLink} copied={share.copied} />
         )}
 
         <div ref={bottomRef} />
 
-        <form
-          className="flex items-end gap-2"
-          onSubmit={(event) => {
-            event.preventDefault();
-            ask(question);
-          }}
-        >
-          <Textarea
-            ref={composerRef}
-            value={question}
-            rows={1}
-            className="max-h-[200px] min-h-[42px] resize-none"
-            onChange={(event) => {
-              setQuestion(event.target.value);
-            }}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                ask(question);
-              }
-            }}
-            placeholder="Ask a question about match data…"
-            disabled={activity !== null}
-          />
-          {activity === null ? (
-            <Button type="submit" disabled={question.trim().length === 0}>
-              Ask
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              variant="outline"
-              className="gap-1.5"
-              onClick={() => {
-                abortRef.current?.abort();
-              }}
-            >
-              <Square className="size-3.5" />
-              Stop
-            </Button>
-          )}
-        </form>
+        <ExploreComposer
+          active={turn.pendingTurn !== null}
+          restoredDraft={restoredDraft}
+          onAsk={ask}
+          onStop={turn.stop}
+        />
       </div>
 
       <RenameConversationDialog
         conversation={renaming}
+        pending={renameMutation.isPending}
         onClose={() => {
           setRenaming(null);
         }}
         onRename={(conversation, nextTitle) => {
-          void (async () => {
-            await renameMutation.mutateAsync({
-              conversationId: conversation.id,
-              title: nextTitle,
-            });
-            setRenaming(null);
-            await refresh();
-          })();
+          void handleRename(conversation, nextTitle);
         }}
       />
 
       <ConfirmDeleteDialog
         conversation={deleting}
+        pending={deleteMutation.isPending}
         onClose={() => {
           setDeleting(null);
         }}
         onConfirm={(conversation) => {
-          void (async () => {
-            await deleteMutation.mutateAsync({
-              conversationId: conversation.id,
-            });
-            if (conversation.id === conversationId) {
-              setConversationId(null);
-            }
-            setDeleting(null);
-            await refresh();
-          })();
+          void handleDelete(conversation);
         }}
       />
     </div>
   );
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /**
@@ -447,49 +439,6 @@ function useExploreConversation(conversationId: string | null) {
     title: transcript.data?.conversation.title ?? "Explore",
     shared: transcript.data?.conversation.shareToken ?? null,
   };
-}
-
-/**
- * Fold one stream event into page state, returning the answer text so far.
- *
- * Lifted out of the component so its switch does not count against the
- * route's complexity budget, and so the event handling reads on its own.
- */
-function applyStreamEvent(
-  event: ExploreStreamEvent,
-  answered: string | null,
-  setters: {
-    setConversationId: (id: string) => void;
-    setActivity: (message: string) => void;
-    setPendingAnswer: (text: string) => void;
-    setError: (message: string) => void;
-  },
-): string | null {
-  switch (event.type) {
-    case "started": {
-      setters.setConversationId(event.conversationId);
-      return answered;
-    }
-    case "tool_call": {
-      setters.setActivity(event.message);
-      return answered;
-    }
-    case "answer_delta": {
-      const next = (answered ?? "") + event.text;
-      setters.setPendingAnswer(next);
-      return next;
-    }
-    case "error": {
-      setters.setError(event.message);
-      return answered;
-    }
-    case "final":
-    case "preview":
-    case "tool_result":
-    case "done": {
-      return answered;
-    }
-  }
 }
 
 const EXAMPLES = [

--- a/packages/scout-for-lol/packages/backend/src/explore/http-route.e2e.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/http-route.e2e.test.ts
@@ -13,12 +13,15 @@ import { z } from "zod";
 import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
+  EXPLORE_INTERRUPTED_CAVEAT,
+  EXPLORE_STOPPED_CAVEAT,
 } from "@scout-for-lol/data";
 import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 
 const trpc = await createOfflineTrpcHarness("explore-http-e2e");
-const { handleExploreRoute } = await import("#src/explore/http-route.ts");
+const { handleExploreRoute, persistPartialAnswer } =
+  await import("#src/explore/http-route.ts");
 
 const allowedGuild = DiscordGuildIdSchema.parse("100000000000009401");
 const otherGuild = DiscordGuildIdSchema.parse("100000000000009402");
@@ -282,7 +285,6 @@ describe("explore turn accounting", () => {
         headers: await authedHeaders(),
         body: JSON.stringify({
           conversationId: conversation.id,
-          parentMessageId: null,
           question: "And by patch?",
         }),
       }),
@@ -319,7 +321,6 @@ describe("explore turn accounting", () => {
           // be a 400 at schema-parse time, before the ticket exists — a
           // different path that never risked the quota.
           conversationId: "00000000-0000-4000-8000-000000000000",
-          parentMessageId: null,
           question: "Who wins?",
         }),
       }),
@@ -335,6 +336,122 @@ describe("explore turn accounting", () => {
     );
     // And the concurrency slot came back too.
     expect(getExploreQuotaStatus({ userId: owner }).activeRun).toBe(false);
+  });
+
+  /**
+   * A regenerate must name the question to answer again. `attach` kinds other
+   * than `message` have no meaning without new question text, and letting one
+   * through would silently answer whatever the current leaf happens to be.
+   */
+  test("a regenerate that names no message is rejected as invalid", async () => {
+    resetExploreRateLimitStateForTests();
+    const conversation = await trpc.prisma.exploreConversation.create({
+      data: {
+        userId: owner,
+        title: "Champion win rates",
+        messages: { create: { role: "user", content: "Which champion wins?" } },
+      },
+    });
+    const before = getExploreQuotaStatus({ userId: owner }).quota;
+
+    const url = new URL("http://localhost/api/explore/stream");
+    const response = await handleExploreRoute(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: await authedHeaders(),
+        body: JSON.stringify({
+          conversationId: conversation.id,
+          question: null,
+          attach: { kind: "leaf" },
+        }),
+      }),
+      url,
+      cors,
+    );
+
+    expect(response?.status).toBe(400);
+    const body = ErrorBody.parse(await response?.json());
+    expect(body.error).toMatch(/existing question/i);
+
+    const after = getExploreQuotaStatus({ userId: owner }).quota;
+    expect(after.map((entry) => entry.remaining)).toEqual(
+      before.map((entry) => entry.remaining),
+    );
+    expect(getExploreQuotaStatus({ userId: owner }).activeRun).toBe(false);
+  });
+});
+
+describe("explore salvage", () => {
+  /** Seed a conversation with just its opening question, returning both ids. */
+  async function seedQuestion(): Promise<{
+    conversationId: string;
+    questionId: string;
+  }> {
+    const conversation = await trpc.prisma.exploreConversation.create({
+      data: {
+        userId: owner,
+        title: "Champion win rates",
+        messages: { create: { role: "user", content: "Which champion wins?" } },
+      },
+      include: { messages: true },
+    });
+    const question = conversation.messages[0];
+    if (question === undefined) {
+      throw new Error("expected the seeded question");
+    }
+    return { conversationId: conversation.id, questionId: question.id };
+  }
+
+  test("a stopped turn with text is saved with the stop caveat", async () => {
+    const seeded = await seedQuestion();
+    const salvaged = await persistPartialAnswer(trpc.prisma, {
+      aborted: true,
+      conversationId: seeded.conversationId,
+      parentMessageId: seeded.questionId,
+      text: "Jinx is ahead so far…",
+      trace: [],
+    });
+
+    expect(salvaged?.parentId).toBe(seeded.questionId);
+    expect(salvaged?.content).toBe("Jinx is ahead so far…");
+    expect(salvaged?.caveats).toEqual([EXPLORE_STOPPED_CAVEAT]);
+    expect(salvaged?.queryText).toBeNull();
+    expect(salvaged?.preview).toBeNull();
+    expect(salvaged?.visualization).toBeNull();
+  });
+
+  test("an errored turn with streamed text is saved with the interrupted caveat", async () => {
+    const seeded = await seedQuestion();
+    const salvaged = await persistPartialAnswer(trpc.prisma, {
+      aborted: false,
+      conversationId: seeded.conversationId,
+      parentMessageId: seeded.questionId,
+      text: "Jinx is ahead so far…",
+      trace: [],
+    });
+
+    expect(salvaged?.caveats).toEqual([EXPLORE_INTERRUPTED_CAVEAT]);
+    // The salvage row is on the path — the reader lands on it, not a bare
+    // question.
+    const conversation = await trpc.prisma.exploreConversation.findUnique({
+      where: { id: seeded.conversationId },
+      select: { currentLeafId: true },
+    });
+    expect(conversation?.currentLeafId).toBe(salvaged?.id ?? "");
+  });
+
+  test("an errored turn with no text saves nothing", async () => {
+    const seeded = await seedQuestion();
+    const salvaged = await persistPartialAnswer(trpc.prisma, {
+      aborted: false,
+      conversationId: seeded.conversationId,
+      parentMessageId: seeded.questionId,
+      text: "   ",
+      trace: [],
+    });
+
+    expect(salvaged).toBeNull();
+    expect(await trpc.prisma.exploreMessage.count()).toBe(1);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/explore/http-route.e2e.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/http-route.e2e.test.ts
@@ -381,27 +381,27 @@ describe("explore turn accounting", () => {
   });
 });
 
-describe("explore salvage", () => {
-  /** Seed a conversation with just its opening question, returning both ids. */
-  async function seedQuestion(): Promise<{
-    conversationId: string;
-    questionId: string;
-  }> {
-    const conversation = await trpc.prisma.exploreConversation.create({
-      data: {
-        userId: owner,
-        title: "Champion win rates",
-        messages: { create: { role: "user", content: "Which champion wins?" } },
-      },
-      include: { messages: true },
-    });
-    const question = conversation.messages[0];
-    if (question === undefined) {
-      throw new Error("expected the seeded question");
-    }
-    return { conversationId: conversation.id, questionId: question.id };
+/** Seed a conversation with just its opening question, returning both ids. */
+async function seedQuestion(): Promise<{
+  conversationId: string;
+  questionId: string;
+}> {
+  const conversation = await trpc.prisma.exploreConversation.create({
+    data: {
+      userId: owner,
+      title: "Champion win rates",
+      messages: { create: { role: "user", content: "Which champion wins?" } },
+    },
+    include: { messages: true },
+  });
+  const question = conversation.messages[0];
+  if (question === undefined) {
+    throw new Error("expected the seeded question");
   }
+  return { conversationId: conversation.id, questionId: question.id };
+}
 
+describe("explore salvage", () => {
   test("a stopped turn with text is saved with the stop caveat", async () => {
     const seeded = await seedQuestion();
     const salvaged = await persistPartialAnswer(trpc.prisma, {

--- a/packages/scout-for-lol/packages/backend/src/explore/http-route.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/http-route.ts
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/bun";
 import {
   EXPLORE_ANSWER_MAX_LENGTH,
+  EXPLORE_INTERRUPTED_CAVEAT,
   EXPLORE_REQUEST_MAX_BYTES,
+  EXPLORE_STOPPED_CAVEAT,
   EXPLORE_TIMEOUT_MS,
   ExploreHttpErrorSchema,
   ExploreShareTokenSchema,
@@ -14,7 +16,7 @@ import {
   type ExploreTraceEntry,
   type ExploreTurnRequest,
 } from "@scout-for-lol/data";
-import { prisma } from "#src/database/index.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { streamExploreAgent } from "#src/explore/agent.ts";
 import {
   getExploreQuotaStatus,
@@ -229,6 +231,7 @@ function runExploreTurnStream(input: {
     type: "started",
     runId: ticket.runId,
     conversationId: started.conversationId,
+    questionMessageId: started.messageId,
   });
 
   // Accumulated as the run goes so a stopped turn can still be saved, and
@@ -278,10 +281,20 @@ function runExploreTurnStream(input: {
       });
     } catch (error) {
       runStatus = abortController.signal.aborted ? "cancelled" : "error";
-      // A stopped turn keeps whatever it had already said. Discarding it
-      // would leave a question with no answer under it, which reads as a
-      // bug rather than as a deliberate stop.
+      // An interrupted turn keeps whatever it had already said — a deliberate
+      // stop and a mid-stream failure alike. Discarding the prose would leave
+      // a question with no answer under it, which reads as a bug rather than
+      // as an interruption.
       //
+      // A non-abort failure is a real error the client will only see as a
+      // caveat (salvage emits `final`, not `error`), so the detail goes to
+      // logs and Sentry here rather than vanishing entirely.
+      if (!abortController.signal.aborted) {
+        logger.error("Explore turn failed mid-stream", errorMessage(error));
+        Sentry.captureException(error, {
+          tags: { source: "explore-turn-run" },
+        });
+      }
       // Guarded on its own because this is a real database write inside a
       // catch block: a throw here would escape the catch, skip both terminal
       // events, and surface as an unhandled rejection from the voided async
@@ -290,7 +303,7 @@ function runExploreTurnStream(input: {
       // about what happened.
       let salvaged: ExploreMessage | null = null;
       try {
-        salvaged = await persistPartialAnswer({
+        salvaged = await persistPartialAnswer(prisma, {
           aborted: abortController.signal.aborted,
           conversationId: started.conversationId,
           parentMessageId: started.messageId,
@@ -381,9 +394,10 @@ async function handleSharedTranscript(
  * Work out which question this turn answers, creating it when the request
  * carries new text.
  *
- * `parentMessageId` is the attach point: null continues the branch on screen,
- * an existing question's parent forks a sibling (an edit), and the question
- * itself with no new text means answer it again (a regenerate).
+ * `attach` is the attach point: `leaf` continues the branch on screen,
+ * `message` forks a sibling under a named parent (an edit), `root` forks the
+ * opening question, and a named message with no new text means answer it
+ * again (a regenerate).
  */
 async function resolveTurnTarget(
   input: ExploreTurnRequest,
@@ -395,7 +409,7 @@ async function resolveTurnTarget(
   question: string;
 }> {
   if (input.question === null) {
-    if (input.conversationId === null || input.parentMessageId === null) {
+    if (input.conversationId === null || input.attach.kind !== "message") {
       throw new ExploreInvalidTurnError(
         "Answering again needs an existing question.",
       );
@@ -403,7 +417,7 @@ async function resolveTurnTarget(
     return await resolveRegenerateTarget(prisma, {
       conversationId: input.conversationId,
       userId: identity.userId,
-      parentMessageId: input.parentMessageId,
+      parentMessageId: input.attach.messageId,
     });
   }
 
@@ -411,35 +425,41 @@ async function resolveTurnTarget(
     conversationId: input.conversationId,
     userId: identity.userId,
     question: input.question,
-    parentMessageId: input.parentMessageId,
+    attach: input.attach,
   });
   return { ...started, question: input.question };
 }
 
 /**
- * Save what a stopped turn had already produced.
+ * Save what an interrupted turn had already produced — a deliberate stop or a
+ * mid-stream failure, distinguished only by the caveat.
  *
- * Only for a deliberate stop with text in hand: a turn that failed outright
- * has nothing worth keeping, and persisting an empty answer would just put a
- * blank bubble under the question.
+ * Only refuses when there is no text: persisting an empty answer would just
+ * put a blank bubble under the question. Exported with an explicit client so
+ * tests can drive the salvage semantics without streaming a turn.
  */
-async function persistPartialAnswer(input: {
-  aborted: boolean;
-  conversationId: string;
-  parentMessageId: string;
-  text: string;
-  trace: ExploreTraceEntry[];
-}): Promise<ExploreMessage | null> {
-  if (!input.aborted || input.text.trim().length === 0) {
+export async function persistPartialAnswer(
+  client: ExtendedPrismaClient,
+  input: {
+    aborted: boolean;
+    conversationId: string;
+    parentMessageId: string;
+    text: string;
+    trace: ExploreTraceEntry[];
+  },
+): Promise<ExploreMessage | null> {
+  if (input.text.trim().length === 0) {
     return null;
   }
-  return await appendExploreAnswer(prisma, {
+  return await appendExploreAnswer(client, {
     conversationId: input.conversationId,
     parentMessageId: input.parentMessageId,
     answer: {
       answer: clampAnswer(input.text),
       queryText: null,
-      caveats: ["This answer was stopped before it finished."],
+      caveats: [
+        input.aborted ? EXPLORE_STOPPED_CAVEAT : EXPLORE_INTERRUPTED_CAVEAT,
+      ],
       followUps: [],
     },
     preview: null,

--- a/packages/scout-for-lol/packages/backend/src/explore/store.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/store.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { createTestDatabase } from "#src/testing/test-database.ts";
-import type { DiscordAccountId } from "@scout-for-lol/data";
+import type { DiscordAccountId, ExploreAttachPoint } from "@scout-for-lol/data";
 import { testAccountId } from "#src/testing/test-ids.ts";
 import {
   ExploreInvalidTurnError,
@@ -54,7 +54,7 @@ const ANSWER = {
 async function askAndAnswer(input: {
   conversationId: string | null;
   question: string;
-  parentMessageId?: string | null;
+  attach?: ExploreAttachPoint;
   answer?: string;
 }): Promise<{
   conversationId: string;
@@ -65,7 +65,7 @@ async function askAndAnswer(input: {
     conversationId: input.conversationId,
     userId,
     question: input.question,
-    parentMessageId: input.parentMessageId ?? null,
+    attach: input.attach ?? { kind: "leaf" },
   });
   const answer = await appendExploreAnswer(prisma, {
     conversationId: started.conversationId,
@@ -111,7 +111,7 @@ describe("explore store", () => {
       conversationId: first.conversationId,
       userId,
       question: "And by patch?",
-      parentMessageId: null,
+      attach: { kind: "leaf" },
     });
 
     expect(await path(first.conversationId)).toEqual([
@@ -126,7 +126,7 @@ describe("explore store", () => {
       conversationId: null,
       userId,
       question: "Which champion has the most games?",
-      parentMessageId: null,
+      attach: { kind: "leaf" },
     });
     expect(started.title).toBe("Which champion has the most games?");
 
@@ -195,7 +195,7 @@ describe("explore store — branching", () => {
     const edited = await askAndAnswer({
       conversationId: first.conversationId,
       question: "And by queue?",
-      parentMessageId: first.answerId,
+      attach: { kind: "message", messageId: first.answerId },
       answer: "ARAM skews it hard.",
     });
 
@@ -235,6 +235,56 @@ describe("explore store — branching", () => {
       "It shifts toward Caitlyn.",
     ]);
     expect(edited.answerId).not.toBe(second.answerId);
+  });
+
+  test("editing the opening question forks a second root", async () => {
+    const first = await askAndAnswer({
+      conversationId: null,
+      question: "Which champion has the most games?",
+    });
+
+    // The root's parentId is null, so only `kind: "root"` can express this
+    // fork — a parent id cannot name "no parent".
+    const edited = await askAndAnswer({
+      conversationId: first.conversationId,
+      question: "Which champion has the most wins?",
+      attach: { kind: "root" },
+      answer: "Caitlyn, narrowly.",
+    });
+
+    // The edited branch is what you land on…
+    expect(await path(first.conversationId)).toEqual([
+      "Which champion has the most wins?",
+      "Caitlyn, narrowly.",
+    ]);
+    // …and nothing was destroyed to get there.
+    expect(await prisma.exploreMessage.count()).toBe(4);
+
+    // Both opening questions are root siblings with version arrows.
+    const transcript = await loadExploreTranscript(
+      prisma,
+      first.conversationId,
+      userId,
+    );
+    const root = transcript?.messages[0];
+    expect(root?.parentId).toBeNull();
+    expect(root?.versionCount).toBe(2);
+    expect(root?.versionIndex).toBe(1);
+    expect(root?.siblingIds).toEqual([first.questionId, edited.questionId]);
+
+    // Switching back restores the original opening branch in full.
+    expect(
+      await setExploreLeaf(
+        prisma,
+        first.conversationId,
+        userId,
+        first.questionId,
+      ),
+    ).toBe(true);
+    expect(await path(first.conversationId)).toEqual([
+      "Which champion has the most games?",
+      ANSWER.answer,
+    ]);
   });
 
   test("regenerating forks the answer, not the question", async () => {
@@ -319,7 +369,7 @@ describe("explore store — branching", () => {
     await askAndAnswer({
       conversationId: first.conversationId,
       question: "And by queue?",
-      parentMessageId: first.answerId,
+      attach: { kind: "message", messageId: first.answerId },
       answer: "ARAM skews it hard.",
     });
 
@@ -419,7 +469,7 @@ describe("explore store — ownership", () => {
         conversationId: first.conversationId,
         userId: otherUserId,
         question: "Sneaking in.",
-        parentMessageId: null,
+        attach: { kind: "leaf" },
       }),
     ).rejects.toBeInstanceOf(ExploreNotFoundError);
   });
@@ -439,7 +489,7 @@ describe("explore store — ownership", () => {
         conversationId: first.conversationId,
         userId,
         question: "Grafting on.",
-        parentMessageId: other.answerId,
+        attach: { kind: "message", messageId: other.answerId },
       }),
     ).rejects.toBeInstanceOf(ExploreNotFoundError);
   });

--- a/packages/scout-for-lol/packages/backend/src/explore/store.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/store.integration.test.ts
@@ -474,6 +474,30 @@ describe("explore store — ownership", () => {
     ).rejects.toBeInstanceOf(ExploreNotFoundError);
   });
 
+  test("a stale currentLeafId cannot become a parent", async () => {
+    // `deepestLeafFrom` returns the pointer unchanged when nothing descends
+    // from it, without checking it is a node at all, and `parentId` has no
+    // foreign key — so an unvalidated stale pointer is written silently and
+    // leaves the question hanging off an id no transcript walk reaches.
+    const first = await askAndAnswer({
+      conversationId: null,
+      question: "Which champion has the most games?",
+    });
+    await prisma.exploreConversation.update({
+      where: { id: first.conversationId },
+      data: { currentLeafId: "44444444-4444-4444-8444-444444444444" },
+    });
+
+    await expect(
+      startExploreTurn(prisma, {
+        conversationId: first.conversationId,
+        userId,
+        question: "Follow-up onto a pointer that is not in the tree.",
+        attach: { kind: "leaf" },
+      }),
+    ).rejects.toBeInstanceOf(ExploreNotFoundError);
+  });
+
   test("attaching to a message from another conversation is refused", async () => {
     const first = await askAndAnswer({
       conversationId: null,

--- a/packages/scout-for-lol/packages/backend/src/explore/store.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/store.integration.test.ts
@@ -474,11 +474,13 @@ describe("explore store — ownership", () => {
     ).rejects.toBeInstanceOf(ExploreNotFoundError);
   });
 
-  test("a stale currentLeafId cannot become a parent", async () => {
+  test("a stale currentLeafId is refused as a 404, not a database fault", async () => {
     // `deepestLeafFrom` returns the pointer unchanged when nothing descends
-    // from it, without checking it is a node at all, and `parentId` has no
-    // foreign key — so an unvalidated stale pointer is written silently and
-    // leaves the question hanging off an id no transcript walk reaches.
+    // from it, without checking it is a node at all. The foreign key on
+    // `parentId` refuses the write either way, so nothing is corrupted — but
+    // unguarded it arrives as a raw Prisma constraint violation, which this
+    // module does not classify and the route answers 500. Asserting the domain
+    // error is what pins it to the 404 a missing parent deserves.
     const first = await askAndAnswer({
       conversationId: null,
       question: "Which champion has the most games?",

--- a/packages/scout-for-lol/packages/backend/src/explore/store.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/store.ts
@@ -314,9 +314,15 @@ export async function startExploreTurn(
   // conversation. `message` names one directly. `leaf` resolves
   // `currentLeafId`, and `deepestLeafFrom` returns that pointer unchanged when
   // nothing descends from it — without checking it is a node at all — so a
-  // stale pointer resolves to itself. `parentId` carries no foreign key, so an
-  // unchecked one is written silently and leaves a message hanging off an id
-  // that is not in the tree, where no transcript walk will ever reach it.
+  // stale pointer resolves to itself.
+  //
+  // The tree is not at risk: `parentId` carries a real foreign key
+  // (`ExploreMessage_parentId_fkey`, with `PRAGMA foreign_keys=ON`), so the row
+  // is refused rather than written. What the check buys is the right error. An
+  // unguarded stale pointer raises a raw Prisma constraint violation, which is
+  // neither of the errors this module classifies, so the route's catch-all
+  // answers 500 — a fault on our side — for what is only a parent that does not
+  // exist. Checking here makes it the 404 it always was.
   //
   // Deliberately strict here and lenient in `buildTranscript`, which resolves
   // the same pointer for reading: a stale pointer should still render a

--- a/packages/scout-for-lol/packages/backend/src/explore/store.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/store.ts
@@ -8,6 +8,7 @@ import {
   VisualizationSnapshotSchema,
   type DiscordAccountId,
   type ExploreAnswer,
+  type ExploreAttachPoint,
   type ExploreConversation,
   type ExploreMessage,
   type ExploreTraceEntry,
@@ -261,9 +262,10 @@ export async function loadSharedExploreTranscript(
  * Written before the model runs so the question survives a failed or abandoned
  * turn — a conversation that loses what was asked is not resumable.
  *
- * `parentMessageId` decides whether this continues the conversation or forks
- * it: passing the parent of an existing question makes the new one a sibling,
- * which is how editing works.
+ * `attach` decides where the question lands: `leaf` continues the branch on
+ * screen, `message` forks a sibling under a named parent (how editing works),
+ * and `root` forks the opening question itself — the one fork a parent id
+ * cannot express, because the root's parent is null.
  */
 export async function startExploreTurn(
   prisma: ExtendedPrismaClient,
@@ -271,7 +273,7 @@ export async function startExploreTurn(
     conversationId: string | null;
     userId: DiscordAccountId;
     question: string;
-    parentMessageId: string | null;
+    attach: ExploreAttachPoint;
   },
 ): Promise<{ conversationId: string; title: string; messageId: string }> {
   if (input.conversationId === null) {
@@ -299,13 +301,19 @@ export async function startExploreTurn(
     throw new ExploreNotFoundError("Conversation not found.");
   }
 
+  // `root` forks the opening question (a new root sibling needs no ownership
+  // check — there is no parent to own); `message` must name a row in this
+  // conversation; `leaf` resolves from the conversation's own pointer.
   const parentId =
-    input.parentMessageId ??
-    deepestLeafFrom(existing.messages, existing.currentLeafId);
-  const parentBelongs =
-    parentId === null ||
-    existing.messages.some((message) => message.id === parentId);
-  if (!parentBelongs) {
+    input.attach.kind === "leaf"
+      ? deepestLeafFrom(existing.messages, existing.currentLeafId)
+      : input.attach.kind === "root"
+        ? null
+        : input.attach.messageId;
+  if (
+    input.attach.kind === "message" &&
+    !existing.messages.some((message) => message.id === parentId)
+  ) {
     throw new ExploreNotFoundError("Message not found.");
   }
 

--- a/packages/scout-for-lol/packages/backend/src/explore/store.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/store.ts
@@ -310,8 +310,19 @@ export async function startExploreTurn(
       : input.attach.kind === "root"
         ? null
         : input.attach.messageId;
+  // Whichever attach point produced it, a parent must be a row in THIS
+  // conversation. `message` names one directly. `leaf` resolves
+  // `currentLeafId`, and `deepestLeafFrom` returns that pointer unchanged when
+  // nothing descends from it — without checking it is a node at all — so a
+  // stale pointer resolves to itself. `parentId` carries no foreign key, so an
+  // unchecked one is written silently and leaves a message hanging off an id
+  // that is not in the tree, where no transcript walk will ever reach it.
+  //
+  // Deliberately strict here and lenient in `buildTranscript`, which resolves
+  // the same pointer for reading: a stale pointer should still render a
+  // conversation, but it must not be able to author into one.
   if (
-    input.attach.kind === "message" &&
+    parentId !== null &&
     !existing.messages.some((message) => message.id === parentId)
   ) {
     throw new ExploreNotFoundError("Message not found.");

--- a/packages/scout-for-lol/packages/data/src/model/explore.ts
+++ b/packages/scout-for-lol/packages/data/src/model/explore.ts
@@ -30,6 +30,13 @@ export const EXPLORE_TIMEOUT_MS = 180_000;
 export const EXPLORE_MAX_HISTORY_TURNS = 8;
 export const EXPLORE_TITLE_MAX_LENGTH = 120;
 
+/** Caveat written onto a turn the asker deliberately stopped. */
+export const EXPLORE_STOPPED_CAVEAT =
+  "This answer was stopped before it finished.";
+/** Caveat written onto a turn an error interrupted mid-stream. */
+export const EXPLORE_INTERRUPTED_CAVEAT =
+  "This answer was interrupted by an error before it finished.";
+
 export const ExploreConversationIdSchema = z.uuid();
 export type ExploreConversationId = z.infer<typeof ExploreConversationIdSchema>;
 
@@ -49,23 +56,44 @@ export const ExploreQuestionSchema = z
   .max(EXPLORE_QUESTION_MAX_LENGTH);
 
 /**
- * One request covers all three ways a turn starts.
+ * Where a turn attaches in the conversation tree.
  *
- * | Flow       | `question` | `parentMessageId`                 |
- * | ---------- | ---------- | --------------------------------- |
- * | Ask        | set        | null (attach at the current leaf)  |
- * | Edit       | set        | the edited message's parent        |
- * | Regenerate | null       | the user message to answer again   |
+ * - `leaf`: continue the branch on screen (the server resolves the current
+ *   leaf).
+ * - `root`: fork the opening question — a new sibling with no parent. Needed
+ *   because the root's parentId IS null, so "the edited message's parent"
+ *   cannot name it.
+ * - `message`: attach under a specific message — an edit names the edited
+ *   question's parent; a regenerate names the question to answer again.
+ */
+export const ExploreAttachPointSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("leaf") }).strict(),
+  z.object({ kind: z.literal("root") }).strict(),
+  z.object({ kind: z.literal("message"), messageId: z.uuid() }).strict(),
+]);
+
+export type ExploreAttachPoint = z.infer<typeof ExploreAttachPointSchema>;
+
+/**
+ * One request covers all four ways a turn starts.
  *
- * A null `question` means "answer this existing user turn again", so the
- * parent must be a user message; the server rejects anything else.
+ * | Flow            | `question` | `attach`                                    |
+ * | --------------- | ---------- | ------------------------------------------- |
+ * | Ask             | set        | { kind: "leaf" }                            |
+ * | Edit (non-root) | set        | { kind: "message", messageId: parent's id } |
+ * | Edit (root)     | set        | { kind: "root" }                            |
+ * | Regenerate      | null       | { kind: "message", messageId: question id } |
+ *
+ * A null `question` means "answer this existing user turn again", so `attach`
+ * must name a user message; the server rejects anything else. A null
+ * `conversationId` starts a new conversation and ignores `attach` entirely.
  */
 export const ExploreTurnRequestSchema = z
   .object({
     /** Null starts a new conversation; the server mints the id. */
     conversationId: ExploreConversationIdSchema.nullable().default(null),
     question: ExploreQuestionSchema.nullable().default(null),
-    parentMessageId: z.uuid().nullable().default(null),
+    attach: ExploreAttachPointSchema.default({ kind: "leaf" }),
   })
   .strict();
 
@@ -199,6 +227,13 @@ export const ExploreStreamEventSchema = z.discriminatedUnion("type", [
       type: z.literal("started"),
       runId: z.uuid(),
       conversationId: ExploreConversationIdSchema,
+      /**
+       * The user message this turn answers: the freshly persisted question
+       * for ask/edit, the existing question for a regenerate. Lets the client
+       * stop rendering its optimistic copy the moment a refetch contains this
+       * id, and recognise a salvaged partial answer after a stop.
+       */
+      questionMessageId: z.uuid(),
     })
     .strict(),
   z


### PR DESCRIPTION
## Why

A multi-angle code review of the Explore chat surface confirmed ten correctness findings plus missing chat-app table stakes. The worst cluster shared one root cause — turn teardown cleared optimistic state before the persisted transcript caught up — and the root-question edit fork was **impossible to express in the wire contract**: `parentMessageId: null` already meant "attach at the current leaf", and the root's parentId is null.

## What

**Contract (breaking, lockstep)**
- `ExploreTurnRequest` replaces `parentMessageId` with an `attach` discriminated union (`leaf` | `root` | `message`) — editing the opening question now forks a sibling root.
- `started` events carry `questionMessageId`, enabling exact duplicate-question suppression and stop catch-up detection.
- Stop/interrupt caveat constants live in `@scout-for-lol/data`.

**Backend**
- `persistPartialAnswer` salvages non-abort errors too (distinct "interrupted" caveat), refuses only empty text, and is exported with an explicit client as the test seam; the previously swallowed mid-stream error now logs and reaches Sentry.

**Turn lifecycle (app)**
- New pure `explore-turn-state.ts` (conversation-keyed pending turn, `turnHasLanded`/`visiblePending` predicates) + `use-explore-turn.ts` hook.
- Pending prose stays on screen until the refetched transcript contains the turn (no flash, no loss on error); Stop runs a bounded salvage catch-up; failed pre-start questions return to the composer; switching/deleting conversations aborts cleanly instead of rendering the stream under the wrong conversation; the first question no longer renders twice while a new conversation streams.

**Surface**
- `/explore/:conversationId?` routing (Zod params, non-blocking loader) — refresh/Back/deep links keep their place.
- Analytics: both explore routes join `normalizePath`'s closed allowlist; share tokens are templated before anything reaches PostHog; pageviews stop landing in `/not-found`.
- Share: link derived from the transcript's `shareToken`, clipboard write before invalidation round trips (Safari/Firefox activation), refused clipboard downgrades to a "copy manually" hint, and a revoke button fronts the existing `explore.revokeShare`.
- Composer: IME `isComposing` guard, Escape-to-stop, focus return, draft restore.
- Transcript: `role=log` + always-mounted `aria-live` region, memoized turns (deltas re-render one leaf), `ReportResultTable`/`Collapsible` reuse, assistant timestamps.
- Fixes: `status.isError` renders a retry panel instead of the rollout-denial copy; setLeaf/rename/delete handlers surface errors and wire `pending`; markdown export emits a correct escaped table with formatted values; pinned auto-scroll stops fighting readers; ECharts `setOption` instead of dispose/re-init; shared `httpErrorMessage` helper replaces two byte-identical copies.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/app`: data 639 pass, app 136 pass (26 new tests: turn-state reducer/visibility, export escaping/formatting, transcript SSR a11y, analytics/router registration), backend 1331 pass.
- New backend coverage: root-fork integration test, salvage caveat suite, regenerate-without-target rejection.
- 3 backend failures on the dev box (report-render S3 "Region is missing" ×2, one rate-limit flake) reproduce identically on a clean tree — pre-existing environment issues, not this branch.
- **Not yet run**: live `dev-web` end-to-end (needs `EXPLORE_GUILD_ALLOWLIST` + OAuth) and the demo GIF/screenshots — the authoring machine has no 1Password/Discord credentials. Both queued before this leaves draft.

## Rollout notes

- Breaking wire change: app + backend must deploy together (they do — stage deploys are lockstep). A browser tab left open across the deploy gets 400s on its next turn until reload; no dual-read shim by design.
- Salvage now persists possibly-mid-sentence prose on errors, flagged by the interrupted caveat — a deliberate trade against losing the answer entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)