### PR TITLE
fix(temporal): harden Scout refresh workflows

### DIFF
--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -79,13 +79,13 @@ auto-pauses or auto-unpauses anything. This is intentional — pause is the one 
 everything else about a schedule lives in source. Don't add a declarative `enabled` flag, it
 would fight the UI.
 
-| To stop…             | Pause schedule id(s)                                                                                                                                               |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Floor preheat        | `good-morning-weekday-preheat`, `good-morning-weekend-preheat`                                                                                                     |
-| Wake-up (heat)       | `good-morning-weekday-wake`, `good-morning-weekend-wake`                                                                                                           |
-| Get-up (volume ramp) | `good-morning-weekday-up`, `good-morning-weekend-up`                                                                                                               |
-| Vacuum               | `vacuum-9am`, `vacuum-12pm`, `vacuum-5pm`                                                                                                                          |
-| LoL / Scout data     | `scout-data-dragon-version-check`, `scout-data-dragon-weekly-refresh`, `scout-season-refresh-weekly`, `scout-showcase-refresh-weekly`, `scout-queue-windows-daily` |
+| To stop…             | Pause schedule id(s)                                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Floor preheat        | `good-morning-weekday-preheat`, `good-morning-weekend-preheat`                                                                                                                                         |
+| Wake-up (heat)       | `good-morning-weekday-wake`, `good-morning-weekend-wake`                                                                                                                                               |
+| Get-up (volume ramp) | `good-morning-weekday-up`, `good-morning-weekend-up`                                                                                                                                                   |
+| Vacuum               | `vacuum-9am`, `vacuum-12pm`, `vacuum-5pm`                                                                                                                                                              |
+| LoL / Scout data     | `scout-data-dragon-version-check`, `scout-data-dragon-weekly-refresh`, `scout-lane-priors-weekly-refresh`, `scout-season-refresh-weekly`, `scout-showcase-refresh-weekly`, `scout-queue-windows-daily` |
 
 ### Catchup window (missed-run replay after a SERVER outage)
 
@@ -484,7 +484,8 @@ the branch it was given, so a branch built from a per-attempt value (a fresh
 `crypto.randomUUID()`, a timestamp) silently defeats that reuse: any failure
 after the PR is created retries the activity under a new branch and opens a
 second PR. Derive it from the content (`data-dragon.ts` uses the Data Dragon
-version; `llm-catalog-refresh.ts` hashes the proposed `catalog.json`) or from
+version; `lane-prior-refresh.ts` hashes the normalized lane-prior artifacts;
+`llm-catalog-refresh.ts` hashes the proposed `catalog.json`) or from
 the workflow's own args (`scout-season-refresh.ts`) — never from a value
 generated inside the attempt. Scratch `/tmp` directories are the opposite: keep
 those per-attempt so a retry cannot trip over a previous attempt's half-cleaned
@@ -503,6 +504,13 @@ edit straight through. Do not swap this for a tree comparison (a branch derived
 from workflow args legitimately changes content every run) or a commit count
 against main (`scout-season-refresh` clones `--depth 1`, so that history is
 absent).
+
+Data Dragon proposals are refreshed when their base is stale. The updater
+regenerates from current `main`, but it first verifies the existing branch's
+tip is still authored and committed by the bot. Human or amended commits are
+never force-pushed over; those proposals require manual attention. Lane-prior
+proposals use content-hash branches, so a changed result gets a new proposal
+instead of replacing an operator's open review.
 
 **Retry-stable is not sufficient — the key must also be stable across scheduled
 runs.** The workflow run id survives retries but changes weekly, so while a

--- a/packages/temporal/scripts/rehearse-bot-clone.ts
+++ b/packages/temporal/scripts/rehearse-bot-clone.ts
@@ -33,7 +33,9 @@
  *                byte-stably, and a bot-style `git commit` of a scout file
  *                succeeds without any pre-commit hook running
  *                (scout-season-refresh-weekly).
- *  4. crd-imports — the cdk8s bin resolves from the cdk8s package's
+ *  4. preflight — generated-output formatting, diff checks, and focused Scout
+ *                validation run in the same bot clone before publication.
+ *  5. crd-imports — the cdk8s bin resolves from the cdk8s package's
  *                cdk8s-cli devDependency after the hook-free install, and the
  *                update-imports script exists (homelab-crd-imports-daily).
  *
@@ -56,6 +58,7 @@ import {
 } from "#activities/bot-clone.ts";
 import { isAllowedGlitterContextRefreshPath } from "#activities/glitter-context-refresh-paths.ts";
 import { runCommand } from "#activities/data-dragon-shell.ts";
+import { runScoutGeneratedPreflight } from "#activities/scout-generated-preflight.ts";
 import { z } from "zod";
 import {
   CHANGELOG_FILE,
@@ -68,6 +71,8 @@ const REPORT_PACKAGE = "packages/scout-for-lol/packages/report";
 const REALDATA_TEST = "src/html/arena/realdata.integration.test.ts";
 // The import that broke: packages/data → @shepherdjerred/llm-models.
 const DATA_PACKAGE = "packages/scout-for-lol/packages/data";
+const LANE_PRIOR_ARTIFACT =
+  "packages/scout-for-lol/packages/data/src/lane-priors/lane-priors.generated.json";
 const BASELINE_ADD_BATCH_SIZE = 250;
 
 function parseArgs(argv: readonly string[]): {
@@ -272,6 +277,18 @@ async function rehearseSnapshotRefresh(repoDir: string): Promise<void> {
     },
   });
   console.error("[rehearsal] snapshot: snapshot test OK (no install refresh)");
+}
+
+async function rehearseGeneratedPreflight(repoDir: string): Promise<void> {
+  console.error(
+    "[rehearsal] preflight: formatter, diff check, and focused Scout validation",
+  );
+  await runScoutGeneratedPreflight({
+    repoDir,
+    changedFiles: [LANE_PRIOR_ARTIFACT],
+    runCommand,
+  });
+  console.error("[rehearsal] preflight: all publication checks passed");
 }
 
 async function armedHookNames(repoDir: string): Promise<string[]> {
@@ -505,6 +522,7 @@ async function main(): Promise<void> {
   await rehearseScoutWorkspace(repoDir);
   await rehearseGlitterContextRefresh(repoDir);
   await rehearseSnapshotRefresh(repoDir);
+  await rehearseGeneratedPreflight(repoDir);
   await rehearseHookFreeCommit(repoDir);
   await rehearseCrdImportsEnvironment(repoDir);
   await rehearseQueueWindowsEnvironment(repoDir);

--- a/packages/temporal/src/activities/data-dragon-diff.ts
+++ b/packages/temporal/src/activities/data-dragon-diff.ts
@@ -1,8 +1,4 @@
 import type { DataDragonUpdateInput } from "./data-dragon.ts";
-import {
-  LANE_PRIOR_ARTIFACT_PATH,
-  LANE_PRIOR_EVAL_REPORT_PATH,
-} from "./data-dragon-lane-priors.ts";
 
 const SCOUT_ROOT = "packages/scout-for-lol";
 const DATA_PACKAGE_ROOT = `${SCOUT_ROOT}/packages/data`;
@@ -35,8 +31,6 @@ export const DATA_DRAGON_GENERATED_PATHS = [
   // This covers future report designs without permitting source edits.
   REPORT_HTML_ROOT,
   CHANGELOG_PATH,
-  LANE_PRIOR_ARTIFACT_PATH,
-  LANE_PRIOR_EVAL_REPORT_PATH,
 ];
 
 export type GitChangeKind =
@@ -148,9 +142,7 @@ function isAllowedDataDragonGeneratedPath(path: string): boolean {
     isWithinDirectory(path, BACKEND_SNAPSHOT_ROOT) ||
     isWithinDirectory(path, REPORT_DATA_DRAGON_SNAPSHOT_ROOT) ||
     isReportHtmlSnapshotPath(path) ||
-    path === CHANGELOG_PATH ||
-    path === LANE_PRIOR_ARTIFACT_PATH ||
-    path === LANE_PRIOR_EVAL_REPORT_PATH
+    path === CHANGELOG_PATH
   );
 }
 

--- a/packages/temporal/src/activities/data-dragon-lane-priors.test.ts
+++ b/packages/temporal/src/activities/data-dragon-lane-priors.test.ts
@@ -4,9 +4,12 @@ import {
   LANE_PRIOR_EVAL_REPORT_PATH,
   lanePriorArtifactPath,
   lanePriorAwsRegion,
+  lanePriorBranchName,
+  lanePriorContentHash,
   lanePriorEvalReportPath,
   updateLanePriors,
 } from "./data-dragon-lane-priors.ts";
+import { branchName as dataDragonBranchName } from "./data-dragon-util.ts";
 
 const REPO_DIR = "/tmp/repo";
 
@@ -166,6 +169,27 @@ describe("updateLanePriors", () => {
       "s3-region",
     );
     expect(lanePriorAwsRegion(config, {})).toBe("us-east-1");
+  });
+});
+
+describe("lane-prior content identity", () => {
+  test("uses normalized artifact content as a stable branch identity", async () => {
+    const repoDir = `/tmp/lane-prior-hash-${crypto.randomUUID()}`;
+    await Bun.$`mkdir -p ${repoDir}/packages/scout-for-lol/packages/data/src/lane-priors`.quiet();
+    await Bun.write(lanePriorArtifactPath(repoDir), '{"lane":"top"}\n');
+    await Bun.write(lanePriorEvalReportPath(repoDir), '{"accuracy":0.9}\n');
+
+    const first = await lanePriorContentHash(repoDir);
+    const second = await lanePriorContentHash(repoDir);
+    expect(first).toBe(second);
+    expect(lanePriorBranchName(first)).toBe(`chore/scout-lane-priors-${first}`);
+
+    await Bun.write(lanePriorEvalReportPath(repoDir), '{"accuracy":0.91}\n');
+    expect(await lanePriorContentHash(repoDir)).not.toBe(first);
+    expect(lanePriorBranchName(first)).not.toBe(
+      dataDragonBranchName("16.15.1"),
+    );
+    await Bun.$`rm -rf ${repoDir}`.quiet();
   });
 });
 

--- a/packages/temporal/src/activities/data-dragon-lane-priors.ts
+++ b/packages/temporal/src/activities/data-dragon-lane-priors.ts
@@ -43,6 +43,22 @@ export function lanePriorEvalReportPath(repoDir: string): string {
   return `${repoDir}/${LANE_PRIOR_EVAL_REPORT_PATH}`;
 }
 
+export async function lanePriorContentHash(repoDir: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(await Bun.file(lanePriorArtifactPath(repoDir)).text());
+  hasher.update("\0");
+  hasher.update(await Bun.file(lanePriorEvalReportPath(repoDir)).text());
+  return hasher.digest("hex").slice(0, 12);
+}
+
+export function lanePriorBranchName(contentHash: string): string {
+  return `chore/scout-lane-priors-${contentHash}`;
+}
+
+export function lanePriorPrTitle(): string {
+  return "chore: refresh Scout lane priors";
+}
+
 const DateOnlySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
 
 export const LanePriorUpdateConfigSchema = z.strictObject({

--- a/packages/temporal/src/activities/data-dragon-pr.test.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { createDataDragonPr } from "./data-dragon-pr.ts";
+import {
+  createDataDragonPr,
+  getPrRevisionState,
+  isPrBasedOnCurrentMain,
+} from "./data-dragon-pr.ts";
 
 const ARGS = {
   repoSlug: "shepherdjerred/monorepo",
@@ -69,5 +73,66 @@ describe("createDataDragonPr", () => {
         findOnHead: async () => new Map<string, string>().get(ARGS.branch),
       }),
     ).rejects.toBe(failure);
+  });
+});
+
+describe("isPrBasedOnCurrentMain", () => {
+  test("detects a current base", async () => {
+    const result = await isPrBasedOnCurrentMain({
+      repoSlug: ARGS.repoSlug,
+      prUrl: "https://github.com/shepherdjerred/monorepo/pull/9",
+      token: ARGS.token,
+      run: async (command) =>
+        command[1] === "pr"
+          ? JSON.stringify({
+              baseRefOid: "abc",
+              headRefOid: "def",
+              headRefName: ARGS.branch,
+            })
+          : JSON.stringify({ object: { sha: "abc" } }),
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test("detects a stale base", async () => {
+    const result = await isPrBasedOnCurrentMain({
+      repoSlug: ARGS.repoSlug,
+      prUrl: "https://github.com/shepherdjerred/monorepo/pull/9",
+      token: ARGS.token,
+      run: async (command) =>
+        command[1] === "pr"
+          ? JSON.stringify({
+              baseRefOid: "old",
+              headRefOid: "def",
+              headRefName: ARGS.branch,
+            })
+          : JSON.stringify({ object: { sha: "new" } }),
+    });
+
+    expect(result).toBe(false);
+  });
+
+  test("returns both PR revisions and the current main revision", async () => {
+    const result = await getPrRevisionState({
+      repoSlug: ARGS.repoSlug,
+      prUrl: "https://github.com/shepherdjerred/monorepo/pull/9",
+      token: ARGS.token,
+      run: async (command) =>
+        command[1] === "pr"
+          ? JSON.stringify({
+              baseRefOid: "base",
+              headRefOid: "head",
+              headRefName: ARGS.branch,
+            })
+          : JSON.stringify({ object: { sha: "main" } }),
+    });
+
+    expect(result).toEqual({
+      baseRefOid: "base",
+      headRefOid: "head",
+      headRefName: ARGS.branch,
+      mainRefOid: "main",
+    });
   });
 });

--- a/packages/temporal/src/activities/data-dragon-pr.ts
+++ b/packages/temporal/src/activities/data-dragon-pr.ts
@@ -17,6 +17,90 @@ const OpenPrListSchema = z.array(
   }),
 );
 
+export type OpenPrListItem = z.infer<typeof OpenPrListSchema>[number];
+
+const PrRevisionStateSchema = z.object({
+  baseRefOid: z.string().min(1),
+  headRefOid: z.string().min(1),
+  headRefName: z.string().min(1),
+});
+const GitRefSchema = z.object({ object: z.object({ sha: z.string().min(1) }) });
+
+export type PrRevisionState = z.infer<typeof PrRevisionStateSchema> & {
+  mainRefOid: string;
+};
+
+export async function getPrRevisionState(input: {
+  repoSlug: string;
+  prUrl: string;
+  token: string;
+  run?: typeof runCommand;
+}): Promise<PrRevisionState> {
+  const run = input.run ?? runCommand;
+  const prState = PrRevisionStateSchema.parse(
+    JSON.parse(
+      await run(
+        [
+          "gh",
+          "pr",
+          "view",
+          input.prUrl,
+          "--repo",
+          input.repoSlug,
+          "--json",
+          "baseRefOid,headRefOid,headRefName",
+        ],
+        { cwd: "/tmp", env: { GH_TOKEN: input.token } },
+      ),
+    ),
+  );
+  const mainRef = GitRefSchema.parse(
+    JSON.parse(
+      await run(["gh", "api", `repos/${input.repoSlug}/git/ref/heads/main`], {
+        cwd: "/tmp",
+        env: { GH_TOKEN: input.token },
+      }),
+    ),
+  );
+  return { ...prState, mainRefOid: mainRef.object.sha };
+}
+
+export async function isPrBasedOnCurrentMain(input: {
+  repoSlug: string;
+  prUrl: string;
+  token: string;
+  run?: typeof runCommand;
+}): Promise<boolean> {
+  const state = await getPrRevisionState(input);
+  return state.baseRefOid === state.mainRefOid;
+}
+
+export async function findOpenGeneratedPrUrl(input: {
+  repoSlug: string;
+  filterArgs: string[];
+  token: string;
+  matches: (pr: OpenPrListItem, appSlug: string) => boolean;
+}): Promise<string | undefined> {
+  const appSlug = await resolveGitHubAppSlug();
+  const output = await runCommand(
+    [
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      input.repoSlug,
+      "--state",
+      "open",
+      ...input.filterArgs,
+      "--json",
+      OPEN_PR_JSON_FIELDS,
+    ],
+    { cwd: "/tmp", env: { GH_TOKEN: input.token } },
+  );
+  const prs = OpenPrListSchema.parse(JSON.parse(output));
+  return prs.find((pr) => input.matches(pr, appSlug))?.url;
+}
+
 /**
  * Lists open PRs matching `filterArgs` and returns the URL of the one
  * AUTHENTICATED as this updater's own PR for `version`, or `undefined`. The
@@ -33,24 +117,13 @@ async function findAuthenticatedDataDragonPrUrl(
   version: string,
   token: string,
 ): Promise<string | undefined> {
-  const appSlug = await resolveGitHubAppSlug();
-  const output = await runCommand(
-    [
-      "gh",
-      "pr",
-      "list",
-      "--repo",
-      repoSlug,
-      "--state",
-      "open",
-      ...filterArgs,
-      "--json",
-      OPEN_PR_JSON_FIELDS,
-    ],
-    { cwd: "/tmp", env: { GH_TOKEN: token } },
-  );
-  const prs = OpenPrListSchema.parse(JSON.parse(output));
-  return findDataDragonPr(prs, version, appSlug)?.url;
+  return await findOpenGeneratedPrUrl({
+    repoSlug,
+    filterArgs,
+    token,
+    matches: (pr, appSlug) =>
+      findDataDragonPr([pr], version, appSlug) !== undefined,
+  });
 }
 
 /**
@@ -81,6 +154,30 @@ export function findOpenDataDragonPrUrl(
     latestVersion,
     token,
   );
+}
+
+export async function getOpenDataDragonPrState(input: {
+  repoSlug: string;
+  latestVersion: string;
+  token: string;
+}): Promise<{
+  prUrl: string | undefined;
+  state: PrRevisionState | undefined;
+}> {
+  const prUrl = await findOpenDataDragonPrUrl(
+    input.repoSlug,
+    input.latestVersion,
+    input.token,
+  );
+  if (prUrl === undefined) return { prUrl, state: undefined };
+  return {
+    prUrl,
+    state: await getPrRevisionState({
+      repoSlug: input.repoSlug,
+      prUrl,
+      token: input.token,
+    }),
+  };
 }
 
 /**
@@ -119,25 +216,54 @@ export type CreateDataDragonPrDeps = {
   findOnHead?: typeof findOpenPrUrlForHead;
 };
 
-/**
- * Opens the Data Dragon PR for `branch`, idempotently across concurrent retry
- * attempts. The entry dedup check (`findOpenDataDragonPrUrl`) can't be atomic
- * across the minutes-long clone/install/update window, so two attempts can both
- * pass it and reach here. The deterministic per-version `branch` (see
- * `branchName`) makes GitHub itself the serialization point: it refuses a second
- * open PR for the same head→base, so at most one racing attempt's `gh pr create`
- * succeeds. The loser's create fails; if the authenticated bot PR now exists on
- * this exact head (`findOnHead`, a lag-free `--head` lookup, not the search
- * index), it raced a sibling attempt — return that PR as `recovered` and let the
- * caller finish auto-merge on it rather than erroring the run. Only a create
- * failure with NO bot PR on the head is a genuine failure and rethrows.
- */
-export async function createDataDragonPr(
-  args: CreateDataDragonPrArgs,
-  deps: CreateDataDragonPrDeps = {},
+export type CreateGeneratedPrArgs = {
+  repoSlug: string;
+  repoDir: string;
+  branch: string;
+  base: string;
+  title: string;
+  body: string;
+  token: string;
+};
+
+export type CreateGeneratedPrDeps = {
+  run?: typeof runCommand;
+  findOnHead: () => Promise<string | undefined>;
+};
+
+export async function ensureGeneratedPrAutoMerge(input: {
+  repoSlug: string;
+  prUrl: string;
+  token: string;
+  run?: typeof runCommand;
+  onFailure?: (error: unknown) => void;
+}): Promise<boolean> {
+  try {
+    await (input.run ?? runCommand)(
+      [
+        "gh",
+        "pr",
+        "merge",
+        "--repo",
+        input.repoSlug,
+        "--auto",
+        "--merge",
+        input.prUrl,
+      ],
+      { cwd: "/tmp", env: { GH_TOKEN: input.token }, redactOutput: true },
+    );
+    return true;
+  } catch (error: unknown) {
+    input.onFailure?.(error);
+    return false;
+  }
+}
+
+export async function createGeneratedPr(
+  args: CreateGeneratedPrArgs,
+  deps: CreateGeneratedPrDeps,
 ): Promise<{ url: string; recovered: boolean }> {
   const run = deps.run ?? runCommand;
-  const findOnHead = deps.findOnHead ?? findOpenPrUrlForHead;
   try {
     const url = await run(
       [
@@ -159,15 +285,40 @@ export async function createDataDragonPr(
     );
     return { url, recovered: false };
   } catch (error) {
-    const existing = await findOnHead(
-      args.repoSlug,
-      args.branch,
-      args.version,
-      args.token,
-    );
+    const existing = await deps.findOnHead();
     if (existing === undefined) {
       throw error;
     }
     return { url: existing, recovered: true };
   }
+}
+
+/**
+ * Opens the Data Dragon PR for `branch`, idempotently across concurrent retry
+ * attempts. The entry dedup check (`findOpenDataDragonPrUrl`) can't be atomic
+ * across the minutes-long clone/install/update window, so two attempts can both
+ * pass it and reach here. The deterministic per-version `branch` (see
+ * `branchName`) makes GitHub itself the serialization point: it refuses a second
+ * open PR for the same head→base, so at most one racing attempt's `gh pr create`
+ * succeeds. The loser's create fails; if the authenticated bot PR now exists on
+ * this exact head (`findOnHead`, a lag-free `--head` lookup, not the search
+ * index), it raced a sibling attempt — return that PR as `recovered` and let the
+ * caller finish auto-merge on it rather than erroring the run. Only a create
+ * failure with NO bot PR on the head is a genuine failure and rethrows.
+ */
+export async function createDataDragonPr(
+  args: CreateDataDragonPrArgs,
+  deps: CreateDataDragonPrDeps = {},
+): Promise<{ url: string; recovered: boolean }> {
+  const generatedDeps: CreateGeneratedPrDeps = {
+    findOnHead: async () =>
+      await (deps.findOnHead ?? findOpenPrUrlForHead)(
+        args.repoSlug,
+        args.branch,
+        args.version,
+        args.token,
+      ),
+  };
+  if (deps.run !== undefined) generatedDeps.run = deps.run;
+  return await createGeneratedPr(args, generatedDeps);
 }

--- a/packages/temporal/src/activities/data-dragon.test.ts
+++ b/packages/temporal/src/activities/data-dragon.test.ts
@@ -48,18 +48,6 @@ const DATA_JSON_PATH =
   "packages/scout-for-lol/packages/data/src/data-dragon/assets/champion/Fiddlesticks.json";
 const GENERATED_TS_PATH =
   "packages/scout-for-lol/packages/data/src/data-dragon/champion-name-overrides.generated.ts";
-const TEST_LANE_PRIORS_CONFIG: DataDragonUpdateInput["lanePriors"] = {
-  bucket: "scout-test-bucket",
-  queueIds: [400, 420, 440, 480, 490],
-  trainingStartDate: "2026-05-06",
-  trainingEndDate: "2026-05-13",
-  holdoutStartDate: "2026-05-14",
-  holdoutEndDate: "2026-05-16",
-  holdoutSampleSize: 100,
-  holdoutSeed: "test-seed",
-  threshold: 0.95,
-};
-
 describe("parseGitStatusLine", () => {
   test("preserves paths for unstaged modifications", () => {
     expect(parseGitStatusLine(` M ${IMAGE_PATH}`)).toEqual({
@@ -248,7 +236,6 @@ describe("buildImageOnlySkipEmailContent", () => {
       currentVersion: "16.10.1",
       latestVersion: "16.10.1",
       updateRequired: false,
-      lanePriors: TEST_LANE_PRIORS_CONFIG,
     };
 
     const content = buildImageOnlySkipEmailContent(input, 214);

--- a/packages/temporal/src/activities/data-dragon.ts
+++ b/packages/temporal/src/activities/data-dragon.ts
@@ -11,22 +11,18 @@ import {
   type GitStatusEntry,
 } from "./data-dragon-diff.ts";
 import {
-  LanePriorUpdateConfigSchema,
-  lanePriorPrBodyLines,
-  revertGeneratedAtOnlyLanePriorChanges,
-  updateLanePriors,
-  type LanePriorUpdateConfig,
-} from "./data-dragon-lane-priors.ts";
-import {
   botCloneCacheDir,
   disarmGitHooks,
   installScoutWorkspace,
 } from "./bot-clone.ts";
+import { runScoutGeneratedPreflight } from "./scout-generated-preflight.ts";
 import { recordAutoMergeFailure, recordRun } from "./data-dragon-metrics.ts";
 import {
   createDataDragonPr,
-  findOpenDataDragonPrUrl,
+  ensureGeneratedPrAutoMerge,
+  getOpenDataDragonPrState,
 } from "./data-dragon-pr.ts";
+import { assertRemoteBranchIsOurs } from "./scout-season-refresh-git.ts";
 import { runCommand } from "./data-dragon-shell.ts";
 import {
   branchName,
@@ -52,14 +48,6 @@ const VersionsResponse = z.array(z.string().min(1)).min(1);
 
 export type DataDragonUpdateMode = "version-check" | "weekly-refresh";
 
-export const DataDragonWorkflowInputSchema = z.strictObject({
-  lanePriors: LanePriorUpdateConfigSchema,
-});
-
-export type DataDragonWorkflowInput = z.infer<
-  typeof DataDragonWorkflowInputSchema
->;
-
 export type DataDragonVersionState = {
   currentVersion: string;
   latestVersion: string;
@@ -68,7 +56,6 @@ export type DataDragonVersionState = {
 
 export type DataDragonUpdateInput = DataDragonVersionState & {
   mode: DataDragonUpdateMode;
-  lanePriors: LanePriorUpdateConfig;
 };
 
 export type DataDragonUpdateResult = DataDragonUpdateInput & {
@@ -146,41 +133,6 @@ async function changedFiles(repoDir: string): Promise<GitStatusEntry[]> {
     );
   }
   return changes;
-}
-
-/**
- * Enables auto-merge on an already-open Data Dragon PR, idempotently. Shared by
- * the create path and the dedup/retry path: `gh pr merge --auto` is safe to
- * re-issue on a PR that already has auto-merge enabled, so a retry whose prior
- * attempt died between `gh pr create` and `gh pr merge --auto` can finish the
- * setup here instead of leaving the PR stuck. On failure it records the
- * dedicated auto-merge-failure signal (so `ScoutDataDragonAutoMergeFailed`
- * fires) and logs, but does NOT throw — a PR exists either way, and the failure
- * is surfaced through its own alert rather than by failing the run. `--repo`
- * plus the full PR URL resolves the PR via the API, so the working directory
- * is irrelevant (the dedup path has no clone) — hence the fixed `/tmp` cwd.
- */
-async function ensurePrAutoMerge(
-  prUrl: string,
-  githubToken: string,
-  mode: DataDragonUpdateMode,
-  logContext: Record<string, unknown>,
-): Promise<boolean> {
-  try {
-    await runCommand(
-      ["gh", "pr", "merge", "--repo", REPO_SLUG, "--auto", "--merge", prUrl],
-      { cwd: "/tmp", env: { GH_TOKEN: githubToken }, redactOutput: true },
-    );
-    return true;
-  } catch (error: unknown) {
-    recordAutoMergeFailure(mode);
-    jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
-      ...logContext,
-      prUrl,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return false;
-  }
 }
 
 export type DataDragonActivities = typeof dataDragonActivities;
@@ -284,26 +236,35 @@ export const dataDragonActivities = {
       // open PR, and skips instead of opening a duplicate under a fresh
       // UUID-suffixed branch. It also short-circuits a prior scheduled run's
       // still-open PR, and does so before the expensive clone/install/refresh.
-      const existingPrUrl = await findOpenDataDragonPrUrl(
-        REPO_SLUG,
-        input.latestVersion,
-        githubToken,
-      );
-      if (existingPrUrl !== undefined) {
+      const { prUrl: existingPrUrl, state: existingPrState } =
+        await getOpenDataDragonPrState({
+          repoSlug: REPO_SLUG,
+          latestVersion: input.latestVersion,
+          token: githubToken,
+        });
+      const existingPrNeedsRefresh =
+        existingPrState !== undefined &&
+        existingPrState.baseRefOid !== existingPrState.mainRefOid;
+      if (existingPrUrl !== undefined && !existingPrNeedsRefresh) {
         // The prior attempt may have died between `gh pr create` and `gh pr
         // merge --auto`, leaving this PR open with auto-merge never enabled.
         // Finish the setup idempotently so the retry doesn't leave the PR
         // stuck (and so an auto-merge failure surfaces via its own alert)
         // before treating the dedup skip as complete.
-        const autoMergeConfigured = await ensurePrAutoMerge(
-          existingPrUrl,
-          githubToken,
-          input.mode,
-          {
-            ...input,
-            reason: "pr-already-open",
+        const autoMergeConfigured = await ensureGeneratedPrAutoMerge({
+          repoSlug: REPO_SLUG,
+          prUrl: existingPrUrl,
+          token: githubToken,
+          onFailure: (error: unknown) => {
+            recordAutoMergeFailure(input.mode);
+            jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
+              ...input,
+              prUrl: existingPrUrl,
+              reason: "pr-already-open",
+              error: error instanceof Error ? error.message : String(error),
+            });
           },
-        );
+        });
         const durationSeconds = (Date.now() - start) / 1000;
         recordRun({
           mode: input.mode,
@@ -329,6 +290,16 @@ export const dataDragonActivities = {
           autoMergeConfigured,
         };
       }
+      if (existingPrNeedsRefresh) {
+        jsonLog(
+          "warning",
+          "Refreshing stale Data Dragon PR from current main",
+          {
+            ...input,
+            prUrl: existingPrUrl,
+          },
+        );
+      }
 
       jsonLog("info", "Starting Data Dragon update", input);
       await runCommand(["mkdir", "-p", tempDir], { cwd: "/tmp" });
@@ -346,6 +317,20 @@ export const dataDragonActivities = {
         "--depth",
         "1",
       ]);
+
+      const branch =
+        existingPrState?.headRefName ?? branchName(input.latestVersion);
+      if (existingPrNeedsRefresh) {
+        await runCommand(
+          [
+            "git",
+            "fetch",
+            "origin",
+            `refs/heads/${branch}:refs/remotes/origin/${branch}`,
+          ],
+          { cwd: repoDir, env: gitEnv, redactOutput: true },
+        );
+      }
 
       // Installs the root workspace once without hooks, then builds the shared
       // producers Scout imports. Without the llm-models build, the updater's
@@ -374,17 +359,7 @@ export const dataDragonActivities = {
           },
         },
       );
-      await updateLanePriors({
-        repoDir,
-        rawConfig: input.lanePriors,
-        runCommand,
-      });
-      const reverted = await revertGeneratedAtOnlyLanePriorChanges(repoDir);
-      if (reverted.length > 0) {
-        jsonLog("info", "Reverted lane-prior timestamp churn", { reverted });
-      }
-
-      const changes = await changedFiles(repoDir);
+      let changes = await changedFiles(repoDir);
       const files = changes.map((change) => change.path);
       const durationSeconds = (Date.now() - start) / 1000;
 
@@ -448,7 +423,14 @@ export const dataDragonActivities = {
         nonSuppressibleExamples: nonSuppressibleChanges.slice(0, 20),
       });
 
-      const branch = branchName(input.latestVersion);
+      await runScoutGeneratedPreflight({
+        repoDir,
+        changedFiles: files,
+        runCommand,
+      });
+      changes = await changedFiles(repoDir);
+      const formattedFiles = changes.map((change) => change.path);
+
       const title = dataDragonPrTitle(input.latestVersion);
       const body = [
         "Automated Scout Data Dragon refresh from Temporal.",
@@ -456,9 +438,7 @@ export const dataDragonActivities = {
         `Current version: ${input.currentVersion}`,
         `Latest version: ${input.latestVersion}`,
         `Mode: ${input.mode}`,
-        `Changed files: ${String(files.length)}`,
-        "",
-        ...lanePriorPrBodyLines(input.lanePriors),
+        `Changed files: ${String(formattedFiles.length)}`,
       ].join("\n");
 
       await runCommand(["git", "config", "user.email", "ci@sjer.red"], {
@@ -476,6 +456,9 @@ export const dataDragonActivities = {
       // activity stays safe if one is ever added.
       await disarmGitHooks(repoDir);
       await runCommand(["git", "commit", "-m", title], { cwd: repoDir });
+      if (existingPrNeedsRefresh) {
+        await assertRemoteBranchIsOurs({ repoDir, branch });
+      }
       const commitHash = await runCommand(["git", "rev-parse", "HEAD"], {
         cwd: repoDir,
       });
@@ -501,15 +484,20 @@ export const dataDragonActivities = {
         version: input.latestVersion,
         token: githubToken,
       });
-      const autoMergeConfigured = await ensurePrAutoMerge(
+      const autoMergeConfigured = await ensureGeneratedPrAutoMerge({
+        repoSlug: REPO_SLUG,
         prUrl,
-        githubToken,
-        input.mode,
-        {
-          ...input,
-          branch,
+        token: githubToken,
+        onFailure: (error: unknown) => {
+          recordAutoMergeFailure(input.mode);
+          jsonLog("warning", "Data Dragon PR auto-merge setup failed", {
+            ...input,
+            branch,
+            prUrl,
+            error: error instanceof Error ? error.message : String(error),
+          });
         },
-      );
+      });
 
       recordRun({
         mode: input.mode,
@@ -517,7 +505,7 @@ export const dataDragonActivities = {
         reason: recovered ? "pr-already-open" : "pr-created",
         currentVersion: input.currentVersion,
         latestVersion: input.latestVersion,
-        changedFiles: files.length,
+        changedFiles: formattedFiles.length,
         durationSeconds,
         prCreated: !recovered,
       });
@@ -531,14 +519,14 @@ export const dataDragonActivities = {
           branch,
           prUrl,
           commitHash,
-          changedFiles: files.length,
+          changedFiles: formattedFiles.length,
           durationSeconds,
         },
       );
 
       return {
         ...input,
-        changedFiles: files,
+        changedFiles: formattedFiles,
         branchName: branch,
         commitHash,
         prUrl,

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -10,6 +10,7 @@ import { agentTaskActivities } from "./agent-task.ts";
 import { zfsMaintenanceActivities } from "./zfs-maintenance.ts";
 import { bugsinkHousekeepingActivities } from "./bugsink.ts";
 import { dataDragonActivities } from "./data-dragon.ts";
+import { lanePriorActivities } from "./lane-prior-refresh.ts";
 import { scoutSeasonRefreshActivities } from "./scout-season-refresh.ts";
 import { veleroOrphanAuditActivities } from "./velero-orphan-audit.ts";
 import { outcomeActivities } from "./outcome.ts";
@@ -46,6 +47,7 @@ export const activities = {
   ...zfsMaintenanceActivities,
   ...bugsinkHousekeepingActivities,
   ...dataDragonActivities,
+  ...lanePriorActivities,
   ...scoutSeasonRefreshActivities,
   ...veleroOrphanAuditActivities,
   ...outcomeActivities,

--- a/packages/temporal/src/activities/lane-prior-refresh.ts
+++ b/packages/temporal/src/activities/lane-prior-refresh.ts
@@ -1,0 +1,324 @@
+import { Context } from "@temporalio/activity";
+import { simpleGit } from "simple-git";
+import { z } from "zod/v4";
+import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
+import {
+  assertRemoteBranchIsOurs,
+  writeGitAskpass,
+} from "./scout-season-refresh-git.ts";
+import {
+  LANE_PRIOR_ARTIFACT_PATH,
+  LANE_PRIOR_EVAL_REPORT_PATH,
+  LanePriorUpdateConfigSchema,
+  lanePriorBranchName,
+  lanePriorContentHash,
+  lanePriorPrBodyLines,
+  lanePriorPrTitle,
+  revertGeneratedAtOnlyLanePriorChanges,
+  updateLanePriors,
+} from "./data-dragon-lane-priors.ts";
+import {
+  createGeneratedPr,
+  ensureGeneratedPrAutoMerge,
+  findOpenGeneratedPrUrl,
+  type OpenPrListItem,
+} from "./data-dragon-pr.ts";
+import { parseGitStatusLine, type GitStatusEntry } from "./data-dragon-diff.ts";
+import { runCommand } from "./data-dragon-shell.ts";
+import { disarmGitHooks, installScoutWorkspace } from "./bot-clone.ts";
+import { runScoutGeneratedPreflight } from "./scout-generated-preflight.ts";
+
+const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
+const REPO_SLUG = "shepherdjerred/monorepo";
+const MAIN_BRANCH = "main";
+
+export const LanePriorWorkflowInputSchema = z.strictObject({
+  lanePriors: LanePriorUpdateConfigSchema,
+});
+
+export type LanePriorWorkflowInput = z.infer<
+  typeof LanePriorWorkflowInputSchema
+>;
+
+export type LanePriorRefreshResult = {
+  changedFiles: string[];
+  contentHash: string | undefined;
+  branchName: string | undefined;
+  commitHash: string | undefined;
+  prUrl: string | undefined;
+  outcome: "success" | "skipped";
+  reason: "pr-created" | "no-diff" | "pr-already-open";
+  autoMergeConfigured?: boolean;
+};
+
+function jsonLog(
+  level: "info" | "warning" | "error",
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  console.warn(
+    JSON.stringify({
+      level,
+      msg: message,
+      component: "scout-lane-prior-refresh",
+      ...fields,
+    }),
+  );
+}
+
+function parseChanges(status: string): GitStatusEntry[] {
+  return status
+    .split("\n")
+    .map((line) => parseGitStatusLine(line))
+    .filter((entry) => entry !== undefined);
+}
+
+function lanePriorDisallowedPaths(
+  changes: readonly GitStatusEntry[],
+): string[] {
+  const allowed = new Set([
+    LANE_PRIOR_ARTIFACT_PATH,
+    LANE_PRIOR_EVAL_REPORT_PATH,
+  ]);
+  const disallowed = new Set<string>();
+  for (const change of changes) {
+    if (!allowed.has(change.path)) disallowed.add(change.path);
+    if (
+      change.previousPath !== undefined &&
+      !allowed.has(change.previousPath)
+    ) {
+      disallowed.add(change.previousPath);
+    }
+  }
+  return [...disallowed].toSorted();
+}
+
+async function changedLanePriorFiles(repoDir: string): Promise<string[]> {
+  const status = await runCommand(["git", "status", "--porcelain"], {
+    cwd: repoDir,
+    trimStdout: false,
+  });
+  const changes = parseChanges(status);
+  const disallowed = lanePriorDisallowedPaths(changes);
+  if (disallowed.length > 0) {
+    throw new Error(
+      `Lane-prior refresh changed disallowed paths: ${disallowed.join(", ")}`,
+    );
+  }
+  return changes.map((change) => change.path).toSorted();
+}
+
+function isLanePriorPr(
+  pr: OpenPrListItem,
+  appSlug: string,
+  branch: string,
+): boolean {
+  return (
+    pr.title === lanePriorPrTitle() &&
+    pr.baseRefName === MAIN_BRANCH &&
+    pr.headRefName === branch &&
+    !pr.isCrossRepository &&
+    pr.author.is_bot &&
+    pr.author.login.replace(/^app\//, "").replace(/\[bot\]$/, "") === appSlug
+  );
+}
+
+async function findOpenLanePriorPrUrl(
+  branch: string,
+  token: string,
+): Promise<string | undefined> {
+  return await findOpenGeneratedPrUrl({
+    repoSlug: REPO_SLUG,
+    filterArgs: ["--head", branch],
+    token,
+    matches: (pr, appSlug) => isLanePriorPr(pr, appSlug, branch),
+  });
+}
+
+export type LanePriorActivities = typeof lanePriorActivities;
+
+export const lanePriorActivities = {
+  async updateLanePriors(
+    input: LanePriorWorkflowInput,
+  ): Promise<LanePriorRefreshResult> {
+    const config = LanePriorWorkflowInputSchema.parse(input);
+    const start = Date.now();
+    const tempDir = `/tmp/scout-lane-priors-${crypto.randomUUID()}`;
+    const repoDir = `${tempDir}/monorepo`;
+    const heartbeat = setInterval(() => {
+      Context.current().heartbeat({
+        phase: "updateLanePriors",
+        elapsedMs: Date.now() - start,
+      });
+    }, 10_000);
+
+    try {
+      const tokenResult = await createGitHubAppInstallationToken();
+      const githubToken = tokenResult.token;
+      await runCommand(["mkdir", "-p", tempDir], { cwd: "/tmp" });
+      const askpass = await writeGitAskpass(tempDir);
+      const gitEnv = {
+        GH_TOKEN: githubToken,
+        GIT_ASKPASS: askpass,
+        GIT_TERMINAL_PROMPT: "0",
+      };
+
+      await simpleGit().clone(REPO_URL, repoDir, [
+        "--branch",
+        MAIN_BRANCH,
+        "--single-branch",
+        "--depth",
+        "1",
+      ]);
+      await installScoutWorkspace(repoDir);
+      await updateLanePriors({
+        repoDir,
+        rawConfig: config.lanePriors,
+        runCommand,
+      });
+      const reverted = await revertGeneratedAtOnlyLanePriorChanges(repoDir);
+      if (reverted.length > 0) {
+        jsonLog("info", "Reverted lane-prior timestamp churn", { reverted });
+      }
+
+      let files = await changedLanePriorFiles(repoDir);
+      if (files.length === 0) {
+        return {
+          changedFiles: [],
+          contentHash: undefined,
+          branchName: undefined,
+          commitHash: undefined,
+          prUrl: undefined,
+          outcome: "skipped",
+          reason: "no-diff",
+        };
+      }
+
+      await runScoutGeneratedPreflight({
+        repoDir,
+        changedFiles: files,
+        runCommand,
+      });
+      files = await changedLanePriorFiles(repoDir);
+      const contentHash = await lanePriorContentHash(repoDir);
+      const branch = lanePriorBranchName(contentHash);
+      const title = lanePriorPrTitle();
+      const existingPrUrl = await findOpenLanePriorPrUrl(branch, githubToken);
+      if (existingPrUrl !== undefined) {
+        const autoMergeConfigured = await ensureGeneratedPrAutoMerge({
+          repoSlug: REPO_SLUG,
+          prUrl: existingPrUrl,
+          token: githubToken,
+          onFailure: (error: unknown) => {
+            jsonLog("warning", "Lane-prior PR auto-merge setup failed", {
+              prUrl: existingPrUrl,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          },
+        });
+        return {
+          changedFiles: files,
+          contentHash,
+          branchName: branch,
+          commitHash: undefined,
+          prUrl: existingPrUrl,
+          outcome: "skipped",
+          reason: "pr-already-open",
+          autoMergeConfigured,
+        };
+      }
+
+      await runCommand(["git", "config", "user.email", "ci@sjer.red"], {
+        cwd: repoDir,
+      });
+      await runCommand(["git", "config", "user.name", "CI Bot"], {
+        cwd: repoDir,
+      });
+      const remoteBranch = await runCommand(
+        ["git", "ls-remote", "--heads", "origin", `refs/heads/${branch}`],
+        { cwd: repoDir, env: gitEnv, redactOutput: true },
+      );
+      if (remoteBranch.length > 0) {
+        await runCommand(
+          [
+            "git",
+            "fetch",
+            "origin",
+            `refs/heads/${branch}:refs/remotes/origin/${branch}`,
+          ],
+          { cwd: repoDir, env: gitEnv, redactOutput: true },
+        );
+      }
+      await runCommand(["git", "checkout", "-B", branch], { cwd: repoDir });
+      await runCommand(
+        [
+          "git",
+          "add",
+          "--",
+          LANE_PRIOR_ARTIFACT_PATH,
+          LANE_PRIOR_EVAL_REPORT_PATH,
+        ],
+        { cwd: repoDir },
+      );
+      await disarmGitHooks(repoDir);
+      await runCommand(["git", "commit", "-m", title], { cwd: repoDir });
+      if (remoteBranch.length > 0) {
+        await assertRemoteBranchIsOurs({ repoDir, branch });
+      }
+      const commitHash = await runCommand(["git", "rev-parse", "HEAD"], {
+        cwd: repoDir,
+      });
+      await runCommand(
+        ["git", "push", "--force-with-lease", "origin", branch],
+        { cwd: repoDir, env: gitEnv, redactOutput: true },
+      );
+      const body = [
+        "Automated Scout lane-prior refresh from Temporal.",
+        "",
+        `Content hash: ${contentHash}`,
+        `Changed files: ${String(files.length)}`,
+        "",
+        ...lanePriorPrBodyLines(config.lanePriors),
+      ].join("\n");
+      const { url: prUrl, recovered } = await createGeneratedPr(
+        {
+          repoSlug: REPO_SLUG,
+          repoDir,
+          branch,
+          base: MAIN_BRANCH,
+          title,
+          body,
+          token: githubToken,
+        },
+        {
+          findOnHead: async () =>
+            await findOpenLanePriorPrUrl(branch, githubToken),
+        },
+      );
+      const autoMergeConfigured = await ensureGeneratedPrAutoMerge({
+        repoSlug: REPO_SLUG,
+        prUrl,
+        token: githubToken,
+        onFailure: (error: unknown) => {
+          jsonLog("warning", "Lane-prior PR auto-merge setup failed", {
+            prUrl,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+      });
+      return {
+        changedFiles: files,
+        contentHash,
+        branchName: branch,
+        commitHash,
+        prUrl,
+        outcome: recovered ? "skipped" : "success",
+        reason: recovered ? "pr-already-open" : "pr-created",
+        autoMergeConfigured,
+      };
+    } finally {
+      clearInterval(heartbeat);
+      await Bun.$`rm -rf ${tempDir}`.quiet();
+    }
+  },
+};

--- a/packages/temporal/src/activities/scout-generated-preflight.test.ts
+++ b/packages/temporal/src/activities/scout-generated-preflight.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  generatedTextPaths,
+  runScoutGeneratedPreflight,
+} from "./scout-generated-preflight.ts";
+
+describe("generatedTextPaths", () => {
+  test("selects and sorts formatter-supported generated files", () => {
+    expect(
+      generatedTextPaths([
+        "packages/data/image.png",
+        "packages/data/z.json",
+        "packages/data/a.ts",
+        "packages/data/raw.html",
+      ]),
+    ).toEqual(["packages/data/a.ts", "packages/data/z.json"]);
+  });
+});
+
+describe("runScoutGeneratedPreflight", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories
+        .splice(0)
+        .map((directory) => rm(directory, { recursive: true, force: true })),
+    );
+  });
+
+  test("formats, checks, and validates before publication", async () => {
+    const calls: string[][] = [];
+    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
+    temporaryDirectories.push(repoDir);
+    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+
+    await runScoutGeneratedPreflight({
+      repoDir,
+      changedFiles: ["packages/data/generated.json", "assets/icon.png"],
+      runCommand: async (command) => {
+        calls.push(command);
+        return "";
+      },
+    });
+
+    expect(calls).toEqual([
+      [
+        "bunx",
+        "--no-install",
+        "prettier",
+        "--write",
+        "--ignore-unknown",
+        "--",
+        "packages/data/generated.json",
+      ],
+      [
+        "bunx",
+        "--no-install",
+        "prettier",
+        "--check",
+        "--ignore-unknown",
+        "--",
+        "packages/data/generated.json",
+      ],
+      ["git", "diff", "--check"],
+      [
+        "bunx",
+        "--no-install",
+        "turbo",
+        "run",
+        "typecheck",
+        "--filter=@scout-for-lol/design-system",
+      ],
+      [
+        "bunx",
+        "--no-install",
+        "turbo",
+        "run",
+        "test",
+        "--filter=@scout-for-lol/data",
+      ],
+    ]);
+  });
+
+  test("stops before later checks when formatting fails", async () => {
+    const calls: string[][] = [];
+    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
+    temporaryDirectories.push(repoDir);
+    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+
+    await expect(
+      runScoutGeneratedPreflight({
+        repoDir,
+        changedFiles: ["packages/data/generated.json"],
+        runCommand: async (command) => {
+          calls.push(command);
+          throw new Error("prettier failed");
+        },
+      }),
+    ).rejects.toThrow("prettier failed");
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("stops before focused validation when git diff check fails", async () => {
+    const calls: string[][] = [];
+    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
+    temporaryDirectories.push(repoDir);
+    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+
+    await expect(
+      runScoutGeneratedPreflight({
+        repoDir,
+        changedFiles: ["packages/data/generated.json"],
+        runCommand: async (command) => {
+          calls.push(command);
+          if (command[0] === "git") throw new Error("diff check failed");
+          return "";
+        },
+      }),
+    ).rejects.toThrow("diff check failed");
+
+    expect(calls).toHaveLength(3);
+    expect(calls[2]).toEqual(["git", "diff", "--check"]);
+  });
+});

--- a/packages/temporal/src/activities/scout-generated-preflight.ts
+++ b/packages/temporal/src/activities/scout-generated-preflight.ts
@@ -1,0 +1,110 @@
+import { runCommand as defaultRunCommand } from "./data-dragon-shell.ts";
+import { botCloneCacheDir } from "./bot-clone.ts";
+
+const PRETTIER_EXTENSIONS = new Set([
+  ".json",
+  ".jsonc",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".snap",
+  ".md",
+  ".mdx",
+]);
+
+type RunCommand = typeof defaultRunCommand;
+
+function extension(path: string): string {
+  const dot = path.lastIndexOf(".");
+  return dot === -1 ? "" : path.slice(dot).toLowerCase();
+}
+
+export function generatedTextPaths(changedFiles: readonly string[]): string[] {
+  return changedFiles
+    .filter((path) => PRETTIER_EXTENSIONS.has(extension(path)))
+    .toSorted();
+}
+
+/**
+ * Validate generated Scout output before it can become a remote proposal.
+ *
+ * The updater itself owns snapshot generation. This gate owns the quality
+ * boundary between generated files and git publication: formatting, whitespace
+ * errors, and the two focused checks that caught PR #2326's CI failure.
+ */
+export async function runScoutGeneratedPreflight(input: {
+  repoDir: string;
+  changedFiles: readonly string[];
+  runCommand?: RunCommand;
+}): Promise<void> {
+  const runCommand = input.runCommand ?? defaultRunCommand;
+  const commandOptions = {
+    cwd: input.repoDir,
+    env: {
+      ENVIRONMENT: undefined,
+      BUN_INSTALL_CACHE_DIR: botCloneCacheDir(input.repoDir),
+    },
+  };
+  const textPaths: string[] = [];
+  for (const path of generatedTextPaths(input.changedFiles)) {
+    if (await Bun.file(`${input.repoDir}/${path}`).exists()) {
+      textPaths.push(path);
+    }
+  }
+
+  if (textPaths.length > 0) {
+    await runCommand(
+      [
+        "bunx",
+        "--no-install",
+        "prettier",
+        "--write",
+        "--ignore-unknown",
+        "--",
+        ...textPaths,
+      ],
+      commandOptions,
+    );
+    await runCommand(
+      [
+        "bunx",
+        "--no-install",
+        "prettier",
+        "--check",
+        "--ignore-unknown",
+        "--",
+        ...textPaths,
+      ],
+      commandOptions,
+    );
+  }
+
+  await runCommand(["git", "diff", "--check"], commandOptions);
+  await runCommand(
+    [
+      "bunx",
+      "--no-install",
+      "turbo",
+      "run",
+      "typecheck",
+      "--filter=@scout-for-lol/design-system",
+    ],
+    commandOptions,
+  );
+  await runCommand(
+    [
+      "bunx",
+      "--no-install",
+      "turbo",
+      "run",
+      "test",
+      "--filter=@scout-for-lol/data",
+    ],
+    commandOptions,
+  );
+}

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, it } from "vitest";
 import type { Duration } from "@temporalio/common";
-import { DataDragonWorkflowInputSchema } from "#activities/data-dragon.ts";
+import { LanePriorWorkflowInputSchema } from "#activities/lane-prior-refresh.ts";
 import { DYNAMIC_AGENT_TASK_MEMO_KEY } from "#shared/agent-task-identifiers.ts";
 import {
   DELETED_SCHEDULE_IDS,
@@ -132,6 +132,7 @@ const WORKFLOWS_WITHOUT_LONG_SLEEPS = new Set([
   "agentTaskWorkflow",
   "runScoutDataDragonVersionCheck",
   "runScoutDataDragonWeeklyRefresh",
+  "runScoutLanePriorsWeeklyRefresh",
   // Clones the monorepo, runs the deterministic catalog cross-check, opens a
   // PR on drift. No long sleeps of its own — the single refreshLlmCatalog
   // activity carries its own startToCloseTimeout + retry budget.
@@ -229,16 +230,10 @@ describe("durationToMs parser", () => {
   });
 });
 
-describe("Scout Data Dragon lane-prior schedule config", () => {
-  test.each([
-    "scout-data-dragon-version-check",
-    "scout-data-dragon-weekly-refresh",
-  ])("%s passes explicit lane-prior eval inputs", (scheduleId) => {
-    const schedule = SCHEDULES.find((candidate) => candidate.id === scheduleId);
-    if (schedule === undefined) {
-      throw new Error(`Missing schedule ${scheduleId}`);
-    }
-    const input = DataDragonWorkflowInputSchema.parse(schedule.args[0]);
+describe("Scout lane-prior schedule config", () => {
+  test("passes explicit lane-prior eval inputs only to its own workflow", () => {
+    const schedule = findScheduleById("scout-lane-priors-weekly-refresh");
+    const input = LanePriorWorkflowInputSchema.parse(schedule.args[0]);
     expect(input.lanePriors).toMatchObject({
       bucket: "scout-prod",
       queueIds: [400, 420, 440, 480, 490],
@@ -250,6 +245,12 @@ describe("Scout Data Dragon lane-prior schedule config", () => {
       holdoutSeed: "scout-lane-priors-patch-cadence-v1",
       threshold: 0.95,
     });
+    expect(findScheduleById("scout-data-dragon-version-check").args).toEqual(
+      [],
+    );
+    expect(findScheduleById("scout-data-dragon-weekly-refresh").args).toEqual(
+      [],
+    );
   });
 });
 

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -213,7 +213,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "scout-data-dragon-version-check",
     workflowType: "runScoutDataDragonVersionCheck",
-    args: [SCOUT_LANE_PRIOR_UPDATE_CONFIG],
+    args: [],
     cronExpression: "0 6 * * 0-5",
     taskQueue: TASK_QUEUES.DEFAULT,
     overlap: ScheduleOverlapPolicy.SKIP,
@@ -228,7 +228,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "scout-data-dragon-weekly-refresh",
     workflowType: "runScoutDataDragonWeeklyRefresh",
-    args: [SCOUT_LANE_PRIOR_UPDATE_CONFIG],
+    args: [],
     cronExpression: "0 6 * * 6",
     taskQueue: TASK_QUEUES.DEFAULT,
     overlap: ScheduleOverlapPolicy.SKIP,
@@ -237,6 +237,16 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // always recorded before the workflow times out.
     workflowExecutionTimeout: "4 hours",
     memo: "Weekly Scout Data Dragon refresh even when version is unchanged",
+  },
+  {
+    id: "scout-lane-priors-weekly-refresh",
+    workflowType: "runScoutLanePriorsWeeklyRefresh",
+    args: [SCOUT_LANE_PRIOR_UPDATE_CONFIG],
+    cronExpression: "0 7 * * 6",
+    taskQueue: TASK_QUEUES.DEFAULT,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "4 hours",
+    memo: "Weekly Scout lane-prior refresh and evaluation",
   },
   {
     id: "llm-catalog-refresh-weekly",

--- a/packages/temporal/src/workflows/data-dragon.test.ts
+++ b/packages/temporal/src/workflows/data-dragon.test.ts
@@ -7,7 +7,6 @@ import type {
   DataDragonUpdateResult,
   DataDragonVersionState,
 } from "#activities/data-dragon.ts";
-import type { LanePriorUpdateConfig } from "#activities/data-dragon-lane-priors.ts";
 import { runScoutDataDragonWeeklyRefresh } from "./index.ts";
 
 const TASK_QUEUE = "scout-data-dragon-test";
@@ -16,18 +15,6 @@ const VERSION_STATE: DataDragonVersionState = {
   currentVersion: "16.15.0",
   latestVersion: "16.15.1",
   updateRequired: true,
-};
-
-const LANE_PRIORS: LanePriorUpdateConfig = {
-  bucket: "scout-lane-priors",
-  queueIds: [420],
-  trainingStartDate: "2026-01-01",
-  trainingEndDate: "2026-02-01",
-  holdoutStartDate: "2026-02-02",
-  holdoutEndDate: "2026-02-09",
-  holdoutSampleSize: 100,
-  holdoutSeed: "seed",
-  threshold: 0.5,
 };
 
 type RecordFailureInput = DataDragonVersionState & {
@@ -75,7 +62,7 @@ async function runWithFailingUpdate(updateError: Error): Promise<{
   try {
     await worker.runUntil(
       testEnvironment.client.workflow.execute(runScoutDataDragonWeeklyRefresh, {
-        args: [{ lanePriors: LANE_PRIORS }],
+        args: [],
         taskQueue: TASK_QUEUE,
         workflowId: `scout-data-dragon-failure-${crypto.randomUUID()}`,
       }),
@@ -149,7 +136,7 @@ describe("runScoutDataDragonWeeklyRefresh terminal-failure recording", () => {
         testEnvironment.client.workflow.execute(
           runScoutDataDragonWeeklyRefresh,
           {
-            args: [{ lanePriors: LANE_PRIORS }],
+            args: [],
             taskQueue: TASK_QUEUE,
             workflowId: `scout-data-dragon-delivery-${crypto.randomUUID()}`,
           },

--- a/packages/temporal/src/workflows/data-dragon.ts
+++ b/packages/temporal/src/workflows/data-dragon.ts
@@ -2,7 +2,6 @@ import { patched, proxyActivities } from "@temporalio/workflow";
 import type {
   DataDragonActivities,
   DataDragonVersionState,
-  DataDragonWorkflowInput,
   DataDragonUpdateMode,
   DataDragonUpdateResult,
 } from "#activities/data-dragon.ts";
@@ -305,7 +304,6 @@ function failureReport(
 
 export async function runScoutDataDragonUpdate(
   mode: DataDragonUpdateMode,
-  input: DataDragonWorkflowInput,
 ): Promise<DataDragonUpdateResult | undefined> {
   const startedAt = new Date().toISOString();
   let state: DataDragonVersionState | undefined;
@@ -328,7 +326,6 @@ export async function runScoutDataDragonUpdate(
       result = await updateDataDragon({
         ...state,
         mode,
-        lanePriors: input.lanePriors,
       });
       report = dataDragonReport(startedAt, mode, state, result);
     }

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -28,10 +28,12 @@ import type {
 } from "#activities/scout-image-gc.ts";
 import { runVeleroOrphanAuditWorkflow as _runVeleroOrphanAuditWorkflow } from "./velero-orphan-audit.ts";
 import { runScoutDataDragonUpdate as _runScoutDataDragonUpdate } from "./data-dragon.ts";
+import { runScoutLanePriorsWeeklyRefresh as _runScoutLanePriorsWeeklyRefresh } from "./lane-prior-refresh.ts";
+import type { DataDragonUpdateResult } from "#activities/data-dragon.ts";
 import type {
-  DataDragonUpdateResult,
-  DataDragonWorkflowInput,
-} from "#activities/data-dragon.ts";
+  LanePriorRefreshResult,
+  LanePriorWorkflowInput,
+} from "#activities/lane-prior-refresh.ts";
 import { runLlmCatalogRefresh as _runLlmCatalogRefresh } from "./llm-catalog-refresh.ts";
 import type { LlmCatalogRefreshResult } from "#activities/llm-catalog-refresh.ts";
 import { runHomelabCrdImportsRefresh as _runHomelabCrdImportsRefresh } from "./homelab-crd-imports-refresh.ts";
@@ -199,16 +201,22 @@ export async function runVeleroOrphanAuditWorkflow(): Promise<void> {
   return _runVeleroOrphanAuditWorkflow();
 }
 
-export async function runScoutDataDragonVersionCheck(
-  input: DataDragonWorkflowInput,
-): Promise<DataDragonUpdateResult | undefined> {
-  return _runScoutDataDragonUpdate("version-check", input);
+export async function runScoutDataDragonVersionCheck(): Promise<
+  DataDragonUpdateResult | undefined
+> {
+  return _runScoutDataDragonUpdate("version-check");
 }
 
-export async function runScoutDataDragonWeeklyRefresh(
-  input: DataDragonWorkflowInput,
-): Promise<DataDragonUpdateResult | undefined> {
-  return _runScoutDataDragonUpdate("weekly-refresh", input);
+export async function runScoutDataDragonWeeklyRefresh(): Promise<
+  DataDragonUpdateResult | undefined
+> {
+  return _runScoutDataDragonUpdate("weekly-refresh");
+}
+
+export async function runScoutLanePriorsWeeklyRefresh(
+  input: LanePriorWorkflowInput,
+): Promise<LanePriorRefreshResult> {
+  return _runScoutLanePriorsWeeklyRefresh(input);
 }
 
 export async function runLlmCatalogRefresh(): Promise<LlmCatalogRefreshResult> {

--- a/packages/temporal/src/workflows/lane-prior-refresh.test.ts
+++ b/packages/temporal/src/workflows/lane-prior-refresh.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import type {
+  LanePriorRefreshResult,
+  LanePriorWorkflowInput,
+} from "#activities/lane-prior-refresh.ts";
+import { runScoutLanePriorsWeeklyRefresh } from "./index.ts";
+
+const TASK_QUEUE = "scout-lane-prior-test";
+const INPUT: LanePriorWorkflowInput = {
+  lanePriors: {
+    bucket: "scout-test",
+    queueIds: [420],
+    trainingStartDate: "2026-01-01",
+    trainingEndDate: "2026-02-01",
+    holdoutStartDate: "2026-02-02",
+    holdoutEndDate: "2026-02-09",
+    holdoutSampleSize: 10,
+    holdoutSeed: "seed",
+    threshold: 0.95,
+  },
+};
+
+const RESULT: LanePriorRefreshResult = {
+  changedFiles: ["lane-priors.generated.json"],
+  contentHash: "0123456789ab",
+  branchName: "chore/scout-lane-priors-0123456789ab",
+  commitHash: "abc123",
+  prUrl: "https://github.com/shepherdjerred/monorepo/pull/99",
+  outcome: "success",
+  reason: "pr-created",
+  autoMergeConfigured: true,
+};
+
+let testEnvironment: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+  testEnvironment = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnvironment.teardown();
+});
+
+describe("runScoutLanePriorsWeeklyRefresh", () => {
+  test("publishes an independent lane-prior result and report", async () => {
+    const reports: unknown[] = [];
+    const worker = await Worker.create({
+      connection: testEnvironment.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        updateLanePriors: (_input: LanePriorWorkflowInput) => RESULT,
+        deliverActivityReport: (input: unknown) => {
+          reports.push(input);
+          return { accepted: true, duplicate: false, reportRunId: "report-1" };
+        },
+      },
+    });
+
+    const result = await worker.runUntil(
+      testEnvironment.client.workflow.execute(runScoutLanePriorsWeeklyRefresh, {
+        args: [INPUT],
+        taskQueue: TASK_QUEUE,
+        workflowId: `scout-lane-prior-${crypto.randomUUID()}`,
+      }),
+    );
+
+    expect(result).toEqual(RESULT);
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      reportType: "scout-lane-priors",
+      scheduleId: "scout-lane-priors-weekly-refresh",
+      verdict: "changed",
+    });
+  }, 30_000);
+});

--- a/packages/temporal/src/workflows/lane-prior-refresh.ts
+++ b/packages/temporal/src/workflows/lane-prior-refresh.ts
@@ -1,0 +1,216 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type {
+  LanePriorActivities,
+  LanePriorRefreshResult,
+  LanePriorWorkflowInput,
+} from "#activities/lane-prior-refresh.ts";
+import type {
+  ActivityReportInput,
+  ReportDeliveryActivities,
+} from "#activities/report-delivery.ts";
+
+const { updateLanePriors } = proxyActivities<LanePriorActivities>({
+  startToCloseTimeout: "90 minutes",
+  heartbeatTimeout: "60 seconds",
+  retry: {
+    maximumAttempts: 2,
+    initialInterval: "5 minutes",
+    backoffCoefficient: 2,
+    maximumInterval: "15 minutes",
+  },
+});
+
+const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  startToCloseTimeout: "2 minutes",
+  retry: { maximumAttempts: 3 },
+});
+
+function evaluation(result: LanePriorRefreshResult): {
+  changed: boolean;
+  pending: boolean;
+  publicationFailed: boolean;
+  autoMergeFailed: boolean;
+} {
+  const publicationRequired =
+    result.reason === "pr-created" || result.reason === "pr-already-open";
+  return {
+    changed: result.reason === "pr-created",
+    pending: result.reason === "pr-already-open",
+    publicationFailed: publicationRequired && result.prUrl === undefined,
+    autoMergeFailed: result.autoMergeConfigured === false,
+  };
+}
+
+function publicationEvidence(
+  result: LanePriorRefreshResult,
+  state: ReturnType<typeof evaluation>,
+  attention: boolean,
+): ActivityReportInput["evidence"][number] | undefined {
+  if (!state.changed && !state.pending) return undefined;
+  return {
+    id: "proposal-publication",
+    source: "GitHub pull request publication and auto-merge state",
+    observedAt: new Date().toISOString(),
+    status: attention ? "failure" : "success",
+    ...(result.prUrl === undefined ? {} : { url: result.prUrl }),
+    excerpt: result.prUrl ?? "PR URL missing",
+  };
+}
+
+function publicationStatus(
+  state: ReturnType<typeof evaluation>,
+): ActivityReportInput["checks"][number]["status"] {
+  if (state.publicationFailed || state.autoMergeFailed) return "failed";
+  if (state.changed || state.pending) return "passed";
+  return "skipped";
+}
+
+function reportVerdict(
+  state: ReturnType<typeof evaluation>,
+): ActivityReportInput["verdict"] {
+  if (state.publicationFailed || state.autoMergeFailed) return "attention";
+  if (state.changed) return "changed";
+  if (state.pending) return "pending";
+  return "clear";
+}
+
+function reportChecks(
+  result: LanePriorRefreshResult,
+  state: ReturnType<typeof evaluation>,
+): ActivityReportInput["checks"] {
+  const publicationRequired = state.changed || state.pending;
+  return [
+    {
+      id: "lane-prior-refresh",
+      label: "Lane-prior generation and evaluation",
+      required: true,
+      status: "passed",
+      summary: `${String(result.changedFiles.length)} changed files`,
+      evidenceReceiptIds: ["refresh-result"],
+    },
+    {
+      id: "proposal-publication",
+      label: "PR publication and auto-merge",
+      required: publicationRequired,
+      status: publicationStatus(state),
+      summary: result.prUrl ?? "No PR required",
+      evidenceReceiptIds: publicationRequired ? ["proposal-publication"] : [],
+    },
+  ];
+}
+
+function reportEvidence(
+  result: LanePriorRefreshResult,
+  state: ReturnType<typeof evaluation>,
+  attention: boolean,
+): ActivityReportInput["evidence"] {
+  const publication = publicationEvidence(result, state, attention);
+  return [
+    {
+      id: "refresh-result",
+      source: "Lane-prior generator, evaluation, preflight, and git diff",
+      observedAt: new Date().toISOString(),
+      status: "success",
+      excerpt: `${result.reason}; files=${result.changedFiles.join(", ") || "none"}`,
+    },
+    ...(publication === undefined ? [] : [publication]),
+  ];
+}
+
+function reportFindings(
+  result: LanePriorRefreshResult,
+  state: ReturnType<typeof evaluation>,
+): ActivityReportInput["findings"] {
+  if (!state.publicationFailed && !state.autoMergeFailed) return [];
+  return [
+    {
+      severity: "warning",
+      summary: "Lane-prior PR publication needs attention",
+      ...(result.prUrl === undefined ? {} : { detail: result.prUrl }),
+      evidenceReceiptIds: ["refresh-result"],
+    },
+  ];
+}
+
+function report(
+  startedAt: string,
+  result: LanePriorRefreshResult,
+): ActivityReportInput {
+  const state = evaluation(result);
+  const attention = state.publicationFailed || state.autoMergeFailed;
+  return {
+    reportType: "scout-lane-priors",
+    title: "Scout lane-prior refresh",
+    scheduleId: "scout-lane-priors-weekly-refresh",
+    startedAt,
+    execution: attention ? "partial" : "complete",
+    verdict: reportVerdict(state),
+    headline: `${result.reason}; ${String(result.changedFiles.length)} files changed${result.contentHash === undefined ? "" : `; hash=${result.contentHash}`}.`,
+    checks: reportChecks(result, state),
+    evidence: reportEvidence(result, state, attention),
+    findings: reportFindings(result, state),
+    limitations: state.autoMergeFailed
+      ? ["The PR exists, but automatic merge could not be configured."]
+      : [],
+    actions: state.autoMergeFailed
+      ? ["Review and merge the lane-prior PR manually when green."]
+      : [],
+    provenance: {
+      source: "Scout lane-prior artifacts and evaluation report",
+      query: "weekly-refresh",
+    },
+  };
+}
+
+function failureReport(startedAt: string, error: unknown): ActivityReportInput {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    reportType: "scout-lane-priors",
+    title: "Scout lane-prior refresh",
+    scheduleId: "scout-lane-priors-weekly-refresh",
+    startedAt,
+    execution: "failed",
+    verdict: "inconclusive",
+    headline: "Lane-prior automation failed; no clean conclusion was made.",
+    checks: [
+      {
+        id: "lane-prior-refresh",
+        label: "Lane-prior generation and evaluation",
+        required: true,
+        status: "failed",
+        summary: message,
+        evidenceReceiptIds: ["run-failure"],
+      },
+    ],
+    evidence: [
+      {
+        id: "run-failure",
+        source: "Scout lane-prior workflow",
+        observedAt: new Date().toISOString(),
+        status: "failure",
+        excerpt: message.slice(0, 2000),
+      },
+    ],
+    findings: [],
+    limitations: ["Lane-prior generation, validation, or publication failed."],
+    actions: ["Inspect the failed activity and rerun the schedule."],
+    provenance: {
+      source: "Scout lane-prior automation",
+      query: "weekly-refresh",
+    },
+  };
+}
+
+export async function runScoutLanePriorsWeeklyRefresh(
+  input: LanePriorWorkflowInput,
+): Promise<LanePriorRefreshResult> {
+  const startedAt = new Date().toISOString();
+  try {
+    const result = await updateLanePriors(input);
+    await deliverActivityReport(report(startedAt, result));
+    return result;
+  } catch (error: unknown) {
+    await deliverActivityReport(failureReport(startedAt, error));
+    throw error;
+  }
+}

--- a/packages/temporal/src/workflows/report-outcomes.test.ts
+++ b/packages/temporal/src/workflows/report-outcomes.test.ts
@@ -125,17 +125,6 @@ function dataDragonResult(
   return {
     ...VERSION_STATE,
     mode: "version-check",
-    lanePriors: {
-      bucket: "scout-prod",
-      queueIds: [420],
-      trainingStartDate: "2026-07-01",
-      trainingEndDate: "2026-07-07",
-      holdoutStartDate: "2026-07-08",
-      holdoutEndDate: "2026-07-10",
-      holdoutSampleSize: 10,
-      holdoutSeed: "seed",
-      threshold: 0.95,
-    },
     changedFiles: ["version.json"],
     branchName: "chore/data-dragon",
     commitHash: "b".repeat(40),


### PR DESCRIPTION
Why:
Scout automation can publish malformed generated output, couple Data Dragon and lane-prior changes, and overwrite stale proposal branches without checking ownership.

What:
- Add a shared generated-output preflight that formats generated text, checks Prettier and git whitespace, and runs focused Scout validation including the design-system typecheck and data tests.
- Keep Data Dragon focused on Data Dragon assets, while adding a dedicated hash-keyed weekly lane-prior workflow with independent publication, reporting, and auto-merge.
- Refresh stale Data Dragon proposals from current main only after the existing bot author/committer ownership guard passes; human-authored or amended branches are protected.
- Update schedules, workflow exports, rehearsal coverage, tests, and Temporal automation guidance.

Verification:
- `bunx --no-install turbo run typecheck test lint --filter=@shepherdjerred/temporal`
- `bunx --no-install turbo run check:rehearsal --filter=@shepherdjerred/temporal`
- `bunx --no-install lefthook run pre-commit`
- `git diff --cached --check`

Rollout:
Auto-merge remains enabled for both generated PR types. No changes were made to PR #2326.