### PR TITLE
fix(scout-for-lol): fit design audit within cluster deadline

### DIFF
--- a/.buildkite/reporting-pipeline.yml
+++ b/.buildkite/reporting-pipeline.yml
@@ -75,9 +75,11 @@ steps:
   # Sixteen sequential Playwright processes cover those 616 cases exactly once
   # and restart the browser every 38-39 cases. The runner owns one server set
   # across every shard so migrations, seeding, and Vite startup are not raced
-  # through sixteen stop/start cycles. The complete stack measured a 11.82Gi
-  # working-set peak in the old 12Gi container, so its request reflects real
-  # use and the 16Gi limit leaves headroom for between-scrape browser peaks.
+  # through sixteen stop/start cycles. The final exact-SHA run measured a
+  # 13.38Gi container working-set peak, so the 12Gi request reflects real use
+  # and the 16Gi limit leaves headroom for between-scrape browser peaks. Render
+  # frames replace fixed per-case sleeps so the run also stays within Kueue's
+  # 30-minute pod-readiness budget.
   #
   # soft_fail is TEMPORARY. The suite had never once passed before the fixes
   # that accompanied this step, so it soaks non-blocking until it has been

--- a/packages/scout-for-lol/packages/design-audit/README.md
+++ b/packages/scout-for-lol/packages/design-audit/README.md
@@ -51,9 +51,10 @@ omitted.
 `SCOUT_DESIGN_AUDIT_MODE=nightly` selects the scheduled validation boundary but
 does not expand the browser matrix. When local servers are enabled, as they are
 in CI, nightly runs the 616 cases exactly once across 16 sequential shards so
-each Playwright process stays inside the 12 GiB pod limit. It uses the same
-deterministic fixture and needs no external origins or Discord credentials. An
-explicitly external or Beta audit must
+each Playwright process stays inside the 16 GiB pod limit and the complete run
+fits the cluster's 30-minute pod-readiness budget. It uses the same deterministic
+fixture and needs no external origins or Discord credentials. An explicitly
+external or Beta audit must
 provide either one base URL or all three surface URLs, plus dedicated read-only
 Discord credentials. Visual snapshots are updated only
 through an explicit local Playwright update command after review; CI never

--- a/packages/scout-for-lol/packages/design-audit/playwright.config.ts
+++ b/packages/scout-for-lol/packages/design-audit/playwright.config.ts
@@ -87,9 +87,8 @@ export default defineConfig({
   forbidOnly: env["CI"] === "true",
   fullyParallel: true,
   // Parallel browser contexts plus the backend, SPA, and two Astro servers
-  // exceeded the nightly pod's 12 GiB limit even at two workers. One worker
-  // keeps the complete 616-case matrix inside that reviewed resource boundary
-  // while remaining within the step's 90-minute timeout.
+  // exceeded the nightly pod's memory boundary even at two workers. One worker
+  // keeps the complete 616-case matrix inside the reviewed 16 GiB limit.
   ...(env["CI"] === "true" ? { workers: 1 } : {}),
   reporter:
     env["CI"] === "true"

--- a/packages/scout-for-lol/packages/design-audit/src/page-checks.ts
+++ b/packages/scout-for-lol/packages/design-audit/src/page-checks.ts
@@ -6,7 +6,6 @@ export function evaluateBrowser<T>(page: Page, callback: () => T): Promise<T> {
 
 export async function waitForStablePage(page: Page): Promise<void> {
   await page.waitForLoadState("load");
-  await page.waitForTimeout(250);
   await expect(
     page.locator("a, button, h1, h2").first(),
     "page must render visible content",
@@ -46,6 +45,8 @@ export async function waitForStablePage(page: Page): Promise<void> {
         }
       }),
     );
+    // Let hydration and decoded-image layout commit without a fixed delay.
+    await new Promise<number>(requestAnimationFrame);
   });
   const brokenImages = await page
     .locator("img")
@@ -297,7 +298,8 @@ export async function preparePageForScreenshot(page: Page): Promise<void> {
   if (viewport !== null) {
     await page.mouse.move(viewport.width - 1, viewport.height - 1);
   }
-  await page.waitForTimeout(50);
+  // Scroll and pointer state settle on the next rendered frame.
+  await page.evaluate(() => new Promise<number>(requestAnimationFrame));
 }
 
 export async function assertRenderedContrast(page: Page): Promise<void> {


### PR DESCRIPTION
## Why

PR #2387 merged while its exact-SHA reporting acceptance run was still in progress. The 616-case suite reached shard 16 with 578 cases green, then Kueue evicted the Buildkite pod at the cluster's 30-minute pod-readiness deadline. The tests had not failed, but the step correctly remained red.

## What

- Replace the audit's fixed 250 ms per-case stability delay with a browser render-frame boundary after fonts and images settle.
- Replace the fixed 50 ms golden-screenshot delay with a render-frame boundary after focus, scroll, and pointer normalization.
- Correct the README, Playwright configuration, and Buildkite comments to describe the measured 13.38 GiB peak, 16 GiB limit, and 30-minute cluster boundary.

This removes about 167 seconds of guaranteed idle time from the 616-case run without weakening any route, browser, theme, viewport, accessibility, interaction, or screenshot assertion.

## Verification

- `bunx turbo run typecheck lint test --filter=@scout-for-lol/design-audit --force`
- `bun test ./.buildkite/scripts/validate-reporting-pipeline.test.ts`
- `bun .buildkite/scripts/validate-reporting-pipeline.ts`
- `mise exec bun@1.4 -- bunx lefthook run pre-commit`
- Exact-SHA [Buildkite reporting #36](https://buildkite.com/sjerred/monorepo-test-reporting/builds/36): all 616/616 Scout cases passed across 16 shards; all reporting jobs passed.

## Rollout

This is the acceptance follow-up to #2387, which merged externally during its final verification. The nightly design step remains advisory at 03:00 PT until several consecutive `main` runs pass.
