### PR TITLE
Make InfoInhibitor firing-only

### DIFF
--- a/packages/docs/plans/2026-08-11_alertmanager-alert-remediation.md
+++ b/packages/docs/plans/2026-08-11_alertmanager-alert-remediation.md
@@ -25,6 +25,9 @@ Kubernetes, logs, and storage state are the rollout acceptance oracle.
   configuration.
 - Accept an omitted `generatorURL` in Alertmanager snapshots, persist it as
   `null`, and retain the strict webhook contract.
+- Keep `Watchdog` and `InfoInhibitor` as non-paging control signals, but replace
+  the stock `InfoInhibitor` expression so pending info alerts do not activate
+  inhibition before Alertmanager receives them.
 
 ## Temporal and Home Assistant
 

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/prometheus.ts
@@ -144,6 +144,9 @@ export async function createPrometheusApp(chart: Chart) {
     },
     defaultRules: {
       disabled: {
+        // Replaced by the local firing-only rule. The chart default also
+        // considers pending info alerts, which makes this control signal noisy.
+        InfoInhibitor: true,
         KubeMemoryOvercommit: true,
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/prometheus.ts
@@ -27,10 +27,24 @@ import { getDiscordPlaysGoalRuleGroups } from "./rules/discord-plays-goal.ts";
 import { getAlertDashboardRuleGroups } from "./rules/alert-dashboard.ts";
 import { createBuildkiteMonitoring } from "@shepherdjerred/homelab/cdk8s/src/resources/monitoring/buildkite.ts";
 import { createBuildkitdMonitoring } from "@shepherdjerred/homelab/cdk8s/src/resources/monitoring/buildkitd.ts";
+import { getAlertingControlRuleGroups } from "./rules/alerting-control.ts";
 
 export function createPrometheusMonitoring(chart: Chart) {
   createBuildkiteMonitoring(chart);
   createBuildkitdMonitoring(chart);
+
+  // Keep the control signal, but do not let pending informational alerts make
+  // InfoInhibitor fire before Alertmanager has received anything to inhibit.
+  new PrometheusRule(chart, "prometheus-alerting-control-rules", {
+    metadata: {
+      name: "prometheus-alerting-control-rules",
+      namespace: "prometheus",
+      labels: { release: "prometheus" },
+    },
+    spec: {
+      groups: getAlertingControlRuleGroups(),
+    },
+  });
 
   // Create Home Assistant rules
   new PrometheusRule(chart, "prometheus-homeassistant-rules", {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/alerting-control.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/alerting-control.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getAlertingControlRuleGroups,
+  INFO_INHIBITOR_EXPRESSION,
+} from "./alerting-control.ts";
+
+describe("alerting control rules", () => {
+  it("inhibits only firing info alerts", () => {
+    const [group] = getAlertingControlRuleGroups();
+    const [rule] = group?.rules ?? [];
+
+    expect(rule?.alert).toBe("InfoInhibitor");
+    expect(rule?.labels).toEqual({ severity: "none" });
+    expect(rule?.expr.value).toBe(INFO_INHIBITOR_EXPRESSION);
+    expect(INFO_INHIBITOR_EXPRESSION).toContain(
+      'ALERTS{alertstate="firing", severity="info"}',
+    );
+    expect(INFO_INHIBITOR_EXPRESSION).not.toContain(
+      'ALERTS{severity="info"} == 1',
+    );
+  });
+
+  it("does not let a warning or critical alert inhibit itself", () => {
+    expect(INFO_INHIBITOR_EXPRESSION).toContain('alertname!="InfoInhibitor"');
+    expect(INFO_INHIBITOR_EXPRESSION).toContain('alertstate="firing"');
+    expect(INFO_INHIBITOR_EXPRESSION).toContain('severity=~"warning|critical"');
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/alerting-control.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/alerting-control.ts
@@ -1,0 +1,40 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+
+/**
+ * The stock kube-prometheus-stack expression does not constrain the source
+ * ALERTS series to alertstate="firing". Pending info alerts therefore create
+ * an InfoInhibitor even though Alertmanager has not received them and cannot
+ * notify for them yet.
+ */
+export const INFO_INHIBITOR_EXPRESSION = `group by (namespace) (
+  ALERTS{alertstate="firing", severity="info"} == 1
+) unless on (namespace) group by (namespace) (
+  ALERTS{
+    alertname!="InfoInhibitor",
+    alertstate="firing",
+    severity=~"warning|critical"
+  } == 1
+)`;
+
+export function getAlertingControlRuleGroups(): PrometheusRuleSpecGroups[] {
+  return [
+    {
+      name: "alerting-control",
+      rules: [
+        {
+          alert: "InfoInhibitor",
+          annotations: {
+            description:
+              "This alert inhibits info-level alerts only while an info-level alert is firing and stops when a warning or critical alert fires in the same namespace.",
+            summary: "Info-level alert inhibition.",
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            INFO_INHIBITOR_EXPRESSION,
+          ),
+          labels: { severity: "none" },
+        },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
## Why
Pending Buildkite informational CPU-throttling alerts were activating the stock InfoInhibitor while still pending. Alertmanager had not received those alerts, so the control signal created misleading inhibition noise without representing a page-worthy incident.

## What
- Replace kube-prometheus-stack's InfoInhibitor with a local rule that selects only firing info alerts.
- Keep Watchdog, info-level non-paging routes, warning/critical paging routes, and Buildkite alert thresholds unchanged.
- Add focused rule coverage and retain the remediation-plan rationale.

## Verification
- `bun run --cwd packages/homelab/src/cdk8s typecheck`
- `cd packages/homelab/src/cdk8s && bun run lint`
- `bun run --cwd packages/homelab/src/cdk8s build`
- Focused alerting/Buildkite tests: 32 passed, 0 failed
- Full cdk8s package tests: 512 passed, 14 skipped, 0 failed
- Synthesized manifests confirmed the custom rule and disabled chart duplicate

Deployment remains GitOps-controlled; this PR has not been deployed.