### PR TITLE
Refine Brim menu-panel quota UX

### DIFF
--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -34,7 +34,8 @@ written to `dist/QuotaBar.app` and ad-hoc signed by default. Set
 available.
 
 `install:macos` is an explicit opt-in operation. It verifies the bundle, then
-replaces the exact target `/Applications/QuotaBar.app` and launches it. Launch
+replaces the exact target `/Applications/Brim.app` and launches it. It removes
+the legacy `/Applications/QuotaBar.app` installation during migration. Launch
 at login requires this real app bundle; it does not claim success for a
 `swift run` executable.
 
@@ -87,7 +88,7 @@ bun run install:notarized
 `notarize:macos` intentionally creates a new submission to Apple's notary
 service. `export:notarized` waits up to ten minutes for Xcode to receive and
 staple the ticket. Verification requires strict `codesign`, a valid stapled
-ticket, and Gatekeeper acceptance before the exact `/Applications/QuotaBar.app`
+ticket, and Gatekeeper acceptance before the exact `/Applications/Brim.app`
 target is replaced. Xcode Organizer's **Distribute App → Developer ID →
 Upload** workflow remains the UI equivalent. Authentication stays in Xcode; no
 Apple password, private key, or notarization credential belongs in the

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/BrimBranding.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/BrimBranding.swift
@@ -7,10 +7,8 @@ struct BrimMenuBarLabel: View {
 
   var body: some View {
     Image(nsImage: BrimAssets.menuBarImage(for: status))
-      .resizable()
       .renderingMode(.template)
-      .aspectRatio(contentMode: .fit)
-      .frame(width: 18, height: 18)
+      .frame(width: 16, height: 16)
       .accessibilityLabel("Brim, \(status.accessibilityDescription)")
   }
 }
@@ -34,6 +32,7 @@ private enum BrimAssets {
   @MainActor
   static func menuBarImage(for status: QuotaStatus) -> NSImage {
     let image = loadImage(named: status.menuBarAssetName)
+    image.size = NSSize(width: 16, height: 16)
     image.isTemplate = true
     return image
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
@@ -11,7 +11,7 @@ struct MenuBarView: View {
     TimelineView(.periodic(from: .now, by: 1)) { timeline in
       content(at: timeline.date)
     }
-    .frame(width: 380)
+    .frame(width: 372)
   }
 
   private func content(at date: Date) -> some View {
@@ -19,10 +19,9 @@ struct MenuBarView: View {
     return VStack(spacing: 0) {
       header(overview: overview, date: date)
       navigationSegments
-      QuotaSummaryView(summary: overview.summary, date: date)
+      WindowColumnHeader()
         .padding(.horizontal, 12)
-        .padding(.top, 2)
-        .padding(.bottom, 8)
+        .padding(.vertical, 5)
       Divider()
       providerList(overview: overview, date: date)
       Divider()
@@ -129,7 +128,7 @@ struct MenuBarView: View {
 
   private var spendRow: some View {
     HStack {
-      Label("Subscriptions", systemImage: "creditcard")
+      Text("Subscriptions")
       Spacer()
       Text("$\(SubscriptionPlan.totalMonthlyCostUSD)/mo")
         .monospacedDigit()

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
@@ -13,6 +13,17 @@ import SwiftUI
   )
 }
 
+#Preview("Brim compact shipping panel") {
+  OverviewPreview(
+    states: PreviewData.states([
+      .claudeCode: .available(PreviewData.shippingClaude),
+      .codex: .available(PreviewData.shippingCodex),
+      .kimi: .available(PreviewData.shippingKimi),
+      .grok: .available(PreviewData.shippingGrok),
+    ])
+  )
+}
+
 #Preview("Loading, stale, unauthenticated, disabled") {
   OverviewPreview(
     states: PreviewData.states([
@@ -67,9 +78,8 @@ private struct OverviewPreview: View {
   var body: some View {
     let overview = QuotaOverview(states: states, at: PreviewData.now)
     VStack(spacing: 0) {
-      QuotaSummaryView(summary: overview.summary, date: PreviewData.now)
-        .padding(.bottom, 8)
-      Divider()
+      WindowColumnHeader()
+        .padding(.vertical, 5)
       ForEach(overview.providers) { provider in
         ProviderSectionView(overview: provider, date: PreviewData.now)
         if provider.id != overview.providers.last?.id {
@@ -78,7 +88,7 @@ private struct OverviewPreview: View {
       }
     }
     .padding(.horizontal, 12)
-    .frame(width: 380)
+    .frame(width: 372)
   }
 }
 
@@ -157,6 +167,50 @@ private enum PreviewData {
     )
   }
 
+  static var shippingClaude: UsageSnapshot {
+    UsageSnapshot(
+      provider: .claudeCode,
+      windows: [
+        window(label: "5-hour", remaining: 23, kind: .rolling(durationSeconds: 18_000)),
+        window(label: "Weekly", remaining: 52),
+        window(
+          label: "Weekly · Fable extended model quota",
+          remaining: 8,
+          kind: .modelScoped(model: "Fable")
+        ),
+        window(
+          label: "Provider quota · Anthropic subscription",
+          remaining: 100,
+          kind: .providerDefined
+        ),
+      ],
+      sourceTimestamp: now
+    )
+  }
+
+  static var shippingCodex: UsageSnapshot {
+    UsageSnapshot(
+      provider: .codex,
+      windows: [window(label: "Weekly", remaining: 14)],
+      sourceTimestamp: now
+    )
+  }
+
+  static var shippingKimi: UsageSnapshot {
+    snapshot(.kimi, remaining: 42)
+      .withSourceTimestamp(now.addingTimeInterval(-5 * 86_400))
+      .markedStale(reason: "Kimi has not returned a fresh usage response.")
+  }
+
+  static var shippingGrok: UsageSnapshot {
+    UsageSnapshot(
+      provider: .grok,
+      windows: [window(label: "Monthly usage allowance", remaining: 38, kind: .monthly)],
+      notes: ["The provider returned current usage without reset metadata."],
+      sourceTimestamp: now.addingTimeInterval(-4 * 86_400)
+    )
+  }
+
   static var manyWindows: UsageSnapshot {
     UsageSnapshot(
       provider: .claudeCode,
@@ -192,5 +246,20 @@ private enum PreviewData {
     } catch {
       preconditionFailure("Invalid preview fixture")
     }
+  }
+}
+
+private extension UsageSnapshot {
+  func withSourceTimestamp(_ timestamp: Date) -> UsageSnapshot {
+    UsageSnapshot(
+      provider: provider,
+      accountLabel: accountLabel,
+      windows: windows,
+      resets: resets,
+      resetErrorMessage: resetErrorMessage,
+      notes: notes,
+      sourceTimestamp: timestamp,
+      freshness: freshness
+    )
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
@@ -2,6 +2,81 @@ import AppKit
 import QuotaBarCore
 import SwiftUI
 
+struct WindowColumnHeader: View {
+  var body: some View {
+    HStack(spacing: 7) {
+      Text("WINDOW")
+        .frame(width: 96, alignment: .leading)
+      Color.clear
+        .frame(width: 82)
+      Text("LEFT")
+        .frame(width: 40, alignment: .trailing)
+      Text("RESETS")
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+    .font(.caption2.monospaced().weight(.semibold))
+    .foregroundStyle(.secondary)
+    .accessibilityHidden(true)
+  }
+}
+
+struct ProviderBadgeView: View {
+  let badge: ProviderBadge
+
+  var body: some View {
+    Text(title)
+      .font(.caption2.monospaced().weight(.semibold))
+      .foregroundStyle(color)
+      .padding(.horizontal, 4)
+      .padding(.vertical, 2)
+      .background(color.opacity(0.14), in: Capsule())
+      .help(helpText)
+      .accessibilityLabel(title)
+      .accessibilityHint(helpText)
+  }
+
+  private var title: String {
+    switch badge.kind {
+    case .stale: return ageTitle(prefix: "STALE")
+    case .partial: return ageTitle(prefix: "PARTIAL")
+    case .noResets: return "NO RESETS"
+    case .resets:
+      let count = badge.expirations.count
+      return "\(count) RESET\(count == 1 ? "" : "S")"
+    case .resetsUnavailable: return "RESETS UNAVAILABLE"
+    }
+  }
+
+  private var helpText: String {
+    switch badge.kind {
+    case .stale, .partial:
+      return [badge.detail, badge.age.map { "Age \($0)" }]
+        .compactMap { $0 }
+        .joined(separator: " · ")
+    case .noResets, .resetsUnavailable:
+      return badge.detail ?? title
+    case .resets:
+      return badge.expirations
+        .map { "Expires \($0.formatted(date: .abbreviated, time: .shortened))" }
+        .joined(separator: "\n")
+    }
+  }
+
+  private var color: Color {
+    switch badge.kind {
+    case .stale, .resetsUnavailable: return .secondary
+    case .partial: return .orange
+    case .noResets: return .secondary
+    case .resets: return .blue
+    }
+  }
+
+  private func ageTitle(prefix: String) -> String {
+    guard let age = badge.age else { return prefix }
+    return "\(prefix) \(age)"
+  }
+}
+
 struct ProviderSectionView: View {
   let overview: ProviderOverview
   let date: Date
@@ -11,7 +86,8 @@ struct ProviderSectionView: View {
       header
       content
     }
-    .padding(.vertical, 9)
+    .padding(.vertical, 8)
+    .opacity(overview.dimsContent ? 0.58 : 1)
     .accessibilityElement(children: .contain)
   }
 
@@ -20,6 +96,9 @@ struct ProviderSectionView: View {
       ProviderLogo(provider: overview.provider)
       Text(overview.provider.displayName)
         .font(.subheadline.weight(.semibold))
+      ForEach(overview.badges) { badge in
+        ProviderBadgeView(badge: badge)
+      }
       Spacer()
       Text("$\(SubscriptionPlan.plan(for: overview.provider).monthlyCostUSD)/mo")
         .font(.caption)
@@ -68,16 +147,7 @@ struct ProviderSectionView: View {
       snapshot.windows.contains { $0.kind == .entitlement }
       ? snapshot.notes.first
       : nil
-    let remainingNotes =
-      entitlementDetail == nil ? snapshot.notes : Array(snapshot.notes.dropFirst())
 
-    if case let .stale(reason) = snapshot.freshness {
-      statusRow(
-        "Stale · \(QuotaTimeFormatter.refreshAge(since: snapshot.sourceTimestamp, at: date))",
-        symbol: "clock.badge.exclamationmark",
-        help: reason
-      )
-    }
     if snapshot.windows.isEmpty {
       statusRow(
         "No quota windows returned",
@@ -93,16 +163,6 @@ struct ProviderSectionView: View {
           entitlementDetail: window.kind == .entitlement ? entitlementDetail : nil
         )
       }
-    }
-    if let resetOverview = overview.resetOverview {
-      CodexResetRow(resetOverview: resetOverview, date: date, stale: isStale)
-    }
-    if overview.provider == .grok, !remainingNotes.isEmpty {
-      statusRow(
-        "Partial data",
-        symbol: "exclamationmark.circle",
-        help: remainingNotes.joined(separator: "\n")
-      )
     }
   }
 
@@ -132,10 +192,10 @@ struct WindowRow: View {
 
   private var quotaRow: some View {
     HStack(spacing: 7) {
-      Text(window.label)
+      Text(window.compactDisplayLabel)
         .lineLimit(1)
         .help(window.label)
-        .frame(width: 91, alignment: .leading)
+        .frame(width: 96, alignment: .leading)
       progress
         .frame(width: 82)
       Text(remainingText)
@@ -149,15 +209,16 @@ struct WindowRow: View {
     .foregroundStyle(stale ? .secondary : .primary)
     .opacity(stale ? 0.65 : 1)
     .accessibilityElement(children: .ignore)
-    .accessibilityLabel(window.label)
+    .accessibilityLabel("\(window.compactDisplayLabel), raw label \(window.label)")
     .accessibilityValue(accessibilityValue)
   }
 
   private var entitlementRow: some View {
     HStack(spacing: 7) {
-      Text(window.label)
+      Text(window.compactDisplayLabel)
         .lineLimit(1)
         .help(window.label)
+        .frame(width: 96, alignment: .leading)
       Spacer(minLength: 8)
       Text(entitlementDetail ?? "Policy only")
         .lineLimit(1)
@@ -167,6 +228,7 @@ struct WindowRow: View {
     .font(.caption)
     .opacity(stale ? 0.65 : 1)
     .accessibilityElement(children: .combine)
+    .accessibilityLabel("\(window.compactDisplayLabel), raw label \(window.label)")
   }
 
   @ViewBuilder private var progress: some View {
@@ -218,135 +280,8 @@ struct WindowRow: View {
     switch QuotaStatus.forRemaining(remaining) {
     case .critical: return .red
     case .warning: return .orange
-    case .healthy, .unavailable: return .secondary
-    }
-  }
-}
-
-struct CodexResetRow: View {
-  let resetOverview: ResetOverview
-  let date: Date
-  let stale: Bool
-
-  var body: some View {
-    Group {
-      switch resetOverview {
-      case .none:
-        Label("No resets available", systemImage: "arrow.counterclockwise.circle")
-      case .available(let resets):
-        HStack(spacing: 7) {
-          Label(
-            "\(resets.count) reset\(resets.count == 1 ? "" : "s")",
-            systemImage: "arrow.counterclockwise.circle.fill"
-          )
-          Spacer()
-          Text(expirationText(resets))
-            .monospacedDigit()
-            .lineLimit(1)
-            .minimumScaleFactor(0.8)
-            .help(absoluteExpirations(resets))
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityValue(absoluteExpirations(resets))
-      case .unavailable(let message):
-        Label("Resets unavailable", systemImage: "arrow.counterclockwise.circle")
-          .help(message)
-          .accessibilityHint(message)
-      }
-    }
-    .font(.caption)
-    .foregroundStyle(.secondary)
-    .opacity(stale ? 0.65 : 1)
-  }
-
-  private func expirationText(_ resets: [Reset]) -> String {
-    resets
-      .map { QuotaTimeFormatter.compactCountdown(to: $0.exp, from: date) }
-      .joined(separator: ", ")
-  }
-
-  private func absoluteExpirations(_ resets: [Reset]) -> String {
-    resets
-      .map { "Expires \($0.exp.formatted(date: .abbreviated, time: .shortened))" }
-      .joined(separator: "\n")
-  }
-}
-
-struct QuotaSummaryView: View {
-  let summary: QuotaOverviewSummary
-  let date: Date
-
-  var body: some View {
-    HStack(spacing: 7) {
-      Image(systemName: symbolName)
-        .foregroundStyle(color)
-      Text(text)
-        .lineLimit(2)
-        .fixedSize(horizontal: false, vertical: true)
-    }
-    .font(.caption)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .help(helpText)
-    .accessibilityElement(children: .combine)
-    .accessibilityValue(helpText)
-  }
-
-  private var text: String {
-    switch summary {
-    case let .quota(provider, window):
-      guard let remaining = window.remainingPercent else {
-        preconditionFailure("Summary window requires a remaining percentage")
-      }
-      var value =
-        "\(provider.displayName) \(window.label) is tightest — "
-        + "\(Int(remaining.rounded()))% left"
-      if let resetAt = window.resetAt {
-        value += " · \(QuotaTimeFormatter.compactCountdown(to: resetAt, from: date)) to reset"
-      }
-      return value
-    case .stale(let provider, _):
-      return "\(provider.displayName) usage is stale"
-    case .unavailable(let provider, _):
-      return "\(provider.displayName) usage is unavailable"
-    case .unauthenticated(let provider, _):
-      return "\(provider.displayName) needs sign-in"
-    case .loading(let provider):
-      return "Checking \(provider.displayName) usage…"
-    case .unknown(let provider):
-      return "\(provider.displayName) usage percentage is unknown"
-    case .noProvidersEnabled:
-      return "No subscription providers are enabled"
-    }
-  }
-
-  private var helpText: String {
-    switch summary {
-    case .quota(_, let window):
-      guard let resetAt = window.resetAt else { return "Tightest current subscription quota." }
-      return "Resets \(resetAt.formatted(date: .abbreviated, time: .shortened))"
-    case .stale(_, let reason): return reason
-    case .unavailable(_, let message): return message
-    case .unauthenticated(_, let message): return message
-    case .loading: return "Brim is waiting for the provider response."
-    case .unknown: return "The provider returned no usage percentage."
-    case .noProvidersEnabled: return "Enable a provider in Settings."
-    }
-  }
-
-  private var symbolName: String {
-    switch summary.status {
-    case .critical: "exclamationmark.circle.fill"
-    case .warning: "exclamationmark.triangle.fill"
-    case .healthy: "circle.fill"
-    case .unavailable: "circle.dashed"
-    }
-  }
-
-  private var color: Color {
-    switch summary.status {
-    case .critical: .red
-    case .warning: .orange
-    case .healthy, .unavailable: .secondary
+    case .healthy: return Color(red: 0.23, green: 0.45, blue: 0.62)
+    case .unavailable: return .secondary
     }
   }
 }
@@ -383,25 +318,6 @@ extension ProviderID {
     case .codex: "codex"
     case .kimi: "kimi"
     case .grok: "grok"
-    }
-  }
-}
-
-extension QuotaStatus {
-  var symbolName: String {
-    switch self {
-    case .healthy: "gauge.with.dots.needle.67percent"
-    case .warning: "gauge.with.dots.needle.33percent"
-    case .critical: "gauge.with.dots.needle.0percent"
-    case .unavailable: "gauge.with.dots.needle.50percent"
-    }
-  }
-
-  var color: Color {
-    switch self {
-    case .warning: .orange
-    case .critical: .red
-    case .healthy, .unavailable: .secondary
     }
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift
@@ -73,6 +73,34 @@ public struct UsageWindow: Identifiable, Equatable, Codable, Sendable {
     usedPercent.map { 100 - $0 }
   }
 
+  public var compactDisplayLabel: String {
+    switch kind {
+    case .rolling:
+      return label == "5-hour" ? label : "Rolling"
+    case .weekly:
+      return label.count <= 18 ? label : "Weekly"
+    case .monthly:
+      return label.count <= 18 ? label : "Monthly"
+    case .modelScoped(let model):
+      if label.count <= 18 { return label }
+      if label.localizedCaseInsensitiveContains("weekly") {
+        return "Weekly · \(model)"
+      }
+      return model
+    case .credits:
+      return label.count <= 18 ? label : "Credits"
+    case .providerDefined:
+      let prefix = "Provider quota · "
+      if label.hasPrefix(prefix) {
+        let detail = String(label.dropFirst(prefix.count))
+        return detail.count <= 18 ? detail : "Provider quota"
+      }
+      return label.count <= 18 ? label : "Provider window"
+    case .entitlement:
+      return label == "Fable 5 policy" ? "Provider quota" : "Policy"
+    }
+  }
+
   public static func validated(
     id: String,
     label: String,
@@ -209,8 +237,8 @@ public enum QuotaStatus: Int, Equatable, Sendable {
   case critical
 
   public static func forRemaining(_ remaining: Double) -> QuotaStatus {
-    if remaining < 5 { return .critical }
-    if remaining <= 20 { return .warning }
+    if remaining < 10 { return .critical }
+    if remaining < 30 { return .warning }
     return .healthy
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift
@@ -105,6 +105,8 @@ public struct ProviderOverview: Identifiable, Equatable, Sendable {
   public let state: ProviderDisplayState
   public let tightestWindow: UsageWindow?
   public let resetOverview: ResetOverview?
+  public let badges: [ProviderBadge]
+  public let dimsContent: Bool
 
   fileprivate var sourceTimestamp: Date? {
     guard case let .available(snapshot) = state else { return nil }
@@ -115,6 +117,7 @@ public struct ProviderOverview: Identifiable, Equatable, Sendable {
     switch state {
     case .available(let snapshot):
       guard snapshot.freshness == .current else { return 2 }
+      if badges.contains(where: { $0.kind == .partial }) { return 2 }
       return tightestWindow == nil ? 1 : 0
     case .loading, .unavailable:
       return 2
@@ -128,6 +131,8 @@ public struct ProviderOverview: Identifiable, Equatable, Sendable {
   fileprivate init(provider: ProviderID, state: ProviderDisplayState, at date: Date) {
     self.provider = provider
     self.state = state
+    let partial = Self.hasPartialData(provider: provider, state: state)
+    dimsContent = Self.shouldDimContent(state: state)
     if case let .available(snapshot) = state, snapshot.freshness == .current {
       tightestWindow = snapshot.windows
         .filter { $0.remainingPercent != nil }
@@ -143,6 +148,64 @@ public struct ProviderOverview: Identifiable, Equatable, Sendable {
       tightestWindow = nil
     }
     resetOverview = Self.makeResetOverview(provider: provider, state: state, at: date)
+    badges = Self.makeBadges(
+      provider: provider,
+      state: state,
+      resetOverview: resetOverview,
+      partial: partial,
+      at: date
+    )
+  }
+
+  private static func hasPartialData(provider: ProviderID, state: ProviderDisplayState) -> Bool {
+    guard provider == .grok, case let .available(snapshot) = state else { return false }
+    return snapshot.freshness == .current && !snapshot.notes.isEmpty
+  }
+
+  private static func shouldDimContent(state: ProviderDisplayState) -> Bool {
+    guard case let .available(snapshot) = state else { return false }
+    return snapshot.freshness != .current
+  }
+
+  private static func makeBadges(
+    provider: ProviderID,
+    state: ProviderDisplayState,
+    resetOverview: ResetOverview?,
+    partial: Bool,
+    at date: Date
+  ) -> [ProviderBadge] {
+    guard case let .available(snapshot) = state else { return [] }
+    var badges: [ProviderBadge] = []
+    switch snapshot.freshness {
+    case .current:
+      if partial {
+        badges.append(
+          .partial(
+            age: QuotaTimeFormatter.compactAge(since: snapshot.sourceTimestamp, at: date),
+            detail: snapshot.notes.joined(separator: " ")
+          )
+        )
+      }
+    case let .stale(reason):
+      badges.append(
+        .stale(
+          age: QuotaTimeFormatter.compactAge(since: snapshot.sourceTimestamp, at: date),
+          detail: reason
+        )
+      )
+    }
+    guard provider == .codex, snapshot.freshness == .current, let resetOverview else {
+      return badges
+    }
+    switch resetOverview {
+    case .none:
+      badges.append(.noResets)
+    case .available(let resets):
+      badges.append(.resets(expirations: resets.map(\.exp)))
+    case .unavailable:
+      badges.append(.resetsUnavailable)
+    }
+    return badges
   }
 
   private static func makeResetOverview(
@@ -161,6 +224,57 @@ public enum ResetOverview: Equatable, Sendable {
   case none
   case available([Reset])
   case unavailable(message: String)
+}
+
+public enum ProviderBadgeKind: Equatable, Sendable {
+  case stale
+  case partial
+  case noResets
+  case resets
+  case resetsUnavailable
+}
+
+public struct ProviderBadge: Equatable, Identifiable, Sendable {
+  public let kind: ProviderBadgeKind
+  public let age: String?
+  public let expirations: [Date]
+  public let detail: String?
+
+  public var id: String {
+    switch kind {
+    case .stale: return "stale"
+    case .partial: return "partial"
+    case .noResets: return "no-resets"
+    case .resets: return "resets"
+    case .resetsUnavailable: return "resets-unavailable"
+    }
+  }
+
+  public static func stale(age: String?, detail: String?) -> ProviderBadge {
+    ProviderBadge(kind: .stale, age: age, expirations: [], detail: detail)
+  }
+
+  public static func partial(age: String?, detail: String?) -> ProviderBadge {
+    ProviderBadge(kind: .partial, age: age, expirations: [], detail: detail)
+  }
+
+  public static let noResets = ProviderBadge(
+    kind: .noResets,
+    age: nil,
+    expirations: [],
+    detail: "No reset windows are currently available."
+  )
+
+  public static func resets(expirations: [Date]) -> ProviderBadge {
+    ProviderBadge(kind: .resets, age: nil, expirations: expirations, detail: nil)
+  }
+
+  public static let resetsUnavailable = ProviderBadge(
+    kind: .resetsUnavailable,
+    age: nil,
+    expirations: [],
+    detail: "The reset endpoint is unavailable."
+  )
 }
 
 public enum QuotaOverviewSummary: Equatable, Sendable {
@@ -210,6 +324,12 @@ public enum QuotaTimeFormatter {
     let hours = minutes / 60
     if hours < 24 { return "\(hours)h ago" }
     return "\(hours / 24)d ago"
+  }
+
+  public static func compactAge(since date: Date, at referenceDate: Date = .now) -> String? {
+    let seconds = boundedSeconds(referenceDate.timeIntervalSince(date))
+    guard seconds >= 86_400 else { return nil }
+    return "\(seconds / 86_400)D"
   }
 
   /// Clamps an interval into `Int`'s representable range before converting, so a malformed or

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/DomainTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/DomainTests.swift
@@ -5,15 +5,73 @@ import XCTest
 
 final class DomainTests: XCTestCase {
   func testPercentageAndStatusBoundaries() throws {
-    XCTAssertEqual(try XCTUnwrap(window(remaining: 4.99).remainingPercent), 4.99, accuracy: 0.001)
-    XCTAssertEqual(snapshot(remaining: 4.99).quotaStatus, .critical)
-    XCTAssertEqual(snapshot(remaining: 5).quotaStatus, .warning)
-    XCTAssertEqual(snapshot(remaining: 20).quotaStatus, .warning)
-    XCTAssertEqual(snapshot(remaining: 20.01).quotaStatus, .healthy)
+    XCTAssertEqual(try XCTUnwrap(window(remaining: 9.99).remainingPercent), 9.99, accuracy: 0.001)
+    XCTAssertEqual(snapshot(remaining: 9.99).quotaStatus, .critical)
+    XCTAssertEqual(snapshot(remaining: 10).quotaStatus, .warning)
+    XCTAssertEqual(snapshot(remaining: 29.99).quotaStatus, .warning)
+    XCTAssertEqual(snapshot(remaining: 30).quotaStatus, .healthy)
     XCTAssertEqual(snapshot(remaining: nil).quotaStatus, .unavailable)
     XCTAssertEqual(
       snapshot(remaining: 80).markedStale(reason: "offline").quotaStatus,
       .unavailable
+    )
+  }
+
+  func testCompactDisplayLabelsPreserveMeaningWithoutBoilerplate() throws {
+    XCTAssertEqual(
+      try UsageWindow.validated(
+        id: "weekly-fable",
+        label: "Weekly · Fable",
+        kind: .modelScoped(model: "Fable"),
+        usedPercent: 50,
+        resetAt: nil,
+        sourceTimestamp: .now
+      ).compactDisplayLabel,
+      "Weekly · Fable"
+    )
+    XCTAssertEqual(
+      try UsageWindow.validated(
+        id: "nimbus",
+        label: "Nimbus Quill extended model quota",
+        kind: .modelScoped(model: "Nimbus Quill"),
+        usedPercent: 50,
+        resetAt: nil,
+        sourceTimestamp: .now
+      ).compactDisplayLabel,
+      "Nimbus Quill"
+    )
+    XCTAssertEqual(
+      try UsageWindow.validated(
+        id: "weekly-fable-long",
+        label: "Weekly · Fable extended model quota",
+        kind: .modelScoped(model: "Fable"),
+        usedPercent: 50,
+        resetAt: nil,
+        sourceTimestamp: .now
+      ).compactDisplayLabel,
+      "Weekly · Fable"
+    )
+    XCTAssertEqual(
+      try UsageWindow.validated(
+        id: "provider-nimbus-quill",
+        label: "Provider quota · Nimbus Quill",
+        kind: .providerDefined,
+        usedPercent: 0,
+        resetAt: nil,
+        sourceTimestamp: .now
+      ).compactDisplayLabel,
+      "Nimbus Quill"
+    )
+    XCTAssertEqual(
+      try UsageWindow.validated(
+        id: "provider",
+        label: "Provider quota · extremely long provider label",
+        kind: .providerDefined,
+        usedPercent: 50,
+        resetAt: nil,
+        sourceTimestamp: .now
+      ).compactDisplayLabel,
+      "Provider quota"
     )
   }
 

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/QuotaOverviewTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/QuotaOverviewTests.swift
@@ -22,6 +22,88 @@ final class QuotaOverviewTests: XCTestCase {
     XCTAssertNil(overview.providers[3].tightestWindow)
   }
 
+  func testPartialCurrentDataSortsAfterTrustedCurrentData() {
+    let overview = QuotaOverview(
+      states: allStates([
+        .claudeCode: .available(snapshot(provider: .claudeCode, remaining: 50)),
+        .codex: .available(snapshot(provider: .codex, remaining: 20)),
+        .grok: .available(
+          UsageSnapshot(
+            provider: .grok,
+            windows: [window(remaining: 1)],
+            notes: ["Monthly usage is unavailable."],
+            sourceTimestamp: referenceDate
+          )
+        ),
+      ]),
+      at: referenceDate
+    )
+
+    XCTAssertEqual(overview.providers.map(\.provider), [.codex, .claudeCode, .grok, .kimi])
+    XCTAssertEqual(overview.providers[2].badges.map(\.kind), [.partial])
+  }
+
+  func testProviderBadgesDescribeFreshnessAndResetDetails() throws {
+    let staleDate = referenceDate.addingTimeInterval(-5 * 86_400)
+    let partialDate = referenceDate.addingTimeInterval(-4 * 86_400)
+    let resetDate = referenceDate.addingTimeInterval(4_000)
+    let overview = QuotaOverview(
+      states: allStates([
+        .codex: .available(
+          UsageSnapshot(
+            provider: .codex,
+            windows: [window(remaining: 14)],
+            resets: [Reset(exp: resetDate)],
+            sourceTimestamp: referenceDate
+          )
+        ),
+        .kimi: .available(
+          snapshot(provider: .kimi, remaining: 40, sourceTimestamp: staleDate)
+            .markedStale(reason: "offline")
+        ),
+        .grok: .available(
+          UsageSnapshot(
+            provider: .grok,
+            windows: [window(remaining: 44)],
+            notes: ["Monthly usage is unavailable."],
+            sourceTimestamp: partialDate
+          )
+        ),
+      ]),
+      at: referenceDate
+    )
+
+    let codex = try XCTUnwrap(overview.providers.first { $0.provider == .codex })
+    XCTAssertEqual(codex.badges.map(\.kind), [.resets])
+    XCTAssertEqual(codex.badges.first?.expirations, [resetDate])
+    XCTAssertNil(codex.badges.first?.detail)
+
+    let kimi = try XCTUnwrap(overview.providers.first { $0.provider == .kimi })
+    XCTAssertEqual(kimi.badges.map(\.kind), [.stale])
+    XCTAssertEqual(kimi.badges.first?.age, "5D")
+    XCTAssertEqual(kimi.badges.first?.detail, "offline")
+    XCTAssertTrue(kimi.dimsContent)
+
+    let grok = try XCTUnwrap(overview.providers.first { $0.provider == .grok })
+    XCTAssertEqual(grok.badges.map(\.kind), [.partial])
+    XCTAssertEqual(grok.badges.first?.age, "4D")
+    XCTAssertEqual(grok.badges.first?.detail, "Monthly usage is unavailable.")
+    XCTAssertFalse(grok.dimsContent)
+  }
+
+  func testCodexNoResetStateUsesCompactBadge() throws {
+    let overview = QuotaOverview(
+      states: allStates([
+        .codex: .available(snapshot(provider: .codex, remaining: 14))
+      ]),
+      at: referenceDate
+    )
+
+    let codex = try XCTUnwrap(overview.providers.first { $0.provider == .codex })
+    XCTAssertEqual(codex.badges.map(\.kind), [.noResets])
+    XCTAssertEqual(codex.badges.first?.detail, "No reset windows are currently available.")
+  }
+
   func testCriticalQuotaTakesPrecedenceOverStaleProvider() {
     let codex = snapshot(provider: .codex, remaining: 2)
     let overview = QuotaOverview(
@@ -146,6 +228,10 @@ final class QuotaOverviewTests: XCTestCase {
       QuotaTimeFormatter.compactCountdown(to: farFuture, from: referenceDate).contains("d"))
     XCTAssertTrue(
       QuotaTimeFormatter.refreshAge(since: farPast, at: referenceDate).hasSuffix("d ago"))
+    XCTAssertNotNil(QuotaTimeFormatter.compactAge(since: farPast, at: referenceDate))
+    XCTAssertTrue(
+      QuotaTimeFormatter.compactAge(since: farPast, at: referenceDate)?.hasSuffix("D") == true
+    )
   }
 
   func testCompactTimeFormattingAndLatestSourceTimestamp() {
@@ -183,6 +269,19 @@ final class QuotaOverviewTests: XCTestCase {
         at: referenceDate
       ),
       "2h ago"
+    )
+    XCTAssertNil(
+      QuotaTimeFormatter.compactAge(
+        since: referenceDate.addingTimeInterval(-3_600),
+        at: referenceDate
+      )
+    )
+    XCTAssertEqual(
+      QuotaTimeFormatter.compactAge(
+        since: referenceDate.addingTimeInterval(-5 * 86_400),
+        at: referenceDate
+      ),
+      "5D"
     )
 
     let newerTimestamp = referenceDate.addingTimeInterval(60)

--- a/packages/macos-ai-subscription-tracker/docs/signing-and-notarization.md
+++ b/packages/macos-ai-subscription-tracker/docs/signing-and-notarization.md
@@ -54,7 +54,8 @@ The commands intentionally separate the release artifacts:
 6. `verify:notarized` validates the app metadata, resources, strict signature,
    stapled ticket, and Gatekeeper assessment.
 7. `install:notarized` repeats the notarized verification before replacing only
-   `/Applications/QuotaBar.app` and launching that exact artifact.
+   `/Applications/Brim.app`, removing the legacy `/Applications/QuotaBar.app`
+   installation during migration, and launching that exact artifact.
 
 Xcode Organizer's **Distribute App → Developer ID → Upload** flow is the
 interactive equivalent of the export and submission steps.

--- a/packages/macos-ai-subscription-tracker/scripts/install-app.ts
+++ b/packages/macos-ai-subscription-tracker/scripts/install-app.ts
@@ -10,8 +10,12 @@ const notarized = mode === "--notarized";
 const source = notarized
   ? resolve(packageRoot, "dist", "notarized", "QuotaBar.app")
   : resolve(packageRoot, "dist", "QuotaBar.app");
-const target = "/Applications/QuotaBar.app";
-if (target !== "/Applications/QuotaBar.app")
+const target = "/Applications/Brim.app";
+const legacyTarget = "/Applications/QuotaBar.app";
+if (
+  target !== "/Applications/Brim.app" ||
+  legacyTarget !== "/Applications/QuotaBar.app"
+)
   throw new Error("Refusing unexpected install target.");
 
 const verificationScript = notarized
@@ -24,21 +28,36 @@ const verification = Bun.spawnSync(["bun", verificationScript], {
 });
 if (verification.exitCode !== 0) process.exit(verification.exitCode);
 
-const installedExecutable = `${target}/Contents/MacOS/QuotaBar`;
-for (const pid of installedProcessIDs(installedExecutable)) {
-  process.kill(pid, "SIGTERM");
+const installedExecutables = [
+  `${target}/Contents/MacOS/QuotaBar`,
+  `${legacyTarget}/Contents/MacOS/QuotaBar`,
+];
+for (const executable of installedExecutables) {
+  for (const pid of installedProcessIDs(executable)) {
+    process.kill(pid, "SIGTERM");
+  }
 }
 for (let attempt = 0; attempt < 50; attempt += 1) {
-  if (installedProcessIDs(installedExecutable).length === 0) break;
+  if (
+    installedExecutables.every(
+      (executable) => installedProcessIDs(executable).length === 0,
+    )
+  )
+    break;
   await Bun.sleep(100);
 }
-if (installedProcessIDs(installedExecutable).length !== 0) {
+if (
+  installedExecutables.some(
+    (executable) => installedProcessIDs(executable).length !== 0,
+  )
+) {
   throw new Error(`Refusing to replace running application at ${target}`);
 }
 
 console.log(`Installing verified bundle to exact target ${target}`);
 await rm(target, { recursive: true, force: true });
 await cp(source, target, { recursive: true });
+await rm(legacyTarget, { recursive: true, force: true });
 const signature = Bun.spawnSync(
   ["codesign", "--verify", "--deep", "--strict", target],
   {


### PR DESCRIPTION
## Why

Brim’s compact menu panel was difficult to scan and obscured whether quota data was current, partial, or stale. This change makes the panel denser while preserving provider response contracts and the existing compatibility identifiers.

## What

- Set the panel to 372pt and replace the summary strip with fixed `WINDOW / LEFT / RESETS` columns.
- Add threshold-aware quota bars: slate-blue at 30%+, amber at 10–29%, red below 10%, and gray for untrusted data.
- Replace redundant status rows with compact freshness, partial-data, and reset badges.
- Dim stale blocks while keeping fresh partial data readable.
- Preserve exact reset times and raw provider labels in help and accessibility text.
- Normalize provider-defined labels such as `Provider quota · Nimbus Quill` to `Nimbus Quill`.
- Sort providers by trusted quota pressure, then degraded state and stable provider order.
- Add representative previews and regression coverage for thresholds, ordering, badges, ages, labels, and accessibility metadata.
- Preserve the compact 16x16 Brim menu-bar icon and install verified bundles as `/Applications/Brim.app`.

## Verification

- `bun run verify:macos`
- 96 Swift tests; QuotaBarCore coverage 90.34%
- `bunx lefthook run pre-commit`
- Bundle signing and strict bundle verification
- Installed and running `/Applications/Brim.app`; legacy `/Applications/QuotaBar.app` absent