### PR TITLE
Clarify 1Password and Cloudflare environment-token authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,24 @@ sandbox/                        # Personal scratch (not shipped, excluded from m
 - **Update docs with code** — When adding a CLI command or feature, update CLAUDE.md and the relevant skills in the same phase, not a later "polish" pass, so the integration points are usable as soon as the feature works. When a change alters a meaningful architecture boundary, operator workflow, or system rationale, also update the nearest human page under `packages/docs/wiki/src/content/docs/`.
 - **Shared data is language-neutral** — Cross-package shared data (catalogs, config) belongs in a language-neutral source of truth (JSON + JSON Schema), validated per-language (Zod in TS, Pydantic in Python). The repo has Bun and Python consumers; don't ship a TS-only module. If TS needs it browser- and node-safe, ship a built package with inlined JSON + `.d.ts`, not a `node:fs` read or a source-only JSON import.
 
+### Local 1Password and Cloudflare credential probes
+
+On the local macOS/Conductor machine, 1Password Desktop integration authenticates
+individual CLI operations through the desktop app and biometric approval. It does
+not necessarily create a persistent shell session. Therefore `op whoami` can
+return `account is not signed in` while the real operation succeeds. Do not run
+`op signin`, ask the user to paste a token, or stop based on `op whoami` alone:
+probe with `op vault list` or the exact `op item get`/`op read` needed by the task.
+
+The local `cf` wrapper receives `CF_API_TOKEN` from the shell environment and
+maps it to `CLOUDFLARE_API_TOKEN` only for the `cf` process. `cf auth list` only
+lists saved named profiles, so an empty list is expected when environment-token
+authentication is in use. Use `cf auth whoami` or a read-only API operation such
+as `cf accounts list` to test access. Keep authentication and authorization
+separate: a valid-token response followed by a 403 means the token lacks the
+requested Cloudflare permission (for example, `Account API Tokens Write`), not
+that 1Password is signed out. Never expose or persist the token value.
+
 ### ArgoCD root prune safety
 
 The homelab CI reconcile script must require an exact root `apps` chart

--- a/packages/dotfiles/dot_agents/skills/op-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/op-helper/SKILL.md
@@ -67,6 +67,32 @@ op item get "<item>" --vault "<vault>" --format json
   *is* a real token, so `op whoami` is meaningful there. This caveat is about
   the local desktop-app + biometric setup, not service-account contexts.
 
+## Cloudflare environment-token integration
+
+On the local macOS setup, the shell already exposes the Cloudflare credential as
+`CF_API_TOKEN`; the tracked `~/.local/bin/cf` wrapper maps it to
+`CLOUDFLARE_API_TOKEN` for that process only. Never print, paste, or persist the
+value. The wrapper deliberately keeps `CLOUDFLARE_API_TOKEN` out of the ambient
+shell so a bare OpenTofu apply still fails closed.
+
+`cf auth list` is not an authentication probe here. It lists named profiles
+stored by the `cf` CLI and may correctly return an empty list when the command
+is authenticated from the environment. Use `cf auth whoami`, which reports the
+environment-token source and validity, or the exact read-only operation needed:
+
+```bash
+cf auth whoami
+cf accounts list
+cf zones list
+```
+
+Treat a successful `cf auth whoami` or API read as proof that Cloudflare
+authentication works, regardless of `op whoami`. Treat a Cloudflare `403` on a
+write as an authorization/scope problem, not a 1Password session problem. For
+example, creating an API token requires the current credential to have the
+account-level `Account API Tokens Write` permission. Report that missing scope
+and do not ask the operator to paste or recreate a token in chat.
+
 ## CLI Commands
 
 ### Auto-Approved Commands


### PR DESCRIPTION
Why

Agents were treating false-negative 1Password session output and an empty Cloudflare profile list as authentication failures, even when the local environment token worked.

What

- Document the macOS Desktop integration behavior where `op whoami` can fail while real reads succeed.
- Explain that `cf auth list` enumerates named profiles, not environment-token authentication.
- Direct agents to `cf auth whoami` and read-only API probes.
- Separate valid authentication from Cloudflare authorization failures such as a missing `Account API Tokens Write` permission.

Verification

- `op whoami` exits 1 while `op vault list` succeeds in the Conductor shell.
- `cf auth whoami` reports an authenticated `CLOUDFLARE_API_TOKEN` environment source.
- `cf accounts list` succeeds.
- `bunx prettier --no-config --check AGENTS.md packages/dotfiles/dot_agents/skills/op-helper/SKILL.md`
- `git diff --check`