### PR TITLE
feat(scout-for-lol): enrich Bryan Bucks and publish weekly leaderboard

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -543,10 +543,9 @@ and audit history. Do not recreate the removed management command trees.
 `/bb` (Bryan Bucks) is the one owner-approved exception, pinned by
 `definitions.test.ts`. It is gated to a single guild by the `betting_enabled`
 flag — effectively beta-only, since that guild runs the beta bot — and a balance
-you cannot check from the same place you place a bet is not usable. Because
-command registration is a global replace, `/bb` is _visible_ everywhere but
-_answers_ in one server, so its description and its not-enabled-here reply both
-say so. Adding anything else needs the same explicit decision.
+you cannot check from the same place you place a bet is not usable. It is
+registered only in that guild, not globally. Adding anything else needs the
+same explicit decision.
 
 **Interactions are routed in `discord/interactions.ts`**, not in
 `discord/commands/index.ts`. That module is the single `interactionCreate`
@@ -840,6 +839,16 @@ The feature scope remains enforced by the flag and guild-scoped registration;
 user-facing betting surfaces should not advertise the allowlist or the private
 redemption joke. `/bb prizes` is the deliberate exception: it exposes the
 1:10 joke and its in-person-with-Bryan footer as a prize catalog.
+
+`/bb balance` and `/bb history` expose only the caller's wallet and positions;
+history uses caller-bound `bbnav:` component IDs and a frozen maximum ledger ID
+so new entries cannot reshuffle pages. `/bb open` shows anonymous side totals,
+never bettor identities or inferred odds. There is no on-demand leaderboard:
+the complete non-house wallet list is posted Fridays at 5 PM
+America/Los_Angeles in the shared Common Denominator channel. Both deployments
+run the cron, but only the Discord application in the one enabled guild posts;
+more than one enabled guild is a hard failure until an explicit channel mapping
+exists.
 
 Bucks exchange at 1:10 Bucks:CAD, in person only, from Bryan, who lives in rural
 Canada. There is no monetary component and nothing transfers to real goods.

--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.integration.test.ts
@@ -1,0 +1,307 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import {
+  getFullLeaderboard,
+  getLedgerPage,
+  getOpenMarketAggregates,
+  getPersonalBucksView,
+} from "#src/betting/accounts.ts";
+import { HOUSE_ACCOUNT_DISCORD_ID } from "#src/betting/constants.ts";
+import {
+  bucksTestDiscordId,
+  bucksTestPuuid,
+  bucksTestRoster,
+} from "#src/testing/bucks-fixtures.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+
+const { prisma: db } = createTestDatabase("bucks-accounts");
+const SERVER_A = DiscordGuildIdSchema.parse("1337623164146155593");
+const SERVER_B = DiscordGuildIdSchema.parse("2337623164146155593");
+const USER_A = bucksTestDiscordId(1);
+const USER_B = bucksTestDiscordId(2);
+
+async function clearAll(): Promise<void> {
+  await db.bucksLedgerEntry.deleteMany();
+  await db.bucksBet.deleteMany();
+  await db.bucksMatchPool.deleteMany();
+  await db.bucksAccount.deleteMany();
+}
+
+beforeEach(clearAll);
+
+afterAll(async () => {
+  await clearAll();
+  await db.$disconnect();
+});
+
+async function createLedger(accountId: number, count: number): Promise<void> {
+  for (let index = 1; index <= count; index++) {
+    await db.bucksLedgerEntry.create({
+      data: {
+        bucksAccountId: accountId,
+        delta: 1,
+        balanceAfter: index,
+        kind: "adjustment",
+        context: JSON.stringify({ type: "adjustment", note: "test" }),
+      },
+    });
+  }
+}
+
+describe("getLedgerPage", () => {
+  test("returns stable first, middle, and last pages", async () => {
+    const account = await db.bucksAccount.create({
+      data: { serverId: SERVER_A, discordId: USER_A, balance: 25 },
+    });
+    await createLedger(account.id, 25);
+
+    const first = await getLedgerPage(
+      { serverId: SERVER_A, discordId: USER_A, page: 0 },
+      db,
+    );
+    expect(first.entries.map((entry) => entry.balanceAfter)).toEqual([
+      25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+    ]);
+    expect(first.totalPages).toBe(3);
+    expect(first.snapshotId).not.toBeNull();
+
+    await createLedger(account.id, 1);
+    const snapshotId = first.snapshotId;
+    if (snapshotId === null) {
+      throw new Error("The populated ledger did not produce a snapshot ID");
+    }
+    const middle = await getLedgerPage(
+      {
+        serverId: SERVER_A,
+        discordId: USER_A,
+        page: 1,
+        snapshotId,
+      },
+      db,
+    );
+    const last = await getLedgerPage(
+      {
+        serverId: SERVER_A,
+        discordId: USER_A,
+        page: 2,
+        snapshotId,
+      },
+      db,
+    );
+
+    expect(middle.entries.map((entry) => entry.balanceAfter)).toEqual([
+      15, 14, 13, 12, 11, 10, 9, 8, 7, 6,
+    ]);
+    expect(last.entries.map((entry) => entry.balanceAfter)).toEqual([
+      5, 4, 3, 2, 1,
+    ]);
+    expect(middle.totalEntries).toBe(25);
+    expect(last.totalPages).toBe(3);
+  });
+
+  test("scopes a snapshot to the caller and guild", async () => {
+    const accountA = await db.bucksAccount.create({
+      data: { serverId: SERVER_A, discordId: USER_A, balance: 1 },
+    });
+    const accountB = await db.bucksAccount.create({
+      data: { serverId: SERVER_B, discordId: USER_A, balance: 2 },
+    });
+    const otherUser = await db.bucksAccount.create({
+      data: { serverId: SERVER_A, discordId: USER_B, balance: 3 },
+    });
+    await createLedger(accountA.id, 1);
+    await createLedger(accountB.id, 2);
+    await createLedger(otherUser.id, 3);
+
+    const page = await getLedgerPage(
+      { serverId: SERVER_A, discordId: USER_A, page: 0 },
+      db,
+    );
+    expect(page.entries).toHaveLength(1);
+    expect(page.entries[0]?.balanceAfter).toBe(1);
+  });
+});
+
+describe("personal positions and open markets", () => {
+  test("returns only the caller's positions while markets expose aggregates", async () => {
+    const caller = await db.bucksAccount.create({
+      data: { serverId: SERVER_A, discordId: USER_A, balance: 80 },
+    });
+    const other = await db.bucksAccount.create({
+      data: { serverId: SERVER_A, discordId: USER_B, balance: 90 },
+    });
+    const house = await db.bucksAccount.create({
+      data: {
+        serverId: SERVER_A,
+        discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        isHouse: true,
+        balance: 10_000,
+      },
+    });
+    const pool = await db.bucksMatchPool.create({
+      data: {
+        matchId: "NA1_5000000100",
+        serverId: SERVER_A,
+        detectedAt: new Date("2030-01-01T00:00:00Z"),
+        closesAt: new Date("2030-01-01T00:10:00Z"),
+        roster: JSON.stringify({ participants: bucksTestRoster() }),
+      },
+    });
+    await db.bucksBet.createMany({
+      data: [
+        {
+          poolId: pool.id,
+          bucksAccountId: caller.id,
+          predictedTeamId: 100,
+          subjectPuuid: bucksTestPuuid(0),
+          stake: 20,
+        },
+        {
+          poolId: pool.id,
+          bucksAccountId: other.id,
+          predictedTeamId: 100,
+          subjectPuuid: bucksTestPuuid(5),
+          stake: 30,
+        },
+        {
+          poolId: pool.id,
+          bucksAccountId: house.id,
+          predictedTeamId: 200,
+          subjectPuuid: bucksTestPuuid(0),
+          stake: 50,
+        },
+      ],
+    });
+
+    const personal = await getPersonalBucksView(
+      { serverId: SERVER_A, discordId: USER_A },
+      db,
+    );
+    expect(personal).toEqual(
+      expect.objectContaining({
+        balance: 80,
+        totalStaked: 20,
+        pendingPositionCount: 1,
+      }),
+    );
+    expect(personal?.pendingPositions).toEqual([
+      expect.objectContaining({
+        subjectAlias: "jerred",
+        side: "WIN",
+        stake: 20,
+      }),
+    ]);
+
+    const markets = await getOpenMarketAggregates(
+      { serverId: SERVER_A, now: new Date("2030-01-01T00:05:00Z") },
+      db,
+    );
+    expect(markets).toEqual([
+      expect.objectContaining({
+        blue: {
+          trackedPlayers: ["jerred"],
+          totalStake: 50,
+          betCount: 2,
+        },
+        red: {
+          trackedPlayers: ["bryan"],
+          totalStake: 0,
+          betCount: 0,
+        },
+      }),
+    ]);
+    const rendered = JSON.stringify(markets);
+    expect(rendered).not.toContain(USER_A);
+    expect(rendered).not.toContain(USER_B);
+    expect(rendered).not.toContain(HOUSE_ACCOUNT_DISCORD_ID);
+  });
+
+  test("caps the detailed personal position list at ten without understating total stake", async () => {
+    const caller = await db.bucksAccount.create({
+      data: { serverId: SERVER_A, discordId: USER_A, balance: 100 },
+    });
+    for (let index = 0; index < 11; index++) {
+      const pool = await db.bucksMatchPool.create({
+        data: {
+          matchId: `NA1_50000002${index.toString().padStart(2, "0")}`,
+          serverId: SERVER_A,
+          detectedAt: new Date("2030-01-01T00:00:00Z"),
+          closesAt: new Date("2030-01-01T00:10:00Z"),
+          roster: JSON.stringify({ participants: bucksTestRoster() }),
+        },
+      });
+      await db.bucksBet.create({
+        data: {
+          poolId: pool.id,
+          bucksAccountId: caller.id,
+          predictedTeamId: 100,
+          subjectPuuid: bucksTestPuuid(0),
+          stake: index + 1,
+        },
+      });
+    }
+
+    const personal = await getPersonalBucksView(
+      { serverId: SERVER_A, discordId: USER_A },
+      db,
+    );
+    expect(personal?.pendingPositionCount).toBe(11);
+    expect(personal?.pendingPositions).toHaveLength(10);
+    expect(personal?.totalStaked).toBe(66);
+  });
+});
+
+describe("getFullLeaderboard", () => {
+  test("includes zero balances, orders ties by account ID, and excludes house/other guilds", async () => {
+    const tiedFirst = await db.bucksAccount.create({
+      data: {
+        serverId: SERVER_A,
+        discordId: bucksTestDiscordId(4),
+        balance: 9,
+      },
+    });
+    const tiedSecond = await db.bucksAccount.create({
+      data: {
+        serverId: SERVER_A,
+        discordId: bucksTestDiscordId(3),
+        balance: 9,
+      },
+    });
+    const zero = await db.bucksAccount.create({
+      data: {
+        serverId: SERVER_A,
+        discordId: bucksTestDiscordId(5),
+        balance: 0,
+      },
+    });
+    await db.bucksAccount.create({
+      data: {
+        serverId: SERVER_A,
+        discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        isHouse: true,
+        balance: 10_000,
+      },
+    });
+    await db.bucksAccount.create({
+      data: {
+        serverId: SERVER_B,
+        discordId: bucksTestDiscordId(6),
+        balance: 99,
+      },
+    });
+
+    expect(await getFullLeaderboard({ serverId: SERVER_A }, db)).toEqual([
+      {
+        accountId: tiedFirst.id,
+        discordId: tiedFirst.discordId,
+        balance: 9,
+      },
+      {
+        accountId: tiedSecond.id,
+        discordId: tiedSecond.discordId,
+        balance: 9,
+      },
+      { accountId: zero.id, discordId: zero.discordId, balance: 0 },
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
@@ -1,4 +1,11 @@
-import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import {
+  BucksPoolRosterSchema,
+  BucksPoolStateSchema,
+  RiotTeamIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+  type RiotTeamId,
+} from "@scout-for-lol/data";
 import { SEED_GRANT } from "#src/betting/constants.ts";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -49,6 +56,23 @@ export type BucksAccountRef = {
   id: number;
   balance: number;
 };
+
+/** The wallet ID for one Discord user in one guild, when it exists. */
+export async function findBucksAccountId(
+  input: { serverId: DiscordGuildId; discordId: DiscordAccountId },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<number | undefined> {
+  const account = await prismaClient.bucksAccount.findUnique({
+    where: {
+      serverId_discordId: {
+        serverId: input.serverId,
+        discordId: input.discordId,
+      },
+    },
+    select: { id: true },
+  });
+  return account?.id;
+}
 
 /**
  * Fetch or create this user's wallet in this guild.
@@ -126,24 +150,8 @@ export async function ensureBucksAccount(
   }
 }
 
-/** Current balance, or undefined when the user has never had a wallet here. */
-export async function getBalance(
-  input: { serverId: DiscordGuildId; discordId: DiscordAccountId },
-  prismaClient: ExtendedPrismaClient = prisma,
-): Promise<number | undefined> {
-  const account = await prismaClient.bucksAccount.findUnique({
-    where: {
-      serverId_discordId: {
-        serverId: input.serverId,
-        discordId: input.discordId,
-      },
-    },
-    select: { balance: true },
-  });
-  return account?.balance;
-}
-
 export type LedgerPageEntry = {
+  id: number;
   delta: number;
   balanceAfter: number;
   kind: string;
@@ -152,32 +160,81 @@ export type LedgerPageEntry = {
   createdAt: Date;
 };
 
-/** Most recent ledger rows, newest first — the "how did I get these" view. */
+export const LEDGER_PAGE_SIZE = 10;
+
+export type LedgerPage = {
+  entries: LedgerPageEntry[];
+  page: number;
+  pageSize: number;
+  totalEntries: number;
+  totalPages: number;
+  snapshotId: number | null;
+};
+
+/**
+ * One stable page of ledger rows, newest first.
+ *
+ * The first read freezes the account's maximum ledger ID. Every later page
+ * filters against that ID, so new earnings and settlements cannot move rows
+ * between pages while someone is navigating the response.
+ */
 export async function getLedgerPage(
   input: {
     serverId: DiscordGuildId;
     discordId: DiscordAccountId;
-    limit: number;
+    page: number;
+    snapshotId?: number;
   },
   prismaClient: ExtendedPrismaClient = prisma,
-): Promise<LedgerPageEntry[]> {
-  const account = await prismaClient.bucksAccount.findUnique({
+): Promise<LedgerPage> {
+  const bucksAccountId = await findBucksAccountId(input, prismaClient);
+  if (bucksAccountId === undefined) {
+    return {
+      entries: [],
+      page: 0,
+      pageSize: LEDGER_PAGE_SIZE,
+      totalEntries: 0,
+      totalPages: 0,
+      snapshotId: null,
+    };
+  }
+
+  const newest = await prismaClient.bucksLedgerEntry.findFirst({
     where: {
-      serverId_discordId: {
-        serverId: input.serverId,
-        discordId: input.discordId,
-      },
+      bucksAccountId,
+      ...(input.snapshotId === undefined
+        ? {}
+        : { id: { lte: input.snapshotId } }),
     },
+    orderBy: { id: "desc" },
     select: { id: true },
   });
-  if (account === null) {
-    return [];
+  const snapshotId = input.snapshotId ?? newest?.id ?? null;
+  if (snapshotId === null) {
+    return {
+      entries: [],
+      page: 0,
+      pageSize: LEDGER_PAGE_SIZE,
+      totalEntries: 0,
+      totalPages: 0,
+      snapshotId: null,
+    };
   }
-  return await prismaClient.bucksLedgerEntry.findMany({
-    where: { bucksAccountId: account.id },
-    orderBy: { createdAt: "desc" },
-    take: input.limit,
+
+  const where = {
+    bucksAccountId,
+    id: { lte: snapshotId },
+  };
+  const totalEntries = await prismaClient.bucksLedgerEntry.count({ where });
+  const totalPages = Math.ceil(totalEntries / LEDGER_PAGE_SIZE);
+  const page = Math.min(input.page, Math.max(totalPages - 1, 0));
+  const entries = await prismaClient.bucksLedgerEntry.findMany({
+    where,
+    orderBy: { id: "desc" },
+    skip: page * LEDGER_PAGE_SIZE,
+    take: LEDGER_PAGE_SIZE,
     select: {
+      id: true,
       delta: true,
       balanceAfter: true,
       kind: true,
@@ -186,17 +243,196 @@ export async function getLedgerPage(
       createdAt: true,
     },
   });
+
+  return {
+    entries,
+    page,
+    pageSize: LEDGER_PAGE_SIZE,
+    totalEntries,
+    totalPages,
+    snapshotId,
+  };
 }
 
-/** Top balances in a guild, for the leaderboard. */
-export async function getLeaderboard(
-  input: { serverId: DiscordGuildId; limit: number },
+export type PendingPosition = {
+  matchId: string;
+  subjectAlias: string;
+  side: "WIN" | "LOSE";
+  stake: number;
+  closesAt: Date;
+  poolState: string;
+};
+
+export type PersonalBucksView = {
+  balance: number;
+  totalStaked: number;
+  pendingPositionCount: number;
+  pendingPositions: PendingPosition[];
+};
+
+/** The caller's balance and at most ten of their pending positions. */
+export async function getPersonalBucksView(
+  input: { serverId: DiscordGuildId; discordId: DiscordAccountId },
   prismaClient: ExtendedPrismaClient = prisma,
-): Promise<{ discordId: string; balance: number }[]> {
-  return await prismaClient.bucksAccount.findMany({
+): Promise<PersonalBucksView | undefined> {
+  return await prismaClient.$transaction(async (tx) => {
+    const account = await tx.bucksAccount.findUnique({
+      where: {
+        serverId_discordId: {
+          serverId: input.serverId,
+          discordId: input.discordId,
+        },
+      },
+      select: { id: true, balance: true },
+    });
+    if (account === null) {
+      return;
+    }
+
+    const [aggregate, bets] = await Promise.all([
+      tx.bucksBet.aggregate({
+        where: { bucksAccountId: account.id, betOutcome: "pending" },
+        _sum: { stake: true },
+        _count: true,
+      }),
+      tx.bucksBet.findMany({
+        where: { bucksAccountId: account.id, betOutcome: "pending" },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        take: 10,
+        select: {
+          stake: true,
+          predictedTeamId: true,
+          subjectPuuid: true,
+          pool: {
+            select: {
+              matchId: true,
+              roster: true,
+              closesAt: true,
+              poolState: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    return {
+      balance: account.balance,
+      totalStaked: aggregate._sum.stake ?? 0,
+      pendingPositionCount: aggregate._count,
+      pendingPositions: bets.map((bet) => {
+        const roster = BucksPoolRosterSchema.parse(
+          JSON.parse(bet.pool.roster),
+        ).participants;
+        const subject = roster.find(
+          (participant) => participant.puuid === bet.subjectPuuid,
+        );
+        if (subject?.trackedAlias === undefined) {
+          throw new Error(
+            `Pending Bryan Bucks position ${bet.pool.matchId} has no tracked subject`,
+          );
+        }
+        return {
+          matchId: bet.pool.matchId,
+          subjectAlias: subject.trackedAlias,
+          side:
+            RiotTeamIdSchema.parse(bet.predictedTeamId) === subject.teamId
+              ? "WIN"
+              : "LOSE",
+          stake: bet.stake,
+          closesAt: bet.pool.closesAt,
+          poolState: BucksPoolStateSchema.parse(bet.pool.poolState),
+        };
+      }),
+    };
+  });
+}
+
+export type OpenMarketSide = {
+  trackedPlayers: string[];
+  totalStake: number;
+  betCount: number;
+};
+
+export type OpenMarketAggregate = {
+  matchId: string;
+  closesAt: Date;
+  blue: OpenMarketSide;
+  red: OpenMarketSide;
+};
+
+function marketSide(
+  teamId: RiotTeamId,
+  roster: ReturnType<typeof BucksPoolRosterSchema.parse>["participants"],
+  bets: readonly { predictedTeamId: number; stake: number }[],
+): OpenMarketSide {
+  const sideBets = bets.filter(
+    (bet) => RiotTeamIdSchema.parse(bet.predictedTeamId) === teamId,
+  );
+  return {
+    trackedPlayers: roster
+      .filter((participant) => participant.teamId === teamId)
+      .map((participant) => participant.trackedAlias)
+      .filter((alias) => alias !== undefined),
+    totalStake: sideBets.reduce((total, bet) => total + bet.stake, 0),
+    betCount: sideBets.length,
+  };
+}
+
+/** Every currently open market, with anonymous stake aggregates only. */
+export async function getOpenMarketAggregates(
+  input: { serverId: DiscordGuildId; now?: Date },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<OpenMarketAggregate[]> {
+  const pools = await prismaClient.bucksMatchPool.findMany({
+    where: {
+      serverId: input.serverId,
+      poolState: "open",
+      closesAt: { gt: input.now ?? new Date() },
+    },
+    orderBy: [{ closesAt: "asc" }, { id: "asc" }],
+    select: {
+      matchId: true,
+      closesAt: true,
+      roster: true,
+      bets: {
+        where: { betOutcome: "pending", bucksAccount: { isHouse: false } },
+        select: { predictedTeamId: true, stake: true },
+      },
+    },
+  });
+
+  return pools.map((pool) => {
+    const roster = BucksPoolRosterSchema.parse(
+      JSON.parse(pool.roster),
+    ).participants;
+    return {
+      matchId: pool.matchId,
+      closesAt: pool.closesAt,
+      blue: marketSide(100, roster, pool.bets),
+      red: marketSide(200, roster, pool.bets),
+    };
+  });
+}
+
+export type FullLeaderboardRow = {
+  accountId: number;
+  discordId: string;
+  balance: number;
+};
+
+/** Every non-house wallet in one guild, for the scheduled weekly post only. */
+export async function getFullLeaderboard(
+  input: { serverId: DiscordGuildId },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<FullLeaderboardRow[]> {
+  const rows = await prismaClient.bucksAccount.findMany({
     where: { serverId: input.serverId, isHouse: false },
     orderBy: [{ balance: "desc" }, { id: "asc" }],
-    take: input.limit,
-    select: { discordId: true, balance: true },
+    select: { id: true, discordId: true, balance: true },
   });
+  return rows.map((row) => ({
+    accountId: row.id,
+    discordId: row.discordId,
+    balance: row.balance,
+  }));
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -4,6 +4,7 @@ import {
   DiscordGuildIdSchema,
   type BucksPoolParticipant,
 } from "@scout-for-lol/data";
+import type { InteractionEditReplyOptions } from "discord.js";
 import { parseBucksCustomId } from "#src/betting/custom-id.ts";
 import { placeBet, type PlaceBetResult } from "#src/betting/place-bet.ts";
 import { cancelBet, type CancelBetResult } from "#src/betting/cancel-bet.ts";
@@ -21,12 +22,17 @@ const logger = createLogger("betting-bet-button");
  * with no cast, and a test can pass a plain object with mock functions. That
  * avoids `castMock` in `discord-mocks.ts`, which is an `as` escape hatch.
  */
+export type BucksButtonEditReplyOptions = {
+  content: string;
+  components?: NonNullable<InteractionEditReplyOptions["components"]>;
+};
+
 export type BetButtonInteraction = {
   customId: string;
   guildId: string | null;
   user: { id: string };
   deferReply: (options: { ephemeral: true }) => Promise<unknown>;
-  editReply: (options: { content: string }) => Promise<unknown>;
+  editReply: (options: BucksButtonEditReplyOptions) => Promise<unknown>;
 };
 
 /** Turn a refusal into something a person can act on. Every branch is ordinary

--- a/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
@@ -4,6 +4,7 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
+import { findBucksAccountId } from "#src/betting/accounts.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -58,16 +59,8 @@ export async function cancelBet(
     return { kind: "no_pool" };
   }
 
-  const account = await prismaClient.bucksAccount.findUnique({
-    where: {
-      serverId_discordId: {
-        serverId: input.serverId,
-        discordId: input.discordId,
-      },
-    },
-    select: { id: true },
-  });
-  if (account === null) {
+  const bucksAccountId = await findBucksAccountId(input, prismaClient);
+  if (bucksAccountId === undefined) {
     // No wallet in this guild means no stake in this pool, so this is the same
     // answer as an empty bet slot rather than a distinct state.
     return { kind: "no_bet" };
@@ -92,7 +85,7 @@ export async function cancelBet(
         where: {
           poolId_bucksAccountId: {
             poolId: pool.id,
-            bucksAccountId: account.id,
+            bucksAccountId,
           },
         },
         select: { id: true },
@@ -123,7 +116,7 @@ export async function cancelBet(
       where: {
         poolId_bucksAccountId: {
           poolId: pool.id,
-          bucksAccountId: account.id,
+          bucksAccountId,
         },
       },
       select: { id: true, stake: true, predictedTeamId: true },
@@ -143,7 +136,7 @@ export async function cancelBet(
 
     // The ledger row references the bet, so credit before deleting it.
     const balanceAfter = await applyBucksDelta(tx, {
-      bucksAccountId: account.id,
+      bucksAccountId,
       delta: bet.stake,
       kind: "bet_refund",
       matchId: input.matchId,

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.integration.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import {
+  formatBucksNavigationId,
+  handleBucksNavigation,
+  parseBucksNavigationId,
+  type BucksNavigationInteraction,
+} from "#src/betting/navigation.ts";
+import type { BucksButtonEditReplyOptions } from "#src/betting/bet-button.ts";
+import { getLedgerPage } from "#src/betting/accounts.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+
+const { prisma: db } = createTestDatabase("bucks-navigation");
+const SERVER_ID = DiscordGuildIdSchema.parse("1337623164146155593");
+const OWNER_ID = bucksTestDiscordId(1);
+const OTHER_ID = bucksTestDiscordId(2);
+
+async function clearAll(): Promise<void> {
+  await db.bucksLedgerEntry.deleteMany();
+  await db.bucksAccount.deleteMany();
+}
+
+beforeEach(clearAll);
+
+afterAll(async () => {
+  await clearAll();
+  await db.$disconnect();
+});
+
+function fakeNavigation(customId: string, userId = OWNER_ID) {
+  const calls: string[] = [];
+  const replies: BucksButtonEditReplyOptions[] = [];
+  const interaction: BucksNavigationInteraction = {
+    customId,
+    guildId: SERVER_ID,
+    user: { id: userId },
+    deferReply: mock(() => {
+      calls.push("deferReply");
+      return Promise.resolve(undefined);
+    }),
+    deferUpdate: mock(() => {
+      calls.push("deferUpdate");
+      return Promise.resolve(undefined);
+    }),
+    editReply: mock((options: BucksButtonEditReplyOptions) => {
+      calls.push("editReply");
+      replies.push(options);
+      return Promise.resolve(undefined);
+    }),
+  };
+  return { interaction, calls, replies };
+}
+
+async function createHistory(count: number) {
+  const account = await db.bucksAccount.create({
+    data: { serverId: SERVER_ID, discordId: OWNER_ID, balance: count },
+  });
+  for (let index = 1; index <= count; index++) {
+    await db.bucksLedgerEntry.create({
+      data: {
+        bucksAccountId: account.id,
+        delta: 1,
+        balanceAfter: index,
+        kind: "adjustment",
+        context: JSON.stringify({ type: "adjustment", note: "test" }),
+      },
+    });
+  }
+  return account;
+}
+
+describe("Bryan Bucks history navigation", () => {
+  test("round-trips the versioned caller-bound ID", () => {
+    const input = {
+      action: "h" as const,
+      ownerId: OWNER_ID,
+      snapshotId: 123,
+      page: 2,
+    };
+    expect(parseBucksNavigationId(formatBucksNavigationId(input))).toEqual(
+      input,
+    );
+  });
+
+  test("rejects a click from anyone except the original caller", async () => {
+    await createHistory(12);
+    const first = await getLedgerPage(
+      { serverId: SERVER_ID, discordId: OWNER_ID, page: 0 },
+      db,
+    );
+    if (first.snapshotId === null) {
+      throw new Error("The populated ledger did not produce a snapshot ID");
+    }
+    const { interaction, calls, replies } = fakeNavigation(
+      formatBucksNavigationId({
+        action: "h",
+        ownerId: OWNER_ID,
+        snapshotId: first.snapshotId,
+        page: 1,
+      }),
+      OTHER_ID,
+    );
+
+    await handleBucksNavigation(interaction, db);
+
+    expect(calls).toEqual(["deferReply", "editReply"]);
+    expect(replies[0]?.content).toContain("Only the person");
+    expect(replies[0]?.content).not.toContain("BB history");
+  });
+
+  test("loads the requested frozen page for its owner", async () => {
+    const account = await createHistory(12);
+    const first = await getLedgerPage(
+      { serverId: SERVER_ID, discordId: OWNER_ID, page: 0 },
+      db,
+    );
+    if (first.snapshotId === null) {
+      throw new Error("The populated ledger did not produce a snapshot ID");
+    }
+    await db.bucksLedgerEntry.create({
+      data: {
+        bucksAccountId: account.id,
+        delta: 50,
+        balanceAfter: 62,
+        kind: "adjustment",
+        context: JSON.stringify({ type: "adjustment", note: "new" }),
+      },
+    });
+    const { interaction, calls, replies } = fakeNavigation(
+      formatBucksNavigationId({
+        action: "h",
+        ownerId: OWNER_ID,
+        snapshotId: first.snapshotId,
+        page: 1,
+      }),
+    );
+
+    await handleBucksNavigation(interaction, db);
+
+    expect(calls).toEqual(["deferUpdate", "editReply"]);
+    expect(replies[0]?.content).toContain("Page 2/2");
+    expect(replies[0]?.content).toContain("→ 2 BB");
+    expect(replies[0]?.content).toContain("→ 1 BB");
+    expect(replies[0]?.content).not.toContain("→ 62 BB");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -1,0 +1,191 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import { getLedgerPage, type LedgerPage } from "#src/betting/accounts.ts";
+import { getFlag } from "#src/configuration/flags.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import type { BucksButtonEditReplyOptions } from "#src/betting/bet-button.ts";
+
+export const BUCKS_NAVIGATION_NAMESPACE = "bbnav";
+export const BUCKS_NAVIGATION_VERSION = "1";
+
+const BucksNavigationIdSchema = z.strictObject({
+  action: z.literal("h"),
+  ownerId: DiscordAccountIdSchema,
+  snapshotId: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  page: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+});
+
+export type BucksNavigationId = z.infer<typeof BucksNavigationIdSchema>;
+
+export function formatBucksNavigationId(input: BucksNavigationId): string {
+  const parsed = BucksNavigationIdSchema.parse(input);
+  const customId = [
+    BUCKS_NAVIGATION_NAMESPACE,
+    BUCKS_NAVIGATION_VERSION,
+    parsed.action,
+    parsed.ownerId,
+    parsed.snapshotId.toString(),
+    parsed.page.toString(),
+  ].join(":");
+  if (customId.length > 100) {
+    throw new Error(
+      `Bryan Bucks navigation ID exceeds Discord's 100-character limit: ${customId}`,
+    );
+  }
+  return customId;
+}
+
+const EXPECTED_SEGMENTS = 6;
+
+export function parseBucksNavigationId(
+  raw: string,
+): BucksNavigationId | undefined {
+  const segments = raw.split(":");
+  if (segments.length !== EXPECTED_SEGMENTS) {
+    return undefined;
+  }
+  const [namespace, version, action, ownerId, snapshotId, page] = segments;
+  if (
+    namespace !== BUCKS_NAVIGATION_NAMESPACE ||
+    version !== BUCKS_NAVIGATION_VERSION
+  ) {
+    return undefined;
+  }
+  const result = BucksNavigationIdSchema.safeParse({
+    action,
+    ownerId,
+    snapshotId: Number(snapshotId),
+    page: Number(page),
+  });
+  return result.success ? result.data : undefined;
+}
+
+export function isBucksNavigationId(raw: string): boolean {
+  return raw.startsWith(`${BUCKS_NAVIGATION_NAMESPACE}:`);
+}
+
+function navigationRow(
+  ownerId: ReturnType<typeof DiscordAccountIdSchema.parse>,
+  page: LedgerPage,
+): ActionRowBuilder<ButtonBuilder>[] {
+  if (page.snapshotId === null || page.totalPages <= 1) {
+    return [];
+  }
+
+  const previousPage = Math.max(page.page - 1, 0);
+  const nextPage = Math.min(page.page + 1, page.totalPages - 1);
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(
+          formatBucksNavigationId({
+            action: "h",
+            ownerId,
+            snapshotId: page.snapshotId,
+            page: previousPage,
+          }),
+        )
+        .setLabel("Previous")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(page.page === 0),
+      new ButtonBuilder()
+        .setCustomId(
+          formatBucksNavigationId({
+            action: "h",
+            ownerId,
+            snapshotId: page.snapshotId,
+            page: nextPage,
+          }),
+        )
+        .setLabel("Next")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(page.page >= page.totalPages - 1),
+    ),
+  ];
+}
+
+export function renderBucksHistory(
+  ownerId: ReturnType<typeof DiscordAccountIdSchema.parse>,
+  page: LedgerPage,
+): BucksButtonEditReplyOptions {
+  if (page.entries.length === 0) {
+    return { content: "No Bryan Bucks history yet.", components: [] };
+  }
+
+  const lines = page.entries.map((entry) => {
+    const sign = entry.delta > 0 ? "+" : "";
+    const where = entry.matchId === null ? "" : ` · ${entry.matchId}`;
+    return `\`${sign}${entry.delta.toString()}\` ${entry.kind}${where} → ${entry.balanceAfter.toString()} BB`;
+  });
+  return {
+    content: [
+      `**Bryan Bucks history** · Page ${(page.page + 1).toString()}/${page.totalPages.toString()}`,
+      ...lines,
+    ].join("\n"),
+    components: navigationRow(ownerId, page),
+  };
+}
+
+export type BucksNavigationInteraction = {
+  customId: string;
+  guildId: string | null;
+  user: { id: string };
+  deferReply: (options: { ephemeral: true }) => Promise<unknown>;
+  deferUpdate: () => Promise<unknown>;
+  editReply: (options: BucksButtonEditReplyOptions) => Promise<unknown>;
+};
+
+export async function handleBucksNavigation(
+  interaction: BucksNavigationInteraction,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  const navigation = parseBucksNavigationId(interaction.customId);
+  if (navigation === undefined) {
+    await interaction.deferUpdate();
+    return;
+  }
+  if (interaction.guildId === null) {
+    await interaction.deferReply({ ephemeral: true });
+    await interaction.editReply({
+      content: "Bryan Bucks only works inside a server.",
+      components: [],
+    });
+    return;
+  }
+
+  const clickerId = DiscordAccountIdSchema.parse(interaction.user.id);
+  if (clickerId !== navigation.ownerId) {
+    await interaction.deferReply({ ephemeral: true });
+    await interaction.editReply({
+      content:
+        "Only the person who opened this history can use these controls.",
+    });
+    return;
+  }
+
+  const serverId = DiscordGuildIdSchema.parse(interaction.guildId);
+  if (!getFlag("betting_enabled", { server: serverId })) {
+    await interaction.deferReply({ ephemeral: true });
+    await interaction.editReply({
+      content: "Bryan Bucks isn't enabled in this server.",
+      components: [],
+    });
+    return;
+  }
+
+  await interaction.deferUpdate();
+  const page = await getLedgerPage(
+    {
+      serverId,
+      discordId: clickerId,
+      page: navigation.page,
+      snapshotId: navigation.snapshotId,
+    },
+    prismaClient,
+  );
+  await interaction.editReply(renderBucksHistory(clickerId, page));
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/settle.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settle.integration.test.ts
@@ -20,7 +20,7 @@ import {
   HOUSE_BANKROLL,
   VOID_GRACE_MS,
 } from "#src/betting/constants.ts";
-import { getLeaderboard } from "#src/betting/accounts.ts";
+import { getFullLeaderboard } from "#src/betting/accounts.ts";
 
 const { prisma: db } = createTestDatabase("bucks-settle");
 
@@ -381,9 +381,13 @@ describe("one-sided house settlement", () => {
       { kind: "bet_stake", delta: -25 },
     ]);
 
-    expect(await getLeaderboard({ serverId: SERVER_A, limit: 10 }, db)).toEqual(
-      [{ discordId: only.account.discordId, balance: 150 }],
-    );
+    expect(await getFullLeaderboard({ serverId: SERVER_A }, db)).toEqual([
+      {
+        accountId: only.account.id,
+        discordId: only.account.discordId,
+        balance: 150,
+      },
+    ]);
 
     const settled = await db.bucksMatchPool.findUniqueOrThrow({
       where: { id: pool.id },

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-leaderboard.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-leaderboard.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import type { MessageCreateOptions } from "discord.js";
+import {
+  DiscordGuildIdSchema,
+  type DiscordChannelId,
+} from "@scout-for-lol/data";
+import type { FullLeaderboardRow } from "#src/betting/accounts.ts";
+import {
+  formatWeeklyBucksLeaderboard,
+  rankBucksLeaderboard,
+  runWeeklyBucksLeaderboard,
+  WEEKLY_BUCKS_CRON,
+  type WeeklyBucksLeaderboardDependencies,
+} from "#src/betting/weekly-leaderboard.ts";
+import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+
+const SERVER_ID = DiscordGuildIdSchema.parse("1337623164146155593");
+const OTHER_SERVER_ID = DiscordGuildIdSchema.parse("2337623164146155593");
+
+function row(index: number, balance: number): FullLeaderboardRow {
+  return {
+    accountId: index,
+    discordId: bucksTestDiscordId(index),
+    balance,
+  };
+}
+
+function dependencies(input: {
+  guilds?: ReturnType<typeof DiscordGuildIdSchema.parse>[];
+  member?: boolean;
+  rows?: FullLeaderboardRow[];
+  sendMessage?: WeeklyBucksLeaderboardDependencies["sendMessage"];
+}): WeeklyBucksLeaderboardDependencies {
+  return {
+    enabledGuilds: () => input.guilds ?? [SERVER_ID],
+    hasGuild: () => input.member ?? true,
+    loadRows: () => Promise.resolve(input.rows ?? []),
+    sendMessage: input.sendMessage ?? (() => Promise.resolve(undefined)),
+    sleep: () => Promise.resolve(),
+  };
+}
+
+describe("weekly Bryan Bucks leaderboard", () => {
+  test("is scheduled Friday at 5 PM Pacific and never on startup", () => {
+    expect(WEEKLY_BUCKS_CRON).toEqual(
+      expect.objectContaining({
+        schedule: "0 0 17 * * 5",
+        timezone: "America/Los_Angeles",
+        runOnInit: false,
+      }),
+    );
+  });
+
+  test("uses competition ranks for ties and retains zero balances", () => {
+    expect(
+      rankBucksLeaderboard([row(1, 20), row(2, 20), row(3, 5), row(4, 0)]).map(
+        (entry) => [entry.rank, entry.balance],
+      ),
+    ).toEqual([
+      [1, 20],
+      [1, 20],
+      [3, 5],
+      [4, 0],
+    ]);
+  });
+
+  test("splits the complete list without dropping a wallet", () => {
+    const rows = Array.from({ length: 20 }, (_unused, index) =>
+      row(index + 1, 100 - index),
+    );
+    const chunks = formatWeeklyBucksLeaderboard(rows, 160);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 160)).toBe(true);
+    const combined = chunks.join("\n");
+    for (const entry of rows) {
+      expect(combined).toContain(`<@${entry.discordId}>`);
+    }
+  });
+
+  test("posts every chunk to the exact channel with mentions disabled", async () => {
+    const sends: {
+      options: MessageCreateOptions;
+      channelId: DiscordChannelId;
+      serverId: ReturnType<typeof DiscordGuildIdSchema.parse>;
+    }[] = [];
+    const rows = Array.from({ length: 80 }, (_unused, index) =>
+      row(index + 1, 100 - index),
+    );
+    const result = await runWeeklyBucksLeaderboard(
+      dependencies({
+        rows,
+        sendMessage: (options, channelId, serverId) => {
+          sends.push({ options, channelId, serverId });
+          return Promise.resolve(undefined);
+        },
+      }),
+    );
+
+    expect(result.status).toBe("sent");
+    expect(result.entryCount).toBe(80);
+    expect(sends).toHaveLength(result.chunkCount);
+    expect(sends.length).toBeGreaterThan(1);
+    for (const sent of sends) {
+      expect(sent.channelId).toBe(COMMON_DENOMINATOR_CHANNEL_ID);
+      expect(sent.serverId).toBe(SERVER_ID);
+      expect(sent.options.allowedMentions).toEqual({ parse: [] });
+      expect(sent.options.enforceNonce).toBe(true);
+      expect(typeof sent.options.nonce).toBe("string");
+    }
+  });
+
+  test("posts an explicit empty state", async () => {
+    const messages: string[] = [];
+    await runWeeklyBucksLeaderboard(
+      dependencies({
+        sendMessage: (options) => {
+          if (options.content !== undefined) {
+            messages.push(options.content);
+          }
+          return Promise.resolve(undefined);
+        },
+      }),
+    );
+    expect(messages).toEqual([
+      expect.stringContaining("No Bryan Bucks wallets exist yet."),
+    ]);
+  });
+
+  test("does nothing when this Discord application is not in the guild", async () => {
+    let loaded = false;
+    let sent = false;
+    const result = await runWeeklyBucksLeaderboard({
+      ...dependencies({ member: false }),
+      loadRows: () => {
+        loaded = true;
+        return Promise.resolve([]);
+      },
+      sendMessage: () => {
+        sent = true;
+        return Promise.resolve(undefined);
+      },
+    });
+    expect(result).toEqual({
+      status: "not_in_guild",
+      entryCount: 0,
+      chunkCount: 0,
+    });
+    expect(loaded).toBe(false);
+    expect(sent).toBe(false);
+  });
+
+  test("fails closed unless exactly one guild is enabled", async () => {
+    await expect(
+      runWeeklyBucksLeaderboard(dependencies({ guilds: [] })),
+    ).rejects.toThrow("requires exactly one enabled guild");
+    await expect(
+      runWeeklyBucksLeaderboard(
+        dependencies({ guilds: [SERVER_ID, OTHER_SERVER_ID] }),
+      ),
+    ).rejects.toThrow("requires exactly one enabled guild");
+  });
+
+  test("retries transient failures idempotently", async () => {
+    const options: MessageCreateOptions[] = [];
+    let attempts = 0;
+    const result = await runWeeklyBucksLeaderboard(
+      dependencies({
+        rows: [row(1, 10)],
+        sendMessage: (message) => {
+          options.push(message);
+          attempts += 1;
+          return attempts === 1
+            ? Promise.reject(new Error("Discord delivery failed"))
+            : Promise.resolve(undefined);
+        },
+      }),
+    );
+
+    expect(result.status).toBe("sent");
+    expect(options).toHaveLength(2);
+    expect(options[0]?.nonce).toBe(options[1]?.nonce);
+    expect(options[0]?.enforceNonce).toBe(true);
+  });
+
+  test("attempts later chunks before surfacing a persistent failure", async () => {
+    const deliveryError = new Error("Discord delivery failed");
+    const attemptedContents: string[] = [];
+    const rows = Array.from({ length: 80 }, (_unused, index) =>
+      row(index + 1, 100 - index),
+    );
+    await expect(
+      runWeeklyBucksLeaderboard(
+        dependencies({
+          rows,
+          sendMessage: (options) => {
+            if (options.content !== undefined) {
+              attemptedContents.push(options.content);
+            }
+            return attemptedContents.length <= 3
+              ? Promise.reject(deliveryError)
+              : Promise.resolve(undefined);
+          },
+        }),
+      ),
+    ).rejects.toThrow("failed to deliver 1/");
+    expect(attemptedContents.length).toBeGreaterThan(3);
+    expect(attemptedContents.at(-1)).toContain(`<@${bucksTestDiscordId(80)}>`);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-leaderboard.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-leaderboard.ts
@@ -1,0 +1,200 @@
+import type { MessageCreateOptions } from "discord.js";
+import type { DiscordChannelId, DiscordGuildId } from "@scout-for-lol/data";
+import {
+  getFullLeaderboard,
+  type FullLeaderboardRow,
+} from "#src/betting/accounts.ts";
+import { listGuildsWithFlagEnabled } from "#src/configuration/flags.ts";
+import { client } from "#src/discord/client.ts";
+import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
+import {
+  ChannelSendError,
+  send as sendChannelMessage,
+} from "#src/league/discord/channel.ts";
+import { createLogger } from "#src/logger.ts";
+import { getErrorMessage } from "#src/utils/errors.ts";
+
+const logger = createLogger("betting-weekly-leaderboard");
+const MAX_CHUNK_SEND_ATTEMPTS = 3;
+const CHUNK_RETRY_BASE_DELAY_MS = 500;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const WEEKLY_BUCKS_CRON = {
+  schedule: "0 0 17 * * 5",
+  jobName: "weekly_bryan_bucks_leaderboard",
+  logMessage: "💰 Posting the weekly Bryan Bucks leaderboard",
+  timezone: "America/Los_Angeles",
+  runOnInit: false,
+} as const;
+
+export type RankedLeaderboardRow = FullLeaderboardRow & { rank: number };
+
+export function rankBucksLeaderboard(
+  rows: readonly FullLeaderboardRow[],
+): RankedLeaderboardRow[] {
+  let previousBalance: number | undefined;
+  let rank = 0;
+  return rows.map((row, index) => {
+    if (previousBalance === undefined || row.balance !== previousBalance) {
+      rank = index + 1;
+      previousBalance = row.balance;
+    }
+    return { ...row, rank };
+  });
+}
+
+export function formatWeeklyBucksLeaderboard(
+  rows: readonly FullLeaderboardRow[],
+  maxLength?: number,
+): string[] {
+  if (rows.length === 0) {
+    return [
+      "💰 **Weekly Bryan Bucks leaderboard**\nNo Bryan Bucks wallets exist yet.",
+    ];
+  }
+
+  const body = rankBucksLeaderboard(rows)
+    .map(
+      (row) =>
+        `**${row.rank.toString()}.** <@${row.discordId}> — **${row.balance.toString()} BB**`,
+    )
+    .join("\n");
+  return splitMessageIntoChunks(
+    `💰 **Weekly Bryan Bucks leaderboard**\n${body}`,
+    maxLength,
+  );
+}
+
+export type WeeklyBucksLeaderboardDependencies = {
+  enabledGuilds: () => DiscordGuildId[];
+  hasGuild: (serverId: DiscordGuildId) => boolean;
+  loadRows: (serverId: DiscordGuildId) => Promise<FullLeaderboardRow[]>;
+  sendMessage: (
+    options: MessageCreateOptions,
+    channelId: DiscordChannelId,
+    serverId: DiscordGuildId,
+  ) => Promise<unknown>;
+  sleep: (milliseconds: number) => Promise<void>;
+};
+
+const defaultDependencies: WeeklyBucksLeaderboardDependencies = {
+  enabledGuilds: () => listGuildsWithFlagEnabled("betting_enabled"),
+  hasGuild: (serverId) => client.guilds.cache.has(serverId),
+  loadRows: async (serverId) => await getFullLeaderboard({ serverId }),
+  sendMessage: async (options, channelId, serverId) =>
+    await sendChannelMessage(options, channelId, serverId),
+  sleep: async (milliseconds) => {
+    await Bun.sleep(milliseconds);
+  },
+};
+
+export type WeeklyBucksLeaderboardResult = {
+  status: "sent" | "not_in_guild";
+  entryCount: number;
+  chunkCount: number;
+};
+
+function chunkNonce(runWeek: number, chunkIndex: number): string {
+  return `bbw:${runWeek.toString(36)}:${chunkIndex.toString(36)}`;
+}
+
+async function sendLeaderboardChunk(
+  dependencies: WeeklyBucksLeaderboardDependencies,
+  options: MessageCreateOptions,
+  serverId: DiscordGuildId,
+  chunkIndex: number,
+): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_CHUNK_SEND_ATTEMPTS; attempt++) {
+    try {
+      await dependencies.sendMessage(
+        options,
+        COMMON_DENOMINATOR_CHANNEL_ID,
+        serverId,
+      );
+      return;
+    } catch (error) {
+      const deterministicFailure =
+        error instanceof ChannelSendError && error.permissionError;
+      if (attempt === MAX_CHUNK_SEND_ATTEMPTS || deterministicFailure) {
+        throw error;
+      }
+      const delayMs = CHUNK_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      logger.warn(
+        `💰 Weekly Bryan Bucks leaderboard chunk ${(chunkIndex + 1).toString()} attempt ${attempt.toString()}/${MAX_CHUNK_SEND_ATTEMPTS.toString()} failed; retrying in ${delayMs.toString()}ms: ${getErrorMessage(error)}`,
+      );
+      await dependencies.sleep(delayMs);
+    }
+  }
+}
+
+/**
+ * Publish the one configured guild's complete leaderboard.
+ *
+ * Both beta and production run background jobs against the same flag registry.
+ * Only beta belongs to the configured guild, so a bot without that membership
+ * deliberately does nothing. The guild count is still enforced first: adding
+ * another enabled guild requires an explicit guild-to-channel mapping rather
+ * than silently disclosing its balances in Common Denominator.
+ */
+export async function runWeeklyBucksLeaderboard(
+  dependencies: WeeklyBucksLeaderboardDependencies = defaultDependencies,
+): Promise<WeeklyBucksLeaderboardResult> {
+  const guilds = dependencies.enabledGuilds();
+  if (guilds.length !== 1) {
+    throw new Error(
+      `Weekly Bryan Bucks leaderboard requires exactly one enabled guild; found ${guilds.length.toString()}`,
+    );
+  }
+  const serverId = guilds[0];
+  if (serverId === undefined) {
+    throw new Error("The enabled Bryan Bucks guild was missing");
+  }
+  if (!dependencies.hasGuild(serverId)) {
+    logger.info(
+      `💰 Skipping weekly Bryan Bucks leaderboard: this Discord application is not in guild ${serverId}`,
+    );
+    return { status: "not_in_guild", entryCount: 0, chunkCount: 0 };
+  }
+
+  const rows = await dependencies.loadRows(serverId);
+  const chunks = formatWeeklyBucksLeaderboard(rows);
+  logger.info(
+    `💰 Weekly Bryan Bucks leaderboard contains ${rows.length.toString()} entries across ${chunks.length.toString()} chunk(s)`,
+  );
+
+  const runWeek = Math.floor(Date.now() / WEEK_MS);
+  const failures: unknown[] = [];
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    try {
+      await sendLeaderboardChunk(
+        dependencies,
+        {
+          content: chunk,
+          allowedMentions: { parse: [] },
+          nonce: chunkNonce(runWeek, chunkIndex),
+          enforceNonce: true,
+        },
+        serverId,
+        chunkIndex,
+      );
+    } catch (error) {
+      failures.push(error);
+      logger.error(
+        `💰 Weekly Bryan Bucks leaderboard chunk ${(chunkIndex + 1).toString()}/${chunks.length.toString()} failed after retries: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Weekly Bryan Bucks leaderboard failed to deliver ${failures.length.toString()}/${chunks.length.toString()} chunk(s)`,
+    );
+  }
+
+  return {
+    status: "sent",
+    entryCount: rows.length,
+    chunkCount: chunks.length,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/channels.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/channels.ts
@@ -1,0 +1,6 @@
+import { DiscordChannelIdSchema } from "@scout-for-lol/data";
+
+/** Common Denominator's shared announcements channel. */
+export const COMMON_DENOMINATOR_CHANNEL_ID = DiscordChannelIdSchema.parse(
+  "1337631455085334650",
+);

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { bbCommand } from "#src/discord/commands/bb.ts";
+import {
+  bbCommand,
+  buildPersonalBucksEmbed,
+  buildBbRulesEmbed,
+  isPublicBbSubcommand,
+} from "#src/discord/commands/bb.ts";
+import type { PersonalBucksView } from "#src/betting/accounts.ts";
 import {
   BB_PRIZES,
   buildBbPrizesEmbed,
@@ -65,5 +71,73 @@ describe("/bb prizes", () => {
     }
 
     expect(rendered).not.toMatch(/one server|single-server|rural canada/iu);
+  });
+});
+
+describe("/bb command contract", () => {
+  test("removes the on-demand leaderboard and adds no-option rules/history", () => {
+    const command = bbCommand.toJSON();
+    const names = command.options?.map((option) => option.name) ?? [];
+    const history = command.options?.find(
+      (option) => option.name === "history",
+    );
+    const rules = command.options?.find((option) => option.name === "rules");
+
+    expect(names).not.toContain("leaderboard");
+    expect(rules).toEqual(
+      expect.objectContaining({ type: 1, name: "rules", options: [] }),
+    );
+    expect(history).toEqual(
+      expect.objectContaining({ type: 1, name: "history", options: [] }),
+    );
+  });
+
+  test("keeps personal and market views private", () => {
+    expect(isPublicBbSubcommand("balance")).toBe(false);
+    expect(isPublicBbSubcommand("history")).toBe(false);
+    expect(isPublicBbSubcommand("open")).toBe(false);
+    expect(isPublicBbSubcommand("bet")).toBe(false);
+    expect(isPublicBbSubcommand("rules")).toBe(true);
+    expect(isPublicBbSubcommand("prizes")).toBe(true);
+  });
+
+  test("keeps long pending-position aliases inside Discord's field limit", () => {
+    const view: PersonalBucksView = {
+      balance: 25,
+      totalStaked: 10,
+      pendingPositionCount: 10,
+      pendingPositions: Array.from({ length: 10 }, (_, index) => ({
+        matchId: `NA1_${index.toString()}`,
+        subjectAlias: `player-${index.toString()}-${"x".repeat(500)}`,
+        side: "WIN",
+        stake: 1,
+        closesAt: new Date(60_000),
+        poolState: "open",
+      })),
+    };
+
+    const pendingField = buildPersonalBucksEmbed(view, 0)
+      .toJSON()
+      .fields?.find((field) => field.name === "Pending positions");
+
+    expect(pendingField?.value.length).toBeLessThanOrEqual(1024);
+    expect(pendingField?.value.endsWith("...")).toBe(true);
+  });
+
+  test("rules explain the complete economy", () => {
+    const rendered = JSON.stringify(buildBbRulesEmbed().toJSON());
+    for (const phrase of [
+      "tracked League players",
+      "25 BB",
+      "+1 BB",
+      "1-1000 BB",
+      "10 minutes",
+      "cancel",
+      "split the losing side's pool",
+      "house matches",
+      "All stakes are returned",
+    ]) {
+      expect(rendered).toContain(phrase);
+    }
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -9,18 +9,29 @@ import {
   DiscordGuildIdSchema,
 } from "@scout-for-lol/data/index.ts";
 import {
-  getBalance,
-  getLeaderboard,
   getLedgerPage,
+  getOpenMarketAggregates,
+  getPersonalBucksView,
+  type PersonalBucksView,
 } from "#src/betting/accounts.ts";
 import { placeBet } from "#src/betting/place-bet.ts";
 import { describeResult } from "#src/betting/bet-button.ts";
 import { announceBetPlacement } from "#src/betting/announce.ts";
-import { MAX_STAKE, MIN_STAKE } from "#src/betting/constants.ts";
+import {
+  BETTING_WINDOW_MS,
+  MAX_STAKE,
+  MIN_STAKE,
+  SEED_GRANT,
+} from "#src/betting/constants.ts";
+import { renderBucksHistory } from "#src/betting/navigation.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
 import { replyError } from "#src/discord/commands/define-command.ts";
 import { buildBbPrizesEmbed } from "#src/discord/commands/bb-prizes.ts";
+import {
+  splitMessageIntoChunks,
+  truncateEmbedFieldValue,
+} from "#src/discord/utils/message.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("command-bb");
@@ -46,11 +57,11 @@ const logger = createLogger("command-bb");
  * cannot drift in what they accept or how they explain a refusal.
  */
 
-const LEADERBOARD_SIZE = 10;
-const DEFAULT_HISTORY = 10;
-const MAX_HISTORY = 25;
-
 const BUCKS_COLOR = 0x2e_cc_71;
+
+export function isPublicBbSubcommand(subcommand: string): boolean {
+  return subcommand === "rules" || subcommand === "prizes";
+}
 
 export const bbCommand = new SlashCommandBuilder()
   .setName("bb")
@@ -62,19 +73,12 @@ export const bbCommand = new SlashCommandBuilder()
     sub.setName("prizes").setDescription("See what your Bryan Bucks can buy"),
   )
   .addSubcommand((sub) =>
-    sub.setName("leaderboard").setDescription("Who has the most Bryan Bucks"),
+    sub.setName("rules").setDescription("How Bryan Bucks works"),
   )
   .addSubcommand((sub) =>
     sub
       .setName("history")
-      .setDescription("How you earned and spent your Bryan Bucks")
-      .addIntegerOption((option) =>
-        option
-          .setName("count")
-          .setDescription(`How many entries (1-${MAX_HISTORY.toString()})`)
-          .setMinValue(1)
-          .setMaxValue(MAX_HISTORY),
-      ),
+      .setDescription("How you earned and spent your Bryan Bucks"),
   )
   .addSubcommand((sub) =>
     sub.setName("open").setDescription("Games you can still bet on"),
@@ -111,13 +115,55 @@ export const bbCommand = new SlashCommandBuilder()
       ),
   );
 
+export function buildPersonalBucksEmbed(
+  view: PersonalBucksView,
+  now: number = Date.now(),
+): EmbedBuilder {
+  const positions = view.pendingPositions.map((position) => {
+    const state =
+      position.poolState === "open" && position.closesAt.getTime() > now
+        ? `closes <t:${Math.floor(position.closesAt.getTime() / 1000).toString()}:R>`
+        : "locked";
+    return `• **${position.subjectAlias} ${position.side}** — ${position.stake.toString()} BB · ${state}`;
+  });
+  if (view.pendingPositionCount > view.pendingPositions.length) {
+    positions.push(
+      `…and ${(view.pendingPositionCount - view.pendingPositions.length).toString()} more pending position(s).`,
+    );
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle("💰 Your Bryan Bucks")
+    .setColor(BUCKS_COLOR)
+    .addFields(
+      {
+        name: "Available",
+        value: `**${view.balance.toString()} BB**`,
+        inline: true,
+      },
+      {
+        name: "Total staked",
+        value: `**${view.totalStaked.toString()} BB**`,
+        inline: true,
+      },
+    );
+  if (positions.length > 0) {
+    embed.addFields({
+      name: "Pending positions",
+      value: truncateEmbedFieldValue(positions.join("\n")),
+    });
+  }
+
+  return embed;
+}
+
 async function replyBalance(
   interaction: ChatInputCommandInteraction,
   serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
   discordId: ReturnType<typeof DiscordAccountIdSchema.parse>,
 ): Promise<void> {
-  const balance = await getBalance({ serverId, discordId });
-  if (balance === undefined) {
+  const view = await getPersonalBucksView({ serverId, discordId });
+  if (view === undefined) {
     await interaction.editReply({
       content:
         "You don't have a Bryan Bucks wallet yet — place your first bet on a live game and you'll be given a starting balance.",
@@ -125,52 +171,8 @@ async function replyBalance(
     return;
   }
 
-  const openBets = await prisma.bucksBet.findMany({
-    where: {
-      bucksAccount: { serverId, discordId },
-      betOutcome: "pending",
-    },
-    select: { stake: true },
-  });
-  const staked = openBets.reduce((total, bet) => total + bet.stake, 0);
-
   await interaction.editReply({
-    content:
-      `You have **${balance.toString()} BB**` +
-      (openBets.length > 0
-        ? ` with **${staked.toString()} BB** riding on ${openBets.length.toString()} open bet(s).`
-        : "."),
-  });
-}
-
-async function replyLeaderboard(
-  interaction: ChatInputCommandInteraction,
-  serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
-): Promise<void> {
-  const rows = await getLeaderboard({ serverId, limit: LEADERBOARD_SIZE });
-  if (rows.length === 0) {
-    await interaction.editReply({
-      content: "Nobody has any Bryan Bucks yet.",
-    });
-    return;
-  }
-
-  const embed = new EmbedBuilder()
-    .setTitle("💰 Bryan Bucks")
-    .setColor(BUCKS_COLOR)
-    .setDescription(
-      rows
-        .map(
-          (row, index) =>
-            `**${(index + 1).toString()}.** <@${row.discordId}> — ${row.balance.toString()} BB`,
-        )
-        .join("\n"),
-    );
-
-  await interaction.editReply({
-    embeds: [embed],
-    // A leaderboard should not ping the top ten people every time it is run.
-    allowedMentions: { parse: [] },
+    embeds: [buildPersonalBucksEmbed(view)],
   });
 }
 
@@ -180,37 +182,61 @@ async function replyPrizes(
   await interaction.editReply({ embeds: [buildBbPrizesEmbed()] });
 }
 
+export function buildBbRulesEmbed(): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("📜 Bryan Bucks rules")
+    .setColor(BUCKS_COLOR)
+    .setDescription(
+      "Bryan Bucks are friendly points for tracked League players. They have no cash value.",
+    )
+    .addFields(
+      {
+        name: "Eligibility & earnings",
+        value:
+          `Your Discord account must be linked to a tracked player. A new wallet starts with **${SEED_GRANT.toString()} BB**. ` +
+          "Eligible ranked games award **+1 BB** for playing, **+1 BB** for winning, and **+1 BB** for MVP.",
+      },
+      {
+        name: "Placing a bet",
+        value:
+          `Stake **${MIN_STAKE.toString()}-${MAX_STAKE.toString()} BB** on a tracked player to WIN or LOSE. ` +
+          `The market stays open for ${Math.floor(BETTING_WINDOW_MS / 60_000).toString()} minutes after Scout detects the game. ` +
+          "You can add to a position or cancel it for a full refund before the window closes; after that, it is locked.",
+      },
+      {
+        name: "Settlement",
+        value:
+          "Winners get their stakes back and split the losing side's pool in proportion to their stakes. " +
+          "If people bet on only one side, the Bryan Bucks house matches the other side when its reserve can cover the stake.",
+      },
+      {
+        name: "Refunds",
+        value:
+          "All stakes are returned when a game is voided or remade, cannot be settled, or the house cannot cover a one-sided market.",
+      },
+    );
+}
+
+async function replyRules(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  await interaction.editReply({ embeds: [buildBbRulesEmbed()] });
+}
+
 async function replyHistory(
   interaction: ChatInputCommandInteraction,
   serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
   discordId: ReturnType<typeof DiscordAccountIdSchema.parse>,
 ): Promise<void> {
-  const limit = interaction.options.getInteger("count") ?? DEFAULT_HISTORY;
-  const entries = await getLedgerPage({ serverId, discordId, limit });
-
-  if (entries.length === 0) {
-    await interaction.editReply({ content: "No Bryan Bucks history yet." });
-    return;
-  }
-
-  const lines = entries.map((entry) => {
-    const sign = entry.delta > 0 ? "+" : "";
-    const where = entry.matchId === null ? "" : ` · ${entry.matchId}`;
-    return `\`${sign}${entry.delta.toString()}\` ${entry.kind}${where} → ${entry.balanceAfter.toString()} BB`;
-  });
-
-  await interaction.editReply({ content: lines.join("\n") });
+  const page = await getLedgerPage({ serverId, discordId, page: 0 });
+  await interaction.editReply(renderBucksHistory(discordId, page));
 }
 
 async function replyOpen(
   interaction: ChatInputCommandInteraction,
   serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
 ): Promise<void> {
-  const pools = await prisma.bucksMatchPool.findMany({
-    where: { serverId, poolState: "open", closesAt: { gt: new Date() } },
-    select: { matchId: true, closesAt: true, roster: true },
-    orderBy: { closesAt: "asc" },
-  });
+  const pools = await getOpenMarketAggregates({ serverId });
 
   if (pools.length === 0) {
     await interaction.editReply({
@@ -219,18 +245,32 @@ async function replyOpen(
     return;
   }
 
-  const lines = pools.map((pool) => {
-    const roster = BucksPoolRosterSchema.parse(
-      JSON.parse(pool.roster),
-    ).participants;
-    const aliases = roster
-      .map((participant) => participant.trackedAlias)
-      .filter((alias) => alias !== undefined);
+  const sections = pools.map((pool) => {
     const closesAtUnix = Math.floor(pool.closesAt.getTime() / 1000);
-    return `**${aliases.join(", ")}** — closes <t:${closesAtUnix.toString()}:R>`;
+    const bluePlayers =
+      pool.blue.trackedPlayers.length > 0
+        ? pool.blue.trackedPlayers.join(", ")
+        : "No tracked players";
+    const redPlayers =
+      pool.red.trackedPlayers.length > 0
+        ? pool.red.trackedPlayers.join(", ")
+        : "No tracked players";
+    return [
+      `## ${bluePlayers} vs ${redPlayers}`,
+      `Closes <t:${closesAtUnix.toString()}:R>`,
+      `🔵 **Blue:** ${pool.blue.totalStake.toString()} BB across ${pool.blue.betCount.toString()} bet(s) — ${bluePlayers}`,
+      `🔴 **Red:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — ${redPlayers}`,
+    ].join("\n");
   });
-
-  await interaction.editReply({ content: lines.join("\n") });
+  const chunks = splitMessageIntoChunks(sections.join("\n\n"));
+  const first = chunks[0];
+  if (first === undefined) {
+    throw new Error("Open Bryan Bucks markets produced no Discord content");
+  }
+  await interaction.editReply({ content: first });
+  for (const chunk of chunks.slice(1)) {
+    await interaction.followUp({ content: chunk, ephemeral: true });
+  }
 }
 
 async function replyBet(
@@ -333,8 +373,9 @@ export async function executeBb(
       return;
     }
 
-    // The leaderboard and prize catalog are public; everything else is personal.
-    const ephemeral = subcommand !== "leaderboard" && subcommand !== "prizes";
+    // Only rules and the prize catalog are public. Wallets, positions, and
+    // market inspection stay private to the caller.
+    const ephemeral = !isPublicBbSubcommand(subcommand);
     await interaction.deferReply({ ephemeral });
 
     const discordId = DiscordAccountIdSchema.parse(interaction.user.id);
@@ -343,11 +384,11 @@ export async function executeBb(
       case "balance":
         await replyBalance(interaction, serverId, discordId);
         break;
-      case "leaderboard":
-        await replyLeaderboard(interaction, serverId);
-        break;
       case "prizes":
         await replyPrizes(interaction);
+        break;
+      case "rules":
+        await replyRules(interaction);
         break;
       case "history":
         await replyHistory(interaction, serverId, discordId);

--- a/packages/scout-for-lol/packages/backend/src/discord/interactions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/interactions.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
+import { DiscordAccountIdSchema } from "@scout-for-lol/data";
 import {
   routeButton,
   type RoutableButtonInteraction,
 } from "#src/discord/interactions.ts";
 import { formatBucksCustomId } from "#src/betting/custom-id.ts";
+import { formatBucksNavigationId } from "#src/betting/navigation.ts";
+
+const USER_ID = DiscordAccountIdSchema.parse("160509172704739328");
 
 /**
  * A stand-in for discord.js's ButtonInteraction, built the same way
@@ -15,7 +19,7 @@ function fakeInteraction(customId: string, guildId: string | null = null) {
   const interaction: RoutableButtonInteraction = {
     customId,
     guildId,
-    user: { id: "160509172704739328" },
+    user: { id: USER_ID },
     deferred: false,
     replied: false,
     deferUpdate: mock(() => {
@@ -59,6 +63,19 @@ describe("routeButton", () => {
     expect(calls).toEqual(["deferUpdate"]);
   });
 
+  test.each([
+    "bbnav:",
+    "bbnav:2:h:160509172704739328:42:0",
+    "bbnav:1:x:160509172704739328:42:0",
+    "bbnav:1:h:not-a-user:42:0",
+    "bbnav:1:h:160509172704739328:0:0",
+    "bbnav:1:h:160509172704739328:42:-1",
+  ])("acknowledges malformed navigation ID %s", async (customId) => {
+    const { interaction, calls } = fakeInteraction(customId);
+    await routeButton(interaction);
+    expect(calls).toEqual(["deferUpdate"]);
+  });
+
   test("a well-formed ID is not short-circuited as malformed", async () => {
     const { interaction, calls } = fakeInteraction(
       formatBucksCustomId({
@@ -74,6 +91,19 @@ describe("routeButton", () => {
     // takes its no-server branch, which defers a real reply and answers — no
     // database, and no `deferUpdate`. What the handler decides for a click
     // inside a guild is `bet-button.integration.test.ts`'s subject.
+    expect(calls).toEqual(["deferReply", "editReply"]);
+  });
+
+  test("routes a well-formed navigation ID separately from bet buttons", async () => {
+    const { interaction, calls } = fakeInteraction(
+      formatBucksNavigationId({
+        action: "h",
+        ownerId: USER_ID,
+        snapshotId: 42,
+        page: 1,
+      }),
+    );
+    await routeButton(interaction);
     expect(calls).toEqual(["deferReply", "editReply"]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/interactions.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/interactions.ts
@@ -5,6 +5,12 @@ import {
   type BetButtonInteraction,
 } from "#src/betting/bet-button.ts";
 import { isBucksCustomId, parseBucksCustomId } from "#src/betting/custom-id.ts";
+import {
+  handleBucksNavigation,
+  isBucksNavigationId,
+  parseBucksNavigationId,
+  type BucksNavigationInteraction,
+} from "#src/betting/navigation.ts";
 import { createLogger } from "#src/logger.ts";
 import { discordComponentsTotal } from "#src/metrics/index.ts";
 
@@ -47,15 +53,42 @@ async function routeInteraction(interaction: Interaction): Promise<void> {
  * with no cast, and a test builds a plain one rather than reaching for the
  * `as`-based mock helpers.
  */
-export type RoutableButtonInteraction = BetButtonInteraction & {
-  deferUpdate: () => Promise<unknown>;
-  deferred: boolean;
-  replied: boolean;
-};
+export type RoutableButtonInteraction = BetButtonInteraction &
+  BucksNavigationInteraction & {
+    deferred: boolean;
+    replied: boolean;
+  };
 
 export async function routeButton(
   interaction: RoutableButtonInteraction,
 ): Promise<void> {
+  if (isBucksNavigationId(interaction.customId)) {
+    try {
+      if (parseBucksNavigationId(interaction.customId) === undefined) {
+        discordComponentsTotal.inc({
+          namespace: "bbnav",
+          status: "malformed",
+        });
+        await interaction.deferUpdate();
+        return;
+      }
+
+      await handleBucksNavigation(interaction);
+      discordComponentsTotal.inc({ namespace: "bbnav", status: "success" });
+    } catch (error) {
+      logger.error("❌ Error handling Bryan Bucks navigation:", error);
+      discordComponentsTotal.inc({ namespace: "bbnav", status: "error" });
+      if (interaction.deferred && !interaction.replied) {
+        await interaction.editReply({
+          content:
+            "😵 Something went wrong loading that page. Try again shortly.",
+          components: [],
+        });
+      }
+    }
+    return;
+  }
+
   if (!isBucksCustomId(interaction.customId)) {
     // Some other feature's component. Not ours to answer, and Discord shows the
     // clicker nothing for a component no handler claims.

--- a/packages/scout-for-lol/packages/backend/src/league/cron.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/cron.ts
@@ -16,6 +16,10 @@ import {
   runReportLakeFold,
   runReportLakeRebuild,
 } from "#src/report-lake/compactor.ts";
+import {
+  runWeeklyBucksLeaderboard,
+  WEEKLY_BUCKS_CRON,
+} from "#src/betting/weekly-leaderboard.ts";
 
 const logger = createLogger("league-cron");
 
@@ -34,6 +38,18 @@ export async function startCronJobs() {
     logMessage: "🔍 Running pre-match active game check",
     timezone: "America/Los_Angeles",
     runOnInit: true,
+  });
+
+  // Full wallet disclosure happens only on this fixed weekly cadence; there is
+  // deliberately no on-demand leaderboard command.
+  logger.info(
+    "📅 Setting up Bryan Bucks leaderboard (Friday 5 PM America/Los_Angeles)",
+  );
+  createCronJob({
+    ...WEEKLY_BUCKS_CRON,
+    task: async () => {
+      await runWeeklyBucksLeaderboard();
+    },
   });
 
   // check match history every minute
@@ -175,6 +191,7 @@ export async function startCronJobs() {
     "📊 Pre-match check (30s), match history polling (1min), competition lifecycle (15min), data validation (hourly), " +
       "match time refresh (6hr), scheduled reports (every minute), " +
       "report-lake fold (15min) and rebuild (2AM UTC), " +
-      "player pruning (3AM UTC), removed-guild reconciliation (4AM UTC) cron jobs are now active",
+      "player pruning (3AM UTC), removed-guild reconciliation (4AM UTC), and " +
+      "Bryan Bucks leaderboard (Friday 5PM PT) cron jobs are now active",
   );
 }

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/pairing/weekly-update.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/pairing/weekly-update.ts
@@ -5,7 +5,6 @@ import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 import {
   type ServerPairingStats,
   type PairingStatsEntry,
-  DiscordChannelIdSchema,
 } from "@scout-for-lol/data/index.ts";
 import {
   getServerPlayers,
@@ -25,11 +24,7 @@ import {
 import { subWeeks, startOfISOWeek, endOfISOWeek } from "date-fns";
 import * as Sentry from "@sentry/bun";
 import { deliverTrackedCoreOutput } from "#src/analytics/guild-lifecycle.ts";
-
-// Channel ID for Common Denominator updates
-const COMMON_DENOMINATOR_CHANNEL_ID = DiscordChannelIdSchema.parse(
-  "1337631455085334650",
-);
+import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
 
 const logger = createLogger("pairing-weekly-update");
 


### PR DESCRIPTION
## Why

Bryan Bucks users need useful self-service detail without letting them inspect other players’ balances on demand. The full leaderboard should instead be disclosed predictably once a week in the beta server’s Common Denominator channel.

## What

- Remove `/bb leaderboard`, add public `/bb rules`, and enrich the private balance and open-market responses.
- Replace counted history lookups with private, owner-bound Previous/Next paging whose initial ledger snapshot stays stable.
- Add personal pending-position and aggregate open-market queries without exposing bettor identities or inferred odds.
- Publish every non-house wallet each Friday at 5:00 PM America/Los_Angeles, with competition ranks, zero balances, disabled mentions, safe multi-message chunking, and an explicit empty state.
- Require exactly one enabled betting guild, no-op when this Discord application is not a member, and always target Common Denominator channel `1337631455085334650`.
- Update the private Scout agent contract and add focused command, privacy, paging, query, scheduling, routing, chunking, and failure tests.

## Verification

- `bun install --frozen-lockfile`
- `bunx turbo run typecheck lint --filter=@scout-for-lol/backend`
- `bun test src/discord/commands/bb-prizes.test.ts src/discord/interactions.test.ts src/betting/custom-id.test.ts src/betting/accounts.integration.test.ts src/betting/navigation.integration.test.ts src/betting/weekly-leaderboard.test.ts src/betting/bet-button.integration.test.ts src/betting/place-bet.integration.test.ts src/betting/settle.integration.test.ts src/betting/earnings.integration.test.ts src/betting/announce.test.ts` — 108 passed, 0 failed
- `bunx lefthook run pre-commit`
- `git diff --check`

Not run: live Discord command registration, scheduled delivery, deployment, or production message acceptance.