### PR TITLE
Add saved Scout Explore questions to Discord

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -535,17 +535,18 @@ Enforced by ESLint:
 
 ### Command Structure
 
-Scout intentionally exposes only seven Discord commands: `/help`, `/setup`,
-`/status`, `/invite`, `/docs`, `/track`, and `/list`. The web dashboard is the
-canonical surface for filters, queues, channels, competitions, reports, roles,
-and audit history. Do not recreate the removed management command trees.
+Scout exposes seven global Discord commands: `/help`, `/setup`, `/status`,
+`/invite`, `/docs`, `/track`, and `/list`. The web dashboard is the canonical
+surface for filters, queues, channels, competitions, saved report
+configuration, roles, audit history, and Explore follow-ups. Do not recreate
+the removed management command trees.
 
-`/bb` (Bryan Bucks) is the one owner-approved exception, pinned by
-`definitions.test.ts`. It is gated to a single guild by the `betting_enabled`
-flag — effectively beta-only, since that guild runs the beta bot — and a balance
-you cannot check from the same place you place a bet is not usable. It is
-registered only in that guild, not globally. Adding anything else needs the
-same explicit decision.
+`/bb` (Bryan Bucks) and `/scout` are the owner-approved guild-scoped exceptions,
+pinned by `definitions.test.ts`. `/bb` follows `betting_enabled`; `/scout`
+follows `EXPLORE_GUILD_ALLOWLIST`. Neither may leak into the global picker.
+`/scout ask` starts one fresh, private, saved Explore conversation and may post
+its frozen result publicly; Discord never continues the conversation. Adding
+another command still needs the same explicit product decision.
 
 **Interactions are routed in `discord/interactions.ts`**, not in
 `discord/commands/index.ts`. That module is the single `interactionCreate`
@@ -556,8 +557,11 @@ dropped every message component.
 
 Definitions are collected in `packages/backend/src/discord/commands/definitions.ts`
 and registered with a full global `applicationCommands` replacement in
-`discord/rest.ts`, which also removes stale commands and autocomplete handlers.
-Handlers are dispatched by name in `discord/commands/index.ts`.
+`discord/rest.ts`. After the gateway connects, every guild in the client's
+cache receives its complete merged guild-command payload — including an empty
+payload when neither feature is enabled, which removes stale commands. A
+`guildCreate` event reconciles that guild immediately. Handlers are dispatched
+by name in `discord/commands/index.ts`.
 
 The retained `/track` and `/list` handlers validate boundary input with Zod,
 delegate to the existing subscription domain services, and use `replyError` for
@@ -743,6 +747,21 @@ SJ-147.
   everyone — it is the entire gate for this surface, so an omitted config must
   fail closed. Every tRPC procedure re-checks it, so losing membership removes
   access to conversations already saved.
+- **Discord Explore is one-shot and uses the same persisted turn runner.**
+  `/scout ask` is registered only in allowlisted guilds, re-checks that exact
+  guild on command and publish-button execution, creates a new user-owned
+  conversation, and renders the saved answer privately. Follow-ups happen only
+  in `/app/explore`. The Discord user upsert may refresh username/avatar but
+  must omit OAuth token fields. HTTP/SSE and Discord both call
+  `explore/run-turn.ts`, which owns quota charging, timeout, metrics, trace,
+  partial salvage, agent execution, answer persistence, and generated titles.
+- **Publishing is a frozen copy, not Explore sharing.** The versioned component
+  id is `scout:1:publish:<conversationId>:<assistantMessageId>`. On click, reload
+  the owner-scoped stored path and post only its question, answer, caveats, and
+  existing visualization. Never rerun the agent or ScoutQL, mint a share token,
+  expose the owner-only Explore URL, raw query, or trace, or allow generated
+  mentions. A successful click disables the private button; a failed send
+  leaves it retryable.
 - **The agent must never state a statistic it did not read from a query result
   in that turn**, and must describe the corpus as the matches Scout ingested
   rather than the League ladder. Both live in `explore/prompt.ts`. A
@@ -813,27 +832,17 @@ guild, **not** a second gate: there is deliberately no environment check, becaus
 one override should be the whole answer to "is it on here?".
 
 **`/bb` is registered per guild, not globally.** `commandDefinitions` holds the
-seven global commands; `guildScopedCommandGroups` (same file) maps a flag to a
-payload, and `discord/rest.ts` resolves it through `listGuildsWithFlagEnabled`
-and PUTs to `applicationGuildCommands` for each. A globally registered
-flag-gated command would sit in the picker of every guild Scout is in and do
-nothing there. Three consequences worth knowing. A guild PUT **replaces** that
-guild's whole command list for the app, so groups are merged per guild before
-sending. A guild the running bot is not in fails with `MISSING_ACCESS`, which is
-logged and skipped rather than fatal — otherwise the prod deployment would
-crash-loop over a command only beta serves; every _other_ failure propagates and
-exits, because startup reporting success over a guild whose registration was
-rejected leaves that guild without `/bb` until someone redeploys.
-
-And **registration reconciles, it does not only register.** Because the PUT is a
-replacement, it is also the only way to take a command back, so the loop runs
-over `listGuildsWithFlagDeclared` — every guild the flag names in _either_
-direction — and sends an empty payload to the ones it is switched off for.
-Visiting only the enabled guilds left `/bb` in a disabled guild's picker
-indefinitely. The corollary is a contract on withdrawal: **switch a guild's
-override to `value: false`; do not delete the entry.** A deleted override leaves
-no record that the guild was ever targeted, and nothing on either side can then
-tell it apart from a guild that never had the feature.
+seven global commands; `guildScopedCommandGroups` (same file) supplies an
+enabled-guild resolver and payload for both `/bb` and `/scout`.
+`discord/rest.ts` walks the connected client's complete guild cache and PUTs
+each guild's merged payload to `applicationGuildCommands`. A globally
+registered gated command would sit in every guild's picker and do nothing
+there. A guild PUT **replaces** that guild's whole command list for the app, so
+the groups must be merged before sending, and a guild where no group is enabled
+must receive `[]` to clear stale commands. A newly joined guild is reconciled
+from `guildCreate`; a guild the running bot cannot access is skipped only for
+Discord's `MISSING_ACCESS`, while every other registration failure remains
+fatal during startup.
 
 The feature scope remains enforced by the flag and guild-scoped registration;
 user-facing betting surfaces should not advertise the allowlist or the private

--- a/packages/scout-for-lol/README.md
+++ b/packages/scout-for-lol/README.md
@@ -71,6 +71,11 @@ Scout automatically checks for matches every minute and posts:
 - `/docs` - Open the documentation
 - `/track` - Track one player in the current channel
 - `/list` - List tracked players (read-only)
+- `/scout ask` - Ask a private, saved Explore question in allowlisted servers;
+  optionally post the frozen answer and chart to the channel
+
+Continue `/scout ask` conversations in the web Explore UI. Discord questions
+are one-shot and each command starts a new saved conversation.
 
 ## Technical Details
 

--- a/packages/scout-for-lol/docs/backend.md
+++ b/packages/scout-for-lol/docs/backend.md
@@ -59,8 +59,14 @@ commands/
 ├── onboarding.ts    # setup/status/invite/docs
 ├── track.ts         # Minimal current-channel subscription
 ├── list.ts          # Read-only subscription overview
+├── scout.ts         # Saved one-shot Explore question
 ├── links.ts         # Stage-aware dashboard/docs links
 └── index.ts         # Dispatcher and metrics
+
+discord/scout/
+├── custom-id.ts     # Versioned publish-button key
+├── messages.ts      # Bounded private/public frozen rendering
+└── publish.ts       # Owner-scoped public publication
 ```
 
 ### Lightweight Discord command flow
@@ -82,11 +88,13 @@ sequenceDiagram
     Handler->>Discord: Reply to interaction
 ```
 
-Discord registration intentionally exposes only `/help`, `/setup`, `/status`,
-`/invite`, `/docs`, `/track`, and `/list`. The dispatcher has no autocomplete
-path and no command-specific management tree. `/track` and `/list` call the
-shared subscription domain services; all advanced management is implemented in
-the web UI and its tRPC router.
+Discord registration keeps `/help`, `/setup`, `/status`, `/invite`, `/docs`,
+`/track`, and `/list` global. `/bb` and `/scout` are complete guild-scoped
+payloads reconciled after the gateway connects and whenever the bot joins a
+guild. `/scout ask` calls the same persisted Explore runner as HTTP/SSE; only
+delivery differs. Publishing reloads the frozen owner-scoped transcript and
+cannot call the agent or query engine. All configuration and Explore follow-ups
+remain in the web UI.
 
 ## Cron Job System
 

--- a/packages/scout-for-lol/packages/backend/src/discord/client.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/client.ts
@@ -1,5 +1,5 @@
 import configuration from "#src/configuration.ts";
-import { Client, GatewayIntentBits } from "discord.js";
+import { Client, GatewayIntentBits, type Guild } from "discord.js";
 import { handleInteractions } from "#src/discord/interactions.ts";
 import {
   discordConnectionStatus,
@@ -57,29 +57,6 @@ client.on("reconnecting", () => {
   discordConnectionStatus.set(0);
 });
 
-// Skip the real Discord login under tests so importing this module (e.g. via
-// the report dispatcher or guild-membership helper) is side-effect free. Tests
-// that need client behavior mock it; production/dev/beta log in as normal.
-if (Bun.env.NODE_ENV === "test") {
-  logger.info("🧪 NODE_ENV=test — skipping Discord login");
-} else if (configuration.enableDiscordGateway) {
-  logger.info("🔑 Logging into Discord");
-  try {
-    await client.login(configuration.discordToken);
-    logger.info("✅ Successfully logged into Discord");
-  } catch (error) {
-    logger.error("❌ Failed to login to Discord:", error);
-    Sentry.captureException(error, {
-      tags: {
-        source: "discord-login",
-      },
-    });
-    throw error;
-  }
-} else {
-  logger.warn("⏭️  Discord gateway disabled — skipping Discord login");
-}
-
 client.on("ready", (readyClient) => {
   logger.info(`✅ Discord bot ready! Logged in as ${readyClient.user.tag}`);
   logger.info(
@@ -109,14 +86,48 @@ client.on("ready", (readyClient) => {
 
   handleInteractions(readyClient);
   logger.info("⚡ Discord command handler initialized");
+
+  void registerConnectedGuildCommands(readyClient.guilds.cache.keys());
 });
 
 // Handle bot being added to new servers
 client.on("guildCreate", (guild) => {
   logger.info(`[Guild Create] Bot added to new server: ${guild.name}`);
   discordGuildsGauge.set(client.guilds.cache.size);
-  void handleGuildCreate(guild);
+  void handleNewGuild(guild);
 });
+
+async function registerConnectedGuildCommands(
+  guildIds: Iterable<string>,
+): Promise<void> {
+  try {
+    const { registerDiscordCommands } = await import("#src/discord/rest.ts");
+    await registerDiscordCommands(guildIds);
+  } catch (error) {
+    logger.error("❌ Failed to register Discord commands:", error);
+    Sentry.captureException(error, {
+      tags: { source: "discord-command-registration" },
+    });
+    process.exit(1);
+  }
+}
+
+async function handleNewGuild(guild: Guild): Promise<void> {
+  try {
+    const { reconcileGuildScopedCommands } =
+      await import("#src/discord/rest.ts");
+    await reconcileGuildScopedCommands([guild.id]);
+  } catch (error) {
+    logger.error(
+      `[Guild Create] Failed to reconcile commands for ${guild.id}:`,
+      error,
+    );
+    Sentry.captureException(error, {
+      tags: { source: "discord-guild-command-registration" },
+    });
+  }
+  await handleGuildCreate(guild);
+}
 
 // Handle bot being removed from servers (kicked, banned, or guild deleted)
 client.on("guildDelete", (guild) => {
@@ -124,5 +135,28 @@ client.on("guildDelete", (guild) => {
   discordGuildsGauge.set(client.guilds.cache.size);
   void handleGuildDelete(guild);
 });
+
+// Install every event handler before login so a fast gateway connection cannot
+// emit `ready` before command reconciliation is listening for it.
+// Tests stay side-effect free; production/dev/beta log in as normal.
+if (Bun.env.NODE_ENV === "test") {
+  logger.info("🧪 NODE_ENV=test — skipping Discord login");
+} else if (configuration.enableDiscordGateway) {
+  logger.info("🔑 Logging into Discord");
+  try {
+    await client.login(configuration.discordToken);
+    logger.info("✅ Successfully logged into Discord");
+  } catch (error) {
+    logger.error("❌ Failed to login to Discord:", error);
+    Sentry.captureException(error, {
+      tags: {
+        source: "discord-login",
+      },
+    });
+    throw error;
+  }
+} else {
+  logger.warn("⏭️  Discord gateway disabled — skipping Discord login");
+}
 
 export { client };

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
@@ -1,13 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   commandDefinitions,
   guildScopedCommandGroups,
 } from "#src/discord/commands/definitions.ts";
-import {
-  getFlag,
-  listGuildsWithFlagEnabled,
-  resetFlagOverrides,
-} from "#src/configuration/flags.ts";
+import { listGuildsWithFlagEnabled } from "#src/configuration/flags.ts";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+
+const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+
+afterEach(() => {
+  if (originalAllowlist === undefined) {
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  } else {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = originalAllowlist;
+  }
+  resetConfigurationForTests();
+});
 
 describe("registered Discord commands", () => {
   test("exposes only the web-first command surface globally", () => {
@@ -32,23 +40,50 @@ describe("registered Discord commands", () => {
     );
 
     expect(guildScopedNames).toContain("bb");
+    expect(guildScopedNames).toContain("scout");
     for (const name of guildScopedNames) {
       expect(globalNames).not.toContain(name);
     }
   });
 
-  test("registers each guild-scoped command only where its flag is on", () => {
-    for (const group of guildScopedCommandGroups) {
-      // Another test file may have cleared this flag; the registry is shared.
-      resetFlagOverrides(group.flag);
-      const guilds = listGuildsWithFlagEnabled(group.flag);
-      // A group that resolves to no guilds would silently register nowhere,
-      // which looks identical to the feature being broken.
-      expect(guilds.length).toBeGreaterThan(0);
-      for (const guildId of guilds) {
-        expect(getFlag(group.flag, { server: guildId })).toBe(true);
-      }
-    }
+  test("resolves flag and Explore guild scopes independently", () => {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000001";
+    resetConfigurationForTests();
+    expect(listGuildsWithFlagEnabled("betting_enabled").length).toBeGreaterThan(
+      0,
+    );
+    const byCommand = new Map(
+      guildScopedCommandGroups.map((group) => [
+        group.payload.map((command) => command.name).join(","),
+        group.enabledGuildIds(),
+      ]),
+    );
+    expect(byCommand.get("bb")?.length).toBeGreaterThan(0);
+    expect(byCommand.get("scout")).toEqual(["100000000000000001"]);
+  });
+
+  test("defines /scout ask with the Explore question bounds", () => {
+    const scout = guildScopedCommandGroups
+      .flatMap((group) => group.payload)
+      .find((command) => command.name === "scout");
+    expect(scout).toEqual(
+      expect.objectContaining({
+        name: "scout",
+        options: [
+          expect.objectContaining({
+            name: "ask",
+            options: [
+              expect.objectContaining({
+                name: "question",
+                required: true,
+                min_length: 1,
+                max_length: 2000,
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
   });
 
   test("does not register autocomplete options", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.ts
@@ -9,7 +9,9 @@ import {
 import { listCommand } from "#src/discord/commands/list.ts";
 import { trackCommand } from "#src/discord/commands/track.ts";
 import { bbCommand } from "#src/discord/commands/bb.ts";
-import type { FlagName } from "#src/configuration/flags.ts";
+import { scoutCommand } from "#src/discord/commands/scout-definition.ts";
+import { listGuildsWithFlagEnabled } from "#src/configuration/flags.ts";
+import { exploreAllowlist } from "#src/explore/access.ts";
 
 /**
  * The commands every guild gets, registered globally.
@@ -42,10 +44,23 @@ export const commandPayload = commandDefinitions.map((command) =>
  * separate edit here.
  */
 export type GuildScopedCommandGroup = {
-  flag: FlagName;
+  enabledGuildIds: () => string[];
   payload: RESTPostAPIApplicationCommandsJSONBody[];
 };
 
 export const guildScopedCommandGroups: GuildScopedCommandGroup[] = [
-  { flag: "betting_enabled", payload: [bbCommand.toJSON()] },
+  {
+    enabledGuildIds: () => listGuildsWithFlagEnabled("betting_enabled"),
+    payload: [bbCommand.toJSON()],
+  },
+  { enabledGuildIds: exploreAllowlist, payload: [scoutCommand.toJSON()] },
 ];
+
+/** Complete guild command payload; an empty array removes stale commands. */
+export function guildCommandPayload(
+  guildId: string,
+): RESTPostAPIApplicationCommandsJSONBody[] {
+  return guildScopedCommandGroups.flatMap((group) =>
+    group.enabledGuildIds().includes(guildId) ? group.payload : [],
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/help.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/help.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { ChatInputCommandInteraction } from "discord.js";
 import type { CommandReply } from "#src/discord/commands/define-command.ts";
 import { executeHelp } from "#src/discord/commands/help.ts";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+
+const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+
+afterEach(() => {
+  if (originalAllowlist === undefined) {
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  } else {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = originalAllowlist;
+  }
+  resetConfigurationForTests();
+});
 
 describe("/help", () => {
   test("presents the retained commands and web-only management areas", async () => {
@@ -11,7 +23,7 @@ describe("/help", () => {
     );
     const reply: CommandReply = replyMock;
 
-    await executeHelp({ reply });
+    await executeHelp({ guildId: null, reply });
 
     expect(replyMock).toHaveBeenCalledWith(
       expect.objectContaining({ ephemeral: true }),
@@ -20,5 +32,21 @@ describe("/help", () => {
     expect(JSON.stringify(payload)).toContain("/track");
     expect(JSON.stringify(payload)).toContain("audit history");
     expect(JSON.stringify(payload)).not.toContain("/subscription");
+    expect(JSON.stringify(payload)).not.toContain("/scout ask");
+  });
+
+  test("includes Scout Explore only inside an allowlisted guild", async () => {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000001";
+    resetConfigurationForTests();
+    const replyMock = mock(
+      (payload: Parameters<ChatInputCommandInteraction["reply"]>[0]) =>
+        Promise.resolve(payload),
+    );
+    const reply: CommandReply = replyMock;
+
+    await executeHelp({ guildId: "100000000000000001", reply });
+    expect(JSON.stringify(replyMock.mock.calls[0]?.[0])).toContain(
+      "/scout ask",
+    );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/help.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/help.ts
@@ -2,9 +2,10 @@ import { EmbedBuilder, Colors, SlashCommandBuilder } from "discord.js";
 import { createLogger } from "#src/logger.ts";
 import { getDocsUrl, getDashboardUrl } from "#src/discord/commands/links.ts";
 import type { CommandReply } from "#src/discord/commands/define-command.ts";
+import { isExploreGuildAllowed } from "#src/explore/access.ts";
 
 const logger = createLogger("commands-help");
-type HelpInteraction = { reply: CommandReply };
+type HelpInteraction = { guildId: string | null; reply: CommandReply };
 
 export const helpCommand = new SlashCommandBuilder()
   .setName("help")
@@ -26,13 +27,7 @@ export async function executeHelp(interaction: HelpInteraction): Promise<void> {
       },
       {
         name: "Lightweight commands",
-        value:
-          "`/setup` — See the recommended web setup flow\n" +
-          "`/track` — Track one player in this channel\n" +
-          "`/list` — List tracked players\n" +
-          "`/status` — Check Scout's status\n" +
-          "`/invite` — Add Scout to another server\n" +
-          "`/docs` — Open the documentation",
+        value: commandList(interaction.guildId),
       },
       {
         name: "Use the dashboard for",
@@ -44,4 +39,19 @@ export async function executeHelp(interaction: HelpInteraction): Promise<void> {
 
   await interaction.reply({ embeds: [embed], ephemeral: true });
   logger.info("✅ Help command completed successfully");
+}
+
+function commandList(guildId: string | null): string {
+  const commands = [
+    "`/setup` — See the recommended web setup flow",
+    "`/track` — Track one player in this channel",
+    "`/list` — List tracked players",
+    "`/status` — Check Scout's status",
+    "`/invite` — Add Scout to another server",
+    "`/docs` — Open the documentation",
+  ];
+  if (guildId !== null && isExploreGuildAllowed(guildId)) {
+    commands.push("`/scout ask` — Ask a private, saved Explore question");
+  }
+  return commands.join("\n");
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/index.ts
@@ -15,6 +15,7 @@ import { executeHelp } from "#src/discord/commands/help.ts";
 import { executeList } from "#src/discord/commands/list.ts";
 import { executeTrack } from "#src/discord/commands/track.ts";
 import { executeBb } from "#src/discord/commands/bb.ts";
+import { executeScout } from "#src/discord/commands/scout.ts";
 
 const logger = createLogger("discord-commands");
 
@@ -62,6 +63,9 @@ export async function handleChatInputCommand(
         break;
       case "bb":
         await executeBb(interaction);
+        break;
+      case "scout":
+        await executeScout(interaction);
         break;
       default:
         await interaction.reply({

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { resetConfigurationForTests } from "#src/configuration.ts";
-import { getDocsUrl } from "#src/discord/commands/links.ts";
+import {
+  getDocsUrl,
+  getExploreConversationUrl,
+} from "#src/discord/commands/links.ts";
 import { buildDiscordInstallUrl } from "#src/lib/discord/install-url.ts";
 
 const originalOrigin = Bun.env["WEB_APP_ORIGIN"];
@@ -20,6 +23,9 @@ describe("stage-aware Discord links", () => {
     resetConfigurationForTests();
 
     expect(getDocsUrl()).toBe("https://beta.scout-for-lol.com/docs/");
+    expect(getExploreConversationUrl("conversation-id")).toBe(
+      "https://beta.scout-for-lol.com/app/explore/conversation-id",
+    );
   });
 
   test("keeps applications.commands in the install URL", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/links.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/links.ts
@@ -14,3 +14,7 @@ export function getDashboardUrl(): string {
 export function getDocsUrl(): string {
   return `${getOrigin()}/docs/`;
 }
+
+export function getExploreConversationUrl(conversationId: string): string {
+  return `${getOrigin()}/app/explore/${conversationId}`;
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/scout-definition.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/scout-definition.ts
@@ -1,0 +1,19 @@
+import { SlashCommandBuilder } from "discord.js";
+import { EXPLORE_QUESTION_MAX_LENGTH } from "@scout-for-lol/data";
+
+export const scoutCommand = new SlashCommandBuilder()
+  .setName("scout")
+  .setDescription("Ask Scout a question about League match data")
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("ask")
+      .setDescription("Ask a saved, one-shot Explore question")
+      .addStringOption((option) =>
+        option
+          .setName("question")
+          .setDescription("What do you want to learn from Scout's match data?")
+          .setRequired(true)
+          .setMinLength(1)
+          .setMaxLength(EXPLORE_QUESTION_MAX_LENGTH),
+      ),
+  );

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/scout.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/scout.integration.test.ts
@@ -1,0 +1,228 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type {
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+} from "discord.js";
+import { MessageFlags } from "discord.js";
+import type { ExploreAgentParams } from "#src/explore/agent.ts";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import {
+  executeScout,
+  type ScoutAskInteraction,
+} from "#src/discord/commands/scout.ts";
+import { resetExploreRateLimitStateForTests } from "#src/explore/rate-limit.ts";
+import { runPersistedExploreTurn } from "#src/explore/run-turn.ts";
+import { scoutTestVisualization } from "#src/discord/scout/test-fixtures.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { testAccountId } from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("discord-scout-command-test");
+const userId = testAccountId("81");
+const allowedGuild = "100000000000000081";
+const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+const originalOrigin = Bun.env["WEB_APP_ORIGIN"];
+
+beforeEach(async () => {
+  resetExploreRateLimitStateForTests();
+  Bun.env["EXPLORE_GUILD_ALLOWLIST"] = allowedGuild;
+  Bun.env["WEB_APP_ORIGIN"] = "https://beta.scout-for-lol.com/";
+  resetConfigurationForTests();
+  await prisma.exploreMessage.deleteMany();
+  await prisma.exploreConversation.deleteMany();
+  await prisma.user.deleteMany();
+});
+
+afterEach(() => {
+  if (originalAllowlist === undefined) {
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  } else {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = originalAllowlist;
+  }
+  if (originalOrigin === undefined) {
+    delete Bun.env["WEB_APP_ORIGIN"];
+  } else {
+    Bun.env["WEB_APP_ORIGIN"] = originalOrigin;
+  }
+  resetConfigurationForTests();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+function fakeInteraction(input?: {
+  guildId?: string | null;
+  question?: string;
+}) {
+  const replies: InteractionReplyOptions[] = [];
+  const edits: InteractionEditReplyOptions[] = [];
+  const followUps: InteractionReplyOptions[] = [];
+  let deferred = 0;
+  const interaction: ScoutAskInteraction = {
+    guildId: input?.guildId === undefined ? allowedGuild : input.guildId,
+    user: { id: userId, username: "fresh-name", avatar: "fresh-avatar" },
+    options: {
+      getSubcommand: () => "ask",
+      getString: () => input?.question ?? "Who wins most often?",
+    },
+    deferReply: () => {
+      deferred++;
+      return Promise.resolve(undefined);
+    },
+    reply: (options) => {
+      replies.push(options);
+      return Promise.resolve(undefined);
+    },
+    editReply: (options) => {
+      edits.push(options);
+      return Promise.resolve(undefined);
+    },
+    followUp: (options) => {
+      followUps.push(options);
+      return Promise.resolve(undefined);
+    },
+  };
+  return { interaction, replies, edits, followUps, deferred: () => deferred };
+}
+
+const successfulAgent = async (_params: ExploreAgentParams) => ({
+  answer: {
+    answer: "Ahri wins most often.",
+    title: "Most frequent winners",
+    queryText: "SELECT champion, wins FROM match_participants",
+    caveats: ["Tracked matches only."],
+    followUps: [],
+  },
+  preview: null,
+  visualization: scoutTestVisualization,
+});
+
+const interruptedAgent = async (params: ExploreAgentParams) => {
+  await params.emit({ type: "answer_delta", text: "The sample suggests" });
+  throw new Error("provider disconnected");
+};
+
+const throwingRun: typeof runPersistedExploreTurn = () =>
+  Promise.reject(new Error("runner setup failed"));
+
+const successfulRun: typeof runPersistedExploreTurn = async (input) =>
+  await runPersistedExploreTurn(input, {
+    client: prisma,
+    executeAgent: successfulAgent,
+    now: Date.now,
+    timeoutMs: 10_000,
+  });
+
+describe("/scout ask", () => {
+  test("rejects DMs, unallowlisted guilds, and invalid questions privately", async () => {
+    for (const input of [
+      { guildId: null, question: "Who wins?" },
+      { guildId: "100000000000000082", question: "Who wins?" },
+      { guildId: allowedGuild, question: " ".repeat(10) },
+      { guildId: allowedGuild, question: "x".repeat(2001) },
+    ]) {
+      const fake = fakeInteraction(input);
+      await executeScout(fake.interaction, {
+        client: prisma,
+        runTurn: successfulRun,
+      });
+      expect(fake.replies).toHaveLength(1);
+      expect(fake.replies[0]?.flags).toBe(MessageFlags.Ephemeral);
+      expect(fake.deferred()).toBe(0);
+    }
+  });
+
+  test("preserves OAuth tokens, saves a fresh answer, and returns private actions", async () => {
+    await prisma.user.create({
+      data: {
+        discordId: userId,
+        discordUsername: "old-name",
+        discordAvatar: "old-avatar",
+        discordAccessToken: "access-token",
+        discordRefreshToken: "refresh-token",
+        tokenExpiresAt: new Date("2026-09-01T00:00:00.000Z"),
+      },
+    });
+    const first = fakeInteraction();
+    await executeScout(first.interaction, {
+      client: prisma,
+      runTurn: successfulRun,
+    });
+    const second = fakeInteraction({ question: "Who has the best KDA?" });
+    await executeScout(second.interaction, {
+      client: prisma,
+      runTurn: successfulRun,
+    });
+
+    const user = await prisma.user.findUnique({ where: { discordId: userId } });
+    expect(user).toEqual(
+      expect.objectContaining({
+        discordUsername: "fresh-name",
+        discordAvatar: "fresh-avatar",
+        discordAccessToken: "access-token",
+        discordRefreshToken: "refresh-token",
+      }),
+    );
+    expect(await prisma.exploreConversation.count({ where: { userId } })).toBe(
+      2,
+    );
+    expect(await prisma.exploreMessage.count()).toBe(4);
+    expect(first.deferred()).toBe(1);
+    expect(first.edits).toHaveLength(1);
+    const responseJson = JSON.stringify(first.edits[0]);
+    expect(responseJson).toContain("Ahri wins most often.");
+    expect(responseJson).toContain("Tracked matches only.");
+    expect(responseJson).toContain("Open in Explore");
+    expect(responseJson).toContain("Post publicly");
+    expect(responseJson).toContain(
+      "https://beta.scout-for-lol.com/app/explore/",
+    );
+    expect(responseJson).toContain('"parse":[]');
+    expect(first.edits[0]).toHaveProperty("files");
+  });
+
+  test("renders a salvaged partial answer as a publishable saved result", async () => {
+    const interruptedRun: typeof runPersistedExploreTurn = async (input) =>
+      await runPersistedExploreTurn(input, {
+        client: prisma,
+        executeAgent: interruptedAgent,
+        now: Date.now,
+        timeoutMs: 10_000,
+      });
+    const fake = fakeInteraction();
+
+    await executeScout(fake.interaction, {
+      client: prisma,
+      runTurn: interruptedRun,
+    });
+
+    const responseJson = JSON.stringify(fake.edits[0]);
+    expect(responseJson).toContain("The sample suggests");
+    expect(responseJson).toContain("interrupted by an error");
+    expect(responseJson).toContain("Post publicly");
+  });
+
+  test("releases the per-user slot when command setup fails", async () => {
+    const failed = fakeInteraction();
+    await expect(
+      executeScout(failed.interaction, {
+        client: prisma,
+        runTurn: throwingRun,
+      }),
+    ).rejects.toThrow("runner setup failed");
+
+    const retry = fakeInteraction({ question: "Can I retry now?" });
+    await executeScout(retry.interaction, {
+      client: prisma,
+      runTurn: successfulRun,
+    });
+    expect(JSON.stringify(retry.edits)).toContain("Ahri wins most often.");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/scout.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/scout.ts
@@ -1,0 +1,190 @@
+import type {
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+} from "discord.js";
+import { MessageFlags } from "discord.js";
+import {
+  DiscordAccountIdSchema,
+  EXPLORE_QUESTION_MAX_LENGTH,
+  ExploreQuestionSchema,
+} from "@scout-for-lol/data";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { isExploreGuildAllowed } from "#src/explore/access.ts";
+import { tryStartExploreTurn } from "#src/explore/rate-limit.ts";
+import { runPersistedExploreTurn } from "#src/explore/run-turn.ts";
+import { loadExploreTranscript, startExploreTurn } from "#src/explore/store.ts";
+import {
+  exploreActionRow,
+  exploreAnswerChunks,
+  exploreChartAttachment,
+  NO_GENERATED_MENTIONS,
+} from "#src/discord/scout/messages.ts";
+import { scoutExploreTurnsTotal } from "#src/metrics/explore.ts";
+
+export type ScoutAskInteraction = {
+  guildId: string | null;
+  user: { id: string; username: string; avatar: string | null };
+  options: {
+    getSubcommand: () => string;
+    getString: (name: string, required: true) => string;
+  };
+  deferReply: (options: { flags: MessageFlags.Ephemeral }) => Promise<unknown>;
+  reply: (options: InteractionReplyOptions) => Promise<unknown>;
+  editReply: (options: InteractionEditReplyOptions) => Promise<unknown>;
+  followUp: (options: InteractionReplyOptions) => Promise<unknown>;
+};
+
+type ScoutCommandDependencies = {
+  client: ExtendedPrismaClient;
+  runTurn: typeof runPersistedExploreTurn;
+};
+
+const defaultDependencies: ScoutCommandDependencies = {
+  client: prisma,
+  runTurn: runPersistedExploreTurn,
+};
+
+export async function executeScout(
+  interaction: ScoutAskInteraction,
+  dependencies: ScoutCommandDependencies = defaultDependencies,
+): Promise<void> {
+  if (interaction.options.getSubcommand() !== "ask") {
+    await interaction.reply({
+      content: "That Scout action is not supported.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  if (interaction.guildId === null) {
+    await interaction.reply({
+      content: "Scout Explore only works inside an enabled server.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  if (!isExploreGuildAllowed(interaction.guildId)) {
+    await interaction.reply({
+      content: "Scout Explore is not enabled in this server.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const question = ExploreQuestionSchema.safeParse(
+    interaction.options.getString("question", true),
+  );
+  if (!question.success) {
+    await interaction.reply({
+      content: `Questions must be between 1 and ${EXPLORE_QUESTION_MAX_LENGTH.toString()} characters.`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  const identity = {
+    userId: DiscordAccountIdSchema.parse(interaction.user.id),
+  };
+  const ticket = tryStartExploreTurn(identity, Date.now());
+  if (!ticket.allowed) {
+    scoutExploreTurnsTotal.inc({ status: "rate_limited" });
+    await interaction.editReply({ content: ticket.reason });
+    return;
+  }
+
+  let runnerOwnsMetrics = false;
+  try {
+    await dependencies.client.user.upsert({
+      where: { discordId: identity.userId },
+      create: {
+        discordId: identity.userId,
+        discordUsername: interaction.user.username,
+        discordAvatar: interaction.user.avatar,
+      },
+      // OAuth credentials are deliberately omitted. A Discord command may
+      // refresh profile display fields, but it never owns web-session tokens.
+      update: {
+        discordUsername: interaction.user.username,
+        discordAvatar: interaction.user.avatar,
+      },
+    });
+    const created = await startExploreTurn(dependencies.client, {
+      conversationId: null,
+      userId: identity.userId,
+      question: question.data,
+      attach: { kind: "leaf" },
+    });
+    const started = { ...created, question: question.data };
+    const transcript = await loadExploreTranscript(
+      dependencies.client,
+      started.conversationId,
+      identity.userId,
+      started.messageId,
+    );
+    if (transcript === null) {
+      throw new Error("New Explore conversation could not be loaded.");
+    }
+
+    runnerOwnsMetrics = true;
+    const terminal = await dependencies.runTurn({
+      ticket,
+      identity,
+      started,
+      history: transcript.messages,
+      emit: () => Promise.resolve(),
+    });
+    if (terminal.type === "error") {
+      await interaction.editReply({
+        content: `${terminal.message}\n\nYour question was saved in Explore, but Scout did not produce an answer.`,
+        allowedMentions: NO_GENERATED_MENTIONS,
+      });
+      return;
+    }
+    await sendPrivateAnswer(
+      interaction,
+      started.conversationId,
+      terminal.message,
+    );
+  } catch (error) {
+    ticket.finish();
+    if (!runnerOwnsMetrics) {
+      scoutExploreTurnsTotal.inc({ status: "error" });
+    }
+    throw error;
+  }
+}
+
+async function sendPrivateAnswer(
+  interaction: ScoutAskInteraction,
+  conversationId: string,
+  answer: Extract<
+    Awaited<ReturnType<typeof runPersistedExploreTurn>>,
+    { type: "final" }
+  >["message"],
+): Promise<void> {
+  const chunks = exploreAnswerChunks(answer);
+  const first = chunks[0];
+  if (first === undefined) {
+    throw new Error("Saved Explore answer had no Discord content.");
+  }
+  const chart = exploreChartAttachment(answer);
+  await interaction.editReply({
+    content: first,
+    components: [
+      exploreActionRow({
+        conversationId,
+        assistantMessageId: answer.id,
+        posted: false,
+      }),
+    ],
+    allowedMentions: NO_GENERATED_MENTIONS,
+    ...(chart === null ? {} : { files: [chart] }),
+  });
+  for (const content of chunks.slice(1)) {
+    await interaction.followUp({
+      content,
+      flags: MessageFlags.Ephemeral,
+      allowedMentions: NO_GENERATED_MENTIONS,
+    });
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/index.ts
@@ -1,2 +1,1 @@
-import "@scout-for-lol/backend/discord/rest.ts";
 import "@scout-for-lol/backend/discord/client.ts";

--- a/packages/scout-for-lol/packages/backend/src/discord/interactions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/interactions.test.ts
@@ -19,7 +19,7 @@ function fakeInteraction(customId: string, guildId: string | null = null) {
   const interaction: RoutableButtonInteraction = {
     customId,
     guildId,
-    user: { id: USER_ID },
+    user: { id: USER_ID, username: "tester" },
     deferred: false,
     replied: false,
     deferUpdate: mock(() => {
@@ -33,6 +33,10 @@ function fakeInteraction(customId: string, guildId: string | null = null) {
     editReply: mock(() => {
       calls.push("editReply");
       return Promise.resolve(undefined);
+    }),
+    followUp: mock(() => {
+      calls.push("followUp");
+      return Promise.resolve({ delete: () => Promise.resolve(undefined) });
     }),
   };
   return { interaction, calls };
@@ -105,5 +109,11 @@ describe("routeButton", () => {
     );
     await routeButton(interaction);
     expect(calls).toEqual(["deferReply", "editReply"]);
+  });
+
+  test("acknowledges a malformed Scout component with a private explanation", async () => {
+    const { interaction, calls } = fakeInteraction("scout:1:publish:broken");
+    await routeButton(interaction);
+    expect(calls).toEqual(["deferUpdate", "followUp"]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/interactions.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/interactions.ts
@@ -1,4 +1,4 @@
-import type { Client, Interaction } from "discord.js";
+import { MessageFlags, type Client, type Interaction } from "discord.js";
 import { handleChatInputCommand } from "#src/discord/commands/index.ts";
 import {
   handleBetButton,
@@ -13,6 +13,14 @@ import {
 } from "#src/betting/navigation.ts";
 import { createLogger } from "#src/logger.ts";
 import { discordComponentsTotal } from "#src/metrics/index.ts";
+import {
+  handleScoutPublishButton,
+  type ScoutPublishButtonInteraction,
+} from "#src/discord/scout/publish.ts";
+import {
+  isScoutCustomId,
+  parseScoutPublishCustomId,
+} from "#src/discord/scout/custom-id.ts";
 
 const logger = createLogger("discord-interactions");
 
@@ -54,7 +62,9 @@ async function routeInteraction(interaction: Interaction): Promise<void> {
  * `as`-based mock helpers.
  */
 export type RoutableButtonInteraction = BetButtonInteraction &
-  BucksNavigationInteraction & {
+  BucksNavigationInteraction &
+  ScoutPublishButtonInteraction & {
+    deferUpdate: () => Promise<unknown>;
     deferred: boolean;
     replied: boolean;
   };
@@ -89,6 +99,10 @@ export async function routeButton(
     return;
   }
 
+  if (isScoutCustomId(interaction.customId)) {
+    await routeScoutButton(interaction);
+    return;
+  }
   if (!isBucksCustomId(interaction.customId)) {
     // Some other feature's component. Not ours to answer, and Discord shows the
     // clicker nothing for a component no handler claims.
@@ -129,5 +143,28 @@ export async function routeButton(
         content: "😵 Something went wrong placing that bet. Try again shortly.",
       });
     }
+  }
+}
+
+async function routeScoutButton(
+  interaction: RoutableButtonInteraction,
+): Promise<void> {
+  try {
+    const malformed =
+      parseScoutPublishCustomId(interaction.customId) === undefined;
+    await handleScoutPublishButton(interaction);
+    discordComponentsTotal.inc({
+      namespace: "scout",
+      status: malformed ? "malformed" : "success",
+    });
+  } catch (error) {
+    logger.error("❌ Error publishing a Scout answer:", error);
+    discordComponentsTotal.inc({ namespace: "scout", status: "error" });
+    await interaction.followUp({
+      content:
+        "Scout could not post that answer. The button is still available to retry.",
+      flags: MessageFlags.Ephemeral,
+      allowedMentions: { parse: [] },
+    });
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/rest.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/rest.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import { listGuildsWithFlagEnabled } from "#src/configuration/flags.ts";
+import { guildCommandPayload } from "#src/discord/commands/definitions.ts";
+import {
+  reconcileGuildScopedCommands,
+  registerDiscordCommands,
+  type DiscordCommandPut,
+} from "#src/discord/rest.ts";
+
+const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+
+afterEach(() => {
+  if (originalAllowlist === undefined) {
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  } else {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = originalAllowlist;
+  }
+  resetConfigurationForTests();
+});
+
+function bettingGuild(): string {
+  const guildId = listGuildsWithFlagEnabled("betting_enabled")[0];
+  if (guildId === undefined) {
+    throw new Error("Tests require one betting-enabled guild fixture.");
+  }
+  return guildId;
+}
+
+const missingAccessPut: DiscordCommandPut = () =>
+  Promise.reject(Object.assign(new Error("Missing access"), { code: 50_001 }));
+
+describe("Discord command reconciliation", () => {
+  test("merges /bb and /scout into one guild replacement payload", () => {
+    const guildId = bettingGuild();
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = guildId;
+    resetConfigurationForTests();
+
+    expect(guildCommandPayload(guildId).map((command) => command.name)).toEqual(
+      ["bb", "scout"],
+    );
+  });
+
+  test("sends empty payloads to clear stale guild commands", async () => {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "";
+    resetConfigurationForTests();
+    const calls: { route: string; names: string[] }[] = [];
+    const put: DiscordCommandPut = (route, body) => {
+      calls.push({ route, names: body.map((command) => command.name) });
+      return Promise.resolve(undefined);
+    };
+
+    await reconcileGuildScopedCommands(["100000000000000099"], put);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.route).toContain("/guilds/100000000000000099/");
+    expect(calls[0]?.names).toEqual([]);
+  });
+
+  test("reconciles globals and the complete connected-guild set after ready", async () => {
+    const calls: { route: string; names: string[] }[] = [];
+    const put: DiscordCommandPut = (route, body) => {
+      calls.push({ route, names: body.map((command) => command.name) });
+      return Promise.resolve(undefined);
+    };
+
+    await registerDiscordCommands(["100000000000000097"], put);
+
+    expect(calls[0]?.names).toEqual([
+      "help",
+      "setup",
+      "status",
+      "invite",
+      "docs",
+      "track",
+      "list",
+    ]);
+    expect(calls[1]?.route).toContain("/guilds/100000000000000097/");
+  });
+
+  test("reconciles a newly joined guild immediately", async () => {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000096";
+    resetConfigurationForTests();
+    const payloads: string[][] = [];
+    const put: DiscordCommandPut = (_route, body) => {
+      payloads.push(body.map((command) => command.name));
+      return Promise.resolve(undefined);
+    };
+
+    await reconcileGuildScopedCommands(["100000000000000096"], put);
+    expect(payloads).toEqual([["scout"]]);
+  });
+
+  test("tolerates a guild configured for the other Discord application", async () => {
+    await expect(
+      reconcileGuildScopedCommands(["100000000000000095"], missingAccessPut),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/rest.ts
@@ -4,39 +4,24 @@ import {
   type RESTPostAPIApplicationCommandsJSONBody,
 } from "discord.js";
 import { z } from "zod";
-import * as Sentry from "@sentry/bun";
 import configuration from "#src/configuration.ts";
 import {
   commandPayload,
-  guildScopedCommandGroups,
+  guildCommandPayload,
 } from "#src/discord/commands/definitions.ts";
-import {
-  listGuildsWithFlagDeclared,
-  listGuildsWithFlagEnabled,
-} from "#src/configuration/flags.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("discord-rest");
-
-logger.info("🔄 Preparing Discord slash commands for registration");
-
-const commands = commandPayload;
-
-logger.info("📋 Commands to register:");
-commands.forEach((command, index) => {
-  logger.info(
-    `  ${(index + 1).toString()}. ${command.name}: ${command.description}`,
-  );
-});
-
-logger.info("🔑 Initializing Discord REST client");
 const rest = new REST().setToken(configuration.discordToken);
-
-/**
- * Discord API error code for "the bot is not in that guild".
- * @see https://discord.com/developers/docs/topics/opcodes-and-status-codes
- */
 const MISSING_ACCESS = 50_001;
+
+export type DiscordCommandPut = (
+  route: `/${string}`,
+  body: RESTPostAPIApplicationCommandsJSONBody[],
+) => Promise<unknown>;
+
+const putCommands: DiscordCommandPut = async (route, body) =>
+  await rest.put(route, { body });
 
 function discordErrorCode(error: unknown): number | undefined {
   const parsed = z
@@ -46,69 +31,50 @@ function discordErrorCode(error: unknown): number | undefined {
   return parsed.success ? parsed.data.code : undefined;
 }
 
+/** Register the unchanged global command surface and every connected guild. */
+export async function registerDiscordCommands(
+  connectedGuildIds: Iterable<string>,
+  put: DiscordCommandPut = putCommands,
+): Promise<void> {
+  logger.info(
+    `🚀 Registering ${commandPayload.length.toString()} global Discord commands`,
+  );
+  await put(
+    Routes.applicationCommands(configuration.applicationId),
+    commandPayload,
+  );
+  await reconcileGuildScopedCommands(connectedGuildIds, put);
+}
+
 /**
- * Reconcile per-guild commands against the flags that own them.
+ * Replace each named guild's complete application-command payload.
  *
- * **Reconcile, not register.** A guild PUT *replaces* that guild's entire
- * command list for this application, which is why groups are merged per guild
- * before sending — but it is also the only way to take a command back. So the
- * loop runs over every guild any group's flag *declares* (see
- * `listGuildsWithFlagDeclared`), not only the ones it is enabled in, and a
- * guild whose flag was switched off is visited with an empty payload. Sending
- * to enabled guilds alone left a disabled command sitting in its guild's picker
- * indefinitely, answering nothing, until the next unrelated deploy that
- * happened to re-add the flag.
- *
- * The corollary is the withdrawal contract stated on `listGuildsWithFlagDeclared`:
- * switch a guild's override to `false`, do not delete it, or there is nothing
- * left to reconcile against.
- *
- * `MISSING_ACCESS` is logged and skipped: a flag names a guild that this
- * particular bot is not in, which is normal when the same flag registry is
- * shared by the beta and prod applications and only one of them was invited.
- * Exiting on that would crash-loop the other deployment over a command it was
- * never going to serve. Every *other* failure — an invalid payload, a rejected
- * token, a 5xx — is a real registration failure that no later poll retries, so
- * it propagates to the caller's exit path rather than letting startup report
- * success over a guild that has no commands.
+ * Discord's guild PUT is replacement, not merge. Building one payload from
+ * every guild-scoped feature preserves `/bb` while adding `/scout`, and an
+ * empty payload removes commands left behind by a disabled flag or allowlist.
  */
-async function registerGuildScopedCommands(): Promise<void> {
-  const byGuild = new Map<string, RESTPostAPIApplicationCommandsJSONBody[]>();
-  for (const group of guildScopedCommandGroups) {
-    // Declared first, so a guild the flag is off for still gets an entry — an
-    // empty payload, which is exactly the PUT that removes the command.
-    for (const guildId of listGuildsWithFlagDeclared(group.flag)) {
-      byGuild.set(guildId, byGuild.get(guildId) ?? []);
-    }
-    for (const guildId of listGuildsWithFlagEnabled(group.flag)) {
-      byGuild.set(guildId, [...(byGuild.get(guildId) ?? []), ...group.payload]);
-    }
-  }
-
-  if (byGuild.size === 0) {
-    logger.info("📭 No guild-scoped commands declared");
-    return;
-  }
-
-  for (const [guildId, payload] of byGuild) {
+export async function reconcileGuildScopedCommands(
+  guildIds: Iterable<string>,
+  put: DiscordCommandPut = putCommands,
+): Promise<void> {
+  for (const guildId of new Set(guildIds)) {
+    const payload = guildCommandPayload(guildId);
     const names = payload.map((command) => command.name).join(", ");
     try {
-      await rest.put(
+      await put(
         Routes.applicationGuildCommands(configuration.applicationId, guildId),
-        { body: payload },
+        payload,
       );
       logger.info(
         payload.length === 0
-          ? `🧹 Cleared guild-scoped commands in guild ${guildId} — its flag is off`
-          : `✅ Registered [${names}] in guild ${guildId}`,
+          ? `🧹 Cleared guild-scoped commands in guild ${guildId}`
+          : `✅ Reconciled [${names}] in guild ${guildId}`,
       );
     } catch (error) {
       if (discordErrorCode(error) === MISSING_ACCESS) {
         logger.info(`⏭️  Skipping guild ${guildId} — this bot is not in it`);
         continue;
       }
-      // Wrapped rather than bare, so the outer handler's Sentry event still
-      // names the guild and the payload the bare Discord error would not.
       throw new Error(
         `Failed to reconcile guild-scoped commands [${names}] in guild ${guildId}`,
         { cause: error },
@@ -116,78 +82,3 @@ async function registerGuildScopedCommands(): Promise<void> {
     }
   }
 }
-
-void (async () => {
-  try {
-    logger.info(
-      `🚀 Starting registration of ${commands.length.toString()} application (/) commands`,
-    );
-    logger.info(`🎯 Target application ID: ${configuration.applicationId}`);
-
-    const startTime = Date.now();
-    const data = await rest.put(
-      Routes.applicationCommands(configuration.applicationId),
-      { body: commands },
-    );
-    const registrationTime = Date.now() - startTime;
-
-    logger.info(
-      `✅ Successfully registered ${commands.length.toString()} application (/) commands in ${registrationTime.toString()}ms`,
-    );
-
-    // Log details about registered commands
-    const CommandSchema = z.object({ name: z.string(), id: z.string() });
-    const commandsResult = z.array(CommandSchema).safeParse(data);
-    if (commandsResult.success) {
-      logger.info("📝 Registered commands details:");
-      commandsResult.data.forEach((command, index) => {
-        logger.info(
-          `  ${(index + 1).toString()}. ${command.name} (ID: ${command.id})`,
-        );
-      });
-    }
-
-    await registerGuildScopedCommands();
-
-    logger.info("🎉 Discord command registration completed successfully");
-  } catch (error) {
-    logger.error("❌ Failed to register Discord commands:", error);
-    Sentry.captureException(error, {
-      tags: { source: "discord-command-registration" },
-    });
-
-    // Log additional error context
-    const ErrorDetailsSchema = z.object({
-      name: z.string(),
-      message: z.string(),
-      stack: z.string().optional(),
-    });
-    const errorResult = ErrorDetailsSchema.safeParse(error);
-    if (errorResult.success) {
-      logger.error("❌ Error name:", errorResult.data.name);
-      logger.error("❌ Error message:", errorResult.data.message);
-      if (
-        errorResult.data.stack !== undefined &&
-        errorResult.data.stack.length > 0
-      ) {
-        logger.error("❌ Error stack:", errorResult.data.stack);
-      }
-    }
-
-    // Check for specific Discord API errors
-    const objectResult = z
-      .object({ status: z.unknown() })
-      .catchall(z.unknown())
-      .safeParse(error);
-    if (objectResult.success) {
-      const discordError = objectResult.data;
-      logger.error("❌ HTTP Status:", discordError.status);
-      logger.error(
-        "❌ Response body:",
-        discordError["rawError"] ?? discordError["body"],
-      );
-    }
-
-    process.exit(1);
-  }
-})();

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/custom-id.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/custom-id.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatScoutPublishCustomId,
+  isScoutCustomId,
+  parseScoutPublishCustomId,
+} from "#src/discord/scout/custom-id.ts";
+
+const conversationId = "10000000-0000-4000-8000-000000000001";
+const assistantMessageId = "10000000-0000-4000-8000-000000000002";
+
+describe("Scout component IDs", () => {
+  test("round-trips the versioned publish key within Discord's limit", () => {
+    const customId = formatScoutPublishCustomId({
+      conversationId,
+      assistantMessageId,
+    });
+    expect(customId).toBe(
+      `scout:1:publish:${conversationId}:${assistantMessageId}`,
+    );
+    expect(customId.length).toBeLessThanOrEqual(100);
+    expect(parseScoutPublishCustomId(customId)).toEqual({
+      conversationId,
+      assistantMessageId,
+    });
+  });
+
+  test.each([
+    "scout:",
+    `scout:2:publish:${conversationId}:${assistantMessageId}`,
+    `scout:1:delete:${conversationId}:${assistantMessageId}`,
+    `scout:1:publish:not-a-uuid:${assistantMessageId}`,
+    `scout:1:publish:${conversationId}`,
+  ])("claims but rejects malformed Scout IDs (%s)", (customId) => {
+    expect(isScoutCustomId(customId)).toBe(true);
+    expect(parseScoutPublishCustomId(customId)).toBeUndefined();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/custom-id.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/custom-id.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import { ExploreConversationIdSchema } from "@scout-for-lol/data";
+import { MAX_CUSTOM_ID_LENGTH } from "#src/betting/custom-id.ts";
+
+export const SCOUT_COMPONENT_NAMESPACE = "scout";
+export const SCOUT_COMPONENT_VERSION = "1";
+
+const ScoutPublishCustomIdSchema = z.strictObject({
+  conversationId: ExploreConversationIdSchema,
+  assistantMessageId: z.uuid(),
+});
+
+export type ScoutPublishCustomId = z.infer<typeof ScoutPublishCustomIdSchema>;
+
+/** `scout:1:publish:<conversationId>:<assistantMessageId>` */
+export function formatScoutPublishCustomId(
+  input: ScoutPublishCustomId,
+): string {
+  const parsed = ScoutPublishCustomIdSchema.parse(input);
+  const id = [
+    SCOUT_COMPONENT_NAMESPACE,
+    SCOUT_COMPONENT_VERSION,
+    "publish",
+    parsed.conversationId,
+    parsed.assistantMessageId,
+  ].join(":");
+  if (id.length > MAX_CUSTOM_ID_LENGTH) {
+    throw new Error(
+      `Scout custom ID is ${id.length.toString()} characters, over Discord's ${MAX_CUSTOM_ID_LENGTH.toString()} limit.`,
+    );
+  }
+  return id;
+}
+
+export function parseScoutPublishCustomId(
+  raw: string,
+): ScoutPublishCustomId | undefined {
+  const segments = raw.split(":");
+  if (segments.length !== 5) {
+    return undefined;
+  }
+  const [namespace, version, action, conversationId, assistantMessageId] =
+    segments;
+  if (
+    namespace !== SCOUT_COMPONENT_NAMESPACE ||
+    version !== SCOUT_COMPONENT_VERSION ||
+    action !== "publish"
+  ) {
+    return undefined;
+  }
+  const parsed = ScoutPublishCustomIdSchema.safeParse({
+    conversationId,
+    assistantMessageId,
+  });
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function isScoutCustomId(raw: string): boolean {
+  return raw.startsWith(`${SCOUT_COMPONENT_NAMESPACE}:`);
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/messages.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/messages.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { ExploreMessageSchema } from "@scout-for-lol/data";
+import {
+  exploreAnswerChunks,
+  exploreChartAttachment,
+  publicExploreChunks,
+} from "#src/discord/scout/messages.ts";
+import { scoutTestVisualization } from "#src/discord/scout/test-fixtures.ts";
+
+const answer = ExploreMessageSchema.parse({
+  id: "10000000-0000-4000-8000-000000000002",
+  role: "assistant",
+  parentId: "10000000-0000-4000-8000-000000000001",
+  siblingIds: ["10000000-0000-4000-8000-000000000002"],
+  content: `@everyone ${"analysis ".repeat(500)}`,
+  caveats: ["Only tracked matches are included."],
+  createdAt: "2026-08-18T00:00:00.000Z",
+});
+
+describe("Scout Discord messages", () => {
+  test("bounds private and public prose into Discord-sized chunks", () => {
+    const privateChunks = exploreAnswerChunks(answer);
+    const publicChunks = publicExploreChunks({
+      username: "asker",
+      question: "Who wins most often?",
+      answer,
+    });
+
+    expect(privateChunks.length).toBeGreaterThan(1);
+    expect(publicChunks.length).toBeGreaterThan(1);
+    for (const chunk of [...privateChunks, ...publicChunks]) {
+      expect(chunk.length).toBeLessThanOrEqual(1900);
+    }
+    expect(publicChunks.join("\n")).toContain("Who wins most often?");
+    expect(publicChunks.join("\n")).toContain(
+      "Only tracked matches are included.",
+    );
+  });
+
+  test("attaches the existing static visualization renderer output", () => {
+    const chartAnswer = ExploreMessageSchema.parse({
+      ...answer,
+      visualization: scoutTestVisualization,
+    });
+
+    const attachment = exploreChartAttachment(chartAnswer);
+    expect(attachment?.name).toBe("scout-explore.png");
+    expect(attachment?.attachment).toBeInstanceOf(Buffer);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/messages.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/messages.ts
@@ -1,0 +1,77 @@
+import {
+  ActionRowBuilder,
+  AttachmentBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  escapeMarkdown,
+} from "discord.js";
+import type { ExploreMessage } from "@scout-for-lol/data";
+import { visualizationSnapshotToImage } from "@scout-for-lol/report";
+import { getExploreConversationUrl } from "#src/discord/commands/links.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
+import { formatScoutPublishCustomId } from "#src/discord/scout/custom-id.ts";
+
+export const NO_GENERATED_MENTIONS = { parse: [] } as const;
+
+export function exploreAnswerChunks(message: ExploreMessage): string[] {
+  return splitMessageIntoChunks(formatAnswer(message));
+}
+
+export function publicExploreChunks(input: {
+  username: string;
+  question: string;
+  answer: ExploreMessage;
+}): string[] {
+  const quotedQuestion = input.question
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+  return splitMessageIntoChunks(
+    `**${escapeMarkdown(input.username)} asked Scout:**\n${quotedQuestion}\n\n${formatAnswer(input.answer)}`,
+  );
+}
+
+export function exploreChartAttachment(
+  message: ExploreMessage,
+): AttachmentBuilder | null {
+  if (message.visualization === null) {
+    return null;
+  }
+  return new AttachmentBuilder(
+    visualizationSnapshotToImage(message.visualization),
+    { name: "scout-explore.png" },
+  );
+}
+
+export function exploreActionRow(input: {
+  conversationId: string;
+  assistantMessageId: string;
+  posted: boolean;
+}): ActionRowBuilder<ButtonBuilder> {
+  const publish = new ButtonBuilder()
+    .setCustomId(
+      formatScoutPublishCustomId({
+        conversationId: input.conversationId,
+        assistantMessageId: input.assistantMessageId,
+      }),
+    )
+    .setLabel(input.posted ? "Posted" : "Post publicly")
+    .setStyle(ButtonStyle.Primary)
+    .setDisabled(input.posted);
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setLabel("Open in Explore")
+      .setStyle(ButtonStyle.Link)
+      .setURL(getExploreConversationUrl(input.conversationId)),
+    publish,
+  );
+}
+
+function formatAnswer(message: ExploreMessage): string {
+  if (message.caveats.length === 0) {
+    return message.content;
+  }
+  return `${message.content}\n\n**Caveats**\n${message.caveats
+    .map((caveat) => `- ${caveat}`)
+    .join("\n")}`;
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/publish.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/publish.integration.test.ts
@@ -1,0 +1,260 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type {
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+} from "discord.js";
+import { MessageFlags } from "discord.js";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import {
+  handleScoutPublishButton,
+  resetScoutPublishStateForTests,
+  type ScoutPublishButtonInteraction,
+} from "#src/discord/scout/publish.ts";
+import { formatScoutPublishCustomId } from "#src/discord/scout/custom-id.ts";
+import { scoutTestVisualization } from "#src/discord/scout/test-fixtures.ts";
+import { appendExploreAnswer, startExploreTurn } from "#src/explore/store.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { testAccountId } from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("discord-scout-publish-test");
+const ownerId = testAccountId("91");
+const strangerId = testAccountId("92");
+const allowedGuild = "100000000000000091";
+const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+
+beforeEach(async () => {
+  resetScoutPublishStateForTests();
+  Bun.env["EXPLORE_GUILD_ALLOWLIST"] = allowedGuild;
+  resetConfigurationForTests();
+  await prisma.exploreMessage.deleteMany();
+  await prisma.exploreConversation.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.user.createMany({
+    data: [
+      { discordId: ownerId, discordUsername: "owner" },
+      { discordId: strangerId, discordUsername: "stranger" },
+    ],
+  });
+});
+
+afterEach(() => {
+  if (originalAllowlist === undefined) {
+    delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
+  } else {
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = originalAllowlist;
+  }
+  resetConfigurationForTests();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function savedAnswer(answerText = "Ahri wins most often.") {
+  const started = await startExploreTurn(prisma, {
+    conversationId: null,
+    userId: ownerId,
+    question: "Who wins most often?",
+    attach: { kind: "leaf" },
+  });
+  const answer = await appendExploreAnswer(prisma, {
+    conversationId: started.conversationId,
+    parentMessageId: started.messageId,
+    answer: {
+      answer: answerText,
+      title: null,
+      queryText: "SELECT secret_query FROM match_participants",
+      caveats: ["Tracked matches only."],
+      followUps: [],
+    },
+    preview: null,
+    visualization: scoutTestVisualization,
+    trace: [
+      { toolName: "run_report_query", message: "private trace", ok: true },
+    ],
+  });
+  return {
+    conversationId: started.conversationId,
+    assistantMessageId: answer.id,
+  };
+}
+
+function fakeInteraction(input: {
+  customId: string;
+  userId?: string;
+  guildId?: string | null;
+  onFollowUp?: (options: InteractionReplyOptions) => Promise<unknown>;
+}) {
+  const calls: string[] = [];
+  const followUps: InteractionReplyOptions[] = [];
+  const edits: InteractionEditReplyOptions[] = [];
+  let deletedMessages = 0;
+  const interaction: ScoutPublishButtonInteraction = {
+    customId: input.customId,
+    guildId: input.guildId === undefined ? allowedGuild : input.guildId,
+    user: { id: input.userId ?? ownerId, username: "owner" },
+    deferUpdate: () => {
+      calls.push("deferUpdate");
+      return Promise.resolve(undefined);
+    },
+    followUp: async (options) => {
+      calls.push("followUp");
+      followUps.push(options);
+      await input.onFollowUp?.(options);
+      return {
+        delete: () => {
+          deletedMessages++;
+          return Promise.resolve(undefined);
+        },
+      };
+    },
+    editReply: (options) => {
+      calls.push("editReply");
+      edits.push(options);
+      return Promise.resolve(undefined);
+    },
+  };
+  return {
+    interaction,
+    calls,
+    followUps,
+    edits,
+    deletedMessages: () => deletedMessages,
+  };
+}
+
+describe("Scout public publishing", () => {
+  test("publishes only frozen public fields and disables the private button", async () => {
+    const saved = await savedAnswer();
+    const fake = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+    });
+
+    await handleScoutPublishButton(fake.interaction, prisma);
+
+    expect(fake.calls[0]).toBe("deferUpdate");
+    const publicJson = JSON.stringify(fake.followUps);
+    expect(publicJson).toContain("Who wins most often?");
+    expect(publicJson).toContain("Ahri wins most often.");
+    expect(publicJson).toContain("Tracked matches only.");
+    expect(fake.followUps[0]).not.toHaveProperty("flags");
+    expect(publicJson).toContain('"parse":[]');
+    expect(publicJson).not.toContain("secret_query");
+    expect(publicJson).not.toContain("private trace");
+    expect(publicJson).not.toContain("/app/explore/");
+    expect(fake.followUps[0]).toHaveProperty("files");
+    expect(JSON.stringify(fake.edits)).toContain("Posted");
+    expect(JSON.stringify(fake.edits)).toContain('"disabled":true');
+  });
+
+  test.each([
+    { kind: "dm", guildId: null },
+    { kind: "wrong guild", guildId: "100000000000000093" },
+  ])("rejects a $kind click privately", async ({ guildId }) => {
+    const saved = await savedAnswer();
+    const fake = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+      guildId,
+    });
+    await handleScoutPublishButton(fake.interaction, prisma);
+    expect(fake.calls).toEqual(["deferUpdate", "followUp"]);
+    expect(fake.followUps[0]?.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  test("rejects malformed, stale, wrong-owner, and revoked clicks privately", async () => {
+    const saved = await savedAnswer();
+    const cases = [
+      fakeInteraction({ customId: "scout:1:publish:broken" }),
+      fakeInteraction({
+        customId: formatScoutPublishCustomId({
+          conversationId: saved.conversationId,
+          assistantMessageId: "10000000-0000-4000-8000-000000000099",
+        }),
+      }),
+      fakeInteraction({
+        customId: formatScoutPublishCustomId(saved),
+        userId: strangerId,
+      }),
+    ];
+    for (const fake of cases) {
+      await handleScoutPublishButton(fake.interaction, prisma);
+      expect(fake.followUps[0]?.flags).toBe(MessageFlags.Ephemeral);
+      expect(fake.edits).toHaveLength(0);
+    }
+
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "";
+    resetConfigurationForTests();
+    const revoked = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+    });
+    await handleScoutPublishButton(revoked.interaction, prisma);
+    expect(revoked.followUps[0]?.flags).toBe(MessageFlags.Ephemeral);
+  });
+
+  test("guards concurrent clicks for the same frozen answer", async () => {
+    const saved = await savedAnswer();
+    const gate = Promise.withResolvers<undefined>();
+    const entered = Promise.withResolvers<undefined>();
+    const first = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+      onFollowUp: (options) => {
+        if (options.flags === undefined) {
+          entered.resolve(undefined);
+          return gate.promise;
+        }
+        return Promise.resolve(undefined);
+      },
+    });
+    const firstRun = handleScoutPublishButton(first.interaction, prisma);
+    await entered.promise;
+    const second = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+    });
+
+    await handleScoutPublishButton(second.interaction, prisma);
+    expect(second.followUps[0]?.flags).toBe(MessageFlags.Ephemeral);
+    expect(JSON.stringify(second.followUps[0])).toContain(
+      "already being posted",
+    );
+    gate.resolve(undefined);
+    await firstRun;
+  });
+
+  test("leaves a failed post retryable without changing the saved answer", async () => {
+    const saved = await savedAnswer("Analysis ".repeat(400));
+    let publicSends = 0;
+    const failed = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+      onFollowUp: (options) => {
+        if (options.flags === undefined) {
+          publicSends++;
+          if (publicSends === 2) {
+            return Promise.reject(new Error("Discord send failed"));
+          }
+        }
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await expect(
+      handleScoutPublishButton(failed.interaction, prisma),
+    ).rejects.toThrow("Discord send failed");
+    expect(failed.edits).toHaveLength(0);
+    expect(failed.deletedMessages()).toBe(1);
+
+    const retry = fakeInteraction({
+      customId: formatScoutPublishCustomId(saved),
+    });
+    await handleScoutPublishButton(retry.interaction, prisma);
+    expect(retry.followUps.length).toBeGreaterThan(1);
+    expect(JSON.stringify(retry.edits)).toContain("Posted");
+    expect(await prisma.exploreMessage.count()).toBe(2);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/publish.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/publish.ts
@@ -1,0 +1,160 @@
+import type {
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+} from "discord.js";
+import { MessageFlags } from "discord.js";
+import { DiscordAccountIdSchema } from "@scout-for-lol/data";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { isExploreGuildAllowed } from "#src/explore/access.ts";
+import { loadExploreTranscript } from "#src/explore/store.ts";
+import { parseScoutPublishCustomId } from "#src/discord/scout/custom-id.ts";
+import {
+  exploreActionRow,
+  exploreChartAttachment,
+  NO_GENERATED_MENTIONS,
+  publicExploreChunks,
+} from "#src/discord/scout/messages.ts";
+
+export type ScoutPublishButtonInteraction = {
+  customId: string;
+  guildId: string | null;
+  user: { id: string; username: string };
+  deferUpdate: () => Promise<unknown>;
+  followUp: (options: InteractionReplyOptions) => Promise<{
+    delete: () => Promise<unknown>;
+  }>;
+  editReply: (options: InteractionEditReplyOptions) => Promise<unknown>;
+};
+
+const publishingMessages = new Set<string>();
+
+export async function handleScoutPublishButton(
+  interaction: ScoutPublishButtonInteraction,
+  client: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  // A component update acknowledgement leaves the original private response
+  // intact and lets subsequent follow-ups be ordinary public messages.
+  await interaction.deferUpdate();
+
+  const parsed = parseScoutPublishCustomId(interaction.customId);
+  if (parsed === undefined) {
+    await privateFollowUp(interaction, "That Scout action is no longer valid.");
+    return;
+  }
+  if (
+    interaction.guildId === null ||
+    !isExploreGuildAllowed(interaction.guildId)
+  ) {
+    await privateFollowUp(
+      interaction,
+      "Scout Explore is not enabled in this server.",
+    );
+    return;
+  }
+
+  if (publishingMessages.has(parsed.assistantMessageId)) {
+    await privateFollowUp(
+      interaction,
+      "This answer is already being posted. Please wait.",
+    );
+    return;
+  }
+  publishingMessages.add(parsed.assistantMessageId);
+
+  try {
+    const userId = DiscordAccountIdSchema.parse(interaction.user.id);
+    const transcript = await loadExploreTranscript(
+      client,
+      parsed.conversationId,
+      userId,
+      parsed.assistantMessageId,
+    );
+    const answer = transcript?.messages.at(-1);
+    const question = transcript?.messages.at(-2);
+    if (
+      answer?.id !== parsed.assistantMessageId ||
+      answer.role !== "assistant" ||
+      question?.role !== "user" ||
+      answer.parentId !== question.id
+    ) {
+      await privateFollowUp(
+        interaction,
+        "That saved Scout answer could not be found for your account.",
+      );
+      return;
+    }
+
+    const chunks = publicExploreChunks({
+      username: interaction.user.username,
+      question: question.content,
+      answer,
+    });
+    const chart = exploreChartAttachment(answer);
+    const publishedMessages: { delete: () => Promise<unknown> }[] = [];
+    try {
+      for (const [index, content] of chunks.entries()) {
+        publishedMessages.push(
+          await interaction.followUp({
+            content,
+            allowedMentions: NO_GENERATED_MENTIONS,
+            ...(index === 0 && chart !== null ? { files: [chart] } : {}),
+          }),
+        );
+      }
+    } catch (publishError) {
+      try {
+        await rollbackPublishedMessages(publishedMessages);
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [publishError, rollbackError],
+          "Scout could not publish or remove its partial public post.",
+          { cause: rollbackError },
+        );
+      }
+      throw publishError;
+    }
+
+    await interaction.editReply({
+      components: [
+        exploreActionRow({
+          conversationId: parsed.conversationId,
+          assistantMessageId: parsed.assistantMessageId,
+          posted: true,
+        }),
+      ],
+    });
+  } finally {
+    publishingMessages.delete(parsed.assistantMessageId);
+  }
+}
+
+async function rollbackPublishedMessages(
+  messages: { delete: () => Promise<unknown> }[],
+): Promise<void> {
+  const errors: unknown[] = [];
+  for (const message of messages.toReversed()) {
+    try {
+      await message.delete();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Could not remove partial Scout posts.");
+  }
+}
+
+async function privateFollowUp(
+  interaction: ScoutPublishButtonInteraction,
+  content: string,
+): Promise<void> {
+  await interaction.followUp({
+    content,
+    flags: MessageFlags.Ephemeral,
+    allowedMentions: NO_GENERATED_MENTIONS,
+  });
+}
+
+export function resetScoutPublishStateForTests(): void {
+  publishingMessages.clear();
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/test-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/test-fixtures.ts
@@ -1,0 +1,22 @@
+import { VisualizationSnapshotSchema } from "@scout-for-lol/data";
+
+export const scoutTestVisualization = VisualizationSnapshotSchema.parse({
+  version: 1,
+  generatedAt: "2026-08-18T00:00:00.000Z",
+  kind: "TABLE",
+  title: "Win rates",
+  temporal: null,
+  bucket: null,
+  display: {
+    theme: null,
+    palette: null,
+    smooth: false,
+    stack: "none",
+    rollingWindow: null,
+    cumulative: false,
+    sparkline: false,
+  },
+  series: [],
+  annotations: [],
+  trends: [],
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/access.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/access.ts
@@ -26,6 +26,11 @@ export function isExploreConfigured(): boolean {
   return exploreAllowlist().length > 0;
 }
 
+/** Whether Discord Explore is enabled in this exact guild right now. */
+export function isExploreGuildAllowed(guildId: string): boolean {
+  return exploreAllowlist().includes(guildId);
+}
+
 /**
  * The access decision itself, separated from fetching the user's servers so
  * it can be tested without a Discord double.

--- a/packages/scout-for-lol/packages/backend/src/explore/http-route.e2e.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/http-route.e2e.test.ts
@@ -20,8 +20,8 @@ import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 
 const trpc = await createOfflineTrpcHarness("explore-http-e2e");
-const { handleExploreRoute, persistPartialAnswer } =
-  await import("#src/explore/http-route.ts");
+const { handleExploreRoute } = await import("#src/explore/http-route.ts");
+const { persistPartialAnswer } = await import("#src/explore/run-turn.ts");
 
 const allowedGuild = DiscordGuildIdSchema.parse("100000000000009401");
 const otherGuild = DiscordGuildIdSchema.parse("100000000000009402");

--- a/packages/scout-for-lol/packages/backend/src/explore/http-route.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/http-route.test.ts
@@ -4,7 +4,7 @@ import {
   EXPLORE_ANSWER_MAX_LENGTH,
   ExploreAnswerSchema,
 } from "@scout-for-lol/data";
-import { clampAnswer } from "#src/explore/http-route.ts";
+import { clampAnswer } from "#src/explore/run-turn.ts";
 
 /**
  * A stopped turn is the one answer path that does not go through

--- a/packages/scout-for-lol/packages/backend/src/explore/http-route.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/http-route.ts
@@ -1,10 +1,6 @@
 import * as Sentry from "@sentry/bun";
 import {
-  EXPLORE_ANSWER_MAX_LENGTH,
-  EXPLORE_INTERRUPTED_CAVEAT,
   EXPLORE_REQUEST_MAX_BYTES,
-  EXPLORE_STOPPED_CAVEAT,
-  EXPLORE_TIMEOUT_MS,
   ExploreHttpErrorSchema,
   ExploreShareTokenSchema,
   ExploreStreamEventSchema,
@@ -13,13 +9,10 @@ import {
   type ExploreMessage,
   type ExploreQuotaSnapshot,
   type ExploreStreamEvent,
-  type ExploreTraceEntry,
   type ExploreTurnRequest,
 } from "@scout-for-lol/data";
-import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
-import { streamExploreAgent } from "#src/explore/agent.ts";
+import { prisma } from "#src/database/index.ts";
 import {
-  getExploreQuotaStatus,
   tryStartExploreTurn,
   type ExploreRateLimitIdentity,
   type ExploreRateLimitTicket,
@@ -27,21 +20,19 @@ import {
 import {
   ExploreInvalidTurnError,
   ExploreNotFoundError,
-  appendExploreAnswer,
-  applyGeneratedTitle,
   loadExploreTranscript,
   loadSharedExploreTranscript,
   resolveRegenerateTarget,
   startExploreTurn,
 } from "#src/explore/store.ts";
 import { authenticateExploreRequest } from "#src/explore/http-auth.ts";
+import {
+  clampExploreMessage,
+  runPersistedExploreTurn,
+} from "#src/explore/run-turn.ts";
 import { createLogger } from "#src/logger.ts";
 import { readBodyWithinLimit } from "#src/utils/bounded-request-body.ts";
-import {
-  scoutExploreActiveRuns,
-  scoutExploreTurnDurationSeconds,
-  scoutExploreTurnsTotal,
-} from "#src/metrics/explore.ts";
+import { scoutExploreTurnsTotal } from "#src/metrics/explore.ts";
 
 const STREAM_PATH = "/api/explore/stream";
 const SHARED_PREFIX = "/api/explore/shared/";
@@ -157,12 +148,6 @@ export async function handleExploreRoute(
       },
     });
 
-    // The turn is valid and now running, so it is charged. Everything that can
-    // reject a request — a bad target, an unreadable transcript — happens
-    // above this line and leaves the quota untouched, so a caller cannot spend
-    // the shared allowance on requests that never ran.
-    ticket.commit();
-
     return new Response(stream, {
       status: 200,
       headers: {
@@ -266,152 +251,26 @@ function runExploreTurnStream(input: {
   history: ExploreMessage[];
 }): void {
   const { controller, request, ticket, identity, started, history } = input;
-  const abortController = new AbortController();
-  const timeout = setTimeout(() => {
-    abortController.abort("Explore turn timed out.");
-  }, EXPLORE_TIMEOUT_MS);
   const writer = createSseWriter(controller);
   const abortFromRequest = () => {
     // Order matters: stop writing before unwinding the run, so nothing the
     // teardown emits can reach the controller the client just took away.
     writer.disconnected();
-    abortController.abort("Client disconnected.");
   };
   request.signal.addEventListener("abort", abortFromRequest);
-  let runStatus = "error";
-  const startedAt = Date.now();
-  scoutExploreActiveRuns.inc();
-
-  const emit = writer.emit;
-
-  emit({
-    type: "started",
-    runId: ticket.runId,
-    conversationId: started.conversationId,
-    questionMessageId: started.messageId,
-  });
-
-  // Accumulated as the run goes so a stopped turn can still be saved, and
-  // so the finished answer carries the trace the reasoning panel shows.
-  const trace: ExploreTraceEntry[] = [];
-  let streamedAnswer = "";
-  const record = (event: ExploreStreamEvent): void => {
-    if (event.type === "answer_delta") {
-      streamedAnswer += event.text;
-    }
-    if (event.type === "tool_result") {
-      trace.push({
-        toolName: event.toolName,
-        message: event.message,
-        ok: event.ok,
-      });
-    }
-    emit(event);
-  };
 
   void (async () => {
     try {
-      const result = await streamExploreAgent({
-        runId: ticket.runId,
-        question: started.question,
-        // Drop the question itself — the agent receives it as the current
-        // turn, and replaying it would duplicate it.
-        history: history.slice(0, -1),
-        abortSignal: abortController.signal,
-        emit: record,
+      await runPersistedExploreTurn({
+        ticket,
+        identity,
+        started,
+        history,
+        abortSignal: request.signal,
+        emit: writer.emit,
       });
-      const message = await appendExploreAnswer(prisma, {
-        conversationId: started.conversationId,
-        parentMessageId: started.messageId,
-        answer: result.answer,
-        preview: result.preview,
-        visualization: result.visualization,
-        trace,
-      });
-      // Only ever changes anything on a conversation still carrying its
-      // question-derived placeholder, so follow-up turns and manual renames
-      // both leave it alone. `started.title` is the conversation's *current*
-      // title, not necessarily that placeholder, so the comparison is made
-      // inside `applyGeneratedTitle` against the opening question instead.
-      const title =
-        result.answer.title === null
-          ? started.title
-          : await applyGeneratedTitle(prisma, {
-              conversationId: started.conversationId,
-              title: result.answer.title,
-            });
-      ticket.finish();
-      runStatus = "success";
-      emit({
-        type: "final",
-        message,
-        title,
-        quota: getExploreQuotaStatus(identity, Date.now()).quota,
-      });
-    } catch (error) {
-      runStatus = abortController.signal.aborted ? "cancelled" : "error";
-      // An interrupted turn keeps whatever it had already said — a deliberate
-      // stop and a mid-stream failure alike. Discarding the prose would leave
-      // a question with no answer under it, which reads as a bug rather than
-      // as an interruption.
-      //
-      // A non-abort failure is a real error the client will only see as a
-      // caveat (salvage emits `final`, not `error`), so the detail goes to
-      // logs and Sentry here rather than vanishing entirely.
-      if (!abortController.signal.aborted) {
-        logger.error("Explore turn failed mid-stream", errorMessage(error));
-        Sentry.captureException(error, {
-          tags: { source: "explore-turn-run" },
-        });
-      }
-      // Guarded on its own because this is a real database write inside a
-      // catch block: a throw here would escape the catch, skip both terminal
-      // events, and surface as an unhandled rejection from the voided async
-      // runner. Salvage is best effort — the turn has already failed, so
-      // failing to keep its remains must not also cost the caller its answer
-      // about what happened.
-      let salvaged: ExploreMessage | null = null;
-      try {
-        salvaged = await persistPartialAnswer(prisma, {
-          aborted: abortController.signal.aborted,
-          conversationId: started.conversationId,
-          parentMessageId: started.messageId,
-          text: streamedAnswer,
-          trace,
-        });
-      } catch (salvageError) {
-        logger.error(
-          "Failed to salvage a stopped explore turn",
-          errorMessage(salvageError),
-        );
-        Sentry.captureException(salvageError, {
-          tags: { source: "explore-salvage" },
-        });
-      }
-      if (salvaged === null) {
-        emit({
-          type: "error",
-          message: clampMessage(errorMessage(error)),
-          retryAfterSeconds: null,
-          quota: getExploreQuotaStatus(identity, Date.now()).quota,
-        });
-      } else {
-        emit({
-          type: "final",
-          message: salvaged,
-          title: started.title,
-          quota: getExploreQuotaStatus(identity, Date.now()).quota,
-        });
-      }
     } finally {
-      clearTimeout(timeout);
       request.signal.removeEventListener("abort", abortFromRequest);
-      ticket.finish();
-      scoutExploreActiveRuns.dec();
-      scoutExploreTurnsTotal.inc({ status: runStatus });
-      scoutExploreTurnDurationSeconds
-        .labels(runStatus)
-        .observe((Date.now() - startedAt) / 1000);
       // A no-op if the client already left: there is nobody to send `done`
       // to, and closing a closed controller throws the same way enqueueing
       // does. The salvage write above is what matters for that case, and it
@@ -509,39 +368,6 @@ async function resolveTurnTarget(
  * put a blank bubble under the question. Exported with an explicit client so
  * tests can drive the salvage semantics without streaming a turn.
  */
-export async function persistPartialAnswer(
-  client: ExtendedPrismaClient,
-  input: {
-    aborted: boolean;
-    conversationId: string;
-    parentMessageId: string;
-    text: string;
-    trace: ExploreTraceEntry[];
-  },
-): Promise<ExploreMessage | null> {
-  if (input.text.trim().length === 0) {
-    return null;
-  }
-  return await appendExploreAnswer(client, {
-    conversationId: input.conversationId,
-    parentMessageId: input.parentMessageId,
-    answer: {
-      answer: clampAnswer(input.text),
-      // A salvaged fragment is a poor summary of the conversation, and the
-      // placeholder is already a faithful one — leave the title alone.
-      title: null,
-      queryText: null,
-      caveats: [
-        input.aborted ? EXPLORE_STOPPED_CAVEAT : EXPLORE_INTERRUPTED_CAVEAT,
-      ],
-      followUps: [],
-    },
-    preview: null,
-    visualization: null,
-    trace: input.trace,
-  });
-}
-
 type ParsedRequestBody =
   | { ok: true; input: ExploreTurnRequest }
   | { ok: false; message: string };
@@ -572,7 +398,7 @@ function jsonError(
     ExploreHttpErrorSchema.parse({
       // Clamped here rather than at each call site: this is the one place
       // every error response is built, so nothing can route around it.
-      error: clampMessage(message),
+      error: clampExploreMessage(message),
       retryAfterSeconds: options.retryAfterSeconds ?? null,
       quota: options.quota ?? null,
     }),
@@ -599,33 +425,3 @@ function errorMessage(error: unknown): string {
  * stopped to keep. The caller has already refused an empty one, so the `min(1)`
  * end of the contract is covered.
  */
-export function clampAnswer(text: string): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= EXPLORE_ANSWER_MAX_LENGTH) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, EXPLORE_ANSWER_MAX_LENGTH - 1)}…`;
-}
-
-/** The longest a message may be in `ExploreHttpErrorSchema` and the SSE error event. */
-const MESSAGE_MAX_LENGTH = 1000;
-
-/**
- * Fit a message inside the schema that will validate it.
- *
- * Both message fields are `.trim().min(1).max(1000)`, and both are parsed on
- * the way out — so an over-long message makes the *error response itself*
- * throw, turning a 400 into a crashed request. A Zod validation error grows
- * with the input, so a wide enough invalid body reaches that length on demand.
- * An empty message would fail `min(1)` just as hard, hence the fallback.
- */
-function clampMessage(message: string): string {
-  const trimmed = message.trim();
-  if (trimmed.length === 0) {
-    return "Request failed.";
-  }
-  if (trimmed.length <= MESSAGE_MAX_LENGTH) {
-    return trimmed;
-  }
-  return `${trimmed.slice(0, MESSAGE_MAX_LENGTH - 1)}…`;
-}

--- a/packages/scout-for-lol/packages/backend/src/explore/run-turn.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-turn.integration.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import type { ExploreAgentParams } from "#src/explore/agent.ts";
+import {
+  getExploreQuotaStatus,
+  resetExploreRateLimitStateForTests,
+  tryStartExploreTurn,
+} from "#src/explore/rate-limit.ts";
+import { runPersistedExploreTurn } from "#src/explore/run-turn.ts";
+import { loadExploreTranscript, startExploreTurn } from "#src/explore/store.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { testAccountId } from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("explore-run-turn-test");
+const userId = testAccountId("73");
+
+const successfulAgent = async (params: ExploreAgentParams) => {
+  await params.emit({
+    type: "tool_result",
+    toolName: "run_report_query",
+    ok: true,
+    message: "Got results.",
+  });
+  return {
+    answer: {
+      answer: "Ahri wins most often.",
+      title: "Most frequent winners",
+      queryText: "SELECT champion, wins FROM match_participants",
+      caveats: ["Tracked matches only."],
+      followUps: [],
+    },
+    preview: null,
+    visualization: null,
+  };
+};
+
+const failingAgent = async (params: ExploreAgentParams) => {
+  await params.emit({ type: "answer_delta", text: "Partial evidence." });
+  throw new Error("provider failed");
+};
+
+beforeEach(async () => {
+  resetExploreRateLimitStateForTests();
+  await prisma.exploreMessage.deleteMany();
+  await prisma.exploreConversation.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.user.create({
+    data: { discordId: userId, discordUsername: "runner" },
+  });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function preparedTurn() {
+  const startedBase = await startExploreTurn(prisma, {
+    conversationId: null,
+    userId,
+    question: "Who wins most often?",
+    attach: { kind: "leaf" },
+  });
+  const started = { ...startedBase, question: "Who wins most often?" };
+  const transcript = await loadExploreTranscript(
+    prisma,
+    started.conversationId,
+    userId,
+    started.messageId,
+  );
+  if (transcript === null) {
+    throw new Error("Expected prepared transcript.");
+  }
+  const ticket = tryStartExploreTurn({ userId }, Date.now());
+  if (!ticket.allowed) {
+    throw new Error("Expected a rate-limit ticket.");
+  }
+  return { started, history: transcript.messages, ticket };
+}
+
+describe("shared persisted Explore turn", () => {
+  test("persists a successful answer, title, trace, and charged quota", async () => {
+    const prepared = await preparedTurn();
+
+    const terminal = await runPersistedExploreTurn(
+      {
+        ...prepared,
+        identity: { userId },
+        emit: () => Promise.resolve(),
+      },
+      {
+        client: prisma,
+        executeAgent: successfulAgent,
+        now: Date.now,
+        timeoutMs: 10_000,
+      },
+    );
+
+    expect(terminal.type).toBe("final");
+    const transcript = await loadExploreTranscript(
+      prisma,
+      prepared.started.conversationId,
+      userId,
+    );
+    expect(transcript?.conversation.title).toBe("Most frequent winners");
+    expect(transcript?.messages[1]?.content).toBe("Ahri wins most often.");
+    expect(transcript?.messages[1]?.trace).toEqual([
+      { toolName: "run_report_query", ok: true, message: "Got results." },
+    ]);
+    expect(getExploreQuotaStatus({ userId }).activeRun).toBe(false);
+    expect(getExploreQuotaStatus({ userId }).quota[0]?.used).toBe(1);
+  });
+
+  test("salvages streamed prose after an agent failure and releases the slot", async () => {
+    const prepared = await preparedTurn();
+
+    const terminal = await runPersistedExploreTurn(
+      {
+        ...prepared,
+        identity: { userId },
+        emit: () => Promise.resolve(),
+      },
+      {
+        client: prisma,
+        executeAgent: failingAgent,
+        now: Date.now,
+        timeoutMs: 10_000,
+      },
+    );
+
+    expect(terminal.type).toBe("final");
+    if (terminal.type === "final") {
+      expect(terminal.message.content).toBe("Partial evidence.");
+      expect(terminal.message.caveats).toContain(
+        "This answer was interrupted by an error before it finished.",
+      );
+    }
+    expect(getExploreQuotaStatus({ userId }).activeRun).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/run-turn.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-turn.ts
@@ -1,0 +1,268 @@
+import * as Sentry from "@sentry/bun";
+import {
+  EXPLORE_ANSWER_MAX_LENGTH,
+  EXPLORE_INTERRUPTED_CAVEAT,
+  EXPLORE_STOPPED_CAVEAT,
+  EXPLORE_TIMEOUT_MS,
+  type ExploreMessage,
+  type ExploreStreamEvent,
+  type ExploreTraceEntry,
+} from "@scout-for-lol/data";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { streamExploreAgent } from "#src/explore/agent.ts";
+import {
+  getExploreQuotaStatus,
+  type ExploreRateLimitIdentity,
+  type ExploreRateLimitTicket,
+} from "#src/explore/rate-limit.ts";
+import {
+  appendExploreAnswer,
+  applyGeneratedTitle,
+} from "#src/explore/store.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  scoutExploreActiveRuns,
+  scoutExploreTurnDurationSeconds,
+  scoutExploreTurnsTotal,
+} from "#src/metrics/explore.ts";
+
+const logger = createLogger("explore-turn");
+
+export type StartedExploreTurn = {
+  conversationId: string;
+  title: string;
+  messageId: string;
+  question: string;
+};
+
+export type ExploreTurnTerminalEvent = Extract<
+  ExploreStreamEvent,
+  { type: "error" | "final" }
+>;
+
+type ExploreTurnDependencies = {
+  client: ExtendedPrismaClient;
+  executeAgent: typeof streamExploreAgent;
+  now: () => number;
+  timeoutMs: number;
+};
+
+const defaultDependencies: ExploreTurnDependencies = {
+  client: prisma,
+  executeAgent: streamExploreAgent,
+  now: Date.now,
+  timeoutMs: EXPLORE_TIMEOUT_MS,
+};
+
+/**
+ * Run and persist one Explore turn independently of its delivery adapter.
+ *
+ * HTTP streams every emitted event over SSE. Discord ignores the progressive
+ * events and renders the returned frozen message after the same runner has
+ * completed. Quota charging, timeout, trace collection, salvage, metrics, and
+ * storage therefore cannot drift between the two entry points.
+ */
+export async function runPersistedExploreTurn(
+  input: {
+    ticket: ExploreRateLimitTicket;
+    identity: ExploreRateLimitIdentity;
+    started: StartedExploreTurn;
+    history: ExploreMessage[];
+    abortSignal?: AbortSignal;
+    emit: (event: ExploreStreamEvent) => void | Promise<void>;
+  },
+  dependencies: ExploreTurnDependencies = defaultDependencies,
+): Promise<ExploreTurnTerminalEvent> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort("Explore turn timed out.");
+  }, dependencies.timeoutMs);
+  const abortFromCaller = () => {
+    abortController.abort(input.abortSignal?.reason);
+  };
+  input.abortSignal?.addEventListener("abort", abortFromCaller);
+  if (input.abortSignal?.aborted === true) {
+    abortFromCaller();
+  }
+
+  let runStatus = "error";
+  const startedAt = dependencies.now();
+  scoutExploreActiveRuns.inc();
+  input.ticket.commit();
+
+  const trace: ExploreTraceEntry[] = [];
+  let streamedAnswer = "";
+  const record = async (event: ExploreStreamEvent): Promise<void> => {
+    if (event.type === "answer_delta") {
+      streamedAnswer += event.text;
+    }
+    if (event.type === "tool_result") {
+      trace.push({
+        toolName: event.toolName,
+        message: event.message,
+        ok: event.ok,
+      });
+    }
+    await input.emit(event);
+  };
+
+  try {
+    await input.emit({
+      type: "started",
+      runId: input.ticket.runId,
+      conversationId: input.started.conversationId,
+      questionMessageId: input.started.messageId,
+    });
+    const result = await dependencies.executeAgent({
+      runId: input.ticket.runId,
+      question: input.started.question,
+      // The last history item is the question being answered. The agent gets
+      // that separately as its current turn, so replaying it duplicates it.
+      history: input.history.slice(0, -1),
+      abortSignal: abortController.signal,
+      emit: record,
+    });
+    const message = await appendExploreAnswer(dependencies.client, {
+      conversationId: input.started.conversationId,
+      parentMessageId: input.started.messageId,
+      answer: result.answer,
+      preview: result.preview,
+      visualization: result.visualization,
+      trace,
+    });
+    const title =
+      result.answer.title === null
+        ? input.started.title
+        : await applyGeneratedTitle(dependencies.client, {
+            conversationId: input.started.conversationId,
+            title: result.answer.title,
+          });
+    input.ticket.finish();
+    runStatus = "success";
+    const terminal: ExploreTurnTerminalEvent = {
+      type: "final",
+      message,
+      title,
+      quota: getExploreQuotaStatus(input.identity, dependencies.now()).quota,
+    };
+    await input.emit(terminal);
+    return terminal;
+  } catch (error) {
+    runStatus = abortController.signal.aborted ? "cancelled" : "error";
+    if (!abortController.signal.aborted) {
+      logger.error("Explore turn failed mid-stream", errorMessage(error));
+      Sentry.captureException(error, {
+        tags: { source: "explore-turn-run" },
+      });
+    }
+
+    let salvaged: ExploreMessage | null = null;
+    try {
+      salvaged = await persistPartialAnswer(dependencies.client, {
+        aborted: abortController.signal.aborted,
+        conversationId: input.started.conversationId,
+        parentMessageId: input.started.messageId,
+        text: streamedAnswer,
+        trace,
+      });
+    } catch (salvageError) {
+      logger.error(
+        "Failed to salvage a stopped explore turn",
+        errorMessage(salvageError),
+      );
+      Sentry.captureException(salvageError, {
+        tags: { source: "explore-salvage" },
+      });
+    }
+
+    input.ticket.finish();
+    const quota = getExploreQuotaStatus(
+      input.identity,
+      dependencies.now(),
+    ).quota;
+    const terminal: ExploreTurnTerminalEvent =
+      salvaged === null
+        ? {
+            type: "error",
+            message: clampExploreMessage(errorMessage(error)),
+            retryAfterSeconds: null,
+            quota,
+          }
+        : {
+            type: "final",
+            message: salvaged,
+            title: input.started.title,
+            quota,
+          };
+    await input.emit(terminal);
+    return terminal;
+  } finally {
+    clearTimeout(timeout);
+    input.abortSignal?.removeEventListener("abort", abortFromCaller);
+    input.ticket.finish();
+    scoutExploreActiveRuns.dec();
+    scoutExploreTurnsTotal.inc({ status: runStatus });
+    scoutExploreTurnDurationSeconds
+      .labels(runStatus)
+      .observe((dependencies.now() - startedAt) / 1000);
+  }
+}
+
+/** Save usable prose from a stopped or failed turn. */
+export async function persistPartialAnswer(
+  client: ExtendedPrismaClient,
+  input: {
+    aborted: boolean;
+    conversationId: string;
+    parentMessageId: string;
+    text: string;
+    trace: ExploreTraceEntry[];
+  },
+): Promise<ExploreMessage | null> {
+  if (input.text.trim().length === 0) {
+    return null;
+  }
+  return await appendExploreAnswer(client, {
+    conversationId: input.conversationId,
+    parentMessageId: input.parentMessageId,
+    answer: {
+      answer: clampAnswer(input.text),
+      title: null,
+      queryText: null,
+      caveats: [
+        input.aborted ? EXPLORE_STOPPED_CAVEAT : EXPLORE_INTERRUPTED_CAVEAT,
+      ],
+      followUps: [],
+    },
+    preview: null,
+    visualization: null,
+    trace: input.trace,
+  });
+}
+
+/** Fit salvaged prose inside the persisted Explore answer contract. */
+export function clampAnswer(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= EXPLORE_ANSWER_MAX_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, EXPLORE_ANSWER_MAX_LENGTH - 1)}…`;
+}
+
+const MESSAGE_MAX_LENGTH = 1000;
+
+/** Fit a message inside the HTTP and stream error schemas. */
+export function clampExploreMessage(message: string): string {
+  const trimmed = message.trim();
+  if (trimmed.length === 0) {
+    return "Request failed.";
+  }
+  if (trimmed.length <= MESSAGE_MAX_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, MESSAGE_MAX_LENGTH - 1)}…`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/web-first.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/web-first.md
@@ -1,14 +1,14 @@
 ---
 title: Why Scout is web-first
-description: Why configuration moved to the browser and only seven commands remain in Discord — and what that costs.
+description: Why configuration and conversation history live in the browser while Discord keeps a small in-the-moment surface.
 sidebar:
   order: 4
 ---
 
 Scout used to be configured entirely through Discord. There were command trees
 for subscriptions, players, accounts, competitions, reports, and permissions —
-dozens of subcommands. Today there are seven commands, and everything else lives
-in the browser.
+dozens of subcommands. Today there are seven global commands, one allowlisted
+Explore command, and everything else lives in the browser.
 
 This page is about why, including the parts that got worse.
 
@@ -18,7 +18,9 @@ Discord commands have a real advantage: zero context switch. You are already in
 the channel, talking to the people you play with, and tracking a player is one
 line. That is why `/track` still exists — the fastest possible path from "we
 should track this person" to a working subscription, with no browser, no sign-in,
-and no navigation.
+and no navigation. `/scout ask` follows the same principle for a different
+moment: ask one question while discussing a game, see the answer privately, and
+decide whether it belongs in the channel.
 
 That advantage is specific to short, single-purpose actions. It does not survive
 contact with complexity.
@@ -51,9 +53,12 @@ a query editor with completion and inline errors, a preview of what a report
 will produce before you save it, and an interface that can display a permission
 matrix without inventing a syntax for it.
 
-A dashboard also lets Scout add capability without adding vocabulary. Reports
-and ScoutQL could not exist as a slash command in any tolerable form; as a page
-with an editor and a preview, they are ordinary.
+A dashboard also lets Scout add capability without adding command vocabulary.
+Creating and maintaining saved reports or ScoutQL is still the wrong shape for a
+slash command; as a page with an editor and a preview, it is ordinary. Explore
+keeps one narrow Discord entry point because natural-language input is already
+one field. Its conversation history, follow-ups, branches, traces, and sharing
+remain in the web UI.
 
 ## What this costs
 
@@ -79,10 +84,16 @@ it was the main argument against the change.
 The rule is roughly: **Discord for things you do in the moment, the browser for
 things you decide.**
 
-Tracking a player and checking what is tracked are momentary — you do them while
-talking about them, so they stayed as commands. Choosing which queues route to
-which channel, who has access, and what the weekly report measures are
-decisions, made once and revisited rarely. Those moved.
+Tracking a player, checking what is tracked, and asking one data question are
+momentary — you do them while talking, so they have lightweight commands.
+Choosing which queues route to which channel, who has access, what a weekly
+report measures, or how an Explore conversation continues are longer-lived
+decisions. Those stay in the browser.
+
+The publication boundary is explicit. `/scout ask` starts private, saves the
+same conversation the web app would, and posts nothing until the asker presses
+**Post publicly**. That posts a frozen copy, not a live query and not an
+owner-only link.
 
 Notifications, of course, remain entirely in Discord. That was never in
 question: Discord is where the server experiences Scout, and the dashboard is

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/discord-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/discord-commands.md
@@ -5,9 +5,10 @@ sidebar:
   order: 1
 ---
 
-Scout registers seven global slash commands. Every reply is **ephemeral** —
-visible only to the person who ran the command. Match notifications and reports
-are posted by Scout separately and are visible to the channel.
+Scout registers seven global slash commands. It also registers `/scout` only in
+servers enabled for the Explore beta. Command replies are **ephemeral** — visible
+only to the person who ran the command — unless the asker explicitly chooses
+**Post publicly** on a completed Scout answer.
 
 ## Command summary
 
@@ -20,6 +21,12 @@ are posted by Scout separately and are visible to the channel.
 | `/docs`   | Open Scout's documentation                      | none            |
 | `/track`  | Track one League player in this Discord channel | 3, all required |
 | `/list`   | List the players Scout tracks for this server   | none            |
+
+In Explore-enabled servers, Scout also registers this guild-scoped command:
+
+| Command      | Description                                   | Options              |
+| ------------ | --------------------------------------------- | -------------------- |
+| `/scout ask` | Ask a private question about Scout match data | `question`, required |
 
 ![The Discord slash-command entry for /track, showing the riot-id, region, and alias option pills with the riot-id hint "Riot ID, for example Faker#KR1".](../../../assets/discord-track-options.png)
 
@@ -80,9 +87,35 @@ gateway latency in milliseconds.
 ## `/help`
 
 An embed containing the dashboard URL, the documentation URL, the command list,
-and a summary of what the dashboard is for.
+and a summary of what the dashboard is for. It includes `/scout ask` only when
+run inside an Explore-enabled server.
 
-![The /help embed listing the dashboard and documentation links, the six other commands with one-line descriptions, and what the dashboard is for.](../../../assets/discord-help.png)
+![The /help embed listing the dashboard and documentation links, the lightweight commands with one-line descriptions, and what the dashboard is for.](../../../assets/discord-help.png)
+
+## `/scout ask`
+
+Asks Scout Explore a one-shot question over the match data Scout has ingested.
+The `question` option accepts 1–2,000 characters. The command is available only
+in servers listed by the operator-managed Explore allowlist and does not work in
+direct messages.
+
+Each invocation starts a **new saved Explore conversation** owned by the Discord
+user who ran it. The answer is initially private and can include caveats and a
+generated chart. Two buttons are shown:
+
+- **Open in Explore** opens the saved conversation in the stage-correct web app.
+- **Post publicly** copies the stored question, answer, caveats, and chart into
+  the channel, then changes to **Posted**.
+
+Publishing uses the frozen saved result. It does not run the model or ScoutQL
+again, does not create a public Explore share link, and does not include the raw
+ScoutQL, tool trace, or owner-only Explore URL. Generated text cannot mention
+Discord users or roles.
+
+Discord is deliberately one-shot: use **Open in Explore** for follow-up
+questions, conversation history, branching, sharing, and other Explore tools.
+Failed validation and runtime errors stay private. If a public post fails, its
+button remains available to retry the same saved result.
 
 ## `/setup`, `/invite`, `/docs`
 
@@ -95,9 +128,10 @@ Link-only commands:
 
 ## What is deliberately not a command
 
-Filters, additional channels, queue selection, mute, competitions, reports,
-roles, permissions, audit history, merges, transfers, and Discord links are
-dashboard-only. See [Why Scout is web-first](/docs/explanation/web-first/).
+Filters, additional channels, queue selection, mute, competitions, saved report
+configuration, roles, permissions, audit history, merges, transfers, Discord
+links, and Explore follow-ups are dashboard-only. See [Why Scout is
+web-first](/docs/explanation/web-first/).
 
 ## Related
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/schedules-and-limits.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/schedules-and-limits.mdx
@@ -73,10 +73,32 @@ count and maximum when you hit one.
 
 ## Discord command limits
 
-| Limit                          | Value            |
-| ------------------------------ | ---------------- |
-| Subscriptions shown by `/list` | 25               |
-| Player alias length (`/track`) | 1–100 characters |
+| Limit                           | Value                    |
+| ------------------------------- | ------------------------ |
+| Subscriptions shown by `/list`  | 25                       |
+| Player alias length (`/track`)  | 1–100 characters         |
+| Explore question (`/scout ask`) | 1–2,000 characters       |
+| Discord message chunk           | at most 1,900 characters |
+
+## Explore question limits
+
+The web Explore UI and `/scout ask` spend from the same per-user and global
+allowances. Starting a question from Discord does not create a second quota.
+
+| Scope  | Window | Questions |
+| ------ | ------ | --------- |
+| user   | minute | 4         |
+| user   | hour   | 30        |
+| user   | day    | 100       |
+| user   | week   | 300       |
+| global | hour   | 120       |
+| global | day    | 600       |
+| global | week   | 2,000     |
+
+One person can have one Explore turn running at a time, and Scout runs at most
+five Explore turns globally at once. A turn times out after three minutes.
+Publishing a saved Discord answer consumes no question allowance because it
+does not rerun the model or query.
 
 ## Related
 

--- a/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
+++ b/packages/scout-for-lol/packages/frontend/src/data/changelog.tsx
@@ -12,6 +12,20 @@ export function renderChangelogToHtml(content: ReactNode): string {
 
 export const changelog: ChangelogEntry[] = [
   buildChangelogEntry({
+    date: "2026 08 18",
+    banner: "Ask Scout from Discord",
+    sections: [
+      {
+        title: "Explore",
+        color: "blue",
+        items: [
+          "Explore-enabled servers can use /scout ask for a private, saved answer about Scout's match data",
+          "Open the conversation in web Explore for follow-ups, or post the frozen question, answer, caveats, and chart to the channel",
+        ],
+      },
+    ],
+  }),
+  buildChangelogEntry({
     date: "2026 08 15",
     banner: "Updated for League patch 26.16",
     sections: [


### PR DESCRIPTION
## Why

Scout users should be able to ask a one-shot data question without leaving a Discord conversation while keeping durable history and follow-ups in the web Explore UI.

## What

- Adds allowlisted, guild-scoped `/scout ask question:<text>` while keeping the seven global commands unchanged.
- Reconciles every connected guild's complete merged command payload, including empty payloads that clear stale commands and immediate reconciliation on guild join.
- Extracts the persisted Explore turn runner so HTTP/SSE and Discord share quota charging, timeout, metrics, traces, partial-answer salvage, model execution, titles, and frozen snapshots.
- Saves every Discord invocation as a fresh owner-scoped Explore conversation and returns bounded private chunks, a stage-aware Explore link, and the existing static chart when present.
- Publishes only the owner-scoped frozen question, answer, caveats, and chart through a versioned button; it suppresses mentions, guards concurrent clicks, and never reruns the model or query.
- Updates the Scout architecture, command reference, web-first explanation, limits, README, agent guidance, and changelog.

Discord remains one-shot. Follow-up questions and history continue in web Explore.

## Verification

- `bun test src/explore src/discord` — 234 passing
- `bunx turbo run typecheck lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/frontend --filter=@scout-for-lol/docs-site` — 17 tasks successful
- Focused ESLint on all changed backend sources and tests
- `bunx lefthook run pre-commit`

## Rollout

- Live beta-guild registration, seeded report-lake execution, public posting, metrics, Bugsink, and model-budget acceptance remain to be run after the beta deployment.
- Production stays unavailable until `EXPLORE_GUILD_ALLOWLIST` is explicitly enabled there.