### PR TITLE
fix(macos-ai-subscription-tracker): use stable local signing identities

### DIFF
--- a/packages/macos-ai-subscription-tracker/README.md
+++ b/packages/macos-ai-subscription-tracker/README.md
@@ -30,9 +30,11 @@ bun run install:macos
 `verify:macos` runs Swift format lint, strict SwiftLint, warnings-as-errors
 tests, the 80% `QuotaBarCore` coverage gate, a release build, app bundling,
 `plutil`, asset checks, and strict code-signature verification. The bundle is
-written to `dist/QuotaBar.app` and ad-hoc signed by default. Set
-`QUOTABAR_CODESIGN_IDENTITY` to a Developer ID Application identity when one is
-available.
+written to `dist/QuotaBar.app` and uses the installed Developer ID Application
+identity automatically when exactly one is available. Set
+`QUOTABAR_CODESIGN_IDENTITY` to an identity hash or name to select a specific
+certificate; machines without a Developer ID identity continue to use an
+ad-hoc local bundle.
 
 `install:macos` is an explicit opt-in operation. It verifies the bundle, then
 replaces the exact target `/Applications/Brim.app` and launches it. It removes

--- a/packages/macos-ai-subscription-tracker/scripts/build-app.ts
+++ b/packages/macos-ai-subscription-tracker/scripts/build-app.ts
@@ -105,7 +105,7 @@ try {
   await rm(temporaryDirectory, { recursive: true, force: true });
 }
 
-const identity = Bun.env.QUOTABAR_CODESIGN_IDENTITY ?? "-";
+const identity = signingIdentity();
 run(["codesign", "--force", "--deep", "--sign", identity, appPath]);
 console.log(`Built and signed ${appPath}`);
 
@@ -117,4 +117,38 @@ function runCapture(command: string[]) {
   });
   if (result.exitCode !== 0) process.exit(result.exitCode);
   return result.stdout.toString().trim();
+}
+
+function signingIdentity(): string {
+  const configuredIdentity = Bun.env.QUOTABAR_CODESIGN_IDENTITY;
+  if (configuredIdentity !== undefined) {
+    if (configuredIdentity.trim().length === 0)
+      throw new Error("QUOTABAR_CODESIGN_IDENTITY cannot be empty.");
+    return configuredIdentity;
+  }
+
+  const identities = runCapture([
+    "security",
+    "find-identity",
+    "-v",
+    "-p",
+    "codesigning",
+  ])
+    .split("\n")
+    .flatMap((line) => {
+      const match =
+        /^\s*\d+\)\s+([0-9A-F]{40})\s+\"Developer ID Application:/.exec(line);
+      if (match === null) return [];
+      const identity = match[1];
+      return identity === undefined ? [] : [identity];
+    });
+
+  if (identities.length > 1) {
+    throw new Error(
+      "Multiple Developer ID Application identities are installed; set " +
+        "QUOTABAR_CODESIGN_IDENTITY to the intended identity hash.",
+    );
+  }
+
+  return identities[0] ?? "-";
 }


### PR DESCRIPTION
## Why

The local Brim bundle script defaulted to ad-hoc signing even when a Developer ID certificate was installed. Rebuilding could therefore invalidate Keychain approvals and trigger repeated credential prompts.

## What

- Automatically select the sole installed Developer ID Application identity by hash.
- Preserve `QUOTABAR_CODESIGN_IDENTITY` as an explicit override.
- Reject ambiguous certificate selection instead of silently choosing one.
- Keep ad-hoc signing as the clean-machine fallback and document the behavior.

## Verification

- `bun run bundle:macos`
- `bun run install:macos`
- `bun run verify:bundle`
- `/Applications/Brim.app` reports Developer ID Application signing with TeamIdentifier `63ZAG7X889`.
- `bunx lefthook run pre-commit`

Full repository verification and notarization were not run.