### PR TITLE
feat(root): make npm releases consumer-driven

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1828,6 +1828,8 @@ steps:
     timeout_in_minutes: 60
     if: build.branch == pipeline.default_branch
     depends_on: verify
+    concurrency: 1
+    concurrency_group: monorepo/release-please
     cancel_on_build_failing: true
     command: |
       . .buildkite/scripts/toolchain.sh

--- a/bun.lock
+++ b/bun.lock
@@ -1071,6 +1071,10 @@
       "dependencies": {
         "release-please": "17.11.1",
       },
+      "devDependencies": {
+        "@vitest/coverage-istanbul": "4.1.9",
+        "vitest": "4.1.9",
+      },
     },
     "packages/resume": {
       "name": "@shepherdjerred/resume",
@@ -2013,7 +2017,6 @@
     "@openrouter/ai-sdk-provider@3.0.0": "patches/@openrouter%2Fai-sdk-provider@3.0.0.patch",
     "twisted@1.82.0": "patches/twisted@1.82.0.patch",
     "markdown-it@10.0.0": "patches/markdown-it@10.0.0.patch",
-    "bun-types@1.4.0": "patches/bun-types@1.4.0.patch",
     "@astrojs/internal-helpers@0.10.2": "patches/@astrojs%2Finternal-helpers@0.10.2.patch",
     "react-native-sound@0.13.0": "patches/react-native-sound@0.13.0.patch",
     "astro@7.1.5": "patches/astro@7.1.5.patch",

--- a/bun.lock
+++ b/bun.lock
@@ -1919,6 +1919,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
         "@openai/codex-sdk": "0.147.0",
         "@shepherdjerred/code-review": "workspace:*",
+        "@shepherdjerred/release-tools": "workspace:*",
         "@shepherdjerred/version-catalog": "workspace:*",
         "fast-xml-builder": "1.3.0",
         "fast-xml-parser": "5.10.1",

--- a/bun.lock
+++ b/bun.lock
@@ -2022,6 +2022,7 @@
     "astro@7.1.5": "patches/astro@7.1.5.patch",
     "@kubernetes/client-node@1.4.0": "patches/@kubernetes%2Fclient-node@1.4.0.patch",
     "react-native-worklets@0.11.3": "patches/react-native-worklets@0.11.3.patch",
+    "bun-types@1.4.0": "patches/bun-types@1.4.0.patch",
   },
   "overrides": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",

--- a/bun.lock
+++ b/bun.lock
@@ -1972,6 +1972,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
         "@openai/codex-sdk": "0.147.0",
         "@shepherdjerred/code-review": "workspace:*",
+        "@shepherdjerred/release-tools": "workspace:*",
         "@shepherdjerred/version-catalog": "workspace:*",
         "fast-xml-builder": "1.3.0",
         "fast-xml-parser": "5.10.1",

--- a/packages/astro-opengraph-images/README.md
+++ b/packages/astro-opengraph-images/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.rawgit.com/shepherdjerred/astro-opengraph-images/main/assets/logo-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://cdn.rawgit.com/shepherdjerred/astro-opengraph-images/main/assets/logo-light.png">
-    <img alt="project logo" src="https://cdn.rawgit.com/shepherdjerred/astro-opengraph-images/main/assets/logo-light.png" height=75>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/shepherdjerred/monorepo/main/packages/astro-opengraph-images/assets/logo-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/shepherdjerred/monorepo/main/packages/astro-opengraph-images/assets/logo-light.png">
+    <img alt="project logo" src="https://raw.githubusercontent.com/shepherdjerred/monorepo/main/packages/astro-opengraph-images/assets/logo-light.png" height=75>
   </picture>
 
 [![astro-opengraph-images](https://img.shields.io/npm/v/astro-opengraph-images.svg)](https://www.npmjs.com/package/astro-opengraph-images)

--- a/packages/homelab/scripts/lint-helm.ts
+++ b/packages/homelab/scripts/lint-helm.ts
@@ -7,7 +7,6 @@ import { chartName, setChartVersion } from "./migration-core.ts";
 if (import.meta.main) {
   const root = import.meta.dir.replace(/\/scripts$/, "");
   const cdk8s = `${root}/src/cdk8s`;
-  await $`bunx turbo run build --filter=@homelab/cdk8s`.cwd(root);
   for (const chartPath of new Bun.Glob("*/Chart.yaml").scanSync({
     cwd: `${cdk8s}/helm`,
     absolute: true,

--- a/packages/homelab/src/cdk8s/eslint.config.ts
+++ b/packages/homelab/src/cdk8s/eslint.config.ts
@@ -40,7 +40,7 @@ const config = [
     },
   },
   {
-    ignores: ["generated/"],
+    ignores: ["dist/", "generated/"],
   },
 ];
 export default config;

--- a/packages/release-tools/README.md
+++ b/packages/release-tools/README.md
@@ -1,9 +1,11 @@
 # @shepherdjerred/release-tools
 
-Wrapper package that pins the `release-please` CLI (its only dependency) for
-the main-branch release lane. `scripts/release.ts` invokes it as
-`bun run --cwd packages/release-tools release-please -- <subcommand>`, so the
-CLI version comes from the root lockfile instead of an ad-hoc fetch. See
+Wrapper package that pins the `release-please` library and CLI for the
+main-branch release lane. The release runner loads the committed manifest,
+applies the in-memory npm consumer eligibility filter, and uses the same
+filtered manifest for release-PR creation and GitHub tagging. The CLI remains
+available for diagnostics, and the version comes from the root lockfile instead
+of an ad-hoc fetch. See
 "Release refinement providers" in the root
 [AGENTS.md](../../AGENTS.md#release-refinement-providers) for the surrounding
 release flow.

--- a/packages/release-tools/package.json
+++ b/packages/release-tools/package.json
@@ -2,10 +2,15 @@
   "name": "@shepherdjerred/release-tools",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "release-please": "release-please"
+    "release-please": "release-please",
+    "test": "bun test"
   },
   "dependencies": {
     "release-please": "17.11.1"
+  },
+  "exports": {
+    "./runner": "./runner.ts"
   }
 }

--- a/packages/release-tools/package.json
+++ b/packages/release-tools/package.json
@@ -5,12 +5,18 @@
   "type": "module",
   "scripts": {
     "release-please": "release-please",
-    "test": "bun test"
+    "test": "bun --no-install --bun vitest --config ../../vitest.config.ts run",
+    "test:ci": "bun ../../scripts/run-ci-test.ts",
+    "test:report": "CI_TEST_COVERAGE=1 bun ../../scripts/run-ci-test.ts"
   },
   "dependencies": {
     "release-please": "17.11.1"
   },
   "exports": {
     "./runner": "./runner.ts"
+  },
+  "devDependencies": {
+    "@vitest/coverage-istanbul": "4.1.9",
+    "vitest": "4.1.9"
   }
 }

--- a/packages/release-tools/runner.test.ts
+++ b/packages/release-tools/runner.test.ts
@@ -15,7 +15,7 @@ test("applies the same component exclusions to the in-memory manifest", () => {
   };
   applyExcludedPathsToConfig(repositoryConfig, ["packages/webring"]);
   expect(repositoryConfig).toEqual({
-    "packages/webring": { excludePaths: ["packages/webring"] },
+    "packages/webring": { excludePaths: ["packages/webring/"] },
     "packages/astro-opengraph-images": {
       excludePaths: ["packages/astro-opengraph-images/typedoc.json"],
     },
@@ -23,11 +23,13 @@ test("applies the same component exclusions to the in-memory manifest", () => {
 });
 
 test("component exclusions cover descendant files in release-please", () => {
-  const commitExclude = new CommitExclude({
+  const repositoryConfig = {
     "packages/webring": {
-      excludePaths: ["packages/webring"],
+      excludePaths: [],
     },
-  });
+  };
+  applyExcludedPathsToConfig(repositoryConfig, ["packages/webring"]);
+  const commitExclude = new CommitExclude(repositoryConfig);
 
   const filtered = commitExclude.excludeCommits({
     "packages/webring": [

--- a/packages/release-tools/runner.test.ts
+++ b/packages/release-tools/runner.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { CommitExclude } from "release-please/build/src/util/commit-exclude.js";
+import { describe, expect, test } from "vitest";
 
 import {
   applyExcludedPathsToConfig,
@@ -19,6 +20,29 @@ test("applies the same component exclusions to the in-memory manifest", () => {
       excludePaths: ["packages/astro-opengraph-images/typedoc.json"],
     },
   });
+});
+
+test("component exclusions cover descendant files in release-please", () => {
+  const commitExclude = new CommitExclude({
+    "packages/webring": {
+      excludePaths: ["packages/webring"],
+    },
+  });
+
+  const filtered = commitExclude.excludeCommits({
+    "packages/webring": [
+      { files: ["packages/webring/typedoc.json"] },
+      { files: ["packages/webring/src/index.ts"] },
+      {
+        files: [
+          "packages/webring/typedoc.json",
+          "packages/release-tools/runner.ts",
+        ],
+      },
+    ],
+  });
+
+  expect(filtered["packages/webring"]).toHaveLength(0);
 });
 
 describe("release-please candidate validation", () => {

--- a/packages/release-tools/runner.test.ts
+++ b/packages/release-tools/runner.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyExcludedPathsToConfig,
+  validateReleaseCandidatePaths,
+} from "./runner.ts";
+
+test("applies the same component exclusions to the in-memory manifest", () => {
+  const repositoryConfig = {
+    "packages/webring": {},
+    "packages/astro-opengraph-images": {
+      excludePaths: ["packages/astro-opengraph-images/typedoc.json"],
+    },
+  };
+  applyExcludedPathsToConfig(repositoryConfig, ["packages/webring"]);
+  expect(repositoryConfig).toEqual({
+    "packages/webring": { excludePaths: ["packages/webring"] },
+    "packages/astro-opengraph-images": {
+      excludePaths: ["packages/astro-opengraph-images/typedoc.json"],
+    },
+  });
+});
+
+describe("release-please candidate validation", () => {
+  test("accepts candidates for eligible packages", () => {
+    expect(() =>
+      validateReleaseCandidatePaths(
+        ["packages/webring"],
+        ["packages/astro-opengraph-images"],
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects candidates for excluded packages", () => {
+    expect(() =>
+      validateReleaseCandidatePaths(
+        ["packages/webring", "packages/astro-opengraph-images"],
+        ["packages/astro-opengraph-images"],
+      ),
+    ).toThrow("proposed ineligible package");
+  });
+});

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -1,0 +1,116 @@
+import {
+  GitHub,
+  Manifest,
+  type Manifest as ManifestType,
+} from "release-please";
+
+export type ReleasePleasePhase = "release-pr" | "github-release";
+
+export type ReleasePleaseRunnerOptions = {
+  readonly phase: ReleasePleasePhase;
+  readonly token: string;
+  readonly repoUrl: string;
+  readonly targetBranch: string;
+  readonly excludedPaths: readonly string[];
+};
+
+export type ReleasePleaseRunnerResult = {
+  readonly phase: ReleasePleasePhase;
+  readonly count: number;
+};
+
+type ReleaseConfig = {
+  excludePaths?: string[];
+};
+
+function repositoryParts(repoUrl: string): {
+  readonly owner: string;
+  readonly repo: string;
+} {
+  const url = new URL(repoUrl);
+  const parts = url.pathname.split("/").filter(Boolean);
+  const owner = parts[0];
+  const repoWithSuffix = parts[1];
+  if (owner === undefined || repoWithSuffix === undefined) {
+    throw new Error(`Could not parse GitHub repository URL: ${repoUrl}`);
+  }
+  const repo = repoWithSuffix.endsWith(".git")
+    ? repoWithSuffix.slice(0, -4)
+    : repoWithSuffix;
+  if (repo === "")
+    throw new Error(`Could not parse GitHub repository URL: ${repoUrl}`);
+  return { owner, repo };
+}
+
+export function applyExcludedPathsToConfig(
+  repositoryConfig: Record<string, ReleaseConfig>,
+  excludedPaths: readonly string[],
+): void {
+  for (const path of excludedPaths) {
+    const config = repositoryConfig[path];
+    if (config === undefined) {
+      throw new Error(
+        `Release policy tried to exclude unconfigured package path ${path}`,
+      );
+    }
+    config.excludePaths = [...new Set([...(config.excludePaths ?? []), path])];
+  }
+}
+
+function applyExcludedPaths(
+  manifest: ManifestType,
+  excludedPaths: readonly string[],
+): void {
+  applyExcludedPathsToConfig(manifest.repositoryConfig, excludedPaths);
+}
+
+export function validateReleaseCandidatePaths(
+  candidatePaths: readonly string[],
+  excludedPaths: readonly string[],
+): void {
+  const excluded = new Set(excludedPaths);
+  const invalid = candidatePaths.filter((path) => excluded.has(path));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Release-please proposed ineligible package(s): ${invalid.join(", ")}. ` +
+        "Close the stale release PR and rerun the release lane after reviewing its diff.",
+    );
+  }
+}
+
+async function createManifest(
+  options: ReleasePleaseRunnerOptions,
+): Promise<ManifestType> {
+  const repository = repositoryParts(options.repoUrl);
+  const github = await GitHub.create({
+    ...repository,
+    token: options.token,
+    defaultBranch: options.targetBranch,
+  });
+  const manifest = await Manifest.fromManifest(
+    github,
+    options.targetBranch,
+    "release-please-config.json",
+    ".release-please-manifest.json",
+  );
+  applyExcludedPaths(manifest, options.excludedPaths);
+  return manifest;
+}
+
+export async function runReleasePlease(
+  options: ReleasePleaseRunnerOptions,
+): Promise<ReleasePleaseRunnerResult> {
+  const manifest = await createManifest(options);
+  if (options.phase === "release-pr") {
+    const pullRequests = await manifest.createPullRequests();
+    return { phase: options.phase, count: pullRequests.filter(Boolean).length };
+  }
+
+  const candidates = await manifest.buildReleases();
+  validateReleaseCandidatePaths(
+    candidates.map((candidate) => candidate.path),
+    options.excludedPaths,
+  );
+  const releases = await manifest.createReleases();
+  return { phase: options.phase, count: releases.filter(Boolean).length };
+}

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -11,6 +11,7 @@ export type ReleasePleaseRunnerOptions = {
   readonly token: string;
   readonly repoUrl: string;
   readonly targetBranch: string;
+  readonly targetBranchSha: string;
   readonly excludedPaths: readonly string[];
 };
 
@@ -22,6 +23,10 @@ export type ReleasePleaseRunnerResult = {
 type ReleaseConfig = {
   excludePaths?: string[];
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 function repositoryParts(repoUrl: string): {
   readonly owner: string;
@@ -69,6 +74,37 @@ function applyExcludedPaths(
   applyExcludedPathsToConfig(manifest.repositoryConfig, excludedPaths);
 }
 
+async function branchSha(
+  repository: { readonly owner: string; readonly repo: string },
+  token: string,
+  branch: string,
+): Promise<string> {
+  const response = await fetch(
+    `https://api.github.com/repos/${repository.owner}/${repository.repo}/git/ref/heads/${encodeURIComponent(branch)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Could not resolve ${branch} on GitHub (${String(response.status)} ${response.statusText})`,
+    );
+  }
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)) {
+    throw new Error(`GitHub returned an invalid ref response for ${branch}`);
+  }
+  const object = payload["object"];
+  if (!isRecord(object) || typeof object["sha"] !== "string") {
+    throw new Error(`GitHub returned no commit SHA for ${branch}`);
+  }
+  return object["sha"];
+}
+
 export function validateReleaseCandidatePaths(
   candidatePaths: readonly string[],
   excludedPaths: readonly string[],
@@ -92,12 +128,34 @@ async function createManifest(
     token: options.token,
     defaultBranch: options.targetBranch,
   });
+  const beforeManifestSha = await branchSha(
+    repository,
+    options.token,
+    options.targetBranch,
+  );
+  if (beforeManifestSha !== options.targetBranchSha) {
+    throw new Error(
+      `Release target ${options.targetBranch} moved from ${options.targetBranchSha} ` +
+        `to ${beforeManifestSha} before release-please loaded its manifest; retry the release lane`,
+    );
+  }
   const manifest = await Manifest.fromManifest(
     github,
     options.targetBranch,
     "release-please-config.json",
     ".release-please-manifest.json",
   );
+  const afterManifestSha = await branchSha(
+    repository,
+    options.token,
+    options.targetBranch,
+  );
+  if (afterManifestSha !== beforeManifestSha) {
+    throw new Error(
+      `Release target ${options.targetBranch} moved while release-please loaded its manifest ` +
+        `(${beforeManifestSha} -> ${afterManifestSha}); retry the release lane`,
+    );
+  }
   applyExcludedPaths(manifest, options.excludedPaths);
   return manifest;
 }

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -53,6 +53,8 @@ export function applyExcludedPathsToConfig(
         `Release policy tried to exclude unconfigured package path ${path}`,
       );
     }
+    // release-please's CommitExclude treats a path as a directory prefix, so
+    // this excludes every changed file below the component path.
     config.excludePaths = [...new Set([...(config.excludePaths ?? []), path])];
   }
 }

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -24,6 +24,10 @@ type ReleaseConfig = {
   excludePaths?: string[];
 };
 
+type ReleaseTargetPin = {
+  enabled: boolean;
+};
+
 function repositoryParts(repoUrl: string): {
   readonly owner: string;
   readonly repo: string;
@@ -68,6 +72,40 @@ function applyExcludedPaths(
   excludedPaths: readonly string[],
 ): void {
   applyExcludedPathsToConfig(manifest.repositoryConfig, excludedPaths);
+}
+
+function pinGitHubReads(
+  github: GitHub,
+  targetBranch: string,
+  targetBranchSha: string,
+): ReleaseTargetPin {
+  const pin: ReleaseTargetPin = { enabled: true };
+  const pinnedBranch = (branch: string): string =>
+    pin.enabled && branch === targetBranch ? targetBranchSha : branch;
+
+  const getFileContentsOnBranch = github.getFileContentsOnBranch.bind(github);
+  github.getFileContentsOnBranch = (path, branch) =>
+    getFileContentsOnBranch(path, pinnedBranch(branch));
+
+  const findFilesByFilenameAndRef =
+    github.findFilesByFilenameAndRef.bind(github);
+  github.findFilesByFilenameAndRef = (filename, ref, prefix) =>
+    findFilesByFilenameAndRef(filename, pinnedBranch(ref), prefix);
+
+  const findFilesByGlobAndRef = github.findFilesByGlobAndRef.bind(github);
+  github.findFilesByGlobAndRef = (glob, ref, prefix) =>
+    findFilesByGlobAndRef(glob, pinnedBranch(ref), prefix);
+
+  const findFilesByExtensionAndRef =
+    github.findFilesByExtensionAndRef.bind(github);
+  github.findFilesByExtensionAndRef = (extension, ref, prefix) =>
+    findFilesByExtensionAndRef(extension, pinnedBranch(ref), prefix);
+
+  const mergeCommitIterator = github.mergeCommitIterator.bind(github);
+  github.mergeCommitIterator = (branch, options) =>
+    mergeCommitIterator(pinnedBranch(branch), options);
+
+  return pin;
 }
 
 async function branchSha(
@@ -125,13 +163,18 @@ export function validateReleaseCandidatePaths(
 
 async function createManifest(
   options: ReleasePleaseRunnerOptions,
-): Promise<ManifestType> {
+): Promise<{ manifest: ManifestType; pin: ReleaseTargetPin }> {
   const repository = repositoryParts(options.repoUrl);
   const github = await GitHub.create({
     ...repository,
     token: options.token,
     defaultBranch: options.targetBranch,
   });
+  const pin = pinGitHubReads(
+    github,
+    options.targetBranch,
+    options.targetBranchSha,
+  );
   const beforeManifestSha = await branchSha(
     repository,
     options.token,
@@ -161,7 +204,7 @@ async function createManifest(
     );
   }
   applyExcludedPaths(manifest, options.excludedPaths);
-  return manifest;
+  return { manifest, pin };
 }
 
 async function assertTargetBranchSha(
@@ -184,12 +227,14 @@ async function assertTargetBranchSha(
 async function createValidatedReleases(
   manifest: ManifestType,
   excludedPaths: readonly string[],
+  pin: ReleaseTargetPin,
 ): Promise<readonly unknown[]> {
   const candidates = await manifest.buildReleases();
   validateReleaseCandidatePaths(
     candidates.map((candidate) => candidate.path),
     excludedPaths,
   );
+  pin.enabled = false;
 
   // release-please 17.11.1 discovers candidates again inside createReleases.
   // Freeze that public method to the validated set for this call so a stale
@@ -203,13 +248,29 @@ async function createValidatedReleases(
   }
 }
 
+async function createPinnedPullRequests(
+  manifest: ManifestType,
+  pin: ReleaseTargetPin,
+): Promise<readonly unknown[]> {
+  const candidates = await manifest.buildPullRequests();
+  pin.enabled = false;
+
+  const originalBuildPullRequests = manifest.buildPullRequests;
+  manifest.buildPullRequests = async () => candidates;
+  try {
+    return await manifest.createPullRequests();
+  } finally {
+    manifest.buildPullRequests = originalBuildPullRequests;
+  }
+}
+
 export async function runReleasePlease(
   options: ReleasePleaseRunnerOptions,
 ): Promise<ReleasePleaseRunnerResult> {
-  const manifest = await createManifest(options);
+  const { manifest, pin } = await createManifest(options);
   if (options.phase === "release-pr") {
     await assertTargetBranchSha(options);
-    const pullRequests = await manifest.createPullRequests();
+    const pullRequests = await createPinnedPullRequests(manifest, pin);
     await assertTargetBranchSha(options);
     return { phase: options.phase, count: pullRequests.filter(Boolean).length };
   }
@@ -218,6 +279,7 @@ export async function runReleasePlease(
   const releases = await createValidatedReleases(
     manifest,
     options.excludedPaths,
+    pin,
   );
   await assertTargetBranchSha(options);
   return { phase: options.phase, count: releases.filter(Boolean).length };

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -24,10 +24,6 @@ type ReleaseConfig = {
   excludePaths?: string[];
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function repositoryParts(repoUrl: string): {
   readonly owner: string;
   readonly repo: string;
@@ -95,14 +91,22 @@ async function branchSha(
     );
   }
   const payload: unknown = await response.json();
-  if (!isRecord(payload)) {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
     throw new Error(`GitHub returned an invalid ref response for ${branch}`);
   }
-  const object = payload["object"];
-  if (!isRecord(object) || typeof object["sha"] !== "string") {
+  const object = Object.entries(payload).find(([key]) => key === "object")?.[1];
+  if (typeof object !== "object" || object === null || Array.isArray(object)) {
     throw new Error(`GitHub returned no commit SHA for ${branch}`);
   }
-  return object["sha"];
+  const sha = Object.entries(object).find(([key]) => key === "sha")?.[1];
+  if (typeof sha !== "string") {
+    throw new Error(`GitHub returned no commit SHA for ${branch}`);
+  }
+  return sha;
 }
 
 export function validateReleaseCandidatePaths(

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -164,20 +164,61 @@ async function createManifest(
   return manifest;
 }
 
+async function assertTargetBranchSha(
+  options: ReleasePleaseRunnerOptions,
+): Promise<void> {
+  const repository = repositoryParts(options.repoUrl);
+  const currentSha = await branchSha(
+    repository,
+    options.token,
+    options.targetBranch,
+  );
+  if (currentSha !== options.targetBranchSha) {
+    throw new Error(
+      `Release target ${options.targetBranch} moved from ${options.targetBranchSha} ` +
+        `to ${currentSha} during release-please; retry the release lane`,
+    );
+  }
+}
+
+async function createValidatedReleases(
+  manifest: ManifestType,
+  excludedPaths: readonly string[],
+): Promise<readonly unknown[]> {
+  const candidates = await manifest.buildReleases();
+  validateReleaseCandidatePaths(
+    candidates.map((candidate) => candidate.path),
+    excludedPaths,
+  );
+
+  // release-please 17.11.1 discovers candidates again inside createReleases.
+  // Freeze that public method to the validated set for this call so a stale
+  // release PR cannot become publishable between validation and tagging.
+  const originalBuildReleases = manifest.buildReleases;
+  manifest.buildReleases = async () => candidates;
+  try {
+    return await manifest.createReleases();
+  } finally {
+    manifest.buildReleases = originalBuildReleases;
+  }
+}
+
 export async function runReleasePlease(
   options: ReleasePleaseRunnerOptions,
 ): Promise<ReleasePleaseRunnerResult> {
   const manifest = await createManifest(options);
   if (options.phase === "release-pr") {
+    await assertTargetBranchSha(options);
     const pullRequests = await manifest.createPullRequests();
+    await assertTargetBranchSha(options);
     return { phase: options.phase, count: pullRequests.filter(Boolean).length };
   }
 
-  const candidates = await manifest.buildReleases();
-  validateReleaseCandidatePaths(
-    candidates.map((candidate) => candidate.path),
+  await assertTargetBranchSha(options);
+  const releases = await createValidatedReleases(
+    manifest,
     options.excludedPaths,
   );
-  const releases = await manifest.createReleases();
+  await assertTargetBranchSha(options);
   return { phase: options.phase, count: releases.filter(Boolean).length };
 }

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -53,9 +53,12 @@ export function applyExcludedPathsToConfig(
         `Release policy tried to exclude unconfigured package path ${path}`,
       );
     }
-    // release-please's CommitExclude treats a path as a directory prefix, so
-    // this excludes every changed file below the component path.
-    config.excludePaths = [...new Set([...(config.excludePaths ?? []), path])];
+    // release-please normalizes this directory prefix before matching changed
+    // files, so every descendant of the ineligible component is excluded.
+    const descendantPath = `${path}/`;
+    config.excludePaths = [
+      ...new Set([...(config.excludePaths ?? []), descendantPath]),
+    ];
   }
 }
 

--- a/packages/release-tools/runner.ts
+++ b/packages/release-tools/runner.ts
@@ -1,8 +1,8 @@
-import {
-  GitHub,
-  Manifest,
-  type Manifest as ManifestType,
-} from "release-please";
+import { Manifest, type Manifest as ManifestType } from "release-please";
+import { LocalGitHub } from "release-please/build/src/local-github.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 export type ReleasePleasePhase = "release-pr" | "github-release";
 
@@ -24,8 +24,9 @@ type ReleaseConfig = {
   excludePaths?: string[];
 };
 
-type ReleaseTargetPin = {
-  enabled: boolean;
+type CreatedManifest = {
+  readonly manifest: ManifestType;
+  readonly cleanup: () => Promise<void>;
 };
 
 function repositoryParts(repoUrl: string): {
@@ -74,38 +75,25 @@ function applyExcludedPaths(
   applyExcludedPathsToConfig(manifest.repositoryConfig, excludedPaths);
 }
 
-function pinGitHubReads(
-  github: GitHub,
+async function runGit(cwd: string, args: readonly string[]): Promise<void> {
+  const child = Bun.spawn(["git", ...args], { cwd });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed with exit code ${exitCode}`);
+  }
+}
+
+async function pinLocalRepository(
+  repositoryPath: string,
   targetBranch: string,
   targetBranchSha: string,
-): ReleaseTargetPin {
-  const pin: ReleaseTargetPin = { enabled: true };
-  const pinnedBranch = (branch: string): string =>
-    pin.enabled && branch === targetBranch ? targetBranchSha : branch;
-
-  const getFileContentsOnBranch = github.getFileContentsOnBranch.bind(github);
-  github.getFileContentsOnBranch = (path, branch) =>
-    getFileContentsOnBranch(path, pinnedBranch(branch));
-
-  const findFilesByFilenameAndRef =
-    github.findFilesByFilenameAndRef.bind(github);
-  github.findFilesByFilenameAndRef = (filename, ref, prefix) =>
-    findFilesByFilenameAndRef(filename, pinnedBranch(ref), prefix);
-
-  const findFilesByGlobAndRef = github.findFilesByGlobAndRef.bind(github);
-  github.findFilesByGlobAndRef = (glob, ref, prefix) =>
-    findFilesByGlobAndRef(glob, pinnedBranch(ref), prefix);
-
-  const findFilesByExtensionAndRef =
-    github.findFilesByExtensionAndRef.bind(github);
-  github.findFilesByExtensionAndRef = (extension, ref, prefix) =>
-    findFilesByExtensionAndRef(extension, pinnedBranch(ref), prefix);
-
-  const mergeCommitIterator = github.mergeCommitIterator.bind(github);
-  github.mergeCommitIterator = (branch, options) =>
-    mergeCommitIterator(pinnedBranch(branch), options);
-
-  return pin;
+): Promise<void> {
+  await runGit(repositoryPath, ["checkout", "--detach", targetBranchSha]);
+  await runGit(repositoryPath, [
+    "update-ref",
+    `refs/heads/${targetBranch}`,
+    targetBranchSha,
+  ]);
 }
 
 async function branchSha(
@@ -163,48 +151,60 @@ export function validateReleaseCandidatePaths(
 
 async function createManifest(
   options: ReleasePleaseRunnerOptions,
-): Promise<{ manifest: ManifestType; pin: ReleaseTargetPin }> {
+): Promise<CreatedManifest> {
   const repository = repositoryParts(options.repoUrl);
-  const github = await GitHub.create({
-    ...repository,
-    token: options.token,
-    defaultBranch: options.targetBranch,
-  });
-  const pin = pinGitHubReads(
-    github,
-    options.targetBranch,
-    options.targetBranchSha,
+  const localRepositoryPath = await mkdtemp(
+    path.join(tmpdir(), "release-please-"),
   );
-  const beforeManifestSha = await branchSha(
-    repository,
-    options.token,
-    options.targetBranch,
-  );
-  if (beforeManifestSha !== options.targetBranchSha) {
-    throw new Error(
-      `Release target ${options.targetBranch} moved from ${options.targetBranchSha} ` +
-        `to ${beforeManifestSha} before release-please loaded its manifest; retry the release lane`,
+  try {
+    const github = await LocalGitHub.create({
+      ...repository,
+      token: options.token,
+      defaultBranch: options.targetBranch,
+      localRepoPath: localRepositoryPath,
+    });
+    await pinLocalRepository(
+      localRepositoryPath,
+      options.targetBranch,
+      options.targetBranchSha,
     );
-  }
-  const manifest = await Manifest.fromManifest(
-    github,
-    options.targetBranch,
-    "release-please-config.json",
-    ".release-please-manifest.json",
-  );
-  const afterManifestSha = await branchSha(
-    repository,
-    options.token,
-    options.targetBranch,
-  );
-  if (afterManifestSha !== beforeManifestSha) {
-    throw new Error(
-      `Release target ${options.targetBranch} moved while release-please loaded its manifest ` +
-        `(${beforeManifestSha} -> ${afterManifestSha}); retry the release lane`,
+    const beforeManifestSha = await branchSha(
+      repository,
+      options.token,
+      options.targetBranch,
     );
+    if (beforeManifestSha !== options.targetBranchSha) {
+      throw new Error(
+        `Release target ${options.targetBranch} moved from ${options.targetBranchSha} ` +
+          `to ${beforeManifestSha} before release-please loaded its manifest; retry the release lane`,
+      );
+    }
+    const manifest = await Manifest.fromManifest(
+      github,
+      options.targetBranch,
+      "release-please-config.json",
+      ".release-please-manifest.json",
+    );
+    const afterManifestSha = await branchSha(
+      repository,
+      options.token,
+      options.targetBranch,
+    );
+    if (afterManifestSha !== beforeManifestSha) {
+      throw new Error(
+        `Release target ${options.targetBranch} moved while release-please loaded its manifest ` +
+          `(${beforeManifestSha} -> ${afterManifestSha}); retry the release lane`,
+      );
+    }
+    applyExcludedPaths(manifest, options.excludedPaths);
+    return {
+      manifest,
+      cleanup: () => rm(localRepositoryPath, { force: true, recursive: true }),
+    };
+  } catch (error) {
+    await rm(localRepositoryPath, { force: true, recursive: true });
+    throw error;
   }
-  applyExcludedPaths(manifest, options.excludedPaths);
-  return { manifest, pin };
 }
 
 async function assertTargetBranchSha(
@@ -227,15 +227,12 @@ async function assertTargetBranchSha(
 async function createValidatedReleases(
   manifest: ManifestType,
   excludedPaths: readonly string[],
-  pin: ReleaseTargetPin,
 ): Promise<readonly unknown[]> {
   const candidates = await manifest.buildReleases();
   validateReleaseCandidatePaths(
     candidates.map((candidate) => candidate.path),
     excludedPaths,
   );
-  pin.enabled = false;
-
   // release-please 17.11.1 discovers candidates again inside createReleases.
   // Freeze that public method to the validated set for this call so a stale
   // release PR cannot become publishable between validation and tagging.
@@ -250,10 +247,8 @@ async function createValidatedReleases(
 
 async function createPinnedPullRequests(
   manifest: ManifestType,
-  pin: ReleaseTargetPin,
 ): Promise<readonly unknown[]> {
   const candidates = await manifest.buildPullRequests();
-  pin.enabled = false;
 
   const originalBuildPullRequests = manifest.buildPullRequests;
   manifest.buildPullRequests = async () => candidates;
@@ -267,20 +262,26 @@ async function createPinnedPullRequests(
 export async function runReleasePlease(
   options: ReleasePleaseRunnerOptions,
 ): Promise<ReleasePleaseRunnerResult> {
-  const { manifest, pin } = await createManifest(options);
-  if (options.phase === "release-pr") {
-    await assertTargetBranchSha(options);
-    const pullRequests = await createPinnedPullRequests(manifest, pin);
-    await assertTargetBranchSha(options);
-    return { phase: options.phase, count: pullRequests.filter(Boolean).length };
-  }
+  const created = await createManifest(options);
+  try {
+    if (options.phase === "release-pr") {
+      await assertTargetBranchSha(options);
+      const pullRequests = await createPinnedPullRequests(created.manifest);
+      await assertTargetBranchSha(options);
+      return {
+        phase: options.phase,
+        count: pullRequests.filter(Boolean).length,
+      };
+    }
 
-  await assertTargetBranchSha(options);
-  const releases = await createValidatedReleases(
-    manifest,
-    options.excludedPaths,
-    pin,
-  );
-  await assertTargetBranchSha(options);
-  return { phase: options.phase, count: releases.filter(Boolean).length };
+    await assertTargetBranchSha(options);
+    const releases = await createValidatedReleases(
+      created.manifest,
+      options.excludedPaths,
+    );
+    await assertTargetBranchSha(options);
+    return { phase: options.phase, count: releases.filter(Boolean).length };
+  } finally {
+    await created.cleanup();
+  }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,7 @@
     { "type": "test", "section": "Tests", "hidden": true },
     { "type": "build", "section": "Build", "hidden": true },
     { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "deps", "section": "Dependencies", "hidden": true },
     { "type": "style", "section": "Style", "hidden": true }
   ],
   "packages": {

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -726,11 +726,6 @@
       "reason": "Static marketing site; no test files exist."
     },
     {
-      "package": "@shepherdjerred/release-tools",
-      "directory": "packages/release-tools",
-      "reason": "Release Please wrapper package; no test files exist."
-    },
-    {
       "package": "@shepherdjerred/resume",
       "directory": "packages/resume",
       "reason": "LaTeX build artifact; no test files exist."

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -687,6 +687,15 @@
           "command": ["bash", "../.buildkite/scripts/toolchain.test.sh"]
         }
       ]
+    },
+    {
+      "package": "@shepherdjerred/release-tools",
+      "directory": "packages/release-tools",
+      "steps": [
+        {
+          "runner": "vitest"
+        }
+      ]
     }
   ],
   "testlessWorkspaces": [

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -716,11 +716,6 @@
       "reason": "Static marketing site; no test files exist."
     },
     {
-      "package": "@shepherdjerred/release-tools",
-      "directory": "packages/release-tools",
-      "reason": "Release Please wrapper package; no test files exist."
-    },
-    {
       "package": "@shepherdjerred/resume",
       "directory": "packages/resume",
       "reason": "LaTeX build artifact; no test files exist."

--- a/scripts/compliance-check.ts
+++ b/scripts/compliance-check.ts
@@ -362,7 +362,6 @@ packages/scout-for-lol:typecheck
 packages/home-assistant:build
 packages/sjer.red:test
 packages/release-tools:build
-packages/release-tools:test
 packages/release-tools:lint
 packages/release-tools:typecheck
 packages/temporal:build

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 
 import {
   classifyConsumerChanges,
   classifyPackageRelease,
   classifyPackageReleaseRange,
+  fetchNpmPackageTags,
   NPM_PACKAGE_POLICIES,
   packageJsonHasConsumerChange,
 } from "./npm-release-eligibility.ts";
@@ -128,6 +129,10 @@ describe("consumer file classification", () => {
 });
 
 describe("historical release regressions", () => {
+  beforeAll(async () => {
+    await fetchNpmPackageTags(process.cwd());
+  });
+
   test("Webring analytics and TypeDoc-only releases are excluded", async () => {
     const policy = NPM_PACKAGE_POLICIES.find(
       (candidate) => candidate.name === "webring",

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -57,6 +57,28 @@ describe("package JSON consumer changes", () => {
     ).toBe(true);
   });
 
+  test("ignores JSON object key reordering", () => {
+    expect(
+      packageJsonHasConsumerChange(
+        JSON.stringify({
+          dependencies: { zod: "^4.0.0", hono: "^4.0.0" },
+          exports: {
+            ".": "./dist/index.js",
+            "./package.json": "./package.json",
+          },
+        }),
+        JSON.stringify({
+          exports: {
+            "./package.json": "./package.json",
+            ".": "./dist/index.js",
+          },
+          dependencies: { hono: "^4.0.0", zod: "^4.0.0" },
+        }),
+        "package.json",
+      ),
+    ).toBe(false);
+  });
+
   test("fails closed on malformed package metadata", () => {
     expect(() =>
       packageJsonHasConsumerChange("not-json", "{}", "package.json"),

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyConsumerChanges,
+  classifyPackageRelease,
+  classifyPackageReleaseRange,
+  NPM_PACKAGE_POLICIES,
+  packageJsonHasConsumerChange,
+} from "./npm-release-eligibility.ts";
+
+const webringPath = "packages/webring";
+const astroPath = "packages/astro-opengraph-images";
+
+describe("package JSON consumer changes", () => {
+  test("ignores development-only package metadata", () => {
+    expect(
+      packageJsonHasConsumerChange(
+        JSON.stringify({
+          version: "1.0.0",
+          scripts: { test: "bun test" },
+          devDependencies: { typescript: "^6.0.0" },
+          overrides: { zod: "^4.0.0" },
+        }),
+        JSON.stringify({
+          version: "1.0.1",
+          scripts: { test: "bun test --coverage" },
+          devDependencies: { typescript: "^7.0.0" },
+          overrides: { zod: "^4.1.0" },
+        }),
+        "package.json",
+      ),
+    ).toBe(false);
+  });
+
+  test("recognizes runtime and public metadata changes", () => {
+    expect(
+      packageJsonHasConsumerChange(
+        JSON.stringify({ dependencies: { zod: "^4.0.0" } }),
+        JSON.stringify({ dependencies: { zod: "^4.1.0" } }),
+        "package.json",
+      ),
+    ).toBe(true);
+    expect(
+      packageJsonHasConsumerChange(
+        JSON.stringify({ exports: { ".": "./dist/index.js" } }),
+        JSON.stringify({ exports: { ".": "./dist/main.js" } }),
+        "package.json",
+      ),
+    ).toBe(true);
+    expect(
+      packageJsonHasConsumerChange(
+        JSON.stringify({ peerDependencies: { astro: "^4.0.0" } }),
+        JSON.stringify({ peerDependencies: { astro: "^5.0.0" } }),
+        "package.json",
+      ),
+    ).toBe(true);
+  });
+
+  test("fails closed on malformed package metadata", () => {
+    expect(() =>
+      packageJsonHasConsumerChange("not-json", "{}", "package.json"),
+    ).toThrow("Could not parse package.json");
+  });
+
+  test("fails closed on an unknown package metadata key", () => {
+    expect(() =>
+      packageJsonHasConsumerChange(
+        JSON.stringify({ internalBuildMode: "old" }),
+        JSON.stringify({ internalBuildMode: "new" }),
+        "package.json",
+      ),
+    ).toThrow("Could not classify package metadata key");
+  });
+});
+
+describe("consumer file classification", () => {
+  test("recognizes source, README, and license changes", () => {
+    expect(
+      classifyConsumerChanges(
+        astroPath,
+        [
+          `${astroPath}/src/index.ts`,
+          `${astroPath}/README.md`,
+          `${astroPath}/LICENSE`,
+        ],
+        false,
+      ).eligible,
+    ).toBe(true);
+  });
+
+  test("ignores repository-only, tests, examples, and lockfiles", () => {
+    expect(
+      classifyConsumerChanges(
+        webringPath,
+        [
+          `${webringPath}/CHANGELOG.md`,
+          `${webringPath}/typedoc.json`,
+          `${webringPath}/posthog.js`,
+          `${webringPath}/bun.lock`,
+          `${webringPath}/src/index.test.ts`,
+          `${webringPath}/src/parser.spec.ts`,
+          `${webringPath}/src/testdata/rss.xml`,
+          `${webringPath}/examples/demo.ts`,
+          `${webringPath}/.github/workflows/ci.yml`,
+          `${webringPath}/tsconfig.json`,
+          `${webringPath}/eslint.config.ts`,
+        ],
+        false,
+      ).eligible,
+    ).toBe(false);
+  });
+
+  test("treats mixed internal and consumer changes as eligible", () => {
+    expect(
+      classifyConsumerChanges(
+        webringPath,
+        [`${webringPath}/typedoc.json`, `${webringPath}/src/index.ts`],
+        false,
+      ).eligible,
+    ).toBe(true);
+  });
+
+  test("fails closed on an unknown package file", () => {
+    expect(() =>
+      classifyConsumerChanges(astroPath, [`${astroPath}/unknown.yaml`], false),
+    ).toThrow("Could not classify changed file");
+  });
+});
+
+describe("historical release regressions", () => {
+  test("Webring analytics and TypeDoc-only releases are excluded", async () => {
+    const policy = NPM_PACKAGE_POLICIES.find(
+      (candidate) => candidate.name === "webring",
+    );
+    if (policy === undefined) throw new Error("Webring policy is missing");
+
+    const oneNine = await classifyPackageReleaseRange(
+      process.cwd(),
+      policy,
+      "webring-v1.8.0",
+      "webring-v1.9.0",
+    );
+    const oneTen = await classifyPackageReleaseRange(
+      process.cwd(),
+      policy,
+      "webring-v1.9.0",
+      "webring-v1.10.0",
+    );
+    expect(oneNine.eligible).toBe(false);
+    expect(oneTen.eligible).toBe(false);
+  });
+
+  test("Astro CI and devDependency-only release is excluded", async () => {
+    const policy = NPM_PACKAGE_POLICIES.find(
+      (candidate) => candidate.name === "astro-opengraph-images",
+    );
+    if (policy === undefined) throw new Error("Astro policy is missing");
+
+    const decision = await classifyPackageReleaseRange(
+      process.cwd(),
+      policy,
+      "astro-opengraph-images-v1.17.4",
+      "astro-opengraph-images-v1.18.0",
+    );
+    expect(decision.eligible).toBe(false);
+  });
+
+  test("missing release tags fail closed", async () => {
+    const policy = NPM_PACKAGE_POLICIES[0];
+    if (policy === undefined) throw new Error("Npm package policy is missing");
+
+    await expect(
+      classifyPackageRelease(process.cwd(), {
+        ...policy,
+        tagPrefix: "does-not-exist-v",
+      }),
+    ).rejects.toThrow("No release tag found");
+  });
+});

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 
 import {
   classifyConsumerChanges,

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -160,6 +160,7 @@ function isKnownRepositoryOnlyPath(relativePath: string): boolean {
     "CHANGELOG.md",
     "AGENTS.md",
     "README.md.tmpl",
+    ".gitignore",
     "_summary.md",
     "bun.lock",
     ".jscpd.json",
@@ -170,6 +171,7 @@ function isKnownRepositoryOnlyPath(relativePath: string): boolean {
     "generate-readme-smoke.test.ts",
     "generate-readme.ts",
     "matomo.js",
+    "mise.toml",
     "plausible.js",
     "posthog.js",
     "tsconfig.scripts.json",
@@ -214,6 +216,19 @@ export function classifyConsumerChanges(
     );
   }
   return { eligible: reasons.length > 0, reasons };
+}
+
+export async function fetchNpmPackageTags(
+  root: string,
+  env: Record<string, string> = {},
+): Promise<void> {
+  for (const policy of NPM_PACKAGE_POLICIES) {
+    const tagRef = `refs/tags/${policy.tagPrefix}*`;
+    await run(["git", "fetch", "--no-tags", "origin", `${tagRef}:${tagRef}`], {
+      cwd: root,
+      env,
+    });
+  }
 }
 
 async function latestTag(

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -109,10 +109,6 @@ function parsePackageJson(contents: string, source: string): JsonObject {
   return JsonObjectSchema.parse(parsed);
 }
 
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function jsonValuesEqual(left: unknown, right: unknown): boolean {
   if (Object.is(left, right)) return true;
   if (Array.isArray(left) && Array.isArray(right)) {
@@ -121,14 +117,17 @@ function jsonValuesEqual(left: unknown, right: unknown): boolean {
       left.every((value, index) => jsonValuesEqual(value, right[index]))
     );
   }
-  if (isJsonObject(left) && isJsonObject(right)) {
-    const leftKeys = Object.keys(left);
-    const rightKeys = Object.keys(right);
+  const leftObject = JsonObjectSchema.safeParse(left);
+  const rightObject = JsonObjectSchema.safeParse(right);
+  if (leftObject.success && rightObject.success) {
+    const leftKeys = Object.keys(leftObject.data);
+    const rightKeys = Object.keys(rightObject.data);
     return (
       leftKeys.length === rightKeys.length &&
       leftKeys.every(
         (key) =>
-          Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key]),
+          Object.hasOwn(rightObject.data, key) &&
+          jsonValuesEqual(leftObject.data[key], rightObject.data[key]),
       )
     );
   }

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -109,8 +109,30 @@ function parsePackageJson(contents: string, source: string): JsonObject {
   return JsonObjectSchema.parse(parsed);
 }
 
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function jsonValuesEqual(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => jsonValuesEqual(value, right[index]))
+    );
+  }
+  if (isJsonObject(left) && isJsonObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key) =>
+          Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key]),
+      )
+    );
+  }
+  return false;
 }
 
 export function packageJsonHasConsumerChange(
@@ -231,6 +253,49 @@ export async function fetchNpmPackageTags(
   }
 }
 
+export async function fetchReleaseTarget(
+  root: string,
+  env: Record<string, string> = {},
+  branch = "main",
+): Promise<string> {
+  const remoteRef = `refs/heads/${branch}`;
+  const remote = await run(["git", "ls-remote", "origin", remoteRef], {
+    cwd: root,
+    env,
+    capture: true,
+    echoCapturedStdout: false,
+  });
+  const remoteSha = remote.stdout
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/)[0])
+    .find((value) => value !== undefined && /^[0-9a-f]{40}$/.test(value));
+  if (remoteSha === undefined) {
+    throw new Error(`Could not resolve origin/${branch} for release preflight`);
+  }
+
+  const localRef = `refs/remotes/origin/${branch}`;
+  await run(
+    ["git", "fetch", "--no-tags", "origin", `${remoteRef}:${localRef}`],
+    {
+      cwd: root,
+      env,
+    },
+  );
+  const local = await run(["git", "rev-parse", localRef], {
+    cwd: root,
+    capture: true,
+    echoCapturedStdout: false,
+  });
+  const localSha = local.stdout.trim();
+  if (localSha !== remoteSha) {
+    throw new Error(
+      `origin/${branch} moved while release preflight fetched it ` +
+        `(${remoteSha} -> ${localSha}); retry the release lane`,
+    );
+  }
+  return remoteSha;
+}
+
 async function latestTag(
   root: string,
   policy: NpmPackagePolicy,
@@ -323,8 +388,16 @@ export async function classifyPackageReleaseRange(
 
 export async function classifyAllPackageReleases(
   root: string,
+  headRef = "HEAD",
 ): Promise<readonly PackageReleaseDecision[]> {
   return Promise.all(
-    NPM_PACKAGE_POLICIES.map((policy) => classifyPackageRelease(root, policy)),
+    NPM_PACKAGE_POLICIES.map(async (policy) =>
+      classifyPackageReleaseFromTag(
+        root,
+        policy,
+        await latestTag(root, policy),
+        headRef,
+      ),
+    ),
   );
 }

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -1,0 +1,315 @@
+import { run } from "./run.ts";
+import { z } from "zod";
+
+export type NpmPackagePolicy = {
+  readonly name: string;
+  readonly path: string;
+  readonly packageJsonPath: string;
+  readonly tagPrefix: string;
+};
+
+export const NPM_PACKAGE_POLICIES: readonly NpmPackagePolicy[] = [
+  {
+    name: "astro-opengraph-images",
+    path: "packages/astro-opengraph-images",
+    packageJsonPath: "packages/astro-opengraph-images/package.json",
+    tagPrefix: "astro-opengraph-images-v",
+  },
+  {
+    name: "webring",
+    path: "packages/webring",
+    packageJsonPath: "packages/webring/package.json",
+    tagPrefix: "webring-v",
+  },
+  {
+    name: "@shepherdjerred/helm-types",
+    path: "packages/homelab/src/helm-types",
+    packageJsonPath: "packages/homelab/src/helm-types/package.json",
+    tagPrefix: "helm-types-v",
+  },
+];
+
+export type ConsumerChangeResult = {
+  readonly eligible: boolean;
+  readonly reasons: readonly string[];
+};
+
+export type PackageReleaseDecision = ConsumerChangeResult & {
+  readonly packageName: string;
+  readonly packagePath: string;
+  readonly latestTag: string;
+  readonly changedFiles: readonly string[];
+};
+
+type JsonObject = Record<string, unknown>;
+
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+const IGNORED_PACKAGE_JSON_KEYS = new Set([
+  "devDependencies",
+  "devEngines",
+  "overrides",
+  "packageManager",
+  "scripts",
+  "version",
+  "workspaces",
+]);
+
+const CONSUMER_PACKAGE_JSON_KEYS = new Set([
+  "author",
+  "bin",
+  "browser",
+  "bugs",
+  "bundledDependencies",
+  "bundleDependencies",
+  "config",
+  "contributors",
+  "cpu",
+  "dependencies",
+  "description",
+  "directories",
+  "engines",
+  "exports",
+  "files",
+  "funding",
+  "homepage",
+  "imports",
+  "keywords",
+  "libc",
+  "license",
+  "main",
+  "man",
+  "module",
+  "name",
+  "optionalDependencies",
+  "os",
+  "peerDependencies",
+  "peerDependenciesMeta",
+  "preferGlobal",
+  "private",
+  "publishConfig",
+  "repository",
+  "sideEffects",
+  "type",
+  "types",
+  "typings",
+  "typesVersions",
+]);
+
+function parsePackageJson(contents: string, source: string): JsonObject {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    throw new Error(
+      `Could not parse ${source}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  return JsonObjectSchema.parse(parsed);
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function packageJsonHasConsumerChange(
+  beforeContents: string,
+  afterContents: string,
+  source: string,
+): boolean {
+  const before = parsePackageJson(
+    beforeContents,
+    `${source} at the previous tag`,
+  );
+  const after = parsePackageJson(afterContents, `${source} at HEAD`);
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of keys) {
+    if (IGNORED_PACKAGE_JSON_KEYS.has(key)) continue;
+    if (!CONSUMER_PACKAGE_JSON_KEYS.has(key)) {
+      throw new Error(
+        `Could not classify package metadata key ${key} in ${source}`,
+      );
+    }
+    if (!jsonValuesEqual(before[key], after[key])) return true;
+  }
+  return false;
+}
+
+function relativePackagePath(file: string, packagePath: string): string {
+  const prefix = `${packagePath}/`;
+  if (!file.startsWith(prefix)) {
+    throw new Error(`Changed file ${file} is outside package ${packagePath}`);
+  }
+  return file.slice(prefix.length);
+}
+
+function isTestOrExamplePath(relativePath: string): boolean {
+  return (
+    /(?:^|\/)(?:[^/]+\.(?:test|spec)\.[^/]+|__tests__|__snapshots__|tests?|testdata|fixtures?|__fixtures__)(?:\/|$)/.test(
+      relativePath,
+    ) ||
+    relativePath.startsWith("examples/") ||
+    relativePath.startsWith("example/") ||
+    relativePath.startsWith("src/__fixtures__/")
+  );
+}
+
+function isKnownRepositoryOnlyPath(relativePath: string): boolean {
+  const exactPaths = new Set([
+    "CHANGELOG.md",
+    "AGENTS.md",
+    "README.md.tmpl",
+    "_summary.md",
+    "bun.lock",
+    ".jscpd.json",
+    ".npmignore",
+    "bunfig.toml",
+    "eslint.config.ts",
+    "generate-readme-core.ts",
+    "generate-readme-smoke.test.ts",
+    "generate-readme.ts",
+    "matomo.js",
+    "plausible.js",
+    "posthog.js",
+    "tsconfig.scripts.json",
+    "tsconfig.json",
+    "typedoc.json",
+  ]);
+  const prefixes = [".github/", ".vscode/", "assets/", "ci/", "scripts/"];
+  return (
+    exactPaths.has(relativePath) ||
+    prefixes.some((prefix) => relativePath.startsWith(prefix))
+  );
+}
+
+export function classifyConsumerChanges(
+  packagePath: string,
+  changedFiles: readonly string[],
+  packageJsonChange: boolean,
+): ConsumerChangeResult {
+  const reasons: string[] = [];
+  for (const file of changedFiles) {
+    const relativePath = relativePackagePath(file, packagePath);
+    if (relativePath === "package.json") {
+      if (packageJsonChange) reasons.push("public package metadata changed");
+      continue;
+    }
+    if (relativePath === "README.md") {
+      reasons.push("published README changed");
+      continue;
+    }
+    if (relativePath === "LICENSE") {
+      reasons.push("published license changed");
+      continue;
+    }
+    if (isTestOrExamplePath(relativePath)) continue;
+    if (isKnownRepositoryOnlyPath(relativePath)) continue;
+    if (relativePath.startsWith("src/") || relativePath.startsWith("dist/")) {
+      reasons.push(`published source changed: ${relativePath}`);
+      continue;
+    }
+    throw new Error(
+      `Could not classify changed file ${file} for npm package ${packagePath}`,
+    );
+  }
+  return { eligible: reasons.length > 0, reasons };
+}
+
+async function latestTag(
+  root: string,
+  policy: NpmPackagePolicy,
+): Promise<string> {
+  const result = await run(
+    ["git", "tag", "--list", `${policy.tagPrefix}*`, "--sort=-version:refname"],
+    { cwd: root, capture: true, echoCapturedStdout: false },
+  );
+  const tag = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (tag === undefined) {
+    throw new Error(
+      `No release tag found for ${policy.name} with prefix ${policy.tagPrefix}`,
+    );
+  }
+  return tag;
+}
+
+async function packageJsonAtTag(
+  root: string,
+  ref: string,
+  packageJsonPath: string,
+): Promise<string> {
+  const result = await run(["git", "show", `${ref}:${packageJsonPath}`], {
+    cwd: root,
+    capture: true,
+    echoCapturedStdout: false,
+  });
+  return result.stdout;
+}
+
+async function classifyPackageReleaseFromTag(
+  root: string,
+  policy: NpmPackagePolicy,
+  tag: string,
+  headRef = "HEAD",
+): Promise<PackageReleaseDecision> {
+  const changed = await run(
+    ["git", "diff", "--name-only", tag, headRef, "--", policy.path],
+    { cwd: root, capture: true, echoCapturedStdout: false },
+  );
+  const changedFiles = changed.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const packageJsonChange = changedFiles.includes(policy.packageJsonPath)
+    ? packageJsonHasConsumerChange(
+        await packageJsonAtTag(root, tag, policy.packageJsonPath),
+        await packageJsonAtTag(root, headRef, policy.packageJsonPath),
+        policy.packageJsonPath,
+      )
+    : false;
+
+  const result = classifyConsumerChanges(
+    policy.path,
+    changedFiles,
+    packageJsonChange,
+  );
+  return {
+    packageName: policy.name,
+    packagePath: policy.path,
+    latestTag: tag,
+    changedFiles,
+    ...result,
+  };
+}
+
+export async function classifyPackageRelease(
+  root: string,
+  policy: NpmPackagePolicy,
+): Promise<PackageReleaseDecision> {
+  return classifyPackageReleaseFromTag(
+    root,
+    policy,
+    await latestTag(root, policy),
+  );
+}
+
+export async function classifyPackageReleaseRange(
+  root: string,
+  policy: NpmPackagePolicy,
+  previousTag: string,
+  headRef: string,
+): Promise<PackageReleaseDecision> {
+  return classifyPackageReleaseFromTag(root, policy, previousTag, headRef);
+}
+
+export async function classifyAllPackageReleases(
+  root: string,
+): Promise<readonly PackageReleaseDecision[]> {
+  return Promise.all(
+    NPM_PACKAGE_POLICIES.map((policy) => classifyPackageRelease(root, policy)),
+  );
+}

--- a/scripts/lib/run.ts
+++ b/scripts/lib/run.ts
@@ -24,6 +24,8 @@ export type RunOptions = {
    * never appear in CI logs.
    */
   secret?: boolean;
+  /** When false (with capture), keep ordinary machine-readable output quiet. */
+  echoCapturedStdout?: boolean;
 };
 
 export type RunResult = {
@@ -104,7 +106,7 @@ export async function runAllowExit(
   const stdout = capture ? await new Response(proc.stdout).text() : "";
   const exitCode = await proc.exited;
   const stderr = await stderrTail;
-  if (capture && opts.secret !== true) {
+  if (capture && opts.secret !== true && opts.echoCapturedStdout !== false) {
     // Echo captured stdout so the operator still sees it in the terminal.
     // Suppressed when `secret` is set — used for secret-bearing output that
     // must never reach the log.

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,6 +14,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
     "@openai/codex-sdk": "0.147.0",
     "@shepherdjerred/code-review": "workspace:*",
+    "@shepherdjerred/release-tools": "workspace:*",
     "@shepherdjerred/version-catalog": "workspace:*",
     "fast-xml-builder": "1.3.0",
     "fast-xml-parser": "5.10.1",

--- a/scripts/prompts/refine-release-please.md
+++ b/scripts/prompts/refine-release-please.md
@@ -92,7 +92,14 @@ git diff --stat <last-tag>..origin/main -- <package-path>
 
 Read every non-trivial file change. Walk through the commits with `git log --oneline <last-tag>..origin/main -- <package-path>` to attribute changes accurately.
 
-### 5. Library-consumer filter — DROP these from the CHANGELOG
+### 5. Library-consumer filter — match the release eligibility preflight
+
+The release lane has already classified each package's diff. That classification
+is authoritative for whether a package is released. Your job is only to explain
+the eligible package's consumer-facing changes clearly; never reintroduce a
+filtered internal change because it appears in the raw Release Please notes.
+
+### 5a. DROP these from the CHANGELOG
 
 These ship as monorepo-internal churn or never reach the npm tarball at all:
 
@@ -111,7 +118,14 @@ These ship as monorepo-internal churn or never reach the npm tarball at all:
 - Runtime-dep changes in `dependencies` or `peerDependencies` (verify version diff via `git diff -- package.json`)
 - Source/behavior changes under `src/` (verify with `git diff -- src/`)
 - README content that ships in the npm tarball (`README.md`)
-- `package.json` metadata that ships: `repository`, `bugs`, `homepage`, `version`, `main`, `exports`, `files`, `type`
+- `package.json` metadata that ships: `repository`, `bugs`, `homepage`, `main`, `exports`, `files`, `type`
+
+The preflight also treats `optionalDependencies`, `peerDependenciesMeta`,
+`bin`, `types`, `engines`, `os`, `cpu`, `publishConfig`, and `license` as
+consumer-visible metadata. It ignores changes limited to `version`,
+`devDependencies`, `scripts`, or `overrides`. Any non-test source change is
+release-eligible even when it looks mechanical; do not make semantic guesses
+about whether it deserves a version.
 
 ### 6. Rewrite each new CHANGELOG section
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -24,6 +24,7 @@ import { requireEnv, run } from "./lib/run.ts";
 import { setupGitAuth } from "./lib/github-auth.ts";
 import {
   classifyAllPackageReleases,
+  NPM_PACKAGE_POLICIES,
   type PackageReleaseDecision,
 } from "./lib/npm-release-eligibility.ts";
 import { runReleaseRefiner } from "./lib/release-refiner.ts";
@@ -53,6 +54,19 @@ function repoRoot(): string {
   return new URL("..", import.meta.url).pathname;
 }
 
+async function fetchNpmPackageTags(
+  root: string,
+  env: Record<string, string>,
+): Promise<void> {
+  for (const policy of NPM_PACKAGE_POLICIES) {
+    const tagRef = `refs/tags/${policy.tagPrefix}*`;
+    await run(["git", "fetch", "--no-tags", "origin", `${tagRef}:${tagRef}`], {
+      cwd: root,
+      env,
+    });
+  }
+}
+
 function usage(): never {
   console.error("Usage: bun scripts/release.ts [--dry-run]");
   process.exit(1);
@@ -78,26 +92,30 @@ async function main(): Promise<void> {
   }
 
   const root = repoRoot();
-  const releaseDecisions = await classifyAllPackageReleases(root);
-  printReleaseDecisions(releaseDecisions);
-  const excludedPaths = releaseDecisions
-    .filter((decision) => !decision.eligible)
-    .map((decision) => decision.packagePath);
-
-  // Validate both providers before release-please mutates the release PR.
-  // Codex is an intentional quota fallback, not an optional best-effort path.
-  const claudeToken = requireEnv("CLAUDE_CODE_OAUTH_TOKEN");
-  const codexAccessToken = requireEnv("CODEX_ACCESS_TOKEN");
-  // Codex runs tool calls through a login shell. Verify that exact boundary,
-  // not only this process's mise-aware PATH, before release-please mutates a PR.
-  await run(["/bin/bash", "-lc", "gh --version"], {
-    cwd: root,
-    capture: true,
-  });
   const auth = await setupGitAuth(root);
   const env = auth.env;
 
   try {
+    // The canonical Buildkite checkout intentionally uses --no-tags. Fetch the
+    // authoritative package tags before the fail-closed eligibility preflight.
+    await fetchNpmPackageTags(root, env);
+    const releaseDecisions = await classifyAllPackageReleases(root);
+    printReleaseDecisions(releaseDecisions);
+    const excludedPaths = releaseDecisions
+      .filter((decision) => !decision.eligible)
+      .map((decision) => decision.packagePath);
+
+    // Validate both providers before release-please mutates the release PR.
+    // Codex is an intentional quota fallback, not an optional best-effort path.
+    const claudeToken = requireEnv("CLAUDE_CODE_OAUTH_TOKEN");
+    const codexAccessToken = requireEnv("CODEX_ACCESS_TOKEN");
+    // Codex runs tool calls through a login shell. Verify that exact boundary,
+    // not only this process's mise-aware PATH, before release-please mutates a PR.
+    await run(["/bin/bash", "-lc", "gh --version"], {
+      cwd: root,
+      capture: true,
+    });
+
     await runReleasePlease({
       phase: "release-pr",
       token: auth.token,

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -24,7 +24,7 @@ import { requireEnv, run } from "./lib/run.ts";
 import { setupGitAuth } from "./lib/github-auth.ts";
 import {
   classifyAllPackageReleases,
-  NPM_PACKAGE_POLICIES,
+  fetchNpmPackageTags,
   type PackageReleaseDecision,
 } from "./lib/npm-release-eligibility.ts";
 import { runReleaseRefiner } from "./lib/release-refiner.ts";
@@ -52,19 +52,6 @@ function printReleaseDecisions(
 /** Repo root = one level up from scripts/. */
 function repoRoot(): string {
   return new URL("..", import.meta.url).pathname;
-}
-
-async function fetchNpmPackageTags(
-  root: string,
-  env: Record<string, string>,
-): Promise<void> {
-  for (const policy of NPM_PACKAGE_POLICIES) {
-    const tagRef = `refs/tags/${policy.tagPrefix}*`;
-    await run(["git", "fetch", "--no-tags", "origin", `${tagRef}:${tagRef}`], {
-      cwd: root,
-      env,
-    });
-  }
 }
 
 function usage(): never {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -25,6 +25,7 @@ import { setupGitAuth } from "./lib/github-auth.ts";
 import {
   classifyAllPackageReleases,
   fetchNpmPackageTags,
+  fetchReleaseTarget,
   type PackageReleaseDecision,
 } from "./lib/npm-release-eligibility.ts";
 import { runReleaseRefiner } from "./lib/release-refiner.ts";
@@ -86,7 +87,11 @@ async function main(): Promise<void> {
     // The canonical Buildkite checkout intentionally uses --no-tags. Fetch the
     // authoritative package tags before the fail-closed eligibility preflight.
     await fetchNpmPackageTags(root, env);
-    const releaseDecisions = await classifyAllPackageReleases(root);
+    const targetBranchSha = await fetchReleaseTarget(root, env);
+    const releaseDecisions = await classifyAllPackageReleases(
+      root,
+      "refs/remotes/origin/main",
+    );
     printReleaseDecisions(releaseDecisions);
     const excludedPaths = releaseDecisions
       .filter((decision) => !decision.eligible)
@@ -108,6 +113,7 @@ async function main(): Promise<void> {
       token: auth.token,
       repoUrl: `https://github.com/${MONOREPO_REPO}.git`,
       targetBranch: "main",
+      targetBranchSha,
       excludedPaths,
     });
 
@@ -139,6 +145,7 @@ async function main(): Promise<void> {
       token: auth.token,
       repoUrl: `https://github.com/${MONOREPO_REPO}.git`,
       targetBranch: "main",
+      targetBranchSha,
       excludedPaths,
     });
     console.log("--- release-please complete");

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -22,10 +22,31 @@
 
 import { requireEnv, run } from "./lib/run.ts";
 import { setupGitAuth } from "./lib/github-auth.ts";
+import {
+  classifyAllPackageReleases,
+  type PackageReleaseDecision,
+} from "./lib/npm-release-eligibility.ts";
 import { runReleaseRefiner } from "./lib/release-refiner.ts";
 import { runMain } from "./lib/transient.ts";
+import { runReleasePlease } from "@shepherdjerred/release-tools/runner";
 
 const MONOREPO_REPO = "shepherdjerred/monorepo";
+
+function printReleaseDecisions(
+  decisions: readonly PackageReleaseDecision[],
+): void {
+  for (const decision of decisions) {
+    const state = decision.eligible ? "eligible" : "excluded";
+    const reason =
+      decision.reasons.length === 0
+        ? "no consumer-facing changes"
+        : decision.reasons.join("; ");
+    console.log(
+      `--- npm release policy: ${decision.packageName} ${state} ` +
+        `(since ${decision.latestTag}; ${reason})`,
+    );
+  }
+}
 
 /** Repo root = one level up from scripts/. */
 function repoRoot(): string {
@@ -57,6 +78,12 @@ async function main(): Promise<void> {
   }
 
   const root = repoRoot();
+  const releaseDecisions = await classifyAllPackageReleases(root);
+  printReleaseDecisions(releaseDecisions);
+  const excludedPaths = releaseDecisions
+    .filter((decision) => !decision.eligible)
+    .map((decision) => decision.packagePath);
+
   // Validate both providers before release-please mutates the release PR.
   // Codex is an intentional quota fallback, not an optional best-effort path.
   const claudeToken = requireEnv("CLAUDE_CODE_OAUTH_TOKEN");
@@ -71,26 +98,13 @@ async function main(): Promise<void> {
   const env = auth.env;
 
   try {
-    // release-please takes the token via --token; it does not need git askpass.
-    const releasePlease = (subcommand: string) =>
-      run(
-        [
-          "bun",
-          "--no-install",
-          "run",
-          "--cwd",
-          "packages/release-tools",
-          "release-please",
-          "--",
-          subcommand,
-          `--token=${auth.token}`,
-          `--repo-url=${MONOREPO_REPO}`,
-          "--target-branch=main",
-        ],
-        { cwd: root, env },
-      );
-
-    await releasePlease("release-pr");
+    await runReleasePlease({
+      phase: "release-pr",
+      token: auth.token,
+      repoUrl: `https://github.com/${MONOREPO_REPO}.git`,
+      targetBranch: "main",
+      excludedPaths,
+    });
 
     // Refine the just-generated CHANGELOGs. The prompt is the source of truth
     // for the agent's behavior; it exits 0 with a status envelope when there
@@ -115,7 +129,13 @@ async function main(): Promise<void> {
     });
     console.log(`--- CHANGELOG refinement complete (provider=${provider})`);
 
-    await releasePlease("github-release");
+    await runReleasePlease({
+      phase: "github-release",
+      token: auth.token,
+      repoUrl: `https://github.com/${MONOREPO_REPO}.git`,
+      targetBranch: "main",
+      excludedPaths,
+    });
     console.log("--- release-please complete");
   } finally {
     await auth.cleanup();


### PR DESCRIPTION
Why:
Release Please was creating npm versions for repository-only churn, leaving noisy CHANGELOG entries and allowing stale release candidates to reach tagging.

What:
- Add a fail-closed consumer-impact preflight for Astro OpenGraph Images, Webring, and Helm Types.
- Run the pinned release-please library with in-memory component exclusions for the combined release PR and GitHub-release phases, rejecting ineligible stale candidates.
- Hide dependency and internal maintenance categories while aligning the CHANGELOG refiner with the authoritative preflight.
- Repair Astro README logo URLs and add regression coverage for historical no-op release ranges.
- Add release-tools tests to Turbo and remove its stale no-tests CI exception.

Verification:
- bun install --frozen-lockfile
- bun test scripts/lib/npm-release-eligibility.test.ts packages/release-tools/runner.test.ts
- bunx turbo run build typecheck test lint --filter=webring --filter=astro-opengraph-images --filter=@shepherdjerred/helm-types
- bunx turbo run test --filter=@shepherdjerred/release-tools
- bunx turbo run typecheck --filter=@shepherdjerred/root-scripts
- bun scripts/compliance-check.ts
- Focused ESLint and Prettier checks passed.
- Replacement README URLs returned HTTP 200.
- Full bun run verify and live release/tagging were not run; existing versions and tags remain untouched.