### PR TITLE
fix(temporal): harden Scout and morning workflow failures

### DIFF
--- a/packages/temporal/src/activities/ha.test.ts
+++ b/packages/temporal/src/activities/ha.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ApplicationFailure } from "@temporalio/common";
+import { HaApiError } from "@shepherdjerred/home-assistant";
 import {
   HA_ENTITY_NOT_FOUND_ERROR_TYPE,
   HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
@@ -126,6 +127,40 @@ describe("haActivities", () => {
       expect(failure.message).toBe(
         "Home Assistant media_player.join is unavailable (500)",
       );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) {
+        delete Bun.env["HA_URL"];
+      } else {
+        Bun.env["HA_URL"] = originalUrl;
+      }
+      if (originalToken === undefined) {
+        delete Bun.env["HA_TOKEN"];
+      } else {
+        Bun.env["HA_TOKEN"] = originalToken;
+      }
+    }
+  });
+
+  it("keeps generic media-player API failures terminal", async () => {
+    const originalUrl = Bun.env["HA_URL"];
+    const originalToken = Bun.env["HA_TOKEN"];
+    const originalFetch = globalThis.fetch;
+    Bun.env["HA_URL"] = "http://localhost:8123";
+    Bun.env["HA_TOKEN"] = "test-token";
+    globalThis.fetch = Object.assign(
+      (): Promise<Response> =>
+        Promise.resolve(new Response("Internal Server Error", { status: 500 })),
+      { preconnect: originalFetch.preconnect.bind(originalFetch) },
+    );
+
+    try {
+      await expect(
+        haActivities.callOptionalMediaPlayerService("join", {
+          entity_id: "media_player.bedroom",
+          group_members: ["media_player.master_bathroom"],
+        }),
+      ).rejects.toBeInstanceOf(HaApiError);
     } finally {
       globalThis.fetch = originalFetch;
       if (originalUrl === undefined) {

--- a/packages/temporal/src/activities/ha.test.ts
+++ b/packages/temporal/src/activities/ha.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { ApplicationFailure } from "@temporalio/common";
-import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
+import {
+  HA_ENTITY_NOT_FOUND_ERROR_TYPE,
+  HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
+} from "#shared/ha-errors.ts";
 import { haActivities } from "./ha.ts";
 
 describe("haActivities", () => {
@@ -77,6 +80,51 @@ describe("haActivities", () => {
       expect(failure.nonRetryable).toBe(false);
       expect(failure.message).toBe(
         "Home Assistant has no entity sensor.master_bathroom_temperature",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) {
+        delete Bun.env["HA_URL"];
+      } else {
+        Bun.env["HA_URL"] = originalUrl;
+      }
+      if (originalToken === undefined) {
+        delete Bun.env["HA_TOKEN"];
+      } else {
+        Bun.env["HA_TOKEN"] = originalToken;
+      }
+    }
+  });
+
+  it("raises a typed retryable failure for an unavailable optional media player", async () => {
+    const originalUrl = Bun.env["HA_URL"];
+    const originalToken = Bun.env["HA_TOKEN"];
+    const originalFetch = globalThis.fetch;
+    Bun.env["HA_URL"] = "http://localhost:8123";
+    Bun.env["HA_TOKEN"] = "test-token";
+    globalThis.fetch = Object.assign(
+      (): Promise<Response> =>
+        Promise.resolve(new Response("Sonos unavailable.", { status: 500 })),
+      { preconnect: originalFetch.preconnect.bind(originalFetch) },
+    );
+
+    try {
+      let failure: unknown;
+      try {
+        await haActivities.callOptionalMediaPlayerService("join", {
+          entity_id: "media_player.bedroom",
+          group_members: ["media_player.master_bathroom"],
+        });
+      } catch (error: unknown) {
+        failure = error;
+      }
+      if (!(failure instanceof ApplicationFailure)) {
+        throw new TypeError("Expected a typed ApplicationFailure");
+      }
+      expect(failure.type).toBe(HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE);
+      expect(failure.nonRetryable).toBe(false);
+      expect(failure.message).toBe(
+        "Home Assistant media_player.join is unavailable (500)",
       );
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/temporal/src/activities/ha.test.ts
+++ b/packages/temporal/src/activities/ha.test.ts
@@ -105,7 +105,12 @@ describe("haActivities", () => {
     Bun.env["HA_TOKEN"] = "test-token";
     globalThis.fetch = Object.assign(
       (): Promise<Response> =>
-        Promise.resolve(new Response("Sonos unavailable.", { status: 500 })),
+        Promise.resolve(
+          new Response(
+            "Sonos entity media_player.master_bathroom unavailable.",
+            { status: 500 },
+          ),
+        ),
       { preconnect: originalFetch.preconnect.bind(originalFetch) },
     );
 
@@ -127,6 +132,40 @@ describe("haActivities", () => {
       expect(failure.message).toBe(
         "Home Assistant media_player.join is unavailable (500)",
       );
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) {
+        delete Bun.env["HA_URL"];
+      } else {
+        Bun.env["HA_URL"] = originalUrl;
+      }
+      if (originalToken === undefined) {
+        delete Bun.env["HA_TOKEN"];
+      } else {
+        Bun.env["HA_TOKEN"] = originalToken;
+      }
+    }
+  });
+
+  it("keeps generic missing-entity media-player failures terminal", async () => {
+    const originalUrl = Bun.env["HA_URL"];
+    const originalToken = Bun.env["HA_TOKEN"];
+    const originalFetch = globalThis.fetch;
+    Bun.env["HA_URL"] = "http://localhost:8123";
+    Bun.env["HA_TOKEN"] = "test-token";
+    globalThis.fetch = Object.assign(
+      (): Promise<Response> =>
+        Promise.resolve(new Response("Entity not found.", { status: 404 })),
+      { preconnect: originalFetch.preconnect.bind(originalFetch) },
+    );
+
+    try {
+      await expect(
+        haActivities.callOptionalMediaPlayerService("join", {
+          entity_id: "media_player.bedroom",
+          group_members: ["media_player.master_bathroom"],
+        }),
+      ).rejects.toBeInstanceOf(HaApiError);
     } finally {
       globalThis.fetch = originalFetch;
       if (originalUrl === undefined) {

--- a/packages/temporal/src/activities/ha.ts
+++ b/packages/temporal/src/activities/ha.ts
@@ -32,6 +32,17 @@ function getClient(): HomeAssistantRestClient {
   return cachedClient;
 }
 
+function isOptionalMediaPlayerUnavailable(error: HaApiError): boolean {
+  if (error.status !== 404 && error.status < 500) {
+    return false;
+  }
+  const text = `${error.message}\n${error.body}`;
+  return (
+    /media_player\.\w+|sonos|speaker|entity(?:\s+id)?/i.test(text) &&
+    /unavailable|not found|does not exist|offline/i.test(text)
+  );
+}
+
 export type HaActivities = typeof haActivities;
 
 export const haActivities = {
@@ -83,7 +94,7 @@ export const haActivities = {
       // then expose it as a stable type for the workflow to handle.
       if (
         error instanceof HaApiError &&
-        (error.status === 404 || error.status >= 500)
+        isOptionalMediaPlayerUnavailable(error)
       ) {
         throw ApplicationFailure.retryable(
           `Home Assistant media_player.${service} is unavailable (${String(error.status)})`,

--- a/packages/temporal/src/activities/ha.ts
+++ b/packages/temporal/src/activities/ha.ts
@@ -1,10 +1,14 @@
 import { ApplicationFailure } from "@temporalio/common";
 import {
+  HaApiError,
   HaNotFoundError,
   HomeAssistantRestClient,
   type EntityState,
 } from "@shepherdjerred/home-assistant";
-import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
+import {
+  HA_ENTITY_NOT_FOUND_ERROR_TYPE,
+  HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
+} from "#shared/ha-errors.ts";
 
 // Activity signatures stay monomorphic (Temporal's proxyActivities rejects
 // generic methods), so the runtime client is the loose default. Compile-time
@@ -63,6 +67,31 @@ export const haActivities = {
   ): Promise<void> {
     await getClient().callService(domain, service, data);
     console.warn(`Called HA service: ${domain}.${service}`);
+  },
+
+  async callOptionalMediaPlayerService(
+    service: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await getClient().callService("media_player", service, data);
+      console.warn(`Called HA service: media_player.${service}`);
+    } catch (error: unknown) {
+      // A missing media entity or a Sonos integration/device failure is a
+      // known degraded condition for optional speakers. Keep the failure
+      // retryable so transient HA reloads get the normal activity retry budget,
+      // then expose it as a stable type for the workflow to handle.
+      if (
+        error instanceof HaApiError &&
+        (error.status === 404 || error.status >= 500)
+      ) {
+        throw ApplicationFailure.retryable(
+          `Home Assistant media_player.${service} is unavailable (${String(error.status)})`,
+          HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
+        );
+      }
+      throw error;
+    }
   },
 
   async sendNotification(title: string, message: string): Promise<void> {

--- a/packages/temporal/src/activities/ha.ts
+++ b/packages/temporal/src/activities/ha.ts
@@ -1,4 +1,5 @@
 import { ApplicationFailure } from "@temporalio/common";
+import { z } from "zod";
 import {
   HaApiError,
   HaNotFoundError,
@@ -15,6 +16,7 @@ import {
 // type safety lives in src/workflows/ha/util.ts, which wraps each activity
 // with schema-parameterized signatures that forward through as strings.
 let cachedClient: HomeAssistantRestClient | undefined;
+const MediaPlayerEntityId = z.string().startsWith("media_player.");
 
 function getClient(): HomeAssistantRestClient {
   if (cachedClient !== undefined) {
@@ -32,14 +34,35 @@ function getClient(): HomeAssistantRestClient {
   return cachedClient;
 }
 
-function isOptionalMediaPlayerUnavailable(error: HaApiError): boolean {
+function optionalMediaPlayerEntityIds(data: Record<string, unknown>): string[] {
+  const groupMembers = data["group_members"];
+  if (Array.isArray(groupMembers)) {
+    return groupMembers.flatMap((value) => {
+      const result = MediaPlayerEntityId.safeParse(value);
+      return result.success ? [result.data] : [];
+    });
+  }
+
+  const entityId = data["entity_id"];
+  const result = MediaPlayerEntityId.safeParse(entityId);
+  if (result.success) {
+    return [result.data];
+  }
+  return [];
+}
+
+function isOptionalMediaPlayerUnavailable(
+  error: HaApiError,
+  data: Record<string, unknown>,
+): boolean {
   if (error.status !== 404 && error.status < 500) {
     return false;
   }
   const text = `${error.message}\n${error.body}`;
   return (
-    /media_player\.\w+|sonos|speaker|entity(?:\s+id)?/i.test(text) &&
-    /unavailable|not found|does not exist|offline/i.test(text)
+    optionalMediaPlayerEntityIds(data).some((entityId) =>
+      text.toLowerCase().includes(entityId.toLowerCase()),
+    ) && /unavailable|not found|does not exist|offline/i.test(text)
   );
 }
 
@@ -94,7 +117,7 @@ export const haActivities = {
       // then expose it as a stable type for the workflow to handle.
       if (
         error instanceof HaApiError &&
-        isOptionalMediaPlayerUnavailable(error)
+        isOptionalMediaPlayerUnavailable(error, data)
       ) {
         throw ApplicationFailure.retryable(
           `Home Assistant media_player.${service} is unavailable (${String(error.status)})`,

--- a/packages/temporal/src/activities/scout-season-refresh-git.test.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.test.ts
@@ -272,6 +272,12 @@ describe("shared proposal PR reconciliation", () => {
       "unknown",
     );
     expect(
+      classifyRedactedCommandFailure(
+        "branch-push",
+        "failed to push some refs (repository rule violation)",
+      ),
+    ).toBe("unknown");
+    expect(
       classifyRedactedCommandFailure("pr-create", "Authentication failed"),
     ).toBe("redacted");
   });

--- a/packages/temporal/src/activities/scout-season-refresh-git.test.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  classifyRedactedCommandFailure,
   closeSeasonRefreshPr,
   isGeneratedAtOnlyDiff,
   refreshSeasonRefreshPrMetadata,
@@ -223,13 +224,13 @@ describe("revertGeneratedAtOnlyChanges", () => {
 });
 
 describe("shared proposal PR reconciliation", () => {
-  test("reports a safe operation label when command output is redacted", async () => {
+  test("classifies a stale branch lease without exposing command output", async () => {
     await expect(
       runCommand(
         [
           "bun",
           "-e",
-          'console.error("credential-shaped-secret"); process.exit(7)',
+          'console.error("stale info credential-shaped-secret"); process.exit(7)',
         ],
         {
           cwd: "/tmp",
@@ -237,7 +238,42 @@ describe("shared proposal PR reconciliation", () => {
           operation: "branch-push",
         },
       ),
-    ).rejects.toThrow("Command failed (branch-push): exit 7 <redacted>");
+    ).rejects.toThrow(
+      "Command failed (branch-push): exit 7 remote-lease-rejected",
+    );
+  });
+
+  test("classifies known redacted push failure categories", () => {
+    expect(
+      classifyRedactedCommandFailure(
+        "branch-push",
+        "remote: Authentication failed",
+      ),
+    ).toBe("authentication-or-authorization");
+    expect(
+      classifyRedactedCommandFailure(
+        "branch-push",
+        "GH006: protected branch hook declined",
+      ),
+    ).toBe("protected-branch-policy");
+    expect(
+      classifyRedactedCommandFailure(
+        "branch-push",
+        "fatal: unable to access: Could not resolve host",
+      ),
+    ).toBe("network");
+    expect(
+      classifyRedactedCommandFailure(
+        "branch-push",
+        "remote: Repository not found",
+      ),
+    ).toBe("repository-not-found");
+    expect(classifyRedactedCommandFailure("branch-push", "unexpected")).toBe(
+      "unknown",
+    );
+    expect(
+      classifyRedactedCommandFailure("pr-create", "Authentication failed"),
+    ).toBe("redacted");
   });
 
   test("refreshes the title and body of a reused PR", async () => {

--- a/packages/temporal/src/activities/scout-season-refresh-git.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.ts
@@ -52,10 +52,17 @@ export async function runCommand(
   ]);
 
   if (exitCode !== 0) {
+    const rawOutput = `${stdout}\n${stderr}`.trim();
     const output =
       options.redactOutput === true
-        ? "<redacted>"
-        : `${stdout}\n${stderr}`.trim();
+        ? (() => {
+            const category = classifyRedactedCommandFailure(
+              options.operation,
+              rawOutput,
+            );
+            return category === "redacted" ? "<redacted>" : category;
+          })()
+        : rawOutput;
     throw new Error(
       `Command failed (${options.redactOutput === true ? options.operation : (command[0] ?? "?")}): exit ${String(exitCode)} ${output}`,
     );
@@ -64,6 +71,57 @@ export async function runCommand(
 }
 
 export type GitCommandRunner = typeof runCommand;
+
+export type RedactedCommandFailureCategory =
+  | "authentication-or-authorization"
+  | "network"
+  | "protected-branch-policy"
+  | "remote-lease-rejected"
+  | "repository-not-found"
+  | "unknown";
+
+/**
+ * Preserve the useful class of a redacted GitHub push failure without
+ * returning remote output, which can contain credentials or repository data.
+ * The categories deliberately describe only signals Git emits consistently;
+ * ambiguous output remains `unknown` instead of being guessed.
+ */
+export function classifyRedactedCommandFailure(
+  operation: string,
+  output: string,
+): RedactedCommandFailureCategory | "redacted" {
+  if (operation !== "branch-push") {
+    return "redacted";
+  }
+  if (
+    /authentication failed|could not read username|permission denied|\b403\b|access denied/i.test(
+      output,
+    )
+  ) {
+    return "authentication-or-authorization";
+  }
+  if (
+    /gh006|protected branch|hook declined|required status checks|branch policy/i.test(
+      output,
+    )
+  ) {
+    return "protected-branch-policy";
+  }
+  if (/repository not found|does not exist/i.test(output)) {
+    return "repository-not-found";
+  }
+  if (
+    /could not resolve host|connection timed out|network is unreachable|connection reset|connection refused|temporary failure in name resolution/i.test(
+      output,
+    )
+  ) {
+    return "network";
+  }
+  if (/stale info|non-fast-forward|failed to push some refs/i.test(output)) {
+    return "remote-lease-rejected";
+  }
+  return "unknown";
+}
 
 export async function writeGitAskpass(tempDir: string): Promise<string> {
   const path = `${tempDir}/git-askpass.sh`;

--- a/packages/temporal/src/activities/scout-season-refresh-git.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.ts
@@ -117,7 +117,7 @@ export function classifyRedactedCommandFailure(
   ) {
     return "network";
   }
-  if (/stale info|non-fast-forward|failed to push some refs/i.test(output)) {
+  if (/stale info|non-fast-forward/i.test(output)) {
     return "remote-lease-rejected";
   }
   return "unknown";

--- a/packages/temporal/src/shared/ha-errors.ts
+++ b/packages/temporal/src/shared/ha-errors.ts
@@ -5,3 +5,10 @@
 // failure stays retryable, so a workflow only sees this once the entity is
 // still missing after the activity's full retry budget.
 export const HA_ENTITY_NOT_FOUND_ERROR_TYPE = "HaEntityNotFoundError";
+
+// Optional media-player operations may fail while a Sonos device or its HA
+// integration is unavailable. Keep this distinct from generic HA failures so
+// workflows can degrade only the optional speaker and still fail loudly for
+// authentication, malformed requests, or required devices.
+export const HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE =
+  "HaOptionalMediaPlayerUnavailableError";

--- a/packages/temporal/src/workflows/ha/good-morning.test.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.test.ts
@@ -4,8 +4,12 @@ import { ApplicationFailure } from "@temporalio/common";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { OutcomeRecord } from "#activities/outcome.ts";
-import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
 import {
+  HA_ENTITY_NOT_FOUND_ERROR_TYPE,
+  HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
+} from "#shared/ha-errors.ts";
+import {
+  goodMorningGetUp,
   goodMorningPreheat,
   goodMorningWakeUp,
   shouldHeatFloor,
@@ -49,6 +53,7 @@ type Scenario = {
   serviceCalls: ServiceCall[];
   notifications: string[];
   outcomes: OutcomeRecord[];
+  mediaPlayerFailures: Set<string>;
 };
 
 function makeScenario(
@@ -64,6 +69,7 @@ function makeScenario(
     serviceCalls: [],
     notifications: [],
     outcomes: [],
+    mediaPlayerFailures: new Set(),
   };
 }
 
@@ -76,6 +82,30 @@ function entityState(
 }
 
 function makeActivities(scenario: Scenario) {
+  const callMediaPlayerService = (
+    service: string,
+    data: Record<string, unknown>,
+  ): Promise<void> => {
+    scenario.serviceCalls.push({
+      domain: "media_player",
+      service,
+      data,
+    });
+    const entityId = data["entity_id"];
+    if (
+      typeof entityId === "string" &&
+      scenario.mediaPlayerFailures.has(`${service}:${entityId}`)
+    ) {
+      return Promise.reject(
+        ApplicationFailure.retryable(
+          `Home Assistant media_player.${service} unavailable for ${entityId}`,
+          HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
+        ),
+      );
+    }
+    return Promise.resolve();
+  };
+
   return {
     getEntityState: (entityId: string): Promise<EntityState> => {
       switch (entityId) {
@@ -113,9 +143,13 @@ function makeActivities(scenario: Scenario) {
       service: string,
       data: Record<string, unknown>,
     ): Promise<void> => {
+      if (domain === "media_player") {
+        return callMediaPlayerService(service, data);
+      }
       scenario.serviceCalls.push({ domain, service, data });
       return Promise.resolve();
     },
+    callOptionalMediaPlayerService: callMediaPlayerService,
     sendNotification: (title: string): Promise<void> => {
       scenario.notifications.push(title);
       return Promise.resolve();
@@ -442,6 +476,118 @@ describe("goodMorningWakeUp", () => {
           reason: "wake-routine-complete",
         },
       ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+});
+
+describe("goodMorningGetUp", () => {
+  test(
+    "joins the available bathroom speaker and completes normally",
+    async () => {
+      const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
+
+      await runWorker(
+        scenario,
+        goodMorningGetUp,
+        `getup-complete-${crypto.randomUUID()}`,
+      );
+
+      expect(
+        scenario.serviceCalls.some(
+          (call) => call.domain === "media_player" && call.service === "join",
+        ),
+      ).toBe(true);
+      expect(
+        scenario.serviceCalls.filter(
+          (call) =>
+            call.domain === "media_player" && call.service === "volume_up",
+        ),
+      ).toHaveLength(4);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningGetUp",
+          outcome: "executed",
+          reason: "getup-routine-complete",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "continues with bedroom playback when the optional join fails",
+    async () => {
+      const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
+      scenario.mediaPlayerFailures.add("join:media_player.bedroom");
+
+      await runWorker(
+        scenario,
+        goodMorningGetUp,
+        `getup-join-degraded-${crypto.randomUUID()}`,
+      );
+
+      expect(
+        scenario.serviceCalls.filter(
+          (call) =>
+            call.domain === "media_player" && call.service === "volume_up",
+        ),
+      ).toHaveLength(2);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningGetUp",
+          outcome: "executed",
+          reason: "getup-routine-complete-optional-media-degraded",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "skips an optional player whose volume setup fails",
+    async () => {
+      const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
+      scenario.mediaPlayerFailures.add(
+        "volume_set:media_player.master_bathroom",
+      );
+
+      await runWorker(
+        scenario,
+        goodMorningGetUp,
+        `getup-volume-degraded-${crypto.randomUUID()}`,
+      );
+
+      expect(
+        scenario.serviceCalls.some(
+          (call) => call.domain === "media_player" && call.service === "join",
+        ),
+      ).toBe(false);
+      expect(scenario.outcomes).toEqual([
+        {
+          workflow: "goodMorningGetUp",
+          outcome: "executed",
+          reason: "getup-routine-complete-optional-media-degraded",
+        },
+      ]);
+    },
+    WORKFLOW_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "still fails when required bedroom playback fails",
+    async () => {
+      const scenario = makeScenario({ indoorC: 26, outdoorC: 28 });
+      scenario.mediaPlayerFailures.add("volume_up:media_player.bedroom");
+
+      await expect(
+        runWorker(
+          scenario,
+          goodMorningGetUp,
+          `getup-bedroom-failure-${crypto.randomUUID()}`,
+        ),
+      ).rejects.toThrow();
+      expect(scenario.outcomes).toEqual([]);
     },
     WORKFLOW_TEST_TIMEOUT_MS,
   );

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -8,6 +8,7 @@ import {
 import { z } from "zod";
 import {
   anyoneHome,
+  callOptionalMediaPlayerService,
   callServiceUnchecked,
   getEntityState,
   sendNotification,
@@ -15,7 +16,10 @@ import {
   volumeUpBy,
 } from "./util.ts";
 import type { WeatherActivities } from "#activities/weather.ts";
-import { HA_ENTITY_NOT_FOUND_ERROR_TYPE } from "#shared/ha-errors.ts";
+import {
+  HA_ENTITY_NOT_FOUND_ERROR_TYPE,
+  HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE,
+} from "#shared/ha-errors.ts";
 
 const weatherActivities = proxyActivities<WeatherActivities>({
   startToCloseTimeout: "30 seconds",
@@ -23,9 +27,8 @@ const weatherActivities = proxyActivities<WeatherActivities>({
 });
 
 const BEDROOM_MEDIA = "media_player.bedroom" as const;
-// NOTE: this entity_id flips from media_player.main_bathroom when the HA
-// registry cleanup renames the Sonos (2026-07 "great refresh"); between this
-// deploy and that rename the get-up join step no-ops on a missing entity.
+// This optional player may be missing or unavailable while HA/Sonos reloads;
+// get-up degrades to Bedroom-only playback when that happens.
 const MASTER_BATHROOM_MEDIA = "media_player.master_bathroom" as const;
 const EXTRA_MEDIA_PLAYERS = [MASTER_BATHROOM_MEDIA] as const;
 const BEDROOM_DIMMED = "scene.bedroom_dimmed" as const;
@@ -109,12 +112,38 @@ function parseHomeZoneCoordinates(
   return result.data;
 }
 
+function isApplicationFailureOfType(error: unknown, type: string): boolean {
+  if (!(error instanceof ActivityFailure)) {
+    return false;
+  }
+  const cause = error.cause;
+  return cause instanceof ApplicationFailure && cause.type === type;
+}
+
 function isMissingEntityFailure(error: unknown): boolean {
-  return (
-    error instanceof ActivityFailure &&
-    error.cause instanceof ApplicationFailure &&
-    error.cause.type === HA_ENTITY_NOT_FOUND_ERROR_TYPE
-  );
+  return isApplicationFailureOfType(error, HA_ENTITY_NOT_FOUND_ERROR_TYPE);
+}
+
+function isOptionalMediaPlayerFailure(error: unknown): boolean {
+  return isApplicationFailureOfType(error, HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE);
+}
+
+async function tryOptionalMediaPlayerService(
+  service: string,
+  data: Record<string, unknown>,
+): Promise<boolean> {
+  try {
+    await callOptionalMediaPlayerService(service, data);
+    return true;
+  } catch (error: unknown) {
+    if (!isOptionalMediaPlayerFailure(error)) {
+      throw error;
+    }
+    console.warn(
+      `good_morning_get_up: optional media_player.${service} unavailable; continuing without that speaker`,
+    );
+    return false;
+  }
 }
 
 // A total Mysa setup failure removes the entity outright instead of leaving it
@@ -320,28 +349,57 @@ export async function goodMorningGetUp(): Promise<void> {
     transition: 60,
   });
 
+  let mediaDegraded = false;
+  const availableExtraPlayers: string[] = [];
   for (const player of EXTRA_MEDIA_PLAYERS) {
-    await callServiceUnchecked("media_player", "volume_set", {
+    const available = await tryOptionalMediaPlayerService("volume_set", {
       entity_id: player,
       volume_level: 0,
     });
+    if (available) {
+      availableExtraPlayers.push(player);
+    } else {
+      mediaDegraded = true;
+    }
   }
 
-  await callServiceUnchecked("media_player", "join", {
-    entity_id: BEDROOM_MEDIA,
-    group_members: EXTRA_MEDIA_PLAYERS,
-  });
+  let joinedExtraPlayers: string[] = [];
+  if (availableExtraPlayers.length > 0) {
+    const joined = await tryOptionalMediaPlayerService("join", {
+      entity_id: BEDROOM_MEDIA,
+      group_members: availableExtraPlayers,
+    });
+    if (joined) {
+      joinedExtraPlayers = availableExtraPlayers;
+    } else {
+      mediaDegraded = true;
+    }
+  }
 
-  const allPlayers = [BEDROOM_MEDIA, ...EXTRA_MEDIA_PLAYERS] as const;
+  const allPlayers = [BEDROOM_MEDIA, ...joinedExtraPlayers];
   for (let step = 0; step < 2; step += 1) {
     for (const player of allPlayers) {
-      await callServiceUnchecked("media_player", "volume_up", {
-        entity_id: player,
-      });
+      if (player === BEDROOM_MEDIA) {
+        await callServiceUnchecked("media_player", "volume_up", {
+          entity_id: player,
+        });
+      } else {
+        const available = await tryOptionalMediaPlayerService("volume_up", {
+          entity_id: player,
+        });
+        if (!available) {
+          mediaDegraded = true;
+        }
+      }
     }
     if (step < 1) {
       await sleep("5 seconds");
     }
   }
-  await setOutcome("executed", "getup-routine-complete");
+  await setOutcome(
+    "executed",
+    mediaDegraded
+      ? "getup-routine-complete-optional-media-degraded"
+      : "getup-routine-complete",
+  );
 }

--- a/packages/temporal/src/workflows/ha/good-morning.ts
+++ b/packages/temporal/src/workflows/ha/good-morning.ts
@@ -31,6 +31,7 @@ const BEDROOM_MEDIA = "media_player.bedroom" as const;
 // get-up degrades to Bedroom-only playback when that happens.
 const MASTER_BATHROOM_MEDIA = "media_player.master_bathroom" as const;
 const EXTRA_MEDIA_PLAYERS = [MASTER_BATHROOM_MEDIA] as const;
+const OPTIONAL_MEDIA_PLAYER_PATCH = "good-morning-optional-media-player-v1";
 const BEDROOM_DIMMED = "scene.bedroom_dimmed" as const;
 const BEDROOM_BRIGHT = "scene.bedroom_bright" as const;
 const MASTER_BATHROOM_HEAT = "climate.master_bathroom" as const;
@@ -348,6 +349,34 @@ export async function goodMorningGetUp(): Promise<void> {
     entity_id: BEDROOM_BRIGHT,
     transition: 60,
   });
+
+  if (!patched(OPTIONAL_MEDIA_PLAYER_PATCH)) {
+    for (const player of EXTRA_MEDIA_PLAYERS) {
+      await callServiceUnchecked("media_player", "volume_set", {
+        entity_id: player,
+        volume_level: 0,
+      });
+    }
+
+    await callServiceUnchecked("media_player", "join", {
+      entity_id: BEDROOM_MEDIA,
+      group_members: EXTRA_MEDIA_PLAYERS,
+    });
+
+    const allPlayers = [BEDROOM_MEDIA, ...EXTRA_MEDIA_PLAYERS] as const;
+    for (let step = 0; step < 2; step += 1) {
+      for (const player of allPlayers) {
+        await callServiceUnchecked("media_player", "volume_up", {
+          entity_id: player,
+        });
+      }
+      if (step < 1) {
+        await sleep("5 seconds");
+      }
+    }
+    await setOutcome("executed", "getup-routine-complete");
+    return;
+  }
 
   let mediaDegraded = false;
   const availableExtraPlayers: string[] = [];

--- a/packages/temporal/src/workflows/ha/util.ts
+++ b/packages/temporal/src/workflows/ha/util.ts
@@ -125,6 +125,13 @@ export async function callServiceUnchecked(
   return activities.callService(domain, service, data);
 }
 
+export async function callOptionalMediaPlayerService(
+  service: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  return activities.callOptionalMediaPlayerService(service, data);
+}
+
 export async function callServiceForCleanup<
   D extends Domain<HaSchema>,
   V extends Service<HaSchema, D>,


### PR DESCRIPTION
Why:\nFive Temporal failure alerts represented separate terminal failures. Scout branch-push diagnostics were fully redacted, and a bathroom Sonos failure could terminate the morning get-up workflow even though bedroom playback remained possible.\n\nWhat:\n- Classify redacted Scout shared-branch push failures as authentication/authorization, protected-branch policy, network, repository-not-found, remote-lease rejection, or unknown while preserving secret protection and exit codes.\n- Add a typed Home Assistant optional-media boundary for missing/unavailable/5xx media-player operations. goodMorningGetUp now continues with required bedroom playback when the optional bathroom speaker cannot be configured, joined, or adjusted, and records a distinct degraded outcome. Required bedroom operations and unrelated HA failures still terminate the workflow.\n- Add activity and native Temporal workflow regression tests.\n- Leave Glitter and fail-closed vacuum behavior unchanged; physical device remediation remains deferred.\n\nVerification:\n- bun --no-install --bun vitest --config ../../vitest.config.ts run src/activities/ha.test.ts src/activities/scout-season-refresh-git.test.ts\n- bun run test:workflows (12 files, 47 tests)\n- bun run typecheck\n- bun run lint (0 errors)\n- bun install --frozen-lockfile --ignore-scripts\n- git diff --check\n\nRollout notes:\nThe stale closed PR #2295 remote branch chore/scout-queue-windows was deleted once manually before the next Scout proposal run. No live workflow rerun was launched from this PR.