### PR TITLE
feat(scout): make parlay shortlists role-aware and simplify results

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -922,14 +922,31 @@ tracked, linked player in a complete Classic 5v5 receives exactly one
 processed. The grant is idempotent per match and guild, and Classic ARAM
 Mayhem (`"classic aram mayhem"`) receives neither the grant nor any market.
 
-**Generation is two passes, and the model never sets the price.** GPT-5.6 Sol
-first proposes 2–6 leg _shapes_ — subject, field, operator, no numbers. Only
-then does the harness know which distributions to measure, so it fetches one
-history snapshot and hands back, per leg, the player's own distribution plus the
-lane and overall population, sliced by game duration and expressed as "the
-threshold that lands N% of the time" already oriented to that leg's operator. A
-second call fills in thresholds, targeting legs that land 40–70% individually.
-Both calls share one 60-second deadline.
+**Generation is two passes, and the model never sets the price.** Before GPT-5.6
+Sol runs, Scout creates an ordered, match-specific shortlist of exactly 20
+targets: 16 player targets distributed as evenly as possible across the tracked
+subjects, plus four game-wide targets. SHA-256 ranks every choice from a
+versioned match seed, so retries, source ordering, and parallel instances
+produce the same shortlist. A player's eligibility is the union of universal
+stats, their inferred lane pool, and Riot's bundled Data Dragon champion tags.
+The tags are deliberately coarse: a Support-tagged champion may receive a
+healing target even when that champion's current kit makes it questionable.
+Participant objective last-hits, multikills, killing sprees, true damage, and
+player `timePlayed` remain settlement-compatible but are never shortlisted.
+
+The four global targets come from team win, five grounded team-objective counts,
+and game duration. Exactly one of 16 hash buckets admits the opponent-ping
+family; when admitted, one of its 13 subtypes is selected deterministically and
+takes one global slot. The exact 20 candidates are stored in the generation
+context and are the validation boundary: model output outside that shortlist is
+rejected. GPT-5.6 Sol first proposes 2–6 leg _shapes_ — subject, field, operator,
+no numbers — and every tracked subject must appear. Only then does the harness
+know which distributions to measure, so it fetches one history snapshot and
+hands back, per leg, the player's own distribution plus the lane and overall
+population, sliced by game duration and expressed as "the threshold that lands
+N% of the time" already oriented to that leg's operator. A second call fills in
+thresholds, targeting legs that land 40–70% individually. Both calls share one
+60-second deadline.
 
 - **`thresholdsMatchProposal` is the load-bearing guard.** Pass two may change
   numbers and nothing else. A response that re-targets a field, flips an
@@ -948,11 +965,12 @@ Both calls share one 60-second deadline.
   publishing a guess. Which fields the lake can answer is
   `PARLAY_HISTORY_COLUMNS`, exhaustive over the catalog so adding a field is a
   compile error until someone decides whether it is groundable.
-- **Pings are opponent-only.** Every ping type is excluded from subject
-  conditions and available as an enemy-team total. Pings cost nothing to send,
-  and subjects do bet on their own parlays mid-game, so a leg on a subject's own
-  pings is settled by whoever holds the ticket. Nobody in the market can move
-  the enemy team's count.
+- **Pings are opponent-only and rare.** Every ping type is excluded from subject
+  conditions. The one admitted subtype is an enemy-team total in exactly one of
+  16 deterministic match buckets. Pings cost nothing to send, and subjects do
+  bet on their own parlays mid-game, so a leg on a subject's own pings is settled
+  by whoever holds the ticket. Nobody in the market can move the enemy team's
+  count.
 - **`PARLAY_EVALUATOR_VERSION` gates settlement.** `evaluateParlay` voids any
   stored definition whose recorded version differs, which refunds it. Bump it
   only when the meaning of an existing condition changes — never merely because
@@ -1098,7 +1116,7 @@ current UTC timestamp for relative date filters, and uses `BB_ASK_MODEL`
     earlier tick" case; `settleParlaysForMatch` returns nothing for it
     afterwards, so omitting the pass loses the result outright.
   - `fitSections` trims in priority order — earnings, then parlay legs, then
-    parlay positions, then outcome rows — instead of throwing at Discord's
+    parlay result rows, then outcome result rows — instead of throwing at Discord's
     6000-character ceiling, which merging made reachable. The description is
     never trimmed and an over-length description still throws.
     The cost, stated plainly: the parlay result now shares a channel's fate with
@@ -1114,8 +1132,14 @@ current UTC timestamp for relative date filters, and uses `BB_ASK_MODEL`
   matched totals, and any aggregate house fill without exposing the synthetic
   house account. Cancellations disappear from the public digest while remaining
   in the audit tables, and mention notifications are suppressed. `/bb history`
-  remains the transaction-level audit trail, while public outcome copy retains
-  the exact gross-cut-net arithmetic.
+  remains the transaction-level audit trail. The post-game embed deliberately
+  omits sides, matching, house fill, pool totals, and gross-return arithmetic.
+  It separates `BET WINNERS`, `BET LOSERS`, `PARLAY WINNERS`, and
+  `PARLAY LOSERS`; winners show net profit, losers show the actual lost stake,
+  and winner fees appear only when nonzero. Outcome and parlay refunds are
+  aggregate summaries with no refunded-bettor rows. User-visible whole numbers
+  use fixed comma grouping, and parlay duration fields render as `MM:SS` with
+  total minutes allowed above 59.
 - **This applies to the parlay market too, and it is why there are no
   per-placement receipts.** The parlay market message is **recomputed from its
   stored definition** rather than snapshotted: legs, subjects, odds, and close

--- a/packages/scout-for-lol/docs/architecture.md
+++ b/packages/scout-for-lol/docs/architecture.md
@@ -325,13 +325,37 @@ messages have no buttons, and the recurring prematch task retries activation
 after restarts. The five-minute clock begins only when persisted messages are
 successfully activated.
 
-GPT-5.6 Sol generates a versioned 2–6 leg criteria tree through OpenRouter with
-medium reasoning, a 4,096-token initial output limit, a 6,144-token truncated
-retry limit, and a shared 60-second deadline. It receives anonymous lobby and
-recent-form context plus the complete allowed field catalog. The model never
+Scout first builds an ordered shortlist of exactly 20 match-specific targets:
+16 player targets distributed evenly across the tracked subjects and four
+game-wide targets. Every selection is SHA-256-ranked from a versioned match seed,
+so retries and parallel workers reproduce the same order regardless of source
+ordering. Player eligibility combines a universal pool, a reviewed inferred-lane
+pool, and Riot champion-tag pools read from the bundled Data Dragon assets.
+Champion tags are coarse by design; for example, a Support-tagged champion may
+receive a healing target even when its individual kit makes that line dubious.
+Zero-heavy participant objective last-hits, multikills, killing sprees, true
+damage, and player `timePlayed` remain evaluable for stored criteria but are not
+shortlisted.
+
+Global candidates are team win, five history-grounded team-objective counts,
+and game duration. Exactly one of 16 hash buckets admits opponent-team pings;
+when admitted, one of the 13 ping subtypes is selected deterministically and
+occupies one global slot. The versioned generation context stores the exact 20
+candidates for audit, and structured model output is rejected unless every
+target is in that list and bound to its listed subject or team.
+
+GPT-5.6 Sol then generates a versioned 2–6 leg criteria tree through OpenRouter
+with medium reasoning, a 4,096-token initial output limit, a 6,144-token
+truncated retry limit, and a shared 60-second deadline. It receives anonymous
+lobby and recent-form context plus only the shortlist. The first pass chooses
+targets and operators while covering every tracked subject; the second pass
+chooses thresholds from measured history. Pricing still replays those thresholds
+over the same history snapshot and is never model-authored. The model never
 supplies code, paths, settlement expressions, or authoritative result prose.
 Settlement evaluates only the persisted canonical tree against the final Riot
-`RawMatch`; remakes take precedence and refund both outcome and parlay markets.
+`RawMatch`; the evaluator version is unchanged because existing criteria retain
+identical meaning. Remakes take precedence and refund both outcome and parlay
+markets.
 
 Neither market has a product stake cap. Positive whole-BB positions are bounded
 by wallet balance, parlay house liability, and the existing Int32 persistence
@@ -339,6 +363,15 @@ domain. Parlay liability is reserved when the position is accepted; total
 positions are repriced with integer-ceiling fixed odds on every top-up. Credits
 also preserve Int32 headroom for every pending stake and house reserve, so a
 later cancellation, remake, or stale-market refund is always representable.
+
+Post-game presentation uses separate `BET WINNERS`, `BET LOSERS`,
+`PARLAY WINNERS`, and `PARLAY LOSERS` sections. Winners show net profit and a
+nonzero fee where applicable; losers show the stake actually lost. Matching,
+predicted sides, house fill, pool totals, and gross-return arithmetic remain on
+the pre-game close receipt and are omitted post-game. Outcome and parlay refunds
+are summarized separately without listing refunded bettors. All user-facing
+whole numbers use fixed comma grouping, while game duration and stored parlay
+time fields render as `MM:SS` without wrapping minutes at 60.
 
 Prompt rendering, semantic validation, catalog coverage, and evaluation run in
 ordinary offline tests. Run the opt-in production prompt acceptance suite with

--- a/packages/scout-for-lol/packages/backend/scripts/test-parlay-live.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/test-parlay-live.ts
@@ -47,6 +47,7 @@ import {
   buildParlayThresholdPrompt,
 } from "#src/betting/parlay-prompt.ts";
 import { createLogger } from "#src/logger.ts";
+import { buildParlayShortlist } from "#src/betting/parlay-shortlist.ts";
 
 const logger = createLogger("test-parlay-live");
 
@@ -148,6 +149,14 @@ function scenario(input: {
         input.historyAvailable ? 6 : 0,
       ),
     })),
+    shortlist: buildParlayShortlist({
+      matchId: `live-${input.queue}-${input.subjectCount.toString()}-${input.historyAvailable.toString()}`,
+      subjects: selected.map((subject) => ({
+        key: subject.key,
+        lane: "adc",
+        tags: ["Assassin"],
+      })),
+    }),
   });
   return { selected, context };
 }
@@ -276,13 +285,14 @@ for (const liveCase of cases) {
 
   // Pass one: legs only.
   const proposalResult = await call(
-    parlayProposalSchemaFor(liveCase.selected),
+    parlayProposalSchemaFor(liveCase.selected, liveCase.context.shortlist),
     buildParlayProposalPrompt(liveCase.context),
     "bryan_bucks_parlay_proposal",
   );
-  const proposal = parlayProposalSchemaFor(liveCase.selected).parse(
-    proposalResult.object,
-  );
+  const proposal = parlayProposalSchemaFor(
+    liveCase.selected,
+    liveCase.context.shortlist,
+  ).parse(proposalResult.object);
 
   const history = syntheticHistory(liveCase.selected);
   const legs = statLegsForProposal(proposal, liveCase.selected);

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
@@ -162,17 +162,17 @@ describe("formatSettlementBody", () => {
       predictionVerdictLine: undefined,
     });
 
+    expect(body).toContain("**BET WINNERS:**");
     expect(body).toContain(
-      `• <@${WINNER_DISCORD_ID}> Blue 10 → matched **10** · +**6 BB** (20 − 4 fee = 16 back)`,
+      `• <@${WINNER_DISCORD_ID}> bet 10BB, won 6BB (4BB fee)`,
     );
-    expect(body).toContain("Matched pool **20 BB** · winner fees **4 BB**");
-    expect(body).toContain(
-      `• <@${LOSER_DISCORD_ID}> Red 10 → matched **10** · −**10 BB**`,
-    );
+    expect(body).toContain("**BET LOSERS:**");
+    expect(body).toContain(`• <@${LOSER_DISCORD_ID}> bet 10BB, lost 10BB`);
+    expect(body).not.toContain("Matched pool");
     expect(body).toContain("🪙 **Aaron** +11 BB (played, clash bonus)");
   });
 
-  test("labels refunds while retaining the original stake", () => {
+  test("summarizes voided and fully unmatched refunds without bettor rows", () => {
     const summary: SettlementSummary = {
       matchId: "NA1_5000000042",
       serverId: "1337623164146155593",
@@ -202,6 +202,64 @@ describe("formatSettlementBody", () => {
       ],
     };
 
+    const unmatchedDiscordId = bucksTestDiscordId(3);
+    const body = formatSettlementBody({
+      includeOutcome: true,
+      parlay: undefined,
+      framing: undefined,
+      summary,
+      earnings: [],
+      predictionSentence: undefined,
+      predictionVerdictLine: undefined,
+      unmatchedPositions: [
+        {
+          betId: 3,
+          discordId: unmatchedDiscordId,
+          teamId: 100,
+          submittedStake: 5,
+          matchedStake: 0,
+          unmatchedStake: 5,
+        },
+      ],
+    });
+
+    expect(body).toContain(
+      "BET REFUNDS: **19BB** across 2 bets (no takers on the other side).",
+    );
+    expect(body).not.toContain(`<@${WINNER_DISCORD_ID}>`);
+    expect(body).not.toContain(`<@${unmatchedDiscordId}>`);
+  });
+
+  test("shows a partial result and summarizes only its unmatched refund", () => {
+    const summary: SettlementSummary = {
+      matchId: "NA1_5000000042",
+      serverId: "1337623164146155593",
+      winningTeamId: 100,
+      voidReason: undefined,
+      winnersPool: 10,
+      losersPool: 10,
+      houseCut: 2,
+      bets: [
+        {
+          betId: 1,
+          bucksAccountId: 1,
+          discordId: WINNER_DISCORD_ID,
+          isHouse: false,
+          predictedTeamId: 100,
+          submittedStake: 15,
+          matchedStake: 10,
+          unmatchedStake: 5,
+          grossPayout: 20,
+          houseCut: 2,
+          payout: 18,
+          winnings: 8,
+          won: true,
+          refunded: false,
+          subjectPuuid: "winner-puuid",
+        },
+      ],
+    };
+
     const body = formatSettlementBody({
       includeOutcome: true,
       parlay: undefined,
@@ -213,14 +271,16 @@ describe("formatSettlementBody", () => {
     });
 
     expect(body).toContain(
-      `• <@${WINNER_DISCORD_ID}> Blue 14 → matched **10**, refunded **4** · refunded **10 BB**`,
+      `• <@${WINNER_DISCORD_ID}> bet 15BB, won 8BB (2BB fee)`,
     );
-    expect(body).toContain("Matched pool **10 BB** · winner fees **0 BB**");
+    expect(body).toContain("BET REFUNDS: **5BB** across 1 bet.");
+    expect(body).not.toContain("matched stake");
+    expect(body).not.toContain("Blue");
   });
 });
 
 describe("formatSettlementBody house cuts", () => {
-  test("shows complete arithmetic when a small winning payout has no cut", () => {
+  test("omits the fee parenthetical when a small winner pays no fee", () => {
     const summary: SettlementSummary = {
       matchId: "NA1_5000000042",
       serverId: "1337623164146155593",
@@ -277,13 +337,11 @@ describe("formatSettlementBody house cuts", () => {
       predictionVerdictLine: undefined,
     });
 
-    expect(body).toContain("Matched pool **2 BB** · winner fees **0 BB**");
-    expect(body).toContain(
-      "Blue 1 → matched **1** · +**1 BB** (2 − 0 fee = 2 back)",
-    );
+    expect(body).toContain(`• <@${WINNER_DISCORD_ID}> bet 1BB, won 1BB`);
+    expect(body).not.toContain("0BB fee");
   });
 
-  test("summarizes the house without exposing its synthetic account", () => {
+  test("omits house-match details and the synthetic account", () => {
     const summary: SettlementSummary = {
       matchId: "NA1_5000000042",
       serverId: "1337623164146155593",
@@ -340,12 +398,10 @@ describe("formatSettlementBody house cuts", () => {
       predictionVerdictLine: undefined,
     });
 
-    expect(body).toContain(
-      "🏦 Bryan Bucks house matched 25 BB on the other side.",
-    );
+    expect(body).not.toContain("Bryan Bucks house matched");
     expect(body).not.toContain(`<@${HOUSE_ACCOUNT_DISCORD_ID}>`);
     expect(body).toContain(
-      `• <@${WINNER_DISCORD_ID}> Blue 25 → matched **25**`,
+      `• <@${WINNER_DISCORD_ID}> bet 25BB, won 15BB (10BB fee)`,
     );
   });
 });
@@ -442,10 +498,9 @@ describe("settlement outcome message", () => {
         0,
       );
     expect(embedLength).toBeLessThanOrEqual(6000);
-    expect(delivered).toContain(
-      "Matched pool **80 BB** · winner fees **32 BB**",
-    );
-    expect(delivered).toContain("+**3 BB** (10 − 2 fee = 8 back)");
+    expect(delivered).toContain("BET WINNERS");
+    expect(delivered).toContain("bet 5BB, won 3BB (2BB fee)");
+    expect(delivered).not.toContain("Matched pool");
     expect(delivered).toContain("🪙 **Aaron** +13 BB");
     expect(delivered).toContain("…and 1 more — see `/bb history`");
   });

--- a/packages/scout-for-lol/packages/backend/src/betting/ask-agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/ask-agent.ts
@@ -365,7 +365,7 @@ The current UTC timestamp is ${currentTime}. Interpret relative periods such as 
 
 Current account balance is private to the asker. Refuse requests for another member's current balance or an on-demand balance leaderboard. Bettor identities and rankings are available only for betting statistics; ledger analytics are guild-wide and never identify individual bettors.
 
-Use a concise, straight-analyst tone. State the matched sample size and the result's date coverage. Every grouped result reports returnedRows, totalGroups, and truncated; when truncated is true, explicitly call the rows a partial top/bottom list and never describe them as exhaustive. If the sample is thin, empty, unresolved, or an alias is unknown, say so. Discord identities may be written as the exact non-pinging <@id> labels returned by tools.
+Use a concise, straight-analyst tone. Format every whole number in prose with en-US comma separators, but preserve Discord IDs, dates, and timestamps exactly. State the matched sample size and the result's date coverage. Every grouped result reports returnedRows, totalGroups, and truncated; when truncated is true, explicitly call the rows a partial top/bottom list and never describe them as exhaustive. If the sample is thin, empty, unresolved, or an alias is unknown, say so. Discord identities may be written as the exact non-pinging <@id> labels returned by tools.
 
 Keep these definitions exact:
 - Current balance, ledger delta, and betting P&L are different measures.

--- a/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/bet-button.ts
@@ -23,6 +23,7 @@ import {
 } from "#src/betting/copy.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 const logger = createLogger("betting-bet-button");
 
@@ -67,7 +68,7 @@ export function describeResult(
       // confirmation: without it the number above reads as a guaranteed loss
       // amount, which is not what was submitted. Everything else is in
       // `/bb rules`.
-      return `✅ **${sideLabel}** — offered up to **${result.totalStake.toString()} BB** · balance **${result.balanceAfter.toString()} BB**. Only matched BB are at risk; the rest is refunded at close.`;
+      return `✅ **${sideLabel}** — offered up to **${formatInteger(result.totalStake)} BB** · balance **${formatInteger(result.balanceAfter)} BB**. Only matched BB are at risk; the rest is refunded at close.`;
     }
     case "window_closed":
       return "⏰ Betting has closed for this game.";
@@ -98,7 +99,7 @@ export function describeResult(
 export function describeCancel(result: CancelBetResult): string {
   switch (result.kind) {
     case "cancelled":
-      return `↩️ Cancelled: **${result.stake.toString()} BB** − **${result.houseCut.toString()} BB** fee = **${result.refunded.toString()} BB** back · balance **${result.balanceAfter.toString()} BB**.`;
+      return `↩️ Cancelled: **${formatInteger(result.stake)} BB** − **${formatInteger(result.houseCut)} BB** fee = **${formatInteger(result.refunded)} BB** back · balance **${formatInteger(result.balanceAfter)} BB**.`;
     case "window_closed":
       return "⏰ Betting is closed — your bet is locked in. Final amounts are on the game message.";
     case "already_resolved":

--- a/packages/scout-for-lol/packages/backend/src/betting/components.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/components.ts
@@ -8,6 +8,7 @@ import {
 import type { BucksPoolParticipant, RiotTeamId } from "@scout-for-lol/data";
 import { BLUE_TEAM_ID, BUTTON_STAKES } from "#src/betting/constants.ts";
 import { formatBucksCustomId } from "#src/betting/custom-id.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 import {
   BETTING_TEAM_IDS,
   hasTrackedPlayersOnBothTeams,
@@ -94,7 +95,7 @@ function buildRow(input: {
             }),
           )
           .setLabel(
-            `${outcomeLabel(teamId, subjectFraming(input.anchor))} · ${stake.toString()} BB`,
+            `${outcomeLabel(teamId, subjectFraming(input.anchor))} · ${formatInteger(stake)} BB`,
           )
           .setStyle(buttonStyleFor(teamId, input.anchor))
           .setDisabled(input.disabled),

--- a/packages/scout-for-lol/packages/backend/src/betting/copy.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/copy.ts
@@ -1,4 +1,5 @@
 import { BUCKS_RULES_HINT } from "#src/betting/prematch-line.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 /**
  * User-facing Bryan Bucks strings shared by more than one surface.
@@ -39,7 +40,7 @@ export const BUCKS_HOUSE_CANNOT_FUND =
   "🏦 The Bryan Bucks house can't fund a new wallet right now. No Bucks moved.";
 
 export function bucksInsufficient(balance: number, needed: number): string {
-  return `💸 You have **${balance.toString()} BB** but need **${needed.toString()} BB**.`;
+  return `💸 You have **${formatInteger(balance)} BB** but need **${formatInteger(needed)} BB**.`;
 }
 
 /** Appended where a reader may want the rules but the surface must not carry them. */

--- a/packages/scout-for-lol/packages/backend/src/betting/display-format.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/display-format.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import {
+  formatDurationSeconds,
+  formatInteger,
+  formatParlayNumericValue,
+} from "#src/betting/display-format.ts";
+
+describe("Bryan Bucks display formatting", () => {
+  test.each([
+    [0, "0"],
+    [3000, "3,000"],
+    [-1_234_567, "-1,234,567"],
+  ])("groups integer %i", (value, expected) => {
+    expect(formatInteger(value)).toBe(expected);
+  });
+
+  test.each([
+    [0, "00:00"],
+    [7, "00:07"],
+    [9 * 60 + 5, "09:05"],
+    [60 * 60 + 2, "60:02"],
+  ])("formats %i seconds without wrapping minutes", (value, expected) => {
+    expect(formatDurationSeconds(value)).toBe(expected);
+  });
+
+  test("formats current and legacy duration fields", () => {
+    for (const field of [
+      "gameDuration",
+      "longestTimeSpentLiving",
+      "timeCCingOthers",
+      "timePlayed",
+      "totalTimeCCDealt",
+      "totalTimeSpentDead",
+    ]) {
+      expect(formatParlayNumericValue(field, 3661)).toBe("61:01");
+    }
+    expect(formatParlayNumericValue("goldEarned", 12_345)).toBe("12,345");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/display-format.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/display-format.ts
@@ -1,0 +1,38 @@
+const INTEGER_FORMATTER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  minimumFractionDigits: 0,
+  useGrouping: true,
+});
+
+const PARLAY_DURATION_FIELDS = new Set([
+  "gameDuration",
+  "longestTimeSpentLiving",
+  "timeCCingOthers",
+  "timePlayed",
+  "totalTimeCCDealt",
+  "totalTimeSpentDead",
+]);
+
+/** Locale-fixed grouping for every user-visible whole number. */
+export function formatInteger(value: number): string {
+  if (!Number.isSafeInteger(value)) {
+    throw new TypeError(`Cannot display non-integer value ${value.toString()}`);
+  }
+  return INTEGER_FORMATTER.format(value);
+}
+
+/** MM:SS, retaining total minutes instead of wrapping after an hour. */
+export function formatDurationSeconds(value: number): string {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`Cannot display invalid duration ${value.toString()}`);
+  }
+  const minutes = Math.floor(value / 60);
+  const seconds = value % 60;
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export function formatParlayNumericValue(field: string, value: number): string {
+  return PARLAY_DURATION_FIELDS.has(field)
+    ? formatDurationSeconds(value)
+    : formatInteger(value);
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/message-refresh.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/message-refresh.integration.test.ts
@@ -485,9 +485,9 @@ describe("announceSettlements unmatched receipts", () => {
     );
 
     expect(sends).toHaveLength(2);
-    expect(JSON.stringify(sends[0])).toContain(
-      `Blue 9 → nothing matched, refunded **9**`,
-    );
+    const outcome = JSON.stringify(sends[0]);
+    expect(outcome).toContain(`BET REFUNDS: **9BB** across 1 bet.`);
+    expect(outcome).not.toContain(`<@${bucksTestDiscordId(1)}>`);
   });
 
   test("does not announce a partial close before matched refunds commit", async () => {
@@ -585,9 +585,9 @@ describe("announceSettlements unmatched receipts", () => {
       },
     );
 
-    expect(JSON.stringify(sends[0])).toContain(
-      `Blue 9 → nothing matched, refunded **9**`,
-    );
+    const outcome = JSON.stringify(sends[0]);
+    expect(outcome).toContain(`BET REFUNDS: **9BB** across 1 bet (remake).`);
+    expect(outcome).not.toContain(`<@${bucksTestDiscordId(1)}>`);
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -11,6 +11,7 @@ import { BUCKS_GUILD_ONLY, BUCKS_NOT_ENABLED } from "#src/betting/copy.ts";
 import { PEEK_PASS_DURATION_LABEL } from "#src/betting/peek-pass.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import type { BucksButtonEditReplyOptions } from "#src/betting/bet-button.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 export const BUCKS_NAVIGATION_NAMESPACE = "bbnav";
 export const BUCKS_NAVIGATION_VERSION = "1";
@@ -155,11 +156,11 @@ export function renderBucksHistory(
   const lines = page.entries.map((entry) => {
     const sign = entry.delta > 0 ? "+" : "";
     const where = entry.matchId === null ? "" : ` · ${entry.matchId}`;
-    return `\`${sign}${entry.delta.toString()}\` ${ledgerKindLabel(entry.kind)}${where} → ${entry.balanceAfter.toString()} BB`;
+    return `\`${sign}${formatInteger(entry.delta)}\` ${ledgerKindLabel(entry.kind)}${where} → ${formatInteger(entry.balanceAfter)} BB`;
   });
   return {
     content: [
-      `**Bryan Bucks history** · Page ${(page.page + 1).toString()}/${page.totalPages.toString()}`,
+      `**Bryan Bucks history** · Page ${formatInteger(page.page + 1)}/${formatInteger(page.totalPages)}`,
       ...lines,
     ].join("\n"),
     components: navigationRow(ownerId, page),

--- a/packages/scout-for-lol/packages/backend/src/betting/outcome-message.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/outcome-message.ts
@@ -1,6 +1,5 @@
 import { EmbedBuilder, type MessageCreateOptions } from "discord.js";
 import {
-  RiotTeamIdSchema,
   type BucksPrediction,
   type BucksVoidReason,
 } from "@scout-for-lol/data";
@@ -9,7 +8,11 @@ import { shouldDisplayPrediction } from "#src/betting/prediction.ts";
 import type { ParlaySettlementSummary } from "#src/betting/parlay-settle.ts";
 import type { SettlementBet, SettlementSummary } from "#src/betting/settle.ts";
 import type { ClosedPosition } from "#src/betting/sweep.ts";
-import { outcomeLabel, type OutcomeFraming } from "#src/betting/team.ts";
+import type { OutcomeFraming } from "#src/betting/team.ts";
+import {
+  formatInteger,
+  formatParlayNumericValue,
+} from "#src/betting/display-format.ts";
 
 /** Beyond this the message stops being readable, so the tail is summarised. */
 const MAX_BET_ROWS = 15;
@@ -36,91 +39,38 @@ export type SettlementMessageInput = {
 
 type SettlementDisplay = {
   summaryLines: string[];
-  betLines: string[];
+  betWinnerLines: string[];
+  betLoserLines: string[];
   parlayLegLines: string[];
-  parlayPositionLines: string[];
+  parlayWinnerLines: string[];
+  parlayLoserLines: string[];
   earningLines: string[];
 };
 
 function voidReasonText(reason: BucksVoidReason): string {
   switch (reason) {
     case "remake":
-      return "Remake — every matched stake refunded.";
+      return "remake";
     case "no_counterparty":
-      return "No takers on the other side — every matched stake refunded.";
+      return "no takers on the other side";
     case "house_unavailable":
-      return "The Bryan Bucks house reserve was unavailable — every matched stake refunded.";
+      return "house reserve unavailable";
     case "expired":
-      return "This game never resolved — every matched stake refunded.";
+      return "game never resolved";
     case "storage_overflow":
-      return "The result exceeded Bryan Bucks storage limits — every matched stake refunded.";
+      return "result exceeded storage limits";
     case "unsupported_mode":
-      return "Unsupported game mode — every matched stake refunded.";
+      return "unsupported game mode";
   }
 }
 
-function settlementSummaryLines(input: SettlementMessageInput): string[] {
-  const { summary } = input;
-  const pool = summary.bets.reduce((total, bet) => total + bet.matchedStake, 0);
-  let outcome: string;
-  if (
-    (input.unmatchedPositions?.length ?? 0) > 0 &&
-    summary.bets.length === 0
-  ) {
-    outcome =
-      "Matched pool **0 BB** · winner fees **0 BB**. No stake was matched; every offer was refunded.";
-  } else if (summary.voidReason === undefined) {
-    outcome = `Matched pool **${pool.toString()} BB** · winner fees **${summary.houseCut.toString()} BB** (winners matched ${summary.winnersPool.toString()} / losers matched ${summary.losersPool.toString()})`;
-  } else {
-    outcome = `Matched pool **${pool.toString()} BB** · winner fees **0 BB**. ${voidReasonText(summary.voidReason)}`;
-  }
-
-  const lines = [outcome];
-  if (input.predictionSentence !== undefined) {
-    const verdict =
-      input.predictionVerdictLine === undefined
-        ? ""
-        : ` ${input.predictionVerdictLine}`;
-    lines.push(`${input.predictionSentence}${verdict}`);
-  }
-  const houseStake = summary.bets
-    .filter((bet) => bet.isHouse)
-    .reduce((total, bet) => total + bet.matchedStake, 0);
-  if (houseStake > 0) {
-    lines.push(
-      `🏦 Bryan Bucks house matched ${houseStake.toString()} BB on the other side.`,
-    );
-  }
-  return lines;
-}
-
-/**
- * The gross/cut/net arithmetic is preserved verbatim: public outcome copy must
- * never make a reader reconstruct it from ledger rows.
- */
-function settlementBetResult(bet: SettlementBet): string {
-  if (bet.refunded) {
-    return `refunded **${bet.payout.toString()} BB**`;
-  }
-  if (bet.won) {
-    return `+**${bet.winnings.toString()} BB** (${bet.grossPayout.toString()} − ${bet.houseCut.toString()} fee = ${bet.payout.toString()} back)`;
-  }
-  return `−**${bet.matchedStake.toString()} BB**`;
-}
-
-function settlementBetLines(input: SettlementMessageInput): string[] {
-  const humanBets = input.summary.bets.filter((bet) => !bet.isHouse);
-  const unmatchedPositions = input.unmatchedPositions ?? [];
-  const visibleHumanBets = humanBets.slice(0, MAX_BET_ROWS);
-  const lines = visibleHumanBets.map((bet) => {
-    const refunded =
-      bet.unmatchedStake > 0
-        ? `, refunded **${bet.unmatchedStake.toString()}**`
-        : "";
-    return `• <@${bet.discordId}> ${outcomeLabel(RiotTeamIdSchema.parse(bet.predictedTeamId), input.framing)} ${bet.submittedStake.toString()} → matched **${bet.matchedStake.toString()}**${refunded} · ${settlementBetResult(bet)}`;
-  });
-  const unmatchedLimit = MAX_BET_ROWS - visibleHumanBets.length;
-  for (const position of unmatchedPositions.slice(0, unmatchedLimit)) {
+function outcomeRefundSummary(
+  input: SettlementMessageInput,
+): string | undefined {
+  const refundedAmounts = input.summary.bets
+    .filter((bet) => !bet.isHouse)
+    .map((bet) => bet.unmatchedStake + (bet.refunded ? bet.matchedStake : 0));
+  for (const position of input.unmatchedPositions ?? []) {
     if (
       position.matchedStake !== 0 ||
       position.unmatchedStake !== position.submittedStake
@@ -129,16 +79,84 @@ function settlementBetLines(input: SettlementMessageInput): string[] {
         `Outcome receipt received non-terminal unmatched bet ${position.betId.toString()}`,
       );
     }
-    lines.push(
-      `• <@${position.discordId}> ${outcomeLabel(position.teamId, input.framing)} ${position.submittedStake.toString()} → nothing matched, refunded **${position.unmatchedStake.toString()}**`,
+    refundedAmounts.push(position.unmatchedStake);
+  }
+  const refunded = refundedAmounts.reduce((total, amount) => total + amount, 0);
+  const count = refundedAmounts.filter((amount) => amount > 0).length;
+  if (refunded === 0) return;
+  const reason =
+    input.summary.voidReason === undefined
+      ? ""
+      : ` (${voidReasonText(input.summary.voidReason)})`;
+  return `BET REFUNDS: **${formatInteger(refunded)}BB** across ${formatInteger(count)} bet${count === 1 ? "" : "s"}${reason}.`;
+}
+
+function parlayRefundSummary(
+  parlay: ParlaySettlementSummary | undefined,
+): string | undefined {
+  if (parlay === undefined) return;
+  const refundedBets = parlay.bets.filter((bet) => bet.outcome === "refunded");
+  const refunded = refundedBets.reduce((total, bet) => total + bet.stake, 0);
+  if (refunded === 0) return;
+  const reason =
+    parlay.voidReason === undefined
+      ? ""
+      : ` (${parlayVoidText(parlay.voidReason)})`;
+  return `PARLAY REFUNDS: **${formatInteger(refunded)}BB** across ${formatInteger(refundedBets.length)} parlay${refundedBets.length === 1 ? "" : "s"}${reason}.`;
+}
+
+function settlementSummaryLines(input: SettlementMessageInput): string[] {
+  const lines: string[] = [];
+  if (input.predictionSentence !== undefined) {
+    const verdict =
+      input.predictionVerdictLine === undefined
+        ? ""
+        : ` ${input.predictionVerdictLine}`;
+    lines.push(`${input.predictionSentence}${verdict}`);
+  }
+  const betRefund = input.includeOutcome
+    ? outcomeRefundSummary(input)
+    : undefined;
+  if (betRefund !== undefined) lines.push(betRefund);
+  const parlayRefund = parlayRefundSummary(input.parlay);
+  if (parlayRefund !== undefined) lines.push(parlayRefund);
+  return lines;
+}
+
+function settlementBetLine(bet: SettlementBet): string {
+  if (bet.refunded) {
+    throw new Error("Refunded bets do not belong in result sections");
+  }
+  if (!bet.won) {
+    return `• <@${bet.discordId}> bet ${formatInteger(bet.submittedStake)}BB, lost ${formatInteger(bet.matchedStake)}BB`;
+  }
+  const fee =
+    bet.houseCut === 0 ? "" : ` (${formatInteger(bet.houseCut)}BB fee)`;
+  return `• <@${bet.discordId}> bet ${formatInteger(bet.submittedStake)}BB, won ${formatInteger(bet.winnings)}BB${fee}`;
+}
+
+function settlementBetLines(input: SettlementMessageInput): {
+  winners: string[];
+  losers: string[];
+} {
+  const humanBets = input.summary.bets.filter(
+    (bet) => !bet.isHouse && !bet.refunded,
+  );
+  const visible = humanBets.slice(0, MAX_BET_ROWS);
+  const winners = visible
+    .filter((bet) => bet.won)
+    .map((bet) => settlementBetLine(bet));
+  const losers = visible
+    .filter((bet) => !bet.won)
+    .map((bet) => settlementBetLine(bet));
+  const hiddenCount = humanBets.length - MAX_BET_ROWS;
+  if (hiddenCount > 0) {
+    const destination = losers.length > 0 ? losers : winners;
+    destination.push(
+      `…and ${formatInteger(hiddenCount)} more — see \`/bb history\``,
     );
   }
-  const hiddenCount =
-    humanBets.length + unmatchedPositions.length - MAX_BET_ROWS;
-  if (hiddenCount > 0) {
-    lines.push(`…and ${hiddenCount.toString()} more — see \`/bb history\``);
-  }
-  return lines;
+  return { winners, losers };
 }
 
 function formatEarningAlias(alias: string): string {
@@ -153,7 +171,7 @@ function settlementEarningLines(input: SettlementMessageInput): string[] {
     .filter((award) => award.serverId === input.summary.serverId)
     .map(
       (award) =>
-        `🪙 **${formatEarningAlias(award.alias)}** +${award.total.toString()} BB (${award.reasons.join(", ")})`,
+        `🪙 **${formatEarningAlias(award.alias)}** +${formatInteger(award.total)} BB (${award.reasons.join(", ")})`,
     );
 }
 
@@ -184,33 +202,64 @@ function parlayLegLines(parlay: ParlaySettlementSummary | undefined): string[] {
     return [];
   }
   if (parlay.voidReason !== undefined) {
-    return [
-      `Every stake and house reserve was returned (${parlayVoidText(parlay.voidReason)}).`,
-    ];
+    return [`Voided — ${parlayVoidText(parlay.voidReason)}.`];
   }
-  return parlay.legs.map(
-    (leg) =>
-      `${leg.passed ? "✅" : "❌"} ${leg.rendered} — ${String(leg.actualValue)}`,
-  );
+  return parlay.legs.map((leg) => {
+    let actual: string;
+    if (typeof leg.actualValue === "boolean") {
+      actual = String(leg.actualValue);
+    } else {
+      switch (leg.condition.kind) {
+        case "participant_numeric":
+        case "match_numeric":
+        case "opponent_team_pings":
+          actual = formatParlayNumericValue(
+            leg.condition.field,
+            leg.actualValue,
+          );
+          break;
+        case "team_objective_kills":
+          actual = formatInteger(leg.actualValue);
+          break;
+        case "participant_boolean":
+        case "team_boolean":
+        case "team_objective_first":
+          throw new Error("Boolean parlay leg carried a numeric result");
+      }
+    }
+    return `${leg.passed ? "✅" : "❌"} ${leg.rendered} — ${actual}`;
+  });
 }
 
-function parlayPositionLines(
-  parlay: ParlaySettlementSummary | undefined,
-): string[] {
+function parlayPositionLines(parlay: ParlaySettlementSummary | undefined): {
+  winners: string[];
+  losers: string[];
+} {
   if (parlay === undefined) {
-    return [];
+    return { winners: [], losers: [] };
   }
-  const lines = parlay.bets
-    .slice(0, MAX_BET_ROWS)
-    .map(
-      (bet) =>
-        `• <@${bet.discordId}> ${bet.side} ${bet.stake.toString()} → ${bet.outcome}, **${bet.payout.toString()} BB**`,
-    );
-  const hidden = parlay.bets.length - MAX_BET_ROWS;
+  const settled = parlay.bets.filter((bet) => bet.outcome !== "refunded");
+  const visible = settled.slice(0, MAX_BET_ROWS).map((bet) => ({
+    outcome: bet.outcome,
+    line:
+      bet.outcome === "won"
+        ? `• <@${bet.discordId}> bet ${formatInteger(bet.stake)}BB, won ${formatInteger(bet.grossPayout - bet.stake)}BB`
+        : `• <@${bet.discordId}> bet ${formatInteger(bet.stake)}BB, lost ${formatInteger(bet.stake)}BB`,
+  }));
+  const winners = visible
+    .filter((row) => row.outcome === "won")
+    .map((row) => row.line);
+  const losers = visible
+    .filter((row) => row.outcome === "lost")
+    .map((row) => row.line);
+  const hidden = settled.length - MAX_BET_ROWS;
   if (hidden > 0) {
-    lines.push(`…and ${hidden.toString()} more — see \`/bb history\``);
+    const destination = losers.length > 0 ? losers : winners;
+    destination.push(
+      `…and ${formatInteger(hidden)} more — see \`/bb history\``,
+    );
   }
-  return lines;
+  return { winners, losers };
 }
 
 /** `Parlay — NO (1/2 legs)`, or the void headline. */
@@ -219,17 +268,21 @@ export function parlayFieldTitle(parlay: ParlaySettlementSummary): string {
     return `Parlay — voided (${parlayVoidText(parlay.voidReason)})`;
   }
   const passed = parlay.legs.filter((leg) => leg.passed).length;
-  return `Parlay — ${parlay.yesResult === true ? "YES" : "NO"} (${passed.toString()}/${parlay.legs.length.toString()} legs)`;
+  return `Parlay — ${parlay.yesResult === true ? "YES" : "NO"} (${formatInteger(passed)}/${formatInteger(parlay.legs.length)} legs)`;
 }
 
 function formatSettlementDisplay(
   input: SettlementMessageInput,
 ): SettlementDisplay {
+  const bets = settlementBetLines(input);
+  const parlays = parlayPositionLines(input.parlay);
   return {
-    summaryLines: input.includeOutcome ? settlementSummaryLines(input) : [],
-    betLines: input.includeOutcome ? settlementBetLines(input) : [],
+    summaryLines: settlementSummaryLines(input),
+    betWinnerLines: input.includeOutcome ? bets.winners : [],
+    betLoserLines: input.includeOutcome ? bets.losers : [],
     parlayLegLines: parlayLegLines(input.parlay),
-    parlayPositionLines: parlayPositionLines(input.parlay),
+    parlayWinnerLines: parlays.winners,
+    parlayLoserLines: parlays.losers,
     earningLines: settlementEarningLines(input),
   };
 }
@@ -262,9 +315,20 @@ export function predictionVerdict(
 
 export function formatSettlementBody(input: SettlementMessageInput): string {
   const display = formatSettlementDisplay(input);
-  const blocks = [display.summaryLines.join("\n")];
-  if (display.betLines.length > 0) {
-    blocks.push(["**Bets**", ...display.betLines].join("\n"));
+  const blocks = [display.summaryLines.join("\n")].filter(
+    (block) => block.length > 0,
+  );
+  for (const [title, lines] of [
+    ["BET WINNERS", display.betWinnerLines],
+    ["BET LOSERS", display.betLoserLines],
+    [
+      input.parlay === undefined ? "PARLAY" : parlayFieldTitle(input.parlay),
+      display.parlayLegLines,
+    ],
+    ["PARLAY WINNERS", display.parlayWinnerLines],
+    ["PARLAY LOSERS", display.parlayLoserLines],
+  ] satisfies readonly (readonly [string, readonly string[]])[]) {
+    if (lines.length > 0) blocks.push([`**${title}:**`, ...lines].join("\n"));
   }
   if (display.earningLines.length > 0) {
     blocks.push(display.earningLines.join("\n"));
@@ -326,15 +390,15 @@ type EmbedSection = {
   title: string;
   lines: string[];
   overflow: (hidden: number) => string;
+  trimPriority: number;
 };
 
 function renderEmbed(
   description: string,
   sections: readonly EmbedSection[],
 ): EmbedBuilder {
-  const embed = new EmbedBuilder()
-    .setTitle("💰 Bryan Bucks")
-    .setDescription(description);
+  const embed = new EmbedBuilder().setTitle("💰 Bryan Bucks");
+  if (description.length > 0) embed.setDescription(description);
   for (const section of sections) {
     addEmbedSection(embed, section.title, section.lines);
   }
@@ -378,7 +442,9 @@ function fitSections(
     if (embedTextLength(embed) <= EMBED_TOTAL_TEXT_LIMIT) {
       return embed;
     }
-    const trimmable = working.find((section) => section.lines.length > 0);
+    const trimmable = working
+      .toSorted((left, right) => left.trimPriority - right.trimPriority)
+      .find((section) => section.lines.length > 0);
     if (trimmable === undefined) {
       throw new Error("A Bryan Bucks outcome exceeds Discord's embed limit");
     }
@@ -393,34 +459,49 @@ export function buildSettlementMessage(
 ): MessageCreateOptions {
   const display = formatSettlementDisplay(input);
   const descriptionLines = [...display.summaryLines];
-  if (input.parlay !== undefined && !input.includeOutcome) {
-    descriptionLines.push(parlayFieldTitle(input.parlay));
-  }
-  // Drop-first order: earnings are the least load-bearing, the outcome bet
-  // rows the most.
+  // Earnings trim first, followed by leg detail and parlay rows. Outcome result
+  // rows remain the last content removed from an oversized embed.
   const allSections: EmbedSection[] = [
     {
-      title: "Bucks earned",
-      lines: display.earningLines,
-      overflow: (hidden) => `…and ${hidden.toString()} more.`,
+      title: "BET WINNERS",
+      lines: display.betWinnerLines,
+      overflow: (hidden) =>
+        `…and ${formatInteger(hidden)} more — see \`/bb history\``,
+      trimPriority: 4,
+    },
+    {
+      title: "BET LOSERS",
+      lines: display.betLoserLines,
+      overflow: (hidden) =>
+        `…and ${formatInteger(hidden)} more — see \`/bb history\``,
+      trimPriority: 4,
     },
     {
       title:
         input.parlay === undefined ? "Parlay" : parlayFieldTitle(input.parlay),
       lines: display.parlayLegLines,
-      overflow: (hidden) => `…and ${hidden.toString()} more legs.`,
+      overflow: (hidden) => `…and ${formatInteger(hidden)} more legs.`,
+      trimPriority: 1,
     },
     {
-      title: "Parlay positions",
-      lines: display.parlayPositionLines,
+      title: "PARLAY WINNERS",
+      lines: display.parlayWinnerLines,
       overflow: (hidden) =>
-        `…and ${hidden.toString()} more — see \`/bb history\``,
+        `…and ${formatInteger(hidden)} more — see \`/bb history\``,
+      trimPriority: 3,
     },
     {
-      title: "Bets",
-      lines: display.betLines,
+      title: "PARLAY LOSERS",
+      lines: display.parlayLoserLines,
       overflow: (hidden) =>
-        `…and ${hidden.toString()} more — see \`/bb history\``,
+        `…and ${formatInteger(hidden)} more — see \`/bb history\``,
+      trimPriority: 3,
+    },
+    {
+      title: "Bucks earned",
+      lines: display.earningLines,
+      overflow: (hidden) => `…and ${formatInteger(hidden)} more.`,
+      trimPriority: 0,
     },
   ];
   const sections = allSections.filter((section) => section.lines.length > 0);

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-bet-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-bet-button.ts
@@ -24,11 +24,12 @@ import {
   BUCKS_STORAGE_LIMIT,
   bucksInsufficient,
 } from "#src/betting/copy.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 export function describeParlayResult(result: PlaceParlayBetResult): string {
   switch (result.kind) {
     case "placed":
-      return `✅ Parlay **${result.side}** position is now **${result.totalStake.toString()} BB**, paying **${result.grossPayout.toString()} BB** if it wins. Balance: **${result.balanceAfter.toString()} BB**.`;
+      return `✅ Parlay **${result.side}** position is now **${formatInteger(result.totalStake)} BB**, paying **${formatInteger(result.grossPayout)} BB** if it wins. Balance: **${formatInteger(result.balanceAfter)} BB**.`;
     case "window_closed":
       return "⏰ Parlay betting has closed for this game.";
     case "no_market":
@@ -57,7 +58,7 @@ export function describeParlayCancel(result: CancelParlayBetResult): string {
     case "cancelled":
       // Says "no fee" explicitly: the outcome market charges one and this is
       // the only place a parlay bettor learns theirs does not.
-      return `↩️ Cancelled: **${result.refunded.toString()} BB** back, no fee · balance **${result.balanceAfter.toString()} BB**.`;
+      return `↩️ Cancelled: **${formatInteger(result.refunded)} BB** back, no fee · balance **${formatInteger(result.balanceAfter)} BB**.`;
     case "no_market":
       return BUCKS_NO_PARLAY_MARKET;
     case "no_bet":

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-catalog.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-catalog.ts
@@ -265,7 +265,7 @@ export const MATCH_NUMERIC_CATALOG = z
   .record(MatchNumericFieldSchema, NumericCatalogEntrySchema)
   .parse({
     gameDuration: {
-      label: "game duration in seconds",
+      label: "game duration",
       thresholdMin: 300,
       thresholdMax: 7200,
     },
@@ -470,27 +470,3 @@ export const OPPONENT_PING_CATALOG = z
       ]),
     ),
   );
-
-export function promptFieldCatalog(
-  participantNumericFields: readonly ParticipantNumericField[] = ParticipantNumericFieldSchema.options,
-  teamObjectives: readonly TeamObjective[] = TeamObjectiveSchema.options,
-): object {
-  return {
-    participantNumeric: Object.fromEntries(
-      participantNumericFields.map((field) => [
-        field,
-        PARTICIPANT_NUMERIC_CATALOG[field],
-      ]),
-    ),
-    participantBoolean: PARTICIPANT_BOOLEAN_CATALOG,
-    teamBoolean: TEAM_BOOLEAN_CATALOG,
-    teamObjectives: Object.fromEntries(
-      teamObjectives.map((objective) => [
-        objective,
-        TEAM_OBJECTIVE_CATALOG[objective],
-      ]),
-    ),
-    matchNumeric: MATCH_NUMERIC_CATALOG,
-    opponentPings: OPPONENT_PING_CATALOG,
-  };
-}

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-components.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-components.ts
@@ -1,6 +1,7 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 import { BUTTON_STAKES } from "#src/betting/constants.ts";
 import { formatParlayCustomId } from "#src/betting/parlay-custom-id.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 export function buildParlayButtons(input: {
   matchId: string;
@@ -20,7 +21,7 @@ export function buildParlayButtons(input: {
               amount: stake,
             }),
           )
-          .setLabel(`${side} ${stake.toString()}`)
+          .setLabel(`${side} ${formatInteger(stake)}`)
           .setStyle(side === "YES" ? ButtonStyle.Success : ButtonStyle.Danger)
           .setDisabled(disabled),
       );

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-criteria.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-criteria.test.ts
@@ -15,6 +15,7 @@ import {
   thresholdsMatchProposal,
 } from "#src/betting/parlay-model-schema.ts";
 import { evaluateParlay } from "#src/betting/parlay-evaluator.ts";
+import { buildParlayShortlist } from "#src/betting/parlay-shortlist.ts";
 import { bucksTestRoster } from "#src/testing/bucks-fixtures.ts";
 
 const fixture = RawMatchSchema.parse(
@@ -22,6 +23,13 @@ const fixture = RawMatchSchema.parse(
     new URL("../../../../testdata/rift.json", import.meta.url),
   ).json(),
 );
+
+function shortlistForOne(matchId: string) {
+  return buildParlayShortlist({
+    matchId,
+    subjects: [{ key: "P1", lane: "adc", tags: ["Assassin"] }],
+  });
+}
 
 describe("parlay model schema", () => {
   test("uses an OpenAI-compatible flat model schema and normalizes it", () => {
@@ -423,7 +431,10 @@ describe("opponent ping conditions", () => {
     const subjects = ParlaySubjectsSchema.parse([
       { key: "P1", puuid: selected[0]?.puuid, alias: "one" },
     ]);
-    const result = parlayProposalSchemaFor(subjects).safeParse({
+    const result = parlayProposalSchemaFor(
+      subjects,
+      shortlistForOne("NA1_subject-pings"),
+    ).safeParse({
       version: 1,
       conditions: [
         {
@@ -551,7 +562,8 @@ describe("proposal grounding", () => {
   const subjects = ParlaySubjectsSchema.parse([
     { key: "P1", puuid: fixture.info.participants[0]?.puuid, alias: "one" },
   ]);
-  const ProposalSchema = parlayProposalSchemaFor(subjects);
+  const shortlist = shortlistForOne("NA1_proposal-grounding");
+  const ProposalSchema = parlayProposalSchemaFor(subjects, shortlist);
   const base = {
     subject: null,
     participantNumericField: null,
@@ -592,6 +604,12 @@ describe("proposal grounding", () => {
   });
 
   test("accepts an objective that does have recorded history", () => {
+    const candidate = shortlist.candidates.find(
+      (target) => target.kind === "team_objective_kills",
+    );
+    if (candidate === undefined) {
+      throw new Error("Expected an objective target in the global shortlist");
+    }
     const result = ProposalSchema.safeParse({
       version: 1,
       conditions: [
@@ -600,7 +618,7 @@ describe("proposal grounding", () => {
           ...base,
           kind: "team_objective_kills",
           team: "selected",
-          objective: "dragon",
+          objective: candidate.objective,
           operator: "gte",
         },
       ],
@@ -616,6 +634,20 @@ describe("proposal grounding", () => {
         {
           ...killsLeg,
           participantNumericField: "spell1Casts",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a grounded target outside the exact match shortlist", () => {
+    const result = ProposalSchema.safeParse({
+      version: 1,
+      conditions: [
+        killsLeg,
+        {
+          ...killsLeg,
+          participantNumericField: "totalHeal",
         },
       ],
     });

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-criteria.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-criteria.ts
@@ -18,9 +18,10 @@ import {
   TeamBooleanFieldSchema,
   TeamObjectiveSchema,
 } from "#src/betting/parlay-catalog.ts";
+import { formatParlayNumericValue } from "#src/betting/display-format.ts";
 
 export const PARLAY_SCHEMA_VERSION = 1;
-export const PARLAY_CATALOG_VERSION = "2026-08-19";
+export const PARLAY_CATALOG_VERSION = "2026-08-23";
 // Deliberately NOT bumped for the opponent-ping condition. This version is a
 // settlement gate: evaluateParlay voids any stored definition whose recorded
 // version differs, which refunds it. Adding a condition kind leaves every
@@ -310,14 +311,18 @@ export function parlaySemanticIssues(
   return [...issues, ...logicalContradictionIssues(parlay)];
 }
 
-function numericPhrase(operator: "gte" | "lte" | "eq", threshold: number) {
+function numericPhrase(
+  operator: "gte" | "lte" | "eq",
+  threshold: number,
+  field: string,
+) {
   const comparison =
     operator === "gte"
       ? "at least"
       : operator === "lte"
         ? "at most"
         : "exactly";
-  return `${comparison} ${threshold.toString()}`;
+  return `${comparison} ${formatParlayNumericValue(field, threshold)}`;
 }
 
 function subjectAlias(subjects: readonly ParlaySubject[], key: string): string {
@@ -330,7 +335,7 @@ export function renderParlayCondition(
 ): string {
   switch (condition.kind) {
     case "participant_numeric":
-      return `${subjectAlias(subjects, condition.subject)} gets ${numericPhrase(condition.operator, condition.threshold)} ${PARTICIPANT_NUMERIC_SETTLEMENT_CATALOG[condition.field].label}`;
+      return `${subjectAlias(subjects, condition.subject)} gets ${numericPhrase(condition.operator, condition.threshold, condition.field)} ${PARTICIPANT_NUMERIC_SETTLEMENT_CATALOG[condition.field].label}`;
     case "participant_boolean": {
       const name = subjectAlias(subjects, condition.subject);
       const field = PARTICIPANT_BOOLEAN_CATALOG[condition.field].label;
@@ -347,11 +352,11 @@ export function renderParlayCondition(
         : `Their team does not get first ${objective}`;
     }
     case "team_objective_kills":
-      return `Their team gets ${numericPhrase(condition.operator, condition.threshold)} ${TEAM_OBJECTIVE_CATALOG[condition.objective].label}${condition.threshold === 1 ? "" : "s"}`;
+      return `Their team gets ${numericPhrase(condition.operator, condition.threshold, condition.objective)} ${TEAM_OBJECTIVE_CATALOG[condition.objective].label}${condition.threshold === 1 ? "" : "s"}`;
     case "match_numeric":
-      return `The ${MATCH_NUMERIC_CATALOG[condition.field].label} is ${numericPhrase(condition.operator, condition.threshold)}`;
+      return `The ${MATCH_NUMERIC_CATALOG[condition.field].label} is ${numericPhrase(condition.operator, condition.threshold, condition.field)}`;
     case "opponent_team_pings":
-      return `The ${OPPONENT_PING_CATALOG[condition.field].label} is ${numericPhrase(condition.operator, condition.threshold)}`;
+      return `The ${OPPONENT_PING_CATALOG[condition.field].label} is ${numericPhrase(condition.operator, condition.threshold, condition.field)}`;
   }
 }
 

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-discord.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-discord.test.ts
@@ -3,6 +3,7 @@ import {
   ParlayConditionSchema,
   PARLAY_SUBJECT_ALIAS_MAX_LENGTH,
   ParlaySubjectsSchema,
+  renderParlayCondition,
 } from "#src/betting/parlay-criteria.ts";
 import { buildSettlementMessage } from "#src/betting/outcome-message.ts";
 import { buildParlayButtons } from "#src/betting/parlay-components.ts";
@@ -172,7 +173,7 @@ describe("parlay Discord experience", () => {
 
   // The parlay result is now a section on the settlement embed rather than its
   // own message, so these assert the embed's parlay fields.
-  test("renders leg actuals, the overall side, positions, and payouts", () => {
+  test("renders leg actuals plus winner profit and loser stake", () => {
     const rendered = parlayEmbed({
       matchId: "NA1_42",
       serverId: "1337623164146155593",
@@ -202,12 +203,24 @@ describe("parlay Discord experience", () => {
           payout: 42,
           outcome: "won",
         },
+        {
+          discordId: "losing-discord-account",
+          side: "YES",
+          stake: 30,
+          grossPayout: 50,
+          payout: 0,
+          outcome: "lost",
+        },
       ],
     });
     expect(rendered).toContain("Parlay — NO (1/2 legs)");
     expect(rendered).toContain("Bryan gets at least 5 kills — 4");
     expect(rendered).toContain("Their team gets first baron — true");
-    expect(rendered).toContain("NO 25 → won, **42 BB**");
+    expect(rendered).toContain("PARLAY WINNERS");
+    expect(rendered).toContain("<@test-discord-account> bet 25BB, won 17BB");
+    expect(rendered).toContain("PARLAY LOSERS");
+    expect(rendered).toContain("<@losing-discord-account> bet 30BB, lost 30BB");
+    expect(rendered).not.toContain("NO 25");
   });
 
   test("names a void in prose rather than leaking the enum", () => {
@@ -218,10 +231,56 @@ describe("parlay Discord experience", () => {
       voidReason: "expired",
       messageRefs: [],
       legs: [],
-      bets: [],
+      bets: [
+        {
+          discordId: "refunded-discord-account",
+          side: "YES",
+          stake: 3000,
+          grossPayout: 5000,
+          payout: 3000,
+          outcome: "refunded",
+        },
+      ],
     });
     expect(rendered).toContain("Parlay — voided (the game never resolved)");
+    expect(rendered).toContain(
+      "PARLAY REFUNDS: **3,000BB** across 1 parlay (the game never resolved).",
+    );
+    expect(rendered).not.toContain("refunded-discord-account");
     expect(rendered).not.toContain("expired");
+  });
+
+  test("formats legacy duration thresholds and leg results as MM:SS", () => {
+    const durationCondition = ParlayConditionSchema.parse({
+      kind: "participant_numeric",
+      subject: "P1",
+      field: "timePlayed",
+      operator: "gte",
+      threshold: 3661,
+    });
+    const rendered = parlayEmbed({
+      matchId: "NA1_42",
+      serverId: "1337623164146155593",
+      yesResult: true,
+      voidReason: undefined,
+      messageRefs: [],
+      legs: [
+        {
+          condition: durationCondition,
+          rendered: renderParlayCondition(durationCondition, subjects),
+          actualValue: 3662,
+          passed: true,
+        },
+        {
+          condition: objectiveCondition,
+          rendered: "Their team gets first baron",
+          actualValue: true,
+          passed: true,
+        },
+      ],
+      bets: [],
+    });
+    expect(rendered).toContain("at least 61:01 time played — 61:02");
   });
 
   // Merging the parlay into the outcome embed made Discord's 6000-character

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
@@ -245,13 +245,14 @@ async function generateAndPersistDefinition(
 
   // Pass one: which legs, no numbers.
   const proposed = await call(
-    parlayProposalSchemaFor(setup.subjects),
+    parlayProposalSchemaFor(setup.subjects, setup.context.shortlist),
     buildParlayProposalPrompt(setup.context),
     "bryan_bucks_parlay_proposal",
   );
-  const proposal = parlayProposalSchemaFor(setup.subjects).parse(
-    proposed.object,
-  );
+  const proposal = parlayProposalSchemaFor(
+    setup.subjects,
+    setup.context.shortlist,
+  ).parse(proposed.object);
   deadline.throwIfAborted();
 
   // The one history snapshot that both the thresholds and the price come from.

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-line.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-line.ts
@@ -10,6 +10,7 @@ import {
 } from "#src/betting/parlay-criteria.ts";
 import { formatDecimalOdds } from "#src/betting/parlay-odds.ts";
 import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 /**
  * The parlay market message.
@@ -63,7 +64,7 @@ function headerLines(input: {
   return [
     "🎲 **Bryan Bucks Parlay** — every leg must hit for YES",
     ...renderParlay(input.criteria, input.subjects).map(
-      (leg, index) => `${(index + 1).toString()}. ${leg}`,
+      (leg, index) => `${formatInteger(index + 1)}. ${leg}`,
     ),
   ];
 }
@@ -99,7 +100,8 @@ function positionLines(positions: readonly ParlayPosition[]): string[] {
     }
     const names = held
       .map(
-        (position) => `<@${position.discordId}> ${position.stake.toString()}`,
+        (position) =>
+          `<@${position.discordId}> ${formatInteger(position.stake)}`,
       )
       .join(" · ");
     lines.push(`**${side}** ${names}`);
@@ -139,7 +141,7 @@ export function buildParlayContent(input: {
       "",
       status,
       ...positionLines(shown),
-      ...(hidden > 0 ? [`…and ${hidden.toString()} more.`] : []),
+      ...(hidden > 0 ? [`…and ${formatInteger(hidden)} more.`] : []),
     ];
     const chunks = splitMessageIntoChunks(lines.join("\n"));
     const message = chunks[0];

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-model-schema.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-model-schema.ts
@@ -11,6 +11,12 @@ import {
   PARLAY_HISTORY_COLUMNS,
   TEAM_OBJECTIVE_HISTORY_COLUMNS,
 } from "#src/betting/parlay-stat-fields.ts";
+import {
+  candidateTargetKey,
+  ParlayCandidateTargetSchema,
+  type ParlayCandidateTarget,
+  type ParlayShortlist,
+} from "#src/betting/parlay-shortlist.ts";
 import { proposalConditionIssues } from "#src/betting/parlay-proposal-validation.ts";
 import {
   GeneratedParlaySchema,
@@ -100,9 +106,63 @@ const ModelParlayProposalSchema = z.strictObject({
 });
 
 export type ModelParlayProposal = z.infer<typeof ModelParlayProposalSchema>;
+type ModelParlayProposalCondition = ModelParlayProposal["conditions"][number];
 
 type ModelParlayCondition = z.infer<typeof ModelParlayConditionSchema>;
 type ModelGeneratedParlay = z.infer<typeof ModelGeneratedParlaySchema>;
+
+function proposalCandidateTarget(
+  condition: ModelParlayProposalCondition,
+): ParlayCandidateTarget | undefined {
+  let candidate: unknown;
+  switch (condition.kind) {
+    case "participant_numeric":
+      candidate = {
+        kind: condition.kind,
+        subject: condition.subject,
+        participantNumericField: condition.participantNumericField,
+      };
+      break;
+    case "team_boolean":
+      candidate = {
+        kind: condition.kind,
+        team: condition.team,
+        teamBooleanField: condition.teamBooleanField,
+      };
+      break;
+    case "team_objective_kills":
+      candidate = {
+        kind: condition.kind,
+        team: condition.team,
+        objective: condition.objective,
+      };
+      break;
+    case "match_numeric":
+      candidate = {
+        kind: condition.kind,
+        matchNumericField: condition.matchNumericField,
+      };
+      break;
+    case "opponent_team_pings":
+      candidate = {
+        kind: condition.kind,
+        opponentPingField: condition.opponentPingField,
+      };
+      break;
+  }
+  const result = ParlayCandidateTargetSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
+}
+
+function shortlistConditionIssues(
+  condition: ModelParlayProposalCondition,
+  allowedTargets: ReadonlySet<string>,
+): string[] {
+  const target = proposalCandidateTarget(condition);
+  return target !== undefined && allowedTargets.has(candidateTargetKey(target))
+    ? []
+    : ["Condition target is not in the match shortlist"];
+}
 
 function canonicalConditionCandidate(condition: ModelParlayCondition): unknown {
   switch (condition.kind) {
@@ -345,13 +405,20 @@ export function generatedParlaySchemaFor(
 /** Pass-one schema: legs only, restricted to subjects actually in this game. */
 export function parlayProposalSchemaFor(
   subjects: readonly ParlaySubject[],
+  shortlist: ParlayShortlist,
 ): z.ZodType<ModelParlayProposal> {
   const selected = new Set(subjects.map((subject) => subject.key));
+  const allowedTargets = new Set(
+    shortlist.candidates.map((candidate) => candidateTargetKey(candidate)),
+  );
   return ModelParlayProposalSchema.superRefine((proposal, context) => {
     const covered = new Set<string>();
     const targets = new Set<string>();
     for (const [index, condition] of proposal.conditions.entries()) {
-      for (const message of proposalConditionIssues(condition, targets)) {
+      for (const message of [
+        ...proposalConditionIssues(condition, targets),
+        ...shortlistConditionIssues(condition, allowedTargets),
+      ]) {
         context.addIssue({
           code: "custom",
           path: ["conditions", index],

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-prompt.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-prompt.test.ts
@@ -3,6 +3,7 @@ import {
   ParlayGenerationContextSchema,
   buildParlayProposalPrompt,
 } from "#src/betting/parlay-prompt.ts";
+import { buildParlayShortlist } from "#src/betting/parlay-shortlist.ts";
 
 const context = ParlayGenerationContextSchema.parse({
   queue: "solo",
@@ -43,14 +44,21 @@ const context = ParlayGenerationContextSchema.parse({
       },
     },
   ],
+  shortlist: buildParlayShortlist({
+    matchId: "NA1_prompt",
+    subjects: [{ key: "P1", lane: "adc", tags: ["Assassin"] }],
+  }),
 });
 
 describe("parlay prompt", () => {
-  test("renders deterministically with the complete closed catalog", () => {
+  test("renders deterministically with exactly the match shortlist", () => {
     const first = buildParlayProposalPrompt(context);
     expect(buildParlayProposalPrompt(context)).toBe(first);
-    expect(first).toContain('"participantNumeric"');
-    expect(first).toContain('"gameEndedInEarlySurrender"');
+    expect(first).toContain("Allowed candidate targets (exactly 20)");
+    for (const candidate of context.shortlist.candidates) {
+      expect(first).toContain(JSON.stringify(candidate));
+    }
+    expect(first).not.toContain('"gameEndedInEarlySurrender"');
     expect(first).toContain("Every selected tracked subject");
     expect(first).toContain("every irrelevant slot to null");
     expect(first).not.toContain("puuid");

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-prompt.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-prompt.ts
@@ -1,22 +1,22 @@
 import { z } from "zod";
 import {
+  getChampionTags,
   rankToString,
   type LoadingScreenData,
   type QueueType,
 } from "@scout-for-lol/data";
 import { createLogger } from "#src/logger.ts";
-import { promptFieldCatalog } from "#src/betting/parlay-catalog.ts";
 import type { ParlaySubject } from "#src/betting/parlay-criteria.ts";
 import {
-  groundedParticipantFields,
-  groundedTeamObjectives,
-} from "#src/betting/parlay-stat-fields.ts";
+  buildParlayShortlist,
+  ParlayShortlistSchema,
+} from "#src/betting/parlay-shortlist.ts";
 import { fetchRecentQueueGamesForPuuids } from "#src/reports/duckdb/lake-reads.ts";
 import { ReportQueryTimeoutError } from "#src/reports/duckdb/instance.ts";
 
 const logger = createLogger("betting-parlay-prompt");
 
-export const PARLAY_PROMPT_VERSION = "2";
+export const PARLAY_PROMPT_VERSION = "3";
 const HISTORY_TIMEOUT_MS = 1500;
 const HISTORY_LIMIT = 30;
 
@@ -53,6 +53,7 @@ export const ParlayGenerationContextSchema = z.strictObject({
     .max(5),
   lobby: z.array(LobbyParticipantSchema).length(10),
   history: z.array(SubjectHistorySchema).min(1).max(5),
+  shortlist: ParlayShortlistSchema,
 });
 
 export type ParlayGenerationContext = z.infer<
@@ -154,13 +155,14 @@ export async function buildParlayGenerationContext(input: {
   subjects: readonly ParlaySubject[];
 }): Promise<ParlayGenerationContext | undefined> {
   if (input.loadingScreenData.layout !== "standard") return;
+  const loadingScreenData = input.loadingScreenData;
   const selectedTeam = input.selectedTeamId === 100 ? "blue" : "red";
   const subjectByPuuid = new Map(
     input.subjects.map((subject) => [subject.puuid, subject]),
   );
   let selectedAnonymous = 0;
   let opponentAnonymous = 0;
-  const lobby = input.loadingScreenData.participants.map((participant) => {
+  const lobby = loadingScreenData.participants.map((participant) => {
     const subject =
       participant.puuid === null
         ? undefined
@@ -180,7 +182,7 @@ export async function buildParlayGenerationContext(input: {
     });
   });
   const championByPuuid = new Map(
-    input.loadingScreenData.participants.flatMap((participant) =>
+    loadingScreenData.participants.flatMap((participant) =>
       participant.puuid === null
         ? []
         : [[participant.puuid, participant.championName]],
@@ -192,11 +194,33 @@ export async function buildParlayGenerationContext(input: {
     subjects: input.subjects,
     championByPuuid,
   });
+  const shortlistSubjects = await Promise.all(
+    input.subjects.map(async (subject) => {
+      const participant = loadingScreenData.participants.find(
+        (candidate) => candidate.puuid === subject.puuid,
+      );
+      if (participant?.lane === undefined) {
+        throw new Error(`No inferred lane for parlay subject ${subject.key}`);
+      }
+      const tags = await getChampionTags(participant.championName);
+      if (tags === undefined) {
+        throw new Error(
+          `No bundled champion tags for ${participant.championName}`,
+        );
+      }
+      return { key: subject.key, lane: participant.lane, tags };
+    }),
+  );
+  const shortlist = buildParlayShortlist({
+    matchId: input.matchId,
+    subjects: shortlistSubjects,
+  });
   return ParlayGenerationContextSchema.parse({
     queue: input.queue,
     selectedSubjects: input.subjects.map((subject) => subject.key),
     lobby,
     history,
+    shortlist,
   });
 }
 
@@ -213,19 +237,23 @@ export const PARLAY_SYSTEM_PROMPT = `You create one entertaining but plausible L
 export function buildParlayProposalPrompt(
   context: ParlayGenerationContext,
 ): string {
+  const anonymousContext = {
+    queue: context.queue,
+    selectedSubjects: context.selectedSubjects,
+    lobby: context.lobby,
+    history: context.history,
+  };
   return [
     "Choose 2-6 distinct conditions for one fixed-odds parlay. Do NOT choose any numbers yet.",
     "Every selected tracked subject must appear in at least one participant condition.",
     "Do not repeat a subject/field or team/objective target, even with another operator.",
     "Pick the operator for each condition: gte for an over, lte for an under.",
     "Aim for a mix: some ordinary lines, some genuinely surprising ones.",
-    "Opponent ping conditions are about the ENEMY team and are a good source of the surprising kind.",
+    "Use only one of the exact candidate targets supplied below. A target is bound to its listed subject or team.",
     "Every condition must include every structured slot. Fill the slots used by its kind and set every irrelevant slot to null.",
     "Do not combine incompatible win booleans or first-objective true with zero objective kills.",
-    `Anonymous lobby and recent form:\n${JSON.stringify(context)}`,
-    `Complete allowed field catalog:\n${JSON.stringify(
-      promptFieldCatalog(groundedParticipantFields(), groundedTeamObjectives()),
-    )}`,
+    `Anonymous lobby and recent form:\n${JSON.stringify(anonymousContext)}`,
+    `Allowed candidate targets (exactly 20):\n${JSON.stringify(context.shortlist.candidates)}`,
   ].join("\n\n");
 }
 

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-shortlist.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-shortlist.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+import {
+  ChampionTagSchema,
+  LaneSchema,
+  type ChampionTag,
+  type Lane,
+} from "@scout-for-lol/data";
+import {
+  buildParlayShortlist,
+  eligibleParticipantFields,
+  parlayPingBucket,
+  type ParlayShortlistSubject,
+} from "#src/betting/parlay-shortlist.ts";
+
+const SUBJECTS: readonly ParlayShortlistSubject[] = [
+  { key: "P1", lane: "top", tags: ["Fighter", "Tank"] },
+  { key: "P2", lane: "jungle", tags: ["Assassin"] },
+  { key: "P3", lane: "middle", tags: ["Mage"] },
+  { key: "P4", lane: "adc", tags: ["Marksman"] },
+  { key: "P5", lane: "support", tags: ["Support", "Mage"] },
+];
+
+describe("parlay shortlist", () => {
+  test("is ordered, deterministic, and independent of subject source order", () => {
+    const input = { matchId: "NA1_123", subjects: SUBJECTS };
+    const first = buildParlayShortlist(input);
+
+    expect(buildParlayShortlist(input)).toEqual(first);
+    expect(
+      buildParlayShortlist({
+        matchId: input.matchId,
+        subjects: SUBJECTS.toReversed().map((subject) => ({
+          ...subject,
+          tags: subject.tags.toReversed(),
+        })),
+      }),
+    ).toEqual(first);
+    expect(
+      buildParlayShortlist({ ...input, matchId: "NA1_124" }).candidates,
+    ).not.toEqual(first.candidates);
+  });
+
+  test.each([1, 2, 3, 4, 5])(
+    "allocates exactly 16 player and four global targets across %i subjects",
+    (subjectCount) => {
+      const subjects = SUBJECTS.slice(0, subjectCount);
+      const shortlist = buildParlayShortlist({
+        matchId: `NA1_${subjectCount.toString()}`,
+        subjects,
+      });
+      const players = shortlist.candidates.filter(
+        (candidate) => candidate.kind === "participant_numeric",
+      );
+      const globals = shortlist.candidates.filter(
+        (candidate) => candidate.kind !== "participant_numeric",
+      );
+
+      expect(players).toHaveLength(16);
+      expect(globals).toHaveLength(4);
+      expect(
+        new Set(
+          shortlist.candidates.map((candidate) => JSON.stringify(candidate)),
+        ).size,
+      ).toBe(20);
+      const counts = subjects.map(
+        (subject) =>
+          players.filter((candidate) => candidate.subject === subject.key)
+            .length,
+      );
+      expect(Math.max(...counts) - Math.min(...counts)).toBeLessThanOrEqual(1);
+      expect(counts.every((count) => count > 0)).toBe(true);
+    },
+  );
+
+  test("uses only the union of universal, lane, and champion-tag fields", () => {
+    const shortlist = buildParlayShortlist({
+      matchId: "NA1_eligibility",
+      subjects: SUBJECTS,
+    });
+    for (const subject of SUBJECTS) {
+      const eligible = new Set(eligibleParticipantFields(subject));
+      const selected = shortlist.candidates
+        .filter((candidate) => candidate.kind === "participant_numeric")
+        .filter((candidate) => candidate.subject === subject.key);
+      expect(
+        selected.every((candidate) =>
+          eligible.has(candidate.participantNumericField),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("accepts coarse Support-tag healing eligibility", () => {
+    expect(
+      eligibleParticipantFields({ lane: "middle", tags: ["Support"] }),
+    ).toContain("totalHealsOnTeammates");
+  });
+
+  const laneTagCases = LaneSchema.options.flatMap((lane: Lane) =>
+    ChampionTagSchema.options.map((tag: ChampionTag) => ({ lane, tag })),
+  );
+
+  test.each(laneTagCases)(
+    "keeps at least 16 eligible fields for $lane $tag",
+    ({ lane, tag }) => {
+      expect(
+        eligibleParticipantFields({ lane, tags: [tag] }).length,
+      ).toBeGreaterThanOrEqual(16);
+    },
+  );
+
+  test("admits pings in exactly one hash bucket and selects one subtype deterministically", () => {
+    const representativeByBucket = new Map<number, string>();
+    for (let index = 0; representativeByBucket.size < 16; index += 1) {
+      const matchId = `NA1_ping_${index.toString()}`;
+      representativeByBucket.set(parlayPingBucket(matchId), matchId);
+    }
+    expect(
+      [...representativeByBucket.keys()].toSorted((a, b) => a - b),
+    ).toEqual(Array.from({ length: 16 }, (_, index) => index));
+
+    for (const [bucket, matchId] of representativeByBucket) {
+      const first = buildParlayShortlist({ matchId, subjects: SUBJECTS });
+      const pings = first.candidates.filter(
+        (candidate) => candidate.kind === "opponent_team_pings",
+      );
+      expect(pings).toHaveLength(bucket === 0 ? 1 : 0);
+      expect(
+        buildParlayShortlist({ matchId, subjects: SUBJECTS }).candidates.filter(
+          (candidate) => candidate.kind === "opponent_team_pings",
+        ),
+      ).toEqual(pings);
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-shortlist.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-shortlist.ts
@@ -1,0 +1,402 @@
+import { z } from "zod";
+import {
+  ChampionTagSchema,
+  LaneSchema,
+  type ChampionTag,
+  type Lane,
+} from "@scout-for-lol/data";
+import {
+  MatchNumericFieldSchema,
+  OpponentPingFieldSchema,
+  TeamBooleanFieldSchema,
+  TeamObjectiveSchema,
+  type OpponentPingField,
+} from "#src/betting/parlay-catalog.ts";
+
+export const PARLAY_SHORTLIST_VERSION = "1";
+const PLAYER_TARGET_COUNT = 16;
+const GLOBAL_TARGET_COUNT = 4;
+
+export const ShortlistParticipantFieldSchema = z.enum([
+  "assists",
+  "champExperience",
+  "champLevel",
+  "damageDealtToObjectives",
+  "damageDealtToTurrets",
+  "damageSelfMitigated",
+  "deaths",
+  "detectorWardsPlaced",
+  "goldEarned",
+  "goldSpent",
+  "kills",
+  "longestTimeSpentLiving",
+  "magicDamageDealtToChampions",
+  "neutralMinionsKilled",
+  "physicalDamageDealtToChampions",
+  "timeCCingOthers",
+  "totalDamageDealt",
+  "totalDamageDealtToChampions",
+  "totalDamageTaken",
+  "totalHeal",
+  "totalHealsOnTeammates",
+  "totalMinionsKilled",
+  "totalTimeSpentDead",
+  "visionScore",
+  "visionWardsBoughtInGame",
+  "wardsKilled",
+  "wardsPlaced",
+]);
+export type ShortlistParticipantField = z.infer<
+  typeof ShortlistParticipantFieldSchema
+>;
+
+const PlayerCandidateTargetSchema = z.strictObject({
+  kind: z.literal("participant_numeric"),
+  subject: z.string().regex(/^P[1-5]$/),
+  participantNumericField: ShortlistParticipantFieldSchema,
+});
+
+const TeamBooleanCandidateTargetSchema = z.strictObject({
+  kind: z.literal("team_boolean"),
+  team: z.literal("selected"),
+  teamBooleanField: TeamBooleanFieldSchema,
+});
+
+const TeamObjectiveCandidateTargetSchema = z.strictObject({
+  kind: z.literal("team_objective_kills"),
+  team: z.literal("selected"),
+  objective: TeamObjectiveSchema.exclude(["riftHerald"]),
+});
+
+const MatchCandidateTargetSchema = z.strictObject({
+  kind: z.literal("match_numeric"),
+  matchNumericField: MatchNumericFieldSchema,
+});
+
+const PingCandidateTargetSchema = z.strictObject({
+  kind: z.literal("opponent_team_pings"),
+  opponentPingField: OpponentPingFieldSchema,
+});
+
+export const ParlayCandidateTargetSchema = z.discriminatedUnion("kind", [
+  PlayerCandidateTargetSchema,
+  TeamBooleanCandidateTargetSchema,
+  TeamObjectiveCandidateTargetSchema,
+  MatchCandidateTargetSchema,
+  PingCandidateTargetSchema,
+]);
+export type ParlayCandidateTarget = z.infer<typeof ParlayCandidateTargetSchema>;
+
+export const ParlayShortlistSchema = z
+  .strictObject({
+    version: z.literal(PARLAY_SHORTLIST_VERSION),
+    candidates: z.array(ParlayCandidateTargetSchema).length(20),
+  })
+  .superRefine((shortlist, context) => {
+    const playerCount = shortlist.candidates.filter(
+      (candidate) => candidate.kind === "participant_numeric",
+    ).length;
+    if (playerCount !== PLAYER_TARGET_COUNT) {
+      context.addIssue({
+        code: "custom",
+        path: ["candidates"],
+        message: `Shortlist must contain ${PLAYER_TARGET_COUNT.toString()} player targets`,
+      });
+    }
+    if (shortlist.candidates.length - playerCount !== GLOBAL_TARGET_COUNT) {
+      context.addIssue({
+        code: "custom",
+        path: ["candidates"],
+        message: `Shortlist must contain ${GLOBAL_TARGET_COUNT.toString()} global targets`,
+      });
+    }
+    const keys = shortlist.candidates.map((candidate) =>
+      candidateTargetKey(candidate),
+    );
+    if (new Set(keys).size !== keys.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["candidates"],
+        message: "Shortlist targets must be unique",
+      });
+    }
+    const pingCount = shortlist.candidates.filter(
+      (candidate) => candidate.kind === "opponent_team_pings",
+    ).length;
+    if (pingCount > 1) {
+      context.addIssue({
+        code: "custom",
+        path: ["candidates"],
+        message: "Shortlist may contain at most one opponent-ping target",
+      });
+    }
+  });
+export type ParlayShortlist = z.infer<typeof ParlayShortlistSchema>;
+
+export const ParlayShortlistSubjectSchema = z.strictObject({
+  key: z.string().regex(/^P[1-5]$/),
+  lane: LaneSchema,
+  tags: z.array(ChampionTagSchema).min(1),
+});
+export type ParlayShortlistSubject = z.infer<
+  typeof ParlayShortlistSubjectSchema
+>;
+
+const UNIVERSAL_FIELDS: readonly ShortlistParticipantField[] = [
+  "assists",
+  "deaths",
+  "kills",
+  "goldEarned",
+  "goldSpent",
+  "longestTimeSpentLiving",
+  "totalDamageDealtToChampions",
+  "totalDamageTaken",
+  "totalTimeSpentDead",
+  "visionScore",
+  "wardsPlaced",
+];
+
+const LANE_FIELDS: Record<Lane, readonly ShortlistParticipantField[]> = {
+  top: [
+    "champExperience",
+    "champLevel",
+    "damageDealtToTurrets",
+    "damageSelfMitigated",
+    "totalDamageDealt",
+    "totalHeal",
+    "totalMinionsKilled",
+  ],
+  jungle: [
+    "damageDealtToObjectives",
+    "detectorWardsPlaced",
+    "neutralMinionsKilled",
+    "timeCCingOthers",
+    "totalDamageDealt",
+    "totalHeal",
+    "wardsKilled",
+  ],
+  middle: [
+    "champExperience",
+    "champLevel",
+    "damageDealtToTurrets",
+    "timeCCingOthers",
+    "totalDamageDealt",
+    "totalMinionsKilled",
+  ],
+  adc: [
+    "champExperience",
+    "champLevel",
+    "damageDealtToTurrets",
+    "totalDamageDealt",
+    "totalMinionsKilled",
+  ],
+  support: [
+    "detectorWardsPlaced",
+    "timeCCingOthers",
+    "totalHeal",
+    "totalHealsOnTeammates",
+    "visionWardsBoughtInGame",
+    "wardsKilled",
+  ],
+};
+
+const TAG_FIELDS: Record<ChampionTag, readonly ShortlistParticipantField[]> = {
+  Assassin: ["damageDealtToTurrets", "totalDamageDealt", "totalMinionsKilled"],
+  Fighter: [
+    "damageDealtToObjectives",
+    "damageDealtToTurrets",
+    "damageSelfMitigated",
+    "physicalDamageDealtToChampions",
+    "totalDamageDealt",
+    "totalHeal",
+    "totalMinionsKilled",
+  ],
+  Mage: ["magicDamageDealtToChampions", "timeCCingOthers", "totalDamageDealt"],
+  Marksman: [
+    "damageDealtToTurrets",
+    "physicalDamageDealtToChampions",
+    "totalDamageDealt",
+    "totalMinionsKilled",
+  ],
+  Support: [
+    "detectorWardsPlaced",
+    "timeCCingOthers",
+    "totalHeal",
+    "totalHealsOnTeammates",
+    "visionWardsBoughtInGame",
+    "wardsKilled",
+  ],
+  Tank: ["damageSelfMitigated", "timeCCingOthers", "totalHeal"],
+};
+
+const GLOBAL_TARGETS: readonly ParlayCandidateTarget[] = [
+  { kind: "team_boolean", team: "selected", teamBooleanField: "win" },
+  { kind: "team_objective_kills", team: "selected", objective: "baron" },
+  {
+    kind: "team_objective_kills",
+    team: "selected",
+    objective: "champion",
+  },
+  { kind: "team_objective_kills", team: "selected", objective: "dragon" },
+  {
+    kind: "team_objective_kills",
+    team: "selected",
+    objective: "inhibitor",
+  },
+  { kind: "team_objective_kills", team: "selected", objective: "tower" },
+  { kind: "match_numeric", matchNumericField: "gameDuration" },
+];
+
+function hash(value: string): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(value);
+  return hasher.digest("hex");
+}
+
+function seedForMatch(matchId: string): string {
+  return `scout-parlay-shortlist:${PARLAY_SHORTLIST_VERSION}:${matchId}`;
+}
+
+function ranked<T>(
+  values: readonly T[],
+  seed: string,
+  scope: string,
+  key: (value: T) => string,
+): T[] {
+  return [...values]
+    .toSorted((left, right) => key(left).localeCompare(key(right)))
+    .map((value) => ({
+      value,
+      key: key(value),
+      rank: hash(`${seed}\0${scope}\0${key(value)}`),
+    }))
+    .toSorted(
+      (left, right) =>
+        left.rank.localeCompare(right.rank) ||
+        left.key.localeCompare(right.key),
+    )
+    .map(({ value }) => value);
+}
+
+export function candidateTargetKey(candidate: ParlayCandidateTarget): string {
+  switch (candidate.kind) {
+    case "participant_numeric":
+      return `${candidate.subject}:${candidate.participantNumericField}`;
+    case "team_boolean":
+      return `team:${candidate.teamBooleanField}`;
+    case "team_objective_kills":
+      return `team:${candidate.objective}:kills`;
+    case "match_numeric":
+      return `match:${candidate.matchNumericField}`;
+    case "opponent_team_pings":
+      return `opponent:${candidate.opponentPingField}`;
+  }
+}
+
+export function eligibleParticipantFields(input: {
+  lane: Lane;
+  tags: readonly ChampionTag[];
+}): ShortlistParticipantField[] {
+  return [
+    ...new Set([
+      ...UNIVERSAL_FIELDS,
+      ...LANE_FIELDS[input.lane],
+      ...input.tags.flatMap((tag) => TAG_FIELDS[tag]),
+    ]),
+  ].toSorted();
+}
+
+/** Exactly one SHA-256 bucket admits a ping target. */
+export function parlayPingBucket(matchId: string): number {
+  return Number.parseInt(
+    hash(`${seedForMatch(matchId)}\0ping-gate`)[0] ?? "",
+    16,
+  );
+}
+
+function selectedPingTarget(
+  matchId: string,
+  seed: string,
+): ParlayCandidateTarget | undefined {
+  if (parlayPingBucket(matchId) !== 0) return;
+  const field = ranked(
+    OpponentPingFieldSchema.options,
+    seed,
+    "ping-type",
+    (value: OpponentPingField) => value,
+  )[0];
+  if (field === undefined) {
+    throw new Error("Opponent ping catalog is empty");
+  }
+  return { kind: "opponent_team_pings", opponentPingField: field };
+}
+
+export function buildParlayShortlist(input: {
+  matchId: string;
+  subjects: readonly ParlayShortlistSubject[];
+}): ParlayShortlist {
+  const subjects = z
+    .array(ParlayShortlistSubjectSchema)
+    .min(1)
+    .max(5)
+    .parse(input.subjects)
+    .toSorted((left, right) => left.key.localeCompare(right.key));
+  if (
+    new Set(subjects.map((subject) => subject.key)).size !== subjects.length
+  ) {
+    throw new Error("Parlay shortlist subjects must be unique");
+  }
+
+  const seed = seedForMatch(input.matchId);
+  const baseAllocation = Math.floor(PLAYER_TARGET_COUNT / subjects.length);
+  const remainder = PLAYER_TARGET_COUNT % subjects.length;
+  const extraSubjects = new Set(
+    ranked(subjects, seed, "subject-allocation", (subject) => subject.key)
+      .slice(0, remainder)
+      .map((subject) => subject.key),
+  );
+  const selectedPlayerCandidates = subjects.flatMap((subject) => {
+    const count = baseAllocation + (extraSubjects.has(subject.key) ? 1 : 0);
+    const eligible = eligibleParticipantFields(subject);
+    if (eligible.length < count) {
+      throw new Error(
+        `${subject.key} has ${eligible.length.toString()} eligible fields but needs ${count.toString()}`,
+      );
+    }
+    return ranked(eligible, seed, `player:${subject.key}`, (field) => field)
+      .slice(0, count)
+      .map((field) => ({
+        kind: "participant_numeric" as const,
+        subject: subject.key,
+        participantNumericField: field,
+      }));
+  });
+  const playerCandidates = ranked(
+    selectedPlayerCandidates,
+    seed,
+    "player-order",
+    candidateTargetKey,
+  );
+
+  const ping = selectedPingTarget(input.matchId, seed);
+  const selectedGlobals = ranked(
+    GLOBAL_TARGETS,
+    seed,
+    "global",
+    candidateTargetKey,
+  ).slice(
+    0,
+    ping === undefined ? GLOBAL_TARGET_COUNT : GLOBAL_TARGET_COUNT - 1,
+  );
+  const globals = ranked(
+    [...selectedGlobals, ...(ping === undefined ? [] : [ping])],
+    seed,
+    "global-order",
+    candidateTargetKey,
+  );
+
+  return ParlayShortlistSchema.parse({
+    version: PARLAY_SHORTLIST_VERSION,
+    candidates: [...playerCandidates, ...globals],
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/peek-pass-button.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/peek-pass-button.ts
@@ -21,6 +21,7 @@ import {
   type PeekPassPrice,
   type PeekPassQuoteResult,
 } from "#src/betting/peek-pass.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 export type PeekPassButtonInteraction = {
   customId: string;
@@ -53,7 +54,7 @@ function quoteButton(input: {
             quotedPrice: input.quote.price,
           }),
         )
-        .setLabel(`Buy for ${input.quote.price.toString()} BB`)
+        .setLabel(`Buy for ${formatInteger(input.quote.price)} BB`)
         .setStyle(ButtonStyle.Primary),
     ),
   ];
@@ -73,7 +74,7 @@ export function renderPeekPassQuote(
       };
     case "insufficient":
       return {
-        content: `A peek pass costs at least **5 BB**. Your balance is **${result.balance.toString()} BB**.`,
+        content: `A peek pass costs at least **5 BB**. Your balance is **${formatInteger(result.balance)} BB**.`,
         components: [],
       };
     case "active":
@@ -87,7 +88,7 @@ export function renderPeekPassQuote(
       );
       return {
         content:
-          `A **${PEEK_PASS_DURATION_LABEL} peek pass** costs **${result.quote.price.toString()} BB** for you right now. ` +
+          `A **${PEEK_PASS_DURATION_LABEL} peek pass** costs **${formatInteger(result.quote.price)} BB** for you right now. ` +
           `This quote expires ${relativeTime(expiresAt)}.`,
         components: quoteButton({
           ownerId,
@@ -152,7 +153,7 @@ export async function handlePeekPassButton(
       await interaction.editReply({
         content:
           `✅ Peek pass active until ${relativeTime(result.expiresAt)}. ` +
-          `Paid **${result.price.toString()} BB** · balance **${result.balanceAfter.toString()} BB**. Use \`/bb peek game:<player>\`.`,
+          `Paid **${formatInteger(result.price)} BB** · balance **${formatInteger(result.balanceAfter)} BB**. Use \`/bb peek game:<player>\`.`,
         components: [],
       });
       return;

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-line.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-line.test.ts
@@ -233,7 +233,7 @@ describe("bucksPrematchSummary", () => {
     });
     const content = withBucksDigest(base, summary);
 
-    expect(summary).toContain("2147483647 → matched **1073741824**");
+    expect(summary).toContain("2,147,483,647 → matched **1,073,741,824**");
     expect(summary).toContain("more.");
     expect(summary.length).toBeLessThanOrEqual(digestBudgetFor(base));
     expect(content.length).toBeLessThanOrEqual(2000);

--- a/packages/scout-for-lol/packages/backend/src/betting/prematch-line.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/prematch-line.ts
@@ -5,6 +5,7 @@ import type {
 } from "@scout-for-lol/data";
 import { BETTING_TEAM_IDS, outcomeLabel } from "#src/betting/team.ts";
 import type { OutcomeFraming } from "#src/betting/team.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 /**
  * The Bryan Bucks lines appended to a prematch message.
@@ -76,7 +77,7 @@ function openPositionLines(
     const names = side
       .map(
         (position) =>
-          `<@${position.discordId}> ${position.offeredStake.toString()}`,
+          `<@${position.discordId}> ${formatInteger(position.offeredStake)}`,
       )
       .join(" · ");
     lines.push(`**${outcomeLabel(teamId, framing)}** ${names}`);
@@ -96,9 +97,9 @@ function closedPositionLines(
     const allocation = finalAllocation(position);
     const refunded =
       allocation.unmatchedStake > 0
-        ? `, refunded **${allocation.unmatchedStake.toString()}**`
+        ? `, refunded **${formatInteger(allocation.unmatchedStake)}**`
         : "";
-    return `• <@${position.discordId}> ${outcomeLabel(position.teamId, framing)} ${position.offeredStake.toString()} → matched **${allocation.matchedStake.toString()}**${refunded}`;
+    return `• <@${position.discordId}> ${outcomeLabel(position.teamId, framing)} ${formatInteger(position.offeredStake)} → matched **${formatInteger(allocation.matchedStake)}**${refunded}`;
   });
 }
 
@@ -131,7 +132,7 @@ function boundedPositionDigest(input: {
     ];
     const hiddenCount = input.positions.length - visibleCount;
     if (hiddenCount > 0) {
-      candidateLines.push(`…and ${hiddenCount.toString()} more.`);
+      candidateLines.push(`…and ${formatInteger(hiddenCount)} more.`);
     }
     const candidate = candidateLines.join("\n");
     if (candidate.length <= input.maxLength) {
@@ -221,7 +222,7 @@ export function bucksPrematchSummary(input: {
     }),
   }));
   const totalsText = totals
-    .map((side) => `${side.label} **${side.total.toString()} BB**`)
+    .map((side) => `${side.label} **${formatInteger(side.total)} BB**`)
     .join(" · ");
 
   const header = isOpen
@@ -247,7 +248,7 @@ function houseClause(
   }
   const parts = houseMatches.map(
     (match) =>
-      `house **${match.matchedStake.toString()}** on ${outcomeLabel(match.teamId, framing)}`,
+      `house **${formatInteger(match.matchedStake)}** on ${outcomeLabel(match.teamId, framing)}`,
   );
   return ` (${parts.join(", ")})`;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-leaderboard.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-leaderboard.ts
@@ -18,6 +18,7 @@ import {
 } from "#src/league/discord/channel.ts";
 import { createLogger } from "#src/logger.ts";
 import { getErrorMessage } from "#src/utils/errors.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 const logger = createLogger("betting-weekly-leaderboard");
 const MAX_CHUNK_SEND_ATTEMPTS = 3;
@@ -61,7 +62,7 @@ export function formatWeeklyBucksLeaderboard(
   const body = rankBucksLeaderboard(rows)
     .map(
       (row) =>
-        `**${row.rank.toString()}.** <@${row.discordId}> — **${row.balance.toString()} BB**`,
+        `**${formatInteger(row.rank)}.** <@${row.discordId}> — **${formatInteger(row.balance)} BB**`,
     )
     .join("\n");
   return splitMessageIntoChunks(

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-ask.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-ask.ts
@@ -12,6 +12,7 @@ import {
   runBucksAskAgent,
 } from "#src/betting/ask-agent.ts";
 import { BucksAskDatasetTooLargeError } from "#src/betting/ask-analytics.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 import { formatBucksAskPublishCustomId } from "#src/betting/ask-custom-id.ts";
 import { tryStartBucksAsk } from "#src/betting/ask-rate-limit.ts";
 import { classifyLlmProviderIssue } from "#src/alerts/provider-metrics.ts";
@@ -52,7 +53,7 @@ export async function replyBucksAsk(
   );
   if (!parsedQuestion.success) {
     await interaction.editReply({
-      content: `Ask a Bryan Bucks question between 1 and ${BB_ASK_MAX_QUESTION_LENGTH.toString()} characters.`,
+      content: `Ask a Bryan Bucks question between 1 and ${formatInteger(BB_ASK_MAX_QUESTION_LENGTH)} characters.`,
     });
     return;
   }

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
@@ -25,8 +25,8 @@ describe("/bb history labels", () => {
       entries: [
         {
           id: 2,
-          delta: -1,
-          balanceAfter: 9,
+          delta: -3000,
+          balanceAfter: 12_345,
           kind: BucksLedgerKindSchema.parse("cancel_fee"),
           matchId: "NA1_1",
           context: "{}",
@@ -50,6 +50,9 @@ describe("/bb history labels", () => {
     });
     expect(rendered.content).toContain("house cut on payout");
     expect(rendered.content).toContain("cancellation fee");
+    expect(rendered.content).toContain("`-3,000`");
+    expect(rendered.content).toContain("12,345 BB");
+    expect(rendered.content).toContain("NA1_1");
     // History is an audit trail, not a place to re-explain the fee schedule.
     expect(rendered.content).not.toContain("20%");
     expect(rendered.content).not.toContain("legacy");

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-market.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-market.ts
@@ -12,6 +12,7 @@ import {
   type OutcomeFraming,
 } from "#src/betting/team.ts";
 import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 type OpenBettingPool = {
   matchId: string;
@@ -109,7 +110,7 @@ export function buildOpenMarketSections(
     const sides = sideEntries
       .map(
         (entry) =>
-          `${outcomeLabel(entry.teamId, framing)} **${entry.side.totalStake.toString()} BB** (${entry.side.betCount.toString()})`,
+          `${outcomeLabel(entry.teamId, framing)} **${formatInteger(entry.side.totalStake)} BB** (${formatInteger(entry.side.betCount)})`,
       )
       .join(" · ");
     const selector =

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.ts
@@ -1,4 +1,5 @@
 import { EmbedBuilder } from "discord.js";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 const BUCKS_COLOR = 0x2e_cc_71;
 const CAD_PER_BB = 10;
@@ -98,10 +99,6 @@ export const BB_PRIZES = [
     bbCost: 100,
   },
 ] as const satisfies readonly BbPrize[];
-
-function formatInteger(value: number): string {
-  return value.toLocaleString("en-CA");
-}
 
 export function buildBbPrizesEmbed(): EmbedBuilder {
   const categories = [...new Set(BB_PRIZES.map((prize) => prize.category))];

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -7,6 +7,7 @@ import {
   SEED_GRANT,
 } from "#src/betting/constants.ts";
 import { EARNED_REWARDS } from "#src/betting/earnings.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 import { HOUSE_CUT_PERCENT } from "#src/betting/house-cut.ts";
 import { PEEK_DELAY_MS } from "#src/betting/pool-open.ts";
 import {
@@ -55,12 +56,12 @@ export function buildBbRulesEmbed(): EmbedBuilder {
       {
         name: "Getting Bucks",
         value:
-          `Link your Discord account to a tracked player. A new wallet starts with **${SEED_GRANT.toString()} BB**. ` +
-          `Every eligible game pays **+${EARNED_REWARDS.played.amount.toString()} BB** for playing, ` +
-          `**+${EARNED_REWARDS.win.amount.toString()} BB** for winning, and ` +
-          `**+${EARNED_REWARDS.mvp.amount.toString()} BB** for MVP. ` +
-          `Ranked 5s adds **+${EARNED_REWARDS["ranked 5s bonus"].amount.toString()} BB** and Clash adds ` +
-          `**+${EARNED_REWARDS["clash bonus"].amount.toString()} BB**. ` +
+          `Link your Discord account to a tracked player. A new wallet starts with **${formatInteger(SEED_GRANT)} BB**. ` +
+          `Every eligible game pays **+${formatInteger(EARNED_REWARDS.played.amount)} BB** for playing, ` +
+          `**+${formatInteger(EARNED_REWARDS.win.amount)} BB** for winning, and ` +
+          `**+${formatInteger(EARNED_REWARDS.mvp.amount)} BB** for MVP. ` +
+          `Ranked 5s adds **+${formatInteger(EARNED_REWARDS["ranked 5s bonus"].amount)} BB** and Clash adds ` +
+          `**+${formatInteger(EARNED_REWARDS["clash bonus"].amount)} BB**. ` +
           `Eligible queues: ${BUCKS_EARNING_QUEUES.join(", ")}. ` +
           "League Classic pays the played point but carries no market, because Riot exposes no post-game payload for it.",
       },
@@ -69,7 +70,7 @@ export function buildBbRulesEmbed(): EmbedBuilder {
         value:
           "Bet **WIN** or **LOSE** on the tracked player. When both teams have a tracked player, pick **Blue** or **Red** instead. " +
           "Your amount is a maximum offer: human offers match first at even money, oversubscribed offers match proportionally, " +
-          `and the house then fills up to **${HOUSE_MATCH_LIMIT.toString()} BB** per game if its balance allows. ` +
+          `and the house then fills up to **${formatInteger(HOUSE_MATCH_LIMIT)} BB** per game if its balance allows. ` +
           "Unmatched BB are refunded at close, free. " +
           `Winners get twice their matched stake, less **${cut}%** of matched profit, rounded down. ` +
           `Cancelling before close costs **${cut}%** of the offer, rounded to the nearest BB.`,
@@ -92,7 +93,7 @@ export function buildBbRulesEmbed(): EmbedBuilder {
         name: "Peek passes",
         value:
           `\`/bb pass\` buys **${hours(PEEK_PASS_DURATION_MS)} hours** of private pregame estimates. ` +
-          `The price scales with your balance and how long you have held it, minimum **${MINIMUM_PRICE.toString()} BB**. ` +
+          `The price scales with your balance and how long you have held it, minimum **${formatInteger(MINIMUM_PRICE)} BB**. ` +
           `Then \`/bb peek game:<tracked player>\` once the game has been live for **${minutes(PEEK_DELAY_MS)} minutes**. ` +
           "Estimates are experimental, frozen before the game, and disappear when the market resolves.",
       },

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -52,6 +52,7 @@ import {
   truncateEmbedFieldValue,
 } from "#src/discord/utils/message.ts";
 import { createLogger } from "#src/logger.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
 
 const logger = createLogger("command-bb");
 
@@ -98,15 +99,15 @@ export function buildPersonalBucksEmbed(
     if (position.marketType === "outcome") {
       const amount =
         position.matchedStake === null
-          ? `offered up to ${position.offeredStake.toString()} BB · match pending`
-          : `matched ${position.matchedStake.toString()} BB · refunded ${(position.unmatchedStake ?? 0).toString()} BB`;
+          ? `offered up to ${formatInteger(position.offeredStake)} BB · match pending`
+          : `matched ${formatInteger(position.matchedStake)} BB · refunded ${formatInteger(position.unmatchedStake ?? 0)} BB`;
       return `• **${position.gameAlias} ${position.sideLabel}** — ${amount} · ${timing}`;
     }
-    return `• **${position.subjectAlias} ${position.side}** — ${position.stake.toString()} BB · ${timing}`;
+    return `• **${position.subjectAlias} ${position.side}** — ${formatInteger(position.stake)} BB · ${timing}`;
   });
   if (view.pendingPositionCount > view.pendingPositions.length) {
     positions.push(
-      `…and ${(view.pendingPositionCount - view.pendingPositions.length).toString()} more pending position(s).`,
+      `…and ${formatInteger(view.pendingPositionCount - view.pendingPositions.length)} more pending position(s).`,
     );
   }
 
@@ -116,12 +117,12 @@ export function buildPersonalBucksEmbed(
     .addFields(
       {
         name: "Available",
-        value: `**${view.balance.toString()} BB**`,
+        value: `**${formatInteger(view.balance)} BB**`,
         inline: true,
       },
       {
         name: "Reserved / at risk",
-        value: `**${view.totalAtRisk.toString()} BB**`,
+        value: `**${formatInteger(view.totalAtRisk)} BB**`,
         inline: true,
       },
     );

--- a/packages/scout-for-lol/packages/data/src/data-dragon/champion.test.ts
+++ b/packages/scout-for-lol/packages/data/src/data-dragon/champion.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { getChampionInfo } from "./champion.ts";
+import { getChampionInfo, getChampionTags } from "./champion.ts";
 
 describe("getChampionInfo", () => {
   test("loads abilities for a standard champion", async () => {
@@ -21,5 +21,12 @@ describe("getChampionInfo", () => {
   test("returns undefined for unknown champion", async () => {
     const info = await getChampionInfo("NonExistentChampion");
     expect(info).toBeUndefined();
+  });
+
+  test("reads Riot's coarse classes from the bundled champion assets", async () => {
+    await expect(getChampionTags("Soraka")).resolves.toContain("Support");
+    await expect(getChampionTags("Pyke")).resolves.toEqual(
+      expect.arrayContaining(["Support", "Assassin"]),
+    );
   });
 });

--- a/packages/scout-for-lol/packages/data/src/data-dragon/champion.ts
+++ b/packages/scout-for-lol/packages/data/src/data-dragon/champion.ts
@@ -8,6 +8,16 @@ const ChampionSpellSchema = z.object({
   tooltip: z.string(),
 });
 
+export const ChampionTagSchema = z.enum([
+  "Assassin",
+  "Fighter",
+  "Mage",
+  "Marksman",
+  "Support",
+  "Tank",
+]);
+export type ChampionTag = z.infer<typeof ChampionTagSchema>;
+
 const ChampionDataSchema = z.object({
   data: z.record(
     z.string(),
@@ -15,6 +25,7 @@ const ChampionDataSchema = z.object({
       id: z.string(),
       name: z.string(),
       title: z.string(),
+      tags: z.array(ChampionTagSchema).min(1),
       spells: z.array(ChampionSpellSchema), // Q, W, E, R
       passive: z.object({
         name: z.string(),
@@ -30,6 +41,7 @@ const championCache = new Map<
   {
     spells: { name: string; description: string; tooltip: string }[];
     passive: { name: string; description: string };
+    tags: ChampionTag[];
   }
 >();
 
@@ -82,6 +94,7 @@ export async function getChampionInfo(championName: string): Promise<
   | {
       spells: { name: string; description: string; tooltip: string }[];
       passive: { name: string; description: string };
+      tags: ChampionTag[];
     }
   | undefined
 > {
@@ -109,6 +122,7 @@ export async function getChampionInfo(championName: string): Promise<
         tooltip: s.tooltip,
       })),
       passive: championData.passive,
+      tags: championData.tags,
     };
 
     // Cache the result
@@ -118,4 +132,12 @@ export async function getChampionInfo(championName: string): Promise<
   } catch {
     return undefined;
   }
+}
+
+/** Read Riot's coarse champion classes from the bundled Data Dragon snapshot. */
+export async function getChampionTags(
+  championName: string,
+): Promise<ChampionTag[] | undefined> {
+  const champion = await getChampionInfo(championName);
+  return champion?.tags;
 }

--- a/packages/scout-for-lol/packages/data/src/index.ts
+++ b/packages/scout-for-lol/packages/data/src/index.ts
@@ -133,7 +133,13 @@ export * from "./data-dragon/summoner.ts";
 export * from "./data-dragon/classic.ts";
 export * from "./data-dragon/item.ts";
 export * from "./data-dragon/runes.ts";
-export { getChampionInfo, getChampionList } from "./data-dragon/champion.ts";
+export {
+  ChampionTagSchema,
+  getChampionInfo,
+  getChampionList,
+  getChampionTags,
+  type ChampionTag,
+} from "./data-dragon/champion.ts";
 export {
   getPatchChangeset,
   selectRelevantPatchChanges,


### PR DESCRIPTION
## Why

Scout gave the parlay model the complete field catalog, so it over-selected pings and could choose fields unrelated to a tracked player's lane or champion role. Bryan Bucks output also mixed ungrouped values, raw seconds, and post-game matched-pool arithmetic.

## What

- deterministically rank and persist a match-specific shortlist of 16 role-aware player targets and four global targets
- combine universal, lane, and bundled Riot champion-tag eligibility while excluding poor shortlist fields without changing legacy settlement meaning
- admit one deterministic opponent-ping subtype in exactly one of 16 match buckets
- validate model proposals against the exact persisted shortlist while retaining measured thresholds, historical pricing, and subject coverage
- format Bryan Bucks integers with fixed comma grouping and duration fields as `MM:SS`
- replace post-game pool details with bounded bet/parlay winner, loser, and aggregate-refund sections
- document the shortlist, seeding, tag limitations, display rules, and unchanged evaluator/pricing contracts

## Verification

- `bun test src/betting/display-format.test.ts src/betting/announce.test.ts src/betting/parlay-shortlist.test.ts src/betting/parlay-criteria.test.ts src/betting/parlay-discord.test.ts src/betting/parlay-prompt.test.ts src/betting/prematch-line.test.ts src/discord/commands/bb-history.test.ts` - 111 passed
- `bun --cwd packages/scout-for-lol/packages/data test src/data-dragon/champion.test.ts` - 8 passed
- `bunx turbo run typecheck lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend` - passed with zero lint errors
- pre-commit hook - Gitleaks, Prettier, suppression, line-ending, merge-marker, environment-name, and file-size checks passed
- opt-in live OpenRouter prompt suite - not run; `OPENROUTER_API_KEY` is unavailable
- production Discord acceptance - not run

## Demo

Rendered Discord settlement proof will be attached before the PR is marked ready.