### PR TITLE
feat(scout-for-lol): enforce the client packages composition direction

### DIFF
--- a/packages/scout-for-lol/packages/app/architecture-fixtures/components-imports-routes.ts
+++ b/packages/scout-for-lol/packages/app/architecture-fixtures/components-imports-routes.ts
@@ -1,0 +1,4 @@
+// Deliberate violation of components-do-not-depend-on-routes.
+import "#src/routes/competition-list.tsx";
+
+export const illegalComponentsDependency = true;

--- a/packages/scout-for-lol/packages/app/architecture-fixtures/hooks-imports-components.ts
+++ b/packages/scout-for-lol/packages/app/architecture-fixtures/hooks-imports-components.ts
@@ -1,0 +1,7 @@
+// Deliberate violation of hooks-do-not-depend-on-routes-or-components.
+// The sibling `hooks-imports-routes.ts` proves the `routes` half of the same
+// rule; this proves the `components` half, which the rule only gained once
+// `ExploreRunsContextValue` moved down to `lib/`.
+import "#src/components/explore-runs-context.ts";
+
+export const illegalHooksComponentDependency = true;

--- a/packages/scout-for-lol/packages/app/architecture-fixtures/hooks-imports-routes.ts
+++ b/packages/scout-for-lol/packages/app/architecture-fixtures/hooks-imports-routes.ts
@@ -1,0 +1,4 @@
+// Deliberate violation of hooks-do-not-depend-on-routes.
+import "#src/routes/competition-list.tsx";
+
+export const illegalHooksDependency = true;

--- a/packages/scout-for-lol/packages/app/architecture-fixtures/hooks-imports-routes.ts
+++ b/packages/scout-for-lol/packages/app/architecture-fixtures/hooks-imports-routes.ts
@@ -1,4 +1,4 @@
-// Deliberate violation of hooks-do-not-depend-on-routes.
+// Deliberate violation of hooks-do-not-depend-on-routes-or-components.
 import "#src/routes/competition-list.tsx";
 
 export const illegalHooksDependency = true;

--- a/packages/scout-for-lol/packages/app/architecture-fixtures/lib-imports-routes.ts
+++ b/packages/scout-for-lol/packages/app/architecture-fixtures/lib-imports-routes.ts
@@ -1,0 +1,4 @@
+// Deliberate violation of lib-does-not-depend-on-routes-or-hooks.
+import "#src/routes/competition-list.tsx";
+
+export const illegalLibDependency = true;

--- a/packages/scout-for-lol/packages/app/architecture.config.ts
+++ b/packages/scout-for-lol/packages/app/architecture.config.ts
@@ -1,0 +1,55 @@
+import { defineArchitecture } from "@shepherdjerred/architecture";
+
+/**
+ * The web app is a browser SPA with one clear direction: a route composes
+ * components, components call hooks, and everything rests on `lib/`.
+ *
+ * `routes/` is the top of that tree. Nothing below it may import a route,
+ * because a module that does can only ever be used on that one page — and it
+ * drags that page's whole component tree into any bundle that touches it.
+ *
+ * `lib/ -> components/` is deliberately *not* forbidden yet. Two form-state
+ * modules read default values and field types declared alongside the form
+ * components that render them. That is the same misplacement pattern this
+ * harness usually catches, but unpicking it means moving form contracts out of
+ * four component files, so it is left for its own change rather than smuggled
+ * in behind a rule.
+ *
+ * The client/server boundary is **not** expressible here. The app names the
+ * backend's `AppRouter` type — three `import type` statements in `lib/trpc.ts`
+ * and `lib/trpc-options.ts` — and must never import backend runtime, but each
+ * cruise is scoped to its own source root on purpose (a package must not be
+ * failed by a dependency's internals), so a cross-package edge is invisible to
+ * this check. The boundary holds today; enforcing it needs a different
+ * mechanism than `check-architecture`.
+ */
+export default defineArchitecture({
+  boundaries: [
+    {
+      name: "lib-does-not-depend-on-routes-or-hooks",
+      comment:
+        "`lib/` is the bottom of the app: the tRPC client, query options, formatting and route " +
+        "loaders. It is called by hooks and routes, never the other way round, which is what " +
+        "keeps it usable from a loader that runs before any component mounts.",
+      from: "lib",
+      to: ["routes", "hooks"],
+    },
+    {
+      name: "hooks-do-not-depend-on-routes",
+      comment:
+        "A hook that imports a route is bound to that page and cannot be reused from another. " +
+        "Take what it needs as an argument, or move the shared piece into `lib/`.",
+      from: "hooks",
+      to: ["routes"],
+    },
+    {
+      name: "components-do-not-depend-on-routes",
+      comment:
+        "A component that imports a route can only be rendered inside it, and pulls that " +
+        "route's entire tree into every bundle that includes the component. Routes compose " +
+        "components; the dependency runs one way.",
+      from: "components",
+      to: ["routes"],
+    },
+  ],
+});

--- a/packages/scout-for-lol/packages/app/architecture.config.ts
+++ b/packages/scout-for-lol/packages/app/architecture.config.ts
@@ -4,7 +4,8 @@ import { defineArchitecture } from "@shepherdjerred/architecture";
  * The web app is a browser SPA with one clear direction: a route composes
  * components, components call hooks, and everything rests on `lib/`.
  *
- * `routes/` is the top of that tree. Nothing below it may import a route,
+ * `routes/` is the top of that tree, and `hooks/` sits below `components/`.
+ * Nothing below a layer may import it: no route may be imported from beneath,
  * because a module that does can only ever be used on that one page — and it
  * drags that page's whole component tree into any bundle that touches it.
  *
@@ -35,12 +36,14 @@ export default defineArchitecture({
       to: ["routes", "hooks"],
     },
     {
-      name: "hooks-do-not-depend-on-routes",
+      name: "hooks-do-not-depend-on-routes-or-components",
       comment:
-        "A hook that imports a route is bound to that page and cannot be reused from another. " +
-        "Take what it needs as an argument, or move the shared piece into `lib/`.",
+        "Components call hooks, so a hook that imports a component inverts the composition order " +
+        "and binds the hook to one rendering of the thing it manages; importing a route binds it " +
+        "to a single page. Take what it needs as an argument, or move the shared contract into " +
+        "`lib/` — which is where `ExploreRunsContextValue` went so this rule could be declared.",
       from: "hooks",
-      to: ["routes"],
+      to: ["routes", "components"],
     },
     {
       name: "components-do-not-depend-on-routes",

--- a/packages/scout-for-lol/packages/app/package.json
+++ b/packages/scout-for-lol/packages/app/package.json
@@ -13,6 +13,7 @@
     "test:report": "CI_TEST_COVERAGE=1 bun ../../../../scripts/run-ci-test.ts"
   },
   "imports": {
+    "#architecture": "./architecture.config.ts",
     "#src/*": "./src/*"
   },
   "dependencies": {

--- a/packages/scout-for-lol/packages/app/src/architecture-boundaries.test.ts
+++ b/packages/scout-for-lol/packages/app/src/architecture-boundaries.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  cruiseArchitectureFixtures,
+  expectedFixtureRuleNames,
+} from "@shepherdjerred/architecture";
+import architecture from "#architecture";
+
+const packageRoot = import.meta.dir.replace(/\/src$/u, "");
+
+describe("dependency-cruiser layer boundaries", () => {
+  it("rejects a committed negative fixture for every declared boundary", async () => {
+    const result = await cruiseArchitectureFixtures({
+      packageRoot,
+      definition: architecture,
+    });
+
+    expect(result.violatedRuleNames).toEqual(
+      expectedFixtureRuleNames(architecture),
+    );
+    expect(result.errorCount).toBe(result.fixtureFiles.length);
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/architecture-boundaries.test.ts
+++ b/packages/scout-for-lol/packages/app/src/architecture-boundaries.test.ts
@@ -1,22 +1,10 @@
-import { describe, expect, it } from "vitest";
-import {
-  cruiseArchitectureFixtures,
-  expectedFixtureRuleNames,
-} from "@shepherdjerred/architecture";
+import { assertArchitectureFixtures } from "@shepherdjerred/architecture";
+import { test } from "vitest";
 import architecture from "#architecture";
 
-const packageRoot = import.meta.dir.replace(/\/src$/u, "");
-
-describe("dependency-cruiser layer boundaries", () => {
-  it("rejects a committed negative fixture for every declared boundary", async () => {
-    const result = await cruiseArchitectureFixtures({
-      packageRoot,
-      definition: architecture,
-    });
-
-    expect(result.violatedRuleNames).toEqual(
-      expectedFixtureRuleNames(architecture),
-    );
-    expect(result.errorCount).toBe(result.fixtureFiles.length);
+test("architecture fixtures prove every app boundary", async () => {
+  await assertArchitectureFixtures({
+    packageRoot: import.meta.dir.replace(/\/src$/u, ""),
+    definition: architecture,
   });
 });

--- a/packages/scout-for-lol/packages/app/src/components/explore-runs-context.ts
+++ b/packages/scout-for-lol/packages/app/src/components/explore-runs-context.ts
@@ -1,32 +1,5 @@
 import { createContext, useContext } from "react";
-import type {
-  ExploreActiveRun,
-  ExploreAttachPoint,
-  ExploreMessage,
-} from "@scout-for-lol/data";
-import type { ExplorePendingTurn } from "#src/lib/explore-turn-state.ts";
-
-export type StartExploreTurnInput = {
-  conversationId: string | null;
-  question: string | null;
-  attach: ExploreAttachPoint;
-  displayQuestion: string | null;
-  leafIdAtStart: string | null;
-};
-
-export type ExploreRunsContextValue = {
-  discoverySettled: boolean;
-  pendingTurn: (conversationId: string | null) => ExplorePendingTurn | null;
-  error: (conversationId: string | null) => string | null;
-  clearError: (conversationId: string | null) => void;
-  acknowledgeVisibleAnswer: (
-    conversationId: string,
-    messages: ExploreMessage[],
-  ) => void;
-  startTurn: (input: StartExploreTurnInput) => Promise<ExploreActiveRun | null>;
-  stop: (conversationId: string | null) => void;
-  status: (conversationId: string) => "running" | "completed" | "failed" | null;
-};
+import type { ExploreRunsContextValue } from "#src/lib/explore-runs-contract.ts";
 
 export const ExploreRunsContext = createContext<ExploreRunsContextValue | null>(
   null,

--- a/packages/scout-for-lol/packages/app/src/components/explore-runs-provider.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-runs-provider.tsx
@@ -44,11 +44,11 @@ import { useExploreRunObserver } from "#src/hooks/use-explore-run-observer.ts";
 import { analyticsCaptureEnabled, track } from "#src/lib/analytics.ts";
 import { claimExploreRunFinished } from "#src/lib/explore-run-analytics.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
-import {
-  ExploreRunsContext,
-  type ExploreRunsContextValue,
-  type StartExploreTurnInput,
-} from "#src/components/explore-runs-context.ts";
+import { ExploreRunsContext } from "#src/components/explore-runs-context.ts";
+import type {
+  ExploreRunsContextValue,
+  StartExploreTurnInput,
+} from "#src/lib/explore-runs-contract.ts";
 
 const NEW_CONVERSATION_KEY = "new";
 function conversationKey(conversationId: string | null): string {

--- a/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn-actions.ts
+++ b/packages/scout-for-lol/packages/app/src/hooks/use-explore-turn-actions.ts
@@ -1,7 +1,7 @@
 import { useCallback, type RefObject } from "react";
 import type { NavigateFunction } from "react-router";
 import type { ExploreMessage } from "@scout-for-lol/data";
-import type { ExploreRunsContextValue } from "#src/components/explore-runs-context.ts";
+import type { ExploreRunsContextValue } from "#src/lib/explore-runs-contract.ts";
 import { track } from "#src/lib/analytics.ts";
 import { shouldOpenStartedExploreConversation } from "#src/lib/explore-navigation.ts";
 

--- a/packages/scout-for-lol/packages/app/src/lib/explore-runs-contract.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/explore-runs-contract.ts
@@ -1,0 +1,36 @@
+import type {
+  ExploreActiveRun,
+  ExploreAttachPoint,
+  ExploreMessage,
+} from "@scout-for-lol/data";
+import type { ExplorePendingTurn } from "#src/lib/explore-turn-state.ts";
+
+/**
+ * What a caller supplies to start an explore turn.
+ *
+ * Declared here rather than beside the React context that carries it: the
+ * hooks which act on a turn need the shape, not the context object, and a hook
+ * reaching into `components/` for a type inverts the app's composition order.
+ */
+export type StartExploreTurnInput = {
+  conversationId: string | null;
+  question: string | null;
+  attach: ExploreAttachPoint;
+  displayQuestion: string | null;
+  leafIdAtStart: string | null;
+};
+
+/** The explore-run operations a consumer of the context can perform. */
+export type ExploreRunsContextValue = {
+  discoverySettled: boolean;
+  pendingTurn: (conversationId: string | null) => ExplorePendingTurn | null;
+  error: (conversationId: string | null) => string | null;
+  clearError: (conversationId: string | null) => void;
+  acknowledgeVisibleAnswer: (
+    conversationId: string,
+    messages: ExploreMessage[],
+  ) => void;
+  startTurn: (input: StartExploreTurnInput) => Promise<ExploreActiveRun | null>;
+  stop: (conversationId: string | null) => void;
+  status: (conversationId: string) => "running" | "completed" | "failed" | null;
+};

--- a/packages/scout-for-lol/packages/app/tsconfig.json
+++ b/packages/scout-for-lol/packages/app/tsconfig.json
@@ -7,6 +7,6 @@
     "jsxImportSource": "react",
     "noEmit": true
   },
-  "include": ["src/**/*", "vite.config.ts"],
+  "include": ["architecture.config.ts", "src/**/*", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/scout-for-lol/packages/frontend/architecture-fixtures/data-imports-components.ts
+++ b/packages/scout-for-lol/packages/frontend/architecture-fixtures/data-imports-components.ts
@@ -1,0 +1,4 @@
+// Deliberate violation of data-does-not-depend-on-the-site.
+import "#src/components/shared-navbar.tsx";
+
+export const illegalDataDependency = true;

--- a/packages/scout-for-lol/packages/frontend/architecture-fixtures/lib-imports-components.ts
+++ b/packages/scout-for-lol/packages/frontend/architecture-fixtures/lib-imports-components.ts
@@ -1,0 +1,4 @@
+// Deliberate violation of lib-does-not-depend-on-the-site.
+import "#src/components/shared-navbar.tsx";
+
+export const illegalLibDependency = true;

--- a/packages/scout-for-lol/packages/frontend/architecture.config.ts
+++ b/packages/scout-for-lol/packages/frontend/architecture.config.ts
@@ -1,0 +1,43 @@
+import { defineArchitecture } from "@shepherdjerred/architecture";
+
+/**
+ * The marketing site is Astro: `pages/` and `layouts/` are almost entirely
+ * `.astro`, with React islands under `components/`, shared helpers in `lib/`
+ * and static content in `data/`.
+ *
+ * That shapes what can be enforced here, and it is worth being explicit about
+ * it. dependency-cruiser reads the `.ts`/`.tsx` half of this package — 83
+ * modules — and not the 38 `.astro` files, so these rules constrain the
+ * islands and the helpers beneath them rather than the page tree. They are
+ * still worth having: `lib/` and `data/` are what an island reaches for, and
+ * they are the parts most likely to accrete a UI import.
+ *
+ * As in the web app, the client/server boundary is out of reach. The site
+ * names the backend's `AppRouter` type in `lib/trpc.ts` and must never import
+ * backend runtime, but each cruise is deliberately scoped to its own source
+ * root, so a cross-package edge is invisible here. The boundary holds today;
+ * enforcing it needs a different mechanism.
+ */
+export default defineArchitecture({
+  boundaries: [
+    {
+      name: "lib-does-not-depend-on-the-site",
+      comment:
+        "`lib/` holds colours, marketing copy constants, the OG-image template and the tRPC " +
+        "client — things a page or an island reaches for. Importing a component or a layout " +
+        "back out of it inverts that and makes the helper unusable from an `.astro` file that " +
+        "does not already render the component.",
+      from: "lib",
+      to: ["components", "data", "layouts", "pages"],
+    },
+    {
+      name: "data-does-not-depend-on-the-site",
+      comment:
+        "`data/` is static content — the changelog and the showcase list. It is rendered by " +
+        "components and pages, so depending on one would tie a piece of copy to a particular " +
+        "presentation of it.",
+      from: "data",
+      to: ["components", "layouts", "lib", "pages"],
+    },
+  ],
+});

--- a/packages/scout-for-lol/packages/frontend/package.json
+++ b/packages/scout-for-lol/packages/frontend/package.json
@@ -78,6 +78,7 @@
     "url": "https://github.com/shepherdjerred/monorepo/issues"
   },
   "imports": {
+    "#architecture": "./architecture.config.ts",
     "#src/*": "./src/*"
   }
 }

--- a/packages/scout-for-lol/packages/frontend/src/architecture-boundaries.test.ts
+++ b/packages/scout-for-lol/packages/frontend/src/architecture-boundaries.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  cruiseArchitectureFixtures,
+  expectedFixtureRuleNames,
+} from "@shepherdjerred/architecture";
+import architecture from "#architecture";
+
+const packageRoot = import.meta.dir.replace(/\/src$/u, "");
+
+describe("dependency-cruiser layer boundaries", () => {
+  it("rejects a committed negative fixture for every declared boundary", async () => {
+    const result = await cruiseArchitectureFixtures({
+      packageRoot,
+      definition: architecture,
+    });
+
+    expect(result.violatedRuleNames).toEqual(
+      expectedFixtureRuleNames(architecture),
+    );
+    expect(result.errorCount).toBe(result.fixtureFiles.length);
+  });
+});

--- a/packages/scout-for-lol/packages/frontend/src/architecture-boundaries.test.ts
+++ b/packages/scout-for-lol/packages/frontend/src/architecture-boundaries.test.ts
@@ -1,22 +1,10 @@
-import { describe, expect, it } from "vitest";
-import {
-  cruiseArchitectureFixtures,
-  expectedFixtureRuleNames,
-} from "@shepherdjerred/architecture";
+import { assertArchitectureFixtures } from "@shepherdjerred/architecture";
+import { test } from "vitest";
 import architecture from "#architecture";
 
-const packageRoot = import.meta.dir.replace(/\/src$/u, "");
-
-describe("dependency-cruiser layer boundaries", () => {
-  it("rejects a committed negative fixture for every declared boundary", async () => {
-    const result = await cruiseArchitectureFixtures({
-      packageRoot,
-      definition: architecture,
-    });
-
-    expect(result.violatedRuleNames).toEqual(
-      expectedFixtureRuleNames(architecture),
-    );
-    expect(result.errorCount).toBe(result.fixtureFiles.length);
+test("architecture fixtures prove every frontend boundary", async () => {
+  await assertArchitectureFixtures({
+    packageRoot: import.meta.dir.replace(/\/src$/u, ""),
+    definition: architecture,
   });
 });

--- a/packages/scout-for-lol/packages/frontend/tsconfig.json
+++ b/packages/scout-for-lol/packages/frontend/tsconfig.json
@@ -2,7 +2,12 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"]
   },
-  "exclude": ["dist", "node_modules", "**/node_modules"],
+  "exclude": [
+    "architecture-fixtures",
+    "dist",
+    "node_modules",
+    "**/node_modules"
+  ],
   "extends": ["../../tsconfig.base.json"],
   "files": ["./src/env.d.ts"],
   "include": [".astro/types.d.ts", "**/*", "postcss.config.ts"]


### PR DESCRIPTION
## Why

The Scout web app and marketing site had cycle detection but no enforceable composition direction.

## What

- Add three checked app boundaries and two checked frontend boundaries, each with a committed negative fixture.
- Move the Explore-run consumer contract into `lib/`, so hooks do not depend on React components.
- Reuse the shared fixture assertion so the proof does not duplicate test harness code.
- Document the harness limits: package-crossing client/server imports and Astro files are outside this dependency cruise.

## Verification

- `bunx turbo run typecheck test lint --filter=@scout-for-lol/app --filter=@scout-for-lol/frontend --filter=@shepherdjerred/architecture`
- `bun run jscpd`
- `git diff --check`

No media: this is build-time architecture enforcement with no rendered UI change.