### PR TITLE
feat(scout-for-lol): add Ranked 5s and Clash Bryan Bucks betting

### DIFF
--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -739,7 +739,8 @@ model BucksLedgerEntry {
   balanceAfter Int
 
   // BucksLedgerKind (@scout-for-lol/data): seed | earn_game | earn_win |
-  // earn_mvp | bet_stake | bet_payout | bet_refund | adjustment.
+  // earn_ranked_5s_bonus | earn_clash_bonus | earn_win | earn_mvp | bet_stake |
+  // bet_payout | bet_refund | adjustment.
   // Not a Prisma enum — the SQLite provider has none. Zod-validated on write
   // and on read.
   kind String

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
@@ -113,8 +113,8 @@ describe("formatSettlementBody", () => {
           serverId: summary.serverId,
           discordId: WINNER_DISCORD_ID,
           alias: "Aaron",
-          reasons: ["played", "win"],
-          total: 2,
+          reasons: ["played", "clash bonus"],
+          total: 11,
         },
       ],
       predictionSentence: undefined,
@@ -127,7 +127,7 @@ describe("formatSettlementBody", () => {
     expect(body).toContain(
       `• <@${LOSER_DISCORD_ID}> staked 10 BB → received 0 BB`,
     );
-    expect(body).toContain("🪙 **Aaron** +2 BB (played, win)");
+    expect(body).toContain("🪙 **Aaron** +11 BB (played, clash bonus)");
   });
 
   test("labels refunds while retaining the original stake", () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/constants.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/constants.ts
@@ -82,17 +82,19 @@ export const REMAKE_MAX_DURATION_SECONDS = 300;
 /**
  * Queues that earn Bucks and can carry a market.
  *
- * Deliberately its own list rather than the existing `isRankedQueue` helper,
  * which also matches "clash" and "aram clash". That helper exists to gate AI
  * review spend; reusing it would mean a future tweak to review heuristics
- * silently moves the economy. Solo and flex are also exactly the queues the
- * MVP weights are calibrated for. Classic intentionally has no prediction
- * inputs, but it still has a binary 5v5 outcome and can carry a market.
+ * silently moves the economy. Solo and flex are exactly the queues the MVP
+ * weights are calibrated for. Classic intentionally has no prediction inputs,
+ * but it still has a binary 5v5 outcome and can carry a market. Standard Clash
+ * is included; ARAM Clash is not.
  */
 export const BUCKS_EARNING_QUEUES: readonly QueueType[] = [
   "solo",
   "flex",
   "classic",
+  "ranked 5s",
+  "clash",
 ];
 
 /** Riot's two team identifiers on Summoner's Rift. */

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.integration.test.ts
@@ -243,7 +243,9 @@ describe("awardBucksForMatch", () => {
     "awards the Ranked 5s participation bonus as a distinct ledger row",
     assertRanked5sParticipationBonus,
   );
+});
 
+describe("awardBucksForMatch additional cases", () => {
   test("stacks the Clash bonus with the win and MVP rewards", async () => {
     await trackPlayer({
       serverId: ENABLED_GUILD,

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.integration.test.ts
@@ -16,7 +16,10 @@ import {
   type RawMatch,
 } from "@scout-for-lol/data/index.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
-import { awardBucksForMatch } from "#src/betting/earnings.ts";
+import {
+  awardBucksForMatch,
+  type EarnedAwardReason,
+} from "#src/betting/earnings.ts";
 import { computeMvp } from "#src/betting/mvp.ts";
 import {
   addFlagOverride,
@@ -60,6 +63,8 @@ if (
 ) {
   throw new Error("fixture should contain an MVP, another winner, and a loser");
 }
+
+const plainLoserPuuid = plainLoser.puuid;
 
 async function trackPlayer(input: {
   serverId: DiscordGuildId;
@@ -111,6 +116,32 @@ function withDuration(seconds: number): RawMatch {
     ...fixture,
     info: { ...fixture.info, gameDuration: seconds },
   });
+}
+
+async function assertRanked5sParticipationBonus() {
+  await trackPlayer({
+    serverId: ENABLED_GUILD,
+    discordId: DiscordAccountIdSchema.parse("16050917270473109"),
+    alias: "ranked-5s-player",
+    puuid: plainLoserPuuid,
+  });
+
+  const awards = await awardBucksForMatch(withQueue(710), db);
+  expect(awards[0]?.reasons).toEqual(["played", "ranked 5s bonus"]);
+  expect(awards[0]?.total).toBe(2);
+
+  const entries = await db.bucksLedgerEntry.findMany({
+    where: { kind: { startsWith: "earn_" } },
+    orderBy: { id: "asc" },
+  });
+  expect(entries.map((entry) => entry.kind)).toEqual([
+    "earn_game",
+    "earn_ranked_5s_bonus",
+  ]);
+  expect(entries.map((entry) => entry.delta)).toEqual([1, 1]);
+
+  const account = await db.bucksAccount.findFirstOrThrow();
+  expect(account.balance).toBe(SEED_GRANT + 2);
 }
 
 beforeEach(async () => {
@@ -208,6 +239,50 @@ describe("awardBucksForMatch", () => {
     expect(account.balance).toBe(SEED_GRANT + 1);
   });
 
+  test(
+    "awards the Ranked 5s participation bonus as a distinct ledger row",
+    assertRanked5sParticipationBonus,
+  );
+
+  test("stacks the Clash bonus with the win and MVP rewards", async () => {
+    await trackPlayer({
+      serverId: ENABLED_GUILD,
+      discordId: DiscordAccountIdSchema.parse("16050917270473110"),
+      alias: "clash-mvp",
+      puuid: mvpPuuid,
+    });
+
+    const awards = await awardBucksForMatch(withQueue(700), db);
+    const expectedReasons: EarnedAwardReason[] = ["played", "clash bonus"];
+    if (mvpParticipant.win) {
+      expectedReasons.push("win");
+    }
+    expectedReasons.push("mvp");
+
+    expect(awards[0]?.reasons).toEqual(expectedReasons);
+    expect(awards[0]?.total).toBe(12 + (mvpParticipant.win ? 1 : 0));
+
+    const entries = await db.bucksLedgerEntry.findMany({
+      where: { kind: { startsWith: "earn_" } },
+      orderBy: { id: "asc" },
+    });
+    const expectedKinds = ["earn_game", "earn_clash_bonus"];
+    const expectedDeltas = [1, 10];
+    if (mvpParticipant.win) {
+      expectedKinds.push("earn_win");
+      expectedDeltas.push(1);
+    }
+    expectedKinds.push("earn_mvp");
+    expectedDeltas.push(1);
+    expect(entries.map((entry) => entry.kind)).toEqual(expectedKinds);
+    expect(entries.map((entry) => entry.delta)).toEqual(expectedDeltas);
+
+    const account = await db.bucksAccount.findFirstOrThrow();
+    expect(account.balance).toBe(
+      SEED_GRANT + 12 + (mvpParticipant.win ? 1 : 0),
+    );
+  });
+
   test("awarding the same match twice does not pay twice", async () => {
     // The regression guard for recoverMissedMatches and gap-detection replays.
     await trackPlayer({
@@ -217,17 +292,18 @@ describe("awardBucksForMatch", () => {
       puuid: plainWinner.puuid,
     });
 
-    await awardBucksForMatch(withQueue(4310), db);
-    const second = await awardBucksForMatch(withQueue(4310), db);
+    const clashMatch = withQueue(700);
+    await awardBucksForMatch(clashMatch, db);
+    const second = await awardBucksForMatch(clashMatch, db);
 
     expect(second).toEqual([]);
     const account = await db.bucksAccount.findFirstOrThrow();
-    expect(account.balance).toBe(SEED_GRANT + 2);
+    expect(account.balance).toBe(SEED_GRANT + 12);
     expect(
       await db.bucksLedgerEntry.count({
         where: { kind: { startsWith: "earn_" } },
       }),
-    ).toBe(2);
+    ).toBe(3);
   });
 
   test("pays a player tracked in two enabled guilds once in each", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
@@ -3,6 +3,7 @@ import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   LeaguePuuidSchema,
+  type BucksLedgerKind,
   parseQueueType,
   type QueueType,
   type RawMatch,
@@ -23,10 +24,9 @@ const logger = createLogger("betting-earnings");
 /**
  * Awarding Bucks for playing.
  *
- * +1 for finishing an eligible game, +1 more for winning, +1 more for being
- * the game's MVP. Three separate ledger rows rather than one combined award,
- * because "how did they get these points" is the requirement and a single +3
- * forces the reader to reconstruct which conditions fired.
+ * the game's MVP. Ranked 5s adds +1 for participating and standard Clash adds
+ * +10. Every reward stays in its own ledger row so "how did they get these
+ * points" never depends on reconstructing a combined total.
  *
  * Gated on `betting_enabled` deliberately. An ungated economy would accrue
  * silently in every server Scout is in, and enabling the flag later would hand
@@ -92,12 +92,32 @@ async function findEarnTargets(
   return targets;
 }
 
+export type EarnedAwardReason =
+  | "played"
+  | "ranked 5s bonus"
+  | "clash bonus"
+  | "win"
+  | "mvp";
+
+type EarnedReward = {
+  kind: BucksLedgerKind;
+  amount: number;
+};
+
+const EARNED_REWARDS = {
+  played: { kind: "earn_game", amount: 1 },
+  "ranked 5s bonus": { kind: "earn_ranked_5s_bonus", amount: 1 },
+  "clash bonus": { kind: "earn_clash_bonus", amount: 10 },
+  win: { kind: "earn_win", amount: 1 },
+  mvp: { kind: "earn_mvp", amount: 1 },
+} satisfies Record<EarnedAwardReason, EarnedReward>;
+
 export type EarnedAward = {
   serverId: string;
   discordId: string;
   alias: string;
-  /** Which of the three conditions fired, in award order. */
-  reasons: ("played" | "win" | "mvp")[];
+  /** Which rewards fired, in ledger order. */
+  reasons: EarnedAwardReason[];
   total: number;
 };
 
@@ -202,6 +222,7 @@ async function awardForGuild(input: {
 
       const awards: EarnedAward[] = [];
       let entryCount = 0;
+      let totalAwarded = 0;
 
       for (const target of input.targets) {
         const accountId = accountIds.get(target.discordId);
@@ -215,6 +236,12 @@ async function awardForGuild(input: {
           input.mvpPuuid === target.participant.puuid;
 
         const reasons: EarnedAward["reasons"] = ["played"];
+        if (input.queueType === "ranked 5s") {
+          reasons.push("ranked 5s bonus");
+        }
+        if (input.queueType === "clash") {
+          reasons.push("clash bonus");
+        }
         if (won) {
           reasons.push("win");
         }
@@ -222,17 +249,13 @@ async function awardForGuild(input: {
           reasons.push("mvp");
         }
 
-        const kinds = {
-          played: "earn_game",
-          win: "earn_win",
-          mvp: "earn_mvp",
-        } as const;
-
+        let total = 0;
         for (const reason of reasons) {
+          const reward = EARNED_REWARDS[reason];
           await applyBucksDelta(tx, {
             bucksAccountId: accountId,
-            delta: 1,
-            kind: kinds[reason],
+            delta: reward.amount,
+            kind: reward.kind,
             matchId: input.matchId,
             context: {
               type: "earn",
@@ -249,6 +272,8 @@ async function awardForGuild(input: {
             },
           });
           entryCount += 1;
+          totalAwarded += reward.amount;
+          total += reward.amount;
         }
 
         awards.push({
@@ -256,7 +281,7 @@ async function awardForGuild(input: {
           discordId: target.discordId,
           alias: target.alias,
           reasons,
-          total: reasons.length,
+          total,
         });
       }
 
@@ -271,7 +296,7 @@ async function awardForGuild(input: {
       });
 
       logger.info(
-        `🪙 Awarded ${entryCount.toString()} Bryan Buck(s) for ${input.matchId}`,
+        `🪙 Awarded ${totalAwarded.toString()} Bryan Buck(s) for ${input.matchId}`,
       );
       return awards;
     });

--- a/packages/scout-for-lol/packages/backend/src/betting/eligibility.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/eligibility.test.ts
@@ -12,17 +12,17 @@ function lobby(teamIds: readonly number[]) {
 const STANDARD = lobby([100, 100, 100, 100, 100, 200, 200, 200, 200, 200]);
 
 describe("isBettableQueue", () => {
-  test("accepts ranked solo, flex, and League Classic", () => {
+  test("accepts every supported ranked queue", () => {
     expect(isBettableQueue("solo")).toBe(true);
     expect(isBettableQueue("flex")).toBe(true);
     expect(isBettableQueue("classic")).toBe(true);
+    expect(isBettableQueue("ranked 5s")).toBe(true);
+    expect(isBettableQueue("clash")).toBe(true);
   });
 
-  test("rejects clash and aram clash", () => {
-    // These are the two the shared `isRankedQueue` helper would have let in.
-    // Keeping them out is why the economy has its own queue list: a change to
-    // AI-review gating must not be able to move what earns Bucks.
-    expect(isBettableQueue("clash")).toBe(false);
+  test("rejects ARAM Clash", () => {
+    // The broader ranked helper permits this mode, but only standard Clash is
+    // part of the economy.
     expect(isBettableQueue("aram clash")).toBe(false);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.integration.test.ts
@@ -1,5 +1,14 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import {
+  BucksPoolRosterSchema,
   DiscordGuildIdSchema,
   LeaguePuuidSchema,
   LoadingScreenDataSchema,
@@ -11,14 +20,17 @@ import {
   prepareBucksPrematch,
   type PrematchHookDependencies,
 } from "#src/betting/prematch-hook.ts";
+import { openBettingPoolsForPrematch } from "#src/betting/pool-open.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
   resetFlagOverrides,
 } from "#src/configuration/flags.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
 
 const ENABLED = DiscordGuildIdSchema.parse("1337623164146155593");
 const DISABLED = DiscordGuildIdSchema.parse("2337623164146155593");
+const { prisma: db } = createTestDatabase("bucks-prematch-hook");
 
 /**
  * A spy for the one step that costs a lake read.
@@ -106,13 +118,18 @@ function loadingScreen(): LoadingScreenData {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await db.bucksMatchPool.deleteMany();
   clearFlagOverrides("betting_enabled");
   addFlagOverride("betting_enabled", true, { server: ENABLED });
 });
 
 afterEach(() => {
   resetFlagOverrides("betting_enabled");
+});
+
+afterAll(async () => {
+  await db.$disconnect();
 });
 
 describe("prepareBucksPrematch", () => {
@@ -205,4 +222,56 @@ describe("prepareBucksPrematch", () => {
     // place-bet integration suites; this file is only about what work is done
     // before that point.
   });
+
+  for (const queue of [
+    { type: "ranked 5s", id: 710 },
+    { type: "clash", id: 700 },
+  ] as const) {
+    test(`proceeds for ${queue.type}`, async () => {
+      const { dependencies, buildPrediction } = spyDependencies();
+
+      await prepareBucksPrematch(
+        {
+          gameInfo: gameInfo({ gameQueueConfigId: queue.id }),
+          trackedPlayers: [trackedPlayer()],
+          queueType: queue.type,
+          targetGuildIds: [ENABLED],
+          loadingScreenData: loadingScreen(),
+          detectedAt: new Date(),
+        },
+        dependencies,
+      );
+
+      expect(buildPrediction).toHaveBeenCalled();
+    });
+  }
+
+  for (const queue of [
+    { type: "ranked 5s", id: 710 },
+    { type: "clash", id: 700 },
+  ] as const) {
+    test(`opens a ${queue.type} market for a standard 5v5`, async () => {
+      const matchId = `NA1_${queue.id.toString()}`;
+      const opened = await openBettingPoolsForPrematch(
+        {
+          matchId,
+          gameInfo: gameInfo({ gameQueueConfigId: queue.id }),
+          queueType: queue.type,
+          guildIds: [ENABLED],
+          detectedAt: new Date(),
+          trackedAliasByPuuid: new Map([[puuidFor(0), "jerred"]]),
+        },
+        db,
+      );
+
+      expect(opened).toEqual(new Set([ENABLED]));
+      const pool = await db.bucksMatchPool.findUniqueOrThrow({
+        where: { matchId_serverId: { matchId, serverId: ENABLED } },
+      });
+      expect(pool.queueType).toBe(queue.type);
+      expect(
+        BucksPoolRosterSchema.parse(JSON.parse(pool.roster)).participants,
+      ).toHaveLength(10);
+    });
+  }
 });

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -27,13 +27,15 @@ import { QueueTypeSchema } from "#src/model/state.ts";
 export type RiotTeamId = z.infer<typeof RiotTeamIdSchema>;
 export const RiotTeamIdSchema = z.union([z.literal(100), z.literal(200)]);
 
-/** Why a ledger row exists. Three separate `earn_*` kinds rather than one
- * combined award, because "how did they get these points" is the requirement
- * and a single `+3` forces the reader to reconstruct which conditions fired. */
+/** Why a ledger row exists. Separate `earn_*` kinds rather than one combined
+ * award, because "how did they get these points" is the requirement and a
+ * single total forces the reader to reconstruct which conditions fired. */
 export type BucksLedgerKind = z.infer<typeof BucksLedgerKindSchema>;
 export const BucksLedgerKindSchema = z.enum([
   "seed",
   "earn_game",
+  "earn_ranked_5s_bonus",
+  "earn_clash_bonus",
   "earn_win",
   "earn_mvp",
   "bet_stake",


### PR DESCRIPTION
Why:
Bryan Bucks could only open markets and reward players for solo/duo and flex games, excluding Ranked 5s and standard Clash.

What:
- Allow Ranked 5s and standard Clash 5v5 games to open Bryan Bucks markets and earn rewards; ARAM Clash remains excluded.
- Add a +1 Ranked 5s participation bonus and a +10 Clash participation bonus, both stacked with played, win, and MVP awards.
- Record each queue bonus as a distinct ledger kind, calculate announcement totals from reward amounts, and cover eligibility, pool creation, earnings, settlement text, and replay idempotency.

Verification:
- bun test ./src/betting/eligibility.test.ts ./src/betting/earnings.integration.test.ts ./src/betting/prematch-hook.integration.test.ts ./src/betting/announce.test.ts (38 passed)
- bun run typecheck
- bun run lint (passes; existing warnings only)
- bunx prettier --check <changed TypeScript files>
- git diff --check

No Prisma migration, live checks, or production deployment were run.