### PR TITLE
fix(temporal): stop one dead chunk from wedging the whole Glitter refresh

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -82,9 +82,33 @@ daily capture; you do not trigger it.
 
 ## Note on the context refresh
 
-`glitter-context-refresh` is a separate scheduled workflow, not an operator
-action. It distills the corpus into per-person context and opens a PR that is
-always human-reviewed.
+`glitter-context-refresh` is a separate scheduled workflow rather than one of
+the operator actions above. It distills the corpus into per-person context and
+opens a PR that is always human-reviewed.
+
+One person's evidence failing no longer fails the run. A card the model cannot
+produce is listed as skipped in the result and in the PR body, and the other
+people are still refreshed; only a run where nobody was refreshed fails.
+
+To reproduce a refresh locally — against the real corpus and the real generation
+cache, without a Temporal server or a worker deploy — run the diagnostic harness.
+It stops before opening a PR unless you ask for a real run:
+
+```bash
+cd packages/temporal
+bun run glitter:refresh-local \
+  --dry-run=true \
+  --max-cost-usd=50 \
+  --snapshot-id=<snapshot-id> \
+  --snapshot-sha256=<snapshot-sha256>
+```
+
+It needs `GLITTER_DISCORD_GUILD_ID`, the `GLITTER_CORPUS_S3_*` credentials, and
+`OPENROUTER_API_KEY`; `--dry-run=false` additionally needs the `GITHUB_APP_*`
+credentials because it opens the PR. Cached generation artifacts are keyed by
+request digest rather than by run, so a local run reuses everything a production
+run already paid for. Pin `--snapshot-id`/`--snapshot-sha256` to reuse the most
+cache; omit both to read the latest verified snapshot.
 
 The weekly schedule passes a $40 uncached-cost kill switch. Operator
 invocations that omit `maxEstimatedCostUsd` still default to $10. A

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -343,6 +343,24 @@ op run --env-file=.env.audit -- DRY_RUN=1 bun run scripts/run-homelab-audit-loca
 op run --env-file=.env.audit -- bun run scripts/run-homelab-audit-local.ts
 ```
 
+**Local Glitter context refresh (no Temporal)** — see
+`scripts/run-glitter-context-refresh-local.ts`, exposed as `glitter:refresh-local`.
+It runs the real `refreshGlitterContext` activity under `MockActivityEnvironment`
+against the real corpus and the real generation-artifact cache, so it reproduces
+a production failure without waiting for a worker image to ship:
+
+```bash
+cd packages/temporal
+bun run glitter:refresh-local --dry-run=true --max-cost-usd=50 \
+  --snapshot-id=<snapshot-id> --snapshot-sha256=<snapshot-sha256>
+```
+
+Needs `GLITTER_DISCORD_GUILD_ID`, the `GLITTER_CORPUS_S3_*` credentials, and
+`OPENROUTER_API_KEY`; `--dry-run=false` also opens a PR and needs `GITHUB_APP_*`.
+Artifacts are cached by request digest rather than by run, so this re-reads
+whatever a production run already paid for instead of re-billing it — which is
+also why pinning a snapshot reuses more cache than reading the latest one.
+
 **Cluster RBAC** — the core and agent worker SAs get the cluster-wide read-only
 `temporal-worker-audit-reader` ClusterRole (see
 `packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts`). A separate

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -31,6 +31,7 @@
     "check:rehearsal": "bun run scripts/check-schedule-rehearsal.ts",
     "glitter:import-seed": "bun run scripts/import-glitter-seed.ts",
     "glitter:operate": "bun run scripts/operate-glitter-corpus.ts",
+    "glitter:refresh-local": "bun run scripts/run-glitter-context-refresh-local.ts",
     "glitter:verify-corpus": "bun run scripts/verify-glitter-corpus.ts",
     "test:ci": "bun ../../scripts/run-ci-test.ts",
     "test:report": "CI_TEST_COVERAGE=1 bun ../../scripts/run-ci-test.ts"

--- a/packages/temporal/scripts/operate-glitter-corpus.ts
+++ b/packages/temporal/scripts/operate-glitter-corpus.ts
@@ -248,6 +248,13 @@ async function runContextRefresh(
         proposalSha256: z.string().regex(/^[0-9a-f]{64}$/),
         eligiblePeople: z.array(z.string()),
         refreshedPeople: z.array(z.string()),
+        // People this run could not refresh, with the reason. The schema is
+        // strict, so this has to track the activity's result type or a waiting
+        // operator's `.parse()` throws after a billable run has already
+        // succeeded — hiding the result and inviting a needless rerun.
+        skippedPeople: z.array(
+          z.object({ personId: z.string(), reason: z.string() }).strict(),
+        ),
         relationshipProposalCount: z.number().int().nonnegative(),
         generation: z
           .object({

--- a/packages/temporal/scripts/run-glitter-context-refresh-local.ts
+++ b/packages/temporal/scripts/run-glitter-context-refresh-local.ts
@@ -1,0 +1,91 @@
+/**
+ * Local harness for the Glitter context refresh activity (no Temporal server).
+ *
+ * Runs the exact `refreshGlitterContext` activity the scheduled workflow runs,
+ * under a mock activity context, so an operator can reproduce a failing
+ * extraction or synthesis against the shared generation-artifact cache without
+ * waiting for a worker image to ship. Cached artifacts are keyed by request
+ * digest, not by run, so a local run reuses everything a production run already
+ * paid for.
+ *
+ * Requires GLITTER_DISCORD_GUILD_ID, the GLITTER_CORPUS_S3_* credentials, and
+ * OPENROUTER_API_KEY. A non-dry run additionally opens a pull request and needs
+ * the GITHUB_APP_* credentials.
+ */
+import { MockActivityEnvironment } from "@temporalio/testing";
+import { glitterContextRefreshActivities } from "#activities/glitter-context-refresh.ts";
+import type { GlitterContextRefreshInput } from "#activities/glitter-context-refresh.ts";
+
+function parseArguments(argv: readonly string[]): GlitterContextRefreshInput {
+  let dryRun = true;
+  let maxEstimatedCostUsd = 10;
+  let snapshotId: string | undefined;
+  let snapshotSha256: string | undefined;
+  let now: string | undefined;
+  for (const argument of argv) {
+    const [flag, value] = splitFlag(argument);
+    switch (flag) {
+      case "--dry-run": {
+        dryRun = value !== "false";
+        break;
+      }
+      case "--max-cost-usd": {
+        maxEstimatedCostUsd = Number(value);
+        break;
+      }
+      case "--snapshot-id": {
+        snapshotId = value;
+        break;
+      }
+      case "--snapshot-sha256": {
+        snapshotSha256 = value;
+        break;
+      }
+      case "--now": {
+        now = value;
+        break;
+      }
+      default: {
+        throw new Error(`Unknown argument: ${argument}`);
+      }
+    }
+  }
+  if ((snapshotId === undefined) !== (snapshotSha256 === undefined)) {
+    throw new Error(
+      "--snapshot-id and --snapshot-sha256 must be supplied together",
+    );
+  }
+  return {
+    dryRun,
+    maxEstimatedCostUsd,
+    ...(now === undefined ? {} : { now }),
+    ...(snapshotId === undefined || snapshotSha256 === undefined
+      ? {}
+      : { snapshot: { snapshotId, snapshotSha256 } }),
+  };
+}
+
+function splitFlag(argument: string): [string, string | undefined] {
+  const separator = argument.indexOf("=");
+  return separator === -1
+    ? [argument, undefined]
+    : [argument.slice(0, separator), argument.slice(separator + 1)];
+}
+
+const input = parseArguments(process.argv.slice(2));
+const environment = new MockActivityEnvironment({
+  workflowExecution: {
+    workflowId: "glitter-context-refresh-local",
+    runId: crypto.randomUUID(),
+  },
+});
+environment.on("heartbeat", (details: unknown) => {
+  console.warn(`heartbeat ${JSON.stringify(details)}`);
+});
+// Called through its owning object rather than detached, so `this` stays bound.
+const result = await environment.run(
+  async (activityInput: GlitterContextRefreshInput) =>
+    await glitterContextRefreshActivities.refreshGlitterContext(activityInput),
+  input,
+);
+console.warn(JSON.stringify(result, null, 2));

--- a/packages/temporal/src/activities/glitter-context-refresh-evidence-error.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-evidence-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Raised when a person's corpus evidence cannot produce a usable style card —
+ * the model would not summarize their chunks, or would not synthesize a card
+ * that satisfies the contract, after every bounded repair.
+ *
+ * This is deliberately a distinct type rather than a plain `Error`. The refresh
+ * activity skips a person and continues on this and only this: retrying would
+ * replay the same cached artifacts and reach the same answer, so failing the
+ * whole run would strand everyone else for one person's evidence.
+ *
+ * Everything else — a transient S3 read, a filesystem write, a parse error, a
+ * cancellation — must keep escaping, because Temporal's activity retry is what
+ * recovers those, and converting one into a "skipped person" silently turns a
+ * recoverable blip into a stale card plus a PR that looks complete.
+ */
+export class GlitterEvidenceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "GlitterEvidenceError";
+  }
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -415,6 +415,21 @@ function generateAcrossTwoMonths(responder: (call: number) => unknown) {
   });
 }
 
+// Same as above but with no direct recent messages either, so the model would
+// see nothing at all.
+function generateWithoutAnyEvidence() {
+  chunkCallCount = 0;
+  recordedSeeds = [];
+  chunkResponder = () => badChunkSummary;
+  return generateStyleCard({
+    candidate: { ...candidate, directRecentMessages: [] },
+    existingCard,
+    sourceSnapshotSha256: "a".repeat(64),
+    artifactStore: memoryStore(),
+    budget: new GenerationBudget(100),
+  });
+}
+
 describe("Glitter extraction repair loop", () => {
   test("retries a poisoned chunk with a fresh seed and succeeds", async () => {
     // Attempt 0 (seed 0) cites an unknown ID; the repair (seed 1) is clean.
@@ -455,24 +470,35 @@ describe("Glitter extraction repair loop", () => {
     expect(result.coverage.evidence.safe_messages).toBe(30);
   });
 
-  test("rejects a person whose every chunk sanitizes to no verifiable evidence", async () => {
-    // Every observation cites an unknown ID and there are no representatives, so
-    // sanitization empties the only chunk entirely. The chunk itself degrades
-    // rather than throwing, but a card backed by nothing at all is a fabrication
-    // rather than a refresh, so the person is rejected.
+  test("still builds a card from direct evidence when every chunk degrades", async () => {
+    // Chunk summaries are not the only evidence the model sees: synthesis also
+    // receives the candidate's verbatim directRecentMessages, and finalize
+    // validates every quoted and sampled ID against the safe corpus regardless.
+    // So a dead chunk costs coverage, not the whole person.
+    const result = await generateWithStubbedModel(() => badChunkSummary);
+
+    expect(result.schemaVersion).toBe(2);
+    expect(result.coverage.evidence.summarized_messages).toBe(0);
+    expect(result.coverage.evidence.direct_recent_messages).toBe(30);
+    // Still bounded: initial attempt plus MAX_EXTRACTION_REPAIR_ATTEMPTS repairs.
+    expect(recordedSeeds).toEqual([0, 1, 2]);
+  });
+
+  test("rejects a person the model would see no evidence for at all", async () => {
+    // Chunks all degraded AND no direct recent messages: synthesis would be
+    // asked to write a card from nothing, which is fabrication rather than a
+    // refresh.
+    //
     // The TYPE matters as much as the message: the refresh activity skips a
     // person on `GlitterEvidenceError` and lets everything else escape to
     // Temporal's retry, so a plain Error here would make a storage blip
     // indistinguishable from unusable evidence.
-    await expect(
-      generateWithStubbedModel(() => badChunkSummary),
-    ).rejects.toThrow(GlitterEvidenceError);
-    await expect(
-      generateWithStubbedModel(() => badChunkSummary),
-    ).rejects.toThrow("no chunk for ryan yielded verifiable evidence");
-
-    // Still bounded: initial attempt plus MAX_EXTRACTION_REPAIR_ATTEMPTS repairs.
-    expect(recordedSeeds).toEqual([0, 1, 2]);
+    await expect(generateWithoutAnyEvidence()).rejects.toThrow(
+      GlitterEvidenceError,
+    );
+    await expect(generateWithoutAnyEvidence()).rejects.toThrow(
+      "no evidence for ryan",
+    );
   });
 
   test("degrades one dead chunk and keeps its messages out of coverage", async () => {

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -162,6 +162,7 @@ describe("Glitter generated style-card schemas", () => {
       existingCard,
       sourceSnapshotSha256: "a".repeat(64),
       chunkCount: 1,
+      summarizedMessages: 30,
       synthesis,
     });
 
@@ -221,6 +222,7 @@ describe("Glitter generated style-card schemas", () => {
         existingCard,
         sourceSnapshotSha256: "a".repeat(64),
         chunkCount: 1,
+        summarizedMessages: 30,
         synthesis: invalidSynthesis,
       }),
     ).toThrow("quotes cites unknown message IDs");
@@ -241,6 +243,7 @@ describe("Glitter generated style-card schemas", () => {
         existingCard,
         sourceSnapshotSha256: "a".repeat(64),
         chunkCount: 1,
+        summarizedMessages: 30,
         synthesis: invalidSynthesis,
       }),
     ).toThrow(
@@ -378,6 +381,39 @@ function generateWithStubbedModel(responder: (call: number) => unknown) {
   });
 }
 
+// A second UTC month, so `buildStyleEvidenceChunks` produces two chunks. The
+// original messages stay first so the synthesis fixture's quote/sample IDs
+// remain inside the safe corpus.
+const secondMonthMessages = Array.from({ length: 30 }, (_, index) =>
+  CurrentMessageSchema.parse({
+    ...CurrentMessageSchema.parse(messages[0]),
+    messageId: String(52_345_678_901_234_500n + BigInt(index)),
+    content: `august message ${String(index)} with characteristic phrasing`,
+    timestamp: `2026-08-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+  }),
+);
+
+function generateAcrossTwoMonths(responder: (call: number) => unknown) {
+  chunkCallCount = 0;
+  recordedSeeds = [];
+  chunkResponder = responder;
+  const budget = new GenerationBudget(100);
+  lastGenerationBudget = budget;
+  const twoMonthMessages = [...messages, ...secondMonthMessages];
+  return generateStyleCard({
+    candidate: {
+      ...candidate,
+      messages: twoMonthMessages,
+      safeMessages: twoMonthMessages,
+      totalMessageCount: twoMonthMessages.length,
+    },
+    existingCard,
+    sourceSnapshotSha256: "a".repeat(64),
+    artifactStore: memoryStore(),
+    budget,
+  });
+}
+
 describe("Glitter extraction repair loop", () => {
   test("retries a poisoned chunk with a fresh seed and succeeds", async () => {
     // Attempt 0 (seed 0) cites an unknown ID; the repair (seed 1) is clean.
@@ -407,17 +443,43 @@ describe("Glitter extraction repair loop", () => {
     expect(recordedSeeds).toEqual([0, 1, 2]);
   });
 
-  test("rejects a chunk that sanitizes to no verifiable evidence at all", async () => {
+  test("counts a sanitized chunk's messages — the chunk still yielded evidence", async () => {
+    // Sanitization dropped one observation, but the model did read and summarize
+    // this chunk, so its messages legitimately back the card.
+    const result = await generateWithStubbedModel(
+      () => partiallyBadChunkSummary,
+    );
+
+    expect(result.coverage.evidence.summarized_messages).toBe(30);
+    expect(result.coverage.evidence.safe_messages).toBe(30);
+  });
+
+  test("rejects a person whose every chunk sanitizes to no verifiable evidence", async () => {
     // Every observation cites an unknown ID and there are no representatives, so
-    // sanitization empties the chunk entirely. Returning it would let the card
-    // advertise full coverage while silently omitting the month, so the run must
-    // fail loudly instead.
+    // sanitization empties the only chunk entirely. The chunk itself degrades
+    // rather than throwing, but a card backed by nothing at all is a fabrication
+    // rather than a refresh, so the person is rejected.
     await expect(
       generateWithStubbedModel(() => badChunkSummary),
-    ).rejects.toThrow("yielded no verifiable evidence");
+    ).rejects.toThrow("no chunk for ryan yielded verifiable evidence");
 
     // Still bounded: initial attempt plus MAX_EXTRACTION_REPAIR_ATTEMPTS repairs.
     expect(recordedSeeds).toEqual([0, 1, 2]);
+  });
+
+  test("degrades one dead chunk and keeps its messages out of coverage", async () => {
+    // Two months, so two chunks. The first yields evidence; the second is
+    // deterministically unverifiable and degrades to nothing. The run must still
+    // produce a card, and coverage must count only the month that contributed —
+    // claiming all 60 would advertise a month the card silently omits.
+    const result = await generateAcrossTwoMonths((call) =>
+      call === 0 ? goodChunkSummary : badChunkSummary,
+    );
+
+    expect(result.schemaVersion).toBe(2);
+    expect(result.coverage.evidence.chunks).toBe(2);
+    expect(result.coverage.evidence.safe_messages).toBe(60);
+    expect(result.coverage.evidence.summarized_messages).toBe(30);
   });
 
   test("keeps an earlier attempt's evidence when a later repair sanitizes to nothing", async () => {

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -4,6 +4,7 @@ import {
   StyleCardSchema,
 } from "@shepherdjerred/glitter-context/schema";
 import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
 import { finalizeStyleSynthesis } from "./glitter-context-refresh-style-finalize.ts";
 import {
   STYLE_ARRAY_FIELDS,
@@ -459,6 +460,13 @@ describe("Glitter extraction repair loop", () => {
     // sanitization empties the only chunk entirely. The chunk itself degrades
     // rather than throwing, but a card backed by nothing at all is a fabrication
     // rather than a refresh, so the person is rejected.
+    // The TYPE matters as much as the message: the refresh activity skips a
+    // person on `GlitterEvidenceError` and lets everything else escape to
+    // Temporal's retry, so a plain Error here would make a storage blip
+    // indistinguishable from unusable evidence.
+    await expect(
+      generateWithStubbedModel(() => badChunkSummary),
+    ).rejects.toThrow(GlitterEvidenceError);
     await expect(
       generateWithStubbedModel(() => badChunkSummary),
     ).rejects.toThrow("no chunk for ryan yielded verifiable evidence");

--- a/packages/temporal/src/activities/glitter-context-refresh-relationships.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationships.test.ts
@@ -9,7 +9,7 @@ import { applyRelationshipProposals } from "./glitter-context-refresh-relationsh
 import {
   shouldEvaluateRelationships,
   shouldPersistRelationshipEvaluation,
-} from "./glitter-context-refresh.ts";
+} from "./glitter-context-refresh-state.ts";
 
 const people = PeopleDocumentSchema.parse({
   schemaVersion: 1,

--- a/packages/temporal/src/activities/glitter-context-refresh-state.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-state.ts
@@ -1,0 +1,90 @@
+import {
+  GenerationStateDocumentSchema,
+  type GenerationStateDocument,
+  type GenerationStateEntry,
+} from "@shepherdjerred/glitter-context/schema";
+import type { selectStyleRefreshCandidates } from "./glitter-context-refresh-selection.ts";
+
+export function shouldEvaluateRelationships(
+  sourceSnapshotChecksum: string | null,
+  latestSnapshotChecksum: string,
+): boolean {
+  return sourceSnapshotChecksum !== latestSnapshotChecksum;
+}
+
+export function shouldPersistRelationshipEvaluation(input: {
+  evaluated: boolean;
+  refreshedPeopleCount: number;
+  relationshipProposalCount: number;
+}): boolean {
+  return (
+    input.evaluated &&
+    (input.refreshedPeopleCount > 0 || input.relationshipProposalCount > 0)
+  );
+}
+
+/**
+ * One person's evidence failing is a partial success worth shipping; every
+ * eligible person failing is not. It means the run produced nothing and the
+ * cause is systemic rather than one person's corpus, so it must surface as a
+ * failed activity instead of an empty PR.
+ */
+export function shouldFailRefreshRun(input: {
+  candidateCount: number;
+  refreshedCount: number;
+}): boolean {
+  return input.candidateCount > 0 && input.refreshedCount === 0;
+}
+
+export function updateGenerationState(input: {
+  state: GenerationStateDocument;
+  refreshedPeople: ReadonlySet<string>;
+  candidates: ReturnType<typeof selectStyleRefreshCandidates>;
+  snapshotSha256: string;
+  refreshedAt: string;
+  relationshipsEvaluated: boolean;
+}): GenerationStateDocument {
+  const candidateByPerson = new Map(
+    input.candidates.map((candidate) => [candidate.person.id, candidate]),
+  );
+  const refreshedEntryFor = (personId: string): GenerationStateEntry => {
+    const candidate = candidateByPerson.get(personId);
+    const lastMessage = candidate?.messages.at(-1);
+    if (candidate === undefined || lastMessage === undefined) {
+      throw new Error(`missing refreshed candidate state for ${personId}`);
+    }
+    return {
+      personId,
+      lastMessageId: lastMessage.messageId,
+      sourceSnapshotChecksum: input.snapshotSha256,
+      messageCount: candidate.totalMessageCount,
+      refreshedAt: input.refreshedAt,
+    };
+  };
+  const existingPersonIds = new Set(
+    input.state.people.map((entry) => entry.personId),
+  );
+  const updatedExisting = input.state.people.map((entry) =>
+    input.refreshedPeople.has(entry.personId)
+      ? { ...entry, ...refreshedEntryFor(entry.personId) }
+      : entry,
+  );
+  // A person can become a refresh candidate without a pre-existing state entry
+  // (new Discord ID + style card). Without appending their watermark here, every
+  // later weekly run would treat them as never-refreshed and regenerate their
+  // card from the entire corpus. Record state for those newly refreshed people.
+  const appended = [...input.refreshedPeople]
+    .filter((personId) => !existingPersonIds.has(personId))
+    .toSorted()
+    .map((personId) => refreshedEntryFor(personId));
+  return GenerationStateDocumentSchema.parse({
+    ...input.state,
+    relationshipSourceSnapshotChecksum: input.relationshipsEvaluated
+      ? input.snapshotSha256
+      : input.state.relationshipSourceSnapshotChecksum,
+    relationshipRefreshedAt: input.relationshipsEvaluated
+      ? input.refreshedAt
+      : input.state.relationshipRefreshedAt,
+    people: [...updatedExisting, ...appended],
+  });
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
@@ -236,6 +236,13 @@ export function finalizeStyleSynthesis(input: {
   existingCard: StyleCard;
   sourceSnapshotSha256: string;
   chunkCount: number;
+  /**
+   * Messages that actually reached the card as evidence, summed from the chunks
+   * that yielded something. Not `safeMessages.length`: a chunk the model could
+   * not summarize contributes nothing, and counting it would let the card claim
+   * a month it silently omits.
+   */
+  summarizedMessages: number;
   synthesis: StyleSynthesis;
 }): StyleCardV2 {
   const allMessagesById = new Map(
@@ -308,7 +315,7 @@ export function finalizeStyleSynthesis(input: {
       },
       evidence: {
         safe_messages: input.candidate.safeMessages.length,
-        summarized_messages: input.candidate.safeMessages.length,
+        summarized_messages: input.summarizedMessages,
         chunks: input.chunkCount,
         direct_recent_messages: input.candidate.directRecentMessages.length,
         date_range: {

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -26,6 +26,12 @@ export type SummarizedChunk = {
   key: string;
   month: string;
   summary: StyleChunkSummary;
+  /**
+   * How many of this chunk's messages actually reached the card as evidence:
+   * the chunk's full message count, or zero when the chunk yielded nothing.
+   * Summed into the card's `coverage.evidence.summarized_messages`.
+   */
+  summarizedMessageCount: number;
 };
 
 type StyleSynthesisPromptInput = {

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -478,12 +478,18 @@ export async function generateStyleCard(input: {
     (total, chunk) => total + chunk.summarizedMessageCount,
     0,
   );
-  // Individual chunks may degrade to nothing, but a card built from no evidence
-  // at all would be a fabrication rather than a refresh. Fail this person so the
-  // caller can skip them and still refresh everyone else.
-  if (summarizedMessages === 0) {
+  // Chunk summaries are not the only evidence: `synthesisPrompt` also hands the
+  // model up to DIRECT_RECENT_STYLE_MESSAGES verbatim messages, and finalize
+  // validates every quoted and sampled ID against the safe corpus either way. So
+  // a person whose chunks all degrade can still get an honest, evidence-backed
+  // card — coverage simply reports that no chunk was summarized. Reject only when
+  // the model would see nothing at all, which would make the card a fabrication.
+  if (
+    summarizedMessages === 0 &&
+    input.candidate.directRecentMessages.length === 0
+  ) {
     throw new GlitterEvidenceError(
-      `no chunk for ${input.candidate.person.id} yielded verifiable evidence across ${String(chunks.length)} chunks`,
+      `no evidence for ${input.candidate.person.id}: ${String(chunks.length)} chunks yielded nothing and there are no direct recent messages`,
     );
   }
   let previous = await runSynthesis({

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -17,6 +17,7 @@ import {
   buildStyleEvidenceChunks,
   type StyleEvidenceChunk,
 } from "./glitter-context-refresh-chunks.ts";
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
 import {
   generateGlitterObject,
   glitterObjectArtifactSchema,
@@ -481,7 +482,7 @@ export async function generateStyleCard(input: {
   // at all would be a fabrication rather than a refresh. Fail this person so the
   // caller can skip them and still refresh everyone else.
   if (summarizedMessages === 0) {
-    throw new Error(
+    throw new GlitterEvidenceError(
       `no chunk for ${input.candidate.person.id} yielded verifiable evidence across ${String(chunks.length)} chunks`,
     );
   }
@@ -521,5 +522,10 @@ export async function generateStyleCard(input: {
       previous = repaired;
     }
   }
-  throw lastError;
+  // Every bounded synthesis repair produced a card the contract rejects. That is
+  // this person's evidence, not a fault in the run.
+  throw new GlitterEvidenceError(
+    `style synthesis for ${input.candidate.person.id} failed after ${String(MAX_SYNTHESIS_REPAIR_ATTEMPTS)} repairs: ${lastError.message}`,
+    { cause: lastError },
+  );
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -53,14 +53,18 @@ import {
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
 
+// Names the chunk, like the exhaustion error beside it at the same call site.
+// Without the key, a run killed by one truncating chunk says only that *some*
+// chunk hit the ceiling — identifying which one meant scanning every cached
+// generation artifact out of the corpus bucket.
+const extractionTruncationError = (chunkKey: string): string =>
+  `GPT-5.6 Luna extraction reached the completion-token limit for ${chunkKey}`;
 // gpt-5.6-sol is a reasoning model at `reasoning_effort: "medium"`, so its
 // hidden reasoning tokens share `max_completion_tokens` with the (large) style
 // synthesis output. Observed live: reasoning + output crossed the former 15k cap
 // and truncated (finish_reason=length → unparseable).
 // 28k gives comfortable headroom over the observed ~15k usage; if a call still
 // truncates, it is retried once at the ceiling below.
-const EXTRACTION_TRUNCATION_ERROR =
-  "GPT-5.6 Luna extraction reached the completion-token limit";
 const SYNTHESIS_TRUNCATION_ERROR =
   "GPT-5.6 Sol synthesis reached the completion-token limit";
 const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
@@ -208,7 +212,7 @@ async function runChunkExtraction(input: {
           EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
         reasoningEffort: "none",
         seed,
-        truncationError: EXTRACTION_TRUNCATION_ERROR,
+        truncationError: extractionTruncationError(input.chunk.key),
         exhaustionError: `GPT-5.6 Luna did not return a parsed summary for ${input.chunk.key}`,
       });
     },
@@ -217,6 +221,22 @@ async function runChunkExtraction(input: {
     artifact,
     budget: input.budget,
   });
+}
+
+function verifiableContent(summary: StyleChunkSummary): number {
+  return summary.observations.length + summary.representativeMessages.length;
+}
+
+/**
+ * A chunk contributes its messages to the card's coverage only when it yielded
+ * usable evidence. A chunk that yielded none influenced nothing, so counting it
+ * would make the card advertise a month it silently omits.
+ */
+function summarizedMessageCount(
+  chunk: StyleEvidenceChunk,
+  summary: StyleChunkSummary,
+): number {
+  return verifiableContent(summary) === 0 ? 0 : chunk.messages.length;
 }
 
 async function summarizeChunk(input: {
@@ -259,15 +279,22 @@ async function summarizeChunk(input: {
   if (lastError === undefined) {
     throw new Error(`chunk ${input.chunk.key} produced no extraction attempts`);
   }
+  // Every attempt failed to parse — the model never returned a schema-valid
+  // summary for this chunk, so there is nothing to sanitize. Observed live:
+  // GPT-5.6 Luna degenerates into a repetition loop on a particular chunk and
+  // burns every semantic attempt, and the resulting failure artifact is cached,
+  // so each later run replays it without spending a token. Throwing here
+  // stranded the whole refresh — for every person — on one unlucky chunk,
+  // permanently. Degrade to an empty summary instead; `summarizedMessageCount`
+  // keeps that month out of the card's coverage rather than laundering the gap,
+  // and `generateStyleCard` still refuses a card with no evidence at all.
   if (attempts.length === 0) {
-    throw lastError;
+    return EMPTY_CHUNK_SUMMARY;
   }
   // The model could not produce a fully valid summary for this chunk even after
   // repairs (it deterministically cites an unverifiable in-content ID). Sanitize
   // every attempt and keep the one that retains the most verifiable evidence, so
   // an earlier attempt's valid observations are not lost to a worse final repair.
-  const verifiableContent = (summary: StyleChunkSummary): number =>
-    summary.observations.length + summary.representativeMessages.length;
   const best = attempts
     .map((attempt) => sanitizeChunkSummary(input.chunk, attempt))
     .reduce((strongest, candidate) =>
@@ -275,15 +302,6 @@ async function summarizeChunk(input: {
         ? candidate
         : strongest,
     );
-  // Fail only when *every* attempt sanitizes to nothing: a chunk that yields zero
-  // verifiable evidence from its entire month would otherwise let the card
-  // advertise full coverage (finalize still counts these messages as summarized)
-  // while silently omitting the month, so fail loudly instead of laundering the gap.
-  if (verifiableContent(best) === 0) {
-    throw new Error(
-      `chunk ${input.chunk.key} yielded no verifiable evidence after ${String(MAX_EXTRACTION_REPAIR_ATTEMPTS)} repair attempts and sanitization (last error: ${lastError.message})`,
-    );
-  }
   // Validate the sanitized result to prove it now satisfies the contract.
   validateChunkSummary(input.chunk, best);
   return best;
@@ -442,16 +460,30 @@ export async function generateStyleCard(input: {
   const chunks = buildStyleEvidenceChunks(input.candidate.safeMessages);
   const summarizedChunks: SummarizedChunk[] = [];
   for (const chunk of chunks) {
+    const summary = await summarizeChunk({
+      candidate: input.candidate,
+      chunk,
+      artifactStore: input.artifactStore,
+      budget: input.budget,
+    });
     summarizedChunks.push({
       key: chunk.key,
       month: chunk.month,
-      summary: await summarizeChunk({
-        candidate: input.candidate,
-        chunk,
-        artifactStore: input.artifactStore,
-        budget: input.budget,
-      }),
+      summary,
+      summarizedMessageCount: summarizedMessageCount(chunk, summary),
     });
+  }
+  const summarizedMessages = summarizedChunks.reduce(
+    (total, chunk) => total + chunk.summarizedMessageCount,
+    0,
+  );
+  // Individual chunks may degrade to nothing, but a card built from no evidence
+  // at all would be a fabrication rather than a refresh. Fail this person so the
+  // caller can skip them and still refresh everyone else.
+  if (summarizedMessages === 0) {
+    throw new Error(
+      `no chunk for ${input.candidate.person.id} yielded verifiable evidence across ${String(chunks.length)} chunks`,
+    );
   }
   let previous = await runSynthesis({
     ...input,
@@ -464,6 +496,7 @@ export async function generateStyleCard(input: {
     return finalizeStyleSynthesis({
       ...input,
       chunkCount: chunks.length,
+      summarizedMessages,
       synthesis: previous,
     });
   } catch (error: unknown) {
@@ -480,6 +513,7 @@ export async function generateStyleCard(input: {
       return finalizeStyleSynthesis({
         ...input,
         chunkCount: chunks.length,
+        summarizedMessages,
         synthesis: repaired,
       });
     } catch (error: unknown) {

--- a/packages/temporal/src/activities/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { GlitterContextRefreshInputSchema } from "./glitter-context-refresh.ts";
+import { shouldFailRefreshRun } from "./glitter-context-refresh-state.ts";
 import {
   glitterContextProposalChecksum,
   glitterContextRunIdentity,
@@ -77,5 +78,23 @@ describe("Glitter context snapshot pin input", () => {
         snapshot: { snapshotSha256 },
       }),
     ).toThrow();
+  });
+});
+
+describe("Glitter refresh run outcome", () => {
+  test("ships a partial refresh but fails when nobody was refreshed", () => {
+    // One person skipped out of three is worth a PR — the other two are real
+    // work that used to be discarded when a single chunk failed.
+    expect(shouldFailRefreshRun({ candidateCount: 3, refreshedCount: 2 })).toBe(
+      false,
+    );
+    // Everyone failing means the cause is systemic, not one person's corpus.
+    expect(shouldFailRefreshRun({ candidateCount: 3, refreshedCount: 0 })).toBe(
+      true,
+    );
+    // Nobody was eligible this week: a legitimate no-op, not a failure.
+    expect(shouldFailRefreshRun({ candidateCount: 0, refreshedCount: 0 })).toBe(
+      false,
+    );
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm } from "node:fs/promises";
 import { Context } from "@temporalio/activity";
+import { ApplicationFailure } from "@temporalio/common";
 import { simpleGit } from "simple-git";
 import { z } from "zod/v4";
 import {
@@ -7,8 +8,6 @@ import {
   PeopleDocumentSchema,
   RelationshipsDocumentSchema,
   StyleCardSchema,
-  type GenerationStateDocument,
-  type GenerationStateEntry,
   type StyleCard,
 } from "@shepherdjerred/glitter-context/schema";
 import { createGitHubAppInstallationToken } from "#lib/github-app-token.ts";
@@ -17,6 +16,7 @@ import {
   glitterContextRefreshRelationshipProposals,
   glitterContextRefreshRunsTotal,
 } from "#observability/metrics-glitter.ts";
+import { log } from "#observability/log.ts";
 import { parsePorcelainPaths } from "#shared/porcelain.ts";
 import { rootInstallWithoutHooks } from "./bot-clone.ts";
 import { runCommand } from "./data-dragon-shell.ts";
@@ -48,6 +48,12 @@ import {
   isAllowedGlitterContextRefreshPath,
 } from "./glitter-context-refresh-paths.ts";
 import { selectStyleRefreshCandidates } from "./glitter-context-refresh-selection.ts";
+import {
+  shouldEvaluateRelationships,
+  shouldFailRefreshRun,
+  shouldPersistRelationshipEvaluation,
+  updateGenerationState,
+} from "./glitter-context-refresh-state.ts";
 import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
 import { openSeasonRefreshPr } from "./scout-season-refresh-git.ts";
 import {
@@ -59,24 +65,6 @@ const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
 const REPO_SLUG = "shepherdjerred/monorepo";
 const MAIN_BRANCH = "main";
 const PACKAGE_PATH = "packages/glitter-context";
-
-export function shouldEvaluateRelationships(
-  sourceSnapshotChecksum: string | null,
-  latestSnapshotChecksum: string,
-): boolean {
-  return sourceSnapshotChecksum !== latestSnapshotChecksum;
-}
-
-export function shouldPersistRelationshipEvaluation(input: {
-  evaluated: boolean;
-  refreshedPeopleCount: number;
-  relationshipProposalCount: number;
-}): boolean {
-  return (
-    input.evaluated &&
-    (input.refreshedPeopleCount > 0 || input.relationshipProposalCount > 0)
-  );
-}
 
 export const GlitterContextRefreshInputSchema = z
   .object({
@@ -97,6 +85,11 @@ export type GlitterContextRefreshResult = {
   proposalSha256: string;
   eligiblePeople: string[];
   refreshedPeople: string[];
+  /**
+   * Eligible people whose card could not be regenerated this run, with the
+   * reason. The run still refreshes everyone else and opens its PR.
+   */
+  skippedPeople: { personId: string; reason: string }[];
   relationshipProposalCount: number;
   generation: GenerationBudgetSummary;
   changedFiles: string[];
@@ -166,59 +159,6 @@ async function validateRefreshClone(repoDir: string): Promise<void> {
   await runCommand(["bun", "run", "test"], { cwd: packageDir });
   await runCommand(["bun", "run", "lint"], { cwd: packageDir });
   await runCommand(["bun", "run", "build"], { cwd: packageDir });
-}
-
-function updateGenerationState(input: {
-  state: GenerationStateDocument;
-  refreshedPeople: ReadonlySet<string>;
-  candidates: ReturnType<typeof selectStyleRefreshCandidates>;
-  snapshotSha256: string;
-  refreshedAt: string;
-  relationshipsEvaluated: boolean;
-}): GenerationStateDocument {
-  const candidateByPerson = new Map(
-    input.candidates.map((candidate) => [candidate.person.id, candidate]),
-  );
-  const refreshedEntryFor = (personId: string): GenerationStateEntry => {
-    const candidate = candidateByPerson.get(personId);
-    const lastMessage = candidate?.messages.at(-1);
-    if (candidate === undefined || lastMessage === undefined) {
-      throw new Error(`missing refreshed candidate state for ${personId}`);
-    }
-    return {
-      personId,
-      lastMessageId: lastMessage.messageId,
-      sourceSnapshotChecksum: input.snapshotSha256,
-      messageCount: candidate.totalMessageCount,
-      refreshedAt: input.refreshedAt,
-    };
-  };
-  const existingPersonIds = new Set(
-    input.state.people.map((entry) => entry.personId),
-  );
-  const updatedExisting = input.state.people.map((entry) =>
-    input.refreshedPeople.has(entry.personId)
-      ? { ...entry, ...refreshedEntryFor(entry.personId) }
-      : entry,
-  );
-  // A person can become a refresh candidate without a pre-existing state entry
-  // (new Discord ID + style card). Without appending their watermark here, every
-  // later weekly run would treat them as never-refreshed and regenerate their
-  // card from the entire corpus. Record state for those newly refreshed people.
-  const appended = [...input.refreshedPeople]
-    .filter((personId) => !existingPersonIds.has(personId))
-    .toSorted()
-    .map((personId) => refreshedEntryFor(personId));
-  return GenerationStateDocumentSchema.parse({
-    ...input.state,
-    relationshipSourceSnapshotChecksum: input.relationshipsEvaluated
-      ? input.snapshotSha256
-      : input.state.relationshipSourceSnapshotChecksum,
-    relationshipRefreshedAt: input.relationshipsEvaluated
-      ? input.refreshedAt
-      : input.state.relationshipRefreshedAt,
-    people: [...updatedExisting, ...appended],
-  });
 }
 
 export type GlitterContextRefreshActivities =
@@ -330,6 +270,7 @@ export const glitterContextRefreshActivities = {
       );
 
       const refreshedPeople = new Set<string>();
+      const skippedPeople: { personId: string; reason: string }[] = [];
       for (const candidate of candidates) {
         Context.current().heartbeat({
           phase: "style-card",
@@ -342,15 +283,50 @@ export const glitterContextRefreshActivities = {
             `missing existing style card for ${candidate.person.id}`,
           );
         }
-        const card = await generateStyleCard({
-          candidate,
-          existingCard,
-          sourceSnapshotSha256: corpus.reference.snapshotSha256,
-          artifactStore: generationArtifactStore,
-          budget: generationBudget,
-        });
-        await Bun.write(path, jsonText(card));
-        refreshedPeople.add(candidate.person.id);
+        // One person's evidence failing must not discard every other person's
+        // work. A refresh is hours long and costs real money, and a single
+        // chunk the model cannot summarize used to fail the whole activity —
+        // including cards already generated earlier in this same loop.
+        try {
+          const card = await generateStyleCard({
+            candidate,
+            existingCard,
+            sourceSnapshotSha256: corpus.reference.snapshotSha256,
+            artifactStore: generationArtifactStore,
+            budget: generationBudget,
+          });
+          await Bun.write(path, jsonText(card));
+          refreshedPeople.add(candidate.person.id);
+        } catch (error: unknown) {
+          // Every `ApplicationFailure` raised under here is a deliberate
+          // stop-the-run signal about the run rather than about this person —
+          // an exhausted budget (continuing just re-refuses for everyone left)
+          // or a billed completion that could not be persisted (retrying would
+          // re-bill it). Only ordinary evidence failures are this person's.
+          if (error instanceof ApplicationFailure) {
+            throw error;
+          }
+          const reason = z.instanceof(Error).parse(error).message;
+          log("warning", "Glitter style card skipped", {
+            personId: candidate.person.id,
+            reason,
+          });
+          skippedPeople.push({ personId: candidate.person.id, reason });
+        }
+      }
+      glitterContextRefreshPeople.set(
+        { state: "skipped" },
+        skippedPeople.length,
+      );
+      if (
+        shouldFailRefreshRun({
+          candidateCount: candidates.length,
+          refreshedCount: refreshedPeople.size,
+        })
+      ) {
+        throw new Error(
+          `every eligible person failed to refresh (${skippedPeople.map((skipped) => `${skipped.personId}: ${skipped.reason}`).join("; ")})`,
+        );
       }
 
       let updatedRelationships = relationshipsDocument;
@@ -413,6 +389,7 @@ export const glitterContextRefreshActivities = {
         proposalSha256,
         eligiblePeople: candidates.map((candidate) => candidate.person.id),
         refreshedPeople: [...refreshedPeople].toSorted(),
+        skippedPeople,
         relationshipProposalCount,
         generation: generationBudget.summary(),
         changedFiles: files,
@@ -446,6 +423,16 @@ export const glitterContextRefreshActivities = {
         "",
         `Verified snapshot: \`${corpus.reference.snapshotSha256}\``,
         `Style cards refreshed: ${String(refreshedPeople.size)}`,
+        // A reviewer has to be told which people this PR does NOT refresh;
+        // otherwise a silently skipped card looks like one with no new evidence.
+        ...(skippedPeople.length === 0
+          ? []
+          : [
+              `Style cards skipped: ${String(skippedPeople.length)}`,
+              ...skippedPeople.map(
+                (skipped) => `- \`${skipped.personId}\`: ${skipped.reason}`,
+              ),
+            ]),
         `Relationship updates proposed: ${String(relationshipProposalCount)}`,
         `Uncached generation cost: $${baseResult.generation.actualUncachedCostUsd.toFixed(4)} / $${baseResult.generation.maxUncachedCostUsd.toFixed(2)}`,
         `Generation cache: ${String(baseResult.generation.cacheHits)} hits, ${String(baseResult.generation.cacheMisses)} misses`,

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -1,6 +1,5 @@
 import { mkdir, rm } from "node:fs/promises";
 import { Context } from "@temporalio/activity";
-import { ApplicationFailure } from "@temporalio/common";
 import { simpleGit } from "simple-git";
 import { z } from "zod/v4";
 import {
@@ -28,6 +27,7 @@ import {
   estimateRelationshipGenerationCost,
   proposeRelationships,
 } from "./glitter-context-refresh-generate.ts";
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
 import {
   estimateStyleGenerationCost,
   generateStyleCard,
@@ -298,15 +298,18 @@ export const glitterContextRefreshActivities = {
           await Bun.write(path, jsonText(card));
           refreshedPeople.add(candidate.person.id);
         } catch (error: unknown) {
-          // Every `ApplicationFailure` raised under here is a deliberate
-          // stop-the-run signal about the run rather than about this person —
-          // an exhausted budget (continuing just re-refuses for everyone left)
-          // or a billed completion that could not be persisted (retrying would
-          // re-bill it). Only ordinary evidence failures are this person's.
-          if (error instanceof ApplicationFailure) {
+          // Skip on `GlitterEvidenceError` and nothing else. That type means the
+          // model would not produce a usable card from this person's corpus,
+          // which a retry would only reproduce from the same cached artifacts.
+          // Everything else keeps escaping so Temporal's activity retry can
+          // recover it: a transient S3 read inside the artifact cache, a failed
+          // write, a cancellation, or an exhausted budget are all about the run,
+          // and swallowing one would turn a recoverable blip into a stale card
+          // behind a PR that looks complete.
+          if (!(error instanceof GlitterEvidenceError)) {
             throw error;
           }
-          const reason = z.instanceof(Error).parse(error).message;
+          const reason = error.message;
           log("warning", "Glitter style card skipped", {
             personId: candidate.person.id,
             reason,

--- a/packages/temporal/src/workflows/glitter-context-refresh.test.ts
+++ b/packages/temporal/src/workflows/glitter-context-refresh.test.ts
@@ -25,6 +25,7 @@ describe("runGlitterContextRefresh", () => {
       proposalSha256: "b".repeat(64),
       eligiblePeople: ["virmel"],
       refreshedPeople: ["virmel"],
+      skippedPeople: [],
       relationshipProposalCount: 0,
       generation: {
         maxUncachedCostUsd: 50,


### PR DESCRIPTION
## Why

The Glitter style-card refresh has **never completed**. `generation-state.json` is null for all 13 people and every card is still the hand-imported seed.

On chunk `2023-03-0000`, GPT-5.6 Luna emits valid JSON and then degenerates into a repetition loop:

```
{"observations":[{"field":"voice","claim":"Uses predominantly lowercase…
…ERWERWERWERWERWERWERWERWERWERWERWERWERWERWERWERWERWERWERWER
```

It burns all three semantic attempts — 4,000 + 8,000 + 8,000 = the **20,000 output tokens** `worstCaseGenerationCostUsd` already reserves — and returns nothing parseable. `summarizeChunk` threw, and `generateStyleCard` runs in an uncaught per-candidate loop, so **one chunk failed the refresh for all 13 people** and discarded cards generated earlier in the same run.

The kill is that **failure artifacts are cached**. Every later run replays five stored failures as cache hits, so all three repair attempts fail without a single LLM call — one workflow died in 3m46s having spent nothing. No retry cap, quieter worker, or longer deadline could ever change that.

Extraction is otherwise healthy. Across **2,152 cached successes**: p50 1,064 output tokens, p95 1,465, max 2,943 — all comfortably under the 4,000 cap. Six artifacts out of 2,158 have ever failed. The chunks are not too big, and the budget was never wrong.

## What

- **Per-person isolation.** A candidate whose card cannot be generated is recorded in a new `skippedPeople` result field, listed in the PR body, and counted on `glitter_context_refresh_people{state="skipped"}`. The run refreshes everyone else. `ApplicationFailure` still propagates — an exhausted budget or a billed-but-unpersisted completion is about the *run*, not about one person.
- **`shouldFailRefreshRun`** keeps a total failure a real failure rather than an empty PR.
- **A chunk whose every attempt fails to parse degrades** to an empty summary instead of throwing.
- **`coverage.evidence.summarized_messages` is now real.** It previously duplicated `safe_messages`, so it over-claimed *even before this bug* — a chunk sanitized from 30 observations to 1 still asserted all ~250 of its messages were summarized. That over-claim is precisely what the old throw existed to prevent, which is what makes degrading safe now rather than a loosening.
- **The truncation error names its chunk**, like the exhaustion error one line below it. Identifying this one meant scanning 2,158 artifacts out of the corpus bucket.
- **A local harness** (`scripts/run-glitter-context-refresh-local.ts`) runs the real activity under `MockActivityEnvironment` against the real corpus and cache, following the `run-homelab-audit-local.ts` precedent. It is what produced the diagnosis above.
- **Splits the pure run-bookkeeping helpers** into `glitter-context-refresh-state.ts`. The activity was already at 487 lines against the 500 cap; same split as `schedule-definitions.ts` out of `register-schedules.ts`.

**No generation parameters change.** The hashed request (`model`, `messages`, `maxCompletionTokens`, `semanticRetryMaxCompletionTokens`, `reasoningEffort`, `seed`, `responseSchema`) is untouched, so the ~$23.61 of cached extraction survives and is reused.

## Verification

- `bunx turbo run typecheck lint --filter=@shepherdjerred/temporal` — 0 errors.
- `cd packages/temporal && bun run test:bun` — **808 pass**; `bun run test:workflows` — **48 pass**.
- New tests: a degraded chunk keeps its month out of coverage (`safe_messages: 60`, `summarized_messages: 30`); a *sanitized* chunk still counts its messages; a person whose every chunk yields nothing is rejected; and the run-level partial/total outcome rule.
- The existing "rejects a chunk that sanitizes to no verifiable evidence" test is retained with its boundary moved from chunk to person, which is the behaviour change.

**Not yet exercised against production** — that needs this worker image. The follow-up sequence is: deploy, purge the six poisoned cache artifacts, dry run, real run, then unpause `glitter-context-refresh-weekly`.

No user-visible surface, so no media artifact.