### PR TITLE
feat(scout-for-lol): send Bryan Bucks settlement DMs

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -18,6 +18,7 @@ import {
 } from "#src/betting/outcome-message.ts";
 import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
+import { deliverSettlementDms } from "#src/betting/settlement-dm-delivery.ts";
 import { bettingSettlementUndeliverableTotal } from "#src/metrics/betting.ts";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
@@ -441,9 +442,31 @@ export async function announceSettlements(
           : BucksPredictionSchema.safeParse(JSON.parse(pool.predictionJson))
               .data;
 
-      const anchor = bettingAnchor(
-        BucksPoolRosterSchema.parse(JSON.parse(pool.roster)).participants,
-      );
+      const roster = BucksPoolRosterSchema.parse(
+        JSON.parse(pool.roster),
+      ).participants;
+      const anchor = bettingAnchor(roster);
+      try {
+        await deliverSettlementDms({
+          summary,
+          includeOutcome,
+          parlay,
+          unmatchedPositions,
+          roster,
+          prismaClient,
+        });
+      } catch (error) {
+        // Settlement is already committed. DMs are audited best-effort output,
+        // so an outage in flags, roster resolution, or dispatch must never
+        // block the public report or the next guild's settlement.
+        logger.error(
+          `❌ Could not prepare Bryan Bucks DMs for ${summary.matchId}:`,
+          error,
+        );
+        Sentry.captureException(error, {
+          tags: { source: "betting-settlement-dm", matchId: summary.matchId },
+        });
+      }
       const message = buildSettlementMessage({
         summary,
         includeOutcome,

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -7,6 +7,7 @@ import {
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   RiotTeamIdSchema,
+  type BucksMessageRefs,
   type DiscordChannelId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
@@ -249,6 +250,45 @@ export async function sendSettlementMessage(
   }
 }
 
+async function sendSettlementMessages(input: {
+  refs: BucksMessageRefs;
+  message: MessageCreateOptions;
+  summary: SettlementSummary;
+  includeOutcome: boolean;
+  postmatchMessageIds: ReadonlyMap<string, string>;
+  dependencies: SettlementDeliveryDependencies;
+}): Promise<void> {
+  for (const ref of input.refs) {
+    // Keep channels isolated because this committed settlement is one-shot.
+    try {
+      const postmatchMessageId = input.postmatchMessageIds.get(ref.channelId);
+      await sendSettlementMessage(
+        {
+          message: input.message,
+          matchId: input.summary.matchId,
+          channelId: ref.channelId,
+          guildId: input.summary.serverId,
+          kind: input.includeOutcome ? "outcome" : "parlay",
+          ...(postmatchMessageId === undefined ? {} : { postmatchMessageId }),
+        },
+        input.dependencies,
+      );
+    } catch (error) {
+      logger.error(
+        `❌ Could not deliver the Bryan Bucks settlement for ${input.summary.matchId} to channel ${ref.channelId}:`,
+        error,
+      );
+      Sentry.captureException(error, {
+        tags: {
+          source: "betting-announce",
+          matchId: input.summary.matchId,
+          channelId: ref.channelId,
+        },
+      });
+    }
+  }
+}
+
 type Announcement = {
   summary: SettlementSummary;
   /** False when the embed exists only to carry a parlay result. */
@@ -446,27 +486,6 @@ export async function announceSettlements(
         JSON.parse(pool.roster),
       ).participants;
       const anchor = bettingAnchor(roster);
-      try {
-        await deliverSettlementDms({
-          summary,
-          includeOutcome,
-          parlay,
-          unmatchedPositions,
-          roster,
-          prismaClient,
-        });
-      } catch (error) {
-        // Settlement is already committed. DMs are audited best-effort output,
-        // so an outage in flags, roster resolution, or dispatch must never
-        // block the public report or the next guild's settlement.
-        logger.error(
-          `❌ Could not prepare Bryan Bucks DMs for ${summary.matchId}:`,
-          error,
-        );
-        Sentry.captureException(error, {
-          tags: { source: "betting-settlement-dm", matchId: summary.matchId },
-        });
-      }
       const message = buildSettlementMessage({
         summary,
         includeOutcome,
@@ -510,43 +529,40 @@ export async function announceSettlements(
           unmatchedCount: unmatchedPositions.length,
           earnings: input.earnings,
         });
-        continue;
+      } else {
+        await sendSettlementMessages({
+          refs,
+          message,
+          summary,
+          includeOutcome,
+          postmatchMessageIds: input.postmatchMessageIds,
+          dependencies: deliveryDependencies,
+        });
       }
-      for (const ref of refs) {
-        // Isolated per channel. The pool has already committed as settled and a
-        // later pass returns no summary, so this delivery is one-shot: letting
-        // a stale or no-longer-writable first ref throw would silently discard
-        // the settlement for every healthy channel behind it.
-        try {
-          const postmatchMessageId = input.postmatchMessageIds.get(
-            ref.channelId,
-          );
-          await sendSettlementMessage(
-            {
-              message,
-              matchId: summary.matchId,
-              channelId: ref.channelId,
-              guildId: summary.serverId,
-              kind: includeOutcome ? "outcome" : "parlay",
-              ...(postmatchMessageId === undefined
-                ? {}
-                : { postmatchMessageId }),
-            },
-            deliveryDependencies,
-          );
-        } catch (error) {
-          logger.error(
-            `❌ Could not deliver the Bryan Bucks settlement for ${summary.matchId} to channel ${ref.channelId}:`,
-            error,
-          );
-          Sentry.captureException(error, {
-            tags: {
-              source: "betting-announce",
-              matchId: summary.matchId,
-              channelId: ref.channelId,
-            },
-          });
-        }
+      // Public settlement delivery runs before DMs. DMs are still best-effort
+      // and independent of public-channel references, so a slow or failed DM
+      // cannot withhold the public recap and a missing ref cannot suppress the
+      // private result.
+      try {
+        await deliverSettlementDms({
+          summary,
+          includeOutcome,
+          parlay,
+          unmatchedPositions,
+          roster,
+          prismaClient,
+        });
+      } catch (error) {
+        // Settlement is already committed. DMs are audited best-effort output,
+        // so an outage in flags, roster resolution, or dispatch must never
+        // block the next guild's settlement.
+        logger.error(
+          `❌ Could not prepare Bryan Bucks DMs for ${summary.matchId}:`,
+          error,
+        );
+        Sentry.captureException(error, {
+          tags: { source: "betting-settlement-dm", matchId: summary.matchId },
+        });
       }
     } catch (error) {
       logger.error(

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
@@ -1,0 +1,163 @@
+import * as Sentry from "@sentry/bun";
+import type { Client } from "discord.js";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  type BucksPoolParticipant,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
+import {
+  buildSettlementDmMessages,
+  type TeamRecipient,
+} from "#src/betting/settlement-dm.ts";
+import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
+import type { SettlementSummary } from "#src/betting/settle.ts";
+import type { ClosedPosition } from "#src/betting/sweep.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { client } from "#src/discord/client.ts";
+import { sendDM } from "#src/discord/utils/dm.ts";
+import { createLogger } from "#src/logger.ts";
+import { bettingSettlementDmsTotal } from "#src/metrics/betting.ts";
+
+const logger = createLogger("betting-settlement-dm");
+
+export type SettlementDmDeliveryDependencies = {
+  client: Client;
+  isPolicyEnabled: typeof isPolicyEnabled;
+  sendDm: typeof sendDM;
+};
+
+const defaultSettlementDmDeliveryDependencies: SettlementDmDeliveryDependencies =
+  {
+    client,
+    isPolicyEnabled,
+    sendDm: sendDM,
+  };
+
+async function playerRecipientsForRoster(input: {
+  roster: readonly BucksPoolParticipant[];
+  serverId: DiscordGuildId;
+  prismaClient: ExtendedPrismaClient;
+}): Promise<TeamRecipient[]> {
+  const trackedParticipants = input.roster.flatMap((participant) => {
+    if (participant.puuid === null || participant.trackedAlias === undefined) {
+      return [];
+    }
+    return [{ puuid: participant.puuid, teamId: participant.teamId }];
+  });
+  if (trackedParticipants.length === 0) {
+    return [];
+  }
+  const accounts = await input.prismaClient.account.findMany({
+    where: {
+      serverId: input.serverId,
+      puuid: {
+        in: trackedParticipants.map((participant) => participant.puuid),
+      },
+    },
+    include: { player: { select: { discordId: true } } },
+  });
+  const discordIdByPuuid = new Map<string, string>();
+  for (const account of accounts) {
+    if (account.player.discordId !== null) {
+      discordIdByPuuid.set(account.puuid, account.player.discordId);
+    }
+  }
+  const recipientByTeam = new Map<string, TeamRecipient>();
+  for (const participant of trackedParticipants) {
+    const discordId = discordIdByPuuid.get(participant.puuid);
+    if (discordId !== undefined) {
+      recipientByTeam.set(`${discordId}:${participant.teamId.toString()}`, {
+        discordId,
+        teamId: participant.teamId,
+      });
+    }
+  }
+  return [...recipientByTeam.values()];
+}
+
+/**
+ * DM delivery is deliberately outside public-announcement references: a
+ * missing or unwritable channel cannot withhold a bettor's private result.
+ */
+export async function deliverSettlementDms(
+  input: {
+    summary: SettlementSummary;
+    includeOutcome: boolean;
+    parlay: ParlaySettlementSummary | undefined;
+    unmatchedPositions: readonly ClosedPosition[];
+    roster: readonly BucksPoolParticipant[];
+    prismaClient?: ExtendedPrismaClient;
+  },
+  dependencies: SettlementDmDeliveryDependencies = defaultSettlementDmDeliveryDependencies,
+): Promise<void> {
+  const prismaClient = input.prismaClient ?? prisma;
+  const guildId = DiscordGuildIdSchema.parse(input.summary.serverId);
+  const receiptsEnabled = await dependencies.isPolicyEnabled(
+    "betting_settlement_dm_enabled",
+    { server: guildId },
+  );
+  if (!receiptsEnabled) {
+    return;
+  }
+  const playerBetOutcomesEnabled = await dependencies.isPolicyEnabled(
+    "betting_player_bet_outcome_dm_enabled",
+    { server: guildId },
+  );
+  const playerRecipients = playerBetOutcomesEnabled
+    ? await playerRecipientsForRoster({
+        roster: input.roster,
+        serverId: guildId,
+        prismaClient,
+      })
+    : [];
+  const anchor = bettingAnchor(input.roster);
+  const messages = buildSettlementDmMessages({
+    summary: input.summary,
+    includeOutcome: input.includeOutcome,
+    parlay: input.parlay,
+    unmatchedPositions: input.unmatchedPositions,
+    framing: anchor === undefined ? undefined : subjectFraming(anchor),
+    receiptsEnabled,
+    playerBetOutcomesEnabled,
+    playerRecipients,
+  });
+  for (const message of messages) {
+    try {
+      const status = await dependencies.sendDm({
+        client: dependencies.client,
+        userId: DiscordAccountIdSchema.parse(message.recipientId),
+        message: message.content,
+        kind: message.kind,
+        guildId,
+        prisma: prismaClient,
+        suppressMentions: true,
+      });
+      bettingSettlementDmsTotal.inc({
+        recipient:
+          message.kind === "betting_settlement_receipt" ? "bettor" : "player",
+        result: status,
+      });
+    } catch (error) {
+      // `sendDM` handles expected Discord failures, but an unexpected caller
+      // failure must still leave every remaining recipient eligible to run.
+      bettingSettlementDmsTotal.inc({
+        recipient:
+          message.kind === "betting_settlement_receipt" ? "bettor" : "player",
+        result: "failed",
+      });
+      logger.error(
+        `❌ Could not deliver Bryan Bucks DM for ${input.summary.matchId} to ${message.recipientId}:`,
+        error,
+      );
+      Sentry.captureException(error, {
+        tags: {
+          source: "betting-settlement-dm",
+          matchId: input.summary.matchId,
+        },
+      });
+    }
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
@@ -243,6 +243,18 @@ describe("Bryan Bucks settlement DMs", () => {
     expect(messages[0]?.content).toContain("YES 5 BB → won 5 BB.");
   });
 
+  test("bounds a combined message to Discord's safe content limit", () => {
+    const messages = build({
+      bets: Array.from({ length: 300 }, (_, index) =>
+        bet({ id: index + 1, discordId: blueBettor, teamId: 100, won: true }),
+      ),
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.content.length).toBeLessThanOrEqual(1900);
+    expect(messages[0]?.content.endsWith("...")).toBe(true);
+  });
+
   test("continues after one DM delivery fails", async () => {
     let sends = 0;
     const dependencies: SettlementDmDeliveryDependencies = {

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "vitest";
+import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
+import {
+  buildSettlementDmMessages,
+  type TeamRecipient,
+} from "#src/betting/settlement-dm.ts";
+import {
+  deliverSettlementDms,
+  type SettlementDmDeliveryDependencies,
+} from "#src/betting/settlement-dm-delivery.ts";
+import type { SettlementBet, SettlementSummary } from "#src/betting/settle.ts";
+import type { ClosedPosition } from "#src/betting/sweep.ts";
+import {
+  bucksTestDiscordId,
+  bucksTestRoster,
+  bucksTestPuuid,
+} from "#src/testing/bucks-fixtures.ts";
+import { mockClient } from "#src/testing/discord-mocks.ts";
+import { testGuildId } from "#src/testing/test-ids.ts";
+
+const blueBettor = bucksTestDiscordId(0);
+const redBettor = bucksTestDiscordId(1);
+const bluePlayer = bucksTestDiscordId(2);
+const redPlayer = bucksTestDiscordId(3);
+const framing = { anchorTeamId: 100, mixedTeams: true } as const;
+
+function bet(input: {
+  id: number;
+  discordId: string;
+  teamId: 100 | 200;
+  won?: boolean;
+  refunded?: boolean;
+  unmatchedStake?: number;
+  isHouse?: boolean;
+}): SettlementBet {
+  const unmatchedStake = input.unmatchedStake ?? 0;
+  const matchedStake = 10 - unmatchedStake;
+  return {
+    betId: input.id,
+    bucksAccountId: input.id,
+    discordId: input.discordId,
+    isHouse: input.isHouse ?? false,
+    predictedTeamId: input.teamId,
+    submittedStake: 10,
+    matchedStake,
+    unmatchedStake,
+    grossPayout: input.won === true ? 20 : matchedStake,
+    houseCut: 0,
+    payout: input.won === true ? 20 : matchedStake,
+    winnings: input.won === true ? 10 : 0,
+    won: input.won ?? false,
+    refunded: input.refunded ?? false,
+    subjectPuuid: bucksTestPuuid(input.id),
+  };
+}
+
+function summary(
+  bets: SettlementBet[],
+  serverId: string,
+  voidReason?: SettlementSummary["voidReason"],
+): SettlementSummary {
+  return {
+    matchId: "match-1",
+    serverId,
+    winningTeamId: 100,
+    voidReason,
+    winnersPool: 10,
+    losersPool: 10,
+    houseCut: 0,
+    bets,
+  };
+}
+
+function build(input: {
+  bets: SettlementBet[];
+  playerRecipients?: TeamRecipient[];
+  unmatchedPositions?: ClosedPosition[];
+  parlay?: ParlaySettlementSummary;
+  playerBetOutcomesEnabled?: boolean;
+  voidReason?: SettlementSummary["voidReason"];
+}) {
+  return buildSettlementDmMessages({
+    summary: summary(input.bets, "server-1", input.voidReason),
+    includeOutcome: true,
+    parlay: input.parlay,
+    unmatchedPositions: input.unmatchedPositions ?? [],
+    framing,
+    receiptsEnabled: true,
+    playerBetOutcomesEnabled: input.playerBetOutcomesEnabled ?? false,
+    playerRecipients: input.playerRecipients ?? [],
+  });
+}
+
+describe("Bryan Bucks settlement DMs", () => {
+  test("sends a bettor who did not play one personal receipt", () => {
+    const messages = build({
+      bets: [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
+    });
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        recipientId: blueBettor,
+        kind: "betting_settlement_receipt",
+      }),
+    ]);
+    expect(messages[0]?.content).toContain("**Your bets**");
+    expect(messages[0]?.content).toContain("Blue 10 BB → won 10 BB.");
+    expect(messages[0]?.content).not.toContain("Bets on your team");
+  });
+
+  test("sends a player team-relative results for other human bettors", () => {
+    const messages = build({
+      bets: [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
+      playerBetOutcomesEnabled: true,
+      playerRecipients: [{ discordId: redPlayer, teamId: 200 }],
+    });
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        recipientId: blueBettor,
+        kind: "betting_settlement_receipt",
+      }),
+      expect.objectContaining({
+        recipientId: redPlayer,
+        kind: "betting_player_bet_outcome",
+      }),
+    ]);
+    expect(messages[1]?.content).toContain(
+      `<@${blueBettor}> bet against your team and won 10 BB.`,
+    );
+  });
+
+  test("does not create a team notice for an unlinked tracked player", () => {
+    const messages = build({
+      bets: [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
+      playerBetOutcomesEnabled: true,
+      // Account → Player has no Discord link, so no recipient is supplied.
+      playerRecipients: [],
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.recipientId).toBe(blueBettor);
+  });
+
+  test("combines a playing bettor's receipt and other bettors' lines once", () => {
+    const messages = build({
+      bets: [
+        bet({ id: 1, discordId: bluePlayer, teamId: 100, won: true }),
+        bet({ id: 2, discordId: redBettor, teamId: 200 }),
+      ],
+      playerBetOutcomesEnabled: true,
+      playerRecipients: [{ discordId: bluePlayer, teamId: 100 }],
+    });
+
+    expect(messages).toHaveLength(2);
+    const playerMessage = messages.find(
+      (message) => message.recipientId === bluePlayer,
+    );
+    expect(playerMessage?.kind).toBe("betting_settlement_receipt");
+    expect(playerMessage?.content).toContain("**Your bets**");
+    expect(playerMessage?.content).toContain("**Bets on your team**");
+    expect(playerMessage?.content).toContain(
+      `<@${redBettor}> bet against your team and lost 10 BB.`,
+    );
+    expect(playerMessage?.content).not.toContain(
+      `<@${bluePlayer}> bet for your team`,
+    );
+  });
+
+  test("renders partial, unmatched, and voided outcome receipts", () => {
+    const unmatched: ClosedPosition = {
+      betId: 4,
+      discordId: redBettor,
+      teamId: 200,
+      submittedStake: 6,
+      matchedStake: 0,
+      unmatchedStake: 6,
+    };
+    const messages = build({
+      bets: [
+        bet({
+          id: 1,
+          discordId: blueBettor,
+          teamId: 100,
+          won: true,
+          unmatchedStake: 4,
+        }),
+        bet({ id: 2, discordId: redBettor, teamId: 200, refunded: true }),
+      ],
+      unmatchedPositions: [unmatched],
+      voidReason: "remake",
+    });
+
+    expect(
+      messages.find((message) => message.recipientId === blueBettor)?.content,
+    ).toContain("4 BB was unmatched and returned.");
+    const redMessage = messages.find(
+      (message) => message.recipientId === redBettor,
+    );
+    expect(redMessage?.content).toContain(
+      "10 BB → 10 BB matched and refunded.",
+    );
+    expect(redMessage?.content).toContain("6 BB was unmatched and refunded.");
+  });
+
+  test("excludes house bets and parlays from player-facing notices", () => {
+    const parlay: ParlaySettlementSummary = {
+      matchId: "match-1",
+      serverId: "server-1",
+      yesResult: true,
+      voidReason: undefined,
+      legs: [],
+      messageRefs: [],
+      bets: [
+        {
+          discordId: redBettor,
+          side: "YES",
+          stake: 5,
+          grossPayout: 10,
+          payout: 10,
+          outcome: "won",
+        },
+      ],
+    };
+    const messages = build({
+      bets: [
+        bet({
+          id: 3,
+          discordId: blueBettor,
+          teamId: 100,
+          won: true,
+          isHouse: true,
+        }),
+      ],
+      parlay,
+      playerBetOutcomesEnabled: true,
+      playerRecipients: [{ discordId: bluePlayer, teamId: 100 }],
+    });
+
+    expect(messages).toEqual([
+      expect.objectContaining({ recipientId: redBettor }),
+    ]);
+    expect(messages[0]?.content).toContain("YES 5 BB → won 5 BB.");
+  });
+
+  test("continues after one DM delivery fails", async () => {
+    let sends = 0;
+    const dependencies: SettlementDmDeliveryDependencies = {
+      client: mockClient(),
+      isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      sendDm: async () => {
+        sends++;
+        if (sends === 1) {
+          throw new Error("first DM failed");
+        }
+        return "sent";
+      },
+    };
+
+    await deliverSettlementDms(
+      {
+        summary: summary(
+          [
+            bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+            bet({ id: 2, discordId: redBettor, teamId: 200 }),
+          ],
+          testGuildId("4"),
+        ),
+        includeOutcome: true,
+        parlay: undefined,
+        unmatchedPositions: [],
+        roster: bucksTestRoster(),
+      },
+      dependencies,
+    );
+
+    expect(sends).toBe(2);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
@@ -1,0 +1,196 @@
+import { RiotTeamIdSchema, type RiotTeamId } from "@scout-for-lol/data";
+import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
+import type { SettlementSummary } from "#src/betting/settle.ts";
+import type { ClosedPosition } from "#src/betting/sweep.ts";
+import { outcomeLabel, type OutcomeFraming } from "#src/betting/team.ts";
+
+export type SettlementDmKind =
+  "betting_settlement_receipt" | "betting_player_bet_outcome";
+
+export type SettlementDmMessage = {
+  recipientId: string;
+  kind: SettlementDmKind;
+  content: string;
+};
+
+export type TeamRecipient = {
+  discordId: string;
+  teamId: RiotTeamId;
+};
+
+type OutcomePosition = {
+  bettorId: string;
+  teamId: RiotTeamId;
+  submittedStake: number;
+  matchedStake: number;
+  unmatchedStake: number;
+  outcome: "won" | "lost" | "refunded" | "unmatched";
+  winnings: number;
+};
+
+type RecipientDraft = {
+  ownLines: string[];
+  teamLines: string[];
+};
+
+function outcomePositions(input: {
+  summary: SettlementSummary;
+  includeOutcome: boolean;
+  unmatchedPositions: readonly ClosedPosition[];
+}): OutcomePosition[] {
+  if (!input.includeOutcome) {
+    return [];
+  }
+  const settled = input.summary.bets
+    .filter((bet) => !bet.isHouse)
+    .map((bet): OutcomePosition => ({
+      bettorId: bet.discordId,
+      teamId: RiotTeamIdSchema.parse(bet.predictedTeamId),
+      submittedStake: bet.submittedStake,
+      matchedStake: bet.matchedStake,
+      unmatchedStake: bet.unmatchedStake,
+      outcome: bet.refunded ? "refunded" : bet.won ? "won" : "lost",
+      winnings: bet.winnings,
+    }));
+  const settledIds = new Set(
+    input.summary.bets.filter((bet) => !bet.isHouse).map((bet) => bet.betId),
+  );
+  const unmatched = input.unmatchedPositions
+    .filter((position) => !settledIds.has(position.betId))
+    .map((position): OutcomePosition => ({
+      bettorId: position.discordId,
+      teamId: position.teamId,
+      submittedStake: position.submittedStake,
+      matchedStake: position.matchedStake,
+      unmatchedStake: position.unmatchedStake,
+      outcome: "unmatched",
+      winnings: 0,
+    }));
+  return [...settled, ...unmatched];
+}
+
+function returnedSuffix(position: OutcomePosition): string {
+  return position.unmatchedStake > 0
+    ? ` ${position.unmatchedStake.toString()} BB was unmatched and returned.`
+    : "";
+}
+
+function ownOutcomeLine(
+  position: OutcomePosition,
+  framing: OutcomeFraming | undefined,
+): string {
+  const side = outcomeLabel(position.teamId, framing);
+  if (position.outcome === "unmatched") {
+    return `• ${side} ${position.submittedStake.toString()} BB was unmatched and refunded.`;
+  }
+  if (position.outcome === "refunded") {
+    return `• ${side} ${position.submittedStake.toString()} BB → ${position.matchedStake.toString()} BB matched and refunded.${returnedSuffix(position)}`;
+  }
+  if (position.outcome === "won") {
+    return `• ${side} ${position.submittedStake.toString()} BB → won ${position.winnings.toString()} BB.${returnedSuffix(position)}`;
+  }
+  return `• ${side} ${position.submittedStake.toString()} BB → lost ${position.matchedStake.toString()} BB.${returnedSuffix(position)}`;
+}
+
+function teamOutcomeLine(
+  position: OutcomePosition,
+  recipientTeamId: RiotTeamId,
+): string {
+  const direction = position.teamId === recipientTeamId ? "for" : "against";
+  const bettor = `<@${position.bettorId}>`;
+  if (position.outcome === "unmatched") {
+    return `• ${bettor} bet ${direction} your team, but ${position.submittedStake.toString()} BB was unmatched and refunded.`;
+  }
+  if (position.outcome === "refunded") {
+    return `• ${bettor} bet ${direction} your team and received a ${position.matchedStake.toString()} BB refund.${returnedSuffix(position)}`;
+  }
+  if (position.outcome === "won") {
+    return `• ${bettor} bet ${direction} your team and won ${position.winnings.toString()} BB.${returnedSuffix(position)}`;
+  }
+  return `• ${bettor} bet ${direction} your team and lost ${position.matchedStake.toString()} BB.${returnedSuffix(position)}`;
+}
+
+function ownParlayLine(bet: ParlaySettlementSummary["bets"][number]): string {
+  if (bet.outcome === "won") {
+    return `• ${bet.side} ${bet.stake.toString()} BB → won ${(bet.payout - bet.stake).toString()} BB.`;
+  }
+  if (bet.outcome === "refunded") {
+    return `• ${bet.side} ${bet.stake.toString()} BB was refunded.`;
+  }
+  return `• ${bet.side} ${bet.stake.toString()} BB → lost ${bet.stake.toString()} BB.`;
+}
+
+function draftFor(
+  drafts: Map<string, RecipientDraft>,
+  recipientId: string,
+): RecipientDraft {
+  const existing = drafts.get(recipientId);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created: RecipientDraft = { ownLines: [], teamLines: [] };
+  drafts.set(recipientId, created);
+  return created;
+}
+
+/** Build one bounded, private result message per recipient and settled match. */
+export function buildSettlementDmMessages(input: {
+  summary: SettlementSummary;
+  includeOutcome: boolean;
+  parlay: ParlaySettlementSummary | undefined;
+  unmatchedPositions: readonly ClosedPosition[];
+  framing: OutcomeFraming | undefined;
+  receiptsEnabled: boolean;
+  playerBetOutcomesEnabled: boolean;
+  playerRecipients: readonly TeamRecipient[];
+}): SettlementDmMessage[] {
+  const drafts = new Map<string, RecipientDraft>();
+  const outcomes = outcomePositions(input);
+
+  if (input.receiptsEnabled) {
+    for (const position of outcomes) {
+      draftFor(drafts, position.bettorId).ownLines.push(
+        ownOutcomeLine(position, input.framing),
+      );
+    }
+    for (const bet of input.parlay?.bets ?? []) {
+      draftFor(drafts, bet.discordId).ownLines.push(ownParlayLine(bet));
+    }
+  }
+
+  if (input.playerBetOutcomesEnabled) {
+    for (const position of outcomes) {
+      for (const recipient of input.playerRecipients) {
+        if (recipient.discordId === position.bettorId) {
+          continue;
+        }
+        draftFor(drafts, recipient.discordId).teamLines.push(
+          teamOutcomeLine(position, recipient.teamId),
+        );
+      }
+    }
+  }
+
+  return [...drafts.entries()].flatMap(([recipientId, draft]) => {
+    if (draft.ownLines.length === 0 && draft.teamLines.length === 0) {
+      return [];
+    }
+    const sections: string[] = ["💰 **Bryan Bucks — game settled**"];
+    if (draft.ownLines.length > 0) {
+      sections.push(["**Your bets**", ...draft.ownLines].join("\n"));
+    }
+    if (draft.teamLines.length > 0) {
+      sections.push(["**Bets on your team**", ...draft.teamLines].join("\n"));
+    }
+    return [
+      {
+        recipientId,
+        kind:
+          draft.ownLines.length > 0
+            ? "betting_settlement_receipt"
+            : "betting_player_bet_outcome",
+        content: sections.join("\n\n"),
+      },
+    ];
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
@@ -3,6 +3,10 @@ import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
 import type { ClosedPosition } from "#src/betting/sweep.ts";
 import { outcomeLabel, type OutcomeFraming } from "#src/betting/team.ts";
+import { truncateDiscordMessage } from "#src/discord/utils/message.ts";
+
+const MAX_SETTLEMENT_DM_LENGTH = 1900;
+const TRUNCATION_SUFFIX = "...";
 
 export type SettlementDmKind =
   "betting_settlement_receipt" | "betting_player_bet_outcome";
@@ -189,7 +193,10 @@ export function buildSettlementDmMessages(input: {
           draft.ownLines.length > 0
             ? "betting_settlement_receipt"
             : "betting_player_bet_outcome",
-        content: sections.join("\n\n"),
+        content: truncateDiscordMessage(
+          sections.join("\n\n"),
+          MAX_SETTLEMENT_DM_LENGTH - TRUNCATION_SUFFIX.length,
+        ),
       },
     ];
   });

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
@@ -26,6 +26,27 @@ afterEach(() => {
   // file from switching `debug` off for every test that runs after it.
   resetFlagOverrides("debug");
   resetFlagOverrides("betting_enabled");
+  resetFlagOverrides("betting_settlement_dm_enabled");
+  resetFlagOverrides("betting_player_bet_outcome_dm_enabled");
+});
+
+describe("Bryan Bucks settlement DM flags", () => {
+  test("are off by default and enabled only for the beta guild", () => {
+    expect(
+      getFlag("betting_settlement_dm_enabled", { server: OTHER_GUILD }),
+    ).toBe(false);
+    expect(
+      getFlag("betting_player_bet_outcome_dm_enabled", {
+        server: OTHER_GUILD,
+      }),
+    ).toBe(false);
+    expect(
+      getFlag("betting_settlement_dm_enabled", { server: MY_SERVER }),
+    ).toBe(true);
+    expect(
+      getFlag("betting_player_bet_outcome_dm_enabled", { server: MY_SERVER }),
+    ).toBe(true);
+  });
 });
 
 describe("listGuildsWithFlagEnabled", () => {

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -142,6 +142,8 @@ export type FlagName =
   | "ai_reports_unlimited"
   | "ai_reviews_enabled"
   | "betting_enabled"
+  | "betting_player_bet_outcome_dm_enabled"
+  | "betting_settlement_dm_enabled"
   | "debug"
   | "tournament_lobbies_enabled";
 
@@ -209,6 +211,18 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
         attributes: { server: MY_SERVER },
       },
     ],
+  },
+  // Settlement messages are a separate rollout from the betting economy: the
+  // economy must keep paying or refunding open positions even while Discord
+  // delivery is disabled. The player-facing notice depends on the bettor
+  // receipt flag so a bettor who is also playing still has exactly one result.
+  betting_settlement_dm_enabled: {
+    default: false,
+    overrides: [{ value: true, attributes: { server: MY_SERVER } }],
+  },
+  betting_player_bet_outcome_dm_enabled: {
+    default: false,
+    overrides: [{ value: true, attributes: { server: MY_SERVER } }],
   },
   debug: {
     default: false,

--- a/packages/scout-for-lol/packages/backend/src/discord/utils/dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/utils/dm.test.ts
@@ -61,6 +61,27 @@ describe("sendDM", () => {
     expect(row?.errorMessage).toBeNull();
   });
 
+  test("can render informational mentions without notifying recipients", async () => {
+    const send = vi.fn(() => Promise.resolve({}));
+    const client = clientWithSend(send);
+
+    const status = await sendDM({
+      client,
+      userId: recipientId,
+      message: "<@123456789012345678> placed a bet",
+      kind: "betting_player_bet_outcome",
+      guildId,
+      prisma,
+      suppressMentions: true,
+    });
+
+    expect(status).toBe("sent");
+    expect(send).toHaveBeenCalledWith({
+      content: "<@123456789012345678> placed a bet",
+      allowedMentions: { parse: [] },
+    });
+  });
+
   test("records a 'dm_disabled' audit row when the user blocks DMs (50007)", async () => {
     const dmDisabled = new DiscordAPIError(
       { code: 50_007, message: "Cannot send messages to this user" },

--- a/packages/scout-for-lol/packages/backend/src/discord/utils/dm.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/utils/dm.ts
@@ -47,6 +47,8 @@ export const DmKindSchema = z.enum([
   "outreach_30d",
   "outreach_manual",
   "data_validation",
+  "betting_settlement_receipt",
+  "betting_player_bet_outcome",
 ]);
 export type DmKind = z.infer<typeof DmKindSchema>;
 
@@ -95,6 +97,8 @@ const CORE_DM_KINDS: ReadonlySet<string> = new Set([
   "competition_invite",
   "prune_notice",
   "data_validation",
+  "betting_settlement_receipt",
+  "betting_player_bet_outcome",
 ]);
 
 export type SendDmOptions = {
@@ -114,6 +118,8 @@ export type SendDmOptions = {
    * appended automatically, and a successful delivery advances the counter.
    */
   budget?: DmBudget;
+  /** Keep rendered mentions informational instead of notifying other users. */
+  suppressMentions?: boolean;
 };
 
 /**
@@ -403,7 +409,11 @@ async function sendDmUnsynchronized(options: SendDmOptions): Promise<DmStatus> {
   try {
     const user = await client.users.fetch(userId);
     recipientTag = recipientTag ?? user.tag;
-    await user.send(message);
+    await user.send(
+      options.suppressMentions
+        ? { content: message, allowedMentions: { parse: [] } }
+        : message,
+    );
     logger.info(`[DM] Successfully sent ${kind} DM to user ${userId}`);
     if (reservedRowId === null) {
       await recordDmAudit(db, {

--- a/packages/scout-for-lol/packages/backend/src/metrics/betting.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/betting.ts
@@ -148,6 +148,13 @@ export const bettingMessageOperationDurationSeconds = new Histogram({
   registers: [registry],
 });
 
+export const bettingSettlementDmsTotal = new Counter({
+  name: "betting_settlement_dms_total",
+  help: "Bryan Bucks post-settlement DM delivery attempts by recipient role and result.",
+  labelNames: ["recipient", "result"] as const,
+  registers: [registry],
+});
+
 export const bettingMessageRefsRecordedTotal = new Counter({
   name: "betting_message_refs_recorded_total",
   help: "Whether a pool's prematch message references became durable.",

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/bryan-bucks-place-and-cancel-a-bet.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/bryan-bucks-place-and-cancel-a-bet.md
@@ -72,6 +72,19 @@ game message.
 That is deliberate — telling someone with a live stake that they have no bet
 would be both wrong and alarming.
 
+## Read a settled game's private summary
+
+When the game settles, Scout sends one private summary for that game when DMs
+are enabled in your server. If you placed an outcome or parlay bet, it includes
+your receipt. If Scout tracked you in that game, it also lists other people's
+outcome bets as **for your team** or **against your team**.
+
+If you both played and bet, those details are combined into one DM. Scout does
+not send a second team-relative line for your own bet, and parlays are only
+shown in the bettor's own receipt. The public settlement recap remains
+available; if DMs are disabled or unavailable, use `/bb history` to see the
+durable ledger entry and running balance.
+
 ## Troubleshooting
 
 | Scout says                                        | What to do                                                                                 |

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/bryan-bucks-read-your-history.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/bryan-bucks-read-your-history.md
@@ -44,8 +44,8 @@ Use **Previous** and **Next** to page. The controls are bound to you; nobody
 else can drive your history. The page is also pinned to a snapshot, so a
 settlement landing mid-read cannot reshuffle rows underneath you.
 
-`/bb history` is the audit trail. When a public settlement recap and your
-memory disagree, this is the record.
+`/bb history` is the audit trail. When a private settlement DM or public recap
+is unavailable, or when your memory disagrees, this is the record.
 
 ## What is open right now
 

--- a/packages/temporal/src/activities/glitter-corpus-discord-client.ts
+++ b/packages/temporal/src/activities/glitter-corpus-discord-client.ts
@@ -186,6 +186,7 @@ export class DiscordRestClient {
     holder: string,
   ): Promise<CompletedDiscordRequest> {
     let releaseNotBeforeMs: number | undefined;
+    let releaseCompletedAtMs: number | undefined;
     let outcome: { request: CompletedDiscordRequest } | { error: unknown };
     try {
       const requestedAt = new Date().toISOString();
@@ -209,6 +210,7 @@ export class DiscordRestClient {
       }
       const completedAt = new Date().toISOString();
       const completedAtMs = Date.parse(completedAt);
+      releaseCompletedAtMs = completedAtMs;
       const metadata = rateLimitMetadata(response.headers);
       if (metadata.remaining === 0 && metadata.resetAfterSeconds !== null) {
         releaseNotBeforeMs =
@@ -238,7 +240,7 @@ export class DiscordRestClient {
     }
     const released = await this.#rateLimitCoordinator.release({
       holder,
-      completedAtMs: Date.now(),
+      completedAtMs: releaseCompletedAtMs ?? Date.now(),
       ...(releaseNotBeforeMs === undefined
         ? {}
         : { notBeforeMs: releaseNotBeforeMs }),


### PR DESCRIPTION
Why:
Bettors need a private receipt, and tracked players need one team-relative summary of other human bets without depending on public settlement-message references.

What:
- Add beta-gated settlement receipt and player-outcome DM delivery.
- Resolve current guild account-to-player Discord links from the frozen roster; merge personal receipts, parlay results, and other bettors' for/against-team lines into one no-ping DM.
- Record delivery outcomes, exclude house/parlay player notices, and preserve public messages plus /bb history as fallbacks.
- Document the combined-message behavior.

## What users see

Every eligible Discord account receives **at most one DM per guild and settled match**. It starts with `💰 Bryan Bucks — game settled` and contains one or both sections below. Values shown here are placeholders; `TEAM` is the team selected by the wager.

### Bettor receipt — `Your bets`

Human outcome bets receive one line per position:

| Settled result | DM line |
| --- | --- |
| Win | `• TEAM 10 BB → won 18 BB.` |
| Loss | `• TEAM 10 BB → lost 10 BB.` |
| Partial win or loss | The normal win/loss line, followed by `4 BB was unmatched and returned.` |
| Void/refund | `• TEAM 10 BB → 6 BB matched and refunded. 4 BB was unmatched and returned.` |
| Completely unmatched | `• TEAM 10 BB was unmatched and refunded.` |

A settled parlay is added to the same section: a win says `won <payout minus stake> BB`, a loss says `lost <stake> BB`, and a refund says `<stake> BB was refunded.`

### Player notification — `Bets on your team`

A linked player receives one line for each **other human outcome bet** concerning either of their frozen-roster teams. Direction comes only from the wager's `predictedTeamId`:

| Settled result | DM line |
| --- | --- |
| Win | `• Bettor bet for/against your team and won 18 BB.` |
| Loss | `• Bettor bet for/against your team and lost 10 BB.` |
| Partial win or loss | The normal line, followed by `4 BB was unmatched and returned.` |
| Void/refund | `• Bettor bet for/against your team and received a 6 BB refund. 4 BB was unmatched and returned.` |
| Completely unmatched | `• Bettor bet for/against your team, but 10 BB was unmatched and refunded.` |

`Bettor` is rendered as their Discord identity, but the DM suppresses mention notifications. The line discloses only team direction and the settled Bryan Bucks result.

### Combined and excluded cases

| Situation | What the user receives |
| --- | --- |
| Bettor only | One DM containing only `Your bets`. |
| Linked player only | One DM containing only other bettors' `Bets on your team` lines. |
| Bettor and linked player | One combined DM: their receipt plus every other bettor's applicable team line. Their own outcome bet is never repeated in `Bets on your team`. |
| Same Discord user is linked to more than one frozen-roster team | Still one DM; it combines all applicable team-relative lines. |
| Bet is on the player's own team | `for your team`. A bet on the other team is `against your team`. |
| House bet | No private receipt or player notification. |
| Parlay | The bettor sees its own receipt; players never see parlay-related team lines. |
| Unlinked/failing Account → Player → Discord mapping | No player notification. |
| No relevant bet or no other human outcome bet | No DM. |
| Settlement-delivery flag off | No DMs; public settlement messages and `/bb history` remain the fallback. |
| Settlement delivery on; player-notification flag off | Bettors receive their receipts, but players receive no team-relative lines. |
| Either delivery attempt fails | That recipient may receive no DM, but other DMs, settlement, reports, and public announcements continue; `/bb history` remains the fallback. |

Verification:
- `bun install --frozen-lockfile`
- `bunx turbo run generate --filter=@scout-for-lol/backend`
- `cd packages/scout-for-lol/packages/backend && bun run test -- src/betting/settlement-dm.test.ts src/betting/announce.test.ts src/discord/utils/dm.test.ts src/configuration/flags.test.ts`
- `cd packages/scout-for-lol/packages/backend && bun run typecheck`
- `cd packages/scout-for-lol/packages/backend && bun x eslint src/betting/announce.ts src/betting/settlement-dm.ts src/betting/settlement-dm-delivery.ts src/betting/settlement-dm.test.ts src/configuration/flags.ts src/configuration/flags.test.ts src/discord/utils/dm.ts src/discord/utils/dm.test.ts`
- `cd packages/scout-for-lol/packages/docs-site && PUBLIC_SCOUT_SITE_FLAVOR=beta bun run build`
- `bunx lefthook run pre-commit`
- Live Discord and deployed verification were not run.

Visual evidence:
- The local beta docs preview returned HTTP 200, but this execution environment has no available browser binding, so a rendered screenshot could not be captured or uploaded.