### PR TITLE
feat(scout): enable Bryan Bucks for League Classic

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/constants.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/constants.ts
@@ -85,10 +85,15 @@ export const REMAKE_MAX_DURATION_SECONDS = 300;
  * Deliberately its own list rather than the existing `isRankedQueue` helper,
  * which also matches "clash" and "aram clash". That helper exists to gate AI
  * review spend; reusing it would mean a future tweak to review heuristics
- * silently moves the economy. These two are also exactly the queues the MVP
- * weights are calibrated for.
+ * silently moves the economy. Solo and flex are also exactly the queues the
+ * MVP weights are calibrated for. Classic intentionally has no prediction
+ * inputs, but it still has a binary 5v5 outcome and can carry a market.
  */
-export const BUCKS_EARNING_QUEUES: readonly QueueType[] = ["solo", "flex"];
+export const BUCKS_EARNING_QUEUES: readonly QueueType[] = [
+  "solo",
+  "flex",
+  "classic",
+];
 
 /** Riot's two team identifiers on Summoner's Rift. */
 export const BLUE_TEAM_ID = 100;

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.integration.test.ts
@@ -159,6 +159,24 @@ describe("awardBucksForMatch", () => {
     expect(entries.every((e) => e.matchId === MATCH_ID)).toBe(true);
   });
 
+  test("awards the normal Bucks for League Classic", async () => {
+    await trackPlayer({
+      serverId: ENABLED_GUILD,
+      discordId: DiscordAccountIdSchema.parse("16050917270473910"),
+      alias: "classic-mvp",
+      puuid: mvpPuuid,
+    });
+
+    const awards = await awardBucksForMatch(withQueue(4310), db);
+
+    expect(awards[0]?.reasons.toSorted()).toEqual(
+      mvpParticipant.win ? ["mvp", "played", "win"] : ["mvp", "played"],
+    );
+    expect(awards[0]?.total).toBe(mvpParticipant.win ? 3 : 2);
+    const account = await db.bucksAccount.findFirstOrThrow();
+    expect(account.balance).toBe(SEED_GRANT + (mvpParticipant.win ? 3 : 2));
+  });
+
   test("awards two Bucks for a win that is not MVP", async () => {
     await trackPlayer({
       serverId: ENABLED_GUILD,
@@ -199,8 +217,8 @@ describe("awardBucksForMatch", () => {
       puuid: plainWinner.puuid,
     });
 
-    await awardBucksForMatch(fixture, db);
-    const second = await awardBucksForMatch(fixture, db);
+    await awardBucksForMatch(withQueue(4310), db);
+    const second = await awardBucksForMatch(withQueue(4310), db);
 
     expect(second).toEqual([]);
     const account = await db.bucksAccount.findFirstOrThrow();
@@ -274,6 +292,18 @@ describe("awardBucksForMatch", () => {
 
     // 450 is ARAM: a real game, but deliberately outside the economy.
     expect(await awardBucksForMatch(withQueue(450), db)).toEqual([]);
+    expect(await db.bucksMatchEarning.count()).toBe(0);
+  });
+
+  test("pays nothing for Classic ARAM Mayhem", async () => {
+    await trackPlayer({
+      serverId: ENABLED_GUILD,
+      discordId: DiscordAccountIdSchema.parse("16050917270473911"),
+      alias: "classic-mayhem",
+      puuid: plainWinner.puuid,
+    });
+
+    expect(await awardBucksForMatch(withQueue(2450), db)).toEqual([]);
     expect(await db.bucksMatchEarning.count()).toBe(0);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
@@ -23,8 +23,8 @@ const logger = createLogger("betting-earnings");
 /**
  * Awarding Bucks for playing.
  *
- * +1 for finishing a ranked game, +1 more for winning, +1 more for being the
- * game's MVP. Three separate ledger rows rather than one combined award,
+ * +1 for finishing an eligible game, +1 more for winning, +1 more for being
+ * the game's MVP. Three separate ledger rows rather than one combined award,
  * because "how did they get these points" is the requirement and a single +3
  * forces the reader to reconstruct which conditions fired.
  *

--- a/packages/scout-for-lol/packages/backend/src/betting/eligibility.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/eligibility.test.ts
@@ -12,9 +12,10 @@ function lobby(teamIds: readonly number[]) {
 const STANDARD = lobby([100, 100, 100, 100, 100, 200, 200, 200, 200, 200]);
 
 describe("isBettableQueue", () => {
-  test("accepts ranked solo and flex", () => {
+  test("accepts ranked solo, flex, and League Classic", () => {
     expect(isBettableQueue("solo")).toBe(true);
     expect(isBettableQueue("flex")).toBe(true);
+    expect(isBettableQueue("classic")).toBe(true);
   });
 
   test("rejects clash and aram clash", () => {
@@ -25,8 +26,9 @@ describe("isBettableQueue", () => {
     expect(isBettableQueue("aram clash")).toBe(false);
   });
 
-  test("rejects non-ranked and unknown queues", () => {
+  test("rejects non-ranked, Classic Mayhem, and unknown queues", () => {
     expect(isBettableQueue("aram")).toBe(false);
+    expect(isBettableQueue("classic aram mayhem")).toBe(false);
     expect(isBettableQueue("arena")).toBe(false);
     expect(isBettableQueue("quickplay")).toBe(false);
     expect(isBettableQueue(undefined)).toBe(false);
@@ -68,9 +70,18 @@ describe("isBettableGame", () => {
     expect(isBettableGame({ queueType: "solo", participants: STANDARD })).toBe(
       true,
     );
+    expect(
+      isBettableGame({ queueType: "classic", participants: STANDARD }),
+    ).toBe(true);
     expect(isBettableGame({ queueType: "aram", participants: STANDARD })).toBe(
       false,
     );
+    expect(
+      isBettableGame({
+        queueType: "classic aram mayhem",
+        participants: STANDARD,
+      }),
+    ).toBe(false);
     expect(
       isBettableGame({ queueType: "solo", participants: lobby([100, 200]) }),
     ).toBe(false);

--- a/packages/scout-for-lol/packages/backend/src/betting/pool-open.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/pool-open.integration.test.ts
@@ -1,0 +1,118 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import {
+  DiscordGuildIdSchema,
+  RawCurrentGameInfoSchema,
+} from "@scout-for-lol/data";
+import {
+  bucksTestPuuid,
+  bucksTestRoster,
+} from "#src/testing/bucks-fixtures.ts";
+import { openBettingPoolsForPrematch } from "#src/betting/pool-open.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  addFlagOverride,
+  clearFlagOverrides,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+
+const { prisma: db } = createTestDatabase("bucks-pool-open");
+const SERVER_ID = DiscordGuildIdSchema.parse("1337623164146155593");
+
+function gameInfo() {
+  return RawCurrentGameInfoSchema.parse({
+    gameId: 5_000_000_001,
+    gameStartTime: Date.now(),
+    gameMode: "JADE",
+    mapId: 453,
+    gameType: "MATCHED_GAME",
+    gameQueueConfigId: 4310,
+    gameLength: -1,
+    platformId: "NA1",
+    participants: bucksTestRoster().map((participant) => ({
+      championId: participant.championId,
+      puuid: participant.puuid,
+      teamId: participant.teamId,
+      riotId: participant.riotId ?? "Unknown#NA1",
+      spell1Id: 4,
+      spell2Id: 14,
+      lastSelectedSkinIndex: 0,
+      bot: false,
+      profileIconId: 1,
+    })),
+    bannedChampions: [],
+  });
+}
+
+async function clearPools() {
+  await db.bucksMatchPool.deleteMany();
+}
+
+beforeEach(async () => {
+  await clearPools();
+  clearFlagOverrides("betting_enabled");
+  addFlagOverride("betting_enabled", true, { server: SERVER_ID });
+});
+
+afterEach(() => {
+  resetFlagOverrides("betting_enabled");
+});
+
+afterAll(async () => {
+  await clearPools();
+  await db.$disconnect();
+});
+
+describe("openBettingPoolsForPrematch", () => {
+  test("opens a Classic pool and stores no prediction", async () => {
+    const opened = await openBettingPoolsForPrematch(
+      {
+        matchId: "NA1_5000000001",
+        gameInfo: gameInfo(),
+        queueType: "classic",
+        guildIds: [SERVER_ID],
+        detectedAt: new Date(),
+        trackedAliasByPuuid: new Map([
+          [bucksTestPuuid(0), "jerred"],
+          [bucksTestPuuid(5), "bryan"],
+        ]),
+      },
+      db,
+    );
+
+    expect(opened).toEqual(new Set([SERVER_ID]));
+    const pool = await db.bucksMatchPool.findUniqueOrThrow({
+      where: {
+        matchId_serverId: {
+          matchId: "NA1_5000000001",
+          serverId: SERVER_ID,
+        },
+      },
+    });
+    expect(pool.queueType).toBe("classic");
+    expect(pool.predictionJson).toBeNull();
+  });
+
+  test("does not open a Classic ARAM Mayhem pool", async () => {
+    const opened = await openBettingPoolsForPrematch(
+      {
+        matchId: "NA1_5000000002",
+        gameInfo: gameInfo(),
+        queueType: "classic aram mayhem",
+        guildIds: [SERVER_ID],
+        detectedAt: new Date(),
+        trackedAliasByPuuid: new Map(),
+      },
+      db,
+    );
+
+    expect(opened).toEqual(new Set());
+    expect(await db.bucksMatchPool.count()).toBe(0);
+  });
+});


### PR DESCRIPTION
Why:
League Classic queue 4310 should participate in the Bryan Bucks economy, while Classic ARAM Mayhem must remain excluded.

What:
- Add exact queue type classic to the shared Bucks earning and betting eligibility gate.
- Preserve standard 5v5 validation, existing rewards, betting, settlement, and ledger behavior.
- Keep prediction generation unchanged; Classic opens a market with no prediction footer.
- Add eligibility, earnings, pool-opening, Mayhem exclusion, and idempotency coverage.

Verification:
- bun test ./src/betting/eligibility.test.ts ./src/betting/earnings.integration.test.ts ./src/betting/pool-open.integration.test.ts ./src/betting/prematch-hook.integration.test.ts
- bunx turbo run typecheck test lint --filter=@scout-for-lol/backend
- bunx prettier --check src/betting/constants.ts src/betting/earnings.ts src/betting/eligibility.test.ts src/betting/earnings.integration.test.ts src/betting/pool-open.integration.test.ts
- No live Discord or production checks were run.