### PR TITLE
fix(scout-for-lol): hold the Bryan Bucks stake cap, name a closed window, and stop losing a settlement

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
@@ -1,5 +1,6 @@
 import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
 import { SEED_GRANT } from "#src/betting/constants.ts";
+import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isUniqueConstraintError } from "#src/lib/player-admin/shared.ts";
 import { createLogger } from "#src/logger.ts";
@@ -54,9 +55,14 @@ export type BucksAccountRef = {
  *
  * A newly created wallet starts at `SEED_GRANT` with a matching `seed` ledger
  * row, because earning alone cannot bootstrap the economy: a player with no
- * Bucks cannot place a bet, and betting is the point. The grant and the row are
- * written in one transaction so a wallet can never exist without the entry that
- * explains its balance.
+ * Bucks cannot place a bet, and betting is the point.
+ *
+ * The row is created at zero and the grant applied through `applyBucksDelta`
+ * inside the same transaction, rather than by writing a starting balance
+ * alongside a hand-built ledger row. `ledger.ts` is documented as the one place
+ * a balance may move, and a bootstrap exception would be a second mutation path
+ * that skips its context validation — so a wallet still cannot exist without
+ * the entry that explains its balance, and there is still only one writer.
  *
  * Racing callers are handled by catching the unique-constraint violation rather
  * than by locking: two concurrent first-clicks would otherwise both see "no
@@ -85,26 +91,23 @@ export async function ensureBucksAccount(
         data: {
           serverId: input.serverId,
           discordId: input.discordId,
-          balance: SEED_GRANT,
+          balance: 0,
         },
-        select: { id: true, balance: true },
+        select: { id: true },
       });
-      await tx.bucksLedgerEntry.create({
-        data: {
-          bucksAccountId: created.id,
-          delta: SEED_GRANT,
-          balanceAfter: SEED_GRANT,
-          kind: "seed",
-          context: JSON.stringify({
-            type: "seed",
-            note: "Welcome grant on first Bryan Bucks wallet",
-          }),
+      const balance = await applyBucksDelta(tx, {
+        bucksAccountId: created.id,
+        delta: SEED_GRANT,
+        kind: "seed",
+        context: {
+          type: "seed",
+          note: "Welcome grant on first Bryan Bucks wallet",
         },
       });
       logger.info(
         `💰 Seeded a Bryan Bucks wallet with ${SEED_GRANT.toString()} BB`,
       );
-      return created;
+      return { id: created.id, balance };
     });
   } catch (error) {
     if (isUniqueConstraintError(error)) {

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -184,6 +184,37 @@ export async function announceSettlements(
       });
 
       const refs = BucksMessageRefsSchema.parse(JSON.parse(pool.messageRefs));
+      if (refs.length === 0) {
+        // No recorded message means no destination, and there is no second
+        // chance: the pool has committed as settled, so a later pass returns no
+        // summary for it. Whoever was owed something here was paid and will
+        // never be told. That happens when the prematch message never landed in
+        // this guild, or when recording its refs failed outright — which is
+        // exactly why `recordPoolMessageRefs` is not the cosmetic write it once
+        // claimed to be, and why this is reported rather than shrugged off.
+        //
+        // Deliberately not redirected to some other channel: the pool's own
+        // message is where its bettors are watching, and substituting a guess
+        // would post a guild's payouts somewhere nobody opted into. A pool that
+        // owed nobody anything is not worth reporting.
+        const owedSomeone =
+          summary.bets.length > 0 ||
+          input.earnings.some((award) => award.serverId === summary.serverId);
+        if (owedSomeone) {
+          logger.error(
+            `❌ Settled Bryan Bucks pool ${summary.matchId} in guild ${summary.serverId} has no recorded message — the settlement was paid but cannot be announced`,
+          );
+          Sentry.captureMessage(
+            "Bryan Bucks settlement had nowhere to announce",
+            {
+              level: "error",
+              tags: { source: "betting-announce", matchId: summary.matchId },
+              extra: { serverId: summary.serverId },
+            },
+          );
+        }
+        continue;
+      }
       const guildId = DiscordGuildIdSchema.parse(summary.serverId);
 
       for (const ref of refs) {

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
@@ -154,6 +154,47 @@ describe("handleBetButton", () => {
     expect(bet.predictedTeamId).toBe(200);
   });
 
+  test("tells a bettor their position is locked rather than missing", async () => {
+    await handleBetButton(fakeInteraction(betId(0, "W", 5)).interaction, db);
+    await db.bucksMatchPool.updateMany({
+      data: { closesAt: new Date(Date.now() - 1000) },
+    });
+
+    const cancelId = formatBucksCustomId({
+      action: "x",
+      matchId: MATCH_ID,
+      subjectIndex: 0,
+      side: "W",
+      amount: 0,
+    });
+    const { interaction, replies } = fakeInteraction(cancelId);
+    await handleBetButton(interaction, db);
+
+    // "You don't have a bet" would be a lie to someone whose stake is sitting
+    // in the pool, and would read as if it had never been recorded.
+    expect(replies[0]).toContain("Betting has closed");
+    expect(replies[0]).not.toContain("don't have a bet");
+
+    // The stake stays staked: no refund sneaks out after close.
+    expect(await db.bucksBet.count()).toBe(1);
+    const account = await db.bucksAccount.findFirstOrThrow();
+    expect(account.balance).toBe(SEED_GRANT - 5);
+  });
+
+  test("still reports a missing bet as missing", async () => {
+    const cancelId = formatBucksCustomId({
+      action: "x",
+      matchId: MATCH_ID,
+      subjectIndex: 0,
+      side: "W",
+      amount: 0,
+    });
+    const { interaction, replies } = fakeInteraction(cancelId);
+    await handleBetButton(interaction, db);
+
+    expect(replies[0]).toContain("don't have a bet");
+  });
+
   test("refuses a click after the window closes", async () => {
     await db.bucksMatchPool.updateMany({
       data: { closesAt: new Date(Date.now() - 1000) },

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -7,7 +7,7 @@ import {
 import { BUCKS_SCOPE_NOTE } from "#src/betting/constants.ts";
 import { parseBucksCustomId } from "#src/betting/custom-id.ts";
 import { placeBet, type PlaceBetResult } from "#src/betting/place-bet.ts";
-import { cancelBet } from "#src/betting/cancel-bet.ts";
+import { cancelBet, type CancelBetResult } from "#src/betting/cancel-bet.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -53,10 +53,28 @@ export function describeResult(
       return `🤔 That player isn't in this game. Try: ${result.validAliases.join(", ")}.`;
     case "invalid_stake":
       return `💱 Stakes must be between ${result.min.toString()} and ${result.max.toString()} BB.`;
+    case "stake_cap":
+      return `💱 You already have **${result.existingStake.toString()} BB** on this game, and a single position tops out at **${result.max.toString()} BB**.`;
     case "insufficient":
       return `💸 You have **${result.balance.toString()} BB** but need **${result.needed.toString()} BB**.`;
     case "side_conflict":
       return "↔️ You already backed the other side of this game. Cancel your bet first.";
+  }
+}
+
+/** Same framing as `describeResult`, for the cancel half of the button row.
+ * A closed window is reported as itself: telling someone with a live stake that
+ * they have no bet is both wrong and alarming. */
+export function describeCancel(result: CancelBetResult): string {
+  switch (result.kind) {
+    case "cancelled":
+      return `↩️ Bet cancelled. **${result.refunded.toString()} BB** returned; balance **${result.balanceAfter.toString()} BB**.`;
+    case "window_closed":
+      return "⏰ Betting has closed for this game, so positions are locked in. Yours settles when the game ends.";
+    case "no_bet":
+      return "🤷 You don't have a bet to cancel on this game.";
+    case "no_pool":
+      return "🚫 There's no Bryan Bucks market for this game.";
   }
 }
 
@@ -128,11 +146,7 @@ export async function handleBetButton(
       { matchId: parsed.matchId, serverId, discordId },
       prismaClient,
     );
-    await interaction.editReply({
-      content: cancelled.cancelled
-        ? `↩️ Bet cancelled. **${cancelled.refunded.toString()} BB** returned; balance **${cancelled.balanceAfter.toString()} BB**.`
-        : "🤷 You don't have a bet to cancel on this game.",
-    });
+    await interaction.editReply({ content: describeCancel(cancelled) });
     return;
   }
 

--- a/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
@@ -9,11 +9,20 @@ import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("betting-cancel-bet");
 
-export type CancelBetResult = {
-  cancelled: boolean;
-  refunded: number;
-  balanceAfter: number;
-};
+/**
+ * Why a cancellation did or did not happen.
+ *
+ * A discriminated union rather than a `cancelled: false` flag, because the
+ * reasons are not interchangeable to the person clicking: "you have no bet" and
+ * "your bet is locked in because the window closed" describe opposite states of
+ * the same wallet, and answering the second with the first tells a bettor with
+ * money on the game that their stake was never recorded.
+ */
+export type CancelBetResult =
+  | { kind: "cancelled"; refunded: number; balanceAfter: number }
+  | { kind: "no_pool" }
+  | { kind: "no_bet" }
+  | { kind: "window_closed" };
 
 /**
  * Withdraw a position while the window is still open.
@@ -38,12 +47,6 @@ export async function cancelBet(
   prismaClient: ExtendedPrismaClient = prisma,
   now: Date = new Date(),
 ): Promise<CancelBetResult> {
-  const empty: CancelBetResult = {
-    cancelled: false,
-    refunded: 0,
-    balanceAfter: 0,
-  };
-
   const pool = await prismaClient.bucksMatchPool.findUnique({
     where: {
       matchId_serverId: { matchId: input.matchId, serverId: input.serverId },
@@ -51,7 +54,7 @@ export async function cancelBet(
     select: { id: true, roster: true },
   });
   if (pool === null) {
-    return empty;
+    return { kind: "no_pool" };
   }
 
   const account = await prismaClient.bucksAccount.findUnique({
@@ -64,7 +67,9 @@ export async function cancelBet(
     select: { id: true },
   });
   if (account === null) {
-    return empty;
+    // No wallet in this guild means no stake in this pool, so this is the same
+    // answer as an empty bet slot rather than a distinct state.
+    return { kind: "no_bet" };
   }
 
   return await prismaClient.$transaction(async (tx) => {
@@ -76,7 +81,11 @@ export async function cancelBet(
       data: { updatedAt: now },
     });
     if (claim.count !== 1) {
-      return empty;
+      // The pool row was read moments ago and nothing deletes pools, so the
+      // only way to miss it here is the predicate: the window has passed or the
+      // pool has already left `open`. That is a different answer from "you have
+      // no bet", and the caller renders it as one.
+      return { kind: "window_closed" };
     }
 
     const bet = await tx.bucksBet.findUnique({
@@ -89,7 +98,7 @@ export async function cancelBet(
       select: { id: true, stake: true, predictedTeamId: true },
     });
     if (bet === null) {
-      return empty;
+      return { kind: "no_bet" };
     }
 
     const roster = BucksPoolRosterSchema.parse(
@@ -126,6 +135,6 @@ export async function cancelBet(
       `↩️ Cancelled a Bryan Bucks bet on ${input.matchId}, refunding ${bet.stake.toString()} BB`,
     );
 
-    return { cancelled: true, refunded: bet.stake, balanceAfter };
+    return { kind: "cancelled", refunded: bet.stake, balanceAfter };
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
@@ -16,7 +16,7 @@ import {
 } from "#src/testing/bucks-fixtures.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
 import { placeBet, type PlaceBetInput } from "#src/betting/place-bet.ts";
-import { SEED_GRANT } from "#src/betting/constants.ts";
+import { MAX_STAKE, SEED_GRANT } from "#src/betting/constants.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
@@ -230,6 +230,39 @@ describe("placeBet — refusing a position", () => {
       expect(await betKind({ stake })).toBe("invalid_stake");
     }
     expect(await db.bucksBet.count()).toBe(0);
+  });
+
+  test("refuses a top-up that would take the position past MAX_STAKE", async () => {
+    await bet({ stake: 1 });
+    // Fund the wallet well past the cap so the refusal below can only be the
+    // cap: a per-position bound that only holds while you are too poor to
+    // exceed it is not a bound.
+    await db.bucksAccount.updateMany({ data: { balance: 10 * MAX_STAKE } });
+
+    const result = await bet({ stake: MAX_STAKE });
+    if (result.kind !== "stake_cap") {
+      throw new Error(`expected the cap to refuse it, got ${result.kind}`);
+    }
+    expect(result.existingStake).toBe(1);
+    expect(result.max).toBe(MAX_STAKE);
+
+    // Nothing charged, and the position is exactly as it was.
+    const account = await db.bucksAccount.findFirstOrThrow();
+    expect(account.balance).toBe(10 * MAX_STAKE);
+    const position = await db.bucksBet.findFirstOrThrow();
+    expect(position.stake).toBe(1);
+    expect(await countLedger("bet_stake")).toBe(1);
+  });
+
+  test("allows a top-up that lands exactly on MAX_STAKE", async () => {
+    await bet({ stake: 1 });
+    await db.bucksAccount.updateMany({ data: { balance: 10 * MAX_STAKE } });
+
+    const result = await bet({ stake: MAX_STAKE - 1 });
+    if (result.kind !== "placed") {
+      throw new Error(`expected the bet to be placed, got ${result.kind}`);
+    }
+    expect(result.totalStake).toBe(MAX_STAKE);
   });
 
   test("refuses a bet in a guild with no pool", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.ts
@@ -39,6 +39,7 @@ export type PlaceBetResult =
   | { kind: "not_eligible" }
   | { kind: "unknown_subject"; validAliases: string[] }
   | { kind: "invalid_stake"; min: number; max: number }
+  | { kind: "stake_cap"; existingStake: number; max: number }
   | { kind: "insufficient"; balance: number; needed: number }
   | { kind: "side_conflict"; existingTeamId: number };
 
@@ -180,6 +181,23 @@ export async function placeBet(
         // predict" unanswerable in the ledger, so it is refused outright
         // rather than netted off.
         throw new SideConflictError(existing.predictedTeamId);
+      }
+
+      // MAX_STAKE bounds a *position*, not a click. The range check above only
+      // sees the increment, so without this a bettor could walk an existing
+      // position past the cap one click at a time — and the cap is what keeps
+      // `stake * losersPool` inside Number.MAX_SAFE_INTEGER in the parimutuel
+      // allocation, so exceeding it is not merely a policy breach.
+      //
+      // Read-then-compare is safe here for the same reason the rest of this
+      // closure is: the claim above took the write lock for this transaction,
+      // so `existing.stake` cannot move underneath us.
+      if (existing !== null && existing.stake + input.stake > MAX_STAKE) {
+        return {
+          kind: "stake_cap",
+          existingStake: existing.stake,
+          max: MAX_STAKE,
+        };
       }
 
       const bet =

--- a/packages/scout-for-lol/packages/backend/src/betting/pool-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/pool-open.ts
@@ -183,12 +183,23 @@ export async function openBettingPoolsForPrematch(
   return opened;
 }
 
+const MESSAGE_REF_ATTEMPTS = 3;
+const MESSAGE_REF_BACKOFF_MS = 250;
+
 /**
- * Record which message carries this guild's buttons, so the close sweep can
- * disable exactly the right ones without re-deriving channel-to-guild.
+ * Record which message carries this guild's buttons.
  *
- * Best-effort: losing this only costs the cosmetic disable, since closure is
- * enforced at bet time against `closesAt`.
+ * Two things read this back, and only one of them is cosmetic. The close sweep
+ * uses it to grey out exactly the right buttons, which closure at bet time
+ * against `closesAt` already enforces anyway — but `announceSettlements` also
+ * uses it as the *only* record of where a pool's bettors are watching. Losing
+ * the write therefore costs the settlement message, and that summary is
+ * one-shot: `settleBettingForMatch` returns nothing for an already-settled
+ * pool, so nothing later can notice the omission and re-send.
+ *
+ * Hence a bounded retry and an error-level report rather than a shrug. It still
+ * must not throw: this runs inside prematch delivery, where a betting failure
+ * may not take the loading screen down with it.
  */
 export async function recordPoolMessageRefs(
   input: {
@@ -198,20 +209,35 @@ export async function recordPoolMessageRefs(
   },
   prismaClient: ExtendedPrismaClient = prisma,
 ): Promise<void> {
-  try {
-    await prismaClient.bucksMatchPool.update({
-      where: {
-        matchId_serverId: { matchId: input.matchId, serverId: input.serverId },
-      },
-      data: { messageRefs: JSON.stringify(input.refs) },
-    });
-  } catch (error) {
-    logger.warn(
-      `⚠️ Could not record Bryan Bucks message refs for ${input.matchId}:`,
-      error,
-    );
-    Sentry.captureException(error, {
-      tags: { source: "betting-record-message-refs", matchId: input.matchId },
-    });
+  for (let attempt = 1; attempt <= MESSAGE_REF_ATTEMPTS; attempt++) {
+    try {
+      await prismaClient.bucksMatchPool.update({
+        where: {
+          matchId_serverId: {
+            matchId: input.matchId,
+            serverId: input.serverId,
+          },
+        },
+        data: { messageRefs: JSON.stringify(input.refs) },
+      });
+      return;
+    } catch (error) {
+      if (attempt < MESSAGE_REF_ATTEMPTS) {
+        const delayMs = MESSAGE_REF_BACKOFF_MS * 2 ** (attempt - 1);
+        logger.warn(
+          `⚠️ Attempt ${attempt.toString()}/${MESSAGE_REF_ATTEMPTS.toString()} to record Bryan Bucks message refs for ${input.matchId} failed; retrying in ${delayMs.toString()}ms:`,
+          error,
+        );
+        await Bun.sleep(delayMs);
+        continue;
+      }
+      logger.error(
+        `❌ Could not record Bryan Bucks message refs for ${input.matchId} — this pool's settlement announcement now has nowhere to go:`,
+        error,
+      );
+      Sentry.captureException(error, {
+        tags: { source: "betting-record-message-refs", matchId: input.matchId },
+      });
+    }
   }
 }


### PR DESCRIPTION
## Why

Qodo raised four findings on #2194 (Bryan Bucks), but that PR was squash-merged as `5387ed62e` before the fixes landed — so **all four defects are live on `main` right now**. This PR carries only those fixes, rebased onto current main.

The stake-cap one matters most: `placeBet()` validated only the incoming *increment* against `MAX_STAKE` and then added it to an existing position, so repeated top-ups could push a single position past the documented per-position cap — which the parimutuel math relies on for numeric safety.

## What

- **`place-bet.ts` — bound the resulting position, not the increment.** `MAX_STAKE` now constrains the post-increment total, with a new `stake_cap` result so the caller can say what actually happened.
- **`accounts.ts` — seed through the chokepoint.** `ensureBucksAccount()` previously created a `BucksAccount` with a non-zero balance and hand-inserted a ledger row, bypassing `applyBucksDelta()` and its `BucksLedgerContextSchema` validation despite that module being documented as the single balance-mutation chokepoint. Seeding now goes through it.
- **`cancel-bet.ts` — distinguish "window closed" from "no bet".** `cancelBet()` returned the same empty result for both, and the button rendered it as "You don't have a bet" — alarming for someone who does have a stake. It now returns a discriminated union so a closed window reads as closed.
- **`pool-open.ts` / `announce.ts` — stop losing settlements.** `recordPoolMessageRefs()` swallowed write failures, leaving `messageRefs` empty so `announceSettlements()` silently announced to nobody. The write now retries and reports at error level, and a settled pool that owed someone no longer goes quiet when it has no destination.

## Verification

- `bunx turbo run typecheck lint test --filter=@scout-for-lol/backend` on this branch's base — 10/10 tasks successful, lint 0 errors (691 pre-existing warnings), **1458 pass / 0 fail / 6 skip**. The 6 skips are the env-gated `prematch-notification.integration.test.ts` suite, untouched by this change.
- Four new regression tests: two for the stake cap, two for the closed-window cancel path.
- Verified independently that the branch is 1 commit on current `main`, single parent, exactly 8 files (+233/−58), and merges cleanly.
- **Not run:** a live Discord betting interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uuQsbBg2CFHfYD6WbFWwN