### PR TITLE
fix(scout-for-lol): restore main by extracting prematch failure reporting

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
@@ -176,6 +176,72 @@ function buildPrematchPayload(input: {
   };
 }
 
+/**
+ * Record a failed loading-screen render, then let the caller fall back to the
+ * text-only notification.
+ *
+ * Lifted out of `sendPrematchNotification` verbatim: that function sits right
+ * on the complexity ceiling, and this branch-heavy reporting is the part with
+ * no bearing on what actually gets delivered. Behaviour is unchanged.
+ */
+function reportLoadingScreenFailure(input: {
+  error: unknown;
+  loadingScreenData: LoadingScreenData | undefined;
+  queueType: QueueType | undefined;
+  gameId: string;
+  gameInfo: RawCurrentGameInfo;
+}): void {
+  const { error, loadingScreenData, queueType, gameId, gameInfo } = input;
+  if (loadingScreenData?.layout === "classic") {
+    classicAssetResolutionFailuresTotal.inc({
+      phase: "prematch",
+      reason: "asset",
+    });
+    logger.error(
+      "Classic prematch loading-screen asset rendering failed",
+      error,
+      {
+        championIds: loadingScreenData.participants.map(
+          (participant) => participant.championId,
+        ),
+      },
+    );
+  }
+  const isRecoverable = error instanceof RecoverableLoadingScreenDataError;
+  prematchLoadingScreenGeneratedTotal.inc({
+    queue_type: queueType ?? "unknown",
+    status: isRecoverable ? "fallback" : "error",
+  });
+  logger.error(
+    `[sendPrematchNotification] ❌ Failed to generate loading screen for game ${gameId}:`,
+    error,
+  );
+  if (isRecoverable) {
+    return;
+  }
+  const tags = {
+    source: "prematch-loading-screen",
+    gameId,
+    gameQueueConfigId: gameInfo.gameQueueConfigId.toString(),
+    mapId: gameInfo.mapId.toString(),
+    gameMode: gameInfo.gameMode,
+  };
+  Sentry.captureException(
+    error,
+    error instanceof UnsupportedLoadingScreenQueueError
+      ? {
+          fingerprint: [
+            "prematch-unsupported-queue",
+            gameInfo.gameQueueConfigId.toString(),
+            gameInfo.gameMode,
+            gameInfo.mapId.toString(),
+          ],
+          tags,
+        }
+      : { tags },
+  );
+}
+
 export async function sendPrematchNotification(
   gameInfo: RawCurrentGameInfo,
   trackedPlayers: PlayerConfigEntry[],
@@ -304,59 +370,13 @@ export async function sendPrematchNotification(
       }
     })();
   } catch (error) {
-    if (loadingScreenData?.layout === "classic") {
-      classicAssetResolutionFailuresTotal.inc({
-        phase: "prematch",
-        reason: "asset",
-      });
-      logger.error(
-        "Classic prematch loading-screen asset rendering failed",
-        error,
-        {
-          championIds: loadingScreenData.participants.map(
-            (participant) => participant.championId,
-          ),
-        },
-      );
-    }
-    const isRecoverable = error instanceof RecoverableLoadingScreenDataError;
-    prematchLoadingScreenGeneratedTotal.inc({
-      queue_type: queueType ?? "unknown",
-      status: isRecoverable ? "fallback" : "error",
-    });
-    logger.error(
-      `[sendPrematchNotification] ❌ Failed to generate loading screen for game ${gameId}:`,
+    reportLoadingScreenFailure({
       error,
-    );
-    if (!isRecoverable) {
-      const context =
-        error instanceof UnsupportedLoadingScreenQueueError
-          ? {
-              fingerprint: [
-                "prematch-unsupported-queue",
-                gameInfo.gameQueueConfigId.toString(),
-                gameInfo.gameMode,
-                gameInfo.mapId.toString(),
-              ],
-              tags: {
-                source: "prematch-loading-screen",
-                gameId,
-                gameQueueConfigId: gameInfo.gameQueueConfigId.toString(),
-                mapId: gameInfo.mapId.toString(),
-                gameMode: gameInfo.gameMode,
-              },
-            }
-          : {
-              tags: {
-                source: "prematch-loading-screen",
-                gameId,
-                gameQueueConfigId: gameInfo.gameQueueConfigId.toString(),
-                mapId: gameInfo.mapId.toString(),
-                gameMode: gameInfo.gameMode,
-              },
-            };
-      Sentry.captureException(error, context);
-    }
+      loadingScreenData,
+      queueType,
+      gameId,
+      gameInfo,
+    });
     // Continue with text-only notification
   }
 


### PR DESCRIPTION
## Why

`main` is red and the entire deploy chain is stalled behind it.

Build [10098](https://buildkite.com/sjerred/monorepo/builds/10098) (`9373a42e3`) fails `:turborepo: verify` on a **single lint error**:

```
src/league/tasks/prematch/prematch-notification.ts
  179:8  error  Async function 'sendPrematchNotification' has a complexity of 21. Maximum allowed is 20  complexity
✖ 746 problems (1 error, 745 warnings)
```

Everything downstream is `waiting_failed` — `helm push`, `argo sync + wait`, and all three Scout release phases — so beta has not received a build since. The violation arrived with #2260, and it blocks every backend PR, not only the deploy.

## What

Lift the loading-screen `catch` body into `reportLoadingScreenFailure`. That block is entirely metrics, logging, and Sentry context — it has no bearing on what actually gets delivered — so it is the cheapest honest place to spend the complexity budget rather than raising the ceiling.

Two simplifications are folded in, both behaviour-preserving:

- the trailing `if (!isRecoverable) { … }` becomes an early `return`, since nothing followed it
- the `tags` object is hoisted out of the Sentry ternary, where it was byte-identical in both branches

Everything else is a verbatim move.

## Verification

| check | result |
| --- | --- |
| `bunx eslint src` | `1 error, 745 warnings` → **`0 errors, 745 warnings`** |
| `bun run typecheck` | passes |
| `bun test` | **1668 pass / 0 fail** across 192 files |

Reviewed the diff line by line for behaviour equivalence, which carried the weight here: `sendPrematchNotification`'s integration test is hardcoded off (`RUN_INTEGRATION_TEST = false`, a documented TODO about process-wide `mock.module()` leakage), so the function has **no direct coverage** to lean on. That gap is worth a follow-up on its own.

Not run: a live prematch send against Discord.