### PR TITLE
feat(glitter): expand the people and relationship graph

### DIFF
--- a/packages/glitter-context/data/people.json
+++ b/packages/glitter-context/data/people.json
@@ -17,6 +17,13 @@
       "discordUserIds": []
     },
     {
+      "id": "alucard",
+      "displayName": "Alucard",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
       "id": "allison",
       "displayName": "Allison",
       "kind": "person",
@@ -25,9 +32,9 @@
     },
     {
       "id": "alyza",
-      "displayName": "Alyza",
+      "displayName": "Grillmaster Alyza",
       "kind": "person",
-      "aliases": [],
+      "aliases": ["Alyza"],
       "discordUserIds": []
     },
     {
@@ -45,11 +52,25 @@
       "discordUserIds": []
     },
     {
+      "id": "aznboi",
+      "displayName": "aznboi",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
       "id": "brian",
       "displayName": "Brian",
       "kind": "person",
       "aliases": ["blohsh", "billibillie"],
       "discordUserIds": ["202595851678384137"]
+    },
+    {
+      "id": "bryan",
+      "displayName": "Bryan",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
     },
     {
       "id": "caitlyn",
@@ -262,6 +283,13 @@
       "discordUserIds": []
     },
     {
+      "id": "group-wwu",
+      "displayName": "WWU",
+      "kind": "group",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
       "id": "hannah",
       "displayName": "Hannah",
       "kind": "person",
@@ -274,6 +302,13 @@
       "kind": "person",
       "aliases": ["yuzka"],
       "discordUserIds": ["528096854831792159"]
+    },
+    {
+      "id": "indonesian-wife",
+      "displayName": "Indonesian Wife",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
     },
     {
       "id": "irfan",
@@ -339,6 +374,13 @@
       "discordUserIds": []
     },
     {
+      "id": "kendrick",
+      "displayName": "Kendrick",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
       "id": "kevin",
       "displayName": "Kevin",
       "kind": "person",
@@ -395,6 +437,20 @@
       "discordUserIds": []
     },
     {
+      "id": "nicole",
+      "displayName": "Nicole",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
+      "id": "nikki",
+      "displayName": "Nikki",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
       "id": "olivia",
       "displayName": "Olivia",
       "kind": "person",
@@ -407,6 +463,13 @@
       "kind": "person",
       "aliases": [],
       "discordUserIds": ["121887985896521732"]
+    },
+    {
+      "id": "rowel",
+      "displayName": "Rowel",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
     },
     {
       "id": "ryan",
@@ -477,6 +540,20 @@
       "kind": "person",
       "aliases": [],
       "discordUserIds": ["208425244128444418"]
+    },
+    {
+      "id": "vietnamese-wife",
+      "displayName": "Vietnamese Wife",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
+    },
+    {
+      "id": "wanye",
+      "displayName": "Wanye",
+      "kind": "person",
+      "aliases": [],
+      "discordUserIds": []
     },
     {
       "id": "wyatt",

--- a/packages/glitter-context/data/relationships.json
+++ b/packages/glitter-context/data/relationships.json
@@ -332,7 +332,7 @@
       "kind": "social",
       "label": "WWU",
       "direction": "undirected",
-      "status": "current",
+      "status": "historical",
       "effectiveAt": null,
       "recordedAt": "2026-07-26T00:00:00-07:00",
       "supersedesEventId": null,
@@ -1518,6 +1518,272 @@
         {
           "kind": "legacy-graph",
           "reference": "packages/glitter/public/index.html legacy graph",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "bryan-caitlyn-dating",
+      "sourceId": "bryan",
+      "targetId": "caitlyn",
+      "kind": "romantic",
+      "label": "Dating",
+      "direction": "undirected",
+      "status": "historical",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed prior relationship",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "bryan-caitlyn-exes",
+      "sourceId": "bryan",
+      "targetId": "caitlyn",
+      "kind": "romantic",
+      "label": "Exes",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": "bryan-caitlyn-dating",
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed breakup",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "irfan-indonesian-wife-married",
+      "sourceId": "irfan",
+      "targetId": "indonesian-wife",
+      "kind": "romantic",
+      "label": "Married",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed marriage",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "brian-vietnamese-wife-married",
+      "sourceId": "brian",
+      "targetId": "vietnamese-wife",
+      "kind": "romantic",
+      "label": "Married",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed marriage",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "danny-hannah-dating",
+      "sourceId": "danny",
+      "targetId": "hannah",
+      "kind": "romantic",
+      "label": "Dating",
+      "direction": "undirected",
+      "status": "historical",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed prior relationship",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "danny-hannah-exes",
+      "sourceId": "danny",
+      "targetId": "hannah",
+      "kind": "romantic",
+      "label": "Exes",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": "danny-hannah-dating",
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed breakup",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "nikki-edward-dating",
+      "sourceId": "nikki",
+      "targetId": "edward",
+      "kind": "romantic",
+      "label": "Dating",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed relationship",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "hirza-nicole-dating",
+      "sourceId": "hirza",
+      "targetId": "nicole",
+      "kind": "romantic",
+      "label": "Dating",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed relationship",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "olivia-teddy-dating",
+      "sourceId": "olivia",
+      "targetId": "teddy",
+      "kind": "romantic",
+      "label": "Dating",
+      "direction": "undirected",
+      "status": "historical",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed prior relationship",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "olivia-teddy-exes",
+      "sourceId": "olivia",
+      "targetId": "teddy",
+      "kind": "romantic",
+      "label": "Exes",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": "olivia-teddy-dating",
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed breakup",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "olivia-joel-dating",
+      "sourceId": "olivia",
+      "targetId": "joel",
+      "kind": "romantic",
+      "label": "Dating",
+      "direction": "undirected",
+      "status": "historical",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed prior relationship",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "olivia-joel-exes",
+      "sourceId": "olivia",
+      "targetId": "joel",
+      "kind": "romantic",
+      "label": "Exes",
+      "direction": "undirected",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": "olivia-joel-dating",
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed breakup",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "danny-group-wwu",
+      "sourceId": "danny",
+      "targetId": "group-wwu",
+      "kind": "membership",
+      "label": "",
+      "direction": "source-to-target",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed WWU membership",
+          "messageIds": []
+        }
+      ]
+    },
+    {
+      "id": "hannah-group-wwu",
+      "sourceId": "hannah",
+      "targetId": "group-wwu",
+      "kind": "membership",
+      "label": "",
+      "direction": "source-to-target",
+      "status": "current",
+      "effectiveAt": null,
+      "recordedAt": "2026-08-24T00:00:00-07:00",
+      "supersedesEventId": null,
+      "provenance": [
+        {
+          "kind": "maintainer-assertion",
+          "reference": "Maintainer-confirmed WWU membership",
           "messageIds": []
         }
       ]

--- a/packages/glitter-context/test/context.test.ts
+++ b/packages/glitter-context/test/context.test.ts
@@ -107,6 +107,83 @@ describe("Glitter context", () => {
     expect(relationshipContextText()).toContain("Caitlyn ↔ Richard (Exes)");
   });
 
+  test("records the requested relationship updates", () => {
+    expect(getPerson("Alucard")?.id).toBe("alucard");
+    expect(getPerson("Rowel")?.id).toBe("rowel");
+    expect(getPerson("Kendrick")?.id).toBe("kendrick");
+    expect(getPerson("aznboi")?.id).toBe("aznboi");
+    expect(getPerson("Grillmaster Alyza")?.id).toBe("alyza");
+    expect(getPerson("Alyza")?.id).toBe("alyza");
+    expect(getPerson("Brian")?.id).toBe("brian");
+    expect(getPerson("Bryan")?.id).toBe("bryan");
+    expect(getPerson("Nicole")?.id).toBe("nicole");
+    expect(getPerson("Wanye")?.id).toBe("wanye");
+
+    expect(
+      getRelationshipHistory("bryan", "caitlyn").map((event) => event.label),
+    ).toEqual(["Dating", "Exes"]);
+    expect(
+      getRelationshipHistory("danny", "hannah").map((event) => event.label),
+    ).toEqual(["WWU", "Dating", "Exes"]);
+    expect(getPerson("WWU")?.kind).toBe("group");
+    expect(
+      currentRelationships.filter(
+        (event) => event.sourceId === "danny" && event.targetId === "hannah",
+      ),
+    ).toMatchObject([{ kind: "romantic", label: "Exes" }]);
+    expect(
+      currentRelationships.filter(
+        (event) =>
+          event.targetId === "group-wwu" &&
+          ["danny", "hannah"].includes(event.sourceId),
+      ),
+    ).toHaveLength(2);
+    expect(
+      currentRelationships.find(
+        (event) =>
+          event.sourceId === "irfan" && event.targetId === "indonesian-wife",
+      )?.label,
+    ).toBe("Married");
+    expect(
+      currentRelationships.find(
+        (event) =>
+          event.sourceId === "brian" && event.targetId === "vietnamese-wife",
+      )?.label,
+    ).toBe("Married");
+    expect(
+      currentRelationships.find(
+        (event) => event.sourceId === "nikki" && event.targetId === "edward",
+      )?.label,
+    ).toBe("Dating");
+    expect(
+      currentRelationships.find(
+        (event) => event.sourceId === "hirza" && event.targetId === "nicole",
+      )?.label,
+    ).toBe("Dating");
+    expect(
+      getRelationshipHistory("olivia", "teddy").map((event) => event.label),
+    ).toEqual(["Dating", "Exes"]);
+    expect(
+      getRelationshipHistory("olivia", "joel").map((event) => event.label),
+    ).toEqual(["Dating", "Exes"]);
+    expect(
+      currentRelationships.filter(
+        (event) =>
+          event.kind === "romantic" &&
+          event.label === "Dating" &&
+          (event.sourceId === "olivia" || event.targetId === "olivia"),
+      ),
+    ).toHaveLength(0);
+    expect(
+      currentRelationships.filter(
+        (event) =>
+          event.kind === "romantic" &&
+          event.label === "Exes" &&
+          (event.sourceId === "olivia" || event.targetId === "olivia"),
+      ),
+    ).toHaveLength(2);
+  });
+
   test("all relationship events reference known people", () => {
     const personIds = new Set(people.map((person) => person.id));
     for (const event of relationshipEvents) {

--- a/packages/glitter/README.md
+++ b/packages/glitter/README.md
@@ -10,10 +10,10 @@ relationships are styled distinctly.
 
 All graph data comes from the workspace package
 [`@shepherdjerred/glitter-context`](../glitter-context/): the build imports its
-`people` and `currentRelationships` exports, filters to people that appear in
-at least one current relationship, and inlines the result as a frozen
-`globalThis.GLITTER_CONTEXT` object in `dist/context-data.js`. There is no
-runtime data fetching — the site is fully static.
+`people` and `currentRelationships` exports and inlines them as a frozen
+`globalThis.GLITTER_CONTEXT` object in `dist/context-data.js`. People without a
+current relationship are included as isolated nodes. There is no runtime data
+fetching — the site is fully static.
 
 ## Structure
 

--- a/packages/glitter/public/index.html
+++ b/packages/glitter/public/index.html
@@ -18,6 +18,7 @@
         display: block;
       }
       .link {
+        fill: none;
         stroke: #999;
         stroke-opacity: 0.55;
       }
@@ -116,7 +117,9 @@
 
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="./context-data.js"></script>
-    <script>
+    <script type="module">
+      import { assignParallelOffsets } from "./link-layout.js";
+
       const context = globalThis.GLITTER_CONTEXT;
       if (context === undefined) {
         throw new Error("Glitter context data did not load");
@@ -132,7 +135,27 @@
         target: relationship.targetId,
         label: relationship.label,
         bidir: relationship.direction === "undirected",
+        parallelOffset: 0,
       }));
+      assignParallelOffsets(links);
+
+      function curveGeometry(link) {
+        const source = link.source;
+        const target = link.target;
+        const dx = target.x - source.x;
+        const dy = target.y - source.y;
+        const distance = Math.hypot(dx, dy) || 1;
+        const midpointX = (source.x + target.x) / 2;
+        const midpointY = (source.y + target.y) / 2;
+        const curve = link.parallelOffset * 28;
+        const controlX = midpointX - (dy / distance) * curve;
+        const controlY = midpointY + (dx / distance) * curve;
+        return {
+          path: `M ${source.x},${source.y} Q ${controlX},${controlY} ${target.x},${target.y}`,
+          labelX: (source.x + 2 * controlX + target.x) / 4,
+          labelY: (source.y + 2 * controlY + target.y) / 4,
+        };
+      }
 
       const svg = d3.select("#chart");
       const width = window.innerWidth;
@@ -181,9 +204,9 @@
 
       const link = container
         .append("g")
-        .selectAll("line")
+        .selectAll("path")
         .data(links)
-        .join("line")
+        .join("path")
         .attr("class", (d) => "link" + (d.bidir ? " bi" : ""))
         .attr("stroke-width", 1.4)
         .attr("marker-end", (d) => (d.bidir ? null : "url(#arrow)"));
@@ -234,14 +257,10 @@
         .text((d) => d.label);
 
       sim.on("tick", () => {
-        link
-          .attr("x1", (d) => d.source.x)
-          .attr("y1", (d) => d.source.y)
-          .attr("x2", (d) => d.target.x)
-          .attr("y2", (d) => d.target.y);
+        link.attr("d", (d) => curveGeometry(d).path);
         linkLabel
-          .attr("x", (d) => (d.source.x + d.target.x) / 2)
-          .attr("y", (d) => (d.source.y + d.target.y) / 2);
+          .attr("x", (d) => curveGeometry(d).labelX)
+          .attr("y", (d) => curveGeometry(d).labelY);
         node.attr("transform", (d) => `translate(${d.x},${d.y})`);
       });
 

--- a/packages/glitter/public/link-layout.js
+++ b/packages/glitter/public/link-layout.js
@@ -1,0 +1,40 @@
+/**
+ * @typedef {object} ParallelLink
+ * @property {string} source
+ * @property {string} target
+ * @property {number} parallelOffset
+ */
+
+/**
+ * Assign symmetric curve offsets without collapsing oppositely directed links.
+ *
+ * The curve renderer derives its perpendicular vector from source to target.
+ * Reversing a link reverses that vector, so its offset must also be reversed to
+ * keep parallel links on separate sides of the shared canonical pair.
+ *
+ * @param {ParallelLink[]} links
+ */
+export function assignParallelOffsets(links) {
+  /** @type {Map<string, ParallelLink[]>} */
+  const linksByPair = new Map();
+
+  for (const link of links) {
+    const pair = [link.source, link.target].sort();
+    const pairKey = pair.join("\u0000");
+    const parallelLinks = linksByPair.get(pairKey);
+    if (parallelLinks === undefined) {
+      linksByPair.set(pairKey, [link]);
+    } else {
+      parallelLinks.push(link);
+    }
+  }
+
+  for (const parallelLinks of linksByPair.values()) {
+    const middle = (parallelLinks.length - 1) / 2;
+    parallelLinks.forEach((link, index) => {
+      const canonicalSource = [link.source, link.target].sort()[0];
+      const orientation = link.source === canonicalSource ? 1 : -1;
+      link.parallelOffset = (index - middle) * orientation;
+    });
+  }
+}

--- a/packages/glitter/scripts/build.ts
+++ b/packages/glitter/scripts/build.ts
@@ -6,16 +6,9 @@ const packageRoot = new URL("..", import.meta.url);
 const publicRoot = new URL("public/", packageRoot);
 const distRoot = new URL("dist/", packageRoot);
 
-const graphPeople = people.filter((person) =>
-  currentRelationships.some(
-    (relationship) =>
-      relationship.sourceId === person.id ||
-      relationship.targetId === person.id,
-  ),
-);
 const contextScript = `globalThis.GLITTER_CONTEXT = Object.freeze(${JSON.stringify(
   {
-    people: graphPeople,
+    people,
     relationships: currentRelationships,
   },
 )});
@@ -28,5 +21,9 @@ await Bun.write(
 await Bun.write(
   new URL("posthog.js", distRoot),
   await Bun.file(new URL("posthog.js", publicRoot)).text(),
+);
+await Bun.write(
+  new URL("link-layout.js", distRoot),
+  await Bun.file(new URL("link-layout.js", publicRoot)).text(),
 );
 await Bun.write(new URL("context-data.js", distRoot), contextScript);

--- a/packages/glitter/test/build.test.ts
+++ b/packages/glitter/test/build.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "vitest";
 import {
   currentRelationships,
   getRelationshipHistory,
+  people,
 } from "@shepherdjerred/glitter-context";
+import { assignParallelOffsets } from "../public/link-layout.js";
 
 describe("Glitter relationship graph data", () => {
   test("renders only the current Caitlyn and Richard relationship", () => {
@@ -18,5 +20,22 @@ describe("Glitter relationship graph data", () => {
         (event) => event.sourceId === "caitlyn" && event.targetId === "richard",
       )?.label,
     ).toBe("Exes");
+  });
+
+  test("keeps isolated people in the static graph context", () => {
+    expect(people.map((person) => person.id)).toEqual(
+      expect.arrayContaining(["nicole", "sean", "wanye"]),
+    );
+  });
+
+  test("separates parallel links with opposite directions", () => {
+    const links = [
+      { source: "danny", target: "hannah", parallelOffset: 0 },
+      { source: "hannah", target: "danny", parallelOffset: 0 },
+    ];
+
+    assignParallelOffsets(links);
+
+    expect(links.map((link) => link.parallelOffset)).toEqual([-0.5, -0.5]);
   });
 });


### PR DESCRIPTION
## Why

The public Glitter graph was missing people and current relationship facts. WWU was also represented as a direct Danny-Hannah relationship instead of a group they both belong to.

## What

- Add Nicole, Bryan, Nikki, Indonesian Wife, Vietnamese Wife, Wanye, Alucard, Rowel, Kendrick, and aznboi.
- Rename Alyza to Grillmaster Alyza while retaining Alyza as an alias.
- Record the requested dating, marriage, and ex relationships while preserving historical dating events.
- Model WWU as a group with Danny and Hannah memberships.
- Include isolated people in the generated graph and render parallel relationship links as separate curves.
- Add regression coverage for the new entities, relationship history, WWU modeling, isolated nodes, and curved links.

## Verification

- `bun run --cwd packages/glitter-context typecheck` — passed
- `bun run --cwd packages/glitter-context lint` — passed
- `bun run --cwd packages/glitter-context test` — passed (18 tests; Python validator reports 82 people, 94 events, and 13 style cards)
- `bun run --cwd packages/glitter build` — passed
- `bun run --cwd packages/glitter test` — passed (2 tests)
- `bunx prettier --check packages/glitter-context/data/people.json packages/glitter-context/data/relationships.json packages/glitter-context/test/context.test.ts packages/glitter/README.md packages/glitter/public/index.html packages/glitter/scripts/build.ts packages/glitter/test/build.test.ts` — passed
- `bunx lefthook run pre-commit` — passed
- Public cache-busted fetches returned 200 and contained the curved-link renderer, requested people, and WWU group.

## Rollout

Published the generated site to the `glitter-boys-ppl` bucket and verified [ppl.glitter-boys.com](https://ppl.glitter-boys.com). A rendered screenshot will be attached in a PR comment.