### PR TITLE
fix(temporal): keep Glitter Luna chunk repairs after parse exhaustion

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -86,9 +86,11 @@ daily capture; you do not trigger it.
 action. It distills the corpus into per-person context and opens a PR that is
 always human-reviewed.
 
-It carries a hard cost cap (default $40) enforced by a preflight estimate, a
-per-call authorization check, and a post-call ceiling check. A completion that
-returns without usage data fails non-retryably rather than risk re-charging.
+The weekly schedule passes a $40 uncached-cost kill switch. Operator
+invocations that omit `maxEstimatedCostUsd` still default to $10. A
+preflight estimate, per-call authorization, and post-call ceiling enforce
+the cap. A completion that returns without usage data fails non-retryably
+rather than risk re-charging.
 
 ## Related
 

--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -86,7 +86,7 @@ daily capture; you do not trigger it.
 action. It distills the corpus into per-person context and opens a PR that is
 always human-reviewed.
 
-It carries a hard cost cap (default $100) enforced by a preflight estimate, a
+It carries a hard cost cap (default $40) enforced by a preflight estimate, a
 per-call authorization check, and a post-call ceiling check. A completion that
 returns without usage data fails non-retryably rather than risk re-charging.
 

--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -86,7 +86,7 @@ daily capture; you do not trigger it.
 action. It distills the corpus into per-person context and opens a PR that is
 always human-reviewed.
 
-It carries a hard cost cap (default $10) enforced by a preflight estimate, a
+It carries a hard cost cap (default $100) enforced by a preflight estimate, a
 per-call authorization check, and a post-call ceiling check. A completion that
 returns without usage data fails non-retryably rather than risk re-charging.
 

--- a/packages/temporal/src/activities/glitter-context-refresh-llm.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-llm.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { GenerationBudget } from "./glitter-context-refresh-budget.ts";
+import {
+  readGlitterObjectArtifact,
+  useGlitterObjectArtifact,
+} from "./glitter-context-refresh-llm.ts";
+import type { GenerationArtifactResult } from "./glitter-context-refresh-cache.ts";
+
+const requestSha256 = "a".repeat(64);
+
+function artifact(
+  response:
+    | { outcome: "success"; value: { ok: true } }
+    | { outcome: "failure"; error: string; rawContent: string | null },
+): GenerationArtifactResult<typeof response> {
+  return {
+    response,
+    key: "artifact",
+    requestSha256,
+    cacheStatus: "hit",
+    billedToCurrentRun: false,
+    usage: {
+      inputTokens: 1,
+      outputTokens: 1,
+      cachedInputTokens: 0,
+      costUsd: 0,
+    },
+  };
+}
+
+describe("glitter object artifacts", () => {
+  test("readGlitterObjectArtifact records a cached parse failure without throwing", () => {
+    const budget = new GenerationBudget(1);
+    const response = readGlitterObjectArtifact({
+      artifact: artifact({
+        outcome: "failure",
+        error: "GPT-5.6 Luna did not return a parsed summary for 2023-03-0000",
+        rawContent: null,
+      }),
+      budget,
+    });
+    expect(response).toEqual({
+      outcome: "failure",
+      error: "GPT-5.6 Luna did not return a parsed summary for 2023-03-0000",
+      rawContent: null,
+    });
+    expect(budget.summary().cacheHits).toBe(1);
+  });
+
+  test("useGlitterObjectArtifact still fails the call site that cannot repair", () => {
+    const budget = new GenerationBudget(1);
+    expect(() =>
+      useGlitterObjectArtifact({
+        artifact: artifact({
+          outcome: "failure",
+          error: "GPT-5.6 Sol did not return a parsed synthesis for aaron",
+          rawContent: null,
+        }),
+        budget,
+      }),
+    ).toThrow("GPT-5.6 Sol did not return a parsed synthesis for aaron");
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-llm.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-llm.ts
@@ -198,9 +198,17 @@ export function useGlitterObjectArtifact<Response>(input: {
   artifact: GenerationArtifactResult<GlitterObjectArtifact<Response>>;
   budget: GenerationBudget;
 }): Response {
-  input.budget.record(input.artifact);
-  if (input.artifact.response.outcome === "failure") {
-    throw new Error(input.artifact.response.error);
+  const response = readGlitterObjectArtifact(input);
+  if (response.outcome === "failure") {
+    throw new Error(response.error);
   }
-  return input.artifact.response.value;
+  return response.value;
+}
+
+export function readGlitterObjectArtifact<Response>(input: {
+  artifact: GenerationArtifactResult<GlitterObjectArtifact<Response>>;
+  budget: GenerationBudget;
+}): GlitterObjectArtifact<Response> {
+  input.budget.record(input.artifact);
+  return input.artifact.response;
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-llm.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-llm.ts
@@ -174,9 +174,7 @@ export async function generateGlitterObject<SCHEMA extends z.ZodType>(input: {
     }
     if (!(error instanceof StructuredOutputExhaustionError)) throw error;
     const lastAttempt = error.attempts.at(-1);
-    const exhaustedByLength = error.attempts.some(
-      (attempt) => attempt.finishReason === "length",
-    );
+    const exhaustedByLength = lastAttempt?.finishReason === "length";
     return glitterObjectArtifact<z.output<SCHEMA>>({
       model: input.model,
       parsed: undefined,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -85,7 +85,7 @@ export function estimateStyleGenerationCost(
   });
   const synthesisInputUpperBound =
     inputTokenUpperBound(synthesisBase) +
-    chunks.length * EXTRACTION_MAX_OUTPUT_TOKENS;
+    chunks.length * EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS;
   // A truncated synthesis retries at the higher ceiling, so every semantic
   // attempt after the first is priced against that ceiling.
   const synthesisInitialCall = worstCaseGenerationCostUsd({

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -15,7 +15,8 @@ import {
 
 export const EXTRACTION_MODEL = "gpt-5.6-luna";
 export const SYNTHESIS_MODEL = "gpt-5.6-sol";
-export const EXTRACTION_MAX_OUTPUT_TOKENS = 2000;
+export const EXTRACTION_MAX_OUTPUT_TOKENS = 4000;
+export const EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 8000;
 export const SYNTHESIS_MAX_OUTPUT_TOKENS = 28_000;
 export const SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 40_000;
 export const MAX_EXTRACTION_REPAIR_ATTEMPTS = 2;
@@ -63,14 +64,16 @@ export function estimateStyleGenerationCost(
       model: EXTRACTION_MODEL,
       inputTokenUpperBound: initialInputTokens,
       outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+      semanticRetryOutputTokenUpperBound:
+        EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
     });
-    // Every repair attempt also serializes the prior summary (bounded by the
-    // output cap) and the validation error back into its request, so its input
-    // is larger than the initial call's.
     const repairCall = worstCaseGenerationCostUsd({
       model: EXTRACTION_MODEL,
-      inputTokenUpperBound: initialInputTokens + EXTRACTION_MAX_OUTPUT_TOKENS,
+      inputTokenUpperBound:
+        initialInputTokens + EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
       outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+      semanticRetryOutputTokenUpperBound:
+        EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
     });
     return total + initialCall + repairCall * MAX_EXTRACTION_REPAIR_ATTEMPTS;
   }, 0);

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -67,6 +67,31 @@ const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
   observations: [],
   representativeMessages: [],
 };
+
+type ChunkExtractionRepair = {
+  previous: StyleChunkSummary;
+  error: string;
+  rawContent: string | null;
+};
+
+function nextParseFailureRepair(
+  prior: ChunkExtractionRepair | null,
+  error: string,
+  rawContent: string | null,
+): ChunkExtractionRepair {
+  if (prior === null) {
+    return {
+      previous: EMPTY_CHUNK_SUMMARY,
+      error,
+      rawContent,
+    };
+  }
+  return {
+    previous: prior.previous,
+    error: prior.error,
+    rawContent: rawContent ?? prior.rawContent,
+  };
+}
 const DETERMINISTIC_SEED = 0;
 
 // Completions are cached before validation, so repairs use distinct seeds
@@ -122,11 +147,7 @@ async function runChunkExtraction(input: {
   artifactStore: GenerationArtifactStore;
   budget: GenerationBudget;
   attempt: number;
-  repair: {
-    previous: StyleChunkSummary;
-    error: string;
-    rawContent: string | null;
-  } | null;
+  repair: ChunkExtractionRepair | null;
 }) {
   const basePrompt = chunkPrompt(input);
   const prompt =
@@ -206,11 +227,7 @@ async function summarizeChunk(input: {
 }): Promise<StyleChunkSummary> {
   const attempts: StyleChunkSummary[] = [];
   let lastError: Error | undefined;
-  let repair: {
-    previous: StyleChunkSummary;
-    error: string;
-    rawContent: string | null;
-  } | null = null;
+  let repair: ChunkExtractionRepair | null = null;
   for (let attempt = 0; attempt <= MAX_EXTRACTION_REPAIR_ATTEMPTS; attempt++) {
     const extracted = await runChunkExtraction({
       ...input,
@@ -219,18 +236,11 @@ async function summarizeChunk(input: {
     });
     if (extracted.outcome === "failure") {
       lastError = new Error(extracted.error);
-      if (repair === null) {
-        repair = {
-          previous: EMPTY_CHUNK_SUMMARY,
-          error: extracted.error,
-          rawContent: extracted.rawContent,
-        };
-      } else {
-        repair = {
-          ...repair,
-          rawContent: extracted.rawContent ?? repair.rawContent,
-        };
-      }
+      repair = nextParseFailureRepair(
+        repair,
+        extracted.error,
+        extracted.rawContent,
+      );
       continue;
     }
     attempts.push(extracted.value);

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -125,6 +125,7 @@ async function runChunkExtraction(input: {
   repair: {
     previous: StyleChunkSummary;
     error: string;
+    rawContent: string | null;
   } | null;
 }) {
   const basePrompt = chunkPrompt(input);
@@ -205,30 +206,44 @@ async function summarizeChunk(input: {
 }): Promise<StyleChunkSummary> {
   const attempts: StyleChunkSummary[] = [];
   let lastError: Error | undefined;
-  let previous = EMPTY_CHUNK_SUMMARY;
+  let repair: {
+    previous: StyleChunkSummary;
+    error: string;
+    rawContent: string | null;
+  } | null = null;
   for (let attempt = 0; attempt <= MAX_EXTRACTION_REPAIR_ATTEMPTS; attempt++) {
     const extracted = await runChunkExtraction({
       ...input,
       attempt,
-      repair:
-        attempt === 0 || lastError === undefined
-          ? null
-          : {
-              previous,
-              error: lastError.message,
-            },
+      repair: attempt === 0 ? null : repair,
     });
     if (extracted.outcome === "failure") {
       lastError = new Error(extracted.error);
+      if (repair === null) {
+        repair = {
+          previous: EMPTY_CHUNK_SUMMARY,
+          error: extracted.error,
+          rawContent: extracted.rawContent,
+        };
+      } else {
+        repair = {
+          ...repair,
+          rawContent: extracted.rawContent ?? repair.rawContent,
+        };
+      }
       continue;
     }
     attempts.push(extracted.value);
-    previous = extracted.value;
     try {
       validateChunkSummary(input.chunk, extracted.value);
       return extracted.value;
     } catch (error: unknown) {
       lastError = z.instanceof(Error).parse(error);
+      repair = {
+        previous: extracted.value,
+        error: lastError.message,
+        rawContent: null,
+      };
     }
   }
   if (lastError === undefined) {

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -79,7 +79,7 @@ function nextParseFailureRepair(
   error: string,
   rawContent: string | null,
 ): ChunkExtractionRepair {
-  if (prior === null) {
+  if (prior === null || prior.previous === EMPTY_CHUNK_SUMMARY) {
     return {
       previous: EMPTY_CHUNK_SUMMARY,
       error,
@@ -89,7 +89,7 @@ function nextParseFailureRepair(
   return {
     previous: prior.previous,
     error: prior.error,
-    rawContent: rawContent ?? prior.rawContent,
+    rawContent: null,
   };
 }
 const DETERMINISTIC_SEED = 0;

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -21,12 +21,14 @@ import {
   generateGlitterObject,
   glitterObjectArtifactSchema,
   glitterPrompt,
+  readGlitterObjectArtifact,
   useGlitterObjectArtifact,
 } from "./glitter-context-refresh-llm.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
 import {
   estimateStyleGenerationCost as estimateStyleGenerationCostInternal,
   EXTRACTION_MAX_OUTPUT_TOKENS,
+  EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
   EXTRACTION_MODEL,
   MAX_EXTRACTION_REPAIR_ATTEMPTS,
   MAX_SYNTHESIS_REPAIR_ATTEMPTS,
@@ -57,8 +59,14 @@ import {
 // and truncated (finish_reason=length → unparseable).
 // 28k gives comfortable headroom over the observed ~15k usage; if a call still
 // truncates, it is retried once at the ceiling below.
+const EXTRACTION_TRUNCATION_ERROR =
+  "GPT-5.6 Luna extraction reached the completion-token limit";
 const SYNTHESIS_TRUNCATION_ERROR =
   "GPT-5.6 Sol synthesis reached the completion-token limit";
+const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
+  observations: [],
+  representativeMessages: [],
+};
 const DETERMINISTIC_SEED = 0;
 
 // Completions are cached before validation, so repairs use distinct seeds
@@ -118,7 +126,7 @@ async function runChunkExtraction(input: {
     previous: StyleChunkSummary;
     error: string;
   } | null;
-}): Promise<StyleChunkSummary> {
+}) {
   const basePrompt = chunkPrompt(input);
   const prompt =
     input.repair === null
@@ -150,6 +158,8 @@ async function runChunkExtraction(input: {
       model: EXTRACTION_MODEL,
       messages,
       maxCompletionTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+      semanticRetryMaxCompletionTokens:
+        EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
       reasoningEffort: "none",
       seed,
       responseSchema: "style-chunk-summary-v2",
@@ -161,6 +171,8 @@ async function runChunkExtraction(input: {
           model: EXTRACTION_MODEL,
           inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(messages)),
           outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+          semanticRetryOutputTokenUpperBound:
+            EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
         }),
       );
       return await generateGlitterObject({
@@ -170,13 +182,16 @@ async function runChunkExtraction(input: {
         ...messages,
         workload: callSite,
         maxOutputTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+        semanticRetryMaxOutputTokens:
+          EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
         reasoningEffort: "none",
         seed,
+        truncationError: EXTRACTION_TRUNCATION_ERROR,
         exhaustionError: `GPT-5.6 Luna did not return a parsed summary for ${input.chunk.key}`,
       });
     },
   });
-  return useGlitterObjectArtifact({
+  return readGlitterObjectArtifact({
     artifact,
     budget: input.budget,
   });
@@ -188,39 +203,39 @@ async function summarizeChunk(input: {
   artifactStore: GenerationArtifactStore;
   budget: GenerationBudget;
 }): Promise<StyleChunkSummary> {
-  // Keep every attempt's raw output: repairs are non-monotonic (a later repair
-  // can cite fewer valid IDs than an earlier one), so the fallback must consider
-  // all of them, not just the last.
   const attempts: StyleChunkSummary[] = [];
-  let lastError: Error;
-  const initial = await runChunkExtraction({
-    ...input,
-    attempt: 0,
-    repair: null,
-  });
-  attempts.push(initial);
-  try {
-    validateChunkSummary(input.chunk, initial);
-    return initial;
-  } catch (error: unknown) {
-    lastError = z.instanceof(Error).parse(error);
-  }
-  for (let attempt = 1; attempt <= MAX_EXTRACTION_REPAIR_ATTEMPTS; attempt++) {
-    const repaired = await runChunkExtraction({
+  let lastError: Error | undefined;
+  let previous = EMPTY_CHUNK_SUMMARY;
+  for (let attempt = 0; attempt <= MAX_EXTRACTION_REPAIR_ATTEMPTS; attempt++) {
+    const extracted = await runChunkExtraction({
       ...input,
       attempt,
-      repair: {
-        previous: attempts.at(-1) ?? initial,
-        error: lastError.message,
-      },
+      repair:
+        attempt === 0 || lastError === undefined
+          ? null
+          : {
+              previous,
+              error: lastError.message,
+            },
     });
-    attempts.push(repaired);
+    if (extracted.outcome === "failure") {
+      lastError = new Error(extracted.error);
+      continue;
+    }
+    attempts.push(extracted.value);
+    previous = extracted.value;
     try {
-      validateChunkSummary(input.chunk, repaired);
-      return repaired;
+      validateChunkSummary(input.chunk, extracted.value);
+      return extracted.value;
     } catch (error: unknown) {
       lastError = z.instanceof(Error).parse(error);
     }
+  }
+  if (lastError === undefined) {
+    throw new Error(`chunk ${input.chunk.key} produced no extraction attempts`);
+  }
+  if (attempts.length === 0) {
+    throw lastError;
   }
   // The model could not produce a fully valid summary for this chunk even after
   // repairs (it deterministically cites an unverifiable in-content ID). Sanitize

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -335,7 +335,7 @@ describe("Glitter context refresh schedule", () => {
     const schedule = findScheduleById("glitter-context-refresh-weekly");
     expect(schedule.taskQueue).toBe("glitter-context");
     expect(schedule.cronExpression).toBe("0 11 * * 1");
-    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 100 }]);
+    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 40 }]);
     expect(schedule.workflowExecutionTimeout).toBe("15 hours");
     expect(buildScheduleState(schedule, {}).paused).toBe(true);
     expect(

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -335,7 +335,7 @@ describe("Glitter context refresh schedule", () => {
     const schedule = findScheduleById("glitter-context-refresh-weekly");
     expect(schedule.taskQueue).toBe("glitter-context");
     expect(schedule.cronExpression).toBe("0 11 * * 1");
-    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 10 }]);
+    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 100 }]);
     expect(schedule.workflowExecutionTimeout).toBe("15 hours");
     expect(buildScheduleState(schedule, {}).paused).toBe(true);
     expect(

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -379,7 +379,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "glitter-context-refresh-weekly",
     workflowType: "runGlitterContextRefresh",
-    args: [{ maxEstimatedCostUsd: 10 }],
+    args: [{ maxEstimatedCostUsd: 100 }],
     // Monday 11:00 PT, isolated from Discord capture and after other PR jobs.
     cronExpression: "0 11 * * 1",
     taskQueue: TASK_QUEUES.GLITTER_CONTEXT,

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -379,7 +379,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "glitter-context-refresh-weekly",
     workflowType: "runGlitterContextRefresh",
-    args: [{ maxEstimatedCostUsd: 100 }],
+    args: [{ maxEstimatedCostUsd: 40 }],
     // Monday 11:00 PT, isolated from Discord capture and after other PR jobs.
     cronExpression: "0 11 * * 1",
     taskQueue: TASK_QUEUES.GLITTER_CONTEXT,


### PR DESCRIPTION
## Why

A production dry-run of `runGlitterContextRefresh` failed after 2h26m on chunk `2023-03-0000`: Luna exhausted structured output. That failure was cached and thrown immediately, so the existing repair loop never ran and every retry replayed the same miss. The weekly `$10` cap also cannot reserve a Sol synthesis after any extraction spend.

## What

- Treat an unparsed Luna chunk artifact as a failed attempt and continue repairs instead of aborting the whole refresh
- Raise Luna’s completion-token ceiling and add a truncation retry (same pattern as Sol)
- Raise the scheduled context-refresh cap from `$10` to `$100`

## Verification

- `bun test src/activities/glitter-context-refresh-llm.test.ts src/schedules/register-schedules.test.ts`
- Live dry-run was **not** re-run; it needs this glitter-worker image after merge

## Rollout

After this worker is live, re-run `context-refresh --dry-run=true --max-estimated-cost-usd=100`, then a real run to open the style-card PR, then unpause `glitter-context-refresh-weekly`.