### PR TITLE
feat(better-skill-capped): faceted sidebar with live counts

### DIFF
--- a/packages/better-skill-capped/src/components/search/facet-checklist.tsx
+++ b/packages/better-skill-capped/src/components/search/facet-checklist.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import type { FacetCounts } from "#src/search/run-search";
+import { Card, CardContent, CardHeader, CardTitle } from "#components/ui/card";
+import { Checkbox } from "#components/ui/checkbox";
+import { Input } from "#components/ui/input";
+import { Label } from "#components/ui/label";
+
+export type FacetChecklistProps = {
+  title: string;
+  counts: FacetCounts;
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  /** Show a filter input when there are more values than this. */
+  searchThreshold?: number;
+  /** Cap the visible list; selected values always show. */
+  visibleLimit?: number;
+};
+
+/**
+ * A facet section: values sorted by count (then name), live conjunctive
+ * counts, optional type-ahead narrowing for high-cardinality facets
+ * (champions). Zero-count unselected values are hidden.
+ */
+export function FacetChecklist({
+  title,
+  counts,
+  selected,
+  onChange,
+  searchThreshold = 12,
+  visibleLimit = 10,
+}: FacetChecklistProps): React.ReactElement | null {
+  const [filter, setFilter] = useState("");
+
+  const values = Object.entries(counts)
+    .filter(([value, count]) => count > 0 || selected.includes(value))
+    .sort(([aValue, aCount], [bValue, bCount]) =>
+      bCount === aCount ? aValue.localeCompare(bValue) : bCount - aCount,
+    );
+
+  if (values.length === 0 && selected.length === 0) {
+    return null;
+  }
+
+  const lowered = filter.toLowerCase();
+  const visible = values
+    .filter(
+      ([value]) =>
+        selected.includes(value) ||
+        lowered === "" ||
+        value.toLowerCase().includes(lowered),
+    )
+    .filter(
+      ([value], index) =>
+        selected.includes(value) || lowered !== "" || index < visibleLimit,
+    );
+
+  const toggle = (value: string) => {
+    onChange(
+      selected.includes(value)
+        ? selected.filter((candidate) => candidate !== value)
+        : [...selected, value],
+    );
+  };
+
+  return (
+    <Card className="py-4">
+      <CardHeader className="px-4">
+        <CardTitle className="text-sm">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2 px-4">
+        {values.length > searchThreshold && (
+          <Input
+            value={filter}
+            placeholder={`Filter ${title.toLowerCase()}…`}
+            className="h-8"
+            onChange={(event) => {
+              setFilter(event.target.value);
+            }}
+          />
+        )}
+        <div className="flex max-h-56 flex-col gap-2 overflow-y-auto">
+          {visible.map(([value, count]) => (
+            <div key={value} className="flex items-center gap-2">
+              <Checkbox
+                id={`${title}-${value}`}
+                checked={selected.includes(value)}
+                onCheckedChange={() => {
+                  toggle(value);
+                }}
+              />
+              <Label
+                htmlFor={`${title}-${value}`}
+                className="flex w-full justify-between gap-2 font-normal"
+              >
+                <span className="truncate">{value}</span>
+                <span className="text-muted-foreground">{count}</span>
+              </Label>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/better-skill-capped/src/components/search/filter-panel.tsx
+++ b/packages/better-skill-capped/src/components/search/filter-panel.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import type { Kind } from "#src/model/content";
+import { KINDS } from "#src/model/content";
 import type { Role } from "#src/model/role";
 import { ROLES, roleDisplayName } from "#src/model/role";
-import type { BookmarkedFilter, Filters, WatchedFilter } from "./filters.ts";
+import type { BookmarkedFilter, WatchedFilter } from "./filters.ts";
+import type { SearchParams } from "#src/routes/search";
+import type { SearchRunResult } from "#src/search/run-search";
+import { FacetChecklist } from "./facet-checklist.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "#components/ui/card";
 import { Checkbox } from "#components/ui/checkbox";
 import { Label } from "#components/ui/label";
 
 export type FilterPanelProps = {
-  filters: Filters;
-  onFiltersUpdate: (newFilters: Filters) => void;
+  params: SearchParams;
+  facets: SearchRunResult["facets"] | undefined;
+  onChange: (updated: Partial<SearchParams>) => void;
 };
 
 const KIND_LABELS: Record<Kind, string> = {
@@ -40,74 +45,91 @@ function FilterSection({
 function CheckRow({
   id,
   label,
+  count,
   checked,
   onToggle,
 }: {
   id: string;
   label: string;
+  count?: number | undefined;
   checked: boolean;
   onToggle: () => void;
 }): React.ReactElement {
   return (
     <div className="flex items-center gap-2">
       <Checkbox id={id} checked={checked} onCheckedChange={onToggle} />
-      <Label htmlFor={id} className="font-normal">
-        {label}
+      <Label
+        htmlFor={id}
+        className="flex w-full justify-between gap-2 font-normal"
+      >
+        <span>{label}</span>
+        {count !== undefined && (
+          <span className="text-muted-foreground">{count}</span>
+        )}
       </Label>
     </div>
   );
 }
 
-export function FilterPanel({
-  filters,
-  onFiltersUpdate,
-}: FilterPanelProps): React.ReactElement {
-  const toggleRole = (role: Role) => {
-    const roles = filters.roles.includes(role)
-      ? filters.roles.filter((candidate) => candidate !== role)
-      : [...filters.roles, role];
-    onFiltersUpdate({ ...filters, roles });
-  };
+/** Toggle within "empty array means everything selected" semantics. */
+function toggleWithinAll<T extends string>(
+  all: readonly T[],
+  current: T[],
+  value: T,
+): T[] {
+  const effective = current.length === 0 ? [...all] : current;
+  const updated = effective.includes(value)
+    ? effective.filter((candidate) => candidate !== value)
+    : [...effective, value];
+  return updated.length === all.length ? [] : updated;
+}
 
-  const toggleType = (type: Kind) => {
-    const types = filters.types.includes(type)
-      ? filters.types.filter((candidate) => candidate !== type)
-      : [...filters.types, type];
-    onFiltersUpdate({ ...filters, types });
-  };
+export function FilterPanel({
+  params,
+  facets,
+  onChange,
+}: FilterPanelProps): React.ReactElement {
+  const effectiveRoles = params.role.length === 0 ? [...ROLES] : params.role;
+  const effectiveKinds = params.kind.length === 0 ? [...KINDS] : params.kind;
 
   const setWatched = (watched: WatchedFilter) => {
-    onFiltersUpdate({ ...filters, watched });
+    onChange({ watched });
+  };
+  const setBookmarked = (bookmarked: BookmarkedFilter) => {
+    onChange({ bookmarked });
   };
 
-  const setBookmarked = (bookmarked: BookmarkedFilter) => {
-    onFiltersUpdate({ ...filters, bookmarked });
-  };
+  // Commentary-specific facets are only meaningful when commentaries are in
+  // scope (progressive disclosure).
+  const commentariesInScope =
+    params.kind.length === 0 || params.kind.includes("commentary");
 
   return (
     <div className="flex flex-col gap-4">
       <FilterSection title="Roles">
-        {ROLES.map((role) => (
+        {ROLES.map((role: Role) => (
           <CheckRow
             key={role}
             id={`role-${role}`}
             label={roleDisplayName(role)}
-            checked={filters.roles.includes(role)}
+            count={facets?.role[role] ?? 0}
+            checked={effectiveRoles.includes(role)}
             onToggle={() => {
-              toggleRole(role);
+              onChange({ role: toggleWithinAll(ROLES, params.role, role) });
             }}
           />
         ))}
       </FilterSection>
       <FilterSection title="Type">
-        {KIND_ORDER.map((type) => (
+        {KIND_ORDER.map((kind) => (
           <CheckRow
-            key={type}
-            id={`type-${type}`}
-            label={KIND_LABELS[type]}
-            checked={filters.types.includes(type)}
+            key={kind}
+            id={`type-${kind}`}
+            label={KIND_LABELS[kind]}
+            count={facets?.kind[kind] ?? 0}
+            checked={effectiveKinds.includes(kind)}
             onToggle={() => {
-              toggleType(type);
+              onChange({ kind: toggleWithinAll(KINDS, params.kind, kind) });
             }}
           />
         ))}
@@ -116,17 +138,17 @@ export function FilterPanel({
         <CheckRow
           id="watched-unwatched"
           label="Only show unwatched"
-          checked={filters.watched === "unwatched"}
+          checked={params.watched === "unwatched"}
           onToggle={() => {
-            setWatched(filters.watched === "unwatched" ? "any" : "unwatched");
+            setWatched(params.watched === "unwatched" ? "any" : "unwatched");
           }}
         />
         <CheckRow
           id="watched-watched"
           label="Only show watched"
-          checked={filters.watched === "watched"}
+          checked={params.watched === "watched"}
           onToggle={() => {
-            setWatched(filters.watched === "watched" ? "any" : "watched");
+            setWatched(params.watched === "watched" ? "any" : "watched");
           }}
         />
       </FilterSection>
@@ -134,24 +156,72 @@ export function FilterPanel({
         <CheckRow
           id="bookmarked-only"
           label="Only show bookmarked"
-          checked={filters.bookmarked === "bookmarked"}
+          checked={params.bookmarked === "bookmarked"}
           onToggle={() => {
             setBookmarked(
-              filters.bookmarked === "bookmarked" ? "any" : "bookmarked",
+              params.bookmarked === "bookmarked" ? "any" : "bookmarked",
             );
           }}
         />
         <CheckRow
           id="bookmarked-unbookmarked"
           label="Only show unbookmarked"
-          checked={filters.bookmarked === "unbookmarked"}
+          checked={params.bookmarked === "unbookmarked"}
           onToggle={() => {
             setBookmarked(
-              filters.bookmarked === "unbookmarked" ? "any" : "unbookmarked",
+              params.bookmarked === "unbookmarked" ? "any" : "unbookmarked",
             );
           }}
         />
       </FilterSection>
+      {facets !== undefined && (
+        <>
+          <FacetChecklist
+            title="Tags"
+            counts={facets.tags}
+            selected={params.tag}
+            onChange={(tag) => {
+              onChange({ tag });
+            }}
+          />
+          {commentariesInScope && (
+            <>
+              <FacetChecklist
+                title="Champion"
+                counts={facets.champion}
+                selected={params.champion}
+                onChange={(champion) => {
+                  onChange({ champion });
+                }}
+              />
+              <FacetChecklist
+                title="Coach"
+                counts={facets.staff}
+                selected={params.staff}
+                onChange={(staff) => {
+                  onChange({ staff });
+                }}
+              />
+              <FacetChecklist
+                title="Carry"
+                counts={facets.carry}
+                selected={params.carry}
+                onChange={(carry) => {
+                  onChange({ carry });
+                }}
+              />
+              <FacetChecklist
+                title="Account Type"
+                counts={facets.commentaryType}
+                selected={params.ctype}
+                onChange={(ctype) => {
+                  onChange({ ctype });
+                }}
+              />
+            </>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/better-skill-capped/src/components/search/search-page.tsx
+++ b/packages/better-skill-capped/src/components/search/search-page.tsx
@@ -4,11 +4,8 @@ import { SearchBar } from "./search-bar.tsx";
 import { FilterPanel } from "./filter-panel.tsx";
 import { PaginationControls } from "./pagination-controls.tsx";
 import { ActiveFilters } from "./active-filters.tsx";
-import type { Filters } from "./filters.ts";
 import { ContentCard } from "#src/components/content/content-card";
 import { ScoutBanner } from "#src/components/layout/scout-banner";
-import { KINDS } from "#src/model/content";
-import { ROLES } from "#src/model/role";
 import { useContent } from "#src/hooks/use-content";
 import { useBookmarks } from "#src/hooks/use-bookmarks";
 import { useWatchStatus } from "#src/hooks/use-watch-status";
@@ -76,14 +73,6 @@ export function SearchPage(): React.ReactElement {
     });
   };
 
-  // The filter panel renders "no filter" as everything checked.
-  const panelFilters: Filters = {
-    roles: search.role.length === 0 ? [...ROLES] : search.role,
-    types: search.kind.length === 0 ? [...KINDS] : search.kind,
-    watched: search.watched,
-    bookmarked: search.bookmarked,
-  };
-
   const items = (result?.docs ?? []).flatMap((doc) => {
     const item = itemsByUuid.get(doc.uuid);
     return item === undefined ? [] : [item];
@@ -104,21 +93,9 @@ export function SearchPage(): React.ReactElement {
       <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 md:grid-cols-[14rem_1fr]">
         <aside>
           <FilterPanel
-            filters={panelFilters}
-            onFiltersUpdate={(newFilters) => {
-              updateSearch({
-                role:
-                  newFilters.roles.length === ROLES.length
-                    ? []
-                    : newFilters.roles,
-                kind:
-                  newFilters.types.length === KINDS.length
-                    ? []
-                    : newFilters.types,
-                watched: newFilters.watched,
-                bookmarked: newFilters.bookmarked,
-              });
-            }}
+            params={search}
+            facets={result?.facets}
+            onChange={updateSearch}
           />
         </aside>
         <main className="min-w-0">

--- a/packages/better-skill-capped/src/routes/search.tsx
+++ b/packages/better-skill-capped/src/routes/search.tsx
@@ -40,9 +40,16 @@ export const SEARCH_DEFAULTS: {
 };
 
 const QSchema = z.string();
-const KindsSchema = z.array(z.enum(KINDS));
-const RolesSchema = z.array(z.enum(ROLES));
-const StringsSchema = z.array(z.string());
+
+// The router serializes arrays itself, but hand-edited URLs naturally use
+// the scalar form (?champion=Graves) — accept both.
+function listOf<T>(inner: z.ZodType<T>): z.ZodType<T[]> {
+  return z.union([z.array(inner), inner.transform((value): T[] => [value])]);
+}
+
+const KindsSchema = listOf(z.enum(KINDS));
+const RolesSchema = listOf(z.enum(ROLES));
+const StringsSchema = listOf(z.string());
 const WatchedSchema = z.enum(["any", "watched", "unwatched"]);
 const BookmarkedSchema = z.enum(["any", "bookmarked", "unbookmarked"]);
 const SortSchema = z.enum([


### PR DESCRIPTION
## Why

Stacked on #2201. The engine has computed champion/coach/carry/type facet counts since the Orama swap, but the sidebar only offered role/kind/watch/bookmark checkboxes. This surfaces the full facet set with live conjunctive counts — the "Graves (48) · Sjorry (560)" experience from the plan.

## What

- **`facet-checklist.tsx`** — reusable facet section: values sorted by count, live counts, type-ahead narrowing for high-cardinality facets (173 champions), zero-count values hidden, selected values always visible.
- **`filter-panel.tsx`** rewritten against the `SearchParams` contract: role/kind rows gain live counts; **Champion, Coach, Carry, Account Type** sections render only when commentaries are in scope (progressive disclosure); the **Tags** section appears automatically once the parser enrichment PR wires course tags into the index (its facet counts are all-zero today, so it self-hides).
- **Fix**: hand-edited scalar URL params (`?champion=Graves`) now coerce to single-element arrays instead of silently dropping the filter — the router serializes arrays itself, but shared URLs are often hand-written.

## Verification

- `bun run typecheck` — 0 · `bun run lint` — clean · `bun test` — 63 pass · `bun run build` — OK
- Live browser: all sections render with counts; `?champion=Graves` returns **exactly the 48 Graves commentaries** known from the production manifest; champion type-ahead narrows the checklist.

Screenshot in comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)