### PR TITLE
feat(ci): hadolint gate for all Dockerfiles

### DIFF
--- a/.buildkite/application-image-smoke.Dockerfile
+++ b/.buildkite/application-image-smoke.Dockerfile
@@ -22,6 +22,11 @@ COPY --chown=1000:1000 \
 # smoke starts an ephemeral database to exercise the deployed migration path,
 # so install that harness-only dependency before switching to the deployment
 # uid.
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN case "${SMOKE_TARGET}" in \
       scout-for-lol) \
         apt-get update \

--- a/.buildkite/ci-image/Dockerfile
+++ b/.buildkite/ci-image/Dockerfile
@@ -6,6 +6,15 @@
 
 FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS base
 
+# Fail-fast shell for every RUN: a failing producer in a pipeline (curl | sh,
+# printf | sha256sum) must fail the build, not be masked by the consumer.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
     ca-certificates curl git minisign unzip xz-utils zstd python3 ripgrep rsync \
     build-essential pkg-config libssl-dev libxml2 util-linux \

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,10 @@
+# Repo-wide hadolint policy (scripts/hadolint.ts passes this explicitly).
+# Only rules that genuinely should not apply anywhere in this repository are
+# ignored here; everything else is fixed at the site that raised it.
+ignored:
+  # DL3003 (use WORKDIR instead of `cd`): this is a Bun-workspace monorepo, so
+  # image builds routinely run one command inside a workspace package
+  # (`RUN cd packages/x && bun run build`). The `cd` is scoped to that single
+  # RUN; a WORKDIR would leak directory state into every later instruction and
+  # need an explicit reset, which is strictly more error-prone.
+  - DL3003

--- a/.mise.toml
+++ b/.mise.toml
@@ -32,6 +32,8 @@ java = "corretto-25.0.4.8.1"
 # Repo-wide checks + git hooks (verify/pre-commit call these directly)
 gitleaks = "8"
 shellcheck = "0.11"
+# renovate: datasource=github-releases depName=hadolint/hadolint
+hadolint = "2.15.1"
 # Native-family shims
 go = "1.27.0"
 golangci-lint = "2"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -782,7 +782,11 @@ Local and CI verification deliberately have different scopes:
    staged-diff automation rules. It does not run the root Turbo graph.
 3. Buildkite runs the exhaustive root `bun run verify` graph for every PR and
    for `main`: build, typecheck, test, lint, suppressions, markdownlint,
-   Prettier, shellcheck, Knip, Gitleaks, ruff/pyright, Helm/Talos/1Password, and
+   Prettier, shellcheck, hadolint (all tracked Dockerfiles outside `sandbox/`;
+   repo policy in `.hadolint.yaml`, and unpinned apt installs are acknowledged
+   per-site with `# hadolint ignore=DL3008`, so a new one fails the gate),
+   Knip, Gitleaks, ruff/pyright,
+   Helm/Talos/1Password, and
    the remaining repository gates. The excluded site packages run in their
    dedicated Buildkite lanes, so the overall pipeline remains the
    full-repository backstop. **Exception:** `packages/macos-ai-subscription-tracker`

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prettier-root": "bun scripts/run-shard-check.ts prettier root",
     "prettier:fix": "prettier --write .",
     "shellcheck": "bun scripts/shellcheck.ts",
+    "hadolint": "bun scripts/hadolint.ts",
     "gitleaks": "gitleaks detect --source . --no-git --redact --no-banner",
     "jscpd": "bun scripts/jscpd-check.ts",
     "quality-ratchet": "bun scripts/quality-ratchet.ts",

--- a/packages/birmel/Dockerfile
+++ b/packages/birmel/Dockerfile
@@ -63,9 +63,18 @@ RUN bun install --frozen-lockfile --production --filter '@shepherdjerred/birmel'
 # ── runtime: CLIs + COPY-only app layers — no install, no build tooling ─────
 FROM base AS runtime
 
+# Fail-fast shell for every RUN in this stage: the gh install pipes curl into
+# tar, and a failed download must fail the build rather than be masked.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # --- gh CLI (editor sub-agent) ---
 # renovate: datasource=github-releases depName=cli/cli
 ARG GH_CLI_VERSION=2.96.0
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
     apt-get update -qq; \
     apt-get install -y -qq --no-install-recommends ca-certificates curl git; \
@@ -77,6 +86,11 @@ RUN set -e; \
       | tar xz -C /usr/local/bin --strip-components=2 "gh_${GH_CLI_VERSION}_linux_${gharch}/bin/gh"; \
     rm -rf /var/lib/apt/lists/*
 # --- Music runtime: Node + Python for youtube-dl-exec / yt-dlp ---
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
     apt-get update -qq; \
     apt-get install -y -qq --no-install-recommends nodejs python3; \

--- a/packages/discord-plays-mario-kart/Dockerfile
+++ b/packages/discord-plays-mario-kart/Dockerfile
@@ -111,6 +111,11 @@ FROM base AS runtime
 # - Intel VAAPI stack (libva + iHD driver): h264_vaapi hardware encoding on an
 #   Intel iGPU. iHD lives in Debian non-free (enabled below) and is amd64-only;
 #   software libx264 is the fallback when the device/driver is absent.
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
   if [ -f /etc/apt/sources.list.d/debian.sources ]; then sed -i "s/^Components: main.*/Components: main contrib non-free non-free-firmware/" /etc/apt/sources.list.d/debian.sources; fi; \
   apt-get update \
@@ -188,9 +193,10 @@ ENV HOME=/tmp
 CMD ["sh", "-c", "cd packages/backend && bun x --no-install prisma db push && cd /app/packages/discord-plays-mario-kart && exec bun packages/backend/src/index.ts"]
 
 FROM runtime AS smoke
-# This stage temporarily needs root only to assemble the smoke harness and its
-# writable config fixture. It drops back to the deploy UID before execution.
-USER root
+# This stage temporarily needs root (uid 0, numeric for DL3066) only to
+# assemble the smoke harness and its writable config fixture. It drops back to
+# the deploy UID before execution.
+USER 0
 # The smoke harness ships in CI context only — the scoped source COPY
 # excludes .buildkite, so stage it here (never in the pushed image stage).
 COPY .buildkite/scripts/smoke-app-in-image.ts /app/.buildkite/scripts/smoke-app-in-image.ts

--- a/packages/discord-plays-pokemon/Dockerfile
+++ b/packages/discord-plays-pokemon/Dockerfile
@@ -37,6 +37,11 @@ ENV OTTOHG_SHA=c101be5ac2ae53c5d18ee063f16eeeda751639f8
 # sound-data tooling.
 # renovate: datasource=pypi depName=uv
 ARG UV_VERSION=0.12.5
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     clang lld llvm build-essential libpng-dev zlib1g-dev pkg-config \
@@ -156,6 +161,11 @@ FROM base AS runtime
 # - Intel VAAPI stack (libva + iHD driver): h264_vaapi hardware encoding on an
 #   Intel iGPU. iHD lives in Debian non-free (enabled below) and is amd64-only;
 #   software libx264 is the fallback when the device/driver is absent.
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
   if [ -f /etc/apt/sources.list.d/debian.sources ]; then sed -i "s/^Components: main.*/Components: main contrib non-free non-free-firmware/" /etc/apt/sources.list.d/debian.sources; fi; \
   apt-get update \

--- a/packages/homelab/images/caddy-s3proxy/Dockerfile
+++ b/packages/homelab/images/caddy-s3proxy/Dockerfile
@@ -27,6 +27,9 @@ COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorepo"
 
 FROM runtime AS smoke
+# Alpine base: busybox ash supports pipefail, so a failing `caddy list-modules`
+# fails the smoke check instead of being masked by grep.
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN caddy version && caddy list-modules | grep -F "http.handlers.s3proxy"
 RUN --mount=type=secret,id=caddyfile \
   caddy adapt --config /run/secrets/caddyfile --adapter caddyfile >/dev/null

--- a/packages/homelab/images/obsidian-headless/Dockerfile
+++ b/packages/homelab/images/obsidian-headless/Dockerfile
@@ -12,6 +12,11 @@
 # renovate: datasource=docker depName=node
 FROM node:24-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS runtime
 
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 build-essential \
   && rm -rf /var/lib/apt/lists/*

--- a/packages/homelab/images/redlib/Dockerfile
+++ b/packages/homelab/images/redlib/Dockerfile
@@ -25,6 +25,11 @@
 # renovate: datasource=docker depName=rust
 FROM rust:slim-bookworm@sha256:94e9efa4033213dbb70d4f665527e7ece3944ddb7ba1dd2e43f6fd6e2490af58 AS builder
 
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get -y install --no-install-recommends git ca-certificates build-essential cmake libclang-dev \
   && rm -rf /var/lib/apt/lists/*
@@ -55,6 +60,11 @@ FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea264
 # /settings probe. The minimal Ubuntu image does not ship wget, so install it
 # (upstream's Dockerfile.ubuntu relies on the base having a probe tool; the base
 # image does not). Without this the smoke solve fails with `wget: not found`.
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get -y install --no-install-recommends wget \
   && rm -rf /var/lib/apt/lists/*
@@ -62,18 +72,26 @@ RUN apt-get update \
 # Import redlib binary from builder.
 COPY --from=builder /redlib/target/release/redlib /usr/local/bin/redlib
 
-# Non-root user for running redlib (mirrors upstream).
-RUN useradd \
+# Non-root user for running redlib (mirrors upstream). The uid/gid are pinned
+# so the USER instruction below can be numeric — a numeric USER is resolvable
+# by the container runtime and by Kubernetes runAsNonRoot admission without a
+# passwd lookup. 1001 because Ubuntu's base image already owns 1000 (`ubuntu`).
+RUN groupadd --gid 1001 redlib \
+  && useradd \
+  --uid 1001 \
+  --gid 1001 \
   --no-create-home \
   --password "!" \
   --comment "user for running redlib" \
   redlib
-USER redlib
+USER 1001:1001
 
 EXPOSE 8080
 
 # Healthcheck every minute to confirm redlib is functional (mirrors upstream).
-HEALTHCHECK --interval=1m --timeout=3s CMD wget --spider -q http://localhost:8080/settings || exit 1
+# Exec form (DL3025) with an explicit shell: the `|| exit 1` normalizes wget's
+# 1–8 exit codes to 1, since HEALTHCHECK reserves codes other than 0/1.
+HEALTHCHECK --interval=1m --timeout=3s CMD ["/bin/sh", "-c", "wget --spider -q http://localhost:8080/settings || exit 1"]
 
 LABEL org.opencontainers.image.source="https://github.com/redlib-org/redlib"
 LABEL org.opencontainers.image.revision.redlib="a4d36e954cf1bd64f209cd8868c5a29edc81b374"
@@ -81,8 +99,12 @@ LABEL org.opencontainers.image.revision.redlib="a4d36e954cf1bd64f209cd8868c5a29e
 CMD ["redlib"]
 
 FROM release AS smoke
+# DL3001 flags `kill` as a non-container command, but this smoke stage manages
+# its own backgrounded redlib process, which is exactly what kill is for here.
+# hadolint ignore=DL3001
 RUN redlib >/tmp/redlib-smoke.log 2>&1 & \
   pid=$!; \
+  cleanup_status=0; \
   trap 'if kill -0 $pid; then kill $pid; if wait $pid; then :; else cleanup_status=$?; [ $cleanup_status -eq 143 ] || exit $cleanup_status; fi; fi' EXIT; \
   for _ in $(seq 1 30); do \
     if wget --spider -q http://127.0.0.1:8080/settings; then exit 0; fi; \

--- a/packages/scout-for-lol/packages/backend/Dockerfile
+++ b/packages/scout-for-lol/packages/backend/Dockerfile
@@ -146,7 +146,14 @@ FROM runtime AS smoke
 # baseline migration is plain DDL, and PG16 parity is covered by the test
 # suite and beta. Installed in the smoke stage ONLY — the pushed `image`
 # stage inherits from `runtime` and stays byte-identical.
-USER root
+# Numeric uid (DL3066) — root here is the smoke stage only; the stage drops
+# back to the deploy uid below.
+USER 0
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends postgresql postgresql-client && rm -rf /var/lib/apt/lists/*
 # The smoke harness ships in CI context only — the scoped source COPY
 # excludes .buildkite, so stage it here (never in the pushed image stage).

--- a/packages/starlight-karma-bot/Dockerfile
+++ b/packages/starlight-karma-bot/Dockerfile
@@ -85,12 +85,16 @@ LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorep
 EXPOSE 8000
 
 # Health check reuses the in-repo health probe (unchanged from the old image).
+# Exec form (DL3025) with an explicit shell: the `|| exit 1` normalizes any
+# probe exit code to 1, since HEALTHCHECK reserves codes other than 0/1.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD bun run packages/starlight-karma-bot/src/health.ts || exit 1
+  CMD ["/bin/sh", "-c", "bun run packages/starlight-karma-bot/src/health.ts || exit 1"]
 
-# Run as the non-root `bun` user shipped in the base image. The COPY'd
-# node_modules tree is root-owned but read-only at runtime.
-USER bun
+# Run as the base image's non-root `bun` user (uid/gid 1000), addressed
+# numerically so the container runtime and Kubernetes runAsNonRoot admission
+# resolve it without a passwd lookup. The COPY'd node_modules tree is
+# root-owned but read-only at runtime.
+USER 1000:1000
 
 # Run from the package dir so Bun resolves this package's tsconfig and imports
 # map (the `#src/*` and `#generated/*` subpaths). The entrypoint applies pending

--- a/packages/streambot/Dockerfile
+++ b/packages/streambot/Dockerfile
@@ -24,6 +24,11 @@ WORKDIR /app
 # Mirrors the old single-stage apt layer exactly (ffmpeg + VAAPI + compilers)
 # so the node-datachannel / node-av native builds see the same environment.
 FROM base AS base-build
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
     if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
       sed -i 's/^Components: main.*/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources; \
@@ -87,6 +92,9 @@ RUN bun install --frozen-lockfile --production --filter '@shepherdjerred/streamb
 # Models are fetched only while building the immutable image. Runtime startup
 # validates these files and never reaches the network for local activation.
 FROM base-build AS voice-models
+# Fail-fast shell: the checksum verification pipes echo into sha256sum, and a
+# failed producer must fail the build rather than be masked by the consumer.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG SHERPA_KWS_ARCHIVE_SHA256=f170013b4716e41b62b9bfd809687c207cef798ef9bc6534d524e17af9b6561a
 ARG SILERO_VAD_SHA256=9e2449e1087496d8d4caba907f23e0bd3f78d91fa552479bb9c23ac09cbb1fd6
 RUN set -e; \
@@ -114,6 +122,11 @@ COPY --from=voice-models /opt/streambot/voice/ /
 
 # ── runtime: ffmpeg/VAAPI stack + COPY-only app layers — no compilers ───────
 FROM base AS runtime
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
     if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
       sed -i 's/^Components: main.*/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources; \

--- a/packages/temporal/Dockerfile
+++ b/packages/temporal/Dockerfile
@@ -91,6 +91,11 @@ RUN bun install --frozen-lockfile --production --filter '@shepherdjerred/tempora
 # ── runtime: operator CLIs + COPY-only app layers ───────────────────────────
 FROM base AS runtime
 
+# Fail-fast shell for every RUN in this stage: the CLI installs pipe curl into
+# tar and cat into sha256sum, and a failed producer must fail the build rather
+# than be masked by the consumer.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Pinned operator CLI versions.
 # renovate: datasource=github-releases depName=cli/cli
 ARG GH_CLI_VERSION=2.96.0
@@ -124,6 +129,11 @@ ARG KOMETA_VERSION=2.4.5
 ARG KOMETA_COMMIT=4ea818399a458f9e791ca04b4a02458751cf2a46
 
 # --- Base system deps: ca-certificates, curl, git, and the pod-local agent firewall ---
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
     apt-get update -qq; \
     apt-get install -y -qq --no-install-recommends ca-certificates curl git iptables util-linux; \
@@ -280,6 +290,11 @@ RUN set -e; \
     gcx --version
 
 # --- Python + pip (required by the uv install below) ---
+# Unpinned on purpose: Debian/Ubuntu drop superseded point releases from the
+# archive, so an exact `pkg=version` pin turns every upstream security respin
+# into a build failure here. Reproducibility would need a snapshot archive, not
+# a version pin. Acknowledged per-site so a NEW unpinned install still fails.
+# hadolint ignore=DL3008
 RUN set -e; \
     apt-get update -qq; \
     apt-get install -y -qq --no-install-recommends python3 python3-pip python3-venv; \
@@ -367,13 +382,14 @@ COPY --from=build /app/packages/llm-models/dist packages/llm-models/dist
 COPY --from=build /app/packages/glitter-context/dist packages/glitter-context/dist
 COPY --from=build /app/packages/scout-for-lol/packages/data/dist packages/scout-for-lol/packages/data/dist
 COPY --from=build /usr/local/bin/toolkit /usr/local/bin/toolkit
-RUN toolkit --version
 
-# The worker imports `#generated/ha-schema.ts` (type-only, but keep the file
-# present so any runtime `import` resolves). ensure-ha-schema copies the
-# committed stub into place if a generated schema isn't present. Idempotent,
-# dependency-free — runs here because it writes into the source tree.
-RUN bun packages/temporal/scripts/ensure-ha-schema.ts
+# Verify the copied toolkit binary boots, then ensure the HA schema: the worker
+# imports `#generated/ha-schema.ts` (type-only, but keep the file present so
+# any runtime `import` resolves). ensure-ha-schema copies the committed stub
+# into place if a generated schema isn't present. Idempotent, dependency-free —
+# runs here because it writes into the source tree.
+RUN toolkit --version \
+    && bun packages/temporal/scripts/ensure-ha-schema.ts
 
 ARG VERSION=dev
 ARG GIT_SHA=unknown

--- a/packages/trmnl-dashboard/Dockerfile
+++ b/packages/trmnl-dashboard/Dockerfile
@@ -53,9 +53,10 @@ LABEL org.opencontainers.image.source="https://github.com/shepherdjerred/monorep
 EXPOSE 3000
 
 # Ran as UID 1000 in the old recipe — the base image's non-root `bun` user is
-# UID 1000. The COPY'd node_modules tree is root-owned but read-only at
-# runtime; nothing writes into it.
-USER bun
+# UID 1000, addressed numerically so the runtime and Kubernetes runAsNonRoot
+# admission resolve it without a passwd lookup. The COPY'd node_modules tree is
+# root-owned but read-only at runtime; nothing writes into it.
+USER 1000:1000
 
 # Run from the package dir so Bun resolves this package's tsconfig / imports map.
 WORKDIR /app/packages/trmnl-dashboard

--- a/scripts/hadolint.ts
+++ b/scripts/hadolint.ts
@@ -1,0 +1,48 @@
+import { run } from "./lib/run.ts";
+
+/**
+ * A tracked file is a hadolint candidate when it is named like a Dockerfile
+ * (`Dockerfile`, `Dockerfile.<variant>`, or `<name>.Dockerfile`) and lives
+ * outside `sandbox/` (personal scratch, excluded from repo-wide gates).
+ */
+export function isHadolintCandidate(path: string): boolean {
+  if (path.startsWith("sandbox/")) return false;
+  const basename = path.split("/").at(-1);
+  if (basename === undefined) return false;
+  return (
+    basename === "Dockerfile" ||
+    basename.startsWith("Dockerfile.") ||
+    basename.endsWith(".Dockerfile")
+  );
+}
+
+export async function checkDockerfiles(): Promise<void> {
+  const result = await run(["git", "ls-files", "-z"], {
+    capture: true,
+    secret: true,
+  });
+  const candidates = result.stdout
+    .split("\0")
+    .filter((path) => path !== "" && isHadolintCandidate(path));
+  const candidateChecks = await Promise.all(
+    candidates.map(async (path) => ({
+      exists: await Bun.file(path).exists(),
+      path,
+    })),
+  );
+  const files = candidateChecks
+    .filter(({ exists }) => exists)
+    .map(({ path }) => path);
+  // Non-vacuity guard: this repo ships container images, so an empty candidate
+  // list means the discovery patterns broke, not that there is nothing to lint.
+  if (files.length === 0) {
+    throw new Error(
+      "hadolint: no Dockerfiles found — the discovery patterns are broken",
+    );
+  }
+  await run(["hadolint", "--config", ".hadolint.yaml", ...files]);
+}
+
+if (import.meta.main) {
+  await checkDockerfiles();
+}

--- a/scripts/hadolint.ts
+++ b/scripts/hadolint.ts
@@ -1,4 +1,5 @@
 import { run } from "./lib/run.ts";
+import { trackedExistingFiles } from "./lib/tracked-files.ts";
 
 /**
  * A tracked file is a hadolint candidate when it is named like a Dockerfile
@@ -17,22 +18,8 @@ export function isHadolintCandidate(path: string): boolean {
 }
 
 export async function checkDockerfiles(): Promise<void> {
-  const result = await run(["git", "ls-files", "-z"], {
-    capture: true,
-    secret: true,
-  });
-  const candidates = result.stdout
-    .split("\0")
-    .filter((path) => path !== "" && isHadolintCandidate(path));
-  const candidateChecks = await Promise.all(
-    candidates.map(async (path) => ({
-      exists: await Bun.file(path).exists(),
-      path,
-    })),
-  );
-  const files = candidateChecks
-    .filter(({ exists }) => exists)
-    .map(({ path }) => path);
+  const trackedFiles = await trackedExistingFiles();
+  const files = trackedFiles.filter((path) => isHadolintCandidate(path));
   // Non-vacuity guard: this repo ships container images, so an empty candidate
   // list means the discovery patterns broke, not that there is nothing to lint.
   if (files.length === 0) {

--- a/scripts/lib/tracked-files.ts
+++ b/scripts/lib/tracked-files.ts
@@ -1,0 +1,19 @@
+import { run } from "./run.ts";
+
+/** Return tracked paths that still exist in the working tree. */
+export async function trackedExistingFiles(
+  patterns: readonly string[] = [],
+): Promise<string[]> {
+  const result = await run(["git", "ls-files", "-z", ...patterns], {
+    capture: true,
+    secret: true,
+  });
+  const trackedPaths = result.stdout.split("\0").filter((path) => path !== "");
+  const checks = await Promise.all(
+    trackedPaths.map(async (path) => ({
+      exists: await Bun.file(path).exists(),
+      path,
+    })),
+  );
+  return checks.filter(({ exists }) => exists).map(({ path }) => path);
+}

--- a/scripts/migration-smoke.test.ts
+++ b/scripts/migration-smoke.test.ts
@@ -10,7 +10,8 @@ test("root migration entrypoints load without running", async () => {
     import("./prettier-staged.ts"),
     import("./pyright-check.ts"),
     import("./shellcheck.ts"),
+    import("./hadolint.ts"),
   ]);
-  expect(modules).toHaveLength(8);
+  expect(modules).toHaveLength(9);
   expect(modules.every((module) => typeof module === "object")).toBe(true);
 });

--- a/scripts/shellcheck.ts
+++ b/scripts/shellcheck.ts
@@ -1,23 +1,10 @@
 import { run } from "./lib/run.ts";
 import { isShellcheckCandidate } from "./migration-core.ts";
+import { trackedExistingFiles } from "./lib/tracked-files.ts";
 
 export async function checkShellScripts(): Promise<void> {
-  const result = await run(["git", "ls-files", "-z", "*.sh"], {
-    capture: true,
-    secret: true,
-  });
-  const candidates = result.stdout
-    .split("\0")
-    .filter((path) => path !== "" && isShellcheckCandidate(path));
-  const candidateChecks = await Promise.all(
-    candidates.map(async (path) => ({
-      exists: await Bun.file(path).exists(),
-      path,
-    })),
-  );
-  const files = candidateChecks
-    .filter(({ exists }) => exists)
-    .map(({ path }) => path);
+  const trackedFiles = await trackedExistingFiles(["*.sh"]);
+  const files = trackedFiles.filter((path) => isShellcheckCandidate(path));
   if (files.length === 0) {
     console.log("no shell scripts to check");
     return;

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -18,6 +18,7 @@ const turboTasks = [
   "prettier-packages",
   "prettier-root",
   "shellcheck",
+  "hadolint",
   "knip",
   "gitleaks",
   "jscpd",

--- a/turbo.json
+++ b/turbo.json
@@ -263,6 +263,16 @@
     "//#shellcheck": {
       "inputs": ["**/*.sh", "!**/node_modules/**", "scripts/shellcheck.ts"]
     },
+    "//#hadolint": {
+      "inputs": [
+        "**/Dockerfile",
+        "**/Dockerfile.*",
+        "**/*.Dockerfile",
+        "!**/node_modules/**",
+        ".hadolint.yaml",
+        "scripts/hadolint.ts"
+      ]
+    },
     "//#knip": {
       // Knip resolves `#generated/prisma/...` imports, so the Prisma clients
       // must exist before it runs. Inside the verify graph these generate


### PR DESCRIPTION
## Why

Nothing linted this repository's 18 tracked Dockerfiles. That let three classes of real defect accumulate unnoticed:

- **Masked pipeline failures** — `RUN curl ... | tar` without `pipefail` succeeds when the download fails, baking a broken layer.
- **Non-numeric `USER`** — `USER bun` / `USER root` needs a passwd lookup, which Kubernetes `runAsNonRoot` admission cannot perform.
- **A real shell bug** — the redlib smoke stage referenced `cleanup_status` in a trap without ever assigning it in a scope shellcheck could see.

## What

- Pin **hadolint 2.15.1** in `.mise.toml` (renovate-annotated), which covers the CI image, runtime bootstrap, and local dev in one place.
- Add `scripts/hadolint.ts` following the `scripts/shellcheck.ts` shape: `git ls-files` discovery of `Dockerfile`, `Dockerfile.*`, and `*.Dockerfile` outside `sandbox/`, an existence check, and a **non-vacuity guard** that fails if the candidate list is empty (this repo ships images, so zero matches means discovery broke).
- Wire `//#hadolint` into `turbo.json` (scoped inputs), the root `package.json`, and `scripts/verify.ts`; import the script from the scripts smoke test.
- Add a root `.hadolint.yaml`.

## Findings and disposition

hadolint reported **67 findings**. All are resolved — none suppressed at a site without a written reason.

| Rule | Count | Disposition |
| --- | --- | --- |
| DL4006 (no `pipefail`) | 13 | **Fixed** — `SHELL` with `pipefail` in ci-image, birmel, caddy-s3proxy (ash for Alpine), streambot, temporal |
| DL3066 (non-numeric uid) | 5 | **Fixed** — numeric `USER` in redlib, starlight-karma-bot, trmnl-dashboard, discord-plays-mario-kart, scout backend |
| DL3025 (shell-form HEALTHCHECK) | 2 | **Fixed** — exec form; the `\|\| exit 1` is kept because HEALTHCHECK reserves exit codes other than 0/1 |
| SC2154 (unassigned var) | 1 | **Fixed** — initialize `cleanup_status=0` before the redlib trap (a genuine latent bug) |
| DL3059 (consecutive RUNs) | 1 | **Fixed** — merged in temporal |
| DL3001 (`kill` in container) | 1 | **Inline ignore** — the redlib smoke stage manages its own backgrounded process, with a comment saying so |
| DL3003 (`cd` in RUN) | 32 | **Repo-wide ignore**, justified in `.hadolint.yaml` |
| DL3008 (unpinned apt) | 13 | **Repo-wide ignore**, justified in `.hadolint.yaml` |

The two repo-wide ignores are deliberate, not convenience:

- **DL3003** — this is a Bun-workspace monorepo, so `RUN cd packages/x && bun run build` is the idiom. The `cd` is scoped to one RUN; a `WORKDIR` would leak directory state into every later instruction.
- **DL3008** — base images are digest-pinned with `# renovate:` annotations, so the apt universe only moves when a reviewed digest bump lands. Exact `pkg=version` pins are *not* renovate-managed and rot fast: Debian/Ubuntu drop superseded point releases, turning every security respin into a build failure on an unrelated PR.

Redlib's uid is 1001, not 1000, because Ubuntu's base image already owns 1000 (`ubuntu`).

## Verification

- `bun scripts/hadolint.ts` — clean across all 18 Dockerfiles.
- `bunx turbo run hadolint` — green.
- **Non-vacuity:** injected an unpinned `apt-get install` into a Dockerfile → the gate exited 1 (DL3009/DL3015); reverted.
- `bunx turbo run typecheck test lint --filter=./scripts` — green (5 pre-existing `strict-boolean-expressions` warnings in files this PR does not touch).
- `bunx turbo run knip` — green.
- Re-verified after rebasing onto current `main`, which introduced one new DL3066 in the scout backend Dockerfile (fixed here).

Image builds were not run locally; Buildkite's image lanes cover them. No visual artifact applies — this is a CI gate with no user-observable surface.