### PR TITLE
feat(macos-ai-subscription-tracker): add OpenRouter API spend reporting

### DIFF
--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -14,9 +14,8 @@ for Grok ($470/month total). This is a reminder, not provider billing data.
 The compact subscription view sorts providers by their tightest current quota,
 keeps each quota and reset on one line, and uses pressure colors only for low or
 critical remaining usage. Cached values remain visible but dimmed and stale.
-The disabled `API & routers` segment records the intended future navigation;
-developer API credentials, router usage, balances, and rate limits are not yet
-supported.
+The `API & routers` segment currently reports OpenRouter credits and API-key
+spend across all workspaces.
 
 ## Build and install
 
@@ -122,12 +121,26 @@ not stable public APIs. Their adapters validate responses and show an explicit
 unavailable/stale state when a provider changes shape. Claude and Codex use
 their authenticated subscription usage surfaces; Kimi Code uses its coding
 subscription surface, not a Kimi Open Platform API key; Grok uses subscription
-usage and credits, not xAI developer API rate limits. API billing cards and
-developer API rate limits are intentionally outside the v1 scope.
+usage and credits, not xAI developer API rate limits. Non-OpenRouter API billing
+cards and developer API rate limits remain outside the v1 scope.
 
 Codex also reads the authenticated reset-credit surface read-only. Available
 banked resets are shown individually with their expiration dates; Brim does
 not redeem or consume them.
+
+### OpenRouter API reporting
+
+The API view requires an OpenRouter Management API key entered manually in
+Settings. Brim stores this key in a dedicated login-Keychain entry and only
+performs read-only requests for credits, workspaces, and API-key usage. Brim
+does not create, update, disable, or delete OpenRouter keys.
+
+The view shows credits remaining, monthly API-key spend, and a projected
+month-end spend. Monthly spend is the sum of OpenRouter's current-month
+usage_monthly and estimated byok_usage_monthly values across every workspace
+and API key, including disabled keys. The projection uses the current Mac-local
+calendar pace against OpenRouter's authoritative monthly usage period. Chatroom
+and Fusion activity is outside this first API-key reporting slice.
 
 Provider contracts are isolated in focused files under `Sources/QuotaBarCore`.
 Claude and Codex endpoints are authenticated subscription web surfaces, while

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/APIPlatformViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/APIPlatformViews.swift
@@ -1,0 +1,142 @@
+import QuotaBarCore
+import SwiftUI
+
+struct APIPlatformSummaryView: View {
+  let state: APIPlatformDisplayState
+  let date: Date
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      header
+      content
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+  }
+
+  private var header: some View {
+    HStack(spacing: 7) {
+      Image(systemName: "network")
+        .foregroundStyle(.blue)
+        .accessibilityHidden(true)
+      Text("OpenRouter")
+        .font(.subheadline.weight(.semibold))
+      Spacer()
+      Text("All workspaces")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  @ViewBuilder private var content: some View {
+    switch state {
+    case .loading:
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.mini)
+        Text("Checking API usage…")
+      }
+      .font(.caption)
+      .foregroundStyle(.secondary)
+    case let .available(snapshot):
+      snapshotContent(snapshot, staleReason: nil)
+    case let .stale(snapshot, reason):
+      snapshotContent(snapshot, staleReason: reason)
+    case let .unauthenticated(message):
+      statusRow(
+        "Management API key required",
+        symbol: "key",
+        help: message
+      )
+    case let .unavailable(message):
+      statusRow("API usage unavailable", symbol: "exclamationmark.triangle", help: message)
+    }
+  }
+
+  private func snapshotContent(
+    _ snapshot: APIPlatformSnapshot,
+    staleReason: String?
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 9) {
+      HStack(spacing: 6) {
+        metric("Credits remaining", value: snapshot.creditsRemaining)
+        metric("Monthly API spend", value: snapshot.monthlySpend)
+        metric("Projected spend", value: snapshot.projectedSpend)
+      }
+      .opacity(staleReason == nil ? 1 : 0.62)
+
+      Text(workspaceDetail(snapshot.workspaceNames))
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .help(snapshot.workspaceNames.joined(separator: ", "))
+
+      HStack(spacing: 5) {
+        if let staleReason {
+          Label("STALE", systemImage: "clock.badge.exclamationmark")
+            .foregroundStyle(.orange)
+            .help(staleReason)
+        }
+        Text("Updated \(QuotaTimeFormatter.refreshAge(since: snapshot.sourceTimestamp, at: date))")
+          .foregroundStyle(.secondary)
+        Spacer()
+      }
+      .font(.caption2)
+
+      Text(
+        "Monthly spend is OpenRouter API-key usage and includes estimated BYOK spend. "
+          + "Projection uses the current local calendar pace."
+      )
+      .font(.caption2)
+      .foregroundStyle(.tertiary)
+      .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private func metric(_ label: String, value: Decimal) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(label)
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(2)
+      Text(currency(value))
+        .font(.subheadline.monospacedDigit().weight(.semibold))
+        .lineLimit(1)
+        .minimumScaleFactor(0.75)
+        .accessibilityLabel("\(label), \(currency(value))")
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private func workspaceDetail(_ names: [String]) -> String {
+    switch names.count {
+    case 0:
+      return "No workspace names returned"
+    case 1:
+      return names[0]
+    default:
+      let visible = names.prefix(2).joined(separator: " · ")
+      let remaining = names.count - min(names.count, 2)
+      let suffix = remaining == 1 ? "" : "s"
+      return remaining == 0
+        ? visible
+        : "\(visible) · +\(remaining) more workspace\(suffix)"
+    }
+  }
+
+  private func currency(_ value: Decimal) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.currencyCode = "USD"
+    formatter.locale = .current
+    return value.formatted(.currency(code: "USD"))
+  }
+
+  private func statusRow(_ text: String, symbol: String, help: String) -> some View {
+    Label(text, systemImage: symbol)
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .help(help)
+      .accessibilityLabel(text)
+      .accessibilityHint(help)
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
@@ -4,30 +4,75 @@ import SwiftUI
 
 struct MenuBarView: View {
   @Bindable var model: QuotaBarModel
+  @Bindable var apiModel: APIPlatformModel
   let startupError: String?
   @State private var measuredProviderHeight: CGFloat = 220
+  @State private var selectedSegment: DashboardSegment = .subscriptions
+  // MenuBarExtra centers short window-style content vertically. Keep both
+  // segments in the same top-anchored menu-bar surface.
+  private let menuBarWindowMinimumHeight: CGFloat = 500
 
   var body: some View {
     TimelineView(.periodic(from: .now, by: 1)) { timeline in
       content(at: timeline.date)
     }
     .frame(width: 372)
+    .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
+    .background(Color(nsColor: .windowBackgroundColor))
   }
 
   private func content(at date: Date) -> some View {
-    let overview = QuotaOverview(states: providerStates, at: date)
-    return VStack(spacing: 0) {
-      header(overview: overview, date: date)
-      navigationSegments
-      WindowColumnHeader()
-        .padding(.horizontal, 12)
-        .padding(.vertical, 5)
-      Divider()
-      providerList(overview: overview, date: date)
-      Divider()
-      spendRow
-      Divider()
-      footer
+    switch selectedSegment {
+    case .subscriptions:
+      let overview = QuotaOverview(states: providerStates, at: date)
+      return AnyView(
+        VStack(spacing: 0) {
+          header(
+            lastUpdatedAt: overview.lastUpdatedAt,
+            isRefreshing: model.isRefreshing,
+            date: date
+          ) {
+            Task { await model.refresh() }
+          }
+          navigationSegments
+          WindowColumnHeader()
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+          Divider()
+          providerList(overview: overview, date: date)
+          Divider()
+          spendRow
+          Spacer(minLength: 0)
+          Divider()
+          footer
+        }
+        .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
+      )
+    case .api:
+      return AnyView(
+        VStack(spacing: 0) {
+          header(
+            lastUpdatedAt: apiLastUpdatedAt,
+            isRefreshing: apiModel.isRefreshing,
+            date: date
+          ) {
+            Task { await apiModel.refresh() }
+          }
+          navigationSegments
+          Divider()
+          APIPlatformSummaryView(state: apiModel.state, date: date)
+            .frame(minHeight: 220)
+          if let cacheError = apiModel.cacheErrorMessage {
+            Divider()
+            StatusMessage(symbol: "externaldrive.badge.exclamationmark", text: cacheError)
+              .padding(.horizontal, 12)
+          }
+          Spacer(minLength: 0)
+          Divider()
+          footer
+        }
+        .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
+      )
     }
   }
 
@@ -39,29 +84,32 @@ struct MenuBarView: View {
     )
   }
 
-  private func header(overview: QuotaOverview, date: Date) -> some View {
+  private func header(
+    lastUpdatedAt: Date?,
+    isRefreshing: Bool,
+    date: Date,
+    refreshAction: @escaping () -> Void
+  ) -> some View {
     HStack(spacing: 8) {
       BrimBrandMark()
       Text("Brim")
         .font(.headline)
       Spacer()
-      Text(lastRefreshText(overview: overview, date: date))
+      Text(lastRefreshText(lastUpdatedAt: lastUpdatedAt, date: date))
         .font(.caption2)
         .foregroundStyle(.secondary)
         .monospacedDigit()
-      Button {
-        Task { await model.refresh() }
-      } label: {
-        if model.isRefreshing {
+      Button(action: refreshAction) {
+        if isRefreshing {
           ProgressView().controlSize(.small)
         } else {
           Image(systemName: "arrow.clockwise")
         }
       }
       .buttonStyle(.plain)
-      .disabled(model.isRefreshing)
-      .help(model.isRefreshing ? "Refreshing usage" : "Refresh usage")
-      .accessibilityLabel(model.isRefreshing ? "Refreshing usage" : "Refresh usage")
+      .disabled(isRefreshing)
+      .help(isRefreshing ? "Refreshing usage" : "Refresh usage")
+      .accessibilityLabel(isRefreshing ? "Refreshing usage" : "Refresh usage")
     }
     .padding(.horizontal, 12)
     .padding(.top, 8)
@@ -70,25 +118,31 @@ struct MenuBarView: View {
 
   private var navigationSegments: some View {
     HStack(spacing: 2) {
-      Text("Subscriptions")
-        .font(.caption.weight(.medium))
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 5)
-        .background(.background, in: RoundedRectangle(cornerRadius: 5))
-        .accessibilityAddTraits(.isSelected)
-      Text("API & routers")
-        .font(.caption)
-        .foregroundStyle(.tertiary)
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 5)
-        .help("API keys and routers are not supported yet.")
-        .accessibilityLabel("API and routers, unavailable")
-        .accessibilityHint("API keys and routers are not supported yet.")
+      segmentButton(.subscriptions, title: "Subscriptions")
+      segmentButton(.api, title: "API & routers")
     }
     .padding(2)
     .background(.quaternary, in: RoundedRectangle(cornerRadius: 7))
     .padding(.horizontal, 12)
     .padding(.bottom, 7)
+  }
+
+  private func segmentButton(_ segment: DashboardSegment, title: String) -> some View {
+    Button {
+      selectedSegment = segment
+    } label: {
+      Text(title)
+        .font(.caption.weight(selectedSegment == segment ? .medium : .regular))
+        .foregroundStyle(selectedSegment == segment ? .primary : .secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 5)
+        .background(
+          selectedSegment == segment ? Color.primary.opacity(0.08) : Color.clear,
+          in: RoundedRectangle(cornerRadius: 5)
+        )
+    }
+    .buttonStyle(.plain)
+    .accessibilityAddTraits(selectedSegment == segment ? .isSelected : [])
   }
 
   private func providerList(overview: QuotaOverview, date: Date) -> some View {
@@ -151,10 +205,24 @@ struct MenuBarView: View {
     .padding(.vertical, 7)
   }
 
-  private func lastRefreshText(overview: QuotaOverview, date: Date) -> String {
-    guard let lastUpdatedAt = overview.lastUpdatedAt else { return "Not refreshed" }
+  private func lastRefreshText(lastUpdatedAt: Date?, date: Date) -> String {
+    guard let lastUpdatedAt else { return "Not refreshed" }
     return QuotaTimeFormatter.refreshAge(since: lastUpdatedAt, at: date)
   }
+
+  private var apiLastUpdatedAt: Date? {
+    switch apiModel.state {
+    case let .available(snapshot), let .stale(snapshot, _):
+      snapshot.sourceTimestamp
+    case .loading, .unavailable, .unauthenticated:
+      nil
+    }
+  }
+}
+
+private enum DashboardSegment {
+  case subscriptions
+  case api
 }
 
 private struct ProviderListHeightPreference: PreferenceKey {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/QuotaBarApp.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/QuotaBarApp.swift
@@ -5,8 +5,10 @@ import SwiftUI
 @main
 struct QuotaBarApp: App {
   @State private var model: QuotaBarModel
+  @State private var apiModel: APIPlatformModel
   @State private var launchAtLogin: LaunchAtLoginController
   private let manualCredentials: ManualCredentialStore
+  private let openRouterCredentials: OpenRouterCredentialStore
   private let startupError: String?
 
   init() {
@@ -26,16 +28,21 @@ struct QuotaBarApp: App {
       startupError = "Brim could not configure its provider URLs."
     }
     self.manualCredentials = manualCredentials
+    let openRouterCredentials = OpenRouterCredentialStore()
+    self.openRouterCredentials = openRouterCredentials
     self.startupError = startupError
     let model = QuotaBarModel(providers: providers, settings: settings)
+    let apiModel = APIPlatformModel(settings: settings, credentials: openRouterCredentials)
     _model = State(initialValue: model)
+    _apiModel = State(initialValue: apiModel)
     _launchAtLogin = State(initialValue: LaunchAtLoginController())
     model.startPolling()
+    apiModel.startPolling()
   }
 
   var body: some Scene {
     MenuBarExtra {
-      MenuBarView(model: model, startupError: startupError)
+      MenuBarView(model: model, apiModel: apiModel, startupError: startupError)
     } label: {
       BrimMenuBarLabel(status: model.overallStatus)
     }
@@ -44,7 +51,9 @@ struct QuotaBarApp: App {
     Settings {
       SettingsView(
         model: model,
+        apiModel: apiModel,
         manualCredentials: manualCredentials,
+        openRouterCredentials: openRouterCredentials,
         launchAtLogin: launchAtLogin
       )
     }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
@@ -4,11 +4,16 @@ import SwiftUI
 
 struct SettingsView: View {
   @Bindable var model: QuotaBarModel
+  @Bindable var apiModel: APIPlatformModel
   let manualCredentials: ManualCredentialStore
+  let openRouterCredentials: OpenRouterCredentialStore
   @Bindable var launchAtLogin: LaunchAtLoginController
   @State private var drafts: [ProviderID: String] = [:]
   @State private var overriddenProviders: Set<ProviderID> = []
   @State private var credentialMessage: String?
+  @State private var openRouterDraft = ""
+  @State private var hasOpenRouterCredential = false
+  @State private var openRouterCredentialMessage: String?
 
   var body: some View {
     Form {
@@ -16,11 +21,45 @@ struct SettingsView: View {
       refreshSection
       loginSection
       credentialSection
+      openRouterCredentialSection
     }
     .formStyle(.grouped)
-    .frame(width: 520, height: 560)
+    .frame(width: 520, height: 680)
     .task { await loadCredentialStatus() }
     .onAppear { launchAtLogin.refresh() }
+  }
+
+  private var openRouterCredentialSection: some View {
+    Section("API platform") {
+      Text(
+        "Enter an OpenRouter Management API key to read credits, workspaces, and API-key usage. "
+          + "Brim only sends read-only requests; the key remains in your login Keychain."
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      if let url = URL(string: "https://openrouter.ai/settings/management-keys") {
+        Link("OpenRouter Management API keys", destination: url)
+      }
+      VStack(alignment: .leading, spacing: 5) {
+        HStack {
+          SecureField("OpenRouter Management API key", text: $openRouterDraft)
+          Button("Save") { saveOpenRouterCredential() }
+            .disabled(openRouterDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          Button("Remove") { removeOpenRouterCredential() }
+            .disabled(!hasOpenRouterCredential)
+        }
+        if hasOpenRouterCredential {
+          Label("Management API key saved in Keychain", systemImage: "key.fill")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+      }
+      if let openRouterCredentialMessage {
+        Text(openRouterCredentialMessage)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
   }
 
   private var providerSection: some View {
@@ -159,6 +198,39 @@ struct SettingsView: View {
         }
       } catch {
         credentialMessage = "Keychain status unavailable."
+      }
+    }
+    do {
+      hasOpenRouterCredential = try await openRouterCredentials.token() != nil
+    } catch {
+      openRouterCredentialMessage = "OpenRouter Keychain status unavailable."
+    }
+  }
+
+  private func saveOpenRouterCredential() {
+    let token = openRouterDraft
+    Task {
+      do {
+        try await openRouterCredentials.save(token)
+        hasOpenRouterCredential = true
+        openRouterDraft = ""
+        openRouterCredentialMessage = "Saved OpenRouter Management API key."
+        await apiModel.handleCredentialChange()
+      } catch {
+        openRouterCredentialMessage = error.localizedDescription
+      }
+    }
+  }
+
+  private func removeOpenRouterCredential() {
+    Task {
+      do {
+        try await openRouterCredentials.remove()
+        hasOpenRouterCredential = false
+        openRouterCredentialMessage = "Removed OpenRouter Management API key."
+        await apiModel.handleCredentialChange()
+      } catch {
+        openRouterCredentialMessage = error.localizedDescription
       }
     }
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatform.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatform.swift
@@ -1,0 +1,93 @@
+public import Foundation
+
+public enum APIPlatformID: String, Codable, Equatable, Sendable {
+  case openRouter = "openrouter"
+
+  public var displayName: String { "OpenRouter" }
+}
+
+public struct APIPlatformSnapshot: Codable, Equatable, Sendable {
+  public let platform: APIPlatformID
+  public let workspaceNames: [String]
+  public let creditsRemaining: Decimal
+  public let monthlySpend: Decimal
+  public let projectedSpend: Decimal
+  public let sourceTimestamp: Date
+
+  public init(
+    platform: APIPlatformID = .openRouter,
+    workspaceNames: [String],
+    creditsRemaining: Decimal,
+    monthlySpend: Decimal,
+    projectedSpend: Decimal,
+    sourceTimestamp: Date
+  ) {
+    self.platform = platform
+    self.workspaceNames = workspaceNames
+    self.creditsRemaining = creditsRemaining
+    self.monthlySpend = monthlySpend
+    self.projectedSpend = projectedSpend
+    self.sourceTimestamp = sourceTimestamp
+  }
+}
+
+public enum APIPlatformDisplayState: Equatable, Sendable {
+  case loading
+  case available(APIPlatformSnapshot)
+  case stale(APIPlatformSnapshot, reason: String)
+  case unavailable(message: String)
+  case unauthenticated(message: String)
+}
+
+public enum APIPlatformError: Error, Equatable, LocalizedError, Sendable {
+  case credentialsMissing
+  case credentialEmpty
+  case keychain(status: Int32)
+  case invalidURL
+  case unauthorized
+  case forbidden
+  case rateLimited
+  case requestTimedOut
+  case network
+  case malformedResponse
+  case cacheCorrupt
+  case cacheWriteFailed
+
+  public var errorDescription: String? {
+    switch self {
+    case .credentialsMissing:
+      "Add an OpenRouter Management API key in Brim Settings."
+    case .credentialEmpty:
+      "Enter an OpenRouter Management API key before saving."
+    case let .keychain(status):
+      "Unable to access the OpenRouter credential in Keychain (status \(status))."
+    case .invalidURL:
+      "The OpenRouter API URL is invalid."
+    case .unauthorized:
+      "OpenRouter rejected the Management API key. Check the key in Brim Settings."
+    case .forbidden:
+      "The OpenRouter key does not have permission to read account usage."
+    case .rateLimited:
+      "OpenRouter temporarily rate-limited Brim."
+    case .requestTimedOut:
+      "OpenRouter did not respond before the timeout."
+    case .network:
+      "Brim could not reach OpenRouter."
+    case .malformedResponse:
+      "OpenRouter returned malformed account data."
+    case .cacheCorrupt:
+      "The saved OpenRouter cache is corrupt."
+    case .cacheWriteFailed:
+      "Brim could not save the latest OpenRouter data."
+    }
+  }
+
+  public var isAuthenticationError: Bool {
+    switch self {
+    case .credentialsMissing, .unauthorized, .forbidden:
+      true
+    default:
+      false
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformModel.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformModel.swift
@@ -1,0 +1,159 @@
+public import Foundation
+public import Observation
+
+@MainActor @Observable
+public final class APIPlatformModel {
+  public let settings: AppSettings
+  public private(set) var state: APIPlatformDisplayState = .loading
+  public private(set) var isRefreshing = false
+  public private(set) var cacheErrorMessage: String?
+
+  private let client: OpenRouterAPIClient
+  private let credentials: OpenRouterCredentialStore
+  private let store: any APIPlatformSnapshotPersisting
+  private let providerTimeout: Duration
+  private var lastSuccessful: APIPlatformSnapshot?
+  private var pollingTask: Task<Void, Never>?
+  private var activeRefresh: Task<Void, Never>?
+
+  public init(
+    settings: AppSettings,
+    client: OpenRouterAPIClient = OpenRouterAPIClient(),
+    credentials: OpenRouterCredentialStore = OpenRouterCredentialStore(),
+    store: any APIPlatformSnapshotPersisting = JSONAPIPlatformSnapshotStore(),
+    providerTimeout: Duration = .seconds(25)
+  ) {
+    self.settings = settings
+    self.client = client
+    self.credentials = credentials
+    self.store = store
+    self.providerTimeout = providerTimeout
+    do {
+      if let snapshot = try store.load() {
+        lastSuccessful = snapshot
+        state = .stale(snapshot, reason: "Cached data; waiting for an OpenRouter refresh.")
+      }
+    } catch {
+      cacheErrorMessage = APIPlatformError.cacheCorrupt.localizedDescription
+    }
+  }
+
+  public func startPolling() {
+    guard pollingTask == nil else { return }
+    pollingTask = Task { [weak self] in
+      guard let self else { return }
+      await refresh()
+      while !Task.isCancelled {
+        do {
+          try await Task.sleep(for: .seconds(settings.pollingInterval))
+        } catch is CancellationError {
+          return
+        } catch {
+          return
+        }
+        await refresh()
+      }
+    }
+  }
+
+  public func stopPolling() {
+    pollingTask?.cancel()
+    pollingTask = nil
+  }
+
+  public func updatePollingInterval(_ interval: TimeInterval) {
+    settings.setPollingInterval(interval)
+    guard pollingTask != nil else { return }
+    stopPolling()
+    startPolling()
+  }
+
+  public func refresh() async {
+    if let activeRefresh {
+      await activeRefresh.value
+      return
+    }
+    let task = Task { [weak self] in
+      guard let self else { return }
+      await self.performRefresh()
+    }
+    activeRefresh = task
+    await task.value
+    activeRefresh = nil
+  }
+
+  public func handleCredentialChange() async {
+    lastSuccessful = nil
+    state = .loading
+    do {
+      try store.remove()
+      cacheErrorMessage = nil
+    } catch {
+      cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
+    }
+    await refresh()
+  }
+
+  private func performRefresh() async {
+    isRefreshing = true
+    defer { isRefreshing = false }
+
+    do {
+      guard let token = try await credentials.token() else {
+        state = .unauthenticated(message: APIPlatformError.credentialsMissing.localizedDescription)
+        return
+      }
+      let snapshot = try await Self.fetch(
+        client: client,
+        managementKey: token,
+        timeout: providerTimeout
+      )
+      lastSuccessful = snapshot
+      state = .available(snapshot)
+      do {
+        try store.save(snapshot)
+        cacheErrorMessage = nil
+      } catch {
+        cacheErrorMessage = APIPlatformError.cacheWriteFailed.localizedDescription
+      }
+    } catch {
+      let apiError = Self.classify(error: error)
+      if let lastSuccessful {
+        state = .stale(lastSuccessful, reason: apiError.localizedDescription)
+      } else if apiError.isAuthenticationError {
+        state = .unauthenticated(message: apiError.localizedDescription)
+      } else {
+        state = .unavailable(message: apiError.localizedDescription)
+      }
+    }
+  }
+
+  nonisolated private static func fetch(
+    client: OpenRouterAPIClient,
+    managementKey: String,
+    timeout: Duration
+  ) async throws -> APIPlatformSnapshot {
+    try await withThrowingTaskGroup(of: APIPlatformSnapshot.self) { group in
+      group.addTask {
+        try await client.fetchSnapshot(managementKey: managementKey)
+      }
+      group.addTask {
+        try await Task.sleep(for: timeout)
+        throw APIPlatformError.requestTimedOut
+      }
+      defer { group.cancelAll() }
+      guard let result = try await group.next() else {
+        throw APIPlatformError.requestTimedOut
+      }
+      return result
+    }
+  }
+
+  nonisolated private static func classify(error: any Error) -> APIPlatformError {
+    if let apiError = error as? APIPlatformError { return apiError }
+    if let quotaError = error as? QuotaError, case let .keychain(status) = quotaError {
+      return .keychain(status: status)
+    }
+    return .network
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformPersistence.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/APIPlatformPersistence.swift
@@ -1,0 +1,57 @@
+public import Foundation
+
+public protocol APIPlatformSnapshotPersisting: Sendable {
+  func load() throws -> APIPlatformSnapshot?
+  func save(_ snapshot: APIPlatformSnapshot) throws
+  func remove() throws
+}
+
+public final class JSONAPIPlatformSnapshotStore: APIPlatformSnapshotPersisting, @unchecked Sendable
+{
+  public let url: URL
+  private let fileManager: FileManager
+
+  public init(url: URL, fileManager: FileManager = .default) {
+    self.url = url
+    self.fileManager = fileManager
+  }
+
+  public convenience init(fileManager: FileManager = .default) {
+    let support =
+      fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent(
+        "Library/Application Support")
+    self.init(
+      url: support.appendingPathComponent("QuotaBar/api-platform-snapshot.json"),
+      fileManager: fileManager
+    )
+  }
+
+  public func load() throws -> APIPlatformSnapshot? {
+    guard fileManager.fileExists(atPath: url.path) else { return nil }
+    do {
+      return try JSONDecoder().decode(APIPlatformSnapshot.self, from: Data(contentsOf: url))
+    } catch {
+      throw APIPlatformError.cacheCorrupt
+    }
+  }
+
+  public func save(_ snapshot: APIPlatformSnapshot) throws {
+    do {
+      try fileManager.createDirectory(
+        at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try JSONEncoder().encode(snapshot).write(to: url, options: .atomic)
+    } catch {
+      throw APIPlatformError.cacheWriteFailed
+    }
+  }
+
+  public func remove() throws {
+    guard fileManager.fileExists(atPath: url.path) else { return }
+    do {
+      try fileManager.removeItem(at: url)
+    } catch {
+      throw APIPlatformError.cacheWriteFailed
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenRouterAPI.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenRouterAPI.swift
@@ -1,0 +1,263 @@
+public import Foundation
+
+public enum APIHTTPMethod: String, Equatable, Sendable {
+  case get = "GET"
+}
+
+public struct OpenRouterRequest: Equatable, Sendable, CustomStringConvertible {
+  public let method: APIHTTPMethod
+  public let url: URL
+  public let bearerToken: String
+  public let timeout: TimeInterval
+
+  public init(
+    method: APIHTTPMethod = .get,
+    url: URL,
+    bearerToken: String,
+    timeout: TimeInterval = 20
+  ) {
+    self.method = method
+    self.url = url
+    self.bearerToken = bearerToken
+    self.timeout = timeout
+  }
+
+  public var description: String {
+    "OpenRouterRequest(method: \(method.rawValue), url: \(url.absoluteString), bearerToken: <redacted>)"
+  }
+}
+
+public struct OpenRouterResponse: Equatable, Sendable {
+  public let statusCode: Int
+  public let data: Data
+
+  public init(statusCode: Int, data: Data) {
+    self.statusCode = statusCode
+    self.data = data
+  }
+}
+
+public protocol OpenRouterTransport: Sendable {
+  func send(_ request: OpenRouterRequest) async throws -> OpenRouterResponse
+}
+
+public final class URLSessionOpenRouterTransport: OpenRouterTransport, @unchecked Sendable {
+  private let session: URLSession
+
+  public init(session: URLSession? = nil) {
+    if let session {
+      self.session = session
+    } else {
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.timeoutIntervalForRequest = 20
+      configuration.timeoutIntervalForResource = 30
+      self.session = URLSession(configuration: configuration)
+    }
+  }
+
+  public func send(_ request: OpenRouterRequest) async throws -> OpenRouterResponse {
+    var urlRequest = URLRequest(url: request.url, timeoutInterval: request.timeout)
+    urlRequest.httpMethod = request.method.rawValue
+    urlRequest.setValue("Bearer \(request.bearerToken)", forHTTPHeaderField: "Authorization")
+    urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+    do {
+      let (data, response) = try await session.data(for: urlRequest)
+      guard let response = response as? HTTPURLResponse else {
+        throw APIPlatformError.network
+      }
+      return OpenRouterResponse(statusCode: response.statusCode, data: data)
+    } catch let error as APIPlatformError {
+      throw error
+    } catch let error as URLError where error.code == .timedOut {
+      throw APIPlatformError.requestTimedOut
+    } catch {
+      throw APIPlatformError.network
+    }
+  }
+}
+
+public struct OpenRouterEndpoints: Sendable {
+  public let baseURL: URL
+
+  public init(baseURL: URL = OpenRouterEndpoints.defaultBaseURL) {
+    guard baseURL.scheme?.lowercased() == "https", baseURL.host != nil else {
+      preconditionFailure("OpenRouter endpoint must use an HTTPS URL with a host.")
+    }
+    self.baseURL = baseURL
+  }
+
+  public static let defaultBaseURL: URL = {
+    guard let url = URL(string: "https://openrouter.ai") else {
+      preconditionFailure("The OpenRouter default URL is invalid.")
+    }
+    return url
+  }()
+
+  public func credits() -> URL {
+    baseURL.appendingPathComponent("api/v1/credits")
+  }
+
+  public func workspaces(offset: Int, limit: Int) -> URL {
+    url(
+      path: "api/v1/workspaces",
+      queryItems: [
+        URLQueryItem(name: "offset", value: String(offset)),
+        URLQueryItem(name: "limit", value: String(limit)),
+      ]
+    )
+  }
+
+  public func keys(workspaceID: String, offset: Int) -> URL {
+    url(
+      path: "api/v1/keys",
+      queryItems: [
+        URLQueryItem(name: "workspace_id", value: workspaceID),
+        URLQueryItem(name: "include_disabled", value: "true"),
+        URLQueryItem(name: "offset", value: String(offset)),
+      ]
+    )
+  }
+
+  private func url(path: String, queryItems: [URLQueryItem]) -> URL {
+    var components = URLComponents()
+    components.scheme = baseURL.scheme
+    components.host = baseURL.host
+    components.port = baseURL.port
+    components.path = baseURL.path + "/" + path
+    components.queryItems = queryItems
+    guard let url = components.url else {
+      preconditionFailure("The OpenRouter endpoint URL could not be constructed.")
+    }
+    return url
+  }
+}
+
+public struct OpenRouterAPIClient: Sendable {
+  private let transport: any OpenRouterTransport
+  private let endpoints: OpenRouterEndpoints
+  private let pageSize = 100
+
+  public init(
+    transport: any OpenRouterTransport = URLSessionOpenRouterTransport(),
+    endpoints: OpenRouterEndpoints = OpenRouterEndpoints()
+  ) {
+    self.transport = transport
+    self.endpoints = endpoints
+  }
+
+  public func fetchSnapshot(
+    managementKey: String,
+    now: Date = .now,
+    timeZone: TimeZone = .autoupdatingCurrent
+  ) async throws -> APIPlatformSnapshot {
+    let credits: CreditsEnvelope = try await get(path: endpoints.credits(), token: managementKey)
+    let workspaces = try await fetchAllWorkspaces(token: managementKey)
+    let keys = try await fetchAllKeys(workspaces: workspaces, token: managementKey)
+    let creditsRemaining = credits.data.totalCredits - credits.data.totalUsage
+    guard creditsRemaining >= 0 else { throw APIPlatformError.malformedResponse }
+
+    let monthlySpend = keys.reduce(Decimal.zero) { total, key in
+      total + key.usageMonthly + key.byokUsageMonthly
+    }
+    guard monthlySpend >= 0 else { throw APIPlatformError.malformedResponse }
+
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+    let elapsedDays = calendar.component(.day, from: now)
+    guard let range = calendar.range(of: .day, in: .month, for: now), elapsedDays > 0 else {
+      throw APIPlatformError.malformedResponse
+    }
+    let daysInMonth = range.count
+    let projectedSpend = monthlySpend / Decimal(elapsedDays) * Decimal(daysInMonth)
+
+    return APIPlatformSnapshot(
+      workspaceNames: workspaces.map(\.name).sorted(),
+      creditsRemaining: creditsRemaining,
+      monthlySpend: monthlySpend,
+      projectedSpend: projectedSpend,
+      sourceTimestamp: now
+    )
+  }
+
+  private func fetchAllWorkspaces(token: String) async throws -> [Workspace] {
+    var offset = 0
+    var result: [Workspace] = []
+    while true {
+      let page: WorkspacePage = try await get(
+        path: endpoints.workspaces(offset: offset, limit: pageSize), token: token)
+      guard page.data.count <= pageSize else { throw APIPlatformError.malformedResponse }
+      result.append(contentsOf: page.data)
+      if result.count >= page.totalCount || page.data.isEmpty { return result }
+      offset += page.data.count
+    }
+  }
+
+  private func fetchAllKeys(workspaces: [Workspace], token: String) async throws -> [APIKey] {
+    var result: [APIKey] = []
+    for workspace in workspaces {
+      var offset = 0
+      while true {
+        let page: APIKeyPage = try await get(
+          path: endpoints.keys(workspaceID: workspace.id, offset: offset), token: token)
+        guard page.data.count <= pageSize else { throw APIPlatformError.malformedResponse }
+        result.append(contentsOf: page.data)
+        if page.data.isEmpty || page.data.count < pageSize { break }
+        offset += page.data.count
+      }
+    }
+    return result
+  }
+
+  private func get<Value: Decodable>(path: URL, token: String) async throws -> Value {
+    let response = try await transport.send(
+      OpenRouterRequest(url: path, bearerToken: token)
+    )
+    switch response.statusCode {
+    case 200..<300:
+      do {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(Value.self, from: response.data)
+      } catch {
+        throw APIPlatformError.malformedResponse
+      }
+    case 401:
+      throw APIPlatformError.unauthorized
+    case 403:
+      throw APIPlatformError.forbidden
+    case 429:
+      throw APIPlatformError.rateLimited
+    default:
+      throw APIPlatformError.network
+    }
+  }
+}
+
+private struct CreditsEnvelope: Decodable {
+  let data: Credits
+}
+
+private struct Credits: Decodable {
+  let totalCredits: Decimal
+  let totalUsage: Decimal
+}
+
+private struct WorkspacePage: Decodable {
+  let data: [Workspace]
+  let totalCount: Int
+}
+
+private struct Workspace: Decodable {
+  let id: String
+  let name: String
+}
+
+private struct APIKeyPage: Decodable {
+  let data: [APIKey]
+}
+
+private struct APIKey: Decodable {
+  let usageMonthly: Decimal
+  let byokUsageMonthly: Decimal
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenRouterCredentials.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/OpenRouterCredentials.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+public actor OpenRouterCredentialStore {
+  public static let service = "com.sjerred.QuotaBar.api-platform"
+  public static let account = "openrouter-management"
+
+  private let keychain: any KeychainClient
+
+  public init(keychain: any KeychainClient = SystemKeychainClient()) {
+    self.keychain = keychain
+  }
+
+  public func token() throws -> String? {
+    do {
+      guard let data = try keychain.read(service: Self.service, account: Self.account) else {
+        return nil
+      }
+      guard let token = String(data: data, encoding: .utf8) else {
+        throw APIPlatformError.keychain(status: errSecDecode)
+      }
+      let normalized = token.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !normalized.isEmpty else { throw APIPlatformError.credentialEmpty }
+      return normalized
+    } catch let error as APIPlatformError {
+      throw error
+    } catch let error as QuotaError {
+      if case let .keychain(status) = error {
+        throw APIPlatformError.keychain(status: status)
+      }
+      throw error
+    }
+  }
+
+  public func save(_ token: String) throws {
+    let normalized = token.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalized.isEmpty else { throw APIPlatformError.credentialEmpty }
+    do {
+      try keychain.write(
+        Data(normalized.utf8), service: Self.service, account: Self.account)
+    } catch let error as QuotaError {
+      if case let .keychain(status) = error {
+        throw APIPlatformError.keychain(status: status)
+      }
+      throw error
+    }
+  }
+
+  public func remove() throws {
+    do {
+      try keychain.delete(service: Self.service, account: Self.account)
+    } catch let error as QuotaError {
+      if case let .keychain(status) = error {
+        throw APIPlatformError.keychain(status: status)
+      }
+      throw error
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-credits.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-credits.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "total_credits": 100.0,
+    "total_usage": 40.0
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-keys-development.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-keys-development.json
@@ -1,0 +1,8 @@
+{
+  "data": [
+    {
+      "usage_monthly": 0.2,
+      "byok_usage_monthly": 0.05
+    }
+  ]
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-keys-production.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-keys-production.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    {
+      "usage_monthly": 2.5,
+      "byok_usage_monthly": 0.5
+    },
+    {
+      "usage_monthly": 1.0,
+      "byok_usage_monthly": 0.25
+    }
+  ]
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-malformed.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-malformed.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "total_credits": "not-a-number"
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-workspaces-page-0.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-workspaces-page-0.json
@@ -1,0 +1,9 @@
+{
+  "data": [
+    {
+      "id": "workspace-production",
+      "name": "Production"
+    }
+  ],
+  "total_count": 2
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-workspaces-page-1.json
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/Fixtures/openrouter-workspaces-page-1.json
@@ -1,0 +1,9 @@
+{
+  "data": [
+    {
+      "id": "workspace-development",
+      "name": "Development"
+    }
+  ],
+  "total_count": 2
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
@@ -1,0 +1,269 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class OpenRouterTests: XCTestCase {
+  func testFetchSnapshotAggregatesAllWorkspacesAndKeys() async throws {
+    let endpoints = testEndpoints()
+    let transport = OpenRouterRoutingTransport(
+      routes: [
+        endpoints.credits().absoluteString: response(fixture("openrouter-credits")),
+        endpoints.workspaces(offset: 0, limit: 100).absoluteString:
+          response(fixture("openrouter-workspaces-page-0")),
+        endpoints.workspaces(offset: 1, limit: 100).absoluteString:
+          response(fixture("openrouter-workspaces-page-1")),
+        endpoints.keys(workspaceID: "workspace-production", offset: 0).absoluteString:
+          response(fixture("openrouter-keys-production")),
+        endpoints.keys(workspaceID: "workspace-development", offset: 0).absoluteString:
+          response(fixture("openrouter-keys-development")),
+      ])
+    let client = OpenRouterAPIClient(transport: transport, endpoints: endpoints)
+
+    let snapshot = try await client.fetchSnapshot(
+      managementKey: "management-secret",
+      now: date("2026-08-16T12:00:00Z"),
+      timeZone: utcTimeZone()
+    )
+
+    XCTAssertEqual(snapshot.workspaceNames, ["Development", "Production"])
+    XCTAssertEqual(snapshot.creditsRemaining, Decimal(string: "60"))
+    XCTAssertEqual(snapshot.monthlySpend, Decimal(string: "4.5"))
+    XCTAssertEqual(snapshot.projectedSpend, Decimal(string: "8.71875"))
+    XCTAssertEqual(snapshot.sourceTimestamp, date("2026-08-16T12:00:00Z"))
+
+    let requests = await transport.requests
+    XCTAssertEqual(requests.count, 5)
+    XCTAssertTrue(requests.allSatisfy { $0.method == .get })
+    XCTAssertTrue(requests.allSatisfy { !$0.description.contains("management-secret") })
+    XCTAssertTrue(
+      requests.contains {
+        $0.url.query?.contains("include_disabled=true") == true
+      }
+    )
+  }
+
+  func testProjectionUsesLocalCalendarMonthLength() async throws {
+    let endpoints = testEndpoints()
+    let transport = OpenRouterRoutingTransport(
+      routes: [
+        endpoints.credits().absoluteString: response(
+          Data(#"{ "data": { "total_credits": 20, "total_usage": 0 } }"#.utf8)
+        ),
+        endpoints.workspaces(offset: 0, limit: 100).absoluteString: response(
+          Data(#"{ "data": [{ "id": "default", "name": "Default" }], "total_count": 1 }"#.utf8)
+        ),
+        endpoints.keys(workspaceID: "default", offset: 0).absoluteString: response(
+          Data(#"{ "data": [{ "usage_monthly": 28, "byok_usage_monthly": 0 }] }"#.utf8)
+        ),
+      ])
+    let client = OpenRouterAPIClient(transport: transport, endpoints: endpoints)
+    let snapshot = try await client.fetchSnapshot(
+      managementKey: "secret",
+      now: date("2026-02-28T12:00:00Z"),
+      timeZone: utcTimeZone()
+    )
+
+    XCTAssertEqual(snapshot.monthlySpend, Decimal(string: "28"))
+    XCTAssertEqual(snapshot.projectedSpend, Decimal(string: "28"))
+  }
+
+  func testHTTPStatusesAndMalformedResponsesAreExplicit() async throws {
+    let endpoints = testEndpoints()
+    let unauthorized = OpenRouterAPIClient(
+      transport: OpenRouterRoutingTransport(
+        routes: [
+          endpoints.credits().absoluteString: OpenRouterResponse(statusCode: 401, data: Data())
+        ]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await unauthorized.fetchSnapshot(managementKey: "secret")
+      XCTFail("Expected unauthorized error")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .unauthorized)
+    }
+
+    let malformed = OpenRouterAPIClient(
+      transport: OpenRouterRoutingTransport(
+        routes: [endpoints.credits().absoluteString: response(fixture("openrouter-malformed"))]
+      ),
+      endpoints: endpoints
+    )
+    do {
+      _ = try await malformed.fetchSnapshot(managementKey: "secret")
+      XCTFail("Expected malformed response error")
+    } catch let error as APIPlatformError {
+      XCTAssertEqual(error, .malformedResponse)
+    }
+  }
+
+  func testOpenRouterCredentialUsesDedicatedKeychainEntry() async throws {
+    let keychain = FakeKeychain()
+    let store = OpenRouterCredentialStore(keychain: keychain)
+
+    let initialToken = try await store.token()
+    XCTAssertNil(initialToken)
+    try await store.save("  management-secret  ")
+    let savedToken = try await store.token()
+    XCTAssertEqual(savedToken, "management-secret")
+    try await store.remove()
+    let removedToken = try await store.token()
+    XCTAssertNil(removedToken)
+
+    XCTAssertNil(
+      try keychain.read(
+        service: ManualCredentialStore.service,
+        account: ProviderID.codex.rawValue
+      )
+    )
+  }
+
+  func testAPIPlatformCacheContainsNoCredential() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = root.appendingPathComponent("api-platform-snapshot.json")
+    let store = JSONAPIPlatformSnapshotStore(url: url)
+    let snapshot = APIPlatformSnapshot(
+      workspaceNames: ["Default"],
+      creditsRemaining: decimal("10"),
+      monthlySpend: decimal("2.5"),
+      projectedSpend: decimal("5"),
+      sourceTimestamp: date("2026-08-16T12:00:00Z")
+    )
+
+    try store.save(snapshot)
+
+    let cached = try Data(contentsOf: url)
+    XCTAssertFalse(String(data: cached, encoding: .utf8)?.contains("management-secret") == true)
+    XCTAssertEqual(try store.load(), snapshot)
+    try store.remove()
+    XCTAssertNil(try store.load())
+  }
+
+  @MainActor
+  func testAPIPlatformModelReportsUnauthenticatedWithoutKey() async {
+    let settings = AppSettings(store: APISettingsStore())
+    let model = APIPlatformModel(
+      settings: settings,
+      credentials: OpenRouterCredentialStore(keychain: FakeKeychain()),
+      store: MemoryAPIPlatformStore()
+    )
+
+    await model.refresh()
+
+    guard case let .unauthenticated(message) = model.state else {
+      XCTFail("Expected missing-key state")
+      return
+    }
+    XCTAssertEqual(message, APIPlatformError.credentialsMissing.localizedDescription)
+  }
+
+  @MainActor
+  func testAPIPlatformModelRetainsCachedSnapshotAsStale() async throws {
+    let endpoints = testEndpoints()
+    let keychain = FakeKeychain()
+    let credentials = OpenRouterCredentialStore(keychain: keychain)
+    try await credentials.save("secret")
+    let cached = APIPlatformSnapshot(
+      workspaceNames: ["Default"],
+      creditsRemaining: decimal("10"),
+      monthlySpend: decimal("2"),
+      projectedSpend: decimal("4"),
+      sourceTimestamp: date("2026-08-16T11:00:00Z")
+    )
+    let store = MemoryAPIPlatformStore(loaded: cached)
+    let model = APIPlatformModel(
+      settings: AppSettings(store: APISettingsStore()),
+      client: OpenRouterAPIClient(
+        transport: OpenRouterRoutingTransport(
+          routes: [
+            endpoints.credits().absoluteString: OpenRouterResponse(statusCode: 401, data: Data())
+          ]
+        ),
+        endpoints: endpoints
+      ),
+      credentials: credentials,
+      store: store
+    )
+
+    await model.refresh()
+
+    guard case let .stale(snapshot, reason) = model.state else {
+      XCTFail("Expected stale cached state")
+      return
+    }
+    XCTAssertEqual(snapshot, cached)
+    XCTAssertEqual(reason, APIPlatformError.unauthorized.localizedDescription)
+  }
+
+  private func response(_ data: Data) -> OpenRouterResponse {
+    OpenRouterResponse(statusCode: 200, data: data)
+  }
+}
+
+private func testEndpoints() -> OpenRouterEndpoints {
+  guard let url = URL(string: "https://openrouter.test") else {
+    preconditionFailure("Invalid test endpoint")
+  }
+  return OpenRouterEndpoints(baseURL: url)
+}
+
+private func utcTimeZone() -> TimeZone {
+  guard let timeZone = TimeZone(secondsFromGMT: 0) else {
+    preconditionFailure("Invalid UTC test time zone")
+  }
+  return timeZone
+}
+
+private func decimal(_ value: String) -> Decimal {
+  guard let result = Decimal(string: value) else {
+    preconditionFailure("Invalid test decimal")
+  }
+  return result
+}
+
+private final class APISettingsStore: SettingsPersisting, @unchecked Sendable {
+  func enabledProviders() throws -> Set<ProviderID>? { Set(ProviderID.allCases) }
+  func pollingInterval() throws -> TimeInterval? { 300 }
+  func save(enabledProviders _: Set<ProviderID>, pollingInterval _: TimeInterval) {}
+}
+
+private final class MemoryAPIPlatformStore: APIPlatformSnapshotPersisting, @unchecked Sendable {
+  private let lock = NSLock()
+  private var snapshot: APIPlatformSnapshot?
+
+  init(loaded: APIPlatformSnapshot? = nil) {
+    snapshot = loaded
+  }
+
+  func load() throws -> APIPlatformSnapshot? {
+    lock.withLock { snapshot }
+  }
+
+  func save(_ snapshot: APIPlatformSnapshot) throws {
+    lock.withLock { self.snapshot = snapshot }
+  }
+
+  func remove() throws {
+    lock.withLock { snapshot = nil }
+  }
+}
+
+private actor OpenRouterRoutingTransport: OpenRouterTransport {
+  private let routes: [String: OpenRouterResponse]
+  private(set) var requests: [OpenRouterRequest] = []
+
+  init(routes: [String: OpenRouterResponse]) {
+    self.routes = routes
+  }
+
+  func send(_ request: OpenRouterRequest) throws -> OpenRouterResponse {
+    requests.append(request)
+    guard let response = routes[request.url.absoluteString] else {
+      throw APIPlatformError.network
+    }
+    return response
+  }
+}


### PR DESCRIPTION
## Why

Brim's existing API & routers segment was disabled, so API-platform credits and spend were not visible alongside subscription quotas.

## What

- Add a separate API-platform domain/model and cached display state for OpenRouter financial data.
- Use only read-only OpenRouter Management API `GET` calls for credits, paginated workspaces, and paginated keys.
- Aggregate `usage_monthly + byok_usage_monthly` across all workspaces and keys, including disabled keys.
- Compute credits remaining from total credits minus total usage, and project month-end spend using the local calendar pace.
- Store the Management API key in a dedicated macOS Keychain namespace; never persist it in snapshots, logs, or UI.
- Add loading, stale-cache, setup, and explicit API error states to the menu-bar surface and Settings.
- Document that the first slice reports API-key usage, including estimated BYOK usage, rather than Chatroom/Fusion activity.

## Verification

- `bun run verify:macos`
- `bun run lint:swift`
- `bun run format:check`
- 103 Swift tests passed; QuotaBarCore coverage: 86.49%.
- Xcode build, bundle signing, and designated-requirement verification passed.
- Staged pre-commit hooks passed, including Prettier, suppression checks, and Gitleaks.
- No live OpenRouter credential was used.

## Rollout notes

OpenRouter Management API keys can have broad account authority. Brim only issues the documented read-only requests and does not call POST, PATCH, or DELETE endpoints.