### PR TITLE
chore(homelab): remove retired Clauderon bucket

### DIFF
--- a/packages/homelab/src/tofu/seaweedfs/buckets.tf
+++ b/packages/homelab/src/tofu/seaweedfs/buckets.tf
@@ -3,13 +3,6 @@ resource "aws_s3_bucket" "better_skill_capped" {
   bucket = "better-skill-capped"
 }
 
-resource "aws_s3_bucket" "clauderon" {
-  # Keep this resource through the site-retirement apply so the provider can
-  # purge the archived site's non-empty bucket before the follow-up removes it.
-  bucket        = "clauderon"
-  force_destroy = true
-}
-
 resource "aws_s3_bucket" "resume" {
   bucket = "resume"
 }


### PR DESCRIPTION
## Why

The retired Clauderon site's archived SeaweedFS bucket is non-empty and should be removed after the redirect and force-destroy setting from the parent change are live.

## What

- Remove the aws_s3_bucket.clauderon declaration.
- Let OpenTofu purge the archived bucket contents and delete the bucket during this dependent apply.

## Verification

- bunx lefthook run pre-commit
- The parent change validates the SeaweedFS configuration and reviews the read-only plan.

## Rollout

This change depends on PR #2222. Apply PR #2222 first; then apply this change to remove the 119 archived objects and the bucket.