### PR TITLE
fix(scout-for-lol): stabilize Beta tracing and parlay diagnostics

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
@@ -31,7 +31,7 @@ import {
 } from "#src/betting/parlay-model-schema.ts";
 import { fetchParlayHistory } from "#src/betting/parlay-history.ts";
 import {
-  numericThresholdsAreMeasured,
+  numericThresholdDiagnostics,
   priceParlay,
   type ParlayPrice,
 } from "#src/betting/parlay-pricing.ts";
@@ -297,9 +297,18 @@ async function generateAndPersistDefinition(
   deadline.throwIfAborted();
 
   const candidate = parseModelGeneratedParlay(filledParlay, 5000);
-  if (
-    !numericThresholdsAreMeasured(candidate.conditions, setup.subjects, history)
-  ) {
+  const thresholdDiagnostics = numericThresholdDiagnostics(
+    candidate.conditions,
+    setup.subjects,
+    history,
+  );
+  if (thresholdDiagnostics.length > 0) {
+    logger.info("Parlay threshold rejected by measured hit-rate guard", {
+      matchId: setup.matchId,
+      minimumHitRate: 0.4,
+      maximumHitRate: 0.7,
+      diagnostics: thresholdDiagnostics,
+    });
     throw new ParlayUnpriceableError(
       "filled thresholds were outside the measured 40-70% hit-rate range",
     );

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-pricing.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-pricing.test.ts
@@ -12,6 +12,8 @@ import {
   MIN_PRICING_GAMES,
   MAX_PRICE_BPS,
   MIN_PRICE_BPS,
+  numericThresholdDiagnostics,
+  numericThresholdsAreMeasured,
   priceParlay,
 } from "#src/betting/parlay-pricing.ts";
 
@@ -115,6 +117,61 @@ describe("joint replay pricing", () => {
 });
 
 describe("refusing to price", () => {
+  test("reports the field, operator, threshold, and hit rate outside the guard", () => {
+    const matches = Array.from({ length: 20 }, (_, index) =>
+      historyMatch({ index, kills: index + 1 }),
+    );
+    const conditions = [killsAtLeast(16)];
+    const subjects = [subject("P1", PUUID_A)];
+    const history: ParlayHistory = new Map([[PUUID_A, matches]]);
+
+    expect(numericThresholdsAreMeasured(conditions, subjects, history)).toBe(
+      false,
+    );
+    expect(numericThresholdDiagnostics(conditions, subjects, history)).toEqual([
+      {
+        conditionKind: "participant_numeric",
+        field: "kills",
+        operator: "gte",
+        threshold: 16,
+        realizedRate: 0.25,
+        reason: "outside_target_range",
+      },
+    ]);
+  });
+
+  test("reports an unmeasured numeric field without inventing a hit rate", () => {
+    const condition: ParlayCondition = {
+      kind: "participant_numeric",
+      subject: "P1",
+      field: "consumablesPurchased",
+      operator: "lte",
+      threshold: 10,
+    };
+    const subjects = [subject("P1", PUUID_A)];
+    const history: ParlayHistory = new Map([
+      [
+        PUUID_A,
+        Array.from({ length: 20 }, (_, index) =>
+          historyMatch({ index, kills: index + 1 }),
+        ),
+      ],
+    ]);
+
+    expect(numericThresholdDiagnostics([condition], subjects, history)).toEqual(
+      [
+        {
+          conditionKind: "participant_numeric",
+          field: "consumablesPurchased",
+          operator: "lte",
+          threshold: 10,
+          realizedRate: null,
+          reason: "unmeasured",
+        },
+      ],
+    );
+  });
+
   test("a leg history cannot answer yields no price at all", () => {
     const matches = Array.from({ length: 20 }, (_, index) =>
       historyMatch({ index, kills: index + 1 }),

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-pricing.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-pricing.ts
@@ -142,13 +142,87 @@ export function conditionRealizedRate(
   return hits / matches.length;
 }
 
-function isNumericCondition(condition: ParlayCondition): boolean {
-  return (
-    condition.kind === "participant_numeric" ||
-    condition.kind === "team_objective_kills" ||
-    condition.kind === "match_numeric" ||
-    condition.kind === "opponent_team_pings"
-  );
+type NumericCondition = Extract<
+  ParlayCondition,
+  | { kind: "participant_numeric" }
+  | { kind: "team_objective_kills" }
+  | { kind: "match_numeric" }
+  | { kind: "opponent_team_pings" }
+>;
+
+export type NumericThresholdDiagnostic = {
+  conditionKind: NumericCondition["kind"];
+  field: string;
+  operator: NumericCondition["operator"];
+  threshold: number;
+  realizedRate: number | null;
+  reason: "missing_subject" | "unmeasured" | "outside_target_range";
+};
+
+function numericConditionField(condition: NumericCondition): string {
+  switch (condition.kind) {
+    case "participant_numeric":
+    case "match_numeric":
+    case "opponent_team_pings":
+      return condition.field;
+    case "team_objective_kills":
+      return `${condition.objective}_kills`;
+  }
+}
+
+/** Explain numeric threshold failures without changing the pricing guard. */
+export function numericThresholdDiagnostics(
+  conditions: readonly ParlayCondition[],
+  subjects: readonly ParlaySubject[],
+  history: ParlayHistory,
+): readonly NumericThresholdDiagnostic[] {
+  const anchor = subjects[0];
+  const diagnostics: NumericThresholdDiagnostic[] = [];
+  for (const condition of conditions) {
+    if (
+      condition.kind !== "participant_numeric" &&
+      condition.kind !== "team_objective_kills" &&
+      condition.kind !== "match_numeric" &&
+      condition.kind !== "opponent_team_pings"
+    ) {
+      continue;
+    }
+    const subject =
+      condition.kind === "participant_numeric"
+        ? subjects.find((candidate) => candidate.key === condition.subject)
+        : anchor;
+    const base = {
+      conditionKind: condition.kind,
+      field: numericConditionField(condition),
+      operator: condition.operator,
+      threshold: condition.threshold,
+    };
+    if (subject === undefined) {
+      diagnostics.push({
+        ...base,
+        realizedRate: null,
+        reason: "missing_subject",
+      });
+      continue;
+    }
+    const rate = conditionRealizedRate(
+      condition,
+      history.get(subject.puuid) ?? [],
+      subject.key,
+    );
+    if (rate === undefined) {
+      diagnostics.push({ ...base, realizedRate: null, reason: "unmeasured" });
+      continue;
+    }
+    if (rate < 0.4 || rate > 0.7) {
+      diagnostics.push({
+        ...base,
+        realizedRate: rate,
+        reason: "outside_target_range",
+      });
+    }
+  }
+  return diagnostics;
 }
 
 /** Require every filled numeric threshold to land in the intended target band. */
@@ -157,28 +231,12 @@ export function numericThresholdsAreMeasured(
   subjects: readonly ParlaySubject[],
   history: ParlayHistory,
 ): boolean {
-  const anchor = subjects[0];
-  if (anchor === undefined) {
+  if (subjects[0] === undefined) {
     return false;
   }
-  return conditions.every((condition) => {
-    if (!isNumericCondition(condition)) {
-      return true;
-    }
-    const subject =
-      condition.kind === "participant_numeric"
-        ? subjects.find((candidate) => candidate.key === condition.subject)
-        : anchor;
-    if (subject === undefined) {
-      return false;
-    }
-    const rate = conditionRealizedRate(
-      condition,
-      history.get(subject.puuid) ?? [],
-      subject.key,
-    );
-    return rate !== undefined && rate >= 0.4 && rate <= 0.7;
-  });
+  return (
+    numericThresholdDiagnostics(conditions, subjects, history).length === 0
+  );
 }
 
 function conditionSubject(condition: ParlayCondition): string | undefined {

--- a/packages/scout-for-lol/packages/backend/src/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/index.ts
@@ -41,6 +41,9 @@ if (
   Sentry.init({
     dsn: configuration.sentryDsn,
     environment: configuration.environment,
+    // Scout's NodeSDK owns the global OpenTelemetry providers. Sentry remains
+    // responsible for error tracking without attempting a second registration.
+    skipOpenTelemetrySetup: true,
     // Use image tag (e.g. "2.0.0-998") as the release so Bugsink groups
     // events per deploy and matches what ArgoCD reports.
     release: configuration.version,

--- a/packages/scout-for-lol/packages/backend/src/observability/tracing.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/observability/tracing.integration.test.ts
@@ -1,0 +1,87 @@
+// Integration regression: Sentry must not claim OpenTelemetry's globals
+// before Scout's NodeSDK starts, and Scout must still export a real OTLP span.
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import * as Sentry from "@sentry/bun";
+import { resetOtelGlobals } from "@shepherdjerred/llm-observability/otel-globals";
+import { diag, DiagLogLevel } from "@opentelemetry/api";
+import { getTracer, initializeTracing, shutdownTracing } from "./tracing.ts";
+
+function ignoreDiagnostic(): void {
+  // The test only needs to capture diagnostic errors.
+}
+
+describe("Scout OpenTelemetry startup and export", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  const posts: { bytes: number; contentType: string }[] = [];
+  const diagnosticErrors: string[] = [];
+
+  beforeAll(() => {
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/v1/traces" && request.method === "POST") {
+          const body = await request.arrayBuffer();
+          posts.push({
+            bytes: body.byteLength,
+            contentType: request.headers.get("content-type") ?? "",
+          });
+          return new Response(new Uint8Array(0), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    Bun.env["TELEMETRY_ENABLED"] = "true";
+    Bun.env["OTLP_ENDPOINT"] = `http://127.0.0.1:${server.url.port}`;
+    Bun.env["TELEMETRY_SERVICE_NAME"] = "scout-backend-test";
+
+    // Match Scout's production order: NodeSDK first, then Sentry. If the
+    // Sentry skip flag regresses, this captures its duplicate-registration
+    // diagnostic instead of letting the test pass on OTLP export alone.
+    initializeTracing();
+    diag.setLogger(
+      {
+        verbose: ignoreDiagnostic,
+        debug: ignoreDiagnostic,
+        info: ignoreDiagnostic,
+        warn: ignoreDiagnostic,
+        error: (message) => {
+          diagnosticErrors.push(message);
+        },
+      },
+      DiagLogLevel.ERROR,
+    );
+    Sentry.init({
+      dsn: "https://public@127.0.0.1:1/0",
+      environment: "test",
+      skipOpenTelemetrySetup: true,
+    });
+  });
+
+  afterAll(async () => {
+    await server.stop(true);
+    resetOtelGlobals();
+  });
+
+  test("starts before Sentry without collisions and exports an OTLP span", async () => {
+    expect(
+      diagnosticErrors.filter((message) =>
+        message.includes("Attempted duplicate registration"),
+      ),
+    ).toEqual([]);
+    const tracer = getTracer();
+    expect(tracer).toBeDefined();
+    const span = tracer?.startSpan("scout.integration.test.span");
+    expect(span).toBeDefined();
+    span?.end();
+
+    await shutdownTracing();
+
+    expect(posts.length).toBeGreaterThanOrEqual(1);
+    const first = posts[0];
+    expect(first).toBeDefined();
+    expect(first?.bytes).toBeGreaterThan(0);
+    expect(first?.contentType).toMatch(/application\/(json|x-protobuf)/);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
+++ b/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
@@ -9,7 +9,6 @@ import {
   diag,
   DiagLogLevel,
   trace,
-  context,
   type DiagLogger,
   type Tracer,
 } from "@opentelemetry/api";
@@ -124,18 +123,10 @@ export function initializeTracing(): void {
 
   // AsyncLocalStorage-backed context manager so OTel active span propagates
   // across awaits — required for the LLM wrappers to see the current span.
-  // `setGlobalContextManager` is one-shot and returns false when another
-  // manager already holds the global: ignoring that leaves this manager
-  // enabled but unregistered, so every wrapper silently sees no active span
-  // while looking correctly configured.
+  // Pass it to NodeSDK rather than registering it here: NodeSDK owns the
+  // global provider registration, and registering twice produces a misleading
+  // duplicate-registration diagnostic during startup.
   const contextManager = new AsyncLocalStorageContextManager();
-  contextManager.enable();
-  if (!context.setGlobalContextManager(contextManager)) {
-    contextManager.disable();
-    throw new Error(
-      "OpenTelemetry context manager is already registered; tracing must own it to propagate spans across awaits",
-    );
-  }
 
   const exporter = new LoggingSpanExporter(
     new OTLPTraceExporter({
@@ -158,6 +149,7 @@ export function initializeTracing(): void {
   });
 
   sdk = new NodeSDK({
+    contextManager,
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: serviceName,
       [ATTR_SERVICE_VERSION]: serviceVersion,


### PR DESCRIPTION
Why:
Scout Beta was healthy after the PostgreSQL migration, but startup still reported duplicate OpenTelemetry registrations. Unpriceable parlay attempts were safe but did not identify which threshold failed the measured-rate guard.

What:
- Let Scout’s NodeSDK own the AsyncLocalStorage context manager and keep Sentry out of OpenTelemetry setup.
- Add a startup regression test that mirrors Scout’s NodeSDK-before-Sentry order, asserts no duplicate-registration diagnostic, and verifies OTLP export.
- Add structured numeric-threshold diagnostics with field, operator, threshold, realized rate, and failure reason.
- Preserve the 40–70% measured-hit-rate guard and existing Riot timeout behavior. No public API or database schema changes.

Verification:
- `bun --no-install --bun vitest --config ../../../../vitest.config.ts run src/betting/parlay-pricing.test.ts src/observability/tracing.integration.test.ts --testTimeout 20000` — 13 passed.
- `bun run typecheck` — passed.
- Targeted ESLint — no errors; targeted Prettier — passed.
- Live Beta verification: Argo `scout-beta` Synced/Healthy at `2.0.0-11178`; backend/PostgreSQL ready with zero restarts; in-pod health endpoints and public `/api/healthz` returned 200. Current pre-fix runtime metrics were 11 Riot timeouts / 7,400 spectator and match-history calls (~0.15%) and 7 successful / 4 unpriceable parlays.

Rollout:
The currently deployed Beta image remains `2.0.0-11178`; after merge and image promotion, recheck startup logs for zero duplicate-registration errors, OTLP export, `/api/healthz`, and representative Riot/parlay metrics.