### PR TITLE
feat(toolkit): search local agent history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -399,9 +399,41 @@ transcripts into the repository, commits, logs, or chat.
 
 ### Example History Queries
 
-There is no single cross-client history index, so combine the read-only queries
-below. The seven-day examples use a rolling window; use explicit start and end
-dates when “last week” means a calendar week.
+`toolkit history` provides the preferred local cross-client index. Install its
+macOS LaunchAgent once; it polls the documented stores every 30 seconds and
+keeps a private, rebuildable FTS5 index under `~/.toolkit/history/`. Search is
+read-only and does not run live GitHub, deployment, Kubernetes, or cloud checks.
+
+```bash
+# Install and start background ingestion.
+toolkit history daemon install
+
+# “What did I work on last week?” (rolling seven-day window).
+toolkit history recent --since 7d
+
+# “Didn't I solve this before?”
+toolkit history search "argocd prune" --since 90d --include-excerpts
+
+# Inspect source coverage and ingestion errors.
+toolkit history sources
+toolkit history daemon status
+
+# “What's the status of X?” — history finds prior context; verify current truth separately.
+toolkit history search "X" --since 30d
+toolkit deployed <service-or-commit>
+toolkit pr health <PR_NUMBER>
+```
+
+Use `--source conductor|claude|codex|cursor|opencode-conductor|opencode-standalone`
+to narrow a search and `--json` for agent-readable output. `--include-excerpts`
+reopens source stores read-only for bounded excerpts; complete transcript bodies
+are not copied into the index. The LaunchAgent, index, socket, state, and logs
+are user-private. Never index or print standalone OpenCode's `auth.json`.
+
+The commands below remain useful as a read-only fallback when the index has not
+been installed or a client has changed its internal schema. The seven-day
+examples use a rolling window; use explicit start and end dates when “last week”
+means a calendar week.
 
 To find recent work across the main stores:
 

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -37,6 +37,7 @@ src/
 │   ├── alerts.ts         # toolkit alerts
 │   ├── bugsink.ts        # toolkit bugsink
 │   ├── grafana.ts        # toolkit gf
+│   ├── history.ts        # toolkit history
 │   └── screenshot.ts     # toolkit screenshot
 ├── commands/
 │   ├── pr/               # PR subcommands
@@ -44,6 +45,7 @@ src/
 │   ├── alerts.ts         # Alert ledger subcommands
 │   ├── bugsink/          # Bugsink subcommands
 │   ├── grafana/          # Grafana subcommands
+│   ├── history/          # Local agent-history commands
 │   └── screenshot/       # `screenshot` orchestration
 └── lib/
     ├── github/           # GitHub API via gh CLI
@@ -53,6 +55,7 @@ src/
     ├── grafana/          # Grafana REST API client
     ├── pinchtab-cli/     # PinchTab CLI wrapper (screenshot's browser driver)
     ├── screenshot/       # Package registry + dev-server lifecycle
+    ├── history/          # Local agent-history index, source adapters, daemon
     └── output/           # Output formatting
 ```
 
@@ -173,6 +176,44 @@ Design notes encoded in the code:
   with `--external ffmpeg-static` (an optional native dep of a voice transitive).
 
 The agent-facing how-to lives in the `discord` skill.
+
+## `history` — search local agent conversations
+
+`toolkit history` searches a private, local FTS5 index built from Conductor,
+Claude Code, Codex, Cursor, bundled OpenCode, and standalone OpenCode. It is a
+historical recollection tool: it never calls GitHub, ArgoCD, Kubernetes, or
+other live services.
+
+```bash
+toolkit history daemon install
+toolkit history recent --since 7d
+toolkit history search "kubernetes ingress" --since 30d --include-excerpts
+toolkit history sources --json
+toolkit history daemon status --json
+toolkit history daemon reindex
+```
+
+The daemon is a user-scoped macOS LaunchAgent named
+`com.jerred.toolkit-history`. It polls every 30 seconds, owns writes to
+`~/.toolkit/history/index.sqlite`, and exposes a 0600 Unix socket for status and
+reindex requests. The index uses a contentless FTS5 table plus metadata; full
+transcript bodies are never stored in ordinary index tables. Excerpts are
+loaded read-only from the original source only when `--include-excerpts` is
+requested.
+
+Runtime files are private: `index.sqlite`, `daemon.sock`, `state.json`, and
+`logs/` are under `~/.toolkit/history/`; the plist is
+`~/Library/LaunchAgents/com.jerred.toolkit-history.plist`. `daemon stop` unloads
+the job without deleting the plist, while `daemon uninstall` unloads and
+removes it. LaunchAgent installation is macOS-only.
+
+Source adapters must inspect only documented conversation tables/files, fail
+with a source-specific schema error when a client changes, and report that
+error through `history sources` rather than silently claiming coverage. Never
+read standalone OpenCode `~/.local/share/opencode/auth.json`; credentials must
+not enter the index, excerpts, logs, tests, or commits. Source SQLite files and
+JSONL transcripts are always opened/read-only. Use the history skill for the
+full command recipes and source boundaries.
 
 ## `pr asset` — PR media host
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -153,6 +153,38 @@ toolkit discord daemon start --ttl 30m
 toolkit discord send 123456789012345678 "hello"
 ```
 
+### `history` — search local agent conversations
+
+`history` maintains a private local index of Conductor, Claude Code, Codex,
+Cursor, bundled OpenCode, and standalone OpenCode conversations. Install the
+macOS LaunchAgent once; search itself only reads the index and never performs
+live service checks.
+
+| Command                                                           | Description                              |
+| ----------------------------------------------------------------- | ---------------------------------------- |
+| `history search <QUERY> [--since 7d] [--source NAME] [--limit N]` | Search indexed work                      |
+| `history search <QUERY> --include-excerpts`                       | Add bounded read-only source excerpts    |
+| `history recent [--since 7d] [--limit N]`                         | List recent indexed sessions             |
+| `history sources [--json]`                                        | Show source availability and scan errors |
+| `history daemon install`                                          | Install and start the macOS LaunchAgent  |
+| `history daemon status\|reindex`                                  | Inspect or refresh ingestion             |
+| `history daemon stop\|start\|uninstall`                           | Manage the LaunchAgent lifecycle         |
+
+```bash
+toolkit history daemon install
+toolkit history recent --since 7d
+toolkit history search "didn't I solve this before" --since 90d --include-excerpts
+toolkit history sources
+```
+
+The rebuildable index is `~/.toolkit/history/index.sqlite`; daemon state,
+socket, and logs are in that private directory. The LaunchAgent is
+`~/Library/LaunchAgents/com.jerred.toolkit-history.plist`. Transcript bodies
+are not copied into ordinary index tables, and standalone OpenCode's
+`~/.local/share/opencode/auth.json` is never read or indexed. Use `deployed`,
+`pr health`, or the relevant live client to verify current status after using
+history for context.
+
 ## Environment variables
 
 | Variable              | Description                                                      |

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -17,7 +17,7 @@
     "build": "bun build ./src/index.ts --compile --external ffmpeg-static --outfile=dist/toolkit",
     "test": "bun run test:unit",
     "test:coverage": "bun test --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage --config ../../scripts/bunfig.coverage.toml --coverage scripts/install.test.ts",
-    "test:unit": "bun test test/lib test/bugsink test/s3 test/deployed test/screenshot scripts",
+    "test:unit": "bun test test/lib test/bugsink test/s3 test/deployed test/screenshot test/history scripts",
     "install:local": "bun scripts/install.ts",
     "test:integration": "bun test test-integration",
     "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit",

--- a/packages/toolkit/skills/history/SKILL.md
+++ b/packages/toolkit/skills/history/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: history
+description: Search local Conductor, Claude Code, Codex, Cursor, and OpenCode work history with toolkit.
+---
+
+# Local agent history
+
+Use the local index for recollection and prior-work discovery. It is not a
+deployment or CI status oracle.
+
+## First-time setup
+
+```bash
+toolkit history daemon install
+toolkit history daemon status
+```
+
+The daemon is a user-scoped macOS LaunchAgent. It polls the source stores every
+30 seconds and writes only to `~/.toolkit/history/`. `daemon reindex` requests a
+full scan; `daemon stop` unloads the job, and `daemon uninstall` also removes
+the plist.
+
+## Search recipes
+
+```bash
+# What did I work on last week?
+toolkit history recent --since 7d
+
+# Didn't I solve this before?
+toolkit history search "argocd prune" --since 90d --include-excerpts
+
+# Limit the search to one client or return structured output.
+toolkit history search "ingress" --source conductor --json
+
+# Check coverage before interpreting an empty result.
+toolkit history sources
+toolkit history daemon status --json
+```
+
+Supported sources are `conductor`, `claude`, `codex`, `cursor`,
+`opencode-conductor`, and `opencode-standalone`. Search defaults to metadata
+and match results. `--include-excerpts` reopens the original stores read-only
+and returns bounded excerpts without persisting transcript bodies in the
+index.
+
+For “what is the current status?”, use history to find the relevant branch,
+PR, or workspace, then verify the live state separately with `toolkit deployed`,
+`toolkit pr health`, or the relevant system client. Do not infer merged,
+deployed, reachable, or running state from a transcript.
+
+## Privacy and failure boundaries
+
+- The index is a rebuildable contentless FTS5 database at
+  `~/.toolkit/history/index.sqlite`; the daemon socket, state, logs, and plist
+  are user-private.
+- Source SQLite databases and JSONL files are read-only. Schema changes are
+  reported per source through `history sources`; they are not silently ignored.
+- Standalone OpenCode `~/.local/share/opencode/auth.json` is credentials and is
+  never read, printed, copied, indexed, or committed.
+- Do not place transcript contents, index databases, daemon state, LaunchAgent
+  files, or credentials in the repository or `.context/`.

--- a/packages/toolkit/src/commands/history/history.ts
+++ b/packages/toolkit/src/commands/history/history.ts
@@ -1,0 +1,327 @@
+import { parseArgs } from "node:util";
+import { HistoryIndex, parseLimit, parseSince } from "#lib/history/index.ts";
+import {
+  historyDaemonRequest,
+  HistoryDaemonResponseSchema,
+  HistoryDaemonStatusSchema,
+  pathExists,
+} from "#lib/history/ipc.ts";
+import {
+  defaultHistoryPaths,
+  defaultHistoryRuntimePaths,
+} from "#lib/history/paths.ts";
+import { createHistorySources } from "#lib/history/sources.ts";
+import { excerptForQuery } from "#lib/history/text.ts";
+import type { HistoryRecord, HistorySourceName } from "#lib/history/types.ts";
+import {
+  HISTORY_LAUNCH_AGENT_LABEL,
+  installLaunchAgent,
+  launchAgentStatus,
+  startLaunchAgent,
+  stopLaunchAgent,
+  uninstallLaunchAgent,
+} from "#lib/history/launchd.ts";
+
+const USAGE = `
+toolkit history — search local agent conversation history
+
+Search and browse the existing local index:
+  toolkit history search <query> [--since 7d] [--source <name>] [--limit 20] [--include-excerpts] [--json]
+  toolkit history recent [--since 7d] [--source <name>] [--limit 20] [--json]
+  toolkit history sources [--json]
+
+Manage background ingestion:
+  toolkit history daemon install
+  toolkit history daemon start|stop|uninstall|status|reindex
+
+Sources: conductor, claude, codex, cursor, opencode-conductor, opencode-standalone
+`;
+
+function parseSource(value: string | undefined): HistorySourceName | null {
+  if (value === undefined) {
+    return null;
+  }
+  switch (value) {
+    case "conductor":
+    case "claude":
+    case "codex":
+    case "cursor":
+    case "opencode-conductor":
+    case "opencode-standalone":
+      return value;
+    default:
+      throw new Error(
+        `Unknown history source "${value}"; run 'toolkit history sources' for valid names`,
+      );
+  }
+}
+
+function parseCommon(args: string[]) {
+  return parseArgs({
+    args,
+    options: {
+      since: { type: "string" },
+      source: { type: "string" },
+      limit: { type: "string" },
+      "include-excerpts": { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+}
+
+async function withReadOnlyIndex<T>(
+  callback: (index: HistoryIndex) => Promise<T> | T,
+): Promise<T> {
+  const index = await HistoryIndex.open(
+    defaultHistoryRuntimePaths(),
+    true,
+  ).catch((error: unknown) => {
+    throw new Error(
+      `History index is not available. Run 'toolkit history daemon install' and wait for its first scan. ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  });
+  try {
+    return await callback(index);
+  } finally {
+    index.close();
+  }
+}
+
+async function addExcerpts(
+  records: HistoryRecord[],
+  query: string,
+): Promise<HistoryRecord[]> {
+  if (records.length === 0) {
+    return records;
+  }
+  const paths = defaultHistoryPaths();
+  const documents = new Map<string, string>();
+  for (const source of createHistorySources()) {
+    const result = await source.scan(paths);
+    if (result.error !== null) {
+      continue;
+    }
+    for (const document of result.documents) {
+      documents.set(
+        `${document.source}:${document.sourceId}`,
+        document.searchText,
+      );
+    }
+  }
+  return records.map((record) => ({
+    ...record,
+    excerpt: excerptForQuery(
+      documents.get(`${record.source}:${record.sourceId}`) ?? "",
+      query,
+    ),
+  }));
+}
+
+function renderRecords(
+  title: string,
+  records: readonly HistoryRecord[],
+): string {
+  const lines = [`## ${title}`, ""];
+  if (records.length === 0) {
+    lines.push("No matching history.");
+    return lines.join("\n");
+  }
+  for (const record of records) {
+    lines.push(
+      `- **${record.title}** — ${record.source} — ${record.updatedAt}`,
+    );
+    if (record.workspace !== null) {
+      lines.push(`  Workspace: \`${record.workspace}\``);
+    }
+    lines.push(`  Source: \`${record.path}\` (${record.sourceId})`);
+    if (record.excerpt !== null && record.excerpt.length > 0) {
+      lines.push(`  Excerpt: ${record.excerpt}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+async function searchCommand(args: string[]): Promise<void> {
+  const { values, positionals } = parseCommon(args);
+  const query = positionals.join(" ").trim();
+  if (query.length === 0) {
+    throw new Error(
+      "Search query is required. Usage: toolkit history search <query>",
+    );
+  }
+  const source = parseSource(values.source);
+  const since = parseSince(values.since);
+  const limit = parseLimit(values.limit);
+  const records = await withReadOnlyIndex((index) =>
+    index.search(query, { since, source, limit }),
+  );
+  const enriched = values["include-excerpts"]
+    ? await addExcerpts(records, query)
+    : records;
+  if (values.json) {
+    console.log(JSON.stringify(enriched, null, 2));
+    return;
+  }
+  console.log(renderRecords(`History search: ${query}`, enriched));
+}
+
+async function recentCommand(args: string[]): Promise<void> {
+  const { values } = parseCommon(args);
+  const source = parseSource(values.source);
+  const since = parseSince(values.since);
+  const limit = parseLimit(values.limit);
+  const records = await withReadOnlyIndex((index) =>
+    index.recent({ since, source, limit }),
+  );
+  if (values.json) {
+    console.log(JSON.stringify(records, null, 2));
+    return;
+  }
+  console.log(renderRecords("Recent agent history", records));
+}
+
+async function sourcesCommand(args: string[]): Promise<void> {
+  const { values } = parseCommon(args);
+  const sourceDefinitions = createHistorySources();
+  const labels = new Map(
+    sourceDefinitions.map((source) => [source.name, source.label]),
+  );
+  const statuses = await withReadOnlyIndex((index) => index.statuses(labels));
+  if (values.json) {
+    console.log(JSON.stringify(statuses, null, 2));
+    return;
+  }
+  console.log(
+    renderRecords(
+      "History sources",
+      statuses.map((status) => ({
+        id: 0,
+        source: status.source,
+        sourceId: status.source,
+        title: status.label,
+        path: status.error ?? (status.available ? "available" : "not found"),
+        workspace: null,
+        agent: `${String(status.indexedDocuments)} indexed`,
+        createdAt: status.lastScanAt ?? "never",
+        updatedAt: status.lastScanAt ?? "never",
+        excerpt: null,
+      })),
+    ),
+  );
+}
+
+async function daemonStatusCommand(json: boolean): Promise<void> {
+  const runtimePaths = defaultHistoryRuntimePaths();
+  const launchAgent = await launchAgentStatus(runtimePaths);
+  const daemonRunning = await pathExists(runtimePaths.socket);
+  const daemon: unknown = daemonRunning
+    ? await historyDaemonRequest(
+        runtimePaths,
+        HistoryDaemonStatusSchema,
+        "/status",
+      )
+    : null;
+  const result = {
+    launchAgent: { label: HISTORY_LAUNCH_AGENT_LABEL, ...launchAgent },
+    daemon,
+  };
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(
+    `LaunchAgent: ${launchAgent.installed ? "installed" : "not installed"} (${launchAgent.loaded ? "loaded" : "not loaded"})`,
+  );
+  if (daemon === null) {
+    console.log("Daemon: not running");
+  } else {
+    const parsed = HistoryDaemonStatusSchema.parse(daemon);
+    console.log(
+      `Daemon: running (pid ${String(parsed.pid)}, last scan ${parsed.lastScanAt ?? "never"})`,
+    );
+    for (const source of parsed.sources) {
+      console.log(
+        `- ${source.label}: ${String(source.indexedDocuments)} indexed${source.error === null ? "" : `; error: ${source.error}`}`,
+      );
+    }
+  }
+}
+
+async function daemonCommand(args: string[]): Promise<void> {
+  const action = args[0] ?? "";
+  const runtimePaths = defaultHistoryRuntimePaths();
+  switch (action) {
+    case "install":
+      await installLaunchAgent(runtimePaths);
+      break;
+    case "start":
+      await startLaunchAgent(runtimePaths);
+      break;
+    case "stop":
+      await stopLaunchAgent(runtimePaths);
+      break;
+    case "uninstall":
+      await uninstallLaunchAgent(runtimePaths);
+      break;
+    case "status": {
+      const parsed = parseArgs({
+        args: args.slice(1),
+        options: { json: { type: "boolean", default: false } },
+      });
+      await daemonStatusCommand(parsed.values.json);
+      break;
+    }
+    case "reindex":
+      await historyDaemonRequest(
+        runtimePaths,
+        HistoryDaemonResponseSchema,
+        "/reindex",
+      );
+      console.log("History reindex complete.");
+      break;
+    case "serve": {
+      const { runHistoryDaemon } = await import("#lib/history/serve.ts");
+      await runHistoryDaemon();
+      break;
+    }
+    default:
+      console.error(USAGE);
+      process.exit(1);
+  }
+}
+
+export async function handleHistoryCommand(
+  subcommand: string | undefined,
+  args: string[],
+): Promise<void> {
+  try {
+    switch (subcommand) {
+      case "search":
+        await searchCommand(args);
+        break;
+      case "recent":
+        await recentCommand(args);
+        break;
+      case "sources":
+        await sourcesCommand(args);
+        break;
+      case "daemon":
+        await daemonCommand(args);
+        break;
+      case undefined:
+      case "help":
+      case "--help":
+        console.log(USAGE);
+        break;
+      default:
+        console.error(`Unknown history subcommand: ${subcommand}`);
+        console.error(USAGE);
+        process.exit(1);
+    }
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/packages/toolkit/src/handlers/history.ts
+++ b/packages/toolkit/src/handlers/history.ts
@@ -1,0 +1,8 @@
+import { handleHistoryCommand as handle } from "#commands/history/history.ts";
+
+export async function handleHistoryCommand(
+  subcommand: string | undefined,
+  args: string[],
+): Promise<void> {
+  await handle(subcommand, args);
+}

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -62,6 +62,11 @@ Commands:
   discord wait <CH>          Block until a matching message arrives
   discord slash <CH> <BOT> <CMD> [ARGS...]  Invoke another bot's slash command
   discord voice join|leave|states           Voice presence + who's streaming
+
+  history search <QUERY>                     Search local agent history
+  history recent                            Show recent indexed work
+  history sources                           Show source/index status
+  history daemon install|start|stop|status   Manage background ingestion
   discord guilds|channels    Discovery
   discord whoami             Daemon identities + uptime
 
@@ -89,6 +94,9 @@ Examples:
   toolkit screenshot stocks-sjer-red /
   toolkit alerts list
   toolkit gf dashboards
+  toolkit history daemon install
+  toolkit history recent --since 7d
+  toolkit history search "kubernetes" --since 30d
 `);
 }
 
@@ -150,6 +158,11 @@ async function main(): Promise<void> {
     case "discord": {
       const { handleDiscordCommand } = await import("./handlers/discord.ts");
       await handleDiscordCommand(subcommand, args.slice(2));
+      break;
+    }
+    case "history": {
+      const { handleHistoryCommand } = await import("./handlers/history.ts");
+      await handleHistoryCommand(subcommand, args.slice(2));
       break;
     }
     default:

--- a/packages/toolkit/src/lib/history/index.ts
+++ b/packages/toolkit/src/lib/history/index.ts
@@ -1,0 +1,452 @@
+import { Database } from "bun:sqlite";
+import { chmod, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import type { HistoryRuntimePaths } from "./paths.ts";
+import type {
+  HistoryRecord,
+  HistorySourceName,
+  HistorySourceResult,
+  HistorySourceStatus,
+} from "./types.ts";
+
+const DocumentRowSchema = z.object({
+  id: z.number(),
+  source: z.string(),
+  source_id: z.string(),
+  title: z.string(),
+  path: z.string(),
+  workspace: z.string().nullable(),
+  agent: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const StatusRowSchema = z.object({
+  source: z.string(),
+  indexed_documents: z.number(),
+  last_scan_at: z.string().nullable(),
+  available: z.number(),
+  error: z.string().nullable(),
+});
+
+function parseSourceName(value: string): HistorySourceName {
+  if (
+    value === "conductor" ||
+    value === "claude" ||
+    value === "codex" ||
+    value === "cursor" ||
+    value === "opencode-conductor" ||
+    value === "opencode-standalone"
+  ) {
+    return value;
+  }
+  throw new Error(`Unknown history source in index: ${value}`);
+}
+
+function hashText(text: string): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(text);
+  return hasher.digest("hex");
+}
+
+async function secureIndexFiles(indexPath: string): Promise<void> {
+  for (const candidate of [indexPath, `${indexPath}-wal`, `${indexPath}-shm`]) {
+    if (await Bun.file(candidate).exists()) {
+      await chmod(candidate, 0o600);
+    }
+  }
+}
+
+function ftsQuery(query: string): string {
+  const terms = query
+    .split(/[^\p{L}\p{N}_-]+/u)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 0)
+    .map((term) => `"${term.replaceAll('"', '""')}"*`);
+  if (terms.length === 0) {
+    throw new Error("Search query must contain at least one letter or number");
+  }
+  return terms.join(" AND ");
+}
+
+function toRecord(row: z.infer<typeof DocumentRowSchema>): HistoryRecord {
+  return {
+    id: row.id,
+    source: parseSourceName(row.source),
+    sourceId: row.source_id,
+    title: row.title,
+    path: row.path,
+    workspace: row.workspace,
+    agent: row.agent,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    excerpt: null,
+  };
+}
+
+export class HistoryIndex {
+  readonly #database: Database;
+  readonly #indexPath: string;
+
+  private constructor(database: Database, indexPath: string) {
+    this.#database = database;
+    this.#indexPath = indexPath;
+  }
+
+  static async open(
+    runtimePaths: HistoryRuntimePaths,
+    readonly = false,
+  ): Promise<HistoryIndex> {
+    if (!readonly) {
+      await mkdir(path.dirname(runtimePaths.indexDb), { recursive: true });
+    }
+    const database = new Database(runtimePaths.indexDb, {
+      readonly,
+      create: !readonly,
+      strict: true,
+    });
+    const index = new HistoryIndex(database, runtimePaths.indexDb);
+    if (!readonly) {
+      index.#database.run(`
+        PRAGMA journal_mode = WAL;
+        PRAGMA busy_timeout = 5000;
+        CREATE TABLE IF NOT EXISTS documents (
+          id INTEGER PRIMARY KEY,
+          source TEXT NOT NULL,
+          source_id TEXT NOT NULL,
+          title TEXT NOT NULL,
+          path TEXT NOT NULL,
+          workspace TEXT,
+          agent TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          content_hash TEXT NOT NULL,
+          UNIQUE(source, source_id)
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
+          title,
+          body,
+          content = '',
+          contentless_delete = 1,
+          tokenize = 'unicode61 remove_diacritics 2'
+        );
+        CREATE TABLE IF NOT EXISTS source_state (
+          source TEXT PRIMARY KEY,
+          available INTEGER NOT NULL,
+          indexed_documents INTEGER NOT NULL,
+          fingerprint TEXT NOT NULL,
+          last_scan_at TEXT,
+          error TEXT
+        );
+      `);
+      await secureIndexFiles(runtimePaths.indexDb);
+    }
+    return index;
+  }
+
+  close(): void {
+    this.#database.close();
+  }
+
+  async ingest(
+    results: readonly HistorySourceResult[],
+    force = false,
+  ): Promise<void> {
+    const upsert = this.#database.prepare(`
+      INSERT INTO documents
+        (source, source_id, title, path, workspace, agent, created_at, updated_at, content_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(source, source_id) DO UPDATE SET
+        title = excluded.title,
+        path = excluded.path,
+        workspace = excluded.workspace,
+        agent = excluded.agent,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        content_hash = excluded.content_hash
+    `);
+    const findExisting = this.#database.prepare(
+      "SELECT id, content_hash FROM documents WHERE source = ? AND source_id = ?",
+    );
+    const insertFts = this.#database.prepare(
+      "INSERT INTO history_fts(rowid, title, body) VALUES (?, ?, ?)",
+    );
+    const deleteFts = this.#database.prepare(
+      "DELETE FROM history_fts WHERE rowid = ?",
+    );
+    const deleteDocument = this.#database.prepare(
+      "DELETE FROM documents WHERE id = ?",
+    );
+    const updateState = this.#database.prepare(`
+      INSERT INTO source_state
+        (source, available, indexed_documents, fingerprint, last_scan_at, error)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(source) DO UPDATE SET
+        available = excluded.available,
+        indexed_documents = excluded.indexed_documents,
+        fingerprint = excluded.fingerprint,
+        last_scan_at = excluded.last_scan_at,
+        error = excluded.error
+    `);
+
+    const transaction = this.#database.transaction(() => {
+      for (const result of results) {
+        const existingIds = new Set(
+          this.#database
+            .prepare("SELECT id, source_id FROM documents WHERE source = ?")
+            .all(result.source)
+            .map((row: unknown) => {
+              const parsed = z
+                .object({ id: z.number(), source_id: z.string() })
+                .parse(row);
+              return parsed;
+            }),
+        );
+        const seenIds = new Set<string>();
+        const stateRow = this.#database
+          .prepare("SELECT fingerprint FROM source_state WHERE source = ?")
+          .get(result.source);
+        const previousFingerprint =
+          stateRow == null
+            ? null
+            : z.object({ fingerprint: z.string() }).parse(stateRow).fingerprint;
+        const changed = force || previousFingerprint !== result.fingerprint;
+
+        if (changed && result.available && result.error === null) {
+          for (const document of result.documents) {
+            seenIds.add(document.sourceId);
+            const contentHash = hashText(document.searchText);
+            const existing = findExisting.get(
+              document.source,
+              document.sourceId,
+            );
+            const existingRow =
+              existing == null
+                ? null
+                : z
+                    .object({ id: z.number(), content_hash: z.string() })
+                    .parse(existing);
+            if (
+              existingRow !== null &&
+              existingRow.content_hash === contentHash
+            ) {
+              upsert.run(
+                document.source,
+                document.sourceId,
+                document.title,
+                document.path,
+                document.workspace,
+                document.agent,
+                document.createdAt,
+                document.updatedAt,
+                contentHash,
+              );
+              continue;
+            }
+            if (existingRow === null) {
+              upsert.run(
+                document.source,
+                document.sourceId,
+                document.title,
+                document.path,
+                document.workspace,
+                document.agent,
+                document.createdAt,
+                document.updatedAt,
+                contentHash,
+              );
+              const replacement = z
+                .object({ id: z.number() })
+                .parse(findExisting.get(document.source, document.sourceId));
+              insertFts.run(
+                replacement.id,
+                document.title,
+                document.searchText,
+              );
+            } else {
+              deleteFts.run(existingRow.id);
+              upsert.run(
+                document.source,
+                document.sourceId,
+                document.title,
+                document.path,
+                document.workspace,
+                document.agent,
+                document.createdAt,
+                document.updatedAt,
+                contentHash,
+              );
+              const replacement = z
+                .object({ id: z.number() })
+                .parse(findExisting.get(document.source, document.sourceId));
+              insertFts.run(
+                replacement.id,
+                document.title,
+                document.searchText,
+              );
+            }
+          }
+
+          for (const existingId of existingIds) {
+            if (!seenIds.has(existingId.source_id)) {
+              deleteFts.run(existingId.id);
+              deleteDocument.run(existingId.id);
+            }
+          }
+        }
+
+        updateState.run(
+          result.source,
+          result.available ? 1 : 0,
+          changed && result.error === null
+            ? result.documents.length
+            : this.count(result.source),
+          result.fingerprint,
+          result.error === null && result.available
+            ? new Date().toISOString()
+            : null,
+          result.error,
+        );
+      }
+    });
+    transaction();
+    await secureIndexFiles(this.#indexPath);
+  }
+
+  private count(source: HistorySourceName): number {
+    const row = z
+      .object({ count: z.number() })
+      .parse(
+        this.#database
+          .prepare("SELECT count(*) AS count FROM documents WHERE source = ?")
+          .get(source),
+      );
+    return row.count;
+  }
+
+  search(
+    query: string,
+    options: {
+      since: string | null;
+      source: HistorySourceName | null;
+      limit: number;
+    },
+  ): HistoryRecord[] {
+    const clauses = ["history_fts MATCH ?"];
+    const values: (string | number)[] = [ftsQuery(query)];
+    if (options.since !== null) {
+      clauses.push("d.updated_at >= ?");
+      values.push(options.since);
+    }
+    if (options.source !== null) {
+      clauses.push("d.source = ?");
+      values.push(options.source);
+    }
+    values.push(options.limit);
+    return this.#database
+      .prepare(
+        `SELECT d.id, d.source, d.source_id, d.title, d.path, d.workspace,
+                d.agent, d.created_at, d.updated_at
+           FROM history_fts
+           JOIN documents d ON d.id = history_fts.rowid
+          WHERE ${clauses.join(" AND ")}
+          ORDER BY d.updated_at DESC
+          LIMIT ?`,
+      )
+      .all(...values)
+      .map((row: unknown) => toRecord(DocumentRowSchema.parse(row)));
+  }
+
+  recent(options: {
+    since: string | null;
+    source: HistorySourceName | null;
+    limit: number;
+  }): HistoryRecord[] {
+    const clauses: string[] = [];
+    const values: (string | number)[] = [];
+    if (options.since !== null) {
+      clauses.push("updated_at >= ?");
+      values.push(options.since);
+    }
+    if (options.source !== null) {
+      clauses.push("source = ?");
+      values.push(options.source);
+    }
+    values.push(options.limit);
+    return this.#database
+      .prepare(
+        `SELECT id, source, source_id, title, path, workspace, agent, created_at, updated_at
+           FROM documents
+          ${clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : ""}
+          ORDER BY updated_at DESC
+          LIMIT ?`,
+      )
+      .all(...values)
+      .map((row: unknown) => toRecord(DocumentRowSchema.parse(row)));
+  }
+
+  statuses(
+    labels: ReadonlyMap<HistorySourceName, string>,
+  ): HistorySourceStatus[] {
+    const rows = this.#database
+      .prepare(
+        "SELECT source, indexed_documents, last_scan_at, available, error FROM source_state ORDER BY source",
+      )
+      .all()
+      .map((row: unknown) => StatusRowSchema.parse(row));
+    return rows.map((row) => ({
+      source: parseSourceName(row.source),
+      label: labels.get(parseSourceName(row.source)) ?? row.source,
+      available: row.available === 1,
+      indexedDocuments: row.indexed_documents,
+      lastScanAt: row.last_scan_at,
+      error: row.error,
+    }));
+  }
+
+  allSourceRecords(source: HistorySourceName): HistoryRecord[] {
+    return this.#database
+      .prepare(
+        "SELECT id, source, source_id, title, path, workspace, agent, created_at, updated_at FROM documents WHERE source = ?",
+      )
+      .all(source)
+      .map((row: unknown) => toRecord(DocumentRowSchema.parse(row)));
+  }
+}
+
+export function parseLimit(value: string | undefined): number {
+  if (value === undefined) {
+    return 20;
+  }
+  const limit = Number.parseInt(value, 10);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+    throw new Error("Limit must be an integer from 1 to 200");
+  }
+  return limit;
+}
+
+export function parseSince(
+  value: string | undefined,
+  now = new Date(),
+): string | null {
+  if (value === undefined) {
+    return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  }
+  const duration = /^(\d+)([hdw])$/u.exec(value.trim());
+  if (duration !== null) {
+    const amount = Number.parseInt(duration[1] ?? "", 10);
+    const unit = duration[2];
+    const multiplier = unit === "w" ? 7 : unit === "d" ? 1 : 1 / 24;
+    return new Date(
+      now.getTime() - amount * multiplier * 24 * 60 * 60 * 1000,
+    ).toISOString();
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new TypeError(
+      `Invalid --since value "${value}"; use 7d, 24h, 1w, or an ISO date`,
+    );
+  }
+  return new Date(timestamp).toISOString();
+}

--- a/packages/toolkit/src/lib/history/ipc.ts
+++ b/packages/toolkit/src/lib/history/ipc.ts
@@ -1,0 +1,78 @@
+import { stat } from "node:fs/promises";
+import { z } from "zod";
+import {
+  defaultHistoryRuntimePaths,
+  type HistoryRuntimePaths,
+} from "./paths.ts";
+
+export const HistoryDaemonStateSchema = z.object({
+  pid: z.number(),
+  startedAt: z.string(),
+  intervalSeconds: z.number(),
+  lastScanAt: z.string().nullable(),
+});
+export type HistoryDaemonState = z.infer<typeof HistoryDaemonStateSchema>;
+
+export const HistoryDaemonStatusSchema = z.object({
+  pid: z.number(),
+  startedAt: z.string(),
+  intervalSeconds: z.number(),
+  lastScanAt: z.string().nullable(),
+  sources: z.array(
+    z.object({
+      source: z.string(),
+      label: z.string(),
+      available: z.boolean(),
+      indexedDocuments: z.number(),
+      lastScanAt: z.string().nullable(),
+      error: z.string().nullable(),
+    }),
+  ),
+});
+export type HistoryDaemonStatus = z.infer<typeof HistoryDaemonStatusSchema>;
+
+export const HistoryDaemonResponseSchema = z.object({ ok: z.boolean() });
+
+export async function pathExists(target: string): Promise<boolean> {
+  try {
+    await stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function historyDaemonRequest<T extends z.ZodType>(
+  runtimePaths: HistoryRuntimePaths = defaultHistoryRuntimePaths(),
+  schema: T,
+  endpoint: string,
+): Promise<z.infer<T>> {
+  if (!(await pathExists(runtimePaths.socket))) {
+    throw new Error(
+      "History daemon is not running. Install and start it with `toolkit history daemon install`.",
+    );
+  }
+  let response: Response;
+  try {
+    response = await fetch(`http://history${endpoint}`, {
+      unix: runtimePaths.socket,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not reach the history daemon (${message}); inspect ${runtimePaths.logsDir} and run ` +
+        "`toolkit history daemon stop` before restarting it.",
+      { cause: error },
+    );
+  }
+  const body: unknown = await response.json();
+  if (!response.ok) {
+    const error = z.object({ error: z.string() }).safeParse(body);
+    throw new Error(
+      error.success
+        ? error.data.error
+        : `History daemon error (HTTP ${String(response.status)})`,
+    );
+  }
+  return schema.parse(body);
+}

--- a/packages/toolkit/src/lib/history/launchd.ts
+++ b/packages/toolkit/src/lib/history/launchd.ts
@@ -1,0 +1,193 @@
+import { chmod, mkdir, rm, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  defaultHistoryRuntimePaths,
+  type HistoryRuntimePaths,
+} from "./paths.ts";
+
+const LABEL = "com.jerred.toolkit-history";
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function serveArgv(): string[] {
+  const executable = process.execPath;
+  const isCompiled = !path.basename(executable).startsWith("bun");
+  return isCompiled
+    ? [executable, "history", "daemon", "serve"]
+    : [executable, "run", Bun.main, "history", "daemon", "serve"];
+}
+
+export function renderLaunchAgent(runtimePaths: HistoryRuntimePaths): string {
+  const programArguments = serveArgv()
+    .map((argument) => `    <string>${xmlEscape(argument)}</string>`)
+    .join("\n");
+  const stdout = path.join(runtimePaths.logsDir, "launchd.stdout.log");
+  const stderr = path.join(runtimePaths.logsDir, "launchd.stderr.log");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${programArguments}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(stdout)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(stderr)}</string>
+</dict>
+</plist>
+`;
+}
+
+async function launchctl(args: string[]): Promise<string> {
+  const processHandle = Bun.spawn(["launchctl", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(processHandle.stdout).text(),
+    new Response(processHandle.stderr).text(),
+    processHandle.exited,
+  ]);
+  if (exitCode !== 0) {
+    const detail =
+      stderr.trim() || stdout.trim() || `exit code ${String(exitCode)}`;
+    throw new Error(`launchctl ${args.join(" ")} failed: ${detail}`);
+  }
+  return stdout.trim();
+}
+
+function guiDomain(): string {
+  const uid = String(os.userInfo().uid);
+  return `gui/${uid}`;
+}
+
+async function jobLoaded(domain: string): Promise<boolean> {
+  const processHandle = Bun.spawn(
+    ["launchctl", "print", `${domain}/${LABEL}`],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const exitCode = await processHandle.exited;
+  return exitCode === 0;
+}
+
+async function bootstrap(
+  runtimePaths: HistoryRuntimePaths,
+  domain: string,
+): Promise<void> {
+  if (await jobLoaded(domain)) {
+    await launchctl(["kickstart", "-k", `${domain}/${LABEL}`]);
+    return;
+  }
+  await launchctl(["bootstrap", domain, runtimePaths.launchAgent]);
+}
+
+export async function installLaunchAgent(
+  runtimePaths = defaultHistoryRuntimePaths(),
+): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "History ingestion uses a macOS LaunchAgent and cannot be installed on this platform.",
+    );
+  }
+  await mkdir(runtimePaths.historyDir, { recursive: true, mode: 0o700 });
+  await mkdir(runtimePaths.logsDir, { recursive: true, mode: 0o700 });
+  await mkdir(path.dirname(runtimePaths.launchAgent), {
+    recursive: true,
+    mode: 0o700,
+  });
+  const temporaryPath = `${runtimePaths.launchAgent}.${String(process.pid)}.tmp`;
+  await Bun.write(temporaryPath, renderLaunchAgent(runtimePaths));
+  await chmod(temporaryPath, 0o600);
+  await rename(temporaryPath, runtimePaths.launchAgent);
+  await chmod(runtimePaths.launchAgent, 0o600);
+  for (const logPath of [
+    path.join(runtimePaths.logsDir, "launchd.stdout.log"),
+    path.join(runtimePaths.logsDir, "launchd.stderr.log"),
+  ]) {
+    await writeFile(logPath, "", { flag: "a", mode: 0o600 });
+    await chmod(logPath, 0o600);
+  }
+  const domain = guiDomain();
+  if (await jobLoaded(domain)) {
+    await launchctl(["bootout", `${domain}/${LABEL}`]);
+  }
+  await launchctl(["bootstrap", domain, runtimePaths.launchAgent]);
+  console.log(`History LaunchAgent installed: ${runtimePaths.launchAgent}`);
+}
+
+export async function startLaunchAgent(
+  runtimePaths = defaultHistoryRuntimePaths(),
+): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "History ingestion uses a macOS LaunchAgent and cannot be started on this platform.",
+    );
+  }
+  if (!(await Bun.file(runtimePaths.launchAgent).exists())) {
+    throw new Error(
+      `LaunchAgent is not installed. Run 'toolkit history daemon install' first.`,
+    );
+  }
+  await bootstrap(runtimePaths, guiDomain());
+  console.log("History daemon started.");
+}
+
+export async function stopLaunchAgent(
+  runtimePaths = defaultHistoryRuntimePaths(),
+): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "History ingestion uses a macOS LaunchAgent and cannot be stopped on this platform.",
+    );
+  }
+  const installed = await Bun.file(runtimePaths.launchAgent).exists();
+  const domain = guiDomain();
+  if (await jobLoaded(domain)) {
+    await launchctl(["bootout", `${domain}/${LABEL}`]);
+  }
+  console.log(
+    installed ? "History daemon stopped." : "History daemon was not installed.",
+  );
+}
+
+export async function uninstallLaunchAgent(
+  runtimePaths = defaultHistoryRuntimePaths(),
+): Promise<void> {
+  await stopLaunchAgent(runtimePaths);
+  await rm(runtimePaths.launchAgent, { force: false });
+  console.log(`History LaunchAgent removed: ${runtimePaths.launchAgent}`);
+}
+
+export async function launchAgentStatus(
+  runtimePaths = defaultHistoryRuntimePaths(),
+): Promise<{ installed: boolean; loaded: boolean }> {
+  if (process.platform !== "darwin") {
+    return { installed: false, loaded: false };
+  }
+  const installed = await Bun.file(runtimePaths.launchAgent).exists();
+  const loaded = installed && (await jobLoaded(guiDomain()));
+  return { installed, loaded };
+}
+
+export const HISTORY_LAUNCH_AGENT_LABEL = LABEL;

--- a/packages/toolkit/src/lib/history/opencode.ts
+++ b/packages/toolkit/src/lib/history/opencode.ts
@@ -1,0 +1,123 @@
+import type { HistoryPaths } from "./paths.ts";
+import {
+  firstText,
+  pathExists,
+  readDatabase,
+  requireTables,
+  rowValue,
+  rows,
+  RowSchema,
+  sourceResult,
+} from "./sources-shared.ts";
+import { extractText, parseJsonLine, stringValue } from "./text.ts";
+import type {
+  HistoryDocument,
+  HistorySource,
+  HistorySourceResult,
+} from "./types.ts";
+
+type OpenCodeSourceName = "opencode-conductor" | "opencode-standalone";
+
+function opencodeDocuments(
+  filePath: string,
+  source: OpenCodeSourceName,
+): HistoryDocument[] {
+  const database = readDatabase(filePath);
+  try {
+    requireTables(database, "OpenCode", ["session", "message", "part"]);
+    const sessionRows = rows(
+      database,
+      "SELECT id, title, directory, agent, model, time_created, time_updated FROM session",
+      RowSchema,
+    );
+    const messageRows = rows(
+      database,
+      "SELECT id, session_id, data, time_created FROM message ORDER BY session_id, time_created",
+      RowSchema,
+    );
+    const partRows = rows(
+      database,
+      "SELECT message_id, data FROM part ORDER BY message_id, time_created",
+      RowSchema,
+    );
+    const partsByMessage = new Map<string, string[]>();
+    for (const row of partRows) {
+      const messageId = String(rowValue(row, "message_id"));
+      const text = extractText(parseJsonLine(String(rowValue(row, "data"))));
+      if (text.length > 0) {
+        const parts = partsByMessage.get(messageId) ?? [];
+        parts.push(text);
+        partsByMessage.set(messageId, parts);
+      }
+    }
+    const messagesBySession = new Map<string, string[]>();
+    for (const row of messageRows) {
+      const sessionId = String(rowValue(row, "session_id"));
+      const messageText = extractText(
+        parseJsonLine(String(rowValue(row, "data"))),
+      );
+      const parts = partsByMessage.get(String(rowValue(row, "id"))) ?? [];
+      const chunks = [messageText, ...parts].filter(
+        (chunk) => chunk.length > 0,
+      );
+      const messages = messagesBySession.get(sessionId) ?? [];
+      messages.push(...chunks);
+      messagesBySession.set(sessionId, messages);
+    }
+    return sessionRows.map((row) => {
+      const sessionId = String(rowValue(row, "id"));
+      const title = stringValue(rowValue(row, "title")) ?? "OpenCode session";
+      const body = messagesBySession.get(sessionId)?.join("\n") ?? "";
+      return {
+        source,
+        sourceId: sessionId,
+        title: firstText(title, "OpenCode session"),
+        path: filePath,
+        workspace: stringValue(rowValue(row, "directory")),
+        agent:
+          stringValue(rowValue(row, "agent")) ??
+          stringValue(rowValue(row, "model")) ??
+          "OpenCode",
+        createdAt: new Date(
+          Number(rowValue(row, "time_created")),
+        ).toISOString(),
+        updatedAt: new Date(
+          Number(rowValue(row, "time_updated")),
+        ).toISOString(),
+        searchText: `${title}\n${body}`,
+      } satisfies HistoryDocument;
+    });
+  } finally {
+    database.close();
+  }
+}
+
+function opencodeSource(
+  source: OpenCodeSourceName,
+  filePath: (paths: HistoryPaths) => string,
+): HistorySource {
+  return {
+    name: source,
+    label:
+      source === "opencode-conductor"
+        ? "OpenCode bundled with Conductor"
+        : "OpenCode standalone",
+    async scan(paths: HistoryPaths): Promise<HistorySourceResult> {
+      const resolvedPath = filePath(paths);
+      const files = (await pathExists(resolvedPath)) ? [resolvedPath] : [];
+      return sourceResult(source, files, () =>
+        opencodeDocuments(resolvedPath, source),
+      );
+    },
+  };
+}
+
+export function createOpenCodeSources(): readonly HistorySource[] {
+  return [
+    opencodeSource("opencode-conductor", (paths) => paths.conductorOpenCodeDb),
+    opencodeSource(
+      "opencode-standalone",
+      (paths) => paths.standaloneOpenCodeDb,
+    ),
+  ];
+}

--- a/packages/toolkit/src/lib/history/paths.ts
+++ b/packages/toolkit/src/lib/history/paths.ts
@@ -1,0 +1,65 @@
+import os from "node:os";
+import path from "node:path";
+
+export type HistoryPaths = {
+  readonly home: string;
+  readonly conductorDb: string;
+  readonly conductorOpenCodeDb: string;
+  readonly claudeProjects: string;
+  readonly codexDir: string;
+  readonly codexCatalogDb: string;
+  readonly codexHistoryJsonl: string;
+  readonly cursorConversationDb: string;
+  readonly standaloneOpenCodeDb: string;
+  readonly standaloneOpenCodeAuth: string;
+};
+
+export type HistoryRuntimePaths = {
+  readonly historyDir: string;
+  readonly indexDb: string;
+  readonly socket: string;
+  readonly state: string;
+  readonly logsDir: string;
+  readonly launchAgent: string;
+};
+
+export function defaultHistoryPaths(home = os.homedir()): HistoryPaths {
+  return {
+    home,
+    conductorDb: path.join(
+      home,
+      "Library/Application Support/com.conductor.app/conductor.db",
+    ),
+    conductorOpenCodeDb: path.join(
+      home,
+      "Library/Application Support/com.conductor.app/opencode/opencode.db",
+    ),
+    claudeProjects: path.join(home, ".claude/projects"),
+    codexDir: path.join(home, ".codex"),
+    codexCatalogDb: path.join(home, ".codex/sqlite/codex-dev.db"),
+    codexHistoryJsonl: path.join(home, ".codex/history.jsonl"),
+    cursorConversationDb: path.join(
+      home,
+      "Library/Application Support/Cursor/User/globalStorage/conversation-search.db",
+    ),
+    standaloneOpenCodeDb: path.join(home, ".local/share/opencode/opencode.db"),
+    standaloneOpenCodeAuth: path.join(home, ".local/share/opencode/auth.json"),
+  };
+}
+
+export function defaultHistoryRuntimePaths(
+  home = os.homedir(),
+): HistoryRuntimePaths {
+  const historyDir = path.join(home, ".toolkit/history");
+  return {
+    historyDir,
+    indexDb: path.join(historyDir, "index.sqlite"),
+    socket: path.join(historyDir, "daemon.sock"),
+    state: path.join(historyDir, "state.json"),
+    logsDir: path.join(historyDir, "logs"),
+    launchAgent: path.join(
+      home,
+      "Library/LaunchAgents/com.jerred.toolkit-history.plist",
+    ),
+  };
+}

--- a/packages/toolkit/src/lib/history/serve.ts
+++ b/packages/toolkit/src/lib/history/serve.ts
@@ -1,0 +1,176 @@
+import { appendFile, chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createHistorySources } from "./sources.ts";
+import { HistoryIndex } from "./index.ts";
+import { defaultHistoryPaths, defaultHistoryRuntimePaths } from "./paths.ts";
+import {
+  HistoryDaemonStatusSchema,
+  HistoryDaemonResponseSchema,
+} from "./ipc.ts";
+import type { HistoryRuntimePaths } from "./paths.ts";
+import type { HistoryDaemonState } from "./ipc.ts";
+
+const INTERVAL_SECONDS = 30;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function logLine(
+  runtimePaths: HistoryRuntimePaths,
+  message: string,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  const day = new Date().toISOString().slice(0, 10);
+  const logPath = path.join(runtimePaths.logsDir, `daemon-${day}.log`);
+  const line = `${JSON.stringify({ ts: new Date().toISOString(), message, ...extra })}\n`;
+  await appendFile(logPath, line, {
+    mode: 0o600,
+  });
+  await chmod(logPath, 0o600);
+}
+
+export async function runHistoryDaemon(): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "The history LaunchAgent daemon is supported only on macOS.",
+    );
+  }
+  const paths = defaultHistoryPaths();
+  const runtimePaths = defaultHistoryRuntimePaths();
+  await mkdir(runtimePaths.historyDir, { recursive: true, mode: 0o700 });
+  await mkdir(runtimePaths.logsDir, { recursive: true, mode: 0o700 });
+  await chmod(runtimePaths.historyDir, 0o700);
+  await chmod(runtimePaths.logsDir, 0o700);
+  await rm(runtimePaths.socket, { force: true });
+
+  const index = await HistoryIndex.open(runtimePaths);
+  const sources = createHistorySources();
+  const labels = new Map(sources.map((source) => [source.name, source.label]));
+  let lastScanAt: string | null = null;
+  let scanning = false;
+  let shuttingDown = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let server: {
+    stop: (closeActiveConnections?: boolean) => Promise<void>;
+  } | null = null;
+
+  const scan = async (force: boolean): Promise<void> => {
+    if (scanning) {
+      return;
+    }
+    scanning = true;
+    try {
+      const results = await Promise.all(
+        sources.map((source) => source.scan(paths)),
+      );
+      await index.ingest(results, force);
+      lastScanAt = new Date().toISOString();
+      await logLine(runtimePaths, "history scan complete", {
+        force,
+        sources: results.map((result) => ({
+          source: result.source,
+          available: result.available,
+          documents: result.documents.length,
+          error: result.error,
+        })),
+      });
+    } catch (error: unknown) {
+      await logLine(runtimePaths, "history scan failed", {
+        error: getErrorMessage(error),
+      });
+      throw error;
+    } finally {
+      scanning = false;
+    }
+  };
+
+  await scan(false);
+
+  const state = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    intervalSeconds: INTERVAL_SECONDS,
+    lastScanAt,
+  } satisfies HistoryDaemonState;
+  await writeFile(runtimePaths.state, JSON.stringify(state, null, 2), {
+    mode: 0o600,
+  });
+  await chmod(runtimePaths.state, 0o600);
+
+  const reindex = async (): Promise<void> => {
+    try {
+      await scan(true);
+    } catch (error: unknown) {
+      await logLine(runtimePaths, "history reindex failed", {
+        error: getErrorMessage(error),
+      });
+    }
+  };
+
+  const shutdown = async (reason: string): Promise<void> => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    if (timer !== null) {
+      clearInterval(timer);
+    }
+    await logLine(runtimePaths, "history daemon stopping", { reason });
+    await server?.stop(true);
+    index.close();
+    await rm(runtimePaths.socket, { force: true });
+    await rm(runtimePaths.state, { force: true });
+    process.exit(0);
+  };
+
+  server = Bun.serve({
+    unix: runtimePaths.socket,
+    fetch: (request): Response => {
+      const url = new URL(request.url);
+      if (url.pathname === "/status") {
+        const status = {
+          ...state,
+          lastScanAt,
+          sources: index.statuses(labels),
+        };
+        return Response.json(HistoryDaemonStatusSchema.parse(status));
+      }
+      if (url.pathname === "/reindex") {
+        void reindex();
+        return Response.json(HistoryDaemonResponseSchema.parse({ ok: true }));
+      }
+      if (url.pathname === "/shutdown") {
+        setTimeout(() => {
+          void shutdown("shutdown requested");
+        }, 25);
+        return Response.json({ ok: true });
+      }
+      return Response.json({ error: "Not found" }, { status: 404 });
+    },
+  });
+  await chmod(runtimePaths.socket, 0o600);
+  const poll = async (): Promise<void> => {
+    try {
+      await scan(false);
+    } catch (error: unknown) {
+      await logLine(runtimePaths, "history poll failed", {
+        error: getErrorMessage(error),
+      });
+    }
+  };
+  timer = setInterval(() => {
+    void poll();
+  }, INTERVAL_SECONDS * 1000);
+
+  process.on("SIGINT", () => {
+    void shutdown("SIGINT");
+  });
+  process.on("SIGTERM", () => {
+    void shutdown("SIGTERM");
+  });
+  await logLine(runtimePaths, "history daemon listening", {
+    socket: runtimePaths.socket,
+    intervalSeconds: INTERVAL_SECONDS,
+  });
+}

--- a/packages/toolkit/src/lib/history/sources-shared.ts
+++ b/packages/toolkit/src/lib/history/sources-shared.ts
@@ -1,0 +1,133 @@
+import { Database } from "bun:sqlite";
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import type {
+  HistoryDocument,
+  HistorySourceName,
+  HistorySourceResult,
+} from "./types.ts";
+
+export const RowSchema = z.record(z.string(), z.unknown());
+
+export function rows<T extends z.ZodType>(
+  database: Database,
+  sql: string,
+  schema: T,
+): z.infer<T>[] {
+  return database
+    .prepare(sql)
+    .all()
+    .map((row: unknown) => schema.parse(row));
+}
+
+export function rowValue(row: Record<string, unknown>, key: string): unknown {
+  return row[key];
+}
+
+export function firstText(value: string, fallback: string): string {
+  const text = value.replaceAll(/\s+/gu, " ").trim();
+  return text.length > 0 ? text.slice(0, 120) : fallback;
+}
+
+export function requireTables(
+  database: Database,
+  source: string,
+  expected: string[],
+): void {
+  const available = new Set(
+    rows(
+      database,
+      "SELECT name FROM sqlite_master WHERE type IN ('table', 'view')",
+      z.object({ name: z.string() }),
+    ).map((row) => row.name),
+  );
+  const missing = expected.filter((table) => !available.has(table));
+  if (missing.length > 0) {
+    throw new Error(`${source} schema is missing: ${missing.join(", ")}`);
+  }
+}
+
+export async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function filesUnder(
+  directory: string,
+  extension?: string,
+): Promise<string[]> {
+  if (!(await pathExists(directory))) {
+    return [];
+  }
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await filesUnder(entryPath, extension)));
+    } else if (extension === undefined || entry.name.endsWith(extension)) {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
+}
+
+async function fingerprint(files: string[]): Promise<string> {
+  const parts: string[] = [];
+  const fingerprintFiles = files.flatMap((file) => [
+    file,
+    `${file}-wal`,
+    `${file}-shm`,
+  ]);
+  for (const file of fingerprintFiles.sort()) {
+    try {
+      const info = await stat(file);
+      parts.push(`${file}:${String(info.mtimeMs)}:${String(info.size)}`);
+    } catch {
+      parts.push(`${file}:missing`);
+    }
+  }
+  return parts.join("|");
+}
+
+export async function sourceResult(
+  source: HistorySourceName,
+  files: string[],
+  read: () => readonly HistoryDocument[] | Promise<readonly HistoryDocument[]>,
+): Promise<HistorySourceResult> {
+  if (files.length === 0) {
+    return {
+      source,
+      available: false,
+      documents: [],
+      fingerprint: "missing",
+      error: null,
+    };
+  }
+  try {
+    return {
+      source,
+      available: true,
+      documents: await read(),
+      fingerprint: await fingerprint(files),
+      error: null,
+    };
+  } catch (error: unknown) {
+    return {
+      source,
+      available: false,
+      documents: [],
+      fingerprint: await fingerprint(files),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function readDatabase(filePath: string): Database {
+  return new Database(filePath, { readonly: true, strict: true });
+}

--- a/packages/toolkit/src/lib/history/sources.ts
+++ b/packages/toolkit/src/lib/history/sources.ts
@@ -1,0 +1,350 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import type { HistoryPaths } from "./paths.ts";
+import { createOpenCodeSources } from "./opencode.ts";
+import {
+  filesUnder,
+  firstText,
+  pathExists,
+  readDatabase,
+  requireTables,
+  rowValue,
+  rows,
+  RowSchema,
+  sourceResult,
+} from "./sources-shared.ts";
+import {
+  cleanText,
+  extractText,
+  parseJsonLine,
+  parseRecord,
+  parseTimestamp,
+  stringValue,
+} from "./text.ts";
+import type {
+  HistoryDocument,
+  HistorySource,
+  HistorySourceResult,
+} from "./types.ts";
+
+async function scanConductor(
+  paths: HistoryPaths,
+): Promise<HistorySourceResult> {
+  const files = (await pathExists(paths.conductorDb))
+    ? [paths.conductorDb]
+    : [];
+  return sourceResult("conductor", files, () => {
+    const database = readDatabase(paths.conductorDb);
+    try {
+      requireTables(database, "Conductor", ["sessions", "session_messages"]);
+      const sessionRows = rows(
+        database,
+        `SELECT s.id, s.title, s.created_at, s.updated_at, s.model,
+                s.agent_type, s.workspace_id,
+                GROUP_CONCAT(COALESCE(sm.content, sm.full_message, ''), '\n') AS body
+           FROM sessions s
+           LEFT JOIN session_messages sm ON sm.session_id = s.id
+          GROUP BY s.id, s.title, s.created_at, s.updated_at, s.model,
+                   s.agent_type, s.workspace_id`,
+        RowSchema,
+      );
+      return sessionRows.map((row) => {
+        const body = stringValue(rowValue(row, "body")) ?? "";
+        const title = stringValue(rowValue(row, "title")) ?? "Untitled";
+        const createdAt =
+          stringValue(rowValue(row, "created_at")) ?? new Date(0).toISOString();
+        const updatedAt = stringValue(rowValue(row, "updated_at")) ?? createdAt;
+        return {
+          source: "conductor",
+          sourceId: String(rowValue(row, "id")),
+          title: firstText(title, "Conductor session"),
+          path: paths.conductorDb,
+          workspace: stringValue(rowValue(row, "workspace_id")),
+          agent:
+            stringValue(rowValue(row, "agent_type")) ??
+            stringValue(rowValue(row, "model")),
+          createdAt: parseTimestamp(createdAt, new Date(0)),
+          updatedAt: parseTimestamp(updatedAt, new Date(0)),
+          searchText: `${title}\n${body}`,
+        } satisfies HistoryDocument;
+      });
+    } finally {
+      database.close();
+    }
+  });
+}
+
+async function scanClaude(paths: HistoryPaths): Promise<HistorySourceResult> {
+  const files = await filesUnder(paths.claudeProjects, ".jsonl");
+  return sourceResult("claude", files, async () => {
+    const documents: HistoryDocument[] = [];
+    for (const file of files) {
+      const raw = await Bun.file(file).text();
+      const lines = raw.split("\n");
+      const textChunks: string[] = [];
+      let createdAt: string | null = null;
+      let updatedAt: string | null = null;
+      let title: string | null = null;
+      for (const line of lines) {
+        if (line.trim().length === 0) {
+          continue;
+        }
+        const value = parseJsonLine(line);
+        const record = parseRecord(value);
+        if (record === null) {
+          continue;
+        }
+        const timestamp = stringValue(record["timestamp"]);
+        if (createdAt === null && timestamp !== null) {
+          createdAt = parseTimestamp(timestamp, new Date(0));
+        }
+        if (timestamp !== null) {
+          updatedAt = parseTimestamp(timestamp, new Date(0));
+        }
+        const text = cleanText(extractText(record));
+        if (text.length > 0) {
+          textChunks.push(text);
+          if (
+            title === null &&
+            (record["type"] === "user" || record["type"] === "human")
+          ) {
+            title = firstText(text, "Claude Code session");
+          }
+        }
+      }
+      const info = await stat(file);
+      const fallback = new Date(info.mtimeMs);
+      documents.push({
+        source: "claude",
+        sourceId: path.relative(paths.claudeProjects, file),
+        title: title ?? path.basename(file, ".jsonl"),
+        path: file,
+        workspace: path.dirname(path.dirname(file)),
+        agent: "Claude Code",
+        createdAt: createdAt ?? fallback.toISOString(),
+        updatedAt: updatedAt ?? fallback.toISOString(),
+        searchText: textChunks.join("\n"),
+      });
+    }
+    return documents;
+  });
+}
+
+type CodexItem = {
+  readonly threadId: string;
+  readonly itemJson: string;
+  readonly createdAtMs: number;
+};
+
+function scanCodexThreadDatabase(filePath: string): HistoryDocument[] {
+  const database = readDatabase(filePath);
+  try {
+    requireTables(database, "Codex thread history", ["thread_items"]);
+    const itemRows = rows(
+      database,
+      "SELECT thread_id, item_json, created_at_ms FROM thread_items ORDER BY thread_id, rollout_ordinal",
+      z.object({
+        thread_id: z.string(),
+        item_json: z.string(),
+        created_at_ms: z.number(),
+      }),
+    );
+    const groups = new Map<string, CodexItem[]>();
+    for (const row of itemRows) {
+      const group = groups.get(row.thread_id) ?? [];
+      group.push({
+        threadId: row.thread_id,
+        itemJson: row.item_json,
+        createdAtMs: row.created_at_ms,
+      });
+      groups.set(row.thread_id, group);
+    }
+    return [...groups.values()].map((items) => {
+      const first = items[0];
+      if (first === undefined) {
+        throw new TypeError("Codex thread group was empty");
+      }
+      const text = items
+        .map((item) => extractText(parseJsonLine(item.itemJson)))
+        .filter((chunk) => chunk.length > 0)
+        .join("\n");
+      const createdAt = new Date(first.createdAtMs).toISOString();
+      const updatedAt = new Date(
+        items.at(-1)?.createdAtMs ?? first.createdAtMs,
+      ).toISOString();
+      return {
+        source: "codex",
+        sourceId: `${filePath}:${first.threadId}`,
+        title: firstText(text, first.threadId),
+        path: filePath,
+        workspace: null,
+        agent: "Codex",
+        createdAt,
+        updatedAt,
+        searchText: text,
+      } satisfies HistoryDocument;
+    });
+  } finally {
+    database.close();
+  }
+}
+
+async function scanCodexHistoryJsonl(
+  filePath: string,
+): Promise<HistoryDocument[]> {
+  const raw = await Bun.file(filePath).text();
+  const info = await stat(filePath);
+  return raw
+    .split("\n")
+    .map((line, index) => ({ line: line.trim(), index }))
+    .filter((entry) => entry.line.length > 0)
+    .map((entry) => {
+      const value = parseJsonLine(entry.line);
+      const record = parseRecord(value);
+      const text = cleanText(extractText(value));
+      const timestamp =
+        record?.["timestamp"] ?? record?.["created_at"] ?? record?.["time"];
+      const updatedAt = parseTimestamp(timestamp, new Date(info.mtimeMs));
+      return {
+        source: "codex",
+        sourceId: `${filePath}:line:${String(entry.index + 1)}`,
+        title: firstText(text, "Codex history entry"),
+        path: filePath,
+        workspace: null,
+        agent: "Codex",
+        createdAt: updatedAt,
+        updatedAt,
+        searchText: text,
+      } satisfies HistoryDocument;
+    });
+}
+
+function scanCodexCatalog(filePath: string): HistoryDocument[] {
+  const database = readDatabase(filePath);
+  try {
+    requireTables(database, "Codex catalog", ["local_thread_catalog"]);
+    const catalogRows = rows(
+      database,
+      `SELECT host_id, thread_id, display_title, source_created_at,
+              source_updated_at, cwd, model_provider, git_branch
+         FROM local_thread_catalog
+        WHERE missing_candidate = 0`,
+      RowSchema,
+    );
+    return catalogRows.map((row) => {
+      const title =
+        stringValue(rowValue(row, "display_title")) ?? "Codex thread";
+      const workspace = stringValue(rowValue(row, "cwd"));
+      const branch = stringValue(rowValue(row, "git_branch"));
+      const text = `${title}\n${workspace ?? ""}\n${branch ?? ""}`;
+      return {
+        source: "codex",
+        sourceId: `${filePath}:${String(rowValue(row, "host_id"))}:${String(rowValue(row, "thread_id"))}`,
+        title: firstText(title, "Codex thread"),
+        path: filePath,
+        workspace,
+        agent: stringValue(rowValue(row, "model_provider")) ?? "Codex",
+        createdAt: parseTimestamp(
+          rowValue(row, "source_created_at"),
+          new Date(0),
+        ),
+        updatedAt: parseTimestamp(
+          rowValue(row, "source_updated_at"),
+          new Date(0),
+        ),
+        searchText: text,
+      } satisfies HistoryDocument;
+    });
+  } finally {
+    database.close();
+  }
+}
+
+async function scanCodex(paths: HistoryPaths): Promise<HistorySourceResult> {
+  const historyFiles = await filesUnder(paths.codexDir);
+  const threadFiles = historyFiles.filter((file) =>
+    /thread_history_.*\.sqlite$/u.test(file),
+  );
+  const files = [
+    ...threadFiles,
+    paths.codexCatalogDb,
+    paths.codexHistoryJsonl,
+  ].filter((file, index, all) => all.indexOf(file) === index);
+  const existingFiles: string[] = [];
+  for (const file of files) {
+    if (await pathExists(file)) {
+      existingFiles.push(file);
+    }
+  }
+  return sourceResult("codex", existingFiles, async () => {
+    const documents: HistoryDocument[] = [];
+    for (const file of threadFiles) {
+      if (await pathExists(file)) {
+        documents.push(...scanCodexThreadDatabase(file));
+      }
+    }
+    if (await pathExists(paths.codexCatalogDb)) {
+      documents.push(...scanCodexCatalog(paths.codexCatalogDb));
+    }
+    if (await pathExists(paths.codexHistoryJsonl)) {
+      documents.push(...(await scanCodexHistoryJsonl(paths.codexHistoryJsonl)));
+    }
+    return documents;
+  });
+}
+
+async function scanCursor(paths: HistoryPaths): Promise<HistorySourceResult> {
+  const files = (await pathExists(paths.cursorConversationDb))
+    ? [paths.cursorConversationDb]
+    : [];
+  return sourceResult("cursor", files, () => {
+    const database = readDatabase(paths.cursorConversationDb);
+    try {
+      requireTables(database, "Cursor conversation search", [
+        "conversations",
+        "conversation_fts",
+      ]);
+      const conversationRows = rows(
+        database,
+        `SELECT c.fts_rowid, c.source, c.scope, c.id, c.title, c.updated_at,
+                f.body
+           FROM conversations c
+           JOIN conversation_fts f ON f.rowid = c.fts_rowid`,
+        RowSchema,
+      );
+      return conversationRows.map((row) => {
+        const title =
+          stringValue(rowValue(row, "title")) ?? "Cursor conversation";
+        const body = stringValue(rowValue(row, "body")) ?? "";
+        const updatedAt = parseTimestamp(
+          rowValue(row, "updated_at"),
+          new Date(0),
+        );
+        return {
+          source: "cursor",
+          sourceId: `${String(rowValue(row, "source"))}:${String(rowValue(row, "scope"))}:${String(rowValue(row, "id"))}`,
+          title: firstText(title, "Cursor conversation"),
+          path: paths.cursorConversationDb,
+          workspace: stringValue(rowValue(row, "scope")),
+          agent: "Cursor",
+          createdAt: updatedAt,
+          updatedAt,
+          searchText: `${title}\n${body}`,
+        } satisfies HistoryDocument;
+      });
+    } finally {
+      database.close();
+    }
+  });
+}
+
+export function createHistorySources(): readonly HistorySource[] {
+  return [
+    { name: "conductor", label: "Conductor", scan: scanConductor },
+    { name: "claude", label: "Claude Code", scan: scanClaude },
+    { name: "codex", label: "Codex", scan: scanCodex },
+    { name: "cursor", label: "Cursor", scan: scanCursor },
+    ...createOpenCodeSources(),
+  ];
+}

--- a/packages/toolkit/src/lib/history/text.ts
+++ b/packages/toolkit/src/lib/history/text.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+const RecordSchema = z.record(z.string(), z.unknown());
+
+export function parseRecord(value: unknown): Record<string, unknown> | null {
+  const parsed = RecordSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+const TEXT_KEYS = new Set([
+  "text",
+  "content",
+  "prompt",
+  "summary",
+  "description",
+  "message",
+  "title",
+  "command",
+  "stdout",
+  "stderr",
+  "output",
+  "input",
+  "reason",
+]);
+
+const SENSITIVE_KEYS = new Set([
+  "access_token",
+  "api_key",
+  "authorization",
+  "cookies",
+  "credentials",
+  "env",
+  "headers",
+  "password",
+  "refresh_token",
+  "secret",
+  "token",
+  "value",
+]);
+
+export function extractText(value: unknown, depth = 0): string {
+  if (depth > 12 || value == null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => extractText(entry, depth + 1))
+      .filter((entry) => entry.length > 0)
+      .join("\n");
+  }
+  const record = parseRecord(value);
+  if (record === null) {
+    return "";
+  }
+  const chunks: string[] = [];
+  for (const [key, child] of Object.entries(record)) {
+    if (SENSITIVE_KEYS.has(key)) {
+      continue;
+    }
+    if (TEXT_KEYS.has(key)) {
+      const text = extractText(child, depth + 1);
+      if (text.length > 0) {
+        chunks.push(text);
+      }
+    } else if (typeof child === "object" && child !== null) {
+      const nested = extractText(child, depth + 1);
+      if (nested.length > 0) {
+        chunks.push(nested);
+      }
+    }
+  }
+  return chunks.join("\n");
+}
+
+export function cleanText(value: string): string {
+  return value.replaceAll(/\s+/gu, " ").trim();
+}
+
+export function excerptForQuery(text: string, query: string): string {
+  const normalized = cleanText(text);
+  if (normalized.length === 0) {
+    return "";
+  }
+  const terms = query
+    .toLocaleLowerCase()
+    .split(/[^\p{L}\p{N}_-]+/u)
+    .filter((term) => term.length >= 2);
+  const lower = normalized.toLocaleLowerCase();
+  const offset = terms
+    .map((term) => lower.indexOf(term))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0];
+  const start = Math.max(0, (offset ?? 0) - 100);
+  const end = Math.min(normalized.length, start + 360);
+  return `${start > 0 ? "…" : ""}${normalized.slice(start, end)}${end < normalized.length ? "…" : ""}`;
+}
+
+export function parseTimestamp(value: unknown, fallback: Date): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const milliseconds = value < 10_000_000_000 ? value * 1000 : value;
+    return new Date(milliseconds).toISOString();
+  }
+  if (typeof value === "string") {
+    const timestamp = Date.parse(value);
+    if (!Number.isNaN(timestamp)) {
+      return new Date(timestamp).toISOString();
+    }
+  }
+  return fallback.toISOString();
+}
+
+export function parseJsonLine(line: string): unknown {
+  try {
+    return JSON.parse(line) as unknown;
+  } catch {
+    return null;
+  }
+}

--- a/packages/toolkit/src/lib/history/types.ts
+++ b/packages/toolkit/src/lib/history/types.ts
@@ -1,0 +1,60 @@
+import type { HistoryPaths } from "./paths.ts";
+
+export const HISTORY_SOURCE_NAMES = [
+  "conductor",
+  "claude",
+  "codex",
+  "cursor",
+  "opencode-conductor",
+  "opencode-standalone",
+] as const;
+
+export type HistorySourceName = (typeof HISTORY_SOURCE_NAMES)[number];
+
+export type HistoryDocument = {
+  readonly source: HistorySourceName;
+  readonly sourceId: string;
+  readonly title: string;
+  readonly path: string;
+  readonly workspace: string | null;
+  readonly agent: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly searchText: string;
+};
+
+export type HistorySourceResult = {
+  readonly source: HistorySourceName;
+  readonly available: boolean;
+  readonly documents: readonly HistoryDocument[];
+  readonly fingerprint: string;
+  readonly error: string | null;
+};
+
+export type HistorySource = {
+  readonly name: HistorySourceName;
+  readonly label: string;
+  scan: (paths: HistoryPaths) => Promise<HistorySourceResult>;
+};
+
+export type HistoryRecord = {
+  readonly id: number;
+  readonly source: HistorySourceName;
+  readonly sourceId: string;
+  readonly title: string;
+  readonly path: string;
+  readonly workspace: string | null;
+  readonly agent: string | null;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly excerpt: string | null;
+};
+
+export type HistorySourceStatus = {
+  readonly source: HistorySourceName;
+  readonly label: string;
+  readonly available: boolean;
+  readonly indexedDocuments: number;
+  readonly lastScanAt: string | null;
+  readonly error: string | null;
+};

--- a/packages/toolkit/test/history/history.test.ts
+++ b/packages/toolkit/test/history/history.test.ts
@@ -1,0 +1,246 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { HistoryIndex, parseSince } from "#lib/history/index.ts";
+import { renderLaunchAgent } from "#lib/history/launchd.ts";
+import {
+  defaultHistoryRuntimePaths,
+  type HistoryPaths,
+} from "#lib/history/paths.ts";
+import { createHistorySources } from "#lib/history/sources.ts";
+
+let fixtureRoot = "";
+let paths: HistoryPaths;
+
+function writeDatabase(
+  filePath: string,
+  schema: string,
+  seed: (database: Database) => void,
+): void {
+  const database = new Database(filePath);
+  database.run(schema);
+  seed(database);
+  database.close();
+}
+
+beforeAll(async () => {
+  fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "toolkit-history-"));
+  const conductorDir = path.join(fixtureRoot, "conductor");
+  const claudeDir = path.join(fixtureRoot, "claude/projects/project");
+  const codexDir = path.join(fixtureRoot, "codex");
+  const cursorDir = path.join(fixtureRoot, "cursor");
+  const opencodeDir = path.join(fixtureRoot, "opencode");
+  await Promise.all([
+    mkdir(conductorDir, { recursive: true }),
+    mkdir(claudeDir, { recursive: true }),
+    mkdir(codexDir, { recursive: true }),
+    mkdir(cursorDir, { recursive: true }),
+    mkdir(opencodeDir, { recursive: true }),
+  ]);
+
+  const conductorDb = path.join(conductorDir, "conductor.db");
+  writeDatabase(
+    conductorDb,
+    `
+      CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT, created_at TEXT, updated_at TEXT,
+        model TEXT, agent_type TEXT, workspace_id TEXT);
+      CREATE TABLE session_messages (id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT,
+        full_message TEXT, created_at TEXT);
+    `,
+    (database) => {
+      database.run(
+        "INSERT INTO sessions VALUES ('s1', 'Ingress repair', '2026-08-10T00:00:00Z', '2026-08-11T00:00:00Z', 'model', 'agent', 'workspace')",
+      );
+      database.run(
+        "INSERT INTO session_messages VALUES ('m1', 's1', 'user', 'Fix kubernetes ingress', NULL, '2026-08-10T00:00:00Z')",
+      );
+    },
+  );
+
+  const claudeFile = path.join(claudeDir, "session.jsonl");
+  await Bun.write(
+    claudeFile,
+    `${JSON.stringify({ type: "user", timestamp: "2026-08-12T00:00:00Z", message: { content: "Investigate database migration" } })}\n${JSON.stringify({ type: "assistant", timestamp: "2026-08-12T00:01:00Z", message: { content: [{ type: "text", text: "Migration is complete" }] } })}\n`,
+  );
+
+  const codexThread = path.join(codexDir, "thread_history_1.sqlite");
+  writeDatabase(
+    codexThread,
+    "CREATE TABLE thread_items (thread_id TEXT, turn_id TEXT, item_id TEXT, rollout_ordinal INTEGER, created_at_ms INTEGER, item_json TEXT, item_type TEXT, updated_at_ordinal INTEGER, PRIMARY KEY (thread_id, turn_id, item_id));",
+    (database) => {
+      database.run(
+        "INSERT INTO thread_items VALUES ('t1', 'turn', 'item', 1, 1786406400000, '{\"type\":\"userMessage\",\"text\":\"Repair Buildkite pipeline\"}', 'userMessage', 0)",
+      );
+    },
+  );
+  const codexHistory = path.join(codexDir, "history.jsonl");
+  await Bun.write(
+    codexHistory,
+    `${JSON.stringify({ timestamp: "2026-08-13T00:00:00Z", prompt: "Review deployment status" })}\n`,
+  );
+  const codexCatalog = path.join(codexDir, "codex-dev.db");
+  writeDatabase(
+    codexCatalog,
+    "CREATE TABLE local_thread_catalog (host_id TEXT, thread_id TEXT, display_title TEXT, source_created_at REAL, source_updated_at REAL, cwd TEXT, model_provider TEXT, git_branch TEXT, missing_candidate INTEGER);",
+    (database) => {
+      database.run(
+        "INSERT INTO local_thread_catalog VALUES ('host', 't1', 'Cataloged work', 1786406400, 1786406400, '/workspace', 'openai', 'main', 0)",
+      );
+    },
+  );
+
+  const cursorDb = path.join(cursorDir, "conversation-search.db");
+  writeDatabase(
+    cursorDb,
+    `
+      CREATE TABLE conversations (fts_rowid INTEGER PRIMARY KEY, source TEXT, scope TEXT, id TEXT,
+        title TEXT, updated_at INTEGER, is_archived INTEGER, root_fingerprint TEXT, cache_fingerprint TEXT);
+      CREATE VIRTUAL TABLE conversation_fts USING fts5(title, body);
+    `,
+    (database) => {
+      database.run(
+        "INSERT INTO conversations VALUES (1, 'local', '', 'c1', 'Cursor fix', 1786406400000, 0, 'root', NULL)",
+      );
+      database.run(
+        "INSERT INTO conversation_fts(rowid, title, body) VALUES (1, 'Cursor fix', 'Resolve TypeScript typecheck')",
+      );
+    },
+  );
+
+  const opencodeDb = path.join(opencodeDir, "opencode.db");
+  writeDatabase(
+    opencodeDb,
+    `
+      CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, agent TEXT, model TEXT,
+        time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER, time_updated INTEGER);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    `,
+    (database) => {
+      database.run(
+        "INSERT INTO session VALUES ('o1', 'OpenCode work', '/workspace', 'build', 'model', 1786406400000, 1786406400000)",
+      );
+      database.run(
+        "INSERT INTO message VALUES ('om1', 'o1', '{\"role\":\"user\"}', 1786406400000, 1786406400000)",
+      );
+      database.run(
+        "INSERT INTO part VALUES ('op1', 'om1', 'o1', 1786406400000, 1786406400000, '{\"type\":\"text\",\"text\":\"Improve launchd ingestion\"}')",
+      );
+    },
+  );
+  await Bun.write(
+    path.join(opencodeDir, "auth.json"),
+    JSON.stringify({ token: "must-not-be-indexed" }),
+  );
+
+  paths = {
+    home: fixtureRoot,
+    conductorDb,
+    conductorOpenCodeDb: opencodeDb,
+    claudeProjects: path.join(fixtureRoot, "claude/projects"),
+    codexDir,
+    codexCatalogDb: codexCatalog,
+    codexHistoryJsonl: codexHistory,
+    cursorConversationDb: cursorDb,
+    standaloneOpenCodeDb: opencodeDb,
+    standaloneOpenCodeAuth: path.join(opencodeDir, "auth.json"),
+  };
+});
+
+afterAll(async () => {
+  if (fixtureRoot.length > 0) {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+describe("history source adapters", () => {
+  test("reads every supported source without reading auth.json", async () => {
+    const results = await Promise.all(
+      createHistorySources().map((source) => source.scan(paths)),
+    );
+    expect(results.every((result) => result.error === null)).toBe(true);
+    expect(
+      results.flatMap((result) => result.documents).length,
+    ).toBeGreaterThanOrEqual(7);
+    expect(
+      results
+        .flatMap((result) => result.documents)
+        .some((document) =>
+          document.searchText.includes("must-not-be-indexed"),
+        ),
+    ).toBe(false);
+  });
+
+  test("reports missing sources without pretending they are indexed", async () => {
+    const missingPaths = {
+      ...paths,
+      conductorDb: path.join(fixtureRoot, "missing.db"),
+    };
+    const source = createHistorySources().find(
+      (entry) => entry.name === "conductor",
+    );
+    expect(source).toBeDefined();
+    const result = await source?.scan(missingPaths);
+    expect(result?.available).toBe(false);
+    expect(result?.documents).toHaveLength(0);
+  });
+});
+
+describe("history index", () => {
+  test("searches, updates, deletes, and filters indexed work", async () => {
+    const runtimePaths = defaultHistoryRuntimePaths(
+      path.join(fixtureRoot, "home"),
+    );
+    const index = await HistoryIndex.open(runtimePaths);
+    const source = createHistorySources().find(
+      (entry) => entry.name === "claude",
+    );
+    expect(source).toBeDefined();
+    const first = await source?.scan(paths);
+    expect(first).toBeDefined();
+    if (first === undefined) {
+      throw new Error("Claude source fixture was not created");
+    }
+    await index.ingest([first]);
+    expect(
+      index.search("database", { since: null, source: "claude", limit: 20 }),
+    ).toHaveLength(1);
+    expect(
+      index.search("database migration", {
+        since: null,
+        source: null,
+        limit: 20,
+      }),
+    ).toHaveLength(1);
+    expect(
+      index.search("database", { since: null, source: "codex", limit: 20 }),
+    ).toHaveLength(0);
+
+    await index.ingest([
+      { ...first, fingerprint: `${first.fingerprint}:changed`, documents: [] },
+    ]);
+    expect(
+      index.search("database", { since: null, source: "claude", limit: 20 }),
+    ).toHaveLength(0);
+    index.close();
+  });
+
+  test("parses useful recency windows", () => {
+    const now = new Date("2026-08-16T00:00:00Z");
+    expect(parseSince("7d", now)).toBe("2026-08-09T00:00:00.000Z");
+    expect(parseSince("24h", now)).toBe("2026-08-15T00:00:00.000Z");
+    expect(parseSince("2026-08-01", now)).toBe("2026-08-01T00:00:00.000Z");
+  });
+});
+
+test("renders a private LaunchAgent with automatic restart", () => {
+  const runtimePaths = defaultHistoryRuntimePaths("/Users/tester");
+  const plist = renderLaunchAgent(runtimePaths);
+  expect(plist).toContain("com.jerred.toolkit-history");
+  expect(plist).toContain("<key>RunAtLoad</key>");
+  expect(plist).toContain("<key>KeepAlive</key>");
+  expect(plist).toContain("/Users/tester/.toolkit/history/logs");
+  expect(plist).not.toContain("auth.json");
+});


### PR DESCRIPTION
Why:
Provide one cheap, private way to recall work across Conductor, Claude Code, Codex, Cursor, and both bundled and standalone OpenCode without creating a second transcript archive.

What:
- Add toolkit history search, recent, sources, and daemon lifecycle commands.
- Add a local SQLite FTS5 metadata index with incremental source adapters, read-only explicit excerpts, unavailable-schema reporting, and auth.json exclusion.
- Add a macOS LaunchAgent daemon with private 0600/0700 runtime state, 30-second polling, IPC reindex, and lifecycle management.
- Document command examples, storage/privacy boundaries, and historical-versus-live status guidance in root/toolkit agent docs, README, and the history skill.

Verification:
- bunx turbo run typecheck test lint --filter=@shepherdjerred/toolkit (79 tests passed)
- bunx turbo run build --filter=@shepherdjerred/toolkit
- bunx prettier --check AGENTS.md packages/toolkit/AGENTS.md packages/toolkit/README.md packages/toolkit/skills/history/SKILL.md
- bunx lefthook run pre-commit
- git diff --check
- macOS smoke: LaunchAgent install/status, initial ingestion, metadata search/recent, reindex, stop, uninstall; runtime state cleaned.

Note: the literal root `bun run build --filter=@shepherdjerred/toolkit` is unavailable because the root package has no `build` script; the equivalent filtered Turbo build passed.