### PR TITLE
feat(scout-for-lol): return Bryan Bucks cuts to the house

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -845,9 +845,11 @@ Discord's `MISSING_ACCESS`, while every other registration failure remains
 fatal during startup.
 
 The feature scope remains enforced by the flag and guild-scoped registration;
-user-facing betting surfaces should not advertise the allowlist or the private
-redemption joke. `/bb prizes` is the deliberate exception: it exposes the
-1:10 joke and its in-person-with-Bryan footer as a prize catalog.
+user-facing betting surfaces should not advertise the allowlist. `/bb prizes`
+is the deliberate exception: it displays the existing 1:10 catalog and
+in-person-with-Bryan footer as joke copy only. There is no command or accounting
+path to redeem, donate, burn, or claim Bucks, and nothing transfers to real
+goods.
 
 `/bb balance` and `/bb history` expose only the caller's wallet and positions;
 history uses caller-bound `bbnav:` component IDs and a frozen maximum ledger ID
@@ -859,14 +861,18 @@ run the cron, but only the Discord application in the one enabled guild posts;
 more than one enabled guild is a hard failure until an explicit channel mapping
 exists.
 
-Bucks exchange at 1:10 Bucks:CAD, in person only, from Bryan, who lives in rural
-Canada. There is no monetary component and nothing transfers to real goods.
-
 One-sided markets are matched by a synthetic per-guild house account with a
 bounded opening bankroll. The house is a real `BucksAccount` and `BucksBet`, so
 its seed, stake, payout, and balance are all ledger-audited; house accounts do
 not appear on the user leaderboard. If the reserve cannot cover the exposure,
 the market is voided with `house_unavailable` and user stakes are refunded.
+The house also receives two audited 20% cuts, rounded to the nearest whole Buck:
+one from each human winner's gross payout and one from a voluntarily cancelled
+position. A winning cut is capped at gross winnings so a correct bet always
+returns at least its stake; the house never charges itself. The ledger records
+the gross player credit, matching player debit, and matching house credit in one
+transaction. Remakes, expired or unsupported pools, and unavailable reserves
+remain full refunds with no cut.
 
 - **The allowlist gates taking Bucks, never returning them.** `betting_enabled`
   is checked in four places: command registration, pool creation, `placeBet`,
@@ -888,6 +894,12 @@ the market is voided with `house_unavailable` and user stakes are refunded.
   commit together. `reconcileBucksBalances` re-derives from the ledger and
   **reports** drift rather than correcting it — a mismatch is a bug in the
   chokepoint, and quietly patching it would hide that.
+- **House-cut conservation includes both destinations.** Settlement asserts
+  that net payouts plus house cuts equal all pool stakes. Cancellation asserts
+  that the returned amount plus its house cut equals the cancelled position.
+  The stored `BucksBet.payout` is net; settlement summaries retain gross
+  payout, cut, net payout, and net winnings so Discord copy never has to
+  reconstruct the arithmetic from ledger rows.
 - **One pool per `(matchId, serverId)`; a bet stores a `predictedTeamId`.**
   Every 5v5 outcome is one binary event, so with two tracked players on opposite
   teams "A wins" _is_ "B loses". The UI still says "bet LOSE on Jerred".
@@ -908,6 +920,9 @@ the market is voided with `house_unavailable` and user stakes are refunded.
   paths both announce the increment and current position in the pool's stored
   prematch message channels. The receipt is best-effort after the ledger
   transaction commits, so a Discord delivery failure never changes the bet.
+  Prematch markets, `/bb open`, placement confirmations and receipts,
+  settlement/refund messages, cancellation replies, and `/bb history` disclose
+  the house-cut policy or the exact gross-cut-net arithmetic relevant there.
 - **Settle and award outside the Discord path.** `settleAndAwardBucks` is called
   from `processMatchAndUpdatePlayers`, after the S3 ingest gate and outside
   `if (!silent)`. `processMatch` returns early with no subscribed channel and

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -730,17 +730,17 @@ model BucksLedgerEntry {
   bucksAccountId Int
   bucksAccount   BucksAccount @relation(fields: [bucksAccountId], references: [id], onDelete: Cascade)
 
-  // Signed change. Negative = stake placed. Positive = earning, payout, refund,
-  // or the one-time seed grant. Never zero.
+  // Signed change. Negative = stake or house cut paid. Positive = earning,
+  // payout, refund, house cut received, or the one-time seed grant. Never zero.
   delta Int
 
   // Balance AFTER this delta, as of the committing transaction. Makes an audit
   // read one query, and localizes any drift to a specific row.
   balanceAfter Int
 
-  // BucksLedgerKind (@scout-for-lol/data): seed | earn_game | earn_win |
+  // BucksLedgerKind (@scout-for-lol/data): seed | earn_game |
   // earn_ranked_5s_bonus | earn_clash_bonus | earn_win | earn_mvp | bet_stake |
-  // bet_payout | bet_refund | adjustment.
+  // bet_payout | bet_refund | house_rake | cancel_fee | adjustment.
   // Not a Prisma enum — the SQLite provider has none. Zod-validated on write
   // and on read.
   kind String
@@ -794,8 +794,8 @@ model BucksBet {
   // ParticipantStatus.
   betOutcome String @default("pending")
 
-  // Gross Bucks returned: stake + winnings, the full stake on a refund, or 0 on
-  // a loss. Null while pending.
+  // Net Bucks returned after the house cut: principal + net winnings, the full
+  // stake on a mandatory refund, or 0 on a loss. Null while pending.
   payout    Int?
   settledAt DateTime?
 

--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
@@ -1,7 +1,9 @@
 import {
+  BucksLedgerKindSchema,
   BucksPoolRosterSchema,
   BucksPoolStateSchema,
   RiotTeamIdSchema,
+  type BucksLedgerKind,
   type DiscordAccountId,
   type DiscordGuildId,
   type RiotTeamId,
@@ -154,7 +156,7 @@ export type LedgerPageEntry = {
   id: number;
   delta: number;
   balanceAfter: number;
-  kind: string;
+  kind: BucksLedgerKind;
   matchId: string | null;
   context: string;
   createdAt: Date;
@@ -220,7 +222,6 @@ export async function getLedgerPage(
       snapshotId: null,
     };
   }
-
   const where = {
     bucksAccountId,
     id: { lte: snapshotId },
@@ -228,7 +229,7 @@ export async function getLedgerPage(
   const totalEntries = await prismaClient.bucksLedgerEntry.count({ where });
   const totalPages = Math.ceil(totalEntries / LEDGER_PAGE_SIZE);
   const page = Math.min(input.page, Math.max(totalPages - 1, 0));
-  const entries = await prismaClient.bucksLedgerEntry.findMany({
+  const rows = await prismaClient.bucksLedgerEntry.findMany({
     where,
     orderBy: { id: "desc" },
     skip: page * LEDGER_PAGE_SIZE,
@@ -243,6 +244,10 @@ export async function getLedgerPage(
       createdAt: true,
     },
   });
+  const entries = rows.map((row) => ({
+    ...row,
+    kind: BucksLedgerKindSchema.parse(row.kind),
+  }));
 
   return {
     entries,

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
@@ -7,6 +7,8 @@ import {
   formatBetPlacementAnnouncement,
   formatSettlementBody,
   predictionVerdict,
+  sendSettlementMessages,
+  splitSettlementBody,
 } from "#src/betting/announce.ts";
 import { HOUSE_ACCOUNT_DISCORD_ID } from "#src/betting/constants.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
@@ -76,6 +78,7 @@ describe("formatSettlementBody", () => {
       voidReason: undefined,
       winnersPool: 10,
       losersPool: 10,
+      houseCut: 4,
       bets: [
         {
           betId: 1,
@@ -84,8 +87,10 @@ describe("formatSettlementBody", () => {
           isHouse: false,
           predictedTeamId: 100,
           stake: 10,
-          payout: 20,
-          winnings: 10,
+          grossPayout: 20,
+          houseCut: 4,
+          payout: 16,
+          winnings: 6,
           won: true,
           refunded: false,
           subjectPuuid: "winner-puuid",
@@ -97,6 +102,8 @@ describe("formatSettlementBody", () => {
           isHouse: false,
           predictedTeamId: 200,
           stake: 10,
+          grossPayout: 0,
+          houseCut: 0,
           payout: 0,
           winnings: 0,
           won: false,
@@ -122,8 +129,10 @@ describe("formatSettlementBody", () => {
     });
 
     expect(body).toContain(
-      `• <@${WINNER_DISCORD_ID}> staked 10 BB → received 20 BB (+10 BB winnings)`,
+      `• <@${WINNER_DISCORD_ID}> staked 10 BB → gross 20 BB − 4 BB house cut = 16 BB received (+6 BB net winnings)`,
     );
+    expect(body).toContain("Pool **20 BB** · house cut **4 BB**");
+    expect(body).toContain("house cut **4 BB**");
     expect(body).toContain(
       `• <@${LOSER_DISCORD_ID}> staked 10 BB → received 0 BB`,
     );
@@ -138,6 +147,7 @@ describe("formatSettlementBody", () => {
       voidReason: "no_counterparty",
       winnersPool: 0,
       losersPool: 0,
+      houseCut: 0,
       bets: [
         {
           betId: 1,
@@ -146,6 +156,8 @@ describe("formatSettlementBody", () => {
           isHouse: false,
           predictedTeamId: 100,
           stake: 10,
+          grossPayout: 10,
+          houseCut: 0,
           payout: 10,
           winnings: 0,
           won: false,
@@ -163,7 +175,66 @@ describe("formatSettlementBody", () => {
     });
 
     expect(body).toContain(
-      `• <@${WINNER_DISCORD_ID}> staked 10 BB → refunded 10 BB`,
+      `• <@${WINNER_DISCORD_ID}> staked 10 BB → refunded 10 BB (no house cut)`,
+    );
+    expect(body).toContain("Pool **10 BB** · house cut **0 BB**");
+  });
+});
+
+describe("formatSettlementBody house cuts", () => {
+  test("shows complete arithmetic when a small winning payout has no cut", () => {
+    const summary: SettlementSummary = {
+      matchId: "NA1_5000000042",
+      serverId: "1337623164146155593",
+      winningTeamId: 100,
+      voidReason: undefined,
+      winnersPool: 1,
+      losersPool: 1,
+      houseCut: 0,
+      bets: [
+        {
+          betId: 1,
+          bucksAccountId: 1,
+          discordId: WINNER_DISCORD_ID,
+          isHouse: false,
+          predictedTeamId: 100,
+          stake: 1,
+          grossPayout: 2,
+          houseCut: 0,
+          payout: 2,
+          winnings: 1,
+          won: true,
+          refunded: false,
+          subjectPuuid: "winner-puuid",
+        },
+        {
+          betId: 2,
+          bucksAccountId: 2,
+          discordId: LOSER_DISCORD_ID,
+          isHouse: false,
+          predictedTeamId: 200,
+          stake: 1,
+          grossPayout: 0,
+          houseCut: 0,
+          payout: 0,
+          winnings: 0,
+          won: false,
+          refunded: false,
+          subjectPuuid: "loser-puuid",
+        },
+      ],
+    };
+
+    const body = formatSettlementBody({
+      summary,
+      earnings: [],
+      predictionSentence: undefined,
+      predictionVerdictLine: undefined,
+    });
+
+    expect(body).toContain("Pool **2 BB** · house cut **0 BB**");
+    expect(body).toContain(
+      "staked 1 BB → gross 2 BB − 0 BB house cut = 2 BB received (+1 BB net winnings)",
     );
   });
 
@@ -175,6 +246,7 @@ describe("formatSettlementBody", () => {
       voidReason: undefined,
       winnersPool: 25,
       losersPool: 25,
+      houseCut: 10,
       bets: [
         {
           betId: 1,
@@ -183,8 +255,10 @@ describe("formatSettlementBody", () => {
           isHouse: false,
           predictedTeamId: 100,
           stake: 25,
-          payout: 50,
-          winnings: 25,
+          grossPayout: 50,
+          houseCut: 10,
+          payout: 40,
+          winnings: 15,
           won: true,
           refunded: false,
           subjectPuuid: "winner-puuid",
@@ -196,6 +270,8 @@ describe("formatSettlementBody", () => {
           isHouse: true,
           predictedTeamId: 200,
           stake: 25,
+          grossPayout: 0,
+          houseCut: 0,
           payout: 0,
           winnings: 0,
           won: false,
@@ -218,6 +294,138 @@ describe("formatSettlementBody", () => {
     expect(body).not.toContain(`<@${HOUSE_ACCOUNT_DISCORD_ID}>`);
     expect(body).toContain(`• <@${WINNER_DISCORD_ID}> staked 25 BB`);
   });
+
+  test("splits a full settlement without dropping payout arithmetic", () => {
+    const summary: SettlementSummary = {
+      matchId: "NA1_5000000042",
+      serverId: "1337623164146155593",
+      winningTeamId: 100,
+      voidReason: undefined,
+      winnersPool: 75,
+      losersPool: 75,
+      houseCut: 30,
+      bets: Array.from({ length: 15 }, (_, index) => ({
+        betId: index + 1,
+        bucksAccountId: index + 1,
+        discordId: bucksTestDiscordId(index + 1),
+        isHouse: false,
+        predictedTeamId: 100,
+        stake: 5,
+        grossPayout: 10,
+        houseCut: 2,
+        payout: 8,
+        winnings: 3,
+        won: true,
+        refunded: false,
+        subjectPuuid: `winner-puuid-${index.toString()}`,
+      })),
+    };
+    const body = formatSettlementBody({
+      summary,
+      earnings: [
+        {
+          serverId: summary.serverId,
+          discordId: WINNER_DISCORD_ID,
+          alias: "Aaron",
+          reasons: ["played", "ranked 5s bonus", "win", "mvp"],
+          total: 13,
+        },
+        {
+          serverId: summary.serverId,
+          discordId: bucksTestDiscordId(2),
+          alias: "Bryan",
+          reasons: ["played", "win"],
+          total: 7,
+        },
+        {
+          serverId: summary.serverId,
+          discordId: bucksTestDiscordId(3),
+          alias: "Chris",
+          reasons: ["played", "clash bonus", "win"],
+          total: 12,
+        },
+        {
+          serverId: summary.serverId,
+          discordId: bucksTestDiscordId(4),
+          alias: "Diana",
+          reasons: ["played", "win", "mvp"],
+          total: 9,
+        },
+      ],
+      predictionSentence:
+        "Scout gave this roster a decisive edge before the match started.",
+      predictionVerdictLine: "Scout called it.",
+    });
+
+    expect(body.length).toBeGreaterThan(1900);
+    const chunks = splitSettlementBody(body);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(1900);
+    }
+    const delivered = chunks.join("\n");
+    expect(delivered).toContain("Pool **75 BB** · house cut **30 BB**");
+    expect(delivered).toContain(
+      "gross 10 BB − 2 BB house cut = 8 BB received (+3 BB net winnings)",
+    );
+    expect(delivered).toContain("🪙 **Aaron** +13 BB");
+  });
+});
+
+describe("sendSettlementMessages", () => {
+  test("retries a failed chunk and still attempts every later chunk", async () => {
+    const attempts: {
+      content: string | undefined;
+      nonce: string | number | undefined;
+      enforceNonce: boolean | undefined;
+    }[] = [];
+    let sleeps = 0;
+
+    await expect(
+      sendSettlementMessages(
+        {
+          messages: ["first", "failed", "last"],
+          matchId: "NA1_5000000042",
+          channelId: "1337623164146155594",
+          guildId: "1337623164146155593",
+        },
+        {
+          sendMessage: (options) => {
+            attempts.push({
+              content: options.content,
+              nonce: options.nonce,
+              enforceNonce: options.enforceNonce,
+            });
+            return options.content === "failed"
+              ? Promise.reject(new Error("Discord delivery failed"))
+              : Promise.resolve(undefined);
+          },
+          sleep: () => {
+            sleeps += 1;
+            return Promise.resolve();
+          },
+        },
+      ),
+    ).rejects.toThrow("failed to deliver 1/3 chunk(s)");
+
+    expect(attempts.map((attempt) => attempt.content)).toEqual([
+      "first",
+      "failed",
+      "failed",
+      "failed",
+      "last",
+    ]);
+    expect(sleeps).toBe(2);
+    const failedAttempts = attempts.filter(
+      (attempt) => attempt.content === "failed",
+    );
+    expect(new Set(failedAttempts.map((attempt) => attempt.nonce)).size).toBe(
+      1,
+    );
+    expect(
+      failedAttempts.every((attempt) => attempt.enforceNonce === true),
+    ).toBe(true);
+  });
 });
 
 describe("formatBetPlacementAnnouncement", () => {
@@ -231,7 +439,7 @@ describe("formatBetPlacementAnnouncement", () => {
         totalStake: 10,
       }),
     ).toBe(
-      `🎲 <@${WINNER_DISCORD_ID}> staked **5 BB** on **Aaron WINS** (position: **10 BB**).`,
+      `🎲 <@${WINNER_DISCORD_ID}> staked **5 BB** on **Aaron WINS** (position: **10 BB**). **20% house cut on winning payouts**.`,
     );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -1,21 +1,32 @@
 import * as Sentry from "@sentry/bun";
+import type { MessageCreateOptions } from "discord.js";
 import {
   BucksMessageRefsSchema,
   BucksPredictionSchema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   type BucksPrediction,
+  type DiscordChannelId,
+  type DiscordGuildId,
 } from "@scout-for-lol/data";
 import type { EarnedAward } from "#src/betting/earnings.ts";
+import { HOUSE_CUT_PLACEMENT_NOTE } from "#src/betting/house-cut.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
 import type { ClosedPool } from "#src/betting/sweep.ts";
 import { shouldDisplayPrediction } from "#src/betting/prediction.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
-import { send } from "#src/league/discord/channel.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
+import {
+  ChannelSendError,
+  send as sendChannelMessage,
+} from "#src/league/discord/channel.ts";
 import { createLogger } from "#src/logger.ts";
+import { getErrorMessage } from "#src/utils/errors.ts";
 
 const logger = createLogger("betting-announce");
+const MAX_SETTLEMENT_CHUNK_SEND_ATTEMPTS = 3;
+const SETTLEMENT_CHUNK_RETRY_BASE_DELAY_MS = 500;
 
 /**
  * Telling the channel what happened.
@@ -76,7 +87,7 @@ export function formatBetPlacementAnnouncement(input: {
   totalStake: number;
 }): string {
   const side = input.subjectWins ? "WINS" : "LOSES";
-  return `🎲 <@${input.discordId}> staked **${input.stake.toString()} BB** on **${input.subjectAlias} ${side}** (position: **${input.totalStake.toString()} BB**).`;
+  return `🎲 <@${input.discordId}> staked **${input.stake.toString()} BB** on **${input.subjectAlias} ${side}** (position: **${input.totalStake.toString()} BB**). ${HOUSE_CUT_PLACEMENT_NOTE}`;
 }
 
 /**
@@ -115,7 +126,7 @@ export async function announceBetPlacement(
     const content = formatBetPlacementAnnouncement(input);
     for (const ref of refs) {
       try {
-        await send(
+        await sendChannelMessage(
           {
             content,
             allowedMentions: { users: [input.discordId] },
@@ -150,10 +161,11 @@ export function formatSettlementBody(input: {
 }): string {
   const { summary } = input;
   const lines: string[] = [];
+  const pool = summary.bets.reduce((total, bet) => total + bet.stake, 0);
 
   if (summary.voidReason === undefined) {
     lines.push(
-      `💰 **Bryan Bucks** — pool ${(summary.winnersPool + summary.losersPool).toString()} BB (winners ${summary.winnersPool.toString()} / losers ${summary.losersPool.toString()})`,
+      `💰 **Bryan Bucks** — Pool **${pool.toString()} BB** · house cut **${summary.houseCut.toString()} BB** (winners ${summary.winnersPool.toString()} / losers ${summary.losersPool.toString()})`,
     );
   } else {
     const reason =
@@ -166,7 +178,9 @@ export function formatSettlementBody(input: {
             : summary.voidReason === "expired"
               ? "This game never resolved — every bet refunded."
               : "Unsupported game mode — every bet refunded.";
-    lines.push(`💰 **Bryan Bucks** — ${reason}`);
+    lines.push(
+      `💰 **Bryan Bucks** — Pool **${pool.toString()} BB** · house cut **0 BB**. ${reason}`,
+    );
   }
 
   if (input.predictionSentence !== undefined) {
@@ -195,11 +209,10 @@ export function formatSettlementBody(input: {
     lines.push("**Bets**");
     for (const bet of humanBets.slice(0, MAX_BET_ROWS)) {
       const result = bet.refunded
-        ? `refunded ${bet.payout.toString()} BB`
-        : `received ${bet.payout.toString()} BB` +
-          (bet.winnings > 0
-            ? ` (+${bet.winnings.toString()} BB winnings)`
-            : "");
+        ? `refunded ${bet.payout.toString()} BB (no house cut)`
+        : bet.won
+          ? `gross ${bet.grossPayout.toString()} BB − ${bet.houseCut.toString()} BB house cut = ${bet.payout.toString()} BB received (+${bet.winnings.toString()} BB net winnings)`
+          : "received 0 BB";
       lines.push(
         `• <@${bet.discordId}> staked ${bet.stake.toString()} BB → ${result}`,
       );
@@ -224,6 +237,122 @@ export function formatSettlementBody(input: {
   }
 
   return lines.join("\n");
+}
+
+/** Split a complete settlement without dropping any gross-cut-net detail. */
+export function splitSettlementBody(body: string): string[] {
+  const chunks = splitMessageIntoChunks(body);
+  if (chunks.length === 0) {
+    throw new Error("A Bryan Bucks settlement produced no Discord content");
+  }
+  return chunks;
+}
+
+export type SettlementDeliveryDependencies = {
+  sendMessage: (
+    options: MessageCreateOptions,
+    channelId: DiscordChannelId,
+    guildId: DiscordGuildId,
+  ) => Promise<unknown>;
+  sleep: (milliseconds: number) => Promise<void>;
+};
+
+const defaultSettlementDeliveryDependencies: SettlementDeliveryDependencies = {
+  sendMessage: async (options, channelId, guildId) =>
+    await sendChannelMessage(options, channelId, guildId),
+  sleep: async (milliseconds) => {
+    await Bun.sleep(milliseconds);
+  },
+};
+
+function settlementChunkNonce(
+  matchId: string,
+  channelId: DiscordChannelId,
+  chunkIndex: number,
+): string {
+  const deliveryKey = `${matchId}:${channelId}:${chunkIndex.toString()}`;
+  return `bbs:${Bun.hash(deliveryKey).toString(36)}`;
+}
+
+async function sendSettlementChunk(
+  dependencies: SettlementDeliveryDependencies,
+  input: {
+    options: MessageCreateOptions;
+    channelId: DiscordChannelId;
+    guildId: DiscordGuildId;
+    chunkIndex: number;
+  },
+): Promise<void> {
+  for (
+    let attempt = 1;
+    attempt <= MAX_SETTLEMENT_CHUNK_SEND_ATTEMPTS;
+    attempt++
+  ) {
+    try {
+      await dependencies.sendMessage(
+        input.options,
+        input.channelId,
+        input.guildId,
+      );
+      return;
+    } catch (error) {
+      const deterministicFailure =
+        error instanceof ChannelSendError && error.permissionError;
+      if (
+        attempt === MAX_SETTLEMENT_CHUNK_SEND_ATTEMPTS ||
+        deterministicFailure
+      ) {
+        throw error;
+      }
+      const delayMs = SETTLEMENT_CHUNK_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      logger.warn(
+        `🎲 Bryan Bucks settlement chunk ${(input.chunkIndex + 1).toString()} attempt ${attempt.toString()}/${MAX_SETTLEMENT_CHUNK_SEND_ATTEMPTS.toString()} failed; retrying in ${delayMs.toString()}ms: ${getErrorMessage(error)}`,
+      );
+      await dependencies.sleep(delayMs);
+    }
+  }
+}
+
+export async function sendSettlementMessages(
+  input: {
+    messages: readonly string[];
+    matchId: string;
+    channelId: string;
+    guildId: string;
+  },
+  dependencies: SettlementDeliveryDependencies = defaultSettlementDeliveryDependencies,
+): Promise<void> {
+  const channelId = DiscordChannelIdSchema.parse(input.channelId);
+  const guildId = DiscordGuildIdSchema.parse(input.guildId);
+  const failures: unknown[] = [];
+  for (const [chunkIndex, content] of input.messages.entries()) {
+    try {
+      await sendSettlementChunk(dependencies, {
+        options: {
+          content,
+          // Stable nonces make a transient retry idempotent at Discord.
+          nonce: settlementChunkNonce(input.matchId, channelId, chunkIndex),
+          enforceNonce: true,
+          // A fifteen-person settlement must not ping fifteen people.
+          allowedMentions: { parse: [] },
+        },
+        channelId,
+        guildId,
+        chunkIndex,
+      });
+    } catch (error) {
+      failures.push(error);
+      logger.error(
+        `🎲 Bryan Bucks settlement chunk ${(chunkIndex + 1).toString()}/${input.messages.length.toString()} failed after retries: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Bryan Bucks settlement failed to deliver ${failures.length.toString()}/${input.messages.length.toString()} chunk(s)`,
+    );
+  }
 }
 
 /**
@@ -275,6 +404,7 @@ export async function announceSettlements(
           summary.winningTeamId,
         ),
       });
+      const messages = splitSettlementBody(body);
 
       const refs = BucksMessageRefsSchema.parse(JSON.parse(pool.messageRefs));
       if (refs.length === 0) {
@@ -308,23 +438,18 @@ export async function announceSettlements(
         }
         continue;
       }
-      const guildId = DiscordGuildIdSchema.parse(summary.serverId);
-
       for (const ref of refs) {
         // Isolated per channel. The pool has already committed as settled and a
         // later pass returns no summary, so this delivery is one-shot: letting
         // a stale or no-longer-writable first ref throw would silently discard
         // the settlement for every healthy channel behind it.
         try {
-          await send(
-            {
-              content: body,
-              // A fifteen-person settlement must not ping fifteen people.
-              allowedMentions: { parse: [] },
-            },
-            DiscordChannelIdSchema.parse(ref.channelId),
-            guildId,
-          );
+          await sendSettlementMessages({
+            messages,
+            matchId: summary.matchId,
+            channelId: ref.channelId,
+            guildId: summary.serverId,
+          });
         } catch (error) {
           logger.error(
             `❌ Could not deliver the Bryan Bucks settlement for ${summary.matchId} to channel ${ref.channelId}:`,

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
@@ -11,7 +11,11 @@ import {
 } from "#src/betting/bet-button.ts";
 import { formatBucksCustomId } from "#src/betting/custom-id.ts";
 import { buildBettingRows } from "#src/betting/components.ts";
-import { SEED_GRANT } from "#src/betting/constants.ts";
+import {
+  HOUSE_ACCOUNT_DISCORD_ID,
+  HOUSE_BANKROLL,
+  SEED_GRANT,
+} from "#src/betting/constants.ts";
 
 const { prisma: db } = createTestDatabase("bucks-bet-button");
 
@@ -96,6 +100,11 @@ describe("handleBetButton", () => {
 
     expect(replies[0]).toContain("Bet placed");
     expect(replies[0]).toContain("jerred WINS");
+    expect(replies[0]).toContain("winning payouts, rounded to the nearest BB");
+    expect(replies[0]).toContain("Winning principal is protected");
+    expect(replies[0]).toContain(
+      "Cancelling costs **20%**, also rounded to the nearest BB",
+    );
     expect(await db.bucksBet.count()).toBe(1);
 
     const account = await db.bucksAccount.findFirstOrThrow();
@@ -126,10 +135,27 @@ describe("handleBetButton", () => {
     await handleBetButton(interaction, db);
 
     expect(replies[0]).toContain("Bet cancelled");
+    expect(replies[0]).toContain(
+      "stake **5 BB** − **1 BB house cut** = **4 BB returned**",
+    );
     expect(await db.bucksBet.count()).toBe(0);
 
-    const account = await db.bucksAccount.findFirstOrThrow();
-    expect(account.balance).toBe(SEED_GRANT);
+    const account = await db.bucksAccount.findUniqueOrThrow({
+      where: {
+        serverId_discordId: { serverId: SERVER_ID, discordId: BETTOR },
+      },
+    });
+    expect(account.balance).toBe(SEED_GRANT - 1);
+
+    const house = await db.bucksAccount.findUniqueOrThrow({
+      where: {
+        serverId_discordId: {
+          serverId: SERVER_ID,
+          discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        },
+      },
+    });
+    expect(house.balance).toBe(HOUSE_BANKROLL + 1);
   });
 
   test("cancelling frees the slot so the other side can be backed", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -6,6 +6,7 @@ import {
 } from "@scout-for-lol/data";
 import type { InteractionEditReplyOptions } from "discord.js";
 import { parseBucksCustomId } from "#src/betting/custom-id.ts";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { placeBet, type PlaceBetResult } from "#src/betting/place-bet.ts";
 import { cancelBet, type CancelBetResult } from "#src/betting/cancel-bet.ts";
 import { announceBetPlacement } from "#src/betting/announce.ts";
@@ -45,7 +46,7 @@ export function describeResult(
   switch (result.kind) {
     case "placed": {
       const side = betOnWin ? "WINS" : "LOSES";
-      return `✅ Bet placed: **${subjectAlias} ${side}** for **${result.totalStake.toString()} BB** total. Balance: **${result.balanceAfter.toString()} BB**.`;
+      return `✅ Bet placed: **${subjectAlias} ${side}** for **${result.totalStake.toString()} BB** total. Balance: **${result.balanceAfter.toString()} BB**. ${HOUSE_CUT_TERMS}`;
     }
     case "window_closed":
       return "⏰ Betting has closed for this game.";
@@ -74,7 +75,7 @@ export function describeResult(
 export function describeCancel(result: CancelBetResult): string {
   switch (result.kind) {
     case "cancelled":
-      return `↩️ Bet cancelled. **${result.refunded.toString()} BB** returned; balance **${result.balanceAfter.toString()} BB**.`;
+      return `↩️ Bet cancelled: stake **${result.stake.toString()} BB** − **${result.houseCut.toString()} BB house cut** = **${result.refunded.toString()} BB returned**; balance **${result.balanceAfter.toString()} BB**.`;
     case "window_closed":
       return "⏰ Betting has closed for this game, so positions are locked in. Yours settles when the game ends.";
     case "already_resolved":

--- a/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
@@ -3,6 +3,11 @@ import {
   type DiscordAccountId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
+import {
+  HOUSE_CUT_PERCENT,
+  cancellationHouseCut,
+} from "#src/betting/house-cut.ts";
+import { transferHouseCut } from "#src/betting/house.ts";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { findBucksAccountId } from "#src/betting/accounts.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -20,7 +25,13 @@ const logger = createLogger("betting-cancel-bet");
  * money on the game that their stake was never recorded.
  */
 export type CancelBetResult =
-  | { kind: "cancelled"; refunded: number; balanceAfter: number }
+  | {
+      kind: "cancelled";
+      stake: number;
+      refunded: number;
+      houseCut: number;
+      balanceAfter: number;
+    }
   | { kind: "no_pool" }
   | { kind: "no_bet" }
   | { kind: "window_closed" }
@@ -29,10 +40,11 @@ export type CancelBetResult =
 /**
  * Withdraw a position while the window is still open.
  *
- * The whole stake comes back and the bet row is **deleted** rather than marked.
- * Two reasons: a parimutuel payout computed against a "cancelled but present"
- * bet would be wrong, and the `@@unique([poolId, bucksAccountId])` slot has to
- * be freed so the bettor can take a fresh position — including the other side,
+ * The gross stake is credited, the cancellation cut is transferred to the
+ * house, and the bet row is **deleted** rather than marked. Two reasons for the
+ * delete: a parimutuel payout computed against a "cancelled but present" bet
+ * would be wrong, and the `@@unique([poolId, bucksAccountId])` slot has to be
+ * freed so the bettor can take a fresh position — including the other side,
  * which is the usual reason for cancelling.
  *
  * Cost of the delete, accepted deliberately: `BucksLedgerEntry.betId` is
@@ -134,8 +146,18 @@ export async function cancelBet(
         .map((participant) => participant.trackedAlias)
         .filter((alias) => alias !== undefined);
 
-    // The ledger row references the bet, so credit before deleting it.
-    const balanceAfter = await applyBucksDelta(tx, {
+    const houseCut = cancellationHouseCut(bet.stake);
+    const refunded = bet.stake - houseCut;
+    if (refunded + houseCut !== bet.stake) {
+      throw new Error(
+        `Cancellation for ${input.matchId} did not conserve Bucks: stake ${bet.stake.toString()}, refund ${refunded.toString()}, house cut ${houseCut.toString()}`,
+      );
+    }
+
+    // The ledger rows reference the bet, so credit and transfer before deleting
+    // it. The gross refund followed by a separate cut keeps both movements
+    // visible in the user's history.
+    const refundBalance = await applyBucksDelta(tx, {
       bucksAccountId,
       delta: bet.stake,
       kind: "bet_refund",
@@ -150,15 +172,43 @@ export async function cancelBet(
         losersPool: 0,
         stakeReturned: bet.stake,
         winnings: 0,
+        grossPayout: bet.stake,
+        houseCut,
+        netPayout: refunded,
       },
     });
+
+    const balanceAfter =
+      houseCut === 0
+        ? refundBalance
+        : await transferHouseCut(tx, {
+            serverId: input.serverId,
+            bucksAccountId,
+            amount: houseCut,
+            kind: "cancel_fee",
+            matchId: input.matchId,
+            betId: bet.id,
+            context: {
+              type: "house_fee",
+              source: "cancellation",
+              ratePercent: HOUSE_CUT_PERCENT,
+              grossAmount: bet.stake,
+              fee: houseCut,
+            },
+          });
 
     await tx.bucksBet.delete({ where: { id: bet.id } });
 
     logger.info(
-      `↩️ Cancelled a Bryan Bucks bet on ${input.matchId}, refunding ${bet.stake.toString()} BB`,
+      `↩️ Cancelled a Bryan Bucks bet on ${input.matchId}, refunding ${refunded.toString()} BB after a ${houseCut.toString()} BB house cut`,
     );
 
-    return { kind: "cancelled", refunded: bet.stake, balanceAfter };
+    return {
+      kind: "cancelled",
+      stake: bet.stake,
+      refunded,
+      houseCut,
+      balanceAfter,
+    };
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/house-cut.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/house-cut.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  cancellationHouseCut,
+  settlementHouseCut,
+} from "#src/betting/house-cut.ts";
+
+describe("settlementHouseCut", () => {
+  test("takes twenty percent of a normal gross payout", () => {
+    expect(
+      settlementHouseCut({
+        grossPayout: 10,
+        grossWinnings: 5,
+        isHouse: false,
+      }),
+    ).toBe(2);
+  });
+
+  test("protects principal in a lopsided pool", () => {
+    expect(
+      settlementHouseCut({
+        grossPayout: 101,
+        grossWinnings: 1,
+        isHouse: false,
+      }),
+    ).toBe(1);
+  });
+
+  test("rounds to the nearest whole Buck", () => {
+    expect(
+      settlementHouseCut({
+        grossPayout: 2,
+        grossWinnings: 1,
+        isHouse: false,
+      }),
+    ).toBe(0);
+    expect(
+      settlementHouseCut({
+        grossPayout: 3,
+        grossWinnings: 2,
+        isHouse: false,
+      }),
+    ).toBe(1);
+  });
+
+  test("never charges the house itself", () => {
+    expect(
+      settlementHouseCut({
+        grossPayout: 100,
+        grossWinnings: 50,
+        isHouse: true,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("cancellationHouseCut", () => {
+  test("charges the rounded rate against the complete position", () => {
+    expect(cancellationHouseCut(1)).toBe(0);
+    expect(cancellationHouseCut(2)).toBe(0);
+    expect(cancellationHouseCut(3)).toBe(1);
+    expect(cancellationHouseCut(5)).toBe(1);
+    expect(cancellationHouseCut(10)).toBe(2);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/house-cut.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/house-cut.ts
@@ -1,0 +1,40 @@
+/**
+ * The Bryan Bucks house cut.
+ *
+ * Bucks are integer-only, so every fee is rounded to the nearest whole Buck.
+ * Twenty percent is one fifth; adding two before integer division implements
+ * nearest-integer rounding for every non-negative amount without floating
+ * point arithmetic.
+ */
+
+export const HOUSE_CUT_PERCENT = 20;
+
+export const HOUSE_CUT_TERMS =
+  "🏦 House cut: **20%** of winning payouts, rounded to the nearest BB. Winning principal is protected. Cancelling costs **20%**, also rounded to the nearest BB.";
+
+export const HOUSE_CUT_PLACEMENT_NOTE = "**20% house cut on winning payouts**.";
+
+function roundedHouseCut(amount: number): number {
+  return Math.floor((amount + 2) / 5);
+}
+
+/**
+ * Charge a human winner against the gross payout, but never take any of the
+ * stake they put up. The cap makes a correct result worth at least principal
+ * even in a very lopsided parimutuel pool.
+ */
+export function settlementHouseCut(input: {
+  grossPayout: number;
+  grossWinnings: number;
+  isHouse: boolean;
+}): number {
+  if (input.isHouse) {
+    return 0;
+  }
+  return Math.min(roundedHouseCut(input.grossPayout), input.grossWinnings);
+}
+
+/** A voluntary cancellation returns the stake less the rounded house cut. */
+export function cancellationHouseCut(stake: number): number {
+  return roundedHouseCut(stake);
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/house.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/house.ts
@@ -1,0 +1,99 @@
+import {
+  type BucksLedgerContext,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import {
+  HOUSE_ACCOUNT_DISCORD_ID,
+  HOUSE_BANKROLL,
+} from "#src/betting/constants.ts";
+import { applyBucksDelta } from "#src/betting/ledger.ts";
+import type { Db } from "#src/lib/audit/index.ts";
+
+/** Fetch or create the audited synthetic account used by one guild's house. */
+export async function ensureHouseAccountInTransaction(
+  tx: Db,
+  serverId: DiscordGuildId,
+): Promise<{ id: number; balance: number }> {
+  const existing = await tx.bucksAccount.findUnique({
+    where: {
+      serverId_discordId: {
+        serverId,
+        discordId: HOUSE_ACCOUNT_DISCORD_ID,
+      },
+    },
+    select: { id: true, balance: true, isHouse: true },
+  });
+  if (existing !== null) {
+    if (!existing.isHouse) {
+      throw new Error(
+        `Bucks account ${existing.id.toString()} uses the reserved house account ID`,
+      );
+    }
+    return existing;
+  }
+
+  const created = await tx.bucksAccount.create({
+    data: {
+      serverId,
+      discordId: HOUSE_ACCOUNT_DISCORD_ID,
+      isHouse: true,
+      balance: 0,
+    },
+    select: { id: true },
+  });
+  const balance = await applyBucksDelta(tx, {
+    bucksAccountId: created.id,
+    delta: HOUSE_BANKROLL,
+    kind: "seed",
+    context: {
+      type: "seed",
+      note: "Opening bankroll for the Bryan Bucks house account",
+    },
+  });
+  return { id: created.id, balance };
+}
+
+/**
+ * Transfer an already-funded fee from a human wallet to the house.
+ *
+ * Callers first credit the gross payout or refund. Keeping the debit and
+ * matching credit as separate ledger rows makes the cut visible from both
+ * accounts while the caller's transaction keeps the transfer all-or-nothing.
+ *
+ * @returns the human account balance after the fee
+ */
+export async function transferHouseCut(
+  tx: Db,
+  input: {
+    serverId: DiscordGuildId;
+    bucksAccountId: number;
+    amount: number;
+    kind: "house_rake" | "cancel_fee";
+    context: BucksLedgerContext;
+    matchId: string;
+    betId: number;
+  },
+): Promise<number> {
+  if (input.amount <= 0) {
+    throw new Error("A house-cut transfer must move at least one Buck");
+  }
+
+  const house = await ensureHouseAccountInTransaction(tx, input.serverId);
+  const balanceAfter = await applyBucksDelta(tx, {
+    bucksAccountId: input.bucksAccountId,
+    delta: -input.amount,
+    kind: input.kind,
+    context: input.context,
+    matchId: input.matchId,
+    betId: input.betId,
+  });
+  await applyBucksDelta(tx, {
+    bucksAccountId: house.id,
+    delta: input.amount,
+    kind: input.kind,
+    context: input.context,
+    matchId: input.matchId,
+    betId: input.betId,
+  });
+  return balanceAfter;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -2,15 +2,36 @@ import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
+  type BucksLedgerKind,
 } from "@scout-for-lol/data";
 import { z } from "zod";
 import { getLedgerPage, type LedgerPage } from "#src/betting/accounts.ts";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { BucksButtonEditReplyOptions } from "#src/betting/bet-button.ts";
 
 export const BUCKS_NAVIGATION_NAMESPACE = "bbnav";
 export const BUCKS_NAVIGATION_VERSION = "1";
+
+const LEDGER_KIND_LABELS = {
+  seed: "welcome grant",
+  earn_game: "game played",
+  earn_ranked_5s_bonus: "Ranked 5s bonus",
+  earn_clash_bonus: "Clash bonus",
+  earn_win: "game won",
+  earn_mvp: "game MVP",
+  bet_stake: "bet stake",
+  bet_payout: "gross bet payout",
+  bet_refund: "bet refund",
+  house_rake: "house cut on payout",
+  cancel_fee: "house cut on cancellation",
+  adjustment: "adjustment",
+} satisfies Record<BucksLedgerKind, string>;
+
+export function ledgerKindLabel(kind: BucksLedgerKind): string {
+  return LEDGER_KIND_LABELS[kind];
+}
 
 const BucksNavigationIdSchema = z.strictObject({
   action: z.literal("h"),
@@ -113,18 +134,23 @@ export function renderBucksHistory(
   page: LedgerPage,
 ): BucksButtonEditReplyOptions {
   if (page.entries.length === 0) {
-    return { content: "No Bryan Bucks history yet.", components: [] };
+    return {
+      content: `No Bryan Bucks history yet.\n\n${HOUSE_CUT_TERMS}`,
+      components: [],
+    };
   }
 
   const lines = page.entries.map((entry) => {
     const sign = entry.delta > 0 ? "+" : "";
     const where = entry.matchId === null ? "" : ` · ${entry.matchId}`;
-    return `\`${sign}${entry.delta.toString()}\` ${entry.kind}${where} → ${entry.balanceAfter.toString()} BB`;
+    return `\`${sign}${entry.delta.toString()}\` ${ledgerKindLabel(entry.kind)}${where} → ${entry.balanceAfter.toString()} BB`;
   });
   return {
     content: [
       `**Bryan Bucks history** · Page ${(page.page + 1).toString()}/${page.totalPages.toString()}`,
       ...lines,
+      "",
+      HOUSE_CUT_TERMS,
     ].join("\n"),
     components: navigationRow(ownerId, page),
   };

--- a/packages/scout-for-lol/packages/backend/src/betting/parimutuel.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parimutuel.ts
@@ -1,12 +1,13 @@
 /**
  * Parimutuel payout allocation.
  *
- * Pure, integer-only, and closed: every Buck staked into a pool comes back out
- * of it. Human two-sided pools remain purely parimutuel; one-sided pools are
- * supplied a synthetic house position by settlement before reaching this
- * function. The sum of payouts always equals the sum of stakes. That identity
- * is asserted rather than assumed — a violation throws, and the caller runs
- * this inside a transaction so the throw rolls the settlement back instead of
+ * Pure, integer-only, and closed: it calculates gross payouts, so every Buck
+ * staked into a pool comes back out of this allocator. Human two-sided pools
+ * remain purely parimutuel; one-sided pools are supplied a synthetic house
+ * position by settlement before reaching this function. Settlement then
+ * transfers the configured cut from each human winner's gross allocation to
+ * the house. The gross identity here, and the net-plus-cuts identity there,
+ * are both asserted so a violation rolls the transaction back instead of
  * minting or destroying currency.
  */
 

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.integration.test.ts
@@ -17,7 +17,13 @@ import {
 import { createTestDatabase } from "#src/testing/test-database.ts";
 import { placeBet, type PlaceBetInput } from "#src/betting/place-bet.ts";
 import { cancelBet } from "#src/betting/cancel-bet.ts";
-import { MAX_STAKE, SEED_GRANT } from "#src/betting/constants.ts";
+import {
+  HOUSE_ACCOUNT_DISCORD_ID,
+  HOUSE_BANKROLL,
+  MAX_STAKE,
+  SEED_GRANT,
+} from "#src/betting/constants.ts";
+import { reconcileBucksBalances } from "#src/betting/reconcile.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
@@ -177,6 +183,115 @@ describe("placeBet — accepting a position", () => {
   });
 });
 
+describe("cancelBet — returning a position", () => {
+  test("returns a 5 BB stake less a paired 1 BB house cut", async () => {
+    await bet({ stake: 5 });
+
+    const result = await cancelBet(
+      { matchId: MATCH_ID, serverId: SERVER_ID, discordId: BETTOR },
+      db,
+    );
+    expect(result).toEqual({
+      kind: "cancelled",
+      stake: 5,
+      refunded: 4,
+      houseCut: 1,
+      balanceAfter: SEED_GRANT - 1,
+    });
+
+    const human = await db.bucksAccount.findUniqueOrThrow({
+      where: {
+        serverId_discordId: { serverId: SERVER_ID, discordId: BETTOR },
+      },
+    });
+    expect(
+      await db.bucksLedgerEntry.findMany({
+        where: { bucksAccountId: human.id },
+        orderBy: { id: "asc" },
+        select: { kind: true, delta: true, balanceAfter: true },
+      }),
+    ).toEqual([
+      { kind: "seed", delta: SEED_GRANT, balanceAfter: SEED_GRANT },
+      {
+        kind: "bet_stake",
+        delta: -5,
+        balanceAfter: SEED_GRANT - 5,
+      },
+      { kind: "bet_refund", delta: 5, balanceAfter: SEED_GRANT },
+      {
+        kind: "cancel_fee",
+        delta: -1,
+        balanceAfter: SEED_GRANT - 1,
+      },
+    ]);
+
+    const house = await db.bucksAccount.findUniqueOrThrow({
+      where: {
+        serverId_discordId: {
+          serverId: SERVER_ID,
+          discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        },
+      },
+    });
+    expect(house.balance).toBe(HOUSE_BANKROLL + 1);
+    expect(
+      await db.bucksLedgerEntry.findMany({
+        where: { bucksAccountId: house.id },
+        orderBy: { id: "asc" },
+        select: { kind: true, delta: true },
+      }),
+    ).toEqual([
+      { kind: "seed", delta: HOUSE_BANKROLL },
+      { kind: "cancel_fee", delta: 1 },
+    ]);
+    const pairedCut = await db.bucksLedgerEntry.findMany({
+      where: { kind: "cancel_fee" },
+      orderBy: { id: "asc" },
+      select: { bucksAccountId: true, delta: true, context: true },
+    });
+    expect(pairedCut).toHaveLength(2);
+    expect(pairedCut[0]).toMatchObject({
+      bucksAccountId: human.id,
+      delta: -1,
+    });
+    expect(pairedCut[1]).toMatchObject({ bucksAccountId: house.id, delta: 1 });
+    expect(pairedCut[0]?.context).toBe(pairedCut[1]?.context);
+    const cutContext: unknown = JSON.parse(pairedCut[0]?.context ?? "null");
+    expect(cutContext).toEqual({
+      type: "house_fee",
+      source: "cancellation",
+      ratePercent: 20,
+      grossAmount: 5,
+      fee: 1,
+    });
+    expect(await reconcileBucksBalances(db)).toEqual([]);
+  });
+
+  test("returns a 1 BB stake in full when rounding produces no cut", async () => {
+    await bet({ stake: 1 });
+
+    const result = await cancelBet(
+      { matchId: MATCH_ID, serverId: SERVER_ID, discordId: BETTOR },
+      db,
+    );
+    expect(result).toEqual({
+      kind: "cancelled",
+      stake: 1,
+      refunded: 1,
+      houseCut: 0,
+      balanceAfter: SEED_GRANT,
+    });
+    expect(
+      await db.bucksLedgerEntry.count({ where: { kind: "cancel_fee" } }),
+    ).toBe(0);
+    expect(
+      await db.bucksAccount.count({
+        where: { discordId: HOUSE_ACCOUNT_DISCORD_ID },
+      }),
+    ).toBe(0);
+  });
+});
+
 describe("placeBet — refusing a position", () => {
   test("refuses the opposing side and leaves the balance untouched", async () => {
     await bet({ stake: 5 });
@@ -206,6 +321,8 @@ describe("placeBet — refusing a position", () => {
 
   test("tells a bettor their position is locked once the window closes", async () => {
     await bet({ stake: 5 });
+    const balanceBefore = await db.bucksAccount.findFirstOrThrow();
+    const ledgerRowsBefore = await db.bucksLedgerEntry.count();
     await db.bucksMatchPool.updateMany({
       data: { closesAt: new Date(Date.now() - 1000) },
     });
@@ -215,6 +332,9 @@ describe("placeBet — refusing a position", () => {
       db,
     );
     expect(result.kind).toBe("window_closed");
+    expect(await db.bucksAccount.findFirstOrThrow()).toEqual(balanceBefore);
+    expect(await db.bucksLedgerEntry.count()).toBe(ledgerRowsBefore);
+    expect(await db.bucksBet.count()).toBe(1);
   });
 
   test("tells a bettor a settled game has already resolved, not that it is pending", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.integration.test.ts
@@ -21,6 +21,7 @@ import {
   type PrematchHookDependencies,
 } from "#src/betting/prematch-hook.ts";
 import { openBettingPoolsForPrematch } from "#src/betting/pool-open.ts";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
@@ -216,7 +217,7 @@ describe("prepareBucksPrematch", () => {
 
     // The complement of the three cases above: in scope, the work happens.
     expect(buildPrediction).toHaveBeenCalled();
-    expect(result.footer).toBe("");
+    expect(result.footer).toBe(HOUSE_CUT_TERMS);
 
     // Pool creation itself needs a database and is covered by the pool and
     // place-bet integration suites; this file is only about what work is done

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-line.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-line.test.ts
@@ -4,6 +4,7 @@ import {
   appendBucksLine,
   bucksPrematchLine,
 } from "#src/betting/prematch-line.ts";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 
 function prediction(winProbability: number) {
   return BucksPredictionSchema.parse({
@@ -16,22 +17,31 @@ function prediction(winProbability: number) {
 }
 
 describe("bucksPrematchLine", () => {
-  test("keeps an interesting call without extra betting copy", () => {
+  test("keeps an interesting call and states the complete house policy", () => {
     const line = bucksPrematchLine({ prediction: prediction(0.6) });
 
-    expect(line).toBe("Scout's call: Aaron WINS — 60%.");
+    expect(line).toBe(`Scout's call: Aaron WINS — 60%.\n${HOUSE_CUT_TERMS}`);
     expect(line).not.toContain("Bets close");
     expect(line).not.toContain("/bb balance");
     expect(line).not.toContain("BB:CAD");
   });
 
   test("omits a near-even call while leaving the market available", () => {
-    expect(bucksPrematchLine({ prediction: prediction(0.49) })).toBe("");
+    expect(bucksPrematchLine({ prediction: prediction(0.49) })).toBe(
+      HOUSE_CUT_TERMS,
+    );
   });
 
   test("does not add blank content when there is no call", () => {
     expect(appendBucksLine("Aaron and Long started a game", "")).toBe(
       "Aaron and Long started a game",
     );
+  });
+
+  test("keeps the house policy when the base reaches Discord's limit", () => {
+    const message = appendBucksLine("x".repeat(2000), HOUSE_CUT_TERMS);
+
+    expect(message).toHaveLength(2000);
+    expect(message.endsWith(HOUSE_CUT_TERMS)).toBe(true);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-line.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-line.ts
@@ -1,4 +1,5 @@
 import type { BucksPrediction } from "@scout-for-lol/data";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { shouldDisplayPrediction } from "#src/betting/prediction.ts";
 
 /**
@@ -21,19 +22,21 @@ const MAX_CONTENT_LENGTH = 2000;
 export function bucksPrematchLine(input: {
   prediction: BucksPrediction | undefined;
 }): string {
-  return input.prediction !== undefined &&
+  const prediction =
+    input.prediction !== undefined &&
     shouldDisplayPrediction(input.prediction.winProbability)
-    ? input.prediction.sentence
-    : "";
+      ? `${input.prediction.sentence}\n`
+      : "";
+  return `${prediction}${HOUSE_CUT_TERMS}`;
 }
 
 /**
- * Append the betting footer to a message, dropping it entirely rather than
- * truncating if it would overflow.
+ * Append the betting footer to a message, truncating the base if needed so an
+ * open market never loses its house-cut disclosure.
  *
- * The base sentence — who started a game — is the core product output and must
- * survive. A half-truncated prediction is worse than no prediction, so the
- * footer is all-or-nothing.
+ * The footer is internal, bounded copy. If it alone cannot fit, that is a
+ * broken caller contract and must fail loudly rather than sending partial
+ * terms.
  */
 export function appendBucksLine(base: string, footer: string): string {
   if (footer.length === 0) {
@@ -43,5 +46,9 @@ export function appendBucksLine(base: string, footer: string): string {
   if (combined.length <= MAX_CONTENT_LENGTH) {
     return combined;
   }
-  return base.slice(0, MAX_CONTENT_LENGTH);
+  const baseLength = MAX_CONTENT_LENGTH - footer.length - 2;
+  if (baseLength < 0) {
+    throw new Error("Bryan Bucks prematch footer exceeds Discord's limit");
+  }
+  return `${base.slice(0, baseLength)}\n\n${footer}`;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/settle.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settle.integration.test.ts
@@ -133,6 +133,16 @@ function withDuration(seconds: number): RawMatch {
   });
 }
 
+function withUnsupportedLobby(): RawMatch {
+  return RawMatchSchema.parse({
+    ...fixture,
+    info: {
+      ...fixture.info,
+      participants: fixture.info.participants.slice(0, 8),
+    },
+  });
+}
+
 beforeEach(clearAll);
 
 afterAll(async () => {
@@ -167,6 +177,27 @@ describe("settleBettingForMatch", () => {
 
     const summaries = await settleBettingForMatch(fixture, db);
     expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.houseCut).toBe(16);
+    expect(
+      summaries[0]?.bets
+        .filter((bet) => bet.won)
+        .map((bet) => ({
+          stake: bet.stake,
+          grossPayout: bet.grossPayout,
+          houseCut: bet.houseCut,
+          payout: bet.payout,
+          winnings: bet.winnings,
+        })),
+    ).toEqual([
+      { stake: 10, grossPayout: 20, houseCut: 4, payout: 16, winnings: 6 },
+      {
+        stake: 30,
+        grossPayout: 60,
+        houseCut: 12,
+        payout: 48,
+        winnings: 18,
+      },
+    ]);
 
     // Winners staked 40 against a losing pool of 40, so each doubles up.
     const a = await db.bucksAccount.findUniqueOrThrow({
@@ -178,15 +209,71 @@ describe("settleBettingForMatch", () => {
     const c = await db.bucksAccount.findUniqueOrThrow({
       where: { id: loser.account.id },
     });
-    expect(a.balance).toBe(120);
-    expect(b.balance).toBe(160);
+    expect(a.balance).toBe(116);
+    expect(b.balance).toBe(148);
     expect(c.balance).toBe(100);
+
+    expect(
+      await db.bucksLedgerEntry.findMany({
+        where: { bucksAccountId: winner1.account.id },
+        orderBy: { id: "asc" },
+        select: { kind: true, delta: true },
+      }),
+    ).toEqual([
+      { kind: "bet_payout", delta: 20 },
+      { kind: "house_rake", delta: -4 },
+    ]);
+
+    const house = await db.bucksAccount.findUniqueOrThrow({
+      where: {
+        serverId_discordId: {
+          serverId: SERVER_A,
+          discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        },
+      },
+    });
+    expect(house.balance).toBe(HOUSE_BANKROLL + 16);
+    expect(
+      await db.bucksLedgerEntry.findMany({
+        where: { bucksAccountId: house.id, kind: "house_rake" },
+        orderBy: { id: "asc" },
+        select: { delta: true, matchId: true },
+      }),
+    ).toEqual([
+      { delta: 4, matchId: MATCH_ID },
+      { delta: 12, matchId: MATCH_ID },
+    ]);
+
+    const pairedCut = await db.bucksLedgerEntry.findMany({
+      where: { betId: winner1.bet.id, kind: "house_rake" },
+      orderBy: { id: "asc" },
+      select: { bucksAccountId: true, delta: true, context: true },
+    });
+    expect(pairedCut).toHaveLength(2);
+    expect(pairedCut[0]).toMatchObject({
+      bucksAccountId: winner1.account.id,
+      delta: -4,
+    });
+    expect(pairedCut[1]).toMatchObject({ bucksAccountId: house.id, delta: 4 });
+    expect(pairedCut[0]?.context).toBe(pairedCut[1]?.context);
+    const cutContext: unknown = JSON.parse(pairedCut[0]?.context ?? "null");
+    expect(cutContext).toEqual({
+      type: "house_fee",
+      source: "settlement",
+      ratePercent: 20,
+      grossAmount: 20,
+      fee: 4,
+    });
 
     const losingBet = await db.bucksBet.findUniqueOrThrow({
       where: { id: loser.bet.id },
     });
     expect(losingBet.betOutcome).toBe("lost");
     expect(losingBet.payout).toBe(0);
+    const winningBet = await db.bucksBet.findUniqueOrThrow({
+      where: { id: winner1.bet.id },
+    });
+    expect(winningBet.payout).toBe(16);
 
     // A losing bet moves nothing at settlement, so it writes no ledger row.
     expect(
@@ -252,15 +339,38 @@ describe("settleBettingForMatch", () => {
       inTransaction.indexOf("BucksBet.findMany"),
     );
   });
+});
 
+describe("settleBettingForMatch refunds and conservation", () => {
   test("refunds everyone on a remake", async () => {
     await makeTwoSidedPool();
 
     const [summary] = await settleBettingForMatch(withDuration(120), db);
     expect(summary?.voidReason).toBe("remake");
+    expect(summary?.houseCut).toBe(0);
 
     const accounts = await db.bucksAccount.findMany();
     expect(accounts.map((a) => a.balance)).toEqual([110, 110]);
+    expect(
+      await db.bucksLedgerEntry.count({ where: { kind: "house_rake" } }),
+    ).toBe(0);
+  });
+
+  test("refunds an unsupported match without charging a cut", async () => {
+    await makeTwoSidedPool();
+
+    const [summary] = await settleBettingForMatch(withUnsupportedLobby(), db);
+    expect(summary?.voidReason).toBe("unsupported_mode");
+    expect(summary?.houseCut).toBe(0);
+    expect(
+      summary?.bets.every((bet) => bet.refunded && bet.houseCut === 0),
+    ).toBe(true);
+
+    const accounts = await db.bucksAccount.findMany();
+    expect(accounts.map((account) => account.balance)).toEqual([110, 110]);
+    expect(
+      await db.bucksLedgerEntry.count({ where: { kind: "house_rake" } }),
+    ).toBe(0);
   });
 
   test("settles each guild's pool independently", async () => {
@@ -301,7 +411,7 @@ describe("settleBettingForMatch", () => {
     const account = await db.bucksAccount.findUniqueOrThrow({
       where: { id: lonely.account.id },
     });
-    expect(account.balance).toBe(140);
+    expect(account.balance).toBe(132);
   });
 
   test("conserves Bucks across the whole settlement", async () => {
@@ -326,11 +436,12 @@ describe("settleBettingForMatch", () => {
 
     await settleBettingForMatch(fixture, db);
 
-    // Stakes were already debited before settlement, so the balances now hold
-    // exactly the pool, redistributed.
+    // The human balances plus the newly seeded house still conserve the
+    // original pool. Cuts redistribute Bucks; they do not create or destroy
+    // any beyond the house's explicit opening bankroll.
     const accounts = await db.bucksAccount.findMany();
     const total = accounts.reduce((sum, a) => sum + a.balance, 0);
-    expect(total).toBe(7 + 11 + 13 + 17 + 19);
+    expect(total).toBe(HOUSE_BANKROLL + 7 + 11 + 13 + 17 + 19);
   });
 });
 
@@ -350,15 +461,28 @@ describe("one-sided house settlement", () => {
     });
     expect(summary?.bets.find((bet) => !bet.isHouse)).toMatchObject({
       stake: 25,
-      payout: 50,
-      winnings: 25,
+      grossPayout: 50,
+      houseCut: 10,
+      payout: 40,
+      winnings: 15,
       won: true,
     });
+    expect(summary?.houseCut).toBe(10);
 
     const account = await db.bucksAccount.findUniqueOrThrow({
       where: { id: only.account.id },
     });
-    expect(account.balance).toBe(150);
+    expect(account.balance).toBe(140);
+    expect(
+      await db.bucksLedgerEntry.findMany({
+        where: { bucksAccountId: only.account.id },
+        orderBy: { id: "asc" },
+        select: { kind: true, delta: true },
+      }),
+    ).toEqual([
+      { kind: "bet_payout", delta: 50 },
+      { kind: "house_rake", delta: -10 },
+    ]);
 
     const house = await db.bucksAccount.findUniqueOrThrow({
       where: {
@@ -369,7 +493,7 @@ describe("one-sided house settlement", () => {
       },
     });
     expect(house.isHouse).toBe(true);
-    expect(house.balance).toBe(HOUSE_BANKROLL - 25);
+    expect(house.balance).toBe(HOUSE_BANKROLL - 15);
     expect(
       await db.bucksLedgerEntry.findMany({
         where: { bucksAccountId: house.id },
@@ -379,13 +503,14 @@ describe("one-sided house settlement", () => {
     ).toEqual([
       { kind: "seed", delta: HOUSE_BANKROLL },
       { kind: "bet_stake", delta: -25 },
+      { kind: "house_rake", delta: 10 },
     ]);
 
     expect(await getFullLeaderboard({ serverId: SERVER_A }, db)).toEqual([
       {
         accountId: only.account.id,
         discordId: only.account.discordId,
-        balance: 150,
+        balance: 140,
       },
     ]);
 
@@ -409,6 +534,7 @@ describe("one-sided house settlement", () => {
 
     const [summary] = await settleBettingForMatch(fixture, db);
     expect(summary?.voidReason).toBe("house_unavailable");
+    expect(summary?.houseCut).toBe(0);
 
     const account = await db.bucksAccount.findUniqueOrThrow({
       where: { id: only.account.id },
@@ -440,6 +566,13 @@ describe("one-sided house settlement", () => {
 
     const [summary] = await settleBettingForMatch(fixture, db);
     expect(summary?.voidReason).toBeUndefined();
+    expect(summary?.houseCut).toBe(0);
+    expect(summary?.bets.find((bet) => bet.isHouse)).toMatchObject({
+      grossPayout: 50,
+      houseCut: 0,
+      payout: 50,
+      winnings: 25,
+    });
 
     const house = await db.bucksAccount.findUniqueOrThrow({
       where: {
@@ -461,6 +594,9 @@ describe("one-sided house settlement", () => {
       { kind: "bet_stake", delta: -25 },
       { kind: "bet_payout", delta: 50 },
     ]);
+    expect(
+      await db.bucksLedgerEntry.count({ where: { kind: "house_rake" } }),
+    ).toBe(0);
   });
 });
 
@@ -491,6 +627,11 @@ describe("voidStaleBettingPools", () => {
       where: { id: bettor.account.id },
     });
     expect(unchanged.balance).toBe(120);
+    expect(
+      await db.bucksLedgerEntry.count({
+        where: { kind: { in: ["house_rake", "cancel_fee"] } },
+      }),
+    ).toBe(0);
   });
 
   test("leaves a pool that is still within its grace period", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/settle.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settle.ts
@@ -8,10 +8,15 @@ import {
   type RawMatch,
 } from "@scout-for-lol/data";
 import { classifyMatchForBetting } from "#src/betting/outcome.ts";
+import { HOUSE_ACCOUNT_DISCORD_ID } from "#src/betting/constants.ts";
 import {
-  HOUSE_ACCOUNT_DISCORD_ID,
-  HOUSE_BANKROLL,
-} from "#src/betting/constants.ts";
+  HOUSE_CUT_PERCENT,
+  settlementHouseCut,
+} from "#src/betting/house-cut.ts";
+import {
+  ensureHouseAccountInTransaction,
+  transferHouseCut,
+} from "#src/betting/house.ts";
 import {
   computeParimutuelPayouts,
   type ParimutuelBet,
@@ -48,6 +53,8 @@ export type SettlementBet = {
   isHouse: boolean;
   predictedTeamId: number;
   stake: number;
+  grossPayout: number;
+  houseCut: number;
   payout: number;
   winnings: number;
   won: boolean;
@@ -62,6 +69,7 @@ export type SettlementSummary = {
   voidReason: BucksVoidReason | undefined;
   winnersPool: number;
   losersPool: number;
+  houseCut: number;
   bets: SettlementBet[];
 };
 
@@ -93,6 +101,7 @@ async function creditBet(
   input: {
     bet: SettlementBet;
     matchId: string;
+    serverId: DiscordGuildId;
     roster: readonly BucksPoolParticipant[];
     winningTeamId: number | undefined;
     voidReason: BucksVoidReason | undefined;
@@ -111,7 +120,7 @@ async function creditBet(
     },
   });
 
-  if (bet.payout === 0) {
+  if (bet.grossPayout === 0) {
     // A losing bet already paid at stake time; there is nothing to move, and a
     // zero-delta ledger row would be noise rather than history.
     return;
@@ -119,7 +128,7 @@ async function creditBet(
 
   await applyBucksDelta(tx, {
     bucksAccountId: bet.bucksAccountId,
-    delta: bet.payout,
+    delta: bet.grossPayout,
     kind: bet.refunded ? "bet_refund" : "bet_payout",
     matchId: input.matchId,
     betId: bet.betId,
@@ -137,9 +146,30 @@ async function creditBet(
       losersPool: input.losersPool,
       stakeReturned: bet.stake,
       winnings: bet.winnings,
+      grossPayout: bet.grossPayout,
+      houseCut: bet.houseCut,
+      netPayout: bet.payout,
       voidReason: input.voidReason,
     },
   });
+
+  if (bet.houseCut > 0) {
+    await transferHouseCut(tx, {
+      serverId: input.serverId,
+      bucksAccountId: bet.bucksAccountId,
+      amount: bet.houseCut,
+      kind: "house_rake",
+      matchId: input.matchId,
+      betId: bet.betId,
+      context: {
+        type: "house_fee",
+        source: "settlement",
+        ratePercent: HOUSE_CUT_PERCENT,
+        grossAmount: bet.grossPayout,
+        fee: bet.houseCut,
+      },
+    });
+  }
 }
 
 type PendingBetRow = {
@@ -158,6 +188,7 @@ function refundAll(rows: readonly PendingBetRow[]): {
   bets: SettlementBet[];
   winnersPool: number;
   losersPool: number;
+  houseCut: number;
 } {
   return {
     bets: rows.map((row) => ({
@@ -167,6 +198,8 @@ function refundAll(rows: readonly PendingBetRow[]): {
       isHouse: row.isHouse,
       predictedTeamId: row.predictedTeamId,
       stake: row.stake,
+      grossPayout: row.stake,
+      houseCut: 0,
       payout: row.stake,
       winnings: 0,
       won: false,
@@ -175,6 +208,7 @@ function refundAll(rows: readonly PendingBetRow[]): {
     })),
     winnersPool: 0,
     losersPool: 0,
+    houseCut: 0,
   };
 }
 
@@ -182,7 +216,12 @@ function toSettlementBets(input: {
   rows: readonly PendingBetRow[];
   winningTeamId: number | undefined;
   voidReason: BucksVoidReason | undefined;
-}): { bets: SettlementBet[]; winnersPool: number; losersPool: number } {
+}): {
+  bets: SettlementBet[];
+  winnersPool: number;
+  losersPool: number;
+  houseCut: number;
+} {
   // A void refunds everyone at 100%, whatever the result was.
   if (input.voidReason !== undefined || input.winningTeamId === undefined) {
     return refundAll(input.rows);
@@ -199,26 +238,39 @@ function toSettlementBets(input: {
     return refundAll(input.rows);
   }
 
-  const byId = new Map(result.allocations.map((a) => [a.betId, a]));
+  const byId = new Map(
+    result.allocations.map((allocation) => [allocation.betId, allocation]),
+  );
+  const bets = input.rows.map((row) => {
+    const allocation = byId.get(row.id);
+    const grossPayout = allocation?.payout ?? 0;
+    const grossWinnings = allocation?.winnings ?? 0;
+    const houseCut = settlementHouseCut({
+      grossPayout,
+      grossWinnings,
+      isHouse: row.isHouse,
+    });
+    return {
+      betId: row.id,
+      bucksAccountId: row.bucksAccountId,
+      discordId: row.discordId,
+      isHouse: row.isHouse,
+      predictedTeamId: row.predictedTeamId,
+      stake: row.stake,
+      grossPayout,
+      houseCut,
+      payout: grossPayout - houseCut,
+      winnings: grossWinnings - houseCut,
+      won: allocation !== undefined,
+      refunded: false,
+      subjectPuuid: row.subjectPuuid,
+    };
+  });
   return {
     winnersPool: result.winnersPool,
     losersPool: result.losersPool,
-    bets: input.rows.map((row) => {
-      const allocation = byId.get(row.id);
-      return {
-        betId: row.id,
-        bucksAccountId: row.bucksAccountId,
-        discordId: row.discordId,
-        isHouse: row.isHouse,
-        predictedTeamId: row.predictedTeamId,
-        stake: row.stake,
-        payout: allocation?.payout ?? 0,
-        winnings: allocation?.winnings ?? 0,
-        won: allocation !== undefined,
-        refunded: false,
-        subjectPuuid: row.subjectPuuid,
-      };
-    }),
+    houseCut: bets.reduce((total, bet) => total + bet.houseCut, 0),
+    bets,
   };
 }
 
@@ -392,6 +444,7 @@ async function settleOnePool(input: {
       await creditBet(tx, {
         bet,
         matchId: input.matchId,
+        serverId: input.serverId,
         roster: input.roster,
         winningTeamId: input.winningTeamId,
         voidReason,
@@ -400,13 +453,14 @@ async function settleOnePool(input: {
       });
     }
 
-    // Conservation, asserted rather than assumed. Throwing rolls the whole
-    // settlement back instead of minting or destroying Bucks.
+    // Conservation, asserted rather than assumed. Human winners receive their
+    // net payout and the house receives every cut, so together they must equal
+    // the stakes held by the pool. Throwing rolls the whole settlement back.
     const staked = settled.bets.reduce((total, bet) => total + bet.stake, 0);
     const paid = settled.bets.reduce((total, bet) => total + bet.payout, 0);
-    if (paid !== staked) {
+    if (paid + settled.houseCut !== staked) {
       throw new Error(
-        `Settlement for ${input.matchId} did not conserve Bucks: staked ${staked.toString()}, paid ${paid.toString()}`,
+        `Settlement for ${input.matchId} did not conserve Bucks: staked ${staked.toString()}, paid ${paid.toString()}, house cut ${settled.houseCut.toString()}`,
       );
     }
 
@@ -421,6 +475,7 @@ async function settleOnePool(input: {
       voidReason,
       winnersPool: settled.winnersPool,
       losersPool: settled.losersPool,
+      houseCut: settled.houseCut,
       bets: settled.bets,
     };
   });
@@ -492,47 +547,4 @@ async function addHousePositionIfNeeded(input: {
     subjectPuuid: representative.subjectPuuid,
   });
   return;
-}
-
-async function ensureHouseAccountInTransaction(
-  tx: Db,
-  serverId: DiscordGuildId,
-): Promise<{ id: number; balance: number }> {
-  const existing = await tx.bucksAccount.findUnique({
-    where: {
-      serverId_discordId: {
-        serverId,
-        discordId: HOUSE_ACCOUNT_DISCORD_ID,
-      },
-    },
-    select: { id: true, balance: true, isHouse: true },
-  });
-  if (existing !== null) {
-    if (!existing.isHouse) {
-      throw new Error(
-        `Bucks account ${existing.id.toString()} uses the reserved house account ID`,
-      );
-    }
-    return existing;
-  }
-
-  const created = await tx.bucksAccount.create({
-    data: {
-      serverId,
-      discordId: HOUSE_ACCOUNT_DISCORD_ID,
-      isHouse: true,
-      balance: 0,
-    },
-    select: { id: true },
-  });
-  const balance = await applyBucksDelta(tx, {
-    bucksAccountId: created.id,
-    delta: HOUSE_BANKROLL,
-    kind: "seed",
-    context: {
-      type: "seed",
-      note: "Opening bankroll for the Bryan Bucks house account",
-    },
-  });
-  return { id: created.id, balance };
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { BucksLedgerKindSchema } from "@scout-for-lol/data/index.ts";
+import {
+  ledgerKindLabel,
+  renderBucksHistory,
+} from "#src/betting/navigation.ts";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+
+describe("/bb history labels", () => {
+  test("renders house transfers as readable cuts", () => {
+    expect(ledgerKindLabel(BucksLedgerKindSchema.parse("house_rake"))).toBe(
+      "house cut on payout",
+    );
+    expect(ledgerKindLabel(BucksLedgerKindSchema.parse("cancel_fee"))).toBe(
+      "house cut on cancellation",
+    );
+
+    const rendered = renderBucksHistory(bucksTestDiscordId(1), {
+      entries: [
+        {
+          id: 2,
+          delta: -1,
+          balanceAfter: 9,
+          kind: BucksLedgerKindSchema.parse("cancel_fee"),
+          matchId: "NA1_1",
+          context: "{}",
+          createdAt: new Date(0),
+        },
+        {
+          id: 1,
+          delta: -2,
+          balanceAfter: 10,
+          kind: BucksLedgerKindSchema.parse("house_rake"),
+          matchId: "NA1_1",
+          context: "{}",
+          createdAt: new Date(0),
+        },
+      ],
+      page: 0,
+      pageSize: 10,
+      totalEntries: 2,
+      totalPages: 1,
+      snapshotId: 2,
+    });
+    expect(rendered.content).toContain("house cut on payout");
+    expect(rendered.content).toContain("house cut on cancellation");
+    expect(rendered.content).toContain(HOUSE_CUT_TERMS);
+    expect(rendered.content).not.toContain("house_rake");
+    expect(rendered.content).not.toContain("cancel_fee");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
@@ -12,6 +12,15 @@ import {
 } from "#src/discord/commands/bb-prizes.ts";
 
 describe("/bb prizes", () => {
+  test("offers no redemption, donation, burn, or claim command", () => {
+    const command = bbCommand.toJSON();
+    const names = command.options?.map((option) => option.name) ?? [];
+
+    for (const absent of ["redeem", "redemption", "donate", "burn", "claim"]) {
+      expect(names).not.toContain(absent);
+    }
+  });
+
   test("registers a no-option prizes subcommand", () => {
     const command = bbCommand.toJSON();
     const prizes = command.options?.find((option) => option.name === "prizes");
@@ -139,5 +148,8 @@ describe("/bb command contract", () => {
     ]) {
       expect(rendered).toContain(phrase);
     }
+    expect(rendered).toContain(
+      "cancel it before the window closes for a 20% house cut, rounded to the nearest BB",
+    );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -23,6 +23,7 @@ import {
   MIN_STAKE,
   SEED_GRANT,
 } from "#src/betting/constants.ts";
+import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { renderBucksHistory } from "#src/betting/navigation.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
@@ -86,7 +87,7 @@ export const bbCommand = new SlashCommandBuilder()
   .addSubcommand((sub) =>
     sub
       .setName("bet")
-      .setDescription("Bet on a tracked player's live game")
+      .setDescription("Bet on a live game; 20% win and cancellation house cuts")
       .addStringOption((option) =>
         option
           .setName("player")
@@ -165,13 +166,13 @@ async function replyBalance(
   const view = await getPersonalBucksView({ serverId, discordId });
   if (view === undefined) {
     await interaction.editReply({
-      content:
-        "You don't have a Bryan Bucks wallet yet — place your first bet on a live game and you'll be given a starting balance.",
+      content: `You don't have a Bryan Bucks wallet yet — place your first bet on a live game and you'll be given a starting balance.\n\n${HOUSE_CUT_TERMS}`,
     });
     return;
   }
 
   await interaction.editReply({
+    content: HOUSE_CUT_TERMS,
     embeds: [buildPersonalBucksEmbed(view)],
   });
 }
@@ -201,18 +202,19 @@ export function buildBbRulesEmbed(): EmbedBuilder {
         value:
           `Stake **${MIN_STAKE.toString()}-${MAX_STAKE.toString()} BB** on a tracked player to WIN or LOSE. ` +
           `The market stays open for ${Math.floor(BETTING_WINDOW_MS / 60_000).toString()} minutes after Scout detects the game. ` +
-          "You can add to a position or cancel it for a full refund before the window closes; after that, it is locked.",
+          "You can add to a position or cancel it before the window closes for a 20% house cut, rounded to the nearest BB; after that, it is locked.",
       },
       {
         name: "Settlement",
         value:
           "Winners get their stakes back and split the losing side's pool in proportion to their stakes. " +
+          "The house takes 20% of each human winner's gross payout, rounded to the nearest BB, without cutting into winning principal. " +
           "If people bet on only one side, the Bryan Bucks house matches the other side when its reserve can cover the stake.",
       },
       {
         name: "Refunds",
         value:
-          "All stakes are returned when a game is voided or remade, cannot be settled, or the house cannot cover a one-sided market.",
+          "All stakes are returned with no house cut when a game is voided or remade, cannot be settled, or the house cannot cover a one-sided market.",
       },
     );
 }
@@ -240,7 +242,7 @@ async function replyOpen(
 
   if (pools.length === 0) {
     await interaction.editReply({
-      content: "No games are open for betting right now.",
+      content: `No games are open for betting right now.\n\n${HOUSE_CUT_TERMS}`,
     });
     return;
   }
@@ -262,7 +264,9 @@ async function replyOpen(
       `🔴 **Red:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} bet(s) — ${redPlayers}`,
     ].join("\n");
   });
-  const chunks = splitMessageIntoChunks(sections.join("\n\n"));
+  const chunks = splitMessageIntoChunks(
+    `${sections.join("\n\n")}\n\n${HOUSE_CUT_TERMS}`,
+  );
   const first = chunks[0];
   if (first === undefined) {
     throw new Error("Open Bryan Bucks markets produced no Discord content");

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
@@ -93,4 +93,16 @@ describe("registered Discord commands", () => {
       ),
     ).not.toContainEqual(expect.objectContaining({ autocomplete: true }));
   });
+
+  test("defines no redemption, donation, burn, or claim command", () => {
+    const registered = [
+      ...commandDefinitions.map((command) => command.toJSON()),
+      ...guildScopedCommandGroups.flatMap((group) => group.payload),
+    ];
+    const serialized = JSON.stringify(registered).toLowerCase();
+
+    for (const absent of ["redeem", "redemption", "donate", "burn", "claim"]) {
+      expect(serialized).not.toContain(`"name":"${absent}"`);
+    }
+  });
 });

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -41,6 +41,8 @@ export const BucksLedgerKindSchema = z.enum([
   "bet_stake",
   "bet_payout",
   "bet_refund",
+  "house_rake",
+  "cancel_fee",
   "adjustment",
 ]);
 
@@ -165,7 +167,19 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     losersPool: z.number().int(),
     stakeReturned: z.number().int(),
     winnings: z.number().int(),
+    /** Added with house cuts. Optional so historical ledger JSON remains
+     * parseable under the current schema. */
+    grossPayout: z.number().int().nonnegative().optional(),
+    houseCut: z.number().int().nonnegative().optional(),
+    netPayout: z.number().int().nonnegative().optional(),
     voidReason: BucksVoidReasonSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal("house_fee"),
+    source: z.enum(["settlement", "cancellation"]),
+    ratePercent: z.number().int().min(0).max(100),
+    grossAmount: z.number().int().positive(),
+    fee: z.number().int().positive(),
   }),
   z.strictObject({
     type: z.literal("adjustment"),


### PR DESCRIPTION
## Why

Bryan Bucks only entered player circulation, so the experimental economy had no automatic route back to its audited house account. Players also needed the cost stated anywhere they could place, inspect, cancel, or settle a bet.

## What

- Take a rounded 20% cut from each human winner gross payout, capped so winning principal is protected.
- Take a rounded 20% cut from voluntary cancellations while preserving full mandatory refunds.
- Record gross credits and paired player/house fee transfers atomically in the existing ledger, with net payouts stored on settled bets.
- Show pool totals, house cuts, gross-cut-net arithmetic, cut-free refunds, cancellation arithmetic, and readable history labels across Discord betting surfaces.
- Extend the validated ledger kinds and JSON context without a Prisma migration; the persisted columns remain strings and JSON.
- Keep Bryan Bucks fake and leave the prize catalog without redemption, donation, burn, or claim actions.

## Verification

- bunx turbo run typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend
  - 15/15 tasks passed
  - 1,593 backend tests passed; 6 existing tests skipped
  - 639 data tests passed
- bunx lefthook run pre-commit
- Focused settlement, cancellation, reconciliation, message, and command-definition coverage passes.

## Rollout and live acceptance

The branch is not deployed. After this reaches beta, capture one cancellation and one settlement, compare the displayed arithmetic with the paired ledger rows and house balance, run reconciliation, and attach representative screenshots. No live money or redemption path exists; Bryan Bucks remain fake points.