### PR TITLE
Guard Velero/R2 orphan cleanup with explicit holds

### DIFF
--- a/packages/homelab/AGENTS.md
+++ b/packages/homelab/AGENTS.md
@@ -336,14 +336,24 @@ The canonical runbook is
 ```bash
 cd src/cdk8s
 # 1. Read-only: write the candidate manifest, then review it by hand.
-op run -- bun run r2:orphans -- inspect --manifest /tmp/r2-orphans.json
+op run -- bun run r2:orphans -- inspect \
+  --manifest /tmp/r2-orphans.json \
+  --hold-backup <reviewed-backup-name>
 # 2. Destructive: re-observes and revalidates before every deletion.
-op run -- bun run r2:orphans -- apply --manifest /tmp/r2-orphans.json --apply
+op run -- bun run r2:orphans -- apply \
+  --manifest /tmp/r2-orphans.json \
+  --hold-backup <reviewed-backup-name> \
+  --apply
 ```
 
 - `inspect` is read-only and rejects the destructive flags. `apply` requires an
   explicit `--apply`, plus either an interactive typed confirmation phrase or
   `--yes` (mandatory when stdin is not a TTY).
+- `--hold-backup` may be repeated. Holds are recorded in the versioned
+  manifest, included in the protected set, and excluded from bulk deletion.
+  Apply requires the exact same hold list. Use `--only-backup` with a fresh
+  inspect/apply pair when one held prefix is later approved as a separate
+  single-prefix cleanup.
 - A prefix is a candidate only if it has no live Velero `Backup` CR, no R2
   metadata, and no object newer than 24 hours. The manifest is revalidated
   against freshly observed state before the run and again before each

--- a/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup-core.test.ts
+++ b/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup-core.test.ts
@@ -202,3 +202,73 @@ describe("R2 orphan cleanup manifest", () => {
     );
   });
 });
+
+describe("R2 orphan cleanup safety options", () => {
+  test("holds an existing prefix out of the deletion manifest", () => {
+    const manifest = buildR2OrphanManifest({
+      observedAt,
+      storage,
+      zfsObjects: [
+        {
+          key: "zfspv-incr/backups/held/chunk",
+          size: 1,
+          lastModified: "2026-08-09T00:00:00.000Z",
+        },
+        {
+          key: "zfspv-incr/backups/orphan/chunk",
+          size: 2,
+          lastModified: "2026-08-09T00:00:00.000Z",
+        },
+      ],
+      liveBackupNames: [],
+      metadataBackupNames: ["unrelated"],
+      heldBackupNames: ["held"],
+    });
+
+    expect(manifest.heldBackupNames).toEqual(["held"]);
+    expect(manifest.protectedBackupNames).toEqual(["held", "unrelated"]);
+    expect(
+      manifest.candidates.map((candidate) => candidate.backupName),
+    ).toEqual(["orphan"]);
+  });
+
+  test("rejects a missing hold", () => {
+    expect(() =>
+      buildR2OrphanManifest({
+        observedAt,
+        storage,
+        zfsObjects: [],
+        liveBackupNames: [],
+        metadataBackupNames: [],
+        heldBackupNames: ["missing"],
+      }),
+    ).toThrow("Held R2 backup prefix is missing");
+  });
+
+  test("selects exactly one eligible backup prefix", () => {
+    const manifest = buildR2OrphanManifest({
+      observedAt,
+      storage,
+      zfsObjects: [
+        {
+          key: "zfspv-incr/backups/selected/chunk",
+          size: 1,
+          lastModified: "2026-08-09T00:00:00.000Z",
+        },
+        {
+          key: "zfspv-incr/backups/other/chunk",
+          size: 2,
+          lastModified: "2026-08-09T00:00:00.000Z",
+        },
+      ],
+      liveBackupNames: [],
+      metadataBackupNames: ["unrelated"],
+      onlyBackupName: "selected",
+    });
+
+    expect(manifest.onlyBackupName).toBe("selected");
+    expect(
+      manifest.candidates.map((candidate) => candidate.backupName),
+    ).toEqual(["selected"]);
+  });
+});

--- a/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup-core.ts
+++ b/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup-core.ts
@@ -19,13 +19,15 @@ const CandidateSchema = z.object({
 });
 
 export const R2OrphanManifestSchema = z.object({
-  contractVersion: z.literal(1),
+  contractVersion: z.literal(2),
   observedAt: z.iso.datetime(),
   minimumAgeHours: z.literal(R2_ORPHAN_MINIMUM_AGE_HOURS),
   storage: z.object({
     bucket: z.string().min(1),
     endpointHost: z.string().min(1),
   }),
+  heldBackupNames: z.array(z.string().min(1)),
+  onlyBackupName: z.string().min(1).nullable(),
   protectedBackupNames: z.array(z.string().min(1)),
   candidates: z.array(CandidateSchema),
 });
@@ -64,6 +66,8 @@ export function buildR2OrphanManifest(input: {
   zfsObjects: readonly R2Object[];
   liveBackupNames: readonly string[];
   metadataBackupNames: readonly string[];
+  heldBackupNames?: readonly string[];
+  onlyBackupName?: string;
 }): R2OrphanManifest {
   const observedAt = Date.parse(input.observedAt);
   if (!Number.isFinite(observedAt)) {
@@ -80,10 +84,7 @@ export function buildR2OrphanManifest(input: {
       `Refusing to propose R2 orphan deletions: ${input.zfsObjects.length.toString()} ZFS backup objects exist but Velero metadata under ${R2_BACKUP_METADATA_BACKUPS_PREFIX} is empty. Confirm the BackupStorageLocation prefix and metadata layout before cleaning up.`,
     );
   }
-  const protectedBackupNames = [
-    ...new Set([...input.liveBackupNames, ...input.metadataBackupNames]),
-  ].toSorted();
-  const protectedSet = new Set(protectedBackupNames);
+  const heldBackupNames = [...new Set(input.heldBackupNames)].toSorted();
   const groups = new Map<
     string,
     { backupName: string; bytes: number; objects: number; newest: string }
@@ -104,24 +105,65 @@ export function buildR2OrphanManifest(input: {
     }
     groups.set(name, existing);
   }
+  const missingHeldNames = heldBackupNames.filter((name) => !groups.has(name));
+  if (missingHeldNames.length > 0) {
+    throw new Error(
+      `Held R2 backup prefix is missing: ${missingHeldNames.join(", ")}; refusing to continue`,
+    );
+  }
+  if (
+    input.onlyBackupName !== undefined &&
+    heldBackupNames.includes(input.onlyBackupName)
+  ) {
+    throw new Error(
+      `Backup ${input.onlyBackupName} cannot be both held and selected for deletion`,
+    );
+  }
+  if (input.onlyBackupName !== undefined && !groups.has(input.onlyBackupName)) {
+    throw new Error(
+      `Selected R2 backup prefix is missing: ${input.onlyBackupName}; refusing to continue`,
+    );
+  }
+  const protectedBackupNames = [
+    ...new Set([
+      ...input.liveBackupNames,
+      ...input.metadataBackupNames,
+      ...heldBackupNames,
+    ]),
+  ].toSorted();
+  const protectedSet = new Set(protectedBackupNames);
   const cutoff = observedAt - R2_ORPHAN_MINIMUM_AGE_HOURS * 3_600_000;
   const candidates = [...groups.values()]
     .filter(
       (group) =>
         !protectedSet.has(group.backupName) &&
-        Date.parse(group.newest) < cutoff,
+        Date.parse(group.newest) < cutoff &&
+        (input.onlyBackupName === undefined ||
+          group.backupName === input.onlyBackupName),
     )
     .map((group) => ({
       prefix: `${R2_ZFS_PREFIX}${group.backupName}/`,
       ...group,
     }))
     .toSorted((left, right) => left.prefix.localeCompare(right.prefix));
+  if (
+    input.onlyBackupName !== undefined &&
+    !candidates.some(
+      (candidate) => candidate.backupName === input.onlyBackupName,
+    )
+  ) {
+    throw new Error(
+      `Selected R2 backup prefix is protected or younger than the 24 hour safety fence: ${input.onlyBackupName}`,
+    );
+  }
 
   return R2OrphanManifestSchema.parse({
-    contractVersion: 1,
+    contractVersion: 2,
     observedAt: new Date(observedAt).toISOString(),
     minimumAgeHours: R2_ORPHAN_MINIMUM_AGE_HOURS,
     storage: input.storage,
+    heldBackupNames,
+    onlyBackupName: input.onlyBackupName ?? null,
     protectedBackupNames,
     candidates,
   });

--- a/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup.test.ts
+++ b/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup.test.ts
@@ -10,6 +10,8 @@ describe("R2 orphan cleanup arguments", () => {
       manifestPath: "/tmp/r2-orphans.json",
       apply: false,
       yes: false,
+      heldBackupNames: [],
+      onlyBackupName: undefined,
     });
   });
 
@@ -31,6 +33,31 @@ describe("R2 orphan cleanup arguments", () => {
       manifestPath: "/tmp/r2-orphans.json",
       apply: true,
       yes: true,
+      heldBackupNames: [],
+      onlyBackupName: undefined,
+    });
+  });
+
+  test("parses holds and a single-backup selector", () => {
+    expect(
+      parseR2OrphanArguments([
+        "inspect",
+        "--manifest",
+        "/tmp/r2-orphans.json",
+        "--hold-backup",
+        "held-b",
+        "--hold-backup",
+        "held-a",
+        "--only-backup",
+        "selected",
+      ]),
+    ).toEqual({
+      command: "inspect",
+      manifestPath: "/tmp/r2-orphans.json",
+      apply: false,
+      yes: false,
+      heldBackupNames: ["held-a", "held-b"],
+      onlyBackupName: "selected",
     });
   });
 

--- a/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup.ts
+++ b/packages/homelab/src/cdk8s/scripts/r2-orphan-cleanup.ts
@@ -19,47 +19,96 @@ type Options = {
   manifestPath: string;
   apply: boolean;
   yes: boolean;
+  heldBackupNames: string[];
+  onlyBackupName: string | undefined;
 };
+
+type ParseState = Omit<Options, "command" | "manifestPath"> & {
+  manifestPath: string | undefined;
+};
+
+function requiredArgument(
+  args: readonly string[],
+  index: number,
+  flag: string,
+): string {
+  const value = args[index + 1];
+  if (value === undefined || value === "") {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function parseArgument(
+  args: readonly string[],
+  index: number,
+  state: ParseState,
+): number {
+  const argument = args[index];
+  if (argument === "--manifest") {
+    state.manifestPath = requiredArgument(args, index, argument);
+    return index + 2;
+  }
+  if (argument === "--apply") {
+    state.apply = true;
+    return index + 1;
+  }
+  if (argument === "--yes") {
+    state.yes = true;
+    return index + 1;
+  }
+  if (argument === "--hold-backup") {
+    const name = requiredArgument(args, index, argument);
+    if (state.heldBackupNames.includes(name)) {
+      throw new Error(`--hold-backup was repeated for ${name}`);
+    }
+    state.heldBackupNames.push(name);
+    return index + 2;
+  }
+  if (argument === "--only-backup") {
+    if (state.onlyBackupName !== undefined) {
+      throw new Error("--only-backup may only be provided once");
+    }
+    state.onlyBackupName = requiredArgument(args, index, argument);
+    return index + 2;
+  }
+  if (argument === undefined) {
+    throw new Error("Missing argument");
+  }
+  throw new Error(`Unknown argument: ${argument}`);
+}
 
 export function parseR2OrphanArguments(args: readonly string[]): Options {
   const command = args[0];
   if (command !== "inspect" && command !== "apply") {
     throw new Error(
-      "Usage: bun run r2:orphans -- inspect|apply --manifest <path> [--apply] [--yes]",
+      "Usage: bun run r2:orphans -- inspect|apply --manifest <path> [--hold-backup <name>]... [--only-backup <name>] [--apply] [--yes]",
     );
   }
-  let manifestPath: string | undefined;
-  let apply = false;
-  let yes = false;
-  for (let index = 1; index < args.length; index += 1) {
-    const argument = args[index];
-    switch (argument) {
-      case "--manifest":
-        manifestPath = args[index + 1];
-        if (manifestPath === undefined || manifestPath === "") {
-          throw new Error("--manifest requires a path");
-        }
-        index += 1;
-        break;
-      case "--apply":
-        apply = true;
-        break;
-      case "--yes":
-        yes = true;
-        break;
-      case undefined:
-        throw new Error("Missing argument");
-      default:
-        throw new Error(`Unknown argument: ${argument}`);
-    }
+  const state: ParseState = {
+    manifestPath: undefined,
+    apply: false,
+    yes: false,
+    heldBackupNames: [],
+    onlyBackupName: undefined,
+  };
+  for (let index = 1; index < args.length; ) {
+    index = parseArgument(args, index, state);
   }
-  if (manifestPath === undefined) {
+  if (state.manifestPath === undefined) {
     throw new Error("--manifest is required");
   }
-  if (command === "inspect" && (apply || yes)) {
+  if (command === "inspect" && (state.apply || state.yes)) {
     throw new Error("inspect does not accept destructive flags");
   }
-  return { command, manifestPath, apply, yes };
+  return {
+    command,
+    manifestPath: state.manifestPath,
+    apply: state.apply,
+    yes: state.yes,
+    heldBackupNames: state.heldBackupNames.toSorted(),
+    onlyBackupName: state.onlyBackupName,
+  };
 }
 
 async function run(
@@ -99,7 +148,11 @@ async function liveBackupNames(): Promise<string[]> {
     .toSorted();
 }
 
-async function observe(observedAt: string): Promise<{
+async function observe(
+  observedAt: string,
+  heldBackupNames: readonly string[],
+  onlyBackupName: string | undefined,
+): Promise<{
   manifest: R2OrphanManifest;
   zfsObjects: Awaited<ReturnType<typeof listR2Objects>>;
 }> {
@@ -119,6 +172,8 @@ async function observe(observedAt: string): Promise<{
       zfsObjects,
       liveBackupNames: liveNames,
       metadataBackupNames: metadataBackupNames(metadataObjects),
+      heldBackupNames,
+      onlyBackupName,
     }),
     zfsObjects,
   };
@@ -164,11 +219,18 @@ async function removePrefix(prefix: string): Promise<void> {
   );
 }
 
-async function inspect(manifestPath: string): Promise<void> {
-  const { manifest } = await observe(new Date().toISOString());
-  await Bun.write(manifestPath, `${JSON.stringify(manifest, undefined, 2)}\n`);
+async function inspect(options: Options): Promise<void> {
+  const { manifest } = await observe(
+    new Date().toISOString(),
+    options.heldBackupNames,
+    options.onlyBackupName,
+  );
+  await Bun.write(
+    options.manifestPath,
+    `${JSON.stringify(manifest, undefined, 2)}\n`,
+  );
   console.log(
-    `Wrote ${manifest.candidates.length.toString()} guarded R2 orphan candidates to ${manifestPath}`,
+    `Wrote ${manifest.candidates.length.toString()} guarded R2 orphan candidates to ${options.manifestPath}`,
   );
   console.log(JSON.stringify(manifest, undefined, 2));
 }
@@ -180,7 +242,24 @@ async function applyCleanup(options: Options): Promise<void> {
   const approved = R2OrphanManifestSchema.parse(
     JSON.parse(await Bun.file(options.manifestPath).text()),
   );
-  const current = await observe(approved.observedAt);
+  if (
+    JSON.stringify(options.heldBackupNames) !==
+    JSON.stringify(approved.heldBackupNames)
+  ) {
+    throw new Error(
+      "Apply hold list does not match the reviewed manifest; pass every --hold-backup name used during inspect",
+    );
+  }
+  if (options.onlyBackupName !== (approved.onlyBackupName ?? undefined)) {
+    throw new Error(
+      "Apply backup selector does not match the reviewed manifest; pass the same --only-backup value used during inspect",
+    );
+  }
+  const current = await observe(
+    approved.observedAt,
+    approved.heldBackupNames,
+    approved.onlyBackupName ?? undefined,
+  );
   assertManifestRevalidated(approved, current.manifest);
   if (!options.yes) {
     if (!process.stdin.isTTY) {
@@ -195,7 +274,11 @@ async function applyCleanup(options: Options): Promise<void> {
 
   let expected = approved;
   for (const candidate of approved.candidates) {
-    const latest = await observe(approved.observedAt);
+    const latest = await observe(
+      approved.observedAt,
+      approved.heldBackupNames,
+      approved.onlyBackupName ?? undefined,
+    );
     assertManifestRevalidated(expected, latest.manifest);
     if (latest.manifest.protectedBackupNames.includes(candidate.backupName)) {
       throw new Error(
@@ -230,6 +313,6 @@ async function applyCleanup(options: Options): Promise<void> {
 
 if (import.meta.main) {
   const options = parseR2OrphanArguments(Bun.argv.slice(2));
-  if (options.command === "inspect") await inspect(options.manifestPath);
+  if (options.command === "inspect") await inspect(options);
   else await applyCleanup(options);
 }

--- a/packages/temporal/runbooks/velero-orphan-snapshot-remediation.md
+++ b/packages/temporal/runbooks/velero-orphan-snapshot-remediation.md
@@ -101,14 +101,23 @@ Generate a reviewed manifest with the operator-only cleanup tool:
 
 ```bash
 cd packages/homelab/src/cdk8s
-op run -- bun run r2:orphans -- inspect --manifest /tmp/r2-orphans.json
+op run -- bun run r2:orphans -- inspect \
+  --manifest /tmp/r2-orphans.json \
+  --hold-backup 6hourly-backup-20260728001550
 ```
 
 The manifest protects the union of live `Backup` CR names and backup metadata
 under `torvalds/backups/`. It only proposes per-backup prefixes under
 `zfspv-incr/backups/` whose newest object is more than 24 hours old. Review
 every candidate, byte count, object count, and newest timestamp before
-continuing.
+continuing. `--hold-backup` may be repeated; held prefixes are recorded in the
+manifest, shown as protected, and excluded from bulk deletion. The hold must
+exist in the R2 listing or inspection fails closed.
+
+For a separately reviewed single-prefix cleanup, use `--only-backup` on both
+`inspect` and `apply`. It requires that the selected prefix exists, is older
+than the 24-hour fence, and is not protected by live Velero metadata or a
+`Backup` CR.
 
 ## Step 3: Sanity-check before destroying
 
@@ -175,6 +184,7 @@ Apply exactly the reviewed manifest:
 cd packages/homelab/src/cdk8s
 op run -- bun run r2:orphans -- apply \
   --manifest /tmp/r2-orphans.json \
+  --hold-backup 6hourly-backup-20260728001550 \
   --apply
 ```
 
@@ -182,7 +192,39 @@ The command re-lists live Backup CRs, backup metadata, and every ZFS backup
 object before deleting anything and again before each prefix. Any drift from
 the reviewed manifest aborts the operation. Non-interactive use additionally
 requires `--yes`. After deletion it verifies that no object remains under any
-approved prefix.
+approved prefix. The hold list must exactly match the inspection command.
+
+When a held R2 prefix is intentionally paired with a local orphan snapshot,
+complete the bulk cleanup first, then create and apply a single-prefix
+manifest:
+
+```bash
+op run -- bun run r2:orphans -- inspect \
+  --manifest /tmp/r2-held.json \
+  --only-backup 6hourly-backup-20260728001550
+op run -- bun run r2:orphans -- apply \
+  --manifest /tmp/r2-held.json \
+  --only-backup 6hourly-backup-20260728001550 \
+  --apply \
+  --yes
+```
+
+Only after the guarded R2 command succeeds, destroy the exact local snapshot
+that was reviewed with it. Do not delete the dataset, PV, or PVC:
+
+```bash
+NODE_POD=$(kubectl -n openebs get pod \
+  -l role=openebs-zfs,app=openebs-zfs-node \
+  --field-selector spec.nodeName=torvalds \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl -n openebs exec -i "$NODE_POD" \
+  -c openebs-zfs-plugin -- \
+  zfs destroy \
+  'zfspv-pool-nvme/pvc-22eaf2de-13ce-402a-ac35-cdaf006cb438@6hourly-backup-20260728001550'
+```
+
+If R2 deletion fails, do not destroy the local snapshot. If the local destroy
+fails after R2 deletion, preserve the dataset and report the exact residual.
 
 ## Step 6: Verify post-prune state
 


### PR DESCRIPTION
## Why

The backup/R2 incident cleanup needed a durable review boundary for the retained backup and its coupled local ZFS snapshot. Bulk deletion must fail closed when live Velero or object state changes.

## What

- Upgrade the R2 orphan manifest to contract v2 with persisted `--hold-backup` and `--only-backup` selections.
- Exclude held prefixes from bulk deletion and reject missing, conflicting, protected, young, or drifted selections.
- Revalidate the manifest before every destructive prefix deletion.
- Document the reviewed R2-then-exact-ZFS-snapshot workflow and add focused safety tests.

## Verification

- `bun run build`
- `bun run test` — 514 passed, 14 skipped, 0 failed
- `bun run typecheck`
- ESLint, Prettier, `git diff --check`, and staged pre-commit checks passed.
- Live cleanup removed 224 guarded candidates, then resumed safely after a legitimate manifest-drift stop; the held prefix and exact local snapshot were removed as a separate coupled operation.
- Post-cleanup R2 inspection reported zero candidates; all 70 PV-backed ZFS datasets remained; Temporal reported zero orphan snapshots and zero orphan bytes; a Velero backup/restore canary completed.

The direct R2 inventory is now approximately 465 GB. The R2 exporter scrape succeeds but its Cloudflare usage metric remains stale, so `R2StorageNearingLimit` is not claimed as cleared. PVC-size alerts remain intentional capacity warnings with unchanged backup scope.