### PR TITLE
feat(toolkit): add `pr review` to see and clear provider findings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1696,6 +1696,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1001.0",
+        "@shepherdjerred/code-review": "workspace:*",
         "asciinema-player": "^3.15.1",
         "debug": "^4.4.3",
         "discord.js": "^14",

--- a/packages/code-review/package.json
+++ b/packages/code-review/package.json
@@ -21,6 +21,10 @@
     "./request-review": {
       "types": "./src/request-review.ts",
       "default": "./src/request-review.ts"
+    },
+    "./qodo": {
+      "types": "./src/providers/qodo.ts",
+      "default": "./src/providers/qodo.ts"
     }
   },
   "scripts": {

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mergeDuplicateFindings } from "./merge-findings.ts";
 import { codexProvider } from "./providers/codex.ts";
 import {
+  markQodoFindingResolved,
   parseQodoFindingTitle,
+  QODO_RESOLVED_CHIP,
   qodoFindingKey,
   qodoProvider,
 } from "./providers/qodo.ts";
@@ -189,5 +191,85 @@ describe("parseQodoFindingTitle", () => {
   test("returns null when no numbered title line exists", () => {
     expect(parseQodoFindingTitle("just prose, no finding here")).toBeNull();
     expect(parseQodoFindingTitle(null)).toBeNull();
+  });
+});
+
+describe("markQodoFindingResolved", () => {
+  // Both sections carry the SAME finding, unstruck. Qodo re-appends its
+  // previous results below the fold marker and the parser reads only what is
+  // above it, so a chip written below would change nothing while rewriting
+  // what the provider recorded.
+  const body = [
+    "<h3>Code Review by Qodo</h3>",
+    '<img alt="Action required">',
+    "<details>",
+    "<summary>  1. Turn outlives session destroy <code>🐞 Bug</code></summary>",
+    "</details>",
+    "<!-- FOLDED_SECTION_START -->",
+    "<details>",
+    "<summary>  1. Turn outlives session destroy <code>🐞 Bug</code></summary>",
+    "</details>",
+  ].join("\n");
+
+  test("chips the finding in the current review", () => {
+    const result = markQodoFindingResolved(
+      body,
+      "Turn outlives session destroy",
+    );
+    expect(result.found).toBe(true);
+    expect(result.changed).toBe(true);
+    expect(result.body).toContain(QODO_RESOLVED_CHIP);
+  });
+
+  test("never edits Qodo's archive of previous results", () => {
+    const result = markQodoFindingResolved(
+      body,
+      "Turn outlives session destroy",
+    );
+    const fold = result.body.indexOf("<!-- FOLDED_SECTION_START -->");
+    expect(result.body.slice(fold)).toBe(
+      body.slice(body.indexOf("<!-- FOLDED_SECTION_START -->")),
+    );
+    // Exactly one chip: the archived copy of the same finding is untouched.
+    expect(result.body.split(QODO_RESOLVED_CHIP)).toHaveLength(2);
+  });
+
+  test("a chipped finding reads back as resolved", () => {
+    // The whole point: the writer's output must satisfy the reader.
+    const chipped = markQodoFindingResolved(
+      body,
+      "Turn outlives session destroy",
+    ).body;
+    expect(chipped).toContain("☑");
+  });
+
+  test("is idempotent", () => {
+    const once = markQodoFindingResolved(body, "Turn outlives session destroy");
+    const twice = markQodoFindingResolved(
+      once.body,
+      "Turn outlives session destroy",
+    );
+    expect(twice.found).toBe(true);
+    expect(twice.changed).toBe(false);
+    expect(twice.body).toBe(once.body);
+  });
+
+  test("leaves a finding Qodo already struck alone", () => {
+    const struck = body.replace(
+      "  1. Turn outlives session destroy <code>🐞 Bug</code>",
+      "<s>  1. Turn outlives session destroy</s> <code>🐞 Bug</code>",
+    );
+    const result = markQodoFindingResolved(
+      struck,
+      "Turn outlives session destroy",
+    );
+    expect(result.changed).toBe(false);
+  });
+
+  test("reports a title it cannot find rather than succeeding at nothing", () => {
+    const result = markQodoFindingResolved(body, "No such finding");
+    expect(result.found).toBe(false);
+    expect(result.changed).toBe(false);
+    expect(result.body).toBe(body);
   });
 });

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -198,6 +198,59 @@ export function parseQodoFindingTitle(body: string | null): string | null {
 }
 
 /**
+ * The chip that marks a finding resolved in Qodo's review comment.
+ *
+ * Qodo never strikes a finding because the code was fixed — it re-lists it on
+ * every review until something says otherwise. This chip is that something, and
+ * `parseSeveritySection` reads it back as `checked`. Writer and reader are kept
+ * side by side deliberately: they are one agreement about what "resolved" looks
+ * like, and splitting them across packages is how they would drift apart.
+ *
+ * It goes inside a `<code>` element so `identityOf` strips it, which keeps a
+ * chipped finding the same finding rather than making it a new one.
+ */
+export const QODO_RESOLVED_CHIP = "<code>\u{2611} resolved</code>";
+
+/**
+ * Mark the finding titled `title` resolved in a Qodo review comment.
+ *
+ * Only the current review is touched. Everything from
+ * `<!-- FOLDED_SECTION_START -->` onward is Qodo's archive of previous results,
+ * which the parser already excludes, so editing there changes no decision while
+ * rewriting history the provider wrote.
+ *
+ * Returns the body unchanged when the finding is already struck or chipped, and
+ * reports whether anything changed so a caller can tell "already done" from
+ * "no such finding" instead of silently succeeding at nothing.
+ */
+export function markQodoFindingResolved(
+  body: string,
+  title: string,
+): { body: string; changed: boolean; found: boolean } {
+  const foldIndex = body.indexOf(QODO_PREVIOUS_RESULTS_START);
+  const current = foldIndex === -1 ? body : body.slice(0, foldIndex);
+  const archived = foldIndex === -1 ? "" : body.slice(foldIndex);
+
+  let found = false;
+  let changed = false;
+  const updated = current.replaceAll(
+    /<summary>([\s\S]*?)<\/summary>/giu,
+    (match, summary: string) => {
+      if (findingTitle(summary) !== title) return match;
+      found = true;
+      if (/<s>[\s\S]*?<\/s>/iu.test(summary) || summary.includes("\u{2611}")) {
+        return match;
+      }
+      changed = true;
+      return `<summary>${summary} ${QODO_RESOLVED_CHIP}</summary>`;
+    },
+  );
+  // `current + archived` reconstructs `body` exactly, so an unchanged pass
+  // returns the original string without needing to special-case it.
+  return { body: updated + archived, changed, found };
+}
+
+/**
  * Identity of the underlying finding, shared by both copies Qodo posts.
  *
  * Case is folded because the two surfaces disagree on it: the review comment

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -215,6 +215,35 @@ exactly like the AWS CLI. Select a profile with `--profile <name>` or
 toolkit pr asset 1234 ./after.png ./flow.mp4 ./demo.cast ./demo-site --profile seaweedfs --markdown
 ```
 
+## `pr review` — see and clear provider findings
+
+`toolkit pr review list <PR>` prints every code-review finding on a PR,
+**deduplicated across the surfaces the provider posted it on**. Qodo renders
+each finding twice — once inside its persistent review comment, once as an
+addressable thread on the offending line — and the two are cleared through
+different APIs. `@shepherdjerred/code-review` merges them into one finding
+carrying both handles; this shows that, so a `blocking_count` becomes a list of
+named problems rather than a number.
+
+`toolkit pr review resolve <PR> --finding <key|title> --evidence <text>` clears
+one finding on **both** surfaces in a single step: it appends the
+`<code>☑ resolved</code>` chip to the finding in the review comment and replies
+to and resolves the review thread. `--evidence` is required — a dismissal
+without a reason is indistinguishable from silencing the finding. Chipping only
+ever edits the region above `<!-- FOLDED_SECTION_START -->`; everything below is
+Qodo's archive of previous results, which the parser excludes.
+
+`toolkit pr review harvest <PR…>` applies the stale-gate rule: a gate that
+failed, whose provider has since finished reviewing _this_ head with nothing
+blocking, is stale and passes on a re-run. It prints the `bk job retry` command
+by default and only re-runs jobs with `--retry`. The Buildkite job id comes out
+of the status URL's fragment, so the failed job is retried rather than the whole
+build.
+
+GitHub access borrows an authenticated `gh`'s token when `GH_TOKEN` is unset,
+keeping the package's no-token-setup convention; the library needs a token
+rather than the CLI because it speaks GraphQL and paginates itself.
+
 ## Shared `lib/http` + `lib/config`
 
 The Grafana, Alerts, and Bugsink service clients share one HTTP layer instead

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1001.0",
+    "@shepherdjerred/code-review": "workspace:*",
     "asciinema-player": "^3.15.1",
     "debug": "^4.4.3",
     "discord.js": "^14",

--- a/packages/toolkit/src/commands/pr/review.ts
+++ b/packages/toolkit/src/commands/pr/review.ts
@@ -1,0 +1,208 @@
+/**
+ * `toolkit pr review` — see and clear a code-review provider's findings.
+ *
+ * The gate reports a count; this reports the findings behind it, deduplicated
+ * across the surfaces the provider posted them on, with the handles needed to
+ * act on each one.
+ */
+
+import {
+  listFindings,
+  resolveFinding,
+  reviewStateFor,
+  type Finding,
+} from "#lib/review/findings.ts";
+import { gateStatusFor, harvestVerdict } from "#lib/review/harvest.ts";
+
+export type ReviewOptions = {
+  repo?: string | undefined;
+  json?: boolean | undefined;
+  finding?: string | undefined;
+  evidence?: string | undefined;
+  all?: boolean | undefined;
+};
+
+const DEFAULT_REPO = "shepherdjerred/monorepo";
+
+/**
+ * A GitHub token for the `code-review` library.
+ *
+ * This package's convention is that GitHub access costs the caller no token
+ * setup, so the token is borrowed from an authenticated `gh` when the
+ * environment does not already supply one. The library needs a token rather
+ * than the CLI because it speaks GraphQL and paginates itself.
+ */
+function requireToken(): string {
+  const fromEnvironment = Bun.env["GH_TOKEN"];
+  if (fromEnvironment !== undefined && fromEnvironment.trim() !== "") {
+    return fromEnvironment.trim();
+  }
+  const result = Bun.spawnSync(["gh", "auth", "token"]);
+  const token = result.stdout.toString().trim();
+  if (token === "" || result.exitCode !== 0) {
+    throw new Error("No GitHub token: run `gh auth login`, or set GH_TOKEN.");
+  }
+  return token;
+}
+
+function requirePr(prNumber: string | undefined): number {
+  const parsed = Number.parseInt(prNumber ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("A pull request number is required");
+  }
+  return parsed;
+}
+
+function describe(finding: Finding): string {
+  const severity =
+    finding.priority === null ? "P?" : `P${String(finding.priority)}`;
+  const where =
+    finding.path === null
+      ? "(general)"
+      : finding.line === null
+        ? finding.path
+        : `${finding.path}:${String(finding.line)}`;
+  const surfaces = [
+    finding.commentId === null ? null : "comment",
+    finding.threadId === null ? null : "thread",
+  ]
+    .filter((surface) => surface !== null)
+    .join("+");
+  const mark = finding.isResolved ? "resolved" : "OPEN    ";
+  return `${mark}  ${severity}  ${finding.title ?? "(untitled)"}\n          ${where}  [${surfaces}]  key=${finding.key}`;
+}
+
+export async function reviewListCommand(
+  prNumber: string | undefined,
+  options: ReviewOptions = {},
+): Promise<void> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const number = requirePr(prNumber);
+  const { head, findings } = await listFindings({
+    repo,
+    number,
+    token: requireToken(),
+  });
+
+  if (options.json === true) {
+    console.log(JSON.stringify({ repo, pr: number, head, findings }, null, 2));
+    return;
+  }
+
+  const open = findings.filter((finding) => !finding.isResolved);
+  console.log(`${repo}#${String(number)} @ ${head.slice(0, 9)}`);
+  console.log(
+    `${String(findings.length)} finding(s), ${String(open.length)} unresolved\n`,
+  );
+  for (const finding of findings) console.log(describe(finding));
+}
+
+export async function reviewResolveCommand(
+  prNumber: string | undefined,
+  options: ReviewOptions = {},
+): Promise<void> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const number = requirePr(prNumber);
+  const key = options.finding;
+  const evidence = options.evidence;
+  if (key === undefined || key.trim() === "") {
+    throw new Error(
+      "--finding <key> is required (see: toolkit pr review list)",
+    );
+  }
+  // A dismissal without a reason is indistinguishable from silencing the
+  // finding, so the reason is not optional.
+  if (evidence === undefined || evidence.trim() === "") {
+    throw new Error(
+      "--evidence <text> is required: say what makes this finding resolved",
+    );
+  }
+
+  const token = requireToken();
+  const { findings } = await listFindings({ repo, number, token });
+  const matches = findings.filter(
+    (finding) => finding.key === key || finding.title === key,
+  );
+  if (matches.length === 0) {
+    throw new Error(
+      `No finding matching "${key}" on ${repo}#${String(number)}`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `"${key}" matches ${String(matches.length)} findings; use the exact key`,
+    );
+  }
+  const finding = matches[0];
+  if (finding === undefined) throw new Error("unreachable: no finding");
+
+  const outcome = await resolveFinding({
+    repo,
+    number,
+    token,
+    finding,
+    evidence,
+  });
+  console.log(
+    `${finding.title ?? finding.key}: ` +
+      `${outcome.chippedComment ? "chipped the review comment" : "review comment already marked"}, ` +
+      (outcome.resolvedThread
+        ? "resolved the review thread"
+        : "no review thread"),
+  );
+}
+
+export async function reviewHarvestCommand(
+  prNumbers: string[],
+  options: ReviewOptions = {},
+): Promise<void> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const token = requireToken();
+  const numbers = prNumbers.map((value) => requirePr(value));
+  if (numbers.length === 0) {
+    throw new Error("At least one pull request number is required");
+  }
+
+  for (const number of numbers) {
+    const { head, findings } = await listFindings({ repo, number, token });
+    const state = await reviewStateFor({ repo, number, token, head });
+    const gate = await gateStatusFor({ repo, ref: head, token });
+    const verdict = harvestVerdict({
+      gate,
+      reviewedAtHead: state.reviewedAtHead,
+      completionSignal: state.completionSignal,
+      blockingCount: findings.filter((finding) => !finding.isResolved).length,
+    });
+
+    if (!verdict.retryable) {
+      console.log(`#${String(number)}: not retryable — ${verdict.reason}`);
+      continue;
+    }
+    // Retrying is a write, so it is opt-in. Printing the command by default
+    // makes the read-only run useful rather than merely safe.
+    if (options.all !== true) {
+      console.log(
+        `#${String(number)}: retryable — bk job retry ${verdict.jobId}`,
+      );
+      continue;
+    }
+    retryBuildkiteJob(verdict.jobId);
+    console.log(`#${String(number)}: retried ${verdict.jobId}`);
+  }
+}
+
+function retryBuildkiteJob(jobId: string): void {
+  const result = Bun.spawnSync([
+    "bk",
+    "job",
+    "retry",
+    jobId,
+    "-y",
+    "--no-input",
+  ]);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `bk job retry ${jobId} failed: ${result.stderr.toString().trim()}`,
+    );
+  }
+}

--- a/packages/toolkit/src/handlers/pr.ts
+++ b/packages/toolkit/src/handlers/pr.ts
@@ -1,5 +1,10 @@
 import { parseArgs } from "node:util";
 import { assetCommand } from "#commands/pr/asset.ts";
+import {
+  reviewHarvestCommand,
+  reviewListCommand,
+  reviewResolveCommand,
+} from "#commands/pr/review.ts";
 import { detectCommand } from "#commands/pr/detect.ts";
 import { healthCommand } from "#commands/pr/health.ts";
 import { logsCommand } from "#commands/pr/logs.ts";
@@ -57,6 +62,51 @@ async function handleAsset(args: string[]): Promise<void> {
   });
 }
 
+async function handleReview(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      repo: { type: "string" },
+      json: { type: "boolean", default: false },
+      finding: { type: "string" },
+      evidence: { type: "string" },
+      retry: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+  const [action, ...rest] = positionals;
+  const options = {
+    repo: values.repo,
+    json: values.json,
+    finding: values.finding,
+    evidence: values.evidence,
+    all: values.retry,
+  };
+  // Handled before the switch rather than as a case: `process.exit` returns
+  // `never`, so a `break` there is unreachable code while its absence reads as
+  // a fallthrough.
+  if (action === undefined) {
+    console.error("Usage: toolkit pr review <list|resolve|harvest> <pr>");
+    process.exit(1);
+  }
+  switch (action) {
+    case "list":
+      await reviewListCommand(rest[0], options);
+      return;
+    case "resolve":
+      await reviewResolveCommand(rest[0], options);
+      return;
+    case "harvest":
+      await reviewHarvestCommand(rest, options);
+      return;
+    default:
+      console.error(
+        `Unknown pr review action: ${action}. Expected list, resolve, or harvest.`,
+      );
+      process.exit(1);
+  }
+}
+
 async function handleDetect(args: string[]): Promise<void> {
   const { values } = parseArgs({
     args,
@@ -91,6 +141,13 @@ Subcommands:
                              print URLs. Dirs need a root index.html; .cast
                              files get a generated HTML player page.
 
+  review list <PR>     Every provider finding, deduplicated across the
+                       surfaces it was posted on, with both handles
+  review resolve <PR>  Clear one finding on every surface at once
+                       (--finding <key|title> --evidence <text>)
+  review harvest <PR…> Report gates that failed only because the review
+                       landed late; --retry to actually re-run them
+
 Options:
   --repo <owner/repo>   Repository (default: auto-detect)
   --json                Output as JSON
@@ -100,6 +157,9 @@ Options:
                         tags for images, labeled links for video/demo/player
                         pages) instead of bare URLs
   --profile <name>      (asset) AWS profile to use (overrides AWS_PROFILE)
+  --finding <key>       (review resolve) Finding key or exact title
+  --evidence <text>     (review resolve) Why it is resolved; required
+  --retry               (review harvest) Re-run the eligible jobs
 
 Credentials (asset):
   Uses the standard AWS toolchain. Credentials, endpoint (endpoint_url), and
@@ -121,6 +181,9 @@ Credentials (asset):
       break;
     case "asset":
       await handleAsset(args);
+      break;
+    case "review":
+      await handleReview(args);
       break;
     default:
       console.error(`Unknown pr subcommand: ${subcommand}`);

--- a/packages/toolkit/src/lib/review/findings.ts
+++ b/packages/toolkit/src/lib/review/findings.ts
@@ -1,0 +1,299 @@
+/**
+ * Reading and clearing a code-review provider's findings on a pull request.
+ *
+ * A provider may render the same finding on more than one surface — Qodo posts
+ * each one both inside its persistent review comment and as an addressable
+ * thread on the offending line — and each surface is cleared through a
+ * different API. `@shepherdjerred/code-review` already merges them into one
+ * finding carrying both handles; this turns that into something a person can
+ * act on in a single step.
+ */
+
+import {
+  isProviderAuthor,
+  resolveRequiredReviewProvider,
+  type ReviewProvider,
+  type ReviewThread,
+} from "@shepherdjerred/code-review";
+import {
+  fetchReviewThreads,
+  resolveReviewState,
+} from "@shepherdjerred/code-review/github";
+import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
+import { markQodoFindingResolved } from "@shepherdjerred/code-review/qodo";
+import { z } from "zod";
+
+const GITHUB_API = "https://api.github.com";
+
+const PrHeadSchema = z.object({ head: z.object({ sha: z.string() }) });
+const CommentSchema = z.object({ id: z.number(), body: z.string() });
+
+export type Finding = {
+  key: string;
+  title: string | null;
+  priority: number | null;
+  path: string | null;
+  line: number | null;
+  isResolved: boolean;
+  threadId: string | null;
+  commentId: number | null;
+  url: string | null;
+};
+
+/** Every provider finding on the PR, deduplicated across surfaces. */
+export async function listFindings(input: {
+  repo: string;
+  number: number;
+  token: string;
+  provider?: ReviewProvider;
+}): Promise<{ head: string; findings: Finding[] }> {
+  const provider = input.provider ?? resolveRequiredReviewProvider();
+  const head = await fetchHeadSha(input);
+  const state = await resolveReviewState({
+    provider,
+    repo: input.repo,
+    head,
+    prNumber: input.number,
+    token: input.token,
+    headPushedAt: await fetchHeadPushedAt({
+      repo: input.repo,
+      sha: head,
+      prNumber: input.number,
+      token: input.token,
+    }),
+  });
+  const { threads } = await fetchReviewThreads({
+    repo: input.repo,
+    number: input.number,
+    token: input.token,
+    provider,
+    issueComment: state.issueComment,
+  });
+  const findings = threads
+    .filter(
+      (thread) =>
+        isProviderAuthor(provider, thread.authorLogin) && !thread.isOutdated,
+    )
+    .map((thread, index) => toFinding(thread, provider, index));
+  return { head, findings };
+}
+
+/**
+ * Whether the provider has finished reviewing this exact head, and how it said
+ * so. The harvest rule needs both: a gate that failed while the review was
+ * still running is stale, one that failed with no review at all is not.
+ */
+export async function reviewStateFor(input: {
+  repo: string;
+  number: number;
+  token: string;
+  head: string;
+  provider?: ReviewProvider;
+}): Promise<{ reviewedAtHead: boolean; completionSignal: string }> {
+  const provider = input.provider ?? resolveRequiredReviewProvider();
+  const state = await resolveReviewState({
+    provider,
+    repo: input.repo,
+    head: input.head,
+    prNumber: input.number,
+    token: input.token,
+    headPushedAt: await fetchHeadPushedAt({
+      repo: input.repo,
+      sha: input.head,
+      prNumber: input.number,
+      token: input.token,
+    }),
+  });
+  return {
+    reviewedAtHead: state.reviewedCommit === input.head,
+    completionSignal: state.completionSignal,
+  };
+}
+
+function toFinding(
+  thread: ReviewThread,
+  provider: ReviewProvider,
+  index: number,
+): Finding {
+  return {
+    // Fall back to a positional key only when the provider cannot identify the
+    // finding, so an unrecognised one is still addressable rather than absent.
+    key: provider.findingKey?.(thread) ?? `#${String(index + 1)}`,
+    title: thread.title,
+    priority: thread.priority,
+    path: thread.path,
+    line: thread.line,
+    isResolved: thread.isResolved,
+    threadId: thread.threadId,
+    commentId: thread.commentId,
+    url: thread.url,
+  };
+}
+
+export type ResolveOutcome = {
+  chippedComment: boolean;
+  resolvedThread: boolean;
+};
+
+/**
+ * Clear one finding on every surface it appears on.
+ *
+ * Both surfaces are cleared even though the gate now treats either as
+ * sufficient: leaving one behind means the next reader still sees the finding
+ * open, and the point of this command is that a finding is one thing.
+ */
+export async function resolveFinding(input: {
+  repo: string;
+  number: number;
+  token: string;
+  finding: Finding;
+  evidence: string;
+}): Promise<ResolveOutcome> {
+  const outcome: ResolveOutcome = {
+    chippedComment: false,
+    resolvedThread: false,
+  };
+
+  if (input.finding.commentId !== null && input.finding.title !== null) {
+    outcome.chippedComment = await chipComment({
+      repo: input.repo,
+      token: input.token,
+      commentId: input.finding.commentId,
+      title: input.finding.title,
+    });
+  }
+
+  if (input.finding.threadId !== null) {
+    await replyToThread(input.token, input.finding.threadId, input.evidence);
+    await resolveThread(input.token, input.finding.threadId);
+    outcome.resolvedThread = true;
+  }
+
+  return outcome;
+}
+
+/** Append the resolved chip to a finding in the provider's review comment. */
+async function chipComment(input: {
+  repo: string;
+  token: string;
+  commentId: number;
+  title: string;
+}): Promise<boolean> {
+  const url = `${GITHUB_API}/repos/${input.repo}/issues/comments/${String(input.commentId)}`;
+  const current = CommentSchema.parse(await getJson(url, input.token));
+  const marked = markQodoFindingResolved(current.body, input.title);
+  if (!marked.found) {
+    throw new Error(
+      `No finding titled "${input.title}" in comment ${String(input.commentId)}`,
+    );
+  }
+  if (!marked.changed) return false;
+  await sendJson("PATCH", url, { body: marked.body }, input.token);
+  return true;
+}
+
+async function replyToThread(
+  token: string,
+  threadId: string,
+  body: string,
+): Promise<void> {
+  await graphql(
+    token,
+    `
+      mutation ($t: ID!, $b: String!) {
+        addPullRequestReviewThreadReply(
+          input: { pullRequestReviewThreadId: $t, body: $b }
+        ) {
+          clientMutationId
+        }
+      }
+    `,
+    { t: threadId, b: body },
+  );
+}
+
+async function resolveThread(token: string, threadId: string): Promise<void> {
+  await graphql(
+    token,
+    `
+      mutation ($t: ID!) {
+        resolveReviewThread(input: { threadId: $t }) {
+          thread {
+            isResolved
+          }
+        }
+      }
+    `,
+    { t: threadId },
+  );
+}
+
+async function fetchHeadSha(input: {
+  repo: string;
+  number: number;
+  token: string;
+}): Promise<string> {
+  const payload = await getJson(
+    `${GITHUB_API}/repos/${input.repo}/pulls/${String(input.number)}`,
+    input.token,
+  );
+  return PrHeadSchema.parse(payload).head.sha;
+}
+
+function headers(token: string): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function getJson(url: string, token: string): Promise<unknown> {
+  const response = await fetch(url, { headers: headers(token) });
+  if (!response.ok) {
+    throw new Error(
+      `GET ${url} failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+async function sendJson(
+  method: string,
+  url: string,
+  body: unknown,
+  token: string,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method,
+    headers: { ...headers(token), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${url} failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+const GraphQlSchema = z.object({ errors: z.unknown().optional() });
+
+async function graphql(
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<void> {
+  const payload = await sendJson(
+    "POST",
+    `${GITHUB_API}/graphql`,
+    { query, variables },
+    token,
+  );
+  const parsed = GraphQlSchema.safeParse(payload);
+  if (parsed.success && parsed.data.errors !== undefined) {
+    throw new Error(
+      `GitHub GraphQL errors: ${JSON.stringify(parsed.data.errors)}`,
+    );
+  }
+}

--- a/packages/toolkit/src/lib/review/harvest.ts
+++ b/packages/toolkit/src/lib/review/harvest.ts
@@ -1,0 +1,119 @@
+/**
+ * Finding review gates that failed for a reason that has since gone away.
+ *
+ * The gate fails when its deadline expires before the provider's review lands.
+ * If the review arrives afterwards and carries nothing blocking, the job is
+ * simply stale: re-running it passes without a single change to the PR. That
+ * rule is fully decidable, and re-deciding it by hand on every stuck PR is how
+ * it was applied before this existed.
+ */
+
+import { z } from "zod";
+
+const GITHUB_API = "https://api.github.com";
+
+export const GATE_CONTEXT =
+  "buildkite/monorepo/pr/robot-face-qodo-review-gate-required";
+
+const StatusSchema = z.object({
+  state: z.string(),
+  statuses: z.array(
+    z.object({
+      context: z.string(),
+      state: z.string(),
+      target_url: z.string().nullable(),
+    }),
+  ),
+});
+
+export type GateStatus = {
+  state: string;
+  targetUrl: string | null;
+};
+
+/**
+ * The Buildkite job id a gate status points at.
+ *
+ * Buildkite writes the job into the URL fragment (`…/builds/9633#<uuid>`), so
+ * retrying the failed job — rather than rebuilding everything — means reading
+ * it back out of there.
+ */
+export function jobIdFromTargetUrl(targetUrl: string | null): string | null {
+  if (targetUrl === null) return null;
+  const fragment = targetUrl.split("#")[1];
+  if (fragment === undefined || fragment === "") return null;
+  return /^[0-9a-f-]{36}$/iu.test(fragment) ? fragment : null;
+}
+
+/** The review gate's status for a commit, or null when it posted none. */
+export async function gateStatusFor(input: {
+  repo: string;
+  ref: string;
+  token: string;
+  context?: string;
+}): Promise<GateStatus | null> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.repo}/commits/${input.ref}/status?per_page=100`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${input.token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Could not read status for ${input.repo}@${input.ref}: ` +
+        `${String(response.status)} ${response.statusText}`,
+    );
+  }
+  const parsed = StatusSchema.parse(await response.json());
+  const context = input.context ?? GATE_CONTEXT;
+  const gate = parsed.statuses.find((status) => status.context === context);
+  return gate === undefined
+    ? null
+    : { state: gate.state, targetUrl: gate.target_url };
+}
+
+export type HarvestVerdict =
+  | { retryable: true; jobId: string }
+  | { retryable: false; reason: string };
+
+/**
+ * Whether a failed gate is stale rather than correct.
+ *
+ * Every condition has to hold: the gate failed, the review that exists is for
+ * the commit the gate judged, the provider actually finished, and nothing it
+ * found blocks. Retrying on any weaker rule re-runs a job that will fail again,
+ * which reads as flakiness rather than as the gate doing its job.
+ */
+export function harvestVerdict(input: {
+  gate: GateStatus | null;
+  reviewedAtHead: boolean;
+  completionSignal: string;
+  blockingCount: number;
+}): HarvestVerdict {
+  if (input.gate === null)
+    return { retryable: false, reason: "no gate status" };
+  if (input.gate.state !== "failure") {
+    return { retryable: false, reason: `gate is ${input.gate.state}` };
+  }
+  if (!input.reviewedAtHead) {
+    return { retryable: false, reason: "no review for this head yet" };
+  }
+  if (input.completionSignal === "none") {
+    return { retryable: false, reason: "provider has not finished reviewing" };
+  }
+  if (input.blockingCount > 0) {
+    return {
+      retryable: false,
+      reason: `${String(input.blockingCount)} blocking finding(s) remain`,
+    };
+  }
+  const jobId = jobIdFromTargetUrl(input.gate.targetUrl);
+  if (jobId === null) {
+    return { retryable: false, reason: "gate status names no Buildkite job" };
+  }
+  return { retryable: true, jobId };
+}

--- a/packages/toolkit/test/lib/review-harvest.test.ts
+++ b/packages/toolkit/test/lib/review-harvest.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  harvestVerdict,
+  jobIdFromTargetUrl,
+  type GateStatus,
+} from "#lib/review/harvest.ts";
+
+const JOB = "01a00a5b-1c30-4310-8a10-20ddaaddca65";
+const failed: GateStatus = {
+  state: "failure",
+  targetUrl: `https://buildkite.com/sjerred/monorepo/builds/9633#${JOB}`,
+};
+
+describe("jobIdFromTargetUrl", () => {
+  test("reads the job out of the URL fragment", () => {
+    expect(jobIdFromTargetUrl(failed.targetUrl)).toBe(JOB);
+  });
+
+  test("returns null when the status names only a build", () => {
+    // Retrying the whole build instead of the job would re-run every step,
+    // so a URL without a job must not be treated as retryable.
+    expect(
+      jobIdFromTargetUrl("https://buildkite.com/sjerred/monorepo/builds/9633"),
+    ).toBeNull();
+  });
+
+  test("rejects a fragment that is not a job id", () => {
+    expect(jobIdFromTargetUrl("https://buildkite.com/x#not-a-uuid")).toBeNull();
+    expect(jobIdFromTargetUrl(null)).toBeNull();
+  });
+});
+
+describe("harvestVerdict", () => {
+  const stale = {
+    gate: failed,
+    reviewedAtHead: true,
+    completionSignal: "issue-comment",
+    blockingCount: 0,
+  };
+
+  test("retries a gate that expired before a clean review landed", () => {
+    expect(harvestVerdict(stale)).toEqual({ retryable: true, jobId: JOB });
+  });
+
+  test("leaves a gate that failed on real findings alone", () => {
+    // This is the case a looser rule would re-run forever: the job fails
+    // again, and a genuine finding starts to look like flakiness.
+    const verdict = harvestVerdict({ ...stale, blockingCount: 2 });
+    expect(verdict.retryable).toBe(false);
+    expect(verdict).toMatchObject({ reason: "2 blocking finding(s) remain" });
+  });
+
+  test("waits when the review is for an older commit", () => {
+    const verdict = harvestVerdict({ ...stale, reviewedAtHead: false });
+    expect(verdict).toEqual({
+      retryable: false,
+      reason: "no review for this head yet",
+    });
+  });
+
+  test("waits when the provider has not finished", () => {
+    const verdict = harvestVerdict({ ...stale, completionSignal: "none" });
+    expect(verdict).toEqual({
+      retryable: false,
+      reason: "provider has not finished reviewing",
+    });
+  });
+
+  test("does nothing to a gate that is not failing", () => {
+    for (const state of ["success", "pending", "error"]) {
+      expect(harvestVerdict({ ...stale, gate: { ...failed, state } })).toEqual({
+        retryable: false,
+        reason: `gate is ${state}`,
+      });
+    }
+  });
+
+  test("does nothing when there is no gate at all", () => {
+    expect(harvestVerdict({ ...stale, gate: null })).toEqual({
+      retryable: false,
+      reason: "no gate status",
+    });
+  });
+
+  test("does not retry when the status names no job", () => {
+    const verdict = harvestVerdict({
+      ...stale,
+      gate: { state: "failure", targetUrl: null },
+    });
+    expect(verdict).toEqual({
+      retryable: false,
+      reason: "gate status names no Buildkite job",
+    });
+  });
+});


### PR DESCRIPTION
Why:
The gate reports a count. Turning that count into "which problems, where, and
what do I do about each" meant hand-writing the same GitHub queries over and
over — and clearing a single finding meant two API calls of different shapes,
because Qodo renders each finding both in its review comment and as an
addressable thread. The retry-harvest rule ("this gate failed only because the
review landed late") is fully decidable and was also being re-decided by hand on
every stuck PR.

What:
- `toolkit pr review list <PR>` — every provider finding, deduplicated across
  surfaces, with severity, location, resolution state, both handles, and the key
  it merged under.
- `toolkit pr review resolve <PR> --finding <key|title> --evidence <text>` —
  clears one finding on both surfaces in one step: chips the review comment and
  replies to and resolves the review thread. `--evidence` is mandatory, so a
  dismissal always carries its reason.
- `toolkit pr review harvest <PR…>` — applies the stale-gate rule and prints the
  `bk job retry` command; `--retry` runs it. The job id is read from the status
  URL's fragment so the failed job is retried, not the whole build.
- `markQodoFindingResolved` lives beside the parser that reads the chip back, so
  the writer and reader are one agreement rather than two that can drift. It
  edits only above `<!-- FOLDED_SECTION_START -->`; Qodo's archive of previous
  results is left exactly as the provider wrote it.

GitHub access borrows an authenticated `gh`'s token when `GH_TOKEN` is unset,
keeping this package's no-token-setup convention while still using the
`code-review` library, which needs a token because it speaks GraphQL.

Verification:
- `bunx turbo run typecheck test lint build` for `@shepherdjerred/toolkit` and
  `@shepherdjerred/code-review`: 8/8 green. 10 new harvest tests (placed under
  `test/lib`, which is in this package's `test:unit` glob — confirmed they run)
  and 6 new chip tests, including one asserting a two-section fixture's archived
  half comes back byte-identical.
- Against live PR #2095: `list` shows 9 findings, every one carrying both
  handles, 2 unresolved — the two design decisions.
- Against live PRs #2095/#2208/#2216/#2218, `harvest` selects exactly the PRs
  the manual rule selected, with the reason it rejected each of the others.
- `resolve` is exercised only through `markQodoFindingResolved`'s unit tests; its
  two GitHub writes are not covered by an integration test.