### PR TITLE
fix(deps): stop invalid Renovate registry lookups

### DIFF
--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1355,7 +1355,8 @@
         "managed": true,
         "datasource": "docker",
         "registryUrl": "https://docker.io",
-        "versioning": "semver"
+        "versioning": "semver",
+        "packageName": "flipt/flipt"
       },
       "value": "v2.11.0@sha256:d20384874048ef6ac326f4937cee64f1db175a1878a87db32916cc8db46c740e",
       "notes": [

--- a/renovate.json
+++ b/renovate.json
@@ -257,6 +257,12 @@
       "matchDatasources": ["terraform-provider"],
       "matchPackageNames": ["hashicorp/aws"],
       "skipArtifactsUpdate": true
+    },
+    {
+      "description": "The repository-owned AsusWRT provider is built and installed from packages/terraform-provider-asuswrt; it is intentionally not published to a provider registry.",
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": ["shepherdjerred/asuswrt"],
+      "enabled": false
     }
   ],
   "minimumReleaseAge": "30 days",

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -14,6 +14,7 @@ const RenovateConfigSchema = z.object({
   packageRules: z.array(
     z.object({
       description: z.string().optional(),
+      matchDatasources: z.array(z.string()).optional(),
       matchFileNames: z.array(z.string()).optional(),
       matchDepNames: z.array(z.string()).optional(),
       matchManagers: z.array(z.string()).optional(),
@@ -81,6 +82,12 @@ test("extracts every managed structured version-catalog field", async () => {
   });
 
   expect(actual).toEqual(expected);
+  expect(actual).toContainEqual(
+    expect.objectContaining({
+      depName: "flipt-io/flipt",
+      packageName: "flipt/flipt",
+    }),
+  );
 });
 
 test("excludes all sandbox dependency files", async () => {
@@ -98,6 +105,25 @@ test("excludes all sandbox dependency files", async () => {
     description:
       "Sandbox is personal scratch space outside maintained dependency automation",
     matchFileNames: ["sandbox/**"],
+    enabled: false,
+  });
+});
+
+test("does not query a registry for the repository-owned AsusWRT provider", async () => {
+  const config = RenovateConfigSchema.parse(
+    await Bun.file(`${root}/renovate.json`).json(),
+  );
+  const rule = config.packageRules.find(
+    (candidate) =>
+      candidate.description ===
+      "The repository-owned AsusWRT provider is built and installed from packages/terraform-provider-asuswrt; it is intentionally not published to a provider registry.",
+  );
+
+  expect(rule).toEqual({
+    description:
+      "The repository-owned AsusWRT provider is built and installed from packages/terraform-provider-asuswrt; it is intentionally not published to a provider registry.",
+    matchDatasources: ["terraform-provider"],
+    matchPackageNames: ["shepherdjerred/asuswrt"],
     enabled: false,
   });
 });


### PR DESCRIPTION
## Why

Dependency Dashboard #481 reports permanent lookup failures for two dependencies whose extracted identities do not match an authoritative registry: the repository-owned AsusWRT provider is intentionally unpublished, and the stable Flipt catalog key is not the Docker Hub repository name.

The third warning, github.com/hashicorp/terraform-plugin-framework, resolves successfully at v1.19.0 from the Go module proxy, so suppressing it would hide valid future updates.

## What

- Disable Renovate lookup for shepherdjerred/asuswrt while preserving the OpenTofu source address used by the locally installed provider.
- Map the stable flipt-io/flipt catalog key to the actual flipt/flipt Docker repository through packageName.
- Add regression assertions for both Renovate declarations.

## Verification

- bun --no-install --bun vitest --config vitest.config.ts run scripts/renovate-config.test.ts
- bunx turbo run build typecheck test lint --filter=@shepherdjerred/version-catalog
- cd packages/terraform-provider-asuswrt && go test ./... && go vet ./... && go mod tidy -diff && go mod verify
- bunx --package renovate renovate-config-validator renovate.json
- bunx lefthook run pre-commit

Live Renovate rerun was not triggered. The dashboard should drop the AsusWRT and Flipt failures after this change reaches main and Renovate runs again; the valid Go module warning should be rechecked rather than suppressed.