### PR TITLE
feat(code-review): count a finding once when a provider posts it twice

### DIFF
--- a/packages/code-review/src/gate.test.ts
+++ b/packages/code-review/src/gate.test.ts
@@ -18,6 +18,8 @@ function thread(overrides: Partial<ReviewThread>): ReviewThread {
     url: "https://github.com/o/r/pull/1#d",
     priority: 2,
     title: null,
+    threadId: null,
+    commentId: null,
     ...overrides,
   };
 }

--- a/packages/code-review/src/github-issue-comments.test.ts
+++ b/packages/code-review/src/github-issue-comments.test.ts
@@ -16,6 +16,7 @@ function acknowledging(sha: string) {
     body: `[Code review](https://github.com/o/r/pull/1#issuecomment-1) by qodo was updated up to the latest commit https://github.com/o/r/commit/${sha}`,
     updatedAt: afterPush,
     url: null,
+    id: null,
   };
 }
 
@@ -181,11 +182,15 @@ const issueCommentProvider: ReviewProvider = {
         url: null,
         priority: 1,
         title: null,
+        threadId: null,
+        commentId: null,
       },
     ],
   },
   detectSkip: null,
   requestReview: null,
+  parseFindingTitle: null,
+  findingKey: null,
 };
 
 test("records the acknowledgement time as issue-comment completion", async () => {

--- a/packages/code-review/src/github-issue-comments.ts
+++ b/packages/code-review/src/github-issue-comments.ts
@@ -3,6 +3,7 @@ import {
   asRecord,
   GITHUB_API_URL,
   getJsonWithLink,
+  numberField,
   recordField,
   stringField,
 } from "./github-http.ts";
@@ -101,7 +102,12 @@ async function scanProviderIssueComments(
       if (body === null) continue;
       const updatedAt =
         stringField(item, "updated_at") ?? stringField(item, "created_at");
-      const comment = { body, updatedAt, url: stringField(item, "html_url") };
+      const comment = {
+        body,
+        updatedAt,
+        url: stringField(item, "html_url"),
+        id: numberField(item, "id"),
+      };
       // An acknowledgement quotes the review comment's title, so classify it
       // first: only a comment that is not an acknowledgement can be the review.
       if (body.includes(completion.acknowledgement.marker)) {

--- a/packages/code-review/src/github-review-threads.ts
+++ b/packages/code-review/src/github-review-threads.ts
@@ -1,0 +1,108 @@
+/**
+ * Reading the PR's review threads off GitHub's GraphQL API and normalising each
+ * one into a {@link ReviewThread}. Kept apart from the completion strategies it
+ * feeds: this is the shape of GitHub's payload, not a decision about it.
+ */
+
+import {
+  arrayField,
+  asRecord,
+  boolField,
+  numberField,
+  recordField,
+  stringField,
+} from "./github-http.ts";
+import type { ReviewProvider, ReviewThread } from "./types.ts";
+
+export const REVIEW_THREADS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      headRefOid
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 1) {
+            nodes { author { login } url body }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export function parseThreadPage(
+  payload: unknown,
+  provider: ReviewProvider,
+): {
+  headRefOid: string | null;
+  threads: ReviewThread[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+} {
+  const payloadRecord = asRecord(payload);
+  const data =
+    payloadRecord === null ? null : recordField(payloadRecord, "data");
+  const repository = data === null ? null : recordField(data, "repository");
+  const pullRequest =
+    repository === null ? null : recordField(repository, "pullRequest");
+  if (pullRequest === null) {
+    throw new Error(
+      "GitHub GraphQL response did not include repository.pullRequest",
+    );
+  }
+  const reviewThreads = recordField(pullRequest, "reviewThreads");
+  if (reviewThreads === null) {
+    throw new Error("GitHub GraphQL response did not include reviewThreads");
+  }
+
+  const threads: ReviewThread[] = [];
+  for (const rawNode of arrayField(reviewThreads, "nodes")) {
+    const node = asRecord(rawNode);
+    if (node === null) continue;
+    const comments = recordField(node, "comments");
+    const commentNodes = comments === null ? [] : arrayField(comments, "nodes");
+    const firstComment = asRecord(commentNodes[0]);
+    let authorLogin: string | null = null;
+    let url: string | null = null;
+    let priority: number | null = null;
+    let title: string | null = null;
+    if (firstComment !== null) {
+      const author = recordField(firstComment, "author");
+      const body = stringField(firstComment, "body");
+      authorLogin = author === null ? null : stringField(author, "login");
+      url = stringField(firstComment, "url");
+      priority = provider.parseSeverity(body);
+      // A thread is addressable, so a consumer *could* re-read it — but the
+      // title is what identifies this finding as the same one the provider may
+      // also have rendered into its review comment, which is what stops it
+      // being counted twice.
+      title = provider.parseFindingTitle?.(body) ?? null;
+    }
+    threads.push({
+      authorLogin,
+      isResolved: boolField(node, "isResolved"),
+      isOutdated: boolField(node, "isOutdated"),
+      path: stringField(node, "path"),
+      line: numberField(node, "line"),
+      url,
+      priority,
+      title,
+      threadId: stringField(node, "id"),
+      commentId: null,
+    });
+  }
+
+  const pageInfo = recordField(reviewThreads, "pageInfo");
+  return {
+    headRefOid: stringField(pullRequest, "headRefOid"),
+    threads,
+    hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
+    endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
+  };
+}

--- a/packages/code-review/src/github.ts
+++ b/packages/code-review/src/github.ts
@@ -9,13 +9,11 @@
 import {
   arrayField,
   asRecord,
-  boolField,
   type CheckConclusion,
   conclusionField,
   GITHUB_API_URL,
   getJsonWithLink,
   graphqlRequest,
-  numberField,
   recordField,
   splitRepo,
   stringField,
@@ -25,7 +23,12 @@ import {
   fetchLatestProviderIssueComment,
   resolveIssueCommentReview,
 } from "./github-issue-comments.ts";
+import {
+  parseThreadPage,
+  REVIEW_THREADS_QUERY,
+} from "./github-review-threads.ts";
 import { isProviderAuthor } from "./identity.ts";
+import { mergeDuplicateFindings } from "./merge-findings.ts";
 import type { CompletionSignal } from "./signal.ts";
 import type {
   PullRequestAuthor,
@@ -34,7 +37,6 @@ import type {
   ReviewState,
   ReviewThread,
 } from "./types.ts";
-
 // ---------------------------------------------------------------------------
 // Pull-request author
 // ---------------------------------------------------------------------------
@@ -77,94 +79,9 @@ export async function fetchPullRequestAuthor(input: {
   const { payload } = await getJsonWithLink(url, input.token);
   return parsePullRequestAuthor(payload);
 }
-
 // ---------------------------------------------------------------------------
 // Review threads (provider-agnostic; priority parsed via the active provider)
 // ---------------------------------------------------------------------------
-
-const REVIEW_THREADS_QUERY = `
-query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $number) {
-      headRefOid
-      reviewThreads(first: 100, after: $cursor) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          isResolved
-          isOutdated
-          path
-          line
-          comments(first: 1) {
-            nodes { author { login } url body }
-          }
-        }
-      }
-    }
-  }
-}`;
-
-function parseThreadPage(
-  payload: unknown,
-  provider: ReviewProvider,
-): {
-  headRefOid: string | null;
-  threads: ReviewThread[];
-  hasNextPage: boolean;
-  endCursor: string | null;
-} {
-  const payloadRecord = asRecord(payload);
-  const data =
-    payloadRecord === null ? null : recordField(payloadRecord, "data");
-  const repository = data === null ? null : recordField(data, "repository");
-  const pullRequest =
-    repository === null ? null : recordField(repository, "pullRequest");
-  if (pullRequest === null) {
-    throw new Error(
-      "GitHub GraphQL response did not include repository.pullRequest",
-    );
-  }
-  const reviewThreads = recordField(pullRequest, "reviewThreads");
-  if (reviewThreads === null) {
-    throw new Error("GitHub GraphQL response did not include reviewThreads");
-  }
-
-  const threads: ReviewThread[] = [];
-  for (const rawNode of arrayField(reviewThreads, "nodes")) {
-    const node = asRecord(rawNode);
-    if (node === null) continue;
-    const comments = recordField(node, "comments");
-    const commentNodes = comments === null ? [] : arrayField(comments, "nodes");
-    const firstComment = asRecord(commentNodes[0]);
-    let authorLogin: string | null = null;
-    let url: string | null = null;
-    let priority: number | null = null;
-    if (firstComment !== null) {
-      const author = recordField(firstComment, "author");
-      authorLogin = author === null ? null : stringField(author, "login");
-      url = stringField(firstComment, "url");
-      priority = provider.parseSeverity(stringField(firstComment, "body"));
-    }
-    threads.push({
-      authorLogin,
-      isResolved: boolField(node, "isResolved"),
-      isOutdated: boolField(node, "isOutdated"),
-      path: stringField(node, "path"),
-      line: numberField(node, "line"),
-      url,
-      priority,
-      // A GitHub thread is addressable: consumers read its comment directly.
-      title: null,
-    });
-  }
-
-  const pageInfo = recordField(reviewThreads, "pageInfo");
-  return {
-    headRefOid: stringField(pullRequest, "headRefOid"),
-    threads,
-    hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
-    endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
-  };
-}
 
 export async function fetchReviewThreads(input: {
   repo: string;
@@ -209,7 +126,10 @@ export async function fetchReviewThreads(input: {
       threads.push(...completion.parseFindings(comment));
     }
   }
-  return { threads, headRefOid };
+  return {
+    threads: mergeDuplicateFindings(threads, input.provider),
+    headRefOid,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { mergeDuplicateFindings } from "./merge-findings.ts";
+import { codexProvider } from "./providers/codex.ts";
+import {
+  parseQodoFindingTitle,
+  qodoFindingKey,
+  qodoProvider,
+} from "./providers/qodo.ts";
+import type { ReviewThread } from "./types.ts";
+
+describe("mergeDuplicateFindings", () => {
+  // Qodo posts every finding twice: once inside its persistent review comment
+  // and once as an addressable thread on the offending line. These are the two
+  // renderings of ONE finding from PR #2095, kept verbatim — the ordinals
+  // differ (4 vs 1), the capitalization differs, and only the thread carries a
+  // Markdown-escaped `\.`. That is exactly what the key has to see through.
+  const fromComment: ReviewThread = {
+    authorLogin: "qodo-code-review",
+    isResolved: false,
+    isOutdated: false,
+    path: "packages/streambot/src/session/destroy-session.ts",
+    line: null,
+    url: "https://github.com/o/r/pull/2095/files#diff-abc",
+    priority: 1,
+    title: "Turn outlives session destroy",
+    threadId: null,
+    commentId: 5_236_306_054,
+  };
+  const fromThread: ReviewThread = {
+    authorLogin: "qodo-code-review",
+    isResolved: false,
+    isOutdated: false,
+    path: "packages/streambot/src/session/destroy-session.ts",
+    line: 10,
+    url: "https://github.com/o/r/pull/2095#discussion_r1",
+    priority: 1,
+    title: "Turn outlives session destroy",
+    threadId: "PRRT_kwDOHf4r4c6ZlJlJ",
+    commentId: null,
+  };
+
+  test("counts one finding rendered on both surfaces once", () => {
+    const merged = mergeDuplicateFindings(
+      [fromComment, fromThread],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+  });
+
+  test("keeps both handles so either surface can be acted on", () => {
+    const [merged] = mergeDuplicateFindings(
+      [fromComment, fromThread],
+      qodoProvider,
+    );
+    expect(merged?.threadId).toBe("PRRT_kwDOHf4r4c6ZlJlJ");
+    expect(merged?.commentId).toBe(5_236_306_054);
+    // The thread knows the line; the comment copy does not.
+    expect(merged?.line).toBe(10);
+  });
+
+  test("resolves the finding when only the thread copy is resolved", () => {
+    const merged = mergeDuplicateFindings(
+      [fromComment, { ...fromThread, isResolved: true }],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.isResolved).toBe(true);
+  });
+
+  test("resolves the finding when only the comment copy is chipped", () => {
+    const merged = mergeDuplicateFindings(
+      [{ ...fromComment, isResolved: true }, fromThread],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.isResolved).toBe(true);
+  });
+
+  test("does not mutate its input", () => {
+    const input = [{ ...fromComment, isResolved: true }, { ...fromThread }];
+    mergeDuplicateFindings(input, qodoProvider);
+    expect(input[1]?.isResolved).toBe(false);
+  });
+
+  test("takes the more severe priority when the surfaces disagree", () => {
+    const merged = mergeDuplicateFindings(
+      [{ ...fromComment, priority: 2 }, fromThread],
+      qodoProvider,
+    );
+    expect(merged[0]?.priority).toBe(1);
+  });
+
+  test("keeps findings in different files apart despite an identical title", () => {
+    const elsewhere = {
+      ...fromThread,
+      path: "packages/streambot/src/other.ts",
+    };
+    expect(
+      mergeDuplicateFindings([fromComment, elsewhere], qodoProvider),
+    ).toHaveLength(2);
+  });
+
+  test("never merges a finding it cannot identify", () => {
+    // A null key means "cannot identify this one". Two unidentifiable findings
+    // must stay two, or an unparseable finding would silently disappear into
+    // another one and stop blocking.
+    const untitled = { ...fromThread, title: null };
+    expect(
+      mergeDuplicateFindings([untitled, { ...untitled }], qodoProvider),
+    ).toHaveLength(2);
+  });
+
+  test("never merges another reviewer's thread into a provider finding", () => {
+    // A second reviewer on the same PR can render a matching headline on the
+    // same file. Folding it into the provider's finding would stop it being
+    // counted at all.
+    const otherReviewer = {
+      ...fromThread,
+      authorLogin: "chatgpt-codex-connector",
+      isResolved: true,
+    };
+    const merged = mergeDuplicateFindings(
+      [fromComment, otherReviewer],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged.find((t) => t.commentId === 5_236_306_054)?.isResolved).toBe(
+      false,
+    );
+  });
+
+  test("leaves providers that post each finding once untouched", () => {
+    const threads = [fromComment, fromThread];
+    expect(mergeDuplicateFindings(threads, codexProvider)).toHaveLength(2);
+  });
+});
+
+describe("parseQodoFindingTitle", () => {
+  // Verbatim from PR #2095, thread PRRT_kwDOHf4r4c6ZlJlJ.
+  const threadBody = [
+    '<img src="https://img.shields.io/badge/High-634FD1?style=flat-square" height="20px" alt="Action required">',
+    "",
+    String.raw`1\. Turn outlives session destroy <code>🐞 Bug</code> <code>☼ Reliability</code>`,
+    "",
+    "<pre>",
+    "destroySession() closes the voice assistant but does not await completion",
+    "</pre>",
+  ].join("\n");
+
+  test("reads the title past the badge, the ordinal, and the category chips", () => {
+    expect(parseQodoFindingTitle(threadBody)).toBe(
+      "Turn outlives session destroy",
+    );
+  });
+
+  test("gives a thread and its review-comment twin the same key", () => {
+    const base = {
+      authorLogin: "qodo-code-review",
+      isResolved: false,
+      isOutdated: false,
+      path: "packages/discord-video-stream/src/client/Streamer.ts",
+      line: null,
+      url: null,
+      priority: 1,
+      threadId: null,
+      commentId: null,
+    };
+    // The comment says "joinVoice"; the thread says "Joinvoice".
+    expect(
+      qodoFindingKey({ ...base, title: "joinVoice can hang forever" }),
+    ).toBe(qodoFindingKey({ ...base, title: "Joinvoice can hang forever" }));
+  });
+
+  test("reads the title of a finding Qodo has struck as resolved", () => {
+    // Verbatim from PR #2095 after its thread was resolved: Qodo wraps the
+    // whole title in <s>, so the line no longer opens with the ordinal.
+    const struck = [
+      '<img src="https://img.shields.io/badge/High-634FD1?style=flat-square" height="20px" alt="Action required">',
+      "",
+      String.raw`<s>1\. Joinvoice can hang forever</s> <code>🐞 Bug</code> <code>☼ Reliability</code>`,
+      "",
+      "<pre><s>",
+      "Streamer.joinVoice() now calls setAudioPacketizer() inside the ready callback",
+      "</s></pre>",
+    ].join("\n");
+    expect(parseQodoFindingTitle(struck)).toBe("Joinvoice can hang forever");
+  });
+
+  test("returns null when no numbered title line exists", () => {
+    expect(parseQodoFindingTitle("just prose, no finding here")).toBeNull();
+    expect(parseQodoFindingTitle(null)).toBeNull();
+  });
+});

--- a/packages/code-review/src/merge-findings.ts
+++ b/packages/code-review/src/merge-findings.ts
@@ -1,0 +1,69 @@
+import { isProviderAuthor } from "./identity.ts";
+import type { ReviewProvider, ReviewThread } from "./types.ts";
+
+/**
+ * Collapse the copies a provider posts to more than one surface into a single
+ * finding.
+ *
+ * Qodo renders every finding twice — once in its persistent review comment and
+ * once as an addressable thread on the offending line — and the two are cleared
+ * through different APIs. Counting both made `blocking_count` roughly double
+ * the number of real findings and made every finding cost two actions to clear.
+ *
+ * A finding is resolved once EITHER copy is resolved. Both gestures are
+ * deliberate and auditable, and each copy is already scoped to what currently
+ * applies: the comment parser reads only the current review section, and
+ * outdated threads are excluded downstream. This mirrors how copies *within*
+ * the review comment have always been merged (`dedupeRenderedFindings`), so one
+ * finding behaves the same however the provider chose to render it.
+ *
+ * Priority takes the most severe copy, so a disagreement between surfaces can
+ * only ever make the gate stricter. A `null` key never merges — an unrecognised
+ * finding is counted on its own rather than folded into an unrelated one.
+ */
+export function mergeDuplicateFindings(
+  threads: readonly ReviewThread[],
+  provider: ReviewProvider,
+): ReviewThread[] {
+  const { findingKey } = provider;
+  if (findingKey === null) return [...threads];
+  const merged: ReviewThread[] = [];
+  const byKey = new Map<string, ReviewThread>();
+  for (const thread of threads) {
+    // Only the configured provider posts a finding twice, so only its own
+    // threads may merge. Without this, another reviewer's thread that happened
+    // to render a matching headline on the same file would be folded into a
+    // provider finding and stop being counted.
+    const key = isProviderAuthor(provider, thread.authorLogin)
+      ? findingKey(thread)
+      : null;
+    if (key === null) {
+      merged.push(thread);
+      continue;
+    }
+    const seen = byKey.get(key);
+    if (seen === undefined) {
+      const copy = { ...thread };
+      byKey.set(key, copy);
+      merged.push(copy);
+      continue;
+    }
+    if (thread.isResolved) seen.isResolved = true;
+    // An outdated copy does not make the finding outdated: the other surface
+    // still shows it, so it is still on screen for a reviewer to act on.
+    if (!thread.isOutdated) seen.isOutdated = false;
+    if (
+      thread.priority !== null &&
+      (seen.priority === null || thread.priority < seen.priority)
+    ) {
+      seen.priority = thread.priority;
+    }
+    // Keep whichever handles each copy contributes, so a consumer can act on
+    // the finding wherever it lives without re-deriving the other surface.
+    seen.threadId ??= thread.threadId;
+    seen.commentId ??= thread.commentId;
+    seen.line ??= thread.line;
+    seen.path ??= thread.path;
+  }
+  return merged;
+}

--- a/packages/code-review/src/providers/codex.ts
+++ b/packages/code-review/src/providers/codex.ts
@@ -22,6 +22,10 @@ export const codexProvider: ReviewProvider = {
   botAuthoredPullRequestPolicy: "skip",
   authorLogins: ["chatgpt-codex-connector"],
   parseSeverity: parseCodexSeverity,
+  // Codex posts each finding once, as an addressable thread, so there is
+  // nothing to recognise a second copy of.
+  parseFindingTitle: null,
+  findingKey: null,
   completion: { kind: "review-at-head", cleanSignal: "thumbsup-reaction" },
   detectSkip: null,
   // Codex re-reviews on push, but an explicit `@codex review` mention forces a

--- a/packages/code-review/src/providers/greptile.ts
+++ b/packages/code-review/src/providers/greptile.ts
@@ -20,6 +20,10 @@ export const greptileProvider: ReviewProvider = {
   botAuthoredPullRequestPolicy: "review",
   authorLogins: ["greptile-apps"],
   parseSeverity: parseGreptileSeverity,
+  // Greptile posts each finding once, as an addressable thread, so there is
+  // nothing to recognise a second copy of.
+  parseFindingTitle: null,
+  findingKey: null,
   completion: { kind: "check-run", namePattern: /greptile/iu },
   detectSkip: {
     marker: "<!-- greptile-status -->",

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -6,6 +6,7 @@ import { qodoProvider, parseQodoIssueComment } from "./qodo.ts";
 const comment = {
   updatedAt: "2026-08-09T12:00:00Z",
   url: "https://github.com/shepherdjerred/monorepo/pull/1#issuecomment-1",
+  id: 1,
   body: `
 <h3>Code Review by Qodo</h3>
 <code>🐞 Bugs (1)</code> <code>📘 Rule violations (1)</code> <code>📎 Requirement gaps (0)</code> <code>🎨 UX issues (0)</code> <code>🔗 Cross-repo conflicts (0)</code> <code>📜 Skill insights (0)</code>
@@ -75,6 +76,8 @@ describe("qodoProvider", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc",
         priority: 1,
+        threadId: null,
+        commentId: 1,
       },
       {
         authorLogin: "qodo-code-review",
@@ -85,6 +88,8 @@ describe("qodoProvider", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-def",
         priority: 2,
+        threadId: null,
+        commentId: 1,
       },
       {
         authorLogin: "qodo-code-review",
@@ -95,6 +100,8 @@ describe("qodoProvider", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-ghi",
         priority: 2,
+        threadId: null,
+        commentId: 1,
       },
     ]);
   });
@@ -382,6 +389,8 @@ describe("qodo re-review copies", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc",
         priority: 1,
+        threadId: null,
+        commentId: 1,
       },
       {
         authorLogin: "qodo-code-review",
@@ -392,6 +401,8 @@ describe("qodo re-review copies", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-jkl",
         priority: 1,
+        threadId: null,
+        commentId: 1,
       },
     ]);
   });
@@ -474,6 +485,8 @@ Older unresolved wording retained for review history.
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-current",
         priority: 2,
+        threadId: null,
+        commentId: 1,
       },
     ]);
   });

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -154,21 +154,72 @@ function identityOf(summary: string, findingBody: string): string {
  * The finding's headline, as a reader would see it: the summary stripped of its
  * position, its resolved styling, and its category chips. Consumers that cannot
  * re-read the comment rely on this to say what the finding is.
+ *
+ * The ordinal may arrive Markdown-escaped (`1\.`): Qodo writes the review
+ * comment as HTML but the inline thread as Markdown, where a leading `1.` would
+ * otherwise start an ordered list. Both spellings must strip to the same title,
+ * because that title is what identifies one finding across the two surfaces.
  */
 function findingTitle(summary: string): string {
   return summary
     .replaceAll(/<code>[^<]*<\/code>/giu, "")
     .replaceAll(/<[^>]*>/gu, "")
-    .replace(/^\s*\d+\.\s*/u, "")
+    .replace(/^\s*\d+\\?\.\s*/u, "")
     .replaceAll(/[☑✓]/gu, "")
     .replaceAll(/\s+/gu, " ")
     .trim();
+}
+
+/**
+ * The title Qodo renders at the top of an inline review thread.
+ *
+ * Qodo posts every finding twice — once in the persistent review comment, once
+ * as an addressable thread on the offending line — and only the comment copy
+ * carries a parsed title. Reading the thread's title is what lets the two be
+ * recognised as one finding rather than counted (and cleared) twice.
+ *
+ * The title is the first ordinal-numbered line of the body, which follows the
+ * severity badge image. Returns `null` when no such line exists, which leaves
+ * the finding unmergeable rather than guessing at its identity.
+ */
+export function parseQodoFindingTitle(body: string | null): string | null {
+  if (body === null) return null;
+  for (const line of body.split("\n")) {
+    // Locate the line by its tag-stripped text, not its raw form: Qodo wraps a
+    // resolved finding's title in `<s>`, so the raw line opens with the strike
+    // tag rather than the ordinal. Requiring the ordinal first silently found
+    // no title on exactly the findings that had been dealt with — which left
+    // them unmergeable and counted twice.
+    if (!/^\s*\d+\\?\.\s+\S/u.test(line.replaceAll(/<[^>]*>/gu, ""))) continue;
+    const title = findingTitle(line);
+    return title === "" ? null : title;
+  }
+  return null;
+}
+
+/**
+ * Identity of the underlying finding, shared by both copies Qodo posts.
+ *
+ * Case is folded because the two surfaces disagree on it: the review comment
+ * renders `joinVoice can hang forever` while the thread renders `Joinvoice can
+ * hang forever`. The ordinal is already stripped by {@link findingTitle}, which
+ * matters because the copies are numbered independently — the same finding is
+ * `3.` in the comment and `1.` on the thread.
+ *
+ * The path is part of the key so two findings that happen to share a headline
+ * in different files stay distinct. A finding with no title returns `null` and
+ * therefore never merges.
+ */
+export function qodoFindingKey(thread: ReviewThread): string | null {
+  if (thread.title === null || thread.title === "") return null;
+  return `${thread.path ?? ""} ${thread.title.toLowerCase()}`;
 }
 
 function parseSeveritySection(
   section: string,
   priority: 1 | 2 | 3,
   commentUrl: string | null,
+  commentId: number | null,
 ): RenderedFinding[] {
   const findings: RenderedFinding[] = [];
   const summaries = [
@@ -217,6 +268,10 @@ function parseSeveritySection(
         line: null,
         url: linkMatch?.[2] ?? commentUrl,
         priority,
+        // A finding parsed out of the review comment is not a thread; it is
+        // cleared by editing the comment it came from.
+        threadId: null,
+        commentId,
       },
     });
   }
@@ -448,7 +503,9 @@ export function parseQodoIssueComment(
     const priority = priorityForSection(section);
     if (priority === null) continue;
     severitySections += 1;
-    rendered.push(...parseSeveritySection(section, priority, comment.url));
+    rendered.push(
+      ...parseSeveritySection(section, priority, comment.url, comment.id),
+    );
   }
 
   // Assert against the renderings, not the deduplicated findings: the layout
@@ -483,6 +540,8 @@ export const qodoProvider: ReviewProvider = {
   botAuthoredPullRequestPolicy: "skip",
   authorLogins: QODO_AUTHOR_LOGINS,
   parseSeverity: parseQodoSeverity,
+  parseFindingTitle: parseQodoFindingTitle,
+  findingKey: qodoFindingKey,
   completion: {
     kind: "issue-comment",
     marker: QODO_REVIEW_MARKER,

--- a/packages/code-review/src/types.ts
+++ b/packages/code-review/src/types.ts
@@ -50,13 +50,24 @@ export type ReviewThread = {
   url: string | null;
   priority: number | null;
   /**
-   * What the finding says, when the provider renders it somewhere a consumer
-   * cannot re-read. Threads carry their own comment bodies, but findings parsed
-   * out of a persistent issue comment do not: without this a consumer is left
-   * with a path and a diff anchor, which name a file rather than the problem.
-   * `null` for providers whose findings are addressable GitHub threads.
+   * What the finding says. Without it a consumer is left with a path and a diff
+   * anchor, which name a file rather than the problem — so it is populated for
+   * BOTH surfaces: parsed out of the persistent issue comment for findings that
+   * live there, and parsed from the first comment's body (via
+   * {@link ReviewProvider.parseFindingTitle}) for addressable GitHub threads.
+   * `null` only when the provider cannot recognise a title.
    */
   title: string | null;
+  /**
+   * GraphQL node id of the review thread, for consumers that resolve it.
+   * `null` for findings parsed out of an issue comment, which are not threads.
+   */
+  threadId: string | null;
+  /**
+   * REST id of the issue comment a finding was parsed out of, for consumers
+   * that edit it. `null` for real review threads.
+   */
+  commentId: number | null;
 };
 
 /** A provider-authored issue comment used as a review completion signal. */
@@ -64,6 +75,11 @@ export type ReviewIssueComment = {
   body: string;
   updatedAt: string | null;
   url: string | null;
+  /**
+   * REST id of the comment, carried onto every finding parsed out of it so a
+   * consumer can address the comment it must edit. `null` when unavailable.
+   */
+  id: number | null;
 };
 
 /**
@@ -160,6 +176,23 @@ export type ReviewProvider = {
   authorLogins: readonly string[];
   /** Parse the severity level (0..3) from a review comment body, or null. */
   parseSeverity: (body: string | null) => number | null;
+  /**
+   * Parse the finding's title out of a review thread's first comment body, or
+   * `null` when the provider renders no recognisable title. Findings parsed
+   * from an issue comment already carry their title; this is what lets an
+   * addressable GitHub thread carry one too, which is what makes the two
+   * surfaces comparable. `null` for providers that do not render titles.
+   */
+  parseFindingTitle: ((body: string | null) => string | null) | null;
+  /**
+   * A stable key identifying the underlying finding, used to collapse the
+   * copies a provider posts to more than one surface into a single finding.
+   *
+   * Returning `null` means "cannot identify this one", and a null key NEVER
+   * merges — an unrecognised finding is counted on its own rather than silently
+   * folded into another. `null` for providers that post each finding once.
+   */
+  findingKey: ((thread: ReviewThread) => string | null) | null;
   /** How the gate detects the provider finished reviewing the head commit. */
   completion: CompletionStrategy;
   /** How the provider signals a deliberate skip, or null if it has none. */

--- a/packages/pr-fleet-controller/test/parsers.test.ts
+++ b/packages/pr-fleet-controller/test/parsers.test.ts
@@ -189,6 +189,7 @@ describe("issue-comment provider findings", () => {
   const qodoComment = {
     updatedAt: "2026-08-13T05:32:39Z",
     url: "https://github.com/o/r/pull/1#issuecomment-1",
+    id: 1,
     body: `
 <h3>Code Review by Qodo</h3>
 <code>\u{1F41E} Bugs (2)</code> <code>\u{1F4D8} Rule violations (0)</code>

--- a/scripts/probe-review-signal.ts
+++ b/scripts/probe-review-signal.ts
@@ -166,6 +166,14 @@ async function probePr(
             isOutdated: thread.isOutdated,
             path: thread.path,
             line: thread.line,
+            // What the finding says, plus the handles needed to act on it and
+            // the key it was deduplicated by. Without these a caller has a
+            // count and a filename, and has to re-derive everything else by
+            // hand from the raw GitHub payloads.
+            title: thread.title,
+            threadId: thread.threadId,
+            commentId: thread.commentId,
+            findingKey: provider.findingKey?.(thread) ?? null,
           })),
         },
       },


### PR DESCRIPTION
Why:
Qodo renders every finding twice — once inside its persistent review comment
and once as an addressable thread on the offending line — and
`fetchReviewThreads` concatenated both sources without deduplicating them. That
roughly doubled `blocking_count`, and made each finding cost two separate
actions to clear: editing the comment body AND resolving the thread, through
different APIs. On PR #2095 the gate reported 13 findings where Qodo itself
listed 9.

What:
- `ReviewThread` gains `threadId` and `commentId`, so a consumer can act on a
  finding on whichever surface it lives on, and `ReviewIssueComment` gains `id`
  to supply the latter.
- Two optional provider hooks: `parseFindingTitle`, which reads a title off a
  review thread's first comment (previously only comment-parsed findings had
  one), and `findingKey`, which identifies the underlying finding. Providers
  that post each finding once declare both `null`.
- Qodo implements them. The key is the path plus the case-folded title, because
  the two surfaces genuinely disagree: the comment renders `3. joinVoice can
  hang forever` while the thread renders `1\. Joinvoice can hang forever`, with
  independent numbering, different capitalisation, and a Markdown-escaped dot.
  Locating that title works off the tag-stripped line, since Qodo wraps a
  resolved finding's title in `<s>` — matching the raw line found no title on
  exactly the findings that had already been dealt with.
- `mergeDuplicateFindings` collapses copies sharing a key. A finding is resolved
  once EITHER copy is, matching how copies within the review comment have always
  been merged; priority takes the most severe copy, so a disagreement can only
  make the gate stricter. Only the configured provider's own threads may merge,
  and a `null` key never merges, so an unrecognised finding is counted on its
  own rather than folded into an unrelated one.
- `probe-review-signal.ts` now reports each finding's title, both handles, and
  the key it was deduplicated by, instead of leaving a caller to re-derive them
  from raw payloads.
- `parseThreadPage` and `mergeDuplicateFindings` move to their own modules,
  keeping `github.ts` within the 500-line limit without suppressing it.

Verification:
- `bunx turbo run typecheck test lint build` for `@shepherdjerred/code-review`,
  `@shepherdjerred/root-scripts`, and `@shepherdjerred/pr-fleet-controller`:
  12/12 tasks green, 124 code-review tests passing (13 new).
- Against live PR #2095: 17 raw threads collapse to 9 distinct findings, which
  is exactly the number Qodo's own comment enumerates, and every one carries
  both handles. Unresolved went 5 to 2 — the two design decisions still open.
- The third, "RTP payload copied per packet", resolves because Qodo itself
  resolved that thread (`resolvedBy: qodo-free-for-open-source-projects[bot]`,
  not outdated) while leaving its comment copy unstruck. The provider's own
  signal was previously being overridden by its stale second rendering.
- Run the repo's tests with FORCE_COLOR unset. Claude Code exports
  `FORCE_COLOR=3`, `bake-images.ts` `execute()` forwards `Bun.env` to the child,
  and the child then colourises `console.error`, failing an exact-output
  assertion for reasons unrelated to any change.