### PR TITLE
feat(temporal): automate storage and laundry room lights

### DIFF
--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -12,6 +12,10 @@ import type {
   HomeAssistantRestClient,
 } from "@shepherdjerred/home-assistant";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
+import {
+  MOTION_LIGHT_ROOMS,
+  type MotionLightRoom,
+} from "#shared/motion-light.ts";
 import { cooldownBucket } from "#shared/presence.ts";
 
 const IOS_ACTION_ID_GOOD_NIGHT = "A91A15AA-479E-416C-8F51-BD983A999266";
@@ -28,6 +32,28 @@ const StateChangedEventData = z.object({
 
 const PERSON_ENTITIES = ["person.jerred", "person.shuxin"] as const;
 const PERSON_ENTITY_SET = new Set<string>(PERSON_ENTITIES);
+const MOTION_LIGHT_ROOMS_BY_ENTITY = new Map<
+  string,
+  {
+    room: MotionLightRoom;
+    lightEntityId: string;
+  }
+>([
+  [
+    MOTION_LIGHT_ROOMS.laundry.motionEntityId,
+    {
+      room: "laundry",
+      lightEntityId: MOTION_LIGHT_ROOMS.laundry.lightEntityId,
+    },
+  ],
+  [
+    MOTION_LIGHT_ROOMS.storage.motionEntityId,
+    {
+      room: "storage",
+      lightEntityId: MOTION_LIGHT_ROOMS.storage.lightEntityId,
+    },
+  ],
+]);
 
 // Singleton id for the debounced front-door lock reconciler. Every presence
 // transition signals this one workflow (starting it if needed) rather than
@@ -160,6 +186,21 @@ export function handleStateChanged(
     // Ignore attribute-only updates (e.g. GPS coordinate churn while the state
     // stays `home`) — only real presence transitions matter.
     if (oldState === newState) {
+      return;
+    }
+
+    const motionLight = MOTION_LIGHT_ROOMS_BY_ENTITY.get(parsed.data.entity_id);
+    if (motionLight !== undefined && oldState === "off" && newState === "on") {
+      await startWorkflow(
+        client,
+        "motionLight",
+        `motion-light-${motionLight.lightEntityId}`,
+        {
+          args: [motionLight.room],
+          workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
+          workflowExecutionTimeout: "30 minutes",
+        },
+      );
       return;
     }
 

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -175,9 +175,6 @@ export function handleStateChanged(
     if (!parsed.success) {
       return;
     }
-    if (!PERSON_ENTITY_SET.has(parsed.data.entity_id)) {
-      return;
-    }
     const oldState = parsed.data.old_state?.state;
     const newState = parsed.data.new_state?.state;
     if (oldState === undefined || newState === undefined) {
@@ -190,17 +187,24 @@ export function handleStateChanged(
     }
 
     const motionLight = MOTION_LIGHT_ROOMS_BY_ENTITY.get(parsed.data.entity_id);
-    if (motionLight !== undefined && oldState === "off" && newState === "on") {
-      await startWorkflow(
-        client,
-        "motionLight",
-        `motion-light-${motionLight.lightEntityId}`,
-        {
-          args: [motionLight.room],
-          workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
-          workflowExecutionTimeout: "30 minutes",
-        },
-      );
+    if (motionLight !== undefined) {
+      if (oldState === "off" && newState === "on") {
+        await startWorkflow(
+          client,
+          "motionLight",
+          `motion-light-${motionLight.lightEntityId}`,
+          {
+            args: [motionLight.room],
+            workflowIdConflictPolicy:
+              WorkflowIdConflictPolicy.TERMINATE_EXISTING,
+            workflowExecutionTimeout: "24 hours",
+          },
+        );
+      }
+      return;
+    }
+
+    if (!PERSON_ENTITY_SET.has(parsed.data.entity_id)) {
       return;
     }
 

--- a/packages/temporal/src/shared/motion-light.ts
+++ b/packages/temporal/src/shared/motion-light.ts
@@ -1,0 +1,12 @@
+export const MOTION_LIGHT_ROOMS = {
+  laundry: {
+    motionEntityId: "binary_sensor.laundry_multisensor_motion_detection",
+    lightEntityId: "switch.laundry_light",
+  },
+  storage: {
+    motionEntityId: "binary_sensor.storage_multisensor_motion_detection",
+    lightEntityId: "switch.storage_light",
+  },
+} as const;
+
+export type MotionLightRoom = keyof typeof MOTION_LIGHT_ROOMS;

--- a/packages/temporal/src/workflows/ha/motion-light.test.ts
+++ b/packages/temporal/src/workflows/ha/motion-light.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { EntityState } from "@shepherdjerred/home-assistant";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import { MOTION_LIGHT_ROOMS } from "#shared/motion-light.ts";
+import { motionLight } from "./motion-light.ts";
+
+const TASK_QUEUE = "motion-light-test";
+
+let testEnv: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+  testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnv.teardown();
+});
+
+describe("motionLight", () => {
+  test("turns on the room light and waits for inactivity before turning it off", async () => {
+    const calls: string[] = [];
+    const motionStates = new Map<string, string[]>([
+      [MOTION_LIGHT_ROOMS.laundry.motionEntityId, ["on", "off"]],
+      [MOTION_LIGHT_ROOMS.storage.motionEntityId, ["off"]],
+    ]);
+
+    const worker = await Worker.create({
+      connection: testEnv.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("../index.ts", import.meta.url).pathname,
+      activities: {
+        getEntityState: async (entityId: string) => {
+          const states = motionStates.get(entityId);
+          if (states === undefined) {
+            throw new Error(`Unexpected entity state read: ${entityId}`);
+          }
+          const state = states.shift();
+          if (state === undefined) {
+            throw new Error(`Unexpected extra entity state read: ${entityId}`);
+          }
+          return {
+            entity_id: entityId,
+            state,
+            attributes: {},
+          } satisfies EntityState;
+        },
+        callService: async (
+          domain: string,
+          service: string,
+          data: Record<string, unknown>,
+        ) => {
+          const entityId = data["entity_id"];
+          if (typeof entityId !== "string") {
+            throw new TypeError("Expected entity_id in switch service call");
+          }
+          calls.push(`${domain}.${service}:${entityId}`);
+        },
+      },
+    });
+
+    await worker.runUntil(async () => {
+      await testEnv.client.workflow.execute(motionLight, {
+        args: ["laundry"],
+        taskQueue: TASK_QUEUE,
+        workflowId: crypto.randomUUID(),
+      });
+      await testEnv.client.workflow.execute(motionLight, {
+        args: ["storage"],
+        taskQueue: TASK_QUEUE,
+        workflowId: crypto.randomUUID(),
+      });
+    });
+
+    expect(calls).toEqual([
+      "switch.turn_on:switch.laundry_light",
+      "switch.turn_off:switch.laundry_light",
+      "switch.turn_on:switch.storage_light",
+      "switch.turn_off:switch.storage_light",
+    ]);
+  }, 60_000);
+});

--- a/packages/temporal/src/workflows/ha/motion-light.test.ts
+++ b/packages/temporal/src/workflows/ha/motion-light.test.ts
@@ -21,8 +21,8 @@ describe("motionLight", () => {
   test("turns on the room light and waits for inactivity before turning it off", async () => {
     const calls: string[] = [];
     const motionStates = new Map<string, string[]>([
-      [MOTION_LIGHT_ROOMS.laundry.motionEntityId, ["on", "off"]],
-      [MOTION_LIGHT_ROOMS.storage.motionEntityId, ["off"]],
+      [MOTION_LIGHT_ROOMS.laundry.motionEntityId, ["on", "off", "off"]],
+      [MOTION_LIGHT_ROOMS.storage.motionEntityId, ["off", "off"]],
     ]);
 
     const worker = await Worker.create({

--- a/packages/temporal/src/workflows/ha/motion-light.ts
+++ b/packages/temporal/src/workflows/ha/motion-light.ts
@@ -1,0 +1,29 @@
+import { sleep } from "@temporalio/workflow";
+import { callServiceUnchecked, getEntityStateUnchecked } from "./util.ts";
+import {
+  MOTION_LIGHT_ROOMS,
+  type MotionLightRoom,
+} from "#shared/motion-light.ts";
+
+const INACTIVITY_TIMEOUT = "5 minutes" as const;
+
+export async function motionLight(room: MotionLightRoom): Promise<void> {
+  const { motionEntityId, lightEntityId } = MOTION_LIGHT_ROOMS[room];
+
+  await callServiceUnchecked("switch", "turn_on", {
+    entity_id: lightEntityId,
+  });
+
+  let motionActive = true;
+  while (motionActive) {
+    await sleep(INACTIVITY_TIMEOUT);
+    const motion = await getEntityStateUnchecked(motionEntityId);
+    if (motion.state === "off") {
+      motionActive = false;
+    }
+  }
+
+  await callServiceUnchecked("switch", "turn_off", {
+    entity_id: lightEntityId,
+  });
+}

--- a/packages/temporal/src/workflows/ha/motion-light.ts
+++ b/packages/temporal/src/workflows/ha/motion-light.ts
@@ -1,5 +1,9 @@
-import { sleep } from "@temporalio/workflow";
-import { callServiceUnchecked, getEntityStateUnchecked } from "./util.ts";
+import { CancellationScope, sleep } from "@temporalio/workflow";
+import {
+  callServiceForCleanup,
+  callServiceUnchecked,
+  getEntityStateUnchecked,
+} from "./util.ts";
 import {
   MOTION_LIGHT_ROOMS,
   type MotionLightRoom,
@@ -10,20 +14,28 @@ const INACTIVITY_TIMEOUT = "5 minutes" as const;
 export async function motionLight(room: MotionLightRoom): Promise<void> {
   const { motionEntityId, lightEntityId } = MOTION_LIGHT_ROOMS[room];
 
-  await callServiceUnchecked("switch", "turn_on", {
-    entity_id: lightEntityId,
-  });
+  try {
+    await callServiceUnchecked("switch", "turn_on", {
+      entity_id: lightEntityId,
+    });
 
-  let motionActive = true;
-  while (motionActive) {
-    await sleep(INACTIVITY_TIMEOUT);
-    const motion = await getEntityStateUnchecked(motionEntityId);
-    if (motion.state === "off") {
-      motionActive = false;
+    let inactive = false;
+    while (!inactive) {
+      await sleep(INACTIVITY_TIMEOUT);
+      const motion = await getEntityStateUnchecked(motionEntityId);
+      if (motion.state !== "off") {
+        continue;
+      }
+
+      await sleep(INACTIVITY_TIMEOUT);
+      const stillInactive = await getEntityStateUnchecked(motionEntityId);
+      inactive = stillInactive.state === "off";
     }
+  } finally {
+    await CancellationScope.nonCancellable(() =>
+      callServiceForCleanup("switch", "turn_off", {
+        entity_id: lightEntityId,
+      }),
+    );
   }
-
-  await callServiceUnchecked("switch", "turn_off", {
-    entity_id: lightEntityId,
-  });
 }

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -15,7 +15,9 @@ import { welcomeHome as _welcomeHome } from "./ha/welcome-home.ts";
 import { leavingHome as _leavingHome } from "./ha/leaving-home.ts";
 import { reconcileLock as _reconcileLock } from "./ha/reconcile-lock.ts";
 import { runVacuumIfNotHome as _runVacuumIfNotHome } from "./ha/run-vacuum-if-not-home.ts";
+import { motionLight as _motionLight } from "./ha/motion-light.ts";
 import { sleepAc as _sleepAc, sleepMusic as _sleepMusic } from "./ha/sleep.ts";
+import type { MotionLightRoom } from "#shared/motion-light.ts";
 import type { SleepAutomationInput } from "#shared/schemas.ts";
 import { runZfsMaintenanceWorkflow as _runZfsMaintenanceWorkflow } from "./zfs-maintenance.ts";
 import { runBugsinkHousekeepingWorkflow as _runBugsinkHousekeepingWorkflow } from "./bugsink.ts";
@@ -165,6 +167,10 @@ export async function reconcileLock(): Promise<void> {
 
 export async function runVacuumIfNotHome(): Promise<void> {
   return _runVacuumIfNotHome();
+}
+
+export async function motionLight(room: MotionLightRoom): Promise<void> {
+  return _motionLight(room);
 }
 
 export async function sleepMusic(input?: SleepAutomationInput): Promise<void> {


### PR DESCRIPTION
Why:
Add motion-triggered lighting for the new storage and laundry room devices.

What:
- Route binary_sensor.laundry_multisensor_motion_detection to switch.laundry_light.
- Route binary_sensor.storage_multisensor_motion_detection to switch.storage_light.
- Turn each switch on on motion and turn it off after five minutes of inactivity.
- Replace the room workflow on renewed motion so the inactivity timer resets.

Verification:
- bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal
- bunx prettier --check src/shared/motion-light.ts src/workflows/ha/motion-light.ts src/workflows/ha/motion-light.test.ts src/workflows/index.ts src/event-bridge/triggers.ts (from packages/temporal)
- Commit hooks passed: Prettier, suppression checks, Gitleaks, and commit-message validation.
- Live deployment was not run; this PR changes the Temporal worker source only.