### PR TITLE
feat(scout-for-lol): separate member discovery from server management

### DIFF
--- a/packages/scout-for-lol/packages/app/index.html
+++ b/packages/scout-for-lol/packages/app/index.html
@@ -6,6 +6,7 @@
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#F0E6D2" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="robots" content="noindex, nofollow" />
     <link
       rel="icon"
       type="image/svg+xml"
@@ -16,7 +17,7 @@
       href="/assets/scout/brand/emblem.svg"
       color="#005A82"
     />
-    <title>Scout for LoL — Manage</title>
+    <title>Scout for LoL</title>
     <script src="/assets/scout/brand/theme-bootstrap.js"></script>
   </head>
   <body>

--- a/packages/scout-for-lol/packages/app/src/components/consumer-guild-avatar.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/consumer-guild-avatar.tsx
@@ -1,0 +1,21 @@
+type ConsumerGuildAvatarProps = {
+  name: string;
+  size: "compact" | "large";
+};
+
+export function ConsumerGuildAvatar(props: ConsumerGuildAvatarProps) {
+  const initial = props.name.trim().slice(0, 1).toLocaleUpperCase();
+  const sizeClasses =
+    props.size === "large"
+      ? "h-12 w-12 rounded-lg text-lg"
+      : "h-10 w-10 rounded-md text-base";
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`flex shrink-0 items-center justify-center bg-scout-hover font-semibold text-scout-subtle ${sizeClasses}`}
+    >
+      {initial}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/player-profile-sections.tsx
@@ -19,6 +19,7 @@ import {
   TableRow,
 } from "@scout-for-lol/design-system/components/table";
 import { ChampionIcon } from "#src/components/champion-icon.tsx";
+import { formatRiotId } from "#src/lib/riot-id-format.ts";
 
 export function formatPercent(value: number | null): string {
   return value === null ? "—" : `${Math.round(value * 100).toString()}%`;
@@ -86,6 +87,22 @@ export function RecentFormCard(props: { form: RecentForm }) {
         </p>
       </CardContent>
     </Card>
+  );
+}
+
+export function PlayerSummaryCards(props: {
+  ranks: { solo?: Rank; flex?: Rank; ranked5s?: Rank };
+  recentForm: RecentForm | null;
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-4">
+      <RankCard label="Ranked solo/duo" rank={props.ranks.solo} />
+      <RankCard label="Ranked flex" rank={props.ranks.flex} />
+      <RankCard label="Ranked 5s" rank={props.ranks.ranked5s} />
+      {props.recentForm === null ? null : (
+        <RecentFormCard form={props.recentForm} />
+      )}
+    </div>
   );
 }
 
@@ -180,7 +197,16 @@ type MatchEntry = {
   csPerMinute: number;
   killParticipation: number | null;
   leaguePointsDelta: number | null;
+  account: {
+    gameName: string | null;
+    tagLine: string | null;
+    region: string;
+  };
 };
+
+function matchAccountLabel(account: MatchEntry["account"]): string {
+  return formatRiotId(account, account.region);
+}
 
 function LeaguePointsBadge(props: { delta: number | null }) {
   if (props.delta === null) return null;
@@ -228,6 +254,9 @@ export function MatchHistoryList(props: { entries: MatchEntry[] }) {
               {entry.queue ?? "Unknown queue"} ·{" "}
               {Math.round(entry.gameDurationSeconds / 60).toString()}m ·{" "}
               {formatRelative(entry.gameCreationMs)}
+            </p>
+            <p className="mt-1 text-xs text-scout-subtle">
+              {matchAccountLabel(entry.account)}
             </p>
           </div>
           <div className="min-w-28">

--- a/packages/scout-for-lol/packages/app/src/lib/analytics-events.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics-events.ts
@@ -43,6 +43,8 @@ const SCOUT_ANALYTICS_EVENTS = [
   "player_renamed",
   "players_merged",
   "player_deleted",
+  "player_search_performed",
+  "player_profile_opened",
   // Competitions
   "competition_created",
   "competition_edited",

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
@@ -170,6 +170,7 @@ describe("normalizePath", () => {
     expect(normalizePath("/g/123/competitions/7")).toBe(
       "/g/:guildId/competitions/:competitionId",
     );
+    expect(normalizePath("/players/42")).toBe("/players/:playerId");
   });
 
   test("preserves known static routes and rejects unknown routes", () => {
@@ -178,6 +179,8 @@ describe("normalizePath", () => {
       "/g/:guildId/reports/help",
     );
     expect(normalizePath("/login")).toBe("/login");
+    expect(normalizePath("/manage")).toBe("/manage");
+    expect(normalizePath("/players")).toBe("/players");
     expect(normalizePath("/something/private")).toBe("/not-found");
   });
 
@@ -480,6 +483,41 @@ describe("track", () => {
         event: "report_preset_used",
         properties: {
           category: "Champions",
+          site_key: "scout-beta",
+          site_hostname: "beta.scout-for-lol.com",
+        },
+        options: undefined,
+      },
+    ]);
+  });
+
+  test("consumer profile events carry only result state and entry surface", () => {
+    const calls = installClient();
+    track("player_search_performed", {
+      outcome: "results",
+      surface: "players_page",
+    });
+    track("player_profile_opened", {
+      outcome: "succeeded",
+      surface: "search_results",
+    });
+
+    expect(calls).toEqual([
+      {
+        event: "player_search_performed",
+        properties: {
+          outcome: "results",
+          surface: "players_page",
+          site_key: "scout-beta",
+          site_hostname: "beta.scout-for-lol.com",
+        },
+        options: undefined,
+      },
+      {
+        event: "player_profile_opened",
+        properties: {
+          outcome: "succeeded",
+          surface: "search_results",
           site_key: "scout-beta",
           site_hostname: "beta.scout-for-lol.com",
         },

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.ts
@@ -437,8 +437,9 @@ export function stopAnalyticsCapture(): void {
  */
 export function normalizePath(pathname: string): string {
   const normalized = pathname
+    .replace(/^\/players\/[^/]+/, "/players/:playerId")
     .replace(/^\/g\/[^/]+/, "/g/:guildId")
-    .replace(/\/players\/[^/]+/, "/players/:alias")
+    .replace(/^\/g\/:guildId\/players\/[^/]+/, "/g/:guildId/players/:alias")
     .replace(
       /\/competitions\/(?!new(?:\/|$))[^/]+/,
       "/competitions/:competitionId",
@@ -453,7 +454,7 @@ export function normalizePath(pathname: string): string {
     .replace(/^\/explore\/s\/[^/]+/, "/explore/s/:shareToken")
     .replace(/^\/explore\/(?!s(?:\/|$))[^/]+/, "/explore/:conversationId");
   const knownRoute =
-    /^(?:\/|\/(?:login|welcome|installed)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
+    /^(?:\/|\/(?:login|welcome|installed|manage)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/players(?:\/:playerId)?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
   return knownRoute.test(normalized) ? normalized : "/not-found";
 }
 

--- a/packages/scout-for-lol/packages/app/src/lib/onboarding-storage.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/onboarding-storage.ts
@@ -1,34 +1,14 @@
 /**
- * Per-user onboarding flags, keyed by Discord id in localStorage (the SPA
- * is always a browser context). `seen` gates the one-time auto-redirect
- * into the wizard; `complete` gates the "Get started" banner.
+ * Per-user onboarding completion, keyed by Discord id in localStorage (the SPA
+ * is always a browser context). The setup wizard records completion, but normal
+ * sign-in always reaches the dashboard instead of redirecting into setup.
  */
-function seenKey(discordId: string): string {
-  return `scout_onboarding_seen_${discordId}`;
-}
-
 function completeKey(discordId: string): string {
   return `scout_onboarding_complete_${discordId}`;
 }
 
-function read(key: string): boolean {
-  return globalThis.window.localStorage.getItem(key) === "true";
-}
-
 function write(key: string): void {
   globalThis.window.localStorage.setItem(key, "true");
-}
-
-export function isOnboardingSeen(discordId: string): boolean {
-  return read(seenKey(discordId));
-}
-
-export function markOnboardingSeen(discordId: string): void {
-  write(seenKey(discordId));
-}
-
-export function isOnboardingComplete(discordId: string): boolean {
-  return read(completeKey(discordId));
 }
 
 export function markOnboardingComplete(discordId: string): void {

--- a/packages/scout-for-lol/packages/app/src/lib/riot-id-format.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/riot-id-format.ts
@@ -1,0 +1,9 @@
+export function formatRiotId(
+  account: { gameName: string | null; tagLine: string | null },
+  fallback: string,
+): string {
+  if (account.gameName === null) return fallback;
+  return account.tagLine === null
+    ? account.gameName
+    : `${account.gameName}#${account.tagLine}`;
+}

--- a/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-loaders.ts
@@ -2,6 +2,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import {
   CompetitionIdSchema,
   ExploreConversationIdSchema,
+  PlayerIdSchema,
   ReportIdSchema,
 } from "@scout-for-lol/data";
 import { queryClient } from "#src/lib/query-client.ts";
@@ -44,6 +45,32 @@ export function requireSessionLoader(): null {
     queryClient.query(
       trpcOptions.guild.listManageable.queryOptions(undefined, {
         staleTime: STALE_TIME_SLOW_LIST,
+      }),
+    ),
+  );
+  void preloadQuery(
+    queryClient.query(trpcOptions.explore.status.queryOptions()),
+  );
+  void preloadQuery(
+    queryClient.query(trpcOptions.consumerPlayer.status.queryOptions()),
+  );
+  return null;
+}
+
+export function consumerPlayersLoader(): null {
+  void preloadQuery(
+    queryClient.query(trpcOptions.consumerPlayer.status.queryOptions()),
+  );
+  return null;
+}
+
+export function consumerPlayerLoader({ params }: LoaderFunctionArgs): null {
+  const parsed = PlayerIdSchema.safeParse(Number(params["playerId"]));
+  if (!parsed.success) return null;
+  void preloadQuery(
+    queryClient.query(
+      trpcOptions.consumerPlayer.status.queryOptions(undefined, {
+        staleTime: 0,
       }),
     ),
   );

--- a/packages/scout-for-lol/packages/app/src/lib/route-params.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/route-params.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   CompetitionIdSchema,
   ExploreConversationIdSchema,
+  PlayerIdSchema,
   ReportIdSchema,
 } from "@scout-for-lol/data";
 
@@ -19,6 +20,10 @@ export const GuildParamsSchema = z.object({ guildId: z.string().min(1) });
 export const PlayerParamsSchema = z.object({
   guildId: z.string().min(1),
   alias: z.string().min(1),
+});
+
+export const ConsumerPlayerParamsSchema = z.object({
+  playerId: z.coerce.number().pipe(PlayerIdSchema),
 });
 
 export const CompetitionParamsSchema = z.object({
@@ -65,6 +70,12 @@ export function useGuildParams(): z.infer<typeof GuildParamsSchema> {
 
 export function usePlayerParams(): z.infer<typeof PlayerParamsSchema> {
   return parseRouteParams(PlayerParamsSchema, useParams());
+}
+
+export function useConsumerPlayerParams(): z.infer<
+  typeof ConsumerPlayerParamsSchema
+> {
+  return parseRouteParams(ConsumerPlayerParamsSchema, useParams());
 }
 
 export function useCompetitionParams(): z.infer<

--- a/packages/scout-for-lol/packages/app/src/router-analytics-identity.test.ts
+++ b/packages/scout-for-lol/packages/app/src/router-analytics-identity.test.ts
@@ -48,4 +48,16 @@ describe("router analytics identity coverage", () => {
     if (guard === undefined) throw new Error("no RequireSession route");
     expect(collectPaths(guard)).not.toContain("login");
   });
+
+  test("consumer player routes remain behind the session guard", () => {
+    const root = rootRoutes[0];
+    if (root === undefined) throw new Error("no RootLayout route");
+    const guard = (root.children ?? []).find(
+      (route) => elementType(route) === RequireSession,
+    );
+    if (guard === undefined) throw new Error("no RequireSession route");
+
+    expect(collectPaths(guard)).toContain("players");
+    expect(collectPaths(guard)).toContain("players/:playerId");
+  });
 });

--- a/packages/scout-for-lol/packages/app/src/router.test.ts
+++ b/packages/scout-for-lol/packages/app/src/router.test.ts
@@ -11,6 +11,7 @@ import { trpcOptions } from "#src/lib/trpc-options.ts";
 const KNOWN_URLS = [
   "/login",
   "/",
+  "/manage",
   "/welcome",
   "/installed",
   // The pair pins react-router's optional-segment support (`:conversationId?`)
@@ -18,6 +19,8 @@ const KNOWN_URLS = [
   "/explore",
   "/explore/1b4e28ba-2fa1-41d2-883f-0016d3cca427",
   "/explore/s/some-share-token",
+  "/players",
+  "/players/42",
   "/g/1/subscriptions",
   "/g/1/players",
   "/g/1/players/Alias",

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, redirect, type RouteObject } from "react-router";
 import { Login } from "#src/routes/login.tsx";
 import { GuildPicker } from "#src/routes/guild-picker.tsx";
+import { ManageServers } from "#src/routes/manage-servers.tsx";
 import { GuildSubscriptions } from "#src/routes/guild-subscriptions.tsx";
 import { GuildAudit } from "#src/routes/guild-audit.tsx";
 import { GuildAccess } from "#src/routes/guild-access.tsx";
@@ -21,6 +22,9 @@ import { ReportForm } from "#src/routes/report-form.tsx";
 import { ReportHelp } from "#src/routes/report-help.tsx";
 import { Explore } from "#src/routes/explore.tsx";
 import { ExploreShared } from "#src/routes/explore-shared.tsx";
+import { ConsumerPlayerSearch } from "#src/routes/consumer-player-search.tsx";
+import { ConsumerPlayerProfile } from "#src/routes/consumer-player-profile.tsx";
+import { ConsumerWorkspace } from "#src/routes/consumer-workspace.tsx";
 import { OnboardingWizard } from "#src/routes/onboarding-wizard.tsx";
 import { InstallLanding } from "#src/routes/install-landing.tsx";
 import { RequireSession } from "#src/routes/require-session.tsx";
@@ -32,6 +36,8 @@ import {
   auditLoader,
   competitionDetailLoader,
   competitionsLoader,
+  consumerPlayerLoader,
+  consumerPlayersLoader,
   exploreLoader,
   guildLoader,
   playerDetailLoader,
@@ -178,15 +184,30 @@ export const routes: RouteObject[] = [
         errorElement: <RouteErrorPanel />,
         children: [
           { index: true, element: <GuildPicker /> },
-          // One route with an optional segment, not two siblings: navigating
-          // `/explore` → `/explore/:id` when the stream's `started` event
-          // mints a conversation must not remount Explore mid-turn.
           {
-            path: "explore/:conversationId?",
-            element: <Explore />,
-            loader: exploreLoader,
-            errorElement: <RouteErrorPanel />,
+            element: <ConsumerWorkspace />,
+            children: [
+              {
+                path: "explore/:conversationId?",
+                element: <Explore />,
+                loader: exploreLoader,
+                errorElement: <RouteErrorPanel />,
+              },
+              {
+                path: "players",
+                element: <ConsumerPlayerSearch />,
+                loader: consumerPlayersLoader,
+                errorElement: <RouteErrorPanel />,
+              },
+              {
+                path: "players/:playerId",
+                element: <ConsumerPlayerProfile />,
+                loader: consumerPlayerLoader,
+                errorElement: <RouteErrorPanel />,
+              },
+            ],
           },
+          { path: "manage", element: <ManageServers /> },
           { path: "welcome", element: <OnboardingWizard /> },
           { path: "installed", element: <InstallLanding /> },
           {

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import {
+  isFreshConsumerProfileAccess,
+  PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS,
+  queueValue,
+} from "#src/routes/consumer-player-profile.tsx";
+
+describe("consumer profile queue filter", () => {
+  test("maps member labels to report-lake queue values", () => {
+    expect(queueValue("all")).toBeUndefined();
+    expect(queueValue("solo")).toBe("solo");
+    expect(queueValue("flex")).toBe("flex");
+  });
+});
+
+describe("consumer profile authorization cache", () => {
+  test("does not render a cached access success during its membership recheck", () => {
+    expect(isFreshConsumerProfileAccess("available", true, true)).toBe(false);
+    expect(isFreshConsumerProfileAccess("available", true, false)).toBe(true);
+    expect(isFreshConsumerProfileAccess("no_shared_guild", true, false)).toBe(
+      false,
+    );
+  });
+
+  test("does not retain protected profile responses after route unmount", () => {
+    expect(PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS).toEqual({
+      staleTime: 0,
+      gcTime: 0,
+      refetchOnMount: "always",
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-profile.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useLocation } from "react-router";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+import { rankToString, type Rank } from "@scout-for-lol/data";
+import { Badge } from "@scout-for-lol/design-system/components/badge";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import { ConsumerGuildAvatar } from "#src/components/consumer-guild-avatar.tsx";
+import { Section } from "#src/components/player-detail-sections.tsx";
+import {
+  ChampionPoolTable,
+  MatchHistoryList,
+  PlayerSummaryCards,
+} from "#src/components/player-profile-sections.tsx";
+import { LoadMore } from "#src/components/load-more.tsx";
+import { track } from "#src/lib/analytics.ts";
+import { formatRiotId } from "#src/lib/riot-id-format.ts";
+import { useConsumerPlayerParams } from "#src/lib/route-params.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+const EntryStateSchema = z.object({
+  entrySurface: z.enum(["search_results", "direct_link"]),
+});
+
+type QueueFilter = "all" | "solo" | "flex";
+
+export const PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS = {
+  staleTime: 0,
+  gcTime: 0,
+  refetchOnMount: "always",
+} as const;
+
+export function isFreshConsumerProfileAccess(
+  state: "available" | "feature_disabled" | "no_shared_guild" | undefined,
+  isSuccess: boolean,
+  isFetching: boolean,
+): boolean {
+  return isSuccess && !isFetching && state === "available";
+}
+
+export function queueValue(queue: QueueFilter): string | undefined {
+  if (queue === "solo") return "solo";
+  if (queue === "flex") return "flex";
+  return undefined;
+}
+
+function queueLabel(queue: QueueFilter): string {
+  if (queue === "solo") return "Solo / duo";
+  if (queue === "flex") return "Flex";
+  return "All queues";
+}
+
+function observedAt(value: Date | string | null): string {
+  if (value === null) return "Not observed yet";
+  return new Date(value).toLocaleString();
+}
+
+function rankLabel(rank: Rank | undefined): string {
+  return rank === undefined ? "Unranked" : rankToString(rank);
+}
+
+export function ConsumerPlayerProfile() {
+  const { playerId } = useConsumerPlayerParams();
+  const trpc = useTRPC();
+  const location = useLocation();
+  const parsedEntry = EntryStateSchema.safeParse(location.state);
+  const entrySurface = parsedEntry.success
+    ? parsedEntry.data.entrySurface
+    : "direct_link";
+  const [queue, setQueue] = useState<QueueFilter>("all");
+  const selectedQueue = queueValue(queue);
+  const queueInput =
+    selectedQueue === undefined ? {} : { queue: selectedQueue };
+  const trackedOutcome = useRef<string | null>(null);
+
+  const accessQuery = useQuery(
+    trpc.consumerPlayer.status.queryOptions(undefined, {
+      staleTime: 0,
+      refetchOnMount: "always",
+    }),
+  );
+  const accessIsFresh = isFreshConsumerProfileAccess(
+    accessQuery.data?.state,
+    accessQuery.isSuccess,
+    accessQuery.isFetching,
+  );
+  const summaryQuery = useQuery(
+    trpc.consumerPlayer.profileSummary.queryOptions(
+      {
+        playerId,
+        ...queueInput,
+      },
+      {
+        enabled: accessIsFresh,
+        ...PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS,
+      },
+    ),
+  );
+  const historyQuery = useInfiniteQuery(
+    trpc.consumerPlayer.matchHistory.infiniteQueryOptions(
+      { playerId, limit: 20, ...queueInput },
+      {
+        enabled:
+          accessIsFresh && summaryQuery.isSuccess && !summaryQuery.isFetching,
+        ...PROTECTED_CONSUMER_PROFILE_QUERY_OPTIONS,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+    ),
+  );
+
+  useEffect(() => {
+    trackedOutcome.current = null;
+  }, [playerId]);
+
+  useEffect(() => {
+    const outcome = summaryQuery.isSuccess
+      ? "succeeded"
+      : summaryQuery.isError ||
+          accessQuery.isError ||
+          (accessQuery.isSuccess && accessQuery.data.state !== "available")
+        ? "failed"
+        : null;
+    if (outcome === null || trackedOutcome.current === outcome) return;
+    trackedOutcome.current = outcome;
+    track("player_profile_opened", {
+      outcome,
+      surface: entrySurface,
+    });
+  }, [
+    accessQuery.data,
+    accessQuery.isError,
+    accessQuery.isSuccess,
+    entrySurface,
+    summaryQuery.isError,
+    summaryQuery.isSuccess,
+  ]);
+
+  if (accessQuery.isPending || accessQuery.isFetching) {
+    return (
+      <ProfileShell>
+        <p className="text-sm text-scout-subtle">Checking profile access…</p>
+      </ProfileShell>
+    );
+  }
+
+  if (
+    accessQuery.isError ||
+    accessQuery.data.state !== "available" ||
+    summaryQuery.isError
+  ) {
+    return (
+      <ProfileShell>
+        <Card>
+          <CardHeader>
+            <CardTitle>Player profile unavailable</CardTitle>
+            <CardDescription>
+              Scout could not find this player inside your currently enabled
+              shared servers, or could not verify membership. No other
+              guild&apos;s player data was returned.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => {
+                if (
+                  accessQuery.isError ||
+                  accessQuery.data.state !== "available"
+                ) {
+                  void accessQuery.refetch();
+                } else {
+                  void summaryQuery.refetch();
+                }
+              }}
+            >
+              Retry
+            </Button>
+            <Button asChild variant="outline">
+              <Link to="/players">Search players</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </ProfileShell>
+    );
+  }
+
+  if (summaryQuery.isPending || summaryQuery.isFetching) {
+    return (
+      <ProfileShell>
+        <p className="text-sm text-scout-subtle">Loading player profile…</p>
+      </ProfileShell>
+    );
+  }
+
+  const summary = summaryQuery.data;
+  const entries =
+    historyQuery.data?.pages.flatMap((page) => page.entries) ?? [];
+
+  return (
+    <ProfileShell>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <ConsumerGuildAvatar name={summary.guild.name} size="large" />
+          <div>
+            <p className="text-sm text-scout-subtle">{summary.guild.name}</p>
+            <h1 className="text-3xl font-semibold tracking-tight">
+              {summary.alias}
+            </h1>
+            <p className="mt-1 text-sm text-scout-subtle">
+              {summary.accountCount === 1
+                ? "1 Riot account"
+                : `${summary.accountCount.toString()} Riot accounts combined`}
+              {" · "}Only games Scout recorded
+            </p>
+          </div>
+        </div>
+        <Button asChild variant="outline">
+          <Link to="/players">Find another player</Link>
+        </Button>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        {summary.accounts.map((account) => (
+          <Card key={`${account.region}:${account.gameName ?? "pending"}`}>
+            <CardHeader className="pb-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <CardTitle className="text-lg">
+                  {formatRiotId(account, "Riot ID pending")}
+                </CardTitle>
+                <Badge variant="outline">{account.region}</Badge>
+              </div>
+              <CardDescription>
+                Last observed match: {observedAt(account.lastMatchTime)}
+                <br />
+                Last checked by Scout: {observedAt(account.lastCheckedAt)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p className="text-scout-subtle">Solo / duo</p>
+                <p className="font-medium">{rankLabel(account.ranks.solo)}</p>
+              </div>
+              <div>
+                <p className="text-scout-subtle">Flex</p>
+                <p className="font-medium">{rankLabel(account.ranks.flex)}</p>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold">Combined performance</h2>
+          <p className="text-sm text-scout-subtle">
+            Accounts are combined only because this guild configured them as one
+            Scout player.
+          </p>
+        </div>
+        <div className="flex gap-2" role="group" aria-label="Queue filter">
+          {(["all", "solo", "flex"] as const).map((value) => (
+            <Button
+              key={value}
+              type="button"
+              size="sm"
+              variant={queue === value ? "default" : "outline"}
+              onClick={() => {
+                setQueue(value);
+              }}
+            >
+              {queueLabel(value)}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <PlayerSummaryCards
+        ranks={summary.ranks}
+        recentForm={summary.recentForm}
+      />
+
+      <Section title="Champion performance">
+        <ChampionPoolTable
+          rows={summary.championPool}
+          minGamesForRate={summary.minGamesForRate}
+        />
+      </Section>
+
+      <Section title="Recorded match history">
+        <p className="mb-3 text-sm text-scout-subtle">
+          This is Scout&apos;s stored coverage, not a complete Riot match
+          history. Each card identifies the account Scout observed.
+        </p>
+        {historyQuery.isPending || historyQuery.isRefetching ? (
+          <p className="text-sm text-scout-subtle">Loading games…</p>
+        ) : historyQuery.isError ? (
+          <div className="flex items-center gap-3">
+            <p className="text-sm text-scout-danger">
+              Match history didn&apos;t load.
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void historyQuery.refetch();
+              }}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <MatchHistoryList entries={entries} />
+            <LoadMore
+              hasNextPage={historyQuery.hasNextPage}
+              isFetchingNextPage={historyQuery.isFetchingNextPage}
+              onLoadMore={() => {
+                void historyQuery.fetchNextPage();
+              }}
+            />
+          </div>
+        )}
+      </Section>
+    </ProfileShell>
+  );
+}
+
+function ProfileShell(props: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:py-12">
+      {props.children}
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import {
+  isConsumerTypeaheadReady,
+  PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS,
+  shouldHideConsumerSuggestions,
+} from "#src/routes/consumer-player-search.tsx";
+
+describe("consumer player typeahead", () => {
+  test("starts after two trimmed characters", () => {
+    expect(isConsumerTypeaheadReady("")).toBe(false);
+    expect(isConsumerTypeaheadReady(" n ")).toBe(false);
+    expect(isConsumerTypeaheadReady(" no ")).toBe(true);
+  });
+
+  test.each([
+    {
+      label: "the debounce has not settled",
+      query: "north",
+      debouncedQuery: "no",
+      isPlaceholderData: false,
+    },
+    {
+      label: "the new request still carries prior data",
+      query: "north",
+      debouncedQuery: "north",
+      isPlaceholderData: true,
+    },
+  ])("hides suggestions while $label", (input) => {
+    expect(shouldHideConsumerSuggestions(input)).toBe(true);
+  });
+
+  test("shows only current settled suggestions", () => {
+    expect(
+      shouldHideConsumerSuggestions({
+        query: " North ",
+        debouncedQuery: "North",
+        isPlaceholderData: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("consumer player search authorization cache", () => {
+  test("does not retain protected search responses after the query changes", () => {
+    expect(PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS).toEqual({
+      staleTime: 0,
+      gcTime: 0,
+      refetchOnMount: "always",
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-player-search.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { Combobox } from "@scout-for-lol/design-system/components/combobox";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import { ConsumerGuildAvatar } from "#src/components/consumer-guild-avatar.tsx";
+import { useDebouncedValue } from "#src/hooks/use-debounced-value.ts";
+import { track } from "#src/lib/analytics.ts";
+import { formatRiotId } from "#src/lib/riot-id-format.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+export const PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS = {
+  staleTime: 0,
+  gcTime: 0,
+  refetchOnMount: "always",
+} as const;
+
+export function isConsumerTypeaheadReady(query: string): boolean {
+  return query.trim().length >= 2;
+}
+
+export function shouldHideConsumerSuggestions(input: {
+  query: string;
+  debouncedQuery: string;
+  isPlaceholderData: boolean;
+}): boolean {
+  return (
+    input.query.trim() !== input.debouncedQuery.trim() ||
+    input.isPlaceholderData
+  );
+}
+
+type SearchResult = {
+  playerId: number;
+  alias: string;
+  guild: { name: string };
+  accounts: {
+    gameName: string | null;
+    tagLine: string | null;
+    region: string;
+  }[];
+};
+
+export function ConsumerPlayerSearch() {
+  const trpc = useTRPC();
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 250);
+  const trimmedQuery = debouncedQuery.trim();
+  const searchEnabled = isConsumerTypeaheadReady(debouncedQuery);
+  const trackedQuery = useRef<string | null>(null);
+  const statusQuery = useQuery(
+    trpc.consumerPlayer.status.queryOptions(undefined, {
+      retry: 2,
+      staleTime: 0,
+      refetchOnMount: "always",
+    }),
+  );
+  const searchQuery = useQuery(
+    trpc.consumerPlayer.search.queryOptions(
+      { query: trimmedQuery },
+      {
+        enabled: searchEnabled && statusQuery.data?.state === "available",
+        placeholderData: keepPreviousData,
+        ...PROTECTED_CONSUMER_SEARCH_QUERY_OPTIONS,
+      },
+    ),
+  );
+  const suggestionsHidden = shouldHideConsumerSuggestions({
+    query,
+    debouncedQuery,
+    isPlaceholderData: searchQuery.isPlaceholderData,
+  });
+  const suggestions = suggestionsHidden
+    ? []
+    : (searchQuery.data?.results ?? []);
+
+  useEffect(() => {
+    if (!searchEnabled) {
+      trackedQuery.current = null;
+      return;
+    }
+    if (suggestionsHidden || searchQuery.isFetching) return;
+    if (!searchQuery.isSuccess && !searchQuery.isError) return;
+    if (trackedQuery.current === trimmedQuery) return;
+    trackedQuery.current = trimmedQuery;
+    track("player_search_performed", {
+      outcome: searchQuery.isError
+        ? "failed"
+        : suggestions.length === 0
+          ? "empty"
+          : "results",
+      surface: "players_typeahead",
+    });
+  }, [
+    searchEnabled,
+    searchQuery.isError,
+    searchQuery.isFetching,
+    searchQuery.isSuccess,
+    suggestions.length,
+    suggestionsHidden,
+    trimmedQuery,
+  ]);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:py-12">
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-primary">Player profiles</p>
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Find a player Scout knows
+        </h1>
+        <p className="max-w-2xl text-scout-subtle">
+          Search a Scout guild alias or Riot ID. Results only include configured
+          players from enabled Discord servers you currently share with Scout.
+        </p>
+      </div>
+
+      {statusQuery.isError ? (
+        <RetryCard
+          title="Scout couldn't verify your servers"
+          description="Your Discord membership was not treated as a denial. Retry this temporary availability check."
+          onRetry={() => {
+            void statusQuery.refetch();
+          }}
+        />
+      ) : statusQuery.data === undefined || statusQuery.isFetching ? (
+        <p className="text-sm text-scout-subtle">Checking access…</p>
+      ) : (
+        renderStatusContent(
+          statusQuery.data.state,
+          <>
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium"
+                htmlFor="consumer-player-search"
+              >
+                Guild alias or Riot ID
+              </label>
+              <Combobox<SearchResult>
+                id="consumer-player-search"
+                value={query}
+                maxLength={100}
+                placeholder="Start typing an alias or Name#Tag"
+                items={suggestions}
+                isLoading={
+                  isConsumerTypeaheadReady(query) &&
+                  (suggestionsHidden || searchQuery.isFetching)
+                }
+                getKey={(player) => player.playerId.toString()}
+                onValueChange={setQuery}
+                onSelect={(player) => {
+                  void navigate("/players/" + player.playerId.toString(), {
+                    state: { entrySurface: "search_results" },
+                  });
+                }}
+                renderItem={(player) => <PlayerSuggestion player={player} />}
+              />
+              <p className="text-xs text-scout-subtle">
+                Suggestions begin after two characters. Use the arrow keys and
+                Enter to open a profile.
+              </p>
+            </div>
+
+            <SearchFeedback
+              query={query}
+              ready={searchEnabled && !suggestionsHidden}
+              pending={searchQuery.isFetching}
+              error={searchQuery.isError}
+              resultCount={suggestions.length}
+              onRetry={() => {
+                void searchQuery.refetch();
+              }}
+            />
+          </>,
+        )
+      )}
+    </div>
+  );
+}
+
+function PlayerSuggestion({ player }: { player: SearchResult }) {
+  return (
+    <span className="flex w-full min-w-0 items-start gap-3 text-left">
+      <ConsumerGuildAvatar name={player.guild.name} size="compact" />
+      <span className="min-w-0 flex-1">
+        <span className="flex flex-wrap items-baseline justify-between gap-2">
+          <span className="font-semibold">{player.alias}</span>
+          <span className="text-xs text-scout-subtle">{player.guild.name}</span>
+        </span>
+        <span className="mt-1 block truncate text-sm text-scout-subtle">
+          {player.accounts
+            .map((account) => formatRiotId(account, "Riot ID pending"))
+            .join(" · ") || "No Riot ID observed yet"}
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function renderStatusContent(
+  state: "available" | "feature_disabled" | "no_shared_guild",
+  availableContent: React.ReactNode,
+): React.ReactNode {
+  if (state === "available") return availableContent;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Player profiles aren&apos;t available here yet</CardTitle>
+        <CardDescription>
+          Profiles roll out server by server. Sign in with a Discord account
+          that shares an enabled Scout server; administrator permission is not
+          required.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button asChild variant="outline">
+          <Link to="/">Back to Scout</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RetryCard(props: {
+  title: string;
+  description: string;
+  onRetry: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{props.title}</CardTitle>
+        <CardDescription>{props.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button variant="outline" onClick={props.onRetry}>
+          Retry
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SearchFeedback(props: {
+  query: string;
+  ready: boolean;
+  pending: boolean;
+  error: boolean;
+  resultCount: number;
+  onRetry: () => void;
+}) {
+  if (!isConsumerTypeaheadReady(props.query)) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Scout-recorded coverage</CardTitle>
+          <CardDescription>
+            These profiles combine only accounts configured in Scout and games
+            Scout ingested. They are not a complete Riot match history.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+  if (!props.ready || props.pending) {
+    return <p className="text-sm text-scout-subtle">Searching players…</p>;
+  }
+  if (props.error) {
+    return (
+      <RetryCard
+        title="Search didn't finish"
+        description="Scout rechecks your shared servers for every search. Retry this request."
+        onRetry={props.onRetry}
+      />
+    );
+  }
+  if (props.resultCount === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>No recorded player matched</CardTitle>
+          <CardDescription>
+            Try another Scout alias or Riot ID. Players outside your enabled
+            shared servers never appear in results.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+  return (
+    <p className="text-sm text-scout-subtle" aria-live="polite">
+      {props.resultCount.toString()} suggested
+      {props.resultCount === 1 ? " player." : " players."}
+    </p>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-workspace.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-workspace.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { consumerNavigationItems } from "#src/routes/consumer-workspace.tsx";
+
+describe("consumer navigation", () => {
+  test.each([
+    {
+      exploreAvailable: true,
+      profilesAvailable: true,
+      expected: ["Explore", "Players"],
+    },
+    {
+      exploreAvailable: true,
+      profilesAvailable: false,
+      expected: ["Explore"],
+    },
+    {
+      exploreAvailable: false,
+      profilesAvailable: true,
+      expected: ["Players"],
+    },
+    {
+      exploreAvailable: false,
+      profilesAvailable: false,
+      expected: [],
+    },
+  ])("shows only enabled member features", (input) => {
+    expect(consumerNavigationItems(input).map((item) => item.label)).toEqual(
+      input.expected,
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/routes/consumer-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/consumer-workspace.tsx
@@ -1,0 +1,53 @@
+import { NavLink, Outlet } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { ProductSubnavigation } from "@scout-for-lol/design-system/layout";
+import { cn } from "#src/lib/cn.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+export function consumerNavigationItems(input: {
+  exploreAvailable: boolean;
+  profilesAvailable: boolean;
+}): { label: string; to: string }[] {
+  return [
+    ...(input.exploreAvailable ? [{ label: "Explore", to: "/explore" }] : []),
+    ...(input.profilesAvailable ? [{ label: "Players", to: "/players" }] : []),
+  ];
+}
+
+export function ConsumerWorkspace() {
+  const trpc = useTRPC();
+  const exploreQuery = useQuery(trpc.explore.status.queryOptions());
+  const profilesQuery = useQuery(
+    trpc.consumerPlayer.status.queryOptions(undefined, { retry: 2 }),
+  );
+  const items = consumerNavigationItems({
+    exploreAvailable: exploreQuery.data?.enabled === true,
+    profilesAvailable: profilesQuery.data?.state === "available",
+  });
+
+  return (
+    <>
+      {items.length > 0 ? (
+        <ProductSubnavigation>
+          {items.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                cn(
+                  "rounded-md px-3 py-2 text-sm font-medium",
+                  isActive
+                    ? "bg-scout-brand text-scout-brand-ink"
+                    : "text-scout-subtle hover:bg-scout-accent hover:text-scout-accent-ink",
+                )
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </ProductSubnavigation>
+      ) : null}
+      <Outlet />
+    </>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/guild-picker.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-picker.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { resolveMemberDestination } from "#src/routes/guild-picker.tsx";
+
+describe("member destination", () => {
+  test.each([
+    {
+      label: "Explore and profiles",
+      exploreAvailable: true,
+      profilesAvailable: true,
+      expected: "/explore",
+    },
+    {
+      label: "Explore only",
+      exploreAvailable: true,
+      profilesAvailable: false,
+      expected: "/explore",
+    },
+    {
+      label: "profiles only",
+      exploreAvailable: false,
+      profilesAvailable: true,
+      expected: "/players",
+    },
+    {
+      label: "neither member feature",
+      exploreAvailable: false,
+      profilesAvailable: false,
+      expected: null,
+    },
+  ])("chooses the member door for $label", (input) => {
+    expect(resolveMemberDestination(input)).toBe(input.expected);
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/routes/guild-picker.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-picker.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { Compass, Settings } from "lucide-react";
 import { useTRPC } from "#src/lib/trpc.ts";
-import { SESSION_QUERY_OPTIONS } from "#src/lib/session-query.ts";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import {
   Card,
@@ -11,196 +10,111 @@ import {
   CardHeader,
   CardTitle,
 } from "@scout-for-lol/design-system/components/card";
-import {
-  isOnboardingComplete,
-  isOnboardingSeen,
-  markOnboardingComplete,
-  markOnboardingSeen,
-  shouldRedirectToOnboarding,
-} from "#src/lib/onboarding-storage.ts";
-import { trackOutboundClick } from "#src/lib/analytics.ts";
-import { STALE_TIME_SLOW_LIST } from "#src/lib/stale-times.ts";
 
-/**
- * Kicks off the bot-install flow. Points at the backend route (not an
- * SPA route), which 302s to Discord's add-to-server screen and returns
- * the admin to /app/installed?guild_id=… — see handleDiscordInstall.
- */
-const INSTALL_URL = "/api/discord/install?surface=guild_picker";
-
-function AddServerButton({
-  variant = "default",
-  children,
-}: {
-  variant?: "default" | "outline";
-  children: React.ReactNode;
-}) {
-  return (
-    <Button asChild variant={variant}>
-      <a
-        href={INSTALL_URL}
-        onClick={(clickEvent) => {
-          trackOutboundClick(clickEvent, "bot_install_click", INSTALL_URL, {
-            surface: "guild_picker",
-          });
-        }}
-      >
-        {children}
-      </a>
-    </Button>
-  );
+export function resolveMemberDestination(input: {
+  exploreAvailable: boolean;
+  profilesAvailable: boolean;
+}): "/explore" | "/players" | null {
+  if (input.exploreAvailable) return "/explore";
+  if (input.profilesAvailable) return "/players";
+  return null;
 }
 
 export function GuildPicker() {
   const trpc = useTRPC();
-  const navigate = useNavigate();
-  const meQuery = useQuery(
-    trpc.auth.sessionState.queryOptions(undefined, SESSION_QUERY_OPTIONS),
+  const exploreQuery = useQuery(trpc.explore.status.queryOptions());
+  const profilesQuery = useQuery(
+    trpc.consumerPlayer.status.queryOptions(undefined, { retry: 2 }),
   );
-  const { data } = useSuspenseQuery(
-    trpc.guild.listManageable.queryOptions(undefined, {
-      staleTime: STALE_TIME_SLOW_LIST,
-    }),
-  );
-  const discordId = meQuery.data?.user?.discordId ?? null;
-  const [bannerDismissed, setBannerDismissed] = useState(false);
-
-  // Keep incomplete users in the guided first-run experience. A user with no
-  // manageable servers always belongs there, even if this browser previously
-  // recorded setup as complete or abandoned. The install redirect (Discord →
-  // /installed → /welcome) still completes setup without passing through here.
-  useEffect(() => {
-    if (discordId === null) return;
-    if (
-      !shouldRedirectToOnboarding(
-        data.length > 0,
-        isOnboardingComplete(discordId),
-      )
-    ) {
-      return;
-    }
-    markOnboardingSeen(discordId);
-    void navigate("/welcome", { replace: true });
-  }, [data.length, discordId, navigate]);
-
-  const showBanner =
-    discordId !== null &&
-    isOnboardingSeen(discordId) &&
-    !isOnboardingComplete(discordId) &&
-    !bannerDismissed;
-
-  const banner = showBanner ? (
-    <GetStartedBanner
-      onDismiss={() => {
-        markOnboardingComplete(discordId);
-        setBannerDismissed(true);
-      }}
-    />
-  ) : null;
-
-  if (data.length === 0) {
-    return (
-      <Shell>
-        {banner}
-        <Card>
-          <CardHeader>
-            <CardTitle>Add Scout to your server</CardTitle>
-            <CardDescription>
-              You need to be a Discord Administrator in a server with Scout
-              installed. Add Scout below — you&apos;ll come right back here to
-              configure it.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-wrap gap-2">
-            <AddServerButton>Add Scout to a server</AddServerButton>
-            <Button asChild variant="outline">
-              <Link to="/welcome">Open setup guide</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </Shell>
-    );
-  }
+  const memberDestination = resolveMemberDestination({
+    exploreAvailable: exploreQuery.data?.enabled === true,
+    profilesAvailable: profilesQuery.data?.state === "available",
+  });
+  const memberPending = exploreQuery.isPending || profilesQuery.isPending;
+  const memberError = exploreQuery.isError || profilesQuery.isError;
 
   return (
-    <Shell>
-      {banner}
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="text-xl font-semibold tracking-tight">Pick a guild</h1>
-        <div className="flex items-center gap-3">
-          <Link
-            to="/explore"
-            className="text-sm text-scout-subtle hover:text-scout-ink"
-          >
-            Explore
-          </Link>
-          <Link
-            to="/welcome"
-            className="text-sm text-scout-subtle hover:text-scout-ink"
-          >
-            Setup guide
-          </Link>
-          <AddServerButton variant="outline">
-            Add another server
-          </AddServerButton>
-        </div>
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:py-12">
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-primary">Scout dashboard</p>
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Choose how you want to use Scout
+        </h1>
+        <p className="max-w-2xl text-scout-subtle">
+          Discover the games Scout recorded as a server member, or administer
+          and install Scout for a Discord server.
+        </p>
       </div>
-      <ul className="grid gap-2">
-        {data.map((g) => (
-          <li key={g.id}>
-            <Link
-              to={`/g/${g.id}`}
-              className="flex items-center gap-3 rounded-md border border-border bg-scout-surface p-3 text-scout-ink transition-colors hover:bg-scout-accent hover:text-scout-accent-ink"
-            >
-              {g.icon === null ? (
-                <div className="h-8 w-8 shrink-0 rounded-md bg-scout-hover" />
-              ) : (
-                <img
-                  src={`https://cdn.discordapp.com/icons/${g.id}/${g.icon}.png?size=64`}
-                  alt=""
-                  width={32}
-                  height={32}
-                  className="h-8 w-8 shrink-0 rounded-md"
-                />
-              )}
-              <span className="flex-1 truncate font-medium">{g.name}</span>
-              {g.isOwner && (
-                <span className="text-xs text-scout-subtle">owner</span>
-              )}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </Shell>
-  );
-}
 
-function GetStartedBanner(props: { onDismiss: () => void }) {
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base">New to Scout?</CardTitle>
-        <CardDescription>
-          Take the quick setup guide to track your first player and learn the
-          basics.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="flex gap-2 pt-0">
-        <Button asChild size="sm">
-          <Link to="/welcome">Start setup guide</Link>
-        </Button>
-        <Button variant="ghost" size="sm" onClick={props.onDismiss}>
-          Dismiss
-        </Button>
-      </CardContent>
-    </Card>
-  );
-}
+      <div className="grid gap-4 md:grid-cols-2">
+        <ExperienceCard
+          title="Explore Scout"
+          description="Ask questions across Scout's recorded games and find configured players from enabled servers you share."
+          icon={<Compass aria-hidden="true" />}
+        >
+          {memberPending ? (
+            <p className="text-sm text-scout-subtle">Checking access…</p>
+          ) : memberError ? (
+            <div className="space-y-3">
+              <p className="text-sm text-scout-subtle">
+                Scout couldn&apos;t verify your member access. This is usually
+                temporary.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  void exploreQuery.refetch();
+                  void profilesQuery.refetch();
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : memberDestination === null ? (
+            <p className="text-sm text-scout-subtle">
+              Member discovery is not enabled for a Scout server you currently
+              share. Administrator permission is not required when it becomes
+              available.
+            </p>
+          ) : (
+            <Button asChild size="lg">
+              <Link to={memberDestination}>Explore Scout</Link>
+            </Button>
+          )}
+        </ExperienceCard>
 
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mx-auto max-w-2xl space-y-4 px-4 py-8 sm:py-12">
-      {children}
+        <ExperienceCard
+          title="Manage Scout"
+          description="Open an existing server workspace, continue setup, or add Scout to a new Discord server."
+          icon={<Settings aria-hidden="true" />}
+        >
+          <Button asChild size="lg" variant="outline">
+            <Link to="/manage">Manage Scout</Link>
+          </Button>
+        </ExperienceCard>
+      </div>
     </div>
+  );
+}
+
+function ExperienceCard(props: {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card className="flex min-h-72 flex-col border-primary/30 bg-gradient-to-br from-scout-surface to-scout-hover/40">
+      <CardHeader className="flex-1 space-y-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          {props.icon}
+        </div>
+        <div className="space-y-2">
+          <CardTitle className="text-2xl">{props.title}</CardTitle>
+          <CardDescription>{props.description}</CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent>{props.children}</CardContent>
+    </Card>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/guild-workspace.tsx
@@ -175,7 +175,7 @@ export function GuildWorkspace() {
               Setup guide
             </Link>
             <NavLink
-              to="/"
+              to="/manage"
               className="text-sm font-medium text-scout-subtle hover:text-scout-ink"
             >
               Change guild

--- a/packages/scout-for-lol/packages/app/src/routes/login.test.ts
+++ b/packages/scout-for-lol/packages/app/src/routes/login.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { LOGIN_DESCRIPTION } from "#src/routes/login.tsx";
+
+describe("login copy", () => {
+  test("describes member and management access without an administrator aside", () => {
+    expect(LOGIN_DESCRIPTION).toBe(
+      "Sign in with Discord to ask Scout, find players in shared servers, or manage servers where you have access.",
+    );
+    expect(LOGIN_DESCRIPTION).not.toContain(
+      "You do not need to be an administrator",
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/routes/login.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/login.tsx
@@ -2,6 +2,9 @@ import { useSearchParams } from "react-router";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import { trackOutboundClick } from "#src/lib/analytics.ts";
 
+export const LOGIN_DESCRIPTION =
+  "Sign in with Discord to ask Scout, find players in shared servers, or manage servers where you have access.";
+
 /**
  * The "Sign in with Discord" anchor points at the backend's
  * /api/auth/discord/start route. That route mints the OAuth state
@@ -22,9 +25,7 @@ export function Login() {
           <h1 className="text-2xl font-semibold tracking-tight">
             Scout for LoL
           </h1>
-          <p className="text-sm text-scout-subtle">
-            Sign in with Discord to manage your guild&apos;s subscriptions.
-          </p>
+          <p className="text-sm text-scout-subtle">{LOGIN_DESCRIPTION}</p>
         </div>
         {error !== null && (
           <p className="text-sm text-scout-danger">{describeError(error)}</p>

--- a/packages/scout-for-lol/packages/app/src/routes/manage-servers.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/manage-servers.tsx
@@ -1,0 +1,120 @@
+import { Link } from "react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Plus, Settings } from "lucide-react";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@scout-for-lol/design-system/components/card";
+import { trackOutboundClick } from "#src/lib/analytics.ts";
+import { STALE_TIME_SLOW_LIST } from "#src/lib/stale-times.ts";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+const INSTALL_URL = "/api/discord/install?surface=manage_servers";
+
+export function ManageServers() {
+  const trpc = useTRPC();
+  const { data: guilds } = useSuspenseQuery(
+    trpc.guild.listManageable.queryOptions(undefined, {
+      staleTime: STALE_TIME_SLOW_LIST,
+    }),
+  );
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-8 px-4 py-8 sm:py-12">
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-primary">Administration</p>
+        <h1 className="text-3xl font-semibold tracking-tight">Manage Scout</h1>
+        <p className="max-w-2xl text-scout-subtle">
+          Configure Scout for servers you can manage, or begin setup for a new
+          Discord server.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Plus className="h-5 w-5" aria-hidden="true" />
+            Set up a new server
+          </CardTitle>
+          <CardDescription>
+            Sign in to Discord&apos;s installation flow, choose a server, then
+            finish tracking your first player in Scout.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          <Button asChild>
+            <a
+              href={INSTALL_URL}
+              onClick={(clickEvent) => {
+                trackOutboundClick(
+                  clickEvent,
+                  "bot_install_click",
+                  INSTALL_URL,
+                  { surface: "manage_servers" },
+                );
+              }}
+            >
+              Set up a new server
+            </a>
+          </Button>
+          <Button asChild variant="outline">
+            <Link to="/welcome">Open setup guide</Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4" aria-labelledby="manageable-servers">
+        <div className="flex items-center gap-2">
+          <Settings className="h-5 w-5 text-scout-subtle" aria-hidden="true" />
+          <h2 id="manageable-servers" className="text-xl font-semibold">
+            Existing servers
+          </h2>
+        </div>
+        {guilds.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">No manageable servers</CardTitle>
+              <CardDescription>
+                You can still set up Scout for a server where Discord allows you
+                to install apps.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {guilds.map((guild) => (
+              <li key={guild.id}>
+                <Link
+                  to={`/g/${guild.id}`}
+                  className="flex items-center gap-3 rounded-lg border border-border bg-scout-surface p-4 text-scout-ink transition-colors hover:border-primary/50 hover:bg-scout-hover"
+                >
+                  {guild.icon === null ? (
+                    <div className="h-10 w-10 shrink-0 rounded-md bg-scout-hover" />
+                  ) : (
+                    <img
+                      src={`https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}.png?size=64`}
+                      alt=""
+                      width={40}
+                      height={40}
+                      className="h-10 w-10 shrink-0 rounded-md"
+                    />
+                  )}
+                  <span className="min-w-0 flex-1 truncate font-medium">
+                    {guild.name}
+                  </span>
+                  {guild.isOwner ? (
+                    <span className="text-xs text-scout-subtle">owner</span>
+                  ) : null}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/routes/player-profile.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/player-profile.tsx
@@ -1,5 +1,4 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { RanksSchema } from "@scout-for-lol/data";
 import { useTRPC } from "#src/lib/trpc.ts";
 import { usePlayerParams } from "#src/lib/route-params.ts";
 import { PlayerTabsNav } from "#src/components/player-tabs-nav.tsx";
@@ -7,8 +6,7 @@ import { Section } from "#src/components/player-detail-sections.tsx";
 import {
   ChampionPoolTable,
   MatchHistoryList,
-  RankCard,
-  RecentFormCard,
+  PlayerSummaryCards,
 } from "#src/components/player-profile-sections.tsx";
 
 /**
@@ -31,7 +29,6 @@ export function PlayerProfile() {
 
   const summary = summaryQuery.data;
   const accountCount = summary.accountCount;
-  const ranks = RanksSchema.parse(summary.ranks);
 
   return (
     <div className="space-y-4">
@@ -48,14 +45,10 @@ export function PlayerProfile() {
 
       <PlayerTabsNav guildId={guildId} alias={alias} />
 
-      <div className="grid gap-4 md:grid-cols-4">
-        <RankCard label="Ranked solo/duo" rank={ranks.solo} />
-        <RankCard label="Ranked flex" rank={ranks.flex} />
-        <RankCard label="Ranked 5s" rank={ranks.ranked5s} />
-        {summary.recentForm !== null && (
-          <RecentFormCard form={summary.recentForm} />
-        )}
-      </div>
+      <PlayerSummaryCards
+        ranks={summary.ranks}
+        recentForm={summary.recentForm}
+      />
 
       <Section title="Champions">
         <ChampionPoolTable

--- a/packages/scout-for-lol/packages/app/src/routes/root-layout.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/root-layout.tsx
@@ -42,6 +42,34 @@ export function appGlobalPath(pathname: string): string {
   return `/app${pathname}`;
 }
 
+function MemberToolLinks(props: { pathname: string }) {
+  return (
+    <>
+      <a
+        className="scout-navbar__link"
+        href="/app/explore"
+        aria-current={
+          props.pathname.startsWith("/explore") ? "page" : undefined
+        }
+      >
+        Explore
+      </a>
+      <a
+        className="scout-navbar__link"
+        href="/app/players"
+        aria-current={
+          props.pathname.startsWith("/players") ? "page" : undefined
+        }
+      >
+        Players
+      </a>
+      <a className="scout-navbar__link" href="/app/manage">
+        Manage servers
+      </a>
+    </>
+  );
+}
+
 /**
  * Top-level chrome shared by every route (login included): the contract
  * mismatch banner above the routed content and the build-identity footer below
@@ -90,11 +118,19 @@ export function RootLayout() {
       <GlobalNavbar
         signedIn={username !== undefined}
         currentPath={appGlobalPath(location.pathname)}
-        guildAccess={
+        utility={
           username === undefined ? undefined : (
-            <a className="scout-navbar__link" href="/app/">
-              Guilds
-            </a>
+            <nav
+              className="scout-navbar__member-links"
+              aria-label="Member tools"
+            >
+              <MemberToolLinks pathname={location.pathname} />
+            </nav>
+          )
+        }
+        mobileNavigation={
+          username === undefined ? undefined : (
+            <MemberToolLinks pathname={location.pathname} />
           )
         }
         accountMenu={

--- a/packages/scout-for-lol/packages/backend/src/database/design-audit-player-fixture.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/design-audit-player-fixture.ts
@@ -1,0 +1,116 @@
+import type { PrismaClient } from "#generated/prisma/client/index.js";
+import type {
+  DiscordAccountId,
+  DiscordGuildId,
+  LeaguePuuid,
+  Region,
+} from "@scout-for-lol/data";
+
+/** Build the deterministic combined-account profile used by visual audits. */
+export async function seedDesignAuditPlayerProfile(input: {
+  prisma: PrismaClient;
+  guildId: DiscordGuildId;
+  discordId: DiscordAccountId;
+  playerAlias: string;
+  puuid: LeaguePuuid;
+  secondaryPuuid: LeaguePuuid;
+  region: Region;
+  now: Date;
+}) {
+  const player = await input.prisma.player.create({
+    data: {
+      serverId: input.guildId,
+      alias: input.playerAlias,
+      discordId: input.discordId,
+      creatorDiscordId: input.discordId,
+      createdTime: input.now,
+      updatedTime: input.now,
+    },
+  });
+
+  await input.prisma.account.createMany({
+    data: [
+      {
+        alias: input.playerAlias,
+        puuid: input.puuid,
+        region: input.region,
+        playerId: player.id,
+        serverId: input.guildId,
+        riotGameName: "MapleCarry",
+        riotTagLine: "NOVA",
+        riotIdUpdatedAt: input.now,
+        lastMatchTime: input.now,
+        lastCheckedAt: input.now,
+        creatorDiscordId: input.discordId,
+        createdTime: input.now,
+        updatedTime: input.now,
+      },
+      {
+        alias: input.playerAlias,
+        puuid: input.secondaryPuuid,
+        region: input.region,
+        playerId: player.id,
+        serverId: input.guildId,
+        riotGameName: "RiverQuartz",
+        riotTagLine: "MINT",
+        riotIdUpdatedAt: input.now,
+        lastMatchTime: new Date("2025-12-30T18:00:00.000Z"),
+        lastCheckedAt: input.now,
+        creatorDiscordId: input.discordId,
+        createdTime: input.now,
+        updatedTime: input.now,
+      },
+    ],
+  });
+
+  await input.prisma.matchRankHistory.createMany({
+    data: [
+      {
+        matchId: "design-audit-match-1",
+        puuid: input.puuid,
+        queueType: "solo",
+        rankBefore: JSON.stringify({
+          tier: "gold",
+          division: 2,
+          lp: 46,
+          wins: 41,
+          losses: 34,
+        }),
+        rankAfter: JSON.stringify({
+          tier: "gold",
+          division: 2,
+          lp: 64,
+          wins: 42,
+          losses: 34,
+        }),
+        matchGameCreationAt: new Date("2026-01-01T12:00:00.000Z"),
+        matchGameEndAt: new Date("2026-01-01T12:30:00.000Z"),
+        capturedAt: input.now,
+      },
+      {
+        matchId: "design-audit-match-2",
+        puuid: input.secondaryPuuid,
+        queueType: "flex",
+        rankBefore: JSON.stringify({
+          tier: "silver",
+          division: 1,
+          lp: 71,
+          wins: 22,
+          losses: 19,
+        }),
+        rankAfter: JSON.stringify({
+          tier: "gold",
+          division: 4,
+          lp: 2,
+          wins: 23,
+          losses: 19,
+        }),
+        matchGameCreationAt: new Date("2025-12-30T18:00:00.000Z"),
+        matchGameEndAt: new Date("2025-12-30T18:31:00.000Z"),
+        capturedAt: input.now,
+      },
+    ],
+  });
+
+  return player;
+}

--- a/packages/scout-for-lol/packages/backend/src/database/design-audit-seed.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/design-audit-seed.ts
@@ -11,6 +11,7 @@ import {
   ReportIdSchema,
 } from "@scout-for-lol/data";
 import { parseAndCompile } from "@scout-for-lol/data/model/report-query-compile.ts";
+import { seedDesignAuditPlayerProfile } from "#src/database/design-audit-player-fixture.ts";
 import { resetTestLake, writeTestLake } from "#src/testing/test-report-lake.ts";
 
 const DEFAULT_GUILD_ID = "1337623164146155593";
@@ -84,6 +85,7 @@ export async function seedDesignAuditDatabase(
   );
   const channelId = DiscordChannelIdSchema.parse("1337623164146155594");
   const puuid = LeaguePuuidSchema.parse("d".repeat(78));
+  const secondaryPuuid = LeaguePuuidSchema.parse("e".repeat(78));
   const region = RegionSchema.parse("AMERICA_NORTH");
   const playerAlias =
     Bun.env["SCOUT_DESIGN_AUDIT_PLAYER_ALIAS"] ?? DEFAULT_PLAYER_ALIAS;
@@ -194,39 +196,22 @@ export async function seedDesignAuditDatabase(
     await prisma.account.deleteMany({
       where: { serverId: guildId },
     });
+    await prisma.matchRankHistory.deleteMany({
+      where: { puuid: { in: [puuid, secondaryPuuid] } },
+    });
     await prisma.player.deleteMany({
       where: { serverId: guildId },
     });
 
-    const player = await prisma.player.create({
-      data: {
-        serverId: guildId,
-        alias: playerAlias,
-        discordId,
-        creatorDiscordId: discordId,
-        createdTime: now,
-        updatedTime: now,
-      },
-    });
-
-    await prisma.account.upsert({
-      where: { serverId_puuid: { serverId: guildId, puuid } },
-      update: {
-        alias: playerAlias,
-        playerId: player.id,
-        region,
-        updatedTime: now,
-      },
-      create: {
-        alias: playerAlias,
-        puuid,
-        region,
-        playerId: player.id,
-        serverId: guildId,
-        creatorDiscordId: discordId,
-        createdTime: now,
-        updatedTime: now,
-      },
+    const player = await seedDesignAuditPlayerProfile({
+      prisma,
+      guildId,
+      discordId,
+      playerAlias,
+      puuid,
+      secondaryPuuid,
+      region,
+      now,
     });
 
     await prisma.subscription.create({
@@ -305,7 +290,7 @@ export async function seedDesignAuditDatabase(
           discordId,
           matchId: "design-audit-match-1",
           puuid,
-          queue: "RANKED_SOLO_5x5",
+          queue: "solo",
           win: true,
           surrendered: false,
           kills: 8,
@@ -314,6 +299,108 @@ export async function seedDesignAuditDatabase(
           championId: 222,
           championName: "Jinx",
           gameCreationAt: new Date("2026-01-01T12:00:00.000Z"),
+        },
+        {
+          playerId: player.id,
+          playerAlias,
+          discordId,
+          matchId: "design-audit-match-2",
+          puuid: secondaryPuuid,
+          queue: "flex",
+          win: true,
+          surrendered: false,
+          kills: 6,
+          deaths: 3,
+          assists: 14,
+          championId: 40,
+          championName: "Janna",
+          gameCreationAt: new Date("2025-12-30T18:00:00.000Z"),
+        },
+        {
+          playerId: player.id,
+          playerAlias,
+          discordId,
+          matchId: "design-audit-match-3",
+          puuid,
+          queue: "solo",
+          win: false,
+          surrendered: false,
+          kills: 4,
+          deaths: 7,
+          assists: 8,
+          championId: 222,
+          championName: "Jinx",
+          gameCreationAt: new Date("2025-12-29T20:00:00.000Z"),
+        },
+        {
+          playerId: player.id,
+          playerAlias,
+          discordId,
+          matchId: "design-audit-match-4",
+          puuid: secondaryPuuid,
+          queue: "flex",
+          win: false,
+          surrendered: false,
+          kills: 2,
+          deaths: 5,
+          assists: 16,
+          championId: 40,
+          championName: "Janna",
+          gameCreationAt: new Date("2025-12-28T21:00:00.000Z"),
+        },
+      ],
+      untrackedMatchFacts: [
+        {
+          playerId: 901,
+          playerAlias: "Teammate One",
+          matchId: "design-audit-match-1",
+          puuid: "f".repeat(78),
+          queue: "solo",
+          win: true,
+          surrendered: false,
+          kills: 20,
+          deaths: 4,
+          assists: 6,
+          gameCreationAt: new Date("2026-01-01T12:00:00.000Z"),
+        },
+        {
+          playerId: 902,
+          playerAlias: "Teammate Two",
+          matchId: "design-audit-match-2",
+          puuid: "g".repeat(78),
+          queue: "flex",
+          win: true,
+          surrendered: false,
+          kills: 24,
+          deaths: 5,
+          assists: 9,
+          gameCreationAt: new Date("2025-12-30T18:00:00.000Z"),
+        },
+        {
+          playerId: 903,
+          playerAlias: "Teammate Three",
+          matchId: "design-audit-match-3",
+          puuid: "h".repeat(78),
+          queue: "solo",
+          win: false,
+          surrendered: false,
+          kills: 18,
+          deaths: 8,
+          assists: 5,
+          gameCreationAt: new Date("2025-12-29T20:00:00.000Z"),
+        },
+        {
+          playerId: 904,
+          playerAlias: "Teammate Four",
+          matchId: "design-audit-match-4",
+          puuid: "i".repeat(78),
+          queue: "flex",
+          win: false,
+          surrendered: false,
+          kills: 22,
+          deaths: 6,
+          assists: 7,
+          gameCreationAt: new Date("2025-12-28T21:00:00.000Z"),
         },
       ],
     });

--- a/packages/scout-for-lol/packages/design-system/src/components/combobox.tsx
+++ b/packages/scout-for-lol/packages/design-system/src/components/combobox.tsx
@@ -22,6 +22,7 @@ export type ComboboxProps<T> = {
   disabled?: boolean | undefined;
   className?: string | undefined;
   id?: string | undefined;
+  maxLength?: number | undefined;
   openOnEmptyQuery?: boolean | undefined;
   onBlur?: (() => void) | undefined;
 };
@@ -81,6 +82,7 @@ export function Combobox<T>(props: ComboboxProps<T>) {
       <PopoverAnchor asChild>
         <Input
           id={props.id}
+          maxLength={props.maxLength}
           value={props.value}
           disabled={props.disabled}
           placeholder={props.placeholder}

--- a/packages/scout-for-lol/packages/design-system/src/layout/index.tsx
+++ b/packages/scout-for-lol/packages/design-system/src/layout/index.tsx
@@ -111,6 +111,7 @@ export function GlobalNavbar(props: {
   signedIn?: boolean | undefined;
   currentPath?: string | undefined;
   utility?: ReactNode | undefined;
+  mobileNavigation?: ReactNode | undefined;
   accountMenu?: ReactNode | undefined;
   guildAccess?: ReactNode | undefined;
   getStartedTrackingEvent?: string | undefined;
@@ -167,6 +168,7 @@ export function GlobalNavbar(props: {
                     currentPath={props.currentPath}
                     origins={props.origins}
                   />
+                  {props.mobileNavigation}
                 </nav>
               </SheetContent>
             </Sheet>

--- a/packages/scout-for-lol/packages/design-system/styles/components.css
+++ b/packages/scout-for-lol/packages/design-system/styles/components.css
@@ -665,6 +665,9 @@ button.scout-control > span:first-child {
   align-items: center;
   gap: 0.35rem;
 }
+.scout-navbar__member-links {
+  display: contents;
+}
 .scout-navbar a:not(.scout-button) {
   color: inherit;
   text-decoration: none;
@@ -945,7 +948,8 @@ button.scout-control > span:first-child {
 }
 
 @media (max-width: 60rem) {
-  .scout-navbar__links {
+  .scout-navbar__links,
+  .scout-navbar__member-links {
     display: none;
   }
   .scout-mobile-nav {


### PR DESCRIPTION
## Why

Scout now serves members as well as server administrators. Ordinary sign-in should make those jobs explicit instead of mixing discovery, installation, and server management on one screen.

## What

- Replace `/app/` with two clear doors: **Explore Scout** for member discovery and **Manage Scout** for administration and installation.
- Add `/app/manage` for manageable servers and **Set up a new server**, while retaining `/app/welcome` and `/app/g/:guildId`.
- Remove the automatic first-login setup redirect and point guild switching back to Manage Scout.
- Add enabled Explore/Players consumer subnavigation and preserve direct OAuth returns.
- Convert player search to a 250 ms, two-character accessible combobox with stale-result suppression, Arrow/Enter/Escape support, direct profile navigation, retry states, and redacted settled-query analytics.
- Retain the combined OP.GG-like profile, per-account freshness/ranks, recent form, champion samples, queue filters, and account-attributed match history.
- Shorten the Discord login explanation to cover Ask Scout, shared-server player discovery, and server management without administrator-independent copy.
- Keep all app routes non-indexed.

## Verification

- `bunx turbo run test typecheck lint build --filter=@scout-for-lol/app --filter=@scout-for-lol/design-system --filter=@scout-for-lol/frontend --filter=@scout-for-lol/docs-site`
- `bunx lefthook run pre-commit`
- PinchTab confirms the revised login copy and that OAuth starts with Beta application ID `1311755320745394317` and preserves `returnTo=/app/`.
- The isolated PinchTab profile reached Discord login; completing the callback still requires human Discord sign-in.

## Visual proof

Revised Discord login explanation:

![Revised Discord login page](https://public.sjer.red/pr/assets/2432/app-login.png)

Two-door signed-in dashboard:

| Light | Dark |
| --- | --- |
| ![Dashboard in light mode](https://public.sjer.red/pr/assets/2432/app-dashboard-light.png) | ![Dashboard in dark mode](https://public.sjer.red/pr/assets/2432/app-dashboard-dark.png) |

![Dashboard at 390 px in dark mode](https://public.sjer.red/pr/assets/2432/app-dashboard-mobile-dark.png)

The debounced typeahead exposes only the pseudonymous shared-server fixture:

![Player typeahead result](https://public.sjer.red/pr/assets/2432/player-typeahead-light.png)

ArrowDown and Enter navigate directly into the combined profile:

![Combined player profile](https://public.sjer.red/pr/assets/2432/player-profile-light.png)

All displayed guild, alias, and Riot identities are deterministic local pseudonyms.
