### PR TITLE
fix(homelab): reconcile stale qBittorrent state after ShelfBridge removal

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/media.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/media.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { App, Chart } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { createMediaApp } from "./media.ts";
+
+const MediaApplicationSchema = z.object({
+  kind: z.literal("Application"),
+  metadata: z.object({ name: z.literal("media") }),
+  spec: z.object({
+    syncPolicy: z.object({
+      automated: z.object({ enabled: z.literal(true) }),
+      syncOptions: z.array(z.string()),
+    }),
+  }),
+});
+
+describe("media Argo CD application", () => {
+  it("uses server-side apply for complete workload reconciliation", () => {
+    const app = new App();
+    const chart = new Chart(app, "test");
+    createMediaApp(chart);
+    const manifest = parseAllDocuments(app.synthYaml())
+      .map((document) => MediaApplicationSchema.safeParse(document.toJS()))
+      .find((result) => result.success);
+    if (!manifest?.success) {
+      throw new Error("Media Application was not synthesized");
+    }
+
+    expect(manifest.data.spec.syncPolicy.syncOptions).toContain(
+      "ServerSideApply=true",
+    );
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/media.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/media.ts
@@ -20,6 +20,7 @@ export function createMediaApp(chart: Chart) {
       },
       syncPolicy: {
         automated: { enabled: true },
+        syncOptions: ["ServerSideApply=true"],
       },
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
@@ -204,6 +204,22 @@ describe("qBittorrent deployment", () => {
     expect(deployment.spec.template.metadata.labels.app).toBe("qbittorrent");
   });
 
+  it("contains no retired ShelfBridge workload resources", () => {
+    expect(
+      deployment.spec.template.spec.containers.map(
+        (container) => container.name,
+      ),
+    ).toEqual(["gluetun", "qbittorrent", "qbittorrent-exporter"]);
+    expect(
+      deployment.spec.template.spec.volumes.map((volume) => volume.name),
+    ).not.toContain("configmap-qbittorrent-shelfbridge-relay-config");
+    expect(
+      deployment.spec.template.spec.volumes.flatMap((volume) =>
+        volume.configMap?.name ? [volume.configMap.name] : [],
+      ),
+    ).toEqual(["qbittorrent-config"]);
+  });
+
   it("gates WebUI traffic on qBittorrent readiness while keeping metrics discoverable", () => {
     const qbittorrent = getContainer("qbittorrent");
 


### PR DESCRIPTION
Why\n\nThe live media Deployment retained the removed ShelfBridge sidecar and ConfigMap volume because the previous apply path did not delete omitted list entries. That left qBittorrent Pending on a ConfigMap that no longer exists.\n\nWhat\n\n- Enable ServerSideApply for the media ArgoCD Application.\n- Add manifest tests proving qBittorrent contains only the active VPN, qBittorrent, and exporter containers plus qbittorrent-config.\n- Repair the live Deployment separately with a resource-scoped Argo replace; no PVCs or ShelfBridge resources were recreated.\n\nVerification\n\n- bun test packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts packages/homelab/src/cdk8s/src/resources/argo-applications/media.test.ts\n- bunx prettier --check packages/homelab/src/cdk8s/src/resources/argo-applications/media.ts packages/homelab/src/cdk8s/src/resources/argo-applications/media.test.ts packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts\n- bunx turbo run typecheck lint --filter=homelab\n- git diff --check origin/main...HEAD\n- Live: argocd app sync media --resource apps:Deployment:media-qbittorrent --replace --assumeYes\n- Live: qBittorrent rollout reached 3/3 Running; both PVCs remained Bound; both Services have ready endpoints\n\nRollout\n\nThe chart publication is intentionally left to the normal post-merge root apps release. After merge, verify media is Synced and Healthy and that future media reconciliations use ServerSideApply.