### PR TITLE
chore(homelab): promote beta images to production

### DIFF
--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -664,7 +664,7 @@
         "versioning": "semver",
         "packageName": "shepherdjerred/scout-for-lol"
       },
-      "value": "2.0.0-8810@sha256:d0783d718761e852b2f5798a234170e6f720be921aa59ee37cc86b1b8e53c6a2",
+      "value": "2.0.0-9495@sha256:513c2c6ef457ee91b8a18ec2c6f999558617560f57b21cc70440e3ab833c0347",
       "notes": [
         "Prod promotion = merging the Renovate PR for this pin. Each 2.0.0-<n>",
         "tag is minted by the scout-tag-release CI step only after site version",
@@ -696,7 +696,7 @@
         "versioning": "semver",
         "packageName": "shepherdjerred/starlight-karma-bot"
       },
-      "value": "2.0.0-8772@sha256:bb187d4427d4cda30e559d249e7b717fcda7f6e459c6b7141461fd8df14390bc"
+      "value": "2.0.0-9414@sha256:e162c7086de402321f7b076ac580e220257d280d3afa7c122836be7073468420"
     },
     {
       "name": "shepherdjerred/birmel",


### PR DESCRIPTION
## Why
Promote the current verified beta images for Scout and Starlight Karma into production.

## What
- Update Scout production from `2.0.0-8810` to `2.0.0-9495`.
- Update Starlight Karma production from `2.0.0-8772` to `2.0.0-9414`.
- Keep both immutable GHCR tag@digest references aligned with their beta pins.

## Verification
- `bun test packages/version-catalog/src/index.test.ts` (4 passed)
- `bun test src/versions.test.ts src/release-configuration.test.ts` from `packages/homelab/src/cdk8s` (10 passed)
- `bun run typecheck` from `packages/homelab/src/cdk8s`
- Verified both GHCR manifest digests.
- Verified Scout `2.0.0-9495` has an immutable archived release state and prod site archive.

No live cluster sync was run locally; merging this GitOps change allows the normal main release pipeline to deploy it.