### PR TITLE
fix(scout-for-lol): observe settlement DM delivery outcomes

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
@@ -24,6 +24,16 @@ import { bettingSettlementDmsTotal } from "#src/metrics/betting.ts";
 
 const logger = createLogger("betting-settlement-dm");
 
+class SettlementDmStatusError extends Error {
+  readonly status: Exclude<DmStatus, "sent">;
+
+  constructor(status: Exclude<DmStatus, "sent">) {
+    super(`Settlement DM delivery returned ${status}.`);
+    this.name = "SettlementDmStatusError";
+    this.status = status;
+  }
+}
+
 export type SettlementDmDeliveryDependencies = {
   client: Client;
   isPolicyEnabled: typeof isPolicyEnabled;
@@ -148,7 +158,7 @@ export async function deliverSettlementDms(
             suppressMentions: true,
           });
           if (status !== "sent") {
-            throw new Error(`Settlement DM delivery returned ${status}.`);
+            throw new SettlementDmStatusError(status);
           }
           return status;
         },
@@ -159,23 +169,29 @@ export async function deliverSettlementDms(
         result: "sent",
       });
     } catch (error) {
-      // `sendDM` handles expected Discord failures, but an unexpected caller
-      // failure must still leave every remaining recipient eligible to run.
+      // `sendDM` handles expected Discord failures. The observer still needs
+      // a rejection to count those statuses, but they are not Sentry errors.
       bettingSettlementDmsTotal.inc({
         recipient:
           message.kind === "betting_settlement_receipt" ? "bettor" : "player",
         result: status ?? "failed",
       });
-      logger.error(
-        `❌ Could not deliver Bryan Bucks DM for ${input.summary.matchId} to ${message.recipientId}:`,
-        error,
-      );
-      Sentry.captureException(error, {
-        tags: {
-          source: "betting-settlement-dm",
-          matchId: input.summary.matchId,
-        },
-      });
+      if (error instanceof SettlementDmStatusError) {
+        logger.info(
+          `Bryan Bucks DM for ${input.summary.matchId} to ${message.recipientId} returned ${error.status}.`,
+        );
+      } else {
+        logger.error(
+          `❌ Could not deliver Bryan Bucks DM for ${input.summary.matchId} to ${message.recipientId}:`,
+          error,
+        );
+        Sentry.captureException(error, {
+          tags: {
+            source: "betting-settlement-dm",
+            matchId: input.summary.matchId,
+          },
+        });
+      }
     }
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
@@ -7,6 +7,7 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { bettingAnchor, subjectFraming } from "#src/betting/components.ts";
+import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 import {
   buildSettlementDmMessages,
   type TeamRecipient,
@@ -17,7 +18,7 @@ import type { ClosedPosition } from "#src/betting/sweep.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
-import { sendDM } from "#src/discord/utils/dm.ts";
+import { sendDM, type DmStatus } from "#src/discord/utils/dm.ts";
 import { createLogger } from "#src/logger.ts";
 import { bettingSettlementDmsTotal } from "#src/metrics/betting.ts";
 
@@ -27,6 +28,7 @@ export type SettlementDmDeliveryDependencies = {
   client: Client;
   isPolicyEnabled: typeof isPolicyEnabled;
   sendDm: typeof sendDM;
+  observeBucksDelivery: typeof observeBucksDelivery;
 };
 
 const defaultSettlementDmDeliveryDependencies: SettlementDmDeliveryDependencies =
@@ -34,6 +36,7 @@ const defaultSettlementDmDeliveryDependencies: SettlementDmDeliveryDependencies 
     client,
     isPolicyEnabled,
     sendDm: sendDM,
+    observeBucksDelivery,
   };
 
 async function playerRecipientsForRoster(input: {
@@ -125,20 +128,35 @@ export async function deliverSettlementDms(
     playerRecipients,
   });
   for (const message of messages) {
+    let status: DmStatus | undefined;
     try {
-      const status = await dependencies.sendDm({
-        client: dependencies.client,
-        userId: DiscordAccountIdSchema.parse(message.recipientId),
-        message: message.content,
-        kind: message.kind,
-        guildId,
-        prisma: prismaClient,
-        suppressMentions: true,
-      });
+      await dependencies.observeBucksDelivery(
+        {
+          surface: "settlement",
+          operation: "send",
+          matchId: input.summary.matchId,
+          serverId: guildId,
+        },
+        async () => {
+          status = await dependencies.sendDm({
+            client: dependencies.client,
+            userId: DiscordAccountIdSchema.parse(message.recipientId),
+            message: message.content,
+            kind: message.kind,
+            guildId,
+            prisma: prismaClient,
+            suppressMentions: true,
+          });
+          if (status !== "sent") {
+            throw new Error(`Settlement DM delivery returned ${status}.`);
+          }
+          return status;
+        },
+      );
       bettingSettlementDmsTotal.inc({
         recipient:
           message.kind === "betting_settlement_receipt" ? "bettor" : "player",
-        result: status,
+        result: "sent",
       });
     } catch (error) {
       // `sendDM` handles expected Discord failures, but an unexpected caller
@@ -146,7 +164,7 @@ export async function deliverSettlementDms(
       bettingSettlementDmsTotal.inc({
         recipient:
           message.kind === "betting_settlement_receipt" ? "bettor" : "player",
-        result: "failed",
+        result: status ?? "failed",
       });
       logger.error(
         `❌ Could not deliver Bryan Bucks DM for ${input.summary.matchId} to ${message.recipientId}:`,

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
@@ -91,6 +91,16 @@ function build(input: {
   });
 }
 
+function deliveryInput(serverSuffix: string, bets: SettlementBet[]) {
+  return {
+    summary: summary(bets, testGuildId(serverSuffix)),
+    includeOutcome: true,
+    parlay: undefined,
+    unmatchedPositions: [],
+    roster: bucksTestRoster(),
+  };
+}
+
 describe("Bryan Bucks settlement DMs", () => {
   test("sends a bettor who did not play one personal receipt", () => {
     const messages = build({
@@ -260,6 +270,7 @@ describe("Bryan Bucks settlement DMs", () => {
     const dependencies: SettlementDmDeliveryDependencies = {
       client: mockClient(),
       isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      observeBucksDelivery: async (_input, run) => run(),
       sendDm: async () => {
         sends++;
         if (sends === 1) {
@@ -270,22 +281,42 @@ describe("Bryan Bucks settlement DMs", () => {
     };
 
     await deliverSettlementDms(
-      {
-        summary: summary(
-          [
-            bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
-            bet({ id: 2, discordId: redBettor, teamId: 200 }),
-          ],
-          testGuildId("4"),
-        ),
-        includeOutcome: true,
-        parlay: undefined,
-        unmatchedPositions: [],
-        roster: bucksTestRoster(),
-      },
+      deliveryInput("4", [
+        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+        bet({ id: 2, discordId: redBettor, teamId: 200 }),
+      ]),
       dependencies,
     );
 
     expect(sends).toBe(2);
+  });
+
+  test("observes settlement DMs and translates non-sent statuses into failures", async () => {
+    let observed = 0;
+    let rejected = 0;
+    const dependencies: SettlementDmDeliveryDependencies = {
+      client: mockClient(),
+      isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      observeBucksDelivery: async (_input, run) => {
+        observed++;
+        try {
+          return await run();
+        } catch (error) {
+          rejected++;
+          throw error;
+        }
+      },
+      sendDm: async () => "dm_disabled",
+    };
+
+    await deliverSettlementDms(
+      deliveryInput("5", [
+        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+      ]),
+      dependencies,
+    );
+
+    expect(observed).toBe(1);
+    expect(rejected).toBe(1);
   });
 });


### PR DESCRIPTION
Why:
The merged Bryan Bucks settlement DM flow called sendDM directly. sendDM records expected Discord failures as statuses instead of throwing, so the standard Bucks delivery observer counted those attempts as successes and missed the failure in its operation metrics.

What:
- Route every settlement receipt and player outcome DM through observeBucksDelivery with the settlement/send labels and match/guild context.
- Convert every non-sent DM status into an isolated delivery failure so the observer records it and later recipients still run.
- Preserve the DM audit record and settlement delivery counters, with regression coverage for observer routing and dm_disabled status handling.

Verification:
- cd packages/scout-for-lol/packages/backend && bun run test -- src/betting/settlement-dm.test.ts
- cd packages/scout-for-lol/packages/backend && bun run typecheck
- cd packages/scout-for-lol/packages/backend && bun x eslint src/betting/settlement-dm-delivery.ts src/betting/settlement-dm.test.ts
- bunx lefthook run pre-commit

Rollout:
This follow-up is independent of the already merged PR #2398 and does not change the beta-only feature flags or user-visible DM wording.