### PR TITLE
Model deterministic Scout weekly parlays

### DIFF
--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260824000000_weekly_parlays/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260824000000_weekly_parlays/migration.sql
@@ -1,0 +1,120 @@
+-- Weekly cross-game Bryan Bucks parlays use separate immutable definitions,
+-- guild markets, positions, contributions, and delivery markers. Existing
+-- match-bound parlay rows remain unchanged.
+CREATE TABLE "BucksWeeklyParlayDefinition" (
+    "id" SERIAL NOT NULL,
+    "serverId" TEXT NOT NULL,
+    "periodKey" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "openAt" TIMESTAMP(3) NOT NULL,
+    "bettingClosesAt" TIMESTAMP(3) NOT NULL,
+    "scoringStartsAt" TIMESTAMP(3) NOT NULL,
+    "scoringEndsAt" TIMESTAMP(3) NOT NULL,
+    "subjects" TEXT NOT NULL,
+    "eligibleQueues" TEXT NOT NULL,
+    "proposal" TEXT NOT NULL,
+    "criteria" TEXT NOT NULL,
+    "historySample" TEXT NOT NULL,
+    "pricing" TEXT NOT NULL,
+    "yesProbabilityBps" INTEGER NOT NULL,
+    "promptVersion" TEXT NOT NULL,
+    "catalogVersion" TEXT NOT NULL,
+    "schemaVersion" INTEGER NOT NULL,
+    "evaluatorVersion" TEXT NOT NULL,
+    "pricingVersion" TEXT NOT NULL,
+    "generationContext" TEXT NOT NULL,
+    "requestedModel" TEXT NOT NULL,
+    "resolvedModel" TEXT,
+    "usage" TEXT NOT NULL,
+    "durationMs" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "BucksWeeklyParlayDefinition_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "BucksWeeklyParlayMarket" (
+    "id" SERIAL NOT NULL,
+    "definitionId" INTEGER NOT NULL,
+    "serverId" TEXT NOT NULL,
+    "periodKey" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "publishedAt" TIMESTAMP(3) NOT NULL,
+    "bettingClosesAt" TIMESTAMP(3) NOT NULL,
+    "scoringEndsAt" TIMESTAMP(3) NOT NULL,
+    "messageRefs" TEXT NOT NULL DEFAULT '[]',
+    "marketState" TEXT NOT NULL DEFAULT 'publishing',
+    "yesResult" BOOLEAN,
+    "legResults" TEXT,
+    "voidReason" TEXT,
+    "settledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "BucksWeeklyParlayMarket_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "BucksWeeklyParlayBet" (
+    "id" SERIAL NOT NULL,
+    "marketId" INTEGER NOT NULL,
+    "bucksAccountId" INTEGER NOT NULL,
+    "side" TEXT NOT NULL,
+    "stake" INTEGER NOT NULL,
+    "houseReserve" INTEGER NOT NULL,
+    "grossPayout" INTEGER NOT NULL,
+    "betOutcome" TEXT NOT NULL DEFAULT 'pending',
+    "payout" INTEGER,
+    "settledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "BucksWeeklyParlayBet_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "BucksWeeklyParlayContribution" (
+    "id" SERIAL NOT NULL,
+    "definitionId" INTEGER NOT NULL,
+    "matchId" TEXT NOT NULL,
+    "subjectKey" TEXT NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL,
+    "ingestedAt" TIMESTAMP(3) NOT NULL,
+    "queueType" TEXT NOT NULL,
+    "snapshot" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "BucksWeeklyParlayContribution_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "BucksWeeklyParlayDelivery" (
+    "id" SERIAL NOT NULL,
+    "marketId" INTEGER NOT NULL,
+    "actionKey" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "deliveryState" TEXT NOT NULL DEFAULT 'pending',
+    "messageRefs" TEXT NOT NULL DEFAULT '[]',
+    "attemptedAt" TIMESTAMP(3),
+    "deliveredAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "BucksWeeklyParlayDelivery_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "BucksLedgerEntry" ADD COLUMN "weeklyParlayBetId" INTEGER;
+
+CREATE UNIQUE INDEX "BucksWeeklyParlayDefinition_serverId_scoringStartsAt_slot_key" ON "BucksWeeklyParlayDefinition"("serverId", "scoringStartsAt", "slot");
+CREATE UNIQUE INDEX "BucksWeeklyParlayDefinition_serverId_periodKey_slot_key" ON "BucksWeeklyParlayDefinition"("serverId", "periodKey", "slot");
+CREATE INDEX "BucksWeeklyParlayDefinition_scoringStartsAt_scoringEndsAt_idx" ON "BucksWeeklyParlayDefinition"("scoringStartsAt", "scoringEndsAt");
+CREATE UNIQUE INDEX "BucksWeeklyParlayMarket_definitionId_key" ON "BucksWeeklyParlayMarket"("definitionId");
+CREATE UNIQUE INDEX "BucksWeeklyParlayMarket_serverId_periodKey_slot_key" ON "BucksWeeklyParlayMarket"("serverId", "periodKey", "slot");
+CREATE INDEX "BucksWeeklyParlayMarket_marketState_bettingClosesAt_idx" ON "BucksWeeklyParlayMarket"("marketState", "bettingClosesAt");
+CREATE INDEX "BucksWeeklyParlayMarket_marketState_scoringEndsAt_idx" ON "BucksWeeklyParlayMarket"("marketState", "scoringEndsAt");
+CREATE UNIQUE INDEX "BucksWeeklyParlayBet_marketId_bucksAccountId_key" ON "BucksWeeklyParlayBet"("marketId", "bucksAccountId");
+CREATE INDEX "BucksWeeklyParlayBet_marketId_side_idx" ON "BucksWeeklyParlayBet"("marketId", "side");
+CREATE UNIQUE INDEX "BucksWeeklyParlayContribution_definitionId_matchId_subjectKey_key" ON "BucksWeeklyParlayContribution"("definitionId", "matchId", "subjectKey");
+CREATE INDEX "BucksWeeklyParlayContribution_definitionId_completedAt_idx" ON "BucksWeeklyParlayContribution"("definitionId", "completedAt");
+CREATE INDEX "BucksWeeklyParlayContribution_matchId_idx" ON "BucksWeeklyParlayContribution"("matchId");
+CREATE UNIQUE INDEX "BucksWeeklyParlayDelivery_marketId_actionKey_key" ON "BucksWeeklyParlayDelivery"("marketId", "actionKey");
+CREATE INDEX "BucksWeeklyParlayDelivery_deliveryState_scheduledAt_idx" ON "BucksWeeklyParlayDelivery"("deliveryState", "scheduledAt");
+
+ALTER TABLE "BucksWeeklyParlayMarket" ADD CONSTRAINT "BucksWeeklyParlayMarket_definitionId_fkey" FOREIGN KEY ("definitionId") REFERENCES "BucksWeeklyParlayDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BucksWeeklyParlayBet" ADD CONSTRAINT "BucksWeeklyParlayBet_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "BucksWeeklyParlayMarket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BucksWeeklyParlayBet" ADD CONSTRAINT "BucksWeeklyParlayBet_bucksAccountId_fkey" FOREIGN KEY ("bucksAccountId") REFERENCES "BucksAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BucksWeeklyParlayContribution" ADD CONSTRAINT "BucksWeeklyParlayContribution_definitionId_fkey" FOREIGN KEY ("definitionId") REFERENCES "BucksWeeklyParlayDefinition"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BucksWeeklyParlayDelivery" ADD CONSTRAINT "BucksWeeklyParlayDelivery_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "BucksWeeklyParlayMarket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BucksLedgerEntry" ADD CONSTRAINT "BucksLedgerEntry_weeklyParlayBetId_fkey" FOREIGN KEY ("weeklyParlayBetId") REFERENCES "BucksWeeklyParlayBet"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -755,10 +755,11 @@ model BucksAccount {
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
-  ledgerEntries BucksLedgerEntry[]
-  bets          BucksBet[]
-  parlayBets    BucksParlayBet[]
-  openPositions BucksOpenPosition[]
+  ledgerEntries    BucksLedgerEntry[]
+  bets             BucksBet[]
+  parlayBets       BucksParlayBet[]
+  weeklyParlayBets BucksWeeklyParlayBet[]
+  openPositions    BucksOpenPosition[]
 
   @@unique([serverId, discordId])
   @@index([serverId, balance])
@@ -801,6 +802,9 @@ model BucksLedgerEntry {
 
   parlayBetId Int?
   parlayBet   BucksParlayBet? @relation(fields: [parlayBetId], references: [id])
+
+  weeklyParlayBetId Int?
+  weeklyParlayBet   BucksWeeklyParlayBet? @relation(fields: [weeklyParlayBetId], references: [id])
 
   // Riot team IDs (100/200). Both null for seed/earn_*/adjustment.
   // `actualWinningTeamId` is also null for bet_stake (unknown at bet time) and
@@ -1070,6 +1074,145 @@ model BucksParlayBet {
 
   @@unique([marketId, bucksAccountId])
   @@index([marketId, side])
+}
+
+// Immutable cross-game proposition for one guild-local Pacific scoring period.
+// The subject/account snapshots and every generation/pricing input are frozen
+// here so later alias, account, model, or catalog changes cannot alter it.
+model BucksWeeklyParlayDefinition {
+  id        Int    @id @default(autoincrement())
+  serverId  String
+  periodKey String
+  slot      Int
+
+  openAt          DateTime
+  bettingClosesAt DateTime
+  scoringStartsAt DateTime
+  scoringEndsAt   DateTime
+
+  subjects       String
+  eligibleQueues String
+  proposal       String
+  criteria       String
+  historySample  String
+  pricing        String
+
+  yesProbabilityBps Int
+  promptVersion     String
+  catalogVersion    String
+  schemaVersion     Int
+  evaluatorVersion  String
+  pricingVersion    String
+  generationContext String
+  requestedModel    String
+  resolvedModel     String?
+  usage             String
+  durationMs        Int
+
+  createdAt DateTime @default(now())
+
+  market        BucksWeeklyParlayMarket?
+  contributions BucksWeeklyParlayContribution[]
+
+  @@unique([serverId, scoringStartsAt, slot])
+  @@unique([serverId, periodKey, slot])
+  @@index([scoringStartsAt, scoringEndsAt])
+}
+
+// Guild-local publication and settlement state for one weekly definition.
+model BucksWeeklyParlayMarket {
+  id           Int                         @id @default(autoincrement())
+  definitionId Int                         @unique
+  definition   BucksWeeklyParlayDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade)
+  serverId     String
+  periodKey    String
+  slot         Int
+
+  publishedAt     DateTime
+  bettingClosesAt DateTime
+  scoringEndsAt   DateTime
+  messageRefs     String   @default("[]")
+
+  // publishing | open | active | settled | voided
+  marketState String    @default("publishing")
+  yesResult   Boolean?
+  legResults  String?
+  voidReason  String?
+  settledAt   DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  bets       BucksWeeklyParlayBet[]
+  deliveries BucksWeeklyParlayDelivery[]
+
+  @@unique([serverId, periodKey, slot])
+  @@index([marketState, bettingClosesAt])
+  @@index([marketState, scoringEndsAt])
+}
+
+// One fixed-odds YES/NO position per wallet and weekly market.
+model BucksWeeklyParlayBet {
+  id             Int                     @id @default(autoincrement())
+  marketId       Int
+  market         BucksWeeklyParlayMarket @relation(fields: [marketId], references: [id], onDelete: Cascade)
+  bucksAccountId Int
+  bucksAccount   BucksAccount            @relation(fields: [bucksAccountId], references: [id], onDelete: Cascade)
+
+  side         String
+  stake        Int
+  houseReserve Int
+  grossPayout  Int
+  betOutcome   String    @default("pending")
+  payout       Int?
+  settledAt    DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  ledgerEntries BucksLedgerEntry[]
+
+  @@unique([marketId, bucksAccountId])
+  @@index([marketId, side])
+}
+
+// Idempotent contribution from one completed, eligible match for one frozen
+// subject. Progress and settlement are derived only from these rows.
+model BucksWeeklyParlayContribution {
+  id           Int                         @id @default(autoincrement())
+  definitionId Int
+  definition   BucksWeeklyParlayDefinition @relation(fields: [definitionId], references: [id], onDelete: Cascade)
+  matchId      String
+  subjectKey   String
+  completedAt  DateTime
+  ingestedAt   DateTime
+  queueType    String
+  snapshot     String
+  createdAt    DateTime                    @default(now())
+
+  @@unique([definitionId, matchId, subjectKey])
+  @@index([definitionId, completedAt])
+  @@index([matchId])
+}
+
+// One durable Discord action attempt per market/action key. The action key is
+// also the enforced Discord nonce, so activity retries cannot duplicate posts.
+model BucksWeeklyParlayDelivery {
+  id            Int                     @id @default(autoincrement())
+  marketId      Int
+  market        BucksWeeklyParlayMarket @relation(fields: [marketId], references: [id], onDelete: Cascade)
+  actionKey     String
+  kind          String
+  scheduledAt   DateTime
+  deliveryState String                  @default("pending")
+  messageRefs   String                  @default("[]")
+  attemptedAt   DateTime?
+  deliveredAt   DateTime?
+  createdAt     DateTime                @default(now())
+  updatedAt     DateTime                @updatedAt
+
+  @@unique([marketId, actionKey])
+  @@index([deliveryState, scheduledAt])
 }
 
 // Durable marker for Bucks EARNINGS on a (match, guild).

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -37,6 +37,11 @@ const LEDGER_KIND_LABELS = {
   parlay_payout: "parlay payout",
   parlay_refund: "parlay refund",
   parlay_release: "parlay reserve release",
+  weekly_parlay_stake: "weekly parlay stake",
+  weekly_parlay_reserve: "weekly parlay house reserve",
+  weekly_parlay_payout: "weekly parlay payout",
+  weekly_parlay_refund: "weekly parlay refund",
+  weekly_parlay_release: "weekly parlay reserve release",
   peek_pass: `${PEEK_PASS_DURATION_LABEL} peek pass`,
   adjustment: "adjustment",
 } satisfies Record<BucksLedgerKind, string>;

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+import {
+  WEEKLY_PARLAY_SCHEMA_VERSION,
+  WeeklyParlayDefinitionCriteriaSchema,
+  WeeklyParlayProposalSchema,
+  WeeklyParlaySubjectSchema,
+  validateWeeklyParlayProposal,
+} from "#src/betting/weekly-parlay-criteria.ts";
+
+const subject = WeeklyParlaySubjectSchema.parse({
+  key: "P1",
+  playerId: 1,
+  alias: "Jerred",
+  discordId: "123",
+  accounts: [
+    { puuid: "a".repeat(78), trackingStartedAt: "2025-01-01T00:00:00.000Z" },
+    { puuid: "b".repeat(78), trackingStartedAt: "2025-02-01T00:00:00.000Z" },
+  ],
+});
+
+describe("weekly parlay closed criteria", () => {
+  test("rejects model-authored settlement logic and pings", () => {
+    expect(
+      WeeklyParlayProposalSchema.safeParse({
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "champion_damage",
+            operator: "gte",
+          },
+          {
+            kind: "rate",
+            subject: "P1",
+            metric: "win_rate_bps",
+            operator: "gte",
+            expression: "SELECT * FROM matches",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      WeeklyParlayProposalSchema.safeParse({
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "pings",
+            operator: "gte",
+          },
+          { kind: "aggregate", subject: "P1", metric: "wins", operator: "gte" },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  test("requires every subject and an explicit participation leg", () => {
+    const proposal = WeeklyParlayProposalSchema.parse({
+      version: WEEKLY_PARLAY_SCHEMA_VERSION,
+      legs: [
+        { kind: "aggregate", subject: "P1", metric: "kills", operator: "gte" },
+        {
+          kind: "champion_games",
+          subject: "P1",
+          champion: "Ahri",
+          winsOnly: true,
+          operator: "gte",
+        },
+        {
+          kind: "role_games",
+          subject: "P1",
+          role: "MIDDLE",
+          winsOnly: false,
+          operator: "gte",
+        },
+      ],
+    });
+    expect(
+      validateWeeklyParlayProposal({
+        proposal,
+        subjects: [subject],
+        observedChampions: new Map([["P1", new Set(["Lux"])]]),
+        observedRoles: new Map([["P1", new Set(["MIDDLE"])]]),
+      }),
+    ).toEqual([
+      "Subject P1 needs a visible games participation leg.",
+      "Ahri was not historically observed for P1.",
+    ]);
+  });
+
+  test("rejects duplicate targets and zero-game participation", () => {
+    expect(
+      WeeklyParlayProposalSchema.safeParse({
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "lte",
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "eq",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      WeeklyParlayDefinitionCriteriaSchema.safeParse({
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+            threshold: 0,
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "wins",
+            operator: "gte",
+            threshold: 1,
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "kills",
+            operator: "gte",
+            threshold: 1,
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.ts
@@ -1,0 +1,269 @@
+import { z } from "zod";
+import { LeaguePuuidSchema } from "@scout-for-lol/data";
+
+export const WEEKLY_PARLAY_SCHEMA_VERSION = 1;
+export const WEEKLY_PARLAY_CATALOG_VERSION = "2026-08-23";
+export const WEEKLY_PARLAY_EVALUATOR_VERSION = "1";
+export const WEEKLY_PARLAY_PRICING_VERSION = "1";
+export const WEEKLY_PARLAY_MIN_LEGS = 3;
+export const WEEKLY_PARLAY_MAX_LEGS = 5;
+export const WEEKLY_PARLAY_MIN_HISTORY_WINDOWS = 15;
+export const WEEKLY_PARLAY_HISTORY_WINDOW_COUNT = 52;
+export const WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS = 4;
+export const WEEKLY_PARLAY_MIN_RECENT_GAMES = 3;
+export const WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS = 4000;
+export const WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS = 6000;
+export const WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS = 5000;
+
+export const WEEKLY_PARLAY_ELIGIBLE_QUEUES = [
+  "solo",
+  "flex",
+  "ranked 5s",
+] as const;
+export const WeeklyParlayEligibleQueueSchema = z.enum(
+  WEEKLY_PARLAY_ELIGIBLE_QUEUES,
+);
+
+export const WeeklyParlayRoleSchema = z.enum([
+  "TOP",
+  "JUNGLE",
+  "MIDDLE",
+  "BOTTOM",
+  "UTILITY",
+]);
+
+export const WeeklyParlaySubjectKeySchema = z.string().regex(/^P[1-5]$/u);
+export const WeeklyParlayFrozenAccountSchema = z.strictObject({
+  puuid: LeaguePuuidSchema,
+  trackingStartedAt: z.iso.datetime(),
+});
+export const WeeklyParlaySubjectSchema = z.strictObject({
+  key: WeeklyParlaySubjectKeySchema,
+  playerId: z.number().int().positive(),
+  alias: z.string().min(1).max(100),
+  discordId: z.string().min(1),
+  accounts: z.array(WeeklyParlayFrozenAccountSchema).min(1),
+});
+export const WeeklyParlaySubjectsSchema = z
+  .array(WeeklyParlaySubjectSchema)
+  .min(1)
+  .max(5);
+export type WeeklyParlaySubject = z.infer<typeof WeeklyParlaySubjectSchema>;
+
+export const WeeklyParlayAggregateMetricSchema = z.enum([
+  "games",
+  "wins",
+  "kills",
+  "deaths",
+  "assists",
+  "champion_damage",
+  "creep_score",
+  "gold",
+  "vision_score",
+  "time_played",
+  "distinct_champions",
+  "distinct_roles",
+  "longest_win_streak",
+  "best_game_kills",
+  "best_game_assists",
+  "best_game_damage",
+]);
+export const WeeklyParlayRateMetricSchema = z.enum([
+  "win_rate_bps",
+  "average_kills_x100",
+  "average_deaths_x100",
+  "average_assists_x100",
+  "average_kda_x100",
+  "average_champion_damage",
+  "average_vision_score_x100",
+]);
+export const WeeklyParlayNumericOperatorSchema = z.enum(["gte", "lte", "eq"]);
+
+const WeeklyParlayAggregateShapeSchema = z.strictObject({
+  kind: z.literal("aggregate"),
+  subject: WeeklyParlaySubjectKeySchema,
+  metric: WeeklyParlayAggregateMetricSchema,
+  operator: WeeklyParlayNumericOperatorSchema,
+});
+const WeeklyParlayRateShapeSchema = z.strictObject({
+  kind: z.literal("rate"),
+  subject: WeeklyParlaySubjectKeySchema,
+  metric: WeeklyParlayRateMetricSchema,
+  operator: WeeklyParlayNumericOperatorSchema,
+});
+const WeeklyParlayChampionShapeSchema = z.strictObject({
+  kind: z.literal("champion_games"),
+  subject: WeeklyParlaySubjectKeySchema,
+  champion: z.string().min(1).max(50),
+  winsOnly: z.boolean(),
+  operator: WeeklyParlayNumericOperatorSchema,
+});
+const WeeklyParlayRoleShapeSchema = z.strictObject({
+  kind: z.literal("role_games"),
+  subject: WeeklyParlaySubjectKeySchema,
+  role: WeeklyParlayRoleSchema,
+  winsOnly: z.boolean(),
+  operator: WeeklyParlayNumericOperatorSchema,
+});
+export const WeeklyParlayLegShapeSchema = z.discriminatedUnion("kind", [
+  WeeklyParlayAggregateShapeSchema,
+  WeeklyParlayRateShapeSchema,
+  WeeklyParlayChampionShapeSchema,
+  WeeklyParlayRoleShapeSchema,
+]);
+export type WeeklyParlayLegShape = z.infer<typeof WeeklyParlayLegShapeSchema>;
+
+function weeklyParlayLegTargetKey(leg: WeeklyParlayLegShape): string {
+  switch (leg.kind) {
+    case "aggregate":
+    case "rate":
+      return `${leg.subject}:${leg.kind}:${leg.metric}`;
+    case "champion_games":
+      return `${leg.subject}:${leg.kind}:${leg.champion}:${String(leg.winsOnly)}`;
+    case "role_games":
+      return `${leg.subject}:${leg.kind}:${leg.role}:${String(leg.winsOnly)}`;
+  }
+}
+
+function rejectDuplicateLegTargets(
+  legs: readonly WeeklyParlayLegShape[],
+  context: z.RefinementCtx,
+): void {
+  const seen = new Set<string>();
+  for (const [index, leg] of legs.entries()) {
+    const key = weeklyParlayLegTargetKey(leg);
+    if (seen.has(key)) {
+      context.addIssue({
+        code: "custom",
+        path: [index],
+        message: `Duplicate weekly parlay target ${key}.`,
+      });
+    }
+    seen.add(key);
+  }
+}
+
+export const WeeklyParlayProposalSchema = z.strictObject({
+  version: z.literal(WEEKLY_PARLAY_SCHEMA_VERSION),
+  legs: z
+    .array(WeeklyParlayLegShapeSchema)
+    .min(WEEKLY_PARLAY_MIN_LEGS)
+    .max(WEEKLY_PARLAY_MAX_LEGS)
+    .superRefine(rejectDuplicateLegTargets),
+});
+export type WeeklyParlayProposal = z.infer<typeof WeeklyParlayProposalSchema>;
+
+export const WeeklyParlayLegSchema = z
+  .discriminatedUnion("kind", [
+    WeeklyParlayAggregateShapeSchema.extend({
+      threshold: z.number().int().nonnegative(),
+    }),
+    WeeklyParlayRateShapeSchema.extend({
+      threshold: z.number().int().nonnegative(),
+    }),
+    WeeklyParlayChampionShapeSchema.extend({
+      threshold: z.number().int().nonnegative(),
+    }),
+    WeeklyParlayRoleShapeSchema.extend({
+      threshold: z.number().int().nonnegative(),
+    }),
+  ])
+  .superRefine((leg, context) => {
+    if (
+      leg.kind === "aggregate" &&
+      leg.metric === "games" &&
+      leg.operator === "gte" &&
+      leg.threshold === 0
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["threshold"],
+        message: "A participation threshold must require at least one game.",
+      });
+    }
+  });
+export type WeeklyParlayLeg = z.infer<typeof WeeklyParlayLegSchema>;
+export const WeeklyParlayDefinitionCriteriaSchema = z.strictObject({
+  version: z.literal(WEEKLY_PARLAY_SCHEMA_VERSION),
+  legs: z
+    .array(WeeklyParlayLegSchema)
+    .min(WEEKLY_PARLAY_MIN_LEGS)
+    .max(WEEKLY_PARLAY_MAX_LEGS)
+    .superRefine(rejectDuplicateLegTargets),
+});
+export type WeeklyParlayDefinitionCriteria = z.infer<
+  typeof WeeklyParlayDefinitionCriteriaSchema
+>;
+
+export const WeeklyParlayContributionSnapshotSchema = z.strictObject({
+  subject: WeeklyParlaySubjectKeySchema,
+  puuid: LeaguePuuidSchema,
+  queue: WeeklyParlayEligibleQueueSchema,
+  completedAt: z.iso.datetime(),
+  win: z.boolean(),
+  champion: z.string().min(1).max(50),
+  role: WeeklyParlayRoleSchema,
+  kills: z.number().int().nonnegative(),
+  deaths: z.number().int().nonnegative(),
+  assists: z.number().int().nonnegative(),
+  championDamage: z.number().int().nonnegative(),
+  creepScore: z.number().int().nonnegative(),
+  gold: z.number().int().nonnegative(),
+  visionScore: z.number().int().nonnegative(),
+  timePlayed: z.number().int().nonnegative(),
+});
+export type WeeklyParlayContributionSnapshot = z.infer<
+  typeof WeeklyParlayContributionSnapshotSchema
+>;
+
+export function validateWeeklyParlayProposal(input: {
+  proposal: WeeklyParlayProposal;
+  subjects: readonly WeeklyParlaySubject[];
+  observedChampions: ReadonlyMap<string, ReadonlySet<string>>;
+  observedRoles: ReadonlyMap<string, ReadonlySet<string>>;
+}): string[] {
+  const issues: string[] = [];
+  const subjectKeys = new Set(input.subjects.map((subject) => subject.key));
+  for (const subject of input.subjects) {
+    const subjectLegs = input.proposal.legs.filter(
+      (leg) => leg.subject === subject.key,
+    );
+    if (subjectLegs.length === 0) {
+      issues.push(`Subject ${subject.key} has no leg.`);
+    }
+    if (
+      !subjectLegs.some(
+        (leg) =>
+          leg.kind === "aggregate" &&
+          leg.metric === "games" &&
+          leg.operator === "gte",
+      )
+    ) {
+      issues.push(
+        `Subject ${subject.key} needs a visible games participation leg.`,
+      );
+    }
+  }
+  for (const leg of input.proposal.legs) {
+    if (!subjectKeys.has(leg.subject)) {
+      issues.push(`Leg references unknown subject ${leg.subject}.`);
+    }
+    if (
+      leg.kind === "champion_games" &&
+      input.observedChampions.get(leg.subject)?.has(leg.champion) !== true
+    ) {
+      issues.push(
+        `${leg.champion} was not historically observed for ${leg.subject}.`,
+      );
+    }
+    if (
+      leg.kind === "role_games" &&
+      input.observedRoles.get(leg.subject)?.has(leg.role) !== true
+    ) {
+      issues.push(
+        `${leg.role} was not historically observed for ${leg.subject}.`,
+      );
+    }
+  }
+  return issues;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "vitest";
+import {
+  WEEKLY_PARLAY_SCHEMA_VERSION,
+  WeeklyParlayContributionSnapshotSchema,
+  type WeeklyParlayDefinitionCriteria,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { evaluateWeeklyParlay } from "#src/betting/weekly-parlay-evaluator.ts";
+
+function contribution(input: {
+  puuid: string;
+  completedAt: string;
+  win: boolean;
+  champion?: string;
+  kills?: number;
+  deaths?: number;
+  damage?: number;
+}) {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: "P1",
+    puuid: input.puuid,
+    queue: "solo",
+    completedAt: input.completedAt,
+    win: input.win,
+    champion: input.champion ?? "Ahri",
+    role: "MIDDLE",
+    kills: input.kills ?? 3,
+    deaths: input.deaths ?? 2,
+    assists: 5,
+    championDamage: input.damage ?? 20_000,
+    creepScore: 200,
+    gold: 12_000,
+    visionScore: 20,
+    timePlayed: 1800,
+  });
+}
+
+describe("weekly parlay evaluator", () => {
+  test("aggregates every frozen account and can prove monotonic YES early", () => {
+    const criteria: WeeklyParlayDefinitionCriteria = {
+      version: WEEKLY_PARLAY_SCHEMA_VERSION,
+      legs: [
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "games",
+          operator: "gte",
+          threshold: 2,
+        },
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "wins",
+          operator: "gte",
+          threshold: 2,
+        },
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "champion_damage",
+          operator: "gte",
+          threshold: 30_000,
+        },
+      ],
+    };
+    const result = evaluateWeeklyParlay(criteria, [
+      contribution({
+        puuid: "a".repeat(78),
+        completedAt: "2026-08-24T10:00:00.000Z",
+        win: true,
+      }),
+      contribution({
+        puuid: "b".repeat(78),
+        completedAt: "2026-08-25T10:00:00.000Z",
+        win: true,
+      }),
+    ]);
+    expect(result.yesResult).toBe(true);
+    expect(result.irreversiblyYes).toBe(true);
+  });
+
+  test("keeps rate and upper-bound legs final-only", () => {
+    const result = evaluateWeeklyParlay(
+      {
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+            threshold: 1,
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "deaths",
+            operator: "lte",
+            threshold: 3,
+          },
+          {
+            kind: "rate",
+            subject: "P1",
+            metric: "win_rate_bps",
+            operator: "gte",
+            threshold: 5000,
+          },
+        ],
+      },
+      [
+        contribution({
+          puuid: "a".repeat(78),
+          completedAt: "2026-08-24T10:00:00.000Z",
+          win: true,
+        }),
+      ],
+    );
+    expect(result.yesResult).toBe(true);
+    expect(result.irreversiblyYes).toBe(false);
+    expect(result.legs.map((leg) => leg.irreversiblyPassed)).toEqual([
+      true,
+      false,
+      false,
+    ]);
+  });
+
+  test("zero games is an ordinary evaluated result", () => {
+    const result = evaluateWeeklyParlay(
+      {
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+            threshold: 1,
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "wins",
+            operator: "gte",
+            threshold: 1,
+          },
+          {
+            kind: "rate",
+            subject: "P1",
+            metric: "win_rate_bps",
+            operator: "gte",
+            threshold: 5000,
+          },
+        ],
+      },
+      [],
+    );
+    expect(result.yesResult).toBe(false);
+    expect(result.legs.map((leg) => leg.current)).toEqual([0, 0, 0]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.ts
@@ -1,0 +1,223 @@
+import type {
+  WeeklyParlayContributionSnapshot,
+  WeeklyParlayDefinitionCriteria,
+  WeeklyParlayLeg,
+  WeeklyParlayLegShape,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { WeeklyParlayDefinitionCriteriaSchema } from "#src/betting/weekly-parlay-criteria.ts";
+
+export type WeeklyParlayLegResult = {
+  leg: WeeklyParlayLeg;
+  current: number;
+  passed: boolean;
+  irreversiblyPassed: boolean;
+};
+
+export type WeeklyParlayEvaluation = {
+  legs: WeeklyParlayLegResult[];
+  yesResult: boolean;
+  irreversiblyYes: boolean;
+};
+
+function numericComparison(
+  value: number,
+  operator: WeeklyParlayLeg["operator"],
+  threshold: number,
+): boolean {
+  switch (operator) {
+    case "gte":
+      return value >= threshold;
+    case "lte":
+      return value <= threshold;
+    case "eq":
+      return value === threshold;
+  }
+}
+
+function sum(
+  contributions: readonly WeeklyParlayContributionSnapshot[],
+  value: (contribution: WeeklyParlayContributionSnapshot) => number,
+): number {
+  return contributions.reduce(
+    (total, contribution) => total + value(contribution),
+    0,
+  );
+}
+
+function maximum(
+  contributions: readonly WeeklyParlayContributionSnapshot[],
+  value: (contribution: WeeklyParlayContributionSnapshot) => number,
+): number {
+  return contributions.reduce(
+    (current, contribution) => Math.max(current, value(contribution)),
+    0,
+  );
+}
+
+function longestWinStreak(
+  contributions: readonly WeeklyParlayContributionSnapshot[],
+): number {
+  const ordered = contributions.toSorted((left, right) =>
+    left.completedAt.localeCompare(right.completedAt),
+  );
+  let current = 0;
+  let longest = 0;
+  for (const contribution of ordered) {
+    current = contribution.win ? current + 1 : 0;
+    longest = Math.max(longest, current);
+  }
+  return longest;
+}
+
+function aggregateValue(
+  leg: Extract<WeeklyParlayLegShape, { kind: "aggregate" }>,
+  contributions: readonly WeeklyParlayContributionSnapshot[],
+): number {
+  switch (leg.metric) {
+    case "games":
+      return contributions.length;
+    case "wins":
+      return contributions.filter((contribution) => contribution.win).length;
+    case "kills":
+      return sum(contributions, (contribution) => contribution.kills);
+    case "deaths":
+      return sum(contributions, (contribution) => contribution.deaths);
+    case "assists":
+      return sum(contributions, (contribution) => contribution.assists);
+    case "champion_damage":
+      return sum(contributions, (contribution) => contribution.championDamage);
+    case "creep_score":
+      return sum(contributions, (contribution) => contribution.creepScore);
+    case "gold":
+      return sum(contributions, (contribution) => contribution.gold);
+    case "vision_score":
+      return sum(contributions, (contribution) => contribution.visionScore);
+    case "time_played":
+      return sum(contributions, (contribution) => contribution.timePlayed);
+    case "distinct_champions":
+      return new Set(contributions.map((contribution) => contribution.champion))
+        .size;
+    case "distinct_roles":
+      return new Set(contributions.map((contribution) => contribution.role))
+        .size;
+    case "longest_win_streak":
+      return longestWinStreak(contributions);
+    case "best_game_kills":
+      return maximum(contributions, (contribution) => contribution.kills);
+    case "best_game_assists":
+      return maximum(contributions, (contribution) => contribution.assists);
+    case "best_game_damage":
+      return maximum(
+        contributions,
+        (contribution) => contribution.championDamage,
+      );
+  }
+}
+
+function average(total: number, count: number): number {
+  return count === 0 ? 0 : Math.round(total / count);
+}
+
+function rateValue(
+  leg: Extract<WeeklyParlayLegShape, { kind: "rate" }>,
+  contributions: readonly WeeklyParlayContributionSnapshot[],
+): number {
+  const games = contributions.length;
+  switch (leg.metric) {
+    case "win_rate_bps":
+      return games === 0
+        ? 0
+        : Math.round(
+            (contributions.filter((contribution) => contribution.win).length *
+              10_000) /
+              games,
+          );
+    case "average_kills_x100":
+      return average(
+        sum(contributions, (contribution) => contribution.kills) * 100,
+        games,
+      );
+    case "average_deaths_x100":
+      return average(
+        sum(contributions, (contribution) => contribution.deaths) * 100,
+        games,
+      );
+    case "average_assists_x100":
+      return average(
+        sum(contributions, (contribution) => contribution.assists) * 100,
+        games,
+      );
+    case "average_kda_x100": {
+      const killsAndAssists = sum(
+        contributions,
+        (contribution) => contribution.kills + contribution.assists,
+      );
+      const deaths = sum(contributions, (contribution) => contribution.deaths);
+      return games === 0
+        ? 0
+        : Math.round((killsAndAssists * 100) / Math.max(1, deaths));
+    }
+    case "average_champion_damage":
+      return average(
+        sum(contributions, (contribution) => contribution.championDamage),
+        games,
+      );
+    case "average_vision_score_x100":
+      return average(
+        sum(contributions, (contribution) => contribution.visionScore) * 100,
+        games,
+      );
+  }
+}
+
+export function weeklyParlayLegValue(
+  leg: WeeklyParlayLegShape,
+  allContributions: readonly WeeklyParlayContributionSnapshot[],
+): number {
+  const contributions = allContributions.filter(
+    (contribution) => contribution.subject === leg.subject,
+  );
+  switch (leg.kind) {
+    case "aggregate":
+      return aggregateValue(leg, contributions);
+    case "rate":
+      return rateValue(leg, contributions);
+    case "champion_games":
+      return contributions.filter(
+        (contribution) =>
+          contribution.champion === leg.champion &&
+          (!leg.winsOnly || contribution.win),
+      ).length;
+    case "role_games":
+      return contributions.filter(
+        (contribution) =>
+          contribution.role === leg.role && (!leg.winsOnly || contribution.win),
+      ).length;
+  }
+}
+
+function isMonotonicGte(leg: WeeklyParlayLeg): boolean {
+  return leg.operator === "gte" && leg.kind !== "rate";
+}
+
+export function evaluateWeeklyParlay(
+  criteriaInput: WeeklyParlayDefinitionCriteria,
+  contributions: readonly WeeklyParlayContributionSnapshot[],
+): WeeklyParlayEvaluation {
+  const criteria = WeeklyParlayDefinitionCriteriaSchema.parse(criteriaInput);
+  const legs = criteria.legs.map((leg) => {
+    const current = weeklyParlayLegValue(leg, contributions);
+    const passed = numericComparison(current, leg.operator, leg.threshold);
+    return {
+      leg,
+      current,
+      passed,
+      irreversiblyPassed: passed && isMonotonicGte(leg),
+    };
+  });
+  return {
+    legs,
+    yesResult: legs.every((leg) => leg.passed),
+    irreversiblyYes: legs.every((leg) => leg.irreversiblyPassed),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import {
+  isWithinWeeklyScoringPeriod,
+  weeklyParlayPeriod,
+} from "#src/betting/weekly-parlay-period.ts";
+
+describe("weekly parlay Pacific periods", () => {
+  test("uses wall time across the spring DST transition", () => {
+    const period = weeklyParlayPeriod("2026-03-09");
+    expect(period.openAt.toISOString()).toBe("2026-03-08T19:00:00.000Z");
+    expect(period.scoringStartsAt.toISOString()).toBe(
+      "2026-03-09T07:00:00.000Z",
+    );
+    expect(period.scoringEndsAt.toISOString()).toBe("2026-03-15T18:00:00.000Z");
+    expect(period.nextOpenAt.toISOString()).toBe("2026-03-15T19:00:00.000Z");
+    expect(period.updateAt).toHaveLength(6);
+  });
+
+  test("uses wall time across the fall DST transition", () => {
+    const period = weeklyParlayPeriod("2026-11-02");
+    expect(period.openAt.toISOString()).toBe("2026-11-01T20:00:00.000Z");
+    expect(period.scoringStartsAt.toISOString()).toBe(
+      "2026-11-02T08:00:00.000Z",
+    );
+    expect(period.scoringEndsAt.toISOString()).toBe("2026-11-08T19:00:00.000Z");
+    expect(period.nextOpenAt.getTime() - period.scoringEndsAt.getTime()).toBe(
+      60 * 60 * 1000,
+    );
+  });
+
+  test("enforces half-open completion boundaries", () => {
+    const period = weeklyParlayPeriod("2026-08-24");
+    expect(isWithinWeeklyScoringPeriod(period.scoringStartsAt, period)).toBe(
+      true,
+    );
+    expect(
+      isWithinWeeklyScoringPeriod(
+        new Date(period.scoringEndsAt.getTime() - 1),
+        period,
+      ),
+    ).toBe(true);
+    expect(isWithinWeeklyScoringPeriod(period.scoringEndsAt, period)).toBe(
+      false,
+    );
+  });
+
+  test("rejects a non-Monday period key", () => {
+    expect(() => weeklyParlayPeriod("2026-08-23")).toThrow("must be a Monday");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts
@@ -1,0 +1,136 @@
+import { addDays, formatISO, parseISO } from "date-fns";
+
+export const WEEKLY_PARLAY_TIMEZONE = "America/Los_Angeles";
+export const WEEKLY_PARLAY_SLOT = 0;
+export const WEEKLY_PARLAY_OPEN_HOUR = 12;
+export const WEEKLY_PARLAY_BETTING_CLOSE_HOUR = 0;
+export const WEEKLY_PARLAY_FINAL_HOUR = 11;
+export const WEEKLY_PARLAY_UPDATE_HOUR = 19;
+export const WEEKLY_PARLAY_UPDATE_COUNT = 6;
+
+export type WeeklyParlayPeriod = {
+  periodKey: string;
+  openAt: Date;
+  reminderAt: Date;
+  bettingClosesAt: Date;
+  scoringStartsAt: Date;
+  updateAt: Date[];
+  scoringEndsAt: Date;
+  nextOpenAt: Date;
+};
+
+function calendarDate(date: Date): string {
+  return formatISO(date, { representation: "date" });
+}
+
+function requiredPart(
+  parts: ReadonlyMap<string, number>,
+  key: "year" | "month" | "day" | "hour" | "minute" | "second",
+): number {
+  const value = parts.get(key);
+  if (value === undefined) {
+    throw new Error(`Missing ${key} timezone part.`);
+  }
+  return value;
+}
+
+/** Resolve a local Pacific wall time without assuming a fixed UTC offset. */
+export function pacificWallTime(date: string, hour: number): Date {
+  const match = /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})$/u.exec(date);
+  const groups = match?.groups;
+  if (
+    groups === undefined ||
+    !Number.isInteger(hour) ||
+    hour < 0 ||
+    hour > 23
+  ) {
+    throw new Error(`Invalid Pacific wall time ${date} ${hour.toString()}:00.`);
+  }
+  const target = {
+    year: Number(groups["year"]),
+    month: Number(groups["month"]),
+    day: Number(groups["day"]),
+    hour,
+  };
+  let timestamp = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+  );
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: WEEKLY_PARLAY_TIMEZONE,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  for (let iteration = 0; iteration < 3; iteration++) {
+    const parts = new Map(
+      formatter
+        .formatToParts(new Date(timestamp))
+        .filter((part) => part.type !== "literal")
+        .map((part) => [part.type, Number(part.value)]),
+    );
+    const actualTimestamp = Date.UTC(
+      requiredPart(parts, "year"),
+      requiredPart(parts, "month") - 1,
+      requiredPart(parts, "day"),
+      requiredPart(parts, "hour"),
+      requiredPart(parts, "minute"),
+      requiredPart(parts, "second"),
+    );
+    const targetTimestamp = Date.UTC(
+      target.year,
+      target.month - 1,
+      target.day,
+      target.hour,
+    );
+    timestamp += targetTimestamp - actualTimestamp;
+  }
+  return new Date(timestamp);
+}
+
+function offsetDate(periodKey: string, days: number): string {
+  return calendarDate(addDays(parseISO(periodKey), days));
+}
+
+/** Build the immutable clocks for a scoring period identified by its Monday. */
+export function weeklyParlayPeriod(periodKey: string): WeeklyParlayPeriod {
+  const monday = parseISO(periodKey);
+  if (Number.isNaN(monday.getTime()) || monday.getDay() !== 1) {
+    throw new Error(`Weekly parlay period ${periodKey} must be a Monday.`);
+  }
+  const openDate = offsetDate(periodKey, -1);
+  const finalDate = offsetDate(periodKey, 6);
+  return {
+    periodKey,
+    openAt: pacificWallTime(openDate, WEEKLY_PARLAY_OPEN_HOUR),
+    reminderAt: pacificWallTime(openDate, WEEKLY_PARLAY_UPDATE_HOUR),
+    bettingClosesAt: pacificWallTime(
+      periodKey,
+      WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
+    ),
+    scoringStartsAt: pacificWallTime(
+      periodKey,
+      WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
+    ),
+    updateAt: Array.from({ length: WEEKLY_PARLAY_UPDATE_COUNT }, (_, index) =>
+      pacificWallTime(offsetDate(periodKey, index), WEEKLY_PARLAY_UPDATE_HOUR),
+    ),
+    scoringEndsAt: pacificWallTime(finalDate, WEEKLY_PARLAY_FINAL_HOUR),
+    nextOpenAt: pacificWallTime(finalDate, WEEKLY_PARLAY_OPEN_HOUR),
+  };
+}
+
+export function isWithinWeeklyScoringPeriod(
+  completedAt: Date,
+  period: Pick<WeeklyParlayPeriod, "scoringStartsAt" | "scoringEndsAt">,
+): boolean {
+  return (
+    completedAt >= period.scoringStartsAt && completedAt < period.scoringEndsAt
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+import {
+  WEEKLY_PARLAY_SCHEMA_VERSION,
+  WeeklyParlayContributionSnapshotSchema,
+  type WeeklyParlayProposal,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  priceWeeklyParlay,
+  type WeeklyParlayReplayWindow,
+} from "#src/betting/weekly-parlay-pricing.ts";
+
+const proposal: WeeklyParlayProposal = {
+  version: WEEKLY_PARLAY_SCHEMA_VERSION,
+  legs: [
+    { kind: "aggregate", subject: "P1", metric: "games", operator: "gte" },
+    { kind: "aggregate", subject: "P1", metric: "wins", operator: "gte" },
+    {
+      kind: "aggregate",
+      subject: "P1",
+      metric: "champion_damage",
+      operator: "gte",
+    },
+  ],
+};
+
+function windows(count: number): WeeklyParlayReplayWindow[] {
+  return Array.from({ length: count }, (_window, windowIndex) => ({
+    periodKey: `window-${windowIndex.toString().padStart(2, "0")}`,
+    contributions:
+      windowIndex % 4 === 0
+        ? []
+        : Array.from({ length: (windowIndex % 5) + 1 }, (_game, gameIndex) =>
+            WeeklyParlayContributionSnapshotSchema.parse({
+              subject: "P1",
+              puuid: gameIndex % 2 === 0 ? "a".repeat(78) : "b".repeat(78),
+              queue: gameIndex % 3 === 0 ? "ranked 5s" : "solo",
+              completedAt: new Date(
+                Date.UTC(2025, 0, 1 + windowIndex, gameIndex),
+              ).toISOString(),
+              win: (windowIndex + gameIndex) % 2 === 0,
+              champion: "Ahri",
+              role: "MIDDLE",
+              kills: 3,
+              deaths: 2,
+              assists: 5,
+              championDamage: 10_000 + windowIndex * 1000,
+              creepScore: 200,
+              gold: 12_000,
+              visionScore: 20,
+              timePlayed: 1800,
+            }),
+          ),
+  }));
+}
+
+describe("weekly parlay replay pricing", () => {
+  test("jointly replays aligned windows including zero-game weeks", () => {
+    const first = priceWeeklyParlay({ proposal, windows: windows(20) });
+    const second = priceWeeklyParlay({ proposal, windows: windows(20) });
+    expect(first).toEqual(second);
+    expect(first?.sampleSize).toBe(20);
+    expect(first?.periodKeys).toContain("window-00");
+    expect(first?.yesProbabilityBps).toBeGreaterThanOrEqual(4000);
+    expect(first?.yesProbabilityBps).toBeLessThanOrEqual(6000);
+    expect(first?.criteria.legs[0]?.threshold).toBeGreaterThan(0);
+  });
+
+  test("rejects a market when history only offers zero participation", () => {
+    expect(
+      priceWeeklyParlay({
+        proposal,
+        windows: windows(20).map((window) => ({
+          ...window,
+          contributions: [],
+        })),
+      }),
+    ).toBeUndefined();
+  });
+
+  test("rejects an under-covered history sample", () => {
+    expect(
+      priceWeeklyParlay({ proposal, windows: windows(14) }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.ts
@@ -1,0 +1,152 @@
+import {
+  WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS,
+  WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
+  WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS,
+  WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
+  type WeeklyParlayContributionSnapshot,
+  type WeeklyParlayDefinitionCriteria,
+  type WeeklyParlayLeg,
+  type WeeklyParlayLegShape,
+  type WeeklyParlayProposal,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  evaluateWeeklyParlay,
+  weeklyParlayLegValue,
+} from "#src/betting/weekly-parlay-evaluator.ts";
+
+const MAX_THRESHOLD_CANDIDATES_PER_LEG = 7;
+
+export type WeeklyParlayReplayWindow = {
+  periodKey: string;
+  contributions: WeeklyParlayContributionSnapshot[];
+};
+
+export type WeeklyParlayPricing = {
+  criteria: WeeklyParlayDefinitionCriteria;
+  yesProbabilityBps: number;
+  yesWindows: number;
+  sampleSize: number;
+  periodKeys: string[];
+};
+
+function stableThresholdCandidates(values: readonly number[]): number[] {
+  const unique = [...new Set(values)].toSorted((left, right) => left - right);
+  if (unique.length <= MAX_THRESHOLD_CANDIDATES_PER_LEG) {
+    return unique;
+  }
+  return [
+    ...new Set(
+      Array.from({ length: MAX_THRESHOLD_CANDIDATES_PER_LEG }, (_, index) => {
+        const position = Math.round(
+          (index * (unique.length - 1)) /
+            (MAX_THRESHOLD_CANDIDATES_PER_LEG - 1),
+        );
+        const value = unique[position];
+        if (value === undefined) {
+          throw new Error("Threshold candidate selection exceeded its input.");
+        }
+        return value;
+      }),
+    ),
+  ];
+}
+
+function legWithThreshold(
+  shape: WeeklyParlayLegShape,
+  threshold: number,
+): WeeklyParlayLeg {
+  return { ...shape, threshold };
+}
+
+function thresholdCombinations(candidates: readonly number[][]): number[][] {
+  let combinations: number[][] = [[]];
+  for (const legCandidates of candidates) {
+    combinations = combinations.flatMap((combination) =>
+      legCandidates.map((candidate) => [...combination, candidate]),
+    );
+  }
+  return combinations;
+}
+
+function thresholdTieKey(thresholds: readonly number[]): string {
+  return thresholds
+    .map((threshold) => threshold.toString().padStart(12, "0"))
+    .join(":");
+}
+
+export function priceWeeklyParlay(input: {
+  proposal: WeeklyParlayProposal;
+  windows: readonly WeeklyParlayReplayWindow[];
+}): WeeklyParlayPricing | undefined {
+  if (input.windows.length < WEEKLY_PARLAY_MIN_HISTORY_WINDOWS) {
+    return;
+  }
+  const candidates = input.proposal.legs.map((leg) =>
+    stableThresholdCandidates(
+      input.windows.map((window) =>
+        weeklyParlayLegValue(leg, window.contributions),
+      ),
+    ).filter(
+      (threshold) =>
+        !(
+          leg.kind === "aggregate" &&
+          leg.metric === "games" &&
+          leg.operator === "gte"
+        ) || threshold > 0,
+    ),
+  );
+  const priced = thresholdCombinations(candidates).flatMap((thresholds) => {
+    const legs = input.proposal.legs.map((shape, index) => {
+      const threshold = thresholds[index];
+      if (threshold === undefined) {
+        throw new Error("Missing deterministic threshold candidate.");
+      }
+      return legWithThreshold(shape, threshold);
+    });
+    const criteria: WeeklyParlayDefinitionCriteria = {
+      version: input.proposal.version,
+      legs,
+    };
+    const yesWindows = input.windows.filter(
+      (window) =>
+        evaluateWeeklyParlay(criteria, window.contributions).yesResult,
+    ).length;
+    const yesProbabilityBps = Math.round(
+      (yesWindows * 10_000) / input.windows.length,
+    );
+    if (
+      yesProbabilityBps < WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS ||
+      yesProbabilityBps > WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS
+    ) {
+      return [];
+    }
+    return [
+      {
+        criteria,
+        yesProbabilityBps,
+        yesWindows,
+        sampleSize: input.windows.length,
+        periodKeys: input.windows.map((window) => window.periodKey),
+        targetDistance: Math.abs(
+          yesProbabilityBps - WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
+        ),
+        tieKey: thresholdTieKey(thresholds),
+      },
+    ];
+  });
+  const selected = priced.toSorted(
+    (left, right) =>
+      left.targetDistance - right.targetDistance ||
+      left.tieKey.localeCompare(right.tieKey),
+  )[0];
+  if (selected === undefined) {
+    return;
+  }
+  return {
+    criteria: selected.criteria,
+    yesProbabilityBps: selected.yesProbabilityBps,
+    yesWindows: selected.yesWindows,
+    sampleSize: selected.sampleSize,
+    periodKeys: selected.periodKeys,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import { orderWeeklyParlayCandidates } from "#src/betting/weekly-parlay-selection.ts";
+
+describe("weekly parlay candidate selection", () => {
+  test("applies activity, coverage, membership, and cooldown gates", () => {
+    const ordered = orderWeeklyParlayCandidates([
+      {
+        playerId: 5,
+        linkedGuildMember: true,
+        recentEligibleGames: 5,
+        fullyObservedWindows: 20,
+        periodsSinceFeatured: null,
+      },
+      {
+        playerId: 3,
+        linkedGuildMember: true,
+        recentEligibleGames: 7,
+        fullyObservedWindows: 20,
+        periodsSinceFeatured: 8,
+      },
+      {
+        playerId: 2,
+        linkedGuildMember: true,
+        recentEligibleGames: 8,
+        fullyObservedWindows: 20,
+        periodsSinceFeatured: 3,
+      },
+      {
+        playerId: 1,
+        linkedGuildMember: false,
+        recentEligibleGames: 20,
+        fullyObservedWindows: 52,
+        periodsSinceFeatured: null,
+      },
+    ]);
+    expect(ordered.map((candidate) => candidate.playerId)).toEqual([5, 3]);
+  });
+
+  test("breaks ties by recent games then stable player ID", () => {
+    const ordered = orderWeeklyParlayCandidates([
+      {
+        playerId: 4,
+        linkedGuildMember: true,
+        recentEligibleGames: 5,
+        fullyObservedWindows: 15,
+        periodsSinceFeatured: 6,
+      },
+      {
+        playerId: 2,
+        linkedGuildMember: true,
+        recentEligibleGames: 5,
+        fullyObservedWindows: 15,
+        periodsSinceFeatured: 6,
+      },
+      {
+        playerId: 3,
+        linkedGuildMember: true,
+        recentEligibleGames: 6,
+        fullyObservedWindows: 15,
+        periodsSinceFeatured: 6,
+      },
+    ]);
+    expect(ordered.map((candidate) => candidate.playerId)).toEqual([3, 2, 4]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.ts
@@ -1,0 +1,38 @@
+import {
+  WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS,
+  WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
+  WEEKLY_PARLAY_MIN_RECENT_GAMES,
+} from "#src/betting/weekly-parlay-criteria.ts";
+
+export type WeeklyParlayCandidate = {
+  playerId: number;
+  linkedGuildMember: boolean;
+  recentEligibleGames: number;
+  fullyObservedWindows: number;
+  periodsSinceFeatured: number | null;
+};
+
+export function orderWeeklyParlayCandidates(
+  candidates: readonly WeeklyParlayCandidate[],
+): WeeklyParlayCandidate[] {
+  return candidates
+    .filter(
+      (candidate) =>
+        candidate.linkedGuildMember &&
+        candidate.recentEligibleGames >= WEEKLY_PARLAY_MIN_RECENT_GAMES &&
+        candidate.fullyObservedWindows >= WEEKLY_PARLAY_MIN_HISTORY_WINDOWS &&
+        (candidate.periodsSinceFeatured === null ||
+          candidate.periodsSinceFeatured >=
+            WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS),
+    )
+    .toSorted((left, right) => {
+      const leftPeriods = left.periodsSinceFeatured ?? Number.MAX_SAFE_INTEGER;
+      const rightPeriods =
+        right.periodsSinceFeatured ?? Number.MAX_SAFE_INTEGER;
+      return (
+        rightPeriods - leftPeriods ||
+        right.recentEligibleGames - left.recentEligibleGames ||
+        left.playerId - right.playerId
+      );
+    });
+}

--- a/packages/scout-for-lol/packages/backend/src/database/legacy-import/models-part-3.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/legacy-import/models-part-3.ts
@@ -335,6 +335,10 @@ export const IMPORT_MODELS_PART_3: ImportModelSpec[] = [
       matchId: toStrOrNull(row, "matchId"),
       betId: toIntOrNull(row, "betId"),
       parlayBetId: toIntOrNullIfMissing(row, "parlayBetId"),
+      // Weekly parlays did not exist in the legacy SQLite deployment. Include
+      // the post-cutover nullable column in the canonical digest material so
+      // verification compares the imported row to its full Postgres shape.
+      weeklyParlayBetId: null,
       predictedTeamId: toIntOrNull(row, "predictedTeamId"),
       actualWinningTeamId: toIntOrNull(row, "actualWinningTeamId"),
       context: toStr(row, "context"),

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -66,6 +66,11 @@ export const BucksLedgerKindSchema = z.enum([
   "parlay_payout",
   "parlay_refund",
   "parlay_release",
+  "weekly_parlay_stake",
+  "weekly_parlay_reserve",
+  "weekly_parlay_payout",
+  "weekly_parlay_refund",
+  "weekly_parlay_release",
   "peek_pass",
   "adjustment",
 ]);
@@ -109,6 +114,28 @@ export const BucksParlayVoidReasonSchema = z.enum([
   "missing_data",
   "unknown_evaluator",
   "invalid_definition",
+  "storage_overflow",
+]);
+
+export type BucksWeeklyParlayMarketState = z.infer<
+  typeof BucksWeeklyParlayMarketStateSchema
+>;
+export const BucksWeeklyParlayMarketStateSchema = z.enum([
+  "publishing",
+  "open",
+  "active",
+  "settled",
+  "voided",
+]);
+
+export type BucksWeeklyParlayVoidReason = z.infer<
+  typeof BucksWeeklyParlayVoidReasonSchema
+>;
+export const BucksWeeklyParlayVoidReasonSchema = z.enum([
+  "infrastructure_failure",
+  "unknown_evaluator",
+  "invalid_definition",
+  "missing_data",
   "storage_overflow",
 ]);
 
@@ -394,6 +421,40 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     grossPayout: BucksStakeSchema,
     credited: z.number().int().nonnegative().max(BUCKS_INT32_MAX),
     voidReason: BucksParlayVoidReasonSchema.optional(),
+  }),
+  z.strictObject({
+    type: z.literal("weekly_parlay_stake"),
+    definitionId: z.number().int().positive(),
+    periodKey: z.iso.date(),
+    slot: z.number().int().nonnegative(),
+    side: BucksParlaySideSchema,
+    yesProbabilityBps: z.number().int().min(4000).max(6000),
+    totalStake: BucksStakeSchema,
+    quotedGrossPayout: BucksStakeSchema,
+  }),
+  z.strictObject({
+    type: z.literal("weekly_parlay_reserve"),
+    definitionId: z.number().int().positive(),
+    periodKey: z.iso.date(),
+    slot: z.number().int().nonnegative(),
+    side: BucksParlaySideSchema,
+    yesProbabilityBps: z.number().int().min(4000).max(6000),
+    totalStake: BucksStakeSchema,
+    totalReserve: z.number().int().nonnegative().max(BUCKS_INT32_MAX),
+    quotedGrossPayout: BucksStakeSchema,
+  }),
+  z.strictObject({
+    type: z.literal("weekly_parlay_settlement"),
+    definitionId: z.number().int().positive(),
+    periodKey: z.iso.date(),
+    slot: z.number().int().nonnegative(),
+    side: BucksParlaySideSchema,
+    yesResult: z.boolean().optional(),
+    stake: BucksStakeSchema,
+    reserve: z.number().int().nonnegative().max(BUCKS_INT32_MAX),
+    grossPayout: BucksStakeSchema,
+    credited: z.number().int().nonnegative().max(BUCKS_INT32_MAX),
+    voidReason: BucksWeeklyParlayVoidReasonSchema.optional(),
   }),
   z.strictObject({
     type: z.literal("peek_pass"),


### PR DESCRIPTION
## Why\n\nScout needs week-spanning Bryan Bucks markets whose results remain reproducible after account, alias, model, or catalog changes. Reusing the match-bound tables would make their required match relations nullable and weaken the existing contract.\n\n## What\n\n- add separate immutable weekly definition, market, bet, contribution, and Discord delivery models\n- add weekly-specific audited ledger references, kinds, and versioned contexts\n- compute Sunday-to-Sunday clocks from Pacific wall time across DST\n- freeze multiple subjects and all linked Riot accounts behind closed Zod schemas\n- evaluate aggregate, count, distinct, streak, best-game, rate, average, champion, and role legs deterministically\n- select eligible subjects with membership, activity, history-coverage, cooldown, and stable-order gates\n- search thresholds by jointly replaying aligned weekly windows, including zero-game windows, and reject markets outside the 40–60% empirical YES band\n\nThis is stack 1 of 3 and has no publication path.\n\n## Verification\n\n- focused weekly-parlay Vitest suite: 13 tests passed\n- backend TypeScript typecheck\n- changed-file ESLint: no errors\n- Prisma validate\n- pre-commit safety suite\n- live model generation and Discord delivery: not run in this domain-only branch