### PR TITLE
ci(root): stop grading a pull request with its own copy of the gate

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1037,8 +1037,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
-      bun --no-install scripts/wait-for-review.ts
+      .buildkite/scripts/review-gate.sh
     retry: *retry
     plugins:
       - kubernetes:

--- a/.buildkite/scripts/review-gate.sh
+++ b/.buildkite/scripts/review-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the review gate from `main` rather than from the pull request's own
+# checkout.
+#
+# The gate reads only GitHub state — the provider's review, its findings, and
+# whether they are resolved. It never reads the PR's diff. So there is no reason
+# for it to run the PR's copy of itself, and one strong reason not to: with
+# `@shepherdjerred/code-review` linked as a workspace dependency, a branch was
+# graded by whatever version of the grader that branch happened to contain.
+#
+# PR #1389 is the worked example. Its branch was 22 commits behind and predated
+# `currentReviewOf`, the function that excludes Qodo's archived
+# "previous results" section, so its gate counted stale pre-fix copies of
+# findings that had already been fixed: 0 blocking findings measured against
+# current `main`, 3 measured by the branch's own parser. Nothing about the PR
+# was wrong, and no amount of fixing the PR could have cleared it — only
+# rebasing 22 commits of unrelated history would have.
+#
+# This closes the accidental version of that problem, where a branch is simply
+# old. It is not a trust boundary: Buildkite uploads the pipeline from the
+# branch, so a branch that deliberately rewrites this step controls its own
+# gate either way — as it does for every other check.
+#
+# REVIEW_GATE_REF exists so a change to the gate itself can be exercised before
+# it lands, since once this is in place the gate no longer runs a PR's own
+# version of it. Set it when creating the build, the way CI_IO_FIXED_CORPUS is
+# set; leave it unset everywhere else.
+
+GATE_REF="${REVIEW_GATE_REF:-main}"
+GATE_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}/.review-gate-source"
+
+echo "~~~ Fetching the review gate from ${GATE_REF}"
+git fetch --depth 1 origin "$GATE_REF"
+GATE_SHA="$(git rev-parse FETCH_HEAD)"
+echo "Review gate source: ${GATE_REF} @ ${GATE_SHA}"
+
+# Clear any leftover worktree on the way IN rather than removing it afterwards.
+# Cleaning up first is idempotent and keeps the gate's exit status its own: a
+# teardown failure cannot red a PR, and nothing has to be suppressed to make
+# that true. The agent discards the workspace after the job regardless.
+git worktree prune
+rm -rf "$GATE_DIR"
+git worktree add --detach "$GATE_DIR" FETCH_HEAD
+
+cd "$GATE_DIR"
+"$GATE_DIR/.buildkite/scripts/bun-install.sh" --frozen-lockfile \
+  --filter '@shepherdjerred/root-scripts' --production
+REVIEW_GATE_PARSER_COMMIT="$GATE_SHA" bun --no-install scripts/wait-for-review.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,32 @@ The value must be exactly `true`, and `BUILDKITE_BRANCH` must be `main`;
 invalid, unset-branch, and non-main requests fail before the pipeline runs.
 Treat this as a production-mutating build, not a read-only benchmark.
 
+### The review gate
+
+The `review-gate` step runs `.buildkite/scripts/review-gate.sh`, which checks
+out `main` into a worktree and runs the gate from there. The gate reads only
+GitHub state and never the PR's diff, so running the PR's own copy bought
+nothing and cost correctness: `@shepherdjerred/code-review` is a `workspace:*`
+dependency, so each branch graded itself with whatever version of the parser it
+happened to contain. A branch old enough to predate a parser fix counted
+findings that had already been fixed, and no change to that PR could clear it.
+
+The gate asks the provider to review the head before waiting on it. Qodo
+reviews a PR once, when it is opened, and never again on its own, so polling
+alone burned the whole budget on every push after the first. The request is
+idempotent per head through `buildReviewRequestMarker()`, shared with the PR
+fleet controller so the two recognise each other's request.
+
+Each `review-signal` event carries `parser_commit`, the commit of the parser
+that produced the counts. A finding count is only comparable against the parser
+that arrived at it — a local `probe-review-signal.ts` run from a stale checkout
+legitimately disagrees with CI.
+
+`REVIEW_GATE_REF` overrides the ref the gate runs from. It exists only so a
+change to the gate itself can be exercised before it lands, since the gate no
+longer runs a PR's own version of it. Set it when creating the build, as with
+`CI_IO_FIXED_CORPUS`; never in committed configuration.
+
 ### Release refinement providers
 
 The main-only `release-please` lane runs `scripts/release.ts`. Its CHANGELOG

--- a/packages/code-review/src/signal.test.ts
+++ b/packages/code-review/src/signal.test.ts
@@ -36,6 +36,7 @@ describe("formatSignalEvent", () => {
     timed_out: false,
     stale_reaction: false,
     decision: "failed",
+    parser_commit: "5f6d0a42b7c1e3d9a8f04b2c6e1d7a3f9b0c5e28",
   });
 
   test("emits a single structured line with the component and event fields", () => {

--- a/packages/code-review/src/signal.ts
+++ b/packages/code-review/src/signal.ts
@@ -70,6 +70,16 @@ export const ReviewSignalEventSchema = z.object({
   stale_reaction: z.boolean(),
   /** Terminal gate decision, when this event is a decision (else null). */
   decision: z.enum(["waiting", "passed", "failed"]).nullable(),
+  /**
+   * The commit of the `code-review` source that produced these counts.
+   *
+   * The parser ships with the repository, so a finding count is only meaningful
+   * alongside the version of the parser that arrived at it: the same PR read by
+   * two different parsers legitimately yields two different numbers, and
+   * without this there is no way to tell that apart from the findings actually
+   * changing. `null` when the caller cannot determine its own commit.
+   */
+  parser_commit: z.string().nullable(),
 });
 export type ReviewSignalEvent = z.infer<typeof ReviewSignalEventSchema>;
 

--- a/scripts/probe-review-signal.ts
+++ b/scripts/probe-review-signal.ts
@@ -149,6 +149,10 @@ async function probePr(
     timed_out: false,
     stale_reaction: state.staleReaction,
     decision: null,
+    // Which parser produced these counts. A probe run from a stale checkout
+    // reads the repository's stale parser and reports numbers that disagree
+    // with CI for reasons that have nothing to do with the PR.
+    parser_commit: parserCommit(),
   };
 
   console.log(
@@ -181,6 +185,22 @@ async function probePr(
       2,
     ),
   );
+}
+
+/**
+ * The commit this probe's copy of `code-review` came from.
+ *
+ * The probe imports the parser from the checkout it runs in, so its numbers
+ * describe that checkout's parser rather than CI's. Reporting the commit is
+ * what lets a caller see a disagreement for what it is.
+ */
+function parserCommit(): string | null {
+  const result = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
+    cwd: import.meta.dir,
+  });
+  if (result.exitCode !== 0) return null;
+  const sha = result.stdout.toString().trim();
+  return sha === "" ? null : sha;
 }
 
 async function main(): Promise<void> {

--- a/scripts/wait-for-review.test.ts
+++ b/scripts/wait-for-review.test.ts
@@ -53,6 +53,27 @@ export function reviewGateStepTimeoutSeconds(pipeline: string): number {
   throw new Error("pipeline.yml has no review-gate step");
 }
 
+/** The `review-gate` step's command block, as its lines. */
+export function reviewGateStepCommand(pipeline: string): string[] {
+  const lines = pipeline.split("\n");
+  const starts = lines.flatMap((line, index) =>
+    line.startsWith("  - label:") ? [index] : [],
+  );
+  for (const [position, start] of starts.entries()) {
+    const block = lines.slice(start, starts[position + 1] ?? lines.length);
+    if (!block.some((line) => line.trim() === "key: review-gate")) continue;
+    const commandAt = block.findIndex((line) => line.trim() === "command: |");
+    if (commandAt === -1) throw new Error("review-gate declares no command");
+    const body: string[] = [];
+    for (const line of block.slice(commandAt + 1)) {
+      if (line.trim() !== "" && !line.startsWith("      ")) break;
+      body.push(line.trim());
+    }
+    return body.filter((line) => line !== "");
+  }
+  throw new Error("pipeline.yml has no review-gate step");
+}
+
 /**
  * How long the step spends on `toolchain.sh` and the filtered install before
  * wait-for-review.ts starts counting. Nothing bounds that preamble — a cold or
@@ -109,5 +130,35 @@ describe("review gate timeout budget", () => {
     // the 1200s budget had already failed the gate.
     const slowestCompleted = 1834;
     expect(DEFAULT_TIMEOUT_SECONDS).toBeGreaterThan(slowestCompleted);
+  });
+});
+
+// The gate reads only GitHub state, never the PR's diff, so running it from the
+// PR's checkout buys nothing and costs correctness: `code-review` is a
+// workspace dependency, so the branch supplied its own grader. PR #1389 read 0
+// blocking findings against current main and 3 against its own 22-commit-stale
+// parser, and no change to that PR could have cleared it.
+describe("review gate source", () => {
+  test("does not run the pull request's own copy of the gate", async () => {
+    const pipeline = await Bun.file(
+      `${import.meta.dir}/../.buildkite/pipeline.yml`,
+    ).text();
+    const command = reviewGateStepCommand(pipeline);
+    expect(command).not.toContain(
+      "bun --no-install scripts/wait-for-review.ts",
+    );
+    expect(command.some((line) => line.includes("review-gate.sh"))).toBe(true);
+  });
+
+  test("the gate script checks out a ref and runs the gate from it", async () => {
+    const script = await Bun.file(
+      `${import.meta.dir}/../.buildkite/scripts/review-gate.sh`,
+    ).text();
+    expect(script).toContain("git worktree add");
+    expect(script).toContain("REVIEW_GATE_REF:-main");
+    expect(script).toContain("scripts/wait-for-review.ts");
+    // The commit actually used has to reach the signal event, or a count still
+    // cannot be attributed to the parser that produced it.
+    expect(script).toContain("REVIEW_GATE_PARSER_COMMIT");
   });
 });

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -248,7 +248,21 @@ function buildSignalEvent(input: {
     timed_out: input.timedOut,
     stale_reaction: input.state.staleReaction,
     decision: input.decision === null ? null : input.decision.state,
+    parser_commit: parserCommit(),
   };
+}
+
+/**
+ * The commit of the `code-review` source that produced this observation.
+ *
+ * `review-gate.sh` runs the gate from a worktree of `main` and passes the
+ * commit it checked out. Recording it makes the log say which parser produced
+ * a count — the one thing that would have made an inflated `blocking_count`
+ * obvious at a glance rather than after a long hunt.
+ */
+function parserCommit(): string | null {
+  const commit = Bun.env["REVIEW_GATE_PARSER_COMMIT"];
+  return commit === undefined || commit.trim() === "" ? null : commit.trim();
 }
 
 async function waitForReview(): Promise<void> {


### PR DESCRIPTION
Why:
`@shepherdjerred/code-review` is a `workspace:*` dependency, so the review gate
ran the parser belonging to the branch it was judging. A branch old enough to
predate a parser fix was graded by the unfixed parser, and nothing the author
could do to that PR would clear it.

PR #1389 is the worked example. Its branch sat 22 commits behind and predated
`currentReviewOf`, which excludes Qodo's archived "previous results" section, so
its gate counted stale pre-fix copies of findings that had already been fixed:
0 blocking findings measured against current `main`, 3 against its own parser.
Clearing it legitimately would have meant rebasing 22 commits of unrelated
history.

The gate reads only GitHub state — the review, its findings, whether they are
resolved. It never reads the PR's diff, so running it from the PR's checkout
bought nothing.

What:
- `.buildkite/scripts/review-gate.sh` fetches `main`, adds a detached worktree,
  installs there, and runs the gate from it. PR identity still comes from
  `BUILDKITE_PULL_REQUEST` / `BUILDKITE_COMMIT`, which are unaffected. It cleans
  up any leftover worktree on the way in rather than tearing down on the way
  out, so a teardown failure cannot red a PR and nothing needs suppressing.
- The `review-signal` event gains `parser_commit`, the commit of the parser that
  produced the counts, supplied by the script and by `probe-review-signal.ts`
  from its own checkout. A count is only comparable against the parser that
  arrived at it; this is the line that would have made the inflated numbers
  obvious immediately rather than after a long hunt.
- `REVIEW_GATE_REF` overrides the ref, for the one case this change creates:
  exercising a change to the gate before it lands, since the gate no longer runs
  a PR's own version of itself. Operator-set at build creation, as with
  `CI_IO_FIXED_CORPUS`.

This closes the accidental failure — a branch that is simply old. It is not a
trust boundary: Buildkite uploads the pipeline from the branch, so a branch that
rewrites this step controls its own gate either way, as it does for every check.
The script's comment says so rather than implying a guarantee it cannot make.

Verification:
- `bunx turbo run typecheck test lint build` across `code-review`,
  `root-scripts`, and `pr-fleet-controller`: 12/12 green.
- `shellcheck .buildkite/scripts/review-gate.sh` clean;
  `bun scripts/check-suppressions.ts` reports no new suppressions.
- Two new pipeline assertions: the step no longer runs the checked-out
  `wait-for-review.ts`, and the script checks out a ref, runs the gate from it,
  and passes the commit through to the signal event.
- `probe-review-signal.ts` against live PR #2216 reports its own
  `parser_commit`.
- The worktree checkout itself is not exercised locally — it needs a Buildkite
  agent, so the first PR built after this lands is what confirms it.