### PR TITLE
fix(asuswrt): reserve AX88U and preserve packed-list writes

### DIFF
--- a/packages/homelab/src/tofu/asuswrt/README.md
+++ b/packages/homelab/src/tofu/asuswrt/README.md
@@ -6,7 +6,7 @@ custom `terraform-provider-asuswrt` (built from `packages/terraform-provider-asu
 | Alias      | Device       | IP            | Mode   | Managed here                                                            |
 | ---------- | ------------ | ------------- | ------ | ----------------------------------------------------------------------- |
 | `router`   | RT-AX88U Pro | 192.168.1.1   | router | system, DHCP static leases, port-forwards, wireless wl0/wl1             |
-| `ap_ax88u` | RT-AX88U     | 192.168.1.213 | AP     | system, wireless wl0/wl1                                                |
+| `ap_ax88u` | RT-AX88U     | 192.168.1.214 | AP     | system, wireless wl0/wl1                                                |
 | `ap_be86u` | RT-BE86U     | 192.168.1.2   | AP     | system (wireless deferred — see `docs/todos/asuswrt-be86u-wireless.md`) |
 
 ## Local-run only (NOT in CI)

--- a/packages/homelab/src/tofu/asuswrt/ap-ax88u.tf
+++ b/packages/homelab/src/tofu/asuswrt/ap-ax88u.tf
@@ -1,4 +1,4 @@
-# RT-AX88U @ 192.168.1.213 (access point, sw_mode=3).
+# RT-AX88U @ 192.168.1.214 (access point, sw_mode=3).
 # In AP mode DHCP-server / WAN / port-forward are inert, so only system and
 # wireless are managed here.
 

--- a/packages/homelab/src/tofu/asuswrt/import.sh
+++ b/packages/homelab/src/tofu/asuswrt/import.sh
@@ -17,6 +17,7 @@ cd "$CHDIR/.."
 IMPORTS=$(
   cat <<'EOF'
 asuswrt_system.router	system
+asuswrt_dhcp_static_lease.ax88u_ap	24:4B:FE:D0:9B:A0
 asuswrt_dhcp_static_lease.plex_host	08:BF:B8:D4:59:7F
 asuswrt_dhcp_static_lease.lease_61	48:DA:35:6F:61:BF
 asuswrt_dhcp_static_lease.lease_90	4C:B9:EA:97:90:5A

--- a/packages/homelab/src/tofu/asuswrt/providers.tf
+++ b/packages/homelab/src/tofu/asuswrt/providers.tf
@@ -36,7 +36,7 @@ provider "asuswrt" {
 
 provider "asuswrt" {
   alias    = "ap_ax88u"
-  host     = "192.168.1.213"
+  host     = "192.168.1.214"
   port     = 8443
   https    = true
   insecure = true

--- a/packages/homelab/src/tofu/asuswrt/router.tf
+++ b/packages/homelab/src/tofu/asuswrt/router.tf
@@ -11,6 +11,13 @@ resource "asuswrt_system" "router" {
 }
 
 # --- DHCP static leases ---
+resource "asuswrt_dhcp_static_lease" "ax88u_ap" {
+  provider = asuswrt.router
+  mac      = "24:4B:FE:D0:9B:A0"
+  ip       = "192.168.1.214"
+  hostname = "RT-AX88U-9BA0"
+}
+
 resource "asuswrt_dhcp_static_lease" "plex_host" {
   provider = asuswrt.router
   mac      = "08:BF:B8:D4:59:7F"

--- a/packages/terraform-provider-asuswrt/internal/client/packed.go
+++ b/packages/terraform-provider-asuswrt/internal/client/packed.go
@@ -16,8 +16,10 @@ import (
 // as data, so the next read returns "&#38#60"/"&#38#62" and the router no longer
 // sees delimiters. Encode*ForWrite performs that boundary conversion.
 const (
+	packedReadAmpersand   = "&#38" // appGet.cgi representation of '&'
 	packedEntryDelim      = "&#60" // appGet.cgi representation of '<'
 	packedFieldDelim      = "&#62" // appGet.cgi representation of '>'
+	packedWriteAmpersand  = "&"    // apply.cgi representation
 	packedWriteEntryDelim = "<"    // apply.cgi representation
 	packedWriteFieldDelim = ">"    // apply.cgi representation
 )
@@ -335,6 +337,8 @@ func EncodeVTSRuleListForWrite(entries []PortForwardEntry) string {
 
 func encodePackedListForWrite(value string) string {
 	return strings.NewReplacer(
+		packedReadAmpersand,
+		packedWriteAmpersand,
 		packedEntryDelim, packedWriteEntryDelim,
 		packedFieldDelim, packedWriteFieldDelim,
 	).Replace(value)

--- a/packages/terraform-provider-asuswrt/internal/client/packed.go
+++ b/packages/terraform-provider-asuswrt/internal/client/packed.go
@@ -5,15 +5,21 @@ import (
 	"strings"
 )
 
-// Asuswrt packs list-valued NVRAM entries using HTML numeric character
-// references as delimiters rather than literal angle brackets: each entry is
-// prefixed by "&#60" (encodes '<') and its fields are separated by "&#62"
-// (encodes '>'). The router stores and returns the literal 4-character token
-// strings — it does NOT emit real '<'/'>' bytes — so parsing/serializing must
-// operate on these tokens to round-trip correctly against live hardware.
+// Asuswrt returns packed list-valued NVRAM entries from appGet.cgi with HTML
+// numeric character references as delimiters: each entry is prefixed by
+// "&#60" (encodes '<') and its fields are separated by "&#62" (encodes '>').
+// Parsing and the state-side serializer operate on that representation so an
+// untouched read round-trips byte-for-byte.
+//
+// apply.cgi is asymmetric: it expects the literal '<'/'>' format built by the
+// firmware's own web UI. Sending the appGet.cgi representation writes the '&'
+// as data, so the next read returns "&#38#60"/"&#38#62" and the router no longer
+// sees delimiters. Encode*ForWrite performs that boundary conversion.
 const (
-	packedEntryDelim = "&#60" // '<' — separates/prefixes entries
-	packedFieldDelim = "&#62" // '>' — separates fields within an entry
+	packedEntryDelim      = "&#60" // appGet.cgi representation of '<'
+	packedFieldDelim      = "&#62" // appGet.cgi representation of '>'
+	packedWriteEntryDelim = "<"    // apply.cgi representation
+	packedWriteFieldDelim = ">"    // apply.cgi representation
 )
 
 // Minimum field counts for a well-formed entry. Trailing fields (DHCP DNS and
@@ -38,13 +44,14 @@ const (
 	vtsSourceIPField  = 5
 )
 
-// PackedDelimiters returns the tokens that delimit packed NVRAM lists.
+// PackedDelimiters returns every read- or write-side delimiter that cannot
+// appear inside a modeled packed-list field.
 //
-// The format has no escaping, so a field value containing either token cannot
+// The format has no escaping, so a field value containing any delimiter cannot
 // be represented. Callers that accept user input destined for a packed list
 // must reject such values before they reach serialization.
 func PackedDelimiters() []string {
-	return []string{packedEntryDelim, packedFieldDelim}
+	return []string{packedEntryDelim, packedFieldDelim, packedWriteEntryDelim, packedWriteFieldDelim}
 }
 
 // splitPackedEntries splits a packed NVRAM value into per-entry field slices.
@@ -196,6 +203,13 @@ func SerializeDHCPStaticList(entries []DHCPStaticEntry) string {
 	return b.String()
 }
 
+// EncodeDHCPStaticListForWrite returns the literal-delimiter representation
+// apply.cgi expects. appGet.cgi exposes the same NVRAM value with the angle
+// brackets HTML-encoded, which SerializeDHCPStaticList deliberately preserves.
+func EncodeDHCPStaticListForWrite(entries []DHCPStaticEntry) string {
+	return encodePackedListForWrite(SerializeDHCPStaticList(entries))
+}
+
 // modeledFieldCount decides how many modeled fields to emit for one entry.
 //
 // It preserves the count the router supplied so an untouched short entry
@@ -311,4 +325,17 @@ func SerializeVTSRuleList(entries []PortForwardEntry) string {
 	}
 
 	return b.String()
+}
+
+// EncodeVTSRuleListForWrite is the port-forward equivalent of
+// EncodeDHCPStaticListForWrite.
+func EncodeVTSRuleListForWrite(entries []PortForwardEntry) string {
+	return encodePackedListForWrite(SerializeVTSRuleList(entries))
+}
+
+func encodePackedListForWrite(value string) string {
+	return strings.NewReplacer(
+		packedEntryDelim, packedWriteEntryDelim,
+		packedFieldDelim, packedWriteFieldDelim,
+	).Replace(value)
 }

--- a/packages/terraform-provider-asuswrt/internal/client/packed_test.go
+++ b/packages/terraform-provider-asuswrt/internal/client/packed_test.go
@@ -373,43 +373,44 @@ func TestVTSRuleListRoundTrip(t *testing.T) {
 	}
 }
 
-// The following tests assert that Serialize produces exactly what the router's
-// own web-UI JavaScript builder emits — an INDEPENDENT oracle (the firmware
-// spec), not a round-trip through our own parser. This is the strongest
-// write-path check available without applying to real hardware.
+// The following tests assert that Encode*ForWrite produces exactly what the
+// router's own web-UI JavaScript builder submits — an INDEPENDENT oracle (the
+// firmware spec), not a round-trip through our own parser.
 //
 // DHCP builder (Advanced_DHCP_Content.asp):
 //   dhcp_staticlist += "<" + mac + ">" + ip + ">" + dns + ">" + hostname
 // VTS builder (Advanced_VirtualServer_Content.asp):
 //   value += "<" + name + ">" + extPort + ">" + intIP + ">" + intPort + ">" + proto + ">" + srcIP
-// (angle brackets are stored as the &#60/&#62 entity tokens on the wire.)
+// appGet.cgi returns those angle brackets as &#60/&#62, but apply.cgi expects the
+// literal builder output. Submitting the read representation double-escapes
+// the ampersands and corrupts the list.
 
-func TestSerializeDHCPStaticListMatchesFirmwareBuilder(t *testing.T) {
+func TestEncodeDHCPStaticListForWriteMatchesFirmwareBuilder(t *testing.T) {
 	t.Parallel()
 
-	got := client.SerializeDHCPStaticList([]client.DHCPStaticEntry{
+	got := client.EncodeDHCPStaticListForWrite([]client.DHCPStaticEntry{
 		{MAC: "AA:BB:CC:DD:EE:FF", IP: "192.168.1.100"},                                 // no DNS/hostname
 		{MAC: "11:22:33:44:55:66", IP: "192.168.1.50", DNS: "1.1.1.1", Hostname: "nas"}, // all fields
 	})
 
-	want := lt + "AA:BB:CC:DD:EE:FF" + gt + "192.168.1.100" + gt + gt +
-		lt + "11:22:33:44:55:66" + gt + "192.168.1.50" + gt + "1.1.1.1" + gt + "nas"
+	want := "<AA:BB:CC:DD:EE:FF>192.168.1.100>>" +
+		"<11:22:33:44:55:66>192.168.1.50>1.1.1.1>nas"
 
 	if got != want {
 		t.Errorf("serialize != firmware builder format:\n want = %q\n got  = %q", want, got)
 	}
 }
 
-func TestSerializeVTSRuleListMatchesFirmwareBuilder(t *testing.T) {
+func TestEncodeVTSRuleListForWriteMatchesFirmwareBuilder(t *testing.T) {
 	t.Parallel()
 
-	got := client.SerializeVTSRuleList([]client.PortForwardEntry{
+	got := client.EncodeVTSRuleListForWrite([]client.PortForwardEntry{
 		{Name: "HTTP", ExternalPort: "80", InternalIP: "192.168.1.100", InternalPort: "80", Protocol: "tcp"},                       // empty src → trailing delimiter
 		{Name: "SSH", ExternalPort: "2222", InternalIP: "192.168.1.50", InternalPort: "22", Protocol: "tcp", SourceIP: "10.0.0.1"}, // src set
 	})
 
-	want := lt + "HTTP" + gt + "80" + gt + "192.168.1.100" + gt + "80" + gt + "tcp" + gt +
-		lt + "SSH" + gt + "2222" + gt + "192.168.1.50" + gt + "22" + gt + "tcp" + gt + "10.0.0.1"
+	want := "<HTTP>80>192.168.1.100>80>tcp>" +
+		"<SSH>2222>192.168.1.50>22>tcp>10.0.0.1"
 
 	if got != want {
 		t.Errorf("serialize != firmware builder format:\n want = %q\n got  = %q", want, got)

--- a/packages/terraform-provider-asuswrt/internal/client/packed_test.go
+++ b/packages/terraform-provider-asuswrt/internal/client/packed_test.go
@@ -417,6 +417,36 @@ func TestEncodeVTSRuleListForWriteMatchesFirmwareBuilder(t *testing.T) {
 	}
 }
 
+func TestEncodeDHCPStaticListForWritePreservesReadSideAmpersands(t *testing.T) {
+	t.Parallel()
+
+	entries, err := client.ParseDHCPStaticList("&#60AA:BB:CC:DD:EE:FF&#62192.168.1.100&#62&#62living&#38room")
+	if err != nil {
+		t.Fatalf("parse read-side list: %v", err)
+	}
+
+	got := client.EncodeDHCPStaticListForWrite(entries)
+	want := "<AA:BB:CC:DD:EE:FF>192.168.1.100>>living&room"
+	if got != want {
+		t.Errorf("encoded list = %q, want %q", got, want)
+	}
+}
+
+func TestEncodeVTSRuleListForWritePreservesReadSideAmpersands(t *testing.T) {
+	t.Parallel()
+
+	entries, err := client.ParseVTSRuleList("&#60web&#6280&#62192.168.1.100&#6280&#62tcp&#62allow&#38guest")
+	if err != nil {
+		t.Fatalf("parse read-side list: %v", err)
+	}
+
+	got := client.EncodeVTSRuleListForWrite(entries)
+	want := "<web>80>192.168.1.100>80>tcp>allow&guest"
+	if got != want {
+		t.Errorf("encoded list = %q, want %q", got, want)
+	}
+}
+
 // TestPackedListsPreserveTrailingFields covers firmware that returns more
 // fields than this provider models. Every mutation rewrites the whole list, so
 // an unmodeled trailing field must survive parse→serialize or an unrelated

--- a/packages/terraform-provider-asuswrt/internal/provider/dhcp_static_lease_resource.go
+++ b/packages/terraform-provider-asuswrt/internal/provider/dhcp_static_lease_resource.go
@@ -330,7 +330,7 @@ func (r *dhcpStaticLeaseResource) readLeases(ctx context.Context) ([]client.DHCP
 
 func (r *dhcpStaticLeaseResource) writeLeases(ctx context.Context, entries []client.DHCPStaticEntry) error {
 	values := map[string]string{
-		"dhcp_staticlist": client.SerializeDHCPStaticList(entries),
+		"dhcp_staticlist": client.EncodeDHCPStaticListForWrite(entries),
 	}
 
 	if err := r.client.NvramSet(ctx, values, client.ServiceDNSMasq); err != nil {

--- a/packages/terraform-provider-asuswrt/internal/provider/helpers_test.go
+++ b/packages/terraform-provider-asuswrt/internal/provider/helpers_test.go
@@ -712,8 +712,9 @@ func TestApplyPlanToEntryLeavesAbsentTrailingFieldAbsent(t *testing.T) {
 }
 
 // TestPackedFieldValidator covers the boundary rejection that keeps packed
-// NVRAM lists parseable. A value carrying a delimiter token cannot be
-// represented in the router's flat, unescaped list format.
+// NVRAM lists parseable. A value carrying either an appGet.cgi delimiter token
+// or a literal apply.cgi delimiter cannot be represented in the router's flat,
+// unescaped list format.
 func TestPackedFieldValidator(t *testing.T) {
 	t.Parallel()
 
@@ -723,7 +724,8 @@ func TestPackedFieldValidator(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "ordinary value", value: types.StringValue("Plex"), wantErr: false},
-		{name: "value with a real angle bracket", value: types.StringValue("a>b"), wantErr: false},
+		{name: "literal field delimiter", value: types.StringValue("a>b"), wantErr: true},
+		{name: "literal entry delimiter", value: types.StringValue("a<b"), wantErr: true},
 		{name: "null", value: types.StringNull(), wantErr: false},
 		{name: "unknown", value: types.StringUnknown(), wantErr: false},
 		{name: "field delimiter token", value: types.StringValue("foo&#62bar"), wantErr: true},

--- a/packages/terraform-provider-asuswrt/internal/provider/mock_server_test.go
+++ b/packages/terraform-provider-asuswrt/internal/provider/mock_server_test.go
@@ -77,13 +77,31 @@ func (m *mockRouter) handler(t *testing.T) http.Handler {
 			if k == "action_mode" || k == "rc_service" {
 				continue
 			}
-			m.nvram[k] = vals[0]
+
+			value := vals[0]
+			if k == "dhcp_staticlist" || k == "vts_rulelist" {
+				value = encodePackedListForRead(value)
+			}
+
+			m.nvram[k] = value
 		}
 		m.mu.Unlock()
 		writeTestJSON(t, w, map[string]string{"modify": "1"})
 	})
 
 	return mux
+}
+
+// appGet.cgi HTML-encodes the literal delimiters accepted by apply.cgi. It
+// also escapes a submitted '&', which is the behavior that turns an incorrect
+// write-side "&#60" into the unreadable "&#38#60" and makes this mock an
+// independent oracle for the provider boundary.
+func encodePackedListForRead(value string) string {
+	return strings.NewReplacer(
+		"&", "&#38",
+		"<", "&#60",
+		">", "&#62",
+	).Replace(value)
 }
 
 func parseLimitedTestForm(t *testing.T, w http.ResponseWriter, r *http.Request) bool {

--- a/packages/terraform-provider-asuswrt/internal/provider/packed_field_validator.go
+++ b/packages/terraform-provider-asuswrt/internal/provider/packed_field_validator.go
@@ -10,15 +10,16 @@ import (
 	"github.com/shepherdjerred/monorepo/packages/terraform-provider-asuswrt/internal/client"
 )
 
-// packedFieldValidator rejects values containing the tokens Asuswrt uses to
-// delimit packed NVRAM lists.
+// packedFieldValidator rejects values containing either representation Asuswrt
+// uses to delimit packed NVRAM lists.
 //
 // Those lists are flat strings with no escape mechanism: the firmware's own
-// parsers split on the literal "&#60" and "&#62" tokens, so a value carrying
-// one is simply not representable. Serializing it anyway would shift every
-// following field, or fabricate an entry, on the next read — and because a
-// mutation rewrites the whole list, that corrupted shape gets written back to
-// the router and can destroy unrelated rules.
+// appGet.cgi returns "&#60"/"&#62", while apply.cgi accepts literal '<'/'>' as
+// built by the firmware UI. A value carrying any of them is not representable.
+// Serializing it anyway would shift every following field, or fabricate an
+// entry, on the next read — and because a mutation rewrites the whole list,
+// that corrupted shape gets written back to the router and can destroy
+// unrelated rules.
 //
 // Escaping is not an option: any scheme we invented would be unknown to the
 // firmware, which reads these same keys. Rejecting at plan time is the only

--- a/packages/terraform-provider-asuswrt/internal/provider/port_forward_resource.go
+++ b/packages/terraform-provider-asuswrt/internal/provider/port_forward_resource.go
@@ -275,7 +275,7 @@ func (r *portForwardResource) writeRules(ctx context.Context, entries []client.P
 	}
 
 	values := map[string]string{
-		"vts_rulelist": client.SerializeVTSRuleList(entries),
+		"vts_rulelist": client.EncodeVTSRuleListForWrite(entries),
 		"vts_enable_x": vtsEnable,
 	}
 


### PR DESCRIPTION
## Why

The RT-AX88U AP uses DHCP and moved from 192.168.1.213 to 192.168.1.214 because the main router had no reservation. The controlled reservation apply also exposed an API boundary mismatch: appGet.cgi returns packed-list delimiters as HTML entities, while apply.cgi expects literal angle brackets. Reusing the read representation on write double-escaped every delimiter and made the DHCP list unreadable.

## What

- Reserve 24:4B:FE:D0:9B:A0 at 192.168.1.214 and point the AX88U provider and operator docs at that stable address.
- Convert DHCP and port-forward packed lists to the literal firmware-UI representation only at the apply.cgi boundary.
- Reject both read-side and write-side delimiters in modeled fields.
- Make the acceptance mock reproduce the router encoding asymmetry so the previous write path fails mechanically.
- Preserve the new reservation in the bootstrap import list.

## Verification

- `go test ./...`
- `go vet ./...`
- `TF_ACC=1 go test ./internal/provider/... -count=1`
- `golangci-lint run ./...`
- `tofu fmt -check -diff`
- `tofu validate`
- `shellcheck import.sh`
- `bunx prettier --check packages/homelab/src/tofu/asuswrt/README.md`
- `bunx lefthook run pre-commit`
- Live targeted saved plan: 1 add, 0 change, 0 destroy; applied successfully.
- Live full OpenTofu plan after the corrected provider install: No changes across 16 managed resources on all three devices.
- AP remains reachable at 192.168.1.214 with its expected MAC.

## Live recovery note

The first controlled apply exposed the delimiter bug by double-escaping the DHCP list. A bounded one-time repair converted only those delimiters back to the firmware format, preserved all seven entries including the new reservation, and restarted dnsmasq once. Raw-router verification and the subsequent full OpenTofu refresh both passed. No wireless configuration was written.

## Stack

This PR targets `feature/asuswrt-tofu-tracking` and should be merged into that branch before #1389. The reservation is already live in shared OpenTofu state; this change keeps source and state aligned.
