### PR TITLE
feat(scout-for-lol): import recent player history without notifications

### DIFF
--- a/packages/docs/wiki/playwright.config.ts
+++ b/packages/docs/wiki/playwright.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from "@playwright/test";
 const PORT = 4358;
 const baseURL = `http://127.0.0.1:${PORT.toString()}`;
 const isCI = process.env.CI !== undefined;
-// Astro's preview command starts a background server and then exits. Keep the
-// Playwright web-server parent alive, and stop that background server when
-// Playwright tears the parent down so local runs never leave a stale preview.
-const previewCommand = `sh -ec 'bun run preview --host 127.0.0.1 --port ${PORT.toString()}; trap "bunx --no-install astro preview stop" EXIT; tail -f /dev/null & wait $!'`;
+// Astro 7 detects agent environments and daemonizes preview automatically.
+// Disable that behavior so Playwright owns the server process, observes startup
+// failures, and tears it down with the test run.
+const previewCommand = `ASTRO_PREVIEW_BACKGROUND=0 bun run preview --host 127.0.0.1 --port ${PORT.toString()}`;
 
 export default defineConfig({
   fullyParallel: true,

--- a/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
+++ b/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
@@ -29,10 +29,12 @@ lake is the wrong place to look.
 ```mermaid
 flowchart LR
   accTitle: Scout report lake read and write flow
-  accDescr: Ingest crons write raw JSON to S3 and must succeed. Prematch prediction capture writes frozen observations to S3 and staging as best effort. A fold compaction every fifteen minutes and a nightly rebuild from S3 both publish immutable Parquet builds behind a CURRENT pointer. Readers union the published Parquet with the staging files, so DuckDB queries see a match seconds after ingest. Competition standings bypass the lake and read raw match JSON and leaderboard snapshots from S3 directly.
+  accDescr: Live ingest crons write raw JSON to S3 and stage lake rows as best effort. A quiet first-run import snapshots twenty Match-V5 IDs and requires both writes before checkpointing. Prematch prediction capture writes frozen observations to S3 and staging as best effort. A fold compaction every fifteen minutes and a nightly rebuild from S3 both publish immutable Parquet builds behind a CURRENT pointer. Readers union the published Parquet with the staging files, so DuckDB queries see a match seconds after ingest. Competition standings bypass the lake and read raw match JSON and leaderboard snapshots from S3 directly.
 
   I[Ingest crons] -->|must succeed| S3[(S3 durable objects)]
   I -->|best effort| ST[NDJSON staging]
+  H[Quiet first-run import] -->|must succeed| S3
+  H -->|must succeed before checkpoint| ST
   P[Prematch prediction capture] -->|best effort| S3
   P -->|best effort| ST
   ST --> F[Fold, every 15 min]
@@ -63,13 +65,29 @@ This split is why schema changes are cheap. Adding a lake column needs no
 migration and no backfill: the nightly rebuild re-derives every row from the
 raw JSON, so the new column simply appears the next morning.
 
-## Writes: one must succeed, one may fail
+## Writes: live ingest can recover staging; initial import cannot
 
 Ingest makes two writes with deliberately different contracts, spelled out in
 [store.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-store/store.ts).
 The S3 put throws on failure, because raw data is unrecoverable. The lake
 staging write never throws, because a lost staging row is re-derived from S3
 that night anyway.
+
+The quiet first-run import tightens that contract. It snapshots exactly 20
+Match-V5 IDs once, imports newest first, and checkpoints a match only when the
+S3 put and immediate staging write both succeed. A failed staging write retries
+the same idempotent S3 key. This lets Explore and global ScoutQL read partial
+history immediately without making guild reports claim readiness too early.
+After match and current-rank enrichment, one coalesced fold refreshes
+`accounts.parquet` and publishes all staged matches before the PUUID-level job
+is complete. Guild-scoped lookbacks therefore see the new identity mapping and
+facts together.
+
+The import never enters the normal post-match processor. Historical matches do
+not send Discord messages, generate reports or AI recaps, write ActiveGame
+state, settle Bryan Bucks, award earnings, or fabricate per-match rank deltas.
+The live poller resumes only after the fixed snapshot is stored and its newest
+ID becomes the cursor, so a game completed during import is notified once.
 
 ```mermaid
 sequenceDiagram

--- a/packages/dotfiles/dot_agents/skills/scout-development/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/scout-development/SKILL.md
@@ -153,6 +153,14 @@ lake is:
 export REPORT_LAKE_DIR="$HOME/.local/share/scout-for-lol/dev-seed/report-lake"
 ```
 
+First-run account history uses `backend/src/league/initial-history/`. Keep it
+separate from the normal post-match processor: the durable PUUID job imports a
+fixed 20-match snapshot into S3 and immediate lake staging, fetches one current
+rank snapshot, and folds account identity before completion. Historical import
+must produce no Discord, report/AI, ActiveGame, Bryan Bucks, earnings, or
+per-match rank-history side effects. Live polling has priority and excludes a
+PUUID only during the `queued` and `matches` phases.
+
 Pass that variable when starting a local backend or `dev:web`. Treat it as
 shared derived data: concurrent reads are fine, but do not run compaction from
 multiple workspaces at once. Rebuilds read raw match JSON from the BETA S3

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
@@ -67,6 +67,21 @@ describe("Scout bot-health alert rules", () => {
     );
   });
 
+  test("warns when the oldest initial history import exceeds six hours", () => {
+    const rule = botHealth?.rules?.find(
+      (candidate) => candidate.alert === "ScoutInitialHistoryImportStale",
+    );
+    if (rule === undefined) {
+      throw new Error("Missing ScoutInitialHistoryImportStale rule");
+    }
+    const expression = JSON.stringify(rule.expr);
+    expect(rule.labels?.["severity"]).toBe("warning");
+    expect(expression).toContain(
+      "scout_initial_history_import_oldest_actionable_timestamp_seconds",
+    );
+    expect(expression).toContain("21600");
+  });
+
   test("warns on a delivery-blocked spike", () => {
     const rule = botHealth?.rules?.find(
       (candidate) => candidate.alert === "ScoutGuildDeliveryBlockedSpike",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -298,6 +298,22 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
           },
         },
         {
+          alert: "ScoutInitialHistoryImportStale",
+          annotations: {
+            summary: "Scout initial match history import is stalled",
+            message: escapePrometheusTemplate(
+              "Scout {{ $labels.environment }} has an actionable first-run history import older than six hours. Check the import phase metrics, Riot 429s, SeaweedFS, and report-lake folding.",
+            ),
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "scout_initial_history_import_oldest_actionable_timestamp_seconds > 0 and (time() - scout_initial_history_import_oldest_actionable_timestamp_seconds) > 21600",
+          ),
+          for: "10m",
+          labels: {
+            severity: "warning",
+          },
+        },
+        {
           // Individual blocked guilds are a USER problem (the owner is DM'd via
           // the backed-off escalation), so don't page on one or two. A spike in
           // blocked guilds at once instead points at a bot-side delivery bug.

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -1286,6 +1286,16 @@ Code lives in `backend/src/league/tournament/` and
   post-match report replies to the card, through the unchanged
   `getPrematchMessageIdsForMatchIdOrEmpty` path. The match-history cursor still
   owns ingest, and its S3 write still gates the cursor advance.
+- **First-run history is a separate, quiet ingest path.** An enabled guild's
+  account-creation transaction enqueues one global PUUID job. The worker runs
+  after live polling, snapshots 20 Match-V5 IDs once, requires both canonical
+  S3 and lake staging before each checkpoint, then fetches current Solo/Flex
+  rank and coalesces completion into a lake fold. It must never call the normal
+  post-match processor: no Discord, reports, AI recaps, ActiveGame writes,
+  Bryan Bucks, earnings, or per-match rank history. `queued` and `matches`
+  PUUIDs stay out of live polling until the newest snapshot ID is installed as
+  their cursor. Reuse within 24 hours republishes the guild account mapping but
+  does not refetch Riot.
 - **Never fabricate a `RawCurrentGameInfo`** from lobby events. That value is
   the canonical S3 match record the report lake rebuilds from; invented
   champion IDs would permanently corrupt ScoutQL, Explore, and AI review.

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260823000001_initial_match_history_import/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260823000001_initial_match_history_import/migration.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "InitialMatchHistoryImport" (
+    "puuid" TEXT NOT NULL,
+    "region" TEXT NOT NULL,
+    "phase" TEXT NOT NULL,
+    "matchIdsJson" TEXT,
+    "snapshotAt" TIMESTAMP(3),
+    "nextMatchIndex" INTEGER NOT NULL DEFAULT 0,
+    "newestMatchId" TEXT,
+    "newestMatchTime" TIMESTAMP(3),
+    "cursorHandedOffAt" TIMESTAMP(3),
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "lastAttemptAt" TIMESTAMP(3),
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL,
+    "errorCode" TEXT,
+    "requestedAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+    "lastImportedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InitialMatchHistoryImport_pkey" PRIMARY KEY ("puuid"),
+    CONSTRAINT "InitialMatchHistoryImport_phase_check"
+      CHECK ("phase" IN ('queued', 'matches', 'rank', 'publish', 'complete', 'failed')),
+    CONSTRAINT "InitialMatchHistoryImport_progress_check"
+      CHECK ("nextMatchIndex" >= 0 AND "nextMatchIndex" <= 20),
+    CONSTRAINT "InitialMatchHistoryImport_attempt_count_check"
+      CHECK ("attemptCount" >= 0),
+    CONSTRAINT "InitialMatchHistoryImport_error_code_check"
+      CHECK (
+        "errorCode" IS NULL OR
+        "errorCode" IN (
+          'rate_limit', 'upstream', 'transport', 'storage', 'staging',
+          'authentication', 'contract', 'untracked'
+        )
+      )
+);
+
+CREATE TABLE "CurrentRankSnapshot" (
+    "puuid" TEXT NOT NULL,
+    "soloRank" TEXT,
+    "flexRank" TEXT,
+    "fetchedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CurrentRankSnapshot_pkey" PRIMARY KEY ("puuid")
+);
+
+CREATE INDEX "InitialMatchHistoryImport_phase_nextAttemptAt_requestedAt_idx"
+ON "InitialMatchHistoryImport"("phase", "nextAttemptAt", "requestedAt");

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -119,6 +119,47 @@ model MatchRankHistory {
   @@index([matchId])
 }
 
+// Durable, globally deduplicated first-run import. The PUUID key makes one
+// Riot snapshot serve every guild that tracks the same account.
+model InitialMatchHistoryImport {
+  puuid  String @id
+  region String
+  phase  String
+
+  // JSON-serialized MatchId[] validated by the application. The list is
+  // captured once so retries cannot move the notification boundary.
+  matchIdsJson      String?
+  snapshotAt        DateTime?
+  nextMatchIndex    Int       @default(0)
+  newestMatchId     String?
+  newestMatchTime   DateTime?
+  cursorHandedOffAt DateTime?
+
+  attemptCount  Int       @default(0)
+  lastAttemptAt DateTime?
+  nextAttemptAt DateTime
+  errorCode     String?
+
+  requestedAt    DateTime
+  completedAt    DateTime?
+  lastImportedAt DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  @@index([phase, nextAttemptAt, requestedAt])
+}
+
+// Current rank is not a per-match observation. Keeping it separate prevents
+// imported games from fabricating historical LP deltas.
+model CurrentRankSnapshot {
+  puuid     String   @id
+  soloRank  String?
+  flexRank  String?
+  fetchedAt DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
 model Report {
   id                     Int       @id @default(autoincrement())
   serverId               String

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
@@ -41,6 +41,7 @@ afterEach(() => {
   // The registry is process-wide. Restoring rather than clearing keeps this
   // file from switching `debug` off for every test that runs after it.
   resetFlagOverrides("debug");
+  resetFlagOverrides("initial_match_history_import_enabled");
   for (const flag of PRODUCTION_DENIED_FLAGS) {
     resetFlagOverrides(flag);
   }
@@ -105,6 +106,28 @@ describe("Bryan Bucks settlement DM flags", () => {
     expect(
       getFlag("betting_player_bet_outcome_dm_enabled", { server: MY_SERVER }),
     ).toBe(true);
+  });
+});
+
+describe("initial history import flag", () => {
+  test("is default-off and can target one guild in production", () => {
+    Bun.env["ENVIRONMENT"] = "prod";
+    resetConfigurationForTests();
+    expect(
+      getFlag("initial_match_history_import_enabled", {
+        server: OTHER_GUILD,
+      }),
+    ).toBe(false);
+
+    addFlagOverride("initial_match_history_import_enabled", true, {
+      server: OTHER_GUILD,
+    });
+    expect(
+      getFlag("initial_match_history_import_enabled", {
+        server: OTHER_GUILD,
+      }),
+    ).toBe(true);
+    resetFlagOverrides("initial_match_history_import_enabled");
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -147,6 +147,7 @@ export type FlagName =
   | "betting_player_bet_outcome_dm_enabled"
   | "betting_settlement_dm_enabled"
   | "debug"
+  | "initial_match_history_import_enabled"
   | "tournament_lobbies_enabled";
 
 /** Flipt is authoritative when available. The registry remains a fail-closed
@@ -259,6 +260,10 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
         attributes: { user: ME },
       },
     ],
+  },
+  initial_match_history_import_enabled: {
+    default: false,
+    overrides: [],
   },
 };
 

--- a/packages/scout-for-lol/packages/backend/src/database/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/index.ts
@@ -52,6 +52,8 @@ export type PlayerAccountWithState = {
   lastCheckedAt: Date | undefined;
 };
 
+type AccountStateClient = Pick<ExtendedPrismaClient, "player">;
+
 // A channel that should be notified about a match, plus the in-match
 // subscriptions routing to it and their parsed notification filters. Filters
 // are per-subscription; the caller decides delivery (e.g. notify the channel
@@ -177,7 +179,7 @@ export async function getChannelsSubscribedToPlayers(
  * @returns Array of player accounts with their polling state
  */
 export async function getAccountsWithState(
-  prismaClient: ExtendedPrismaClient = prisma,
+  prismaClient: AccountStateClient = prisma,
   activeServerIds?: Set<string>,
 ): Promise<PlayerAccountWithState[]> {
   logger.info("🔍 Fetching all player accounts with state");

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/track.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/track.ts
@@ -26,6 +26,7 @@ import type {
   CommandReply,
 } from "#src/discord/commands/define-command.ts";
 import { getDashboardUrl } from "#src/discord/commands/links.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
 
 export const trackCommand = new SlashCommandBuilder()
   .setName("track")
@@ -122,6 +123,10 @@ export async function executeTrack(
     game_name: puuidResult.gameName,
     tag_line: puuidResult.tagLine,
   };
+  const initialHistoryImportEnabled = await isPolicyEnabled(
+    "initial_match_history_import_enabled",
+    { server: args.data.guildId },
+  );
 
   try {
     const result = await prisma.$transaction(async (tx) => {
@@ -137,6 +142,7 @@ export async function executeTrack(
         },
         LeaguePuuidSchema.parse(puuidResult.puuid),
         tx,
+        initialHistoryImportEnabled,
       );
       // The audit log is documented as covering Discord commands too, so the
       // row goes in the same transaction as the mutation — exactly as the web
@@ -207,10 +213,14 @@ export async function executeTrack(
 
     await interaction.editReply({ content: formatTrackResult(result) });
 
-    if (result.kind === "created") {
+    if (
+      !initialHistoryImportEnabled &&
+      (result.kind === "created" ||
+        result.kind === "subscription-already-exists")
+    ) {
       void runBackfillAfterCommit({
         alias: args.data.alias,
-        puuid: LeaguePuuidSchema.parse(result.account.puuid),
+        puuid: LeaguePuuidSchema.parse(puuidResult.puuid),
         region: args.data.region,
         discordUserId: undefined,
       });

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/rate-limiter.ts
@@ -9,6 +9,11 @@ export type RateLimiterOptions = {
   maxRetries?: number | undefined;
 };
 
+export type RateLimitedRequestOptions = {
+  /** Override automatic retries for one request without bypassing the limiter. */
+  maxRetries?: number | undefined;
+};
+
 type RateLimiterRuntime = {
   now: () => number;
   sleep: (milliseconds: number) => Promise<void>;
@@ -144,10 +149,12 @@ export class RateLimiter {
   public async execute(
     url: string,
     executeRequest: RequestExecutor,
+    options: RateLimitedRequestOptions = {},
   ): Promise<Response> {
+    const maxRetries = options.maxRetries ?? this.maxRetries;
     let attempts = 0;
 
-    while (attempts <= this.maxRetries) {
+    while (attempts <= maxRetries) {
       attempts += 1;
 
       const response = await this.executeAttempt(executeRequest);
@@ -159,12 +166,12 @@ export class RateLimiter {
       const status = response.status;
 
       // 429: Rate Limit Exceeded
-      if (status === 429 && attempts <= this.maxRetries) {
+      if (status === 429 && attempts <= maxRetries) {
         continue;
       }
 
       // 503: Service Unavailable (Riot API server overload / temporary outage)
-      if (status === 503 && attempts <= this.maxRetries) {
+      if (status === 503 && attempts <= maxRetries) {
         const baseDelayMs = 1000 * 2 ** (attempts - 1);
         const delayMs = baseDelayMs + this.runtime.random() * 300;
         await this.runtime.sleep(delayMs);
@@ -184,7 +191,7 @@ export class RateLimiter {
     }
 
     throw new Error(
-      `Exceeded maximum retry attempts (${this.maxRetries.toString()}) for ${url}`,
+      `Exceeded maximum retry attempts (${maxRetries.toString()}) for ${url}`,
     );
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/riot-client.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/riot-client.test.ts
@@ -175,4 +175,29 @@ describe("RiotClient", () => {
     expect(callCount).toBe(2);
     expect(result).toEqual({ matchId: testMatchId });
   });
+
+  test("can disable internal retries without bypassing the shared limiter", async () => {
+    const mockFetch: FetchFunction = vi.fn(() =>
+      Promise.resolve(
+        Response.json(
+          { message: "Rate limit exceeded" },
+          {
+            status: 429,
+            statusText: "Too Many Requests",
+            headers: { "Retry-After": "0" },
+          },
+        ),
+      ),
+    );
+    const client = new RiotClient({
+      apiKey,
+      fetchFn: mockFetch,
+      maxRetries: 3,
+    });
+
+    await expect(
+      client.match.get(testMatchId, "AMERICAS", { maxRetries: 0 }),
+    ).rejects.toThrow(RiotHttpError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/api/client/riot-client.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/api/client/riot-client.ts
@@ -12,7 +12,11 @@ import {
   MatchIdSchema,
 } from "@scout-for-lol/data";
 import { z } from "zod";
-import { RateLimiter, type RateLimiterOptions } from "./rate-limiter.ts";
+import {
+  RateLimiter,
+  type RateLimitedRequestOptions,
+  type RateLimiterOptions,
+} from "./rate-limiter.ts";
 
 export type MatchListParams = {
   count?: number | undefined;
@@ -49,14 +53,20 @@ export class RiotClient {
     this.fetchFn = options.fetchFn ?? fetch;
   }
 
-  private async fetchJson(url: string): Promise<unknown> {
-    const response = await this.rateLimiter.execute(url, () =>
-      this.fetchFn(url, {
-        headers: {
-          "X-Riot-Token": this.apiKey,
-          Accept: "application/json",
-        },
-      }),
+  private async fetchJson(
+    url: string,
+    requestOptions: RateLimitedRequestOptions = {},
+  ): Promise<unknown> {
+    const response = await this.rateLimiter.execute(
+      url,
+      () =>
+        this.fetchFn(url, {
+          headers: {
+            "X-Riot-Token": this.apiKey,
+            Accept: "application/json",
+          },
+        }),
+      requestOptions,
     );
     return response.json();
   }
@@ -89,6 +99,7 @@ export class RiotClient {
       puuid: LeaguePuuid,
       regionalRoute: RegionalRoute,
       params: MatchListParams = {},
+      requestOptions: RateLimitedRequestOptions = {},
     ): Promise<MatchId[]> => {
       const searchParams = new URLSearchParams();
       if (params.count !== undefined)
@@ -106,16 +117,17 @@ export class RiotClient {
       const qs = searchParams.toString();
       const queryString = qs.length > 0 ? `?${qs}` : "";
       const url = `https://${regionalRoute.toLowerCase()}.api.riotgames.com/lol/match/v5/matches/by-puuid/${encodeURIComponent(puuid)}/ids${queryString}`;
-      const data = await this.fetchJson(url);
+      const data = await this.fetchJson(url, requestOptions);
       return MatchIdListSchema.parse(data);
     },
 
     get: async (
       matchId: MatchId | string,
       regionalRoute: RegionalRoute,
+      requestOptions: RateLimitedRequestOptions = {},
     ): Promise<unknown> => {
       const url = `https://${regionalRoute.toLowerCase()}.api.riotgames.com/lol/match/v5/matches/${encodeURIComponent(matchId)}`;
-      return this.fetchJson(url);
+      return this.fetchJson(url, requestOptions);
     },
 
     timeline: async (
@@ -131,9 +143,10 @@ export class RiotClient {
     byPuuid: async (
       puuid: LeaguePuuid,
       platform: PlatformRoute,
+      requestOptions: RateLimitedRequestOptions = {},
     ): Promise<unknown> => {
       const url = `https://${platform.toLowerCase()}.api.riotgames.com/lol/league/v4/entries/by-puuid/${encodeURIComponent(puuid)}`;
-      return this.fetchJson(url);
+      return this.fetchJson(url, requestOptions);
     },
   };
 

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/enqueue.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/enqueue.integration.test.ts
@@ -1,0 +1,373 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { MatchIdSchema } from "@scout-for-lol/data";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import { enqueueInitialMatchHistoryImport } from "#src/league/initial-history/enqueue.ts";
+import {
+  testAccountId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("initial-history-enqueue");
+const puuid = testPuuid("initial-history-puuid");
+
+beforeEach(async () => {
+  await deleteIfExists(() => prisma.initialMatchHistoryImport.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+describe("initial history enqueue", () => {
+  test("rolls back with the account-creation transaction", async () => {
+    await expect(
+      prisma.$transaction(async (tx) => {
+        await enqueueInitialMatchHistoryImport({
+          puuid,
+          region: "AMERICA_NORTH",
+          db: tx,
+        });
+        throw new Error("rollback account create");
+      }),
+    ).rejects.toThrow("rollback account create");
+
+    expect(await prisma.initialMatchHistoryImport.count()).toBe(0);
+  });
+
+  test("deduplicates concurrent cross-guild requests by PUUID", async () => {
+    await Promise.all([
+      prisma.$transaction((tx) =>
+        enqueueInitialMatchHistoryImport({
+          puuid,
+          region: "AMERICA_NORTH",
+          db: tx,
+        }),
+      ),
+      prisma.$transaction((tx) =>
+        enqueueInitialMatchHistoryImport({
+          puuid,
+          region: "AMERICA_NORTH",
+          db: tx,
+        }),
+      ),
+    ]);
+
+    expect(await prisma.initialMatchHistoryImport.count()).toBe(1);
+  });
+
+  test("reuses a recent import only to republish guild identity", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid,
+        region: "AMERICA_NORTH",
+        phase: "complete",
+        matchIdsJson: JSON.stringify(["NA1_1"]),
+        nextMatchIndex: 1,
+        newestMatchId: "NA1_1",
+        cursorHandedOffAt: new Date(now.getTime() - 25 * 60 * 60 * 1000),
+        nextAttemptAt: now,
+        requestedAt: now,
+        completedAt: now,
+        lastImportedAt: new Date(now.getTime() - 60 * 60 * 1000),
+      },
+    });
+
+    const activeRequestAt = new Date("2026-08-23T12:05:00.000Z");
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: activeRequestAt,
+      }),
+    );
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid },
+    });
+    expect(job.phase).toBe("publish");
+    expect(job.matchIdsJson).toBe(JSON.stringify(["NA1_1"]));
+    expect(job.nextMatchIndex).toBe(1);
+  });
+
+  test("seeds a reused account from the most advanced shared cursor", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    const existingPlayer = await prisma.player.create({
+      data: {
+        alias: "Existing",
+        serverId: testGuildId("4101"),
+        creatorDiscordId: testAccountId("5101"),
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+    const newPlayer = await prisma.player.create({
+      data: {
+        alias: "New",
+        serverId: testGuildId("4102"),
+        creatorDiscordId: testAccountId("5101"),
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+    await prisma.account.create({
+      data: {
+        alias: "Existing",
+        puuid,
+        region: "AMERICA_NORTH",
+        playerId: existingPlayer.id,
+        serverId: existingPlayer.serverId,
+        creatorDiscordId: testAccountId("5101"),
+        lastProcessedMatchId: MatchIdSchema.parse("NA1_3"),
+        lastMatchTime: new Date("2026-08-23T11:30:00.000Z"),
+        lastCheckedAt: new Date("2026-08-23T11:35:00.000Z"),
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+    const newAccount = await prisma.account.create({
+      data: {
+        alias: "New",
+        puuid,
+        region: "AMERICA_NORTH",
+        playerId: newPlayer.id,
+        serverId: newPlayer.serverId,
+        creatorDiscordId: testAccountId("5101"),
+        createdTime: now,
+        updatedTime: now,
+      },
+    });
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid,
+        region: "AMERICA_NORTH",
+        phase: "complete",
+        matchIdsJson: JSON.stringify(["NA1_1"]),
+        nextMatchIndex: 1,
+        newestMatchId: "NA1_1",
+        newestMatchTime: new Date("2026-08-23T10:00:00.000Z"),
+        cursorHandedOffAt: new Date("2026-08-23T10:05:00.000Z"),
+        nextAttemptAt: now,
+        requestedAt: now,
+        completedAt: now,
+        lastImportedAt: new Date("2026-08-23T10:10:00.000Z"),
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: now,
+      }),
+    );
+
+    await expect(
+      prisma.account.findUniqueOrThrow({ where: { id: newAccount.id } }),
+    ).resolves.toMatchObject({
+      lastProcessedMatchId: "NA1_3",
+      lastMatchTime: new Date("2026-08-23T11:30:00.000Z"),
+      lastCheckedAt: new Date("2026-08-23T11:35:00.000Z"),
+    });
+
+    await prisma.account.update({
+      where: { id: newAccount.id },
+      data: {
+        lastProcessedMatchId: null,
+        lastMatchTime: null,
+        lastCheckedAt: null,
+      },
+    });
+    const activeRequestAt = new Date("2026-08-23T12:05:00.000Z");
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: activeRequestAt,
+      }),
+    );
+    await expect(
+      prisma.account.findUniqueOrThrow({ where: { id: newAccount.id } }),
+    ).resolves.toMatchObject({
+      lastProcessedMatchId: "NA1_3",
+      lastMatchTime: new Date("2026-08-23T11:30:00.000Z"),
+      lastCheckedAt: new Date("2026-08-23T11:35:00.000Z"),
+    });
+    await expect(
+      prisma.initialMatchHistoryImport.findUniqueOrThrow({ where: { puuid } }),
+    ).resolves.toMatchObject({
+      phase: "publish",
+      requestedAt: activeRequestAt,
+    });
+  });
+});
+
+describe("initial history enqueue recovery", () => {
+  test("allows a Riot refetch after the 24-hour cooldown", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid,
+        region: "AMERICA_NORTH",
+        phase: "complete",
+        matchIdsJson: JSON.stringify(["NA1_1"]),
+        nextMatchIndex: 1,
+        newestMatchId: "NA1_1",
+        nextAttemptAt: now,
+        requestedAt: now,
+        completedAt: now,
+        lastImportedAt: new Date(now.getTime() - 25 * 60 * 60 * 1000),
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: now,
+      }),
+    );
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid },
+    });
+    expect(job).toMatchObject({
+      phase: "queued",
+      matchIdsJson: null,
+      nextMatchIndex: 0,
+      newestMatchId: null,
+      cursorHandedOffAt: null,
+      lastImportedAt: null,
+    });
+  });
+
+  test("resumes a repaired pre-handoff terminal failure", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid,
+        region: "AMERICA_NORTH",
+        phase: "failed",
+        matchIdsJson: JSON.stringify(["NA1_2", "NA1_1"]),
+        snapshotAt: new Date(now.getTime() - 60 * 60 * 1000),
+        nextMatchIndex: 1,
+        newestMatchId: "NA1_2",
+        attemptCount: 4,
+        nextAttemptAt: now,
+        requestedAt: new Date(now.getTime() - 60 * 60 * 1000),
+        completedAt: new Date(now.getTime() - 30 * 60 * 1000),
+        errorCode: "contract",
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: now,
+      }),
+    );
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid },
+      }),
+    ).toMatchObject({
+      phase: "matches",
+      nextMatchIndex: 1,
+      attemptCount: 0,
+      errorCode: null,
+      completedAt: null,
+      nextAttemptAt: now,
+    });
+  });
+
+  test("resumes a recent partial snapshot after delete and re-add", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid,
+        region: "AMERICA_NORTH",
+        phase: "complete",
+        matchIdsJson: JSON.stringify(["NA1_2", "NA1_1"]),
+        snapshotAt: new Date(now.getTime() - 60 * 60 * 1000),
+        nextMatchIndex: 1,
+        newestMatchId: "NA1_2",
+        nextAttemptAt: now,
+        requestedAt: now,
+        completedAt: now,
+        errorCode: "untracked",
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: now,
+      }),
+    );
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid },
+      }),
+    ).toMatchObject({
+      phase: "matches",
+      nextMatchIndex: 1,
+      newestMatchId: "NA1_2",
+      errorCode: null,
+    });
+  });
+
+  test("re-enters cursor handoff when every snapshot match was stored before removal", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid,
+        region: "AMERICA_NORTH",
+        phase: "complete",
+        matchIdsJson: JSON.stringify(["NA1_2", "NA1_1"]),
+        snapshotAt: new Date(now.getTime() - 60 * 60 * 1000),
+        nextMatchIndex: 2,
+        newestMatchId: "NA1_2",
+        nextAttemptAt: now,
+        requestedAt: now,
+        completedAt: now,
+        errorCode: "untracked",
+      },
+    });
+
+    await prisma.$transaction((tx) =>
+      enqueueInitialMatchHistoryImport({
+        puuid,
+        region: "AMERICA_NORTH",
+        db: tx,
+        requestedAt: now,
+      }),
+    );
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid },
+      }),
+    ).toMatchObject({
+      phase: "matches",
+      nextMatchIndex: 2,
+      cursorHandedOffAt: null,
+      errorCode: null,
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/enqueue.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/enqueue.ts
@@ -1,0 +1,188 @@
+import {
+  MatchIdSchema,
+  type LeaguePuuid,
+  type Region,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import type { InitialMatchHistoryImport } from "#generated/prisma/client/index.js";
+import type { Db } from "#src/lib/audit/index.ts";
+
+export const INITIAL_HISTORY_REFETCH_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const StoredMatchIdsSchema = z.array(MatchIdSchema).max(20);
+
+export async function lockInitialMatchHistoryImport(
+  db: Pick<Db, "$executeRaw">,
+  puuid: LeaguePuuid,
+): Promise<void> {
+  await db.$executeRaw`SELECT pg_advisory_xact_lock(hashtext('scout-initial-history'), hashtext(${puuid}))`;
+}
+
+async function installSharedCursor(input: {
+  db: Db;
+  puuid: LeaguePuuid;
+  newestMatchId: string | null;
+  newestMatchTime: Date | null;
+  handedOffAt: Date;
+  requestedAt: Date;
+}): Promise<void> {
+  const latestAccount = await input.db.account.findFirst({
+    where: { puuid: input.puuid, lastProcessedMatchId: { not: null } },
+    orderBy: { lastCheckedAt: { sort: "desc", nulls: "last" } },
+    select: {
+      lastProcessedMatchId: true,
+      lastMatchTime: true,
+      lastCheckedAt: true,
+    },
+  });
+  const cursor =
+    latestAccount?.lastProcessedMatchId ??
+    (input.newestMatchId === null
+      ? null
+      : MatchIdSchema.parse(input.newestMatchId));
+  await input.db.account.updateMany({
+    where: { puuid: input.puuid, lastProcessedMatchId: null },
+    data: {
+      lastProcessedMatchId: cursor,
+      lastMatchTime: latestAccount?.lastMatchTime ?? input.newestMatchTime,
+      lastCheckedAt: latestAccount?.lastCheckedAt ?? input.handedOffAt,
+      updatedTime: input.requestedAt,
+    },
+  });
+}
+
+async function installSharedCursorIfHandedOff(input: {
+  db: Db;
+  puuid: LeaguePuuid;
+  job: InitialMatchHistoryImport;
+  requestedAt: Date;
+}): Promise<void> {
+  if (input.job.cursorHandedOffAt === null) return;
+  await installSharedCursor({
+    db: input.db,
+    puuid: input.puuid,
+    newestMatchId: input.job.newestMatchId,
+    newestMatchTime: input.job.newestMatchTime,
+    handedOffAt: input.job.cursorHandedOffAt,
+    requestedAt: input.requestedAt,
+  });
+}
+
+export async function enqueueInitialMatchHistoryImport(input: {
+  puuid: LeaguePuuid;
+  region: Region;
+  db: Db;
+  requestedAt?: Date;
+}): Promise<void> {
+  const requestedAt = input.requestedAt ?? new Date();
+
+  await lockInitialMatchHistoryImport(input.db, input.puuid);
+
+  const existing = await input.db.initialMatchHistoryImport.findUnique({
+    where: { puuid: input.puuid },
+  });
+  if (existing === null) {
+    await input.db.initialMatchHistoryImport.create({
+      data: {
+        puuid: input.puuid,
+        region: input.region,
+        phase: "queued",
+        nextAttemptAt: requestedAt,
+        requestedAt,
+      },
+    });
+    return;
+  }
+
+  if (["queued", "matches", "rank", "publish"].includes(existing.phase)) {
+    await installSharedCursorIfHandedOff({
+      db: input.db,
+      puuid: input.puuid,
+      job: existing,
+      requestedAt,
+    });
+    await input.db.initialMatchHistoryImport.update({
+      where: { puuid: input.puuid },
+      data: { requestedAt },
+    });
+    return;
+  }
+
+  if (existing.phase === "failed") {
+    const resumedPhase =
+      existing.cursorHandedOffAt === null
+        ? existing.matchIdsJson === null
+          ? "queued"
+          : "matches"
+        : "rank";
+    await installSharedCursorIfHandedOff({
+      db: input.db,
+      puuid: input.puuid,
+      job: existing,
+      requestedAt,
+    });
+    await input.db.initialMatchHistoryImport.update({
+      where: { puuid: input.puuid },
+      data: {
+        region: input.region,
+        phase: resumedPhase,
+        requestedAt,
+        nextAttemptAt: requestedAt,
+        completedAt: null,
+        attemptCount: 0,
+        errorCode: null,
+      },
+    });
+    return;
+  }
+
+  const lastFetchAt = existing.lastImportedAt ?? existing.snapshotAt;
+  const importedRecently =
+    lastFetchAt !== null &&
+    requestedAt.getTime() - lastFetchAt.getTime() <
+      INITIAL_HISTORY_REFETCH_COOLDOWN_MS;
+  if (importedRecently && existing.phase === "complete") {
+    let resumedPhase = "publish";
+    if (existing.lastImportedAt === null) {
+      StoredMatchIdsSchema.parse(JSON.parse(existing.matchIdsJson ?? "null"));
+      resumedPhase = existing.cursorHandedOffAt === null ? "matches" : "rank";
+    }
+    await installSharedCursorIfHandedOff({
+      db: input.db,
+      puuid: input.puuid,
+      job: existing,
+      requestedAt,
+    });
+    await input.db.initialMatchHistoryImport.update({
+      where: { puuid: input.puuid },
+      data: {
+        phase: resumedPhase,
+        requestedAt,
+        nextAttemptAt: requestedAt,
+        completedAt: null,
+        attemptCount: 0,
+        errorCode: null,
+      },
+    });
+    return;
+  }
+
+  await input.db.initialMatchHistoryImport.update({
+    where: { puuid: input.puuid },
+    data: {
+      region: input.region,
+      phase: "queued",
+      matchIdsJson: null,
+      snapshotAt: null,
+      nextMatchIndex: 0,
+      newestMatchId: null,
+      newestMatchTime: null,
+      cursorHandedOffAt: null,
+      attemptCount: 0,
+      nextAttemptAt: requestedAt,
+      errorCode: null,
+      requestedAt,
+      completedAt: null,
+      lastImportedAt: null,
+    },
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/errors.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/errors.ts
@@ -1,0 +1,32 @@
+export type PermanentImportErrorCode = "authentication" | "contract";
+
+export class PermanentImportError extends Error {
+  readonly code: PermanentImportErrorCode;
+
+  constructor(
+    code: PermanentImportErrorCode,
+    message: string,
+    cause?: unknown,
+  ) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "PermanentImportError";
+    this.code = code;
+  }
+}
+
+export class LakeStagingError extends Error {
+  constructor(subject: string, cause?: unknown) {
+    super(
+      `Lake staging failed for ${subject}`,
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "LakeStagingError";
+  }
+}
+
+export class ImportStorageError extends Error {
+  constructor(matchId: string, cause: unknown) {
+    super(`Canonical storage failed for imported match ${matchId}`, { cause });
+    this.name = "ImportStorageError";
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/live-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/live-polling.ts
@@ -1,0 +1,21 @@
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+
+type InitialHistoryReadClient = Pick<
+  ExtendedPrismaClient,
+  "initialMatchHistoryImport"
+>;
+
+export async function getPuuidsBlockedFromLivePolling(
+  db: InitialHistoryReadClient = prisma,
+): Promise<Set<string>> {
+  const jobs = await db.initialMatchHistoryImport.findMany({
+    where: {
+      OR: [
+        { phase: { in: ["queued", "matches"] } },
+        { phase: "failed", cursorHandedOffAt: null },
+      ],
+    },
+    select: { puuid: true },
+  });
+  return new Set(jobs.map((job) => job.puuid));
+}

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/publish.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/publish.ts
@@ -1,0 +1,60 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { initialHistoryImportPhasesTotal } from "#src/metrics/initial-history-import.ts";
+import { runReportLakeFold } from "#src/report-lake/compactor.ts";
+
+export async function publishReadyImports(
+  db: ExtendedPrismaClient,
+  now: Date,
+): Promise<void> {
+  const jobs = await db.initialMatchHistoryImport.findMany({
+    where: { phase: "publish", nextAttemptAt: { lte: now } },
+    orderBy: [{ requestedAt: "asc" }],
+  });
+  if (jobs.length === 0) return;
+
+  const accounts = await db.account.findMany({
+    where: { puuid: { in: jobs.map((job) => job.puuid) } },
+    select: { puuid: true },
+    distinct: ["puuid"],
+  });
+  const trackedPuuids = new Set(accounts.map((account) => account.puuid));
+  const abandoned = jobs.filter((job) => !trackedPuuids.has(job.puuid));
+  if (abandoned.length > 0) {
+    await db.initialMatchHistoryImport.updateMany({
+      where: { puuid: { in: abandoned.map((job) => job.puuid) } },
+      data: { phase: "complete", errorCode: "untracked", completedAt: now },
+    });
+  }
+
+  const ready = jobs.filter((job) => trackedPuuids.has(job.puuid));
+  if (ready.length === 0) return;
+  const summary = await runReportLakeFold({ prisma: db });
+  if (summary === null) return;
+
+  const completions = await Promise.all(
+    ready.map(
+      async (job) =>
+        await db.initialMatchHistoryImport.updateMany({
+          where: {
+            puuid: job.puuid,
+            phase: "publish",
+            requestedAt: job.requestedAt,
+          },
+          data: {
+            phase: "complete",
+            errorCode: null,
+            completedAt: now,
+            lastAttemptAt: now,
+          },
+        }),
+    ),
+  );
+  const completedCount = completions.reduce(
+    (total, result) => total + result.count,
+    0,
+  );
+  initialHistoryImportPhasesTotal.inc(
+    { phase: "publish", outcome: "complete" },
+    completedCount,
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/riot.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/riot.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import {
+  LeaguePuuidSchema,
+  MatchIdSchema,
+  RawMatchSchema,
+  RawSummonerLeagueListSchema,
+  type MatchId,
+  type Rank,
+  type RawMatch,
+  type Region,
+  type Ranks,
+  isCustomMatchPayload,
+  missingExpectedMatchFields,
+  platformToRegionalRoute,
+  regionToPlatformRoute,
+} from "@scout-for-lol/data";
+import { riotClient } from "#src/league/api/api.ts";
+import { extractHttpStatus } from "#src/league/api/client/errors.ts";
+import { callRiotOrThrow } from "#src/league/api/riot-call.ts";
+import { getRank } from "#src/league/model/rank.ts";
+import { saveFailedPayloadToS3 } from "#src/storage/s3-helpers.ts";
+import { PermanentImportError } from "#src/league/initial-history/errors.ts";
+
+export const INITIAL_HISTORY_MATCH_COUNT = 20;
+
+export async function fetchInitialMatchIds(input: {
+  puuid: string;
+  region: Region;
+}): Promise<MatchId[]> {
+  const puuid = LeaguePuuidSchema.parse(input.puuid);
+  return await callRiotOrThrow(
+    {
+      source: "initial-history-list",
+      schema: z.array(MatchIdSchema).max(INITIAL_HISTORY_MATCH_COUNT),
+      context: { region: input.region },
+      sentry: true,
+    },
+    () =>
+      riotClient.match.list(
+        puuid,
+        platformToRegionalRoute(input.region),
+        {
+          count: INITIAL_HISTORY_MATCH_COUNT,
+        },
+        { maxRetries: 0 },
+      ),
+  );
+}
+
+export async function fetchInitialMatch(input: {
+  matchId: MatchId;
+  region: Region;
+}): Promise<RawMatch | null> {
+  let match: RawMatch;
+  try {
+    match = await callRiotOrThrow(
+      {
+        source: "initial-history-match",
+        schema: RawMatchSchema,
+        schemaLabel: "match",
+        context: { matchId: input.matchId, region: input.region },
+        onValidationFailure: {
+          kind: "save-to-s3",
+          assetType: "match",
+          id: input.matchId,
+        },
+        sentry: true,
+      },
+      () =>
+        riotClient.match.get(
+          input.matchId,
+          platformToRegionalRoute(input.region),
+          { maxRetries: 0 },
+        ),
+    );
+  } catch (error) {
+    if (extractHttpStatus(error) === 404) return null;
+    throw error;
+  }
+
+  const missing = missingExpectedMatchFields(match);
+  if (missing.length === 0 || isCustomMatchPayload(match)) return match;
+
+  await saveFailedPayloadToS3({
+    matchId: input.matchId,
+    assetType: "match",
+    rawPayload: match,
+    validationError: {
+      issues: missing.map((path) => ({
+        path: path.split("."),
+        message: "Required field absent from a matchmade payload",
+        code: "invalid_type",
+      })),
+    },
+  });
+  throw new PermanentImportError(
+    "contract",
+    `Imported match ${input.matchId} is missing required matchmade fields: ${missing.join(", ")}`,
+  );
+}
+
+function rankOrUndefined(
+  entries: Parameters<typeof getRank>[0],
+  queue: Parameters<typeof getRank>[1],
+): Rank | undefined {
+  return getRank(entries, queue);
+}
+
+export async function fetchCurrentRanks(input: {
+  puuid: string;
+  region: Region;
+}): Promise<Ranks> {
+  const puuid = LeaguePuuidSchema.parse(input.puuid);
+  const entries = await callRiotOrThrow(
+    {
+      source: "initial-history-rank",
+      schema: RawSummonerLeagueListSchema,
+      schemaLabel: "summoner-league",
+      context: { region: input.region },
+      sentry: true,
+    },
+    () =>
+      riotClient.league.byPuuid(puuid, regionToPlatformRoute(input.region), {
+        maxRetries: 0,
+      }),
+  );
+  return {
+    solo: rankOrUndefined(entries, "RANKED_SOLO_5x5"),
+    flex: rankOrUndefined(entries, "RANKED_FLEX_SR"),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/worker.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/worker.integration.test.ts
@@ -1,0 +1,597 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  MatchIdSchema,
+  RawMatchSchema,
+  type MatchId,
+  type RawMatch,
+} from "@scout-for-lol/data";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+import { RiotHttpError } from "#src/league/api/client/errors.ts";
+import { filterNewMatches } from "#src/league/api/match-history.ts";
+
+const { prisma } = createTestDatabase("initial-history-worker");
+const importedPuuid = testPuuid("initial-worker");
+const matchIds = Array.from({ length: 20 }, (_, index) =>
+  MatchIdSchema.parse(`NA1_${(20 - index).toString()}`),
+);
+const rawFixture = RawMatchSchema.parse(
+  await Bun.file(
+    new URL(
+      "../model/__tests__/testdata/matches_2025_09_19_NA1_5370986469.json",
+      import.meta.url,
+    ),
+  ).json(),
+);
+
+function matchForId(matchId: MatchId) {
+  return RawMatchSchema.parse({
+    ...rawFixture,
+    metadata: { ...rawFixture.metadata, matchId },
+  });
+}
+
+const fetchInitialMatchIds = vi.fn(() => Promise.resolve(matchIds));
+const fetchInitialMatch = vi.fn(
+  (input: { matchId: MatchId }): Promise<RawMatch | null> =>
+    Promise.resolve(matchForId(input.matchId)),
+);
+const fetchCurrentRanks = vi.fn(() =>
+  Promise.resolve({
+    solo: {
+      tier: "gold",
+      division: 2,
+      lp: 61,
+      wins: 12,
+      losses: 9,
+    },
+    flex: undefined,
+  }),
+);
+const recordMatchForReportStore = vi.fn(() =>
+  Promise.resolve({ staged: true, stored: true }),
+);
+const runReportLakeFold = vi.fn(() => Promise.resolve({ buildId: "test" }));
+
+vi.doMock("#src/league/initial-history/riot.ts", () => ({
+  INITIAL_HISTORY_MATCH_COUNT: 20,
+  fetchInitialMatchIds,
+  fetchInitialMatch,
+  fetchCurrentRanks,
+}));
+vi.doMock("#src/report-store/live-ingest.ts", () => ({
+  recordMatchForReportStore,
+}));
+vi.doMock("#src/report-lake/compactor.ts", () => ({ runReportLakeFold }));
+
+const { getPuuidsBlockedFromLivePolling } =
+  await import("#src/league/initial-history/live-polling.ts");
+const { enqueueInitialMatchHistoryImport } =
+  await import("#src/league/initial-history/enqueue.ts");
+const { resetInitialHistoryWorkerStateForTests, runInitialHistoryImportTick } =
+  await import("#src/league/initial-history/worker.ts");
+
+beforeEach(async () => {
+  resetInitialHistoryWorkerStateForTests();
+  vi.clearAllMocks();
+  await deleteIfExists(() => prisma.initialMatchHistoryImport.deleteMany());
+  await deleteIfExists(() => prisma.currentRankSnapshot.deleteMany());
+  await deleteIfExists(() => prisma.matchRankHistory.deleteMany());
+  await deleteIfExists(() => prisma.bucksMatchEarning.deleteMany());
+  await deleteIfExists(() => prisma.activeGame.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+async function createTrackedJob(puuid = importedPuuid): Promise<void> {
+  const now = new Date("2026-08-23T12:00:00.000Z");
+  const player = await prisma.player.create({
+    data: {
+      alias: `Player-${puuid}`,
+      serverId: testGuildId("4100"),
+      creatorDiscordId: testAccountId("5100"),
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await prisma.account.create({
+    data: {
+      alias: `Account-${puuid}`,
+      puuid,
+      region: "AMERICA_NORTH",
+      playerId: player.id,
+      serverId: testGuildId("4100"),
+      creatorDiscordId: testAccountId("5100"),
+      createdTime: now,
+      updatedTime: now,
+    },
+  });
+  await prisma.initialMatchHistoryImport.create({
+    data: {
+      puuid,
+      region: "AMERICA_NORTH",
+      phase: "queued",
+      nextAttemptAt: now,
+      requestedAt: now,
+    },
+  });
+}
+
+async function verifyConcurrentReenqueueWins(): Promise<void> {
+  const initialRequestAt = new Date("2026-08-23T12:00:00.000Z");
+  const newRequestAt = new Date("2026-08-23T12:01:00.000Z");
+  await prisma.initialMatchHistoryImport.create({
+    data: {
+      puuid: importedPuuid,
+      region: "AMERICA_NORTH",
+      phase: "queued",
+      nextAttemptAt: initialRequestAt,
+      requestedAt: initialRequestAt,
+    },
+  });
+  const transactionReady = Promise.withResolvers<undefined>();
+  const releaseTransaction = Promise.withResolvers<undefined>();
+  const accountCreation = prisma.$transaction(async (tx) => {
+    const player = await tx.player.create({
+      data: {
+        alias: "Re-added Player",
+        serverId: testGuildId("4100"),
+        creatorDiscordId: testAccountId("5100"),
+        createdTime: newRequestAt,
+        updatedTime: newRequestAt,
+      },
+    });
+    await tx.account.create({
+      data: {
+        alias: "Re-added Account",
+        puuid: importedPuuid,
+        region: "AMERICA_NORTH",
+        playerId: player.id,
+        serverId: testGuildId("4100"),
+        creatorDiscordId: testAccountId("5100"),
+        createdTime: newRequestAt,
+        updatedTime: newRequestAt,
+      },
+    });
+    await enqueueInitialMatchHistoryImport({
+      puuid: importedPuuid,
+      region: "AMERICA_NORTH",
+      db: tx,
+      requestedAt: newRequestAt,
+    });
+    transactionReady.resolve(undefined);
+    await releaseTransaction.promise;
+  });
+  await transactionReady.promise;
+
+  const workerTick = runInitialHistoryImportTick(prisma, initialRequestAt);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  releaseTransaction.resolve(undefined);
+  await Promise.all([accountCreation, workerTick]);
+
+  await expect(
+    prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    }),
+  ).resolves.toMatchObject({
+    phase: "queued",
+    requestedAt: newRequestAt,
+    completedAt: null,
+    errorCode: null,
+  });
+  expect(fetchInitialMatchIds).not.toHaveBeenCalled();
+  expect(await getPuuidsBlockedFromLivePolling(prisma)).toContain(
+    importedPuuid,
+  );
+}
+
+describe("initial history worker", () => {
+  test("imports exactly 20 games in five budgeted ticks and publishes quietly", async () => {
+    await createTrackedJob();
+
+    expect(await getPuuidsBlockedFromLivePolling(prisma)).toContain(
+      importedPuuid,
+    );
+    for (let minute = 0; minute < 5; minute += 1) {
+      await runInitialHistoryImportTick(
+        prisma,
+        new Date(`2026-08-23T12:0${minute.toString()}:00.000Z`),
+      );
+      const expectedCalls = [4, 9, 14, 19, 20][minute];
+      if (expectedCalls === undefined) throw new Error("missing call budget");
+      expect(fetchInitialMatch).toHaveBeenCalledTimes(expectedCalls);
+    }
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    const account = await prisma.account.findFirstOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    const rank = await prisma.currentRankSnapshot.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    expect(job).toMatchObject({
+      phase: "complete",
+      nextMatchIndex: 20,
+      newestMatchId: matchIds[0],
+      cursorHandedOffAt: new Date("2026-08-23T12:04:00.000Z"),
+      errorCode: null,
+    });
+    expect(account.lastProcessedMatchId).toBe(matchIds[0]);
+    const completedDuringImport = MatchIdSchema.parse("NA1_21");
+    expect(
+      filterNewMatches(
+        [completedDuringImport, ...matchIds],
+        account.lastProcessedMatchId,
+      ),
+    ).toEqual({ matchIds: [completedDuringImport], gapDetected: false });
+    expect(rank.soloRank).toContain('"tier":"gold"');
+    expect(rank.flexRank).toBeNull();
+    expect(fetchInitialMatchIds).toHaveBeenCalledTimes(1);
+    expect(fetchInitialMatch).toHaveBeenCalledTimes(20);
+    expect(fetchCurrentRanks).toHaveBeenCalledTimes(1);
+    expect(recordMatchForReportStore).toHaveBeenCalledTimes(20);
+    expect(runReportLakeFold).toHaveBeenCalledTimes(1);
+    expect(await getPuuidsBlockedFromLivePolling(prisma)).not.toContain(
+      importedPuuid,
+    );
+
+    expect(await prisma.matchRankHistory.count()).toBe(0);
+    expect(await prisma.activeGame.count()).toBe(0);
+    expect(await prisma.bucksMatchEarning.count()).toBe(0);
+  });
+
+  test("rotates fairly between due PUUIDs", async () => {
+    const secondPuuid = testPuuid("initial-worker-second");
+    await createTrackedJob(importedPuuid);
+    await createTrackedJob(secondPuuid);
+
+    await runInitialHistoryImportTick(
+      prisma,
+      new Date("2026-08-23T12:00:00.000Z"),
+    );
+    await runInitialHistoryImportTick(
+      prisma,
+      new Date("2026-08-23T12:01:00.000Z"),
+    );
+
+    const jobs = await prisma.initialMatchHistoryImport.findMany({
+      orderBy: { puuid: "asc" },
+    });
+    expect(jobs).toHaveLength(2);
+    expect(jobs.every((job) => job.nextMatchIndex === 4)).toBe(true);
+  });
+
+  test("cancels without Riot traffic when no account remains", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await prisma.initialMatchHistoryImport.create({
+      data: {
+        puuid: importedPuuid,
+        region: "AMERICA_NORTH",
+        phase: "queued",
+        nextAttemptAt: now,
+        requestedAt: now,
+      },
+    });
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    expect(fetchInitialMatchIds).not.toHaveBeenCalled();
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).toMatchObject({ phase: "complete", errorCode: "untracked" });
+  });
+
+  test("does not overwrite an account creation that re-enqueues the job", async () => {
+    await verifyConcurrentReenqueueWins();
+  });
+
+  test("completes an empty history and establishes the present as the cursor boundary", async () => {
+    fetchInitialMatchIds.mockResolvedValueOnce([]);
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    const account = await prisma.account.findFirstOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    expect(job.phase).toBe("complete");
+    expect(account.lastProcessedMatchId).toBeNull();
+    expect(account.lastCheckedAt).toEqual(now);
+    expect(fetchInitialMatch).not.toHaveBeenCalled();
+    expect(fetchCurrentRanks).toHaveBeenCalledTimes(1);
+  });
+
+  test("imports fewer than 20 available games without padding the snapshot", async () => {
+    const shortHistory = matchIds.slice(0, 3);
+    fetchInitialMatchIds.mockResolvedValueOnce(shortHistory);
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(
+      prisma,
+      new Date("2026-08-23T12:00:00.000Z"),
+    );
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    expect(job).toMatchObject({
+      phase: "complete",
+      matchIdsJson: JSON.stringify(shortHistory),
+      nextMatchIndex: 3,
+    });
+    expect(fetchInitialMatch).toHaveBeenCalledTimes(3);
+    expect(fetchCurrentRanks).toHaveBeenCalledTimes(1);
+  });
+
+  test("checkpoints a permanently missing individual match and continues", async () => {
+    fetchInitialMatch.mockResolvedValueOnce(null);
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(
+      prisma,
+      new Date("2026-08-23T12:00:00.000Z"),
+    );
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    expect(job).toMatchObject({ phase: "matches", nextMatchIndex: 4 });
+    expect(fetchInitialMatch).toHaveBeenCalledTimes(4);
+    expect(recordMatchForReportStore).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("initial history worker failure handling", () => {
+  test("retries Riot 429s after one minute without consuming another job checkpoint", async () => {
+    fetchInitialMatchIds.mockRejectedValueOnce(
+      new RiotHttpError({
+        status: 429,
+        statusText: "Too Many Requests",
+        body: null,
+        url: "https://riot.test/matches",
+        headers: new Headers({ "retry-after": "60" }),
+      }),
+    );
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).toMatchObject({
+      phase: "queued",
+      attemptCount: 1,
+      errorCode: "rate_limit",
+      nextAttemptAt: new Date("2026-08-23T12:01:00.000Z"),
+    });
+  });
+
+  test("backs repeated retryable failures off by 1, 5, 15, then 60 minutes", async () => {
+    const rateLimitError = new RiotHttpError({
+      status: 429,
+      statusText: "Too Many Requests",
+      body: null,
+      url: "https://riot.test/matches",
+      headers: new Headers(),
+    });
+    fetchInitialMatchIds
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError);
+    await createTrackedJob();
+
+    const attempts = [
+      ["2026-08-23T12:00:00.000Z", "2026-08-23T12:01:00.000Z"],
+      ["2026-08-23T12:01:00.000Z", "2026-08-23T12:06:00.000Z"],
+      ["2026-08-23T12:06:00.000Z", "2026-08-23T12:21:00.000Z"],
+      ["2026-08-23T12:21:00.000Z", "2026-08-23T13:21:00.000Z"],
+    ];
+    for (const [attemptAt, expectedNextAttemptAt] of attempts) {
+      if (attemptAt === undefined || expectedNextAttemptAt === undefined) {
+        throw new Error("missing retry schedule fixture");
+      }
+      await runInitialHistoryImportTick(prisma, new Date(attemptAt));
+      const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      });
+      expect(job.nextAttemptAt).toEqual(new Date(expectedNextAttemptAt));
+    }
+  });
+
+  test("restarts backoff after progress within the same tick", async () => {
+    const upstreamError = new RiotHttpError({
+      status: 503,
+      statusText: "Service Unavailable",
+      body: null,
+      url: "https://riot.test/match",
+      headers: new Headers(),
+    });
+    fetchInitialMatch.mockRejectedValueOnce(upstreamError);
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+    await prisma.initialMatchHistoryImport.update({
+      where: { puuid: importedPuuid },
+      data: { attemptCount: 4 },
+    });
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).toMatchObject({
+      phase: "matches",
+      nextMatchIndex: 0,
+      attemptCount: 1,
+      nextAttemptAt: new Date("2026-08-23T12:01:00.000Z"),
+    });
+  });
+
+  test("fails loudly on Riot authentication errors", async () => {
+    fetchInitialMatchIds.mockRejectedValueOnce(
+      new RiotHttpError({
+        status: 403,
+        statusText: "Forbidden",
+        body: null,
+        url: "https://riot.test/matches",
+        headers: new Headers(),
+      }),
+    );
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).toMatchObject({
+      phase: "failed",
+      errorCode: "authentication",
+      completedAt: now,
+    });
+    expect(await getPuuidsBlockedFromLivePolling(prisma)).toContain(
+      importedPuuid,
+    );
+  });
+
+  test("does not block live polling after a post-handoff terminal failure", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+    await prisma.initialMatchHistoryImport.update({
+      where: { puuid: importedPuuid },
+      data: {
+        phase: "failed",
+        cursorHandedOffAt: now,
+        errorCode: "contract",
+        completedAt: now,
+      },
+    });
+
+    expect(await getPuuidsBlockedFromLivePolling(prisma)).not.toContain(
+      importedPuuid,
+    );
+  });
+});
+
+describe("initial history worker storage and publish failures", () => {
+  test("does not checkpoint when canonical S3 storage is unavailable", async () => {
+    recordMatchForReportStore.mockResolvedValueOnce({
+      staged: true,
+      stored: false,
+    });
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).toMatchObject({
+      phase: "matches",
+      nextMatchIndex: 0,
+      attemptCount: 1,
+      errorCode: "storage",
+    });
+  });
+
+  test("does not checkpoint when immediate lake staging fails", async () => {
+    recordMatchForReportStore.mockResolvedValueOnce({
+      staged: false,
+      stored: true,
+    });
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    await createTrackedJob();
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).toMatchObject({
+      phase: "matches",
+      nextMatchIndex: 0,
+      attemptCount: 1,
+      errorCode: "staging",
+    });
+  });
+
+  test("retries a failed report-lake fold as a staging failure", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    runReportLakeFold.mockRejectedValueOnce(new Error("fold failed"));
+    await createTrackedJob();
+    await prisma.initialMatchHistoryImport.update({
+      where: { puuid: importedPuuid },
+      data: { phase: "publish" },
+    });
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    const job = await prisma.initialMatchHistoryImport.findUniqueOrThrow({
+      where: { puuid: importedPuuid },
+    });
+    expect(job).toMatchObject({
+      phase: "publish",
+      attemptCount: 1,
+      errorCode: "staging",
+      nextAttemptAt: new Date("2026-08-23T12:01:00.000Z"),
+    });
+  });
+
+  test("does not complete a publish generation accepted during the fold", async () => {
+    const now = new Date("2026-08-23T12:00:00.000Z");
+    const newerRequestAt = new Date("2026-08-23T12:01:00.000Z");
+    await createTrackedJob();
+    await prisma.initialMatchHistoryImport.update({
+      where: { puuid: importedPuuid },
+      data: { phase: "publish" },
+    });
+    runReportLakeFold.mockImplementationOnce(async () => {
+      await prisma.initialMatchHistoryImport.update({
+        where: { puuid: importedPuuid },
+        data: { requestedAt: newerRequestAt },
+      });
+      return { buildId: "stale-fold" };
+    });
+
+    await runInitialHistoryImportTick(prisma, now);
+
+    await expect(
+      prisma.initialMatchHistoryImport.findUniqueOrThrow({
+        where: { puuid: importedPuuid },
+      }),
+    ).resolves.toMatchObject({
+      phase: "publish",
+      requestedAt: newerRequestAt,
+      completedAt: null,
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/initial-history/worker.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/initial-history/worker.ts
@@ -1,0 +1,486 @@
+import { z, ZodError } from "zod";
+import * as Sentry from "@sentry/bun";
+import {
+  MatchIdSchema,
+  LeaguePuuidSchema,
+  RegionSchema,
+  type LeaguePuuid,
+  type MatchId,
+  type Rank,
+} from "@scout-for-lol/data";
+import type { InitialMatchHistoryImport } from "#generated/prisma/client/index.js";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { extractHttpStatus } from "#src/league/api/client/errors.ts";
+import {
+  ImportStorageError,
+  LakeStagingError,
+  PermanentImportError,
+} from "#src/league/initial-history/errors.ts";
+import {
+  fetchCurrentRanks,
+  fetchInitialMatch,
+  fetchInitialMatchIds,
+  INITIAL_HISTORY_MATCH_COUNT,
+} from "#src/league/initial-history/riot.ts";
+import { lockInitialMatchHistoryImport } from "#src/league/initial-history/enqueue.ts";
+import { publishReadyImports } from "#src/league/initial-history/publish.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  initialHistoryImportJobs,
+  initialHistoryImportMatchesTotal,
+  initialHistoryImportOldestActionableTimestamp,
+  initialHistoryImportPhasesTotal,
+  initialHistoryImportRankTotal,
+  initialHistoryImportRetriesTotal,
+} from "#src/metrics/initial-history-import.ts";
+import { recordMatchForReportStore } from "#src/report-store/live-ingest.ts";
+
+const logger = createLogger("initial-history-import");
+const RIOT_CALLS_PER_TICK = 5;
+const RETRY_DELAYS_MS = [60_000, 300_000, 900_000, 3_600_000];
+const ACTIONABLE_PHASES = ["queued", "matches", "rank", "publish"];
+const ALL_PHASES = [...ACTIONABLE_PHASES, "complete", "failed"];
+let riotBudgetMinute: number | undefined;
+let riotCallsThisMinute = 0;
+let workerInProgress = false;
+
+const MatchSnapshotSchema = z
+  .array(MatchIdSchema)
+  .max(INITIAL_HISTORY_MATCH_COUNT);
+
+type RetryReason =
+  "rate_limit" | "upstream" | "transport" | "storage" | "staging";
+
+function serializeRank(rank: Rank | undefined): string | null {
+  return rank === undefined ? null : JSON.stringify(rank);
+}
+
+function classifyFailure(
+  error: unknown,
+):
+  | { kind: "permanent"; code: "authentication" | "contract" }
+  | { kind: "retry"; reason: RetryReason } {
+  if (error instanceof PermanentImportError) {
+    return { kind: "permanent", code: error.code };
+  }
+  if (error instanceof ZodError) {
+    return { kind: "permanent", code: "contract" };
+  }
+  if (error instanceof LakeStagingError) {
+    return { kind: "retry", reason: "staging" };
+  }
+  if (error instanceof ImportStorageError) {
+    return { kind: "retry", reason: "storage" };
+  }
+  const status = extractHttpStatus(error);
+  if (status === 401 || status === 403) {
+    return { kind: "permanent", code: "authentication" };
+  }
+  if (status !== 429 && status !== undefined && status >= 400 && status < 500) {
+    return { kind: "permanent", code: "contract" };
+  }
+  if (status === 429) return { kind: "retry", reason: "rate_limit" };
+  if (status !== undefined) return { kind: "retry", reason: "upstream" };
+  return { kind: "retry", reason: "transport" };
+}
+
+async function trackedAliases(
+  db: ExtendedPrismaClient,
+  puuid: LeaguePuuid,
+): Promise<string[]> {
+  const accounts = await db.account.findMany({
+    where: { puuid },
+    include: { player: { select: { alias: true } } },
+  });
+  return [...new Set(accounts.map((account) => account.player.alias))];
+}
+
+async function claimTrackedJobOrCompleteUntracked(
+  db: ExtendedPrismaClient,
+  selected: InitialMatchHistoryImport,
+  now: Date,
+): Promise<boolean> {
+  const puuid = LeaguePuuidSchema.parse(selected.puuid);
+  return await db.$transaction(async (tx) => {
+    await lockInitialMatchHistoryImport(tx, puuid);
+    const current = await tx.initialMatchHistoryImport.findUnique({
+      where: { puuid },
+      select: { phase: true, updatedAt: true },
+    });
+    if (
+      current?.phase !== selected.phase ||
+      current.updatedAt.getTime() !== selected.updatedAt.getTime()
+    ) {
+      return false;
+    }
+
+    const tracked = await tx.account.count({ where: { puuid } });
+    if (tracked > 0) return true;
+
+    await tx.initialMatchHistoryImport.updateMany({
+      where: {
+        puuid,
+        phase: selected.phase,
+        updatedAt: selected.updatedAt,
+      },
+      data: {
+        phase: "complete",
+        completedAt: now,
+        errorCode: "untracked",
+        lastAttemptAt: now,
+      },
+    });
+    return false;
+  });
+}
+
+async function handOffLiveCursor(
+  db: ExtendedPrismaClient,
+  job: InitialMatchHistoryImport,
+  now: Date,
+): Promise<InitialMatchHistoryImport> {
+  return await db.$transaction(async (tx) => {
+    await tx.account.updateMany({
+      where: { puuid: job.puuid },
+      data: {
+        lastProcessedMatchId:
+          job.newestMatchId === null
+            ? null
+            : MatchIdSchema.parse(job.newestMatchId),
+        lastMatchTime: job.newestMatchTime,
+        lastCheckedAt: now,
+        updatedTime: now,
+      },
+    });
+    return await tx.initialMatchHistoryImport.update({
+      where: { puuid: job.puuid },
+      data: {
+        phase: "rank",
+        cursorHandedOffAt: now,
+        attemptCount: 0,
+        errorCode: null,
+        lastAttemptAt: now,
+        nextAttemptAt: now,
+      },
+    });
+  });
+}
+
+async function ingestOneMatch(
+  db: ExtendedPrismaClient,
+  job: InitialMatchHistoryImport,
+  matchIds: MatchId[],
+  now: Date,
+): Promise<InitialMatchHistoryImport> {
+  const matchId = MatchIdSchema.parse(matchIds[job.nextMatchIndex]);
+  const region = RegionSchema.parse(job.region);
+  const match = await fetchInitialMatch({ matchId, region });
+  if (match === null) {
+    initialHistoryImportMatchesTotal.inc({ outcome: "skipped" });
+    return await db.initialMatchHistoryImport.update({
+      where: { puuid: job.puuid },
+      data: {
+        nextMatchIndex: { increment: 1 },
+        attemptCount: 0,
+        errorCode: null,
+        lastAttemptAt: now,
+        nextAttemptAt: now,
+      },
+    });
+  }
+
+  let ingestResult: { staged: boolean; stored: boolean };
+  try {
+    ingestResult = await recordMatchForReportStore({
+      match,
+      source: "initial_history_import",
+      trackedPlayerAliases: await trackedAliases(
+        db,
+        LeaguePuuidSchema.parse(job.puuid),
+      ),
+    });
+  } catch (error) {
+    throw new ImportStorageError(matchId, error);
+  }
+  if (!ingestResult.stored) {
+    throw new ImportStorageError(
+      matchId,
+      new Error("Canonical S3 storage is unavailable"),
+    );
+  }
+  if (!ingestResult.staged) throw new LakeStagingError(matchId);
+
+  initialHistoryImportMatchesTotal.inc({ outcome: "stored" });
+  return await db.initialMatchHistoryImport.update({
+    where: { puuid: job.puuid },
+    data: {
+      nextMatchIndex: { increment: 1 },
+      newestMatchTime: job.newestMatchTime ?? new Date(match.info.gameCreation),
+      attemptCount: 0,
+      errorCode: null,
+      lastAttemptAt: now,
+      nextAttemptAt: now,
+    },
+  });
+}
+
+async function processRiotPhases(
+  db: ExtendedPrismaClient,
+  selected: InitialMatchHistoryImport,
+  now: Date,
+  availableCalls: number,
+): Promise<void> {
+  let job = selected;
+  let calls = 0;
+  const countCall = (): void => {
+    calls += 1;
+    riotCallsThisMinute += 1;
+  };
+  while (calls < availableCalls) {
+    if (job.phase === "queued") {
+      let matchIds: MatchId[];
+      try {
+        matchIds = await fetchInitialMatchIds({
+          puuid: job.puuid,
+          region: RegionSchema.parse(job.region),
+        });
+      } finally {
+        countCall();
+      }
+      job = await db.initialMatchHistoryImport.update({
+        where: { puuid: job.puuid },
+        data: {
+          phase: "matches",
+          matchIdsJson: JSON.stringify(matchIds),
+          snapshotAt: now,
+          newestMatchId: matchIds[0] ?? null,
+          nextMatchIndex: 0,
+          attemptCount: 0,
+          errorCode: null,
+          lastAttemptAt: now,
+          nextAttemptAt: now,
+        },
+      });
+      initialHistoryImportPhasesTotal.inc({
+        phase: "queued",
+        outcome: "complete",
+      });
+      continue;
+    }
+
+    if (job.phase === "matches") {
+      const matchIds = MatchSnapshotSchema.parse(
+        JSON.parse(job.matchIdsJson ?? "null"),
+      );
+      if (job.nextMatchIndex >= matchIds.length) {
+        job = await handOffLiveCursor(db, job, now);
+        initialHistoryImportPhasesTotal.inc({
+          phase: "matches",
+          outcome: "complete",
+        });
+        continue;
+      }
+      try {
+        job = await ingestOneMatch(db, job, matchIds, now);
+      } finally {
+        countCall();
+      }
+      continue;
+    }
+
+    if (job.phase === "rank") {
+      let ranks: Awaited<ReturnType<typeof fetchCurrentRanks>>;
+      try {
+        ranks = await fetchCurrentRanks({
+          puuid: job.puuid,
+          region: RegionSchema.parse(job.region),
+        });
+      } finally {
+        countCall();
+      }
+      await db.currentRankSnapshot.upsert({
+        where: { puuid: job.puuid },
+        create: {
+          puuid: job.puuid,
+          soloRank: serializeRank(ranks.solo),
+          flexRank: serializeRank(ranks.flex),
+          fetchedAt: now,
+        },
+        update: {
+          soloRank: serializeRank(ranks.solo),
+          flexRank: serializeRank(ranks.flex),
+          fetchedAt: now,
+        },
+      });
+      await db.initialMatchHistoryImport.update({
+        where: { puuid: job.puuid },
+        data: {
+          phase: "publish",
+          lastImportedAt: now,
+          attemptCount: 0,
+          errorCode: null,
+          lastAttemptAt: now,
+          nextAttemptAt: now,
+        },
+      });
+      initialHistoryImportRankTotal.inc({ outcome: "stored" });
+      initialHistoryImportPhasesTotal.inc({
+        phase: "rank",
+        outcome: "complete",
+      });
+    }
+    return;
+  }
+}
+
+async function persistFailure(
+  db: ExtendedPrismaClient,
+  job: InitialMatchHistoryImport,
+  error: unknown,
+  now: Date,
+): Promise<void> {
+  const failure = classifyFailure(error);
+  if (failure.kind === "permanent") {
+    await db.initialMatchHistoryImport.update({
+      where: { puuid: job.puuid },
+      data: {
+        phase: "failed",
+        errorCode: failure.code,
+        completedAt: now,
+        lastAttemptAt: now,
+      },
+    });
+    initialHistoryImportPhasesTotal.inc({
+      phase: job.phase,
+      outcome: "failed",
+    });
+    if (job.phase === "rank") {
+      initialHistoryImportRankTotal.inc({ outcome: "failed" });
+    }
+    Sentry.captureException(error, {
+      tags: { source: "initial-history-import", errorCode: failure.code },
+    });
+    return;
+  }
+
+  const attemptCount = job.attemptCount + 1;
+  const delay = RETRY_DELAYS_MS[Math.min(attemptCount - 1, 3)];
+  if (delay === undefined) throw new Error("Import retry schedule is empty");
+  await db.initialMatchHistoryImport.update({
+    where: { puuid: job.puuid },
+    data: {
+      attemptCount,
+      errorCode: failure.reason,
+      lastAttemptAt: now,
+      nextAttemptAt: new Date(now.getTime() + delay),
+    },
+  });
+  initialHistoryImportRetriesTotal.inc({ reason: failure.reason });
+  initialHistoryImportPhasesTotal.inc({
+    phase: job.phase,
+    outcome: "retry",
+  });
+  if (job.phase === "rank") {
+    initialHistoryImportRankTotal.inc({ outcome: "retry" });
+  }
+}
+
+async function refreshQueueMetrics(db: ExtendedPrismaClient): Promise<void> {
+  const [counts, oldest] = await Promise.all([
+    db.initialMatchHistoryImport.groupBy({
+      by: ["phase"],
+      _count: { _all: true },
+    }),
+    db.initialMatchHistoryImport.findFirst({
+      where: { phase: { in: ACTIONABLE_PHASES } },
+      orderBy: { requestedAt: "asc" },
+      select: { requestedAt: true },
+    }),
+  ]);
+  const countByPhase = new Map(
+    counts.map((entry) => [entry.phase, entry._count._all]),
+  );
+  for (const phase of ALL_PHASES) {
+    initialHistoryImportJobs.set({ phase }, countByPhase.get(phase) ?? 0);
+  }
+  initialHistoryImportOldestActionableTimestamp.set(
+    oldest?.requestedAt.getTime() === undefined
+      ? 0
+      : oldest.requestedAt.getTime() / 1000,
+  );
+}
+
+export async function runInitialHistoryImportTick(
+  db: ExtendedPrismaClient = prisma,
+  now = new Date(),
+): Promise<void> {
+  if (workerInProgress) return;
+  workerInProgress = true;
+  try {
+    const minute = Math.floor(now.getTime() / 60_000);
+    if (riotBudgetMinute !== minute) {
+      riotBudgetMinute = minute;
+      riotCallsThisMinute = 0;
+    }
+    const availableCalls = Math.max(
+      0,
+      RIOT_CALLS_PER_TICK - riotCallsThisMinute,
+    );
+    const selected = await db.initialMatchHistoryImport.findFirst({
+      where: {
+        phase: { in: ACTIONABLE_PHASES },
+        nextAttemptAt: { lte: now },
+      },
+      orderBy: [
+        { lastAttemptAt: { sort: "asc", nulls: "first" } },
+        { requestedAt: "asc" },
+      ],
+    });
+
+    if (selected !== null) {
+      const shouldProcess = await claimTrackedJobOrCompleteUntracked(
+        db,
+        selected,
+        now,
+      );
+      if (shouldProcess && selected.phase !== "publish" && availableCalls > 0) {
+        try {
+          await processRiotPhases(db, selected, now, availableCalls);
+        } catch (error) {
+          logger.error("Initial match history import attempt failed", error);
+          const latest = await db.initialMatchHistoryImport.findUniqueOrThrow({
+            where: { puuid: selected.puuid },
+          });
+          await persistFailure(db, latest, error, now);
+        }
+      }
+    }
+
+    try {
+      await publishReadyImports(db, now);
+    } catch (error) {
+      logger.error("Initial history report-lake publish failed", error);
+      const publishing = await db.initialMatchHistoryImport.findFirst({
+        where: { phase: "publish", nextAttemptAt: { lte: now } },
+        orderBy: { requestedAt: "asc" },
+      });
+      if (publishing !== null) {
+        await persistFailure(
+          db,
+          publishing,
+          new LakeStagingError("report-lake fold", error),
+          now,
+        );
+      }
+    }
+    await refreshQueueMetrics(db);
+  } finally {
+    workerInProgress = false;
+  }
+}
+
+export function resetInitialHistoryWorkerStateForTests(): void {
+  riotBudgetMinute = undefined;
+  riotCallsThisMinute = 0;
+  workerInProgress = false;
+}

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/index.ts
@@ -1,5 +1,8 @@
 import { retryPendingBucksEarnings } from "#src/betting/earnings-retry.ts";
-import { checkMatchHistory } from "#src/league/tasks/postmatch/match-history-polling.ts";
+import {
+  checkMatchHistory,
+  isMatchHistoryPollingInProgress,
+} from "#src/league/tasks/postmatch/match-history-polling.ts";
 import { announceSettlements } from "#src/betting/announce.ts";
 import { refreshClosedBucksMessages } from "#src/betting/message-refresh.ts";
 import { voidStaleBettingPools } from "#src/betting/void-stale.ts";
@@ -8,6 +11,7 @@ import { getPostmatchMessageIdsForMatchIdOrEmpty } from "#src/league/tasks/prema
 import { MatchIdSchema } from "@scout-for-lol/data/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { isFeatureHardDisabled } from "#src/configuration/flags.ts";
+import { runInitialHistoryImportTick } from "#src/league/initial-history/worker.ts";
 
 const logger = createLogger("tasks-postmatch");
 
@@ -35,6 +39,18 @@ export async function checkPostMatch() {
           : "❌ Match history polling failed; running Bryan Bucks recovery anyway:",
         error,
       );
+    }
+    if (matchHistoryError === undefined && !isMatchHistoryPollingInProgress()) {
+      try {
+        await runInitialHistoryImportTick();
+      } catch (error) {
+        // The durable job retained its checkpoint. Import traffic must never
+        // turn a successful notification-critical poll into a failed cron run.
+        logger.error(
+          "Initial history import tick failed after live polling",
+          error,
+        );
+      }
     }
 
     if (bettingHardDisabled) {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -54,6 +54,7 @@ import {
   recordPostmatchMessageIds,
 } from "#src/league/tasks/prematch/active-game-queries.ts";
 import { recordCoreOutputsDelivered } from "#src/analytics/guild-lifecycle.ts";
+import { getPuuidsBlockedFromLivePolling } from "#src/league/initial-history/live-polling.ts";
 
 const logger = createLogger("postmatch-match-history-polling");
 
@@ -405,12 +406,19 @@ export async function checkMatchHistory(): Promise<void> {
 
   try {
     // Get all tracked player accounts with their polling state
-    const accountsWithState = await getAccountsWithState(
-      prisma,
-      getActiveServerIds(),
+    const [allAccountsWithState, blockedPuuids] = await prisma.$transaction(
+      async (tx) =>
+        await Promise.all([
+          getAccountsWithState(tx, getActiveServerIds()),
+          getPuuidsBlockedFromLivePolling(tx),
+        ]),
+      { isolationLevel: "RepeatableRead" },
+    );
+    const accountsWithState = allAccountsWithState.filter(
+      ({ config }) => !blockedPuuids.has(config.league.leagueAccount.puuid),
     );
     logger.info(
-      `📊 Found ${accountsWithState.length.toString()} total player account(s)`,
+      `📊 Found ${accountsWithState.length.toString()} pollable player account(s); ${blockedPuuids.size.toString()} PUUID(s) are completing initial history import`,
     );
 
     if (accountsWithState.length === 0) {

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.test.ts
@@ -16,6 +16,10 @@ import {
   testGuildId,
   testPuuid,
 } from "#src/testing/test-ids.ts";
+import {
+  addFlagOverride,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
 
 const { prisma } = createTestDatabase("account-admin-mutations");
 const puuidsByRiotName = new Map<string, LeaguePuuid>();
@@ -41,7 +45,7 @@ vi.doMock("#src/lib/riot/resolve-puuid.ts", () => ({
     }),
 }));
 
-const { deleteAccount, transferAccount } =
+const { addAccount, deleteAccount, transferAccount } =
   await import("#src/lib/player-admin/account-mutations.ts");
 
 const guildId = testGuildId("9931");
@@ -52,7 +56,9 @@ const ctx = {
 };
 
 beforeEach(async () => {
+  resetFlagOverrides("initial_match_history_import_enabled");
   puuidsByRiotName.clear();
+  await deleteIfExists(() => prisma.initialMatchHistoryImport.deleteMany());
   await deleteIfExists(() => prisma.auditLog.deleteMany());
   await deleteIfExists(() => prisma.subscription.deleteMany());
   await deleteIfExists(() => prisma.account.deleteMany());
@@ -66,6 +72,43 @@ afterAll(async () => {
 });
 
 describe("account admin mutations", () => {
+  test("atomically enqueues first-run history when the guild flag is enabled", async () => {
+    await createPlayer("History Player");
+    const puuid = testPuuid("history-account");
+    puuidsByRiotName.set("HistoryMain", puuid);
+    addFlagOverride("initial_match_history_import_enabled", true, {
+      server: guildId,
+    });
+
+    await addAccount(ctx, {
+      guildId,
+      playerAlias: "History Player",
+      riotId: { game_name: "HistoryMain", tag_line: "NA1" },
+      region: "AMERICA_NORTH",
+    });
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUnique({ where: { puuid } }),
+    ).toMatchObject({ phase: "queued", region: "AMERICA_NORTH" });
+  });
+
+  test("preserves timestamp-only onboarding when the guild flag is disabled", async () => {
+    await createPlayer("Legacy Player");
+    const puuid = testPuuid("legacy-account");
+    puuidsByRiotName.set("LegacyMain", puuid);
+
+    await addAccount(ctx, {
+      guildId,
+      playerAlias: "Legacy Player",
+      riotId: { game_name: "LegacyMain", tag_line: "NA1" },
+      region: "AMERICA_NORTH",
+    });
+
+    expect(
+      await prisma.initialMatchHistoryImport.findUnique({ where: { puuid } }),
+    ).toBeNull();
+  });
+
   test("deleteAccount rejects deleting the last account without audit", async () => {
     const player = await createPlayer("Solo");
     const puuid = testPuuid("solo-account");

--- a/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-admin/account-mutations.ts
@@ -12,6 +12,8 @@ import { recordAudit } from "#src/lib/audit/index.ts";
 import { resolvePuuidFromRiotId } from "#src/lib/riot/resolve-puuid.ts";
 import { backfillLastMatchTime } from "#src/league/api/backfill-match-history.ts";
 import { getRiotIdByPuuid } from "#src/lib/riot/account-riot-id.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { enqueueInitialMatchHistoryImport } from "#src/league/initial-history/enqueue.ts";
 import {
   AliasSchema,
   conflict,
@@ -88,6 +90,10 @@ export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
     alias: input.playerAlias,
   });
   const puuid = await resolvePuuidOrThrow(input);
+  const initialHistoryImportEnabled = await isPolicyEnabled(
+    "initial_match_history_import_enabled",
+    { server: input.guildId },
+  );
 
   const now = new Date();
   const accountAlias = `${input.riotId.game_name}#${input.riotId.tag_line}`;
@@ -120,6 +126,14 @@ export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
           updatedTime: now,
         },
       });
+      if (initialHistoryImportEnabled) {
+        await enqueueInitialMatchHistoryImport({
+          puuid,
+          region: input.region,
+          db: tx,
+          requestedAt: now,
+        });
+      }
       await recordAudit(
         {
           action: "ACCOUNT_ADD",
@@ -157,7 +171,9 @@ export async function addAccount(ctx: WebCtx, input: AddAccountInputData) {
           },
         }),
   };
-  void backfillLastMatchTime(playerConfigEntry, puuid);
+  if (!initialHistoryImportEnabled) {
+    void backfillLastMatchTime(playerConfigEntry, puuid);
+  }
   return { accountId: created.id, accountAlias: created.alias };
 }
 

--- a/packages/scout-for-lol/packages/backend/src/lib/player-profile/queries.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/player-profile/queries.ts
@@ -81,20 +81,49 @@ function parseRank(serialized: string | null): Rank | undefined {
 async function latestRanks(
   puuids: string[],
 ): Promise<{ solo: Rank | undefined; flex: Rank | undefined }> {
-  const [solo, flex] = await Promise.all(
-    (["solo", "flex"] as const).map(async (queueType) =>
-      prisma.matchRankHistory.findFirst({
-        where: { puuid: { in: puuids }, queueType, rankAfter: { not: null } },
-        orderBy: [
-          { matchGameEndAt: { sort: "desc", nulls: "last" } },
-          { capturedAt: "desc" },
-        ],
-      }),
+  const [rankHistory, current] = await Promise.all([
+    Promise.all(
+      (["solo", "flex"] as const).map(async (queueType) =>
+        prisma.matchRankHistory.findFirst({
+          where: {
+            puuid: { in: puuids },
+            queueType,
+            rankAfter: { not: null },
+          },
+          orderBy: [
+            { matchGameEndAt: { sort: "desc", nulls: "last" } },
+            { capturedAt: "desc" },
+          ],
+        }),
+      ),
     ),
-  );
+    prisma.currentRankSnapshot.findMany({
+      where: { puuid: { in: puuids } },
+      orderBy: { fetchedAt: "desc" },
+    }),
+  ]);
+
+  function newestRank(
+    live: (typeof rankHistory)[number] | undefined,
+    queueType: "solo" | "flex",
+  ): Rank | undefined {
+    const snapshot = current.find((entry) =>
+      queueType === "solo" ? entry.soloRank !== null : entry.flexRank !== null,
+    );
+    const snapshotValue =
+      queueType === "solo" ? snapshot?.soloRank : snapshot?.flexRank;
+    if (
+      snapshot !== undefined &&
+      (live == null || snapshot.fetchedAt > live.capturedAt)
+    ) {
+      return parseRank(snapshotValue ?? null);
+    }
+    return parseRank(live?.rankAfter ?? null);
+  }
+
   return {
-    solo: parseRank(solo?.rankAfter ?? null),
-    flex: parseRank(flex?.rankAfter ?? null),
+    solo: newestRank(rankHistory[0], "solo"),
+    flex: newestRank(rankHistory[1], "flex"),
   };
 }
 

--- a/packages/scout-for-lol/packages/backend/src/lib/subscription/add.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/subscription/add.integration.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+import { addSubscription } from "#src/lib/subscription/add.ts";
+
+const { prisma } = createTestDatabase("subscription-initial-history");
+const guildId = testGuildId("7100");
+const channelId = testChannelId("7200");
+const creatorDiscordId = testAccountId("7300");
+
+beforeEach(async () => {
+  await deleteIfExists(() => prisma.initialMatchHistoryImport.deleteMany());
+  await deleteIfExists(() => prisma.subscription.deleteMany());
+  await deleteIfExists(() => prisma.account.deleteMany());
+  await deleteIfExists(() => prisma.player.deleteMany());
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+function input(gameName: string) {
+  return {
+    guildId,
+    channelId,
+    region: "AMERICA_NORTH" as const,
+    riotId: { game_name: gameName, tag_line: "NA1" },
+    alias: "Tracked Player",
+    creatorDiscordId,
+    filters: null,
+  };
+}
+
+describe("subscription initial history enqueue", () => {
+  test("enqueues in the same transaction when enabled", async () => {
+    const puuid = testPuuid("subscription-history");
+    const result = await prisma.$transaction((tx) =>
+      addSubscription(input("HistoryMain"), puuid, tx, true),
+    );
+
+    expect(result.kind).toBe("created");
+    expect(
+      await prisma.initialMatchHistoryImport.findUnique({ where: { puuid } }),
+    ).toMatchObject({ phase: "queued" });
+  });
+
+  test("does not enqueue when disabled", async () => {
+    const puuid = testPuuid("subscription-legacy");
+    const result = await prisma.$transaction((tx) =>
+      addSubscription(input("LegacyMain"), puuid, tx, false),
+    );
+
+    expect(result.kind).toBe("created");
+    expect(
+      await prisma.initialMatchHistoryImport.findUnique({ where: { puuid } }),
+    ).toBeNull();
+  });
+
+  test("enqueues an additional account even when the channel subscription exists", async () => {
+    const firstPuuid = testPuuid("subscription-first");
+    const secondPuuid = testPuuid("subscription-second");
+    await prisma.$transaction((tx) =>
+      addSubscription(input("FirstMain"), firstPuuid, tx, false),
+    );
+
+    const result = await prisma.$transaction((tx) =>
+      addSubscription(input("SecondMain"), secondPuuid, tx, true),
+    );
+
+    expect(result.kind).toBe("subscription-already-exists");
+    expect(
+      await prisma.initialMatchHistoryImport.findUnique({
+        where: { puuid: secondPuuid },
+      }),
+    ).toMatchObject({ phase: "queued" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/lib/subscription/add.ts
+++ b/packages/scout-for-lol/packages/backend/src/lib/subscription/add.ts
@@ -16,6 +16,7 @@ import type {
 } from "#src/lib/subscription/types.ts";
 import { resolveRiotIdToPuuid } from "#src/lib/riot/resolve-puuid.ts";
 import { checkSubscriptionAndAccountLimits } from "#src/lib/subscription/limits.ts";
+import { enqueueInitialMatchHistoryImport } from "#src/league/initial-history/enqueue.ts";
 
 const logger = createLogger("subscription-add");
 
@@ -34,8 +35,9 @@ async function commitSubscription(params: {
   input: AddSubscriptionInput;
   puuid: LeaguePuuid;
   db: Db;
+  initialHistoryImportEnabled: boolean;
 }): Promise<AddSubscriptionResult> {
-  const { input, puuid, db } = params;
+  const { input, puuid, db, initialHistoryImportEnabled } = params;
   const {
     guildId,
     channelId,
@@ -107,6 +109,15 @@ async function commitSubscription(params: {
       updatedTime: now,
     },
   });
+
+  if (initialHistoryImportEnabled) {
+    await enqueueInitialMatchHistoryImport({
+      puuid,
+      region,
+      db,
+      requestedAt: now,
+    });
+  }
 
   const playerAccount = await db.account.findUnique({
     where: { id: account.id },
@@ -225,9 +236,15 @@ export async function addSubscription(
   input: AddSubscriptionInput,
   puuid: LeaguePuuid,
   db: Db,
+  initialHistoryImportEnabled: boolean,
 ): Promise<AddSubscriptionResult> {
   try {
-    return await commitSubscription({ input, puuid, db });
+    return await commitSubscription({
+      input,
+      puuid,
+      db,
+      initialHistoryImportEnabled,
+    });
   } catch (error) {
     logger.error("❌ Database error during subscription:", error);
     return { kind: "internal-error", message: getErrorMessage(error) };

--- a/packages/scout-for-lol/packages/backend/src/metrics/initial-history-import.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/initial-history-import.ts
@@ -1,0 +1,43 @@
+import { Counter, Gauge } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+export const initialHistoryImportJobs = new Gauge({
+  name: "scout_initial_history_import_jobs",
+  help: "Initial history import jobs by bounded workflow phase.",
+  labelNames: ["phase"] as const,
+  registers: [registry],
+});
+
+export const initialHistoryImportOldestActionableTimestamp = new Gauge({
+  name: "scout_initial_history_import_oldest_actionable_timestamp_seconds",
+  help: "Request timestamp of the oldest actionable initial history import, or zero.",
+  registers: [registry],
+});
+
+export const initialHistoryImportPhasesTotal = new Counter({
+  name: "scout_initial_history_import_phases_total",
+  help: "Initial history import phase outcomes.",
+  labelNames: ["phase", "outcome"] as const,
+  registers: [registry],
+});
+
+export const initialHistoryImportMatchesTotal = new Counter({
+  name: "scout_initial_history_import_matches_total",
+  help: "Initial history matches by bounded ingest outcome.",
+  labelNames: ["outcome"] as const,
+  registers: [registry],
+});
+
+export const initialHistoryImportRetriesTotal = new Counter({
+  name: "scout_initial_history_import_retries_total",
+  help: "Initial history import retries by bounded failure class.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+export const initialHistoryImportRankTotal = new Counter({
+  name: "scout_initial_history_import_rank_total",
+  help: "Current rank enrichment outcomes for initial history imports.",
+  labelNames: ["outcome"] as const,
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts
@@ -36,6 +36,10 @@ import {
 import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 import { fetchCompetitionRankHistory } from "#src/reports/duckdb/lake-reads.ts";
+import {
+  buildMatchesSource,
+  resolveLakeFiles,
+} from "#src/reports/duckdb/lake.ts";
 
 const { prisma } = createTestDatabase("report-lake-test");
 const serverId = testGuildId("888");
@@ -469,6 +473,40 @@ describe("compactor", () => {
       await runReportLakeFold({ prisma, lakeDir });
       const builds = await readdir(path.join(lakeDir, "builds"));
       expect(builds.length).toBeLessThanOrEqual(2);
+    } finally {
+      await rm(lakeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("compactor idempotency and schema transitions", () => {
+  test("re-importing a folded match remains one logical row per participant", async () => {
+    const match = await loadMatchFixture();
+    const lakeDir = await makeLakeDir();
+    try {
+      await runReportLakeRebuild({ prisma, lakeDir });
+      expect(await writeMatchStagingFile(lakeDir, match)).toBe(true);
+      await runReportLakeFold({ prisma, lakeDir });
+
+      // A later cooldown refetch can stage the same immutable Match-V5 ID.
+      expect(await writeMatchStagingFile(lakeDir, match)).toBe(true);
+      await runReportLakeFold({ prisma, lakeDir });
+
+      const source = buildMatchesSource(await resolveLakeFiles(lakeDir), {
+        sql: "",
+        params: [],
+      });
+      if (source === undefined) throw new Error("missing match lake source");
+      const rowCount = await withDuckDBConnection(async (session) => {
+        const rows = await session.run(
+          `SELECT COUNT(*)::BIGINT AS n FROM (${source.sql})`,
+          source.params.map((param) =>
+            param.kind === "list" ? session.list(param.values) : param.value,
+          ),
+        );
+        return CountRowSchema.parse(rows[0]).n;
+      });
+      expect(rowCount).toBe(match.info.participants.length);
     } finally {
       await rm(lakeDir, { recursive: true, force: true });
     }

--- a/packages/scout-for-lol/packages/backend/src/report-store/live-ingest.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/live-ingest.ts
@@ -74,13 +74,17 @@ function recordFailure(
 
 export async function recordMatchForReportStore(
   options: MatchIngestOptions,
-): Promise<void> {
+): Promise<{ staged: boolean; stored: boolean }> {
   try {
-    await ingestMatch(options.match, options.trackedPlayerAliases);
+    const result = await ingestMatch(
+      options.match,
+      options.trackedPlayerAliases,
+    );
     recordSuccess("match", options.source);
     logger.info(
       `[ReportStoreIngest] Stored match ${options.match.metadata.matchId} from ${options.source}`,
     );
+    return result;
   } catch (error) {
     recordFailure("match", options.source, error);
     throw error;

--- a/packages/scout-for-lol/packages/backend/src/report-store/store.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/store.test.ts
@@ -1,0 +1,30 @@
+import { expect, test, vi } from "vitest";
+import { RawMatchSchema } from "@scout-for-lol/data";
+
+const saveMatchToS3 = vi.fn(() => Promise.resolve("skipped_no_bucket"));
+const writeMatchStagingFile = vi.fn(() => Promise.resolve(true));
+
+vi.doMock("#src/storage/s3.ts", () => ({ saveMatchToS3 }));
+vi.doMock("#src/report-lake/paths.ts", () => ({
+  resolveLakeDir: () => "/test/report-lake",
+}));
+vi.doMock("#src/report-lake/staging.ts", () => ({ writeMatchStagingFile }));
+
+const { ingestMatch } = await import("#src/report-store/store.ts");
+const match = RawMatchSchema.parse(
+  await Bun.file(
+    new URL(
+      "../league/model/__tests__/testdata/matches_2025_09_19_NA1_5370986469.json",
+      import.meta.url,
+    ),
+  ).json(),
+);
+
+test("preserves local staging while reporting unavailable S3 storage", async () => {
+  await expect(ingestMatch(match, [])).resolves.toEqual({
+    staged: true,
+    stored: false,
+  });
+  expect(saveMatchToS3).toHaveBeenCalledOnce();
+  expect(writeMatchStagingFile).toHaveBeenCalledOnce();
+});

--- a/packages/scout-for-lol/packages/backend/src/report-store/store.ts
+++ b/packages/scout-for-lol/packages/backend/src/report-store/store.ts
@@ -31,12 +31,13 @@ import {
 export async function ingestMatch(
   match: RawMatch,
   trackedPlayerAliases: string[],
-): Promise<void> {
+): Promise<{ staged: boolean; stored: boolean }> {
   // Authoritative: throws on failure.
-  await saveMatchToS3(match, trackedPlayerAliases);
+  const storageStatus = await saveMatchToS3(match, trackedPlayerAliases);
   // Best-effort lake staging so the DuckDB report engine sees this match
   // before the next compaction; never throws.
-  await writeMatchStagingFile(resolveLakeDir(), match);
+  const staged = await writeMatchStagingFile(resolveLakeDir(), match);
+  return { staged, stored: storageStatus === "saved" };
 }
 
 export async function ingestTimeline(

--- a/packages/scout-for-lol/packages/backend/src/storage/s3.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3.test.ts
@@ -241,8 +241,7 @@ describe("S3 Match Storage", () => {
       .on(PutObjectCommand)
       .resolves({ $metadata: { httpStatusCode: 200 } });
 
-    // Returns void without throwing and makes no S3 calls.
-    await expect(saveMatchToS3(match, [])).resolves.toBeUndefined();
+    await expect(saveMatchToS3(match, [])).resolves.toBe("skipped_no_bucket");
     expect(s3Mock.calls().length).toBe(0);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/storage/s3.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3.ts
@@ -24,14 +24,15 @@ export type PrematchPayloadSaveResult = {
  * Save a League of Legends match to S3 storage
  * @param match The match data to save
  * @param trackedPlayerAliases Array of tracked player aliases in this match (empty array if none)
- * @returns Promise that resolves when the match is saved
+ * @returns whether the canonical write happened or S3 is unavailable
  */
 export async function saveMatchToS3(
   match: RawMatch,
   trackedPlayerAliases: string[],
-): Promise<void> {
+): Promise<"saved" | "skipped_no_bucket"> {
   const matchId = MatchIdSchema.parse(match.metadata.matchId);
   const body = JSON.stringify(match, null, 2);
+  const storageAvailable = configuration.s3BucketName !== undefined;
 
   await saveToS3({
     matchId,
@@ -67,6 +68,7 @@ export async function saveMatchToS3(
       gameDuration: match.info.gameDuration,
     },
   });
+  return storageAvailable ? "saved" : "skipped_no_bucket";
 }
 
 /**

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/player-profile.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/player-profile.router.test.ts
@@ -83,6 +83,7 @@ function matchFact(options: {
 }
 
 beforeEach(async () => {
+  await testPrisma.currentRankSnapshot.deleteMany();
   await testPrisma.matchRankHistory.deleteMany();
   await testPrisma.account.deleteMany();
   await testPrisma.player.deleteMany();
@@ -135,6 +136,126 @@ describe("player.profileSummary", () => {
     // Two games is far below the rate threshold and must say so.
     expect(summary.championPool[0]?.lowSample).toBe(true);
     expect(summary.minGamesForRate).toBe(10);
+  });
+
+  test("uses the newest value between imported current rank and live rank history", async () => {
+    await seedPlayer({ serverId: guildId, alias: "Ranked", puuids: [MAIN] });
+    await testPrisma.matchRankHistory.create({
+      data: {
+        matchId: "NA1_rank_old",
+        puuid: MAIN,
+        queueType: "solo",
+        rankAfter: JSON.stringify({
+          tier: "silver",
+          division: 1,
+          lp: 20,
+          wins: 8,
+          losses: 7,
+        }),
+        capturedAt: new Date("2026-08-23T10:00:00.000Z"),
+      },
+    });
+    await testPrisma.currentRankSnapshot.create({
+      data: {
+        puuid: MAIN,
+        soloRank: JSON.stringify({
+          tier: "gold",
+          division: 4,
+          lp: 55,
+          wins: 12,
+          losses: 9,
+        }),
+        flexRank: null,
+        fetchedAt: new Date("2026-08-23T11:00:00.000Z"),
+      },
+    });
+
+    const imported = await trpc
+      .authedCaller()
+      .player.profileSummary({ guildId, alias: "Ranked" });
+    expect(imported.ranks.solo).toMatchObject({ tier: "gold", lp: 55 });
+    expect(imported.ranks.flex).toBeUndefined();
+
+    await testPrisma.matchRankHistory.create({
+      data: {
+        matchId: "NA1_rank_new",
+        puuid: MAIN,
+        queueType: "solo",
+        rankAfter: JSON.stringify({
+          tier: "platinum",
+          division: 4,
+          lp: 10,
+          wins: 13,
+          losses: 9,
+        }),
+        capturedAt: new Date("2026-08-23T12:00:00.000Z"),
+      },
+    });
+
+    const live = await trpc
+      .authedCaller()
+      .player.profileSummary({ guildId, alias: "Ranked" });
+    expect(live.ranks.solo).toMatchObject({ tier: "platinum", lp: 10 });
+
+    await testPrisma.matchRankHistory.create({
+      data: {
+        matchId: "NA1_rank_unavailable",
+        puuid: MAIN,
+        queueType: "solo",
+        rankAfter: null,
+        capturedAt: new Date("2026-08-23T13:00:00.000Z"),
+      },
+    });
+    const afterUnavailableLookup = await trpc
+      .authedCaller()
+      .player.profileSummary({ guildId, alias: "Ranked" });
+    expect(afterUnavailableLookup.ranks.solo).toMatchObject({
+      tier: "platinum",
+      lp: 10,
+    });
+  });
+
+  test("selects imported current ranks independently across accounts", async () => {
+    await seedPlayer({
+      serverId: guildId,
+      alias: "MultiRanked",
+      puuids: [MAIN, SMURF],
+    });
+    await testPrisma.currentRankSnapshot.createMany({
+      data: [
+        {
+          puuid: MAIN,
+          soloRank: null,
+          flexRank: JSON.stringify({
+            tier: "gold",
+            division: 2,
+            lp: 40,
+            wins: 10,
+            losses: 8,
+          }),
+          fetchedAt: new Date("2026-08-23T10:00:00.000Z"),
+        },
+        {
+          puuid: SMURF,
+          soloRank: JSON.stringify({
+            tier: "diamond",
+            division: 4,
+            lp: 20,
+            wins: 15,
+            losses: 10,
+          }),
+          flexRank: null,
+          fetchedAt: new Date("2026-08-23T11:00:00.000Z"),
+        },
+      ],
+    });
+
+    const summary = await trpc
+      .authedCaller()
+      .player.profileSummary({ guildId, alias: "MultiRanked" });
+
+    expect(summary.ranks.solo).toMatchObject({ tier: "diamond", lp: 20 });
+    expect(summary.ranks.flex).toMatchObject({ tier: "gold", lp: 40 });
   });
 
   test("refuses a player belonging to another guild", async () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/subscription.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/subscription.router.ts
@@ -44,6 +44,7 @@ import { ListSubscriptionsInputSchema } from "#src/lib/subscription/types.ts";
 import { recordAudit, AuditActionSchema } from "#src/lib/audit/index.ts";
 import { runAuditedMutation } from "#src/lib/audit/audited-mutation.ts";
 import { captureFirstSubscriptionCreated } from "#src/analytics/guild-lifecycle.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
 
 const GuildIdInput = z.object({ guildId: DiscordGuildIdSchema });
 
@@ -136,12 +137,16 @@ export const subscriptionRouter = router({
         game_name: puuidResult.gameName,
         tag_line: puuidResult.tagLine,
       };
+      const initialHistoryImportEnabled = await isPolicyEnabled(
+        "initial_match_history_import_enabled",
+        { server: input.guildId },
+      );
 
-      const result = await runAuditedMutation(
+      const result: AddSubscriptionResult = await runAuditedMutation(
         ctx,
         input.guildId,
-        (tx) =>
-          addSubscription(
+        async (tx): Promise<AddSubscriptionResult> => {
+          const created = await addSubscription(
             {
               guildId: input.guildId,
               channelId: input.channelId,
@@ -154,7 +159,18 @@ export const subscriptionRouter = router({
             },
             puuid,
             tx,
-          ),
+            initialHistoryImportEnabled,
+          );
+          // addSubscription preserves its public result contract by turning
+          // database failures into `internal-error`. Rethrow inside this
+          // transaction so Account and import-job creation stay atomic.
+          if (created.kind === "internal-error") {
+            throw new Error(
+              `Subscription creation failed for ${input.alias}: ${created.message}`,
+            );
+          }
+          return created;
+        },
         (r) => {
           if (r.kind === "created") {
             return {
@@ -188,14 +204,14 @@ export const subscriptionRouter = router({
         },
       );
 
-      if (result.kind === "created") {
-        if (result.isFirstSubscription) {
-          await captureFirstSubscriptionCreated(input.guildId, "web");
-        }
-        // Best-effort match-history backfill so the poll cycle doesn't
-        // emit notifications for historical matches the first time it
-        // encounters the account. Fire-and-forget; never block the
-        // mutation response on it.
+      if (result.kind === "created" && result.isFirstSubscription) {
+        await captureFirstSubscriptionCreated(input.guildId, "web");
+      }
+      if (
+        !initialHistoryImportEnabled &&
+        (result.kind === "created" ||
+          result.kind === "subscription-already-exists")
+      ) {
         void runBackfillAfterCommit({
           alias: input.alias,
           puuid,

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/how-scout-works.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/how-scout-works.md
@@ -48,8 +48,16 @@ feeling immediate and staying within what Riot allows.
 
 Scout also tracks where each account's history stands, which is what stops a
 freshly created subscription from replaying an entire back catalogue of old
-games into your channel. It also means matches finished before you tracked
-someone will never post.
+games into your channel. During onboarding it snapshots and quietly imports up
+to the account's 20 most recent games for Explore, reports, AI review context,
+and the player profile. Matches finished before that snapshot enrich history
+but never post notifications or trigger automatic post-match side effects.
+
+The import runs only after the live post-match poll and uses a small shared Riot
+API budget. Scout pauses live polling for that account until its fixed snapshot
+is stored, then hands the newest snapshot match to the normal cursor. A game
+that finishes during the import is therefore detected once on the next live
+poll instead of being lost or replayed.
 
 ## Delivery is decided per subscription
 
@@ -80,15 +88,16 @@ reports query that store rather than replaying Riot's API. This is what makes a
 query over 30 days of a server's history return in a moment instead of costing
 thousands of API calls.
 
-That store is refreshed on a schedule: freshly ingested matches are folded in
-every 15 minutes, and the whole thing is rebuilt nightly from the raw match data
-Scout keeps. The rebuild exists so the store can be treated as disposable —
-derived data that can always be reconstructed from the raw JSON, which is the
-real source of truth.
+Freshly ingested matches are staged for reads immediately, folded into Parquet
+every 15 minutes, and rebuilt nightly from the raw match data Scout keeps. The
+rebuild exists so the store can be treated as disposable — derived data that
+can always be reconstructed from the raw JSON, which is the real source of
+truth. Initial history waits for a fold before it is marked ready so the new
+guild identity mapping and its matches become visible together.
 
-The visible consequence: a game that finished two minutes ago has certainly
-produced a notification, and may not yet appear in a report. If a report looks
-like it is missing a recent game, waiting for the next fold usually resolves it.
+The visible consequence: a newly tracked account's imported history may fill in
+over several minutes. Normal live matches can be queried from staging as soon
+as ingest succeeds.
 
 ## Competitions sit in between
 
@@ -107,7 +116,7 @@ no stored state to repair.
 - A recap that never arrives after a game genuinely ended is a delivery problem
   — mute, filter, or channel permissions — not a detection problem. See
   [Diagnose a missing notification](/docs/how-to/troubleshoot-notifications/).
-- A report missing the last few minutes of games is expected, not broken.
+- A newly tracked account can take a few minutes to populate historical reports.
 
 ## Related
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/add-players.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/add-players.md
@@ -15,6 +15,9 @@ Run this in the channel that should receive the notifications:
 
 `/track` is a single happy path: one account, one channel, no filters. It
 creates the player if the alias is new and attaches the Riot account to it.
+Scout then quietly imports up to that account's 20 most recent games and its
+current Solo/Flex ranks. The history fills Explore, reports, AI review context,
+and the player profile; old games never post notifications.
 
 Use it when you want a player tracked in the channel you are already standing
 in. For anything else, use the dashboard.
@@ -54,6 +57,9 @@ not two players. That way their games aggregate into one leaderboard row.
 
 Both accounts now feed the same alias. Any subscription for that player covers
 matches on either account.
+
+The added account receives the same quiet history import. Re-adding an account
+within 24 hours reuses its existing import instead of refetching Riot data.
 
 ## Move an account to a different player
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/troubleshoot-notifications.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/how-to/troubleshoot-notifications.md
@@ -90,9 +90,13 @@ tracked players](/docs/how-to/add-players/).
 
 When a subscription is created, Scout records where that account's history
 currently stands so it does not flood your channel with old games. Matches
-finished **before** you ran `/track` will not post.
+finished **before** you ran `/track` will not post notifications.
 
-Track first, then play.
+Scout quietly imports up to the 20 most recent games for Explore, ScoutQL
+reports, AI review context, and the player profile. Those older games may appear
+in history after a few minutes, but they never produce recaps, betting results,
+earnings, or other automatic messages. Only games completed after the import's
+snapshot can notify.
 
 ## 9. Check the audit log
 
@@ -111,10 +115,9 @@ If a _scheduled report_ did not post:
    away fires at a time that looks wrong locally.
 4. Confirm Scout has **Attach Files** in the report's channel.
 
-Freshly finished games take a few minutes to become available to reports — match
-data is folded into the report store every fifteen minutes, so a report run
-immediately after a game may not include it. Notifications are unaffected; they
-do not wait for this.
+Freshly finished games are staged for reports immediately. A newly tracked
+account can still take a few minutes to appear in a server-scoped report while
+Scout publishes the account mapping and imported history together.
 
 ## Still missing
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-report.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-report.md
@@ -11,8 +11,9 @@ chart, and schedule it to post itself to a channel every week. You will meet
 `SELECT`, `FROM`, `GROUP BY`, DURING LAST 30 DAYS `ORDER BY`, and `RENDER`.
 
 You need at least one tracked player who has played recently. Reports read the
-last 30 days of match history by default, so a server that has just been set up
-will return empty rows.
+last 30 days of match history by default. When you add an account, Scout quietly
+imports up to its 20 most recent games, so a new server usually has useful rows
+within a few minutes. An account with no recent games still returns empty rows.
 
 ## What you will end up with
 


### PR DESCRIPTION
## Why

Newly tracked players currently begin with no historical context. Explore, `/scout ask`, match-backed ScoutQL lookbacks, AI review history, and the OP.GG-style profile should become useful on first run without replaying historical notifications or economy side effects.

## What

- Add a default-off, guild-targeted `initial_match_history_import_enabled` flag to every account-creation path.
- Transactionally enqueue one durable job per PUUID, reuse active/recent work, and enforce a 24-hour refetch cooldown.
- Import a fixed 20-ID Match-V5 snapshot newest-first after live polling, with five single-attempt Riot requests per minute through the shared limiter.
- Require canonical S3 storage and immediate lake staging before checkpointing, then hand off the live cursor atomically.
- Fetch one current Solo/Flex rank snapshot without fabricating per-match LP changes.
- Coalesce publish-ready imports into a report-lake fold so match facts and guild identity mappings become ready together.
- Keep historical ingest outside the post-match processor: no Discord sends, reports, AI recaps, ActiveGame writes, Bryan Bucks settlement, earnings, or match-rank history.
- Add bounded queue/phase/retry/rank metrics and a warning when actionable work exceeds six hours.
- Update Scout user docs, report-lake architecture, and agent guidance.

The branch is 43 files / 2,704 additions / 86 deletions. Most of the volume is the durable worker and its focused integration coverage; the schema, worker, observability, and documentation ship together behind a default-off flag.

## Verification

- `cd packages/scout-for-lol/packages/backend && bun run generate && bunx prisma validate && bun run typecheck`
- 126 focused backend tests covering enqueue transactions, deduplication/cooldown, repaired-failure resumption, cross-guild cursor reuse and pre-handoff delete/re-add recovery, concurrent worker/re-enqueue serialization, fair request budgeting, retry classification/backoff, quiet ingest, cursor handoff and terminal-failure blocking, publish-generation races, canonical S3 enforcement with local staging compatibility, per-account current ranks, report-lake deduplication, global/guild ScoutQL, AI-review history, profile reads, and live polling
- Focused ESLint on changed backend files (no errors; repository duplication advisories only)
- `cd packages/scout-for-lol/packages/docs-site && bun run typecheck && bun run test && bun run build && bun run lint`
- `cd packages/docs/wiki && bun run typecheck && bun run test && bun run build && bun run test:e2e && bun run lint`
- `cd packages/homelab/src/cdk8s && bun run typecheck`, focused ESLint, and 21 Scout alert tests
- `bunx lefthook run pre-commit`

Production rollout and live Riot/S3/Discord acceptance were not run. The flag defaults off.

## Rollout

Enable beta guilds first. Verify S3 and report-lake visibility, zero historical notifications/Bucks side effects, queue age, and Riot 429 behavior before ramping production. Accepted jobs continue if the flag is disabled.

## Visual proof

Desktop: the updated player-onboarding guide states that Scout imports up to 20 games and current Solo/Flex ranks without posting old-game notifications.

![Scout quiet history import documentation at desktop width](https://public.sjer.red/pr/assets/2429/scout-history-docs-desktop.png)

Mobile: the same first-run boundary remains readable in the narrow responsive layout.

![Scout quiet history import documentation at mobile width](https://public.sjer.red/pr/assets/2429/scout-history-docs-mobile.png)
