### PR TITLE
feat(toolkit): rank and inspect local agent history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,8 +481,9 @@ toolkit history daemon install
 # “What did I work on last week?” (rolling seven-day window).
 toolkit history recent --since 7d
 
-# “Didn't I solve this before?”
-toolkit history search "argocd prune" --since 90d --include-excerpts
+# “Didn't I solve this before?” — narrow first, then read one bounded record.
+toolkit history search "argocd prune" --since 90d
+toolkit history show <ID_FROM_SEARCH> --query "argocd prune"
 
 # Inspect source coverage and ingestion errors.
 toolkit history sources
@@ -495,10 +496,21 @@ toolkit pr health <PR_NUMBER>
 ```
 
 Use `--source conductor|claude|codex|cursor|opencode-conductor|opencode-standalone`
-to narrow a search and `--json` for agent-readable output. `--include-excerpts`
-reopens source stores read-only for bounded excerpts; complete transcript bodies
-are not copied into the index. The LaunchAgent, index, socket, state, and logs
-are user-private. Never index or print standalone OpenCode's `auth.json`.
+to narrow a search and `--json` for agent-readable output. BM25 ranks substantive
+dialogue ahead of low-value tool mentions, while recency breaks ties. Unquoted
+terms are AND-prefix matches; literal quotes inside the query request an exact
+phrase. The current Conductor/Codex run is hidden and parallel sessions with the
+same opening prompt are grouped by default; use `--include-current` or
+`--include-duplicates` to override that behavior.
+
+`--include-excerpts` reopens only returned source records for bounded excerpts.
+Use `show` for the fast second stage: it returns at most eight messages and 6,000
+characters by default, omits system/reasoning/compaction records, and includes
+tool output only when it matches `--query` unless `--include-tools` is set.
+Complete transcript bodies are not copied into the index. JSON search/recent
+responses include a `warnings` array; human warnings go to stderr. The
+LaunchAgent, index, socket, state, and logs are user-private. Never index or
+print standalone OpenCode's `auth.json`.
 
 The commands below remain useful as a read-only fallback when the index has not
 been installed or a client has changed its internal schema. The seven-day

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -222,7 +222,8 @@ other live services.
 ```bash
 toolkit history daemon install
 toolkit history recent --since 7d
-toolkit history search "kubernetes ingress" --since 30d --include-excerpts
+toolkit history search "kubernetes ingress" --since 30d
+toolkit history show <ID_FROM_SEARCH> --query "kubernetes ingress"
 toolkit history sources --json
 toolkit history daemon status --json
 toolkit history daemon reindex
@@ -231,10 +232,19 @@ toolkit history daemon reindex
 The daemon is a user-scoped macOS LaunchAgent named
 `com.jerred.toolkit-history`. It polls every 30 seconds, owns writes to
 `~/.toolkit/history/index.sqlite`, and exposes a 0600 Unix socket for status and
-reindex requests. The index uses a contentless FTS5 table plus metadata; full
-transcript bodies are never stored in ordinary index tables. Excerpts are
-loaded read-only from the original source only when `--include-excerpts` is
-requested.
+reindex requests. The versioned index uses contentless FTS5 title, dialogue,
+and tool-output columns with BM25 weights `8.0`, `3.0`, and `0.25`; recency is
+only a tie-breaker. Full transcript bodies are never stored in ordinary index
+tables. Excerpts and `show` context use batched targeted reads of returned
+records.
+
+Search/recent hide the current `CONDUCTOR_SESSION_ID`/`CODEX_THREAD_ID` and
+group identical normalized opening prompts in earliest-anchored 30-minute
+clusters by default. `--include-current` and `--include-duplicates` override
+those behaviors. Search/recent JSON are warning-bearing envelopes; human source
+warnings go to stderr. `show` IDs are rebuild-local, and context is capped at
+eight messages/6,000 characters by default. Role-aware adapters omit system,
+reasoning, and compaction records. Cursor's flattened index uses `unknown`.
 
 Runtime files are private: `index.sqlite`, `daemon.sock`, `state.json`, and
 `logs/` are under `~/.toolkit/history/`; the plist is
@@ -247,8 +257,10 @@ with a source-specific schema error when a client changes, and report that
 error through `history sources` rather than silently claiming coverage. Never
 read standalone OpenCode `~/.local/share/opencode/auth.json`; credentials must
 not enter the index, excerpts, logs, tests, or commits. Source SQLite files and
-JSONL transcripts are always opened/read-only. Use the history skill for the
-full command recipes and source boundaries.
+JSONL transcripts are always opened/read-only. Cursor may use SQLite's immutable
+URI only after ordinary read-only access reports `CANTOPEN` and no live WAL is
+present. Use the history skill for the full command recipes and source
+boundaries.
 
 ## `pr asset` — PR media host
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -103,6 +103,55 @@ is already occupied rather than capturing an unrelated process.
 - `toolkit history ...` searches the private, rebuildable local agent-history
   index. It never treats prior conversation as current deployment truth.
 
+#### History search
+
+`history` maintains a private local index of Conductor, Claude Code, Codex,
+Cursor, bundled OpenCode, and standalone OpenCode conversations. Install the
+macOS LaunchAgent once; search itself only reads the index and never performs
+live service checks.
+
+| Command                                                                      | Description                                   |
+| ---------------------------------------------------------------------------- | --------------------------------------------- |
+| `history search <QUERY> [--since 7d] [--source NAME] [--limit N]`            | Rank indexed work with BM25                   |
+| `history search <QUERY> --include-excerpts`                                  | Add targeted 360-character source excerpts    |
+| `history recent [--since 7d] [--limit N]`                                    | List recent indexed sessions                  |
+| `history show <ID> [--query TEXT] [--messages 8] [--include-tools] [--json]` | Read bounded, role-aware conversation context |
+| `history sources [--json]`                                                   | Show source availability and scan errors      |
+| `history daemon install`                                                     | Install and start the macOS LaunchAgent       |
+| `history daemon status\|reindex`                                             | Inspect or refresh ingestion                  |
+| `history daemon stop\|start\|uninstall`                                      | Manage the LaunchAgent lifecycle              |
+
+```bash
+toolkit history daemon install
+toolkit history recent --since 7d
+toolkit history search "argocd prune" --since 90d
+toolkit history show <ID_FROM_SEARCH> --query "argocd prune"
+toolkit history sources
+```
+
+Search ranks title, dialogue, and tool text separately and uses recency only to
+break relevance ties. Unquoted terms keep AND-prefix behavior; pass literal
+quotes inside the query for an exact phrase, for example
+`toolkit history search '"Bryan Bucks"'`. The current Conductor/Codex run and
+30-minute parallel duplicates are hidden/grouped by default; use
+`--include-current` or `--include-duplicates` when needed. Source failures are
+warnings on stderr, or in the JSON `warnings` array.
+
+JSON search and recent output are envelopes (`{ query, results, warnings }` and
+`{ results, warnings }`). `show --json` returns
+`{ record, messages, truncated }`. Local index IDs can change after a rebuild;
+rerun search when an ID is missing.
+
+The rebuildable index is `~/.toolkit/history/index.sqlite`; daemon state,
+socket, and logs are in that private directory. The LaunchAgent is
+`~/Library/LaunchAgents/com.jerred.toolkit-history.plist`. Transcript bodies
+are not copied into ordinary index tables. `show` returns at most eight
+messages and 6,000 characters by default, excluding system, reasoning, and
+compaction records. Standalone OpenCode's
+`~/.local/share/opencode/auth.json` is never read or indexed. Use `deployed`,
+`pr health`, or the relevant live client to verify current status after using
+history for context.
+
 Run `toolkit --help` or a workflow’s `--help` for the complete command surface.
 
 ## Environment variables

--- a/packages/toolkit/skills/history/SKILL.md
+++ b/packages/toolkit/skills/history/SKILL.md
@@ -26,8 +26,9 @@ the plist.
 # What did I work on last week?
 toolkit history recent --since 7d
 
-# Didn't I solve this before?
-toolkit history search "argocd prune" --since 90d --include-excerpts
+# Didn't I solve this before? Narrow first, then inspect one selected record.
+toolkit history search "argocd prune" --since 90d
+toolkit history show <ID_FROM_SEARCH> --query "argocd prune"
 
 # Limit the search to one client or return structured output.
 toolkit history search "ingress" --source conductor --json
@@ -38,10 +39,29 @@ toolkit history daemon status --json
 ```
 
 Supported sources are `conductor`, `claude`, `codex`, `cursor`,
-`opencode-conductor`, and `opencode-standalone`. Search defaults to metadata
-and match results. `--include-excerpts` reopens the original stores read-only
-and returns bounded excerpts without persisting transcript bodies in the
-index.
+`opencode-conductor`, and `opencode-standalone`. Search uses BM25 relevance;
+recency only breaks ties. Unquoted terms are AND-prefix matches. To request an
+exact phrase, preserve literal quotes in the query, for example
+`toolkit history search '"Bryan Bucks"'`.
+
+Search and recent hide the current Conductor/Codex run and group parallel
+sessions that opened with the same normalized prompt. Use `--include-current`
+or `--include-duplicates` to override those defaults. `--include-excerpts`
+reopens only returned records and adds 360-character dialogue-first excerpts.
+
+`show` is the normal second stage. By default it returns the opening request
+plus latest dialogue, bounded to eight messages and 6,000 characters. With
+`--query`, it centers on the best dialogue match and admits only matching tool
+messages; `--include-tools` admits all nearby tools. System instructions,
+reasoning, and compaction records are excluded. Cursor messages use `unknown`
+because its flattened index has no roles. IDs are local to the current rebuild;
+rerun search if an ID is missing.
+
+Search JSON is `{ query, results, warnings }`, recent JSON is
+`{ results, warnings }`, and show JSON is `{ record, messages, truncated }`.
+Human-readable source warnings go to stderr. An unavailable source is silent in
+an all-source query when it is merely uninstalled, but warns when explicitly
+requested.
 
 For “what is the current status?”, use history to find the relevant branch,
 PR, or workspace, then verify the live state separately with `toolkit deployed`,

--- a/packages/toolkit/src/commands/history/history.ts
+++ b/packages/toolkit/src/commands/history/history.ts
@@ -1,18 +1,13 @@
 import { parseArgs } from "node:util";
-import { HistoryIndex, parseLimit, parseSince } from "#lib/history/index.ts";
+import { parseMessageLimit, selectShowMessages } from "#lib/history/context.ts";
+import { HistoryIndex } from "#lib/history/index.ts";
+import { ftsQuery, parseLimit, parseSince } from "#lib/history/query.ts";
 import {
   historyDaemonRequest,
   HistoryDaemonResponseSchema,
   HistoryDaemonStatusSchema,
   pathExists,
 } from "#lib/history/ipc.ts";
-import {
-  defaultHistoryPaths,
-  defaultHistoryRuntimePaths,
-} from "#lib/history/paths.ts";
-import { createHistorySources } from "#lib/history/sources.ts";
-import { excerptForQuery } from "#lib/history/text.ts";
-import type { HistoryRecord, HistorySourceName } from "#lib/history/types.ts";
 import {
   HISTORY_LAUNCH_AGENT_LABEL,
   installLaunchAgent,
@@ -21,13 +16,29 @@ import {
   stopLaunchAgent,
   uninstallLaunchAgent,
 } from "#lib/history/launchd.ts";
+import { defaultHistoryRuntimePaths } from "#lib/history/paths.ts";
+import {
+  collectHistoryResults,
+  publicRecord,
+  sourceWarnings,
+} from "#lib/history/results.ts";
+import {
+  printHistoryWarnings,
+  renderHistoryRecords,
+  renderHistoryShow,
+} from "#lib/history/render.ts";
+import { currentHistoryRuntimes } from "#lib/history/runtime.ts";
+import { createHistorySources } from "#lib/history/sources.ts";
+import { addExcerpts, targetedMessages } from "#lib/history/targeted.ts";
+import type { HistorySourceName } from "#lib/history/types.ts";
 
 const USAGE = `
 toolkit history — search local agent conversation history
 
 Search and browse the existing local index:
-  toolkit history search <query> [--since 7d] [--source <name>] [--limit 20] [--include-excerpts] [--json]
-  toolkit history recent [--since 7d] [--source <name>] [--limit 20] [--json]
+  toolkit history search <query> [--since 7d] [--source <name>] [--limit 20] [--include-excerpts] [--include-current] [--include-duplicates] [--json]
+  toolkit history recent [--since 7d] [--source <name>] [--limit 20] [--include-current] [--include-duplicates] [--json]
+  toolkit history show <id> [--query <text>] [--messages 8] [--include-tools] [--json]
   toolkit history sources [--json]
 
 Manage background ingestion:
@@ -36,7 +47,6 @@ Manage background ingestion:
 
 Sources: conductor, claude, codex, cursor, opencode-conductor, opencode-standalone
 `;
-
 function parseSource(value: string | undefined): HistorySourceName | null {
   if (value === undefined) {
     return null;
@@ -64,6 +74,8 @@ function parseCommon(args: string[]) {
       source: { type: "string" },
       limit: { type: "string" },
       "include-excerpts": { type: "boolean", default: false },
+      "include-current": { type: "boolean", default: false },
+      "include-duplicates": { type: "boolean", default: false },
       json: { type: "boolean", default: false },
     },
     allowPositionals: true,
@@ -89,58 +101,14 @@ async function withReadOnlyIndex<T>(
   }
 }
 
-async function addExcerpts(
-  records: HistoryRecord[],
-  query: string,
-): Promise<HistoryRecord[]> {
-  if (records.length === 0) {
-    return records;
-  }
-  const paths = defaultHistoryPaths();
-  const documents = new Map<string, string>();
-  for (const source of createHistorySources()) {
-    const result = await source.scan(paths);
-    if (result.error !== null) {
-      continue;
-    }
-    for (const document of result.documents) {
-      documents.set(
-        `${document.source}:${document.sourceId}`,
-        document.searchText,
-      );
-    }
-  }
-  return records.map((record) => ({
-    ...record,
-    excerpt: excerptForQuery(
-      documents.get(`${record.source}:${record.sourceId}`) ?? "",
-      query,
-    ),
-  }));
+function sourceDefinitions() {
+  return createHistorySources();
 }
 
-function renderRecords(
-  title: string,
-  records: readonly HistoryRecord[],
-): string {
-  const lines = [`## ${title}`, ""];
-  if (records.length === 0) {
-    lines.push("No matching history.");
-    return lines.join("\n");
-  }
-  for (const record of records) {
-    lines.push(
-      `- **${record.title}** — ${record.source} — ${record.updatedAt}`,
-    );
-    if (record.workspace !== null) {
-      lines.push(`  Workspace: \`${record.workspace}\``);
-    }
-    lines.push(`  Source: \`${record.path}\` (${record.sourceId})`);
-    if (record.excerpt !== null && record.excerpt.length > 0) {
-      lines.push(`  Excerpt: ${record.excerpt}`);
-    }
-  }
-  return lines.join("\n");
+function sourceLabels() {
+  return new Map(
+    sourceDefinitions().map((source) => [source.name, source.label]),
+  );
 }
 
 async function searchCommand(args: string[]): Promise<void> {
@@ -154,17 +122,54 @@ async function searchCommand(args: string[]): Promise<void> {
   const source = parseSource(values.source);
   const since = parseSince(values.since);
   const limit = parseLimit(values.limit);
-  const records = await withReadOnlyIndex((index) =>
-    index.search(query, { since, source, limit }),
+  const runtimes = currentHistoryRuntimes();
+  const resultOptions = {
+    includeCurrent: values["include-current"],
+    includeDuplicates: values["include-duplicates"],
+    currentRuntimes: runtimes,
+    limit,
+  };
+  const excludedRuntimes = values["include-current"] ? [] : runtimes;
+  const indexed = await withReadOnlyIndex((index) =>
+    index.readSnapshot(() => ({
+      results: collectHistoryResults(
+        (offset, pageLimit) =>
+          index.search(query, {
+            since,
+            source,
+            limit: pageLimit,
+            offset,
+            excludedRuntimes,
+          }),
+        (openingPromptHash) =>
+          index.recent({
+            since,
+            source,
+            openingPromptHash,
+            excludedRuntimes,
+          }),
+        resultOptions,
+      ),
+      statuses: index.statuses(sourceLabels()),
+    })),
   );
   const enriched = values["include-excerpts"]
-    ? await addExcerpts(records, query)
-    : records;
+    ? await addExcerpts(indexed.results, query)
+    : { results: indexed.results, warnings: [] };
+  const warnings = [
+    ...sourceWarnings(indexed.statuses, source),
+    ...enriched.warnings,
+  ];
   if (values.json) {
-    console.log(JSON.stringify(enriched, null, 2));
+    console.log(
+      JSON.stringify({ query, results: enriched.results, warnings }, null, 2),
+    );
     return;
   }
-  console.log(renderRecords(`History search: ${query}`, enriched));
+  printHistoryWarnings(warnings);
+  console.log(
+    renderHistoryRecords(`History search: ${query}`, enriched.results),
+  );
 }
 
 async function recentCommand(args: string[]): Promise<void> {
@@ -172,44 +177,141 @@ async function recentCommand(args: string[]): Promise<void> {
   const source = parseSource(values.source);
   const since = parseSince(values.since);
   const limit = parseLimit(values.limit);
-  const records = await withReadOnlyIndex((index) =>
-    index.recent({ since, source, limit }),
+  const runtimes = currentHistoryRuntimes();
+  const resultOptions = {
+    includeCurrent: values["include-current"],
+    includeDuplicates: values["include-duplicates"],
+    currentRuntimes: runtimes,
+    limit,
+  };
+  const excludedRuntimes = values["include-current"] ? [] : runtimes;
+  const indexed = await withReadOnlyIndex((index) =>
+    index.readSnapshot(() => ({
+      results: collectHistoryResults(
+        (offset, pageLimit) =>
+          index.recent({
+            since,
+            source,
+            limit: pageLimit,
+            offset,
+            excludedRuntimes,
+          }),
+        (openingPromptHash) =>
+          index.recent({
+            since,
+            source,
+            openingPromptHash,
+            excludedRuntimes,
+          }),
+        resultOptions,
+      ),
+      statuses: index.statuses(sourceLabels()),
+    })),
   );
+  const warnings = sourceWarnings(indexed.statuses, source);
   if (values.json) {
-    console.log(JSON.stringify(records, null, 2));
+    console.log(
+      JSON.stringify({ results: indexed.results, warnings }, null, 2),
+    );
     return;
   }
-  console.log(renderRecords("Recent agent history", records));
+  printHistoryWarnings(warnings);
+  console.log(renderHistoryRecords("Recent agent history", indexed.results));
+}
+
+function parseShowId(value: string | undefined): number {
+  if (value === undefined || !/^[1-9]\d*$/u.test(value)) {
+    throw new RangeError(
+      "A positive local index ID is required. Usage: toolkit history show <id>",
+    );
+  }
+  const id = Number(value);
+  if (!Number.isSafeInteger(id)) {
+    throw new RangeError(
+      "A positive local index ID is required. Usage: toolkit history show <id>",
+    );
+  }
+  return id;
+}
+
+async function showCommand(args: string[]): Promise<void> {
+  const parsed = parseArgs({
+    args,
+    options: {
+      query: { type: "string" },
+      messages: { type: "string" },
+      "include-tools": { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+  });
+  const id = parseShowId(parsed.positionals[0]);
+  if (parsed.positionals.length > 1) {
+    throw new Error("show accepts exactly one local index ID");
+  }
+  const query = parsed.values.query ?? null;
+  if (query !== null) {
+    ftsQuery(query);
+  }
+  const record = await withReadOnlyIndex((index) => index.record(id));
+  if (record === null) {
+    throw new Error(
+      `History record ${String(id)} no longer exists. Local index IDs can change after a rebuild; rerun 'toolkit history search' and use the new ID.`,
+    );
+  }
+  const targeted = await targetedMessages([publicRecord(record)]);
+  if (targeted.warnings.length > 0) {
+    throw new Error(
+      targeted.warnings.map((warning) => warning.message).join("; "),
+    );
+  }
+  const selected = selectShowMessages(
+    targeted.messages.get(`${record.source}:${record.sourceId}`) ?? [],
+    {
+      query,
+      messageLimit: parseMessageLimit(parsed.values.messages),
+      includeTools: parsed.values["include-tools"],
+    },
+  );
+  const visibleRecord = publicRecord(record);
+  if (parsed.values.json) {
+    console.log(
+      JSON.stringify(
+        {
+          record: visibleRecord,
+          messages: selected.messages,
+          truncated: selected.truncated,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  console.log(
+    renderHistoryShow(visibleRecord, selected.messages, selected.truncated),
+  );
 }
 
 async function sourcesCommand(args: string[]): Promise<void> {
   const { values } = parseCommon(args);
-  const sourceDefinitions = createHistorySources();
-  const labels = new Map(
-    sourceDefinitions.map((source) => [source.name, source.label]),
+  const statuses = await withReadOnlyIndex((index) =>
+    index.statuses(sourceLabels()),
   );
-  const statuses = await withReadOnlyIndex((index) => index.statuses(labels));
   if (values.json) {
     console.log(JSON.stringify(statuses, null, 2));
     return;
   }
-  console.log(
-    renderRecords(
-      "History sources",
-      statuses.map((status) => ({
-        id: 0,
-        source: status.source,
-        sourceId: status.source,
-        title: status.label,
-        path: status.error ?? (status.available ? "available" : "not found"),
-        workspace: null,
-        agent: `${String(status.indexedDocuments)} indexed`,
-        createdAt: status.lastScanAt ?? "never",
-        updatedAt: status.lastScanAt ?? "never",
-        excerpt: null,
-      })),
-    ),
-  );
+  const lines = ["## History sources", ""];
+  for (const status of statuses) {
+    lines.push(
+      `- **${status.label}** — ${status.available ? "available" : "unavailable"} — ${String(status.indexedDocuments)} indexed`,
+    );
+    if (status.error !== null) {
+      lines.push(`  Error: ${status.error}`);
+    }
+  }
+  console.log(lines.join("\n"));
 }
 
 async function daemonStatusCommand(json: boolean): Promise<void> {
@@ -279,7 +381,7 @@ async function daemonCommand(args: string[]): Promise<void> {
         HistoryDaemonResponseSchema,
         "/reindex",
       );
-      console.log("History reindex complete.");
+      console.log("History reindex requested.");
       break;
     case "serve": {
       const { runHistoryDaemon } = await import("#lib/history/serve.ts");
@@ -303,6 +405,9 @@ export async function handleHistoryCommand(
         break;
       case "recent":
         await recentCommand(args);
+        break;
+      case "show":
+        await showCommand(args);
         break;
       case "sources":
         await sourcesCommand(args);

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -56,6 +56,8 @@ Examples:
   toolkit pr health
   toolkit deployed scout/prod
   toolkit history recent --since 7d
+  toolkit history search "kubernetes" --since 30d
+  toolkit history show <ID> --query "kubernetes"
 `);
 }
 

--- a/packages/toolkit/src/lib/history/codex-catalog.ts
+++ b/packages/toolkit/src/lib/history/codex-catalog.ts
@@ -1,0 +1,56 @@
+import {
+  firstText,
+  readDatabase,
+  requireTables,
+  rowValue,
+  rows,
+  RowSchema,
+} from "./sources-shared.ts";
+import { parseTimestamp, stringValue } from "./text.ts";
+import type { HistoryDocument } from "./types.ts";
+
+export function scanCodexCatalog(filePath: string): HistoryDocument[] {
+  const database = readDatabase(filePath);
+  try {
+    requireTables(database, "Codex catalog", ["local_thread_catalog"]);
+    const catalogRows = rows(
+      database,
+      `SELECT host_id, thread_id, display_title, source_created_at,
+              source_updated_at, cwd, model_provider, git_branch
+         FROM local_thread_catalog
+        WHERE missing_candidate = 0`,
+      RowSchema,
+    );
+    return catalogRows.map((row) => {
+      const title =
+        stringValue(rowValue(row, "display_title")) ?? "Codex thread";
+      const workspace = stringValue(rowValue(row, "cwd"));
+      const branch = stringValue(rowValue(row, "git_branch"));
+      const threadId = String(rowValue(row, "thread_id"));
+      return {
+        source: "codex",
+        sourceId: `${filePath}:${String(rowValue(row, "host_id"))}:${threadId}`,
+        title: firstText(title, "Codex thread"),
+        path: filePath,
+        workspace,
+        agent: stringValue(rowValue(row, "model_provider")) ?? "Codex",
+        createdAt: parseTimestamp(
+          rowValue(row, "source_created_at"),
+          new Date(0),
+        ),
+        updatedAt: parseTimestamp(
+          rowValue(row, "source_updated_at"),
+          new Date(0),
+        ),
+        runtimeId: threadId,
+        openingPromptHash: null,
+        dialogueText: "",
+        toolOutputText: [workspace, branch]
+          .filter((value) => value !== null)
+          .join("\n"),
+      } satisfies HistoryDocument;
+    });
+  } finally {
+    database.close();
+  }
+}

--- a/packages/toolkit/src/lib/history/codex-history.ts
+++ b/packages/toolkit/src/lib/history/codex-history.ts
@@ -1,0 +1,161 @@
+import { stat } from "node:fs/promises";
+import { makeHistoryDocument } from "./messages.ts";
+import { firstText } from "./sources-shared.ts";
+import {
+  cleanText,
+  extractText,
+  parseJsonLine,
+  parseRecord,
+  parseTimestamp,
+  stringValue,
+} from "./text.ts";
+import type { HistoryDocument, HistoryMessage } from "./types.ts";
+
+function sourceId(filePath: string, lineNumber: number): string {
+  return `${filePath}:line:${String(lineNumber)}`;
+}
+
+function promptFromLine(line: string): {
+  readonly text: string;
+  readonly timestamp: unknown;
+  readonly runtimeId: string | null;
+} | null {
+  const value = parseJsonLine(line);
+  const record = parseRecord(value);
+  if (record === null) {
+    return null;
+  }
+  const text = cleanText(
+    extractText(record["prompt"] ?? record["text"] ?? record["content"]),
+  );
+  if (text.length === 0) {
+    return null;
+  }
+  return {
+    text,
+    timestamp:
+      record["timestamp"] ??
+      record["created_at"] ??
+      record["time"] ??
+      record["ts"],
+    runtimeId:
+      stringValue(record["session_id"]) ??
+      stringValue(record["sessionId"]) ??
+      stringValue(record["thread_id"]) ??
+      stringValue(record["threadId"]),
+  };
+}
+
+export async function scanCodexHistoryJsonl(
+  filePath: string,
+): Promise<HistoryDocument[]> {
+  const raw = await Bun.file(filePath).text();
+  const info = await stat(filePath);
+  return raw
+    .split("\n")
+    .map((line, index) => ({ line: line.trim(), index }))
+    .filter((entry) => entry.line.length > 0)
+    .flatMap((entry) => {
+      const prompt = promptFromLine(entry.line);
+      if (prompt === null) {
+        return [];
+      }
+      const updatedAt = parseTimestamp(
+        prompt.timestamp,
+        new Date(info.mtimeMs),
+      );
+      const id = sourceId(filePath, entry.index + 1);
+      return [
+        makeHistoryDocument(
+          {
+            source: "codex",
+            sourceId: id,
+            title: firstText(prompt.text, "Codex history entry"),
+            path: filePath,
+            workspace: null,
+            agent: "Codex",
+            createdAt: updatedAt,
+            updatedAt,
+            runtimeId: prompt.runtimeId,
+          },
+          prompt.text.length === 0
+            ? []
+            : [{ role: "user", text: prompt.text, createdAt: updatedAt }],
+        ),
+      ];
+    });
+}
+
+export async function readCodexHistoryJsonl(
+  filePath: string,
+  selectedSourceIds: ReadonlySet<string>,
+): Promise<ReadonlyMap<string, readonly HistoryMessage[]>> {
+  const prefix = `${filePath}:line:`;
+  const selectedLines = new Set(
+    [...selectedSourceIds].flatMap((id) => {
+      if (!id.startsWith(prefix)) {
+        return [];
+      }
+      const line = Number.parseInt(id.slice(prefix.length), 10);
+      return Number.isInteger(line) && line > 0 ? [line] : [];
+    }),
+  );
+  if (selectedLines.size === 0) {
+    return new Map();
+  }
+
+  const info = await stat(filePath);
+  const latestSelectedLine = Math.max(...selectedLines);
+  const messages = new Map<string, readonly HistoryMessage[]>();
+  const reader = Bun.file(filePath).stream().getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let lineNumber = 0;
+  let done = false;
+  while (!done && lineNumber < latestSelectedLine) {
+    const chunk = await reader.read();
+    done = chunk.done;
+    buffered += decoder.decode(chunk.value, { stream: !done });
+    let newline = buffered.indexOf("\n");
+    while (newline !== -1) {
+      lineNumber += 1;
+      const line = buffered.slice(0, newline).trim();
+      buffered = buffered.slice(newline + 1);
+      if (selectedLines.has(lineNumber) && line.length > 0) {
+        const prompt = promptFromLine(line);
+        if (prompt !== null) {
+          const createdAt = parseTimestamp(
+            prompt.timestamp,
+            new Date(info.mtimeMs),
+          );
+          messages.set(sourceId(filePath, lineNumber), [
+            { role: "user", text: prompt.text, createdAt },
+          ]);
+        }
+      }
+      if (lineNumber >= latestSelectedLine) {
+        break;
+      }
+      newline = buffered.indexOf("\n");
+    }
+  }
+  if (
+    lineNumber < latestSelectedLine &&
+    buffered.trim().length > 0 &&
+    selectedLines.has(lineNumber + 1)
+  ) {
+    const finalLine = lineNumber + 1;
+    const prompt = promptFromLine(buffered.trim());
+    if (prompt !== null) {
+      const createdAt = parseTimestamp(
+        prompt.timestamp,
+        new Date(info.mtimeMs),
+      );
+      messages.set(sourceId(filePath, finalLine), [
+        { role: "user", text: prompt.text, createdAt },
+      ]);
+    }
+  }
+  await reader.cancel();
+  return messages;
+}

--- a/packages/toolkit/src/lib/history/conductor.ts
+++ b/packages/toolkit/src/lib/history/conductor.ts
@@ -1,0 +1,263 @@
+import type { Database } from "bun:sqlite";
+import {
+  historyMessageRole,
+  INDEXED_MESSAGE_PARSE_LIMIT,
+  makeHistoryDocument,
+  parseConversationEnvelope,
+} from "./messages.ts";
+import type { HistoryPaths } from "./paths.ts";
+import {
+  firstText,
+  pathExists,
+  readDatabase,
+  requireTables,
+  rowValue,
+  rows,
+  RowSchema,
+  sourceReadResult,
+  sourceResult,
+} from "./sources-shared.ts";
+import { parseJsonLine, parseTimestamp, stringValue } from "./text.ts";
+import type {
+  HistoryMessage,
+  HistoryRecord,
+  HistorySource,
+  HistorySourceReadResult,
+  HistorySourceResult,
+} from "./types.ts";
+
+function placeholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function batches<T>(values: readonly T[], size = 8): T[][] {
+  const result: T[][] = [];
+  for (let offset = 0; offset < values.length; offset += size) {
+    result.push(values.slice(offset, offset + size));
+  }
+  return result;
+}
+
+function conductorMessages(
+  database: Database,
+  sessionIds: readonly string[],
+  maxCharacters = Number.POSITIVE_INFINITY,
+): ReadonlyMap<string, readonly HistoryMessage[]> {
+  if (sessionIds.length === 0) {
+    return new Map();
+  }
+  const messages = new Map<string, HistoryMessage[]>(
+    sessionIds.map((sessionId) => [sessionId, []]),
+  );
+  for (const batch of batches(sessionIds)) {
+    const messageRows = rows(
+      database,
+      `SELECT id, session_id, length(COALESCE(content, full_message, '')) AS content_length
+         FROM session_messages
+        WHERE session_id IN (${placeholders(batch.length)})
+        ORDER BY session_id, created_at, id`,
+      RowSchema,
+      batch,
+    );
+    const readMessage = database.prepare(
+      `SELECT role, content, full_message, created_at
+         FROM session_messages WHERE id = ?`,
+    );
+    const readBoundedMessage = database.prepare(
+      `WITH selected AS (
+         SELECT role, created_at, COALESCE(content, full_message, '') AS raw
+           FROM session_messages WHERE id = ?
+       )
+       SELECT role, created_at,
+              CASE WHEN json_valid(raw)
+                   THEN json_extract(raw, '$.type')
+                   ELSE NULL END AS envelope_type,
+              CASE WHEN json_valid(raw)
+                   THEN json_extract(raw, '$.message.role')
+                   ELSE NULL END AS nested_role,
+              NULL AS block_type,
+              CASE WHEN json_valid(raw)
+                   THEN CASE WHEN json_type(raw, '$.message.content') = 'array'
+                        THEN (
+                          SELECT json_object(
+                            'type', json_extract(raw, '$.type'),
+                            'message', json_object(
+                              'role', json_extract(raw, '$.message.role'),
+                              'content', json(json_group_array(json_object(
+                                'type', CASE WHEN block.type = 'object'
+                                             THEN json_extract(block.value, '$.type')
+                                             ELSE NULL END,
+                                'text', substr(
+                                  CASE WHEN block.type = 'object'
+                                       THEN COALESCE(
+                                         json_extract(block.value, '$.text'),
+                                         json_extract(block.value, '$.content'),
+                                         json_extract(block.value, '$.input.command'),
+                                         json_extract(block.value, '$.name'),
+                                         ''
+                                       )
+                                       ELSE CAST(block.value AS TEXT) END,
+                                  1,
+                                  max(1, CAST(? / max((
+                                    SELECT count(*)
+                                      FROM json_each(raw, '$.message.content')
+                                  ), 1) AS INTEGER))
+                                )
+                              )))
+                            )
+                          )
+                            FROM json_each(raw, '$.message.content') AS block
+                        )
+                        ELSE NULL END
+                   ELSE NULL END AS bounded_envelope,
+              substr(
+                CASE WHEN json_valid(raw)
+                     THEN COALESCE(
+                       json_extract(raw, '$.message.text'),
+                       CASE WHEN json_type(raw, '$.message.content') = 'text'
+                            THEN json_extract(raw, '$.message.content')
+                            ELSE NULL END,
+                       json_extract(raw, '$.text'),
+                       CASE WHEN json_type(raw, '$.content') = 'text'
+                            THEN json_extract(raw, '$.content')
+                            ELSE '' END
+                     )
+                     ELSE raw END,
+                1, ?
+              ) AS indexed_text
+         FROM selected`,
+    );
+    for (const metadata of messageRows) {
+      const sessionId = String(rowValue(metadata, "session_id"));
+      const contentLength = Number(rowValue(metadata, "content_length"));
+      const messageId = String(rowValue(metadata, "id"));
+      const bounded =
+        Number.isFinite(maxCharacters) && contentLength > maxCharacters * 4;
+      const row = RowSchema.parse(
+        bounded
+          ? readBoundedMessage.get(messageId, maxCharacters, maxCharacters)
+          : readMessage.get(messageId),
+      );
+      const raw =
+        stringValue(rowValue(row, "content")) ??
+        stringValue(rowValue(row, "full_message"));
+      const indexedText = stringValue(rowValue(row, "indexed_text"));
+      const boundedEnvelope = stringValue(rowValue(row, "bounded_envelope"));
+      if (raw === null && indexedText === null && boundedEnvelope === null) {
+        continue;
+      }
+      const timestamp = stringValue(rowValue(row, "created_at"));
+      const blockType = stringValue(rowValue(row, "block_type"));
+      const envelopeType = stringValue(rowValue(row, "envelope_type"));
+      const nestedRole = stringValue(rowValue(row, "nested_role"));
+      const parsed =
+        raw === null
+          ? (parseJsonLine(boundedEnvelope ?? "") ?? {
+              type: envelopeType,
+              message: {
+                role: nestedRole,
+                content:
+                  blockType === null
+                    ? indexedText
+                    : [{ type: blockType, text: indexedText }],
+              },
+            })
+          : (parseJsonLine(raw) ?? raw);
+      const entries = parseConversationEnvelope(
+        parsed,
+        historyMessageRole(rowValue(row, "role")),
+        timestamp === null ? null : parseTimestamp(timestamp, new Date(0)),
+        maxCharacters,
+      );
+      const existing = messages.get(sessionId) ?? [];
+      existing.push(...entries);
+      messages.set(sessionId, existing);
+    }
+  }
+  return messages;
+}
+
+async function scanConductor(
+  paths: HistoryPaths,
+): Promise<HistorySourceResult> {
+  const files = (await pathExists(paths.conductorDb))
+    ? [paths.conductorDb]
+    : [];
+  return sourceResult("conductor", files, () => {
+    const database = readDatabase(paths.conductorDb);
+    try {
+      requireTables(database, "Conductor", ["sessions", "session_messages"]);
+      const sessionRows = rows(
+        database,
+        `SELECT id, title, created_at, updated_at, model, agent_type, workspace_id
+           FROM sessions`,
+        RowSchema,
+      );
+      const sessionIds = sessionRows.map((row) => String(rowValue(row, "id")));
+      const messages = conductorMessages(
+        database,
+        sessionIds,
+        INDEXED_MESSAGE_PARSE_LIMIT,
+      );
+      return sessionRows.map((row) => {
+        const sourceId = String(rowValue(row, "id"));
+        const title = stringValue(rowValue(row, "title")) ?? "Untitled";
+        const createdAt = parseTimestamp(
+          rowValue(row, "created_at"),
+          new Date(0),
+        );
+        return makeHistoryDocument(
+          {
+            source: "conductor",
+            sourceId,
+            title: firstText(title, "Conductor session"),
+            path: paths.conductorDb,
+            workspace: stringValue(rowValue(row, "workspace_id")),
+            agent:
+              stringValue(rowValue(row, "agent_type")) ??
+              stringValue(rowValue(row, "model")),
+            createdAt,
+            updatedAt: parseTimestamp(rowValue(row, "updated_at"), new Date(0)),
+            runtimeId: sourceId,
+          },
+          messages.get(sourceId) ?? [],
+        );
+      });
+    } finally {
+      database.close();
+    }
+  });
+}
+
+async function readConductor(
+  paths: HistoryPaths,
+  records: readonly HistoryRecord[],
+): Promise<HistorySourceReadResult> {
+  const requestedSourceIds = records.map((record) => record.sourceId);
+  return sourceReadResult("conductor", requestedSourceIds, () => {
+    const database = readDatabase(paths.conductorDb);
+    try {
+      requireTables(database, "Conductor", ["sessions", "session_messages"]);
+      const existingIds = batches(requestedSourceIds).flatMap((batch) =>
+        rows(
+          database,
+          `SELECT id FROM sessions WHERE id IN (${placeholders(batch.length)})`,
+          RowSchema,
+          batch,
+        ).map((row) => String(rowValue(row, "id"))),
+      );
+      return conductorMessages(database, existingIds);
+    } finally {
+      database.close();
+    }
+  });
+}
+
+export function createConductorSource(): HistorySource {
+  return {
+    name: "conductor",
+    label: "Conductor",
+    scan: scanConductor,
+    read: readConductor,
+  };
+}

--- a/packages/toolkit/src/lib/history/context.ts
+++ b/packages/toolkit/src/lib/history/context.ts
@@ -1,0 +1,231 @@
+import { cleanText, excerptForQuery } from "./text.ts";
+import {
+  historyQueryParts,
+  queryPartIndex,
+  searchTokens,
+  type HistoryQueryPart,
+} from "./query.ts";
+import type { HistoryMessage } from "./types.ts";
+
+const SHOW_CHARACTER_LIMIT = 6000;
+
+function partMatches(
+  tokens: readonly string[],
+  part: HistoryQueryPart,
+): boolean {
+  return queryPartIndex(tokens, part) >= 0;
+}
+
+export function messageMatchesQuery(text: string, query: string): boolean {
+  const tokens = searchTokens(cleanText(text));
+  const parts = historyQueryParts(query);
+  return parts.length > 0 && parts.every((part) => partMatches(tokens, part));
+}
+
+function matchScore(text: string, query: string): number {
+  const tokens = searchTokens(cleanText(text));
+  return historyQueryParts(query).reduce((score, part) => {
+    const first = queryPartIndex(tokens, part);
+    if (first === -1) {
+      return score;
+    }
+    return score + (part.type === "phrase" ? 10 : 1) + 1 / (first + 1);
+  }, 0);
+}
+
+function boundedMessages(
+  messages: readonly HistoryMessage[],
+  limit: number,
+  query: string | null,
+  priorityIndex: number | null = null,
+): {
+  readonly messages: readonly HistoryMessage[];
+  readonly truncated: boolean;
+} {
+  const window = messages.slice(0, limit);
+  const visitOrder =
+    priorityIndex === null
+      ? window.map((_, index) => index)
+      : window
+          .map((_, index) => index)
+          .sort(
+            (left, right) =>
+              Math.abs(left - priorityIndex) -
+                Math.abs(right - priorityIndex) || left - right,
+          );
+  const selected: { readonly index: number; readonly entry: HistoryMessage }[] =
+    [];
+  let characters = 0;
+  let truncated = messages.length > limit;
+  for (const [visitIndex, index] of visitOrder.entries()) {
+    const entry = window[index];
+    if (entry === undefined) {
+      throw new Error(`History message ${String(index)} is missing`);
+    }
+    const remaining = SHOW_CHARACTER_LIMIT - characters;
+    if (remaining <= 0) {
+      truncated = true;
+      break;
+    }
+    const remainingEntries = visitOrder.length - visitIndex;
+    const entryLimit = Math.max(1, Math.floor(remaining / remainingEntries));
+    if (entry.text.length <= entryLimit) {
+      selected.push({ index, entry });
+      characters += entry.text.length;
+      continue;
+    }
+    const text =
+      query === null || !messageMatchesQuery(entry.text, query)
+        ? `${entry.text.slice(0, Math.max(0, entryLimit - 1))}…`
+        : excerptForQuery(entry.text, query, entryLimit);
+    if (
+      query === null ||
+      entry.role !== "tool" ||
+      messageMatchesQuery(text, query)
+    ) {
+      selected.push({ index, entry: { ...entry, text } });
+      characters += text.length;
+    }
+    truncated = true;
+  }
+  return {
+    messages: selected
+      .sort((left, right) => left.index - right.index)
+      .map(({ entry }) => entry),
+    truncated,
+  };
+}
+
+export function selectShowMessages(
+  messages: readonly HistoryMessage[],
+  options: {
+    readonly query: string | null;
+    readonly messageLimit: number;
+    readonly includeTools: boolean;
+  },
+): {
+  readonly messages: readonly HistoryMessage[];
+  readonly truncated: boolean;
+} {
+  if (messages.length === 0) {
+    return { messages: [], truncated: false };
+  }
+  if (options.query !== null) {
+    const eligible = messages.filter(
+      (entry) =>
+        entry.role !== "tool" ||
+        options.includeTools ||
+        messageMatchesQuery(entry.text, options.query ?? ""),
+    );
+    const candidates = eligible.map((entry, index) => ({ entry, index }));
+    const matchingDialogue = candidates.filter(
+      ({ entry }) =>
+        entry.role !== "tool" &&
+        messageMatchesQuery(entry.text, options.query ?? ""),
+    );
+    const matchingTools = candidates.filter(
+      ({ entry }) =>
+        entry.role === "tool" &&
+        messageMatchesQuery(entry.text, options.query ?? ""),
+    );
+    const partialDialogue = candidates.filter(
+      ({ entry }) => entry.role !== "tool",
+    );
+    const centeringCandidates =
+      matchingDialogue.length > 0
+        ? matchingDialogue
+        : matchingTools.length > 0
+          ? matchingTools
+          : partialDialogue;
+    const best = centeringCandidates.reduce<{
+      readonly index: number;
+      readonly score: number;
+    } | null>((current, candidate) => {
+      const score = matchScore(candidate.entry.text, options.query ?? "");
+      return current === null || score > current.score
+        ? { index: candidate.index, score }
+        : current;
+    }, null);
+    const center = best?.index ?? Math.max(0, eligible.length - 1);
+    const start = Math.max(
+      0,
+      Math.min(
+        center - Math.floor(options.messageLimit / 2),
+        eligible.length - options.messageLimit,
+      ),
+    );
+    const window = eligible.slice(start, start + options.messageLimit);
+    const bounded = boundedMessages(
+      window,
+      options.messageLimit,
+      options.query,
+      center - start,
+    );
+    return {
+      messages: bounded.messages,
+      truncated:
+        bounded.truncated ||
+        eligible.length !== messages.length ||
+        start > 0 ||
+        start + window.length < eligible.length,
+    };
+  }
+
+  const eligible = options.includeTools
+    ? [...messages]
+    : messages.filter((entry) => entry.role !== "tool");
+  const openingIndex = eligible.findIndex((entry) => entry.role === "user");
+  const opening = openingIndex === -1 ? null : (eligible[openingIndex] ?? null);
+  const tailCount = Math.max(
+    0,
+    options.messageLimit - (opening === null ? 0 : 1),
+  );
+  const tail = eligible
+    .filter((_, index) => index !== openingIndex)
+    .slice(-tailCount);
+  const selected =
+    opening === null
+      ? eligible.slice(-options.messageLimit)
+      : [opening, ...tail];
+  const bounded = boundedMessages(selected, options.messageLimit, null);
+  return {
+    messages: bounded.messages,
+    truncated:
+      bounded.truncated ||
+      eligible.length !== messages.length ||
+      selected.length < eligible.length,
+  };
+}
+
+export function dialogueFirstExcerpt(
+  messages: readonly HistoryMessage[],
+  query: string,
+): string {
+  const dialogue = messages
+    .filter((entry) => entry.role !== "tool")
+    .map((entry) => entry.text)
+    .join("\n");
+  const tools = messages
+    .filter((entry) => entry.role === "tool")
+    .map((entry) => entry.text)
+    .join("\n");
+  return excerptForQuery(
+    [dialogue, tools].filter((text) => text.length > 0).join("\n"),
+    query,
+  );
+}
+
+export function parseMessageLimit(value: string | undefined): number {
+  if (value === undefined) {
+    return 8;
+  }
+  const limit = Number(value);
+  if (
+    !/^[1-9]\d*$/u.test(value) ||
+    !Number.isSafeInteger(limit) ||
+    limit > 50
+  ) {
+    throw new RangeError("Messages must be an integer from 1 to 50");
+  }
+  return limit;
+}

--- a/packages/toolkit/src/lib/history/cursor.ts
+++ b/packages/toolkit/src/lib/history/cursor.ts
@@ -1,0 +1,194 @@
+import {
+  dialogueText,
+  INDEXED_MESSAGE_PARSE_LIMIT,
+  openingPrompt,
+  openingPromptHash,
+  toolOutputText,
+} from "./messages.ts";
+import type { HistoryPaths } from "./paths.ts";
+import {
+  firstText,
+  pathExists,
+  readCursorDatabase,
+  requireTables,
+  rowValue,
+  rows,
+  RowSchema,
+  sourceReadResult,
+  sourceResult,
+} from "./sources-shared.ts";
+import { cleanText, parseTimestamp, stringValue } from "./text.ts";
+import type {
+  HistoryDocument,
+  HistoryMessage,
+  HistoryRecord,
+  HistorySource,
+} from "./types.ts";
+
+const CURSOR_INDEX_WINDOW_LIMIT = 16;
+
+function cursorBodyMessages(
+  body: string,
+  createdAt: string,
+  maxCharacters: number,
+): readonly HistoryMessage[] {
+  if (body.length === 0) {
+    return [];
+  }
+  if (!Number.isFinite(maxCharacters)) {
+    return [{ role: "unknown", text: body, createdAt }];
+  }
+  const windowSize = Math.max(1, Math.floor(maxCharacters / 2));
+  const windowCount = Math.min(
+    CURSOR_INDEX_WINDOW_LIMIT,
+    Math.ceil(body.length / windowSize),
+  );
+  return Array.from({ length: windowCount }, (_, index) => {
+    const offset =
+      windowCount === 1
+        ? 0
+        : Math.round(
+            (index * Math.max(0, body.length - windowSize)) / (windowCount - 1),
+          );
+    return {
+      role: "unknown",
+      text: body.slice(offset, offset + windowSize),
+      createdAt,
+    } satisfies HistoryMessage;
+  });
+}
+
+async function cursorDocuments(
+  filePath: string,
+  selectedIds: ReadonlySet<string> | null = null,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): Promise<HistoryDocument[]> {
+  const database = await readCursorDatabase(filePath);
+  try {
+    requireTables(database, "Cursor conversation search", [
+      "conversations",
+      "conversation_fts",
+    ]);
+    const cursorIds =
+      selectedIds === null
+        ? []
+        : [...selectedIds].map((sourceId) =>
+            sourceId.slice(sourceId.lastIndexOf(":") + 1),
+          );
+    const selection =
+      cursorIds.length === 0
+        ? ""
+        : ` WHERE c.id IN (${Array.from({ length: cursorIds.length }, () => "?").join(", ")})`;
+    const conversationRows = rows(
+      database,
+      `SELECT c.fts_rowid, c.source, c.scope, c.id, c.title, c.updated_at, f.body
+         FROM conversations c
+         JOIN conversation_fts f ON f.rowid = c.fts_rowid${selection}`,
+      RowSchema,
+      cursorIds,
+    );
+    return conversationRows.flatMap((row) => {
+      const sourceId = `${String(rowValue(row, "source"))}:${String(rowValue(row, "scope"))}:${String(rowValue(row, "id"))}`;
+      if (selectedIds !== null && !selectedIds.has(sourceId)) {
+        return [];
+      }
+      const title =
+        stringValue(rowValue(row, "title")) ?? "Cursor conversation";
+      const body = cleanText(stringValue(rowValue(row, "body")) ?? "");
+      const updatedAt = parseTimestamp(
+        rowValue(row, "updated_at"),
+        new Date(0),
+      );
+      const messages = cursorBodyMessages(body, updatedAt, maxCharacters);
+      return [
+        {
+          source: "cursor",
+          sourceId,
+          title: firstText(title, "Cursor conversation"),
+          path: filePath,
+          workspace: stringValue(rowValue(row, "scope")),
+          agent: "Cursor",
+          createdAt: updatedAt,
+          updatedAt,
+          runtimeId: String(rowValue(row, "id")),
+          openingPromptHash: openingPromptHash(openingPrompt(messages)),
+          dialogueText: dialogueText(messages),
+          toolOutputText: toolOutputText(messages),
+        } satisfies HistoryDocument,
+      ];
+    });
+  } finally {
+    database.close();
+  }
+}
+
+async function cursorMessages(
+  filePath: string,
+  records: readonly HistoryRecord[],
+): Promise<ReadonlyMap<string, readonly HistoryMessage[]>> {
+  if (records.length === 0) {
+    return new Map();
+  }
+  const selectedIds = new Set(records.map((record) => record.sourceId));
+  const cursorIds = records.map((record) =>
+    record.sourceId.slice(record.sourceId.lastIndexOf(":") + 1),
+  );
+  const database = await readCursorDatabase(filePath);
+  try {
+    requireTables(database, "Cursor conversation search", [
+      "conversations",
+      "conversation_fts",
+    ]);
+    const conversationRows = rows(
+      database,
+      `SELECT c.source, c.scope, c.id, c.updated_at, f.body
+         FROM conversations c
+         JOIN conversation_fts f ON f.rowid = c.fts_rowid
+        WHERE c.id IN (${Array.from({ length: cursorIds.length }, () => "?").join(", ")})`,
+      RowSchema,
+      cursorIds,
+    );
+    return new Map(
+      conversationRows.flatMap((row) => {
+        const sourceId = `${String(rowValue(row, "source"))}:${String(rowValue(row, "scope"))}:${String(rowValue(row, "id"))}`;
+        if (!selectedIds.has(sourceId)) {
+          return [];
+        }
+        const text = cleanText(stringValue(rowValue(row, "body")) ?? "");
+        const updatedAt = parseTimestamp(
+          rowValue(row, "updated_at"),
+          new Date(0),
+        );
+        return [[sourceId, cursorBodyMessages(text, updatedAt, Infinity)]];
+      }),
+    );
+  } finally {
+    database.close();
+  }
+}
+
+export function createCursorSource(): HistorySource {
+  return {
+    name: "cursor",
+    label: "Cursor",
+    async scan(paths: HistoryPaths) {
+      const files = (await pathExists(paths.cursorConversationDb))
+        ? [paths.cursorConversationDb]
+        : [];
+      return sourceResult("cursor", files, () =>
+        cursorDocuments(
+          paths.cursorConversationDb,
+          null,
+          INDEXED_MESSAGE_PARSE_LIMIT,
+        ),
+      );
+    },
+    async read(paths: HistoryPaths, records: readonly HistoryRecord[]) {
+      return sourceReadResult(
+        "cursor",
+        records.map((record) => record.sourceId),
+        () => cursorMessages(paths.cursorConversationDb, records),
+      );
+    },
+  };
+}

--- a/packages/toolkit/src/lib/history/index.ts
+++ b/packages/toolkit/src/lib/history/index.ts
@@ -3,12 +3,25 @@ import { chmod, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import type { HistoryRuntimePaths } from "./paths.ts";
+import { ftsQuery } from "./query.ts";
 import type {
-  HistoryRecord,
   HistorySourceName,
+  HistoryRuntimeRef,
   HistorySourceResult,
   HistorySourceStatus,
+  IndexedHistoryRecord,
 } from "./types.ts";
+
+const INDEX_SCHEMA_VERSION = 2;
+
+type HistoryQueryOptions = {
+  readonly since: string | null;
+  readonly source: HistorySourceName | null;
+  readonly limit?: number;
+  readonly offset?: number;
+  readonly openingPromptHash?: string;
+  readonly excludedRuntimes?: readonly HistoryRuntimeRef[];
+};
 
 const DocumentRowSchema = z.object({
   id: z.number(),
@@ -20,6 +33,8 @@ const DocumentRowSchema = z.object({
   agent: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
+  runtime_id: z.string().nullable(),
+  opening_prompt_hash: z.string().nullable(),
 });
 
 const StatusRowSchema = z.object({
@@ -29,6 +44,38 @@ const StatusRowSchema = z.object({
   available: z.number(),
   error: z.string().nullable(),
 });
+
+const SourceStateRowSchema = z.object({
+  fingerprint: z.string(),
+  available: z.number(),
+  error: z.string().nullable(),
+});
+
+function sourceNeedsIngest(
+  force: boolean,
+  fingerprint: string,
+  previousState: z.infer<typeof SourceStateRowSchema> | null,
+): boolean {
+  return (
+    force ||
+    previousState?.available !== 1 ||
+    previousState.error !== null ||
+    previousState.fingerprint !== fingerprint
+  );
+}
+
+function addRuntimeExclusions(
+  clauses: string[],
+  values: (string | number)[],
+  exclusions: readonly HistoryRuntimeRef[],
+): void {
+  for (const exclusion of exclusions) {
+    clauses.push(
+      "(d.source != ? OR d.runtime_id IS NULL OR d.runtime_id != ?)",
+    );
+    values.push(exclusion.source, exclusion.runtimeId);
+  }
+}
 
 function parseSourceName(value: string): HistorySourceName {
   if (
@@ -44,13 +91,18 @@ function parseSourceName(value: string): HistorySourceName {
   throw new Error(`Unknown history source in index: ${value}`);
 }
 
-function hashText(text: string): string {
+function hashDocument(
+  title: string,
+  dialogue: string,
+  toolOutput: string,
+): string {
   const hasher = new Bun.CryptoHasher("sha256");
-  hasher.update(text);
+  hasher.update(JSON.stringify([title, dialogue, toolOutput]));
   return hasher.digest("hex");
 }
 
 async function secureIndexFiles(indexPath: string): Promise<void> {
+  await chmod(path.dirname(indexPath), 0o700);
   for (const candidate of [indexPath, `${indexPath}-wal`, `${indexPath}-shm`]) {
     if (await Bun.file(candidate).exists()) {
       await chmod(candidate, 0o600);
@@ -58,19 +110,9 @@ async function secureIndexFiles(indexPath: string): Promise<void> {
   }
 }
 
-function ftsQuery(query: string): string {
-  const terms = query
-    .split(/[^\p{L}\p{N}_-]+/u)
-    .map((term) => term.trim())
-    .filter((term) => term.length > 0)
-    .map((term) => `"${term.replaceAll('"', '""')}"*`);
-  if (terms.length === 0) {
-    throw new Error("Search query must contain at least one letter or number");
-  }
-  return terms.join(" AND ");
-}
-
-function toRecord(row: z.infer<typeof DocumentRowSchema>): HistoryRecord {
+function toRecord(
+  row: z.infer<typeof DocumentRowSchema>,
+): IndexedHistoryRecord {
   return {
     id: row.id,
     source: parseSourceName(row.source),
@@ -82,7 +124,63 @@ function toRecord(row: z.infer<typeof DocumentRowSchema>): HistoryRecord {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     excerpt: null,
+    runtimeId: row.runtime_id,
+    openingPromptHash: row.opening_prompt_hash,
   };
+}
+
+function schemaVersion(database: Database): number {
+  return z
+    .object({ user_version: z.number() })
+    .parse(database.query("PRAGMA user_version").get()).user_version;
+}
+
+function createSchema(database: Database): void {
+  database.run(`
+    CREATE TABLE documents (
+      id INTEGER PRIMARY KEY,
+      source TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      path TEXT NOT NULL,
+      workspace TEXT,
+      agent TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      runtime_id TEXT,
+      opening_prompt_hash TEXT,
+      content_hash TEXT NOT NULL,
+      UNIQUE(source, source_id)
+    );
+    CREATE VIRTUAL TABLE history_fts USING fts5(
+      title,
+      dialogue,
+      tool_output,
+      content = '',
+      contentless_delete = 1,
+      tokenize = 'unicode61 remove_diacritics 2'
+    );
+    CREATE TABLE source_state (
+      source TEXT PRIMARY KEY,
+      available INTEGER NOT NULL,
+      indexed_documents INTEGER NOT NULL,
+      fingerprint TEXT NOT NULL,
+      last_scan_at TEXT,
+      error TEXT
+    );
+    PRAGMA user_version = ${String(INDEX_SCHEMA_VERSION)};
+  `);
+}
+
+function rebuildSchema(database: Database): void {
+  database.transaction(() => {
+    database.run(`
+      DROP TABLE IF EXISTS history_fts;
+      DROP TABLE IF EXISTS documents;
+      DROP TABLE IF EXISTS source_state;
+    `);
+    createSchema(database);
+  })();
 }
 
 export class HistoryIndex {
@@ -99,48 +197,37 @@ export class HistoryIndex {
     readonly = false,
   ): Promise<HistoryIndex> {
     if (!readonly) {
-      await mkdir(path.dirname(runtimePaths.indexDb), { recursive: true });
+      await mkdir(path.dirname(runtimePaths.indexDb), {
+        recursive: true,
+        mode: 0o700,
+      });
     }
     const database = new Database(runtimePaths.indexDb, {
       readonly,
       create: !readonly,
       strict: true,
     });
+    const version = schemaVersion(database);
+    if (readonly && version !== INDEX_SCHEMA_VERSION) {
+      database.close();
+      throw new Error(
+        `History index schema is v${String(version)}; restart the daemon to rebuild v${String(INDEX_SCHEMA_VERSION)}.`,
+      );
+    }
     const index = new HistoryIndex(database, runtimePaths.indexDb);
     if (!readonly) {
-      index.#database.run(`
-        PRAGMA journal_mode = WAL;
-        PRAGMA busy_timeout = 5000;
-        CREATE TABLE IF NOT EXISTS documents (
-          id INTEGER PRIMARY KEY,
-          source TEXT NOT NULL,
-          source_id TEXT NOT NULL,
-          title TEXT NOT NULL,
-          path TEXT NOT NULL,
-          workspace TEXT,
-          agent TEXT,
-          created_at TEXT NOT NULL,
-          updated_at TEXT NOT NULL,
-          content_hash TEXT NOT NULL,
-          UNIQUE(source, source_id)
+      try {
+        index.#database.run(
+          "PRAGMA journal_mode = WAL; PRAGMA busy_timeout = 5000;",
         );
-        CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
-          title,
-          body,
-          content = '',
-          contentless_delete = 1,
-          tokenize = 'unicode61 remove_diacritics 2'
-        );
-        CREATE TABLE IF NOT EXISTS source_state (
-          source TEXT PRIMARY KEY,
-          available INTEGER NOT NULL,
-          indexed_documents INTEGER NOT NULL,
-          fingerprint TEXT NOT NULL,
-          last_scan_at TEXT,
-          error TEXT
-        );
-      `);
-      await secureIndexFiles(runtimePaths.indexDb);
+        if (version !== INDEX_SCHEMA_VERSION) {
+          rebuildSchema(index.#database);
+        }
+        await secureIndexFiles(runtimePaths.indexDb);
+      } catch (error) {
+        index.close();
+        throw error;
+      }
     }
     return index;
   }
@@ -149,14 +236,22 @@ export class HistoryIndex {
     this.#database.close();
   }
 
+  readSnapshot<T>(callback: () => T): T {
+    return this.#database.transaction(callback)();
+  }
+
   async ingest(
     results: readonly HistorySourceResult[],
     force = false,
   ): Promise<void> {
+    if (force) {
+      rebuildSchema(this.#database);
+    }
     const upsert = this.#database.prepare(`
       INSERT INTO documents
-        (source, source_id, title, path, workspace, agent, created_at, updated_at, content_hash)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (source, source_id, title, path, workspace, agent, created_at, updated_at,
+         runtime_id, opening_prompt_hash, content_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(source, source_id) DO UPDATE SET
         title = excluded.title,
         path = excluded.path,
@@ -164,13 +259,15 @@ export class HistoryIndex {
         agent = excluded.agent,
         created_at = excluded.created_at,
         updated_at = excluded.updated_at,
+        runtime_id = excluded.runtime_id,
+        opening_prompt_hash = excluded.opening_prompt_hash,
         content_hash = excluded.content_hash
     `);
     const findExisting = this.#database.prepare(
       "SELECT id, content_hash FROM documents WHERE source = ? AND source_id = ?",
     );
     const insertFts = this.#database.prepare(
-      "INSERT INTO history_fts(rowid, title, body) VALUES (?, ?, ?)",
+      "INSERT INTO history_fts(rowid, title, dialogue, tool_output) VALUES (?, ?, ?, ?)",
     );
     const deleteFts = this.#database.prepare(
       "DELETE FROM history_fts WHERE rowid = ?",
@@ -192,31 +289,34 @@ export class HistoryIndex {
 
     const transaction = this.#database.transaction(() => {
       for (const result of results) {
-        const existingIds = new Set(
-          this.#database
-            .prepare("SELECT id, source_id FROM documents WHERE source = ?")
-            .all(result.source)
-            .map((row: unknown) => {
-              const parsed = z
-                .object({ id: z.number(), source_id: z.string() })
-                .parse(row);
-              return parsed;
-            }),
-        );
+        const existingIds = this.#database
+          .prepare("SELECT id, source_id FROM documents WHERE source = ?")
+          .all(result.source)
+          .map((row: unknown) =>
+            z.object({ id: z.number(), source_id: z.string() }).parse(row),
+          );
         const seenIds = new Set<string>();
         const stateRow = this.#database
-          .prepare("SELECT fingerprint FROM source_state WHERE source = ?")
+          .prepare(
+            "SELECT fingerprint, available, error FROM source_state WHERE source = ?",
+          )
           .get(result.source);
-        const previousFingerprint =
-          stateRow == null
-            ? null
-            : z.object({ fingerprint: z.string() }).parse(stateRow).fingerprint;
-        const changed = force || previousFingerprint !== result.fingerprint;
+        const previousState =
+          stateRow == null ? null : SourceStateRowSchema.parse(stateRow);
+        const changed = sourceNeedsIngest(
+          force,
+          result.fingerprint,
+          previousState,
+        );
 
         if (changed && result.available && result.error === null) {
           for (const document of result.documents) {
             seenIds.add(document.sourceId);
-            const contentHash = hashText(document.searchText);
+            const contentHash = hashDocument(
+              document.title,
+              document.dialogueText,
+              document.toolOutputText,
+            );
             const existing = findExisting.get(
               document.source,
               document.sourceId,
@@ -229,61 +329,32 @@ export class HistoryIndex {
                     .parse(existing);
             if (
               existingRow !== null &&
-              existingRow.content_hash === contentHash
+              existingRow.content_hash !== contentHash
             ) {
-              upsert.run(
-                document.source,
-                document.sourceId,
-                document.title,
-                document.path,
-                document.workspace,
-                document.agent,
-                document.createdAt,
-                document.updatedAt,
-                contentHash,
-              );
-              continue;
-            }
-            if (existingRow === null) {
-              upsert.run(
-                document.source,
-                document.sourceId,
-                document.title,
-                document.path,
-                document.workspace,
-                document.agent,
-                document.createdAt,
-                document.updatedAt,
-                contentHash,
-              );
-              const replacement = z
-                .object({ id: z.number() })
-                .parse(findExisting.get(document.source, document.sourceId));
-              insertFts.run(
-                replacement.id,
-                document.title,
-                document.searchText,
-              );
-            } else {
               deleteFts.run(existingRow.id);
-              upsert.run(
-                document.source,
-                document.sourceId,
-                document.title,
-                document.path,
-                document.workspace,
-                document.agent,
-                document.createdAt,
-                document.updatedAt,
-                contentHash,
-              );
+            }
+            upsert.run(
+              document.source,
+              document.sourceId,
+              document.title,
+              document.path,
+              document.workspace,
+              document.agent,
+              document.createdAt,
+              document.updatedAt,
+              document.runtimeId,
+              document.openingPromptHash,
+              contentHash,
+            );
+            if (existingRow?.content_hash !== contentHash) {
               const replacement = z
                 .object({ id: z.number() })
                 .parse(findExisting.get(document.source, document.sourceId));
               insertFts.run(
                 replacement.id,
                 document.title,
-                document.searchText,
+                document.dialogueText,
+                document.toolOutputText,
               );
             }
           }
@@ -315,24 +386,16 @@ export class HistoryIndex {
   }
 
   private count(source: HistorySourceName): number {
-    const row = z
+    return z
       .object({ count: z.number() })
       .parse(
         this.#database
           .prepare("SELECT count(*) AS count FROM documents WHERE source = ?")
           .get(source),
-      );
-    return row.count;
+      ).count;
   }
 
-  search(
-    query: string,
-    options: {
-      since: string | null;
-      source: HistorySourceName | null;
-      limit: number;
-    },
-  ): HistoryRecord[] {
+  search(query: string, options: HistoryQueryOptions): IndexedHistoryRecord[] {
     const clauses = ["history_fts MATCH ?"];
     const values: (string | number)[] = [ftsQuery(query)];
     if (options.since !== null) {
@@ -343,110 +406,92 @@ export class HistoryIndex {
       clauses.push("d.source = ?");
       values.push(options.source);
     }
-    values.push(options.limit);
+    if (options.openingPromptHash !== undefined) {
+      clauses.push("d.opening_prompt_hash = ?");
+      values.push(options.openingPromptHash);
+    }
+    addRuntimeExclusions(clauses, values, options.excludedRuntimes ?? []);
+    const pagination = options.limit === undefined ? "" : " LIMIT ? OFFSET ?";
+    if (options.limit !== undefined) {
+      values.push(options.limit, options.offset ?? 0);
+    }
     return this.#database
       .prepare(
         `SELECT d.id, d.source, d.source_id, d.title, d.path, d.workspace,
-                d.agent, d.created_at, d.updated_at
+                d.agent, d.created_at, d.updated_at, d.runtime_id,
+                d.opening_prompt_hash
            FROM history_fts
-           JOIN documents d ON d.id = history_fts.rowid
+          JOIN documents d ON d.id = history_fts.rowid
           WHERE ${clauses.join(" AND ")}
-          ORDER BY d.updated_at DESC
-          LIMIT ?`,
+          ORDER BY bm25(history_fts, 8.0, 3.0, 0.25), d.updated_at DESC,
+                   d.id ASC${pagination}`,
       )
       .all(...values)
       .map((row: unknown) => toRecord(DocumentRowSchema.parse(row)));
   }
 
-  recent(options: {
-    since: string | null;
-    source: HistorySourceName | null;
-    limit: number;
-  }): HistoryRecord[] {
+  recent(options: HistoryQueryOptions): IndexedHistoryRecord[] {
     const clauses: string[] = [];
     const values: (string | number)[] = [];
     if (options.since !== null) {
-      clauses.push("updated_at >= ?");
+      clauses.push("d.updated_at >= ?");
       values.push(options.since);
     }
     if (options.source !== null) {
-      clauses.push("source = ?");
+      clauses.push("d.source = ?");
       values.push(options.source);
     }
-    values.push(options.limit);
+    if (options.openingPromptHash !== undefined) {
+      clauses.push("d.opening_prompt_hash = ?");
+      values.push(options.openingPromptHash);
+    }
+    addRuntimeExclusions(clauses, values, options.excludedRuntimes ?? []);
+    const pagination = options.limit === undefined ? "" : " LIMIT ? OFFSET ?";
+    if (options.limit !== undefined) {
+      values.push(options.limit, options.offset ?? 0);
+    }
     return this.#database
       .prepare(
-        `SELECT id, source, source_id, title, path, workspace, agent, created_at, updated_at
-           FROM documents
+        `SELECT id, source, source_id, title, path, workspace, agent,
+                created_at, updated_at, runtime_id, opening_prompt_hash
+           FROM documents d
           ${clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : ""}
-          ORDER BY updated_at DESC
-          LIMIT ?`,
+          ORDER BY updated_at DESC, id ASC${pagination}`,
       )
       .all(...values)
       .map((row: unknown) => toRecord(DocumentRowSchema.parse(row)));
+  }
+
+  record(id: number): IndexedHistoryRecord | null {
+    const row = this.#database
+      .prepare(
+        `SELECT id, source, source_id, title, path, workspace, agent,
+                created_at, updated_at, runtime_id, opening_prompt_hash
+           FROM documents WHERE id = ?`,
+      )
+      .get(id);
+    return row == null ? null : toRecord(DocumentRowSchema.parse(row));
   }
 
   statuses(
     labels: ReadonlyMap<HistorySourceName, string>,
   ): HistorySourceStatus[] {
-    const rows = this.#database
+    return this.#database
       .prepare(
         "SELECT source, indexed_documents, last_scan_at, available, error FROM source_state ORDER BY source",
       )
       .all()
-      .map((row: unknown) => StatusRowSchema.parse(row));
-    return rows.map((row) => ({
-      source: parseSourceName(row.source),
-      label: labels.get(parseSourceName(row.source)) ?? row.source,
-      available: row.available === 1,
-      indexedDocuments: row.indexed_documents,
-      lastScanAt: row.last_scan_at,
-      error: row.error,
-    }));
+      .map((row: unknown) => StatusRowSchema.parse(row))
+      .map((row) => {
+        const source = parseSourceName(row.source);
+        return {
+          source,
+          label: labels.get(source) ?? row.source,
+          available: row.available === 1,
+          indexedDocuments: row.indexed_documents,
+          lastScanAt: row.last_scan_at,
+          error: row.error,
+        };
+      });
   }
-
-  allSourceRecords(source: HistorySourceName): HistoryRecord[] {
-    return this.#database
-      .prepare(
-        "SELECT id, source, source_id, title, path, workspace, agent, created_at, updated_at FROM documents WHERE source = ?",
-      )
-      .all(source)
-      .map((row: unknown) => toRecord(DocumentRowSchema.parse(row)));
-  }
-}
-
-export function parseLimit(value: string | undefined): number {
-  if (value === undefined) {
-    return 20;
-  }
-  const limit = Number.parseInt(value, 10);
-  if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
-    throw new Error("Limit must be an integer from 1 to 200");
-  }
-  return limit;
-}
-
-export function parseSince(
-  value: string | undefined,
-  now = new Date(),
-): string | null {
-  if (value === undefined) {
-    return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
-  }
-  const duration = /^(\d+)([hdw])$/u.exec(value.trim());
-  if (duration !== null) {
-    const amount = Number.parseInt(duration[1] ?? "", 10);
-    const unit = duration[2];
-    const multiplier = unit === "w" ? 7 : unit === "d" ? 1 : 1 / 24;
-    return new Date(
-      now.getTime() - amount * multiplier * 24 * 60 * 60 * 1000,
-    ).toISOString();
-  }
-  const timestamp = Date.parse(value);
-  if (Number.isNaN(timestamp)) {
-    throw new TypeError(
-      `Invalid --since value "${value}"; use 7d, 24h, 1w, or an ISO date`,
-    );
-  }
-  return new Date(timestamp).toISOString();
 }

--- a/packages/toolkit/src/lib/history/launchd.ts
+++ b/packages/toolkit/src/lib/history/launchd.ts
@@ -91,6 +91,22 @@ async function jobLoaded(domain: string): Promise<boolean> {
   return exitCode === 0;
 }
 
+async function bootoutIfLoaded(domain: string): Promise<void> {
+  if (!(await jobLoaded(domain))) {
+    return;
+  }
+  await launchctl(["bootout", `${domain}/${LABEL}`]);
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!(await jobLoaded(domain))) {
+      return;
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error(
+    `LaunchAgent ${LABEL} remained loaded after launchctl bootout`,
+  );
+}
+
 async function bootstrap(
   runtimePaths: HistoryRuntimePaths,
   domain: string,
@@ -129,9 +145,7 @@ export async function installLaunchAgent(
     await chmod(logPath, 0o600);
   }
   const domain = guiDomain();
-  if (await jobLoaded(domain)) {
-    await launchctl(["bootout", `${domain}/${LABEL}`]);
-  }
+  await bootoutIfLoaded(domain);
   await launchctl(["bootstrap", domain, runtimePaths.launchAgent]);
   console.log(`History LaunchAgent installed: ${runtimePaths.launchAgent}`);
 }
@@ -163,9 +177,7 @@ export async function stopLaunchAgent(
   }
   const installed = await Bun.file(runtimePaths.launchAgent).exists();
   const domain = guiDomain();
-  if (await jobLoaded(domain)) {
-    await launchctl(["bootout", `${domain}/${LABEL}`]);
-  }
+  await bootoutIfLoaded(domain);
   console.log(
     installed ? "History daemon stopped." : "History daemon was not installed.",
   );

--- a/packages/toolkit/src/lib/history/messages.ts
+++ b/packages/toolkit/src/lib/history/messages.ts
@@ -1,0 +1,313 @@
+import { cleanText, extractText, parseRecord, stringValue } from "./text.ts";
+import type {
+  HistoryDocument,
+  HistoryMessage,
+  HistoryMessageRole,
+} from "./types.ts";
+
+const OMITTED_BLOCK_TYPES = new Set([
+  "contextCompaction",
+  "redacted_thinking",
+  "reasoning",
+  "system",
+  "thinking",
+]);
+
+const TOOL_BLOCK_TYPES = new Set([
+  "command_execution",
+  "computer_initialize_state",
+  "file_change",
+  "function",
+  "function_call",
+  "function_call_output",
+  "image_view",
+  "mcp_tool_call",
+  "mcp_tool_result",
+  "tool",
+  "tool_result",
+  "tool_use",
+  "web_search",
+]);
+
+const INDEXED_DIALOGUE_MESSAGE_LIMIT = 4000;
+const INDEXED_DIALOGUE_DOCUMENT_LIMIT = 64_000;
+const INDEXED_TOOL_MESSAGE_LIMIT = 160;
+const INDEXED_TOOL_DOCUMENT_LIMIT = 2000;
+
+export const INDEXED_MESSAGE_PARSE_LIMIT = 8000;
+
+const messageEnvelopes = new WeakMap<HistoryMessage, object>();
+
+function roleFromValue(
+  value: unknown,
+  fallback: HistoryMessageRole,
+): HistoryMessageRole {
+  switch (value) {
+    case "user":
+    case "human":
+      return "user";
+    case "assistant":
+    case "agent":
+      return "assistant";
+    case "tool":
+      return "tool";
+    default:
+      return fallback;
+  }
+}
+
+export function historyMessageRole(value: unknown): HistoryMessageRole {
+  return roleFromValue(value, "unknown");
+}
+
+function isSystemText(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith("<system_instruction>") ||
+    trimmed.startsWith("<system-reminder>") ||
+    trimmed.startsWith("<system>")
+  );
+}
+
+function message(
+  role: HistoryMessageRole,
+  value: unknown,
+  createdAt: string | null,
+  maxCharacters: number,
+): HistoryMessage | null {
+  const text = cleanText(extractText(value, 0, maxCharacters));
+  if (text.length === 0 || isSystemText(text)) {
+    return null;
+  }
+  return { role, text, createdAt };
+}
+
+function messagesFromContent(
+  value: unknown,
+  role: HistoryMessageRole,
+  createdAt: string | null,
+  maxCharacters: number,
+): HistoryMessage[] {
+  if (!Array.isArray(value)) {
+    const parsed = message(role, value, createdAt, maxCharacters);
+    return parsed === null ? [] : [parsed];
+  }
+
+  const result: HistoryMessage[] = [];
+  const envelope = {};
+  for (const block of value) {
+    const record = parseRecord(block);
+    const blockType = stringValue(record?.["type"]);
+    if (blockType !== null && OMITTED_BLOCK_TYPES.has(blockType)) {
+      continue;
+    }
+    const blockRole =
+      blockType !== null && TOOL_BLOCK_TYPES.has(blockType) ? "tool" : role;
+    const parsed = message(blockRole, block, createdAt, maxCharacters);
+    if (parsed !== null) {
+      messageEnvelopes.set(parsed, envelope);
+      result.push(parsed);
+    }
+  }
+  return result;
+}
+
+export function parseConversationEnvelope(
+  value: unknown,
+  fallbackRole: HistoryMessageRole,
+  createdAt: string | null,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): HistoryMessage[] {
+  if (typeof value === "string") {
+    const parsed = message(fallbackRole, value, createdAt, maxCharacters);
+    return parsed === null ? [] : [parsed];
+  }
+  const record = parseRecord(value);
+  if (record === null) {
+    return [];
+  }
+  const envelopeType = stringValue(record["type"]);
+  if (envelopeType !== null && OMITTED_BLOCK_TYPES.has(envelopeType)) {
+    return [];
+  }
+  if (record["isMeta"] === true || record["is_meta"] === true) {
+    return [];
+  }
+
+  const nested = parseRecord(record["message"]);
+  if (nested !== null) {
+    if (nested["isMeta"] === true || nested["is_meta"] === true) {
+      return [];
+    }
+    const role = roleFromValue(
+      nested["role"],
+      roleFromValue(envelopeType, fallbackRole),
+    );
+    return messagesFromContent(
+      nested["content"] ?? nested["text"] ?? nested,
+      role,
+      createdAt,
+      maxCharacters,
+    );
+  }
+
+  const role = roleFromValue(
+    record["role"],
+    roleFromValue(envelopeType, fallbackRole),
+  );
+  return messagesFromContent(
+    record["content"] ?? record["text"] ?? record,
+    role,
+    createdAt,
+    maxCharacters,
+  );
+}
+
+export function parseCodexItem(
+  itemType: string,
+  value: unknown,
+  createdAt: string,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): HistoryMessage[] {
+  let role: HistoryMessageRole;
+  switch (itemType) {
+    case "userMessage":
+      role = "user";
+      break;
+    case "agentMessage":
+    case "plan":
+      role = "assistant";
+      break;
+    case "collabAgentToolCall":
+    case "commandExecution":
+    case "fileChange":
+    case "imageView":
+    case "mcpToolCall":
+    case "subAgentActivity":
+    case "webSearch":
+      role = "tool";
+      break;
+    case "contextCompaction":
+    case "reasoning":
+    case "system":
+      return [];
+    default:
+      return [];
+  }
+  const parsed = message(role, value, createdAt, maxCharacters);
+  return parsed === null ? [] : [parsed];
+}
+
+function boundedIndexedText(
+  messages: readonly HistoryMessage[],
+  include: (message: HistoryMessage) => boolean,
+  messageLimit: number,
+  documentLimit: number,
+): string {
+  const eligible = messages.filter((entry) => include(entry));
+  const maximumChunks = Math.max(1, Math.floor(documentLimit / 2));
+  const selected =
+    eligible.length <= maximumChunks
+      ? eligible
+      : Array.from({ length: maximumChunks }).flatMap((_, index) => {
+          const offset = Math.round(
+            (index * (eligible.length - 1)) / (maximumChunks - 1),
+          );
+          const entry = eligible[offset];
+          return entry === undefined ? [] : [entry];
+        });
+  const chunks: string[] = [];
+  let remaining = documentLimit;
+  for (const [index, entry] of selected.entries()) {
+    const separatorLength = chunks.length === 0 ? 0 : 1;
+    if (remaining <= separatorLength) {
+      break;
+    }
+    remaining -= separatorLength;
+    const remainingMessages = selected.length - index;
+    const fairShare = Math.max(1, Math.floor(remaining / remainingMessages));
+    const text = entry.text.slice(
+      0,
+      Math.min(messageLimit, fairShare, remaining),
+    );
+    if (text.length > 0) {
+      chunks.push(text);
+      remaining -= text.length;
+    }
+  }
+  return chunks.join("\n");
+}
+
+export function dialogueText(messages: readonly HistoryMessage[]): string {
+  return boundedIndexedText(
+    messages,
+    (entry) => entry.role !== "tool",
+    INDEXED_DIALOGUE_MESSAGE_LIMIT,
+    INDEXED_DIALOGUE_DOCUMENT_LIMIT,
+  );
+}
+
+export function toolOutputText(messages: readonly HistoryMessage[]): string {
+  return boundedIndexedText(
+    messages,
+    (entry) => entry.role === "tool",
+    INDEXED_TOOL_MESSAGE_LIMIT,
+    INDEXED_TOOL_DOCUMENT_LIMIT,
+  );
+}
+
+export function openingPrompt(
+  messages: readonly HistoryMessage[],
+): string | null {
+  const firstUser = messages.find((entry) => entry.role === "user");
+  if (firstUser === undefined) {
+    return null;
+  }
+  const envelope = messageEnvelopes.get(firstUser);
+  if (envelope === undefined) {
+    return firstUser.text;
+  }
+  return messages
+    .filter(
+      (entry) =>
+        entry.role === "user" && messageEnvelopes.get(entry) === envelope,
+    )
+    .map((entry) => entry.text)
+    .join("\n");
+}
+
+export function normalizeOpeningPrompt(value: string): string {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase()
+    .replaceAll(/\s+/gu, " ")
+    .trim();
+}
+
+export function openingPromptHash(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = normalizeOpeningPrompt(value);
+  if (normalized.length === 0) {
+    return null;
+  }
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(normalized);
+  return hasher.digest("hex");
+}
+
+export function makeHistoryDocument(
+  metadata: Omit<
+    HistoryDocument,
+    "dialogueText" | "toolOutputText" | "openingPromptHash"
+  >,
+  messages: readonly HistoryMessage[],
+): HistoryDocument {
+  return {
+    ...metadata,
+    openingPromptHash: openingPromptHash(openingPrompt(messages)),
+    dialogueText: dialogueText(messages),
+    toolOutputText: toolOutputText(messages),
+  };
+}

--- a/packages/toolkit/src/lib/history/opencode.ts
+++ b/packages/toolkit/src/lib/history/opencode.ts
@@ -1,3 +1,10 @@
+import {
+  dialogueText,
+  INDEXED_MESSAGE_PARSE_LIMIT,
+  openingPrompt,
+  openingPromptHash,
+  toolOutputText,
+} from "./messages.ts";
 import type { HistoryPaths } from "./paths.ts";
 import {
   firstText,
@@ -7,67 +14,196 @@ import {
   rowValue,
   rows,
   RowSchema,
+  sourceReadResult,
   sourceResult,
 } from "./sources-shared.ts";
-import { extractText, parseJsonLine, stringValue } from "./text.ts";
+import {
+  cleanText,
+  extractText,
+  parseJsonLine,
+  parseRecord,
+  stringValue,
+} from "./text.ts";
 import type {
   HistoryDocument,
+  HistoryMessage,
+  HistoryMessageRole,
+  HistoryRecord,
   HistorySource,
   HistorySourceResult,
 } from "./types.ts";
 
 type OpenCodeSourceName = "opencode-conductor" | "opencode-standalone";
 
-function opencodeDocuments(
+const OMITTED_PART_TYPES = new Set([
+  "reasoning",
+  "snapshot",
+  "step-finish",
+  "step-start",
+]);
+
+function messageRole(value: unknown): HistoryMessageRole {
+  switch (value) {
+    case "user":
+      return "user";
+    case "assistant":
+      return "assistant";
+    case "tool":
+      return "tool";
+    default:
+      return "unknown";
+  }
+}
+
+function textMessage(
+  role: HistoryMessageRole,
+  value: unknown,
+  createdAt: string | null,
+  maxCharacters: number,
+): HistoryMessage | null {
+  const text = cleanText(extractText(value, 0, maxCharacters));
+  return text.length === 0 ? null : { role, text, createdAt };
+}
+
+function chronologicalMessages(
+  messages: readonly HistoryMessage[],
+): HistoryMessage[] {
+  return messages
+    .map((entry, index) => ({ entry, index }))
+    .sort((left, right) => {
+      const leftTimestamp =
+        left.entry.createdAt === null
+          ? Number.MAX_SAFE_INTEGER
+          : Date.parse(left.entry.createdAt);
+      const rightTimestamp =
+        right.entry.createdAt === null
+          ? Number.MAX_SAFE_INTEGER
+          : Date.parse(right.entry.createdAt);
+      return leftTimestamp - rightTimestamp || left.index - right.index;
+    })
+    .map(({ entry }) => entry);
+}
+
+type OpenCodeData = {
+  readonly documents: readonly HistoryDocument[];
+  readonly messages: ReadonlyMap<string, readonly HistoryMessage[]>;
+};
+
+function placeholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function selectedValues(selected: ReadonlySet<string> | null): string[] {
+  return selected === null ? [] : [...selected];
+}
+
+function sessionSelection(selected: ReadonlySet<string> | null): string {
+  return selected === null
+    ? ""
+    : ` WHERE id IN (${placeholders(selected.size)})`;
+}
+
+function readOpenCodeData(
   filePath: string,
   source: OpenCodeSourceName,
-): HistoryDocument[] {
+  selected: ReadonlySet<string> | null = null,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): OpenCodeData {
   const database = readDatabase(filePath);
   try {
     requireTables(database, "OpenCode", ["session", "message", "part"]);
     const sessionRows = rows(
       database,
-      "SELECT id, title, directory, agent, model, time_created, time_updated FROM session",
+      `SELECT id, title, directory, agent, model, time_created, time_updated
+         FROM session${sessionSelection(selected)}`,
       RowSchema,
+      selectedValues(selected),
     );
+    const selectedIds = new Set(
+      sessionRows.map((row) => String(rowValue(row, "id"))),
+    );
+    if (selectedIds.size === 0) {
+      return { documents: [], messages: new Map() };
+    }
     const messageRows = rows(
       database,
-      "SELECT id, session_id, data, time_created FROM message ORDER BY session_id, time_created",
+      `SELECT id, session_id, data, time_created FROM message
+        WHERE session_id IN (${placeholders(selectedIds.size)})
+        ORDER BY session_id, time_created, id`,
       RowSchema,
+      [...selectedIds],
+    );
+    const selectedMessageIds = new Set(
+      messageRows.map((row) => String(rowValue(row, "id"))),
     );
     const partRows = rows(
       database,
-      "SELECT message_id, data FROM part ORDER BY message_id, time_created",
+      `SELECT message_id, data, time_created FROM part
+        WHERE message_id IN (${placeholders(selectedMessageIds.size)})
+        ORDER BY message_id, time_created, id`,
       RowSchema,
+      [...selectedMessageIds],
     );
-    const partsByMessage = new Map<string, string[]>();
-    for (const row of partRows) {
-      const messageId = String(rowValue(row, "message_id"));
-      const text = extractText(parseJsonLine(String(rowValue(row, "data"))));
-      if (text.length > 0) {
-        const parts = partsByMessage.get(messageId) ?? [];
-        parts.push(text);
-        partsByMessage.set(messageId, parts);
+    const messageMetadata = new Map<
+      string,
+      { readonly sessionId: string; readonly role: HistoryMessageRole }
+    >();
+    const messagesBySession = new Map<string, HistoryMessage[]>(
+      [...selectedIds].map((sessionId) => [sessionId, []]),
+    );
+
+    for (const row of messageRows) {
+      const messageId = String(rowValue(row, "id"));
+      const sessionId = String(rowValue(row, "session_id"));
+      const data = parseRecord(parseJsonLine(String(rowValue(row, "data"))));
+      const role = messageRole(data?.["role"]);
+      messageMetadata.set(messageId, { sessionId, role });
+      const createdAt = new Date(
+        Number(rowValue(row, "time_created")),
+      ).toISOString();
+      const parsed = textMessage(
+        role,
+        data?.["text"] ?? data?.["content"],
+        createdAt,
+        maxCharacters,
+      );
+      if (parsed !== null) {
+        const existing = messagesBySession.get(sessionId) ?? [];
+        existing.push(parsed);
+        messagesBySession.set(sessionId, existing);
       }
     }
-    const messagesBySession = new Map<string, string[]>();
-    for (const row of messageRows) {
-      const sessionId = String(rowValue(row, "session_id"));
-      const messageText = extractText(
-        parseJsonLine(String(rowValue(row, "data"))),
-      );
-      const parts = partsByMessage.get(String(rowValue(row, "id"))) ?? [];
-      const chunks = [messageText, ...parts].filter(
-        (chunk) => chunk.length > 0,
-      );
-      const messages = messagesBySession.get(sessionId) ?? [];
-      messages.push(...chunks);
-      messagesBySession.set(sessionId, messages);
+
+    for (const row of partRows) {
+      const metadata = messageMetadata.get(String(rowValue(row, "message_id")));
+      if (metadata === undefined) {
+        continue;
+      }
+      const data = parseRecord(parseJsonLine(String(rowValue(row, "data"))));
+      const partType = stringValue(data?.["type"]);
+      if (partType !== null && OMITTED_PART_TYPES.has(partType)) {
+        continue;
+      }
+      const role = partType === "tool" ? "tool" : metadata.role;
+      const createdAt = new Date(
+        Number(rowValue(row, "time_created")),
+      ).toISOString();
+      const parsed = textMessage(role, data, createdAt, maxCharacters);
+      if (parsed !== null) {
+        const existing = messagesBySession.get(metadata.sessionId) ?? [];
+        existing.push(parsed);
+        messagesBySession.set(metadata.sessionId, existing);
+      }
     }
-    return sessionRows.map((row) => {
+
+    for (const [sessionId, messages] of messagesBySession) {
+      messagesBySession.set(sessionId, chronologicalMessages(messages));
+    }
+
+    const documents = sessionRows.map((row) => {
       const sessionId = String(rowValue(row, "id"));
       const title = stringValue(rowValue(row, "title")) ?? "OpenCode session";
-      const body = messagesBySession.get(sessionId)?.join("\n") ?? "";
+      const messages = messagesBySession.get(sessionId) ?? [];
       return {
         source,
         sourceId: sessionId,
@@ -84,9 +220,13 @@ function opencodeDocuments(
         updatedAt: new Date(
           Number(rowValue(row, "time_updated")),
         ).toISOString(),
-        searchText: `${title}\n${body}`,
+        runtimeId: sessionId,
+        openingPromptHash: openingPromptHash(openingPrompt(messages)),
+        dialogueText: dialogueText(messages),
+        toolOutputText: toolOutputText(messages),
       } satisfies HistoryDocument;
     });
+    return { documents, messages: messagesBySession };
   } finally {
     database.close();
   }
@@ -105,8 +245,26 @@ function opencodeSource(
     async scan(paths: HistoryPaths): Promise<HistorySourceResult> {
       const resolvedPath = filePath(paths);
       const files = (await pathExists(resolvedPath)) ? [resolvedPath] : [];
-      return sourceResult(source, files, () =>
-        opencodeDocuments(resolvedPath, source),
+      return sourceResult(
+        source,
+        files,
+        () =>
+          readOpenCodeData(
+            resolvedPath,
+            source,
+            null,
+            INDEXED_MESSAGE_PARSE_LIMIT,
+          ).documents,
+      );
+    },
+    async read(paths: HistoryPaths, records: readonly HistoryRecord[]) {
+      const requestedSourceIds = records.map((record) => record.sourceId);
+      return sourceReadResult(
+        source,
+        requestedSourceIds,
+        () =>
+          readOpenCodeData(filePath(paths), source, new Set(requestedSourceIds))
+            .messages,
       );
     },
   };

--- a/packages/toolkit/src/lib/history/query.ts
+++ b/packages/toolkit/src/lib/history/query.ts
@@ -1,0 +1,97 @@
+export type HistoryQueryPart = {
+  readonly type: "phrase" | "prefix";
+  readonly value: string;
+};
+
+export function normalizeSearchToken(value: string): string {
+  return value
+    .normalize("NFD")
+    .replaceAll(/\p{M}+/gu, "")
+    .toLocaleLowerCase();
+}
+
+export function searchTokens(text: string): string[] {
+  return [...text.matchAll(/[\p{L}\p{N}]+/gu)]
+    .map((match) => normalizeSearchToken(match[0]))
+    .filter((word) => word.length > 0);
+}
+
+export function historyQueryParts(query: string): HistoryQueryPart[] {
+  const parts: HistoryQueryPart[] = [];
+  for (const match of query.matchAll(/"([^"]+)"|([^\s"]+)/gu)) {
+    const phrase = searchTokens(match[1] ?? "");
+    if (phrase.length > 0) {
+      parts.push({ type: "phrase", value: phrase.join(" ") });
+      continue;
+    }
+    for (const value of searchTokens(match[2] ?? "")) {
+      parts.push({ type: "prefix", value });
+    }
+  }
+  return parts;
+}
+
+export function queryPartIndex(
+  tokens: readonly string[],
+  part: HistoryQueryPart,
+): number {
+  if (part.type === "prefix") {
+    return tokens.findIndex((token) => token.startsWith(part.value));
+  }
+  const phrase = part.value.split(" ");
+  for (let index = 0; index <= tokens.length - phrase.length; index += 1) {
+    if (phrase.every((value, offset) => tokens[index + offset] === value)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+export function ftsQuery(query: string): string {
+  const clauses = historyQueryParts(query).map((part) =>
+    part.type === "phrase"
+      ? `"${part.value.replaceAll('"', '""')}"`
+      : `"${part.value.replaceAll('"', '""')}"*`,
+  );
+  if (clauses.length === 0) {
+    throw new Error("Search query must contain at least one letter or number");
+  }
+  return clauses.join(" AND ");
+}
+
+export function parseLimit(value: string | undefined): number {
+  if (value === undefined) {
+    return 20;
+  }
+  const limit = Number(value);
+  const validSyntax = /^[1-9]\d*$/u.test(value);
+  if (!validSyntax || !Number.isSafeInteger(limit) || limit > 200) {
+    throw new RangeError("Limit must be an integer from 1 to 200");
+  }
+  return limit;
+}
+
+export function parseSince(
+  value: string | undefined,
+  now = new Date(),
+): string | null {
+  if (value === undefined) {
+    return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  }
+  const duration = /^(\d+)([hdw])$/u.exec(value.trim());
+  if (duration !== null) {
+    const amount = Number.parseInt(duration[1] ?? "", 10);
+    const unit = duration[2];
+    const multiplier = unit === "w" ? 7 : unit === "d" ? 1 : 1 / 24;
+    return new Date(
+      now.getTime() - amount * multiplier * 24 * 60 * 60 * 1000,
+    ).toISOString();
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new TypeError(
+      `Invalid --since value "${value}"; use 7d, 24h, 1w, or an ISO date`,
+    );
+  }
+  return new Date(timestamp).toISOString();
+}

--- a/packages/toolkit/src/lib/history/render.ts
+++ b/packages/toolkit/src/lib/history/render.ts
@@ -1,0 +1,91 @@
+import { stripVTControlCharacters } from "node:util";
+import type {
+  HistoryMessage,
+  HistoryRecord,
+  HistoryResult,
+  HistoryWarning,
+} from "./types.ts";
+
+function terminalSafe(value: string): string {
+  let result = "";
+  for (const character of stripVTControlCharacters(value)) {
+    const codePoint = character.codePointAt(0);
+    if (
+      codePoint === 9 ||
+      codePoint === 10 ||
+      (codePoint !== undefined &&
+        codePoint >= 32 &&
+        (codePoint < 127 || codePoint > 159))
+    ) {
+      result += character;
+    }
+  }
+  return result;
+}
+
+export function renderHistoryRecords(
+  title: string,
+  records: readonly HistoryResult[],
+): string {
+  const lines = [`## ${title}`, ""];
+  if (records.length === 0) {
+    lines.push("No matching history.");
+    return lines.join("\n");
+  }
+  for (const record of records) {
+    lines.push(
+      `- **${record.title}** — ${record.source} — ${record.updatedAt} — ID ${String(record.id)}`,
+    );
+    if (record.workspace !== null) {
+      lines.push(`  Workspace: \`${record.workspace}\``);
+    }
+    lines.push(`  Source: \`${record.path}\` (${record.sourceId})`);
+    if (record.members.length > 1) {
+      lines.push(`  Parallel sessions: ${String(record.members.length)}`);
+      for (const member of record.members) {
+        lines.push(
+          `  - ID ${String(member.id)} — ${member.source} — ${member.createdAt} — ${member.title}`,
+        );
+      }
+    }
+    if (record.excerpt !== null && record.excerpt.length > 0) {
+      lines.push(`  Excerpt: ${record.excerpt}`);
+    }
+  }
+  return terminalSafe(lines.join("\n"));
+}
+
+export function renderHistoryShow(
+  record: HistoryRecord,
+  messages: readonly HistoryMessage[],
+  truncated: boolean,
+): string {
+  const lines = [
+    `## ${record.title}`,
+    "",
+    `ID: ${String(record.id)} · ${record.source} · ${record.updatedAt}`,
+    "",
+  ];
+  for (const message of messages) {
+    lines.push(
+      `**${message.role}**${message.createdAt === null ? "" : ` · ${message.createdAt}`}`,
+    );
+    lines.push(message.text, "");
+  }
+  if (truncated) {
+    lines.push(
+      "_Context truncated. Increase --messages (maximum 50) for a wider bounded view._",
+    );
+  }
+  return terminalSafe(lines.join("\n"));
+}
+
+export function printHistoryWarnings(
+  warnings: readonly HistoryWarning[],
+): void {
+  for (const warning of warnings) {
+    console.error(
+      terminalSafe(`Warning [${warning.source}]: ${warning.message}`),
+    );
+  }
+}

--- a/packages/toolkit/src/lib/history/results.ts
+++ b/packages/toolkit/src/lib/history/results.ts
@@ -1,0 +1,251 @@
+import type {
+  HistoryGroupMember,
+  HistoryRecord,
+  HistoryResult,
+  HistoryRuntimeRef,
+  HistorySourceName,
+  HistorySourceStatus,
+  HistoryWarning,
+  IndexedHistoryRecord,
+} from "./types.ts";
+
+const DUPLICATE_WINDOW_MS = 30 * 60 * 1000;
+const RESULT_PAGE_SIZE = 128;
+
+type ResultOptions = {
+  readonly includeCurrent: boolean;
+  readonly includeDuplicates: boolean;
+  readonly currentRuntimes: readonly HistoryRuntimeRef[];
+  readonly limit: number;
+};
+
+export function publicRecord(record: IndexedHistoryRecord): HistoryRecord {
+  return {
+    id: record.id,
+    source: record.source,
+    sourceId: record.sourceId,
+    title: record.title,
+    path: record.path,
+    workspace: record.workspace,
+    agent: record.agent,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    excerpt: record.excerpt,
+  };
+}
+
+function groupMember(record: IndexedHistoryRecord): HistoryGroupMember {
+  const visible = publicRecord(record);
+  return {
+    id: visible.id,
+    source: visible.source,
+    sourceId: visible.sourceId,
+    title: visible.title,
+    path: visible.path,
+    workspace: visible.workspace,
+    agent: visible.agent,
+    createdAt: visible.createdAt,
+    updatedAt: visible.updatedAt,
+  };
+}
+
+function singleton(record: IndexedHistoryRecord): HistoryResult {
+  return { ...publicRecord(record), members: [groupMember(record)] };
+}
+
+function isVisible(
+  record: IndexedHistoryRecord,
+  options: ResultOptions,
+): boolean {
+  return (
+    options.includeCurrent ||
+    record.runtimeId === null ||
+    !options.currentRuntimes.some(
+      (runtime) =>
+        runtime.source === record.source &&
+        runtime.runtimeId === record.runtimeId,
+    )
+  );
+}
+
+function promptClusters(
+  rankedRecords: readonly IndexedHistoryRecord[],
+): IndexedHistoryRecord[][] {
+  const rank = new Map(
+    rankedRecords.map((record, index) => [record.id, index]),
+  );
+  const chronological = [...rankedRecords].sort(
+    (left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt),
+  );
+  const clusters: IndexedHistoryRecord[][] = [];
+  let cluster: IndexedHistoryRecord[] = [];
+  let anchor = 0;
+  for (const record of chronological) {
+    const createdAt = Date.parse(record.createdAt);
+    if (cluster.length === 0 || createdAt - anchor <= DUPLICATE_WINDOW_MS) {
+      if (cluster.length === 0) {
+        anchor = createdAt;
+      }
+      cluster.push(record);
+    } else {
+      clusters.push(cluster);
+      cluster = [record];
+      anchor = createdAt;
+    }
+  }
+  if (cluster.length > 0) {
+    clusters.push(cluster);
+  }
+  return clusters.map((members) =>
+    members.sort(
+      (left, right) =>
+        (rank.get(left.id) ?? Number.MAX_SAFE_INTEGER) -
+        (rank.get(right.id) ?? Number.MAX_SAFE_INTEGER),
+    ),
+  );
+}
+
+function resultForCluster(
+  rankedCluster: readonly IndexedHistoryRecord[],
+): HistoryResult {
+  const representative = rankedCluster[0];
+  if (representative === undefined) {
+    throw new Error("History duplicate cluster was empty");
+  }
+  return {
+    ...publicRecord(representative),
+    members: rankedCluster.map((record) => groupMember(record)),
+  };
+}
+
+export function prepareResults(
+  rankedRecords: readonly IndexedHistoryRecord[],
+  options: ResultOptions,
+): HistoryResult[] {
+  const records = rankedRecords.filter((record) => isVisible(record, options));
+  if (options.includeDuplicates) {
+    return records.slice(0, options.limit).map((record) => singleton(record));
+  }
+
+  const rank = new Map(records.map((record, index) => [record.id, index]));
+  const byPrompt = Map.groupBy(
+    records.filter((record) => record.openingPromptHash !== null),
+    (record) => record.openingPromptHash ?? "",
+  );
+  const groupedIds = new Set<number>();
+  const clusters: IndexedHistoryRecord[][] = [];
+  for (const promptRecords of byPrompt.values()) {
+    for (const record of promptRecords) {
+      groupedIds.add(record.id);
+    }
+    clusters.push(...promptClusters(promptRecords));
+  }
+  for (const record of records) {
+    if (!groupedIds.has(record.id)) {
+      clusters.push([record]);
+    }
+  }
+
+  const representativeRank = (cluster: readonly IndexedHistoryRecord[]) =>
+    Math.min(
+      ...cluster.map(
+        (record) => rank.get(record.id) ?? Number.MAX_SAFE_INTEGER,
+      ),
+    );
+  return clusters
+    .sort((left, right) => representativeRank(left) - representativeRank(right))
+    .slice(0, options.limit)
+    .map((cluster) => resultForCluster(cluster));
+}
+
+export function collectHistoryResults(
+  readPage: (offset: number, limit: number) => readonly IndexedHistoryRecord[],
+  readPromptMatches: (
+    openingPromptHash: string,
+  ) => readonly IndexedHistoryRecord[],
+  options: ResultOptions,
+): HistoryResult[] {
+  const results: HistoryResult[] = [];
+  const consumedIds = new Set<number>();
+  const cachedClusters = new Map<string, IndexedHistoryRecord[][]>();
+  let offset = 0;
+
+  while (results.length < options.limit) {
+    const page = readPage(offset, RESULT_PAGE_SIZE);
+    offset += page.length;
+    for (const record of page) {
+      if (!isVisible(record, options) || consumedIds.has(record.id)) {
+        continue;
+      }
+      if (options.includeDuplicates || record.openingPromptHash === null) {
+        consumedIds.add(record.id);
+        results.push(singleton(record));
+      } else {
+        const hash = record.openingPromptHash;
+        let clusters = cachedClusters.get(hash);
+        if (clusters === undefined) {
+          clusters = promptClusters(
+            readPromptMatches(hash).filter((member) =>
+              isVisible(member, options),
+            ),
+          );
+          cachedClusters.set(hash, clusters);
+        }
+        const cluster = clusters.find((members) =>
+          members.some((member) => member.id === record.id),
+        );
+        if (cluster === undefined) {
+          throw new Error(
+            `History prompt cluster did not contain indexed record ${String(record.id)}`,
+          );
+        }
+        for (const member of cluster) {
+          consumedIds.add(member.id);
+        }
+        results.push(
+          resultForCluster([
+            record,
+            ...cluster.filter((member) => member.id !== record.id),
+          ]),
+        );
+      }
+      if (results.length === options.limit) {
+        break;
+      }
+    }
+    if (page.length < RESULT_PAGE_SIZE) {
+      break;
+    }
+  }
+  return results;
+}
+
+export function sourceWarnings(
+  statuses: readonly HistorySourceStatus[],
+  requestedSource: HistorySourceName | null,
+): HistoryWarning[] {
+  const warnings = statuses.flatMap((status) => {
+    if (status.error !== null) {
+      return [{ source: status.source, message: status.error }];
+    }
+    if (requestedSource === status.source && !status.available) {
+      return [
+        {
+          source: status.source,
+          message: `${status.label} is not installed or its history store is unavailable.`,
+        },
+      ];
+    }
+    return [];
+  });
+  if (
+    requestedSource !== null &&
+    !statuses.some((status) => status.source === requestedSource)
+  ) {
+    warnings.push({
+      source: requestedSource,
+      message: `${requestedSource} has not been scanned by the history daemon.`,
+    });
+  }
+  return warnings;
+}

--- a/packages/toolkit/src/lib/history/runtime.ts
+++ b/packages/toolkit/src/lib/history/runtime.ts
@@ -1,0 +1,12 @@
+import type { HistoryRuntimeRef } from "./types.ts";
+
+export function currentHistoryRuntimes(): readonly HistoryRuntimeRef[] {
+  return [
+    { source: "conductor" as const, value: Bun.env["CONDUCTOR_SESSION_ID"] },
+    { source: "codex" as const, value: Bun.env["CODEX_THREAD_ID"] },
+  ].flatMap(({ source, value }) =>
+    value === undefined || value.length === 0
+      ? []
+      : [{ source, runtimeId: value }],
+  );
+}

--- a/packages/toolkit/src/lib/history/serve.ts
+++ b/packages/toolkit/src/lib/history/serve.ts
@@ -7,10 +7,12 @@ import {
   HistoryDaemonStatusSchema,
   HistoryDaemonResponseSchema,
 } from "./ipc.ts";
-import type { HistoryRuntimePaths } from "./paths.ts";
+import type { HistoryPaths, HistoryRuntimePaths } from "./paths.ts";
 import type { HistoryDaemonState } from "./ipc.ts";
+import type { HistorySource, HistorySourceResult } from "./types.ts";
 
 const INTERVAL_SECONDS = 30;
+const SOURCE_SCAN_CONCURRENCY = 2;
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -28,6 +30,27 @@ async function logLine(
     mode: 0o600,
   });
   await chmod(logPath, 0o600);
+}
+
+export async function scanHistorySources(
+  sources: readonly HistorySource[],
+  paths: HistoryPaths,
+): Promise<HistorySourceResult[]> {
+  const results: HistorySourceResult[] = [];
+  for (
+    let offset = 0;
+    offset < sources.length;
+    offset += SOURCE_SCAN_CONCURRENCY
+  ) {
+    results.push(
+      ...(await Promise.all(
+        sources
+          .slice(offset, offset + SOURCE_SCAN_CONCURRENCY)
+          .map(async (source) => source.scan(paths)),
+      )),
+    );
+  }
+  return results;
 }
 
 export async function runHistoryDaemon(): Promise<void> {
@@ -61,9 +84,7 @@ export async function runHistoryDaemon(): Promise<void> {
     }
     scanning = true;
     try {
-      const results = await Promise.all(
-        sources.map((source) => source.scan(paths)),
-      );
+      const results = await scanHistorySources(sources, paths);
       await index.ingest(results, force);
       lastScanAt = new Date().toISOString();
       await logLine(runtimePaths, "history scan complete", {

--- a/packages/toolkit/src/lib/history/sources-shared.ts
+++ b/packages/toolkit/src/lib/history/sources-shared.ts
@@ -1,10 +1,13 @@
 import { Database } from "bun:sqlite";
 import { readdir, stat } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { z } from "zod";
 import type {
   HistoryDocument,
+  HistoryMessage,
   HistorySourceName,
+  HistorySourceReadResult,
   HistorySourceResult,
 } from "./types.ts";
 
@@ -14,10 +17,11 @@ export function rows<T extends z.ZodType>(
   database: Database,
   sql: string,
   schema: T,
+  values: readonly (string | number)[] = [],
 ): z.infer<T>[] {
   return database
     .prepare(sql)
-    .all()
+    .all(...values)
     .map((row: unknown) => schema.parse(row));
 }
 
@@ -130,4 +134,77 @@ export async function sourceResult(
 
 export function readDatabase(filePath: string): Database {
   return new Database(filePath, { readonly: true, strict: true });
+}
+
+type DatabaseOpener = (filePath: string) => Database;
+
+function isCantOpen(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("SQLITE_CANTOPEN") ||
+    message.toLocaleLowerCase().includes("unable to open database file")
+  );
+}
+
+export async function readCursorDatabase(
+  filePath: string,
+  openOrdinary: DatabaseOpener = readDatabase,
+): Promise<Database> {
+  let ordinary: Database | null = null;
+  try {
+    ordinary = openOrdinary(filePath);
+    ordinary.query("SELECT 1").get();
+    return ordinary;
+  } catch (error: unknown) {
+    ordinary?.close();
+    if (!isCantOpen(error)) {
+      throw error;
+    }
+    try {
+      const wal = await stat(`${filePath}-wal`);
+      if (wal.size > 0) {
+        throw new Error(
+          `Cursor database cannot be opened read-only while its live WAL is present: ${filePath}-wal`,
+          { cause: error },
+        );
+      }
+    } catch (walError: unknown) {
+      const code = z
+        .object({ code: z.string().optional() })
+        .safeParse(walError);
+      if (!code.success || code.data.code !== "ENOENT") {
+        throw walError;
+      }
+    }
+    const immutableUrl = pathToFileURL(filePath);
+    immutableUrl.searchParams.set("immutable", "1");
+    return new Database(immutableUrl.href, { readonly: true, strict: true });
+  }
+}
+
+export async function sourceReadResult(
+  source: HistorySourceName,
+  requestedSourceIds: readonly string[],
+  read: () =>
+    | ReadonlyMap<string, readonly HistoryMessage[]>
+    | Promise<ReadonlyMap<string, readonly HistoryMessage[]>>,
+): Promise<HistorySourceReadResult> {
+  try {
+    const messages = await read();
+    return {
+      source,
+      messages,
+      missingSourceIds: requestedSourceIds.filter(
+        (sourceId) => !messages.has(sourceId),
+      ),
+      error: null,
+    };
+  } catch (error: unknown) {
+    return {
+      source,
+      messages: new Map(),
+      missingSourceIds: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/packages/toolkit/src/lib/history/sources.ts
+++ b/packages/toolkit/src/lib/history/sources.ts
@@ -1,22 +1,34 @@
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
-import type { HistoryPaths } from "./paths.ts";
+import { scanCodexCatalog } from "./codex-catalog.ts";
+import {
+  readCodexHistoryJsonl,
+  scanCodexHistoryJsonl,
+} from "./codex-history.ts";
+import { createConductorSource } from "./conductor.ts";
+import { createCursorSource } from "./cursor.ts";
+import {
+  historyMessageRole,
+  INDEXED_MESSAGE_PARSE_LIMIT,
+  makeHistoryDocument,
+  openingPrompt,
+  parseCodexItem,
+  parseConversationEnvelope,
+} from "./messages.ts";
 import { createOpenCodeSources } from "./opencode.ts";
+import type { HistoryPaths } from "./paths.ts";
 import {
   filesUnder,
   firstText,
   pathExists,
   readDatabase,
   requireTables,
-  rowValue,
   rows,
-  RowSchema,
+  sourceReadResult,
   sourceResult,
 } from "./sources-shared.ts";
 import {
-  cleanText,
-  extractText,
   parseJsonLine,
   parseRecord,
   parseTimestamp,
@@ -24,55 +36,68 @@ import {
 } from "./text.ts";
 import type {
   HistoryDocument,
+  HistoryMessage,
+  HistoryRecord,
   HistorySource,
+  HistorySourceReadResult,
   HistorySourceResult,
 } from "./types.ts";
 
-async function scanConductor(
-  paths: HistoryPaths,
-): Promise<HistorySourceResult> {
-  const files = (await pathExists(paths.conductorDb))
-    ? [paths.conductorDb]
-    : [];
-  return sourceResult("conductor", files, () => {
-    const database = readDatabase(paths.conductorDb);
-    try {
-      requireTables(database, "Conductor", ["sessions", "session_messages"]);
-      const sessionRows = rows(
-        database,
-        `SELECT s.id, s.title, s.created_at, s.updated_at, s.model,
-                s.agent_type, s.workspace_id,
-                GROUP_CONCAT(COALESCE(sm.content, sm.full_message, ''), '\n') AS body
-           FROM sessions s
-           LEFT JOIN session_messages sm ON sm.session_id = s.id
-          GROUP BY s.id, s.title, s.created_at, s.updated_at, s.model,
-                   s.agent_type, s.workspace_id`,
-        RowSchema,
-      );
-      return sessionRows.map((row) => {
-        const body = stringValue(rowValue(row, "body")) ?? "";
-        const title = stringValue(rowValue(row, "title")) ?? "Untitled";
-        const createdAt =
-          stringValue(rowValue(row, "created_at")) ?? new Date(0).toISOString();
-        const updatedAt = stringValue(rowValue(row, "updated_at")) ?? createdAt;
-        return {
-          source: "conductor",
-          sourceId: String(rowValue(row, "id")),
-          title: firstText(title, "Conductor session"),
-          path: paths.conductorDb,
-          workspace: stringValue(rowValue(row, "workspace_id")),
-          agent:
-            stringValue(rowValue(row, "agent_type")) ??
-            stringValue(rowValue(row, "model")),
-          createdAt: parseTimestamp(createdAt, new Date(0)),
-          updatedAt: parseTimestamp(updatedAt, new Date(0)),
-          searchText: `${title}\n${body}`,
-        } satisfies HistoryDocument;
-      });
-    } finally {
-      database.close();
+function placeholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function batches<T>(values: readonly T[], size = 8): T[][] {
+  const result: T[][] = [];
+  for (let offset = 0; offset < values.length; offset += size) {
+    result.push(values.slice(offset, offset + size));
+  }
+  return result;
+}
+
+type ClaudeTranscript = {
+  readonly messages: readonly HistoryMessage[];
+  readonly createdAt: string | null;
+  readonly updatedAt: string | null;
+  readonly runtimeId: string | null;
+};
+
+async function readClaudeTranscript(
+  file: string,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): Promise<ClaudeTranscript> {
+  const raw = await Bun.file(file).text();
+  const messages: HistoryMessage[] = [];
+  let createdAt: string | null = null;
+  let updatedAt: string | null = null;
+  let runtimeId: string | null = null;
+  for (const line of raw.split("\n")) {
+    if (line.trim().length === 0) {
+      continue;
     }
-  });
+    const value = parseJsonLine(line);
+    const record = parseRecord(value);
+    if (record === null) {
+      continue;
+    }
+    runtimeId ??=
+      stringValue(record["sessionId"]) ?? stringValue(record["session_id"]);
+    const timestamp = stringValue(record["timestamp"]);
+    if (timestamp !== null) {
+      const parsedTimestamp = parseTimestamp(timestamp, new Date(0));
+      createdAt ??= parsedTimestamp;
+      updatedAt = parsedTimestamp;
+    }
+    messages.push(
+      ...parseConversationEnvelope(
+        value,
+        historyMessageRole(record["type"]),
+        timestamp === null ? null : parseTimestamp(timestamp, new Date(0)),
+        maxCharacters,
+      ),
+    );
+  }
+  return { messages, createdAt, updatedAt, runtimeId };
 }
 
 async function scanClaude(paths: HistoryPaths): Promise<HistorySourceResult> {
@@ -80,185 +105,169 @@ async function scanClaude(paths: HistoryPaths): Promise<HistorySourceResult> {
   return sourceResult("claude", files, async () => {
     const documents: HistoryDocument[] = [];
     for (const file of files) {
-      const raw = await Bun.file(file).text();
-      const lines = raw.split("\n");
-      const textChunks: string[] = [];
-      let createdAt: string | null = null;
-      let updatedAt: string | null = null;
-      let title: string | null = null;
-      for (const line of lines) {
-        if (line.trim().length === 0) {
-          continue;
-        }
-        const value = parseJsonLine(line);
-        const record = parseRecord(value);
-        if (record === null) {
-          continue;
-        }
-        const timestamp = stringValue(record["timestamp"]);
-        if (createdAt === null && timestamp !== null) {
-          createdAt = parseTimestamp(timestamp, new Date(0));
-        }
-        if (timestamp !== null) {
-          updatedAt = parseTimestamp(timestamp, new Date(0));
-        }
-        const text = cleanText(extractText(record));
-        if (text.length > 0) {
-          textChunks.push(text);
-          if (
-            title === null &&
-            (record["type"] === "user" || record["type"] === "human")
-          ) {
-            title = firstText(text, "Claude Code session");
-          }
-        }
-      }
+      const transcript = await readClaudeTranscript(
+        file,
+        INDEXED_MESSAGE_PARSE_LIMIT,
+      );
       const info = await stat(file);
-      const fallback = new Date(info.mtimeMs);
-      documents.push({
-        source: "claude",
-        sourceId: path.relative(paths.claudeProjects, file),
-        title: title ?? path.basename(file, ".jsonl"),
-        path: file,
-        workspace: path.dirname(path.dirname(file)),
-        agent: "Claude Code",
-        createdAt: createdAt ?? fallback.toISOString(),
-        updatedAt: updatedAt ?? fallback.toISOString(),
-        searchText: textChunks.join("\n"),
-      });
+      const fallback = new Date(info.mtimeMs).toISOString();
+      const firstUser = openingPrompt(transcript.messages);
+      documents.push(
+        makeHistoryDocument(
+          {
+            source: "claude",
+            sourceId: path.relative(paths.claudeProjects, file),
+            title: firstText(
+              firstUser ?? path.basename(file, ".jsonl"),
+              "Claude Code session",
+            ),
+            path: file,
+            workspace: path.dirname(path.dirname(file)),
+            agent: "Claude Code",
+            createdAt: transcript.createdAt ?? fallback,
+            updatedAt: transcript.updatedAt ?? fallback,
+            runtimeId: transcript.runtimeId,
+          },
+          transcript.messages,
+        ),
+      );
     }
     return documents;
   });
 }
 
+async function readClaude(
+  _paths: HistoryPaths,
+  records: readonly HistoryRecord[],
+): Promise<HistorySourceReadResult> {
+  return sourceReadResult(
+    "claude",
+    records.map((record) => record.sourceId),
+    async () => {
+      const messages = new Map<string, readonly HistoryMessage[]>();
+      for (const record of records) {
+        const transcript = await readClaudeTranscript(record.path);
+        messages.set(record.sourceId, transcript.messages);
+      }
+      return messages;
+    },
+  );
+}
+
 type CodexItem = {
   readonly threadId: string;
-  readonly itemJson: string;
   readonly createdAtMs: number;
+  readonly updatedAtMs: number;
 };
 
-function scanCodexThreadDatabase(filePath: string): HistoryDocument[] {
+function codexThreadMessages(
+  filePath: string,
+  threadIds: readonly string[] | null = null,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): ReadonlyMap<string, readonly HistoryMessage[]> {
   const database = readDatabase(filePath);
   try {
     requireTables(database, "Codex thread history", ["thread_items"]);
-    const itemRows = rows(
-      database,
-      "SELECT thread_id, item_json, created_at_ms FROM thread_items ORDER BY thread_id, rollout_ordinal",
-      z.object({
-        thread_id: z.string(),
-        item_json: z.string(),
-        created_at_ms: z.number(),
-      }),
-    );
-    const groups = new Map<string, CodexItem[]>();
-    for (const row of itemRows) {
-      const group = groups.get(row.thread_id) ?? [];
-      group.push({
-        threadId: row.thread_id,
-        itemJson: row.item_json,
-        createdAtMs: row.created_at_ms,
-      });
-      groups.set(row.thread_id, group);
-    }
-    return [...groups.values()].map((items) => {
-      const first = items[0];
-      if (first === undefined) {
-        throw new TypeError("Codex thread group was empty");
+    const selectedThreadIds =
+      threadIds ??
+      rows(
+        database,
+        "SELECT DISTINCT thread_id FROM thread_items ORDER BY thread_id",
+        z.object({ thread_id: z.string() }),
+      ).map((row) => row.thread_id);
+    const messages = new Map<string, HistoryMessage[]>();
+    for (const batch of batches(selectedThreadIds)) {
+      const itemRows = rows(
+        database,
+        `SELECT rowid AS history_rowid, thread_id
+           FROM thread_items
+          WHERE thread_id IN (${placeholders(batch.length)})
+          ORDER BY thread_id, rollout_ordinal`,
+        z.object({ history_rowid: z.number(), thread_id: z.string() }),
+        batch,
+      );
+      const readItem = database.prepare(
+        `SELECT item_json, item_type, created_at_ms
+           FROM thread_items WHERE rowid = ?`,
+      );
+      for (const metadata of itemRows) {
+        const row = z
+          .object({
+            item_json: z.string(),
+            item_type: z.string(),
+            created_at_ms: z.number(),
+          })
+          .parse(readItem.get(metadata.history_rowid));
+        const createdAt = new Date(row.created_at_ms).toISOString();
+        const entries = parseCodexItem(
+          row.item_type,
+          parseJsonLine(row.item_json),
+          createdAt,
+          maxCharacters,
+        );
+        const existing = messages.get(metadata.thread_id) ?? [];
+        existing.push(...entries);
+        messages.set(metadata.thread_id, existing);
       }
-      const text = items
-        .map((item) => extractText(parseJsonLine(item.itemJson)))
-        .filter((chunk) => chunk.length > 0)
-        .join("\n");
-      const createdAt = new Date(first.createdAtMs).toISOString();
-      const updatedAt = new Date(
-        items.at(-1)?.createdAtMs ?? first.createdAtMs,
-      ).toISOString();
-      return {
-        source: "codex",
-        sourceId: `${filePath}:${first.threadId}`,
-        title: firstText(text, first.threadId),
-        path: filePath,
-        workspace: null,
-        agent: "Codex",
-        createdAt,
-        updatedAt,
-        searchText: text,
-      } satisfies HistoryDocument;
-    });
+    }
+    return messages;
   } finally {
     database.close();
   }
 }
 
-async function scanCodexHistoryJsonl(
-  filePath: string,
-): Promise<HistoryDocument[]> {
-  const raw = await Bun.file(filePath).text();
-  const info = await stat(filePath);
-  return raw
-    .split("\n")
-    .map((line, index) => ({ line: line.trim(), index }))
-    .filter((entry) => entry.line.length > 0)
-    .map((entry) => {
-      const value = parseJsonLine(entry.line);
-      const record = parseRecord(value);
-      const text = cleanText(extractText(value));
-      const timestamp =
-        record?.["timestamp"] ?? record?.["created_at"] ?? record?.["time"];
-      const updatedAt = parseTimestamp(timestamp, new Date(info.mtimeMs));
-      return {
-        source: "codex",
-        sourceId: `${filePath}:line:${String(entry.index + 1)}`,
-        title: firstText(text, "Codex history entry"),
-        path: filePath,
-        workspace: null,
-        agent: "Codex",
-        createdAt: updatedAt,
-        updatedAt,
-        searchText: text,
-      } satisfies HistoryDocument;
-    });
-}
-
-function scanCodexCatalog(filePath: string): HistoryDocument[] {
+function scanCodexThreadDatabase(filePath: string): HistoryDocument[] {
   const database = readDatabase(filePath);
+  let items: readonly CodexItem[];
   try {
-    requireTables(database, "Codex catalog", ["local_thread_catalog"]);
-    const catalogRows = rows(
+    requireTables(database, "Codex thread history", ["thread_items"]);
+    items = rows(
       database,
-      `SELECT host_id, thread_id, display_title, source_created_at,
-              source_updated_at, cwd, model_provider, git_branch
-         FROM local_thread_catalog
-        WHERE missing_candidate = 0`,
-      RowSchema,
+      `SELECT thread_id, min(created_at_ms) AS created_at_ms,
+              max(created_at_ms) AS updated_at_ms
+         FROM thread_items
+        GROUP BY thread_id
+        ORDER BY thread_id`,
+      z
+        .object({
+          thread_id: z.string(),
+          created_at_ms: z.number(),
+          updated_at_ms: z.number(),
+        })
+        .transform((row) => ({
+          threadId: row.thread_id,
+          createdAtMs: row.created_at_ms,
+          updatedAtMs: row.updated_at_ms,
+        })),
     );
-    return catalogRows.map((row) => {
-      const title =
-        stringValue(rowValue(row, "display_title")) ?? "Codex thread";
-      const workspace = stringValue(rowValue(row, "cwd"));
-      const branch = stringValue(rowValue(row, "git_branch"));
-      const text = `${title}\n${workspace ?? ""}\n${branch ?? ""}`;
-      return {
-        source: "codex",
-        sourceId: `${filePath}:${String(rowValue(row, "host_id"))}:${String(rowValue(row, "thread_id"))}`,
-        title: firstText(title, "Codex thread"),
-        path: filePath,
-        workspace,
-        agent: stringValue(rowValue(row, "model_provider")) ?? "Codex",
-        createdAt: parseTimestamp(
-          rowValue(row, "source_created_at"),
-          new Date(0),
-        ),
-        updatedAt: parseTimestamp(
-          rowValue(row, "source_updated_at"),
-          new Date(0),
-        ),
-        searchText: text,
-      } satisfies HistoryDocument;
-    });
   } finally {
     database.close();
   }
+  const messages = codexThreadMessages(
+    filePath,
+    null,
+    INDEXED_MESSAGE_PARSE_LIMIT,
+  );
+  return items.map((item) => {
+    const threadMessages = messages.get(item.threadId) ?? [];
+    return makeHistoryDocument(
+      {
+        source: "codex",
+        sourceId: `${filePath}:${item.threadId}`,
+        title: firstText(
+          openingPrompt(threadMessages) ?? item.threadId,
+          item.threadId,
+        ),
+        path: filePath,
+        workspace: null,
+        agent: "Codex",
+        createdAt: new Date(item.createdAtMs).toISOString(),
+        updatedAt: new Date(item.updatedAtMs).toISOString(),
+        runtimeId: item.threadId,
+      },
+      threadMessages,
+    );
+  });
 }
 
 async function scanCodex(paths: HistoryPaths): Promise<HistorySourceResult> {
@@ -278,14 +287,53 @@ async function scanCodex(paths: HistoryPaths): Promise<HistorySourceResult> {
     }
   }
   return sourceResult("codex", existingFiles, async () => {
-    const documents: HistoryDocument[] = [];
+    const threadDocuments: HistoryDocument[] = [];
     for (const file of threadFiles) {
       if (await pathExists(file)) {
-        documents.push(...scanCodexThreadDatabase(file));
+        threadDocuments.push(...scanCodexThreadDatabase(file));
       }
     }
+    const catalogDocuments = (await pathExists(paths.codexCatalogDb))
+      ? scanCodexCatalog(paths.codexCatalogDb)
+      : [];
+    const catalogByThread = new Map(
+      catalogDocuments.flatMap((document) =>
+        document.runtimeId === null
+          ? []
+          : [[document.runtimeId, document] as const],
+      ),
+    );
+    const indexedThreadIds = new Set(
+      threadDocuments.flatMap((document) =>
+        document.runtimeId === null ? [] : [document.runtimeId],
+      ),
+    );
+    const documents = threadDocuments.map((document) => {
+      const catalog =
+        document.runtimeId === null
+          ? undefined
+          : catalogByThread.get(document.runtimeId);
+      if (catalog === undefined) {
+        return document;
+      }
+      return {
+        ...document,
+        title: catalog.title,
+        workspace: catalog.workspace,
+        agent: catalog.agent,
+        toolOutputText: [document.toolOutputText, catalog.toolOutputText]
+          .filter((text) => text.length > 0)
+          .join("\n"),
+      } satisfies HistoryDocument;
+    });
     if (await pathExists(paths.codexCatalogDb)) {
-      documents.push(...scanCodexCatalog(paths.codexCatalogDb));
+      documents.push(
+        ...catalogDocuments.filter(
+          (document) =>
+            document.runtimeId === null ||
+            !indexedThreadIds.has(document.runtimeId),
+        ),
+      );
     }
     if (await pathExists(paths.codexHistoryJsonl)) {
       documents.push(...(await scanCodexHistoryJsonl(paths.codexHistoryJsonl)));
@@ -294,57 +342,93 @@ async function scanCodex(paths: HistoryPaths): Promise<HistorySourceResult> {
   });
 }
 
-async function scanCursor(paths: HistoryPaths): Promise<HistorySourceResult> {
-  const files = (await pathExists(paths.cursorConversationDb))
-    ? [paths.cursorConversationDb]
-    : [];
-  return sourceResult("cursor", files, () => {
-    const database = readDatabase(paths.cursorConversationDb);
-    try {
-      requireTables(database, "Cursor conversation search", [
-        "conversations",
-        "conversation_fts",
-      ]);
-      const conversationRows = rows(
-        database,
-        `SELECT c.fts_rowid, c.source, c.scope, c.id, c.title, c.updated_at,
-                f.body
-           FROM conversations c
-           JOIN conversation_fts f ON f.rowid = c.fts_rowid`,
-        RowSchema,
+async function readCodex(
+  paths: HistoryPaths,
+  records: readonly HistoryRecord[],
+): Promise<HistorySourceReadResult> {
+  return sourceReadResult(
+    "codex",
+    records.map((record) => record.sourceId),
+    async () => {
+      const result = new Map<string, readonly HistoryMessage[]>();
+      const catalogDocuments = (await pathExists(paths.codexCatalogDb))
+        ? scanCodexCatalog(paths.codexCatalogDb)
+        : [];
+      const catalogByThread = new Map(
+        catalogDocuments.flatMap((document) =>
+          document.runtimeId === null
+            ? []
+            : [[document.runtimeId, document] as const],
+        ),
       );
-      return conversationRows.map((row) => {
-        const title =
-          stringValue(rowValue(row, "title")) ?? "Cursor conversation";
-        const body = stringValue(rowValue(row, "body")) ?? "";
-        const updatedAt = parseTimestamp(
-          rowValue(row, "updated_at"),
-          new Date(0),
-        );
-        return {
-          source: "cursor",
-          sourceId: `${String(rowValue(row, "source"))}:${String(rowValue(row, "scope"))}:${String(rowValue(row, "id"))}`,
-          title: firstText(title, "Cursor conversation"),
-          path: paths.cursorConversationDb,
-          workspace: stringValue(rowValue(row, "scope")),
-          agent: "Cursor",
-          createdAt: updatedAt,
-          updatedAt,
-          searchText: `${title}\n${body}`,
-        } satisfies HistoryDocument;
-      });
-    } finally {
-      database.close();
-    }
-  });
+      const catalogBySourceId = new Map(
+        catalogDocuments.map((document) => [document.sourceId, document]),
+      );
+      const catalogMessages = (
+        document: HistoryDocument | undefined,
+      ): readonly HistoryMessage[] => {
+        if (document === undefined) {
+          return [];
+        }
+        const text = [document.title, document.toolOutputText]
+          .filter((part) => part.length > 0)
+          .join("\n");
+        return [{ role: "tool", text, createdAt: document.updatedAt }];
+      };
+      const byPath = Map.groupBy(records, (record) => record.path);
+      for (const [filePath, fileRecords] of byPath) {
+        if (/thread_history_.*\.sqlite$/u.test(filePath)) {
+          const threadIds = fileRecords.map((record) =>
+            record.sourceId.slice(filePath.length + 1),
+          );
+          const messages = codexThreadMessages(filePath, threadIds);
+          for (const record of fileRecords) {
+            const threadId = record.sourceId.slice(filePath.length + 1);
+            const threadMessages = messages.get(threadId);
+            if (threadMessages === undefined) {
+              continue;
+            }
+            result.set(record.sourceId, [
+              ...threadMessages,
+              ...catalogMessages(catalogByThread.get(threadId)),
+            ]);
+          }
+        } else if (filePath === paths.codexHistoryJsonl) {
+          const selected = new Set(
+            fileRecords.map((record) => record.sourceId),
+          );
+          const messages = await readCodexHistoryJsonl(filePath, selected);
+          for (const record of fileRecords) {
+            const recordMessages = messages.get(record.sourceId);
+            if (recordMessages !== undefined) {
+              result.set(record.sourceId, recordMessages);
+            }
+          }
+        } else {
+          for (const record of fileRecords) {
+            const document = catalogBySourceId.get(record.sourceId);
+            if (document !== undefined) {
+              result.set(record.sourceId, catalogMessages(document));
+            }
+          }
+        }
+      }
+      return result;
+    },
+  );
 }
 
 export function createHistorySources(): readonly HistorySource[] {
   return [
-    { name: "conductor", label: "Conductor", scan: scanConductor },
-    { name: "claude", label: "Claude Code", scan: scanClaude },
-    { name: "codex", label: "Codex", scan: scanCodex },
-    { name: "cursor", label: "Cursor", scan: scanCursor },
+    createConductorSource(),
+    {
+      name: "claude",
+      label: "Claude Code",
+      scan: scanClaude,
+      read: readClaude,
+    },
+    { name: "codex", label: "Codex", scan: scanCodex, read: readCodex },
+    createCursorSource(),
     ...createOpenCodeSources(),
   ];
 }

--- a/packages/toolkit/src/lib/history/targeted.ts
+++ b/packages/toolkit/src/lib/history/targeted.ts
@@ -1,0 +1,78 @@
+import { dialogueFirstExcerpt } from "./context.ts";
+import { defaultHistoryPaths } from "./paths.ts";
+import { createHistorySources } from "./sources.ts";
+import type {
+  HistoryMessage,
+  HistoryRecord,
+  HistoryResult,
+  HistoryWarning,
+} from "./types.ts";
+
+export async function targetedMessages(
+  records: readonly HistoryRecord[],
+): Promise<{
+  readonly messages: ReadonlyMap<string, readonly HistoryMessage[]>;
+  readonly warnings: readonly HistoryWarning[];
+}> {
+  const sources = new Map(
+    createHistorySources().map((source) => [source.name, source]),
+  );
+  const bySource = Map.groupBy(records, (record) => record.source);
+  const messages = new Map<string, readonly HistoryMessage[]>();
+  const warnings: HistoryWarning[] = [];
+  const paths = defaultHistoryPaths();
+  await Promise.all(
+    [...bySource.entries()].map(async ([sourceName, sourceRecords]) => {
+      const source = sources.get(sourceName);
+      if (source === undefined) {
+        throw new Error(`No history adapter exists for ${sourceName}`);
+      }
+      const result = await source.read(paths, sourceRecords);
+      if (result.error !== null) {
+        warnings.push({ source: sourceName, message: result.error });
+        return;
+      }
+      const missingSourceIds = new Set(result.missingSourceIds);
+      for (const record of sourceRecords) {
+        if (missingSourceIds.has(record.sourceId)) {
+          warnings.push({
+            source: sourceName,
+            message: `History record ${String(record.id)} is no longer available in ${source.label}; rerun 'toolkit history search'.`,
+          });
+          continue;
+        }
+        const recordMessages = result.messages.get(record.sourceId);
+        if (recordMessages === undefined) {
+          throw new Error(
+            `${source.label} did not classify requested record ${String(record.id)}`,
+          );
+        }
+        messages.set(`${record.source}:${record.sourceId}`, recordMessages);
+      }
+    }),
+  );
+  return { messages, warnings };
+}
+
+export async function addExcerpts(
+  records: readonly HistoryResult[],
+  query: string,
+): Promise<{
+  readonly results: readonly HistoryResult[];
+  readonly warnings: readonly HistoryWarning[];
+}> {
+  if (records.length === 0) {
+    return { results: records, warnings: [] };
+  }
+  const targeted = await targetedMessages(records);
+  return {
+    results: records.map((record) => ({
+      ...record,
+      excerpt: dialogueFirstExcerpt(
+        targeted.messages.get(`${record.source}:${record.sourceId}`) ?? [],
+        query,
+      ),
+    })),
+    warnings: targeted.warnings,
+  };
+}

--- a/packages/toolkit/src/lib/history/text.ts
+++ b/packages/toolkit/src/lib/history/text.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import {
+  historyQueryParts,
+  normalizeSearchToken,
+  queryPartIndex,
+  type HistoryQueryPart,
+} from "./query.ts";
 
 const RecordSchema = z.record(z.string(), z.unknown());
 
@@ -42,64 +48,150 @@ const SENSITIVE_KEYS = new Set([
   "value",
 ]);
 
-export function extractText(value: unknown, depth = 0): string {
-  if (depth > 12 || value == null) {
+export function extractText(
+  value: unknown,
+  depth = 0,
+  maxCharacters = Number.POSITIVE_INFINITY,
+): string {
+  if (depth > 12 || value == null || maxCharacters <= 0) {
     return "";
   }
   if (typeof value === "string") {
-    return value;
+    return value.slice(0, maxCharacters);
   }
   if (Array.isArray(value)) {
-    return value
-      .map((entry) => extractText(entry, depth + 1))
-      .filter((entry) => entry.length > 0)
-      .join("\n");
+    const chunks: string[] = [];
+    let remaining = maxCharacters;
+    for (const entry of value) {
+      const text = extractText(entry, depth + 1, remaining);
+      if (text.length > 0) {
+        chunks.push(text);
+        remaining -= text.length + 1;
+      }
+      if (remaining <= 0) {
+        break;
+      }
+    }
+    return chunks.join("\n").slice(0, maxCharacters);
   }
   const record = parseRecord(value);
   if (record === null) {
     return "";
   }
   const chunks: string[] = [];
+  let remaining = maxCharacters;
   for (const [key, child] of Object.entries(record)) {
     if (SENSITIVE_KEYS.has(key)) {
       continue;
     }
     if (TEXT_KEYS.has(key)) {
-      const text = extractText(child, depth + 1);
+      const text = extractText(child, depth + 1, remaining);
       if (text.length > 0) {
         chunks.push(text);
+        remaining -= text.length + 1;
       }
     } else if (typeof child === "object" && child !== null) {
-      const nested = extractText(child, depth + 1);
+      const nested = extractText(child, depth + 1, remaining);
       if (nested.length > 0) {
         chunks.push(nested);
+        remaining -= nested.length + 1;
       }
     }
+    if (remaining <= 0) {
+      break;
+    }
   }
-  return chunks.join("\n");
+  return chunks.join("\n").slice(0, maxCharacters);
 }
 
 export function cleanText(value: string): string {
   return value.replaceAll(/\s+/gu, " ").trim();
 }
 
-export function excerptForQuery(text: string, query: string): string {
+type LocatedToken = {
+  readonly value: string;
+  readonly start: number;
+  readonly end: number;
+};
+
+function locatedTokens(text: string): LocatedToken[] {
+  return [...text.matchAll(/[\p{L}\p{N}]+/gu)].map((match) => ({
+    value: normalizeSearchToken(match[0]),
+    start: match.index,
+    end: match.index + match[0].length,
+  }));
+}
+
+function partRange(
+  tokens: readonly LocatedToken[],
+  part: HistoryQueryPart,
+): { readonly start: number; readonly end: number } | null {
+  const index = queryPartIndex(
+    tokens.map((entry) => entry.value),
+    part,
+  );
+  if (index < 0) {
+    return null;
+  }
+  const first = tokens[index];
+  const tokenCount = part.type === "phrase" ? part.value.split(" ").length : 1;
+  const last = tokens[index + tokenCount - 1];
+  if (first === undefined || last === undefined) {
+    throw new Error("Located history query tokens were incomplete");
+  }
+  return { start: first.start, end: last.end };
+}
+
+export function excerptForQuery(
+  text: string,
+  query: string,
+  limit = 360,
+): string {
+  if (limit <= 0) {
+    return "";
+  }
   const normalized = cleanText(text);
+  if (normalized.length <= limit) {
+    return normalized;
+  }
   if (normalized.length === 0) {
     return "";
   }
-  const terms = query
-    .toLocaleLowerCase()
-    .split(/[^\p{L}\p{N}_-]+/u)
-    .filter((term) => term.length >= 2);
-  const lower = normalized.toLocaleLowerCase();
-  const offset = terms
-    .map((term) => lower.indexOf(term))
-    .filter((index) => index >= 0)
-    .sort((a, b) => a - b)[0];
-  const start = Math.max(0, (offset ?? 0) - 100);
-  const end = Math.min(normalized.length, start + 360);
-  return `${start > 0 ? "…" : ""}${normalized.slice(start, end)}${end < normalized.length ? "…" : ""}`;
+  const tokens = locatedTokens(normalized);
+  const parts = historyQueryParts(query);
+  const ranges = parts.flatMap((part) => {
+    const range = partRange(tokens, part);
+    return range === null ? [] : [range];
+  });
+  if (ranges.length !== parts.length || ranges.length === 0) {
+    return `${normalized.slice(0, Math.max(0, limit - 1))}…`.slice(0, limit);
+  }
+  const rangeStart = Math.min(...ranges.map((range) => range.start));
+  const rangeEnd = Math.max(...ranges.map((range) => range.end));
+  if (limit <= 2) {
+    return normalized.slice(rangeStart, rangeStart + limit);
+  }
+  const contentBudget = Math.max(1, limit - 2);
+  if (rangeEnd - rangeStart <= contentBudget) {
+    const context = contentBudget - (rangeEnd - rangeStart);
+    const start = Math.max(
+      0,
+      Math.min(
+        rangeStart - Math.floor(context / 2),
+        normalized.length - contentBudget,
+      ),
+    );
+    const end = Math.min(normalized.length, start + contentBudget);
+    return `${start > 0 ? "…" : ""}${normalized.slice(start, end)}${end < normalized.length ? "…" : ""}`.slice(
+      0,
+      limit,
+    );
+  }
+  const separatedMatches = ranges
+    .sort((left, right) => left.start - right.start)
+    .map((range) => normalized.slice(range.start, range.end))
+    .join(" … ");
+  return separatedMatches.slice(0, limit);
 }
 
 export function parseTimestamp(value: unknown, fallback: Date): string {

--- a/packages/toolkit/src/lib/history/types.ts
+++ b/packages/toolkit/src/lib/history/types.ts
@@ -11,6 +11,11 @@ export const HISTORY_SOURCE_NAMES = [
 
 export type HistorySourceName = (typeof HISTORY_SOURCE_NAMES)[number];
 
+export type HistoryRuntimeRef = {
+  readonly source: HistorySourceName;
+  readonly runtimeId: string;
+};
+
 export type HistoryDocument = {
   readonly source: HistorySourceName;
   readonly sourceId: string;
@@ -20,7 +25,18 @@ export type HistoryDocument = {
   readonly agent: string | null;
   readonly createdAt: string;
   readonly updatedAt: string;
-  readonly searchText: string;
+  readonly runtimeId: string | null;
+  readonly openingPromptHash: string | null;
+  readonly dialogueText: string;
+  readonly toolOutputText: string;
+};
+
+export type HistoryMessageRole = "user" | "assistant" | "tool" | "unknown";
+
+export type HistoryMessage = {
+  readonly role: HistoryMessageRole;
+  readonly text: string;
+  readonly createdAt: string | null;
 };
 
 export type HistorySourceResult = {
@@ -35,6 +51,10 @@ export type HistorySource = {
   readonly name: HistorySourceName;
   readonly label: string;
   scan: (paths: HistoryPaths) => Promise<HistorySourceResult>;
+  read: (
+    paths: HistoryPaths,
+    records: readonly HistoryRecord[],
+  ) => Promise<HistorySourceReadResult>;
 };
 
 export type HistoryRecord = {
@@ -48,6 +68,29 @@ export type HistoryRecord = {
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly excerpt: string | null;
+};
+
+export type IndexedHistoryRecord = HistoryRecord & {
+  readonly runtimeId: string | null;
+  readonly openingPromptHash: string | null;
+};
+
+export type HistoryGroupMember = Omit<HistoryRecord, "excerpt">;
+
+export type HistoryResult = HistoryRecord & {
+  readonly members: readonly HistoryGroupMember[];
+};
+
+export type HistorySourceReadResult = {
+  readonly source: HistorySourceName;
+  readonly messages: ReadonlyMap<string, readonly HistoryMessage[]>;
+  readonly missingSourceIds: readonly string[];
+  readonly error: string | null;
+};
+
+export type HistoryWarning = {
+  readonly source: HistorySourceName;
+  readonly message: string;
 };
 
 export type HistorySourceStatus = {

--- a/packages/toolkit/test/history/cli.test.ts
+++ b/packages/toolkit/test/history/cli.test.ts
@@ -1,0 +1,320 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import { HistoryIndex } from "#lib/history/index.ts";
+import {
+  defaultHistoryPaths,
+  defaultHistoryRuntimePaths,
+} from "#lib/history/paths.ts";
+import { createHistorySources } from "#lib/history/sources.ts";
+import type { HistorySourceResult } from "#lib/history/types.ts";
+
+let fixtureHome = "";
+let recordId = 0;
+
+function unavailable(
+  source: "cursor" | "claude",
+  error: string | null,
+): HistorySourceResult {
+  return {
+    source,
+    available: false,
+    documents: [],
+    fingerprint: "missing",
+    error,
+  };
+}
+
+beforeAll(async () => {
+  fixtureHome = await mkdtemp(path.join(os.tmpdir(), "toolkit-history-cli-"));
+  const paths = defaultHistoryPaths(fixtureHome);
+  await mkdir(path.dirname(paths.conductorDb), { recursive: true });
+  const database = new Database(paths.conductorDb);
+  database.run(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, title TEXT, created_at TEXT, updated_at TEXT,
+      model TEXT, agent_type TEXT, workspace_id TEXT
+    );
+    CREATE TABLE session_messages (
+      id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT,
+      full_message TEXT, created_at TEXT
+    );
+  `);
+  database.run(
+    "INSERT INTO sessions VALUES ('current-session', 'Synthetic history', '2026-08-18T00:00:00Z', '2026-08-18T00:02:00Z', 'model', 'agent', '/fixture')",
+  );
+  database.run(
+    "INSERT INTO session_messages VALUES ('m1', 'current-session', 'user', 'Investigate synthetic history ranking', NULL, '2026-08-18T00:00:00Z')",
+  );
+  database.run(
+    "INSERT INTO session_messages VALUES ('m2', 'current-session', 'assistant', 'Synthetic history answer', NULL, '2026-08-18T00:01:00Z')",
+  );
+  database.close();
+
+  const conductor = createHistorySources().find(
+    (source) => source.name === "conductor",
+  );
+  if (conductor === undefined) {
+    throw new Error("Conductor history adapter is missing");
+  }
+  const scanned = await conductor.scan(paths);
+  const index = await HistoryIndex.open(
+    defaultHistoryRuntimePaths(fixtureHome),
+  );
+  await index.ingest([
+    scanned,
+    {
+      source: "codex",
+      available: true,
+      documents: [
+        {
+          source: "codex",
+          sourceId: "codex-collision",
+          title: "Runtime collision fixture",
+          path: "/fixture/codex-collision",
+          workspace: "/fixture",
+          agent: "fixture",
+          createdAt: "2026-08-18T00:00:00Z",
+          updatedAt: "2026-08-18T00:01:00Z",
+          runtimeId: "current-session",
+          openingPromptHash: null,
+          dialogueText: "Unique collisionterm dialogue",
+          toolOutputText: "",
+        },
+      ],
+      fingerprint: "codex-collision-fixture",
+      error: null,
+    },
+    unavailable("cursor", "fixture cursor warning"),
+    unavailable("claude", null),
+  ]);
+  const match = index.search("synthetic", { since: null, source: null })[0];
+  if (match === undefined) {
+    throw new Error("Synthetic history record was not indexed");
+  }
+  recordId = match.id;
+  index.close();
+});
+
+afterAll(async () => {
+  if (fixtureHome.length > 0) {
+    await rm(fixtureHome, { recursive: true, force: true });
+  }
+});
+
+async function runHistory(
+  args: readonly string[],
+  conductorSessionId = "different-session",
+  codexThreadId = "different-thread",
+): Promise<{
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}> {
+  const child = Bun.spawn(
+    [process.execPath, "run", "src/index.ts", "history", ...args],
+    {
+      cwd: path.join(import.meta.dir, "../.."),
+      env: {
+        ...Bun.env,
+        HOME: fixtureHome,
+        CONDUCTOR_SESSION_ID: conductorSessionId,
+        CODEX_THREAD_ID: codexThreadId,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+describe("history JSON interfaces", () => {
+  test("returns search and recent envelopes with warnings", async () => {
+    const search = await runHistory([
+      "search",
+      "synthetic",
+      "--since",
+      "7d",
+      "--json",
+    ]);
+    expect(search).toEqual(expect.objectContaining({ exitCode: 0 }));
+    const searchBody = z
+      .object({
+        query: z.string(),
+        results: z.array(
+          z.object({ id: z.number(), members: z.array(z.unknown()) }),
+        ),
+        warnings: z.array(
+          z.object({ source: z.string(), message: z.string() }),
+        ),
+      })
+      .parse(JSON.parse(search.stdout));
+    expect(Object.keys(searchBody).sort()).toEqual([
+      "query",
+      "results",
+      "warnings",
+    ]);
+    expect(searchBody.results).toHaveLength(1);
+    expect(searchBody.warnings).toContainEqual({
+      source: "cursor",
+      message: "fixture cursor warning",
+    });
+
+    const recent = await runHistory(["recent", "--since", "7d", "--json"]);
+    expect(recent.exitCode).toBe(0);
+    const recentBody = z
+      .object({ results: z.array(z.unknown()), warnings: z.array(z.unknown()) })
+      .parse(JSON.parse(recent.stdout));
+    expect(Object.keys(recentBody).sort()).toEqual(["results", "warnings"]);
+  });
+
+  test("hides the current session unless --include-current is supplied", async () => {
+    const hidden = await runHistory(
+      ["search", "synthetic", "--since", "7d", "--json"],
+      "current-session",
+    );
+    const hiddenBody = z
+      .object({ results: z.array(z.unknown()) })
+      .parse(JSON.parse(hidden.stdout));
+    expect(hiddenBody.results).toHaveLength(0);
+
+    const included = await runHistory(
+      ["search", "synthetic", "--since", "7d", "--include-current", "--json"],
+      "current-session",
+    );
+    const includedBody = z
+      .object({ results: z.array(z.unknown()) })
+      .parse(JSON.parse(included.stdout));
+    expect(includedBody.results).toHaveLength(1);
+  });
+
+  test("scopes current runtime IDs to their source", async () => {
+    const conductorCollision = await runHistory(
+      ["search", "collisionterm", "--since", "7d", "--json"],
+      "current-session",
+    );
+    const conductorBody = z
+      .object({ results: z.array(z.object({ source: z.string() })) })
+      .parse(JSON.parse(conductorCollision.stdout));
+    expect(conductorBody.results).toEqual([{ source: "codex" }]);
+
+    const codexCurrent = await runHistory(
+      ["search", "collisionterm", "--since", "7d", "--json"],
+      "different-session",
+      "current-session",
+    );
+    const codexBody = z
+      .object({ results: z.array(z.unknown()) })
+      .parse(JSON.parse(codexCurrent.stdout));
+    expect(codexBody.results).toHaveLength(0);
+  });
+
+  test("returns bounded show context and an actionable missing-ID error", async () => {
+    const shown = await runHistory([
+      "show",
+      String(recordId),
+      "--query",
+      "synthetic",
+      "--json",
+    ]);
+    expect(shown.exitCode).toBe(0);
+    const body = z
+      .object({
+        record: z.object({ id: z.number() }),
+        messages: z.array(z.object({ role: z.string(), text: z.string() })),
+        truncated: z.boolean(),
+      })
+      .parse(JSON.parse(shown.stdout));
+    expect(Object.keys(body).sort()).toEqual([
+      "messages",
+      "record",
+      "truncated",
+    ]);
+    expect(body.record.id).toBe(recordId);
+    expect(body.messages.length).toBeLessThanOrEqual(8);
+
+    const missing = await runHistory(["show", "999999", "--json"]);
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain("rerun 'toolkit history search'");
+
+    const malformed = await runHistory(["show", `${String(recordId)}junk`]);
+    expect(malformed.exitCode).toBe(1);
+    expect(malformed.stderr).toContain("positive local index ID");
+
+    const malformedMessages = await runHistory([
+      "show",
+      String(recordId),
+      "--messages",
+      "8junk",
+    ]);
+    expect(malformedMessages.exitCode).toBe(1);
+    expect(malformedMessages.stderr).toContain("Messages must be an integer");
+
+    const malformedLimit = await runHistory([
+      "search",
+      "synthetic",
+      "--limit",
+      "2junk",
+    ]);
+    expect(malformedLimit.exitCode).toBe(1);
+    expect(malformedLimit.stderr).toContain("Limit must be an integer");
+
+    const tokenlessQuery = await runHistory([
+      "show",
+      String(recordId),
+      "--query",
+      "!!!",
+    ]);
+    expect(tokenlessQuery.exitCode).toBe(1);
+    expect(tokenlessQuery.stderr).toContain(
+      "Search query must contain at least one letter or number",
+    );
+  });
+
+  test("writes human warnings to stderr", async () => {
+    const result = await runHistory(["search", "synthetic", "--since", "7d"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Synthetic history");
+    expect(result.stderr).toContain("Warning [cursor]: fixture cursor warning");
+  });
+
+  test("reports an indexed record that disappeared from its source", async () => {
+    const database = new Database(defaultHistoryPaths(fixtureHome).conductorDb);
+    database.run("DELETE FROM sessions WHERE id = ?", ["current-session"]);
+    database.close();
+
+    const shown = await runHistory(["show", String(recordId), "--json"]);
+    expect(shown.exitCode).toBe(1);
+    expect(shown.stderr).toContain("no longer available");
+    expect(shown.stderr).toContain("rerun 'toolkit history search'");
+
+    const searched = await runHistory([
+      "search",
+      "synthetic",
+      "--since",
+      "7d",
+      "--include-excerpts",
+      "--json",
+    ]);
+    expect(searched.exitCode).toBe(0);
+    const body = z
+      .object({
+        warnings: z.array(
+          z.object({ source: z.string(), message: z.string() }),
+        ),
+      })
+      .parse(JSON.parse(searched.stdout));
+    expect(body.warnings).toContainEqual({
+      source: "conductor",
+      message: expect.stringContaining("no longer available"),
+    });
+  });
+});

--- a/packages/toolkit/test/history/history.test.ts
+++ b/packages/toolkit/test/history/history.test.ts
@@ -1,15 +1,19 @@
 import { Database } from "bun:sqlite";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { HistoryIndex, parseSince } from "#lib/history/index.ts";
+import { HistoryIndex } from "#lib/history/index.ts";
+import { parseSince } from "#lib/history/query.ts";
 import { renderLaunchAgent } from "#lib/history/launchd.ts";
 import {
   defaultHistoryRuntimePaths,
   type HistoryPaths,
 } from "#lib/history/paths.ts";
 import { createHistorySources } from "#lib/history/sources.ts";
+import { scanHistorySources } from "#lib/history/serve.ts";
+import { readCursorDatabase } from "#lib/history/sources-shared.ts";
+import type { HistoryDocument, HistoryRecord } from "#lib/history/types.ts";
 
 let fixtureRoot = "";
 let paths: HistoryPaths;
@@ -25,12 +29,33 @@ function writeDatabase(
   database.close();
 }
 
+function seedLongConductorSession(database: Database): void {
+  database.run(
+    "INSERT INTO sessions VALUES ('s-long', 'Long session', '2026-08-10T00:00:00Z', '2026-08-11T00:00:00Z', 'model', 'agent', 'workspace')",
+  );
+  const insertMessage = database.prepare(
+    "INSERT INTO session_messages VALUES (?, 's-long', 'assistant', ?, NULL, ?)",
+  );
+  const insertMessages = database.transaction(() => {
+    for (let index = 0; index < 1100; index += 1) {
+      insertMessage.run(
+        `long-${String(index).padStart(4, "0")}`,
+        index === 400
+          ? "middle-search-marker substantive dialogue"
+          : `routine dialogue ${String(index)}`,
+        new Date(Date.UTC(2026, 7, 10, 0, 0, index)).toISOString(),
+      );
+    }
+  });
+  insertMessages();
+}
+
 beforeAll(async () => {
   fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "toolkit-history-"));
   const conductorDir = path.join(fixtureRoot, "conductor");
   const claudeDir = path.join(fixtureRoot, "claude/projects/project");
   const codexDir = path.join(fixtureRoot, "codex");
-  const cursorDir = path.join(fixtureRoot, "cursor");
+  const cursorDir = path.join(fixtureRoot, "Cursor data with spaces");
   const opencodeDir = path.join(fixtureRoot, "opencode");
   await Promise.all([
     mkdir(conductorDir, { recursive: true }),
@@ -54,15 +79,73 @@ beforeAll(async () => {
         "INSERT INTO sessions VALUES ('s1', 'Ingress repair', '2026-08-10T00:00:00Z', '2026-08-11T00:00:00Z', 'model', 'agent', 'workspace')",
       );
       database.run(
+        "INSERT INTO sessions VALUES ('s-empty', 'Empty session', '2026-08-09T00:00:00Z', '2026-08-09T00:00:00Z', 'model', 'agent', 'workspace')",
+      );
+      database.run(
         "INSERT INTO session_messages VALUES ('m1', 's1', 'user', 'Fix kubernetes ingress', NULL, '2026-08-10T00:00:00Z')",
       );
+      database.run(
+        `INSERT INTO session_messages VALUES ('m2', 's1', 'assistant', '${JSON.stringify(
+          {
+            type: "assistant",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Substantive ingress dialogue" },
+                { type: "thinking", thinking: "omit-conductor-reasoning" },
+                {
+                  type: "tool_use",
+                  name: "shell",
+                  input: { command: "kubectl get ingress" },
+                },
+              ],
+            },
+          },
+        ).replaceAll("'", "''")}', NULL, '2026-08-10T00:01:00Z')`,
+      );
+      database.run(
+        `INSERT INTO session_messages VALUES ('m3', 's1', 'assistant', '${JSON.stringify({ type: "user", message: { role: "user", content: "<system_instruction>omit-conductor-system</system_instruction>" } }).replaceAll("'", "''")}', NULL, '2026-08-10T00:02:00Z')`,
+      );
+      database.run(
+        `INSERT INTO session_messages VALUES ('m4', 's1', 'assistant', '${JSON.stringify(
+          {
+            type: "assistant",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "x".repeat(40_000) },
+                { type: "text", text: "later-content-block-marker" },
+              ],
+            },
+          },
+        ).replaceAll("'", "''")}', NULL, '2026-08-10T00:03:00Z')`,
+      );
+      seedLongConductorSession(database);
     },
   );
 
   const claudeFile = path.join(claudeDir, "session.jsonl");
   await Bun.write(
     claudeFile,
-    `${JSON.stringify({ type: "user", timestamp: "2026-08-12T00:00:00Z", message: { content: "Investigate database migration" } })}\n${JSON.stringify({ type: "assistant", timestamp: "2026-08-12T00:01:00Z", message: { content: [{ type: "text", text: "Migration is complete" }] } })}\n`,
+    `${JSON.stringify({ type: "user", sessionId: "claude-session", timestamp: "2026-08-12T00:00:00Z", message: { role: "user", content: "Investigate database migration" } })}\n${JSON.stringify(
+      {
+        type: "assistant",
+        sessionId: "claude-session",
+        timestamp: "2026-08-12T00:01:00Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Migration is complete" },
+            { type: "thinking", thinking: "omit-claude-reasoning" },
+            {
+              type: "tool_use",
+              name: "shell",
+              input: { command: "bun test migration" },
+            },
+          ],
+        },
+      },
+    )}\n${JSON.stringify({ type: "system", timestamp: "2026-08-12T00:02:00Z", content: "omit-claude-system" })}\n`,
   );
 
   const codexThread = path.join(codexDir, "thread_history_1.sqlite");
@@ -73,12 +156,18 @@ beforeAll(async () => {
       database.run(
         "INSERT INTO thread_items VALUES ('t1', 'turn', 'item', 1, 1786406400000, '{\"type\":\"userMessage\",\"text\":\"Repair Buildkite pipeline\"}', 'userMessage', 0)",
       );
+      database.run(
+        "INSERT INTO thread_items VALUES ('t1', 'turn', 'reasoning', 2, 1786406401000, '{\"text\":\"omit-codex-reasoning\"}', 'reasoning', 0)",
+      );
+      database.run(
+        "INSERT INTO thread_items VALUES ('t1', 'turn', 'tool', 3, 1786406402000, '{\"command\":\"bk build view\"}', 'commandExecution', 0)",
+      );
     },
   );
   const codexHistory = path.join(codexDir, "history.jsonl");
   await Bun.write(
     codexHistory,
-    `${JSON.stringify({ timestamp: "2026-08-13T00:00:00Z", prompt: "Review deployment status" })}\n`,
+    `${JSON.stringify({ session_id: "history-session", timestamp: "2026-08-13T00:00:00Z", prompt: "Review deployment status" })}\nnot-json\n"scalar prompt"\n${JSON.stringify({ session_id: "metadata-only" })}\n`,
   );
   const codexCatalog = path.join(codexDir, "codex-dev.db");
   writeDatabase(
@@ -87,6 +176,9 @@ beforeAll(async () => {
     (database) => {
       database.run(
         "INSERT INTO local_thread_catalog VALUES ('host', 't1', 'Cataloged work', 1786406400, 1786406400, '/workspace', 'openai', 'main', 0)",
+      );
+      database.run(
+        "INSERT INTO local_thread_catalog VALUES ('host', 't2', 'Catalog only', 1786406400, 1786406400, '/catalog', 'openai', 'feature', 0)",
       );
     },
   );
@@ -103,9 +195,14 @@ beforeAll(async () => {
       database.run(
         "INSERT INTO conversations VALUES (1, 'local', '', 'c1', 'Cursor fix', 1786406400000, 0, 'root', NULL)",
       );
-      database.run(
-        "INSERT INTO conversation_fts(rowid, title, body) VALUES (1, 'Cursor fix', 'Resolve TypeScript typecheck')",
-      );
+      database
+        .prepare(
+          "INSERT INTO conversation_fts(rowid, title, body) VALUES (1, ?, ?)",
+        )
+        .run(
+          "Cursor fix",
+          `Resolve TypeScript typecheck ${"routine cursor context ".repeat(1000)}cursor-tail-search-marker`,
+        );
     },
   );
 
@@ -126,7 +223,16 @@ beforeAll(async () => {
         "INSERT INTO message VALUES ('om1', 'o1', '{\"role\":\"user\"}', 1786406400000, 1786406400000)",
       );
       database.run(
+        'INSERT INTO message VALUES (\'om2\', \'o1\', \'{"role":"assistant","text":"Later direct message"}\', 1786406405000, 1786406405000)',
+      );
+      database.run(
         "INSERT INTO part VALUES ('op1', 'om1', 'o1', 1786406400000, 1786406400000, '{\"type\":\"text\",\"text\":\"Improve launchd ingestion\"}')",
+      );
+      database.run(
+        "INSERT INTO part VALUES ('op2', 'om1', 'o1', 1786406400001, 1786406400001, '{\"type\":\"reasoning\",\"text\":\"omit-opencode-reasoning\"}')",
+      );
+      database.run(
+        "INSERT INTO part VALUES ('op3', 'om1', 'o1', 1786406400002, 1786406400002, '{\"type\":\"tool\",\"command\":\"launchctl print fixture\"}')",
       );
     },
   );
@@ -168,9 +274,212 @@ describe("history source adapters", () => {
       results
         .flatMap((result) => result.documents)
         .some((document) =>
-          document.searchText.includes("must-not-be-indexed"),
+          `${document.dialogueText}\n${document.toolOutputText}`.includes(
+            "must-not-be-indexed",
+          ),
         ),
     ).toBe(false);
+  });
+
+  test("classifies dialogue and tool text while omitting private control records", async () => {
+    const results = await Promise.all(
+      createHistorySources().map((source) => source.scan(paths)),
+    );
+    const documents = results.flatMap((result) => result.documents);
+    const conductor = documents.find(
+      (document) => document.source === "conductor",
+    );
+    const claude = documents.find((document) => document.source === "claude");
+    const codex = documents.find(
+      (document) =>
+        document.source === "codex" && document.path.includes("thread_history"),
+    );
+    const opencode = documents.find(
+      (document) => document.source === "opencode-conductor",
+    );
+    expect(conductor?.dialogueText).toContain("Substantive ingress dialogue");
+    expect(conductor?.toolOutputText).toContain("kubectl get ingress");
+    expect(conductor?.dialogueText).not.toContain("omit-conductor");
+    expect(claude?.dialogueText).toContain("Migration is complete");
+    expect(claude?.toolOutputText).toContain("bun test migration");
+    expect(claude?.dialogueText).not.toContain("omit-claude");
+    expect(codex?.dialogueText).toContain("Repair Buildkite pipeline");
+    expect(codex?.toolOutputText).toContain("bk build view");
+    expect(codex?.dialogueText).not.toContain("omit-codex-reasoning");
+    expect(opencode?.dialogueText).toContain("Improve launchd ingestion");
+    expect(
+      opencode?.dialogueText.indexOf("Improve launchd ingestion"),
+    ).toBeLessThan(
+      opencode?.dialogueText.indexOf("Later direct message") ?? -1,
+    );
+    expect(opencode?.toolOutputText).toContain("launchctl print fixture");
+    expect(opencode?.dialogueText).not.toContain("omit-opencode-reasoning");
+    const codexThreadCopies = documents.filter(
+      (document) => document.source === "codex" && document.runtimeId === "t1",
+    );
+    expect(codexThreadCopies).toHaveLength(1);
+    expect(codexThreadCopies[0]?.title).toBe("Cataloged work");
+    expect(codexThreadCopies[0]?.workspace).toBe("/workspace");
+    expect(codexThreadCopies[0]?.toolOutputText).toContain("main");
+  });
+
+  test("retains Cursor tails and rejects malformed Codex history lines", async () => {
+    const results = await Promise.all(
+      createHistorySources().map((source) => source.scan(paths)),
+    );
+    const documents = results.flatMap((result) => result.documents);
+    const codexPrompts = documents.filter(
+      (document) =>
+        document.source === "codex" && document.path.endsWith("history.jsonl"),
+    );
+    const cursor = documents.find((document) => document.source === "cursor");
+
+    expect(codexPrompts).toHaveLength(1);
+    expect(codexPrompts[0]?.runtimeId).toBe("history-session");
+    expect(cursor?.dialogueText).toContain("cursor-tail-search-marker");
+  });
+
+  test("indexes middle messages and later oversized Conductor blocks", async () => {
+    const conductor = createHistorySources().find(
+      (source) => source.name === "conductor",
+    );
+    if (conductor === undefined) {
+      throw new Error("Conductor source is missing");
+    }
+    const scanned = await conductor.scan(paths);
+    const longSession = scanned.documents.find(
+      (document) => document.sourceId === "s-long",
+    );
+    const oversizedBlocks = scanned.documents.find(
+      (document) => document.sourceId === "s1",
+    );
+
+    expect(longSession?.dialogueText).toContain("middle-search-marker");
+    expect(oversizedBlocks?.dialogueText).toContain(
+      "later-content-block-marker",
+    );
+  });
+
+  test("returns indexed Codex catalog metadata from targeted reads", async () => {
+    const codexSource = createHistorySources().find(
+      (source) => source.name === "codex",
+    );
+    if (codexSource === undefined) {
+      throw new Error("Codex source is missing");
+    }
+    const scanned = await codexSource.scan(paths);
+    const thread = scanned.documents.find(
+      (document) => document.runtimeId === "t1",
+    );
+    const catalogOnly = scanned.documents.find(
+      (document) => document.runtimeId === "t2",
+    );
+    const codexRecords = [thread, catalogOnly].flatMap((document, index) =>
+      document === undefined ? [] : [recordFromDocument(document, index + 1)],
+    );
+    const codexMessages = await codexSource.read(paths, codexRecords);
+    expect([...codexMessages.messages.values()].flat()).toContainEqual(
+      expect.objectContaining({
+        role: "tool",
+        text: expect.stringContaining("main"),
+      }),
+    );
+    expect([...codexMessages.messages.values()].flat()).toContainEqual(
+      expect.objectContaining({
+        role: "tool",
+        text: expect.stringContaining("feature"),
+      }),
+    );
+  });
+
+  test("scans history sources with bounded concurrency", async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const sources = Array.from({ length: 5 }, (_, index) => ({
+      name: "conductor" as const,
+      label: `Fixture ${String(index)}`,
+      scan: async () => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await Bun.sleep(5);
+        active -= 1;
+        return {
+          source: "conductor" as const,
+          available: true,
+          documents: [],
+          fingerprint: String(index),
+          error: null,
+        };
+      },
+      read: async () => ({
+        source: "conductor" as const,
+        messages: new Map(),
+        missingSourceIds: [],
+        error: null,
+      }),
+    }));
+
+    const results = await scanHistorySources(sources, paths);
+
+    expect(results).toHaveLength(5);
+    expect(maximumActive).toBe(2);
+  });
+});
+
+describe("history source adapter reads", () => {
+  test("performs batched reads only for selected indexed records", async () => {
+    const sources = createHistorySources();
+    for (const source of sources) {
+      const scanned = await source.scan(paths);
+      const document = scanned.documents[0];
+      expect(document).toBeDefined();
+      if (document === undefined) {
+        throw new Error(`Missing ${source.name} fixture document`);
+      }
+      const record = recordFromDocument(document, 1);
+      const selected = await source.read(paths, [record]);
+      expect(selected.error).toBeNull();
+      expect(selected.missingSourceIds).toEqual([]);
+      expect([...selected.messages.keys()]).toEqual([document.sourceId]);
+      expect(
+        [...selected.messages.values()]
+          .flat()
+          .some((message) => message.text.includes("must-not-be-indexed")),
+      ).toBe(false);
+      if (source.name === "cursor") {
+        expect(selected.messages.get(document.sourceId)?.[0]?.role).toBe(
+          "unknown",
+        );
+      }
+    }
+  });
+
+  test("distinguishes an empty source record from a missing one", async () => {
+    const source = createHistorySources().find(
+      (entry) => entry.name === "conductor",
+    );
+    if (source === undefined) {
+      throw new Error("Conductor source is missing");
+    }
+    const scanned = await source.scan(paths);
+    const empty = scanned.documents.find(
+      (document) => document.sourceId === "s-empty",
+    );
+    if (empty === undefined) {
+      throw new Error("Empty Conductor fixture was not indexed");
+    }
+    const emptyRecord = recordFromDocument(empty, 1);
+    const missingRecord = {
+      ...emptyRecord,
+      id: 2,
+      sourceId: "missing-session",
+    };
+
+    const selected = await source.read(paths, [emptyRecord, missingRecord]);
+
+    expect(selected.error).toBeNull();
+    expect(selected.messages.get("s-empty")).toEqual([]);
+    expect(selected.missingSourceIds).toEqual(["missing-session"]);
   });
 
   test("reports missing sources without pretending they are indexed", async () => {
@@ -186,7 +495,63 @@ describe("history source adapters", () => {
     expect(result?.available).toBe(false);
     expect(result?.documents).toHaveLength(0);
   });
+
+  test("opens immutable Cursor data from a path with spaces", async () => {
+    const immutableDir = path.join(fixtureRoot, "immutable Cursor fixture");
+    await mkdir(immutableDir, { recursive: true });
+    const immutablePath = path.join(immutableDir, "conversation search.db");
+    writeDatabase(
+      immutablePath,
+      "CREATE TABLE fixture (value TEXT);",
+      (database) => {
+        database.run("PRAGMA journal_mode = WAL");
+        database.run("INSERT INTO fixture VALUES ('readable')");
+      },
+    );
+    await chmod(immutablePath, 0o400);
+    await chmod(immutableDir, 0o500);
+    try {
+      let ordinaryAttempted = false;
+      const database = await readCursorDatabase(immutablePath, () => {
+        ordinaryAttempted = true;
+        throw new Error("SQLITE_CANTOPEN: fixture ordinary read failed");
+      });
+      expect(ordinaryAttempted).toBe(true);
+      const row = database.query("SELECT value FROM fixture").get();
+      expect(row).toEqual({ value: "readable" });
+      database.close();
+
+      await chmod(immutableDir, 0o700);
+      await Bun.write(`${immutablePath}-wal`, "live WAL fixture");
+      await expect(
+        readCursorDatabase(immutablePath, () => {
+          throw new Error("SQLITE_CANTOPEN: fixture ordinary read failed");
+        }),
+      ).rejects.toThrow("live WAL is present");
+      await rm(`${immutablePath}-wal`);
+    } finally {
+      await chmod(immutableDir, 0o700);
+    }
+  });
 });
+
+function recordFromDocument(
+  document: HistoryDocument,
+  id: number,
+): HistoryRecord {
+  return {
+    id,
+    source: document.source,
+    sourceId: document.sourceId,
+    title: document.title,
+    path: document.path,
+    workspace: document.workspace,
+    agent: document.agent,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+    excerpt: null,
+  };
+}
 
 describe("history index", () => {
   test("searches, updates, deletes, and filters indexed work", async () => {
@@ -205,24 +570,23 @@ describe("history index", () => {
     }
     await index.ingest([first]);
     expect(
-      index.search("database", { since: null, source: "claude", limit: 20 }),
+      index.search("database", { since: null, source: "claude" }),
     ).toHaveLength(1);
     expect(
       index.search("database migration", {
         since: null,
         source: null,
-        limit: 20,
       }),
     ).toHaveLength(1);
     expect(
-      index.search("database", { since: null, source: "codex", limit: 20 }),
+      index.search("database", { since: null, source: "codex" }),
     ).toHaveLength(0);
 
     await index.ingest([
       { ...first, fingerprint: `${first.fingerprint}:changed`, documents: [] },
     ]);
     expect(
-      index.search("database", { since: null, source: "claude", limit: 20 }),
+      index.search("database", { since: null, source: "claude" }),
     ).toHaveLength(0);
     index.close();
   });

--- a/packages/toolkit/test/history/index-ranking.test.ts
+++ b/packages/toolkit/test/history/index-ranking.test.ts
@@ -1,0 +1,413 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { HistoryIndex } from "#lib/history/index.ts";
+import { defaultHistoryRuntimePaths } from "#lib/history/paths.ts";
+import { ftsQuery } from "#lib/history/query.ts";
+import type {
+  HistoryDocument,
+  HistorySourceName,
+  HistorySourceResult,
+} from "#lib/history/types.ts";
+
+const roots: string[] = [];
+
+async function runtime() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "toolkit-history-index-"));
+  roots.push(root);
+  return defaultHistoryRuntimePaths(root);
+}
+
+function document(
+  sourceId: string,
+  values: {
+    readonly title?: string;
+    readonly dialogue?: string;
+    readonly tool?: string;
+    readonly createdAt?: string;
+    readonly promptHash?: string;
+    readonly runtimeId?: string;
+    readonly source?: HistorySourceName;
+  },
+): HistoryDocument {
+  const createdAt = values.createdAt ?? "2026-08-01T00:00:00.000Z";
+  return {
+    source: values.source ?? "conductor",
+    sourceId,
+    title: values.title ?? `Session ${sourceId}`,
+    path: `/fixture/${sourceId}`,
+    workspace: "/fixture",
+    agent: "fixture",
+    createdAt,
+    updatedAt: createdAt,
+    runtimeId: values.runtimeId ?? sourceId,
+    openingPromptHash: values.promptHash ?? null,
+    dialogueText: values.dialogue ?? "",
+    toolOutputText: values.tool ?? "",
+  };
+}
+
+function result(
+  documents: readonly HistoryDocument[],
+  source: HistorySourceName = "conductor",
+): HistorySourceResult {
+  return {
+    source,
+    available: true,
+    documents,
+    fingerprint: "fixture-v1",
+    error: null,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("history BM25 index", () => {
+  test("ranks dialogue above newer tool-only mentions", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([
+        document("substantive", {
+          dialogue:
+            "Bryan Bucks betting model analysis with calibration and bankroll evaluation",
+          createdAt: "2026-08-01T00:00:00.000Z",
+        }),
+        document("branch", {
+          tool: "git branch list pull-up-bryan-bucks-v1",
+          createdAt: "2026-08-18T00:00:00.000Z",
+        }),
+      ]),
+    ]);
+
+    const matches = index.search("Bryan Bucks", {
+      since: null,
+      source: null,
+    });
+    expect(matches.map((match) => match.sourceId)).toEqual([
+      "substantive",
+      "branch",
+    ]);
+    index.close();
+  });
+
+  test("supports exact quoted phrases and AND-prefix terms", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([
+        document("exact", { dialogue: "Deploy Bryan Bucks model safely" }),
+        document("separated", {
+          dialogue: "Deploy Bryan experimental model before Bucks reporting",
+        }),
+        document("punctuated", { dialogue: "Deploy foo bar safely" }),
+        document("accented", { dialogue: "Review the café forecast" }),
+      ]),
+    ]);
+
+    expect(
+      index
+        .search('"Bryan Bucks"', { since: null, source: null })
+        .map((match) => match.sourceId),
+    ).toEqual(["exact"]);
+    expect(
+      index
+        .search("depl buck", { since: null, source: null })
+        .map((match) => match.sourceId)
+        .sort(),
+    ).toEqual(["exact", "separated"]);
+    expect(ftsQuery('"Bryan Bucks" model')).toBe('"bryan bucks" AND "model"*');
+    expect(ftsQuery('"foo.bar"')).toBe('"foo bar"');
+    expect(
+      index
+        .search('"foo.bar"', { since: null, source: null })
+        .map((match) => match.sourceId),
+    ).toEqual(["punctuated"]);
+    expect(
+      index
+        .search("cafe", { since: null, source: null })
+        .map((match) => match.sourceId),
+    ).toEqual(["accented"]);
+    index.close();
+  });
+
+  test("loads every same-prompt sibling without applying the FTS query", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([
+        document("matching", {
+          dialogue: "later dialogue contains the retrieval term",
+          createdAt: "2026-08-01T00:10:00.000Z",
+          promptHash: "shared-prompt",
+        }),
+        document("sibling", {
+          dialogue: "the parallel branch took another direction",
+          createdAt: "2026-08-01T00:00:00.000Z",
+          promptHash: "shared-prompt",
+        }),
+      ]),
+    ]);
+
+    expect(
+      index.search("retrieval", { since: null, source: null }),
+    ).toHaveLength(1);
+    expect(
+      index
+        .recent({
+          since: null,
+          source: null,
+          openingPromptHash: "shared-prompt",
+        })
+        .map((match) => match.sourceId)
+        .sort(),
+    ).toEqual(["matching", "sibling"]);
+    index.close();
+  });
+
+  test("paginates ranked rows after filtering current runtimes", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([
+        document("oldest", {
+          dialogue: "bounded history match",
+          createdAt: "2026-08-01T00:00:00.000Z",
+        }),
+        document("middle", {
+          dialogue: "bounded history match",
+          createdAt: "2026-08-02T00:00:00.000Z",
+        }),
+        document("current", {
+          dialogue: "bounded history match",
+          createdAt: "2026-08-03T00:00:00.000Z",
+        }),
+      ]),
+    ]);
+
+    const options = {
+      since: null,
+      source: null,
+      excludedRuntimes: [
+        { source: "conductor" as const, runtimeId: "current" },
+      ],
+      limit: 1,
+      offset: 1,
+    };
+    expect(
+      index.search("bounded", options).map((match) => match.sourceId),
+    ).toEqual(["oldest"]);
+    expect(index.recent(options).map((match) => match.sourceId)).toEqual([
+      "oldest",
+    ]);
+    index.close();
+  });
+});
+
+describe("history read snapshots", () => {
+  test("holds one read snapshot across paged queries", async () => {
+    const paths = await runtime();
+    const writer = await HistoryIndex.open(paths);
+    await writer.ingest([
+      result([
+        document("oldest", {
+          createdAt: "2026-08-01T00:00:00.000Z",
+        }),
+        document("middle", {
+          createdAt: "2026-08-02T00:00:00.000Z",
+        }),
+        document("newest", {
+          createdAt: "2026-08-03T00:00:00.000Z",
+        }),
+      ]),
+    ]);
+    writer.close();
+
+    const reader = await HistoryIndex.open(paths, true);
+    const concurrentWriter = new Database(paths.indexDb, { strict: true });
+    const observed = reader.readSnapshot(() => {
+      const first = reader.recent({
+        since: null,
+        source: null,
+        limit: 1,
+        offset: 0,
+      });
+      concurrentWriter.run(
+        "UPDATE documents SET updated_at = ? WHERE source_id = ?",
+        ["2026-08-04T00:00:00.000Z", "oldest"],
+      );
+      const second = reader.recent({
+        since: null,
+        source: null,
+        limit: 1,
+        offset: 1,
+      });
+      return [...first, ...second].map((record) => record.sourceId);
+    });
+
+    expect(observed).toEqual(["newest", "middle"]);
+    expect(
+      reader
+        .recent({ since: null, source: null, limit: 1, offset: 0 })
+        .map((record) => record.sourceId),
+    ).toEqual(["oldest"]);
+    concurrentWriter.close();
+    reader.close();
+  });
+});
+
+describe("history BM25 index", () => {
+  test("scopes runtime exclusions to their owning source", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([
+        document("conductor-current", {
+          dialogue: "shared runtime collision",
+          runtimeId: "shared-runtime",
+        }),
+      ]),
+      result(
+        [
+          document("codex-unrelated", {
+            dialogue: "shared runtime collision",
+            runtimeId: "shared-runtime",
+            source: "codex",
+          }),
+        ],
+        "codex",
+      ),
+    ]);
+    const options = {
+      since: null,
+      source: null,
+      excludedRuntimes: [
+        { source: "conductor" as const, runtimeId: "shared-runtime" },
+      ],
+    };
+
+    expect(
+      index.search("collision", options).map((row) => row.sourceId),
+    ).toEqual(["codex-unrelated"]);
+    expect(index.recent(options).map((row) => row.sourceId)).toEqual([
+      "codex-unrelated",
+    ]);
+    index.close();
+  });
+});
+
+describe("history index rebuilds", () => {
+  test("force reindex rebuilds the derived corpus", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([
+        document("removed", { dialogue: "old derived row" }),
+        document("retained", { dialogue: "retained conversation" }),
+      ]),
+    ]);
+
+    await index.ingest(
+      [result([document("retained", { dialogue: "retained conversation" })])],
+      true,
+    );
+
+    expect(index.search("retained", { since: null, source: null })).toEqual([
+      expect.objectContaining({ id: 1, sourceId: "retained" }),
+    ]);
+    expect(index.search("derived", { since: null, source: null })).toEqual([]);
+    index.close();
+  });
+
+  test("retries a source after a forced reindex scan fails", async () => {
+    const paths = await runtime();
+    const index = await HistoryIndex.open(paths);
+    await index.ingest(
+      [
+        {
+          source: "conductor",
+          available: false,
+          documents: [],
+          fingerprint: "unchanged-source",
+          error: "fixture database could not be read",
+        },
+      ],
+      true,
+    );
+
+    await index.ingest([
+      {
+        ...result([
+          document("recovered", { dialogue: "recovered history record" }),
+        ]),
+        fingerprint: "unchanged-source",
+      },
+    ]);
+
+    expect(index.search("recovered", { since: null, source: null })).toEqual([
+      expect.objectContaining({ sourceId: "recovered" }),
+    ]);
+    index.close();
+  });
+
+  test("rebuilds an older derived index and secures private files", async () => {
+    const paths = await runtime();
+    await mkdir(paths.historyDir, { recursive: true, mode: 0o755 });
+    const old = new Database(paths.indexDb);
+    old.run(
+      "CREATE TABLE documents (id INTEGER PRIMARY KEY, body TEXT); PRAGMA user_version = 1;",
+    );
+    old.close();
+
+    const index = await HistoryIndex.open(paths);
+    await index.ingest([
+      result([document("rebuilt", { dialogue: "schema rebuild succeeded" })]),
+    ]);
+    expect(index.search("schema", { since: null, source: null })).toHaveLength(
+      1,
+    );
+    index.close();
+
+    const directoryInfo = await stat(paths.historyDir);
+    const indexInfo = await stat(paths.indexDb);
+    const directoryMode = directoryInfo.mode & 0o777;
+    const indexMode = indexInfo.mode & 0o777;
+    expect(directoryMode).toBe(0o700);
+    expect(indexMode).toBe(0o600);
+  });
+
+  test("preserves the older index when an atomic schema rebuild fails", async () => {
+    const paths = await runtime();
+    await mkdir(paths.historyDir, { recursive: true });
+    const old = new Database(paths.indexDb);
+    old.run(`
+      CREATE TABLE documents (id INTEGER PRIMARY KEY, body TEXT);
+      INSERT INTO documents (body) VALUES ('preserved derived row');
+      CREATE TABLE history_fts (body TEXT);
+      INSERT INTO history_fts (body) VALUES ('preserved search row');
+      CREATE VIEW source_state AS SELECT 1 AS available;
+      PRAGMA user_version = 1;
+    `);
+    old.close();
+
+    expect(HistoryIndex.open(paths)).rejects.toThrow();
+
+    const preserved = new Database(paths.indexDb, { readonly: true });
+    expect(preserved.query("SELECT body FROM documents").get()).toEqual({
+      body: "preserved derived row",
+    });
+    expect(preserved.query("SELECT body FROM history_fts").get()).toEqual({
+      body: "preserved search row",
+    });
+    expect(preserved.query("PRAGMA user_version").get()).toEqual({
+      user_version: 1,
+    });
+    preserved.close();
+  });
+});

--- a/packages/toolkit/test/history/messages.test.ts
+++ b/packages/toolkit/test/history/messages.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  openingPrompt,
+  openingPromptHash,
+  parseConversationEnvelope,
+} from "#lib/history/messages.ts";
+
+function parsedOpening(secondBlock: string) {
+  return parseConversationEnvelope(
+    {
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "Shared first block" },
+          { type: "tool_result", content: "role-aware tool output" },
+          { type: "text", text: secondBlock },
+        ],
+      },
+    },
+    "unknown",
+    "2026-08-18T00:00:00.000Z",
+  );
+}
+
+describe("history opening prompts", () => {
+  test("hashes every dialogue block in the first envelope", () => {
+    const first = parsedOpening("First session detail");
+    const second = parsedOpening("Second session detail");
+
+    expect(first.map((message) => message.role)).toEqual([
+      "user",
+      "tool",
+      "user",
+    ]);
+    expect(openingPrompt(first)).toBe(
+      "Shared first block\nFirst session detail",
+    );
+    expect(openingPromptHash(openingPrompt(first))).not.toBe(
+      openingPromptHash(openingPrompt(second)),
+    );
+  });
+});

--- a/packages/toolkit/test/history/results-context.test.ts
+++ b/packages/toolkit/test/history/results-context.test.ts
@@ -1,0 +1,528 @@
+import { describe, expect, test } from "bun:test";
+import {
+  dialogueFirstExcerpt,
+  messageMatchesQuery,
+  selectShowMessages,
+} from "#lib/history/context.ts";
+import { dialogueText, toolOutputText } from "#lib/history/messages.ts";
+import {
+  collectHistoryResults,
+  prepareResults,
+  sourceWarnings,
+} from "#lib/history/results.ts";
+import {
+  renderHistoryRecords,
+  renderHistoryShow,
+} from "#lib/history/render.ts";
+import type {
+  HistoryMessage,
+  HistorySourceName,
+  IndexedHistoryRecord,
+} from "#lib/history/types.ts";
+
+function record(
+  id: number,
+  values: {
+    readonly source?: HistorySourceName;
+    readonly createdAt?: string;
+    readonly runtimeId?: string;
+    readonly promptHash?: string | null;
+  } = {},
+): IndexedHistoryRecord {
+  const source = values.source ?? "conductor";
+  const createdAt = values.createdAt ?? "2026-08-18T00:00:00.000Z";
+  return {
+    id,
+    source,
+    sourceId: `${source}-${String(id)}`,
+    title: `Session ${String(id)}`,
+    path: `/fixture/${String(id)}`,
+    workspace: "/fixture",
+    agent: "fixture",
+    createdAt,
+    updatedAt: createdAt,
+    excerpt: null,
+    runtimeId: values.runtimeId ?? `${source}-${String(id)}`,
+    openingPromptHash: values.promptHash ?? null,
+  };
+}
+
+describe("history result filtering and grouping", () => {
+  test("excludes the current runtime unless requested", () => {
+    const records = [
+      record(1, { runtimeId: "current" }),
+      record(2, { source: "codex", runtimeId: "current" }),
+    ];
+    const hidden = prepareResults(records, {
+      includeCurrent: false,
+      includeDuplicates: false,
+      currentRuntimes: [{ source: "conductor", runtimeId: "current" }],
+      limit: 20,
+    });
+    expect(hidden.map((entry) => entry.id)).toEqual([2]);
+    const included = prepareResults(records, {
+      includeCurrent: true,
+      includeDuplicates: false,
+      currentRuntimes: [{ source: "conductor", runtimeId: "current" }],
+      limit: 20,
+    });
+    expect(included.map((entry) => entry.id)).toEqual([1, 2]);
+  });
+
+  test("groups cross-source prompts in earliest-anchored 30-minute clusters", () => {
+    const records = [
+      record(2, {
+        source: "codex",
+        promptHash: "same",
+        createdAt: "2026-08-18T00:20:00.000Z",
+      }),
+      record(1, {
+        promptHash: "same",
+        createdAt: "2026-08-18T00:00:00.000Z",
+      }),
+      record(3, {
+        source: "claude",
+        promptHash: "same",
+        createdAt: "2026-08-18T00:40:00.000Z",
+      }),
+    ];
+    const grouped = prepareResults(records, {
+      includeCurrent: true,
+      includeDuplicates: false,
+      currentRuntimes: [],
+      limit: 20,
+    });
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0]?.id).toBe(2);
+    expect(grouped[0]?.members.map((member) => member.id)).toEqual([2, 1]);
+    expect(grouped[1]?.members.map((member) => member.id)).toEqual([3]);
+  });
+
+  test("applies limit after grouping and can return duplicates individually", () => {
+    const records = [
+      record(1, { promptHash: "same" }),
+      record(2, { promptHash: "same" }),
+      record(3),
+    ];
+    const grouped = prepareResults(records, {
+      includeCurrent: true,
+      includeDuplicates: false,
+      currentRuntimes: [],
+      limit: 2,
+    });
+    expect(grouped.map((entry) => entry.id)).toEqual([1, 3]);
+    expect(grouped[0]?.members).toHaveLength(2);
+
+    const duplicates = prepareResults(records, {
+      includeCurrent: true,
+      includeDuplicates: true,
+      currentRuntimes: [],
+      limit: 2,
+    });
+    expect(duplicates.map((entry) => entry.id)).toEqual([1, 2]);
+    expect(duplicates.every((entry) => entry.members.length === 1)).toBe(true);
+  });
+
+  test("reads bounded pages until the post-grouping limit is satisfied", () => {
+    const duplicates = Array.from({ length: 200 }, (_, index) =>
+      record(index + 1, { promptHash: "same" }),
+    );
+    const ranked = [...duplicates, record(201)];
+    const requestedPageLimits: number[] = [];
+    const grouped = collectHistoryResults(
+      (offset, limit) => {
+        requestedPageLimits.push(limit);
+        return ranked.slice(offset, offset + limit);
+      },
+      (promptHash) =>
+        ranked.filter((entry) => entry.openingPromptHash === promptHash),
+      {
+        includeCurrent: true,
+        includeDuplicates: false,
+        currentRuntimes: [],
+        limit: 2,
+      },
+    );
+
+    expect(requestedPageLimits).toEqual([128, 128]);
+    expect(grouped.map((entry) => entry.id)).toEqual([1, 201]);
+    expect(grouped[0]?.members).toHaveLength(200);
+  });
+
+  test("includes non-matching prompt siblings while preserving the ranked representative", () => {
+    const matching = record(2, {
+      source: "codex",
+      promptHash: "same",
+      createdAt: "2026-08-18T00:10:00.000Z",
+    });
+    const nonMatching = record(1, {
+      promptHash: "same",
+      createdAt: "2026-08-18T00:00:00.000Z",
+    });
+    const grouped = collectHistoryResults(
+      () => [matching],
+      () => [nonMatching, matching],
+      {
+        includeCurrent: true,
+        includeDuplicates: false,
+        currentRuntimes: [],
+        limit: 1,
+      },
+    );
+
+    expect(grouped[0]?.id).toBe(2);
+    expect(grouped[0]?.members.map((member) => member.id)).toEqual([2, 1]);
+  });
+
+  test("warns on source errors and explicit unavailable sources", () => {
+    const statuses = [
+      {
+        source: "cursor" as const,
+        label: "Cursor",
+        available: false,
+        indexedDocuments: 0,
+        lastScanAt: null,
+        error: "unable to open fixture",
+      },
+      {
+        source: "claude" as const,
+        label: "Claude Code",
+        available: false,
+        indexedDocuments: 0,
+        lastScanAt: null,
+        error: null,
+      },
+    ];
+    expect(sourceWarnings(statuses, null)).toEqual([
+      { source: "cursor", message: "unable to open fixture" },
+    ]);
+    expect(sourceWarnings(statuses, "claude")).toEqual([
+      { source: "cursor", message: "unable to open fixture" },
+      {
+        source: "claude",
+        message:
+          "Claude Code is not installed or its history store is unavailable.",
+      },
+    ]);
+  });
+});
+
+function message(role: HistoryMessage["role"], text: string): HistoryMessage {
+  return { role, text, createdAt: null };
+}
+
+describe("bounded history context", () => {
+  test("strips terminal control sequences only from human rendering", () => {
+    const unsafe = "before\u{1B}]52;c;payload\u{7}after\u{1B}[31mred\u{1B}[0m";
+    const historyRecord = record(1);
+    const shown = renderHistoryShow(
+      { ...historyRecord, title: unsafe, path: unsafe },
+      [message("assistant", unsafe)],
+      false,
+    );
+    const listed = renderHistoryRecords("History", [
+      {
+        ...historyRecord,
+        title: unsafe,
+        path: unsafe,
+        excerpt: unsafe,
+        members: [],
+      },
+    ]);
+
+    expect(shown).toContain("beforeafterred");
+    expect(listed).toContain("beforeafterred");
+    expect(`${shown}${listed}`).not.toContain("\u{1B}");
+    expect(`${shown}${listed}`).not.toContain("\u{7}");
+    expect(unsafe).toContain("\u{1B}]52");
+  });
+
+  test("bounds indexed dialogue and low-weight tool payloads", () => {
+    const messages = [
+      message("assistant", "d".repeat(300_000)),
+      message("tool", "t".repeat(100_000)),
+    ];
+    expect(dialogueText(messages).length).toBeLessThanOrEqual(64_000);
+    expect(toolOutputText(messages).length).toBeLessThanOrEqual(2000);
+  });
+
+  test("centers query context and admits only matching tools by default", () => {
+    const messages = [
+      message("user", "Opening request"),
+      message("assistant", "Unrelated setup"),
+      message("tool", "tool output unrelated"),
+      message("assistant", "Bryan Bucks model analysis"),
+      message("tool", "Bryan Bucks calibration output"),
+      message("tool", "credentials output unrelated"),
+      message("assistant", "Final answer"),
+    ];
+    const selected = selectShowMessages(messages, {
+      query: '"Bryan Bucks"',
+      messageLimit: 4,
+      includeTools: false,
+    });
+    expect(selected.messages.map((entry) => entry.text)).toContain(
+      "Bryan Bucks model analysis",
+    );
+    expect(selected.messages.map((entry) => entry.text)).toContain(
+      "Bryan Bucks calibration output",
+    );
+    expect(selected.messages.map((entry) => entry.text)).not.toContain(
+      "credentials output unrelated",
+    );
+
+    const withTools = selectShowMessages(messages, {
+      query: '"Bryan Bucks"',
+      messageLimit: 7,
+      includeTools: true,
+    });
+    expect(withTools.messages.map((entry) => entry.text)).toContain(
+      "credentials output unrelated",
+    );
+  });
+
+  test("centers on a matching tool when dialogue does not match", () => {
+    const messages = [
+      ...Array.from({ length: 10 }, (_, index) =>
+        message("assistant", `Unrelated dialogue ${String(index)}`),
+      ),
+      message("tool", "Bryan Bucks branch result"),
+      message("assistant", "Latest unrelated dialogue"),
+    ];
+    const selected = selectShowMessages(messages, {
+      query: "Bryan Bucks",
+      messageLimit: 4,
+      includeTools: false,
+    });
+
+    expect(selected.messages.map((entry) => entry.text)).toContain(
+      "Bryan Bucks branch result",
+    );
+    expect(selected.messages[0]?.text).toBe("Unrelated dialogue 8");
+  });
+
+  test("shows the opening request plus latest dialogue without a query", () => {
+    const messages = [
+      message("user", "Opening request"),
+      message("assistant", "Old response"),
+      message("tool", "large tool output"),
+      message("user", "Latest question"),
+      message("assistant", "Latest response"),
+    ];
+    const selected = selectShowMessages(messages, {
+      query: null,
+      messageLimit: 3,
+      includeTools: false,
+    });
+    expect(selected.messages.map((entry) => entry.text)).toEqual([
+      "Opening request",
+      "Latest question",
+      "Latest response",
+    ]);
+    expect(selected.truncated).toBe(true);
+  });
+
+  test("enforces message and character bounds", () => {
+    const messages = Array.from({ length: 12 }, (_, index) =>
+      message("assistant", `${String(index)}-${"x".repeat(1000)}`),
+    );
+    const selected = selectShowMessages(messages, {
+      query: null,
+      messageLimit: 8,
+      includeTools: false,
+    });
+    expect(selected.messages.length).toBeLessThanOrEqual(8);
+    expect(
+      selected.messages.reduce((total, entry) => total + entry.text.length, 0),
+    ).toBeLessThanOrEqual(6000);
+    expect(selected.truncated).toBe(true);
+  });
+});
+
+describe("query-aware bounded history context", () => {
+  test("preserves the query when truncating a long matching tool message", () => {
+    const selected = selectShowMessages(
+      [
+        message("assistant", "Relevant dialogue about Bryan Bucks"),
+        message("tool", `${"x".repeat(7000)} Bryan Bucks tool result`),
+      ],
+      {
+        query: "Bryan Bucks",
+        messageLimit: 2,
+        includeTools: false,
+      },
+    );
+    const tool = selected.messages.find((entry) => entry.role === "tool");
+
+    expect(tool).toBeDefined();
+    expect(messageMatchesQuery(tool?.text ?? "", "Bryan Bucks")).toBe(true);
+    expect(selected.truncated).toBe(true);
+  });
+
+  test("preserves the centered match after a long preceding message", () => {
+    const selected = selectShowMessages(
+      [
+        message("assistant", `Earlier context ${"x".repeat(7000)}`),
+        message("assistant", "Bryan Bucks centered answer"),
+        message("assistant", "Later context"),
+      ],
+      {
+        query: "Bryan Bucks",
+        messageLimit: 3,
+        includeTools: false,
+      },
+    );
+
+    expect(selected.messages.map((entry) => entry.text)).toContain(
+      "Bryan Bucks centered answer",
+    );
+    expect(
+      selected.messages.reduce((total, entry) => total + entry.text.length, 0),
+    ).toBeLessThanOrEqual(6000);
+    expect(selected.truncated).toBe(true);
+  });
+
+  test("keeps surrounding context after excerpting a long match", () => {
+    const selected = selectShowMessages(
+      [
+        message("assistant", "Earlier context"),
+        message(
+          "assistant",
+          `${"a".repeat(3500)} Bryan Bucks ${"b".repeat(3500)}`,
+        ),
+        message("assistant", "Later context"),
+      ],
+      {
+        query: "Bryan Bucks",
+        messageLimit: 3,
+        includeTools: false,
+      },
+    );
+
+    expect(selected.messages.map((entry) => entry.text)).toContain(
+      "Earlier context",
+    );
+    expect(selected.messages.map((entry) => entry.text)).toContain(
+      "Later context",
+    );
+    expect(
+      selected.messages.some((entry) =>
+        messageMatchesQuery(entry.text, "Bryan Bucks"),
+      ),
+    ).toBe(true);
+  });
+
+  test("preserves a one-character query in a long tool match", () => {
+    const selected = selectShowMessages(
+      [
+        message("assistant", "Nearby dialogue"),
+        message("tool", `${"a".repeat(7000)} q result`),
+      ],
+      {
+        query: "q",
+        messageLimit: 2,
+        includeTools: false,
+      },
+    );
+
+    expect(
+      selected.messages.some(
+        (entry) =>
+          entry.role === "tool" && messageMatchesQuery(entry.text, "q"),
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps the opening request and latest dialogue within the bound", () => {
+    const selected = selectShowMessages(
+      [
+        message("user", `Opening ${"x".repeat(7000)}`),
+        message("assistant", "Latest response"),
+      ],
+      {
+        query: null,
+        messageLimit: 2,
+        includeTools: false,
+      },
+    );
+
+    expect(selected.messages.at(-1)?.text).toBe("Latest response");
+    expect(
+      selected.messages.reduce((total, entry) => total + entry.text.length, 0),
+    ).toBeLessThanOrEqual(6000);
+  });
+
+  test("uses AND-prefix matching and dialogue-first excerpts", () => {
+    expect(messageMatchesQuery("Deploy Bryan Bucks", "depl buck")).toBe(true);
+    expect(messageMatchesQuery("Bryan model Bucks", '"Bryan Bucks"')).toBe(
+      false,
+    );
+    expect(messageMatchesQuery("Deploy foo.bar safely", '"foo bar"')).toBe(
+      true,
+    );
+    expect(messageMatchesQuery("Deploy foo bar safely", '"foo.bar"')).toBe(
+      true,
+    );
+    expect(messageMatchesQuery("the artist", '"he art"')).toBe(false);
+    const excerpt = dialogueFirstExcerpt(
+      [
+        message("assistant", "Dialogue explains Bryan Bucks in context"),
+        message("tool", "Tool branch bryan-bucks-v1"),
+      ],
+      "Bryan Bucks",
+    );
+    expect(excerpt).toStartWith("Dialogue explains");
+    expect(
+      dialogueFirstExcerpt(
+        [message("user", `prefix ${"detail ".repeat(100)}Bryan Bucks result`)],
+        "Bryan Bucks",
+      ).length,
+    ).toBeLessThanOrEqual(360);
+  });
+
+  test("centers accent-insensitive matches like FTS5", () => {
+    const selected = selectShowMessages(
+      [
+        message("assistant", "Unrelated setup"),
+        message(
+          "assistant",
+          `${"detail ".repeat(1000)}The café forecast is ready`,
+        ),
+      ],
+      {
+        query: "cafe",
+        messageLimit: 2,
+        includeTools: false,
+      },
+    );
+
+    expect(messageMatchesQuery("The café forecast", "cafe")).toBe(true);
+    expect(selected.messages.at(-1)?.text).toContain("café forecast");
+  });
+
+  test("centers exact phrases on token boundaries like FTS5", () => {
+    const selected = selectShowMessages(
+      [
+        message(
+          "assistant",
+          `${"prefix ".repeat(20)}he art is the exact phrase`,
+        ),
+        message("assistant", "Unrelated middle context"),
+        message("assistant", "the artist is only a substring match"),
+        message("assistant", "Unrelated latest context"),
+      ],
+      {
+        query: '"he art"',
+        messageLimit: 2,
+        includeTools: false,
+      },
+    );
+
+    expect(
+      selected.messages.some((entry) => entry.text.includes("he art")),
+    ).toBe(true);
+    expect(
+      selected.messages.some((entry) => entry.text.includes("the artist")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

History search was recency-first, so incidental branch and tool-output mentions could outrank substantive work. Excerpts rescanned every source, the active conversation appeared in its own results, parallel agent sessions were noisy duplicates, and there was no bounded way to inspect a selected result.

## What

- Replace the derived index with versioned contentless FTS5 fields for title, dialogue, and low-weight tool output, ranked with BM25 and recency only as a tie-breaker.
- Hide current Conductor/Codex runs by default, group identical opening prompts within earliest-anchored 30-minute clusters, preserve phrase/prefix query behavior, and add warning-bearing JSON envelopes.
- Page broad ranked queries in bounded batches while fetching complete metadata for selected duplicate clusters, so limit-after-grouping remains exact without materializing the full result set.
- Parse source records into typed, chronological dialogue/tool messages, omit system/reasoning/compaction content, target only selected records for excerpts and `show`, and safely reopen static Cursor indexes through an immutable URI after `CANTOPEN` without a live WAL.
- Add `history show` with message/character bounds, dialogue-first query centering, matching-tool fallback, fair nearby-context allocation, reliable LaunchAgent restart sequencing, and synchronized CLI, root recipe, and history skill documentation.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/toolkit` (194 tests passed)
- `bunx turbo run build --filter=@shepherdjerred/toolkit`
- `bunx lefthook run pre-commit`
- Reinstalled/restarted the local history LaunchAgent and forced a v2 reindex.
- Confirmed all six sources are healthy, including 39 Cursor conversations.
- Confirmed Bryan Bucks current-run exclusion, duplicate grouping, substantive-over-tool ranking, and bounded query-centered `show` output.
- Five targeted excerpts completed in 2.31 seconds after the final reindex versus the observed 4.40-second full-rescan path; the selected set included one Claude transcript and four Conductor conversations.
- Added regression coverage for review findings including tool-only centering, OpenCode chronology, complete multi-block opening prompt hashes, exact duplicate expansion, stable read snapshots across concurrent WAL updates, stale-versus-empty targeted records, strict and token-bearing argument parsing, source-scoped current-runtime filtering, accent-insensitive and exact-token phrase agreement between FTS and `show`, Codex runtime/catalog handling and malformed-line rejection, representative Cursor tail indexing, targeted metadata reads, bounded-concurrency source scans and sequential Claude transcript reads, long-session coverage, terminal control-sequence safety, failed-source recovery, atomic schema-rebuild rollback, query-preserving excerpts for short terms, fair character allocation around centered matches, and bounded indexing across every structured content block.

## Demo

Synthetic terminal demo: [history-search-demo.cast](https://public.sjer.red/pr/assets/2281/history-search-demo.cast.html)

Synthetic data demonstrates BM25 ordering, 30-minute duplicate grouping, the JSON envelope, and bounded role-aware `show` output. No real transcript content is included.

## Rollout

The index is private and rebuildable. Full transcript bodies remain in their original read-only stores. The JSON envelope changes are intentionally breaking; repository search found no consumers.
