### PR TITLE
feat(scout-for-lol): render /scout ask tables and KPIs as Discord embeds

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3972,7 +3972,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -9166,6 +9166,8 @@
 
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "tasks-for-obsidian/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
@@ -11026,6 +11028,8 @@
 
     "table/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "tasks-for-obsidian/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "tsup/postcss-load-config/lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "tw-to-css/tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
@@ -12126,6 +12130,8 @@
 
     "socket.io/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "tasks-for-obsidian/@types/bun/bun-types/@types/node": ["@types/node@25.9.4", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g=="],
+
     "tw-to-css/tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tw-to-css/tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -12397,6 +12403,8 @@
     "sanitize-html/htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "shadcn/@babel/core/@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "tasks-for-obsidian/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "tw-to-css/tailwindcss/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/scout.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/scout.integration.test.ts
@@ -185,7 +185,10 @@ describe("/scout ask", () => {
       "https://beta.scout-for-lol.com/app/explore/",
     );
     expect(responseJson).toContain('"parse":[]');
-    expect(first.edits[0]).toHaveProperty("files");
+    expect(first.edits[0]).toHaveProperty("embeds");
+    expect(first.edits[0]).not.toHaveProperty("files");
+    expect(responseJson).toContain("Win rates");
+    expect(responseJson).toContain("Aurora");
   });
 
   test("renders a salvaged partial answer as a publishable saved result", async () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/scout.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/scout.ts
@@ -16,9 +16,9 @@ import { loadExploreTranscript, startExploreTurn } from "#src/explore/store.ts";
 import {
   exploreActionRow,
   exploreAnswerChunks,
-  exploreChartAttachment,
   NO_GENERATED_MENTIONS,
 } from "#src/discord/scout/messages.ts";
+import { exploreVisualizationPayload } from "#src/discord/scout/visualization.ts";
 import { scoutExploreTurnsTotal } from "#src/metrics/explore.ts";
 
 export type ScoutAskInteraction = {
@@ -172,7 +172,7 @@ async function sendPrivateAnswer(
   if (first === undefined) {
     throw new Error("Saved Explore answer had no Discord content.");
   }
-  const chart = exploreChartAttachment(answer);
+  const visualization = exploreVisualizationPayload(answer);
   await interaction.editReply({
     content: first,
     components: [
@@ -183,7 +183,7 @@ async function sendPrivateAnswer(
       }),
     ],
     allowedMentions: NO_GENERATED_MENTIONS,
-    ...(chart === null ? {} : { files: [chart] }),
+    ...visualization,
   });
   for (const content of chunks.slice(1)) {
     await interaction.followUp({

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/messages.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/messages.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { ExploreMessageSchema } from "@scout-for-lol/data";
 import {
   exploreAnswerChunks,
-  exploreChartAttachment,
   publicExploreChunks,
 } from "#src/discord/scout/messages.ts";
-import { scoutTestVisualization } from "#src/discord/scout/test-fixtures.ts";
 
 const answer = ExploreMessageSchema.parse({
   id: "10000000-0000-4000-8000-000000000002",
@@ -35,16 +33,5 @@ describe("Scout Discord messages", () => {
     expect(publicChunks.join("\n")).toContain(
       "Only tracked matches are included.",
     );
-  });
-
-  test("attaches the existing static visualization renderer output", () => {
-    const chartAnswer = ExploreMessageSchema.parse({
-      ...answer,
-      visualization: scoutTestVisualization,
-    });
-
-    const attachment = exploreChartAttachment(chartAnswer);
-    expect(attachment?.name).toBe("scout-explore.png");
-    expect(attachment?.attachment).toBeInstanceOf(Buffer);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/messages.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/messages.ts
@@ -1,12 +1,10 @@
 import {
   ActionRowBuilder,
-  AttachmentBuilder,
   ButtonBuilder,
   ButtonStyle,
   escapeMarkdown,
 } from "discord.js";
 import type { ExploreMessage } from "@scout-for-lol/data";
-import { visualizationSnapshotToImage } from "@scout-for-lol/report";
 import { getExploreConversationUrl } from "#src/discord/commands/links.ts";
 import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 import { formatScoutPublishCustomId } from "#src/discord/scout/custom-id.ts";
@@ -28,18 +26,6 @@ export function publicExploreChunks(input: {
     .join("\n");
   return splitMessageIntoChunks(
     `**${escapeMarkdown(input.username)} asked Scout:**\n${quotedQuestion}\n\n${formatAnswer(input.answer)}`,
-  );
-}
-
-export function exploreChartAttachment(
-  message: ExploreMessage,
-): AttachmentBuilder | null {
-  if (message.visualization === null) {
-    return null;
-  }
-  return new AttachmentBuilder(
-    visualizationSnapshotToImage(message.visualization),
-    { name: "scout-explore.png" },
   );
 }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/publish.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/publish.integration.test.ts
@@ -158,7 +158,9 @@ describe("Scout public publishing", () => {
     expect(publicJson).not.toContain("secret_query");
     expect(publicJson).not.toContain("private trace");
     expect(publicJson).not.toContain("/app/explore/");
-    expect(fake.followUps[0]).toHaveProperty("files");
+    expect(fake.followUps[0]).toHaveProperty("embeds");
+    expect(fake.followUps[0]).not.toHaveProperty("files");
+    expect(publicJson).toContain("Win rates");
     expect(JSON.stringify(fake.edits)).toContain("Posted");
     expect(JSON.stringify(fake.edits)).toContain('"disabled":true');
   });

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/publish.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/publish.ts
@@ -10,10 +10,10 @@ import { loadExploreTranscript } from "#src/explore/store.ts";
 import { parseScoutPublishCustomId } from "#src/discord/scout/custom-id.ts";
 import {
   exploreActionRow,
-  exploreChartAttachment,
   NO_GENERATED_MENTIONS,
   publicExploreChunks,
 } from "#src/discord/scout/messages.ts";
+import { exploreVisualizationPayload } from "#src/discord/scout/visualization.ts";
 
 export type ScoutPublishButtonInteraction = {
   customId: string;
@@ -89,7 +89,7 @@ export async function handleScoutPublishButton(
       question: question.content,
       answer,
     });
-    const chart = exploreChartAttachment(answer);
+    const visualization = exploreVisualizationPayload(answer);
     const publishedMessages: { delete: () => Promise<unknown> }[] = [];
     try {
       for (const [index, content] of chunks.entries()) {
@@ -97,7 +97,7 @@ export async function handleScoutPublishButton(
           await interaction.followUp({
             content,
             allowedMentions: NO_GENERATED_MENTIONS,
-            ...(index === 0 && chart !== null ? { files: [chart] } : {}),
+            ...(index === 0 ? visualization : {}),
           }),
         );
       }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/test-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/test-fixtures.ts
@@ -69,7 +69,7 @@ export const scoutTestKpi = VisualizationSnapshotSchema.parse({
       label: "Games counted",
       metric: "games",
       additive: true,
-      points: [point("total", 56, 56)],
+      points: [point("earlier", 42), point("total", 56, 56)],
     },
   ],
   annotations: [],

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/test-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/test-fixtures.ts
@@ -1,5 +1,26 @@
 import { VisualizationSnapshotSchema } from "@scout-for-lol/data";
 
+const display = {
+  theme: null,
+  palette: null,
+  smooth: false,
+  stack: "none" as const,
+  rollingWindow: null,
+  cumulative: false,
+  sparkline: false,
+};
+
+function point(label: string, value: number, sampleSize = 8) {
+  return {
+    key: label,
+    label,
+    start: "2026-01-01T00:00:00.000Z",
+    end: "2026-01-02T00:00:00.000Z",
+    value,
+    evidence: { sampleSize, confidenceInterval: null },
+  };
+}
+
 export const scoutTestVisualization = VisualizationSnapshotSchema.parse({
   version: 1,
   generatedAt: "2026-08-18T00:00:00.000Z",
@@ -7,16 +28,65 @@ export const scoutTestVisualization = VisualizationSnapshotSchema.parse({
   title: "Win rates",
   temporal: null,
   bucket: null,
-  display: {
-    theme: null,
-    palette: null,
-    smooth: false,
-    stack: "none",
-    rollingWindow: null,
-    cumulative: false,
-    sparkline: false,
-  },
-  series: [],
+  display,
+  series: [
+    {
+      id: "games",
+      label: "Games",
+      metric: "games",
+      additive: true,
+      points: [point("Aurora", 8), point("Jhin", 7)],
+    },
+    {
+      id: "win_rate",
+      label: "Win rate",
+      metric: "win_rate",
+      additive: false,
+      points: [point("Aurora", 1), point("Jhin", 0.286)],
+    },
+  ],
   annotations: [],
   trends: [],
+});
+
+export const scoutTestLeaderboard = VisualizationSnapshotSchema.parse({
+  ...scoutTestVisualization,
+  kind: "LEADERBOARD",
+  title: "Vision score per game",
+});
+
+export const scoutTestKpi = VisualizationSnapshotSchema.parse({
+  version: 1,
+  generatedAt: "2026-08-18T00:00:00.000Z",
+  kind: "KPI_CARD",
+  title: "Games for lolop#dog",
+  temporal: null,
+  bucket: null,
+  display,
+  series: [
+    {
+      id: "games",
+      label: "Games counted",
+      metric: "games",
+      additive: true,
+      points: [point("total", 56, 56)],
+    },
+  ],
+  annotations: [],
+  trends: [],
+});
+
+export const scoutTestBarChart = VisualizationSnapshotSchema.parse({
+  ...scoutTestVisualization,
+  kind: "BAR_CHART",
+  title: "Vision score per game",
+  series: [
+    {
+      id: "vision",
+      label: "Vision / game",
+      metric: "vision_score",
+      additive: false,
+      points: [point("Francesca#000", 79.8, 31)],
+    },
+  ],
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -1,0 +1,109 @@
+import {
+  formatReportDisplayValue,
+  REPORT_METRICS,
+  type ReportAiPreviewSummary,
+  type TemporalSeries,
+  type VisualizationSnapshot,
+} from "@scout-for-lol/data";
+
+export type NativeRowValue = string | number | null;
+export type NativeRow = {
+  key: string;
+  label: string;
+  values: Map<string, NativeRowValue>;
+};
+
+export function formatPreviewValue(
+  column: ReportAiPreviewSummary["columns"][number],
+  value: NativeRowValue,
+): string {
+  return value === null ? "Unknown" : formatReportDisplayValue(column, value);
+}
+
+export function requireRowValue(
+  row: NativeRow,
+  column: string,
+): NativeRowValue {
+  const value = row.values.get(column);
+  if (value === undefined) {
+    throw new Error(`Visualization row missing value for ${column}.`);
+  }
+  return value;
+}
+
+export function formatNativeSeriesValue(
+  snapshot: VisualizationSnapshot,
+  series: TemporalSeries,
+  row: NativeRow,
+): string {
+  const value = formatSeriesValue(
+    snapshot,
+    series,
+    requireNumericRowValue(row, series.id),
+  );
+  const point = series.points.find((item) => item.key === row.key);
+  if (
+    point === undefined ||
+    (snapshot.temporal?.comparison === undefined &&
+      point.comparisonEvidence === undefined)
+  ) {
+    return value;
+  }
+  const percentage = point.percentageDelta;
+  return `${value} · Baseline: ${formatSeriesValue(
+    snapshot,
+    series,
+    point.comparisonValue ?? null,
+  )} · Δ ${formatAbsoluteDelta(snapshot, series, point.absoluteDelta ?? null)} · ${
+    percentage === null || percentage === undefined
+      ? "Unknown"
+      : `${(percentage * 100).toFixed(1)}%`
+  }`;
+}
+
+export function formatSeriesValue(
+  snapshot: VisualizationSnapshot,
+  series: TemporalSeries,
+  value: number | null,
+): string {
+  if (value === null) {
+    return "Unknown";
+  }
+  const isRate =
+    snapshot.display.stack === "percent" ||
+    REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
+      "rate";
+  if (isRate) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 3 }).format(
+    value,
+  );
+}
+
+export function formatAbsoluteDelta(
+  snapshot: VisualizationSnapshot,
+  series: TemporalSeries,
+  value: number | null,
+): string {
+  const isRate =
+    snapshot.display.stack === "percent" ||
+    REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
+      "rate";
+  return isRate
+    ? value === null
+      ? "Unknown"
+      : `${(value * 100).toFixed(1)} pp`
+    : formatSeriesValue(snapshot, series, value);
+}
+
+export function requireNumericRowValue(
+  row: NativeRow,
+  column: string,
+): number | null {
+  const value = row.values.get(column) ?? null;
+  if (typeof value !== "number" && value !== null) {
+    throw new Error(`Visualization row value for ${column} is not numeric.`);
+  }
+  return value;
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -185,7 +185,7 @@ function pointMatchesRow(
   if (pointDimension === null) {
     return false;
   }
-  const dimension = pointDimension ?? row.key;
+  const dimension = pointDimension;
   return (
     displayDimensionMatches(dimension, point.key) ||
     displayDimensionMatches(dimension, point.label)

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -136,9 +136,8 @@ export function formatPreviewValueWithEvidence(
     if (!row.key.startsWith(`${seriesDimension} • `)) {
       return [];
     }
-    const pointDimension = row.key.slice(seriesDimension.length + 3);
     const point = item.points.find((candidate) =>
-      pointMatchesRow(candidate, row, pointDimension),
+      pointMatchesNamedSeries(candidate, row, seriesDimension),
     );
     return point === undefined
       ? []
@@ -155,6 +154,19 @@ export function formatPreviewValueWithEvidence(
     seriesMatch.item,
     seriesMatch.point,
   )}`;
+}
+
+function pointMatchesNamedSeries(
+  point: TemporalSeries["points"][number],
+  row: NativeRow,
+  seriesDimension: string,
+): boolean {
+  return (
+    row.key === `${seriesDimension} • ${point.key}` ||
+    row.key === `${seriesDimension} • ${point.label}` ||
+    row.label === `${seriesDimension} • ${point.key}` ||
+    row.label === `${seriesDimension} • ${point.label}`
+  );
 }
 
 function pointMatchesRow(

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -48,7 +48,6 @@ export function formatPreviewValueWithEvidence(
   row: NativeRow,
 ): string {
   const value = formatPreviewValue(column, requireRowValue(row, column.key));
-  const rowDimensions = new Set(row.key.split(" • "));
   const series = snapshot.series.find((item) => {
     if (item.metric !== column.key) {
       return false;
@@ -56,12 +55,15 @@ export function formatPreviewValueWithEvidence(
     const separator = item.id.lastIndexOf(":");
     const seriesDimension =
       separator === -1 ? "All" : item.id.slice(0, separator);
-    const pointDimensions = new Set(rowDimensions);
-    if (seriesDimension !== "All" && !pointDimensions.delete(seriesDimension)) {
+    if (seriesDimension === "All") {
+      return item.points.some((point) => pointMatchesRow(point, row, null));
+    }
+    if (!row.key.startsWith(`${seriesDimension} • `)) {
       return false;
     }
+    const pointDimension = row.key.slice(seriesDimension.length + 3);
     return item.points.some((point) =>
-      pointMatchesRow(point, row, pointDimensions),
+      pointMatchesRow(point, row, pointDimension),
     );
   });
   if (series === undefined) {
@@ -70,12 +72,12 @@ export function formatPreviewValueWithEvidence(
   const separator = series.id.lastIndexOf(":");
   const seriesDimension =
     separator === -1 ? "All" : series.id.slice(0, separator);
-  const pointDimensions = new Set(rowDimensions);
-  if (seriesDimension !== "All") {
-    pointDimensions.delete(seriesDimension);
-  }
+  const pointDimension =
+    seriesDimension === "All"
+      ? null
+      : row.key.slice(seriesDimension.length + 3);
   const point = series.points.find((candidate) =>
-    pointMatchesRow(candidate, row, pointDimensions),
+    pointMatchesRow(candidate, row, pointDimension),
   );
   return `${value}${formatConfidenceInterval(snapshot, series, point)}`;
 }
@@ -83,13 +85,24 @@ export function formatPreviewValueWithEvidence(
 function pointMatchesRow(
   point: TemporalSeries["points"][number],
   row: NativeRow,
-  pointDimensions: Set<string>,
+  pointDimension: string | null,
 ): boolean {
+  if (point.key === row.key || point.label === row.label) {
+    return true;
+  }
+  const dimension = pointDimension ?? row.key;
   return (
-    point.key === row.key ||
-    point.label === row.label ||
-    pointDimensions.has(point.key) ||
-    pointDimensions.has(point.label)
+    displayDimensionMatches(dimension, point.key) ||
+    displayDimensionMatches(dimension, point.label)
+  );
+}
+
+function displayDimensionMatches(value: string, dimension: string): boolean {
+  return (
+    value === dimension ||
+    value.startsWith(`${dimension} • `) ||
+    value.endsWith(` • ${dimension}`) ||
+    value.includes(` • ${dimension} • `)
   );
 }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -20,6 +20,27 @@ export function formatPreviewValue(
   return value === null ? "Unknown" : formatReportDisplayValue(column, value);
 }
 
+export function formatPreviewValueWithEvidence(
+  snapshot: VisualizationSnapshot,
+  column: ReportAiPreviewSummary["columns"][number],
+  row: NativeRow,
+): string {
+  const value = formatPreviewValue(column, requireRowValue(row, column.key));
+  const series = snapshot.series.find((item) => item.id === column.key);
+  if (series === undefined) {
+    return value;
+  }
+  const rowDimensions = new Set(row.key.split(" • "));
+  const point = series.points.find(
+    (item) =>
+      item.key === row.key ||
+      item.label === row.label ||
+      rowDimensions.has(item.key) ||
+      rowDimensions.has(item.label),
+  );
+  return `${value}${formatConfidenceInterval(snapshot, series, point)}`;
+}
+
 export function requireRowValue(
   row: NativeRow,
   column: string,
@@ -42,15 +63,11 @@ export function formatNativeSeriesValue(
     requireNumericRowValue(row, series.id),
   );
   const point = series.points.find((item) => item.key === row.key);
-  const confidenceInterval = point?.evidence.confidenceInterval;
-  const confidenceIntervalText =
-    confidenceInterval === null || confidenceInterval === undefined
-      ? ""
-      : ` · 95% CI ${formatSeriesValue(
-          snapshot,
-          series,
-          confidenceInterval.lower,
-        )}–${formatSeriesValue(snapshot, series, confidenceInterval.upper)}`;
+  const confidenceIntervalText = formatConfidenceInterval(
+    snapshot,
+    series,
+    point,
+  );
   if (
     point === undefined ||
     (snapshot.temporal?.comparison === undefined &&
@@ -68,6 +85,21 @@ export function formatNativeSeriesValue(
       ? "Unknown"
       : `${(percentage * 100).toFixed(1)}%`
   }`;
+}
+
+function formatConfidenceInterval(
+  snapshot: VisualizationSnapshot,
+  series: TemporalSeries,
+  point: TemporalSeries["points"][number] | undefined,
+): string {
+  const confidenceInterval = point?.evidence.confidenceInterval;
+  return confidenceInterval === null || confidenceInterval === undefined
+    ? ""
+    : ` · 95% CI ${formatSeriesValue(
+        snapshot,
+        series,
+        confidenceInterval.lower,
+      )}–${formatSeriesValue(snapshot, series, confidenceInterval.upper)}`;
 }
 
 export function formatSeriesValue(

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -174,8 +174,16 @@ function pointMatchesRow(
   row: NativeRow,
   pointDimension: string | null,
 ): boolean {
-  if (point.key === row.key || point.label === row.label) {
+  if (
+    point.key === row.key ||
+    point.key === row.label ||
+    point.label === row.key ||
+    point.label === row.label
+  ) {
     return true;
+  }
+  if (pointDimension === null) {
+    return false;
   }
   const dimension = pointDimension ?? row.key;
   return (

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -6,12 +6,31 @@ import {
   type VisualizationSnapshot,
 } from "@scout-for-lol/data";
 
+const MAX_NATIVE_CELL_LENGTH = 160;
+const nativeCellGraphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
 export type NativeRowValue = string | number | null;
 export type NativeRow = {
   key: string;
   label: string;
   values: Map<string, NativeRowValue>;
 };
+
+export function truncateNativeCell(value: string): string {
+  if (value.length <= MAX_NATIVE_CELL_LENGTH) {
+    return value;
+  }
+  let truncated = "";
+  for (const { segment } of nativeCellGraphemeSegmenter.segment(value)) {
+    if (truncated.length + segment.length > MAX_NATIVE_CELL_LENGTH - 1) {
+      break;
+    }
+    truncated += segment;
+  }
+  return `${truncated}…`;
+}
 
 export function formatPreviewValue(
   column: ReportAiPreviewSummary["columns"][number],

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -27,21 +27,48 @@ export function formatPreviewValueWithEvidence(
 ): string {
   const value = formatPreviewValue(column, requireRowValue(row, column.key));
   const rowDimensions = new Set(row.key.split(" • "));
-  const pointMatchesRow = (item: TemporalSeries["points"][number]) =>
-    item.key === row.key ||
-    item.label === row.label ||
-    rowDimensions.has(item.key) ||
-    rowDimensions.has(item.label);
-  const series = snapshot.series.find(
-    (item) =>
-      item.metric === column.key &&
-      item.points.some((point) => pointMatchesRow(point)),
-  );
+  const series = snapshot.series.find((item) => {
+    if (item.metric !== column.key) {
+      return false;
+    }
+    const separator = item.id.lastIndexOf(":");
+    const seriesDimension =
+      separator === -1 ? "All" : item.id.slice(0, separator);
+    const pointDimensions = new Set(rowDimensions);
+    if (seriesDimension !== "All") {
+      pointDimensions.delete(seriesDimension);
+    }
+    return item.points.some((point) =>
+      pointMatchesRow(point, row, pointDimensions),
+    );
+  });
   if (series === undefined) {
     return value;
   }
-  const point = series.points.find((candidate) => pointMatchesRow(candidate));
+  const separator = series.id.lastIndexOf(":");
+  const seriesDimension =
+    separator === -1 ? "All" : series.id.slice(0, separator);
+  const pointDimensions = new Set(rowDimensions);
+  if (seriesDimension !== "All") {
+    pointDimensions.delete(seriesDimension);
+  }
+  const point = series.points.find((candidate) =>
+    pointMatchesRow(candidate, row, pointDimensions),
+  );
   return `${value}${formatConfidenceInterval(snapshot, series, point)}`;
+}
+
+function pointMatchesRow(
+  point: TemporalSeries["points"][number],
+  row: NativeRow,
+  pointDimensions: Set<string>,
+): boolean {
+  return (
+    point.key === row.key ||
+    point.label === row.label ||
+    pointDimensions.has(point.key) ||
+    pointDimensions.has(point.label)
+  );
 }
 
 export function requireRowValue(

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -42,15 +42,24 @@ export function formatNativeSeriesValue(
     requireNumericRowValue(row, series.id),
   );
   const point = series.points.find((item) => item.key === row.key);
+  const confidenceInterval = point?.evidence.confidenceInterval;
+  const confidenceIntervalText =
+    confidenceInterval === null || confidenceInterval === undefined
+      ? ""
+      : ` · 95% CI ${formatSeriesValue(
+          snapshot,
+          series,
+          confidenceInterval.lower,
+        )}–${formatSeriesValue(snapshot, series, confidenceInterval.upper)}`;
   if (
     point === undefined ||
     (snapshot.temporal?.comparison === undefined &&
       point.comparisonEvidence === undefined)
   ) {
-    return value;
+    return `${value}${confidenceIntervalText}`;
   }
   const percentage = point.percentageDelta;
-  return `${value} · Baseline: ${formatSeriesValue(
+  return `${value}${confidenceIntervalText} · Baseline: ${formatSeriesValue(
     snapshot,
     series,
     point.comparisonValue ?? null,

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -26,18 +26,21 @@ export function formatPreviewValueWithEvidence(
   row: NativeRow,
 ): string {
   const value = formatPreviewValue(column, requireRowValue(row, column.key));
-  const series = snapshot.series.find((item) => item.id === column.key);
+  const rowDimensions = new Set(row.key.split(" • "));
+  const pointMatchesRow = (item: TemporalSeries["points"][number]) =>
+    item.key === row.key ||
+    item.label === row.label ||
+    rowDimensions.has(item.key) ||
+    rowDimensions.has(item.label);
+  const series = snapshot.series.find(
+    (item) =>
+      item.metric === column.key &&
+      item.points.some((point) => pointMatchesRow(point)),
+  );
   if (series === undefined) {
     return value;
   }
-  const rowDimensions = new Set(row.key.split(" • "));
-  const point = series.points.find(
-    (item) =>
-      item.key === row.key ||
-      item.label === row.label ||
-      rowDimensions.has(item.key) ||
-      rowDimensions.has(item.label),
-  );
+  const point = series.points.find((candidate) => pointMatchesRow(candidate));
   return `${value}${formatConfidenceInterval(snapshot, series, point)}`;
 }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -120,38 +120,41 @@ export function formatPreviewValueWithEvidence(
   row: NativeRow,
 ): string {
   const value = formatPreviewValue(column, requireRowValue(row, column.key));
-  const series = snapshot.series.find((item) => {
+  const seriesMatches = snapshot.series.flatMap((item) => {
     if (item.metric !== column.key) {
-      return false;
+      return [];
     }
     const separator = item.id.lastIndexOf(":");
     const seriesDimension =
       separator === -1 ? "All" : item.id.slice(0, separator);
     if (seriesDimension === "All") {
-      return item.points.some((point) => pointMatchesRow(point, row, null));
+      const point = item.points.find((candidate) =>
+        pointMatchesRow(candidate, row, null),
+      );
+      return point === undefined ? [] : [{ item, point, specificity: 0 }];
     }
     if (!row.key.startsWith(`${seriesDimension} • `)) {
-      return false;
+      return [];
     }
     const pointDimension = row.key.slice(seriesDimension.length + 3);
-    return item.points.some((point) =>
-      pointMatchesRow(point, row, pointDimension),
+    const point = item.points.find((candidate) =>
+      pointMatchesRow(candidate, row, pointDimension),
     );
+    return point === undefined
+      ? []
+      : [{ item, point, specificity: seriesDimension.length }];
   });
-  if (series === undefined) {
+  const seriesMatch = seriesMatches.sort(
+    (left, right) => right.specificity - left.specificity,
+  )[0];
+  if (seriesMatch === undefined) {
     return value;
   }
-  const separator = series.id.lastIndexOf(":");
-  const seriesDimension =
-    separator === -1 ? "All" : series.id.slice(0, separator);
-  const pointDimension =
-    seriesDimension === "All"
-      ? null
-      : row.key.slice(seriesDimension.length + 3);
-  const point = series.points.find((candidate) =>
-    pointMatchesRow(candidate, row, pointDimension),
-  );
-  return `${value}${formatConfidenceInterval(snapshot, series, point)}`;
+  return `${value}${formatConfidenceInterval(
+    snapshot,
+    seriesMatch.item,
+    seriesMatch.point,
+  )}`;
 }
 
 function pointMatchesRow(

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -35,6 +35,78 @@ export function truncateNativeCell(
   return `${truncated}…`;
 }
 
+const displayWidthGraphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+export function displayWidth(value: string): number {
+  let width = 0;
+  for (const { segment } of displayWidthGraphemeSegmenter.segment(value)) {
+    width += displayGraphemeWidth(segment);
+  }
+  return width;
+}
+
+function displayGraphemeWidth(segment: string): number {
+  let width = 0;
+  let regionalIndicatorCount = 0;
+  let hasKeycapMark = false;
+  let hasEmojiVariationSelector = false;
+  for (const character of segment) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined) {
+      continue;
+    }
+    if (codePoint >= 0x1_f1_e6 && codePoint <= 0x1_f1_ff) {
+      regionalIndicatorCount += 1;
+      continue;
+    }
+    if (codePoint === 0x20_0d) {
+      continue;
+    }
+    if (codePoint === 0x20_e3) {
+      hasKeycapMark = true;
+      continue;
+    }
+    if (codePoint === 0xfe_0f) {
+      hasEmojiVariationSelector = true;
+      continue;
+    }
+    if (
+      /\p{Mark}/u.test(character) ||
+      (codePoint >= 0xfe_00 && codePoint <= 0xfe_0e)
+    ) {
+      continue;
+    }
+    width = Math.max(width, isWideCodePoint(codePoint) ? 2 : 1);
+  }
+  return hasKeycapMark ||
+    hasEmojiVariationSelector ||
+    regionalIndicatorCount === 2
+    ? 2
+    : width;
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x11_00 && codePoint <= 0x11_5f) ||
+    codePoint === 0x23_29 ||
+    codePoint === 0x23_2a ||
+    (codePoint >= 0x2e_80 && codePoint <= 0xa4_cf) ||
+    (codePoint >= 0xac_00 && codePoint <= 0xd7_a3) ||
+    (codePoint >= 0xf9_00 && codePoint <= 0xfa_ff) ||
+    (codePoint >= 0xfe_10 && codePoint <= 0xfe_19) ||
+    (codePoint >= 0xfe_30 && codePoint <= 0xfe_6f) ||
+    (codePoint >= 0xff_00 && codePoint <= 0xff_60) ||
+    (codePoint >= 0xff_e0 && codePoint <= 0xff_e6) ||
+    (codePoint >= 0x1_f3_00 && codePoint <= 0x1_fa_ff)
+  );
+}
+
+export function padDisplayWidth(value: string, width: number): string {
+  return value + " ".repeat(Math.max(0, width - displayWidth(value)));
+}
+
 export function formatPreviewValue(
   column: ReportAiPreviewSummary["columns"][number],
   value: NativeRowValue,

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization-format.ts
@@ -18,13 +18,16 @@ export type NativeRow = {
   values: Map<string, NativeRowValue>;
 };
 
-export function truncateNativeCell(value: string): string {
-  if (value.length <= MAX_NATIVE_CELL_LENGTH) {
+export function truncateNativeCell(
+  value: string,
+  maxLength = MAX_NATIVE_CELL_LENGTH,
+): string {
+  if (value.length <= maxLength) {
     return value;
   }
   let truncated = "";
   for (const { segment } of nativeCellGraphemeSegmenter.segment(value)) {
-    if (truncated.length + segment.length > MAX_NATIVE_CELL_LENGTH - 1) {
+    if (truncated.length + segment.length > maxLength - 1) {
       break;
     }
     truncated += segment;
@@ -54,8 +57,8 @@ export function formatPreviewValueWithEvidence(
     const seriesDimension =
       separator === -1 ? "All" : item.id.slice(0, separator);
     const pointDimensions = new Set(rowDimensions);
-    if (seriesDimension !== "All") {
-      pointDimensions.delete(seriesDimension);
+    if (seriesDimension !== "All" && !pointDimensions.delete(seriesDimension)) {
+      return false;
     }
     return item.points.some((point) =>
       pointMatchesRow(point, row, pointDimensions),

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -124,6 +124,19 @@ describe("Scout Discord visualizations", () => {
     expect(comparisonDescription).toContain("Baseline: 42");
     expect(comparisonDescription).toContain("Δ 14");
     expect(comparisonDescription).toContain("33.3%");
+    expect(kpiDescription).not.toContain("Baseline:");
+  });
+
+  test("renders an explicit empty state for empty native results", () => {
+    const empty = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      series: [],
+    });
+    const payload = exploreVisualizationPayload({
+      ...answer,
+      visualization: empty,
+    });
+    expect(payload.embeds?.[0]?.data.description).toBe("No results found.");
   });
 
   test("keeps every native description within Discord's limit", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -514,6 +514,12 @@ test("preserves confidence intervals in native temporal rows", () => {
   expect(visualizationToEmbed(snapshot)?.data.description).toContain(
     "95% CI 75.0%–100.0%",
   );
+  expect(
+    visualizationToEmbed(
+      VisualizationSnapshotSchema.parse({ ...snapshot, temporal: null }),
+      preview,
+    )?.data.description,
+  ).toContain("95% CI 75.0%–100.0%");
 });
 
 test("renders percent-stack snapshot values instead of raw preview values", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -531,7 +531,7 @@ test("keeps native values visible when labels exceed the description budget", ()
       label: "Series label ".repeat(500),
       points: series.points.map((point) => ({
         ...point,
-        label: "Point label ".repeat(500),
+        label: "Point label 😀".repeat(500),
       })),
     })),
   });
@@ -541,6 +541,7 @@ test("keeps native values visible when labels exceed the description budget", ()
       VisualizationSnapshotSchema.parse({ ...snapshot, kind }),
     )?.data.description;
     expect(description).toContain("100.0%");
+    expect(description).not.toContain("�");
   }
 });
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -195,8 +195,8 @@ describe("Scout Discord visualization bounds", () => {
     });
     const sparseDescription =
       visualizationToEmbed(sparseSnapshot)?.data.description;
-    expect(sparseDescription).toContain("Aurora    8    Unknown");
-    expect(sparseDescription).toContain("Jhin    Unknown    28.6%");
+    expect(sparseDescription).toContain("Aurora    8          Unknown");
+    expect(sparseDescription).toContain("Jhin      Unknown    28.6%");
 
     const incompletePreview = ReportAiPreviewSummarySchema.parse({
       ...preview,
@@ -213,7 +213,9 @@ describe("Scout Discord visualization bounds", () => {
       scoutTestVisualization,
       incompletePreview,
     )?.data.description;
-    expect(incompleteDescription).toContain("Aurora    8    Unknown");
+    expect(incompleteDescription).toContain(
+      "Aurora              8        Unknown",
+    );
   });
 
   test("keeps row labels on one Markdown line", () => {
@@ -240,6 +242,55 @@ describe("Scout Discord visualization bounds", () => {
     )?.data.description;
     expect(description).toContain("Aurora Jhin");
     expect(description).not.toContain("Aurora\nJhin");
+  });
+
+  test("uses normalized temporal rows and aligned table columns", () => {
+    const temporalSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      kind: "TABLE",
+      temporal: {
+        window: {
+          kind: "calendar",
+          startDate: "2026-01-01",
+          endDate: "2026-01-03",
+        },
+        bucket: "day",
+        timezone: "UTC",
+      },
+      series: scoutTestVisualization.series.map((series) => ({
+        ...series,
+        points: [
+          ...series.points,
+          {
+            ...series.points[0],
+            key: "2026-01-03",
+            label: "2026-01-03",
+          },
+        ],
+      })),
+    });
+    const temporalPreview = ReportAiPreviewSummarySchema.parse({
+      ...preview,
+      rows: [
+        {
+          label: "wrong preview order",
+          values: [
+            { column: "games", value: 1 },
+            { column: "win_rate", value: 1 },
+          ],
+        },
+      ],
+      visualizationRows: [],
+      rowsReturned: 1,
+    });
+    const description = visualizationToEmbed(temporalSnapshot, temporalPreview)
+      ?.data.description;
+    expect(description).toContain("Games");
+    expect(description).toContain("Aurora");
+    expect(description).not.toContain("wrong preview order");
+    expect(description).toContain("2026-01-03");
+    const lines = description?.split("\n") ?? [];
+    expect(lines[1]?.length).toBe(lines[2]?.length);
   });
 
   test("keeps every native description within Discord's limit", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -478,3 +478,17 @@ test("renders transformed snapshot values instead of raw preview values", () => 
   expect(description).toContain("9");
   expect(description).not.toContain("7");
 });
+
+test("renders percent-stack snapshot values instead of raw preview values", () => {
+  const snapshot = structuredClone(scoutTestVisualization);
+  snapshot.display.stack = "percent";
+  snapshot.series.forEach((series) => {
+    series.points = series.points.map((point, index) => ({
+      ...point,
+      value: index === 0 ? 0.5 : 0.25,
+    }));
+  });
+  const description = visualizationToEmbed(snapshot, preview)?.data.description;
+  expect(description).toContain("25.0%");
+  expect(description).not.toContain("7");
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -15,6 +15,7 @@ import {
   usesNativeDiscordVisualization,
   visualizationToEmbed,
 } from "#src/discord/scout/visualization.ts";
+import { displayWidth } from "#src/discord/scout/visualization-format.ts";
 
 const answer = ExploreMessageSchema.parse({
   id: "10000000-0000-4000-8000-000000000002",
@@ -559,6 +560,14 @@ test("preserves evidence when a series dimension contains the display separator"
   expect(
     visualizationToEmbed(snapshot, aliasedPreview)?.data.description,
   ).toContain("95% CI 75.0%–100.0%");
+});
+
+test("counts emoji-presentation graphemes at their rendered width", () => {
+  expect(displayWidth("♥️")).toBe(2);
+  expect(displayWidth("©️")).toBe(2);
+  expect(displayWidth("🇺🇸")).toBe(2);
+  expect(displayWidth("#️⃣")).toBe(2);
+  expect(displayWidth("é")).toBe(1);
 });
 
 test("keeps native values visible when labels exceed the description budget", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -98,6 +98,17 @@ describe("Scout Discord visualizations", () => {
     expect(kpiDescription).toContain("Games counted");
     expect(kpiDescription).not.toContain("42");
 
+    const subtitleKpi = VisualizationSnapshotSchema.parse({
+      ...scoutTestKpi,
+      display: {
+        ...scoutTestKpi.display,
+        options: { subtitle: "By player" },
+      },
+    });
+    expect(visualizationToEmbed(subtitleKpi)?.data.description).toContain(
+      "By player",
+    );
+
     const comparisonKpi = VisualizationSnapshotSchema.parse({
       ...scoutTestKpi,
       series: [
@@ -154,6 +165,14 @@ describe("Scout Discord visualization edge cases", () => {
     expect(visualizationToEmbed(emptySeriesSnapshot)?.data.description).toBe(
       "No results found.",
     );
+
+    const emptyKpiSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestKpi,
+      series: [],
+    });
+    expect(visualizationToEmbed(emptyKpiSnapshot)?.data.description).toBe(
+      "No results found.",
+    );
   });
 
   test("sanitizes table headers before rendering", () => {
@@ -168,7 +187,7 @@ describe("Scout Discord visualization edge cases", () => {
 
     const description = visualizationToEmbed(headerSnapshot)?.data.description;
     expect(description).toContain("Games ′");
-    expect(description).toContain(String.raw`\| unsafe`);
+    expect(description).toContain("| unsafe");
     expect(description).not.toContain("Games `\n");
   });
 
@@ -186,6 +205,33 @@ describe("Scout Discord visualization edge cases", () => {
     expect(description).toContain(
       "additional rows omitted from the stored preview",
     );
+  });
+
+  test("escapes Markdown in native labels and preview values", () => {
+    const textPreview = ReportAiPreviewSummarySchema.parse({
+      columns: [
+        { key: "label", label: "Player", format: "text" },
+        { key: "note", label: "Note", format: "text" },
+      ],
+      rows: [
+        {
+          label: "[name](https://example.com) ~~strike~~",
+          values: [{ column: "note", value: "[unsafe]\n~~value~~" }],
+        },
+      ],
+      rowsScanned: 1,
+      renderKind: "LIST",
+    });
+    const description = visualizationToEmbed(
+      VisualizationSnapshotSchema.parse({
+        ...scoutTestVisualization,
+        kind: "LIST",
+      }),
+      textPreview,
+    )?.data.description;
+    expect(description).not.toContain("[name](https://example.com)");
+    expect(description).not.toContain("~~strike~~");
+    expect(description).not.toContain("[unsafe]\n~~value~~");
   });
 });
 
@@ -257,13 +303,9 @@ describe("Scout Discord visualization bounds", () => {
       visualizationRows: [],
       rowsReturned: 1,
     });
-    const incompleteDescription = visualizationToEmbed(
-      scoutTestVisualization,
-      incompletePreview,
-    )?.data.description;
-    expect(incompleteDescription).toContain(
-      "Aurora              8        Unknown",
-    );
+    expect(() =>
+      visualizationToEmbed(scoutTestVisualization, incompletePreview),
+    ).toThrow("Visualization row missing value for win_rate.");
   });
 
   test("keeps row labels on one Markdown line", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -35,7 +35,8 @@ describe("Scout Discord visualizations", () => {
     const tableJson = JSON.stringify(table.embeds);
     expect(table.files).toBeUndefined();
     expect(tableJson).toContain("Win rates");
-    expect(tableJson).toContain("| Games |");
+    expect(tableJson).toContain("Games");
+    expect(tableJson).not.toContain("| Games |");
     expect(tableJson).toContain("Aurora");
     expect(tableJson).toContain("100.0%");
 
@@ -53,8 +54,11 @@ describe("Scout Discord visualizations", () => {
       }),
     });
     const listJson = JSON.stringify(list.embeds);
-    expect(listJson).toContain("- Aurora:");
+    expect(listJson).toContain("- Aurora: Games: 8, Win rate: 100.0%");
     expect(listJson).not.toContain("| Games |");
+
+    const leaderboardJson = JSON.stringify(board.embeds);
+    expect(leaderboardJson).toContain("Games: 8 · Win rate: 100.0%");
 
     const kpi = exploreVisualizationPayload({
       ...answer,
@@ -81,11 +85,16 @@ describe("Scout Discord visualizations", () => {
 
     for (const kind of ["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"] as const) {
       const embed = visualizationToEmbed(
-        VisualizationSnapshotSchema.parse({ ...longSnapshot, kind }),
+        VisualizationSnapshotSchema.parse({
+          ...longSnapshot,
+          kind,
+          title: "A title that is too long ".repeat(20),
+        }),
       );
       const description = embed?.data.description;
       expect(description).toBeString();
       expect(description?.length).toBeLessThanOrEqual(3900);
+      expect(embed?.data.title?.length).toBeLessThanOrEqual(256);
     }
   });
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -15,7 +15,10 @@ import {
   usesNativeDiscordVisualization,
   visualizationToEmbed,
 } from "#src/discord/scout/visualization.ts";
-import { displayWidth } from "#src/discord/scout/visualization-format.ts";
+import {
+  displayWidth,
+  formatPreviewValueWithEvidence,
+} from "#src/discord/scout/visualization-format.ts";
 
 const answer = ExploreMessageSchema.parse({
   id: "10000000-0000-4000-8000-000000000002",
@@ -568,6 +571,74 @@ test("counts emoji-presentation graphemes at their rendered width", () => {
   expect(displayWidth("🇺🇸")).toBe(2);
   expect(displayWidth("#️⃣")).toBe(2);
   expect(displayWidth("é")).toBe(1);
+});
+
+test("chooses the most specific matching series for preview evidence", () => {
+  const winRateSeries = scoutTestVisualization.series.find(
+    (series) => series.metric === "win_rate",
+  );
+  if (winRateSeries === undefined) {
+    throw new Error("Win rate test series is missing.");
+  }
+  const point = winRateSeries.points[0];
+  if (point === undefined) {
+    throw new Error("Win rate test point is missing.");
+  }
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    series: [
+      {
+        ...winRateSeries,
+        id: "Foo:win_rate",
+        points: [
+          {
+            ...point,
+            key: "Bar",
+            label: "Bar",
+            evidence: {
+              ...point.evidence,
+              confidenceInterval: {
+                level: 0.95,
+                lower: 0.1,
+                upper: 0.2,
+              },
+            },
+          },
+        ],
+      },
+      {
+        ...winRateSeries,
+        id: "Foo • Bar:win_rate",
+        points: [
+          {
+            ...point,
+            key: "Queue",
+            label: "Queue",
+            evidence: {
+              ...point.evidence,
+              confidenceInterval: {
+                level: 0.95,
+                lower: 0.9,
+                upper: 1,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+  const column = preview.columns.find((item) => item.key === "win_rate");
+  if (column === undefined) {
+    throw new Error("Win rate preview column is missing.");
+  }
+
+  expect(
+    formatPreviewValueWithEvidence(snapshot, column, {
+      key: "Foo • Bar • Queue",
+      label: "Foo • Bar • Queue",
+      values: new Map([["win_rate", 1]]),
+    }),
+  ).toContain("95% CI 90.0%–100.0%");
 });
 
 test("keeps native values visible when labels exceed the description budget", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -181,7 +181,7 @@ describe("Scout Discord visualization edge cases", () => {
       kind: "TABLE",
       series: scoutTestVisualization.series.map((series) => ({
         ...series,
-        label: "Games `\n| unsafe",
+        label: "Games `\r\n| unsafe",
       })),
     });
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -139,6 +139,44 @@ describe("Scout Discord visualizations", () => {
     expect(payload.embeds?.[0]?.data.description).toBe("No results found.");
   });
 
+  test("renders the stored visualization rows and only claims real overflow", () => {
+    const rows = Array.from({ length: 12 }, (_, index) => ({
+      label: `Champion ${index.toString()}`,
+      values: [
+        { column: "games", value: index + 1 },
+        { column: "win_rate", value: 0.5 },
+      ],
+    }));
+    const extendedPreview = ReportAiPreviewSummarySchema.parse({
+      ...preview,
+      rows: rows.slice(0, 10),
+      visualizationRows: rows,
+      rowsReturned: 13,
+    });
+    const extendedDescription = visualizationToEmbed(
+      scoutTestVisualization,
+      extendedPreview,
+    )?.data.description;
+    expect(extendedDescription).toContain("Champion 11");
+    expect(extendedDescription).toContain(
+      "additional rows omitted from the stored preview",
+    );
+
+    const completePreview = ReportAiPreviewSummarySchema.parse({
+      ...preview,
+      rows: rows.slice(0, 10),
+      visualizationRows: rows.slice(0, 10),
+      rowsReturned: 10,
+    });
+    const completeDescription = visualizationToEmbed(
+      scoutTestVisualization,
+      completePreview,
+    )?.data.description;
+    expect(completeDescription).not.toContain(
+      "additional rows omitted from the stored preview",
+    );
+  });
+
   test("keeps every native description within Discord's limit", () => {
     const longSnapshot = VisualizationSnapshotSchema.parse({
       ...scoutTestVisualization,

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { ExploreMessageSchema } from "@scout-for-lol/data";
+import {
+  scoutTestBarChart,
+  scoutTestKpi,
+  scoutTestLeaderboard,
+  scoutTestVisualization,
+} from "#src/discord/scout/test-fixtures.ts";
+import {
+  exploreVisualizationPayload,
+  usesNativeDiscordVisualization,
+} from "#src/discord/scout/visualization.ts";
+
+const answer = ExploreMessageSchema.parse({
+  id: "10000000-0000-4000-8000-000000000002",
+  role: "assistant",
+  parentId: "10000000-0000-4000-8000-000000000001",
+  siblingIds: ["10000000-0000-4000-8000-000000000002"],
+  content: "Aurora leads.",
+  caveats: [],
+  createdAt: "2026-08-18T00:00:00.000Z",
+});
+
+describe("Scout Discord visualizations", () => {
+  test("renders tables, leaderboards, and KPI cards as embeds", () => {
+    expect(usesNativeDiscordVisualization(scoutTestVisualization)).toBe(true);
+    const table = exploreVisualizationPayload({
+      ...answer,
+      visualization: scoutTestVisualization,
+    });
+    const tableJson = JSON.stringify(table.embeds);
+    expect(table.files).toBeUndefined();
+    expect(tableJson).toContain("Win rates");
+    expect(tableJson).toContain("| Games |");
+    expect(tableJson).toContain("Aurora");
+    expect(tableJson).toContain("100.0%");
+
+    const board = exploreVisualizationPayload({
+      ...answer,
+      visualization: scoutTestLeaderboard,
+    });
+    expect(JSON.stringify(board.embeds)).toContain("**1.** Aurora");
+
+    const kpi = exploreVisualizationPayload({
+      ...answer,
+      visualization: scoutTestKpi,
+    });
+    expect(JSON.stringify(kpi.embeds)).toContain("56");
+    expect(JSON.stringify(kpi.embeds)).toContain("Games counted");
+  });
+
+  test("still attaches a PNG for chart kinds", () => {
+    expect(usesNativeDiscordVisualization(scoutTestBarChart)).toBe(false);
+    const payload = exploreVisualizationPayload({
+      ...answer,
+      visualization: scoutTestBarChart,
+    });
+    expect(payload.embeds).toBeUndefined();
+    expect(payload.files?.[0]?.name).toBe("scout-explore.png");
+    expect(payload.files?.[0]?.attachment).toBeInstanceOf(Buffer);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -95,6 +95,10 @@ describe("Scout Discord visualizations", () => {
       expect(description).toBeString();
       expect(description?.length).toBeLessThanOrEqual(3900);
       expect(embed?.data.title?.length).toBeLessThanOrEqual(256);
+      if (kind === "TABLE") {
+        expect(description).toContain("```\n");
+        expect(description).toContain("\n```\n\n_Visualization truncated");
+      }
     }
   });
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { ExploreMessageSchema } from "@scout-for-lol/data";
+import {
+  ExploreMessageSchema,
+  VisualizationSnapshotSchema,
+} from "@scout-for-lol/data";
 import {
   scoutTestBarChart,
   scoutTestKpi,
@@ -9,6 +12,7 @@ import {
 import {
   exploreVisualizationPayload,
   usesNativeDiscordVisualization,
+  visualizationToEmbed,
 } from "#src/discord/scout/visualization.ts";
 
 const answer = ExploreMessageSchema.parse({
@@ -41,12 +45,48 @@ describe("Scout Discord visualizations", () => {
     });
     expect(JSON.stringify(board.embeds)).toContain("**1.** Aurora");
 
+    const list = exploreVisualizationPayload({
+      ...answer,
+      visualization: VisualizationSnapshotSchema.parse({
+        ...scoutTestVisualization,
+        kind: "LIST",
+      }),
+    });
+    const listJson = JSON.stringify(list.embeds);
+    expect(listJson).toContain("- Aurora:");
+    expect(listJson).not.toContain("| Games |");
+
     const kpi = exploreVisualizationPayload({
       ...answer,
       visualization: scoutTestKpi,
     });
-    expect(JSON.stringify(kpi.embeds)).toContain("56");
-    expect(JSON.stringify(kpi.embeds)).toContain("Games counted");
+    const kpiDescription = kpi.embeds?.[0]?.data.description;
+    expect(kpiDescription).toContain("56");
+    expect(kpiDescription).toContain("Games counted");
+    expect(kpiDescription).not.toContain("42");
+  });
+
+  test("keeps every native description within Discord's limit", () => {
+    const longSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      series: scoutTestVisualization.series.map((series) => ({
+        ...series,
+        label: "Series label ".repeat(200),
+        points: series.points.map((point) => ({
+          ...point,
+          label: "Point label ".repeat(200),
+        })),
+      })),
+    });
+
+    for (const kind of ["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"] as const) {
+      const embed = visualizationToEmbed(
+        VisualizationSnapshotSchema.parse({ ...longSnapshot, kind }),
+      );
+      const description = embed?.data.description;
+      expect(description).toBeString();
+      expect(description?.length).toBeLessThanOrEqual(3900);
+    }
   });
 
   test("still attaches a PNG for chart kinds", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -138,7 +138,9 @@ describe("Scout Discord visualizations", () => {
     });
     expect(payload.embeds?.[0]?.data.description).toBe("No results found.");
   });
+});
 
+describe("Scout Discord visualization bounds", () => {
   test("renders the stored visualization rows and only claims real overflow", () => {
     const rows = Array.from({ length: 12 }, (_, index) => ({
       label: `Champion ${index.toString()}`,
@@ -175,6 +177,69 @@ describe("Scout Discord visualizations", () => {
     expect(completeDescription).not.toContain(
       "additional rows omitted from the stored preview",
     );
+  });
+
+  test("renders sparse and incomplete rows as unknown values", () => {
+    const sparseSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      series: [
+        {
+          ...scoutTestVisualization.series[0],
+          points: [scoutTestVisualization.series[0]?.points[0]],
+        },
+        {
+          ...scoutTestVisualization.series[1],
+          points: [scoutTestVisualization.series[1]?.points[1]],
+        },
+      ],
+    });
+    const sparseDescription =
+      visualizationToEmbed(sparseSnapshot)?.data.description;
+    expect(sparseDescription).toContain("Aurora    8    Unknown");
+    expect(sparseDescription).toContain("Jhin    Unknown    28.6%");
+
+    const incompletePreview = ReportAiPreviewSummarySchema.parse({
+      ...preview,
+      rows: [
+        {
+          label: "Aurora",
+          values: [{ column: "games", value: 8 }],
+        },
+      ],
+      visualizationRows: [],
+      rowsReturned: 1,
+    });
+    const incompleteDescription = visualizationToEmbed(
+      scoutTestVisualization,
+      incompletePreview,
+    )?.data.description;
+    expect(incompleteDescription).toContain("Aurora    8    Unknown");
+  });
+
+  test("keeps row labels on one Markdown line", () => {
+    const newlinePreview = ReportAiPreviewSummarySchema.parse({
+      ...preview,
+      rows: [
+        {
+          label: "Aurora\nJhin",
+          values: [
+            { column: "games", value: 8 },
+            { column: "win_rate", value: 1 },
+          ],
+        },
+      ],
+      visualizationRows: [],
+      rowsReturned: 1,
+    });
+    const description = visualizationToEmbed(
+      VisualizationSnapshotSchema.parse({
+        ...scoutTestVisualization,
+        kind: "LIST",
+      }),
+      newlinePreview,
+    )?.data.description;
+    expect(description).toContain("Aurora Jhin");
+    expect(description).not.toContain("Aurora\nJhin");
   });
 
   test("keeps every native description within Discord's limit", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ExploreMessageSchema,
+  ReportAiPreviewSummarySchema,
   VisualizationSnapshotSchema,
 } from "@scout-for-lol/data";
 import {
@@ -25,11 +26,38 @@ const answer = ExploreMessageSchema.parse({
   createdAt: "2026-08-18T00:00:00.000Z",
 });
 
+const preview = ReportAiPreviewSummarySchema.parse({
+  columns: [
+    { key: "label", label: "Champion / queue", format: "text" },
+    { key: "games", label: "Games", format: "integer" },
+    { key: "win_rate", label: "Win rate", format: "percent" },
+  ],
+  rows: [
+    {
+      label: "Aurora • solo",
+      values: [
+        { column: "games", value: 8 },
+        { column: "win_rate", value: 1 },
+      ],
+    },
+    {
+      label: "Jhin • flex",
+      values: [
+        { column: "games", value: 7 },
+        { column: "win_rate", value: 0.286 },
+      ],
+    },
+  ],
+  rowsScanned: 2,
+  renderKind: "LEADERBOARD",
+});
+
 describe("Scout Discord visualizations", () => {
   test("renders tables, leaderboards, and KPI cards as embeds", () => {
     expect(usesNativeDiscordVisualization(scoutTestVisualization)).toBe(true);
     const table = exploreVisualizationPayload({
       ...answer,
+      preview,
       visualization: scoutTestVisualization,
     });
     const tableJson = JSON.stringify(table.embeds);
@@ -37,14 +65,15 @@ describe("Scout Discord visualizations", () => {
     expect(tableJson).toContain("Win rates");
     expect(tableJson).toContain("Games");
     expect(tableJson).not.toContain("| Games |");
-    expect(tableJson).toContain("Aurora");
+    expect(tableJson).toContain("Aurora • solo");
     expect(tableJson).toContain("100.0%");
 
     const board = exploreVisualizationPayload({
       ...answer,
+      preview,
       visualization: scoutTestLeaderboard,
     });
-    expect(JSON.stringify(board.embeds)).toContain("**1.** Aurora");
+    expect(JSON.stringify(board.embeds)).toContain("**1.** Aurora • solo");
 
     const list = exploreVisualizationPayload({
       ...answer,
@@ -68,6 +97,33 @@ describe("Scout Discord visualizations", () => {
     expect(kpiDescription).toContain("56");
     expect(kpiDescription).toContain("Games counted");
     expect(kpiDescription).not.toContain("42");
+
+    const comparisonKpi = VisualizationSnapshotSchema.parse({
+      ...scoutTestKpi,
+      series: [
+        {
+          ...scoutTestKpi.series[0],
+          points: [
+            {
+              ...scoutTestKpi.series[0]?.points[1],
+              comparisonValue: 42,
+              absoluteDelta: 14,
+              percentageDelta: 1 / 3,
+              comparisonEvidence: {
+                sampleSize: 42,
+                confidenceInterval: null,
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const comparisonDescription =
+      visualizationToEmbed(comparisonKpi)?.data.description;
+    expect(comparisonDescription).toContain("n=56");
+    expect(comparisonDescription).toContain("Baseline: 42");
+    expect(comparisonDescription).toContain("Δ 14");
+    expect(comparisonDescription).toContain("33.3%");
   });
 
   test("keeps every native description within Discord's limit", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -735,6 +735,42 @@ test("keeps native values visible when labels exceed the description budget", ()
   }
 });
 
+test("truncates oversized first rows at grapheme boundaries", () => {
+  const columns = [
+    { key: "label", label: "Label", format: "text" as const },
+    ...Array.from({ length: 19 }, (_, index) => ({
+      key: `metric-${index.toString()}`,
+      label: "m".repeat(155),
+      format: "text" as const,
+    })),
+  ];
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    kind: "LIST",
+  });
+  const oversizedPreview = ReportAiPreviewSummarySchema.parse({
+    columns,
+    rows: [
+      {
+        label: "r".repeat(159),
+        values: Array.from({ length: 19 }, (_, index) => ({
+          column: `metric-${index.toString()}`,
+          value: "😀".repeat(80),
+        })),
+      },
+    ],
+    rowsReturned: 1,
+    rowsScanned: 1,
+    renderKind: "LIST",
+  });
+
+  const description = visualizationToEmbed(snapshot, oversizedPreview)?.data
+    .description;
+  expect(description).toBeDefined();
+  expect(description).not.toContain("�");
+  expect(description).toContain("Visualization truncated");
+});
+
 test("renders percent-stack snapshot values instead of raw preview values", () => {
   const snapshot = structuredClone(scoutTestVisualization);
   snapshot.display.stack = "percent";

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -235,7 +235,7 @@ describe("Scout Discord visualization edge cases", () => {
       preview,
     )?.data.description;
     expect(collapsedDescription).toContain(
-      "additional rows omitted from the stored preview",
+      "additional rows may be omitted from the stored visualization",
     );
   });
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -441,13 +441,14 @@ describe("Scout Discord visualization bounds", () => {
         VisualizationSnapshotSchema.parse({
           ...longSnapshot,
           kind,
-          title: "A title that is too long ".repeat(20),
+          title: `${"A title that is too long ".repeat(10)}😀x`,
         }),
       );
       const description = embed?.data.description;
       expect(description).toBeString();
       expect(description?.length).toBeLessThanOrEqual(3900);
       expect(embed?.data.title?.length).toBeLessThanOrEqual(256);
+      expect(embed?.data.title).not.toContain("�");
       if (kind === "TABLE") {
         expect(description).toContain("```\n");
         expect(description).not.toContain("Visualization truncated");

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -171,6 +171,22 @@ describe("Scout Discord visualization edge cases", () => {
     expect(description).toContain(String.raw`\| unsafe`);
     expect(description).not.toContain("Games `\n");
   });
+
+  test("preserves overflow state for legacy previews", () => {
+    const legacyPreview = ReportAiPreviewSummarySchema.parse({
+      columns: preview.columns,
+      rows: preview.rows.slice(0, 1),
+      rowsScanned: preview.rowsScanned,
+      renderKind: preview.renderKind,
+    });
+    const description = visualizationToEmbed(
+      scoutTestVisualization,
+      legacyPreview,
+    )?.data.description;
+    expect(description).toContain(
+      "additional rows omitted from the stored preview",
+    );
+  });
 });
 
 describe("Scout Discord visualization bounds", () => {
@@ -196,7 +212,6 @@ describe("Scout Discord visualization bounds", () => {
     expect(extendedDescription).toContain(
       "additional rows omitted from the stored preview",
     );
-
     const completePreview = ReportAiPreviewSummarySchema.parse({
       ...preview,
       rows: rows.slice(0, 10),

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -140,6 +140,39 @@ describe("Scout Discord visualizations", () => {
   });
 });
 
+describe("Scout Discord visualization edge cases", () => {
+  test("renders an explicit empty state for generated empty series", () => {
+    const emptySeriesSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      kind: "LIST",
+      series: scoutTestVisualization.series.map((series) => ({
+        ...series,
+        points: [],
+      })),
+    });
+
+    expect(visualizationToEmbed(emptySeriesSnapshot)?.data.description).toBe(
+      "No results found.",
+    );
+  });
+
+  test("sanitizes table headers before rendering", () => {
+    const headerSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      kind: "TABLE",
+      series: scoutTestVisualization.series.map((series) => ({
+        ...series,
+        label: "Games `\n| unsafe",
+      })),
+    });
+
+    const description = visualizationToEmbed(headerSnapshot)?.data.description;
+    expect(description).toContain("Games ′");
+    expect(description).toContain(String.raw`\| unsafe`);
+    expect(description).not.toContain("Games `\n");
+  });
+});
+
 describe("Scout Discord visualization bounds", () => {
   test("renders the stored visualization rows and only claims real overflow", () => {
     const rows = Array.from({ length: 12 }, (_, index) => ({

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -458,3 +458,17 @@ describe("Scout Discord visualization bounds", () => {
     expect(payload.files?.[0]?.attachment).toBeInstanceOf(Buffer);
   });
 });
+
+test("renders transformed snapshot values instead of raw preview values", () => {
+  const snapshot = structuredClone(scoutTestVisualization);
+  snapshot.display.cumulative = true;
+  snapshot.series.forEach((series) => {
+    series.points = series.points.map((point, index) => ({
+      ...point,
+      value: index === 0 ? 8 : 9,
+    }));
+  });
+  const description = visualizationToEmbed(snapshot, preview)?.data.description;
+  expect(description).toContain("9");
+  expect(description).not.toContain("7");
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -382,7 +382,13 @@ describe("Scout Discord visualization bounds", () => {
       series: scoutTestVisualization.series.map((series) => ({
         ...series,
         points: [
-          ...series.points,
+          ...series.points.map((point) => ({
+            ...point,
+            comparisonValue: point.value,
+            absoluteDelta: 1,
+            percentageDelta: 0.5,
+            comparisonEvidence: point.evidence,
+          })),
           {
             ...series.points[0],
             key: "2026-01-03",
@@ -411,8 +417,8 @@ describe("Scout Discord visualization bounds", () => {
     expect(description).toContain("Aurora");
     expect(description).not.toContain("wrong preview order");
     expect(description).toContain("2026-01-03");
-    const lines = description?.split("\n") ?? [];
-    expect(lines[1]?.length).toBe(lines[2]?.length);
+    expect(description).toContain("Baseline:");
+    expect(description).toContain("Δ");
   });
 
   test("keeps every native description within Discord's limit", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -502,6 +502,8 @@ test("preserves confidence intervals in native temporal rows", () => {
       id: `All:${series.id}`,
       points: series.points.map((point) => ({
         ...point,
+        key: `${point.key} • ${point.key === "Aurora" ? "solo" : "flex"}`,
+        label: `${point.label} • ${point.label === "Aurora" ? "solo" : "flex"}`,
         evidence:
           series.id === "win_rate" && point.key === "Aurora"
             ? {
@@ -647,6 +649,68 @@ test("chooses the most specific matching series for preview evidence", () => {
   expect(formatPreviewValueWithEvidence(cappedSnapshot, column, row)).toBe(
     "100.0%",
   );
+});
+
+test("matches All-series evidence by exact row identity", () => {
+  const winRateSeries = scoutTestVisualization.series.find(
+    (series) => series.metric === "win_rate",
+  );
+  if (winRateSeries === undefined) {
+    throw new Error("Win rate test series is missing.");
+  }
+  const sourcePoint = winRateSeries.points[0];
+  if (sourcePoint === undefined) {
+    throw new Error("Win rate test point is missing.");
+  }
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    series: [
+      {
+        ...winRateSeries,
+        id: "All:win_rate",
+        points: [
+          {
+            ...sourcePoint,
+            key: "Foo",
+            label: "Foo",
+            evidence: {
+              ...sourcePoint.evidence,
+              confidenceInterval: {
+                level: 0.95,
+                lower: 0.1,
+                upper: 0.2,
+              },
+            },
+          },
+          {
+            ...sourcePoint,
+            key: "Foo • Bar",
+            label: "Foo • Bar",
+            evidence: {
+              ...sourcePoint.evidence,
+              confidenceInterval: {
+                level: 0.95,
+                lower: 0.9,
+                upper: 1,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+  const column = preview.columns.find((item) => item.key === "win_rate");
+  if (column === undefined) {
+    throw new Error("Win rate preview column is missing.");
+  }
+
+  expect(
+    formatPreviewValueWithEvidence(snapshot, column, {
+      key: "Foo • Bar",
+      label: "Foo • Bar",
+      values: new Map([["win_rate", 1]]),
+    }),
+  ).toContain("95% CI 90.0%–100.0%");
 });
 
 test("keeps native values visible when labels exceed the description budget", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -631,14 +631,22 @@ test("chooses the most specific matching series for preview evidence", () => {
   if (column === undefined) {
     throw new Error("Win rate preview column is missing.");
   }
+  const row = {
+    key: "Foo • Bar • Queue",
+    label: "Foo • Bar • Queue",
+    values: new Map([["win_rate", 1]]),
+  };
 
-  expect(
-    formatPreviewValueWithEvidence(snapshot, column, {
-      key: "Foo • Bar • Queue",
-      label: "Foo • Bar • Queue",
-      values: new Map([["win_rate", 1]]),
-    }),
-  ).toContain("95% CI 90.0%–100.0%");
+  expect(formatPreviewValueWithEvidence(snapshot, column, row)).toContain(
+    "95% CI 90.0%–100.0%",
+  );
+  const cappedSnapshot = VisualizationSnapshotSchema.parse({
+    ...snapshot,
+    series: snapshot.series.slice(0, 1),
+  });
+  expect(formatPreviewValueWithEvidence(cappedSnapshot, column, row)).toBe(
+    "100.0%",
+  );
 });
 
 test("keeps native values visible when labels exceed the description budget", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -419,6 +419,8 @@ describe("Scout Discord visualization bounds", () => {
     expect(description).toContain("2026-01-03");
     expect(description).toContain("Baseline:");
     expect(description).toContain("Δ");
+    const lines = description?.split("\n") ?? [];
+    expect(lines[1]?.length).toBe(lines[2]?.length);
   });
 
   test("keeps every native description within Discord's limit", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -108,6 +108,17 @@ describe("Scout Discord visualizations", () => {
     expect(visualizationToEmbed(subtitleKpi)?.data.description).toContain(
       "By player",
     );
+    const longSubtitleKpi = VisualizationSnapshotSchema.parse({
+      ...subtitleKpi,
+      display: {
+        ...subtitleKpi.display,
+        options: { subtitle: "By player ".repeat(500) },
+      },
+    });
+    const longSubtitleDescription =
+      visualizationToEmbed(longSubtitleKpi)?.data.description;
+    expect(longSubtitleDescription).toContain("Games counted");
+    expect(longSubtitleDescription).toContain("56");
 
     const comparisonKpi = VisualizationSnapshotSchema.parse({
       ...scoutTestKpi,
@@ -212,11 +223,16 @@ describe("Scout Discord visualization edge cases", () => {
         ...series,
         id: `Champion ${index.toString()}:${series.metric}`,
         label: `Champion ${index.toString()} — ${series.label}`,
+        points: series.points.map((point) => ({
+          ...point,
+          key: "solo",
+          label: "solo",
+        })),
       })),
     });
     const collapsedDescription = visualizationToEmbed(
       collapsedSnapshot,
-      legacyPreview,
+      preview,
     )?.data.description;
     expect(collapsedDescription).toContain(
       "additional rows omitted from the stored preview",

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -450,7 +450,7 @@ describe("Scout Discord visualization bounds", () => {
       expect(embed?.data.title?.length).toBeLessThanOrEqual(256);
       if (kind === "TABLE") {
         expect(description).toContain("```\n");
-        expect(description).toContain("\n```\n\n_Visualization truncated");
+        expect(description).not.toContain("Visualization truncated");
       }
     }
   });
@@ -521,6 +521,27 @@ test("preserves confidence intervals in native temporal rows", () => {
       preview,
     )?.data.description,
   ).toContain("95% CI 75.0%–100.0%");
+});
+
+test("keeps native values visible when labels exceed the description budget", () => {
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    series: scoutTestVisualization.series.map((series) => ({
+      ...series,
+      label: "Series label ".repeat(500),
+      points: series.points.map((point) => ({
+        ...point,
+        label: "Point label ".repeat(500),
+      })),
+    })),
+  });
+
+  for (const kind of ["TABLE", "LIST", "LEADERBOARD"] as const) {
+    const description = visualizationToEmbed(
+      VisualizationSnapshotSchema.parse({ ...snapshot, kind }),
+    )?.data.description;
+    expect(description).toContain("100.0%");
+  }
 });
 
 test("renders percent-stack snapshot values instead of raw preview values", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -524,6 +524,43 @@ test("preserves confidence intervals in native temporal rows", () => {
   ).toContain("95% CI 75.0%–100.0%");
 });
 
+test("preserves evidence when a series dimension contains the display separator", () => {
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    series: scoutTestVisualization.series.map((series) => ({
+      ...series,
+      id: `Queue • Ranked:${series.id}`,
+      points: series.points.map((point) => ({
+        ...point,
+        key: `${point.key} • solo`,
+        label: `${point.label} • solo`,
+        evidence:
+          series.id === "win_rate" && point.key === "Aurora"
+            ? {
+                ...point.evidence,
+                confidenceInterval: {
+                  level: 0.95,
+                  lower: 0.75,
+                  upper: 1,
+                },
+              }
+            : point.evidence,
+      })),
+    })),
+  });
+  const aliasedPreview = ReportAiPreviewSummarySchema.parse({
+    ...preview,
+    rows: preview.rows.map((row) => ({
+      ...row,
+      label: `Queue • Ranked • ${row.label}`,
+    })),
+  });
+
+  expect(
+    visualizationToEmbed(snapshot, aliasedPreview)?.data.description,
+  ).toContain("95% CI 75.0%–100.0%");
+});
+
 test("keeps native values visible when labels exceed the description budget", () => {
   const snapshot = VisualizationSnapshotSchema.parse({
     ...scoutTestVisualization,

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -192,12 +192,12 @@ describe("Scout Discord visualization edge cases", () => {
       kind: "TABLE",
       series: scoutTestVisualization.series.map((series) => ({
         ...series,
-        label: "Games `\r\n| unsafe",
+        label: "Games ` and ```\r\n| unsafe",
       })),
     });
 
     const description = visualizationToEmbed(headerSnapshot)?.data.description;
-    expect(description).toContain("Games ′");
+    expect(description).toContain("Games ` and ′′′");
     expect(description).toContain("| unsafe");
     expect(description).not.toContain("Games `\n");
   });
@@ -479,6 +479,41 @@ test("renders transformed snapshot values instead of raw preview values", () => 
   const description = visualizationToEmbed(snapshot, preview)?.data.description;
   expect(description).toContain("9");
   expect(description).not.toContain("7");
+});
+
+test("preserves confidence intervals in native temporal rows", () => {
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    temporal: {
+      window: {
+        kind: "relative",
+        days: 30,
+      },
+      bucket: "day",
+      timezone: "UTC",
+    },
+    series: scoutTestVisualization.series.map((series) => ({
+      ...series,
+      points: series.points.map((point) => ({
+        ...point,
+        evidence:
+          series.id === "win_rate" && point.key === "Aurora"
+            ? {
+                ...point.evidence,
+                confidenceInterval: {
+                  level: 0.95,
+                  lower: 0.75,
+                  upper: 1,
+                },
+              }
+            : point.evidence,
+      })),
+    })),
+  });
+
+  expect(visualizationToEmbed(snapshot)?.data.description).toContain(
+    "95% CI 75.0%–100.0%",
+  );
 });
 
 test("renders percent-stack snapshot values instead of raw preview values", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -494,6 +494,7 @@ test("preserves confidence intervals in native temporal rows", () => {
     },
     series: scoutTestVisualization.series.map((series) => ({
       ...series,
+      id: `All:${series.id}`,
       points: series.points.map((point) => ({
         ...point,
         evidence:

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -205,6 +205,22 @@ describe("Scout Discord visualization edge cases", () => {
     expect(description).toContain(
       "additional rows omitted from the stored preview",
     );
+
+    const collapsedSnapshot = VisualizationSnapshotSchema.parse({
+      ...scoutTestVisualization,
+      series: scoutTestVisualization.series.map((series, index) => ({
+        ...series,
+        id: `Champion ${index.toString()}:${series.metric}`,
+        label: `Champion ${index.toString()} — ${series.label}`,
+      })),
+    });
+    const collapsedDescription = visualizationToEmbed(
+      collapsedSnapshot,
+      legacyPreview,
+    )?.data.description;
+    expect(collapsedDescription).toContain(
+      "additional rows omitted from the stored preview",
+    );
   });
 
   test("escapes Markdown in native labels and preview values", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.test.ts
@@ -771,6 +771,42 @@ test("truncates oversized first rows at grapheme boundaries", () => {
   expect(description).toContain("Visualization truncated");
 });
 
+test("reserves a table row when long headers fill the embed", () => {
+  const columns = [
+    { key: "label", label: "Label", format: "text" as const },
+    ...Array.from({ length: 19 }, (_, index) => ({
+      key: `metric-${index.toString()}`,
+      label: "m".repeat(155),
+      format: "text" as const,
+    })),
+  ];
+  const snapshot = VisualizationSnapshotSchema.parse({
+    ...scoutTestVisualization,
+    kind: "TABLE",
+  });
+  const oversizedPreview = ReportAiPreviewSummarySchema.parse({
+    columns,
+    rows: [
+      {
+        label: "r".repeat(159),
+        values: Array.from({ length: 19 }, (_, index) => ({
+          column: `metric-${index.toString()}`,
+          value: "😀".repeat(80),
+        })),
+      },
+    ],
+    rowsReturned: 1,
+    rowsScanned: 1,
+    renderKind: "TABLE",
+  });
+
+  const description = visualizationToEmbed(snapshot, oversizedPreview)?.data
+    .description;
+  expect(description).toBeDefined();
+  expect(description).toContain("😀");
+  expect(description).toContain("Visualization truncated");
+});
+
 test("renders percent-stack snapshot values instead of raw preview values", () => {
   const snapshot = structuredClone(scoutTestVisualization);
   snapshot.display.stack = "percent";

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -184,7 +184,11 @@ function formatList(
   const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(source.preview, allRows);
+  const previewExtra = hasPreviewRowsBeyondStoredRows(
+    snapshot,
+    source.preview,
+    allRows,
+  );
   const lines = rows.map((row) => {
     const values = formatRowValues(snapshot, row, source.preview).join(", ");
     return `- ${escapeMarkdown(row.label)}: ${values}`;
@@ -205,7 +209,11 @@ function formatLeaderboard(
   const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(source.preview, allRows);
+  const previewExtra = hasPreviewRowsBeyondStoredRows(
+    snapshot,
+    source.preview,
+    allRows,
+  );
   const lines = rows.map((row, index) => {
     const values = formatRowValues(snapshot, row, source.preview).join(" · ");
     return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
@@ -226,7 +234,11 @@ function formatTable(
   const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(source.preview, allRows);
+  const previewExtra = hasPreviewRowsBeyondStoredRows(
+    snapshot,
+    source.preview,
+    allRows,
+  );
   const headers =
     source.preview === null
       ? ["", ...snapshot.series.map((series) => series.label)]
@@ -341,10 +353,22 @@ function nativeRowSource(
 }
 
 function hasPreviewRowsBeyondStoredRows(
+  snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
   rows: NativeRow[],
 ): boolean {
-  return preview !== null && preview.rowsReturned > rows.length;
+  if (preview === null) {
+    return false;
+  }
+  if (preview.rowsReturned > rows.length) {
+    return true;
+  }
+  return (
+    preview.rowsReturned === 0 &&
+    preview.visualizationRows.length === 0 &&
+    snapshot.temporal === null &&
+    alignedRows(snapshot).length > rows.length
+  );
 }
 
 function previewMetricColumns(preview: ReportAiPreviewSummary) {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -190,7 +190,7 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
   const subtitle = snapshot.display.options?.subtitle;
   return subtitle === undefined
     ? description
-    : `${escapeMarkdown(subtitle)}\n\n${description}`;
+    : `${description}\n\n${escapeMarkdown(subtitle)}`;
 }
 
 function formatList(
@@ -390,9 +390,7 @@ function hasPreviewRowsBeyondStoredRows(
     snapshot.series.some((series) => {
       const separator = series.id.lastIndexOf(":");
       return separator !== -1 && series.id.slice(0, separator) !== "All";
-    }) &&
-    snapshot.series.reduce((total, series) => total + series.points.length, 0) >
-      rows.length;
+    }) && snapshotRows.length < rows.length;
   return (
     preview.rowsReturned === 0 &&
     preview.visualizationRows.length === 0 &&

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -21,6 +21,7 @@ import {
 
 const NATIVE_KINDS = new Set(["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"]);
 const MAX_NATIVE_ROWS = 12;
+const MAX_NATIVE_CELL_LENGTH = 160;
 const MAX_EMBED_DESCRIPTION = 3900;
 const MAX_EMBED_TITLE = 256;
 const DESCRIPTION_TRUNCATION_SUFFIX =
@@ -164,7 +165,7 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
     .map((series) => {
       const point = series.points.at(-1);
       if (point === undefined) {
-        return `**${escapeMarkdown(series.label)}**\nUnknown n=0`;
+        return `**${escapeMarkdown(truncateNativeCell(series.label))}**\nUnknown n=0`;
       }
       const value = formatSeriesValue(snapshot, series, point.value);
       const sampleSize = point.evidence.sampleSize;
@@ -187,13 +188,13 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
               : `${(point.percentageDelta * 100).toFixed(1)}%`
           }`
         : `n=${sampleSize.toString()}`;
-      return `**${escapeMarkdown(series.label)}**\n${value} ${details}`;
+      return `**${escapeMarkdown(truncateNativeCell(series.label))}**\n${value} ${details}`;
     })
     .join("\n\n");
   const subtitle = snapshot.display.options?.subtitle;
   return subtitle === undefined
     ? description
-    : `${description}\n\n${escapeMarkdown(subtitle)}`;
+    : `${description}\n\n${escapeMarkdown(truncateNativeCell(subtitle))}`;
 }
 
 function formatList(
@@ -212,7 +213,7 @@ function formatList(
   );
   const lines = rows.map((row) => {
     const values = formatRowValues(snapshot, row, source.preview).join(", ");
-    return `- ${escapeMarkdown(row.label)}: ${values}`;
+    return `- ${escapeMarkdown(truncateNativeCell(row.label))}: ${values}`;
   });
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more_`);
@@ -238,7 +239,9 @@ function formatLeaderboard(
   );
   const lines = rows.map((row, index) => {
     const values = formatRowValues(snapshot, row, source.preview).join(" · ");
-    return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
+    return `**${(index + 1).toString()}.** ${escapeMarkdown(
+      truncateNativeCell(row.label),
+    )} — ${values}`;
   });
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more_`);
@@ -266,16 +269,22 @@ function formatTable(
     source.preview === null
       ? ["", ...snapshot.series.map((series) => series.label)]
       : source.preview.columns.map((column) => column.label);
-  const escapedHeaders = headers.map((header) => escapeTableCell(header));
+  const escapedHeaders = headers.map((header) =>
+    escapeTableCell(truncateNativeCell(header)),
+  );
   const bodyRows = rows.map((row) => [
-    escapeTableCell(row.label),
+    escapeTableCell(truncateNativeCell(row.label)),
     ...(source.preview === null
       ? snapshot.series.map((series) =>
-          escapeTableCell(formatNativeSeriesValue(snapshot, series, row)),
+          escapeTableCell(
+            truncateNativeCell(formatNativeSeriesValue(snapshot, series, row)),
+          ),
         )
       : previewMetricColumns(source.preview).map((column) =>
           escapeTableCell(
-            formatPreviewValueWithEvidence(snapshot, column, row),
+            truncateNativeCell(
+              formatPreviewValueWithEvidence(snapshot, column, row),
+            ),
           ),
         )),
   ]);
@@ -454,14 +463,22 @@ function formatRowValues(
 ): string[] {
   if (preview !== null) {
     return previewMetricColumns(preview).map((column) => {
-      const value = formatPreviewValueWithEvidence(snapshot, column, row);
-      return `${escapeMarkdown(column.label)}: ${escapeMarkdown(value)}`;
+      const value = truncateNativeCell(
+        formatPreviewValueWithEvidence(snapshot, column, row),
+      );
+      return `${escapeMarkdown(truncateNativeCell(column.label))}: ${escapeMarkdown(value)}`;
     });
   }
   return snapshot.series.map(
     (series) =>
-      `${escapeMarkdown(series.label)}: ${formatNativeSeriesValue(snapshot, series, row)}`,
+      `${escapeMarkdown(truncateNativeCell(series.label))}: ${truncateNativeCell(formatNativeSeriesValue(snapshot, series, row))}`,
   );
+}
+
+function truncateNativeCell(value: string): string {
+  return value.length <= MAX_NATIVE_CELL_LENGTH
+    ? value
+    : `${value.slice(0, MAX_NATIVE_CELL_LENGTH - 1)}…`;
 }
 
 function escapeMarkdown(value: string): string {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -179,7 +179,8 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
             series,
             point.absoluteDelta ?? null,
           )} · ${
-            point.percentageDelta === null
+            point.percentageDelta === null ||
+            point.percentageDelta === undefined
               ? "Unknown"
               : `${(point.percentageDelta * 100).toFixed(1)}%`
           }`

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -74,14 +74,12 @@ export function visualizationToEmbed(
   }
   return embed;
 }
-
 function truncateTitle(title: string): string {
   if (title.length <= MAX_EMBED_TITLE) {
     return title;
   }
   return `${title.slice(0, MAX_EMBED_TITLE - 1)}…`;
 }
-
 function nativeDescription(
   snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
@@ -112,7 +110,6 @@ function nativeDescription(
     ? truncateTableDescription(description)
     : truncateDescription(description);
 }
-
 function truncateDescription(description: string): string {
   if (description.length <= MAX_EMBED_DESCRIPTION) {
     return description;
@@ -369,7 +366,11 @@ function nativeRowSource(
   snapshotRows: NativeRow[];
 } {
   const snapshotRows = alignedRows(snapshot);
-  if (preview === null || snapshot.temporal !== null) {
+  const hasTransformedValues =
+    snapshot.display.rollingWindow !== null ||
+    snapshot.display.cumulative ||
+    snapshot.display.stack === "percent";
+  if (hasTransformedValues || preview === null || snapshot.temporal !== null) {
     return { rows: snapshotRows, preview: null, snapshotRows };
   }
   return { rows: previewRows(preview), preview, snapshotRows };
@@ -405,7 +406,6 @@ function previewOverflowNotice(
 function previewMetricColumns(preview: ReportAiPreviewSummary) {
   return preview.columns.filter((column) => column.key !== "label");
 }
-
 function formatRowValues(
   snapshot: VisualizationSnapshot,
   row: NativeRow,
@@ -437,7 +437,6 @@ function requireRowValue(row: NativeRow, column: string): NativeRowValue {
   }
   return value;
 }
-
 function requireNumericRowValue(row: NativeRow, column: string): number | null {
   const value = row.values.get(column) ?? null;
   if (typeof value !== "number" && value !== null) {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -13,9 +13,8 @@ import { visualizationSnapshotToImage } from "@scout-for-lol/report";
 import {
   formatAbsoluteDelta,
   formatNativeSeriesValue,
-  formatPreviewValue,
+  formatPreviewValueWithEvidence,
   formatSeriesValue,
-  requireRowValue,
   type NativeRow,
   type NativeRowValue,
 } from "#src/discord/scout/visualization-format.ts";
@@ -276,7 +275,7 @@ function formatTable(
         )
       : previewMetricColumns(source.preview).map((column) =>
           escapeTableCell(
-            formatPreviewValue(column, requireRowValue(row, column.key)),
+            formatPreviewValueWithEvidence(snapshot, column, row),
           ),
         )),
   ]);
@@ -455,10 +454,7 @@ function formatRowValues(
 ): string[] {
   if (preview !== null) {
     return previewMetricColumns(preview).map((column) => {
-      const value = formatPreviewValue(
-        column,
-        requireRowValue(row, column.key),
-      );
+      const value = formatPreviewValueWithEvidence(snapshot, column, row);
       return `${escapeMarkdown(column.label)}: ${escapeMarkdown(value)}`;
     });
   }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -154,7 +154,7 @@ function truncateLines(description: string, available: number): string {
   }
   const prefix = lines.join("\n");
   if (prefix.length === 0) {
-    return description.slice(0, available);
+    return truncateNativeCell(description, available);
   }
   return prefix;
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -1,4 +1,9 @@
-import { AttachmentBuilder, Colors, EmbedBuilder } from "discord.js";
+import {
+  AttachmentBuilder,
+  Colors,
+  EmbedBuilder,
+  escapeMarkdown as escapeDiscordMarkdown,
+} from "discord.js";
 import {
   formatReportDisplayValue,
   REPORT_METRICS,
@@ -88,7 +93,11 @@ function nativeDescription(
     snapshot.temporal === null &&
     preview !== null &&
     previewRows(preview).length > 0;
-  if (!hasSnapshotPoints && !hasPreviewRows && snapshot.kind !== "KPI_CARD") {
+  if (
+    !hasSnapshotPoints &&
+    !hasPreviewRows &&
+    (snapshot.kind !== "KPI_CARD" || snapshot.series.length === 0)
+  ) {
     return "No results found.";
   }
   const description =
@@ -149,7 +158,7 @@ function truncateLines(description: string, available: number): string {
 }
 
 function formatKpi(snapshot: VisualizationSnapshot): string {
-  return snapshot.series
+  const description = snapshot.series
     .map((series) => {
       const point = series.points.at(-1);
       if (point === undefined) {
@@ -174,6 +183,10 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
       return `**${escapeMarkdown(series.label)}**\n${value} ${details}`;
     })
     .join("\n\n");
+  const subtitle = snapshot.display.options?.subtitle;
+  return subtitle === undefined
+    ? description
+    : `${escapeMarkdown(subtitle)}\n\n${description}`;
 }
 
 function formatList(
@@ -385,13 +398,13 @@ function formatRowValues(
   preview: ReportAiPreviewSummary | null,
 ): string[] {
   if (preview !== null) {
-    return previewMetricColumns(preview).map(
-      (column) =>
-        `${escapeMarkdown(column.label)}: ${formatPreviewValue(
-          column,
-          requireRowValue(row, column.key),
-        )}`,
-    );
+    return previewMetricColumns(preview).map((column) => {
+      const value = formatPreviewValue(
+        column,
+        requireRowValue(row, column.key),
+      );
+      return `${escapeMarkdown(column.label)}: ${escapeMarkdown(value)}`;
+    });
   }
   return snapshot.series.map(
     (series) =>
@@ -404,11 +417,15 @@ function formatRowValues(
 }
 
 function requireRowValue(row: NativeRow, column: string): NativeRowValue {
-  return row.values.get(column) ?? null;
+  const value = row.values.get(column);
+  if (value === undefined) {
+    throw new Error(`Visualization row missing value for ${column}.`);
+  }
+  return value;
 }
 
 function requireNumericRowValue(row: NativeRow, column: string): number | null {
-  const value = requireRowValue(row, column);
+  const value = row.values.get(column) ?? null;
   if (typeof value !== "number" && value !== null) {
     throw new Error(`Visualization row value for ${column} is not numeric.`);
   }
@@ -465,14 +482,12 @@ function formatPercent(value: number | null): string {
 }
 
 function escapeMarkdown(value: string): string {
-  return value
-    .replaceAll(/[\r\n]+/g, " ")
-    .replaceAll(/[\\_*`|]/g, (char) => `\\${char}`);
+  return escapeDiscordMarkdown(value.replaceAll(/[\r\n]+/g, " ")).replaceAll(
+    /[()[\]<>]/g,
+    (char) => `\\${char}`,
+  );
 }
 
 function escapeTableCell(value: string): string {
-  return value
-    .replaceAll("`", "′")
-    .replaceAll("|", String.raw`\|`)
-    .replaceAll("\n", " ");
+  return value.replaceAll("`", "′").replaceAll("\n", " ");
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -1,6 +1,7 @@
 import { AttachmentBuilder, Colors, EmbedBuilder } from "discord.js";
 import {
   formatReportDisplayValue,
+  REPORT_AI_PREVIEW_MAX_ROWS,
   REPORT_METRICS,
   type ExploreMessage,
   type ReportAiPreviewSummary,
@@ -82,7 +83,10 @@ function nativeDescription(
   preview: ReportAiPreviewSummary | null,
 ): string | null {
   if (snapshot.series.length === 0) {
-    return null;
+    const hasPreviewRows = preview !== null && preview.rows.length > 0;
+    if (!hasPreviewRows || snapshot.kind === "KPI_CARD") {
+      return "No results found.";
+    }
   }
   const description =
     snapshot.kind === "KPI_CARD"
@@ -151,10 +155,8 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
       const value = formatSeriesValue(snapshot, series, point.value);
       const sampleSize = point.evidence.sampleSize;
       const comparison =
-        point.comparisonEvidence !== undefined ||
-        point.comparisonValue !== undefined ||
-        point.absoluteDelta !== undefined ||
-        point.percentageDelta !== undefined;
+        snapshot.temporal?.comparison !== undefined ||
+        point.comparisonEvidence !== undefined;
       const details = comparison
         ? `n=${sampleSize.toString()} · Baseline: ${formatSeriesValue(
             snapshot,
@@ -179,12 +181,16 @@ function formatList(
     preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
+  const previewExtra =
+    preview !== null && preview.rows.length >= REPORT_AI_PREVIEW_MAX_ROWS;
   const lines = rows.map((row) => {
     const values = formatRowValues(snapshot, row, preview).join(", ");
     return `- ${escapeMarkdown(row.label)}: ${values}`;
   });
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more_`);
+  } else if (previewExtra) {
+    lines.push("_…additional rows omitted from the stored preview_");
   }
   return lines.join("\n");
 }
@@ -197,12 +203,16 @@ function formatLeaderboard(
     preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
+  const previewExtra =
+    preview !== null && preview.rows.length >= REPORT_AI_PREVIEW_MAX_ROWS;
   const lines = rows.map((row, index) => {
     const values = formatRowValues(snapshot, row, preview).join(" · ");
     return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
   });
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more_`);
+  } else if (previewExtra) {
+    lines.push("_…additional rows omitted from the stored preview_");
   }
   return lines.join("\n");
 }
@@ -215,6 +225,8 @@ function formatTable(
     preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
+  const previewExtra =
+    preview !== null && preview.rows.length >= REPORT_AI_PREVIEW_MAX_ROWS;
   const headers =
     preview === null
       ? ["", ...snapshot.series.map((series) => series.label)]
@@ -245,6 +257,8 @@ function formatTable(
   ];
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more rows_`);
+  } else if (previewExtra) {
+    lines.push("_…additional rows omitted from the stored preview_");
   }
   return lines.join("\n");
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -1,7 +1,6 @@
 import { AttachmentBuilder, Colors, EmbedBuilder } from "discord.js";
 import {
   formatReportDisplayValue,
-  REPORT_AI_PREVIEW_MAX_ROWS,
   REPORT_METRICS,
   type ExploreMessage,
   type ReportAiPreviewSummary,
@@ -83,7 +82,7 @@ function nativeDescription(
   preview: ReportAiPreviewSummary | null,
 ): string | null {
   if (snapshot.series.length === 0) {
-    const hasPreviewRows = preview !== null && preview.rows.length > 0;
+    const hasPreviewRows = preview !== null && previewRows(preview).length > 0;
     if (!hasPreviewRows || snapshot.kind === "KPI_CARD") {
       return "No results found.";
     }
@@ -181,8 +180,7 @@ function formatList(
     preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra =
-    preview !== null && preview.rows.length >= REPORT_AI_PREVIEW_MAX_ROWS;
+  const previewExtra = hasPreviewRowsBeyondStoredRows(preview, allRows);
   const lines = rows.map((row) => {
     const values = formatRowValues(snapshot, row, preview).join(", ");
     return `- ${escapeMarkdown(row.label)}: ${values}`;
@@ -203,8 +201,7 @@ function formatLeaderboard(
     preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra =
-    preview !== null && preview.rows.length >= REPORT_AI_PREVIEW_MAX_ROWS;
+  const previewExtra = hasPreviewRowsBeyondStoredRows(preview, allRows);
   const lines = rows.map((row, index) => {
     const values = formatRowValues(snapshot, row, preview).join(" · ");
     return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
@@ -225,8 +222,7 @@ function formatTable(
     preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra =
-    preview !== null && preview.rows.length >= REPORT_AI_PREVIEW_MAX_ROWS;
+  const previewExtra = hasPreviewRowsBeyondStoredRows(preview, allRows);
   const headers =
     preview === null
       ? ["", ...snapshot.series.map((series) => series.label)]
@@ -301,10 +297,21 @@ function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {
 }
 
 function previewRows(preview: ReportAiPreviewSummary): NativeRow[] {
-  return preview.rows.map((row) => ({
+  const rows =
+    preview.visualizationRows.length > 0
+      ? preview.visualizationRows
+      : preview.rows;
+  return rows.map((row) => ({
     label: row.label,
     values: new Map(row.values.map((value) => [value.column, value.value])),
   }));
+}
+
+function hasPreviewRowsBeyondStoredRows(
+  preview: ReportAiPreviewSummary | null,
+  rows: NativeRow[],
+): boolean {
+  return preview !== null && preview.rowsReturned > rows.length;
 }
 
 function previewMetricColumns(preview: ReportAiPreviewSummary) {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -81,10 +81,7 @@ export function visualizationToEmbed(
   return embed;
 }
 function truncateTitle(title: string): string {
-  if (title.length <= MAX_EMBED_TITLE) {
-    return title;
-  }
-  return `${title.slice(0, MAX_EMBED_TITLE - 1)}…`;
+  return truncateNativeCell(title, MAX_EMBED_TITLE);
 }
 function nativeDescription(
   snapshot: VisualizationSnapshot,

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -10,6 +10,7 @@ import { visualizationSnapshotToImage } from "@scout-for-lol/report";
 const NATIVE_KINDS = new Set(["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"]);
 const MAX_NATIVE_ROWS = 12;
 const MAX_EMBED_DESCRIPTION = 3900;
+const MAX_EMBED_TITLE = 256;
 const DESCRIPTION_TRUNCATION_SUFFIX =
   "\n\n_Visualization truncated to fit Discord._";
 
@@ -61,9 +62,16 @@ export function visualizationToEmbed(
     .setColor(Colors.DarkGold)
     .setDescription(description);
   if (snapshot.title !== null) {
-    embed.setTitle(snapshot.title);
+    embed.setTitle(truncateTitle(snapshot.title));
   }
   return embed;
+}
+
+function truncateTitle(title: string): string {
+  if (title.length <= MAX_EMBED_TITLE) {
+    return title;
+  }
+  return `${title.slice(0, MAX_EMBED_TITLE - 1)}…`;
 }
 
 function nativeDescription(snapshot: VisualizationSnapshot): string | null {
@@ -120,8 +128,13 @@ function formatList(snapshot: VisualizationSnapshot): string {
   const extra = allRows.length - rows.length;
   const lines = rows.map((row) => {
     const values = snapshot.series
-      .map((series) =>
-        formatSeriesValue(snapshot, series, row.values.get(series.id) ?? null),
+      .map(
+        (series) =>
+          `${escapeMarkdown(series.label)}: ${formatSeriesValue(
+            snapshot,
+            series,
+            row.values.get(series.id) ?? null,
+          )}`,
       )
       .join(", ");
     return `- ${escapeMarkdown(row.label)}: ${values}`;
@@ -138,8 +151,13 @@ function formatLeaderboard(snapshot: VisualizationSnapshot): string {
   const extra = allRows.length - rows.length;
   const lines = rows.map((row, index) => {
     const values = snapshot.series
-      .map((series) =>
-        formatSeriesValue(snapshot, series, row.values.get(series.id) ?? null),
+      .map(
+        (series) =>
+          `${escapeMarkdown(series.label)}: ${formatSeriesValue(
+            snapshot,
+            series,
+            row.values.get(series.id) ?? null,
+          )}`,
       )
       .join(" · ");
     return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
@@ -156,28 +174,28 @@ function formatTable(snapshot: VisualizationSnapshot): string {
   const extra = allRows.length - rows.length;
   const headers = ["", ...snapshot.series.map((series) => series.label)];
   const lines = [
-    `| ${headers.map((header) => escapeTableCell(header)).join(" | ")} |`,
-    `| ${headers.map((_, index) => (index === 0 ? "---" : "---:")).join(" | ")} |`,
-    ...rows.map(
-      (row) =>
-        `| ${[
-          escapeTableCell(row.label),
-          ...snapshot.series.map((series) =>
-            escapeTableCell(
-              formatSeriesValue(
-                snapshot,
-                series,
-                row.values.get(series.id) ?? null,
-              ),
+    headers.map((header) => escapeTableCell(header)).join("    "),
+    headers.map(() => "----").join("    "),
+    ...rows.map((row) =>
+      [
+        escapeTableCell(row.label),
+        ...snapshot.series.map((series) =>
+          escapeTableCell(
+            formatSeriesValue(
+              snapshot,
+              series,
+              row.values.get(series.id) ?? null,
             ),
           ),
-        ].join(" | ")} |`,
+        ),
+      ].join("    "),
     ),
   ];
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more rows_`);
   }
-  return lines.join("\n");
+  const codeFence = "```";
+  return `${codeFence}\n${lines.join("\n")}\n${codeFence}`;
 }
 
 function alignedRows(snapshot: VisualizationSnapshot): {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -81,11 +81,15 @@ function nativeDescription(
   snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
 ): string | null {
-  if (snapshot.series.length === 0) {
-    const hasPreviewRows = preview !== null && previewRows(preview).length > 0;
-    if (!hasPreviewRows || snapshot.kind === "KPI_CARD") {
-      return "No results found.";
-    }
+  const hasSnapshotPoints = snapshot.series.some(
+    (series) => series.points.length > 0,
+  );
+  const hasPreviewRows =
+    snapshot.temporal === null &&
+    preview !== null &&
+    previewRows(preview).length > 0;
+  if (!hasSnapshotPoints && !hasPreviewRows && snapshot.kind !== "KPI_CARD") {
+    return "No results found.";
   }
   const description =
     snapshot.kind === "KPI_CARD"
@@ -227,6 +231,7 @@ function formatTable(
     source.preview === null
       ? ["", ...snapshot.series.map((series) => series.label)]
       : source.preview.columns.map((column) => column.label);
+  const escapedHeaders = headers.map((header) => escapeTableCell(header));
   const bodyRows = rows.map((row) => [
     escapeTableCell(row.label),
     ...(source.preview === null
@@ -247,12 +252,12 @@ function formatTable(
   ]);
   const widths = headers.map((_, index) =>
     Math.max(
-      headers[index]?.length ?? 0,
+      escapedHeaders[index]?.length ?? 0,
       ...bodyRows.map((row) => row[index]?.length ?? 0),
     ),
   );
   const lines = [
-    formatTableRow(headers, widths),
+    formatTableRow(escapedHeaders, widths),
     formatTableRow(
       widths.map((width) => "-".repeat(width)),
       widths,

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -5,14 +5,20 @@ import {
   escapeMarkdown as escapeDiscordMarkdown,
 } from "discord.js";
 import {
-  formatReportDisplayValue,
-  REPORT_METRICS,
   type ExploreMessage,
   type ReportAiPreviewSummary,
-  type TemporalSeries,
   type VisualizationSnapshot,
 } from "@scout-for-lol/data";
 import { visualizationSnapshotToImage } from "@scout-for-lol/report";
+import {
+  formatAbsoluteDelta,
+  formatNativeSeriesValue,
+  formatPreviewValue,
+  formatSeriesValue,
+  requireRowValue,
+  type NativeRow,
+  type NativeRowValue,
+} from "#src/discord/scout/visualization-format.ts";
 
 const NATIVE_KINDS = new Set(["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"]);
 const MAX_NATIVE_ROWS = 12;
@@ -266,13 +272,7 @@ function formatTable(
     escapeTableCell(row.label),
     ...(source.preview === null
       ? snapshot.series.map((series) =>
-          escapeTableCell(
-            formatSeriesValue(
-              snapshot,
-              series,
-              requireNumericRowValue(row, series.id),
-            ),
-          ),
+          escapeTableCell(formatNativeSeriesValue(snapshot, series, row)),
         )
       : previewMetricColumns(source.preview).map((column) =>
           escapeTableCell(
@@ -309,12 +309,6 @@ function formatTableRow(cells: string[], widths: number[]): string {
     .trimEnd();
 }
 
-type NativeRowValue = string | number | null;
-type NativeRow = {
-  label: string;
-  values: Map<string, NativeRowValue>;
-};
-
 function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {
   const order: string[] = [];
   const labels = new Map<string, string>();
@@ -342,7 +336,7 @@ function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {
     if (rowValues === undefined) {
       throw new Error(`Visualization values missing key ${key}.`);
     }
-    return { label, values: rowValues };
+    return { key, label, values: rowValues };
   });
 }
 
@@ -352,6 +346,7 @@ function previewRows(preview: ReportAiPreviewSummary): NativeRow[] {
       ? preview.visualizationRows
       : preview.rows;
   return rows.map((row) => ({
+    key: row.label,
     label: row.label,
     values: new Map(row.values.map((value) => [value.column, value.value])),
   }));
@@ -422,70 +417,8 @@ function formatRowValues(
   }
   return snapshot.series.map(
     (series) =>
-      `${escapeMarkdown(series.label)}: ${formatSeriesValue(
-        snapshot,
-        series,
-        requireNumericRowValue(row, series.id),
-      )}`,
+      `${escapeMarkdown(series.label)}: ${formatNativeSeriesValue(snapshot, series, row)}`,
   );
-}
-
-function requireRowValue(row: NativeRow, column: string): NativeRowValue {
-  const value = row.values.get(column);
-  if (value === undefined) {
-    throw new Error(`Visualization row missing value for ${column}.`);
-  }
-  return value;
-}
-function requireNumericRowValue(row: NativeRow, column: string): number | null {
-  const value = row.values.get(column) ?? null;
-  if (typeof value !== "number" && value !== null) {
-    throw new Error(`Visualization row value for ${column} is not numeric.`);
-  }
-  return value;
-}
-
-function formatPreviewValue(
-  column: ReportAiPreviewSummary["columns"][number],
-  value: NativeRowValue,
-): string {
-  return value === null ? "Unknown" : formatReportDisplayValue(column, value);
-}
-
-function formatSeriesValue(
-  snapshot: VisualizationSnapshot,
-  series: TemporalSeries,
-  value: number | null,
-): string {
-  if (value === null) {
-    return "Unknown";
-  }
-  const isRate =
-    snapshot.display.stack === "percent" ||
-    REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
-      "rate";
-  if (isRate) {
-    return `${(value * 100).toFixed(1)}%`;
-  }
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 3 }).format(
-    value,
-  );
-}
-
-function formatAbsoluteDelta(
-  snapshot: VisualizationSnapshot,
-  series: TemporalSeries,
-  value: number | null,
-): string {
-  const isRate =
-    snapshot.display.stack === "percent" ||
-    REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
-      "rate";
-  return isRate
-    ? value === null
-      ? "Unknown"
-      : `${(value * 100).toFixed(1)} pp`
-    : formatSeriesValue(snapshot, series, value);
 }
 
 function escapeMarkdown(value: string): string {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -201,7 +201,7 @@ function formatList(
   const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(
+  const previewNotice = previewOverflowNotice(
     source.preview,
     allRows,
     source.snapshotRows,
@@ -213,8 +213,8 @@ function formatList(
   });
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more_`);
-  } else if (previewExtra) {
-    lines.push("_…additional rows omitted from the stored preview_");
+  } else if (previewNotice !== null) {
+    lines.push(previewNotice);
   }
   return lines.join("\n");
 }
@@ -227,7 +227,7 @@ function formatLeaderboard(
   const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(
+  const previewNotice = previewOverflowNotice(
     source.preview,
     allRows,
     source.snapshotRows,
@@ -239,8 +239,8 @@ function formatLeaderboard(
   });
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more_`);
-  } else if (previewExtra) {
-    lines.push("_…additional rows omitted from the stored preview_");
+  } else if (previewNotice !== null) {
+    lines.push(previewNotice);
   }
   return lines.join("\n");
 }
@@ -253,7 +253,7 @@ function formatTable(
   const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(
+  const previewNotice = previewOverflowNotice(
     source.preview,
     allRows,
     source.snapshotRows,
@@ -298,8 +298,8 @@ function formatTable(
   ];
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more rows_`);
-  } else if (previewExtra) {
-    lines.push("_…additional rows omitted from the stored preview_");
+  } else if (previewNotice !== null) {
+    lines.push(previewNotice);
   }
   return lines.join("\n");
 }
@@ -374,28 +374,31 @@ function nativeRowSource(
   return { rows: previewRows(preview), preview, snapshotRows };
 }
 
-function hasPreviewRowsBeyondStoredRows(
+function previewOverflowNotice(
   preview: ReportAiPreviewSummary | null,
   rows: NativeRow[],
   snapshotRows: NativeRow[],
   snapshot: VisualizationSnapshot,
-): boolean {
+): string | null {
   if (preview === null) {
-    return false;
+    return null;
   }
   if (preview.rowsReturned > rows.length) {
-    return true;
+    return "_…additional rows omitted from the stored preview_";
   }
-  const hasCollapsedLegacyRows =
-    snapshot.series.some((series) => {
-      const separator = series.id.lastIndexOf(":");
-      return separator !== -1 && series.id.slice(0, separator) !== "All";
-    }) && snapshotRows.length < rows.length;
-  return (
-    preview.rowsReturned === 0 &&
-    preview.visualizationRows.length === 0 &&
-    (snapshotRows.length > rows.length || hasCollapsedLegacyRows)
-  );
+  if (preview.rowsReturned !== 0 || preview.visualizationRows.length > 0) {
+    return null;
+  }
+  if (snapshotRows.length > rows.length) {
+    return "_…additional rows omitted from the stored preview_";
+  }
+  const hasNamedSeries = snapshot.series.some((series) => {
+    const separator = series.id.lastIndexOf(":");
+    return separator !== -1 && series.id.slice(0, separator) !== "All";
+  });
+  return hasNamedSeries && snapshotRows.length < rows.length
+    ? "_…additional rows may be omitted from the stored visualization_"
+    : null;
 }
 
 function previewMetricColumns(preview: ReportAiPreviewSummary) {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -15,6 +15,8 @@ import {
   formatNativeSeriesValue,
   formatPreviewValueWithEvidence,
   formatSeriesValue,
+  displayWidth,
+  padDisplayWidth,
   truncateNativeCell,
   type NativeRow,
   type NativeRowValue,
@@ -313,66 +315,6 @@ function formatTableRow(cells: string[], widths: number[]): string {
       padDisplayWidth(cell, widths[index] ?? displayWidth(cell)),
     )
     .join("    ");
-}
-const graphemeSegmenter = new Intl.Segmenter(undefined, {
-  granularity: "grapheme",
-});
-function displayWidth(value: string): number {
-  let width = 0;
-  for (const { segment } of graphemeSegmenter.segment(value)) {
-    width += displayGraphemeWidth(segment);
-  }
-  return width;
-}
-function displayGraphemeWidth(segment: string): number {
-  let width = 0;
-  let regionalIndicatorCount = 0;
-  let hasKeycapMark = false;
-  for (const character of segment) {
-    const codePoint = character.codePointAt(0);
-    if (codePoint === undefined) {
-      continue;
-    }
-    if (codePoint >= 0x1_f1_e6 && codePoint <= 0x1_f1_ff) {
-      regionalIndicatorCount += 1;
-      continue;
-    }
-    if (codePoint === 0x20_0d) {
-      continue;
-    }
-    if (codePoint === 0x20_e3) {
-      hasKeycapMark = true;
-      continue;
-    }
-    if (
-      /\p{Mark}/u.test(character) ||
-      (codePoint >= 0xfe_00 && codePoint <= 0xfe_0f)
-    ) {
-      continue;
-    }
-    width = Math.max(width, isWideCodePoint(codePoint) ? 2 : 1);
-  }
-  return hasKeycapMark || regionalIndicatorCount === 2 ? 2 : width;
-}
-
-function isWideCodePoint(codePoint: number): boolean {
-  return (
-    (codePoint >= 0x11_00 && codePoint <= 0x11_5f) ||
-    codePoint === 0x23_29 ||
-    codePoint === 0x23_2a ||
-    (codePoint >= 0x2e_80 && codePoint <= 0xa4_cf) ||
-    (codePoint >= 0xac_00 && codePoint <= 0xd7_a3) ||
-    (codePoint >= 0xf9_00 && codePoint <= 0xfa_ff) ||
-    (codePoint >= 0xfe_10 && codePoint <= 0xfe_19) ||
-    (codePoint >= 0xfe_30 && codePoint <= 0xfe_6f) ||
-    (codePoint >= 0xff_00 && codePoint <= 0xff_60) ||
-    (codePoint >= 0xff_e0 && codePoint <= 0xff_e6) ||
-    (codePoint >= 0x1_f3_00 && codePoint <= 0x1_fa_ff)
-  );
-}
-
-function padDisplayWidth(value: string, width: number): string {
-  return value + " ".repeat(Math.max(0, width - displayWidth(value)));
 }
 
 function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -343,11 +343,7 @@ function formatRowValues(
 }
 
 function requireRowValue(row: NativeRow, column: string): NativeRowValue {
-  const value = row.values.get(column);
-  if (value === undefined) {
-    throw new Error(`Visualization row missing column ${column}.`);
-  }
-  return value;
+  return row.values.get(column) ?? null;
 }
 
 function requireNumericRowValue(row: NativeRow, column: string): number | null {
@@ -408,7 +404,9 @@ function formatPercent(value: number | null): string {
 }
 
 function escapeMarkdown(value: string): string {
-  return value.replaceAll(/[\\_*`|]/g, (char) => `\\${char}`);
+  return value
+    .replaceAll(/[\r\n]+/g, " ")
+    .replaceAll(/[\\_*`|]/g, (char) => `\\${char}`);
 }
 
 function escapeTableCell(value: string): string {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -489,5 +489,5 @@ function escapeMarkdown(value: string): string {
 }
 
 function escapeTableCell(value: string): string {
-  return value.replaceAll("`", "′").replaceAll("\n", " ");
+  return value.replaceAll("`", "′").replaceAll(/[\r\n]+/g, " ");
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -86,7 +86,9 @@ function nativeDescription(snapshot: VisualizationSnapshot): string | null {
         : snapshot.kind === "LIST"
           ? formatList(snapshot)
           : formatTable(snapshot);
-  return truncateDescription(description);
+  return snapshot.kind === "TABLE"
+    ? truncateTableDescription(description)
+    : truncateDescription(description);
 }
 
 function truncateDescription(description: string): string {
@@ -95,6 +97,27 @@ function truncateDescription(description: string): string {
   }
   const available =
     MAX_EMBED_DESCRIPTION - DESCRIPTION_TRUNCATION_SUFFIX.length;
+  return `${truncateLines(description, available)}${DESCRIPTION_TRUNCATION_SUFFIX}`;
+}
+
+function truncateTableDescription(description: string): string {
+  const codeFence = "```";
+  const openingFence = `${codeFence}\n`;
+  const closingFence = `\n${codeFence}`;
+  const fullDescription = `${openingFence}${description}${closingFence}`;
+  if (fullDescription.length <= MAX_EMBED_DESCRIPTION) {
+    return fullDescription;
+  }
+  const available =
+    MAX_EMBED_DESCRIPTION -
+    openingFence.length -
+    closingFence.length -
+    DESCRIPTION_TRUNCATION_SUFFIX.length;
+  const truncated = truncateLines(description, available);
+  return `${openingFence}${truncated}${closingFence}${DESCRIPTION_TRUNCATION_SUFFIX}`;
+}
+
+function truncateLines(description: string, available: number): string {
   const lines: string[] = [];
   let length = 0;
   for (const line of description.split("\n")) {
@@ -107,9 +130,9 @@ function truncateDescription(description: string): string {
   }
   const prefix = lines.join("\n");
   if (prefix.length === 0) {
-    return `${description.slice(0, available)}${DESCRIPTION_TRUNCATION_SUFFIX}`;
+    return description.slice(0, available);
   }
-  return `${prefix}${DESCRIPTION_TRUNCATION_SUFFIX}`;
+  return prefix;
 }
 
 function formatKpi(snapshot: VisualizationSnapshot): string {
@@ -194,8 +217,7 @@ function formatTable(snapshot: VisualizationSnapshot): string {
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more rows_`);
   }
-  const codeFence = "```";
-  return `${codeFence}\n${lines.join("\n")}\n${codeFence}`;
+  return lines.join("\n");
 }
 
 function alignedRows(snapshot: VisualizationSnapshot): {
@@ -250,5 +272,8 @@ function escapeMarkdown(value: string): string {
 }
 
 function escapeTableCell(value: string): string {
-  return value.replaceAll("|", String.raw`\|`).replaceAll("\n", " ");
+  return value
+    .replaceAll("`", "′")
+    .replaceAll("|", String.raw`\|`)
+    .replaceAll("\n", " ");
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -185,9 +185,9 @@ function formatList(
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
   const previewExtra = hasPreviewRowsBeyondStoredRows(
-    snapshot,
     source.preview,
     allRows,
+    source.snapshotRows,
   );
   const lines = rows.map((row) => {
     const values = formatRowValues(snapshot, row, source.preview).join(", ");
@@ -210,9 +210,9 @@ function formatLeaderboard(
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
   const previewExtra = hasPreviewRowsBeyondStoredRows(
-    snapshot,
     source.preview,
     allRows,
+    source.snapshotRows,
   );
   const lines = rows.map((row, index) => {
     const values = formatRowValues(snapshot, row, source.preview).join(" · ");
@@ -235,9 +235,9 @@ function formatTable(
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
   const previewExtra = hasPreviewRowsBeyondStoredRows(
-    snapshot,
     source.preview,
     allRows,
+    source.snapshotRows,
   );
   const headers =
     source.preview === null
@@ -342,20 +342,25 @@ function previewRows(preview: ReportAiPreviewSummary): NativeRow[] {
 function nativeRowSource(
   snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
-): { rows: NativeRow[]; preview: ReportAiPreviewSummary | null } {
+): {
+  rows: NativeRow[];
+  preview: ReportAiPreviewSummary | null;
+  snapshotRows: NativeRow[];
+} {
+  const snapshotRows = alignedRows(snapshot);
   if (snapshot.temporal !== null) {
-    return { rows: alignedRows(snapshot), preview: null };
+    return { rows: snapshotRows, preview: null, snapshotRows };
   }
   if (preview === null) {
-    return { rows: alignedRows(snapshot), preview: null };
+    return { rows: snapshotRows, preview: null, snapshotRows };
   }
-  return { rows: previewRows(preview), preview };
+  return { rows: previewRows(preview), preview, snapshotRows };
 }
 
 function hasPreviewRowsBeyondStoredRows(
-  snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
   rows: NativeRow[],
+  snapshotRows: NativeRow[],
 ): boolean {
   if (preview === null) {
     return false;
@@ -366,8 +371,7 @@ function hasPreviewRowsBeyondStoredRows(
   return (
     preview.rowsReturned === 0 &&
     preview.visualizationRows.length === 0 &&
-    snapshot.temporal === null &&
-    alignedRows(snapshot).length > rows.length
+    snapshotRows.length > rows.length
   );
 }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -1,7 +1,9 @@
 import { AttachmentBuilder, Colors, EmbedBuilder } from "discord.js";
 import {
+  formatReportDisplayValue,
   REPORT_METRICS,
   type ExploreMessage,
+  type ReportAiPreviewSummary,
   type TemporalSeries,
   type VisualizationSnapshot,
 } from "@scout-for-lol/data";
@@ -27,7 +29,7 @@ export function exploreVisualizationPayload(
     return {};
   }
   if (usesNativeDiscordVisualization(snapshot)) {
-    const embed = visualizationToEmbed(snapshot);
+    const embed = visualizationToEmbed(snapshot, message.preview);
     return embed === null ? {} : { embeds: [embed] };
   }
   return {
@@ -53,8 +55,9 @@ export function usesNativeDiscordVisualization(
 
 export function visualizationToEmbed(
   snapshot: VisualizationSnapshot,
+  preview: ReportAiPreviewSummary | null = null,
 ): EmbedBuilder | null {
-  const description = nativeDescription(snapshot);
+  const description = nativeDescription(snapshot, preview);
   if (description === null) {
     return null;
   }
@@ -74,7 +77,10 @@ function truncateTitle(title: string): string {
   return `${title.slice(0, MAX_EMBED_TITLE - 1)}…`;
 }
 
-function nativeDescription(snapshot: VisualizationSnapshot): string | null {
+function nativeDescription(
+  snapshot: VisualizationSnapshot,
+  preview: ReportAiPreviewSummary | null,
+): string | null {
   if (snapshot.series.length === 0) {
     return null;
   }
@@ -82,10 +88,10 @@ function nativeDescription(snapshot: VisualizationSnapshot): string | null {
     snapshot.kind === "KPI_CARD"
       ? formatKpi(snapshot)
       : snapshot.kind === "LEADERBOARD"
-        ? formatLeaderboard(snapshot)
+        ? formatLeaderboard(snapshot, preview)
         : snapshot.kind === "LIST"
-          ? formatList(snapshot)
-          : formatTable(snapshot);
+          ? formatList(snapshot, preview)
+          : formatTable(snapshot, preview);
   return snapshot.kind === "TABLE"
     ? truncateTableDescription(description)
     : truncateDescription(description);
@@ -139,27 +145,42 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
   return snapshot.series
     .map((series) => {
       const point = series.points.at(-1);
-      const value = formatSeriesValue(snapshot, series, point?.value ?? null);
-      return `**${escapeMarkdown(series.label)}**\n${value}`;
+      if (point === undefined) {
+        return `**${escapeMarkdown(series.label)}**\nUnknown n=0`;
+      }
+      const value = formatSeriesValue(snapshot, series, point.value);
+      const sampleSize = point.evidence.sampleSize;
+      const comparison =
+        point.comparisonEvidence !== undefined ||
+        point.comparisonValue !== undefined ||
+        point.absoluteDelta !== undefined ||
+        point.percentageDelta !== undefined;
+      const details = comparison
+        ? `n=${sampleSize.toString()} · Baseline: ${formatSeriesValue(
+            snapshot,
+            series,
+            point.comparisonValue ?? null,
+          )} · Δ ${formatAbsoluteDelta(
+            snapshot,
+            series,
+            point.absoluteDelta ?? null,
+          )} · ${formatPercent(point.percentageDelta ?? null)}`
+        : `n=${sampleSize.toString()}`;
+      return `**${escapeMarkdown(series.label)}**\n${value} ${details}`;
     })
     .join("\n\n");
 }
 
-function formatList(snapshot: VisualizationSnapshot): string {
-  const allRows = alignedRows(snapshot);
+function formatList(
+  snapshot: VisualizationSnapshot,
+  preview: ReportAiPreviewSummary | null,
+): string {
+  const allRows =
+    preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
   const lines = rows.map((row) => {
-    const values = snapshot.series
-      .map(
-        (series) =>
-          `${escapeMarkdown(series.label)}: ${formatSeriesValue(
-            snapshot,
-            series,
-            row.values.get(series.id) ?? null,
-          )}`,
-      )
-      .join(", ");
+    const values = formatRowValues(snapshot, row, preview).join(", ");
     return `- ${escapeMarkdown(row.label)}: ${values}`;
   });
   if (extra > 0) {
@@ -168,21 +189,16 @@ function formatList(snapshot: VisualizationSnapshot): string {
   return lines.join("\n");
 }
 
-function formatLeaderboard(snapshot: VisualizationSnapshot): string {
-  const allRows = alignedRows(snapshot);
+function formatLeaderboard(
+  snapshot: VisualizationSnapshot,
+  preview: ReportAiPreviewSummary | null,
+): string {
+  const allRows =
+    preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
   const lines = rows.map((row, index) => {
-    const values = snapshot.series
-      .map(
-        (series) =>
-          `${escapeMarkdown(series.label)}: ${formatSeriesValue(
-            snapshot,
-            series,
-            row.values.get(series.id) ?? null,
-          )}`,
-      )
-      .join(" · ");
+    const values = formatRowValues(snapshot, row, preview).join(" · ");
     return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
   });
   if (extra > 0) {
@@ -191,26 +207,39 @@ function formatLeaderboard(snapshot: VisualizationSnapshot): string {
   return lines.join("\n");
 }
 
-function formatTable(snapshot: VisualizationSnapshot): string {
-  const allRows = alignedRows(snapshot);
+function formatTable(
+  snapshot: VisualizationSnapshot,
+  preview: ReportAiPreviewSummary | null,
+): string {
+  const allRows =
+    preview === null ? alignedRows(snapshot) : previewRows(preview);
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const headers = ["", ...snapshot.series.map((series) => series.label)];
+  const headers =
+    preview === null
+      ? ["", ...snapshot.series.map((series) => series.label)]
+      : preview.columns.map((column) => column.label);
   const lines = [
     headers.map((header) => escapeTableCell(header)).join("    "),
     headers.map(() => "----").join("    "),
     ...rows.map((row) =>
       [
         escapeTableCell(row.label),
-        ...snapshot.series.map((series) =>
-          escapeTableCell(
-            formatSeriesValue(
-              snapshot,
-              series,
-              row.values.get(series.id) ?? null,
-            ),
-          ),
-        ),
+        ...(preview === null
+          ? snapshot.series.map((series) =>
+              escapeTableCell(
+                formatSeriesValue(
+                  snapshot,
+                  series,
+                  requireNumericRowValue(row, series.id),
+                ),
+              ),
+            )
+          : previewMetricColumns(preview).map((column) =>
+              escapeTableCell(
+                formatPreviewValue(column, requireRowValue(row, column.key)),
+              ),
+            )),
       ].join("    "),
     ),
   ];
@@ -220,13 +249,16 @@ function formatTable(snapshot: VisualizationSnapshot): string {
   return lines.join("\n");
 }
 
-function alignedRows(snapshot: VisualizationSnapshot): {
+type NativeRowValue = string | number | null;
+type NativeRow = {
   label: string;
-  values: Map<string, number | null>;
-}[] {
+  values: Map<string, NativeRowValue>;
+};
+
+function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {
   const order: string[] = [];
   const labels = new Map<string, string>();
-  const values = new Map<string, Map<string, number | null>>();
+  const values = new Map<string, Map<string, NativeRowValue>>();
   for (const series of snapshot.series) {
     for (const point of series.points) {
       if (!labels.has(point.key)) {
@@ -241,10 +273,78 @@ function alignedRows(snapshot: VisualizationSnapshot): {
       rowValues.set(series.id, point.value);
     }
   }
-  return order.map((key) => ({
-    label: labels.get(key) ?? key,
-    values: values.get(key) ?? new Map(),
+  return order.map((key) => {
+    const label = labels.get(key);
+    if (label === undefined) {
+      throw new Error(`Visualization label missing key ${key}.`);
+    }
+    const rowValues = values.get(key);
+    if (rowValues === undefined) {
+      throw new Error(`Visualization values missing key ${key}.`);
+    }
+    return { label, values: rowValues };
+  });
+}
+
+function previewRows(preview: ReportAiPreviewSummary): NativeRow[] {
+  return preview.rows.map((row) => ({
+    label: row.label,
+    values: new Map(row.values.map((value) => [value.column, value.value])),
   }));
+}
+
+function previewMetricColumns(preview: ReportAiPreviewSummary) {
+  return preview.columns.filter((column) => column.key !== "label");
+}
+
+function formatRowValues(
+  snapshot: VisualizationSnapshot,
+  row: NativeRow,
+  preview: ReportAiPreviewSummary | null,
+): string[] {
+  if (preview !== null) {
+    return previewMetricColumns(preview).map(
+      (column) =>
+        `${escapeMarkdown(column.label)}: ${formatPreviewValue(
+          column,
+          requireRowValue(row, column.key),
+        )}`,
+    );
+  }
+  return snapshot.series.map(
+    (series) =>
+      `${escapeMarkdown(series.label)}: ${formatSeriesValue(
+        snapshot,
+        series,
+        requireNumericRowValue(row, series.id),
+      )}`,
+  );
+}
+
+function requireRowValue(row: NativeRow, column: string): NativeRowValue {
+  const value = row.values.get(column);
+  if (value === undefined) {
+    throw new Error(`Visualization row missing column ${column}.`);
+  }
+  return value;
+}
+
+function requireNumericRowValue(row: NativeRow, column: string): number | null {
+  const value = requireRowValue(row, column);
+  if (typeof value !== "number" && value !== null) {
+    throw new Error(`Visualization row value for ${column} is not numeric.`);
+  }
+  return value;
+}
+
+function formatPreviewValue(
+  column: ReportAiPreviewSummary["columns"][number],
+  value: NativeRowValue,
+): string {
+  if (value === null) {
+    return "Unknown";
+  }
+  return formatReportDisplayValue(column, value);
 }
 
 function formatSeriesValue(
@@ -265,6 +365,25 @@ function formatSeriesValue(
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 3 }).format(
     value,
   );
+}
+
+function formatAbsoluteDelta(
+  snapshot: VisualizationSnapshot,
+  series: TemporalSeries,
+  value: number | null,
+): string {
+  const isRate =
+    snapshot.display.stack === "percent" ||
+    REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
+      "rate";
+  if (isRate) {
+    return value === null ? "Unknown" : `${(value * 100).toFixed(1)} pp`;
+  }
+  return formatSeriesValue(snapshot, series, value);
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? "Unknown" : `${(value * 100).toFixed(1)}%`;
 }
 
 function escapeMarkdown(value: string): string {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -15,13 +15,13 @@ import {
   formatNativeSeriesValue,
   formatPreviewValueWithEvidence,
   formatSeriesValue,
+  truncateNativeCell,
   type NativeRow,
   type NativeRowValue,
 } from "#src/discord/scout/visualization-format.ts";
 
 const NATIVE_KINDS = new Set(["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"]);
 const MAX_NATIVE_ROWS = 12;
-const MAX_NATIVE_CELL_LENGTH = 160;
 const MAX_EMBED_DESCRIPTION = 3900;
 const MAX_EMBED_TITLE = 256;
 const DESCRIPTION_TRUNCATION_SUFFIX =
@@ -473,12 +473,6 @@ function formatRowValues(
     (series) =>
       `${escapeMarkdown(truncateNativeCell(series.label))}: ${truncateNativeCell(formatNativeSeriesValue(snapshot, series, row))}`,
   );
-}
-
-function truncateNativeCell(value: string): string {
-  return value.length <= MAX_NATIVE_CELL_LENGTH
-    ? value
-    : `${value.slice(0, MAX_NATIVE_CELL_LENGTH - 1)}…`;
 }
 
 function escapeMarkdown(value: string): string {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -10,6 +10,8 @@ import { visualizationSnapshotToImage } from "@scout-for-lol/report";
 const NATIVE_KINDS = new Set(["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"]);
 const MAX_NATIVE_ROWS = 12;
 const MAX_EMBED_DESCRIPTION = 3900;
+const DESCRIPTION_TRUNCATION_SUFFIX =
+  "\n\n_Visualization truncated to fit Discord._";
 
 export type ExploreVisualizationPayload = {
   files?: AttachmentBuilder[];
@@ -68,23 +70,66 @@ function nativeDescription(snapshot: VisualizationSnapshot): string | null {
   if (snapshot.series.length === 0) {
     return null;
   }
-  if (snapshot.kind === "KPI_CARD") {
-    return formatKpi(snapshot);
+  const description =
+    snapshot.kind === "KPI_CARD"
+      ? formatKpi(snapshot)
+      : snapshot.kind === "LEADERBOARD"
+        ? formatLeaderboard(snapshot)
+        : snapshot.kind === "LIST"
+          ? formatList(snapshot)
+          : formatTable(snapshot);
+  return truncateDescription(description);
+}
+
+function truncateDescription(description: string): string {
+  if (description.length <= MAX_EMBED_DESCRIPTION) {
+    return description;
   }
-  if (snapshot.kind === "LEADERBOARD") {
-    return formatLeaderboard(snapshot);
+  const available =
+    MAX_EMBED_DESCRIPTION - DESCRIPTION_TRUNCATION_SUFFIX.length;
+  const lines: string[] = [];
+  let length = 0;
+  for (const line of description.split("\n")) {
+    const nextLength = length + (lines.length === 0 ? 0 : 1) + line.length;
+    if (nextLength > available) {
+      break;
+    }
+    lines.push(line);
+    length = nextLength;
   }
-  return formatTable(snapshot);
+  const prefix = lines.join("\n");
+  if (prefix.length === 0) {
+    return `${description.slice(0, available)}${DESCRIPTION_TRUNCATION_SUFFIX}`;
+  }
+  return `${prefix}${DESCRIPTION_TRUNCATION_SUFFIX}`;
 }
 
 function formatKpi(snapshot: VisualizationSnapshot): string {
   return snapshot.series
     .map((series) => {
-      const point = series.points[0];
+      const point = series.points.at(-1);
       const value = formatSeriesValue(snapshot, series, point?.value ?? null);
       return `**${escapeMarkdown(series.label)}**\n${value}`;
     })
     .join("\n\n");
+}
+
+function formatList(snapshot: VisualizationSnapshot): string {
+  const allRows = alignedRows(snapshot);
+  const rows = allRows.slice(0, MAX_NATIVE_ROWS);
+  const extra = allRows.length - rows.length;
+  const lines = rows.map((row) => {
+    const values = snapshot.series
+      .map((series) =>
+        formatSeriesValue(snapshot, series, row.values.get(series.id) ?? null),
+      )
+      .join(", ");
+    return `- ${escapeMarkdown(row.label)}: ${values}`;
+  });
+  if (extra > 0) {
+    lines.push(`_…and ${extra.toString()} more_`);
+  }
+  return lines.join("\n");
 }
 
 function formatLeaderboard(snapshot: VisualizationSnapshot): string {
@@ -132,11 +177,7 @@ function formatTable(snapshot: VisualizationSnapshot): string {
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more rows_`);
   }
-  const text = lines.join("\n");
-  if (text.length <= MAX_EMBED_DESCRIPTION) {
-    return text;
-  }
-  return `${lines.slice(0, 4).join("\n")}\n_Table truncated to fit Discord._`;
+  return lines.join("\n");
 }
 
 function alignedRows(snapshot: VisualizationSnapshot): {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -305,8 +305,7 @@ function formatTable(
 function formatTableRow(cells: string[], widths: number[]): string {
   return cells
     .map((cell, index) => cell.padEnd(widths[index] ?? cell.length))
-    .join("    ")
-    .trimEnd();
+    .join("    ");
 }
 
 function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -282,8 +282,8 @@ function formatTable(
   ]);
   const widths = headers.map((_, index) =>
     Math.max(
-      escapedHeaders[index]?.length ?? 0,
-      ...bodyRows.map((row) => row[index]?.length ?? 0),
+      displayWidth(escapedHeaders[index] ?? ""),
+      ...bodyRows.map((row) => displayWidth(row[index] ?? "")),
     ),
   );
   const lines = [
@@ -304,8 +304,56 @@ function formatTable(
 
 function formatTableRow(cells: string[], widths: number[]): string {
   return cells
-    .map((cell, index) => cell.padEnd(widths[index] ?? cell.length))
+    .map((cell, index) =>
+      padDisplayWidth(cell, widths[index] ?? displayWidth(cell)),
+    )
     .join("    ");
+}
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+  granularity: "grapheme",
+});
+
+function displayWidth(value: string): number {
+  let width = 0;
+  for (const { segment } of graphemeSegmenter.segment(value)) {
+    for (const character of segment) {
+      const codePoint = character.codePointAt(0);
+      if (codePoint === undefined) {
+        continue;
+      }
+      if (
+        codePoint === 0x20_0d ||
+        /\p{Mark}/u.test(character) ||
+        (codePoint >= 0xfe_00 && codePoint <= 0xfe_0f)
+      ) {
+        continue;
+      }
+      width += isWideCodePoint(codePoint) ? 2 : 1;
+      break;
+    }
+  }
+  return width;
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x11_00 && codePoint <= 0x11_5f) ||
+    codePoint === 0x23_29 ||
+    codePoint === 0x23_2a ||
+    (codePoint >= 0x2e_80 && codePoint <= 0xa4_cf) ||
+    (codePoint >= 0xac_00 && codePoint <= 0xd7_a3) ||
+    (codePoint >= 0xf9_00 && codePoint <= 0xfa_ff) ||
+    (codePoint >= 0xfe_10 && codePoint <= 0xfe_19) ||
+    (codePoint >= 0xfe_30 && codePoint <= 0xfe_6f) ||
+    (codePoint >= 0xff_00 && codePoint <= 0xff_60) ||
+    (codePoint >= 0xff_e0 && codePoint <= 0xff_e6) ||
+    (codePoint >= 0x1_f3_00 && codePoint <= 0x1_fa_ff)
+  );
+}
+
+function padDisplayWidth(value: string, width: number): string {
+  return value + " ".repeat(Math.max(0, width - displayWidth(value)));
 }
 
 function alignedRows(snapshot: VisualizationSnapshot): NativeRow[] {
@@ -428,5 +476,7 @@ function escapeMarkdown(value: string): string {
 }
 
 function escapeTableCell(value: string): string {
-  return value.replaceAll("`", "′").replaceAll(/[\r\n]+/g, " ");
+  return value
+    .replaceAll(/`{3,}/g, (ticks) => "′".repeat(ticks.length))
+    .replaceAll(/[\r\n]+/g, " ");
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -1,0 +1,195 @@
+import { AttachmentBuilder, Colors, EmbedBuilder } from "discord.js";
+import {
+  REPORT_METRICS,
+  type ExploreMessage,
+  type TemporalSeries,
+  type VisualizationSnapshot,
+} from "@scout-for-lol/data";
+import { visualizationSnapshotToImage } from "@scout-for-lol/report";
+
+const NATIVE_KINDS = new Set(["TABLE", "LIST", "LEADERBOARD", "KPI_CARD"]);
+const MAX_NATIVE_ROWS = 12;
+const MAX_EMBED_DESCRIPTION = 3900;
+
+export type ExploreVisualizationPayload = {
+  files?: AttachmentBuilder[];
+  embeds?: EmbedBuilder[];
+};
+
+export function exploreVisualizationPayload(
+  message: ExploreMessage,
+): ExploreVisualizationPayload {
+  const snapshot = message.visualization;
+  if (snapshot === null) {
+    return {};
+  }
+  if (usesNativeDiscordVisualization(snapshot)) {
+    const embed = visualizationToEmbed(snapshot);
+    return embed === null ? {} : { embeds: [embed] };
+  }
+  return {
+    files: [
+      new AttachmentBuilder(visualizationSnapshotToImage(snapshot), {
+        name: "scout-explore.png",
+      }),
+    ],
+  };
+}
+
+export function exploreChartAttachment(
+  message: ExploreMessage,
+): AttachmentBuilder | null {
+  return exploreVisualizationPayload(message).files?.[0] ?? null;
+}
+
+export function usesNativeDiscordVisualization(
+  snapshot: VisualizationSnapshot,
+): boolean {
+  return NATIVE_KINDS.has(snapshot.kind) && !snapshot.display.sparkline;
+}
+
+export function visualizationToEmbed(
+  snapshot: VisualizationSnapshot,
+): EmbedBuilder | null {
+  const description = nativeDescription(snapshot);
+  if (description === null) {
+    return null;
+  }
+  const embed = new EmbedBuilder()
+    .setColor(Colors.DarkGold)
+    .setDescription(description);
+  if (snapshot.title !== null) {
+    embed.setTitle(snapshot.title);
+  }
+  return embed;
+}
+
+function nativeDescription(snapshot: VisualizationSnapshot): string | null {
+  if (snapshot.series.length === 0) {
+    return null;
+  }
+  if (snapshot.kind === "KPI_CARD") {
+    return formatKpi(snapshot);
+  }
+  if (snapshot.kind === "LEADERBOARD") {
+    return formatLeaderboard(snapshot);
+  }
+  return formatTable(snapshot);
+}
+
+function formatKpi(snapshot: VisualizationSnapshot): string {
+  return snapshot.series
+    .map((series) => {
+      const point = series.points[0];
+      const value = formatSeriesValue(snapshot, series, point?.value ?? null);
+      return `**${escapeMarkdown(series.label)}**\n${value}`;
+    })
+    .join("\n\n");
+}
+
+function formatLeaderboard(snapshot: VisualizationSnapshot): string {
+  const allRows = alignedRows(snapshot);
+  const rows = allRows.slice(0, MAX_NATIVE_ROWS);
+  const extra = allRows.length - rows.length;
+  const lines = rows.map((row, index) => {
+    const values = snapshot.series
+      .map((series) =>
+        formatSeriesValue(snapshot, series, row.values.get(series.id) ?? null),
+      )
+      .join(" · ");
+    return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
+  });
+  if (extra > 0) {
+    lines.push(`_…and ${extra.toString()} more_`);
+  }
+  return lines.join("\n");
+}
+
+function formatTable(snapshot: VisualizationSnapshot): string {
+  const allRows = alignedRows(snapshot);
+  const rows = allRows.slice(0, MAX_NATIVE_ROWS);
+  const extra = allRows.length - rows.length;
+  const headers = ["", ...snapshot.series.map((series) => series.label)];
+  const lines = [
+    `| ${headers.map((header) => escapeTableCell(header)).join(" | ")} |`,
+    `| ${headers.map((_, index) => (index === 0 ? "---" : "---:")).join(" | ")} |`,
+    ...rows.map(
+      (row) =>
+        `| ${[
+          escapeTableCell(row.label),
+          ...snapshot.series.map((series) =>
+            escapeTableCell(
+              formatSeriesValue(
+                snapshot,
+                series,
+                row.values.get(series.id) ?? null,
+              ),
+            ),
+          ),
+        ].join(" | ")} |`,
+    ),
+  ];
+  if (extra > 0) {
+    lines.push(`_…and ${extra.toString()} more rows_`);
+  }
+  const text = lines.join("\n");
+  if (text.length <= MAX_EMBED_DESCRIPTION) {
+    return text;
+  }
+  return `${lines.slice(0, 4).join("\n")}\n_Table truncated to fit Discord._`;
+}
+
+function alignedRows(snapshot: VisualizationSnapshot): {
+  label: string;
+  values: Map<string, number | null>;
+}[] {
+  const order: string[] = [];
+  const labels = new Map<string, string>();
+  const values = new Map<string, Map<string, number | null>>();
+  for (const series of snapshot.series) {
+    for (const point of series.points) {
+      if (!labels.has(point.key)) {
+        order.push(point.key);
+        labels.set(point.key, point.label);
+        values.set(point.key, new Map());
+      }
+      const rowValues = values.get(point.key);
+      if (rowValues === undefined) {
+        throw new Error(`Visualization row missing key ${point.key}.`);
+      }
+      rowValues.set(series.id, point.value);
+    }
+  }
+  return order.map((key) => ({
+    label: labels.get(key) ?? key,
+    values: values.get(key) ?? new Map(),
+  }));
+}
+
+function formatSeriesValue(
+  snapshot: VisualizationSnapshot,
+  series: TemporalSeries,
+  value: number | null,
+): string {
+  if (value === null) {
+    return "Unknown";
+  }
+  const isRate =
+    snapshot.display.stack === "percent" ||
+    REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
+      "rate";
+  if (isRate) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 3 }).format(
+    value,
+  );
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replaceAll(/[\\_*`|]/g, (char) => `\\${char}`);
+}
+
+function escapeTableCell(value: string): string {
+  return value.replaceAll("|", String.raw`\|`).replaceAll("\n", " ");
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -176,13 +176,13 @@ function formatList(
   snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
 ): string {
-  const allRows =
-    preview === null ? alignedRows(snapshot) : previewRows(preview);
+  const source = nativeRowSource(snapshot, preview);
+  const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(preview, allRows);
+  const previewExtra = hasPreviewRowsBeyondStoredRows(source.preview, allRows);
   const lines = rows.map((row) => {
-    const values = formatRowValues(snapshot, row, preview).join(", ");
+    const values = formatRowValues(snapshot, row, source.preview).join(", ");
     return `- ${escapeMarkdown(row.label)}: ${values}`;
   });
   if (extra > 0) {
@@ -197,13 +197,13 @@ function formatLeaderboard(
   snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
 ): string {
-  const allRows =
-    preview === null ? alignedRows(snapshot) : previewRows(preview);
+  const source = nativeRowSource(snapshot, preview);
+  const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(preview, allRows);
+  const previewExtra = hasPreviewRowsBeyondStoredRows(source.preview, allRows);
   const lines = rows.map((row, index) => {
-    const values = formatRowValues(snapshot, row, preview).join(" · ");
+    const values = formatRowValues(snapshot, row, source.preview).join(" · ");
     return `**${(index + 1).toString()}.** ${escapeMarkdown(row.label)} — ${values}`;
   });
   if (extra > 0) {
@@ -218,38 +218,46 @@ function formatTable(
   snapshot: VisualizationSnapshot,
   preview: ReportAiPreviewSummary | null,
 ): string {
-  const allRows =
-    preview === null ? alignedRows(snapshot) : previewRows(preview);
+  const source = nativeRowSource(snapshot, preview);
+  const allRows = source.rows;
   const rows = allRows.slice(0, MAX_NATIVE_ROWS);
   const extra = allRows.length - rows.length;
-  const previewExtra = hasPreviewRowsBeyondStoredRows(preview, allRows);
+  const previewExtra = hasPreviewRowsBeyondStoredRows(source.preview, allRows);
   const headers =
-    preview === null
+    source.preview === null
       ? ["", ...snapshot.series.map((series) => series.label)]
-      : preview.columns.map((column) => column.label);
-  const lines = [
-    headers.map((header) => escapeTableCell(header)).join("    "),
-    headers.map(() => "----").join("    "),
-    ...rows.map((row) =>
-      [
-        escapeTableCell(row.label),
-        ...(preview === null
-          ? snapshot.series.map((series) =>
-              escapeTableCell(
-                formatSeriesValue(
-                  snapshot,
-                  series,
-                  requireNumericRowValue(row, series.id),
-                ),
-              ),
-            )
-          : previewMetricColumns(preview).map((column) =>
-              escapeTableCell(
-                formatPreviewValue(column, requireRowValue(row, column.key)),
-              ),
-            )),
-      ].join("    "),
+      : source.preview.columns.map((column) => column.label);
+  const bodyRows = rows.map((row) => [
+    escapeTableCell(row.label),
+    ...(source.preview === null
+      ? snapshot.series.map((series) =>
+          escapeTableCell(
+            formatSeriesValue(
+              snapshot,
+              series,
+              requireNumericRowValue(row, series.id),
+            ),
+          ),
+        )
+      : previewMetricColumns(source.preview).map((column) =>
+          escapeTableCell(
+            formatPreviewValue(column, requireRowValue(row, column.key)),
+          ),
+        )),
+  ]);
+  const widths = headers.map((_, index) =>
+    Math.max(
+      headers[index]?.length ?? 0,
+      ...bodyRows.map((row) => row[index]?.length ?? 0),
     ),
+  );
+  const lines = [
+    formatTableRow(headers, widths),
+    formatTableRow(
+      widths.map((width) => "-".repeat(width)),
+      widths,
+    ),
+    ...bodyRows.map((row) => formatTableRow(row, widths)),
   ];
   if (extra > 0) {
     lines.push(`_…and ${extra.toString()} more rows_`);
@@ -257,6 +265,13 @@ function formatTable(
     lines.push("_…additional rows omitted from the stored preview_");
   }
   return lines.join("\n");
+}
+
+function formatTableRow(cells: string[], widths: number[]): string {
+  return cells
+    .map((cell, index) => cell.padEnd(widths[index] ?? cell.length))
+    .join("    ")
+    .trimEnd();
 }
 
 type NativeRowValue = string | number | null;
@@ -305,6 +320,19 @@ function previewRows(preview: ReportAiPreviewSummary): NativeRow[] {
     label: row.label,
     values: new Map(row.values.map((value) => [value.column, value.value])),
   }));
+}
+
+function nativeRowSource(
+  snapshot: VisualizationSnapshot,
+  preview: ReportAiPreviewSummary | null,
+): { rows: NativeRow[]; preview: ReportAiPreviewSummary | null } {
+  if (snapshot.temporal !== null) {
+    return { rows: alignedRows(snapshot), preview: null };
+  }
+  if (preview === null) {
+    return { rows: alignedRows(snapshot), preview: null };
+  }
+  return { rows: previewRows(preview), preview };
 }
 
 function hasPreviewRowsBeyondStoredRows(

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -314,31 +314,45 @@ function formatTableRow(cells: string[], widths: number[]): string {
     )
     .join("    ");
 }
-
 const graphemeSegmenter = new Intl.Segmenter(undefined, {
   granularity: "grapheme",
 });
-
 function displayWidth(value: string): number {
   let width = 0;
   for (const { segment } of graphemeSegmenter.segment(value)) {
-    for (const character of segment) {
-      const codePoint = character.codePointAt(0);
-      if (codePoint === undefined) {
-        continue;
-      }
-      if (
-        codePoint === 0x20_0d ||
-        /\p{Mark}/u.test(character) ||
-        (codePoint >= 0xfe_00 && codePoint <= 0xfe_0f)
-      ) {
-        continue;
-      }
-      width += isWideCodePoint(codePoint) ? 2 : 1;
-      break;
-    }
+    width += displayGraphemeWidth(segment);
   }
   return width;
+}
+function displayGraphemeWidth(segment: string): number {
+  let width = 0;
+  let regionalIndicatorCount = 0;
+  let hasKeycapMark = false;
+  for (const character of segment) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined) {
+      continue;
+    }
+    if (codePoint >= 0x1_f1_e6 && codePoint <= 0x1_f1_ff) {
+      regionalIndicatorCount += 1;
+      continue;
+    }
+    if (codePoint === 0x20_0d) {
+      continue;
+    }
+    if (codePoint === 0x20_e3) {
+      hasKeycapMark = true;
+      continue;
+    }
+    if (
+      /\p{Mark}/u.test(character) ||
+      (codePoint >= 0xfe_00 && codePoint <= 0xfe_0f)
+    ) {
+      continue;
+    }
+    width = Math.max(width, isWideCodePoint(codePoint) ? 2 : 1);
+  }
+  return hasKeycapMark || regionalIndicatorCount === 2 ? 2 : width;
 }
 
 function isWideCodePoint(codePoint: number): boolean {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -137,8 +137,24 @@ function truncateTableDescription(description: string): string {
     openingFence.length -
     closingFence.length -
     DESCRIPTION_TRUNCATION_SUFFIX.length;
-  const truncated = truncateLines(description, available);
+  const truncated = truncateTableLines(description, available);
   return `${openingFence}${truncated}${closingFence}${DESCRIPTION_TRUNCATION_SUFFIX}`;
+}
+
+function truncateTableLines(description: string, available: number): string {
+  const lines = description.split("\n");
+  const firstRows = lines.slice(0, 3);
+  const firstRowsLength = firstRows.reduce(
+    (total, line) => total + line.length,
+    firstRows.length - 1,
+  );
+  if (firstRows.length < 3 || firstRowsLength <= available) {
+    return truncateLines(description, available);
+  }
+  const lineBudget = Math.floor((available - 2) / 3);
+  return firstRows
+    .map((line) => truncateNativeCell(line, lineBudget))
+    .join("\n");
 }
 
 function truncateLines(description: string, available: number): string {

--- a/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/scout/visualization.ts
@@ -178,7 +178,11 @@ function formatKpi(snapshot: VisualizationSnapshot): string {
             snapshot,
             series,
             point.absoluteDelta ?? null,
-          )} · ${formatPercent(point.percentageDelta ?? null)}`
+          )} · ${
+            point.percentageDelta === null
+              ? "Unknown"
+              : `${(point.percentageDelta * 100).toFixed(1)}%`
+          }`
         : `n=${sampleSize.toString()}`;
       return `**${escapeMarkdown(series.label)}**\n${value} ${details}`;
     })
@@ -201,6 +205,7 @@ function formatList(
     source.preview,
     allRows,
     source.snapshotRows,
+    snapshot,
   );
   const lines = rows.map((row) => {
     const values = formatRowValues(snapshot, row, source.preview).join(", ");
@@ -226,6 +231,7 @@ function formatLeaderboard(
     source.preview,
     allRows,
     source.snapshotRows,
+    snapshot,
   );
   const lines = rows.map((row, index) => {
     const values = formatRowValues(snapshot, row, source.preview).join(" · ");
@@ -251,6 +257,7 @@ function formatTable(
     source.preview,
     allRows,
     source.snapshotRows,
+    snapshot,
   );
   const headers =
     source.preview === null
@@ -361,10 +368,7 @@ function nativeRowSource(
   snapshotRows: NativeRow[];
 } {
   const snapshotRows = alignedRows(snapshot);
-  if (snapshot.temporal !== null) {
-    return { rows: snapshotRows, preview: null, snapshotRows };
-  }
-  if (preview === null) {
+  if (preview === null || snapshot.temporal !== null) {
     return { rows: snapshotRows, preview: null, snapshotRows };
   }
   return { rows: previewRows(preview), preview, snapshotRows };
@@ -374,6 +378,7 @@ function hasPreviewRowsBeyondStoredRows(
   preview: ReportAiPreviewSummary | null,
   rows: NativeRow[],
   snapshotRows: NativeRow[],
+  snapshot: VisualizationSnapshot,
 ): boolean {
   if (preview === null) {
     return false;
@@ -381,10 +386,17 @@ function hasPreviewRowsBeyondStoredRows(
   if (preview.rowsReturned > rows.length) {
     return true;
   }
+  const hasCollapsedLegacyRows =
+    snapshot.series.some((series) => {
+      const separator = series.id.lastIndexOf(":");
+      return separator !== -1 && series.id.slice(0, separator) !== "All";
+    }) &&
+    snapshot.series.reduce((total, series) => total + series.points.length, 0) >
+      rows.length;
   return (
     preview.rowsReturned === 0 &&
     preview.visualizationRows.length === 0 &&
-    snapshotRows.length > rows.length
+    (snapshotRows.length > rows.length || hasCollapsedLegacyRows)
   );
 }
 
@@ -436,10 +448,7 @@ function formatPreviewValue(
   column: ReportAiPreviewSummary["columns"][number],
   value: NativeRowValue,
 ): string {
-  if (value === null) {
-    return "Unknown";
-  }
-  return formatReportDisplayValue(column, value);
+  return value === null ? "Unknown" : formatReportDisplayValue(column, value);
 }
 
 function formatSeriesValue(
@@ -471,14 +480,11 @@ function formatAbsoluteDelta(
     snapshot.display.stack === "percent" ||
     REPORT_METRICS.find((metric) => metric.id === series.metric)?.kind ===
       "rate";
-  if (isRate) {
-    return value === null ? "Unknown" : `${(value * 100).toFixed(1)} pp`;
-  }
-  return formatSeriesValue(snapshot, series, value);
-}
-
-function formatPercent(value: number | null): string {
-  return value === null ? "Unknown" : `${(value * 100).toFixed(1)}%`;
+  return isRate
+    ? value === null
+      ? "Unknown"
+      : `${(value * 100).toFixed(1)} pp`
+    : formatSeriesValue(snapshot, series, value);
 }
 
 function escapeMarkdown(value: string): string {

--- a/packages/scout-for-lol/packages/backend/src/explore/agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/agent.ts
@@ -1,4 +1,5 @@
 import { Output, stepCountIs, tool, ToolLoopAgent } from "ai";
+import { z } from "zod";
 import {
   EXPLORE_MAX_HISTORY_TURNS,
   EXPLORE_MAX_OUTPUT_TOKENS,
@@ -8,6 +9,8 @@ import {
   ExploreAnswerSchema,
   ExploreAnswerWireSchema,
   modelSupportsParameter,
+  ReportAiModelPreviewSummarySchema,
+  ReportQueryTextSchema,
   type ExploreAnswer,
   type ExploreMessage,
   type ExploreStreamEvent,
@@ -30,9 +33,9 @@ import {
 } from "#src/metrics/explore.ts";
 import {
   createFormatTool,
+  createLanguageTool,
   createValidateTool,
   QueryResultToolOutputSchema,
-  ScoutQlQueryToolInputSchema,
   validateQuery,
   type ToolTracker,
 } from "#src/reports/ai/scoutql-tools.ts";
@@ -201,7 +204,7 @@ function createExploreTools(params: ExploreAgentParams, state: RunState) {
   const runReportQuery = tool({
     description:
       "Run a valid ScoutQL query against all ingested match data and return the resulting rows. Every statistic you state must come from a result of this tool.",
-    inputSchema: ScoutQlQueryToolInputSchema,
+    inputSchema: z.object({ queryText: ReportQueryTextSchema }).strict(),
     outputSchema: QueryResultToolOutputSchema,
     execute: (inputData) =>
       track("run_report_query", async () => {
@@ -225,6 +228,7 @@ function createExploreTools(params: ExploreAgentParams, state: RunState) {
           queryText: validation.formattedQueryText,
         });
         const preview = reportQueryPreviewSummary(result);
+        const modelPreview = ReportAiModelPreviewSummarySchema.parse(preview);
         state.lastPreview = preview;
         state.lastVisualization = result.visualization ?? null;
 
@@ -240,12 +244,13 @@ function createExploreTools(params: ExploreAgentParams, state: RunState) {
               ? `No rows matched after scanning ${preview.rowsScanned.toString()} rows. The data does not cover this — say so rather than estimating.`
               : `Returned ${preview.rowsReturned.toString()} rows after scanning ${preview.rowsScanned.toString()} rows.`,
           formattedQueryText: validation.formattedQueryText,
-          preview,
+          preview: modelPreview,
         };
       }),
   });
 
   return {
+    get_report_language: createLanguageTool(track),
     validate_report_query: createValidateTool(track),
     run_report_query: runReportQuery,
     format_report_query: createFormatTool(track),

--- a/packages/scout-for-lol/packages/backend/src/explore/agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/agent.ts
@@ -236,9 +236,9 @@ function createExploreTools(params: ExploreAgentParams, state: RunState) {
         return {
           ok: true,
           message:
-            preview.rows.length === 0
+            preview.rowsReturned === 0
               ? `No rows matched after scanning ${preview.rowsScanned.toString()} rows. The data does not cover this — say so rather than estimating.`
-              : `Returned ${preview.rows.length.toString()} rows after scanning ${preview.rowsScanned.toString()} rows.`,
+              : `Returned ${preview.rowsReturned.toString()} rows after scanning ${preview.rowsScanned.toString()} rows.`,
           formattedQueryText: validation.formattedQueryText,
           preview,
         };

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { ReportAiModelPreviewSummarySchema } from "@scout-for-lol/data";
+import { inspectExploreToolResult } from "#src/explore/tool-inspection.ts";
+
+test("records the total query row count in Explore trace details", () => {
+  const preview = ReportAiModelPreviewSummarySchema.parse({
+    columns: [{ key: "games", label: "Games", format: "integer" }],
+    rows: Array.from({ length: 10 }, (_, index) => ({
+      label: `Row ${index.toString()}`,
+      values: [{ column: "games", value: index }],
+    })),
+    rowsReturned: 11,
+    rowsScanned: 42,
+    renderKind: "TABLE",
+  });
+
+  const inspection = inspectExploreToolResult(
+    "run_report_query",
+    { queryText: "FROM matches SELECT games" },
+    {
+      ok: true,
+      message: "Returned 11 rows.",
+      formattedQueryText: "FROM matches SELECT games",
+      preview,
+    },
+  );
+
+  expect(inspection.details).toEqual({
+    kind: "execution",
+    queryText: "FROM matches SELECT games",
+    ok: true,
+    rowsReturned: 11,
+    rowsScanned: 42,
+    renderKind: "TABLE",
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
@@ -129,7 +129,7 @@ export function inspectExploreToolResult(
         kind: "execution",
         queryText: parsedInput.queryText,
         ok: parsedOutput.ok,
-        rowsReturned: parsedOutput.preview?.rows.length ?? null,
+        rowsReturned: parsedOutput.preview?.rowsReturned ?? null,
         rowsScanned: parsedOutput.preview?.rowsScanned ?? null,
         renderKind: parsedOutput.preview?.renderKind ?? null,
       },

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent.ts
@@ -9,6 +9,7 @@ import {
   REPORT_AI_MAX_STEPS,
   REPORT_AI_MAX_TOOL_CALLS,
   modelSupportsParameter,
+  ReportAiModelPreviewSummarySchema,
   ReportQueryTextSchema,
   type ReportAiEditRequest,
   type ReportAiFinalDraft,
@@ -192,13 +193,14 @@ function createReportQueryTools(params: ReportQueryAgentParams) {
             inputData.sourceCompetitionId ?? params.input.sourceCompetitionId,
         });
         const preview = reportQueryPreviewSummary(result);
+        const modelPreview = ReportAiModelPreviewSummarySchema.parse(preview);
 
         await params.emit({ type: "preview", preview });
         return {
           ok: true,
           message: `Preview returned ${preview.rowsReturned.toString()} rows after scanning ${preview.rowsScanned.toString()} rows.`,
           formattedQueryText: validation.formattedQueryText,
-          preview,
+          preview: modelPreview,
         };
       }),
   });

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent.ts
@@ -196,7 +196,7 @@ function createReportQueryTools(params: ReportQueryAgentParams) {
         await params.emit({ type: "preview", preview });
         return {
           ok: true,
-          message: `Preview returned ${preview.rows.length.toString()} rows after scanning ${preview.rowsScanned.toString()} rows.`,
+          message: `Preview returned ${preview.rowsReturned.toString()} rows after scanning ${preview.rowsScanned.toString()} rows.`,
           formattedQueryText: validation.formattedQueryText,
           preview,
         };

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.test.ts
@@ -36,5 +36,34 @@ describe("reportQueryPreviewSummary", () => {
         values: [{ column: "games", value: null }],
       },
     ]);
+    expect(reportQueryPreviewSummary(result).visualizationRows).toEqual([
+      {
+        label: "All",
+        values: [{ column: "games", value: null }],
+      },
+    ]);
+    expect(reportQueryPreviewSummary(result).rowsReturned).toBe(1);
+  });
+
+  test("keeps enough rows for frozen Discord visualizations", () => {
+    const result: ReportQueryResult = {
+      plan: parseAndCompile(
+        "SELECT games FROM match_participants GROUP BY champion LIMIT 25 RENDER table",
+      ),
+      columns: ["games"],
+      rows: Array.from({ length: 13 }, (_, index) => ({
+        label: `Champion ${index.toString()}`,
+        dimensions: [],
+        mentionIdentity: null,
+        values: [{ column: "games", value: index }],
+      })),
+      rowsScanned: 13,
+    };
+
+    const preview = reportQueryPreviewSummary(result);
+    expect(preview.rows).toHaveLength(10);
+    expect(preview.visualizationRows).toHaveLength(12);
+    expect(preview.rowsReturned).toBe(13);
+    expect(preview.visualizationRows.at(-1)?.label).toBe("Champion 11");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { parseAndCompile } from "@scout-for-lol/data";
+import {
+  parseAndCompile,
+  ReportAiModelPreviewSummarySchema,
+} from "@scout-for-lol/data";
 import { reportQueryPreviewSummary } from "#src/reports/ai/report-query-preview-summary.ts";
 import type { ReportQueryResult } from "#src/reports/query-engine.ts";
 
@@ -65,5 +68,8 @@ describe("reportQueryPreviewSummary", () => {
     expect(preview.visualizationRows).toHaveLength(12);
     expect(preview.rowsReturned).toBe(13);
     expect(preview.visualizationRows.at(-1)?.label).toBe("Champion 11");
+    expect(ReportAiModelPreviewSummarySchema.parse(preview)).not.toHaveProperty(
+      "visualizationRows",
+    );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.ts
@@ -1,5 +1,6 @@
 import {
   REPORT_AI_PREVIEW_MAX_ROWS,
+  REPORT_VISUALIZATION_PREVIEW_MAX_ROWS,
   reportResultColumns,
   ReportAiPreviewSummarySchema,
   type ReportAiPreviewSummary,
@@ -18,6 +19,16 @@ export function reportQueryPreviewSummary(
         value: value.value,
       })),
     })),
+    visualizationRows: result.rows
+      .slice(0, REPORT_VISUALIZATION_PREVIEW_MAX_ROWS)
+      .map((row) => ({
+        label: row.label,
+        values: row.values.map((value) => ({
+          column: value.column,
+          value: value.value,
+        })),
+      })),
+    rowsReturned: result.rows.length,
     rowsScanned: result.rowsScanned,
     renderKind: result.plan.render.kind,
   });

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/scoutql-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/scoutql-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import {
-  ReportAiPreviewSummarySchema,
+  ReportAiModelPreviewSummarySchema,
   formatReportQuery,
   lintReportQuery,
   parseAndCompile,
@@ -63,7 +63,7 @@ export const QueryResultToolOutputSchema = z
     ok: z.boolean(),
     message: z.string(),
     formattedQueryText: z.string().nullable(),
-    preview: ReportAiPreviewSummarySchema.nullable(),
+    preview: ReportAiModelPreviewSummarySchema.nullable(),
   })
   .strict();
 

--- a/packages/scout-for-lol/packages/data/src/model/report-ai.ts
+++ b/packages/scout-for-lol/packages/data/src/model/report-ai.ts
@@ -168,6 +168,13 @@ export type ReportAiPreviewSummary = z.infer<
   typeof ReportAiPreviewSummarySchema
 >;
 
+export const ReportAiModelPreviewSummarySchema =
+  ReportAiPreviewSummarySchema.omit({ visualizationRows: true }).strip();
+
+export type ReportAiModelPreviewSummary = z.infer<
+  typeof ReportAiModelPreviewSummarySchema
+>;
+
 export const ReportAiStreamEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("started"), runId: z.uuid() }).strict(),
   z

--- a/packages/scout-for-lol/packages/data/src/model/report-ai.ts
+++ b/packages/scout-for-lol/packages/data/src/model/report-ai.ts
@@ -12,6 +12,7 @@ export const REPORT_AI_MAX_STEPS = 10;
 export const REPORT_AI_MAX_TOOL_CALLS = 30;
 export const REPORT_AI_MAX_PREVIEW_CALLS = 10;
 export const REPORT_AI_PREVIEW_MAX_ROWS = 10;
+export const REPORT_VISUALIZATION_PREVIEW_MAX_ROWS = 12;
 export const REPORT_AI_TIMEOUT_MS = 180_000;
 export const REPORT_AI_MAX_OUTPUT_TOKENS = 4000;
 export const REPORT_AI_DEFAULT_WEEKLY_LIMIT = 30;
@@ -122,6 +123,20 @@ export const ReportResultColumnSchema = z
   .strict();
 export type ReportResultColumn = z.infer<typeof ReportResultColumnSchema>;
 
+const ReportAiPreviewRowSchema = z
+  .object({
+    label: z.string(),
+    values: z.array(
+      z
+        .object({
+          column: z.string(),
+          value: z.union([z.string(), z.number(), z.null()]),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
 export const ReportAiEditStatusSchema = z
   .object({
     enabled: z.boolean(),
@@ -138,23 +153,12 @@ export type ReportAiEditStatus = z.infer<typeof ReportAiEditStatusSchema>;
 export const ReportAiPreviewSummarySchema = z
   .object({
     columns: z.array(ReportResultColumnSchema).max(20),
-    rows: z
-      .array(
-        z
-          .object({
-            label: z.string(),
-            values: z.array(
-              z
-                .object({
-                  column: z.string(),
-                  value: z.union([z.string(), z.number(), z.null()]),
-                })
-                .strict(),
-            ),
-          })
-          .strict(),
-      )
-      .max(REPORT_AI_PREVIEW_MAX_ROWS),
+    rows: z.array(ReportAiPreviewRowSchema).max(REPORT_AI_PREVIEW_MAX_ROWS),
+    visualizationRows: z
+      .array(ReportAiPreviewRowSchema)
+      .max(REPORT_VISUALIZATION_PREVIEW_MAX_ROWS)
+      .default([]),
+    rowsReturned: z.number().int().nonnegative().default(0),
     rowsScanned: z.number().int().nonnegative(),
     renderKind: ReportOutputFormatSchema,
   })

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/discord-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/discord-commands.md
@@ -100,12 +100,14 @@ in servers listed by the operator-managed Explore allowlist and does not work in
 direct messages.
 
 Each invocation starts a **new saved Explore conversation** owned by the Discord
-user who ran it. The answer is initially private and can include caveats and a
-generated chart. Two buttons are shown:
+user who ran it. The answer is initially private and can include caveats plus
+the last result: a Discord table, leaderboard, or KPI card for those kinds, or
+a generated chart image for everything else. Two buttons are shown:
 
 - **Open in Explore** opens the saved conversation in the stage-correct web app.
-- **Post publicly** copies the stored question, answer, caveats, and chart into
-  the channel, then changes to **Posted**.
+- **Post publicly** copies the stored question, answer, caveats, and that same
+  table, leaderboard, KPI card, or chart into the channel, then changes to
+  **Posted**.
 
 Publishing uses the frozen saved result. It does not run the model or ScoutQL
 again, does not create a public Explore share link, and does not include the raw


### PR DESCRIPTION
## Why

Beta `/scout ask` mostly produced TABLE, LEADERBOARD, or KPI_CARD results, then attached them as a 1600×900 `scout-explore.png`. Those kinds are text widgets. The PNG sat next to prose that already had the numbers and looked like a spreadsheet screenshot.

## What

- Tables, lists, leaderboards, and KPI cards render as Discord embeds (markdown table, numbered list, titled value).
- Bar/line/stacked and other chart kinds still attach `scout-explore.png`.
- Private `/scout ask` replies and **Post publicly** share this payload.
- Native tables cap at 12 rows (then “and N more”).
- Docs updated for the command reference.

## Verification

- `bunx turbo run test --filter=@scout-for-lol/backend -- --bail src/discord/scout/visualization.test.ts src/discord/scout/messages.test.ts src/discord/scout/publish.integration.test.ts src/discord/commands/scout.integration.test.ts`
- ESLint on the touched Discord scout files
- Posted the three embed payloads as Scout (beta) in Glitter `#blitter-goys`; Discord stored title + description for each; test messages were deleted
- Did not run a live `/scout ask` on this branch (beta is not serving it)