### PR TITLE
Restore alert dashboard Postal email delivery

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.test.ts
@@ -60,6 +60,8 @@ const DeploymentSchema = z.object({
 
 const DATA_PATH = "/data";
 const DATABASE_URL = "file:/data/alert-dashboard.db";
+const POSTAL_HOST =
+  "http://postal-postal-web-service.postal.svc.cluster.local:5000";
 
 function synthesizeDeployment(): z.infer<typeof DeploymentSchema> {
   const app = new App();
@@ -122,5 +124,17 @@ describe("Alert Dashboard deployment", () => {
         seccompProfile: { type: "RuntimeDefault" },
       });
     }
+  });
+
+  test("uses the rendered Postal web service for email delivery", () => {
+    const podSpec = synthesizeDeployment().spec.template.spec;
+    const dashboardContainer = podSpec.containers.find(
+      (container) => container.name === "alert-dashboard",
+    );
+
+    expect(
+      dashboardContainer?.env?.find((entry) => entry.name === "POSTAL_HOST")
+        ?.value,
+    ).toBe(POSTAL_HOST);
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/alert-dashboard/index.ts
@@ -136,7 +136,7 @@ export function createAlertDashboardDeployment(chart: Chart) {
           "http://prometheus-grafana.prometheus.svc.cluster.local:80",
         ),
         POSTAL_HOST: EnvValue.fromValue(
-          "http://postal-web-service.postal.svc.cluster.local:5000",
+          "http://postal-postal-web-service.postal.svc.cluster.local:5000",
         ),
         EMAIL_ENABLED: EnvValue.fromSecretValue({
           secret,


### PR DESCRIPTION
## Why
The alert dashboard had email delivery enabled, but its Postal hostname did not match the rendered Kubernetes Service name. All four queued messages were failing with in-cluster connection errors.

## What
- Point `POSTAL_HOST` at `postal-postal-web-service.postal.svc.cluster.local:5000`.
- Add a rendered-manifest regression test for the exact hostname.

## Verification
- `bun run build`
- `bun test src/resources/alert-dashboard/index.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx lefthook run pre-commit`

## Rollout notes
After merge, verify ArgoCD sync/health, the running pod hostname, `trpc/system.status` Postal health, outbox drain, Postal request logs, and actual inbox delivery. No direct cluster mutation or synthetic email was used.