### PR TITLE
feat(scout-for-lol): count and log every Bryan Bucks transition and message delivery

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -1169,11 +1169,37 @@ current UTC timestamp for relative date filters, and uses `BB_ASK_MODEL`
   out with a silent `deferUpdate()` and counted as `bb/malformed`, never as
   `bb/success`.
 - **Pregame estimates are never public.** Prematch messages contain only market
-  controls and house terms. A pass holder sees the estimate ephemerally after
-  the two-minute delay. Settlement may reveal it after the result, except that
+  controls. A pass holder sees the estimate ephemerally after the two-minute
+  delay. Settlement may reveal it after the result, except that
   calls displaying as 45–55% remain suppressed. `predictionVerdict` also
   returns nothing for those near-even rows because scoring them would claim a
   direction the stored estimate did not take.
+- **Every state transition is counted and logged, post-commit only.**
+  `src/metrics/betting.ts` holds the counters and gauges;
+  `src/betting/transition-log.ts` holds `logBucksTransition`. Both fire
+  **after** the owning `$transaction` resolves — `settleOnePool`,
+  `matchPoolAtClose`, `cancelBet`, `placeBet`, and `purchasePeekPass` all
+  return from inside their transaction, so their observations live at the
+  call site or in a thin wrapper. A metric emitted inside a transaction that
+  then rolls back is a lie that survives forever. `logBucksTransition` never
+  throws; observability must not fail a money movement.
+  Metric labels are closed unions and carry **no IDs** — Bryan Bucks runs in
+  one guild, so a `server_id` label costs a dimension and says nothing.
+- **Retention: logs are 90 days, counters are not history.** Promtail ships
+  stdout to Loki with a 90-day retention, and Prometheus counters reset on
+  restart. The permanent record is SQLite — `BucksLedgerEntry` plus the pool
+  and bet timestamp columns (`createdAt`, `matchedAt`, `settledAt`,
+  `cancelledAt`, `matchingJson`). Do not treat logs or counters as the audit
+  trail.
+- **All Bucks sends and edits go through `observeBucksDelivery`**, which
+  classifies the failure, counts it, and **rethrows unchanged** — every caller
+  owns its own catch, and `announce.ts`'s per-channel isolation depends on
+  seeing the error. The three refresh paths that used to return silently
+  (`pool === null`, `prematchContentBase === null`, `refs.length === 0`) now
+  call `recordBucksDeliverySkip`. They are not equally alarming:
+  `skipped_no_base` is expected forever for pre-column pools and must never be
+  alerted on, while `skipped_no_refs` is the leading indicator of "settlement
+  had nowhere to announce".
 
 ## Database (Prisma)
 

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -17,6 +17,8 @@ import {
   predictionVerdict,
 } from "#src/betting/outcome-message.ts";
 import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
+import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
+import { bettingSettlementUndeliverableTotal } from "#src/metrics/betting.ts";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
 import type { ClosedPool } from "#src/betting/sweep.ts";
@@ -151,10 +153,21 @@ async function sendSettlementWithRetries(
     attempt++
   ) {
     try {
-      await dependencies.sendMessage(
-        input.options,
-        input.channelId,
-        input.guildId,
+      // Wrapped per attempt, so a retried delivery shows its failures rather
+      // than only its eventual success.
+      await observeBucksDelivery(
+        {
+          surface: "settlement",
+          operation: "send",
+          channelId: input.channelId,
+          serverId: input.guildId,
+        },
+        () =>
+          dependencies.sendMessage(
+            input.options,
+            input.channelId,
+            input.guildId,
+          ),
       );
       return;
     } catch (error) {
@@ -276,6 +289,9 @@ function reportUndeliverableSettlement(input: {
     input.unmatchedCount > 0 ||
     (input.parlay?.bets.length ?? 0) > 0 ||
     input.earnings.some((award) => award.serverId === input.summary.serverId);
+  bettingSettlementUndeliverableTotal.inc({
+    reason: owedSomeone ? "no_refs_owed" : "no_refs_unowed",
+  });
   if (!owedSomeone) {
     return;
   }
@@ -408,6 +424,7 @@ export async function announceSettlements(
         },
       });
       if (pool === null) {
+        bettingSettlementUndeliverableTotal.inc({ reason: "pool_missing" });
         continue;
       }
       const settledBetIds = new Set(summary.bets.map((bet) => bet.betId));

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -204,6 +204,7 @@ export async function handleBetButton(
       subjectPuuid: subject.puuid,
       subjectWins: betOnWin,
       stake: parsed.amount,
+      surface: "button",
     },
     prismaClient,
   );

--- a/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/cancel-bet.ts
@@ -12,6 +12,12 @@ import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { findBucksAccountId } from "#src/betting/accounts.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
+import {
+  bettingBetCancellationsTotal,
+  bettingSettlementConservationFailuresTotal,
+  bettingStakeBucksTotal,
+} from "#src/metrics/betting.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
 
 const logger = createLogger("betting-cancel-bet");
 
@@ -46,6 +52,43 @@ export type CancelBetResult =
  * offer without severing any ledger links.
  */
 export async function cancelBet(
+  input: {
+    matchId: string;
+    serverId: DiscordGuildId;
+    discordId: DiscordAccountId;
+    surface?: "button" | "command";
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+  now: Date = new Date(),
+): Promise<CancelBetResult> {
+  const result = await cancelBetInner(input, prismaClient, now);
+  const surface = input.surface ?? "button";
+  bettingBetCancellationsTotal.inc({ surface, result: result.kind });
+  if (result.kind === "cancelled") {
+    bettingStakeBucksTotal.inc(
+      { movement: "refunded_cancel" },
+      result.refunded,
+    );
+    bettingStakeBucksTotal.inc(
+      { movement: "house_cut_cancellation" },
+      result.houseCut,
+    );
+    logBucksTransition({
+      event: "bucks.bet.cancelled",
+      matchId: input.matchId,
+      serverId: input.serverId,
+      actorDiscordId: input.discordId,
+      stake: result.stake,
+      houseCut: result.houseCut,
+      payout: result.refunded,
+      balanceAfter: result.balanceAfter,
+      surface,
+    });
+  }
+  return result;
+}
+
+async function cancelBetInner(
   input: {
     matchId: string;
     serverId: DiscordGuildId;
@@ -152,6 +195,7 @@ export async function cancelBet(
     const houseCut = cancellationHouseCut(bet.stake);
     const refunded = bet.stake - houseCut;
     if (refunded + houseCut !== bet.stake) {
+      bettingSettlementConservationFailuresTotal.inc({ stage: "cancellation" });
       throw new Error(
         `Cancellation for ${input.matchId} did not conserve Bucks: offer ${bet.stake.toString()}, refund ${refunded.toString()}, cancellation fee ${houseCut.toString()}`,
       );

--- a/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import {
+  observeBucksDelivery,
+  recordBucksDeliverySkip,
+} from "#src/betting/delivery-observability.ts";
+import { ChannelSendError } from "#src/league/discord/channel.ts";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Counters are process-global and `bun test` runs files in parallel, so every
+ * assertion here diffs before and after rather than reading an absolute value.
+ */
+async function countOf(labels: Record<string, string>): Promise<number> {
+  const metric = registry.getSingleMetric("betting_message_operations_total");
+  if (metric === undefined) {
+    throw new Error("betting_message_operations_total is not registered");
+  }
+  const collected = await metric.get();
+  const match = collected.values.find((value) =>
+    Object.entries(labels).every(
+      ([key, expected]) => value.labels[key] === expected,
+    ),
+  );
+  return match?.value ?? 0;
+}
+
+describe("observeBucksDelivery", () => {
+  test("counts a successful delivery", async () => {
+    const labels = {
+      surface: "prematch",
+      operation: "edit",
+      result: "success",
+    };
+    const before = await countOf(labels);
+
+    await expect(
+      observeBucksDelivery({ surface: "prematch", operation: "edit" }, () =>
+        Promise.resolve("done"),
+      ),
+    ).resolves.toBe("done");
+
+    expect(await countOf(labels)).toBe(before + 1);
+  });
+
+  // Rethrowing is load-bearing: every caller owns its own catch and Sentry
+  // semantics, and announce.ts's per-channel isolation depends on seeing the
+  // error. Swallowing here would silently change product behaviour.
+  test("classifies a permission failure and rethrows it unchanged", async () => {
+    const labels = {
+      surface: "settlement",
+      operation: "send",
+      result: "permission_error",
+    };
+    const before = await countOf(labels);
+    const thrown = new ChannelSendError("no perms", "channel-1", true);
+
+    await expect(
+      observeBucksDelivery({ surface: "settlement", operation: "send" }, () =>
+        Promise.reject(thrown),
+      ),
+    ).rejects.toBe(thrown);
+
+    expect(await countOf(labels)).toBe(before + 1);
+  });
+
+  test("classifies an unknown failure as an error and rethrows it", async () => {
+    const labels = {
+      surface: "parlay_market",
+      operation: "edit",
+      result: "error",
+    };
+    const before = await countOf(labels);
+    const thrown = new Error("transient Discord failure");
+
+    await expect(
+      observeBucksDelivery(
+        { surface: "parlay_market", operation: "edit" },
+        () => Promise.reject(thrown),
+      ),
+    ).rejects.toBe(thrown);
+
+    expect(await countOf(labels)).toBe(before + 1);
+  });
+});
+
+describe("recordBucksDeliverySkip", () => {
+  test("counts each skip reason under its own label", async () => {
+    const labels = {
+      surface: "prematch",
+      operation: "edit",
+      result: "skipped_no_refs",
+    };
+    const before = await countOf(labels);
+
+    recordBucksDeliverySkip({
+      surface: "prematch",
+      operation: "edit",
+      reason: "skipped_no_refs",
+      matchId: "NA1_1",
+      serverId: "1337623164146155593",
+    });
+
+    expect(await countOf(labels)).toBe(before + 1);
+  });
+
+  test("counts the expected-forever legacy skip too", async () => {
+    const labels = {
+      surface: "prematch",
+      operation: "edit",
+      result: "skipped_no_base",
+    };
+    const before = await countOf(labels);
+
+    recordBucksDeliverySkip({
+      surface: "prematch",
+      operation: "edit",
+      reason: "skipped_no_base",
+      matchId: "NA1_1",
+      serverId: "1337623164146155593",
+    });
+
+    expect(await countOf(labels)).toBe(before + 1);
+  });
+});
+
+describe("betting metric naming", () => {
+  test("every betting metric is snake_case with the right suffix", async () => {
+    await import("#src/metrics/betting.ts");
+    const metrics = await registry.getMetricsAsJSON();
+    const betting = metrics.filter((metric) =>
+      metric.name.startsWith("betting_"),
+    );
+
+    expect(betting.length).toBeGreaterThan(10);
+    for (const metric of betting) {
+      expect(metric.name).toMatch(/^betting_[a-z0-9_]+$/u);
+      const type = String(metric.type);
+      if (type === "counter") {
+        expect(metric.name).toEndWith("_total");
+      }
+      if (type === "histogram") {
+        expect(metric.name).toEndWith("_seconds");
+      }
+    }
+  });
+
+  test("no betting metric declares an identifier label", async () => {
+    await import("#src/metrics/betting.ts");
+    const metrics = await registry.getMetricsAsJSON();
+    const forbidden = [
+      "match_id",
+      "server_id",
+      "discord_id",
+      "channel_id",
+      "puuid",
+    ];
+    for (const metric of metrics.filter((entry) =>
+      entry.name.startsWith("betting_"),
+    )) {
+      for (const value of metric.values) {
+        for (const label of Object.keys(value.labels)) {
+          expect(forbidden).not.toContain(label);
+        }
+      }
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.ts
@@ -1,0 +1,149 @@
+import {
+  bettingMessageOperationDurationSeconds,
+  bettingMessageOperationsTotal,
+} from "#src/metrics/betting.ts";
+import { ChannelSendError } from "#src/league/discord/channel.ts";
+import {
+  isMissingChannelError,
+  isPermissionError,
+} from "#src/discord/utils/permissions.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("betting-delivery");
+
+/**
+ * Observability for every Bryan Bucks Discord send and edit.
+ *
+ * Deliberately per-call-site rather than inside the shared `send()`, for three
+ * reasons that compound:
+ *
+ * 1. `send()` cannot see **edits** at all, and every message refresh is an
+ *    edit. That is half the surface area.
+ * 2. `send()` cannot see the **skips** — the refresh paths that return before
+ *    any Discord call. Those are precisely what "why didn't the message
+ *    update?" needs, and they were silent.
+ * 3. Threading a surface label through `send()` means touching every caller
+ *    anyway, and an "unknown" default would make the label useless.
+ *
+ * `send()` still owns transport health (`discord_permission_errors_total` and
+ * owner escalation); this owns the betting-semantic story.
+ */
+
+export type BucksMessageSurface =
+  | "prematch"
+  | "parlay_preparation"
+  | "parlay_market"
+  | "settlement"
+  | "weekly_leaderboard";
+
+export type BucksMessageOperation = "send" | "edit";
+
+/**
+ * Why a refresh returned without touching Discord.
+ *
+ * These are not equally alarming and must not be logged at the same level.
+ * `skipped_no_base` is expected forever for pools created before
+ * `prematchContentBase` existed — the schema comment and AGENTS.md both say
+ * legacy pools are deliberately not edited, so it must never be alerted on.
+ * `skipped_no_refs` follows a failed `recordPoolMessageRefs` and is the
+ * leading indicator of "settlement had nowhere to announce".
+ */
+export type BucksMessageSkipReason =
+  | "skipped_no_pool"
+  | "skipped_no_base"
+  | "skipped_no_refs";
+
+function classify(
+  error: unknown,
+): "permission_error" | "channel_missing" | "error" {
+  if (error instanceof ChannelSendError && error.permissionError) {
+    return "permission_error";
+  }
+  if (isPermissionError(error)) {
+    return "permission_error";
+  }
+  if (isMissingChannelError(error)) {
+    return "channel_missing";
+  }
+  return "error";
+}
+
+/**
+ * Time and count one Discord operation, then **rethrow unchanged**.
+ *
+ * Never swallows: every caller already owns its own catch and Sentry
+ * semantics, and `announce.ts`'s per-channel isolation in particular is
+ * load-bearing. Swallowing here would silently change product behaviour.
+ */
+export async function observeBucksDelivery<T>(
+  input: {
+    surface: BucksMessageSurface;
+    operation: BucksMessageOperation;
+    matchId?: string;
+    serverId?: string;
+    channelId?: string;
+  },
+  run: () => Promise<T>,
+): Promise<T> {
+  const stop = bettingMessageOperationDurationSeconds.startTimer({
+    surface: input.surface,
+    operation: input.operation,
+  });
+  try {
+    const result = await run();
+    stop();
+    bettingMessageOperationsTotal.inc({
+      surface: input.surface,
+      operation: input.operation,
+      result: "success",
+    });
+    return result;
+  } catch (error) {
+    stop();
+    const result = classify(error);
+    bettingMessageOperationsTotal.inc({
+      surface: input.surface,
+      operation: input.operation,
+      result,
+    });
+    logger.warn("bucks.delivery.failed", {
+      event: "bucks.delivery.failed",
+      surface: input.surface,
+      operation: input.operation,
+      result,
+      ...(input.matchId === undefined ? {} : { matchId: input.matchId }),
+      ...(input.serverId === undefined ? {} : { serverId: input.serverId }),
+      ...(input.channelId === undefined ? {} : { channelId: input.channelId }),
+    });
+    throw error;
+  }
+}
+
+/** Record a refresh that returned before reaching Discord. */
+export function recordBucksDeliverySkip(input: {
+  surface: BucksMessageSurface;
+  operation: BucksMessageOperation;
+  reason: BucksMessageSkipReason;
+  matchId: string;
+  serverId: string;
+}): void {
+  bettingMessageOperationsTotal.inc({
+    surface: input.surface,
+    operation: input.operation,
+    result: input.reason,
+  });
+  const fields = {
+    event: "bucks.delivery.skipped",
+    surface: input.surface,
+    operation: input.operation,
+    reason: input.reason,
+    matchId: input.matchId,
+    serverId: input.serverId,
+  };
+  if (input.reason === "skipped_no_base") {
+    // Expected forever for pre-`prematchContentBase` pools.
+    logger.info("bucks.delivery.skipped", fields);
+    return;
+  }
+  logger.warn("bucks.delivery.skipped", fields);
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/earnings.ts
@@ -24,6 +24,11 @@ import { getFlag } from "#src/configuration/flags.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isUniqueConstraintError } from "#src/lib/player-admin/shared.ts";
 import { createLogger } from "#src/logger.ts";
+import {
+  bettingEarningsAwardedTotal,
+  bettingEarningsBucksTotal,
+} from "#src/metrics/betting.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { z } from "zod";
 
 const logger = createLogger("betting-earnings");
@@ -327,7 +332,7 @@ export async function awardForGuild(input: {
   }
 
   try {
-    return await input.prismaClient.$transaction(async (tx) => {
+    const committed = await input.prismaClient.$transaction(async (tx) => {
       // FIRST statement, and the exactly-once token. Only one retry can claim a
       // pending marker; a failure rolls the transient processing state back to
       // pending with the rest of the transaction.
@@ -428,6 +433,27 @@ export async function awardForGuild(input: {
       );
       return awards;
     });
+    // Post-commit: counting inside the transaction would survive a rollback.
+    for (const award of committed) {
+      for (const reason of award.reasons) {
+        const label = reason.replaceAll(" ", "_");
+        bettingEarningsAwardedTotal.inc({ reason: label });
+        bettingEarningsBucksTotal.inc(
+          { reason: label },
+          EARNED_REWARDS[reason].amount,
+        );
+      }
+      logBucksTransition({
+        event: "bucks.earning.awarded",
+        matchId: input.matchId,
+        serverId: award.serverId,
+        actorDiscordId: award.discordId,
+        payout: award.total,
+        reason: award.reasons.join(","),
+        surface: "postmatch",
+      });
+    }
+    return committed;
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       logger.debug(

--- a/packages/scout-for-lol/packages/backend/src/betting/message-refresh.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/message-refresh.integration.test.ts
@@ -17,6 +17,7 @@ import {
   bucksTestPuuid,
   bucksTestRoster,
 } from "#src/testing/bucks-fixtures.ts";
+import { registry } from "#src/metrics/registry.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
 
 const { prisma: db } = createTestDatabase("bucks-message-refresh");
@@ -587,5 +588,35 @@ describe("announceSettlements unmatched receipts", () => {
     expect(JSON.stringify(sends[0])).toContain(
       `Blue 9 → nothing matched, refunded **9**`,
     );
+  });
+});
+
+describe("refreshBucksMessages observability", () => {
+  // These three paths returned silently before, which is exactly what made
+  // "why didn't the message update?" unanswerable.
+  test("counts each silent refresh skip instead of returning quietly", async () => {
+    const found = registry.getSingleMetric("betting_message_operations_total");
+    if (found === undefined) {
+      throw new Error("betting_message_operations_total is not registered");
+    }
+    const metric = found;
+    async function skipCount(reason: string): Promise<number> {
+      const collected = await metric.get();
+      return (
+        collected.values.find(
+          (value) =>
+            value.labels["surface"] === "prematch" &&
+            value.labels["result"] === reason,
+        )?.value ?? 0
+      );
+    }
+
+    const before = await skipCount("skipped_no_pool");
+    await refreshBucksMessages(
+      { matchId: "NA1_does-not-exist", serverId: SERVER_ID },
+      db,
+      recordingEditor([]),
+    );
+    expect(await skipCount("skipped_no_pool")).toBe(before + 1);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/message-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/message-refresh.ts
@@ -19,6 +19,10 @@ import {
 } from "#src/betting/prematch-line.ts";
 import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
+import {
+  observeBucksDelivery,
+  recordBucksDeliverySkip,
+} from "#src/betting/delivery-observability.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
 import { createLogger } from "#src/logger.ts";
@@ -85,14 +89,38 @@ async function refreshOnce(
     },
   });
   if (pool === null) {
+    recordBucksDeliverySkip({
+      surface: "prematch",
+      operation: "edit",
+      reason: "skipped_no_pool",
+      matchId: input.matchId,
+      serverId: input.serverId,
+    });
     return;
   }
   if (pool.prematchContentBase === null) {
+    // Expected forever for pools created before this column existed.
+    recordBucksDeliverySkip({
+      surface: "prematch",
+      operation: "edit",
+      reason: "skipped_no_base",
+      matchId: input.matchId,
+      serverId: input.serverId,
+    });
     return;
   }
 
   const refs = BucksMessageRefsSchema.parse(JSON.parse(pool.messageRefs));
   if (refs.length === 0) {
+    // Follows a failed recordPoolMessageRefs, and is the leading indicator of
+    // "settlement had nowhere to announce".
+    recordBucksDeliverySkip({
+      surface: "prematch",
+      operation: "edit",
+      reason: "skipped_no_refs",
+      matchId: input.matchId,
+      serverId: input.serverId,
+    });
     return;
   }
   const prediction =
@@ -145,15 +173,25 @@ async function refreshOnce(
 
   for (const ref of refs) {
     try {
-      await editMessage({
-        channelId: DiscordChannelIdSchema.parse(ref.channelId),
-        messageId: ref.messageId,
-        options: {
-          content,
-          allowedMentions: { parse: [] },
-          ...(input.removeComponents ? { components: [] } : {}),
+      await observeBucksDelivery(
+        {
+          surface: "prematch",
+          operation: "edit",
+          matchId: input.matchId,
+          serverId: input.serverId,
+          channelId: ref.channelId,
         },
-      });
+        () =>
+          editMessage({
+            channelId: DiscordChannelIdSchema.parse(ref.channelId),
+            messageId: ref.messageId,
+            options: {
+              content,
+              allowedMentions: { parse: [] },
+              ...(input.removeComponents ? { components: [] } : {}),
+            },
+          }),
+      );
     } catch (error) {
       logger.warn(
         `⚠️ Could not refresh Bryan Bucks message ${ref.messageId} for ${input.matchId}:`,

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-refresh.ts
@@ -19,6 +19,10 @@ import {
 } from "#src/betting/parlay-line.ts";
 import { buildParlayButtons } from "#src/betting/parlay-components.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
+import {
+  observeBucksDelivery,
+  recordBucksDeliverySkip,
+} from "#src/betting/delivery-observability.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
 import { createLogger } from "#src/logger.ts";
@@ -70,6 +74,13 @@ async function refreshOnce(
     },
   });
   if (market === null) {
+    recordBucksDeliverySkip({
+      surface: "parlay_market",
+      operation: "edit",
+      reason: "skipped_no_pool",
+      matchId: input.matchId,
+      serverId: input.serverId,
+    });
     return;
   }
 
@@ -84,6 +95,13 @@ async function refreshOnce(
 
   const refs = BucksMessageRefsSchema.parse(JSON.parse(market.messageRefs));
   if (refs.length === 0) {
+    recordBucksDeliverySkip({
+      surface: "parlay_market",
+      operation: "edit",
+      reason: "skipped_no_refs",
+      matchId: input.matchId,
+      serverId: input.serverId,
+    });
     return;
   }
 
@@ -116,15 +134,25 @@ async function refreshOnce(
 
   for (const ref of refs) {
     try {
-      await editMessage({
-        channelId: DiscordChannelIdSchema.parse(ref.channelId),
-        messageId: ref.messageId,
-        options: {
-          content,
-          allowedMentions: { parse: [] },
-          components,
+      await observeBucksDelivery(
+        {
+          surface: "parlay_market",
+          operation: "edit",
+          matchId: input.matchId,
+          serverId: input.serverId,
+          channelId: ref.channelId,
         },
-      });
+        () =>
+          editMessage({
+            channelId: DiscordChannelIdSchema.parse(ref.channelId),
+            messageId: ref.messageId,
+            options: {
+              content,
+              allowedMentions: { parse: [] },
+              components,
+            },
+          }),
+      );
     } catch (error) {
       logger.warn(
         `⚠️ Could not refresh Bryan Bucks parlay message ${ref.messageId} for ${input.matchId}:`,

--- a/packages/scout-for-lol/packages/backend/src/betting/peek-pass.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/peek-pass.ts
@@ -3,6 +3,8 @@ import { ensureHouseAccountInTransaction } from "#src/betting/house.ts";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
+import { bettingPeekPassesTotal } from "#src/metrics/betting.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
 
 export const PEEK_PASS_DURATION_MS = 24 * 60 * 60 * 1000;
 
@@ -185,6 +187,32 @@ export type PurchasePeekPassResult =
   | { kind: "quote_changed"; quote: PeekPassPrice; quotedAt: Date };
 
 export async function purchasePeekPass(
+  input: {
+    serverId: DiscordGuildId;
+    discordId: DiscordAccountId;
+    quotedPrice: number;
+    quotedAt: Date;
+    now?: Date;
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<PurchasePeekPassResult> {
+  const result = await purchasePeekPassInner(input, prismaClient);
+  // Post-commit; the inner call has already resolved its transaction.
+  bettingPeekPassesTotal.inc({ result: result.kind });
+  if (result.kind === "purchased") {
+    logBucksTransition({
+      event: "bucks.peek_pass.purchased",
+      serverId: input.serverId,
+      actorDiscordId: input.discordId,
+      payout: result.price,
+      balanceAfter: result.balanceAfter,
+      surface: "button",
+    });
+  }
+  return result;
+}
+
+async function purchasePeekPassInner(
   input: {
     serverId: DiscordGuildId;
     discordId: DiscordAccountId;

--- a/packages/scout-for-lol/packages/backend/src/betting/place-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/place-bet.ts
@@ -23,6 +23,11 @@ import { addInt32 } from "#src/betting/parlay-odds.ts";
 import { bettingOversizedStakeRejectedTotal } from "#src/metrics/betting-parlay.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
+import {
+  bettingBetPlacementsTotal,
+  bettingStakeBucksTotal,
+} from "#src/metrics/betting.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
 
 const logger = createLogger("betting-place-bet");
 
@@ -56,6 +61,8 @@ export type PlaceBetResult =
   | { kind: "side_conflict"; existingTeamId: number };
 
 export type PlaceBetInput = {
+  /** Which surface asked, so the two cannot drift apart unnoticed. */
+  surface?: "button" | "command";
   matchId: string;
   serverId: DiscordGuildId;
   discordId: DiscordAccountId;
@@ -91,7 +98,48 @@ function aliasesOf(roster: readonly BucksPoolParticipant[]): string[] {
     .filter((alias) => alias !== undefined);
 }
 
+/**
+ * Place or top up an outcome bet, counting the result.
+ *
+ * The count and transition log fire here rather than at the two call sites for
+ * the same reason the function is shared: the button and the slash command
+ * must not drift apart. Both are post-commit — `placeBetInner` returns only
+ * after its transaction resolves.
+ */
 export async function placeBet(
+  input: PlaceBetInput,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<PlaceBetResult> {
+  const result = await placeBetInner(input, prismaClient);
+  const surface = input.surface ?? "button";
+  bettingBetPlacementsTotal.inc({ surface, result: result.kind });
+  if (result.kind === "placed") {
+    bettingStakeBucksTotal.inc({ movement: "placed" }, input.stake);
+    logBucksTransition({
+      event: "bucks.bet.placed",
+      matchId: input.matchId,
+      serverId: input.serverId,
+      actorDiscordId: input.discordId,
+      teamId: result.side,
+      stake: input.stake,
+      balanceAfter: result.balanceAfter,
+      surface,
+    });
+  } else {
+    logBucksTransition({
+      event: "bucks.bet.rejected",
+      matchId: input.matchId,
+      serverId: input.serverId,
+      actorDiscordId: input.discordId,
+      reason: result.kind,
+      stake: input.stake,
+      surface,
+    });
+  }
+  return result;
+}
+
+async function placeBetInner(
   input: PlaceBetInput,
   prismaClient: ExtendedPrismaClient = prisma,
 ): Promise<PlaceBetResult> {

--- a/packages/scout-for-lol/packages/backend/src/betting/pool-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/pool-open.ts
@@ -14,6 +14,17 @@ import { isBettableGame } from "#src/betting/eligibility.ts";
 import { getFlag } from "#src/configuration/flags.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
+import {
+  bettingMessageRefsRecordedTotal,
+  bettingPoolOpenFailuresTotal,
+  bettingPoolsOpenedTotal,
+} from "#src/metrics/betting.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+
+/** Prometheus label values must be bounded; a queue with spaces is normalised. */
+function metricQueueType(queueType: string | undefined): string {
+  return (queueType ?? "unknown").replaceAll(" ", "_");
+}
 
 const logger = createLogger("betting-pool-open");
 
@@ -192,6 +203,18 @@ export async function openBettingPoolsForPrematch(
         update: {},
       });
       opened.add(serverId);
+      // Post-commit: the upsert above has already resolved.
+      bettingPoolsOpenedTotal.inc({
+        queue_type: metricQueueType(input.queueType),
+      });
+      logBucksTransition({
+        event: "bucks.pool.opened",
+        matchId: input.matchId,
+        serverId,
+        toState: "open",
+        queueType: input.queueType ?? "unknown",
+        surface: "prematch",
+      });
     }
 
     logger.info(
@@ -202,6 +225,7 @@ export async function openBettingPoolsForPrematch(
       `❌ Could not open Bryan Bucks pools for ${input.matchId}:`,
       error,
     );
+    bettingPoolOpenFailuresTotal.inc();
     Sentry.captureException(error, {
       tags: { source: "betting-pool-open", matchId: input.matchId },
     });
@@ -252,6 +276,7 @@ export async function recordPoolMessageRefs(
           prematchContentBase: input.prematchContentBase,
         },
       });
+      bettingMessageRefsRecordedTotal.inc({ status: "recorded" });
       return;
     } catch (error) {
       if (attempt < MESSAGE_REF_ATTEMPTS) {
@@ -267,6 +292,7 @@ export async function recordPoolMessageRefs(
         `❌ Could not record Bryan Bucks message refs for ${input.matchId} in guild ${input.serverId} — this pool's settlement announcement now has nowhere to go:`,
         error,
       );
+      bettingMessageRefsRecordedTotal.inc({ status: "failed" });
       Sentry.captureException(error, {
         tags: {
           source: "betting-record-message-refs",

--- a/packages/scout-for-lol/packages/backend/src/betting/reconcile.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/reconcile.ts
@@ -11,6 +11,11 @@ import {
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 import { createLogger } from "#src/logger.ts";
+import {
+  bettingReconciliationFindings,
+  bettingReconciliationLastRunTimestampSeconds,
+  bettingReconciliationRunsTotal,
+} from "#src/metrics/betting.ts";
 
 const logger = createLogger("betting-reconcile");
 
@@ -106,12 +111,21 @@ function reportAuditResult(
   findings: BucksAuditCollector,
   accountCount: number,
 ): void {
+  // Reset per run: a gauge answers "is the ledger drifting right now"
+  // directly, where a nightly counter's increase() alert would be noisy.
+  bettingReconciliationFindings.reset();
+  bettingReconciliationLastRunTimestampSeconds.set(Date.now() / 1000);
+  for (const kind of findings.findingKinds) {
+    bettingReconciliationFindings.set({ kind }, 1);
+  }
   if (findings.totalCount === 0) {
+    bettingReconciliationRunsTotal.inc({ status: "clean" });
     logger.info(
       `✅ Reconciled ${accountCount.toString()} Bryan Bucks account(s) with no findings`,
     );
     return;
   }
+  bettingReconciliationRunsTotal.inc({ status: "findings" });
   logger.error(
     `🚨 Bryan Bucks reconciliation found ${findings.totalCount.toString()} accounting issue(s)`,
   );

--- a/packages/scout-for-lol/packages/backend/src/betting/settle.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settle.ts
@@ -19,6 +19,13 @@ import {
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 import { createLogger } from "#src/logger.ts";
+import {
+  bettingPoolSettlementsTotal,
+  bettingPoolVoidsTotal,
+  bettingSettlementConservationFailuresTotal,
+  bettingStakeBucksTotal,
+} from "#src/metrics/betting.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
 
 const logger = createLogger("betting-settle");
 
@@ -246,6 +253,7 @@ export async function closeAndSettleBettingForMatch(
         });
         if (summary !== undefined) {
           summaries.push(summary);
+          recordSettlementObservations(summary, pool.id);
         }
       } catch (error) {
         logger.error(
@@ -270,6 +278,72 @@ export async function closeAndSettleBettingForMatch(
   }
 
   return { closures, settlements: summaries };
+}
+
+/**
+ * Count and log a settled pool.
+ *
+ * Called from the caller of `settleWithOverflowFallback`, never from inside
+ * it: `settleOnePool` returns from within its `$transaction`, so an increment
+ * there would survive a rollback.
+ */
+function recordSettlementObservations(
+  summary: SettlementSummary,
+  poolId: number,
+): void {
+  const voided = summary.voidReason !== undefined;
+  bettingPoolSettlementsTotal.inc({ result: voided ? "voided" : "decided" });
+  if (summary.voidReason !== undefined) {
+    bettingPoolVoidsTotal.inc({ reason: summary.voidReason });
+  }
+  logBucksTransition({
+    event: voided ? "bucks.pool.voided" : "bucks.pool.settled",
+    matchId: summary.matchId,
+    serverId: summary.serverId,
+    poolId,
+    fromState: "closed",
+    toState: voided ? "voided" : "settled",
+    houseCut: summary.houseCut,
+    surface: "postmatch",
+    ...(summary.winningTeamId === undefined
+      ? {}
+      : { teamId: summary.winningTeamId }),
+    ...(summary.voidReason === undefined ? {} : { reason: summary.voidReason }),
+  });
+  for (const bet of summary.bets) {
+    if (bet.isHouse) {
+      continue;
+    }
+    bettingStakeBucksTotal.inc(
+      { movement: bet.refunded ? "refunded_void" : "paid_out" },
+      bet.payout,
+    );
+    if (bet.houseCut > 0) {
+      bettingStakeBucksTotal.inc(
+        { movement: "house_cut_settlement" },
+        bet.houseCut,
+      );
+    }
+    logBucksTransition({
+      event: bet.refunded
+        ? "bucks.bet.refunded"
+        : bet.won
+          ? "bucks.bet.won"
+          : "bucks.bet.lost",
+      matchId: summary.matchId,
+      serverId: summary.serverId,
+      poolId,
+      betId: bet.betId,
+      bucksAccountId: bet.bucksAccountId,
+      actorDiscordId: bet.discordId,
+      teamId: bet.predictedTeamId,
+      matchedStake: bet.matchedStake,
+      grossPayout: bet.grossPayout,
+      houseCut: bet.houseCut,
+      payout: bet.payout,
+      surface: "postmatch",
+    });
+  }
 }
 
 /** Settle every guild pool for a finished match at fixed even money. */
@@ -389,6 +463,14 @@ async function settleOnePool(input: {
     const staked = settled.bets.reduce((sum, bet) => sum + bet.matchedStake, 0);
     const paid = settled.bets.reduce((sum, bet) => sum + bet.payout, 0);
     if (paid + settled.houseCut !== staked) {
+      // Counted before throwing: the throw aborts the transaction, so without
+      // this the invariant violation only surfaces two frames up.
+      bettingSettlementConservationFailuresTotal.inc({ stage: "settlement" });
+      Sentry.captureMessage("Bryan Bucks settlement did not conserve Bucks", {
+        level: "error",
+        tags: { source: "betting-settle-pool", matchId: input.matchId },
+        extra: { staked, paid, houseCut: settled.houseCut },
+      });
       throw new Error(
         `Settlement for ${input.matchId} did not conserve matched Bucks: staked ${staked.toString()}, paid ${paid.toString()}, winner fees ${settled.houseCut.toString()}`,
       );

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep-observability.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep-observability.ts
@@ -1,0 +1,87 @@
+import type { ClosedPool } from "#src/betting/sweep.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+import {
+  bettingBetsMatchedTotal,
+  bettingHouseFillsTotal,
+  bettingPoolsClosedTotal,
+  bettingStakeBucksTotal,
+} from "#src/metrics/betting.ts";
+
+/**
+ * Count and log a pool that just closed and matched.
+ *
+ * Lives outside `sweep.ts` because that file is already near the 500-line cap,
+ * and is called from the *caller* of `matchPoolAtClose`: that function returns
+ * from inside its `$transaction`, so an increment there would survive a
+ * rollback.
+ */
+export function recordClosedPool(
+  pool: ClosedPool,
+  trigger: "window_expired" | "match_finished" | "stale_void",
+): void {
+  bettingPoolsClosedTotal.inc({ trigger });
+  logBucksTransition({
+    event: "bucks.pool.closed",
+    matchId: pool.matchId,
+    serverId: pool.serverId,
+    fromState: "open",
+    toState: "closed",
+    matchedStake: pool.totalMatchedPerSide,
+    surface: trigger === "match_finished" ? "postmatch" : "sweep",
+  });
+
+  if (pool.houseFill > 0) {
+    const requested = pool.totalMatchedPerSide - pool.humanMatchedPerSide;
+    bettingHouseFillsTotal.inc({
+      result: pool.houseFill >= requested ? "full" : "partial",
+    });
+    bettingStakeBucksTotal.inc({ movement: "matched" }, pool.houseFill);
+    logBucksTransition({
+      event: "bucks.bet.house_filled",
+      matchId: pool.matchId,
+      serverId: pool.serverId,
+      matchedStake: pool.houseFill,
+      isHouse: true,
+      surface: trigger === "match_finished" ? "postmatch" : "sweep",
+    });
+  } else {
+    bettingHouseFillsTotal.inc({ result: "none" });
+  }
+
+  for (const position of pool.positions) {
+    const result =
+      position.matchedStake === 0
+        ? "unmatched_refunded"
+        : position.unmatchedStake === 0
+          ? "fully_matched"
+          : "partially_matched";
+    bettingBetsMatchedTotal.inc({ result });
+    if (position.matchedStake > 0) {
+      bettingStakeBucksTotal.inc(
+        { movement: "matched" },
+        position.matchedStake,
+      );
+    }
+    if (position.unmatchedStake > 0) {
+      bettingStakeBucksTotal.inc(
+        { movement: "refunded_unmatched" },
+        position.unmatchedStake,
+      );
+    }
+    logBucksTransition({
+      event:
+        position.matchedStake === 0
+          ? "bucks.bet.unmatched_refunded"
+          : "bucks.bet.matched",
+      matchId: pool.matchId,
+      serverId: pool.serverId,
+      betId: position.betId,
+      actorDiscordId: position.discordId,
+      teamId: position.teamId,
+      stake: position.submittedStake,
+      matchedStake: position.matchedStake,
+      unmatchedStake: position.unmatchedStake,
+      surface: trigger === "match_finished" ? "postmatch" : "sweep",
+    });
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep.ts
@@ -17,6 +17,7 @@ import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { matchBucksOffers } from "#src/betting/matching.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
+import { recordClosedPool } from "#src/betting/sweep-observability.ts";
 
 const logger = createLogger("betting-sweep");
 
@@ -346,6 +347,7 @@ export async function closeExpiredBettingWindows(
       });
       if (result !== undefined) {
         closed.push(result);
+        recordClosedPool(result, "window_expired");
       }
     } catch (error) {
       logger.error(
@@ -406,6 +408,7 @@ export async function closeBettingWindowsForMatch(
       });
       if (result !== undefined) {
         closed.push(result);
+        recordClosedPool(result, "match_finished");
       }
     } catch (error) {
       // A malformed pool for one guild must not block healthy guild pools,

--- a/packages/scout-for-lol/packages/backend/src/betting/transition-log.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transition-log.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+
+describe("logBucksTransition", () => {
+  test("accepts a minimal transition", () => {
+    expect(() => {
+      logBucksTransition({ event: "bucks.pool.opened" });
+    }).not.toThrow();
+  });
+
+  test("accepts a fully populated transition", () => {
+    expect(() => {
+      logBucksTransition({
+        event: "bucks.bet.placed",
+        matchId: "NA1_1",
+        serverId: "1337623164146155593",
+        poolId: 1,
+        betId: 2,
+        bucksAccountId: 3,
+        actorDiscordId: "test-discord-account",
+        fromState: "open",
+        toState: "open",
+        teamId: 100,
+        stake: 5,
+        balanceAfter: 20,
+        surface: "button",
+        queueType: "solo",
+      });
+    }).not.toThrow();
+  });
+
+  // Observability must never fail product behaviour. This helper sits inside
+  // settlement paths, so a throw here would abort a money movement. Every
+  // event in the union must be safe to log.
+  test("never throws for any event in the union", () => {
+    const events = [
+      "bucks.pool.opened",
+      "bucks.pool.closed",
+      "bucks.pool.settled",
+      "bucks.pool.voided",
+      "bucks.bet.placed",
+      "bucks.bet.rejected",
+      "bucks.bet.cancelled",
+      "bucks.parlay.settled",
+      "bucks.earning.awarded",
+      "bucks.peek_pass.purchased",
+    ] as const;
+    for (const event of events) {
+      expect(() => {
+        logBucksTransition({ event });
+      }).not.toThrow();
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/transition-log.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transition-log.ts
@@ -1,0 +1,95 @@
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("betting-transition");
+
+/**
+ * The canonical Bryan Bucks state-transition log.
+ *
+ * Convention: a stable event name as the message, plus exactly one flat object
+ * bag as the second argument. The rest of `src/betting/` interpolates into the
+ * message, which only a human can read; these lines exist to be queried.
+ *
+ * **Retention.** Loki holds 90 days of stdout. These lines are a rolling
+ * quarter, not history — the permanent record is SQLite (`BucksLedgerEntry`
+ * plus the pool and bet timestamp columns). Do not treat this as the audit
+ * trail.
+ *
+ * **Caveat.** stdout is tslog `pretty`, so the bag is embedded in the line
+ * rather than being the line. `{app="scout"} |= "bucks.pool.settled"` works
+ * today; a clean `| json` needs a regex extraction, or a JSON stdout transport
+ * that would change every log line in the service.
+ *
+ * Discord IDs are fine here. The prohibition in AGENTS.md is scoped to PostHog
+ * captures and browser distinct ids, because a distinct id is a durable
+ * cross-product join key; existing code already logs channel and guild IDs and
+ * puts them in Sentry tags. `subjectPuuid` is deliberately omitted: `teamId` is
+ * what the wager *is*, and the PUUID is a Riot identifier that adds nothing.
+ *
+ * **Every call must be post-commit.** A transition logged inside a transaction
+ * that then rolls back is a lie that survives for 90 days.
+ */
+export type BucksTransitionEvent =
+  | "bucks.pool.opened"
+  | "bucks.pool.closed"
+  | "bucks.pool.settled"
+  | "bucks.pool.voided"
+  | "bucks.bet.placed"
+  | "bucks.bet.topped_up"
+  | "bucks.bet.rejected"
+  | "bucks.bet.cancelled"
+  | "bucks.bet.matched"
+  | "bucks.bet.unmatched_refunded"
+  | "bucks.bet.house_filled"
+  | "bucks.bet.won"
+  | "bucks.bet.lost"
+  | "bucks.bet.refunded"
+  | "bucks.parlay.published"
+  | "bucks.parlay.opened"
+  | "bucks.parlay.closed"
+  | "bucks.parlay.settled"
+  | "bucks.parlay.voided"
+  | "bucks.parlay_bet.placed"
+  | "bucks.parlay_bet.cancelled"
+  | "bucks.parlay_bet.settled"
+  | "bucks.earning.awarded"
+  | "bucks.peek_pass.purchased";
+
+export type BucksTransitionFields = {
+  event: BucksTransitionEvent;
+  matchId?: string;
+  serverId?: string;
+  poolId?: number;
+  marketId?: number;
+  betId?: number;
+  parlayBetId?: number;
+  bucksAccountId?: number;
+  actorDiscordId?: string;
+  fromState?: string;
+  toState?: string;
+  teamId?: number;
+  side?: "YES" | "NO";
+  stake?: number;
+  matchedStake?: number;
+  unmatchedStake?: number;
+  grossPayout?: number;
+  houseCut?: number;
+  payout?: number;
+  balanceAfter?: number;
+  reason?: string;
+  surface?: "button" | "command" | "sweep" | "postmatch" | "cron" | "prematch";
+  queueType?: string;
+  isHouse?: boolean;
+};
+
+export function logBucksTransition(fields: BucksTransitionFields): void {
+  // Observability must never fail product behaviour. This is the one place in
+  // the transition path that can throw, so it is the one place that catches.
+  try {
+    // Absent optional fields are simply not enumerable, and
+    // `exactOptionalPropertyTypes` stops a caller passing an explicit
+    // `undefined`, so the bag is already minimal for Loki.
+    logger.info(fields.event, fields);
+  } catch {
+    // Intentionally empty: a failed log must not abort a settlement.
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -320,6 +320,7 @@ async function replyBet(
       subjectPuuid: game.subjectPuuid,
       subjectWins,
       stake,
+      surface: "command",
     });
     await interaction.editReply({
       content: describeResult(result, outcomeLabel(selectedTeamId, framing)),

--- a/packages/scout-for-lol/packages/backend/src/metrics/betting-sweep.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/betting-sweep.ts
@@ -1,0 +1,81 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  bettingHouseBalanceBucks,
+  bettingOldestUnresolvedPoolAgeSeconds,
+  bettingPendingStakeBucks,
+  bettingPoolsByState,
+} from "#src/metrics/betting.ts";
+
+const logger = createLogger("metrics-betting-sweep");
+
+const POOL_STATES = ["open", "closed", "settled", "voided"] as const;
+
+/**
+ * Refresh the Bryan Bucks gauges from the database.
+ *
+ * Called from `getMetrics()` so the values are current at scrape time, the
+ * same pattern `updateUsageMetrics` uses. Wrapped so a metrics query can never
+ * fail the `/metrics` response.
+ */
+export async function updateBettingMetrics(
+  prismaClient?: ExtendedPrismaClient,
+): Promise<void> {
+  try {
+    const databaseModule = await import("../database/index.js");
+    const prisma = prismaClient ?? databaseModule.prisma;
+
+    const [byState, oldestUnresolved, pendingStake, houseAccounts] =
+      await Promise.all([
+        prisma.bucksMatchPool.groupBy({
+          by: ["poolState"],
+          _count: { _all: true },
+        }),
+        prisma.bucksMatchPool.findFirst({
+          where: { poolState: { in: ["open", "closed"] } },
+          orderBy: { closesAt: "asc" },
+          select: { closesAt: true },
+        }),
+        prisma.bucksBet.findMany({
+          where: { betOutcome: "pending" },
+          select: { stake: true, matchedStake: true },
+        }),
+        prisma.bucksAccount.findMany({
+          where: { isHouse: true },
+          select: { balance: true },
+        }),
+      ]);
+
+    const counts = new Map(
+      byState.map((row) => [row.poolState, row._count._all]),
+    );
+    for (const state of POOL_STATES) {
+      bettingPoolsByState.set({ state }, counts.get(state) ?? 0);
+    }
+
+    bettingOldestUnresolvedPoolAgeSeconds.set(
+      oldestUnresolved === null
+        ? 0
+        : Math.max(
+            0,
+            Math.floor(
+              (Date.now() - oldestUnresolved.closesAt.getTime()) / 1000,
+            ),
+          ),
+    );
+
+    bettingPendingStakeBucks.set(
+      pendingStake.reduce(
+        (total, bet) => total + (bet.matchedStake ?? bet.stake),
+        0,
+      ),
+    );
+
+    bettingHouseBalanceBucks.set(
+      houseAccounts.reduce((total, account) => total + account.balance, 0),
+    );
+  } catch (error) {
+    logger.error("❌ Error updating Bryan Bucks metrics:", error);
+    // Deliberately not rethrown: a metrics query must never fail /metrics.
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/metrics/betting.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/betting.ts
@@ -1,0 +1,230 @@
+import { Counter, Gauge, Histogram } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Bryan Bucks lifecycle and message-delivery metrics.
+ *
+ * Two rules govern every label here:
+ *
+ * 1. **Bounded label sets only.** Every label value comes from a closed
+ *    TypeScript or Zod union. No `matchId`, `serverId`, `discordId`,
+ *    `channelId`, or `puuid` — Bryan Bucks runs in exactly one guild, so a
+ *    `server_id` label would carry zero information at the cost of a
+ *    dimension.
+ * 2. **Post-commit only.** Every increment fires *after* its `$transaction`
+ *    resolves. A counter emitted inside a transaction that then rolls back is
+ *    a lie that survives forever.
+ *
+ * Counters reset on pod restart and lose up to one scrape interval, so they
+ * are a trend, never an audit trail. The permanent record is SQLite:
+ * `BucksLedgerEntry` plus the pool and bet timestamp columns.
+ */
+
+/* --------------------------------------------------------------- pools -- */
+
+export const bettingPoolsOpenedTotal = new Counter({
+  name: "betting_pools_opened_total",
+  help: "Bryan Bucks outcome pools opened, by queue.",
+  labelNames: ["queue_type"] as const,
+  registers: [registry],
+});
+
+export const bettingPoolOpenFailuresTotal = new Counter({
+  name: "betting_pool_open_failures_total",
+  help: "Bryan Bucks outcome pools that could not be opened.",
+  registers: [registry],
+});
+
+export const bettingPoolsClosedTotal = new Counter({
+  name: "betting_pools_closed_total",
+  help: "Bryan Bucks outcome pools closed and matched, by what triggered it.",
+  labelNames: ["trigger"] as const,
+  registers: [registry],
+});
+
+export const bettingPoolSettlementsTotal = new Counter({
+  name: "betting_pool_settlements_total",
+  help: "Bryan Bucks outcome pools reaching a terminal state.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+/**
+ * Deliberately overlaps `betting_pool_settlements_total{result="voided"}`: that
+ * one is the state-machine count, this one is the reason breakdown. Do not
+ * "fix" the duplication. Note the parlay twin `betting_parlay_voids_total`
+ * already exists and must not be reused for outcome pools.
+ */
+export const bettingPoolVoidsTotal = new Counter({
+  name: "betting_pool_voids_total",
+  help: "Bryan Bucks outcome pools voided, by reason.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+export const bettingSettlementConservationFailuresTotal = new Counter({
+  name: "betting_settlement_conservation_failures_total",
+  help: "Bryan Bucks conservation assertions that failed before throwing.",
+  labelNames: ["stage"] as const,
+  registers: [registry],
+});
+
+/* ---------------------------------------------------------------- bets -- */
+
+export const bettingBetPlacementsTotal = new Counter({
+  name: "betting_bet_placements_total",
+  help: "Bryan Bucks outcome bet placements by surface and result.",
+  labelNames: ["surface", "result"] as const,
+  registers: [registry],
+});
+
+export const bettingBetCancellationsTotal = new Counter({
+  name: "betting_bet_cancellations_total",
+  help: "Bryan Bucks outcome bet cancellations by surface and result.",
+  labelNames: ["surface", "result"] as const,
+  registers: [registry],
+});
+
+export const bettingBetsMatchedTotal = new Counter({
+  name: "betting_bets_matched_total",
+  help: "Bryan Bucks outcome positions by how much of them matched at close.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const bettingHouseFillsTotal = new Counter({
+  name: "betting_house_fills_total",
+  help: "How completely the house filled a one-sided Bryan Bucks market.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const bettingStakeBucksTotal = new Counter({
+  name: "betting_stake_bucks_total",
+  help: "Bryan Bucks moved through the outcome market, by movement kind.",
+  labelNames: ["movement"] as const,
+  registers: [registry],
+});
+
+/* ------------------------------------------------------------ earnings -- */
+
+export const bettingEarningsAwardedTotal = new Counter({
+  name: "betting_earnings_awarded_total",
+  help: "Bryan Bucks earning awards, by reason.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+export const bettingEarningsBucksTotal = new Counter({
+  name: "betting_earnings_bucks_total",
+  help: "Bryan Bucks awarded as earnings, by reason.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+/* --------------------------------------------------------- peek passes -- */
+
+export const bettingPeekPassesTotal = new Counter({
+  name: "betting_peek_passes_total",
+  help: "Bryan Bucks peek-pass purchase attempts, by result.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+/* --------------------------------------------------- message delivery -- */
+
+export const bettingMessageOperationsTotal = new Counter({
+  name: "betting_message_operations_total",
+  help: "Bryan Bucks Discord sends and edits, by surface and outcome.",
+  labelNames: ["surface", "operation", "result"] as const,
+  registers: [registry],
+});
+
+export const bettingMessageOperationDurationSeconds = new Histogram({
+  name: "betting_message_operation_duration_seconds",
+  help: "Bryan Bucks Discord send and edit latency.",
+  labelNames: ["surface", "operation"] as const,
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+  registers: [registry],
+});
+
+export const bettingMessageRefsRecordedTotal = new Counter({
+  name: "betting_message_refs_recorded_total",
+  help: "Whether a pool's prematch message references became durable.",
+  labelNames: ["status"] as const,
+  registers: [registry],
+});
+
+/**
+ * A settlement that was paid but cannot be announced.
+ *
+ * `no_refs_owed` is the alarming one: somebody was owed something and will
+ * never be told, and the pool has committed as settled so there is no retry.
+ */
+export const bettingSettlementUndeliverableTotal = new Counter({
+  name: "betting_settlement_undeliverable_total",
+  help: "Bryan Bucks settlements with no destination, by reason.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+/* ------------------------------------------------------ reconciliation -- */
+
+export const bettingReconciliationRunsTotal = new Counter({
+  name: "betting_reconciliation_runs_total",
+  help: "Bryan Bucks reconciliation runs, by outcome.",
+  labelNames: ["status"] as const,
+  registers: [registry],
+});
+
+/**
+ * The CURRENT run's finding counts, reset each run.
+ *
+ * A gauge rather than only a counter because a nightly job's `increase()`
+ * alert is noisy; this answers "is the ledger drifting right now" directly.
+ */
+export const bettingReconciliationFindings = new Gauge({
+  name: "betting_reconciliation_findings",
+  help: "Bryan Bucks reconciliation findings from the most recent run.",
+  labelNames: ["kind"] as const,
+  registers: [registry],
+});
+
+export const bettingReconciliationLastRunTimestampSeconds = new Gauge({
+  name: "betting_reconciliation_last_run_timestamp_seconds",
+  help: "When Bryan Bucks reconciliation last completed.",
+  registers: [registry],
+});
+
+/* --------------------------------------------------------- DB-swept -- */
+
+export const bettingPoolsByState = new Gauge({
+  name: "betting_pools_by_state",
+  help: "Bryan Bucks outcome pools currently in each state.",
+  labelNames: ["state"] as const,
+  registers: [registry],
+});
+
+/**
+ * Age of the oldest pool that has not reached a terminal state.
+ *
+ * Past `VOID_GRACE_MS` this means `voidStaleBettingPools` itself is not
+ * running, which is the one failure that silently destroys staked Bucks.
+ */
+export const bettingOldestUnresolvedPoolAgeSeconds = new Gauge({
+  name: "betting_oldest_unresolved_pool_age_seconds",
+  help: "Age of the oldest unresolved Bryan Bucks pool.",
+  registers: [registry],
+});
+
+export const bettingPendingStakeBucks = new Gauge({
+  name: "betting_pending_stake_bucks",
+  help: "Bryan Bucks currently at risk in pending positions.",
+  registers: [registry],
+});
+
+export const bettingHouseBalanceBucks = new Gauge({
+  name: "betting_house_balance_bucks",
+  help: "Current Bryan Bucks house balance.",
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -2,6 +2,7 @@ import { Counter, Gauge, Histogram } from "prom-client";
 import configuration from "#src/configuration.ts";
 import { createLogger } from "#src/logger.ts";
 import { registry } from "#src/metrics/registry.ts";
+import { updateBettingMetrics } from "#src/metrics/betting-sweep.ts";
 import { seedProviderIssueMetrics } from "#src/metrics/provider-issue-seeds.ts";
 import "#src/metrics/season-schedule.ts";
 import "#src/metrics/product-analytics.ts";
@@ -756,5 +757,6 @@ export async function getMetrics(): Promise<string> {
   updateUptimeMetric();
   await updateUsageMetrics();
   await updateLimitMetrics();
+  await updateBettingMetrics();
   return await registry.metrics();
 }

--- a/packages/scout-for-lol/packages/backend/src/report-lake/schema.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ACCOUNT_LAKE_COLUMNS,
+  COMPETITION_RANK_HISTORY_LAKE_COLUMNS,
+  MATCH_LAKE_COLUMNS,
+  PREDICTION_OBSERVATION_LAKE_COLUMNS,
+  PREMATCH_LAKE_COLUMNS,
+  lakeSchemaFingerprint,
+} from "#src/report-lake/schema.ts";
+
+/**
+ * The fingerprint is the only mechanism that forces a full lake rebuild when a
+ * column changes; a fold would otherwise hardlink the previous build and
+ * publish parquet files that disagree on columns, which fails to bind at all.
+ *
+ * A table missing from the fingerprint silently loses that protection —
+ * `prediction_observations` was missing until this test existed. Recomputing
+ * the expected hash from an explicit list is what makes a future sixth table
+ * fail here until someone updates both places.
+ */
+describe("lakeSchemaFingerprint", () => {
+  test("covers every lake table", () => {
+    const tables: Record<string, Record<string, string>> = {
+      matches: MATCH_LAKE_COLUMNS,
+      prematch: PREMATCH_LAKE_COLUMNS,
+      prediction_observations: PREDICTION_OBSERVATION_LAKE_COLUMNS,
+      accounts: ACCOUNT_LAKE_COLUMNS,
+      competition_rank_history: COMPETITION_RANK_HISTORY_LAKE_COLUMNS,
+    };
+    const hasher = new Bun.CryptoHasher("sha256");
+    for (const [table, columns] of Object.entries(tables)) {
+      const signature = Object.entries(columns)
+        .map(([name, type]) => `${name}:${type}`)
+        .sort()
+        .join(",");
+      hasher.update(`${table}=${signature}\n`);
+    }
+
+    expect(lakeSchemaFingerprint()).toBe(hasher.digest("hex").slice(0, 16));
+  });
+
+  test("changes when a covered table's columns change", () => {
+    const before = lakeSchemaFingerprint();
+    // Sanity: the fingerprint is derived, not a frozen literal.
+    expect(before).toHaveLength(16);
+    expect(before).toMatch(/^[0-9a-f]{16}$/u);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/report-lake/schema.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/schema.ts
@@ -442,6 +442,7 @@ export function lakeSchemaFingerprint(): string {
   const tables: Record<string, Record<string, DuckDbColumnType>> = {
     matches: MATCH_LAKE_COLUMNS,
     prematch: PREMATCH_LAKE_COLUMNS,
+    prediction_observations: PREDICTION_OBSERVATION_LAKE_COLUMNS,
     accounts: ACCOUNT_LAKE_COLUMNS,
     competition_rank_history: COMPETITION_RANK_HISTORY_LAKE_COLUMNS,
   };


### PR DESCRIPTION
Why:
Two questions had no answer. "Why didn't that message post or update?" was
unanswerable because three refresh paths returned silently before reaching
Discord — a missing pool, a legacy pool with no stored content base, and a pool
whose message refs were never recorded. And "who placed what, and how did it
settle?" could only be reconstructed by hand from ledger rows.

Prometheus was already wired with a `/metrics` endpoint, and
`discord_components_total` already counted button routing, but nothing existed
for the bet lifecycle or for message send/edit.

What:
`src/metrics/betting.ts` adds 25 series covering pool lifecycle, bet placement
and cancellation by surface, matching and house fill, stake movement, earnings,
peek passes, reconciliation, and message delivery. Every label is a closed
union and none carry an ID: Bryan Bucks runs in exactly one guild, so a
`server_id` label would cost a dimension and say nothing.

`observeBucksDelivery` wraps every Bucks send and edit. It is deliberately
per-call-site rather than inside the shared `send()`, which cannot see edits at
all — every refresh is an edit — and cannot see the skips, which return before
any Discord call. It classifies the failure, counts it, and **rethrows
unchanged**: every caller owns its own catch, and `announce.ts`'s per-channel
isolation depends on seeing the error.

The three silent skips now call `recordBucksDeliverySkip`, and they are
deliberately not equally alarming. `skipped_no_base` is expected forever for
pools created before `prematchContentBase` existed and must never be alerted
on; `skipped_no_refs` follows a failed `recordPoolMessageRefs` and is the
leading indicator of "settlement had nowhere to announce".

`logBucksTransition` emits a stable event name plus one flat field bag, so the
lines are queryable rather than merely readable. It never throws — it sits
inside settlement paths, so a failed log must not abort a money movement.

Every increment and transition fires **post-commit**. `settleOnePool`,
`matchPoolAtClose`, `cancelBet`, `placeBet`, and `purchasePeekPass` all return
from inside their own `$transaction`, so their observations live at the call
site or in a thin wrapper; a counter emitted inside a transaction that then
rolls back is a lie that survives forever. `sweep-observability.ts` exists
because `sweep.ts` is already near the 500-line cap.

Also fixes `lakeSchemaFingerprint`, which omitted `prediction_observations`
from its table map. That guard exists to force a full lake rebuild when columns
change — a fold otherwise hardlinks the previous build and publishes parquet
files that disagree, which fails to bind at all. The omission silently removed
that protection for one table.

Rollout note: this changes the fingerprint, so the first deploy after it falls
back to a full lake rebuild from S3. That is the guard working as designed.

Verification:
- `bun test` in packages/backend — 1951 pass, 6 pre-existing skips, 0 fail.
- `bun run lint` — 0 errors.
- `bunx tsc --noEmit` — clean.
- Collected the registry directly and confirmed all 25 `betting_*` series
  register and render.
- Grepped every exported metric for an increment site; none are declared
  without one.
- New tests pin: success/permission/error classification with rethrow, both
  skip reasons, that every `betting_*` name is snake_case with the right
  suffix, that no betting metric emits an identifier label, that
  `logBucksTransition` never throws for any event in its union, and that
  `lakeSchemaFingerprint` covers every lake table.
- An integration case asserts the previously-silent `skipped_no_pool` path now
  increments; counter assertions diff before/after because counters are
  process-global under parallel test files.
- Not run: live `/metrics` scrape or Loki query against beta.