### PR TITLE
fix(scout-for-lol): force a lake rebuild when report columns change

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/report-lake/compactor.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/compactor.ts
@@ -1,5 +1,6 @@
 import { copyFile, link, mkdir, readdir, unlink } from "node:fs/promises";
 import path from "node:path";
+import { z } from "zod";
 import { prisma as defaultPrisma } from "#src/database/index.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
@@ -35,6 +36,7 @@ import {
   PREMATCH_LAKE_COLUMNS,
   PrematchLakeRowSchema,
   duckDbColumnsSpec,
+  lakeSchemaFingerprint,
 } from "#src/report-lake/schema.ts";
 import {
   listStagingFiles,
@@ -154,8 +156,39 @@ async function writeManifest(
 ): Promise<void> {
   await Bun.write(
     path.join(buildDir, "manifest.json"),
-    JSON.stringify({ ...summary, builtAt: new Date().toISOString() }, null, 2),
+    JSON.stringify(
+      {
+        ...summary,
+        schemaFingerprint: lakeSchemaFingerprint(),
+        builtAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
   );
+}
+
+const PublishedManifestSchema = z.object({
+  schemaFingerprint: z.string().optional(),
+});
+
+/**
+ * The column-set fingerprint recorded by the published build, or undefined
+ * when it has no manifest or predates fingerprinting. Both mean the same thing
+ * to the caller: the published columns cannot be confirmed to match this
+ * binary's, so the build is not safe to hardlink and extend.
+ */
+async function readPublishedFingerprint(
+  buildDir: string,
+): Promise<string | undefined> {
+  const manifest = Bun.file(path.join(buildDir, "manifest.json"));
+  if (!(await manifest.exists())) {
+    return undefined;
+  }
+  const parsed = PublishedManifestSchema.safeParse(
+    JSON.parse(await manifest.text()),
+  );
+  return parsed.success ? parsed.data.schemaFingerprint : undefined;
 }
 
 function publishMetrics(summary: Omit<CompactionSummary, "durationMs">): void {
@@ -307,6 +340,17 @@ export async function runReportLakeFold(
     const currentDir = await readCurrentBuildDir(lakeDir);
     if (currentDir === undefined) {
       logger.info("No published build yet; folding via full rebuild");
+      return await rebuildLocked(prisma, lakeDir, startedAt);
+    }
+    // A fold hardlinks the published parquet and appends fold files beside it.
+    // If this binary's column set differs, that mix cannot be read at all, so
+    // rebuild from S3 rather than publishing an unreadable build.
+    const published = await readPublishedFingerprint(currentDir);
+    const expected = lakeSchemaFingerprint();
+    if (published !== expected) {
+      logger.info(
+        `Lake column set changed (published ${published ?? "unrecorded"}, expected ${expected}); folding via full rebuild`,
+      );
       return await rebuildLocked(prisma, lakeDir, startedAt);
     }
 

--- a/packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts
@@ -26,6 +26,7 @@ import {
 } from "#src/report-lake/compactor.ts";
 import { flattenMatch, flattenPrematch } from "#src/report-lake/flatten.ts";
 import { readCurrentBuildDir } from "#src/report-lake/paths.ts";
+import { lakeSchemaFingerprint } from "#src/report-lake/schema.ts";
 import { matchObjectKey } from "#src/report-store/s3-raw-source.ts";
 import {
   listStagingFiles,
@@ -39,6 +40,15 @@ import { fetchCompetitionRankHistory } from "#src/reports/duckdb/lake-reads.ts";
 const { prisma } = createTestDatabase("report-lake-test");
 const serverId = testGuildId("888");
 const creatorDiscordId = testAccountId("888");
+
+/**
+ * The manifest field the fold-vs-rebuild guard reads. Loose so a test that
+ * rewrites the fingerprint keeps the rest of the published build's summary
+ * rather than silently truncating the manifest it is standing in for.
+ */
+const ManifestFingerprintSchema = z.looseObject({
+  schemaFingerprint: z.string(),
+});
 
 // The full rebuild reads canonical raw JSON from S3 (SeaweedFS). Mock it
 // in-memory: ListObjectsV2 enumerates the seeded objects for the requested
@@ -438,6 +448,74 @@ describe("compactor", () => {
       await runReportLakeFold({ prisma, lakeDir });
       const builds = await readdir(path.join(lakeDir, "builds"));
       expect(builds.length).toBeLessThanOrEqual(2);
+    } finally {
+      await rm(lakeDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fold records the column-set fingerprint in the published manifest", async () => {
+    const lakeDir = await makeLakeDir();
+    try {
+      await runReportLakeRebuild({ prisma, lakeDir });
+      const buildDir = await readCurrentBuildDir(lakeDir);
+      if (buildDir === undefined) {
+        throw new Error("no build dir");
+      }
+      const manifest = ManifestFingerprintSchema.parse(
+        await Bun.file(path.join(buildDir, "manifest.json")).json(),
+      );
+      expect(manifest.schemaFingerprint).toBe(lakeSchemaFingerprint());
+    } finally {
+      await rm(lakeDir, { recursive: true, force: true });
+    }
+  });
+
+  // A fold hardlinks the published parquet and appends fold files beside it.
+  // Those files must agree on columns: reads select an explicit column list, so
+  // a mixed build raises a DuckDB binder error rather than returning NULLs, and
+  // every report would fail until a rebuild replaced the last old file.
+  test("fold rebuilds instead when the published column set differs", async () => {
+    const match = await loadMatchFixture();
+    const lakeDir = await makeLakeDir();
+    try {
+      const first = await runReportLakeRebuild({ prisma, lakeDir });
+      expect(first?.tier).toBe("rebuild");
+
+      // Stand in for a binary whose lake columns changed since this build.
+      const buildDir = await readCurrentBuildDir(lakeDir);
+      if (buildDir === undefined) {
+        throw new Error("no build dir");
+      }
+      const manifestPath = path.join(buildDir, "manifest.json");
+      const published: unknown = await Bun.file(manifestPath).json();
+      await Bun.write(
+        manifestPath,
+        JSON.stringify({
+          ...ManifestFingerprintSchema.parse(published),
+          schemaFingerprint: "0000000000000000",
+        }),
+      );
+
+      await writeMatchStagingFile(lakeDir, match);
+      const second = await runReportLakeFold({ prisma, lakeDir });
+      expect(second?.tier).toBe("rebuild");
+    } finally {
+      await rm(lakeDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fold rebuilds instead when the published build has no manifest", async () => {
+    const lakeDir = await makeLakeDir();
+    try {
+      await runReportLakeRebuild({ prisma, lakeDir });
+      const buildDir = await readCurrentBuildDir(lakeDir);
+      if (buildDir === undefined) {
+        throw new Error("no build dir");
+      }
+      await rm(path.join(buildDir, "manifest.json"));
+
+      const second = await runReportLakeFold({ prisma, lakeDir });
+      expect(second?.tier).toBe("rebuild");
     } finally {
       await rm(lakeDir, { recursive: true, force: true });
     }

--- a/packages/scout-for-lol/packages/backend/src/report-lake/schema.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/schema.ts
@@ -329,3 +329,43 @@ export function duckDbEmptySelect(
     .map(([name, type]) => `CAST(NULL AS ${type}) AS ${name}`)
     .join(", ")} WHERE FALSE`;
 }
+
+/** Sorted `name:TYPE` pairs — reads bind by name, so only the set matters. */
+function columnSetSignature(columns: Record<string, DuckDbColumnType>): string {
+  return Object.entries(columns)
+    .map(([name, type]) => `${name}:${type}`)
+    .sort()
+    .join(",");
+}
+
+/**
+ * Fingerprint of every lake table's column set, recorded in each build's
+ * manifest.
+ *
+ * Adding a column is NOT backward compatible with already-published parquet.
+ * `buildUnionSource` selects an explicit column list across the whole file
+ * list, so a build whose files disagree on columns does not degrade to NULLs —
+ * DuckDB refuses to bind at all ("Referenced column ... not found"). The fold
+ * tier hardlinks the previous build's parquet and appends new fold files, so
+ * changing this map would otherwise publish exactly that unreadable mixed
+ * build and break every report, Explore answer, and ScoutQL query until the
+ * next full rebuild replaced the last old file.
+ *
+ * So the compactor compares this against the published build and rebuilds from
+ * S3 instead of folding when it differs. Sorting means a pure reordering costs
+ * nothing, while any added, removed, or retyped column forces the rebuild.
+ */
+export function lakeSchemaFingerprint(): string {
+  const signature = [
+    `matches=${columnSetSignature(MATCH_LAKE_COLUMNS)}`,
+    `prematch=${columnSetSignature(PREMATCH_LAKE_COLUMNS)}`,
+    `accounts=${columnSetSignature(ACCOUNT_LAKE_COLUMNS)}`,
+    `competition_rank_history=${columnSetSignature(
+      COMPETITION_RANK_HISTORY_LAKE_COLUMNS,
+    )}`,
+  ].join("|");
+  return new Bun.CryptoHasher("sha256")
+    .update(signature)
+    .digest("hex")
+    .slice(0, 16);
+}


### PR DESCRIPTION
## Why

Adding a column to the report lake is **not** backward compatible with already-published parquet, and nothing detected that.

`buildUnionSource` (`reports/duckdb/lake.ts:135`) selects an explicit column list across the whole parquet file list. A build whose files disagree on columns does not degrade to NULLs — DuckDB refuses to bind at all. Verified directly against the beta lake:

```
explicit-column-list read FAILED: Binder Error: Referenced column "danger_pings" not found in FROM clause!
union_by_name read SUCCEEDED:    [{kills:1, deaths:2, danger_pings:null}, {kills:3, deaths:4, danger_pings:5}]
```

The **fold** tier hardlinks the previous build's parquet and appends fold files beside it. So the first fold after a column change publishes exactly that unreadable mixed build, breaking every report, Explore answer, and ScoutQL query until the nightly rebuild happens to replace the last old file. Scout's `CLAUDE.md` ("the nightly rebuild picks up new lake columns") describes the steady state; it does not cover that window, and the manifest carried no schema marker to force the rebuild.

`union_by_name` is deliberately **not** the fix — it returns NULLs for pre-rebuild rows, which silently understates any aggregate over a new column.

## What

- Record a fingerprint of every lake table's column set in each build's `manifest.json`.
- `runReportLakeFold` falls back to the existing full-rebuild path when the published build's fingerprint is missing or differs.
- The fingerprint sorts columns by name, matching how reads bind them, so a pure reordering costs nothing while any added, removed, or retyped column forces the rebuild.

Builds predating this change carry no fingerprint and so rebuild once on first fold. That is the intended migration.

## Verification

`bun test src/report-lake/report-lake.integration.test.ts` — **14 pass / 0 fail**, including three new cases:

- the manifest records the fingerprint
- a mismatched fingerprint rebuilds instead of folding
- a missing manifest rebuilds instead of folding

Both guard cases were confirmed to fire for the right reason, not to pass vacuously:

```
Lake column set changed (published 0000000000000000, expected 9035495e298e66ff); folding via full rebuild
Lake column set changed (published unrecorded, expected 9035495e298e66ff); folding via full rebuild
```

`bunx turbo run typecheck --filter=@scout-for-lol/backend` passes.

Not run: a live compaction against beta or prod.

## Note

Stacked below #2299. Both sit behind #2298, which unblocks `main`'s red `verify`.