### PR TITLE
feat(scout-for-lol): add player profile and match history

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/champion-icon.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/champion-icon.tsx
@@ -1,0 +1,38 @@
+import {
+  championNameToDisplayName,
+  getChampionImageUrl,
+} from "@scout-for-lol/data";
+import { cn } from "#src/lib/cn.ts";
+
+/**
+ * The app's first browser-side Data Dragon asset.
+ *
+ * `champion.json` is already in this bundle (report-query-champions.ts parses
+ * it for the champion combobox), so the icon costs no extra bundle weight —
+ * `getChampionImageUrl` only builds a CDN URL.
+ *
+ * Champion names on match data are Data Dragon asset keys, so the key goes to
+ * the image lookup while every visible label goes through
+ * `championNameToDisplayName` (the difference between "MonkeyKing" and
+ * "Wukong").
+ */
+export function ChampionIcon(props: {
+  championName: string;
+  size?: "sm" | "md";
+  className?: string;
+}) {
+  const display = championNameToDisplayName(props.championName);
+  const pixels = props.size === "md" ? 40 : 32;
+
+  return (
+    <img
+      src={getChampionImageUrl(props.championName)}
+      alt={display}
+      title={display}
+      width={pixels}
+      height={pixels}
+      loading="lazy"
+      className={cn("rounded-md bg-muted", props.className)}
+    />
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
@@ -3,14 +3,13 @@ import {
   rankToString,
   type Rank,
 } from "@scout-for-lol/data";
-import { ChampionIcon } from "#src/components/champion-icon.tsx";
-import { Badge } from "#src/components/ui/badge.tsx";
+import { Badge } from "@scout-for-lol/design-system/components/badge";
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
-} from "#src/components/ui/card.tsx";
+} from "@scout-for-lol/design-system/components/card";
 import {
   Table,
   TableBody,
@@ -18,7 +17,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "#src/components/ui/table.tsx";
+} from "@scout-for-lol/design-system/components/table";
+import { ChampionIcon } from "#src/components/champion-icon.tsx";
 
 export function formatPercent(value: number | null): string {
   return value === null ? "—" : `${Math.round(value * 100).toString()}%`;

--- a/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
@@ -1,0 +1,264 @@
+import {
+  championNameToDisplayName,
+  rankToString,
+  type Rank,
+} from "@scout-for-lol/data";
+import { ChampionIcon } from "#src/components/champion-icon.tsx";
+import { Badge } from "#src/components/ui/badge.tsx";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "#src/components/ui/card.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "#src/components/ui/table.tsx";
+
+export function formatPercent(value: number | null): string {
+  return value === null ? "—" : `${Math.round(value * 100).toString()}%`;
+}
+
+function formatKda(kills: number, deaths: number, assists: number): string {
+  const value = deaths === 0 ? kills + assists : (kills + assists) / deaths;
+  return value.toFixed(2);
+}
+
+function formatRelative(epochMs: number): string {
+  const days = Math.floor((Date.now() - epochMs) / 86_400_000);
+  if (days <= 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days.toString()}d ago`;
+  return new Date(epochMs).toLocaleDateString();
+}
+
+export function RankCard(props: { label: string; rank: Rank | undefined }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {props.label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-lg font-semibold">
+          {props.rank === undefined ? "Unranked" : rankToString(props.rank)}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+type RecentForm = {
+  games: number;
+  wins: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  averageKillParticipation: number | null;
+};
+
+export function RecentFormCard(props: { form: RecentForm }) {
+  const { form } = props;
+  const losses = form.games - form.wins;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          Last {form.games.toString()} games
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        <p className="text-lg font-semibold">
+          {form.wins.toString()}W {losses.toString()}L
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            {formatPercent(form.games > 0 ? form.wins / form.games : null)}
+          </span>
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {formatKda(form.kills, form.deaths, form.assists)} KDA ·{" "}
+          {formatPercent(form.averageKillParticipation)} kill participation
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+type ChampionRow = {
+  championId: number;
+  championName: string;
+  games: number;
+  wins: number;
+  winRate: number;
+  kda: number;
+  csPerMinute: number;
+  lowSample: boolean;
+};
+
+export function ChampionPoolTable(props: {
+  rows: ChampionRow[];
+  minGamesForRate: number;
+}) {
+  if (props.rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No games in Scout&apos;s history for this player yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Champion</TableHead>
+            <TableHead className="text-right">Games</TableHead>
+            <TableHead className="text-right">Win rate</TableHead>
+            <TableHead className="text-right">KDA</TableHead>
+            <TableHead className="text-right">CS/min</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {props.rows.map((row) => (
+            <TableRow key={row.championId}>
+              <TableCell>
+                <span className="flex items-center gap-2">
+                  <ChampionIcon championName={row.championName} />
+                  {championNameToDisplayName(row.championName)}
+                </span>
+              </TableCell>
+              <TableCell className="text-right">
+                {row.games.toString()}
+              </TableCell>
+              <TableCell className="text-right">
+                {/* A rate over a handful of games is noise; say so rather than
+                    printing a confident number next to a real one. */}
+                {row.lowSample ? (
+                  <span className="text-muted-foreground">
+                    {formatPercent(row.winRate)}*
+                  </span>
+                ) : (
+                  formatPercent(row.winRate)
+                )}
+              </TableCell>
+              <TableCell className="text-right">{row.kda.toFixed(2)}</TableCell>
+              <TableCell className="text-right">
+                {row.csPerMinute.toFixed(1)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {props.rows.some((row) => row.lowSample) && (
+        <p className="text-xs text-muted-foreground">
+          * Fewer than {props.minGamesForRate.toString()} games — treat the rate
+          as indicative only.
+        </p>
+      )}
+    </div>
+  );
+}
+
+type MatchEntry = {
+  matchId: string;
+  gameCreationMs: number;
+  gameDurationSeconds: number;
+  queue: string | null;
+  championName: string;
+  teamPosition: string;
+  win: boolean;
+  kills: number;
+  deaths: number;
+  assists: number;
+  creepScore: number;
+  csPerMinute: number;
+  killParticipation: number | null;
+  leaguePointsDelta: number | null;
+};
+
+function LeaguePointsBadge(props: { delta: number | null }) {
+  if (props.delta === null) return null;
+  const positive = props.delta >= 0;
+  return (
+    <span
+      className={
+        positive
+          ? "text-xs font-medium text-emerald-600 dark:text-emerald-400"
+          : "text-xs font-medium text-red-600 dark:text-red-400"
+      }
+    >
+      {positive ? "+" : ""}
+      {props.delta.toString()} LP
+    </span>
+  );
+}
+
+export function MatchHistoryList(props: { entries: MatchEntry[] }) {
+  if (props.entries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Scout hasn&apos;t recorded any games for this player yet.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {props.entries.map((entry) => (
+        <li
+          key={entry.matchId}
+          className={`flex flex-wrap items-center gap-3 rounded-md border p-3 ${
+            entry.win
+              ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30"
+              : "border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/30"
+          }`}
+        >
+          <ChampionIcon championName={entry.championName} size="md" />
+          <div className="min-w-32">
+            <p className="text-sm font-medium">
+              {entry.win ? "Victory" : "Defeat"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {entry.queue ?? "Unknown queue"} ·{" "}
+              {Math.round(entry.gameDurationSeconds / 60).toString()}m ·{" "}
+              {formatRelative(entry.gameCreationMs)}
+            </p>
+          </div>
+          <div className="min-w-28">
+            <p className="text-sm font-medium">
+              {entry.kills.toString()} / {entry.deaths.toString()} /{" "}
+              {entry.assists.toString()}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {formatKda(entry.kills, entry.deaths, entry.assists)} KDA
+            </p>
+          </div>
+          <div className="min-w-28">
+            <p className="text-sm">
+              {entry.creepScore.toString()} CS
+              <span className="text-muted-foreground">
+                {" "}
+                ({entry.csPerMinute.toFixed(1)}/m)
+              </span>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {formatPercent(entry.killParticipation)} KP
+            </p>
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            {entry.teamPosition.length > 0 && (
+              <Badge variant="outline">{entry.teamPosition}</Badge>
+            )}
+            <LeaguePointsBadge delta={entry.leaguePointsDelta} />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/player-tabs-nav.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-tabs-nav.tsx
@@ -1,0 +1,38 @@
+import { NavLink } from "react-router";
+import { cn } from "#src/lib/cn.ts";
+
+/**
+ * Profile / Manage switcher for a player.
+ *
+ * These are routes rather than local tab state so a profile is linkable — the
+ * point of the surface is that someone pastes it into Discord.
+ */
+export function PlayerTabsNav(props: { guildId: string; alias: string }) {
+  const base = `/g/${props.guildId}/players/${encodeURIComponent(props.alias)}`;
+  const tabs = [
+    { to: base, label: "Profile", end: true },
+    { to: `${base}/manage`, label: "Manage", end: false },
+  ];
+
+  return (
+    <nav className="flex flex-wrap gap-2 border-b border-border pb-2">
+      {tabs.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.end}
+          className={({ isActive }) =>
+            cn(
+              "rounded-md px-3 py-2 text-sm font-medium",
+              isActive
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            )
+          }
+        >
+          {tab.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
@@ -159,6 +159,11 @@ describe("normalizePath", () => {
     expect(normalizePath("/g/123/players/SomeAlias")).toBe(
       "/g/:guildId/players/:alias",
     );
+    // The manage tab is a sub-route; knownRoute is a closed allowlist, so
+    // omitting it would report every manage pageview as /not-found.
+    expect(normalizePath("/g/123/players/SomeAlias/manage")).toBe(
+      "/g/:guildId/players/:alias/manage",
+    );
     expect(normalizePath("/g/123/reports/45/edit")).toBe(
       "/g/:guildId/reports/:reportId/edit",
     );

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.ts
@@ -448,7 +448,7 @@ export function normalizePath(pathname: string): string {
     .replace(/^\/explore\/s\/[^/]+/, "/explore/s/:shareToken")
     .replace(/^\/explore\/(?!s(?:\/|$))[^/]+/, "/explore/:conversationId");
   const knownRoute =
-    /^(?:\/|\/(?:login|welcome|installed)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
+    /^(?:\/|\/(?:login|welcome|installed)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
   return knownRoute.test(normalized) ? normalized : "/not-found";
 }
 

--- a/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
@@ -81,6 +81,18 @@ export function playerDetailLoader({ params }: LoaderFunctionArgs): null {
   return null;
 }
 
+export function playerProfileLoader({ params }: LoaderFunctionArgs): null {
+  const { guildId, alias } = params;
+  if (guildId === undefined || alias === undefined) return null;
+  void queryClient.prefetchQuery(
+    trpcOptions.player.profileSummary.queryOptions({ guildId, alias }),
+  );
+  void queryClient.prefetchQuery(
+    trpcOptions.player.matchHistory.queryOptions({ guildId, alias, limit: 20 }),
+  );
+  return null;
+}
+
 export function competitionsLoader({ params }: LoaderFunctionArgs): null {
   const { guildId } = params;
   if (guildId === undefined) return null;

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -11,6 +11,7 @@ import {
 } from "#src/routes/guild-workspace.tsx";
 import { PlayerList } from "#src/routes/player-list.tsx";
 import { PlayerDetail } from "#src/routes/player-detail.tsx";
+import { PlayerProfile } from "#src/routes/player-profile.tsx";
 import { CompetitionList } from "#src/routes/competition-list.tsx";
 import { CompetitionDetail } from "#src/routes/competition-detail.tsx";
 import { CompetitionForm } from "#src/routes/competition-form.tsx";
@@ -34,6 +35,7 @@ import {
   exploreLoader,
   guildLoader,
   playerDetailLoader,
+  playerProfileLoader,
   playersLoader,
   reportDetailLoader,
   reportsLoader,
@@ -62,7 +64,15 @@ const guildChildren: RouteObject[] = [
     errorElement: <RouteErrorPanel />,
   },
   {
+    // Profile is the default: a non-admin clicking a friend's name wants their
+    // games, not subscription plumbing.
     path: "players/:alias",
+    element: <PlayerProfile />,
+    loader: playerProfileLoader,
+    errorElement: <RouteErrorPanel />,
+  },
+  {
+    path: "players/:alias/manage",
     element: <PlayerDetail />,
     loader: playerDetailLoader,
     errorElement: <RouteErrorPanel />,

--- a/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-detail.tsx
@@ -24,6 +24,7 @@ import {
 } from "@scout-for-lol/design-system/components/card";
 import { DiscordUser } from "#src/components/discord-user.tsx";
 import { PlayerHeaderActions } from "#src/components/player-header-actions.tsx";
+import { PlayerTabsNav } from "#src/components/player-tabs-nav.tsx";
 import {
   CompetitionSection,
   PlayerAccountsTable,
@@ -210,7 +211,10 @@ export function PlayerDetail() {
     void queryClient.invalidateQueries({
       queryKey: trpc.player.listPlayers.pathKey(),
     });
-    void navigate(`/g/${guildId}/players/${encodeURIComponent(nextAlias)}`);
+    // Stay on the manage tab — the user was mid-administration.
+    void navigate(
+      `/g/${guildId}/players/${encodeURIComponent(nextAlias)}/manage`,
+    );
   }
 
   const unlinkMutation = useMutation(
@@ -287,6 +291,8 @@ export function PlayerDetail() {
           }}
         />
       </div>
+
+      <PlayerTabsNav guildId={guildId} alias={alias} />
 
       {actionError !== null && (
         <p className="text-sm text-scout-danger">{actionError}</p>

--- a/packages/scout-for-lol/packages/app/src/routes/player-profile.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-profile.tsx
@@ -1,0 +1,77 @@
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useTRPC } from "#src/lib/trpc.ts";
+import { usePlayerParams } from "#src/lib/route-params.ts";
+import { PlayerTabsNav } from "#src/components/player-tabs-nav.tsx";
+import { Section } from "#src/components/player-detail-sections.tsx";
+import {
+  ChampionPoolTable,
+  MatchHistoryList,
+  RankCard,
+  RecentFormCard,
+} from "#src/components/player-profile-sections.tsx";
+
+/**
+ * A player's gameplay profile over the matches Scout ingested for this server.
+ *
+ * The denominator matters and is stated in the UI: this is not the League
+ * ladder, it is the games Scout happened to watch. Rates over a handful of
+ * games are marked rather than printed as if they were solid.
+ */
+export function PlayerProfile() {
+  const { guildId, alias } = usePlayerParams();
+  const trpc = useTRPC();
+
+  const summaryQuery = useSuspenseQuery(
+    trpc.player.profileSummary.queryOptions({ guildId, alias }),
+  );
+  const historyQuery = useQuery(
+    trpc.player.matchHistory.queryOptions({ guildId, alias, limit: 20 }),
+  );
+
+  const summary = summaryQuery.data;
+  const accountCount = summary.accountCount;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight">{alias}</h2>
+        <p className="text-sm text-muted-foreground">
+          {accountCount === 1
+            ? "1 Riot account"
+            : `${accountCount.toString()} Riot accounts combined`}
+          {" · "}
+          Games Scout has recorded for this server
+        </p>
+      </div>
+
+      <PlayerTabsNav guildId={guildId} alias={alias} />
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <RankCard label="Ranked solo/duo" rank={summary.ranks.solo} />
+        <RankCard label="Ranked flex" rank={summary.ranks.flex} />
+        {summary.recentForm !== null && (
+          <RecentFormCard form={summary.recentForm} />
+        )}
+      </div>
+
+      <Section title="Champions">
+        <ChampionPoolTable
+          rows={summary.championPool}
+          minGamesForRate={summary.minGamesForRate}
+        />
+      </Section>
+
+      <Section title="Match history">
+        {historyQuery.isPending ? (
+          <p className="text-sm text-muted-foreground">Loading games…</p>
+        ) : historyQuery.isError ? (
+          <p className="text-sm text-destructive">
+            Couldn&apos;t load match history.
+          </p>
+        ) : (
+          <MatchHistoryList entries={historyQuery.data.entries} />
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/lib/player-profile/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-profile/queries.ts
@@ -1,0 +1,319 @@
+import { z } from "zod";
+import { RankSchema, leaguePointsDelta, type Rank } from "@scout-for-lol/data";
+import { prisma } from "#src/database/index.ts";
+import {
+  PlayerLookupInput,
+  getPlayerOrThrow,
+} from "#src/lib/player-admin/shared.ts";
+import {
+  fetchPlayerChampionPool,
+  fetchPlayerMatchHistory,
+  fetchTeamTotalsForMatches,
+  type LakePlayerMatchHistoryRow,
+  type MatchHistoryCursor,
+} from "#src/reports/duckdb/lake-reads.ts";
+
+/**
+ * Read models for the player profile surface.
+ *
+ * Authorization note: `resolveGuildPuuids` is the only way into the lake here.
+ * The matches parquet carries no `server_id`, so the puuid list these queries
+ * pass down IS the guild boundary — it comes from `getPlayerOrThrow`, which
+ * looks a player up by the `(serverId, alias)` unique and returns only that
+ * server's accounts. Never source puuids any other way.
+ */
+
+/**
+ * Below this many games a rate is noise, so the UI labels it rather than
+ * printing a confident number. Matches the pairing job's existing threshold
+ * (`league/tasks/pairing/weekly-update.ts`).
+ */
+export const MIN_GAMES_FOR_RATE = 10;
+
+/** Games summarised for "recent form"; also the default history page size. */
+const RECENT_FORM_GAMES = 20;
+
+const MatchHistoryCursorSchema = z.object({
+  gameCreationMs: z.number().int(),
+  matchId: z.string().min(1),
+});
+
+export const PlayerProfileInput = PlayerLookupInput.extend({
+  queue: z.string().trim().min(1).max(50).optional(),
+});
+
+export const PlayerMatchHistoryInput = PlayerLookupInput.extend({
+  limit: z.number().int().min(1).max(50).default(RECENT_FORM_GAMES),
+  cursor: MatchHistoryCursorSchema.optional(),
+  queue: z.string().trim().min(1).max(50).optional(),
+});
+
+async function resolveGuildPuuids(input: {
+  guildId: string;
+  alias: string;
+}): Promise<{
+  playerId: number;
+  alias: string;
+  discordId: string | null;
+  puuids: string[];
+  accounts: { riotGameName: string | null; riotTagLine: string | null }[];
+}> {
+  const player = await getPlayerOrThrow(input);
+  return {
+    playerId: player.id,
+    alias: player.alias,
+    discordId: player.discordId,
+    puuids: player.accounts.map((account) => account.puuid),
+    accounts: player.accounts.map((account) => ({
+      riotGameName: account.riotGameName,
+      riotTagLine: account.riotTagLine,
+    })),
+  };
+}
+
+function parseRank(serialized: string | null): Rank | undefined {
+  if (serialized === null) return undefined;
+  const parsed = RankSchema.safeParse(JSON.parse(serialized));
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Latest known rank per queue, newest game first. */
+async function latestRanks(
+  puuids: string[],
+): Promise<{ solo: Rank | undefined; flex: Rank | undefined }> {
+  const [solo, flex] = await Promise.all(
+    (["solo", "flex"] as const).map(async (queueType) =>
+      prisma.matchRankHistory.findFirst({
+        where: { puuid: { in: puuids }, queueType, rankAfter: { not: null } },
+        orderBy: [{ matchGameEndAt: "desc" }, { capturedAt: "desc" }],
+      }),
+    ),
+  );
+  return {
+    solo: parseRank(solo?.rankAfter ?? null),
+    flex: parseRank(flex?.rankAfter ?? null),
+  };
+}
+
+export type MatchHistoryEntry = {
+  matchId: string;
+  gameCreationMs: number;
+  gameDurationSeconds: number;
+  queue: string | null;
+  championId: number;
+  championName: string;
+  teamPosition: string;
+  win: boolean;
+  kills: number;
+  deaths: number;
+  assists: number;
+  creepScore: number;
+  csPerMinute: number;
+  visionScore: number;
+  goldEarned: number;
+  /** Null when the team's totals are absent — never silently 0. */
+  killParticipation: number | null;
+  damageShare: number | null;
+  /** LP change for this game; null unless both before and after are known. */
+  leaguePointsDelta: number | null;
+};
+
+function ratio(part: number, whole: number): number | null {
+  return whole > 0 ? part / whole : null;
+}
+
+/**
+ * Attach team-relative and rank-relative context to raw lake rows.
+ *
+ * Team totals come from a separate match-scoped query because the history rows
+ * themselves are puuid-filtered and therefore cannot see teammates.
+ */
+async function decorateHistoryRows(
+  rows: LakePlayerMatchHistoryRow[],
+  puuids: string[],
+): Promise<MatchHistoryEntry[]> {
+  if (rows.length === 0) return [];
+  const matchIds = rows.map((row) => row.match_id);
+
+  const [teamTotals, rankRows] = await Promise.all([
+    fetchTeamTotalsForMatches({ matchIds }),
+    prisma.matchRankHistory.findMany({
+      where: { matchId: { in: matchIds }, puuid: { in: puuids } },
+    }),
+  ]);
+
+  const totalsByKey = new Map(
+    teamTotals.map((total) => [
+      `${total.match_id}:${total.team_id.toString()}`,
+      total,
+    ]),
+  );
+  const rankByMatch = new Map(rankRows.map((row) => [row.matchId, row]));
+
+  return rows.map((row) => {
+    const totals = totalsByKey.get(`${row.match_id}:${row.team_id.toString()}`);
+    const rankRow = rankByMatch.get(row.match_id);
+    const before = parseRank(rankRow?.rankBefore ?? null);
+    const after = parseRank(rankRow?.rankAfter ?? null);
+    const minutes = row.time_played / 60;
+
+    return {
+      matchId: row.match_id,
+      gameCreationMs: row.game_creation_ms,
+      gameDurationSeconds: row.game_duration_seconds,
+      queue: row.queue,
+      championId: row.champion_id,
+      championName: row.champion_name,
+      teamPosition: row.team_position,
+      win: row.win,
+      kills: row.kills,
+      deaths: row.deaths,
+      assists: row.assists,
+      creepScore: row.creep_score,
+      csPerMinute: minutes > 0 ? row.creep_score / minutes : 0,
+      visionScore: row.vision_score,
+      goldEarned: row.gold_earned,
+      killParticipation:
+        totals === undefined
+          ? null
+          : ratio(row.kills + row.assists, totals.team_kills),
+      damageShare:
+        totals === undefined
+          ? null
+          : ratio(
+              row.total_damage_dealt_to_champions,
+              totals.team_damage_to_champions,
+            ),
+      leaguePointsDelta:
+        before === undefined || after === undefined
+          ? null
+          : leaguePointsDelta(before, after),
+    };
+  });
+}
+
+export async function getPlayerMatchHistory(
+  input: z.infer<typeof PlayerMatchHistoryInput>,
+): Promise<{
+  entries: MatchHistoryEntry[];
+  nextCursor: MatchHistoryCursor | null;
+}> {
+  const { puuids } = await resolveGuildPuuids(input);
+  if (puuids.length === 0) {
+    return { entries: [], nextCursor: null };
+  }
+
+  // Fetch one extra row to learn whether another page exists without a count.
+  const rows = await fetchPlayerMatchHistory({
+    puuids,
+    limit: input.limit + 1,
+    ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
+    ...(input.queue === undefined ? {} : { queue: input.queue }),
+  });
+  const page = rows.slice(0, input.limit);
+  const last = rows.length > input.limit ? page.at(-1) : undefined;
+
+  return {
+    entries: await decorateHistoryRows(page, puuids),
+    nextCursor:
+      last === undefined
+        ? null
+        : { gameCreationMs: last.game_creation_ms, matchId: last.match_id },
+  };
+}
+
+export type ChampionPoolEntry = {
+  championId: number;
+  championName: string;
+  games: number;
+  wins: number;
+  winRate: number;
+  kda: number;
+  csPerMinute: number;
+  /** True when `games` is too small for the rates above to mean much. */
+  lowSample: boolean;
+};
+
+export async function getPlayerProfileSummary(
+  input: z.infer<typeof PlayerProfileInput>,
+) {
+  const player = await resolveGuildPuuids(input);
+  if (player.puuids.length === 0) {
+    return {
+      alias: player.alias,
+      discordId: player.discordId,
+      accountCount: 0,
+      riotIds: [],
+      ranks: { solo: undefined, flex: undefined },
+      recentForm: null,
+      championPool: [],
+      minGamesForRate: MIN_GAMES_FOR_RATE,
+    };
+  }
+
+  const [ranks, recentRows, pool] = await Promise.all([
+    latestRanks(player.puuids),
+    fetchPlayerMatchHistory({
+      puuids: player.puuids,
+      limit: RECENT_FORM_GAMES,
+      ...(input.queue === undefined ? {} : { queue: input.queue }),
+    }),
+    fetchPlayerChampionPool({
+      puuids: player.puuids,
+      ...(input.queue === undefined ? {} : { queue: input.queue }),
+    }),
+  ]);
+
+  const recent = await decorateHistoryRows(recentRows, player.puuids);
+  const participations = recent
+    .map((entry) => entry.killParticipation)
+    .filter((value) => value !== null);
+
+  return {
+    alias: player.alias,
+    discordId: player.discordId,
+    // Surfaced so the UI can say the profile spans several accounts — the
+    // thing a public tracker cannot do, because it never knows they are one
+    // person.
+    accountCount: player.puuids.length,
+    riotIds: player.accounts
+      .filter((account) => account.riotGameName !== null)
+      .map((account) => ({
+        gameName: account.riotGameName,
+        tagLine: account.riotTagLine,
+      })),
+    ranks,
+    recentForm:
+      recent.length === 0
+        ? null
+        : {
+            games: recent.length,
+            wins: recent.filter((entry) => entry.win).length,
+            kills: recent.reduce((sum, entry) => sum + entry.kills, 0),
+            deaths: recent.reduce((sum, entry) => sum + entry.deaths, 0),
+            assists: recent.reduce((sum, entry) => sum + entry.assists, 0),
+            averageKillParticipation:
+              participations.length === 0
+                ? null
+                : participations.reduce((sum, value) => sum + value, 0) /
+                  participations.length,
+          },
+    championPool: pool.map((row): ChampionPoolEntry => {
+      const minutes = row.time_played / 60;
+      return {
+        championId: row.champion_id,
+        championName: row.champion_name,
+        games: row.games,
+        wins: row.wins,
+        winRate: row.games > 0 ? row.wins / row.games : 0,
+        kda:
+          row.deaths === 0
+            ? row.kills + row.assists
+            : (row.kills + row.assists) / row.deaths,
+        csPerMinute: minutes > 0 ? row.creep_score / minutes : 0,
+        lowSample: row.games < MIN_GAMES_FOR_RATE,
+      };
+    }),
+    minGamesForRate: MIN_GAMES_FOR_RATE,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake-reads.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/lake-reads.ts
@@ -17,6 +17,7 @@ import {
   resolveLakeFiles,
   scalarParam,
   type BoundParam,
+  type SqlFragment,
 } from "#src/reports/duckdb/lake.ts";
 
 /**
@@ -132,6 +133,252 @@ export async function fetchTeamRowsForMatches(options: {
   return await withDuckDBConnection(async (session) => {
     const rows = await session.run(sql, bindParams(session, source.params));
     return rows.map((row) => TeamRowSchema.parse(row));
+  });
+}
+
+/** DuckDB returns integer aggregates as BIGINT; normalise to number. */
+const LakeIntSchema = z.union([z.bigint(), z.number()]).transform(Number);
+
+/**
+ * Resolve the lake and build a matches source for one predicate.
+ * `undefined` means the lake has no files yet — callers return [].
+ */
+async function matchesSourceFor(
+  lakeDir: string | undefined,
+  predicate: SqlFragment,
+): Promise<SqlFragment | undefined> {
+  const files = await resolveLakeFiles(lakeDir ?? resolveLakeDir());
+  return buildMatchesSource(files, predicate);
+}
+
+/** Run `sql` over a built source and parse every row with `schema`. */
+async function runLakeQuery<T>(options: {
+  source: SqlFragment;
+  sql: string;
+  extraParams?: BoundParam[];
+  schema: z.ZodType<T>;
+}): Promise<T[]> {
+  return await withDuckDBConnection(async (session) => {
+    const rows = await session.run(
+      options.sql,
+      bindParams(session, [
+        ...options.source.params,
+        ...(options.extraParams ?? []),
+      ]),
+    );
+    return rows.map((row) => options.schema.parse(row));
+  });
+}
+
+/**
+ * `puuid IN (…)` plus an optional queue filter — the predicate shared by every
+ * per-player profile read. The puuid list is the caller's whole authorization
+ * surface; see {@link fetchPlayerMatchHistory}.
+ */
+function playerPredicate(options: {
+  puuids: string[];
+  queue?: string;
+}): SqlFragment {
+  const sql = ["puuid IN (SELECT unnest(?))"];
+  const params: BoundParam[] = [listParam(options.puuids)];
+  if (options.queue !== undefined) {
+    sql.push("queue = ?");
+    params.push(scalarParam(options.queue));
+  }
+  return { sql: sql.join(" AND "), params };
+}
+
+/**
+ * One match as played by a tracked player, newest first.
+ *
+ * Deduped to one row per `match_id`: a Scout `Player` owns several `Account`s,
+ * and `mergePlayers` can leave one Player holding two PUUIDs that appear in the
+ * same game. Without the QUALIFY that match would be listed — and counted in
+ * every aggregate below — twice.
+ */
+const PlayerMatchHistoryRowSchema = z.object({
+  match_id: z.string(),
+  puuid: z.string(),
+  game_creation_ms: LakeIntSchema,
+  game_duration_seconds: LakeIntSchema,
+  queue: z.string().nullable(),
+  queue_id: LakeIntSchema,
+  champion_id: LakeIntSchema,
+  champion_name: z.string(),
+  team_position: z.string(),
+  team_id: LakeIntSchema,
+  win: z.boolean(),
+  kills: LakeIntSchema,
+  deaths: LakeIntSchema,
+  assists: LakeIntSchema,
+  creep_score: LakeIntSchema,
+  gold_earned: LakeIntSchema,
+  total_damage_dealt_to_champions: LakeIntSchema,
+  vision_score: LakeIntSchema,
+  time_played: LakeIntSchema,
+});
+
+export type LakePlayerMatchHistoryRow = z.infer<
+  typeof PlayerMatchHistoryRowSchema
+>;
+
+/** One row per match, newest first — `puuid` deduped as described above. */
+const DEDUPE_TO_ONE_ROW_PER_MATCH =
+  "QUALIFY row_number() OVER (PARTITION BY match_id ORDER BY puuid) = 1";
+
+export type MatchHistoryCursor = {
+  gameCreationMs: number;
+  matchId: string;
+};
+
+/**
+ * A page of a player's match history across ALL of their accounts.
+ *
+ * `puuids` is the caller's whole authorization surface — the matches parquet
+ * carries no `server_id`, so this function cannot tell a guild's account from
+ * anyone else's. Callers must resolve the puuid list within the requesting
+ * guild; see `player.router.ts`.
+ *
+ * Keyset pagination on `(game_creation_at, match_id)` rather than OFFSET, so a
+ * match ingested mid-scroll cannot shift the page boundary and duplicate a row.
+ */
+export async function fetchPlayerMatchHistory(options: {
+  puuids: string[];
+  limit: number;
+  cursor?: MatchHistoryCursor;
+  queue?: string;
+  lakeDir?: string;
+}): Promise<LakePlayerMatchHistoryRow[]> {
+  if (options.puuids.length === 0) {
+    return [];
+  }
+  const predicate = playerPredicate(options);
+  const clauses = [predicate.sql];
+  const params = [...predicate.params];
+  if (options.cursor !== undefined) {
+    clauses.push(
+      "(epoch_ms(game_creation_at) < ? OR (epoch_ms(game_creation_at) = ? AND match_id < ?))",
+    );
+    params.push(
+      scalarParam(options.cursor.gameCreationMs),
+      scalarParam(options.cursor.gameCreationMs),
+      scalarParam(options.cursor.matchId),
+    );
+  }
+
+  const source = await matchesSourceFor(options.lakeDir, {
+    sql: clauses.join(" AND "),
+    params,
+  });
+  if (source === undefined) {
+    return [];
+  }
+  return await runLakeQuery({
+    source,
+    sql:
+      `SELECT match_id, puuid, epoch_ms(game_creation_at)::BIGINT AS game_creation_ms, ` +
+      `game_duration_seconds, queue, queue_id, champion_id, champion_name, ` +
+      `team_position, team_id, win, kills, deaths, assists, creep_score, ` +
+      `gold_earned, total_damage_dealt_to_champions, vision_score, time_played ` +
+      `FROM (${source.sql}) ${DEDUPE_TO_ONE_ROW_PER_MATCH} ` +
+      `ORDER BY game_creation_ms DESC, match_id DESC LIMIT ?`,
+    extraParams: [scalarParam(Math.floor(options.limit))],
+    schema: PlayerMatchHistoryRowSchema,
+  });
+}
+
+const ChampionPoolRowSchema = z.object({
+  champion_id: LakeIntSchema,
+  champion_name: z.string(),
+  games: LakeIntSchema,
+  wins: LakeIntSchema,
+  kills: LakeIntSchema,
+  deaths: LakeIntSchema,
+  assists: LakeIntSchema,
+  creep_score: LakeIntSchema,
+  time_played: LakeIntSchema,
+});
+
+export type LakeChampionPoolRow = z.infer<typeof ChampionPoolRowSchema>;
+
+/**
+ * Per-champion totals across all of a player's accounts, most-played first.
+ *
+ * Returns raw totals, not rates: the caller derives win rate / KDA / CS-min so
+ * that minimum-sample suppression is decided once, in one place, against the
+ * `games` count rather than re-derived per metric.
+ *
+ * Same authorization contract as {@link fetchPlayerMatchHistory}.
+ */
+export async function fetchPlayerChampionPool(options: {
+  puuids: string[];
+  queue?: string;
+  lakeDir?: string;
+}): Promise<LakeChampionPoolRow[]> {
+  if (options.puuids.length === 0) {
+    return [];
+  }
+  const source = await matchesSourceFor(
+    options.lakeDir,
+    playerPredicate(options),
+  );
+  if (source === undefined) {
+    return [];
+  }
+  return await runLakeQuery({
+    source,
+    sql:
+      `SELECT champion_id, champion_name, count(*) AS games, ` +
+      `sum(CASE WHEN win THEN 1 ELSE 0 END)::BIGINT AS wins, ` +
+      `sum(kills)::BIGINT AS kills, sum(deaths)::BIGINT AS deaths, ` +
+      `sum(assists)::BIGINT AS assists, sum(creep_score)::BIGINT AS creep_score, ` +
+      `sum(time_played)::BIGINT AS time_played ` +
+      `FROM (SELECT * FROM (${source.sql}) ${DEDUPE_TO_ONE_ROW_PER_MATCH}) ` +
+      `GROUP BY champion_id, champion_name ORDER BY games DESC, champion_name ASC`,
+    schema: ChampionPoolRowSchema,
+  });
+}
+
+const TeamTotalsRowSchema = z.object({
+  match_id: z.string(),
+  team_id: LakeIntSchema,
+  team_kills: LakeIntSchema,
+  team_damage_to_champions: LakeIntSchema,
+});
+
+export type LakeTeamTotalsRow = z.infer<typeof TeamTotalsRowSchema>;
+
+/**
+ * Per-team kill and damage totals for the given matches — the denominators for
+ * kill participation and damage share.
+ *
+ * This deliberately filters on `match_id` ONLY, never on the player's puuid.
+ * The source predicate is pushed down into the parquet scan, so a puuid-filtered
+ * source contains just that one participant: summing it would yield the player's
+ * own kills as the "team" total and a participation of exactly 1.0 every game.
+ * Filtering by match alone is what makes all ten participants visible.
+ */
+export async function fetchTeamTotalsForMatches(options: {
+  matchIds: string[];
+  lakeDir?: string;
+}): Promise<LakeTeamTotalsRow[]> {
+  if (options.matchIds.length === 0) {
+    return [];
+  }
+  const source = await matchesSourceFor(options.lakeDir, {
+    sql: "match_id IN (SELECT unnest(?))",
+    params: [listParam(options.matchIds)],
+  });
+  if (source === undefined) {
+    return [];
+  }
+  return await runLakeQuery({
+    source,
+    sql:
+      `SELECT match_id, team_id, sum(kills)::BIGINT AS team_kills, ` +
+      `sum(total_damage_dealt_to_champions)::BIGINT AS team_damage_to_champions ` +
+      `FROM (${source.sql}) GROUP BY match_id, team_id`,
+    schema: TeamTotalsRowSchema,
   });
 }
 

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/player-profile-reads.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/player-profile-reads.integration.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
+import { testGuildId, testPuuid } from "#src/testing/test-ids.ts";
+import {
+  fetchPlayerChampionPool,
+  fetchPlayerMatchHistory,
+  fetchTeamTotalsForMatches,
+} from "#src/reports/duckdb/lake-reads.ts";
+
+/**
+ * Profile reads run over the raw matches table with no accounts join, so the
+ * properties guarded here are the ones nothing downstream would catch:
+ *
+ *  - a Scout Player owns several accounts, and the profile must aggregate them
+ *    as one person (the thing op.gg structurally cannot do);
+ *  - team denominators must see participants the requesting player is not,
+ *    which only works because the team query filters on match_id alone.
+ */
+
+const lakeDir = resolveLakeDir();
+const serverId = testGuildId("515151");
+const base = new Date(Date.UTC(2026, 4, 17, 12, 0, 0));
+
+const MAIN = testPuuid("profile-main");
+const SMURF = testPuuid("profile-smurf");
+
+function at(offsetMinutes: number): Date {
+  return new Date(base.getTime() + offsetMinutes * 60_000);
+}
+
+type FactOverrides = {
+  puuid?: string;
+  win?: boolean;
+  kills?: number;
+  championId?: number;
+  championName?: string;
+  teamId?: number;
+  totalDamageDealtToChampions?: number;
+  playerId?: number;
+};
+
+function fact(matchId: string, when: Date, overrides: FactOverrides = {}) {
+  return {
+    playerId: overrides.playerId ?? 1,
+    playerAlias: "Profile Player",
+    matchId,
+    puuid: overrides.puuid ?? MAIN,
+    queue: "solo",
+    win: overrides.win ?? true,
+    surrendered: false,
+    kills: overrides.kills ?? 5,
+    deaths: 2,
+    assists: 7,
+    championId: overrides.championId ?? 22,
+    championName: overrides.championName ?? "Ashe",
+    teamId: overrides.teamId ?? 100,
+    totalDamageDealtToChampions:
+      overrides.totalDamageDealtToChampions ?? 12_000,
+    gameCreationAt: when,
+  };
+}
+
+beforeEach(async () => {
+  await resetTestLake(lakeDir);
+});
+
+describe("fetchPlayerMatchHistory", () => {
+  test("returns one row per match, newest first", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_1", at(0)),
+        fact("NA1_2", at(60)),
+        fact("NA1_3", at(120)),
+      ],
+    });
+
+    const rows = await fetchPlayerMatchHistory({
+      puuids: [MAIN],
+      limit: 10,
+      lakeDir,
+    });
+
+    expect(rows.map((row) => row.match_id)).toEqual([
+      "NA1_3",
+      "NA1_2",
+      "NA1_1",
+    ]);
+  });
+
+  test("aggregates every account of one player into a single history", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_main", at(0)),
+        fact("NA1_smurf", at(60), { puuid: SMURF }),
+      ],
+    });
+
+    const bothAccounts = await fetchPlayerMatchHistory({
+      puuids: [MAIN, SMURF],
+      limit: 10,
+      lakeDir,
+    });
+    const mainOnly = await fetchPlayerMatchHistory({
+      puuids: [MAIN],
+      limit: 10,
+      lakeDir,
+    });
+
+    expect(bothAccounts.map((row) => row.match_id)).toEqual([
+      "NA1_smurf",
+      "NA1_main",
+    ]);
+    // Passing fewer puuids must narrow the result — this is the whole
+    // authorization surface, so it has to actually filter.
+    expect(mainOnly.map((row) => row.match_id)).toEqual(["NA1_main"]);
+  });
+
+  test("lists a match once when two of the player's puuids appear in it", async () => {
+    // mergePlayers can leave one Player holding two PUUIDs that met in a game.
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_merged", at(0), { puuid: MAIN, teamId: 100 }),
+        fact("NA1_merged", at(0), { puuid: SMURF, teamId: 200, win: false }),
+      ],
+    });
+
+    const rows = await fetchPlayerMatchHistory({
+      puuids: [MAIN, SMURF],
+      limit: 10,
+      lakeDir,
+    });
+
+    expect(rows).toHaveLength(1);
+  });
+
+  test("keyset cursor walks pages without repeating or skipping a match", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_1", at(0)),
+        fact("NA1_2", at(60)),
+        fact("NA1_3", at(120)),
+        fact("NA1_4", at(180)),
+      ],
+    });
+
+    const first = await fetchPlayerMatchHistory({
+      puuids: [MAIN],
+      limit: 2,
+      lakeDir,
+    });
+    const last = first.at(-1);
+    if (last === undefined) throw new Error("expected a first page");
+
+    const second = await fetchPlayerMatchHistory({
+      puuids: [MAIN],
+      limit: 2,
+      cursor: { gameCreationMs: last.game_creation_ms, matchId: last.match_id },
+      lakeDir,
+    });
+
+    expect(first.map((row) => row.match_id)).toEqual(["NA1_4", "NA1_3"]);
+    expect(second.map((row) => row.match_id)).toEqual(["NA1_2", "NA1_1"]);
+  });
+
+  test("filters by queue when asked", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_solo", at(0)),
+        { ...fact("NA1_aram", at(60)), queue: "aram" },
+      ],
+    });
+
+    const rows = await fetchPlayerMatchHistory({
+      puuids: [MAIN],
+      limit: 10,
+      queue: "aram",
+      lakeDir,
+    });
+
+    expect(rows.map((row) => row.match_id)).toEqual(["NA1_aram"]);
+  });
+
+  test("returns nothing for an empty puuid list rather than everything", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [fact("NA1_1", at(0))],
+    });
+
+    expect(
+      await fetchPlayerMatchHistory({ puuids: [], limit: 10, lakeDir }),
+    ).toEqual([]);
+  });
+});
+
+describe("fetchPlayerChampionPool", () => {
+  test("totals per champion across every account, most played first", async () => {
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_1", at(0), { championId: 22, championName: "Ashe" }),
+        fact("NA1_2", at(60), {
+          championId: 22,
+          championName: "Ashe",
+          win: false,
+        }),
+        fact("NA1_3", at(120), {
+          puuid: SMURF,
+          championId: 22,
+          championName: "Ashe",
+        }),
+        fact("NA1_4", at(180), { championId: 64, championName: "LeeSin" }),
+      ],
+    });
+
+    const pool = await fetchPlayerChampionPool({
+      puuids: [MAIN, SMURF],
+      lakeDir,
+    });
+
+    expect(pool).toHaveLength(2);
+    const [ashe, lee] = pool;
+    if (ashe === undefined || lee === undefined) {
+      throw new Error("expected two champions");
+    }
+    expect(ashe.champion_name).toBe("Ashe");
+    expect(ashe.games).toBe(3);
+    expect(ashe.wins).toBe(2);
+    expect(lee.champion_name).toBe("LeeSin");
+    expect(lee.games).toBe(1);
+  });
+});
+
+describe("fetchTeamTotalsForMatches", () => {
+  test("sums participants the requesting player cannot see", async () => {
+    // The player is one of five; the other four are untracked. A puuid-filtered
+    // implementation would return the player's own 5 kills as the team total
+    // and make kill participation exactly 1.0 in every game.
+    await writeTestLake(lakeDir, {
+      serverId,
+      matchFacts: [
+        fact("NA1_team", at(0), {
+          kills: 5,
+          teamId: 100,
+          totalDamageDealtToChampions: 10_000,
+        }),
+      ],
+      untrackedMatchFacts: [
+        fact("NA1_team", at(0), {
+          playerId: 91,
+          puuid: testPuuid("ally-a"),
+          kills: 3,
+          teamId: 100,
+          totalDamageDealtToChampions: 5000,
+        }),
+        fact("NA1_team", at(0), {
+          playerId: 92,
+          puuid: testPuuid("ally-b"),
+          kills: 2,
+          teamId: 100,
+          totalDamageDealtToChampions: 5000,
+        }),
+        fact("NA1_team", at(0), {
+          playerId: 93,
+          puuid: testPuuid("enemy-a"),
+          kills: 7,
+          teamId: 200,
+          totalDamageDealtToChampions: 9000,
+          win: false,
+        }),
+      ],
+    });
+
+    const totals = await fetchTeamTotalsForMatches({
+      matchIds: ["NA1_team"],
+      lakeDir,
+    });
+
+    const blue = totals.find((row) => row.team_id === 100);
+    const red = totals.find((row) => row.team_id === 200);
+    if (blue === undefined || red === undefined) {
+      throw new Error("expected both teams");
+    }
+    expect(blue.team_kills).toBe(10);
+    expect(blue.team_damage_to_champions).toBe(20_000);
+    // Partitioned per team, not per match.
+    expect(red.team_kills).toBe(7);
+  });
+
+  test("returns nothing for an empty match list", async () => {
+    expect(await fetchTeamTotalsForMatches({ matchIds: [], lakeDir })).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/testing/test-report-lake.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-report-lake.ts
@@ -42,6 +42,10 @@ export type TestLakeMatchFact = {
   assists: number;
   gameDurationSeconds?: number;
   timePlayedSeconds?: number;
+  /** Override to make per-participant damage vary, e.g. for damage-share tests. */
+  totalDamageDealtToChampions?: number;
+  /** Override to make per-participant CS vary, e.g. for CS-per-minute tests. */
+  creepScore?: number;
   teamId?: number;
   /** Arena subteam (1-8); leave unset for non-Arena queues. */
   playerSubteamId?: number;
@@ -108,13 +112,13 @@ function matchRowFromFact(fact: TestLakeMatchFact): MatchLakeRow {
       fact.deaths === 0
         ? fact.kills + fact.assists
         : (fact.kills + fact.assists) / fact.deaths,
-    creep_score: 150,
+    creep_score: fact.creepScore ?? 150,
     total_minions_killed: 140,
     neutral_minions_killed: 10,
     gold_earned: 10_000,
     gold_spent: 9500,
     total_damage_dealt: 50_000,
-    total_damage_dealt_to_champions: 12_000,
+    total_damage_dealt_to_champions: fact.totalDamageDealtToChampions ?? 12_000,
     total_damage_taken: 20_000,
     damage_self_mitigated: 8000,
     damage_dealt_to_objectives: 4000,

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/player-profile.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/player-profile.router.test.ts
@@ -1,0 +1,310 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  type DiscordGuildId,
+  type LeaguePuuid,
+} from "@scout-for-lol/data";
+import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
+import { testPuuid } from "#src/testing/test-ids.ts";
+
+// Offline tRPC harness: real router, no Discord OAuth. See
+// src/testing/test-trpc-caller.ts. Must be created before appRouter is imported.
+const trpc = await createOfflineTrpcHarness("trpc-player-profile-test");
+const { prisma: testPrisma } = trpc;
+
+const guildId = DiscordGuildIdSchema.parse("100000000000000021");
+const otherGuildId = DiscordGuildIdSchema.parse("100000000000000022");
+const actorDiscordId = DiscordAccountIdSchema.parse("300000000000000021");
+const lakeDir = resolveLakeDir();
+
+const MAIN = testPuuid("router-main");
+const SMURF = testPuuid("router-smurf");
+const gameCreatedAt = new Date(Date.UTC(2026, 4, 17, 12, 0, 0));
+
+async function seedPlayer(options: {
+  serverId: DiscordGuildId;
+  alias: string;
+  puuids: LeaguePuuid[];
+}) {
+  const now = new Date();
+  const player = await testPrisma.player.create({
+    data: {
+      alias: options.alias,
+      serverId: options.serverId,
+      creatorDiscordId: actorDiscordId,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  for (const [index, puuid] of options.puuids.entries()) {
+    await testPrisma.account.create({
+      data: {
+        alias: `${options.alias}-${index.toString()}`,
+        puuid,
+        region: "AMERICA_NORTH",
+        playerId: player.id,
+        serverId: options.serverId,
+        creatorDiscordId: actorDiscordId,
+        riotGameName: `${options.alias}${index.toString()}`,
+        riotTagLine: "NA1",
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+  }
+  return player;
+}
+
+function matchFact(options: {
+  matchId: string;
+  puuid: string;
+  kills: number;
+  teamId: number;
+  win: boolean;
+  playerId: number;
+}) {
+  return {
+    playerId: options.playerId,
+    playerAlias: "Router Player",
+    matchId: options.matchId,
+    puuid: options.puuid,
+    queue: "solo",
+    win: options.win,
+    surrendered: false,
+    kills: options.kills,
+    deaths: 2,
+    assists: 3,
+    teamId: options.teamId,
+    gameCreationAt: gameCreatedAt,
+  };
+}
+
+beforeEach(async () => {
+  await testPrisma.matchRankHistory.deleteMany();
+  await testPrisma.account.deleteMany();
+  await testPrisma.player.deleteMany();
+  await resetTestLake(lakeDir);
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+describe("player.profileSummary", () => {
+  test("aggregates every account of one player into one profile", async () => {
+    await seedPlayer({
+      serverId: guildId,
+      alias: "Smurfer",
+      puuids: [MAIN, SMURF],
+    });
+    await writeTestLake(lakeDir, {
+      serverId: guildId,
+      matchFacts: [
+        matchFact({
+          matchId: "NA1_a",
+          puuid: MAIN,
+          kills: 5,
+          teamId: 100,
+          win: true,
+          playerId: 1,
+        }),
+        matchFact({
+          matchId: "NA1_b",
+          puuid: SMURF,
+          kills: 4,
+          teamId: 100,
+          win: false,
+          playerId: 1,
+        }),
+      ],
+    });
+
+    const summary = await trpc
+      .authedCaller()
+      .player.profileSummary({ guildId, alias: "Smurfer" });
+
+    expect(summary.accountCount).toBe(2);
+    expect(summary.recentForm?.games).toBe(2);
+    expect(summary.recentForm?.wins).toBe(1);
+    // One champion, played on both accounts.
+    expect(summary.championPool).toHaveLength(1);
+    expect(summary.championPool[0]?.games).toBe(2);
+    // Two games is far below the rate threshold and must say so.
+    expect(summary.championPool[0]?.lowSample).toBe(true);
+    expect(summary.minGamesForRate).toBe(10);
+  });
+
+  test("refuses a player belonging to another guild", async () => {
+    await seedPlayer({
+      serverId: otherGuildId,
+      alias: "Stranger",
+      puuids: [MAIN],
+    });
+
+    // Alias lookup is keyed by (serverId, alias); a guild must not reach
+    // another server's player, which is what keeps its puuids — and therefore
+    // its whole match history — out of this guild's reads.
+    await expect(
+      trpc.authedCaller().player.profileSummary({ guildId, alias: "Stranger" }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  test("rejects an anonymous caller", async () => {
+    await seedPlayer({ serverId: guildId, alias: "Solo", puuids: [MAIN] });
+
+    await expect(
+      trpc.anonCaller().player.profileSummary({ guildId, alias: "Solo" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("player.matchHistory", () => {
+  test("computes kill participation against the whole team", async () => {
+    await seedPlayer({ serverId: guildId, alias: "Solo", puuids: [MAIN] });
+    await writeTestLake(lakeDir, {
+      serverId: guildId,
+      matchFacts: [
+        matchFact({
+          matchId: "NA1_team",
+          puuid: MAIN,
+          kills: 5,
+          teamId: 100,
+          win: true,
+          playerId: 1,
+        }),
+      ],
+      // Teammates Scout has match rows for but this guild does not track.
+      untrackedMatchFacts: [
+        matchFact({
+          matchId: "NA1_team",
+          puuid: testPuuid("router-ally"),
+          kills: 5,
+          teamId: 100,
+          win: true,
+          playerId: 91,
+        }),
+        matchFact({
+          matchId: "NA1_team",
+          puuid: testPuuid("router-enemy"),
+          kills: 7,
+          teamId: 200,
+          win: false,
+          playerId: 92,
+        }),
+      ],
+    });
+
+    const history = await trpc
+      .authedCaller()
+      .player.matchHistory({ guildId, alias: "Solo", limit: 20 });
+
+    const entry = history.entries[0];
+    if (entry === undefined) throw new Error("expected one entry");
+    // 5 kills + 3 assists over a team total of 10 kills. A puuid-scoped team
+    // query would make this 1.0.
+    expect(entry.killParticipation).toBeCloseTo(0.8, 5);
+    expect(history.nextCursor).toBeNull();
+  });
+
+  test("reports the LP change for a game", async () => {
+    await seedPlayer({ serverId: guildId, alias: "Solo", puuids: [MAIN] });
+    await writeTestLake(lakeDir, {
+      serverId: guildId,
+      matchFacts: [
+        matchFact({
+          matchId: "NA1_lp",
+          puuid: MAIN,
+          kills: 5,
+          teamId: 100,
+          win: true,
+          playerId: 1,
+        }),
+      ],
+    });
+    await testPrisma.matchRankHistory.create({
+      data: {
+        matchId: "NA1_lp",
+        puuid: MAIN,
+        queueType: "solo",
+        rankBefore: JSON.stringify({
+          tier: "gold",
+          division: 2,
+          lp: 40,
+          wins: 10,
+          losses: 5,
+        }),
+        rankAfter: JSON.stringify({
+          tier: "gold",
+          division: 2,
+          lp: 62,
+          wins: 11,
+          losses: 5,
+        }),
+        capturedAt: new Date(),
+      },
+    });
+
+    const history = await trpc
+      .authedCaller()
+      .player.matchHistory({ guildId, alias: "Solo", limit: 20 });
+
+    expect(history.entries[0]?.leaguePointsDelta).toBe(22);
+  });
+
+  test("leaves LP null when the game has no rank snapshot", async () => {
+    await seedPlayer({ serverId: guildId, alias: "Solo", puuids: [MAIN] });
+    await writeTestLake(lakeDir, {
+      serverId: guildId,
+      matchFacts: [
+        matchFact({
+          matchId: "NA1_norank",
+          puuid: MAIN,
+          kills: 5,
+          teamId: 100,
+          win: true,
+          playerId: 1,
+        }),
+      ],
+    });
+
+    const history = await trpc
+      .authedCaller()
+      .player.matchHistory({ guildId, alias: "Solo", limit: 20 });
+
+    expect(history.entries[0]?.leaguePointsDelta).toBeNull();
+  });
+
+  test("returns a cursor only when another page exists", async () => {
+    await seedPlayer({ serverId: guildId, alias: "Solo", puuids: [MAIN] });
+    await writeTestLake(lakeDir, {
+      serverId: guildId,
+      matchFacts: [0, 1, 2].map((index) => ({
+        ...matchFact({
+          matchId: `NA1_${index.toString()}`,
+          puuid: MAIN,
+          kills: 5,
+          teamId: 100,
+          win: true,
+          playerId: 1,
+        }),
+        gameCreationAt: new Date(gameCreatedAt.getTime() + index * 60_000),
+      })),
+    });
+
+    const firstPage = await trpc
+      .authedCaller()
+      .player.matchHistory({ guildId, alias: "Solo", limit: 2 });
+    expect(firstPage.entries).toHaveLength(2);
+    const cursor = firstPage.nextCursor;
+    if (cursor === null) throw new Error("expected a next cursor");
+
+    const secondPage = await trpc
+      .authedCaller()
+      .player.matchHistory({ guildId, alias: "Solo", limit: 2, cursor });
+    expect(secondPage.entries).toHaveLength(1);
+    expect(secondPage.nextCursor).toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/player.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/player.router.ts
@@ -24,6 +24,12 @@ import {
   updateAccount,
 } from "#src/lib/player-admin/account-mutations.ts";
 import {
+  PlayerMatchHistoryInput,
+  PlayerProfileInput,
+  getPlayerMatchHistory,
+  getPlayerProfileSummary,
+} from "#src/lib/player-profile/queries.ts";
+import {
   LinkDiscordInput,
   MergePlayersInput,
   RenamePlayerInput,
@@ -43,6 +49,18 @@ export const playerRouter = router({
   getPlayer: guildProcedure("players", "read")
     .input(PlayerLookupInput)
     .query(async ({ ctx, input }) => getPlayer(input, ctx.permissions)),
+
+  // Profile reads reuse players:read rather than introducing a `matches`
+  // resource: roles are presets over per-permission grant rows and VIEWER is a
+  // hardcoded list, so a new resource would leave every existing viewer grant
+  // without it and silently downgrade those grants to "custom".
+  profileSummary: guildProcedure("players", "read")
+    .input(PlayerProfileInput)
+    .query(async ({ input }) => getPlayerProfileSummary(input)),
+
+  matchHistory: guildProcedure("players", "read")
+    .input(PlayerMatchHistoryInput)
+    .query(async ({ input }) => getPlayerMatchHistory(input)),
 
   getCurrentLinkedPlayer: guildProcedure("players", "read")
     .input(GuildIdInput)


### PR DESCRIPTION
## Why

Scout currently shows player subscription and account management, but not the gameplay history it has already ingested. This adds a linkable, Scout-scoped player profile so teammates can inspect recent games without relying on Discord report images or a public ladder tracker.

## What

- Add `/g/:guildId/players/:alias` as the default player profile route, with management moved to `/manage`.
- Expose authorized `player.profileSummary` and cursor-paginated `player.matchHistory` reads.
- Aggregate every Riot account attached to a Scout player, with rank cards, recent form, champion pool, and match rows.
- Show champion icons via the shared Data Dragon lookup and label low-sample rates honestly.
- Keep team-relative metrics scoped correctly and enforce the existing `players:read` guild permission boundary.
- Fix profile UI imports to use the current shared design-system components.

## Verification

- `bun install --frozen-lockfile` ✅
- Focused backend ESLint ✅
- App ESLint ✅ (zero errors; existing duplication warnings remain)
- Prettier on all changed files ✅
- Git pre-commit safety and commit-message hooks ✅
- App/backend typechecks and new integration tests were attempted but are blocked in this checkout by existing workspace/generated-environment issues: unresolved `@shepherdjerred/glitter-context` from the Scout data package, missing generated/package resolution before codegen, and unrelated current-main type errors.
- Visual verification was not run because the authenticated Scout dev web environment is unavailable here.