### PR TITLE
feat(scout-for-lol): bet on Bryan Bucks outcomes by team

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -901,8 +901,10 @@ remain full refunds with no cut.
   payout, cut, net payout, and net winnings so Discord copy never has to
   reconstruct the arithmetic from ledger rows.
 - **One pool per `(matchId, serverId)`; a bet stores a `predictedTeamId`.**
-  Every 5v5 outcome is one binary event, so with two tracked players on opposite
-  teams "A wins" _is_ "B loses". The UI still says "bet LOSE on Jerred".
+  Every 5v5 outcome is one binary event, so the prematch UI offers Blue and Red
+  exactly once each rather than repeating WIN/LOSE controls for every tracked
+  player. `/bb bet` also names the team directly; its tracked-player `game`
+  option identifies the open pool and does not define the wagered outcome.
 - **Settlement idempotency is the `poolState` column, not a marker table.**
   Unlike `MatchAiAttempt` — marked _before_ its call because OpenAI spend cannot
   join a transaction — every side effect here is local, so the transition
@@ -945,14 +947,17 @@ remain full refunds with no cut.
   and is left alone.
 - **A custom ID carries a key, never state.** Buttons encode a roster _index_
   into the pool's frozen snapshot, so they survive a restart and stay inside
-  Discord's 100-character cap. Parsing never throws — it is an unauthenticated
-  surface, and every field is re-validated against server state before a Buck
-  moves. But **not throwing is not the same as not answering**: `isBucksCustomId`
-  is only a prefix check, so once `routeButton` claims a `bb:` interaction it owes
-  Discord an acknowledgement within seconds or the clicker is shown "This
-  interaction failed". An ID that is claimed by namespace and then fails to parse
-  is closed out with a silent `deferUpdate()` and counted as `bb/malformed`, never
-  as `bb/success`.
+  Discord's 100-character cap. That participant is a display-only game anchor:
+  the visible Blue/Red choice is translated into the existing WIN/LOSE bit
+  relative to the anchor, while `predictedTeamId` remains the authoritative
+  wager. Parsing never throws — it is an unauthenticated surface, and every
+  field is re-validated against server state before a Buck moves. But **not
+  throwing is not the same as not answering**: `isBucksCustomId` is only a
+  prefix check, so once `routeButton` claims a `bb:` interaction it owes Discord
+  an acknowledgement within seconds or the clicker is shown "This interaction
+  failed". An ID that is claimed by namespace and then fails to parse is closed
+  out with a silent `deferUpdate()` and counted as `bb/malformed`, never as
+  `bb/success`.
 - **Near-even predictions stay internal.** The formula has no intercept, so a
   symmetric lobby returns exactly `0.500`; calls that display as 45–55% are
   omitted from prematch and settlement copy while remaining available for

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -781,8 +781,9 @@ model BucksBet {
   // Riot team ID the user is backing: 100 or 200.
   predictedTeamId Int
 
-  // Whose outcome the user framed the bet around, for display only. Every 5v5
-  // position reduces to a team, so this never affects settlement.
+  // Display-only tracked-player anchor used to identify the game and preserve
+  // the v1 subject-relative button encoding. `predictedTeamId` alone defines
+  // the wager and settlement outcome.
   subjectPuuid String
 
   // Running total staked. Adding to a position increments this; each increment

--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.integration.test.ts
@@ -144,7 +144,13 @@ describe("personal positions and open markets", () => {
         serverId: SERVER_A,
         detectedAt: new Date("2030-01-01T00:00:00Z"),
         closesAt: new Date("2030-01-01T00:10:00Z"),
-        roster: JSON.stringify({ participants: bucksTestRoster() }),
+        roster: JSON.stringify({
+          participants: bucksTestRoster().map((participant, index) =>
+            index === 1
+              ? { ...participant, puuid: null, trackedAlias: "scrubbed" }
+              : participant,
+          ),
+        }),
       },
     });
     await db.bucksBet.createMany({
@@ -186,9 +192,21 @@ describe("personal positions and open markets", () => {
     );
     expect(personal?.pendingPositions).toEqual([
       expect.objectContaining({
-        subjectAlias: "jerred",
-        side: "WIN",
+        gameAlias: "jerred",
+        teamId: 100,
         stake: 20,
+      }),
+    ]);
+
+    const redAnchorPersonal = await getPersonalBucksView(
+      { serverId: SERVER_A, discordId: USER_B },
+      db,
+    );
+    expect(redAnchorPersonal?.pendingPositions).toEqual([
+      expect.objectContaining({
+        gameAlias: "bryan",
+        teamId: 100,
+        stake: 30,
       }),
     ]);
 
@@ -211,6 +229,7 @@ describe("personal positions and open markets", () => {
       }),
     ]);
     const rendered = JSON.stringify(markets);
+    expect(rendered).not.toContain("scrubbed");
     expect(rendered).not.toContain(USER_A);
     expect(rendered).not.toContain(USER_B);
     expect(rendered).not.toContain(HOUSE_ACCOUNT_DISCORD_ID);

--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
@@ -261,8 +261,8 @@ export async function getLedgerPage(
 
 export type PendingPosition = {
   matchId: string;
-  subjectAlias: string;
-  side: "WIN" | "LOSE";
+  gameAlias: string;
+  teamId: RiotTeamId;
   stake: number;
   closesAt: Date;
   poolState: string;
@@ -338,11 +338,8 @@ export async function getPersonalBucksView(
         }
         return {
           matchId: bet.pool.matchId,
-          subjectAlias: subject.trackedAlias,
-          side:
-            RiotTeamIdSchema.parse(bet.predictedTeamId) === subject.teamId
-              ? "WIN"
-              : "LOSE",
+          gameAlias: subject.trackedAlias,
+          teamId: RiotTeamIdSchema.parse(bet.predictedTeamId),
           stake: bet.stake,
           closesAt: bet.pool.closesAt,
           poolState: BucksPoolStateSchema.parse(bet.pool.poolState),
@@ -375,7 +372,10 @@ function marketSide(
   );
   return {
     trackedPlayers: roster
-      .filter((participant) => participant.teamId === teamId)
+      .filter(
+        (participant) =>
+          participant.teamId === teamId && participant.puuid !== null,
+      )
       .map((participant) => participant.trackedAlias)
       .filter((alias) => alias !== undefined),
     totalStake: sideBets.reduce((total, bet) => total + bet.stake, 0),

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
@@ -433,13 +433,23 @@ describe("formatBetPlacementAnnouncement", () => {
     expect(
       formatBetPlacementAnnouncement({
         discordId: WINNER_DISCORD_ID,
-        subjectAlias: "Aaron",
-        subjectWins: true,
+        teamId: 100,
         stake: 5,
         totalStake: 10,
       }),
     ).toBe(
-      `🎲 <@${WINNER_DISCORD_ID}> staked **5 BB** on **Aaron WINS** (position: **10 BB**). **20% house cut on winning payouts**.`,
+      `🎲 <@${WINNER_DISCORD_ID}> staked **5 BB** on **Blue Team to win** (position: **10 BB**). **20% house cut on winning payouts**.`,
     );
+  });
+
+  test("names Red team placements directly", () => {
+    expect(
+      formatBetPlacementAnnouncement({
+        discordId: WINNER_DISCORD_ID,
+        teamId: 200,
+        stake: 1,
+        totalStake: 6,
+      }),
+    ).toContain("**Red Team to win**");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -8,12 +8,14 @@ import {
   type BucksPrediction,
   type DiscordChannelId,
   type DiscordGuildId,
+  type RiotTeamId,
 } from "@scout-for-lol/data";
 import type { EarnedAward } from "#src/betting/earnings.ts";
 import { HOUSE_CUT_PLACEMENT_NOTE } from "#src/betting/house-cut.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
 import type { ClosedPool } from "#src/betting/sweep.ts";
 import { shouldDisplayPrediction } from "#src/betting/prediction.ts";
+import { teamName } from "#src/betting/team.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
 import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
@@ -81,13 +83,11 @@ export function predictionVerdict(
 
 export function formatBetPlacementAnnouncement(input: {
   discordId: string;
-  subjectAlias: string;
-  subjectWins: boolean;
+  teamId: RiotTeamId;
   stake: number;
   totalStake: number;
 }): string {
-  const side = input.subjectWins ? "WINS" : "LOSES";
-  return `🎲 <@${input.discordId}> staked **${input.stake.toString()} BB** on **${input.subjectAlias} ${side}** (position: **${input.totalStake.toString()} BB**). ${HOUSE_CUT_PLACEMENT_NOTE}`;
+  return `🎲 <@${input.discordId}> staked **${input.stake.toString()} BB** on **${teamName(input.teamId)} to win** (position: **${input.totalStake.toString()} BB**). ${HOUSE_CUT_PLACEMENT_NOTE}`;
 }
 
 /**
@@ -101,8 +101,7 @@ export async function announceBetPlacement(
     matchId: string;
     serverId: ReturnType<typeof DiscordGuildIdSchema.parse>;
     discordId: string;
-    subjectAlias: string;
-    subjectWins: boolean;
+    teamId: RiotTeamId;
     stake: number;
     totalStake: number;
   },

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
@@ -1,5 +1,9 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { DiscordGuildIdSchema } from "@scout-for-lol/data/index.ts";
+import { ButtonStyle } from "discord.js";
+import {
+  DiscordGuildIdSchema,
+  type BucksPoolParticipant,
+} from "@scout-for-lol/data/index.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
 import {
   bucksTestDiscordId,
@@ -9,7 +13,10 @@ import {
   handleBetButton,
   type BetButtonInteraction,
 } from "#src/betting/bet-button.ts";
-import { formatBucksCustomId } from "#src/betting/custom-id.ts";
+import {
+  formatBucksCustomId,
+  parseBucksCustomId,
+} from "#src/betting/custom-id.ts";
 import { buildBettingRows } from "#src/betting/components.ts";
 import {
   HOUSE_ACCOUNT_DISCORD_ID,
@@ -55,6 +62,28 @@ function betId(subjectIndex: number, side: "W" | "L", amount: number) {
   });
 }
 
+function buttonIdForLabel(
+  roster: readonly BucksPoolParticipant[],
+  label: string,
+): string {
+  const row = buildBettingRows({ matchId: MATCH_ID, roster })[0];
+  if (row === undefined) {
+    throw new Error("expected a betting row");
+  }
+  const button = row.components.find((candidate) => {
+    const candidateJson = candidate.toJSON();
+    return "label" in candidateJson && candidateJson.label === label;
+  });
+  if (button === undefined) {
+    throw new Error(`expected a ${label} button`);
+  }
+  const json = button.toJSON();
+  if (!("custom_id" in json)) {
+    throw new Error("team betting buttons must carry a custom id");
+  }
+  return json.custom_id;
+}
+
 async function clearAll() {
   await db.bucksLedgerEntry.deleteMany();
   await db.bucksBet.deleteMany();
@@ -94,32 +123,58 @@ afterAll(async () => {
 });
 
 describe("handleBetButton", () => {
-  test("places a bet from a button click", async () => {
-    const { interaction, replies } = fakeInteraction(betId(0, "W", 5));
-    await handleBetButton(interaction, db);
+  test.each([
+    ["Blue · 1 BB", 100, 1, "Blue Team"],
+    ["Blue · 5 BB", 100, 5, "Blue Team"],
+    ["Red · 1 BB", 200, 1, "Red Team"],
+    ["Red · 5 BB", 200, 5, "Red Team"],
+  ])(
+    "%s places a direct team bet",
+    async (label, expectedTeamId, expectedStake, expectedTeamName) => {
+      const customId = buttonIdForLabel(bucksTestRoster(), label);
+      const { interaction, replies } = fakeInteraction(customId);
+      await handleBetButton(interaction, db);
 
-    expect(replies[0]).toContain("Bet placed");
-    expect(replies[0]).toContain("jerred WINS");
-    expect(replies[0]).toContain("winning payouts, rounded to the nearest BB");
-    expect(replies[0]).toContain("Winning principal is protected");
-    expect(replies[0]).toContain(
-      "Cancelling costs **20%**, also rounded to the nearest BB",
-    );
-    expect(await db.bucksBet.count()).toBe(1);
+      expect(replies[0]).toContain("Bet placed");
+      expect(replies[0]).toContain(expectedTeamName);
+      expect(replies[0]).not.toContain("jerred WINS");
+      expect(replies[0]).toContain(
+        "winning payouts, rounded to the nearest BB",
+      );
+      expect(replies[0]).toContain("Winning principal is protected");
+      expect(replies[0]).toContain(
+        "Cancelling costs **20%**, also rounded to the nearest BB",
+      );
+      expect(await db.bucksBet.count()).toBe(1);
+      const bet = await db.bucksBet.findFirstOrThrow();
+      expect(bet.predictedTeamId).toBe(expectedTeamId);
+      expect(bet.stake).toBe(expectedStake);
 
-    const account = await db.bucksAccount.findFirstOrThrow();
-    expect(account.balance).toBe(SEED_GRANT - 5);
-  });
+      const account = await db.bucksAccount.findFirstOrThrow();
+      expect(account.balance).toBe(SEED_GRANT - expectedStake);
+    },
+  );
 
-  test("a LOSE button backs the opposing team", async () => {
-    const { interaction, replies } = fakeInteraction(betId(0, "L", 1));
-    await handleBetButton(interaction, db);
+  test.each([
+    ["Blue · 1 BB", 100, "Blue Team"],
+    ["Red · 1 BB", 200, "Red Team"],
+  ])(
+    "%s persists the selected team through a Red-side anchor",
+    async (label, expectedTeamId, expectedTeamName) => {
+      const redAnchorRoster = bucksTestRoster().map((participant, index) => ({
+        ...participant,
+        trackedAlias: index === 5 ? "bryan" : undefined,
+      }));
+      const customId = buttonIdForLabel(redAnchorRoster, label);
 
-    expect(replies[0]).toContain("jerred LOSES");
-    const bet = await db.bucksBet.findFirstOrThrow();
-    // Subject index 0 is on team 100, so betting it loses backs team 200.
-    expect(bet.predictedTeamId).toBe(200);
-  });
+      const { interaction, replies } = fakeInteraction(customId);
+      await handleBetButton(interaction, db);
+
+      expect(replies[0]).toContain(expectedTeamName);
+      const bet = await db.bucksBet.findFirstOrThrow();
+      expect(bet.predictedTeamId).toBe(expectedTeamId);
+    },
+  );
 
   test("cancels a position and refunds it", async () => {
     await handleBetButton(fakeInteraction(betId(0, "W", 5)).interaction, db);
@@ -259,18 +314,69 @@ describe("handleBetButton", () => {
 });
 
 describe("buildBettingRows", () => {
-  test("builds one row of five components per tracked player", () => {
+  test("builds one row of five components for both team outcomes", () => {
     const rows = buildBettingRows({
       matchId: MATCH_ID,
       roster: bucksTestRoster(),
     });
 
-    // The fixture tracks two players, on opposite teams.
-    expect(rows).toHaveLength(2);
-    for (const row of rows) {
-      // Discord's per-row cap, which is what fixes the stake denominations.
-      expect(row.components).toHaveLength(5);
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    if (row === undefined) {
+      throw new Error("expected a betting row");
     }
+    expect(row.components).toHaveLength(5);
+    expect(
+      row.components.map((button) => {
+        const json = button.toJSON();
+        return "label" in json ? json.label : undefined;
+      }),
+    ).toEqual([
+      "Blue · 1 BB",
+      "Blue · 5 BB",
+      "Red · 1 BB",
+      "Red · 5 BB",
+      "Cancel",
+    ]);
+    expect(row.components.map((button) => button.toJSON().style)).toEqual([
+      ButtonStyle.Primary,
+      ButtonStyle.Primary,
+      ButtonStyle.Danger,
+      ButtonStyle.Danger,
+      ButtonStyle.Secondary,
+    ]);
+  });
+
+  test("uses one tracked player as the anchor even when several share a team", () => {
+    const roster = bucksTestRoster().map((participant, index) => ({
+      ...participant,
+      trackedAlias: index === 0 ? "jerred" : index === 1 ? "aaron" : undefined,
+    }));
+
+    const rows = buildBettingRows({ matchId: MATCH_ID, roster });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.components).toHaveLength(5);
+  });
+
+  test("maps direct team choices through a Red-side anchor", () => {
+    const roster = bucksTestRoster().map((participant, index) => ({
+      ...participant,
+      trackedAlias: index === 5 ? "bryan" : undefined,
+    }));
+    const rows = buildBettingRows({ matchId: MATCH_ID, roster });
+    const row = rows[0];
+    if (row === undefined) {
+      throw new Error("expected a betting row");
+    }
+
+    const sides = row.components.slice(0, 4).map((button) => {
+      const json = button.toJSON();
+      if (!("custom_id" in json)) {
+        throw new Error("team betting buttons must carry a custom id");
+      }
+      return parseBucksCustomId(json.custom_id)?.side;
+    });
+    expect(sides).toEqual(["L", "L", "W", "W"]);
   });
 
   test("every button carries a parseable, in-range custom ID", () => {
@@ -298,5 +404,16 @@ describe("buildBettingRows", () => {
     expect(buildBettingRows({ matchId: MATCH_ID, roster: untracked })).toEqual(
       [],
     );
+  });
+
+  test("renders the whole team row disabled after the window closes", () => {
+    const rows = buildBettingRows({
+      matchId: MATCH_ID,
+      roster: bucksTestRoster(),
+      disabled: true,
+    });
+    expect(
+      rows[0]?.components.every((button) => button.toJSON().disabled),
+    ).toBe(true);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -3,6 +3,7 @@ import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   type BucksPoolParticipant,
+  type RiotTeamId,
 } from "@scout-for-lol/data";
 import type { InteractionEditReplyOptions } from "discord.js";
 import { parseBucksCustomId } from "#src/betting/custom-id.ts";
@@ -10,6 +11,7 @@ import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { placeBet, type PlaceBetResult } from "#src/betting/place-bet.ts";
 import { cancelBet, type CancelBetResult } from "#src/betting/cancel-bet.ts";
 import { announceBetPlacement } from "#src/betting/announce.ts";
+import { teamIdForSubjectOutcome, teamName } from "#src/betting/team.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -40,13 +42,11 @@ export type BetButtonInteraction = {
  * user input at a system boundary, so none of them are errors. */
 export function describeResult(
   result: PlaceBetResult,
-  subjectAlias: string,
-  betOnWin: boolean,
+  selectedTeamId: RiotTeamId,
 ): string {
   switch (result.kind) {
     case "placed": {
-      const side = betOnWin ? "WINS" : "LOSES";
-      return `✅ Bet placed: **${subjectAlias} ${side}** for **${result.totalStake.toString()} BB** total. Balance: **${result.balanceAfter.toString()} BB**. ${HOUSE_CUT_TERMS}`;
+      return `✅ Bet placed: **${teamName(selectedTeamId)} wins** for **${result.totalStake.toString()} BB** total. Balance: **${result.balanceAfter.toString()} BB**. ${HOUSE_CUT_TERMS}`;
     }
     case "window_closed":
       return "⏰ Betting has closed for this game.";
@@ -145,12 +145,10 @@ export async function handleBetButton(
   const subject = subjectFrom(roster, parsed.subjectIndex);
   if (subject?.puuid == null) {
     await interaction.editReply({
-      content: "🤔 That player isn't in this game any more.",
+      content: "🤔 That game's betting anchor isn't available any more.",
     });
     return;
   }
-
-  const alias = subject.trackedAlias ?? "that player";
 
   if (parsed.action === "x") {
     const cancelled = await cancelBet(
@@ -162,6 +160,7 @@ export async function handleBetButton(
   }
 
   const betOnWin = parsed.side === "W";
+  const selectedTeamId = teamIdForSubjectOutcome(subject.teamId, betOnWin);
   const result = await placeBet(
     {
       matchId: parsed.matchId,
@@ -175,7 +174,7 @@ export async function handleBetButton(
   );
 
   await interaction.editReply({
-    content: describeResult(result, alias, betOnWin),
+    content: describeResult(result, selectedTeamId),
   });
 
   if (result.kind === "placed") {
@@ -184,8 +183,7 @@ export async function handleBetButton(
         matchId: parsed.matchId,
         serverId,
         discordId,
-        subjectAlias: alias,
-        subjectWins: betOnWin,
+        teamId: selectedTeamId,
         stake: parsed.amount,
         totalStake: result.totalStake,
       },

--- a/packages/scout-for-lol/packages/backend/src/betting/components.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/components.ts
@@ -5,106 +5,77 @@ import {
   type APIActionRowComponent,
   type APIComponentInMessageActionRow,
 } from "discord.js";
-import type { BucksPoolParticipant } from "@scout-for-lol/data";
-import { BUTTON_STAKES } from "#src/betting/constants.ts";
+import type { BucksPoolParticipant, RiotTeamId } from "@scout-for-lol/data";
+import { BLUE_TEAM_ID, BUTTON_STAKES } from "#src/betting/constants.ts";
 import { formatBucksCustomId } from "#src/betting/custom-id.ts";
+import {
+  BETTING_TEAM_IDS,
+  shortTeamName,
+  subjectWinsForTeam,
+} from "#src/betting/team.ts";
 
 /**
  * The betting buttons attached to a prematch message.
  *
- * One row per tracked player, each holding exactly five components — Discord's
- * per-row cap — which is what fixes the stake denominations at two values plus
- * a cancel. Anything else goes through `/bb bet`.
+ * One row for the game's two possible outcomes. Each team gets the two fixed
+ * stake denominations and the fifth component cancels the bettor's position.
+ * Anything else goes through `/bb bet`.
  */
-
-/** Discord's cap on action rows in a message. */
-const MAX_ROWS = 5;
-
-/** Discord's cap on a button label. Aliases are truncated well inside it so a
- * long name cannot break the send. */
-const MAX_ALIAS_LENGTH = 12;
-
-function truncateAlias(alias: string): string {
-  if (alias.length <= MAX_ALIAS_LENGTH) {
-    return alias;
-  }
-  return `${alias.slice(0, MAX_ALIAS_LENGTH - 1)}…`;
-}
 
 export type BettableSubject = {
   /** Index into the pool's frozen roster — what the custom ID carries. */
   index: number;
-  alias: string;
+  /** Used only to translate a direct team choice into the v1 WIN/LOSE ID. */
+  teamId: RiotTeamId;
 };
 
 /**
- * The tracked players in a roster that can be bet on, in roster order.
+ * The first tracked player in roster order, used as this game's button anchor.
  *
- * A privacy-scrubbed participant carries no PUUID and so can never be a bet's
- * subject; it is skipped rather than rendered as an unusable button.
+ * The custom ID remains player-relative for compatibility, but the visible
+ * controls are team-relative. A privacy-scrubbed participant carries no PUUID
+ * and cannot anchor a bet.
  */
-export function bettableSubjects(
+export function bettingAnchor(
   roster: readonly BucksPoolParticipant[],
-): BettableSubject[] {
-  const subjects: BettableSubject[] = [];
+): BettableSubject | undefined {
   for (const [index, participant] of roster.entries()) {
     if (participant.trackedAlias === undefined || participant.puuid === null) {
       continue;
     }
-    subjects.push({ index, alias: participant.trackedAlias });
+    return { index, teamId: participant.teamId };
   }
-  return subjects;
+  return undefined;
 }
 
 function buildRow(input: {
   matchId: string;
-  subject: BettableSubject;
+  anchor: BettableSubject;
   /** Rendered greyed out once the window has closed. */
   disabled: boolean;
-  /** Only the first row names the player, since the rest are self-evident. */
-  showAlias: boolean;
 }): ActionRowBuilder<ButtonBuilder> {
-  const alias = truncateAlias(input.subject.alias);
   const buttons: ButtonBuilder[] = [];
 
-  for (const [position, stake] of BUTTON_STAKES.entries()) {
-    buttons.push(
-      new ButtonBuilder()
-        .setCustomId(
-          formatBucksCustomId({
-            action: "b",
-            matchId: input.matchId,
-            subjectIndex: input.subject.index,
-            side: "W",
-            amount: stake,
-          }),
-        )
-        .setLabel(
-          position === 0 && input.showAlias
-            ? `${alias} WIN ${stake.toString()}`
-            : `WIN ${stake.toString()}`,
-        )
-        .setStyle(ButtonStyle.Success)
-        .setDisabled(input.disabled),
-    );
-  }
-
-  for (const stake of BUTTON_STAKES) {
-    buttons.push(
-      new ButtonBuilder()
-        .setCustomId(
-          formatBucksCustomId({
-            action: "b",
-            matchId: input.matchId,
-            subjectIndex: input.subject.index,
-            side: "L",
-            amount: stake,
-          }),
-        )
-        .setLabel(`LOSE ${stake.toString()}`)
-        .setStyle(ButtonStyle.Danger)
-        .setDisabled(input.disabled),
-    );
+  for (const teamId of BETTING_TEAM_IDS) {
+    for (const stake of BUTTON_STAKES) {
+      buttons.push(
+        new ButtonBuilder()
+          .setCustomId(
+            formatBucksCustomId({
+              action: "b",
+              matchId: input.matchId,
+              subjectIndex: input.anchor.index,
+              side: subjectWinsForTeam(input.anchor.teamId, teamId) ? "W" : "L",
+              amount: stake,
+            }),
+          )
+          .setLabel(`${shortTeamName(teamId)} · ${stake.toString()} BB`)
+          .setStyle(
+            teamId === BLUE_TEAM_ID ? ButtonStyle.Primary : ButtonStyle.Danger,
+          )
+          .setDisabled(input.disabled),
+      );
+    }
   }
 
   buttons.push(
@@ -113,7 +84,7 @@ function buildRow(input: {
         formatBucksCustomId({
           action: "x",
           matchId: input.matchId,
-          subjectIndex: input.subject.index,
+          subjectIndex: input.anchor.index,
           side: "W",
           amount: 0,
         }),
@@ -137,15 +108,17 @@ export function buildBettingRows(input: {
   roster: readonly BucksPoolParticipant[];
   disabled?: boolean;
 }): ActionRowBuilder<ButtonBuilder>[] {
-  const subjects = bettableSubjects(input.roster).slice(0, MAX_ROWS);
-  return subjects.map((subject, position) =>
+  const anchor = bettingAnchor(input.roster);
+  if (anchor === undefined) {
+    return [];
+  }
+  return [
     buildRow({
       matchId: input.matchId,
-      subject,
+      anchor,
       disabled: input.disabled ?? false,
-      showAlias: position === 0 || subjects.length > 1,
     }),
-  );
+  ];
 }
 
 /**
@@ -167,7 +140,3 @@ export function disableRows(
     ),
   }));
 }
-
-/** How many players the message can offer buttons for, so callers can tell the
- * reader when some were left out. */
-export const MAX_BETTING_ROWS = MAX_ROWS;

--- a/packages/scout-for-lol/packages/backend/src/betting/custom-id.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/custom-id.ts
@@ -9,8 +9,10 @@ import { z } from "zod";
  *
  * **The ID carries a key, never state.** `subjectIndex` points into the pool's
  * own frozen roster rather than naming a player, so a button keeps working
- * across a bot restart with nothing held in memory. It also keeps the ID short:
- * a PUUID is 78 characters and Discord's cap is 100.
+ * across a bot restart with nothing held in memory. The visible controls name
+ * Blue and Red directly; `side` is the compatibility adapter that expresses
+ * that team choice relative to this anchor. It also keeps the ID short: a PUUID
+ * is 78 characters and Discord's cap is 100.
  *
  * **A malformed ID is never fatal.** This is an unauthenticated input surface —
  * anyone can craft a component interaction — so parsing returns a result rather
@@ -35,7 +37,7 @@ export const BucksCustomIdSchema = z.strictObject({
   matchId: z.string().min(1),
   /** Index into `BucksMatchPool.roster.participants`. */
   subjectIndex: z.number().int().min(0).max(9),
-  /** Whether the bettor is backing the subject to win or to lose. */
+  /** Whether the selected team matches the anchor's team. */
   side: BucksSideSchema,
   /** Stake in Bucks. Zero for a cancel, where it carries no meaning. */
   amount: z.number().int().min(0).max(1000),

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.ts
@@ -4,8 +4,10 @@ import {
   type DiscordAccountId,
   type DiscordGuildId,
   type LeaguePuuid,
+  type RiotTeamId,
 } from "@scout-for-lol/data";
 import { MAX_STAKE, MIN_STAKE } from "#src/betting/constants.ts";
+import { teamIdForSubjectOutcome } from "#src/betting/team.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import {
   ensureBucksAccount,
@@ -32,7 +34,12 @@ const logger = createLogger("betting-place-bet");
  * get a friendly ephemeral reply, not a Sentry event.
  */
 export type PlaceBetResult =
-  | { kind: "placed"; totalStake: number; balanceAfter: number; side: number }
+  | {
+      kind: "placed";
+      totalStake: number;
+      balanceAfter: number;
+      side: RiotTeamId;
+    }
   | { kind: "window_closed" }
   | { kind: "no_pool" }
   | { kind: "feature_disabled" }
@@ -48,13 +55,12 @@ export type PlaceBetInput = {
   serverId: DiscordGuildId;
   discordId: DiscordAccountId;
   /**
-   * The tracked player the bettor is framing the bet around. Branded, because
-   * both callers resolve it out of the pool's own roster snapshot rather than
-   * from free text — the button carries a roster index and `/bb bet` matches an
-   * alias.
+   * The tracked player used to identify this game and translate a direct team
+   * choice into the v1 subject-relative button contract. Branded because both
+   * callers resolve it out of the pool's frozen roster snapshot.
    */
   subjectPuuid: LeaguePuuid;
-  /** True when betting the subject WINS. */
+  /** Compatibility adapter: true when the selected team is the anchor's team. */
   subjectWins: boolean;
   stake: number;
   now?: Date;
@@ -125,13 +131,13 @@ export async function placeBet(
     return { kind: "unknown_subject", validAliases: aliasesOf(roster) };
   }
 
-  // "Bet that Jerred loses" and "bet that the other team wins" are the same
-  // position on a 5v5, so a subject plus a direction resolves to one team.
-  const predictedTeamId = input.subjectWins
-    ? subject.teamId
-    : subject.teamId === 100
-      ? 200
-      : 100;
+  // The public surfaces name Blue or Red directly. The v1 button contract and
+  // display-only subjectPuuid stay player-relative for compatibility, so the
+  // anchor plus direction resolves that direct choice back to one team.
+  const predictedTeamId = teamIdForSubjectOutcome(
+    subject.teamId,
+    input.subjectWins,
+  );
 
   // Eligibility and wallet creation sit outside the transaction on purpose: a
   // freshly seeded zero-risk wallet is harmless, and keeping the create out of

--- a/packages/scout-for-lol/packages/backend/src/betting/team.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/team.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BucksTeamChoiceSchema,
+  shortTeamName,
+  subjectWinsForTeam,
+  teamIdForChoice,
+  teamIdForSubjectOutcome,
+  teamName,
+} from "#src/betting/team.ts";
+
+describe("Bryan Bucks team mapping", () => {
+  test("maps Discord choices to Riot team IDs", () => {
+    expect(teamIdForChoice(BucksTeamChoiceSchema.parse("blue"))).toBe(100);
+    expect(teamIdForChoice(BucksTeamChoiceSchema.parse("red"))).toBe(200);
+    expect(BucksTeamChoiceSchema.safeParse("green").success).toBe(false);
+  });
+
+  test("formats the shared Blue and Red labels", () => {
+    expect(shortTeamName(100)).toBe("Blue");
+    expect(shortTeamName(200)).toBe("Red");
+    expect(teamName(100)).toBe("Blue Team");
+    expect(teamName(200)).toBe("Red Team");
+  });
+
+  test("translates direct choices through anchors on either side", () => {
+    expect(subjectWinsForTeam(100, 100)).toBe(true);
+    expect(subjectWinsForTeam(100, 200)).toBe(false);
+    expect(subjectWinsForTeam(200, 100)).toBe(false);
+    expect(subjectWinsForTeam(200, 200)).toBe(true);
+
+    expect(teamIdForSubjectOutcome(100, true)).toBe(100);
+    expect(teamIdForSubjectOutcome(100, false)).toBe(200);
+    expect(teamIdForSubjectOutcome(200, true)).toBe(200);
+    expect(teamIdForSubjectOutcome(200, false)).toBe(100);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/team.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/team.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import type { RiotTeamId } from "@scout-for-lol/data";
+import { BLUE_TEAM_ID, RED_TEAM_ID } from "#src/betting/constants.ts";
+
+export const BucksTeamChoiceSchema = z.enum(["blue", "red"]);
+
+export type BucksTeamChoice = z.infer<typeof BucksTeamChoiceSchema>;
+
+export const BETTING_TEAM_IDS: readonly RiotTeamId[] = [
+  BLUE_TEAM_ID,
+  RED_TEAM_ID,
+];
+
+export function teamIdForChoice(choice: BucksTeamChoice): RiotTeamId {
+  return choice === "blue" ? BLUE_TEAM_ID : RED_TEAM_ID;
+}
+
+export function shortTeamName(teamId: RiotTeamId): "Blue" | "Red" {
+  return teamId === BLUE_TEAM_ID ? "Blue" : "Red";
+}
+
+export function teamName(teamId: RiotTeamId): "Blue Team" | "Red Team" {
+  return `${shortTeamName(teamId)} Team`;
+}
+
+export function teamIdForSubjectOutcome(
+  subjectTeamId: RiotTeamId,
+  subjectWins: boolean,
+): RiotTeamId {
+  if (subjectWins) {
+    return subjectTeamId;
+  }
+  return subjectTeamId === BLUE_TEAM_ID ? RED_TEAM_ID : BLUE_TEAM_ID;
+}
+
+export function subjectWinsForTeam(
+  subjectTeamId: RiotTeamId,
+  selectedTeamId: RiotTeamId,
+): boolean {
+  return subjectTeamId === selectedTeamId;
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
@@ -117,8 +117,8 @@ describe("/bb command contract", () => {
       pendingPositionCount: 10,
       pendingPositions: Array.from({ length: 10 }, (_, index) => ({
         matchId: `NA1_${index.toString()}`,
-        subjectAlias: `player-${index.toString()}-${"x".repeat(500)}`,
-        side: "WIN",
+        gameAlias: `player-${index.toString()}-${"x".repeat(500)}`,
+        teamId: 100,
         stake: 1,
         closesAt: new Date(60_000),
         poolState: "open",
@@ -131,6 +131,30 @@ describe("/bb command contract", () => {
 
     expect(pendingField?.value.length).toBeLessThanOrEqual(1024);
     expect(pendingField?.value.endsWith("...")).toBe(true);
+  });
+
+  test("renders pending positions as direct team picks", () => {
+    const view: PersonalBucksView = {
+      balance: 20,
+      totalStaked: 5,
+      pendingPositionCount: 1,
+      pendingPositions: [
+        {
+          matchId: "NA1_1",
+          gameAlias: "bryan",
+          teamId: 200,
+          stake: 5,
+          closesAt: new Date(60_000),
+          poolState: "open",
+        },
+      ],
+    };
+
+    const rendered = JSON.stringify(buildPersonalBucksEmbed(view, 0).toJSON());
+    expect(rendered).toContain("Red Team");
+    expect(rendered).toContain("game: `bryan`");
+    expect(rendered).not.toContain("WIN");
+    expect(rendered).not.toContain("LOSE");
   });
 
   test("rules explain the complete economy", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
@@ -3,6 +3,7 @@ import { bucksTestRoster } from "#src/testing/bucks-fixtures.ts";
 import {
   bbCommand,
   buildOpenMarketSections,
+  buildUnknownGameReplyChunks,
   formatGameSelectors,
   resolveOpenGameByAlias,
   trackedGameAliases,
@@ -123,6 +124,22 @@ describe("/bb bet", () => {
 
   test("suggests only aliases accepted by the game selector", () => {
     expect(trackedGameAliases(bucksTestRoster())).toEqual(["jerred", "bryan"]);
+  });
+
+  test("keeps every suggested alias within Discord-safe reply chunks", () => {
+    const aliases = Array.from(
+      { length: 200 },
+      (_, index) => `tracked-player-${index.toString().padStart(3, "0")}`,
+    );
+    const chunks = buildUnknownGameReplyChunks("missing", aliases);
+    const fullReply = chunks.join("\n");
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 1900)).toBe(true);
+    expect(fullReply).toContain("No open game for **missing**");
+    for (const alias of aliases) {
+      expect(fullReply).toContain(`- \`${alias}\``);
+    }
   });
 
   test("shows every open-game alias with its Blue or Red team", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { bucksTestRoster } from "#src/testing/bucks-fixtures.ts";
 import {
   bbCommand,
+  buildOpenMarketSections,
+  formatGameSelectors,
   resolveOpenGameByAlias,
   trackedGameAliases,
-  trackedGameLabels,
 } from "#src/discord/commands/bb.ts";
 
 function pool(matchId: string) {
@@ -88,20 +89,62 @@ describe("/bb bet", () => {
     expect(resolveOpenGameByAlias([pool("NA1_1")], "missing")).toBeUndefined();
   });
 
+  test("does not match a tracked alias whose participant was scrubbed", () => {
+    const roster = bucksTestRoster().map((participant, index) =>
+      index === 1
+        ? { ...participant, puuid: null, trackedAlias: "scrubbed" }
+        : participant,
+    );
+    expect(
+      resolveOpenGameByAlias(
+        [
+          {
+            matchId: "NA1_scrubbed",
+            roster: JSON.stringify({ participants: roster }),
+          },
+        ],
+        "scrubbed",
+      ),
+    ).toBeUndefined();
+  });
+
   test("refuses to choose arbitrarily when an alias matches multiple pools", () => {
     expect(() =>
       resolveOpenGameByAlias([pool("NA1_1"), pool("NA1_2")], "jerred"),
     ).toThrow("matched 2 open Bryan Bucks pools");
   });
 
-  test("labels every tracked game anchor with a copyable alias and its team", () => {
-    expect(trackedGameLabels(bucksTestRoster())).toEqual([
-      "game: `jerred` — Blue Team",
-      "game: `bryan` — Red Team",
+  test("formats every suggested game alias as a copyable selector", () => {
+    expect(formatGameSelectors(["jerred", "bryan"])).toEqual([
+      "game: `jerred`",
+      "game: `bryan`",
     ]);
   });
 
   test("suggests only aliases accepted by the game selector", () => {
     expect(trackedGameAliases(bucksTestRoster())).toEqual(["jerred", "bryan"]);
+  });
+
+  test("shows every open-game alias with its Blue or Red team", () => {
+    const sections = buildOpenMarketSections([
+      {
+        matchId: "NA1_open",
+        closesAt: new Date("2030-01-01T00:10:00Z"),
+        blue: {
+          trackedPlayers: ["jerred", "friend"],
+          totalStake: 6,
+          betCount: 2,
+        },
+        red: { trackedPlayers: ["bryan"], totalStake: 5, betCount: 1 },
+      },
+    ]);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toContain(
+      "🔵 **Blue Team:** 6 BB across 2 bet(s) — game: `jerred`, game: `friend`",
+    );
+    expect(sections[0]).toContain(
+      "🔴 **Red Team:** 5 BB across 1 bet(s) — game: `bryan`",
+    );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { bucksTestRoster } from "#src/testing/bucks-fixtures.ts";
+import {
+  bbCommand,
+  resolveOpenGameByAlias,
+  trackedGameLabels,
+} from "#src/discord/commands/bb.ts";
+
+function pool(matchId: string) {
+  return {
+    matchId,
+    roster: JSON.stringify({ participants: bucksTestRoster() }),
+  };
+}
+
+function fixturePuuidAt(index: number) {
+  const puuid = bucksTestRoster()[index]?.puuid;
+  if (puuid === undefined || puuid === null) {
+    throw new Error(
+      `expected a tracked-player fixture at index ${index.toString()}`,
+    );
+  }
+  return puuid;
+}
+
+describe("/bb bet", () => {
+  test("registers game, team, and amount as required options", () => {
+    const command = bbCommand.toJSON();
+    const bet = command.options?.find((option) => option.name === "bet");
+    if (bet === undefined || !("options" in bet)) {
+      throw new Error("expected the /bb bet subcommand");
+    }
+
+    expect(bet).toEqual(
+      expect.objectContaining({
+        type: 1,
+        name: "bet",
+        description: "Bet on Blue or Red; 20% win and cancellation house cuts",
+      }),
+    );
+    expect(bet.options).toEqual([
+      expect.objectContaining({
+        name: "game",
+        description: "A tracked player in the game",
+        required: true,
+      }),
+      expect.objectContaining({
+        name: "team",
+        description: "The team to win",
+        required: true,
+        choices: [
+          { name: "Blue", value: "blue" },
+          { name: "Red", value: "red" },
+        ],
+      }),
+      expect.objectContaining({
+        name: "amount",
+        required: true,
+        min_value: 1,
+        max_value: 1000,
+      }),
+    ]);
+  });
+
+  test("matches the game alias case-insensitively on either team", () => {
+    const roster = bucksTestRoster();
+    const pools = [
+      {
+        matchId: "NA1_blue-and-red",
+        roster: JSON.stringify({ participants: roster }),
+      },
+    ];
+
+    expect(resolveOpenGameByAlias(pools, "JERRED")).toEqual({
+      matchId: "NA1_blue-and-red",
+      subjectPuuid: fixturePuuidAt(0),
+      subjectTeamId: 100,
+    });
+    expect(resolveOpenGameByAlias(pools, "BrYaN")).toEqual({
+      matchId: "NA1_blue-and-red",
+      subjectPuuid: fixturePuuidAt(5),
+      subjectTeamId: 200,
+    });
+  });
+
+  test("returns no game for an unknown alias", () => {
+    expect(resolveOpenGameByAlias([pool("NA1_1")], "missing")).toBeUndefined();
+  });
+
+  test("refuses to choose arbitrarily when an alias matches multiple pools", () => {
+    expect(() =>
+      resolveOpenGameByAlias([pool("NA1_1"), pool("NA1_2")], "jerred"),
+    ).toThrow("matched 2 open Bryan Bucks pools");
+  });
+
+  test("labels every tracked game anchor with its team", () => {
+    expect(trackedGameLabels(bucksTestRoster())).toEqual([
+      "jerred (Blue)",
+      "bryan (Red)",
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
@@ -3,6 +3,7 @@ import { bucksTestRoster } from "#src/testing/bucks-fixtures.ts";
 import {
   bbCommand,
   resolveOpenGameByAlias,
+  trackedGameAliases,
   trackedGameLabels,
 } from "#src/discord/commands/bb.ts";
 
@@ -93,10 +94,14 @@ describe("/bb bet", () => {
     ).toThrow("matched 2 open Bryan Bucks pools");
   });
 
-  test("labels every tracked game anchor with its team", () => {
+  test("labels every tracked game anchor with a copyable alias and its team", () => {
     expect(trackedGameLabels(bucksTestRoster())).toEqual([
-      "jerred (Blue)",
-      "bryan (Red)",
+      "game: `jerred` — Blue Team",
+      "game: `bryan` — Red Team",
     ]);
+  });
+
+  test("suggests only aliases accepted by the game selector", () => {
+    expect(trackedGameAliases(bucksTestRoster())).toEqual(["jerred", "bryan"]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -15,6 +15,7 @@ import {
   getLedgerPage,
   getOpenMarketAggregates,
   getPersonalBucksView,
+  type OpenMarketAggregate,
   type PersonalBucksView,
 } from "#src/betting/accounts.ts";
 import { placeBet } from "#src/betting/place-bet.ts";
@@ -22,17 +23,19 @@ import { describeResult } from "#src/betting/bet-button.ts";
 import { announceBetPlacement } from "#src/betting/announce.ts";
 import {
   BETTING_WINDOW_MS,
+  BLUE_TEAM_ID,
   MAX_STAKE,
   MIN_STAKE,
+  RED_TEAM_ID,
   SEED_GRANT,
 } from "#src/betting/constants.ts";
 import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { renderBucksHistory } from "#src/betting/navigation.ts";
 import {
   BucksTeamChoiceSchema,
-  shortTeamName,
   subjectWinsForTeam,
   teamIdForChoice,
+  teamName,
 } from "#src/betting/team.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
@@ -134,7 +137,7 @@ export function buildPersonalBucksEmbed(
       position.poolState === "open" && position.closesAt.getTime() > now
         ? `closes <t:${Math.floor(position.closesAt.getTime() / 1000).toString()}:R>`
         : "locked";
-    return `• **${position.subjectAlias} ${position.side}** — ${position.stake.toString()} BB · ${state}`;
+    return `• **${teamName(position.teamId)}** — game: \`${position.gameAlias}\` · ${position.stake.toString()} BB · ${state}`;
   });
   if (view.pendingPositionCount > view.pendingPositions.length) {
     positions.push(
@@ -182,16 +185,8 @@ function parseRoster(raw: string): BucksPoolParticipant[] {
   return BucksPoolRosterSchema.parse(JSON.parse(raw)).participants;
 }
 
-export function trackedGameLabels(
-  roster: readonly BucksPoolParticipant[],
-): string[] {
-  return roster.flatMap((participant) =>
-    participant.trackedAlias === undefined || participant.puuid === null
-      ? []
-      : [
-          `game: \`${participant.trackedAlias}\` — ${shortTeamName(participant.teamId)} Team`,
-        ],
-  );
+export function formatGameSelectors(aliases: readonly string[]): string[] {
+  return aliases.map((alias) => `game: \`${alias}\``);
 }
 
 export function trackedGameAliases(
@@ -271,7 +266,7 @@ export function buildBbRulesEmbed(): EmbedBuilder {
         name: "Eligibility & earnings",
         value:
           `Your Discord account must be linked to a tracked player. A new wallet starts with **${SEED_GRANT.toString()} BB**. ` +
-          "Eligible ranked games award **+1 BB** for playing, **+1 BB** for winning, and **+1 BB** for MVP.",
+          "Eligible games award **+1 BB** for playing, **+1 BB** for winning, and **+1 BB** for MVP.",
       },
       {
         name: "Placing a bet",
@@ -323,23 +318,7 @@ async function replyOpen(
     return;
   }
 
-  const sections = pools.map((pool) => {
-    const closesAtUnix = Math.floor(pool.closesAt.getTime() / 1000);
-    const bluePlayers =
-      pool.blue.trackedPlayers.length > 0
-        ? pool.blue.trackedPlayers.map((alias) => `\`${alias}\``).join(", ")
-        : "No tracked players";
-    const redPlayers =
-      pool.red.trackedPlayers.length > 0
-        ? pool.red.trackedPlayers.map((alias) => `\`${alias}\``).join(", ")
-        : "No tracked players";
-    return [
-      `## ${bluePlayers} vs ${redPlayers}`,
-      `Closes <t:${closesAtUnix.toString()}:R>`,
-      `🔵 **Blue Team:** ${pool.blue.totalStake.toString()} BB across ${pool.blue.betCount.toString()} bet(s) — game: ${bluePlayers}`,
-      `🔴 **Red Team:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — game: ${redPlayers}`,
-    ].join("\n");
-  });
+  const sections = buildOpenMarketSections(pools);
   const chunks = splitMessageIntoChunks(
     `${sections.join("\n\n")}\n\n${HOUSE_CUT_TERMS}`,
   );
@@ -351,6 +330,28 @@ async function replyOpen(
   for (const chunk of chunks.slice(1)) {
     await interaction.followUp({ content: chunk, ephemeral: true });
   }
+}
+
+export function buildOpenMarketSections(
+  pools: readonly OpenMarketAggregate[],
+): string[] {
+  return pools.map((pool) => {
+    const closesAtUnix = Math.floor(pool.closesAt.getTime() / 1000);
+    const blueSelectors = formatGameSelectors(pool.blue.trackedPlayers);
+    const redSelectors = formatGameSelectors(pool.red.trackedPlayers);
+    const bluePlayers =
+      blueSelectors.length > 0
+        ? blueSelectors.join(", ")
+        : "No tracked players";
+    const redPlayers =
+      redSelectors.length > 0 ? redSelectors.join(", ") : "No tracked players";
+    return [
+      `## ${bluePlayers} vs ${redPlayers}`,
+      `Closes <t:${closesAtUnix.toString()}:R>`,
+      `🔵 **${teamName(BLUE_TEAM_ID)}:** ${pool.blue.totalStake.toString()} BB across ${pool.blue.betCount.toString()} bet(s) — ${bluePlayers}`,
+      `🔴 **${teamName(RED_TEAM_ID)}:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — ${redPlayers}`,
+    ].join("\n");
+  });
 }
 
 async function replyBet(

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -305,6 +305,20 @@ async function replyHistory(
   await interaction.editReply(renderBucksHistory(discordId, page));
 }
 
+async function editReplyInChunks(
+  interaction: ChatInputCommandInteraction,
+  chunks: readonly string[],
+): Promise<void> {
+  const first = chunks[0];
+  if (first === undefined) {
+    throw new Error("Bryan Bucks reply produced no Discord content");
+  }
+  await interaction.editReply({ content: first });
+  for (const chunk of chunks.slice(1)) {
+    await interaction.followUp({ content: chunk, ephemeral: true });
+  }
+}
+
 async function replyOpen(
   interaction: ChatInputCommandInteraction,
   serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
@@ -319,17 +333,10 @@ async function replyOpen(
   }
 
   const sections = buildOpenMarketSections(pools);
-  const chunks = splitMessageIntoChunks(
-    `${sections.join("\n\n")}\n\n${HOUSE_CUT_TERMS}`,
+  await editReplyInChunks(
+    interaction,
+    splitMessageIntoChunks(`${sections.join("\n\n")}\n\n${HOUSE_CUT_TERMS}`),
   );
-  const first = chunks[0];
-  if (first === undefined) {
-    throw new Error("Open Bryan Bucks markets produced no Discord content");
-  }
-  await interaction.editReply({ content: first });
-  for (const chunk of chunks.slice(1)) {
-    await interaction.followUp({ content: chunk, ephemeral: true });
-  }
 }
 
 export function buildOpenMarketSections(
@@ -352,6 +359,18 @@ export function buildOpenMarketSections(
       `🔴 **${teamName(RED_TEAM_ID)}:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — ${redPlayers}`,
     ].join("\n");
   });
+}
+
+export function buildUnknownGameReplyChunks(
+  requestedAlias: string,
+  availableAliases: readonly string[],
+): string[] {
+  return splitMessageIntoChunks(
+    [
+      `No open game for **${requestedAlias}**. Valid game aliases:`,
+      ...availableAliases.map((alias) => `- \`${alias}\``),
+    ].join("\n"),
+  );
 }
 
 async function replyBet(
@@ -404,12 +423,17 @@ async function replyBet(
     trackedGameAliases(parseRoster(pool.roster)),
   );
 
-  await interaction.editReply({
-    content:
-      available.length === 0
-        ? "No games are open for betting right now."
-        : `No open game for **${requestedAlias}**. Valid game aliases: ${available.map((alias) => `\`${alias}\``).join(", ")}.`,
-  });
+  if (available.length === 0) {
+    await interaction.editReply({
+      content: "No games are open for betting right now.",
+    });
+    return;
+  }
+
+  await editReplyInChunks(
+    interaction,
+    buildUnknownGameReplyChunks(requestedAlias, available),
+  );
 }
 
 export async function executeBb(

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -266,7 +266,7 @@ export function buildBbRulesEmbed(): EmbedBuilder {
         name: "Eligibility & earnings",
         value:
           `Your Discord account must be linked to a tracked player. A new wallet starts with **${SEED_GRANT.toString()} BB**. ` +
-          "Eligible games award **+1 BB** for playing, **+1 BB** for winning, and **+1 BB** for MVP.",
+          "Eligible ranked games award **+1 BB** for playing, **+1 BB** for winning, and **+1 BB** for MVP.",
       },
       {
         name: "Placing a bet",

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -188,7 +188,19 @@ export function trackedGameLabels(
   return roster.flatMap((participant) =>
     participant.trackedAlias === undefined || participant.puuid === null
       ? []
-      : [`${participant.trackedAlias} (${shortTeamName(participant.teamId)})`],
+      : [
+          `game: \`${participant.trackedAlias}\` — ${shortTeamName(participant.teamId)} Team`,
+        ],
+  );
+}
+
+export function trackedGameAliases(
+  roster: readonly BucksPoolParticipant[],
+): string[] {
+  return roster.flatMap((participant) =>
+    participant.trackedAlias === undefined || participant.puuid === null
+      ? []
+      : [participant.trackedAlias],
   );
 }
 
@@ -388,14 +400,14 @@ async function replyBet(
   }
 
   const available = pools.flatMap((pool) =>
-    trackedGameLabels(parseRoster(pool.roster)),
+    trackedGameAliases(parseRoster(pool.roster)),
   );
 
   await interaction.editReply({
     content:
       available.length === 0
         ? "No games are open for betting right now."
-        : `No open game for **${requestedAlias}**. Try: ${available.join(", ")}.`,
+        : `No open game for **${requestedAlias}**. Valid game aliases: ${available.map((alias) => `\`${alias}\``).join(", ")}.`,
   });
 }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -7,6 +7,9 @@ import {
   BucksPoolRosterSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
+  type BucksPoolParticipant,
+  type LeaguePuuid,
+  type RiotTeamId,
 } from "@scout-for-lol/data/index.ts";
 import {
   getLedgerPage,
@@ -25,6 +28,12 @@ import {
 } from "#src/betting/constants.ts";
 import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { renderBucksHistory } from "#src/betting/navigation.ts";
+import {
+  BucksTeamChoiceSchema,
+  shortTeamName,
+  subjectWinsForTeam,
+  teamIdForChoice,
+} from "#src/betting/team.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
 import { replyError } from "#src/discord/commands/define-command.ts";
@@ -87,21 +96,21 @@ export const bbCommand = new SlashCommandBuilder()
   .addSubcommand((sub) =>
     sub
       .setName("bet")
-      .setDescription("Bet on a live game; 20% win and cancellation house cuts")
+      .setDescription("Bet on Blue or Red; 20% win and cancellation house cuts")
       .addStringOption((option) =>
         option
-          .setName("player")
-          .setDescription("The tracked player to bet on")
+          .setName("game")
+          .setDescription("A tracked player in the game")
           .setRequired(true),
       )
       .addStringOption((option) =>
         option
-          .setName("side")
-          .setDescription("Whether they win or lose")
+          .setName("team")
+          .setDescription("The team to win")
           .setRequired(true)
           .addChoices(
-            { name: "WIN", value: "win" },
-            { name: "LOSE", value: "lose" },
+            { name: "Blue", value: "blue" },
+            { name: "Red", value: "red" },
           ),
       )
       .addIntegerOption((option) =>
@@ -158,6 +167,61 @@ export function buildPersonalBucksEmbed(
   return embed;
 }
 
+type OpenBettingPool = {
+  matchId: string;
+  roster: string;
+};
+
+export type OpenGameAnchor = {
+  matchId: string;
+  subjectPuuid: LeaguePuuid;
+  subjectTeamId: RiotTeamId;
+};
+
+function parseRoster(raw: string): BucksPoolParticipant[] {
+  return BucksPoolRosterSchema.parse(JSON.parse(raw)).participants;
+}
+
+export function trackedGameLabels(
+  roster: readonly BucksPoolParticipant[],
+): string[] {
+  return roster.flatMap((participant) =>
+    participant.trackedAlias === undefined || participant.puuid === null
+      ? []
+      : [`${participant.trackedAlias} (${shortTeamName(participant.teamId)})`],
+  );
+}
+
+export function resolveOpenGameByAlias(
+  pools: readonly OpenBettingPool[],
+  requestedAlias: string,
+): OpenGameAnchor | undefined {
+  const normalizedAlias = requestedAlias.toLowerCase();
+  const matches: OpenGameAnchor[] = [];
+
+  for (const pool of pools) {
+    const subject = parseRoster(pool.roster).find(
+      (participant) =>
+        participant.puuid !== null &&
+        participant.trackedAlias?.toLowerCase() === normalizedAlias,
+    );
+    if (subject !== undefined && subject.puuid !== null) {
+      matches.push({
+        matchId: pool.matchId,
+        subjectPuuid: subject.puuid,
+        subjectTeamId: subject.teamId,
+      });
+    }
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Tracked alias ${requestedAlias} matched ${matches.length.toString()} open Bryan Bucks pools`,
+    );
+  }
+  return matches[0];
+}
+
 async function replyBalance(
   interaction: ChatInputCommandInteraction,
   serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
@@ -200,7 +264,7 @@ export function buildBbRulesEmbed(): EmbedBuilder {
       {
         name: "Placing a bet",
         value:
-          `Stake **${MIN_STAKE.toString()}-${MAX_STAKE.toString()} BB** on a tracked player to WIN or LOSE. ` +
+          `Stake **${MIN_STAKE.toString()}-${MAX_STAKE.toString()} BB** on the Blue or Red Team in a tracked player's game. ` +
           `The market stays open for ${Math.floor(BETTING_WINDOW_MS / 60_000).toString()} minutes after Scout detects the game. ` +
           "You can add to a position or cancel it before the window closes for a 20% house cut, rounded to the nearest BB; after that, it is locked.",
       },
@@ -251,17 +315,17 @@ async function replyOpen(
     const closesAtUnix = Math.floor(pool.closesAt.getTime() / 1000);
     const bluePlayers =
       pool.blue.trackedPlayers.length > 0
-        ? pool.blue.trackedPlayers.join(", ")
+        ? pool.blue.trackedPlayers.map((alias) => `\`${alias}\``).join(", ")
         : "No tracked players";
     const redPlayers =
       pool.red.trackedPlayers.length > 0
-        ? pool.red.trackedPlayers.join(", ")
+        ? pool.red.trackedPlayers.map((alias) => `\`${alias}\``).join(", ")
         : "No tracked players";
     return [
       `## ${bluePlayers} vs ${redPlayers}`,
       `Closes <t:${closesAtUnix.toString()}:R>`,
-      `🔵 **Blue:** ${pool.blue.totalStake.toString()} BB across ${pool.blue.betCount.toString()} bet(s) — ${bluePlayers}`,
-      `🔴 **Red:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — ${redPlayers}`,
+      `🔵 **Blue Team:** ${pool.blue.totalStake.toString()} BB across ${pool.blue.betCount.toString()} bet(s) — game: ${bluePlayers}`,
+      `🔴 **Red Team:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — game: ${redPlayers}`,
     ].join("\n");
   });
   const chunks = splitMessageIntoChunks(
@@ -282,8 +346,10 @@ async function replyBet(
   serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
   discordId: ReturnType<typeof DiscordAccountIdSchema.parse>,
 ): Promise<void> {
-  const requestedAlias = interaction.options.getString("player", true);
-  const betOnWin = interaction.options.getString("side", true) === "win";
+  const requestedAlias = interaction.options.getString("game", true);
+  const selectedTeamId = teamIdForChoice(
+    BucksTeamChoiceSchema.parse(interaction.options.getString("team", true)),
+  );
   const stake = interaction.options.getInteger("amount", true);
 
   // Free text rather than autocomplete: matching an alias against the open
@@ -294,41 +360,26 @@ async function replyBet(
     select: { matchId: true, roster: true },
   });
 
-  for (const pool of pools) {
-    const roster = BucksPoolRosterSchema.parse(
-      JSON.parse(pool.roster),
-    ).participants;
-    const subject = roster.find(
-      (participant) =>
-        participant.trackedAlias?.toLowerCase() ===
-        requestedAlias.toLowerCase(),
-    );
-    if (subject?.puuid == null) {
-      continue;
-    }
-
+  const game = resolveOpenGameByAlias(pools, requestedAlias);
+  if (game !== undefined) {
+    const subjectWins = subjectWinsForTeam(game.subjectTeamId, selectedTeamId);
     const result = await placeBet({
-      matchId: pool.matchId,
+      matchId: game.matchId,
       serverId,
       discordId,
-      subjectPuuid: subject.puuid,
-      subjectWins: betOnWin,
+      subjectPuuid: game.subjectPuuid,
+      subjectWins,
       stake,
     });
     await interaction.editReply({
-      content: describeResult(
-        result,
-        subject.trackedAlias ?? requestedAlias,
-        betOnWin,
-      ),
+      content: describeResult(result, selectedTeamId),
     });
     if (result.kind === "placed") {
       await announceBetPlacement({
-        matchId: pool.matchId,
+        matchId: game.matchId,
         serverId,
         discordId,
-        subjectAlias: subject.trackedAlias ?? requestedAlias,
-        subjectWins: betOnWin,
+        teamId: selectedTeamId,
         stake,
         totalStake: result.totalStake,
       });
@@ -336,13 +387,9 @@ async function replyBet(
     return;
   }
 
-  const available = pools
-    .flatMap(
-      (pool) =>
-        BucksPoolRosterSchema.parse(JSON.parse(pool.roster)).participants,
-    )
-    .map((participant) => participant.trackedAlias)
-    .filter((alias) => alias !== undefined);
+  const available = pools.flatMap((pool) =>
+    trackedGameLabels(parseRoster(pool.roster)),
+  );
 
   await interaction.editReply({
     content:


### PR DESCRIPTION
## Why

Bryan Bucks repeated the same binary game outcome once per tracked player. Teammates appeared to create separate markets, while players on opposite teams exposed redundant inverse choices.

## What

- Render one Discord row with Blue 1 BB, Blue 5 BB, Red 1 BB, Red 5 BB, and Cancel buttons.
- Keep the v1 player-relative custom ID format by translating direct team picks through one tracked, non-scrubbed game anchor.
- Change `/bb bet` to accept `game`, `team`, and `amount`; match the game alias case-insensitively against exactly one open pool.
- Show every non-scrubbed tracked alias with its Blue or Red team in `/bb open`, expose copyable game selectors, and return valid selectors for unknown aliases.
- Split large unknown-game selector lists into Discord-safe ephemeral replies without dropping aliases.
- Name Blue Team or Red Team directly in placement receipts, public announcements, and pending balance positions.
- Preserve the current 20% winning-payout and cancellation house cuts, including their command, receipt, market, and announcement disclosures.
- Keep `predictedTeamId` authoritative; no database migration, ledger, payout, settlement, house-matching, or limit changes.
- Update Bryan Bucks guidance and schema comments, with focused coverage for team layouts, anchor sides, command registration, alias matching, persistence, receipts, and announcements.

## Verification

- `bunx turbo run test typecheck lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/data` — 2,255 passed, 6 skipped, 0 failed; typecheck passed; lint passed with 0 errors and the existing duplication-warning baseline
- `bun test packages/scout-for-lol/packages/backend/src/betting/accounts.integration.test.ts packages/scout-for-lol/packages/backend/src/betting/announce.test.ts packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts packages/scout-for-lol/packages/backend/src/betting/team.test.ts packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts` — 58 passed, 0 failed
- `bunx lefthook run pre-commit` — passed
- Prettier check and `git diff --check` — passed

## Visual evidence

![Local Discord component preview showing the single Blue, Red, and Cancel row](https://public.sjer.red/pr/assets/2274/bryan-bucks-discord-preview.png)

One team-based row replaces repeated per-player WIN/LOSE rows. This is a local component preview; live Discord was not mutated.

## Not run

- Live Discord interaction and deployment verification
