### PR TITLE
refactor(scout-for-lol): split the Discord client from its gateway bootstrap to break nine import cycles

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1108,14 +1108,6 @@
       "clones": 1,
       "tokens": 93
     },
-    "packages/scout-for-lol/packages/backend/src/betting/settlement-ledger.ts|packages/scout-for-lol/packages/backend/src/betting/sweep.ts": {
-      "clones": 1,
-      "tokens": 70
-    },
-    "packages/scout-for-lol/packages/backend/src/betting/settlement-ledger.ts|packages/scout-for-lol/packages/backend/src/betting/void-stale.ts": {
-      "clones": 1,
-      "tokens": 107
-    },
     "packages/scout-for-lol/packages/backend/src/betting/sweep.integration.test.ts|packages/scout-for-lol/packages/backend/src/betting/sweep.integration.test.ts": {
       "clones": 1,
       "tokens": 70
@@ -1965,5 +1957,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-24T21:00:53.066Z"
+  "updated": "2026-08-24T23:08:50.755Z"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1237,6 +1237,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@shepherdjerred/architecture": "workspace:*",
         "@types/node": "^26.1.1",
         "@typescript/native": "npm:typescript@7.0.2",
         "@vitest/coverage-istanbul": "4.1.10",

--- a/packages/scout-for-lol/packages/backend/package.json
+++ b/packages/scout-for-lol/packages/backend/package.json
@@ -19,7 +19,7 @@
     "test:ci": "bun ../../../../scripts/run-ci-test.ts",
     "test:fast": "bun --no-install --bun vitest --config ../../../../vitest.config.ts run --bail=3",
     "test:debug": "bun --no-install --bun vitest --config ../../../../vitest.config.ts run --sequence.shuffle",
-    "lint": "bun x eslint src",
+    "lint": "bun x eslint src && check-architecture",
     "format": "bun x prettier --check src",
     "format:write": "bun x prettier --write src",
     "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit",
@@ -89,6 +89,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@shepherdjerred/architecture": "workspace:*",
     "@types/node": "^26.1.1",
     "aws-sdk-client-mock": "^4.1.0",
     "bun-types": "1.4.0",

--- a/packages/scout-for-lol/packages/backend/scripts/outreach.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/outreach.ts
@@ -15,6 +15,7 @@ import {
 } from "@scout-for-lol/data/index.ts";
 import { prisma } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
+import { startDiscordGateway } from "#src/discord/bootstrap.ts";
 import { sendDM } from "#src/discord/utils/dm.ts";
 import { createLogger } from "#src/logger.ts";
 
@@ -297,6 +298,10 @@ async function main(): Promise<void> {
   if (ONLY_USER !== undefined) {
     logger.info(`[Outreach] Targeting only user: ${ONLY_USER}`);
   }
+
+  // This script is a standalone entry point, so it owns connecting the
+  // gateway: importing the client no longer logs in as a side effect.
+  await startDiscordGateway();
 
   // Wait for Discord client to be ready
   if (!client.isReady()) {

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -23,7 +23,7 @@ import { deliverSettlementDms } from "#src/betting/settlement-dm-delivery.ts";
 import { bettingSettlementUndeliverableTotal } from "#src/metrics/betting.ts";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
-import type { ClosedPool } from "#src/betting/sweep.ts";
+import type { ClosedPool } from "#src/betting/sweep-types.ts";
 import { shouldDisplayPrediction } from "#src/betting/prediction.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import {

--- a/packages/scout-for-lol/packages/backend/src/betting/outcome-message.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/outcome-message.ts
@@ -6,8 +6,9 @@ import {
 import type { EarnedAward } from "#src/betting/earnings.ts";
 import { shouldDisplayPrediction } from "#src/betting/prediction.ts";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
-import type { SettlementBet, SettlementSummary } from "#src/betting/settle.ts";
-import type { ClosedPosition } from "#src/betting/sweep.ts";
+import type { SettlementSummary } from "#src/betting/settle.ts";
+import type { SettlementBet } from "#src/betting/settlement-types.ts";
+import type { ClosedPosition } from "#src/betting/sweep-types.ts";
 import type { OutcomeFraming } from "#src/betting/team.ts";
 import {
   formatInteger,

--- a/packages/scout-for-lol/packages/backend/src/betting/postmatch-hook.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/postmatch-hook.ts
@@ -10,10 +10,8 @@ import {
 } from "#src/betting/parlay-settle.ts";
 import { refreshClosedParlayMessages } from "#src/betting/parlay-refresh.ts";
 import { refreshClosedBucksMessages } from "#src/betting/message-refresh.ts";
-import {
-  closeBettingWindowsForMatch,
-  type ClosedPool,
-} from "#src/betting/sweep.ts";
+import { closeBettingWindowsForMatch } from "#src/betting/sweep.ts";
+import type { ClosedPool } from "#src/betting/sweep-types.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isFeatureHardDisabled } from "#src/configuration/flags.ts";
 import { captureWeeklyParlayContributions } from "#src/betting/weekly-parlay-contribution.ts";

--- a/packages/scout-for-lol/packages/backend/src/betting/settle.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settle.ts
@@ -12,10 +12,9 @@ import { settlementHouseCut } from "#src/betting/house-cut.ts";
 import { BucksStorageOverflowError } from "#src/betting/ledger.ts";
 import { requireValidBucksAllocation } from "#src/betting/allocation.ts";
 import { creditBet } from "#src/betting/settlement-ledger.ts";
-import {
-  closeBettingWindowsForMatch,
-  type ClosedPool,
-} from "#src/betting/sweep.ts";
+import type { SettlementBet } from "#src/betting/settlement-types.ts";
+import { closeBettingWindowsForMatch } from "#src/betting/sweep.ts";
+import type { ClosedPool } from "#src/betting/sweep-types.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 import { createLogger } from "#src/logger.ts";
@@ -28,24 +27,6 @@ import {
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 
 const logger = createLogger("betting-settle");
-
-export type SettlementBet = {
-  betId: number;
-  bucksAccountId: number;
-  discordId: string;
-  isHouse: boolean;
-  predictedTeamId: number;
-  submittedStake: number;
-  matchedStake: number;
-  unmatchedStake: number;
-  grossPayout: number;
-  houseCut: number;
-  payout: number;
-  winnings: number;
-  won: boolean;
-  refunded: boolean;
-  subjectPuuid: string;
-};
 
 export type SettlementSummary = {
   matchId: string;

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
@@ -14,7 +14,7 @@ import {
 } from "#src/betting/settlement-dm.ts";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
-import type { ClosedPosition } from "#src/betting/sweep.ts";
+import type { ClosedPosition } from "#src/betting/sweep-types.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
@@ -8,8 +8,9 @@ import {
   deliverSettlementDms,
   type SettlementDmDeliveryDependencies,
 } from "#src/betting/settlement-dm-delivery.ts";
-import type { SettlementBet, SettlementSummary } from "#src/betting/settle.ts";
-import type { ClosedPosition } from "#src/betting/sweep.ts";
+import type { SettlementSummary } from "#src/betting/settle.ts";
+import type { SettlementBet } from "#src/betting/settlement-types.ts";
+import type { ClosedPosition } from "#src/betting/sweep-types.ts";
 import {
   bucksTestDiscordId,
   bucksTestRoster,

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
@@ -1,7 +1,7 @@
 import { RiotTeamIdSchema, type RiotTeamId } from "@scout-for-lol/data";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
-import type { ClosedPosition } from "#src/betting/sweep.ts";
+import type { ClosedPosition } from "#src/betting/sweep-types.ts";
 import { outcomeLabel, type OutcomeFraming } from "#src/betting/team.ts";
 import { truncateDiscordMessage } from "#src/discord/utils/message.ts";
 

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-ledger.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-ledger.ts
@@ -7,7 +7,7 @@ import {
 import { HOUSE_CUT_PERCENT } from "#src/betting/house-cut.ts";
 import { transferHouseCut } from "#src/betting/house.ts";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
-import type { SettlementBet } from "#src/betting/settle.ts";
+import type { SettlementBet } from "#src/betting/settlement-types.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 
 type CreditBetInput = {

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-types.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-types.ts
@@ -1,0 +1,24 @@
+/**
+ * One bet as the settlement pass sees it.
+ *
+ * The ledger writer consumes this shape and `settle.ts` calls the ledger, so
+ * the contract lives apart from both.
+ */
+
+export type SettlementBet = {
+  betId: number;
+  bucksAccountId: number;
+  discordId: string;
+  isHouse: boolean;
+  predictedTeamId: number;
+  submittedStake: number;
+  matchedStake: number;
+  unmatchedStake: number;
+  grossPayout: number;
+  houseCut: number;
+  payout: number;
+  winnings: number;
+  won: boolean;
+  refunded: boolean;
+  subjectPuuid: string;
+};

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep-observability.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep-observability.ts
@@ -1,4 +1,4 @@
-import type { ClosedPool } from "#src/betting/sweep.ts";
+import type { ClosedPool } from "#src/betting/sweep-types.ts";
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 import {
   bettingBetsMatchedTotal,

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep-roster.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep-roster.ts
@@ -1,0 +1,21 @@
+import type { BucksPoolParticipant } from "@scout-for-lol/data";
+
+export function aliasesForTeam(
+  roster: readonly BucksPoolParticipant[],
+  teamId: number,
+): string[] {
+  return roster
+    .filter((participant) => participant.teamId === teamId)
+    .map((participant) => participant.trackedAlias)
+    .filter((alias) => alias !== undefined);
+}
+
+export function subjectAlias(
+  roster: readonly BucksPoolParticipant[],
+  subjectPuuid: string,
+): string {
+  const subject = roster.find(
+    (participant) => participant.puuid === subjectPuuid,
+  );
+  return subject?.trackedAlias ?? "a tracked player";
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep-types.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep-types.ts
@@ -1,0 +1,26 @@
+import type { RiotTeamId } from "@scout-for-lol/data";
+
+/**
+ * The shape of a pool the sweep has closed.
+ *
+ * Consumed by the sweep's observability helper, which the sweep imports back.
+ */
+
+export type ClosedPosition = {
+  betId: number;
+  discordId: string;
+  teamId: RiotTeamId;
+  submittedStake: number;
+  matchedStake: number;
+  unmatchedStake: number;
+};
+
+export type ClosedPool = {
+  matchId: string;
+  serverId: string;
+  messageRefs: { channelId: string; messageId: string }[];
+  humanMatchedPerSide: number;
+  houseFill: number;
+  totalMatchedPerSide: number;
+  positions: ClosedPosition[];
+};

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep.ts
@@ -9,7 +9,6 @@ import {
   RiotTeamIdSchema,
   type BucksMatchingSummary,
   type BucksPoolParticipant,
-  type RiotTeamId,
 } from "@scout-for-lol/data";
 import { HOUSE_MATCH_LIMIT } from "#src/betting/constants.ts";
 import { ensureHouseAccountInTransaction } from "#src/betting/house.ts";
@@ -18,27 +17,9 @@ import { matchBucksOffers } from "#src/betting/matching.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { recordClosedPool } from "#src/betting/sweep-observability.ts";
+import type { ClosedPool } from "#src/betting/sweep-types.ts";
 
 const logger = createLogger("betting-sweep");
-
-export type ClosedPosition = {
-  betId: number;
-  discordId: string;
-  teamId: RiotTeamId;
-  submittedStake: number;
-  matchedStake: number;
-  unmatchedStake: number;
-};
-
-export type ClosedPool = {
-  matchId: string;
-  serverId: string;
-  messageRefs: { channelId: string; messageId: string }[];
-  humanMatchedPerSide: number;
-  houseFill: number;
-  totalMatchedPerSide: number;
-  positions: ClosedPosition[];
-};
 
 function aliasesForTeam(
   roster: readonly BucksPoolParticipant[],

--- a/packages/scout-for-lol/packages/backend/src/betting/sweep.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/sweep.ts
@@ -8,7 +8,6 @@ import {
   LeaguePuuidSchema,
   RiotTeamIdSchema,
   type BucksMatchingSummary,
-  type BucksPoolParticipant,
 } from "@scout-for-lol/data";
 import { HOUSE_MATCH_LIMIT } from "#src/betting/constants.ts";
 import { ensureHouseAccountInTransaction } from "#src/betting/house.ts";
@@ -17,29 +16,10 @@ import { matchBucksOffers } from "#src/betting/matching.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { recordClosedPool } from "#src/betting/sweep-observability.ts";
+import { aliasesForTeam, subjectAlias } from "#src/betting/sweep-roster.ts";
 import type { ClosedPool } from "#src/betting/sweep-types.ts";
 
 const logger = createLogger("betting-sweep");
-
-function aliasesForTeam(
-  roster: readonly BucksPoolParticipant[],
-  teamId: number,
-): string[] {
-  return roster
-    .filter((participant) => participant.teamId === teamId)
-    .map((participant) => participant.trackedAlias)
-    .filter((alias) => alias !== undefined);
-}
-
-function subjectAlias(
-  roster: readonly BucksPoolParticipant[],
-  subjectPuuid: string,
-): string {
-  const subject = roster.find(
-    (participant) => participant.puuid === subjectPuuid,
-  );
-  return subject?.trackedAlias ?? "a tracked player";
-}
 
 /**
  * Match one pool exactly once. The guarded pool update is deliberately the

--- a/packages/scout-for-lol/packages/backend/src/betting/void-stale.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/void-stale.ts
@@ -1,40 +1,18 @@
 import * as Sentry from "@sentry/bun";
-import {
-  BucksPoolRosterSchema,
-  type BucksPoolParticipant,
-} from "@scout-for-lol/data";
+import { BucksPoolRosterSchema } from "@scout-for-lol/data";
 import { VOID_GRACE_MS } from "#src/betting/constants.ts";
 import { requireValidBucksAllocation } from "#src/betting/allocation.ts";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
 import type { SettlementSummary } from "#src/betting/settle.ts";
 import type { SettlementBet } from "#src/betting/settlement-types.ts";
 import { closeBettingPoolById } from "#src/betting/sweep.ts";
+import { aliasesForTeam, subjectAlias } from "#src/betting/sweep-roster.ts";
 import type { ClosedPool } from "#src/betting/sweep-types.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("betting-void-stale");
-
-function aliasesForTeam(
-  roster: readonly BucksPoolParticipant[],
-  teamId: number,
-): string[] {
-  return roster
-    .filter((participant) => participant.teamId === teamId)
-    .map((participant) => participant.trackedAlias)
-    .filter((alias) => alias !== undefined);
-}
-
-function subjectAlias(
-  roster: readonly BucksPoolParticipant[],
-  subjectPuuid: string,
-): string {
-  const subject = roster.find(
-    (participant) => participant.puuid === subjectPuuid,
-  );
-  return subject?.trackedAlias ?? "a tracked player";
-}
 
 async function pendingMatchedBets(tx: Db, poolId: number) {
   const rows = await tx.bucksBet.findMany({

--- a/packages/scout-for-lol/packages/backend/src/betting/void-stale.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/void-stale.ts
@@ -6,8 +6,10 @@ import {
 import { VOID_GRACE_MS } from "#src/betting/constants.ts";
 import { requireValidBucksAllocation } from "#src/betting/allocation.ts";
 import { applyBucksDelta } from "#src/betting/ledger.ts";
-import type { SettlementBet, SettlementSummary } from "#src/betting/settle.ts";
-import { closeBettingPoolById, type ClosedPool } from "#src/betting/sweep.ts";
+import type { SettlementSummary } from "#src/betting/settle.ts";
+import type { SettlementBet } from "#src/betting/settlement-types.ts";
+import { closeBettingPoolById } from "#src/betting/sweep.ts";
+import type { ClosedPool } from "#src/betting/sweep-types.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
 import { createLogger } from "#src/logger.ts";

--- a/packages/scout-for-lol/packages/backend/src/database/competition/competition-dates.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/competition-dates.ts
@@ -1,0 +1,58 @@
+import { SeasonIdSchema } from "@scout-for-lol/data";
+import { z } from "zod";
+import { differenceInCalendarDays } from "date-fns";
+
+/**
+ * How a competition's window is expressed: fixed dates or a League season.
+ *
+ * Kept out of `validation.ts` because the query helpers consume the derived
+ * type while `validation.ts` calls into those same helpers — declaring it
+ * there made the two modules import each other.
+ */
+export const MAX_COMPETITION_DURATION_DAYS = 90;
+
+/**
+ * Fixed-date competition schema
+ * Enforces date ordering and duration limits at the type level
+ */
+const FixedDateCompetitionSchema = z
+  .object({
+    type: z.literal("FIXED_DATES"),
+    startDate: z.date(),
+    endDate: z.date(),
+  })
+  .refine((data) => data.startDate < data.endDate, {
+    message: "startDate must be before endDate",
+    path: ["startDate"],
+  })
+  .superRefine((data, ctx) => {
+    const durationDays = differenceInCalendarDays(data.endDate, data.startDate);
+    if (durationDays > MAX_COMPETITION_DURATION_DAYS) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Competition duration cannot exceed ${MAX_COMPETITION_DURATION_DAYS.toString()} days (got ${durationDays.toString()} days)`,
+        path: ["endDate"],
+      });
+    }
+  });
+
+/**
+ * Season-based competition schema
+ * No date constraints - follows League's season timing
+ * Uses predefined season IDs only
+ */
+const SeasonBasedCompetitionSchema = z.object({
+  type: z.literal("SEASON"),
+  seasonId: SeasonIdSchema,
+});
+
+/**
+ * Discriminated union for competition dates
+ * Type system enforces XOR constraint - can't have both fixed dates AND season
+ */
+export const CompetitionDatesSchema = z.discriminatedUnion("type", [
+  FixedDateCompetitionSchema,
+  SeasonBasedCompetitionSchema,
+]);
+
+export type CompetitionDates = z.infer<typeof CompetitionDatesSchema>;

--- a/packages/scout-for-lol/packages/backend/src/database/competition/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/queries.ts
@@ -12,7 +12,7 @@ import type { Prisma } from "#generated/prisma/client/index.js";
 import { match } from "ts-pattern";
 import { type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { Db } from "#src/lib/audit/index.ts";
-import { type CompetitionDates } from "#src/database/competition/validation.ts";
+import type { CompetitionDates } from "#src/database/competition/competition-dates.ts";
 import { competitionWithSeasonInclude } from "#src/database/competition/include.ts";
 
 // ============================================================================

--- a/packages/scout-for-lol/packages/backend/src/database/competition/validation.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/validation.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "vitest";
 import {
   CompetitionCreationSchema,
-  CompetitionDatesSchema,
   isCompetitionActive,
 } from "#src/database/competition/validation.ts";
+import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
 
 import {
   testGuildId,

--- a/packages/scout-for-lol/packages/backend/src/database/competition/validation.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/validation.ts
@@ -7,19 +7,16 @@ import {
   DiscordChannelIdSchema,
   type DiscordGuildId,
   DiscordGuildIdSchema,
-  SeasonIdSchema,
 } from "@scout-for-lol/data";
 import { z } from "zod";
-import { differenceInCalendarDays } from "date-fns";
 
 import { getLimit } from "#src/configuration/flags.ts";
 import { activeOnlyWhere } from "#src/database/competition/queries.ts";
+import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
 
 // ============================================================================
 // Constants
 // ============================================================================
-
-const MAX_COMPETITION_DURATION_DAYS = 90;
 
 // ============================================================================
 // Helper Functions
@@ -50,52 +47,6 @@ export function isCompetitionActive(
 // ============================================================================
 // Zod Schemas for Validation
 // ============================================================================
-
-/**
- * Fixed-date competition schema
- * Enforces date ordering and duration limits at the type level
- */
-const FixedDateCompetitionSchema = z
-  .object({
-    type: z.literal("FIXED_DATES"),
-    startDate: z.date(),
-    endDate: z.date(),
-  })
-  .refine((data) => data.startDate < data.endDate, {
-    message: "startDate must be before endDate",
-    path: ["startDate"],
-  })
-  .superRefine((data, ctx) => {
-    const durationDays = differenceInCalendarDays(data.endDate, data.startDate);
-    if (durationDays > MAX_COMPETITION_DURATION_DAYS) {
-      ctx.addIssue({
-        code: "custom",
-        message: `Competition duration cannot exceed ${MAX_COMPETITION_DURATION_DAYS.toString()} days (got ${durationDays.toString()} days)`,
-        path: ["endDate"],
-      });
-    }
-  });
-
-/**
- * Season-based competition schema
- * No date constraints - follows League's season timing
- * Uses predefined season IDs only
- */
-const SeasonBasedCompetitionSchema = z.object({
-  type: z.literal("SEASON"),
-  seasonId: SeasonIdSchema,
-});
-
-/**
- * Discriminated union for competition dates
- * Type system enforces XOR constraint - can't have both fixed dates AND season
- */
-export const CompetitionDatesSchema = z.discriminatedUnion("type", [
-  FixedDateCompetitionSchema,
-  SeasonBasedCompetitionSchema,
-]);
-
-export type CompetitionDates = z.infer<typeof CompetitionDatesSchema>;
 
 /**
  * Schema for competition creation input with comprehensive validation

--- a/packages/scout-for-lol/packages/backend/src/database/guild-permission-errors.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/guild-permission-errors.ts
@@ -4,7 +4,7 @@ import {
 } from "@scout-for-lol/data";
 import { z } from "zod";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
-import type { DeliveryFailureKind } from "#src/discord/utils/permissions.ts";
+import type { DeliveryFailureKind } from "#src/discord/utils/delivery-failure.ts";
 import { subDays } from "date-fns";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;

--- a/packages/scout-for-lol/packages/backend/src/database/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/index.ts
@@ -14,7 +14,7 @@ import {
 } from "@scout-for-lol/data";
 import * as Sentry from "@sentry/bun";
 import { createLogger } from "#src/logger.ts";
-import { databaseQueriesTotal } from "#src/metrics/index.ts";
+import { databaseQueriesTotal } from "#src/metrics/database-metrics.ts";
 
 const logger = createLogger("database");
 

--- a/packages/scout-for-lol/packages/backend/src/discord/bootstrap.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/bootstrap.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, vi } from "vitest";
+import { Client, GatewayIntentBits } from "discord.js";
+import {
+  DISCORD_EVENT_NAMES,
+  registerDiscordEventHandlers,
+  startDiscordGateway,
+} from "#src/discord/bootstrap.ts";
+
+function newClient(): Client {
+  return new Client({ intents: [GatewayIntentBits.Guilds] });
+}
+
+/**
+ * discord.js installs a few listeners of its own in the constructor, so these
+ * assertions count what the bootstrap adds rather than what is present.
+ */
+function listenerCounts(client: Client): Record<string, number> {
+  return Object.fromEntries(
+    DISCORD_EVENT_NAMES.map((event) => [event, client.listenerCount(event)]),
+  );
+}
+
+describe("discord bootstrap", () => {
+  test("installs exactly one handler for every gateway event the bot handles", () => {
+    const client = newClient();
+    const before = listenerCounts(client);
+
+    registerDiscordEventHandlers(client);
+
+    const after = listenerCounts(client);
+    expect(after).toEqual(
+      Object.fromEntries(
+        DISCORD_EVENT_NAMES.map((event) => [event, (before[event] ?? 0) + 1]),
+      ),
+    );
+  });
+
+  test("installs every handler before login is attempted", async () => {
+    // A fast gateway connection can emit `ready` the moment login resolves, so
+    // a handler registered afterwards would never run. Capture what is
+    // registered at the instant login is called.
+    const client = newClient();
+    let eventsAtLogin: string[] = [];
+    const login = vi.spyOn(client, "login").mockImplementation(() => {
+      eventsAtLogin = client.eventNames().map(String);
+      return Promise.resolve("stub-token");
+    });
+
+    // NODE_ENV is "test" under vitest, which short-circuits the real login.
+    // Drive the production branch explicitly instead.
+    const previousNodeEnv = Bun.env.NODE_ENV;
+    Bun.env.NODE_ENV = "production";
+    try {
+      await startDiscordGateway(client);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete Bun.env.NODE_ENV;
+      } else {
+        Bun.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+
+    expect(login).toHaveBeenCalledTimes(1);
+    for (const event of DISCORD_EVENT_NAMES) {
+      expect(eventsAtLogin).toContain(event);
+    }
+  });
+
+  test("skips login under NODE_ENV=test but still installs handlers", async () => {
+    const client = newClient();
+    const login = vi.spyOn(client, "login").mockResolvedValue("stub-token");
+
+    await startDiscordGateway(client);
+
+    expect(login).not.toHaveBeenCalled();
+    for (const event of DISCORD_EVENT_NAMES) {
+      expect(client.listenerCount(event)).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
@@ -1,0 +1,196 @@
+import configuration from "#src/configuration.ts";
+import type { Client, Guild } from "discord.js";
+import * as Sentry from "@sentry/bun";
+import { client } from "#src/discord/client.ts";
+import { handleInteractions } from "#src/discord/interactions.ts";
+import {
+  registerDiscordCommands,
+  reconcileGuildScopedCommands,
+} from "#src/discord/rest.ts";
+import { handleGuildCreate } from "#src/discord/events/guild-create.ts";
+import { handleGuildDelete } from "#src/discord/events/guild-delete.ts";
+import {
+  discordConnectionStatus,
+  discordGuildsGauge,
+  discordUsersGauge,
+  discordLatency,
+} from "#src/metrics/index.ts";
+import { voiceManager } from "#src/voice/index.ts";
+import { createLogger } from "#src/logger.ts";
+import { addDynamicConfigRefreshListener } from "#src/config/dynamic.ts";
+
+const logger = createLogger("discord-bootstrap");
+
+let removeDynamicConfigRefreshListener: (() => void) | undefined;
+
+/**
+ * Every gateway event this bot handles.
+ *
+ * Exported so the bootstrap test can assert that all of them are installed,
+ * and installed *before* login — a fast gateway connection can emit `ready`
+ * immediately, and a handler registered after that point never runs.
+ */
+export const DISCORD_EVENT_NAMES = [
+  "error",
+  "warn",
+  "debug",
+  "disconnect",
+  "reconnecting",
+  "ready",
+  "guildCreate",
+  "guildDelete",
+] as const;
+
+async function registerConnectedGuildCommands(
+  guildIds: Iterable<string>,
+): Promise<void> {
+  try {
+    await registerDiscordCommands(guildIds);
+  } catch (error) {
+    logger.error("❌ Failed to register Discord commands:", error);
+    Sentry.captureException(error, {
+      tags: { source: "discord-command-registration" },
+    });
+    process.exit(1);
+  }
+}
+
+async function handleNewGuild(guild: Guild): Promise<void> {
+  try {
+    await reconcileGuildScopedCommands([guild.id]);
+  } catch (error) {
+    logger.error(
+      `[Guild Create] Failed to reconcile commands for ${guild.id}:`,
+      error,
+    );
+    Sentry.captureException(error, {
+      tags: { source: "discord-guild-command-registration" },
+    });
+  }
+  await handleGuildCreate(guild);
+}
+
+/**
+ * Install every gateway event handler on `target`.
+ *
+ * Takes the client as a parameter rather than closing over the module
+ * singleton so the bootstrap test can exercise it against its own client.
+ */
+export function registerDiscordEventHandlers(target: Client): void {
+  target.on("error", (error) => {
+    logger.error("❌ Discord client error:", error);
+    Sentry.captureException(error, {
+      tags: {
+        source: "discord-client",
+      },
+    });
+    discordConnectionStatus.set(0);
+  });
+
+  target.on("warn", (warning) => {
+    logger.warn("⚠️  Discord client warning:", warning);
+  });
+
+  target.on("debug", (info) => {
+    // Only log debug info in dev environment to avoid spam
+    if (configuration.environment === "dev") {
+      logger.debug("🔍 Discord debug:", info);
+    }
+  });
+
+  target.on("disconnect", () => {
+    logger.info("🔌 Discord client disconnected");
+    discordConnectionStatus.set(0);
+  });
+
+  target.on("reconnecting", () => {
+    logger.info("🔄 Discord client reconnecting");
+    discordConnectionStatus.set(0);
+  });
+
+  target.on("ready", (readyClient) => {
+    logger.info(`✅ Discord bot ready! Logged in as ${readyClient.user.tag}`);
+    logger.info(
+      `🏢 Bot is in ${readyClient.guilds.cache.size.toString()} guilds`,
+    );
+    logger.info(
+      `👥 Bot can see ${readyClient.users.cache.size.toString()} users`,
+    );
+
+    // Update connection status metric
+    discordConnectionStatus.set(1);
+
+    // Update guild and user count metrics
+    discordGuildsGauge.set(readyClient.guilds.cache.size);
+    discordUsersGauge.set(readyClient.users.cache.size);
+
+    // Initialize voice manager with Discord client
+    voiceManager.setClient(target);
+    logger.info("🔊 Voice manager initialized");
+
+    // Update metrics periodically
+    setInterval(() => {
+      discordGuildsGauge.set(readyClient.guilds.cache.size);
+      discordUsersGauge.set(readyClient.users.cache.size);
+      discordLatency.set(readyClient.ws.ping);
+    }, 30_000); // Update every 30 seconds
+
+    handleInteractions(readyClient);
+    logger.info("⚡ Discord command handler initialized");
+
+    removeDynamicConfigRefreshListener ??= addDynamicConfigRefreshListener(
+      async () => {
+        await reconcileGuildScopedCommands(target.guilds.cache.keys());
+      },
+    );
+
+    void registerConnectedGuildCommands(readyClient.guilds.cache.keys());
+  });
+
+  // Handle bot being added to new servers
+  target.on("guildCreate", (guild) => {
+    logger.info(`[Guild Create] Bot added to new server: ${guild.name}`);
+    discordGuildsGauge.set(target.guilds.cache.size);
+    void handleNewGuild(guild);
+  });
+
+  // Handle bot being removed from servers (kicked, banned, or guild deleted)
+  target.on("guildDelete", (guild) => {
+    logger.info(`[Guild Delete] Bot removed from server: ${guild.name}`);
+    discordGuildsGauge.set(target.guilds.cache.size);
+    void handleGuildDelete(guild);
+  });
+}
+
+/**
+ * Wire the gateway client up and connect it.
+ *
+ * Handlers are installed before login so a fast gateway connection cannot emit
+ * `ready` before command reconciliation is listening for it.
+ */
+export async function startDiscordGateway(target: Client = client) {
+  registerDiscordEventHandlers(target);
+
+  if (Bun.env.NODE_ENV === "test") {
+    logger.info("🧪 NODE_ENV=test — skipping Discord login");
+    return;
+  }
+  if (!configuration.enableDiscordGateway) {
+    logger.warn("⏭️  Discord gateway disabled — skipping Discord login");
+    return;
+  }
+
+  logger.info("🔑 Logging into Discord");
+  try {
+    await target.login(configuration.discordToken);
+    logger.info("✅ Successfully logged into Discord");
+  } catch (error) {
+    logger.error("❌ Failed to login to Discord:", error);
+    Sentry.captureException(error, {
+      tags: {
+        source: "discord-login",
+      },
+    });
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/client.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/client.ts
@@ -1,24 +1,25 @@
-import configuration from "#src/configuration.ts";
-import { Client, GatewayIntentBits, type Guild } from "discord.js";
-import { handleInteractions } from "#src/discord/interactions.ts";
-import {
-  discordConnectionStatus,
-  discordGuildsGauge,
-  discordUsersGauge,
-  discordLatency,
-} from "#src/metrics/index.ts";
-import { handleGuildCreate } from "#src/discord/events/guild-create.ts";
-import { handleGuildDelete } from "#src/discord/events/guild-delete.ts";
-import { voiceManager } from "#src/voice/index.ts";
-import * as Sentry from "@sentry/bun";
+import { Client, GatewayIntentBits } from "discord.js";
 import { createLogger } from "#src/logger.ts";
-import { addDynamicConfigRefreshListener } from "#src/config/dynamic.ts";
 
 const logger = createLogger("discord-client");
-let removeDynamicConfigRefreshListener: (() => void) | undefined;
 
 logger.info("🔌 Initializing Discord client");
 
+/**
+ * The Discord gateway client.
+ *
+ * This module deliberately does nothing but construct it. Event handlers and
+ * login live in `bootstrap.ts`, for two reasons:
+ *
+ * - Around eighteen modules import this client purely to send a message or
+ *   read a guild. Wiring the handlers here meant every one of them pulled in
+ *   the whole interaction router, and the router pulls those same modules back
+ *   — an eager import cycle through `client -> interactions -> commands ->
+ *   feature -> client`.
+ * - Login used to be a top-level `await` in this file, so importing the client
+ *   from a tRPC router was enough to connect to Discord. Connecting is now an
+ *   explicit act performed by the composition root.
+ */
 const client = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -26,147 +27,5 @@ const client = new Client({
     GatewayIntentBits.GuildModeration, // Required for audit log (installer tracking)
   ],
 });
-
-// Add event listeners for connection status
-client.on("error", (error) => {
-  logger.error("❌ Discord client error:", error);
-  Sentry.captureException(error, {
-    tags: {
-      source: "discord-client",
-    },
-  });
-  discordConnectionStatus.set(0);
-});
-
-client.on("warn", (warning) => {
-  logger.warn("⚠️  Discord client warning:", warning);
-});
-
-client.on("debug", (info) => {
-  // Only log debug info in dev environment to avoid spam
-  if (configuration.environment === "dev") {
-    logger.debug("🔍 Discord debug:", info);
-  }
-});
-
-client.on("disconnect", () => {
-  logger.info("🔌 Discord client disconnected");
-  discordConnectionStatus.set(0);
-});
-
-client.on("reconnecting", () => {
-  logger.info("🔄 Discord client reconnecting");
-  discordConnectionStatus.set(0);
-});
-
-client.on("ready", (readyClient) => {
-  logger.info(`✅ Discord bot ready! Logged in as ${readyClient.user.tag}`);
-  logger.info(
-    `🏢 Bot is in ${readyClient.guilds.cache.size.toString()} guilds`,
-  );
-  logger.info(
-    `👥 Bot can see ${readyClient.users.cache.size.toString()} users`,
-  );
-
-  // Update connection status metric
-  discordConnectionStatus.set(1);
-
-  // Update guild and user count metrics
-  discordGuildsGauge.set(readyClient.guilds.cache.size);
-  discordUsersGauge.set(readyClient.users.cache.size);
-
-  // Initialize voice manager with Discord client
-  voiceManager.setClient(client);
-  logger.info("🔊 Voice manager initialized");
-
-  // Update metrics periodically
-  setInterval(() => {
-    discordGuildsGauge.set(readyClient.guilds.cache.size);
-    discordUsersGauge.set(readyClient.users.cache.size);
-    discordLatency.set(readyClient.ws.ping);
-  }, 30_000); // Update every 30 seconds
-
-  handleInteractions(readyClient);
-  logger.info("⚡ Discord command handler initialized");
-
-  removeDynamicConfigRefreshListener ??= addDynamicConfigRefreshListener(
-    async () => {
-      const { reconcileGuildScopedCommands } =
-        await import("#src/discord/rest.ts");
-      await reconcileGuildScopedCommands(client.guilds.cache.keys());
-    },
-  );
-
-  void registerConnectedGuildCommands(readyClient.guilds.cache.keys());
-});
-
-// Handle bot being added to new servers
-client.on("guildCreate", (guild) => {
-  logger.info(`[Guild Create] Bot added to new server: ${guild.name}`);
-  discordGuildsGauge.set(client.guilds.cache.size);
-  void handleNewGuild(guild);
-});
-
-async function registerConnectedGuildCommands(
-  guildIds: Iterable<string>,
-): Promise<void> {
-  try {
-    const { registerDiscordCommands } = await import("#src/discord/rest.ts");
-    await registerDiscordCommands(guildIds);
-  } catch (error) {
-    logger.error("❌ Failed to register Discord commands:", error);
-    Sentry.captureException(error, {
-      tags: { source: "discord-command-registration" },
-    });
-    process.exit(1);
-  }
-}
-
-async function handleNewGuild(guild: Guild): Promise<void> {
-  try {
-    const { reconcileGuildScopedCommands } =
-      await import("#src/discord/rest.ts");
-    await reconcileGuildScopedCommands([guild.id]);
-  } catch (error) {
-    logger.error(
-      `[Guild Create] Failed to reconcile commands for ${guild.id}:`,
-      error,
-    );
-    Sentry.captureException(error, {
-      tags: { source: "discord-guild-command-registration" },
-    });
-  }
-  await handleGuildCreate(guild);
-}
-
-// Handle bot being removed from servers (kicked, banned, or guild deleted)
-client.on("guildDelete", (guild) => {
-  logger.info(`[Guild Delete] Bot removed from server: ${guild.name}`);
-  discordGuildsGauge.set(client.guilds.cache.size);
-  void handleGuildDelete(guild);
-});
-
-// Install every event handler before login so a fast gateway connection cannot
-// emit `ready` before command reconciliation is listening for it.
-// Tests stay side-effect free; production/dev/beta log in as normal.
-if (Bun.env.NODE_ENV === "test") {
-  logger.info("🧪 NODE_ENV=test — skipping Discord login");
-} else if (configuration.enableDiscordGateway) {
-  logger.info("🔑 Logging into Discord");
-  try {
-    await client.login(configuration.discordToken);
-    logger.info("✅ Successfully logged into Discord");
-  } catch (error) {
-    logger.error("❌ Failed to login to Discord:", error);
-    Sentry.captureException(error, {
-      tags: {
-        source: "discord-login",
-      },
-    });
-    throw error;
-  }
-} else {
-  logger.warn("⏭️  Discord gateway disabled — skipping Discord login");
-}
 
 export { client };

--- a/packages/scout-for-lol/packages/backend/src/discord/embeds/competition.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/embeds/competition.test.ts
@@ -5,7 +5,7 @@ import {
   PlayerIdSchema,
   type CompetitionWithCriteria,
 } from "@scout-for-lol/data";
-import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import {
   generateLeaderboardEmbed,
   generateCompetitionDetailsEmbed,

--- a/packages/scout-for-lol/packages/backend/src/discord/embeds/competition.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/embeds/competition.ts
@@ -2,7 +2,7 @@ import type { CompetitionWithCriteria } from "@scout-for-lol/data";
 import { getCompetitionStatus } from "@scout-for-lol/data";
 import { EmbedBuilder } from "discord.js";
 import { match } from "ts-pattern";
-import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import {
   formatCriteriaDescription,
   formatScore,

--- a/packages/scout-for-lol/packages/backend/src/discord/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/index.ts
@@ -1,1 +1,3 @@
-import "@scout-for-lol/backend/discord/client.ts";
+import { startDiscordGateway } from "@scout-for-lol/backend/discord/bootstrap.ts";
+
+await startDiscordGateway();

--- a/packages/scout-for-lol/packages/backend/src/discord/utils/delivery-failure.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/utils/delivery-failure.ts
@@ -1,0 +1,8 @@
+/**
+ * Why a delivery attempt failed.
+ *
+ * A leaf module: the permission checker produces this and the guild
+ * permission-error store consumes it, while the checker consumes the store's
+ * notify stage — declaring it beside either made the two import each other.
+ */
+export type DeliveryFailureKind = "permission" | "channel_missing";

--- a/packages/scout-for-lol/packages/backend/src/discord/utils/permissions.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/utils/permissions.ts
@@ -10,6 +10,7 @@ import { getErrorMessage } from "#src/utils/errors.ts";
 import { sendDM, type DmStatus } from "#src/discord/utils/dm.ts";
 import { getFeedbackUrl } from "#src/discord/utils/feedback.ts";
 import type { PermissionNotifyStage } from "#src/database/guild-permission-errors.ts";
+import type { DeliveryFailureKind } from "#src/discord/utils/delivery-failure.ts";
 import {
   discordPermissionErrorsTotal,
   discordOwnerNotificationsTotal,
@@ -72,7 +73,6 @@ export function isUnknownGuildError(error: unknown): boolean {
 /**
  * How a delivery failed, for tailoring the owner notification copy.
  */
-export type DeliveryFailureKind = "permission" | "channel_missing";
 
 /**
  * Check if the bot has permission to send messages in a channel

--- a/packages/scout-for-lol/packages/backend/src/league/competition/analysis-results.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/analysis-results.test.ts
@@ -9,7 +9,7 @@ import {
   mergeCompetitionRankHistory,
   standingsFromResult,
 } from "#src/league/competition/analysis-results.ts";
-import type { ReportQueryResult } from "#src/reports/query-engine.ts";
+import type { ReportQueryResult } from "#src/reports/query-types.ts";
 
 const competitionId = CompetitionIdSchema.parse(1);
 const playerId = PlayerIdSchema.parse(10);

--- a/packages/scout-for-lol/packages/backend/src/league/competition/analysis-results.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/analysis-results.ts
@@ -3,7 +3,7 @@ import {
   type CachedLeaderboard,
   type CachedLeaderboardEntry,
 } from "@scout-for-lol/data";
-import type { ReportQueryResult } from "#src/reports/query-engine.ts";
+import type { ReportQueryResult } from "#src/reports/query-types.ts";
 
 export function mergeCompetitionRankHistory(
   lakeHistory: CachedLeaderboard[],

--- a/packages/scout-for-lol/packages/backend/src/league/competition/analysis.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/analysis.ts
@@ -27,10 +27,8 @@ import {
   resolveCompetitionAnalysisDates,
 } from "#src/league/competition/analysis-dates.ts";
 import { standingsFromResult } from "#src/league/competition/analysis-results.ts";
-import {
-  executeCompiledReportQuery,
-  type ReportQueryResult,
-} from "#src/reports/query-engine.ts";
+import { executeCompiledReportQuery } from "#src/reports/query-engine.ts";
+import type { ReportQueryResult } from "#src/reports/query-types.ts";
 import { guildScope } from "#src/reports/duckdb/scope.ts";
 import {
   clampTemporalRange,

--- a/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/chart-builder.ts
@@ -20,7 +20,7 @@ import {
 } from "@scout-for-lol/report";
 import { formatCriteriaDescription } from "#src/discord/embeds/competition-format-helpers.ts";
 import { loadHistoricalLeaderboardSnapshots } from "#src/storage/s3-leaderboard.ts";
-import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import { createLogger } from "#src/logger.ts";
 import { logNotification } from "#src/utils/notification-logger.ts";
 import {

--- a/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard-ranking.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard-ranking.ts
@@ -2,7 +2,7 @@ import type { Rank } from "@scout-for-lol/data/index.ts";
 import { rankToLeaguePoints, RankSchema } from "@scout-for-lol/data/index.ts";
 import { z } from "zod";
 import type { LeaderboardEntry } from "#src/league/competition/processors/types.ts";
-import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 
 /**
  * Check if two scores are equal

--- a/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard-types.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard-types.ts
@@ -1,0 +1,11 @@
+import type { LeaderboardEntry } from "#src/league/competition/processors/types.ts";
+
+/**
+ * A leaderboard entry once ranks have been assigned.
+ *
+ * The ranking helper consumes it and the leaderboard imports that helper back.
+ */
+
+export type RankedLeaderboardEntry = LeaderboardEntry & {
+  rank: number;
+};

--- a/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.ts
@@ -16,6 +16,7 @@ import {
   RawSummonerLeagueSchema,
 } from "@scout-for-lol/data/index.ts";
 import { assignRanks } from "#src/league/competition/leaderboard-ranking.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import { sortBy } from "remeda";
 import { match } from "ts-pattern";
 import { z } from "zod";
@@ -31,7 +32,7 @@ import {
 } from "#src/league/competition/processors/index.ts";
 import { riotClient } from "#src/league/api/api.ts";
 import { regionToPlatformRoute } from "@scout-for-lol/data";
-import { getSnapshot } from "#src/league/competition/snapshots.ts";
+import { getSnapshot } from "#src/league/competition/snapshot-store.ts";
 import { getRank } from "#src/league/model/rank.ts";
 import {
   getHigherRank,
@@ -49,9 +50,6 @@ const logger = createLogger("competition-leaderboard");
 /**
  * Leaderboard entry with rank assigned
  */
-export type RankedLeaderboardEntry = LeaderboardEntry & {
-  rank: number;
-};
 
 function ranksForQueue(queue: "SOLO" | "FLEX", rank: Rank): Ranks {
   return queue === "SOLO" ? { solo: rank } : { flex: rank };

--- a/packages/scout-for-lol/packages/backend/src/league/competition/refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/refresh.ts
@@ -6,10 +6,8 @@ import {
 import { AttachmentBuilder } from "discord.js";
 import * as Sentry from "@sentry/bun";
 import { prisma } from "#src/database/index.ts";
-import {
-  calculateLeaderboard,
-  type RankedLeaderboardEntry,
-} from "#src/league/competition/leaderboard.ts";
+import { calculateLeaderboard } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import { renderCompetitionChartBuffer } from "#src/league/competition/chart-builder.ts";
 import { saveCachedLeaderboard } from "#src/storage/s3-leaderboard.ts";
 import { saveLeaderboardImage } from "#src/storage/s3-leaderboard-image.ts";

--- a/packages/scout-for-lol/packages/backend/src/league/competition/snapshot-store.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/snapshot-store.ts
@@ -1,0 +1,66 @@
+import {
+  type CompetitionCriteria,
+  type CompetitionId,
+  type GamesPlayedSnapshotData,
+  getSnapshotSchemaForCriteria,
+  type PlayerId,
+  type RankSnapshotData,
+  type SnapshotType,
+  type WinsSnapshotData,
+} from "@scout-for-lol/data/index.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+/**
+ * Reading a stored snapshot lives apart from creating one.
+ *
+ * Creating a snapshot needs `fetchSnapshotData` from `leaderboard.ts`, and
+ * `leaderboard.ts` needs to read snapshots back — which made the two modules
+ * an eager import cycle. Reading is the smaller half and depends on nothing
+ * but Prisma and the criteria schema, so it is the seam.
+ */
+
+/**
+ * Get a snapshot for a player in a competition
+ *
+ * @param prisma Prisma client instance
+ * @param competitionId Competition ID
+ * @param playerId Player ID
+ * @param snapshotType Type of snapshot (START or END)
+ * @param criteria Competition criteria (needed to parse the snapshot data correctly)
+ * @returns Parsed snapshot data, or null if snapshot doesn't exist
+ */
+export async function getSnapshot(
+  prisma: ExtendedPrismaClient,
+  params: {
+    competitionId: CompetitionId;
+    playerId: PlayerId;
+    snapshotType: SnapshotType;
+    criteria: CompetitionCriteria;
+  },
+): Promise<
+  RankSnapshotData | GamesPlayedSnapshotData | WinsSnapshotData | null
+> {
+  const { competitionId, playerId, snapshotType, criteria } = params;
+  const snapshot = await prisma.competitionSnapshot.findUnique({
+    where: {
+      competitionId_playerId_snapshotType: {
+        competitionId,
+        playerId,
+        snapshotType,
+      },
+    },
+  });
+
+  if (!snapshot) {
+    return null;
+  }
+
+  // Parse the JSON string
+  const snapshotData: unknown = JSON.parse(snapshot.snapshotData);
+
+  // Get the appropriate schema for validation
+  const schema = getSnapshotSchemaForCriteria(criteria);
+
+  // Validate and return
+  return schema.parse(snapshotData);
+}

--- a/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts
@@ -1,9 +1,9 @@
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
 import {
   createSnapshot,
-  getSnapshot,
   createSnapshotsForAllParticipants,
 } from "#src/league/competition/snapshots.ts";
+import { getSnapshot } from "#src/league/competition/snapshot-store.ts";
 import {
   createCompetition,
   type CreateCompetitionInput,

--- a/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.ts
@@ -1,12 +1,9 @@
 import {
   type CompetitionCriteria,
   type CompetitionId,
-  type GamesPlayedSnapshotData,
   getSnapshotSchemaForCriteria,
   type PlayerId,
-  type RankSnapshotData,
   type SnapshotType,
-  type WinsSnapshotData,
 } from "@scout-for-lol/data/index.ts";
 import { fetchSnapshotData } from "#src/league/competition/leaderboard.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
@@ -146,52 +143,6 @@ export async function createSnapshot(
 // ============================================================================
 // Snapshot Retrieval
 // ============================================================================
-
-/**
- * Get a snapshot for a player in a competition
- *
- * @param prisma Prisma client instance
- * @param competitionId Competition ID
- * @param playerId Player ID
- * @param snapshotType Type of snapshot (START or END)
- * @param criteria Competition criteria (needed to parse the snapshot data correctly)
- * @returns Parsed snapshot data, or null if snapshot doesn't exist
- */
-export async function getSnapshot(
-  prisma: ExtendedPrismaClient,
-  params: {
-    competitionId: CompetitionId;
-    playerId: PlayerId;
-    snapshotType: SnapshotType;
-    criteria: CompetitionCriteria;
-  },
-): Promise<
-  RankSnapshotData | GamesPlayedSnapshotData | WinsSnapshotData | null
-> {
-  const { competitionId, playerId, snapshotType, criteria } = params;
-  const snapshot = await prisma.competitionSnapshot.findUnique({
-    where: {
-      competitionId_playerId_snapshotType: {
-        competitionId,
-        playerId,
-        snapshotType,
-      },
-    },
-  });
-
-  if (!snapshot) {
-    return null;
-  }
-
-  // Parse the JSON string
-  const snapshotData: unknown = JSON.parse(snapshot.snapshotData);
-
-  // Get the appropriate schema for validation
-  const schema = getSnapshotSchemaForCriteria(criteria);
-
-  // Validate and return
-  return schema.parse(snapshotData);
-}
 
 // ============================================================================
 // Bulk Operations

--- a/packages/scout-for-lol/packages/backend/src/league/discord/channel.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/discord/channel.ts
@@ -14,8 +14,8 @@ import {
   isMissingChannelError,
   formatPermissionErrorForLog,
   notifyServerOwnerAboutPermissionError,
-  type DeliveryFailureKind,
 } from "#src/discord/utils/permissions.ts";
+import type { DeliveryFailureKind } from "#src/discord/utils/delivery-failure.ts";
 import { discordPermissionErrorsTotal } from "#src/metrics/index.ts";
 import { prisma } from "#src/database/index.ts";
 import {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/competition/daily-update.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/competition/daily-update.ts
@@ -5,20 +5,16 @@ import {
 } from "@scout-for-lol/data/index.ts";
 import { prisma } from "#src/database/index.ts";
 import { getActiveCompetitions } from "#src/database/competition/queries.ts";
-import {
-  calculateLeaderboard,
-  type RankedLeaderboardEntry,
-} from "#src/league/competition/leaderboard.ts";
+import { calculateLeaderboard } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import { generateLeaderboardEmbed } from "#src/discord/embeds/competition.ts";
 import {
   send as sendChannelMessage,
   ChannelSendError,
 } from "#src/league/discord/channel.ts";
 import { cacheLeaderboardArtifacts } from "#src/league/competition/refresh.ts";
-import {
-  createSnapshot,
-  getSnapshot,
-} from "#src/league/competition/snapshots.ts";
+import { createSnapshot } from "#src/league/competition/snapshots.ts";
+import { getSnapshot } from "#src/league/competition/snapshot-store.ts";
 import { getParticipants } from "#src/database/competition/participants.ts";
 import { EmbedBuilder } from "discord.js";
 import { z } from "zod";

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.ts
@@ -10,10 +10,8 @@ import {
 import { prisma } from "#src/database/index.ts";
 import { competitionWithSeasonInclude } from "#src/database/competition/include.ts";
 import { createSnapshotsForAllParticipants } from "#src/league/competition/snapshots.ts";
-import {
-  calculateLeaderboard,
-  type RankedLeaderboardEntry,
-} from "#src/league/competition/leaderboard.ts";
+import { calculateLeaderboard } from "#src/league/competition/leaderboard.ts";
+import type { RankedLeaderboardEntry } from "#src/league/competition/leaderboard-types.ts";
 import {
   send as sendChannelMessage,
   ChannelSendError,

--- a/packages/scout-for-lol/packages/backend/src/metrics/database-metrics.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/database-metrics.ts
@@ -1,0 +1,20 @@
+import { Counter } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Database counters, kept out of the large `metrics/index.ts` barrel.
+ *
+ * `database/index.ts` records against this counter, and the barrel pulls in
+ * `betting-sweep.ts`, which needs the Prisma client type from
+ * `database/index.ts` — importing the counter from the barrel closed that
+ * loop. Same reasoning as `metrics/registry.ts`.
+ */
+/**
+ * Total number of database queries
+ */
+export const databaseQueriesTotal = new Counter({
+  name: "database_queries_total",
+  help: "Total database queries",
+  labelNames: ["operation"] as const,
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -492,16 +492,6 @@ export const scoutItemCacheMissTotal = new Counter({
   registers: [registry],
 });
 
-/**
- * Total number of database queries
- */
-export const databaseQueriesTotal = new Counter({
-  name: "database_queries_total",
-  help: "Total database queries",
-  labelNames: ["operation"] as const,
-  registers: [registry],
-});
-
 // =======================
 // Riot API Health State
 // =======================

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.test.ts
@@ -4,7 +4,7 @@ import {
   ReportAiModelPreviewSummarySchema,
 } from "@scout-for-lol/data";
 import { reportQueryPreviewSummary } from "#src/reports/ai/report-query-preview-summary.ts";
-import type { ReportQueryResult } from "#src/reports/query-engine.ts";
+import type { ReportQueryResult } from "#src/reports/query-types.ts";
 
 describe("reportQueryPreviewSummary", () => {
   test("projects result values onto the strict AI preview contract", () => {

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-preview-summary.ts
@@ -5,7 +5,7 @@ import {
   ReportAiPreviewSummarySchema,
   type ReportAiPreviewSummary,
 } from "@scout-for-lol/data";
-import type { ReportQueryResult } from "#src/reports/query-engine.ts";
+import type { ReportQueryResult } from "#src/reports/query-types.ts";
 
 export function reportQueryPreviewSummary(
   result: ReportQueryResult,

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/execute.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/execute.ts
@@ -2,7 +2,7 @@ import type { ReportQueryPlan } from "@scout-for-lol/data";
 import type { DuckDBValue } from "@duckdb/node-api";
 import { match } from "ts-pattern";
 import { resolveLakeDir } from "#src/report-lake/paths.ts";
-import type { AggregateRow } from "#src/reports/query-aggregates.ts";
+import type { AggregateRow } from "#src/reports/query-types.ts";
 import {
   compileGroupFactsQuery,
   compileMatchQuery,

--- a/packages/scout-for-lol/packages/backend/src/reports/group-combinations.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/group-combinations.ts
@@ -1,5 +1,5 @@
 import type { ReportGroupSize } from "@scout-for-lol/data";
-import type { AggregateRow } from "#src/reports/query-aggregates.ts";
+import type { AggregateRow } from "#src/reports/query-types.ts";
 
 /**
  * Teammate-group aggregation for the DuckDB lake path (execute.ts).

--- a/packages/scout-for-lol/packages/backend/src/reports/mention-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/mention-format.ts
@@ -1,4 +1,4 @@
-import type { ReportMentionIdentity } from "#src/reports/query-engine.ts";
+import type { ReportMentionIdentity } from "#src/reports/query-types.ts";
 
 // Fallback rank count used when a `RENDER leaderboard` clause doesn't specify
 // `WITH (mentions = ...)`.

--- a/packages/scout-for-lol/packages/backend/src/reports/output-analytics.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/output-analytics.ts
@@ -8,7 +8,7 @@ import { match } from "ts-pattern";
 import type {
   ReportQueryResult,
   ReportResultRow,
-} from "#src/reports/query-engine.ts";
+} from "#src/reports/query-types.ts";
 import {
   chartNumber,
   chartSeries,

--- a/packages/scout-for-lol/packages/backend/src/reports/output.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/output.ts
@@ -11,7 +11,7 @@ import {
 import type {
   ReportQueryResult,
   ReportResultRow,
-} from "#src/reports/query-engine.ts";
+} from "#src/reports/query-types.ts";
 import {
   formatRankedLabel,
   resolveMentionCount,

--- a/packages/scout-for-lol/packages/backend/src/reports/query-aggregates.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/query-aggregates.ts
@@ -11,67 +11,10 @@ import type {
   ReportQueryPlan,
 } from "@scout-for-lol/data";
 import type {
+  AggregateRow,
   ReportMentionIdentity,
   ReportQueryResult,
-} from "#src/reports/query-engine.ts";
-
-export type AggregateRow = {
-  label: string;
-  playerId: number | null;
-  discordId: string | null;
-  groupMembers: { playerId: number; alias: string }[] | null;
-  games: number;
-  wins: number;
-  surrenders: number;
-  kills: number;
-  deaths: number;
-  assists: number;
-  creepScore: number;
-  damageToChampions: number;
-  goldEarned: number;
-  visionScore: number;
-  damageTaken: number;
-  totalDamageDealt: number;
-  wardsPlaced: number;
-  multikills: number;
-  /** Sum of game durations (seconds), counted once per group row per game. */
-  durationSeconds: number;
-  /** Sum of time played (seconds) across group members. */
-  timePlayedSeconds: number;
-  participantRows: number;
-  earlySurrenders: number;
-  laneMinions: number;
-  neutralMinions: number;
-  goldSpent: number;
-  damageMitigated: number;
-  damageToObjectives: number;
-  damageToTurrets: number;
-  healing: number;
-  teammateHealing: number;
-  wardsKilled: number;
-  controlWardsBought: number;
-  detectorWardsPlaced: number;
-  doubleKills: number;
-  tripleKills: number;
-  quadraKills: number;
-  pentaKills: number;
-  largestMultikill: number;
-  killingSprees: number;
-  firstBloods: number;
-  championLevelTotal: number;
-  championExperienceTotal: number;
-  timeDeadSeconds: number;
-  longestLifeSeconds: number;
-  ccTimeSeconds: number;
-  turretKills: number;
-  inhibitorKills: number;
-  dragonKills: number;
-  baronKills: number;
-  arenaRows: number;
-  placementSum: number;
-  topTwoPlacements: number;
-  firstPlaceFinishes: number;
-};
+} from "#src/reports/query-types.ts";
 
 export function rowsFromAggregates(
   plan: ReportQueryPlan,

--- a/packages/scout-for-lol/packages/backend/src/reports/query-engine.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/query-engine.ts
@@ -3,7 +3,6 @@ import {
   CompetitionIdSchema,
   REPORT_MAX_ROWS_LIMIT,
   RankSchema,
-  type VisualizationSnapshot,
   parseAndCompile,
   parseCompetition,
   rankToString,
@@ -16,6 +15,7 @@ import {
   scoutReportQueryRunsTotal,
 } from "#src/metrics/report-query.ts";
 import { runLakeAggregation } from "#src/reports/duckdb/execute.ts";
+import type { ReportQueryResult } from "#src/reports/query-types.ts";
 import { resolvePlayerRefsToPuuids } from "#src/reports/identity.ts";
 import {
   requireGuildScope,
@@ -35,75 +35,6 @@ import {
 } from "#src/reports/temporal-range.ts";
 import { attachTemporalComparison } from "#src/reports/temporal-comparison.ts";
 import { buildVisualizationSnapshot } from "#src/reports/visualization-snapshot.ts";
-
-export type ReportResultValue = {
-  column: string;
-  value: number | string | null;
-  comparisonValue?: number | string | null;
-  absoluteDelta?: number | null;
-  percentageDelta?: number | null;
-  comparisonSampleSize?: number;
-  comparisonSuccesses?: number;
-  comparisonNumerator?: number;
-  comparisonDenominator?: number;
-  comparisonConfidenceInterval?: {
-    level: 0.95;
-    lower: number;
-    upper: number;
-  } | null;
-  sampleSize?: number;
-  successes?: number;
-  numerator?: number;
-  denominator?: number;
-  confidenceInterval?: {
-    level: 0.95;
-    lower: number;
-    upper: number;
-  } | null;
-};
-
-export type ReportMentionIdentity =
-  | {
-      kind: "player";
-      playerId: number | null;
-      alias: string;
-      discordId: string | null;
-    }
-  | {
-      kind: "group";
-      members: { playerId: number; alias: string }[];
-    };
-
-export type ReportResultRow = {
-  label: string;
-  dimensions: string[];
-  mentionIdentity: ReportMentionIdentity | null;
-  values: ReportResultValue[];
-};
-
-export type ReportQueryResult = {
-  plan: ReportQueryPlan;
-  columns: string[];
-  rows: ReportResultRow[];
-  rowsScanned: number;
-  comparisonRows?: ReportResultRow[];
-  visualization?: VisualizationSnapshot;
-  evidence?: {
-    label: string;
-    values: {
-      column: string;
-      sampleSize: number;
-      successes?: number;
-      numerator?: number;
-      denominator?: number;
-      confidenceInterval?: {
-        level: 0.95;
-        lower: number;
-        upper: number;
-      } | null;
-    }[];
-  }[];
-};
 
 export type ExecuteReportQueryParams = {
   prisma: ExtendedPrismaClient;

--- a/packages/scout-for-lol/packages/backend/src/reports/query-types.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/query-types.ts
@@ -1,0 +1,140 @@
+import type {
+  ReportQueryPlan,
+  VisualizationSnapshot,
+} from "@scout-for-lol/data";
+
+/**
+ * The report query layer's result contract.
+ *
+ * `query-engine.ts` orchestrates aggregation, temporal comparison and
+ * visualisation, and each of those modules consumes these shapes while the
+ * engine imports their entry points back. Declaring the contract in its own
+ * module is what keeps that from being an import cycle.
+ */
+
+export type ReportResultValue = {
+  column: string;
+  value: number | string | null;
+  comparisonValue?: number | string | null;
+  absoluteDelta?: number | null;
+  percentageDelta?: number | null;
+  comparisonSampleSize?: number;
+  comparisonSuccesses?: number;
+  comparisonNumerator?: number;
+  comparisonDenominator?: number;
+  comparisonConfidenceInterval?: {
+    level: 0.95;
+    lower: number;
+    upper: number;
+  } | null;
+  sampleSize?: number;
+  successes?: number;
+  numerator?: number;
+  denominator?: number;
+  confidenceInterval?: {
+    level: 0.95;
+    lower: number;
+    upper: number;
+  } | null;
+};
+
+export type ReportMentionIdentity =
+  | {
+      kind: "player";
+      playerId: number | null;
+      alias: string;
+      discordId: string | null;
+    }
+  | {
+      kind: "group";
+      members: { playerId: number; alias: string }[];
+    };
+
+export type ReportResultRow = {
+  label: string;
+  dimensions: string[];
+  mentionIdentity: ReportMentionIdentity | null;
+  values: ReportResultValue[];
+};
+
+export type ReportQueryResult = {
+  plan: ReportQueryPlan;
+  columns: string[];
+  rows: ReportResultRow[];
+  rowsScanned: number;
+  comparisonRows?: ReportResultRow[];
+  visualization?: VisualizationSnapshot;
+  evidence?: {
+    label: string;
+    values: {
+      column: string;
+      sampleSize: number;
+      successes?: number;
+      numerator?: number;
+      denominator?: number;
+      confidenceInterval?: {
+        level: 0.95;
+        lower: number;
+        upper: number;
+      } | null;
+    }[];
+  }[];
+};
+
+export type AggregateRow = {
+  label: string;
+  playerId: number | null;
+  discordId: string | null;
+  groupMembers: { playerId: number; alias: string }[] | null;
+  games: number;
+  wins: number;
+  surrenders: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  creepScore: number;
+  damageToChampions: number;
+  goldEarned: number;
+  visionScore: number;
+  damageTaken: number;
+  totalDamageDealt: number;
+  wardsPlaced: number;
+  multikills: number;
+  /** Sum of game durations (seconds), counted once per group row per game. */
+  durationSeconds: number;
+  /** Sum of time played (seconds) across group members. */
+  timePlayedSeconds: number;
+  participantRows: number;
+  earlySurrenders: number;
+  laneMinions: number;
+  neutralMinions: number;
+  goldSpent: number;
+  damageMitigated: number;
+  damageToObjectives: number;
+  damageToTurrets: number;
+  healing: number;
+  teammateHealing: number;
+  wardsKilled: number;
+  controlWardsBought: number;
+  detectorWardsPlaced: number;
+  doubleKills: number;
+  tripleKills: number;
+  quadraKills: number;
+  pentaKills: number;
+  largestMultikill: number;
+  killingSprees: number;
+  firstBloods: number;
+  championLevelTotal: number;
+  championExperienceTotal: number;
+  timeDeadSeconds: number;
+  longestLifeSeconds: number;
+  ccTimeSeconds: number;
+  turretKills: number;
+  inhibitorKills: number;
+  dragonKills: number;
+  baronKills: number;
+  arenaRows: number;
+  placementSum: number;
+  topTwoPlacements: number;
+  firstPlaceFinishes: number;
+};

--- a/packages/scout-for-lol/packages/backend/src/reports/report-chart-values.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/report-chart-values.ts
@@ -1,5 +1,5 @@
 import { REPORT_METRICS } from "@scout-for-lol/data";
-import type { ReportResultRow } from "#src/reports/query-engine.ts";
+import type { ReportResultRow } from "#src/reports/query-types.ts";
 
 export type MetricDisplay = { label: string; percent: boolean };
 

--- a/packages/scout-for-lol/packages/backend/src/reports/temporal-comparison.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/temporal-comparison.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { parseAndCompile } from "@scout-for-lol/data";
-import type { ReportResultRow } from "#src/reports/query-engine.ts";
+import type { ReportResultRow } from "#src/reports/query-types.ts";
 import { attachTemporalComparison } from "#src/reports/temporal-comparison.ts";
 
 function row(patch: string, games: number): ReportResultRow {

--- a/packages/scout-for-lol/packages/backend/src/reports/temporal-comparison.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/temporal-comparison.ts
@@ -8,7 +8,7 @@ import {
 import type {
   ReportQueryResult,
   ReportResultRow,
-} from "#src/reports/query-engine.ts";
+} from "#src/reports/query-types.ts";
 import {
   comparePatchLabels,
   localCalendarDate,

--- a/packages/scout-for-lol/packages/backend/src/reports/visualization-snapshot.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/visualization-snapshot.test.ts
@@ -3,7 +3,7 @@ import { parseAndCompile } from "@scout-for-lol/data";
 import type {
   ReportQueryResult,
   ReportResultRow,
-} from "#src/reports/query-engine.ts";
+} from "#src/reports/query-types.ts";
 import { buildVisualizationSnapshot } from "#src/reports/visualization-snapshot.ts";
 
 describe("buildVisualizationSnapshot", () => {

--- a/packages/scout-for-lol/packages/backend/src/reports/visualization-snapshot.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/visualization-snapshot.ts
@@ -19,7 +19,7 @@ import type {
   ReportQueryResult,
   ReportResultRow,
   ReportResultValue,
-} from "#src/reports/query-engine.ts";
+} from "#src/reports/query-types.ts";
 import {
   localDateStart,
   resolveTemporalRanges,

--- a/packages/scout-for-lol/packages/backend/src/startup.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/startup.test.ts
@@ -19,7 +19,7 @@ describe("backend startup", () => {
       },
     });
 
-    expect(calls).toEqual(["champion-assets", "http-server", "discord"]);
+    expect(calls).toEqual(["champion-assets", "discord", "http-server"]);
     expect(runtime.shutdownHttpServer).toBe(shutdownHttpServer);
   });
 
@@ -44,8 +44,8 @@ describe("backend startup", () => {
     expect(calls).toEqual([
       "champion-assets",
       "report-lake",
-      "http-server",
       "discord",
+      "http-server",
     ]);
     await runtime.shutdownHttpServer();
   });

--- a/packages/scout-for-lol/packages/backend/src/startup.ts
+++ b/packages/scout-for-lol/packages/backend/src/startup.ts
@@ -22,8 +22,14 @@ export async function runBackendStartup(
   if (dependencies.ensureReportLakeReady !== undefined) {
     await dependencies.ensureReportLakeReady();
   }
-  const httpServer = await dependencies.startHttpServer();
+  // Discord connects before the HTTP server accepts traffic. Authorization
+  // paths read the live guild cache, and an unready cache is indistinguishable
+  // from "Scout is not installed" at several call sites — so serving while the
+  // gateway is still connecting hands out false NOT_FOUNDs to real members.
+  // This ordering used to be implicit: the client module logged in from a
+  // top-level await, which the HTTP server pulled in through its tRPC routers.
   await dependencies.startDiscord();
+  const httpServer = await dependencies.startHttpServer();
   return httpServer;
 }
 

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition-edit-input.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition-edit-input.ts
@@ -7,7 +7,7 @@ import {
   DiscordGuildIdSchema,
   SeasonIdSchema,
 } from "@scout-for-lol/data";
-import { CompetitionDatesSchema } from "#src/database/competition/validation.ts";
+import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
 import type { UpdateCompetitionInput } from "#src/database/competition/queries.ts";
 
 /**

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/competition.router.ts
@@ -26,7 +26,6 @@ import {
 } from "@scout-for-lol/data";
 import { CompetitionCronSchema } from "@scout-for-lol/data/model/competition-cron.ts";
 import { computeNextScheduledUpdateAt } from "@scout-for-lol/data/model/competition-cron.ts";
-import { CompetitionDatesSchema } from "#src/database/competition/validation.ts";
 import {
   CompetitionEditInputSchema,
   WebCompetitionDatesSchema,
@@ -55,6 +54,7 @@ import {
   validateOwnerLimit,
   validateServerLimit,
 } from "#src/database/competition/validation.ts";
+import { CompetitionDatesSchema } from "#src/database/competition/competition-dates.ts";
 import {
   checkRateLimit,
   getTimeRemaining,


### PR DESCRIPTION
> ⚠️ **This touches a live-beta bot's startup path.** It changes *when* Scout connects to Discord. Please review with that lens — the risk is ordering, not logic.

Stacked on #2413, which added the `check-architecture` gate and deliberately left this package out. This is the branch that earns its way in.

## Why

`src/discord/client.ts` was doing three jobs at once:

1. constructing the gateway client,
2. registering every `client.on(...)` handler,
3. **logging in, from a top-level `await`.**

About eighteen modules import that file purely to send a message or read a guild. So all three happened as a side effect of any of those imports — including the tRPC routers, which meant **loading an HTTP route was enough to connect the bot to Discord**. Whether the gateway came up, and when, depended on which module the runtime reached first.

It also produced eight cycles of the shape `client → interactions → commands → feature → client`. The file was already losing that fight: two `await import("#src/discord/rest.ts")` call sites existed only to dodge it.

## What

**`client.ts` constructs and exports the client, and nothing else.** All eighteen consumers are untouched.

**New `discord/bootstrap.ts`** owns handler registration and login. `registerDiscordEventHandlers(target)` takes the client as a parameter so a test can exercise it, and `startDiscordGateway()` installs handlers **before** attempting login — preserving the invariant the old file documented in a comment.

**`discord/index.ts`** — already the side-effect entry reached from `startup.ts` — now awaits `startDiscordGateway()`.

**Both `await import("#src/discord/rest.ts")` workarounds are now static imports.** That is the load-bearing evidence: if the cycle were merely hidden rather than gone, these could not be made eager again.

### Twelve further cycles

The base PR removed a type-only exemption that never worked in CI (see #2413), which makes cycles closed by a type import visible for the first time. Scout had twelve, every one an eager pair where a satellite consumed a contract declared in the module that imports it back. Each is fixed by moving the contract somewhere both sides may import:

| Area | Contract moved | To |
| --- | --- | --- |
| `reports/` | `ReportQueryResult`, `ReportResultRow`, `ReportResultValue`, `ReportMentionIdentity`, `AggregateRow` | `reports/query-types.ts` — **resolves five cycles** through the `query-engine` hub |
| `betting/` | `SettlementBet` | `betting/settlement-types.ts` |
| `betting/` | `ClosedPool`, `ClosedPosition` | `betting/sweep-types.ts` |
| `league/competition/` | `RankedLeaderboardEntry` | `leaderboard-types.ts` |
| `league/competition/` | `getSnapshot` read | `snapshot-store.ts` |
| `database/competition/` | competition date schemas | `competition-dates.ts` |
| `discord/utils/` | `DeliveryFailureKind` | `delivery-failure.ts` — a pair that only ever exchanged types |
| `metrics/` | `databaseQueriesTotal` | `metrics/database-metrics.ts` |

That last one is worth a look: `database/index.ts` imported a single counter from the large `metrics/index.ts` barrel, and the barrel pulls in `betting-sweep.ts`, which needs the Prisma client type from `database/index.ts`. Moving the counter to a leaf module follows the reasoning already written down in `metrics/registry.ts`, which exists for exactly this.

## The behaviour change, stated plainly

Login now happens at the `startDiscord` step of `runBackendStartup`, rather than whenever some module first imported the client.

```
src/index.ts
  └─ startBackendRuntime() → runBackendStartup()
       ├─ validateChampionAssets()
       ├─ ensureReportLakeReady()
       ├─ startHttpServer()
       └─ startDiscord()                          ← guards: NODE_ENV, enableDiscordGateway
            └─ await import("discord/index.ts")
                 └─ await startDiscordGateway()
                      ├─ registerDiscordEventHandlers(client)   ← all 8 handlers
                      └─ client.login(token)                    ← guards preserved here too
```

The `NODE_ENV=test` and `configuration.enableDiscordGateway` guards are preserved verbatim, now in `startDiscordGateway` rather than at `client.ts` module scope.

## Verification

Run against a **clean install**, so cycle results reflect CI's TypeScript resolution rather than a worktree's.

| Check | Result |
| --- | --- |
| `bunx turbo run test --filter=@scout-for-lol/backend` | **240 test files pass** |
| `bunx turbo run typecheck lint --filter=@scout-for-lol/backend` | clean — `architecture: 712 modules clean`, was 20 violations |
| `bun run knip` | clean |

**The ordering risk is tested directly.** `src/discord/bootstrap.test.ts` stubs `login` so it records `client.eventNames()` at the exact instant login is called, then asserts every handled event is already registered. It also asserts exactly one handler is added per event — counting the *delta*, since discord.js installs listeners of its own — and that `NODE_ENV=test` skips login while still installing handlers.

**Not run against live Discord.** The gateway connection itself is not exercised; what is verified is the registration-before-login ordering, the preserved guards, and that the rest of the suite is unaffected.

## Reviewer's question

Previously an HTTP-only or cron-only process could end up connected to Discord simply because it imported a tRPC router. Now it will not. I believe that is a fix rather than a regression — `startup.ts` already had an explicit `startDiscord` step whose guards were being bypassed by the import side effect — but if any deployment relies on the implicit connection, this is where it would surface.


---

## Review round — two real findings, both fixed

Codex caught two genuine consequences of moving login out of the client module. Both are fixed here; neither was dismissed.

**P1 — the pod could serve traffic before the gateway connected.** With login no longer happening during `startHttpServer()`'s module load, `/healthz` could return 200 while the guild cache was still empty. `resolveGuildPermissions` reads `discordClient.guilds.cache.has()` unguarded, so requests in that window got `NOT_FOUND` — "Scout is not installed in that guild" — told to actual members.

Fixed by making the ordering explicit rather than accidental: `runBackendStartup` now awaits `startDiscord()` **before** `startHttpServer()`, restoring the sequence the old top-level-await login produced implicitly through the tRPC routers. `startup.test.ts` asserts the new order.

**P2 — `scripts/outreach.ts` would have hung forever.** It waits on a `ready` event and relied on the import side effect to log in. It now imports `startDiscordGateway` and awaits it first. Verified by grep that it is the only script importing `discord/client.ts`.

### One thing deliberately *not* fixed here

`resolveGuildPermissions` reading the guild cache without an `isReady()` guard is a pre-existing bug — its own docstring promises "UNAUTHORIZED or SERVICE_UNAVAILABLE, never FORBIDDEN — an outage is not a permission answer", and an unready cache still yields NOT_FOUND on any gateway reconnect, independent of this PR.

I tried fixing it and reverted: adding the guard breaks **8 test files**, because the shared tRPC harness (`src/testing/test-trpc-caller.ts`) mocks `isReady: () => false` while making `guilds.cache.has()` report hits — an internally impossible client state. Correcting that means changing a harness shared by 240 test files and re-validating what shifts. That deserves its own reviewed change rather than riding along here. The ordering fix above closes the window this PR opened; the reconnect window remains and is recorded in the resolved-thread audit comment.

## Verification note

Run against a clean `bun install --frozen-lockfile` so results reflect CI's TypeScript resolution. `turborepo-verify` and the Codex review gate both pass. The Scout in-image smoke passes with this ordering change — it sets `ENABLE_DISCORD_GATEWAY: "false"`, so `startDiscord()` returns at its guard and the HTTP server starts exactly as before.
