### PR TITLE
feat(starlight-karma-bot): expand recap configuration and history

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/starlight-karma-bot.md
+++ b/packages/docs/wiki/src/content/docs/explanation/starlight-karma-bot.md
@@ -95,11 +95,12 @@ making the same milestone eligible again.
 
 ## The recap posts without being asked
 
-A guild owner points the recap at a channel with `/karma config` (requires
-Manage Server). A dispatcher polls once a minute for guilds whose next fire time
-has passed, posts the month's top receivers and top givers plus an "on this
-day" entry from the archive, then advances the next fire time from the guild's
-CRON expression.
+A guild owner points the recap at a channel with `/karma config` (or the
+configured bot admin, who does not need Manage Server). A dispatcher polls once
+a minute for guilds whose next fire time has passed, posts the month's top
+receivers and top givers plus up to three historical entries from the same
+calendar week in an older year, then advances the next fire time from the
+guild's CRON expression.
 
 It advances that timestamp **even when posting fails**. Otherwise a deleted
 channel or a revoked permission turns into a retry every single minute forever.

--- a/packages/homelab/src/cdk8s/src/resources/starlight-karma-bot/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/starlight-karma-bot/index.ts
@@ -120,6 +120,9 @@ export function createStarlightKarmaBotDeployment(chart: Chart, stage: Stage) {
           key: "DISCORD_TOKEN",
         }),
         APPLICATION_ID: EnvValue.fromValue(applicationId),
+        // The bot owner may configure recaps without holding Manage Server in
+        // the guild. This is an identity, not a credential.
+        KARMA_ADMIN_USER_ID: EnvValue.fromValue("160509172704739328"),
         DATA_DIR: EnvValue.fromValue("/data"),
         // Prisma-native database, backfilled on first boot from the legacy
         // TypeORM `glitter.sqlite`.

--- a/packages/starlight-karma-bot/README.md
+++ b/packages/starlight-karma-bot/README.md
@@ -58,23 +58,29 @@ bun run health     # health check against a running instance
 
 Everything lives under one `/karma` slash command (defined in `src/karma/command-definitions.ts`):
 
-| Subcommand    | Description                                                                                            |
-| ------------- | ------------------------------------------------------------------------------------------------------ |
-| `give`        | Give karma to someone, with an optional reason (max 200 chars) and amount (1, 2, or 3; default 1)      |
-| `leaderboard` | Server rankings, with `type` (received / most generous) and `period` (all time, this year, this month) |
-| `check`       | See how much karma someone has (defaults to you)                                                       |
-| `stats`       | A karma profile: totals, rank, and who gives you most                                                  |
-| `why`         | See what someone earned their karma for                                                                |
-| `search`      | Search karma reasons for a word or phrase                                                              |
-| `undo`        | Take back the karma you just gave                                                                      |
-| `config`      | Configure the scheduled recap: channel, enabled, and a UTC cron expression (requires Manage Server)    |
-| `history`     | View recent changes to a person's karma                                                                |
+| Subcommand    | Description                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `give`        | Give karma to someone, with an optional reason (max 200 chars) and amount (1, 2, or 3; default 1)                |
+| `leaderboard` | Server rankings, with `type` (received / most generous) and `period` (all time, this year, this month)           |
+| `check`       | See how much karma someone has (defaults to you)                                                                 |
+| `stats`       | A karma profile: totals, rank, and who gives you most                                                            |
+| `why`         | See what someone earned their karma for                                                                          |
+| `search`      | Search karma reasons for a word or phrase                                                                        |
+| `undo`        | Take back the karma you just gave                                                                                |
+| `config`      | Configure the scheduled recap: channel, enabled, and a UTC cron expression (requires Manage Server or bot admin) |
+| `history`     | View recent changes to a person's karma                                                                          |
 
 Karma can also be given by reacting with the karma emoji (`KARMA_EMOJI`, default a star) or via **Apps → Give Karma** on any message.
 
 ## Scheduled recap
 
-The bot posts a periodic recap (leaderboard top 5, most generous, and a slice of the reason archive) without anyone typing a command. `src/karma/recap.ts` polls for due guilds once a minute and advances the next-fire timestamp even when posting fails, so a deleted channel is not retried forever. The schedule is a per-guild cron expression evaluated in UTC (`src/karma/recap-schedule.ts`, default `0 17 * * 5` — Fridays 17:00 UTC), configured with `/karma config`.
+The bot posts a periodic recap (leaderboard top 5, most generous, and up to
+three historical entries from the same Monday-Sunday calendar week in an older year)
+without anyone typing a command. `src/karma/recap.ts` polls for due guilds once
+a minute and advances the next-fire timestamp even when posting fails, so a
+deleted channel is not retried forever. The schedule is a per-guild cron
+expression evaluated in UTC (`src/karma/recap-schedule.ts`, default `0 17 * * 5`
+— Fridays 17:00 UTC), configured with `/karma config`.
 
 ## Milestones and reason filters
 
@@ -123,6 +129,8 @@ Optional environment variables:
 
 - `SENTRY_DSN`: Sentry DSN for error tracking
 - `PORT`: Server port (default: 8000)
+- `KARMA_ADMIN_USER_ID`: Discord user ID allowed to configure recaps without
+  the Manage Server permission
 - `LEGACY_DATABASE_PATH`: **upgrades only** — see below. Leave it unset on a
   fresh install.
 - `KARMA_EMOJI`: emoji that awards karma when reacted with (default `⭐`). A

--- a/packages/starlight-karma-bot/src/configuration.ts
+++ b/packages/starlight-karma-bot/src/configuration.ts
@@ -14,6 +14,8 @@ export default {
   port: env.get("PORT").default("8000").asPortNumber(),
   discordToken: env.get("DISCORD_TOKEN").required().asString(),
   applicationId: env.get("APPLICATION_ID").required().asString(),
+  /** Discord user ID allowed to configure recaps without Manage Server. */
+  karmaAdminUserId: env.get("KARMA_ADMIN_USER_ID").default("").asString(),
   /** Emoji that awards karma when reacted with. A unicode character matches by
    *  name; a custom guild emoji matches by its snowflake id. */
   karmaEmoji: env.get("KARMA_EMOJI").default("⭐").asString(),

--- a/packages/starlight-karma-bot/src/karma/authorization.test.ts
+++ b/packages/starlight-karma-bot/src/karma/authorization.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { canConfigureKarma } from "./authorization.ts";
+
+describe("canConfigureKarma", () => {
+  test("allows the configured bot admin without Manage Server", () => {
+    expect(
+      canConfigureKarma({
+        userId: "admin",
+        adminUserId: "admin",
+        hasManageGuild: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("allows guild managers", () => {
+    expect(
+      canConfigureKarma({
+        userId: "manager",
+        adminUserId: "admin",
+        hasManageGuild: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects other users without Manage Server", () => {
+    expect(
+      canConfigureKarma({
+        userId: "member",
+        adminUserId: "admin",
+        hasManageGuild: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/starlight-karma-bot/src/karma/authorization.ts
+++ b/packages/starlight-karma-bot/src/karma/authorization.ts
@@ -1,0 +1,8 @@
+/** Authorization for guild-level karma configuration. */
+export function canConfigureKarma(params: {
+  userId: string;
+  adminUserId: string;
+  hasManageGuild: boolean;
+}): boolean {
+  return params.hasManageGuild || params.userId === params.adminUserId;
+}

--- a/packages/starlight-karma-bot/src/karma/commands.ts
+++ b/packages/starlight-karma-bot/src/karma/commands.ts
@@ -9,6 +9,8 @@ import {
   userMention,
 } from "discord.js";
 import { prisma } from "#src/db/index.ts";
+import configuration from "#src/configuration.ts";
+import { canConfigureKarma } from "#src/karma/authorization.ts";
 import { karmaAmountFor, KARMA_GIVE_AMOUNT } from "#src/karma/scoring.ts";
 import { handleKarmaLeaderboard } from "#src/karma/leaderboard.ts";
 import {
@@ -332,8 +334,15 @@ async function handleKarmaConfig(interaction: ChatInputCommandInteraction) {
   if (guildId === null) {
     return;
   }
+  const hasManageGuild =
+    interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild) ===
+    true;
   if (
-    interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild) !== true
+    !canConfigureKarma({
+      userId: interaction.user.id,
+      adminUserId: configuration.karmaAdminUserId,
+      hasManageGuild,
+    })
   ) {
     await interaction.reply({
       content: "You need the Manage Server permission to change karma config.",

--- a/packages/starlight-karma-bot/src/karma/recap-history.test.ts
+++ b/packages/starlight-karma-bot/src/karma/recap-history.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { isInHistoricalUtcWeek } from "./recap-history.ts";
+
+describe("isInHistoricalUtcWeek", () => {
+  const now = new Date("2026-08-12T12:00:00.000Z");
+
+  test("matches the same Monday-Sunday week from an older year", () => {
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-08-09T12:00:00.000Z"), now),
+    ).toBe(false);
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-08-11T12:00:00.000Z"), now),
+    ).toBe(true);
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-08-16T12:00:00.000Z"), now),
+    ).toBe(true);
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-08-17T12:00:00.000Z"), now),
+    ).toBe(false);
+  });
+
+  test("handles a week that crosses New Year's Day", () => {
+    const newYearNow = new Date("2028-01-02T12:00:00.000Z");
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-12-30T12:00:00.000Z"), newYearNow),
+    ).toBe(true);
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-01-01T12:00:00.000Z"), newYearNow),
+    ).toBe(true);
+    expect(
+      isInHistoricalUtcWeek(new Date("2025-12-26T12:00:00.000Z"), newYearNow),
+    ).toBe(false);
+  });
+});

--- a/packages/starlight-karma-bot/src/karma/recap-history.ts
+++ b/packages/starlight-karma-bot/src/karma/recap-history.ts
@@ -1,0 +1,28 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Whether a historical timestamp falls in the current UTC Monday-Sunday week.
+ *
+ * The year is intentionally ignored. The caller filters out recent rows first,
+ * so this matches the same calendar week from the older archive, including
+ * weeks that cross New Year's Day. */
+export function isInHistoricalUtcWeek(datetime: Date, now: Date): boolean {
+  const daysSinceMonday = (now.getUTCDay() + 6) % 7;
+  const weekStart = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - daysSinceMonday,
+    ),
+  );
+
+  for (let offset = 0; offset < 7; offset += 1) {
+    const day = new Date(weekStart.getTime() + offset * DAY_MS);
+    if (
+      datetime.getUTCMonth() === day.getUTCMonth() &&
+      datetime.getUTCDate() === day.getUTCDate()
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/starlight-karma-bot/src/karma/recap.ts
+++ b/packages/starlight-karma-bot/src/karma/recap.ts
@@ -14,12 +14,14 @@ import { bold, ChannelType, time, userMention } from "discord.js";
 import client from "#src/discord/client.ts";
 import { prisma } from "#src/db/index.ts";
 import { getLeaderboard } from "#src/karma/queries.ts";
+import { isInHistoricalUtcWeek } from "#src/karma/recap-history.ts";
 import { humanReasonFilter } from "#src/karma/reason-filters.ts";
 import { computeNextRecapAt } from "#src/karma/recap-schedule.ts";
 import { SingleFlight } from "#src/karma/single-flight.ts";
 
 const POLL_INTERVAL_MS = 60_000;
 const RECAP_TOP_N = 5;
+const HISTORICAL_ENTRY_LIMIT = 3;
 
 /** Guilds whose recap is due. A null `nextRecapAt` counts as due — that is the
  *  self-heal path for a row enabled before a time was ever computed. */
@@ -39,10 +41,10 @@ async function displayName(id: string): Promise<string> {
   return user.username;
 }
 
-/** Karma given on this calendar day in any previous year.
+/** Karma given during this calendar week in any previous year.
  *  The archive is the bot's most valuable and least used asset: 362 entries
  *  going back to 2023, 89% of them carrying a human-written reason. */
-async function onThisDay(guildId: string, now: Date) {
+async function onThisWeek(guildId: string, now: Date) {
   const rows = await prisma.karma.findMany({
     where: {
       guildId,
@@ -57,11 +59,7 @@ async function onThisDay(guildId: string, now: Date) {
       receiverId: true,
     },
   });
-  return rows.filter(
-    (row) =>
-      row.datetime.getUTCMonth() === now.getUTCMonth() &&
-      row.datetime.getUTCDate() === now.getUTCDate(),
-  );
+  return rows.filter((row) => isInHistoricalUtcWeek(row.datetime, now));
 }
 
 export async function buildRecap(
@@ -71,7 +69,7 @@ export async function buildRecap(
   const [received, given, memories] = await Promise.all([
     getLeaderboard({ guildId, kind: "received", period: "month", now }),
     getLeaderboard({ guildId, kind: "given", period: "month", now }),
-    onThisDay(guildId, now),
+    onThisWeek(guildId, now),
   ]);
 
   if (received.length === 0 && given.length === 0 && memories.length === 0) {
@@ -102,10 +100,15 @@ export async function buildRecap(
     sections.push(`\nMost generous this month:\n${lines.join("\n")}`);
   }
 
-  const memory = memories[0];
-  if (memory !== undefined) {
+  const historicalEntries = memories.slice(0, HISTORICAL_ENTRY_LIMIT);
+  if (historicalEntries.length > 0) {
     sections.push(
-      `\nOn this day, ${time(memory.datetime, "D")}:\n${userMention(memory.giverId)} gave ${userMention(memory.receiverId)} karma for \`${memory.reason ?? ""}\``,
+      `\nThis week in karma:\n${historicalEntries
+        .map(
+          (entry) =>
+            `${time(entry.datetime, "D")}: ${userMention(entry.giverId)} gave ${userMention(entry.receiverId)} karma for \`${entry.reason ?? ""}\``,
+        )
+        .join("\n")}`,
     );
   }
 


### PR DESCRIPTION
Why

The bot admin needs to configure guild recaps without Manage Server, and a single daily historical entry is too sparse for a useful weekly recap.

What

- Allow the configured bot admin to use /karma config without Manage Server.
- Replace the historical on-this-day item with up to three entries from the matching UTC Monday-Sunday week in older years, newest first.
- Update deployment configuration, focused tests, README, plan, and wiki documentation.

Verification

- 146 bot tests pass.
- Bot package typecheck, lint, and formatting pass.
- Wiki typecheck, unit tests, static build, and 7 browser tests pass.
- Homelab cdk8s build passes.
- git diff --check passes.

Rollout

The PR includes the deployment environment configuration but has not been deployed to the live bot.