### PR TITLE
feat(quotabar): show weekly pacing against an even split

### DIFF
--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
@@ -60,6 +60,23 @@ import SwiftUI
   )
 }
 
+#Preview("Weekly pacing") {
+  OverviewPreview(
+    states: PreviewData.states([
+      .claudeCode: .available(
+        PreviewData.snapshot(.claudeCode, remaining: 20, resetsInDays: 3)
+      ),
+      .codex: .available(
+        PreviewData.snapshot(.codex, remaining: 60, resetsInDays: 3)
+      ),
+      .kimi: .available(
+        PreviewData.snapshot(.kimi, remaining: 49, resetsInDays: 3)
+      ),
+      .grok: .disabled,
+    ])
+  )
+}
+
 #Preview("Dark appearance") {
   OverviewPreview(
     states: PreviewData.states([
@@ -109,6 +126,16 @@ private enum PreviewData {
     UsageSnapshot(
       provider: provider,
       windows: [window(label: "Weekly", remaining: remaining)],
+      sourceTimestamp: now
+    )
+  }
+
+  static func snapshot(_ provider: ProviderID, remaining: Double, resetsInDays: Double)
+    -> UsageSnapshot
+  {
+    UsageSnapshot(
+      provider: provider,
+      windows: [window(label: "Weekly", remaining: remaining, resetsInDays: resetsInDays)],
       sourceTimestamp: now
     )
   }
@@ -232,7 +259,8 @@ private enum PreviewData {
   private static func window(
     label: String,
     remaining: Double?,
-    kind: WindowKind = .weekly
+    kind: WindowKind = .weekly,
+    resetsInDays: Double = 1
   ) -> UsageWindow {
     do {
       return try UsageWindow.validated(
@@ -240,7 +268,7 @@ private enum PreviewData {
         label: label,
         kind: kind,
         usedPercent: remaining.map { 100 - $0 },
-        resetAt: kind == .entitlement ? nil : now.addingTimeInterval(86_400),
+        resetAt: kind == .entitlement ? nil : now.addingTimeInterval(resetsInDays * 86_400),
         sourceTimestamp: now
       )
     } catch {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
@@ -191,19 +191,25 @@ struct WindowRow: View {
   }
 
   private var quotaRow: some View {
-    HStack(spacing: 7) {
-      Text(window.compactDisplayLabel)
-        .lineLimit(1)
-        .help(window.label)
-        .frame(width: 96, alignment: .leading)
-      progress
-        .frame(width: 82)
-      Text(remainingText)
-        .monospacedDigit()
-        .frame(width: 40, alignment: .trailing)
-      resetText
-        .monospacedDigit()
-        .frame(maxWidth: .infinity, alignment: .trailing)
+    VStack(alignment: .leading, spacing: 2) {
+      HStack(spacing: 7) {
+        Text(window.compactDisplayLabel)
+          .lineLimit(1)
+          .help(window.label)
+          .frame(width: 96, alignment: .leading)
+        progress
+          .frame(width: 82)
+        Text(remainingText)
+          .monospacedDigit()
+          .frame(width: 40, alignment: .trailing)
+        resetText
+          .monospacedDigit()
+          .frame(maxWidth: .infinity, alignment: .trailing)
+      }
+      if let pacing = WindowPacing.compute(window: window, at: date) {
+        pacingCaption(pacing)
+          .padding(.leading, 103)
+      }
     }
     .font(.caption)
     .foregroundStyle(stale ? .secondary : .primary)
@@ -211,6 +217,32 @@ struct WindowRow: View {
     .accessibilityElement(children: .ignore)
     .accessibilityLabel("\(window.compactDisplayLabel), raw label \(window.label)")
     .accessibilityValue(accessibilityValue)
+  }
+
+  private func pacingCaption(_ pacing: WindowPacing) -> some View {
+    Text(
+      "pace \(WindowPacing.format(pacing.actualPacePerDay)) · even \(WindowPacing.format(pacing.evenPacePerDay))"
+    )
+    .font(.caption2)
+    .monospacedDigit()
+    .foregroundStyle(stale ? .secondary : pacingColor(for: pacing.status))
+    .help(pacingHelp(pacing))
+    .accessibilityHidden(true)
+  }
+
+  private func pacingHelp(_ pacing: WindowPacing) -> String {
+    let days = String(format: "%.1f", pacing.daysRemaining)
+    return "You have \(remainingText) left with \(days) days to go: "
+      + "\(WindowPacing.format(pacing.actualPacePerDay)) available per day vs "
+      + "\(WindowPacing.format(pacing.evenPacePerDay)) at an even split."
+  }
+
+  private func pacingColor(for status: WindowPacing.Status) -> Color {
+    switch status {
+    case .ahead: return Color(red: 0.24, green: 0.55, blue: 0.36)
+    case .onPace: return .secondary
+    case .behind: return .orange
+    }
   }
 
   private var entitlementRow: some View {
@@ -271,6 +303,11 @@ struct WindowRow: View {
     if stale { values.append("stale") }
     if let resetAt = window.resetAt {
       values.append("resets \(resetAt.formatted(date: .abbreviated, time: .shortened))")
+    }
+    if let pacing = WindowPacing.compute(window: window, at: date) {
+      values.append(
+        "pace \(WindowPacing.format(pacing.actualPacePerDay)), even split \(WindowPacing.format(pacing.evenPacePerDay))"
+      )
     }
     return values.joined(separator: ", ")
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
@@ -206,7 +206,7 @@ struct WindowRow: View {
           .monospacedDigit()
           .frame(maxWidth: .infinity, alignment: .trailing)
       }
-      if let pacing = WindowPacing.compute(window: window, at: date) {
+      if let pacing = WindowPacing.compute(window: window, at: pacingDate) {
         pacingCaption(pacing)
           .padding(.leading, 103)
       }
@@ -303,6 +303,10 @@ struct WindowRow: View {
     return "\(Int(remaining.rounded()))%"
   }
 
+  private var pacingDate: Date {
+    stale ? window.sourceTimestamp : date
+  }
+
   private var accessibilityValue: String {
     var values: [String] = []
     if let remaining = window.remainingPercent {
@@ -314,7 +318,7 @@ struct WindowRow: View {
     if let resetAt = window.resetAt {
       values.append("resets \(resetAt.formatted(date: .abbreviated, time: .shortened))")
     }
-    if let pacing = WindowPacing.compute(window: window, at: date) {
+    if let pacing = WindowPacing.compute(window: window, at: pacingDate) {
       let label = pacingStatusLabel(pacing.status)
       let actual = WindowPacing.format(pacing.actualPacePerDay)
       let even = WindowPacing.format(pacing.evenPacePerDay)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
@@ -220,19 +220,29 @@ struct WindowRow: View {
   }
 
   private func pacingCaption(_ pacing: WindowPacing) -> some View {
-    Text(
-      "pace \(WindowPacing.format(pacing.actualPacePerDay)) · even \(WindowPacing.format(pacing.evenPacePerDay))"
-    )
-    .font(.caption2)
-    .monospacedDigit()
-    .foregroundStyle(stale ? .secondary : pacingColor(for: pacing.status))
-    .help(pacingHelp(pacing))
-    .accessibilityHidden(true)
+    let label = pacingStatusLabel(pacing.status)
+    let actual = WindowPacing.format(pacing.actualPacePerDay)
+    let even = WindowPacing.format(pacing.evenPacePerDay)
+    return Text("\(label) · pace \(actual) · even \(even)")
+      .font(.caption2)
+      .monospacedDigit()
+      .foregroundStyle(stale ? .secondary : pacingColor(for: pacing.status))
+      .help(pacingHelp(pacing))
+      .accessibilityHidden(true)
+  }
+
+  private func pacingStatusLabel(_ status: WindowPacing.Status) -> String {
+    switch status {
+    case .ahead: return "ahead"
+    case .onPace: return "on pace"
+    case .behind: return "behind"
+    }
   }
 
   private func pacingHelp(_ pacing: WindowPacing) -> String {
     let days = String(format: "%.1f", pacing.daysRemaining)
-    return "You have \(remainingText) left with \(days) days to go: "
+    return "You are \(pacingStatusLabel(pacing.status)) of an even split: "
+      + "you have \(remainingText) left with \(days) days to go, or "
       + "\(WindowPacing.format(pacing.actualPacePerDay)) available per day vs "
       + "\(WindowPacing.format(pacing.evenPacePerDay)) at an even split."
   }
@@ -305,9 +315,10 @@ struct WindowRow: View {
       values.append("resets \(resetAt.formatted(date: .abbreviated, time: .shortened))")
     }
     if let pacing = WindowPacing.compute(window: window, at: date) {
-      values.append(
-        "pace \(WindowPacing.format(pacing.actualPacePerDay)), even split \(WindowPacing.format(pacing.evenPacePerDay))"
-      )
+      let label = pacingStatusLabel(pacing.status)
+      let actual = WindowPacing.format(pacing.actualPacePerDay)
+      let even = WindowPacing.format(pacing.evenPacePerDay)
+      values.append("\(label), pace \(actual), even split \(even)")
     }
     return values.joined(separator: ", ")
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Pacing.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Pacing.swift
@@ -1,0 +1,53 @@
+public import Foundation
+
+public struct WindowPacing: Equatable, Sendable {
+  public enum Status: Equatable, Sendable {
+    case ahead
+    case onPace
+    case behind
+  }
+
+  public static let weeklyDurationSeconds: TimeInterval = 7 * 86_400
+  private static let onPaceTolerance = 0.15
+
+  public let evenPacePerDay: Double
+  public let actualPacePerDay: Double
+  public let daysRemaining: Double
+  public let status: Status
+
+  public static func compute(window: UsageWindow, at date: Date) -> WindowPacing? {
+    guard window.kind == .weekly,
+      let remaining = window.remainingPercent,
+      let resetAt = window.resetAt
+    else {
+      return nil
+    }
+    let secondsRemaining = resetAt.timeIntervalSince(date)
+    guard secondsRemaining.isFinite, secondsRemaining > 0,
+      secondsRemaining <= weeklyDurationSeconds
+    else {
+      return nil
+    }
+    let daysRemaining = secondsRemaining / 86_400
+    let evenPace = 100 / (weeklyDurationSeconds / 86_400)
+    let actualPace = remaining / daysRemaining
+    let status: Status
+    if actualPace <= evenPace {
+      status = .ahead
+    } else if actualPace <= evenPace * (1 + onPaceTolerance) {
+      status = .onPace
+    } else {
+      status = .behind
+    }
+    return WindowPacing(
+      evenPacePerDay: evenPace,
+      actualPacePerDay: actualPace,
+      daysRemaining: daysRemaining,
+      status: status
+    )
+  }
+
+  public static func format(_ pacePerDay: Double) -> String {
+    String(format: "%.1f%%/d", locale: Locale(identifier: "en_US_POSIX"), pacePerDay)
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Pacing.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Pacing.swift
@@ -32,12 +32,12 @@ public struct WindowPacing: Equatable, Sendable {
     let evenPace = 100 / (weeklyDurationSeconds / 86_400)
     let actualPace = remaining / daysRemaining
     let status: Status
-    if actualPace <= evenPace {
+    if actualPace >= evenPace * (1 + onPaceTolerance) {
       status = .ahead
-    } else if actualPace <= evenPace * (1 + onPaceTolerance) {
-      status = .onPace
-    } else {
+    } else if actualPace <= evenPace * (1 - onPaceTolerance) {
       status = .behind
+    } else {
+      status = .onPace
     }
     return WindowPacing(
       evenPacePerDay: evenPace,

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PacingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PacingTests.swift
@@ -16,7 +16,7 @@ final class PacingTests: XCTestCase {
     XCTAssertEqual(pacing.daysRemaining, 3, accuracy: 0.001)
     XCTAssertEqual(pacing.evenPacePerDay, 100.0 / 7.0, accuracy: 0.0001)
     XCTAssertEqual(pacing.actualPacePerDay, 20.0 / 3.0, accuracy: 0.001)
-    XCTAssertEqual(pacing.status, .ahead)
+    XCTAssertEqual(pacing.status, .behind)
   }
 
   func testEvenSplitIsOnPace() throws {
@@ -27,10 +27,10 @@ final class PacingTests: XCTestCase {
       )
     )
     XCTAssertEqual(pacing.actualPacePerDay, pacing.evenPacePerDay, accuracy: 0.0001)
-    XCTAssertEqual(pacing.status, .ahead)
+    XCTAssertEqual(pacing.status, .onPace)
   }
 
-  func testSlightlyFasterThanEvenIsOnPace() throws {
+  func testSlightlySlowerThanEvenIsOnPace() throws {
     let pacing = try XCTUnwrap(
       WindowPacing.compute(
         window: window(remaining: 49, resetAt: now.addingTimeInterval(3 * 86_400)),
@@ -40,7 +40,7 @@ final class PacingTests: XCTestCase {
     XCTAssertEqual(pacing.status, .onPace)
   }
 
-  func testBurningTooFastIsBehind() throws {
+  func testBurningTooSlowIsAhead() throws {
     let pacing = try XCTUnwrap(
       WindowPacing.compute(
         window: window(remaining: 30, resetAt: now.addingTimeInterval(86_400)),
@@ -48,7 +48,7 @@ final class PacingTests: XCTestCase {
       )
     )
     XCTAssertEqual(pacing.actualPacePerDay, 30, accuracy: 0.001)
-    XCTAssertEqual(pacing.status, .behind)
+    XCTAssertEqual(pacing.status, .ahead)
   }
 
   func testNonWeeklyWindowIsSkipped() throws {
@@ -108,14 +108,14 @@ final class PacingTests: XCTestCase {
   }
 
   func testRealWeeklyFixtureWindowsProducePacing() throws {
+    let fixtureNow = date("2026-08-12T00:00:00Z")
     let data = fixture("claude-success")
-    let snapshot = try ClaudeCodeProvider.parse(data: data, now: now)
+    let snapshot = try ClaudeCodeProvider.parse(data: data, now: fixtureNow)
     let weekly = snapshot.windows.filter { $0.kind == .weekly }
     XCTAssertFalse(weekly.isEmpty)
     for window in weekly {
-      if let pacing = WindowPacing.compute(window: window, at: now) {
-        XCTAssertEqual(pacing.evenPacePerDay, 100.0 / 7.0, accuracy: 0.0001)
-      }
+      let pacing = try XCTUnwrap(WindowPacing.compute(window: window, at: fixtureNow))
+      XCTAssertEqual(pacing.evenPacePerDay, 100.0 / 7.0, accuracy: 0.0001)
     }
   }
 }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PacingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PacingTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class PacingTests: XCTestCase {
+  private let now = date("2026-08-19T00:00:00Z")
+
+  func testEvenSplitExampleFromRequest() throws {
+    let pacing = try XCTUnwrap(
+      WindowPacing.compute(
+        window: window(remaining: 20, resetAt: now.addingTimeInterval(3 * 86_400)),
+        at: now
+      )
+    )
+    XCTAssertEqual(pacing.daysRemaining, 3, accuracy: 0.001)
+    XCTAssertEqual(pacing.evenPacePerDay, 100.0 / 7.0, accuracy: 0.0001)
+    XCTAssertEqual(pacing.actualPacePerDay, 20.0 / 3.0, accuracy: 0.001)
+    XCTAssertEqual(pacing.status, .ahead)
+  }
+
+  func testEvenSplitIsOnPace() throws {
+    let pacing = try XCTUnwrap(
+      WindowPacing.compute(
+        window: window(remaining: 50, resetAt: now.addingTimeInterval(3.5 * 86_400)),
+        at: now
+      )
+    )
+    XCTAssertEqual(pacing.actualPacePerDay, pacing.evenPacePerDay, accuracy: 0.0001)
+    XCTAssertEqual(pacing.status, .ahead)
+  }
+
+  func testSlightlyFasterThanEvenIsOnPace() throws {
+    let pacing = try XCTUnwrap(
+      WindowPacing.compute(
+        window: window(remaining: 49, resetAt: now.addingTimeInterval(3 * 86_400)),
+        at: now
+      )
+    )
+    XCTAssertEqual(pacing.status, .onPace)
+  }
+
+  func testBurningTooFastIsBehind() throws {
+    let pacing = try XCTUnwrap(
+      WindowPacing.compute(
+        window: window(remaining: 30, resetAt: now.addingTimeInterval(86_400)),
+        at: now
+      )
+    )
+    XCTAssertEqual(pacing.actualPacePerDay, 30, accuracy: 0.001)
+    XCTAssertEqual(pacing.status, .behind)
+  }
+
+  func testNonWeeklyWindowIsSkipped() throws {
+    let rolling = try UsageWindow.validated(
+      id: "five-hour",
+      label: "5-hour",
+      kind: .rolling(durationSeconds: 18_000),
+      usedPercent: 40,
+      resetAt: now.addingTimeInterval(7_200),
+      sourceTimestamp: now
+    )
+    XCTAssertNil(WindowPacing.compute(window: rolling, at: now))
+  }
+
+  func testModelScopedWeeklyIsSkipped() throws {
+    let scoped = try UsageWindow.validated(
+      id: "weekly-fable",
+      label: "Weekly · Fable",
+      kind: .modelScoped(model: "Fable"),
+      usedPercent: 40,
+      resetAt: now.addingTimeInterval(3 * 86_400),
+      sourceTimestamp: now
+    )
+    XCTAssertNil(WindowPacing.compute(window: scoped, at: now))
+  }
+
+  func testMissingResetOrUsageIsSkipped() {
+    XCTAssertNil(
+      WindowPacing.compute(window: window(remaining: 40, resetAt: nil), at: now)
+    )
+    XCTAssertNil(
+      WindowPacing.compute(
+        window: window(remaining: nil, resetAt: now.addingTimeInterval(86_400)),
+        at: now
+      )
+    )
+  }
+
+  func testPastOrDistantResetIsSkipped() {
+    XCTAssertNil(
+      WindowPacing.compute(
+        window: window(remaining: 40, resetAt: now.addingTimeInterval(-60)),
+        at: now
+      )
+    )
+    XCTAssertNil(
+      WindowPacing.compute(
+        window: window(remaining: 40, resetAt: now.addingTimeInterval(30 * 86_400)),
+        at: now
+      )
+    )
+  }
+
+  func testFormat() {
+    XCTAssertEqual(WindowPacing.format(100.0 / 7.0), "14.3%/d")
+    XCTAssertEqual(WindowPacing.format(20.0 / 3.0), "6.7%/d")
+  }
+
+  func testRealWeeklyFixtureWindowsProducePacing() throws {
+    let data = fixture("claude-success")
+    let snapshot = try ClaudeCodeProvider.parse(data: data, now: now)
+    let weekly = snapshot.windows.filter { $0.kind == .weekly }
+    XCTAssertFalse(weekly.isEmpty)
+    for window in weekly {
+      if let pacing = WindowPacing.compute(window: window, at: now) {
+        XCTAssertEqual(pacing.evenPacePerDay, 100.0 / 7.0, accuracy: 0.0001)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Why: With a weekly quota, the raw remaining percent does not say whether you are burning faster or slower than an even split across the week. Seeing both paces makes it obvious at a glance.

What: Add WindowPacing in QuotaBarCore, computed only for overall weekly windows with a valid resetAt and usedPercent: even pace (100/7 per day) and actual pace (remaining% / days left), classified ahead / on pace (+/-15%) / behind. WindowRow renders a caption line under weekly rows ("pace 6.7%/d · even 14.3%/d") tinted by status, with an explanatory tooltip and accessibility value. Includes a new Previews state and PacingTests covering the request example, boundaries, and edge cases.

Verification: bun run test:macos (113 pass), bun run format:check, bun run lint:swift, bun run build:macos in packages/macos-ai-subscription-tracker. Not run: full bun run verify (Buildkite gate).