### PR TITLE
fix(ci): count clean Codex reviews

### DIFF
--- a/packages/code-review/src/github-review-threads.test.ts
+++ b/packages/code-review/src/github-review-threads.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderReview,
 } from "./github-review-threads.ts";
 import { qodoProvider } from "./providers/qodo.ts";
+import { codexProvider } from "./providers/codex.ts";
 
 describe("attributeRaisedInReview", () => {
   test("counts clean provider reviews before finding-bearing reviews", () => {
@@ -42,6 +43,51 @@ describe("attributeRaisedInReview", () => {
     const [thread] = attributeRaisedInReview(
       parsed,
       qodoProvider,
+      1,
+      providerReviews,
+    );
+
+    expect(thread?.raisedInReview).toEqual({
+      ordinal: 2,
+      hadBlockingSeverity: false,
+    });
+  });
+
+  test("counts clean Codex reactions before finding-bearing reviews", () => {
+    const parsed: ParsedReviewThread[] = [
+      {
+        thread: {
+          authorLogin: "chatgpt-codex-connector",
+          isResolved: false,
+          isOutdated: false,
+          path: "src/example.ts",
+          line: 1,
+          url: null,
+          priority: 2,
+          title: "Example finding",
+          threadId: "thread-1",
+          commentId: null,
+          raisedInReview: null,
+        },
+        review: { id: "finding-review", submittedAt: "2026-08-22T02:00:00Z" },
+      },
+    ];
+    const providerReviews: ProviderReview[] = [
+      {
+        id: "reaction-0",
+        submittedAt: "2026-08-22T01:00:00Z",
+        authorLogin: "chatgpt-codex-connector",
+      },
+      {
+        id: "finding-review",
+        submittedAt: "2026-08-22T02:00:00Z",
+        authorLogin: "chatgpt-codex-connector",
+      },
+    ];
+
+    const [thread] = attributeRaisedInReview(
+      parsed,
+      codexProvider,
       1,
       providerReviews,
     );

--- a/packages/code-review/src/github.ts
+++ b/packages/code-review/src/github.ts
@@ -130,6 +130,21 @@ export async function fetchReviewThreads(input: {
     if (!page.hasNextPage || page.endCursor === null) break;
     reviewCursor = page.endCursor;
   }
+  if (input.provider.completion.kind === "review-at-head") {
+    const reactions = await fetchProviderThumbsUps({
+      repo: input.repo,
+      number: input.number,
+      token: input.token,
+      provider: input.provider,
+    });
+    for (const [index, reaction] of reactions.entries()) {
+      providerReviews.push({
+        id: `reaction-${String(index)}`,
+        submittedAt: reaction.createdAt,
+        authorLogin: reaction.authorLogin,
+      });
+    }
+  }
   // Attribution needs every page: a thread's ordinal is its review's position
   // among all of this provider's reviews, including clean reviews that opened
   // no thread and therefore do not appear in `parsed`.
@@ -339,10 +354,33 @@ export async function fetchProviderThumbsUp(input: {
   token: string;
   provider: ReviewProvider;
 }): Promise<{ createdAt: string | null } | null> {
-  let url: string | null =
-    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/reactions?per_page=100`;
+  const reactions = await fetchProviderThumbsUps(input);
   let latest: { createdAt: string | null } | null = null;
   let latestScore = Number.NEGATIVE_INFINITY;
+  for (const reaction of reactions) {
+    const score = Date.parse(reaction.createdAt ?? "");
+    const normalized = Number.isFinite(score)
+      ? score
+      : Number.NEGATIVE_INFINITY;
+    if (latest === null || normalized >= latestScore) {
+      latest = { createdAt: reaction.createdAt };
+      latestScore = normalized;
+    }
+  }
+  return latest;
+}
+
+/** Every provider +1 reaction, including clean Codex reviews with no review object. */
+export async function fetchProviderThumbsUps(input: {
+  repo: string;
+  number: number;
+  token: string;
+  provider: ReviewProvider;
+}): Promise<{ createdAt: string | null; authorLogin: string | null }[]> {
+  let url: string | null =
+    `${GITHUB_API_URL}/repos/${input.repo}/issues/${String(input.number)}/reactions?per_page=100`;
+  const matches: { createdAt: string | null; authorLogin: string | null }[] =
+    [];
   while (url !== null) {
     const { payload, linkNext } = await getJsonWithLink(url, input.token);
     const reactions = Array.isArray(payload) ? payload : [];
@@ -354,18 +392,11 @@ export async function fetchProviderThumbsUp(input: {
       const login = user === null ? null : stringField(user, "login");
       if (!isProviderAuthor(input.provider, login)) continue;
       const createdAt = stringField(item, "created_at");
-      const score = Date.parse(createdAt ?? "");
-      const normalized = Number.isFinite(score)
-        ? score
-        : Number.NEGATIVE_INFINITY;
-      if (latest === null || normalized >= latestScore) {
-        latest = { createdAt };
-        latestScore = normalized;
-      }
+      matches.push({ createdAt, authorLogin: login });
     }
     url = linkNext;
   }
-  return latest;
+  return matches;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/review-analytics-github.ts
+++ b/scripts/lib/review-analytics-github.ts
@@ -131,6 +131,12 @@ export const IssueCommentSchema = z.object({
   user: z.object({ login: z.string() }).nullable(),
 });
 
+export const IssueReactionSchema = z.object({
+  content: z.string(),
+  created_at: z.string(),
+  user: z.object({ login: z.string() }).nullable(),
+});
+
 /** The two providers the required gate runs; Greptile is dormant. */
 const CI_PROVIDERS: readonly (readonly [ProviderId, ReviewProvider])[] = [
   ["qodo", PROVIDERS.qodo],

--- a/scripts/review-analytics.ts
+++ b/scripts/review-analytics.ts
@@ -29,6 +29,7 @@ import {
   fetchPrRounds,
   graphql,
   IssueCommentSchema,
+  IssueReactionSchema,
   ghAll,
   listPrs,
   requireToken,
@@ -37,7 +38,11 @@ import {
 } from "./lib/review-analytics-github.ts";
 import type { z } from "zod";
 
-type ReviewAnswer = { head: string | null; at: string };
+type ReviewAnswer = {
+  head: string | null;
+  at: string;
+  kind: "review" | "reaction";
+};
 
 const QODO_ACKNOWLEDGEMENT = "was updated up to the latest commit";
 
@@ -155,55 +160,90 @@ async function commandRequests(
   }[] = [];
 
   for (const pr of prs) {
-    if (pr.rounds.length === 0) continue;
     const raw = await ghAll(
       `/repos/${repo}/issues/${String(pr.number)}/comments?per_page=100`,
       token,
     );
+    const rawReactions = await ghAll(
+      `/repos/${repo}/issues/${String(pr.number)}/reactions?per_page=100`,
+      token,
+    );
     const comments = raw.map((item) => IssueCommentSchema.parse(item));
+    const reactions = rawReactions.map((item) =>
+      IssueReactionSchema.parse(item),
+    );
     const acks: ReviewAnswer[] = comments
       .filter((comment) => comment.body.includes(QODO_ACKNOWLEDGEMENT))
       .map((comment) => ({
         head: acknowledgedHead(comment.body),
         at: comment.created_at,
+        kind: "review",
       }));
     const codexReviews: ReviewAnswer[] = pr.rounds
       .filter((round) => round.provider === "codex")
-      .map((round) => ({ head: round.head, at: round.at }));
+      .map((round) => ({ head: round.head, at: round.at, kind: "review" }));
+    const codexReactions: ReviewAnswer[] = reactions
+      .filter(
+        (reaction) =>
+          reaction.content === "+1" &&
+          reaction.user !== null &&
+          reaction.user.login.replace(/\[bot\]$/u, "").toLowerCase() ===
+            "chatgpt-codex-connector",
+      )
+      .map((reaction) => ({
+        head: null,
+        at: reaction.created_at,
+        kind: "reaction",
+      }));
+
+    const requests = comments.flatMap((comment) => {
+      const isRequest =
+        /^\s*\/(?:agentic_)?review\b/mu.test(comment.body) ||
+        comment.body.includes("@codex review");
+      if (!isRequest) return [];
+      const marker = /<!-- review-request:([a-z]+):([0-9a-f]{40})/u.exec(
+        comment.body,
+      );
+      return [
+        {
+          askedAt: Date.parse(comment.created_at),
+          askedProvider:
+            marker?.[1] ??
+            (comment.body.includes("@codex review") ? "codex" : "qodo"),
+          requestedHead: marker?.[2] ?? null,
+          automated: marker !== null,
+        },
+      ];
+    });
 
     let automated = 0;
     let manual = 0;
     let converted = 0;
-    for (const comment of comments) {
-      const isRequest =
-        /^\s*\/(?:agentic_)?review\b/mu.test(comment.body) ||
-        comment.body.includes("@codex review");
-      if (!isRequest) continue;
-      const marker = /<!-- review-request:([a-z]+):([0-9a-f]{40})/u.exec(
-        comment.body,
-      );
-      if (marker === null) manual += 1;
-      else automated += 1;
-      const askedAt = Date.parse(comment.created_at);
-      // Which provider was asked. A hand-typed request carries no marker, so
-      // falling back to the marker alone would score every manual `@codex
-      // review` against Qodo's acknowledgements — counting a later Qodo
-      // acknowledgement as the answer while ignoring the Codex review that did
-      // arrive. That would corrupt the conversion rate the retry policy is
-      // justified by, so the command itself decides when the marker cannot.
-      const askedProvider =
-        marker?.[1] ??
-        (comment.body.includes("@codex review") ? "codex" : "qodo");
-      const answers = askedProvider === "codex" ? codexReviews : acks;
-      const requestedHead = marker?.[2] ?? null;
+    for (const request of requests) {
+      if (request.automated) automated += 1;
+      else manual += 1;
+      const answers =
+        request.askedProvider === "codex"
+          ? [...codexReviews, ...codexReactions]
+          : acks;
       if (
         answers.some((answer) => {
-          const gap = Date.parse(answer.at) - askedAt;
-          return (
-            (requestedHead === null || answer.head === requestedHead) &&
-            gap > 0 &&
-            gap < 60 * 60 * 1000
-          );
+          const gap = Date.parse(answer.at) - request.askedAt;
+          const headMatches =
+            request.requestedHead === null ||
+            answer.head === request.requestedHead ||
+            (answer.kind === "reaction" &&
+              request.askedProvider === "codex" &&
+              // GitHub's reaction has no commit SHA. It answers an automated
+              // request only when no later Codex request was posted before the
+              // reaction; otherwise the reaction belongs to that later head.
+              !requests.some(
+                (later) =>
+                  later.askedProvider === request.askedProvider &&
+                  later.askedAt > request.askedAt &&
+                  later.askedAt < Date.parse(answer.at),
+              ));
+          return headMatches && gap > 0 && gap < 60 * 60 * 1000;
         })
       ) {
         converted += 1;


### PR DESCRIPTION
Why\nClean Codex reviews arrive as 👍 reactions without review objects. The review gate and analytics must treat those reactions as completed clean reviews so later findings keep the correct ordinal and request conversion remains accurate.\n\nWhat\nInclude provider reactions in review chronology and request conversion analytics, binding a reaction to the latest matching Codex request. Add regression coverage for clean reactions before finding-bearing reviews.\n\nVerification\n- bunx turbo run typecheck test lint --filter=@shepherdjerred/code-review\n- bunx turbo run lint typecheck --filter=@shepherdjerred/root-scripts\n- bunx prettier --check packages/code-review/src/github.ts packages/code-review/src/github-review-threads.test.ts scripts/lib/review-analytics-github.ts scripts/review-analytics.ts\n- bunx lefthook run pre-commit\n- Live deployment/production checks not run.