### PR TITLE
fix(scout-for-lol): restore legacy beta reports

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -445,9 +445,9 @@ tests and manual debugging; it is ignored for non-ranked queues, which continue
 to use the legacy 4760×3500 report.
 
 `MatchRenderOptions.enableRankedDesigns` gates the two designs above and
-defaults to `true`. The backend passes `false` in prod, so production ranked
-matches currently render the legacy 4760×3500 report too; only beta and local
-dev see the new designs until the redesign is promoted.
+defaults to `true`. The backend passes `false` outside local dev, so Beta and
+production ranked matches render the legacy 4760×3500 report; only local dev
+sees the new designs until the redesign is promoted.
 
 Champion names stored on match data are Data Dragon asset keys. Keep those keys
 for image lookup and pass every user-visible champion label through

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
@@ -107,9 +107,9 @@ async function createMatchImage(
     svgData = await classicMatchToSvg(matchToRender);
   } else {
     svgData = await matchToSvg(matchToRender, {
-      // Gate the new ranked banner/square designs to beta + local dev;
-      // prod keeps the legacy report until the redesign is promoted.
-      enableRankedDesigns: configuration.environment !== "prod",
+      // Keep the new ranked banner/square designs local-only until the
+      // redesign is promoted.
+      enableRankedDesigns: configuration.environment === "dev",
     });
   }
   const svg = z.string().parse(svgData);

--- a/packages/scout-for-lol/packages/report/src/html/index.tsx
+++ b/packages/scout-for-lol/packages/report/src/html/index.tsx
@@ -35,8 +35,8 @@ export type MatchRenderOptions = {
   /**
    * Gate the new ranked banner/square designs. When `false`, ranked solo/flex
    * matches fall back to the legacy 4760×3500 report. Defaults to `true`.
-   * The backend sets this to `false` in prod so the redesign only ships to
-   * beta + local dev until it's promoted.
+   * The backend sets this to `false` outside local dev so the redesign stays
+   * local-only until it's promoted.
    */
   enableRankedDesigns?: boolean;
 };


### PR DESCRIPTION
Why:

Beta should remain on the stable legacy ranked report while the new banner and square designs stay local-only.

What:

- Gate `enableRankedDesigns` on `ENVIRONMENT=dev`.
- Keep the report package and Scout package guidance aligned with the rollout gate.

Verification:

- `bunx turbo run typecheck --filter=@scout-for-lol/backend --filter=@scout-for-lol/report`
- `bunx turbo run test --filter=@scout-for-lol/report --filter=@scout-for-lol/backend` — 129 report tests and 1,454 backend tests passed.
- `bunx prettier --check ...`
- `bunx lefthook run pre-commit`

Not run: live Beta or production deployment verification.