### PR TITLE
feat(homelab): manage PostHog with OpenTofu

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -264,9 +264,8 @@ common:
                   readOnly: true
                 - name: buildkite-tofu-plugin-cache
                   mountPath: /buildkite/tofu-plugin-cache
-  # Main-only PostHog apply runs trusted code after release admission. Keep
-  # both explicit PostHog fields here so a future field on the item cannot
-  # leak into the process, and keep this anchor separate from PR validation.
+  # Main-only PostHog plan/apply runs trusted code after release admission.
+  # Keep every credential explicit so unrelated fields cannot enter the pod.
   - pod_posthog_tofu_apply: &pod_posthog_tofu_apply
       kubernetes: &pod_posthog_tofu_apply_kubernetes
         checkout:
@@ -285,6 +284,16 @@ common:
               env:
                 - name: BUILDKITE_SHELL
                   value: "/bin/bash -e -c"
+                - name: SEAWEEDFS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: buildkite-ci-secrets
+                      key: SEAWEEDFS_ACCESS_KEY_ID
+                - name: SEAWEEDFS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: buildkite-ci-secrets
+                      key: SEAWEEDFS_SECRET_ACCESS_KEY
                 - name: POSTHOG_CLI_API_KEY
                   valueFrom:
                     secretKeyRef:
@@ -305,8 +314,6 @@ common:
                   readOnly: true
                 - name: buildkite-tofu-plugin-cache
                   mountPath: /buildkite/tofu-plugin-cache
-              envFrom:
-                - secretRef: { name: buildkite-ci-secrets }
   # The combined PR deploy rehearsal needs the OpenTofu provider cache but its
   # measured command-container working set is higher than the light Tofu lanes.
   - pod_pr_dryrun: &pod_pr_dryrun
@@ -1861,6 +1868,7 @@ steps:
         export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
         export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
         flock -x 9
+        bun --no-install packages/homelab/scripts/tofu-stack.ts posthog plan
         bun --no-install packages/homelab/scripts/tofu-stack.ts posthog apply
       ) 9>/buildkite/tofu-plugin-cache/.lock
     retry: *retry

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -233,11 +233,42 @@ common:
                   mountPath: /buildkite/tofu-plugin-cache
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
-  # PostHog state credentials have a narrower boundary than the shared CI
-  # secret: only this pod maps the API key and state passphrase, and each key
-  # is explicit so a future field on the item cannot leak into the container.
+  # Untrusted PR validation must not receive PostHog credentials or the shared
+  # CI secret. It only runs backend-free OpenTofu validation with a
+  # non-sensitive encryption placeholder.
   - pod_posthog_tofu: &pod_posthog_tofu
       kubernetes: &pod_posthog_tofu_kubernetes
+        checkout:
+          cloneFlags: "--no-tags"
+        podSpecPatch:
+          serviceAccountName: buildkite-agent-stack-k8s-controller
+          volumes:
+            - name: buildkite-tofu-plugin-cache
+              persistentVolumeClaim:
+                claimName: buildkite-tofu-plugin-cache
+          containers:
+            - *checkout_container
+            - name: container-0
+              image: "${CI_BASE_IMAGE}"
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: BUILDKITE_SHELL
+                  value: "/bin/bash -e -c"
+              resources:
+                requests:
+                  { cpu: "250m", memory: "512Mi", ephemeral-storage: "1Gi" }
+                limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "20Gi" }
+              volumeMounts:
+                - name: buildkite-git-mirrors
+                  mountPath: /buildkite/git-mirrors
+                  readOnly: true
+                - name: buildkite-tofu-plugin-cache
+                  mountPath: /buildkite/tofu-plugin-cache
+  # Main-only PostHog apply runs trusted code after release admission. Keep
+  # both explicit PostHog fields here so a future field on the item cannot
+  # leak into the process, and keep this anchor separate from PR validation.
+  - pod_posthog_tofu_apply: &pod_posthog_tofu_apply
+      kubernetes: &pod_posthog_tofu_apply_kubernetes
         checkout:
           cloneFlags: "--no-tags"
         podSpecPatch:
@@ -1380,10 +1411,9 @@ steps:
       export CI_CHANGED_BASE
       if ! bun --no-install .buildkite/scripts/ci-changed.ts tofu-posthog; then exit 0; fi
       (
-        export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
         export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
         flock -x 9
-        bun --no-install packages/homelab/scripts/tofu-stack.ts posthog plan
+        bun --no-install packages/homelab/scripts/tofu-stack.ts posthog validate
       ) 9>/buildkite/tofu-plugin-cache/.lock
     retry: *retry
     plugins:
@@ -1836,7 +1866,7 @@ steps:
     retry: *retry
     plugins:
       - kubernetes:
-          <<: *pod_posthog_tofu_kubernetes
+          <<: *pod_posthog_tofu_apply_kubernetes
           metadata:
             labels:
               ci.sjer.red/step-key: tofu-posthog

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -233,6 +233,49 @@ common:
                   mountPath: /buildkite/tofu-plugin-cache
               envFrom:
                 - secretRef: { name: buildkite-ci-secrets }
+  # PostHog state credentials have a narrower boundary than the shared CI
+  # secret: only this pod maps the API key and state passphrase, and each key
+  # is explicit so a future field on the item cannot leak into the container.
+  - pod_posthog_tofu: &pod_posthog_tofu
+      kubernetes: &pod_posthog_tofu_kubernetes
+        checkout:
+          cloneFlags: "--no-tags"
+        podSpecPatch:
+          serviceAccountName: buildkite-agent-stack-k8s-controller
+          volumes:
+            - name: buildkite-tofu-plugin-cache
+              persistentVolumeClaim:
+                claimName: buildkite-tofu-plugin-cache
+          containers:
+            - *checkout_container
+            - name: container-0
+              image: "${CI_BASE_IMAGE}"
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: BUILDKITE_SHELL
+                  value: "/bin/bash -e -c"
+                - name: POSTHOG_CLI_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: posthog-tofu-credentials
+                      key: POSTHOG_API_KEY
+                - name: POSTHOG_TOFU_STATE_PASSPHRASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: posthog-tofu-credentials
+                      key: POSTHOG_TOFU_STATE_PASSPHRASE
+              resources:
+                requests:
+                  { cpu: "250m", memory: "512Mi", ephemeral-storage: "1Gi" }
+                limits: { cpu: "7", memory: "12Gi", ephemeral-storage: "20Gi" }
+              volumeMounts:
+                - name: buildkite-git-mirrors
+                  mountPath: /buildkite/git-mirrors
+                  readOnly: true
+                - name: buildkite-tofu-plugin-cache
+                  mountPath: /buildkite/tofu-plugin-cache
+              envFrom:
+                - secretRef: { name: buildkite-ci-secrets }
   # The combined PR deploy rehearsal needs the OpenTofu provider cache but its
   # measured command-container working set is higher than the light Tofu lanes.
   - pod_pr_dryrun: &pod_pr_dryrun
@@ -1297,6 +1340,59 @@ steps:
             labels:
               ci.sjer.red/step-key: pr-dryrun
 
+  # PostHog requires its own credential boundary, so it cannot join the shared
+  # PR dry-run pod. The generic Tofu plan above continues to cover Cloudflare.
+  - label: ":terraform: OpenTofu plan — PostHog control plane"
+    key: tofu-posthog-plan
+    timeout_in_minutes: 60
+    if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
+    if_changed:
+      include:
+        - ".buildkite/main-bootstrap.yml"
+        - ".buildkite/pipeline.yml"
+        - ".buildkite/scripts/buildkite-handoff.ts"
+        - ".buildkite/scripts/ci-changed.ts"
+        - ".buildkite/scripts/migration-core.ts"
+        - ".buildkite/scripts/prepare-ci-changed-base.ts"
+        - ".buildkite/scripts/read-buildkite-handoff.ts"
+        - ".buildkite/scripts/select-main-pipeline.ts"
+        - ".buildkite/scripts/upload-pipeline.sh"
+        - "bun.lock"
+        - "bunfig.toml"
+        - "package.json"
+        - "patches/**"
+        - "turbo.json"
+        - "packages/homelab/src/tofu/posthog/**"
+        - "packages/homelab/scripts/tofu-stack.ts"
+        - "packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts"
+        - "packages/homelab/src/cdk8s/onepassword-vault-snapshot.json"
+        - "scripts/lib/run.ts"
+        - "scripts/lib/transient.ts"
+        - "config/analytics-sites.json"
+    depends_on: verify
+    cancel_on_build_failing: true
+    command: |
+      . .buildkite/scripts/toolchain.sh
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter homelab --production
+      if ! CI_CHANGED_BASE=$(git merge-base origin/main HEAD); then
+        CI_CHANGED_BASE=""
+      fi
+      export CI_CHANGED_BASE
+      if ! bun --no-install .buildkite/scripts/ci-changed.ts tofu-posthog; then exit 0; fi
+      (
+        export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
+        export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
+        flock -x 9
+        bun --no-install packages/homelab/scripts/tofu-stack.ts posthog plan
+      ) 9>/buildkite/tofu-plugin-cache/.lock
+    retry: *retry
+    plugins:
+      - kubernetes:
+          <<: *pod_posthog_tofu_kubernetes
+          metadata:
+            labels:
+              ci.sjer.red/step-key: tofu-posthog-plan
+
   - label: ":docker: images — build + smoke (PR dry-run)"
     key: images-pr
     timeout_in_minutes: 60
@@ -1713,6 +1809,38 @@ steps:
             labels:
               ci.sjer.red/step-key: tofu-github
 
+  - label: ":terraform: OpenTofu apply — PostHog control plane"
+    key: tofu-posthog
+    timeout_in_minutes: 60
+    if: build.branch == pipeline.default_branch
+    depends_on: homelab-release-admission
+    cancel_on_build_failing: true
+    concurrency: 1
+    concurrency_group: monorepo/tofu-posthog
+    command: |
+      release_admission=$$(bun --no-install .buildkite/scripts/homelab-release-admission.ts consume)
+      if [ "$$release_admission" = "superseded" ]; then exit 0; fi
+      if [ "$$release_admission" != "admitted" ]; then
+        echo "invalid homelab release admission outcome: $$release_admission"
+        exit 1
+      fi
+      if ! bun --no-install .buildkite/scripts/ci-changed.ts tofu-posthog; then exit 0; fi
+      . .buildkite/scripts/toolchain.sh
+      .buildkite/scripts/bun-install.sh --frozen-lockfile --filter homelab --production
+      (
+        export AWS_ACCESS_KEY_ID="$$SEAWEEDFS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$$SEAWEEDFS_SECRET_ACCESS_KEY"
+        export TF_PLUGIN_CACHE_DIR=/buildkite/tofu-plugin-cache
+        flock -x 9
+        bun --no-install packages/homelab/scripts/tofu-stack.ts posthog apply
+      ) 9>/buildkite/tofu-plugin-cache/.lock
+    retry: *retry
+    plugins:
+      - kubernetes:
+          <<: *pod_posthog_tofu_kubernetes
+          metadata:
+            labels:
+              ci.sjer.red/step-key: tofu-posthog
+
   - label: ":argo: sync + wait"
     key: argocd-sync
     timeout_in_minutes: 60
@@ -2022,6 +2150,7 @@ steps:
       - helm-push
       - tofu-apply
       - tofu-github
+      - tofu-posthog
       - argocd-sync
       - scout-beta-release
       - publish

--- a/.buildkite/scripts/ci-lane-coverage.test.ts
+++ b/.buildkite/scripts/ci-lane-coverage.test.ts
@@ -74,6 +74,7 @@ const LANE_TO_STEP: Record<string, string | null> = {
   "ci-playwright": null,
   "helm-types": "pr-dryrun",
   tofu: "pr-dryrun",
+  "tofu-posthog": "tofu-posthog-plan",
   helm: "pr-dryrun",
   argocd: "pr-dryrun",
   npm: "pr-dryrun",

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -18,6 +18,7 @@ const FIXED_CORPUS_LANES: ReadonlySet<string> = new Set([
   "playwright",
   "resume",
   "tofu",
+  "tofu-posthog",
 ]);
 
 export class FixedCorpusConfigurationError extends Error {}
@@ -183,6 +184,7 @@ export const summarySteps = [
   "helm-push",
   "tofu-apply",
   "tofu-github",
+  "tofu-posthog",
   "argocd-sync",
   "scout-beta-release",
   "publish",
@@ -214,6 +216,7 @@ export const summaryLanes = [
   "tofu",
   "argocd",
   "helm-types",
+  "tofu-posthog",
   "npm",
   "cooklang",
   "scout-reconcile",
@@ -368,6 +371,16 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
     "packages/homelab/scripts/tofu-stack.ts",
     "scripts/lib/run.ts",
     "scripts/lib/transient.ts",
+  ],
+  "tofu-posthog": [
+    ...workspacePaths,
+    "packages/homelab/src/tofu/posthog",
+    "packages/homelab/scripts/tofu-stack.ts",
+    "packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts",
+    "packages/homelab/src/cdk8s/onepassword-vault-snapshot.json",
+    "scripts/lib/run.ts",
+    "scripts/lib/transient.ts",
+    "config/analytics-sites.json",
   ],
   helm: [
     ...workspacePaths,

--- a/.buildkite/scripts/select-main-pipeline.ts
+++ b/.buildkite/scripts/select-main-pipeline.ts
@@ -56,6 +56,7 @@ const STEP_LANE_REQUIREMENTS: Readonly<Record<string, readonly string[]>> = {
   "helm-push": ["helm", "argocd", "images"],
   "tofu-apply": ["tofu"],
   "tofu-github": ["tofu"],
+  "tofu-posthog": ["tofu-posthog"],
   "argocd-sync": ["helm", "argocd", "images"],
   "tofu-cloudflare": ["tofu", "argocd"],
   "scout-beta-release": ["site-scout", "images"],

--- a/.buildkite/scripts/validate-pipeline-lib.ts
+++ b/.buildkite/scripts/validate-pipeline-lib.ts
@@ -10,6 +10,7 @@ export const SHARED_POD_ANCHORS = [
   "pod_light_kubernetes",
   "pod_release_codex_auth_kubernetes",
   "pod_tofu_kubernetes",
+  "pod_posthog_tofu_kubernetes",
   "pod_pr_dryrun_kubernetes",
 ] as const;
 export const CHECKOUT_CONTAINER_ALIAS = "- *checkout_container";

--- a/.buildkite/scripts/validate-pipeline-lib.ts
+++ b/.buildkite/scripts/validate-pipeline-lib.ts
@@ -11,6 +11,7 @@ export const SHARED_POD_ANCHORS = [
   "pod_release_codex_auth_kubernetes",
   "pod_tofu_kubernetes",
   "pod_posthog_tofu_kubernetes",
+  "pod_posthog_tofu_apply_kubernetes",
   "pod_pr_dryrun_kubernetes",
 ] as const;
 export const CHECKOUT_CONTAINER_ALIAS = "- *checkout_container";

--- a/.buildkite/scripts/validate-pipeline-release.test.ts
+++ b/.buildkite/scripts/validate-pipeline-release.test.ts
@@ -108,6 +108,7 @@ if [ "$$release_admission" != "admitted" ]; then exit 1; fi
       ["helm-push", mutatingStep],
       ["tofu-apply", mutatingStep],
       ["tofu-github", mutatingStep],
+      ["tofu-posthog", mutatingStep],
       [
         "argocd-sync",
         `${mutatingStep}\nbuildkite-agent artifact upload "homelab-release-result.json"`,

--- a/.buildkite/scripts/validate-pipeline-release.ts
+++ b/.buildkite/scripts/validate-pipeline-release.ts
@@ -69,6 +69,7 @@ export function validateHomelabReleaseAdmission(
     "helm-push",
     "tofu-apply",
     "tofu-github",
+    "tofu-posthog",
     "argocd-sync",
     "tofu-cloudflare",
   ]) {

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -111,6 +111,44 @@ configures an explicit local git backend on a ZFS PVC, which is backed up by
 Velero. A regression test asserts that configuration is present, because losing
 it produces a service that looks like it works.
 
+## Analytics has a different ownership boundary
+
+PostHog records behaviour. It is not the switch that decides whether behaviour
+exists. Product rollout therefore remains in Flipt, while PostHog's supported
+control-plane objects live in OpenTofu. That makes dashboards, insights,
+layouts, the project proxy, and their supported settings reviewable rather than
+personal UI state.
+
+This boundary is intentionally selective. A provider cannot represent every
+PostHog setting, so options such as IP anonymisation and retention remain
+UI-managed. Supported resources do not get that exception: a UI edit is drift
+and the next OpenTofu reconciliation restores the reviewed configuration.
+Dashboard layouts deserve special care because the provider treats each layout
+as complete, not partial. A missing tile is therefore a deletion, not an
+unmanaged detail. The [layout resource documentation](https://registry.terraform.io/providers/PostHog/posthog/latest/docs/resources/dashboard_layout)
+explains that authority model.
+
+The allowed browser origins come from the shared
+[analytics registry](https://github.com/shepherdjerred/monorepo/blob/main/config/analytics-sites.json),
+not from a hand-maintained PostHog list. This keeps the project URL policy and
+session-replay policy aligned with the sites that actually emit analytics. The
+unproxied [`j.sjer.red` CNAME](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/tofu/cloudflare/sjer-red.tf)
+is part of the same boundary: Cloudflare routes the hostname, while PostHog owns
+the ProxyHog target behind it.
+
+Analytics state is unusually sensitive because it contains the complete shape
+of the control plane. Its SeaweedFS state and plans use enforced,
+[PBKDF2-derived AES-GCM encryption](https://opentofu.org/docs/v1.12/language/state/encryption/).
+The dedicated passphrase is deliberately not recoverable from the backend. That
+trade rejects convenient emergency access in favour of keeping state useful
+only to the intended operator.
+
+Finally, configuration success is not ingestion success. A clean plan and a
+resolving CNAME show that the control plane agrees with Git. They do not show
+that a browser event arrived or that replay persisted. Live Events across every
+registered site are the acceptance boundary because they observe the product
+path that the configuration exists to support.
+
 ## Where a flag does nothing
 
 Before adding one, check where the value is read:

--- a/packages/homelab/AGENTS.md
+++ b/packages/homelab/AGENTS.md
@@ -307,6 +307,38 @@ missing credential, and that is a deliberate guardrail.
 
 OpenTofu/Terraform state for the `src/tofu/*` stacks is stored in **SeaweedFS** (S3-compatible), not locally. `tofu init` therefore needs AWS credentials for the backend. To validate `.tf` without state access, use `tofu init -backend=false` (syntax) and `tofu validate` (resource schemas).
 
+### PostHog control-plane stack
+
+`src/tofu/posthog/` owns the provider-supported PostHog resources for project
+`549883`, while `src/tofu/cloudflare/sjer-red.tf` owns the unproxied `j.sjer.red`
+ProxyHog CNAME. Its permanent `import` blocks are bootstrap provenance: do not
+replace them with imperative `tofu import` commands or delete them after a
+successful apply.
+
+The stack's SeaweedFS state and saved plans use enforced PBKDF2-derived AES-GCM
+encryption. Supply its passphrase only through `TF_VAR_state_passphrase`; it is
+not recoverable from SeaweedFS or OpenTofu if the passphrase is lost. Never put
+the value in a `.tfvars` file, a shell history argument, or repository content.
+
+`tofu-stack.ts posthog` requires both `POSTHOG_CLI_API_KEY` and
+`POSTHOG_TOFU_STATE_PASSPHRASE`, then maps them to the provider's
+`POSTHOG_API_KEY` and the encryption variable. Buildkite injects those values
+only through explicit keys of `buildkite/posthog-tofu-credentials`; do not add
+them to `buildkite-ci-secrets` or another shared pod template.
+
+After import, OpenTofu is authoritative for supported dashboards, layouts,
+insights, cohort, source, proxy, owner membership, project, and project
+settings. UI edits to those resources are drift. Dashboard layouts are fully
+authoritative, so preserve every existing tile. Unsupported project options
+remain UI-managed. `app_urls` and `recording_domains` are derived from
+`config/analytics-sites.json`; product rollout flags remain in Flipt, not
+PostHog.
+
+Run the dedicated PostHog plan before an apply and treat a no-change plan as
+the ownership check. Source inspection and the proxy CNAME only prove setup;
+runtime acceptance requires Live Events for every registry site, including a
+pageview and a session recording where replay is enabled.
+
 ## R2 orphan cleanup (destructive)
 
 `bun run r2:orphans` (in `src/cdk8s`) permanently deletes ZFS backup data from

--- a/packages/homelab/scripts/tofu-stack.ts
+++ b/packages/homelab/scripts/tofu-stack.ts
@@ -7,9 +7,9 @@
  * Bun script; every credential is a plain env var.
  *
  * Usage:
- *   bun packages/homelab/scripts/tofu-stack.ts <stack> plan|apply [--dry-run]
+ *   bun packages/homelab/scripts/tofu-stack.ts <stack> validate|plan|apply [--dry-run]
  *
- * Env (required):
+ * Env (required for plan/apply):
  *   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY   — S3 backend + provider creds
  *
  * Env (optional — each is wired to its TF var only when present; a
@@ -21,11 +21,12 @@
  *   TF_VAR_PRIVATEHD_PASSWORD, TF_VAR_PRIVATEHD_PID, TF_VAR_AVISTAZ_PASSWORD,
  *   TF_VAR_AVISTAZ_PID, TF_VAR_ANIMEZ_PASSWORD, TF_VAR_ANIMEZ_PID,
  *
- * Env (required for the `posthog` stack only):
+ * Env (required for plan/apply on the `posthog` stack only):
  *   POSTHOG_CLI_API_KEY, POSTHOG_TOFU_STATE_PASSPHRASE
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 import {
   run,
   runAllowExit,
@@ -111,7 +112,8 @@ function buildTofuEnv(stack: string): Record<string, string> {
 
 function usage(): never {
   console.error(
-    "Usage: bun packages/homelab/scripts/tofu-stack.ts <stack> plan|apply " +
+    "Usage: bun packages/homelab/scripts/tofu-stack.ts <stack> " +
+      "validate|plan|apply " +
       "[--dry-run]",
   );
   process.exit(1);
@@ -130,8 +132,10 @@ async function main(): Promise<void> {
     console.error("A stack name is required.");
     usage();
   }
-  if (action !== "plan" && action !== "apply") {
-    console.error(`Action must be "plan" or "apply", got: ${String(action)}`);
+  if (action !== "validate" && action !== "plan" && action !== "apply") {
+    console.error(
+      `Action must be "validate", "plan", or "apply", got: ${String(action)}`,
+    );
     usage();
   }
 
@@ -151,8 +155,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  const env = buildTofuEnv(stack);
-
   // `tofu init` — NOTE: the old code wrapped init in a bounded retry loop to
   // survive slow provider-registry / GitHub release CDN responses. That retry
   // is intentionally OMITTED here: this runs locally under an operator who can
@@ -161,6 +163,41 @@ async function main(): Promise<void> {
   // blindly — a failed apply there can leave GitHub repo/ruleset state
   // half-written, and a naive retry could compound the drift; the operator
   // should inspect and re-run deliberately.
+  if (action === "validate") {
+    // PR validation runs untrusted branch code. It must not receive the
+    // encrypted state passphrase, provider API key, backend credentials, or
+    // any other runtime secret. The placeholder only satisfies the required
+    // encryption variable while backend-free validation checks the HCL and
+    // provider schemas without contacting PostHog.
+    const env: Record<string, string> = {
+      TF_VAR_state_passphrase: "ci-validation-only-placeholder",
+      TF_DATA_DIR: mkdtempSync(`${tmpdir()}/posthog-tofu-validation-`),
+    };
+    const pluginCacheDir = optionalEnv("TF_PLUGIN_CACHE_DIR");
+    if (pluginCacheDir !== null) {
+      env["TF_PLUGIN_CACHE_DIR"] = pluginCacheDir;
+    }
+    await run(
+      [
+        "tofu",
+        `-chdir=${STACKS_REL}/${stack}`,
+        "init",
+        "-backend=false",
+        "-reconfigure",
+        "-input=false",
+      ],
+      { cwd: root, env },
+    );
+    await run(["tofu", `-chdir=${STACKS_REL}/${stack}`, "validate"], {
+      cwd: root,
+      env,
+    });
+    console.log("Validation passed.");
+    return;
+  }
+
+  const env = buildTofuEnv(stack);
+
   await run(["tofu", `-chdir=${STACKS_REL}/${stack}`, "init", "-input=false"], {
     cwd: root,
     env,

--- a/packages/homelab/scripts/tofu-stack.ts
+++ b/packages/homelab/scripts/tofu-stack.ts
@@ -20,6 +20,9 @@
  *   TF_VAR_PROWLARR_API_KEY, TF_VAR_QBITTORRENT_PASSWORD,
  *   TF_VAR_PRIVATEHD_PASSWORD, TF_VAR_PRIVATEHD_PID, TF_VAR_AVISTAZ_PASSWORD,
  *   TF_VAR_AVISTAZ_PID, TF_VAR_ANIMEZ_PASSWORD, TF_VAR_ANIMEZ_PID,
+ *
+ * Env (required for the `posthog` stack only):
+ *   POSTHOG_CLI_API_KEY, POSTHOG_TOFU_STATE_PASSPHRASE
  */
 
 import { existsSync } from "node:fs";
@@ -84,6 +87,17 @@ function buildTofuEnv(stack: string): Record<string, string> {
     env["AWS_DEFAULT_REGION"] = "us-east-1";
     env["AWS_REQUEST_CHECKSUM_CALCULATION"] = "WHEN_REQUIRED";
     env["AWS_RESPONSE_CHECKSUM_VALIDATION"] = "WHEN_REQUIRED";
+  }
+
+  // The PostHog provider uses its standard POSTHOG_API_KEY name, while the
+  // repository's CLI environment deliberately uses POSTHOG_CLI_API_KEY. The
+  // encrypted backend also fails closed unless this stack's passphrase is
+  // supplied; never make either an optional cross-stack secret.
+  if (stack === "posthog") {
+    env["POSTHOG_API_KEY"] = requireEnv("POSTHOG_CLI_API_KEY");
+    env["TF_VAR_state_passphrase"] = requireEnv(
+      "POSTHOG_TOFU_STATE_PASSPHRASE",
+    );
   }
 
   for (const [source, target] of OPTIONAL_SECRET_ENV) {

--- a/packages/homelab/src/tofu/cloudflare/better-skill-capped-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/better-skill-capped-com.tf
@@ -41,6 +41,7 @@ resource "cloudflare_dns_record" "better_skill_capped_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "better_skill_capped_com" {
   zone_id = cloudflare_zone.better_skill_capped_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/clauderon-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/clauderon-com.tf
@@ -115,6 +115,7 @@ resource "cloudflare_dns_record" "clauderon_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "clauderon_com" {
   zone_id = cloudflare_zone.clauderon_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/discord-plays-pokemon-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/discord-plays-pokemon-com.tf
@@ -69,6 +69,7 @@ resource "cloudflare_dns_record" "discord_plays_pokemon_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "discord_plays_pokemon_com" {
   zone_id = cloudflare_zone.discord_plays_pokemon_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/glitter-boys-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/glitter-boys-com.tf
@@ -60,6 +60,7 @@ resource "cloudflare_dns_record" "glitter_boys_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "glitter_boys_com" {
   zone_id = cloudflare_zone.glitter_boys_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/jerred-is.tf
+++ b/packages/homelab/src/tofu/cloudflare/jerred-is.tf
@@ -50,6 +50,13 @@ resource "cloudflare_dns_record" "jerred_is_dkim_wildcard" {
 # DNSSEC (pending — .is TLD requires manual DS record at registrar)
 resource "cloudflare_zone_dnssec" "jerred_is" {
   zone_id = cloudflare_zone.jerred_is.id
+
+  # Cloudflare reports the in-progress delegation as `pending`, but the v5
+  # provider accepts only active or disabled as configuration. Retain the live
+  # value until the parent delegation completes instead of forcing either.
+  lifecycle {
+    ignore_changes = [status]
+  }
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/jerredshepherd-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/jerredshepherd-com.tf
@@ -50,6 +50,7 @@ resource "cloudflare_dns_record" "jerredshepherd_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "jerredshepherd_com" {
   zone_id = cloudflare_zone.jerredshepherd_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/scout-for-lol-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/scout-for-lol-com.tf
@@ -50,6 +50,7 @@ resource "cloudflare_dns_record" "scout_for_lol_com_dkim_wildcard" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "scout_for_lol_com" {
   zone_id = cloudflare_zone.scout_for_lol_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/shepherdjerred-com.tf
+++ b/packages/homelab/src/tofu/cloudflare/shepherdjerred-com.tf
@@ -95,10 +95,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_mx_wildcard2" {
 # ── SRV (FastMail autodiscovery) ────────────────────────────────────────────
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_caldavs" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_caldavs._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_caldavs._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -108,10 +109,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_caldavs" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_caldav" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_caldav._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_caldav._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -121,10 +123,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_caldav" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_carddavs" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_carddavs._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_carddavs._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -134,10 +137,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_carddavs" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_carddav" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_carddav._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_carddav._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -147,10 +151,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_carddav" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_imaps" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_imaps._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_imaps._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -160,10 +165,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_imaps" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_imap" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_imap._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_imap._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -173,10 +179,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_imap" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_pop3s" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_pop3s._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_pop3s._tcp"
+  type     = "SRV"
+  priority = 10
   data = {
     priority = 10
     weight   = 1
@@ -186,10 +193,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_pop3s" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_pop3" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_pop3._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_pop3._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -199,10 +207,11 @@ resource "cloudflare_dns_record" "shepherdjerred_com_srv_pop3" {
 }
 
 resource "cloudflare_dns_record" "shepherdjerred_com_srv_submission" {
-  zone_id = cloudflare_zone.shepherdjerred_com.id
-  ttl     = 1
-  name    = "_submission._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.shepherdjerred_com.id
+  ttl      = 1
+  name     = "_submission._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -232,6 +241,7 @@ resource "cloudflare_dns_record" "shepherdjerred_com_dmarc" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "shepherdjerred_com" {
   zone_id = cloudflare_zone.shepherdjerred_com.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/sjer-red.tf
+++ b/packages/homelab/src/tofu/cloudflare/sjer-red.tf
@@ -14,6 +14,26 @@ resource "cloudflare_dns_record" "sjer_red_cname_apex" {
   proxied = true
 }
 
+# PostHog's managed reverse proxy returns the target CNAME; this record is kept
+# unproxied so PostHog can validate and terminate the analytics proxy directly.
+import {
+  to = cloudflare_dns_record.sjer_red_cname_posthog
+  id = "879487f81194d63121d0b8dddd16f08f/cf96abd1cc751274baa8e16df54e2b45"
+}
+
+resource "cloudflare_dns_record" "sjer_red_cname_posthog" {
+  zone_id = cloudflare_zone.sjer_red.id
+  ttl     = 3600
+  name    = "j"
+  type    = "CNAME"
+  content = "a9373961b1c868668128.cf-prod-us-proxy.proxyhog.com"
+  proxied = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "cloudflare_dns_record" "sjer_red_cname_argocd" {
   zone_id = cloudflare_zone.sjer_red.id
   ttl     = 1
@@ -426,10 +446,11 @@ resource "cloudflare_dns_record" "sjer_red_mx_rp2" {
 # ── SRV (FastMail autodiscovery) ────────────────────────────────────────────
 
 resource "cloudflare_dns_record" "sjer_red_srv_caldavs" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_caldavs._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_caldavs._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -439,10 +460,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_caldavs" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_caldav" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_caldav._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_caldav._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -452,10 +474,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_caldav" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_carddavs" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_carddavs._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_carddavs._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -465,10 +488,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_carddavs" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_carddav" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_carddav._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_carddav._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -478,10 +502,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_carddav" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_imaps" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_imaps._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_imaps._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -491,10 +516,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_imaps" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_imap" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_imap._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_imap._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -504,10 +530,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_imap" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_minecraft" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_minecraft._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_minecraft._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 5
@@ -517,10 +544,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_minecraft" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_minecraft_shuxin" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_minecraft._tcp.shuxin"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_minecraft._tcp.shuxin"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 5
@@ -530,10 +558,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_minecraft_shuxin" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_pop3s" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_pop3s._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_pop3s._tcp"
+  type     = "SRV"
+  priority = 10
   data = {
     priority = 10
     weight   = 1
@@ -543,10 +572,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_pop3s" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_pop3" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_pop3._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_pop3._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 0
@@ -556,10 +586,11 @@ resource "cloudflare_dns_record" "sjer_red_srv_pop3" {
 }
 
 resource "cloudflare_dns_record" "sjer_red_srv_submission" {
-  zone_id = cloudflare_zone.sjer_red.id
-  ttl     = 1
-  name    = "_submission._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.sjer_red.id
+  ttl      = 1
+  name     = "_submission._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 1
@@ -696,6 +727,7 @@ resource "cloudflare_dns_record" "sjer_red_acme_syncthing" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "sjer_red" {
   zone_id = cloudflare_zone.sjer_red.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/cloudflare/ts-mc-net.tf
+++ b/packages/homelab/src/tofu/cloudflare/ts-mc-net.tf
@@ -105,10 +105,11 @@ resource "cloudflare_dns_record" "ts_mc_net_mx_wildcard2" {
 # ── SRV ─────────────────────────────────────────────────────────────────────
 
 resource "cloudflare_dns_record" "ts_mc_net_srv_minecraft" {
-  zone_id = cloudflare_zone.ts_mc_net.id
-  ttl     = 1
-  name    = "_minecraft._tcp"
-  type    = "SRV"
+  zone_id  = cloudflare_zone.ts_mc_net.id
+  ttl      = 1
+  name     = "_minecraft._tcp"
+  type     = "SRV"
+  priority = 0
   data = {
     priority = 0
     weight   = 5
@@ -138,6 +139,7 @@ resource "cloudflare_dns_record" "ts_mc_net_dmarc" {
 # DNSSEC
 resource "cloudflare_zone_dnssec" "ts_mc_net" {
   zone_id = cloudflare_zone.ts_mc_net.id
+  status  = "active"
 }
 
 # ── CAA: authorize CAs Cloudflare may use to issue certs for this zone ─────

--- a/packages/homelab/src/tofu/posthog/.terraform.lock.hcl
+++ b/packages/homelab/src/tofu/posthog/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/posthog/posthog" {
+  version     = "1.0.17"
+  constraints = "~> 1.0"
+  hashes = [
+    "h1:C+6U1LoXa3a29UQZayJp56ikf3TOI/QmZMI4N3YCMZc=",
+    "h1:D9vgZu3wV3dhp7uR96hglQjlfvJ2iawCGLr0RN0qxR4=",
+    "h1:EB8YSbaC2sqfIqtkKqv8MaOgRjsagx6p4nvLtGU0l7w=",
+    "h1:GA4tnlCfE89NragvBsoWw5oYcRotm1MogSPArUgRqXs=",
+    "h1:Iufz3sM/d+/MGZUEz8Pv18ekJ0DzCLfIqp8my7uHYUE=",
+    "h1:O4sB4yirCGJBoa2F9ZWm9EgRpiQNLKoC8siFLpiuOP4=",
+    "h1:XChO/GkEX8b3euCdrGUmEYw5QNQsEmZYvaqRNNHgSRQ=",
+    "h1:XQzruei5aDdLqAc09+JXSo+cJqw2BNafOZhYo8IB2Xs=",
+    "h1:eaERl3s1FIwR2+p2CsvLQTXkS/FGXvAlRfgABmNLRVI=",
+    "h1:j5q8tdnX6tHDNxj3vHku3Mbm6RV4UEk6nblrQ6RaO40=",
+    "h1:jjTuU/2g7qIaT26sV5JyT5yCMkVaTBz8C8jnYzvLHoE=",
+    "h1:k7TTYNmKDFjf27t2G3yE3ZFKpuKFwrOD1NPf9iYsQfQ=",
+    "h1:nCMD4lu1rJorJZzQRr/RbAGCuVFf88+qAojPA7e8SNU=",
+    "zh:1f31c2d8b6ecad16a8c7d89e384da161fbe4a3a47f161e429b744b835a8b1216",
+    "zh:268778dcd27f1a8876a418cc53f524b70b672861e5b6a590c62c26eb6dca8503",
+    "zh:35f626086c77fcda3fa2e7d0cfde00f49f5bf50a48ddf73f5025b14b905f1abc",
+    "zh:3ec865005477589789fa8e4d6618153ae03ff7fd5d5492b9717a9f7b20571c64",
+    "zh:52cd739b4510fd4e2886eee79b3d8d6fb9f8d12d59270f2a4b134e275ea5cf1b",
+    "zh:659303cccc8f41fd4ab62052aaf2307d5c38b183b6941dda5f2777da19385566",
+    "zh:6dd02cc157d8536c8e67c2e30044b5282152e61d952e742bda13ba87fefa450b",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8fa1a11c652ba2dc42da98bcd8499992095ed3c20243405b85a44f8b9a7ab9a9",
+    "zh:95c62b125221dbc6ae958d7c7177b5f6d510b1ef0f87e9900675a79f2f927eb1",
+    "zh:aeffe7033a09766438a1b9c371ba6d5ae38d8519c374091b2128002046638ff7",
+    "zh:cf0ce03d2be28dbc9ef07fe21d1533456dd07e340488fe175619787a623fc6fd",
+    "zh:d7d2f15d2ad53a39de4e5a49c1c20167a3598b2277742ca866bf4450b3f58bcb",
+    "zh:f77151e26440ac47fc3c087d37770388951266b555e763d9026da69960260e3a",
+  ]
+}

--- a/packages/homelab/src/tofu/posthog/backend.tf
+++ b/packages/homelab/src/tofu/posthog/backend.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {
+    bucket = "homelab-tofu-state"
+    key    = "posthog/terraform.tfstate"
+    # Tailscale (tailnet-only) instead of Cloudflare tunnel -- CF rewrites
+    # Accept-Encoding headers which breaks SigV4 signatures (hashicorp/terraform#36412)
+    endpoints                   = { s3 = "https://seaweedfs-s3.tailnet-1a49.ts.net" }
+    region                      = "auto"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+  }
+}

--- a/packages/homelab/src/tofu/posthog/encryption.tf
+++ b/packages/homelab/src/tofu/posthog/encryption.tf
@@ -1,0 +1,21 @@
+terraform {
+  encryption {
+    key_provider "pbkdf2" "posthog" {
+      passphrase = var.state_passphrase
+    }
+
+    method "aes_gcm" "posthog" {
+      keys = key_provider.pbkdf2.posthog
+    }
+
+    state {
+      method   = method.aes_gcm.posthog
+      enforced = true
+    }
+
+    plan {
+      method   = method.aes_gcm.posthog
+      enforced = true
+    }
+  }
+}

--- a/packages/homelab/src/tofu/posthog/generated.tf
+++ b/packages/homelab/src/tofu/posthog/generated.tf
@@ -1,0 +1,4263 @@
+# __generated__ by OpenTofu
+# Please review these resources and move them into your main configuration files.
+
+# __generated__ by OpenTofu from "549883/10881555"
+resource "posthog_insight" "insight_10881555" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "How many people come back week after week after their first visit. The clearest signal of whether your product is sticky."
+  name             = "Retention"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      kind               = "RetentionQuery"
+      properties         = []
+      retentionFilter = {
+        period        = "Week"
+        retentionType = "retention_first_time"
+        returningEntity = {
+          id   = "$pageview"
+          type = "events"
+        }
+        targetEntity = {
+          id   = "$pageview"
+          type = "events"
+        }
+        totalIntervals = 11
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892235"
+resource "posthog_insight" "insight_10892235" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Pages Per User"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "total"
+        name  = "$pageview"
+        }, {
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        formula                 = "A/B"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297195"
+resource "posthog_insight" "insight_11297195" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Daily unique non-house Bucks members with activity."
+  name             = "Bryan Bucks daily active members"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "bryan_bucks_member_activity"
+        kind  = "EventsNode"
+        math  = "dau"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10881550"
+resource "posthog_insight" "insight_10881550" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Unique people who used your app in the last 30 days. A quick pulse on your overall reach."
+  name             = "Active users (last 30 days)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        kind = "GroupNode"
+        math = "dau"
+        name = "Pageview or screen"
+        nodes = [{
+          event = "$pageview"
+          kind  = "EventsNode"
+          name  = "$pageview"
+          }, {
+          event = "$screen"
+          kind  = "EventsNode"
+          name  = "$screen"
+        }]
+        operator = "OR"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10881554"
+resource "posthog_insight" "insight_10881554" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Unique people who use your app each week. Smooths out daily noise to show the underlying trend."
+  name             = "Weekly active users (WAUs)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-90d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        kind = "GroupNode"
+        math = "dau"
+        name = "Pageview or screen"
+        nodes = [{
+          event = "$pageview"
+          kind  = "EventsNode"
+          name  = "$pageview"
+          }, {
+          event = "$screen"
+          kind  = "EventsNode"
+          name  = "$screen"
+        }]
+        operator = "OR"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297213"
+resource "posthog_insight" "insight_11297213" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Deduplicated daily economy snapshot count; a missing current-day point indicates stale telemetry."
+  name             = "Bryan Bucks snapshot freshness"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-30d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event      = "bryan_bucks_economy_snapshot"
+        kind       = "EventsNode"
+        math       = "hogql"
+        math_hogql = "count(distinct uuid)"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "019fe7f8-ecce-0000-adca-fe93618022c7/549883"
+resource "posthog_project" "monorepo" {
+  name            = "monorepo"
+  organization_id = "019fe7f8-ecce-0000-adca-fe93618022c7"
+  timezone        = "America/Los_Angeles"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# __generated__ by OpenTofu from "549883/1977280"
+resource "posthog_dashboard" "dashboard_1977280" {
+  deleted     = false
+  description = "Understand how many users are visiting your website, the most popular pages, and in which countries is your website being visited from."
+  name        = "Website Metrics"
+  pinned      = false
+  project_id  = "549883"
+  tags        = null
+}
+
+# __generated__ by OpenTofu from "549883/1977280"
+resource "posthog_dashboard_layout" "dashboard_1977280" {
+  dashboard_id = 1977280
+  project_id   = "549883"
+  tiles = [
+    {
+      color      = "blue"
+      insight_id = 10892230
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          i    = "21"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 0
+        }
+        xs = {
+          h    = 5
+          i    = "21"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 0
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "green"
+      insight_id = 10892231
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          i    = "22"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 0
+        }
+        xs = {
+          h    = 5
+          i    = "22"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 5
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "blue"
+      insight_id = 10892232
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          i    = "23"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 5
+        }
+        xs = {
+          h    = 5
+          i    = "23"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 10
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "green"
+      insight_id = 10892233
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          i    = "24"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 5
+        }
+        xs = {
+          h    = 5
+          i    = "24"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 15
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892234
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          i    = "25"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 10
+        }
+        xs = {
+          h    = 5
+          i    = "25"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 20
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892235
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          i    = "26"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 10
+        }
+        xs = {
+          h    = 5
+          i    = "26"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 25
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "black"
+      insight_id = 10892236
+      layouts_json = jsonencode({
+        sm = {
+          h    = 8
+          i    = "27"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 15
+        }
+        xs = {
+          h    = 5
+          i    = "27"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 30
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "black"
+      insight_id = 10892237
+      layouts_json = jsonencode({
+        sm = {
+          h    = 8
+          i    = "28"
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 15
+        }
+        xs = {
+          h    = 5
+          i    = "28"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 35
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892238
+      layouts_json = jsonencode({
+        sm = {
+          h    = 8
+          i    = "29"
+          minH = 5
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 23
+        }
+        xs = {
+          h    = 5
+          i    = "29"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 40
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/10881557"
+resource "posthog_insight" "insight_10881557" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Of people who land on a page, how many go on to interact. Replace these steps with your own events to track real conversions."
+  name             = "Visit to interaction funnel"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      funnelsFilter = {
+        breakdownAttributionType = "first_touch"
+        exclusions               = []
+        funnelOrderType          = "ordered"
+        funnelStepReference      = "total"
+        funnelVizType            = "steps"
+        funnelWindowInterval     = 14
+        funnelWindowIntervalUnit = "day"
+        layout                   = "horizontal"
+      }
+      interval   = "day"
+      kind       = "FunnelsQuery"
+      properties = []
+      series = [{
+        custom_name = "Viewed a page"
+        event       = "$pageview"
+        kind        = "EventsNode"
+        name        = "$pageview"
+        }, {
+        custom_name = "Clicked something"
+        event       = "$autocapture"
+        kind        = "EventsNode"
+        name        = "$autocapture"
+      }]
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892226"
+resource "posthog_insight" "insight_10892226" {
+  create_in_folder = null
+  dashboard_ids    = [1977279]
+  deleted          = false
+  derived_name     = null
+  description      = "How many of your users are new, returning, resurrecting, or dormant each week."
+  name             = "Growth accounting"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "LifecycleQuery"
+      lifecycleFilter = {
+        showLegend = false
+      }
+      properties = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        name  = "$pageview"
+      }]
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "019fe7f8-ecce-0000-adca-fe93618022c7/019fea37-95d4-0000-a853-32ba533f6f8c"
+resource "posthog_proxy_record" "j_sjer_red" {
+  domain          = "j.sjer.red"
+  organization_id = "019fe7f8-ecce-0000-adca-fe93618022c7"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# __generated__ by OpenTofu from "549883/10892238"
+resource "posthog_insight" "insight_10892238" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Website Users by Location"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$geoip_country_code"
+        breakdown_type = "person"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "WorldMap"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1975723"
+resource "posthog_dashboard_layout" "dashboard_1975723" {
+  dashboard_id = 1975723
+  project_id   = "549883"
+  tiles = [
+    {
+      color      = null
+      insight_id = null
+      layouts_json = jsonencode({
+        sm = {
+          h    = 2
+          minH = 1
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 0
+        }
+        xs = {
+          h    = 3
+          minH = 1
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 0
+        }
+      })
+      show_description = null
+      text_body        = "# 👋 Start here\n\nEverything below is captured automatically (pageviews, clicks, sessions, and location), so this dashboard fills in from day one with no extra setup. The headline numbers will feel familiar; the retention and funnel tiles are where you point PostHog at your own events. Edit any tile, or duplicate the dashboard to make it your own."
+    },
+    {
+      color      = "blue"
+      insight_id = 10881550
+      layouts_json = jsonencode({
+        sm = {
+          h    = 3
+          minH = 3
+          minW = 3
+          w    = 4
+          x    = 0
+          y    = 2
+        }
+        xs = {
+          h    = 3
+          minH = 3
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 3
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "blue"
+      insight_id = 10881551
+      layouts_json = jsonencode({
+        sm = {
+          h    = 3
+          minH = 3
+          minW = 3
+          w    = 4
+          x    = 4
+          y    = 2
+        }
+        xs = {
+          h    = 3
+          minH = 3
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 6
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "blue"
+      insight_id = 10881552
+      layouts_json = jsonencode({
+        sm = {
+          h    = 3
+          minH = 3
+          minW = 3
+          w    = 4
+          x    = 8
+          y    = 2
+        }
+        xs = {
+          h    = 3
+          minH = 3
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 9
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = null
+      layouts_json = jsonencode({
+        sm = {
+          h    = 2
+          minH = 1
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 5
+        }
+        xs = {
+          h    = 3
+          minH = 1
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 12
+        }
+      })
+      show_description = null
+      text_body        = "## Are people coming back?\n\nActive users show your trend; retention shows how many return after their first visit. The clearest sign your product is sticky."
+    },
+    {
+      color      = "blue"
+      insight_id = 10881553
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 7
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 15
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "green"
+      insight_id = 10881554
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 7
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 20
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "blue"
+      insight_id = 10881555
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 12
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 25
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = null
+      layouts_json = jsonencode({
+        sm = {
+          h    = 2
+          minH = 1
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 17
+        }
+        xs = {
+          h    = 3
+          minH = 1
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 30
+        }
+      })
+      show_description = null
+      text_body        = "## Where your visitors come from\n\nThe sites and channels sending people to your app."
+    },
+    {
+      color      = "purple"
+      insight_id = 10881556
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 19
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 33
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = null
+      layouts_json = jsonencode({
+        sm = {
+          h    = 2
+          minH = 1
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 24
+        }
+        xs = {
+          h    = 3
+          minH = 1
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 38
+        }
+      })
+      show_description = null
+      text_body        = "## Turning visits into actions\n\nA funnel from page view to click. Swap in your own events (signup, purchase, upgrade) to measure real conversion."
+    },
+    {
+      color      = "black"
+      insight_id = 10881557
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 26
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 41
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = null
+      layouts_json = jsonencode({
+        sm = {
+          h    = 2
+          minH = 1
+          minW = 3
+          w    = 12
+          x    = 0
+          y    = 31
+        }
+        xs = {
+          h    = 3
+          minH = 1
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 46
+        }
+      })
+      show_description = null
+      text_body        = "## What to do next\n\nYou've got the numbers. Watch how people actually behave, explore raw events, or dig into traffic and acquisition."
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/11251182"
+resource "posthog_insight" "insight_11251182" {
+  create_in_folder = null
+  dashboard_ids    = [2022116]
+  deleted          = false
+  derived_name     = null
+  description      = "What servers actually consume: prematch/postmatch vs reports, competitions, pairing."
+  name             = "Core output mix by kind (weekly)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "output_kind"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "core_output_delivered"
+        kind  = "EventsNode"
+        name  = "core_output_delivered"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsStackedBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1977268"
+resource "posthog_dashboard_layout" "dashboard_1977268" {
+  dashboard_id = 1977268
+  project_id   = "549883"
+  tiles = [
+    {
+      color      = null
+      insight_id = null
+      layouts_json = jsonencode({
+        sm = {
+          h      = 4
+          i      = "257126"
+          minH   = 2
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 12
+          x      = 0
+          y      = 0
+        }
+        xs = {
+          h    = 6
+          i    = "257126"
+          minH = 2
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 50
+        }
+      })
+      show_description = null
+      text_body        = "### How to use this dashboard\n\nThis dashboard enables you to analyze trends on your website landing pages. Including:\n\n1. Unique session trends\n2. The most popular landing pages\n3. Referring domains\n4. Pages per session\n5. Average session duration\n6. Where users are from\n7. Device and browser type\n\nTo view data for a specific page, or group of pages, click on 'Add filter' and search for 'Current URL' to filter by URL parameters."
+    },
+    {
+      color      = null
+      insight_id = 10892178
+      layouts_json = jsonencode({
+        sm = {
+          h      = 7
+          i      = "256443"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 12
+          x      = 0
+          y      = 4
+        }
+        xs = {
+          h    = 5
+          i    = "256443"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 20
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892183
+      layouts_json = jsonencode({
+        sm = {
+          h      = 4
+          i      = "256417"
+          minH   = 4
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 6
+          x      = 0
+          y      = 11
+        }
+        xs = {
+          h    = 5
+          i    = "256417"
+          minH = 4
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 5
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892186
+      layouts_json = jsonencode({
+        sm = {
+          h      = 4
+          i      = "256484"
+          minH   = 4
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 6
+          x      = 6
+          y      = 11
+        }
+        xs = {
+          h    = 5
+          i    = "256484"
+          minH = 4
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 25
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892179
+      layouts_json = jsonencode({
+        sm = {
+          h      = 8
+          i      = "256402"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 6
+          x      = 0
+          y      = 15
+        }
+        xs = {
+          h    = 5
+          i    = "256402"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 0
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892180
+      layouts_json = jsonencode({
+        sm = {
+          h      = 8
+          i      = "256415"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 6
+          x      = 6
+          y      = 15
+        }
+        xs = {
+          h    = 5
+          i    = "256415"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 10
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892185
+      layouts_json = jsonencode({
+        sm = {
+          h      = 6
+          i      = "256485"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 6
+          x      = 0
+          y      = 23
+        }
+        xs = {
+          h    = 5
+          i    = "256485"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 30
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892181
+      layouts_json = jsonencode({
+        sm = {
+          h      = 6
+          i      = "257111"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 6
+          x      = 6
+          y      = 23
+        }
+        xs = {
+          h    = 5
+          i    = "257111"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 35
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892177
+      layouts_json = jsonencode({
+        sm = {
+          h      = 5
+          i      = "256430"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 4
+          x      = 0
+          y      = 29
+        }
+        xs = {
+          h    = 5
+          i    = "256430"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 15
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892176
+      layouts_json = jsonencode({
+        sm = {
+          h      = 5
+          i      = "257119"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 4
+          x      = 4
+          y      = 29
+        }
+        xs = {
+          h    = 5
+          i    = "257119"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 40
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = null
+      insight_id = 10892182
+      layouts_json = jsonencode({
+        sm = {
+          h      = 5
+          i      = "257118"
+          minH   = 5
+          minW   = 3
+          moved  = false
+          static = false
+          w      = 4
+          x      = 8
+          y      = 29
+        }
+        xs = {
+          h    = 5
+          i    = "257118"
+          minH = 5
+          minW = 1
+          w    = 1
+          x    = 0
+          y    = 45
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/11297204"
+resource "posthog_insight" "insight_11297204" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Deduplicated market lifecycle counts by transition."
+  name             = "Bryan Bucks markets opened settled and voided"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+        breakdowns = [{
+          property = "transition"
+          type     = "event"
+        }]
+      }
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event      = "bryan_bucks_lifecycle"
+        kind       = "EventsNode"
+        math       = "hogql"
+        math_hogql = "count(distinct uuid)"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsStackedBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297203"
+resource "posthog_insight" "insight_11297203" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Deduplicated daily stake volume from the economy ledger."
+  name             = "Bryan Bucks stake volume"
+  project_id       = "549883"
+  query_json = jsonencode({
+    display = "ActionsLineGraph"
+    kind    = "DataVisualizationNode"
+    source = {
+      kind  = "HogQLQuery"
+      query = "SELECT day, sum(-delta) AS stake_volume FROM (SELECT uuid, toStartOfDay(timestamp) AS day, argMax(toFloat(properties[delta_bucks]), timestamp) AS delta FROM events WHERE event = bryan_bucks_economy AND properties[movement] IN (bet_stake, parlay_stake) GROUP BY uuid, day) GROUP BY day ORDER BY day"
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/2022116"
+resource "posthog_dashboard_layout" "dashboard_2022116" {
+  dashboard_id = 2022116
+  project_id   = "549883"
+  tiles = [
+    {
+      color            = null
+      insight_id       = 11251185
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11251184
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11251183
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11251182
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11251174
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11251173
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/10892236"
+resource "posthog_insight" "insight_10892236" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Top Website Pages (Overall)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$current_url"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties = {
+        type = "AND"
+        values = [{
+          type = "AND"
+          values = [{
+            key      = "$current_url"
+            operator = "not_icontains"
+            type     = "event"
+            value    = "?"
+          }]
+        }]
+      }
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892181"
+resource "posthog_insight" "insight_10892181" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "Unique users broken down by new and returning"
+  name             = "New & Returning Users"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "week"
+      kind               = "LifecycleQuery"
+      lifecycleFilter = {
+        showLegend         = false
+        showValuesOnSeries = true
+        toggledLifecycles  = ["new", "returning"]
+      }
+      properties = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        name  = "$pageview"
+      }]
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892223"
+resource "posthog_insight" "insight_10892223" {
+  create_in_folder = null
+  dashboard_ids    = [1977279]
+  deleted          = false
+  derived_name     = null
+  description      = "Shows the number of unique users that use your app every day."
+  name             = "Daily active users (DAUs)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892217"
+resource "posthog_insight" "insight_10892217" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart shows which devices your unique users have been using over the past 30 days, so you can ensure you are designing your products and website for the right primary devices. You can get more detailed information by changing the 'Breakdown by' to 'Device ID'."
+  name             = "What devices do users access my product with?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$device_type"
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = false
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1977268"
+resource "posthog_dashboard" "dashboard_1977268" {
+  deleted     = false
+  description = "Analyze trends on landing pages, including where users come from, browser, and device type."
+  name        = "Landing Pages Report"
+  pinned      = false
+  project_id  = "549883"
+  tags        = null
+}
+
+# __generated__ by OpenTofu from "549883/1975723"
+resource "posthog_dashboard" "dashboard_1975723" {
+  deleted     = false
+  description = "How people use your app at a glance: traffic, retention, where visitors come from, and whether they take action. Built from automatically captured events, so it works on day one. Swap in your own events to make it yours."
+  name        = "Your starter dashboard"
+  pinned      = true
+  project_id  = "549883"
+  tags        = null
+}
+
+# __generated__ by OpenTofu from "549883/10892212"
+resource "posthog_insight" "insight_10892212" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This path shows the most 7 common paths taken by users over the last 30 days, starting at their initial pageview and proceeding for 5 steps. The size of a path reflects how common it is, while red areas reflect early drop-off. This can be especially useful for seeing where users get lost and understanding the most popular destinations."
+  name             = "How do most users access my product?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      kind               = "PathsQuery"
+      pathsFilter = {
+        edgeLimit                = 7
+        excludeEvents            = []
+        includeEventTypes        = ["$pageview"]
+        localPathCleaningFilters = []
+        pathGroupings            = []
+        stepLimit                = 5
+      }
+      properties = []
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu
+resource "posthog_external_data_source" "pinterest_ads" {
+  job_inputs_json = jsonencode({
+    ad_account_id                = "549768245877"
+    pinterest_ads_integration_id = "209503"
+  })
+  prefix      = null
+  project_id  = "549883"
+  schemas     = ["ad_accounts", "ad_analytics", "ad_group_analytics", "ad_groups", "ad_group_targeting_analytics", "ads", "ad_targeting_analytics", "audiences", "campaign_analytics", "campaigns", "campaign_targeting_analytics", "conversion_tags", "keywords"]
+  source_type = "PinterestAds"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# __generated__ by OpenTofu from "549883/10892183"
+resource "posthog_insight" "insight_10892183" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "The number of unique users who visited a landing page compared to the previous period"
+  name             = "Unique Users on Landing Page(s)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = true
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892232"
+resource "posthog_insight" "insight_10892232" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Website Unique Users (Breakdown)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBar"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/019fe7f8-ee1c-0000-8f3e-476e8dac0c40"
+resource "posthog_hog_function" "geoip" {
+  description     = "Adds geoip data to the event"
+  enabled         = true
+  execution_order = 1
+  filters_json = jsonencode({
+    source = "events"
+  })
+  hog                   = "// Define the properties to be added to the event\nlet geoipProperties := {\n    'city_name': null,\n    'city_confidence': null,\n    'subdivision_2_name': null,\n    'subdivision_2_code': null,\n    'subdivision_1_name': null,\n    'subdivision_1_code': null,\n    'country_name': null,\n    'country_code': null,\n    'continent_name': null,\n    'continent_code': null,\n    'postal_code': null,\n    'latitude': null,\n    'longitude': null,\n    'accuracy_radius': null,\n    'time_zone': null\n}\n// Check if the event has an IP address\nif (event.properties?.$geoip_disable or empty(event.properties?.$ip)) {\n    print('geoip disabled or no ip.')\n    return event\n}\nlet ip := event.properties.$ip\n// Check for localhost and common private network IPs\nif (ip == '127.0.0.1' or substring(ip, 1, 8) == '192.168.') {\n    print('spoofing ip for local development', ip)\n    ip := '89.160.20.129'\n}\nlet response := geoipLookup(ip)\nif (not response) {\n    print('geoip lookup failed for ip', ip)\n    return event\n}\nlet location := {}\nif (response.city) {\n    location['city_name'] := response.city.names?.en\n}\nif (response.country) {\n    location['country_name'] := response.country.names?.en\n    location['country_code'] := response.country.isoCode\n}\nif (response.continent) {\n    location['continent_name'] := response.continent.names?.en\n    location['continent_code'] := response.continent.code\n}\nif (response.postal) {\n    location['postal_code'] := response.postal.code\n}\nif (response.location) {\n    location['latitude'] := response.location?.latitude\n    location['longitude'] := response.location?.longitude\n    location['accuracy_radius'] := response.location?.accuracyRadius\n    location['time_zone'] := response.location?.timeZone\n}\nif (response.subdivisions) {\n    for (let index, subdivision in response.subdivisions) {\n        location[f'subdivision_{index + 1}_code'] := subdivision.isoCode\n        location[f'subdivision_{index + 1}_name'] := subdivision.names?.en\n    }\n}\nprint('geoip location data for ip:', location) \nlet returnEvent := event\nreturnEvent.properties := returnEvent.properties ?? {}\nreturnEvent.properties.$set := returnEvent.properties.$set ?? {}\nreturnEvent.properties.$set_once := returnEvent.properties.$set_once ?? {}\nfor (let key, value in geoipProperties) {\n    if (value != null) {\n        returnEvent.properties.$set[f'$geoip_{key}'] := value\n        returnEvent.properties.$set_once[f'$initial_geoip_{key}'] := value\n    }\n    returnEvent.properties.$set[f'$geoip_{key}'] := value\n    returnEvent.properties.$set_once[f'$initial_geoip_{key}'] := value\n}\nfor (let key, value in location) {\n    returnEvent.properties[f'$geoip_{key}'] := value\n    returnEvent.properties.$set[f'$geoip_{key}'] := value\n    returnEvent.properties.$set_once[f'$initial_geoip_{key}'] := value\n}\nreturn returnEvent"
+  icon_url              = "/static/transformations/geoip.png"
+  inputs_json           = null
+  inputs_schema_json    = null
+  mappings_json         = null
+  masking_json          = null
+  name                  = "GeoIP"
+  project_id            = "549883"
+  sensitive_inputs_json = null # sensitive
+  template_id           = "template-geoip"
+  type                  = "transformation"
+}
+
+# __generated__ by OpenTofu from "549883/11251173"
+resource "posthog_insight" "insight_11251173" {
+  create_in_folder = null
+  dashboard_ids    = [2022116]
+  deleted          = false
+  derived_name     = null
+  description      = "Per installation identity, 14-day conversion window, last 30 days. Activation is decided in minutes — watch step 2."
+  name             = "Install funnel: installed → first subscription → first output"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-30d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      funnelsFilter = {
+        breakdownAttributionType              = "first_touch"
+        exclusions                            = []
+        funnelOrderType                       = "ordered"
+        funnelStepReference                   = "total"
+        funnelVizType                         = "steps"
+        funnelWindowInterval                  = 14
+        funnelWindowIntervalUnit              = "day"
+        hideIncompleteConversionWindowPeriods = false
+        layout                                = "vertical"
+        legendPosition                        = "bottom"
+        showAnnotations                       = true
+        showLegend                            = false
+        showValuesOnSeries                    = false
+      }
+      kind       = "FunnelsQuery"
+      properties = []
+      series = [{
+        event = "guild_installed"
+        kind  = "EventsNode"
+        name  = "guild_installed"
+        }, {
+        event = "first_subscription_created"
+        kind  = "EventsNode"
+        name  = "first_subscription_created"
+        }, {
+        event = "first_core_output_delivered"
+        kind  = "EventsNode"
+        name  = "first_core_output_delivered"
+      }]
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11251184"
+resource "posthog_insight" "insight_11251184" {
+  create_in_folder = null
+  dashboard_ids    = [2022116]
+  deleted          = false
+  derived_name     = null
+  description      = "Was a lost guild ever activated? installed_only churn points at first-5-minutes friction."
+  name             = "Removals by activation state"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "activation_state"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "guild_removed"
+        kind  = "EventsNode"
+        name  = "guild_removed"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsStackedBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892237"
+resource "posthog_insight" "insight_10892237" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Top Website Pages (via Google)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$current_url"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties = {
+        type = "AND"
+        values = [{
+          type = "AND"
+          values = [{
+            key      = "$current_url"
+            operator = "not_icontains"
+            type     = "event"
+            value    = "?"
+            }, {
+            key      = "$referring_domain"
+            operator = "icontains"
+            type     = "event"
+            value    = "google"
+          }]
+        }]
+      }
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11251183"
+resource "posthog_insight" "insight_11251183" {
+  create_in_folder = null
+  dashboard_ids    = [2022116]
+  deleted          = false
+  derived_name     = null
+  description      = "Net guild growth. Removals carry activation_state and tenure_bucket for drill-down."
+  name             = "Installs vs removals (weekly)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "guild_installed"
+        kind  = "EventsNode"
+        name  = "guild_installed"
+        }, {
+        event = "guild_removed"
+        kind  = "EventsNode"
+        name  = "guild_removed"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/469393"
+resource "posthog_cohort" "internal_test_users" {
+  deleted     = false
+  description = "People who are internal team members or test users. Used for filtering out internal traffic from analytics."
+  filters = jsonencode({
+    properties = {
+      type = "OR"
+      values = [{
+        type = "AND"
+        values = [{
+          key      = "$internal_or_test_user"
+          operator = "exact"
+          type     = "person"
+          value    = [true]
+        }]
+        }, {
+        type = "AND"
+        values = [{
+          key      = "email"
+          operator = "icontains"
+          type     = "person"
+          value    = "@sjer.red"
+        }]
+      }]
+    }
+  })
+  is_static  = false
+  name       = "Internal / Test users"
+  project_id = "549883"
+}
+
+# __generated__ by OpenTofu from "549883/10892225"
+resource "posthog_insight" "insight_10892225" {
+  create_in_folder = null
+  dashboard_ids    = [1977279]
+  deleted          = false
+  derived_name     = null
+  description      = "Weekly retention of your users."
+  name             = "Retention"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      kind               = "RetentionQuery"
+      properties         = []
+      retentionFilter = {
+        period        = "Week"
+        retentionType = "retention_first_time"
+        returningEntity = {
+          id   = "$pageview"
+          name = "$pageview"
+          type = "events"
+        }
+        targetEntity = {
+          id   = "$pageview"
+          name = "$pageview"
+          type = "events"
+        }
+        totalIntervals = 11
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/2027696"
+resource "posthog_dashboard" "dashboard_2027696" {
+  deleted     = false
+  description = "Beta-only Bryan Bucks engagement, market lifecycle, economy, retention, and data freshness. Member retention uses opaque app-owned account identities; house accounts are excluded."
+  name        = "Bryan Bucks Beta Activity"
+  pinned      = false
+  project_id  = "549883"
+  tags        = ["activity", "beta", "bryan-bucks"]
+}
+
+# __generated__ by OpenTofu from "549883/10892179"
+resource "posthog_insight" "insight_10892179" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "Breakdown of most popular landing pages by unique sessions"
+  name             = "Most Popular Landing Pages"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown               = "$current_url"
+        breakdown_normalize_url = true
+        breakdown_type          = "event"
+      }
+      compareFilter = {
+        compare = false
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsTable"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297196"
+resource "posthog_insight" "insight_11297196" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Weekly unique non-house Bucks members with activity."
+  name             = "Bryan Bucks weekly active members"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "bryan_bucks_member_activity"
+        kind  = "EventsNode"
+        math  = "weekly_active"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/2022116"
+resource "posthog_dashboard" "dashboard_2022116" {
+  deleted     = false
+  description = "Install funnel, active guilds, output mix, churn, and channel attribution for Scout for LoL. Created 2026-08-22; attribution + Explore + command tiles extend it once PRs #2337/#2338 deploy."
+  name        = "Scout Growth & Retention"
+  pinned      = true
+  project_id  = "549883"
+  tags        = null
+}
+
+# __generated__ by OpenTofu from "549883/10892216"
+resource "posthog_insight" "insight_10892216" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart shows on which pages users have rageclicked the most in the last 30 days. This can be helpful for finding areas of your product where users experience significant frustration."
+  name             = "Where are my users experiencing frustration?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$current_url"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$rageclick"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$rageclick"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10881553"
+resource "posthog_insight" "insight_10881553" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Unique people who use your app each day. Watch for steady growth or sudden drops."
+  name             = "Daily active users (DAUs)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        kind = "GroupNode"
+        math = "dau"
+        name = "Pageview or screen"
+        nodes = [{
+          event = "$pageview"
+          kind  = "EventsNode"
+          name  = "$pageview"
+          }, {
+          event = "$screen"
+          kind  = "EventsNode"
+          name  = "$screen"
+        }]
+        operator = "OR"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892224"
+resource "posthog_insight" "insight_10892224" {
+  create_in_folder = null
+  dashboard_ids    = [1977279]
+  deleted          = false
+  derived_name     = null
+  description      = "Shows the number of unique users that use your app every week."
+  name             = "Weekly active users (WAUs)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-90d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "weekly_active"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892178"
+resource "posthog_insight" "insight_10892178" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "Unique sessions on landing page(s)"
+  name             = "Unique Sessions Trend"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        custom_name = "Unique Sessions"
+        event       = "$pageview"
+        kind        = "EventsNode"
+        math        = "unique_session"
+        name        = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsAreaGraph"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = true
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892177"
+resource "posthog_insight" "insight_10892177" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "Users broken down by country"
+  name             = "Which country are users from?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$geoip_country_name"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        custom_name = "Country"
+        event       = "$pageview"
+        kind        = "EventsNode"
+        math        = "dau"
+        name        = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892231"
+resource "posthog_insight" "insight_10892231" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Organic SEO Unique Users (Total)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = true
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties = {
+        type = "AND"
+        values = [{
+          type = "AND"
+          values = [{
+            key      = "$referring_domain"
+            operator = "icontains"
+            type     = "event"
+            value    = "google"
+            }, {
+            key      = "utm_source"
+            operator = "is_not_set"
+            type     = "event"
+            value    = "is_not_set"
+          }]
+        }]
+      }
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1977279"
+resource "posthog_dashboard" "dashboard_1977279" {
+  deleted     = false
+  description = "High-level overview of your product including daily active users, weekly active users, retention, and growth accounting."
+  name        = "Product Analytics"
+  pinned      = false
+  project_id  = "549883"
+  tags        = null
+}
+
+# __generated__ by OpenTofu from "549883/10892234"
+resource "posthog_insight" "insight_10892234" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Sessions Per User"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+        }, {
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        formula                 = "B/A"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892180"
+resource "posthog_insight" "insight_10892180" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "How users arrived on your landing pages broken down by referring domain"
+  name             = "Referring Domains"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$referring_domain"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsTable"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1977278"
+resource "posthog_dashboard_layout" "dashboard_1977278" {
+  dashboard_id = 1977278
+  project_id   = "549883"
+  tiles = [
+    {
+      color            = null
+      insight_id       = 10892220
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892219
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892218
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892217
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892216
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892215
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892214
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892213
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 10892212
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/11297206"
+resource "posthog_insight" "insight_11297206" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Deduplicated daily earnings and payouts from the economy ledger."
+  name             = "Bryan Bucks earnings and payouts"
+  project_id       = "549883"
+  query_json = jsonencode({
+    display = "ActionsLineGraph"
+    kind    = "DataVisualizationNode"
+    source = {
+      kind  = "HogQLQuery"
+      query = "SELECT day, sumIf(delta, movement IN (earn_game, earn_win, earn_mvp, earn_ranked_5s_bonus)) AS earnings, sumIf(delta, movement IN (bet_payout, parlay_payout)) AS payouts FROM (SELECT uuid, toStartOfDay(timestamp) AS day, properties[movement] AS movement, argMax(toFloat(properties[delta_bucks]), timestamp) AS delta FROM events WHERE event = bryan_bucks_economy GROUP BY uuid, day, movement) GROUP BY day ORDER BY day"
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892220"
+resource "posthog_insight" "insight_10892220" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart shows where all pageviews for unique users originated from over the last 30 days."
+  name             = "Where are my users located?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$geoip_country_code"
+        breakdown_type = "person"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "WorldMap"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892185"
+resource "posthog_insight" "insight_10892185" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = "How many pages users visit in each unique session."
+  name             = "Pages Per Session"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = false
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "total"
+        name  = "$pageview"
+        }, {
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsAreaGraph"
+        formula                 = "A/B"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = true
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1977279"
+resource "posthog_dashboard_layout" "dashboard_1977279" {
+  dashboard_id = 1977279
+  project_id   = "549883"
+  tiles = [
+    {
+      color      = "blue"
+      insight_id = 10892223
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 0
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 1
+          x    = 0
+          y    = 0
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "green"
+      insight_id = 10892224
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 0
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 1
+          x    = 0
+          y    = 5
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "purple"
+      insight_id = 10892226
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 5
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 1
+          x    = 0
+          y    = 15
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "blue"
+      insight_id = 10892225
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 5
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 1
+          x    = 0
+          y    = 10
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "black"
+      insight_id = 10892227
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 0
+          y    = 10
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 1
+          x    = 0
+          y    = 20
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+    {
+      color      = "green"
+      insight_id = 10892228
+      layouts_json = jsonencode({
+        sm = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 6
+          x    = 6
+          y    = 10
+        }
+        xs = {
+          h    = 5
+          minH = 5
+          minW = 3
+          w    = 1
+          x    = 0
+          y    = 25
+        }
+      })
+      show_description = null
+      text_body        = null
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/10892182"
+resource "posthog_insight" "insight_10892182" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Unique Users by Device Type"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$device_type"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsPie"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = true
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/2027696"
+resource "posthog_dashboard_layout" "dashboard_2027696" {
+  dashboard_id = 2027696
+  project_id   = "549883"
+  tiles = [
+    {
+      color            = null
+      insight_id       = 11297213
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297212
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297206
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297204
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297203
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297201
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297198
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297197
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297196
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+    {
+      color            = null
+      insight_id       = 11297195
+      layouts_json     = null
+      show_description = null
+      text_body        = null
+    },
+  ]
+}
+
+# __generated__ by OpenTofu from "549883/10892218"
+resource "posthog_insight" "insight_10892218" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart shows the referring domain for all pageviews by unique users in the last 30 days. This can be especially helpful for understanding how users find your product."
+  name             = "How do users find my product?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$referring_domain"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10881552"
+resource "posthog_insight" "insight_10881552" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Total pages viewed in the last 7 days, repeat views included. The classic traffic-volume number."
+  name             = "Pageviews (last 7 days)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "total"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10881556"
+resource "posthog_insight" "insight_10881556" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Which sites send you the most visitors, like search, social, and direct. Your acquisition channels at a glance."
+  name             = "Top referrers"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$referring_domain"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892213"
+resource "posthog_insight" "insight_10892213" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart shows what the most popular screen height is for unique users over the past 30 days. You can correlate this with screen width by changing the 'Breakdown by' option to specify 'Screen Width'."
+  name             = "What screen size do users have?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$screen_height"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = true
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892215"
+resource "posthog_insight" "insight_10892215" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "The GREEN section of this lifecycle chart shows identified users who completed a pageview in the last 30 days and in the previous 30 days, indicated strong engagement. By clicking through on each bar you can see a full list of the identified users, which is useful for arranging customer interviews or examining their sessions."
+  name             = "Which users are highly engaged?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "week"
+      kind               = "LifecycleQuery"
+      lifecycleFilter = {
+        showLegend = false
+      }
+      properties = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        name  = "$pageview"
+        properties = [{
+          key      = "email"
+          operator = "is_set"
+          type     = "person"
+          value    = "is_set"
+        }]
+      }]
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10881551"
+resource "posthog_insight" "insight_10881551" {
+  create_in_folder = null
+  dashboard_ids    = [1975723]
+  deleted          = false
+  derived_name     = null
+  description      = "Distinct visits in the last 7 days. A session groups everything one person does in a single sitting."
+  name             = "Sessions (last 7 days)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "unique_session"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892214"
+resource "posthog_insight" "insight_10892214" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart looks at the most popular languages among users over the last 30 days, identified by the language they've chosen for their browser. This can help you identify if you need to consider translating your product, or marketing to specific geographies."
+  name             = "What languages do users prefer?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$browser_language"
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = false
+      }
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat = "numeric"
+        display               = "ActionsBarValue"
+        resultCustomizationBy = "position"
+        resultCustomizations = {
+          "1" = {
+            assignmentBy = "position"
+            hidden       = true
+          }
+        }
+        showAlertThresholdLines = false
+        showLegend              = true
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297198"
+resource "posthog_insight" "insight_11297198" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Weekly retention after a member first uses Bryan Bucks."
+  name             = "Bryan Bucks first-use retention cohorts"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      kind               = "RetentionQuery"
+      properties         = []
+      retentionFilter = {
+        aggregationPropertyType = "event"
+        aggregationType         = "count"
+        cohortLabelStartIndex   = 0
+        cumulative              = false
+        period                  = "Week"
+        retentionReference      = "total"
+        retentionType           = "retention_first_time"
+        returningEntity = {
+          id   = "bryan_bucks_member_activity"
+          name = "Bryan Bucks activity"
+          type = "events"
+        }
+        targetEntity = {
+          id   = "bryan_bucks_member_activity"
+          name = "Bryan Bucks activity"
+          type = "events"
+        }
+        totalIntervals = 8
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/1977278"
+resource "posthog_dashboard" "dashboard_1977278" {
+  deleted     = false
+  description = "Understand who your users are, how they interact with your product and what browsers or devices they use. Additionally, you can use the 'Which users are highly engaged?' insight to find identified power users, so you can approach them for customer interviews or view their session recordings."
+  name        = "User Research"
+  pinned      = false
+  project_id  = "549883"
+  tags        = null
+}
+
+# __generated__ by OpenTofu from "549883/10892186"
+resource "posthog_insight" "insight_10892186" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Average Session Duration"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = true
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event         = "$pageview"
+        kind          = "EventsNode"
+        math          = "avg"
+        math_property = "$session_duration"
+        name          = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "duration"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892230"
+resource "posthog_insight" "insight_10892230" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = "Shows the number of unique users over the last 30 days."
+  name             = "Website Unique Users (Total)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      compareFilter = {
+        compare = true
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "BoldNumber"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297197"
+resource "posthog_insight" "insight_11297197" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "First-use members compared with daily active members."
+  name             = "Bryan Bucks new versus returning members"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "bryan_bucks_member_activity"
+        kind  = "EventsNode"
+        math  = "dau"
+        }, {
+        event = "bryan_bucks_member_activity"
+        kind  = "EventsNode"
+        math  = "first_time_for_user"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883"
+resource "posthog_project_settings" "monorepo" {
+  app_urls                                         = local.app_urls
+  autocapture_exceptions_opt_in                    = null
+  autocapture_web_vitals_opt_in                    = true
+  capture_performance_opt_in                       = true
+  cookieless_server_hash_mode                      = 0
+  heatmaps_opt_in                                  = true
+  project_id                                       = "549883"
+  recording_domains                                = local.recording_domains
+  session_recording_network_payload_capture_config = null
+  session_recording_opt_in                         = true
+  surveys_opt_in                                   = null
+  test_account_filters = jsonencode([{
+    key      = "id"
+    operator = "not_in"
+    type     = "cohort"
+    value    = posthog_cohort.internal_test_users.id
+  }])
+  test_account_filters_default_checked = null
+}
+
+# __generated__ by OpenTofu from "019fe7f8-ecce-0000-adca-fe93618022c7/019fe7f8-ecd5-0000-33c2-62f36e0cec32"
+resource "posthog_organization_member" "owner" {
+  level             = "owner"
+  organization_id   = "019fe7f8-ecce-0000-adca-fe93618022c7"
+  retain_on_destroy = true
+  user_uuid         = "019fe7f8-ecd5-0000-33c2-62f36e0cec32"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# __generated__ by OpenTofu from "549883/10892176"
+resource "posthog_insight" "insight_10892176" {
+  create_in_folder = null
+  dashboard_ids    = [1977268]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Unique Users by Browser"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$browser"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsPie"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = true
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892228"
+resource "posthog_insight" "insight_10892228" {
+  create_in_folder = null
+  dashboard_ids    = [1977279]
+  deleted          = false
+  derived_name     = null
+  description      = "This example funnel shows how many of your users have completed 3 page views, broken down by browser."
+  name             = "Pageview funnel, by browser"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$browser"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-7d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      funnelsFilter = {
+        breakdownAttributionType = "first_touch"
+        exclusions               = []
+        funnelOrderType          = "ordered"
+        funnelStepReference      = "total"
+        funnelVizType            = "steps"
+        funnelWindowInterval     = 14
+        funnelWindowIntervalUnit = "day"
+        layout                   = "horizontal"
+      }
+      interval   = "day"
+      kind       = "FunnelsQuery"
+      properties = []
+      series = [{
+        custom_name = "First page view"
+        event       = "$pageview"
+        kind        = "EventsNode"
+        name        = "$pageview"
+        }, {
+        custom_name = "Second page view"
+        event       = "$pageview"
+        kind        = "EventsNode"
+        name        = "$pageview"
+        }, {
+        custom_name = "Third page view"
+        event       = "$pageview"
+        kind        = "EventsNode"
+        name        = "$pageview"
+      }]
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297212"
+resource "posthog_insight" "insight_11297212" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Daily maximum observed member balance, house balance, and pending liability."
+  name             = "Bryan Bucks economy balances and pending liability"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event         = "bryan_bucks_economy_snapshot"
+        kind          = "EventsNode"
+        math          = "max"
+        math_property = "total_member_balance_bucks"
+        name          = "Member balance"
+        }, {
+        event         = "bryan_bucks_economy_snapshot"
+        kind          = "EventsNode"
+        math          = "max"
+        math_property = "pending_stake_bucks"
+        name          = "Pending liability"
+        }, {
+        event         = "bryan_bucks_economy_snapshot"
+        kind          = "EventsNode"
+        math          = "max"
+        math_property = "house_balance_bucks"
+        name          = "House balance"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11251185"
+resource "posthog_insight" "insight_11251185" {
+  create_in_folder = null
+  dashboard_ids    = [2022116]
+  deleted          = false
+  derived_name     = null
+  description      = "Interim channel attribution until guild_install_attributed / bot_install_completed land (PR #2338): CTA clicks broken down by the person's first-touch utm_source."
+  name             = "Get Started clicks by first-touch source"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$initial_utm_source"
+        breakdown_type = "person"
+      }
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "get_started_click"
+        kind  = "EventsNode"
+        name  = "get_started_click"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsStackedBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892219"
+resource "posthog_insight" "insight_10892219" {
+  create_in_folder = null
+  dashboard_ids    = [1977278]
+  deleted          = false
+  derived_name     = null
+  description      = "This chart tracks which browsers your unique users have been using over the last 30 days. It can be useful to correlate this with which devices users have been using, so you can ensure compatibility. Hover over a section to reveal what proportion of your users each browser represents."
+  name             = "What browsers do users prefer?"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$browser"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = true
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsPie"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11297201"
+resource "posthog_insight" "insight_11297201" {
+  create_in_folder = null
+  dashboard_ids    = [2027696]
+  deleted          = false
+  derived_name     = null
+  description      = "Deduplicated member activity split by command versus button surface."
+  name             = "Bryan Bucks activity by betting surface"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+        breakdowns = [{
+          property = "surface"
+          type     = "event"
+        }]
+      }
+      dateRange = {
+        date_from                = "-90d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event      = "bryan_bucks_member_activity"
+        kind       = "EventsNode"
+        math       = "hogql"
+        math_hogql = "count(distinct uuid)"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsStackedBar"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892233"
+resource "posthog_insight" "insight_10892233" {
+  create_in_folder = null
+  dashboard_ids    = [1977280]
+  deleted          = false
+  derived_name     = null
+  description      = null
+  name             = "Organic SEO Unique Users (Breakdown)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-30d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "week"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+        properties = [{
+          key      = "$referring_domain"
+          operator = "icontains"
+          type     = "event"
+          value    = "google"
+          }, {
+          key      = "utm_source"
+          operator = "is_not_set"
+          type     = "event"
+          value    = "is_not_set"
+        }]
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBar"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/10892227"
+resource "posthog_insight" "insight_10892227" {
+  create_in_folder = null
+  dashboard_ids    = [1977279]
+  deleted          = false
+  derived_name     = null
+  description      = "Shows the most common referring domains for your users over the past 14 days."
+  name             = "Referring domain (last 14 days)"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      breakdownFilter = {
+        breakdown      = "$referring_domain"
+        breakdown_type = "event"
+      }
+      dateRange = {
+        date_from    = "-14d"
+        explicitDate = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event = "$pageview"
+        kind  = "EventsNode"
+        math  = "dau"
+        name  = "$pageview"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsBarValue"
+        showAlertThresholdLines = false
+        showLegend              = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        yAxisScaleType          = "linear"
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}
+
+# __generated__ by OpenTofu from "549883/11251174"
+resource "posthog_insight" "insight_11251174" {
+  create_in_folder = null
+  dashboard_ids    = [2022116]
+  deleted          = false
+  derived_name     = null
+  description      = "Unique guild_id receiving any core output (prematch, postmatch, reports, competitions) per day."
+  name             = "Daily active guilds"
+  project_id       = "549883"
+  query_json = jsonencode({
+    kind = "InsightVizNode"
+    source = {
+      dateRange = {
+        date_from                = "-30d"
+        excludeIncompletePeriods = false
+        explicitDate             = false
+      }
+      filterTestAccounts = false
+      interval           = "day"
+      kind               = "TrendsQuery"
+      properties         = []
+      series = [{
+        event      = "core_output_delivered"
+        kind       = "EventsNode"
+        math       = "hogql"
+        math_hogql = "count(DISTINCT properties.guild_id)"
+        name       = "Active guilds"
+      }]
+      trendsFilter = {
+        aggregationAxisFormat   = "numeric"
+        display                 = "ActionsLineGraph"
+        excludeBoxPlotOutliers  = true
+        hideWeekends            = false
+        legendPosition          = "bottom"
+        metricColorByDirection  = false
+        metricShowChange        = true
+        metricSummary           = "total"
+        resultCustomizationBy   = "value"
+        showAlertThresholdLines = false
+        showAnnotations         = true
+        showLegend              = false
+        showMultipleYAxes       = false
+        showPercentStackView    = false
+        showValuesOnSeries      = false
+        smoothingIntervals      = 1
+        stackBreakdownValues    = false
+        yAxisScaleType          = "linear"
+        yAxisStartAtZero        = true
+      }
+    }
+  })
+  query_sql = null
+  tags      = null
+}

--- a/packages/homelab/src/tofu/posthog/imports.tf
+++ b/packages/homelab/src/tofu/posthog/imports.tf
@@ -1,0 +1,397 @@
+# Existing PostHog objects are adopted declaratively. These blocks remain as
+# durable provenance and become no-ops after the first successful apply.
+
+import {
+  to = posthog_project.monorepo
+  id = "019fe7f8-ecce-0000-adca-fe93618022c7/549883"
+}
+
+import {
+  to = posthog_project_settings.monorepo
+  id = "549883"
+}
+
+import {
+  to = posthog_organization_member.owner
+  id = "019fe7f8-ecce-0000-adca-fe93618022c7/019fe7f8-ecd5-0000-33c2-62f36e0cec32"
+}
+
+import {
+  to = posthog_cohort.internal_test_users
+  id = "549883/469393"
+}
+
+import {
+  to = posthog_dashboard.dashboard_2022116
+  id = "549883/2022116"
+}
+
+import {
+  to = posthog_dashboard.dashboard_1975723
+  id = "549883/1975723"
+}
+
+import {
+  to = posthog_dashboard.dashboard_2027696
+  id = "549883/2027696"
+}
+
+import {
+  to = posthog_dashboard.dashboard_1977268
+  id = "549883/1977268"
+}
+
+import {
+  to = posthog_dashboard.dashboard_1977279
+  id = "549883/1977279"
+}
+
+import {
+  to = posthog_dashboard.dashboard_1977278
+  id = "549883/1977278"
+}
+
+import {
+  to = posthog_dashboard.dashboard_1977280
+  id = "549883/1977280"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_2022116
+  id = "549883/2022116"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_1975723
+  id = "549883/1975723"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_2027696
+  id = "549883/2027696"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_1977268
+  id = "549883/1977268"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_1977279
+  id = "549883/1977279"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_1977278
+  id = "549883/1977278"
+}
+
+import {
+  to = posthog_dashboard_layout.dashboard_1977280
+  id = "549883/1977280"
+}
+
+import {
+  to = posthog_insight.insight_11297206
+  id = "549883/11297206"
+}
+
+import {
+  to = posthog_insight.insight_11297203
+  id = "549883/11297203"
+}
+
+import {
+  to = posthog_insight.insight_11297213
+  id = "549883/11297213"
+}
+
+import {
+  to = posthog_insight.insight_11297204
+  id = "549883/11297204"
+}
+
+import {
+  to = posthog_insight.insight_11297201
+  id = "549883/11297201"
+}
+
+import {
+  to = posthog_insight.insight_11297212
+  id = "549883/11297212"
+}
+
+import {
+  to = posthog_insight.insight_11297198
+  id = "549883/11297198"
+}
+
+import {
+  to = posthog_insight.insight_11297197
+  id = "549883/11297197"
+}
+
+import {
+  to = posthog_insight.insight_11297196
+  id = "549883/11297196"
+}
+
+import {
+  to = posthog_insight.insight_11297195
+  id = "549883/11297195"
+}
+
+import {
+  to = posthog_insight.insight_11251185
+  id = "549883/11251185"
+}
+
+import {
+  to = posthog_insight.insight_11251184
+  id = "549883/11251184"
+}
+
+import {
+  to = posthog_insight.insight_11251183
+  id = "549883/11251183"
+}
+
+import {
+  to = posthog_insight.insight_11251182
+  id = "549883/11251182"
+}
+
+import {
+  to = posthog_insight.insight_11251174
+  id = "549883/11251174"
+}
+
+import {
+  to = posthog_insight.insight_11251173
+  id = "549883/11251173"
+}
+
+import {
+  to = posthog_insight.insight_10892238
+  id = "549883/10892238"
+}
+
+import {
+  to = posthog_insight.insight_10892237
+  id = "549883/10892237"
+}
+
+import {
+  to = posthog_insight.insight_10892236
+  id = "549883/10892236"
+}
+
+import {
+  to = posthog_insight.insight_10892235
+  id = "549883/10892235"
+}
+
+import {
+  to = posthog_insight.insight_10892234
+  id = "549883/10892234"
+}
+
+import {
+  to = posthog_insight.insight_10892233
+  id = "549883/10892233"
+}
+
+import {
+  to = posthog_insight.insight_10892232
+  id = "549883/10892232"
+}
+
+import {
+  to = posthog_insight.insight_10892231
+  id = "549883/10892231"
+}
+
+import {
+  to = posthog_insight.insight_10892230
+  id = "549883/10892230"
+}
+
+import {
+  to = posthog_insight.insight_10892228
+  id = "549883/10892228"
+}
+
+import {
+  to = posthog_insight.insight_10892227
+  id = "549883/10892227"
+}
+
+import {
+  to = posthog_insight.insight_10892226
+  id = "549883/10892226"
+}
+
+import {
+  to = posthog_insight.insight_10892225
+  id = "549883/10892225"
+}
+
+import {
+  to = posthog_insight.insight_10892224
+  id = "549883/10892224"
+}
+
+import {
+  to = posthog_insight.insight_10892223
+  id = "549883/10892223"
+}
+
+import {
+  to = posthog_insight.insight_10892220
+  id = "549883/10892220"
+}
+
+import {
+  to = posthog_insight.insight_10892219
+  id = "549883/10892219"
+}
+
+import {
+  to = posthog_insight.insight_10892218
+  id = "549883/10892218"
+}
+
+import {
+  to = posthog_insight.insight_10892217
+  id = "549883/10892217"
+}
+
+import {
+  to = posthog_insight.insight_10892216
+  id = "549883/10892216"
+}
+
+import {
+  to = posthog_insight.insight_10892215
+  id = "549883/10892215"
+}
+
+import {
+  to = posthog_insight.insight_10892214
+  id = "549883/10892214"
+}
+
+import {
+  to = posthog_insight.insight_10892213
+  id = "549883/10892213"
+}
+
+import {
+  to = posthog_insight.insight_10892212
+  id = "549883/10892212"
+}
+
+import {
+  to = posthog_insight.insight_10892186
+  id = "549883/10892186"
+}
+
+import {
+  to = posthog_insight.insight_10892185
+  id = "549883/10892185"
+}
+
+import {
+  to = posthog_insight.insight_10892183
+  id = "549883/10892183"
+}
+
+import {
+  to = posthog_insight.insight_10892182
+  id = "549883/10892182"
+}
+
+import {
+  to = posthog_insight.insight_10892181
+  id = "549883/10892181"
+}
+
+import {
+  to = posthog_insight.insight_10892180
+  id = "549883/10892180"
+}
+
+import {
+  to = posthog_insight.insight_10892179
+  id = "549883/10892179"
+}
+
+import {
+  to = posthog_insight.insight_10892178
+  id = "549883/10892178"
+}
+
+import {
+  to = posthog_insight.insight_10892177
+  id = "549883/10892177"
+}
+
+import {
+  to = posthog_insight.insight_10892176
+  id = "549883/10892176"
+}
+
+import {
+  to = posthog_insight.insight_10881557
+  id = "549883/10881557"
+}
+
+import {
+  to = posthog_insight.insight_10881556
+  id = "549883/10881556"
+}
+
+import {
+  to = posthog_insight.insight_10881555
+  id = "549883/10881555"
+}
+
+import {
+  to = posthog_insight.insight_10881554
+  id = "549883/10881554"
+}
+
+import {
+  to = posthog_insight.insight_10881553
+  id = "549883/10881553"
+}
+
+import {
+  to = posthog_insight.insight_10881552
+  id = "549883/10881552"
+}
+
+import {
+  to = posthog_insight.insight_10881551
+  id = "549883/10881551"
+}
+
+import {
+  to = posthog_insight.insight_10881550
+  id = "549883/10881550"
+}
+
+import {
+  to = posthog_hog_function.geoip
+  id = "549883/019fe7f8-ee1c-0000-8f3e-476e8dac0c40"
+}
+
+import {
+  to = posthog_external_data_source.pinterest_ads
+  id = "549883/019fea2b-19c4-0000-44e0-a7cc6f88a65b"
+}
+
+import {
+  to = posthog_proxy_record.j_sjer_red
+  id = "019fe7f8-ecce-0000-adca-fe93618022c7/019fea37-95d4-0000-a853-32ba533f6f8c"
+}

--- a/packages/homelab/src/tofu/posthog/providers.tf
+++ b/packages/homelab/src/tofu/posthog/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    posthog = {
+      source  = "PostHog/posthog"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "posthog" {
+  organization_id = local.organization_id
+  project_id      = local.project_id
+}

--- a/packages/homelab/src/tofu/posthog/variables.tf
+++ b/packages/homelab/src/tofu/posthog/variables.tf
@@ -1,0 +1,24 @@
+variable "state_passphrase" {
+  description = "Passphrase used to encrypt this stack's state and plan data."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = length(var.state_passphrase) >= 16
+    error_message = "The PostHog state passphrase must contain at least 16 characters."
+  }
+}
+
+locals {
+  organization_id = "019fe7f8-ecce-0000-adca-fe93618022c7"
+  project_id      = "549883"
+
+  analytics_registry = jsondecode(file("${path.module}/../../../../../config/analytics-sites.json"))
+  app_urls = [
+    for site in local.analytics_registry.sites : "https://${site.hostname}"
+  ]
+  recording_domains = [
+    for site in local.analytics_registry.sites : "https://${site.hostname}"
+    if site.sessionReplay
+  ]
+}

--- a/scripts/check-ci-env.test.ts
+++ b/scripts/check-ci-env.test.ts
@@ -4,10 +4,11 @@ import { parse } from "yaml";
 import {
   ciSecretItemId,
   collectErrors,
-  collectSteps,
+  onePasswordItemIds,
   type RequiredEnv,
   type SecretFields,
 } from "./check-ci-env.ts";
+import { collectSteps } from "./lib/ci-env-pipeline.ts";
 import {
   assignedEnvNames,
   commandScopes,
@@ -86,6 +87,17 @@ describe("ciSecretItemId", () => {
     expect(() =>
       ciSecretItemId('new OnePasswordItem(chart, "buildkite-ci-secrets", {});'),
     ).toThrow("declares no vaults");
+  });
+
+  test("indexes each declared Kubernetes secret by its own 1Password item", () => {
+    const itemIds = onePasswordItemIds(
+      `${declaration}
+      new OnePasswordItem(chart, "posthog-tofu-credentials", {
+        spec: { itemPath: "vaults/vault-a/items/item-for-posthog" },
+      });`,
+    );
+    expect(itemIds.get("buildkite-ci-secrets")).toBe("item-for-the-ci-secret");
+    expect(itemIds.get("posthog-tofu-credentials")).toBe("item-for-posthog");
   });
 });
 
@@ -219,6 +231,11 @@ steps:
                     value: ""
                   - name: FROM_FIELD_REF
                     valueFrom: { fieldRef: { fieldPath: metadata.name } }
+                  - name: FROM_POSTHOG_SECRET
+                    valueFrom:
+                      secretKeyRef:
+                        name: posthog-tofu-credentials
+                        key: POSTHOG_API_KEY
 `,
       { merge: true },
     );
@@ -228,6 +245,13 @@ steps:
     expect(step?.providedNames.has("CONTAINER_EMPTY")).toBe(false);
     // An absent `value` means valueFrom, which does provide one.
     expect(step?.providedNames.has("FROM_FIELD_REF")).toBe(true);
+    // A secretKeyRef needs vault-snapshot validation; treating it as a literal
+    // value would let a typo or blank 1Password field pass CI.
+    expect(step?.providedNames.has("FROM_POSTHOG_SECRET")).toBe(false);
+    expect(step?.explicitSecretRefs?.get("FROM_POSTHOG_SECRET")).toEqual({
+      secretName: "posthog-tofu-credentials",
+      key: "POSTHOG_API_KEY",
+    });
   });
 
   test("records the CI secret, container env, and global env per step", () => {
@@ -291,6 +315,86 @@ describe("collectErrors", () => {
       steps: [step],
       secret: secretWith(["NPM_TOKEN"], ["NPM_TOKEN"]),
       requiredFor: () => required({ NPM_TOKEN: "scripts/release.ts:20" }),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("BLANK");
+  });
+
+  test("validates explicit secretKeyRefs against their own declared item", () => {
+    const explicitSecrets = new Map([
+      ["posthog-tofu-credentials", secretWith(["POSTHOG_API_KEY"])],
+    ]);
+    const errors = collectErrors({
+      steps: [
+        {
+          ...step,
+          explicitSecretRefs: new Map([
+            [
+              "POSTHOG_CLI_API_KEY",
+              {
+                secretName: "posthog-tofu-credentials",
+                key: "POSTHOG_API_KEY",
+              },
+            ],
+          ]),
+        },
+      ],
+      secret: secretWith([]),
+      explicitSecrets,
+      requiredFor: () => required({ POSTHOG_CLI_API_KEY: "tofu-stack.ts:80" }),
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("reports a missing explicit secretKeyRef field", () => {
+    const errors = collectErrors({
+      steps: [
+        {
+          ...step,
+          explicitSecretRefs: new Map([
+            [
+              "POSTHOG_CLI_API_KEY",
+              {
+                secretName: "posthog-tofu-credentials",
+                key: "POSTHOG_API_KEY",
+              },
+            ],
+          ]),
+        },
+      ],
+      secret: secretWith([]),
+      explicitSecrets: new Map([["posthog-tofu-credentials", secretWith([])]]),
+      requiredFor: () => required({ POSTHOG_CLI_API_KEY: "tofu-stack.ts:80" }),
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("posthog-tofu-credentials");
+    expect(errors[0]).toContain("POSTHOG_API_KEY");
+  });
+
+  test("reports a blank explicit secretKeyRef field", () => {
+    const errors = collectErrors({
+      steps: [
+        {
+          ...step,
+          explicitSecretRefs: new Map([
+            [
+              "POSTHOG_CLI_API_KEY",
+              {
+                secretName: "posthog-tofu-credentials",
+                key: "POSTHOG_API_KEY",
+              },
+            ],
+          ]),
+        },
+      ],
+      secret: secretWith([]),
+      explicitSecrets: new Map([
+        [
+          "posthog-tofu-credentials",
+          secretWith(["POSTHOG_API_KEY"], ["POSTHOG_API_KEY"]),
+        ],
+      ]),
+      requiredFor: () => required({ POSTHOG_CLI_API_KEY: "tofu-stack.ts:80" }),
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("BLANK");

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -35,7 +35,11 @@ import path from "node:path";
 import { parse } from "yaml";
 import { Project, SyntaxKind, type SourceFile } from "ts-morph";
 import { z } from "zod";
-import { commandScopes } from "./lib/ci-env-command.ts";
+import {
+  CI_SECRET_NAME,
+  collectSteps,
+  type PipelineStep,
+} from "./lib/ci-env-pipeline.ts";
 
 const REPOSITORY_ROOT = path.resolve(import.meta.dir, "..");
 const PIPELINE_PATH = path.join(REPOSITORY_ROOT, ".buildkite", "pipeline.yml");
@@ -47,8 +51,6 @@ const SNAPSHOT_PATH = path.join(
   "cdk8s",
   "onepassword-vault-snapshot.json",
 );
-/** The secret `envFrom: { secretRef: { name } }` names in every pipeline step. */
-const CI_SECRET_NAME = "buildkite-ci-secrets";
 /**
  * cdk8s owns which 1Password item backs that secret, so the item id is read
  * from the `OnePasswordItem` declaration rather than duplicated here — a
@@ -115,6 +117,34 @@ const STEP_REQUIREMENT_EXCEPTIONS: readonly {
 }[] = [
   {
     step: "pr-dryrun",
+    script: "packages/homelab/scripts/tofu-stack.ts",
+    names: ["POSTHOG_CLI_API_KEY", "POSTHOG_TOFU_STATE_PASSPHRASE"],
+    reason:
+      "The shared PR Tofu pod plans only seaweedfs, tailscale, buildkite, arr, " +
+      "github, and cloudflare. posthog has its own credential-isolated plan pod.",
+  },
+  {
+    step: "tofu-apply",
+    script: "packages/homelab/scripts/tofu-stack.ts",
+    names: ["POSTHOG_CLI_API_KEY", "POSTHOG_TOFU_STATE_PASSPHRASE"],
+    reason:
+      "The infra-state apply loop excludes posthog, which has a dedicated " +
+      "credential-isolated main apply lane.",
+  },
+  {
+    step: "tofu-github",
+    script: "packages/homelab/scripts/tofu-stack.ts",
+    names: ["POSTHOG_CLI_API_KEY", "POSTHOG_TOFU_STATE_PASSPHRASE"],
+    reason: "This lane invokes only the github stack.",
+  },
+  {
+    step: "tofu-cloudflare",
+    script: "packages/homelab/scripts/tofu-stack.ts",
+    names: ["POSTHOG_CLI_API_KEY", "POSTHOG_TOFU_STATE_PASSPHRASE"],
+    reason: "This lane invokes only the cloudflare stack.",
+  },
+  {
+    step: "pr-dryrun",
     script: "scripts/deploy-site.ts",
     names: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
     reason:
@@ -175,6 +205,32 @@ export function hash(value: string): string {
  * unreadable declaration means this check would otherwise validate against
  * the wrong item and report a clean run.
  */
+export function onePasswordItemIds(
+  declarationSource: string,
+): Map<string, string> {
+  const declarations = declarationSource.split("new OnePasswordItem(chart,");
+  const ids = new Map<string, string>();
+  for (const declaration of declarations.slice(1)) {
+    const name = /^\s*"([^"]+)"/u.exec(declaration)?.[1];
+    if (name === undefined) continue;
+    const nextDeclaration = declaration.indexOf("new OnePasswordItem(chart,");
+    const body =
+      nextDeclaration === -1
+        ? declaration
+        : declaration.slice(0, nextDeclaration);
+    const itemId = /vaults\/[\w-]+\/items\/([\w-]+)/u.exec(body)?.[1];
+    if (itemId === undefined) continue;
+    if (ids.has(name)) {
+      throw new Error(
+        `multiple OnePasswordItem declarations are named "${name}"`,
+      );
+    }
+    ids.set(name, itemId);
+  }
+  return ids;
+}
+
+/** The item id backing the shared `buildkite-ci-secrets` Secret. */
 export function ciSecretItemId(declarationSource: string): string {
   const anchor = declarationSource.indexOf(`"${CI_SECRET_NAME}"`);
   if (anchor === -1) {
@@ -182,129 +238,13 @@ export function ciSecretItemId(declarationSource: string): string {
       `no OnePasswordItem named "${CI_SECRET_NAME}" in the cdk8s declaration`,
     );
   }
-  const itemPath = /vaults\/[\w-]+\/items\/([\w-]+)/u.exec(
-    declarationSource.slice(anchor),
-  );
-  const id = itemPath?.[1];
+  const id = onePasswordItemIds(declarationSource).get(CI_SECRET_NAME);
   if (id === undefined) {
     throw new Error(
       `the "${CI_SECRET_NAME}" OnePasswordItem declares no vaults/…/items/… itemPath`,
     );
   }
   return id;
-}
-
-type PipelineStep = {
-  key: string;
-  providedNames: Set<string>;
-  usesCiSecret: boolean;
-  scripts: string[];
-};
-
-const StepSchema = z
-  .object({
-    key: z.string().optional(),
-    label: z.string().optional(),
-    command: z.union([z.string(), z.array(z.string())]).optional(),
-    env: z.record(z.string(), z.unknown()).optional(),
-    plugins: z.array(z.unknown()).optional(),
-  })
-  .loose();
-
-const ContainerEnvSchema = z.object({
-  env: z
-    .array(z.object({ name: z.string(), value: z.string().optional() }).loose())
-    .optional(),
-  envFrom: z
-    .array(
-      z.object({ secretRef: z.object({ name: z.string() }).loose() }).loose(),
-    )
-    .optional(),
-});
-const RecordSchema = z.record(z.string(), z.unknown());
-
-/**
- * Every `env` name and `envFrom` secret reachable anywhere inside a step. The
- * kubernetes plugin nests containers differently per anchor (`podSpec` vs
- * `podSpecPatch`), so this walks the whole subtree rather than a fixed path.
- */
-function collectContainerEnv(
-  node: unknown,
-  names: Set<string>,
-  secrets: Set<string>,
-): void {
-  if (Array.isArray(node)) {
-    for (const item of node) collectContainerEnv(item, names, secrets);
-    return;
-  }
-  const record = RecordSchema.safeParse(node);
-  if (!record.success) return;
-  const container = ContainerEnvSchema.safeParse(record.data);
-  if (container.success) {
-    for (const entry of container.data.env ?? []) {
-      // An explicitly empty value is not a provision: requireEnv treats "" as
-      // missing and throws, so counting it would pass the check on a step
-      // whose script fails at runtime. An absent `value` means `valueFrom`
-      // (secret/fieldRef), which does provide one.
-      if (entry.value === "") continue;
-      names.add(entry.name);
-    }
-    for (const entry of container.data.envFrom ?? []) {
-      secrets.add(entry.secretRef.name);
-    }
-  }
-  for (const value of Object.values(record.data)) {
-    collectContainerEnv(value, names, secrets);
-  }
-}
-
-export function collectSteps(
-  pipeline: unknown,
-  globalEnvNames: readonly string[],
-): PipelineStep[] {
-  const document = z
-    .object({
-      env: z.record(z.string(), z.unknown()).optional(),
-      steps: z.array(z.unknown()).optional(),
-    })
-    .loose()
-    .parse(pipeline);
-  const steps: PipelineStep[] = [];
-  for (const [index, raw] of (document.steps ?? []).entries()) {
-    const parsed = StepSchema.safeParse(raw);
-    if (!parsed.success) continue;
-    const step = parsed.data;
-    const command =
-      step.command === undefined
-        ? ""
-        : Array.isArray(step.command)
-          ? step.command.join("\n")
-          : step.command;
-    if (command.trim() === "") continue;
-    const stepNames = new Set<string>([
-      ...globalEnvNames,
-      // Same rule as container env: a step-level key set to an empty string
-      // satisfies nothing, because requireEnv rejects "" as missing.
-      ...Object.entries(step.env ?? {})
-        .filter(([, value]) => value !== "")
-        .map(([key]) => key),
-    ]);
-    const secrets = new Set<string>();
-    collectContainerEnv(step.plugins, stepNames, secrets);
-    const key = step.key ?? step.label ?? `step[${String(index)}]`;
-    // One entry per subshell scope: a name exported inside `( … )` reaches the
-    // scripts in that block and no others.
-    for (const scope of commandScopes(command)) {
-      if (scope.scripts.length === 0) continue;
-      steps.push({
-        key,
-        providedNames: new Set([...stepNames, ...scope.assigned]),
-        usesCiSecret: secrets.has(CI_SECRET_NAME),
-        scripts: [...new Set(scope.scripts)].toSorted(),
-      });
-    }
-  }
-  return steps;
 }
 
 export type RequiredEnv = {
@@ -416,11 +356,36 @@ function unmetRequirement(
     site: string;
   },
   secret: SecretFields,
+  explicitSecrets: ReadonlyMap<string, SecretFields>,
 ): string | null {
   const { step, entry, name, site } = requirement;
   if (isAgentProvided(name)) return null;
   if (step.providedNames.has(name)) return null;
   const prefix = `step "${step.key}" runs ${entry}, which requires ${name} (${site})`;
+  const explicitRef = step.explicitSecretRefs?.get(name);
+  if (explicitRef !== undefined) {
+    const referencedSecret = explicitSecrets.get(explicitRef.secretName);
+    if (referencedSecret === undefined) {
+      return (
+        `${prefix}, but its secretKeyRef names ${explicitRef.secretName}, which has no ` +
+        `OnePasswordItem declaration backed by the vault snapshot.`
+      );
+    }
+    if (!referencedSecret.hasField(explicitRef.key)) {
+      return (
+        `${prefix}, but ${explicitRef.secretName} does not contain key ${explicitRef.key} ` +
+        `in its declared 1Password item. Refresh the vault snapshot after adding it.`
+      );
+    }
+    if (referencedSecret.isBlank(explicitRef.key)) {
+      return (
+        `${prefix}, but ${explicitRef.secretName} key ${explicitRef.key} is BLANK ` +
+        `in its declared 1Password item. The operator skips empty fields, so the ` +
+        `variable would be missing at runtime.`
+      );
+    }
+    return null;
+  }
   if (step.usesCiSecret && secret.hasField(name)) {
     if (!secret.isBlank(name)) return null;
     return (
@@ -442,6 +407,7 @@ function errorsForInvocation(
     required: RequiredEnv;
   },
   secret: SecretFields,
+  explicitSecrets: ReadonlyMap<string, SecretFields>,
   exceptionsByFile: ReadonlyMap<string, DynamicCallException>,
 ): string[] {
   const { step, entry, required } = invocation;
@@ -469,7 +435,11 @@ function errorsForInvocation(
   );
   for (const [name, site] of names) {
     if (excepted.has(name)) continue;
-    const unmet = unmetRequirement({ step, entry, name, site }, secret);
+    const unmet = unmetRequirement(
+      { step, entry, name, site },
+      secret,
+      explicitSecrets,
+    );
     if (unmet !== null) errors.push(unmet);
   }
   return errors;
@@ -478,6 +448,8 @@ function errorsForInvocation(
 export function collectErrors(input: {
   steps: readonly PipelineStep[];
   secret: SecretFields;
+  /** Secrets addressed through explicit Kubernetes secretKeyRefs. */
+  explicitSecrets?: ReadonlyMap<string, SecretFields>;
   requiredFor: (entry: string) => RequiredEnv;
   /** Defaults to the declared table; injected by tests. */
   dynamicCallExceptions?: readonly DynamicCallException[];
@@ -495,6 +467,7 @@ export function collectErrors(input: {
         ...errorsForInvocation(
           { step, entry, required: input.requiredFor(entry) },
           input.secret,
+          input.explicitSecrets ?? new Map(),
           exceptionsByFile,
         ),
       );
@@ -511,6 +484,7 @@ function fail(message: string, code: number): never {
 async function main(): Promise<void> {
   let steps: PipelineStep[];
   let secret: SecretFields;
+  let explicitSecrets: Map<string, SecretFields>;
   try {
     const pipeline: unknown = parse(await Bun.file(PIPELINE_PATH).text(), {
       merge: true,
@@ -528,7 +502,9 @@ async function main(): Promise<void> {
   }
   try {
     const snapshot = SnapshotSchema.parse(await Bun.file(SNAPSHOT_PATH).json());
-    const itemId = ciSecretItemId(await Bun.file(CI_SECRET_DECLARATION).text());
+    const declarations = await Bun.file(CI_SECRET_DECLARATION).text();
+    const itemIds = onePasswordItemIds(declarations);
+    const itemId = ciSecretItemId(declarations);
     const item = snapshot.items.find((entry) => entry.ref === hash(itemId));
     if (item === undefined) {
       fail(
@@ -543,6 +519,19 @@ async function main(): Promise<void> {
       hasField: (name: string) => fields.has(hash(name)),
       isBlank: (name: string) => blanks.has(hash(name)),
     };
+    explicitSecrets = new Map();
+    for (const [secretName, declaredItemId] of itemIds) {
+      const declaredItem = snapshot.items.find(
+        (entry) => entry.ref === hash(declaredItemId),
+      );
+      if (declaredItem === undefined) continue;
+      const declaredFields = new Set(declaredItem.fields);
+      const declaredBlanks = new Set(declaredItem.blankFields);
+      explicitSecrets.set(secretName, {
+        hasField: (name: string) => declaredFields.has(hash(name)),
+        isBlank: (name: string) => declaredBlanks.has(hash(name)),
+      });
+    }
   } catch (error: unknown) {
     fail(
       `check-ci-env: could not read the vault snapshot: ${String(error)}`,
@@ -564,7 +553,12 @@ async function main(): Promise<void> {
     return computed;
   };
 
-  const errors = collectErrors({ steps, secret, requiredFor });
+  const errors = collectErrors({
+    steps,
+    secret,
+    explicitSecrets,
+    requiredFor,
+  });
   if (errors.length > 0) {
     for (const error of errors) console.error(`✗ ${error}`);
     fail(

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -144,6 +144,19 @@ const STEP_REQUIREMENT_EXCEPTIONS: readonly {
     reason: "This lane invokes only the cloudflare stack.",
   },
   {
+    step: "tofu-posthog-plan",
+    script: "packages/homelab/scripts/tofu-stack.ts",
+    names: [
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "POSTHOG_CLI_API_KEY",
+      "POSTHOG_TOFU_STATE_PASSPHRASE",
+    ],
+    reason:
+      "PRs run the posthog validate action with backend-free OpenTofu and a " +
+      "non-sensitive placeholder; the credentialed plan/apply runs only on main.",
+  },
+  {
     step: "pr-dryrun",
     script: "scripts/deploy-site.ts",
     names: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],

--- a/scripts/check-ci-env.ts
+++ b/scripts/check-ci-env.ts
@@ -153,8 +153,7 @@ const STEP_REQUIREMENT_EXCEPTIONS: readonly {
       "POSTHOG_TOFU_STATE_PASSPHRASE",
     ],
     reason:
-      "PRs run the posthog validate action with backend-free OpenTofu and a " +
-      "non-sensitive placeholder; the credentialed plan/apply runs only on main.",
+      "PR validation uses backend-free OpenTofu with a placeholder; main alone gets credentials.",
   },
   {
     step: "pr-dryrun",

--- a/scripts/lib/ci-env-pipeline.ts
+++ b/scripts/lib/ci-env-pipeline.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+
+import { commandScopes } from "./ci-env-command.ts";
+
+export const CI_SECRET_NAME = "buildkite-ci-secrets";
+
+export type SecretKeyRef = { secretName: string; key: string };
+
+export type PipelineStep = {
+  key: string;
+  providedNames: Set<string>;
+  usesCiSecret: boolean;
+  explicitSecretRefs?: ReadonlyMap<string, SecretKeyRef>;
+  scripts: string[];
+};
+
+const StepSchema = z
+  .object({
+    key: z.string().optional(),
+    label: z.string().optional(),
+    command: z.union([z.string(), z.array(z.string())]).optional(),
+    env: z.record(z.string(), z.unknown()).optional(),
+    plugins: z.array(z.unknown()).optional(),
+  })
+  .loose();
+
+const ValueFromSchema = z
+  .object({
+    secretKeyRef: z.object({ name: z.string(), key: z.string() }).optional(),
+  })
+  .loose();
+const ContainerEnvSchema = z.object({
+  env: z
+    .array(
+      z
+        .object({
+          name: z.string(),
+          value: z.string().optional(),
+          valueFrom: ValueFromSchema.optional(),
+        })
+        .loose(),
+    )
+    .optional(),
+  envFrom: z
+    .array(
+      z.object({ secretRef: z.object({ name: z.string() }).loose() }).loose(),
+    )
+    .optional(),
+});
+const RecordSchema = z.record(z.string(), z.unknown());
+
+/**
+ * Every `env` name and `envFrom` secret reachable anywhere inside a step. The
+ * kubernetes plugin nests containers differently per anchor (`podSpec` vs
+ * `podSpecPatch`), so this walks the whole subtree rather than a fixed path.
+ */
+function collectContainerEnv(
+  node: unknown,
+  names: Set<string>,
+  secrets: Set<string>,
+  explicitSecretRefs: Map<string, SecretKeyRef>,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectContainerEnv(item, names, secrets, explicitSecretRefs);
+    }
+    return;
+  }
+  const record = RecordSchema.safeParse(node);
+  if (!record.success) return;
+  const container = ContainerEnvSchema.safeParse(record.data);
+  if (container.success) {
+    for (const entry of container.data.env ?? []) {
+      // An explicitly empty value is not a provision: requireEnv treats "" as
+      // missing and throws, so counting it would pass the check on a step
+      // whose script fails at runtime. A secretKeyRef is checked against its
+      // declaring OnePasswordItem and hashed vault snapshot below; other
+      // valueFrom sources (for example a pod fieldRef) do provide a value.
+      if (entry.value !== undefined) {
+        if (entry.value !== "") names.add(entry.name);
+      } else if (entry.valueFrom?.secretKeyRef !== undefined) {
+        explicitSecretRefs.set(entry.name, {
+          secretName: entry.valueFrom.secretKeyRef.name,
+          key: entry.valueFrom.secretKeyRef.key,
+        });
+      } else if (entry.valueFrom !== undefined) {
+        names.add(entry.name);
+      }
+    }
+    for (const entry of container.data.envFrom ?? []) {
+      secrets.add(entry.secretRef.name);
+    }
+  }
+  for (const value of Object.values(record.data)) {
+    collectContainerEnv(value, names, secrets, explicitSecretRefs);
+  }
+}
+
+export function collectSteps(
+  pipeline: unknown,
+  globalEnvNames: readonly string[],
+): PipelineStep[] {
+  const document = z
+    .object({
+      env: z.record(z.string(), z.unknown()).optional(),
+      steps: z.array(z.unknown()).optional(),
+    })
+    .loose()
+    .parse(pipeline);
+  const steps: PipelineStep[] = [];
+  for (const [index, raw] of (document.steps ?? []).entries()) {
+    const parsed = StepSchema.safeParse(raw);
+    if (!parsed.success) continue;
+    const step = parsed.data;
+    const command =
+      step.command === undefined
+        ? ""
+        : Array.isArray(step.command)
+          ? step.command.join("\n")
+          : step.command;
+    if (command.trim() === "") continue;
+    const stepNames = new Set<string>([
+      ...globalEnvNames,
+      // Same rule as container env: a step-level key set to an empty string
+      // satisfies nothing, because requireEnv rejects "" as missing.
+      ...Object.entries(step.env ?? {})
+        .filter(([, value]) => value !== "")
+        .map(([key]) => key),
+    ]);
+    const secrets = new Set<string>();
+    const explicitSecretRefs = new Map<string, SecretKeyRef>();
+    collectContainerEnv(step.plugins, stepNames, secrets, explicitSecretRefs);
+    const key = step.key ?? step.label ?? `step[${String(index)}]`;
+    // One entry per subshell scope: a name exported inside `( … )` reaches the
+    // scripts in that block and no others.
+    for (const scope of commandScopes(command)) {
+      if (scope.scripts.length === 0) continue;
+      steps.push({
+        key,
+        providedNames: new Set([...stepNames, ...scope.assigned]),
+        usesCiSecret: secrets.has(CI_SECRET_NAME),
+        explicitSecretRefs,
+        scripts: [...new Set(scope.scripts)].toSorted(),
+      });
+    }
+  }
+  return steps;
+}


### PR DESCRIPTION
## Why

PostHog's supported control-plane resources currently live outside GitOps. This
adopts them without recreation, keeps encryption material out of state history,
and ensures only the dedicated Tofu jobs can read the PostHog credentials.

## What

- Adds an encrypted `posthog` OpenTofu stack with permanent imports for 79
  existing resources and provider v1.0.17.
- Imports the existing unproxied `j.sjer.red` ProxyHog CNAME in the Cloudflare
  stack; both the DNS record and destructive PostHog resources are guarded.
- Adds backend-free, secretless PR validation plus a trusted main-only
  credentialed plan/apply lane. `POSTHOG_CLI_API_KEY` maps only inside that
  main process to provider-standard `POSTHOG_API_KEY`; the passphrase maps only
  to `TF_VAR_state_passphrase`, and the apply pod receives only explicit
  SeaweedFS and PostHog fields.
- Extends `check-ci-env` to validate explicit `secretKeyRef` fields against the
  declared 1Password item and hashed snapshot, including missing and blank
  fields.
- Documents ownership, drift, encrypted-state recovery, provider limits, and
  Live Events verification.

The only intended product behavior change is updating `app_urls` and
`recording_domains` from the 13 registered analytics origins. Dashboard layouts
are fully authoritative and preserve every existing tile.

## Verification

- `bun test scripts/check-ci-env.test.ts`
- `bun run scripts/check-ci-env.ts`
- `bun test ./.buildkite/scripts/ci-lane-coverage.test.ts`
- `bun test ./.buildkite/scripts/validate-pipeline-release.test.ts`
- `bun test ./.buildkite/scripts/select-main-pipeline.test.ts`
- `bun test ./.buildkite/scripts/ci-changed.test.ts`
- `bun test ./.buildkite/scripts/annotate-build-summary.test.ts`
- `bunx turbo run typecheck --filter=homelab`
- `bun --no-install packages/homelab/scripts/tofu-stack.ts posthog validate`
- `bun run --cwd packages/homelab/src/cdk8s scripts/check-1password-items.ts`
- `bun --no-install .buildkite/scripts/validate-pipeline.ts`
- `tofu fmt -check`, backend-free init, and `tofu validate`
- Read-only PostHog plan: **79 imports, 0 adds, 2 intentional changes, 0 destroys**.
- Read-only Cloudflare plan: **1 CNAME import, 0 adds/changes/destroys**.
- `bun run verify`: 297/298 tasks passed; the sole local failure is the resume
  package's missing `xelatex` executable.

Visual documentation proof is pending because the local in-app browser was not
available to capture the rendered wiki page. The wiki build, typecheck, and
tests pass.

## Rollout

The prerequisite PR #2452 is merged and its GitOps release created the
`posthog-tofu-credentials` Secret with the two expected keys (verified by name
only). Its exact-main Buildkite build #11491 subsequently failed in
`release-please`, so the prerequisite does not yet have the required green
exact-main build record. After merge, validate a no-change plan, 79 state
addresses, the Cloudflare CNAME, PostHog API reads, and Live Events/session
recording from all 13 registered origins.
