### PR TITLE
chore(deps): refresh routine tooling, images, and Helm charts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -827,7 +827,7 @@
         "@types/lodash": "^4.17.24",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitest/coverage-istanbul": "4.1.10",
-        "cdk8s-cli": "2.207.54",
+        "cdk8s-cli": "2.207.55",
         "eslint": "^10.3.0",
         "jiti": "^2.7.0",
         "prettier": "^3.9.6",
@@ -1074,8 +1074,8 @@
         "release-please": "17.11.1",
       },
       "devDependencies": {
-        "@vitest/coverage-istanbul": "4.1.9",
-        "vitest": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "vitest": "4.1.10",
       },
     },
     "packages/resume": {
@@ -2038,7 +2038,7 @@
     "js-cookie": "3.0.8",
     "js-yaml": "5.3.0",
     "linkify-it": "6.1.0",
-    "nanoid": "6.0.0",
+    "nanoid": "6.0.1",
     "pdfjs-dist": "6.2.108",
     "postcss": "8.5.26",
     "protobufjs": "^7.5.7",
@@ -4823,7 +4823,7 @@
 
     "cdk8s": ["cdk8s@2.70.94", "", { "dependencies": { "fast-json-patch": "^3.1.1", "follow-redirects": "^1.16.0", "yaml": "2.9.0" }, "peerDependencies": { "constructs": "^10" } }, "sha512-KIA0Lkn013nh2k+NmXQ7D1cVGpqMNGroPMC1R7cyTMKlVjD0OsATRJ9MXBdm48qjjKz+rM2Yv2vWCrlbrzNMdQ=="],
 
-    "cdk8s-cli": ["cdk8s-cli@2.207.54", "", { "dependencies": { "@types/node": "^16", "ajv": "^8.20.0", "cdk8s": "^2.70.93", "cdk8s-plus-33": "^2.5.49", "codemaker": "^1.139.0", "colors": "1.4.0", "constructs": "^10.8.1", "fs-extra": "^8", "jsii-pacmak": "^1.139.0", "jsii-rosetta": "^5.9.62", "jsii-srcmak": "0.1.1319", "json2jsii": "0.5.19", "semver": "^7.8.5", "sscaff": "^1.2.274", "table": "^6.9.0", "yaml": "2.9.0", "yargs": "^15" }, "bin": { "cdk8s": "bin/cdk8s" } }, "sha512-/30U5M90v7jR0e3zGyuehZTf0O3ZRHsmlYbmfWC1QD996WYPfaz3R+JWp2PlBaiLpXVorC8lShJzQBxmJlcsQg=="],
+    "cdk8s-cli": ["cdk8s-cli@2.207.55", "", { "dependencies": { "@types/node": "^16", "ajv": "^8.20.0", "cdk8s": "^2.70.94", "cdk8s-plus-33": "^2.5.49", "codemaker": "^1.139.0", "colors": "1.4.0", "constructs": "^10.8.1", "fs-extra": "^8", "jsii-pacmak": "^1.139.0", "jsii-rosetta": "^5.9.62", "jsii-srcmak": "0.1.1319", "json2jsii": "0.5.19", "semver": "^7.8.5", "sscaff": "^1.2.274", "table": "^6.9.0", "yaml": "2.9.0", "yargs": "^15" }, "bin": { "cdk8s": "bin/cdk8s" } }, "sha512-m3k8raGWRan7ZxYKt02+FZU1KzOGaGQ5pMIOY7gkPSg9E25LJH8QJKYpeEwfyWI3M6S17m6rvfyVrynghlZXWA=="],
 
     "cdk8s-plus-31": ["cdk8s-plus-31@2.6.43", "", { "dependencies": { "minimatch": "^9.0.9" }, "peerDependencies": { "cdk8s": "^2.68.11", "constructs": "^10.3.0" } }, "sha512-OtG09kUe3ErIZR1vriuwNYCqQYkB7g0cbqft5c1GItGFRmqcUKW2/rKrdDUjYmFMZDLj5bxccJitP3MUUCg1gw=="],
 
@@ -6453,7 +6453,7 @@
 
     "nano-css": ["nano-css@5.6.2", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "css-tree": "^1.1.2", "csstype": "^3.1.2", "fastest-stable-stringify": "^2.0.2", "inline-style-prefixer": "^7.0.1", "rtl-css-js": "^1.16.1", "stacktrace-js": "^2.0.2", "stylis": "^4.3.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw=="],
 
-    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
+    "nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -8295,10 +8295,6 @@
 
     "@shepherdjerred/discord-plays-core/@shepherdjerred/eslint-config": ["@shepherdjerred/eslint-config@file:packages/eslint-config", { "dependencies": { "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1", "@eslint/compat": "^2.1.0", "@eslint/js": "^10.0.1", "@typescript-eslint/utils": "^8.67.0", "eslint-config-prettier": "^10.1.8", "eslint-import-resolver-node": "^0.4.0", "eslint-import-resolver-typescript": "^4.4.4", "eslint-import-resolver-typescript-bun": "^0.0.104", "eslint-plugin-astro": "^3.0.1", "eslint-plugin-import": "^2.32.0", "eslint-plugin-jsx-a11y": "^6.10.2", "eslint-plugin-no-secrets": "^2.3.3", "eslint-plugin-react": "^7.37.5", "eslint-plugin-react-hooks": "^7.1.1", "eslint-plugin-react-native": "^5.0.0", "eslint-plugin-regexp": "^3.0.0", "eslint-plugin-unicorn": "^73.0.0", "jiti": "^2.7.0", "typescript-eslint": "^8.67.0" }, "devDependencies": { "@types/node": "^26.1.1", "@typescript-eslint/rule-tester": "^8.59.0", "@typescript/native": "npm:typescript@7.0.2", "@vitest/coverage-istanbul": "4.1.10", "vitest": "4.1.10" }, "peerDependencies": { "eslint": "^10.4.0", "typescript": "^6.0.3" } }],
 
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul": ["@vitest/coverage-istanbul@4.1.9", "", { "dependencies": { "@babel/core": "^7.29.0", "@istanbuljs/schema": "^0.1.3", "@jridgewell/gen-mapping": "^0.3.13", "@jridgewell/trace-mapping": "0.3.31", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA=="],
-
-    "@shepherdjerred/release-tools/vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
-
     "@shinyoshiaki/binary-data/is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
     "@shuding/opentype.js/fflate": ["fflate@0.7.3", "", {}, "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw=="],
@@ -9841,22 +9837,6 @@
 
     "@sentry/react-native/@sentry/browser/@sentry/replay-canvas": ["@sentry/replay-canvas@10.69.0", "", { "dependencies": { "@sentry/core": "10.69.0", "@sentry/replay": "10.69.0" } }, "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A=="],
 
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
-
-    "@shepherdjerred/release-tools/vitest/@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
-
     "@so-ric/colorspace/color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
 
     "@so-ric/colorspace/color/color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
@@ -11249,22 +11229,6 @@
 
     "@sentry/bundler-plugins/@sentry/cli/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
     "@so-ric/colorspace/color/color-convert/color-name": ["color-name@2.1.1", "", {}, "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg=="],
 
     "@so-ric/colorspace/color/color-string/color-name": ["color-name@2.1.1", "", {}, "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg=="],
@@ -11916,22 +11880,6 @@
     "@sentry/bundler-plugins/@sentry/cli/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "@sentry/bundler-plugins/@sentry/cli/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@shepherdjerred/release-tools/@vitest/coverage-istanbul/@babel/core/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@types/sanitize-html/htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "brace-expansion": "5.0.9",
     "ip-address": "10.5.0",
     "js-cookie": "3.0.8",
-    "nanoid": "6.0.0",
+    "nanoid": "6.0.1",
     "pdfjs-dist": "6.2.108",
     "postcss": "8.5.26",
     "protobufjs": "^7.5.7",

--- a/packages/homelab/src/cdk8s/generated/helm/postgres-operator.types.ts
+++ b/packages/homelab/src/cdk8s/generated/helm/postgres-operator.types.ts
@@ -10,7 +10,7 @@ export type PostgresoperatorHelmValuesImage = {
    */
   repository?: string;
   /**
-   * @default "v2.0.1"
+   * @default "v2.0.2"
    */
   tag?: string;
   /**
@@ -769,7 +769,7 @@ export type PostgresoperatorHelmValuesConfigConnectionPooler = {
   /**
    * docker image
    *
-   * @default "ghcr.io/zalando/postgres-operator/pgbouncer:v2.0.1"
+   * @default "ghcr.io/zalando/postgres-operator/pgbouncer:v2.0.2"
    */
   connection_pooler_image?: string;
   /**

--- a/packages/homelab/src/cdk8s/generated/helm/seaweedfs.types.ts
+++ b/packages/homelab/src/cdk8s/generated/helm/seaweedfs.types.ts
@@ -16,7 +16,7 @@ export type SeaweedfsHelmValuesGlobal = {
    * All app-specific global values are namespaced under global.seaweedfs
    * to avoid polluting the shared global namespace when used as a subchart.
    *
-   * @default {...} (16 keys)
+   * @default {...} (17 keys)
    */
   seaweedfs?: SeaweedfsHelmValuesGlobalSeaweedfs;
 };
@@ -30,6 +30,15 @@ export type SeaweedfsHelmValuesGlobalSeaweedfs = {
    * @default {"repository":"","name":"chrislusf/seaweedfs"}
    */
   image?: SeaweedfsHelmValuesGlobalSeaweedfsImage;
+  /**
+   * Enterprise license file, held in a Secret in the release namespace and
+   * mounted read-only on the components that run a master. A renewed Secret
+   * reaches the running master without a restart. SEAWEED_LICENSE is reserved
+   * while this is set: an extraEnvironmentVars entry of that name is dropped.
+   *
+   * @default {"existingSecret":"","secretKey":"seaweed-license.json","mountPath":"/etc/seaweedfs/license"}
+   */
+  license?: SeaweedfsHelmValuesGlobalSeaweedfsLicense;
   /**
    * @default "IfNotPresent"
    */
@@ -104,9 +113,26 @@ export type SeaweedfsHelmValuesGlobalSeaweedfsImage = {
    */
   repository?: string;
   /**
+   * chrislusf/seaweedfs-enterprise for the enterprise edition
+   *
    * @default "chrislusf/seaweedfs"
    */
   name?: string;
+};
+
+export type SeaweedfsHelmValuesGlobalSeaweedfsLicense = {
+  /**
+   * @default ""
+   */
+  existingSecret?: string;
+  /**
+   * @default "seaweed-license.json"
+   */
+  secretKey?: string;
+  /**
+   * @default "/etc/seaweedfs/license"
+   */
+  mountPath?: string;
 };
 
 export type SeaweedfsHelmValuesGlobalSeaweedfsSecurityConfig = {
@@ -328,7 +354,7 @@ export type SeaweedfsHelmValuesMaster = {
   /**
    * You can also use emptyDir storage:
    *
-   * @default {"type":"hostPath","storageClass":"","hostPathPrefix":"/ssd"}
+   * @default {...} (4 keys)
    */
   data?: SeaweedfsHelmValuesMasterData;
   /**
@@ -432,6 +458,13 @@ export type SeaweedfsHelmValuesMaster = {
    */
   priorityClassName?: string;
   /**
+   * used to specify a custom scheduler for master pods
+   * ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+   *
+   * @default ""
+   */
+  schedulerName?: string;
+  /**
    * used to assign a service account.
    * ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
    *
@@ -490,6 +523,10 @@ export type SeaweedfsHelmValuesMasterData = {
    * @default "hostPath"
    */
   type?: string;
+  /**
+   * @default "1Gi"
+   */
+  size?: string;
   /**
    * @default ""
    */
@@ -884,6 +921,13 @@ export type SeaweedfsHelmValuesVolume = {
    * @default ""
    */
   priorityClassName?: string;
+  /**
+   * used to specify a custom scheduler for volume pods
+   * ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+   *
+   * @default ""
+   */
+  schedulerName?: string;
   /**
    * used to assign a service account.
    * ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -1354,6 +1398,13 @@ export type SeaweedfsHelmValuesFiler = {
    */
   priorityClassName?: string;
   /**
+   * used to specify a custom scheduler for filer pods
+   * ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+   *
+   * @default ""
+   */
+  schedulerName?: string;
+  /**
    * used to assign a service account.
    * ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
    *
@@ -1591,6 +1642,8 @@ export type SeaweedfsHelmValuesFilerIngressesGrpcAnnotations = {
 
 export type SeaweedfsHelmValuesFilerExtraEnvironmentVars = {
   /**
+   * the WEED_MYSQL_* keys and the db credential secret only render while this is "true"
+   *
    * @default "false"
    */
   WEED_MYSQL_ENABLED?: boolean;
@@ -1900,6 +1953,13 @@ export type SeaweedfsHelmValuesS3 = {
    * @default ""
    */
   priorityClassName?: string;
+  /**
+   * used to assign a custom scheduler to server pods
+   * ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+   *
+   * @default ""
+   */
+  schedulerName?: string;
   /**
    * used to assign a service account.
    * ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -2352,6 +2412,10 @@ export type SeaweedfsHelmValuesSftp = {
   /**
    * @default ""
    */
+  schedulerName?: string;
+  /**
+   * @default ""
+   */
   serviceAccountName?: string;
   /**
    * @default {}
@@ -2621,6 +2685,10 @@ export type SeaweedfsHelmValuesAdmin = {
    * @default ""
    */
   priorityClassName?: string;
+  /**
+   * @default ""
+   */
+  schedulerName?: string;
   /**
    * @default ""
    */
@@ -3090,6 +3158,10 @@ export type SeaweedfsHelmValuesWorker = {
   /**
    * @default ""
    */
+  schedulerName?: string;
+  /**
+   * @default ""
+   */
   serviceAccountName?: string;
   /**
    * @default {}
@@ -3490,6 +3562,13 @@ export type SeaweedfsHelmValuesAllInOne = {
    */
   priorityClassName?: string;
   /**
+   * Used to assign a custom scheduler to pods
+   * ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+   *
+   * @default ""
+   */
+  schedulerName?: string;
+  /**
    * Used to assign a service account.
    * ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
    *
@@ -3849,6 +3928,13 @@ export type SeaweedfsHelmValuesCosi = {
    */
   containerSecurityContext?: SeaweedfsHelmValuesCosiContainerSecurityContext;
   /**
+   * used to assign a custom scheduler to cosi pods
+   * ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+   *
+   * @default ""
+   */
+  schedulerName?: string;
+  /**
    * @default ""
    */
   extraVolumes?: string;
@@ -4072,7 +4158,7 @@ export type SeaweedfsHelmValuesNetworkPolicyComponents = object;
 
 export type SeaweedfsHelmValues = {
   /**
-   * @default {"imageRegistry":"","imagePullSecrets":"","seaweedfs":{"createClusterRole":true,"image":{"repository":"","name":"chrislusf/seaweedfs"},"imagePullPolicy":"IfNotPresent","restartPolicy":"Always","loggingLevel":1,"enableSecurity":false,"masterServer":null,"securityConfig":{"jwtSigning":{"volumeWrite":true,"volumeRead":false,"filerWrite":false,"filerRead":false,"expiresAfterSeconds":{"volumeWrite":0,"volumeRead":0,"filerWrite":0,"filerRead":0}}},"serviceAccountName":"seaweedfs","serviceAccountAnnotations":{},"automountServiceAccountToken":true,"certificates":{"duration":"87600h","renewBefore":"720h","alphacrds":false},"monitoring":{"enabled":false,"gatewayHost":null,"gatewayPort":null,"additionalLabels":{}},"enableReplication":false,"replicationPlacement":"001","extraEnvironmentVars":{"WEED_CLUSTER_DEFAULT":"sw","WEED_CLUSTER_SW_MASTER":"{{ include \"seaweedfs.cluster.masterAddress\" . }}","WEED_CLUSTER_SW_FILER":"{{ include \"seaweedfs.cluster.filerAddress\" . }}"}}}
+   * @default {"imageRegistry":"","imagePullSecrets":"","seaweedfs":{"createClusterRole":true,"image":{"repository":"","name":"chrislusf/seaweedfs"},"license":{"existingSecret":"","secretKey":"seaweed-license.json","mountPath":"/etc/seaweedfs/license"},"imagePullPolicy":"IfNotPresent","restartPolicy":"Always","loggingLevel":1,"enableSecurity":false,"masterServer":null,"securityConfig":{"jwtSigning":{"volumeWrite":true,"volumeRead":false,"filerWrite":false,"filerRead":false,"expiresAfterSeconds":{"volumeWrite":0,"volumeRead":0,"filerWrite":0,"filerRead":0}}},"serviceAccountName":"seaweedfs","serviceAccountAnnotations":{},"automountServiceAccountToken":true,"certificates":{"duration":"87600h","renewBefore":"720h","alphacrds":false},"monitoring":{"enabled":false,"gatewayHost":null,"gatewayPort":null,"additionalLabels":{}},"enableReplication":false,"replicationPlacement":"001","extraEnvironmentVars":{"WEED_CLUSTER_DEFAULT":"sw","WEED_CLUSTER_SW_MASTER":"{{ include \"seaweedfs.cluster.masterAddress\" . }}","WEED_CLUSTER_SW_FILER":"{{ include \"seaweedfs.cluster.filerAddress\" . }}"}}}
    */
   global?: SeaweedfsHelmValuesGlobal;
   /**
@@ -4080,11 +4166,11 @@ export type SeaweedfsHelmValues = {
    */
   image?: SeaweedfsHelmValuesImage;
   /**
-   * @default {...} (47 keys)
+   * @default {...} (48 keys)
    */
   master?: SeaweedfsHelmValuesMaster;
   /**
-   * @default {...} (49 keys)
+   * @default {...} (50 keys)
    */
   volume?: SeaweedfsHelmValuesVolume;
   /**
@@ -4094,29 +4180,29 @@ export type SeaweedfsHelmValues = {
    */
   volumes?: SeaweedfsHelmValuesVolumes;
   /**
-   * @default {...} (51 keys)
+   * @default {...} (52 keys)
    */
   filer?: SeaweedfsHelmValuesFiler;
   /**
-   * @default {...} (38 keys)
+   * @default {...} (39 keys)
    */
   s3?: SeaweedfsHelmValuesS3;
   /**
-   * @default {...} (43 keys)
+   * @default {...} (44 keys)
    */
   sftp?: SeaweedfsHelmValuesSftp;
   /**
-   * @default {...} (38 keys)
+   * @default {...} (39 keys)
    */
   admin?: SeaweedfsHelmValuesAdmin;
   /**
-   * @default {...} (35 keys)
+   * @default {...} (36 keys)
    */
   worker?: SeaweedfsHelmValuesWorker;
   /**
    * All-in-one deployment configuration
    *
-   * @default {...} (38 keys)
+   * @default {...} (39 keys)
    */
   allInOne?: SeaweedfsHelmValuesAllInOne;
   /**
@@ -4124,7 +4210,7 @@ export type SeaweedfsHelmValues = {
    * Requires COSI CRDs and controller to be installed in the cluster
    * For more information, visit: https://container-object-storage-interface.github.io/docs/deployment-guide
    *
-   * @default {...} (15 keys)
+   * @default {...} (16 keys)
    */
   cosi?: SeaweedfsHelmValuesCosi;
   /**
@@ -4155,6 +4241,9 @@ export type SeaweedfsHelmParameters = {
   "global.seaweedfs.createClusterRole"?: string;
   "global.seaweedfs.image.repository"?: string;
   "global.seaweedfs.image.name"?: string;
+  "global.seaweedfs.license.existingSecret"?: string;
+  "global.seaweedfs.license.secretKey"?: string;
+  "global.seaweedfs.license.mountPath"?: string;
   "global.seaweedfs.imagePullPolicy"?: string;
   "global.seaweedfs.restartPolicy"?: string;
   "global.seaweedfs.loggingLevel"?: string;
@@ -4208,6 +4297,7 @@ export type SeaweedfsHelmParameters = {
   "master.extraArgs"?: string;
   "master.config"?: string;
   "master.data.type"?: string;
+  "master.data.size"?: string;
   "master.data.storageClass"?: string;
   "master.data.hostPathPrefix"?: string;
   "master.logs.type"?: string;
@@ -4226,6 +4316,7 @@ export type SeaweedfsHelmParameters = {
   "master.tolerations"?: string;
   "master.nodeSelector"?: string;
   "master.priorityClassName"?: string;
+  "master.schedulerName"?: string;
   "master.serviceAccountName"?: string;
   "master.ingress.enabled"?: string;
   "master.ingress.className"?: string;
@@ -4293,6 +4384,7 @@ export type SeaweedfsHelmParameters = {
   "volume.tolerations"?: string;
   "volume.nodeSelector"?: string;
   "volume.priorityClassName"?: string;
+  "volume.schedulerName"?: string;
   "volume.serviceAccountName"?: string;
   "volume.extraEnvironmentVars"?: string;
   "volume.livenessProbe.enabled"?: string;
@@ -4362,6 +4454,7 @@ export type SeaweedfsHelmParameters = {
   "filer.tolerations"?: string;
   "filer.nodeSelector"?: string;
   "filer.priorityClassName"?: string;
+  "filer.schedulerName"?: string;
   "filer.serviceAccountName"?: string;
   "filer.ingresses.http.enabled"?: string;
   "filer.ingresses.http.className"?: string;
@@ -4432,6 +4525,7 @@ export type SeaweedfsHelmParameters = {
   "s3.tolerations"?: string;
   "s3.nodeSelector"?: string;
   "s3.priorityClassName"?: string;
+  "s3.schedulerName"?: string;
   "s3.serviceAccountName"?: string;
   "s3.logs.type"?: string;
   "s3.logs.size"?: string;
@@ -4505,6 +4599,7 @@ export type SeaweedfsHelmParameters = {
   "sftp.tolerations"?: string;
   "sftp.nodeSelector"?: string;
   "sftp.priorityClassName"?: string;
+  "sftp.schedulerName"?: string;
   "sftp.serviceAccountName"?: string;
   "sftp.logs.type"?: string;
   "sftp.logs.hostPathPrefix"?: string;
@@ -4560,6 +4655,7 @@ export type SeaweedfsHelmParameters = {
   "admin.tolerations"?: string;
   "admin.nodeSelector"?: string;
   "admin.priorityClassName"?: string;
+  "admin.schedulerName"?: string;
   "admin.serviceAccountName"?: string;
   "admin.livenessProbe.enabled"?: string;
   "admin.livenessProbe.httpGet.path"?: string;
@@ -4615,6 +4711,7 @@ export type SeaweedfsHelmParameters = {
   "worker.tolerations"?: string;
   "worker.nodeSelector"?: string;
   "worker.priorityClassName"?: string;
+  "worker.schedulerName"?: string;
   "worker.serviceAccountName"?: string;
   "worker.livenessProbe.enabled"?: string;
   "worker.livenessProbe.httpGet.path"?: string;
@@ -4715,6 +4812,7 @@ export type SeaweedfsHelmParameters = {
   "allInOne.tolerations"?: string;
   "allInOne.nodeSelector"?: string;
   "allInOne.priorityClassName"?: string;
+  "allInOne.schedulerName"?: string;
   "allInOne.serviceAccountName"?: string;
   "allInOne.resources"?: string;
   "cosi.enabled"?: string;
@@ -4727,6 +4825,7 @@ export type SeaweedfsHelmParameters = {
   "cosi.sidecar.resources"?: string;
   "cosi.enableAuth"?: string;
   "cosi.existingConfigSecret"?: string;
+  "cosi.schedulerName"?: string;
   "cosi.extraVolumes"?: string;
   "cosi.extraVolumeMounts"?: string;
   "cosi.resources"?: string;

--- a/packages/homelab/src/cdk8s/package.json
+++ b/packages/homelab/src/cdk8s/package.json
@@ -49,7 +49,7 @@
     "@types/bun": "1.4.0",
     "@types/lodash": "^4.17.24",
     "@typescript/native": "npm:typescript@7.0.2",
-    "cdk8s-cli": "2.207.54",
+    "cdk8s-cli": "2.207.55",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
     "prettier": "^3.9.6",

--- a/packages/release-tools/package.json
+++ b/packages/release-tools/package.json
@@ -16,7 +16,7 @@
     "./runner": "./runner.ts"
   },
   "devDependencies": {
-    "@vitest/coverage-istanbul": "4.1.9",
-    "vitest": "4.1.9"
+    "@vitest/coverage-istanbul": "4.1.10",
+    "vitest": "4.1.10"
   }
 }

--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -287,7 +287,7 @@
         "registryUrl": "https://ghcr.io",
         "versioning": "docker"
       },
-      "value": "5.2.3@sha256:212b86dff59e3962b4082b5ef20a577e76c8f8527d2ab505cfa887b4bcecb0b0",
+      "value": "5.2.3@sha256:304b19cf94bf4fda534e0b086cab9c5f1a9e139a8180c05c0ad7d2ba1526fa99",
       "notes": [
         "Keep this on qBittorrent app versions only. LinuxServer also publishes",
         "stale OS-style tags like 20.04.1 that resolve to old app builds."
@@ -998,7 +998,7 @@
         "registryUrl": "https://opensource.zalando.com/postgres-operator/charts/postgres-operator",
         "versioning": "semver"
       },
-      "value": "2.0.1"
+      "value": "2.0.2"
     },
     {
       "name": "cooperspencer/gickup",
@@ -1070,7 +1070,7 @@
         "registryUrl": "https://seaweedfs.github.io/seaweedfs/helm",
         "versioning": "semver"
       },
-      "value": "4.41.0"
+      "value": "4.44.0"
     },
     {
       "name": "mariadb",
@@ -1082,7 +1082,7 @@
         "registryUrl": "https://charts.bitnami.com/bitnami",
         "versioning": "semver"
       },
-      "value": "27.0.6"
+      "value": "27.0.7"
     },
     {
       "name": "bitnami/mariadb",
@@ -1217,9 +1217,9 @@
         "managed": true,
         "datasource": "docker",
         "registryUrl": "https://docker.io",
-        "versioning": "semver"
+        "versioning": "docker"
       },
-      "value": "1.31.2@sha256:b5a9a3cfc86b81dd6f1458d53f2ad2b559cc255653d2efd6cacee5636bf2066f"
+      "value": "1.31.2-alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa"
     },
     {
       "name": "bugsink/bugsink",

--- a/renovate.json
+++ b/renovate.json
@@ -222,6 +222,19 @@
       "enabled": false
     },
     {
+      "description": "Native TypeScript 7 owns typechecking; keep direct TypeScript on 6 for typescript-eslint project service, Astro Check, Twoslash, and TypeDoc.",
+      "matchManagers": ["npm"],
+      "matchDepNames": ["typescript"],
+      "allowedVersions": "<7"
+    },
+    {
+      "description": "Keep the custom Corretto regex manager authoritative; disable only the native mise java dependency so Renovate cannot replace Corretto with another JDK distribution.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["java"],
+      "matchFileNames": [".mise.toml"],
+      "enabled": false
+    },
+    {
       "description": "Group @types/node with Node.js major updates",
       "groupName": "Node.js",
       "matchPackageNames": ["@types/node", "node"],

--- a/scripts/migration-core.ts
+++ b/scripts/migration-core.ts
@@ -1,5 +1,5 @@
 // renovate: datasource=npm depName=pyright
-export const PYRIGHT_VERSION = "1.1.411";
+export const PYRIGHT_VERSION = "1.1.413";
 
 export function deckCommand(deck: string): string[] {
   return [

--- a/scripts/pyright-check.ts
+++ b/scripts/pyright-check.ts
@@ -16,7 +16,7 @@ export async function checkPythonTypes(): Promise<void> {
     "--python",
     ".venv/bin/python",
   ]);
-  await run(["uvx", `pyright@${PYRIGHT_VERSION}`]);
+  await run(["bunx", "--bun", `pyright@${PYRIGHT_VERSION}`]);
 }
 
 if (import.meta.main) {

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -90,6 +90,14 @@ test("extracts every managed structured version-catalog field", async () => {
       packageName: "flipt/flipt",
     }),
   );
+  expect(actual).toContainEqual(
+    expect.objectContaining({
+      depName: "library/nginx",
+      datasource: "docker",
+      versioning: "docker",
+      currentValue: "1.31.2-alpine",
+    }),
+  );
 });
 
 test("excludes all sandbox dependency files", async () => {
@@ -176,6 +184,46 @@ test("groups Talos, Kubernetes, and installer updates into one PR", async () => 
       "kubernetes/kubernetes",
     ],
     minimumReleaseAge: "0 days",
+  });
+});
+
+test("keeps direct TypeScript on 6 without constraining the native alias", async () => {
+  const config = RenovateConfigSchema.parse(
+    await Bun.file(`${root}/renovate.json`).json(),
+  );
+  const rule = config.packageRules.find(
+    (candidate) =>
+      candidate.description ===
+      "Native TypeScript 7 owns typechecking; keep direct TypeScript on 6 for typescript-eslint project service, Astro Check, Twoslash, and TypeDoc.",
+  );
+
+  expect(rule).toEqual({
+    description:
+      "Native TypeScript 7 owns typechecking; keep direct TypeScript on 6 for typescript-eslint project service, Astro Check, Twoslash, and TypeDoc.",
+    matchManagers: ["npm"],
+    matchDepNames: ["typescript"],
+    allowedVersions: "<7",
+  });
+  expect(rule?.matchDepNames).not.toContain("@typescript/native");
+});
+
+test("keeps the custom Corretto manager authoritative for mise Java", async () => {
+  const config = RenovateConfigSchema.parse(
+    await Bun.file(`${root}/renovate.json`).json(),
+  );
+  const rule = config.packageRules.find(
+    (candidate) =>
+      candidate.description ===
+      "Keep the custom Corretto regex manager authoritative; disable only the native mise java dependency so Renovate cannot replace Corretto with another JDK distribution.",
+  );
+
+  expect(rule).toEqual({
+    description:
+      "Keep the custom Corretto regex manager authoritative; disable only the native mise java dependency so Renovate cannot replace Corretto with another JDK distribution.",
+    matchManagers: ["mise"],
+    matchDepNames: ["java"],
+    matchFileNames: [".mise.toml"],
+    enabled: false,
   });
 });
 


### PR DESCRIPTION
## Why

Routine Renovate proposals had accumulated across development tooling, immutable image pins, Helm charts, and dependency-manager policy. This maintenance batch updates the supported variants together without changing public APIs, schemas, runtime configuration interfaces, or first-party production image channels.

## What

- Refresh release-tools Vitest and coverage, nanoid, cdk8s-cli, and Pyright. Pyright now runs through its pinned npm package so execution matches the Renovate datasource.
- Advance Minecraft to 2026.8.2-java25, refresh the qBittorrent 5.2.3 digest, retain the independently confirmed nginx 1.31.2-alpine digest with Docker compatibility versioning, and update MariaDB, postgres-operator, and SeaweedFS charts.
- Regenerate deterministic Helm types. MariaDB retains its pinned images; postgres-operator advances its v2.0.2 images and adds Recreate strategy; SeaweedFS advances its chart images and removes inactive MySQL output. Immutable selectors, claim templates, service specs, and security contexts remain unchanged.
- Keep direct npm TypeScript below 7 while leaving the native TypeScript alias unconstrained, and disable only the native mise Java dependency so the custom Corretto manager remains authoritative.
- Retain the canonical Kueue registry coordinate and existing qBittorrent semantic-version and v20 protections.

The branch intentionally excludes first-party production image promotions, .NET, TypeScript 7 replacement, Talos/Kubernetes, UniFFI, React Native, the deprecated Discord selfbot migration, and qBittorrent v20. The KeyboardShortcuts 3.0.1 floor and nginx digest update landed independently on main while this branch was in progress, so they are accepted from the base rather than duplicated here.

## Verification

- `bun install`
- `bun install --frozen-lockfile`
- Focused release-tools, Pyright, root-scripts, version-catalog, and Renovate tests
- TaskNotes `mac:verify`, including XCFramework preflight and release launch smoke, before the equivalent KeyboardShortcuts floor change landed on main
- CDK8s generate, build, typecheck, lint, unit tests, and live-fetch Helm render tests
- Two full Helm type generations with an identical resulting diff hash
- Old/new Helm template comparisons for all three upgraded charts
- Independent exact-tag digest checks for Minecraft, nginx, qBittorrent, and Kueue
- Zero-diff comparison for every catalog entry ending in `/prod`
- Explicit checks for no .NET files and no TypeScript manifest changes
- `bunx lefthook run pre-commit` for every commit

No media is required for this dependency and infrastructure configuration change.

Buildkite #11051 passed on the exact PR head, including exhaustive repository verification, browser/E2E checks, the required Codex review gate, and infrastructure/image dry-runs. The optional Trivy findings lane soft-failed and does not block the gate.

Dependency Dashboard #481 was manually triggered, but hosted Renovate has not consumed the checkbox yet. Because the new policy is not on the default branch until merge, confirm the TypeScript, native Java, KeyboardShortcuts, qBittorrent v20, and Kueue outcomes with another dashboard run after merge.

No Argo, deployment, reachability, or runtime acceptance is claimed; those remain post-merge checks.
