### PR TITLE
fix(scout-for-lol): keep mobile docs menu above footer

### DIFF
--- a/packages/scout-for-lol/packages/docs-site/src/styles/scout.css
+++ b/packages/scout-for-lol/packages/docs-site/src/styles/scout.css
@@ -98,14 +98,6 @@
   margin-inline-start: calc(50% - 50dvw);
 }
 
-:root[data-has-sidebar] .scout-footer {
-  /* The sidebar remains sticky through the article's grid track. At the end
-     of the page, the full-bleed footer must paint over that track instead of
-     appearing underneath the sidebar. */
-  position: relative;
-  z-index: calc(var(--sl-z-index-menu) + 1);
-}
-
 html,
 body {
   overflow-x: clip;
@@ -119,6 +111,12 @@ body {
 
 @media (min-width: 50rem) {
   :root[data-has-sidebar] .scout-footer {
+    /* The sidebar remains sticky through the article's grid track. At the end
+       of the page, the full-bleed footer must paint over that track instead
+       of appearing underneath the sidebar. Keep this desktop-only so the
+       mobile menu can remain above the footer. */
+    position: relative;
+    z-index: calc(var(--sl-z-index-menu) + 1);
     margin-inline-start: calc(
       -1 * (var(--sl-content-inline-start) + var(--sl-content-pad-x))
     );


### PR DESCRIPTION
## Why

The desktop footer stacking fix also raised the footer above the mobile docs menu. When the hamburger menu was opened near the bottom of a page, the footer could cover menu links and intercept pointer input.

## What

Scope the footer z-index elevation to the desktop breakpoint. Desktop keeps the sticky sidebar protected at the page end, while mobile leaves the fixed navigation menu above the footer.

## Verification

- `bun run --filter=@scout-for-lol/docs-site build`
- `bunx prettier --check packages/scout-for-lol/packages/docs-site/src/styles/scout.css`
- `git diff --check main...HEAD`
- The branch diff against current `main` contains only the mobile stacking fix.

Production deployment was not run.