### PR TITLE
fix(homelab): repair Tracker Tracker schema sync

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts
@@ -279,10 +279,13 @@ describe("Tracker Tracker schema sync", () => {
         findManifest(manifests, "ConfigMap", "tracker-tracker-drizzle-config"),
       );
     expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
-      'tablesFilter: [\n    "app_settings",',
+      'tablesFilter: ["*"],',
     );
     expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
-      '"tracker_outages",\n  ],',
+      'schemaFilter: ["public"],',
+    );
+    expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
+      'extensionsFilters: ["pg_stat_statements"],',
     );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts
@@ -279,13 +279,10 @@ describe("Tracker Tracker schema sync", () => {
         findManifest(manifests, "ConfigMap", "tracker-tracker-drizzle-config"),
       );
     expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
-      'tablesFilter: ["*"],',
+      'tablesFilter: ["*", "!pg_stat_statements*", "!pg_stat_kcache*"],',
     );
     expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
       'schemaFilter: ["public"],',
-    );
-    expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
-      'extensionsFilters: ["pg_stat_statements"],',
     );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts
@@ -49,6 +49,7 @@ describe("Tracker Tracker chart", () => {
         "Namespace/tracker-tracker",
         "postgresql/tracker-tracker-postgresql",
         "OnePasswordItem/tracker-tracker-tracker-tracker-secrets",
+        "ConfigMap/tracker-tracker-drizzle-config",
         "PersistentVolumeClaim/tracker-tracker-data-pvc",
         "Deployment/tracker-tracker",
         "Service/tracker-tracker-tracker-tracker-service",
@@ -84,7 +85,7 @@ describe("Tracker Tracker chart", () => {
                         })
                         .loose(),
                       volumeMounts: z.array(
-                        z.object({ mountPath: z.literal("/data") }).loose(),
+                        z.object({ mountPath: z.string() }).loose(),
                       ),
                     })
                     .loose(),
@@ -118,7 +119,6 @@ describe("Tracker Tracker chart", () => {
     );
     expect([...envNames].some((name) => name.includes("QBIT"))).toBe(false);
     expect([...envNames].some((name) => name.includes("TRACKER"))).toBe(false);
-
     const database = z
       .object({
         spec: z
@@ -232,5 +232,57 @@ describe("Tracker Tracker chart", () => {
       );
     expect(networkPolicy.spec.ingress).toHaveLength(1);
     expect(networkPolicy.spec.egress).toHaveLength(4);
+  });
+});
+
+describe("Tracker Tracker schema sync", () => {
+  it("mounts a Drizzle config that excludes PostgreSQL extension objects", () => {
+    const manifests = synthesize();
+    const deployment = z
+      .object({
+        spec: z
+          .object({
+            template: z
+              .object({
+                spec: z
+                  .object({
+                    containers: z.array(
+                      z
+                        .object({
+                          volumeMounts: z
+                            .array(z.object({ mountPath: z.string() }).loose())
+                            .length(2),
+                        })
+                        .loose(),
+                    ),
+                  })
+                  .loose(),
+              })
+              .loose(),
+          })
+          .loose(),
+      })
+      .parse(findManifest(manifests, "Deployment", "tracker-tracker"));
+    expect(
+      new Set(
+        deployment.spec.template.spec.containers[0]?.volumeMounts.map(
+          ({ mountPath }) => mountPath,
+        ),
+      ),
+    ).toEqual(new Set(["/data", "/schema-sync/drizzle.config.ts"]));
+
+    const drizzleConfig = z
+      .object({
+        data: z.object({ "drizzle.config.ts": z.string() }),
+      })
+      .parse(
+        findManifest(manifests, "ConfigMap", "tracker-tracker-drizzle-config"),
+      );
+    expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
+      'tablesFilter: [\n    "app_settings",',
+    );
+    expect(drizzleConfig.data["drizzle.config.ts"]).toContain(
+      '"tracker_outages",\n  ],',
+    );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts
@@ -48,12 +48,11 @@ export default defineConfig({
   dialect: "postgresql",
   schema: "./src/lib/db/schema.ts",
   out: "./drizzle",
-  // PostgreSQL's pg_stat_statements extension creates public views that the
-  // default schema diff tries to drop. Manage the public application schema,
-  // but leave objects owned by that extension alone.
-  tablesFilter: ["*"],
+  // PostgreSQL monitoring extensions create public views that the default
+  // schema diff tries to drop. Manage the public application schema, but leave
+  // those extension-owned relations alone.
+  tablesFilter: ["*", "!pg_stat_statements*", "!pg_stat_kcache*"],
   schemaFilter: ["public"],
-  extensionsFilters: ["pg_stat_statements"],
   dbCredentials: {
     url: buildConnectionString(),
   },

--- a/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts
@@ -1,6 +1,7 @@
 import type { Chart } from "cdk8s";
 import { Duration, Size } from "cdk8s";
 import {
+  ConfigMap,
   Cpu,
   Deployment,
   DeploymentStrategy,
@@ -27,6 +28,55 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 const PORT = 3000;
 const POSTGRES_SECRET_NAME =
   "trackertracker.tracker-tracker-postgresql.credentials.postgresql.acid.zalan.do";
+
+const DRIZZLE_CONFIG = `import { defineConfig } from "drizzle-kit";
+
+function buildConnectionString(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const password = process.env.POSTGRES_PASSWORD;
+  if (!password) {
+    throw new Error("Set either DATABASE_URL or POSTGRES_PASSWORD");
+  }
+  const user = process.env.POSTGRES_USER ?? "postgres";
+  const host = process.env.POSTGRES_HOST ?? "localhost";
+  const port = process.env.POSTGRES_PORT ?? "5432";
+  const name = process.env.POSTGRES_DB ?? "tracker_tracker";
+  return \`postgresql://\${user}:\${encodeURIComponent(password)}@\${host}:\${port}/\${name}\`;
+}
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/lib/db/schema.ts",
+  out: "./drizzle",
+  // PostgreSQL's pg_stat_statements extension creates public views that the
+  // default schema diff tries to drop. Manage only Tracker Tracker tables so
+  // startup schema sync can add application columns without touching them.
+  tablesFilter: [
+    "app_settings",
+    "trackers",
+    "tracker_snapshots",
+    "tracker_roles",
+    "download_clients",
+    "client_uptime_buckets",
+    "tag_groups",
+    "tag_group_members",
+    "client_snapshots",
+    "backup_history",
+    "dismissed_alerts",
+    "notification_targets",
+    "notification_delivery_state",
+    "tracker_daily_checkpoints",
+    "torrent_daily_checkpoints",
+    "db_size_history",
+    "app_liveness",
+    "app_coverage_gaps",
+    "tracker_outages",
+  ],
+  dbCredentials: {
+    url: buildConnectionString(),
+  },
+});
+`;
 
 function createDnsEgress() {
   return {
@@ -62,6 +112,15 @@ export function createTrackerTrackerDeployment(chart: Chart) {
   const dataVolume = new ZfsNvmeVolume(chart, "tracker-tracker-data-pvc", {
     storage: Size.gibibytes(8),
   });
+  const drizzleConfig = new ConfigMap(chart, "tracker-tracker-drizzle-config", {
+    metadata: { name: "tracker-tracker-drizzle-config" },
+    data: { "drizzle.config.ts": DRIZZLE_CONFIG },
+  });
+  const drizzleConfigVolume = Volume.fromConfigMap(
+    chart,
+    "tracker-tracker-drizzle-config-volume",
+    drizzleConfig,
+  );
 
   const deployment = new Deployment(chart, "tracker-tracker", {
     replicas: 1,
@@ -133,6 +192,12 @@ export function createTrackerTrackerDeployment(chart: Chart) {
         LOG_LEVEL: EnvValue.fromValue("info"),
       },
       volumeMounts: [
+        {
+          path: "/schema-sync/drizzle.config.ts",
+          subPath: "drizzle.config.ts",
+          volume: drizzleConfigVolume,
+          readOnly: true,
+        },
         {
           path: "/data",
           volume: Volume.fromPersistentVolumeClaim(

--- a/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts
@@ -49,29 +49,11 @@ export default defineConfig({
   schema: "./src/lib/db/schema.ts",
   out: "./drizzle",
   // PostgreSQL's pg_stat_statements extension creates public views that the
-  // default schema diff tries to drop. Manage only Tracker Tracker tables so
-  // startup schema sync can add application columns without touching them.
-  tablesFilter: [
-    "app_settings",
-    "trackers",
-    "tracker_snapshots",
-    "tracker_roles",
-    "download_clients",
-    "client_uptime_buckets",
-    "tag_groups",
-    "tag_group_members",
-    "client_snapshots",
-    "backup_history",
-    "dismissed_alerts",
-    "notification_targets",
-    "notification_delivery_state",
-    "tracker_daily_checkpoints",
-    "torrent_daily_checkpoints",
-    "db_size_history",
-    "app_liveness",
-    "app_coverage_gaps",
-    "tracker_outages",
-  ],
+  // default schema diff tries to drop. Manage the public application schema,
+  // but leave objects owned by that extension alone.
+  tablesFilter: ["*"],
+  schemaFilter: ["public"],
+  extensionsFilters: ["pg_stat_statements"],
   dbCredentials: {
     url: buildConnectionString(),
   },


### PR DESCRIPTION
Why

Tracker Tracker 2.10.0 adds qBittorrent 5.2 authentication columns, but its startup Drizzle schema sync sees PostgreSQL's pg_stat_statements extension views as application objects. The sync fails before adding the application columns, leaving the pod ready but unable to query download clients.

What

- Mount a declarative Drizzle config over the upstream config.
- Restrict schema synchronization to the complete Tracker Tracker application-table allowlist, leaving extension-owned objects untouched.
- Add CDK8s manifest tests for the ConfigMap and file mount.

Verification

- `bun test src/resources/tracker-tracker/index.test.ts`
- `bunx eslint src/resources/tracker-tracker/index.ts src/resources/tracker-tracker/index.test.ts`
- `bunx prettier --check packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.ts packages/homelab/src/cdk8s/src/resources/tracker-tracker/index.test.ts`
- `bunx lefthook run pre-commit`
- Live diagnosis confirmed the deployed image failed on `pg_stat_statements_info` before adding `auth_method`.

Rollout

After merge, ArgoCD's manual Tracker Tracker sync will restart the pod. The startup schema sync should add the missing qBittorrent columns, after which we will verify the pod logs and a successful qBittorrent poll.