### PR TITLE
chore(homelab): promote Karma metrics image to production

### DIFF
--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -696,7 +696,7 @@
         "versioning": "semver",
         "packageName": "shepherdjerred/starlight-karma-bot"
       },
-      "value": "2.0.0-9414@sha256:e162c7086de402321f7b076ac580e220257d280d3afa7c122836be7073468420"
+      "value": "2.0.0-10760@sha256:59ede53611cb036939bdce730c4b8341b159f41a9f774d719b6c03a2ad04f1f0"
     },
     {
       "name": "shepherdjerred/birmel",


### PR DESCRIPTION
Why: Production Starlight Karma is running 2.0.0-9414, whose server returns 404 for /metrics, so Prometheus records up=0. Beta 2.0.0-10760 serves the handler and is the verified remediation.

What: Promote production to 2.0.0-10760@sha256:59ede53611cb036939bdce730c4b8341b159f41a9f774d719b6c03a2ad04f1f0 in the language-neutral version catalog. This is the exact immutable digest already running in beta.

Verification:
- GHCR manifest: 2.0.0-10760 resolves to sha256:59ede53611cb036939bdce730c4b8341b159f41a9f774d719b6c03a2ad04f1f0.
- Catalog tests: 4/4.
- Homelab versions/release tests: 10/10.
- Homelab typecheck: passed.
- Pre-commit hooks: passed.
- Live before promotion: prod /metrics HTTP 404 and Prometheus up=0; beta /metrics HTTP 200 and up=1.

Rollout: Merge this PR through the normal main release and ArgoCD workflow; no direct Kubernetes mutation was used.