### PR TITLE
feat(homelab): sync dedicated PostHog Tofu credentials

### DIFF
--- a/packages/dotfiles/private_dot_config/private_fish/config.fish.tmpl
+++ b/packages/dotfiles/private_dot_config/private_fish/config.fish.tmpl
@@ -65,9 +65,10 @@ set -gx HASS_TOKEN '{{ onepasswordRead "op://yx6je6mgj2oiss6z5bm42h3cxy/y4c2gno3
 set -gx HASS_BASE_URL 'https://homeassistant.sjer.red'
 set -gx LINEAR_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/iixelnobjabehkgxhl3ekacdy4/LINEAR_API_KEY" }}'
 # posthog-cli reads POSTHOG_CLI_*, not the POSTHOG_API_KEY label the value is
-# stored under. These are the shared project-scoped credentials for the CLI tools.
-set -gx POSTHOG_CLI_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/iixelnobjabehkgxhl3ekacdy4/POSTHOG_API_KEY" }}'
+# stored under. The dedicated item also supplies the encrypted state passphrase.
+set -gx POSTHOG_CLI_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/yh3xvqemmr4ic2up5zluo2rkcq/POSTHOG_API_KEY" }}'
 set -gx POSTHOG_CLI_PROJECT_ID '549883'
+set -gx POSTHOG_TOFU_STATE_PASSPHRASE '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/yh3xvqemmr4ic2up5zluo2rkcq/POSTHOG_TOFU_STATE_PASSPHRASE" }}'
 # Deliberately NOT named CLOUDFLARE_API_TOKEN. src/tofu/cloudflare authenticates
 # from that name ambiently, so exporting it globally would let a bare `tofu apply`
 # with no `op run` authenticate and apply instead of failing closed. ~/.local/bin/cf

--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-24T06:17:55.749Z",
+  "generatedAt": "2026-08-24T21:16:42.640Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -55,6 +55,18 @@
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
         "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+      ]
+    },
+    {
+      "ref": "117b1af8161f886135faccb8457fa6aff688cf4136f6511bdca4379cfe505f50",
+      "title": "c835b9accd074310c9fcd44ed62efb6a1e3dee1c8422353187689ca87900a4f9",
+      "fields": [
+        "2630df56173be52531b43917ae41d060109021a204999d5b59e7514c7844810e",
+        "3b2b663a9f65276c859d9f71f9e84be697095a362515d2cbe19cc2891c4683c4",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ]
     },
     {
@@ -445,7 +457,6 @@
       "title": "a8e7536eb0c3913bc363dac0c0b9d626206eaf589a824eb63dc86098175be11d",
       "fields": [
         "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
-        "2630df56173be52531b43917ae41d060109021a204999d5b59e7514c7844810e",
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
         "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8",
         "fd20618c32ad05f0a4d62640eb6180a43e71668bb989a2dc151ef24435a64bb2"

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
@@ -92,6 +92,22 @@ const TempoConfigMapSchema = z
   })
   .loose();
 
+const PostHogTofuCredentialsSchema = z
+  .object({
+    apiVersion: z.literal("onepassword.com/v1"),
+    kind: z.literal("OnePasswordItem"),
+    metadata: z.object({
+      name: z.literal("posthog-tofu-credentials"),
+      namespace: z.literal("buildkite"),
+    }),
+    spec: z.object({
+      itemPath: z.literal(
+        "vaults/v64ocnykdqju4ui6j6pua56xw4/items/yh3xvqemmr4ic2up5zluo2rkcq",
+      ),
+    }),
+  })
+  .loose();
+
 function synthBuildkiteResources() {
   const chart = Testing.chart();
   createBuildkiteApp(chart);
@@ -211,6 +227,15 @@ it("uses the Tempo 3 configuration schema for the E2E sidecar", () => {
   expect(tempoConfig).toContain("distributor:");
   expect(tempoConfig).toContain("storage:");
   expect(tempoConfig).not.toMatch(/^(?:ingester|compactor):/mu);
+});
+
+it("syncs the dedicated PostHog OpenTofu credentials", () => {
+  const { resources } = synthBuildkiteResources();
+  expect(
+    resources.some(
+      (manifest) => PostHogTofuCredentialsSchema.safeParse(manifest).success,
+    ),
+  ).toBe(true);
 });
 
 describe("Buildkite application", () => {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -80,6 +80,17 @@ export function createBuildkiteApp(chart: Chart) {
     },
   });
 
+  new OnePasswordItem(chart, "posthog-tofu-credentials", {
+    spec: {
+      itemPath:
+        "vaults/v64ocnykdqju4ui6j6pua56xw4/items/yh3xvqemmr4ic2up5zluo2rkcq",
+    },
+    metadata: {
+      name: "posthog-tofu-credentials",
+      namespace: "buildkite",
+    },
+  });
+
   // Default resource requests/limits for any generated sidecar that doesn't set its
   // own resources. The known agent and checkout containers are patched explicitly
   // below; this LimitRange remains a fail-safe for new containers introduced by the


### PR DESCRIPTION
## Why

PostHog OpenTofu plans and applies need a project API key and state-encryption passphrase. Those credentials must reach only the dedicated Tofu jobs, and the Kubernetes Secret must be created through ArgoCD rather than a direct bootstrap.

## What

- Create a dedicated two-field 1Password item and declare it as `buildkite/posthog-tofu-credentials`.
- Point local Fish PostHog references at that dedicated item.
- Refresh the value-free, hashed 1Password vault snapshot.
- Assert the synthesized `OnePasswordItem` name, namespace, and item path.

## Verification

- `bun run scripts/check-1password-items.ts`
- `bun test src/resources/argo-applications/buildkite.test.ts scripts/check-1password-items.test.ts`
- `bun run typecheck`
- Pre-commit: environment names, large files, merge markers, line endings, suppression policy, Prettier, and Gitleaks passed.

## Rollout

This is the prerequisite for the upper PostHog OpenTofu PR. After this merges, wait for the exact-main ArgoCD release to sync `posthog-tofu-credentials`, then verify only the Secret's key names before enabling PostHog CI. No credential values are committed or printed.
