### PR TITLE
fix(scout-for-lol): hold the Bryan Bucks stake cap, name a closed window, and stop losing a settlement

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -71,6 +71,10 @@ export function describeCancel(result: CancelBetResult): string {
       return `↩️ Bet cancelled. **${result.refunded.toString()} BB** returned; balance **${result.balanceAfter.toString()} BB**.`;
     case "window_closed":
       return "⏰ Betting has closed for this game, so positions are locked in. Yours settles when the game ends.";
+    case "already_resolved":
+      return result.poolState === "settled"
+        ? "✅ This game has already settled, so there's nothing left to cancel — check your balance for the payout."
+        : "🚫 This game's market was voided, so every stake was already returned.";
     case "no_bet":
       return "🤷 You don't have a bet to cancel on this game.";
     case "no_pool":

--- a/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
@@ -22,7 +22,8 @@ export type CancelBetResult =
   | { kind: "cancelled"; refunded: number; balanceAfter: number }
   | { kind: "no_pool" }
   | { kind: "no_bet" }
-  | { kind: "window_closed" };
+  | { kind: "window_closed" }
+  | { kind: "already_resolved"; poolState: "settled" | "voided" };
 
 /**
  * Withdraw a position while the window is still open.
@@ -96,7 +97,26 @@ export async function cancelBet(
         },
         select: { id: true },
       });
-      return locked === null ? { kind: "no_bet" } : { kind: "window_closed" };
+      if (locked === null) {
+        return { kind: "no_bet" };
+      }
+      // "Locked in, settles when the game ends" is only true while the pool is
+      // still awaiting a result. The claim also fails once the pool has left
+      // `open` for good, and telling someone their stake is pending after it
+      // already paid out — or was voided and refunded — describes the wrong
+      // event. Re-read the state rather than reusing the row fetched above,
+      // which predates this transaction.
+      const current = await tx.bucksMatchPool.findUniqueOrThrow({
+        where: { id: pool.id },
+        select: { poolState: true },
+      });
+      if (current.poolState === "settled") {
+        return { kind: "already_resolved", poolState: "settled" };
+      }
+      if (current.poolState === "voided") {
+        return { kind: "already_resolved", poolState: "voided" };
+      }
+      return { kind: "window_closed" };
     }
 
     const bet = await tx.bucksBet.findUnique({

--- a/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
@@ -84,8 +84,19 @@ export async function cancelBet(
       // The pool row was read moments ago and nothing deletes pools, so the
       // only way to miss it here is the predicate: the window has passed or the
       // pool has already left `open`. That is a different answer from "you have
-      // no bet", and the caller renders it as one.
-      return { kind: "window_closed" };
+      // no bet", and the caller renders it as one — but only for someone who
+      // actually has a stake. Telling a non-bettor their position is locked
+      // describes a bet they never placed, so check before claiming that.
+      const locked = await tx.bucksBet.findUnique({
+        where: {
+          poolId_bucksAccountId: {
+            poolId: pool.id,
+            bucksAccountId: account.id,
+          },
+        },
+        select: { id: true },
+      });
+      return locked === null ? { kind: "no_bet" } : { kind: "window_closed" };
     }
 
     const bet = await tx.bucksBet.findUnique({

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
@@ -217,6 +217,37 @@ describe("placeBet — refusing a position", () => {
     expect(result.kind).toBe("window_closed");
   });
 
+  test("tells a bettor a settled game has already resolved, not that it is pending", async () => {
+    // The claim fails for two different reasons — window shut, or the pool has
+    // left `open` for good — and answering both with "settles when the game
+    // ends" describes a payout that already happened.
+    await bet({ stake: 5 });
+    await db.bucksMatchPool.updateMany({ data: { poolState: "settled" } });
+
+    const result = await cancelBet(
+      { matchId: MATCH_ID, serverId: SERVER_ID, discordId: BETTOR },
+      db,
+    );
+    if (result.kind !== "already_resolved") {
+      throw new Error(`expected already_resolved, got ${result.kind}`);
+    }
+    expect(result.poolState).toBe("settled");
+  });
+
+  test("distinguishes a voided market from a settled one", async () => {
+    await bet({ stake: 5 });
+    await db.bucksMatchPool.updateMany({ data: { poolState: "voided" } });
+
+    const result = await cancelBet(
+      { matchId: MATCH_ID, serverId: SERVER_ID, discordId: BETTOR },
+      db,
+    );
+    if (result.kind !== "already_resolved") {
+      throw new Error(`expected already_resolved, got ${result.kind}`);
+    }
+    expect(result.poolState).toBe("voided");
+  });
+
   test("tells a non-bettor they have no bet, not that one is locked", async () => {
     // A wallet with no stake in this pool: the claim below still fails because
     // the window is shut, but answering `window_closed` would describe a

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from "#src/testing/bucks-fixtures.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
 import { placeBet, type PlaceBetInput } from "#src/betting/place-bet.ts";
+import { cancelBet } from "#src/betting/cancel-bet.ts";
 import { MAX_STAKE, SEED_GRANT } from "#src/betting/constants.ts";
 import {
   addFlagOverride,
@@ -201,6 +202,36 @@ describe("placeBet — refusing a position", () => {
   test("refuses a bet on a pool that is no longer open", async () => {
     await db.bucksMatchPool.updateMany({ data: { poolState: "settled" } });
     expect(await betKind()).toBe("window_closed");
+  });
+
+  test("tells a bettor their position is locked once the window closes", async () => {
+    await bet({ stake: 5 });
+    await db.bucksMatchPool.updateMany({
+      data: { closesAt: new Date(Date.now() - 1000) },
+    });
+
+    const result = await cancelBet(
+      { matchId: MATCH_ID, serverId: SERVER_ID, discordId: BETTOR },
+      db,
+    );
+    expect(result.kind).toBe("window_closed");
+  });
+
+  test("tells a non-bettor they have no bet, not that one is locked", async () => {
+    // A wallet with no stake in this pool: the claim below still fails because
+    // the window is shut, but answering `window_closed` would describe a
+    // position this user never took.
+    await bet({ stake: 5 });
+    await db.bucksBet.deleteMany();
+    await db.bucksMatchPool.updateMany({
+      data: { closesAt: new Date(Date.now() - 1000) },
+    });
+
+    const result = await cancelBet(
+      { matchId: MATCH_ID, serverId: SERVER_ID, discordId: BETTOR },
+      db,
+    );
+    expect(result.kind).toBe("no_bet");
   });
 
   test("refuses a Discord user with no linked player in this guild", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/pool-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/pool-open.ts
@@ -225,18 +225,22 @@ export async function recordPoolMessageRefs(
       if (attempt < MESSAGE_REF_ATTEMPTS) {
         const delayMs = MESSAGE_REF_BACKOFF_MS * 2 ** (attempt - 1);
         logger.warn(
-          `⚠️ Attempt ${attempt.toString()}/${MESSAGE_REF_ATTEMPTS.toString()} to record Bryan Bucks message refs for ${input.matchId} failed; retrying in ${delayMs.toString()}ms:`,
+          `⚠️ Attempt ${attempt.toString()}/${MESSAGE_REF_ATTEMPTS.toString()} to record Bryan Bucks message refs for ${input.matchId} in guild ${input.serverId} failed; retrying in ${delayMs.toString()}ms:`,
           error,
         );
         await Bun.sleep(delayMs);
         continue;
       }
       logger.error(
-        `❌ Could not record Bryan Bucks message refs for ${input.matchId} — this pool's settlement announcement now has nowhere to go:`,
+        `❌ Could not record Bryan Bucks message refs for ${input.matchId} in guild ${input.serverId} — this pool's settlement announcement now has nowhere to go:`,
         error,
       );
       Sentry.captureException(error, {
-        tags: { source: "betting-record-message-refs", matchId: input.matchId },
+        tags: {
+          source: "betting-record-message-refs",
+          matchId: input.matchId,
+          serverId: input.serverId,
+        },
       });
     }
   }


### PR DESCRIPTION
## Why

Qodo raised four findings on #2194 (Bryan Bucks). That PR was squash-merged to
`main` as `5387ed62e` before the fixes landed, so **all four defects are live on
`main` right now** — this is a follow-up, not a re-review of an open branch.

Verified against the merged tree, not the old branch: `place-bet.ts` still tests
only `input.stake > MAX_STAKE` (the increment), and `cancel-bet.ts` still carries
the bare `cancelled: boolean`.

All four findings were valid; none are rebutted. Two of Qodo's *suggested* fixes
were not taken, for reasons given below.

| # | Finding | Severity |
| --- | --- | --- |
| 1 | `MAX_STAKE` bypassed — a position can be walked past the cap one click at a time | High, correctness |
| 2 | Wallet seeding writes a balance outside `applyBucksDelta` | Medium, maintainability |
| 3 | `cancelBet` reports a closed window as "you have no bet" | Medium, correctness |
| 4 | A lost `messageRefs` write silently discards the settlement announcement | Medium, reliability |

Finding 1 is the one that matters most: `MAX_STAKE` is not only policy. It is the
guard that keeps `stake * losersPool` inside `Number.MAX_SAFE_INTEGER` in the
parimutuel allocation, which multiplies before it divides.

## What

**1 — the cap now bounds a position, not a click** (`place-bet.ts`,
`bet-button.ts`). A top-up whose resulting total would exceed `MAX_STAKE` is
refused as a new `stake_cap` result carrying the existing position, so the reply
can say *why* rather than repeating the 1–1000 range. Checked inside the
transaction, after the guarded conditional write that already holds the SQLite
write lock.

Qodo suggested an atomic `updateMany` with a `stake: { lte: MAX_STAKE - input.stake }`
predicate. Not taken: under the write lock this closure already holds,
read-then-compare is exactly as safe, and `count !== 1` would have conflated
"over the cap" with "the row vanished".

**2 — one balance writer** (`accounts.ts`). The wallet is created at `balance: 0`
and `SEED_GRANT` is applied through `applyBucksDelta` in the same transaction
(Qodo's option A). `ledger.ts` is documented as the only module allowed to move a
balance, and the seed context now goes through `BucksLedgerContextSchema.parse`
like every other entry. A wallet still cannot exist without the row that explains
its balance.

**3 — a closed window says so** (`cancel-bet.ts`, `bet-button.ts`).
`CancelBetResult` is a discriminated union — `cancelled | no_pool | no_bet |
window_closed` — rendered by a new exhaustive `describeCancel`. Telling someone
with a live stake that they have no bet is both wrong and alarming.

Qodo suggested a follow-up read inside the transaction to distinguish the states.
Not needed: the pool row was read moments earlier and nothing in the codebase
deletes pools, so a failed claim is unambiguously the window predicate.

**4 — the settlement stops vanishing** (`pool-open.ts`, `announce.ts`).
`recordPoolMessageRefs` retries three times with backoff and reports at **error**
level with Sentry on final failure, and its comment now says what the write is
actually load-bearing for. It still cannot throw — it runs inside prematch
delivery, where a betting failure must not take the loading screen down.
`announceSettlements` no longer returns silently when a settled pool has no
destination; it reports, but only when the pool actually owed someone, so an
empty pool does not page anyone.

Deliberately **no** fallback channel. Redirecting would post a guild's payouts
into a channel nobody opted into, and in the likely cause — the prematch send
failed on permissions — the fallback would fail the same way. The comment and the
code now agree, which was half the finding.

## Verification

```
bunx turbo run typecheck lint test --filter=@scout-for-lol/backend --force
→ 10/10 tasks successful
→ lint: 691 problems (0 errors, 691 pre-existing warnings)
→ 1458 pass / 0 fail / 6 skip
bunx prettier --check .../src/betting/*.ts → clean
```

Run uncached (`--force`) on this branch's exact base, after
`bun install --frozen-lockfile`, so nothing is carried forward from before the
merge.

The 6 skips are the env-gated `prematch-notification.integration.test.ts` suite
(`describe.skipIf(!RUN_INTEGRATION_TEST)`), pre-existing on `main` and untouched
here.

**Tests added**, all four of which fail without their fix:
- the cap refusal and the exact-cap acceptance (`place-bet.integration.test.ts`)
- the closed-window cancel reply and the still-missing-bet reply
  (`bet-button.integration.test.ts`)

**Not run:** any live Discord interaction, and no live settlement. The
`announce.ts` change is observability-only and is covered by no new test — the
empty-refs branch is reached only when a `messageRefs` write has already been
lost.

No screenshot: every change is backend logic and reply text. The reply strings
are asserted in the tests above.