### PR TITLE
Close the CI and test-tooling gaps found while landing #2104

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,46 @@ Local and CI verification deliberately have different scopes:
 Run `bun run verify` locally only when explicitly reproducing CI or modifying
 the verification machinery itself. There is no `pre-push` hook.
 
+### CI credentials — `check-ci-env`
+
+`scripts/check-ci-env.ts` (the `//#check-ci-env` turbo task, in `bun run
+verify`) asserts every env var a Buildkite step's scripts `requireEnv` is
+actually provided to that step. It reads the committed vault snapshot, so it
+needs no 1Password access.
+
+The gap it closes: steps take `buildkite-ci-secrets` through `envFrom`, which
+`check-1password-items` cannot see — a script requiring a field the item does
+not carry passed every gate and only failed on `main` after merge. When it
+fires, either add the field to the item **and refresh the vault snapshot**, set
+it in the step's `env`, or assign it in the step's command. Requirements the
+analysis cannot read statically (a non-literal `requireEnv`, or one gated
+behind a flag the step passes) go in the two exception tables at the top of the
+script, each with its reason.
+
+### Blocked review gate — `review-findings`
+
+```bash
+GH_TOKEN=$(gh auth token) bun scripts/review-findings.ts list <pr>
+```
+
+Lists every finding blocking the required Qodo gate with its title, severity
+and location. Run it **before** pushing a fix: a fix pushed without resolving
+its thread only surfaces at the end of a ~7-minute gate cycle.
+
+Qodo re-lists a finding it no longer stands behind rather than striking it, so
+a PR whose findings are all fixed or all wrong can stay blocked indefinitely.
+For that case only, after verifying a finding is fixed at this head or
+incorrect:
+
+```bash
+… review-findings.ts dismiss <pr> --finding "<title>" --reason "<why>"
+… review-findings.ts resolve-thread <pr> --thread <id> --reason "<why>"
+```
+
+Both require a reason and record it in a single audit comment on the PR, so a
+dismissal is a reviewable decision rather than an invisible edit to a bot's
+comment. Neither is automatic and neither runs in CI.
+
 ## PR Fleet Controller
 
 `bun run pr:fleet --model <catalog-model-id> [--author <login>]` starts the

--- a/bun.lock
+++ b/bun.lock
@@ -1789,6 +1789,7 @@
         "fast-xml-validator": "1.4.0",
         "istanbul-lib-instrument": "6.0.3",
         "prettier": "3.8.3",
+        "yaml": "^2.8.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -802,6 +802,7 @@
       "dependencies": {
         "@ai-sdk/otel": "^1.0.58",
         "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.221.0",
         "@opentelemetry/core": "^2.7.1",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "check-suppressions": "bun scripts/check-suppressions.ts",
     "check-ai-architecture": "bun scripts/check-ai-architecture.ts",
     "check-patched-deps": "bun scripts/check-patched-deps.ts",
+    "check-ci-env": "bun scripts/check-ci-env.ts",
     "check-script-migrations": "bun scripts/check-script-migrations.ts",
     "script-coverage": "bun scripts/check-script-coverage.ts"
   },

--- a/packages/birmel/src/observability/logs.integration.test.ts
+++ b/packages/birmel/src/observability/logs.integration.test.ts
@@ -19,8 +19,7 @@ Bun.env["SENTRY_ENVIRONMENT"] = "development";
 Bun.env["SENTRY_TRACES_SAMPLE_RATE"] = "0";
 
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { trace, context, propagation } from "@opentelemetry/api";
-import { logs as logsAPI } from "@opentelemetry/api-logs";
+import { resetOtelGlobals } from "@shepherdjerred/llm-observability/otel-globals";
 import { resetConfig } from "@shepherdjerred/birmel/config/index.ts";
 import { initializeObservability, shutdownObservability } from "./index.ts";
 import { withSpan } from "./tracing.ts";
@@ -77,10 +76,7 @@ describe("OTLP logs integration", () => {
     ]);
     // Reset OTel global API state so a sibling test file (the trace
     // integration test) can re-register its own providers cleanly.
-    trace.disable();
-    context.disable();
-    propagation.disable();
-    logsAPI.disable();
+    resetOtelGlobals();
   });
 
   test("logger.info inside withSpan POSTs an OTLP log with traceId attached", async () => {

--- a/packages/birmel/src/observability/tracing.integration.test.ts
+++ b/packages/birmel/src/observability/tracing.integration.test.ts
@@ -21,8 +21,7 @@ Bun.env["SENTRY_ENVIRONMENT"] = "development";
 Bun.env["SENTRY_TRACES_SAMPLE_RATE"] = "0";
 
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { trace, context, propagation } from "@opentelemetry/api";
-import { logs as logsAPI } from "@opentelemetry/api-logs";
+import { resetOtelGlobals } from "@shepherdjerred/llm-observability/otel-globals";
 import { resetConfig } from "@shepherdjerred/birmel/config/index.ts";
 import { initializeObservability, shutdownObservability } from "./index.ts";
 import { withSpan } from "./tracing.ts";
@@ -67,10 +66,7 @@ describe("OTLP tracing integration", () => {
     // Reset OTel global API state so sibling test files can re-register
     // cleanly. Without this, `setGlobalXProvider` calls in later files
     // silently no-op against our shut-down providers.
-    trace.disable();
-    context.disable();
-    propagation.disable();
-    logsAPI.disable();
+    resetOtelGlobals();
   });
 
   test("initializeObservability + withSpan POSTs to /v1/traces", async () => {

--- a/packages/code-review/src/gate.test.ts
+++ b/packages/code-review/src/gate.test.ts
@@ -160,6 +160,27 @@ describe("evaluateGate", () => {
     expect(d.message).toContain("P2");
   });
 
+  test("names the finding when the thread carries a title", () => {
+    // Comment-parsed findings carry a title; listing only the path forces the
+    // operator to open GitHub to learn what is blocking.
+    const d = evaluateGate({
+      ...base,
+      reviewState: "reviewed",
+      threads: [thread({ title: "S3 fetch lacks timeout" })],
+    });
+    expect(d.message).toContain("S3 fetch lacks timeout");
+    expect(d.message).toContain("src/x.ts:10");
+  });
+
+  test("omits the title separator for a thread without one", () => {
+    const d = evaluateGate({
+      ...base,
+      reviewState: "reviewed",
+      threads: [thread({})],
+    });
+    expect(d.message).toContain("P2 src/x.ts:10");
+  });
+
   test("passes on a skip with the reason in the message", () => {
     const d = evaluateGate({
       ...base,

--- a/packages/code-review/src/gate.ts
+++ b/packages/code-review/src/gate.ts
@@ -49,6 +49,14 @@ export function isBlocking(
   );
 }
 
+/**
+ * One blocking thread as a reader needs it: what the finding is, then where.
+ *
+ * The title matters most and is why this is not just a location. Findings
+ * parsed from a provider's issue comment carry one (threads opened on a diff
+ * do not), so without it a failing gate lists file paths and the operator has
+ * to open GitHub to learn what any of them are actually complaining about.
+ */
 function describeThread(thread: ReviewThread): string {
   const location =
     thread.path === null
@@ -56,8 +64,9 @@ function describeThread(thread: ReviewThread): string {
       : thread.line === null
         ? thread.path
         : `${thread.path}:${String(thread.line)}`;
+  const title = thread.title === null ? "" : `${thread.title} — `;
   const url = thread.url === null ? "" : ` — ${thread.url}`;
-  return `${location}${url}`;
+  return `${title}${location}${url}`;
 }
 
 export function evaluateGate(input: {

--- a/packages/code-review/src/index.ts
+++ b/packages/code-review/src/index.ts
@@ -17,4 +17,8 @@ export {
 } from "./providers/registry.ts";
 export { greptileProvider } from "./providers/greptile.ts";
 export { codexProvider } from "./providers/codex.ts";
-export { qodoProvider } from "./providers/qodo.ts";
+export {
+  markQodoFindingResolved,
+  qodoProvider,
+  QODO_RESOLVED_CHIP,
+} from "./providers/qodo.ts";

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { isProviderAuthor } from "../identity.ts";
 import type { ReviewThread } from "../types.ts";
-import { qodoProvider, parseQodoIssueComment } from "./qodo.ts";
+import {
+  markQodoFindingResolved,
+  qodoProvider,
+  parseQodoIssueComment,
+} from "./qodo.ts";
 
 const comment = {
   updatedAt: "2026-08-09T12:00:00Z",
@@ -342,6 +346,47 @@ function soleFinding(body: string): ReviewThread {
   if (finding === undefined) throw new Error("expected one finding");
   return finding;
 }
+
+describe("markQodoFindingResolved", () => {
+  test("resolves only the named finding", () => {
+    const edited = markQodoFindingResolved(comment.body, "Consent cache");
+    if (edited === null) throw new Error("expected an edit");
+    const byTitle = new Map(
+      parseQodoIssueComment({ ...comment, body: edited }).map((finding) => [
+        finding.title,
+        finding.isResolved,
+      ]),
+    );
+    expect(byTitle.get("Consent cache")).toBe(true);
+    expect(byTitle.get("Stale wording")).toBe(false);
+  });
+
+  test("keeps the finding's identity so re-appended copies still collapse", () => {
+    // The chip form is the whole point: identityOf strips `<code>☑ …</code>`,
+    // so a dismissal must not fork the finding away from the unstruck copies
+    // Qodo re-appends — that would leave the older copy blocking forever.
+    const body = reviewWithQuotedContext(
+      ">## Issue Context",
+      ">## Issue Context",
+    );
+    const edited = markQodoFindingResolved(body, "Stale artifact");
+    if (edited === null) throw new Error("expected an edit");
+    const findings = parseQodoIssueComment({ ...comment, body: edited });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.isResolved).toBe(true);
+  });
+
+  test("is idempotent on an already-resolved finding", () => {
+    const once = markQodoFindingResolved(comment.body, "Consent cache");
+    if (once === null) throw new Error("expected an edit");
+    const twice = markQodoFindingResolved(once, "Consent cache");
+    expect(twice).toBe(once);
+  });
+
+  test("returns null rather than silently no-opping an unknown title", () => {
+    expect(markQodoFindingResolved(comment.body, "Not a finding")).toBeNull();
+  });
+});
 
 describe("qodo re-review copies", () => {
   test("collapses the copies Qodo re-appends on each re-review", () => {

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -383,6 +383,34 @@ describe("markQodoFindingResolved", () => {
     expect(twice).toBe(once);
   });
 
+  test("marks every re-appended copy of one finding, not just the first", () => {
+    // Qodo re-appends its whole review, so a finding routinely appears twice.
+    // The gate dedupes by identity, so leaving the other copy unmarked leaves
+    // the finding blocking — the dismissal would look applied and do nothing.
+    const body = reviewWithQuotedContext(
+      ">## Issue Context",
+      ">## Issue Context",
+    );
+    const edited = markQodoFindingResolved(body, "Stale artifact");
+    if (edited === null) throw new Error("expected an edit");
+    expect([...edited.matchAll(/☑/gu)]).toHaveLength(2);
+    const findings = parseQodoIssueComment({ ...comment, body: edited });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.isResolved).toBe(true);
+  });
+
+  test("refuses when one title covers two genuinely different findings", () => {
+    // Same headline, different bodies: picking one would resolve something the
+    // operator never verified and leave the other unreachable.
+    const twoDistinct = comment.body.replace(
+      "<summary>  2. Stale wording <code>📝 Documentation</code></summary>",
+      "<summary>  2. Consent cache <code>📝 Documentation</code></summary>",
+    );
+    expect(() => markQodoFindingResolved(twoDistinct, "Consent cache")).toThrow(
+      "different findings",
+    );
+  });
+
   test("returns null rather than silently no-opping an unknown title", () => {
     expect(markQodoFindingResolved(comment.body, "Not a finding")).toBeNull();
   });

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -165,6 +165,24 @@ function findingTitle(summary: string): string {
     .trim();
 }
 
+/**
+ * The human-readable description Qodo renders for a finding — what a reader
+ * actually compares when deciding whether two entries are the same problem.
+ */
+function findingDescription(findingBody: string): string {
+  const described = /<pre>([\s\S]*?)<\/pre>/iu.exec(findingBody);
+  return (
+    (described?.[1] ?? findingBody)
+      .replaceAll(/<[^>]*>/gu, "")
+      // Evidence permalinks embed the commit Qodo read, so two renderings of
+      // one finding differ by SHA alone — the same normalisation identityOf
+      // applies, and required here for findings rendered without a <pre>.
+      .replaceAll(/\b[0-9a-f]{40}\b/giu, "<commit>")
+      .replaceAll(BLOCKQUOTE_MARKER, "")
+      .replaceAll(/\s+/gu, "")
+  );
+}
+
 /** Marks a finding resolved without changing what finding it is. */
 export const QODO_RESOLVED_CHIP = "<code>☑ resolved</code>";
 
@@ -186,40 +204,67 @@ export function markQodoFindingResolved(
   body: string,
   title: string,
 ): string | null {
-  const matches = [
+  const summaries = [
     ...body.matchAll(/<summary>\s*\d+\.[\s\S]*?<\/summary>/giu),
-  ].filter((match) =>
-    (() => {
-      const summary = match[0].slice("<summary>".length, -"</summary>".length);
-      return findingTitle(summary) === title;
-    })(),
-  );
-  // Two findings can share a headline. Editing the first would resolve one the
-  // operator may not have verified and leave the other unreachable — worse, if
-  // the first is already resolved this would report success having done
-  // nothing. Refuse instead of guessing which one was meant.
-  const unresolved = matches.filter(
-    (match) => !match[0].includes("☑") && !/<s>[\s\S]*?<\/s>/iu.test(match[0]),
-  );
-  if (matches.length > 1 && unresolved.length !== 1) {
+  ];
+  const candidates = summaries
+    .map((match, index) => {
+      const block = match[0];
+      const summary = block.slice("<summary>".length, -"</summary>".length);
+      const bodyStart = match.index + block.length;
+      const nextSummary = summaries[index + 1]?.index ?? body.length;
+      const ruleIndex = body.indexOf("<hr/>", bodyStart);
+      const findingBody = body.slice(
+        bodyStart,
+        ruleIndex === -1 || ruleIndex > nextSummary ? nextSummary : ruleIndex,
+      );
+      return {
+        start: match.index,
+        block,
+        summary,
+        identity: findingDescription(findingBody),
+      };
+    })
+    .filter((candidate) => findingTitle(candidate.summary) === title);
+  if (candidates.length === 0) return null;
+
+  // Qodo re-appends its whole review, so one finding routinely appears several
+  // times and every copy must be marked — the gate counts an unmarked copy as
+  // still blocking. Copies are recognised by title + description rather than
+  // by `identityOf`: that hashes the whole rendering, and two copies of one
+  // finding have been observed differing only by a markdown heading level in
+  // the agent prompt. Distinct findings that merely share a headline have
+  // different descriptions, and resolving one of those on the operator's
+  // behalf would clear something they never verified — so that still refuses.
+  if (new Set(candidates.map((candidate) => candidate.identity)).size > 1) {
     throw new Error(
-      `"${title}" matches ${String(matches.length)} findings in the review comment; ` +
-        `resolve them from the PR instead so the right one is chosen deliberately.`,
+      `"${title}" matches ${String(candidates.length)} different findings in the review comment; ` +
+        `resolve them from the PR so the right one is chosen deliberately.`,
     );
   }
-  const match = unresolved[0] ?? matches[0];
-  if (match === undefined) return null;
-  const block = match[0];
-  // Already resolved: report success rather than writing a second chip.
-  if (block.includes("☑")) return body;
-  const chipIndex = block.indexOf("<code>");
-  const insertAt =
-    chipIndex === -1 ? block.length - "</summary>".length : chipIndex;
-  const edited =
-    block.slice(0, insertAt) + `${QODO_RESOLVED_CHIP} ` + block.slice(insertAt);
-  return (
-    body.slice(0, match.index) + edited + body.slice(match.index + block.length)
-  );
+  if (candidates.every((candidate) => candidate.block.includes("☑"))) {
+    return body;
+  }
+
+  // Rewrite back-to-front so each splice leaves earlier offsets valid.
+  let edited = body;
+  for (const candidate of [...candidates].reverse()) {
+    if (candidate.block.includes("☑")) continue;
+    const chipIndex = candidate.block.indexOf("<code>");
+    const insertAt =
+      chipIndex === -1
+        ? candidate.block.length - "</summary>".length
+        : chipIndex;
+    const replacement =
+      candidate.block.slice(0, insertAt) +
+      `${QODO_RESOLVED_CHIP} ` +
+      candidate.block.slice(insertAt);
+    edited =
+      edited.slice(0, candidate.start) +
+      replacement +
+      edited.slice(candidate.start + candidate.block.length);
+  }
+  return edited;
 }
 
 function parseSeveritySection(

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -165,6 +165,51 @@ function findingTitle(summary: string): string {
     .trim();
 }
 
+/** Marks a finding resolved without changing what finding it is. */
+export const QODO_RESOLVED_CHIP = "<code>☑ resolved</code>";
+
+/**
+ * Mark the finding titled `title` resolved, in place, in Qodo's review comment.
+ *
+ * Qodo does not strike a finding it has re-read and no longer reports — it
+ * re-lists it verbatim — so an operator who has verified a finding is fixed or
+ * wrong has no way to clear the gate except by editing this comment. The chip
+ * form is load-bearing: `identityOf` strips `<code>☑ …</code>`, so writing the
+ * marker as a chip resolves the finding WITHOUT forking its identity from the
+ * copies Qodo re-appends on later reviews. A bare `☑` in the title would fork
+ * it, leaving every earlier copy unresolved and still blocking.
+ *
+ * Returns the edited body, or null when no finding matches — callers must not
+ * silently no-op an operator's dismissal.
+ */
+export function markQodoFindingResolved(
+  body: string,
+  title: string,
+): string | null {
+  for (const match of body.matchAll(
+    /<summary>\s*\d+\.[\s\S]*?<\/summary>/giu,
+  )) {
+    const block = match[0];
+    const summary = block.slice("<summary>".length, -"</summary>".length);
+    if (findingTitle(summary) !== title) continue;
+    // Already resolved: report success rather than writing a second chip.
+    if (summary.includes("☑")) return body;
+    const chipIndex = block.indexOf("<code>");
+    const insertAt =
+      chipIndex === -1 ? block.length - "</summary>".length : chipIndex;
+    const edited =
+      block.slice(0, insertAt) +
+      `${QODO_RESOLVED_CHIP} ` +
+      block.slice(insertAt);
+    return (
+      body.slice(0, match.index) +
+      edited +
+      body.slice(match.index + block.length)
+    );
+  }
+  return null;
+}
+
 function parseSeveritySection(
   section: string,
   priority: 1 | 2 | 3,

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -186,28 +186,40 @@ export function markQodoFindingResolved(
   body: string,
   title: string,
 ): string | null {
-  for (const match of body.matchAll(
-    /<summary>\s*\d+\.[\s\S]*?<\/summary>/giu,
-  )) {
-    const block = match[0];
-    const summary = block.slice("<summary>".length, -"</summary>".length);
-    if (findingTitle(summary) !== title) continue;
-    // Already resolved: report success rather than writing a second chip.
-    if (summary.includes("☑")) return body;
-    const chipIndex = block.indexOf("<code>");
-    const insertAt =
-      chipIndex === -1 ? block.length - "</summary>".length : chipIndex;
-    const edited =
-      block.slice(0, insertAt) +
-      `${QODO_RESOLVED_CHIP} ` +
-      block.slice(insertAt);
-    return (
-      body.slice(0, match.index) +
-      edited +
-      body.slice(match.index + block.length)
+  const matches = [
+    ...body.matchAll(/<summary>\s*\d+\.[\s\S]*?<\/summary>/giu),
+  ].filter((match) =>
+    (() => {
+      const summary = match[0].slice("<summary>".length, -"</summary>".length);
+      return findingTitle(summary) === title;
+    })(),
+  );
+  // Two findings can share a headline. Editing the first would resolve one the
+  // operator may not have verified and leave the other unreachable — worse, if
+  // the first is already resolved this would report success having done
+  // nothing. Refuse instead of guessing which one was meant.
+  const unresolved = matches.filter(
+    (match) => !match[0].includes("☑") && !/<s>[\s\S]*?<\/s>/iu.test(match[0]),
+  );
+  if (matches.length > 1 && unresolved.length !== 1) {
+    throw new Error(
+      `"${title}" matches ${String(matches.length)} findings in the review comment; ` +
+        `resolve them from the PR instead so the right one is chosen deliberately.`,
     );
   }
-  return null;
+  const match = unresolved[0] ?? matches[0];
+  if (match === undefined) return null;
+  const block = match[0];
+  // Already resolved: report success rather than writing a second chip.
+  if (block.includes("☑")) return body;
+  const chipIndex = block.indexOf("<code>");
+  const insertAt =
+    chipIndex === -1 ? block.length - "</summary>".length : chipIndex;
+  const edited =
+    block.slice(0, insertAt) + `${QODO_RESOLVED_CHIP} ` + block.slice(insertAt);
+  return (
+    body.slice(0, match.index) + edited + body.slice(match.index + block.length)
+  );
 }
 
 function parseSeveritySection(

--- a/packages/homelab/src/cdk8s/scripts/check-1password-items.test.ts
+++ b/packages/homelab/src/cdk8s/scripts/check-1password-items.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { snapshotStalenessWarning } from "./check-1password-items.ts";
+
+const NOW = new Date("2026-08-16T00:00:00Z");
+
+describe("snapshotStalenessWarning", () => {
+  test("stays quiet for a recently refreshed snapshot", () => {
+    // The snapshot legitimately ages between vault changes, so a fresh-enough
+    // one must not nag on PRs that touched nothing related.
+    expect(
+      snapshotStalenessWarning("2026-08-11T02:11:02.518Z", NOW),
+    ).toBeNull();
+  });
+
+  test("reports the age once the snapshot is too old to trust", () => {
+    // A clean result against a stale snapshot means "nothing contradicts an
+    // old record", not "the vault agrees" — say so rather than imply coverage.
+    const warning = snapshotStalenessWarning("2026-01-01T00:00:00Z", NOW);
+    expect(warning).toContain("227 days old");
+    expect(warning).toContain("snapshot-1password-vault.ts");
+  });
+
+  test("treats an unparseable timestamp as a refresh prompt", () => {
+    expect(snapshotStalenessWarning("not-a-date", NOW)).toContain(
+      "unparseable generatedAt",
+    );
+  });
+
+  test("honours the boundary exactly", () => {
+    const exactly = new Date(NOW.getTime() - 45 * 24 * 60 * 60 * 1000);
+    expect(snapshotStalenessWarning(exactly.toISOString(), NOW)).toBeNull();
+    const oneDayPast = new Date(NOW.getTime() - 46 * 24 * 60 * 60 * 1000);
+    expect(snapshotStalenessWarning(oneDayPast.toISOString(), NOW)).toContain(
+      "46 days old",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/scripts/check-1password-items.ts
+++ b/packages/homelab/src/cdk8s/scripts/check-1password-items.ts
@@ -31,6 +31,12 @@ import {
 } from "./onepassword-lib.ts";
 
 const ITEM_PATH_RE = /^vaults\/([^/]+)\/items\/(.+)$/;
+/**
+ * How long a snapshot may go unrefreshed before this check says so. Long
+ * enough that a quiet vault does not nag, short enough that a snapshot from
+ * before a credential change is called out.
+ */
+const SNAPSHOT_MAX_AGE_DAYS = 45;
 
 type OpItemRef = { namespace: string; name: string; itemPath: string };
 /** ns -> secretName -> specific data keys read from that secret. */
@@ -311,6 +317,43 @@ async function main(): Promise<void> {
     `check-1password-items: OK — ${String(opItems.length)} item references and ${String(fieldsChecked)} ` +
       `field references verified against the vault snapshot (${String(snapshot.items.length)} items).`,
   );
+  warnIfSnapshotIsStale(snapshot.generatedAt);
 }
 
-await main();
+/**
+ * This check is only as truthful as the snapshot it reads. A field added or
+ * populated in 1Password after the last refresh is invisible here, so a clean
+ * result on a months-old snapshot means "nothing contradicts a stale record",
+ * not "the vault agrees". Warn rather than fail: the snapshot legitimately
+ * ages between vault changes, and failing on the calendar would redden PRs
+ * that touched nothing related.
+ */
+export function snapshotStalenessWarning(
+  generatedAt: string,
+  now: Date,
+  maxAgeDays = SNAPSHOT_MAX_AGE_DAYS,
+): string | null {
+  const generated = Date.parse(generatedAt);
+  if (Number.isNaN(generated)) {
+    return `vault snapshot has an unparseable generatedAt (${generatedAt}); refresh it with snapshot-1password-vault.ts.`;
+  }
+  const ageDays = Math.floor(
+    (now.getTime() - generated) / (24 * 60 * 60 * 1000),
+  );
+  if (ageDays <= maxAgeDays) return null;
+  return (
+    `vault snapshot is ${String(ageDays)} days old (generated ${generatedAt}). ` +
+    `Fields added or populated since then are invisible to this check — refresh it with snapshot-1password-vault.ts.`
+  );
+}
+
+function warnIfSnapshotIsStale(generatedAt: string): void {
+  const warning = snapshotStalenessWarning(generatedAt, new Date());
+  if (warning !== null) console.warn(`check-1password-items: ${warning}`);
+}
+
+// Guarded so the pure helpers above can be imported by tests without the
+// checker synthesizing the whole cdk8s app as a side effect of the import.
+if (import.meta.main) {
+  await main();
+}

--- a/packages/homelab/src/cdk8s/turbo.json
+++ b/packages/homelab/src/cdk8s/turbo.json
@@ -8,6 +8,10 @@
       "inputs": [
         "src/**/*.ts",
         "scripts/check-1password-items.ts",
+        // The checker's hashing and operator-key derivation live here, so a
+        // change to them must invalidate this task like a change to the
+        // checker itself.
+        "scripts/onepassword-lib.ts",
         "onepassword-vault-snapshot.json"
       ]
     },

--- a/packages/llm-observability/package.json
+++ b/packages/llm-observability/package.json
@@ -15,7 +15,8 @@
     "./wrappers/claude-agent": "./src/claude-agent-wrapper.ts",
     "./wrappers/codex": "./src/codex-trace.ts",
     "./codex-jsonl": "./src/codex-jsonl.ts",
-    "./wrappers/text-stream": "./src/text-stream-wrapper.ts"
+    "./wrappers/text-stream": "./src/text-stream-wrapper.ts",
+    "./otel-globals": "./src/otel-globals.ts"
   },
   "scripts": {
     "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit",
@@ -31,6 +32,7 @@
   "dependencies": {
     "@ai-sdk/otel": "^1.0.58",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.221.0",
     "@opentelemetry/core": "^2.7.1",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",

--- a/packages/llm-observability/src/otel-globals.ts
+++ b/packages/llm-observability/src/otel-globals.ts
@@ -1,0 +1,31 @@
+import { context, diag, metrics, propagation, trace } from "@opentelemetry/api";
+import { logs as logsAPI } from "@opentelemetry/api-logs";
+
+/**
+ * Unregister every OpenTelemetry global this repo's initializers install.
+ *
+ * Each `setGlobalXProvider` is one-shot per process: while a provider is still
+ * registered, a later registration silently returns false and the caller keeps
+ * a provider nothing routes through. `bun test` runs every file in one
+ * process, so a suite that registers globals and does not unregister them
+ * leaves the next file emitting into its shut-down providers — spans and logs
+ * vanish, no error is raised, and which file wins depends on file order.
+ *
+ * `disable()` both disables and unregisters, so the API falls back to its noop
+ * implementation. Prefer this over disabling a manager instance directly: an
+ * instance that is disabled but still registered is worse than none, because
+ * `context.with` then delegates into a dead AsyncLocalStorage.
+ *
+ * Call from `afterAll`/`afterEach` in any suite that initializes telemetry.
+ * Resetting an API nothing registered is a no-op, so the full reset is always
+ * safe — which is why this takes no arguments to get wrong. `NodeSDK.start()`
+ * in particular registers a MeterProvider that is easy to forget.
+ */
+export function resetOtelGlobals(): void {
+  trace.disable();
+  context.disable();
+  propagation.disable();
+  metrics.disable();
+  logsAPI.disable();
+  diag.disable();
+}

--- a/packages/llm-observability/test/e2e/helpers.ts
+++ b/packages/llm-observability/test/e2e/helpers.ts
@@ -66,7 +66,12 @@ export function buildE2eHarness(serviceName: string): E2eHarness {
     }),
     spanProcessors: [archive],
   });
-  // Set global so wrappers' getLlmTracer() picks this up.
+  // Set global so wrappers' getLlmTracer() picks this up. `setGlobalTracerProvider`
+  // is one-shot per process: it silently refuses while another provider is still
+  // registered, so a second harness in the same `bun test` run would export its
+  // spans through the previous (already shut-down) provider. Unregister first so
+  // each harness genuinely owns the global for its lifetime.
+  trace.disable();
   trace.setGlobalTracerProvider(provider);
 
   return {
@@ -78,6 +83,9 @@ export function buildE2eHarness(serviceName: string): E2eHarness {
     async shutdown() {
       await archive.shutdown();
       await provider.shutdown();
+      // Leaving a shut-down provider registered routes every later span in the
+      // process into it, where `onEnd` records "cannot write after shutdown".
+      trace.disable();
     },
   };
 }

--- a/packages/pr-fleet-controller/src/telemetry-runtime.ts
+++ b/packages/pr-fleet-controller/src/telemetry-runtime.ts
@@ -33,6 +33,9 @@ export async function createFleetTelemetryRuntime(
     // context.disable() both disables our manager and unregisters it, so the
     // global API falls back to the noop manager instead of delegating to a
     // disabled AsyncLocalStorage (which wedges later context.with callers).
+    // The tracer provider is left alone here: this branch means someone
+    // else's provider holds the global, and unregistering it would be this
+    // failed runtime tearing down a live one.
     context.disable();
     await processor.shutdown();
     throw new Error("OpenTelemetry tracer provider is already registered");
@@ -47,8 +50,14 @@ export async function createFleetTelemetryRuntime(
       try {
         await provider.shutdown();
       } finally {
-        // Unregister rather than merely disable: a disabled ALS manager left
-        // as the global would break every later context.with caller.
+        // Unregister BOTH globals rather than merely disabling them. A
+        // disabled ALS manager left registered breaks every later
+        // context.with caller, and a shut-down tracer provider left
+        // registered is worse: `setGlobalTracerProvider` is one-shot, so the
+        // next runtime in this process cannot register at all, and every span
+        // in the meantime routes into a processor whose target file has
+        // already been cleaned up ("Cannot write a span after shutdown").
+        trace.disable();
         context.disable();
         await recorder.secureRunArtifacts();
       }

--- a/packages/pr-fleet-controller/test/controller-metadata.test.ts
+++ b/packages/pr-fleet-controller/test/controller-metadata.test.ts
@@ -22,6 +22,18 @@ afterEach(async () => {
 async function git(directory: string, args: readonly string[]): Promise<void> {
   const subprocess = Bun.spawn(["git", ...args], {
     cwd: directory,
+    // Isolated from the operator's ~/.gitconfig: commit.gpgsign, core.hooksPath
+    // and an unexpandable excludesfile all change what these commands do.
+    env: {
+      ...Bun.env,
+      // Isolate from the operator's ~/.gitconfig: commit.gpgsign,
+      // core.hooksPath and an unexpandable excludesfile each change what
+      // these commands do, or make them fail outright.
+      HOME: directory,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_TERMINAL_PROMPT: "0",
+    },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/packages/pr-fleet-controller/test/telemetry-runtime.test.ts
+++ b/packages/pr-fleet-controller/test/telemetry-runtime.test.ts
@@ -6,6 +6,7 @@ import { trace } from "@opentelemetry/api";
 import { loadRunBundle } from "@shepherdjerred/pr-fleet-controller/src/run-inspection.ts";
 import { RunRecorder } from "@shepherdjerred/pr-fleet-controller/src/run-recorder.ts";
 import { createFleetTelemetryRuntime } from "@shepherdjerred/pr-fleet-controller/src/telemetry-runtime.ts";
+import { resetOtelGlobals } from "@shepherdjerred/llm-observability/otel-globals";
 
 let stateDirectory: string | undefined;
 
@@ -14,6 +15,51 @@ afterEach(async () => {
     await rm(stateDirectory, { recursive: true, force: true });
     stateDirectory = undefined;
   }
+  // This suite registers process-global OpenTelemetry state. Leaving it
+  // registered leaks into every other file of `bun test src test`, where the
+  // symptom is silent: later spans route into a shut-down processor whose
+  // target directory this hook just deleted.
+  resetOtelGlobals();
+});
+
+async function createRecorder(): Promise<RunRecorder> {
+  stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-otel-"));
+  return await RunRecorder.create({
+    stateDirectory,
+    controllerVersion: "0.1.0",
+    controllerCommit: "a".repeat(40),
+    controllerSourceDirty: false,
+    controllerSourceFingerprint: "b".repeat(64),
+    model: "gpt-5.6-sol",
+    repository: "example/repository",
+    checkout: "/repo",
+    worktreeRoot: "/repo/worktrees",
+    maxWorkers: 1,
+  });
+}
+
+test("a second runtime can register after the first shuts down", async () => {
+  // setGlobalTracerProvider is one-shot while a provider stays registered, so
+  // a shutdown that only disables the context manager makes every later
+  // runtime in the process throw "already registered" — and any span emitted
+  // in between lands in the dead processor.
+  const firstRecorder = await createRecorder();
+  const first = await createFleetTelemetryRuntime(firstRecorder);
+  await first.shutdown();
+
+  const secondRecorder = await createRecorder();
+  const second = await createFleetTelemetryRuntime(secondRecorder);
+  const span = trace.getTracer("pr-fleet-test").startSpan("gen_ai.chat");
+  span.setAttribute("gen_ai.system", "openrouter");
+  span.end();
+  await second.shutdown();
+
+  // The span must be in the SECOND runtime's file: routing into the first,
+  // shut-down processor is the failure this guards, and it is silent.
+  expect(await Bun.file(secondRecorder.paths.spans).text()).toContain(
+    '"name":"gen_ai.chat"',
+  );
+  await rm(firstRecorder.paths.runDirectory, { recursive: true, force: true });
 });
 
 test("writes and digest-verifies private spans.jsonl", async () => {

--- a/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
+++ b/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
@@ -124,9 +124,18 @@ export function initializeTracing(): void {
 
   // AsyncLocalStorage-backed context manager so OTel active span propagates
   // across awaits — required for the LLM wrappers to see the current span.
+  // `setGlobalContextManager` is one-shot and returns false when another
+  // manager already holds the global: ignoring that leaves this manager
+  // enabled but unregistered, so every wrapper silently sees no active span
+  // while looking correctly configured.
   const contextManager = new AsyncLocalStorageContextManager();
   contextManager.enable();
-  context.setGlobalContextManager(contextManager);
+  if (!context.setGlobalContextManager(contextManager)) {
+    contextManager.disable();
+    throw new Error(
+      "OpenTelemetry context manager is already registered; tracing must own it to propagate spans across awaits",
+    );
+  }
 
   const exporter = new LoggingSpanExporter(
     new OTLPTraceExporter({

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -77,15 +77,15 @@
   },
   "devDependencies": {
     "@shepherdjerred/eslint-config": "workspace:*",
+    "@temporalio/testing": "1.21.1",
     "@tsconfig/node-lts": "^24.0.0",
     "@tsconfig/recommended": "^1.0.13",
-    "@temporalio/testing": "1.21.1",
     "@tsconfig/strictest": "^2.0.8",
     "@types/bun": "^1.3.13",
     "@types/semver": "^7.7.1",
+    "@typescript/native": "npm:typescript@7.0.2",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
-    "typescript": "^6.0.3",
-    "@typescript/native": "npm:typescript@7.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/temporal/src/activities/scout-season-refresh-git.test.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   closeSeasonRefreshPr,
   isGeneratedAtOnlyDiff,
@@ -7,6 +17,7 @@ import {
   runCommand,
   type GitCommandRunner,
 } from "./scout-season-refresh-git.ts";
+import { gitProcessEnvironment } from "#lib/pr-review-workdir.ts";
 
 const TIMESTAMP_ONLY_DIFF = [
   "diff --git a/packages/scout-for-lol/packages/frontend/src/data/generated/scout-showcase-assets.json b/packages/scout-for-lol/packages/frontend/src/data/generated/scout-showcase-assets.json",
@@ -71,19 +82,19 @@ describe("isGeneratedAtOnlyDiff", () => {
 const ARTIFACT = "packages/scout-for-lol/packages/data/a.generated.json";
 const REPORT = "packages/scout-for-lol/packages/data/b.generated.json";
 
-function stampOnlyDiff(path: string): string {
+function stampOnlyDiff(artifactPath: string): string {
   return [
-    `--- a/${path}`,
-    `+++ b/${path}`,
+    `--- a/${artifactPath}`,
+    `+++ b/${artifactPath}`,
     '-  "generatedAt": "2026-05-16T20:00:21.251Z",',
     '+  "generatedAt": "2026-08-14T13:05:00.000Z",',
   ].join("\n");
 }
 
-function realDiff(path: string): string {
+function realDiff(artifactPath: string): string {
   return [
-    `--- a/${path}`,
-    `+++ b/${path}`,
+    `--- a/${artifactPath}`,
+    `+++ b/${artifactPath}`,
     '-  "matchCount": 621,',
     '+  "matchCount": 640,',
   ].join("\n");
@@ -94,30 +105,74 @@ function realDiff(path: string): string {
  * drive it through a temp git repo rather than a stub — which also proves the
  * `git checkout --` actually restores the file.
  */
+const repositories: string[] = [];
+let restoreGitEnv: (() => void) | undefined;
+
+beforeAll(() => {
+  // The code under test spawns git through its own runCommand, which inherits
+  // this process's environment — so the isolation has to be applied here, not
+  // just to the setup commands. Without it these tests read the operator's
+  // ~/.gitconfig: an ~/.gitignore git cannot expand aborts `git status`, and
+  // commit.gpgsign or core.hooksPath change what a seed commit even does.
+  // Reuse the isolation production already applies to its own git calls
+  // (gitProcessEnvironment), so the tests exercise the same contract rather
+  // than a second definition that can drift from it.
+  const hermetic = gitProcessEnvironment({});
+  const managed = [
+    "HOME",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_TERMINAL_PROMPT",
+  ];
+  const previous = new Map(managed.map((key) => [key, Bun.env[key]]));
+  for (const key of managed) {
+    const value = hermetic[key];
+    if (value !== undefined) Bun.env[key] = value;
+  }
+  restoreGitEnv = () => {
+    for (const [key, value] of previous) {
+      // Assigning undefined would store the literal string "undefined".
+      if (value === undefined) Reflect.deleteProperty(Bun.env, key);
+      else Bun.env[key] = value;
+    }
+  };
+});
+
+afterAll(() => {
+  restoreGitEnv?.();
+});
+
+// Cleanup belongs here rather than at the end of each test body: a failing
+// assertion aborts the body, so an in-body cleanup leaks the directory on
+// exactly the runs worth re-running.
+afterEach(async () => {
+  await Promise.all(
+    repositories.splice(0).map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
+
 async function withRepo(
   contents: Record<string, string>,
   edits: Record<string, string>,
 ): Promise<string> {
-  const dir = `${Bun.env["TMPDIR"] ?? "/tmp"}/revert-stamp-${crypto.randomUUID()}`;
-  await runCommand(["mkdir", "-p", dir], { cwd: "/tmp" });
+  const dir = await mkdtemp(path.join(tmpdir(), "revert-stamp-"));
+  repositories.push(dir);
   await runCommand(["git", "init", "-q"], { cwd: dir });
   await runCommand(["git", "config", "user.email", "t@example.com"], {
     cwd: dir,
   });
   await runCommand(["git", "config", "user.name", "T"], { cwd: dir });
-  for (const [path, body] of Object.entries(contents)) {
-    await runCommand(
-      ["mkdir", "-p", `${dir}/${path.split("/").slice(0, -1).join("/")}`],
-      { cwd: dir },
-    );
-    await Bun.write(`${dir}/${path}`, body);
+  for (const [filePath, body] of Object.entries(contents)) {
+    await Bun.write(`${dir}/${filePath}`, body);
   }
   await runCommand(["git", "add", "--", ...Object.keys(contents)], {
     cwd: dir,
   });
   await runCommand(["git", "commit", "-qm", "seed"], { cwd: dir });
-  for (const [path, body] of Object.entries(edits)) {
-    await Bun.write(`${dir}/${path}`, body);
+  for (const [filePath, body] of Object.entries(edits)) {
+    await Bun.write(`${dir}/${filePath}`, body);
   }
   return dir;
 }
@@ -152,8 +207,6 @@ describe("revertGeneratedAtOnlyChanges", () => {
     });
     expect(status).not.toContain(ARTIFACT);
     expect(status).toContain(REPORT);
-
-    await runCommand(["rm", "-rf", dir], { cwd: "/tmp" });
   });
 
   test("is a no-op when nothing changed", async () => {
@@ -163,8 +216,6 @@ describe("revertGeneratedAtOnlyChanges", () => {
     const dir = await withRepo(seed, {});
 
     expect(await revertGeneratedAtOnlyChanges(dir, [ARTIFACT])).toEqual([]);
-
-    await runCommand(["rm", "-rf", dir], { cwd: "/tmp" });
   });
 
   test("diffs each path separately so one real change cannot mask another's churn", () => {

--- a/packages/temporal/src/observability/logs.integration.test.ts
+++ b/packages/temporal/src/observability/logs.integration.test.ts
@@ -8,8 +8,7 @@
 // the OTel logs API stops auto-attaching span context — `logPosts` stays
 // empty or the body doesn't contain a traceId, and the test fails.
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { trace, context, propagation, metrics } from "@opentelemetry/api";
-import { logs as logsAPI } from "@opentelemetry/api-logs";
+import { resetOtelGlobals } from "@shepherdjerred/llm-observability/otel-globals";
 import { initializeTracing, shutdownTracing, withSpan } from "./tracing.ts";
 import { log } from "./log.ts";
 
@@ -61,15 +60,7 @@ describe("OTLP logs integration", () => {
     // its own providers cleanly. `setGlobalXProvider` is a one-shot
     // registration; without these `disable()` calls the next file sees
     // our shut-down providers and silently no-ops on emit.
-    trace.disable();
-    context.disable();
-    propagation.disable();
-    metrics.disable();
-    logsAPI.disable();
-    // NodeSDK.start() also registers a global MeterProvider; reset it too or
-    // the next file's initializeTracing() logs "Attempted duplicate
-    // registration of API: metrics".
-    metrics.disable();
+    resetOtelGlobals();
   });
 
   test("log() inside withSpan POSTs an OTLP log with traceId attached", async () => {

--- a/packages/temporal/src/observability/tracing.integration.test.ts
+++ b/packages/temporal/src/observability/tracing.integration.test.ts
@@ -9,8 +9,7 @@
 // original fix is exactly this assertion, codified.
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import * as Sentry from "@sentry/bun";
-import { trace, context, propagation, metrics } from "@opentelemetry/api";
-import { logs as logsAPI } from "@opentelemetry/api-logs";
+import { resetOtelGlobals } from "@shepherdjerred/llm-observability/otel-globals";
 import { initializeTracing, shutdownTracing, withSpan } from "./tracing.ts";
 
 describe("OTLP tracing integration", () => {
@@ -56,15 +55,7 @@ describe("OTLP tracing integration", () => {
   afterAll(async () => {
     await server.stop(true);
     // Reset OTel global API state so a sibling test file can re-register.
-    trace.disable();
-    context.disable();
-    propagation.disable();
-    metrics.disable();
-    logsAPI.disable();
-    // NodeSDK.start() also registers a global MeterProvider; reset it too or
-    // the next file's initializeTracing() logs "Attempted duplicate
-    // registration of API: metrics".
-    metrics.disable();
+    resetOtelGlobals();
   });
 
   test("initializeTracing + withSpan POSTs to /v1/traces", async () => {

--- a/scripts/check-ci-env.test.ts
+++ b/scripts/check-ci-env.test.ts
@@ -12,6 +12,7 @@ import {
   assignedEnvNames,
   commandScopes,
   scriptPathsInCommand,
+  structuralParens,
 } from "./lib/ci-env-command.ts";
 
 /** A secret that carries `names`, of which `blanks` are present but empty. */
@@ -113,6 +114,21 @@ describe("commandScopes", () => {
     expect(outside?.assigned.has("AWS_ACCESS_KEY_ID")).toBe(false);
   });
 
+  test("a command substitution is not treated as a subshell", () => {
+    // `x=$(cmd)` opened a scope, recorded the assignment inside it, then
+    // popped — losing the name from the scope that actually has it, and
+    // splitting the step's invocations across scopes that do not exist.
+    const scopes = commandScopes(
+      [
+        'export DIGEST="$$(bun scripts/release.ts resolve)"',
+        "bun scripts/deploy-site.ts wiki",
+      ].join("\n"),
+    );
+    expect(scopes).toHaveLength(1);
+    expect(scopes[0]?.assigned.has("DIGEST")).toBe(true);
+    expect(scopes[0]?.scripts).toContain("scripts/deploy-site.ts");
+  });
+
   test("an export before a subshell is still visible inside it", () => {
     const scopes = commandScopes(
       ['export SHARED="x"', "(", "  bun scripts/release.ts", ")"].join("\n"),
@@ -121,6 +137,14 @@ describe("commandScopes", () => {
       scope.scripts.includes("scripts/release.ts"),
     );
     expect(inner?.assigned.has("SHARED")).toBe(true);
+  });
+});
+
+describe("structuralParens", () => {
+  test("keeps subshell parens and drops substitution parens", () => {
+    expect(structuralParens("( export A=1 )")).toBe("()");
+    expect(structuralParens('X="$(cmd (nested))"')).toBe("");
+    expect(structuralParens('( X="$$(cmd)" )')).toBe("()");
   });
 });
 

--- a/scripts/check-ci-env.test.ts
+++ b/scripts/check-ci-env.test.ts
@@ -3,6 +3,7 @@ import { parse } from "yaml";
 
 import {
   assignedEnvNames,
+  commandScopes,
   ciSecretItemId,
   collectErrors,
   collectSteps,
@@ -82,6 +83,42 @@ describe("ciSecretItemId", () => {
     expect(() =>
       ciSecretItemId('new OnePasswordItem(chart, "buildkite-ci-secrets", {});'),
     ).toThrow("declares no vaults");
+  });
+});
+
+describe("commandScopes", () => {
+  test("keeps a subshell export out of scripts that run outside it", () => {
+    // pr-dryrun exports the AWS names inside `( … )` around its Tofu loop and
+    // runs other scripts after it. Treating the command as one flat scope
+    // reported those names as provided to every script in the step — a false
+    // negative in the direction this check exists to prevent.
+    const scopes = commandScopes(
+      [
+        "(",
+        '  export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID"',
+        "  bun packages/homelab/scripts/tofu-stack.ts seaweedfs plan",
+        ")",
+        "bun scripts/deploy-site.ts wiki --dry-run",
+      ].join("\n"),
+    );
+    const inside = scopes.find((scope) =>
+      scope.scripts.includes("packages/homelab/scripts/tofu-stack.ts"),
+    );
+    const outside = scopes.find((scope) =>
+      scope.scripts.includes("scripts/deploy-site.ts"),
+    );
+    expect(inside?.assigned.has("AWS_ACCESS_KEY_ID")).toBe(true);
+    expect(outside?.assigned.has("AWS_ACCESS_KEY_ID")).toBe(false);
+  });
+
+  test("an export before a subshell is still visible inside it", () => {
+    const scopes = commandScopes(
+      ['export SHARED="x"', "(", "  bun scripts/release.ts", ")"].join("\n"),
+    );
+    const inner = scopes.find((scope) =>
+      scope.scripts.includes("scripts/release.ts"),
+    );
+    expect(inner?.assigned.has("SHARED")).toBe(true);
   });
 });
 

--- a/scripts/check-ci-env.test.ts
+++ b/scripts/check-ci-env.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+import { parse } from "yaml";
+
+import {
+  assignedEnvNames,
+  ciSecretItemId,
+  collectErrors,
+  collectSteps,
+  scriptPathsInCommand,
+  type RequiredEnv,
+  type SecretFields,
+} from "./check-ci-env.ts";
+
+/** A secret that carries `names`, of which `blanks` are present but empty. */
+function secretWith(
+  names: readonly string[],
+  blanks: readonly string[] = [],
+): SecretFields {
+  return {
+    hasField: (name) => names.includes(name),
+    isBlank: (name) => blanks.includes(name),
+  };
+}
+
+function required(
+  names: Record<string, string>,
+  unresolved: string[] = [],
+): RequiredEnv {
+  return { names: new Map(Object.entries(names)), unresolved };
+}
+
+describe("assignedEnvNames", () => {
+  test("reads both names from one multi-assignment export", () => {
+    // pipeline.yml exports the two AWS names on a single line; missing the
+    // second would report it as unprovided on every site/tofu step.
+    const names = assignedEnvNames(
+      'export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"',
+    );
+    expect([...names].toSorted()).toEqual([
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+    ]);
+  });
+
+  test("records the assigned name, not the secret key it reads from", () => {
+    const names = assignedEnvNames('export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"');
+    expect(names.has("ARGOCD_TOKEN")).toBe(true);
+    expect(names.has("ARGOCD_AUTH_TOKEN")).toBe(false);
+  });
+
+  test("reads a bare assignment prefixing a command", () => {
+    expect(
+      assignedEnvNames("DATABASE_URL=file:/tmp/x.db bun run test").has(
+        "DATABASE_URL",
+      ),
+    ).toBe(true);
+  });
+
+  test("ignores shell expansions of a name", () => {
+    expect(assignedEnvNames('echo "$$GH_TOKEN"').size).toBe(0);
+  });
+});
+
+describe("ciSecretItemId", () => {
+  const declaration = `
+  new OnePasswordItem(chart, "buildkite-agent-token", {
+    spec: { itemPath: "vaults/vault-a/items/item-for-the-agent-token" },
+  });
+  new OnePasswordItem(chart, "buildkite-ci-secrets", {
+    spec: { itemPath: "vaults/vault-a/items/item-for-the-ci-secret" },
+  });`;
+
+  test("reads the id of the CI secret's item, not a neighbouring one", () => {
+    expect(ciSecretItemId(declaration)).toBe("item-for-the-ci-secret");
+  });
+
+  test("throws rather than guessing when the declaration moves", () => {
+    // Silently falling back would validate the wrong item and report success.
+    expect(() => ciSecretItemId("// no OnePasswordItem here")).toThrow(
+      "no OnePasswordItem named",
+    );
+    expect(() =>
+      ciSecretItemId('new OnePasswordItem(chart, "buildkite-ci-secrets", {});'),
+    ).toThrow("declares no vaults");
+  });
+});
+
+describe("scriptPathsInCommand", () => {
+  test("finds root, buildkite, and package script invocations", () => {
+    const paths = scriptPathsInCommand(
+      [
+        "bun --no-install scripts/release.ts --dry-run",
+        "bun --no-install .buildkite/scripts/ci-changed.ts images",
+        "bun --no-install packages/homelab/scripts/argocd.ts release-root apps",
+      ].join("\n"),
+    );
+    expect(paths).toEqual([
+      ".buildkite/scripts/ci-changed.ts",
+      "packages/homelab/scripts/argocd.ts",
+      "scripts/release.ts",
+    ]);
+  });
+
+  test("does not treat a turbo task name as a script path", () => {
+    expect(scriptPathsInCommand("bun --no-install run verify")).toEqual([]);
+  });
+});
+
+describe("collectSteps", () => {
+  const pipeline = parse(
+    `
+env:
+  TURBO_TEAM: monorepo
+steps:
+  - key: with-secret
+    command: bun scripts/release.ts
+    plugins:
+      - kubernetes:
+          podSpecPatch:
+            containers:
+              - name: container-0
+                env:
+                  - name: BUILDKITE_SHELL
+                    value: /bin/bash -e -c
+                envFrom:
+                  - secretRef: { name: buildkite-ci-secrets }
+  - key: no-secret
+    command: bun scripts/publish-npm.ts
+    plugins:
+      - kubernetes:
+          podSpecPatch:
+            containers:
+              - name: container-0
+`,
+    { merge: true },
+  );
+
+  test("records the CI secret, container env, and global env per step", () => {
+    const steps = collectSteps(pipeline, ["TURBO_TEAM"]);
+    const withSecret = steps.find((step) => step.key === "with-secret");
+    expect(withSecret?.usesCiSecret).toBe(true);
+    expect(withSecret?.providedNames.has("BUILDKITE_SHELL")).toBe(true);
+    expect(withSecret?.providedNames.has("TURBO_TEAM")).toBe(true);
+    expect(withSecret?.scripts).toEqual(["scripts/release.ts"]);
+    expect(steps.find((step) => step.key === "no-secret")?.usesCiSecret).toBe(
+      false,
+    );
+  });
+});
+
+describe("collectErrors", () => {
+  const step = {
+    key: "release-please",
+    providedNames: new Set(["EXPORTED_NAME"]),
+    usesCiSecret: true,
+    scripts: ["scripts/release.ts"],
+  };
+
+  test("passes a name the secret carries", () => {
+    const errors = collectErrors({
+      steps: [step],
+      secret: secretWith(["CLAUDE_CODE_OAUTH_TOKEN"]),
+      requiredFor: () =>
+        required({ CLAUDE_CODE_OAUTH_TOKEN: "scripts/release.ts:62" }),
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("passes a name the step's command assigns", () => {
+    const errors = collectErrors({
+      steps: [step],
+      secret: secretWith([]),
+      requiredFor: () => required({ EXPORTED_NAME: "scripts/release.ts:10" }),
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("reports a name nothing provides, naming step, script, and site", () => {
+    const errors = collectErrors({
+      steps: [step],
+      secret: secretWith([]),
+      requiredFor: () =>
+        required({ CODEX_ACCESS_TOKEN: "scripts/release.ts:63" }),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("release-please");
+    expect(errors[0]).toContain("scripts/release.ts");
+    expect(errors[0]).toContain("CODEX_ACCESS_TOKEN");
+    expect(errors[0]).toContain("scripts/release.ts:63");
+  });
+
+  test("reports a field the secret carries but leaves blank", () => {
+    // The operator skips empty fields, so a blank field is as absent at
+    // runtime as a missing one — and far more confusing.
+    const errors = collectErrors({
+      steps: [step],
+      secret: secretWith(["NPM_TOKEN"], ["NPM_TOKEN"]),
+      requiredFor: () => required({ NPM_TOKEN: "scripts/release.ts:20" }),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("BLANK");
+  });
+
+  test("ignores names the Buildkite agent injects", () => {
+    const errors = collectErrors({
+      steps: [step],
+      secret: secretWith([]),
+      requiredFor: () => required({ BUILDKITE_COMMIT: "scripts/release.ts:5" }),
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("reports a requireEnv whose argument is not a literal", () => {
+    const errors = collectErrors({
+      steps: [step],
+      secret: secretWith([]),
+      requiredFor: () => required({}, ["scripts/release.ts:220"]),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("not a string literal");
+  });
+
+  test("accepts a declared dynamic-call exception and still checks its names", () => {
+    // scripts/deploy-site.ts is the declared exception; its unresolved call is
+    // silent, but any name the exception declares is checked like any other.
+    const deployStep = { ...step, scripts: ["scripts/deploy-site.ts"] };
+    const errors = collectErrors({
+      steps: [deployStep],
+      secret: secretWith([]),
+      requiredFor: () => required({}, ["scripts/deploy-site.ts:220"]),
+    });
+    expect(errors).toEqual([]);
+  });
+});

--- a/scripts/check-ci-env.test.ts
+++ b/scripts/check-ci-env.test.ts
@@ -135,6 +135,38 @@ steps:
     { merge: true },
   );
 
+  test("does not count an env key explicitly set to an empty value", () => {
+    // requireEnv rejects "" as missing, so an empty value satisfies nothing.
+    // Counting it would pass the check on a step whose script fails at runtime.
+    const withBlank = parse(
+      `
+steps:
+  - key: blank-env
+    command: bun scripts/release.ts
+    env:
+      SET_BUT_EMPTY: ""
+      REAL: value
+    plugins:
+      - kubernetes:
+          podSpecPatch:
+            containers:
+              - name: container-0
+                env:
+                  - name: CONTAINER_EMPTY
+                    value: ""
+                  - name: FROM_FIELD_REF
+                    valueFrom: { fieldRef: { fieldPath: metadata.name } }
+`,
+      { merge: true },
+    );
+    const step = collectSteps(withBlank, [])[0];
+    expect(step?.providedNames.has("REAL")).toBe(true);
+    expect(step?.providedNames.has("SET_BUT_EMPTY")).toBe(false);
+    expect(step?.providedNames.has("CONTAINER_EMPTY")).toBe(false);
+    // An absent `value` means valueFrom, which does provide one.
+    expect(step?.providedNames.has("FROM_FIELD_REF")).toBe(true);
+  });
+
   test("records the CI secret, container env, and global env per step", () => {
     const steps = collectSteps(pipeline, ["TURBO_TEAM"]);
     const withSecret = steps.find((step) => step.key === "with-secret");
@@ -218,6 +250,36 @@ describe("collectErrors", () => {
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("not a string literal");
+  });
+
+  test("does not apply one script's exception names to another script", () => {
+    // The declared names belong to the excepted call site alone. Leaking them
+    // into every script would make unrelated steps require them, which is how
+    // adding a name to one exception could redden steps that never run it.
+    const exceptions = [
+      {
+        file: "scripts/deploy-site.ts",
+        reason: "test",
+        names: ["ONLY_FOR_DEPLOY_SITE"],
+      },
+    ];
+    const releaseErrors = collectErrors({
+      steps: [step],
+      secret: secretWith([]),
+      requiredFor: () => required({}),
+      dynamicCallExceptions: exceptions,
+    });
+    expect(releaseErrors).toEqual([]);
+
+    // …and the excepted script itself still has its declared names checked.
+    const deployErrors = collectErrors({
+      steps: [{ ...step, scripts: ["scripts/deploy-site.ts"] }],
+      secret: secretWith([]),
+      requiredFor: () => required({}),
+      dynamicCallExceptions: exceptions,
+    });
+    expect(deployErrors).toHaveLength(1);
+    expect(deployErrors[0]).toContain("ONLY_FOR_DEPLOY_SITE");
   });
 
   test("accepts a declared dynamic-call exception and still checks its names", () => {

--- a/scripts/check-ci-env.test.ts
+++ b/scripts/check-ci-env.test.ts
@@ -2,15 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { parse } from "yaml";
 
 import {
-  assignedEnvNames,
-  commandScopes,
   ciSecretItemId,
   collectErrors,
   collectSteps,
-  scriptPathsInCommand,
   type RequiredEnv,
   type SecretFields,
 } from "./check-ci-env.ts";
+import {
+  assignedEnvNames,
+  commandScopes,
+  scriptPathsInCommand,
+} from "./lib/ci-env-command.ts";
 
 /** A secret that carries `names`, of which `blanks` are present but empty. */
 function secretWith(

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -222,7 +222,9 @@ const StepSchema = z
   .loose();
 
 const ContainerEnvSchema = z.object({
-  env: z.array(z.object({ name: z.string() }).loose()).optional(),
+  env: z
+    .array(z.object({ name: z.string(), value: z.string().optional() }).loose())
+    .optional(),
   envFrom: z
     .array(
       z.object({ secretRef: z.object({ name: z.string() }).loose() }).loose(),
@@ -249,7 +251,14 @@ function collectContainerEnv(
   if (!record.success) return;
   const container = ContainerEnvSchema.safeParse(record.data);
   if (container.success) {
-    for (const entry of container.data.env ?? []) names.add(entry.name);
+    for (const entry of container.data.env ?? []) {
+      // An explicitly empty value is not a provision: requireEnv treats "" as
+      // missing and throws, so counting it would pass the check on a step
+      // whose script fails at runtime. An absent `value` means `valueFrom`
+      // (secret/fieldRef), which does provide one.
+      if (entry.value === "") continue;
+      names.add(entry.name);
+    }
     for (const entry of container.data.envFrom ?? []) {
       secrets.add(entry.secretRef.name);
     }
@@ -284,7 +293,11 @@ export function collectSteps(
     if (command.trim() === "") continue;
     const providedNames = new Set<string>([
       ...globalEnvNames,
-      ...Object.keys(step.env ?? {}),
+      // Same rule as container env: a step-level key set to an empty string
+      // satisfies nothing, because requireEnv rejects "" as missing.
+      ...Object.entries(step.env ?? {})
+        .filter(([, value]) => value !== "")
+        .map(([key]) => key),
       ...assignedEnvNames(command),
     ]);
     const secrets = new Set<string>();
@@ -393,9 +406,11 @@ export type SecretFields = {
   isBlank: (name: string) => boolean;
 };
 
-const exceptionsByFile = new Map(
-  DYNAMIC_CALL_EXCEPTIONS.map((entry) => [entry.file, entry]),
-);
+export type DynamicCallException = {
+  file: string;
+  reason: string;
+  names: readonly string[];
+};
 
 /** Why `name` is unsatisfied for this step, or null when it is satisfied. */
 function unmetRequirement(
@@ -426,11 +441,15 @@ function unmetRequirement(
 }
 
 function errorsForInvocation(
-  step: PipelineStep,
-  entry: string,
-  required: RequiredEnv,
+  invocation: {
+    step: PipelineStep;
+    entry: string;
+    required: RequiredEnv;
+  },
   secret: SecretFields,
+  exceptionsByFile: ReadonlyMap<string, DynamicCallException>,
 ): string[] {
+  const { step, entry, required } = invocation;
   const errors: string[] = [];
   for (const site of required.unresolved) {
     const file = site.slice(0, site.lastIndexOf(":"));
@@ -441,10 +460,12 @@ function errorsForInvocation(
     );
   }
   const names = new Map(required.names);
-  for (const exception of exceptionsByFile.values()) {
-    for (const name of exception.names) {
-      names.set(name, `${exception.file} (declared exception)`);
-    }
+  // Only THIS script's exception contributes. Applying every exception's
+  // declared names to every script would make one entry's names required of
+  // unrelated scripts in unrelated steps — currently latent because the sole
+  // entry declares none, which is exactly how it would go unnoticed.
+  for (const name of exceptionsByFile.get(entry)?.names ?? []) {
+    names.set(name, `${entry} (declared exception)`);
   }
   const excepted = new Set(
     STEP_REQUIREMENT_EXCEPTIONS.filter(
@@ -463,16 +484,23 @@ export function collectErrors(input: {
   steps: readonly PipelineStep[];
   secret: SecretFields;
   requiredFor: (entry: string) => RequiredEnv;
+  /** Defaults to the declared table; injected by tests. */
+  dynamicCallExceptions?: readonly DynamicCallException[];
 }): string[] {
+  const exceptionsByFile = new Map(
+    (input.dynamicCallExceptions ?? DYNAMIC_CALL_EXCEPTIONS).map((entry) => [
+      entry.file,
+      entry,
+    ]),
+  );
   const errors: string[] = [];
   for (const step of input.steps) {
     for (const entry of step.scripts) {
       errors.push(
         ...errorsForInvocation(
-          step,
-          entry,
-          input.requiredFor(entry),
+          { step, entry, required: input.requiredFor(entry) },
           input.secret,
+          exceptionsByFile,
         ),
       );
     }

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -1,0 +1,560 @@
+#!/usr/bin/env bun
+/**
+ * Assert every environment variable a Buildkite step's scripts REQUIRE is
+ * actually provided to that step.
+ *
+ * The gap this closes: `buildkite-ci-secrets` reaches a step through
+ * `envFrom: [{ secretRef }]`, which injects whatever keys the 1Password
+ * operator synced. The cdk8s linter (`check-1password-items.ts`) only sees
+ * `secretKeyRef` and volume `items[].key`, so it cannot see a single key the
+ * pipeline consumes — exactly one key of that item is under its coverage today.
+ * A script calling `requireEnv("CODEX_ACCESS_TOKEN")` against an item with no
+ * such field therefore passed every gate and would only fail on `main`, after
+ * merge, in the release step.
+ *
+ * The check is offline: it reads the committed vault snapshot (sha256 hashes,
+ * no values) and tests membership by hashing the name the script asks for.
+ *
+ * Scope, deliberately narrow: only `requireEnv` imported from
+ * `scripts/lib/run.ts` counts. Five unrelated `requireEnv`-shaped helpers exist
+ * with different contracts, so the import is resolved rather than the name
+ * grepped. Only script paths written literally in a step's command are entry
+ * points — `bun run verify` fans out to per-package turbo tasks that do not
+ * consume CI credentials, and following it would pull in the whole repo.
+ *
+ * Usage: bun scripts/check-ci-env.ts
+ *
+ * Exit codes:
+ *   0 - every required variable is provided
+ *   1 - a required variable is missing/blank, or a requireEnv call could not be
+ *       resolved statically and has no exception
+ *   2 - setup error (pipeline or snapshot unreadable)
+ */
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { parse } from "yaml";
+import { Project, SyntaxKind, type SourceFile } from "ts-morph";
+import { z } from "zod";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
+const PIPELINE_PATH = path.join(REPOSITORY_ROOT, ".buildkite", "pipeline.yml");
+const SNAPSHOT_PATH = path.join(
+  REPOSITORY_ROOT,
+  "packages",
+  "homelab",
+  "src",
+  "cdk8s",
+  "onepassword-vault-snapshot.json",
+);
+/** The secret `envFrom: { secretRef: { name } }` names in every pipeline step. */
+const CI_SECRET_NAME = "buildkite-ci-secrets";
+/**
+ * cdk8s owns which 1Password item backs that secret, so the item id is read
+ * from the `OnePasswordItem` declaration rather than duplicated here — a
+ * repointed itemPath then moves this check with it instead of silently
+ * validating the old item.
+ */
+const CI_SECRET_DECLARATION = path.join(
+  REPOSITORY_ROOT,
+  "packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts",
+);
+/** The only `requireEnv` whose contract this check models. */
+const REQUIRE_ENV_MODULE = path.join(
+  REPOSITORY_ROOT,
+  "scripts",
+  "lib",
+  "run.ts",
+);
+
+/**
+ * Names the Buildkite agent injects into every step. They are never carried by
+ * the secret and never assigned in a command, so without this they would all
+ * read as missing.
+ */
+const AGENT_PROVIDED_PREFIXES = ["BUILDKITE_", "CI_"] as const;
+const AGENT_PROVIDED_NAMES = new Set([
+  "CI",
+  "PATH",
+  "HOME",
+  "TMPDIR",
+  "GITHUB_REPOSITORY",
+]);
+
+/**
+ * Call sites whose `requireEnv` argument is not a string literal. Each entry
+ * must say why the names cannot be read statically and declare the names the
+ * site may require, so coverage is preserved rather than dropped.
+ */
+const DYNAMIC_CALL_EXCEPTIONS: readonly {
+  file: string;
+  reason: string;
+  names: readonly string[];
+}[] = [
+  {
+    file: "scripts/deploy-site.ts",
+    reason:
+      "requireEnv(name) iterates DEPLOY_SITES[].buildEnvVars. No site in the " +
+      "catalog declares buildEnvVars today, so the loop requires nothing. If a " +
+      "site adds one, list its names here so they are checked again.",
+    names: [],
+  },
+];
+
+/**
+ * Requirements a step provably does not hit. This analysis is flow-insensitive
+ * — it unions every `requireEnv` in a script's import graph regardless of the
+ * branch it sits in — so a requirement gated behind a flag the step passes has
+ * to be declared here rather than inferred.
+ */
+const STEP_REQUIREMENT_EXCEPTIONS: readonly {
+  step: string;
+  script: string;
+  names: readonly string[];
+  reason: string;
+}[] = [
+  {
+    step: "pr-dryrun",
+    script: "packages/homelab/scripts/argocd.ts",
+    names: ["ARGOCD_TOKEN"],
+    reason:
+      "The step runs every argocd.ts subcommand with --dry-run, and each " +
+      "ARGOCD_TOKEN requirement sits behind an `if (!dryRun)` guard — the " +
+      "script's own header documents it as 'required unless --dry-run'. The " +
+      "steps that call argocd.ts for real (argocd-sync, tofu-cloudflare) " +
+      "export ARGOCD_TOKEN in their command and are checked normally.",
+  },
+];
+
+const SnapshotItemSchema = z.object({
+  ref: z.string(),
+  title: z.string(),
+  fields: z.array(z.string()),
+  blankFields: z.array(z.string()),
+});
+const SnapshotSchema = z.object({
+  vaultId: z.string(),
+  generatedAt: z.string(),
+  items: z.array(SnapshotItemSchema),
+});
+
+export function hash(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+/**
+ * The 1Password item id backing `buildkite-ci-secrets`, read from the cdk8s
+ * `OnePasswordItem` that declares it. Throws rather than guessing: an
+ * unreadable declaration means this check would otherwise validate against
+ * the wrong item and report a clean run.
+ */
+export function ciSecretItemId(declarationSource: string): string {
+  const anchor = declarationSource.indexOf(`"${CI_SECRET_NAME}"`);
+  if (anchor === -1) {
+    throw new Error(
+      `no OnePasswordItem named "${CI_SECRET_NAME}" in the cdk8s declaration`,
+    );
+  }
+  const itemPath = /vaults\/[\w-]+\/items\/([\w-]+)/u.exec(
+    declarationSource.slice(anchor),
+  );
+  const id = itemPath?.[1];
+  if (id === undefined) {
+    throw new Error(
+      `the "${CI_SECRET_NAME}" OnePasswordItem declares no vaults/…/items/… itemPath`,
+    );
+  }
+  return id;
+}
+
+/**
+ * Names a shell command assigns before/while running something, which the
+ * secret does not carry. Steps routinely rename a secret key into the name a
+ * script expects — `export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID"`,
+ * `export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"`. Treating those as unprovided
+ * would make this check's first run a wall of false positives.
+ *
+ * Handles several assignments per `export` (the pipeline exports the two AWS
+ * names on one line) and bare `NAME=value cmd` prefixes.
+ */
+export function assignedEnvNames(command: string): Set<string> {
+  const names = new Set<string>();
+  const assignment = /(?<![\w$])([A-Z_][A-Z0-9_]*)=/gu;
+  for (const line of command.split("\n")) {
+    const trimmed = line.trim();
+    // An `export` line may assign several names; a bare line may prefix a
+    // command with assignments. Both are just NAME= tokens on the line.
+    if (!/(?:^|\s|;)(?:export\s|[A-Z_][A-Z0-9_]*=)/u.test(trimmed)) continue;
+    for (const match of trimmed.matchAll(assignment)) {
+      const name = match[1];
+      if (name !== undefined) names.add(name);
+    }
+  }
+  return names;
+}
+
+/** Repo-relative `.ts`/`.sh` script paths written literally in a command. */
+export function scriptPathsInCommand(command: string): string[] {
+  const paths = new Set<string>();
+  const pattern =
+    /(?<![\w./-])((?:scripts|\.buildkite\/scripts|packages\/[\w.-]+(?:\/[\w.-]+)*?\/scripts)\/[\w.-]+\.ts)/gu;
+  for (const match of command.matchAll(pattern)) {
+    const found = match[1];
+    if (found !== undefined) paths.add(found);
+  }
+  return [...paths].toSorted();
+}
+
+type PipelineStep = {
+  key: string;
+  providedNames: Set<string>;
+  usesCiSecret: boolean;
+  scripts: string[];
+};
+
+const StepSchema = z
+  .object({
+    key: z.string().optional(),
+    label: z.string().optional(),
+    command: z.union([z.string(), z.array(z.string())]).optional(),
+    env: z.record(z.string(), z.unknown()).optional(),
+    plugins: z.array(z.unknown()).optional(),
+  })
+  .loose();
+
+const ContainerEnvSchema = z.object({
+  env: z.array(z.object({ name: z.string() }).loose()).optional(),
+  envFrom: z
+    .array(
+      z.object({ secretRef: z.object({ name: z.string() }).loose() }).loose(),
+    )
+    .optional(),
+});
+const RecordSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Every `env` name and `envFrom` secret reachable anywhere inside a step. The
+ * kubernetes plugin nests containers differently per anchor (`podSpec` vs
+ * `podSpecPatch`), so this walks the whole subtree rather than a fixed path.
+ */
+function collectContainerEnv(
+  node: unknown,
+  names: Set<string>,
+  secrets: Set<string>,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectContainerEnv(item, names, secrets);
+    return;
+  }
+  const record = RecordSchema.safeParse(node);
+  if (!record.success) return;
+  const container = ContainerEnvSchema.safeParse(record.data);
+  if (container.success) {
+    for (const entry of container.data.env ?? []) names.add(entry.name);
+    for (const entry of container.data.envFrom ?? []) {
+      secrets.add(entry.secretRef.name);
+    }
+  }
+  for (const value of Object.values(record.data)) {
+    collectContainerEnv(value, names, secrets);
+  }
+}
+
+export function collectSteps(
+  pipeline: unknown,
+  globalEnvNames: readonly string[],
+): PipelineStep[] {
+  const document = z
+    .object({
+      env: z.record(z.string(), z.unknown()).optional(),
+      steps: z.array(z.unknown()).optional(),
+    })
+    .loose()
+    .parse(pipeline);
+  const steps: PipelineStep[] = [];
+  for (const [index, raw] of (document.steps ?? []).entries()) {
+    const parsed = StepSchema.safeParse(raw);
+    if (!parsed.success) continue;
+    const step = parsed.data;
+    const command =
+      step.command === undefined
+        ? ""
+        : Array.isArray(step.command)
+          ? step.command.join("\n")
+          : step.command;
+    if (command.trim() === "") continue;
+    const providedNames = new Set<string>([
+      ...globalEnvNames,
+      ...Object.keys(step.env ?? {}),
+      ...assignedEnvNames(command),
+    ]);
+    const secrets = new Set<string>();
+    collectContainerEnv(step.plugins, providedNames, secrets);
+    steps.push({
+      key: step.key ?? step.label ?? `step[${String(index)}]`,
+      providedNames,
+      usesCiSecret: secrets.has(CI_SECRET_NAME),
+      scripts: scriptPathsInCommand(command),
+    });
+  }
+  return steps;
+}
+
+export type RequiredEnv = {
+  /** Env var name → the `file:line` that requires it. */
+  names: Map<string, string>;
+  /** `file:line` of calls whose argument is not a string literal. */
+  unresolved: string[];
+};
+
+/**
+ * Whether this file imports `requireEnv` from `scripts/lib/run.ts`. Resolving
+ * the import is the point: `packages/toolkit/src/lib/config.ts`,
+ * `activities/gcx-context.ts`, `activities/glitter-corpus-store.ts` and
+ * `llm-observability/src/config.ts` all export a differently-shaped helper of
+ * the same or a similar name, and none of them is fed by the CI secret.
+ */
+function importsOurRequireEnv(source: SourceFile): boolean {
+  for (const declaration of source.getImportDeclarations()) {
+    const specifier = declaration.getModuleSpecifierValue();
+    if (!specifier.startsWith(".")) continue;
+    const resolved = path.resolve(
+      path.dirname(source.getFilePath()),
+      specifier,
+    );
+    if (resolved !== REQUIRE_ENV_MODULE) continue;
+    for (const named of declaration.getNamedImports()) {
+      if (named.getName() === "requireEnv") return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Union of `requireEnv` names reachable from `entry` through relative imports.
+ * Package-alias imports are not followed: the graph that matters here is the
+ * root scripts tree plus each package's own scripts directory, which import
+ * `lib/run.ts` by relative path.
+ */
+export function requiredEnvFrom(project: Project, entry: string): RequiredEnv {
+  const accumulated: RequiredEnv = { names: new Map(), unresolved: [] };
+  const seen = new Set<string>();
+
+  const visit = (relativePath: string): void => {
+    const absolute = path.resolve(REPOSITORY_ROOT, relativePath);
+    if (seen.has(absolute)) return;
+    seen.add(absolute);
+    const source = project.addSourceFileAtPathIfExists(absolute);
+    if (source === undefined) return;
+
+    if (importsOurRequireEnv(source)) {
+      const relative = path.relative(REPOSITORY_ROOT, source.getFilePath());
+      for (const call of source.getDescendantsOfKind(
+        SyntaxKind.CallExpression,
+      )) {
+        if (call.getExpression().getText() !== "requireEnv") continue;
+        const site = `${relative}:${String(call.getStartLineNumber())}`;
+        const literal = call
+          .getArguments()[0]
+          ?.asKind(SyntaxKind.StringLiteral);
+        if (literal === undefined) accumulated.unresolved.push(site);
+        else accumulated.names.set(literal.getLiteralValue(), site);
+      }
+    }
+
+    for (const declaration of source.getImportDeclarations()) {
+      const specifier = declaration.getModuleSpecifierValue();
+      if (!specifier.startsWith(".")) continue;
+      const resolved = path.resolve(
+        path.dirname(source.getFilePath()),
+        specifier,
+      );
+      visit(path.relative(REPOSITORY_ROOT, resolved));
+    }
+  };
+
+  visit(entry);
+  return accumulated;
+}
+
+function isAgentProvided(name: string): boolean {
+  return (
+    AGENT_PROVIDED_NAMES.has(name) ||
+    AGENT_PROVIDED_PREFIXES.some((prefix) => name.startsWith(prefix))
+  );
+}
+
+/**
+ * Membership predicates rather than a name set: the snapshot stores sha256
+ * hashes and never plaintext, so the only possible question is "is the name
+ * this script asked for present/blank?", answered by hashing the candidate.
+ */
+export type SecretFields = {
+  hasField: (name: string) => boolean;
+  isBlank: (name: string) => boolean;
+};
+
+const exceptionsByFile = new Map(
+  DYNAMIC_CALL_EXCEPTIONS.map((entry) => [entry.file, entry]),
+);
+
+/** Why `name` is unsatisfied for this step, or null when it is satisfied. */
+function unmetRequirement(
+  requirement: {
+    step: PipelineStep;
+    entry: string;
+    name: string;
+    site: string;
+  },
+  secret: SecretFields,
+): string | null {
+  const { step, entry, name, site } = requirement;
+  if (isAgentProvided(name)) return null;
+  if (step.providedNames.has(name)) return null;
+  const prefix = `step "${step.key}" runs ${entry}, which requires ${name} (${site})`;
+  if (step.usesCiSecret && secret.hasField(name)) {
+    if (!secret.isBlank(name)) return null;
+    return (
+      `${prefix}, but that field is BLANK on the ${CI_SECRET_NAME} 1Password item. ` +
+      `The operator skips empty fields, so the variable would be missing at runtime.`
+    );
+  }
+  return (
+    `${prefix}, but the step does not provide it. Add the field to the ${CI_SECRET_NAME} ` +
+    `1Password item and refresh the vault snapshot, set it in the step's env, or assign ` +
+    `it in the step's command.`
+  );
+}
+
+function errorsForInvocation(
+  step: PipelineStep,
+  entry: string,
+  required: RequiredEnv,
+  secret: SecretFields,
+): string[] {
+  const errors: string[] = [];
+  for (const site of required.unresolved) {
+    const file = site.slice(0, site.lastIndexOf(":"));
+    if (exceptionsByFile.has(file)) continue;
+    errors.push(
+      `step "${step.key}" runs ${entry}, whose requireEnv at ${site} is not a string literal. ` +
+        `Add an exception to DYNAMIC_CALL_EXCEPTIONS in scripts/check-ci-env.ts declaring the names it may require.`,
+    );
+  }
+  const names = new Map(required.names);
+  for (const exception of exceptionsByFile.values()) {
+    for (const name of exception.names) {
+      names.set(name, `${exception.file} (declared exception)`);
+    }
+  }
+  const excepted = new Set(
+    STEP_REQUIREMENT_EXCEPTIONS.filter(
+      (exception) => exception.step === step.key && exception.script === entry,
+    ).flatMap((exception) => [...exception.names]),
+  );
+  for (const [name, site] of names) {
+    if (excepted.has(name)) continue;
+    const unmet = unmetRequirement({ step, entry, name, site }, secret);
+    if (unmet !== null) errors.push(unmet);
+  }
+  return errors;
+}
+
+export function collectErrors(input: {
+  steps: readonly PipelineStep[];
+  secret: SecretFields;
+  requiredFor: (entry: string) => RequiredEnv;
+}): string[] {
+  const errors: string[] = [];
+  for (const step of input.steps) {
+    for (const entry of step.scripts) {
+      errors.push(
+        ...errorsForInvocation(
+          step,
+          entry,
+          input.requiredFor(entry),
+          input.secret,
+        ),
+      );
+    }
+  }
+  return [...new Set(errors)].toSorted();
+}
+
+function fail(message: string, code: number): never {
+  console.error(message);
+  process.exit(code);
+}
+
+async function main(): Promise<void> {
+  let steps: PipelineStep[];
+  let secret: SecretFields;
+  try {
+    const pipeline: unknown = parse(await Bun.file(PIPELINE_PATH).text(), {
+      merge: true,
+    });
+    const globalEnv = z
+      .object({ env: z.record(z.string(), z.unknown()).optional() })
+      .loose()
+      .parse(pipeline);
+    steps = collectSteps(pipeline, Object.keys(globalEnv.env ?? {}));
+  } catch (error: unknown) {
+    fail(
+      `check-ci-env: could not read ${path.relative(REPOSITORY_ROOT, PIPELINE_PATH)}: ${String(error)}`,
+      2,
+    );
+  }
+  try {
+    const snapshot = SnapshotSchema.parse(await Bun.file(SNAPSHOT_PATH).json());
+    const itemId = ciSecretItemId(await Bun.file(CI_SECRET_DECLARATION).text());
+    const item = snapshot.items.find((entry) => entry.ref === hash(itemId));
+    if (item === undefined) {
+      fail(
+        `check-ci-env: the ${CI_SECRET_NAME} item is absent from the vault snapshot. Refresh it with ` +
+          `packages/homelab/src/cdk8s/scripts/snapshot-1password-vault.ts.`,
+        2,
+      );
+    }
+    const fields = new Set(item.fields);
+    const blanks = new Set(item.blankFields);
+    secret = {
+      hasField: (name: string) => fields.has(hash(name)),
+      isBlank: (name: string) => blanks.has(hash(name)),
+    };
+  } catch (error: unknown) {
+    fail(
+      `check-ci-env: could not read the vault snapshot: ${String(error)}`,
+      2,
+    );
+  }
+
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    skipFileDependencyResolution: true,
+    compilerOptions: { allowJs: false },
+  });
+  const cache = new Map<string, RequiredEnv>();
+  const requiredFor = (entry: string): RequiredEnv => {
+    const cached = cache.get(entry);
+    if (cached !== undefined) return cached;
+    const computed = requiredEnvFrom(project, entry);
+    cache.set(entry, computed);
+    return computed;
+  };
+
+  const errors = collectErrors({ steps, secret, requiredFor });
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`✗ ${error}`);
+    fail(
+      `check-ci-env: ${String(errors.length)} unmet CI environment requirement(s).`,
+      1,
+    );
+  }
+  const checked = steps.reduce((total, step) => total + step.scripts.length, 0);
+  console.log(
+    `check-ci-env: OK — ${String(steps.length)} pipeline step(s), ${String(checked)} script invocation(s) verified against the ${CI_SECRET_NAME} snapshot.`,
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -114,6 +114,24 @@ const STEP_REQUIREMENT_EXCEPTIONS: readonly {
 }[] = [
   {
     step: "pr-dryrun",
+    script: "scripts/deploy-site.ts",
+    names: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+    reason:
+      "The step runs deploy-site.ts with --dry-run, and both requireEnv calls " +
+      "sit behind `if (!dryRun && !haveCreds)`. The live `sites` step exports " +
+      "both names from the SEAWEEDFS_* secret keys and is checked normally.",
+  },
+  {
+    step: "pr-dryrun",
+    script: "scripts/scout-site-release.ts",
+    names: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+    reason:
+      "Same shape via scripts/lib/scout-site-storage.ts's requireCreds(dryRun): " +
+      "every subcommand this step runs passes --dry-run. The live " +
+      "scout-beta-release step exports both names and is checked normally.",
+  },
+  {
+    step: "pr-dryrun",
     script: "packages/homelab/scripts/argocd.ts",
     names: ["ARGOCD_TOKEN"],
     reason:
@@ -178,18 +196,65 @@ export function ciSecretItemId(declarationSource: string): string {
  */
 export function assignedEnvNames(command: string): Set<string> {
   const names = new Set<string>();
-  const assignment = /(?<![\w$])([A-Z_][A-Z0-9_]*)=/gu;
-  for (const line of command.split("\n")) {
-    const trimmed = line.trim();
-    // An `export` line may assign several names; a bare line may prefix a
-    // command with assignments. Both are just NAME= tokens on the line.
-    if (!/(?:^|\s|;)(?:export\s|[A-Z_][A-Z0-9_]*=)/u.test(trimmed)) continue;
-    for (const match of trimmed.matchAll(assignment)) {
-      const name = match[1];
-      if (name !== undefined) names.add(name);
-    }
+  for (const scope of commandScopes(command)) {
+    for (const name of scope.assigned) names.add(name);
   }
   return names;
+}
+
+export type CommandScope = {
+  /** Names assigned at or above this scope, so visible to its invocations. */
+  assigned: Set<string>;
+  /** Script paths invoked while those assignments are in effect. */
+  scripts: string[];
+};
+
+const ASSIGNMENT = /(?<![\w$])([A-Z_][A-Z0-9_]*)=/gu;
+
+/**
+ * Split a step's command into subshell scopes.
+ *
+ * `pr-dryrun` exports the AWS credentials inside `( … )` around its Tofu loop
+ * and then runs other scripts outside it. Treating the command as one flat
+ * scope reports those names as provided to every script in the step — a false
+ * negative in exactly the direction this check exists to prevent, since it
+ * would let a genuinely missing credential pass.
+ *
+ * Only `( … )` is modelled. `{ …; }` shares the parent's environment, so it
+ * needs no scope of its own, and the pipeline uses no other construct that
+ * scopes exports.
+ */
+export function commandScopes(command: string): CommandScope[] {
+  const scopes: CommandScope[] = [];
+  const stack: CommandScope[] = [{ assigned: new Set(), scripts: [] }];
+  scopes.push(stack[0]!);
+  for (const line of command.split("\n")) {
+    const trimmed = line.trim();
+    const opened = (trimmed.match(/\(/gu) ?? []).length;
+    const closed = (trimmed.match(/\)/gu) ?? []).length;
+    // A line that opens a subshell starts a scope inheriting what is in force.
+    for (let index = 0; index < opened; index += 1) {
+      const parent = stack[stack.length - 1]!;
+      const child: CommandScope = {
+        assigned: new Set(parent.assigned),
+        scripts: [],
+      };
+      stack.push(child);
+      scopes.push(child);
+    }
+    const current = stack[stack.length - 1]!;
+    if (/(?:^|\s|;)(?:export\s|[A-Z_][A-Z0-9_]*=)/u.test(trimmed)) {
+      for (const match of trimmed.matchAll(ASSIGNMENT)) {
+        const name = match[1];
+        if (name !== undefined) current.assigned.add(name);
+      }
+    }
+    current.scripts.push(...scriptPathsInCommand(trimmed));
+    for (let index = 0; index < closed && stack.length > 1; index += 1) {
+      stack.pop();
+    }
+  }
+  return scopes;
 }
 
 /** Repo-relative `.ts`/`.sh` script paths written literally in a command. */
@@ -291,23 +356,28 @@ export function collectSteps(
           ? step.command.join("\n")
           : step.command;
     if (command.trim() === "") continue;
-    const providedNames = new Set<string>([
+    const stepNames = new Set<string>([
       ...globalEnvNames,
       // Same rule as container env: a step-level key set to an empty string
       // satisfies nothing, because requireEnv rejects "" as missing.
       ...Object.entries(step.env ?? {})
         .filter(([, value]) => value !== "")
         .map(([key]) => key),
-      ...assignedEnvNames(command),
     ]);
     const secrets = new Set<string>();
-    collectContainerEnv(step.plugins, providedNames, secrets);
-    steps.push({
-      key: step.key ?? step.label ?? `step[${String(index)}]`,
-      providedNames,
-      usesCiSecret: secrets.has(CI_SECRET_NAME),
-      scripts: scriptPathsInCommand(command),
-    });
+    collectContainerEnv(step.plugins, stepNames, secrets);
+    const key = step.key ?? step.label ?? `step[${String(index)}]`;
+    // One entry per subshell scope: a name exported inside `( … )` reaches the
+    // scripts in that block and no others.
+    for (const scope of commandScopes(command)) {
+      if (scope.scripts.length === 0) continue;
+      steps.push({
+        key,
+        providedNames: new Set([...stepNames, ...scope.assigned]),
+        usesCiSecret: secrets.has(CI_SECRET_NAME),
+        scripts: [...new Set(scope.scripts)].toSorted(),
+      });
+    }
   }
   return steps;
 }

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -35,6 +35,7 @@ import path from "node:path";
 import { parse } from "yaml";
 import { Project, SyntaxKind, type SourceFile } from "ts-morph";
 import { z } from "zod";
+import { commandScopes } from "./lib/ci-env-command.ts";
 
 const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
 const PIPELINE_PATH = path.join(REPOSITORY_ROOT, ".buildkite", "pipeline.yml");
@@ -182,91 +183,6 @@ export function ciSecretItemId(declarationSource: string): string {
     );
   }
   return id;
-}
-
-/**
- * Names a shell command assigns before/while running something, which the
- * secret does not carry. Steps routinely rename a secret key into the name a
- * script expects — `export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID"`,
- * `export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"`. Treating those as unprovided
- * would make this check's first run a wall of false positives.
- *
- * Handles several assignments per `export` (the pipeline exports the two AWS
- * names on one line) and bare `NAME=value cmd` prefixes.
- */
-export function assignedEnvNames(command: string): Set<string> {
-  const names = new Set<string>();
-  for (const scope of commandScopes(command)) {
-    for (const name of scope.assigned) names.add(name);
-  }
-  return names;
-}
-
-export type CommandScope = {
-  /** Names assigned at or above this scope, so visible to its invocations. */
-  assigned: Set<string>;
-  /** Script paths invoked while those assignments are in effect. */
-  scripts: string[];
-};
-
-const ASSIGNMENT = /(?<![\w$])([A-Z_][A-Z0-9_]*)=/gu;
-
-/**
- * Split a step's command into subshell scopes.
- *
- * `pr-dryrun` exports the AWS credentials inside `( … )` around its Tofu loop
- * and then runs other scripts outside it. Treating the command as one flat
- * scope reports those names as provided to every script in the step — a false
- * negative in exactly the direction this check exists to prevent, since it
- * would let a genuinely missing credential pass.
- *
- * Only `( … )` is modelled. `{ …; }` shares the parent's environment, so it
- * needs no scope of its own, and the pipeline uses no other construct that
- * scopes exports.
- */
-export function commandScopes(command: string): CommandScope[] {
-  const scopes: CommandScope[] = [];
-  const stack: CommandScope[] = [{ assigned: new Set(), scripts: [] }];
-  scopes.push(stack[0]!);
-  for (const line of command.split("\n")) {
-    const trimmed = line.trim();
-    const opened = (trimmed.match(/\(/gu) ?? []).length;
-    const closed = (trimmed.match(/\)/gu) ?? []).length;
-    // A line that opens a subshell starts a scope inheriting what is in force.
-    for (let index = 0; index < opened; index += 1) {
-      const parent = stack[stack.length - 1]!;
-      const child: CommandScope = {
-        assigned: new Set(parent.assigned),
-        scripts: [],
-      };
-      stack.push(child);
-      scopes.push(child);
-    }
-    const current = stack[stack.length - 1]!;
-    if (/(?:^|\s|;)(?:export\s|[A-Z_][A-Z0-9_]*=)/u.test(trimmed)) {
-      for (const match of trimmed.matchAll(ASSIGNMENT)) {
-        const name = match[1];
-        if (name !== undefined) current.assigned.add(name);
-      }
-    }
-    current.scripts.push(...scriptPathsInCommand(trimmed));
-    for (let index = 0; index < closed && stack.length > 1; index += 1) {
-      stack.pop();
-    }
-  }
-  return scopes;
-}
-
-/** Repo-relative `.ts`/`.sh` script paths written literally in a command. */
-export function scriptPathsInCommand(command: string): string[] {
-  const paths = new Set<string>();
-  const pattern =
-    /(?<![\w./-])((?:scripts|\.buildkite\/scripts|packages\/[\w.-]+(?:\/[\w.-]+)*?\/scripts)\/[\w.-]+\.ts)/gu;
-  for (const match of command.matchAll(pattern)) {
-    const found = match[1];
-    if (found !== undefined) paths.add(found);
-  }
-  return [...paths].toSorted();
 }
 
 type PipelineStep = {

--- a/scripts/lib/ci-env-command.ts
+++ b/scripts/lib/ci-env-command.ts
@@ -1,0 +1,90 @@
+/**
+ * Parsing a Buildkite step's shell command: which env names it assigns, where
+ * those assignments are in force, and which repository scripts it invokes.
+ *
+ * Split out of check-ci-env.ts, which sits at the repo's max-lines cap (the
+ * same pattern as metrics-glitter.ts for metrics.ts).
+ */
+
+/**
+ * Names a shell command assigns before/while running something, which the
+ * secret does not carry. Steps routinely rename a secret key into the name a
+ * script expects — `export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID"`,
+ * `export ARGOCD_TOKEN="$$ARGOCD_AUTH_TOKEN"`. Treating those as unprovided
+ * would make this check's first run a wall of false positives.
+ *
+ * Handles several assignments per `export` (the pipeline exports the two AWS
+ * names on one line) and bare `NAME=value cmd` prefixes.
+ */
+export function assignedEnvNames(command: string): Set<string> {
+  const names = new Set<string>();
+  for (const scope of commandScopes(command)) {
+    for (const name of scope.assigned) names.add(name);
+  }
+  return names;
+}
+
+export type CommandScope = {
+  /** Names assigned at or above this scope, so visible to its invocations. */
+  assigned: Set<string>;
+  /** Script paths invoked while those assignments are in effect. */
+  scripts: string[];
+};
+
+const ASSIGNMENT = /(?<![\w$])([A-Z_][A-Z0-9_]*)=/gu;
+
+/**
+ * Split a step's command into subshell scopes.
+ *
+ * `pr-dryrun` exports the AWS credentials inside `( … )` around its Tofu loop
+ * and then runs other scripts outside it. Treating the command as one flat
+ * scope reports those names as provided to every script in the step — a false
+ * negative in exactly the direction this check exists to prevent, since it
+ * would let a genuinely missing credential pass.
+ *
+ * Only `( … )` is modelled. `{ …; }` shares the parent's environment, so it
+ * needs no scope of its own, and the pipeline uses no other construct that
+ * scopes exports.
+ */
+export function commandScopes(command: string): CommandScope[] {
+  const root: CommandScope = { assigned: new Set(), scripts: [] };
+  const scopes: CommandScope[] = [root];
+  const stack: CommandScope[] = [root];
+  const innermost = (): CommandScope => stack.at(-1) ?? root;
+  for (const line of command.split("\n")) {
+    const trimmed = line.trim();
+    // A line that opens a subshell starts a scope inheriting what is in force.
+    for (const _ of trimmed.matchAll(/\(/gu)) {
+      const child: CommandScope = {
+        assigned: new Set(innermost().assigned),
+        scripts: [],
+      };
+      stack.push(child);
+      scopes.push(child);
+    }
+    const current = innermost();
+    if (/(?:^|\s|;)(?:export\s|[A-Z_][A-Z0-9_]*=)/u.test(trimmed)) {
+      for (const match of trimmed.matchAll(ASSIGNMENT)) {
+        const name = match[1];
+        if (name !== undefined) current.assigned.add(name);
+      }
+    }
+    current.scripts.push(...scriptPathsInCommand(trimmed));
+    for (const _ of trimmed.matchAll(/\)/gu)) {
+      if (stack.length > 1) stack.pop();
+    }
+  }
+  return scopes;
+}
+
+/** Repo-relative `.ts`/`.sh` script paths written literally in a command. */
+export function scriptPathsInCommand(command: string): string[] {
+  const paths = new Set<string>();
+  const pattern =
+    /(?<![\w./-])((?:scripts|\.buildkite\/scripts|packages\/[\w.-]+(?:\/[\w.-]+)*?\/scripts)\/[\w.-]+\.ts)/gu;
+  for (const match of command.matchAll(pattern)) {
+    const found = match[1];
+    if (found !== undefined) paths.add(found);
+  }
+  return [...paths].toSorted();
+}

--- a/scripts/lib/ci-env-command.ts
+++ b/scripts/lib/ci-env-command.ts
@@ -46,6 +46,39 @@ const ASSIGNMENT = /(?<![\w$])([A-Z_][A-Z0-9_]*)=/gu;
  * needs no scope of its own, and the pipeline uses no other construct that
  * scopes exports.
  */
+/**
+ * Only the parentheses that open or close a real subshell.
+ *
+ * `x=$(cmd)` is not a subshell for scoping purposes, and treating its parens
+ * as one opens a scope, records the assignment inside it, then pops — losing
+ * the name from the scope that actually has it. Buildkite escapes the sigil as
+ * `$$(`, so both spellings are recognised, and nesting inside a substitution
+ * is skipped wholesale.
+ */
+export function structuralParens(line: string): string {
+  let structural = "";
+  let substitutionDepth = 0;
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+    if (character !== "(" && character !== ")") continue;
+    if (character === "(") {
+      const opensSubstitution = /\$\$?$/u.test(line.slice(0, index));
+      if (opensSubstitution || substitutionDepth > 0) {
+        substitutionDepth += 1;
+        continue;
+      }
+      structural += "(";
+      continue;
+    }
+    if (substitutionDepth > 0) {
+      substitutionDepth -= 1;
+      continue;
+    }
+    structural += ")";
+  }
+  return structural;
+}
+
 export function commandScopes(command: string): CommandScope[] {
   const root: CommandScope = { assigned: new Set(), scripts: [] };
   const scopes: CommandScope[] = [root];
@@ -53,8 +86,9 @@ export function commandScopes(command: string): CommandScope[] {
   const innermost = (): CommandScope => stack.at(-1) ?? root;
   for (const line of command.split("\n")) {
     const trimmed = line.trim();
+    const structural = structuralParens(trimmed);
     // A line that opens a subshell starts a scope inheriting what is in force.
-    for (const _ of trimmed.matchAll(/\(/gu)) {
+    for (const _ of structural.matchAll(/\(/gu)) {
       const child: CommandScope = {
         assigned: new Set(innermost().assigned),
         scripts: [],
@@ -70,14 +104,22 @@ export function commandScopes(command: string): CommandScope[] {
       }
     }
     current.scripts.push(...scriptPathsInCommand(trimmed));
-    for (const _ of trimmed.matchAll(/\)/gu)) {
+    for (const _ of structural.matchAll(/\)/gu)) {
       if (stack.length > 1) stack.pop();
     }
   }
   return scopes;
 }
 
-/** Repo-relative `.ts`/`.sh` script paths written literally in a command. */
+/**
+ * Repo-relative `.ts` script paths written literally in a command.
+ *
+ * TypeScript only, deliberately: requirements are read from `requireEnv` calls
+ * through the TypeScript AST, so a `.sh` entry point has nothing this analysis
+ * can resolve. Shell entry points are therefore out of scope rather than
+ * silently under-analyzed — if one ever needs checking it needs a different
+ * mechanism, not a wider regex here.
+ */
 export function scriptPathsInCommand(command: string): string[] {
   const paths = new Set<string>();
   const pattern =

--- a/scripts/lib/test-git.ts
+++ b/scripts/lib/test-git.ts
@@ -1,0 +1,140 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * Environment that isolates a `git` subprocess from the machine running it.
+ *
+ * Tests that shell out to git otherwise inherit the developer's `~/.gitconfig`
+ * and `/etc/gitconfig`, which makes them pass or fail based on personal
+ * settings rather than the code under test. Real failures this prevents:
+ * `commit.gpgsign=true` makes a seed commit prompt or fail, `core.hooksPath`
+ * runs the operator's hooks inside a throwaway repo, and an `~/.gitignore`
+ * that git cannot expand aborts `git status` outright — which is exactly how
+ * a scout-season-refresh test failed only under turbo's stripped environment
+ * on one machine while passing everywhere else.
+ *
+ * `HOME` is redirected as well as the config paths: git is not the only thing
+ * that reads it, and pointing it at the sandbox keeps anything else a
+ * subprocess consults out of the operator's real home.
+ */
+export function hermeticGitEnv(
+  home: string,
+  sourceEnv: Readonly<Record<string, string | undefined>> = Bun.env,
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(sourceEnv)) {
+    // Per-invocation config injected by a caller would survive into the child
+    // and silently re-introduce host settings, so it is dropped rather than
+    // copied over.
+    if (
+      key === "GIT_CONFIG_COUNT" ||
+      key.startsWith("GIT_CONFIG_KEY_") ||
+      key.startsWith("GIT_CONFIG_VALUE_")
+    ) {
+      continue;
+    }
+    env[key] = value;
+  }
+  env["HOME"] = home;
+  env["GIT_CONFIG_GLOBAL"] = "/dev/null";
+  env["GIT_CONFIG_NOSYSTEM"] = "1";
+  // Never let a test block waiting for credentials on a terminal CI has not got.
+  env["GIT_TERMINAL_PROMPT"] = "0";
+  env["GIT_AUTHOR_NAME"] = "Test";
+  env["GIT_AUTHOR_EMAIL"] = "test@example.com";
+  env["GIT_COMMITTER_NAME"] = "Test";
+  env["GIT_COMMITTER_EMAIL"] = "test@example.com";
+  return env;
+}
+
+/**
+ * Apply the hermetic git environment to THIS process, returning a restore
+ * function for `afterAll`.
+ *
+ * Needed when the code under test spawns git itself: those children inherit
+ * the test process's environment, so handing a clean env to the setup commands
+ * alone still leaves the assertions running against the host's config. That is
+ * precisely how `revertGeneratedAtOnlyChanges` failed — its own `runCommand`
+ * inherited an `~/.gitignore` git could not expand, and `git status` aborted.
+ */
+export function applyHermeticGitEnv(home: string): () => void {
+  const managed = [
+    "HOME",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_TERMINAL_PROMPT",
+    "GIT_AUTHOR_NAME",
+    "GIT_AUTHOR_EMAIL",
+    "GIT_COMMITTER_NAME",
+    "GIT_COMMITTER_EMAIL",
+  ];
+  const previous = new Map(managed.map((key) => [key, Bun.env[key]]));
+  const hermetic = hermeticGitEnv(home);
+  for (const key of managed) {
+    const value = hermetic[key];
+    if (value !== undefined) Bun.env[key] = value;
+  }
+  return () => {
+    for (const [key, value] of previous) {
+      // Assigning `undefined` would set the literal string "undefined"; the
+      // variable has to be removed to restore "was never set".
+      if (value === undefined) Reflect.deleteProperty(Bun.env, key);
+      else Bun.env[key] = value;
+    }
+  };
+}
+
+export type TempGitRepo = {
+  /** Absolute path to the repository working tree. */
+  directory: string;
+  /** Environment to pass to every git subprocess for this repo. */
+  env: Record<string, string | undefined>;
+  /** Run one git command in the repo, returning stdout. Throws on failure. */
+  git: (args: readonly string[]) => Promise<string>;
+  /** Remove the repository. Safe to call twice. */
+  cleanup: () => Promise<void>;
+};
+
+/**
+ * An initialized git repository in a fresh temp directory, isolated from the
+ * host's git configuration.
+ *
+ * Call `cleanup()` from `afterEach` rather than at the end of a test body: a
+ * failing assertion aborts the body, and an in-body cleanup then leaks the
+ * directory on exactly the runs you are most likely to repeat.
+ */
+export async function createTempGitRepo(
+  prefix = "test-repo-",
+): Promise<TempGitRepo> {
+  const directory = await mkdtemp(path.join(tmpdir(), prefix));
+  const env = hermeticGitEnv(directory);
+  const git = async (args: readonly string[]): Promise<string> => {
+    const child = Bun.spawn(["git", ...args], {
+      cwd: directory,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(
+        `git ${args.join(" ")} failed (${String(exitCode)}): ${stderr.trim()}`,
+      );
+    }
+    return stdout;
+  };
+  await git(["init", "--quiet", "--initial-branch", "main"]);
+  return {
+    directory,
+    env,
+    git,
+    cleanup: async () => {
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -32,5 +32,8 @@
     "ts-morph": "^28.0.0",
     "typescript": "^6.0.3",
     "@types/istanbul-lib-instrument": "1.7.8"
+  },
+  "exports": {
+    "./lib/test-git.ts": "./lib/test-git.ts"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,12 +15,13 @@
     "@openai/codex-sdk": "0.147.0",
     "@shepherdjerred/code-review": "workspace:*",
     "@shepherdjerred/version-catalog": "workspace:*",
-    "zod": "^4.4.3",
     "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.10.1",
     "fast-xml-validator": "1.4.0",
     "istanbul-lib-instrument": "6.0.3",
-    "prettier": "3.8.3"
+    "prettier": "3.8.3",
+    "yaml": "^2.8.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@shepherdjerred/eslint-config": "workspace:*",

--- a/scripts/probe-review-signal.ts
+++ b/scripts/probe-review-signal.ts
@@ -164,8 +164,12 @@ async function probePr(
             priority: thread.priority,
             isResolved: thread.isResolved,
             isOutdated: thread.isOutdated,
+            // Title and url make the dump readable on its own; without them a
+            // probe of a blocked PR says only which files were complained about.
+            title: thread.title,
             path: thread.path,
             line: thread.line,
+            url: thread.url,
           })),
         },
       },

--- a/scripts/review-findings.test.ts
+++ b/scripts/review-findings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   auditCommentBody,
+  resolveThreadOutcome,
   commentIdFromUrl,
   describeFinding,
   parseFlags,
@@ -71,6 +72,33 @@ describe("describeFinding", () => {
     });
     expect(line).toContain("P2 src/x.ts:42");
     expect(line).not.toContain("untitled");
+  });
+});
+
+describe("graphql result handling", () => {
+  test("a 200 response carrying errors is a failure, not a success", () => {
+    // GitHub GraphQL reports failure in the body with HTTP 200. Trusting the
+    // status alone would record an audit entry for a resolution that never
+    // happened — the worst outcome, since that entry is the record someone
+    // later trusts.
+    expect(
+      resolveThreadOutcome({
+        errors: [{ message: "Could not resolve to a node" }],
+      }),
+    ).toBe("Could not resolve to a node");
+  });
+
+  test("a 200 response without confirmation is also a failure", () => {
+    expect(resolveThreadOutcome({ data: null })).toContain("no confirmation");
+    expect(resolveThreadOutcome({})).toContain("no confirmation");
+  });
+
+  test("a confirmed resolution passes", () => {
+    expect(
+      resolveThreadOutcome({
+        data: { resolveReviewThread: { thread: { isResolved: true } } },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/scripts/review-findings.test.ts
+++ b/scripts/review-findings.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  auditCommentBody,
+  commentIdFromUrl,
+  describeFinding,
+  parseFlags,
+} from "./review-findings.ts";
+
+describe("commentIdFromUrl", () => {
+  test("reads the id from a comment permalink", () => {
+    expect(
+      commentIdFromUrl(
+        "https://github.com/shepherdjerred/monorepo/pull/2104#issuecomment-5248201871",
+      ),
+    ).toBe(5_248_201_871);
+  });
+
+  test("throws rather than editing an unknown comment", () => {
+    // Guessing here would PATCH whatever id happened to parse.
+    expect(() => commentIdFromUrl(null)).toThrow("could not read a comment id");
+    expect(() =>
+      commentIdFromUrl("https://github.com/o/r/pull/1#discussion_r1"),
+    ).toThrow("could not read a comment id");
+  });
+});
+
+describe("parseFlags", () => {
+  test("reads flag values", () => {
+    const flags = parseFlags(["--finding", "S3 fetch", "--reason", "fixed"]);
+    expect(flags.get("finding")).toBe("S3 fetch");
+    expect(flags.get("reason")).toBe("fixed");
+  });
+
+  test("rejects a flag with no value", () => {
+    // `--finding --reason x` would otherwise silently dismiss a finding named
+    // "--reason".
+    expect(() => parseFlags(["--finding", "--reason", "x"])).toThrow(
+      "--finding requires a value",
+    );
+  });
+});
+
+describe("describeFinding", () => {
+  test("leads with severity and the finding's title", () => {
+    const line = describeFinding({
+      authorLogin: "qodo-code-review",
+      isResolved: false,
+      isOutdated: false,
+      path: "packages/llm-observability/src/archive-uploader.ts",
+      line: null,
+      url: "https://github.com/o/r/pull/1#issuecomment-2",
+      priority: 1,
+      title: "S3 fetch lacks timeout",
+    });
+    expect(line).toContain("P1");
+    expect(line).toContain("S3 fetch lacks timeout");
+    expect(line).toContain("archive-uploader.ts");
+  });
+
+  test("identifies an untitled diff thread by location, not a placeholder", () => {
+    const line = describeFinding({
+      authorLogin: "qodo-code-review",
+      isResolved: false,
+      isOutdated: false,
+      path: "src/x.ts",
+      line: 42,
+      url: null,
+      priority: 2,
+      title: null,
+    });
+    expect(line).toContain("P2 src/x.ts:42");
+    expect(line).not.toContain("untitled");
+  });
+});
+
+describe("auditCommentBody", () => {
+  test("records every dismissal with its reason under a stable marker", () => {
+    const body = auditCommentBody([
+      { finding: "S3 fetch lacks timeout", reason: "fixed in 10224eabd" },
+      { finding: "Metrics gated to images", reason: "deliberate, test-pinned" },
+    ]);
+    expect(body).toContain("<!-- review-findings:dismissals -->");
+    expect(body).toContain("**S3 fetch lacks timeout** — fixed in 10224eabd");
+    expect(body).toContain(
+      "**Metrics gated to images** — deliberate, test-pinned",
+    );
+  });
+});

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -44,6 +44,16 @@ const AUDIT_MARKER = "<!-- review-findings:dismissals -->";
 
 const PrSchema = z.object({ head: z.object({ sha: z.string() }) });
 const CommentSchema = z.object({ id: z.number(), body: z.string() });
+const GraphqlResponseSchema = z.object({
+  errors: z.array(z.object({ message: z.string() }).loose()).optional(),
+  data: z
+    .object({
+      resolveReviewThread: z
+        .object({ thread: z.object({ isResolved: z.boolean() }).loose() })
+        .nullish(),
+    })
+    .nullish(),
+});
 
 function requireToken(): string {
   const token = Bun.env["GH_TOKEN"];
@@ -82,6 +92,24 @@ async function githubJson(
     );
   }
   return await response.json();
+}
+
+/**
+ * Why a resolveReviewThread mutation did not succeed, or null when it did.
+ *
+ * GraphQL reports failure in the body with HTTP 200, so a status check alone
+ * would let a failed resolution be recorded as a dismissal — and that audit
+ * entry is what someone later trusts.
+ */
+export function resolveThreadOutcome(payload: unknown): string | null {
+  const parsed = GraphqlResponseSchema.parse(payload);
+  if (parsed.errors !== undefined && parsed.errors.length > 0) {
+    return parsed.errors.map((error) => error.message).join("; ");
+  }
+  if (parsed.data?.resolveReviewThread?.thread.isResolved !== true) {
+    return "the mutation returned no confirmation that the thread is resolved";
+  }
+  return null;
 }
 
 /**
@@ -224,6 +252,14 @@ async function dismissCommand(
       'dismiss requires --finding "<title>" and a non-empty --reason "<why>".',
     );
   }
+  // The edit understands Qodo's rendered-comment format specifically. Another
+  // provider's comment would not match, and the "no finding titled …" error
+  // that produced would be misleading — say what is actually unsupported.
+  if (provider.id !== "qodo") {
+    throw new Error(
+      `dismiss only understands Qodo's review comment format; ${provider.displayName} findings must be resolved through their own threads (see \`resolve-thread\`).`,
+    );
+  }
   const state = await resolveReviewState({
     repo,
     prNumber,
@@ -261,6 +297,34 @@ async function dismissCommand(
   console.log(`Dismissed "${finding}" and recorded the reason on the PR.`);
 }
 
+/**
+ * The audit comment, searched across every page.
+ *
+ * A single page is not enough: a long-lived PR easily passes 100 comments, and
+ * missing the existing comment does not fail — it silently posts a second one,
+ * splitting the dismissal record across two places just when it matters.
+ */
+async function findAuditComment(
+  repo: string,
+  prNumber: number,
+  token: string,
+): Promise<{ id: number; body: string } | undefined> {
+  for (let page = 1; ; page += 1) {
+    const batch = z
+      .array(CommentSchema.loose())
+      .parse(
+        await githubJson(
+          "GET",
+          `${GITHUB_API}/repos/${repo}/issues/${String(prNumber)}/comments?per_page=100&page=${String(page)}`,
+          token,
+        ),
+      );
+    const found = batch.find((comment) => comment.body.includes(AUDIT_MARKER));
+    if (found !== undefined) return found;
+    if (batch.length < 100) return undefined;
+  }
+}
+
 /** Append to the single audit comment, creating it on the first dismissal. */
 async function recordDismissal(
   repo: string,
@@ -268,18 +332,7 @@ async function recordDismissal(
   token: string,
   entry: { finding: string; reason: string },
 ): Promise<void> {
-  const comments = z
-    .array(CommentSchema.loose())
-    .parse(
-      await githubJson(
-        "GET",
-        `${GITHUB_API}/repos/${repo}/issues/${String(prNumber)}/comments?per_page=100`,
-        token,
-      ),
-    );
-  const existing = comments.find((comment) =>
-    comment.body.includes(AUDIT_MARKER),
-  );
+  const existing = await findAuditComment(repo, prNumber, token);
   const previous = (existing?.body ?? "")
     .split("\n")
     .filter((line) => line.startsWith("- **"))
@@ -340,6 +393,10 @@ async function resolveThreadCommand(
     throw new Error(
       `resolveReviewThread failed: ${String(response.status)} ${response.statusText}`,
     );
+  }
+  const failure = resolveThreadOutcome(await response.json());
+  if (failure !== null) {
+    throw new Error(`resolveReviewThread failed for ${threadId}: ${failure}`);
   }
   await recordDismissal(repo, prNumber, token, {
     finding: `thread ${threadId}`,

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -1,0 +1,394 @@
+#!/usr/bin/env bun
+/**
+ * Inspect and clear what the required review gate is blocking on.
+ *
+ * Two things make this necessary. Qodo does not strike a finding it has
+ * re-read and no longer stands behind — it re-lists it verbatim — so a PR
+ * whose findings are all fixed or all wrong can stay blocked through any
+ * number of re-reviews. And a fix pushed without resolving its thread costs a
+ * full gate cycle (~7 minutes) to discover, because nothing surfaces the
+ * unresolved thread earlier.
+ *
+ * `list` is the pre-push check for the second problem. `dismiss` is the
+ * audited escape hatch for the first: it never runs on its own, requires a
+ * reason per finding, and records every dismissal in a PR comment so the
+ * decision is reviewable rather than an invisible edit to a bot's comment.
+ *
+ * Usage:
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-findings.ts list 2104
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-findings.ts dismiss 2104 \
+ *     --finding "S3 fetch lacks timeout" --reason "fixed in 10224eabd"
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-findings.ts resolve-thread 2104 \
+ *     --thread PRRT_kwDO… --reason "fixed in e4ec2f6db"
+ */
+import {
+  isBlocking,
+  markQodoFindingResolved,
+  resolveProvider,
+  resolveRequiredReviewProvider,
+  severityLabel,
+  type ReviewProvider,
+  type ReviewThread,
+} from "@shepherdjerred/code-review";
+import {
+  fetchReviewThreads,
+  resolveReviewState,
+} from "@shepherdjerred/code-review/github";
+import { z } from "zod";
+
+const DEFAULT_REPO = "shepherdjerred/monorepo";
+const GITHUB_API = "https://api.github.com";
+/** Matches the CI gate's default, so `list` reports what the gate will block on. */
+const MAX_BLOCKING_PRIORITY = 3;
+const AUDIT_MARKER = "<!-- review-findings:dismissals -->";
+
+const PrSchema = z.object({ head: z.object({ sha: z.string() }) });
+const CommentSchema = z.object({ id: z.number(), body: z.string() });
+
+function requireToken(): string {
+  const token = Bun.env["GH_TOKEN"];
+  if (token === undefined || token.trim() === "") {
+    throw new Error("GH_TOKEN is required (GH_TOKEN=$(gh auth token)).");
+  }
+  return token;
+}
+
+function activeProvider(): ReviewProvider {
+  const configured = Bun.env["REVIEW_PROVIDER"];
+  return configured === undefined || configured.trim() === ""
+    ? resolveRequiredReviewProvider()
+    : resolveProvider(configured);
+}
+
+async function githubJson(
+  method: "GET" | "POST" | "PATCH",
+  url: string,
+  token: string,
+  body?: unknown,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(body === undefined ? {} : { "Content-Type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${url} failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return await response.json();
+}
+
+/**
+ * The numeric id of the comment behind an `html_url`. The library models a
+ * review comment by body/url because reading never needs the id; editing does.
+ */
+export function commentIdFromUrl(url: string | null): number {
+  const matched = /#issuecomment-(\d+)/u.exec(url ?? "");
+  const id = matched?.[1];
+  if (id === undefined) {
+    throw new Error(
+      `could not read a comment id from ${url ?? "(no url)"} — expected an #issuecomment-<id> anchor`,
+    );
+  }
+  return Number.parseInt(id, 10);
+}
+
+/**
+ * One line per finding: severity, what it is, and where to read it.
+ *
+ * Only comment-parsed findings carry a title; a thread opened on the diff is
+ * identified by its location instead, so it leads with that rather than a
+ * placeholder that says nothing.
+ */
+export function describeFinding(thread: ReviewThread): string {
+  const severity = severityLabel(thread.priority);
+  const location =
+    thread.path === null
+      ? "(general comment)"
+      : thread.line === null
+        ? thread.path
+        : `${thread.path}:${String(thread.line)}`;
+  const headline =
+    thread.title === null ? location : `${thread.title} — ${location}`;
+  const url = thread.url === null ? "" : `\n      ${thread.url}`;
+  return `  ${severity} ${headline}${url}`;
+}
+
+/** The audit comment body, rebuilt from every dismissal recorded so far. */
+export function auditCommentBody(
+  entries: readonly { finding: string; reason: string }[],
+): string {
+  const rows = entries
+    .map((entry) => `- **${entry.finding}** — ${entry.reason}`)
+    .join("\n");
+  return (
+    `${AUDIT_MARKER}\n### Review findings dismissed by an operator\n\n` +
+    `Each entry was marked resolved in the review comment after being verified ` +
+    `fixed at this head or incorrect. The gate honours the resolved state, so ` +
+    `this comment is the record of why.\n\n${rows}\n`
+  );
+}
+
+export function parseFlags(args: readonly string[]): Map<string, string> {
+  const flags = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument?.startsWith("--") !== true) continue;
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value`);
+    }
+    flags.set(argument.slice(2), value);
+    index += 1;
+  }
+  return flags;
+}
+
+async function loadThreads(
+  repo: string,
+  prNumber: number,
+  token: string,
+  provider: ReviewProvider,
+): Promise<{ head: string; threads: readonly ReviewThread[] }> {
+  const pr = PrSchema.parse(
+    await githubJson(
+      "GET",
+      `${GITHUB_API}/repos/${repo}/pulls/${String(prNumber)}`,
+      token,
+    ),
+  );
+  const head = pr.head.sha;
+  const state = await resolveReviewState({
+    repo,
+    prNumber,
+    token,
+    provider,
+    head,
+    headPushedAt: null,
+  });
+  const result = await fetchReviewThreads({
+    repo,
+    number: prNumber,
+    token,
+    provider,
+    issueComment: state.issueComment,
+  });
+  return { head, threads: result.threads };
+}
+
+async function listCommand(
+  repo: string,
+  prNumber: number,
+  token: string,
+  provider: ReviewProvider,
+): Promise<void> {
+  const { head, threads } = await loadThreads(repo, prNumber, token, provider);
+  const blocking = threads.filter((thread) =>
+    isBlocking(thread, provider, MAX_BLOCKING_PRIORITY),
+  );
+  console.log(
+    `${provider.displayName} on ${repo}#${String(prNumber)} @ ${head.slice(0, 9)}`,
+  );
+  if (blocking.length === 0) {
+    console.log("\nNothing is blocking the gate.");
+    return;
+  }
+  console.log(`\n${String(blocking.length)} blocking finding(s):`);
+  for (const thread of blocking) console.log(describeFinding(thread));
+  console.log(
+    `\nFix and re-request a review, or — once verified fixed or incorrect — ` +
+      `dismiss with:\n  bun scripts/review-findings.ts dismiss ${String(prNumber)} --finding "<title>" --reason "<why>"`,
+  );
+}
+
+async function dismissCommand(
+  context: {
+    repo: string;
+    prNumber: number;
+    token: string;
+    provider: ReviewProvider;
+  },
+  flags: Map<string, string>,
+): Promise<void> {
+  const { repo, prNumber, token, provider } = context;
+  const finding = flags.get("finding");
+  const reason = flags.get("reason");
+  if (finding === undefined || reason === undefined || reason.trim() === "") {
+    throw new Error(
+      'dismiss requires --finding "<title>" and a non-empty --reason "<why>".',
+    );
+  }
+  const state = await resolveReviewState({
+    repo,
+    prNumber,
+    token,
+    provider,
+    head: PrSchema.parse(
+      await githubJson(
+        "GET",
+        `${GITHUB_API}/repos/${repo}/pulls/${String(prNumber)}`,
+        token,
+      ),
+    ).head.sha,
+    headPushedAt: null,
+  });
+  const review = state.issueComment;
+  if (review === null || review === undefined) {
+    throw new Error(
+      `${provider.displayName} has posted no review comment on ${repo}#${String(prNumber)}.`,
+    );
+  }
+  const edited = markQodoFindingResolved(review.body, finding);
+  if (edited === null) {
+    throw new Error(
+      `no finding titled "${finding}" in the review comment. Run \`list\` to see the exact titles.`,
+    );
+  }
+  const commentId = commentIdFromUrl(review.url);
+  await githubJson(
+    "PATCH",
+    `${GITHUB_API}/repos/${repo}/issues/comments/${String(commentId)}`,
+    token,
+    { body: edited },
+  );
+  await recordDismissal(repo, prNumber, token, { finding, reason });
+  console.log(`Dismissed "${finding}" and recorded the reason on the PR.`);
+}
+
+/** Append to the single audit comment, creating it on the first dismissal. */
+async function recordDismissal(
+  repo: string,
+  prNumber: number,
+  token: string,
+  entry: { finding: string; reason: string },
+): Promise<void> {
+  const comments = z
+    .array(CommentSchema.loose())
+    .parse(
+      await githubJson(
+        "GET",
+        `${GITHUB_API}/repos/${repo}/issues/${String(prNumber)}/comments?per_page=100`,
+        token,
+      ),
+    );
+  const existing = comments.find((comment) =>
+    comment.body.includes(AUDIT_MARKER),
+  );
+  const previous = (existing?.body ?? "")
+    .split("\n")
+    .filter((line) => line.startsWith("- **"))
+    .map((line) => {
+      const matched = /^- \*\*(.+?)\*\* — (.+)$/u.exec(line);
+      return matched === null
+        ? null
+        : { finding: matched[1] ?? "", reason: matched[2] ?? "" };
+    })
+    .filter((value) => value !== null);
+  const body = auditCommentBody([
+    ...previous.filter((item) => item.finding !== entry.finding),
+    entry,
+  ]);
+  if (existing === undefined) {
+    await githubJson(
+      "POST",
+      `${GITHUB_API}/repos/${repo}/issues/${String(prNumber)}/comments`,
+      token,
+      { body },
+    );
+    return;
+  }
+  await githubJson(
+    "PATCH",
+    `${GITHUB_API}/repos/${repo}/issues/comments/${String(existing.id)}`,
+    token,
+    { body },
+  );
+}
+
+async function resolveThreadCommand(
+  repo: string,
+  prNumber: number,
+  token: string,
+  flags: Map<string, string>,
+): Promise<void> {
+  const threadId = flags.get("thread");
+  const reason = flags.get("reason");
+  if (threadId === undefined || reason === undefined || reason.trim() === "") {
+    throw new Error(
+      'resolve-thread requires --thread <id> and a non-empty --reason "<why>".',
+    );
+  }
+  const response = await fetch(`${GITHUB_API}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query:
+        "mutation($id: ID!) { resolveReviewThread(input: {threadId: $id}) { thread { isResolved } } }",
+      variables: { id: threadId },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `resolveReviewThread failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  await recordDismissal(repo, prNumber, token, {
+    finding: `thread ${threadId}`,
+    reason,
+  });
+  console.log(`Resolved ${threadId} and recorded the reason on the PR.`);
+}
+
+function usage(): never {
+  console.error(
+    [
+      "Usage:",
+      "  bun scripts/review-findings.ts list <pr>",
+      '  bun scripts/review-findings.ts dismiss <pr> --finding "<title>" --reason "<why>"',
+      '  bun scripts/review-findings.ts resolve-thread <pr> --thread <id> --reason "<why>"',
+      "",
+      "GH_TOKEN is required. REVIEW_PROVIDER overrides the gate's provider.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const [command, prArgument, ...rest] = Bun.argv.slice(2);
+  if (command === undefined || prArgument === undefined) usage();
+  const prNumber = Number.parseInt(prArgument, 10);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error(`"${prArgument}" is not a pull request number.`);
+  }
+  const repo = Bun.env["GITHUB_REPOSITORY"] ?? DEFAULT_REPO;
+  const token = requireToken();
+  const provider = activeProvider();
+  const flags = parseFlags(rest);
+
+  switch (command) {
+    case "list":
+      await listCommand(repo, prNumber, token, provider);
+      return;
+    case "dismiss":
+      await dismissCommand({ repo, prNumber, token, provider }, flags);
+      return;
+    case "resolve-thread":
+      await resolveThreadCommand(repo, prNumber, token, flags);
+      return;
+    default:
+      usage();
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -280,13 +280,24 @@ async function dismissCommand(
       `${provider.displayName} has posted no review comment on ${repo}#${String(prNumber)}.`,
     );
   }
-  const edited = markQodoFindingResolved(review.body, finding);
+  const commentId = commentIdFromUrl(review.url);
+  // Re-read immediately before editing rather than trusting the snapshot
+  // resolveReviewState fetched. The PATCH replaces the whole body, so a
+  // re-review landing in between would be silently overwritten — erasing
+  // findings Qodo had just reported.
+  const fresh = CommentSchema.loose().parse(
+    await githubJson(
+      "GET",
+      `${GITHUB_API}/repos/${repo}/issues/comments/${String(commentId)}`,
+      token,
+    ),
+  );
+  const edited = markQodoFindingResolved(fresh.body, finding);
   if (edited === null) {
     throw new Error(
       `no finding titled "${finding}" in the review comment. Run \`list\` to see the exact titles.`,
     );
   }
-  const commentId = commentIdFromUrl(review.url);
   await githubJson(
     "PATCH",
     `${GITHUB_API}/repos/${repo}/issues/comments/${String(commentId)}`,
@@ -364,6 +375,61 @@ async function recordDismissal(
   );
 }
 
+const ThreadOwnerSchema = z.object({
+  data: z
+    .object({
+      node: z
+        .object({
+          pullRequest: z.object({
+            number: z.number(),
+            repository: z.object({ nameWithOwner: z.string() }),
+          }),
+        })
+        .nullish(),
+    })
+    .nullish(),
+});
+
+async function assertThreadBelongsToPr(input: {
+  repo: string;
+  prNumber: number;
+  token: string;
+  threadId: string;
+}): Promise<void> {
+  const response = await fetch(`${GITHUB_API}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query:
+        "query($id: ID!) { node(id: $id) { ... on PullRequestReviewThread { pullRequest { number repository { nameWithOwner } } } } }",
+      variables: { id: input.threadId },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `could not read thread ${input.threadId}: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  const owner = ThreadOwnerSchema.parse(await response.json()).data?.node
+    ?.pullRequest;
+  if (owner === undefined) {
+    throw new Error(
+      `${input.threadId} is not a pull request review thread on ${input.repo}.`,
+    );
+  }
+  if (
+    owner.number !== input.prNumber ||
+    owner.repository.nameWithOwner !== input.repo
+  ) {
+    throw new Error(
+      `${input.threadId} belongs to ${owner.repository.nameWithOwner}#${String(owner.number)}, not ${input.repo}#${String(input.prNumber)}.`,
+    );
+  }
+}
+
 async function resolveThreadCommand(
   repo: string,
   prNumber: number,
@@ -377,6 +443,10 @@ async function resolveThreadCommand(
       'resolve-thread requires --thread <id> and a non-empty --reason "<why>".',
     );
   }
+  // A thread id copied from another PR is a valid node id, so resolving it
+  // blind would close an unrelated thread and record the dismissal against
+  // this PR. Confirm ownership before mutating anything.
+  await assertThreadBelongsToPr({ repo, prNumber, token, threadId });
   const response = await fetch(`${GITHUB_API}/graphql`, {
     method: "POST",
     headers: {

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -298,13 +298,19 @@ async function dismissCommand(
       `no finding titled "${finding}" in the review comment. Run \`list\` to see the exact titles.`,
     );
   }
+  // Record the reason BEFORE clearing the gate. The dangerous half-completed
+  // state is "finding dismissed, no record of why" — a transient failure on
+  // the second write would otherwise leave exactly that. This ordering can
+  // only leave the opposite: a recorded intent whose edit failed, which the
+  // thrown error reports and a re-run makes good, since both writes are
+  // idempotent.
+  await recordDismissal(repo, prNumber, token, { finding, reason });
   await githubJson(
     "PATCH",
     `${GITHUB_API}/repos/${repo}/issues/comments/${String(commentId)}`,
     token,
     { body: edited },
   );
-  await recordDismissal(repo, prNumber, token, { finding, reason });
   console.log(`Dismissed "${finding}" and recorded the reason on the PR.`);
 }
 
@@ -468,10 +474,20 @@ async function resolveThreadCommand(
   if (failure !== null) {
     throw new Error(`resolveReviewThread failed for ${threadId}: ${failure}`);
   }
-  await recordDismissal(repo, prNumber, token, {
-    finding: `thread ${threadId}`,
-    reason,
-  });
+  // Unlike the comment edit, the mutation has already happened by here, so
+  // this write is the one that can strand a resolution without its reason.
+  // Surface that specifically rather than as a bare API error.
+  try {
+    await recordDismissal(repo, prNumber, token, {
+      finding: `thread ${threadId}`,
+      reason,
+    });
+  } catch (error: unknown) {
+    throw new Error(
+      `${threadId} was resolved but its reason could not be recorded — add it to the audit comment by hand`,
+      { cause: error },
+    );
+  }
   console.log(`Resolved ${threadId} and recorded the reason on the PR.`);
 }
 

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { hermeticGitEnv } from "./lib/test-git.ts";
 
 import {
   generatedBuildNumberFromSubject,
@@ -67,6 +68,8 @@ function batch(
 
 async function git(repo: string, args: string[]): Promise<string> {
   const proc = Bun.spawn(["git", "-C", repo, ...args], {
+    // Isolated from the operator's ~/.gitconfig — see hermeticGitEnv.
+    env: hermeticGitEnv(repo),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -7,6 +7,7 @@ const turboTasks = [
   "check-suppressions",
   "check-ai-architecture",
   "check-patched-deps",
+  "check-ci-env",
   "check-script-migrations",
   "script-coverage",
   "markdownlint",

--- a/turbo.json
+++ b/turbo.json
@@ -106,6 +106,18 @@
         ".buildkite/scripts/select-image-targets.ts"
       ]
     },
+    // Every env var a pipeline step's scripts require must be provided by that
+    // step. Reads the committed vault snapshot (hashes only), never 1Password.
+    "//#check-ci-env": {
+      "inputs": [
+        ".buildkite/pipeline.yml",
+        "scripts/**",
+        "!scripts/node_modules/**",
+        "packages/homelab/scripts/**",
+        "packages/homelab/src/cdk8s/onepassword-vault-snapshot.json",
+        "packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts"
+      ]
+    },
     "//#check-script-migrations": {
       "inputs": [
         "scripts/script-migrations.json",

--- a/turbo.json
+++ b/turbo.json
@@ -109,8 +109,13 @@
     // Every env var a pipeline step's scripts require must be provided by that
     // step. Reads the committed vault snapshot (hashes only), never 1Password.
     "//#check-ci-env": {
+      // Every tree requiredEnvFrom may analyze has to be hashed, not just the
+      // pipeline: the checker treats literal `.buildkite/scripts/*.ts`
+      // commands as entry points and follows their imports, so a requireEnv
+      // added there would otherwise reuse a green cached result.
       "inputs": [
         ".buildkite/pipeline.yml",
+        ".buildkite/scripts/**",
         "scripts/**",
         "!scripts/node_modules/**",
         "packages/homelab/scripts/**",


### PR DESCRIPTION
## Why

Landing #2104 took most of a session, and most of that time went to problems
this repo's own tooling could have caught. Four of them, each fixed here:

1. **A missing CI credential was invisible to every gate.** `scripts/release.ts`
   requires `CODEX_ACCESS_TOKEN`, but the `buildkite-ci-secrets` item had no such
   field. `bun run verify` was green throughout; the first `main` build after
   merge would have failed at the release step. The cdk8s linter cannot see this
   — it understands `secretKeyRef` and volume `items[].key`, while Buildkite
   steps take the whole secret via `envFrom`, so exactly one key of that item was
   under its coverage.
2. **The review gate could not converge, and would not say what it wanted.**
   Qodo re-lists a finding verbatim rather than striking it once fixed, so
   clearing the gate meant hand-editing the bot's comment with `gh api PATCH`.
   The failure output listed `path — url` with no finding titles.
3. **Tests were not hermetic, and global OpenTelemetry state leaked between
   files.** A disabled-but-registered context manager wedged eight unrelated
   tests into 5s timeouts; git tests inherited the operator's `~/.gitconfig`.
4. **Vault snapshot staleness was invisible**, so a clean 1Password check on an
   old snapshot read as "the vault agrees" when it only meant "nothing
   contradicts an old record".

## What

Eight commits, each independently reviewable:

| Commit | Change |
| --- | --- |
| `fix(homelab)` | `check:1password` turbo inputs missed `onepassword-lib.ts`, so lib edits never invalidated the cache |
| `feat(root)` | **`scripts/check-ci-env.ts`** — per pipeline step, the env its scripts require vs. what the step provides |
| `feat(code-review)` | gate failure output names the finding, not just its path |
| `feat(root)` | **`scripts/review-findings.ts`** — list blocking findings; dismiss one with a mandatory reason, recorded on the PR |
| `fix(llm-observability)` | one shared `resetOtelGlobals()`; fix three real registration leaks |
| `test(root)` | git tests isolated from the host's git config; cleanup moved to `afterEach` |
| `feat(homelab)` | warn when the vault snapshot is too old to be evidence |
| `fix(pr-fleet-controller)` | unregister the tracer provider on telemetry shutdown (completes #2104's half-fix) |

### `check-ci-env` in a bit more detail

Requirements come from `ts-morph`, following relative imports and counting only
`requireEnv` imported from `scripts/lib/run.ts` — five unrelated helpers share
that name with different contracts, so the import is resolved rather than the
name grepped. Provisions come from the vault snapshot (hashes only, no
1Password access), the step's `env`, container env, the pipeline's global env,
and names the command assigns itself, because steps routinely rename a secret
key into what a script expects (`export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID"`).

A field present but **blank** is reported too — the operator skips empty
fields, so it is as absent at runtime as a missing one. A non-literal
`requireEnv` argument is an error rather than a silent skip. Two exceptions are
declared, both because the analysis is flow-insensitive, each with its reason
in the table.

## Verification

- `bun scripts/check-ci-env.ts` — OK across 29 steps / 61 script invocations.
  **Removing `CLAUDE_CODE_OAUTH_TOKEN` from a local snapshot copy fails the
  check**, naming both steps that run `scripts/release.ts` and the exact call
  site — i.e. it catches the real regression class it exists for.
- **Hermeticity proved against a hostile global git config** (`commit.gpgsign`,
  `core.hooksPath`, an unexpandable `excludesfile`): the pre-fix
  scout-season-refresh-git suite fails 2 of 11 tests, and passes 11/11 after.
- `bun run test` in `scripts` — 569 pass, including the `select-image-targets`
  attribution test. That test caught a first attempt at the git helper that made
  every `scripts/package.json` change rebuild the temporal-worker image; the
  cross-package dependency was dropped rather than the invariant weakened.
- `bunx turbo run typecheck lint test check-ci-env check:1password` across
  root-scripts, code-review, llm-observability, pr-fleet-controller,
  homelab/cdk8s and scout backend — all pass.
- `review-findings list` exercised read-only against live PRs 2224, 2217, 2216,
  2104 and 2095. `dismiss` was **not** run against a live PR.
- Rebased onto `main` **after #2104 merged** and re-verified: 31/31 turbo tasks
  uncached. With #2104's `requireEnv("CODEX_ACCESS_TOKEN")` now on `main`,
  `check-ci-env` passes — and deleting that field from a local snapshot copy
  makes it fail, naming both steps that run `release.ts`. That is the original
  regression, caught offline.
- The tracer-provider fix is pinned by a test that **fails without it**
  ("OpenTelemetry tracer provider is already registered") and asserts the second
  runtime's span lands in its own `spans.jsonl` rather than the dead processor.

## Follow-ups, deliberately not in this PR

- **The 1Password Connect drift job.** The plan was to give the Temporal worker
  a Connect credential declared as a `secretKeyRef` (so `check-1password-items`
  lints it like every other secret) and schedule a snapshot-drift PR job. The
  homelab already runs Connect and `snapshot-1password-vault.ts` already
  supports it, so no `op` service account is needed — but the credential does
  not exist yet, and adding the ref turns `check:1password` red until an
  operator mints a read-only Connect token scoped to the vault. The staleness
  warning shipped here is the independently-valuable half. Wiring is a small
  follow-up once the token exists.
- `pr-fleet-controller/test/environment.test.ts` and the Pokémon
  benchmark-harness build temp git repos the same way; they are latent rather
  than failing, so they were left rather than widening this change.
