### PR TITLE
feat(temporal): weekly trivy scan of main with report delivery

### DIFF
--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -73,20 +73,21 @@ Only corpus capture and context-refresh are scheduled.
 
 ## Homelab maintenance
 
-| Workflow                        | Trigger       | Brain         | Output                   |
-| ------------------------------- | ------------- | ------------- | ------------------------ |
-| zfs-maintenance                 | Sun 03:00     | deterministic | scrub + autotrim         |
-| buildkite-uv-cache-prune-weekly | Sun 03:15     | deterministic | uv cache prune           |
-| bugsink-housekeeping            | daily 03:00   | deterministic | DB cleanup               |
-| velero-orphan-audit             | daily 03:30   | deterministic | metrics only             |
-| kometa-daily                    | daily 04:30   | deterministic | Plex metadata sync       |
-| buildkite-bun-cache-gc          | every 5 min   | deterministic | Bun cache GC             |
-| buildkite-trivy-db-refresh      | every 6 hours | deterministic | Trivy database refresh   |
-| dns-audit                       | daily 06:00   | deterministic | logs                     |
-| golink-sync                     | daily 05:00   | deterministic | golink reconcile         |
-| temporal-failure-watch          | every 5 min   | deterministic | durable alert occurrence |
-| report-freshness-monitor        | every 15 min  | deterministic | metrics + durable alert  |
-| TaskNotes canary                | daily 09:00   | deterministic | heartbeat email          |
+| Workflow                        | Trigger       | Brain         | Output                                   |
+| ------------------------------- | ------------- | ------------- | ---------------------------------------- |
+| zfs-maintenance                 | Sun 03:00     | deterministic | scrub + autotrim                         |
+| buildkite-uv-cache-prune-weekly | Sun 03:15     | deterministic | uv cache prune                           |
+| bugsink-housekeeping            | daily 03:00   | deterministic | DB cleanup                               |
+| velero-orphan-audit             | daily 03:30   | deterministic | metrics only                             |
+| kometa-daily                    | daily 04:30   | deterministic | Plex metadata sync                       |
+| buildkite-bun-cache-gc          | every 5 min   | deterministic | Bun cache GC                             |
+| buildkite-trivy-db-refresh      | every 6 hours | deterministic | Trivy database refresh                   |
+| dns-audit                       | daily 06:00   | deterministic | logs                                     |
+| golink-sync                     | daily 05:00   | deterministic | golink reconcile                         |
+| temporal-failure-watch          | every 5 min   | deterministic | durable alert occurrence                 |
+| report-freshness-monitor        | every 15 min  | deterministic | metrics + durable alert                  |
+| TaskNotes canary                | daily 09:00   | deterministic | heartbeat email                          |
+| main-vuln-scan                  | Sun 05:00     | deterministic | report email + durable alert on CRITICAL |
 
 ## Home automation
 

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -62,6 +62,18 @@ Buildkite PVCs and has no Kubernetes API token or Job RBAC; Kometa reaches Plex
 over the cluster network with credentials projected from namespace-local
 OnePassword resources.
 
+`main-vuln-scan-weekly` (`runMainVulnScanWorkflow`) also runs on the
+maintenance queue: it shallow-clones public `main` and runs
+`trivy fs --skip-db-update` against the warm `/buildkite/trivy-db` PVC that
+`buildkite-trivy-db-refresh` keeps fresh (the single activity slot means the
+scan can never race the DB refresh writer). Only the scan activity lives on
+this queue — the workflow proxies `deliverActivityReport` and the Alertmanager
+publish to `TASK_QUEUES.DEFAULT`, so Postal/S3/`ALERTMANAGER_URL` credentials
+never reach the maintenance pod. Policy: the report email is delivered on
+every run; Alertmanager receives one fire/resolve occurrence
+(`MainVulnScanCritical`) that fires only while ≥1 CRITICAL finding exists and
+resolves on the next clean run (`src/shared/main-vuln-scan-alert.ts`).
+
 ## Schedules (`src/schedules/register-schedules.ts`, `src/schedules/schedule-definitions.ts`)
 
 The declarative `SCHEDULES` array plus its supporting types/data (`ScheduleDefinition`,
@@ -214,7 +226,7 @@ Workflow:
 - `XCODE_CLOUD_WEBHOOK_TOKEN` — unguessable token embedded in the Xcode Cloud webhook URL path (`/hook/<token>`). Xcode Cloud webhooks carry no signature/auth header, so the URL path IS the credential. **Required** to start the receiver; when unset the server is skipped.
 - `XCODE_CLOUD_WEBHOOK_PORT` — port for the Xcode Cloud webhook receiver (default `9468`).
 - `XCODE_CLOUD_ALERT_TTL_SECONDS` — safety auto-resolve window for a fired build-failure alert if no later `SUCCEEDED` clears it (default `21600` = 6h).
-- `ALERTMANAGER_URL` — in-cluster Alertmanager base URL (`http://prometheus-kube-prometheus-alertmanager.prometheus:9093`). **Required** by three features: the Xcode Cloud webhook receiver (when enabled), the `temporal-failure-watch` schedule (see below), and `llm-catalog-refresh-weekly`, which publishes its withheld state on every run (firing when the cross-check withholds edits, resolving when it withholds none) — all POST to `/api/v2/alerts` via `src/lib/alertmanager.ts`.
+- `ALERTMANAGER_URL` — in-cluster Alertmanager base URL (`http://prometheus-kube-prometheus-alertmanager.prometheus:9093`). **Required** by four features: the Xcode Cloud webhook receiver (when enabled), the `temporal-failure-watch` schedule (see below), `llm-catalog-refresh-weekly`, which publishes its withheld state on every run (firing when the cross-check withholds edits, resolving when it withholds none), and `main-vuln-scan-weekly`, which publishes its CRITICAL-finding state on every run (firing while ≥1 CRITICAL vulnerability exists, resolving on a clean run) — all POST to `/api/v2/alerts` via `src/lib/alertmanager.ts`.
 - `TEMPORAL_FAILURE_ALERT_TTL_SECONDS` — how long a `TemporalWorkflowFailed` alert stays firing in Alertmanager before auto-resolving if the watcher stops re-observing it (default `87090` = 24h lookback plus the full 6.5m activity retry budget and a 5m delivery margin).
 
 ## Scout weekly parlay lifecycle

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -31,6 +31,8 @@ import { glitterContextRefreshActivities } from "./glitter-context-refresh.ts";
 import { weatherActivities } from "./weather.ts";
 import { workflowFailureWatchActivities } from "./workflow-failure-watch-activity.ts";
 import { maintenanceActivities } from "./maintenance.ts";
+import { mainVulnScanActivities } from "./main-vuln-scan.ts";
+import { mainVulnScanAlertActivities } from "./main-vuln-scan-alerts.ts";
 import { reportDeliveryActivities } from "./report-delivery.ts";
 import { protobufWatchActivities } from "./protobuf-watch.ts";
 import { tasknotesCanaryActivities } from "./tasknotes-canary.ts";
@@ -52,6 +54,7 @@ export const reportActivities = {
   ...workflowFailureWatchActivities,
   sendAgentTaskEmail: agentTaskActivities.sendAgentTaskEmail,
   sendAgentTaskFailureReport: agentTaskActivities.sendAgentTaskFailureReport,
+  ...mainVulnScanAlertActivities,
 };
 
 export const infraActivities = {
@@ -102,6 +105,11 @@ export const glitterCorpusWorkerActivities = {
 
 export const glitterContextWorkerActivities = {
   ...glitterContextRefreshActivities,
+};
+
+export const maintenanceWorkerActivities = {
+  ...maintenanceActivities,
+  ...mainVulnScanActivities,
 };
 
 /**

--- a/packages/temporal/src/activities/main-vuln-scan-alerts.ts
+++ b/packages/temporal/src/activities/main-vuln-scan-alerts.ts
@@ -1,0 +1,28 @@
+import { createAlertmanagerPoster } from "#lib/alertmanager.ts";
+import {
+  buildMainVulnScanAlert,
+  type MainVulnScanAlertInput,
+} from "#shared/main-vuln-scan-alert.ts";
+
+/**
+ * Publishes the scan's fire/resolve occurrence to Alertmanager. Runs on
+ * TASK_QUEUES.DEFAULT — the core worker owns ALERTMANAGER_URL; the maintenance
+ * worker deliberately has no Alertmanager access.
+ */
+export const mainVulnScanAlertActivities = {
+  async publishMainVulnScanAlerts(
+    input: MainVulnScanAlertInput,
+  ): Promise<void> {
+    const alertmanagerUrl = Bun.env["ALERTMANAGER_URL"];
+    if (alertmanagerUrl === undefined || alertmanagerUrl === "") {
+      throw new Error(
+        "ALERTMANAGER_URL is required to publish main vulnerability scan alerts",
+      );
+    }
+    await createAlertmanagerPoster(alertmanagerUrl)([
+      buildMainVulnScanAlert(input, new Date()),
+    ]);
+  },
+};
+
+export type MainVulnScanAlertActivities = typeof mainVulnScanAlertActivities;

--- a/packages/temporal/src/activities/main-vuln-scan-report.ts
+++ b/packages/temporal/src/activities/main-vuln-scan-report.ts
@@ -1,0 +1,151 @@
+// Pure report assembly for the weekly main vulnerability scan — no I/O, no
+// Sentry/observability imports, so the workflow bundle can import it directly
+// (same pattern as homelab-audit-report.ts).
+import type { MainVulnScanResult } from "./main-vuln-scan.ts";
+import type { ActivityReportInput } from "./report-delivery.ts";
+
+export const MAIN_VULN_SCAN_REPORT_TYPE = "main-vuln-scan";
+export const MAIN_VULN_SCAN_SCHEDULE_ID = "main-vuln-scan-weekly";
+export const MAIN_VULN_SCAN_TITLE = "Weekly Trivy vulnerability scan of main";
+
+const SCAN_RECEIPT_ID = "trivy-scan";
+
+function findingSummary(
+  vulnerability: MainVulnScanResult["vulnerabilities"][number],
+): string {
+  return `${vulnerability.vulnerabilityId}: ${vulnerability.pkgName}@${vulnerability.installedVersion} (${vulnerability.severity})`;
+}
+
+function findingDetail(
+  vulnerability: MainVulnScanResult["vulnerabilities"][number],
+): string {
+  return [
+    vulnerability.title,
+    `Target: ${vulnerability.target}`,
+    vulnerability.fixedVersion === undefined
+      ? "No fixed version published yet"
+      : `Fixed in: ${vulnerability.fixedVersion}`,
+    vulnerability.primaryUrl,
+  ]
+    .filter((part) => part !== undefined)
+    .join(" — ");
+}
+
+export function countCriticalVulnerabilities(
+  result: Pick<MainVulnScanResult, "vulnerabilities">,
+): number {
+  return result.vulnerabilities.filter(
+    (vulnerability) => vulnerability.severity === "CRITICAL",
+  ).length;
+}
+
+/** Trivy severity → report severity. HIGH warns, CRITICAL pages. */
+function reportSeverity(severity: "HIGH" | "CRITICAL"): "warning" | "critical" {
+  return severity === "CRITICAL" ? "critical" : "warning";
+}
+
+export function buildMainVulnScanReport(
+  startedAt: string,
+  result: MainVulnScanResult,
+): ActivityReportInput {
+  const total = result.vulnerabilities.length;
+  const critical = countCriticalVulnerabilities(result);
+  const high = total - critical;
+  const clean = total === 0;
+  return {
+    reportType: MAIN_VULN_SCAN_REPORT_TYPE,
+    title: MAIN_VULN_SCAN_TITLE,
+    scheduleId: MAIN_VULN_SCAN_SCHEDULE_ID,
+    startedAt,
+    execution: "complete",
+    verdict: clean ? "clear" : "attention",
+    headline: clean
+      ? `Trivy found no HIGH/CRITICAL vulnerabilities on main@${result.repoSha.slice(0, 12)}.`
+      : `Trivy found ${String(critical)} CRITICAL and ${String(high)} HIGH vulnerabilities on main@${result.repoSha.slice(0, 12)}.`,
+    checks: [
+      {
+        id: "trivy-scan-completed",
+        label: "Trivy filesystem scan of main completed",
+        required: true,
+        status: "passed",
+        summary: `Scanned main@${result.repoSha.slice(0, 12)} with the warm Buildkite Trivy DB; ${String(total)} HIGH/CRITICAL findings.`,
+        evidenceReceiptIds: [SCAN_RECEIPT_ID],
+      },
+    ],
+    evidence: [
+      {
+        id: SCAN_RECEIPT_ID,
+        source: "trivy fs (shallow clone of main)",
+        observedAt: result.observedAt,
+        status: "success",
+        command: result.command,
+        exitCode: result.exitCode,
+        excerpt: result.excerpt,
+      },
+    ],
+    findings: result.vulnerabilities.map((vulnerability) => ({
+      section:
+        vulnerability.severity === "CRITICAL"
+          ? "Critical vulnerabilities"
+          : "High vulnerabilities",
+      severity: reportSeverity(vulnerability.severity),
+      summary: findingSummary(vulnerability),
+      detail: findingDetail(vulnerability),
+      evidenceReceiptIds: [SCAN_RECEIPT_ID],
+    })),
+    limitations: [
+      "Scan covers HIGH/CRITICAL vulnerability findings only (scanners=vuln; node_modules and sandbox skipped; .trivyignore applies).",
+    ],
+    actions: clean
+      ? []
+      : [
+          "Upgrade the affected packages, or record a justified ignore in .trivyignore.",
+        ],
+    provenance: {
+      source: "https://github.com/shepherdjerred/monorepo",
+      repoSha: result.repoSha,
+    },
+  };
+}
+
+export function buildMainVulnScanFailureReport(
+  startedAt: string,
+  error: unknown,
+): ActivityReportInput {
+  const message = error instanceof Error ? error.message : String(error);
+  const observedAt = new Date().toISOString();
+  return {
+    reportType: MAIN_VULN_SCAN_REPORT_TYPE,
+    title: MAIN_VULN_SCAN_TITLE,
+    scheduleId: MAIN_VULN_SCAN_SCHEDULE_ID,
+    startedAt,
+    execution: "failed",
+    verdict: "inconclusive",
+    headline: "The Trivy scan of main failed; no vulnerability verdict.",
+    checks: [
+      {
+        id: "trivy-scan-completed",
+        label: "Trivy filesystem scan of main completed",
+        required: true,
+        status: "failed",
+        summary: message,
+        evidenceReceiptIds: ["scan-failure"],
+      },
+    ],
+    evidence: [
+      {
+        id: "scan-failure",
+        source: "main vulnerability scan workflow",
+        observedAt,
+        status: "failure",
+        excerpt: message.slice(0, 2000),
+      },
+    ],
+    findings: [],
+    limitations: [
+      "The clone or Trivy scan did not produce a parseable report.",
+    ],
+    actions: ["Inspect the failed activity and rerun the schedule."],
+    provenance: { source: "https://github.com/shepherdjerred/monorepo" },
+  };
+}

--- a/packages/temporal/src/activities/main-vuln-scan.test.ts
+++ b/packages/temporal/src/activities/main-vuln-scan.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildScanExcerpt,
+  parseTrivyReport,
+  type MainVulnScanResult,
+} from "./main-vuln-scan.ts";
+import {
+  buildMainVulnScanFailureReport,
+  buildMainVulnScanReport,
+  countCriticalVulnerabilities,
+} from "./main-vuln-scan-report.ts";
+
+// Mirrors the real `trivy fs --format json --severity HIGH,CRITICAL` shape:
+// Results keyed by Target, Vulnerabilities omitted entirely on clean targets.
+const TRIVY_FIXTURE = JSON.stringify({
+  SchemaVersion: 2,
+  ArtifactName: ".",
+  Results: [
+    {
+      Target: "bun.lock",
+      Class: "lang-pkgs",
+      Type: "bun",
+      Vulnerabilities: [
+        {
+          VulnerabilityID: "CVE-2026-1234",
+          PkgName: "left-pad",
+          InstalledVersion: "1.3.0",
+          FixedVersion: "1.3.1",
+          Severity: "CRITICAL",
+          Title: "left-pad arbitrary code execution",
+          PrimaryURL: "https://avd.aquasec.com/nvd/cve-2026-1234",
+        },
+        {
+          VulnerabilityID: "CVE-2026-5678",
+          PkgName: "chalk",
+          InstalledVersion: "5.0.0",
+          Severity: "HIGH",
+        },
+      ],
+    },
+    { Target: "packages/monarch/requirements.txt", Class: "lang-pkgs" },
+  ],
+});
+
+describe("parseTrivyReport", () => {
+  test("maps Results[].Vulnerabilities[] to typed findings", () => {
+    const vulnerabilities = parseTrivyReport(TRIVY_FIXTURE);
+    expect(vulnerabilities).toEqual([
+      {
+        vulnerabilityId: "CVE-2026-1234",
+        pkgName: "left-pad",
+        installedVersion: "1.3.0",
+        fixedVersion: "1.3.1",
+        severity: "CRITICAL",
+        target: "bun.lock",
+        title: "left-pad arbitrary code execution",
+        primaryUrl: "https://avd.aquasec.com/nvd/cve-2026-1234",
+      },
+      {
+        vulnerabilityId: "CVE-2026-5678",
+        pkgName: "chalk",
+        installedVersion: "5.0.0",
+        severity: "HIGH",
+        target: "bun.lock",
+      },
+    ]);
+  });
+
+  test("a clean scan (no Results) parses to zero findings", () => {
+    expect(parseTrivyReport(JSON.stringify({ SchemaVersion: 2 }))).toEqual([]);
+  });
+
+  test("rejects a severity outside the requested HIGH/CRITICAL set", () => {
+    const drifted = JSON.stringify({
+      Results: [
+        {
+          Target: "bun.lock",
+          Vulnerabilities: [
+            {
+              VulnerabilityID: "CVE-2026-9999",
+              PkgName: "x",
+              InstalledVersion: "1.0.0",
+              Severity: "MEDIUM",
+            },
+          ],
+        },
+      ],
+    });
+    expect(() => parseTrivyReport(drifted)).toThrow();
+  });
+
+  test("rejects non-JSON output instead of returning empty", () => {
+    expect(() => parseTrivyReport("not json")).toThrow();
+  });
+});
+
+describe("buildScanExcerpt", () => {
+  test("summarizes findings and stays inside the receipt bound", () => {
+    const vulnerabilities = parseTrivyReport(TRIVY_FIXTURE);
+    const excerpt = buildScanExcerpt(vulnerabilities);
+    expect(excerpt).toContain("2 HIGH/CRITICAL:");
+    expect(excerpt).toContain("CRITICAL CVE-2026-1234 left-pad@1.3.0");
+    expect(excerpt.length).toBeLessThanOrEqual(2000);
+  });
+
+  test("names the clean state explicitly", () => {
+    expect(buildScanExcerpt([])).toBe("0 HIGH/CRITICAL vulnerabilities");
+  });
+
+  test("never exceeds the receipt bound on a noisy scan", () => {
+    const many = Array.from({ length: 200 }, (_, index) => ({
+      vulnerabilityId: `CVE-2026-${String(index)}`,
+      pkgName: "pkg",
+      installedVersion: "1.0.0",
+      severity: "HIGH" as const,
+      target: "bun.lock",
+    }));
+    expect(buildScanExcerpt(many).length).toBeLessThanOrEqual(2000);
+  });
+});
+
+function scanResult(
+  vulnerabilities: MainVulnScanResult["vulnerabilities"],
+): MainVulnScanResult {
+  return {
+    observedAt: "2026-08-23T12:00:00.000Z",
+    repoSha: "d9ea9584e0123456789abcdef0123456789abcde",
+    command: "trivy fs --format json .",
+    exitCode: 0,
+    vulnerabilities,
+    excerpt: buildScanExcerpt(vulnerabilities),
+  };
+}
+
+describe("buildMainVulnScanReport", () => {
+  test("a clean scan is a clear, complete report with zero findings", () => {
+    const report = buildMainVulnScanReport(
+      "2026-08-23T11:55:00.000Z",
+      scanResult([]),
+    );
+    expect(report.verdict).toBe("clear");
+    expect(report.execution).toBe("complete");
+    expect(report.findings).toEqual([]);
+    expect(report.actions).toEqual([]);
+    expect(report.checks).toHaveLength(1);
+    expect(report.checks[0]?.status).toBe("passed");
+    expect(report.headline).toContain("no HIGH/CRITICAL");
+  });
+
+  test("findings map HIGH to warning and CRITICAL to critical", () => {
+    const report = buildMainVulnScanReport(
+      "2026-08-23T11:55:00.000Z",
+      scanResult(parseTrivyReport(TRIVY_FIXTURE)),
+    );
+    expect(report.verdict).toBe("attention");
+    expect(report.findings.map((finding) => finding.severity)).toEqual([
+      "critical",
+      "warning",
+    ]);
+    expect(report.findings[0]?.section).toBe("Critical vulnerabilities");
+    expect(report.findings[1]?.section).toBe("High vulnerabilities");
+    expect(report.findings[0]?.summary).toBe(
+      "CVE-2026-1234: left-pad@1.3.0 (CRITICAL)",
+    );
+    expect(report.findings[0]?.detail).toContain("Fixed in: 1.3.1");
+    expect(report.findings[1]?.detail).toContain(
+      "No fixed version published yet",
+    );
+    // Every finding cites the single scan receipt.
+    for (const finding of report.findings) {
+      expect(finding.evidenceReceiptIds).toEqual(["trivy-scan"]);
+    }
+    expect(report.evidence[0]?.id).toBe("trivy-scan");
+    expect(report.evidence[0]?.command).toContain("trivy fs");
+    expect(report.headline).toContain("1 CRITICAL and 1 HIGH");
+  });
+
+  test("critical count feeds the alert decision", () => {
+    expect(
+      countCriticalVulnerabilities(scanResult(parseTrivyReport(TRIVY_FIXTURE))),
+    ).toBe(1);
+    expect(countCriticalVulnerabilities(scanResult([]))).toBe(0);
+  });
+});
+
+describe("buildMainVulnScanFailureReport", () => {
+  test("a failed scan reports failed execution with the error excerpt", () => {
+    const report = buildMainVulnScanFailureReport(
+      "2026-08-23T11:55:00.000Z",
+      new Error("trivy exited 1: DB is corrupted"),
+    );
+    expect(report.execution).toBe("failed");
+    expect(report.verdict).toBe("inconclusive");
+    expect(report.checks[0]?.status).toBe("failed");
+    expect(report.evidence[0]?.excerpt).toContain("DB is corrupted");
+  });
+});

--- a/packages/temporal/src/activities/main-vuln-scan.test.ts
+++ b/packages/temporal/src/activities/main-vuln-scan.test.ts
@@ -67,11 +67,39 @@ describe("parseTrivyReport", () => {
   });
 
   test("a clean scan (no Results) parses to zero findings", () => {
+    // Real trivy 0.72.0 output for a clean filesystem scan: the envelope is
+    // present and `Results` is omitted entirely (captured from the pinned
+    // binary in the worker image).
+    const cleanScan = JSON.stringify({
+      SchemaVersion: 2,
+      Trivy: { Version: "0.72.0" },
+      ArtifactName: "/probe",
+      ArtifactType: "filesystem",
+    });
+    expect(parseTrivyReport(cleanScan)).toEqual([]);
     expect(parseTrivyReport(JSON.stringify({ SchemaVersion: 2 }))).toEqual([]);
+  });
+
+  test("refuses drifted top-level output instead of reading it as clean", () => {
+    // The fail-open this guards: valid JSON whose contract drifted would
+    // otherwise yield zero findings, publishing a false `clear` report and
+    // resolving a live critical alert.
+    expect(() => parseTrivyReport("{}")).toThrow();
+    expect(() =>
+      parseTrivyReport(JSON.stringify({ SchemaVersion: 3, Results: [] })),
+    ).toThrow();
+    expect(() =>
+      parseTrivyReport(
+        JSON.stringify({ Findings: [], Trivy: { Version: "0.72.0" } }),
+      ),
+    ).toThrow();
   });
 
   test("rejects a severity outside the requested HIGH/CRITICAL set", () => {
     const drifted = JSON.stringify({
+      // Envelope present, so this asserts severity rejection specifically and
+      // not merely a missing SchemaVersion.
+      SchemaVersion: 2,
       Results: [
         {
           Target: "bun.lock",

--- a/packages/temporal/src/activities/main-vuln-scan.ts
+++ b/packages/temporal/src/activities/main-vuln-scan.ts
@@ -41,7 +41,22 @@ const TrivyResultSchema = z.object({
   Vulnerabilities: z.array(TrivyVulnerabilitySchema).optional(),
 });
 
+/**
+ * `Results` is legitimately absent from a clean scan — trivy 0.72.0 emits only
+ * the envelope (`SchemaVersion`, `Trivy`, `ArtifactName`, …) when it finds
+ * nothing. An optional-only schema therefore cannot tell "nothing found" from
+ * "the top-level contract drifted", and the latter would publish a false
+ * `clear` report and resolve a live critical alert.
+ *
+ * Pinning the expected `SchemaVersion` closes that: `{}` or a renamed result
+ * field fails loudly instead of reading as a clean scan. The trivy binary is
+ * version-pinned in the worker image, so a schema bump is a deliberate,
+ * reviewed event rather than a surprise.
+ */
+const TRIVY_SCHEMA_VERSION = 2;
+
 const TrivyReportSchema = z.object({
+  SchemaVersion: z.literal(TRIVY_SCHEMA_VERSION),
   Results: z.array(TrivyResultSchema).optional(),
 });
 

--- a/packages/temporal/src/activities/main-vuln-scan.ts
+++ b/packages/temporal/src/activities/main-vuln-scan.ts
@@ -1,0 +1,207 @@
+import { mkdir, rm } from "node:fs/promises";
+import { z } from "zod/v4";
+import {
+  maintenanceActivityHooks,
+  maintenanceCommandEnvironment,
+  spawnMaintenanceCommand,
+  spawnMaintenanceCommandCapturingStdout,
+  type MaintenanceCommand,
+  type MaintenanceCommandHooks,
+} from "./maintenance.ts";
+
+const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
+const MAIN_BRANCH = "main";
+/**
+ * The warm Trivy database PVC mounted into the maintenance worker — kept fresh
+ * every six hours by `buildkite-trivy-db-refresh`, which is why the scan runs
+ * with `--skip-db-update` on the maintenance queue instead of downloading a
+ * database per run on the default queue.
+ */
+const TRIVY_CACHE_DIR = "/buildkite/trivy-db";
+const EXCERPT_LIMIT = 2000;
+
+/**
+ * Minimal schema for the slice of Trivy's JSON report this scan consumes.
+ * Severity is a closed enum on purpose: the command requests only
+ * HIGH,CRITICAL, so anything else appearing is a contract change that should
+ * fail loudly rather than be silently bucketed.
+ */
+const TrivyVulnerabilitySchema = z.object({
+  VulnerabilityID: z.string().min(1),
+  PkgName: z.string().min(1),
+  InstalledVersion: z.string().min(1),
+  FixedVersion: z.string().optional(),
+  Severity: z.enum(["HIGH", "CRITICAL"]),
+  Title: z.string().optional(),
+  PrimaryURL: z.string().optional(),
+});
+
+const TrivyResultSchema = z.object({
+  Target: z.string().min(1),
+  Vulnerabilities: z.array(TrivyVulnerabilitySchema).optional(),
+});
+
+const TrivyReportSchema = z.object({
+  Results: z.array(TrivyResultSchema).optional(),
+});
+
+export type MainVulnScanVulnerability = {
+  vulnerabilityId: string;
+  pkgName: string;
+  installedVersion: string;
+  fixedVersion?: string;
+  severity: "HIGH" | "CRITICAL";
+  target: string;
+  title?: string;
+  primaryUrl?: string;
+};
+
+export type MainVulnScanResult = {
+  observedAt: string;
+  repoSha: string;
+  command: string;
+  exitCode: number;
+  vulnerabilities: MainVulnScanVulnerability[];
+  /** Bounded evidence excerpt (vulnerability ids per target). */
+  excerpt: string;
+};
+
+/** Pure: Trivy JSON text → typed HIGH/CRITICAL vulnerability list. */
+export function parseTrivyReport(json: string): MainVulnScanVulnerability[] {
+  const report = TrivyReportSchema.parse(JSON.parse(json));
+  return (report.Results ?? []).flatMap((result) =>
+    (result.Vulnerabilities ?? []).map((vulnerability) => ({
+      vulnerabilityId: vulnerability.VulnerabilityID,
+      pkgName: vulnerability.PkgName,
+      installedVersion: vulnerability.InstalledVersion,
+      severity: vulnerability.Severity,
+      target: result.Target,
+      ...(vulnerability.FixedVersion === undefined
+        ? {}
+        : { fixedVersion: vulnerability.FixedVersion }),
+      ...(vulnerability.Title === undefined
+        ? {}
+        : { title: vulnerability.Title }),
+      ...(vulnerability.PrimaryURL === undefined
+        ? {}
+        : { primaryUrl: vulnerability.PrimaryURL }),
+    })),
+  );
+}
+
+/** Pure: bounded plain-text evidence excerpt for the report receipt. */
+export function buildScanExcerpt(
+  vulnerabilities: readonly MainVulnScanVulnerability[],
+): string {
+  if (vulnerabilities.length === 0) {
+    return "0 HIGH/CRITICAL vulnerabilities";
+  }
+  const lines = vulnerabilities.map(
+    (vulnerability) =>
+      `${vulnerability.severity} ${vulnerability.vulnerabilityId} ${vulnerability.pkgName}@${vulnerability.installedVersion} (${vulnerability.target})`,
+  );
+  return [`${String(vulnerabilities.length)} HIGH/CRITICAL:`, ...lines]
+    .join("\n")
+    .slice(0, EXCERPT_LIMIT);
+}
+
+function scanCommand(
+  command: readonly string[],
+  cwd: string,
+): MaintenanceCommand {
+  return {
+    kind: "main-vuln-scan",
+    command,
+    cwd,
+    env: maintenanceCommandEnvironment({}),
+    secretValues: [],
+  };
+}
+
+const TRIVY_SCAN_COMMAND = [
+  "trivy",
+  "fs",
+  "--format",
+  "json",
+  "--skip-db-update",
+  "--cache-dir",
+  TRIVY_CACHE_DIR,
+  "--scanners",
+  "vuln",
+  "--severity",
+  "HIGH,CRITICAL",
+  "--skip-dirs",
+  "node_modules",
+  "--skip-dirs",
+  "sandbox",
+  ".",
+] as const;
+
+/**
+ * Shallow-clones current `main` (the repo is public — no credentials) and runs
+ * a Trivy filesystem scan for HIGH/CRITICAL vulnerabilities against the warm
+ * Buildkite Trivy database. The clone's own `.trivyignore` applies
+ * automatically because the scan runs from the clone root.
+ *
+ * Runs on the maintenance queue: that worker mounts the warm DB PVC, and its
+ * single activity slot cannot race the six-hourly DB refresh writer.
+ */
+async function scanMainForVulnerabilities(
+  hooks: MaintenanceCommandHooks = maintenanceActivityHooks(),
+): Promise<MainVulnScanResult> {
+  // Per-attempt scratch directory so a retry never trips over a previous
+  // attempt's half-cleaned clone. Never derive anything durable from it.
+  const tempDir = `/tmp/main-vuln-scan-${crypto.randomUUID()}`;
+  const repoDir = `${tempDir}/monorepo`;
+  await mkdir(tempDir, { recursive: true });
+  try {
+    await spawnMaintenanceCommand(
+      scanCommand(
+        [
+          "git",
+          "clone",
+          "--depth",
+          "1",
+          "--branch",
+          MAIN_BRANCH,
+          "--single-branch",
+          REPO_URL,
+          repoDir,
+        ],
+        tempDir,
+      ),
+      hooks,
+    );
+    const revParse = await spawnMaintenanceCommandCapturingStdout(
+      scanCommand(["git", "rev-parse", "HEAD"], repoDir),
+      hooks,
+    );
+    const repoSha = revParse.stdout.trim();
+    if (repoSha === "") {
+      throw new Error("git rev-parse HEAD returned no commit for the clone");
+    }
+    const scan = await spawnMaintenanceCommandCapturingStdout(
+      scanCommand(TRIVY_SCAN_COMMAND, repoDir),
+      hooks,
+    );
+    const vulnerabilities = parseTrivyReport(scan.stdout);
+    return {
+      observedAt: new Date().toISOString(),
+      repoSha,
+      command: TRIVY_SCAN_COMMAND.join(" "),
+      exitCode: scan.exitCode,
+      vulnerabilities,
+      excerpt: buildScanExcerpt(vulnerabilities),
+    };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+export const mainVulnScanActivities = {
+  async scanMainForVulnerabilities(): Promise<MainVulnScanResult> {
+    return scanMainForVulnerabilities();
+  },
+};
+
+export type MainVulnScanActivities = typeof mainVulnScanActivities;

--- a/packages/temporal/src/activities/maintenance-capture.test.ts
+++ b/packages/temporal/src/activities/maintenance-capture.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+import {
+  maintenanceCommandEnvironment,
+  spawnMaintenanceCommand,
+  spawnMaintenanceCommandCapturingStdout,
+  type MaintenanceCommand,
+  type MaintenanceCommandHooks,
+} from "./maintenance.ts";
+
+function command(
+  args: readonly string[],
+  secretValues: readonly string[] = [],
+): MaintenanceCommand {
+  return {
+    kind: "main-vuln-scan",
+    command: args,
+    cwd: "/tmp",
+    env: maintenanceCommandEnvironment({}),
+    secretValues,
+  };
+}
+
+function hooks(): MaintenanceCommandHooks {
+  return {
+    heartbeat: () => {
+      // Recorded via Temporal in production; a no-op suffices here.
+    },
+    onCancellation: () => {
+      // No cancellation in these subprocess tests.
+    },
+  };
+}
+
+describe("spawnMaintenanceCommandCapturingStdout", () => {
+  test("returns complete stdout instead of only a tail", async () => {
+    const lines = Array.from(
+      { length: 50 },
+      (_, index) => `line-${String(index)}`,
+    );
+    const result = await spawnMaintenanceCommandCapturingStdout(
+      command(["sh", "-c", String.raw`printf '%s\n' ${lines.join(" ")}`]),
+      hooks(),
+    );
+    expect(result.exitCode).toBe(0);
+    // 50 lines exceeds the 20-line log tail — capture keeps every one.
+    expect(result.stdout.split("\n")).toEqual(lines);
+  });
+
+  test("redacts secret values from captured output", async () => {
+    const result = await spawnMaintenanceCommandCapturingStdout(
+      command(["sh", "-c", "echo token=hunter2"], ["hunter2"]),
+      hooks(),
+    );
+    expect(result.stdout).toBe("token=<redacted>");
+  });
+
+  test("throws on an unaccepted exit code with the stderr tail", async () => {
+    await expect(
+      spawnMaintenanceCommandCapturingStdout(
+        command(["sh", "-c", "echo boom >&2; exit 3"]),
+        hooks(),
+      ),
+    ).rejects.toThrow(/exited 3.*boom/s);
+  });
+
+  test("returns instead of throwing for a declared findings exit code", async () => {
+    const result = await spawnMaintenanceCommandCapturingStdout(
+      command(["sh", "-c", "echo findings; exit 2"]),
+      hooks(),
+      { acceptedExitCodes: [0, 2] },
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toBe("findings");
+  });
+});
+
+describe("spawnMaintenanceCommand", () => {
+  test("still returns the zero exit code for a successful command", async () => {
+    await expect(
+      spawnMaintenanceCommand(command(["true"]), hooks()),
+    ).resolves.toBe(0);
+  });
+
+  test("still throws on a non-zero exit", async () => {
+    await expect(
+      spawnMaintenanceCommand(command(["sh", "-c", "exit 1"]), hooks()),
+    ).rejects.toThrow(/exited 1/);
+  });
+});

--- a/packages/temporal/src/activities/maintenance.ts
+++ b/packages/temporal/src/activities/maintenance.ts
@@ -44,8 +44,17 @@ export type MaintenanceKind =
   | "buildkite-uv-cache-prune"
   | "buildkite-trivy-db-refresh";
 
+/**
+ * Label attached to every maintenance subprocess for logs and error messages.
+ * `MaintenanceKind` values also key the maintenance metrics via
+ * {@link executeMaintenance}; the extra members label activities that build
+ * their commands directly (and own their own reporting) without widening the
+ * exhaustive `buildMaintenanceCommand` switch.
+ */
+export type MaintenanceSubprocessKind = MaintenanceKind | "main-vuln-scan";
+
 export type MaintenanceCommand = {
-  kind: MaintenanceKind;
+  kind: MaintenanceSubprocessKind;
   command: readonly string[];
   cwd: string;
   env: Record<string, string>;
@@ -83,7 +92,7 @@ async function requiredSecretFile(name: string): Promise<string> {
   return value;
 }
 
-function activityHooks(): MaintenanceCommandHooks {
+export function maintenanceActivityHooks(): MaintenanceCommandHooks {
   const context = Context.current();
 
   const hooks: MaintenanceCommandHooks = {
@@ -98,7 +107,7 @@ function activityHooks(): MaintenanceCommandHooks {
   return hooks;
 }
 
-function commandEnvironment(
+export function maintenanceCommandEnvironment(
   overrides: Record<string, string>,
 ): Record<string, string> {
   const environment: Record<string, string> = {};
@@ -123,7 +132,7 @@ export async function buildMaintenanceCommand(
         kind,
         command: ["kometa", "--config", KOMETA_CONFIG_PATH, "--run"],
         cwd: MAINTENANCE_WORKDIR,
-        env: commandEnvironment({
+        env: maintenanceCommandEnvironment({
           KOMETA_PLEXTOKEN: plexToken,
           KOMETA_TMDBAPIKEY: tmdbApiKey,
           KOMETA_READ_ONLY_CONFIG: "true",
@@ -137,7 +146,7 @@ export async function buildMaintenanceCommand(
         kind,
         command: ["bash", "/buildkite/maintenance/bun-cache-gc.sh"],
         cwd: MAINTENANCE_WORKDIR,
-        env: commandEnvironment({
+        env: maintenanceCommandEnvironment({
           BUN_INSTALL_CACHE_DIR: "/buildkite/bun-cache/data",
           BUN_CACHE_LOCK_FILE: "/buildkite/bun-cache-control/.gc.lock",
           BUN_CACHE_GC_THRESHOLD_PERCENT: "60",
@@ -149,7 +158,9 @@ export async function buildMaintenanceCommand(
         kind,
         command: ["uv", "cache", "prune", "--ci"],
         cwd: MAINTENANCE_WORKDIR,
-        env: commandEnvironment({ UV_CACHE_DIR: "/buildkite/uv-cache" }),
+        env: maintenanceCommandEnvironment({
+          UV_CACHE_DIR: "/buildkite/uv-cache",
+        }),
         secretValues: [],
       };
     case "buildkite-trivy-db-refresh":
@@ -163,7 +174,7 @@ export async function buildMaintenanceCommand(
           "/buildkite/trivy-db",
         ],
         cwd: MAINTENANCE_WORKDIR,
-        env: commandEnvironment({}),
+        env: maintenanceCommandEnvironment({}),
         secretValues: [],
       };
   }
@@ -187,13 +198,47 @@ function appendOutputTail(tail: string[], line: string): void {
   }
 }
 
+/**
+ * How a subprocess stream is consumed:
+ *
+ * - `log` — every line is redacted and streamed to the worker logs, and only a
+ *   bounded tail is retained for error messages. This is the right mode for
+ *   long-running maintenance jobs whose output is operational noise.
+ * - `capture` — the redacted output is retained in full and returned to the
+ *   caller (nothing is streamed to the logs line-by-line, which would flood
+ *   Loki with a machine-readable payload). This is the mode for commands whose
+ *   stdout IS the result, e.g. a `--format json` scanner.
+ */
+type StreamMode = "log" | "capture";
+
+type StreamOutcome = {
+  tail: string;
+  /** Complete redacted output; empty string in `log` mode. */
+  captured: string;
+};
+
 async function streamMaintenanceOutput(
   stream: ReadableStream<Uint8Array>,
   streamName: "stdout" | "stderr",
   command: MaintenanceCommand,
-): Promise<string> {
+  mode: StreamMode,
+): Promise<StreamOutcome> {
   const decoder = new TextDecoder();
   const tail: string[] = [];
+  const captured: string[] = [];
+  const consumeLine = (line: string): void => {
+    const redacted = redact(line, command.secretValues);
+    appendOutputTail(tail, redacted);
+    if (mode === "capture") {
+      captured.push(redacted);
+      return;
+    }
+    log("info", "Maintenance subprocess output", {
+      maintenanceKind: command.kind,
+      stream: streamName,
+      line: redacted,
+    });
+  };
   let pending = "";
   for await (const value of stream) {
     pending += decoder.decode(value, { stream: true });
@@ -204,32 +249,32 @@ async function streamMaintenanceOutput(
     const completeLines = pending.slice(0, lastNewline).split("\n");
     pending = pending.slice(lastNewline + 1);
     for (const line of completeLines) {
-      const redacted = redact(line.replace(/\r$/, ""), command.secretValues);
-      appendOutputTail(tail, redacted);
-      log("info", "Maintenance subprocess output", {
-        maintenanceKind: command.kind,
-        stream: streamName,
-        line: redacted,
-      });
+      consumeLine(line.replace(/\r$/, ""));
     }
   }
   pending += decoder.decode();
   if (pending !== "") {
-    const redacted = redact(pending, command.secretValues);
-    appendOutputTail(tail, redacted);
-    log("info", "Maintenance subprocess output", {
-      maintenanceKind: command.kind,
-      stream: streamName,
-      line: redacted,
-    });
+    consumeLine(pending);
   }
-  return tail.join("\n");
+  return { tail: tail.join("\n"), captured: captured.join("\n") };
 }
 
-export const spawnMaintenanceCommand: MaintenanceCommandRunner = async (
-  command,
-  hooks,
-) => {
+type MaintenanceSubprocessOutcome = {
+  exitCode: number;
+  stdout: StreamOutcome;
+  stderr: StreamOutcome;
+};
+
+/**
+ * Shared subprocess core: heartbeats, process-group cancellation
+ * (SIGTERM → SIGKILL), and redacted output handling live here exactly once.
+ * Callers decide what a non-zero exit means; this function only reports it.
+ */
+async function runMaintenanceSubprocess(
+  command: MaintenanceCommand,
+  hooks: MaintenanceCommandHooks,
+  stdoutMode: StreamMode,
+): Promise<MaintenanceSubprocessOutcome> {
   const childEnv = command.env;
   const subprocess = Bun.spawn([...command.command], {
     cwd: command.cwd,
@@ -265,11 +310,11 @@ export const spawnMaintenanceCommand: MaintenanceCommandRunner = async (
     abort();
   }
 
-  let result: [string, string, number] | undefined;
+  let result: [StreamOutcome, StreamOutcome, number] | undefined;
   try {
     const completion = Promise.all([
-      streamMaintenanceOutput(subprocess.stdout, "stdout", command),
-      streamMaintenanceOutput(subprocess.stderr, "stderr", command),
+      streamMaintenanceOutput(subprocess.stdout, "stdout", command, stdoutMode),
+      streamMaintenanceOutput(subprocess.stderr, "stderr", command, "log"),
       subprocess.exited,
     ]);
     result = await completion;
@@ -286,21 +331,66 @@ export const spawnMaintenanceCommand: MaintenanceCommandRunner = async (
   }
 
   const [stdout, stderr, exitCode] = result;
-  if (exitCode !== 0) {
-    const detail = [stdout, stderr]
-      .filter((output) => output !== "")
-      .join("\n");
-    throw new Error(
-      `${command.kind} command exited ${String(exitCode)}${detail === "" ? "" : `: ${detail}`}`,
-    );
+  return { exitCode, stdout, stderr };
+}
+
+function throwOnMaintenanceExit(
+  command: MaintenanceCommand,
+  outcome: MaintenanceSubprocessOutcome,
+): void {
+  const detail = [outcome.stdout.tail, outcome.stderr.tail]
+    .filter((output) => output !== "")
+    .join("\n");
+  throw new Error(
+    `${command.kind} command exited ${String(outcome.exitCode)}${detail === "" ? "" : `: ${detail}`}`,
+  );
+}
+
+export const spawnMaintenanceCommand: MaintenanceCommandRunner = async (
+  command,
+  hooks,
+) => {
+  const outcome = await runMaintenanceSubprocess(command, hooks, "log");
+  if (outcome.exitCode !== 0) {
+    throwOnMaintenanceExit(command, outcome);
   }
-  return exitCode;
+  return outcome.exitCode;
 };
+
+export type MaintenanceCaptureResult = {
+  exitCode: number;
+  /** Complete redacted stdout — the command's machine-readable result. */
+  stdout: string;
+};
+
+/**
+ * Variant of {@link spawnMaintenanceCommand} for commands whose stdout is the
+ * result (e.g. `--format json` scanners): stdout is captured in full and
+ * returned instead of being streamed to the logs, while stderr keeps the
+ * ordinary log-and-tail behavior. Heartbeats, cancellation, and redaction are
+ * the same shared implementation — do not fork this into a bare `Bun.spawn`.
+ *
+ * `acceptedExitCodes` exists for scanners that reserve a non-zero exit for
+ * "findings present" (e.g. lychee exits 2 when links are broken); every other
+ * exit still fails fast with the bounded output tails.
+ */
+export async function spawnMaintenanceCommandCapturingStdout(
+  command: MaintenanceCommand,
+  hooks: MaintenanceCommandHooks,
+  options: { acceptedExitCodes?: readonly number[] } = {},
+): Promise<MaintenanceCaptureResult> {
+  const acceptedExitCodes = options.acceptedExitCodes ?? [0];
+  const outcome = await runMaintenanceSubprocess(command, hooks, "capture");
+  if (!acceptedExitCodes.includes(outcome.exitCode)) {
+    throwOnMaintenanceExit(command, outcome);
+  }
+  return { exitCode: outcome.exitCode, stdout: outcome.stdout.captured };
+}
 
 export async function executeMaintenance(
   kind: MaintenanceKind,
   runner: MaintenanceCommandRunner = spawnMaintenanceCommand,
-  hooks: MaintenanceCommandHooks = activityHooks(),
+  hooks: MaintenanceCommandHooks = maintenanceActivityHooks(),
 ): Promise<void> {
   const command = await buildMaintenanceCommand(kind);
   try {

--- a/packages/temporal/src/activities/report-freshness.test.ts
+++ b/packages/temporal/src/activities/report-freshness.test.ts
@@ -235,3 +235,58 @@ describe("freshnessDeploymentState", () => {
     });
   });
 });
+
+describe("newly rolled-out schedule activation", () => {
+  // A brand-new weekly schedule has no receipt and no prior action on its
+  // first deployment. `evaluateFreshness` then bounds the pending window at
+  // receiptRequiredAfter + cadence + grace, so an activation inherited from an
+  // older worker is already expired and the 15-minute monitor reports
+  // `missing` — paging TemporalReportHeartbeatStale for a full cadence before
+  // the schedule has had any chance to run.
+  const scannerRegistration = {
+    scheduleId: "main-vuln-scan-weekly",
+    reportType: "main-vuln-scan",
+    cadenceHours: 168,
+    graceHours: 6,
+    receiptRequiredAfter: "2026-09-01T00:00:00.000Z",
+  };
+
+  function statusAtRollout(receiptRequiredAfter: string, now: string) {
+    return evaluateFreshness({
+      registration: { ...scannerRegistration, receiptRequiredAfter },
+      now: new Date(now),
+      acceptedAt: undefined,
+      lastActionTakenAt: undefined,
+      deployed: true,
+      paused: false,
+    }).status;
+  }
+
+  test("stays pending from rollout until the first run can deliver", () => {
+    // Rollout day, and the first Sunday 05:00 PT run (2026-09-06T12:00Z).
+    expect(
+      statusAtRollout("2026-09-01T00:00:00.000Z", "2026-09-01T00:05:00.000Z"),
+    ).toBe("pending");
+    expect(
+      statusAtRollout("2026-09-01T00:00:00.000Z", "2026-09-06T12:00:00.000Z"),
+    ).toBe("pending");
+  });
+
+  test("reports missing only after a full cadence plus grace elapsed", () => {
+    // 168h + 6h after activation = 2026-09-08T06:00Z.
+    expect(
+      statusAtRollout("2026-09-01T00:00:00.000Z", "2026-09-08T05:59:00.000Z"),
+    ).toBe("pending");
+    expect(
+      statusAtRollout("2026-09-01T00:00:00.000Z", "2026-09-08T06:01:00.000Z"),
+    ).toBe("missing");
+  });
+
+  test("an inherited stale activation would page before the first run", () => {
+    // The defect this guards: the original worker activation makes the very
+    // first freshness evaluation report `missing` on rollout day.
+    expect(
+      statusAtRollout("2026-08-11T23:52:18.000Z", "2026-09-01T00:05:00.000Z"),
+    ).toBe("missing");
+  });
+});

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -31,6 +31,7 @@ describe("direct maintenance schedules", () => {
     ["buildkite-uv-cache-prune-weekly", "runUvCachePruneWorkflow", "2 hours"],
     ["buildkite-trivy-db-refresh", "runTrivyDbRefreshWorkflow", "2 hours"],
     ["turbo-cache-clean-daily", "runTurboCacheCleanWorkflow", "30 minutes"],
+    ["main-vuln-scan-weekly", "runMainVulnScanWorkflow", "2 hours"],
   ] as const;
 
   it.each(definitions)(
@@ -165,6 +166,10 @@ const WORKFLOWS_WITHOUT_LONG_SLEEPS = new Set([
   "runUvCachePruneWorkflow",
   "runTrivyDbRefreshWorkflow",
   "runTurboCacheCleanWorkflow",
+  // Awaits one scan activity (clone + trivy fs) then report delivery and the
+  // Alertmanager publish. No workflow-level sleeps; each activity carries its
+  // own startToCloseTimeout + retry budget.
+  "runMainVulnScanWorkflow",
   "monitorReportFreshness",
   "generateDependencySummary",
   "runProtobufWatch",

--- a/packages/temporal/src/schedules/report-registry.test.ts
+++ b/packages/temporal/src/schedules/report-registry.test.ts
@@ -24,13 +24,41 @@ describe("report schedule registry", () => {
     }
   });
 
-  test("activates receipt enforcement from the deployed receipt-capable worker", () => {
+  test("anchors receipt enforcement to a rollout the schedule could meet", () => {
+    // Two activations: the original receipt-capable worker, and the rollout of
+    // the weekly scanner schedules added later.
     expect(
       new Set(
         REPORT_SCHEDULE_REGISTRY.map(
           (registration) => registration.receiptRequiredAfter,
         ),
       ),
-    ).toEqual(new Set(["2026-08-11T23:52:18.000Z"]));
+    ).toEqual(
+      new Set(["2026-08-11T23:52:18.000Z", "2026-09-01T00:00:00.000Z"]),
+    );
+  });
+
+  test("a schedule never activates before a rollout it could not have met", () => {
+    // Regression guard. Before its first receipt a schedule's pending window
+    // is bounded at receiptRequiredAfter + cadence + grace, so inheriting an
+    // older schedule's activation makes a brand-new weekly job report
+    // `missing` and page TemporalReportHeartbeatStale for a full cadence
+    // before it can run once. Each activation must leave room for at least one
+    // full cadence after it.
+    for (const registration of REPORT_SCHEDULE_REGISTRY) {
+      const activation = Date.parse(registration.receiptRequiredAfter);
+      expect(Number.isFinite(activation)).toBe(true);
+      const pendingWindowHours =
+        registration.cadenceHours + registration.graceHours;
+      expect(pendingWindowHours).toBeGreaterThan(registration.cadenceHours);
+    }
+    for (const scheduleId of ["main-vuln-scan-weekly"]) {
+      const registration = REPORT_SCHEDULE_REGISTRY.find(
+        (candidate) => candidate.scheduleId === scheduleId,
+      );
+      expect(registration?.receiptRequiredAfter).toBe(
+        "2026-09-01T00:00:00.000Z",
+      );
+    }
   });
 });

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -234,6 +234,21 @@ export const SCHEDULES: ScheduleDefinition[] = [
     memo: "Buildkite Trivy vulnerability database refresh every six hours",
   },
   {
+    id: "main-vuln-scan-weekly",
+    workflowType: "runMainVulnScanWorkflow",
+    args: [],
+    // Sun 05:00 PT — after the 03:00–04:30 maintenance window and clear of the
+    // six-hourly trivy-db-refresh slots (:30 past 0/6/12/18), so the scan reads
+    // a database refreshed at 00:30 and never queues behind the refresh writer.
+    cronExpression: "0 5 * * 0",
+    taskQueue: TASK_QUEUES.MAINTENANCE,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    // Three 20-minute scan attempts plus backoff, then report delivery and the
+    // Alertmanager publish with their own three-attempt budgets.
+    workflowExecutionTimeout: "2 hours",
+    memo: "Weekly Trivy HIGH/CRITICAL vulnerability scan of main (warm Buildkite Trivy DB) with report delivery; CRITICAL findings page via Alertmanager",
+  },
+  {
     id: "bugsink-housekeeping",
     workflowType: "runBugsinkHousekeepingWorkflow",
     args: [],

--- a/packages/temporal/src/shared/main-vuln-scan-alert.test.ts
+++ b/packages/temporal/src/shared/main-vuln-scan-alert.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildMainVulnScanAlert,
+  MAIN_VULN_SCAN_ALERT_TTL_MS,
+} from "./main-vuln-scan-alert.ts";
+
+const NOW = new Date("2026-08-23T12:00:00.000Z");
+const REPO_SHA = "d9ea9584e0123456789abcdef0123456789abcde";
+
+describe("buildMainVulnScanAlert", () => {
+  test("fires with the TTL while critical findings exist", () => {
+    const alert = buildMainVulnScanAlert(
+      { criticalCount: 2, repoSha: REPO_SHA },
+      NOW,
+    );
+    expect(alert.labels).toEqual({
+      alertname: "MainVulnScanCritical",
+      severity: "critical",
+      component: "main-vuln-scan",
+    });
+    expect(alert.annotations["summary"]).toContain("2 CRITICAL finding(s)");
+    expect(Date.parse(alert.endsAt) - Date.parse(alert.startsAt)).toBe(
+      MAIN_VULN_SCAN_ALERT_TTL_MS,
+    );
+  });
+
+  test("a clean run resolves under the identical label set", () => {
+    const firing = buildMainVulnScanAlert(
+      { criticalCount: 1, repoSha: REPO_SHA },
+      NOW,
+    );
+    const resolved = buildMainVulnScanAlert(
+      { criticalCount: 0, repoSha: REPO_SHA },
+      NOW,
+    );
+    // Alertmanager identifies an alert by label set alone — the resolve must
+    // carry exactly the firing labels or the earlier occurrence never closes.
+    expect(resolved.labels).toEqual(firing.labels);
+    expect(resolved.endsAt).toBe(resolved.startsAt);
+    expect(resolved.annotations["summary"]).toContain("resolved");
+  });
+
+  test("the TTL outlives the weekly cadence so findings cannot self-expire", () => {
+    expect(MAIN_VULN_SCAN_ALERT_TTL_MS).toBeGreaterThan(
+      7 * 24 * 60 * 60 * 1000,
+    );
+  });
+});

--- a/packages/temporal/src/shared/main-vuln-scan-alert.ts
+++ b/packages/temporal/src/shared/main-vuln-scan-alert.ts
@@ -1,0 +1,62 @@
+import type { AlertmanagerAlert } from "#lib/alertmanager.ts";
+
+const GENERATOR_URL = "https://github.com/shepherdjerred/monorepo";
+
+/**
+ * How long a critical-vulnerability alert stays firing without being re-fired.
+ * The scan runs weekly, so anything shorter would let the alert resolve itself
+ * between runs; eight days keeps it alive until the next run either re-fires
+ * or explicitly resolves it. Mirrors LLM_CATALOG_WITHHELD_ALERT_TTL_MS.
+ */
+export const MAIN_VULN_SCAN_ALERT_TTL_MS = 8 * 24 * 60 * 60 * 1000;
+
+export type MainVulnScanAlertInput = {
+  /** Number of CRITICAL-severity vulnerabilities this run found. */
+  criticalCount: number;
+  /** Commit of main that was scanned. */
+  repoSha: string;
+};
+
+/**
+ * Pure fire/resolve builder for the weekly scan's Alertmanager occurrence.
+ *
+ * Every run publishes exactly one occurrence under a fixed label set:
+ * firing (endsAt = now + TTL) while at least one CRITICAL vulnerability is
+ * present, resolving (endsAt = startsAt) the moment a run finds none — so a
+ * remediated scan clears the page instead of leaving it to age out over eight
+ * days. HIGH findings deliberately do not page: the report email carries them,
+ * and only `critical` routes.
+ */
+export function buildMainVulnScanAlert(
+  input: MainVulnScanAlertInput,
+  now: Date,
+): AlertmanagerAlert {
+  const firing = input.criticalCount > 0;
+  const shortSha = input.repoSha.slice(0, 12);
+  const summary = firing
+    ? `main vulnerability scan: ${String(input.criticalCount)} CRITICAL finding(s) on main@${shortSha}`
+    : `main vulnerability scan: no CRITICAL findings on main@${shortSha} — earlier finding is resolved`;
+  const description = firing
+    ? [
+        `The weekly Trivy scan of main@${shortSha} found ${String(input.criticalCount)} CRITICAL`,
+        "vulnerability finding(s). The full list (with affected packages and fixed",
+        "versions) is in the main-vuln-scan report email. Upgrade the affected",
+        "packages or record a justified ignore in .trivyignore.",
+      ].join("\n")
+    : `The weekly Trivy scan of main@${shortSha} found no CRITICAL vulnerabilities.`;
+  return {
+    labels: {
+      alertname: "MainVulnScanCritical",
+      severity: "critical",
+      component: "main-vuln-scan",
+    },
+    // `message` mirrors `description` — the Alerts template reads either
+    // depending on the alert source (see xcode-cloud-webhook.ts).
+    annotations: { summary, description, message: description },
+    startsAt: now.toISOString(),
+    endsAt: new Date(
+      now.getTime() + (firing ? MAIN_VULN_SCAN_ALERT_TTL_MS : 0),
+    ).toISOString(),
+    generatorURL: GENERATOR_URL,
+  };
+}

--- a/packages/temporal/src/shared/report-registry.ts
+++ b/packages/temporal/src/shared/report-registry.ts
@@ -8,6 +8,22 @@ export type ReportScheduleRegistration = {
 
 const REPORT_RECEIPT_ACTIVATION = "2026-08-11T23:52:18.000Z";
 
+/**
+ * Activation for schedules rolled out with the weekly scanner reports.
+ *
+ * A registration's activation must not precede its real rollout by more than
+ * `graceHours`. Before a schedule's first receipt exists, `evaluateFreshness`
+ * bounds the pending window at `receiptRequiredAfter + cadenceHours +
+ * graceHours`, so reusing REPORT_RECEIPT_ACTIVATION here would hand a brand-new
+ * weekly schedule a deadline of 2026-08-19 — already expired — and the
+ * 15-minute monitor would report `missing` and page
+ * `TemporalReportHeartbeatStale` for a full cadence before the schedule could
+ * run even once. Setting it later than the rollout is safe (the pending window
+ * simply starts later); setting it earlier is not. Bump this date if the
+ * rollout slips past it.
+ */
+const SCANNER_REPORT_ACTIVATION = "2026-09-01T00:00:00.000Z";
+
 export function defaultReportGraceHours(cadenceHours: number): number {
   if (cadenceHours < 24) return 0.5;
   return cadenceHours < 168 ? 2 : 6;
@@ -75,7 +91,7 @@ export const REPORT_SCHEDULE_REGISTRY: readonly ReportScheduleRegistration[] = [
     reportType: "main-vuln-scan",
     cadenceHours: 168,
     graceHours: defaultReportGraceHours(168),
-    receiptRequiredAfter: REPORT_RECEIPT_ACTIVATION,
+    receiptRequiredAfter: SCANNER_REPORT_ACTIVATION,
   },
   {
     scheduleId: "ci-io-post-merge-impact",

--- a/packages/temporal/src/shared/report-registry.ts
+++ b/packages/temporal/src/shared/report-registry.ts
@@ -71,6 +71,13 @@ export const REPORT_SCHEDULE_REGISTRY: readonly ReportScheduleRegistration[] = [
     receiptRequiredAfter: REPORT_RECEIPT_ACTIVATION,
   },
   {
+    scheduleId: "main-vuln-scan-weekly",
+    reportType: "main-vuln-scan",
+    cadenceHours: 168,
+    graceHours: defaultReportGraceHours(168),
+    receiptRequiredAfter: REPORT_RECEIPT_ACTIVATION,
+  },
+  {
     scheduleId: "ci-io-post-merge-impact",
     reportType: "ci-io-impact",
     cadenceHours: 24,

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -8,8 +8,8 @@ import {
   repoActivities,
   reportActivities,
   scoutActivities,
+  maintenanceWorkerActivities,
 } from "./activities/index.ts";
-import { maintenanceActivities } from "./activities/maintenance.ts";
 import { TASK_QUEUES, type TaskQueue } from "./shared/task-queues.ts";
 import type { WorkerRole } from "./shared/worker-role.ts";
 
@@ -100,7 +100,7 @@ export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
   {
     role: "maintenance",
     taskQueue: TASK_QUEUES.MAINTENANCE,
-    activities: maintenanceActivities,
+    activities: maintenanceWorkerActivities,
     maxConcurrentActivityTaskExecutions: 1,
     maxConcurrentWorkflowTaskExecutions: 2,
   },

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -71,7 +71,14 @@ export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
   },
   {
     role: "scout",
-    taskQueue: TASK_QUEUES.SCOUT,
+    taskQueue: TASK_QUEUES.SCOUT_BETA,
+    activities: scoutActivities,
+    maxConcurrentActivityTaskExecutions: 1,
+    maxConcurrentWorkflowTaskExecutions: 2,
+  },
+  {
+    role: "scout",
+    taskQueue: TASK_QUEUES.SCOUT_PROD,
     activities: scoutActivities,
     maxConcurrentActivityTaskExecutions: 1,
     maxConcurrentWorkflowTaskExecutions: 2,

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -107,6 +107,7 @@ import type {
   GlitterContextRefreshInput,
   GlitterContextRefreshResult,
 } from "#activities/glitter-context-refresh.ts";
+import { runMainVulnScanWorkflow as runMainVulnScanWorkflowImplementation } from "./main-vuln-scan.ts";
 import {
   runKometaWorkflow as runKometaWorkflowImplementation,
   runBunCacheGcWorkflow as runBunCacheGcWorkflowImplementation,
@@ -122,6 +123,10 @@ export async function fetchSkillCappedManifest(): Promise<void> {
 
 export async function runKometaWorkflow(): Promise<void> {
   return runKometaWorkflowImplementation();
+}
+
+export async function runMainVulnScanWorkflow(): Promise<void> {
+  return runMainVulnScanWorkflowImplementation();
 }
 
 export async function runBunCacheGcWorkflow(): Promise<void> {

--- a/packages/temporal/src/workflows/main-vuln-scan.test.ts
+++ b/packages/temporal/src/workflows/main-vuln-scan.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import type { MainVulnScanResult } from "#activities/main-vuln-scan.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { runMainVulnScanWorkflow } from "./main-vuln-scan.ts";
+
+// The workflow proxies report delivery and the Alertmanager publish to
+// TASK_QUEUES.DEFAULT, so the test worker polls that queue and the workflow is
+// started on it — otherwise those activities are scheduled to a queue nothing
+// is polling and the workflow blocks forever.
+const TASK_QUEUE = TASK_QUEUES.DEFAULT;
+const REPO_SHA = "d9ea9584e0123456789abcdef0123456789abcde";
+
+let testEnv: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+  testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnv.teardown();
+});
+
+function scanResult(
+  vulnerabilities: MainVulnScanResult["vulnerabilities"],
+): MainVulnScanResult {
+  return {
+    observedAt: "2026-08-23T12:00:00.000Z",
+    repoSha: REPO_SHA,
+    command: "trivy fs --format json .",
+    exitCode: 0,
+    vulnerabilities,
+    excerpt: "fixture",
+  };
+}
+
+const CRITICAL_VULNERABILITY = {
+  vulnerabilityId: "CVE-2026-1234",
+  pkgName: "left-pad",
+  installedVersion: "1.3.0",
+  severity: "CRITICAL" as const,
+  target: "bun.lock",
+};
+
+// Activity inputs arrive as `unknown` through the Temporal payload boundary;
+// narrow them with Zod rather than a type assertion.
+const DeliveredReportSchema = z.object({
+  execution: z.string().min(1),
+  verdict: z.string().min(1),
+});
+const PublishedAlertSchema = z.object({
+  criticalCount: z.number().int().nonnegative(),
+  repoSha: z.string().min(1),
+});
+
+type Harness = {
+  reports: z.infer<typeof DeliveredReportSchema>[];
+  alerts: z.infer<typeof PublishedAlertSchema>[];
+};
+
+async function runWorkflow(
+  overrides: {
+    scan?: () => Promise<MainVulnScanResult>;
+    publish?: () => Promise<void>;
+  },
+  vulnerabilities: MainVulnScanResult["vulnerabilities"] = [],
+): Promise<{ harness: Harness; failure: unknown }> {
+  const harness: Harness = { reports: [], alerts: [] };
+  const worker = await Worker.create({
+    connection: testEnv.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowsPath: new URL("index.ts", import.meta.url).pathname,
+    activities: {
+      scanMainForVulnerabilities:
+        overrides.scan ?? (async () => scanResult(vulnerabilities)),
+      deliverActivityReport: (input: unknown) => {
+        harness.reports.push(DeliveredReportSchema.parse(input));
+        return { accepted: true, duplicate: false, reportRunId: "report-1" };
+      },
+      publishMainVulnScanAlerts:
+        overrides.publish ??
+        ((input: unknown) => {
+          harness.alerts.push(PublishedAlertSchema.parse(input));
+          return Promise.resolve();
+        }),
+    },
+  });
+
+  let failure: unknown;
+  try {
+    await worker.runUntil(
+      testEnv.client.workflow.execute(runMainVulnScanWorkflow, {
+        args: [],
+        taskQueue: TASK_QUEUE,
+        workflowId: `test-main-vuln-scan-${crypto.randomUUID()}`,
+      }),
+    );
+  } catch (error: unknown) {
+    failure = error;
+  }
+  return { harness, failure };
+}
+
+describe("runMainVulnScanWorkflow", () => {
+  it("delivers one clear report and resolves the alert on a clean scan", async () => {
+    const { harness, failure } = await runWorkflow({});
+    expect(failure).toBeUndefined();
+    expect(harness.reports).toEqual([
+      { execution: "complete", verdict: "clear" },
+    ]);
+    expect(harness.alerts).toEqual([{ criticalCount: 0, repoSha: REPO_SHA }]);
+  }, 60_000);
+
+  it("fires the alert with the critical count when findings exist", async () => {
+    const { harness, failure } = await runWorkflow({}, [
+      CRITICAL_VULNERABILITY,
+    ]);
+    expect(failure).toBeUndefined();
+    expect(harness.reports).toEqual([
+      { execution: "complete", verdict: "attention" },
+    ]);
+    expect(harness.alerts).toEqual([{ criticalCount: 1, repoSha: REPO_SHA }]);
+  }, 60_000);
+
+  it("delivers a failed report before rethrowing a scan failure", async () => {
+    const { harness, failure } = await runWorkflow({
+      scan: () => {
+        throw new Error("trivy database unavailable");
+      },
+    });
+    expect(failure).toBeInstanceOf(Error);
+    expect(harness.reports).toEqual([
+      { execution: "failed", verdict: "inconclusive" },
+    ]);
+    expect(harness.alerts).toEqual([]);
+  }, 60_000);
+
+  it("never contradicts a delivered scan report when the alert publish fails", async () => {
+    // Regression guard: an Alertmanager outage after a successful scan and a
+    // delivered report must not send a second report claiming the scan failed.
+    // The workflow fails (temporal-failure-watch raises its own occurrence)
+    // with exactly one, accurate report on the wire.
+    const { harness, failure } = await runWorkflow(
+      {
+        publish: () => {
+          throw new Error("alertmanager unreachable");
+        },
+      },
+      [CRITICAL_VULNERABILITY],
+    );
+    expect(failure).toBeInstanceOf(Error);
+    expect(harness.reports).toEqual([
+      { execution: "complete", verdict: "attention" },
+    ]);
+    expect(
+      harness.reports.some((report) => report.execution === "failed"),
+    ).toBe(false);
+  }, 120_000);
+});

--- a/packages/temporal/src/workflows/main-vuln-scan.ts
+++ b/packages/temporal/src/workflows/main-vuln-scan.ts
@@ -1,0 +1,64 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type { MainVulnScanActivities } from "#activities/main-vuln-scan.ts";
+import type { MainVulnScanAlertActivities } from "#activities/main-vuln-scan-alerts.ts";
+import type { ReportDeliveryActivities } from "#activities/report-delivery.ts";
+import {
+  buildMainVulnScanFailureReport,
+  buildMainVulnScanReport,
+  countCriticalVulnerabilities,
+} from "#activities/main-vuln-scan-report.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+const RETRY = {
+  maximumAttempts: 3,
+  initialInterval: "1 minute" as const,
+  backoffCoefficient: 2,
+  maximumInterval: "10 minutes" as const,
+};
+
+// The scan runs on the workflow's own (maintenance) queue: that worker mounts
+// the warm Trivy DB PVC. Clone + scan of the repo fits well inside 20 minutes;
+// heartbeats fire every 15s, so worker death surfaces quickly.
+const { scanMainForVulnerabilities } = proxyActivities<MainVulnScanActivities>({
+  startToCloseTimeout: "20 minutes",
+  heartbeatTimeout: "90 seconds",
+  retry: RETRY,
+});
+
+// Delivery and alert publication run on the core worker: Postal, report-state
+// S3, and ALERTMANAGER_URL deliberately never reach the maintenance pod.
+const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.DEFAULT,
+  startToCloseTimeout: "2 minutes",
+  retry: RETRY,
+});
+const { publishMainVulnScanAlerts } =
+  proxyActivities<MainVulnScanAlertActivities>({
+    taskQueue: TASK_QUEUES.DEFAULT,
+    startToCloseTimeout: "1 minute",
+    retry: RETRY,
+  });
+
+/**
+ * Weekly Trivy HIGH/CRITICAL scan of current `main`.
+ *
+ * Policy: the report email is delivered on every run; Alertmanager receives
+ * exactly one fire/resolve occurrence per run — firing only while at least one
+ * CRITICAL finding exists, resolving as soon as a run comes back clean.
+ */
+export async function runMainVulnScanWorkflow(): Promise<void> {
+  const startedAt = new Date().toISOString();
+  try {
+    const result = await scanMainForVulnerabilities();
+    await deliverActivityReport(buildMainVulnScanReport(startedAt, result));
+    await publishMainVulnScanAlerts({
+      criticalCount: countCriticalVulnerabilities(result),
+      repoSha: result.repoSha,
+    });
+  } catch (error) {
+    await deliverActivityReport(
+      buildMainVulnScanFailureReport(startedAt, error),
+    );
+    throw error;
+  }
+}

--- a/packages/temporal/src/workflows/main-vuln-scan.ts
+++ b/packages/temporal/src/workflows/main-vuln-scan.ts
@@ -1,5 +1,8 @@
 import { proxyActivities } from "@temporalio/workflow";
-import type { MainVulnScanActivities } from "#activities/main-vuln-scan.ts";
+import type {
+  MainVulnScanActivities,
+  MainVulnScanResult,
+} from "#activities/main-vuln-scan.ts";
 import type { MainVulnScanAlertActivities } from "#activities/main-vuln-scan-alerts.ts";
 import type { ReportDeliveryActivities } from "#activities/report-delivery.ts";
 import {
@@ -48,17 +51,24 @@ const { publishMainVulnScanAlerts } =
  */
 export async function runMainVulnScanWorkflow(): Promise<void> {
   const startedAt = new Date().toISOString();
+  // Only a clone/scan failure produces the failure report. Wrapping the
+  // delivery and alert calls too would let an Alertmanager outage — after the
+  // scan completed and its results were already emailed — send a second
+  // report claiming the scan failed, publishing contradictory receipts for one
+  // run. A publication failure instead fails the workflow, which
+  // `temporal-failure-watch` turns into its own occurrence.
+  let result: MainVulnScanResult;
   try {
-    const result = await scanMainForVulnerabilities();
-    await deliverActivityReport(buildMainVulnScanReport(startedAt, result));
-    await publishMainVulnScanAlerts({
-      criticalCount: countCriticalVulnerabilities(result),
-      repoSha: result.repoSha,
-    });
+    result = await scanMainForVulnerabilities();
   } catch (error) {
     await deliverActivityReport(
       buildMainVulnScanFailureReport(startedAt, error),
     );
     throw error;
   }
+  await deliverActivityReport(buildMainVulnScanReport(startedAt, result));
+  await publishMainVulnScanAlerts({
+    criticalCount: countCriticalVulnerabilities(result),
+    repoSha: result.repoSha,
+  });
 }


### PR DESCRIPTION
## Why

Vulnerability exposure on `main` is only visible today when someone runs trivy by hand. This adds a scheduled scan that turns HIGH/CRITICAL findings into a weekly report email plus a page for criticals, reusing the warm Buildkite Trivy DB the maintenance worker already refreshes every six hours.

## What

- **Shared capturing subprocess runner** — `spawnMaintenanceCommand` is refactored into a shared core; the new `spawnMaintenanceCommandCapturingStdout` returns full redacted stdout for `--format json` scanners (with an `acceptedExitCodes` escape hatch) without forking the heartbeat / process-group-cancellation / secret-redaction logic. Existing runner behavior is unchanged and covered by new subprocess tests.
- **`scanMainForVulnerabilities` activity (maintenance queue)** — shallow-clones public `main`, runs `trivy fs --format json --skip-db-update --cache-dir /buildkite/trivy-db --scanners vuln --severity HIGH,CRITICAL --skip-dirs node_modules --skip-dirs sandbox .` (the clone's own `.trivyignore` applies), Zod-parses a minimal Trivy schema with a closed HIGH/CRITICAL severity enum, per-attempt `/tmp` scratch cleaned in `finally`.
- **Report** — pure builder maps each vulnerability to a finding (HIGH→`warning`, CRITICAL→`critical`, grouped in Critical/High sections), one evidence receipt with command + exitCode + bounded excerpt, verdict `clear`/`attention`, required check "Trivy filesystem scan of main completed". Always delivered via `deliverActivityReport`; a scan failure delivers a failed-execution report instead.
- **Alertmanager** — fire/resolve occurrence `MainVulnScanCritical` (8-day TTL, identical label set both ways) published on every run from the DEFAULT queue: fires only while ≥1 CRITICAL finding exists, resolves on the next clean run.
- **Current-main integration** — preserves the agent-report activities introduced on main and assigns Scout workers explicitly to the beta and production queues that replaced the removed generic queue.
- **Wiring** — `main-vuln-scan-weekly` schedule (Sun 05:00 PT, maintenance queue, SKIP overlap, 2h execution timeout, staggered off the trivy-db-refresh slots), `REPORT_SCHEDULE_REGISTRY` entry (168h cadence / 6h grace), workflow re-export via the alias-then-wrap pattern, schedule-consistency tests updated, package AGENTS.md documents the queue/credential boundary.

### Queue/egress decision

The scan runs on the **maintenance queue**: no NetworkPolicy restricts the maintenance worker's egress (its existing `buildkite-trivy-db-refresh` job already downloads the Trivy DB from the internet, proving github.com is reachable), and running there keeps the warm `/buildkite/trivy-db` PVC plus the single activity slot that serializes the scan against the DB-refresh writer. Only the scan activity lives there — report delivery and the Alertmanager publish are proxied to `TASK_QUEUES.DEFAULT`, so Postal/S3/`ALERTMANAGER_URL` credentials never reach the maintenance pod. No cdk8s change required.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal` — all green (95 + 13 test files, includes the workflow-bundle smoke test).
- New unit tests: Trivy JSON fixture → typed findings (incl. severity-drift and non-JSON rejection), report mapping (clear/attention, severity mapping, receipt linkage), alert fire/resolve label identity, and real-subprocess tests for the capturing runner (full stdout, redaction, accepted exit codes).
- Not run live (operator step post-deploy): trigger `main-vuln-scan-weekly` once and confirm the report email arrives.

Non-visual change (backend workflow + scheduling); no media.