### PR TITLE
chore(deps): make Talos group release age explicit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -183,7 +183,8 @@
         "siderolabs/talos",
         "ghcr.io/siderolabs/installer",
         "kubernetes/kubernetes"
-      ]
+      ],
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Talos factory images are not digest-compatible with the base ghcr.io/siderolabs/installer image digest.",

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -175,6 +175,7 @@ test("groups Talos, Kubernetes, and installer updates into one PR", async () => 
       "ghcr.io/siderolabs/installer",
       "kubernetes/kubernetes",
     ],
+    minimumReleaseAge: "0 days",
   });
 });
 


### PR DESCRIPTION
## Why

PR #2379 grouped Talos, Kubernetes, and installer updates, but Semgrep cannot infer that the grouping rule inherits the zero-day release policy from the adjacent critical-infrastructure rule. It therefore soft-failed the merged build for a missing minimum release age.

## What

- Declare `minimumReleaseAge: 0 days` directly on the Talos and Kubernetes grouping rule.
- Extend the focused Renovate config test to lock in that policy.

## Verification

- `bun --no-install --bun vitest run scripts/renovate-config.test.ts` — 8 passed
- `bunx turbo run lint --filter=@shepherdjerred/root-scripts` — passed with five existing warnings
- `bunx lefthook run pre-commit`