### PR TITLE
feat(root): make the review gate ask for the review it waits on

### DIFF
--- a/packages/code-review/package.json
+++ b/packages/code-review/package.json
@@ -17,6 +17,10 @@
     "./head-pushed-at": {
       "types": "./src/head-pushed-at.ts",
       "default": "./src/head-pushed-at.ts"
+    },
+    "./request-review": {
+      "types": "./src/request-review.ts",
+      "default": "./src/request-review.ts"
     }
   },
   "scripts": {

--- a/packages/code-review/src/github-http.ts
+++ b/packages/code-review/src/github-http.ts
@@ -144,6 +144,32 @@ export async function graphqlRequest(
   return payload;
 }
 
+/**
+ * POST a JSON body to a REST endpoint and return the parsed response.
+ *
+ * The gate runs in a light CI pod with a token and no `gh` CLI, so the one
+ * write it performs — asking the provider to review the head — goes through the
+ * same fetch path as every read.
+ */
+export async function postJson(
+  url: string,
+  body: unknown,
+  token: string,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `GitHub request to ${url} failed with ${String(response.status)} ${response.statusText}: ${text}`,
+    );
+  }
+  return response.json();
+}
+
 export function splitRepo(repo: string): { owner: string; name: string } {
   const [owner, name] = repo.split("/");
   if (

--- a/packages/code-review/src/request-review.test.ts
+++ b/packages/code-review/src/request-review.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { codexProvider } from "./providers/codex.ts";
+import { greptileProvider } from "./providers/greptile.ts";
+import { qodoProvider } from "./providers/qodo.ts";
+import {
+  buildReviewRequestMarker,
+  requestReviewAtHead,
+} from "./request-review.ts";
+
+const HEAD = "ddca47f32df5f95b0fa79b96171aed94a1ce9536";
+const originalFetch = globalThis.fetch;
+
+type FetchInput = Parameters<typeof globalThis.fetch>[0];
+type FetchInit = Parameters<typeof globalThis.fetch>[1];
+
+/**
+ * A stand-in for global `fetch`. Bun's `fetch` carries a `preconnect` method
+ * alongside the call signature, so a bare function does not satisfy the type;
+ * the real one is carried over rather than asserted away.
+ */
+function fakeFetch(
+  handler: (input: FetchInput, init: FetchInit) => Promise<Response>,
+): typeof globalThis.fetch {
+  return Object.assign(handler, { preconnect: originalFetch.preconnect });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/** Record every request, answering comment reads with `comments`. */
+function stubGitHub(comments: readonly { body: string }[]) {
+  const posted: { url: string; body: unknown }[] = [];
+  globalThis.fetch = fakeFetch(async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (init?.method === "POST") {
+      const raw = typeof init.body === "string" ? init.body : "";
+      posted.push({ url, body: JSON.parse(raw) });
+      return Response.json({ id: 1 });
+    }
+    return Response.json(comments);
+  });
+  return posted;
+}
+
+describe("buildReviewRequestMarker", () => {
+  test("names the provider and the exact head", () => {
+    expect(buildReviewRequestMarker("qodo", HEAD)).toBe(
+      `<!-- review-request:qodo:${HEAD} -->`,
+    );
+  });
+
+  test("gives different heads different markers", () => {
+    expect(buildReviewRequestMarker("qodo", HEAD)).not.toBe(
+      buildReviewRequestMarker("qodo", "a".repeat(40)),
+    );
+  });
+});
+
+describe("requestReviewAtHead", () => {
+  const request = { repo: "o/r", number: 2095, head: HEAD, token: "t" };
+
+  test("asks a provider that reviews only when asked", async () => {
+    const posted = stubGitHub([]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(true);
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.url).toBe(
+      "https://api.github.com/repos/o/r/issues/2095/comments",
+    );
+    expect(posted[0]?.body).toEqual({
+      body: `/review\n\n<!-- review-request:qodo:${HEAD} -->`,
+    });
+  });
+
+  test("does not ask twice for the same head", async () => {
+    const posted = stubGitHub([
+      { body: `/review\n\n${buildReviewRequestMarker("qodo", HEAD)}` },
+    ]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(false);
+    expect(posted).toHaveLength(0);
+  });
+
+  test("recognises a request another consumer already posted", async () => {
+    // The PR-fleet controller builds its marker with the same helper, so a
+    // request it posted for this head must suppress the gate's.
+    const posted = stubGitHub([
+      { body: `something else` },
+      { body: `/review\n\n${buildReviewRequestMarker("qodo", HEAD)}\n` },
+    ]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(false);
+    expect(posted).toHaveLength(0);
+  });
+
+  test("still asks when only an older head was requested", async () => {
+    const posted = stubGitHub([
+      { body: buildReviewRequestMarker("qodo", "b".repeat(40)) },
+    ]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(true);
+    expect(posted).toHaveLength(1);
+  });
+
+  test("never asks a provider that reviews automatically", async () => {
+    const posted = stubGitHub([]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: greptileProvider }),
+    ).toBe(false);
+    expect(posted).toHaveLength(0);
+  });
+
+  test("uses the configured provider's own trigger, never another's", async () => {
+    const posted = stubGitHub([]);
+    await requestReviewAtHead({ ...request, provider: codexProvider });
+    const body = posted[0]?.body;
+    expect(JSON.stringify(body)).toContain("codex");
+    expect(JSON.stringify(body)).not.toContain("qodo");
+  });
+
+  test("fails loudly when the request cannot be posted", async () => {
+    // Swallowing this would restore the behaviour this exists to remove:
+    // waiting out the whole budget for a review nobody asked for.
+    globalThis.fetch = fakeFetch(async (_input, init) =>
+      init?.method === "POST"
+        ? new Response("no", { status: 403, statusText: "Forbidden" })
+        : Response.json([]),
+    );
+    await expect(
+      requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).rejects.toThrow(/403/u);
+  });
+
+  test("fails loudly when the comment listing is not an array", async () => {
+    globalThis.fetch = fakeFetch(async () =>
+      Response.json({ message: "Not Found" }),
+    );
+    await expect(
+      requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).rejects.toThrow(/was not an array/u);
+  });
+});

--- a/packages/code-review/src/request-review.ts
+++ b/packages/code-review/src/request-review.ts
@@ -1,0 +1,87 @@
+/**
+ * Asking a provider to review the current head.
+ *
+ * Providers that review automatically declare `requestReview: null` and are
+ * never asked. Qodo does not: it reviews a PR once, when the PR is opened, and
+ * never again on its own. A gate that only polls therefore waits out its whole
+ * budget on every push after the first, then fails a PR whose diff is fine.
+ *
+ * The request is idempotent through a marker naming the provider and the exact
+ * head, so re-running a step — or a second consumer asking for the same head —
+ * cannot produce a second request comment.
+ */
+
+import { z } from "zod";
+import { GITHUB_API_URL, getJsonWithLink, postJson } from "./github-http.ts";
+import type { ReviewProvider } from "./types.ts";
+
+/** The only field of an issue comment this module reads. */
+const CommentBodySchema = z.object({ body: z.string() });
+
+/**
+ * The hidden marker that makes a review request idempotent for one head.
+ *
+ * Shared by every consumer that can trigger a review — the CI gate and the
+ * PR-fleet controller — so that two of them running against the same head
+ * recognise each other's request instead of each posting one.
+ */
+export function buildReviewRequestMarker(
+  providerId: string,
+  headSha: string,
+): string {
+  return `<!-- review-request:${providerId}:${headSha} -->`;
+}
+
+/**
+ * Ask `provider` to review `head`, unless it already has been asked.
+ *
+ * Returns whether a comment was posted. Errors propagate: a request that cannot
+ * be posted must fail the caller loudly, because silently skipping it restores
+ * exactly the behaviour this exists to remove — waiting out the full timeout
+ * for a review nobody asked for.
+ */
+export async function requestReviewAtHead(input: {
+  repo: string;
+  number: number;
+  head: string;
+  token: string;
+  provider: ReviewProvider;
+}): Promise<boolean> {
+  const strategy = input.provider.requestReview;
+  if (strategy === null) return false;
+
+  const marker = buildReviewRequestMarker(input.provider.id, input.head);
+  if (await hasComment(input, marker)) return false;
+
+  await postJson(
+    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments`,
+    { body: strategy.buildComment(marker) },
+    input.token,
+  );
+  return true;
+}
+
+/** Whether any comment on the PR already contains `marker`. */
+async function hasComment(
+  input: { repo: string; number: number; token: string },
+  marker: string,
+): Promise<boolean> {
+  let url: string | null =
+    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments?per_page=100`;
+  while (url !== null) {
+    const { payload, linkNext } = await getJsonWithLink(url, input.token);
+    if (!Array.isArray(payload)) {
+      // Reading an unexpected shape as "no marker" would post a duplicate
+      // request on every poll.
+      throw new TypeError(
+        `GitHub issue comments response for ${input.repo}#${String(input.number)} was not an array`,
+      );
+    }
+    for (const item of payload) {
+      const parsed = CommentBodySchema.safeParse(item);
+      if (parsed.success && parsed.data.body.includes(marker)) return true;
+    }
+    url = linkNext;
+  }
+  return false;
+}

--- a/packages/pr-fleet-controller/src/git-operations.ts
+++ b/packages/pr-fleet-controller/src/git-operations.ts
@@ -1,6 +1,7 @@
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import type { ReviewProvider } from "@shepherdjerred/code-review";
+import { buildReviewRequestMarker } from "@shepherdjerred/code-review/request-review";
 import { z } from "zod";
 import { isTelemetryCaptureError } from "./controller-telemetry.ts";
 import { parseHeadSha, splitRepo } from "./evidence-parsers.ts";
@@ -364,7 +365,9 @@ export class GitOperations {
       return;
     }
     const { owner, name } = splitRepo(this.#repo);
-    const marker = `<!-- pr-fleet-review:${this.#provider.id}:${headSha} -->`;
+    // The same marker the CI gate uses, so whichever of the two asks first is
+    // recognised by the other and the head gets one request rather than two.
+    const marker = buildReviewRequestMarker(this.#provider.id, headSha);
     const bodies = await this.#mustRun(
       "gh",
       [

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -33,6 +33,7 @@ import {
   type ReviewThread,
 } from "@shepherdjerred/code-review";
 import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
+import { requestReviewAtHead } from "@shepherdjerred/code-review/request-review";
 import {
   fetchPullRequestAuthor,
   fetchReviewThreads,
@@ -388,6 +389,10 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
   let lastState: ReviewStateResult | null = null;
   let lastThreads: readonly ReviewThread[] = [];
   let lastPollError: Error | null = null;
+  // Whether this run has already asked the provider to review the head. The
+  // marker check makes a duplicate request impossible anyway; this avoids
+  // paying for a comment scan on every poll.
+  let requested = false;
 
   while (Date.now() <= deadline) {
     let stateResult: ReviewStateResult;
@@ -486,6 +491,37 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         `PR #${String(number)} head is now ${threadResult.headRefOid}, but this build is for ${head}; evaluating ${head}.`,
       );
       warnedMismatch = true;
+    }
+
+    // Ask for the review this loop is waiting on, once we have seen that the
+    // provider has not already reviewed this head.
+    //
+    // Qodo reviews a PR once, when it is opened, and never again on its own.
+    // Polling alone therefore waits out the entire budget on every push after
+    // the first and then fails a PR whose diff is fine. The request is asked
+    // for after the first observation rather than before it, so a head the
+    // provider has already reviewed is never asked again; the marker makes a
+    // repeat impossible even so.
+    if (!requested && stateResult.reviewedCommit !== head) {
+      requested = true;
+      const posted = await requestReviewAtHead({
+        repo,
+        number,
+        head,
+        token,
+        provider,
+      });
+      console.log(
+        JSON.stringify({
+          level: "info",
+          msg: posted ? "review-requested" : "review-request-already-present",
+          component: "review-gate",
+          provider: provider.id,
+          repo,
+          pr: number,
+          head_sha: head,
+        }),
+      );
     }
 
     const decision = evaluateGate({


### PR DESCRIPTION
Why:
Qodo reviews a pull request once, when it is opened, and never again on its own.
`wait-for-review.ts` only polled, so every push after the first waited out the
full 40-minute budget for a signal nothing would ever send, and then failed a PR
whose diff was fine. The capability to fix this was already in the repository:
`requestReview.buildComment` on the provider, and a working marker-guarded
consumer in the PR-fleet controller. Nothing in CI called it.

What:
- `requestReviewAtHead()` asks the configured provider to review a specific head,
  guarded by a marker naming the provider and that exact head so a re-run — or a
  second consumer — cannot post a duplicate request. Providers that review
  automatically declare `requestReview: null` and are never asked.
- `buildReviewRequestMarker()` is shared, and the PR-fleet controller now builds
  its marker with it instead of inlining its own. Whichever of the two asks
  first, the other recognises it and the head gets one request rather than two.
- `postJson` in `github-http.ts` mirrors `graphqlRequest`, so the gate's one
  write goes through the same fetch path as its reads and needs no `gh` CLI in
  the light CI pod.
- The gate asks once per run, after the first poll has shown the provider has
  not already reviewed this head, and logs a structured `review-requested` /
  `review-request-already-present` line.

A failed request throws rather than degrading to a silent wait: swallowing it
would restore precisely the behaviour being removed.

Verification:
- `bunx turbo run typecheck test lint build` for `@shepherdjerred/code-review`,
  `@shepherdjerred/root-scripts`, and `@shepherdjerred/pr-fleet-controller`:
  12/12 tasks green, 144 code-review tests (10 new for the request path).
- New tests cover the marker's head-binding, suppression of a second request for
  the same head, recognition of a request another consumer posted, that an older
  head's request does not suppress a new one, that an automatic provider is never
  asked, that only the configured provider's trigger is used, and that both a
  failed POST and a malformed comment listing throw.
- Not exercised end-to-end against a live provider; the first PR built after this
  lands is what confirms the request is answered.