### PR TITLE
feat(scout-for-lol): add midweek weekly-parlay catch-ups

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/temporal/workflow-families.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/workflow-families.md
@@ -139,6 +139,14 @@ a slice expires). The schedule has no workflow execution timeout, so a prolonged
 outage cannot abandon bets. Distinct weekly executions may overlap so a delayed
 prior finalization cannot suppress the next period.
 
+A separate operator-started catch-up workflow repairs a missed Sunday opening
+without changing the recurring schedule. It freezes the workflow start as the
+open time, then chooses the first Pacific midnight beyond the minimum betting
+budget. Scout persists those clocks and uses their shortened weekday shape for
+historical replay. Later activities carry only the period and slot, so Scout
+reconciles against the immutable market rather than trusting caller-supplied
+time overrides.
+
 ## Glitter
 
 The most guardrailed workflows in the fleet, on dedicated queues so Discord rate

--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -43,12 +43,19 @@ changing model identity.
 | queue-windows              | daily 06:45                          | deterministic          | heartbeat + gated PR             |
 | image-gc                   | daily 04:00                          | deterministic          | S3 deletions                     |
 | weekly parlay lifecycle    | Sun, source-defined Pacific timeline | deterministic          | beta Scout market reconciliation |
+| weekly parlay catch-up     | operator, stable period/slot ID      | deterministic          | shortened beta Scout market      |
 
 The weekly parlay workflow uses the Pacific timeline defined by its source
 constants and reconciles each period through finalization. Its schedule remains
 initially paused until the private-beta Discord fixture cycle is approved; see
 the [workflow-family explanation](/explanation/temporal/workflow-families/#weekly-parlay-lifecycle)
 for the durability rationale.
+
+The operator-started workflow type is
+`runScoutWeeklyParlayCatchupWorkflow`. Its input is `{ periodKey, slot }`, and
+its workflow ID is `scout-weekly-parlay-catchup-<periodKey>-<slot>`. Temporal
+rejects a duplicate live ID. The workflow does not create or modify the
+recurring schedule.
 
 ## Glitter
 

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -953,6 +953,16 @@ It calls the beta-only authenticated control endpoint with stable period/action
 keys. Keep the endpoint absent when its token is not configured; do not add an
 in-process timer. Pause the Temporal schedule for operational suspension.
 
+Missed Sunday openings use the separate, manually started
+`runScoutWeeklyParlayCatchupWorkflow`. Only its `open` action may carry a
+closed `catch_up` window. Scout validates the minimum betting duration and
+Sunday cutoff, freezes the clocks on the definition, and rejects a retry whose
+period/slot already has different clocks. Every later action derives reminder,
+progress, and settlement timing from that stored definition. Historical replay
+uses the same Pacific weekday/hour shape as the shortened live window,
+including zero-game windows. Catch-up execution never edits or replaces the
+recurring schedule.
+
 League Classic (`queueType: "classic"`, Riot queue 4310) is not a betting or
 parlay queue because this integration has no supported post-game payload. A
 tracked, linked player in a complete Classic 5v5 receives exactly one

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -125,7 +125,7 @@ function catchupTimeline(
     shape,
   );
   const minimumClose =
-    timeline.openAt.getTime() +
+    now.getTime() +
     WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS +
     WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS;
   if (
@@ -214,6 +214,13 @@ async function reconcileStart(
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
   const period = persistedTimeline(action, market);
+  if (context.now < period.scoringStartsAt) {
+    return {
+      status: "skipped",
+      detail: "before_scoring_start",
+      marketId: market.id,
+    };
+  }
   if (market.marketState === "publishing") {
     await settleWeeklyParlayMarket(
       {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { DiscordGuildIdSchema } from "@scout-for-lol/data";
 import {
   WEEKLY_PARLAY_LIFECYCLE,
+  WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS,
   WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS,
 } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import {
@@ -11,7 +12,12 @@ import {
 import { openWeeklyParlay } from "#src/betting/weekly-parlay-open.ts";
 import {
   WEEKLY_PARLAY_SLOT,
+  weeklyParlayScoringShape,
+  weeklyParlayScoringWindowForPeriod,
+  weeklyParlayTimelineFromWindow,
   weeklyParlayPeriod,
+  type WeeklyParlayFrozenWindow,
+  type WeeklyParlayRuntimeTimeline,
 } from "#src/betting/weekly-parlay-period.ts";
 import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -20,6 +26,14 @@ import { logBucksTransition } from "#src/betting/transition-log.ts";
 
 export const WEEKLY_PARLAY_CONTROL_PATH =
   "/api/internal/weekly-parlays/actions";
+
+export const WeeklyParlayCatchupWindowSchema = z.strictObject({
+  kind: z.literal("catch_up"),
+  openAt: z.iso.datetime(),
+  bettingClosesAt: z.iso.datetime(),
+  scoringStartsAt: z.iso.datetime(),
+  scoringEndsAt: z.iso.datetime(),
+});
 
 export const WeeklyParlayControlActionSchema = z
   .strictObject({
@@ -32,6 +46,7 @@ export const WeeklyParlayControlActionSchema = z
       .min(0)
       .max(WEEKLY_PARLAY_LIFECYCLE.updateCount - 1)
       .optional(),
+    window: WeeklyParlayCatchupWindowSchema.optional(),
   })
   .superRefine((action, context) => {
     if (action.action === "progress" && action.updateIndex === undefined) {
@@ -46,6 +61,13 @@ export const WeeklyParlayControlActionSchema = z
         code: "custom",
         path: ["updateIndex"],
         message: "Only progress actions accept an update index.",
+      });
+    }
+    if (action.action !== "open" && action.window !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["window"],
+        message: "Only open actions accept a catch-up window.",
       });
     }
   });
@@ -70,11 +92,77 @@ type ControlContext = {
   signal?: AbortSignal;
 };
 
+type PersistedMarket = {
+  id: number;
+  marketState: string;
+  definition: {
+    openAt: Date;
+    bettingClosesAt: Date;
+    scoringStartsAt: Date;
+    scoringEndsAt: Date;
+  };
+};
+
+function catchupTimeline(
+  action: WeeklyParlayControlAction,
+  now: Date,
+): WeeklyParlayFrozenWindow {
+  const custom = action.window;
+  if (custom === undefined) {
+    return weeklyParlayPeriod(action.periodKey);
+  }
+  const standard = weeklyParlayPeriod(action.periodKey);
+  const timeline = {
+    periodKey: action.periodKey,
+    openAt: new Date(custom.openAt),
+    bettingClosesAt: new Date(custom.bettingClosesAt),
+    scoringStartsAt: new Date(custom.scoringStartsAt),
+    scoringEndsAt: new Date(custom.scoringEndsAt),
+  };
+  const shape = weeklyParlayScoringShape(timeline);
+  const canonicalScoringWindow = weeklyParlayScoringWindowForPeriod(
+    action.periodKey,
+    shape,
+  );
+  const minimumClose =
+    timeline.openAt.getTime() +
+    WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS +
+    WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS;
+  if (
+    timeline.openAt > now ||
+    timeline.openAt < standard.openAt ||
+    timeline.bettingClosesAt.getTime() !== timeline.scoringStartsAt.getTime() ||
+    timeline.bettingClosesAt.getTime() < minimumClose ||
+    timeline.scoringStartsAt >= timeline.scoringEndsAt ||
+    timeline.scoringStartsAt.getTime() !==
+      canonicalScoringWindow.scoringStartsAt.getTime() ||
+    timeline.scoringEndsAt.getTime() !== standard.scoringEndsAt.getTime() ||
+    shape.startHour !== WEEKLY_PARLAY_LIFECYCLE.bettingCloseHour ||
+    shape.startDayOffset < 0 ||
+    shape.startDayOffset > 6 ||
+    shape.endDayOffset !== 6 ||
+    shape.endHour !== WEEKLY_PARLAY_LIFECYCLE.finalHour
+  ) {
+    throw new Error("Invalid weekly parlay catch-up timeline.");
+  }
+  return timeline;
+}
+
+function persistedTimeline(
+  action: WeeklyParlayControlAction,
+  market: PersistedMarket,
+): WeeklyParlayRuntimeTimeline {
+  return weeklyParlayTimelineFromWindow({
+    periodKey: action.periodKey,
+    ...market.definition,
+  });
+}
+
 async function reconcileOpen(
   action: WeeklyParlayControlAction,
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
-  const period = weeklyParlayPeriod(action.periodKey);
+  const period = catchupTimeline(action, context.now);
   if (
     context.now.getTime() + WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS >=
     period.bettingClosesAt.getTime()
@@ -86,6 +174,7 @@ async function reconcileOpen(
       serverId: context.serverId,
       periodKey: action.periodKey,
       slot: action.slot,
+      timeline: period,
       ...(context.signal === undefined ? {} : { signal: context.signal }),
     },
     context.prismaClient,
@@ -93,7 +182,7 @@ async function reconcileOpen(
   if (opened.kind !== "created" && opened.kind !== "existing") {
     return { status: "skipped", detail: opened.kind };
   }
-  if (new Date() >= period.bettingClosesAt) {
+  if (context.now >= period.bettingClosesAt) {
     return {
       status: "skipped",
       detail: "betting window already closed",
@@ -121,10 +210,10 @@ async function reconcileOpen(
 
 async function reconcileStart(
   action: WeeklyParlayControlAction,
-  market: { id: number; marketState: string },
+  market: PersistedMarket,
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
-  const period = weeklyParlayPeriod(action.periodKey);
+  const period = persistedTimeline(action, market);
   if (market.marketState === "publishing") {
     await settleWeeklyParlayMarket(
       {
@@ -173,10 +262,11 @@ async function reconcileStart(
 
 async function reconcileFinalize(
   action: WeeklyParlayControlAction,
-  marketId: number,
+  market: PersistedMarket,
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
-  const period = weeklyParlayPeriod(action.periodKey);
+  const period = persistedTimeline(action, market);
+  const marketId = market.id;
   await settleWeeklyParlayMarket(
     { marketId, mode: "final", now: context.now },
     context.prismaClient,
@@ -215,10 +305,10 @@ async function reconcileFinalize(
 
 async function reconcileReminder(
   action: WeeklyParlayControlAction,
-  market: { id: number; marketState: string },
+  market: PersistedMarket,
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
-  const period = weeklyParlayPeriod(action.periodKey);
+  const period = persistedTimeline(action, market);
   if (context.now >= period.bettingClosesAt) {
     return { status: "skipped", detail: "stale_reminder", marketId: market.id };
   }
@@ -228,6 +318,9 @@ async function reconcileReminder(
       detail: "market_not_open",
       marketId: market.id,
     };
+  }
+  if (period.reminderAt === undefined) {
+    return { status: "skipped", detail: "no_reminder", marketId: market.id };
   }
   await deliverWeeklyParlayDiscord(
     {
@@ -243,10 +336,11 @@ async function reconcileReminder(
 
 async function reconcileProgress(
   action: WeeklyParlayControlAction,
-  marketId: number,
+  market: PersistedMarket,
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
-  const period = weeklyParlayPeriod(action.periodKey);
+  const period = persistedTimeline(action, market);
+  const marketId = market.id;
   const updateIndex = action.updateIndex;
   if (updateIndex === undefined) {
     throw new Error("A weekly progress action requires updateIndex.");
@@ -305,7 +399,18 @@ async function runWeeklyParlayControlActionInternal(
         slot: action.slot,
       },
     },
-    select: { id: true, marketState: true },
+    select: {
+      id: true,
+      marketState: true,
+      definition: {
+        select: {
+          openAt: true,
+          bettingClosesAt: true,
+          scoringStartsAt: true,
+          scoringEndsAt: true,
+        },
+      },
+    },
   });
   if (market === null) {
     return { status: "skipped", detail: "no_market" };
@@ -314,12 +419,12 @@ async function runWeeklyParlayControlActionInternal(
     return await reconcileStart(action, market, context);
   }
   if (action.action === "finalize") {
-    return await reconcileFinalize(action, market.id, context);
+    return await reconcileFinalize(action, market, context);
   }
   if (action.action === "reminder") {
     return await reconcileReminder(action, market, context);
   }
-  return await reconcileProgress(action, market.id, context);
+  return await reconcileProgress(action, market, context);
 }
 
 export async function runWeeklyParlayControlAction(

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -124,10 +124,7 @@ function catchupTimeline(
     action.periodKey,
     shape,
   );
-  const minimumClose =
-    now.getTime() +
-    WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS +
-    WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS;
+  const minimumClose = now.getTime() + WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS;
   if (
     timeline.openAt > now ||
     timeline.openAt < standard.openAt ||
@@ -163,18 +160,20 @@ async function reconcileOpen(
   context: ControlContext,
 ): Promise<WeeklyParlayControlResult> {
   const period = catchupTimeline(action, context.now);
-  if (
-    context.now.getTime() + WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS >=
-    period.bettingClosesAt.getTime()
-  ) {
-    return { status: "skipped", detail: "betting window already closed" };
-  }
+  const generationDeadline = new Date(
+    context.now.getTime() +
+      (action.window === undefined
+        ? WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS
+        : WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS +
+          WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS),
+  );
   const opened = await openWeeklyParlay(
     {
       serverId: context.serverId,
       periodKey: action.periodKey,
       slot: action.slot,
       timeline: period,
+      generationDeadline,
       ...(context.signal === undefined ? {} : { signal: context.signal }),
     },
     context.prismaClient,
@@ -358,6 +357,13 @@ async function reconcileProgress(
   const scheduledAt = period.updateAt[updateIndex];
   if (scheduledAt === undefined) {
     throw new Error("Weekly progress index has no scheduled wall time.");
+  }
+  if (context.now < scheduledAt) {
+    return {
+      status: "skipped",
+      detail: "before_progress_time",
+      marketId,
+    };
   }
   const nextScheduledAt =
     period.updateAt[updateIndex + 1] ?? period.scoringEndsAt;

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -27,6 +27,7 @@ import {
 } from "#src/metrics/betting-weekly-parlay.ts";
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
+import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 
 export type WeeklyParlayDiscordKind =
   "open" | "reminder" | "progress" | "settlement";
@@ -146,21 +147,23 @@ export function deliveryTitle(
   kind: WeeklyParlayDiscordKind,
   marketState: string,
   yesResult: boolean | null,
+  catchup = false,
 ): string {
+  const prefix = catchup ? "Catch-up weekly" : "Weekly";
   switch (kind) {
     case "open":
-      return "📅 **Weekly Bryan Bucks parlay is open**";
+      return `📅 **${prefix} Bryan Bucks parlay is open**`;
     case "reminder":
-      return "⏰ **Weekly parlay betting reminder**";
+      return `⏰ **${prefix} parlay betting reminder**`;
     case "progress":
-      return "📈 **Weekly parlay progress**";
+      return `📈 **${prefix} parlay progress**`;
     case "settlement":
       if (marketState === "voided") {
-        return "↩️ **Weekly parlay refunded**";
+        return `↩️ **${prefix} parlay refunded**`;
       }
       return yesResult === true
-        ? "✅ **Weekly parlay settled YES**"
-        : "❌ **Weekly parlay settled NO**";
+        ? `✅ **${prefix} parlay settled YES**`
+        : `❌ **${prefix} parlay settled NO**`;
   }
 }
 
@@ -171,15 +174,23 @@ function currentLegValue(
   return kind === "open" || kind === "reminder" ? undefined : current;
 }
 
-export function deliveryTimeCopy(
-  kind: WeeklyParlayDiscordKind,
-  bettingClosesAt: Date,
-  scoringEndsAt: Date,
-): string {
-  if (kind === "open" || kind === "reminder") {
-    return `Betting closes <t:${Math.floor(bettingClosesAt.getTime() / 1000).toString()}:R>. Use this message's buttons so your market is unambiguous.`;
+export function deliveryTimeCopy(input: {
+  kind: WeeklyParlayDiscordKind;
+  bettingClosesAt: Date;
+  scoringEndsAt: Date;
+  scoringStartsAt?: Date;
+  catchup?: boolean;
+}): string {
+  if (input.catchup === true) {
+    if (input.scoringStartsAt === undefined) {
+      throw new Error("Catch-up weekly parlay copy requires scoringStartsAt.");
+    }
+    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:F>. Scoring runs <t:${Math.floor(input.scoringStartsAt.getTime() / 1000).toString()}:F> through <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
   }
-  return `Final cutoff <t:${Math.floor(scoringEndsAt.getTime() / 1000).toString()}:F>.`;
+  if (input.kind === "open" || input.kind === "reminder") {
+    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:R>. Use this message's buttons so your market is unambiguous.`;
+  }
+  return `Final cutoff <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
 }
 
 export function weeklyParlayButtons(
@@ -255,6 +266,10 @@ export async function deliverWeeklyParlayDiscord(
           subjects: true,
           criteria: true,
           yesProbabilityBps: true,
+          openAt: true,
+          bettingClosesAt: true,
+          scoringStartsAt: true,
+          scoringEndsAt: true,
           contributions: { select: { snapshot: true } },
         },
       },
@@ -330,15 +345,28 @@ export async function deliverWeeklyParlayDiscord(
     ...new Set([...subjects.map((subject) => subject.discordId), ...bettorIds]),
   ];
   const totalStaked = market.bets.reduce((total, bet) => total + bet.stake, 0);
+  const catchup = isWeeklyParlayCatchupTimeline({
+    periodKey: market.periodKey,
+    openAt: market.definition.openAt,
+    bettingClosesAt: market.definition.bettingClosesAt,
+    scoringStartsAt: market.definition.scoringStartsAt,
+    scoringEndsAt: market.definition.scoringEndsAt,
+  });
   const content = [
-    deliveryTitle(input.kind, market.marketState, market.yesResult),
+    deliveryTitle(input.kind, market.marketState, market.yesResult, catchup),
     ...(isVoidedSettlement
       ? [`Reason: **${market.voidReason ?? "unknown"}**`]
       : []),
     `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
     ...legs,
     `**${market.bets.length.toString()} ${countLabel(market.bets.length, "bettor")} · ${totalStaked.toString()} BB staked**`,
-    deliveryTimeCopy(input.kind, market.bettingClosesAt, market.scoringEndsAt),
+    deliveryTimeCopy({
+      kind: input.kind,
+      bettingClosesAt: market.bettingClosesAt,
+      scoringEndsAt: market.scoringEndsAt,
+      scoringStartsAt: market.definition.scoringStartsAt,
+      catchup,
+    }),
   ]
     .filter((line) => line.length > 0)
     .join("\n");

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { WeeklyParlayContributionSnapshotSchema } from "#src/betting/weekly-parlay-criteria.ts";
+import { buildObservedWeeklyReplayWindows } from "#src/betting/weekly-parlay-history.ts";
+
+describe("weekly parlay historical window alignment", () => {
+  test("preserves zero-game windows for the shortened Pacific scoring shape", () => {
+    const contribution = WeeklyParlayContributionSnapshotSchema.parse({
+      subject: "P1",
+      puuid: "p".repeat(78),
+      queue: "solo",
+      completedAt: "2026-08-19T18:00:00.000Z",
+      win: true,
+      champion: "Ziggs",
+      role: "MIDDLE",
+      kills: 4,
+      deaths: 2,
+      assists: 9,
+      championDamage: 22_000,
+      creepScore: 180,
+      gold: 12_000,
+      visionScore: 18,
+      timePlayed: 1800,
+    });
+    const windows = buildObservedWeeklyReplayWindows({
+      periodKey: "2026-08-24",
+      scoringWindow: {
+        scoringStartsAt: new Date("2026-08-26T07:00:00.000Z"),
+        scoringEndsAt: new Date("2026-08-30T18:00:00.000Z"),
+      },
+      trackingStartedAt: new Date("2025-08-01T00:00:00.000Z"),
+      contributions: [contribution],
+    });
+    expect(windows).toHaveLength(52);
+    expect(windows.at(-1)).toEqual({
+      periodKey: "2026-08-17",
+      contributions: [contribution],
+    });
+    expect(
+      windows.filter((window) => window.contributions.length === 0),
+    ).toHaveLength(51);
+  });
+
+  test("counts only windows whose shortened start is fully tracked", () => {
+    const windows = buildObservedWeeklyReplayWindows({
+      periodKey: "2026-08-24",
+      scoringWindow: {
+        scoringStartsAt: new Date("2026-08-26T07:00:00.000Z"),
+        scoringEndsAt: new Date("2026-08-30T18:00:00.000Z"),
+      },
+      trackingStartedAt: new Date("2026-07-29T07:00:00.000Z"),
+      contributions: [],
+    });
+    expect(windows.map((window) => window.periodKey)).toEqual([
+      "2026-07-27",
+      "2026-08-03",
+      "2026-08-10",
+      "2026-08-17",
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
@@ -9,7 +9,11 @@ import {
   type WeeklyParlayContributionSnapshot,
   type WeeklyParlaySubject,
 } from "#src/betting/weekly-parlay-criteria.ts";
-import { weeklyParlayPeriod } from "#src/betting/weekly-parlay-period.ts";
+import {
+  weeklyParlayScoringShape,
+  weeklyParlayScoringWindowForPeriod,
+  type WeeklyParlayFrozenWindow,
+} from "#src/betting/weekly-parlay-period.ts";
 import { resolveLakeDir } from "#src/report-lake/paths.ts";
 import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
 import {
@@ -83,8 +87,45 @@ function snapshotFor(
   });
 }
 
+export function buildObservedWeeklyReplayWindows(input: {
+  periodKey: string;
+  scoringWindow: Pick<
+    WeeklyParlayFrozenWindow,
+    "scoringStartsAt" | "scoringEndsAt"
+  >;
+  trackingStartedAt: Date;
+  contributions: readonly WeeklyParlayContributionSnapshot[];
+}): WeeklyParlayReplayWindow[] {
+  const shape = weeklyParlayScoringShape({
+    periodKey: input.periodKey,
+    ...input.scoringWindow,
+  });
+  return periodKeysBefore(input.periodKey).flatMap((periodKey) => {
+    const period = weeklyParlayScoringWindowForPeriod(periodKey, shape);
+    if (period.scoringStartsAt < input.trackingStartedAt) {
+      return [];
+    }
+    return [
+      {
+        periodKey,
+        contributions: input.contributions.filter((snapshot) => {
+          const completedAt = new Date(snapshot.completedAt);
+          return (
+            completedAt >= period.scoringStartsAt &&
+            completedAt < period.scoringEndsAt
+          );
+        }),
+      },
+    ];
+  });
+}
+
 export async function fetchWeeklyCandidateHistories(input: {
   periodKey: string;
+  scoringWindow: Pick<
+    WeeklyParlayFrozenWindow,
+    "scoringStartsAt" | "scoringEndsAt"
+  >;
   subjects: readonly WeeklyParlaySubject[];
   lakeDir?: string;
   abortSignal?: AbortSignal;
@@ -93,8 +134,15 @@ export async function fetchWeeklyCandidateHistories(input: {
     return [];
   }
   const keys = periodKeysBefore(input.periodKey);
-  const firstPeriod = weeklyParlayPeriod(keys[0] ?? "");
-  const lastPeriod = weeklyParlayPeriod(keys.at(-1) ?? "");
+  const shape = weeklyParlayScoringShape({
+    periodKey: input.periodKey,
+    ...input.scoringWindow,
+  });
+  const firstPeriod = weeklyParlayScoringWindowForPeriod(keys[0] ?? "", shape);
+  const lastPeriod = weeklyParlayScoringWindowForPeriod(
+    keys.at(-1) ?? "",
+    shape,
+  );
   const puuids = input.subjects.flatMap((subject) =>
     subject.accounts.map((account) => account.puuid),
   );
@@ -168,27 +216,19 @@ export async function fetchWeeklyCandidateHistories(input: {
       );
       const historyRows = historyRowsByPlayer.get(subject.playerId) ?? [];
       const snapshots = historyRows.map((row) => row.snapshot);
-      const windows = keys
-        .map((key) => {
-          const period = weeklyParlayPeriod(key);
-          return {
-            periodKey: key,
-            observed: period.scoringStartsAt.getTime() >= trackingStartedAt,
-            contributions: snapshots.filter((snapshot) => {
-              const completedAt = new Date(snapshot.completedAt);
-              return (
-                completedAt >= period.scoringStartsAt &&
-                completedAt < period.scoringEndsAt
-              );
-            }),
-          };
-        })
-        .filter((window) => window.observed)
-        .map((window) => ({
-          periodKey: window.periodKey,
-          contributions: window.contributions,
-        }));
-      const recentPeriod = weeklyParlayPeriod(keys.at(-1) ?? "");
+      const windows = buildObservedWeeklyReplayWindows({
+        periodKey: input.periodKey,
+        scoringWindow: input.scoringWindow,
+        trackingStartedAt: new Date(trackingStartedAt),
+        contributions: snapshots,
+      });
+      const alignedSnapshots = windows.flatMap(
+        (window) => window.contributions,
+      );
+      const recentPeriod = weeklyParlayScoringWindowForPeriod(
+        keys.at(-1) ?? "",
+        shape,
+      );
       const recentMatchIds = new Set(
         historyRows
           .filter((row) => {
@@ -206,9 +246,11 @@ export async function fetchWeeklyCandidateHistories(input: {
         fullyObservedWindows: windows.length,
         recentEligibleGames: recentMatchIds.size,
         observedChampions: new Set(
-          snapshots.map((snapshot) => snapshot.champion),
+          alignedSnapshots.map((snapshot) => snapshot.champion),
         ),
-        observedRoles: new Set(snapshots.map((snapshot) => snapshot.role)),
+        observedRoles: new Set(
+          alignedSnapshots.map((snapshot) => snapshot.role),
+        ),
       };
     })
     .filter(

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -58,11 +58,16 @@ function periodsSinceFeatured(
 function openActionIsActive(
   period: Pick<WeeklyParlayFrozenWindow, "bettingClosesAt">,
   signal: AbortSignal | undefined,
+  generationDeadline: Date | undefined,
 ): boolean {
   if (signal?.aborted === true) {
     throw signal.reason ?? new Error("Weekly parlay open was aborted.");
   }
-  return new Date() < period.bettingClosesAt;
+  return (
+    new Date() < period.bettingClosesAt &&
+    (generationDeadline === undefined ||
+      generationDeadline.getTime() < period.bettingClosesAt.getTime())
+  );
 }
 
 type OpenWeeklyParlayInput = {
@@ -188,12 +193,6 @@ async function openWeeklyParlayInternal(
     assertMatchingTimeline(existing, period);
     return { kind: "existing", marketId: existing.id };
   }
-  if (
-    input.generationDeadline !== undefined &&
-    input.generationDeadline.getTime() >= period.bettingClosesAt.getTime()
-  ) {
-    return { kind: "too_late" };
-  }
   const [bettingEnabled, weeklyEnabled] = await Promise.all([
     isPolicyEnabled("betting_enabled", { server: serverId }),
     isPolicyEnabled("weekly_parlays_enabled", { server: serverId }),
@@ -287,7 +286,7 @@ async function openWeeklyParlayInternal(
     if (priced === undefined) {
       continue;
     }
-    if (!openActionIsActive(period, input.signal)) {
+    if (!openActionIsActive(period, input.signal, input.generationDeadline)) {
       return { kind: "too_late" };
     }
     try {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -20,8 +20,11 @@ import {
   WEEKLY_PARLAY_PROMPT_VERSION,
 } from "#src/betting/weekly-parlay-model.ts";
 import {
+  isWeeklyParlayCatchupTimeline,
   WEEKLY_PARLAY_SLOT,
+  weeklyParlayScoringShape,
   weeklyParlayPeriod,
+  type WeeklyParlayFrozenWindow,
 } from "#src/betting/weekly-parlay-period.ts";
 import { priceWeeklyParlay } from "#src/betting/weekly-parlay-pricing.ts";
 import { orderWeeklyParlayCandidates } from "#src/betting/weekly-parlay-selection.ts";
@@ -53,13 +56,64 @@ function periodsSinceFeatured(
 }
 
 function openActionIsActive(
-  period: ReturnType<typeof weeklyParlayPeriod>,
+  period: Pick<WeeklyParlayFrozenWindow, "bettingClosesAt">,
   signal: AbortSignal | undefined,
 ): boolean {
   if (signal?.aborted === true) {
     throw signal.reason ?? new Error("Weekly parlay open was aborted.");
   }
   return new Date() < period.bettingClosesAt;
+}
+
+type OpenWeeklyParlayInput = {
+  serverId: string;
+  periodKey: string;
+  slot?: number;
+  timeline?: WeeklyParlayFrozenWindow;
+  signal?: AbortSignal;
+};
+
+function resolveOpenTimeline(
+  input: Pick<OpenWeeklyParlayInput, "periodKey" | "timeline">,
+): WeeklyParlayFrozenWindow {
+  if (input.timeline === undefined) {
+    return weeklyParlayPeriod(input.periodKey);
+  }
+  if (input.timeline.periodKey !== input.periodKey) {
+    throw new Error("Weekly parlay timeline period key does not match input.");
+  }
+  weeklyParlayScoringShape(input.timeline);
+  return input.timeline;
+}
+
+function assertMatchingTimeline(
+  existing: {
+    definition: {
+      openAt: Date;
+      bettingClosesAt: Date;
+      scoringStartsAt: Date;
+      scoringEndsAt: Date;
+    };
+  },
+  requested: WeeklyParlayFrozenWindow,
+): void {
+  const stored = existing.definition;
+  if (
+    stored.openAt.getTime() !== requested.openAt.getTime() ||
+    stored.bettingClosesAt.getTime() !== requested.bettingClosesAt.getTime() ||
+    stored.scoringStartsAt.getTime() !== requested.scoringStartsAt.getTime() ||
+    stored.scoringEndsAt.getTime() !== requested.scoringEndsAt.getTime()
+  ) {
+    throw new Error(
+      "Weekly parlay period and slot already exist with a conflicting timeline.",
+    );
+  }
+}
+
+function timelineKind(
+  period: WeeklyParlayFrozenWindow,
+): "standard" | "catch_up" {
+  return isWeeklyParlayCatchupTimeline(period) ? "catch_up" : "standard";
 }
 
 async function linkedMemberSubjects(
@@ -107,23 +161,30 @@ async function linkedMemberSubjects(
 }
 
 async function openWeeklyParlayInternal(
-  input: {
-    serverId: string;
-    periodKey: string;
-    slot?: number;
-    signal?: AbortSignal;
-  },
+  input: OpenWeeklyParlayInput,
   prismaClient: ExtendedPrismaClient = prisma,
 ): Promise<OpenWeeklyParlayResult> {
   const serverId = DiscordGuildIdSchema.parse(input.serverId);
   const slot = input.slot ?? WEEKLY_PARLAY_SLOT;
+  const period = resolveOpenTimeline(input);
   const existing = await prismaClient.bucksWeeklyParlayMarket.findUnique({
     where: {
       serverId_periodKey_slot: { serverId, periodKey: input.periodKey, slot },
     },
-    select: { id: true },
+    select: {
+      id: true,
+      definition: {
+        select: {
+          openAt: true,
+          bettingClosesAt: true,
+          scoringStartsAt: true,
+          scoringEndsAt: true,
+        },
+      },
+    },
   });
   if (existing !== null) {
+    assertMatchingTimeline(existing, period);
     return { kind: "existing", marketId: existing.id };
   }
   const [bettingEnabled, weeklyEnabled] = await Promise.all([
@@ -134,7 +195,6 @@ async function openWeeklyParlayInternal(
     return { kind: "feature_disabled" };
   }
   const startedAt = Date.now();
-  const period = weeklyParlayPeriod(input.periodKey);
   const subjects = await linkedMemberSubjects(serverId, prismaClient);
   if (subjects.length === 0) {
     return { kind: "no_candidate" };
@@ -142,6 +202,10 @@ async function openWeeklyParlayInternal(
   const [histories, previousDefinitions] = await Promise.all([
     fetchWeeklyCandidateHistories({
       periodKey: input.periodKey,
+      scoringWindow: {
+        scoringStartsAt: period.scoringStartsAt,
+        scoringEndsAt: period.scoringEndsAt,
+      },
       subjects,
       ...(input.signal === undefined ? {} : { abortSignal: input.signal }),
     }),
@@ -254,6 +318,8 @@ async function openWeeklyParlayInternal(
               observedRoles: [...history.observedRoles].toSorted(),
               recentEligibleGames: history.recentEligibleGames,
               fullyObservedWindows: history.fullyObservedWindows,
+              timelineKind: timelineKind(period),
+              scoringShape: weeklyParlayScoringShape(period),
             }),
             requestedModel: generated.model,
             resolvedModel: generated.resolvedModel,
@@ -289,8 +355,19 @@ async function openWeeklyParlayInternal(
               slot,
             },
           },
-          select: { id: true },
+          select: {
+            id: true,
+            definition: {
+              select: {
+                openAt: true,
+                bettingClosesAt: true,
+                scoringStartsAt: true,
+                scoringEndsAt: true,
+              },
+            },
+          },
         });
+      assertMatchingTimeline(racedMarket, period);
       return { kind: "existing", marketId: racedMarket.id };
     }
   }
@@ -298,12 +375,7 @@ async function openWeeklyParlayInternal(
 }
 
 export async function openWeeklyParlay(
-  input: {
-    serverId: string;
-    periodKey: string;
-    slot?: number;
-    signal?: AbortSignal;
-  },
+  input: OpenWeeklyParlayInput,
   prismaClient: ExtendedPrismaClient = prisma,
 ): Promise<OpenWeeklyParlayResult> {
   const startedAt = Date.now();

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -70,6 +70,7 @@ type OpenWeeklyParlayInput = {
   periodKey: string;
   slot?: number;
   timeline?: WeeklyParlayFrozenWindow;
+  generationDeadline?: Date;
   signal?: AbortSignal;
 };
 
@@ -186,6 +187,12 @@ async function openWeeklyParlayInternal(
   if (existing !== null) {
     assertMatchingTimeline(existing, period);
     return { kind: "existing", marketId: existing.id };
+  }
+  if (
+    input.generationDeadline !== undefined &&
+    input.generationDeadline.getTime() >= period.bettingClosesAt.getTime()
+  ) {
+    return { kind: "too_late" };
   }
   const [bettingEnabled, weeklyEnabled] = await Promise.all([
     isPolicyEnabled("betting_enabled", { server: serverId }),

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.test.ts
@@ -4,6 +4,9 @@ import {
   WEEKLY_PARLAY_INGESTION_GRACE_MS,
   weeklyParlayFinalSettlementAt,
   weeklyParlayPeriod,
+  weeklyParlayScoringShape,
+  weeklyParlayScoringWindowForPeriod,
+  weeklyParlayTimelineFromWindow,
 } from "#src/betting/weekly-parlay-period.ts";
 
 describe("weekly parlay Pacific periods", () => {
@@ -59,5 +62,42 @@ describe("weekly parlay Pacific periods", () => {
 
   test("rejects a non-Monday period key", () => {
     expect(() => weeklyParlayPeriod("2026-08-23")).toThrow("must be a Monday");
+  });
+
+  test("derives a shortened catch-up timeline from frozen clocks", () => {
+    const timeline = weeklyParlayTimelineFromWindow({
+      periodKey: "2026-08-24",
+      openAt: new Date("2026-08-24T19:00:00.000Z"),
+      bettingClosesAt: new Date("2026-08-25T07:00:00.000Z"),
+      scoringStartsAt: new Date("2026-08-25T07:00:00.000Z"),
+      scoringEndsAt: new Date("2026-08-30T18:00:00.000Z"),
+    });
+    expect(timeline.reminderAt?.toISOString()).toBe("2026-08-25T02:00:00.000Z");
+    expect(timeline.updateAt.map((instant) => instant.toISOString())).toEqual([
+      "2026-08-26T02:00:00.000Z",
+      "2026-08-27T02:00:00.000Z",
+      "2026-08-28T02:00:00.000Z",
+      "2026-08-29T02:00:00.000Z",
+      "2026-08-30T02:00:00.000Z",
+    ]);
+  });
+
+  test("replays the same Pacific weekday and hour shape across DST", () => {
+    const shape = weeklyParlayScoringShape({
+      periodKey: "2026-10-26",
+      scoringStartsAt: new Date("2026-10-28T07:00:00.000Z"),
+      scoringEndsAt: new Date("2026-11-01T19:00:00.000Z"),
+    });
+    expect(shape).toEqual({
+      startDayOffset: 2,
+      startHour: 0,
+      endDayOffset: 6,
+      endHour: 11,
+    });
+    const replay = weeklyParlayScoringWindowForPeriod("2027-03-08", shape);
+    expect(replay.scoringStartsAt.toISOString()).toBe(
+      "2027-03-10T08:00:00.000Z",
+    );
+    expect(replay.scoringEndsAt.toISOString()).toBe("2027-03-14T18:00:00.000Z");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts
@@ -1,4 +1,9 @@
-import { addDays, formatISO, parseISO } from "date-fns";
+import {
+  addDays,
+  differenceInCalendarDays,
+  formatISO,
+  parseISO,
+} from "date-fns";
 import { POLLING_INTERVALS } from "@scout-for-lol/data/polling-config.ts";
 import { WEEKLY_PARLAY_LIFECYCLE } from "@scout-for-lol/data/model/weekly-parlay.ts";
 
@@ -10,6 +15,8 @@ export const WEEKLY_PARLAY_BETTING_CLOSE_HOUR =
 export const WEEKLY_PARLAY_FINAL_HOUR = WEEKLY_PARLAY_LIFECYCLE.finalHour;
 export const WEEKLY_PARLAY_UPDATE_HOUR = WEEKLY_PARLAY_LIFECYCLE.updateHour;
 export const WEEKLY_PARLAY_UPDATE_COUNT = WEEKLY_PARLAY_LIFECYCLE.updateCount;
+export const WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS =
+  WEEKLY_PARLAY_LIFECYCLE.catchupMinimumBettingHours;
 const WEEKLY_PARLAY_INGESTION_POLL_WINDOWS = 2;
 export const WEEKLY_PARLAY_INGESTION_GRACE_MINUTES =
   POLLING_INTERVALS.MAX * WEEKLY_PARLAY_INGESTION_POLL_WINDOWS;
@@ -35,6 +42,26 @@ export type WeeklyParlayPeriod = {
   updateAt: Date[];
   scoringEndsAt: Date;
   nextOpenAt: Date;
+};
+
+export type WeeklyParlayFrozenWindow = {
+  periodKey: string;
+  openAt: Date;
+  bettingClosesAt: Date;
+  scoringStartsAt: Date;
+  scoringEndsAt: Date;
+};
+
+export type WeeklyParlayRuntimeTimeline = WeeklyParlayFrozenWindow & {
+  reminderAt?: Date;
+  updateAt: Date[];
+};
+
+export type WeeklyParlayScoringShape = {
+  startDayOffset: number;
+  startHour: number;
+  endDayOffset: number;
+  endHour: number;
 };
 
 function calendarDate(date: Date): string {
@@ -114,6 +141,118 @@ export function pacificWallTime(date: string, hour: number): Date {
 
 function offsetDate(periodKey: string, days: number): string {
   return calendarDate(addDays(parseISO(periodKey), days));
+}
+
+function pacificDateAndHour(instant: Date): { date: string; hour: number } {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: WEEKLY_PARLAY_TIMEZONE,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+  });
+  const parts = new Map(
+    formatter
+      .formatToParts(instant)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+  const year = parts.get("year");
+  const month = parts.get("month");
+  const day = parts.get("day");
+  const hour = parts.get("hour");
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    hour === undefined
+  ) {
+    throw new Error("Could not derive Pacific weekly parlay time parts.");
+  }
+  return { date: `${year}-${month}-${day}`, hour: Number(hour) };
+}
+
+export function weeklyParlayScoringShape(
+  window: Pick<
+    WeeklyParlayFrozenWindow,
+    "periodKey" | "scoringStartsAt" | "scoringEndsAt"
+  >,
+): WeeklyParlayScoringShape {
+  weeklyParlayPeriod(window.periodKey);
+  const start = pacificDateAndHour(window.scoringStartsAt);
+  const end = pacificDateAndHour(window.scoringEndsAt);
+  return {
+    startDayOffset: differenceInCalendarDays(
+      parseISO(start.date),
+      parseISO(window.periodKey),
+    ),
+    startHour: start.hour,
+    endDayOffset: differenceInCalendarDays(
+      parseISO(end.date),
+      parseISO(window.periodKey),
+    ),
+    endHour: end.hour,
+  };
+}
+
+export function weeklyParlayScoringWindowForPeriod(
+  periodKey: string,
+  shape: WeeklyParlayScoringShape,
+): Pick<WeeklyParlayFrozenWindow, "scoringStartsAt" | "scoringEndsAt"> {
+  weeklyParlayPeriod(periodKey);
+  return {
+    scoringStartsAt: pacificWallTime(
+      offsetDate(periodKey, shape.startDayOffset),
+      shape.startHour,
+    ),
+    scoringEndsAt: pacificWallTime(
+      offsetDate(periodKey, shape.endDayOffset),
+      shape.endHour,
+    ),
+  };
+}
+
+export function weeklyParlayTimelineFromWindow(
+  window: WeeklyParlayFrozenWindow,
+): WeeklyParlayRuntimeTimeline {
+  weeklyParlayPeriod(window.periodKey);
+  const dailyUpdates = Array.from({ length: 7 }, (_, dayOffset) =>
+    pacificWallTime(
+      offsetDate(window.periodKey, dayOffset),
+      WEEKLY_PARLAY_UPDATE_HOUR,
+    ),
+  );
+  const reminderAt = [
+    pacificWallTime(
+      offsetDate(window.periodKey, -1),
+      WEEKLY_PARLAY_UPDATE_HOUR,
+    ),
+    ...dailyUpdates,
+  ].findLast(
+    (candidate) =>
+      candidate > window.openAt && candidate < window.bettingClosesAt,
+  );
+  return {
+    ...window,
+    ...(reminderAt === undefined ? {} : { reminderAt }),
+    updateAt: dailyUpdates.filter(
+      (candidate) =>
+        candidate >= window.scoringStartsAt && candidate < window.scoringEndsAt,
+    ),
+  };
+}
+
+export function isWeeklyParlayCatchupTimeline(
+  window: WeeklyParlayFrozenWindow,
+): boolean {
+  const standard = weeklyParlayPeriod(window.periodKey);
+  return (
+    window.openAt.getTime() !== standard.openAt.getTime() ||
+    window.bettingClosesAt.getTime() !== standard.bettingClosesAt.getTime() ||
+    window.scoringStartsAt.getTime() !== standard.scoringStartsAt.getTime() ||
+    window.scoringEndsAt.getTime() !== standard.scoringEndsAt.getTime()
+  );
 }
 
 /** Build the immutable clocks for a scoring period identified by its Monday. */

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -14,6 +14,7 @@ import {
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
+import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 
 /** Edit the original open-market message after a bet or cancellation. */
 export async function refreshWeeklyParlayMessage(
@@ -34,6 +35,10 @@ export async function refreshWeeklyParlayMessage(
             subjects: true,
             criteria: true,
             yesProbabilityBps: true,
+            openAt: true,
+            bettingClosesAt: true,
+            scoringStartsAt: true,
+            scoringEndsAt: true,
           },
         },
         bets: {
@@ -54,14 +59,27 @@ export async function refreshWeeklyParlayMessage(
     const aliases = new Map(
       subjects.map((subject) => [subject.key, subject.alias]),
     );
+    const catchup = isWeeklyParlayCatchupTimeline({
+      periodKey: market.periodKey,
+      openAt: market.definition.openAt,
+      bettingClosesAt: market.definition.bettingClosesAt,
+      scoringStartsAt: market.definition.scoringStartsAt,
+      scoringEndsAt: market.definition.scoringEndsAt,
+    });
     const content = [
-      deliveryTitle("open", market.marketState, null),
+      deliveryTitle("open", market.marketState, null, catchup),
       `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
       ...criteria.legs.map((leg) =>
         legLine(leg, undefined, aliases.get(leg.subject) ?? leg.subject),
       ),
       `**${market.bets.length.toString()} ${countLabel(market.bets.length, "bettor")} · ${market.bets.reduce((total, bet) => total + bet.stake, 0).toString()} BB staked**`,
-      deliveryTimeCopy("open", market.bettingClosesAt, market.scoringEndsAt),
+      deliveryTimeCopy({
+        kind: "open",
+        bettingClosesAt: market.bettingClosesAt,
+        scoringEndsAt: market.scoringEndsAt,
+        scoringStartsAt: market.definition.scoringStartsAt,
+        catchup,
+      }),
     ].join("\n");
     for (const [index, ref] of refs.entries()) {
       const channel = await client.channels.fetch(ref.channelId);

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -130,19 +130,30 @@ async function makeMarket(input?: {
   criteria?: ReturnType<typeof hitCriteria>;
   marketState?: "publishing" | "open" | "active";
   slot?: number;
+  timeline?: {
+    openAt: Date;
+    bettingClosesAt: Date;
+    scoringStartsAt: Date;
+    scoringEndsAt: Date;
+  };
 }) {
   const player = await db.player.findFirstOrThrow({
     where: { serverId: SERVER_ID, discordId: BETTOR },
   });
-  const scoringStartsAt = new Date(COMPLETED_AT.getTime() - 60 * 60_000);
-  const scoringEndsAt = new Date(COMPLETED_AT.getTime() + 60 * 60_000);
+  const timeline = input?.timeline ?? {
+    scoringStartsAt: new Date(COMPLETED_AT.getTime() - 60 * 60_000),
+    scoringEndsAt: new Date(COMPLETED_AT.getTime() + 60 * 60_000),
+    openAt: new Date(COMPLETED_AT.getTime() - 3 * 60 * 60_000),
+    bettingClosesAt: new Date(COMPLETED_AT.getTime() - 2 * 60 * 60_000),
+  };
+  const { bettingClosesAt, openAt, scoringEndsAt, scoringStartsAt } = timeline;
   const definition = await db.bucksWeeklyParlayDefinition.create({
     data: {
       serverId: SERVER_ID,
       periodKey: PERIOD_KEY,
       slot: input?.slot ?? 0,
-      openAt: new Date(COMPLETED_AT.getTime() - 3 * 60 * 60_000),
-      bettingClosesAt: new Date(COMPLETED_AT.getTime() - 2 * 60 * 60_000),
+      openAt,
+      bettingClosesAt,
       scoringStartsAt,
       scoringEndsAt,
       subjects: JSON.stringify([subject(player.id)]),
@@ -169,8 +180,8 @@ async function makeMarket(input?: {
       serverId: SERVER_ID,
       periodKey: PERIOD_KEY,
       slot: input?.slot ?? 0,
-      publishedAt: new Date(COMPLETED_AT.getTime() - 3 * 60 * 60_000),
-      bettingClosesAt: new Date(COMPLETED_AT.getTime() - 2 * 60 * 60_000),
+      publishedAt: openAt,
+      bettingClosesAt,
       scoringEndsAt,
       marketState: input?.marketState ?? "open",
     },
@@ -633,7 +644,90 @@ describe("weekly parlay contributions and control actions", () => {
       ),
     ).resolves.toMatchObject({ status: "skipped", detail: "stale_progress" });
   });
+});
 
+describe("weekly parlay catch-up controls", () => {
+  test("rejects an open retry whose catch-up clocks conflict with the stored definition", async () => {
+    await makeMarket({ marketState: "open" });
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const openAt = new Date("2026-08-24T19:00:00.000Z");
+    await expect(
+      runWeeklyParlayControlAction(
+        {
+          periodKey: PERIOD_KEY,
+          action: "open",
+          slot: 0,
+          window: {
+            kind: "catch_up",
+            openAt: openAt.toISOString(),
+            bettingClosesAt: "2026-08-25T07:00:00.000Z",
+            scoringStartsAt: "2026-08-25T07:00:00.000Z",
+            scoringEndsAt: period.scoringEndsAt.toISOString(),
+          },
+        },
+        {
+          serverId: SERVER_ID,
+          now: openAt,
+          prismaClient: db,
+        },
+      ),
+    ).rejects.toThrow("conflicting timeline");
+  });
+
+  test("rejects catch-up clocks that do not preserve the minimum betting window", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const openAt = new Date("2026-08-25T02:30:00.000Z");
+    await expect(
+      runWeeklyParlayControlAction(
+        {
+          periodKey: PERIOD_KEY,
+          action: "open",
+          slot: 0,
+          window: {
+            kind: "catch_up",
+            openAt: openAt.toISOString(),
+            bettingClosesAt: "2026-08-25T07:00:00.000Z",
+            scoringStartsAt: "2026-08-25T07:00:00.000Z",
+            scoringEndsAt: period.scoringEndsAt.toISOString(),
+          },
+        },
+        {
+          serverId: SERVER_ID,
+          now: openAt,
+          prismaClient: db,
+        },
+      ),
+    ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
+  });
+
+  test("rejects a catch-up scoring cutoff that is not an exact Pacific midnight", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const openAt = new Date("2026-08-24T19:00:00.000Z");
+    await expect(
+      runWeeklyParlayControlAction(
+        {
+          periodKey: PERIOD_KEY,
+          action: "open",
+          slot: 0,
+          window: {
+            kind: "catch_up",
+            openAt: openAt.toISOString(),
+            bettingClosesAt: "2026-08-25T07:30:00.000Z",
+            scoringStartsAt: "2026-08-25T07:30:00.000Z",
+            scoringEndsAt: period.scoringEndsAt.toISOString(),
+          },
+        },
+        {
+          serverId: SERVER_ID,
+          now: openAt,
+          prismaClient: db,
+        },
+      ),
+    ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
+  });
+});
+
+describe("weekly parlay contribution capture", () => {
   test("appends once and accepts a pre-cutoff completion ingested during reconciliation", async () => {
     const finalOnly = hitCriteria();
     finalOnly.legs[0] = {
@@ -773,6 +867,42 @@ describe("weekly parlay ingestion boundaries", () => {
 describe("weekly parlay Discord delivery", () => {
   test("uses one settlement delivery key across settlement origins", () => {
     expect(weeklyParlaySettlementActionKey(42)).toBe("settlement:42");
+  });
+
+  test("labels catch-up messages and renders their frozen betting and scoring clocks", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const market = await makeMarket({
+      marketState: "publishing",
+      timeline: {
+        openAt: new Date("2026-08-24T19:00:00.000Z"),
+        bettingClosesAt: new Date("2026-08-25T07:00:00.000Z"),
+        scoringStartsAt: new Date("2026-08-25T07:00:00.000Z"),
+        scoringEndsAt: period.scoringEndsAt,
+      },
+    });
+    const sent: Parameters<WeeklyParlayDiscordSender>[0][] = [];
+    const sender: WeeklyParlayDiscordSender = async (options) => {
+      sent.push(options);
+      return { channelId: "160509172704739999", id: "catch-up-open" };
+    };
+    await expect(
+      deliverWeeklyParlayDiscord(
+        {
+          marketId: market.id,
+          actionKey: "open",
+          kind: "open",
+          scheduledAt: market.definition.openAt,
+        },
+        db,
+        sender,
+      ),
+    ).resolves.toBe("sent");
+    expect(sent[0]?.content).toContain(
+      "Catch-up weekly Bryan Bucks parlay is open",
+    );
+    expect(sent[0]?.content).toContain("Betting closes <t:1787641200:F>");
+    expect(sent[0]?.content).toContain("Scoring runs <t:1787641200:F>");
+    expect(sent[0]?.content).toContain("through <t:1788112800:F>");
   });
 
   test("chunks and deduplicates private mention delivery with a stable nonce", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -28,6 +28,7 @@ import {
   type WeeklyParlayDiscordSender,
 } from "#src/betting/weekly-parlay-discord.ts";
 import { runWeeklyParlayControlAction } from "#src/betting/weekly-parlay-control.ts";
+import { openWeeklyParlay } from "#src/betting/weekly-parlay-open.ts";
 import {
   WEEKLY_PARLAY_INGESTION_GRACE_MS,
   weeklyParlayFinalSettlementAt,
@@ -726,6 +727,41 @@ describe("weekly parlay catch-up controls", () => {
     ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
   });
 
+  test("allows a matching publication retry inside the generation budget", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const openAt = new Date("2026-08-24T19:00:00.000Z");
+    const market = await makeMarket({
+      marketState: "open",
+      timeline: {
+        openAt,
+        bettingClosesAt: new Date("2026-08-25T07:00:00.000Z"),
+        scoringStartsAt: new Date("2026-08-25T07:00:00.000Z"),
+        scoringEndsAt: period.scoringEndsAt,
+      },
+    });
+    await expect(
+      openWeeklyParlay(
+        {
+          serverId: SERVER_ID,
+          periodKey: PERIOD_KEY,
+          slot: 0,
+          timeline: {
+            periodKey: PERIOD_KEY,
+            openAt,
+            bettingClosesAt: new Date("2026-08-25T07:00:00.000Z"),
+            scoringStartsAt: new Date("2026-08-25T07:00:00.000Z"),
+            scoringEndsAt: period.scoringEndsAt,
+          },
+          generationDeadline: new Date("2026-08-25T07:04:00.000Z"),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({
+      kind: "existing",
+      marketId: market.id,
+    });
+  });
+
   test("defers a start received before the persisted scoring clock", async () => {
     const period = weeklyParlayPeriod(PERIOD_KEY);
     const market = await makeMarket({
@@ -757,6 +793,38 @@ describe("weekly parlay catch-up controls", () => {
         select: { marketState: true },
       }),
     ).resolves.toMatchObject({ marketState: "open" });
+  });
+
+  test("defers progress received before the persisted update clock", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const market = await makeMarket({
+      marketState: "open",
+      timeline: {
+        openAt: period.openAt,
+        bettingClosesAt: period.bettingClosesAt,
+        scoringStartsAt: new Date("2026-08-25T07:00:00.000Z"),
+        scoringEndsAt: period.scoringEndsAt,
+      },
+    });
+    await expect(
+      runWeeklyParlayControlAction(
+        {
+          periodKey: PERIOD_KEY,
+          action: "progress",
+          slot: 0,
+          updateIndex: 0,
+        },
+        {
+          serverId: SERVER_ID,
+          now: new Date("2026-08-25T07:00:00.000Z"),
+          prismaClient: db,
+        },
+      ),
+    ).resolves.toMatchObject({
+      status: "skipped",
+      detail: "before_progress_time",
+      marketId: market.id,
+    });
   });
 
   test("rejects a catch-up scoring cutoff that is not an exact Pacific midnight", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -700,6 +700,65 @@ describe("weekly parlay catch-up controls", () => {
     ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
   });
 
+  test("rechecks the minimum betting window from the retry time", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const openAt = new Date("2026-08-24T19:00:00.000Z");
+    await expect(
+      runWeeklyParlayControlAction(
+        {
+          periodKey: PERIOD_KEY,
+          action: "open",
+          slot: 0,
+          window: {
+            kind: "catch_up",
+            openAt: openAt.toISOString(),
+            bettingClosesAt: "2026-08-25T07:00:00.000Z",
+            scoringStartsAt: "2026-08-25T07:00:00.000Z",
+            scoringEndsAt: period.scoringEndsAt.toISOString(),
+          },
+        },
+        {
+          serverId: SERVER_ID,
+          now: new Date("2026-08-25T02:00:00.000Z"),
+          prismaClient: db,
+        },
+      ),
+    ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
+  });
+
+  test("defers a start received before the persisted scoring clock", async () => {
+    const period = weeklyParlayPeriod(PERIOD_KEY);
+    const market = await makeMarket({
+      marketState: "open",
+      timeline: {
+        openAt: period.openAt,
+        bettingClosesAt: period.bettingClosesAt,
+        scoringStartsAt: new Date("2026-08-26T07:00:00.000Z"),
+        scoringEndsAt: period.scoringEndsAt,
+      },
+    });
+    await expect(
+      runWeeklyParlayControlAction(
+        { periodKey: PERIOD_KEY, action: "start", slot: 0 },
+        {
+          serverId: SERVER_ID,
+          now: new Date("2026-08-25T07:00:00.000Z"),
+          prismaClient: db,
+        },
+      ),
+    ).resolves.toMatchObject({
+      status: "skipped",
+      detail: "before_scoring_start",
+      marketId: market.id,
+    });
+    await expect(
+      db.bucksWeeklyParlayMarket.findUniqueOrThrow({
+        where: { id: market.id },
+        select: { marketState: true },
+      }),
+    ).resolves.toMatchObject({ marketState: "open" });
+  });
+
   test("rejects a catch-up scoring cutoff that is not an exact Pacific midnight", async () => {
     const period = weeklyParlayPeriod(PERIOD_KEY);
     const openAt = new Date("2026-08-24T19:00:00.000Z");

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -21,6 +21,7 @@ import {
 } from "#src/betting/weekly-parlay-criteria.ts";
 import {
   WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
+  WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS,
   WEEKLY_PARLAY_FINAL_HOUR,
   WEEKLY_PARLAY_INGESTION_GRACE_MINUTES,
   WEEKLY_PARLAY_OPEN_HOUR,
@@ -103,7 +104,9 @@ export function buildBbRulesEmbed(): EmbedBuilder {
           `It opens Sunday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_OPEN_HOUR)} and betting closes Monday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_BETTING_CLOSE_HOUR)} in ${WEEKLY_PARLAY_TIMEZONE}. ` +
           `Only completed ${WEEKLY_PARLAY_ELIGIBLE_QUEUES.join(", ")} games count, through Sunday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_FINAL_HOUR)}. ` +
           `Scout waits **${WEEKLY_PARLAY_INGESTION_GRACE_MINUTES.toString()} minutes** after that cutoff for completed games to ingest. ` +
-          "Scout may settle YES early only after every leg is impossible to undo; NO always waits for final settlement. Cancelling before Monday is free.",
+          `If Sunday opening is missed, an exceptional catch-up market may open midweek with at least **${WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS.toString()} hours** to bet before the next eligible Pacific midnight. ` +
+          "Its message shows the exact betting and scoring timestamps, and games completed before betting closes never count. " +
+          "Scout may settle YES early only after every leg is impossible to undo; NO always waits for final settlement. Cancelling before betting closes is free.",
       },
       {
         name: "Voids",

--- a/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.test.ts
@@ -40,6 +40,37 @@ describe("weekly parlay control action schema", () => {
       }),
     ).toMatchObject({ slot: 0, updateIndex: 5 });
   });
+
+  test("accepts catch-up clocks only on open actions", () => {
+    const window = {
+      kind: "catch_up",
+      openAt: "2026-08-24T19:00:00.000Z",
+      bettingClosesAt: "2026-08-25T07:00:00.000Z",
+      scoringStartsAt: "2026-08-25T07:00:00.000Z",
+      scoringEndsAt: "2026-08-30T18:00:00.000Z",
+    };
+    expect(
+      WeeklyParlayControlActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        action: "open",
+        window,
+      }).success,
+    ).toBe(true);
+    expect(
+      WeeklyParlayControlActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        action: "start",
+        window,
+      }).success,
+    ).toBe(false);
+    expect(
+      WeeklyParlayControlActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        action: "open",
+        window: { ...window, arbitraryClock: "2026-08-26T00:00:00.000Z" },
+      }).success,
+    ).toBe(false);
+  });
 });
 
 describe("weekly parlay control HTTP boundary", () => {

--- a/packages/scout-for-lol/packages/data/dist/model/weekly-parlay.js
+++ b/packages/scout-for-lol/packages/data/dist/model/weekly-parlay.js
@@ -8,6 +8,7 @@ var weekly_parlay_default = {
   openHour: 12,
   bettingCloseHour: 0,
   openActionBudgetMinutes: 4,
+  catchupMinimumBettingHours: 6,
   finalHour: 11,
   updateHour: 19,
   updateCount: 6,
@@ -21,6 +22,7 @@ var WeeklyParlayLifecycleSchema = z.strictObject({
   openHour: z.number().int().min(0).max(23),
   bettingCloseHour: z.number().int().min(0).max(23),
   openActionBudgetMinutes: z.number().int().positive(),
+  catchupMinimumBettingHours: z.number().int().positive(),
   finalHour: z.number().int().min(0).max(23),
   updateHour: z.number().int().min(0).max(23),
   updateCount: z.number().int().positive(),
@@ -34,7 +36,9 @@ var WeeklyParlayLifecycleSchema = z.strictObject({
 });
 var WEEKLY_PARLAY_LIFECYCLE = WeeklyParlayLifecycleSchema.parse(weekly_parlay_default);
 var WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS = WEEKLY_PARLAY_LIFECYCLE.openActionBudgetMinutes * 60 * 1000;
+var WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS = WEEKLY_PARLAY_LIFECYCLE.catchupMinimumBettingHours * 60 * 60 * 1000;
 export {
+  WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS,
   WEEKLY_PARLAY_LIFECYCLE,
   WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS
 };

--- a/packages/scout-for-lol/packages/data/dist/weekly-parlay.d.ts
+++ b/packages/scout-for-lol/packages/data/dist/weekly-parlay.d.ts
@@ -5,6 +5,7 @@ declare const WeeklyParlayLifecycleSchema: z.ZodObject<{
     openHour: z.ZodNumber;
     bettingCloseHour: z.ZodNumber;
     openActionBudgetMinutes: z.ZodNumber;
+    catchupMinimumBettingHours: z.ZodNumber;
     finalHour: z.ZodNumber;
     updateHour: z.ZodNumber;
     updateCount: z.ZodNumber;
@@ -16,6 +17,7 @@ export declare const WEEKLY_PARLAY_LIFECYCLE: {
     openHour: number;
     bettingCloseHour: number;
     openActionBudgetMinutes: number;
+    catchupMinimumBettingHours: number;
     finalHour: number;
     updateHour: number;
     updateCount: number;
@@ -23,4 +25,5 @@ export declare const WEEKLY_PARLAY_LIFECYCLE: {
 };
 export type WeeklyParlayLifecycle = z.infer<typeof WeeklyParlayLifecycleSchema>;
 export declare const WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS: number;
+export declare const WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS: number;
 export {};

--- a/packages/scout-for-lol/packages/data/src/model/weekly-parlay.json
+++ b/packages/scout-for-lol/packages/data/src/model/weekly-parlay.json
@@ -4,6 +4,7 @@
   "openHour": 12,
   "bettingCloseHour": 0,
   "openActionBudgetMinutes": 4,
+  "catchupMinimumBettingHours": 6,
   "finalHour": 11,
   "updateHour": 19,
   "updateCount": 6,

--- a/packages/scout-for-lol/packages/data/src/model/weekly-parlay.schema.json
+++ b/packages/scout-for-lol/packages/data/src/model/weekly-parlay.schema.json
@@ -9,6 +9,7 @@
     "openHour",
     "bettingCloseHour",
     "openActionBudgetMinutes",
+    "catchupMinimumBettingHours",
     "finalHour",
     "updateHour",
     "updateCount",
@@ -24,6 +25,10 @@
       "maximum": 23
     },
     "openActionBudgetMinutes": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "catchupMinimumBettingHours": {
       "type": "integer",
       "minimum": 1
     },

--- a/packages/scout-for-lol/packages/data/src/model/weekly-parlay.ts
+++ b/packages/scout-for-lol/packages/data/src/model/weekly-parlay.ts
@@ -7,6 +7,7 @@ const WeeklyParlayLifecycleSchema = z.strictObject({
   openHour: z.number().int().min(0).max(23),
   bettingCloseHour: z.number().int().min(0).max(23),
   openActionBudgetMinutes: z.number().int().positive(),
+  catchupMinimumBettingHours: z.number().int().positive(),
   finalHour: z.number().int().min(0).max(23),
   updateHour: z.number().int().min(0).max(23),
   updateCount: z.number().int().positive(),
@@ -25,3 +26,5 @@ export type WeeklyParlayLifecycle = z.infer<typeof WeeklyParlayLifecycleSchema>;
 
 export const WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS =
   WEEKLY_PARLAY_LIFECYCLE.openActionBudgetMinutes * 60 * 1000;
+export const WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS =
+  WEEKLY_PARLAY_LIFECYCLE.catchupMinimumBettingHours * 60 * 60 * 1000;

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
@@ -31,6 +31,7 @@ import {
 } from "@scout-for-lol/backend/betting/weekly-parlay-criteria.ts";
 import {
   WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
+  WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS,
   WEEKLY_PARLAY_FINAL_HOUR,
   WEEKLY_PARLAY_INGESTION_GRACE_MINUTES,
   WEEKLY_PARLAY_OPEN_HOUR,
@@ -83,6 +84,12 @@ published only when replaying aligned historical weeks measures a YES rate
 between {WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS / 100}% and{" "}
 {WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS / 100}%. If no candidate clears every
 gate, Scout publishes no weekly parlay.
+
+If the standard Sunday opening is missed, an operator may start a catch-up
+market for that period. Betting remains open for at least{" "}
+{WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS} hours before scoring starts at a
+Pacific midnight. The market message shows the frozen betting and scoring
+timestamps. Games completed before betting closes do not count.
 
 ## Stakes
 

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -237,6 +237,28 @@ period's Sunday execution. The schedule's initial pause is the private-beta
 fixture gate. After activation, pause it in Temporal for operational suspension
 rather than adding a second enable switch.
 
+`runScoutWeeklyParlayCatchupWorkflow` is the exceptional operator path for a
+missed Sunday opening. It freezes `workflowInfo().startTime`, chooses the first
+Pacific midnight at least the configured minimum betting duration plus the
+open-action budget away, and retains the standard Sunday finalization. It may
+omit the reminder and may run fewer progress updates. Only the open action
+carries the frozen clocks; Scout reads its persisted definition thereafter.
+Start one run with a stable period/slot ID and reject every reuse:
+
+```bash
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true \
+  toolkit temporal workflow start \
+    --workflow-id scout-weekly-parlay-catchup-2026-08-24-0 \
+    --type runScoutWeeklyParlayCatchupWorkflow \
+    --task-queue default \
+    --input '{"periodKey":"2026-08-24","slot":0}' \
+    --id-conflict-policy Fail \
+    --id-reuse-policy RejectDuplicate
+```
+
+Do not add this workflow to `SCHEDULES`. The ordinary
+`scout-weekly-parlay` schedule remains the next-week path.
+
 ## Homelab audit (daily)
 
 `homelab-audit-daily` (cron `30 6 * * *` PT) runs the deterministic

--- a/packages/temporal/src/activities/scout-weekly-parlay.test.ts
+++ b/packages/temporal/src/activities/scout-weekly-parlay.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
+  buildScoutWeeklyParlayCatchupTimeline,
   buildScoutWeeklyParlayTimeline,
+  ScoutWeeklyParlayActionSchema,
   scoutWeeklyParlayActionKey,
 } from "./scout-weekly-parlay.ts";
 
@@ -40,5 +42,71 @@ describe("Scout weekly parlay Pacific timeline", () => {
         updateIndex: 4,
       }),
     ).toBe("scout-weekly-parlay:2027-03-08:2:progress:4");
+  });
+
+  test("opens the first catch-up scoring midnight beyond the minimum budget", () => {
+    const timeline = buildScoutWeeklyParlayCatchupTimeline(
+      "2026-08-24T19:00:00.000Z",
+      "2026-08-24",
+    );
+    expect(timeline).toEqual({
+      periodKey: "2026-08-24",
+      openAt: "2026-08-24T19:00:00.000Z",
+      reminderAt: "2026-08-25T02:00:00.000Z",
+      startsAt: "2026-08-25T07:00:00.000Z",
+      updatesAt: [
+        "2026-08-26T02:00:00.000Z",
+        "2026-08-27T02:00:00.000Z",
+        "2026-08-28T02:00:00.000Z",
+        "2026-08-29T02:00:00.000Z",
+        "2026-08-30T02:00:00.000Z",
+      ],
+      finalizesAt: "2026-08-30T18:00:00.000Z",
+    });
+  });
+
+  test("rolls the catch-up cutoff forward when the next midnight is too close", () => {
+    const timeline = buildScoutWeeklyParlayCatchupTimeline(
+      "2026-08-25T00:57:00.000Z",
+      "2026-08-24",
+    );
+    expect(timeline.startsAt).toBe("2026-08-26T07:00:00.000Z");
+    expect(timeline.reminderAt).toBe("2026-08-26T02:00:00.000Z");
+    expect(timeline.updatesAt).toHaveLength(4);
+  });
+
+  test("rejects a catch-up start with no scoring window before Sunday", () => {
+    expect(() =>
+      buildScoutWeeklyParlayCatchupTimeline(
+        "2026-08-30T01:00:00.000Z",
+        "2026-08-24",
+      ),
+    ).toThrow("No catch-up scoring window remains");
+  });
+
+  test("allows catch-up clocks only on the open control action", () => {
+    const window = {
+      kind: "catch_up",
+      openAt: "2026-08-24T19:00:00.000Z",
+      bettingClosesAt: "2026-08-25T07:00:00.000Z",
+      scoringStartsAt: "2026-08-25T07:00:00.000Z",
+      scoringEndsAt: "2026-08-30T18:00:00.000Z",
+    };
+    expect(
+      ScoutWeeklyParlayActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        slot: 0,
+        action: "open",
+        window,
+      }).success,
+    ).toBe(true);
+    expect(
+      ScoutWeeklyParlayActionSchema.safeParse({
+        periodKey: "2026-08-24",
+        slot: 0,
+        action: "finalize",
+        window,
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/temporal/src/activities/scout-weekly-parlay.ts
+++ b/packages/temporal/src/activities/scout-weekly-parlay.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS,
   WEEKLY_PARLAY_LIFECYCLE,
   WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS,
 } from "@scout-for-lol/data/model/weekly-parlay.ts";
@@ -20,6 +21,14 @@ const UPDATE_COUNT = WEEKLY_PARLAY_LIFECYCLE.updateCount;
 const OPEN_ACTION_TIMEOUT_MS = WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS;
 const STANDARD_ACTION_TIMEOUT_MS = 20 * 1000;
 
+export const ScoutWeeklyParlayCatchupWindowSchema = z.strictObject({
+  kind: z.literal("catch_up"),
+  openAt: z.iso.datetime(),
+  bettingClosesAt: z.iso.datetime(),
+  scoringStartsAt: z.iso.datetime(),
+  scoringEndsAt: z.iso.datetime(),
+});
+
 export const ScoutWeeklyParlayActionSchema = z
   .strictObject({
     periodKey: z.iso.date(),
@@ -31,6 +40,7 @@ export const ScoutWeeklyParlayActionSchema = z
       .min(0)
       .max(UPDATE_COUNT - 1)
       .optional(),
+    window: ScoutWeeklyParlayCatchupWindowSchema.optional(),
   })
   .superRefine((action, context) => {
     if (action.action === "progress" && action.updateIndex === undefined) {
@@ -47,6 +57,13 @@ export const ScoutWeeklyParlayActionSchema = z
         message: "Only progress actions accept an update index.",
       });
     }
+    if (action.action !== "open" && action.window !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["window"],
+        message: "Only open actions accept a catch-up window.",
+      });
+    }
   });
 export type ScoutWeeklyParlayAction = z.infer<
   typeof ScoutWeeklyParlayActionSchema
@@ -55,9 +72,9 @@ export type ScoutWeeklyParlayAction = z.infer<
 export const ScoutWeeklyParlayTimelineSchema = z.strictObject({
   periodKey: z.iso.date(),
   openAt: z.iso.datetime(),
-  reminderAt: z.iso.datetime(),
+  reminderAt: z.iso.datetime().optional(),
   startsAt: z.iso.datetime(),
-  updatesAt: z.array(z.iso.datetime()).length(UPDATE_COUNT),
+  updatesAt: z.array(z.iso.datetime()).max(UPDATE_COUNT),
   finalizesAt: z.iso.datetime(),
 });
 export type ScoutWeeklyParlayTimeline = z.infer<
@@ -192,6 +209,56 @@ export function buildScoutWeeklyParlayTimeline(
   });
 }
 
+export function buildScoutWeeklyParlayCatchupTimeline(
+  workflowStartAt: string,
+  periodKey: string,
+): ScoutWeeklyParlayTimeline {
+  const workflowStart = new Date(z.iso.datetime().parse(workflowStartAt));
+  const parsedPeriod = new Date(
+    `${z.iso.date().parse(periodKey)}T00:00:00.000Z`,
+  );
+  if (parsedPeriod.getUTCDay() !== 1) {
+    throw new Error(`Weekly parlay period ${periodKey} must be a Monday.`);
+  }
+  const standardOpen = pacificWallTime(dateOffset(periodKey, -1), OPEN_HOUR);
+  const finalizesAt = pacificWallTime(dateOffset(periodKey, 6), FINAL_HOUR);
+  if (workflowStart < standardOpen || workflowStart >= finalizesAt) {
+    throw new Error("Catch-up workflow start is outside its weekly period.");
+  }
+  const earliestStart =
+    workflowStart.getTime() +
+    WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS +
+    OPEN_ACTION_TIMEOUT_MS;
+  const startsAt = Array.from({ length: 7 }, (_, dayOffset) =>
+    pacificWallTime(dateOffset(periodKey, dayOffset), START_HOUR),
+  ).find(
+    (candidate) =>
+      candidate.getTime() >= earliestStart && candidate < finalizesAt,
+  );
+  if (startsAt === undefined) {
+    throw new Error("No catch-up scoring window remains before finalization.");
+  }
+  const actionTimes = Array.from({ length: 8 }, (_, index) =>
+    pacificWallTime(dateOffset(periodKey, index - 1), UPDATE_HOUR),
+  );
+  const reminderAt = actionTimes.findLast(
+    (candidate) => candidate > workflowStart && candidate < startsAt,
+  );
+  const updatesAt = actionTimes.filter(
+    (candidate) => candidate >= startsAt && candidate < finalizesAt,
+  );
+  return ScoutWeeklyParlayTimelineSchema.parse({
+    periodKey,
+    openAt: workflowStart.toISOString(),
+    ...(reminderAt === undefined
+      ? {}
+      : { reminderAt: reminderAt.toISOString() }),
+    startsAt: startsAt.toISOString(),
+    updatesAt: updatesAt.map((candidate) => candidate.toISOString()),
+    finalizesAt: finalizesAt.toISOString(),
+  });
+}
+
 export function scoutWeeklyParlayActionKey(
   action: ScoutWeeklyParlayAction,
 ): string {
@@ -264,6 +331,10 @@ export type ScoutWeeklyParlayActivities = {
   resolveScoutWeeklyParlayTimeline: (
     scheduledStartAt: string,
   ) => Promise<ScoutWeeklyParlayTimeline>;
+  resolveScoutWeeklyParlayCatchupTimeline: (
+    workflowStartAt: string,
+    periodKey: string,
+  ) => Promise<ScoutWeeklyParlayTimeline>;
   invokeScoutWeeklyParlayAction: (
     action: ScoutWeeklyParlayAction,
   ) => Promise<ScoutWeeklyParlayControlResult>;
@@ -274,5 +345,12 @@ export const scoutWeeklyParlayActivities = {
     scheduledStartAt: string,
   ): Promise<ScoutWeeklyParlayTimeline> =>
     Promise.resolve(buildScoutWeeklyParlayTimeline(scheduledStartAt)),
+  resolveScoutWeeklyParlayCatchupTimeline: (
+    workflowStartAt: string,
+    periodKey: string,
+  ): Promise<ScoutWeeklyParlayTimeline> =>
+    Promise.resolve(
+      buildScoutWeeklyParlayCatchupTimeline(workflowStartAt, periodKey),
+    ),
   invokeScoutWeeklyParlayAction,
 } satisfies ScoutWeeklyParlayActivities;

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -41,11 +41,17 @@ import type { HomelabCrdImportsRefreshResult } from "#activities/homelab-crd-imp
 import { runPokeemeraldDataRefresh as _runPokeemeraldDataRefresh } from "./dpp-pokeemerald-data-refresh.ts";
 import type { PokeemeraldDataRefreshResult } from "#activities/dpp-pokeemerald-data-refresh.ts";
 import { runScoutShowcaseRefresh as _runScoutShowcaseRefresh } from "./scout-showcase-refresh.ts";
-import { runScoutWeeklyParlayWorkflow as _runScoutWeeklyParlayWorkflow } from "./scout-weekly-parlay.ts";
+import {
+  runScoutWeeklyParlayCatchupWorkflow as _runScoutWeeklyParlayCatchupWorkflow,
+  runScoutWeeklyParlayWorkflow as _runScoutWeeklyParlayWorkflow,
+} from "./scout-weekly-parlay.ts";
 import { runScoutQueueWindowsWatch as _runScoutQueueWindowsWatch } from "./scout-queue-windows.ts";
 import type { ScoutQueueWindowsResult } from "#activities/scout-queue-windows.ts";
 import type { ScoutShowcaseRefreshResult } from "#activities/scout-showcase-refresh.ts";
-import type { ScoutWeeklyParlayWorkflowInput } from "./scout-weekly-parlay.ts";
+import type {
+  ScoutWeeklyParlayCatchupWorkflowInput,
+  ScoutWeeklyParlayWorkflowInput,
+} from "./scout-weekly-parlay.ts";
 import { runScoutSeasonRefreshWorkflow as _runScoutSeasonRefreshWorkflow } from "./scout-season-refresh.ts";
 import type {
   ScoutSeasonRefreshInput,
@@ -246,6 +252,12 @@ export async function runScoutWeeklyParlayWorkflow(
   input: ScoutWeeklyParlayWorkflowInput = {},
 ): Promise<void> {
   return _runScoutWeeklyParlayWorkflow(input);
+}
+
+export async function runScoutWeeklyParlayCatchupWorkflow(
+  input: ScoutWeeklyParlayCatchupWorkflowInput,
+): Promise<void> {
+  return _runScoutWeeklyParlayCatchupWorkflow(input);
 }
 
 export async function runScoutQueueWindowsWatch(): Promise<ScoutQueueWindowsResult> {

--- a/packages/temporal/src/workflows/scout-weekly-parlay.test.ts
+++ b/packages/temporal/src/workflows/scout-weekly-parlay.test.ts
@@ -5,7 +5,10 @@ import type {
   ScoutWeeklyParlayAction,
   ScoutWeeklyParlayTimeline,
 } from "#activities/scout-weekly-parlay.ts";
-import { runScoutWeeklyParlayWorkflow } from "./scout-weekly-parlay.ts";
+import {
+  runScoutWeeklyParlayCatchupWorkflow,
+  runScoutWeeklyParlayWorkflow,
+} from "./scout-weekly-parlay.ts";
 
 const TASK_QUEUE = "scout-weekly-parlay-test";
 const TIMELINE: ScoutWeeklyParlayTimeline = {
@@ -59,7 +62,7 @@ afterEach(async () => {
 });
 
 describe("runScoutWeeklyParlayWorkflow", () => {
-  test("runs the frozen open, reminder, start, six updates, and final action sequence", async () => {
+  test("runs the frozen standard open, reminder, start, updates, and final action sequence", async () => {
     const actions: ScoutWeeklyParlayAction[] = [];
     let timelineAnchor: string | undefined;
     const worker = await weeklyParlayWorker({
@@ -96,6 +99,68 @@ describe("runScoutWeeklyParlayWorkflow", () => {
         updateIndex,
       })),
       { periodKey: TIMELINE.periodKey, slot: 2, action: "finalize" },
+    ]);
+  }, 30_000);
+
+  test("runs a frozen catch-up timeline and rejects a duplicate workflow ID", async () => {
+    const actions: ScoutWeeklyParlayAction[] = [];
+    let timelineAnchor: string | undefined;
+    const catchupTimeline: ScoutWeeklyParlayTimeline = {
+      periodKey: "2026-08-24",
+      openAt: "2026-08-29T23:00:00.000Z",
+      startsAt: "2026-08-30T07:00:00.000Z",
+      updatesAt: [],
+      finalizesAt: "2026-08-30T18:00:00.000Z",
+    };
+    const worker = await weeklyParlayWorker({
+      resolveScoutWeeklyParlayCatchupTimeline: (workflowStartAt: string) => {
+        timelineAnchor = workflowStartAt;
+        return catchupTimeline;
+      },
+      invokeScoutWeeklyParlayAction: (action: ScoutWeeklyParlayAction) => {
+        actions.push(action);
+        return { status: "reconciled", detail: action.action };
+      },
+    });
+
+    const catchupWorkflowId = "scout-weekly-parlay-catchup-2026-08-24-3";
+    const catchupHandle = await testEnvironment.client.workflow.start(
+      runScoutWeeklyParlayCatchupWorkflow,
+      {
+        args: [{ periodKey: catchupTimeline.periodKey, slot: 3 }],
+        taskQueue: TASK_QUEUE,
+        workflowId: catchupWorkflowId,
+      },
+    );
+    await expect(
+      testEnvironment.client.workflow.start(
+        runScoutWeeklyParlayCatchupWorkflow,
+        {
+          args: [{ periodKey: catchupTimeline.periodKey, slot: 3 }],
+          taskQueue: TASK_QUEUE,
+          workflowId: catchupWorkflowId,
+        },
+      ),
+    ).rejects.toThrow();
+    await worker.runUntil(catchupHandle.result());
+
+    const description = await catchupHandle.describe();
+    expect(timelineAnchor).toBe(description.startTime.toISOString());
+    expect(actions).toEqual([
+      {
+        periodKey: catchupTimeline.periodKey,
+        slot: 3,
+        action: "open",
+        window: {
+          kind: "catch_up",
+          openAt: catchupTimeline.openAt,
+          bettingClosesAt: catchupTimeline.startsAt,
+          scoringStartsAt: catchupTimeline.startsAt,
+          scoringEndsAt: catchupTimeline.finalizesAt,
+        },
+      },
+      { periodKey: catchupTimeline.periodKey, slot: 3, action: "start" },
+      { periodKey: catchupTimeline.periodKey, slot: 3, action: "finalize" },
     ]);
   }, 30_000);
 

--- a/packages/temporal/src/workflows/scout-weekly-parlay.ts
+++ b/packages/temporal/src/workflows/scout-weekly-parlay.ts
@@ -10,6 +10,7 @@ import { WEEKLY_PARLAY_LIFECYCLE } from "@scout-for-lol/data/model/weekly-parlay
 import type {
   ScoutWeeklyParlayAction,
   ScoutWeeklyParlayActivities,
+  ScoutWeeklyParlayTimeline,
 } from "#activities/scout-weekly-parlay.ts";
 
 const deliveryActivities = proxyActivities<ScoutWeeklyParlayActivities>({
@@ -52,6 +53,15 @@ const ScoutWeeklyParlayWorkflowInputSchema = z.strictObject({
 });
 export type ScoutWeeklyParlayWorkflowInput = z.input<
   typeof ScoutWeeklyParlayWorkflowInputSchema
+>;
+
+const ScoutWeeklyParlayCatchupWorkflowInputSchema = z.strictObject({
+  periodKey: z.iso.date(),
+  slot: z.number().int().nonnegative().default(WEEKLY_PARLAY_LIFECYCLE.slot),
+  phase: z.enum(["lifecycle", "finalize"]).default("lifecycle"),
+});
+export type ScoutWeeklyParlayCatchupWorkflowInput = z.input<
+  typeof ScoutWeeklyParlayCatchupWorkflowInputSchema
 >;
 
 async function sleepUntil(timestamp: string): Promise<void> {
@@ -127,6 +137,7 @@ async function reconcileStartUntilFinalization(
 
 async function reconcileFinalization(
   action: ScoutWeeklyParlayAction,
+  mode: "standard" | "catch_up",
 ): Promise<void> {
   const retryUntil = Date.now() + FINALIZATION_CONTINUE_AS_NEW_AFTER_MS;
   while (Date.now() < retryUntil) {
@@ -161,53 +172,53 @@ async function reconcileFinalization(
     periodKey: action.periodKey,
     slot: action.slot,
   });
-  await continueAsNew<typeof runScoutWeeklyParlayWorkflow>({
-    slot: action.slot,
-    phase: "finalize",
-    periodKey: action.periodKey,
-  });
+  if (mode === "catch_up") {
+    await continueAsNew<typeof runScoutWeeklyParlayCatchupWorkflow>({
+      slot: action.slot,
+      phase: "finalize",
+      periodKey: action.periodKey,
+    });
+  } else {
+    await continueAsNew<typeof runScoutWeeklyParlayWorkflow>({
+      slot: action.slot,
+      phase: "finalize",
+      periodKey: action.periodKey,
+    });
+  }
 }
 
-export async function runScoutWeeklyParlayWorkflow(
-  rawInput: ScoutWeeklyParlayWorkflowInput = {},
+async function runFrozenTimeline(
+  timeline: ScoutWeeklyParlayTimeline,
+  slot: number,
+  mode: "standard" | "catch_up",
 ): Promise<void> {
-  const input = ScoutWeeklyParlayWorkflowInputSchema.parse(rawInput);
-  if (input.phase === "finalize") {
-    if (input.periodKey === undefined) {
-      throw new Error("Finalization continuation requires periodKey.");
-    }
-    await reconcileFinalization({
-      periodKey: input.periodKey,
-      slot: input.slot,
-      action: "finalize",
-    });
-    return;
-  }
-  // Temporal records this instant when the Schedule starts the execution. It
-  // remains stable even if no worker can process the first task until later.
-  const scheduledStartAt = workflowInfo().startTime.toISOString();
-  const timeline =
-    await deliveryActivities.resolveScoutWeeklyParlayTimeline(scheduledStartAt);
-  const base = { periodKey: timeline.periodKey, slot: input.slot };
+  const base = { periodKey: timeline.periodKey, slot };
 
   await sleepUntil(timeline.openAt);
   await invokeDeliveryAction({
     ...base,
     action: "open",
+    ...(mode === "catch_up"
+      ? {
+          window: {
+            kind: "catch_up" as const,
+            openAt: timeline.openAt,
+            bettingClosesAt: timeline.startsAt,
+            scoringStartsAt: timeline.startsAt,
+            scoringEndsAt: timeline.finalizesAt,
+          },
+        }
+      : {}),
   });
 
-  await sleepUntil(timeline.reminderAt);
-  await invokeDeliveryAction({
-    ...base,
-    action: "reminder",
-  });
+  if (timeline.reminderAt !== undefined) {
+    await sleepUntil(timeline.reminderAt);
+    await invokeDeliveryAction({ ...base, action: "reminder" });
+  }
 
   await sleepUntil(timeline.startsAt);
   await reconcileStartUntilFinalization(
-    {
-      ...base,
-      action: "start",
-    },
+    { ...base, action: "start" },
     timeline.finalizesAt,
   );
 
@@ -221,8 +232,55 @@ export async function runScoutWeeklyParlayWorkflow(
   }
 
   await sleepUntil(timeline.finalizesAt);
-  await reconcileFinalization({
-    ...base,
-    action: "finalize",
-  });
+  await reconcileFinalization({ ...base, action: "finalize" }, mode);
+}
+
+export async function runScoutWeeklyParlayWorkflow(
+  rawInput: ScoutWeeklyParlayWorkflowInput = {},
+): Promise<void> {
+  const input = ScoutWeeklyParlayWorkflowInputSchema.parse(rawInput);
+  if (input.phase === "finalize") {
+    if (input.periodKey === undefined) {
+      throw new Error("Finalization continuation requires periodKey.");
+    }
+    await reconcileFinalization(
+      {
+        periodKey: input.periodKey,
+        slot: input.slot,
+        action: "finalize",
+      },
+      "standard",
+    );
+    return;
+  }
+  // Temporal records this instant when the Schedule starts the execution. It
+  // remains stable even if no worker can process the first task until later.
+  const scheduledStartAt = workflowInfo().startTime.toISOString();
+  const timeline =
+    await deliveryActivities.resolveScoutWeeklyParlayTimeline(scheduledStartAt);
+  await runFrozenTimeline(timeline, input.slot, "standard");
+}
+
+export async function runScoutWeeklyParlayCatchupWorkflow(
+  rawInput: ScoutWeeklyParlayCatchupWorkflowInput,
+): Promise<void> {
+  const input = ScoutWeeklyParlayCatchupWorkflowInputSchema.parse(rawInput);
+  if (input.phase === "finalize") {
+    await reconcileFinalization(
+      {
+        periodKey: input.periodKey,
+        slot: input.slot,
+        action: "finalize",
+      },
+      "catch_up",
+    );
+    return;
+  }
+  const workflowStartAt = workflowInfo().startTime.toISOString();
+  const timeline =
+    await deliveryActivities.resolveScoutWeeklyParlayCatchupTimeline(
+      workflowStartAt,
+      input.periodKey,
+    );
+  await runFrozenTimeline(timeline, input.slot, "catch_up");
 }


### PR DESCRIPTION
## Why

Scout's first weekly Bryan Bucks parlay missed its normal Sunday opening while
the recurring Temporal schedule remained paused. We need a reusable recovery
path for this week without changing the ordinary Sunday schedule or exposing a
broad manual market API.

## What

- Adds `runScoutWeeklyParlayCatchupWorkflow`, a manually started Temporal
  workflow whose timeline is frozen from its recorded workflow start. It picks
  the first Pacific midnight at least six hours plus the bounded generation
  budget away, then reconciles through the existing Sunday 11:00 AM cutoff.
- Extends only the authenticated Scout `open` action with a strict catch-up
  clock object. Later actions read the immutable clocks from the persisted
  definition; conflicting period/slot retries fail instead of rewriting a
  market.
- Replays the shortened weekday/hour shape across aligned Pacific history,
  preserving zero-game windows, full-account coverage, cooldowns,
  deterministic ordering, and the existing 40–60% empirical publication gate.
- Reuses the existing betting, contribution, ledger, early-YES-only,
  settlement, refund, nonce, and feature-flag boundaries. No table, flag,
  credential, or recurring schedule changes are introduced.
- Labels catch-up Discord messages and renders the authoritative betting and
  scoring timestamps. Updates `/bb rules`, the Bryan Bucks reference, Scout and
  Temporal agent guidance, and the Temporal workflow reference.

## Verification

- `bunx turbo run test --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@shepherdjerred/temporal`
  - Scout backend: 256 files / 2,295 tests passed
  - Temporal time-skipping suite: 14 files / 51 tests passed
  - Scout data and Temporal unit suites passed
- Focused changed-path Scout tests: 4 files / 47 tests passed
- Focused weekly Temporal time-skipping tests: 1 file / 4 tests passed
- Focused package lint and typecheck passed for Scout data/backend/docs,
  Temporal, and the human wiki.
- Scout docs and human wiki production builds passed.
- `bunx lefthook run pre-commit`

Live BETA deployment, the `2026-08-24` catch-up start, and the recurring
schedule unpause were intentionally not run before merge.

## Rollout

1. Merge and wait for both BETA Scout and Temporal to deploy the exact merge.
2. Verify both workloads are healthy.
3. Start workflow ID `scout-weekly-parlay-catchup-2026-08-24-0` with
   `{"periodKey":"2026-08-24","slot":0}` and reject duplicate IDs.
4. Confirm the Discord market appears, accepts bets, and reaches active state
   at the frozen Pacific midnight.
5. Unpause `scout-weekly-parlay` with an operator reason so the normal Sunday
   schedule creates the `2026-08-31` market.
6. Monitor nightly progress and final settlement; pause the recurring schedule
   again if the live lifecycle exposes a settlement or delivery failure.

## Evidence

Fixture Discord opening, progress, and settlement evidence will be attached
before this draft is promoted for review.