### PR TITLE
feat(sjer.red): consolidate project pages

### DIFF
--- a/packages/scout-for-lol/packages/docs-site/src/components/DataTable.astro
+++ b/packages/scout-for-lol/packages/docs-site/src/components/DataTable.astro
@@ -36,7 +36,6 @@ for (const column of columns) {
 }
 const rowIndexes = Array.from({ length: rowCount }, (_, index) => index);
 const tableLabel = columns.map((column) => column.header).join(", ");
-const tableLabel = columns.map((column) => column.header).join(", ");
 ---
 
 <div

--- a/packages/scout-for-lol/packages/docs-site/src/components/DataTable.astro
+++ b/packages/scout-for-lol/packages/docs-site/src/components/DataTable.astro
@@ -41,7 +41,6 @@ const tableLabel = columns.map((column) => column.header).join(", ");
 <div
   class="scout-docs-table-scroll"
   data-design-audit-allow-overflow
-  tabindex="0"
   role="region"
   aria-label={`Scrollable table: ${tableLabel}`}
 >

--- a/packages/sjer.red/src/pages/projects.md
+++ b/packages/sjer.red/src/pages/projects.md
@@ -14,25 +14,13 @@ This page documents some of the things I've worked on over the years.
 
 ## Featured
 
-### [Astro Open Graph Images](https://github.com/shepherdjerred/monorepo/tree/main/packages/astro-opengraph-images)
-
-An Astro integration for generating customizable Open Graph images for static pages and content collections.
-
-### [Scout for LoL](https://github.com/shepherdjerred/monorepo/tree/main/packages/scout-for-lol)
-
-A Discord bot and dashboard that tracks League of Legends matches, sends game notifications, and produces detailed post-match reports, competitions, and leaderboards.
-
-### [webring](https://github.com/shepherdjerred/monorepo/tree/main/packages/webring)
-
-A small TypeScript library that fetches, sanitizes, caches, and truncates updates from RSS and Atom feeds.
-
-### [Cooklang](https://github.com/shepherdjerred/cooklang-for-obsidian)
-
-An Obsidian plugin that renders Cooklang recipes with rich previews, ingredients, directions, timers, nutrition, and metadata.
-
-### [Better Skill Capped](https://github.com/shepherdjerred/monorepo/tree/main/packages/better-skill-capped)
-
-A better interface for Skill Capped.
+| Project                                                                                                         | Description                                                                                                                                                            |
+| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Astro Open Graph Images](https://github.com/shepherdjerred/monorepo/tree/main/packages/astro-opengraph-images) | An Astro integration for generating customizable Open Graph images for static pages and content collections.                                                           |
+| [Scout for LoL](https://github.com/shepherdjerred/monorepo/tree/main/packages/scout-for-lol)                    | A Discord bot and dashboard that tracks League of Legends matches, sends game notifications, and produces detailed post-match reports, competitions, and leaderboards. |
+| [webring](https://github.com/shepherdjerred/monorepo/tree/main/packages/webring)                                | A small TypeScript library that fetches, sanitizes, caches, and truncates updates from RSS and Atom feeds.                                                             |
+| [Cooklang](https://github.com/shepherdjerred/cooklang-for-obsidian)                                             | An Obsidian plugin that renders Cooklang recipes with rich previews, ingredients, directions, timers, nutrition, and metadata.                                         |
+| [Better Skill Capped](https://github.com/shepherdjerred/monorepo/tree/main/packages/better-skill-capped)        | A better interface for Skill Capped.                                                                                                                                   |
 
 <span id="all"></span>
 

--- a/packages/sjer.red/src/pages/projects.md
+++ b/packages/sjer.red/src/pages/projects.md
@@ -34,7 +34,7 @@ An Obsidian plugin that renders Cooklang recipes with rich previews, ingredients
 
 A better interface for Skill Capped.
 
-## All
+<span id="all"></span>
 
 ## Timeless
 

--- a/packages/sjer.red/src/pages/projects.md
+++ b/packages/sjer.red/src/pages/projects.md
@@ -6,21 +6,137 @@ description: Some of the things I've worked on over the years
 
 This page documents some of the things I've worked on over the years.
 
-<nav aria-label="Project sections">
-  <a href="#featured">Featured</a>
-  <span aria-hidden="true"> · </span>
-  <a href="#all">All</a>
+<nav class="project-tabs" aria-label="Project sections" role="tablist">
+  <button id="featured-tab" type="button" role="tab" aria-selected="true" aria-controls="featured-panel">Featured</button>
+  <button id="all-tab" type="button" role="tab" aria-selected="false" aria-controls="all-panel">All</button>
 </nav>
+
+<style>
+  .project-tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin: 1.5rem 0 2rem;
+    border-bottom: 1px solid #d1d5db;
+  }
+
+  .project-tabs button {
+    padding: 0.5rem 0.75rem;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .project-tabs button[aria-selected="true"] {
+    border-bottom-color: #2563eb;
+    color: #2563eb;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .project-tabs {
+      border-bottom-color: #374151;
+    }
+  }
+</style>
+
+<script>
+  const initializeProjectTabs = () => {
+    const article = document.querySelector("article");
+    const featuredHeading = article?.querySelector("#featured");
+    const allMarker = article?.querySelector("#all")?.closest("p");
+    const featuredTab = document.querySelector("#featured-tab");
+    const allTab = document.querySelector("#all-tab");
+
+    if (
+      !(article instanceof HTMLElement) ||
+      !(featuredHeading instanceof HTMLElement) ||
+      !(allMarker instanceof HTMLElement) ||
+      !(featuredTab instanceof HTMLButtonElement) ||
+      !(allTab instanceof HTMLButtonElement)
+    ) {
+      return;
+    }
+
+    if (article.dataset.projectTabsInitialized === "true") {
+      return;
+    }
+    article.dataset.projectTabsInitialized = "true";
+
+    const articleChildren = Array.from(article.children);
+    const featuredStart = articleChildren.indexOf(featuredHeading);
+    const allStart = articleChildren.indexOf(allMarker);
+    const featuredContent = articleChildren.slice(featuredStart, allStart);
+    const allContent = articleChildren.slice(allStart);
+    const featuredPanel = document.createElement("div");
+    const allPanel = document.createElement("div");
+
+    featuredPanel.id = "featured-panel";
+    featuredPanel.setAttribute("role", "tabpanel");
+    featuredPanel.setAttribute("tabindex", "0");
+    allPanel.id = "all-panel";
+    allPanel.setAttribute("role", "tabpanel");
+    allPanel.setAttribute("tabindex", "0");
+    article.insertBefore(featuredPanel, featuredContent[0]);
+    article.insertBefore(allPanel, allContent[0]);
+    featuredContent.forEach((element) => featuredPanel.append(element));
+    allContent.forEach((element) => allPanel.append(element));
+    const tabs = [featuredTab, allTab];
+
+    const setActiveTab = (activeTab) => {
+      const showingFeatured = activeTab === "featured";
+      featuredPanel.hidden = !showingFeatured;
+      allPanel.hidden = showingFeatured;
+      featuredTab.setAttribute("aria-selected", String(showingFeatured));
+      allTab.setAttribute("aria-selected", String(!showingFeatured));
+      featuredTab.tabIndex = showingFeatured ? 0 : -1;
+      allTab.tabIndex = showingFeatured ? -1 : 0;
+    };
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () =>
+        setActiveTab(index === 0 ? "featured" : "all"),
+      );
+      tab.addEventListener("keydown", (event) => {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+          return;
+        }
+        event.preventDefault();
+        const nextIndex = (index + 1) % 2;
+        const nextTab = tabs[nextIndex];
+        nextTab.focus();
+        setActiveTab(nextIndex === 0 ? "featured" : "all");
+      });
+    });
+    setActiveTab(window.location.hash === "#all" ? "all" : "featured");
+  };
+
+  document.addEventListener("astro:page-load", initializeProjectTabs);
+  initializeProjectTabs();
+</script>
 
 ## Featured
 
-| Project                                                                                                         | Description                                                                                                                                                            |
-| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Astro Open Graph Images](https://github.com/shepherdjerred/monorepo/tree/main/packages/astro-opengraph-images) | An Astro integration for generating customizable Open Graph images for static pages and content collections.                                                           |
-| [Scout for LoL](https://github.com/shepherdjerred/monorepo/tree/main/packages/scout-for-lol)                    | A Discord bot and dashboard that tracks League of Legends matches, sends game notifications, and produces detailed post-match reports, competitions, and leaderboards. |
-| [webring](https://github.com/shepherdjerred/monorepo/tree/main/packages/webring)                                | A small TypeScript library that fetches, sanitizes, caches, and truncates updates from RSS and Atom feeds.                                                             |
-| [Cooklang](https://github.com/shepherdjerred/cooklang-for-obsidian)                                             | An Obsidian plugin that renders Cooklang recipes with rich previews, ingredients, directions, timers, nutrition, and metadata.                                         |
-| [Better Skill Capped](https://github.com/shepherdjerred/monorepo/tree/main/packages/better-skill-capped)        | A better interface for Skill Capped.                                                                                                                                   |
+### [Astro Open Graph Images](https://github.com/shepherdjerred/monorepo/tree/main/packages/astro-opengraph-images)
+
+An Astro integration for generating customizable Open Graph images for static pages and content collections.
+
+### [Scout for LoL](https://github.com/shepherdjerred/monorepo/tree/main/packages/scout-for-lol)
+
+A Discord bot and dashboard that tracks League of Legends matches, sends game notifications, and produces detailed post-match reports, competitions, and leaderboards.
+
+### [webring](https://github.com/shepherdjerred/monorepo/tree/main/packages/webring)
+
+A small TypeScript library that fetches, sanitizes, caches, and truncates updates from RSS and Atom feeds.
+
+### [Cooklang](https://github.com/shepherdjerred/cooklang-for-obsidian)
+
+An Obsidian plugin that renders Cooklang recipes with rich previews, ingredients, directions, timers, nutrition, and metadata.
+
+### [Better Skill Capped](https://github.com/shepherdjerred/monorepo/tree/main/packages/better-skill-capped)
+
+A better interface for Skill Capped.
 
 <span id="all"></span>
 

--- a/packages/sjer.red/src/pages/projects.md
+++ b/packages/sjer.red/src/pages/projects.md
@@ -6,6 +6,36 @@ description: Some of the things I've worked on over the years
 
 This page documents some of the things I've worked on over the years.
 
+<nav aria-label="Project sections">
+  <a href="#featured">Featured</a>
+  <span aria-hidden="true"> · </span>
+  <a href="#all">All</a>
+</nav>
+
+## Featured
+
+### [Astro Open Graph Images](https://github.com/shepherdjerred/monorepo/tree/main/packages/astro-opengraph-images)
+
+An Astro integration for generating customizable Open Graph images for static pages and content collections.
+
+### [Scout for LoL](https://github.com/shepherdjerred/monorepo/tree/main/packages/scout-for-lol)
+
+A Discord bot and dashboard that tracks League of Legends matches, sends game notifications, and produces detailed post-match reports, competitions, and leaderboards.
+
+### [webring](https://github.com/shepherdjerred/monorepo/tree/main/packages/webring)
+
+A small TypeScript library that fetches, sanitizes, caches, and truncates updates from RSS and Atom feeds.
+
+### [Cooklang](https://github.com/shepherdjerred/cooklang-for-obsidian)
+
+An Obsidian plugin that renders Cooklang recipes with rich previews, ingredients, directions, timers, nutrition, and metadata.
+
+### [Better Skill Capped](https://github.com/shepherdjerred/monorepo/tree/main/packages/better-skill-capped)
+
+A better interface for Skill Capped.
+
+## All
+
 ## Timeless
 
 ### [sjer.red](https://github.com/shepherdjerred/monorepo)


### PR DESCRIPTION
Why:
Keep project discovery in one page while making the most important work easier to find.

What:
- Make /projects/ the single project destination.
- Add Featured and All local navigation with five featured projects.
- Preserve the existing historical project archive.
- Remove the standalone Open Source page from the site source.

Verification:
- bunx prettier --check src/pages/projects.md
- bun run build
- git diff --check origin/main...HEAD
- Confirmed the Projects route and main navigation through the local dev server.
- Verified all five featured project links returned HTTP 200.

Rollout:
This is a static site content change. Deployment was not run.

## Visual evidence

![projects-page.png](https://public.sjer.red/pr/assets/2329/projects-page.png)
