### PR TITLE
chore(root): require dashboard approval for Renovate updates

### DIFF
--- a/packages/dotfiles/dot_agents/skills/version-management/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/version-management/SKILL.md
@@ -288,11 +288,26 @@ deploys.
 
 ## Renovate Configuration
 
-The project uses Renovate for automated updates:
+The project uses Mend-hosted Renovate as a dashboard-first dependency inventory:
 
 1. Renovate's custom manager parses structured entries in `catalog.json`
-2. Creates PRs for version bumps
-3. PRs run `bun run verify` (affected-scoped) on the static Buildkite pipeline (`.buildkite/pipeline.yml`) — check the `buildkite/monorepo/pr` status before merging
+2. Renovate reports available updates in the GitHub Dependency Dashboard
+3. A human selects a dashboard checkbox to authorize a branch and PR for one update
+4. Humans rebase and merge approved PRs; Renovate never does either automatically
+5. PRs run `bun run verify` (affected-scoped) on the static Buildkite pipeline (`.buildkite/pipeline.yml`) — check the `buildkite/monorepo/pr` status before merging
+
+Renovate vulnerability remediation and OSV alerts are disabled so they cannot
+bypass dashboard approval. GitHub's separate security-alert interface is
+unchanged. Approved Bun updates still run a full install, so
+`BUN_CONFIG_MAX_HTTP_REQUESTS=4` limits their HTTP concurrency for the
+Mend-hosted 3 GB runner. Validate the repository configuration against Mend's
+exact Renovate version and environment allowlist:
+
+```bash
+RENOVATE_ALLOWED_ENV='["BUN_CONFIG_MAX_HTTP_REQUESTS"]' \
+  bunx --package renovate@44.39.0 \
+  renovate-config-validator --no-global renovate.json
+```
 
 ### Digest/pin updates bypass `minimumReleaseAge`
 

--- a/packages/temporal/runbooks/homelab-audit.md
+++ b/packages/temporal/runbooks/homelab-audit.md
@@ -442,9 +442,16 @@ Flag: merge conflicts against `main`, failing required checks, missing approvals
 
 ```bash
 toolkit gh pr list --state open --author "app/renovate" --json number,title,mergeable,statusCheckRollup
+
+toolkit gh issue list --state open --author "app/renovate" \
+  --search '"Dependency Dashboard" in:title' \
+  --json number,title,updatedAt,body
 ```
 
-Flag: Renovate PRs with failing CI (broken upgrade pipeline), or a large backlog of open Renovate PRs (automerge broken).
+Flag: the Dependency Dashboard not updating after its Sunday schedule, a
+dashboard-approved update that never produces a branch or PR, or an approved PR
+with failing CI or no human activity for ~14 days. A backlog of unapproved
+dashboard items is expected and is not a finding.
 
 ## Section 13: Application Health Matrix
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "automerge": true,
-  "automergeStrategy": "rebase",
+  "dependencyDashboardApproval": true,
+  "automerge": false,
+  "platformAutomerge": false,
+  "rebaseWhen": "never",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "osvVulnerabilityAlerts": false,
+  "env": {
+    "BUN_CONFIG_MAX_HTTP_REQUESTS": "4"
+  },
   "extends": ["config:recommended"],
   "homeassistant-manifest": {
     "enabled": false
@@ -147,7 +156,7 @@
     },
     {
       "description": "Playwright client packages are promoted atomically with the tested ci-playwright image digest; Renovate owns only the official Dockerfile source pin.",
-      "matchManagers": ["npm"],
+      "matchManagers": ["bun", "npm"],
       "matchPackageNames": ["playwright", "@playwright/test"],
       "enabled": false
     },
@@ -223,7 +232,7 @@
     },
     {
       "description": "Native TypeScript 7 owns typechecking; keep direct TypeScript on 6 for typescript-eslint project service, Astro Check, Twoslash, and TypeDoc.",
-      "matchManagers": ["npm"],
+      "matchManagers": ["bun", "npm"],
       "matchDepNames": ["typescript"],
       "allowedVersions": "<7"
     },

--- a/scripts/renovate-config.test.ts
+++ b/scripts/renovate-config.test.ts
@@ -10,6 +10,21 @@ const RegexManagerSchema = z.object({
 });
 
 const RenovateConfigSchema = z.object({
+  dependencyDashboardApproval: z.boolean(),
+  automerge: z.boolean(),
+  automergeStrategy: z.string().optional(),
+  platformAutomerge: z.boolean(),
+  rebaseWhen: z.string(),
+  vulnerabilityAlerts: z.object({
+    enabled: z.boolean(),
+  }),
+  osvVulnerabilityAlerts: z.boolean(),
+  env: z.record(z.string(), z.string()),
+  mode: z.string().optional(),
+  schedule: z.array(z.string()),
+  commitHourlyLimit: z.number().optional(),
+  prHourlyLimit: z.number(),
+  prConcurrentLimit: z.number(),
   customManagers: z.array(RegexManagerSchema),
   packageRules: z.array(
     z.object({
@@ -30,6 +45,32 @@ const RenovateConfigSchema = z.object({
 });
 
 const root = `${import.meta.dir}/..`;
+
+test("uses Renovate as a manually approved dependency dashboard", async () => {
+  const config = RenovateConfigSchema.parse(
+    await Bun.file(`${root}/renovate.json`).json(),
+  );
+
+  expect(config).toMatchObject({
+    dependencyDashboardApproval: true,
+    automerge: false,
+    platformAutomerge: false,
+    rebaseWhen: "never",
+    vulnerabilityAlerts: {
+      enabled: false,
+    },
+    osvVulnerabilityAlerts: false,
+    schedule: ["after 3am on Sunday"],
+    prHourlyLimit: 5,
+    prConcurrentLimit: 3,
+  });
+  expect(config.automergeStrategy).toBeUndefined();
+  expect(config.mode).toBeUndefined();
+  expect(config.commitHourlyLimit).toBeUndefined();
+  expect(config.env).toEqual({
+    BUN_CONFIG_MAX_HTTP_REQUESTS: "4",
+  });
+});
 
 test("extracts every managed structured version-catalog field", async () => {
   const config = RenovateConfigSchema.parse(
@@ -152,7 +193,7 @@ test("drives Playwright upgrades from the official image source only", async () 
   expect(rule).toEqual({
     description:
       "Playwright client packages are promoted atomically with the tested ci-playwright image digest; Renovate owns only the official Dockerfile source pin.",
-    matchManagers: ["npm"],
+    matchManagers: ["bun", "npm"],
     matchPackageNames: ["playwright", "@playwright/test"],
     enabled: false,
   });
@@ -202,7 +243,7 @@ test("keeps direct TypeScript on 6 without constraining the native alias", async
   expect(rule).toEqual({
     description:
       "Native TypeScript 7 owns typechecking; keep direct TypeScript on 6 for typescript-eslint project service, Astro Check, Twoslash, and TypeDoc.",
-    matchManagers: ["npm"],
+    matchManagers: ["bun", "npm"],
     matchDepNames: ["typescript"],
     allowedVersions: "<7",
   });


### PR DESCRIPTION
## Why

Mend-hosted Renovate is used primarily for its Dependency Dashboard, while automatic Bun lockfile generation can exhaust the 3 GB hosted runner.

## What

- require dashboard approval before every ordinary Renovate branch or PR
- disable Renovate vulnerability PRs, automerge, platform automerge, and automatic branch updates
- limit approved Bun updates to four concurrent HTTP requests
- apply the TypeScript and Playwright policies to Bun-managed workspace files
- document and test the dashboard-first operator workflow

## Verification

- `RENOVATE_ALLOWED_ENV='["BUN_CONFIG_MAX_HTTP_REQUESTS"]' bunx --package renovate@44.39.0 renovate-config-validator --no-global renovate.json`
- `bun --no-install --bun vitest --config vitest.config.ts run scripts/renovate-config.test.ts`
- `bunx prettier --check renovate.json scripts/renovate-config.test.ts packages/dotfiles/dot_agents/skills/version-management/SKILL.md`
- `packages/dotfiles/node_modules/.bin/eslint scripts/renovate-config.test.ts`
- `bunx lefthook run pre-commit`

## Rollout

Existing Renovate PRs and GitHub state are intentionally untouched. After this reaches `main`, manually trigger one Mend run without selecting a dashboard item and confirm the dashboard refreshes, the repository finishes without OOM, and no branch is generated. Live Mend acceptance has not yet been run.