### PR TITLE
feat(brim): add local quota history and legacy provider controls

### DIFF
--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -1,15 +1,17 @@
 # Brim
 
 Brim is a personal macOS menu-bar app for monitoring AI subscription
-quotas. It currently targets Claude Code, Codex, Kimi Code, and Grok.
+quotas. It targets Claude Code and Codex by default. Kimi Code and Grok remain
+available only through the Advanced legacy-provider setting.
 
 Brim is the product name; QuotaBar is the Xcode target, bundle id
 (`com.sjerred.QuotaBar`), and workspace package id
 (`@shepherdjerred/quotabar`).
 
 The menu bar also shows the configured personal subscription spend: $200/month
-for Claude Code, $200/month for Codex, $40/month for Kimi Code, and $30/month
-for Grok ($470/month total). This is a reminder, not provider billing data.
+for Claude Code and $200/month for Codex ($400/month total). Enabling legacy
+providers adds Kimi Code ($40/month) and Grok ($30/month). This is a reminder,
+not provider billing data.
 
 The compact subscription view sorts providers by their tightest current quota,
 keeps each quota and reset on one line, and uses pressure colors only for low or
@@ -107,10 +109,13 @@ macOS release checks; this package does not add a macOS CI lane.
 Brim reads existing local OAuth credentials or accepts an optional token
 override in Settings. Overrides are stored in the macOS login Keychain, take
 precedence over local discovery, and can be removed from the same screen.
-Brim does not log tokens or include them in its JSON usage cache.
+Brim does not log tokens or include them in its JSON usage cache. It stores only
+local historical quota samples (provider/window metadata, percentages, reset
+times, and timestamps) for up to 30 days so it can render the History graph.
 
-Claude and Codex use their typed local credential formats. Kimi Code reads its
-`KIMI_CODE_HOME` credential directory (default `~/.kimi-code`). Kimi and Grok
+Claude and Codex use their typed local credential formats. When the legacy
+provider setting is enabled, Kimi Code reads its `KIMI_CODE_HOME` credential
+directory (default `~/.kimi-code`). Kimi and Grok
 can also read typed OAuth entries from OpenCode. OpenCode remains the sole owner
 and writer of those OAuth token chains: Brim never rotates, refreshes, or
 rewrites OpenCode files or its credential database. An expired or rejected
@@ -143,10 +148,11 @@ calendar pace against OpenRouter's authoritative monthly usage period. Chatroom
 and Fusion activity is outside this first API-key reporting slice.
 
 Provider contracts are isolated in focused files under `Sources/QuotaBarCore`.
-Claude and Codex endpoints are authenticated subscription web surfaces, while
-Kimi and Grok use private subscription quota surfaces. They are unsupported
-contracts and may change without notice. Provider response changes produce an
-explicit unavailable, partial, or stale state rather than a fabricated zero.
+Claude and Codex endpoints are authenticated subscription web surfaces. Legacy
+Kimi and Grok support uses private subscription quota surfaces and is disabled
+by default because those contracts may change without notice. When enabled,
+provider response changes produce an explicit unavailable, partial, or stale
+state rather than a fabricated zero.
 
 ## Development
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/BrimBranding.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/BrimBranding.swift
@@ -20,7 +20,7 @@ struct BrimBrandMark: View {
         .fill(Color(red: 0.15, green: 0.15, blue: 0.36))
       Image(nsImage: BrimAssets.markImage)
         .resizable()
-        .aspectRatio(contentMode: .fit)
+        .scaledToFit()
         .padding(4)
     }
     .frame(width: 24, height: 24)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/MenuBarView.swift
@@ -21,59 +21,84 @@ struct MenuBarView: View {
     .background(Color(nsColor: .windowBackgroundColor))
   }
 
-  private func content(at date: Date) -> some View {
+  @ViewBuilder private func content(at date: Date) -> some View {
     switch selectedSegment {
     case .subscriptions:
-      let overview = QuotaOverview(states: providerStates, at: date)
-      return AnyView(
-        VStack(spacing: 0) {
-          header(
-            lastUpdatedAt: overview.lastUpdatedAt,
-            isRefreshing: model.isRefreshing,
-            date: date
-          ) {
-            Task { await model.refresh() }
-          }
-          navigationSegments
-          WindowColumnHeader()
-            .padding(.horizontal, 12)
-            .padding(.vertical, 5)
-          Divider()
-          providerList(overview: overview, date: date)
-          Divider()
-          spendRow
-          Spacer(minLength: 0)
-          Divider()
-          footer
-        }
-        .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
-      )
+      subscriptionContent(at: date)
     case .api:
-      return AnyView(
-        VStack(spacing: 0) {
-          header(
-            lastUpdatedAt: apiLastUpdatedAt,
-            isRefreshing: apiModel.isRefreshing,
-            date: date
-          ) {
-            Task { await apiModel.refresh() }
-          }
-          navigationSegments
-          Divider()
-          APIPlatformSummaryView(state: apiModel.state, date: date)
-            .frame(minHeight: 220)
-          if let cacheError = apiModel.cacheErrorMessage {
-            Divider()
-            StatusMessage(symbol: "externaldrive.badge.exclamationmark", text: cacheError)
-              .padding(.horizontal, 12)
-          }
-          Spacer(minLength: 0)
-          Divider()
-          footer
-        }
-        .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
-      )
+      apiContent(at: date)
+    case .history:
+      historyContent(at: date)
     }
+  }
+
+  private func subscriptionContent(at date: Date) -> some View {
+    let overview = QuotaOverview(
+      states: providerStates,
+      providerIDs: model.settings.visibleProviderIDs,
+      at: date
+    )
+    return VStack(spacing: 0) {
+      header(lastUpdatedAt: overview.lastUpdatedAt, isRefreshing: model.isRefreshing, date: date) {
+        Task { await model.refresh() }
+      }
+      navigationSegments
+      WindowColumnHeader().padding(.horizontal, 12).padding(.vertical, 5)
+      Divider()
+      providerList(overview: overview, date: date)
+      Divider()
+      spendRow
+      Spacer(minLength: 0)
+      Divider()
+      footer
+    }
+    .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
+  }
+
+  private func apiContent(at date: Date) -> some View {
+    VStack(spacing: 0) {
+      header(lastUpdatedAt: apiLastUpdatedAt, isRefreshing: apiModel.isRefreshing, date: date) {
+        Task { await apiModel.refresh() }
+      }
+      navigationSegments
+      Divider()
+      APIPlatformSummaryView(state: apiModel.state, date: date).frame(minHeight: 220)
+      if let cacheError = apiModel.cacheErrorMessage {
+        Divider()
+        StatusMessage(symbol: "externaldrive.badge.exclamationmark", text: cacheError)
+          .padding(.horizontal, 12)
+      }
+      Spacer(minLength: 0)
+      Divider()
+      footer
+    }
+    .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
+  }
+
+  private func historyContent(at date: Date) -> some View {
+    VStack(spacing: 0) {
+      header(
+        lastUpdatedAt: model.history.last?.recordedAt, isRefreshing: model.isRefreshing, date: date
+      ) {
+        Task { await model.refresh() }
+      }
+      navigationSegments
+      Divider()
+      UsageHistoryView(
+        samples: model.history,
+        visibleProviderIDs: model.settings.visibleProviderIDs,
+        date: date
+      )
+      if let historyError = model.historyErrorMessage {
+        Divider()
+        StatusMessage(symbol: "externaldrive.badge.exclamationmark", text: historyError)
+          .padding(.horizontal, 12)
+      }
+      Spacer(minLength: 0)
+      Divider()
+      footer
+    }
+    .frame(minHeight: menuBarWindowMinimumHeight, alignment: .top)
   }
 
   private var providerStates: [ProviderID: ProviderDisplayState] {
@@ -120,6 +145,7 @@ struct MenuBarView: View {
     HStack(spacing: 2) {
       segmentButton(.subscriptions, title: "Subscriptions")
       segmentButton(.api, title: "API & routers")
+      segmentButton(.history, title: "History")
     }
     .padding(2)
     .background(.quaternary, in: RoundedRectangle(cornerRadius: 7))
@@ -152,7 +178,7 @@ struct MenuBarView: View {
           StatusMessage(symbol: "exclamationmark.triangle", text: startupError)
         }
         ForEach(overview.providers) { provider in
-          ProviderSectionView(overview: provider, date: date)
+          ProviderSectionView(overview: provider, date: date, history: model.history)
           if provider.id != overview.providers.last?.id {
             Divider().padding(.leading, 25)
           }
@@ -184,14 +210,20 @@ struct MenuBarView: View {
     HStack {
       Text("Subscriptions")
       Spacer()
-      Text("$\(SubscriptionPlan.totalMonthlyCostUSD)/mo")
-        .monospacedDigit()
+      Text(
+        "$\(SubscriptionPlan.totalMonthlyCostUSD(includingLegacy: model.settings.showsLegacyProviders))/mo"
+      )
+      .monospacedDigit()
     }
     .font(.caption)
     .foregroundStyle(.secondary)
     .padding(.horizontal, 12)
     .padding(.vertical, 7)
-    .help("Claude Code $200, Codex $200, Kimi $40, Grok $30")
+    .help(
+      model.settings.showsLegacyProviders
+        ? "Claude Code $200, Codex $200, Kimi Code $40, Grok $30"
+        : "Claude Code $200, Codex $200"
+    )
   }
 
   private var footer: some View {
@@ -223,6 +255,7 @@ struct MenuBarView: View {
 private enum DashboardSegment {
   case subscriptions
   case api
+  case history
 }
 
 private struct ProviderListHeightPreference: PreferenceKey {

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/Previews.swift
@@ -98,7 +98,7 @@ private struct OverviewPreview: View {
       WindowColumnHeader()
         .padding(.vertical, 5)
       ForEach(overview.providers) { provider in
-        ProviderSectionView(overview: provider, date: PreviewData.now)
+        ProviderSectionView(overview: provider, date: PreviewData.now, history: [])
         if provider.id != overview.providers.last?.id {
           Divider().padding(.leading, 25)
         }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/ProviderViews.swift
@@ -80,6 +80,7 @@ struct ProviderBadgeView: View {
 struct ProviderSectionView: View {
   let overview: ProviderOverview
   let date: Date
+  let history: [UsageHistorySample]
 
   var body: some View {
     VStack(alignment: .leading, spacing: 7) {
@@ -160,7 +161,15 @@ struct ProviderSectionView: View {
           window: window,
           date: date,
           stale: isStale,
-          entitlementDetail: window.kind == .entitlement ? entitlementDetail : nil
+          entitlementDetail: window.kind == .entitlement ? entitlementDetail : nil,
+          todayUsedPercent: window.isWeekly
+            ? UsageHistory.todayUsedPercent(
+              provider: snapshot.provider,
+              windowID: window.id,
+              samples: history,
+              at: date
+            )
+            : nil
         )
       }
     }
@@ -181,6 +190,7 @@ struct WindowRow: View {
   let date: Date
   let stale: Bool
   let entitlementDetail: String?
+  let todayUsedPercent: Double?
 
   var body: some View {
     if window.kind == .entitlement {
@@ -210,6 +220,10 @@ struct WindowRow: View {
         pacingCaption(pacing)
           .padding(.leading, 103)
       }
+      if window.isWeekly {
+        todayCaption
+          .padding(.leading, 103)
+      }
     }
     .font(.caption)
     .foregroundStyle(stale ? .secondary : .primary)
@@ -228,6 +242,18 @@ struct WindowRow: View {
       .monospacedDigit()
       .foregroundStyle(stale ? .secondary : pacingColor(for: pacing.status))
       .help(pacingHelp(pacing))
+      .accessibilityHidden(true)
+  }
+
+  private var todayCaption: some View {
+    Text(todayUsedPercent.map { "Today: \(Int($0.rounded()))% used" } ?? "Today: —")
+      .font(.caption2)
+      .monospacedDigit()
+      .foregroundStyle(stale ? .secondary : .secondary)
+      .help(
+        "Usage percentage points consumed since local midnight from Brim's successful samples. "
+          + "A quota reset does not subtract from today's total."
+      )
       .accessibilityHidden(true)
   }
 
@@ -323,6 +349,13 @@ struct WindowRow: View {
       let actual = WindowPacing.format(pacing.actualPacePerDay)
       let even = WindowPacing.format(pacing.evenPacePerDay)
       values.append("\(label), pace \(actual), even split \(even)")
+    }
+    if window.isWeekly {
+      if let todayUsedPercent {
+        values.append("\(Int(todayUsedPercent.rounded())) percent used today")
+      } else {
+        values.append("today's usage unavailable until another sample is recorded")
+      }
     }
     return values.joined(separator: ", ")
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/QuotaBarApp.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/QuotaBarApp.swift
@@ -19,9 +19,12 @@ struct QuotaBarApp: App {
       local: LocalCredentialStore()
     )
     let providers: [any UsageProvider]
+    let providerFactory: (Set<ProviderID>) throws -> [any UsageProvider] = { providerIDs in
+      try Providers.live(credentials: credentials, providerIDs: providerIDs)
+    }
     let startupError: String?
     do {
-      providers = try Providers.live(credentials: credentials)
+      providers = try providerFactory(settings.visibleProviderIDs)
       startupError = nil
     } catch {
       providers = []
@@ -31,7 +34,11 @@ struct QuotaBarApp: App {
     let openRouterCredentials = OpenRouterCredentialStore()
     self.openRouterCredentials = openRouterCredentials
     self.startupError = startupError
-    let model = QuotaBarModel(providers: providers, settings: settings)
+    let model = QuotaBarModel(
+      providers: providers,
+      settings: settings,
+      providerFactory: providerFactory
+    )
     let apiModel = APIPlatformModel(settings: settings, credentials: openRouterCredentials)
     _model = State(initialValue: model)
     _apiModel = State(initialValue: apiModel)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
@@ -27,6 +27,9 @@ struct SettingsView: View {
     .formStyle(.grouped)
     .frame(width: 520, height: 720)
     .task { await loadCredentialStatus() }
+    .onChange(of: model.settings.visibleProviderIDs) { _, _ in
+      Task { await loadCredentialStatus() }
+    }
     .onAppear { launchAtLogin.refresh() }
   }
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/SettingsView.swift
@@ -18,13 +18,14 @@ struct SettingsView: View {
   var body: some View {
     Form {
       providerSection
+      advancedSection
       refreshSection
       loginSection
       credentialSection
       openRouterCredentialSection
     }
     .formStyle(.grouped)
-    .frame(width: 520, height: 680)
+    .frame(width: 520, height: 720)
     .task { await loadCredentialStatus() }
     .onAppear { launchAtLogin.refresh() }
   }
@@ -64,7 +65,7 @@ struct SettingsView: View {
 
   private var providerSection: some View {
     Section("Providers") {
-      ForEach(ProviderID.allCases) { provider in
+      ForEach(ProviderID.allCases.filter(model.settings.visibleProviderIDs.contains)) { provider in
         HStack {
           Toggle(provider.displayName, isOn: providerBinding(provider))
           Spacer()
@@ -75,6 +76,17 @@ struct SettingsView: View {
         Label(error, systemImage: "exclamationmark.triangle")
           .foregroundStyle(.red)
       }
+    }
+  }
+
+  private var advancedSection: some View {
+    Section("Advanced") {
+      Toggle("Show legacy providers", isOn: legacyProviderBinding)
+      Text(
+        "Kimi Code and Grok use unsupported subscription surfaces. They remain off unless you opt in."
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
     }
   }
 
@@ -113,7 +125,7 @@ struct SettingsView: View {
       )
       .font(.caption)
       .foregroundStyle(.secondary)
-      ForEach(ProviderID.allCases) { provider in
+      ForEach(ProviderID.allCases.filter(model.settings.visibleProviderIDs.contains)) { provider in
         VStack(alignment: .leading, spacing: 5) {
           HStack {
             SecureField("\(provider.displayName) token", text: draftBinding(provider))
@@ -145,6 +157,13 @@ struct SettingsView: View {
     Binding(
       get: { model.settings.pollingInterval },
       set: { model.updatePollingInterval($0) }
+    )
+  }
+
+  private var legacyProviderBinding: Binding<Bool> {
+    Binding(
+      get: { model.settings.showsLegacyProviders },
+      set: { model.setShowsLegacyProviders($0) }
     )
   }
 
@@ -191,7 +210,7 @@ struct SettingsView: View {
   }
 
   private func loadCredentialStatus() async {
-    for provider in ProviderID.allCases {
+    for provider in model.settings.visibleProviderIDs {
       do {
         if try await manualCredentials.credentialIfPresent(for: provider) != nil {
           overriddenProviders.insert(provider)

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/UsageHistoryView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/UsageHistoryView.swift
@@ -41,6 +41,7 @@ struct UsageHistoryView: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .onAppear { selectDefaultWindowIfNeeded() }
     .onChange(of: samples) { _, _ in selectDefaultWindowIfNeeded() }
+    .onChange(of: visibleProviderIDs) { _, _ in selectDefaultWindowIfNeeded() }
   }
 
   private var windows: [HistoryWindow] {
@@ -59,7 +60,9 @@ struct UsageHistoryView: View {
     guard let selectedWindowKey else { return [] }
     let cutoff = date.addingTimeInterval(-range.duration)
     return samples.filter { sample in
-      sample.windowIDWithProvider == selectedWindowKey && sample.recordedAt >= cutoff
+      visibleProviderIDs.contains(sample.provider)
+        && sample.windowIDWithProvider == selectedWindowKey
+        && sample.recordedAt >= cutoff
     }
     .sorted { $0.recordedAt < $1.recordedAt }
   }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBar/UsageHistoryView.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBar/UsageHistoryView.swift
@@ -1,0 +1,163 @@
+import Charts
+import QuotaBarCore
+import SwiftUI
+
+struct UsageHistoryView: View {
+  let samples: [UsageHistorySample]
+  let visibleProviderIDs: Set<ProviderID>
+  let date: Date
+  @State private var selectedWindowKey: String?
+  @State private var range: HistoryRange = .day
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if windows.isEmpty {
+        emptyState
+      } else {
+        Picker("Quota window", selection: $selectedWindowKey) {
+          ForEach(windows) { window in
+            Text("\(window.provider.displayName) · \(window.label)").tag(Optional(window.id))
+          }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+
+        Picker("History range", selection: $range) {
+          ForEach(HistoryRange.allCases) { range in
+            Text(range.label).tag(range)
+          }
+        }
+        .pickerStyle(.segmented)
+
+        if selectedSamples.count >= 2 {
+          chart
+          context
+        } else {
+          emptyState
+        }
+      }
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .onAppear { selectDefaultWindowIfNeeded() }
+    .onChange(of: samples) { _, _ in selectDefaultWindowIfNeeded() }
+  }
+
+  private var windows: [HistoryWindow] {
+    var latest: [String: UsageHistorySample] = [:]
+    for sample in samples where visibleProviderIDs.contains(sample.provider) {
+      guard latest[sample.windowIDWithProvider]?.recordedAt ?? .distantPast < sample.recordedAt
+      else { continue }
+      latest[sample.windowIDWithProvider] = sample
+    }
+    return latest.values
+      .map(HistoryWindow.init)
+      .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+  }
+
+  private var selectedSamples: [UsageHistorySample] {
+    guard let selectedWindowKey else { return [] }
+    let cutoff = date.addingTimeInterval(-range.duration)
+    return samples.filter { sample in
+      sample.windowIDWithProvider == selectedWindowKey && sample.recordedAt >= cutoff
+    }
+    .sorted { $0.recordedAt < $1.recordedAt }
+  }
+
+  private var chart: some View {
+    Chart(selectedSamples) { sample in
+      LineMark(
+        x: .value("Time", sample.recordedAt),
+        y: .value("Used", sample.usedPercent)
+      )
+      .interpolationMethod(.catmullRom)
+      .foregroundStyle(Color.accentColor)
+      PointMark(
+        x: .value("Time", sample.recordedAt),
+        y: .value("Used", sample.usedPercent)
+      )
+      .foregroundStyle(Color.accentColor)
+    }
+    .chartYScale(domain: 0...100)
+    .chartYAxisLabel("Used %")
+    .chartXAxis {
+      AxisMarks(values: .automatic(desiredCount: 4))
+    }
+    .frame(height: 220)
+    .accessibilityLabel("Subscription usage history graph")
+  }
+
+  private var context: some View {
+    HStack {
+      if let current = selectedSamples.last {
+        Text("Current: \(Int(current.usedPercent.rounded()))% used")
+        if let resetAt = current.resetAt {
+          Spacer()
+          Text("Resets \(QuotaTimeFormatter.compactCountdown(to: resetAt, from: date))")
+        }
+      }
+    }
+    .font(.caption)
+    .foregroundStyle(.secondary)
+    .monospacedDigit()
+  }
+
+  private var emptyState: some View {
+    ContentUnavailableView(
+      "No history yet",
+      systemImage: "chart.xyaxis.line",
+      description: Text(
+        "Brim graphs successful refreshes after it is updated. At least two samples are needed.")
+    )
+    .frame(maxWidth: .infinity, minHeight: 260)
+  }
+
+  private func selectDefaultWindowIfNeeded() {
+    guard selectedWindowKey == nil || !windows.contains(where: { $0.id == selectedWindowKey })
+    else {
+      return
+    }
+    selectedWindowKey = windows.first?.id
+  }
+}
+
+private enum HistoryRange: CaseIterable, Identifiable {
+  case day
+  case week
+  case month
+
+  var id: Self { self }
+  var duration: TimeInterval {
+    switch self {
+    case .day: 24 * 60 * 60
+    case .week: 7 * 24 * 60 * 60
+    case .month: 30 * 24 * 60 * 60
+    }
+  }
+
+  var label: String {
+    switch self {
+    case .day: "24h"
+    case .week: "7d"
+    case .month: "30d"
+    }
+  }
+}
+
+private struct HistoryWindow: Identifiable {
+  let provider: ProviderID
+  let id: String
+  let label: String
+
+  init(sample: UsageHistorySample) {
+    provider = sample.provider
+    id = sample.windowIDWithProvider
+    label = sample.label
+  }
+
+  var title: String { "\(provider.displayName) · \(label)" }
+}
+
+private extension UsageHistorySample {
+  var windowIDWithProvider: String { "\(provider.rawValue):\(windowID)" }
+}

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Domain.swift
@@ -6,6 +6,9 @@ public enum ProviderID: String, CaseIterable, Codable, Identifiable, Sendable {
   case kimi
   case grok
 
+  public static let standard: Set<ProviderID> = [.claudeCode, .codex]
+  public static let legacy: Set<ProviderID> = [.kimi, .grok]
+
   public var id: String { rawValue }
 
   public var displayName: String {
@@ -32,19 +35,26 @@ public struct SubscriptionPlan: Identifiable, Equatable, Sendable {
   public let provider: ProviderID
   public let monthlyCostUSD: Int
 
-  public static let active: [SubscriptionPlan] = [
+  public static let standard: [SubscriptionPlan] = [
     SubscriptionPlan(provider: .claudeCode, monthlyCostUSD: 200),
     SubscriptionPlan(provider: .codex, monthlyCostUSD: 200),
+  ]
+
+  public static let legacy: [SubscriptionPlan] = [
     SubscriptionPlan(provider: .kimi, monthlyCostUSD: 40),
     SubscriptionPlan(provider: .grok, monthlyCostUSD: 30),
   ]
 
-  public static var totalMonthlyCostUSD: Int {
-    active.reduce(0) { total, plan in total + plan.monthlyCostUSD }
+  public static func plans(includingLegacy: Bool) -> [SubscriptionPlan] {
+    standard + (includingLegacy ? legacy : [])
+  }
+
+  public static func totalMonthlyCostUSD(includingLegacy: Bool = false) -> Int {
+    plans(includingLegacy: includingLegacy).reduce(0) { total, plan in total + plan.monthlyCostUSD }
   }
 
   public static func plan(for provider: ProviderID) -> SubscriptionPlan {
-    guard let plan = active.first(where: { $0.provider == provider }) else {
+    guard let plan = (standard + legacy).first(where: { $0.provider == provider }) else {
       preconditionFailure("Missing subscription plan for \(provider.rawValue)")
     }
     return plan
@@ -99,6 +109,11 @@ public struct UsageWindow: Identifiable, Equatable, Codable, Sendable {
     case .entitlement:
       return label == "Fable 5 policy" ? "Provider quota" : "Policy"
     }
+  }
+
+  public var isWeekly: Bool {
+    if kind == .weekly { return true }
+    return label.localizedCaseInsensitiveContains("weekly")
   }
 
   public static func validated(

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Errors.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Errors.swift
@@ -14,6 +14,8 @@ public enum QuotaError: Error, Equatable, LocalizedError, Sendable {
   case unsupportedResponse(ProviderID)
   case cacheCorrupt
   case cacheWriteFailed
+  case historyCorrupt
+  case historyWriteFailed
   case commandFailed(String)
   case settingsCorrupt
 
@@ -54,6 +56,10 @@ public enum QuotaError: Error, Equatable, LocalizedError, Sendable {
       "The saved Brim cache is corrupt."
     case .cacheWriteFailed:
       "Brim could not save its latest successful usage data."
+    case .historyCorrupt:
+      "The saved Brim usage history is corrupt."
+    case .historyWriteFailed:
+      "Brim could not save usage history."
     case let .commandFailed(command):
       "Brim could not read local credentials with \(command)."
     case .settingsCorrupt:

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Providers.swift
@@ -2,24 +2,32 @@ public enum Providers {
   public static func live(
     credentials: any CredentialStore,
     transport: any HTTPTransport = URLSessionTransport(),
-    endpoints: ProviderEndpoints? = nil
+    endpoints: ProviderEndpoints? = nil,
+    providerIDs: Set<ProviderID> = ProviderID.standard
   ) throws -> [any UsageProvider] {
     let endpoints = try endpoints ?? ProviderEndpoints.live()
     let client = ProviderHTTPClient(transport: transport, credentials: credentials)
-    return [
-      ClaudeCodeProvider(client: client, endpoint: endpoints.claudeUsage),
-      CodexProvider(
-        client: client,
-        usageEndpoint: endpoints.codexUsage,
-        resetEndpoint: endpoints.codexResets
-      ),
-      KimiProvider(client: client, endpoint: endpoints.kimiUsage),
-      GrokProvider(
-        client: client,
-        userEndpoint: endpoints.grokUser,
-        billingEndpoint: endpoints.grokBilling,
-        creditsEndpoint: endpoints.grokCredits
-      ),
-    ]
+    return ProviderID.allCases.compactMap { provider in
+      guard providerIDs.contains(provider) else { return nil }
+      switch provider {
+      case .claudeCode:
+        return ClaudeCodeProvider(client: client, endpoint: endpoints.claudeUsage)
+      case .codex:
+        return CodexProvider(
+          client: client,
+          usageEndpoint: endpoints.codexUsage,
+          resetEndpoint: endpoints.codexResets
+        )
+      case .kimi:
+        return KimiProvider(client: client, endpoint: endpoints.kimiUsage)
+      case .grok:
+        return GrokProvider(
+          client: client,
+          userEndpoint: endpoints.grokUser,
+          billingEndpoint: endpoints.grokBilling,
+          creditsEndpoint: endpoints.grokCredits
+        )
+      }
+    }
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaBarModel.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaBarModel.swift
@@ -13,13 +13,17 @@ private struct ActiveRefresh {
 
 @MainActor @Observable
 public final class QuotaBarModel {
-  public let providers: [any UsageProvider]
+  public private(set) var providers: [any UsageProvider]
   public let settings: AppSettings
   public private(set) var states: [ProviderID: ProviderDisplayState] = [:]
   public private(set) var isRefreshing = false
   public private(set) var cacheErrorMessage: String?
+  public private(set) var history: [UsageHistorySample] = []
+  public private(set) var historyErrorMessage: String?
 
   private let store: any SnapshotPersisting
+  private let historyStore: any UsageHistoryPersisting
+  private let providerFactory: ((Set<ProviderID>) throws -> [any UsageProvider])?
   private let providerTimeout: Duration
   private var lastSuccessful: [ProviderID: UsageSnapshot] = [:]
   private var pollingTask: Task<Void, Never>?
@@ -31,11 +35,15 @@ public final class QuotaBarModel {
     providers: [any UsageProvider],
     settings: AppSettings,
     store: any SnapshotPersisting = JSONSnapshotStore(),
+    historyStore: any UsageHistoryPersisting = JSONUsageHistoryStore(),
+    providerFactory: ((Set<ProviderID>) throws -> [any UsageProvider])? = nil,
     providerTimeout: Duration = .seconds(25)
   ) {
     self.providers = providers
     self.settings = settings
     self.store = store
+    self.historyStore = historyStore
+    self.providerFactory = providerFactory
     self.providerTimeout = providerTimeout
     do {
       lastSuccessful = try store.load()
@@ -47,15 +55,22 @@ public final class QuotaBarModel {
     } catch {
       cacheErrorMessage = QuotaError.cacheCorrupt.localizedDescription
     }
+    do {
+      history = try historyStore.load()
+    } catch {
+      historyErrorMessage = QuotaError.historyCorrupt.localizedDescription
+    }
   }
 
   public func state(for provider: ProviderID) -> ProviderDisplayState {
-    guard settings.enabledProviders.contains(provider) else { return .disabled }
+    guard settings.visibleProviderIDs.contains(provider),
+      settings.enabledProviders.contains(provider)
+    else { return .disabled }
     return states[provider] ?? .loading
   }
 
   public var overallStatus: QuotaStatus {
-    let enabledStates = ProviderID.allCases
+    let enabledStates = settings.visibleProviderIDs
       .filter(settings.enabledProviders.contains)
       .map(state(for:))
     guard !enabledStates.isEmpty else { return .unavailable }
@@ -99,6 +114,25 @@ public final class QuotaBarModel {
         .available($0.markedStale(reason: "Cached data; waiting for a provider refresh."))
       } ?? .loading
     refreshAfterEnabling(provider)
+  }
+
+  public func setShowsLegacyProviders(_ showsLegacyProviders: Bool) {
+    settings.setShowsLegacyProviders(showsLegacyProviders)
+    guard let providerFactory else { return }
+    do {
+      providers = try providerFactory(settings.visibleProviderIDs)
+      if showsLegacyProviders {
+        for provider in ProviderID.legacy {
+          states[provider] =
+            lastSuccessful[provider].map {
+              .available($0.markedStale(reason: "Cached data; waiting for a provider refresh."))
+            } ?? .loading
+        }
+        Task { [weak self] in await self?.refresh() }
+      }
+    } catch {
+      cacheErrorMessage = "Brim could not configure its provider URLs."
+    }
   }
 
   public func refresh() async {
@@ -198,6 +232,7 @@ public final class QuotaBarModel {
     case let .success(provider, snapshot):
       lastSuccessful[provider] = snapshot
       states[provider] = .available(snapshot)
+      recordHistory(snapshot)
       return true
     case let .failure(provider, error):
       if let snapshot = lastSuccessful[provider] {
@@ -208,6 +243,18 @@ public final class QuotaBarModel {
         states[provider] = .unavailable(message: error.localizedDescription)
       }
       return false
+    }
+  }
+
+  private func recordHistory(_ snapshot: UsageSnapshot) {
+    let samples = UsageHistorySample.samples(from: snapshot)
+    guard !samples.isEmpty else { return }
+    history = UsageHistory.compact(history + samples)
+    do {
+      try historyStore.save(history)
+      historyErrorMessage = nil
+    } catch {
+      historyErrorMessage = QuotaError.historyWriteFailed.localizedDescription
     }
   }
 

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaBarModel.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaBarModel.swift
@@ -56,7 +56,16 @@ public final class QuotaBarModel {
       cacheErrorMessage = QuotaError.cacheCorrupt.localizedDescription
     }
     do {
-      history = try historyStore.load()
+      let loadedHistory = try historyStore.load()
+      let compactedHistory = UsageHistory.compact(loadedHistory)
+      history = compactedHistory
+      if compactedHistory != loadedHistory {
+        do {
+          try historyStore.save(compactedHistory)
+        } catch {
+          historyErrorMessage = QuotaError.historyWriteFailed.localizedDescription
+        }
+      }
     } catch {
       historyErrorMessage = QuotaError.historyCorrupt.localizedDescription
     }
@@ -154,6 +163,7 @@ public final class QuotaBarModel {
 
   public func handleCredentialChange(for provider: ProviderID) async {
     let refreshAtCredentialBoundary = activeRefresh
+    clearHistory(for: provider)
     invalidateCachedSnapshot(for: provider)
     if let refreshAtCredentialBoundary {
       await refreshAtCredentialBoundary.task.value
@@ -250,6 +260,18 @@ public final class QuotaBarModel {
     let samples = UsageHistorySample.samples(from: snapshot)
     guard !samples.isEmpty else { return }
     history = UsageHistory.compact(history + samples)
+    do {
+      try historyStore.save(history)
+      historyErrorMessage = nil
+    } catch {
+      historyErrorMessage = QuotaError.historyWriteFailed.localizedDescription
+    }
+  }
+
+  private func clearHistory(for provider: ProviderID) {
+    let clearedHistory = history.filter { $0.provider != provider }
+    guard clearedHistory.count != history.count else { return }
+    history = clearedHistory
     do {
       try historyStore.save(history)
       historyErrorMessage = nil

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/QuotaOverview.swift
@@ -5,8 +5,12 @@ public struct QuotaOverview: Equatable, Sendable {
   public let summary: QuotaOverviewSummary
   public let lastUpdatedAt: Date?
 
-  public init(states: [ProviderID: ProviderDisplayState], at date: Date = .now) {
-    let overviews = ProviderID.allCases.map { provider in
+  public init(
+    states: [ProviderID: ProviderDisplayState],
+    providerIDs: Set<ProviderID> = Set(ProviderID.allCases),
+    at date: Date = .now
+  ) {
+    let overviews = ProviderID.allCases.filter(providerIDs.contains).map { provider in
       guard let state = states[provider] else {
         preconditionFailure("Missing display state for \(provider.rawValue)")
       }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Settings.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/Settings.swift
@@ -3,8 +3,13 @@ public import Observation
 
 public protocol SettingsPersisting: Sendable {
   func enabledProviders() throws -> Set<ProviderID>?
+  func showsLegacyProviders() throws -> Bool?
   func pollingInterval() throws -> TimeInterval?
-  func save(enabledProviders: Set<ProviderID>, pollingInterval: TimeInterval)
+  func save(
+    enabledProviders: Set<ProviderID>,
+    showsLegacyProviders: Bool,
+    pollingInterval: TimeInterval
+  )
 }
 
 public final class UserDefaultsSettingsStore: SettingsPersisting, @unchecked Sendable {
@@ -35,11 +40,22 @@ public final class UserDefaultsSettingsStore: SettingsPersisting, @unchecked Sen
     return value
   }
 
-  public func save(enabledProviders: Set<ProviderID>, pollingInterval: TimeInterval) {
+  public func showsLegacyProviders() throws -> Bool? {
+    guard let storedValue = defaults.object(forKey: "showsLegacyProviders") else { return nil }
+    guard let value = storedValue as? Bool else { throw QuotaError.settingsCorrupt }
+    return value
+  }
+
+  public func save(
+    enabledProviders: Set<ProviderID>,
+    showsLegacyProviders: Bool,
+    pollingInterval: TimeInterval
+  ) {
     let unknownIdentifiers = (defaults.stringArray(forKey: "enabledProviders") ?? [])
       .filter { ProviderID(rawValue: $0) == nil }
     let knownIdentifiers = enabledProviders.map(\.rawValue)
     defaults.set(Set(knownIdentifiers + unknownIdentifiers).sorted(), forKey: "enabledProviders")
+    defaults.set(showsLegacyProviders, forKey: "showsLegacyProviders")
     defaults.set(pollingInterval, forKey: "pollingInterval")
   }
 }
@@ -47,6 +63,7 @@ public final class UserDefaultsSettingsStore: SettingsPersisting, @unchecked Sen
 @MainActor @Observable
 public final class AppSettings {
   public private(set) var enabledProviders: Set<ProviderID>
+  public private(set) var showsLegacyProviders: Bool
   public private(set) var pollingInterval: TimeInterval
   public private(set) var validationErrorMessage: String?
 
@@ -61,15 +78,21 @@ public final class AppSettings {
     self.minimumPollingInterval = minimumPollingInterval
     var corrupted = false
     do {
-      self.enabledProviders = try store.enabledProviders() ?? Set(ProviderID.allCases)
+      self.enabledProviders = try store.enabledProviders() ?? ProviderID.standard
     } catch {
-      self.enabledProviders = Set(ProviderID.allCases)
+      self.enabledProviders = ProviderID.standard
       corrupted = true
     }
     do {
       self.pollingInterval = max(minimumPollingInterval, try store.pollingInterval() ?? 300)
     } catch {
       self.pollingInterval = minimumPollingInterval
+      corrupted = true
+    }
+    do {
+      self.showsLegacyProviders = try store.showsLegacyProviders() ?? false
+    } catch {
+      self.showsLegacyProviders = false
       corrupted = true
     }
     self.validationErrorMessage = corrupted ? QuotaError.settingsCorrupt.localizedDescription : nil
@@ -89,7 +112,23 @@ public final class AppSettings {
     save()
   }
 
+  public func setShowsLegacyProviders(_ showsLegacyProviders: Bool) {
+    self.showsLegacyProviders = showsLegacyProviders
+    if showsLegacyProviders {
+      enabledProviders.formUnion(ProviderID.legacy)
+    }
+    save()
+  }
+
+  public var visibleProviderIDs: Set<ProviderID> {
+    ProviderID.standard.union(showsLegacyProviders ? ProviderID.legacy : [])
+  }
+
   private func save() {
-    store.save(enabledProviders: enabledProviders, pollingInterval: pollingInterval)
+    store.save(
+      enabledProviders: enabledProviders,
+      showsLegacyProviders: showsLegacyProviders,
+      pollingInterval: pollingInterval
+    )
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/UsageHistory.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/UsageHistory.swift
@@ -142,7 +142,11 @@ public enum UsageHistory {
       .sorted { $0.recordedAt < $1.recordedAt }
     guard today.count >= 2 else { return nil }
     return zip(today, today.dropFirst()).reduce(0) { total, pair in
-      total + max(0, pair.1.usedPercent - pair.0.usedPercent)
+      let earlier = pair.0
+      let later = pair.1
+      let increase = later.usedPercent - earlier.usedPercent
+      if increase >= 0 { return total + increase }
+      return earlier.resetAt == later.resetAt ? total : total + later.usedPercent
     }
   }
 }

--- a/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/UsageHistory.swift
+++ b/packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/UsageHistory.swift
@@ -1,0 +1,148 @@
+public import Foundation
+
+public struct UsageHistorySample: Identifiable, Equatable, Codable, Sendable {
+  public let provider: ProviderID
+  public let windowID: String
+  public let label: String
+  public let kind: WindowKind
+  public let usedPercent: Double
+  public let resetAt: Date?
+  public let recordedAt: Date
+
+  public var id: String {
+    "\(provider.rawValue):\(windowID):\(recordedAt.timeIntervalSince1970)"
+  }
+
+  public init(
+    provider: ProviderID,
+    windowID: String,
+    label: String,
+    kind: WindowKind,
+    usedPercent: Double,
+    resetAt: Date?,
+    recordedAt: Date
+  ) throws {
+    guard !windowID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+      !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+      usedPercent.isFinite,
+      0...100 ~= usedPercent
+    else {
+      throw QuotaValidationError.invalidPercentage
+    }
+    self.provider = provider
+    self.windowID = windowID
+    self.label = label
+    self.kind = kind
+    self.usedPercent = usedPercent
+    self.resetAt = resetAt
+    self.recordedAt = recordedAt
+  }
+
+  public static func samples(from snapshot: UsageSnapshot) -> [UsageHistorySample] {
+    snapshot.windows.compactMap { window in
+      guard let usedPercent = window.usedPercent else { return nil }
+      return try? UsageHistorySample(
+        provider: snapshot.provider,
+        windowID: window.id,
+        label: window.label,
+        kind: window.kind,
+        usedPercent: usedPercent,
+        resetAt: window.resetAt,
+        recordedAt: snapshot.sourceTimestamp
+      )
+    }
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self = try UsageHistorySample(
+      provider: container.decode(ProviderID.self, forKey: .provider),
+      windowID: container.decode(String.self, forKey: .windowID),
+      label: container.decode(String.self, forKey: .label),
+      kind: container.decode(WindowKind.self, forKey: .kind),
+      usedPercent: container.decode(Double.self, forKey: .usedPercent),
+      resetAt: container.decodeIfPresent(Date.self, forKey: .resetAt),
+      recordedAt: container.decode(Date.self, forKey: .recordedAt)
+    )
+  }
+}
+
+public protocol UsageHistoryPersisting: Sendable {
+  func load() throws -> [UsageHistorySample]
+  func save(_ samples: [UsageHistorySample]) throws
+}
+
+public final class JSONUsageHistoryStore: UsageHistoryPersisting, @unchecked Sendable {
+  public let url: URL
+  private let fileManager: FileManager
+
+  public init(url: URL, fileManager: FileManager = .default) {
+    self.url = url
+    self.fileManager = fileManager
+  }
+
+  public convenience init(fileManager: FileManager = .default) {
+    let support =
+      fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+      ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent(
+        "Library/Application Support")
+    self.init(
+      url: support.appendingPathComponent("QuotaBar/history.json"), fileManager: fileManager)
+  }
+
+  public func load() throws -> [UsageHistorySample] {
+    guard fileManager.fileExists(atPath: url.path) else { return [] }
+    do {
+      return try JSONDecoder().decode([UsageHistorySample].self, from: Data(contentsOf: url))
+    } catch {
+      throw QuotaError.historyCorrupt
+    }
+  }
+
+  public func save(_ samples: [UsageHistorySample]) throws {
+    do {
+      try fileManager.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try JSONEncoder().encode(samples).write(to: url, options: .atomic)
+    } catch {
+      throw QuotaError.historyWriteFailed
+    }
+  }
+}
+
+public enum UsageHistory {
+  public static let retention: TimeInterval = 30 * 24 * 60 * 60
+
+  public static func compact(
+    _ samples: [UsageHistorySample],
+    at date: Date = .now,
+    retention: TimeInterval = retention
+  ) -> [UsageHistorySample] {
+    let cutoff = date.addingTimeInterval(-retention)
+    var unique: [String: UsageHistorySample] = [:]
+    for sample in samples where sample.recordedAt >= cutoff {
+      unique[sample.id] = sample
+    }
+    return unique.values.sorted { $0.recordedAt < $1.recordedAt }
+  }
+
+  public static func todayUsedPercent(
+    provider: ProviderID,
+    windowID: String,
+    samples: [UsageHistorySample],
+    at date: Date = .now,
+    calendar: Calendar = .current
+  ) -> Double? {
+    let start = calendar.startOfDay(for: date)
+    let today =
+      samples
+      .filter { $0.provider == provider && $0.windowID == windowID && $0.recordedAt >= start }
+      .sorted { $0.recordedAt < $1.recordedAt }
+    guard today.count >= 2 else { return nil }
+    return zip(today, today.dropFirst()).reduce(0) { total, pair in
+      total + max(0, pair.1.usedPercent - pair.0.usedPercent)
+    }
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/DomainTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/DomainTests.swift
@@ -149,8 +149,9 @@ final class DomainTests: XCTestCase {
   }
 
   func testSubscriptionPlansAndProviderMetadata() {
-    XCTAssertEqual(SubscriptionPlan.totalMonthlyCostUSD, 470)
-    XCTAssertEqual(SubscriptionPlan.active.count, 4)
+    XCTAssertEqual(SubscriptionPlan.totalMonthlyCostUSD(), 400)
+    XCTAssertEqual(SubscriptionPlan.totalMonthlyCostUSD(includingLegacy: true), 470)
+    XCTAssertEqual(SubscriptionPlan.standard.count, 2)
     XCTAssertEqual(SubscriptionPlan.plan(for: .claudeCode).monthlyCostUSD, 200)
     XCTAssertEqual(SubscriptionPlan.plan(for: .codex).monthlyCostUSD, 200)
     XCTAssertEqual(SubscriptionPlan.plan(for: .kimi).monthlyCostUSD, 40)

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/HistoryModelTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/HistoryModelTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+@MainActor final class HistoryModelTests: XCTestCase {
+  func testStartupCompactsAndPersistsExpiredHistory() throws {
+    let current = Date.now
+    let retained = try historySample(provider: .codex, usedPercent: 30, at: current)
+    let expired = try historySample(
+      provider: .codex,
+      usedPercent: 20,
+      at: current.addingTimeInterval(-UsageHistory.retention - 1)
+    )
+    let historyStore = MemoryHistoryStore(saved: [expired, retained])
+
+    let model = makeModel(providers: [], historyStore: historyStore)
+
+    XCTAssertEqual(model.history, [retained])
+    XCTAssertEqual(historyStore.saved, [retained])
+  }
+
+  func testCredentialChangeClearsOnlyThatProvidersHistory() async throws {
+    let current = Date.now
+    let oldCodex = try historySample(provider: .codex, usedPercent: 80, at: current)
+    let claude = try historySample(provider: .claudeCode, usedPercent: 30, at: current)
+    let provider = FakeProvider(
+      id: .codex,
+      results: [.success(snapshot(provider: .codex, remaining: 60))]
+    )
+    let model = makeModel(
+      providers: [provider],
+      historyStore: MemoryHistoryStore(saved: [oldCodex, claude])
+    )
+
+    await model.handleCredentialChange(for: .codex)
+
+    XCTAssertFalse(model.history.contains(oldCodex))
+    XCTAssertTrue(model.history.contains(claude))
+  }
+
+  private func historySample(provider: ProviderID, usedPercent: Double, at date: Date) throws
+    -> UsageHistorySample
+  {
+    try UsageHistorySample(
+      provider: provider,
+      windowID: "weekly",
+      label: "Weekly",
+      kind: .weekly,
+      usedPercent: usedPercent,
+      resetAt: nil,
+      recordedAt: date
+    )
+  }
+
+  private func makeModel(
+    providers: [any UsageProvider],
+    historyStore: MemoryHistoryStore
+  ) -> QuotaBarModel {
+    let settings = AppSettings(
+      store: HistoryModelSettingsStore(enabled: Set(providers.map(\.id))),
+      minimumPollingInterval: 60
+    )
+    return QuotaBarModel(
+      providers: providers,
+      settings: settings,
+      historyStore: historyStore,
+      providerTimeout: .seconds(1)
+    )
+  }
+
+  private func snapshot(provider: ProviderID, remaining: Double) -> UsageSnapshot {
+    UsageSnapshot(
+      provider: provider,
+      windows: [window(remaining: remaining)],
+      sourceTimestamp: .now
+    )
+  }
+}
+
+private final class HistoryModelSettingsStore: SettingsPersisting, @unchecked Sendable {
+  private let enabled: Set<ProviderID>
+
+  init(enabled: Set<ProviderID>) {
+    self.enabled = enabled
+  }
+
+  func enabledProviders() -> Set<ProviderID>? { enabled }
+  func showsLegacyProviders() -> Bool? { false }
+  func pollingInterval() -> TimeInterval? { nil }
+  func save(
+    enabledProviders _: Set<ProviderID>,
+    showsLegacyProviders _: Bool,
+    pollingInterval _: TimeInterval
+  ) {}
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/HistoryTestSupport.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/HistoryTestSupport.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+@testable import QuotaBarCore
+
+actor FakeProvider: UsageProvider {
+  nonisolated let id: ProviderID
+  private var results: [Result<UsageSnapshot, QuotaError>]
+  private let delay: Duration
+  private(set) var fetchCount = 0
+
+  init(
+    id: ProviderID,
+    results: [Result<UsageSnapshot, QuotaError>],
+    delay: Duration = .zero
+  ) {
+    self.id = id
+    self.results = results
+    self.delay = delay
+  }
+
+  func fetch() async throws -> UsageSnapshot {
+    fetchCount += 1
+    if delay != .zero { try await Task.sleep(for: delay) }
+    guard !results.isEmpty else { throw QuotaError.network(id) }
+    return try results.removeFirst().get()
+  }
+}
+
+final class MemoryHistoryStore: UsageHistoryPersisting, @unchecked Sendable {
+  private let loadError: QuotaError?
+  private(set) var saved: [UsageHistorySample] = []
+
+  init(saved: [UsageHistorySample] = [], loadError: QuotaError? = nil) {
+    self.saved = saved
+    self.loadError = loadError
+  }
+
+  func load() throws -> [UsageHistorySample] {
+    if let loadError { throw loadError }
+    return saved
+  }
+
+  func save(_ samples: [UsageHistorySample]) throws {
+    saved = samples
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ModelTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ModelTests.swift
@@ -372,30 +372,6 @@ final class ModelTests: XCTestCase {
   }
 }
 
-private actor FakeProvider: UsageProvider {
-  nonisolated let id: ProviderID
-  private var results: [Result<UsageSnapshot, QuotaError>]
-  private let delay: Duration
-  private(set) var fetchCount = 0
-
-  init(
-    id: ProviderID,
-    results: [Result<UsageSnapshot, QuotaError>],
-    delay: Duration = .zero
-  ) {
-    self.id = id
-    self.results = results
-    self.delay = delay
-  }
-
-  func fetch() async throws -> UsageSnapshot {
-    fetchCount += 1
-    if delay != .zero { try await Task.sleep(for: delay) }
-    guard !results.isEmpty else { throw QuotaError.network(id) }
-    return try results.removeFirst().get()
-  }
-}
-
 private struct ValidationFailureProvider: UsageProvider {
   let id = ProviderID.grok
 
@@ -453,22 +429,4 @@ private final class MemoryModelSettingsStore: SettingsPersisting, @unchecked Sen
     showsLegacyProviders _: Bool,
     pollingInterval _: TimeInterval
   ) {}
-}
-
-private final class MemoryHistoryStore: UsageHistoryPersisting, @unchecked Sendable {
-  private let loadError: QuotaError?
-  private(set) var saved: [UsageHistorySample] = []
-
-  init(loadError: QuotaError? = nil) {
-    self.loadError = loadError
-  }
-
-  func load() throws -> [UsageHistorySample] {
-    if let loadError { throw loadError }
-    return saved
-  }
-
-  func save(_ samples: [UsageHistorySample]) throws {
-    saved = samples
-  }
 }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ModelTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/ModelTests.swift
@@ -34,6 +34,37 @@ final class ModelTests: XCTestCase {
     XCTAssertNil(model.cacheErrorMessage)
   }
 
+  func testSuccessfulRefreshRecordsHistoryButFailureDoesNot() async {
+    let successful = FakeProvider(
+      id: .codex,
+      results: [.success(snapshot(provider: .codex, remaining: 60))]
+    )
+    let historyStore = MemoryHistoryStore()
+    let model = makeModel(providers: [successful], historyStore: historyStore)
+    await model.refresh()
+    XCTAssertEqual(model.history.count, 1)
+    XCTAssertEqual(historyStore.saved.count, 1)
+
+    let failed = FakeProvider(id: .codex, results: [.failure(.network(.codex))])
+    let failedModel = makeModel(providers: [failed], historyStore: MemoryHistoryStore())
+    await failedModel.refresh()
+    XCTAssertTrue(failedModel.history.isEmpty)
+  }
+
+  func testCorruptHistoryDoesNotPreventLiveRefresh() async {
+    let provider = FakeProvider(
+      id: .codex,
+      results: [.success(snapshot(provider: .codex, remaining: 60))]
+    )
+    let model = makeModel(
+      providers: [provider],
+      historyStore: MemoryHistoryStore(loadError: .historyCorrupt)
+    )
+    XCTAssertEqual(model.historyErrorMessage, QuotaError.historyCorrupt.localizedDescription)
+    await model.refresh()
+    XCTAssertEqual(model.overallStatus, .healthy)
+  }
+
   func testRateLimitRetainsLastSnapshotAsStale() async {
     let cached = snapshot(provider: .codex, remaining: 60)
     let codex = FakeProvider(id: .codex, results: [.failure(.rateLimited(.codex))])
@@ -197,7 +228,7 @@ final class ModelTests: XCTestCase {
       results: [.success(snapshot(provider: .kimi, remaining: 65))]
     )
     let settings = AppSettings(
-      store: MemoryModelSettingsStore(enabled: [.codex]),
+      store: MemoryModelSettingsStore(enabled: [.codex], showsLegacy: true),
       minimumPollingInterval: 60
     )
     let model = QuotaBarModel(
@@ -301,17 +332,22 @@ final class ModelTests: XCTestCase {
   private func makeModel(
     providers: [any UsageProvider],
     store: MemorySnapshotStore = MemorySnapshotStore(),
+    historyStore: MemoryHistoryStore = MemoryHistoryStore(),
     timeout: Duration = .seconds(1),
     minimumInterval: TimeInterval = 60
   ) -> QuotaBarModel {
     let settings = AppSettings(
-      store: MemoryModelSettingsStore(enabled: Set(providers.map(\.id))),
+      store: MemoryModelSettingsStore(
+        enabled: Set(providers.map(\.id)),
+        showsLegacy: !Set(providers.map(\.id)).isDisjoint(with: ProviderID.legacy)
+      ),
       minimumPollingInterval: minimumInterval
     )
     return QuotaBarModel(
       providers: providers,
       settings: settings,
       store: store,
+      historyStore: historyStore,
       providerTimeout: timeout
     )
   }
@@ -402,12 +438,37 @@ private final class MemorySnapshotStore: SnapshotPersisting, @unchecked Sendable
 
 private final class MemoryModelSettingsStore: SettingsPersisting, @unchecked Sendable {
   let enabled: Set<ProviderID>
+  let showsLegacy: Bool
 
-  init(enabled: Set<ProviderID>) {
+  init(enabled: Set<ProviderID>, showsLegacy: Bool = false) {
     self.enabled = enabled
+    self.showsLegacy = showsLegacy
   }
 
   func enabledProviders() -> Set<ProviderID>? { enabled }
+  func showsLegacyProviders() -> Bool? { showsLegacy }
   func pollingInterval() -> TimeInterval? { nil }
-  func save(enabledProviders _: Set<ProviderID>, pollingInterval _: TimeInterval) {}
+  func save(
+    enabledProviders _: Set<ProviderID>,
+    showsLegacyProviders _: Bool,
+    pollingInterval _: TimeInterval
+  ) {}
+}
+
+private final class MemoryHistoryStore: UsageHistoryPersisting, @unchecked Sendable {
+  private let loadError: QuotaError?
+  private(set) var saved: [UsageHistorySample] = []
+
+  init(loadError: QuotaError? = nil) {
+    self.loadError = loadError
+  }
+
+  func load() throws -> [UsageHistorySample] {
+    if let loadError { throw loadError }
+    return saved
+  }
+
+  func save(_ samples: [UsageHistorySample]) throws {
+    saved = samples
+  }
 }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/NetworkingTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/NetworkingTests.swift
@@ -352,7 +352,14 @@ final class NetworkingTests: XCTestCase {
     XCTAssertThrowsError(
       try ProviderEndpoints.live(environment: ["QUOTABAR_KIMI_USAGE_URL": "http://["]))
     let credentials = StubCredentialStore(tokens: ["token"])
-    XCTAssertEqual(try Providers.live(credentials: credentials).map(\.id), ProviderID.allCases)
+    XCTAssertEqual(
+      try Providers.live(credentials: credentials).map(\.id),
+      [.claudeCode, .codex]
+    )
+    XCTAssertEqual(
+      try Providers.live(credentials: credentials, providerIDs: Set(ProviderID.allCases)).map(\.id),
+      ProviderID.allCases
+    )
   }
 
   func testEndpointRejectsRelativeOverrideURL() throws {

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/OpenRouterTests.swift
@@ -226,8 +226,13 @@ private func decimal(_ value: String) -> Decimal {
 
 private final class APISettingsStore: SettingsPersisting, @unchecked Sendable {
   func enabledProviders() throws -> Set<ProviderID>? { Set(ProviderID.allCases) }
+  func showsLegacyProviders() throws -> Bool? { true }
   func pollingInterval() throws -> TimeInterval? { 300 }
-  func save(enabledProviders _: Set<ProviderID>, pollingInterval _: TimeInterval) {}
+  func save(
+    enabledProviders _: Set<ProviderID>,
+    showsLegacyProviders _: Bool,
+    pollingInterval _: TimeInterval
+  ) {}
 }
 
 private final class MemoryAPIPlatformStore: APIPlatformSnapshotPersisting, @unchecked Sendable {

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PersistenceSettingsTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/PersistenceSettingsTests.swift
@@ -40,7 +40,7 @@ final class PersistenceSettingsTests: XCTestCase {
 
   @MainActor
   func testSettingsLoadClampAndPersist() {
-    let store = MemorySettingsStore(enabled: [.codex], interval: 5)
+    let store = MemorySettingsStore(enabled: [.codex], showsLegacy: false, interval: 5)
     let settings = AppSettings(store: store, minimumPollingInterval: 60)
     XCTAssertEqual(settings.enabledProviders, [.codex])
     XCTAssertEqual(settings.pollingInterval, 60)
@@ -51,6 +51,22 @@ final class PersistenceSettingsTests: XCTestCase {
     XCTAssertEqual(settings.pollingInterval, 900)
     XCTAssertEqual(store.savedEnabled, [.grok])
     XCTAssertEqual(store.savedInterval, 900)
+    XCTAssertFalse(store.savedShowsLegacy)
+  }
+
+  @MainActor
+  func testLegacyProvidersAreHiddenByDefaultAndRestoredOnOptIn() {
+    let store = MemorySettingsStore(enabled: nil, showsLegacy: nil, interval: nil)
+    let settings = AppSettings(store: store)
+
+    XCTAssertEqual(settings.visibleProviderIDs, ProviderID.standard)
+    XCTAssertFalse(settings.showsLegacyProviders)
+
+    settings.setShowsLegacyProviders(true)
+
+    XCTAssertEqual(settings.visibleProviderIDs, Set(ProviderID.allCases))
+    XCTAssertTrue(settings.enabledProviders.isSuperset(of: ProviderID.legacy))
+    XCTAssertTrue(store.savedShowsLegacy)
   }
 
   @MainActor
@@ -64,7 +80,7 @@ final class PersistenceSettingsTests: XCTestCase {
     defaults.set([ProviderID.codex.rawValue, "future-provider"], forKey: "enabledProviders")
     let settings = AppSettings(store: UserDefaultsSettingsStore(defaults: defaults))
 
-    XCTAssertEqual(settings.enabledProviders, Set(ProviderID.allCases))
+    XCTAssertEqual(settings.enabledProviders, ProviderID.standard)
     XCTAssertEqual(
       settings.validationErrorMessage,
       QuotaError.settingsCorrupt.localizedDescription
@@ -122,21 +138,30 @@ final class PersistenceSettingsTests: XCTestCase {
 private final class MemorySettingsStore: SettingsPersisting, @unchecked Sendable {
   private let lock = NSLock()
   private let initialEnabled: Set<ProviderID>?
+  private let initialShowsLegacy: Bool?
   private let initialInterval: TimeInterval?
   private(set) var savedEnabled: Set<ProviderID> = []
+  private(set) var savedShowsLegacy = false
   private(set) var savedInterval: TimeInterval = 0
 
-  init(enabled: Set<ProviderID>?, interval: TimeInterval?) {
+  init(enabled: Set<ProviderID>?, showsLegacy: Bool? = nil, interval: TimeInterval?) {
     self.initialEnabled = enabled
+    self.initialShowsLegacy = showsLegacy
     self.initialInterval = interval
   }
 
   func enabledProviders() -> Set<ProviderID>? { initialEnabled }
+  func showsLegacyProviders() -> Bool? { initialShowsLegacy }
   func pollingInterval() -> TimeInterval? { initialInterval }
 
-  func save(enabledProviders: Set<ProviderID>, pollingInterval: TimeInterval) {
+  func save(
+    enabledProviders: Set<ProviderID>,
+    showsLegacyProviders: Bool,
+    pollingInterval: TimeInterval
+  ) {
     lock.withLock {
       savedEnabled = enabledProviders
+      savedShowsLegacy = showsLegacyProviders
       savedInterval = pollingInterval
     }
   }

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/UsageHistoryTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/UsageHistoryTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import XCTest
+
+@testable import QuotaBarCore
+
+final class UsageHistoryTests: XCTestCase {
+  func testHistoryStoreRoundTripAndCorruptFile() throws {
+    let root = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = root.appendingPathComponent("history/history.json")
+    let store = JSONUsageHistoryStore(url: url)
+    let sample = try makeSample(usedPercent: 25, at: "2026-08-09T08:00:00Z")
+
+    XCTAssertTrue(try store.load().isEmpty)
+    try store.save([sample])
+    XCTAssertEqual(try store.load(), [sample])
+
+    try Data("not-json".utf8).write(to: url)
+    XCTAssertThrowsError(try store.load()) { error in
+      XCTAssertEqual(error as? QuotaError, .historyCorrupt)
+    }
+  }
+
+  func testHistoryCompactsDuplicatesAndPrunesAfterThirtyDays() throws {
+    let now = date("2026-08-31T12:00:00Z")
+    let retained = try makeSample(usedPercent: 25, at: "2026-08-01T12:00:00Z")
+    let expired = try makeSample(usedPercent: 15, at: "2026-08-01T11:59:59Z")
+
+    XCTAssertEqual(
+      UsageHistory.compact([retained, retained, expired], at: now),
+      [retained]
+    )
+  }
+
+  func testTodayUsageSumsIncreasesAndIgnoresResetDrops() throws {
+    let calendar = utcCalendar()
+    let current = date("2026-08-09T12:00:00Z")
+    let samples = [
+      try makeSample(usedPercent: 10, at: "2026-08-09T00:10:00Z"),
+      try makeSample(usedPercent: 15, at: "2026-08-09T04:00:00Z"),
+      try makeSample(usedPercent: 2, at: "2026-08-09T08:00:00Z"),
+      try makeSample(usedPercent: 8, at: "2026-08-09T11:00:00Z"),
+      try makeSample(usedPercent: 90, at: "2026-08-08T23:00:00Z"),
+    ]
+
+    XCTAssertEqual(
+      UsageHistory.todayUsedPercent(
+        provider: .codex,
+        windowID: "weekly",
+        samples: samples,
+        at: current,
+        calendar: calendar
+      ),
+      11
+    )
+  }
+
+  func testTodayUsageRequiresTwoSameDaySamplesAndKeepsWindowsSeparate() throws {
+    let calendar = utcCalendar()
+    let current = date("2026-08-09T12:00:00Z")
+    let weekly = try makeSample(usedPercent: 10, at: "2026-08-09T10:00:00Z")
+    let otherWindow = try UsageHistorySample(
+      provider: .codex,
+      windowID: "five-hour",
+      label: "5-hour",
+      kind: .rolling(durationSeconds: 18_000),
+      usedPercent: 30,
+      resetAt: nil,
+      recordedAt: date("2026-08-09T11:00:00Z")
+    )
+
+    XCTAssertNil(
+      UsageHistory.todayUsedPercent(
+        provider: .codex,
+        windowID: "weekly",
+        samples: [weekly, otherWindow],
+        at: current,
+        calendar: calendar
+      )
+    )
+  }
+
+  func testWeeklyWindowRecognitionIncludesModelScopedWeeklyLabels() throws {
+    let modelWeekly = try UsageWindow.validated(
+      id: "weekly-fable",
+      label: "Weekly · Fable",
+      kind: .modelScoped(model: "Fable"),
+      usedPercent: 40,
+      resetAt: nil,
+      sourceTimestamp: .now
+    )
+    XCTAssertTrue(modelWeekly.isWeekly)
+  }
+
+  private func makeSample(usedPercent: Double, at timestamp: String) throws -> UsageHistorySample {
+    try UsageHistorySample(
+      provider: .codex,
+      windowID: "weekly",
+      label: "Weekly",
+      kind: .weekly,
+      usedPercent: usedPercent,
+      resetAt: nil,
+      recordedAt: date(timestamp)
+    )
+  }
+
+  private func utcCalendar() -> Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    guard let timeZone = TimeZone(secondsFromGMT: 0) else {
+      preconditionFailure("Expected UTC time zone")
+    }
+    calendar.timeZone = timeZone
+    return calendar
+  }
+}

--- a/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/UsageHistoryTests.swift
+++ b/packages/macos-ai-subscription-tracker/Tests/QuotaBarCoreTests/UsageHistoryTests.swift
@@ -55,6 +55,30 @@ final class UsageHistoryTests: XCTestCase {
     )
   }
 
+  func testTodayUsageIncludesConsumptionAfterAReportedReset() throws {
+    let calendar = utcCalendar()
+    let current = date("2026-08-09T12:00:00Z")
+    let oldReset = date("2026-08-09T06:00:00Z")
+    let newReset = date("2026-08-16T08:00:00Z")
+    let samples = [
+      try makeSample(usedPercent: 10, resetAt: oldReset, at: "2026-08-09T00:10:00Z"),
+      try makeSample(usedPercent: 15, resetAt: oldReset, at: "2026-08-09T04:00:00Z"),
+      try makeSample(usedPercent: 2, resetAt: newReset, at: "2026-08-09T08:00:00Z"),
+      try makeSample(usedPercent: 8, resetAt: newReset, at: "2026-08-09T11:00:00Z"),
+    ]
+
+    XCTAssertEqual(
+      UsageHistory.todayUsedPercent(
+        provider: .codex,
+        windowID: "weekly",
+        samples: samples,
+        at: current,
+        calendar: calendar
+      ),
+      13
+    )
+  }
+
   func testTodayUsageRequiresTwoSameDaySamplesAndKeepsWindowsSeparate() throws {
     let calendar = utcCalendar()
     let current = date("2026-08-09T12:00:00Z")
@@ -92,14 +116,18 @@ final class UsageHistoryTests: XCTestCase {
     XCTAssertTrue(modelWeekly.isWeekly)
   }
 
-  private func makeSample(usedPercent: Double, at timestamp: String) throws -> UsageHistorySample {
+  private func makeSample(
+    usedPercent: Double,
+    resetAt: Date? = nil,
+    at timestamp: String
+  ) throws -> UsageHistorySample {
     try UsageHistorySample(
       provider: .codex,
       windowID: "weekly",
       label: "Weekly",
       kind: .weekly,
       usedPercent: usedPercent,
-      resetAt: nil,
+      resetAt: resetAt,
       recordedAt: date(timestamp)
     )
   }


### PR DESCRIPTION
Why
Brim should show how subscription quota is progressing over time and keep unsupported provider integrations out of the normal experience.

What
- Persist a credential-free, 30-day local history from successful quota refreshes.
- Add range and window selection to a native History chart, plus reset/current context.
- Show local-midnight weekly usage beside the current quota percentage.
- Default to Claude Code and Codex ($400/month); make Kimi Code and Grok a persisted Advanced opt-in.

Verification
- cd packages/macos-ai-subscription-tracker && bun run verify:macos (Swift format, SwiftLint, 121 tests, coverage, Xcode bundle verification)
- git diff --check origin/main...HEAD
- git merge-tree --write-tree origin/main HEAD
- Installed and launched the verified local bundle at /Applications/Brim.app.