### PR TITLE
fix(ci): ship the config and feature-flags sources into every image that reads flags

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -184,6 +184,11 @@ assets = "/tmp"
 enabled = false
 `;
 
+// `FEATURE_FLAGS_MODE: "disabled"` appears on every app that consumes
+// @shepherdjerred/feature-flags. The variable deliberately has no default, so a
+// service that reads flags cannot boot without one; `flipt` is unreachable from
+// an image build, and this harness only proves the process starts, so it opts
+// out explicitly rather than pretending a flag backend is there.
 const commands: Record<
   string,
   { readonly command: string; readonly env: Record<string, string> }
@@ -309,6 +314,7 @@ const commands: Record<
       APPLICATION_ID: "000000000000000000",
       DATA_DIR: "/tmp/smoke-data",
       DATABASE_PATH: "/tmp/smoke-data/karma.db",
+      FEATURE_FLAGS_MODE: "disabled",
     },
   },
   streambot: {
@@ -335,6 +341,7 @@ const commands: Record<
       USER_TOKENS: "smoke-test-dummy",
       ADMIN_IDS: "000000000000000000",
       VIDEOS_DIR: "/tmp/videos",
+      FEATURE_FLAGS_MODE: "disabled",
     },
   },
   "scout-evals": {
@@ -460,6 +467,7 @@ const commands: Record<
       ENABLE_BACKGROUND_JOBS: "false",
       REPORT_LAKE_DIR: "/tmp/report-lake",
       PORT: "18791",
+      FEATURE_FLAGS_MODE: "disabled",
     },
   },
   "discord-plays-pokemon": {

--- a/packages/scout-for-lol/packages/backend/Dockerfile
+++ b/packages/scout-for-lol/packages/backend/Dockerfile
@@ -69,6 +69,10 @@ FROM base AS runtime
 COPY --from=prod-deps /app/ /app/
 # Scoped source closure. Report Satori imports resolve through the shared
 # design-system package, which also owns the exact font and rank-crest bytes.
+# @shepherdjerred/config and @shepherdjerred/feature-flags export their
+# TypeScript source (`exports` points at `./src/index.ts`), so the workspace
+# symlink the production install creates is dangling without their sources here
+# and the backend dies at startup with `Cannot find module`.
 COPY --parents \
   tsconfig.base.json \
   packages/scout-for-lol/tsconfig.base.json \
@@ -79,6 +83,8 @@ COPY --parents \
   packages/llm-models \
   packages/llm-observability \
   packages/llm-runtime \
+  packages/config \
+  packages/feature-flags \
   ./
 # Bake the Prisma engines into the production tree. prod-deps installs
 # without lifecycle scripts, so @prisma/engines ships empty and the CLI

--- a/packages/starlight-karma-bot/Dockerfile
+++ b/packages/starlight-karma-bot/Dockerfile
@@ -53,11 +53,16 @@ FROM base AS runtime
 # so copying the whole install root between same-rooted stages is safe. Kept
 # BEFORE the source COPY so a source edit doesn't re-push this layer.
 COPY --from=prod-deps /app/ /app/
-# Scoped source closure (no runtime workspace deps); root tsconfig kept for
-# uniformity with the other app images.
+# Scoped source closure; root tsconfig kept for uniformity with the other app
+# images. @shepherdjerred/config and @shepherdjerred/feature-flags export their
+# TypeScript source (`exports` points at `./src/index.ts`), so the workspace
+# symlink the production install creates is dangling without their sources here
+# and the bot dies at startup with `Cannot find module`.
 COPY --parents \
   tsconfig.base.json \
   packages/starlight-karma-bot \
+  packages/config \
+  packages/feature-flags \
   ./
 # Bake Prisma's engines into the production dependency tree. Bun's production
 # install omits lifecycle scripts, so the CLI would otherwise download engines

--- a/packages/streambot/Dockerfile
+++ b/packages/streambot/Dockerfile
@@ -153,11 +153,17 @@ COPY --from=prod-deps /app/ /app/
 
 # Scoped source closure + the built dists from the build stage. The canonical
 # evaluation corpus is intentionally excluded from production layers.
+# @shepherdjerred/config and @shepherdjerred/feature-flags export their
+# TypeScript source (`exports` points at `./src/index.ts`), so the workspace
+# symlink the production install creates is dangling without their sources here
+# and the bot dies at startup with `Cannot find module`.
 COPY --exclude=packages/streambot/test/fixtures/voice-corpus --parents \
   tsconfig.base.json \
   packages/streambot \
   packages/discord-stream-lifecycle \
   packages/discord-video-stream \
+  packages/config \
+  packages/feature-flags \
   ./
 COPY --from=build /app/packages/discord-stream-lifecycle/dist packages/discord-stream-lifecycle/dist
 COPY --from=build /app/packages/discord-video-stream/dist packages/discord-video-stream/dist


### PR DESCRIPTION
## Why

[#2314](https://github.com/shepherdjerred/monorepo/pull/2314) added `@shepherdjerred/config` and `@shepherdjerred/feature-flags` as workspace dependencies of `starlight-karma-bot`, `streambot`, and the Scout backend. All three runtime stages build a **scoped source closure** — they copy only the package directories they name — and none of them were updated. Both new packages point `exports` at `./src/index.ts`, so the production install creates a workspace symlink into a directory the image never received:

```
[App] fatal error: uncaughtException error: Cannot find module '@shepherdjerred/config' from '/app/packages/starlight-karma-bot/src/config.ts'
```

That fails the `images — build, smoke, push` step. `images` gates `version commit-back`, and `cancel_on_build_failing` kills it, so **no image pin has been promoted to the version catalog since #2314 merged** — every service is stuck on a pre-merge image.

`FEATURE_FLAGS_MODE` compounds it. It deliberately has no default ("a service that silently served call-site defaults would look healthy while ignoring every flag"), so once the module resolves, an app that reads flags still cannot boot without one.

## What

- Add `packages/config` and `packages/feature-flags` to the runtime source closure of the three affected Dockerfiles.
- Set `FEATURE_FLAGS_MODE=disabled` for those apps in `smoke-app-in-image.ts`. `flipt` is unreachable from an image build and the harness only proves the process boots, so it opts out explicitly rather than pretending a flag backend is there.

Only the three images that consume the packages change; nothing else gains a layer.

## Verification

- `docker buildx build --target smoke --platform linux/arm64` against all three Dockerfiles — `starlight-karma-bot`, `scout-for-lol`, and `streambot` smokes pass. `starlight-karma-bot` reproduced the exact CI failure before the change and passes after, and the second failure (`FEATURE_FLAGS_MODE is required`) was surfaced and fixed by the same local loop.
- `bunx turbo run typecheck lint --filter=@shepherdjerred/root-scripts` — 0 errors.
- `bunx prettier --check .buildkite/scripts/smoke-app-in-image.ts` — clean.

No user-visible surface changes, so no media artifact.