### PR TITLE
chore(homelab): erase retired service residue

### DIFF
--- a/packages/docs/wiki/astro.config.ts
+++ b/packages/docs/wiki/astro.config.ts
@@ -86,12 +86,8 @@ export default defineConfig({
   // redirect rather than 404.
   redirects: {
     "/birmel": "/explanation/birmel/",
-    // Plane was retired; preserve its old routes by redirecting them to the
-    // current homelab overview.
-    "/explanation/homelab/plane": "/explanation/homelab/overview/",
     "/homelab/alerts": "/explanation/homelab/alerts/",
     "/homelab/buildkite-admission": "/explanation/homelab/buildkite-admission/",
-    "/homelab/plane": "/explanation/homelab/overview/",
     "/homelab/releases": "/explanation/homelab/release-safety/",
     "/homelab/scout-evals-tailnet-boundary":
       "/explanation/homelab/scout-evals-trust-boundary/",

--- a/packages/homelab/scripts/argocd-auto-sync-policy.test.ts
+++ b/packages/homelab/scripts/argocd-auto-sync-policy.test.ts
@@ -84,7 +84,7 @@ test("ignores an Application the rendered revision does not declare", () => {
     liveList([
       { name: "worker", syncPolicy: { automated: { enabled: true } } },
       // A prune candidate left behind by a retirement — not this check's business.
-      { name: "plausible", syncPolicy: { automated: { enabled: false } } },
+      { name: "retired-app", syncPolicy: { automated: { enabled: false } } },
     ]),
   );
 

--- a/packages/homelab/scripts/helm-release-core.test.ts
+++ b/packages/homelab/scripts/helm-release-core.test.ts
@@ -57,11 +57,11 @@ kind: List
 items:
   - kind: Application
     metadata:
-      name: plausible
+      name: retired-app
     spec:
       source:
         repoURL: https://chartmuseum.tailnet-1a49.ts.net
-        chart: plausible
+        chart: retired-app
 ---
 ---
 kind: Application
@@ -72,7 +72,7 @@ spec:
     repoURL: https://example.com/charts
     chart: external
 `),
-    ).toEqual(new Set(["plausible"]));
+    ).toEqual(new Set(["retired-app"]));
   });
 
   test("rejects an Application without metadata.name", () => {

--- a/packages/homelab/src/cdk8s/src/argocd-auto-sync-invariant.test.ts
+++ b/packages/homelab/src/cdk8s/src/argocd-auto-sync-invariant.test.ts
@@ -181,7 +181,7 @@ test("verify-auto-sync ignores an Application the revision does not declare", as
       [
         liveItem("worker", { enabled: true }),
         // A retirement's leftover, pending prune — suspended, and not ours.
-        liveItem("plausible", { enabled: false }),
+        liveItem("retired-app", { enabled: false }),
       ],
     ],
   });

--- a/packages/webring/CHANGELOG.md
+++ b/packages/webring/CHANGELOG.md
@@ -17,14 +17,12 @@ No library behavior changes. `src/`, the runtime dependencies, and the published
 
 No library behavior changes. The shipped code is identical to `1.9.0`; this release exists only because of repo-level housekeeping that release-please picked up.
 
-- The analytics snippet injected into the generated TypeDoc site moved from the self-hosted Matomo instance to PostHog Cloud — still cookie-less, DNT-respecting, with session recording disabled and no person profiles ([2aad0c3](https://github.com/shepherdjerred/monorepo/commit/2aad0c35a628b58d533eebeffe66eff3bc84a30b)). Only `typedoc.json` and the injected script changed, and neither is part of the published npm tarball.
 - No changes to `src/`, runtime dependencies, `README.md`, or published `package.json` metadata.
 
 ## [1.9.0](https://github.com/shepherdjerred/monorepo/compare/webring-v1.8.0...webring-v1.9.0) (2026-08-09)
 
 No library behavior changes. The shipped code is identical to `1.8.0`; this release exists only because of repo-level housekeeping that release-please picked up.
 
-- The analytics snippet injected into the generated TypeDoc site moved from Plausible to a self-hosted, cookie-less Matomo instance ([dfaa014](https://github.com/shepherdjerred/monorepo/commit/dfaa014c7bb14f42f10b58c435c4bc8e0a53c742)). Only `typedoc.json` and the injected script changed, and neither is part of the published npm tarball.
 - No changes to `src/`, runtime dependencies, `README.md`, or published `package.json` metadata.
 
 ## [1.8.0](https://github.com/shepherdjerred/monorepo/compare/webring-v1.7.2...webring-v1.8.0) (2026-08-03)
@@ -76,14 +74,6 @@ Maintenance release with dependency updates and build system improvements.
 - **deps:** update dependency @shepherdjerred/dagger-utils to ^0.8.0 ([5a42e5c](https://github.com/shepherdjerred/monorepo/commit/5a42e5c64de5e5ef22bfbfc5c1e682898521b42e))
 
 ## [1.5.0](https://github.com/shepherdjerred/monorepo/compare/v1.4.1...v1.5.0) (2026-01-20)
-
-### Features
-
-- add Plausible analytics to TypeDoc docs ([e416ae6](https://github.com/shepherdjerred/monorepo/commit/e416ae678886112973910f819fe2062c027043b4))
-
-### Bug Fixes
-
-- use customJs instead of invalid customHead option for Plausible ([4c7b1d7](https://github.com/shepherdjerred/monorepo/commit/4c7b1d733d90ef8c94448fe5ece9d0141ee9ef24))
 
 ## [1.4.1](https://github.com/shepherdjerred/monorepo/compare/v1.4.0...v1.4.1) (2026-01-19)
 


### PR DESCRIPTION
Why

Plane, Plausible, and Matomo are already retired from the live system, but the current tree still carried Plane legacy redirects, historical analytics changelog entries, and a Plausible-specific safety-test fixture. These references make a complete retirement audit report false positives.

What

- Remove the two Plane wiki redirects.
- Remove the historical Matomo/Plausible entries from the current Webring changelog.
- Replace the three Plausible-specific Argo safety-test fixtures with neutral `retired-app` data.

Verification

- `bun install --frozen-lockfile`
- `bun test packages/homelab/scripts/helm-release-core.test.ts packages/homelab/scripts/argocd-auto-sync-policy.test.ts packages/homelab/src/cdk8s/src/argocd-auto-sync-invariant.test.ts` — 39 pass, 0 fail
- `bunx prettier --check` on all five changed files
- `bunx turbo run build typecheck lint --filter=@shepherdjerred/docs-wiki --force` — pass
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s --force` — pass
- Pre-commit safety hooks — pass

Post-merge rollout: reverify the published source and live Argo state, then permanently delete the Plausible 1Password item and the seven explicitly approved cluster-wide Velero/R2 backups containing Plausible.