### PR TITLE
fix(homelab): right-size torvalds workload memory

### DIFF
--- a/packages/homelab/src/cdk8s/src/container-resources.test.ts
+++ b/packages/homelab/src/cdk8s/src/container-resources.test.ts
@@ -266,6 +266,20 @@ describe("Container resource requests backstop", () => {
         },
       ],
       [
+        "mario-kart/main",
+        {
+          requests: { cpu: "1000m", memory: "1792Mi" },
+          limits: { cpu: "8000m", memory: "4096Mi" },
+        },
+      ],
+      [
+        "pinchtab/main",
+        {
+          requests: { cpu: "250m", memory: "512Mi" },
+          limits: { cpu: "2000m", memory: "4096Mi" },
+        },
+      ],
+      [
         "scout-beta-scout-backend/main",
         { requests: { cpu: "50m", memory: "2048Mi" } },
       ],
@@ -285,6 +299,13 @@ describe("Container resource requests backstop", () => {
         {
           requests: { cpu: "1", memory: "3072Mi" },
           limits: { cpu: "2", memory: "6144Mi" },
+        },
+      ],
+      [
+        "temporal-temporal-agent-worker/temporal-agent-worker",
+        {
+          requests: { cpu: "500m", memory: "768Mi" },
+          limits: { cpu: "1500m", memory: "1024Mi" },
         },
       ],
     ]);

--- a/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
+++ b/packages/homelab/src/cdk8s/src/resources/mario-kart.ts
@@ -153,14 +153,15 @@ export function createMarioKartDeployment(chart: Chart) {
         allowPrivilegeEscalation: false,
       },
       // Software RDP is CPU-heavy and there's no GPU on the node — give it burst room
-      // via the limit. 30d peak is ~900m, so the guaranteed request stays modest.
+      // via the limit. The 30d working-set peak is ~1.36GiB, so a 1.75GiB
+      // request keeps 25% memory headroom without reserving the full 2GiB.
       resources: {
         cpu: {
           request: Cpu.millis(1000),
           limit: Cpu.millis(8000),
         },
         memory: {
-          request: Size.gibibytes(2),
+          request: Size.mebibytes(1792),
           limit: Size.gibibytes(4),
         },
       },

--- a/packages/homelab/src/cdk8s/src/resources/pinchtab/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/pinchtab/index.ts
@@ -125,9 +125,11 @@ export function createPinchtabDeployment(chart: Chart) {
           limit: Cpu.millis(2000),
         },
         memory: {
-          // Limit must comfortably exceed the 2Gi Memory-backed /dev/shm below
-          // plus Chrome's working set.
-          request: Size.gibibytes(1),
+          // The 30d working-set peak is ~237MiB. Keep a rounded 512MiB
+          // scheduler reservation, while the limit must still comfortably
+          // exceed the 2Gi Memory-backed /dev/shm below plus Chrome's working
+          // set.
+          request: Size.mebibytes(512),
           limit: Size.gibibytes(4),
         },
       },

--- a/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
@@ -163,8 +163,11 @@ ip6tables -L OUTPUT -n`,
           limit: Cpu.millis(1500),
         },
         memory: {
-          request: Size.gibibytes(3),
-          limit: Size.gibibytes(6),
+          // The 30d working-set peak is ~505MiB. Keep a rounded 768MiB
+          // request and 1GiB limit for task bursts without reserving the 3GiB
+          // used by the larger core and glitter workers.
+          request: Size.mebibytes(768),
+          limit: Size.gibibytes(1),
         },
       },
       ...temporalWorkerHealthProbes(),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
@@ -163,9 +163,12 @@ ip6tables -L OUTPUT -n`,
           limit: Cpu.millis(1500),
         },
         memory: {
-          // The 30d working-set peak is ~505MiB. Keep a rounded 768MiB
-          // request and 1GiB limit for task bursts without reserving the 3GiB
-          // used by the larger core and glitter workers.
+          // The 30d working-set peak is ~505MiB, and that peak is a real bound
+          // because the agent-task worker pins maxConcurrentActivityTaskExecutions
+          // to 1 (packages/temporal/src/worker.ts), so overlapping scheduled
+          // tasks queue instead of multiplying provider subprocesses. Keep a
+          // rounded 768MiB request and 1GiB limit for task bursts without
+          // reserving the 3GiB used by the larger core and glitter workers.
           request: Size.mebibytes(768),
           limit: Size.gibibytes(1),
         },

--- a/packages/homelab/src/talos/README.md
+++ b/packages/homelab/src/talos/README.md
@@ -23,7 +23,7 @@ Patches are applied to the base Talos machine configuration to customize the clu
 **Current settings**:
 
 - `max-pods: 300` - Maximum number of pods per node (increased from 250)
-- `systemReserved.memory: 40Gi` - Non-pod memory reserved for ZFS ARC (16 GiB) plus host kernel/OS burst (~24 GiB — kernel slab from ZFS dnode/dbuf metadata alone peaked at 30.3Gi under a full CI storm). Right-sized from 56Gi to 24Gi on 2026-07-10 when pod requests hit 99.99% of allocatable and CI pods went unschedulable, then corrected to 40Gi on 2026-07-11 after a global-OOM freeze proved the "8Gi OS overhead" estimate only holds when idle.
+- `systemReserved.memory: 24Gi` - Non-pod memory reserved for ZFS ARC (16 GiB) plus an ~8 GiB production-only host kernel/OS burst. The 40 GiB CI-era budget included a BuildKit/Dagger storm that now runs on liskov; post-migration torvalds slab peaked at ~7.2 GiB. Re-raise this value in lockstep with `zfs_arc_max` if a production-only soak demonstrates a larger burst.
 - `systemReserved.cpu: 4` - Non-pod CPU reserved for the host and control-plane services
 - `kubeReserved.memory: 8Gi` - Memory reserved for Kubernetes system daemons (raised 2Gi → 8Gi 2026-07-11 after the /podruntime memcg-OOM outage; see the original investigation)
 - `kubeReserved.cpu: 1` - CPU reserved for Kubernetes system daemons

--- a/packages/homelab/src/talos/liskov/patches/kubelet.yaml
+++ b/packages/homelab/src/talos/liskov/patches/kubelet.yaml
@@ -6,11 +6,12 @@
 # history. The CI fork-storm armor ports unchanged because the CI storm is
 # exactly the workload moving to this node; only the sizes differ:
 #
-# - systemReserved.memory 24Gi (torvalds: 40Gi) = 16 ARC + ~8 kernel/OS/slab
+# - systemReserved.memory 24Gi (torvalds: also 24Gi) = 16 ARC + ~8 kernel/OS/slab
 #   burst. Liskov's Prometheus soak showed its slab and ARC fit comfortably
 #   inside this budget while CI ran, so the reserved capacity can be returned
-#   to the CI scheduler. If ZfsArcHitRateLow fires sustained, raise zfs_arc_max
-#   and this in lockstep.
+#   to the CI scheduler. Torvalds converged on the same 24Gi budget once the CI
+#   storm moved here and its own slab peak dropped to ~7.2Gi. If
+#   ZfsArcHitRateLow fires sustained, raise zfs_arc_max and this in lockstep.
 # - kubeReserved.memory 4Gi (torvalds: 8Gi): no etcd on a worker; torvalds'
 #   /podruntime usage settled ~2.2Gi WITH etcd. Measure
 #   /sys/fs/cgroup/podruntime/memory.peak before resizing.

--- a/packages/homelab/src/talos/torvalds/patches/kubelet.yaml
+++ b/packages/homelab/src/talos/torvalds/patches/kubelet.yaml
@@ -25,19 +25,17 @@ machine:
       # the ARC and kernel slab are kernel memory capped/bounded outside the
       # cgroup — the reservation still budgets for them in allocatable math).
       #
-      # 40Gi = 16 ARC + ~24 kernel/OS burst. History: right-sized 56Gi -> 24Gi on
-      # 2026-07-10 (30d evidence: 48Gi ARC massively oversized, CI unschedulable
-      # at 99.99% requested), then corrected 24Gi -> 40Gi on 2026-07-11 after a
-      # global-OOM freeze: under a full CI storm + dagger cache rebuild, kernel
-      # slab (ZFS dnode/dbuf metadata from buildkit small-file IO) alone peaked
-      # at 30.3Gi — the original "8Gi OS overhead" estimate only holds when idle.
-      # Sum of ceilings must leave real physical slack: kubepods (capacity-48Gi
-      # = 77.4Gi) + ARC 16 + slab burst fits in 125.4Gi physical with this value.
+      # 24Gi = 16Gi ARC + ~8Gi kernel/OS burst. CI jobs now run on the dedicated
+      # liskov worker, so the torvalds reservation no longer needs to budget for
+      # the historical BuildKit/Dagger storm. Post-migration torvalds slab peaked
+      # at ~7.2Gi over the retained observation window. Keep this reservation
+      # above the ARC cap and re-raise it in lockstep with zfs_arc_max if a
+      # production-only soak demonstrates a larger host burst.
       # If ZfsArcHitRateLow fires sustained, raise zfs_arc_max and this value in
       # lockstep.
       systemReserved:
         cpu: "4"
-        memory: "40Gi"
+        memory: "24Gi"
       # /system — Talos's CgroupSystem: every non-Kubernetes Talos daemon (udevd,
       # apid, trustd, extensions, dashboard, the system-level containerd) runs
       # here. Sourced from siderolabs/talos `pkg/machinery/constants/constants.go`

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -276,12 +276,28 @@ async function main(): Promise<void> {
     // account. Queue isolation therefore covers both head-of-line blocking and
     // Kubernetes authorization; the agent pod has read-only audit RBAC and no
     // namespace-scoped exec roles.
+    //
+    // Activity concurrency stays 1: each agent activity spawns a Claude/Codex
+    // provider subprocess, so overlapping independently scheduled tasks would
+    // multiply the pod's peak RSS. Serializing makes the observed single-run
+    // working set an actual bound for the deployment's memory limit (see
+    // packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts).
+    // Agent activities set no scheduleToStartTimeout, so a queued task waits
+    // for the slot instead of failing. Workflow-task concurrency must be ≥2
+    // when sticky cache is on — Core rejects max_cached_workflows>0 with a
+    // single workflow-task poller/slot.
     const agentTaskWorker = await Worker.create({
       ...commonWorkerOptions,
       taskQueue: TASK_QUEUES.AGENT_TASK,
+      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentWorkflowTaskExecutions: 2,
     });
     workers.push(agentTaskWorker);
-    jsonLog("info", "Worker created", { taskQueue: TASK_QUEUES.AGENT_TASK });
+    jsonLog("info", "Worker created", {
+      taskQueue: TASK_QUEUES.AGENT_TASK,
+      maxConcurrentActivityTaskExecutions: 1,
+      maxConcurrentWorkflowTaskExecutions: 2,
+    });
   }
 
   if (workerRoleRunsGlitter(role)) {


### PR DESCRIPTION
## Why

Torvalds still carries the pre-migration 40Gi system reservation even though CI workloads now run on liskov. A 30-day workload audit also found a small set of evidence-backed scheduler reservations that can be reduced without changing the larger stateful/cache-sensitive workloads.

## What

- Temporal agent worker: memory request 3Gi -> 768Mi; finite limit 6Gi -> 1Gi.
  The 30-day working-set peak was approximately 505MiB; 768MiB is the next 256MiB boundary above 25% headroom.
- Pinchtab: request 1Gi -> 512Mi; retain the 4Gi limit because the pod uses a 2Gi memory-backed /dev/shm plus Chrome burst room.
- Mario Kart: request 2Gi -> 1792Mi; retain the 4Gi limit.
- Torvalds Talos kubelet: systemReserved.memory 40Gi -> 24Gi.
  kubeReserved.memory remains 8Gi, evictionHard.memory.available remains 4Gi, and the 16Gi ZFS ARC cap remains below the system reservation.
- Added exact synthesized resource backstops for the changed workload containers.
- Audited historical peaks for all currently scheduled workload owners and preserved qBittorrent, Plex, Temporal core, Temporal Glitter, Loki chunks cache, and other under-requested or stateful/cache-sensitive workloads where reducing requests would not be evidence-backed. Loki cache hit/eviction metrics were unavailable, so its reservation is intentionally unchanged.
- Inactive follow-up candidates are retained and not deleted: minecraft-shuxin, minecraft-sjerred, and minecraft-tsmc StatefulSets are currently scaled to zero.

The three workload changes release approximately 3Gi of scheduler request reservations. The 16Gi system-reservation reduction is expected to increase torvalds allocatable memory from approximately 73.4Gi to approximately 89.4Gi. Based on the live request snapshot, the projected request ratio falls from approximately 99% to approximately 78%; this is a projection until the source is merged and reconciled.

## Verification

Passed:

- Focused Bun tests: 21 passing across container resource, capacity remediation, Temporal audit tooling, and Temporal network-boundary suites.
- bun run build
- bun run typecheck
- Focused ESLint
- Prettier check
- bun run check:talos
- git diff --check
- Staged bunx lefthook run pre-commit, including suppressions, formatting, and gitleaks checks.

Not yet run because this draft is not merged:

- ArgoCD/GitOps deployment of synthesized workloads.
- Talos full control-plane configuration apply with --mode=no-reboot.
- Post-rollout allocatable, kubelet reservation, cgroup, node-condition, alert, workload-readiness, Temporal exit-137, and 24-hour memory-headroom verification.

The live node remains on the pre-PR configuration until the PR is reviewed, merged, and rolled out through the documented paths.