### PR TITLE
fix(homelab): keep monitoring failures on independent email path

### DIFF
--- a/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
+++ b/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
@@ -262,6 +262,17 @@ describe("Alerts route selection", () => {
     ).toBe("postal-fallback");
   });
 
+  it("routes the cluster-wide webhook delivery-failure alert to Postal alongside its single-instance sibling", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "AlertmanagerClusterFailedToSendAlerts",
+        namespace: "prometheus",
+        severity: "critical",
+        integration: "webhook",
+      }),
+    ).toBe("postal-fallback");
+  });
+
   it("keeps email-integration delivery failures off the broken Postal path", () => {
     expect(
       resolveReceiver(route, {

--- a/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
+++ b/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
@@ -225,6 +225,30 @@ describe("Alerts route selection", () => {
         alert_dashboard_fallback: "true",
       }),
     ).toBe("postal-fallback");
+    expect(
+      resolveReceiver(route, {
+        alertname: "ServiceProbeDown",
+        namespace: "alert-dashboard",
+        severity: "warning",
+      }),
+    ).toBe("postal-fallback");
+  });
+
+  it("routes notification delivery health alerts to Postal", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "AlertmanagerFailedToSendAlerts",
+        namespace: "prometheus",
+        severity: "warning",
+      }),
+    ).toBe("postal-fallback");
+    expect(
+      resolveReceiver(route, {
+        alertname: "PrometheusErrorSendingAlertsToSomeAlertmanagers",
+        namespace: "prometheus",
+        severity: "warning",
+      }),
+    ).toBe("postal-fallback");
   });
 
   it("keeps Watchdog and info alerts suppressed", () => {

--- a/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
+++ b/packages/homelab/src/cdk8s/src/alertmanager-routing.test.ts
@@ -234,12 +234,23 @@ describe("Alerts route selection", () => {
     ).toBe("postal-fallback");
   });
 
-  it("routes notification delivery health alerts to Postal", () => {
+  it("keeps info-level dashboard-namespace alerts suppressed instead of paging Postal", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "SomethingInfo",
+        namespace: "alert-dashboard",
+        severity: "info",
+      }),
+    ).toBe("null");
+  });
+
+  it("routes only webhook-integration delivery failures to Postal", () => {
     expect(
       resolveReceiver(route, {
         alertname: "AlertmanagerFailedToSendAlerts",
         namespace: "prometheus",
         severity: "warning",
+        integration: "webhook",
       }),
     ).toBe("postal-fallback");
     expect(
@@ -249,6 +260,27 @@ describe("Alerts route selection", () => {
         severity: "warning",
       }),
     ).toBe("postal-fallback");
+  });
+
+  it("keeps email-integration delivery failures off the broken Postal path", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "AlertmanagerFailedToSendAlerts",
+        namespace: "monitoring",
+        severity: "warning",
+        integration: "email",
+      }),
+    ).toBe("alerts");
+  });
+
+  it("does not blanket-route unrelated Alertmanager health alerts to Postal", () => {
+    expect(
+      resolveReceiver(route, {
+        alertname: "AlertmanagerConfigInconsistent",
+        namespace: "monitoring",
+        severity: "critical",
+      }),
+    ).toBe("alerts");
   });
 
   it("keeps Watchdog and info alerts suppressed", () => {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -312,18 +312,40 @@ export async function createPrometheusApp(chart: Chart) {
               // namespace must retain an independent notification path while
               // that service is unavailable. This covers Kubernetes rollout
               // alerts and blackbox probe failures in addition to the explicit
-              // AlertDashboard* rules above.
-              receiver: "postal-fallback",
-              matchers: ['namespace = "alert-dashboard"'],
-            },
-            {
-              // Notification-health alerts cannot be delivered through the
-              // integration they are diagnosing. Keep these on Postal so a
-              // dashboard outage cannot turn Alertmanager's own failure alert
-              // into another failed webhook attempt.
+              // AlertDashboard* rules above. Constrained to warning/critical so
+              // it cannot outrun the info/Watchdog suppression routes below by
+              // matching first — an info-level alert in this namespace must
+              // still land on the null receiver.
               receiver: "postal-fallback",
               matchers: [
-                'alertname =~ "Alertmanager.*|PrometheusErrorSendingAlertsTo.*|PrometheusNotConnectedToAlertmanagers"',
+                'namespace = "alert-dashboard"',
+                'severity =~ "critical|warning"',
+              ],
+            },
+            {
+              // AlertmanagerFailedToSendAlerts fires once per failed
+              // notification integration. Only route the webhook integration's
+              // failures here — that's the one this fallback exists to
+              // diagnose. Email-integration failures must stay on the normal
+              // Alerts receiver: routing a "Postal is broken" diagnostic
+              // through Postal itself would mean it never arrives.
+              receiver: "postal-fallback",
+              matchers: [
+                'alertname = "AlertmanagerFailedToSendAlerts"',
+                'integration = "webhook"',
+              ],
+            },
+            {
+              // Prometheus-to-Alertmanager connectivity alerts diagnose the
+              // webhook delivery path itself and cannot be delivered through
+              // it. Deliberately an explicit alertname list, not `Alertmanager.*`
+              // — that wildcard would also capture unrelated cluster/config
+              // health alerts (e.g. AlertmanagerConfigInconsistent) that have
+              // nothing to do with notification delivery and should notify
+              // through the normal Alerts receiver like any other alert.
+              receiver: "postal-fallback",
+              matchers: [
+                'alertname =~ "PrometheusErrorSendingAlertsTo.*|PrometheusNotConnectedToAlertmanagers"',
               ],
             },
             {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -323,15 +323,19 @@ export async function createPrometheusApp(chart: Chart) {
               ],
             },
             {
-              // AlertmanagerFailedToSendAlerts fires once per failed
-              // notification integration. Only route the webhook integration's
-              // failures here — that's the one this fallback exists to
-              // diagnose. Email-integration failures must stay on the normal
-              // Alerts receiver: routing a "Postal is broken" diagnostic
-              // through Postal itself would mean it never arrives.
+              // AlertmanagerFailedToSendAlerts (single instance) and
+              // AlertmanagerClusterFailedToSendAlerts (all instances, critical)
+              // both fire once per failed notification integration — they
+              // have historically fired together for this cluster (see
+              // packages/docs/archive/homelab-audits/2026-04-04_homelab-health-audit-2.md).
+              // Only route the webhook integration's failures here — that's
+              // the one this fallback exists to diagnose. Email-integration
+              // failures must stay on the normal Alerts receiver: routing a
+              // "Postal is broken" diagnostic through Postal itself would
+              // mean it never arrives.
               receiver: "postal-fallback",
               matchers: [
-                'alertname = "AlertmanagerFailedToSendAlerts"',
+                'alertname =~ "AlertmanagerFailedToSendAlerts|AlertmanagerClusterFailedToSendAlerts"',
                 'integration = "webhook"',
               ],
             },

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -308,6 +308,25 @@ export async function createPrometheusApp(chart: Chart) {
               matchers: ['alert_dashboard_fallback = "true"'],
             },
             {
+              // The Alerts webhook is the dashboard itself, so its own
+              // namespace must retain an independent notification path while
+              // that service is unavailable. This covers Kubernetes rollout
+              // alerts and blackbox probe failures in addition to the explicit
+              // AlertDashboard* rules above.
+              receiver: "postal-fallback",
+              matchers: ['namespace = "alert-dashboard"'],
+            },
+            {
+              // Notification-health alerts cannot be delivered through the
+              // integration they are diagnosing. Keep these on Postal so a
+              // dashboard outage cannot turn Alertmanager's own failure alert
+              // into another failed webhook attempt.
+              receiver: "postal-fallback",
+              matchers: [
+                'alertname =~ "Alertmanager.*|PrometheusErrorSendingAlertsTo.*|PrometheusNotConnectedToAlertmanagers"',
+              ],
+            },
+            {
               receiver: "null",
               matchers: ['alertname = "Watchdog"'],
             },


### PR DESCRIPTION
## Why

Alertmanager webhook delivery failures recurred when the single-replica alert-dashboard service was unavailable. The resulting Alertmanager health alerts were routed through the same unavailable webhook, so the notification failure could not reach an independent operator path.

## What

- Route all alert-dashboard namespace health and rollout alerts to the existing Postal fallback receiver.
- Route Alertmanager and Prometheus-to-Alertmanager delivery health alerts to Postal instead of the dashboard webhook.
- Add rendered-route regression coverage for dashboard probe failures and notification delivery failures.

## Verification

- `cd packages/homelab/src/cdk8s && bun run build`
- `cd packages/homelab/src/cdk8s && bun test` — 511 passed, 14 existing environment-dependent skips, 0 failed
- `cd packages/homelab/src/cdk8s && bun run typecheck`
- Focused ESLint on the changed files
- Live evidence: alert-dashboard endpoint is currently Ready with a healthy Service endpoint; Alertmanager has no active requested-family alerts. The new route is source-only until this change is merged and reconciled by ArgoCD.

## Rollout notes

The existing alert-dashboard webhook remains the normal receiver for ordinary alerts. Postal is used only for dashboard-health and notification-delivery health signals so those alerts retain an independent path during a dashboard outage.