### PR TITLE
docs(dotfiles): route observability queries through toolkit

### DIFF
--- a/packages/dotfiles/AGENTS.md
+++ b/packages/dotfiles/AGENTS.md
@@ -160,6 +160,12 @@ write boundary, and dated deep references.
 - **Never export `TEMPORAL_ADDRESS` globally.** `packages/temporal/scripts/*.ts`
   read it and fall back to localhost, so a global export silently retargets every
   "local" script at production. Use `temporal --profile homelab` instead.
+- **Use `toolkit` for observability queries.** Prefer `toolkit prom query`
+  for PromQL and the corresponding `toolkit grafana`, `toolkit loki`, or
+  `toolkit tempo` passthroughs for those services. This preserves the
+  configured datasource, authentication, and agent-friendly output. Use raw
+  HTTP only when troubleshooting the toolkit/transport itself or when no
+  toolkit command exists.
 - **`gcx` owns `~/.config/gcx/config.yaml`.** Chezmoi deliberately does not manage
   it: gcx migrates any inline token into the macOS Keychain and rewrites the file
   on first use. `run_onchange_after_configure-gcx.sh.tmpl` provisions the context


### PR DESCRIPTION
Why:
Make the user-level agent workflow consistently use the repository's configured toolkit boundary for observability queries. Raw HTTP bypassed that boundary during the Buildkite cache investigation.

What:
- Prefer toolkit prom query for PromQL.
- Prefer the corresponding toolkit grafana, toolkit loki, and toolkit tempo passthroughs for those services.
- Reserve raw HTTP for toolkit/transport troubleshooting or unsupported operations.

Verification:
- git diff --check -- packages/dotfiles/AGENTS.md
- bunx lefthook run pre-commit
- bun install --frozen-lockfile

This is a user-level instruction/source update; no deployment or full repository verification was run.