### PR TITLE
chore(dotfiles): sync live-mutated config and fix apply-time bugs

### DIFF
--- a/packages/dotfiles/.chezmoiignore
+++ b/packages/dotfiles/.chezmoiignore
@@ -26,6 +26,9 @@ Library/Application Support/Claude/claude_desktop_config.json
 node_modules
 coverage
 .turbo
+package.json
+tsconfig.json
+eslint.config.ts
 
 # Claude Code rewrites model/effortLevel/fast into this file on every /model or
 # /effort, so tracking it caused perpetual drift and re-add snapshotting a

--- a/packages/dotfiles/private_dot_codex/private_config.toml
+++ b/packages/dotfiles/private_dot_codex/private_config.toml
@@ -8,6 +8,7 @@ project_doc_max_bytes = 65536
 personality = "pragmatic"
 
 notify = ["/Users/jerred/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended"]
+service_tier = "default"
 
 [notice]
   [notice.model_migrations]
@@ -28,6 +29,12 @@ trust_level = "trusted"
 trust_level = "trusted"
 
 [projects."/Users/jerred/git/6422-workspace"]
+trust_level = "trusted"
+
+[projects."/Users/jerred/Library/Application Support/com.conductor.app/bin"]
+trust_level = "trusted"
+
+[projects."/Users/jerred/Downloads"]
 trust_level = "trusted"
 
 [plugins."github@openai-curated"]
@@ -51,6 +58,18 @@ enabled = true
 [plugins."browser@openai-bundled"]
 enabled = true
 
+[plugins."pdf@openai-primary-runtime"]
+enabled = true
+
+[plugins."template-creator@openai-primary-runtime"]
+enabled = true
+
+[plugins."google-calendar@openai-curated"]
+enabled = true
+
+[plugins."slack@openai-curated"]
+enabled = true
+
 [tui]
 theme = "catppuccin-latte"
 vim_mode_default = true
@@ -60,40 +79,42 @@ vim_mode_default = true
 "gpt-5.6-sol" = 4
 
 [marketplaces.openai-bundled]
-last_updated = "2026-07-19T20:12:38Z"
+last_updated = "2026-08-06T05:00:33Z"
 source_type = "local"
 source = "/Users/jerred/.codex/.tmp/bundled-marketplaces/openai-bundled"
 
 [marketplaces.openai-primary-runtime]
-last_updated = "2026-06-01T18:47:47Z"
+last_updated = "2026-08-06T05:01:06Z"
 source_type = "local"
 source = "/Users/jerred/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
 
 [mcp_servers.node_repl]
-args = []
 command = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl"
-startup_timeout_sec = 120
+startup_timeout_sec = 120.0
 
 [mcp_servers.node_repl.env]
-NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
-NODE_REPL_NODE_MODULE_DIRS = "/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules"
-NODE_REPL_NODE_PATH = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
-NODE_REPL_TRUSTED_CODE_PATHS = "/Users/jerred/.codex"
-CODEX_HOME = "/Users/jerred/.codex"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "461c4ba94b821ec805da79c8e8138fe510b1b3358609fc93da47387a2cf3fbf3,6d25aa7656feac858f3a3bdaea5bcbab0dbfd426c9de8e6931ce90c399ee8e4f"
 BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
+BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
+BROWSER_USE_CODEX_APP_VERSION = "26.730.61639"
+CODEX_CLI_PATH = "/Applications/ChatGPT.app/Contents/Resources/codex"
+CODEX_HOME = "/Users/jerred/.codex"
 NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
 NODE_REPL_INSTRUCTIONS_USE_CASE_CHROME = "Control the Chrome browser in conjunction with the Chrome Plugin. Prefer this method of controlling Chrome over alternatives (such as Computer Use) unless the user explicitly mentions an alternative."
 NODE_REPL_INSTRUCTIONS_USE_CASE_COMPUTER_USE = "Control desktop apps on macOS through Computer Use."
-BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
-BROWSER_USE_CODEX_APP_VERSION = "26.715.31925"
-CODEX_CLI_PATH = "/Applications/ChatGPT.app/Contents/Resources/codex"
+NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
+NODE_REPL_NODE_MODULE_DIRS = "/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules"
+NODE_REPL_NODE_PATH = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "091a81603ff202a16ed56557709bf42d97caf8f0dd2e07ae9e26d7c014d71035"
+NODE_REPL_TRUSTED_CODE_PATHS = "/Users/jerred/.codex:/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules"
 
 [mcp_servers.computer-use]
 command = "./Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient"
 args = ["mcp"]
 cwd = "."
 enabled = false
+
+[mcp_servers.openaiDeveloperDocs]
+url = "https://developers.openai.com/mcp"
 
 [features]
 memories = true
@@ -111,7 +132,8 @@ followUpQueueMode = "queue"
 git-show-sidebar-pr-icons = true
 selected-avatar-id = "seedy"
 dock-icon-preference = "codex-system"
-conversationDetailMode = "STEPS_PROSE"
+conversationDetailMode = "STEPS_COMMANDS"
+ambient-suggestions-enabled = true
 
 [desktop.appearanceLightChromeTheme]
 accent = "#0285ff"
@@ -148,8 +170,8 @@ global = "zed"
 
 [shell_environment_policy.set]
 BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "461c4ba94b821ec805da79c8e8138fe510b1b3358609fc93da47387a2cf3fbf3,6d25aa7656feac858f3a3bdaea5bcbab0dbfd426c9de8e6931ce90c399ee8e4f"
-NODE_REPL_TRUSTED_CODE_PATHS = "/Users/jerred/.codex"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "091a81603ff202a16ed56557709bf42d97caf8f0dd2e07ae9e26d7c014d71035"
+NODE_REPL_TRUSTED_CODE_PATHS = "/Users/jerred/.codex:/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules"
 # Plain tool defaults for agent shells: no nvim editor, no pagers, and a
 # curated agent gitconfig (no delta pager, no difftastic external diff) that
 # keeps identity, gh credentials, and git-spice settings. Modern tools stay

--- a/packages/dotfiles/private_dot_config/private_zed/private_settings.json
+++ b/packages/dotfiles/private_dot_config/private_zed/private_settings.json
@@ -7,11 +7,21 @@
 // custom settings, run `zed: open default settings` from the
 // command palette (cmd-shift-p / ctrl-shift-p)
 {
+  "buffer_font_family": "Berkeley Mono",
   "project_panel": {
     "dock": "left"
   },
+  "session": {
+    "trust_all_worktrees": true
+  },
   "vim_mode": true,
   "agent_servers": {
+    "github-copilot-cli": {
+      "type": "registry"
+    },
+    "cursor": {
+      "type": "registry"
+    },
     "codex-acp": {
       "type": "registry"
     },

--- a/packages/dotfiles/private_dot_ssh/private_config
+++ b/packages/dotfiles/private_dot_ssh/private_config
@@ -1,4 +1,4 @@
-Include /Users/jerred/.ssh/conductor_config
+Include ~/.ssh/conductor_config
 
 Include ~/.orbstack/ssh/config
 

--- a/packages/dotfiles/private_dot_ssh/private_config
+++ b/packages/dotfiles/private_dot_ssh/private_config
@@ -1,3 +1,5 @@
+Include /Users/jerred/.ssh/conductor_config
+
 Include ~/.orbstack/ssh/config
 
 Host *

--- a/packages/dotfiles/run_onchange_after_install-opencode-plugins.sh.tmpl
+++ b/packages/dotfiles/run_onchange_after_install-opencode-plugins.sh.tmpl
@@ -91,7 +91,22 @@ fi
 # so a nested `apply` call deadlocks until it times out. `execute-template`
 # only renders output and takes no lock, so it can run from inside a script.
 opencode_config_dir="$source_dir/private_dot_config/private_opencode"
-chezmoi execute-template -f "$opencode_config_dir/private_opencode.jsonc.tmpl" >~/.config/opencode/opencode.jsonc
-chezmoi execute-template -f "$opencode_config_dir/private_tui.jsonc.tmpl" >~/.config/opencode/tui.jsonc
-chmod 600 ~/.config/opencode/opencode.jsonc ~/.config/opencode/tui.jsonc
+
+# Render to a sibling temp file and rename into place so a failed or partial
+# render (e.g. a template error) can never truncate the existing config.
+render_config() {
+  local template="$1"
+  local dest="$2"
+  local tmp
+  tmp="$(mktemp "${dest}.XXXXXX")"
+  if ! chezmoi execute-template -f "$template" >"$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  chmod 600 "$tmp"
+  mv "$tmp" "$dest"
+}
+
+render_config "$opencode_config_dir/private_opencode.jsonc.tmpl" ~/.config/opencode/opencode.jsonc
+render_config "$opencode_config_dir/private_tui.jsonc.tmpl" ~/.config/opencode/tui.jsonc
 {{- end -}}

--- a/packages/dotfiles/run_onchange_after_install-opencode-plugins.sh.tmpl
+++ b/packages/dotfiles/run_onchange_after_install-opencode-plugins.sh.tmpl
@@ -86,7 +86,12 @@ fi
 
 # The plugin entries are conditional on these checkouts existing. Re-render
 # them now that the bootstrap has created and built the repositories.
-chezmoi --source "$source_dir" apply --force \
-  ~/.config/opencode/opencode.jsonc \
-  ~/.config/opencode/tui.jsonc
+# `chezmoi apply` (even with --force) acquires the persistent-state lock, and
+# this script itself runs inside an already-locked `chezmoi apply` transaction,
+# so a nested `apply` call deadlocks until it times out. `execute-template`
+# only renders output and takes no lock, so it can run from inside a script.
+opencode_config_dir="$source_dir/private_dot_config/private_opencode"
+chezmoi execute-template -f "$opencode_config_dir/private_opencode.jsonc.tmpl" >~/.config/opencode/opencode.jsonc
+chezmoi execute-template -f "$opencode_config_dir/private_tui.jsonc.tmpl" >~/.config/opencode/tui.jsonc
+chmod 600 ~/.config/opencode/opencode.jsonc ~/.config/opencode/tui.jsonc
 {{- end -}}


### PR DESCRIPTION
## Why
`chezmoi apply` had been silently broken on this machine for a while: a
backlog of unapplied source changes had piled up, and one `run_onchange`
script was failing on every single apply, discarding its own build work each
time.

## What
- Re-add live-mutated app state back into source: Codex CLI's trust
  list/plugin toggles/marketplace timestamps, Zed's agent-server
  registrations, and Conductor's `~/.ssh/config` include line.
- Drop two `mcp-gateway-*` MCP server blocks from live Codex config — a prior
  commit (`6c8c96735`, "Remove MCP gateway and stale coding-agent
  configuration") had already removed them from source, but they were never
  re-applied to this machine.
- Add `package.json`/`tsconfig.json`/`eslint.config.ts` to `.chezmoiignore`.
  These are this package's own bun-workspace build tooling, not dotfiles
  content — a comment already said so — but they were missing from the ignore
  list, and `chezmoi apply` was about to place them at `$HOME`.
- Fix `run_onchange_after_install-opencode-plugins.sh.tmpl`: its last step
  called `chezmoi apply --force` on two rendered config files, but the script
  itself runs *inside* an active `chezmoi apply` transaction, so the nested
  `apply` deadlocked on chezmoi's persistent-state lock and errored out on
  every run — after successfully cloning and building both plugin repos,
  wasting that work. Replaced with `chezmoi execute-template`, which only
  renders and takes no lock.

## Verification
- `chezmoi diff` clean for every re-added file (`.codex/config.toml`, Zed
  settings, `~/.ssh/config`, `~/.talos/config`, `~/AGENTS.md` via the already
  git-committed source it had been out of sync with).
- Rendered `install-opencode-plugins.sh` passes `bash -n` and `shellcheck`;
  re-ran it live end-to-end (exit 0); confirmed `chezmoi execute-template`
  output for `opencode.jsonc`/`tui.jsonc` byte-for-byte matches the already
  chezmoi-applied live files.
- Not run: root `bun run verify` (not reproducing/changing the verification
  system itself; Buildkite runs it for this PR).

## Rollout notes
Two items remain live-diverged on this machine, not fixable from this
session — no action needed in this PR, noted for awareness:
- `configure-gcx.sh`: the homelab `torvalds` node is unreachable over
  Tailscale right now (infra outage, unrelated to this change).
- `install-claude-managed-settings.sh`: writes to `/Library/Application
  Support/ClaudeCode`, which needs an interactive `sudo` TTY this session
  doesn't have.