### PR TITLE
Run deterministic weekly Bryan Bucks parlays

### DIFF
--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-24T06:10:46.077Z",
+  "generatedAt": "2026-08-24T06:17:55.749Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -275,6 +275,19 @@
       ],
       "blankFields": [
         "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
+        "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+      ]
+    },
+    {
+      "ref": "496081099fb053c329a3ed9506243779d3c23fc8851671a9391a3af49cfaec73",
+      "title": "9a6688184fc99d09c6bb24262ce6fc9aa5321ff71131688b8a03ab4163ec8078",
+      "fields": [
+        "3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
         "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
       ]
     },

--- a/packages/scout-for-lol/packages/backend/package.json
+++ b/packages/scout-for-lol/packages/backend/package.json
@@ -41,7 +41,8 @@
     "generate:marketing-showcase": "bun run scripts/generate-marketing-showcase.ts",
     "test:review": "bun run src/league/review/test-reviews.ts",
     "test:report": "CI_TEST_COVERAGE=1 bun ../../../../scripts/run-ci-test.ts",
-    "test:parlay:live": "bun run scripts/test-parlay-live.ts"
+    "test:parlay:live": "bun run scripts/test-parlay-live.ts",
+    "test:weekly-parlay:live": "bun run scripts/test-weekly-parlay-live.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1001.0",

--- a/packages/scout-for-lol/packages/backend/scripts/test-weekly-parlay-live.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/test-weekly-parlay-live.ts
@@ -1,0 +1,56 @@
+import { DiscordAccountIdSchema, LeaguePuuidSchema } from "@scout-for-lol/data";
+import {
+  validateWeeklyParlayProposal,
+  WeeklyParlaySubjectSchema,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { generateWeeklyParlayProposal } from "#src/betting/weekly-parlay-model.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("test-weekly-parlay-live");
+if (Bun.env["OPENROUTER_API_KEY"] === undefined) {
+  throw new Error("OPENROUTER_API_KEY is required for test:weekly-parlay:live");
+}
+
+const subject = WeeklyParlaySubjectSchema.parse({
+  key: "P1",
+  playerId: 1,
+  alias: "Weekly Test Player",
+  discordId: DiscordAccountIdSchema.parse("160509172704739328"),
+  accounts: [
+    {
+      puuid: LeaguePuuidSchema.parse("weekly-live".padEnd(78, "x")),
+      trackingStartedAt: "2025-01-01T00:00:00.000Z",
+    },
+  ],
+});
+const champions = new Set(["Ahri", "Jinx", "Lee Sin", "Nautilus", "Ornn"]);
+const roles = new Set([
+  "TOP",
+  "JUNGLE",
+  "MIDDLE",
+  "BOTTOM",
+  "UTILITY",
+] as const);
+const generated = await generateWeeklyParlayProposal({
+  periodKey: "2026-08-24",
+  subjects: [subject],
+  observedChampions: new Map([[subject.key, champions]]),
+  observedRoles: new Map([[subject.key, roles]]),
+  recentEligibleGames: new Map([[subject.key, 6]]),
+  historyWindows: 30,
+});
+const issues = validateWeeklyParlayProposal({
+  proposal: generated.proposal,
+  subjects: [subject],
+  observedChampions: new Map([[subject.key, champions]]),
+  observedRoles: new Map([[subject.key, roles]]),
+});
+if (issues.length > 0) {
+  throw new Error(
+    `Weekly prompt failed semantic validation: ${issues.join("; ")}`,
+  );
+}
+logger.info("Weekly parlay live prompt accepted", {
+  model: generated.resolvedModel ?? generated.model,
+  legs: generated.proposal.legs.length,
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/accounts.ts
@@ -2,6 +2,7 @@ import {
   BucksLedgerKindSchema,
   BucksParlayMarketStateSchema,
   BucksParlaySideSchema,
+  BucksWeeklyParlayMarketStateSchema,
   BucksPoolRosterSchema,
   BucksPoolStateSchema,
   RiotTeamIdSchema,
@@ -17,6 +18,7 @@ import {
   InsufficientBucksError,
 } from "#src/betting/ledger.ts";
 import { ParlaySubjectsSchema } from "#src/betting/parlay-criteria.ts";
+import { WeeklyParlaySubjectsSchema } from "#src/betting/weekly-parlay-criteria.ts";
 import {
   hasTrackedPlayersOnBothTeams,
   outcomeLabel,
@@ -354,7 +356,13 @@ export async function getPersonalBucksView(
       return;
     }
 
-    const [outcomeBets, parlayAggregate, parlayBets] = await Promise.all([
+    const [
+      outcomeBets,
+      parlayAggregate,
+      parlayBets,
+      weeklyAggregate,
+      weeklyBets,
+    ] = await Promise.all([
       tx.bucksBet.findMany({
         where: { bucksAccountId: account.id, betOutcome: "pending" },
         orderBy: [{ createdAt: "desc" }, { id: "desc" }],
@@ -394,6 +402,30 @@ export async function getPersonalBucksView(
             select: {
               matchId: true,
               closesAt: true,
+              marketState: true,
+              definition: { select: { subjects: true } },
+            },
+          },
+        },
+      }),
+      tx.bucksWeeklyParlayBet.aggregate({
+        where: { bucksAccountId: account.id, betOutcome: "pending" },
+        _sum: { stake: true },
+        _count: true,
+      }),
+      tx.bucksWeeklyParlayBet.findMany({
+        where: { bucksAccountId: account.id, betOutcome: "pending" },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        take: 10,
+        select: {
+          id: true,
+          createdAt: true,
+          stake: true,
+          side: true,
+          market: {
+            select: {
+              periodKey: true,
+              bettingClosesAt: true,
               marketState: true,
               definition: { select: { subjects: true } },
             },
@@ -448,7 +480,28 @@ export async function getPersonalBucksView(
       closesAt: bet.market.closesAt,
       poolState: BucksParlayMarketStateSchema.parse(bet.market.marketState),
     }));
-    const pendingPositions = [...outcomePositions, ...parlayPositions]
+    const weeklyPositions = weeklyBets.map((bet) => ({
+      id: bet.id,
+      createdAt: bet.createdAt,
+      marketType: "parlay" as const,
+      matchId: `weekly:${bet.market.periodKey}`,
+      subjectAlias: `Weekly (${WeeklyParlaySubjectsSchema.parse(
+        JSON.parse(bet.market.definition.subjects),
+      )
+        .map((subject) => subject.alias)
+        .join(", ")})`,
+      side: BucksParlaySideSchema.parse(bet.side),
+      stake: bet.stake,
+      closesAt: bet.market.bettingClosesAt,
+      poolState: BucksWeeklyParlayMarketStateSchema.parse(
+        bet.market.marketState,
+      ),
+    }));
+    const pendingPositions = [
+      ...outcomePositions,
+      ...parlayPositions,
+      ...weeklyPositions,
+    ]
       .toSorted(
         (left, right) =>
           right.createdAt.getTime() - left.createdAt.getTime() ||
@@ -463,8 +516,11 @@ export async function getPersonalBucksView(
         outcomeBets.reduce(
           (total, bet) => total + (bet.matchedStake ?? bet.stake),
           0,
-        ) + (parlayAggregate._sum.stake ?? 0),
-      pendingPositionCount: outcomeBets.length + parlayAggregate._count,
+        ) +
+        (parlayAggregate._sum.stake ?? 0) +
+        (weeklyAggregate._sum.stake ?? 0),
+      pendingPositionCount:
+        outcomeBets.length + parlayAggregate._count + weeklyAggregate._count,
       pendingPositions,
     };
   });

--- a/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.ts
@@ -34,6 +34,7 @@ export type BucksMessageSurface =
   | "parlay_preparation"
   | "parlay_market"
   | "settlement"
+  | "weekly_parlay"
   | "weekly_leaderboard";
 
 export type BucksMessageOperation = "send" | "edit";

--- a/packages/scout-for-lol/packages/backend/src/betting/ledger.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/ledger.ts
@@ -53,6 +53,7 @@ export type ApplyBucksDeltaInput = {
   matchId?: string | undefined;
   betId?: number | undefined;
   parlayBetId?: number | undefined;
+  weeklyParlayBetId?: number | undefined;
   predictedTeamId?: number | undefined;
   actualWinningTeamId?: number | undefined;
   /**
@@ -95,7 +96,13 @@ export async function refundableBucksHeldForAccounts(
         .map((account) => account.serverId),
     ),
   ];
-  const [outcomeRows, humanParlayRows, houseParlayRows] = await Promise.all([
+  const [
+    outcomeRows,
+    humanParlayRows,
+    houseParlayRows,
+    humanWeeklyRows,
+    houseWeeklyRows,
+  ] = await Promise.all([
     tx.bucksBet.findMany({
       where: {
         bucksAccountId: { in: accountIds },
@@ -121,6 +128,24 @@ export async function refundableBucksHeldForAccounts(
         market: { select: { serverId: true } },
       },
     }),
+    tx.bucksWeeklyParlayBet.groupBy({
+      by: ["bucksAccountId"],
+      where: {
+        bucksAccountId: { in: humanAccountIds },
+        betOutcome: "pending",
+      },
+      _sum: { stake: true },
+    }),
+    tx.bucksWeeklyParlayBet.findMany({
+      where: {
+        betOutcome: "pending",
+        market: { serverId: { in: houseServerIds } },
+      },
+      select: {
+        houseReserve: true,
+        market: { select: { serverId: true } },
+      },
+    }),
   ]);
 
   const outcomeByAccount = new Map<number, bigint>();
@@ -134,8 +159,18 @@ export async function refundableBucksHeldForAccounts(
   const parlayByAccount = new Map(
     humanParlayRows.map((row) => [row.bucksAccountId, row._sum.stake ?? 0]),
   );
+  const weeklyByAccount = new Map(
+    humanWeeklyRows.map((row) => [row.bucksAccountId, row._sum.stake ?? 0]),
+  );
   const reserveByServer = new Map<string, bigint>();
   for (const row of houseParlayRows) {
+    reserveByServer.set(
+      row.market.serverId,
+      (reserveByServer.get(row.market.serverId) ?? 0n) +
+        BigInt(row.houseReserve),
+    );
+  }
+  for (const row of houseWeeklyRows) {
     reserveByServer.set(
       row.market.serverId,
       (reserveByServer.get(row.market.serverId) ?? 0n) +
@@ -149,7 +184,8 @@ export async function refundableBucksHeldForAccounts(
       (outcomeByAccount.get(account.id) ?? 0n) +
         (account.isHouse
           ? (reserveByServer.get(account.serverId) ?? 0n)
-          : BigInt(parlayByAccount.get(account.id) ?? 0)),
+          : BigInt(parlayByAccount.get(account.id) ?? 0) +
+            BigInt(weeklyByAccount.get(account.id) ?? 0)),
     ]),
   );
 }
@@ -177,20 +213,43 @@ export async function refundableBucksHeld(
     0n,
   );
   if (account.isHouse) {
-    const parlay = await tx.bucksParlayBet.aggregate({
-      where: {
-        betOutcome: "pending",
-        market: { serverId: account.serverId },
-      },
-      _sum: { houseReserve: true },
-    });
-    return outcomeHeld + BigInt(parlay._sum.houseReserve ?? 0);
+    const [parlay, weekly] = await Promise.all([
+      tx.bucksParlayBet.aggregate({
+        where: {
+          betOutcome: "pending",
+          market: { serverId: account.serverId },
+        },
+        _sum: { houseReserve: true },
+      }),
+      tx.bucksWeeklyParlayBet.aggregate({
+        where: {
+          betOutcome: "pending",
+          market: { serverId: account.serverId },
+        },
+        _sum: { houseReserve: true },
+      }),
+    ]);
+    return (
+      outcomeHeld +
+      BigInt(parlay._sum.houseReserve ?? 0) +
+      BigInt(weekly._sum.houseReserve ?? 0)
+    );
   }
-  const parlay = await tx.bucksParlayBet.aggregate({
-    where: { bucksAccountId, betOutcome: "pending" },
-    _sum: { stake: true },
-  });
-  return outcomeHeld + BigInt(parlay._sum.stake ?? 0);
+  const [parlay, weekly] = await Promise.all([
+    tx.bucksParlayBet.aggregate({
+      where: { bucksAccountId, betOutcome: "pending" },
+      _sum: { stake: true },
+    }),
+    tx.bucksWeeklyParlayBet.aggregate({
+      where: { bucksAccountId, betOutcome: "pending" },
+      _sum: { stake: true },
+    }),
+  ]);
+  return (
+    outcomeHeld +
+    BigInt(parlay._sum.stake ?? 0) +
+    BigInt(weekly._sum.stake ?? 0)
+  );
 }
 
 /**
@@ -278,6 +337,7 @@ export async function applyBucksDelta(
       matchId: input.matchId ?? null,
       betId: input.betId ?? null,
       parlayBetId: input.parlayBetId ?? null,
+      weeklyParlayBetId: input.weeklyParlayBetId ?? null,
       predictedTeamId: input.predictedTeamId ?? null,
       actualWinningTeamId: input.actualWinningTeamId ?? null,
       // Validated on the way in, so a malformed explanation can never be

--- a/packages/scout-for-lol/packages/backend/src/betting/postmatch-hook.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/postmatch-hook.ts
@@ -16,6 +16,7 @@ import {
 } from "#src/betting/sweep.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isFeatureHardDisabled } from "#src/configuration/flags.ts";
+import { captureWeeklyParlayContributions } from "#src/betting/weekly-parlay-contribution.ts";
 
 export async function refreshSettledPoolMessages(
   straightPools: readonly { matchId: string; serverId: string }[],
@@ -72,6 +73,10 @@ export async function settleAndAwardBucks(
     matchData,
     prismaClient,
   );
+  // The canonical match has already been persisted by the caller. Weekly
+  // progress is append-only and may settle only an irreversible YES here;
+  // Sunday finalization remains the only path to an early-false result.
+  await captureWeeklyParlayContributions(matchData, prismaClient);
   const earnings = await awardBucksForMatch(matchData, prismaClient);
   // Discord cleanup runs after the committed local operations and regardless
   // of whether the caller suppresses an old match's post-match notification.

--- a/packages/scout-for-lol/packages/backend/src/betting/transition-log.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transition-log.ts
@@ -51,6 +51,16 @@ export type BucksTransitionEvent =
   | "bucks.parlay_bet.placed"
   | "bucks.parlay_bet.cancelled"
   | "bucks.parlay_bet.settled"
+  | "bucks.weekly_parlay.published"
+  | "bucks.weekly_parlay.opened"
+  | "bucks.weekly_parlay.started"
+  | "bucks.weekly_parlay.settled"
+  | "bucks.weekly_parlay.voided"
+  | "bucks.weekly_parlay_bet.placed"
+  | "bucks.weekly_parlay_bet.topped_up"
+  | "bucks.weekly_parlay_bet.cancelled"
+  | "bucks.weekly_parlay_bet.settled"
+  | "bucks.weekly_parlay.contribution_recorded"
   | "bucks.earning.awarded"
   | "bucks.peek_pass.purchased";
 
@@ -62,6 +72,9 @@ export type BucksTransitionFields = {
   marketId?: number;
   betId?: number;
   parlayBetId?: number;
+  definitionId?: number;
+  periodKey?: string;
+  slot?: number;
   bucksAccountId?: number;
   actorDiscordId?: string;
   fromState?: string;
@@ -79,6 +92,7 @@ export type BucksTransitionFields = {
   surface?: "button" | "command" | "sweep" | "postmatch" | "cron" | "prematch";
   queueType?: string;
   isHouse?: boolean;
+  contributionCount?: number;
 };
 
 export function logBucksTransition(fields: BucksTransitionFields): void {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet-button.ts
@@ -9,6 +9,7 @@ import {
   type PlaceWeeklyParlayBetResult,
 } from "#src/betting/weekly-parlay-bet.ts";
 import { parseWeeklyParlayCustomId } from "#src/betting/weekly-parlay-custom-id.ts";
+import { refreshWeeklyParlayMessage } from "#src/betting/weekly-parlay-discord.ts";
 import type { BetButtonInteraction } from "#src/betting/bet-button.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 
@@ -81,6 +82,9 @@ export async function handleWeeklyParlayBetButton(
   if (parsed.action === "x") {
     const result = await cancelWeeklyParlayBet(common, prismaClient);
     await interaction.editReply({ content: describeCancel(result) });
+    if (result.kind === "cancelled") {
+      await refreshWeeklyParlayMessage(parsed.marketId, prismaClient);
+    }
     return;
   }
   const result = await placeWeeklyParlayBet(
@@ -88,4 +92,7 @@ export async function handleWeeklyParlayBetButton(
     prismaClient,
   );
   await interaction.editReply({ content: describeWeeklyParlayBet(result) });
+  if (result.kind === "placed") {
+    await refreshWeeklyParlayMessage(parsed.marketId, prismaClient);
+  }
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet-button.ts
@@ -1,0 +1,91 @@
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import {
+  cancelWeeklyParlayBet,
+  placeWeeklyParlayBet,
+  type CancelWeeklyParlayBetResult,
+  type PlaceWeeklyParlayBetResult,
+} from "#src/betting/weekly-parlay-bet.ts";
+import { parseWeeklyParlayCustomId } from "#src/betting/weekly-parlay-custom-id.ts";
+import type { BetButtonInteraction } from "#src/betting/bet-button.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+
+export function describeWeeklyParlayBet(
+  result: PlaceWeeklyParlayBetResult,
+): string {
+  switch (result.kind) {
+    case "placed":
+      return `✅ Weekly **${result.side}** position: **${result.totalStake.toString()} BB**, paying **${result.grossPayout.toString()} BB** if it wins. Balance: **${result.balanceAfter.toString()} BB**.`;
+    case "window_closed":
+      return "⏰ Weekly parlay betting has closed.";
+    case "no_market":
+      return "No matching weekly parlay exists.";
+    case "feature_disabled":
+      return "Weekly parlays are not accepting new positions.";
+    case "not_eligible":
+      return "Link a tracked player before betting Bryan Bucks.";
+    case "invalid_stake":
+      return "Use a positive whole-BB stake.";
+    case "storage_limit":
+      return "That position exceeds Bryan Bucks storage limits.";
+    case "insufficient":
+      return `You have ${result.balance.toString()} BB but need ${result.needed.toString()} BB.`;
+    case "wallet_house_insufficient":
+    case "house_insufficient":
+      return "🏦 The Bryan Bucks house cannot reserve that payout. No Bucks moved.";
+    case "side_conflict":
+      return `You already backed ${result.existingSide}. Cancel from this message first.`;
+  }
+}
+
+function describeCancel(result: CancelWeeklyParlayBetResult): string {
+  switch (result.kind) {
+    case "cancelled":
+      return `↩️ Cancelled: **${result.refunded.toString()} BB** back, no fee · balance **${result.balanceAfter.toString()} BB**.`;
+    case "no_market":
+      return "No matching weekly parlay exists.";
+    case "no_bet":
+      return "You do not have a position on this weekly parlay.";
+    case "window_closed":
+      return "⏰ Betting has closed, so the position is locked.";
+    case "already_resolved":
+      return result.marketState === "settled"
+        ? "This weekly parlay already settled."
+        : "This weekly parlay was already refunded.";
+  }
+}
+
+export async function handleWeeklyParlayBetButton(
+  interaction: BetButtonInteraction,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  const parsed = parseWeeklyParlayCustomId(interaction.customId);
+  if (parsed === undefined) {
+    return;
+  }
+  await interaction.deferReply({ ephemeral: true });
+  if (interaction.guildId === null) {
+    await interaction.editReply({
+      content: "Bryan Bucks only works in a server.",
+    });
+    return;
+  }
+  const common = {
+    marketId: parsed.marketId,
+    serverId: DiscordGuildIdSchema.parse(interaction.guildId),
+    discordId: DiscordAccountIdSchema.parse(interaction.user.id),
+    surface: "button" as const,
+  };
+  if (parsed.action === "x") {
+    const result = await cancelWeeklyParlayBet(common, prismaClient);
+    await interaction.editReply({ content: describeCancel(result) });
+    return;
+  }
+  const result = await placeWeeklyParlayBet(
+    { ...common, side: parsed.side, stake: parsed.amount },
+    prismaClient,
+  );
+  await interaction.editReply({ content: describeWeeklyParlayBet(result) });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet-button.ts
@@ -9,7 +9,7 @@ import {
   type PlaceWeeklyParlayBetResult,
 } from "#src/betting/weekly-parlay-bet.ts";
 import { parseWeeklyParlayCustomId } from "#src/betting/weekly-parlay-custom-id.ts";
-import { refreshWeeklyParlayMessage } from "#src/betting/weekly-parlay-discord.ts";
+import { refreshWeeklyParlayMessage } from "#src/betting/weekly-parlay-refresh.ts";
 import type { BetButtonInteraction } from "#src/betting/bet-button.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-bet.ts
@@ -1,0 +1,424 @@
+import {
+  BucksParlaySideSchema,
+  BucksStakeSchema,
+  type BucksParlaySide,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import {
+  ensureBucksAccount,
+  findEligiblePlayer,
+  HouseInsufficientError as WalletHouseInsufficientError,
+} from "#src/betting/accounts.ts";
+import { ensureHouseAccountInTransaction } from "#src/betting/house.ts";
+import {
+  applyBucksDelta,
+  BucksStorageOverflowError,
+  InsufficientBucksError,
+} from "#src/betting/ledger.ts";
+import { addInt32, quoteParlayPosition } from "#src/betting/parlay-odds.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  bettingWeeklyParlayBetCancellationsTotal,
+  bettingWeeklyParlayBetPlacementsTotal,
+} from "#src/metrics/betting-weekly-parlay.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+
+export type PlaceWeeklyParlayBetResult =
+  | {
+      kind: "placed";
+      side: BucksParlaySide;
+      totalStake: number;
+      grossPayout: number;
+      balanceAfter: number;
+      wasTopUp: boolean;
+    }
+  | { kind: "window_closed" | "no_market" | "feature_disabled" }
+  | { kind: "not_eligible" | "invalid_stake" | "storage_limit" }
+  | { kind: "insufficient"; balance: number; needed: number }
+  | { kind: "wallet_house_insufficient" | "house_insufficient" }
+  | { kind: "side_conflict"; existingSide: BucksParlaySide };
+
+class WeeklyHouseInsufficientError extends Error {
+  constructor() {
+    super("The Bryan Bucks house cannot reserve this weekly liability");
+    this.name = "WeeklyHouseInsufficientError";
+  }
+}
+
+async function placeWeeklyParlayBetInternal(
+  input: {
+    marketId: number;
+    serverId: DiscordGuildId;
+    discordId: DiscordAccountId;
+    side: BucksParlaySide;
+    stake: number;
+    now?: Date;
+    surface?: "button" | "command";
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<PlaceWeeklyParlayBetResult> {
+  const [bettingEnabled, weeklyEnabled] = await Promise.all([
+    isPolicyEnabled("betting_enabled", { server: input.serverId }),
+    isPolicyEnabled("weekly_parlays_enabled", { server: input.serverId }),
+  ]);
+  if (!bettingEnabled || !weeklyEnabled) {
+    return { kind: "feature_disabled" };
+  }
+  const stake = BucksStakeSchema.safeParse(input.stake);
+  const side = BucksParlaySideSchema.safeParse(input.side);
+  if (!stake.success || !side.success) {
+    return { kind: "invalid_stake" };
+  }
+  const market = await prismaClient.bucksWeeklyParlayMarket.findFirst({
+    where: { id: input.marketId, serverId: input.serverId },
+    select: {
+      id: true,
+      periodKey: true,
+      slot: true,
+      definition: { select: { id: true, yesProbabilityBps: true } },
+    },
+  });
+  if (market === null) {
+    return { kind: "no_market" };
+  }
+  const player = await findEligiblePlayer(
+    { serverId: input.serverId, discordId: input.discordId },
+    prismaClient,
+  );
+  if (player === undefined) {
+    return { kind: "not_eligible" };
+  }
+  let account: Awaited<ReturnType<typeof ensureBucksAccount>>;
+  try {
+    account = await ensureBucksAccount(
+      { serverId: input.serverId, discordId: input.discordId },
+      prismaClient,
+    );
+  } catch (error) {
+    if (error instanceof WalletHouseInsufficientError) {
+      return { kind: "wallet_house_insufficient" };
+    }
+    throw error;
+  }
+
+  try {
+    return await prismaClient.$transaction(async (tx) => {
+      const now = input.now ?? new Date();
+      // FIRST write: guarded closure check and market-row lock.
+      const claim = await tx.bucksWeeklyParlayMarket.updateMany({
+        where: {
+          id: market.id,
+          marketState: "open",
+          bettingClosesAt: { gt: now },
+        },
+        data: { updatedAt: now },
+      });
+      if (claim.count !== 1) {
+        return { kind: "window_closed" };
+      }
+      const existing = await tx.bucksWeeklyParlayBet.findUnique({
+        where: {
+          marketId_bucksAccountId: {
+            marketId: market.id,
+            bucksAccountId: account.id,
+          },
+        },
+        select: { id: true, side: true, stake: true, houseReserve: true },
+      });
+      if (existing !== null) {
+        const existingSide = BucksParlaySideSchema.parse(existing.side);
+        if (existingSide !== side.data) {
+          return { kind: "side_conflict", existingSide };
+        }
+      }
+      const totalStake = addInt32(existing?.stake ?? 0, stake.data);
+      if (totalStake === undefined) {
+        return { kind: "storage_limit" };
+      }
+      const quote = quoteParlayPosition({
+        totalStake,
+        yesProbabilityBps: market.definition.yesProbabilityBps,
+        side: side.data,
+      });
+      if (quote === undefined) {
+        return { kind: "storage_limit" };
+      }
+      const additionalReserve =
+        quote.houseReserve - (existing?.houseReserve ?? 0);
+      if (additionalReserve < 0) {
+        throw new Error("A weekly top-up reduced reserved liability.");
+      }
+      const house = await ensureHouseAccountInTransaction(tx, input.serverId);
+      const bet =
+        existing === null
+          ? await tx.bucksWeeklyParlayBet.create({
+              data: {
+                marketId: market.id,
+                bucksAccountId: account.id,
+                side: side.data,
+                stake: stake.data,
+                houseReserve: quote.houseReserve,
+                grossPayout: quote.grossPayout,
+              },
+              select: { id: true },
+            })
+          : await tx.bucksWeeklyParlayBet.update({
+              where: { id: existing.id },
+              data: {
+                stake: totalStake,
+                houseReserve: quote.houseReserve,
+                grossPayout: quote.grossPayout,
+              },
+              select: { id: true },
+            });
+      const balanceAfter = await applyBucksDelta(tx, {
+        bucksAccountId: account.id,
+        delta: -stake.data,
+        kind: "weekly_parlay_stake",
+        weeklyParlayBetId: bet.id,
+        context: {
+          type: "weekly_parlay_stake",
+          version: 1,
+          definitionId: market.definition.id,
+          periodKey: market.periodKey,
+          slot: market.slot,
+          side: side.data,
+          yesProbabilityBps: market.definition.yesProbabilityBps,
+          totalStake,
+          quotedGrossPayout: quote.grossPayout,
+        },
+      });
+      if (additionalReserve > 0) {
+        try {
+          await applyBucksDelta(tx, {
+            bucksAccountId: house.id,
+            delta: -additionalReserve,
+            kind: "weekly_parlay_reserve",
+            weeklyParlayBetId: bet.id,
+            context: {
+              type: "weekly_parlay_reserve",
+              version: 1,
+              definitionId: market.definition.id,
+              periodKey: market.periodKey,
+              slot: market.slot,
+              side: side.data,
+              yesProbabilityBps: market.definition.yesProbabilityBps,
+              totalStake,
+              totalReserve: quote.houseReserve,
+              quotedGrossPayout: quote.grossPayout,
+            },
+          });
+        } catch (error) {
+          if (error instanceof InsufficientBucksError) {
+            throw new WeeklyHouseInsufficientError();
+          }
+          throw error;
+        }
+      }
+      return {
+        kind: "placed",
+        side: side.data,
+        totalStake,
+        grossPayout: quote.grossPayout,
+        balanceAfter,
+        wasTopUp: existing !== null,
+      };
+    });
+  } catch (error) {
+    if (error instanceof WeeklyHouseInsufficientError) {
+      return { kind: "house_insufficient" };
+    }
+    if (error instanceof InsufficientBucksError) {
+      const current = await prismaClient.bucksAccount.findUnique({
+        where: { id: account.id },
+        select: { balance: true },
+      });
+      return {
+        kind: "insufficient",
+        balance: current?.balance ?? 0,
+        needed: stake.data,
+      };
+    }
+    if (error instanceof BucksStorageOverflowError) {
+      return { kind: "storage_limit" };
+    }
+    throw error;
+  }
+}
+
+export async function placeWeeklyParlayBet(
+  input: {
+    marketId: number;
+    serverId: DiscordGuildId;
+    discordId: DiscordAccountId;
+    side: BucksParlaySide;
+    stake: number;
+    now?: Date;
+    surface?: "button" | "command";
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<PlaceWeeklyParlayBetResult> {
+  const result = await placeWeeklyParlayBetInternal(input, prismaClient);
+  if (result.kind === "placed") {
+    const transition = result.wasTopUp ? "topped_up" : "placed";
+    bettingWeeklyParlayBetPlacementsTotal.inc({ result: transition });
+    logBucksTransition({
+      event: result.wasTopUp
+        ? "bucks.weekly_parlay_bet.topped_up"
+        : "bucks.weekly_parlay_bet.placed",
+      serverId: input.serverId,
+      marketId: input.marketId,
+      actorDiscordId: input.discordId,
+      side: result.side,
+      stake: result.totalStake,
+      grossPayout: result.grossPayout,
+      balanceAfter: result.balanceAfter,
+      surface: input.surface ?? "button",
+    });
+  }
+  return result;
+}
+
+export type CancelWeeklyParlayBetResult =
+  | { kind: "cancelled"; refunded: number; balanceAfter: number }
+  | { kind: "no_market" | "no_bet" | "window_closed" }
+  | { kind: "already_resolved"; marketState: "settled" | "voided" };
+
+async function cancelWeeklyParlayBetInternal(
+  input: {
+    marketId: number;
+    serverId: DiscordGuildId;
+    discordId: DiscordAccountId;
+    now?: Date;
+    surface?: "button" | "command";
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<CancelWeeklyParlayBetResult> {
+  const market = await prismaClient.bucksWeeklyParlayMarket.findFirst({
+    where: { id: input.marketId, serverId: input.serverId },
+    select: {
+      id: true,
+      periodKey: true,
+      slot: true,
+      definition: { select: { id: true } },
+    },
+  });
+  if (market === null) {
+    return { kind: "no_market" };
+  }
+  const account = await prismaClient.bucksAccount.findUnique({
+    where: {
+      serverId_discordId: {
+        serverId: input.serverId,
+        discordId: input.discordId,
+      },
+    },
+    select: { id: true },
+  });
+  if (account === null) {
+    return { kind: "no_bet" };
+  }
+  const now = input.now ?? new Date();
+  return await prismaClient.$transaction(async (tx) => {
+    const claim = await tx.bucksWeeklyParlayMarket.updateMany({
+      where: {
+        id: market.id,
+        marketState: "open",
+        bettingClosesAt: { gt: now },
+      },
+      data: { updatedAt: now },
+    });
+    if (claim.count !== 1) {
+      const current = await tx.bucksWeeklyParlayMarket.findUniqueOrThrow({
+        where: { id: market.id },
+        select: { marketState: true },
+      });
+      if (
+        current.marketState === "settled" ||
+        current.marketState === "voided"
+      ) {
+        return { kind: "already_resolved", marketState: current.marketState };
+      }
+      return { kind: "window_closed" };
+    }
+    const bet = await tx.bucksWeeklyParlayBet.findUnique({
+      where: {
+        marketId_bucksAccountId: {
+          marketId: market.id,
+          bucksAccountId: account.id,
+        },
+      },
+      select: {
+        id: true,
+        side: true,
+        stake: true,
+        houseReserve: true,
+        grossPayout: true,
+      },
+    });
+    if (bet === null) {
+      return { kind: "no_bet" };
+    }
+    const side = BucksParlaySideSchema.parse(bet.side);
+    const house = await ensureHouseAccountInTransaction(tx, input.serverId);
+    await tx.bucksWeeklyParlayBet.update({
+      where: { id: bet.id },
+      data: { betOutcome: "refunded", payout: bet.stake, settledAt: now },
+    });
+    const contextBase = {
+      type: "weekly_parlay_settlement" as const,
+      version: 1 as const,
+      definitionId: market.definition.id,
+      periodKey: market.periodKey,
+      slot: market.slot,
+      side,
+      stake: bet.stake,
+      reserve: bet.houseReserve,
+      grossPayout: bet.grossPayout,
+    };
+    const balanceAfter = await applyBucksDelta(tx, {
+      bucksAccountId: account.id,
+      delta: bet.stake,
+      kind: "weekly_parlay_refund",
+      weeklyParlayBetId: bet.id,
+      context: { ...contextBase, credited: bet.stake },
+    });
+    await applyBucksDelta(tx, {
+      bucksAccountId: house.id,
+      delta: bet.houseReserve,
+      kind: "weekly_parlay_release",
+      weeklyParlayBetId: bet.id,
+      context: { ...contextBase, credited: bet.houseReserve },
+    });
+    await tx.bucksWeeklyParlayBet.delete({ where: { id: bet.id } });
+    return { kind: "cancelled", refunded: bet.stake, balanceAfter };
+  });
+}
+
+export async function cancelWeeklyParlayBet(
+  input: {
+    marketId: number;
+    serverId: DiscordGuildId;
+    discordId: DiscordAccountId;
+    now?: Date;
+    surface?: "button" | "command";
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<CancelWeeklyParlayBetResult> {
+  const result = await cancelWeeklyParlayBetInternal(input, prismaClient);
+  if (result.kind === "cancelled") {
+    bettingWeeklyParlayBetCancellationsTotal.inc();
+    logBucksTransition({
+      event: "bucks.weekly_parlay_bet.cancelled",
+      serverId: input.serverId,
+      marketId: input.marketId,
+      actorDiscordId: input.discordId,
+      stake: result.refunded,
+      balanceAfter: result.balanceAfter,
+      surface: input.surface ?? "button",
+    });
+  }
+  return result;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-contribution.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-contribution.ts
@@ -1,0 +1,253 @@
+import * as Sentry from "@sentry/bun";
+import {
+  LeaguePuuidSchema,
+  resolveQueueTypeFromGame,
+  type RawMatch,
+  type RawParticipant,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import { classifyMatchForBetting } from "#src/betting/outcome.ts";
+import {
+  WEEKLY_PARLAY_ELIGIBLE_QUEUES,
+  WeeklyParlayContributionSnapshotSchema,
+  WeeklyParlaySubjectsSchema,
+  type WeeklyParlayContributionSnapshot,
+  type WeeklyParlaySubject,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
+import { deliverWeeklyParlayDiscord } from "#src/betting/weekly-parlay-discord.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { createLogger } from "#src/logger.ts";
+import { bettingWeeklyParlayContributionsTotal } from "#src/metrics/betting-weekly-parlay.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+
+const logger = createLogger("betting-weekly-parlay-contribution");
+
+function contributionFor(
+  participant: RawParticipant,
+  subject: WeeklyParlaySubject,
+  queue: (typeof WEEKLY_PARLAY_ELIGIBLE_QUEUES)[number],
+  completedAt: Date,
+): WeeklyParlayContributionSnapshot {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: subject.key,
+    puuid: participant.puuid,
+    queue,
+    completedAt: completedAt.toISOString(),
+    win: participant.win,
+    champion: participant.championName,
+    role: participant.teamPosition,
+    kills: participant.kills,
+    deaths: participant.deaths,
+    assists: participant.assists,
+    championDamage: participant.totalDamageDealtToChampions,
+    creepScore:
+      participant.totalMinionsKilled + participant.neutralMinionsKilled,
+    gold: participant.goldEarned,
+    visionScore: participant.visionScore,
+    timePlayed: participant.timePlayed,
+  });
+}
+
+export function weeklyContributionsForMatch(input: {
+  matchData: RawMatch;
+  subjects: readonly WeeklyParlaySubject[];
+}): WeeklyParlayContributionSnapshot[] {
+  if (classifyMatchForBetting(input.matchData).kind !== "decided") {
+    return [];
+  }
+  const queue = resolveQueueTypeFromGame(
+    input.matchData.info.queueId,
+    input.matchData.info.gameMode,
+    input.matchData.info.gameType,
+  );
+  const parsedQueue = z.enum(WEEKLY_PARLAY_ELIGIBLE_QUEUES).safeParse(queue);
+  if (!parsedQueue.success) {
+    return [];
+  }
+  const completedAt = new Date(input.matchData.info.gameEndTimestamp);
+  const subjectByPuuid = new Map(
+    input.subjects.flatMap((subject) =>
+      subject.accounts.map((account) => [account.puuid, subject]),
+    ),
+  );
+  return input.matchData.info.participants.flatMap((participant) => {
+    const subject = subjectByPuuid.get(
+      LeaguePuuidSchema.parse(participant.puuid),
+    );
+    return subject === undefined
+      ? []
+      : [contributionFor(participant, subject, parsedQueue.data, completedAt)];
+  });
+}
+
+export async function captureWeeklyParlayContributions(
+  matchData: RawMatch,
+  prismaClient: ExtendedPrismaClient = prisma,
+  ingestedAt: Date = new Date(),
+): Promise<number> {
+  const completedAt = new Date(matchData.info.gameEndTimestamp);
+  const definitions = await (async () => {
+    try {
+      return await prismaClient.bucksWeeklyParlayDefinition.findMany({
+        where: {
+          scoringStartsAt: { lte: completedAt },
+          scoringEndsAt: { gt: completedAt },
+          market: { is: { marketState: { in: ["open", "active"] } } },
+        },
+        select: {
+          id: true,
+          serverId: true,
+          periodKey: true,
+          slot: true,
+          subjects: true,
+          market: { select: { id: true } },
+        },
+      });
+    } catch (error) {
+      logger.error(
+        `Could not load weekly parlays for ${matchData.metadata.matchId}:`,
+        error,
+      );
+      Sentry.captureException(error, {
+        tags: {
+          source: "betting-weekly-parlay-contribution-load",
+          matchId: matchData.metadata.matchId,
+        },
+      });
+      throw error;
+    }
+  })();
+
+  let inserted = 0;
+  for (const definition of definitions) {
+    try {
+      const subjects = WeeklyParlaySubjectsSchema.parse(
+        JSON.parse(definition.subjects),
+      );
+      const contributions = weeklyContributionsForMatch({
+        matchData,
+        subjects,
+      });
+      if (contributions.length === 0 || definition.market === null) {
+        continue;
+      }
+      const marketId = definition.market.id;
+      const result = await prismaClient.$transaction(async (tx) => {
+        // FIRST write: serialize this append with final settlement. If the
+        // finalizer already claimed the market, this match was not ingested in
+        // time and contributes nothing.
+        const claim = await tx.bucksWeeklyParlayMarket.updateMany({
+          where: {
+            id: marketId,
+            marketState: { in: ["open", "active"] },
+            scoringEndsAt: { gt: completedAt },
+          },
+          data: { updatedAt: ingestedAt },
+        });
+        if (claim.count !== 1) {
+          return { count: 0 };
+        }
+        return await tx.bucksWeeklyParlayContribution.createMany({
+          data: contributions.map((snapshot) => ({
+            definitionId: definition.id,
+            matchId: matchData.metadata.matchId,
+            subjectKey: snapshot.subject,
+            completedAt: new Date(snapshot.completedAt),
+            ingestedAt,
+            queueType: snapshot.queue,
+            snapshot: JSON.stringify(snapshot),
+          })),
+          skipDuplicates: true,
+        });
+      });
+      inserted += result.count;
+      if (result.count === 0) {
+        continue;
+      }
+      bettingWeeklyParlayContributionsTotal.inc(result.count);
+      logBucksTransition({
+        event: "bucks.weekly_parlay.contribution_recorded",
+        matchId: matchData.metadata.matchId,
+        marketId,
+        definitionId: definition.id,
+        serverId: definition.serverId,
+        periodKey: definition.periodKey,
+        slot: definition.slot,
+        contributionCount: result.count,
+        surface: "postmatch",
+      });
+      const settlement = await settleWeeklyParlayMarket(
+        {
+          marketId,
+          mode: "early_yes",
+          now: ingestedAt,
+          surface: "postmatch",
+        },
+        prismaClient,
+      );
+      if (settlement !== undefined) {
+        await deliverWeeklyParlayDiscord(
+          {
+            marketId: definition.market.id,
+            actionKey: `${definition.id.toString()}:early-settlement`,
+            kind: "settlement",
+            scheduledAt: ingestedAt,
+          },
+          prismaClient,
+        );
+      }
+    } catch (error) {
+      logger.error(
+        `Could not record weekly parlay ${definition.id.toString()} contribution for ${matchData.metadata.matchId}:`,
+        error,
+      );
+      Sentry.captureException(error, {
+        tags: {
+          source: "betting-weekly-parlay-contribution",
+          matchId: matchData.metadata.matchId,
+          definitionId: definition.id.toString(),
+        },
+      });
+      if (definition.market === null) {
+        continue;
+      }
+      try {
+        const voided = await settleWeeklyParlayMarket(
+          {
+            marketId: definition.market.id,
+            mode: "void",
+            voidReason: "infrastructure_failure",
+            now: ingestedAt,
+            surface: "postmatch",
+          },
+          prismaClient,
+        );
+        if (voided !== undefined) {
+          await deliverWeeklyParlayDiscord(
+            {
+              marketId: definition.market.id,
+              actionKey: `${definition.id.toString()}:infrastructure-void`,
+              kind: "settlement",
+              scheduledAt: ingestedAt,
+            },
+            prismaClient,
+          );
+        }
+      } catch (voidError) {
+        logger.error(
+          `Could not void weekly parlay ${definition.id.toString()} after contribution failure:`,
+          voidError,
+        );
+        Sentry.captureException(voidError, {
+          tags: {
+            source: "betting-weekly-parlay-contribution-void",
+            matchId: matchData.metadata.matchId,
+            definitionId: definition.id.toString(),
+          },
+        });
+      }
+    }
+  }
+  return inserted;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-contribution.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-contribution.ts
@@ -15,7 +15,10 @@ import {
   type WeeklyParlaySubject,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
-import { deliverWeeklyParlayDiscord } from "#src/betting/weekly-parlay-discord.ts";
+import {
+  deliverWeeklyParlayDiscord,
+  weeklyParlaySettlementActionKey,
+} from "#src/betting/weekly-parlay-discord.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { bettingWeeklyParlayContributionsTotal } from "#src/metrics/betting-weekly-parlay.ts";
@@ -190,7 +193,7 @@ export async function captureWeeklyParlayContributions(
         await deliverWeeklyParlayDiscord(
           {
             marketId: definition.market.id,
-            actionKey: `${definition.id.toString()}:early-settlement`,
+            actionKey: weeklyParlaySettlementActionKey(definition.market.id),
             kind: "settlement",
             scheduledAt: ingestedAt,
           },
@@ -227,7 +230,7 @@ export async function captureWeeklyParlayContributions(
           await deliverWeeklyParlayDiscord(
             {
               marketId: definition.market.id,
-              actionKey: `${definition.id.toString()}:infrastructure-void`,
+              actionKey: weeklyParlaySettlementActionKey(definition.market.id),
               kind: "settlement",
               scheduledAt: ingestedAt,
             },

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -1,0 +1,307 @@
+import { z } from "zod";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import { deliverWeeklyParlayDiscord } from "#src/betting/weekly-parlay-discord.ts";
+import { openWeeklyParlay } from "#src/betting/weekly-parlay-open.ts";
+import {
+  WEEKLY_PARLAY_SLOT,
+  weeklyParlayPeriod,
+} from "#src/betting/weekly-parlay-period.ts";
+import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { bettingWeeklyParlayControlActionsTotal } from "#src/metrics/betting-weekly-parlay.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+
+export const WEEKLY_PARLAY_CONTROL_PATH =
+  "/api/internal/weekly-parlays/actions";
+
+export const WeeklyParlayControlActionSchema = z
+  .strictObject({
+    periodKey: z.iso.date(),
+    slot: z.number().int().nonnegative().default(WEEKLY_PARLAY_SLOT),
+    action: z.enum(["open", "reminder", "start", "progress", "finalize"]),
+    updateIndex: z.number().int().min(0).max(5).optional(),
+  })
+  .superRefine((action, context) => {
+    if (action.action === "progress" && action.updateIndex === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["updateIndex"],
+        message: "Progress actions require an update index.",
+      });
+    }
+    if (action.action !== "progress" && action.updateIndex !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["updateIndex"],
+        message: "Only progress actions accept an update index.",
+      });
+    }
+  });
+export type WeeklyParlayControlAction = z.infer<
+  typeof WeeklyParlayControlActionSchema
+>;
+
+export type WeeklyParlayControlResult = {
+  status: "reconciled" | "skipped";
+  detail: string;
+  marketId?: number;
+};
+
+function actionKey(action: WeeklyParlayControlAction): string {
+  return `${action.periodKey}:${action.slot.toString()}:${action.action}:${action.updateIndex?.toString() ?? "-"}`;
+}
+
+type ControlContext = {
+  serverId: string;
+  now: Date;
+  prismaClient: ExtendedPrismaClient;
+};
+
+async function reconcileOpen(
+  action: WeeklyParlayControlAction,
+  context: ControlContext,
+): Promise<WeeklyParlayControlResult> {
+  const period = weeklyParlayPeriod(action.periodKey);
+  if (context.now >= period.bettingClosesAt) {
+    return { status: "skipped", detail: "betting window already closed" };
+  }
+  const opened = await openWeeklyParlay(
+    {
+      serverId: context.serverId,
+      periodKey: action.periodKey,
+      slot: action.slot,
+    },
+    context.prismaClient,
+  );
+  if (opened.kind !== "created" && opened.kind !== "existing") {
+    return { status: "skipped", detail: opened.kind };
+  }
+  await deliverWeeklyParlayDiscord(
+    {
+      marketId: opened.marketId,
+      actionKey: actionKey(action),
+      kind: "open",
+      scheduledAt: period.openAt,
+    },
+    context.prismaClient,
+  );
+  return {
+    status: "reconciled",
+    detail: opened.kind,
+    marketId: opened.marketId,
+  };
+}
+
+async function reconcileStart(
+  action: WeeklyParlayControlAction,
+  market: { id: number; marketState: string },
+  context: ControlContext,
+): Promise<WeeklyParlayControlResult> {
+  const period = weeklyParlayPeriod(action.periodKey);
+  if (market.marketState === "publishing") {
+    await settleWeeklyParlayMarket(
+      {
+        marketId: market.id,
+        mode: "void",
+        voidReason: "infrastructure_failure",
+        now: context.now,
+      },
+      context.prismaClient,
+    );
+    await deliverWeeklyParlayDiscord(
+      {
+        marketId: market.id,
+        actionKey: actionKey(action),
+        kind: "settlement",
+        scheduledAt: period.scoringStartsAt,
+      },
+      context.prismaClient,
+    );
+    return {
+      status: "reconciled",
+      detail: "publication_failed",
+      marketId: market.id,
+    };
+  }
+  const started = await context.prismaClient.bucksWeeklyParlayMarket.updateMany(
+    {
+      where: { id: market.id, marketState: "open" },
+      data: { marketState: "active", updatedAt: context.now },
+    },
+  );
+  if (started.count === 1) {
+    logBucksTransition({
+      event: "bucks.weekly_parlay.started",
+      serverId: context.serverId,
+      marketId: market.id,
+      periodKey: action.periodKey,
+      slot: action.slot,
+      fromState: "open",
+      toState: "active",
+      surface: "cron",
+    });
+  }
+  return { status: "reconciled", detail: "started", marketId: market.id };
+}
+
+async function reconcileFinalize(
+  action: WeeklyParlayControlAction,
+  marketId: number,
+  context: ControlContext,
+): Promise<WeeklyParlayControlResult> {
+  const period = weeklyParlayPeriod(action.periodKey);
+  await settleWeeklyParlayMarket(
+    { marketId, mode: "final", now: context.now },
+    context.prismaClient,
+  );
+  const finalized =
+    await context.prismaClient.bucksWeeklyParlayMarket.findUnique({
+      where: { id: marketId },
+      select: {
+        marketState: true,
+        deliveries: {
+          where: { kind: "settlement", deliveryState: "delivered" },
+          select: { id: true },
+          take: 1,
+        },
+      },
+    });
+  if (
+    finalized === null ||
+    (finalized.marketState !== "settled" && finalized.marketState !== "voided")
+  ) {
+    return { status: "skipped", detail: "not_finalized", marketId };
+  }
+  if (finalized.deliveries.length === 0) {
+    await deliverWeeklyParlayDiscord(
+      {
+        marketId,
+        actionKey: actionKey(action),
+        kind: "settlement",
+        scheduledAt: period.scoringEndsAt,
+      },
+      context.prismaClient,
+    );
+  }
+  return { status: "reconciled", detail: "finalized", marketId };
+}
+
+async function reconcileReminder(
+  action: WeeklyParlayControlAction,
+  marketId: number,
+  context: ControlContext,
+): Promise<WeeklyParlayControlResult> {
+  const period = weeklyParlayPeriod(action.periodKey);
+  if (context.now >= period.bettingClosesAt) {
+    return { status: "skipped", detail: "stale_reminder", marketId };
+  }
+  await deliverWeeklyParlayDiscord(
+    {
+      marketId,
+      actionKey: actionKey(action),
+      kind: "reminder",
+      scheduledAt: period.reminderAt,
+    },
+    context.prismaClient,
+  );
+  return { status: "reconciled", detail: "reminded", marketId };
+}
+
+async function reconcileProgress(
+  action: WeeklyParlayControlAction,
+  marketId: number,
+  context: ControlContext,
+): Promise<WeeklyParlayControlResult> {
+  const period = weeklyParlayPeriod(action.periodKey);
+  const updateIndex = action.updateIndex;
+  if (updateIndex === undefined) {
+    throw new Error("A weekly progress action requires updateIndex.");
+  }
+  if (context.now >= period.scoringEndsAt) {
+    return { status: "skipped", detail: "stale_progress", marketId };
+  }
+  const scheduledAt = period.updateAt[updateIndex];
+  if (scheduledAt === undefined) {
+    throw new Error("Weekly progress index has no scheduled wall time.");
+  }
+  const nextScheduledAt =
+    period.updateAt[updateIndex + 1] ?? period.scoringEndsAt;
+  if (context.now >= nextScheduledAt) {
+    return { status: "skipped", detail: "stale_progress", marketId };
+  }
+  await deliverWeeklyParlayDiscord(
+    {
+      marketId,
+      actionKey: actionKey(action),
+      kind: "progress",
+      scheduledAt,
+    },
+    context.prismaClient,
+  );
+  return { status: "reconciled", detail: "progressed", marketId };
+}
+
+async function runWeeklyParlayControlActionInternal(
+  input: WeeklyParlayControlAction,
+  options: {
+    serverId: string;
+    now?: Date;
+    prismaClient?: ExtendedPrismaClient;
+  },
+): Promise<WeeklyParlayControlResult> {
+  const action = WeeklyParlayControlActionSchema.parse(input);
+  const serverId = DiscordGuildIdSchema.parse(options.serverId);
+  const prismaClient = options.prismaClient ?? prisma;
+  const now = options.now ?? new Date();
+  const context = { serverId, prismaClient, now };
+  if (action.action === "open") {
+    return await reconcileOpen(action, context);
+  }
+  const market = await prismaClient.bucksWeeklyParlayMarket.findUnique({
+    where: {
+      serverId_periodKey_slot: {
+        serverId,
+        periodKey: action.periodKey,
+        slot: action.slot,
+      },
+    },
+    select: { id: true, marketState: true },
+  });
+  if (market === null) {
+    return { status: "skipped", detail: "no_market" };
+  }
+  if (action.action === "start") {
+    return await reconcileStart(action, market, context);
+  }
+  if (action.action === "finalize") {
+    return await reconcileFinalize(action, market.id, context);
+  }
+  if (action.action === "reminder") {
+    return await reconcileReminder(action, market.id, context);
+  }
+  return await reconcileProgress(action, market.id, context);
+}
+
+export async function runWeeklyParlayControlAction(
+  input: WeeklyParlayControlAction,
+  options: {
+    serverId: string;
+    now?: Date;
+    prismaClient?: ExtendedPrismaClient;
+  },
+): Promise<WeeklyParlayControlResult> {
+  try {
+    const result = await runWeeklyParlayControlActionInternal(input, options);
+    bettingWeeklyParlayControlActionsTotal.inc({
+      action: input.action,
+      result: result.status,
+    });
+    return result;
+  } catch (error) {
+    bettingWeeklyParlayControlActionsTotal.inc({
+      action: input.action,
+      result: "error",
+    });
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -191,23 +191,30 @@ async function reconcileFinalize(
 
 async function reconcileReminder(
   action: WeeklyParlayControlAction,
-  marketId: number,
+  market: { id: number; marketState: string },
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
   const period = weeklyParlayPeriod(action.periodKey);
   if (context.now >= period.bettingClosesAt) {
-    return { status: "skipped", detail: "stale_reminder", marketId };
+    return { status: "skipped", detail: "stale_reminder", marketId: market.id };
+  }
+  if (market.marketState !== "open") {
+    return {
+      status: "skipped",
+      detail: "market_not_open",
+      marketId: market.id,
+    };
   }
   await deliverWeeklyParlayDiscord(
     {
-      marketId,
+      marketId: market.id,
       actionKey: actionKey(action),
       kind: "reminder",
       scheduledAt: period.reminderAt,
     },
     context.prismaClient,
   );
-  return { status: "reconciled", detail: "reminded", marketId };
+  return { status: "reconciled", detail: "reminded", marketId: market.id };
 }
 
 async function reconcileProgress(
@@ -280,7 +287,7 @@ async function runWeeklyParlayControlActionInternal(
     return await reconcileFinalize(action, market.id, context);
   }
   if (action.action === "reminder") {
-    return await reconcileReminder(action, market.id, context);
+    return await reconcileReminder(action, market, context);
   }
   return await reconcileProgress(action, market.id, context);
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { DiscordGuildIdSchema } from "@scout-for-lol/data";
-import { deliverWeeklyParlayDiscord } from "#src/betting/weekly-parlay-discord.ts";
+import {
+  deliverWeeklyParlayDiscord,
+  weeklyParlaySettlementActionKey,
+} from "#src/betting/weekly-parlay-discord.ts";
 import { openWeeklyParlay } from "#src/betting/weekly-parlay-open.ts";
 import {
   WEEKLY_PARLAY_SLOT,
@@ -111,7 +114,7 @@ async function reconcileStart(
     await deliverWeeklyParlayDiscord(
       {
         marketId: market.id,
-        actionKey: actionKey(action),
+        actionKey: weeklyParlaySettlementActionKey(market.id),
         kind: "settlement",
         scheduledAt: period.scoringStartsAt,
       },
@@ -176,7 +179,7 @@ async function reconcileFinalize(
     await deliverWeeklyParlayDiscord(
       {
         marketId,
-        actionKey: actionKey(action),
+        actionKey: weeklyParlaySettlementActionKey(marketId),
         kind: "settlement",
         scheduledAt: period.scoringEndsAt,
       },

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-custom-id.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-custom-id.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import {
+  formatWeeklyParlayCustomId,
+  isWeeklyParlayCustomId,
+  parseWeeklyParlayCustomId,
+} from "#src/betting/weekly-parlay-custom-id.ts";
+
+describe("weekly parlay custom IDs", () => {
+  test("round trips the compact versioned format", () => {
+    const input = {
+      action: "b" as const,
+      marketId: 42,
+      side: "NO" as const,
+      amount: 25,
+    };
+    expect(
+      parseWeeklyParlayCustomId(formatWeeklyParlayCustomId(input)),
+    ).toEqual(input);
+  });
+
+  test("claims malformed namespaced IDs without parsing them", () => {
+    expect(isWeeklyParlayCustomId("bbw:old")).toBe(true);
+    expect(parseWeeklyParlayCustomId("bbw:old")).toBeUndefined();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-custom-id.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-custom-id.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { BUCKS_INT32_MAX, BucksParlaySideSchema } from "@scout-for-lol/data";
+import { MAX_CUSTOM_ID_LENGTH } from "#src/betting/custom-id.ts";
+
+export const WEEKLY_PARLAY_COMPONENT_NAMESPACE = "bbw";
+export const WEEKLY_PARLAY_COMPONENT_VERSION = "1";
+
+export const WeeklyParlayCustomIdSchema = z.strictObject({
+  action: z.enum(["b", "x"]),
+  marketId: z.number().int().positive(),
+  side: BucksParlaySideSchema,
+  amount: z.number().int().nonnegative().max(BUCKS_INT32_MAX),
+});
+export type WeeklyParlayCustomId = z.infer<typeof WeeklyParlayCustomIdSchema>;
+
+export function formatWeeklyParlayCustomId(
+  input: WeeklyParlayCustomId,
+): string {
+  const parsed = WeeklyParlayCustomIdSchema.parse(input);
+  const id = [
+    WEEKLY_PARLAY_COMPONENT_NAMESPACE,
+    WEEKLY_PARLAY_COMPONENT_VERSION,
+    parsed.action,
+    parsed.marketId.toString(36),
+    parsed.side === "YES" ? "Y" : "N",
+    parsed.amount.toString(36),
+  ].join(":");
+  if (id.length > MAX_CUSTOM_ID_LENGTH) {
+    throw new Error("Weekly parlay custom ID exceeds Discord's limit.");
+  }
+  return id;
+}
+
+export function parseWeeklyParlayCustomId(
+  raw: string,
+): WeeklyParlayCustomId | undefined {
+  const [namespace, version, action, market, compactSide, amount, extra] =
+    raw.split(":");
+  if (
+    extra !== undefined ||
+    namespace !== WEEKLY_PARLAY_COMPONENT_NAMESPACE ||
+    version !== WEEKLY_PARLAY_COMPONENT_VERSION
+  ) {
+    return;
+  }
+  const parsed = WeeklyParlayCustomIdSchema.safeParse({
+    action,
+    marketId: Number.parseInt(market ?? "", 36),
+    side:
+      compactSide === "Y" ? "YES" : compactSide === "N" ? "NO" : compactSide,
+    amount: Number.parseInt(amount ?? "", 36),
+  });
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function isWeeklyParlayCustomId(raw: string): boolean {
+  return raw.startsWith(`${WEEKLY_PARLAY_COMPONENT_NAMESPACE}:`);
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -35,6 +35,25 @@ export function weeklyParlaySettlementActionKey(marketId: number): string {
   return `settlement:${marketId.toString()}`;
 }
 
+export async function refreshWeeklyParlayMessage(
+  marketId: number,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  const market = await prismaClient.bucksWeeklyParlayMarket.findUniqueOrThrow({
+    where: { id: marketId },
+    select: { updatedAt: true },
+  });
+  await deliverWeeklyParlayDiscord(
+    {
+      marketId,
+      actionKey: `mutation:${marketId.toString()}:${market.updatedAt.getTime().toString()}`,
+      kind: "reminder",
+      scheduledAt: market.updatedAt,
+    },
+    prismaClient,
+  );
+}
+
 export type WeeklyParlayDiscordSender = (
   options: MessageCreateOptions,
   channelId: DiscordChannelId,
@@ -206,6 +225,7 @@ export async function deliverWeeklyParlayDiscord(
       slot: true,
       marketState: true,
       yesResult: true,
+      voidReason: true,
       bettingClosesAt: true,
       scoringEndsAt: true,
       definition: {
@@ -253,28 +273,36 @@ export async function deliverWeeklyParlayDiscord(
     });
     return "stale";
   }
-  const subjects = WeeklyParlaySubjectsSchema.parse(
-    JSON.parse(market.definition.subjects),
-  );
-  const criteria = WeeklyParlayDefinitionCriteriaSchema.parse(
-    JSON.parse(market.definition.criteria),
-  );
-  const contributions = z
-    .array(WeeklyParlayContributionSnapshotSchema)
-    .parse(
-      market.definition.contributions.map((row) => JSON.parse(row.snapshot)),
-    );
-  const evaluation = evaluateWeeklyParlay(criteria, contributions);
+  const isVoidedSettlement =
+    input.kind === "settlement" && market.marketState === "voided";
+  const subjects = isVoidedSettlement
+    ? []
+    : WeeklyParlaySubjectsSchema.parse(JSON.parse(market.definition.subjects));
+  const evaluation = isVoidedSettlement
+    ? undefined
+    : evaluateWeeklyParlay(
+        WeeklyParlayDefinitionCriteriaSchema.parse(
+          JSON.parse(market.definition.criteria),
+        ),
+        z
+          .array(WeeklyParlayContributionSnapshotSchema)
+          .parse(
+            market.definition.contributions.map((row) =>
+              JSON.parse(row.snapshot),
+            ),
+          ),
+      );
   const aliases = new Map(
     subjects.map((subject) => [subject.key, subject.alias]),
   );
-  const legs = evaluation.legs.map((result) =>
-    legLine(
-      result.leg,
-      currentLegValue(input.kind, result.current),
-      aliases.get(result.leg.subject) ?? result.leg.subject,
-    ),
-  );
+  const legs =
+    evaluation?.legs.map((result) =>
+      legLine(
+        result.leg,
+        currentLegValue(input.kind, result.current),
+        aliases.get(result.leg.subject) ?? result.leg.subject,
+      ),
+    ) ?? [];
   const bettorIds = market.bets.map((bet) => bet.bucksAccount.discordId);
   const mentionIds = [
     ...new Set([...subjects.map((subject) => subject.discordId), ...bettorIds]),
@@ -282,6 +310,9 @@ export async function deliverWeeklyParlayDiscord(
   const totalStaked = market.bets.reduce((total, bet) => total + bet.stake, 0);
   const content = [
     deliveryTitle(input.kind, market.marketState, market.yesResult),
+    ...(isVoidedSettlement
+      ? [`Reason: **${market.voidReason ?? "unknown"}**`]
+      : []),
     `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
     ...legs,
     `**${market.bets.length.toString()} bettors · ${totalStaked.toString()} BB staked**`,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -31,6 +31,10 @@ import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 export type WeeklyParlayDiscordKind =
   "open" | "reminder" | "progress" | "settlement";
 
+export function weeklyParlaySettlementActionKey(marketId: number): string {
+  return `settlement:${marketId.toString()}`;
+}
+
 export type WeeklyParlayDiscordSender = (
   options: MessageCreateOptions,
   channelId: DiscordChannelId,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -35,25 +35,6 @@ export function weeklyParlaySettlementActionKey(marketId: number): string {
   return `settlement:${marketId.toString()}`;
 }
 
-export async function refreshWeeklyParlayMessage(
-  marketId: number,
-  prismaClient: ExtendedPrismaClient = prisma,
-): Promise<void> {
-  const market = await prismaClient.bucksWeeklyParlayMarket.findUniqueOrThrow({
-    where: { id: marketId },
-    select: { updatedAt: true },
-  });
-  await deliverWeeklyParlayDiscord(
-    {
-      marketId,
-      actionKey: `mutation:${marketId.toString()}:${market.updatedAt.getTime().toString()}`,
-      kind: "reminder",
-      scheduledAt: market.updatedAt,
-    },
-    prismaClient,
-  );
-}
-
 export type WeeklyParlayDiscordSender = (
   options: MessageCreateOptions,
   channelId: DiscordChannelId,
@@ -71,18 +52,59 @@ function operatorCopy(leg: WeeklyParlayLeg): string {
   }
 }
 
+export function countLabel(
+  value: number,
+  singular: string,
+  plural = `${singular}s`,
+): string {
+  return value === 1 ? singular : plural;
+}
+
+function aggregateMetricCopy(
+  metric: Extract<WeeklyParlayLeg, { kind: "aggregate" }>["metric"],
+  threshold: number,
+): string {
+  switch (metric) {
+    case "games":
+    case "wins":
+    case "kills":
+    case "deaths":
+    case "assists":
+      return countLabel(threshold, metric.slice(0, -1), metric);
+    case "distinct_champions":
+      return `distinct ${countLabel(threshold, "champion")}`;
+    case "distinct_roles":
+      return `distinct ${countLabel(threshold, "role")}`;
+    case "longest_win_streak":
+      return "wins in a row";
+    case "best_game_kills":
+      return "kills in one game";
+    case "best_game_assists":
+      return "assists in one game";
+    case "best_game_damage":
+      return "champion damage in one game";
+    case "champion_damage":
+    case "creep_score":
+    case "gold":
+    case "vision_score":
+    case "time_played":
+      return metric.replaceAll("_", " ");
+  }
+}
+
 function metricCopy(leg: WeeklyParlayLeg): string {
   switch (leg.kind) {
     case "aggregate":
+      return aggregateMetricCopy(leg.metric, leg.threshold);
     case "rate":
       return leg.metric
         .replaceAll("_x100", "")
         .replaceAll("_bps", "")
         .replaceAll("_", " ");
     case "champion_games":
-      return `${leg.winsOnly ? "wins" : "games"} on ${leg.champion}`;
+      return `${countLabel(leg.threshold, leg.winsOnly ? "win" : "game")} on ${leg.champion}`;
     case "role_games":
-      return `${leg.winsOnly ? "wins" : "games"} as ${leg.role.toLowerCase()}`;
+      return `${countLabel(leg.threshold, leg.winsOnly ? "win" : "game")} as ${leg.role.toLowerCase()}`;
   }
 }
 
@@ -98,7 +120,7 @@ function metricValue(leg: WeeklyParlayLeg, value: number): string {
   return value.toLocaleString("en-US");
 }
 
-function legLine(
+export function legLine(
   leg: WeeklyParlayLeg,
   current: number | undefined,
   subjectAlias: string,
@@ -120,7 +142,7 @@ function stableNonce(
 
 const MENTIONS_PER_MESSAGE = 20;
 
-function deliveryTitle(
+export function deliveryTitle(
   kind: WeeklyParlayDiscordKind,
   marketState: string,
   yesResult: boolean | null,
@@ -149,7 +171,7 @@ function currentLegValue(
   return kind === "open" || kind === "reminder" ? undefined : current;
 }
 
-function deliveryTimeCopy(
+export function deliveryTimeCopy(
   kind: WeeklyParlayDiscordKind,
   bettingClosesAt: Date,
   scoringEndsAt: Date,
@@ -160,7 +182,7 @@ function deliveryTimeCopy(
   return `Final cutoff <t:${Math.floor(scoringEndsAt.getTime() / 1000).toString()}:F>.`;
 }
 
-function weeklyParlayButtons(
+export function weeklyParlayButtons(
   kind: WeeklyParlayDiscordKind,
   marketId: number,
 ): ActionRowBuilder<ButtonBuilder>[] {
@@ -315,7 +337,7 @@ export async function deliverWeeklyParlayDiscord(
       : []),
     `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
     ...legs,
-    `**${market.bets.length.toString()} bettors · ${totalStaked.toString()} BB staked**`,
+    `**${market.bets.length.toString()} ${countLabel(market.bets.length, "bettor")} · ${totalStaked.toString()} BB staked**`,
     deliveryTimeCopy(input.kind, market.bettingClosesAt, market.scoringEndsAt),
   ]
     .filter((line) => line.length > 0)

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -1,0 +1,392 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type MessageCreateOptions,
+} from "discord.js";
+import {
+  DiscordGuildIdSchema,
+  type DiscordChannelId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import {
+  WeeklyParlayContributionSnapshotSchema,
+  WeeklyParlayDefinitionCriteriaSchema,
+  WeeklyParlaySubjectsSchema,
+  type WeeklyParlayLeg,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { evaluateWeeklyParlay } from "#src/betting/weekly-parlay-evaluator.ts";
+import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
+import { send } from "#src/league/discord/channel.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { formatWeeklyParlayCustomId } from "#src/betting/weekly-parlay-custom-id.ts";
+import {
+  bettingWeeklyParlayDeliveriesTotal,
+  bettingWeeklyParlayMarketsOpenedTotal,
+} from "#src/metrics/betting-weekly-parlay.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
+
+export type WeeklyParlayDiscordKind =
+  "open" | "reminder" | "progress" | "settlement";
+
+export type WeeklyParlayDiscordSender = (
+  options: MessageCreateOptions,
+  channelId: DiscordChannelId,
+  serverId: DiscordGuildId,
+) => Promise<{ channelId: string; id: string }>;
+
+function operatorCopy(leg: WeeklyParlayLeg): string {
+  switch (leg.operator) {
+    case "gte":
+      return "at least";
+    case "lte":
+      return "at most";
+    case "eq":
+      return "exactly";
+  }
+}
+
+function metricCopy(leg: WeeklyParlayLeg): string {
+  switch (leg.kind) {
+    case "aggregate":
+    case "rate":
+      return leg.metric
+        .replaceAll("_x100", "")
+        .replaceAll("_bps", "")
+        .replaceAll("_", " ");
+    case "champion_games":
+      return `${leg.winsOnly ? "wins" : "games"} on ${leg.champion}`;
+    case "role_games":
+      return `${leg.winsOnly ? "wins" : "games"} as ${leg.role.toLowerCase()}`;
+  }
+}
+
+function metricValue(leg: WeeklyParlayLeg, value: number): string {
+  if (leg.kind === "rate") {
+    if (leg.metric === "win_rate_bps") {
+      return `${(value / 100).toFixed(1)}%`;
+    }
+    if (leg.metric.endsWith("_x100")) {
+      return (value / 100).toFixed(2);
+    }
+  }
+  return value.toLocaleString("en-US");
+}
+
+function legLine(
+  leg: WeeklyParlayLeg,
+  current: number | undefined,
+  subjectAlias: string,
+): string {
+  const progress =
+    current === undefined
+      ? ""
+      : ` — **${metricValue(leg, current)} / ${metricValue(leg, leg.threshold)}**`;
+  return `• **${subjectAlias}** ${operatorCopy(leg)} **${metricValue(leg, leg.threshold)} ${metricCopy(leg)}**${progress}`;
+}
+
+function stableNonce(
+  marketId: number,
+  actionKey: string,
+  messageIndex: number,
+): string {
+  return `ww:${marketId.toString(36)}:${Bun.hash(actionKey).toString(36)}:${messageIndex.toString(36)}`;
+}
+
+const MENTIONS_PER_MESSAGE = 20;
+
+function deliveryTitle(
+  kind: WeeklyParlayDiscordKind,
+  marketState: string,
+  yesResult: boolean | null,
+): string {
+  switch (kind) {
+    case "open":
+      return "📅 **Weekly Bryan Bucks parlay is open**";
+    case "reminder":
+      return "⏰ **Weekly parlay betting reminder**";
+    case "progress":
+      return "📈 **Weekly parlay progress**";
+    case "settlement":
+      if (marketState === "voided") {
+        return "↩️ **Weekly parlay refunded**";
+      }
+      return yesResult === true
+        ? "✅ **Weekly parlay settled YES**"
+        : "❌ **Weekly parlay settled NO**";
+  }
+}
+
+function currentLegValue(
+  kind: WeeklyParlayDiscordKind,
+  current: number,
+): number | undefined {
+  return kind === "open" || kind === "reminder" ? undefined : current;
+}
+
+function deliveryTimeCopy(
+  kind: WeeklyParlayDiscordKind,
+  bettingClosesAt: Date,
+  scoringEndsAt: Date,
+): string {
+  if (kind === "open" || kind === "reminder") {
+    return `Betting closes <t:${Math.floor(bettingClosesAt.getTime() / 1000).toString()}:R>. Use this message's buttons so your market is unambiguous.`;
+  }
+  return `Final cutoff <t:${Math.floor(scoringEndsAt.getTime() / 1000).toString()}:F>.`;
+}
+
+function weeklyParlayButtons(
+  kind: WeeklyParlayDiscordKind,
+  marketId: number,
+): ActionRowBuilder<ButtonBuilder>[] {
+  if (kind !== "open" && kind !== "reminder") {
+    return [];
+  }
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(
+          formatWeeklyParlayCustomId({
+            action: "b",
+            marketId,
+            side: "YES",
+            amount: 1,
+          }),
+        )
+        .setLabel("YES · 1 BB")
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId(
+          formatWeeklyParlayCustomId({
+            action: "b",
+            marketId,
+            side: "NO",
+            amount: 1,
+          }),
+        )
+        .setLabel("NO · 1 BB")
+        .setStyle(ButtonStyle.Danger),
+      new ButtonBuilder()
+        .setCustomId(
+          formatWeeklyParlayCustomId({
+            action: "x",
+            marketId,
+            side: "YES",
+            amount: 0,
+          }),
+        )
+        .setLabel("Cancel")
+        .setStyle(ButtonStyle.Secondary),
+    ),
+  ];
+}
+
+export async function deliverWeeklyParlayDiscord(
+  input: {
+    marketId: number;
+    actionKey: string;
+    kind: WeeklyParlayDiscordKind;
+    scheduledAt: Date;
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+  sender: WeeklyParlayDiscordSender = send,
+): Promise<"sent" | "already_sent" | "stale"> {
+  const market = await prismaClient.bucksWeeklyParlayMarket.findUnique({
+    where: { id: input.marketId },
+    select: {
+      id: true,
+      serverId: true,
+      periodKey: true,
+      slot: true,
+      marketState: true,
+      yesResult: true,
+      bettingClosesAt: true,
+      scoringEndsAt: true,
+      definition: {
+        select: {
+          subjects: true,
+          criteria: true,
+          yesProbabilityBps: true,
+          contributions: { select: { snapshot: true } },
+        },
+      },
+      bets: {
+        where: input.kind === "settlement" ? {} : { betOutcome: "pending" },
+        select: {
+          stake: true,
+          bucksAccount: { select: { discordId: true } },
+        },
+      },
+      deliveries: {
+        where: { actionKey: input.actionKey },
+        select: { deliveryState: true },
+      },
+    },
+  });
+  if (market === null) {
+    bettingWeeklyParlayDeliveriesTotal.inc({
+      kind: input.kind,
+      result: "stale",
+    });
+    return "stale";
+  }
+  if (market.deliveries[0]?.deliveryState === "delivered") {
+    bettingWeeklyParlayDeliveriesTotal.inc({
+      kind: input.kind,
+      result: "already_sent",
+    });
+    return "already_sent";
+  }
+  if (
+    input.kind !== "settlement" &&
+    (market.marketState === "settled" || market.marketState === "voided")
+  ) {
+    bettingWeeklyParlayDeliveriesTotal.inc({
+      kind: input.kind,
+      result: "stale",
+    });
+    return "stale";
+  }
+  const subjects = WeeklyParlaySubjectsSchema.parse(
+    JSON.parse(market.definition.subjects),
+  );
+  const criteria = WeeklyParlayDefinitionCriteriaSchema.parse(
+    JSON.parse(market.definition.criteria),
+  );
+  const contributions = z
+    .array(WeeklyParlayContributionSnapshotSchema)
+    .parse(
+      market.definition.contributions.map((row) => JSON.parse(row.snapshot)),
+    );
+  const evaluation = evaluateWeeklyParlay(criteria, contributions);
+  const aliases = new Map(
+    subjects.map((subject) => [subject.key, subject.alias]),
+  );
+  const legs = evaluation.legs.map((result) =>
+    legLine(
+      result.leg,
+      currentLegValue(input.kind, result.current),
+      aliases.get(result.leg.subject) ?? result.leg.subject,
+    ),
+  );
+  const bettorIds = market.bets.map((bet) => bet.bucksAccount.discordId);
+  const mentionIds = [
+    ...new Set([...subjects.map((subject) => subject.discordId), ...bettorIds]),
+  ];
+  const totalStaked = market.bets.reduce((total, bet) => total + bet.stake, 0);
+  const content = [
+    deliveryTitle(input.kind, market.marketState, market.yesResult),
+    `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
+    ...legs,
+    `**${market.bets.length.toString()} bettors · ${totalStaked.toString()} BB staked**`,
+    deliveryTimeCopy(input.kind, market.bettingClosesAt, market.scoringEndsAt),
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
+  const mentionChunks = Array.from(
+    {
+      length: Math.max(1, Math.ceil(mentionIds.length / MENTIONS_PER_MESSAGE)),
+    },
+    (_, index) =>
+      mentionIds.slice(
+        index * MENTIONS_PER_MESSAGE,
+        (index + 1) * MENTIONS_PER_MESSAGE,
+      ),
+  );
+  const options: MessageCreateOptions[] = mentionChunks.map(
+    (chunk, messageIndex) => ({
+      content:
+        messageIndex === 0
+          ? [chunk.map((id) => `<@${id}>`).join(" "), content]
+              .filter((line) => line.length > 0)
+              .join("\n")
+          : `Weekly parlay update mentions (continued): ${chunk.map((id) => `<@${id}>`).join(" ")}`,
+      allowedMentions: { users: chunk },
+      nonce: stableNonce(market.id, input.actionKey, messageIndex),
+      enforceNonce: true,
+      components:
+        messageIndex === 0 ? weeklyParlayButtons(input.kind, market.id) : [],
+    }),
+  );
+  await prismaClient.bucksWeeklyParlayDelivery.upsert({
+    where: {
+      marketId_actionKey: { marketId: market.id, actionKey: input.actionKey },
+    },
+    create: {
+      marketId: market.id,
+      actionKey: input.actionKey,
+      kind: input.kind,
+      scheduledAt: input.scheduledAt,
+      attemptedAt: new Date(),
+    },
+    update: { attemptedAt: new Date() },
+  });
+  const refs: { channelId: string; messageId: string }[] = [];
+  try {
+    for (const messageOptions of options) {
+      const message = await observeBucksDelivery(
+        {
+          surface: "weekly_parlay",
+          operation: "send",
+          serverId: market.serverId,
+          channelId: COMMON_DENOMINATOR_CHANNEL_ID,
+        },
+        async () =>
+          await sender(
+            messageOptions,
+            COMMON_DENOMINATOR_CHANNEL_ID,
+            DiscordGuildIdSchema.parse(market.serverId),
+          ),
+      );
+      refs.push({ channelId: message.channelId, messageId: message.id });
+    }
+  } catch (error) {
+    bettingWeeklyParlayDeliveriesTotal.inc({
+      kind: input.kind,
+      result: "error",
+    });
+    throw error;
+  }
+  const opened = await prismaClient.$transaction(async (tx) => {
+    // FIRST write: an open delivery may race start reconciliation or a void.
+    // Only the process that still owns publishing may activate the market.
+    const marketUpdate = await tx.bucksWeeklyParlayMarket.updateMany({
+      where: {
+        id: market.id,
+        ...(input.kind === "open" ? { marketState: "publishing" } : {}),
+      },
+      data: {
+        messageRefs: JSON.stringify(refs),
+        ...(input.kind === "open" ? { marketState: "open" } : {}),
+      },
+    });
+    await tx.bucksWeeklyParlayDelivery.update({
+      where: {
+        marketId_actionKey: { marketId: market.id, actionKey: input.actionKey },
+      },
+      data: {
+        deliveryState: "delivered",
+        deliveredAt: new Date(),
+        messageRefs: JSON.stringify(refs),
+      },
+    });
+    return input.kind === "open" && marketUpdate.count === 1;
+  });
+  bettingWeeklyParlayDeliveriesTotal.inc({ kind: input.kind, result: "sent" });
+  if (opened) {
+    bettingWeeklyParlayMarketsOpenedTotal.inc();
+    logBucksTransition({
+      event: "bucks.weekly_parlay.opened",
+      serverId: market.serverId,
+      marketId: market.id,
+      periodKey: market.periodKey,
+      slot: market.slot,
+      fromState: "publishing",
+      toState: "open",
+      surface: "cron",
+    });
+  }
+  return "sent";
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
@@ -1,0 +1,210 @@
+import { addWeeks, formatISO, parseISO } from "date-fns";
+import { z } from "zod";
+import { LeaguePuuidSchema } from "@scout-for-lol/data";
+import {
+  WEEKLY_PARLAY_HISTORY_WINDOW_COUNT,
+  WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
+  WeeklyParlayContributionSnapshotSchema,
+  WeeklyParlaySubjectSchema,
+  type WeeklyParlayContributionSnapshot,
+  type WeeklyParlaySubject,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { weeklyParlayPeriod } from "#src/betting/weekly-parlay-period.ts";
+import { resolveLakeDir } from "#src/report-lake/paths.ts";
+import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
+import {
+  buildMatchesSource,
+  listParam,
+  resolveLakeFiles,
+  scalarParam,
+} from "#src/reports/duckdb/lake.ts";
+import { bindParams } from "#src/reports/duckdb/lake-reads.ts";
+import type { WeeklyParlayReplayWindow } from "#src/betting/weekly-parlay-pricing.ts";
+
+const LakeNumberSchema = z.union([z.number(), z.bigint()]).transform(Number);
+const WeeklyHistoryRowSchema = z.object({
+  match_id: z.string(),
+  puuid: z.string(),
+  completed_at_ms: LakeNumberSchema,
+  queue: z.enum(["solo", "flex", "ranked 5s"]),
+  win: z.boolean(),
+  champion_name: z.string(),
+  team_position: z.enum(["TOP", "JUNGLE", "MIDDLE", "BOTTOM", "UTILITY"]),
+  kills: LakeNumberSchema,
+  deaths: LakeNumberSchema,
+  assists: LakeNumberSchema,
+  champion_damage: LakeNumberSchema,
+  creep_score: LakeNumberSchema,
+  gold: LakeNumberSchema,
+  vision_score: LakeNumberSchema,
+  time_played: LakeNumberSchema,
+});
+
+export type WeeklyParlayCandidateHistory = {
+  subject: WeeklyParlaySubject;
+  windows: WeeklyParlayReplayWindow[];
+  fullyObservedWindows: number;
+  recentEligibleGames: number;
+  observedChampions: Set<string>;
+  observedRoles: Set<string>;
+};
+
+function periodKeysBefore(periodKey: string): string[] {
+  const current = parseISO(periodKey);
+  return Array.from(
+    { length: WEEKLY_PARLAY_HISTORY_WINDOW_COUNT },
+    (_, index) =>
+      formatISO(addWeeks(current, index - WEEKLY_PARLAY_HISTORY_WINDOW_COUNT), {
+        representation: "date",
+      }),
+  );
+}
+
+function snapshotFor(
+  row: z.infer<typeof WeeklyHistoryRowSchema>,
+  subject: WeeklyParlaySubject,
+): WeeklyParlayContributionSnapshot {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: subject.key,
+    puuid: row.puuid,
+    queue: row.queue,
+    completedAt: new Date(row.completed_at_ms).toISOString(),
+    win: row.win,
+    champion: row.champion_name,
+    role: row.team_position,
+    kills: row.kills,
+    deaths: row.deaths,
+    assists: row.assists,
+    championDamage: row.champion_damage,
+    creepScore: row.creep_score,
+    gold: row.gold,
+    visionScore: row.vision_score,
+    timePlayed: row.time_played,
+  });
+}
+
+export async function fetchWeeklyCandidateHistories(input: {
+  periodKey: string;
+  subjects: readonly WeeklyParlaySubject[];
+  lakeDir?: string;
+}): Promise<WeeklyParlayCandidateHistory[]> {
+  if (input.subjects.length === 0) {
+    return [];
+  }
+  const keys = periodKeysBefore(input.periodKey);
+  const firstPeriod = weeklyParlayPeriod(keys[0] ?? "");
+  const lastPeriod = weeklyParlayPeriod(keys.at(-1) ?? "");
+  const puuids = input.subjects.flatMap((subject) =>
+    subject.accounts.map((account) => account.puuid),
+  );
+  const files = await resolveLakeFiles(input.lakeDir ?? resolveLakeDir());
+  const source = buildMatchesSource(files, {
+    sql:
+      "queue IN (SELECT unnest(?)) " +
+      "AND epoch_ms(game_end_at) >= ? AND epoch_ms(game_end_at) < ?",
+    params: [
+      listParam(["solo", "flex", "ranked 5s"]),
+      scalarParam(firstPeriod.scoringStartsAt.getTime()),
+      scalarParam(lastPeriod.scoringEndsAt.getTime()),
+    ],
+  });
+  if (source === undefined) {
+    return [];
+  }
+  const rows = await withDuckDBConnection(async (session) => {
+    const result = await session.run(
+      "WITH scoring_rows AS (" +
+        source.sql +
+        "), eligible_matches AS (" +
+        "SELECT match_id FROM scoring_rows GROUP BY match_id HAVING count(*) = 10 " +
+        "AND count_if(team_id = 100) = 5 AND count_if(team_id = 200) = 5 " +
+        "AND bool_and(end_of_game_result = 'GameComplete') " +
+        "AND min(game_duration_seconds) >= 300 AND NOT bool_or(early_surrendered) " +
+        "AND count_if(win) = 5 " +
+        "AND count(DISTINCT CASE WHEN win THEN team_id END) = 1) " +
+        "SELECT match_id, puuid, epoch_ms(game_end_at)::BIGINT AS completed_at_ms, " +
+        "queue, win, champion_name, team_position, kills, deaths, assists, " +
+        "total_damage_dealt_to_champions AS champion_damage, creep_score, " +
+        "gold_earned AS gold, vision_score, time_played FROM scoring_rows " +
+        "INNER JOIN eligible_matches USING (match_id) " +
+        "WHERE puuid IN (SELECT unnest(?)) AND team_position <> '' " +
+        "ORDER BY completed_at_ms ASC, match_id ASC",
+      bindParams(session, [...source.params, listParam(puuids)]),
+    );
+    return result.map((row) => WeeklyHistoryRowSchema.parse(row));
+  });
+  const subjectByPuuid = new Map(
+    input.subjects.flatMap((subject) =>
+      subject.accounts.map((account) => [account.puuid, subject]),
+    ),
+  );
+  const historyRowsBySubject = new Map<
+    string,
+    { matchId: string; snapshot: WeeklyParlayContributionSnapshot }[]
+  >();
+  for (const row of rows) {
+    const subject = subjectByPuuid.get(LeaguePuuidSchema.parse(row.puuid));
+    if (subject === undefined) {
+      continue;
+    }
+    const bucket = historyRowsBySubject.get(subject.key) ?? [];
+    bucket.push({ matchId: row.match_id, snapshot: snapshotFor(row, subject) });
+    historyRowsBySubject.set(subject.key, bucket);
+  }
+  return input.subjects
+    .map((subject) => {
+      const trackingStartedAt = Math.max(
+        ...subject.accounts.map((account) =>
+          new Date(account.trackingStartedAt).getTime(),
+        ),
+      );
+      const historyRows = historyRowsBySubject.get(subject.key) ?? [];
+      const snapshots = historyRows.map((row) => row.snapshot);
+      const windows = keys
+        .map((key) => {
+          const period = weeklyParlayPeriod(key);
+          return {
+            periodKey: key,
+            observed: period.scoringStartsAt.getTime() >= trackingStartedAt,
+            contributions: snapshots.filter((snapshot) => {
+              const completedAt = new Date(snapshot.completedAt);
+              return (
+                completedAt >= period.scoringStartsAt &&
+                completedAt < period.scoringEndsAt
+              );
+            }),
+          };
+        })
+        .filter((window) => window.observed)
+        .map((window) => ({
+          periodKey: window.periodKey,
+          contributions: window.contributions,
+        }));
+      const recentPeriod = weeklyParlayPeriod(keys.at(-1) ?? "");
+      const recentMatchIds = new Set(
+        historyRows
+          .filter((row) => {
+            const completedAt = new Date(row.snapshot.completedAt);
+            return (
+              completedAt >= recentPeriod.scoringStartsAt &&
+              completedAt < recentPeriod.scoringEndsAt
+            );
+          })
+          .map((row) => row.matchId),
+      );
+      return {
+        subject: WeeklyParlaySubjectSchema.parse(subject),
+        windows,
+        fullyObservedWindows: windows.length,
+        recentEligibleGames: recentMatchIds.size,
+        observedChampions: new Set(
+          snapshots.map((snapshot) => snapshot.champion),
+        ),
+        observedRoles: new Set(snapshots.map((snapshot) => snapshot.role)),
+      };
+    })
+    .filter(
+      (history) =>
+        history.fullyObservedWindows >= WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
+    );
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
@@ -138,8 +138,8 @@ export async function fetchWeeklyCandidateHistories(input: {
       subject.accounts.map((account) => [account.puuid, subject]),
     ),
   );
-  const historyRowsBySubject = new Map<
-    string,
+  const historyRowsByPlayer = new Map<
+    number,
     { matchId: string; snapshot: WeeklyParlayContributionSnapshot }[]
   >();
   for (const row of rows) {
@@ -147,9 +147,9 @@ export async function fetchWeeklyCandidateHistories(input: {
     if (subject === undefined) {
       continue;
     }
-    const bucket = historyRowsBySubject.get(subject.key) ?? [];
+    const bucket = historyRowsByPlayer.get(subject.playerId) ?? [];
     bucket.push({ matchId: row.match_id, snapshot: snapshotFor(row, subject) });
-    historyRowsBySubject.set(subject.key, bucket);
+    historyRowsByPlayer.set(subject.playerId, bucket);
   }
   return input.subjects
     .map((subject) => {
@@ -158,7 +158,7 @@ export async function fetchWeeklyCandidateHistories(input: {
           new Date(account.trackingStartedAt).getTime(),
         ),
       );
-      const historyRows = historyRowsBySubject.get(subject.key) ?? [];
+      const historyRows = historyRowsByPlayer.get(subject.playerId) ?? [];
       const snapshots = historyRows.map((row) => row.snapshot);
       const windows = keys
         .map((key) => {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-model.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-model.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import { generateValidatedObject } from "@shepherdjerred/llm-runtime";
+import { bettingParlayAiModel } from "#src/config/dynamic.ts";
+import {
+  PARLAY_INITIAL_OUTPUT_TOKENS,
+  PARLAY_RETRY_OUTPUT_TOKENS,
+} from "#src/betting/constants.ts";
+import {
+  WEEKLY_PARLAY_SCHEMA_VERSION,
+  WeeklyParlayAggregateMetricSchema,
+  WeeklyParlayProposalSchema,
+  WeeklyParlayRateMetricSchema,
+  WeeklyParlayRoleSchema,
+  WeeklyParlaySubjectKeySchema,
+  type WeeklyParlayProposal,
+  type WeeklyParlaySubject,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { getOpenRouterRuntime } from "#src/league/review/ai-clients.ts";
+
+export const WEEKLY_PARLAY_PROMPT_VERSION = "1";
+
+const ModelWeeklyLegSchema = z.strictObject({
+  kind: z.enum(["aggregate", "rate", "champion_games", "role_games"]),
+  subject: WeeklyParlaySubjectKeySchema,
+  aggregateMetric: WeeklyParlayAggregateMetricSchema.nullable(),
+  rateMetric: WeeklyParlayRateMetricSchema.nullable(),
+  champion: z.string().min(1).max(50).nullable(),
+  role: WeeklyParlayRoleSchema.nullable(),
+  winsOnly: z.boolean().nullable(),
+  operator: z.enum(["gte", "lte", "eq"]),
+});
+const ModelWeeklyProposalSchema = z.strictObject({
+  version: z.literal(WEEKLY_PARLAY_SCHEMA_VERSION),
+  legs: z.array(ModelWeeklyLegSchema).min(3).max(5),
+});
+
+function canonicalProposal(
+  model: z.infer<typeof ModelWeeklyProposalSchema>,
+): WeeklyParlayProposal {
+  return WeeklyParlayProposalSchema.parse({
+    version: model.version,
+    legs: model.legs.map((leg) => {
+      switch (leg.kind) {
+        case "aggregate":
+          return {
+            kind: leg.kind,
+            subject: leg.subject,
+            metric: leg.aggregateMetric,
+            operator: leg.operator,
+          };
+        case "rate":
+          return {
+            kind: leg.kind,
+            subject: leg.subject,
+            metric: leg.rateMetric,
+            operator: leg.operator,
+          };
+        case "champion_games":
+          return {
+            kind: leg.kind,
+            subject: leg.subject,
+            champion: leg.champion,
+            winsOnly: leg.winsOnly,
+            operator: leg.operator,
+          };
+        case "role_games":
+          return {
+            kind: leg.kind,
+            subject: leg.subject,
+            role: leg.role,
+            winsOnly: leg.winsOnly,
+            operator: leg.operator,
+          };
+      }
+    }),
+  });
+}
+
+export async function generateWeeklyParlayProposal(input: {
+  periodKey: string;
+  subjects: readonly WeeklyParlaySubject[];
+  observedChampions: ReadonlyMap<string, ReadonlySet<string>>;
+  observedRoles: ReadonlyMap<string, ReadonlySet<string>>;
+  recentEligibleGames: ReadonlyMap<string, number>;
+  historyWindows: number;
+}): Promise<{
+  proposal: WeeklyParlayProposal;
+  model: string;
+  resolvedModel: string | null;
+  usage: unknown;
+}> {
+  const runtime = getOpenRouterRuntime();
+  if (runtime === undefined) {
+    throw new Error(
+      "OPENROUTER_API_KEY is required for weekly parlay generation.",
+    );
+  }
+  const model = bettingParlayAiModel();
+  const result = await generateValidatedObject(runtime, {
+    model,
+    schema: ModelWeeklyProposalSchema,
+    schemaName: "bryan_bucks_weekly_parlay_proposal",
+    schemaDescription:
+      "Three to five weekly AND legs from Scout's closed catalog, with no thresholds or odds.",
+    system:
+      "Choose a coherent, fun weekly League of Legends parlay. Use only the schema. " +
+      "Include every subject and a games gte participation leg for every subject. " +
+      "Never invent thresholds, odds, fields, paths, expressions, or settlement logic.",
+    prompt: JSON.stringify({
+      periodKey: input.periodKey,
+      subjects: input.subjects.map((subject) => ({
+        key: subject.key,
+        alias: subject.alias,
+        recentEligibleGames: input.recentEligibleGames.get(subject.key),
+        historicallyObservedChampions: [
+          ...(input.observedChampions.get(subject.key) ?? []),
+        ].toSorted(),
+        historicallyObservedRoles: [
+          ...(input.observedRoles.get(subject.key) ?? []),
+        ].toSorted(),
+      })),
+      fullyObservedHistoryWindows: input.historyWindows,
+    }),
+    workload: "scout.betting.weekly-parlay.generate",
+    sessionId: `${input.periodKey}:${input.subjects.map((subject) => subject.playerId).join("-")}`,
+    reasoningEffort: "medium",
+    maxOutputTokens: PARLAY_INITIAL_OUTPUT_TOKENS,
+    semanticRetryMaxOutputTokens: PARLAY_RETRY_OUTPUT_TOKENS,
+  });
+  const parsed = ModelWeeklyProposalSchema.parse(result.object);
+  return {
+    proposal: canonicalProposal(parsed),
+    model,
+    resolvedModel: result.metadata.at(-1)?.resolvedModel ?? null,
+    usage: result.usage,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -72,13 +72,13 @@ async function linkedMemberSubjects(
     },
     orderBy: { id: "asc" },
   });
-  return players.flatMap((player) => {
+  return players.flatMap((player, index) => {
     if (player.discordId === null || !members.has(player.discordId)) {
       return [];
     }
     return [
       WeeklyParlaySubjectsSchema.element.parse({
-        key: "P1",
+        key: `P${(index + 1).toString()}`,
         playerId: player.id,
         alias: player.alias,
         discordId: player.discordId,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -72,13 +72,16 @@ async function linkedMemberSubjects(
     },
     orderBy: { id: "asc" },
   });
-  return players.flatMap((player, index) => {
+  return players.flatMap((player) => {
     if (player.discordId === null || !members.has(player.discordId)) {
       return [];
     }
     return [
       WeeklyParlaySubjectsSchema.element.parse({
-        key: `P${(index + 1).toString()}`,
+        // Candidate subjects are evaluated one at a time in V1. Keep the
+        // schema-valid market key as a placeholder; history is keyed by the
+        // immutable player ID until a subject is selected.
+        key: "P1",
         playerId: player.id,
         alias: player.alias,
         discordId: player.discordId,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -1,0 +1,301 @@
+import { differenceInCalendarWeeks } from "date-fns";
+import {
+  DiscordGuildIdSchema,
+  LeaguePuuidSchema,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import {
+  WEEKLY_PARLAY_CATALOG_VERSION,
+  WEEKLY_PARLAY_ELIGIBLE_QUEUES,
+  WEEKLY_PARLAY_EVALUATOR_VERSION,
+  WEEKLY_PARLAY_PRICING_VERSION,
+  WEEKLY_PARLAY_SCHEMA_VERSION,
+  WeeklyParlaySubjectsSchema,
+  validateWeeklyParlayProposal,
+  type WeeklyParlaySubject,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { fetchWeeklyCandidateHistories } from "#src/betting/weekly-parlay-history.ts";
+import {
+  generateWeeklyParlayProposal,
+  WEEKLY_PARLAY_PROMPT_VERSION,
+} from "#src/betting/weekly-parlay-model.ts";
+import {
+  WEEKLY_PARLAY_SLOT,
+  weeklyParlayPeriod,
+} from "#src/betting/weekly-parlay-period.ts";
+import { priceWeeklyParlay } from "#src/betting/weekly-parlay-pricing.ts";
+import { orderWeeklyParlayCandidates } from "#src/betting/weekly-parlay-selection.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { client } from "#src/discord/client.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { isUniqueConstraintError } from "#src/lib/player-admin/shared.ts";
+import {
+  bettingWeeklyParlayGenerationDurationSeconds,
+  bettingWeeklyParlayGenerationTotal,
+} from "#src/metrics/betting-weekly-parlay.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+
+export type OpenWeeklyParlayResult =
+  | { kind: "created" | "existing"; marketId: number }
+  | { kind: "feature_disabled" | "no_candidate" | "no_price" };
+
+function periodsSinceFeatured(
+  current: string,
+  previous: string | undefined,
+): number | null {
+  return previous === undefined
+    ? null
+    : differenceInCalendarWeeks(new Date(current), new Date(previous), {
+        weekStartsOn: 1,
+      });
+}
+
+async function linkedMemberSubjects(
+  serverId: DiscordGuildId,
+  prismaClient: ExtendedPrismaClient,
+): Promise<WeeklyParlaySubject[]> {
+  const guild = client.guilds.cache.get(serverId);
+  if (guild === undefined) {
+    return [];
+  }
+  const members = await guild.members.fetch();
+  const players = await prismaClient.player.findMany({
+    where: { serverId, discordId: { not: null }, accounts: { some: {} } },
+    select: {
+      id: true,
+      alias: true,
+      discordId: true,
+      accounts: {
+        select: { puuid: true, createdTime: true },
+        orderBy: { id: "asc" },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+  return players.flatMap((player) => {
+    if (player.discordId === null || !members.has(player.discordId)) {
+      return [];
+    }
+    return [
+      WeeklyParlaySubjectsSchema.element.parse({
+        key: "P1",
+        playerId: player.id,
+        alias: player.alias,
+        discordId: player.discordId,
+        accounts: player.accounts.map((account) => ({
+          puuid: LeaguePuuidSchema.parse(account.puuid),
+          trackingStartedAt: account.createdTime.toISOString(),
+        })),
+      }),
+    ];
+  });
+}
+
+async function openWeeklyParlayInternal(
+  input: { serverId: string; periodKey: string; slot?: number },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<OpenWeeklyParlayResult> {
+  const serverId = DiscordGuildIdSchema.parse(input.serverId);
+  const slot = input.slot ?? WEEKLY_PARLAY_SLOT;
+  const existing = await prismaClient.bucksWeeklyParlayMarket.findUnique({
+    where: {
+      serverId_periodKey_slot: { serverId, periodKey: input.periodKey, slot },
+    },
+    select: { id: true },
+  });
+  if (existing !== null) {
+    return { kind: "existing", marketId: existing.id };
+  }
+  const [bettingEnabled, weeklyEnabled] = await Promise.all([
+    isPolicyEnabled("betting_enabled", { server: serverId }),
+    isPolicyEnabled("weekly_parlays_enabled", { server: serverId }),
+  ]);
+  if (!bettingEnabled || !weeklyEnabled) {
+    return { kind: "feature_disabled" };
+  }
+  const startedAt = Date.now();
+  const period = weeklyParlayPeriod(input.periodKey);
+  const subjects = await linkedMemberSubjects(serverId, prismaClient);
+  if (subjects.length === 0) {
+    return { kind: "no_candidate" };
+  }
+  const [histories, previousDefinitions] = await Promise.all([
+    fetchWeeklyCandidateHistories({ periodKey: input.periodKey, subjects }),
+    prismaClient.bucksWeeklyParlayDefinition.findMany({
+      where: { serverId, scoringStartsAt: { lt: period.scoringStartsAt } },
+      select: { periodKey: true, subjects: true },
+      orderBy: { scoringStartsAt: "desc" },
+      take: 52,
+    }),
+  ]);
+  const lastFeaturedByPlayer = new Map<number, string>();
+  for (const definition of previousDefinitions) {
+    for (const subject of WeeklyParlaySubjectsSchema.parse(
+      JSON.parse(definition.subjects),
+    )) {
+      if (!lastFeaturedByPlayer.has(subject.playerId)) {
+        lastFeaturedByPlayer.set(subject.playerId, definition.periodKey);
+      }
+    }
+  }
+  const historyByPlayer = new Map(
+    histories.map((history) => [history.subject.playerId, history]),
+  );
+  const ordered = orderWeeklyParlayCandidates(
+    histories.map((history) => ({
+      playerId: history.subject.playerId,
+      linkedGuildMember: true,
+      recentEligibleGames: history.recentEligibleGames,
+      fullyObservedWindows: history.fullyObservedWindows,
+      periodsSinceFeatured: periodsSinceFeatured(
+        input.periodKey,
+        lastFeaturedByPlayer.get(history.subject.playerId),
+      ),
+    })),
+  );
+  if (ordered.length === 0) {
+    return { kind: "no_candidate" };
+  }
+  for (const candidate of ordered) {
+    const history = historyByPlayer.get(candidate.playerId);
+    if (history === undefined) {
+      throw new Error("Ordered weekly candidate lost its history snapshot.");
+    }
+    const generated = await generateWeeklyParlayProposal({
+      periodKey: input.periodKey,
+      subjects: [history.subject],
+      observedChampions: new Map([
+        [history.subject.key, history.observedChampions],
+      ]),
+      observedRoles: new Map([[history.subject.key, history.observedRoles]]),
+      recentEligibleGames: new Map([
+        [history.subject.key, history.recentEligibleGames],
+      ]),
+      historyWindows: history.fullyObservedWindows,
+    });
+    const issues = validateWeeklyParlayProposal({
+      proposal: generated.proposal,
+      subjects: [history.subject],
+      observedChampions: new Map([
+        [history.subject.key, history.observedChampions],
+      ]),
+      observedRoles: new Map([[history.subject.key, history.observedRoles]]),
+    });
+    if (issues.length > 0) {
+      continue;
+    }
+    const priced = priceWeeklyParlay({
+      proposal: generated.proposal,
+      windows: history.windows,
+    });
+    if (priced === undefined) {
+      continue;
+    }
+    try {
+      const market = await prismaClient.$transaction(async (tx) => {
+        const definition = await tx.bucksWeeklyParlayDefinition.create({
+          data: {
+            serverId,
+            periodKey: input.periodKey,
+            slot,
+            openAt: period.openAt,
+            bettingClosesAt: period.bettingClosesAt,
+            scoringStartsAt: period.scoringStartsAt,
+            scoringEndsAt: period.scoringEndsAt,
+            subjects: JSON.stringify([history.subject]),
+            eligibleQueues: JSON.stringify(WEEKLY_PARLAY_ELIGIBLE_QUEUES),
+            proposal: JSON.stringify(generated.proposal),
+            criteria: JSON.stringify(priced.criteria),
+            historySample: JSON.stringify(history.windows),
+            pricing: JSON.stringify({
+              yesProbabilityBps: priced.yesProbabilityBps,
+              yesWindows: priced.yesWindows,
+              sampleSize: priced.sampleSize,
+              periodKeys: priced.periodKeys,
+            }),
+            yesProbabilityBps: priced.yesProbabilityBps,
+            promptVersion: WEEKLY_PARLAY_PROMPT_VERSION,
+            catalogVersion: WEEKLY_PARLAY_CATALOG_VERSION,
+            schemaVersion: WEEKLY_PARLAY_SCHEMA_VERSION,
+            evaluatorVersion: WEEKLY_PARLAY_EVALUATOR_VERSION,
+            pricingVersion: WEEKLY_PARLAY_PRICING_VERSION,
+            generationContext: JSON.stringify({
+              candidateOrder: ordered.map((entry) => entry.playerId),
+              selectedPlayerId: history.subject.playerId,
+              observedChampions: [...history.observedChampions].toSorted(),
+              observedRoles: [...history.observedRoles].toSorted(),
+              recentEligibleGames: history.recentEligibleGames,
+              fullyObservedWindows: history.fullyObservedWindows,
+            }),
+            requestedModel: generated.model,
+            resolvedModel: generated.resolvedModel,
+            usage: JSON.stringify(generated.usage),
+            durationMs: Date.now() - startedAt,
+          },
+          select: { id: true },
+        });
+        return await tx.bucksWeeklyParlayMarket.create({
+          data: {
+            definitionId: definition.id,
+            serverId,
+            periodKey: input.periodKey,
+            slot,
+            publishedAt: period.openAt,
+            bettingClosesAt: period.bettingClosesAt,
+            scoringEndsAt: period.scoringEndsAt,
+          },
+          select: { id: true },
+        });
+      });
+      return { kind: "created", marketId: market.id };
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) {
+        throw error;
+      }
+      const racedMarket =
+        await prismaClient.bucksWeeklyParlayMarket.findUniqueOrThrow({
+          where: {
+            serverId_periodKey_slot: {
+              serverId,
+              periodKey: input.periodKey,
+              slot,
+            },
+          },
+          select: { id: true },
+        });
+      return { kind: "existing", marketId: racedMarket.id };
+    }
+  }
+  return { kind: "no_price" };
+}
+
+export async function openWeeklyParlay(
+  input: { serverId: string; periodKey: string; slot?: number },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<OpenWeeklyParlayResult> {
+  const startedAt = Date.now();
+  let result: OpenWeeklyParlayResult;
+  try {
+    result = await openWeeklyParlayInternal(input, prismaClient);
+  } catch (error) {
+    bettingWeeklyParlayGenerationTotal.inc({ result: "error" });
+    throw error;
+  }
+  bettingWeeklyParlayGenerationTotal.inc({ result: result.kind });
+  if (result.kind === "created") {
+    bettingWeeklyParlayGenerationDurationSeconds.observe(
+      (Date.now() - startedAt) / 1000,
+    );
+    logBucksTransition({
+      event: "bucks.weekly_parlay.published",
+      serverId: input.serverId,
+      marketId: result.marketId,
+      periodKey: input.periodKey,
+      slot: input.slot ?? WEEKLY_PARLAY_SLOT,
+      fromState: "none",
+      toState: "publishing",
+      surface: "cron",
+    });
+  }
+  return result;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
   isWithinWeeklyScoringPeriod,
+  WEEKLY_PARLAY_INGESTION_GRACE_MS,
+  weeklyParlayFinalSettlementAt,
   weeklyParlayPeriod,
 } from "#src/betting/weekly-parlay-period.ts";
 
@@ -42,6 +44,17 @@ describe("weekly parlay Pacific periods", () => {
     expect(isWithinWeeklyScoringPeriod(period.scoringEndsAt, period)).toBe(
       false,
     );
+  });
+
+  test("reserves a bounded ingestion reconciliation window after scoring", () => {
+    const period = weeklyParlayPeriod("2026-03-09");
+    expect(
+      weeklyParlayFinalSettlementAt(period.scoringEndsAt).getTime() -
+        period.scoringEndsAt.getTime(),
+    ).toBe(WEEKLY_PARLAY_INGESTION_GRACE_MS);
+    expect(
+      weeklyParlayFinalSettlementAt(period.scoringEndsAt).getTime(),
+    ).toBeLessThan(period.nextOpenAt.getTime());
   });
 
   test("rejects a non-Monday period key", () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts
@@ -1,4 +1,5 @@
 import { addDays, formatISO, parseISO } from "date-fns";
+import { POLLING_INTERVALS } from "@scout-for-lol/data/polling-config.ts";
 
 export const WEEKLY_PARLAY_TIMEZONE = "America/Los_Angeles";
 export const WEEKLY_PARLAY_SLOT = 0;
@@ -7,6 +8,21 @@ export const WEEKLY_PARLAY_BETTING_CLOSE_HOUR = 0;
 export const WEEKLY_PARLAY_FINAL_HOUR = 11;
 export const WEEKLY_PARLAY_UPDATE_HOUR = 19;
 export const WEEKLY_PARLAY_UPDATE_COUNT = 6;
+const WEEKLY_PARLAY_INGESTION_POLL_WINDOWS = 2;
+export const WEEKLY_PARLAY_INGESTION_GRACE_MINUTES =
+  POLLING_INTERVALS.MAX * WEEKLY_PARLAY_INGESTION_POLL_WINDOWS;
+export const WEEKLY_PARLAY_INGESTION_GRACE_MS =
+  WEEKLY_PARLAY_INGESTION_GRACE_MINUTES * 60_000;
+
+export function weeklyParlayWallClockLabel(hour: number): string {
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    throw new Error(
+      `Invalid weekly parlay wall-clock hour ${hour.toString()}.`,
+    );
+  }
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${displayHour.toString()}:00 ${hour < 12 ? "AM" : "PM"}`;
+}
 
 export type WeeklyParlayPeriod = {
   periodKey: string;
@@ -133,4 +149,8 @@ export function isWithinWeeklyScoringPeriod(
   return (
     completedAt >= period.scoringStartsAt && completedAt < period.scoringEndsAt
   );
+}
+
+export function weeklyParlayFinalSettlementAt(scoringEndsAt: Date): Date {
+  return new Date(scoringEndsAt.getTime() + WEEKLY_PARLAY_INGESTION_GRACE_MS);
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -1,0 +1,81 @@
+import type { MessageEditOptions } from "discord.js";
+import { BucksMessageRefsSchema } from "@scout-for-lol/data";
+import {
+  WeeklyParlayDefinitionCriteriaSchema,
+  WeeklyParlaySubjectsSchema,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  countLabel,
+  deliveryTimeCopy,
+  deliveryTitle,
+  legLine,
+  weeklyParlayButtons,
+} from "#src/betting/weekly-parlay-discord.ts";
+import { runSerialized } from "#src/betting/refresh-queue.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { client } from "#src/discord/client.ts";
+
+/** Edit the original open-market message after a bet or cancellation. */
+export async function refreshWeeklyParlayMessage(
+  marketId: number,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  await runSerialized(`weekly:${marketId.toString()}`, async () => {
+    const market = await prismaClient.bucksWeeklyParlayMarket.findUnique({
+      where: { id: marketId },
+      select: {
+        messageRefs: true,
+        marketState: true,
+        periodKey: true,
+        bettingClosesAt: true,
+        scoringEndsAt: true,
+        definition: {
+          select: {
+            subjects: true,
+            criteria: true,
+            yesProbabilityBps: true,
+          },
+        },
+        bets: {
+          where: { betOutcome: "pending" },
+          select: { stake: true },
+        },
+      },
+    });
+    if (market?.marketState !== "open") return;
+    const refs = BucksMessageRefsSchema.parse(JSON.parse(market.messageRefs));
+    if (refs.length === 0) return;
+    const subjects = WeeklyParlaySubjectsSchema.parse(
+      JSON.parse(market.definition.subjects),
+    );
+    const criteria = WeeklyParlayDefinitionCriteriaSchema.parse(
+      JSON.parse(market.definition.criteria),
+    );
+    const aliases = new Map(
+      subjects.map((subject) => [subject.key, subject.alias]),
+    );
+    const content = [
+      deliveryTitle("open", market.marketState, null),
+      `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
+      ...criteria.legs.map((leg) =>
+        legLine(leg, undefined, aliases.get(leg.subject) ?? leg.subject),
+      ),
+      `**${market.bets.length.toString()} ${countLabel(market.bets.length, "bettor")} · ${market.bets.reduce((total, bet) => total + bet.stake, 0).toString()} BB staked**`,
+      deliveryTimeCopy("open", market.bettingClosesAt, market.scoringEndsAt),
+    ].join("\n");
+    for (const [index, ref] of refs.entries()) {
+      const channel = await client.channels.fetch(ref.channelId);
+      if (channel?.isTextBased() !== true) {
+        throw new Error(
+          `Weekly parlay channel ${ref.channelId} is unavailable or not text based`,
+        );
+      }
+      const options: MessageEditOptions = {
+        content,
+        allowedMentions: { parse: [] },
+        components: index === 0 ? weeklyParlayButtons("open", marketId) : [],
+      };
+      await channel.messages.edit(ref.messageId, options);
+    }
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -1,0 +1,842 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  LeaguePuuidSchema,
+  RawMatchSchema,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import {
+  cancelWeeklyParlayBet,
+  placeWeeklyParlayBet,
+} from "#src/betting/weekly-parlay-bet.ts";
+import {
+  captureWeeklyParlayContributions,
+  weeklyContributionsForMatch,
+} from "#src/betting/weekly-parlay-contribution.ts";
+import {
+  deliverWeeklyParlayDiscord,
+  type WeeklyParlayDiscordSender,
+} from "#src/betting/weekly-parlay-discord.ts";
+import { runWeeklyParlayControlAction } from "#src/betting/weekly-parlay-control.ts";
+import {
+  WEEKLY_PARLAY_INGESTION_GRACE_MS,
+  weeklyParlayFinalSettlementAt,
+  weeklyParlayPeriod,
+} from "#src/betting/weekly-parlay-period.ts";
+import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
+import { WeeklyParlaySubjectSchema } from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  addFlagOverride,
+  clearFlagOverrides,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+
+const { prisma: db } = createTestDatabase("bucks-weekly-parlay-runtime");
+const fixture = RawMatchSchema.parse(
+  await Bun.file(
+    new URL("../../../../testdata/rift.json", import.meta.url),
+  ).json(),
+);
+const SERVER_ID = DiscordGuildIdSchema.parse("1337623164146155593");
+const BETTOR = DiscordAccountIdSchema.parse("160509172704739328");
+const PERIOD_KEY = "2026-08-24";
+
+function participant() {
+  const value = fixture.info.participants[0];
+  if (value === undefined) {
+    throw new Error("Rift fixture needs a participant.");
+  }
+  return value;
+}
+
+const PARTICIPANT = participant();
+const PARTICIPANT_PUUID = LeaguePuuidSchema.parse(PARTICIPANT.puuid);
+const COMPLETED_AT = new Date(fixture.info.gameEndTimestamp);
+
+function subject(
+  playerId: number,
+  puuids: readonly string[] = [PARTICIPANT_PUUID],
+) {
+  return WeeklyParlaySubjectSchema.parse({
+    key: "P1",
+    playerId,
+    alias: "jerred",
+    discordId: BETTOR,
+    accounts: puuids.map((puuid) => ({
+      puuid: LeaguePuuidSchema.parse(puuid),
+      trackingStartedAt: new Date(
+        COMPLETED_AT.getTime() - 60 * 60_000,
+      ).toISOString(),
+    })),
+  });
+}
+
+function hitCriteria() {
+  return {
+    version: 1,
+    legs: [
+      {
+        kind: "aggregate",
+        subject: "P1",
+        metric: "games",
+        operator: "gte",
+        threshold: 1,
+      },
+      {
+        kind: "aggregate",
+        subject: "P1",
+        metric: "kills",
+        operator: "gte",
+        threshold: PARTICIPANT.kills,
+      },
+      {
+        kind: "aggregate",
+        subject: "P1",
+        metric: "champion_damage",
+        operator: "gte",
+        threshold: PARTICIPANT.totalDamageDealtToChampions,
+      },
+    ],
+  };
+}
+
+async function clearAll(): Promise<void> {
+  await db.bucksLedgerEntry.deleteMany();
+  await db.bucksWeeklyParlayDelivery.deleteMany();
+  await db.bucksWeeklyParlayContribution.deleteMany();
+  await db.bucksWeeklyParlayBet.deleteMany();
+  await db.bucksWeeklyParlayMarket.deleteMany();
+  await db.bucksWeeklyParlayDefinition.deleteMany();
+  await db.bucksBet.deleteMany();
+  await db.bucksMatchPool.deleteMany();
+  await db.bucksAccount.deleteMany();
+  await db.account.deleteMany();
+  await db.player.deleteMany();
+}
+
+async function makeMarket(input?: {
+  criteria?: ReturnType<typeof hitCriteria>;
+  marketState?: "publishing" | "open" | "active";
+  slot?: number;
+}) {
+  const player = await db.player.findFirstOrThrow({
+    where: { serverId: SERVER_ID, discordId: BETTOR },
+  });
+  const scoringStartsAt = new Date(COMPLETED_AT.getTime() - 60 * 60_000);
+  const scoringEndsAt = new Date(COMPLETED_AT.getTime() + 60 * 60_000);
+  const definition = await db.bucksWeeklyParlayDefinition.create({
+    data: {
+      serverId: SERVER_ID,
+      periodKey: PERIOD_KEY,
+      slot: input?.slot ?? 0,
+      openAt: new Date(COMPLETED_AT.getTime() - 3 * 60 * 60_000),
+      bettingClosesAt: new Date(COMPLETED_AT.getTime() - 2 * 60 * 60_000),
+      scoringStartsAt,
+      scoringEndsAt,
+      subjects: JSON.stringify([subject(player.id)]),
+      eligibleQueues: JSON.stringify(["solo", "flex", "ranked 5s"]),
+      proposal: JSON.stringify({ version: 1, legs: [] }),
+      criteria: JSON.stringify(input?.criteria ?? hitCriteria()),
+      historySample: "[]",
+      pricing: "{}",
+      yesProbabilityBps: 5000,
+      promptVersion: "test",
+      catalogVersion: "test",
+      schemaVersion: 1,
+      evaluatorVersion: "1",
+      pricingVersion: "1",
+      generationContext: "{}",
+      requestedModel: "test",
+      usage: "{}",
+      durationMs: 1,
+    },
+  });
+  return await db.bucksWeeklyParlayMarket.create({
+    data: {
+      definitionId: definition.id,
+      serverId: SERVER_ID,
+      periodKey: PERIOD_KEY,
+      slot: input?.slot ?? 0,
+      publishedAt: new Date(COMPLETED_AT.getTime() - 3 * 60 * 60_000),
+      bettingClosesAt: new Date(COMPLETED_AT.getTime() - 2 * 60 * 60_000),
+      scoringEndsAt,
+      marketState: input?.marketState ?? "open",
+    },
+    include: { definition: true },
+  });
+}
+
+function place(marketId: number, side: "YES" | "NO", stake: number) {
+  return placeWeeklyParlayBet(
+    {
+      marketId,
+      serverId: SERVER_ID,
+      discordId: BETTOR,
+      side,
+      stake,
+      now: new Date(COMPLETED_AT.getTime() - 150 * 60_000),
+    },
+    db,
+  );
+}
+
+beforeEach(async () => {
+  await clearAll();
+  for (const flag of ["betting_enabled", "weekly_parlays_enabled"] as const) {
+    clearFlagOverrides(flag);
+    addFlagOverride(flag, true, { server: SERVER_ID });
+  }
+  const now = new Date(COMPLETED_AT.getTime() - 24 * 60 * 60_000);
+  const player = await db.player.create({
+    data: {
+      alias: "jerred",
+      discordId: BETTOR,
+      serverId: SERVER_ID,
+      creatorDiscordId: BETTOR,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await db.account.create({
+    data: {
+      alias: "jerred",
+      puuid: PARTICIPANT_PUUID,
+      region: "AMERICA_NORTH",
+      playerId: player.id,
+      serverId: SERVER_ID,
+      creatorDiscordId: BETTOR,
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await db.bucksAccount.create({
+    data: { serverId: SERVER_ID, discordId: BETTOR, balance: 100 },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetFlagOverrides("betting_enabled");
+  resetFlagOverrides("weekly_parlays_enabled");
+});
+
+afterAll(async () => {
+  await clearAll();
+  await db.$disconnect();
+});
+
+describe("weekly parlay match eligibility", () => {
+  test.each([
+    [420, "solo"],
+    [440, "flex"],
+    [710, "ranked 5s"],
+  ] as const)("includes exact ranked queue %i as %s", (queueId, queue) => {
+    const match = RawMatchSchema.parse({
+      ...fixture,
+      info: { ...fixture.info, queueId },
+    });
+    expect(
+      weeklyContributionsForMatch({ matchData: match, subjects: [subject(1)] }),
+    ).toMatchObject([{ queue }]);
+  });
+
+  test.each([0, 400, 450, 700, 720, 1700])(
+    "excludes non-ranked queue %i",
+    (queueId) => {
+      const match = RawMatchSchema.parse({
+        ...fixture,
+        info: { ...fixture.info, queueId },
+      });
+      expect(
+        weeklyContributionsForMatch({
+          matchData: match,
+          subjects: [subject(1)],
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  test("aggregates all frozen accounts for one subject", () => {
+    const secondPuuid = fixture.info.participants[1]?.puuid;
+    if (secondPuuid === undefined) {
+      throw new Error("Rift fixture needs a second participant.");
+    }
+    const frozen = subject(1, [PARTICIPANT_PUUID, secondPuuid]);
+    expect(
+      weeklyContributionsForMatch({ matchData: fixture, subjects: [frozen] }),
+    ).toHaveLength(2);
+  });
+
+  test("extracts contributions for every frozen subject", () => {
+    const secondPuuid = fixture.info.participants[1]?.puuid;
+    if (secondPuuid === undefined) {
+      throw new Error("Rift fixture needs a second participant.");
+    }
+    const secondSubject = WeeklyParlaySubjectSchema.parse({
+      ...subject(1, [secondPuuid]),
+      key: "P2",
+      playerId: 2,
+      alias: "bryan",
+      discordId: bucksTestDiscordId(900),
+    });
+    expect(
+      weeklyContributionsForMatch({
+        matchData: fixture,
+        subjects: [subject(1), secondSubject],
+      }).map((contribution) => contribution.subject),
+    ).toEqual(["P1", "P2"]);
+  });
+});
+
+describe("weekly parlay ledger and settlement", () => {
+  test("reprices top-ups and cancels for free with ledger conservation", async () => {
+    const market = await makeMarket();
+    await expect(place(market.id, "YES", 10)).resolves.toMatchObject({
+      kind: "placed",
+      totalStake: 10,
+      grossPayout: 20,
+      wasTopUp: false,
+    });
+    await expect(place(market.id, "YES", 5)).resolves.toMatchObject({
+      kind: "placed",
+      totalStake: 15,
+      grossPayout: 30,
+      wasTopUp: true,
+    });
+    await expect(
+      cancelWeeklyParlayBet(
+        {
+          marketId: market.id,
+          serverId: SERVER_ID,
+          discordId: BETTOR,
+          now: new Date(COMPLETED_AT.getTime() - 150 * 60_000),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({ kind: "cancelled", refunded: 15 });
+    const [wallet, ledger] = await Promise.all([
+      db.bucksAccount.findUniqueOrThrow({
+        where: {
+          serverId_discordId: { serverId: SERVER_ID, discordId: BETTOR },
+        },
+      }),
+      db.bucksLedgerEntry.findMany({}),
+    ]);
+    const weeklyLedger = ledger.filter((entry) =>
+      entry.kind.startsWith("weekly_parlay_"),
+    );
+    expect(wallet.balance).toBe(100);
+    expect(weeklyLedger.reduce((total, entry) => total + entry.delta, 0)).toBe(
+      0,
+    );
+    expect(
+      weeklyLedger.map(
+        (entry) =>
+          z.object({ version: z.literal(1) }).parse(JSON.parse(entry.context))
+            .version,
+      ),
+    ).toEqual([1, 1, 1, 1, 1, 1]);
+  });
+
+  test("flag revocation blocks new stakes but preserves cancellation", async () => {
+    const market = await makeMarket();
+    await expect(place(market.id, "YES", 10)).resolves.toMatchObject({
+      kind: "placed",
+    });
+    clearFlagOverrides("weekly_parlays_enabled");
+    addFlagOverride("weekly_parlays_enabled", false, { server: SERVER_ID });
+    await expect(place(market.id, "YES", 1)).resolves.toEqual({
+      kind: "feature_disabled",
+    });
+    await expect(
+      cancelWeeklyParlayBet(
+        {
+          marketId: market.id,
+          serverId: SERVER_ID,
+          discordId: BETTOR,
+          now: new Date(COMPLETED_AT.getTime() - 150 * 60_000),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({ kind: "cancelled", refunded: 10 });
+  });
+
+  test("serializes concurrent top-ups against one house liability", async () => {
+    const market = await makeMarket();
+    const results = await Promise.all([
+      place(market.id, "YES", 10),
+      place(market.id, "YES", 10),
+    ]);
+    expect(results.every((result) => result.kind === "placed")).toBe(true);
+    const account = await db.bucksAccount.findUniqueOrThrow({
+      where: {
+        serverId_discordId: { serverId: SERVER_ID, discordId: BETTOR },
+      },
+    });
+    await expect(
+      db.bucksWeeklyParlayBet.findUniqueOrThrow({
+        where: {
+          marketId_bucksAccountId: {
+            marketId: market.id,
+            bucksAccountId: account.id,
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ stake: 20, houseReserve: 20, grossPayout: 40 });
+  });
+});
+
+describe("weekly parlay settlement", () => {
+  test("never settles NO early and finalizes NO after ingestion reconciliation", async () => {
+    const market = await makeMarket();
+    await place(market.id, "NO", 10);
+    await db.bucksWeeklyParlayMarket.update({
+      where: { id: market.id },
+      data: { marketState: "active" },
+    });
+    await expect(
+      settleWeeklyParlayMarket(
+        { marketId: market.id, mode: "early_yes", now: COMPLETED_AT },
+        db,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      settleWeeklyParlayMarket(
+        {
+          marketId: market.id,
+          mode: "final",
+          now: weeklyParlayFinalSettlementAt(market.scoringEndsAt),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({ yesResult: false });
+    await expect(
+      db.bucksWeeklyParlayBet.findFirstOrThrow({
+        where: { marketId: market.id },
+      }),
+    ).resolves.toMatchObject({ betOutcome: "won", payout: 20 });
+  });
+
+  test("voids an open market when finalization reveals start never ran", async () => {
+    const market = await makeMarket();
+    await place(market.id, "NO", 10);
+    await expect(
+      settleWeeklyParlayMarket(
+        {
+          marketId: market.id,
+          mode: "final",
+          now: weeklyParlayFinalSettlementAt(market.scoringEndsAt),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({
+      fromState: "open",
+      voidReason: "infrastructure_failure",
+    });
+    await expect(
+      db.bucksWeeklyParlayBet.findFirstOrThrow({
+        where: { marketId: market.id },
+      }),
+    ).resolves.toMatchObject({ betOutcome: "refunded", payout: 10 });
+  });
+
+  test("settles YES early only after every persisted leg is irreversible", async () => {
+    const market = await makeMarket();
+    await place(market.id, "YES", 10);
+    await db.bucksWeeklyParlayMarket.update({
+      where: { id: market.id },
+      data: { marketState: "active" },
+    });
+    const snapshot = weeklyContributionsForMatch({
+      matchData: fixture,
+      subjects: [subject(market.definition.id)],
+    })[0];
+    if (snapshot === undefined) {
+      throw new Error("Expected a weekly contribution snapshot.");
+    }
+    await db.bucksWeeklyParlayContribution.create({
+      data: {
+        definitionId: market.definitionId,
+        matchId: fixture.metadata.matchId,
+        subjectKey: snapshot.subject,
+        completedAt: new Date(snapshot.completedAt),
+        ingestedAt: COMPLETED_AT,
+        queueType: snapshot.queue,
+        snapshot: JSON.stringify(snapshot),
+      },
+    });
+    await expect(
+      settleWeeklyParlayMarket(
+        { marketId: market.id, mode: "early_yes", now: COMPLETED_AT },
+        db,
+      ),
+    ).resolves.toMatchObject({ yesResult: true });
+  });
+
+  test("voids and refunds every reserved position on evaluator failure", async () => {
+    const market = await makeMarket();
+    await place(market.id, "YES", 10);
+    await db.bucksWeeklyParlayMarket.update({
+      where: { id: market.id },
+      data: { marketState: "active" },
+    });
+    await db.bucksWeeklyParlayDefinition.update({
+      where: { id: market.definitionId },
+      data: { evaluatorVersion: "unknown" },
+    });
+    await expect(
+      settleWeeklyParlayMarket(
+        {
+          marketId: market.id,
+          mode: "final",
+          now: weeklyParlayFinalSettlementAt(market.scoringEndsAt),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({ voidReason: "unknown_evaluator" });
+    const [wallet, bet] = await Promise.all([
+      db.bucksAccount.findUniqueOrThrow({
+        where: {
+          serverId_discordId: { serverId: SERVER_ID, discordId: BETTOR },
+        },
+      }),
+      db.bucksWeeklyParlayBet.findFirstOrThrow({
+        where: { marketId: market.id },
+      }),
+    ]);
+    expect(wallet.balance).toBe(100);
+    expect(bet).toMatchObject({ betOutcome: "refunded", payout: 10 });
+  });
+});
+
+describe("weekly parlay contributions and control actions", () => {
+  test("propagates definition lookup failures so post-match ingestion retries", async () => {
+    vi.spyOn(db.bucksWeeklyParlayDefinition, "findMany").mockRejectedValueOnce(
+      new Error("weekly lookup unavailable"),
+    );
+    await expect(
+      captureWeeklyParlayContributions(fixture, db, COMPLETED_AT),
+    ).rejects.toThrow("weekly lookup unavailable");
+  });
+
+  test("appends independently to concurrent market slots", async () => {
+    const finalOnly = hitCriteria();
+    finalOnly.legs[0] = {
+      kind: "aggregate",
+      subject: "P1",
+      metric: "games",
+      operator: "eq",
+      threshold: 1,
+    };
+    await Promise.all([
+      makeMarket({ criteria: finalOnly, marketState: "active", slot: 0 }),
+      makeMarket({ criteria: finalOnly, marketState: "active", slot: 1 }),
+    ]);
+    await expect(
+      captureWeeklyParlayContributions(
+        fixture,
+        db,
+        new Date(COMPLETED_AT.getTime() + 60_000),
+      ),
+    ).resolves.toBe(2);
+    await expect(db.bucksWeeklyParlayContribution.count()).resolves.toBe(2);
+  });
+
+  test("reconciles duplicate starts and skips stale reminders", async () => {
+    const market = await makeMarket({ marketState: "open" });
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const start = { periodKey: PERIOD_KEY, action: "start" as const, slot: 0 };
+    await expect(
+      runWeeklyParlayControlAction(start, {
+        serverId: SERVER_ID,
+        now: period.scoringStartsAt,
+        prismaClient: db,
+      }),
+    ).resolves.toMatchObject({ status: "reconciled", marketId: market.id });
+    await expect(
+      runWeeklyParlayControlAction(start, {
+        serverId: SERVER_ID,
+        now: period.scoringStartsAt,
+        prismaClient: db,
+      }),
+    ).resolves.toMatchObject({ status: "reconciled", marketId: market.id });
+    await db.bucksWeeklyParlayMarket.update({
+      where: { id: market.id },
+      data: { marketState: "open" },
+    });
+    const secondUpdate = period.updateAt[1];
+    if (secondUpdate === undefined) {
+      throw new Error("Weekly fixture needs a second progress update.");
+    }
+    await expect(
+      runWeeklyParlayControlAction(
+        { periodKey: PERIOD_KEY, action: "reminder", slot: 0 },
+        {
+          serverId: SERVER_ID,
+          now: period.bettingClosesAt,
+          prismaClient: db,
+        },
+      ),
+    ).resolves.toMatchObject({ status: "skipped", detail: "stale_reminder" });
+    await expect(
+      runWeeklyParlayControlAction(
+        {
+          periodKey: PERIOD_KEY,
+          action: "progress",
+          slot: 0,
+          updateIndex: 0,
+        },
+        {
+          serverId: SERVER_ID,
+          now: secondUpdate,
+          prismaClient: db,
+        },
+      ),
+    ).resolves.toMatchObject({ status: "skipped", detail: "stale_progress" });
+  });
+
+  test("appends once and accepts a pre-cutoff completion ingested during reconciliation", async () => {
+    const finalOnly = hitCriteria();
+    finalOnly.legs[0] = {
+      kind: "aggregate",
+      subject: "P1",
+      metric: "games",
+      operator: "eq",
+      threshold: 1,
+    };
+    const market = await makeMarket({
+      criteria: finalOnly,
+      marketState: "active",
+    });
+    const ingestedAt = new Date(COMPLETED_AT.getTime() + 60_000);
+    await expect(
+      captureWeeklyParlayContributions(fixture, db, ingestedAt),
+    ).resolves.toBe(1);
+    await expect(
+      db.bucksWeeklyParlayMarket.findUniqueOrThrow({
+        where: { id: market.id },
+      }),
+    ).resolves.toMatchObject({ marketState: "active" });
+    await expect(
+      captureWeeklyParlayContributions(fixture, db, ingestedAt),
+    ).resolves.toBe(0);
+    await db.bucksWeeklyParlayContribution.deleteMany();
+    await expect(
+      captureWeeklyParlayContributions(
+        fixture,
+        db,
+        new Date(market.scoringEndsAt.getTime() + 60_000),
+      ),
+    ).resolves.toBe(1);
+  });
+
+  test("captures a completed game while scoring start is delayed", async () => {
+    const finalOnly = hitCriteria();
+    finalOnly.legs[0] = {
+      kind: "aggregate",
+      subject: "P1",
+      metric: "games",
+      operator: "eq",
+      threshold: 1,
+    };
+    const market = await makeMarket({
+      criteria: finalOnly,
+      marketState: "open",
+    });
+    await expect(
+      captureWeeklyParlayContributions(fixture, db, COMPLETED_AT),
+    ).resolves.toBe(1);
+    await expect(
+      db.bucksWeeklyParlayContribution.count({
+        where: { definitionId: market.definitionId },
+      }),
+    ).resolves.toBe(1);
+  });
+});
+
+describe("weekly parlay ingestion boundaries", () => {
+  test("excludes completion at the half-open cutoff", async () => {
+    const finalOnly = hitCriteria();
+    finalOnly.legs[0] = {
+      kind: "aggregate",
+      subject: "P1",
+      metric: "games",
+      operator: "eq",
+      threshold: 1,
+    };
+    const market = await makeMarket({
+      criteria: finalOnly,
+      marketState: "active",
+    });
+    const cutoffFixture = RawMatchSchema.parse({
+      ...fixture,
+      info: {
+        ...fixture.info,
+        gameEndTimestamp: market.scoringEndsAt.getTime(),
+      },
+    });
+    await expect(
+      captureWeeklyParlayContributions(
+        cutoffFixture,
+        db,
+        new Date(
+          market.scoringEndsAt.getTime() + WEEKLY_PARLAY_INGESTION_GRACE_MS - 1,
+        ),
+      ),
+    ).resolves.toBe(0);
+  });
+
+  test("does not settle before the ingestion window and includes a late contribution", async () => {
+    const finalOnly = hitCriteria();
+    finalOnly.legs[0] = {
+      kind: "aggregate",
+      subject: "P1",
+      metric: "games",
+      operator: "eq",
+      threshold: 1,
+    };
+    const market = await makeMarket({
+      criteria: finalOnly,
+      marketState: "active",
+    });
+    await expect(
+      settleWeeklyParlayMarket(
+        {
+          marketId: market.id,
+          mode: "final",
+          now: new Date(
+            weeklyParlayFinalSettlementAt(market.scoringEndsAt).getTime() - 1,
+          ),
+        },
+        db,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      captureWeeklyParlayContributions(
+        fixture,
+        db,
+        new Date(market.scoringEndsAt.getTime() + 60_000),
+      ),
+    ).resolves.toBe(1);
+    await expect(
+      settleWeeklyParlayMarket(
+        {
+          marketId: market.id,
+          mode: "final",
+          now: weeklyParlayFinalSettlementAt(market.scoringEndsAt),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({ yesResult: true });
+  });
+});
+
+describe("weekly parlay Discord delivery", () => {
+  test("chunks and deduplicates private mention delivery with a stable nonce", async () => {
+    const market = await makeMarket({ marketState: "open" });
+    const discordIds = Array.from({ length: 25 }, (_unused, index) =>
+      index === 0 ? BETTOR : bucksTestDiscordId(index + 500),
+    );
+    await db.bucksAccount.createMany({
+      data: discordIds.slice(1).map((discordId) => ({
+        serverId: SERVER_ID,
+        discordId,
+        balance: 10,
+      })),
+    });
+    const accounts = await db.bucksAccount.findMany({
+      where: { serverId: SERVER_ID, discordId: { in: discordIds } },
+      orderBy: { id: "asc" },
+    });
+    await db.bucksWeeklyParlayBet.createMany({
+      data: accounts.map((account) => ({
+        marketId: market.id,
+        bucksAccountId: account.id,
+        side: account.discordId === BETTOR ? "YES" : "NO",
+        stake: 1,
+        houseReserve: 1,
+        grossPayout: 2,
+      })),
+    });
+    const sent: Parameters<WeeklyParlayDiscordSender>[0][] = [];
+    const sender: WeeklyParlayDiscordSender = async (options) => {
+      sent.push(options);
+      return {
+        channelId: "160509172704739999",
+        id: `message-${sent.length.toString()}`,
+      };
+    };
+    const delivery = {
+      marketId: market.id,
+      actionKey: "progress:0",
+      kind: "progress" as const,
+      scheduledAt: COMPLETED_AT,
+    };
+    await expect(
+      deliverWeeklyParlayDiscord(delivery, db, sender),
+    ).resolves.toBe("sent");
+    expect(sent).toHaveLength(2);
+    const mentioned = new Set(
+      sent.flatMap((options) => options.allowedMentions?.users ?? []),
+    );
+    expect(mentioned).toEqual(new Set(discordIds));
+    expect(sent.every((options) => options.enforceNonce === true)).toBe(true);
+    expect(new Set(sent.map((options) => options.nonce)).size).toBe(2);
+    await expect(
+      deliverWeeklyParlayDiscord(delivery, db, sender),
+    ).resolves.toBe("already_sent");
+    expect(sent).toHaveLength(2);
+  });
+
+  test("does not resurrect a market voided while its open message sends", async () => {
+    const market = await makeMarket({ marketState: "publishing" });
+    const sender: WeeklyParlayDiscordSender = async () => {
+      await db.bucksWeeklyParlayMarket.update({
+        where: { id: market.id },
+        data: {
+          marketState: "voided",
+          voidReason: "infrastructure_failure",
+          settledAt: COMPLETED_AT,
+        },
+      });
+      return { channelId: "160509172704739999", id: "open-message" };
+    };
+    await expect(
+      deliverWeeklyParlayDiscord(
+        {
+          marketId: market.id,
+          actionKey: "open",
+          kind: "open",
+          scheduledAt: COMPLETED_AT,
+        },
+        db,
+        sender,
+      ),
+    ).resolves.toBe("sent");
+    await expect(
+      db.bucksWeeklyParlayMarket.findUniqueOrThrow({
+        where: { id: market.id },
+      }),
+    ).resolves.toMatchObject({
+      marketState: "voided",
+    });
+    await expect(
+      db.bucksWeeklyParlayDelivery.findUniqueOrThrow({
+        where: {
+          marketId_actionKey: { marketId: market.id, actionKey: "open" },
+        },
+      }),
+    ).resolves.toMatchObject({ deliveryState: "delivered" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -24,6 +24,7 @@ import {
 } from "#src/betting/weekly-parlay-contribution.ts";
 import {
   deliverWeeklyParlayDiscord,
+  weeklyParlaySettlementActionKey,
   type WeeklyParlayDiscordSender,
 } from "#src/betting/weekly-parlay-discord.ts";
 import { runWeeklyParlayControlAction } from "#src/betting/weekly-parlay-control.ts";
@@ -743,6 +744,10 @@ describe("weekly parlay ingestion boundaries", () => {
 });
 
 describe("weekly parlay Discord delivery", () => {
+  test("uses one settlement delivery key across settlement origins", () => {
+    expect(weeklyParlaySettlementActionKey(42)).toBe("settlement:42");
+  });
+
   test("chunks and deduplicates private mention delivery with a stable nonce", async () => {
     const market = await makeMarket({ marketState: "open" });
     const discordIds = Array.from({ length: 25 }, (_unused, index) =>

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.test.ts
@@ -26,6 +26,13 @@ describe("weekly parlay candidate selection", () => {
         periodsSinceFeatured: 3,
       },
       {
+        playerId: 4,
+        linkedGuildMember: true,
+        recentEligibleGames: 8,
+        fullyObservedWindows: 20,
+        periodsSinceFeatured: 4,
+      },
+      {
         playerId: 1,
         linkedGuildMember: false,
         recentEligibleGames: 20,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-selection.ts
@@ -22,7 +22,7 @@ export function orderWeeklyParlayCandidates(
         candidate.recentEligibleGames >= WEEKLY_PARLAY_MIN_RECENT_GAMES &&
         candidate.fullyObservedWindows >= WEEKLY_PARLAY_MIN_HISTORY_WINDOWS &&
         (candidate.periodsSinceFeatured === null ||
-          candidate.periodsSinceFeatured >=
+          candidate.periodsSinceFeatured >
             WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS),
     )
     .toSorted((left, right) => {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-settle.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-settle.ts
@@ -1,0 +1,414 @@
+import {
+  BucksParlaySideSchema,
+  BucksWeeklyParlayVoidReasonSchema,
+  type BucksParlaySide,
+  type BucksWeeklyParlayVoidReason,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import { ensureHouseAccountInTransaction } from "#src/betting/house.ts";
+import {
+  applyBucksDelta,
+  BucksStorageOverflowError,
+  refundableBucksHeldForAccounts,
+} from "#src/betting/ledger.ts";
+import {
+  WEEKLY_PARLAY_EVALUATOR_VERSION,
+  WeeklyParlayContributionSnapshotSchema,
+  WeeklyParlayDefinitionCriteriaSchema,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { evaluateWeeklyParlay } from "#src/betting/weekly-parlay-evaluator.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  bettingWeeklyParlayBetSettlementsTotal,
+  bettingWeeklyParlayMarketSettlementsTotal,
+} from "#src/metrics/betting-weekly-parlay.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+import { WEEKLY_PARLAY_INGESTION_GRACE_MS } from "#src/betting/weekly-parlay-period.ts";
+
+export type WeeklyParlaySettlementMode = "early_yes" | "final" | "void";
+
+export type WeeklyParlaySettlementSummary = {
+  marketId: number;
+  serverId: string;
+  periodKey: string;
+  definitionId: number;
+  slot: number;
+  fromState: string;
+  yesResult: boolean | undefined;
+  voidReason: BucksWeeklyParlayVoidReason | undefined;
+  bettors: string[];
+  betOutcomes: ("won" | "lost" | "refunded")[];
+};
+
+type SettlementDecision =
+  | { kind: "result"; yesResult: boolean; legResults: string }
+  | { kind: "void"; reason: BucksWeeklyParlayVoidReason };
+
+type ParsedJson = { success: true; value: unknown } | { success: false };
+
+function parseJson(value: string): ParsedJson {
+  try {
+    return { success: true, value: JSON.parse(value) };
+  } catch {
+    return { success: false };
+  }
+}
+
+function decisionFor(input: {
+  evaluatorVersion: string;
+  criteria: string;
+  snapshots: string[];
+  mode: WeeklyParlaySettlementMode;
+  voidReason?: BucksWeeklyParlayVoidReason | undefined;
+}): SettlementDecision | undefined {
+  if (input.mode === "void") {
+    return {
+      kind: "void",
+      reason: BucksWeeklyParlayVoidReasonSchema.parse(input.voidReason),
+    };
+  }
+  if (input.evaluatorVersion !== WEEKLY_PARLAY_EVALUATOR_VERSION) {
+    return { kind: "void", reason: "unknown_evaluator" };
+  }
+  const parsedCriteria = parseJson(input.criteria);
+  if (!parsedCriteria.success) {
+    return { kind: "void", reason: "invalid_definition" };
+  }
+  const criteria = WeeklyParlayDefinitionCriteriaSchema.safeParse(
+    parsedCriteria.value,
+  );
+  if (!criteria.success) {
+    return { kind: "void", reason: "invalid_definition" };
+  }
+  const parsedSnapshots = input.snapshots.map((snapshot) =>
+    parseJson(snapshot),
+  );
+  if (parsedSnapshots.some((snapshot) => !snapshot.success)) {
+    return { kind: "void", reason: "missing_data" };
+  }
+  const contributions = z
+    .array(WeeklyParlayContributionSnapshotSchema)
+    .safeParse(
+      parsedSnapshots.flatMap((snapshot) =>
+        snapshot.success ? [snapshot.value] : [],
+      ),
+    );
+  if (!contributions.success) {
+    return { kind: "void", reason: "missing_data" };
+  }
+  let evaluation: ReturnType<typeof evaluateWeeklyParlay>;
+  try {
+    evaluation = evaluateWeeklyParlay(criteria.data, contributions.data);
+  } catch {
+    return { kind: "void", reason: "infrastructure_failure" };
+  }
+  if (input.mode === "early_yes" && !evaluation.irreversiblyYes) {
+    return;
+  }
+  return {
+    kind: "result",
+    yesResult: evaluation.yesResult,
+    legResults: JSON.stringify(evaluation.legs),
+  };
+}
+
+function claimableStates(mode: WeeklyParlaySettlementMode): string[] {
+  switch (mode) {
+    case "void":
+      return ["publishing", "open", "active"];
+    case "early_yes":
+      return ["active"];
+    case "final":
+      return ["open", "active"];
+  }
+}
+
+function settlementSummary(
+  market: {
+    id: number;
+    serverId: string;
+    periodKey: string;
+    slot: number;
+    marketState: string;
+    definition: { id: number };
+  },
+  decision: SettlementDecision,
+  bettors: string[],
+  betOutcomes: ("won" | "lost" | "refunded")[],
+): WeeklyParlaySettlementSummary {
+  return {
+    marketId: market.id,
+    serverId: market.serverId,
+    periodKey: market.periodKey,
+    definitionId: market.definition.id,
+    slot: market.slot,
+    fromState: market.marketState,
+    yesResult: decision.kind === "result" ? decision.yesResult : undefined,
+    voidReason: decision.kind === "void" ? decision.reason : undefined,
+    bettors,
+    betOutcomes,
+  };
+}
+
+function observeSettlement(
+  summary: WeeklyParlaySettlementSummary,
+  surface: "postmatch" | "cron",
+): void {
+  const marketResult =
+    summary.voidReason === undefined
+      ? summary.yesResult === true
+        ? "yes"
+        : "no"
+      : "voided";
+  bettingWeeklyParlayMarketSettlementsTotal.inc({ result: marketResult });
+  logBucksTransition({
+    event:
+      summary.voidReason === undefined
+        ? "bucks.weekly_parlay.settled"
+        : "bucks.weekly_parlay.voided",
+    serverId: summary.serverId,
+    marketId: summary.marketId,
+    definitionId: summary.definitionId,
+    periodKey: summary.periodKey,
+    slot: summary.slot,
+    fromState: summary.fromState,
+    toState: summary.voidReason === undefined ? "settled" : "voided",
+    ...(summary.voidReason === undefined ? {} : { reason: summary.voidReason }),
+    surface,
+  });
+  for (const [index, outcome] of summary.betOutcomes.entries()) {
+    bettingWeeklyParlayBetSettlementsTotal.inc({ result: outcome });
+    const actorDiscordId = summary.bettors[index];
+    logBucksTransition({
+      event: "bucks.weekly_parlay_bet.settled",
+      serverId: summary.serverId,
+      marketId: summary.marketId,
+      definitionId: summary.definitionId,
+      periodKey: summary.periodKey,
+      slot: summary.slot,
+      ...(actorDiscordId === undefined ? {} : { actorDiscordId }),
+      reason: outcome,
+      surface,
+    });
+  }
+}
+
+export async function settleWeeklyParlayMarket(
+  input: {
+    marketId: number;
+    mode: WeeklyParlaySettlementMode;
+    voidReason?: BucksWeeklyParlayVoidReason;
+    now?: Date;
+    surface?: "postmatch" | "cron";
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<WeeklyParlaySettlementSummary | undefined> {
+  const now = input.now ?? new Date();
+  // The workflow begins final reconciliation at the scoring cutoff. Keep the
+  // market claimable by post-match ingestion for two worst-case polling
+  // windows so a game that completed just before the cutoff can reach Match-V5.
+  const latestFinalizableScoringEnd = new Date(
+    now.getTime() - WEEKLY_PARLAY_INGESTION_GRACE_MS,
+  );
+  try {
+    const summary = await prismaClient.$transaction(async (tx) => {
+      // FIRST write: lock the same market row contribution ingestion locks. A
+      // finalizer therefore sees every contribution whose append won the row
+      // before it, and no contribution can slip in after the evaluation read.
+      const claim = await tx.bucksWeeklyParlayMarket.updateMany({
+        where: {
+          id: input.marketId,
+          marketState: { in: claimableStates(input.mode) },
+          ...(input.mode === "final"
+            ? { scoringEndsAt: { lte: latestFinalizableScoringEnd } }
+            : {}),
+        },
+        data: { updatedAt: now },
+      });
+      if (claim.count !== 1) {
+        return;
+      }
+
+      const market = await tx.bucksWeeklyParlayMarket.findUniqueOrThrow({
+        where: { id: input.marketId },
+        select: {
+          id: true,
+          serverId: true,
+          periodKey: true,
+          slot: true,
+          marketState: true,
+          definition: {
+            select: {
+              id: true,
+              criteria: true,
+              evaluatorVersion: true,
+              contributions: { select: { snapshot: true } },
+            },
+          },
+        },
+      });
+      const decision: SettlementDecision | undefined =
+        input.mode === "final" && market.marketState === "open"
+          ? { kind: "void", reason: "infrastructure_failure" }
+          : decisionFor({
+              evaluatorVersion: market.definition.evaluatorVersion,
+              criteria: market.definition.criteria,
+              snapshots: market.definition.contributions.map(
+                (contribution) => contribution.snapshot,
+              ),
+              mode: input.mode,
+              voidReason: input.voidReason,
+            });
+      if (decision === undefined) {
+        return;
+      }
+      await tx.bucksWeeklyParlayMarket.update({
+        where: { id: market.id },
+        data:
+          decision.kind === "void"
+            ? {
+                marketState: "voided",
+                voidReason: decision.reason,
+                settledAt: now,
+              }
+            : {
+                marketState: "settled",
+                yesResult: decision.yesResult,
+                legResults: decision.legResults,
+                settledAt: now,
+              },
+      });
+
+      const bets = await tx.bucksWeeklyParlayBet.findMany({
+        where: { marketId: market.id, betOutcome: "pending" },
+        select: {
+          id: true,
+          bucksAccountId: true,
+          side: true,
+          stake: true,
+          houseReserve: true,
+          grossPayout: true,
+          bucksAccount: {
+            select: { discordId: true, serverId: true, isHouse: true },
+          },
+        },
+        orderBy: { id: "asc" },
+      });
+      if (bets.length === 0) {
+        return settlementSummary(market, decision, [], []);
+      }
+      const house = await ensureHouseAccountInTransaction(tx, market.serverId);
+      const held = await refundableBucksHeldForAccounts(tx, [
+        ...bets.map((bet) => ({
+          id: bet.bucksAccountId,
+          serverId: bet.bucksAccount.serverId,
+          isHouse: bet.bucksAccount.isHouse,
+        })),
+        { id: house.id, serverId: market.serverId, isHouse: true },
+      ]);
+      const remainingHeld = new Map(held);
+      const bettorIds: string[] = [];
+      const betOutcomes: ("won" | "lost" | "refunded")[] = [];
+      for (const bet of bets) {
+        const side = BucksParlaySideSchema.parse(bet.side);
+        const userHeld = remainingHeld.get(bet.bucksAccountId);
+        const houseHeld = remainingHeld.get(house.id);
+        if (userHeld === undefined || houseHeld === undefined) {
+          throw new Error("Missing refundable weekly parlay holdings.");
+        }
+        const userHeldAfter = userHeld - BigInt(bet.stake);
+        const houseHeldAfter = houseHeld - BigInt(bet.houseReserve);
+        remainingHeld.set(bet.bucksAccountId, userHeldAfter);
+        remainingHeld.set(house.id, houseHeldAfter);
+        const contextBase = {
+          type: "weekly_parlay_settlement" as const,
+          version: 1 as const,
+          definitionId: market.definition.id,
+          periodKey: market.periodKey,
+          slot: market.slot,
+          side,
+          stake: bet.stake,
+          reserve: bet.houseReserve,
+          grossPayout: bet.grossPayout,
+        };
+        if (decision.kind === "void") {
+          await applyBucksDelta(tx, {
+            bucksAccountId: bet.bucksAccountId,
+            delta: bet.stake,
+            kind: "weekly_parlay_refund",
+            weeklyParlayBetId: bet.id,
+            context: {
+              ...contextBase,
+              credited: bet.stake,
+              voidReason: decision.reason,
+            },
+            knownRefundableHeld: userHeldAfter,
+          });
+          await applyBucksDelta(tx, {
+            bucksAccountId: house.id,
+            delta: bet.houseReserve,
+            kind: "weekly_parlay_release",
+            weeklyParlayBetId: bet.id,
+            context: {
+              ...contextBase,
+              credited: bet.houseReserve,
+              voidReason: decision.reason,
+            },
+            knownRefundableHeld: houseHeldAfter,
+          });
+          await tx.bucksWeeklyParlayBet.update({
+            where: { id: bet.id },
+            data: { betOutcome: "refunded", payout: bet.stake, settledAt: now },
+          });
+          betOutcomes.push("refunded");
+        } else {
+          const winningSide: BucksParlaySide = decision.yesResult
+            ? "YES"
+            : "NO";
+          const won = side === winningSide;
+          await applyBucksDelta(tx, {
+            bucksAccountId: won ? bet.bucksAccountId : house.id,
+            delta: bet.grossPayout,
+            kind: won ? "weekly_parlay_payout" : "weekly_parlay_release",
+            weeklyParlayBetId: bet.id,
+            context: {
+              ...contextBase,
+              yesResult: decision.yesResult,
+              credited: bet.grossPayout,
+            },
+            knownRefundableHeld: won ? userHeldAfter : houseHeldAfter,
+          });
+          await tx.bucksWeeklyParlayBet.update({
+            where: { id: bet.id },
+            data: {
+              betOutcome: won ? "won" : "lost",
+              payout: won ? bet.grossPayout : 0,
+              settledAt: now,
+            },
+          });
+          betOutcomes.push(won ? "won" : "lost");
+        }
+        bettorIds.push(bet.bucksAccount.discordId);
+      }
+      return settlementSummary(market, decision, bettorIds, betOutcomes);
+    });
+    if (summary !== undefined) {
+      observeSettlement(summary, input.surface ?? "cron");
+    }
+    return summary;
+  } catch (error) {
+    if (error instanceof BucksStorageOverflowError && input.mode !== "void") {
+      return await settleWeeklyParlayMarket(
+        {
+          marketId: input.marketId,
+          mode: "void",
+          voidReason: "storage_overflow",
+          now,
+          ...(input.surface === undefined ? {} : { surface: input.surface }),
+        },
+        prismaClient,
+      );
+    }
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/configuration.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration.ts
@@ -196,6 +196,9 @@ function computeConfiguration() {
       "BETTING_PARLAY_AI_MODEL",
       "gpt-5.6-sol",
     ),
+    // Bootstrap credential for Temporal's private weekly-parlay control
+    // endpoint. When absent, the route is not registered at all.
+    weeklyParlayControlToken: getOptionalEnvVar("WEEKLY_PARLAY_CONTROL_TOKEN"),
     exploreModel: env.get("EXPLORE_MODEL").default("gpt-5.6-luna").asString(),
     bucksAskModel: env.get("BB_ASK_MODEL").default("gpt-5.6-luna").asString(),
     // Beta Explore access is an explicit Discord server allowlist. Production
@@ -330,6 +333,9 @@ const configuration: Configuration = {
   },
   get bettingParlayAiModel() {
     return getConfiguration().bettingParlayAiModel;
+  },
+  get weeklyParlayControlToken() {
+    return getConfiguration().weeklyParlayControlToken;
   },
   get exploreModel() {
     return getConfiguration().exploreModel;

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -143,6 +143,7 @@ export type FlagName =
   | "ai_reports_unlimited"
   | "ai_reviews_enabled"
   | "betting_enabled"
+  | "weekly_parlays_enabled"
   | "betting_player_bet_outcome_dm_enabled"
   | "betting_settlement_dm_enabled"
   | "debug"
@@ -164,6 +165,7 @@ const PRODUCTION_HARD_DISABLED_FLAGS: ReadonlySet<FlagName> = new Set<FlagName>(
     "ai_reports_unlimited",
     "ai_reviews_enabled",
     "betting_enabled",
+    "weekly_parlays_enabled",
     "betting_player_bet_outcome_dm_enabled",
     "betting_settlement_dm_enabled",
     "tournament_lobbies_enabled",
@@ -229,6 +231,13 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
         attributes: { server: MY_SERVER },
       },
     ],
+  },
+  // Week-spanning Bryan Bucks markets remain a narrower private-beta rollout
+  // than the betting economy itself. New positions require both flags;
+  // settlement and refunds deliberately do not.
+  weekly_parlays_enabled: {
+    default: false,
+    overrides: [{ value: true, attributes: { server: MY_SERVER } }],
   },
   // Settlement messages are a separate rollout from the betting economy: the
   // economy must keep paying or refunding open positions even while Discord

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -14,6 +14,19 @@ import {
   MINIMUM_PRICE,
   PEEK_PASS_DURATION_MS,
 } from "#src/betting/peek-pass.ts";
+import {
+  WEEKLY_PARLAY_ELIGIBLE_QUEUES,
+  WEEKLY_PARLAY_MAX_LEGS,
+  WEEKLY_PARLAY_MIN_LEGS,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
+  WEEKLY_PARLAY_FINAL_HOUR,
+  WEEKLY_PARLAY_INGESTION_GRACE_MINUTES,
+  WEEKLY_PARLAY_OPEN_HOUR,
+  WEEKLY_PARLAY_TIMEZONE,
+  weeklyParlayWallClockLabel,
+} from "#src/betting/weekly-parlay-period.ts";
 
 const BUCKS_COLOR = 0x2e_cc_71;
 
@@ -82,6 +95,15 @@ export function buildBbRulesEmbed(): EmbedBuilder {
           "Odds are fixed and quoted when you bet, and the house reserves the full payout at that price. " +
           "It is a live in-play market published after the game starts, so early events may already be visible. " +
           "Cancelling a parlay is free and returns the whole stake.",
+      },
+      {
+        name: "Weekly parlays",
+        value:
+          `A ${WEEKLY_PARLAY_MIN_LEGS.toString()}-${WEEKLY_PARLAY_MAX_LEGS.toString()} leg YES/NO market across one or more tracked players. ` +
+          `It opens Sunday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_OPEN_HOUR)} and betting closes Monday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_BETTING_CLOSE_HOUR)} in ${WEEKLY_PARLAY_TIMEZONE}. ` +
+          `Only completed ${WEEKLY_PARLAY_ELIGIBLE_QUEUES.join(", ")} games count, through Sunday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_FINAL_HOUR)}. ` +
+          `Scout waits **${WEEKLY_PARLAY_INGESTION_GRACE_MINUTES.toString()} minutes** after that cutoff for completed games to ingest. ` +
+          "Scout may settle YES early only after every leg is impossible to undo; NO always waits for final settlement. Cancelling before Monday is free.",
       },
       {
         name: "Voids",

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -31,6 +31,7 @@ import { placeParlayBet } from "#src/betting/parlay-place-bet.ts";
 import { WeeklyParlaySubjectsSchema } from "#src/betting/weekly-parlay-criteria.ts";
 import { placeWeeklyParlayBet } from "#src/betting/weekly-parlay-bet.ts";
 import { describeWeeklyParlayBet } from "#src/betting/weekly-parlay-bet-button.ts";
+import { refreshWeeklyParlayMessage } from "#src/betting/weekly-parlay-refresh.ts";
 import { selectParlayMarketForAlias } from "#src/betting/parlay-market-selection.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
@@ -316,6 +317,9 @@ async function replyParlay(
       surface: "command",
     });
     await interaction.editReply({ content: describeWeeklyParlayBet(result) });
+    if (result.kind === "placed") {
+      await refreshWeeklyParlayMessage(weekly.id);
+    }
     return;
   }
   if (selection.kind === "not_found") {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -28,6 +28,9 @@ import { refreshParlayMessages } from "#src/betting/parlay-refresh.ts";
 import { ParlaySubjectsSchema } from "#src/betting/parlay-criteria.ts";
 import { describeParlayResult } from "#src/betting/parlay-bet-button.ts";
 import { placeParlayBet } from "#src/betting/parlay-place-bet.ts";
+import { WeeklyParlaySubjectsSchema } from "#src/betting/weekly-parlay-criteria.ts";
+import { placeWeeklyParlayBet } from "#src/betting/weekly-parlay-bet.ts";
+import { describeWeeklyParlayBet } from "#src/betting/weekly-parlay-bet-button.ts";
 import { selectParlayMarketForAlias } from "#src/betting/parlay-market-selection.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
@@ -201,8 +204,29 @@ async function replyOpen(
     },
     orderBy: { closesAt: "asc" },
   });
+  const weeklyParlays = await prisma.bucksWeeklyParlayMarket.findMany({
+    where: {
+      serverId,
+      marketState: "open",
+      bettingClosesAt: { gt: new Date() },
+    },
+    select: {
+      id: true,
+      bettingClosesAt: true,
+      definition: { select: { subjects: true } },
+      bets: {
+        where: { betOutcome: "pending" },
+        select: { stake: true },
+      },
+    },
+    orderBy: { bettingClosesAt: "asc" },
+  });
 
-  if (pools.length === 0 && parlays.length === 0) {
+  if (
+    pools.length === 0 &&
+    parlays.length === 0 &&
+    weeklyParlays.length === 0
+  ) {
     await interaction.editReply({
       content: "Nothing open right now.",
     });
@@ -217,6 +241,19 @@ async function replyOpen(
     const closesAtUnix = Math.floor(parlay.closesAt.getTime() / 1000);
     sections.push(
       `**Parlay · ${aliases.join(", ")}** · closes <t:${closesAtUnix.toString()}:R> — \`/bb parlay player:${aliases[0] ?? ""}\``,
+    );
+  }
+  for (const parlay of weeklyParlays) {
+    const aliases = WeeklyParlaySubjectsSchema.parse(
+      JSON.parse(parlay.definition.subjects),
+    ).map((subject) => subject.alias);
+    const closesAtUnix = Math.floor(parlay.bettingClosesAt.getTime() / 1000);
+    const totalStaked = parlay.bets.reduce(
+      (total, bet) => total + bet.stake,
+      0,
+    );
+    sections.push(
+      `**Weekly parlay · ${aliases.join(", ")}** · ${parlay.bets.length.toString()} bettors · ${totalStaked.toString()} BB · closes <t:${closesAtUnix.toString()}:R> — use its message buttons`,
     );
   }
   await editReplyInChunks(
@@ -240,13 +277,45 @@ async function replyParlay(
       definition: { select: { subjects: true } },
     },
   });
+  const weeklyMarkets = await prisma.bucksWeeklyParlayMarket.findMany({
+    where: {
+      serverId,
+      marketState: "open",
+      bettingClosesAt: { gt: new Date() },
+    },
+    select: { id: true, definition: { select: { subjects: true } } },
+  });
+  const normalizedAlias = requestedAlias.trim().toLocaleLowerCase();
+  const matchingWeekly = weeklyMarkets.filter((market) =>
+    WeeklyParlaySubjectsSchema.parse(
+      JSON.parse(market.definition.subjects),
+    ).some((subject) => subject.alias.toLocaleLowerCase() === normalizedAlias),
+  );
   const selection = selectParlayMarketForAlias(markets, requestedAlias);
-  if (selection.kind === "ambiguous") {
+  if (
+    selection.kind === "ambiguous" ||
+    matchingWeekly.length > 1 ||
+    (selection.kind === "selected" && matchingWeekly.length > 0)
+  ) {
     await interaction.editReply({
       content:
-        `Multiple open parlays include **${requestedAlias}** (matches: ${selection.matchIds.map((matchId) => `\`${matchId}\``).join(", ")}). ` +
-        "Use the buttons on the desired parlay message.",
+        `Multiple open parlays include **${requestedAlias}**. ` +
+        "Use the buttons on the desired message so Scout can identify the market.",
     });
+    return;
+  }
+  const weekly = matchingWeekly[0];
+  if (weekly !== undefined && selection.kind === "not_found") {
+    const parsedSide = side === "YES" ? "YES" : "NO";
+    const result = await placeWeeklyParlayBet({
+      marketId: weekly.id,
+      serverId,
+      discordId,
+      side: parsedSide,
+      stake,
+      surface: "command",
+    });
+    await interaction.editReply({ content: describeWeeklyParlayBet(result) });
     return;
   }
   if (selection.kind === "not_found") {

--- a/packages/scout-for-lol/packages/backend/src/discord/interactions.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/interactions.ts
@@ -31,6 +31,11 @@ import {
 } from "#src/betting/parlay-custom-id.ts";
 import { handleParlayBetButton } from "#src/betting/parlay-bet-button.ts";
 import {
+  isWeeklyParlayCustomId,
+  parseWeeklyParlayCustomId,
+} from "#src/betting/weekly-parlay-custom-id.ts";
+import { handleWeeklyParlayBetButton } from "#src/betting/weekly-parlay-bet-button.ts";
+import {
   handlePeekPassButton,
   type PeekPassButtonInteraction,
 } from "#src/betting/peek-pass-button.ts";
@@ -122,6 +127,28 @@ export type RoutableButtonInteraction = BetButtonInteraction &
     replied: boolean;
   };
 
+async function routeWeeklyParlayButton(
+  interaction: RoutableButtonInteraction,
+): Promise<void> {
+  try {
+    if (parseWeeklyParlayCustomId(interaction.customId) === undefined) {
+      discordComponentsTotal.inc({ namespace: "bbw", status: "malformed" });
+      await interaction.deferUpdate();
+      return;
+    }
+    await handleWeeklyParlayBetButton(interaction);
+    discordComponentsTotal.inc({ namespace: "bbw", status: "success" });
+  } catch (error) {
+    logger.error("❌ Error handling a weekly Bryan Bucks button:", error);
+    discordComponentsTotal.inc({ namespace: "bbw", status: "error" });
+    if (interaction.deferred && !interaction.replied) {
+      await interaction.editReply({
+        content: "😵 Weekly bet failed. Try again shortly.",
+      });
+    }
+  }
+}
+
 export async function routeButton(
   interaction: RoutableButtonInteraction,
 ): Promise<void> {
@@ -153,6 +180,10 @@ export async function routeButton(
         });
       }
     }
+    return;
+  }
+  if (isWeeklyParlayCustomId(interaction.customId)) {
+    await routeWeeklyParlayButton(interaction);
     return;
   }
   if (isBucksNavigationId(interaction.customId)) {

--- a/packages/scout-for-lol/packages/backend/src/http-server.ts
+++ b/packages/scout-for-lol/packages/backend/src/http-server.ts
@@ -23,6 +23,7 @@ import {
   statusClass,
 } from "#src/http/route-label.ts";
 import { httpRequestDuration, httpRequestsTotal } from "#src/metrics/web.ts";
+import { handleWeeklyParlayControl } from "#src/http/weekly-parlay-control.ts";
 
 const logger = createLogger("http-server");
 
@@ -297,6 +298,13 @@ async function dispatch(request: Request, url: URL): Promise<Response> {
   // resolution) to justify promoting this to an accelerator later.
   if (url.pathname === "/api/riot/tournament-callback") {
     return handleTournamentCallback(request);
+  }
+
+  // Temporal-only weekly Bryan Bucks control surface. The handler is absent
+  // (returns null) unless its bootstrap credential is configured.
+  const weeklyParlayResponse = await handleWeeklyParlayControl(request, url);
+  if (weeklyParlayResponse !== null) {
+    return weeklyParlayResponse;
   }
 
   // Metrics endpoint for Prometheus

--- a/packages/scout-for-lol/packages/backend/src/http/route-label.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/route-label.test.ts
@@ -27,6 +27,7 @@ describe("classifyRoute", () => {
     "/api/dev/login",
     "/api/summoner-icon",
     "/api/reports/query-agent/stream",
+    "/api/internal/weekly-parlays/actions",
   ])("maps the known route %s to itself", (path) => {
     expect(classifyRoute(path)).toBe(path);
   });

--- a/packages/scout-for-lol/packages/backend/src/http/route-label.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/route-label.ts
@@ -26,6 +26,7 @@ const EXACT_ROUTES = new Set<string>([
   "/api/dev/login",
   "/api/summoner-icon",
   "/api/reports/query-agent/stream",
+  "/api/internal/weekly-parlays/actions",
 ]);
 
 /** Paths with dynamic segments, mapped to a templated label. */

--- a/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { WeeklyParlayControlActionSchema } from "#src/betting/weekly-parlay-control.ts";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+import { handleWeeklyParlayControl } from "#src/http/weekly-parlay-control.ts";
+
+const PATH = "http://localhost/api/internal/weekly-parlays/actions";
+const initialToken = Bun.env["WEEKLY_PARLAY_CONTROL_TOKEN"];
+
+function restoreToken(): void {
+  if (initialToken === undefined) {
+    delete Bun.env["WEEKLY_PARLAY_CONTROL_TOKEN"];
+  } else {
+    Bun.env["WEEKLY_PARLAY_CONTROL_TOKEN"] = initialToken;
+  }
+  resetConfigurationForTests();
+}
+
+afterEach(restoreToken);
+
+describe("weekly parlay control action schema", () => {
+  test("requires an index only for progress actions", () => {
+    expect(
+      WeeklyParlayControlActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        action: "progress",
+      }).success,
+    ).toBe(false);
+    expect(
+      WeeklyParlayControlActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        action: "open",
+        updateIndex: 0,
+      }).success,
+    ).toBe(false);
+    expect(
+      WeeklyParlayControlActionSchema.parse({
+        periodKey: "2026-08-24",
+        action: "progress",
+        updateIndex: 5,
+      }),
+    ).toMatchObject({ slot: 0, updateIndex: 5 });
+  });
+});
+
+describe("weekly parlay control HTTP boundary", () => {
+  test("is absent when its credential is not configured", async () => {
+    delete Bun.env["WEEKLY_PARLAY_CONTROL_TOKEN"];
+    resetConfigurationForTests();
+    await expect(
+      handleWeeklyParlayControl(
+        new Request(PATH, { method: "POST" }),
+        new URL(PATH),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  test("rejects unauthorized requests before parsing actions", async () => {
+    Bun.env["WEEKLY_PARLAY_CONTROL_TOKEN"] = "test-control-secret";
+    resetConfigurationForTests();
+    const response = await handleWeeklyParlayControl(
+      new Request(PATH, {
+        method: "POST",
+        headers: { Authorization: "Bearer wrong-secret" },
+      }),
+      new URL(PATH),
+    );
+    expect(response?.status).toBe(401);
+  });
+
+  test("accepts the bearer boundary and rejects malformed actions", async () => {
+    Bun.env["WEEKLY_PARLAY_CONTROL_TOKEN"] = "test-control-secret";
+    resetConfigurationForTests();
+    const response = await handleWeeklyParlayControl(
+      new Request(PATH, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-control-secret",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ periodKey: "not-a-date", action: "open" }),
+      }),
+      new URL(PATH),
+    );
+    expect(response?.status).toBe(400);
+    await expect(response?.json()).resolves.toEqual({
+      error: "invalid_action",
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.ts
@@ -1,0 +1,47 @@
+import { timingSafeEqual } from "node:crypto";
+import configuration from "#src/configuration.ts";
+import {
+  runWeeklyParlayControlAction,
+  WEEKLY_PARLAY_CONTROL_PATH,
+  WeeklyParlayControlActionSchema,
+} from "#src/betting/weekly-parlay-control.ts";
+import { MY_SERVER } from "#src/configuration/flags.ts";
+
+function authorized(request: Request, expected: string): boolean {
+  const header = request.headers.get("Authorization");
+  if (header?.startsWith("Bearer ") !== true) {
+    return false;
+  }
+  const presentedBytes = Buffer.from(header.slice("Bearer ".length));
+  const expectedBytes = Buffer.from(expected);
+  return (
+    presentedBytes.length === expectedBytes.length &&
+    timingSafeEqual(presentedBytes, expectedBytes)
+  );
+}
+
+export async function handleWeeklyParlayControl(
+  request: Request,
+  url: URL,
+): Promise<Response | null> {
+  const token = configuration.weeklyParlayControlToken;
+  if (token === undefined || url.pathname !== WEEKLY_PARLAY_CONTROL_PATH) {
+    return null;
+  }
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  if (!authorized(request, token)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const body = WeeklyParlayControlActionSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!body.success) {
+    return Response.json({ error: "invalid_action" }, { status: 400 });
+  }
+  const result = await runWeeklyParlayControlAction(body.data, {
+    serverId: MY_SERVER,
+  });
+  return Response.json(result, { status: 200 });
+}

--- a/packages/scout-for-lol/packages/backend/src/metrics/betting-sweep.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/betting-sweep.ts
@@ -25,26 +25,40 @@ export async function updateBettingMetrics(
     const databaseModule = await import("#src/database/index.ts");
     const prisma = prismaClient ?? databaseModule.prisma;
 
-    const [byState, oldestUnresolved, pendingStake, houseAccounts] =
-      await Promise.all([
-        prisma.bucksMatchPool.groupBy({
-          by: ["poolState"],
-          _count: { _all: true },
-        }),
-        prisma.bucksMatchPool.findFirst({
-          where: { poolState: { in: ["open", "closed"] } },
-          orderBy: { closesAt: "asc" },
-          select: { closesAt: true },
-        }),
-        prisma.bucksBet.findMany({
-          where: { betOutcome: "pending" },
-          select: { stake: true, matchedStake: true },
-        }),
-        prisma.bucksAccount.findMany({
-          where: { isHouse: true },
-          select: { balance: true },
-        }),
-      ]);
+    const [
+      byState,
+      oldestUnresolved,
+      pendingStake,
+      pendingParlayStake,
+      pendingWeeklyStake,
+      houseAccounts,
+    ] = await Promise.all([
+      prisma.bucksMatchPool.groupBy({
+        by: ["poolState"],
+        _count: { _all: true },
+      }),
+      prisma.bucksMatchPool.findFirst({
+        where: { poolState: { in: ["open", "closed"] } },
+        orderBy: { closesAt: "asc" },
+        select: { closesAt: true },
+      }),
+      prisma.bucksBet.findMany({
+        where: { betOutcome: "pending" },
+        select: { stake: true, matchedStake: true },
+      }),
+      prisma.bucksParlayBet.aggregate({
+        where: { betOutcome: "pending" },
+        _sum: { stake: true },
+      }),
+      prisma.bucksWeeklyParlayBet.aggregate({
+        where: { betOutcome: "pending" },
+        _sum: { stake: true },
+      }),
+      prisma.bucksAccount.findMany({
+        where: { isHouse: true },
+        select: { balance: true },
+      }),
+    ]);
 
     const counts = new Map(
       byState.map((row) => [row.poolState, row._count._all]),
@@ -68,7 +82,9 @@ export async function updateBettingMetrics(
       pendingStake.reduce(
         (total, bet) => total + (bet.matchedStake ?? bet.stake),
         0,
-      ),
+      ) +
+        (pendingParlayStake._sum.stake ?? 0) +
+        (pendingWeeklyStake._sum.stake ?? 0),
     );
 
     bettingHouseBalanceBucks.set(

--- a/packages/scout-for-lol/packages/backend/src/metrics/betting-weekly-parlay.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/betting-weekly-parlay.ts
@@ -1,0 +1,69 @@
+import { Counter, Histogram } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+export const bettingWeeklyParlayGenerationTotal = new Counter({
+  name: "betting_weekly_parlay_generation_total",
+  help: "Weekly Bryan Bucks generation attempts by terminal result.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayGenerationDurationSeconds = new Histogram({
+  name: "betting_weekly_parlay_generation_duration_seconds",
+  help: "Weekly Bryan Bucks generation duration for published markets.",
+  buckets: [1, 2, 5, 10, 20, 40, 60, 90],
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayMarketsOpenedTotal = new Counter({
+  name: "betting_weekly_parlay_markets_opened_total",
+  help: "Weekly Bryan Bucks markets whose Discord publication became durable.",
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayMarketSettlementsTotal = new Counter({
+  name: "betting_weekly_parlay_market_settlements_total",
+  help: "Weekly Bryan Bucks markets reaching a terminal state.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayBetPlacementsTotal = new Counter({
+  name: "betting_weekly_parlay_bet_placements_total",
+  help: "Successful weekly Bryan Bucks position placements and top-ups.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayBetCancellationsTotal = new Counter({
+  name: "betting_weekly_parlay_bet_cancellations_total",
+  help: "Successful weekly Bryan Bucks position cancellations.",
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayBetSettlementsTotal = new Counter({
+  name: "betting_weekly_parlay_bet_settlements_total",
+  help: "Weekly Bryan Bucks positions reaching a terminal outcome.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayContributionsTotal = new Counter({
+  name: "betting_weekly_parlay_contributions_total",
+  help: "Idempotent eligible match contributions appended to weekly markets.",
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayControlActionsTotal = new Counter({
+  name: "betting_weekly_parlay_control_actions_total",
+  help: "Authenticated Temporal weekly-parlay actions by action and result.",
+  labelNames: ["action", "result"] as const,
+  registers: [registry],
+});
+
+export const bettingWeeklyParlayDeliveriesTotal = new Counter({
+  name: "betting_weekly_parlay_deliveries_total",
+  help: "Weekly Bryan Bucks Discord action deliveries by kind and result.",
+  labelNames: ["kind", "result"] as const,
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -424,6 +424,7 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
   }),
   z.strictObject({
     type: z.literal("weekly_parlay_stake"),
+    version: z.literal(1),
     definitionId: z.number().int().positive(),
     periodKey: z.iso.date(),
     slot: z.number().int().nonnegative(),
@@ -434,6 +435,7 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
   }),
   z.strictObject({
     type: z.literal("weekly_parlay_reserve"),
+    version: z.literal(1),
     definitionId: z.number().int().positive(),
     periodKey: z.iso.date(),
     slot: z.number().int().nonnegative(),
@@ -445,6 +447,7 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
   }),
   z.strictObject({
     type: z.literal("weekly_parlay_settlement"),
+    version: z.literal(1),
     definitionId: z.number().int().positive(),
     periodKey: z.iso.date(),
     slot: z.number().int().nonnegative(),


### PR DESCRIPTION
## Why

The weekly parlay domain needs a runtime that can ingest eligible matches, preserve Bryan Bucks liabilities, update Discord privately, and settle independently of rollout-flag revocation.

## What

- generate frozen, defensibly priced weekly markets from the closed deterministic domain
- append idempotent multi-account/multi-subject contributions by game completion time, including delayed Monday activation and post-cutoff ingestion
- wait two worst-case Match-V5 polling intervals, then serialize final settlement against the last contribution
- implement guarded fixed-odds bets, top-ups, free cancellation, reserves, early-YES-only settlement, final settlement, and void/refund handling
- add weekly Discord buttons and `/bb` surfaces, nonce-enforced deliveries, aggregate positions, deduplicated mentions, authenticated control routing, flags, metrics, and prompt coverage

## Verification

- `bun run typecheck`
- `bun run lint` — no errors; existing warnings remain
- `bun run test` — 248 files and 2,197 tests passed
- `bunx lefthook run pre-commit`
- integration tests cover delayed start, exact cutoff, late ingestion, exact-grace settlement, early YES, final NO, refunds, concurrent bets, reserves, and ledger reconciliation

## Rollout

Stack layer 2 of 3. The feature remains default-off and private-beta-only. Temporal, deployment wiring, documentation, and demo evidence land in layer 3.