### PR TITLE
feat(root): make the review gate ask for, correctly source, and correctly count its reviews

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1037,8 +1037,7 @@ steps:
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh
-      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter '@shepherdjerred/root-scripts' --production
-      bun --no-install scripts/wait-for-review.ts
+      .buildkite/scripts/review-gate.sh
     retry: *retry
     plugins:
       - kubernetes:

--- a/.buildkite/scripts/review-gate.sh
+++ b/.buildkite/scripts/review-gate.sh
@@ -32,7 +32,9 @@ GATE_REF="${REVIEW_GATE_REF:-main}"
 GATE_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}/.review-gate-source"
 
 echo "~~~ Fetching the review gate from ${GATE_REF}"
-git fetch --depth 1 origin "$GATE_REF"
+# `--` so an operator-supplied REVIEW_GATE_REF beginning with `-` is fetched as
+# a ref rather than parsed as a git option.
+git fetch --depth 1 origin -- "$GATE_REF"
 GATE_SHA="$(git rev-parse FETCH_HEAD)"
 echo "Review gate source: ${GATE_REF} @ ${GATE_SHA}"
 

--- a/.buildkite/scripts/review-gate.sh
+++ b/.buildkite/scripts/review-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the review gate from `main` rather than from the pull request's own
+# checkout.
+#
+# The gate reads only GitHub state — the provider's review, its findings, and
+# whether they are resolved. It never reads the PR's diff. So there is no reason
+# for it to run the PR's copy of itself, and one strong reason not to: with
+# `@shepherdjerred/code-review` linked as a workspace dependency, a branch was
+# graded by whatever version of the grader that branch happened to contain.
+#
+# PR #1389 is the worked example. Its branch was 22 commits behind and predated
+# `currentReviewOf`, the function that excludes Qodo's archived
+# "previous results" section, so its gate counted stale pre-fix copies of
+# findings that had already been fixed: 0 blocking findings measured against
+# current `main`, 3 measured by the branch's own parser. Nothing about the PR
+# was wrong, and no amount of fixing the PR could have cleared it — only
+# rebasing 22 commits of unrelated history would have.
+#
+# This closes the accidental version of that problem, where a branch is simply
+# old. It is not a trust boundary: Buildkite uploads the pipeline from the
+# branch, so a branch that deliberately rewrites this step controls its own
+# gate either way — as it does for every other check.
+#
+# REVIEW_GATE_REF exists so a change to the gate itself can be exercised before
+# it lands, since once this is in place the gate no longer runs a PR's own
+# version of it. Set it when creating the build, the way CI_IO_FIXED_CORPUS is
+# set; leave it unset everywhere else.
+
+GATE_REF="${REVIEW_GATE_REF:-main}"
+GATE_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH:-$PWD}/.review-gate-source"
+
+echo "~~~ Fetching the review gate from ${GATE_REF}"
+git fetch --depth 1 origin "$GATE_REF"
+GATE_SHA="$(git rev-parse FETCH_HEAD)"
+echo "Review gate source: ${GATE_REF} @ ${GATE_SHA}"
+
+# Clear any leftover worktree on the way IN rather than removing it afterwards.
+# Cleaning up first is idempotent and keeps the gate's exit status its own: a
+# teardown failure cannot red a PR, and nothing has to be suppressed to make
+# that true. The agent discards the workspace after the job regardless.
+git worktree prune
+rm -rf "$GATE_DIR"
+git worktree add --detach "$GATE_DIR" FETCH_HEAD
+
+cd "$GATE_DIR"
+"$GATE_DIR/.buildkite/scripts/bun-install.sh" --frozen-lockfile \
+  --filter '@shepherdjerred/root-scripts' --production
+REVIEW_GATE_PARSER_COMMIT="$GATE_SHA" bun --no-install scripts/wait-for-review.ts

--- a/.buildkite/scripts/review-gate.sh
+++ b/.buildkite/scripts/review-gate.sh
@@ -40,8 +40,14 @@ echo "Review gate source: ${GATE_REF} @ ${GATE_SHA}"
 # Cleaning up first is idempotent and keeps the gate's exit status its own: a
 # teardown failure cannot red a PR, and nothing has to be suppressed to make
 # that true. The agent discards the workspace after the job regardless.
-git worktree prune
+#
+# The directory goes before the prune, not after: `git worktree prune` drops the
+# registrations whose working tree is already gone, so pruning first cannot
+# clear the one this run is about to delete. On a reused checkout that left the
+# registration behind, `git worktree add` then refuses the path as already
+# registered and the gate fails before it reads anything.
 rm -rf "$GATE_DIR"
+git worktree prune
 git worktree add --detach "$GATE_DIR" FETCH_HEAD
 
 cd "$GATE_DIR"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,32 @@ The value must be exactly `true`, and `BUILDKITE_BRANCH` must be `main`;
 invalid, unset-branch, and non-main requests fail before the pipeline runs.
 Treat this as a production-mutating build, not a read-only benchmark.
 
+### The review gate
+
+The `review-gate` step runs `.buildkite/scripts/review-gate.sh`, which checks
+out `main` into a worktree and runs the gate from there. The gate reads only
+GitHub state and never the PR's diff, so running the PR's own copy bought
+nothing and cost correctness: `@shepherdjerred/code-review` is a `workspace:*`
+dependency, so each branch graded itself with whatever version of the parser it
+happened to contain. A branch old enough to predate a parser fix counted
+findings that had already been fixed, and no change to that PR could clear it.
+
+The gate asks the provider to review the head before waiting on it. Qodo
+reviews a PR once, when it is opened, and never again on its own, so polling
+alone burned the whole budget on every push after the first. The request is
+idempotent per head through `buildReviewRequestMarker()`, shared with the PR
+fleet controller so the two recognise each other's request.
+
+Each `review-signal` event carries `parser_commit`, the commit of the parser
+that produced the counts. A finding count is only comparable against the parser
+that arrived at it — a local `probe-review-signal.ts` run from a stale checkout
+legitimately disagrees with CI.
+
+`REVIEW_GATE_REF` overrides the ref the gate runs from. It exists only so a
+change to the gate itself can be exercised before it lands, since the gate no
+longer runs a PR's own version of it. Set it when creating the build, as with
+`CI_IO_FIXED_CORPUS`; never in committed configuration.
+
 ### Release refinement providers
 
 The main-only `release-please` lane runs `scripts/release.ts`. Its CHANGELOG

--- a/bun.lock
+++ b/bun.lock
@@ -1697,6 +1697,7 @@
       },
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1001.0",
+        "@shepherdjerred/code-review": "workspace:*",
         "asciinema-player": "^3.15.1",
         "debug": "^4.4.3",
         "discord.js": "^14",

--- a/packages/code-review/package.json
+++ b/packages/code-review/package.json
@@ -17,6 +17,10 @@
     "./head-pushed-at": {
       "types": "./src/head-pushed-at.ts",
       "default": "./src/head-pushed-at.ts"
+    },
+    "./request-review": {
+      "types": "./src/request-review.ts",
+      "default": "./src/request-review.ts"
     }
   },
   "scripts": {

--- a/packages/code-review/package.json
+++ b/packages/code-review/package.json
@@ -21,6 +21,10 @@
     "./request-review": {
       "types": "./src/request-review.ts",
       "default": "./src/request-review.ts"
+    },
+    "./qodo": {
+      "types": "./src/providers/qodo.ts",
+      "default": "./src/providers/qodo.ts"
     }
   },
   "scripts": {

--- a/packages/code-review/src/gate.test.ts
+++ b/packages/code-review/src/gate.test.ts
@@ -18,6 +18,8 @@ function thread(overrides: Partial<ReviewThread>): ReviewThread {
     url: "https://github.com/o/r/pull/1#d",
     priority: 2,
     title: null,
+    threadId: null,
+    commentId: null,
     ...overrides,
   };
 }

--- a/packages/code-review/src/github-http.ts
+++ b/packages/code-review/src/github-http.ts
@@ -144,6 +144,32 @@ export async function graphqlRequest(
   return payload;
 }
 
+/**
+ * POST a JSON body to a REST endpoint and return the parsed response.
+ *
+ * The gate runs in a light CI pod with a token and no `gh` CLI, so the one
+ * write it performs — asking the provider to review the head — goes through the
+ * same fetch path as every read.
+ */
+export async function postJson(
+  url: string,
+  body: unknown,
+  token: string,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `GitHub request to ${url} failed with ${String(response.status)} ${response.statusText}: ${text}`,
+    );
+  }
+  return response.json();
+}
+
 export function splitRepo(repo: string): { owner: string; name: string } {
   const [owner, name] = repo.split("/");
   if (

--- a/packages/code-review/src/github-http.ts
+++ b/packages/code-review/src/github-http.ts
@@ -164,7 +164,7 @@ export async function postJson(
   if (!response.ok) {
     const text = await response.text();
     throw new Error(
-      `GitHub request to ${url} failed with ${String(response.status)} ${response.statusText}: ${text}`,
+      `GitHub API request failed with ${String(response.status)} ${response.statusText}: ${text}`,
     );
   }
   return response.json();

--- a/packages/code-review/src/github-issue-comments.test.ts
+++ b/packages/code-review/src/github-issue-comments.test.ts
@@ -16,6 +16,7 @@ function acknowledging(sha: string) {
     body: `[Code review](https://github.com/o/r/pull/1#issuecomment-1) by qodo was updated up to the latest commit https://github.com/o/r/commit/${sha}`,
     updatedAt: afterPush,
     url: null,
+    id: null,
   };
 }
 
@@ -181,11 +182,15 @@ const issueCommentProvider: ReviewProvider = {
         url: null,
         priority: 1,
         title: null,
+        threadId: null,
+        commentId: null,
       },
     ],
   },
   detectSkip: null,
   requestReview: null,
+  parseFindingTitle: null,
+  findingKey: null,
 };
 
 test("records the acknowledgement time as issue-comment completion", async () => {

--- a/packages/code-review/src/github-issue-comments.ts
+++ b/packages/code-review/src/github-issue-comments.ts
@@ -3,6 +3,7 @@ import {
   asRecord,
   GITHUB_API_URL,
   getJsonWithLink,
+  numberField,
   recordField,
   stringField,
 } from "./github-http.ts";
@@ -101,7 +102,12 @@ async function scanProviderIssueComments(
       if (body === null) continue;
       const updatedAt =
         stringField(item, "updated_at") ?? stringField(item, "created_at");
-      const comment = { body, updatedAt, url: stringField(item, "html_url") };
+      const comment = {
+        body,
+        updatedAt,
+        url: stringField(item, "html_url"),
+        id: numberField(item, "id"),
+      };
       // An acknowledgement quotes the review comment's title, so classify it
       // first: only a comment that is not an acknowledgement can be the review.
       if (body.includes(completion.acknowledgement.marker)) {

--- a/packages/code-review/src/github-review-threads.ts
+++ b/packages/code-review/src/github-review-threads.ts
@@ -1,0 +1,108 @@
+/**
+ * Reading the PR's review threads off GitHub's GraphQL API and normalising each
+ * one into a {@link ReviewThread}. Kept apart from the completion strategies it
+ * feeds: this is the shape of GitHub's payload, not a decision about it.
+ */
+
+import {
+  arrayField,
+  asRecord,
+  boolField,
+  numberField,
+  recordField,
+  stringField,
+} from "./github-http.ts";
+import type { ReviewProvider, ReviewThread } from "./types.ts";
+
+export const REVIEW_THREADS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      headRefOid
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 1) {
+            nodes { author { login } url body }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export function parseThreadPage(
+  payload: unknown,
+  provider: ReviewProvider,
+): {
+  headRefOid: string | null;
+  threads: ReviewThread[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+} {
+  const payloadRecord = asRecord(payload);
+  const data =
+    payloadRecord === null ? null : recordField(payloadRecord, "data");
+  const repository = data === null ? null : recordField(data, "repository");
+  const pullRequest =
+    repository === null ? null : recordField(repository, "pullRequest");
+  if (pullRequest === null) {
+    throw new Error(
+      "GitHub GraphQL response did not include repository.pullRequest",
+    );
+  }
+  const reviewThreads = recordField(pullRequest, "reviewThreads");
+  if (reviewThreads === null) {
+    throw new Error("GitHub GraphQL response did not include reviewThreads");
+  }
+
+  const threads: ReviewThread[] = [];
+  for (const rawNode of arrayField(reviewThreads, "nodes")) {
+    const node = asRecord(rawNode);
+    if (node === null) continue;
+    const comments = recordField(node, "comments");
+    const commentNodes = comments === null ? [] : arrayField(comments, "nodes");
+    const firstComment = asRecord(commentNodes[0]);
+    let authorLogin: string | null = null;
+    let url: string | null = null;
+    let priority: number | null = null;
+    let title: string | null = null;
+    if (firstComment !== null) {
+      const author = recordField(firstComment, "author");
+      const body = stringField(firstComment, "body");
+      authorLogin = author === null ? null : stringField(author, "login");
+      url = stringField(firstComment, "url");
+      priority = provider.parseSeverity(body);
+      // A thread is addressable, so a consumer *could* re-read it — but the
+      // title is what identifies this finding as the same one the provider may
+      // also have rendered into its review comment, which is what stops it
+      // being counted twice.
+      title = provider.parseFindingTitle?.(body) ?? null;
+    }
+    threads.push({
+      authorLogin,
+      isResolved: boolField(node, "isResolved"),
+      isOutdated: boolField(node, "isOutdated"),
+      path: stringField(node, "path"),
+      line: numberField(node, "line"),
+      url,
+      priority,
+      title,
+      threadId: stringField(node, "id"),
+      commentId: null,
+    });
+  }
+
+  const pageInfo = recordField(reviewThreads, "pageInfo");
+  return {
+    headRefOid: stringField(pullRequest, "headRefOid"),
+    threads,
+    hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
+    endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
+  };
+}

--- a/packages/code-review/src/github.ts
+++ b/packages/code-review/src/github.ts
@@ -9,13 +9,11 @@
 import {
   arrayField,
   asRecord,
-  boolField,
   type CheckConclusion,
   conclusionField,
   GITHUB_API_URL,
   getJsonWithLink,
   graphqlRequest,
-  numberField,
   recordField,
   splitRepo,
   stringField,
@@ -25,7 +23,12 @@ import {
   fetchLatestProviderIssueComment,
   resolveIssueCommentReview,
 } from "./github-issue-comments.ts";
+import {
+  parseThreadPage,
+  REVIEW_THREADS_QUERY,
+} from "./github-review-threads.ts";
 import { isProviderAuthor } from "./identity.ts";
+import { mergeDuplicateFindings } from "./merge-findings.ts";
 import type { CompletionSignal } from "./signal.ts";
 import type {
   PullRequestAuthor,
@@ -34,7 +37,6 @@ import type {
   ReviewState,
   ReviewThread,
 } from "./types.ts";
-
 // ---------------------------------------------------------------------------
 // Pull-request author
 // ---------------------------------------------------------------------------
@@ -77,94 +79,9 @@ export async function fetchPullRequestAuthor(input: {
   const { payload } = await getJsonWithLink(url, input.token);
   return parsePullRequestAuthor(payload);
 }
-
 // ---------------------------------------------------------------------------
 // Review threads (provider-agnostic; priority parsed via the active provider)
 // ---------------------------------------------------------------------------
-
-const REVIEW_THREADS_QUERY = `
-query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $number) {
-      headRefOid
-      reviewThreads(first: 100, after: $cursor) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          isResolved
-          isOutdated
-          path
-          line
-          comments(first: 1) {
-            nodes { author { login } url body }
-          }
-        }
-      }
-    }
-  }
-}`;
-
-function parseThreadPage(
-  payload: unknown,
-  provider: ReviewProvider,
-): {
-  headRefOid: string | null;
-  threads: ReviewThread[];
-  hasNextPage: boolean;
-  endCursor: string | null;
-} {
-  const payloadRecord = asRecord(payload);
-  const data =
-    payloadRecord === null ? null : recordField(payloadRecord, "data");
-  const repository = data === null ? null : recordField(data, "repository");
-  const pullRequest =
-    repository === null ? null : recordField(repository, "pullRequest");
-  if (pullRequest === null) {
-    throw new Error(
-      "GitHub GraphQL response did not include repository.pullRequest",
-    );
-  }
-  const reviewThreads = recordField(pullRequest, "reviewThreads");
-  if (reviewThreads === null) {
-    throw new Error("GitHub GraphQL response did not include reviewThreads");
-  }
-
-  const threads: ReviewThread[] = [];
-  for (const rawNode of arrayField(reviewThreads, "nodes")) {
-    const node = asRecord(rawNode);
-    if (node === null) continue;
-    const comments = recordField(node, "comments");
-    const commentNodes = comments === null ? [] : arrayField(comments, "nodes");
-    const firstComment = asRecord(commentNodes[0]);
-    let authorLogin: string | null = null;
-    let url: string | null = null;
-    let priority: number | null = null;
-    if (firstComment !== null) {
-      const author = recordField(firstComment, "author");
-      authorLogin = author === null ? null : stringField(author, "login");
-      url = stringField(firstComment, "url");
-      priority = provider.parseSeverity(stringField(firstComment, "body"));
-    }
-    threads.push({
-      authorLogin,
-      isResolved: boolField(node, "isResolved"),
-      isOutdated: boolField(node, "isOutdated"),
-      path: stringField(node, "path"),
-      line: numberField(node, "line"),
-      url,
-      priority,
-      // A GitHub thread is addressable: consumers read its comment directly.
-      title: null,
-    });
-  }
-
-  const pageInfo = recordField(reviewThreads, "pageInfo");
-  return {
-    headRefOid: stringField(pullRequest, "headRefOid"),
-    threads,
-    hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
-    endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
-  };
-}
 
 export async function fetchReviewThreads(input: {
   repo: string;
@@ -209,7 +126,10 @@ export async function fetchReviewThreads(input: {
       threads.push(...completion.parseFindings(comment));
     }
   }
-  return { threads, headRefOid };
+  return {
+    threads: mergeDuplicateFindings(threads, input.provider),
+    headRefOid,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -173,6 +173,30 @@ describe("parseQodoFindingTitle", () => {
     ).toBe(qodoFindingKey({ ...base, title: "Joinvoice can hang forever" }));
   });
 
+  test("keys a finding with a string that survives a process argument", () => {
+    const base = {
+      authorLogin: "qodo-code-review",
+      isResolved: false,
+      isOutdated: false,
+      line: null,
+      url: null,
+      priority: 1,
+      threadId: null,
+      commentId: null,
+    };
+    // `toolkit pr review list` prints the key and `resolve --finding <key>`
+    // matches it back by equality, so a control character in the key puts the
+    // finding out of reach of the command built to clear it.
+    const key = qodoFindingKey({ ...base, path: "a b/c.ts", title: "Boom" });
+    expect(key).not.toBeNull();
+    expect(key).not.toMatch(/\p{Cc}/u);
+    // Escaping the path keeps the space separator unambiguous, so a path that
+    // contains one cannot collide with a different path plus a longer title.
+    expect(qodoFindingKey({ ...base, path: "a b", title: "c" })).not.toBe(
+      qodoFindingKey({ ...base, path: "a", title: "b c" }),
+    );
+  });
+
   test("reads the title of a finding Qodo has struck as resolved", () => {
     // Verbatim from PR #2095 after its thread was resolved: Qodo wraps the
     // whole title in <s>, so the line no longer opens with the ordinal.

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { mergeDuplicateFindings } from "./merge-findings.ts";
+import { codexProvider } from "./providers/codex.ts";
+import {
+  parseQodoFindingTitle,
+  qodoFindingKey,
+  qodoProvider,
+} from "./providers/qodo.ts";
+import type { ReviewThread } from "./types.ts";
+
+describe("mergeDuplicateFindings", () => {
+  // Qodo posts every finding twice: once inside its persistent review comment
+  // and once as an addressable thread on the offending line. These are the two
+  // renderings of ONE finding from PR #2095, kept verbatim — the ordinals
+  // differ (4 vs 1), the capitalization differs, and only the thread carries a
+  // Markdown-escaped `\.`. That is exactly what the key has to see through.
+  const fromComment: ReviewThread = {
+    authorLogin: "qodo-code-review",
+    isResolved: false,
+    isOutdated: false,
+    path: "packages/streambot/src/session/destroy-session.ts",
+    line: null,
+    url: "https://github.com/o/r/pull/2095/files#diff-abc",
+    priority: 1,
+    title: "Turn outlives session destroy",
+    threadId: null,
+    commentId: 5_236_306_054,
+  };
+  const fromThread: ReviewThread = {
+    authorLogin: "qodo-code-review",
+    isResolved: false,
+    isOutdated: false,
+    path: "packages/streambot/src/session/destroy-session.ts",
+    line: 10,
+    url: "https://github.com/o/r/pull/2095#discussion_r1",
+    priority: 1,
+    title: "Turn outlives session destroy",
+    threadId: "PRRT_kwDOHf4r4c6ZlJlJ",
+    commentId: null,
+  };
+
+  test("counts one finding rendered on both surfaces once", () => {
+    const merged = mergeDuplicateFindings(
+      [fromComment, fromThread],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+  });
+
+  test("keeps both handles so either surface can be acted on", () => {
+    const [merged] = mergeDuplicateFindings(
+      [fromComment, fromThread],
+      qodoProvider,
+    );
+    expect(merged?.threadId).toBe("PRRT_kwDOHf4r4c6ZlJlJ");
+    expect(merged?.commentId).toBe(5_236_306_054);
+    // The thread knows the line; the comment copy does not.
+    expect(merged?.line).toBe(10);
+  });
+
+  test("resolves the finding when only the thread copy is resolved", () => {
+    const merged = mergeDuplicateFindings(
+      [fromComment, { ...fromThread, isResolved: true }],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.isResolved).toBe(true);
+  });
+
+  test("resolves the finding when only the comment copy is chipped", () => {
+    const merged = mergeDuplicateFindings(
+      [{ ...fromComment, isResolved: true }, fromThread],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.isResolved).toBe(true);
+  });
+
+  test("does not mutate its input", () => {
+    const input = [{ ...fromComment, isResolved: true }, { ...fromThread }];
+    mergeDuplicateFindings(input, qodoProvider);
+    expect(input[1]?.isResolved).toBe(false);
+  });
+
+  test("takes the more severe priority when the surfaces disagree", () => {
+    const merged = mergeDuplicateFindings(
+      [{ ...fromComment, priority: 2 }, fromThread],
+      qodoProvider,
+    );
+    expect(merged[0]?.priority).toBe(1);
+  });
+
+  test("keeps findings in different files apart despite an identical title", () => {
+    const elsewhere = {
+      ...fromThread,
+      path: "packages/streambot/src/other.ts",
+    };
+    expect(
+      mergeDuplicateFindings([fromComment, elsewhere], qodoProvider),
+    ).toHaveLength(2);
+  });
+
+  test("never merges a finding it cannot identify", () => {
+    // A null key means "cannot identify this one". Two unidentifiable findings
+    // must stay two, or an unparseable finding would silently disappear into
+    // another one and stop blocking.
+    const untitled = { ...fromThread, title: null };
+    expect(
+      mergeDuplicateFindings([untitled, { ...untitled }], qodoProvider),
+    ).toHaveLength(2);
+  });
+
+  test("never merges another reviewer's thread into a provider finding", () => {
+    // A second reviewer on the same PR can render a matching headline on the
+    // same file. Folding it into the provider's finding would stop it being
+    // counted at all.
+    const otherReviewer = {
+      ...fromThread,
+      authorLogin: "chatgpt-codex-connector",
+      isResolved: true,
+    };
+    const merged = mergeDuplicateFindings(
+      [fromComment, otherReviewer],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(2);
+    expect(merged.find((t) => t.commentId === 5_236_306_054)?.isResolved).toBe(
+      false,
+    );
+  });
+
+  test("leaves providers that post each finding once untouched", () => {
+    const threads = [fromComment, fromThread];
+    expect(mergeDuplicateFindings(threads, codexProvider)).toHaveLength(2);
+  });
+});
+
+describe("parseQodoFindingTitle", () => {
+  // Verbatim from PR #2095, thread PRRT_kwDOHf4r4c6ZlJlJ.
+  const threadBody = [
+    '<img src="https://img.shields.io/badge/High-634FD1?style=flat-square" height="20px" alt="Action required">',
+    "",
+    String.raw`1\. Turn outlives session destroy <code>🐞 Bug</code> <code>☼ Reliability</code>`,
+    "",
+    "<pre>",
+    "destroySession() closes the voice assistant but does not await completion",
+    "</pre>",
+  ].join("\n");
+
+  test("reads the title past the badge, the ordinal, and the category chips", () => {
+    expect(parseQodoFindingTitle(threadBody)).toBe(
+      "Turn outlives session destroy",
+    );
+  });
+
+  test("gives a thread and its review-comment twin the same key", () => {
+    const base = {
+      authorLogin: "qodo-code-review",
+      isResolved: false,
+      isOutdated: false,
+      path: "packages/discord-video-stream/src/client/Streamer.ts",
+      line: null,
+      url: null,
+      priority: 1,
+      threadId: null,
+      commentId: null,
+    };
+    // The comment says "joinVoice"; the thread says "Joinvoice".
+    expect(
+      qodoFindingKey({ ...base, title: "joinVoice can hang forever" }),
+    ).toBe(qodoFindingKey({ ...base, title: "Joinvoice can hang forever" }));
+  });
+
+  test("reads the title of a finding Qodo has struck as resolved", () => {
+    // Verbatim from PR #2095 after its thread was resolved: Qodo wraps the
+    // whole title in <s>, so the line no longer opens with the ordinal.
+    const struck = [
+      '<img src="https://img.shields.io/badge/High-634FD1?style=flat-square" height="20px" alt="Action required">',
+      "",
+      String.raw`<s>1\. Joinvoice can hang forever</s> <code>🐞 Bug</code> <code>☼ Reliability</code>`,
+      "",
+      "<pre><s>",
+      "Streamer.joinVoice() now calls setAudioPacketizer() inside the ready callback",
+      "</s></pre>",
+    ].join("\n");
+    expect(parseQodoFindingTitle(struck)).toBe("Joinvoice can hang forever");
+  });
+
+  test("returns null when no numbered title line exists", () => {
+    expect(parseQodoFindingTitle("just prose, no finding here")).toBeNull();
+    expect(parseQodoFindingTitle(null)).toBeNull();
+  });
+});

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -78,6 +78,35 @@ describe("mergeDuplicateFindings", () => {
     expect(merged[0]?.isResolved).toBe(true);
   });
 
+  test("does not let an outdated resolved copy resolve a live finding", () => {
+    // The gate blocks on `!isResolved && !isOutdated`, so taking resolution
+    // from the outdated copy while the current copy keeps the finding current
+    // produced a merged finding that was neither — and passed the gate on a
+    // finding nobody had dealt with.
+    for (const order of [
+      [fromComment, { ...fromThread, isOutdated: true, isResolved: true }],
+      [{ ...fromThread, isOutdated: true, isResolved: true }, fromComment],
+    ]) {
+      const merged = mergeDuplicateFindings(order, qodoProvider);
+      expect(merged).toHaveLength(1);
+      expect(merged[0]?.isResolved).toBe(false);
+      expect(merged[0]?.isOutdated).toBe(false);
+    }
+  });
+
+  test("reports an all-outdated finding's resolution from its outdated copies", () => {
+    const merged = mergeDuplicateFindings(
+      [
+        { ...fromComment, isOutdated: true },
+        { ...fromThread, isOutdated: true, isResolved: true },
+      ],
+      qodoProvider,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.isOutdated).toBe(true);
+    expect(merged[0]?.isResolved).toBe(true);
+  });
+
   test("does not mutate its input", () => {
     const input = [{ ...fromComment, isResolved: true }, { ...fromThread }];
     mergeDuplicateFindings(input, qodoProvider);

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mergeDuplicateFindings } from "./merge-findings.ts";
 import { codexProvider } from "./providers/codex.ts";
 import {
+  markQodoFindingResolved,
   parseQodoFindingTitle,
+  QODO_RESOLVED_CHIP,
   qodoFindingKey,
   qodoProvider,
 } from "./providers/qodo.ts";
@@ -189,5 +191,82 @@ describe("parseQodoFindingTitle", () => {
   test("returns null when no numbered title line exists", () => {
     expect(parseQodoFindingTitle("just prose, no finding here")).toBeNull();
     expect(parseQodoFindingTitle(null)).toBeNull();
+  });
+});
+
+describe("markQodoFindingResolved", () => {
+  // Both sections carry the SAME finding, unstruck. Qodo re-appends its
+  // previous results below the fold marker and the parser reads only what is
+  // above it, so a chip written below would change nothing while rewriting
+  // what the provider recorded.
+  const body = [
+    "<h3>Code Review by Qodo</h3>",
+    '<img alt="Action required">',
+    "<details>",
+    "<summary>  1. Turn outlives session destroy <code>🐞 Bug</code></summary>",
+    "</details>",
+    "<!-- FOLDED_SECTION_START -->",
+    "<details>",
+    "<summary>  1. Turn outlives session destroy <code>🐞 Bug</code></summary>",
+    "</details>",
+  ].join("\n");
+
+  test("chips the finding in the current review", () => {
+    const edited = markQodoFindingResolved(
+      body,
+      "Turn outlives session destroy",
+    );
+    if (edited === null) throw new Error("expected an edit");
+    expect(edited).toContain(QODO_RESOLVED_CHIP);
+  });
+
+  test("never edits Qodo's archive of previous results", () => {
+    const edited = markQodoFindingResolved(
+      body,
+      "Turn outlives session destroy",
+    );
+    if (edited === null) throw new Error("expected an edit");
+    const fold = edited.indexOf("<!-- FOLDED_SECTION_START -->");
+    expect(edited.slice(fold)).toBe(
+      body.slice(body.indexOf("<!-- FOLDED_SECTION_START -->")),
+    );
+    // Exactly one chip: the archived copy of the same finding is untouched.
+    expect(edited.split(QODO_RESOLVED_CHIP)).toHaveLength(2);
+  });
+
+  test("a chipped finding reads back as resolved", () => {
+    // The whole point: the writer's output must satisfy the reader.
+    const edited = markQodoFindingResolved(
+      body,
+      "Turn outlives session destroy",
+    );
+    if (edited === null) throw new Error("expected an edit");
+    expect(edited).toContain("☑");
+  });
+
+  test("is idempotent", () => {
+    const once = markQodoFindingResolved(body, "Turn outlives session destroy");
+    if (once === null) throw new Error("expected an edit");
+    const twice = markQodoFindingResolved(
+      once,
+      "Turn outlives session destroy",
+    );
+    expect(twice).toBe(once);
+  });
+
+  test("leaves a finding Qodo already struck alone", () => {
+    const struck = body.replace(
+      "  1. Turn outlives session destroy <code>🐞 Bug</code>",
+      "<s>  1. Turn outlives session destroy</s> <code>🐞 Bug</code>",
+    );
+    const result = markQodoFindingResolved(
+      struck,
+      "Turn outlives session destroy",
+    );
+    expect(result).toBe(struck);
+  });
+
+  test("reports a title it cannot find rather than succeeding at nothing", () => {
+    expect(markQodoFindingResolved(body, "No such finding")).toBeNull();
   });
 });

--- a/packages/code-review/src/merge-findings.ts
+++ b/packages/code-review/src/merge-findings.ts
@@ -10,12 +10,14 @@ import type { ReviewProvider, ReviewThread } from "./types.ts";
  * through different APIs. Counting both made `blocking_count` roughly double
  * the number of real findings and made every finding cost two actions to clear.
  *
- * A finding is resolved once EITHER copy is resolved. Both gestures are
- * deliberate and auditable, and each copy is already scoped to what currently
- * applies: the comment parser reads only the current review section, and
- * outdated threads are excluded downstream. This mirrors how copies *within*
- * the review comment have always been merged (`dedupeRenderedFindings`), so one
- * finding behaves the same however the provider chose to render it.
+ * A finding is resolved once either copy that STILL APPLIES is resolved. Both
+ * gestures are deliberate and auditable. Reading resolution off an outdated
+ * copy instead would let a stale resolved thread mark a live finding resolved,
+ * and the gate blocks on `!isResolved && !isOutdated` — so the merged finding
+ * would be neither, and a finding nobody had dealt with would pass. This
+ * mirrors how copies *within* the review comment have always been merged
+ * (`dedupeRenderedFindings`), so one finding behaves the same however the
+ * provider chose to render it.
  *
  * Priority takes the most severe copy, so a disagreement between surfaces can
  * only ever make the gate stricter. A `null` key never merges — an unrecognised
@@ -28,7 +30,10 @@ export function mergeDuplicateFindings(
   const { findingKey } = provider;
   if (findingKey === null) return [...threads];
   const merged: ReviewThread[] = [];
-  const byKey = new Map<string, ReviewThread>();
+  const byKey = new Map<
+    string,
+    { finding: ReviewThread; copies: ReviewThread[] }
+  >();
   for (const thread of threads) {
     // Only the configured provider posts a finding twice, so only its own
     // threads may merge. Without this, another reviewer's thread that happened
@@ -43,27 +48,39 @@ export function mergeDuplicateFindings(
     }
     const seen = byKey.get(key);
     if (seen === undefined) {
-      const copy = { ...thread };
-      byKey.set(key, copy);
-      merged.push(copy);
+      const finding = { ...thread };
+      byKey.set(key, { finding, copies: [thread] });
+      merged.push(finding);
       continue;
     }
-    if (thread.isResolved) seen.isResolved = true;
-    // An outdated copy does not make the finding outdated: the other surface
-    // still shows it, so it is still on screen for a reviewer to act on.
-    if (!thread.isOutdated) seen.isOutdated = false;
+    seen.copies.push(thread);
+    const { finding } = seen;
     if (
       thread.priority !== null &&
-      (seen.priority === null || thread.priority < seen.priority)
+      (finding.priority === null || thread.priority < finding.priority)
     ) {
-      seen.priority = thread.priority;
+      finding.priority = thread.priority;
     }
     // Keep whichever handles each copy contributes, so a consumer can act on
     // the finding wherever it lives without re-deriving the other surface.
-    seen.threadId ??= thread.threadId;
-    seen.commentId ??= thread.commentId;
-    seen.line ??= thread.line;
-    seen.path ??= thread.path;
+    finding.threadId ??= thread.threadId;
+    finding.commentId ??= thread.commentId;
+    finding.line ??= thread.line;
+    finding.path ??= thread.path;
+  }
+  // Decided over the whole group rather than folded in copy by copy, so the
+  // answer cannot depend on which surface the provider happened to list first.
+  for (const { finding, copies } of byKey.values()) {
+    // An outdated copy does not make the finding outdated: the other surface
+    // still shows it, so it is still on screen for a reviewer to act on.
+    const current = copies.filter((copy) => !copy.isOutdated);
+    finding.isOutdated = current.length === 0;
+    // Only the copies that still apply may resolve it. When every copy is
+    // outdated the finding is outdated anyway, so its resolution gates nothing
+    // and is reported from what is there.
+    finding.isResolved = (current.length === 0 ? copies : current).some(
+      (copy) => copy.isResolved,
+    );
   }
   return merged;
 }

--- a/packages/code-review/src/merge-findings.ts
+++ b/packages/code-review/src/merge-findings.ts
@@ -1,0 +1,69 @@
+import { isProviderAuthor } from "./identity.ts";
+import type { ReviewProvider, ReviewThread } from "./types.ts";
+
+/**
+ * Collapse the copies a provider posts to more than one surface into a single
+ * finding.
+ *
+ * Qodo renders every finding twice — once in its persistent review comment and
+ * once as an addressable thread on the offending line — and the two are cleared
+ * through different APIs. Counting both made `blocking_count` roughly double
+ * the number of real findings and made every finding cost two actions to clear.
+ *
+ * A finding is resolved once EITHER copy is resolved. Both gestures are
+ * deliberate and auditable, and each copy is already scoped to what currently
+ * applies: the comment parser reads only the current review section, and
+ * outdated threads are excluded downstream. This mirrors how copies *within*
+ * the review comment have always been merged (`dedupeRenderedFindings`), so one
+ * finding behaves the same however the provider chose to render it.
+ *
+ * Priority takes the most severe copy, so a disagreement between surfaces can
+ * only ever make the gate stricter. A `null` key never merges — an unrecognised
+ * finding is counted on its own rather than folded into an unrelated one.
+ */
+export function mergeDuplicateFindings(
+  threads: readonly ReviewThread[],
+  provider: ReviewProvider,
+): ReviewThread[] {
+  const { findingKey } = provider;
+  if (findingKey === null) return [...threads];
+  const merged: ReviewThread[] = [];
+  const byKey = new Map<string, ReviewThread>();
+  for (const thread of threads) {
+    // Only the configured provider posts a finding twice, so only its own
+    // threads may merge. Without this, another reviewer's thread that happened
+    // to render a matching headline on the same file would be folded into a
+    // provider finding and stop being counted.
+    const key = isProviderAuthor(provider, thread.authorLogin)
+      ? findingKey(thread)
+      : null;
+    if (key === null) {
+      merged.push(thread);
+      continue;
+    }
+    const seen = byKey.get(key);
+    if (seen === undefined) {
+      const copy = { ...thread };
+      byKey.set(key, copy);
+      merged.push(copy);
+      continue;
+    }
+    if (thread.isResolved) seen.isResolved = true;
+    // An outdated copy does not make the finding outdated: the other surface
+    // still shows it, so it is still on screen for a reviewer to act on.
+    if (!thread.isOutdated) seen.isOutdated = false;
+    if (
+      thread.priority !== null &&
+      (seen.priority === null || thread.priority < seen.priority)
+    ) {
+      seen.priority = thread.priority;
+    }
+    // Keep whichever handles each copy contributes, so a consumer can act on
+    // the finding wherever it lives without re-deriving the other surface.
+    seen.threadId ??= thread.threadId;
+    seen.commentId ??= thread.commentId;
+    seen.line ??= thread.line;
+    seen.path ??= thread.path;
+  }
+  return merged;
+}

--- a/packages/code-review/src/providers/codex.ts
+++ b/packages/code-review/src/providers/codex.ts
@@ -22,6 +22,10 @@ export const codexProvider: ReviewProvider = {
   botAuthoredPullRequestPolicy: "skip",
   authorLogins: ["chatgpt-codex-connector"],
   parseSeverity: parseCodexSeverity,
+  // Codex posts each finding once, as an addressable thread, so there is
+  // nothing to recognise a second copy of.
+  parseFindingTitle: null,
+  findingKey: null,
   completion: { kind: "review-at-head", cleanSignal: "thumbsup-reaction" },
   detectSkip: null,
   // Codex re-reviews on push, but an explicit `@codex review` mention forces a

--- a/packages/code-review/src/providers/greptile.ts
+++ b/packages/code-review/src/providers/greptile.ts
@@ -20,6 +20,10 @@ export const greptileProvider: ReviewProvider = {
   botAuthoredPullRequestPolicy: "review",
   authorLogins: ["greptile-apps"],
   parseSeverity: parseGreptileSeverity,
+  // Greptile posts each finding once, as an addressable thread, so there is
+  // nothing to recognise a second copy of.
+  parseFindingTitle: null,
+  findingKey: null,
   completion: { kind: "check-run", namePattern: /greptile/iu },
   detectSkip: {
     marker: "<!-- greptile-status -->",

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -390,17 +390,17 @@ describe("markQodoFindingResolved", () => {
     expect(twice).toBe(once);
   });
 
-  test("marks every re-appended copy of one finding, not just the first", () => {
+  test("marks every unresolved re-appended copy of one finding", () => {
     // Qodo re-appends its whole review, so a finding routinely appears twice.
-    // The gate dedupes by identity, so leaving the other copy unmarked leaves
-    // the finding blocking — the dismissal would look applied and do nothing.
+    // The gate dedupes by identity, so every unresolved copy needs the chip;
+    // the copy Qodo already struck stays untouched.
     const body = reviewWithQuotedContext(
       ">## Issue Context",
       ">## Issue Context",
     );
     const edited = markQodoFindingResolved(body, "Stale artifact");
     if (edited === null) throw new Error("expected an edit");
-    expect([...edited.matchAll(/☑/gu)]).toHaveLength(2);
+    expect([...edited.matchAll(/☑/gu)]).toHaveLength(1);
     const findings = parseQodoIssueComment({ ...comment, body: edited });
     expect(findings).toHaveLength(1);
     expect(findings[0]?.isResolved).toBe(true);

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -368,6 +368,22 @@ describe("markQodoFindingResolved", () => {
     expect(byTitle.get("Stale wording")).toBe(false);
   });
 
+  test("chips a finding the thread surface spells with different case", () => {
+    // Verbatim from PR #2244: the review comment titled it "NUL in finding
+    // key" and the thread "Nul in finding key". A merged finding carries one
+    // of the two, so an exact match refused to chip a finding the caller had
+    // just named — the same disagreement qodoFindingKey folds case for.
+    const edited = markQodoFindingResolved(comment.body, "CONSENT CACHE");
+    if (edited === null) throw new Error("expected an edit");
+    const byTitle = new Map(
+      parseQodoIssueComment({ ...comment, body: edited }).map((finding) => [
+        finding.title,
+        finding.isResolved,
+      ]),
+    );
+    expect(byTitle.get("Consent cache")).toBe(true);
+  });
+
   test("keeps the finding's identity so re-appended copies still collapse", () => {
     // The chip form is the whole point: identityOf strips `<code>☑ …</code>`,
     // so a dismissal must not fork the finding away from the unstruck copies

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -10,6 +10,7 @@ import {
 const comment = {
   updatedAt: "2026-08-09T12:00:00Z",
   url: "https://github.com/shepherdjerred/monorepo/pull/1#issuecomment-1",
+  id: 1,
   body: `
 <h3>Code Review by Qodo</h3>
 <code>🐞 Bugs (1)</code> <code>📘 Rule violations (1)</code> <code>📎 Requirement gaps (0)</code> <code>🎨 UX issues (0)</code> <code>🔗 Cross-repo conflicts (0)</code> <code>📜 Skill insights (0)</code>
@@ -79,6 +80,8 @@ describe("qodoProvider", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc",
         priority: 1,
+        threadId: null,
+        commentId: 1,
       },
       {
         authorLogin: "qodo-code-review",
@@ -89,6 +92,8 @@ describe("qodoProvider", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-def",
         priority: 2,
+        threadId: null,
+        commentId: 1,
       },
       {
         authorLogin: "qodo-code-review",
@@ -99,6 +104,8 @@ describe("qodoProvider", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-ghi",
         priority: 2,
+        threadId: null,
+        commentId: 1,
       },
     ]);
   });
@@ -455,6 +462,8 @@ describe("qodo re-review copies", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-abc",
         priority: 1,
+        threadId: null,
+        commentId: 1,
       },
       {
         authorLogin: "qodo-code-review",
@@ -465,6 +474,8 @@ describe("qodo re-review copies", () => {
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-jkl",
         priority: 1,
+        threadId: null,
+        commentId: 1,
       },
     ]);
   });
@@ -547,6 +558,8 @@ Older unresolved wording retained for review history.
         line: null,
         url: "https://github.com/shepherdjerred/monorepo/pull/1/files#diff-current",
         priority: 2,
+        threadId: null,
+        commentId: 1,
       },
     ]);
   });

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -206,6 +206,12 @@ export const QODO_RESOLVED_CHIP = "<code>☑ resolved</code>";
  * `<!-- FOLDED_SECTION_START -->` onward is Qodo's archive of previous results,
  * which the parser excludes and an operator action must not rewrite.
  *
+ * The title is matched case-insensitively, for the same reason
+ * {@link qodoFindingKey} folds case: the two surfaces disagree on it. Qodo
+ * rendered one finding as "NUL in finding key" in this comment and "Nul in
+ * finding key" on its thread, so an exact match refused to chip a finding the
+ * caller had just identified from the merged pair.
+ *
  * Returns the edited body, or null when no finding matches — callers must not
  * silently no-op an operator's dismissal.
  */
@@ -238,7 +244,7 @@ export function markQodoFindingResolved(
     .filter(
       (candidate) =>
         /^\s*\d+\.\s+\S/u.test(candidate.summary.replaceAll(/<[^>]*>/gu, "")) &&
-        findingTitle(candidate.summary) === title,
+        findingTitle(candidate.summary).toLowerCase() === title.toLowerCase(),
     );
   if (candidates.length === 0) return null;
 

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -202,6 +202,10 @@ export const QODO_RESOLVED_CHIP = "<code>☑ resolved</code>";
  * copies Qodo re-appends on later reviews. A bare `☑` in the title would fork
  * it, leaving every earlier copy unresolved and still blocking.
  *
+ * Only the current review is touched. Everything from
+ * `<!-- FOLDED_SECTION_START -->` onward is Qodo's archive of previous results,
+ * which the parser excludes and an operator action must not rewrite.
+ *
  * Returns the edited body, or null when no finding matches — callers must not
  * silently no-op an operator's dismissal.
  */
@@ -209,17 +213,18 @@ export function markQodoFindingResolved(
   body: string,
   title: string,
 ): string | null {
-  const summaries = [
-    ...body.matchAll(/<summary>\s*\d+\.[\s\S]*?<\/summary>/giu),
-  ];
+  const foldIndex = body.indexOf(QODO_PREVIOUS_RESULTS_START);
+  const current = foldIndex === -1 ? body : body.slice(0, foldIndex);
+  const archived = foldIndex === -1 ? "" : body.slice(foldIndex);
+  const summaries = [...current.matchAll(/<summary>[\s\S]*?<\/summary>/giu)];
   const candidates = summaries
     .map((match, index) => {
       const block = match[0];
       const summary = block.slice("<summary>".length, -"</summary>".length);
       const bodyStart = match.index + block.length;
-      const nextSummary = summaries[index + 1]?.index ?? body.length;
-      const ruleIndex = body.indexOf("<hr/>", bodyStart);
-      const findingBody = body.slice(
+      const nextSummary = summaries[index + 1]?.index ?? current.length;
+      const ruleIndex = current.indexOf("<hr/>", bodyStart);
+      const findingBody = current.slice(
         bodyStart,
         ruleIndex === -1 || ruleIndex > nextSummary ? nextSummary : ruleIndex,
       );
@@ -230,7 +235,11 @@ export function markQodoFindingResolved(
         identity: findingDescription(findingBody),
       };
     })
-    .filter((candidate) => findingTitle(candidate.summary) === title);
+    .filter(
+      (candidate) =>
+        /^\s*\d+\.\s+\S/u.test(candidate.summary.replaceAll(/<[^>]*>/gu, "")) &&
+        findingTitle(candidate.summary) === title,
+    );
   if (candidates.length === 0) return null;
 
   // Qodo re-appends its whole review, so one finding routinely appears several
@@ -247,14 +256,17 @@ export function markQodoFindingResolved(
         `resolve them from the PR so the right one is chosen deliberately.`,
     );
   }
-  if (candidates.every((candidate) => candidate.block.includes("☑"))) {
+  const candidateIsResolved = (candidate: (typeof candidates)[number]) =>
+    /<s>[\s\S]*?<\/s>/iu.test(candidate.summary) ||
+    candidate.block.includes("☑");
+  if (candidates.every((candidate) => candidateIsResolved(candidate))) {
     return body;
   }
 
   // Rewrite back-to-front so each splice leaves earlier offsets valid.
-  let edited = body;
+  let edited = current;
   for (const candidate of [...candidates].reverse()) {
-    if (candidate.block.includes("☑")) continue;
+    if (candidateIsResolved(candidate)) continue;
     const chipIndex = candidate.block.indexOf("<code>");
     const insertAt =
       chipIndex === -1
@@ -269,7 +281,7 @@ export function markQodoFindingResolved(
       replacement +
       edited.slice(candidate.start + candidate.block.length);
   }
-  return edited;
+  return edited + archived;
 }
 
 /**

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -323,10 +323,19 @@ export function parseQodoFindingTitle(body: string | null): string | null {
  * The path is part of the key so two findings that happen to share a headline
  * in different files stay distinct. A finding with no title returns `null` and
  * therefore never merges.
+ *
+ * The separator is a space rather than a control character because the key is
+ * printed by `toolkit pr review list` and handed straight back as
+ * `--finding <key>`; a NUL cannot survive a process argument. Percent-escaping
+ * the path keeps that space unambiguous for the rare path that contains one,
+ * so two findings can still never collide into a single key.
  */
 export function qodoFindingKey(thread: ReviewThread): string | null {
   if (thread.title === null || thread.title === "") return null;
-  return `${thread.path ?? ""} ${thread.title.toLowerCase()}`;
+  const path = (thread.path ?? "")
+    .replaceAll("%", "%25")
+    .replaceAll(" ", "%20");
+  return `${path} ${thread.title.toLowerCase()}`;
 }
 
 function parseSeveritySection(

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -154,12 +154,17 @@ function identityOf(summary: string, findingBody: string): string {
  * The finding's headline, as a reader would see it: the summary stripped of its
  * position, its resolved styling, and its category chips. Consumers that cannot
  * re-read the comment rely on this to say what the finding is.
+ *
+ * The ordinal may arrive Markdown-escaped (`1\.`): Qodo writes the review
+ * comment as HTML but the inline thread as Markdown, where a leading `1.` would
+ * otherwise start an ordered list. Both spellings must strip to the same title,
+ * because that title is what identifies one finding across the two surfaces.
  */
 function findingTitle(summary: string): string {
   return summary
     .replaceAll(/<code>[^<]*<\/code>/giu, "")
     .replaceAll(/<[^>]*>/gu, "")
-    .replace(/^\s*\d+\.\s*/u, "")
+    .replace(/^\s*\d+\\?\.\s*/u, "")
     .replaceAll(/[☑✓]/gu, "")
     .replaceAll(/\s+/gu, " ")
     .trim();
@@ -267,10 +272,56 @@ export function markQodoFindingResolved(
   return edited;
 }
 
+/**
+ * The title Qodo renders at the top of an inline review thread.
+ *
+ * Qodo posts every finding twice — once in the persistent review comment, once
+ * as an addressable thread on the offending line — and only the comment copy
+ * carries a parsed title. Reading the thread's title is what lets the two be
+ * recognised as one finding rather than counted (and cleared) twice.
+ *
+ * The title is the first ordinal-numbered line of the body, which follows the
+ * severity badge image. Returns `null` when no such line exists, which leaves
+ * the finding unmergeable rather than guessing at its identity.
+ */
+export function parseQodoFindingTitle(body: string | null): string | null {
+  if (body === null) return null;
+  for (const line of body.split("\n")) {
+    // Locate the line by its tag-stripped text, not its raw form: Qodo wraps a
+    // resolved finding's title in `<s>`, so the raw line opens with the strike
+    // tag rather than the ordinal. Requiring the ordinal first silently found
+    // no title on exactly the findings that had been dealt with — which left
+    // them unmergeable and counted twice.
+    if (!/^\s*\d+\\?\.\s+\S/u.test(line.replaceAll(/<[^>]*>/gu, ""))) continue;
+    const title = findingTitle(line);
+    return title === "" ? null : title;
+  }
+  return null;
+}
+
+/**
+ * Identity of the underlying finding, shared by both copies Qodo posts.
+ *
+ * Case is folded because the two surfaces disagree on it: the review comment
+ * renders `joinVoice can hang forever` while the thread renders `Joinvoice can
+ * hang forever`. The ordinal is already stripped by {@link findingTitle}, which
+ * matters because the copies are numbered independently — the same finding is
+ * `3.` in the comment and `1.` on the thread.
+ *
+ * The path is part of the key so two findings that happen to share a headline
+ * in different files stay distinct. A finding with no title returns `null` and
+ * therefore never merges.
+ */
+export function qodoFindingKey(thread: ReviewThread): string | null {
+  if (thread.title === null || thread.title === "") return null;
+  return `${thread.path ?? ""} ${thread.title.toLowerCase()}`;
+}
+
 function parseSeveritySection(
   section: string,
   priority: 1 | 2 | 3,
   commentUrl: string | null,
+  commentId: number | null,
 ): RenderedFinding[] {
   const findings: RenderedFinding[] = [];
   const summaries = [
@@ -319,6 +370,10 @@ function parseSeveritySection(
         line: null,
         url: linkMatch?.[2] ?? commentUrl,
         priority,
+        // A finding parsed out of the review comment is not a thread; it is
+        // cleared by editing the comment it came from.
+        threadId: null,
+        commentId,
       },
     });
   }
@@ -550,7 +605,9 @@ export function parseQodoIssueComment(
     const priority = priorityForSection(section);
     if (priority === null) continue;
     severitySections += 1;
-    rendered.push(...parseSeveritySection(section, priority, comment.url));
+    rendered.push(
+      ...parseSeveritySection(section, priority, comment.url, comment.id),
+    );
   }
 
   // Assert against the renderings, not the deduplicated findings: the layout
@@ -585,6 +642,8 @@ export const qodoProvider: ReviewProvider = {
   botAuthoredPullRequestPolicy: "skip",
   authorLogins: QODO_AUTHOR_LOGINS,
   parseSeverity: parseQodoSeverity,
+  parseFindingTitle: parseQodoFindingTitle,
+  findingKey: qodoFindingKey,
   completion: {
     kind: "issue-comment",
     marker: QODO_REVIEW_MARKER,

--- a/packages/code-review/src/request-review.test.ts
+++ b/packages/code-review/src/request-review.test.ts
@@ -64,7 +64,7 @@ describe("requestReviewAtHead", () => {
     const posted = stubGitHub([]);
     expect(
       await requestReviewAtHead({ ...request, provider: qodoProvider }),
-    ).toBe(true);
+    ).toBe("requested");
     expect(posted).toHaveLength(1);
     expect(posted[0]?.url).toBe(
       "https://api.github.com/repos/o/r/issues/2095/comments",
@@ -80,7 +80,7 @@ describe("requestReviewAtHead", () => {
     ]);
     expect(
       await requestReviewAtHead({ ...request, provider: qodoProvider }),
-    ).toBe(false);
+    ).toBe("already-requested");
     expect(posted).toHaveLength(0);
   });
 
@@ -93,7 +93,7 @@ describe("requestReviewAtHead", () => {
     ]);
     expect(
       await requestReviewAtHead({ ...request, provider: qodoProvider }),
-    ).toBe(false);
+    ).toBe("already-requested");
     expect(posted).toHaveLength(0);
   });
 
@@ -103,7 +103,7 @@ describe("requestReviewAtHead", () => {
     ]);
     expect(
       await requestReviewAtHead({ ...request, provider: qodoProvider }),
-    ).toBe(true);
+    ).toBe("requested");
     expect(posted).toHaveLength(1);
   });
 
@@ -111,7 +111,7 @@ describe("requestReviewAtHead", () => {
     const posted = stubGitHub([]);
     expect(
       await requestReviewAtHead({ ...request, provider: greptileProvider }),
-    ).toBe(false);
+    ).toBe("unsupported");
     expect(posted).toHaveLength(0);
   });
 

--- a/packages/code-review/src/request-review.test.ts
+++ b/packages/code-review/src/request-review.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { codexProvider } from "./providers/codex.ts";
+import { greptileProvider } from "./providers/greptile.ts";
+import { qodoProvider } from "./providers/qodo.ts";
+import {
+  buildReviewRequestMarker,
+  requestReviewAtHead,
+} from "./request-review.ts";
+
+const HEAD = "ddca47f32df5f95b0fa79b96171aed94a1ce9536";
+const originalFetch = globalThis.fetch;
+
+type FetchInput = Parameters<typeof globalThis.fetch>[0];
+type FetchInit = Parameters<typeof globalThis.fetch>[1];
+
+/**
+ * A stand-in for global `fetch`. Bun's `fetch` carries a `preconnect` method
+ * alongside the call signature, so a bare function does not satisfy the type;
+ * the real one is carried over rather than asserted away.
+ */
+function fakeFetch(
+  handler: (input: FetchInput, init: FetchInit) => Promise<Response>,
+): typeof globalThis.fetch {
+  return Object.assign(handler, { preconnect: originalFetch.preconnect });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/** Record every request, answering comment reads with `comments`. */
+function stubGitHub(comments: readonly { body: string }[]) {
+  const posted: { url: string; body: unknown }[] = [];
+  globalThis.fetch = fakeFetch(async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (init?.method === "POST") {
+      const raw = typeof init.body === "string" ? init.body : "";
+      posted.push({ url, body: JSON.parse(raw) });
+      return Response.json({ id: 1 });
+    }
+    return Response.json(comments);
+  });
+  return posted;
+}
+
+describe("buildReviewRequestMarker", () => {
+  test("names the provider and the exact head", () => {
+    expect(buildReviewRequestMarker("qodo", HEAD)).toBe(
+      `<!-- review-request:qodo:${HEAD} -->`,
+    );
+  });
+
+  test("gives different heads different markers", () => {
+    expect(buildReviewRequestMarker("qodo", HEAD)).not.toBe(
+      buildReviewRequestMarker("qodo", "a".repeat(40)),
+    );
+  });
+});
+
+describe("requestReviewAtHead", () => {
+  const request = { repo: "o/r", number: 2095, head: HEAD, token: "t" };
+
+  test("asks a provider that reviews only when asked", async () => {
+    const posted = stubGitHub([]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(true);
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.url).toBe(
+      "https://api.github.com/repos/o/r/issues/2095/comments",
+    );
+    expect(posted[0]?.body).toEqual({
+      body: `/review\n\n<!-- review-request:qodo:${HEAD} -->`,
+    });
+  });
+
+  test("does not ask twice for the same head", async () => {
+    const posted = stubGitHub([
+      { body: `/review\n\n${buildReviewRequestMarker("qodo", HEAD)}` },
+    ]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(false);
+    expect(posted).toHaveLength(0);
+  });
+
+  test("recognises a request another consumer already posted", async () => {
+    // The PR-fleet controller builds its marker with the same helper, so a
+    // request it posted for this head must suppress the gate's.
+    const posted = stubGitHub([
+      { body: `something else` },
+      { body: `/review\n\n${buildReviewRequestMarker("qodo", HEAD)}\n` },
+    ]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(false);
+    expect(posted).toHaveLength(0);
+  });
+
+  test("still asks when only an older head was requested", async () => {
+    const posted = stubGitHub([
+      { body: buildReviewRequestMarker("qodo", "b".repeat(40)) },
+    ]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).toBe(true);
+    expect(posted).toHaveLength(1);
+  });
+
+  test("never asks a provider that reviews automatically", async () => {
+    const posted = stubGitHub([]);
+    expect(
+      await requestReviewAtHead({ ...request, provider: greptileProvider }),
+    ).toBe(false);
+    expect(posted).toHaveLength(0);
+  });
+
+  test("uses the configured provider's own trigger, never another's", async () => {
+    const posted = stubGitHub([]);
+    await requestReviewAtHead({ ...request, provider: codexProvider });
+    const body = posted[0]?.body;
+    expect(JSON.stringify(body)).toContain("codex");
+    expect(JSON.stringify(body)).not.toContain("qodo");
+  });
+
+  test("fails loudly when the request cannot be posted", async () => {
+    // Swallowing this would restore the behaviour this exists to remove:
+    // waiting out the whole budget for a review nobody asked for.
+    globalThis.fetch = fakeFetch(async (_input, init) =>
+      init?.method === "POST"
+        ? new Response("no", { status: 403, statusText: "Forbidden" })
+        : Response.json([]),
+    );
+    await expect(
+      requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).rejects.toThrow(/403/u);
+  });
+
+  test("fails loudly when the comment listing is not an array", async () => {
+    globalThis.fetch = fakeFetch(async () =>
+      Response.json({ message: "Not Found" }),
+    );
+    await expect(
+      requestReviewAtHead({ ...request, provider: qodoProvider }),
+    ).rejects.toThrow(/was not an array/u);
+  });
+});

--- a/packages/code-review/src/request-review.ts
+++ b/packages/code-review/src/request-review.ts
@@ -1,0 +1,87 @@
+/**
+ * Asking a provider to review the current head.
+ *
+ * Providers that review automatically declare `requestReview: null` and are
+ * never asked. Qodo does not: it reviews a PR once, when the PR is opened, and
+ * never again on its own. A gate that only polls therefore waits out its whole
+ * budget on every push after the first, then fails a PR whose diff is fine.
+ *
+ * The request is idempotent through a marker naming the provider and the exact
+ * head, so re-running a step — or a second consumer asking for the same head —
+ * cannot produce a second request comment.
+ */
+
+import { z } from "zod";
+import { GITHUB_API_URL, getJsonWithLink, postJson } from "./github-http.ts";
+import type { ReviewProvider } from "./types.ts";
+
+/** The only field of an issue comment this module reads. */
+const CommentBodySchema = z.object({ body: z.string() });
+
+/**
+ * The hidden marker that makes a review request idempotent for one head.
+ *
+ * Shared by every consumer that can trigger a review — the CI gate and the
+ * PR-fleet controller — so that two of them running against the same head
+ * recognise each other's request instead of each posting one.
+ */
+export function buildReviewRequestMarker(
+  providerId: string,
+  headSha: string,
+): string {
+  return `<!-- review-request:${providerId}:${headSha} -->`;
+}
+
+/**
+ * Ask `provider` to review `head`, unless it already has been asked.
+ *
+ * Returns whether a comment was posted. Errors propagate: a request that cannot
+ * be posted must fail the caller loudly, because silently skipping it restores
+ * exactly the behaviour this exists to remove — waiting out the full timeout
+ * for a review nobody asked for.
+ */
+export async function requestReviewAtHead(input: {
+  repo: string;
+  number: number;
+  head: string;
+  token: string;
+  provider: ReviewProvider;
+}): Promise<boolean> {
+  const strategy = input.provider.requestReview;
+  if (strategy === null) return false;
+
+  const marker = buildReviewRequestMarker(input.provider.id, input.head);
+  if (await hasComment(input, marker)) return false;
+
+  await postJson(
+    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments`,
+    { body: strategy.buildComment(marker) },
+    input.token,
+  );
+  return true;
+}
+
+/** Whether any comment on the PR already contains `marker`. */
+async function hasComment(
+  input: { repo: string; number: number; token: string },
+  marker: string,
+): Promise<boolean> {
+  let url: string | null =
+    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments?per_page=100`;
+  while (url !== null) {
+    const { payload, linkNext } = await getJsonWithLink(url, input.token);
+    if (!Array.isArray(payload)) {
+      // Reading an unexpected shape as "no marker" would post a duplicate
+      // request on every poll.
+      throw new TypeError(
+        `GitHub issue comments response for ${input.repo}#${String(input.number)} was not an array`,
+      );
+    }
+    for (const item of payload) {
+      const parsed = CommentBodySchema.safeParse(item);
+      if (parsed.success && parsed.data.body.includes(marker)) return true;
+    }
+    url = linkNext;
+  }
+  return false;
+}

--- a/packages/code-review/src/request-review.ts
+++ b/packages/code-review/src/request-review.ts
@@ -33,12 +33,26 @@ export function buildReviewRequestMarker(
 }
 
 /**
+ * What asking for a review came to.
+ *
+ * Three outcomes rather than a boolean, because "no comment was posted" covers
+ * two situations a reader has to tell apart: a provider that reviews on its own
+ * and is never asked, and a request that some run had already made. Logging
+ * both as the latter said a marker suppressed a request that was never
+ * attempted.
+ */
+export type ReviewRequestOutcome =
+  | "requested"
+  | "already-requested"
+  | "unsupported";
+
+/**
  * Ask `provider` to review `head`, unless it already has been asked.
  *
- * Returns whether a comment was posted. Errors propagate: a request that cannot
- * be posted must fail the caller loudly, because silently skipping it restores
- * exactly the behaviour this exists to remove — waiting out the full timeout
- * for a review nobody asked for.
+ * Errors propagate: a request that cannot be posted must fail the caller
+ * loudly, because silently skipping it restores exactly the behaviour this
+ * exists to remove — waiting out the full timeout for a review nobody asked
+ * for.
  */
 export async function requestReviewAtHead(input: {
   repo: string;
@@ -46,19 +60,19 @@ export async function requestReviewAtHead(input: {
   head: string;
   token: string;
   provider: ReviewProvider;
-}): Promise<boolean> {
+}): Promise<ReviewRequestOutcome> {
   const strategy = input.provider.requestReview;
-  if (strategy === null) return false;
+  if (strategy === null) return "unsupported";
 
   const marker = buildReviewRequestMarker(input.provider.id, input.head);
-  if (await hasComment(input, marker)) return false;
+  if (await hasComment(input, marker)) return "already-requested";
 
   await postJson(
     `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments`,
     { body: strategy.buildComment(marker) },
     input.token,
   );
-  return true;
+  return "requested";
 }
 
 /** Whether any comment on the PR already contains `marker`. */

--- a/packages/code-review/src/signal.test.ts
+++ b/packages/code-review/src/signal.test.ts
@@ -36,6 +36,7 @@ describe("formatSignalEvent", () => {
     timed_out: false,
     stale_reaction: false,
     decision: "failed",
+    parser_commit: "5f6d0a42b7c1e3d9a8f04b2c6e1d7a3f9b0c5e28",
   });
 
   test("emits a single structured line with the component and event fields", () => {

--- a/packages/code-review/src/signal.ts
+++ b/packages/code-review/src/signal.ts
@@ -70,6 +70,16 @@ export const ReviewSignalEventSchema = z.object({
   stale_reaction: z.boolean(),
   /** Terminal gate decision, when this event is a decision (else null). */
   decision: z.enum(["waiting", "passed", "failed"]).nullable(),
+  /**
+   * The commit of the `code-review` source that produced these counts.
+   *
+   * The parser ships with the repository, so a finding count is only meaningful
+   * alongside the version of the parser that arrived at it: the same PR read by
+   * two different parsers legitimately yields two different numbers, and
+   * without this there is no way to tell that apart from the findings actually
+   * changing. `null` when the caller cannot determine its own commit.
+   */
+  parser_commit: z.string().nullable(),
 });
 export type ReviewSignalEvent = z.infer<typeof ReviewSignalEventSchema>;
 

--- a/packages/code-review/src/types.ts
+++ b/packages/code-review/src/types.ts
@@ -50,13 +50,24 @@ export type ReviewThread = {
   url: string | null;
   priority: number | null;
   /**
-   * What the finding says, when the provider renders it somewhere a consumer
-   * cannot re-read. Threads carry their own comment bodies, but findings parsed
-   * out of a persistent issue comment do not: without this a consumer is left
-   * with a path and a diff anchor, which name a file rather than the problem.
-   * `null` for providers whose findings are addressable GitHub threads.
+   * What the finding says. Without it a consumer is left with a path and a diff
+   * anchor, which name a file rather than the problem — so it is populated for
+   * BOTH surfaces: parsed out of the persistent issue comment for findings that
+   * live there, and parsed from the first comment's body (via
+   * {@link ReviewProvider.parseFindingTitle}) for addressable GitHub threads.
+   * `null` only when the provider cannot recognise a title.
    */
   title: string | null;
+  /**
+   * GraphQL node id of the review thread, for consumers that resolve it.
+   * `null` for findings parsed out of an issue comment, which are not threads.
+   */
+  threadId: string | null;
+  /**
+   * REST id of the issue comment a finding was parsed out of, for consumers
+   * that edit it. `null` for real review threads.
+   */
+  commentId: number | null;
 };
 
 /** A provider-authored issue comment used as a review completion signal. */
@@ -64,6 +75,11 @@ export type ReviewIssueComment = {
   body: string;
   updatedAt: string | null;
   url: string | null;
+  /**
+   * REST id of the comment, carried onto every finding parsed out of it so a
+   * consumer can address the comment it must edit. `null` when unavailable.
+   */
+  id: number | null;
 };
 
 /**
@@ -160,6 +176,23 @@ export type ReviewProvider = {
   authorLogins: readonly string[];
   /** Parse the severity level (0..3) from a review comment body, or null. */
   parseSeverity: (body: string | null) => number | null;
+  /**
+   * Parse the finding's title out of a review thread's first comment body, or
+   * `null` when the provider renders no recognisable title. Findings parsed
+   * from an issue comment already carry their title; this is what lets an
+   * addressable GitHub thread carry one too, which is what makes the two
+   * surfaces comparable. `null` for providers that do not render titles.
+   */
+  parseFindingTitle: ((body: string | null) => string | null) | null;
+  /**
+   * A stable key identifying the underlying finding, used to collapse the
+   * copies a provider posts to more than one surface into a single finding.
+   *
+   * Returning `null` means "cannot identify this one", and a null key NEVER
+   * merges — an unrecognised finding is counted on its own rather than silently
+   * folded into another. `null` for providers that post each finding once.
+   */
+  findingKey: ((thread: ReviewThread) => string | null) | null;
   /** How the gate detects the provider finished reviewing the head commit. */
   completion: CompletionStrategy;
   /** How the provider signals a deliberate skip, or null if it has none. */

--- a/packages/pr-fleet-controller/src/git-operations.ts
+++ b/packages/pr-fleet-controller/src/git-operations.ts
@@ -1,6 +1,7 @@
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import type { ReviewProvider } from "@shepherdjerred/code-review";
+import { buildReviewRequestMarker } from "@shepherdjerred/code-review/request-review";
 import { z } from "zod";
 import { isTelemetryCaptureError } from "./controller-telemetry.ts";
 import { parseHeadSha, splitRepo } from "./evidence-parsers.ts";
@@ -364,7 +365,9 @@ export class GitOperations {
       return;
     }
     const { owner, name } = splitRepo(this.#repo);
-    const marker = `<!-- pr-fleet-review:${this.#provider.id}:${headSha} -->`;
+    // The same marker the CI gate uses, so whichever of the two asks first is
+    // recognised by the other and the head gets one request rather than two.
+    const marker = buildReviewRequestMarker(this.#provider.id, headSha);
     const bodies = await this.#mustRun(
       "gh",
       [

--- a/packages/pr-fleet-controller/test/parsers.test.ts
+++ b/packages/pr-fleet-controller/test/parsers.test.ts
@@ -189,6 +189,7 @@ describe("issue-comment provider findings", () => {
   const qodoComment = {
     updatedAt: "2026-08-13T05:32:39Z",
     url: "https://github.com/o/r/pull/1#issuecomment-1",
+    id: 1,
     body: `
 <h3>Code Review by Qodo</h3>
 <code>\u{1F41E} Bugs (2)</code> <code>\u{1F4D8} Rule violations (0)</code>

--- a/packages/temporal/src/activities/observe-review-signals.ts
+++ b/packages/temporal/src/activities/observe-review-signals.ts
@@ -209,6 +209,7 @@ async function buildSignalEvent(input: {
     timed_out: false,
     stale_reaction: state.staleReaction,
     decision: null,
+    parser_commit: null,
   };
 }
 

--- a/packages/temporal/src/shared/review-signals.test.ts
+++ b/packages/temporal/src/shared/review-signals.test.ts
@@ -28,6 +28,7 @@ function makeEvent(
     timed_out: false,
     stale_reaction: false,
     decision: null,
+    parser_commit: null,
     ...overrides,
   };
 }

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -256,6 +256,35 @@ exactly like the AWS CLI. Select a profile with `--profile <name>` or
 toolkit pr asset 1234 ./after.png ./flow.mp4 ./demo.cast ./demo-site --profile seaweedfs --markdown
 ```
 
+## `pr review` — see and clear provider findings
+
+`toolkit pr review list <PR>` prints every code-review finding on a PR,
+**deduplicated across the surfaces the provider posted it on**. Qodo renders
+each finding twice — once inside its persistent review comment, once as an
+addressable thread on the offending line — and the two are cleared through
+different APIs. `@shepherdjerred/code-review` merges them into one finding
+carrying both handles; this shows that, so a `blocking_count` becomes a list of
+named problems rather than a number.
+
+`toolkit pr review resolve <PR> --finding <key|title> --evidence <text>` clears
+one finding on **both** surfaces in a single step: it appends the
+`<code>☑ resolved</code>` chip to the finding in the review comment and replies
+to and resolves the review thread. `--evidence` is required — a dismissal
+without a reason is indistinguishable from silencing the finding. Chipping only
+ever edits the region above `<!-- FOLDED_SECTION_START -->`; everything below is
+Qodo's archive of previous results, which the parser excludes.
+
+`toolkit pr review harvest <PR…>` applies the stale-gate rule: a gate that
+failed, whose provider has since finished reviewing _this_ head with nothing
+blocking, is stale and passes on a re-run. It prints the `bk job retry` command
+by default and only re-runs jobs with `--retry`. The Buildkite job id comes out
+of the status URL's fragment, so the failed job is retried rather than the whole
+build.
+
+GitHub access borrows an authenticated `gh`'s token when `GH_TOKEN` is unset,
+keeping the package's no-token-setup convention; the library needs a token
+rather than the CLI because it speaks GraphQL and paginates itself.
+
 ## Shared `lib/http` + `lib/config`
 
 The Grafana, Alerts, and Bugsink service clients share one HTTP layer instead

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1001.0",
+    "@shepherdjerred/code-review": "workspace:*",
     "asciinema-player": "^3.15.1",
     "debug": "^4.4.3",
     "discord.js": "^14",

--- a/packages/toolkit/src/commands/pr/review.ts
+++ b/packages/toolkit/src/commands/pr/review.ts
@@ -143,13 +143,23 @@ export async function reviewResolveCommand(
     finding,
     evidence,
   });
-  console.log(
-    `${finding.title ?? finding.key}: ` +
-      `${outcome.chippedComment ? "chipped the review comment" : "review comment already marked"}, ` +
-      (outcome.resolvedThread
+  // Report each surface by what actually happened to it. `chippedComment` is
+  // false both when the finding has no comment to chip and when the chip was
+  // already there, and reporting those the same way tells a reader the command
+  // skipped work it never had to do.
+  const comment =
+    finding.commentId === null
+      ? "no review comment"
+      : outcome.chippedComment
+        ? "chipped the review comment"
+        : "review comment already marked";
+  const thread =
+    finding.threadId === null
+      ? "no review thread"
+      : outcome.resolvedThread
         ? "resolved the review thread"
-        : "no review thread"),
-  );
+        : "review thread already resolved";
+  console.log(`${finding.title ?? finding.key}: ${comment}, ${thread}`);
 }
 
 export async function reviewHarvestCommand(

--- a/packages/toolkit/src/commands/pr/review.ts
+++ b/packages/toolkit/src/commands/pr/review.ts
@@ -1,0 +1,208 @@
+/**
+ * `toolkit pr review` — see and clear a code-review provider's findings.
+ *
+ * The gate reports a count; this reports the findings behind it, deduplicated
+ * across the surfaces the provider posted them on, with the handles needed to
+ * act on each one.
+ */
+
+import {
+  listFindings,
+  resolveFinding,
+  reviewStateFor,
+  type Finding,
+} from "#lib/review/findings.ts";
+import { gateStatusFor, harvestVerdict } from "#lib/review/harvest.ts";
+
+export type ReviewOptions = {
+  repo?: string | undefined;
+  json?: boolean | undefined;
+  finding?: string | undefined;
+  evidence?: string | undefined;
+  all?: boolean | undefined;
+};
+
+const DEFAULT_REPO = "shepherdjerred/monorepo";
+
+/**
+ * A GitHub token for the `code-review` library.
+ *
+ * This package's convention is that GitHub access costs the caller no token
+ * setup, so the token is borrowed from an authenticated `gh` when the
+ * environment does not already supply one. The library needs a token rather
+ * than the CLI because it speaks GraphQL and paginates itself.
+ */
+function requireToken(): string {
+  const fromEnvironment = Bun.env["GH_TOKEN"];
+  if (fromEnvironment !== undefined && fromEnvironment.trim() !== "") {
+    return fromEnvironment.trim();
+  }
+  const result = Bun.spawnSync(["gh", "auth", "token"]);
+  const token = result.stdout.toString().trim();
+  if (token === "" || result.exitCode !== 0) {
+    throw new Error("No GitHub token: run `gh auth login`, or set GH_TOKEN.");
+  }
+  return token;
+}
+
+function requirePr(prNumber: string | undefined): number {
+  const parsed = Number.parseInt(prNumber ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("A pull request number is required");
+  }
+  return parsed;
+}
+
+function describe(finding: Finding): string {
+  const severity =
+    finding.priority === null ? "P?" : `P${String(finding.priority)}`;
+  const where =
+    finding.path === null
+      ? "(general)"
+      : finding.line === null
+        ? finding.path
+        : `${finding.path}:${String(finding.line)}`;
+  const surfaces = [
+    finding.commentId === null ? null : "comment",
+    finding.threadId === null ? null : "thread",
+  ]
+    .filter((surface) => surface !== null)
+    .join("+");
+  const mark = finding.isResolved ? "resolved" : "OPEN    ";
+  return `${mark}  ${severity}  ${finding.title ?? "(untitled)"}\n          ${where}  [${surfaces}]  key=${finding.key}`;
+}
+
+export async function reviewListCommand(
+  prNumber: string | undefined,
+  options: ReviewOptions = {},
+): Promise<void> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const number = requirePr(prNumber);
+  const { head, findings } = await listFindings({
+    repo,
+    number,
+    token: requireToken(),
+  });
+
+  if (options.json === true) {
+    console.log(JSON.stringify({ repo, pr: number, head, findings }, null, 2));
+    return;
+  }
+
+  const open = findings.filter((finding) => !finding.isResolved);
+  console.log(`${repo}#${String(number)} @ ${head.slice(0, 9)}`);
+  console.log(
+    `${String(findings.length)} finding(s), ${String(open.length)} unresolved\n`,
+  );
+  for (const finding of findings) console.log(describe(finding));
+}
+
+export async function reviewResolveCommand(
+  prNumber: string | undefined,
+  options: ReviewOptions = {},
+): Promise<void> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const number = requirePr(prNumber);
+  const key = options.finding;
+  const evidence = options.evidence;
+  if (key === undefined || key.trim() === "") {
+    throw new Error(
+      "--finding <key> is required (see: toolkit pr review list)",
+    );
+  }
+  // A dismissal without a reason is indistinguishable from silencing the
+  // finding, so the reason is not optional.
+  if (evidence === undefined || evidence.trim() === "") {
+    throw new Error(
+      "--evidence <text> is required: say what makes this finding resolved",
+    );
+  }
+
+  const token = requireToken();
+  const { findings } = await listFindings({ repo, number, token });
+  const matches = findings.filter(
+    (finding) => finding.key === key || finding.title === key,
+  );
+  if (matches.length === 0) {
+    throw new Error(
+      `No finding matching "${key}" on ${repo}#${String(number)}`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `"${key}" matches ${String(matches.length)} findings; use the exact key`,
+    );
+  }
+  const finding = matches[0];
+  if (finding === undefined) throw new Error("unreachable: no finding");
+
+  const outcome = await resolveFinding({
+    repo,
+    number,
+    token,
+    finding,
+    evidence,
+  });
+  console.log(
+    `${finding.title ?? finding.key}: ` +
+      `${outcome.chippedComment ? "chipped the review comment" : "review comment already marked"}, ` +
+      (outcome.resolvedThread
+        ? "resolved the review thread"
+        : "no review thread"),
+  );
+}
+
+export async function reviewHarvestCommand(
+  prNumbers: string[],
+  options: ReviewOptions = {},
+): Promise<void> {
+  const repo = options.repo ?? DEFAULT_REPO;
+  const token = requireToken();
+  const numbers = prNumbers.map((value) => requirePr(value));
+  if (numbers.length === 0) {
+    throw new Error("At least one pull request number is required");
+  }
+
+  for (const number of numbers) {
+    const { head, findings } = await listFindings({ repo, number, token });
+    const state = await reviewStateFor({ repo, number, token, head });
+    const gate = await gateStatusFor({ repo, ref: head, token });
+    const verdict = harvestVerdict({
+      gate,
+      reviewedAtHead: state.reviewedAtHead,
+      completionSignal: state.completionSignal,
+      blockingCount: findings.filter((finding) => !finding.isResolved).length,
+    });
+
+    if (!verdict.retryable) {
+      console.log(`#${String(number)}: not retryable — ${verdict.reason}`);
+      continue;
+    }
+    // Retrying is a write, so it is opt-in. Printing the command by default
+    // makes the read-only run useful rather than merely safe.
+    if (options.all !== true) {
+      console.log(
+        `#${String(number)}: retryable — bk job retry ${verdict.jobId}`,
+      );
+      continue;
+    }
+    retryBuildkiteJob(verdict.jobId);
+    console.log(`#${String(number)}: retried ${verdict.jobId}`);
+  }
+}
+
+function retryBuildkiteJob(jobId: string): void {
+  const result = Bun.spawnSync([
+    "bk",
+    "job",
+    "retry",
+    jobId,
+    "-y",
+    "--no-input",
+  ]);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `bk job retry ${jobId} failed: ${result.stderr.toString().trim()}`,
+    );
+  }
+}

--- a/packages/toolkit/src/handlers/pr.ts
+++ b/packages/toolkit/src/handlers/pr.ts
@@ -1,5 +1,10 @@
 import { parseArgs } from "node:util";
 import { assetCommand } from "#commands/pr/asset.ts";
+import {
+  reviewHarvestCommand,
+  reviewListCommand,
+  reviewResolveCommand,
+} from "#commands/pr/review.ts";
 import { detectCommand } from "#commands/pr/detect.ts";
 import { healthCommand } from "#commands/pr/health.ts";
 import { logsCommand } from "#commands/pr/logs.ts";
@@ -57,6 +62,51 @@ async function handleAsset(args: string[]): Promise<void> {
   });
 }
 
+async function handleReview(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      repo: { type: "string" },
+      json: { type: "boolean", default: false },
+      finding: { type: "string" },
+      evidence: { type: "string" },
+      retry: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+  const [action, ...rest] = positionals;
+  const options = {
+    repo: values.repo,
+    json: values.json,
+    finding: values.finding,
+    evidence: values.evidence,
+    all: values.retry,
+  };
+  // Handled before the switch rather than as a case: `process.exit` returns
+  // `never`, so a `break` there is unreachable code while its absence reads as
+  // a fallthrough.
+  if (action === undefined) {
+    console.error("Usage: toolkit pr review <list|resolve|harvest> <pr>");
+    process.exit(1);
+  }
+  switch (action) {
+    case "list":
+      await reviewListCommand(rest[0], options);
+      return;
+    case "resolve":
+      await reviewResolveCommand(rest[0], options);
+      return;
+    case "harvest":
+      await reviewHarvestCommand(rest, options);
+      return;
+    default:
+      console.error(
+        `Unknown pr review action: ${action}. Expected list, resolve, or harvest.`,
+      );
+      process.exit(1);
+  }
+}
+
 async function handleDetect(args: string[]): Promise<void> {
   const { values } = parseArgs({
     args,
@@ -91,6 +141,13 @@ Subcommands:
                              print URLs. Dirs need a root index.html; .cast
                              files get a generated HTML player page.
 
+  review list <PR>     Every provider finding, deduplicated across the
+                       surfaces it was posted on, with both handles
+  review resolve <PR>  Clear one finding on every surface at once
+                       (--finding <key|title> --evidence <text>)
+  review harvest <PR…> Report gates that failed only because the review
+                       landed late; --retry to actually re-run them
+
 Options:
   --repo <owner/repo>   Repository (default: auto-detect)
   --json                Output as JSON
@@ -100,6 +157,9 @@ Options:
                         tags for images, labeled links for video/demo/player
                         pages) instead of bare URLs
   --profile <name>      (asset) AWS profile to use (overrides AWS_PROFILE)
+  --finding <key>       (review resolve) Finding key or exact title
+  --evidence <text>     (review resolve) Why it is resolved; required
+  --retry               (review harvest) Re-run the eligible jobs
 
 Credentials (asset):
   Uses the standard AWS toolchain. Credentials, endpoint (endpoint_url), and
@@ -121,6 +181,9 @@ Credentials (asset):
       break;
     case "asset":
       await handleAsset(args);
+      break;
+    case "review":
+      await handleReview(args);
       break;
     default:
       console.error(`Unknown pr subcommand: ${subcommand}`);

--- a/packages/toolkit/src/lib/review/findings.ts
+++ b/packages/toolkit/src/lib/review/findings.ts
@@ -180,7 +180,14 @@ export async function resolveFinding(input: {
     });
   }
 
-  if (input.finding.threadId !== null) {
+  // Asking first is what makes this idempotent, and it is what `chipComment`
+  // already does by comparing the body it would write. Resolving unconditionally
+  // posted a second copy of the evidence on a thread that was already resolved,
+  // and reported "resolved the review thread" for work it had not done.
+  if (
+    input.finding.threadId !== null &&
+    !(await threadIsResolved(input.token, input.finding.threadId))
+  ) {
     await replyToThread(input.token, input.finding.threadId, input.evidence);
     await resolveThread(input.token, input.finding.threadId);
     outcome.resolvedThread = true;
@@ -227,6 +234,42 @@ async function replyToThread(
     `,
     { t: threadId, b: body },
   );
+}
+
+const ThreadStateSchema = z.object({
+  data: z.object({ node: z.object({ isResolved: z.boolean() }) }),
+});
+
+/**
+ * Whether the review thread is already resolved.
+ *
+ * Asked before resolving so the outcome the CLI prints describes what this run
+ * did. `resolveReviewThread` is idempotent and reports the state after the
+ * mutation, so it cannot answer this on its own.
+ */
+async function threadIsResolved(
+  token: string,
+  threadId: string,
+): Promise<boolean> {
+  const payload = await sendJson(
+    "POST",
+    `${GITHUB_API}/graphql`,
+    {
+      query: `
+        query ($t: ID!) {
+          node(id: $t) {
+            ... on PullRequestReviewThread {
+              isResolved
+            }
+          }
+        }
+      `,
+      variables: { t: threadId },
+    },
+    token,
+  );
+  assertGraphQlOk(payload);
+  return ThreadStateSchema.parse(payload).data.node.isResolved;
 }
 
 async function resolveThread(token: string, threadId: string): Promise<void> {

--- a/packages/toolkit/src/lib/review/findings.ts
+++ b/packages/toolkit/src/lib/review/findings.ts
@@ -110,15 +110,32 @@ export async function reviewStateFor(input: {
   };
 }
 
+/**
+ * A key for a finding the provider cannot identify.
+ *
+ * `resolve` re-lists the findings before matching the key it was given, so a
+ * purely positional key names whatever finding happens to be in that slot the
+ * second time — a reordered list would clear the wrong thread. A GitHub node id
+ * names one exact surface forever, so it is preferred wherever one exists.
+ *
+ * Two unidentifiable findings inside the same review comment do collapse to the
+ * same key, and that is the safe direction: `resolve` refuses an ambiguous key
+ * rather than picking one. The positional last resort is reached only by a
+ * finding with neither handle, which `resolveFinding` cannot act on at all.
+ */
+export function fallbackKey(thread: ReviewThread, index: number): string {
+  if (thread.threadId !== null) return `thread:${thread.threadId}`;
+  if (thread.commentId !== null) return `comment:${String(thread.commentId)}`;
+  return `#${String(index + 1)}`;
+}
+
 function toFinding(
   thread: ReviewThread,
   provider: ReviewProvider,
   index: number,
 ): Finding {
   return {
-    // Fall back to a positional key only when the provider cannot identify the
-    // finding, so an unrecognised one is still addressable rather than absent.
-    key: provider.findingKey?.(thread) ?? `#${String(index + 1)}`,
+    key: provider.findingKey?.(thread) ?? fallbackKey(thread, index),
     title: thread.title,
     priority: thread.priority,
     path: thread.path,

--- a/packages/toolkit/src/lib/review/findings.ts
+++ b/packages/toolkit/src/lib/review/findings.ts
@@ -1,0 +1,299 @@
+/**
+ * Reading and clearing a code-review provider's findings on a pull request.
+ *
+ * A provider may render the same finding on more than one surface — Qodo posts
+ * each one both inside its persistent review comment and as an addressable
+ * thread on the offending line — and each surface is cleared through a
+ * different API. `@shepherdjerred/code-review` already merges them into one
+ * finding carrying both handles; this turns that into something a person can
+ * act on in a single step.
+ */
+
+import {
+  isProviderAuthor,
+  resolveRequiredReviewProvider,
+  type ReviewProvider,
+  type ReviewThread,
+} from "@shepherdjerred/code-review";
+import {
+  fetchReviewThreads,
+  resolveReviewState,
+} from "@shepherdjerred/code-review/github";
+import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
+import { markQodoFindingResolved } from "@shepherdjerred/code-review/qodo";
+import { z } from "zod";
+
+const GITHUB_API = "https://api.github.com";
+
+const PrHeadSchema = z.object({ head: z.object({ sha: z.string() }) });
+const CommentSchema = z.object({ id: z.number(), body: z.string() });
+
+export type Finding = {
+  key: string;
+  title: string | null;
+  priority: number | null;
+  path: string | null;
+  line: number | null;
+  isResolved: boolean;
+  threadId: string | null;
+  commentId: number | null;
+  url: string | null;
+};
+
+/** Every provider finding on the PR, deduplicated across surfaces. */
+export async function listFindings(input: {
+  repo: string;
+  number: number;
+  token: string;
+  provider?: ReviewProvider;
+}): Promise<{ head: string; findings: Finding[] }> {
+  const provider = input.provider ?? resolveRequiredReviewProvider();
+  const head = await fetchHeadSha(input);
+  const state = await resolveReviewState({
+    provider,
+    repo: input.repo,
+    head,
+    prNumber: input.number,
+    token: input.token,
+    headPushedAt: await fetchHeadPushedAt({
+      repo: input.repo,
+      sha: head,
+      prNumber: input.number,
+      token: input.token,
+    }),
+  });
+  const { threads } = await fetchReviewThreads({
+    repo: input.repo,
+    number: input.number,
+    token: input.token,
+    provider,
+    issueComment: state.issueComment,
+  });
+  const findings = threads
+    .filter(
+      (thread) =>
+        isProviderAuthor(provider, thread.authorLogin) && !thread.isOutdated,
+    )
+    .map((thread, index) => toFinding(thread, provider, index));
+  return { head, findings };
+}
+
+/**
+ * Whether the provider has finished reviewing this exact head, and how it said
+ * so. The harvest rule needs both: a gate that failed while the review was
+ * still running is stale, one that failed with no review at all is not.
+ */
+export async function reviewStateFor(input: {
+  repo: string;
+  number: number;
+  token: string;
+  head: string;
+  provider?: ReviewProvider;
+}): Promise<{ reviewedAtHead: boolean; completionSignal: string }> {
+  const provider = input.provider ?? resolveRequiredReviewProvider();
+  const state = await resolveReviewState({
+    provider,
+    repo: input.repo,
+    head: input.head,
+    prNumber: input.number,
+    token: input.token,
+    headPushedAt: await fetchHeadPushedAt({
+      repo: input.repo,
+      sha: input.head,
+      prNumber: input.number,
+      token: input.token,
+    }),
+  });
+  return {
+    reviewedAtHead: state.reviewedCommit === input.head,
+    completionSignal: state.completionSignal,
+  };
+}
+
+function toFinding(
+  thread: ReviewThread,
+  provider: ReviewProvider,
+  index: number,
+): Finding {
+  return {
+    // Fall back to a positional key only when the provider cannot identify the
+    // finding, so an unrecognised one is still addressable rather than absent.
+    key: provider.findingKey?.(thread) ?? `#${String(index + 1)}`,
+    title: thread.title,
+    priority: thread.priority,
+    path: thread.path,
+    line: thread.line,
+    isResolved: thread.isResolved,
+    threadId: thread.threadId,
+    commentId: thread.commentId,
+    url: thread.url,
+  };
+}
+
+export type ResolveOutcome = {
+  chippedComment: boolean;
+  resolvedThread: boolean;
+};
+
+/**
+ * Clear one finding on every surface it appears on.
+ *
+ * Both surfaces are cleared even though the gate now treats either as
+ * sufficient: leaving one behind means the next reader still sees the finding
+ * open, and the point of this command is that a finding is one thing.
+ */
+export async function resolveFinding(input: {
+  repo: string;
+  number: number;
+  token: string;
+  finding: Finding;
+  evidence: string;
+}): Promise<ResolveOutcome> {
+  const outcome: ResolveOutcome = {
+    chippedComment: false,
+    resolvedThread: false,
+  };
+
+  if (input.finding.commentId !== null && input.finding.title !== null) {
+    outcome.chippedComment = await chipComment({
+      repo: input.repo,
+      token: input.token,
+      commentId: input.finding.commentId,
+      title: input.finding.title,
+    });
+  }
+
+  if (input.finding.threadId !== null) {
+    await replyToThread(input.token, input.finding.threadId, input.evidence);
+    await resolveThread(input.token, input.finding.threadId);
+    outcome.resolvedThread = true;
+  }
+
+  return outcome;
+}
+
+/** Append the resolved chip to a finding in the provider's review comment. */
+async function chipComment(input: {
+  repo: string;
+  token: string;
+  commentId: number;
+  title: string;
+}): Promise<boolean> {
+  const url = `${GITHUB_API}/repos/${input.repo}/issues/comments/${String(input.commentId)}`;
+  const current = CommentSchema.parse(await getJson(url, input.token));
+  const marked = markQodoFindingResolved(current.body, input.title);
+  if (marked === null) {
+    throw new Error(
+      `No finding titled "${input.title}" in comment ${String(input.commentId)}`,
+    );
+  }
+  if (marked === current.body) return false;
+  await sendJson("PATCH", url, { body: marked }, input.token);
+  return true;
+}
+
+async function replyToThread(
+  token: string,
+  threadId: string,
+  body: string,
+): Promise<void> {
+  await graphql(
+    token,
+    `
+      mutation ($t: ID!, $b: String!) {
+        addPullRequestReviewThreadReply(
+          input: { pullRequestReviewThreadId: $t, body: $b }
+        ) {
+          clientMutationId
+        }
+      }
+    `,
+    { t: threadId, b: body },
+  );
+}
+
+async function resolveThread(token: string, threadId: string): Promise<void> {
+  await graphql(
+    token,
+    `
+      mutation ($t: ID!) {
+        resolveReviewThread(input: { threadId: $t }) {
+          thread {
+            isResolved
+          }
+        }
+      }
+    `,
+    { t: threadId },
+  );
+}
+
+async function fetchHeadSha(input: {
+  repo: string;
+  number: number;
+  token: string;
+}): Promise<string> {
+  const payload = await getJson(
+    `${GITHUB_API}/repos/${input.repo}/pulls/${String(input.number)}`,
+    input.token,
+  );
+  return PrHeadSchema.parse(payload).head.sha;
+}
+
+function headers(token: string): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function getJson(url: string, token: string): Promise<unknown> {
+  const response = await fetch(url, { headers: headers(token) });
+  if (!response.ok) {
+    throw new Error(
+      `GET ${url} failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+async function sendJson(
+  method: string,
+  url: string,
+  body: unknown,
+  token: string,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method,
+    headers: { ...headers(token), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${url} failed: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+const GraphQlSchema = z.object({ errors: z.unknown().optional() });
+
+async function graphql(
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<void> {
+  const payload = await sendJson(
+    "POST",
+    `${GITHUB_API}/graphql`,
+    { query, variables },
+    token,
+  );
+  const parsed = GraphQlSchema.safeParse(payload);
+  if (parsed.success && parsed.data.errors !== undefined) {
+    throw new Error(
+      `GitHub GraphQL errors: ${JSON.stringify(parsed.data.errors)}`,
+    );
+  }
+}

--- a/packages/toolkit/src/lib/review/findings.ts
+++ b/packages/toolkit/src/lib/review/findings.ts
@@ -294,23 +294,36 @@ async function sendJson(
   return response.json();
 }
 
-const GraphQlSchema = z.object({ errors: z.unknown().optional() });
+const GraphQlSchema = z.object({ errors: z.array(z.unknown()).optional() });
+
+/**
+ * Throw unless the payload says the mutation succeeded.
+ *
+ * GraphQL answers 200 with an `errors` array, so the HTTP status proves
+ * nothing. A payload this cannot read is not a success either: `resolveFinding`
+ * reports `resolvedThread` from the mere absence of a throw, and the CLI prints
+ * "resolved the review thread" from that — so swallowing an unreadable response
+ * told an operator a finding was cleared when the outcome was unknown, and left
+ * it blocking the gate.
+ */
+export function assertGraphQlOk(payload: unknown): void {
+  const parsed = GraphQlSchema.parse(payload);
+  if (parsed.errors !== undefined && parsed.errors.length > 0) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(parsed.errors)}`);
+  }
+}
 
 async function graphql(
   token: string,
   query: string,
   variables: Record<string, unknown>,
 ): Promise<void> {
-  const payload = await sendJson(
-    "POST",
-    `${GITHUB_API}/graphql`,
-    { query, variables },
-    token,
+  assertGraphQlOk(
+    await sendJson(
+      "POST",
+      `${GITHUB_API}/graphql`,
+      { query, variables },
+      token,
+    ),
   );
-  const parsed = GraphQlSchema.safeParse(payload);
-  if (parsed.success && parsed.data.errors !== undefined) {
-    throw new Error(
-      `GitHub GraphQL errors: ${JSON.stringify(parsed.data.errors)}`,
-    );
-  }
 }

--- a/packages/toolkit/src/lib/review/harvest.ts
+++ b/packages/toolkit/src/lib/review/harvest.ts
@@ -1,0 +1,119 @@
+/**
+ * Finding review gates that failed for a reason that has since gone away.
+ *
+ * The gate fails when its deadline expires before the provider's review lands.
+ * If the review arrives afterwards and carries nothing blocking, the job is
+ * simply stale: re-running it passes without a single change to the PR. That
+ * rule is fully decidable, and re-deciding it by hand on every stuck PR is how
+ * it was applied before this existed.
+ */
+
+import { z } from "zod";
+
+const GITHUB_API = "https://api.github.com";
+
+export const GATE_CONTEXT =
+  "buildkite/monorepo/pr/robot-face-qodo-review-gate-required";
+
+const StatusSchema = z.object({
+  state: z.string(),
+  statuses: z.array(
+    z.object({
+      context: z.string(),
+      state: z.string(),
+      target_url: z.string().nullable(),
+    }),
+  ),
+});
+
+export type GateStatus = {
+  state: string;
+  targetUrl: string | null;
+};
+
+/**
+ * The Buildkite job id a gate status points at.
+ *
+ * Buildkite writes the job into the URL fragment (`…/builds/9633#<uuid>`), so
+ * retrying the failed job — rather than rebuilding everything — means reading
+ * it back out of there.
+ */
+export function jobIdFromTargetUrl(targetUrl: string | null): string | null {
+  if (targetUrl === null) return null;
+  const fragment = targetUrl.split("#")[1];
+  if (fragment === undefined || fragment === "") return null;
+  return /^[0-9a-f-]{36}$/iu.test(fragment) ? fragment : null;
+}
+
+/** The review gate's status for a commit, or null when it posted none. */
+export async function gateStatusFor(input: {
+  repo: string;
+  ref: string;
+  token: string;
+  context?: string;
+}): Promise<GateStatus | null> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.repo}/commits/${input.ref}/status?per_page=100`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${input.token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Could not read status for ${input.repo}@${input.ref}: ` +
+        `${String(response.status)} ${response.statusText}`,
+    );
+  }
+  const parsed = StatusSchema.parse(await response.json());
+  const context = input.context ?? GATE_CONTEXT;
+  const gate = parsed.statuses.find((status) => status.context === context);
+  return gate === undefined
+    ? null
+    : { state: gate.state, targetUrl: gate.target_url };
+}
+
+export type HarvestVerdict =
+  | { retryable: true; jobId: string }
+  | { retryable: false; reason: string };
+
+/**
+ * Whether a failed gate is stale rather than correct.
+ *
+ * Every condition has to hold: the gate failed, the review that exists is for
+ * the commit the gate judged, the provider actually finished, and nothing it
+ * found blocks. Retrying on any weaker rule re-runs a job that will fail again,
+ * which reads as flakiness rather than as the gate doing its job.
+ */
+export function harvestVerdict(input: {
+  gate: GateStatus | null;
+  reviewedAtHead: boolean;
+  completionSignal: string;
+  blockingCount: number;
+}): HarvestVerdict {
+  if (input.gate === null)
+    return { retryable: false, reason: "no gate status" };
+  if (input.gate.state !== "failure") {
+    return { retryable: false, reason: `gate is ${input.gate.state}` };
+  }
+  if (!input.reviewedAtHead) {
+    return { retryable: false, reason: "no review for this head yet" };
+  }
+  if (input.completionSignal === "none") {
+    return { retryable: false, reason: "provider has not finished reviewing" };
+  }
+  if (input.blockingCount > 0) {
+    return {
+      retryable: false,
+      reason: `${String(input.blockingCount)} blocking finding(s) remain`,
+    };
+  }
+  const jobId = jobIdFromTargetUrl(input.gate.targetUrl);
+  if (jobId === null) {
+    return { retryable: false, reason: "gate status names no Buildkite job" };
+  }
+  return { retryable: true, jobId };
+}

--- a/packages/toolkit/src/lib/review/harvest.ts
+++ b/packages/toolkit/src/lib/review/harvest.ts
@@ -45,35 +45,56 @@ export function jobIdFromTargetUrl(targetUrl: string | null): string | null {
   return /^[0-9a-f-]{36}$/iu.test(fragment) ? fragment : null;
 }
 
-/** The review gate's status for a commit, or null when it posted none. */
+/** The `rel="next"` URL of a GitHub `Link` header, or null on the last page. */
+export function nextPageUrl(link: string | null): string | null {
+  if (link === null) return null;
+  for (const part of link.split(",")) {
+    const match = /<([^>]+)>\s*;\s*rel="next"/u.exec(part);
+    if (match?.[1] !== undefined) return match[1];
+  }
+  return null;
+}
+
+/**
+ * The review gate's status for a commit, or null when it posted none.
+ *
+ * The commit-status list is paginated, and `null` here is read by
+ * `harvestVerdict` as "this PR has no gate to retry". Stopping at the first
+ * page would turn a gate that merely sorted onto a later page into that answer
+ * — a stale gate reported as nothing to do, which is the one outcome this
+ * module exists to prevent. So every page is read before answering `null`.
+ */
 export async function gateStatusFor(input: {
   repo: string;
   ref: string;
   token: string;
   context?: string;
 }): Promise<GateStatus | null> {
-  const response = await fetch(
-    `${GITHUB_API}/repos/${input.repo}/commits/${input.ref}/status?per_page=100`,
-    {
+  const context = input.context ?? GATE_CONTEXT;
+  let url: string | null =
+    `${GITHUB_API}/repos/${input.repo}/commits/${input.ref}/status?per_page=100`;
+  while (url !== null) {
+    const response = await fetch(url, {
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${input.token}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
-    },
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Could not read status for ${input.repo}@${input.ref}: ` +
-        `${String(response.status)} ${response.statusText}`,
-    );
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Could not read status for ${input.repo}@${input.ref}: ` +
+          `${String(response.status)} ${response.statusText}`,
+      );
+    }
+    const parsed = StatusSchema.parse(await response.json());
+    const gate = parsed.statuses.find((status) => status.context === context);
+    if (gate !== undefined) {
+      return { state: gate.state, targetUrl: gate.target_url };
+    }
+    url = nextPageUrl(response.headers.get("link"));
   }
-  const parsed = StatusSchema.parse(await response.json());
-  const context = input.context ?? GATE_CONTEXT;
-  const gate = parsed.statuses.find((status) => status.context === context);
-  return gate === undefined
-    ? null
-    : { state: gate.state, targetUrl: gate.target_url };
+  return null;
 }
 
 export type HarvestVerdict =

--- a/packages/toolkit/src/lib/review/harvest.ts
+++ b/packages/toolkit/src/lib/review/harvest.ts
@@ -42,7 +42,14 @@ export function jobIdFromTargetUrl(targetUrl: string | null): string | null {
   if (targetUrl === null) return null;
   const fragment = targetUrl.split("#")[1];
   if (fragment === undefined || fragment === "") return null;
-  return /^[0-9a-f-]{36}$/iu.test(fragment) ? fragment : null;
+  // Matched as a UUID rather than as 36 hex-or-hyphen characters: the loose
+  // form accepted strings like 36 hyphens, and every non-null id here is
+  // reported as retryable and handed to `bk job retry`.
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
+    fragment,
+  )
+    ? fragment
+    : null;
 }
 
 /** The `rel="next"` URL of a GitHub `Link` header, or null on the last page. */

--- a/packages/toolkit/test/lib/review-findings.test.ts
+++ b/packages/toolkit/test/lib/review-findings.test.ts
@@ -1,6 +1,6 @@
 import type { ReviewThread } from "@shepherdjerred/code-review";
 import { describe, expect, test } from "bun:test";
-import { fallbackKey } from "#lib/review/findings.ts";
+import { assertGraphQlOk, fallbackKey } from "#lib/review/findings.ts";
 
 const thread: ReviewThread = {
   authorLogin: "qodo-code-review",
@@ -14,6 +14,36 @@ const thread: ReviewThread = {
   threadId: null,
   commentId: null,
 };
+
+describe("assertGraphQlOk", () => {
+  test("accepts a mutation that reported no errors", () => {
+    expect(() => {
+      assertGraphQlOk({
+        data: { resolveReviewThread: { thread: { id: "1" } } },
+      });
+    }).not.toThrow();
+    expect(() => {
+      assertGraphQlOk({ data: {}, errors: [] });
+    }).not.toThrow();
+  });
+
+  test("throws on the errors GraphQL returns alongside a 200", () => {
+    expect(() => {
+      assertGraphQlOk({ errors: [{ message: "Resource not accessible" }] });
+    }).toThrow("Resource not accessible");
+  });
+
+  test("throws on a payload it cannot read rather than calling it a success", () => {
+    // The caller reports the thread resolved from the absence of a throw, so
+    // an unreadable response must not pass for one.
+    expect(() => {
+      assertGraphQlOk("<html>502 Bad Gateway</html>");
+    }).toThrow();
+    expect(() => {
+      assertGraphQlOk({ errors: "boom" });
+    }).toThrow();
+  });
+});
 
 describe("fallbackKey", () => {
   test("names the thread, so the key survives a reordered list", () => {

--- a/packages/toolkit/test/lib/review-findings.test.ts
+++ b/packages/toolkit/test/lib/review-findings.test.ts
@@ -1,0 +1,50 @@
+import type { ReviewThread } from "@shepherdjerred/code-review";
+import { describe, expect, test } from "bun:test";
+import { fallbackKey } from "#lib/review/findings.ts";
+
+const thread: ReviewThread = {
+  authorLogin: "qodo-code-review",
+  isResolved: false,
+  isOutdated: false,
+  path: null,
+  line: null,
+  url: null,
+  priority: 1,
+  title: null,
+  threadId: null,
+  commentId: null,
+};
+
+describe("fallbackKey", () => {
+  test("names the thread, so the key survives a reordered list", () => {
+    // `resolve` re-lists the findings before matching, so a positional key
+    // pointed at whatever landed in that slot the second time.
+    expect(fallbackKey({ ...thread, threadId: "PRRT_kwDO1" }, 0)).toBe(
+      fallbackKey({ ...thread, threadId: "PRRT_kwDO1" }, 7),
+    );
+    expect(fallbackKey({ ...thread, threadId: "PRRT_kwDO1" }, 0)).not.toBe(
+      fallbackKey({ ...thread, threadId: "PRRT_kwDO2" }, 0),
+    );
+  });
+
+  test("prefers the thread id over the comment it also appears in", () => {
+    expect(
+      fallbackKey(
+        { ...thread, threadId: "PRRT_kwDO1", commentId: 5_309_425_861 },
+        0,
+      ),
+    ).toBe("thread:PRRT_kwDO1");
+  });
+
+  test("names the comment when that is the only handle", () => {
+    expect(fallbackKey({ ...thread, commentId: 5_309_425_861 }, 3)).toBe(
+      "comment:5309425861",
+    );
+  });
+
+  test("falls back to a position only for a finding with no surface at all", () => {
+    // Nothing can be cleared on such a finding, so an unstable key cannot
+    // clear the wrong one.
+    expect(fallbackKey(thread, 3)).toBe("#4");
+  });
+});

--- a/packages/toolkit/test/lib/review-harvest.test.ts
+++ b/packages/toolkit/test/lib/review-harvest.test.ts
@@ -27,6 +27,14 @@ describe("jobIdFromTargetUrl", () => {
 
   test("rejects a fragment that is not a job id", () => {
     expect(jobIdFromTargetUrl("https://buildkite.com/x#not-a-uuid")).toBeNull();
+    // 36 characters of hex and hyphens, but not a UUID. Anything non-null here
+    // is reported as retryable and handed to `bk job retry`.
+    expect(
+      jobIdFromTargetUrl(`https://buildkite.com/x#${"-".repeat(36)}`),
+    ).toBeNull();
+    expect(
+      jobIdFromTargetUrl(`https://buildkite.com/x#${"a".repeat(36)}`),
+    ).toBeNull();
     expect(jobIdFromTargetUrl(null)).toBeNull();
   });
 });

--- a/packages/toolkit/test/lib/review-harvest.test.ts
+++ b/packages/toolkit/test/lib/review-harvest.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+  harvestVerdict,
+  jobIdFromTargetUrl,
+  type GateStatus,
+} from "#lib/review/harvest.ts";
+
+const JOB = "01a00a5b-1c30-4310-8a10-20ddaaddca65";
+const failed: GateStatus = {
+  state: "failure",
+  targetUrl: `https://buildkite.com/sjerred/monorepo/builds/9633#${JOB}`,
+};
+
+describe("jobIdFromTargetUrl", () => {
+  test("reads the job out of the URL fragment", () => {
+    expect(jobIdFromTargetUrl(failed.targetUrl)).toBe(JOB);
+  });
+
+  test("returns null when the status names only a build", () => {
+    // Retrying the whole build instead of the job would re-run every step,
+    // so a URL without a job must not be treated as retryable.
+    expect(
+      jobIdFromTargetUrl("https://buildkite.com/sjerred/monorepo/builds/9633"),
+    ).toBeNull();
+  });
+
+  test("rejects a fragment that is not a job id", () => {
+    expect(jobIdFromTargetUrl("https://buildkite.com/x#not-a-uuid")).toBeNull();
+    expect(jobIdFromTargetUrl(null)).toBeNull();
+  });
+});
+
+describe("harvestVerdict", () => {
+  const stale = {
+    gate: failed,
+    reviewedAtHead: true,
+    completionSignal: "issue-comment",
+    blockingCount: 0,
+  };
+
+  test("retries a gate that expired before a clean review landed", () => {
+    expect(harvestVerdict(stale)).toEqual({ retryable: true, jobId: JOB });
+  });
+
+  test("leaves a gate that failed on real findings alone", () => {
+    // This is the case a looser rule would re-run forever: the job fails
+    // again, and a genuine finding starts to look like flakiness.
+    const verdict = harvestVerdict({ ...stale, blockingCount: 2 });
+    expect(verdict.retryable).toBe(false);
+    expect(verdict).toMatchObject({ reason: "2 blocking finding(s) remain" });
+  });
+
+  test("waits when the review is for an older commit", () => {
+    const verdict = harvestVerdict({ ...stale, reviewedAtHead: false });
+    expect(verdict).toEqual({
+      retryable: false,
+      reason: "no review for this head yet",
+    });
+  });
+
+  test("waits when the provider has not finished", () => {
+    const verdict = harvestVerdict({ ...stale, completionSignal: "none" });
+    expect(verdict).toEqual({
+      retryable: false,
+      reason: "provider has not finished reviewing",
+    });
+  });
+
+  test("does nothing to a gate that is not failing", () => {
+    for (const state of ["success", "pending", "error"]) {
+      expect(harvestVerdict({ ...stale, gate: { ...failed, state } })).toEqual({
+        retryable: false,
+        reason: `gate is ${state}`,
+      });
+    }
+  });
+
+  test("does nothing when there is no gate at all", () => {
+    expect(harvestVerdict({ ...stale, gate: null })).toEqual({
+      retryable: false,
+      reason: "no gate status",
+    });
+  });
+
+  test("does not retry when the status names no job", () => {
+    const verdict = harvestVerdict({
+      ...stale,
+      gate: { state: "failure", targetUrl: null },
+    });
+    expect(verdict).toEqual({
+      retryable: false,
+      reason: "gate status names no Buildkite job",
+    });
+  });
+});

--- a/packages/toolkit/test/lib/review-harvest.test.ts
+++ b/packages/toolkit/test/lib/review-harvest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   harvestVerdict,
   jobIdFromTargetUrl,
+  nextPageUrl,
   type GateStatus,
 } from "#lib/review/harvest.ts";
 
@@ -91,5 +92,29 @@ describe("harvestVerdict", () => {
       retryable: false,
       reason: "gate status names no Buildkite job",
     });
+  });
+});
+
+describe("nextPageUrl", () => {
+  test("follows the next link when the statuses span pages", () => {
+    expect(
+      nextPageUrl(
+        '<https://api.github.com/repositories/1/commits/abc/status?page=2>; rel="next", ' +
+          '<https://api.github.com/repositories/1/commits/abc/status?page=9>; rel="last"',
+      ),
+    ).toBe("https://api.github.com/repositories/1/commits/abc/status?page=2");
+  });
+
+  test("stops on the last page, which carries prev and first but no next", () => {
+    expect(
+      nextPageUrl(
+        '<https://api.github.com/repositories/1/commits/abc/status?page=8>; rel="prev", ' +
+          '<https://api.github.com/repositories/1/commits/abc/status?page=1>; rel="first"',
+      ),
+    ).toBeNull();
+  });
+
+  test("stops when the response carries no Link header at all", () => {
+    expect(nextPageUrl(null)).toBeNull();
   });
 });

--- a/scripts/probe-review-signal.ts
+++ b/scripts/probe-review-signal.ts
@@ -149,6 +149,10 @@ async function probePr(
     timed_out: false,
     stale_reaction: state.staleReaction,
     decision: null,
+    // Which parser produced these counts. A probe run from a stale checkout
+    // reads the repository's stale parser and reports numbers that disagree
+    // with CI for reasons that have nothing to do with the PR.
+    parser_commit: parserCommit(),
   };
 
   console.log(
@@ -182,6 +186,22 @@ async function probePr(
       2,
     ),
   );
+}
+
+/**
+ * The commit this probe's copy of `code-review` came from.
+ *
+ * The probe imports the parser from the checkout it runs in, so its numbers
+ * describe that checkout's parser rather than CI's. Reporting the commit is
+ * what lets a caller see a disagreement for what it is.
+ */
+function parserCommit(): string | null {
+  const result = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
+    cwd: import.meta.dir,
+  });
+  if (result.exitCode !== 0) return null;
+  const sha = result.stdout.toString().trim();
+  return sha === "" ? null : sha;
 }
 
 async function main(): Promise<void> {

--- a/scripts/probe-review-signal.ts
+++ b/scripts/probe-review-signal.ts
@@ -164,12 +164,17 @@ async function probePr(
             priority: thread.priority,
             isResolved: thread.isResolved,
             isOutdated: thread.isOutdated,
-            // Title and url make the dump readable on its own; without them a
-            // probe of a blocked PR says only which files were complained about.
+            // What the finding says, plus the handles needed to act on it and
+            // the key it was deduplicated by. Without these a caller has a
+            // count and a filename, and has to re-derive everything else by
+            // hand from the raw GitHub payloads.
             title: thread.title,
             path: thread.path,
             line: thread.line,
             url: thread.url,
+            threadId: thread.threadId,
+            commentId: thread.commentId,
+            findingKey: provider.findingKey?.(thread) ?? null,
           })),
         },
       },

--- a/scripts/review-findings.test.ts
+++ b/scripts/review-findings.test.ts
@@ -53,6 +53,8 @@ describe("describeFinding", () => {
       url: "https://github.com/o/r/pull/1#issuecomment-2",
       priority: 1,
       title: "S3 fetch lacks timeout",
+      threadId: null,
+      commentId: null,
     });
     expect(line).toContain("P1");
     expect(line).toContain("S3 fetch lacks timeout");
@@ -69,6 +71,8 @@ describe("describeFinding", () => {
       url: null,
       priority: 2,
       title: null,
+      threadId: null,
+      commentId: null,
     });
     expect(line).toContain("P2 src/x.ts:42");
     expect(line).not.toContain("untitled");

--- a/scripts/script-migrations.json
+++ b/scripts/script-migrations.json
@@ -153,6 +153,11 @@
       ]
     },
     {
+      "source": ".buildkite/scripts/review-gate.sh",
+      "disposition": "retain",
+      "reason": "Buildkite wrapper selects and checks out the trusted parser source before installing Bun"
+    },
+    {
       "source": ".buildkite/scripts/toolchain.sh",
       "disposition": "retain",
       "reason": "Sourced bootstrap installs Bun and exports into the parent shell"

--- a/scripts/wait-for-review.test.ts
+++ b/scripts/wait-for-review.test.ts
@@ -53,6 +53,27 @@ export function reviewGateStepTimeoutSeconds(pipeline: string): number {
   throw new Error("pipeline.yml has no review-gate step");
 }
 
+/** The `review-gate` step's command block, as its lines. */
+export function reviewGateStepCommand(pipeline: string): string[] {
+  const lines = pipeline.split("\n");
+  const starts = lines.flatMap((line, index) =>
+    line.startsWith("  - label:") ? [index] : [],
+  );
+  for (const [position, start] of starts.entries()) {
+    const block = lines.slice(start, starts[position + 1] ?? lines.length);
+    if (!block.some((line) => line.trim() === "key: review-gate")) continue;
+    const commandAt = block.findIndex((line) => line.trim() === "command: |");
+    if (commandAt === -1) throw new Error("review-gate declares no command");
+    const body: string[] = [];
+    for (const line of block.slice(commandAt + 1)) {
+      if (line.trim() !== "" && !line.startsWith("      ")) break;
+      body.push(line.trim());
+    }
+    return body.filter((line) => line !== "");
+  }
+  throw new Error("pipeline.yml has no review-gate step");
+}
+
 /**
  * How long the step spends on `toolchain.sh` and the filtered install before
  * wait-for-review.ts starts counting. Nothing bounds that preamble — a cold or
@@ -109,5 +130,35 @@ describe("review gate timeout budget", () => {
     // the 1200s budget had already failed the gate.
     const slowestCompleted = 1834;
     expect(DEFAULT_TIMEOUT_SECONDS).toBeGreaterThan(slowestCompleted);
+  });
+});
+
+// The gate reads only GitHub state, never the PR's diff, so running it from the
+// PR's checkout buys nothing and costs correctness: `code-review` is a
+// workspace dependency, so the branch supplied its own grader. PR #1389 read 0
+// blocking findings against current main and 3 against its own 22-commit-stale
+// parser, and no change to that PR could have cleared it.
+describe("review gate source", () => {
+  test("does not run the pull request's own copy of the gate", async () => {
+    const pipeline = await Bun.file(
+      `${import.meta.dir}/../.buildkite/pipeline.yml`,
+    ).text();
+    const command = reviewGateStepCommand(pipeline);
+    expect(command).not.toContain(
+      "bun --no-install scripts/wait-for-review.ts",
+    );
+    expect(command.some((line) => line.includes("review-gate.sh"))).toBe(true);
+  });
+
+  test("the gate script checks out a ref and runs the gate from it", async () => {
+    const script = await Bun.file(
+      `${import.meta.dir}/../.buildkite/scripts/review-gate.sh`,
+    ).text();
+    expect(script).toContain("git worktree add");
+    expect(script).toContain("REVIEW_GATE_REF:-main");
+    expect(script).toContain("scripts/wait-for-review.ts");
+    // The commit actually used has to reach the signal event, or a count still
+    // cannot be attributed to the parser that produced it.
+    expect(script).toContain("REVIEW_GATE_PARSER_COMMIT");
   });
 });

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -33,6 +33,7 @@ import {
   type ReviewThread,
 } from "@shepherdjerred/code-review";
 import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
+import { requestReviewAtHead } from "@shepherdjerred/code-review/request-review";
 import {
   fetchPullRequestAuthor,
   fetchReviewThreads,
@@ -388,6 +389,10 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
   let lastState: ReviewStateResult | null = null;
   let lastThreads: readonly ReviewThread[] = [];
   let lastPollError: Error | null = null;
+  // Whether this run has already asked the provider to review the head. The
+  // marker check makes a duplicate request impossible anyway; this avoids
+  // paying for a comment scan on every poll.
+  let requested = false;
 
   while (Date.now() <= deadline) {
     let stateResult: ReviewStateResult;
@@ -486,6 +491,37 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         `PR #${String(number)} head is now ${threadResult.headRefOid}, but this build is for ${head}; evaluating ${head}.`,
       );
       warnedMismatch = true;
+    }
+
+    // Ask for the review this loop is waiting on, once we have seen that the
+    // provider has not already reviewed this head.
+    //
+    // Qodo reviews a PR once, when it is opened, and never again on its own.
+    // Polling alone therefore waits out the entire budget on every push after
+    // the first and then fails a PR whose diff is fine. The request is asked
+    // for after the first observation rather than before it, so a head the
+    // provider has already reviewed is never asked again; the marker makes a
+    // repeat impossible even so.
+    if (!requested && stateResult.reviewedCommit !== head) {
+      requested = true;
+      const posted = await requestReviewAtHead({
+        repo,
+        number,
+        head,
+        token,
+        provider,
+      });
+      console.log(
+        JSON.stringify({
+          level: "info",
+          msg: posted ? "review-requested" : "review-request-already-present",
+          component: "review-gate",
+          provider: provider.id,
+          repo,
+          pr: number,
+          head_sha: head,
+        }),
+      );
     }
 
     const decision = evaluateGate({

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -248,7 +248,21 @@ function buildSignalEvent(input: {
     timed_out: input.timedOut,
     stale_reaction: input.state.staleReaction,
     decision: input.decision === null ? null : input.decision.state,
+    parser_commit: parserCommit(),
   };
+}
+
+/**
+ * The commit of the `code-review` source that produced this observation.
+ *
+ * `review-gate.sh` runs the gate from a worktree of `main` and passes the
+ * commit it checked out. Recording it makes the log say which parser produced
+ * a count — the one thing that would have made an inflated `blocking_count`
+ * obvious at a glance rather than after a long hunt.
+ */
+function parserCommit(): string | null {
+  const commit = Bun.env["REVIEW_GATE_PARSER_COMMIT"];
+  return commit === undefined || commit.trim() === "" ? null : commit.trim();
 }
 
 async function waitForReview(): Promise<void> {

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -495,7 +495,7 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
       // provider has already reviewed is never asked again; the marker makes a
       // repeat impossible even so.
       if (!requested && stateResult.reviewedCommit !== head) {
-        const posted = await requestReviewAtHead({
+        const outcome = await requestReviewAtHead({
           repo,
           number,
           head,
@@ -506,7 +506,7 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         console.log(
           JSON.stringify({
             level: "info",
-            msg: posted ? "review-requested" : "review-request-already-present",
+            msg: `review-request-${outcome}`,
             component: "review-gate",
             provider: provider.id,
             repo,

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -482,6 +482,39 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         // whole comment history twice on every poll.
         issueComment: stateResult.issueComment,
       });
+
+      // Ask for the review this loop is waiting on, once we have seen that the
+      // provider has not already reviewed this head. Keep this write inside the
+      // same retry boundary as the reads above: a transient failure while
+      // checking or posting the request must not fail the gate immediately.
+      //
+      // Qodo reviews a PR once, when it is opened, and never again on its own.
+      // Polling alone therefore waits out the entire budget on every push after
+      // the first and then fails a PR whose diff is fine. The request is asked
+      // for after the first observation rather than before it, so a head the
+      // provider has already reviewed is never asked again; the marker makes a
+      // repeat impossible even so.
+      if (!requested && stateResult.reviewedCommit !== head) {
+        const posted = await requestReviewAtHead({
+          repo,
+          number,
+          head,
+          token,
+          provider,
+        });
+        requested = true;
+        console.log(
+          JSON.stringify({
+            level: "info",
+            msg: posted ? "review-requested" : "review-request-already-present",
+            component: "review-gate",
+            provider: provider.id,
+            repo,
+            pr: number,
+            head_sha: head,
+          }),
+        );
+      }
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       if (!isRetryablePollError(err)) throw err;
@@ -505,37 +538,6 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         `PR #${String(number)} head is now ${threadResult.headRefOid}, but this build is for ${head}; evaluating ${head}.`,
       );
       warnedMismatch = true;
-    }
-
-    // Ask for the review this loop is waiting on, once we have seen that the
-    // provider has not already reviewed this head.
-    //
-    // Qodo reviews a PR once, when it is opened, and never again on its own.
-    // Polling alone therefore waits out the entire budget on every push after
-    // the first and then fails a PR whose diff is fine. The request is asked
-    // for after the first observation rather than before it, so a head the
-    // provider has already reviewed is never asked again; the marker makes a
-    // repeat impossible even so.
-    if (!requested && stateResult.reviewedCommit !== head) {
-      requested = true;
-      const posted = await requestReviewAtHead({
-        repo,
-        number,
-        head,
-        token,
-        provider,
-      });
-      console.log(
-        JSON.stringify({
-          level: "info",
-          msg: posted ? "review-requested" : "review-request-already-present",
-          component: "review-gate",
-          provider: provider.id,
-          repo,
-          pr: number,
-          head_sha: head,
-        }),
-      );
     }
 
     const decision = evaluateGate({


### PR DESCRIPTION
## Why

Driving the open PR fleet to green took a full night, and most of that time went
into fighting the review gate rather than fixing code. Four problems, each
diagnosed against live PRs in this repository:

| Problem | Evidence |
| --- | --- |
| The gate waited for a review it never asked for | Qodo reviews a PR **once**, when it is opened. `wait-for-review.ts` only polled, so every push after the first burned the full 40-minute budget and then failed a PR whose diff was fine. `requestReview.buildComment` already existed on the provider and no CI code called it. |
| The gate graded a PR with that PR's own copy of the grader | `code-review` is a `workspace:*` dependency. #1389 sat 22 commits behind and predated `currentReviewOf`, so its gate counted stale pre-fix copies of already-fixed findings: **0** blocking measured against `main`, **3** against its own parser. |
| Every finding was counted twice | Qodo renders each finding both in its review comment and as an inline thread. `fetchReviewThreads` concatenated both with no dedup, and each copy had to be cleared through a different API. #2095 reported **13** where Qodo itself listed **9**. |
| Recurring actions were hand-rolled | Listing findings, clearing them on both surfaces, and the retry-harvest rule were re-derived with ad-hoc scripts every time. |

## What

Four commits, each independently reviewable:

1. **`feat(code-review)`** — one finding, not two. Providers gain optional
   `parseFindingTitle` and `findingKey` hooks; `mergeDuplicateFindings` collapses
   copies sharing a key. A finding is resolved once **either** copy is, matching
   how copies *within* the review comment were already merged. Priority takes the
   most severe copy, only the configured provider's own threads may merge, and a
   `null` key never merges. `ReviewThread` carries `threadId` and `commentId` so
   a consumer can act on whichever surface a finding lives on.
2. **`feat(root)`** — the gate asks for the review it waits on, guarded by a
   marker naming the provider and exact head. `buildReviewRequestMarker()` is
   shared with the PR-fleet controller so the two recognise each other's request.
   A failed request throws rather than degrading to a silent 40-minute wait.
3. **`ci(root)`** — `review-gate.sh` runs the gate from a `main` worktree. The
   gate reads only GitHub state and never the PR's diff, so running the PR's copy
   bought nothing. Each `review-signal` event now carries `parser_commit`.
4. **`feat(toolkit)`** — `toolkit pr review list | resolve | harvest`. `resolve`
   clears a finding on both surfaces at once and requires `--evidence`; `harvest`
   applies the stale-gate rule and prints `bk job retry`, only re-running with
   `--retry`.

## Verification

- `bunx turbo run typecheck test lint build` across `code-review`,
  `root-scripts`, `pr-fleet-controller`, and `toolkit`: **18/18 green**, on a
  branch restacked onto current `main`.
- **Against live PR #2095:** 17 raw threads collapse to **9** distinct findings —
  exactly the number Qodo's own comment enumerates — each carrying both handles.
- **Against live PRs #2095/#2208/#2216/#2218:** `harvest` selects exactly the PRs
  the manual rule selected, with a stated reason for each rejection.
- 29 new tests: cross-surface merge semantics, the review-request path, chip
  safety (a two-section fixture's archived half returns byte-identical), and the
  harvest rule.

Two findings from running this against real data rather than fixtures:

- The title parser initially required the line to open with the ordinal, but Qodo
  wraps a **resolved** finding's title in `<s>`. It silently found no title on
  precisely the findings already dealt with, leaving them double-counted. Fixed,
  with a test using the real body.
- Where resolved-if-either changes the gate's answer, it is reading a signal that
  was previously being overridden. On both #2095's "RTP payload copied per
  packet" and #2208's "Abandoned refresh not guaranteed", **Qodo itself** had
  resolved the thread (`resolvedBy: qodo…[bot]`, not outdated) while leaving its
  comment copy unstruck. #2208's last "blocking finding" was never real.

## Rollout notes

- Once this lands, a PR that changes the gate is no longer exercised by its own
  gate. `REVIEW_GATE_REF` exists for that case — operator-set at build creation,
  as with `CI_IO_FIXED_CORPUS`.
- This closes the *accidental* self-grading problem, where a branch is simply
  old. It is **not** a trust boundary: Buildkite uploads the pipeline from the
  branch, so a branch that rewrites the step controls its own gate either way, as
  it does for every check. The script says so rather than implying otherwise.
- `resolve`'s two GitHub writes are covered only by unit tests on the pure chip
  function, not by an integration test.