### PR TITLE
feat(scout-for-lol): frame Bryan Bucks bets as WIN/LOSE and stop restating the rules

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
@@ -17,6 +17,10 @@ import {
   InsufficientBucksError,
 } from "#src/betting/ledger.ts";
 import { ParlaySubjectsSchema } from "#src/betting/parlay-criteria.ts";
+import {
+  hasTrackedPlayersOnBothTeams,
+  outcomeLabel,
+} from "#src/betting/team.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isUniqueConstraintError } from "#src/lib/player-admin/shared.ts";
 import { createLogger } from "#src/logger.ts";
@@ -311,6 +315,8 @@ export type PendingPosition =
       marketType: "outcome";
       gameAlias: string;
       teamId: RiotTeamId;
+      /** WIN/LOSE for this game, or Blue/Red when both teams are tracked. */
+      sideLabel: string;
       offeredStake: number;
       matchedStake: number | null;
       unmatchedStake: number | null;
@@ -415,6 +421,11 @@ export async function getPersonalBucksView(
         matchId: bet.pool.matchId,
         gameAlias: subject.trackedAlias,
         teamId: RiotTeamIdSchema.parse(bet.predictedTeamId),
+        // The roster is already parsed here, so framing costs nothing extra.
+        sideLabel: outcomeLabel(RiotTeamIdSchema.parse(bet.predictedTeamId), {
+          anchorTeamId: subject.teamId,
+          mixedTeams: hasTrackedPlayersOnBothTeams(roster),
+        }),
         offeredStake: bet.stake,
         matchedStake: bet.matchedStake,
         unmatchedStake: bet.unmatchedStake,

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.integration.test.ts
@@ -136,26 +136,30 @@ afterAll(async () => {
 });
 
 describe("handleBetButton", () => {
+  // The shared test roster tracks players on BOTH teams, so it is the mixed
+  // lobby and keeps the literal Blue/Red framing.
   test.each([
-    ["Blue · 1 BB", 100, 1, "Blue Team"],
-    ["Blue · 5 BB", 100, 5, "Blue Team"],
-    ["Red · 1 BB", 200, 1, "Red Team"],
-    ["Red · 5 BB", 200, 5, "Red Team"],
+    ["Blue · 1 BB", 100, 1, "Blue"],
+    ["Blue · 5 BB", 100, 5, "Blue"],
+    ["Red · 1 BB", 200, 1, "Red"],
+    ["Red · 5 BB", 200, 5, "Red"],
   ])(
     "%s places a direct team bet",
-    async (label, expectedTeamId, expectedStake, expectedTeamName) => {
+    async (label, expectedTeamId, expectedStake, expectedSideLabel) => {
       const customId = buttonIdForLabel(bucksTestRoster(), label);
       const { interaction, replies } = fakeInteraction(customId);
       await handleBetButton(interaction, db);
 
-      expect(replies[0]).toContain("Offer placed");
-      expect(replies[0]).toContain(expectedTeamName);
-      expect(replies[0]).not.toContain("jerred WINS");
-      expect(replies[0]).toContain("for up to");
-      expect(replies[0]).toContain("only matched BB are at risk");
-      expect(replies[0]).toContain("5 BB per game");
-      expect(replies[0]).toContain("20% of matched profit**, rounded down");
-      expect(replies[0]).toContain("parlay cancellation is fully refunded");
+      expect(replies[0]).toContain(`**${expectedSideLabel}**`);
+      expect(replies[0]).toContain("offered up to");
+      // The one rule that survives on a confirmation, because without it the
+      // number reads as a guaranteed loss rather than a maximum offer.
+      expect(replies[0]).toContain("Only matched BB are at risk");
+      // Everything else belongs in /bb rules and must not be restated here.
+      expect(replies[0]).not.toContain("20%");
+      expect(replies[0]).not.toContain("5 BB per game");
+      expect(replies[0]).not.toContain("rounded down");
+      expect(replies[0]).not.toContain("parlay cancellation");
       expect(await db.bucksBet.count()).toBe(1);
       const bet = await db.bucksBet.findFirstOrThrow();
       expect(bet.predictedTeamId).toBe(expectedTeamId);
@@ -168,12 +172,17 @@ describe("handleBetButton", () => {
     },
   );
 
+  // The BUTTONS here are built from a roster where only the Red-side player is
+  // tracked, so they reframe to WIN/LOSE — WIN means team 200. The reply label
+  // comes from the pool's own frozen roster, which is the shared mixed one, so
+  // it still reads Blue/Red. In production both are the same roster; what this
+  // pins is that the anchor translation stores the right team either way.
   test.each([
-    ["Blue · 1 BB", 100, "Blue Team"],
-    ["Red · 1 BB", 200, "Red Team"],
+    ["WIN · 1 BB", 200, "Red"],
+    ["LOSE · 1 BB", 100, "Blue"],
   ])(
     "%s persists the selected team through a Red-side anchor",
-    async (label, expectedTeamId, expectedTeamName) => {
+    async (label, expectedTeamId, expectedSideLabel) => {
       const redAnchorRoster = bucksTestRoster().map((participant, index) => ({
         ...participant,
         trackedAlias: index === 5 ? "bryan" : undefined,
@@ -183,7 +192,7 @@ describe("handleBetButton", () => {
       const { interaction, replies } = fakeInteraction(customId);
       await handleBetButton(interaction, db);
 
-      expect(replies[0]).toContain(expectedTeamName);
+      expect(replies[0]).toContain(`**${expectedSideLabel}**`);
       const bet = await db.bucksBet.findFirstOrThrow();
       expect(bet.predictedTeamId).toBe(expectedTeamId);
     },
@@ -203,10 +212,8 @@ describe("handleBetButton", () => {
     const refreshes: { matchId: string; serverId: string }[] = [];
     await handleBetButton(interaction, db, recordingRefreshes(refreshes));
 
-    expect(replies[0]).toContain("Offer cancelled");
-    expect(replies[0]).toContain(
-      "offered **5 BB** − **1 BB cancellation fee** = **4 BB returned**",
-    );
+    expect(replies[0]).toContain("Cancelled");
+    expect(replies[0]).toContain("**5 BB** − **1 BB** fee = **4 BB** back");
     expect(await db.bucksBet.count()).toBe(1);
     expect(await db.bucksOpenPosition.count()).toBe(0);
     expect(await db.bucksBet.findFirstOrThrow()).toEqual(
@@ -268,7 +275,7 @@ describe("handleBetButton", () => {
       return f;
     })();
 
-    expect(replies[0]).toContain("Offer placed");
+    expect(replies[0]).toContain("offered up to");
     expect(await db.bucksBet.count()).toBe(2);
     const bet = await db.bucksBet.findFirstOrThrow({
       where: { betOutcome: "pending" },
@@ -294,8 +301,8 @@ describe("handleBetButton", () => {
 
     // "You don't have a bet" would be a lie to someone whose stake is sitting
     // in the pool, and would read as if it had never been recorded.
-    expect(replies[0]).toContain("Betting has closed");
-    expect(replies[0]).toContain("check the close announcement");
+    expect(replies[0]).toContain("Betting is closed");
+    expect(replies[0]).toContain("your bet is locked in");
     expect(replies[0]).not.toContain("were returned");
     expect(replies[0]).not.toContain("don't have a bet");
 

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -3,15 +3,24 @@ import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   type BucksPoolParticipant,
-  type RiotTeamId,
 } from "@scout-for-lol/data";
 import type { InteractionEditReplyOptions } from "discord.js";
 import { parseBucksCustomId } from "#src/betting/custom-id.ts";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { placeBet, type PlaceBetResult } from "#src/betting/place-bet.ts";
 import { cancelBet, type CancelBetResult } from "#src/betting/cancel-bet.ts";
 import { refreshBucksMessages } from "#src/betting/message-refresh.ts";
-import { teamIdForSubjectOutcome, teamName } from "#src/betting/team.ts";
+import { outcomeLabel, teamIdForSubjectOutcome } from "#src/betting/team.ts";
+import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
+import {
+  BUCKS_GUILD_ONLY,
+  BUCKS_HOUSE_CANNOT_FUND,
+  BUCKS_INVALID_STAKE,
+  BUCKS_NOT_ELIGIBLE,
+  BUCKS_NOT_ENABLED,
+  BUCKS_NO_OUTCOME_MARKET,
+  BUCKS_STORAGE_LIMIT,
+  bucksInsufficient,
+} from "#src/betting/copy.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -50,32 +59,36 @@ const defaultDependencies: BetButtonDependencies = {
  * user input at a system boundary, so none of them are errors. */
 export function describeResult(
   result: PlaceBetResult,
-  selectedTeamId: RiotTeamId,
+  sideLabel: string,
 ): string {
   switch (result.kind) {
     case "placed": {
-      return `✅ Offer placed: **${teamName(selectedTeamId)} wins** for up to **${result.totalStake.toString()} BB**. The final matched amount will be announced at close. Available balance: **${result.balanceAfter.toString()} BB**. ${HOUSE_CUT_TERMS}`;
+      // "Only matched BB are at risk" is the one rule that survives on a
+      // confirmation: without it the number above reads as a guaranteed loss
+      // amount, which is not what was submitted. Everything else is in
+      // `/bb rules`.
+      return `✅ **${sideLabel}** — offered up to **${result.totalStake.toString()} BB** · balance **${result.balanceAfter.toString()} BB**. Only matched BB are at risk; the rest is refunded at close.`;
     }
     case "window_closed":
       return "⏰ Betting has closed for this game.";
     case "no_pool":
-      return "🚫 There's no Bryan Bucks market for this game.";
+      return BUCKS_NO_OUTCOME_MARKET;
     case "feature_disabled":
-      return "🚫 Bryan Bucks is no longer enabled in this server.";
+      return BUCKS_NOT_ENABLED;
     case "not_eligible":
-      return "🔒 Only tracked players can bet. Ask an admin to link your Discord account to a player in the dashboard.";
+      return BUCKS_NOT_ELIGIBLE;
     case "unknown_subject":
       return `🤔 That player isn't in this game. Try: ${result.validAliases.join(", ")}.`;
     case "invalid_stake":
-      return "💱 Offers must be a positive whole number of BB.";
+      return BUCKS_INVALID_STAKE;
     case "storage_limit":
-      return "💱 That position is too large for the current Bryan Bucks storage format.";
+      return BUCKS_STORAGE_LIMIT;
     case "insufficient":
-      return `💸 You have **${result.balance.toString()} BB** but need **${result.needed.toString()} BB**.`;
+      return bucksInsufficient(result.balance, result.needed);
     case "house_insufficient":
-      return "🏦 The Bryan Bucks house cannot fund a new wallet right now. No Bucks moved.";
+      return BUCKS_HOUSE_CANNOT_FUND;
     case "side_conflict":
-      return "↔️ You already backed the other side of this game. Cancel your bet first.";
+      return "↔️ You already backed the other side. Cancel that bet first.";
   }
 }
 
@@ -85,17 +98,17 @@ export function describeResult(
 export function describeCancel(result: CancelBetResult): string {
   switch (result.kind) {
     case "cancelled":
-      return `↩️ Offer cancelled: offered **${result.stake.toString()} BB** − **${result.houseCut.toString()} BB cancellation fee** = **${result.refunded.toString()} BB returned**; balance **${result.balanceAfter.toString()} BB**.`;
+      return `↩️ Cancelled: **${result.stake.toString()} BB** − **${result.houseCut.toString()} BB** fee = **${result.refunded.toString()} BB** back · balance **${result.balanceAfter.toString()} BB**.`;
     case "window_closed":
-      return "⏰ Betting has closed for this game. Your offer can no longer be cancelled; check the close announcement for your final matched amount and any unmatched refund.";
+      return "⏰ Betting is closed — your bet is locked in. Final amounts are on the game message.";
     case "already_resolved":
       return result.poolState === "settled"
-        ? "✅ This game has already settled, so there's nothing left to cancel — check your balance for the payout."
-        : "🚫 This game's market was voided, so matched BB were refunded and unmatched BB were already returned.";
+        ? "✅ Already settled — check `/bb balance`."
+        : "🚫 Voided — everything was refunded.";
     case "no_bet":
       return "🤷 You don't have a bet to cancel on this game.";
     case "no_pool":
-      return "🚫 There's no Bryan Bucks market for this game.";
+      return BUCKS_NO_OUTCOME_MARKET;
   }
 }
 
@@ -129,7 +142,7 @@ export async function handleBetButton(
   if (interaction.guildId === null) {
     await interaction.deferReply({ ephemeral: true });
     await interaction.editReply({
-      content: "🏠 Bryan Bucks only works inside a server.",
+      content: BUCKS_GUILD_ONLY,
     });
     return;
   }
@@ -145,7 +158,7 @@ export async function handleBetButton(
   });
   if (pool === null) {
     await interaction.editReply({
-      content: "🚫 There's no Bryan Bucks market for this game.",
+      content: BUCKS_NO_OUTCOME_MARKET,
     });
     return;
   }
@@ -178,6 +191,11 @@ export async function handleBetButton(
 
   const betOnWin = parsed.side === "W";
   const selectedTeamId = teamIdForSubjectOutcome(subject.teamId, betOnWin);
+  const anchor = bettingAnchor(roster);
+  const sideLabel = outcomeLabel(
+    selectedTeamId,
+    anchor === undefined ? undefined : subjectFraming(anchor),
+  );
   const result = await placeBet(
     {
       matchId: parsed.matchId,
@@ -191,7 +209,7 @@ export async function handleBetButton(
   );
 
   await interaction.editReply({
-    content: describeResult(result, selectedTeamId),
+    content: describeResult(result, sideLabel),
   });
 
   if (result.kind === "placed") {

--- a/packages/scout-for-lol/packages/backend/src/betting/components.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/components.ts
@@ -10,8 +10,10 @@ import { BLUE_TEAM_ID, BUTTON_STAKES } from "#src/betting/constants.ts";
 import { formatBucksCustomId } from "#src/betting/custom-id.ts";
 import {
   BETTING_TEAM_IDS,
-  shortTeamName,
+  hasTrackedPlayersOnBothTeams,
+  outcomeLabel,
   subjectWinsForTeam,
+  type OutcomeFraming,
 } from "#src/betting/team.ts";
 
 /**
@@ -27,7 +29,14 @@ export type BettableSubject = {
   index: number;
   /** Used only to translate a direct team choice into the v1 WIN/LOSE ID. */
   teamId: RiotTeamId;
+  /** Tracked players on both teams, so this game's copy stays Blue/Red. */
+  mixedTeams: boolean;
 };
+
+/** How this game's two outcomes should be named. */
+export function subjectFraming(subject: BettableSubject): OutcomeFraming {
+  return { anchorTeamId: subject.teamId, mixedTeams: subject.mixedTeams };
+}
 
 /**
  * The first tracked player in roster order, used as this game's button anchor.
@@ -39,13 +48,28 @@ export type BettableSubject = {
 export function bettingAnchor(
   roster: readonly BucksPoolParticipant[],
 ): BettableSubject | undefined {
+  const mixedTeams = hasTrackedPlayersOnBothTeams(roster);
   for (const [index, participant] of roster.entries()) {
     if (participant.trackedAlias === undefined || participant.puuid === null) {
       continue;
     }
-    return { index, teamId: participant.teamId };
+    return { index, teamId: participant.teamId, mixedTeams };
   }
   return undefined;
+}
+
+/**
+ * Green for the tracked player winning, red for losing; the mixed lobby keeps
+ * the literal Blue/Red colours because neither side is "ours".
+ */
+function buttonStyleFor(
+  teamId: RiotTeamId,
+  anchor: BettableSubject,
+): ButtonStyle.Primary | ButtonStyle.Success | ButtonStyle.Danger {
+  if (anchor.mixedTeams) {
+    return teamId === BLUE_TEAM_ID ? ButtonStyle.Primary : ButtonStyle.Danger;
+  }
+  return teamId === anchor.teamId ? ButtonStyle.Success : ButtonStyle.Danger;
 }
 
 function buildRow(input: {
@@ -69,10 +93,10 @@ function buildRow(input: {
               amount: stake,
             }),
           )
-          .setLabel(`${shortTeamName(teamId)} · ${stake.toString()} BB`)
-          .setStyle(
-            teamId === BLUE_TEAM_ID ? ButtonStyle.Primary : ButtonStyle.Danger,
+          .setLabel(
+            `${outcomeLabel(teamId, subjectFraming(input.anchor))} · ${stake.toString()} BB`,
           )
+          .setStyle(buttonStyleFor(teamId, input.anchor))
           .setDisabled(input.disabled),
       );
     }

--- a/packages/scout-for-lol/packages/backend/src/betting/copy.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/copy.ts
@@ -1,0 +1,48 @@
+import { BUCKS_RULES_HINT } from "#src/betting/prematch-line.ts";
+
+/**
+ * User-facing Bryan Bucks strings shared by more than one surface.
+ *
+ * Two rules govern everything in this file:
+ *
+ * 1. **State numbers, not rules.** `/bb rules` is the only place a fee, a
+ *    window, or a rounding mode is explained. Every other surface that
+ *    restated them drifted: the rules embed and the old prematch blurb once
+ *    described the winner fee as two different amounts at the same time.
+ * 2. **One concept, one string.** The outcome and parlay handlers previously
+ *    carried five copies of the DM guard in two dialects, three copies of
+ *    "no market", and a parlay "only tracked players can bet" that silently
+ *    dropped the remediation sentence its outcome twin carried.
+ */
+
+export const BUCKS_GUILD_ONLY = "🏠 Bryan Bucks only works inside a server.";
+
+export const BUCKS_NOT_ENABLED = "🚫 Bryan Bucks isn't enabled in this server.";
+
+export const BUCKS_NO_OUTCOME_MARKET =
+  "🚫 There's no Bryan Bucks market for this game.";
+
+export const BUCKS_NO_PARLAY_MARKET =
+  "🚫 There's no parlay market for this game.";
+
+/** Keeps the actionable second sentence; the parlay copy used to drop it. */
+export const BUCKS_NOT_ELIGIBLE =
+  "🔒 Only tracked players can bet. Ask an admin to link your Discord account to a player in the dashboard.";
+
+export const BUCKS_INVALID_STAKE =
+  "💱 Bets must be a positive whole number of BB.";
+
+export const BUCKS_STORAGE_LIMIT =
+  "💱 That position is too large for the current Bryan Bucks storage format.";
+
+export const BUCKS_HOUSE_CANNOT_FUND =
+  "🏦 The Bryan Bucks house can't fund a new wallet right now. No Bucks moved.";
+
+export function bucksInsufficient(balance: number, needed: number): string {
+  return `💸 You have **${balance.toString()} BB** but need **${needed.toString()} BB**.`;
+}
+
+/** Appended where a reader may want the rules but the surface must not carry them. */
+export function withRulesHint(text: string): string {
+  return `${text} ${BUCKS_RULES_HINT}`;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
@@ -97,7 +97,7 @@ type EarnedReward = {
   amount: number;
 };
 
-const EARNED_REWARDS = {
+export const EARNED_REWARDS = {
   played: { kind: "earn_game", amount: 1 },
   "ranked 5s bonus": { kind: "earn_ranked_5s_bonus", amount: 1 },
   "clash bonus": { kind: "earn_clash_bonus", amount: 10 },

--- a/packages/scout-for-lol/packages/backend/src/betting/house-cut.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/house-cut.ts
@@ -3,18 +3,25 @@
  *
  * Bucks are integer-only. Winner fees round down so every winning 1 BB match
  * remains profitable; voluntary cancellation keeps nearest-Buck rounding.
+ *
+ * `HOUSE_CUT_PERCENT` is the single representation of this number. It used to
+ * sit beside two magic-number implementations and five hand-typed "20%"
+ * strings, and they drifted: for a day the `/bb rules` embed told players the
+ * fee was 20% of *gross payout* rounded to the nearest BB while the market
+ * copy said 20% of *matched profit* rounded down — two different amounts, both
+ * live. Every fee, and every sentence describing one, now derives from here.
  */
 
 export const HOUSE_CUT_PERCENT = 20;
 
-export const HOUSE_CUT_TERMS =
-  "🎯 An outcome amount is a maximum offer; only matched BB are at risk and unmatched BB are refunded at close. The house can fill up to **5 BB per game** after human matching. 🏦 Outcome winners pay **20% of matched profit**, rounded down. Cancelling an outcome offer costs **20%**, rounded to the nearest BB; parlay cancellation is fully refunded.";
+/** Round down, so a winning 1 BB match still profits. */
+function houseCutRoundedDown(amount: number): number {
+  return Math.floor((amount * HOUSE_CUT_PERCENT) / 100);
+}
 
-export const HOUSE_CUT_PLACEMENT_NOTE =
-  "**Only matched BB are at risk; winners pay 20% of matched profit.**";
-
-function roundedHouseCut(amount: number): number {
-  return Math.floor((amount + 2) / 5);
+/** Round to the nearest Buck, which is what a voluntary cancellation uses. */
+function houseCutRoundedNearest(amount: number): number {
+  return Math.round((amount * HOUSE_CUT_PERCENT) / 100);
 }
 
 /**
@@ -28,10 +35,10 @@ export function settlementHouseCut(input: {
   if (input.isHouse) {
     return 0;
   }
-  return Math.floor(input.matchedProfit / 5);
+  return houseCutRoundedDown(input.matchedProfit);
 }
 
 /** A voluntary cancellation returns the offer less the rounded fee. */
 export function cancellationHouseCut(stake: number): number {
-  return roundedHouseCut(stake);
+  return houseCutRoundedNearest(stake);
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/message-refresh.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/message-refresh.integration.test.ts
@@ -171,9 +171,10 @@ describe("refreshBucksMessages", () => {
     ]);
     expect(edits.every((edit) => edit.suppressedMentions)).toBe(true);
     expect(edits.every((edit) => !edit.removedComponents)).toBe(true);
-    expect(edits[0]?.content).toContain(
-      "Blue **6 BB offered** · Red **5 BB offered**",
-    );
+    expect(edits[0]?.content).toContain("🎲 **Bets open**");
+    // The refresh supplies the authoritative close time from the pool.
+    expect(edits[0]?.content).toContain("closes <t:");
+    expect(edits[0]?.content).toContain("Blue **6 BB** · Red **5 BB**");
     expect(edits[0]?.content).toContain(`<@${bucksTestDiscordId(1)}>`);
     expect(edits[0]?.content).toContain(`<@${bucksTestDiscordId(2)}>`);
     expect(edits[0]?.content).not.toContain(`<@${bucksTestDiscordId(99)}>`);
@@ -189,9 +190,7 @@ describe("refreshBucksMessages", () => {
       recordingEditor(edits),
     );
     expect(edits[0]?.content).not.toContain(`<@${bucksTestDiscordId(2)}>`);
-    expect(edits[0]?.content).toContain(
-      "Blue **6 BB offered** · Red **0 BB offered**",
-    );
+    expect(edits[0]?.content).toContain("Blue **6 BB** · Red **0 BB**");
     expect(await db.bucksBet.count({ where: { poolId: pool.id } })).toBe(2);
   });
 
@@ -285,14 +284,17 @@ describe("refreshBucksMessages", () => {
 
     expect(edits.every((edit) => edit.removedComponents)).toBe(true);
     expect(edits[0]?.content).toContain(
-      "**Final matched stakes** — Blue **5 BB** · Red **5 BB**",
+      "🎲 **Bets closed** — Blue **5 BB** · Red **5 BB**",
     );
+    // The aggregate house fill, without exposing the synthetic account.
+    expect(edits[0]?.content).toContain("(house **4** on Red)");
     expect(edits[0]?.content).toContain(
-      "offered **5 BB** · matched **5 BB** · refunded **0 BB**",
+      `<@${bucksTestDiscordId(1)}> Blue 5 → matched **5**`,
     );
-    expect(edits[0]?.content).toContain(
-      "🏦 House matched **4 BB** on **Red Team**.",
-    );
+    // A fully matched offer says nothing about a zero refund.
+    expect(edits[0]?.content).not.toContain("refunded **0**");
+    // The market never restates the fee schedule.
+    expect(edits[0]?.content).not.toContain("20%");
     expect(edits[0]?.content).not.toContain(`<@${bucksTestDiscordId(99)}>`);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/message-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/message-refresh.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/bun";
 import type { MessageEditOptions } from "discord.js";
 import {
   BucksMessageRefsSchema,
+  BucksPoolRosterSchema,
   BucksPoolStateSchema,
   BucksPredictionSchema,
   DiscordChannelIdSchema,
@@ -11,10 +12,12 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import {
-  appendBucksLine,
+  withBucksDigest,
+  digestBudgetFor,
   bucksPrematchSummary,
   type BucksPrematchPosition,
 } from "#src/betting/prematch-line.ts";
+import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
 import { createLogger } from "#src/logger.ts";
@@ -64,6 +67,8 @@ async function refreshOnce(
       prematchContentBase: true,
       poolState: true,
       predictionJson: true,
+      roster: true,
+      closesAt: true,
       bets: {
         select: {
           id: true,
@@ -123,13 +128,19 @@ async function refreshOnce(
       matchedStake: bet.matchedStake,
     };
   });
-  const content = appendBucksLine(
+  const anchor = bettingAnchor(
+    BucksPoolRosterSchema.parse(JSON.parse(pool.roster)).participants,
+  );
+  const content = withBucksDigest(
     pool.prematchContentBase,
     bucksPrematchSummary({
       prediction,
       poolState,
       positions,
       houseMatches,
+      framing: anchor === undefined ? undefined : subjectFraming(anchor),
+      closesAt: pool.closesAt,
+      maxLength: digestBudgetFor(pool.prematchContentBase),
     }),
   );
 

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -6,8 +6,9 @@ import {
 } from "@scout-for-lol/data";
 import { z } from "zod";
 import { getLedgerPage, type LedgerPage } from "#src/betting/accounts.ts";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { getFlag } from "#src/configuration/flags.ts";
+import { BUCKS_GUILD_ONLY, BUCKS_NOT_ENABLED } from "#src/betting/copy.ts";
+import { PEEK_PASS_DURATION_LABEL } from "#src/betting/peek-pass.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { BucksButtonEditReplyOptions } from "#src/betting/bet-button.ts";
 
@@ -28,15 +29,15 @@ const LEDGER_KIND_LABELS = {
   bet_void_refund: "matched stake refunded",
   winner_fee: "winner fee",
   house_match: "house match reserved",
-  bet_refund: "legacy bet refund",
-  house_rake: "legacy house cut on payout",
+  bet_refund: "bet refunded",
+  house_rake: "house cut on payout",
   cancel_fee: "cancellation fee",
   parlay_stake: "parlay stake",
   parlay_reserve: "parlay house reserve",
   parlay_payout: "parlay payout",
   parlay_refund: "parlay refund",
   parlay_release: "parlay reserve release",
-  peek_pass: "24-hour peek pass",
+  peek_pass: `${PEEK_PASS_DURATION_LABEL} peek pass`,
   adjustment: "adjustment",
 } satisfies Record<BucksLedgerKind, string>;
 
@@ -146,7 +147,7 @@ export function renderBucksHistory(
 ): BucksButtonEditReplyOptions {
   if (page.entries.length === 0) {
     return {
-      content: `No Bryan Bucks history yet.\n\n${HOUSE_CUT_TERMS}`,
+      content: "No Bryan Bucks history yet.",
       components: [],
     };
   }
@@ -160,8 +161,6 @@ export function renderBucksHistory(
     content: [
       `**Bryan Bucks history** · Page ${(page.page + 1).toString()}/${page.totalPages.toString()}`,
       ...lines,
-      "",
-      HOUSE_CUT_TERMS,
     ].join("\n"),
     components: navigationRow(ownerId, page),
   };
@@ -188,7 +187,7 @@ export async function handleBucksNavigation(
   if (interaction.guildId === null) {
     await interaction.deferReply({ ephemeral: true });
     await interaction.editReply({
-      content: "Bryan Bucks only works inside a server.",
+      content: BUCKS_GUILD_ONLY,
       components: [],
     });
     return;
@@ -208,7 +207,7 @@ export async function handleBucksNavigation(
   if (!getFlag("betting_enabled", { server: serverId })) {
     await interaction.deferReply({ ephemeral: true });
     await interaction.editReply({
-      content: "Bryan Bucks isn't enabled in this server.",
+      content: BUCKS_NOT_ENABLED,
       components: [],
     });
     return;

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-bet-button.ts
@@ -14,6 +14,16 @@ import {
 } from "#src/betting/parlay-place-bet.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { BetButtonInteraction } from "#src/betting/bet-button.ts";
+import {
+  BUCKS_GUILD_ONLY,
+  BUCKS_HOUSE_CANNOT_FUND,
+  BUCKS_INVALID_STAKE,
+  BUCKS_NOT_ELIGIBLE,
+  BUCKS_NOT_ENABLED,
+  BUCKS_NO_PARLAY_MARKET,
+  BUCKS_STORAGE_LIMIT,
+  bucksInsufficient,
+} from "#src/betting/copy.ts";
 
 export function describeParlayResult(result: PlaceParlayBetResult): string {
   switch (result.kind) {
@@ -22,21 +32,21 @@ export function describeParlayResult(result: PlaceParlayBetResult): string {
     case "window_closed":
       return "⏰ Parlay betting has closed for this game.";
     case "no_market":
-      return "🚫 There's no parlay market for this game.";
+      return BUCKS_NO_PARLAY_MARKET;
     case "feature_disabled":
-      return "🚫 Bryan Bucks is no longer enabled in this server.";
+      return BUCKS_NOT_ENABLED;
     case "not_eligible":
-      return "🔒 Only tracked players can bet.";
+      return BUCKS_NOT_ELIGIBLE;
     case "invalid_stake":
-      return "💱 Stakes must be a positive whole number of BB.";
+      return BUCKS_INVALID_STAKE;
     case "storage_limit":
-      return "💱 That position is too large for the current Bryan Bucks storage format.";
+      return BUCKS_STORAGE_LIMIT;
     case "insufficient":
-      return `💸 You have **${result.balance.toString()} BB** but need **${result.needed.toString()} BB**.`;
+      return bucksInsufficient(result.balance, result.needed);
     case "wallet_house_insufficient":
-      return "🏦 The Bryan Bucks house cannot fund a new wallet right now. No Bucks moved.";
+      return BUCKS_HOUSE_CANNOT_FUND;
     case "house_insufficient":
-      return "🏦 The Bryan Bucks house cannot fully reserve that payout. No Bucks moved.";
+      return "🏦 The Bryan Bucks house can't fully reserve that payout. No Bucks moved.";
     case "side_conflict":
       return `↔️ You already backed ${result.existingSide}. Cancel that position first.`;
   }
@@ -45,9 +55,11 @@ export function describeParlayResult(result: PlaceParlayBetResult): string {
 export function describeParlayCancel(result: CancelParlayBetResult): string {
   switch (result.kind) {
     case "cancelled":
-      return `↩️ Parlay cancelled. **${result.refunded.toString()} BB** returned; balance **${result.balanceAfter.toString()} BB**.`;
+      // Says "no fee" explicitly: the outcome market charges one and this is
+      // the only place a parlay bettor learns theirs does not.
+      return `↩️ Cancelled: **${result.refunded.toString()} BB** back, no fee · balance **${result.balanceAfter.toString()} BB**.`;
     case "no_market":
-      return "🚫 There's no parlay market for this game.";
+      return BUCKS_NO_PARLAY_MARKET;
     case "no_bet":
       return "🤷 You don't have a parlay position to cancel on this game.";
     case "window_closed":
@@ -68,7 +80,7 @@ export async function handleParlayBetButton(
   await interaction.deferReply({ ephemeral: true });
   if (interaction.guildId === null) {
     await interaction.editReply({
-      content: "🏠 Bryan Bucks only works inside a server.",
+      content: BUCKS_GUILD_ONLY,
     });
     return;
   }

--- a/packages/scout-for-lol/packages/backend/src/betting/peek-pass-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/peek-pass-button.ts
@@ -7,12 +7,14 @@ import {
 } from "@scout-for-lol/data";
 import type { BucksButtonEditReplyOptions } from "#src/betting/bet-button.ts";
 import { getFlag } from "#src/configuration/flags.ts";
+import { BUCKS_GUILD_ONLY, BUCKS_NOT_ENABLED } from "#src/betting/copy.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import {
   formatPeekPassCustomId,
   parsePeekPassCustomId,
 } from "#src/betting/peek-pass-custom-id.ts";
 import {
+  PEEK_PASS_DURATION_LABEL,
   PEEK_PASS_QUOTE_TTL_MS,
   purchasePeekPass,
   quotePeekPass,
@@ -85,7 +87,7 @@ export function renderPeekPassQuote(
       );
       return {
         content:
-          `A **24-hour peek pass** costs **${result.quote.price.toString()} BB** at your current balance and weighted holding age. ` +
+          `A **${PEEK_PASS_DURATION_LABEL} peek pass** costs **${result.quote.price.toString()} BB** for you right now. ` +
           `This quote expires ${relativeTime(expiresAt)}.`,
         components: quoteButton({
           ownerId,
@@ -110,7 +112,7 @@ export async function handlePeekPassButton(
   if (interaction.guildId === null) {
     await interaction.deferReply({ ephemeral: true });
     await interaction.editReply({
-      content: "Bryan Bucks only works inside a server.",
+      content: BUCKS_GUILD_ONLY,
       components: [],
     });
     return;
@@ -128,7 +130,7 @@ export async function handlePeekPassButton(
   }
   if (!getFlag("betting_enabled", { server: currentServerId })) {
     await interaction.editReply({
-      content: "Bryan Bucks isn't enabled in this server.",
+      content: BUCKS_NOT_ENABLED,
       components: [],
     });
     return;
@@ -147,8 +149,8 @@ export async function handlePeekPassButton(
     case "purchased":
       await interaction.editReply({
         content:
-          `✅ Peek pass active. It expires ${relativeTime(result.expiresAt)}. ` +
-          `Paid **${result.price.toString()} BB**; balance **${result.balanceAfter.toString()} BB**. Use \`/bb peek\` once a game has been live for two minutes.`,
+          `✅ Peek pass active until ${relativeTime(result.expiresAt)}. ` +
+          `Paid **${result.price.toString()} BB** · balance **${result.balanceAfter.toString()} BB**. Use \`/bb peek game:<player>\`.`,
         components: [],
       });
       return;

--- a/packages/scout-for-lol/packages/backend/src/betting/peek-pass.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/peek-pass.ts
@@ -5,9 +5,14 @@ import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 
 export const PEEK_PASS_DURATION_MS = 24 * 60 * 60 * 1000;
+
+/** "24-hour", derived — the duration used to be hand-typed on five surfaces. */
+export const PEEK_PASS_DURATION_LABEL = `${Math.floor(
+  PEEK_PASS_DURATION_MS / 3_600_000,
+).toString()}-hour`;
 export const PEEK_PASS_QUOTE_TTL_MS = 10 * 60 * 1000;
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-const MINIMUM_PRICE = 5;
+export const MINIMUM_PRICE = 5;
 
 type LedgerLotInput = {
   id: number;

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.integration.test.ts
@@ -18,7 +18,6 @@ import {
 import { prepareBucksPrematch } from "#src/betting/prematch-hook.ts";
 import { retryPendingBucksEarnings } from "#src/betting/earnings-retry.ts";
 import { openBettingPoolsForPrematch } from "#src/betting/pool-open.ts";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
@@ -229,8 +228,9 @@ describe("prepareBucksPrematch", () => {
       db,
     );
     expect(result.bettingGuildIds).toEqual(new Set([ENABLED]));
-    expect(result.footer).toContain(HOUSE_CUT_TERMS);
-    expect(result.footer).toContain("**Live offers** — No offers yet.");
+    expect(result.footer).toContain("no offers yet");
+    // The market message states numbers, never rules.
+    expect(result.footer).not.toContain("20%");
     expect(result.footer).not.toContain("58%");
     const pool = await db.bucksMatchPool.findUniqueOrThrow({
       where: {

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-hook.ts
@@ -6,7 +6,11 @@ import type {
   RawCurrentGameInfo,
   BucksPrediction,
 } from "@scout-for-lol/data";
-import { buildBettingRows } from "#src/betting/components.ts";
+import {
+  bettingAnchor,
+  buildBettingRows,
+  subjectFraming,
+} from "#src/betting/components.ts";
 import { awardClassicPrematchForGame } from "#src/betting/classic-prematch-earnings.ts";
 import { isBettableGame, isStandardLobby } from "#src/betting/eligibility.ts";
 import {
@@ -109,18 +113,20 @@ export async function prepareBucksPrematch(
     prismaClient,
   );
 
+  const roster = buildRosterForButtons(input.gameInfo, trackedAliasByPuuid);
   const rows =
-    bettingGuildIds.size === 0
-      ? []
-      : buildBettingRows({
-          matchId,
-          roster: buildRosterForButtons(input.gameInfo, trackedAliasByPuuid),
-        });
+    bettingGuildIds.size === 0 ? [] : buildBettingRows({ matchId, roster });
 
+  // `closesAt` is deliberately omitted here: `recordPrematchOutputs` refreshes
+  // from the persisted pool within a second of delivery, and that refresh has
+  // the authoritative close time. Recomputing it here would duplicate
+  // `computeClosesAt` on the hot path to save one edit.
+  const anchor = bettingAnchor(roster);
   const footer = bucksPrematchSummary({
     prediction: input.prediction,
     poolState: "open",
     positions: [],
+    framing: anchor === undefined ? undefined : subjectFraming(anchor),
   });
 
   return { bettingGuildIds, rows, footer, matchId };

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-line.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-line.test.ts
@@ -1,52 +1,93 @@
 import { describe, expect, test } from "bun:test";
 import {
-  appendBucksLine,
-  bucksPrematchLine,
+  BUCKS_RULES_HINT,
   bucksPrematchSummary,
+  digestBudgetFor,
+  withBucksDigest,
 } from "#src/betting/prematch-line.ts";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 
-describe("bucksPrematchLine", () => {
-  test("publishes the house policy without leaking prediction percentages", () => {
-    const line = bucksPrematchLine();
-    expect(line).toBe(HOUSE_CUT_TERMS);
-    expect(line).not.toContain("estimate");
-    expect(line).not.toContain("Scout's call");
-  });
+const BLUE_ANCHOR = { anchorTeamId: 100, mixedTeams: false } as const;
+const MIXED = { anchorTeamId: 100, mixedTeams: true } as const;
+const CLOSES_AT = new Date("2026-08-21T00:00:00.000Z");
 
-  test("does not add blank content when there is no footer", () => {
-    expect(appendBucksLine("Aaron and Long started a game", "")).toBe(
+describe("withBucksDigest", () => {
+  test("does not add blank content when there is no digest", () => {
+    expect(withBucksDigest("Aaron and Long started a game", "")).toBe(
       "Aaron and Long started a game",
     );
   });
 
   test("does not prefix a text-only fallback with blank lines", () => {
-    expect(appendBucksLine("", HOUSE_CUT_TERMS)).toBe(HOUSE_CUT_TERMS);
+    expect(withBucksDigest("", "🎲 **Bets open**")).toBe("🎲 **Bets open**");
   });
 
-  test("keeps the house policy when the base reaches Discord's limit", () => {
-    const message = appendBucksLine("x".repeat(2000), HOUSE_CUT_TERMS);
-    expect(message).toHaveLength(2000);
-    expect(message.endsWith(HOUSE_CUT_TERMS)).toBe(true);
+  // The old contract truncated the base to protect a house-cut disclosure that
+  // no longer exists. Losing the players' names to protect boilerplate was the
+  // wrong trade, so an over-budget digest is now a broken caller.
+  test("refuses to truncate the base content", () => {
+    expect(() => withBucksDigest("x".repeat(2000), "🎲 anything")).toThrow(
+      "exceeds Discord's limit",
+    );
+  });
+
+  test("budgets the digest against the base it will follow", () => {
+    expect(digestBudgetFor("")).toBe(2000);
+    expect(digestBudgetFor("x".repeat(100))).toBe(1898);
   });
 });
 
 describe("bucksPrematchSummary", () => {
-  test("shows an empty live market", () => {
+  test("states no rules, only numbers and a pointer to /bb rules", () => {
+    const summary = bucksPrematchSummary({
+      prediction: undefined,
+      poolState: "open",
+      positions: [],
+      closesAt: CLOSES_AT,
+    });
+
+    expect(summary).toContain("no offers yet");
+    expect(summary).toContain(BUCKS_RULES_HINT);
+    expect(summary).toContain("closes <t:1787270400:R>");
+    // The concepts that used to be restated on every single game.
+    expect(summary).not.toContain("20%");
+    expect(summary).not.toContain("maximum offer");
+    expect(summary).not.toContain("rounded");
+  });
+
+  test("omits the close clause when the caller has no authoritative time", () => {
     const summary = bucksPrematchSummary({
       prediction: undefined,
       poolState: "open",
       positions: [],
     });
 
-    expect(summary).toContain(HOUSE_CUT_TERMS);
-    expect(summary).toContain("**Live offers** — No offers yet.");
+    expect(summary).not.toContain("closes <t:");
   });
 
-  test("groups named positions by team with complete totals", () => {
+  test("never leaks the pregame estimate", () => {
+    const summary = bucksPrematchSummary({
+      prediction: {
+        version: 2,
+        blueWinProbability: 0.73,
+        dataQuality: "high",
+        coverage: { covered: 10, applicable: 10 },
+        drivers: ["Blue rank edge"],
+      },
+      poolState: "open",
+      positions: [],
+      framing: BLUE_ANCHOR,
+    });
+
+    expect(summary).not.toContain("73");
+    expect(summary).not.toContain("estimate");
+    expect(summary).not.toContain("Scout's call");
+  });
+
+  test("names sides WIN and LOSE and inlines offers per side", () => {
     const summary = bucksPrematchSummary({
       prediction: undefined,
       poolState: "open",
+      framing: BLUE_ANCHOR,
       positions: [
         {
           discordId: "1337623164146155591",
@@ -72,66 +113,41 @@ describe("bucksPrematchSummary", () => {
       ],
     });
 
-    expect(summary).toContain("Blue **10 BB offered** · Red **5 BB offered**");
+    expect(summary).toContain("WIN **10 BB** · LOSE **5 BB**");
+    expect(summary).toContain(
+      "**WIN** <@1337623164146155591> 6 · <@1337623164146155592> 4",
+    );
+    expect(summary).toContain("**LOSE** <@1337623164146155593> 5");
     expect(summary.indexOf("1337623164146155591")).toBeLessThan(
       summary.indexOf("1337623164146155592"),
     );
-    expect(summary).toContain("**Blue Team**");
-    expect(summary).toContain("**Red Team**");
   });
 
-  test("keeps a bounded named digest and the complete team totals", () => {
-    const positions = Array.from({ length: 17 }, (_, index) => ({
-      discordId: `133762316414615${(1000 + index).toString()}`,
-      teamId: index % 2 === 0 ? (100 as const) : (200 as const),
-      offeredStake: 5,
-      matchedStake: 5,
-      unmatchedStake: 0,
-    }));
+  test("falls back to Blue and Red when both teams are tracked", () => {
     const summary = bucksPrematchSummary({
       prediction: undefined,
-      poolState: "closed",
-      positions,
-      houseMatches: [{ teamId: 200, matchedStake: 5 }],
+      poolState: "open",
+      framing: MIXED,
+      positions: [
+        {
+          discordId: "1337623164146155591",
+          teamId: 100,
+          offeredStake: 6,
+          matchedStake: null,
+          unmatchedStake: null,
+        },
+      ],
     });
-    const content = appendBucksLine("x".repeat(2000), summary);
 
-    expect(summary).toContain("Blue **45 BB** · Red **45 BB**");
-    expect(summary).toContain("…and 2 more position(s).");
-    expect(summary).toContain("**Final matched stakes**");
-    expect(content).toHaveLength(2000);
+    expect(summary).toContain("Blue **6 BB** · Red **0 BB**");
+    expect(summary).not.toContain("WIN");
   });
 
-  test("trims maximum-length final allocations to Discord's limit", () => {
-    const maximumStake = 2_147_483_647;
-    const matchedStake = 1_073_741_824;
-    const unmatchedStake = maximumStake - matchedStake;
-    const positions = Array.from({ length: 15 }, (_, index) => ({
-      discordId: `133762316414615${(1000 + index).toString()}`,
-      teamId: index % 2 === 0 ? (100 as const) : (200 as const),
-      offeredStake: maximumStake,
-      matchedStake,
-      unmatchedStake,
-    }));
+  test("becomes a receipt at close with the full allocation arithmetic", () => {
     const summary = bucksPrematchSummary({
       prediction: undefined,
       poolState: "closed",
-      positions,
-    });
-    const content = appendBucksLine("x".repeat(2000), summary);
-
-    expect(summary.length).toBeLessThanOrEqual(2000);
-    expect(summary).toContain("offered **2147483647 BB**");
-    expect(summary).toContain("matched **1073741824 BB**");
-    expect(summary).toContain("refunded **1073741823 BB**");
-    expect(summary).toContain("more position(s)");
-    expect(content).toHaveLength(2000);
-  });
-
-  test("shows offered, matched, refunded, and aggregate house matching", () => {
-    const summary = bucksPrematchSummary({
-      prediction: undefined,
-      poolState: "closed",
+      framing: BLUE_ANCHOR,
       positions: [
         {
           discordId: "1337623164146155591",
@@ -152,11 +168,87 @@ describe("bucksPrematchSummary", () => {
     });
 
     expect(summary).toContain(
-      "**Final matched stakes** — Blue **6 BB** · Red **6 BB**",
+      "🎲 **Bets closed** — WIN **6 BB** · LOSE **6 BB**",
     );
-    expect(summary).toContain("🏦 House matched **5 BB** on **Red Team**.");
+    expect(summary).toContain("(house **5** on LOSE)");
     expect(summary).toContain(
-      "offered **10 BB** · matched **6 BB** · refunded **4 BB**",
+      "• <@1337623164146155591> WIN 10 → matched **6**, refunded **4**",
     );
+    // A fully matched offer says nothing about a zero refund.
+    expect(summary).toContain(
+      "• <@1337623164146155592> LOSE 1 → matched **1**",
+    );
+    expect(summary).not.toContain("refunded **0**");
+  });
+
+  test("reports an empty close plainly", () => {
+    expect(
+      bucksPrematchSummary({
+        prediction: undefined,
+        poolState: "closed",
+        positions: [],
+      }),
+    ).toBe("🎲 **Bets closed** — no offers matched.");
+  });
+
+  test("bounds the digest and keeps the complete totals", () => {
+    const positions = Array.from({ length: 17 }, (_, index) => ({
+      discordId: `133762316414615${(1000 + index).toString()}`,
+      teamId: index % 2 === 0 ? (100 as const) : (200 as const),
+      offeredStake: 5,
+      matchedStake: 5,
+      unmatchedStake: 0,
+    }));
+    const summary = bucksPrematchSummary({
+      prediction: undefined,
+      poolState: "closed",
+      framing: BLUE_ANCHOR,
+      positions,
+      houseMatches: [{ teamId: 200, matchedStake: 5 }],
+    });
+
+    expect(summary).toContain("WIN **45 BB** · LOSE **45 BB**");
+    expect(summary).toContain("…and 2 more.");
+    expect(summary.length).toBeLessThanOrEqual(2000);
+  });
+
+  test("shrinks the digest to fit the budget the base leaves", () => {
+    const positions = Array.from({ length: 15 }, (_, index) => ({
+      discordId: `133762316414615${(1000 + index).toString()}`,
+      teamId: index % 2 === 0 ? (100 as const) : (200 as const),
+      offeredStake: 2_147_483_647,
+      matchedStake: 1_073_741_824,
+      unmatchedStake: 1_073_741_823,
+    }));
+    // A base long enough that the digest genuinely has to shrink. The new copy
+    // is terse enough that fifteen max-width positions fit a bare message,
+    // which the old house-cut footer could not.
+    const base = "x".repeat(1000);
+    const summary = bucksPrematchSummary({
+      prediction: undefined,
+      poolState: "closed",
+      framing: BLUE_ANCHOR,
+      positions,
+      maxLength: digestBudgetFor(base),
+    });
+    const content = withBucksDigest(base, summary);
+
+    expect(summary).toContain("2147483647 → matched **1073741824**");
+    expect(summary).toContain("more.");
+    expect(summary.length).toBeLessThanOrEqual(digestBudgetFor(base));
+    expect(content.length).toBeLessThanOrEqual(2000);
+    // The base survives intact; only the digest shrinks.
+    expect(content.startsWith(base)).toBe(true);
+  });
+
+  test("refuses a house match on an open pool", () => {
+    expect(() =>
+      bucksPrematchSummary({
+        prediction: undefined,
+        poolState: "open",
+        positions: [],
+        houseMatches: [{ teamId: 200, matchedStake: 5 }],
+      }),
+    ).toThrow("cannot contain a house match");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-line.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-line.ts
@@ -3,8 +3,8 @@ import type {
   BucksPrediction,
   RiotTeamId,
 } from "@scout-for-lol/data";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
-import { teamName } from "#src/betting/team.ts";
+import { BETTING_TEAM_IDS, outcomeLabel } from "#src/betting/team.ts";
+import type { OutcomeFraming } from "#src/betting/team.ts";
 
 /**
  * The Bryan Bucks lines appended to a prematch message.
@@ -12,11 +12,18 @@ import { teamName } from "#src/betting/team.ts";
  * Kept separate from the notification module so the text can be unit-tested
  * without a Discord client, and so the length rule below lives next to the
  * strings it governs.
+ *
+ * These lines state numbers, never rules. Every rule lives in `/bb rules`; a
+ * market that re-explained the fee schedule on every game was 17% of all the
+ * Bryan Bucks text a player ever saw.
  */
 
 /** Discord's hard limit on message content. */
 const MAX_CONTENT_LENGTH = 2000;
 const MAX_VISIBLE_POSITIONS = 15;
+
+/** Where the rules actually live, so no other surface has to restate them. */
+export const BUCKS_RULES_HINT = "`/bb rules`";
 
 export type BucksPrematchPosition = {
   discordId: string;
@@ -30,59 +37,6 @@ export type BucksPrematchHouseMatch = {
   teamId: RiotTeamId;
   matchedStake: number;
 };
-
-function positionLines(
-  positions: readonly BucksPrematchPosition[],
-  isOpen: boolean,
-): string[] {
-  const lines: string[] = [];
-  for (const teamId of [100, 200] satisfies readonly RiotTeamId[]) {
-    const teamPositions = positions.filter(
-      (position) => position.teamId === teamId,
-    );
-    if (teamPositions.length === 0) {
-      continue;
-    }
-    lines.push(`**${teamName(teamId)}**`);
-    for (const position of teamPositions) {
-      if (isOpen) {
-        lines.push(
-          `• <@${position.discordId}> — offered **${position.offeredStake.toString()} BB**`,
-        );
-      } else {
-        const allocation = finalAllocation(position);
-        lines.push(
-          `• <@${position.discordId}> — offered **${position.offeredStake.toString()} BB** · matched **${allocation.matchedStake.toString()} BB** · refunded **${allocation.unmatchedStake.toString()} BB**`,
-        );
-      }
-    }
-  }
-  return lines;
-}
-
-function boundedPositionDigest(input: {
-  lines: readonly string[];
-  positions: readonly BucksPrematchPosition[];
-  isOpen: boolean;
-}): string {
-  let visibleCount = Math.min(input.positions.length, MAX_VISIBLE_POSITIONS);
-  while (visibleCount >= 0) {
-    const candidateLines = [
-      ...input.lines,
-      ...positionLines(input.positions.slice(0, visibleCount), input.isOpen),
-    ];
-    const hiddenCount = input.positions.length - visibleCount;
-    if (hiddenCount > 0) {
-      candidateLines.push(`…and ${hiddenCount.toString()} more position(s).`);
-    }
-    const candidate = candidateLines.join("\n");
-    if (candidate.length <= MAX_CONTENT_LENGTH) {
-      return candidate;
-    }
-    visibleCount -= 1;
-  }
-  throw new Error("Bryan Bucks prematch footer exceeds Discord's limit");
-}
 
 function finalAllocation(position: BucksPrematchPosition): {
   matchedStake: number;
@@ -104,15 +58,118 @@ function finalAllocation(position: BucksPrematchPosition): {
 }
 
 /**
- * Build the optional betting line.
+ * While the market is open, names are grouped one line per side.
  *
- * A prediction close to even odds is deliberately omitted: the buttons are
- * useful, but a nearly arbitrary call is not useful to read.
+ * One line per bettor was the single largest contributor to the old footer's
+ * length, and the offered amount is the only number that matters before close.
  */
-export function bucksPrematchLine(_input?: {
-  prediction: BucksPrediction | undefined;
+function openPositionLines(
+  positions: readonly BucksPrematchPosition[],
+  framing: OutcomeFraming | undefined,
+): string[] {
+  const lines: string[] = [];
+  for (const teamId of BETTING_TEAM_IDS) {
+    const side = positions.filter((position) => position.teamId === teamId);
+    if (side.length === 0) {
+      continue;
+    }
+    const names = side
+      .map(
+        (position) =>
+          `<@${position.discordId}> ${position.offeredStake.toString()}`,
+      )
+      .join(" · ");
+    lines.push(`**${outcomeLabel(teamId, framing)}** ${names}`);
+  }
+  return lines;
+}
+
+/**
+ * At close the message becomes the receipt, so each bettor gets their own row
+ * with the offered/matched/refunded arithmetic preserved in full.
+ */
+function closedPositionLines(
+  positions: readonly BucksPrematchPosition[],
+  framing: OutcomeFraming | undefined,
+): string[] {
+  return positions.map((position) => {
+    const allocation = finalAllocation(position);
+    const refunded =
+      allocation.unmatchedStake > 0
+        ? `, refunded **${allocation.unmatchedStake.toString()}**`
+        : "";
+    return `• <@${position.discordId}> ${outcomeLabel(position.teamId, framing)} ${position.offeredStake.toString()} → matched **${allocation.matchedStake.toString()}**${refunded}`;
+  });
+}
+
+function positionLines(
+  positions: readonly BucksPrematchPosition[],
+  isOpen: boolean,
+  framing: OutcomeFraming | undefined,
+): string[] {
+  return isOpen
+    ? openPositionLines(positions, framing)
+    : closedPositionLines(positions, framing);
+}
+
+function boundedPositionDigest(input: {
+  lines: readonly string[];
+  positions: readonly BucksPrematchPosition[];
+  isOpen: boolean;
+  framing: OutcomeFraming | undefined;
+  maxLength: number;
 }): string {
-  return HOUSE_CUT_TERMS;
+  let visibleCount = Math.min(input.positions.length, MAX_VISIBLE_POSITIONS);
+  while (visibleCount >= 0) {
+    const candidateLines = [
+      ...input.lines,
+      ...positionLines(
+        input.positions.slice(0, visibleCount),
+        input.isOpen,
+        input.framing,
+      ),
+    ];
+    const hiddenCount = input.positions.length - visibleCount;
+    if (hiddenCount > 0) {
+      candidateLines.push(`…and ${hiddenCount.toString()} more.`);
+    }
+    const candidate = candidateLines.join("\n");
+    if (candidate.length <= input.maxLength) {
+      return candidate;
+    }
+    visibleCount -= 1;
+  }
+  throw new Error("Bryan Bucks prematch digest exceeds its length budget");
+}
+
+function totalsFor(input: {
+  positions: readonly BucksPrematchPosition[];
+  houseMatches: readonly BucksPrematchHouseMatch[];
+  teamId: RiotTeamId;
+  isOpen: boolean;
+}): number {
+  const own = input.positions
+    .filter((position) => position.teamId === input.teamId)
+    .reduce(
+      (total, position) =>
+        total +
+        (input.isOpen
+          ? position.offeredStake
+          : finalAllocation(position).matchedStake),
+      0,
+    );
+  const house = input.houseMatches
+    .filter((match) => match.teamId === input.teamId)
+    .reduce((total, match) => total + match.matchedStake, 0);
+  return own + house;
+}
+
+/** `closes <t:…:R>`, omitted when the caller has no authoritative close time. */
+function closesClause(closesAt: Date | undefined): string {
+  if (closesAt === undefined) {
+    return "";
+  }
+  return ` · closes <t:${Math.floor(closesAt.getTime() / 1000).toString()}:R>`;
 }
 
 /**
@@ -120,96 +177,110 @@ export function bucksPrematchLine(_input?: {
  *
  * Positions are already sorted by the database query that reads them. Keeping
  * that order here means repeated refreshes do not make rows jump around.
+ *
+ * `prediction` is accepted and deliberately unused: pregame estimates are never
+ * public, and keeping the parameter documents that this is a decision rather
+ * than an omission.
  */
 export function bucksPrematchSummary(input: {
   prediction: BucksPrediction | undefined;
   poolState: BucksPoolState;
   positions: readonly BucksPrematchPosition[];
-  houseMatches?: readonly BucksPrematchHouseMatch[];
+  houseMatches?: readonly BucksPrematchHouseMatch[] | undefined;
+  framing?: OutcomeFraming | undefined;
+  closesAt?: Date | undefined;
+  /** Characters available after the non-betting content. */
+  maxLength?: number | undefined;
 }): string {
-  const lines = [bucksPrematchLine({ prediction: input.prediction })];
   const houseMatches = input.houseMatches ?? [];
   const isOpen = input.poolState === "open";
+  const maxLength = input.maxLength ?? MAX_CONTENT_LENGTH;
 
   if (isOpen && houseMatches.length > 0) {
     throw new Error("An open Bryan Bucks pool cannot contain a house match");
   }
 
-  lines.push("");
   if (input.positions.length === 0) {
-    lines.push(
-      isOpen
-        ? "🎲 **Live offers** — No offers yet."
-        : "🎲 **Final matched stakes** — No active offers at close.",
-    );
-    return lines.join("\n");
+    return isOpen
+      ? `🎲 **Bets open**${closesClause(input.closesAt)} — no offers yet · ${BUCKS_RULES_HINT}`
+      : "🎲 **Bets closed** — no offers matched.";
   }
 
-  if (isOpen) {
-    const blueOffered = input.positions
-      .filter((position) => position.teamId === 100)
-      .reduce((total, position) => total + position.offeredStake, 0);
-    const redOffered = input.positions
-      .filter((position) => position.teamId === 200)
-      .reduce((total, position) => total + position.offeredStake, 0);
-    lines.push(
-      `🎲 **Live offers** — Blue **${blueOffered.toString()} BB offered** · Red **${redOffered.toString()} BB offered**`,
-    );
-  } else {
-    const matchedForTeam = (teamId: RiotTeamId): number =>
-      input.positions
-        .filter((position) => position.teamId === teamId)
-        .reduce(
-          (total, position) => total + finalAllocation(position).matchedStake,
-          0,
-        ) +
-      houseMatches
-        .filter((position) => position.teamId === teamId)
-        .reduce((total, position) => total + position.matchedStake, 0);
-    const blueMatched = matchedForTeam(100);
-    const redMatched = matchedForTeam(200);
-    lines.push(
-      `🎲 **Final matched stakes** — Blue **${blueMatched.toString()} BB** · Red **${redMatched.toString()} BB**`,
-    );
-    for (const houseMatch of houseMatches) {
-      lines.push(
-        `🏦 House matched **${houseMatch.matchedStake.toString()} BB** on **${teamName(houseMatch.teamId)}**.`,
-      );
-    }
+  const [first, second] = BETTING_TEAM_IDS;
+  if (first === undefined || second === undefined) {
+    throw new Error("Bryan Bucks has no betting sides configured");
   }
+  const totals = [first, second].map((teamId) => ({
+    teamId,
+    label: outcomeLabel(teamId, input.framing),
+    total: totalsFor({
+      positions: input.positions,
+      houseMatches,
+      teamId,
+      isOpen,
+    }),
+  }));
+  const totalsText = totals
+    .map((side) => `${side.label} **${side.total.toString()} BB**`)
+    .join(" · ");
+
+  const header = isOpen
+    ? `🎲 **Bets open**${closesClause(input.closesAt)} — ${totalsText}`
+    : `🎲 **Bets closed** — ${totalsText}${houseClause(houseMatches, input.framing)}`;
 
   return boundedPositionDigest({
-    lines,
+    lines: [header],
     positions: input.positions,
     isOpen,
+    framing: input.framing,
+    maxLength,
   });
 }
 
+/** `(house **5** on LOSE)` — the aggregate fill, without naming the account. */
+function houseClause(
+  houseMatches: readonly BucksPrematchHouseMatch[],
+  framing: OutcomeFraming | undefined,
+): string {
+  if (houseMatches.length === 0) {
+    return "";
+  }
+  const parts = houseMatches.map(
+    (match) =>
+      `house **${match.matchedStake.toString()}** on ${outcomeLabel(match.teamId, framing)}`,
+  );
+  return ` (${parts.join(", ")})`;
+}
+
+/** Characters a digest may use once the non-betting content is accounted for. */
+export function digestBudgetFor(base: string): number {
+  if (base.length === 0) {
+    return MAX_CONTENT_LENGTH;
+  }
+  return MAX_CONTENT_LENGTH - base.length - 2;
+}
+
 /**
- * Append the betting footer to a message, truncating the base if needed so an
- * open market never loses its house-cut disclosure.
+ * Join the non-betting content and the betting digest.
  *
- * The footer is internal, bounded copy. If it alone cannot fit, that is a
- * broken caller contract and must fail loudly rather than sending partial
- * terms.
+ * The digest is bounded by `digestBudgetFor` before it reaches here, so the
+ * base is never truncated. That inverts the previous contract, which sacrificed
+ * the player names to protect a house-cut disclosure that no longer exists — a
+ * digest that cannot fit is now a broken caller, not a reason to eat the report.
  */
-export function appendBucksLine(base: string, footer: string): string {
-  if (footer.length === 0) {
+export function withBucksDigest(base: string, digest: string): string {
+  if (digest.length === 0) {
     return base;
   }
   if (base.length === 0) {
-    if (footer.length > MAX_CONTENT_LENGTH) {
-      throw new Error("Bryan Bucks prematch footer exceeds Discord's limit");
+    if (digest.length > MAX_CONTENT_LENGTH) {
+      throw new Error("Bryan Bucks prematch digest exceeds Discord's limit");
     }
-    return footer;
+    return digest;
   }
-  const combined = `${base}\n\n${footer}`;
-  if (combined.length <= MAX_CONTENT_LENGTH) {
-    return combined;
+  const combined = `${base}\n\n${digest}`;
+  if (combined.length > MAX_CONTENT_LENGTH) {
+    throw new Error("Bryan Bucks prematch content exceeds Discord's limit");
   }
-  const baseLength = MAX_CONTENT_LENGTH - footer.length - 2;
-  if (baseLength < 0) {
-    throw new Error("Bryan Bucks prematch footer exceeds Discord's limit");
-  }
-  return `${base.slice(0, baseLength)}\n\n${footer}`;
+  return combined;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/team.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/team.test.ts
@@ -1,25 +1,133 @@
 import { describe, expect, test } from "bun:test";
 import {
-  BucksTeamChoiceSchema,
+  LeaguePuuidSchema,
+  type BucksPoolParticipant,
+} from "@scout-for-lol/data";
+import {
+  BucksOutcomeChoiceSchema,
+  hasTrackedPlayersOnBothTeams,
+  outcomeLabel,
+  resolveOutcomeChoice,
   shortTeamName,
   subjectWinsForTeam,
-  teamIdForChoice,
   teamIdForSubjectOutcome,
-  teamName,
 } from "#src/betting/team.ts";
 
-describe("Bryan Bucks team mapping", () => {
-  test("maps Discord choices to Riot team IDs", () => {
-    expect(teamIdForChoice(BucksTeamChoiceSchema.parse("blue"))).toBe(100);
-    expect(teamIdForChoice(BucksTeamChoiceSchema.parse("red"))).toBe(200);
-    expect(BucksTeamChoiceSchema.safeParse("green").success).toBe(false);
+function participant(
+  teamId: 100 | 200,
+  tracked: boolean,
+  scrubbed = false,
+): BucksPoolParticipant {
+  return {
+    puuid: scrubbed
+      ? null
+      : LeaguePuuidSchema.parse(
+          `puuid-${teamId.toString()}-${String(tracked)}`.padEnd(78, "0"),
+        ),
+    teamId,
+    championId: 1,
+    ...(tracked ? { trackedAlias: "alias" } : {}),
+  };
+}
+
+const BLUE_ANCHOR = { anchorTeamId: 100, mixedTeams: false } as const;
+const RED_ANCHOR = { anchorTeamId: 200, mixedTeams: false } as const;
+const MIXED = { anchorTeamId: 100, mixedTeams: true } as const;
+
+describe("Bryan Bucks outcome framing", () => {
+  test("names the anchor's side WIN and the other LOSE", () => {
+    expect(outcomeLabel(100, BLUE_ANCHOR)).toBe("WIN");
+    expect(outcomeLabel(200, BLUE_ANCHOR)).toBe("LOSE");
+    expect(outcomeLabel(200, RED_ANCHOR)).toBe("WIN");
+    expect(outcomeLabel(100, RED_ANCHOR)).toBe("LOSE");
   });
 
+  test("falls back to Blue/Red when both teams are tracked", () => {
+    expect(outcomeLabel(100, MIXED)).toBe("Blue");
+    expect(outcomeLabel(200, MIXED)).toBe("Red");
+  });
+
+  test("falls back to Blue/Red when the caller has no framing", () => {
+    expect(outcomeLabel(100, undefined)).toBe("Blue");
+    expect(outcomeLabel(200, undefined)).toBe("Red");
+  });
+
+  test("detects tracked players on both teams", () => {
+    expect(
+      hasTrackedPlayersOnBothTeams([
+        participant(100, true),
+        participant(200, false),
+      ]),
+    ).toBe(false);
+    expect(
+      hasTrackedPlayersOnBothTeams([
+        participant(100, true),
+        participant(200, true),
+      ]),
+    ).toBe(true);
+    // Two tracked players on the SAME team is the case Blue/Red was
+    // introduced for, and must not read as mixed.
+    expect(
+      hasTrackedPlayersOnBothTeams([
+        participant(100, true),
+        participant(100, true),
+      ]),
+    ).toBe(false);
+  });
+
+  test("a privacy-scrubbed participant cannot make a lobby mixed", () => {
+    expect(
+      hasTrackedPlayersOnBothTeams([
+        participant(100, true),
+        participant(200, true, true),
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("Bryan Bucks outcome choices", () => {
+  test("resolves win and lose against the anchor", () => {
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("win"), BLUE_ANCHOR),
+    ).toEqual({ kind: "resolved", teamId: 100 });
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("lose"), BLUE_ANCHOR),
+    ).toEqual({ kind: "resolved", teamId: 200 });
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("win"), RED_ANCHOR),
+    ).toEqual({ kind: "resolved", teamId: 200 });
+  });
+
+  // The whole reason four static choices work: blue/red need no framing, so
+  // they still resolve for the lobby where win/lose cannot.
+  test("resolves blue and red without framing, even when mixed", () => {
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("blue"), MIXED),
+    ).toEqual({ kind: "resolved", teamId: 100 });
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("red"), MIXED),
+    ).toEqual({ kind: "resolved", teamId: 200 });
+  });
+
+  test("refuses win and lose for a mixed lobby instead of guessing", () => {
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("win"), MIXED),
+    ).toEqual({ kind: "ambiguous" });
+    expect(
+      resolveOutcomeChoice(BucksOutcomeChoiceSchema.parse("lose"), MIXED),
+    ).toEqual({ kind: "ambiguous" });
+  });
+
+  test("rejects an unknown choice", () => {
+    expect(BucksOutcomeChoiceSchema.safeParse("green").success).toBe(false);
+    expect(BucksOutcomeChoiceSchema.safeParse("team").success).toBe(false);
+  });
+});
+
+describe("Bryan Bucks team mapping", () => {
   test("formats the shared Blue and Red labels", () => {
     expect(shortTeamName(100)).toBe("Blue");
     expect(shortTeamName(200)).toBe("Red");
-    expect(teamName(100)).toBe("Blue Team");
-    expect(teamName(200)).toBe("Red Team");
   });
 
   test("translates direct choices through anchors on either side", () => {
@@ -32,5 +140,17 @@ describe("Bryan Bucks team mapping", () => {
     expect(teamIdForSubjectOutcome(100, false)).toBe(200);
     expect(teamIdForSubjectOutcome(200, true)).toBe(200);
     expect(teamIdForSubjectOutcome(200, false)).toBe(100);
+  });
+
+  // The two conversions are exact inverses, which is what makes the WIN/LOSE
+  // reframe lossless: storage stays team-relative.
+  test("round-trips every anchor and selection pair", () => {
+    for (const anchor of [100, 200] as const) {
+      for (const selected of [100, 200] as const) {
+        expect(
+          teamIdForSubjectOutcome(anchor, subjectWinsForTeam(anchor, selected)),
+        ).toBe(selected);
+      }
+    }
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/team.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/team.ts
@@ -1,26 +1,111 @@
 import { z } from "zod";
-import type { RiotTeamId } from "@scout-for-lol/data";
+import type { BucksPoolParticipant, RiotTeamId } from "@scout-for-lol/data";
 import { BLUE_TEAM_ID, RED_TEAM_ID } from "#src/betting/constants.ts";
 
-export const BucksTeamChoiceSchema = z.enum(["blue", "red"]);
+/**
+ * What `/bb bet` accepts for the wagered outcome.
+ *
+ * `win`/`lose` are the ordinary framing, relative to the game's tracked
+ * anchor. `blue`/`red` exist because slash-command choices are frozen at
+ * registration time and cannot vary per game: they are the escape hatch for
+ * the rare lobby with tracked players on both teams, where WIN/LOSE names no
+ * single outcome.
+ */
+export const BucksOutcomeChoiceSchema = z.enum(["win", "lose", "blue", "red"]);
 
-export type BucksTeamChoice = z.infer<typeof BucksTeamChoiceSchema>;
+export type BucksOutcomeChoice = z.infer<typeof BucksOutcomeChoiceSchema>;
 
 export const BETTING_TEAM_IDS: readonly RiotTeamId[] = [
   BLUE_TEAM_ID,
   RED_TEAM_ID,
 ];
 
-export function teamIdForChoice(choice: BucksTeamChoice): RiotTeamId {
-  return choice === "blue" ? BLUE_TEAM_ID : RED_TEAM_ID;
+/**
+ * How one game's two outcomes should be named.
+ *
+ * Storage stays team-relative — `predictedTeamId` remains the authoritative
+ * wager and settlement is unchanged — so this is purely a rendering concern.
+ */
+export type OutcomeFraming = {
+  /** The tracked anchor's team. "WIN" means this team wins. */
+  anchorTeamId: RiotTeamId;
+  /**
+   * Both teams carry a tracked player, so "WIN" would be ambiguous and the
+   * copy falls back to Blue/Red.
+   */
+  mixedTeams: boolean;
+};
+
+export type OutcomeChoiceResolution =
+  | { kind: "resolved"; teamId: RiotTeamId }
+  | { kind: "ambiguous" };
+
+/**
+ * A roster participant Scout tracks and can name.
+ *
+ * A privacy-scrubbed participant carries no PUUID, so it can neither anchor a
+ * bet nor prove that the other team is tracked.
+ */
+function isTrackedParticipant(participant: BucksPoolParticipant): boolean {
+  return participant.trackedAlias !== undefined && participant.puuid !== null;
+}
+
+/** True when tracked players sit on both teams, which makes WIN/LOSE ambiguous. */
+export function hasTrackedPlayersOnBothTeams(
+  roster: readonly BucksPoolParticipant[],
+): boolean {
+  const trackedTeamIds = new Set(
+    roster
+      .filter((participant) => isTrackedParticipant(participant))
+      .map((participant) => participant.teamId),
+  );
+  return trackedTeamIds.size > 1;
 }
 
 export function shortTeamName(teamId: RiotTeamId): "Blue" | "Red" {
   return teamId === BLUE_TEAM_ID ? "Blue" : "Red";
 }
 
-export function teamName(teamId: RiotTeamId): "Blue Team" | "Red Team" {
-  return `${shortTeamName(teamId)} Team`;
+/**
+ * Name one side of a game's binary outcome.
+ *
+ * Without framing — a caller with no roster in hand — this degrades to the
+ * team name, which is also the correct answer for a mixed lobby.
+ */
+export function outcomeLabel(
+  teamId: RiotTeamId,
+  framing: OutcomeFraming | undefined,
+): "WIN" | "LOSE" | "Blue" | "Red" {
+  if (framing === undefined || framing.mixedTeams) {
+    return shortTeamName(teamId);
+  }
+  return teamId === framing.anchorTeamId ? "WIN" : "LOSE";
+}
+
+/**
+ * Resolve a `/bb bet` choice to the team it wagers on.
+ *
+ * `blue`/`red` resolve without framing, which is what lets four static choices
+ * cover a per-game distinction. `win`/`lose` cannot be resolved for a mixed
+ * lobby, and the caller must ask for a side instead of guessing.
+ */
+export function resolveOutcomeChoice(
+  choice: BucksOutcomeChoice,
+  framing: OutcomeFraming,
+): OutcomeChoiceResolution {
+  if (choice === "blue") {
+    return { kind: "resolved", teamId: BLUE_TEAM_ID };
+  }
+  if (choice === "red") {
+    return { kind: "resolved", teamId: RED_TEAM_ID };
+  }
+  if (framing.mixedTeams) {
+    return { kind: "ambiguous" };
+  }
+  return {
+    kind: "resolved",
+    teamId: teamIdForSubjectOutcome(framing.anchorTeamId, choice === "win"),
+  };
 }
 
 export function teamIdForSubjectOutcome(

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
@@ -40,7 +40,7 @@ export const bbCommand = addBbPeekSubcommands(
     .addSubcommand((sub) =>
       sub
         .setName("bet")
-        .setDescription("Offer up to an amount; only matched Bucks are at risk")
+        .setDescription("Bet on a tracked player's game")
         .addStringOption((option) =>
           option
             .setName("game")
@@ -49,10 +49,18 @@ export const bbCommand = addBbPeekSubcommands(
         )
         .addStringOption((option) =>
           option
-            .setName("team")
-            .setDescription("The team to win")
+            .setName("outcome")
+            // Four static choices, because slash-command choices are frozen at
+            // registration and cannot vary per game. Blue/Red resolve without
+            // knowing the game, which is what covers the rare lobby with
+            // tracked players on both teams.
+            .setDescription(
+              "Win or lose for the tracked player — or pick a side",
+            )
             .setRequired(true)
             .addChoices(
+              { name: "Win", value: "win" },
+              { name: "Lose", value: "lose" },
               { name: "Blue", value: "blue" },
               { name: "Red", value: "red" },
             ),

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
@@ -4,13 +4,12 @@ import {
   ledgerKindLabel,
   renderBucksHistory,
 } from "#src/betting/navigation.ts";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
 import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
 
 describe("/bb history labels", () => {
   test("renders current and legacy house transfers readably", () => {
     expect(ledgerKindLabel(BucksLedgerKindSchema.parse("house_rake"))).toBe(
-      "legacy house cut on payout",
+      "house cut on payout",
     );
     expect(ledgerKindLabel(BucksLedgerKindSchema.parse("cancel_fee"))).toBe(
       "cancellation fee",
@@ -49,9 +48,11 @@ describe("/bb history labels", () => {
       totalPages: 1,
       snapshotId: 2,
     });
-    expect(rendered.content).toContain("legacy house cut on payout");
+    expect(rendered.content).toContain("house cut on payout");
     expect(rendered.content).toContain("cancellation fee");
-    expect(rendered.content).toContain(HOUSE_CUT_TERMS);
+    // History is an audit trail, not a place to re-explain the fee schedule.
+    expect(rendered.content).not.toContain("20%");
+    expect(rendered.content).not.toContain("legacy");
     expect(rendered.content).not.toContain("house_rake");
     expect(rendered.content).not.toContain("cancel_fee");
   });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-market.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-market.ts
@@ -6,7 +6,11 @@ import {
 } from "@scout-for-lol/data";
 import type { OpenMarketAggregate } from "#src/betting/open-market.ts";
 import { BLUE_TEAM_ID, RED_TEAM_ID } from "#src/betting/constants.ts";
-import { teamName } from "#src/betting/team.ts";
+import {
+  hasTrackedPlayersOnBothTeams,
+  outcomeLabel,
+  type OutcomeFraming,
+} from "#src/betting/team.ts";
 import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 
 type OpenBettingPool = {
@@ -18,6 +22,8 @@ export type OpenGameAnchor = {
   matchId: string;
   subjectPuuid: LeaguePuuid;
   subjectTeamId: RiotTeamId;
+  /** Tracked players on both teams, so `/bb bet outcome:win` is ambiguous. */
+  mixedTeams: boolean;
 };
 
 export function parseBettingRoster(raw: string): BucksPoolParticipant[] {
@@ -46,7 +52,8 @@ export function resolveOpenGameByAlias(
   const matches: OpenGameAnchor[] = [];
 
   for (const pool of pools) {
-    const subject = parseBettingRoster(pool.roster).find(
+    const roster = parseBettingRoster(pool.roster);
+    const subject = roster.find(
       (participant) =>
         participant.puuid !== null &&
         participant.trackedAlias?.toLowerCase() === normalizedAlias,
@@ -56,6 +63,7 @@ export function resolveOpenGameByAlias(
         matchId: pool.matchId,
         subjectPuuid: subject.puuid,
         subjectTeamId: subject.teamId,
+        mixedTeams: hasTrackedPlayersOnBothTeams(roster),
       });
     }
   }
@@ -68,24 +76,47 @@ export function resolveOpenGameByAlias(
   return matches[0];
 }
 
+/**
+ * How to name this pool's sides in `/bb open`.
+ *
+ * The aggregate already splits tracked players by team, so a mixed lobby is
+ * visible without reparsing the roster.
+ */
+function framingForAggregate(pool: OpenMarketAggregate): OutcomeFraming {
+  const blueIsTracked = pool.blue.trackedPlayers.length > 0;
+  const redIsTracked = pool.red.trackedPlayers.length > 0;
+  return {
+    anchorTeamId: blueIsTracked ? BLUE_TEAM_ID : RED_TEAM_ID,
+    mixedTeams: blueIsTracked && redIsTracked,
+  };
+}
+
 export function buildOpenMarketSections(
   pools: readonly OpenMarketAggregate[],
 ): string[] {
   return pools.map((pool) => {
     const closesAtUnix = Math.floor(pool.closesAt.getTime() / 1000);
-    const blueSelectors = formatGameSelectors(pool.blue.trackedPlayers);
-    const redSelectors = formatGameSelectors(pool.red.trackedPlayers);
-    const bluePlayers =
-      blueSelectors.length > 0
-        ? blueSelectors.join(", ")
-        : "No tracked players";
-    const redPlayers =
-      redSelectors.length > 0 ? redSelectors.join(", ") : "No tracked players";
+    const framing = framingForAggregate(pool);
+    const players = [...pool.blue.trackedPlayers, ...pool.red.trackedPlayers];
+    const title = players.length > 0 ? players.join(", ") : "Untracked lobby";
+    const sideEntries: readonly {
+      teamId: RiotTeamId;
+      side: OpenMarketAggregate["blue"];
+    }[] = [
+      { teamId: BLUE_TEAM_ID, side: pool.blue },
+      { teamId: RED_TEAM_ID, side: pool.red },
+    ];
+    const sides = sideEntries
+      .map(
+        (entry) =>
+          `${outcomeLabel(entry.teamId, framing)} **${entry.side.totalStake.toString()} BB** (${entry.side.betCount.toString()})`,
+      )
+      .join(" · ");
+    const selector =
+      players[0] === undefined ? "" : ` — \`/bb bet game:${players[0]}\``;
     return [
-      `## ${bluePlayers} vs ${redPlayers}`,
-      `Closes <t:${closesAtUnix.toString()}:R>`,
-      `🔵 **${teamName(BLUE_TEAM_ID)} offers:** ${pool.blue.totalStake.toString()} BB across ${pool.blue.betCount.toString()} offer(s) — ${bluePlayers}`,
-      `🔴 **${teamName(RED_TEAM_ID)} offers:** ${pool.red.totalStake.toString()} BB across ${pool.red.betCount.toString()} offer(s) — ${redPlayers}`,
+      `**${title}** · closes <t:${closesAtUnix.toString()}:R>`,
+      `${sides}${selector}`,
     ].join("\n");
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-peek.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-peek.ts
@@ -1,6 +1,7 @@
 import { type SlashCommandSubcommandsOnlyBuilder } from "discord.js";
 import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
 import { buildPeekPassQuoteReply } from "#src/betting/peek-pass-button.ts";
+import { PEEK_PASS_DURATION_LABEL } from "#src/betting/peek-pass.ts";
 import { describePeekResult, peekAtGame } from "#src/betting/peek.ts";
 import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
 
@@ -11,7 +12,7 @@ export function addBbPeekSubcommands(
     .addSubcommand((subcommand) =>
       subcommand
         .setName("pass")
-        .setDescription("Get a 24-hour peek-pass quote"),
+        .setDescription(`Get a ${PEEK_PASS_DURATION_LABEL} peek-pass quote`),
     )
     .addSubcommand((subcommand) =>
       subcommand

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
@@ -144,8 +144,9 @@ describe("/bb command contract", () => {
     expect(peek.options).toEqual([
       expect.objectContaining({ name: "game", required: true }),
     ]);
+    // The two-minute delay is a rule, so it lives in /bb rules only.
     expect(JSON.stringify(buildBbRulesEmbed().toJSON())).toContain(
-      "two minutes",
+      "**2 minutes**",
     );
   });
 
@@ -159,6 +160,7 @@ describe("/bb command contract", () => {
         matchId: `NA1_${index.toString()}`,
         gameAlias: `player-${index.toString()}-${"x".repeat(500)}`,
         teamId: 100,
+        sideLabel: "WIN",
         offeredStake: 1,
         matchedStake: null,
         unmatchedStake: null,
@@ -175,7 +177,7 @@ describe("/bb command contract", () => {
     expect(pendingField?.value.endsWith("...")).toBe(true);
   });
 
-  test("renders pending positions as direct team picks", () => {
+  test("renders pending positions with the game's own framing", () => {
     const view: PersonalBucksView = {
       balance: 20,
       totalAtRisk: 5,
@@ -186,6 +188,7 @@ describe("/bb command contract", () => {
           matchId: "NA1_1",
           gameAlias: "bryan",
           teamId: 200,
+          sideLabel: "LOSE",
           offeredStake: 5,
           matchedStake: null,
           unmatchedStake: null,
@@ -196,11 +199,11 @@ describe("/bb command contract", () => {
     };
 
     const rendered = JSON.stringify(buildPersonalBucksEmbed(view, 0).toJSON());
-    expect(rendered).toContain("Red Team");
-    expect(rendered).toContain("game: `bryan`");
+    // The label is resolved where the roster is already parsed, so the view
+    // renders it verbatim rather than re-deriving Blue/Red here.
+    expect(rendered).toContain("bryan LOSE");
     expect(rendered).toContain("offered up to 5 BB");
-    expect(rendered).not.toContain("WIN");
-    expect(rendered).not.toContain("LOSE");
+    expect(rendered).not.toContain("Red Team");
   });
 
   test("renders pending parlays independently from direct team picks", () => {
@@ -233,23 +236,70 @@ describe("/bb command contract", () => {
       "tracked League players",
       "25 BB",
       "+1 BB",
-      "any positive whole-BB amount",
+      "maximum offer",
       "10 minutes",
       "5 minutes",
-      "YES/NO parlay",
-      "cancel",
-      "Human offers match first",
-      "house then fills up to 5 BB",
-      "all unmatched BB are refunded",
-      "Matched outcome stakes are returned",
+      "match first at even money",
+      "house then fills up to **5 BB**",
+      "Unmatched BB are refunded at close, free",
+      "return every matched stake with no fee",
     ]) {
       expect(rendered).toContain(phrase);
     }
     expect(rendered).toContain(
-      "Cancelling an outcome offer costs 20% of the submitted amount",
+      "Cancelling before close costs **20%** of the offer, rounded to the nearest BB",
+    );
+    expect(rendered).toContain("Cancelling a parlay is free");
+  });
+
+  // Gaps that existed while these facts lived only on market messages, or not
+  // at all. /bb rules is now the only explainer, so it has to be complete.
+  test("rules cover what only the market message used to say", () => {
+    const rendered = JSON.stringify(buildBbRulesEmbed().toJSON());
+    expect(rendered).toContain("Every leg must hit for YES");
+    expect(rendered).toContain("live in-play market");
+    // The Clash bonus is the largest single award and was documented nowhere.
+    expect(rendered).toContain("Clash adds **+10 BB**");
+    // Normal 5v5 earns too; the old copy said "ranked" and was wrong.
+    expect(rendered).toContain("normal 5v5");
+    expect(rendered).not.toContain("Eligible ranked games");
+    // WIN/LOSE with the documented Blue/Red fallback.
+    expect(rendered).toContain("**WIN** or **LOSE**");
+    expect(rendered).toContain("both teams have a tracked player");
+  });
+
+  // /bb rules used to say "no cash value" while /bb prizes printed CAD figures
+  // up to $1,000,000 with no cross-reference.
+  test("rules and prizes agree that the exchange rate is a joke", () => {
+    const rules = JSON.stringify(buildBbRulesEmbed().toJSON());
+    expect(rules).toContain("a joke");
+    expect(rules).toContain("nothing can actually be redeemed");
+    expect(rules).toContain("`/bb prizes`");
+  });
+
+  // Every number is interpolated from the constant that implements it. The
+  // rules embed and the market copy once stated two different winner fees at
+  // the same time because both were hand-typed.
+  test("rules derive their numbers from the implementing constants", async () => {
+    const [{ HOUSE_CUT_PERCENT }, constants, { MINIMUM_PRICE }] =
+      await Promise.all([
+        import("#src/betting/house-cut.ts"),
+        import("#src/betting/constants.ts"),
+        import("#src/betting/peek-pass.ts"),
+      ]);
+    const rendered = JSON.stringify(buildBbRulesEmbed().toJSON());
+
+    expect(rendered).toContain(`**${HOUSE_CUT_PERCENT.toString()}%**`);
+    expect(rendered).toContain(`**${constants.SEED_GRANT.toString()} BB**`);
+    expect(rendered).toContain(
+      `**${constants.HOUSE_MATCH_LIMIT.toString()} BB** per game`,
+    );
+    expect(rendered).toContain(`minimum **${MINIMUM_PRICE.toString()} BB**`);
+    expect(rendered).toContain(
+      `${Math.floor(constants.BETTING_WINDOW_MS / 60_000).toString()} minutes`,
     );
     expect(rendered).toContain(
-      "cancelling a parlay returns its full stake and releases the house reserve",
+      `${Math.floor(constants.PARLAY_BETTING_WINDOW_MS / 60_000).toString()} minutes`,
     );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
@@ -260,8 +260,13 @@ describe("/bb command contract", () => {
     expect(rendered).toContain("live in-play market");
     // The Clash bonus is the largest single award and was documented nowhere.
     expect(rendered).toContain("Clash adds **+10 BB**");
-    // Normal 5v5 earns too; the old copy said "ranked" and was wrong.
-    expect(rendered).toContain("normal 5v5");
+    // The queue list is derived from BUCKS_EARNING_QUEUES rather than typed,
+    // and League Classic's split behaviour (played point, no market) is
+    // stated rather than left for a player to discover.
+    expect(rendered).toContain("Eligible queues:");
+    expect(rendered).toContain(
+      "League Classic pays the played point but carries no market",
+    );
     expect(rendered).not.toContain("Eligible ranked games");
     // WIN/LOSE with the documented Blue/Red fallback.
     expect(rendered).toContain("**WIN** or **LOSE**");

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -1,49 +1,98 @@
 import { EmbedBuilder } from "discord.js";
 import {
   BETTING_WINDOW_MS,
+  HOUSE_MATCH_LIMIT,
   PARLAY_BETTING_WINDOW_MS,
   SEED_GRANT,
 } from "#src/betting/constants.ts";
+import { EARNED_REWARDS } from "#src/betting/earnings.ts";
+import { HOUSE_CUT_PERCENT } from "#src/betting/house-cut.ts";
+import { PEEK_DELAY_MS } from "#src/betting/pool-open.ts";
+import {
+  MINIMUM_PRICE,
+  PEEK_PASS_DURATION_MS,
+} from "#src/betting/peek-pass.ts";
 
 const BUCKS_COLOR = 0x2e_cc_71;
 
+/**
+ * The single place Bryan Bucks rules are explained.
+ *
+ * No other surface states a fee, a window, a cap, or a rounding mode. Market
+ * messages and confirmations show numbers and point here. Two reasons:
+ *
+ * 1. The old house-terms blurb was 344 characters rendered on seven surfaces —
+ *    17% of every character a player ever saw — and four of those surfaces
+ *    were not a betting decision.
+ * 2. Restating a rule means maintaining it twice, and it drifted: for a day
+ *    this embed said the winner fee was 20% of *gross payout* rounded to the
+ *    nearest BB while the market copy said 20% of *matched profit* rounded
+ *    down. Two different amounts, both live.
+ *
+ * Every number below is interpolated from the constant that implements it.
+ * Do not hand-type one.
+ */
+function minutes(milliseconds: number): string {
+  return Math.floor(milliseconds / 60_000).toString();
+}
+
+function hours(milliseconds: number): string {
+  return Math.floor(milliseconds / 3_600_000).toString();
+}
+
 export function buildBbRulesEmbed(): EmbedBuilder {
+  const outcomeWindow = minutes(BETTING_WINDOW_MS);
+  const parlayWindow = minutes(PARLAY_BETTING_WINDOW_MS);
+  const cut = HOUSE_CUT_PERCENT.toString();
   return new EmbedBuilder()
     .setTitle("📜 Bryan Bucks rules")
     .setColor(BUCKS_COLOR)
     .setDescription(
-      "Bryan Bucks are friendly points for tracked League players. They have no cash value.",
+      "Bryan Bucks are friendly points for tracked League players. They are a joke — there is no cash value and nothing can actually be redeemed. `/bb prizes` is part of the joke.",
     )
     .addFields(
       {
-        name: "Eligibility & earnings",
+        name: "Getting Bucks",
         value:
-          `Your Discord account must be linked to a tracked player. A new wallet starts with **${SEED_GRANT.toString()} BB**. ` +
-          "Eligible ranked games award **+1 BB** for playing, **+1 BB** for winning, and **+1 BB** for MVP.",
+          `Link your Discord account to a tracked player. A new wallet starts with **${SEED_GRANT.toString()} BB**. ` +
+          `Every eligible game pays **+${EARNED_REWARDS.played.amount.toString()} BB** for playing, ` +
+          `**+${EARNED_REWARDS.win.amount.toString()} BB** for winning, and ` +
+          `**+${EARNED_REWARDS.mvp.amount.toString()} BB** for MVP. ` +
+          `Ranked 5s adds **+${EARNED_REWARDS["ranked 5s bonus"].amount.toString()} BB** and Clash adds ` +
+          `**+${EARNED_REWARDS["clash bonus"].amount.toString()} BB**. ` +
+          "Solo/duo, flex, normal 5v5, ranked 5s, and Clash all count.",
       },
       {
-        name: "Placing a bet",
+        name: `Outcome bets — ${outcomeWindow} minutes`,
         value:
-          `Offer any positive whole-BB amount your wallet can cover on the Blue or Red Team in a tracked player's game; that market stays open for ${Math.floor(BETTING_WINDOW_MS / 60_000).toString()} minutes. Only the final matched amount is at risk. ` +
-          `A separate YES/NO parlay may open for ${Math.floor(PARLAY_BETTING_WINDOW_MS / 60_000).toString()} minutes, with its full house liability reserved when you bet. ` +
-          "You can add to a position before its window closes. Cancelling an outcome offer costs 20% of the submitted amount, rounded to the nearest BB; cancelling a parlay returns its full stake and releases the house reserve.",
+          "Bet **WIN** or **LOSE** on the tracked player. When both teams have a tracked player, pick **Blue** or **Red** instead. " +
+          "Your amount is a maximum offer: human offers match first at even money, oversubscribed offers match proportionally, " +
+          `and the house then fills up to **${HOUSE_MATCH_LIMIT.toString()} BB** per game if its balance allows. ` +
+          "Unmatched BB are refunded at close, free. " +
+          `Winners get twice their matched stake, less **${cut}%** of matched profit, rounded down. ` +
+          `Cancelling before close costs **${cut}%** of the offer, rounded to the nearest BB.`,
       },
       {
-        name: "Outcome matching & settlement",
+        name: `Parlays — ${parlayWindow} minutes`,
         value:
-          "Human offers match first at even money. The house then fills up to 5 BB of the remaining gap for the whole game, subject to its balance. Oversubscribed offers are matched proportionally, and all unmatched BB are refunded at close. " +
-          "A winner receives twice their matched stake before a fee of 20% of matched profit, rounded down.",
+          "A separate YES/NO market on 2-6 legs about the live game. **Every leg must hit for YES.** " +
+          "Odds are fixed and quoted when you bet, and the house reserves the full payout at that price. " +
+          "It is a live in-play market published after the game starts, so early events may already be visible. " +
+          "Cancelling a parlay is free and returns the whole stake.",
+      },
+      {
+        name: "Voids",
+        value:
+          "Remakes, unsupported modes, and games that never resolve return every matched stake with no fee. " +
+          "Unmatched BB are always refunded free. Parlay voids also release the reserved house payout.",
       },
       {
         name: "Peek passes",
         value:
-          "Use `/bb pass` to buy unlimited private peeks for 24 hours. The price depends on your current balance and how long you have held it, with a 5 BB minimum. " +
-          "Use `/bb peek game:<tracked player>` after the game has been live for two minutes. Estimates are experimental, frozen before the game, and disappear when the market resolves.",
-      },
-      {
-        name: "Settlement",
-        value:
-          "Outcome BB that do not match are refunded automatically with no fee. Matched outcome stakes are returned with no fee when a game is voided, remade, unsupported, or cannot be settled. Parlay voids return the stake and release the reserved house liability.",
+          `\`/bb pass\` buys **${hours(PEEK_PASS_DURATION_MS)} hours** of private pregame estimates. ` +
+          `The price scales with your balance and how long you have held it, minimum **${MINIMUM_PRICE.toString()} BB**. ` +
+          `Then \`/bb peek game:<tracked player>\` once the game has been live for **${minutes(PEEK_DELAY_MS)} minutes**. ` +
+          "Estimates are experimental, frozen before the game, and disappear when the market resolves.",
       },
     );
 }

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from "discord.js";
 import {
   BETTING_WINDOW_MS,
+  BUCKS_EARNING_QUEUES,
   HOUSE_MATCH_LIMIT,
   PARLAY_BETTING_WINDOW_MS,
   SEED_GRANT,
@@ -60,7 +61,8 @@ export function buildBbRulesEmbed(): EmbedBuilder {
           `**+${EARNED_REWARDS.mvp.amount.toString()} BB** for MVP. ` +
           `Ranked 5s adds **+${EARNED_REWARDS["ranked 5s bonus"].amount.toString()} BB** and Clash adds ` +
           `**+${EARNED_REWARDS["clash bonus"].amount.toString()} BB**. ` +
-          "Solo/duo, flex, normal 5v5, ranked 5s, and Clash all count.",
+          `Eligible queues: ${BUCKS_EARNING_QUEUES.join(", ")}. ` +
+          "League Classic pays the played point but carries no market, because Riot exposes no post-game payload for it.",
       },
       {
         name: `Outcome bets — ${outcomeWindow} minutes`,

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.test.ts
@@ -27,7 +27,7 @@ function fixturePuuidAt(index: number) {
 }
 
 describe("/bb bet", () => {
-  test("registers game, team, and amount as required options", () => {
+  test("registers game, outcome, and amount as required options", () => {
     const command = bbCommand.toJSON();
     const bet = command.options?.find((option) => option.name === "bet");
     if (bet === undefined || !("options" in bet)) {
@@ -38,7 +38,7 @@ describe("/bb bet", () => {
       expect.objectContaining({
         type: 1,
         name: "bet",
-        description: "Offer up to an amount; only matched Bucks are at risk",
+        description: "Bet on a tracked player's game",
       }),
     );
     expect(bet.options).toEqual([
@@ -47,11 +47,16 @@ describe("/bb bet", () => {
         description: "A tracked player in the game",
         required: true,
       }),
+      // Four static choices: slash-command choices are frozen at registration,
+      // so Blue/Red have to stay available for the rare lobby where win/lose
+      // names no single outcome.
       expect.objectContaining({
-        name: "team",
-        description: "The team to win",
+        name: "outcome",
+        description: "Win or lose for the tracked player — or pick a side",
         required: true,
         choices: [
+          { name: "Win", value: "win" },
+          { name: "Lose", value: "lose" },
           { name: "Blue", value: "blue" },
           { name: "Red", value: "red" },
         ],
@@ -78,11 +83,13 @@ describe("/bb bet", () => {
       matchId: "NA1_blue-and-red",
       subjectPuuid: fixturePuuidAt(0),
       subjectTeamId: 100,
+      mixedTeams: true,
     });
     expect(resolveOpenGameByAlias(pools, "BrYaN")).toEqual({
       matchId: "NA1_blue-and-red",
       subjectPuuid: fixturePuuidAt(5),
       subjectTeamId: 200,
+      mixedTeams: true,
     });
   });
 
@@ -142,7 +149,7 @@ describe("/bb bet", () => {
     }
   });
 
-  test("shows every open-game alias with its Blue or Red team", () => {
+  test("names sides WIN and LOSE and offers a copyable selector", () => {
     const sections = buildOpenMarketSections([
       {
         matchId: "NA1_open",
@@ -157,11 +164,26 @@ describe("/bb bet", () => {
     ]);
 
     expect(sections).toHaveLength(1);
-    expect(sections[0]).toContain(
-      "🔵 **Blue Team offers:** 6 BB across 2 offer(s) — game: `jerred`, game: `friend`",
-    );
-    expect(sections[0]).toContain(
-      "🔴 **Red Team offers:** 5 BB across 1 offer(s) — game: `bryan`",
-    );
+    // Tracked players on both teams, so this lobby keeps Blue/Red.
+    expect(sections[0]).toContain("**jerred, friend, bryan**");
+    expect(sections[0]).toContain("Blue **6 BB** (2) · Red **5 BB** (1)");
+    expect(sections[0]).toContain("`/bb bet game:jerred`");
+  });
+
+  test("names sides WIN and LOSE when only one team is tracked", () => {
+    const sections = buildOpenMarketSections([
+      {
+        matchId: "NA1_open",
+        closesAt: new Date("2030-01-01T00:10:00Z"),
+        blue: {
+          trackedPlayers: ["jerred", "friend"],
+          totalStake: 6,
+          betCount: 2,
+        },
+        red: { trackedPlayers: [], totalStake: 5, betCount: 1 },
+      },
+    ]);
+
+    expect(sections[0]).toContain("WIN **6 BB** (2) · LOSE **5 BB** (1)");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -11,14 +11,18 @@ import {
 import { placeBet } from "#src/betting/place-bet.ts";
 import { describeResult } from "#src/betting/bet-button.ts";
 import { refreshBucksMessages } from "#src/betting/message-refresh.ts";
-import { HOUSE_CUT_TERMS } from "#src/betting/house-cut.ts";
+import {
+  BUCKS_GUILD_ONLY,
+  BUCKS_NOT_ENABLED,
+  withRulesHint,
+} from "#src/betting/copy.ts";
 import { renderBucksHistory } from "#src/betting/navigation.ts";
 import { getOpenMarketAggregates } from "#src/betting/open-market.ts";
 import {
-  BucksTeamChoiceSchema,
+  BucksOutcomeChoiceSchema,
   subjectWinsForTeam,
-  teamIdForChoice,
-  teamName,
+  outcomeLabel,
+  resolveOutcomeChoice,
 } from "#src/betting/team.ts";
 import { announceParlayPlacement } from "#src/betting/parlay-announce.ts";
 import { ParlaySubjectsSchema } from "#src/betting/parlay-criteria.ts";
@@ -96,7 +100,7 @@ export function buildPersonalBucksEmbed(
         position.matchedStake === null
           ? `offered up to ${position.offeredStake.toString()} BB · match pending`
           : `matched ${position.matchedStake.toString()} BB · refunded ${(position.unmatchedStake ?? 0).toString()} BB`;
-      return `• **${teamName(position.teamId)}** — game: \`${position.gameAlias}\` · ${amount} · ${timing}`;
+      return `• **${position.gameAlias} ${position.sideLabel}** — ${amount} · ${timing}`;
     }
     return `• **${position.subjectAlias} ${position.side}** — ${position.stake.toString()} BB · ${timing}`;
   });
@@ -139,13 +143,14 @@ async function replyBalance(
   const view = await getPersonalBucksView({ serverId, discordId });
   if (view === undefined) {
     await interaction.editReply({
-      content: `You don't have a Bryan Bucks wallet yet — place your first bet on a live game and you'll be given a starting balance.\n\n${HOUSE_CUT_TERMS}`,
+      content: withRulesHint(
+        "No wallet yet — bet on a live game and you'll get a starting balance.",
+      ),
     });
     return;
   }
 
   await interaction.editReply({
-    content: HOUSE_CUT_TERMS,
     embeds: [buildPersonalBucksEmbed(view)],
   });
 }
@@ -198,7 +203,7 @@ async function replyOpen(
 
   if (pools.length === 0 && parlays.length === 0) {
     await interaction.editReply({
-      content: `No games are open for betting right now.\n\n${HOUSE_CUT_TERMS}`,
+      content: "Nothing open right now.",
     });
     return;
   }
@@ -210,16 +215,12 @@ async function replyOpen(
     ).map((subject) => subject.alias);
     const closesAtUnix = Math.floor(parlay.closesAt.getTime() / 1000);
     sections.push(
-      [
-        `## Parlay · ${aliases.join(", ")}`,
-        `Match: \`${parlay.matchId}\``,
-        `Closes <t:${closesAtUnix.toString()}:R>`,
-      ].join("\n"),
+      `**Parlay · ${aliases.join(", ")}** · closes <t:${closesAtUnix.toString()}:R> — \`/bb parlay player:${aliases[0] ?? ""}\``,
     );
   }
   await editReplyInChunks(
     interaction,
-    splitMessageIntoChunks(`${sections.join("\n\n")}\n\n${HOUSE_CUT_TERMS}`),
+    splitMessageIntoChunks(sections.join("\n\n")),
   );
 }
 
@@ -285,8 +286,8 @@ async function replyBet(
   discordId: ReturnType<typeof DiscordAccountIdSchema.parse>,
 ): Promise<void> {
   const requestedAlias = interaction.options.getString("game", true);
-  const selectedTeamId = teamIdForChoice(
-    BucksTeamChoiceSchema.parse(interaction.options.getString("team", true)),
+  const choice = BucksOutcomeChoiceSchema.parse(
+    interaction.options.getString("outcome", true),
   );
   const stake = interaction.options.getInteger("amount", true);
 
@@ -300,6 +301,22 @@ async function replyBet(
 
   const game = resolveOpenGameByAlias(pools, requestedAlias);
   if (game !== undefined) {
+    const framing = {
+      anchorTeamId: game.subjectTeamId,
+      mixedTeams: game.mixedTeams,
+    };
+    const resolved = resolveOutcomeChoice(choice, framing);
+    if (resolved.kind === "ambiguous") {
+      // Slash-command choices are frozen at registration, so the rare lobby
+      // with tracked players on both teams has to be handled here rather than
+      // by varying the option list per game.
+      await interaction.editReply({
+        content:
+          "Both teams have a tracked player in this game, so `win` and `lose` are ambiguous — pick `Blue` or `Red`.",
+      });
+      return;
+    }
+    const selectedTeamId = resolved.teamId;
     const subjectWins = subjectWinsForTeam(game.subjectTeamId, selectedTeamId);
     const result = await placeBet({
       matchId: game.matchId,
@@ -310,7 +327,7 @@ async function replyBet(
       stake,
     });
     await interaction.editReply({
-      content: describeResult(result, selectedTeamId),
+      content: describeResult(result, outcomeLabel(selectedTeamId, framing)),
     });
     if (result.kind === "placed") {
       await refreshBucksMessages({ matchId: game.matchId, serverId });
@@ -324,7 +341,7 @@ async function replyBet(
 
   if (available.length === 0) {
     await interaction.editReply({
-      content: "No games are open for betting right now.",
+      content: "Nothing open right now.",
     });
     return;
   }
@@ -344,7 +361,7 @@ export async function executeBb(
   try {
     if (interaction.guildId === null) {
       await interaction.reply({
-        content: "Bryan Bucks only works inside a server.",
+        content: BUCKS_GUILD_ONLY,
         ephemeral: true,
       });
       return;
@@ -355,7 +372,7 @@ export async function executeBb(
       // Reachable only if the flag was turned off after registration, since
       // the command is not registered anywhere the flag is off.
       await interaction.reply({
-        content: "Bryan Bucks isn't enabled in this server.",
+        content: BUCKS_NOT_ENABLED,
         ephemeral: true,
       });
       return;

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/prematch-notification.ts
@@ -36,7 +36,7 @@ import {
 } from "#src/metrics/index.ts";
 import { capturePredictionForPrematch } from "#src/betting/prediction-capture.ts";
 import { isBettableGame, isStandardLobby } from "#src/betting/eligibility.ts";
-import { appendBucksLine } from "#src/betting/prematch-line.ts";
+import { withBucksDigest } from "#src/betting/prematch-line.ts";
 import {
   prepareBucksPrematch,
   type BucksPrematchAttachment,
@@ -158,7 +158,7 @@ function buildPrematchPayload(input: {
   if (input.loadingScreenAttachment && input.loadingScreenEmbed) {
     return {
       content: input.betsOpen
-        ? appendBucksLine(input.baseContent, input.bucks.footer)
+        ? withBucksDigest(input.baseContent, input.bucks.footer)
         : input.baseContent,
       files: [input.loadingScreenAttachment],
       embeds: [input.loadingScreenEmbed],


### PR DESCRIPTION
Why:
Two problems in the same copy.

The market framed every bet as Blue/Red, which is indirect: there is
effectively never a game with tracked players on both teams, so "Blue Team to
win" names a side the reader has to translate back to "does Hirza win".

Separately, `HOUSE_CUT_TERMS` — 344 characters of fee, cap and rounding policy
— was rendered on seven sites across five surfaces, four of which are not a
betting decision at all (`/bb balance`, `/bb open`, `/bb history`, and every
public prematch message). At 2,408 delivered characters it was 17% of every
character a Bryan Bucks player could see, and 2.7x the entire `/bb prizes`
catalogue. `appendBucksLine` even truncated the match report to protect it.

Restating a rule also means maintaining it twice, and it drifted in
production: on 2026-08-19 the `/bb rules` embed told players the winner fee was
"20% of each human winner's gross payout, rounded to the nearest BB" while the
market copy said "20% of matched profit, rounded down" — two different amounts,
live at the same time. `HOUSE_CUT_PERCENT` existed and neither used it.

What:
WIN/LOSE is a presentation change only. The substrate was already there:
`custom-id.ts` still encodes "W"/"L", `placeBet` already takes
`{ subjectPuuid, subjectWins }`, and `bettingAnchor` already picks one tracked
anchor per game. `outcomeLabel(teamId, framing)` is the new adapter;
`predictedTeamId`, matching, and settlement arithmetic are untouched, and
`teamIdForSubjectOutcome`/`subjectWinsForTeam` are exact inverses, so the
reframe is lossless in both directions.

Blue/Red survives as the fallback for the rare lobby with tracked players on
both teams, detected by `hasTrackedPlayersOnBothTeams` over the frozen roster —
no schema change and no new query. Keeping ONE anchor per game preserves the
fix from #2274: same-team teammates must not render as duplicate markets, so
per-tracked-player rows do not come back.

`/bb bet` takes `outcome` with four static choices (Win/Lose/Blue/Red).
Slash-command choices are frozen at registration and cannot vary per game, so
Blue/Red are the escape hatch that makes a per-game distinction expressible;
`win`/`lose` on a mixed lobby is refused with an explanation rather than
guessed.

`HOUSE_CUT_TERMS` and the already-dead `HOUSE_CUT_PLACEMENT_NOTE` are deleted.
`/bb rules` is now the only place a rule is stated, and it also closes its own
gaps: "every leg must hit for YES" and the live/in-play disclosure existed only
on the market message, the Clash bonus (+10 BB, the largest single award) and
the Ranked 5s bonus were documented nowhere, and it claimed only "ranked" games
earn when normal 5v5 does too. It also reconciles the contradiction with
`/bb prizes`, which prints CAD figures up to $1,000,000 while the rules said
"no cash value".

Every number in the rules embed is now interpolated from the constant that
implements it, and both fee functions derive from `HOUSE_CUT_PERCENT` instead
of the magic `Math.floor(x/5)` and `Math.floor((x+2)/5)`.

The prematch digest is rewritten: names are inlined one line per side while
open, the receipt keeps the full offered/matched/refunded arithmetic at close,
and `appendBucksLine` becomes `withBucksDigest`, which bounds the digest
against the space the base leaves rather than truncating the base.

Shared refusal copy moves to `betting/copy.ts`, resolving five copies of the DM
guard in two dialects, five strings for "not enabled", three for "no market",
and an "Offers"/"Stakes" split for identical validation. The parlay
"Only tracked players can bet." adopts the outcome wording, which keeps the
remediation sentence it was dropping. `/bb history` no longer shows players the
words "legacy bet refund" and "legacy house cut on payout".

Verification:
- `bun test` in packages/backend — 1924 pass, 6 pre-existing skips, 0 fail.
- `bun run lint` — 0 errors (849 pre-existing duplication warnings).
- `bunx tsc --noEmit` — clean.
- The fee refactor was proved arithmetically identical to the previous magic
  numbers for every integer 0..2,147,483 and at both Int32 ceiling values,
  before relying on `house-cut.test.ts`.
- New `team.test.ts` cases pin the mixed-lobby fallback, that two tracked
  players on the SAME team is not mixed, that a privacy-scrubbed participant
  cannot make a lobby mixed, and that the anchor conversions round-trip.
- New `bb-prizes.test.ts` cases pin that the rules cover the previously
  market-only facts and that every number is interpolated from its constant.
- `grep` confirms no remaining `HOUSE_CUT_TERMS` reference and no hand-typed
  rule number in user-facing copy.
- Not run: live Discord verification against beta.