### PR TITLE
feat(ci): make the PR review gate converge

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1031,7 +1031,7 @@ steps:
   # than Buildkite killing the pod first.
   - label: ":robot_face: Qodo review gate (required)"
     key: review-gate
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
     env:
       REVIEW_PROVIDER: qodo
@@ -1048,7 +1048,7 @@ steps:
 
   - label: ":robot_face: Codex review gate (required)"
     key: codex-review-gate
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
     env:
       REVIEW_PROVIDER: codex

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -24,7 +24,8 @@
 handle_push_trigger = true
 push_commands = ["/agentic_review"]
 
-[config]
-# Bot-authored pull requests are already skipped by Qodo's own author policy;
-# this covers human-opened chores that are not worth a review round.
-ignore_pr_labels = ["chore", "skip-review"]
+# Deliberately NO `ignore_pr_labels` / `ignore_pr_*` here. Telling Qodo to skip a
+# pull request does not tell the gate to skip it: `qodoProvider.detectSkip` is
+# null and the gate only skips bot authors, so a label Qodo honours would leave
+# the required gate waiting for a review that is never coming, until it times
+# out. Any exclusion added here needs a matching gate-visible skip policy first.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -20,7 +20,7 @@
 # gate's completion signal (`QODO_ACKNOWLEDGEMENT_MARKER`), so switching it off
 # makes every review gate wait out its full budget and fail.
 
-[github]
+[github_app]
 handle_push_trigger = true
 push_commands = ["/agentic_review"]
 

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,30 @@
+# Qodo (`.pr_agent.toml`) — provider-side configuration for the required review
+# gate. Prefer settings here over comments the CI gate has to post: a comment
+# costs a round-trip, is posted under a human's token so it reads as a person
+# asking, and is only sent once the gate pod has booted.
+#
+# `handle_push_trigger` defaults to false, which is why the gate had to ask at
+# all: Qodo reviews a pull request when it is opened and never again on its own.
+# With it enabled Qodo re-reviews on every push and updates its persistent
+# review comment in place, so `requestReviewAtHead` becomes a fallback rather
+# than the normal path. See
+# https://docs.qodo.ai/code-review/persistent-review-comments
+#
+# DO NOT add the documented "lean review" display settings here without first
+# checking them against `parseQodoIssueComment`
+# (packages/code-review/src/providers/qodo.ts). That parser is deliberately
+# strict and throws on unrecognised layout: `declaredFindingCount` needs both
+# the `<h3>Code Review by Qodo</h3>` marker and the `Grey Divider` alt text, and
+# the lean recipe turns divider lines off. Disabling the persistent-comment
+# notification is worse still — "was updated up to the latest commit" IS the
+# gate's completion signal (`QODO_ACKNOWLEDGEMENT_MARKER`), so switching it off
+# makes every review gate wait out its full budget and fail.
+
+[github]
+handle_push_trigger = true
+push_commands = ["/agentic_review"]
+
+[config]
+# Bot-authored pull requests are already skipped by Qodo's own author policy;
+# this covers human-opened chores that are not worth a review round.
+ignore_pr_labels = ["chore", "skip-review"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,12 +368,46 @@ and provider adapters remain from `main`; once `main` accepts Codex, the path
 is automatically unreachable. This is a one-time rollout bridge, not a
 permanent PR-self-sourced gate.
 
-Each gate asks its provider to review the head before waiting on it. Qodo
-reviews a PR once, when it is opened, and Codex needs an explicit `@codex
-review` trigger for a fresh head; polling alone can therefore burn the whole
-budget. The request is idempotent per provider and head through
-`buildReviewRequestMarker()`, shared with the PR-fleet controller so consumers
-recognise each other's request.
+**What blocks.** A finding at P1 or above always blocks. A lower-severity
+finding blocks only when it came from the PR's **first** review, or from a
+review that **also** raised a P1 — another round is already being paid for, so
+everything in it gets fixed. Anything else is advisory: still posted, no longer
+a gate. Severity is bound to the review that raised a finding
+(`ReviewThread.raisedInReview`), not to the current round; binding it to the
+round degenerates, because the gate blocks on unresolved threads and lowering
+the threshold at round 2 would also unblock every round-1 finding, letting any
+throwaway push clear the sweep. A finding that cannot be attributed to a review
+blocks. `REVIEW_MAX_BLOCKING_PRIORITY` still works, and setting it to `1`
+disables the low-severity rules entirely, so the policy can be neutralised from
+the pipeline without a revert.
+
+This is measured, not assumed. Across PRs #2259–#2308 the loop ran 260
+finding-bearing rounds over 33 PRs, and 93% of the findings raised from round 8
+onward flagged a line that did not exist at first review — the review was mostly
+reviewing its own churn. Blind grading of 76 findings put the defect-reality rate
+at ~97%, with P1 at ~50% production bugs against 0% one tier down, which is where
+the line is drawn. Re-measure with `scripts/review-analytics.ts`.
+
+**Asking for a review.** Prefer provider configuration over a comment: the
+repo-root `.pr_agent.toml` sets Qodo's `handle_push_trigger`, so Qodo re-reviews
+on push without being asked. Codex has no per-push setting — its "Automatic
+reviews" fire on PR open only — so a fresh head still needs `@codex review`.
+Each request carries a visible "automated re-review request" line plus a hidden
+marker (`buildReviewRequestMarker()`, shared with the PR-fleet controller so
+consumers recognise each other's request). An unanswered request is re-asked
+once after `REVIEW_REQUEST_RETRY_SECONDS` (default 31 min), capped at two
+attempts, with the clock read from the first request comment's own creation time
+so a retried CI job continues the schedule rather than restarting it.
+
+The gate also warns — without blocking — when a first review returns four or
+more findings: no PR measured at that level has converged within three rounds.
+
+**Do not change Qodo's display settings without checking the parser.**
+`parseQodoIssueComment` throws on unrecognised layout, and the documented "lean
+review" recipe turns off divider lines (which `declaredFindingCount` needs) and
+can turn off the persistent-comment notification, which _is_ the gate's
+completion signal. Either change fails every review gate closed. See the
+comments in `.pr_agent.toml`.
 
 Each `review-signal` event carries `parser_commit`, the commit of the parser
 that produced the counts. A finding count is only comparable against the parser
@@ -683,6 +717,28 @@ incorrect:
 Both require a reason and record it in a single audit comment on the PR, so a
 dismissal is a reviewable decision rather than an invisible edit to a bot's
 comment. Neither is automatic and neither runs in CI.
+
+### Measuring the review loop — `review-analytics`
+
+```bash
+GH_TOKEN=$(toolkit gh auth token) bun scripts/review-analytics.ts rounds --last 50
+GH_TOKEN=$(toolkit gh auth token) bun scripts/review-analytics.ts requests --last 50
+GH_TOKEN=$(toolkit gh auth token) bun scripts/review-analytics.ts blame --pr 2301
+```
+
+`rounds` prints the per-push finding sequence and severity mix, `requests`
+compares automated against hand-typed review requests and how often each drew a
+response inside an hour, and `blame` reports what share of findings flag a line
+written after the PR's first review — i.e. churn the loop caused itself. `--json`
+for machine-readable output, `--pr N,M` for specific pull requests.
+
+This is deliberately a live query rather than another archive: reviews, review
+comments and their timestamps are retained by GitHub indefinitely, so every
+figure here is reconstructible after the fact. The 6-hourly
+`review-signals-collect` archive stays as it is, but note it snapshots only the
+_current_ head and so cannot answer a per-push question. Severity is parsed with
+the checkout's own provider rules, so run it from the checkout whose numbers you
+mean to compare.
 
 ## PR Fleet Controller
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,10 +394,28 @@ on push without being asked. Codex has no per-push setting — its "Automatic
 reviews" fire on PR open only — so a fresh head still needs `@codex review`.
 Each request carries a visible "automated re-review request" line plus a hidden
 marker (`buildReviewRequestMarker()`, shared with the PR-fleet controller so
-consumers recognise each other's request). An unanswered request is re-asked
-once after `REVIEW_REQUEST_RETRY_SECONDS` (default 31 min), capped at two
+consumers recognise each other's request).
+
+The gate does not ask immediately. Both providers start on their own — Qodo per
+push, Codex on open — and that begins before the gate pod boots, so an immediate
+request would enqueue a second review of a head already being read. It waits
+`REVIEW_REQUEST_GRACE_SECONDS` (default 10 min) from the head's push time, then
+re-asks once after `REVIEW_REQUEST_RETRY_SECONDS` (default 15 min), capped at two
 attempts, with the clock read from the first request comment's own creation time
 so a retried CI job continues the schedule rather than restarting it.
+
+Those two constants and the gate deadline are one budget, not three independent
+knobs: the last request has to land early enough that the slowest review we have
+watched complete (1834s) still fits before the deadline, or the retry is
+advertised and then cut off. `reviewRequestScheduleBounds()` states the relation
+and `wait-for-review.test.ts` asserts it, so raising the retry without raising
+`DEFAULT_TIMEOUT_SECONDS` (and the steps' `timeout_in_minutes` above it) fails
+the suite instead of silently disabling the retry.
+
+Do not add `ignore_pr_*` rules to `.pr_agent.toml`. Telling Qodo to skip a pull
+request does not tell the gate to skip it — `qodoProvider.detectSkip` is null
+and the gate only skips bot authors — so the required gate would wait out its
+deadline for a review that is never coming.
 
 The gate also warns — without blocking — when a first review returns four or
 more findings: no PR measured at that level has converged within three rounds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,13 +396,14 @@ Each request carries a visible "automated re-review request" line plus a hidden
 marker (`buildReviewRequestMarker()`, shared with the PR-fleet controller so
 consumers recognise each other's request).
 
-The gate does not ask immediately. Both providers start on their own — Qodo per
-push, Codex on open — and that begins before the gate pod boots, so an immediate
-request would enqueue a second review of a head already being read. It waits
-`REVIEW_REQUEST_GRACE_SECONDS` (default 10 min) from the head's push time, then
-re-asks once after `REVIEW_REQUEST_RETRY_SECONDS` (default 15 min), capped at two
-attempts, with the clock read from the first request comment's own creation time
-so a retried CI job continues the schedule rather than restarting it.
+The gate applies `REVIEW_REQUEST_GRACE_SECONDS` (default 10 min) from the head's
+push time only to providers that start reviews on push. That keeps Qodo's
+push-triggered review from receiving a duplicate request while it is already
+working. Codex has no per-push setting, so a fresh head gets an immediate
+explicit request. Either provider is re-asked once after
+`REVIEW_REQUEST_RETRY_SECONDS` (default 15 min), capped at two attempts, with
+the clock read from the first request comment's own creation time so a retried
+CI job continues the schedule rather than restarting it.
 
 Those two constants and the gate deadline are one budget, not three independent
 knobs: the last request has to land early enough that the slowest review we have

--- a/packages/code-review/src/gate.test.ts
+++ b/packages/code-review/src/gate.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  blockingPolicyForThreshold,
   evaluateGate,
+  firstReviewFindingCount,
   isBlocking,
+  type LowSeverityPolicy,
   reviewGateSkipReasonForAuthor,
 } from "./gate.ts";
 import { codexProvider } from "./providers/codex.ts";
@@ -20,8 +23,18 @@ function thread(overrides: Partial<ReviewThread>): ReviewThread {
     title: null,
     threadId: null,
     commentId: null,
+    // Unattributed by default, which the policy treats as blocking. The
+    // attribution-sensitive cases set this explicitly.
+    raisedInReview: null,
     ...overrides,
   };
+}
+
+function policy(
+  maxBlockingPriority = 3,
+  lowSeverity: LowSeverityPolicy = "first-review-or-accompanied",
+) {
+  return blockingPolicyForThreshold(maxBlockingPriority, lowSeverity);
 }
 
 describe("reviewGateSkipReasonForAuthor", () => {
@@ -88,39 +101,149 @@ describe("reviewGateSkipReasonForAuthor", () => {
 
 describe("isBlocking", () => {
   test("blocks an unresolved, non-outdated provider thread within threshold", () => {
-    expect(isBlocking(thread({}), codexProvider, 3)).toBe(true);
+    expect(isBlocking(thread({}), codexProvider, policy())).toBe(true);
   });
   test("does not block a resolved thread", () => {
-    expect(isBlocking(thread({ isResolved: true }), codexProvider, 3)).toBe(
-      false,
-    );
+    expect(
+      isBlocking(thread({ isResolved: true }), codexProvider, policy()),
+    ).toBe(false);
   });
   test("does not block an outdated thread", () => {
-    expect(isBlocking(thread({ isOutdated: true }), codexProvider, 3)).toBe(
-      false,
-    );
+    expect(
+      isBlocking(thread({ isOutdated: true }), codexProvider, policy()),
+    ).toBe(false);
   });
   test("does not block a thread from another author", () => {
     expect(
-      isBlocking(thread({ authorLogin: "some-human" }), codexProvider, 3),
+      isBlocking(
+        thread({ authorLogin: "some-human" }),
+        codexProvider,
+        policy(),
+      ),
     ).toBe(false);
   });
   test("does not block a thread below the priority threshold", () => {
-    expect(isBlocking(thread({ priority: 3 }), codexProvider, 2)).toBe(false);
-  });
-  test("does not block a thread with no severity badge", () => {
-    expect(isBlocking(thread({ priority: null }), codexProvider, 3)).toBe(
+    expect(isBlocking(thread({ priority: 3 }), codexProvider, policy(2))).toBe(
       false,
     );
+  });
+  test("does not block a thread with no severity badge", () => {
+    expect(
+      isBlocking(thread({ priority: null }), codexProvider, policy()),
+    ).toBe(false);
   });
   test("matches the REST [bot] login form", () => {
     expect(
       isBlocking(
         thread({ authorLogin: "chatgpt-codex-connector[bot]" }),
         codexProvider,
-        3,
+        policy(),
       ),
     ).toBe(true);
+  });
+});
+
+describe("isBlocking — low-severity policy", () => {
+  const p1 = { ordinal: 1, hadBlockingSeverity: false };
+  test("an always-blocking finding blocks whenever it was raised", () => {
+    expect(
+      isBlocking(
+        thread({
+          priority: 1,
+          raisedInReview: { ordinal: 9, hadBlockingSeverity: true },
+        }),
+        codexProvider,
+        policy(),
+      ),
+    ).toBe(true);
+  });
+
+  test("a low-severity finding from the first review blocks", () => {
+    expect(
+      isBlocking(
+        thread({ priority: 2, raisedInReview: p1 }),
+        codexProvider,
+        policy(),
+      ),
+    ).toBe(true);
+  });
+
+  test("a later-review low-severity finding alone does not block", () => {
+    expect(
+      isBlocking(
+        thread({
+          priority: 2,
+          raisedInReview: { ordinal: 4, hadBlockingSeverity: false },
+        }),
+        codexProvider,
+        policy(),
+      ),
+    ).toBe(false);
+  });
+
+  test("a later-review low-severity finding blocks when its review also carried a blocking one", () => {
+    expect(
+      isBlocking(
+        thread({
+          priority: 2,
+          raisedInReview: { ordinal: 4, hadBlockingSeverity: true },
+        }),
+        codexProvider,
+        policy(),
+      ),
+    ).toBe(true);
+  });
+
+  test("an unattributable low-severity finding blocks", () => {
+    expect(
+      isBlocking(
+        thread({ priority: 2, raisedInReview: null }),
+        codexProvider,
+        policy(),
+      ),
+    ).toBe(true);
+  });
+
+  test('the "always" policy ignores attribution entirely', () => {
+    expect(
+      isBlocking(
+        thread({
+          priority: 2,
+          raisedInReview: { ordinal: 9, hadBlockingSeverity: false },
+        }),
+        codexProvider,
+        policy(3, "always"),
+      ),
+    ).toBe(true);
+  });
+
+  test("lowering the threshold to the always-blocking severity disables the low-severity rules", () => {
+    expect(
+      isBlocking(
+        thread({ priority: 2, raisedInReview: p1 }),
+        codexProvider,
+        policy(1),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("firstReviewFindingCount", () => {
+  test("counts only the provider's first-review findings", () => {
+    const threads = [
+      thread({ raisedInReview: { ordinal: 1, hadBlockingSeverity: false } }),
+      thread({ raisedInReview: { ordinal: 1, hadBlockingSeverity: false } }),
+      thread({ raisedInReview: { ordinal: 2, hadBlockingSeverity: false } }),
+      thread({
+        authorLogin: "some-human",
+        raisedInReview: { ordinal: 1, hadBlockingSeverity: false },
+      }),
+    ];
+    expect(firstReviewFindingCount(threads, codexProvider)).toBe(2);
+  });
+
+  test("is null when nothing is attributed to a first review", () => {
+    expect(firstReviewFindingCount([thread({})], codexProvider)).toBeNull();
   });
 });
 
@@ -128,7 +251,7 @@ describe("evaluateGate", () => {
   const base = {
     head: "abc123",
     provider: codexProvider,
-    maxBlockingPriority: 3,
+    policy: policy(),
   };
 
   test("waits while reviewing", () => {
@@ -181,6 +304,70 @@ describe("evaluateGate", () => {
       threads: [thread({})],
     });
     expect(d.message).toContain("P2 src/x.ts:10");
+  });
+
+  // The degeneration the raising-review binding exists to prevent. A threshold
+  // bound to the CURRENT round would stop blocking on the first review's
+  // low-severity findings as soon as a second review existed, so pushing
+  // anything at all would clear the sweep without fixing it.
+  test("a first-review low-severity finding still blocks after later reviews arrive", () => {
+    const d = evaluateGate({
+      ...base,
+      reviewState: "reviewed",
+      threads: [
+        thread({
+          priority: 2,
+          title: "unfixed from the first review",
+          raisedInReview: { ordinal: 1, hadBlockingSeverity: false },
+        }),
+        thread({
+          priority: 2,
+          title: "raised later, advisory",
+          raisedInReview: { ordinal: 5, hadBlockingSeverity: false },
+        }),
+      ],
+    });
+    expect(d.state).toBe("failed");
+    expect(d.message).toContain("1 unresolved Codex comment");
+    expect(d.message).toContain("unfixed from the first review");
+    expect(d.message).not.toContain("raised later, advisory");
+  });
+
+  test("passes once only later-review low-severity findings remain", () => {
+    const d = evaluateGate({
+      ...base,
+      reviewState: "reviewed",
+      threads: [
+        thread({
+          priority: 2,
+          raisedInReview: { ordinal: 5, hadBlockingSeverity: false },
+        }),
+      ],
+    });
+    expect(d.state).toBe("passed");
+  });
+
+  test("explains why a ride-along low-severity finding is blocking", () => {
+    const d = evaluateGate({
+      ...base,
+      reviewState: "reviewed",
+      threads: [
+        thread({
+          priority: 1,
+          title: "the blocking one",
+          raisedInReview: { ordinal: 5, hadBlockingSeverity: true },
+        }),
+        thread({
+          priority: 2,
+          title: "rides along",
+          raisedInReview: { ordinal: 5, hadBlockingSeverity: true },
+        }),
+      ],
+    });
+    expect(d.state).toBe("failed");
+    expect(d.message).toContain("2 unresolved Codex comment");
+    expect(d.message).toContain("rides along");
+    expect(d.message).toContain("round you are already paying for");
   });
 
   test("passes on a skip with the reason in the message", () => {

--- a/packages/code-review/src/gate.ts
+++ b/packages/code-review/src/gate.ts
@@ -30,23 +30,110 @@ export function reviewGateSkipReasonForAuthor(input: {
 }
 
 /**
+ * The severity that blocks unconditionally, whenever it was raised.
+ *
+ * Measured over PRs #2259–#2308: findings at this severity are ~50% production
+ * bugs under blind grading, against 0% one tier down. That gap is what makes it
+ * the right place to draw an unconditional line.
+ */
+export const ALWAYS_BLOCKING_PRIORITY = 1;
+
+/**
+ * When a finding below {@link ALWAYS_BLOCKING_PRIORITY} still has to be fixed.
+ *
+ * The loop this exists to end did not converge: over 33 PRs it ran 260
+ * finding-bearing rounds, and 93% of the findings raised from round 8 onward
+ * flagged a line that did not exist when the pull request was first reviewed —
+ * the review was mostly reviewing its own churn. Blocking on every severity
+ * forever is what fed that; blocking on the top severity alone throws away a
+ * whole tier of real findings (36/36 of the sampled ones were genuine defects).
+ *
+ * So a lower-severity finding blocks in exactly the two cases where fixing it
+ * is close to free:
+ *
+ * - **`first-review`** — the initial review of the diff as authored. This is the
+ *   one full quality pass over code the author actually wrote, and it costs no
+ *   extra round because the gate is failing on that review regardless.
+ * - **`accompanied-by-blocking`** — the same review also raised an
+ *   always-blocking finding, so another round is already being paid for. Bundling
+ *   is measurably close to free: across 227 consecutive reviewed heads,
+ *   ρ(fix size, findings in the next round) = 0.23, and a 20× larger fix drew
+ *   only ~46% more findings.
+ *
+ * Anything else is advisory: still posted, still readable, no longer a gate.
+ */
+export type LowSeverityPolicy = "always" | "first-review-or-accompanied";
+
+/** How the gate decides what blocks, independent of any single thread. */
+export type BlockingPolicy = {
+  /** Severities at or above this always block. */
+  alwaysBlockingPriority: number;
+  /**
+   * The least severe priority the gate will ever block on. Findings less severe
+   * than this never block, whenever they were raised.
+   */
+  maxBlockingPriority: number;
+  /** When priorities between the two thresholds block. */
+  lowSeverity: LowSeverityPolicy;
+};
+
+/**
+ * Whether a finding below the always-blocking severity still has to be fixed.
+ *
+ * A finding that cannot be attributed to a review blocks. Attribution comes from
+ * an addressable thread copy, so a null means the parser did not recognise where
+ * this finding came from — and treating the least-understood findings as
+ * advisory is precisely the wrong direction to fail in.
+ */
+function lowSeverityBlocks(
+  thread: ReviewThread,
+  policy: LowSeverityPolicy,
+): boolean {
+  if (policy === "always") return true;
+  if (thread.raisedInReview === null) return true;
+  return (
+    thread.raisedInReview.ordinal === 1 ||
+    thread.raisedInReview.hadBlockingSeverity
+  );
+}
+
+/**
  * A thread blocks the gate iff it is authored by the active provider, still
- * applies to the latest revision (not resolved, not outdated), and carries a
- * severity at or above (more severe than) the threshold. Threads with no
- * severity badge never block.
+ * applies to the latest revision (not resolved, not outdated), carries a
+ * severity within the blocking range, and — below the always-blocking
+ * severity — satisfies {@link LowSeverityPolicy}. Threads with no severity
+ * badge never block.
  */
 export function isBlocking(
   thread: ReviewThread,
   provider: ReviewProvider,
-  maxBlockingPriority: number,
+  policy: BlockingPolicy,
 ): boolean {
-  return (
-    isProviderAuthor(provider, thread.authorLogin) &&
-    !thread.isResolved &&
-    !thread.isOutdated &&
-    thread.priority !== null &&
-    thread.priority <= maxBlockingPriority
-  );
+  if (!isProviderAuthor(provider, thread.authorLogin)) return false;
+  if (thread.isResolved || thread.isOutdated) return false;
+  if (thread.priority === null) return false;
+  if (thread.priority > policy.maxBlockingPriority) return false;
+  if (thread.priority <= policy.alwaysBlockingPriority) return true;
+  return lowSeverityBlocks(thread, policy.lowSeverity);
+}
+
+/**
+ * The policy a caller gets when it only knows a severity threshold.
+ *
+ * `REVIEW_MAX_BLOCKING_PRIORITY` stays meaningful — setting it to the
+ * always-blocking severity or lower disables the low-severity rules entirely by
+ * making the range empty, which is the documented escape hatch if the policy
+ * needs to be neutralised from the pipeline without a revert.
+ */
+export function blockingPolicyForThreshold(
+  maxBlockingPriority: number,
+  lowSeverity: LowSeverityPolicy = "first-review-or-accompanied",
+): BlockingPolicy {
+  return {
+    alwaysBlockingPriority: ALWAYS_BLOCKING_PRIORITY,
+    maxBlockingPriority,
+    lowSeverity,
+  };
 }
 
 /**
@@ -69,16 +156,38 @@ function describeThread(thread: ReviewThread): string {
   return `${title}${location}${url}`;
 }
 
+/**
+ * How many findings the provider's first review raised, or `null` when no
+ * finding could be attributed to a first review.
+ *
+ * Used for a non-blocking warning, not a decision: of the PRs whose first review
+ * returned four or more findings, none converged within three rounds (median 15,
+ * worst 38), while PRs at zero or one finding took a median of one round. That
+ * makes the first review's count the earliest available signal that a pull
+ * request wants splitting rather than iterating.
+ */
+export function firstReviewFindingCount(
+  threads: readonly ReviewThread[],
+  provider: ReviewProvider,
+): number | null {
+  const attributed = threads.filter(
+    (thread) =>
+      isProviderAuthor(provider, thread.authorLogin) &&
+      thread.raisedInReview?.ordinal === 1,
+  );
+  return attributed.length === 0 ? null : attributed.length;
+}
+
 export function evaluateGate(input: {
   head: string;
   provider: ReviewProvider;
   reviewState: ReviewState;
   threads: readonly ReviewThread[];
-  maxBlockingPriority: number;
+  policy: BlockingPolicy;
   /** Provider skip reason (e.g. "no-reviewable-files"), or null. */
   skipReason?: string | null;
 }): GateDecision {
-  const { head, provider, reviewState, threads, maxBlockingPriority } = input;
+  const { head, provider, reviewState, threads, policy } = input;
   const skipReason = input.skipReason ?? null;
   const name = provider.displayName;
 
@@ -99,7 +208,7 @@ export function evaluateGate(input: {
   }
 
   const blocking = threads.filter((thread) =>
-    isBlocking(thread, provider, maxBlockingPriority),
+    isBlocking(thread, provider, policy),
   );
 
   if (blocking.length === 0) {
@@ -111,7 +220,7 @@ export function evaluateGate(input: {
       state: "passed",
       message:
         `${prefix}; no unresolved ${name} comments at ` +
-        `${severityLabel(maxBlockingPriority)} or more severe remain.`,
+        `${severityLabel(policy.maxBlockingPriority)} or more severe remain.`,
     };
   }
 
@@ -121,10 +230,26 @@ export function evaluateGate(input: {
         `  - ${severityLabel(thread.priority)} ${describeThread(thread)}`,
     )
     .join("\n");
+  // Naming the ride-along explicitly matters: a reader who knows that these
+  // lower-severity findings are only blocking because a more severe one shares
+  // their review also knows that fixing them costs no additional round.
+  const accompanied =
+    policy.lowSeverity === "first-review-or-accompanied" &&
+    blocking.some(
+      (thread) =>
+        thread.priority !== null &&
+        thread.priority > policy.alwaysBlockingPriority &&
+        thread.raisedInReview?.hadBlockingSeverity === true &&
+        thread.raisedInReview.ordinal !== 1,
+    )
+      ? `\nLower-severity findings above share a review with a ` +
+        `${severityLabel(policy.alwaysBlockingPriority)} finding, so they are ` +
+        `included in the round you are already paying for.`
+      : "";
   return {
     state: "failed",
     message:
-      `${String(blocking.length)} unresolved ${name} comment(s) on ${head}:\n${list}\n` +
+      `${String(blocking.length)} unresolved ${name} comment(s) on ${head}:\n${list}${accompanied}\n` +
       `Resolve each thread (or push a fix and let ${name} re-review), then re-run this step.`,
   };
 }

--- a/packages/code-review/src/github-issue-comments.test.ts
+++ b/packages/code-review/src/github-issue-comments.test.ts
@@ -164,6 +164,7 @@ describe("reviewCommentBoundToHead", () => {
 const issueCommentProvider: ReviewProvider = {
   id: "issue-comment-fixture",
   displayName: "Issue comment fixture",
+  startsReviewOnPush: false,
   botAuthoredPullRequestPolicy: "review",
   authorLogins: ["review-bot"],
   parseSeverity: () => null,

--- a/packages/code-review/src/github-issue-comments.test.ts
+++ b/packages/code-review/src/github-issue-comments.test.ts
@@ -184,6 +184,7 @@ const issueCommentProvider: ReviewProvider = {
         title: null,
         threadId: null,
         commentId: null,
+        raisedInReview: null,
       },
     ],
   },

--- a/packages/code-review/src/github-review-threads.test.ts
+++ b/packages/code-review/src/github-review-threads.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  attributeRaisedInReview,
+  type ParsedReviewThread,
+  type ProviderReview,
+} from "./github-review-threads.ts";
+import { qodoProvider } from "./providers/qodo.ts";
+
+describe("attributeRaisedInReview", () => {
+  test("counts clean provider reviews before finding-bearing reviews", () => {
+    const parsed: ParsedReviewThread[] = [
+      {
+        thread: {
+          authorLogin: "qodo-code-review",
+          isResolved: false,
+          isOutdated: false,
+          path: "src/example.ts",
+          line: 1,
+          url: null,
+          priority: 2,
+          title: "Example finding",
+          threadId: "thread-1",
+          commentId: null,
+          raisedInReview: null,
+        },
+        review: { id: "finding-review", submittedAt: "2026-08-22T02:00:00Z" },
+      },
+    ];
+    const providerReviews: ProviderReview[] = [
+      {
+        id: "clean-review",
+        submittedAt: "2026-08-22T01:00:00Z",
+        authorLogin: "qodo-code-review",
+      },
+      {
+        id: "finding-review",
+        submittedAt: "2026-08-22T02:00:00Z",
+        authorLogin: "qodo-code-review",
+      },
+    ];
+
+    const [thread] = attributeRaisedInReview(
+      parsed,
+      qodoProvider,
+      1,
+      providerReviews,
+    );
+
+    expect(thread?.raisedInReview).toEqual({
+      ordinal: 2,
+      hadBlockingSeverity: false,
+    });
+  });
+});

--- a/packages/code-review/src/github-review-threads.ts
+++ b/packages/code-review/src/github-review-threads.ts
@@ -4,6 +4,7 @@
  * feeds: this is the shape of GitHub's payload, not a decision about it.
  */
 
+import { isProviderAuthor } from "./identity.ts";
 import {
   arrayField,
   asRecord,
@@ -28,7 +29,12 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
           path
           line
           comments(first: 1) {
-            nodes { author { login } url body }
+            nodes {
+              author { login }
+              url
+              body
+              pullRequestReview { id submittedAt }
+            }
           }
         }
       }
@@ -36,12 +42,25 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
   }
 }`;
 
+/**
+ * A thread plus the review that opened it.
+ *
+ * The review is carried alongside rather than on {@link ReviewThread} because a
+ * thread's `raisedInReview` ordinal cannot be known from the thread alone — it
+ * depends on every other review on the pull request, so it is assigned by
+ * {@link attributeRaisedInReview} once all pages have been read.
+ */
+export type ParsedReviewThread = {
+  thread: ReviewThread;
+  review: { id: string; submittedAt: string | null } | null;
+};
+
 export function parseThreadPage(
   payload: unknown,
   provider: ReviewProvider,
 ): {
   headRefOid: string | null;
-  threads: ReviewThread[];
+  threads: ParsedReviewThread[];
   hasNextPage: boolean;
   endCursor: string | null;
 } {
@@ -61,7 +80,7 @@ export function parseThreadPage(
     throw new Error("GitHub GraphQL response did not include reviewThreads");
   }
 
-  const threads: ReviewThread[] = [];
+  const threads: ParsedReviewThread[] = [];
   for (const rawNode of arrayField(reviewThreads, "nodes")) {
     const node = asRecord(rawNode);
     if (node === null) continue;
@@ -72,6 +91,7 @@ export function parseThreadPage(
     let url: string | null = null;
     let priority: number | null = null;
     let title: string | null = null;
+    let review: ParsedReviewThread["review"] = null;
     if (firstComment !== null) {
       const author = recordField(firstComment, "author");
       const body = stringField(firstComment, "body");
@@ -83,18 +103,33 @@ export function parseThreadPage(
       // also have rendered into its review comment, which is what stops it
       // being counted twice.
       title = provider.parseFindingTitle?.(body) ?? null;
+      const pullRequestReview = recordField(firstComment, "pullRequestReview");
+      if (pullRequestReview !== null) {
+        const reviewId = stringField(pullRequestReview, "id");
+        if (reviewId !== null) {
+          review = {
+            id: reviewId,
+            submittedAt: stringField(pullRequestReview, "submittedAt"),
+          };
+        }
+      }
     }
     threads.push({
-      authorLogin,
-      isResolved: boolField(node, "isResolved"),
-      isOutdated: boolField(node, "isOutdated"),
-      path: stringField(node, "path"),
-      line: numberField(node, "line"),
-      url,
-      priority,
-      title,
-      threadId: stringField(node, "id"),
-      commentId: null,
+      thread: {
+        authorLogin,
+        isResolved: boolField(node, "isResolved"),
+        isOutdated: boolField(node, "isOutdated"),
+        path: stringField(node, "path"),
+        line: numberField(node, "line"),
+        url,
+        priority,
+        title,
+        threadId: stringField(node, "id"),
+        commentId: null,
+        // Assigned by attributeRaisedInReview once every page has been read.
+        raisedInReview: null,
+      },
+      review,
     });
   }
 
@@ -105,4 +140,62 @@ export function parseThreadPage(
     hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
     endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
   };
+}
+
+/**
+ * Assign each thread the review that raised it, as an ordinal plus whether that
+ * review also carried a blocking-severity finding.
+ *
+ * Only the active provider's own reviews are counted, so a human review left
+ * between two provider reviews cannot shift the ordinals and silently turn a
+ * first-review finding into a later-review one.
+ *
+ * Reviews are ordered by `submittedAt`. GitHub reports null for a review that
+ * was never submitted; those sort last and keep a stable relative order, which
+ * is the conservative choice — a finding that cannot be placed early is treated
+ * as late, and the caller's policy already fails such findings closed.
+ */
+export function attributeRaisedInReview(
+  parsed: readonly ParsedReviewThread[],
+  provider: ReviewProvider,
+  alwaysBlockingPriority: number,
+): ReviewThread[] {
+  const groups = new Map<
+    string,
+    { submittedAt: string | null; seenAt: number; threads: ReviewThread[] }
+  >();
+  for (const [index, entry] of parsed.entries()) {
+    if (entry.review === null) continue;
+    if (!isProviderAuthor(provider, entry.thread.authorLogin)) continue;
+    const existing = groups.get(entry.review.id);
+    if (existing === undefined) {
+      groups.set(entry.review.id, {
+        submittedAt: entry.review.submittedAt,
+        seenAt: index,
+        threads: [entry.thread],
+      });
+      continue;
+    }
+    existing.threads.push(entry.thread);
+  }
+
+  const ordered = [...groups.values()].sort((left, right) => {
+    if (left.submittedAt === right.submittedAt)
+      return left.seenAt - right.seenAt;
+    if (left.submittedAt === null) return 1;
+    if (right.submittedAt === null) return -1;
+    return left.submittedAt.localeCompare(right.submittedAt);
+  });
+
+  for (const [index, group] of ordered.entries()) {
+    const hadBlockingSeverity = group.threads.some(
+      (thread) =>
+        thread.priority !== null && thread.priority <= alwaysBlockingPriority,
+    );
+    for (const thread of group.threads) {
+      thread.raisedInReview = { ordinal: index + 1, hadBlockingSeverity };
+    }
+  }
+
+  return parsed.map((entry) => entry.thread);
 }

--- a/packages/code-review/src/github-review-threads.ts
+++ b/packages/code-review/src/github-review-threads.ts
@@ -55,6 +55,71 @@ export type ParsedReviewThread = {
   review: { id: string; submittedAt: string | null } | null;
 };
 
+/** A provider review, including clean reviews that opened no threads. */
+export type ProviderReview = {
+  id: string;
+  submittedAt: string | null;
+  authorLogin: string | null;
+};
+
+export const REVIEW_REVIEWS_QUERY = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviews(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          submittedAt
+          author { login }
+        }
+      }
+    }
+  }
+}`;
+
+export function parseReviewPage(payload: unknown): {
+  reviews: ProviderReview[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+} {
+  const payloadRecord = asRecord(payload);
+  const data =
+    payloadRecord === null ? null : recordField(payloadRecord, "data");
+  const repository = data === null ? null : recordField(data, "repository");
+  const pullRequest =
+    repository === null ? null : recordField(repository, "pullRequest");
+  if (pullRequest === null) {
+    throw new Error(
+      "GitHub GraphQL response did not include repository.pullRequest",
+    );
+  }
+  const reviews = recordField(pullRequest, "reviews");
+  if (reviews === null) {
+    throw new Error("GitHub GraphQL response did not include reviews");
+  }
+  const parsed = arrayField(reviews, "nodes").flatMap((rawReview) => {
+    const review = asRecord(rawReview);
+    if (review === null) return [];
+    const id = stringField(review, "id");
+    if (id === null) return [];
+    const author = recordField(review, "author");
+    return [
+      {
+        id,
+        submittedAt: stringField(review, "submittedAt"),
+        authorLogin: author === null ? null : stringField(author, "login"),
+      },
+    ];
+  });
+  const pageInfo = recordField(reviews, "pageInfo");
+  return {
+    reviews: parsed,
+    hasNextPage: pageInfo !== null && boolField(pageInfo, "hasNextPage"),
+    endCursor: pageInfo === null ? null : stringField(pageInfo, "endCursor"),
+  };
+}
+
 export function parseThreadPage(
   payload: unknown,
   provider: ReviewProvider,
@@ -144,7 +209,9 @@ export function parseThreadPage(
 
 /**
  * Assign each thread the review that raised it, as an ordinal plus whether that
- * review also carried a blocking-severity finding.
+ * review also carried a blocking-severity finding. `providerReviews` includes
+ * clean reviews with no threads, so a later finding cannot be misclassified as
+ * a first-review finding just because the first review was clean.
  *
  * Only the active provider's own reviews are counted, so a human review left
  * between two provider reviews cannot shift the ordinals and silently turn a
@@ -159,11 +226,20 @@ export function attributeRaisedInReview(
   parsed: readonly ParsedReviewThread[],
   provider: ReviewProvider,
   alwaysBlockingPriority: number,
+  providerReviews: readonly ProviderReview[] = [],
 ): ReviewThread[] {
   const groups = new Map<
     string,
     { submittedAt: string | null; seenAt: number; threads: ReviewThread[] }
   >();
+  for (const [index, review] of providerReviews.entries()) {
+    if (!isProviderAuthor(provider, review.authorLogin)) continue;
+    groups.set(review.id, {
+      submittedAt: review.submittedAt,
+      seenAt: index,
+      threads: [],
+    });
+  }
   for (const [index, entry] of parsed.entries()) {
     if (entry.review === null) continue;
     if (!isProviderAuthor(provider, entry.thread.authorLogin)) continue;
@@ -175,6 +251,9 @@ export function attributeRaisedInReview(
         threads: [entry.thread],
       });
       continue;
+    }
+    if (existing.submittedAt === null && entry.review.submittedAt !== null) {
+      existing.submittedAt = entry.review.submittedAt;
     }
     existing.threads.push(entry.thread);
   }

--- a/packages/code-review/src/github.ts
+++ b/packages/code-review/src/github.ts
@@ -28,6 +28,9 @@ import {
   attributeRaisedInReview,
   type ParsedReviewThread,
   parseThreadPage,
+  parseReviewPage,
+  type ProviderReview,
+  REVIEW_REVIEWS_QUERY,
   REVIEW_THREADS_QUERY,
 } from "./github-review-threads.ts";
 import { isProviderAuthor } from "./identity.ts";
@@ -100,6 +103,7 @@ export async function fetchReviewThreads(input: {
 }): Promise<{ threads: ReviewThread[]; headRefOid: string | null }> {
   const { owner, name } = splitRepo(input.repo);
   const parsed: ParsedReviewThread[] = [];
+  const providerReviews: ProviderReview[] = [];
   let headRefOid: string | null = null;
   let cursor: string | null = null;
   for (;;) {
@@ -114,12 +118,26 @@ export async function fetchReviewThreads(input: {
     if (!page.hasNextPage || page.endCursor === null) break;
     cursor = page.endCursor;
   }
+  let reviewCursor: string | null = null;
+  for (;;) {
+    const payload = await graphqlRequest(
+      REVIEW_REVIEWS_QUERY,
+      { owner, name, number: input.number, cursor: reviewCursor },
+      input.token,
+    );
+    const page = parseReviewPage(payload);
+    providerReviews.push(...page.reviews);
+    if (!page.hasNextPage || page.endCursor === null) break;
+    reviewCursor = page.endCursor;
+  }
   // Attribution needs every page: a thread's ordinal is its review's position
-  // among all of this provider's reviews, which is not knowable page by page.
+  // among all of this provider's reviews, including clean reviews that opened
+  // no thread and therefore do not appear in `parsed`.
   const threads: ReviewThread[] = attributeRaisedInReview(
     parsed,
     input.provider,
     ALWAYS_BLOCKING_PRIORITY,
+    providerReviews,
   );
   const { completion } = input.provider;
   if (completion.kind === "issue-comment") {

--- a/packages/code-review/src/github.ts
+++ b/packages/code-review/src/github.ts
@@ -23,7 +23,10 @@ import {
   fetchLatestProviderIssueComment,
   resolveIssueCommentReview,
 } from "./github-issue-comments.ts";
+import { ALWAYS_BLOCKING_PRIORITY } from "./gate.ts";
 import {
+  attributeRaisedInReview,
+  type ParsedReviewThread,
   parseThreadPage,
   REVIEW_THREADS_QUERY,
 } from "./github-review-threads.ts";
@@ -96,7 +99,7 @@ export async function fetchReviewThreads(input: {
   issueComment?: ReviewIssueComment | null | undefined;
 }): Promise<{ threads: ReviewThread[]; headRefOid: string | null }> {
   const { owner, name } = splitRepo(input.repo);
-  const threads: ReviewThread[] = [];
+  const parsed: ParsedReviewThread[] = [];
   let headRefOid: string | null = null;
   let cursor: string | null = null;
   for (;;) {
@@ -107,10 +110,17 @@ export async function fetchReviewThreads(input: {
     );
     const page = parseThreadPage(payload, input.provider);
     if (page.headRefOid !== null) headRefOid = page.headRefOid;
-    threads.push(...page.threads);
+    parsed.push(...page.threads);
     if (!page.hasNextPage || page.endCursor === null) break;
     cursor = page.endCursor;
   }
+  // Attribution needs every page: a thread's ordinal is its review's position
+  // among all of this provider's reviews, which is not knowable page by page.
+  const threads: ReviewThread[] = attributeRaisedInReview(
+    parsed,
+    input.provider,
+    ALWAYS_BLOCKING_PRIORITY,
+  );
   const { completion } = input.provider;
   if (completion.kind === "issue-comment") {
     const comment =

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -97,7 +97,7 @@ describe("mergeDuplicateFindings", () => {
     }
   });
 
-  test("attributes a duplicate to the current review, regardless of order", () => {
+  test("preserves first-review provenance, regardless of copy order", () => {
     const oldCopy = {
       ...fromThread,
       threadId: "old-thread",
@@ -115,8 +115,8 @@ describe("mergeDuplicateFindings", () => {
     ]) {
       const [merged] = mergeDuplicateFindings(order, qodoProvider);
       expect(merged?.raisedInReview).toEqual({
-        ordinal: 2,
-        hadBlockingSeverity: false,
+        ordinal: 1,
+        hadBlockingSeverity: true,
       });
     }
   });

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -27,6 +27,8 @@ describe("mergeDuplicateFindings", () => {
     title: "Turn outlives session destroy",
     threadId: null,
     commentId: 5_236_306_054,
+    // The review comment records no round; only the thread copy can say.
+    raisedInReview: null,
   };
   const fromThread: ReviewThread = {
     authorLogin: "qodo-code-review",
@@ -39,6 +41,7 @@ describe("mergeDuplicateFindings", () => {
     title: "Turn outlives session destroy",
     threadId: "PRRT_kwDOHf4r4c6ZlJlJ",
     commentId: null,
+    raisedInReview: { ordinal: 2, hadBlockingSeverity: true },
   };
 
   test("counts one finding rendered on both surfaces once", () => {
@@ -195,6 +198,7 @@ describe("parseQodoFindingTitle", () => {
       priority: 1,
       threadId: null,
       commentId: null,
+      raisedInReview: null,
     };
     // The comment says "joinVoice"; the thread says "Joinvoice".
     expect(
@@ -212,6 +216,7 @@ describe("parseQodoFindingTitle", () => {
       priority: 1,
       threadId: null,
       commentId: null,
+      raisedInReview: null,
     };
     // `toolkit pr review list` prints the key and `resolve --finding <key>`
     // matches it back by equality, so a control character in the key puts the

--- a/packages/code-review/src/merge-findings.test.ts
+++ b/packages/code-review/src/merge-findings.test.ts
@@ -97,6 +97,30 @@ describe("mergeDuplicateFindings", () => {
     }
   });
 
+  test("attributes a duplicate to the current review, regardless of order", () => {
+    const oldCopy = {
+      ...fromThread,
+      threadId: "old-thread",
+      isOutdated: true,
+      raisedInReview: { ordinal: 1, hadBlockingSeverity: true },
+    };
+    const currentCopy = {
+      ...fromThread,
+      threadId: "current-thread",
+      raisedInReview: { ordinal: 2, hadBlockingSeverity: false },
+    };
+    for (const order of [
+      [oldCopy, currentCopy],
+      [currentCopy, oldCopy],
+    ]) {
+      const [merged] = mergeDuplicateFindings(order, qodoProvider);
+      expect(merged?.raisedInReview).toEqual({
+        ordinal: 2,
+        hadBlockingSeverity: false,
+      });
+    }
+  });
+
   test("reports an all-outdated finding's resolution from its outdated copies", () => {
     const merged = mergeDuplicateFindings(
       [

--- a/packages/code-review/src/merge-findings.ts
+++ b/packages/code-review/src/merge-findings.ts
@@ -67,13 +67,6 @@ export function mergeDuplicateFindings(
     finding.commentId ??= thread.commentId;
     finding.line ??= thread.line;
     finding.path ??= thread.path;
-    // Only the addressable thread copy knows which review raised the finding —
-    // a provider that keeps its findings in a rewritten issue comment records
-    // no round in that comment. Inheriting it here is what lets a severity
-    // policy bound to the raising review work for such a provider at all; a
-    // finding whose thread copy never merged keeps `null` and, by the gate's
-    // rule, blocks.
-    finding.raisedInReview ??= thread.raisedInReview;
   }
   // Decided over the whole group rather than folded in copy by copy, so the
   // answer cannot depend on which surface the provider happened to list first.
@@ -88,6 +81,26 @@ export function mergeDuplicateFindings(
     finding.isResolved = (current.length === 0 ? copies : current).some(
       (copy) => copy.isResolved,
     );
+    // Only the current copies may determine which review raised the finding.
+    // Qodo's persistent comment and addressable thread can both be present,
+    // and a later review leaves the old thread outdated beside the new one.
+    // Prefer the newest attributed current review; ties are conservative and
+    // deterministic because all copies from one review carry the same value.
+    const attributionCopies = (current.length === 0 ? copies : current)
+      .filter((copy) => copy.raisedInReview !== null)
+      .sort((left, right) => {
+        const leftReview = left.raisedInReview;
+        const rightReview = right.raisedInReview;
+        if (leftReview === null || rightReview === null) return 0;
+        if (leftReview.ordinal !== rightReview.ordinal) {
+          return rightReview.ordinal - leftReview.ordinal;
+        }
+        return (
+          Number(rightReview.hadBlockingSeverity) -
+          Number(leftReview.hadBlockingSeverity)
+        );
+      });
+    finding.raisedInReview = attributionCopies[0]?.raisedInReview ?? null;
   }
   return merged;
 }

--- a/packages/code-review/src/merge-findings.ts
+++ b/packages/code-review/src/merge-findings.ts
@@ -67,6 +67,13 @@ export function mergeDuplicateFindings(
     finding.commentId ??= thread.commentId;
     finding.line ??= thread.line;
     finding.path ??= thread.path;
+    // Only the addressable thread copy knows which review raised the finding —
+    // a provider that keeps its findings in a rewritten issue comment records
+    // no round in that comment. Inheriting it here is what lets a severity
+    // policy bound to the raising review work for such a provider at all; a
+    // finding whose thread copy never merged keeps `null` and, by the gate's
+    // rule, blocks.
+    finding.raisedInReview ??= thread.raisedInReview;
   }
   // Decided over the whole group rather than folded in copy by copy, so the
   // answer cannot depend on which surface the provider happened to list first.

--- a/packages/code-review/src/merge-findings.ts
+++ b/packages/code-review/src/merge-findings.ts
@@ -81,19 +81,19 @@ export function mergeDuplicateFindings(
     finding.isResolved = (current.length === 0 ? copies : current).some(
       (copy) => copy.isResolved,
     );
-    // Only the current copies may determine which review raised the finding.
-    // Qodo's persistent comment and addressable thread can both be present,
-    // and a later review leaves the old thread outdated beside the new one.
-    // Prefer the newest attributed current review; ties are conservative and
-    // deterministic because all copies from one review carry the same value.
-    const attributionCopies = (current.length === 0 ? copies : current)
+    // Preserve the earliest review that raised this finding. Qodo's persistent
+    // comment and addressable thread can both be present, and a later review
+    // leaves the old thread outdated beside the new one. Selecting only the
+    // current copy would let an unresolved first-review finding become
+    // advisory merely because the provider repeated it after a push.
+    const attributionCopies = copies
       .filter((copy) => copy.raisedInReview !== null)
       .sort((left, right) => {
         const leftReview = left.raisedInReview;
         const rightReview = right.raisedInReview;
         if (leftReview === null || rightReview === null) return 0;
         if (leftReview.ordinal !== rightReview.ordinal) {
-          return rightReview.ordinal - leftReview.ordinal;
+          return leftReview.ordinal - rightReview.ordinal;
         }
         return (
           Number(rightReview.hadBlockingSeverity) -

--- a/packages/code-review/src/providers/codex.ts
+++ b/packages/code-review/src/providers/codex.ts
@@ -28,9 +28,8 @@ export const codexProvider: ReviewProvider = {
   findingKey: null,
   completion: { kind: "review-at-head", cleanSignal: "thumbsup-reaction" },
   detectSkip: null,
-  // Codex re-reviews on push, but an explicit `@codex review` mention forces a
-  // fresh review of the current head (used after a bot publishes a fix).
-  requestReview: {
-    buildComment: (marker) => `@codex review\n\n${marker}`,
-  },
+  // Codex's "Automatic reviews" setting reviews a pull request when it is
+  // opened, not on every push, so a new head still has to be asked for
+  // explicitly. There is no per-push configuration to move this to.
+  requestReview: { command: "@codex review" },
 };

--- a/packages/code-review/src/providers/codex.ts
+++ b/packages/code-review/src/providers/codex.ts
@@ -19,6 +19,7 @@ import type { ReviewProvider } from "../types.ts";
 export const codexProvider: ReviewProvider = {
   id: "codex",
   displayName: "Codex",
+  startsReviewOnPush: false,
   botAuthoredPullRequestPolicy: "skip",
   authorLogins: ["chatgpt-codex-connector"],
   parseSeverity: parseCodexSeverity,

--- a/packages/code-review/src/providers/greptile.ts
+++ b/packages/code-review/src/providers/greptile.ts
@@ -17,6 +17,7 @@ import type { ReviewProvider } from "../types.ts";
 export const greptileProvider: ReviewProvider = {
   id: "greptile",
   displayName: "Greptile",
+  startsReviewOnPush: true,
   botAuthoredPullRequestPolicy: "review",
   authorLogins: ["greptile-apps"],
   parseSeverity: parseGreptileSeverity,

--- a/packages/code-review/src/providers/qodo.test.ts
+++ b/packages/code-review/src/providers/qodo.test.ts
@@ -45,9 +45,7 @@ describe("qodoProvider", () => {
       inProgress: { marker: "<h3>New Review Started</h3>" },
       parseFindings: parseQodoIssueComment,
     });
-    expect(qodoProvider.requestReview?.buildComment("marker")).toBe(
-      "/review\n\nmarker",
-    );
+    expect(qodoProvider.requestReview?.command).toBe("/agentic_review");
   });
 
   test("recognizes every Qodo app login without admitting look-alikes", () => {
@@ -82,6 +80,7 @@ describe("qodoProvider", () => {
         priority: 1,
         threadId: null,
         commentId: 1,
+        raisedInReview: null,
       },
       {
         authorLogin: "qodo-code-review",
@@ -94,6 +93,7 @@ describe("qodoProvider", () => {
         priority: 2,
         threadId: null,
         commentId: 1,
+        raisedInReview: null,
       },
       {
         authorLogin: "qodo-code-review",
@@ -106,6 +106,7 @@ describe("qodoProvider", () => {
         priority: 2,
         threadId: null,
         commentId: 1,
+        raisedInReview: null,
       },
     ]);
   });
@@ -480,6 +481,7 @@ describe("qodo re-review copies", () => {
         priority: 1,
         threadId: null,
         commentId: 1,
+        raisedInReview: null,
       },
       {
         authorLogin: "qodo-code-review",
@@ -492,6 +494,7 @@ describe("qodo re-review copies", () => {
         priority: 1,
         threadId: null,
         commentId: 1,
+        raisedInReview: null,
       },
     ]);
   });
@@ -576,6 +579,7 @@ Older unresolved wording retained for review history.
         priority: 2,
         threadId: null,
         commentId: 1,
+        raisedInReview: null,
       },
     ]);
   });

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -670,6 +670,7 @@ function parseQodoSeverity(body: string | null): number | null {
 export const qodoProvider: ReviewProvider = {
   id: "qodo",
   displayName: "Qodo",
+  startsReviewOnPush: true,
   // Qodo skips bot-authored PRs by default (`ignore_bot_pr = true`). Keep the
   // gate's bot behavior explicit until Qodo is configured otherwise.
   botAuthoredPullRequestPolicy: "skip",

--- a/packages/code-review/src/providers/qodo.ts
+++ b/packages/code-review/src/providers/qodo.ts
@@ -401,6 +401,12 @@ function parseSeveritySection(
         // cleared by editing the comment it came from.
         threadId: null,
         commentId,
+        // The review comment is rewritten in place on every re-review and
+        // records no round, so this copy cannot say which review raised it.
+        // `mergeDuplicateFindings` inherits it from the addressable thread copy
+        // Qodo posts for the same finding; a finding that never merges keeps
+        // null and blocks.
+        raisedInReview: null,
       },
     });
   }
@@ -679,7 +685,10 @@ export const qodoProvider: ReviewProvider = {
     parseFindings: parseQodoIssueComment,
   },
   detectSkip: null,
-  requestReview: {
-    buildComment: (marker) => `/review\n\n${marker}`,
-  },
+  // Qodo 2.x documents `/agentic_review` as the manual trigger. The older
+  // `/review` still works, but it is no longer the documented spelling and can
+  // stop working without notice. Preferred over asking at all: enabling
+  // `handle_push_trigger` in `.pr_agent.toml`, which re-reviews on push and
+  // needs no comment — this remains the fallback for when that is not in effect.
+  requestReview: { command: "/agentic_review" },
 };

--- a/packages/code-review/src/request-review.test.ts
+++ b/packages/code-review/src/request-review.test.ts
@@ -70,13 +70,59 @@ describe("requestReviewAtHead", () => {
       "https://api.github.com/repos/o/r/issues/2095/comments",
     );
     expect(posted[0]?.body).toEqual({
-      body: `/review\n\n<!-- review-request:qodo:${HEAD} -->`,
+      body:
+        `/agentic_review\n\n<sub>Automated re-review request for ` +
+        `\`${HEAD.slice(0, 7)}\` from the CI review gate.</sub>\n` +
+        `<!-- review-request:qodo:${HEAD} -->`,
     });
+  });
+
+  test("says a request is automated so a reader knows it is not a person", async () => {
+    const posted = stubGitHub([]);
+    await requestReviewAtHead({ ...request, provider: codexProvider });
+    expect(JSON.stringify(posted[0]?.body)).toContain(
+      "Automated re-review request",
+    );
+  });
+
+  test("marks a retry as such and keeps it separately idempotent", async () => {
+    // The first attempt's marker must not suppress the second, or the retry
+    // this exists to add would never be posted.
+    const posted = stubGitHub([
+      { body: `/agentic_review\n\n${buildReviewRequestMarker("qodo", HEAD)}` },
+    ]);
+    expect(
+      await requestReviewAtHead({
+        ...request,
+        provider: qodoProvider,
+        attempt: 2,
+      }),
+    ).toBe("requested");
+    expect(JSON.stringify(posted[0]?.body)).toContain("attempt 2 of 2");
+    expect(JSON.stringify(posted[0]?.body)).toContain(
+      `<!-- review-request:qodo:${HEAD}:2 -->`,
+    );
+  });
+
+  test("does not repeat the same retry attempt", async () => {
+    const posted = stubGitHub([
+      {
+        body: `/agentic_review\n\n${buildReviewRequestMarker("qodo", HEAD, 2)}`,
+      },
+    ]);
+    expect(
+      await requestReviewAtHead({
+        ...request,
+        provider: qodoProvider,
+        attempt: 2,
+      }),
+    ).toBe("already-requested");
+    expect(posted).toHaveLength(0);
   });
 
   test("does not ask twice for the same head", async () => {
     const posted = stubGitHub([
-      { body: `/review\n\n${buildReviewRequestMarker("qodo", HEAD)}` },
+      { body: `/agentic_review\n\n${buildReviewRequestMarker("qodo", HEAD)}` },
     ]);
     expect(
       await requestReviewAtHead({ ...request, provider: qodoProvider }),
@@ -89,7 +135,9 @@ describe("requestReviewAtHead", () => {
     // request it posted for this head must suppress the gate's.
     const posted = stubGitHub([
       { body: `something else` },
-      { body: `/review\n\n${buildReviewRequestMarker("qodo", HEAD)}\n` },
+      {
+        body: `/agentic_review\n\n${buildReviewRequestMarker("qodo", HEAD)}\n`,
+      },
     ]);
     expect(
       await requestReviewAtHead({ ...request, provider: qodoProvider }),

--- a/packages/code-review/src/request-review.ts
+++ b/packages/code-review/src/request-review.ts
@@ -3,33 +3,82 @@
  *
  * Providers that review automatically declare `requestReview: null` and are
  * never asked. Qodo does not: it reviews a PR once, when the PR is opened, and
- * never again on its own. A gate that only polls therefore waits out its whole
- * budget on every push after the first, then fails a PR whose diff is fine.
+ * never again on its own unless push-trigger handling is enabled in its own
+ * configuration. A gate that only polls therefore waits out its whole budget on
+ * every push after the first, then fails a PR whose diff is fine.
  *
- * The request is idempotent through a marker naming the provider and the exact
- * head, so re-running a step — or a second consumer asking for the same head —
- * cannot produce a second request comment.
+ * The request is idempotent through a marker naming the provider, the exact
+ * head, and the attempt, so re-running a step — or a second consumer asking for
+ * the same head — cannot produce a duplicate request comment.
  */
 
 import { z } from "zod";
 import { GITHUB_API_URL, getJsonWithLink, postJson } from "./github-http.ts";
 import type { ReviewProvider } from "./types.ts";
 
-/** The only field of an issue comment this module reads. */
-const CommentBodySchema = z.object({ body: z.string() });
+/** The fields of an issue comment this module reads. */
+const CommentSchema = z.object({
+  body: z.string(),
+  created_at: z.string().optional(),
+});
 
 /**
- * The hidden marker that makes a review request idempotent for one head.
+ * How many times one head may be asked for.
+ *
+ * A single request is dropped by the provider surprisingly often — measured
+ * across PRs #2259–#2308, only ~64% of automated requests drew a response within
+ * an hour — and nothing re-asked, so the gate polled to its deadline and a human
+ * eventually re-typed the comment by hand. One retry addresses that without
+ * turning a quiet provider into a comment loop.
+ */
+export const MAX_REVIEW_REQUEST_ATTEMPTS = 2;
+
+/**
+ * The hidden marker that makes a review request idempotent for one head and
+ * attempt.
  *
  * Shared by every consumer that can trigger a review — the CI gate and the
  * PR-fleet controller — so that two of them running against the same head
  * recognise each other's request instead of each posting one.
+ *
+ * The first attempt deliberately keeps the original marker format. Consumers
+ * that only ever ask once (the fleet controller) still recognise, and are
+ * recognised by, a first request written before attempts existed.
  */
 export function buildReviewRequestMarker(
   providerId: string,
   headSha: string,
+  attempt = 1,
 ): string {
-  return `<!-- review-request:${providerId}:${headSha} -->`;
+  return attempt === 1
+    ? `<!-- review-request:${providerId}:${headSha} -->`
+    : `<!-- review-request:${providerId}:${headSha}:${String(attempt)} -->`;
+}
+
+/**
+ * The comment body for a review request: the provider's trigger command, a
+ * visible line saying who asked and why, and the hidden idempotency marker.
+ *
+ * Assembled here rather than by each provider so the marker cannot be omitted
+ * by a provider that forgets it — which would make every poll post another
+ * request — and so a reader of the pull request can tell at a glance that the
+ * comment is CI machinery rather than a person asking for another look.
+ */
+export function buildReviewRequestBody(input: {
+  command: string;
+  head: string;
+  attempt: number;
+  marker: string;
+}): string {
+  const attemptNote =
+    input.attempt > 1
+      ? ` (attempt ${String(input.attempt)} of ${String(MAX_REVIEW_REQUEST_ATTEMPTS)})`
+      : "";
+  return (
+    `${input.command}\n\n` +
+    `<sub>Automated re-review request for \`${input.head.slice(0, 7)}\`${attemptNote} ` +
+    `from the CI review gate.</sub>\n${input.marker}`
+  );
 }
 
 /**
@@ -46,40 +95,32 @@ export type ReviewRequestOutcome =
   | "already-requested"
   | "unsupported";
 
-/**
- * Ask `provider` to review `head`, unless it already has been asked.
- *
- * Errors propagate: a request that cannot be posted must fail the caller
- * loudly, because silently skipping it restores exactly the behaviour this
- * exists to remove — waiting out the full timeout for a review nobody asked
- * for.
- */
-export async function requestReviewAtHead(input: {
+type RequestInput = {
   repo: string;
   number: number;
   head: string;
   token: string;
   provider: ReviewProvider;
-}): Promise<ReviewRequestOutcome> {
-  const strategy = input.provider.requestReview;
-  if (strategy === null) return "unsupported";
+  /** 1-based attempt; defaults to the first. */
+  attempt?: number;
+};
 
-  const marker = buildReviewRequestMarker(input.provider.id, input.head);
-  if (await hasComment(input, marker)) return "already-requested";
-
-  await postJson(
-    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments`,
-    { body: strategy.buildComment(marker) },
-    input.token,
+/**
+ * When `attempt` was asked for on this pull request, or null if it never was.
+ *
+ * The creation time is what lets a caller decide whether a request has gone
+ * unanswered long enough to escalate. Reading it from GitHub rather than
+ * remembering it in-process means a gate that restarts — a retried CI job —
+ * still escalates on schedule instead of restarting the clock.
+ */
+export async function findReviewRequest(
+  input: RequestInput,
+): Promise<{ createdAt: string | null } | null> {
+  const marker = buildReviewRequestMarker(
+    input.provider.id,
+    input.head,
+    input.attempt ?? 1,
   );
-  return "requested";
-}
-
-/** Whether any comment on the PR already contains `marker`. */
-async function hasComment(
-  input: { repo: string; number: number; token: string },
-  marker: string,
-): Promise<boolean> {
   let url: string | null =
     `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments?per_page=100`;
   while (url !== null) {
@@ -92,10 +133,48 @@ async function hasComment(
       );
     }
     for (const item of payload) {
-      const parsed = CommentBodySchema.safeParse(item);
-      if (parsed.success && parsed.data.body.includes(marker)) return true;
+      const parsed = CommentSchema.safeParse(item);
+      if (parsed.success && parsed.data.body.includes(marker)) {
+        return { createdAt: parsed.data.created_at ?? null };
+      }
     }
     url = linkNext;
   }
-  return false;
+  return null;
+}
+
+/**
+ * Ask `provider` to review `head`, unless this attempt already has been made.
+ *
+ * Errors propagate: a request that cannot be posted must fail the caller
+ * loudly, because silently skipping it restores exactly the behaviour this
+ * exists to remove — waiting out the full timeout for a review nobody asked
+ * for.
+ */
+export async function requestReviewAtHead(
+  input: RequestInput,
+): Promise<ReviewRequestOutcome> {
+  const strategy = input.provider.requestReview;
+  if (strategy === null) return "unsupported";
+
+  const attempt = input.attempt ?? 1;
+  if ((await findReviewRequest(input)) !== null) return "already-requested";
+
+  await postJson(
+    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/comments`,
+    {
+      body: buildReviewRequestBody({
+        command: strategy.command,
+        head: input.head,
+        attempt,
+        marker: buildReviewRequestMarker(
+          input.provider.id,
+          input.head,
+          attempt,
+        ),
+      }),
+    },
+    input.token,
+  );
+  return "requested";
 }

--- a/packages/code-review/src/signal.test.ts
+++ b/packages/code-review/src/signal.test.ts
@@ -36,6 +36,7 @@ describe("formatSignalEvent", () => {
     timed_out: false,
     stale_reaction: false,
     decision: "failed",
+    request_attempts: 1,
     parser_commit: "5f6d0a42b7c1e3d9a8f04b2c6e1d7a3f9b0c5e28",
   });
 

--- a/packages/code-review/src/signal.ts
+++ b/packages/code-review/src/signal.ts
@@ -71,6 +71,15 @@ export const ReviewSignalEventSchema = z.object({
   /** Terminal gate decision, when this event is a decision (else null). */
   decision: z.enum(["waiting", "passed", "failed"]).nullable(),
   /**
+   * How many review requests this gate run had posted for this head when the
+   * observation was made, or `null` for an observer that never asks.
+   *
+   * The retry it records is not assumed to work: ~36% of first requests drew no
+   * response within an hour, and whether a second one recovers them is only
+   * answerable by comparing outcomes across this field.
+   */
+  request_attempts: z.number().int().nonnegative().nullable(),
+  /**
    * The commit of the `code-review` source that produced these counts.
    *
    * The parser ships with the repository, so a finding count is only meaningful

--- a/packages/code-review/src/types.ts
+++ b/packages/code-review/src/types.ts
@@ -68,6 +68,31 @@ export type ReviewThread = {
    * that edit it. `null` for real review threads.
    */
   commentId: number | null;
+  /**
+   * The provider review that raised this finding: its 1-based position among
+   * that provider's reviews on the pull request, and whether that same review
+   * also carried a finding at or above the blocking severity.
+   *
+   * This is what lets a severity threshold be bound to *when a finding was
+   * raised* rather than to the current round. Binding it to the round
+   * degenerates: the gate blocks on unresolved threads, so lowering the
+   * threshold after round 1 also unblocks every round-1 finding, and any
+   * throwaway push clears the sweep.
+   *
+   * `null` means "cannot be attributed" — a finding parsed out of a provider's
+   * issue comment that never merged with an addressable thread copy. Consumers
+   * MUST treat null as blocking; reading it as advisory would let exactly the
+   * findings the parser understands least escape the gate.
+   */
+  raisedInReview: RaisedInReview | null;
+};
+
+/** Where a finding was raised, for severity policies that depend on it. */
+export type RaisedInReview = {
+  /** 1-based position of the raising review among the provider's reviews. */
+  ordinal: number;
+  /** Whether that same review also carried a blocking-severity finding. */
+  hadBlockingSeverity: boolean;
 };
 
 /** A provider-authored issue comment used as a review completion signal. */
@@ -146,12 +171,15 @@ export type SkipStrategy = {
  * How to explicitly ask a provider to (re-)review the current head, or `null`
  * when the provider reviews automatically and needs no trigger comment.
  *
- * `buildComment` receives an idempotency `marker` that the caller must include
- * verbatim in the posted comment body; a caller suppresses a duplicate request
- * for the same head by checking whether that marker already appears on the PR.
+ * Only the trigger command itself, because the rest of the comment — the
+ * visible "this is CI, not a person" line and the hidden idempotency marker —
+ * is assembled by `buildReviewRequestBody`. A provider that assembled its own
+ * body could omit the marker, and a request without one is posted again on
+ * every poll.
  */
 export type ReviewRequestStrategy = {
-  buildComment: (marker: string) => string;
+  /** The provider's trigger phrase, e.g. `"@codex review"`. */
+  command: string;
 };
 
 /** A registered code-review provider. */

--- a/packages/code-review/src/types.ts
+++ b/packages/code-review/src/types.ts
@@ -188,6 +188,8 @@ export type ReviewProvider = {
   id: string;
   /** Human-facing name for gate messages, e.g. `"Greptile"`, `"Codex"`. */
   displayName: string;
+  /** Whether the provider starts a review automatically when a head is pushed. */
+  startsReviewOnPush: boolean;
   /**
    * Whether bot-authored pull requests need this provider's normal review.
    * `skip` is an explicit provider capability for reviewers that cannot emit

--- a/packages/pr-fleet-controller/src/git-operations.ts
+++ b/packages/pr-fleet-controller/src/git-operations.ts
@@ -1,7 +1,10 @@
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import type { ReviewProvider } from "@shepherdjerred/code-review";
-import { buildReviewRequestMarker } from "@shepherdjerred/code-review/request-review";
+import {
+  buildReviewRequestBody,
+  buildReviewRequestMarker,
+} from "@shepherdjerred/code-review/request-review";
 import { z } from "zod";
 import { validateCommitMessage } from "@shepherdjerred/root-scripts/lib/commit-message.ts";
 import { isTelemetryCaptureError } from "./controller-telemetry.ts";
@@ -447,7 +450,12 @@ export class GitOperations {
         "--repo",
         this.#repo,
         "--body",
-        strategy.buildComment(marker),
+        buildReviewRequestBody({
+          command: strategy.command,
+          head: headSha,
+          attempt: 1,
+          marker,
+        }),
       ],
       undefined,
       { signal },

--- a/packages/temporal/src/activities/observe-review-signals.ts
+++ b/packages/temporal/src/activities/observe-review-signals.ts
@@ -2,6 +2,7 @@ import { Context } from "@temporalio/activity";
 import { Octokit } from "octokit";
 import * as Sentry from "@sentry/bun";
 import {
+  blockingPolicyForThreshold,
   isBlocking,
   isProviderAuthor,
   REVIEW_SIGNAL_SCHEMA,
@@ -175,7 +176,11 @@ async function buildSignalEvent(input: {
       isProviderAuthor(provider, thread.authorLogin) && !thread.isOutdated,
   );
   const blocking = threadResult.threads.filter((thread) =>
-    isBlocking(thread, provider, MAX_BLOCKING_PRIORITY),
+    isBlocking(
+      thread,
+      provider,
+      blockingPolicyForThreshold(MAX_BLOCKING_PRIORITY),
+    ),
   );
 
   // Latency only when the reviewed commit IS the head (else a stale review of
@@ -209,6 +214,8 @@ async function buildSignalEvent(input: {
     timed_out: false,
     stale_reaction: state.staleReaction,
     decision: null,
+    // The collector observes; it never asks for a review.
+    request_attempts: null,
     parser_commit: null,
   };
 }

--- a/packages/temporal/src/shared/review-signals.test.ts
+++ b/packages/temporal/src/shared/review-signals.test.ts
@@ -28,6 +28,7 @@ function makeEvent(
     timed_out: false,
     stale_reaction: false,
     decision: null,
+    request_attempts: null,
     parser_commit: null,
     ...overrides,
   };

--- a/packages/toolkit/test/lib/review-findings.test.ts
+++ b/packages/toolkit/test/lib/review-findings.test.ts
@@ -13,6 +13,7 @@ const thread: ReviewThread = {
   title: null,
   threadId: null,
   commentId: null,
+  raisedInReview: null,
 };
 
 describe("assertGraphQlOk", () => {

--- a/scripts/lib/review-analytics-github.ts
+++ b/scripts/lib/review-analytics-github.ts
@@ -1,0 +1,285 @@
+/**
+ * GitHub reads behind `scripts/review-analytics.ts`: listing pull requests,
+ * reconstructing each provider review of each head, and blaming the line a
+ * finding points at.
+ *
+ * Split from the command layer so the script that prints the tables stays under
+ * the repo's max-lines cap, and so the parsing rules — which decide what counts
+ * as a round — can be read on their own.
+ */
+
+import { PROVIDERS, type ReviewProvider } from "@shepherdjerred/code-review";
+import { z } from "zod";
+
+export const DEFAULT_REPO = "shepherdjerred/monorepo";
+export const GITHUB_API = "https://api.github.com";
+
+export type ProviderId = "qodo" | "codex";
+
+/** A provider review of one head: which provider, when, and what it flagged. */
+export type Round = {
+  provider: ProviderId;
+  head: string;
+  at: string;
+  findings: {
+    priority: number | null;
+    path: string | null;
+    line: number | null;
+  }[];
+};
+
+export type PrRounds = {
+  number: number;
+  title: string;
+  author: string;
+  state: string;
+  createdAt: string;
+  rounds: Round[];
+};
+
+export function requireToken(): string {
+  const token = Bun.env["GH_TOKEN"];
+  if (token === undefined || token.trim() === "") {
+    throw new Error("GH_TOKEN is required (GH_TOKEN=$(gh auth token)).");
+  }
+  return token;
+}
+
+export async function ghAll(path: string, token: string): Promise<unknown[]> {
+  let url: string | null = `${GITHUB_API}${path}`;
+  const out: unknown[] = [];
+  while (url !== null) {
+    const response: Response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GET ${url} failed: ${String(response.status)} ${response.statusText}`,
+      );
+    }
+    const payload: unknown = await response.json();
+    if (!Array.isArray(payload)) {
+      throw new TypeError(`GET ${url} did not return an array`);
+    }
+    const items: unknown[] = payload;
+    out.push(...items);
+    const link = response.headers.get("link") ?? "";
+    const next = /<([^>]+)>;\s*rel="next"/u.exec(link);
+    url = next?.[1] ?? null;
+  }
+  return out;
+}
+
+export async function graphql(
+  query: string,
+  variables: Record<string, unknown>,
+  token: string,
+): Promise<unknown> {
+  const response = await fetch(`${GITHUB_API}/graphql`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const payload: unknown = await response.json();
+  const parsed = z
+    .object({
+      errors: z.array(z.object({ message: z.string() }).loose()).optional(),
+    })
+    .loose()
+    .parse(payload);
+  if (parsed.errors !== undefined && parsed.errors.length > 0) {
+    throw new Error(parsed.errors.map((error) => error.message).join("; "));
+  }
+  return payload;
+}
+
+export const PrSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  user: z.object({ login: z.string() }).nullable(),
+  state: z.string(),
+  draft: z.boolean().optional(),
+  merged_at: z.string().nullable().optional(),
+  created_at: z.string(),
+});
+
+const ReviewSchema = z.object({
+  id: z.number(),
+  commit_id: z.string().nullable(),
+  submitted_at: z.string().nullable(),
+  user: z.object({ login: z.string() }).nullable(),
+});
+
+const ReviewCommentSchema = z.object({
+  pull_request_review_id: z.number().nullable(),
+  body: z.string(),
+  path: z.string().nullable(),
+  original_line: z.number().nullable(),
+  line: z.number().nullable(),
+});
+
+export const IssueCommentSchema = z.object({
+  body: z.string(),
+  created_at: z.string(),
+  user: z.object({ login: z.string() }).nullable(),
+});
+
+/** The two providers the required gate runs; Greptile is dormant. */
+const CI_PROVIDERS: readonly (readonly [ProviderId, ReviewProvider])[] = [
+  ["qodo", PROVIDERS.qodo],
+  ["codex", PROVIDERS.codex],
+];
+
+/** Strip the REST `[bot]` suffix and resolve to a provider we model, or null. */
+function providerFor(login: string | null): ProviderId | null {
+  if (login === null) return null;
+  const bare = login.replace(/\[bot\]$/u, "").toLowerCase();
+  for (const [id, provider] of CI_PROVIDERS) {
+    if (provider.authorLogins.some((known) => known.toLowerCase() === bare)) {
+      return id;
+    }
+  }
+  return null;
+}
+
+/** Severity of one finding, via the provider's own badge parser. */
+function severityOf(providerId: ProviderId, body: string): number | null {
+  return PROVIDERS[providerId].parseSeverity(body);
+}
+
+export async function fetchPrRounds(
+  repo: string,
+  pr: z.infer<typeof PrSchema>,
+  token: string,
+): Promise<PrRounds> {
+  const [rawReviews, rawComments] = await Promise.all([
+    ghAll(
+      `/repos/${repo}/pulls/${String(pr.number)}/reviews?per_page=100`,
+      token,
+    ),
+    ghAll(
+      `/repos/${repo}/pulls/${String(pr.number)}/comments?per_page=100`,
+      token,
+    ),
+  ]);
+  const reviews = rawReviews.map((item) => ReviewSchema.parse(item));
+  const comments = rawComments.map((item) => ReviewCommentSchema.parse(item));
+
+  const byReview = new Map<number, typeof comments>();
+  for (const comment of comments) {
+    if (comment.pull_request_review_id === null) continue;
+    const bucket = byReview.get(comment.pull_request_review_id) ?? [];
+    bucket.push(comment);
+    byReview.set(comment.pull_request_review_id, bucket);
+  }
+
+  const rounds: Round[] = [];
+  for (const review of reviews.toSorted((left, right) =>
+    (left.submitted_at ?? "").localeCompare(right.submitted_at ?? ""),
+  )) {
+    const provider = providerFor(review.user?.login ?? null);
+    if (provider === null || review.commit_id === null) continue;
+    const own = byReview.get(review.id) ?? [];
+    rounds.push({
+      provider,
+      head: review.commit_id,
+      at: review.submitted_at ?? "",
+      findings: own.map((comment) => ({
+        priority: severityOf(provider, comment.body),
+        path: comment.path,
+        line: comment.original_line ?? comment.line,
+      })),
+    });
+  }
+
+  return {
+    number: pr.number,
+    title: pr.title,
+    author: pr.user?.login ?? "unknown",
+    state: pr.merged_at == null ? pr.state : "merged",
+    createdAt: pr.created_at,
+    rounds,
+  };
+}
+
+/** One pull request by number, for `--pr`. */
+export async function fetchPr(
+  repo: string,
+  number: number,
+  token: string,
+): Promise<z.infer<typeof PrSchema>> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${repo}/pulls/${String(number)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Could not read PR #${String(number)}: ${String(response.status)} ${response.statusText}`,
+    );
+  }
+  return PrSchema.parse(await response.json());
+}
+
+export async function listPrs(
+  repo: string,
+  limit: number,
+  token: string,
+): Promise<z.infer<typeof PrSchema>[]> {
+  const raw = await ghAll(
+    `/repos/${repo}/pulls?state=all&sort=created&direction=desc&per_page=${String(Math.min(limit, 100))}`,
+    token,
+  );
+  return raw.slice(0, limit).map((item) => PrSchema.parse(item));
+}
+
+export const BLAME_QUERY = `
+query($owner: String!, $name: String!, $expression: String!, $path: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Commit {
+        blame(path: $path) {
+          ranges { startingLine endingLine commit { committedDate } }
+        }
+      }
+    }
+  }
+}`;
+
+export const BlameSchema = z.object({
+  data: z.object({
+    repository: z
+      .object({
+        object: z
+          .object({
+            blame: z.object({
+              ranges: z.array(
+                z.object({
+                  startingLine: z.number(),
+                  endingLine: z.number(),
+                  commit: z.object({ committedDate: z.string() }),
+                }),
+              ),
+            }),
+          })
+          .nullable(),
+      })
+      .nullable(),
+  }),
+});
+
+/**
+ * What share of findings flag a line that did not exist when the pull request
+ * was first reviewed — i.e. code the review loop's own fix churn introduced.
+ */

--- a/scripts/lib/review-gate-policy.ts
+++ b/scripts/lib/review-gate-policy.ts
@@ -20,23 +20,65 @@ import {
 } from "@shepherdjerred/code-review";
 
 /**
- * How long an unanswered review request waits before it is asked again.
+ * The slowest review measured completing normally (PR #2152, 1834s).
  *
- * Must exceed ordinary provider latency or the retry is noise: completed Qodo
- * reviews have been measured at 1637s and 1834s, so this sits above the second
- * of those. Tune from the `attempt` field on the `review-signal` events rather
- * than by guessing.
+ * Every timing constant here is expressed against it: a request the gate has no
+ * time left to act on is not a retry, it is a comment.
  */
-export const DEFAULT_REQUEST_RETRY_SECONDS = 31 * 60;
+export const SLOWEST_COMPLETED_REVIEW_SECONDS = 1834;
+
+/**
+ * How long a head goes unreviewed before the gate asks at all.
+ *
+ * Both providers start reviews on their own — Qodo on every push once
+ * `.pr_agent.toml` enables `handle_push_trigger`, Codex when the pull request is
+ * opened — and that work begins at push time, before this pod has booted. Asking
+ * immediately would therefore enqueue a second review of a head already being
+ * read, which is the comment churn the configuration exists to remove. The gate
+ * waits out this grace first and only asks for a head nothing appears to be
+ * working on.
+ */
+export const DEFAULT_REQUEST_GRACE_SECONDS = 10 * 60;
+
+/**
+ * How long an unanswered request waits before it is asked once more.
+ *
+ * Roughly a third of automated requests drew no response within an hour and
+ * nothing ever re-asked, which is what produced every hand-typed request in the
+ * measured sample.
+ */
+export const DEFAULT_REQUEST_RETRY_SECONDS = 15 * 60;
+
+/**
+ * The budget the request schedule needs from the gate's own deadline.
+ *
+ * Stated positively so it can be asserted rather than eyeballed: the last
+ * request the gate will make has to be posted early enough that the slowest
+ * review we have actually watched complete still fits before the deadline.
+ * Without this the retry is advertised and then reliably cut off — the exact
+ * shape of bug that a constant tuned in isolation produces.
+ */
+export function reviewRequestScheduleBounds(input: {
+  graceSeconds: number;
+  retryAfterSeconds: number;
+}): { lastRequestAtSeconds: number; minimumGateTimeoutSeconds: number } {
+  const lastRequestAtSeconds = input.graceSeconds + input.retryAfterSeconds;
+  return {
+    lastRequestAtSeconds,
+    minimumGateTimeoutSeconds:
+      lastRequestAtSeconds + SLOWEST_COMPLETED_REVIEW_SECONDS,
+  };
+}
 
 /**
  * Whether it is time to make request `attempt` for this head.
  *
- * The first attempt is made as soon as the provider is seen not to have
- * reviewed the head. A later attempt waits for the previous one to have gone
- * unanswered for `retryAfterSeconds`, measured from the previous request
- * comment's creation time — GitHub's record, not this process's memory, so a
- * restarted gate neither re-asks immediately nor forgets that it already asked.
+ * The first attempt waits for `graceSeconds` since the head was pushed, so a
+ * provider reviewing on its own is not asked to start again. A later attempt
+ * waits for the previous one to have gone unanswered for `retryAfterSeconds`,
+ * measured from the previous request comment's creation time — GitHub's record,
+ * not this process's memory, so a restarted gate neither re-asks immediately nor
+ * forgets that it already asked.
  */
 export async function shouldEscalateReviewRequest(input: {
   repo: string;
@@ -45,9 +87,23 @@ export async function shouldEscalateReviewRequest(input: {
   token: string;
   provider: ReviewProvider;
   attempt: number;
+  graceSeconds: number;
   retryAfterSeconds: number;
+  headPushedAt: string | null;
+  startedAt: number;
 }): Promise<boolean> {
-  if (input.attempt <= 1) return true;
+  if (input.attempt <= 1) {
+    // Age the head from its push time when GitHub reports one. Falling back to
+    // this process's start is deliberately conservative: it can only delay the
+    // first request, never bring it forward into the window where the provider
+    // is most likely already working.
+    const since =
+      input.headPushedAt === null
+        ? input.startedAt
+        : Date.parse(input.headPushedAt);
+    if (!Number.isFinite(since)) return true;
+    return (Date.now() - since) / 1000 >= input.graceSeconds;
+  }
   const previous = await findReviewRequest({
     ...input,
     attempt: input.attempt - 1,
@@ -119,7 +175,10 @@ export async function ensureReviewRequested(input: {
   token: string;
   provider: ReviewProvider;
   attempt: number;
+  graceSeconds: number;
   retryAfterSeconds: number;
+  headPushedAt: string | null;
+  startedAt: number;
   reviewedCommit: string | null;
 }): Promise<number> {
   if (input.attempt > MAX_REVIEW_REQUEST_ATTEMPTS) return input.attempt;

--- a/scripts/lib/review-gate-policy.ts
+++ b/scripts/lib/review-gate-policy.ts
@@ -1,0 +1,143 @@
+/**
+ * Policy the CI review gate applies around its poll loop: when an unanswered
+ * review request is asked again, and when a first review is large enough to
+ * warn that the pull request will not converge.
+ *
+ * Split out of `wait-for-review.ts`, which sits at the repo's max-lines cap.
+ * Both decisions are about *pacing the loop* rather than about whether the head
+ * is reviewed, so they read better apart from the polling machinery anyway.
+ */
+
+import {
+  findReviewRequest,
+  MAX_REVIEW_REQUEST_ATTEMPTS,
+  requestReviewAtHead,
+} from "@shepherdjerred/code-review/request-review";
+import {
+  firstReviewFindingCount,
+  type ReviewProvider,
+  type ReviewThread,
+} from "@shepherdjerred/code-review";
+
+/**
+ * How long an unanswered review request waits before it is asked again.
+ *
+ * Must exceed ordinary provider latency or the retry is noise: completed Qodo
+ * reviews have been measured at 1637s and 1834s, so this sits above the second
+ * of those. Tune from the `attempt` field on the `review-signal` events rather
+ * than by guessing.
+ */
+export const DEFAULT_REQUEST_RETRY_SECONDS = 31 * 60;
+
+/**
+ * Whether it is time to make request `attempt` for this head.
+ *
+ * The first attempt is made as soon as the provider is seen not to have
+ * reviewed the head. A later attempt waits for the previous one to have gone
+ * unanswered for `retryAfterSeconds`, measured from the previous request
+ * comment's creation time — GitHub's record, not this process's memory, so a
+ * restarted gate neither re-asks immediately nor forgets that it already asked.
+ */
+export async function shouldEscalateReviewRequest(input: {
+  repo: string;
+  number: number;
+  head: string;
+  token: string;
+  provider: ReviewProvider;
+  attempt: number;
+  retryAfterSeconds: number;
+}): Promise<boolean> {
+  if (input.attempt <= 1) return true;
+  const previous = await findReviewRequest({
+    ...input,
+    attempt: input.attempt - 1,
+  });
+  // No previous request recorded: nothing to escalate from, so make this one.
+  if (previous === null) return true;
+  // A request whose creation time GitHub did not report cannot be aged. Waiting
+  // forever would disable the retry silently, so treat it as due.
+  if (previous.createdAt === null) return true;
+  const elapsedSeconds = (Date.now() - Date.parse(previous.createdAt)) / 1000;
+  return elapsedSeconds >= input.retryAfterSeconds;
+}
+
+/**
+ * The first-review finding count above which a pull request has never been
+ * observed to converge within three rounds.
+ *
+ * Measured over PRs #2259–#2308: of the six pull requests whose first review
+ * returned four or more findings, none finished in three rounds (median 15,
+ * worst 38), while those returning zero or one finished in a median of one.
+ */
+export const OVERSIZED_FIRST_REVIEW_FINDINGS = 4;
+
+/**
+ * Warn — without blocking — when the first review is large enough that this pull
+ * request is unlikely to converge.
+ *
+ * Deliberately advisory. The signal is strong but the right response is a human
+ * judgement about splitting the change, and a gate that refused the PR outright
+ * would be enforcing a size rule the data does not support: splitting to very
+ * small pull requests costs more CI than it saves, because per-build cost is
+ * flat regardless of diff size.
+ *
+ * Returns whether the warning was emitted, so the caller can keep it to once per
+ * gate run rather than once per poll.
+ */
+export function warnIfFirstReviewIsOversized(input: {
+  provider: ReviewProvider;
+  number: number;
+  threads: readonly ReviewThread[];
+}): boolean {
+  const count = firstReviewFindingCount(input.threads, input.provider);
+  if (count === null || count < OVERSIZED_FIRST_REVIEW_FINDINGS) return false;
+  console.warn(
+    `PR #${String(input.number)}: ${input.provider.displayName}'s first review raised ` +
+      `${String(count)} findings. No pull request measured with four or more has ` +
+      `converged within three review rounds; consider splitting this change ` +
+      `rather than iterating on it.`,
+  );
+  return true;
+}
+
+/**
+ * Ask the provider to review `head` if it is time to, returning the next
+ * attempt number.
+ *
+ * Kept here rather than inline in the poll loop so the loop reads as "observe,
+ * decide, maybe ask" — the escalation rules are their own concern, and the
+ * loop's branch count is already at the linter's cap.
+ *
+ * The provider is never asked about a head it has already reviewed, and each
+ * attempt is idempotent through its own marker, so a re-run of this step cannot
+ * post a duplicate.
+ */
+export async function ensureReviewRequested(input: {
+  repo: string;
+  number: number;
+  head: string;
+  token: string;
+  provider: ReviewProvider;
+  attempt: number;
+  retryAfterSeconds: number;
+  reviewedCommit: string | null;
+}): Promise<number> {
+  if (input.attempt > MAX_REVIEW_REQUEST_ATTEMPTS) return input.attempt;
+  if (input.reviewedCommit === input.head) return input.attempt;
+  if (!(await shouldEscalateReviewRequest(input))) return input.attempt;
+
+  const outcome = await requestReviewAtHead(input);
+  console.log(
+    JSON.stringify({
+      level: "info",
+      msg: `review-request-${outcome}`,
+      component: "review-gate",
+      provider: input.provider.id,
+      repo: input.repo,
+      pr: input.number,
+      head_sha: input.head,
+      attempt: input.attempt,
+    }),
+  );
+  return input.attempt + 1;
+}

--- a/scripts/lib/review-gate-policy.ts
+++ b/scripts/lib/review-gate-policy.ts
@@ -76,6 +76,22 @@ export function reviewRequestScheduleBounds(input: {
   };
 }
 
+/** Reject timing overrides that leave the advertised retry no time to finish. */
+export function validateReviewRequestSchedule(input: {
+  graceSeconds: number;
+  retryAfterSeconds: number;
+  timeoutSeconds: number;
+}): void {
+  const bounds = reviewRequestScheduleBounds(input);
+  if (input.timeoutSeconds < bounds.minimumGateTimeoutSeconds) {
+    throw new Error(
+      `Review request timing requires at least ${String(bounds.minimumGateTimeoutSeconds)}s ` +
+        `of gate timeout, but REVIEW_WAIT_TIMEOUT_SECONDS is ${String(input.timeoutSeconds)}s ` +
+        `(grace=${String(input.graceSeconds)}s, retry=${String(input.retryAfterSeconds)}s).`,
+    );
+  }
+}
+
 /**
  * Whether it is time to make request `attempt` for this head.
  *

--- a/scripts/lib/review-gate-policy.ts
+++ b/scripts/lib/review-gate-policy.ts
@@ -30,15 +30,21 @@ export const SLOWEST_COMPLETED_REVIEW_SECONDS = 1834;
 /**
  * How long a head goes unreviewed before the gate asks at all.
  *
- * Both providers start reviews on their own — Qodo on every push once
- * `.pr_agent.toml` enables `handle_push_trigger`, Codex when the pull request is
- * opened — and that work begins at push time, before this pod has booted. Asking
- * immediately would therefore enqueue a second review of a head already being
- * read, which is the comment churn the configuration exists to remove. The gate
- * waits out this grace first and only asks for a head nothing appears to be
- * working on.
+ * Providers that start reviews on push get a head start before the gate asks.
+ * That work begins before this pod has booted, so asking immediately would
+ * enqueue a second review of a head already being read. Providers without a
+ * push trigger, such as Codex, get no grace: a fresh head needs an explicit
+ * request as soon as the gate observes that it is unreviewed.
  */
 export const DEFAULT_REQUEST_GRACE_SECONDS = 10 * 60;
+
+/** Apply the grace only to providers that can actually review a pushed head. */
+export function requestGraceSecondsForProvider(
+  provider: ReviewProvider,
+  configuredGraceSeconds: number,
+): number {
+  return provider.startsReviewOnPush ? configuredGraceSeconds : 0;
+}
 
 /**
  * How long an unanswered request waits before it is asked once more.

--- a/scripts/lib/review-gate-signal.ts
+++ b/scripts/lib/review-gate-signal.ts
@@ -1,0 +1,97 @@
+/**
+ * Building the shared `review-signal` observability event from what the gate
+ * observed. Pure: the caller does the I/O and the logging.
+ *
+ * Split out of `wait-for-review.ts`, which sits at the repo's max-lines cap.
+ */
+
+import {
+  isBlocking,
+  isProviderAuthor,
+  REVIEW_SIGNAL_SCHEMA,
+  tallyFindings,
+  type BlockingPolicy,
+  type GateDecision,
+  type ReviewProvider,
+  type ReviewSignalEvent,
+  type ReviewThread,
+} from "@shepherdjerred/code-review";
+import type { ReviewStateResult } from "@shepherdjerred/code-review/github";
+
+function latencySeconds(
+  reviewedAt: string | null,
+  headPushedAt: string | null,
+): number | null {
+  if (reviewedAt === null || headPushedAt === null) return null;
+  const reviewed = Date.parse(reviewedAt);
+  const pushed = Date.parse(headPushedAt);
+  if (!Number.isFinite(reviewed) || !Number.isFinite(pushed)) return null;
+  return Math.round((reviewed - pushed) / 1000);
+}
+
+/**
+ * The commit of the `code-review` source that produced this observation.
+ *
+ * `review-gate.sh` runs the gate from a worktree of `main` and passes the
+ * commit it checked out. Recording it makes the log say which parser produced
+ * a count — the one thing that would have made an inflated `blocking_count`
+ * obvious at a glance rather than after a long hunt.
+ */
+function parserCommit(): string | null {
+  const commit = Bun.env["REVIEW_GATE_PARSER_COMMIT"];
+  return commit === undefined || commit.trim() === "" ? null : commit.trim();
+}
+
+export function buildSignalEvent(input: {
+  provider: ReviewProvider;
+  pr: number;
+  head: string;
+  headPushedAt: string | null;
+  state: ReviewStateResult;
+  threads: readonly ReviewThread[];
+  policy: BlockingPolicy;
+  gateWaitSeconds: number;
+  timedOut: boolean;
+  decision: GateDecision | null;
+  requestAttempts: number;
+}): ReviewSignalEvent {
+  const providerThreads = input.threads.filter(
+    (thread) =>
+      isProviderAuthor(input.provider, thread.authorLogin) &&
+      !thread.isOutdated,
+  );
+  const blocking = input.threads.filter((thread) =>
+    isBlocking(thread, input.provider, input.policy),
+  );
+  const reviewState =
+    input.state.completionSignal === "thumbsup-reaction"
+      ? "reviewed-clean-reaction"
+      : input.state.state;
+  return {
+    schema: REVIEW_SIGNAL_SCHEMA,
+    ts: new Date().toISOString(),
+    provider: input.provider.id,
+    pr: input.pr,
+    head_sha: input.head,
+    head_pushed_at: input.headPushedAt,
+    review_state: reviewState,
+    completion_signal: input.state.completionSignal,
+    reviewed_at_head: input.state.reviewedCommit === input.head,
+    // Latency is only meaningful when the reviewed commit IS the head; a stale
+    // review of an older commit must not produce a (possibly negative) latency.
+    latency_s:
+      input.state.reviewedCommit === input.head
+        ? latencySeconds(input.state.reviewedAt, input.headPushedAt)
+        : null,
+    findings: tallyFindings(providerThreads.map((thread) => thread.priority)),
+    blocking_count: blocking.length,
+    unresolved_count: providerThreads.filter((thread) => !thread.isResolved)
+      .length,
+    gate_wait_s: input.gateWaitSeconds,
+    timed_out: input.timedOut,
+    stale_reaction: input.state.staleReaction,
+    decision: input.decision === null ? null : input.decision.state,
+    request_attempts: input.requestAttempts,
+    parser_commit: parserCommit(),
+  };
+}

--- a/scripts/probe-review-signal.ts
+++ b/scripts/probe-review-signal.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  blockingPolicyForThreshold,
   isBlocking,
   isProviderAuthor,
   REVIEW_SIGNAL_SCHEMA,
@@ -116,7 +117,7 @@ async function probePr(
       isProviderAuthor(provider, thread.authorLogin) && !thread.isOutdated,
   );
   const blocking = threadResult.threads.filter((thread) =>
-    isBlocking(thread, provider, 3),
+    isBlocking(thread, provider, blockingPolicyForThreshold(3)),
   );
   // Latency only when the reviewed commit IS the head (else a stale review of
   // an older commit yields a bogus/negative value).
@@ -149,6 +150,8 @@ async function probePr(
     timed_out: false,
     stale_reaction: state.staleReaction,
     decision: null,
+    // A probe reads state; it never asks for a review.
+    request_attempts: null,
     // Which parser produced these counts. A probe run from a stale checkout
     // reads the repository's stale parser and reports numbers that disagree
     // with CI for reasons that have nothing to do with the PR.

--- a/scripts/review-analytics.ts
+++ b/scripts/review-analytics.ts
@@ -37,6 +37,16 @@ import {
 } from "./lib/review-analytics-github.ts";
 import type { z } from "zod";
 
+type ReviewAnswer = { head: string | null; at: string };
+
+const QODO_ACKNOWLEDGEMENT = "was updated up to the latest commit";
+
+function acknowledgedHead(body: string): string | null {
+  const markerAt = body.indexOf(QODO_ACKNOWLEDGEMENT);
+  if (markerAt === -1) return null;
+  return /\b([0-9a-f]{40})\b/iu.exec(body.slice(markerAt))?.[1] ?? null;
+}
+
 /** Distinct reviewed heads in chronological order, with per-provider counts. */
 function headsOf(pr: PrRounds) {
   const byHead = new Map<
@@ -151,14 +161,15 @@ async function commandRequests(
       token,
     );
     const comments = raw.map((item) => IssueCommentSchema.parse(item));
-    const acks = comments
-      .filter((comment) =>
-        comment.body.includes("was updated up to the latest commit"),
-      )
-      .map((comment) => comment.created_at);
-    const codexReviews = pr.rounds
+    const acks: ReviewAnswer[] = comments
+      .filter((comment) => comment.body.includes(QODO_ACKNOWLEDGEMENT))
+      .map((comment) => ({
+        head: acknowledgedHead(comment.body),
+        at: comment.created_at,
+      }));
+    const codexReviews: ReviewAnswer[] = pr.rounds
       .filter((round) => round.provider === "codex")
-      .map((round) => round.at);
+      .map((round) => ({ head: round.head, at: round.at }));
 
     let automated = 0;
     let manual = 0;
@@ -184,10 +195,15 @@ async function commandRequests(
         marker?.[1] ??
         (comment.body.includes("@codex review") ? "codex" : "qodo");
       const answers = askedProvider === "codex" ? codexReviews : acks;
+      const requestedHead = marker?.[2] ?? null;
       if (
-        answers.some((at) => {
-          const gap = Date.parse(at) - askedAt;
-          return gap > 0 && gap < 60 * 60 * 1000;
+        answers.some((answer) => {
+          const gap = Date.parse(answer.at) - askedAt;
+          return (
+            (requestedHead === null || answer.head === requestedHead) &&
+            gap > 0 &&
+            gap < 60 * 60 * 1000
+          );
         })
       ) {
         converted += 1;

--- a/scripts/review-analytics.ts
+++ b/scripts/review-analytics.ts
@@ -174,7 +174,16 @@ async function commandRequests(
       if (marker === null) manual += 1;
       else automated += 1;
       const askedAt = Date.parse(comment.created_at);
-      const answers = marker?.[1] === "codex" ? codexReviews : acks;
+      // Which provider was asked. A hand-typed request carries no marker, so
+      // falling back to the marker alone would score every manual `@codex
+      // review` against Qodo's acknowledgements — counting a later Qodo
+      // acknowledgement as the answer while ignoring the Codex review that did
+      // arrive. That would corrupt the conversion rate the retry policy is
+      // justified by, so the command itself decides when the marker cannot.
+      const askedProvider =
+        marker?.[1] ??
+        (comment.body.includes("@codex review") ? "codex" : "qodo");
+      const answers = askedProvider === "codex" ? codexReviews : acks;
       if (
         answers.some((at) => {
           const gap = Date.parse(at) - askedAt;

--- a/scripts/review-analytics.ts
+++ b/scripts/review-analytics.ts
@@ -1,0 +1,428 @@
+#!/usr/bin/env bun
+/**
+ * Measure what the required review gate actually costs, from GitHub.
+ *
+ * This exists instead of a bigger archive. Everything it reports is
+ * reconstructible from GitHub after the fact — reviews, review comments, their
+ * `commit_id`s and timestamps are retained indefinitely — so copying them into
+ * S3 would duplicate a durable store and leave a second thing to keep correct.
+ * The durable collector (`review-signals-collect`) stays as it is; it snapshots
+ * the *current* head every six hours and therefore cannot answer any per-push
+ * question, which is what this answers.
+ *
+ * Severity is parsed with the repository's own provider rules, so a count is
+ * only comparable against the parser that produced it — run this from the
+ * checkout whose numbers you mean to compare.
+ *
+ * Usage:
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-analytics.ts rounds --last 50
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-analytics.ts requests --last 50
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-analytics.ts blame --pr 2301
+ *   GH_TOKEN=$(gh auth token) bun scripts/review-analytics.ts rounds --last 20 --json
+ */
+
+import {
+  BLAME_QUERY,
+  BlameSchema,
+  DEFAULT_REPO,
+  fetchPr,
+  fetchPrRounds,
+  graphql,
+  IssueCommentSchema,
+  ghAll,
+  listPrs,
+  requireToken,
+  type PrRounds,
+  type PrSchema,
+} from "./lib/review-analytics-github.ts";
+import type { z } from "zod";
+
+/** Distinct reviewed heads in chronological order, with per-provider counts. */
+function headsOf(pr: PrRounds) {
+  const byHead = new Map<
+    string,
+    { head: string; at: string; qodo: number[]; codex: number[] }
+  >();
+  for (const round of pr.rounds) {
+    const entry = byHead.get(round.head) ?? {
+      head: round.head,
+      at: round.at,
+      qodo: [],
+      codex: [],
+    };
+    if (round.at !== "" && (entry.at === "" || round.at < entry.at)) {
+      entry.at = round.at;
+    }
+    for (const finding of round.findings) {
+      if (finding.priority === null) continue;
+      entry[round.provider].push(finding.priority);
+    }
+    byHead.set(round.head, entry);
+  }
+  return [...byHead.values()].toSorted((left, right) =>
+    left.at.localeCompare(right.at),
+  );
+}
+
+function tally(priorities: readonly number[]): string {
+  if (priorities.length === 0) return "-";
+  const counts = new Map<number, number>();
+  for (const priority of priorities) {
+    counts.set(priority, (counts.get(priority) ?? 0) + 1);
+  }
+  return (
+    [...counts.entries()]
+      .toSorted((left, right) => left[0] - right[0])
+      .map(([priority, n]) => `${String(n)}p${String(priority)}`)
+      .join("+") || "-"
+  );
+}
+
+function commandRounds(repo: string, prs: PrRounds[], json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify({ repo, prs }, null, 2));
+    return;
+  }
+  const active = prs.filter((pr) => pr.rounds.length > 0);
+  let totalHeads = 0;
+  let totalFindings = 0;
+  const bySeverity = new Map<number, number>();
+
+  console.log(
+    `${String(prs.length)} PR(s) scanned, ${String(active.length)} with provider reviews.\n`,
+  );
+  console.log("Per-push finding sequence — n[qodo|codex]:\n");
+  for (const pr of active.toSorted(
+    (left, right) => right.rounds.length - left.rounds.length,
+  )) {
+    const heads = headsOf(pr);
+    totalHeads += heads.length;
+    for (const head of heads) {
+      totalFindings += head.qodo.length + head.codex.length;
+      for (const priority of [...head.qodo, ...head.codex]) {
+        bySeverity.set(priority, (bySeverity.get(priority) ?? 0) + 1);
+      }
+    }
+    const sequence = heads
+      .map(
+        (head, index) =>
+          `${String(index + 1)}[${tally(head.qodo)}|${tally(head.codex)}]`,
+      )
+      .join(" ");
+    console.log(
+      `#${String(pr.number)} (${pr.state}, ${String(heads.length)} reviewed heads)`,
+    );
+    console.log(`  ${sequence}\n`);
+  }
+
+  console.log("---");
+  console.log(`finding-bearing rounds: ${String(totalHeads)}`);
+  console.log(`findings: ${String(totalFindings)}`);
+  for (const [priority, n] of [...bySeverity.entries()].toSorted(
+    (left, right) => left[0] - right[0],
+  )) {
+    const share = totalFindings === 0 ? 0 : (100 * n) / totalFindings;
+    console.log(`  P${String(priority)}: ${String(n)} (${share.toFixed(0)}%)`);
+  }
+  if (totalHeads > 0) {
+    console.log(
+      `mean findings per round: ${(totalFindings / totalHeads).toFixed(2)}`,
+    );
+  }
+}
+
+async function commandRequests(
+  repo: string,
+  prs: PrRounds[],
+  token: string,
+  json: boolean,
+): Promise<void> {
+  const rows: {
+    pr: number;
+    automated: number;
+    manual: number;
+    converted: number;
+  }[] = [];
+
+  for (const pr of prs) {
+    if (pr.rounds.length === 0) continue;
+    const raw = await ghAll(
+      `/repos/${repo}/issues/${String(pr.number)}/comments?per_page=100`,
+      token,
+    );
+    const comments = raw.map((item) => IssueCommentSchema.parse(item));
+    const acks = comments
+      .filter((comment) =>
+        comment.body.includes("was updated up to the latest commit"),
+      )
+      .map((comment) => comment.created_at);
+    const codexReviews = pr.rounds
+      .filter((round) => round.provider === "codex")
+      .map((round) => round.at);
+
+    let automated = 0;
+    let manual = 0;
+    let converted = 0;
+    for (const comment of comments) {
+      const isRequest =
+        /^\s*\/(?:agentic_)?review\b/mu.test(comment.body) ||
+        comment.body.includes("@codex review");
+      if (!isRequest) continue;
+      const marker = /<!-- review-request:([a-z]+):([0-9a-f]{40})/u.exec(
+        comment.body,
+      );
+      if (marker === null) manual += 1;
+      else automated += 1;
+      const askedAt = Date.parse(comment.created_at);
+      const answers = marker?.[1] === "codex" ? codexReviews : acks;
+      if (
+        answers.some((at) => {
+          const gap = Date.parse(at) - askedAt;
+          return gap > 0 && gap < 60 * 60 * 1000;
+        })
+      ) {
+        converted += 1;
+      }
+    }
+    rows.push({ pr: pr.number, automated, manual, converted });
+  }
+
+  if (json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  const totals = rows.reduce(
+    (accumulator, row) => ({
+      automated: accumulator.automated + row.automated,
+      manual: accumulator.manual + row.manual,
+      converted: accumulator.converted + row.converted,
+    }),
+    { automated: 0, manual: 0, converted: 0 },
+  );
+  console.log("PR\tautomated\tmanual\tanswered<60m");
+  for (const row of rows) {
+    console.log(
+      `${String(row.pr)}\t${String(row.automated)}\t\t${String(row.manual)}\t${String(row.converted)}`,
+    );
+  }
+  const all = totals.automated + totals.manual;
+  console.log("---");
+  console.log(
+    `requests: ${String(all)} (automated ${String(totals.automated)}, manual ${String(totals.manual)})`,
+  );
+  if (all > 0) {
+    console.log(
+      `answered within 60 min: ${String(totals.converted)} (${((100 * totals.converted) / all).toFixed(0)}%)`,
+    );
+  }
+}
+
+type BlameRange = { start: number; end: number; at: string };
+
+/**
+ * Blame ranges for one file at one commit, cached across findings — several
+ * findings routinely point at the same file in the same review, and blame is
+ * the expensive call here.
+ */
+async function blameRanges(input: {
+  owner: string;
+  name: string;
+  head: string;
+  path: string;
+  token: string;
+  cache: Map<string, BlameRange[]>;
+}): Promise<BlameRange[]> {
+  const key = `${input.head} ${input.path}`;
+  const cached = input.cache.get(key);
+  if (cached !== undefined) return cached;
+  const payload = await graphql(
+    BLAME_QUERY,
+    {
+      owner: input.owner,
+      name: input.name,
+      expression: input.head,
+      path: input.path,
+    },
+    input.token,
+  );
+  const parsed = BlameSchema.safeParse(payload);
+  const blame = parsed.success
+    ? (parsed.data.data.repository?.object?.blame.ranges ?? null)
+    : null;
+  const ranges =
+    blame?.map((range) => ({
+      start: range.startingLine,
+      end: range.endingLine,
+      at: range.commit.committedDate,
+    })) ?? [];
+  input.cache.set(key, ranges);
+  return ranges;
+}
+
+/**
+ * When the flagged line was last written, or null when blame cannot place it.
+ */
+async function flaggedLineAuthoredAt(input: {
+  owner: string;
+  name: string;
+  head: string;
+  path: string | null;
+  line: number | null;
+  token: string;
+  cache: Map<string, BlameRange[]>;
+}): Promise<string | null> {
+  const { path, line } = input;
+  if (path === null || line === null) return null;
+  const ranges = await blameRanges({ ...input, path });
+  const hit = ranges.find((range) => range.start <= line && line <= range.end);
+  return hit?.at ?? null;
+}
+
+async function commandBlame(
+  repo: string,
+  prs: PrRounds[],
+  token: string,
+  json: boolean,
+): Promise<void> {
+  const [owner, name] = repo.split("/");
+  if (owner === undefined || name === undefined) {
+    throw new Error(`repo must be "owner/name", got "${repo}"`);
+  }
+  const cache = new Map<string, BlameRange[]>();
+  const rows: {
+    pr: number;
+    total: number;
+    selfInflicted: number;
+    unresolved: number;
+  }[] = [];
+
+  for (const pr of prs) {
+    if (pr.rounds.length === 0) continue;
+    const firstReviewAt = pr.rounds
+      .map((round) => round.at)
+      .filter((at) => at !== "")
+      .toSorted()[0];
+    if (firstReviewAt === undefined) continue;
+
+    let total = 0;
+    let selfInflicted = 0;
+    let unresolved = 0;
+    for (const round of pr.rounds) {
+      for (const finding of round.findings) {
+        total += 1;
+        const authoredAt = await flaggedLineAuthoredAt({
+          owner,
+          name,
+          head: round.head,
+          path: finding.path,
+          line: finding.line,
+          token,
+          cache,
+        });
+        if (authoredAt === null) {
+          unresolved += 1;
+          continue;
+        }
+        if (Date.parse(authoredAt) > Date.parse(firstReviewAt)) {
+          selfInflicted += 1;
+        }
+      }
+    }
+    rows.push({ pr: pr.number, total, selfInflicted, unresolved });
+  }
+
+  if (json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  const totals = rows.reduce(
+    (accumulator, row) => ({
+      total: accumulator.total + row.total,
+      selfInflicted: accumulator.selfInflicted + row.selfInflicted,
+      unresolved: accumulator.unresolved + row.unresolved,
+    }),
+    { total: 0, selfInflicted: 0, unresolved: 0 },
+  );
+  console.log("PR\tfindings\tchurn-authored\tunresolved");
+  for (const row of rows) {
+    console.log(
+      `${String(row.pr)}\t${String(row.total)}\t\t${String(row.selfInflicted)}\t\t${String(row.unresolved)}`,
+    );
+  }
+  console.log("---");
+  const resolved = totals.total - totals.unresolved;
+  console.log(
+    `findings: ${String(totals.total)} (${String(totals.unresolved)} lines not resolvable by blame)`,
+  );
+  if (resolved > 0) {
+    console.log(
+      `flagging a line written after the first review: ${String(totals.selfInflicted)} ` +
+        `(${((100 * totals.selfInflicted) / resolved).toFixed(0)}%)`,
+    );
+  }
+}
+
+function parseArgs(argv: readonly string[]) {
+  const command = argv[0];
+  const options = new Map<string, string>();
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg?.startsWith("--") !== true) continue;
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      options.set(key, "true");
+      continue;
+    }
+    options.set(key, next);
+    index += 1;
+  }
+  return { command, options };
+}
+
+async function main(): Promise<void> {
+  const { command, options } = parseArgs(Bun.argv.slice(2));
+  const commands = new Set(["rounds", "requests", "blame"]);
+  if (command === undefined || !commands.has(command)) {
+    throw new Error(
+      `Usage: review-analytics.ts <${[...commands].join("|")}> [--last N | --pr N] [--repo owner/name] [--json]`,
+    );
+  }
+  const token = requireToken();
+  const repo = options.get("repo") ?? DEFAULT_REPO;
+  const json = options.get("json") === "true";
+
+  const explicit = options.get("pr");
+  const prs: z.infer<typeof PrSchema>[] = [];
+  if (explicit === undefined) {
+    const last = Number.parseInt(options.get("last") ?? "50", 10);
+    if (Number.isInteger(last) && last > 0) {
+      prs.push(...(await listPrs(repo, last, token)));
+    } else {
+      throw new Error(
+        `--last expects a positive integer, got "${options.get("last") ?? ""}"`,
+      );
+    }
+  } else {
+    for (const raw of explicit.split(",")) {
+      const number = Number.parseInt(raw.trim(), 10);
+      if (Number.isInteger(number) && number > 0) {
+        prs.push(await fetchPr(repo, number, token));
+        continue;
+      }
+      throw new Error(`--pr expects positive PR numbers, got "${raw}"`);
+    }
+  }
+
+  const resolved: PrRounds[] = [];
+  for (const pr of prs) {
+    resolved.push(await fetchPrRounds(repo, pr, token));
+  }
+
+  if (command === "rounds") commandRounds(repo, resolved, json);
+  else if (command === "requests")
+    await commandRequests(repo, resolved, token, json);
+  else await commandBlame(repo, resolved, token, json);
+}
+
+await main();

--- a/scripts/review-findings.test.ts
+++ b/scripts/review-findings.test.ts
@@ -55,6 +55,7 @@ describe("describeFinding", () => {
       title: "S3 fetch lacks timeout",
       threadId: null,
       commentId: null,
+      raisedInReview: null,
     });
     expect(line).toContain("P1");
     expect(line).toContain("S3 fetch lacks timeout");
@@ -73,6 +74,7 @@ describe("describeFinding", () => {
       title: null,
       threadId: null,
       commentId: null,
+      raisedInReview: null,
     });
     expect(line).toContain("P2 src/x.ts:42");
     expect(line).not.toContain("untitled");

--- a/scripts/review-findings.ts
+++ b/scripts/review-findings.ts
@@ -22,6 +22,7 @@
  *     --thread PRRT_kwDO… --reason "fixed in e4ec2f6db"
  */
 import {
+  blockingPolicyForThreshold,
   isBlocking,
   markQodoFindingResolved,
   resolveProvider,
@@ -218,7 +219,11 @@ async function listCommand(
 ): Promise<void> {
   const { head, threads } = await loadThreads(repo, prNumber, token, provider);
   const blocking = threads.filter((thread) =>
-    isBlocking(thread, provider, MAX_BLOCKING_PRIORITY),
+    isBlocking(
+      thread,
+      provider,
+      blockingPolicyForThreshold(MAX_BLOCKING_PRIORITY),
+    ),
   );
   console.log(
     `${provider.displayName} on ${repo}#${String(prNumber)} @ ${head.slice(0, 9)}`,

--- a/scripts/wait-for-review.test.ts
+++ b/scripts/wait-for-review.test.ts
@@ -5,6 +5,7 @@ import {
   requestGraceSecondsForProvider,
   reviewRequestScheduleBounds,
   SLOWEST_COMPLETED_REVIEW_SECONDS,
+  validateReviewRequestSchedule,
 } from "./lib/review-gate-policy.ts";
 import {
   DEFAULT_TIMEOUT_SECONDS,
@@ -211,6 +212,24 @@ describe("review gate timeout budget", () => {
         retryAfterSeconds: DEFAULT_REQUEST_RETRY_SECONDS,
       }).lastRequestAtSeconds,
     ).toBe(DEFAULT_REQUEST_GRACE_SECONDS + DEFAULT_REQUEST_RETRY_SECONDS);
+  });
+
+  test("rejects timing overrides that cut off the retry budget", () => {
+    expect(() =>
+      validateReviewRequestSchedule({
+        graceSeconds: 600,
+        retryAfterSeconds: 3000,
+        timeoutSeconds: 3600,
+      }),
+    ).toThrow("requires at least 5434s");
+    expect(() =>
+      validateReviewRequestSchedule({
+        graceSeconds: 0,
+        retryAfterSeconds: DEFAULT_REQUEST_RETRY_SECONDS,
+        timeoutSeconds:
+          DEFAULT_REQUEST_RETRY_SECONDS + SLOWEST_COMPLETED_REVIEW_SECONDS,
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/scripts/wait-for-review.test.ts
+++ b/scripts/wait-for-review.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DEFAULT_REQUEST_GRACE_SECONDS,
+  DEFAULT_REQUEST_RETRY_SECONDS,
+  reviewRequestScheduleBounds,
+  SLOWEST_COMPLETED_REVIEW_SECONDS,
+} from "./lib/review-gate-policy.ts";
+import {
   DEFAULT_TIMEOUT_SECONDS,
   parseMaxBlockingPriority,
   resolveReviewGateProvider,
@@ -162,8 +168,36 @@ describe("review gate timeout budget", () => {
   test("does not regress below the slowest completed review", () => {
     // Both measured on PR #2152, on reviews that completed normally only after
     // the 1200s budget had already failed the gate.
-    const slowestCompleted = 1834;
-    expect(DEFAULT_TIMEOUT_SECONDS).toBeGreaterThan(slowestCompleted);
+    expect(DEFAULT_TIMEOUT_SECONDS).toBeGreaterThan(
+      SLOWEST_COMPLETED_REVIEW_SECONDS,
+    );
+  });
+
+  // The retry is only a retry if the gate is still alive to see its answer. A
+  // grace period and a retry interval tuned in isolation produced exactly that
+  // bug: the second request landed 31 minutes in, against a 40-minute deadline,
+  // leaving nine minutes for a review that routinely needs thirty.
+  test("leaves the slowest completed review time to finish after the last request", () => {
+    const bounds = reviewRequestScheduleBounds({
+      graceSeconds: DEFAULT_REQUEST_GRACE_SECONDS,
+      retryAfterSeconds: DEFAULT_REQUEST_RETRY_SECONDS,
+    });
+    expect(DEFAULT_TIMEOUT_SECONDS).toBeGreaterThanOrEqual(
+      bounds.minimumGateTimeoutSeconds,
+    );
+  });
+
+  test("asks for the first review only after the provider has had a head start", () => {
+    // Both providers begin on their own — Qodo per push via `.pr_agent.toml`,
+    // Codex on open — and that starts before this pod boots. Asking at once
+    // would enqueue a second review of a head already being read.
+    expect(DEFAULT_REQUEST_GRACE_SECONDS).toBeGreaterThan(0);
+    expect(
+      reviewRequestScheduleBounds({
+        graceSeconds: DEFAULT_REQUEST_GRACE_SECONDS,
+        retryAfterSeconds: DEFAULT_REQUEST_RETRY_SECONDS,
+      }).lastRequestAtSeconds,
+    ).toBe(DEFAULT_REQUEST_GRACE_SECONDS + DEFAULT_REQUEST_RETRY_SECONDS);
   });
 });
 

--- a/scripts/wait-for-review.test.ts
+++ b/scripts/wait-for-review.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_REQUEST_GRACE_SECONDS,
   DEFAULT_REQUEST_RETRY_SECONDS,
+  requestGraceSecondsForProvider,
   reviewRequestScheduleBounds,
   SLOWEST_COMPLETED_REVIEW_SECONDS,
 } from "./lib/review-gate-policy.ts";
@@ -10,6 +11,7 @@ import {
   parseMaxBlockingPriority,
   resolveReviewGateProvider,
 } from "./wait-for-review.ts";
+import { codexProvider, qodoProvider } from "@shepherdjerred/code-review";
 
 describe("resolveReviewGateProvider", () => {
   test("defaults direct invocations to Qodo", () => {
@@ -187,11 +189,22 @@ describe("review gate timeout budget", () => {
     );
   });
 
-  test("asks for the first review only after the provider has had a head start", () => {
-    // Both providers begin on their own — Qodo per push via `.pr_agent.toml`,
-    // Codex on open — and that starts before this pod boots. Asking at once
-    // would enqueue a second review of a head already being read.
+  test("applies the first-review grace only to push-triggered providers", () => {
+    // Qodo starts on every push via `.pr_agent.toml`; Codex only starts when the
+    // pull request opens, so a new head needs an immediate explicit request.
     expect(DEFAULT_REQUEST_GRACE_SECONDS).toBeGreaterThan(0);
+    expect(
+      requestGraceSecondsForProvider(
+        qodoProvider,
+        DEFAULT_REQUEST_GRACE_SECONDS,
+      ),
+    ).toBe(DEFAULT_REQUEST_GRACE_SECONDS);
+    expect(
+      requestGraceSecondsForProvider(
+        codexProvider,
+        DEFAULT_REQUEST_GRACE_SECONDS,
+      ),
+    ).toBe(0);
     expect(
       reviewRequestScheduleBounds({
         graceSeconds: DEFAULT_REQUEST_GRACE_SECONDS,

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -17,23 +17,25 @@
  */
 
 import {
+  type BlockingPolicy,
+  blockingPolicyForThreshold,
   evaluateGate,
   formatSignalEvent,
-  isBlocking,
-  isProviderAuthor,
-  REVIEW_SIGNAL_SCHEMA,
   resolveProvider,
   reviewGateSkipReasonForAuthor,
   resolveRequiredReviewProvider,
-  tallyFindings,
   type GateDecision,
   type PullRequestAuthor,
   type ReviewProvider,
-  type ReviewSignalEvent,
   type ReviewThread,
 } from "@shepherdjerred/code-review";
 import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
-import { requestReviewAtHead } from "@shepherdjerred/code-review/request-review";
+import { buildSignalEvent } from "./lib/review-gate-signal.ts";
+import {
+  DEFAULT_REQUEST_RETRY_SECONDS,
+  ensureReviewRequested,
+  warnIfFirstReviewIsOversized,
+} from "./lib/review-gate-policy.ts";
 import {
   fetchPullRequestAuthor,
   fetchReviewThreads,
@@ -133,17 +135,6 @@ function repoFromEnvironment(): string {
   return DEFAULT_REPO;
 }
 
-function latencySeconds(
-  reviewedAt: string | null,
-  headPushedAt: string | null,
-): number | null {
-  if (reviewedAt === null || headPushedAt === null) return null;
-  const reviewed = Date.parse(reviewedAt);
-  const pushed = Date.parse(headPushedAt);
-  if (!Number.isFinite(reviewed) || !Number.isFinite(pushed)) return null;
-  return Math.round((reviewed - pushed) / 1000);
-}
-
 /**
  * Recognized transport-level failure signatures (no HTTP status): the socket
  * dropped, DNS/connection failed, or the request timed out. Covers both
@@ -205,71 +196,6 @@ function isRetryablePollError(error: Error): boolean {
   return TRANSPORT_FAILURE_RE.test(message);
 }
 
-function buildSignalEvent(input: {
-  provider: ReviewProvider;
-  pr: number;
-  head: string;
-  headPushedAt: string | null;
-  state: ReviewStateResult;
-  threads: readonly ReviewThread[];
-  maxBlockingPriority: number;
-  gateWaitSeconds: number;
-  timedOut: boolean;
-  decision: GateDecision | null;
-}): ReviewSignalEvent {
-  const providerThreads = input.threads.filter(
-    (thread) =>
-      isProviderAuthor(input.provider, thread.authorLogin) &&
-      !thread.isOutdated,
-  );
-  const blocking = input.threads.filter((thread) =>
-    isBlocking(thread, input.provider, input.maxBlockingPriority),
-  );
-  const reviewState =
-    input.state.completionSignal === "thumbsup-reaction"
-      ? "reviewed-clean-reaction"
-      : input.state.state;
-  return {
-    schema: REVIEW_SIGNAL_SCHEMA,
-    ts: new Date().toISOString(),
-    provider: input.provider.id,
-    pr: input.pr,
-    head_sha: input.head,
-    head_pushed_at: input.headPushedAt,
-    review_state: reviewState,
-    completion_signal: input.state.completionSignal,
-    reviewed_at_head: input.state.reviewedCommit === input.head,
-    // Latency is only meaningful when the reviewed commit IS the head; a stale
-    // review of an older commit must not produce a (possibly negative) latency.
-    latency_s:
-      input.state.reviewedCommit === input.head
-        ? latencySeconds(input.state.reviewedAt, input.headPushedAt)
-        : null,
-    findings: tallyFindings(providerThreads.map((thread) => thread.priority)),
-    blocking_count: blocking.length,
-    unresolved_count: providerThreads.filter((thread) => !thread.isResolved)
-      .length,
-    gate_wait_s: input.gateWaitSeconds,
-    timed_out: input.timedOut,
-    stale_reaction: input.state.staleReaction,
-    decision: input.decision === null ? null : input.decision.state,
-    parser_commit: parserCommit(),
-  };
-}
-
-/**
- * The commit of the `code-review` source that produced this observation.
- *
- * `review-gate.sh` runs the gate from a worktree of `main` and passes the
- * commit it checked out. Recording it makes the log say which parser produced
- * a count — the one thing that would have made an inflated `blocking_count`
- * obvious at a glance rather than after a long hunt.
- */
-function parserCommit(): string | null {
-  const commit = Bun.env["REVIEW_GATE_PARSER_COMMIT"];
-  return commit === undefined || commit.trim() === "" ? null : commit.trim();
-}
-
 async function waitForReview(): Promise<void> {
   const pullRequest = Bun.env["BUILDKITE_PULL_REQUEST"];
   if (
@@ -299,7 +225,7 @@ async function waitForReview(): Promise<void> {
   const head = commit.trim();
   const repo = repoFromEnvironment();
   const provider = resolveReviewGateProvider(Bun.env["REVIEW_PROVIDER"]);
-  const maxBlockingPriority = parseMaxBlockingPriority();
+  const policy = blockingPolicyForThreshold(parseMaxBlockingPriority());
   const timeoutSeconds = parsePositiveIntegerEnv(
     "REVIEW_WAIT_TIMEOUT_SECONDS",
     DEFAULT_TIMEOUT_SECONDS,
@@ -308,10 +234,15 @@ async function waitForReview(): Promise<void> {
     "REVIEW_WAIT_INTERVAL_SECONDS",
     DEFAULT_INTERVAL_SECONDS,
   );
+  const retryAfterSeconds = parsePositiveIntegerEnv(
+    "REVIEW_REQUEST_RETRY_SECONDS",
+    DEFAULT_REQUEST_RETRY_SECONDS,
+  );
 
   console.log(
     `Review gate: provider=${provider.id}, repo=${repo}, pr=#${String(number)}, head=${head}, ` +
-      `timeout=${String(timeoutSeconds)}s, blockingPriority<=P${String(maxBlockingPriority)}.`,
+      `timeout=${String(timeoutSeconds)}s, blockingPriority<=P${String(policy.maxBlockingPriority)}, ` +
+      `lowSeverity=${policy.lowSeverity}.`,
   );
 
   await pollReviewGate({
@@ -320,7 +251,8 @@ async function waitForReview(): Promise<void> {
     number,
     head,
     token,
-    maxBlockingPriority,
+    policy,
+    retryAfterSeconds,
     timeoutSeconds,
     intervalSeconds,
   });
@@ -332,7 +264,8 @@ type GateConfig = {
   number: number;
   head: string;
   token: string;
-  maxBlockingPriority: number;
+  policy: BlockingPolicy;
+  retryAfterSeconds: number;
   timeoutSeconds: number;
   intervalSeconds: number;
 };
@@ -346,6 +279,7 @@ function emitSignal(input: {
   startedAt: number;
   timedOut: boolean;
   decision: GateDecision | null;
+  requestAttempts: number;
 }): void {
   const { config } = input;
   console.log(
@@ -357,10 +291,11 @@ function emitSignal(input: {
         headPushedAt: input.headPushedAt,
         state: input.state,
         threads: input.threads,
-        maxBlockingPriority: config.maxBlockingPriority,
+        policy: config.policy,
         gateWaitSeconds: Math.round((Date.now() - input.startedAt) / 1000),
         timedOut: input.timedOut,
         decision: input.decision,
+        requestAttempts: input.requestAttempts,
       }),
     ),
   );
@@ -388,7 +323,8 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
     number,
     head,
     token,
-    maxBlockingPriority,
+    policy,
+    retryAfterSeconds,
     timeoutSeconds,
     intervalSeconds,
   } = config;
@@ -396,6 +332,7 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
   const startedAt = Date.now();
   const deadline = startedAt + timeoutSeconds * 1000;
   let warnedMismatch = false;
+  let warnedOversizedFirstReview = false;
   // The head push time is REQUIRED for the clean-review 👍 binding (not
   // telemetry-only), so it is fetched INSIDE the retry loop and CACHED only once
   // a real timestamp resolves. A null result is deliberately NOT cached: the
@@ -411,7 +348,10 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
   // Whether this run has already asked the provider to review the head. The
   // marker check makes a duplicate request impossible anyway; this avoids
   // paying for a comment scan on every poll.
-  let requested = false;
+  // The next request attempt to make for this head, 1-based. Incremented only
+  // once an attempt has actually been posted, so a poll that decides it is too
+  // early to escalate re-decides on the next one.
+  let attempt = 1;
 
   while (Date.now() <= deadline) {
     let stateResult: ReviewStateResult;
@@ -489,37 +429,19 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
       });
 
       // Ask for the review this loop is waiting on, once we have seen that the
-      // provider has not already reviewed this head. Keep this write inside the
-      // same retry boundary as the reads above: a transient failure while
-      // checking or posting the request must not fail the gate immediately.
-      //
-      // Qodo reviews a PR once, when it is opened, and never again on its own.
-      // Polling alone therefore waits out the entire budget on every push after
-      // the first and then fails a PR whose diff is fine. The request is asked
-      // for after the first observation rather than before it, so a head the
-      // provider has already reviewed is never asked again; the marker makes a
-      // repeat impossible even so.
-      if (!requested && stateResult.reviewedCommit !== head) {
-        const outcome = await requestReviewAtHead({
-          repo,
-          number,
-          head,
-          token,
-          provider,
-        });
-        requested = true;
-        console.log(
-          JSON.stringify({
-            level: "info",
-            msg: `review-request-${outcome}`,
-            component: "review-gate",
-            provider: provider.id,
-            repo,
-            pr: number,
-            head_sha: head,
-          }),
-        );
-      }
+      // provider has not already reviewed this head. Kept inside the same retry
+      // boundary as the reads above: a transient failure while checking or
+      // posting the request must not fail the gate immediately.
+      attempt = await ensureReviewRequested({
+        repo,
+        number,
+        head,
+        token,
+        provider,
+        attempt,
+        retryAfterSeconds,
+        reviewedCommit: stateResult.reviewedCommit,
+      });
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       if (!isRetryablePollError(err)) throw err;
@@ -550,9 +472,17 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
       provider,
       reviewState: stateResult.state,
       threads: threadResult.threads,
-      maxBlockingPriority,
+      policy,
       skipReason: stateResult.skipReason,
     });
+
+    if (!warnedOversizedFirstReview) {
+      warnedOversizedFirstReview = warnIfFirstReviewIsOversized({
+        provider,
+        number,
+        threads: threadResult.threads,
+      });
+    }
 
     emitSignal({
       config,
@@ -562,6 +492,8 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
       startedAt,
       timedOut: false,
       decision,
+      // Attempts already made, not the next one queued up.
+      requestAttempts: attempt - 1,
     });
 
     if (decision.state === "passed") {
@@ -588,6 +520,7 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
     startedAt,
     timedOut: true,
     decision: null,
+    requestAttempts: attempt - 1,
   });
 
   if (lastPollError !== null) {

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -32,6 +32,7 @@ import {
 import { fetchHeadPushedAt } from "@shepherdjerred/code-review/head-pushed-at";
 import { buildSignalEvent } from "./lib/review-gate-signal.ts";
 import {
+  DEFAULT_REQUEST_GRACE_SECONDS,
   DEFAULT_REQUEST_RETRY_SECONDS,
   ensureReviewRequested,
   warnIfFirstReviewIsOversized,
@@ -59,6 +60,15 @@ const DEFAULT_REPO = "shepherdjerred/monorepo";
  * undershooting costs a false red on a healthy PR, so the asymmetry favours
  * headroom.
  *
+ * It also has to hold the request schedule. The gate waits a grace period before
+ * asking at all and may ask once more after that, so the deadline must leave the
+ * slowest review we have watched complete still able to finish after the LAST
+ * request — otherwise the retry is advertised and then cut off.
+ * `reviewRequestScheduleBounds()` states that relation and
+ * `wait-for-review.test.ts` asserts it, which is why raising the retry interval
+ * without raising this fails the suite rather than silently disabling the
+ * retry.
+ *
  * The durable fix is ordering rather than duration — not starting the gate
  * until the review exists — but that is a CI-architecture change, not a
  * constant.
@@ -70,7 +80,7 @@ const DEFAULT_REPO = "shepherdjerred/monorepo";
  * `wait-for-review.test.ts` asserts that ordering against the pipeline,
  * reading the step's own declared timeout rather than the first one it finds.
  */
-export const DEFAULT_TIMEOUT_SECONDS = 40 * 60;
+export const DEFAULT_TIMEOUT_SECONDS = 60 * 60;
 const DEFAULT_INTERVAL_SECONDS = 30;
 
 export function resolveReviewGateProvider(
@@ -238,6 +248,10 @@ async function waitForReview(): Promise<void> {
     "REVIEW_REQUEST_RETRY_SECONDS",
     DEFAULT_REQUEST_RETRY_SECONDS,
   );
+  const graceSeconds = parsePositiveIntegerEnv(
+    "REVIEW_REQUEST_GRACE_SECONDS",
+    DEFAULT_REQUEST_GRACE_SECONDS,
+  );
 
   console.log(
     `Review gate: provider=${provider.id}, repo=${repo}, pr=#${String(number)}, head=${head}, ` +
@@ -252,6 +266,7 @@ async function waitForReview(): Promise<void> {
     head,
     token,
     policy,
+    graceSeconds,
     retryAfterSeconds,
     timeoutSeconds,
     intervalSeconds,
@@ -265,6 +280,7 @@ type GateConfig = {
   head: string;
   token: string;
   policy: BlockingPolicy;
+  graceSeconds: number;
   retryAfterSeconds: number;
   timeoutSeconds: number;
   intervalSeconds: number;
@@ -324,6 +340,7 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
     head,
     token,
     policy,
+    graceSeconds,
     retryAfterSeconds,
     timeoutSeconds,
     intervalSeconds,
@@ -439,7 +456,10 @@ async function pollReviewGate(config: GateConfig): Promise<void> {
         token,
         provider,
         attempt,
+        graceSeconds,
         retryAfterSeconds,
+        headPushedAt,
+        startedAt,
         reviewedCommit: stateResult.reviewedCommit,
       });
     } catch (error) {

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -36,6 +36,7 @@ import {
   DEFAULT_REQUEST_RETRY_SECONDS,
   ensureReviewRequested,
   requestGraceSecondsForProvider,
+  validateReviewRequestSchedule,
   warnIfFirstReviewIsOversized,
 } from "./lib/review-gate-policy.ts";
 import {
@@ -257,6 +258,11 @@ async function waitForReview(): Promise<void> {
     provider,
     configuredGraceSeconds,
   );
+  validateReviewRequestSchedule({
+    graceSeconds,
+    retryAfterSeconds,
+    timeoutSeconds,
+  });
 
   console.log(
     `Review gate: provider=${provider.id}, repo=${repo}, pr=#${String(number)}, head=${head}, ` +

--- a/scripts/wait-for-review.ts
+++ b/scripts/wait-for-review.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_REQUEST_GRACE_SECONDS,
   DEFAULT_REQUEST_RETRY_SECONDS,
   ensureReviewRequested,
+  requestGraceSecondsForProvider,
   warnIfFirstReviewIsOversized,
 } from "./lib/review-gate-policy.ts";
 import {
@@ -248,9 +249,13 @@ async function waitForReview(): Promise<void> {
     "REVIEW_REQUEST_RETRY_SECONDS",
     DEFAULT_REQUEST_RETRY_SECONDS,
   );
-  const graceSeconds = parsePositiveIntegerEnv(
+  const configuredGraceSeconds = parsePositiveIntegerEnv(
     "REVIEW_REQUEST_GRACE_SECONDS",
     DEFAULT_REQUEST_GRACE_SECONDS,
+  );
+  const graceSeconds = requestGraceSecondsForProvider(
+    provider,
+    configuredGraceSeconds,
   );
 
   console.log(


### PR DESCRIPTION
## Why

The required review gate has no terminating condition. Measured across PRs #2259–#2308 (33 human-authored PRs; 17 bump PRs both providers skip):

| | |
| --- | --- |
| Finding-bearing rounds | **260** |
| Findings | **572** (26% P1, 73% P2, 4 P3) |
| Review requests posted | **616** |
| Buildkite builds / minutes | **408 / 3,401** |
| Worst PR (#2301) | 38 rounds, 103 requests, 58 builds |

The findings are not the problem. 76 of them were graded blind — severity badges stripped, shuffled across six independent graders that verified each claim against the source at the reviewing commit — and the 29 load-bearing verdicts were then handed to two adversarial refuters told to default to refuted. **~97% describe real defects.**

The problem is that the loop reviews its own output. Blaming the exact line each finding points at, against the PR's first review time: **69% of all findings — and 93% of those from round 8 onward — flag a line that did not exist when the PR was first reviewed.**

Severity separates cleanly, and blind graders recovered the split without seeing the label:

| label | n | production bugs | edge case | hardening | polish |
| --- | ---: | ---: | ---: | ---: | ---: |
| P1 | 36 | **18 (50%)** | 17 | 0 | 0 |
| P2 | 36 | **3 (8%)** | 22 | 5 | 6 |

Adversarial review *strengthened* that ordering: of the production-bug claims tested, all 3 P2s were downgraded while 7 of 18 P1s survived. But P2 is not noise — 36/36 were real defects — so dropping it outright gives up genuine edge-case correctness fixes.

## What

**P1 always blocks. A lower-severity finding blocks only when it came from the PR's first review, or from a review that also raised a P1** — another round is already being paid for, so everything in it gets fixed. Everything else is advisory: still posted, no longer a gate.

Projected against the measured sequences: **260 → 88 rounds, ~408 → ~169 builds (−59% CI)**, while still requiring 116 of 417 P2 findings to be fixed rather than the 60 a first-review-only rule would.

Severity is bound to the review that *raised* a finding, not to the current round. Binding it to the round degenerates: the gate blocks on unresolved threads, so lowering the threshold at round 2 would also unblock every round-1 finding and any throwaway push would clear the first review's sweep. `ReviewThread.raisedInReview` carries the raising review's ordinal and whether it also held a P1; Qodo findings — parsed from a rewritten issue comment that records no round — inherit it through `mergeDuplicateFindings` from their addressable thread copy. **A finding that cannot be attributed blocks.** `REVIEW_MAX_BLOCKING_PRIORITY=1` disables the low-severity rules entirely, so the policy can be neutralised from the pipeline without a revert.

Also here:

- **Config over comments.** New `.pr_agent.toml` enables Qodo's `handle_push_trigger`, so Qodo re-reviews on push without a comment — 329 of the 616 requests. Codex has no per-push setting (its "Automatic reviews" fire on PR open only), so its request path stays.
- **Requests say they are automated**, and Qodo's trigger moves to the documented `/agentic_review`.
- **Grace, then one retry.** Only ~64% of automated requests drew a response within an hour and nothing ever re-asked — that gap produced all 86 hand-typed requests. The gate now waits `REVIEW_REQUEST_GRACE_SECONDS` (10 min) from the head's push before asking at all, so a provider already reviewing on its own is not told to start again, then re-asks once after `REVIEW_REQUEST_RETRY_SECONDS` (15 min), capped at two attempts, with the clock read from the first request comment's creation time. Grace, retry and the gate deadline are one budget — `reviewRequestScheduleBounds()` requires the last request to leave the slowest observed review (1834s) time to finish, asserted in `wait-for-review.test.ts`; the deadline moves to 60 min and both gate steps to 90 min to hold the existing preamble margin.
- **Round-1 warning**, non-blocking: no PR whose first review returned ≥4 findings converged within three rounds (median 15, worst 38).
- **`scripts/review-analytics.ts`** (`rounds` / `requests` / `blame`) makes every figure above reproducible instead of a one-off.

## Verification

- `bunx turbo run typecheck` — **90/90 green** repo-wide.
- `bunx turbo run lint` — **93/93 green** repo-wide.
- `bunx turbo run test` across code-review, root-scripts, pr-fleet-controller, temporal, toolkit — green; 167 tests in `code-review`.
- `bun scripts/check-ci-env.ts` — OK, 27 steps / 66 invocations. `//#knip` green.
- New `gate.test.ts` cases pin the degeneration directly: a first-review low-severity finding still blocks after later reviews exist; a later-review one alone does not; one sharing a review with a P1 does.
- `review-analytics.ts` reproduces the hand-computed numbers exactly against live GitHub — #2301's 38-round sequence character for character, #2306's 14 automated / 7 manual requests, its 6-of-11 churn-authored findings.

**Not verified live**, and deliberately left for this PR to answer:

1. No CI build has run this gate yet. Exercise it with `REVIEW_GATE_REF=<this branch>` on a real PR build before trusting it on `main`.
2. Three Qodo config assumptions are only checkable against the live app, and **this PR's own pushes are the test**: whether the free open-source Qodo app reads a repo-root `.pr_agent.toml` at all, whether the GitHub section is `[github]` (the docs example uses `[gitlab]`), and which default wins where the portal and TOML pages disagree. If it does not take effect, the gate's comment path still works — the config is additive.

## Follow-up, deliberately not in this PR

**105 findings (26 P1, 79 P2) are unresolved and still current on PRs that merged**, 61 of them Codex. For Qodo that is explained by ☑-chip dismissal leaving the inline thread open; the Codex half has no explanation yet. One concrete instance: `packages/pr-fleet-controller/src/tools.ts` still spawns the worker command through the operator's `$SHELL` with plain `['-c']` and no `--no-config`, so fish sources `config.fish` and re-exports the eight 1Password-backed tokens `workerCommandEnvironment()` had just stripped (confirmed empirically — `env -i fish -c` repopulates `LINEAR_API_KEY`). Separate defect, separate risk profile; it should not wait on gate changes.
