### PR TITLE
fix(better-skill-capped): polish dark mode search and Scout promotion

### DIFF
--- a/packages/better-skill-capped/src/components/content/content-card.tsx
+++ b/packages/better-skill-capped/src/components/content/content-card.tsx
@@ -150,7 +150,7 @@ function VideoCard(
 function CommentaryCard(
   props: ContentCardProps & { commentary: Commentary },
 ): React.ReactElement {
-  const { commentary } = props;
+  const { commentary, matchedStrings } = props;
   return (
     <Card className="mb-4">
       <CardContent className="grid gap-4 sm:grid-cols-[1fr_16rem]">
@@ -161,7 +161,11 @@ function CommentaryCard(
               href={commentary.skillCappedUrl}
               className="underline-offset-2 hover:underline"
             >
-              {commentary.champion} vs {commentary.opponent}
+              <Highlighter
+                searchWords={matchedStrings}
+                textToHighlight={`${commentary.champion} vs ${commentary.opponent}`}
+                autoEscape={true}
+              />
             </a>
             <ChampionIcon
               name={commentary.opponent}
@@ -174,7 +178,10 @@ function CommentaryCard(
               {roleDisplayName(commentary.role)}
             </Badge>
             <ReleasedBadge date={commentary.releaseDate} />
-            <CoachAttribution name={commentary.staff} />
+            <CoachAttribution
+              name={commentary.staff}
+              matchedStrings={matchedStrings}
+            />
             <Badge variant="outline">
               K/D/A: {commentary.kills}/{commentary.deaths}/{commentary.assists}
             </Badge>

--- a/packages/better-skill-capped/src/components/layout/scout-banner.tsx
+++ b/packages/better-skill-capped/src/components/layout/scout-banner.tsx
@@ -8,13 +8,13 @@ import { Card, CardContent } from "#components/ui/card";
  */
 export function ScoutBanner(): React.ReactElement {
   return (
-    <Card className="mb-4 border-amber-300/60 bg-amber-50 py-4 dark:border-amber-400/20 dark:bg-amber-950/30">
+    <Card className="mb-4 border-amber-300/60 bg-amber-50 py-4 dark:border-primary/40 dark:bg-primary/10 dark:text-primary-foreground">
       <CardContent className="flex items-center gap-3 px-4 text-sm">
         <span aria-hidden className="text-xl">
           🔭
         </span>
         <p>
-          Check out{" "}
+          Never miss a game from your friends. Try{" "}
           <a
             href="https://scout-for-lol.com/"
             className="font-semibold underline underline-offset-2"
@@ -22,8 +22,8 @@ export function ScoutBanner(): React.ReactElement {
             Scout
             <ExternalLink className="ml-0.5 inline size-3.5 align-text-top" />
           </a>{" "}
-          — a Discord bot that notifies you when friends finish League matches,
-          with detailed post-match reports.
+          for Discord alerts, detailed post-match reports, and custom
+          competitions with daily leaderboards.
         </p>
       </CardContent>
     </Card>

--- a/packages/better-skill-capped/src/components/search/search-bar.tsx
+++ b/packages/better-skill-capped/src/components/search/search-bar.tsx
@@ -33,7 +33,7 @@ export function SearchBar({
             onChange={(event) => {
               onValueUpdate(event.target.value);
             }}
-            className="h-12 bg-background pl-10 text-base text-foreground md:text-lg"
+            className="h-12 bg-card pl-10 text-base text-foreground md:text-lg"
           />
         </div>
       </div>

--- a/packages/better-skill-capped/src/components/search/search-page.tsx
+++ b/packages/better-skill-capped/src/components/search/search-page.tsx
@@ -106,7 +106,7 @@ export function SearchPage(): React.ReactElement {
             replace: true,
           });
         }}
-        placeholder="Search for courses, videos, or game commentary — typos are okay"
+        placeholder="Search for courses, videos, or game commentary"
       />
       <div className="mx-auto grid max-w-6xl gap-6 px-4 py-6 md:grid-cols-[14rem_1fr]">
         <aside>

--- a/packages/better-skill-capped/src/components/ui/input.tsx
+++ b/packages/better-skill-capped/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/packages/better-skill-capped/src/components/ui/input.tsx
+++ b/packages/better-skill-capped/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none dark:bg-input/30 file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/packages/better-skill-capped/src/features/commentaries/coach-attribution.tsx
+++ b/packages/better-skill-capped/src/features/commentaries/coach-attribution.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Highlighter from "react-highlight-words";
 import { Link } from "@tanstack/react-router";
 import { useContent } from "#src/hooks/use-content";
 
@@ -9,8 +10,10 @@ import { useContent } from "#src/hooks/use-content";
  */
 export function CoachAttribution({
   name,
+  matchedStrings,
 }: {
   name: string;
+  matchedStrings: string[];
 }): React.ReactElement {
   const { content } = useContent();
   const staff = content?.staffByName.get(name);
@@ -31,7 +34,11 @@ export function CoachAttribution({
           className="size-5 rounded-full border bg-background"
         />
       )}
-      <span>{name}</span>
+      <Highlighter
+        searchWords={matchedStrings}
+        textToHighlight={name}
+        autoEscape={true}
+      />
       {staff !== undefined && typeof staff.playerPeakRank === "number" && (
         <span className="text-muted-foreground">
           #{staff.playerPeakRank} peak

--- a/packages/better-skill-capped/src/styles/globals.css
+++ b/packages/better-skill-capped/src/styles/globals.css
@@ -99,37 +99,37 @@ textarea {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
+    --background: oklch(0.18 0.025 255);
+    --foreground: oklch(0.96 0.015 245);
+    --card: oklch(0.235 0.03 255);
+    --card-foreground: oklch(0.96 0.015 245);
+    --popover: oklch(0.235 0.03 255);
+    --popover-foreground: oklch(0.96 0.015 245);
+    --primary: oklch(0.43 0.08 188);
+    --primary-foreground: oklch(0.98 0.01 190);
+    --secondary: oklch(0.3 0.035 255);
+    --secondary-foreground: oklch(0.95 0.015 245);
+    --muted: oklch(0.28 0.03 255);
+    --muted-foreground: oklch(0.76 0.04 250);
+    --accent: oklch(0.3 0.055 190);
+    --accent-foreground: oklch(0.96 0.015 190);
     --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
+    --border: oklch(0.4 0.035 255);
+    --input: oklch(0.48 0.035 255);
+    --ring: oklch(0.61 0.1 185);
     --chart-1: oklch(0.87 0 0);
     --chart-2: oklch(0.556 0 0);
     --chart-3: oklch(0.439 0 0);
     --chart-4: oklch(0.371 0 0);
     --chart-5: oklch(0.269 0 0);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+    --sidebar: oklch(0.21 0.03 255);
+    --sidebar-foreground: oklch(0.96 0.015 245);
+    --sidebar-primary: oklch(0.43 0.08 188);
+    --sidebar-primary-foreground: oklch(0.98 0.01 190);
+    --sidebar-accent: oklch(0.3 0.055 190);
+    --sidebar-accent-foreground: oklch(0.96 0.015 190);
+    --sidebar-border: oklch(0.4 0.035 255);
+    --sidebar-ring: oklch(0.61 0.1 185);
   }
 }
 


### PR DESCRIPTION
Why:
Better Skill Capped dark mode lacked a coherent surface hierarchy, and visible commentary and coach matches could be returned without highlighting. The Scout cross-promotion also did not explain its report and competition features.

What:
- Tune dark-mode slate/teal surfaces, borders, inputs, and the Scout banner.
- Highlight commentary matchups and coach names alongside video and course titles.
- Remove the typo-tolerance placeholder copy.
- Promote Scout alerts, detailed post-match reports, custom competitions, and daily leaderboards.

Verification:
- `cd packages/better-skill-capped && bun run typecheck`
- `cd packages/better-skill-capped && bun test` (73 pass)
- `cd packages/better-skill-capped && bun run lint`
- `cd packages/better-skill-capped && bun run build`
- PinchTab verified the dark-mode page, Tryndamere and Sjorry highlights, and the rendered Scout CTA.
- No production deploy run.