### PR TITLE
fix(scout-for-lol): bound parlay Discord messages

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-announce.ts
@@ -7,6 +7,7 @@ import {
 } from "@scout-for-lol/data";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 import { send } from "#src/league/discord/channel.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -109,30 +110,48 @@ export function formatParlaySettlement(
   return lines.join("\n");
 }
 
+export function formatParlaySettlementChunks(
+  summary: ParlaySettlementSummary,
+): string[] {
+  return splitMessageIntoChunks(formatParlaySettlement(summary));
+}
+
+type SettlementAnnouncementDependencies = {
+  sendMessage?: (
+    options: Parameters<typeof send>[0],
+    channelId: Parameters<typeof send>[1],
+    serverId: Parameters<typeof send>[2],
+  ) => Promise<unknown>;
+};
+
 export async function announceParlaySettlements(
   summaries: readonly ParlaySettlementSummary[],
+  dependencies: SettlementAnnouncementDependencies = {},
 ): Promise<void> {
+  const sendMessage = dependencies.sendMessage ?? send;
   for (const summary of summaries) {
-    const content = formatParlaySettlement(summary);
+    const contents = formatParlaySettlementChunks(summary);
     for (const ref of summary.messageRefs) {
-      try {
-        await send(
-          { content, allowedMentions: { parse: [] } },
-          DiscordChannelIdSchema.parse(ref.channelId),
-          DiscordGuildIdSchema.parse(summary.serverId),
-        );
-      } catch (error) {
-        logger.error(
-          `Could not announce parlay settlement for ${summary.matchId} in ${ref.channelId}:`,
-          error,
-        );
-        Sentry.captureException(error, {
-          tags: {
-            source: "betting-parlay-settlement-announce",
-            matchId: summary.matchId,
-            channelId: ref.channelId,
-          },
-        });
+      for (const content of contents) {
+        try {
+          await sendMessage(
+            { content, allowedMentions: { parse: [] } },
+            DiscordChannelIdSchema.parse(ref.channelId),
+            DiscordGuildIdSchema.parse(summary.serverId),
+          );
+        } catch (error) {
+          logger.error(
+            `Could not announce parlay settlement for ${summary.matchId} in ${ref.channelId}:`,
+            error,
+          );
+          Sentry.captureException(error, {
+            tags: {
+              source: "betting-parlay-settlement-announce",
+              matchId: summary.matchId,
+              channelId: ref.channelId,
+            },
+          });
+        }
       }
     }
   }

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-criteria.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-criteria.ts
@@ -20,6 +20,7 @@ import {
 export const PARLAY_SCHEMA_VERSION = 1;
 export const PARLAY_CATALOG_VERSION = "2026-08-18";
 export const PARLAY_EVALUATOR_VERSION = "1";
+export const PARLAY_SUBJECT_ALIAS_MAX_LENGTH = 100;
 
 const NumericOperatorSchema = z.enum(["gte", "lte", "eq"]);
 const SelectedTeamSchema = z.literal("selected");
@@ -90,7 +91,7 @@ export type GeneratedParlay = z.infer<typeof GeneratedParlaySchema>;
 export const ParlaySubjectSchema = z.strictObject({
   key: z.string().regex(/^P[1-5]$/),
   puuid: LeaguePuuidSchema,
-  alias: z.string().min(1),
+  alias: z.string().min(1).max(PARLAY_SUBJECT_ALIAS_MAX_LENGTH),
 });
 
 export type ParlaySubject = z.infer<typeof ParlaySubjectSchema>;

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-discord.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-discord.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import {
   ParlayConditionSchema,
+  PARLAY_SUBJECT_ALIAS_MAX_LENGTH,
   ParlaySubjectsSchema,
 } from "#src/betting/parlay-criteria.ts";
-import { formatParlaySettlement } from "#src/betting/parlay-announce.ts";
+import {
+  announceParlaySettlements,
+  formatParlaySettlement,
+  formatParlaySettlementChunks,
+} from "#src/betting/parlay-announce.ts";
 import { buildParlayButtons } from "#src/betting/parlay-components.ts";
 import { buildParlayMessage } from "#src/betting/parlay-publish.ts";
+import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 
 const subjects = ParlaySubjectsSchema.parse([
   {
@@ -34,6 +40,37 @@ const criteria = {
   conditions: [participantCondition, objectiveCondition],
 };
 
+function largeSettlementSummary(
+  messageRefs: ParlaySettlementSummary["messageRefs"] = [],
+): ParlaySettlementSummary {
+  const renderedLegs = Array.from(
+    { length: 6 },
+    (_, index) =>
+      `${"a".repeat(PARLAY_SUBJECT_ALIAS_MAX_LENGTH)} ${"resolves a deliberately verbose canonical result ".repeat(4)}leg ${(index + 1).toString()}`,
+  );
+  return {
+    matchId: "NA1_42",
+    serverId: "1337623164146155593",
+    yesResult: true,
+    voidReason: undefined,
+    messageRefs,
+    legs: renderedLegs.map((rendered) => ({
+      condition: participantCondition,
+      rendered,
+      actualValue: 2_147_483_647,
+      passed: true,
+    })),
+    bets: Array.from({ length: 15 }, (_, index) => ({
+      discordId: (1_000_000_000_000_000_000n + BigInt(index)).toString(),
+      side: "YES",
+      stake: 2_147_483_647,
+      grossPayout: 2_147_483_647,
+      payout: 2_147_483_647,
+      outcome: "won",
+    })),
+  };
+}
+
 describe("parlay Discord experience", () => {
   test("renders a dedicated live-market follow-up and five actions", () => {
     const content = buildParlayMessage({
@@ -54,6 +91,55 @@ describe("parlay Discord experience", () => {
         "label" in component ? component.label : undefined,
       ),
     ).toEqual(["YES 1", "YES 5", "NO 1", "NO 5", "Cancel"]);
+  });
+
+  test("keeps the largest supported publication within one Discord message", () => {
+    const longSubjects = ParlaySubjectsSchema.parse([
+      {
+        key: "P1",
+        puuid: "test-puuid".padEnd(78, "x"),
+        alias: "a".repeat(PARLAY_SUBJECT_ALIAS_MAX_LENGTH),
+      },
+    ]);
+    const longCriteria = {
+      version: 1 as const,
+      yesProbabilityBps: 4000,
+      conditions: [
+        "magicDamageDealtToChampions",
+        "physicalDamageDealtToChampions",
+        "totalDamageShieldedOnTeammates",
+        "totalEnemyJungleMinionsKilled",
+        "totalAllyJungleMinionsKilled",
+        "visionWardsBoughtInGame",
+      ].map((field) =>
+        ParlayConditionSchema.parse({
+          kind: "participant_numeric",
+          subject: "P1",
+          field,
+          operator: "gte",
+          threshold: 10_000,
+        }),
+      ),
+    };
+    const content = buildParlayMessage({
+      criteria: longCriteria,
+      subjects: longSubjects,
+      closesAt: new Date("2026-08-18T12:05:00.000Z"),
+    });
+    expect(content.length).toBeLessThanOrEqual(1900);
+    expect(content).toContain("a".repeat(PARLAY_SUBJECT_ALIAS_MAX_LENGTH));
+  });
+
+  test("rejects subject aliases longer than the publication contract", () => {
+    expect(() =>
+      ParlaySubjectsSchema.parse([
+        {
+          key: "P1",
+          puuid: "test-puuid".padEnd(78, "x"),
+          alias: "a".repeat(PARLAY_SUBJECT_ALIAS_MAX_LENGTH + 1),
+        },
+      ]),
+    ).toThrow();
   });
 
   test("renders leg actuals, the overall side, positions, and payouts", () => {
@@ -92,5 +178,39 @@ describe("parlay Discord experience", () => {
     expect(content).toContain("actual **true**");
     expect(content).toContain("Overall result: **NO**");
     expect(content).toContain("NO 25 BB → won, 42 BB");
+  });
+
+  test("chunks a large settlement without dropping legs or positions", () => {
+    const summary = largeSettlementSummary();
+    const renderedLegs = summary.legs.map((leg) => leg.rendered);
+    const chunks = formatParlaySettlementChunks(summary);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 1900)).toBe(true);
+    const combined = chunks.join("\n");
+    for (const rendered of renderedLegs) {
+      expect(combined).toContain(rendered);
+    }
+    expect(combined).toContain("<@1000000000000000014>");
+  });
+
+  test("attempts later settlement chunks after one send fails", async () => {
+    const summary = largeSettlementSummary([
+      {
+        channelId: "1337623164146155593",
+        messageId: "1337623164146155594",
+      },
+    ]);
+    const chunks = formatParlaySettlementChunks(summary);
+    let attempts = 0;
+    await announceParlaySettlements([summary], {
+      sendMessage: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("transient Discord failure");
+        }
+      },
+    });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(attempts).toBe(chunks.length);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-publish.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-publish.ts
@@ -14,6 +14,7 @@ import { buildParlayButtons } from "#src/betting/parlay-components.ts";
 import { formatDecimalOdds } from "#src/betting/parlay-odds.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 import { send } from "#src/league/discord/channel.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -83,13 +84,24 @@ export function buildParlayMessage(input: {
   const legs = renderParlay(input.criteria, input.subjects).map(
     (leg, index) => `${(index + 1).toString()}. ${leg}`,
   );
-  return [
+  const content = [
     "🎲 **Bryan Bucks Parlay** — every leg must hit for YES",
     ...legs,
     "",
     `**YES** ${probabilityPercent(yes)} (${formatDecimalOdds(yes)}×) · **NO** ${probabilityPercent(no)} (${formatDecimalOdds(no)}×)`,
     `Closes <t:${closeUnix.toString()}:R> · Live/in-play market: early game events may already be visible.`,
   ].join("\n");
+  const chunks = splitMessageIntoChunks(content);
+  if (chunks.length !== 1) {
+    throw new Error(
+      "Bryan Bucks parlay publication exceeds Discord's message limit.",
+    );
+  }
+  const message = chunks[0];
+  if (message === undefined) {
+    throw new Error("Bryan Bucks parlay publication rendered no content.");
+  }
+  return message;
 }
 
 async function activateMessageReference(input: {


### PR DESCRIPTION
## Why

The final Qodo review for #2283 identified that a large parlay publication or settlement could exceed Discord's hard message-content limit. The feature PR was merged while that review was still running, so this focused follow-up closes the reliability gap.

## What

- Bound persisted parlay subject aliases to the same 100-character product boundary used by player administration.
- Assert that the complete canonical publication fits in one safe Discord message before activation.
- Split settlement details into safe chunks so every leg and capped position row is delivered without truncation, while isolating a failed send so later chunks are still attempted.
- Add boundary tests for maximum publication content, rejected oversized aliases, multi-message settlement output, and per-chunk failure isolation.

## Verification

- `bun test src/betting/parlay-discord.test.ts` — passed, 6 tests.
- `bun run typecheck` — passed.
- `bunx eslint src/betting/parlay-criteria.ts src/betting/parlay-publish.ts src/betting/parlay-announce.ts src/betting/parlay-discord.test.ts` — passed.
- `bunx turbo run generate typecheck test lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/data` — passed, 15/15 tasks; backend 1,666 passed with 6 existing skips and 0 failed; data 639 passed and 0 failed.
- `bunx lefthook run pre-commit` — passed.

Live Discord verification was not run because no explicit bot identity and guild/channel target were provided. This is a message-boundary reliability fix, so no additional visual artifact is needed.
