### PR TITLE
feat(better-skill-capped): Orama search core with facets and champion normalization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.7.0",
+        "@orama/orama": "^3.1.18",
         "@sentry/react": "^10.49.0",
         "@tanstack/query-async-storage-persister": "^5.101.4",
         "@tanstack/react-query": "^5.101.4",
@@ -2957,6 +2958,8 @@
     "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.10.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.10.0", "@opentelemetry/core": "2.10.0", "@opentelemetry/sdk-trace-base": "2.10.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 

--- a/knip.json
+++ b/knip.json
@@ -63,7 +63,7 @@
       "project": ["src/**/*.{ts,tsx}"]
     },
     "packages/better-skill-capped": {
-      "entry": ["src/main.tsx", "vite.config.ts"],
+      "entry": ["src/main.tsx", "src/**/*.test.ts", "vite.config.ts"],
       "project": ["src/**/*.{ts,tsx}", "vite.config.ts"],
       "ignoreDependencies": ["shadcn"],
       "vite": false

--- a/packages/better-skill-capped/package.json
+++ b/packages/better-skill-capped/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
+    "@orama/orama": "^3.1.18",
     "@sentry/react": "^10.49.0",
     "@tanstack/query-async-storage-persister": "^5.101.4",
     "@tanstack/react-query": "^5.101.4",

--- a/packages/better-skill-capped/src/search/fixtures/search-fixture.ts
+++ b/packages/better-skill-capped/src/search/fixtures/search-fixture.ts
@@ -1,0 +1,247 @@
+import type { Content } from "#src/model/content";
+import { ManifestSchema } from "#src/parser/manifest";
+import { parseManifest } from "#src/parser/parser";
+
+/**
+ * A hand-built, schema-validated corpus sized for ranking assertions:
+ * distinct docs match "wave control" via title, child video titles, and
+ * description only; champions cover the apostrophe cases; coaches have a
+ * known distribution.
+ */
+
+type RawVideo = {
+  role: string;
+  title: string;
+  desc: string;
+  rDate: number;
+  durSec: number;
+  uuid: string;
+  tId: number;
+  tSS: string;
+  cSS: string;
+};
+
+function makeVideo(options: {
+  uuid: string;
+  title: string;
+  role: string;
+  desc?: string;
+  rDate?: number;
+  durSec?: number;
+}): RawVideo {
+  return {
+    role: options.role,
+    title: options.title,
+    desc: options.desc ?? "",
+    rDate: options.rDate ?? 1_700_000_000_000,
+    durSec: options.durSec ?? 400,
+    uuid: options.uuid,
+    tId: 1,
+    tSS: "",
+    cSS: "",
+  };
+}
+
+function makeCommentary(options: {
+  uuid: string;
+  role: string;
+  staff: string;
+  yourChampion: string;
+  theirChampion: string;
+  rDate?: number;
+  durSec?: number;
+  carry?: string;
+  type?: string;
+}): Record<string, unknown> {
+  return {
+    role: options.role,
+    rDate: options.rDate ?? 1_690_000_000_000,
+    durSec: options.durSec ?? 900,
+    uuid: options.uuid,
+    tId: 2,
+    tSS: "",
+    staff: options.staff,
+    matchLink: "https://www.leagueofgraphs.com/match/na/1",
+    yourChampion: options.yourChampion,
+    theirChampion: options.theirChampion,
+    k: 5,
+    d: 2,
+    a: 7,
+    gameTime: "25m30s",
+    carry: options.carry ?? "Light",
+    type: options.type ?? "Smurf",
+    rune1: "",
+    rune2: "",
+    rune3: "",
+    item1: "",
+    item2: "",
+    item3: "",
+  };
+}
+
+function makeCourse(options: {
+  uuid: string;
+  title: string;
+  role: string;
+  rDate?: number;
+}): Record<string, unknown> {
+  return {
+    title: options.title,
+    uuid: options.uuid,
+    desc: "",
+    rDate: options.rDate ?? 1_710_000_000_000,
+    role: options.role,
+    courseImage: "https://example.com/a.png",
+    courseImage2: "https://example.com/b.png",
+    courseImage3: "https://example.com/c.png",
+    tags: [],
+    recommended: false,
+    override: false,
+    overlay: "none",
+  };
+}
+
+const RAW_MANIFEST = {
+  timeStamp: 1_720_000_000_000,
+  patch: {
+    patchVal: "26.16",
+    releaseDate: 1_710_000_000_000,
+    patchUrl: "https://example.com/patch",
+  },
+  config: { game: "lol", tcoaching: "true", "": "" },
+  videos: [
+    makeVideo({
+      uuid: "v-intro",
+      title: "Intro To Botlane",
+      role: "support",
+      rDate: 1_712_000_000_000,
+      durSec: 300,
+    }),
+    makeVideo({
+      uuid: "v-trading",
+      title: "Trading Stance",
+      role: "support",
+      rDate: 1_711_000_000_000,
+      durSec: 350,
+    }),
+    makeVideo({
+      uuid: "v-wave-fund",
+      title: "Wave Control Fundamentals",
+      role: "mid",
+      rDate: 1_713_000_000_000,
+      durSec: 500,
+    }),
+    makeVideo({
+      uuid: "v-laning",
+      title: "Laning Basics",
+      role: "top",
+      desc: "Everything about wave control and tempo for beginners.",
+      rDate: 1_714_000_000_000,
+      durSec: 800,
+    }),
+  ],
+  commentaries: [
+    makeCommentary({
+      uuid: "c-kaisa",
+      role: "adc",
+      staff: "Sjorry",
+      yourChampion: "Kai'Sa",
+      theirChampion: "Fizz",
+      rDate: 1_715_000_000_000,
+      durSec: 1200,
+      carry: "Heavy",
+      type: "High Elo",
+    }),
+    makeCommentary({
+      uuid: "c-ksante",
+      role: "top",
+      staff: "Hector",
+      yourChampion: "K'Sante",
+      theirChampion: "Garen",
+      rDate: 1_716_000_000_000,
+      durSec: 1100,
+    }),
+    makeCommentary({
+      uuid: "c-graves",
+      role: "jungle",
+      staff: "Sjorry",
+      yourChampion: "Graves",
+      theirChampion: "Lee Sin",
+      rDate: 1_717_000_000_000,
+      durSec: 1000,
+      carry: "Medium",
+    }),
+    makeCommentary({
+      uuid: "c-lux",
+      role: "support",
+      staff: "Sam the Man",
+      yourChampion: "Lux",
+      theirChampion: "Ahri",
+      rDate: 1_718_000_000_000,
+      durSec: 950,
+      type: "Earpiece",
+    }),
+  ],
+  staff: [
+    {
+      name: "Sjorry",
+      summonerName: "Sjorry",
+      profileImage: "https://example.com/s.svg",
+      profileImageWithRank: "https://example.com/s.png",
+      playerPeakRank: 5,
+    },
+  ],
+  courses: [
+    makeCourse({
+      uuid: "crs-wave",
+      title: "Wave Control {support}",
+      role: "support",
+      rDate: 1_719_000_000_000,
+    }),
+    makeCourse({
+      uuid: "crs-macro",
+      title: "Macro Mastery {mid}",
+      role: "mid",
+      rDate: 1_709_000_000_000,
+    }),
+    makeCourse({
+      uuid: "crs-laning",
+      title: "Laning 101 {top}",
+      role: "top",
+      rDate: 1_708_000_000_000,
+    }),
+  ],
+  thisWeekData: [],
+  carousel: [],
+  tagInfo: [],
+  videosToCourses: {
+    "Wave Control {support}": {
+      chapters: [
+        {
+          title: "Course Content",
+          vids: [{ uuid: "v-intro" }, { uuid: "v-trading" }],
+        },
+      ],
+    },
+    "Macro Mastery {mid}": {
+      chapters: [
+        {
+          title: "Course Content",
+          vids: [{ uuid: "v-wave-fund" }],
+        },
+      ],
+    },
+    "Laning 101 {top}": {
+      chapters: [
+        {
+          title: "Course Content",
+          vids: [{ uuid: "v-laning" }],
+        },
+      ],
+    },
+  },
+};
+
+export function searchFixtureContent(): Content {
+  return parseManifest(ManifestSchema.parse(RAW_MANIFEST));
+}

--- a/packages/better-skill-capped/src/search/highlight.ts
+++ b/packages/better-skill-capped/src/search/highlight.ts
@@ -1,0 +1,26 @@
+import { normalizeName } from "./normalize.ts";
+
+/**
+ * Terms to feed react-highlight-words. Orama v3 does not return match
+ * positions, so highlighting re-derives from the query: every token of at
+ * least two characters, plus any champion display name whose normalized form
+ * matches a normalized query token ("kaisa" highlights "Kai'Sa").
+ *
+ * Accepted limitation: tolerance-corrected typos don't highlight.
+ */
+export function getHighlightTerms(
+  query: string,
+  championAliases: ReadonlyMap<string, string>,
+): string[] {
+  const tokens = query
+    .split(/[\s|]+/)
+    .map((token) => token.replaceAll(/^[='!^$]+|[='!^$]+$/g, ""))
+    .filter((token) => token.length >= 2);
+
+  const championMatches = tokens.flatMap((token) => {
+    const display = championAliases.get(normalizeName(token));
+    return display === undefined ? [] : [display];
+  });
+
+  return [...new Set([...tokens, ...championMatches])];
+}

--- a/packages/better-skill-capped/src/search/index-builder.ts
+++ b/packages/better-skill-capped/src/search/index-builder.ts
@@ -1,0 +1,41 @@
+import { create, insertMultiple } from "@orama/orama";
+import type { SearchDoc } from "./search-doc.ts";
+
+export const SEARCH_SCHEMA = {
+  title: "string",
+  description: "string",
+  childTitles: "string",
+  champions: "string",
+  staffText: "string",
+  searchAux: "string",
+  kind: "enum",
+  role: "enum",
+  staff: "enum",
+  yourChampion: "enum",
+  theirChampion: "enum",
+  tags: "enum[]",
+  carry: "enum",
+  commentaryType: "enum",
+  recommended: "boolean",
+  releaseDate: "number",
+  durationInSeconds: "number",
+} as const;
+
+function buildEmptyIndex() {
+  return create({ schema: SEARCH_SCHEMA });
+}
+
+export type SearchIndex = ReturnType<typeof buildEmptyIndex>;
+
+/**
+ * Builds the single unified index over all ~6.3k docs. Cheap enough (tens of
+ * milliseconds) to rebuild whenever the manifest itself changes — and only
+ * then; filters, bookmarks, and watch toggles never trigger a rebuild.
+ */
+export async function createSearchIndex(
+  docs: SearchDoc[],
+): Promise<SearchIndex> {
+  const index = buildEmptyIndex();
+  await insertMultiple(index, docs);
+  return index;
+}

--- a/packages/better-skill-capped/src/search/normalize.ts
+++ b/packages/better-skill-capped/src/search/normalize.ts
@@ -1,0 +1,39 @@
+/**
+ * Champion names (Kai'Sa, K'Sante, Cho'Gath, Bel'Veth…) contain punctuation
+ * that splits into separate tokens under Orama's default tokenizer. Instead
+ * of a custom tokenizer, both the index and the query path store/derive a
+ * normalized form: NFKD-fold diacritics, lowercase, strip apostrophes,
+ * periods, spaces, ampersands, and hyphens — so "kaisa", "kai'sa", and
+ * "kai sa" all reach the same token.
+ */
+export function normalizeName(input: string): string {
+  return input
+    .normalize("NFKD")
+    .replaceAll(/\p{M}/gu, "")
+    .toLowerCase()
+    .replaceAll(/['’.\s&-]/g, "");
+}
+
+/** Map from normalized champion name to its display form. */
+export function buildChampionAliases(
+  champions: Iterable<string>,
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const champion of champions) {
+    aliases.set(normalizeName(champion), champion);
+  }
+  return aliases;
+}
+
+/**
+ * Normalized variants of words that would tokenize badly (contain an
+ * apostrophe or period), e.g. a title "Kai'Sa ADC Guide" yields "kaisa".
+ */
+export function auxiliaryTerms(text: string): string {
+  return text
+    .split(/\s+/)
+    .filter((word) => /['’.]/.test(word))
+    .map((word) => normalizeName(word))
+    .filter((word) => word.length > 0)
+    .join(" ");
+}

--- a/packages/better-skill-capped/src/search/run-search.test.ts
+++ b/packages/better-skill-capped/src/search/run-search.test.ts
@@ -1,0 +1,204 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { buildChampionAliases, normalizeName } from "./normalize.ts";
+import { contentToSearchDocs } from "./search-doc.ts";
+import { createSearchIndex, type SearchIndex } from "./index-builder.ts";
+import {
+  runSearch,
+  type SearchRunParams,
+  type UserContentState,
+} from "./run-search.ts";
+import { getHighlightTerms } from "./highlight.ts";
+import { searchFixtureContent } from "./fixtures/search-fixture.ts";
+
+const NO_STATE: UserContentState = {
+  watchedUuids: new Set(),
+  bookmarkedUuids: new Set(),
+};
+
+function params(overrides: Partial<SearchRunParams> = {}): SearchRunParams {
+  return {
+    q: "",
+    kind: [],
+    role: [],
+    champion: [],
+    staff: [],
+    tag: [],
+    carry: [],
+    ctype: [],
+    watched: "any",
+    bookmarked: "any",
+    sort: "relevance",
+    page: 1,
+    ...overrides,
+  };
+}
+
+let index: SearchIndex;
+
+beforeAll(async () => {
+  index = await createSearchIndex(contentToSearchDocs(searchFixtureContent()));
+});
+
+describe("normalizeName", () => {
+  test("strips apostrophes, punctuation, and case", () => {
+    expect(normalizeName("Kai'Sa")).toBe("kaisa");
+    expect(normalizeName("K'Sante")).toBe("ksante");
+    expect(normalizeName("Cho'Gath")).toBe("chogath");
+    expect(normalizeName("Bel’Veth")).toBe("belveth");
+    expect(normalizeName("Dr. Mundo")).toBe("drmundo");
+    expect(normalizeName("Nunu & Willump")).toBe("nunuwillump");
+  });
+});
+
+describe("runSearch", () => {
+  test("browse mode returns everything, newest first", async () => {
+    const result = await runSearch(index, params(), NO_STATE);
+    expect(result.total).toBe(11);
+    expect(result.docs[0]?.uuid).toBe("crs-wave");
+    const dates = result.docs.map((doc) => doc.releaseDate);
+    expect(dates).toEqual([...dates].sort((a, b) => b - a));
+  });
+
+  test("finds Kai'Sa by normalized, apostrophed, and split spellings", async () => {
+    for (const query of ["kaisa", "kai'sa", "kai sa"]) {
+      const result = await runSearch(index, params({ q: query }), NO_STATE);
+      expect(result.docs.map((doc) => doc.uuid)).toContain("c-kaisa");
+    }
+  });
+
+  test("finds K'Sante by normalized spelling", async () => {
+    const result = await runSearch(index, params({ q: "ksante" }), NO_STATE);
+    expect(result.docs.map((doc) => doc.uuid)).toContain("c-ksante");
+  });
+
+  test("ranks title matches above child-title and description matches", async () => {
+    const result = await runSearch(
+      index,
+      params({ q: "wave control" }),
+      NO_STATE,
+    );
+    const uuids = result.docs.map((doc) => doc.uuid);
+    expect(uuids).toContain("crs-wave");
+    expect(uuids).toContain("crs-macro");
+    expect(uuids).toContain("v-laning");
+    expect(uuids.indexOf("crs-wave")).toBeLessThan(uuids.indexOf("crs-macro"));
+    expect(uuids.indexOf("crs-macro")).toBeLessThan(uuids.indexOf("v-laning"));
+  });
+
+  test("typo-tolerant queries still return results", async () => {
+    const result = await runSearch(
+      index,
+      params({ q: "wave contrl" }),
+      NO_STATE,
+    );
+    expect(result.total).toBeGreaterThan(0);
+  });
+
+  test("kind and role where-clauses restrict results", async () => {
+    const commentaries = await runSearch(
+      index,
+      params({ kind: ["commentary"] }),
+      NO_STATE,
+    );
+    expect(commentaries.total).toBe(4);
+    expect(commentaries.docs.every((doc) => doc.kind === "commentary")).toBe(
+      true,
+    );
+
+    const jungle = await runSearch(
+      index,
+      params({ role: ["jungle"] }),
+      NO_STATE,
+    );
+    expect(jungle.docs.map((doc) => doc.uuid)).toEqual(["c-graves"]);
+  });
+
+  test("facet counts reflect the corpus", async () => {
+    const result = await runSearch(index, params(), NO_STATE);
+    expect(result.facets.kind).toEqual({
+      course: 3,
+      video: 4,
+      commentary: 4,
+    });
+    expect(result.facets.staff["Sjorry"]).toBe(2);
+    expect(result.facets.staff["Hector"]).toBe(1);
+    expect(result.facets.champion["Kai'Sa"]).toBe(1);
+  });
+
+  test("watched filter excludes docs and corrects facet counts", async () => {
+    const state: UserContentState = {
+      watchedUuids: new Set(["c-kaisa", "v-laning"]),
+      bookmarkedUuids: new Set(),
+    };
+    const result = await runSearch(
+      index,
+      params({ watched: "unwatched" }),
+      state,
+    );
+    const uuids = result.docs.map((doc) => doc.uuid);
+    expect(uuids).not.toContain("c-kaisa");
+    expect(uuids).not.toContain("v-laning");
+    expect(result.total).toBe(9);
+    // Corrected counts: the watched Kai'Sa commentary no longer counts.
+    expect(result.facets.kind["commentary"]).toBe(3);
+    expect(result.facets.kind["video"]).toBe(3);
+    expect(result.facets.staff["Sjorry"]).toBe(1);
+    expect(result.facets.champion["Kai'Sa"]).toBe(0);
+  });
+
+  test("bookmarked filter narrows to bookmarked docs", async () => {
+    const state: UserContentState = {
+      watchedUuids: new Set(),
+      bookmarkedUuids: new Set(["crs-wave"]),
+    };
+    const result = await runSearch(
+      index,
+      params({ bookmarked: "bookmarked" }),
+      state,
+    );
+    expect(result.docs.map((doc) => doc.uuid)).toEqual(["crs-wave"]);
+  });
+
+  test("sort options reorder results", async () => {
+    const shortest = await runSearch(
+      index,
+      params({ sort: "shortest" }),
+      NO_STATE,
+    );
+    const durations = shortest.docs.map((doc) => doc.durationInSeconds);
+    expect(durations).toEqual([...durations].sort((a, b) => a - b));
+
+    const oldest = await runSearch(index, params({ sort: "oldest" }), NO_STATE);
+    const dates = oldest.docs.map((doc) => doc.releaseDate);
+    expect(dates).toEqual([...dates].sort((a, b) => a - b));
+  });
+
+  test("pagination slices and reports page count", async () => {
+    const page1 = await runSearch(index, params(), NO_STATE);
+    expect(page1.pageCount).toBe(1);
+    expect(page1.docs).toHaveLength(11);
+
+    const page2 = await runSearch(index, params({ page: 2 }), NO_STATE);
+    expect(page2.docs).toHaveLength(0);
+    expect(page2.total).toBe(11);
+  });
+});
+
+describe("getHighlightTerms", () => {
+  const aliases = buildChampionAliases(["Kai'Sa", "K'Sante", "Lux"]);
+
+  test("returns query tokens plus matching champion display names", () => {
+    expect(getHighlightTerms("kaisa guide", aliases).toSorted()).toEqual([
+      "Kai'Sa",
+      "guide",
+      "kaisa",
+    ]);
+  });
+
+  test("drops single-character tokens and operator prefixes", () => {
+    expect(getHighlightTerms("a =lux", aliases).toSorted()).toEqual([
+      "Lux",
+      "lux",
+    ]);
+  });
+});

--- a/packages/better-skill-capped/src/search/run-search.ts
+++ b/packages/better-skill-capped/src/search/run-search.ts
@@ -1,0 +1,282 @@
+import { count, search } from "@orama/orama";
+import type { Results, SearchParamsFullText } from "@orama/orama";
+import type { Kind } from "#src/model/content";
+import type { Role } from "#src/model/role";
+import type { SearchIndex } from "./index-builder.ts";
+import type { SearchDoc } from "./search-doc.ts";
+
+export type SortOption =
+  | "relevance"
+  | "newest"
+  | "oldest"
+  | "shortest"
+  | "longest";
+
+export type SearchRunParams = {
+  q: string;
+  kind: Kind[];
+  role: Role[];
+  champion: string[];
+  staff: string[];
+  tag: string[];
+  carry: string[];
+  ctype: string[];
+  watched: "any" | "watched" | "unwatched";
+  bookmarked: "any" | "bookmarked" | "unbookmarked";
+  sort: SortOption;
+  page: number;
+};
+
+export type UserContentState = {
+  watchedUuids: ReadonlySet<string>;
+  bookmarkedUuids: ReadonlySet<string>;
+};
+
+export type FacetCounts = Record<string, number>;
+
+export type SearchRunResult = {
+  /** The requested page of matching docs. */
+  docs: SearchDoc[];
+  /** Total matches after all filtering. */
+  total: number;
+  pageCount: number;
+  /** Conjunctive facet counts, corrected for the post-filter pass. */
+  facets: {
+    kind: FacetCounts;
+    role: FacetCounts;
+    champion: FacetCounts;
+    staff: FacetCounts;
+    tags: FacetCounts;
+    carry: FacetCounts;
+    commentaryType: FacetCounts;
+  };
+};
+
+export const SEARCH_PAGE_SIZE = 20;
+
+const SEARCHED_PROPERTIES = [
+  "title",
+  "champions",
+  "searchAux",
+  "childTitles",
+  "staffText",
+  "description",
+] as const;
+
+const BOOSTS = {
+  title: 4,
+  champions: 3,
+  searchAux: 3,
+  childTitles: 2,
+  staffText: 2,
+  description: 1,
+};
+
+// Orama caps facet values at 10 by default; every real cardinality here is
+// known (173 champions, ~25 coaches, ~100 tags).
+const FACETS_CONFIG = {
+  kind: { limit: 3 },
+  role: { limit: 6 },
+  yourChampion: { limit: 200 },
+  staff: { limit: 50 },
+  tags: { limit: 150 },
+  carry: { limit: 3 },
+  commentaryType: { limit: 5 },
+};
+
+type EnumInClause = { in: string[] };
+
+function buildWhere(
+  params: SearchRunParams,
+): Record<string, EnumInClause> | undefined {
+  const where: Record<string, EnumInClause> = {};
+  if (params.kind.length > 0) {
+    where["kind"] = { in: params.kind };
+  }
+  if (params.role.length > 0) {
+    where["role"] = { in: params.role };
+  }
+  if (params.champion.length > 0) {
+    where["yourChampion"] = { in: params.champion };
+  }
+  if (params.staff.length > 0) {
+    where["staff"] = { in: params.staff };
+  }
+  if (params.carry.length > 0) {
+    where["carry"] = { in: params.carry };
+  }
+  if (params.ctype.length > 0) {
+    where["commentaryType"] = { in: params.ctype };
+  }
+  return Object.keys(where).length > 0 ? where : undefined;
+}
+
+function passesUserState(
+  doc: SearchDoc,
+  params: SearchRunParams,
+  state: UserContentState,
+): boolean {
+  if (params.watched === "watched" && !state.watchedUuids.has(doc.uuid)) {
+    return false;
+  }
+  if (params.watched === "unwatched" && state.watchedUuids.has(doc.uuid)) {
+    return false;
+  }
+  if (
+    params.bookmarked === "bookmarked" &&
+    !state.bookmarkedUuids.has(doc.uuid)
+  ) {
+    return false;
+  }
+  if (
+    params.bookmarked === "unbookmarked" &&
+    state.bookmarkedUuids.has(doc.uuid)
+  ) {
+    return false;
+  }
+  // Multi-select tags are OR within the group.
+  if (
+    params.tag.length > 0 &&
+    !params.tag.some((tag) => doc.tags.includes(tag))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function extractFacets(results: Results<SearchDoc>): SearchRunResult["facets"] {
+  const read = (field: keyof typeof FACETS_CONFIG): FacetCounts => {
+    const facet = results.facets?.[field];
+    return facet === undefined ? {} : { ...facet.values };
+  };
+  return {
+    kind: read("kind"),
+    role: read("role"),
+    champion: read("yourChampion"),
+    staff: read("staff"),
+    tags: read("tags"),
+    carry: read("carry"),
+    commentaryType: read("commentaryType"),
+  };
+}
+
+function decrement(counts: FacetCounts, value: string): void {
+  const current = counts[value];
+  if (current !== undefined) {
+    counts[value] = current - 1;
+  }
+}
+
+function decrementFacetsFor(
+  facets: SearchRunResult["facets"],
+  doc: SearchDoc,
+): void {
+  decrement(facets.kind, doc.kind);
+  decrement(facets.role, doc.role);
+  if (doc.yourChampion !== "") {
+    decrement(facets.champion, doc.yourChampion);
+  }
+  if (doc.staff !== "") {
+    decrement(facets.staff, doc.staff);
+  }
+  for (const tag of doc.tags) {
+    decrement(facets.tags, tag);
+  }
+  if (doc.carry !== "") {
+    decrement(facets.carry, doc.carry);
+  }
+  if (doc.commentaryType !== "") {
+    decrement(facets.commentaryType, doc.commentaryType);
+  }
+}
+
+function sortDocs(docs: SearchDoc[], sort: SortOption): SearchDoc[] {
+  switch (sort) {
+    case "relevance": {
+      // Relevance is the engine's hit order; with no query it degrades to
+      // the already-applied recency order.
+      return docs;
+    }
+    case "newest": {
+      return [...docs].sort((a, b) => b.releaseDate - a.releaseDate);
+    }
+    case "oldest": {
+      return [...docs].sort((a, b) => a.releaseDate - b.releaseDate);
+    }
+    case "shortest": {
+      return [...docs].sort(
+        (a, b) => a.durationInSeconds - b.durationInSeconds,
+      );
+    }
+    case "longest": {
+      return [...docs].sort(
+        (a, b) => b.durationInSeconds - a.durationInSeconds,
+      );
+    }
+  }
+}
+
+/**
+ * One pure search pass: Orama query (facets + enum where-clauses), then a
+ * linear post-filter for user-local state (watched/bookmarked live in
+ * localStorage and mutate constantly — pushing them into the index would
+ * mean remove/insert churn per toggle), then facet-count correction for the
+ * removed docs, then sort and pagination.
+ */
+export async function runSearch(
+  index: SearchIndex,
+  params: SearchRunParams,
+  state: UserContentState,
+): Promise<SearchRunResult> {
+  const limit = count(index);
+  const term = params.q.trim();
+  const where = buildWhere(params);
+
+  const baseParams: SearchParamsFullText<SearchIndex, SearchDoc> = {
+    limit,
+    facets: FACETS_CONFIG,
+  };
+  if (where !== undefined) {
+    baseParams.where = where;
+  }
+  if (term === "") {
+    baseParams.sortBy = { property: "releaseDate", order: "DESC" };
+  } else {
+    baseParams.term = term;
+    baseParams.properties = [...SEARCHED_PROPERTIES];
+    baseParams.boost = BOOSTS;
+    baseParams.tolerance = 1;
+    baseParams.threshold = 0;
+  }
+
+  let results = await search<SearchIndex, SearchDoc>(index, baseParams);
+  if (term !== "" && results.hits.length === 0) {
+    // AND semantics came up empty; degrade gracefully to OR for typo-heavy
+    // multi-word queries instead of returning nothing.
+    results = await search<SearchIndex, SearchDoc>(index, {
+      ...baseParams,
+      threshold: 1,
+    });
+  }
+
+  const facets = extractFacets(results);
+  const kept: SearchDoc[] = [];
+  for (const hit of results.hits) {
+    if (passesUserState(hit.document, params, state)) {
+      kept.push(hit.document);
+    } else {
+      decrementFacetsFor(facets, hit.document);
+    }
+  }
+
+  const sorted = sortDocs(kept, params.sort);
+  const pageCount = Math.ceil(sorted.length / SEARCH_PAGE_SIZE);
+  const start = (params.page - 1) * SEARCH_PAGE_SIZE;
+
+  return {
+    docs: sorted.slice(start, start + SEARCH_PAGE_SIZE),
+    total: sorted.length,
+    pageCount,
+    facets,
+  };
+}

--- a/packages/better-skill-capped/src/search/search-doc.ts
+++ b/packages/better-skill-capped/src/search/search-doc.ts
@@ -1,0 +1,134 @@
+import type {
+  Content,
+  Course,
+  Commentary,
+  Kind,
+  Video,
+} from "#src/model/content";
+import type { Role } from "#src/model/role";
+import { auxiliaryTerms, normalizeName } from "./normalize.ts";
+
+/**
+ * The flattened, index-ready projection of a ContentItem. Searchable string
+ * fields carry both display and normalized token forms; enum fields exist
+ * for faceting and where-clauses. Consumers resolve `uuid` back to the full
+ * ContentItem.
+ */
+export type SearchDoc = {
+  id: string;
+  uuid: string;
+  kind: Kind;
+  // Searchable strings
+  title: string;
+  description: string;
+  childTitles: string;
+  champions: string;
+  staffText: string;
+  searchAux: string;
+  // Facet / filter fields
+  role: Role;
+  staff: string;
+  yourChampion: string;
+  theirChampion: string;
+  tags: string[];
+  carry: string;
+  commentaryType: string;
+  recommended: boolean;
+  // Sortable numbers
+  releaseDate: number;
+  durationInSeconds: number;
+};
+
+function videoToDoc(video: Video): SearchDoc {
+  return {
+    id: `video:${video.uuid}`,
+    uuid: video.uuid,
+    kind: "video",
+    title: video.title,
+    description: video.description,
+    childTitles: "",
+    champions: "",
+    staffText: "",
+    searchAux: auxiliaryTerms(`${video.title} ${video.description}`),
+    role: video.role,
+    staff: "",
+    yourChampion: "",
+    theirChampion: "",
+    tags: [],
+    carry: "",
+    commentaryType: "",
+    recommended: false,
+    releaseDate: video.releaseDate.getTime(),
+    durationInSeconds: video.durationInSeconds,
+  };
+}
+
+function courseToDoc(course: Course): SearchDoc {
+  const childTitles = course.videos
+    .map((courseVideo) => courseVideo.alternateTitle ?? courseVideo.video.title)
+    .join(" ");
+  return {
+    id: `course:${course.uuid}`,
+    uuid: course.uuid,
+    kind: "course",
+    title: course.title,
+    description: course.description ?? "",
+    childTitles,
+    champions: "",
+    staffText: "",
+    searchAux: auxiliaryTerms(`${course.title} ${childTitles}`),
+    role: course.role,
+    staff: "",
+    yourChampion: "",
+    theirChampion: "",
+    // Tags arrive with the parser enrichment phase; the field is already
+    // indexed so wiring them is a one-line change in courseToDoc.
+    tags: [],
+    carry: "",
+    commentaryType: "",
+    recommended: false,
+    releaseDate: course.releaseDate.getTime(),
+    durationInSeconds: course.videos.reduce(
+      (total, courseVideo) => total + courseVideo.video.durationInSeconds,
+      0,
+    ),
+  };
+}
+
+function commentaryToDoc(commentary: Commentary): SearchDoc {
+  const champions = [
+    commentary.champion,
+    normalizeName(commentary.champion),
+    commentary.opponent,
+    normalizeName(commentary.opponent),
+  ].join(" ");
+  return {
+    id: `commentary:${commentary.uuid}`,
+    uuid: commentary.uuid,
+    kind: "commentary",
+    title: commentary.title,
+    description: commentary.description,
+    childTitles: "",
+    champions,
+    staffText: commentary.staff,
+    searchAux: auxiliaryTerms(commentary.title),
+    role: commentary.role,
+    staff: commentary.staff,
+    yourChampion: commentary.champion,
+    theirChampion: commentary.opponent,
+    tags: [],
+    carry: commentary.carry,
+    commentaryType: commentary.type,
+    recommended: false,
+    releaseDate: commentary.releaseDate.getTime(),
+    durationInSeconds: commentary.durationInSeconds,
+  };
+}
+
+export function contentToSearchDocs(content: Content): SearchDoc[] {
+  return [
+    ...content.courses.map((course) => courseToDoc(course)),
+    ...content.videos.map((video) => videoToDoc(video)),
+    ...content.commentaries.map((commentary) => commentaryToDoc(commentary)),
+  ];
+}


### PR DESCRIPTION
## Why

Stacked on #2197. fuse.js bitap matching has no relevance model, no facets, and no typo tolerance; the planned search UX (facet counts with live updates, champion-aware matching, BM25 ranking) needs an engine that supports them natively. **This PR is the pure core only** — the app still runs fuse until the next PR swaps the UI, so there is zero behavior change.

Orama is net-new to the repo (user-sanctioned; see the plan doc).

## What (`src/search/`)

- **`normalize.ts`** — NFKD + punctuation-stripping `normalizeName` (`kaisa` ≡ `Kai'Sa` ≡ `kai sa`), champion alias map, auxiliary-term derivation for apostrophed title words. No custom tokenizer: both index and query paths carry normalized forms in the data.
- **`search-doc.ts`** — flat `SearchDoc` projection of `ContentItem`: searchable strings (incl. course child titles and champion display+normalized forms), enum facet fields, sortable numbers. `tags`/`recommended` are indexed but empty until the parser-enrichment PR wires them (one-line change).
- **`index-builder.ts`** — one unified Orama index over all docs (BM25 scores comparable across kinds; one `kind` facet; rebuilt only when the manifest changes — never on filter/bookmark/watch changes).
- **`run-search.ts`** — pure `runSearch(index, params, userState)`: enum `where` clauses; field boosts (title 4 > champions/searchAux 3 > childTitles/staffText 2 > description 1); `tolerance: 1` with an AND→OR fallback when a typo-heavy query returns nothing; browse mode through the same code path (facet counts always available, recency order); **post-filter** for localStorage-backed watched/bookmarked state + tag OR-matching, with facet-count correction for removed docs; sort options; pagination.
- **`highlight.ts`** — query tokens + champion display names for react-highlight-words (Orama v3 returns no match positions; accepted limitation: tolerance-corrected typos don't highlight).
- **`fixtures/search-fixture.ts`** — schema-validated corpus (built through `ManifestSchema.parse` + `parseManifest`, so it can't drift from the real pipeline) with known ranking and facet distributions.

Also: knip gains test-file entries for this package, and the vendored shadcn card/dialog exports are `ignoreIssues`'d (repo pattern, same as scout's ui components — that half also pushed into #2197 where the components landed).

## Verification

`bun run typecheck` — 0 · `bun run lint` — clean · `bun test` — 63 pass, 16 new:
- `normalizeName`: Kai'Sa/K'Sante/Cho'Gath/Bel'Veth/Dr. Mundo/Nunu & Willump
- `kaisa`/`kai'sa`/`kai sa`/`ksante` all reach the right commentaries
- "wave control" ranks title match > child-title match > description-only match
- typo "wave contrl" still returns results; browse mode returns all docs newest-first
- where-clauses (kind/role); facet counts equal hand-computed values; watched/bookmarked post-filters with corrected facet counts; sorts; pagination
- `bunx knip --workspace packages/better-skill-capped` green · `bun run build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)