### PR TITLE
fix(homelab): prevent false OpenRouter Broadcast outage alert

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -14,6 +14,17 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
   expect(serialized).toContain("OpenRouterBroadcastTargetDown");
 
   const rules = groups.flatMap(({ rules: groupRules }) => groupRules);
+
+  const targetDown = rules.find(
+    (rule) => rule?.alert === "OpenRouterBroadcastTargetDown",
+  );
+  expect(targetDown?.expr?.value).toContain(
+    'service="openrouter-broadca-openrouter-broadcast-ingest-service"',
+  );
+  expect(targetDown?.expr?.value).not.toContain(
+    'service="openrouter-broadcast-ingest-service"',
+  );
+
   for (const alertName of [
     "BirmelAdmissionClassifierErrors",
     "BirmelMemoryExtractionErrors",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -101,7 +101,7 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "OpenRouterBroadcastTargetDown",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'absent(up{namespace="openrouter-broadcast-ingest",service="openrouter-broadcast-ingest-service"}) or max(up{namespace="openrouter-broadcast-ingest",service="openrouter-broadcast-ingest-service"}) == 0',
+            'absent(up{namespace="openrouter-broadcast-ingest",service="openrouter-broadca-openrouter-broadcast-ingest-service"}) or max(up{namespace="openrouter-broadcast-ingest",service="openrouter-broadca-openrouter-broadcast-ingest-service"}) == 0',
           ),
           for: "5m",
           labels: { severity: "critical", category: "llm" },


### PR DESCRIPTION
Why:
OpenRouterBroadcastTargetDown matched the unprefixed Kubernetes Service name, while the live Prometheus target uses the CDK8s-generated name openrouter-broadca-openrouter-broadcast-ingest-service. This produced a critical alert during a healthy ingest scrape.

What:
- Update the alert expression to match the live generated service label.
- Add a regression assertion that rejects the stale unprefixed selector.

Verification:
- Focused cdk8s Vitest tests passed for the monitoring rule and Broadcast ingest manifests.
- ESLint and Prettier checks passed for both changed files.
- cdk8s typecheck passed via bunx turbo run typecheck --filter=@homelab/cdk8s.
- Live kubectl checks confirmed the Service endpoints and ingest pod readiness.
- Deployment was not performed; ArgoCD/GitOps will apply the change after merge.