### PR TITLE
fix(scout-for-lol): make Discord Explore links directly routable

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts
@@ -24,7 +24,7 @@ describe("stage-aware Discord links", () => {
 
     expect(getDocsUrl()).toBe("https://beta.scout-for-lol.com/docs/");
     expect(getExploreConversationUrl("conversation-id")).toBe(
-      "https://beta.scout-for-lol.com/app/explore/conversation-id",
+      "https://beta.scout-for-lol.com/app/explore/conversation-id/",
     );
   });
 

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/links.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/links.ts
@@ -16,5 +16,5 @@ export function getDocsUrl(): string {
 }
 
 export function getExploreConversationUrl(conversationId: string): string {
-  return `${getOrigin()}/app/explore/${conversationId}`;
+  return `${getOrigin()}/app/explore/${conversationId}/`;
 }


### PR DESCRIPTION
## Why

The live beta E2E for #2273 found that Discord generated `/app/explore/<conversationId>` without the trailing slash required by Scout’s object-hosted SPA. Opening that button directly returned HTTP 404 instead of reaching the authenticated Explore route.

## What

- Generate canonical `/app/explore/<conversationId>/` URLs for Discord’s **Open in Explore** button.
- Pin the beta-origin URL, including its trailing slash, in the existing link contract test.

## Verification

- `bun test src/discord/commands/links.test.ts src/discord/commands/scout.integration.test.ts`
- `bunx turbo run typecheck lint --filter=@scout-for-lol/backend`
- `bunx prettier --check packages/scout-for-lol/packages/backend/src/discord/commands/links.ts packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts`
- `bunx lefthook run pre-commit`
- Live beta before fix: the slashless conversation URL returned HTTP 404; the canonical trailing-slash URL reached the authenticated app boundary and returned HTTP 403 without a session.

## Rollout

After merge and beta deployment, invoke `/scout ask` once and verify the new button carries the trailing-slash URL and opens the owner-only conversation under an authenticated Discord session.