### PR TITLE
feat(homelab): provision scoped Buildkite credentials

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/ci-pipeline-shape.md
+++ b/packages/docs/wiki/src/content/docs/explanation/ci-pipeline-shape.md
@@ -114,6 +114,28 @@ The [release pod definition](https://github.com/shepherdjerred/monorepo/blob/mai
 and [refiner boundary](https://github.com/shepherdjerred/monorepo/blob/main/scripts/lib/release-refiner.ts)
 define that separation.
 
+## Credentials follow issuer and rotation boundaries
+
+Buildkite credentials are stored in 1Password by issuer or rotation unit, not
+by an arbitrary target number of Secrets. GitHub, Buildkite, Turbo, npm,
+Claude, ChartMuseum, Argo CD, SeaweedFS, Cloudflare, Tailscale, and the ARR and
+tracker services therefore have independent items and Kubernetes Secrets.
+Semantic field names distinguish identities that may initially carry the same
+value but must rotate independently later, such as GitHub download, review,
+package publication, App, and OpenTofu access.
+
+The migration uses two stages. The first stage provisions all replacement
+Secrets while existing jobs continue reading the legacy aggregate Secret. It
+also creates the tokenless `buildkite-job` service account without a
+RoleBinding. This keeps the bootstrap additive: Argo CD can reconcile the new
+boundary before any running job depends on it. The second stage assigns each
+command container only its declared `secretKeyRef` grants, moves jobs to
+`buildkite-job`, and removes the legacy Secret declaration in the same change.
+
+The stable field names make later rotations pipeline-independent. The
+[Buildkite credential rotation procedure](/how-to/rotate-buildkite-credentials/)
+defines the reconciliation, acceptance, and archival checks.
+
 ## Related
 
 - [About the monorepo](/explanation/monorepo/) — why CI is Buildkite at all

--- a/packages/docs/wiki/src/content/docs/how-to/rotate-buildkite-credentials.md
+++ b/packages/docs/wiki/src/content/docs/how-to/rotate-buildkite-credentials.md
@@ -1,0 +1,82 @@
+---
+title: Rotate a Buildkite CI credential
+description: Replace one scoped Buildkite credential and verify its 1Password, Kubernetes, CI, and legacy-retirement boundaries.
+---
+
+Use this procedure after Buildkite jobs have moved to the exact grants in
+`.buildkite/secret-grants.json`. Rotate one semantic field at a time so a failed
+acceptance check identifies one provider boundary.
+
+## 1. Identify the rotation unit
+
+Find the job grants for the credential in
+`.buildkite/secret-grants.json`. Confirm the field belongs to the expected
+issuer item and list the affected Buildkite step keys. Do not change the
+pipeline when replacing a value behind an existing semantic field.
+
+If a narrower provider identity is not ready, stop. Copying a broad value into
+a semantic field is acceptable only during the initial migration; it is not a
+completed rotation.
+
+## 2. Replace the field in 1Password
+
+Mint the replacement identity with the provider, then update only the matching
+field in its dedicated Buildkite 1Password item. Use the 1Password app or a
+non-printing `op item edit` invocation. Do not place the value in a shell
+argument, file, snapshot, command output, or chat.
+
+Keep the previous identity active until the replacement passes the live checks
+below.
+
+## 3. Wait for 1Password reconciliation
+
+Argo CD owns the `OnePasswordItem` resource. The 1Password Connect operator
+turns that resource into the same-named Kubernetes Secret. Wait for the
+Application to become synced and healthy, then confirm both resources exist:
+
+```bash
+kubectl get onepassworditem -n buildkite <secret-name>
+kubectl get secret -n buildkite <secret-name>
+```
+
+Print key names only and compare them with the manifest. Do not print or decode
+values:
+
+```bash
+kubectl get secret -n buildkite <secret-name> -o json |
+  jq -r '.data | keys[]'
+```
+
+## 4. Prove the job boundary
+
+Confirm the job identity still cannot enumerate or read Kubernetes Secrets:
+
+```bash
+kubectl auth can-i list secrets \
+  --as=system:serviceaccount:buildkite:buildkite-job -n buildkite
+kubectl auth can-i get secrets \
+  --as=system:serviceaccount:buildkite:buildkite-job -n buildkite
+```
+
+Both commands must return `no`. Inspect a pod from each affected step and
+confirm only `container-0` contains the expected `secretKeyRef`; the agent,
+checkout, init, and sidecar containers must contain none. The pod must use
+`buildkite-job` with `automountServiceAccountToken: false`.
+
+## 5. Run live acceptance
+
+Trigger or wait for the affected lane on the exact current `main` commit. A
+source check or successful Secret reconciliation is not enough: require the
+Buildkite job itself to pass and require any deployment it performs to finish
+successfully.
+
+If the job fails authentication, restore the previous field value, wait for the
+1Password operator to reconcile it, and diagnose the provider identity before
+trying another rotation.
+
+## 6. Retire the previous identity
+
+After the exact-main job and its deployment acceptance pass, revoke the prior
+provider identity. During the aggregate-Secret migration, first confirm no live
+pod references `buildkite-ci-secrets` and Argo CD has removed that Secret; only
+then archive the old aggregate 1Password item.

--- a/packages/dotfiles/private_dot_config/private_turbo-cache/private_env.fish.tmpl
+++ b/packages/dotfiles/private_dot_config/private_turbo-cache/private_env.fish.tmpl
@@ -2,7 +2,7 @@
 # Managed by chezmoi. Local-only is the default for unreliable networks.
 set -gx TURBO_API 'https://turbo-cache.tailnet-1a49.ts.net'
 set -gx TURBO_TEAM 'monorepo'
-set -gx TURBO_TOKEN '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/rzk3lawpk4yspyyu5rxlz44ssi/TURBO_TOKEN" }}'
+set -gx TURBO_TOKEN '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/mzvcz4pqqbda75ufu7l5myd4ey/TURBO_TOKEN" }}'
 set -gx TURBO_CACHE 'local:rw'
 
 function turbo_cache_local

--- a/packages/dotfiles/private_dot_config/private_turbo-cache/private_env.sh.tmpl
+++ b/packages/dotfiles/private_dot_config/private_turbo-cache/private_env.sh.tmpl
@@ -3,7 +3,7 @@
 # development local-only so unreliable Wi-Fi never transfers large artifacts.
 export TURBO_API='https://turbo-cache.tailnet-1a49.ts.net'
 export TURBO_TEAM='monorepo'
-export TURBO_TOKEN='{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/rzk3lawpk4yspyyu5rxlz44ssi/TURBO_TOKEN" }}'
+export TURBO_TOKEN='{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/mzvcz4pqqbda75ufu7l5myd4ey/TURBO_TOKEN" }}'
 export TURBO_CACHE='local:rw'
 
 turbo_cache_local() {

--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-24T21:16:42.640Z",
+  "generatedAt": "2026-08-25T00:13:59.763Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -119,6 +119,17 @@
       ]
     },
     {
+      "ref": "1b45edaeff573fba0037aee27aecfe86b360038f9805f6c2254e0a6a3fe5213d",
+      "title": "2f7bfccde3741ae76d4c912e817ecbfa01bab184fcb41eed52ca4190a0dca74f",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "644d92882fbaeb58cc8cbcaaa7ecb19e105378700cc2dee08b66e5f79b936749"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
       "ref": "1e70247400f9abe6c7995276fcd39541f29ca215f2cc2560dd3f5d8ce994be22",
       "title": "63812042f04db7f4235c8ce0fade21d17a2c24db9cdbdab8562bb1959e6f9f62",
       "fields": [
@@ -174,6 +185,18 @@
       ]
     },
     {
+      "ref": "24dfedaa9adac1f1ec1c9309611ef807017a6b5c5a4244c0cb93b9a1aca72872",
+      "title": "a2467acec4b6a16b9fb4d21fc9e5e56a32bf7450e3db3323bfaaed2cc7e79541",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "53538d159bc4f71e53bc3177b220898e722e825ba52817b3e49efc0847d6d29b",
+        "5459a942f4c61e242c0c72d725e36f2a87433fbfaba0f499a4864c19fb364702"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
       "ref": "268a7c574621e35a7b7d253c814282e4083cecabf975e4d8400611012c40d18d",
       "title": "fc0d97320a875fa38318aab2c4cb9695fb620778935bdf8a6a2fdd35b987a79b",
       "fields": [
@@ -211,6 +234,49 @@
         "dc2feb9e98dbd48a0ff3a799bff22d17d991d386517c10b06b259ade81623c28",
         "eec17ee3f7a2b2b13460a496fb2b7084c7563290cdf9dc6e28d7288d68a19573",
         "fbfb7351a8f802c1186e76e4d7f67bf2fb2c4aaf5d279fb52065296aa027ab4e"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
+      "ref": "2f846e43d61613fecf26b205ea14d02c890b44e07c75bf0df47983a67b23c590",
+      "title": "45c461730456da0bb75707f1f3dcc1c45d5a7326ddaf7d6f38f876895b959cf2",
+      "fields": [
+        "07f4a3c9d3e0aa6b4bc1403bbf49dd9842f4a9e9a91fffc71546418aa5b72166",
+        "0a180501f6173999c6af2c6e027f79caff765b69c23eac494ea9531344b76aca",
+        "2087c94f5dde5ec39dacbcd3ac6bc81f1dee49b9dbc208ed344c0837651b701a",
+        "317ce4e922f459e73e0baac2e906992f8c8d1a41fb2f0ea64226f70c0da60d01",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "5e5028a4aaef474be94b68d9a703e17cef531587341f19ef181f5721803663df",
+        "6169f3b70bef175f2b6ac925a828df5ca05f0a295d30a2074b10ed6a9df13899",
+        "626a797f36bc722ee2dd8c774931706e2ad947fdfd1af3bf5f12b36dd4f68d1f",
+        "7b203e46be18e0cb8d91f738a400351de3c68e90b0f26dab6aed85e0a1352220",
+        "7ef33266019a524d13b413498bdf45144c923b7312f5047bc13a46a0b642239f",
+        "9e6b47dfd00b7dfd8f97c765993ce785600ea61c51fb2985c030c7f91768e7ff"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
+      "ref": "3641e4f35bb1bb3fac29f096926c960d0a3281e7b06aa20a1478695c9d970c24",
+      "title": "1b8bbe991a7ba70eeffebec8ab81b8fe5362d98d8710434187da8fe4b682b659",
+      "fields": [
+        "191bf2b2ff994981ecbe83a75ceb1d555233aa70b50dcde633ab18ca881a4f7b",
+        "44308c0d987ddd85851441a3d59744f8fce53d0b3a17b58466fe77984c62557f",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
+      "ref": "3bf10b8ab2d395a591c8a5f6667eaa4917b5956accd61afab8394534852738eb",
+      "title": "f20b90964961cb377edae1b4c9ededf88f9d69e09f148c015408eef0fe87ed21",
+      "fields": [
+        "114da3602c91dc19eb5e88c1f7d0f391d863cb048ca4a52a1de6999d9512d909",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ],
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
@@ -381,6 +447,23 @@
       ]
     },
     {
+      "ref": "4e89178ae7fae6cce090e0c8235eb376420c2cad7dac794332dce9832b1bc4ea",
+      "title": "441a75989f94076a2af8e3fc120cda68f41a7d3a7f0d6eba66b684f81105d191",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "53e95b63354c3511832ee578c12d7c788a2a6898b50ff8953a07da1b31c4b37e",
+        "7ef78c928cb7af48c53be39a3a632669cf6788f65ac166291a8cf120fb5c7ac4",
+        "917e372236c84cc4724513c647b1ddb565aca8633e970cda05944192b0cf9f46",
+        "ab8abdb9d9aaf9ccb77de7b5fca1e130f67f1b35ab66294dd182fe507fa2ad58",
+        "d3bb83aae6f5b246f9f4db539a8ccd8c091243c85269abae343fa287d5ed7ced",
+        "e09ccd6ff02fa1d43a4f8e1a10454c25dca3d7703a228b58995bb193ce90092d",
+        "f788eeb60837500772626606d7af26f5ecba2e8513b9ab2ee5d42a56865db7f9"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
       "ref": "5262eb835e9814ce29a234ba4188ddd557a155f0926629b3d52f1339611d0c91",
       "title": "bd6f4e5c8e489b056f5e0bc2a307e45e5356045fdcd92fd39fb04d4cc2fc2f34",
       "fields": [
@@ -447,6 +530,17 @@
         "e95bef022831072b6321c93788dfb2d494cffb40db77b6d95ffc9293d1792a07",
         "ebddc65228adce27ab19c980bf8a5861566a1318454b2a23140bf0b674c19119",
         "f788eeb60837500772626606d7af26f5ecba2e8513b9ab2ee5d42a56865db7f9"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
+      "ref": "59ec3e781a1e4dda1b885c7671255eb60c84bedf713258f30d574708c30596ba",
+      "title": "519cccb16d70040b42dd27450d6d02bf1190334c03036c3206f1a95334eb0ce5",
+      "fields": [
+        "4262c6858742f9f0523d83323529d13401cb15727d84f91d02fb902486903651",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ],
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
@@ -597,6 +691,18 @@
       ]
     },
     {
+      "ref": "6b367591c22d406afa19b0591ccd3ff4c593b14831c14c4e63298910e571510a",
+      "title": "6dfb5af9fb990c70b4f90547aa1a9d6d533fa902a28535b78dfae12312e0564e",
+      "fields": [
+        "1a726fcc4de338bfffdf0b25403d051f788808fce054b0819f94e54628d1b327",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "b9b0428cdc70e397f20d36342267a8e88e7cf1b832103a33d293fd87e4f49a47"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
       "ref": "6c11f52b618fd33c090b9e66acb976c2b5eb9bfa9a35899187a0fd2640ff9f2c",
       "title": "8ea9bd0d9810e449fea9093a51c93a3a68c79a068b55244cee7cfe02aed1ee48",
       "fields": [
@@ -627,6 +733,20 @@
         "7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682",
         "e265b6f564601a1fe8dc42785cd18a868bd8013eb5899560e79248767a683e6b",
         "f974a07ea4988c92d27cf645c46bc533075d4dd5a8059c03fe460a4aa9d4dd5a"
+      ]
+    },
+    {
+      "ref": "6d596e06ffebd7f2b361e5c92b9fd69ccf5d95cc22c0ea58cbbd3829157ebc03",
+      "title": "f6c3de7f4626f20541c130c88701eef47c61c3214708de260bb2c4fb5292773f",
+      "fields": [
+        "106ddc9ed4ca3522a09a4b5872d244372cb4de6875fc96efba387f2d419287e4",
+        "23de2d4827f535b47d76c6af9801186fa9dc7a1d5f505bd944869a03e51c7ad0",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "61d6c96c4f7528101ada41b8eda36058de252264d28cfea0547586c6bbff7938",
+        "6f0e9e6064da617391f66f111d94c6f8d315b9c7f9ba48bab160e02387b97387"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ]
     },
     {
@@ -715,6 +835,18 @@
         "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
         "e265b6f564601a1fe8dc42785cd18a868bd8013eb5899560e79248767a683e6b"
+      ]
+    },
+    {
+      "ref": "7ee15f3b68f5068408cdfdacb931cd64881ac7ff1b2c338a76da799dfb57d2e4",
+      "title": "301f880b2c5e88cf4324dee4301a6cf3ca6b6096e715eae0c2a58d6775a5eb62",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "76e0737a6a84219b7fda68ffdaea0ae3674cd6d3a517bf5661881b6895839636",
+        "ce496433e84d0bb5da565093c8e40c51d5f05667c9b1b53f0e7aa2a1f87220a0"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ]
     },
     {
@@ -1076,6 +1208,17 @@
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
         "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+      ]
+    },
+    {
+      "ref": "d9e1810ded4c8aa114c3b5d1d3b02172f61472eb07040f6e0c2e6992bdd2ac69",
+      "title": "f4e514df31c803354ba06032e68cb98285d4af5d01c2d50573ee04b5094b68ab",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "c63ba17775a9a1414761dd45228883e4f0841e177eb10f459e5e0eed6b31c126"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ]
     },
     {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-maintenance-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-maintenance-worker.ts
@@ -129,7 +129,7 @@ export function createBuildkiteMaintenanceWorker(chart: Chart): void {
   const turboCacheSecret = Secret.fromSecretName(
     chart,
     "temporal-maintenance-turbo-cache-secret",
-    "buildkite-ci-secrets",
+    "buildkite-turbo-cache-credentials",
   );
   const deployment = new Deployment(chart, WORKER_NAME, {
     replicas: 1,

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
@@ -108,6 +108,44 @@ const PostHogTofuCredentialsSchema = z
   })
   .loose();
 
+const CredentialItemSchema = z
+  .object({
+    apiVersion: z.literal("onepassword.com/v1"),
+    kind: z.literal("OnePasswordItem"),
+    metadata: z.object({
+      name: z.string(),
+      namespace: z.literal("buildkite"),
+    }),
+    spec: z.object({ itemPath: z.string() }),
+  })
+  .loose();
+
+const JobServiceAccountSchema = z
+  .object({
+    apiVersion: z.literal("v1"),
+    kind: z.literal("ServiceAccount"),
+    metadata: z.object({
+      name: z.literal("buildkite-job"),
+      namespace: z.literal("buildkite"),
+    }),
+    automountServiceAccountToken: z.literal(false),
+  })
+  .loose();
+
+const EXPECTED_CREDENTIAL_SECRET_NAMES = [
+  "buildkite-github-credentials",
+  "buildkite-api-credentials",
+  "buildkite-turbo-cache-credentials",
+  "buildkite-npm-credentials",
+  "buildkite-claude-credentials",
+  "buildkite-chartmuseum-credentials",
+  "buildkite-argocd-credentials",
+  "buildkite-seaweedfs-credentials",
+  "buildkite-cloudflare-credentials",
+  "buildkite-tailscale-credentials",
+  "buildkite-arr-credentials",
+];
+
 function synthBuildkiteResources() {
   const chart = Testing.chart();
   createBuildkiteApp(chart);
@@ -234,6 +272,37 @@ it("syncs the dedicated PostHog OpenTofu credentials", () => {
   expect(
     resources.some(
       (manifest) => PostHogTofuCredentialsSchema.safeParse(manifest).success,
+    ),
+  ).toBe(true);
+});
+
+it("syncs one Buildkite Secret per credential rotation boundary", () => {
+  const { resources } = synthBuildkiteResources();
+  const items = resources.flatMap((manifest) => {
+    const result = CredentialItemSchema.safeParse(manifest);
+    return result.success &&
+      EXPECTED_CREDENTIAL_SECRET_NAMES.includes(result.data.metadata.name)
+      ? [result.data]
+      : [];
+  });
+
+  expect(items).toHaveLength(EXPECTED_CREDENTIAL_SECRET_NAMES.length);
+  expect(items.map((item) => item.metadata.name).sort()).toEqual(
+    EXPECTED_CREDENTIAL_SECRET_NAMES.toSorted(),
+  );
+  for (const item of items) {
+    expect(item.metadata.namespace).toBe("buildkite");
+    expect(item.spec.itemPath).toMatch(
+      /^vaults\/v64ocnykdqju4ui6j6pua56xw4\/items\/[a-z0-9]{26}$/,
+    );
+  }
+});
+
+it("provisions a tokenless service account for Buildkite jobs", () => {
+  const { resources } = synthBuildkiteResources();
+  expect(
+    resources.some(
+      (manifest) => JobServiceAccountSchema.safeParse(manifest).success,
     ),
   ).toBe(true);
 });
@@ -403,7 +472,7 @@ describe("Buildkite application", () => {
         }),
         expect.objectContaining({
           secret: expect.objectContaining({
-            secretName: "buildkite-ci-secrets",
+            secretName: "buildkite-turbo-cache-credentials",
           }),
         }),
       ]),

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -7,6 +7,7 @@ import {
   KubeLimitRange,
   KubeConfigMap,
   KubePersistentVolumeClaim,
+  KubeServiceAccount,
   Quantity,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { NVME_STORAGE_CLASS_LZ4 } from "@shepherdjerred/homelab/cdk8s/src/misc/storage-classes.ts";
@@ -16,6 +17,7 @@ import {
   CI_NODE_TOLERATION,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/nodes.ts";
 import { BUILDKITE_MAX_IN_FLIGHT } from "@shepherdjerred/homelab/cdk8s/src/misc/buildkite.ts";
+import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
 import {
   BUN_CACHE_MOUNT_PATH,
   createBuildkiteBunCache,
@@ -53,10 +55,75 @@ sleep 20
   });
 }
 
+const BUILDKITE_CREDENTIAL_ITEMS = [
+  {
+    secretName: "buildkite-github-credentials",
+    itemId: "34gzcrhwdm34lpadyly3rcsu44",
+  },
+  {
+    secretName: "buildkite-api-credentials",
+    itemId: "qtyxi2cqocze43ekdgb72uvtr4",
+  },
+  {
+    secretName: "buildkite-turbo-cache-credentials",
+    itemId: "mzvcz4pqqbda75ufu7l5myd4ey",
+  },
+  {
+    secretName: "buildkite-npm-credentials",
+    itemId: "4fmd5otmvwcpsrxjaptrloppvu",
+  },
+  {
+    secretName: "buildkite-claude-credentials",
+    itemId: "2r6nqphyvaegtnbjgcg4avff3m",
+  },
+  {
+    secretName: "buildkite-chartmuseum-credentials",
+    itemId: "cnutkdwa7uka5hk3wx5gimyfom",
+  },
+  {
+    secretName: "buildkite-argocd-credentials",
+    itemId: "xyytntqvtchctebb3ugoiub7u4",
+  },
+  {
+    secretName: "buildkite-seaweedfs-credentials",
+    itemId: "eyfsbfkxojth6ymr65l47yyfxy",
+  },
+  {
+    secretName: "buildkite-cloudflare-credentials",
+    itemId: "djl2blalora2unjogqnsadlokq",
+  },
+  {
+    secretName: "buildkite-tailscale-credentials",
+    itemId: "eoqdhvwgu7rjfqe6dknexihitu",
+  },
+  {
+    secretName: "buildkite-arr-credentials",
+    itemId: "vkzv5jm2euzb7727x6uxdpwu5y",
+  },
+] as const;
+
+function createBuildkiteCredentialBoundaries(chart: Chart): void {
+  for (const { secretName, itemId } of BUILDKITE_CREDENTIAL_ITEMS) {
+    new OnePasswordItem(chart, secretName, {
+      spec: { itemPath: vaultItemPath(itemId) },
+      metadata: { name: secretName, namespace: "buildkite" },
+    });
+  }
+
+  // The agent-stack controller keeps its own service account and RBAC. Step
+  // pods switch to this tokenless identity only after every dedicated Secret
+  // has reconciled, so provisioning this boundary does not alter running CI.
+  new KubeServiceAccount(chart, "buildkite-job", {
+    metadata: { name: "buildkite-job", namespace: "buildkite" },
+    automountServiceAccountToken: false,
+  });
+}
+
 export function createBuildkiteApp(chart: Chart) {
   createBuildkiteNamespace(chart);
   createBuildkiteBunCache(chart);
   createBuildkiteMaintenanceWorker(chart);
+  createBuildkiteCredentialBoundaries(chart);
 
   new OnePasswordItem(chart, "buildkite-agent-token", {
     spec: {

--- a/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
@@ -46,12 +46,11 @@ export function createTurboCacheDeployment(chart: Chart) {
   const secrets = new OnePasswordItem(chart, "turbo-cache-secrets", {
     spec: {
       // vaultItemPath takes the 1Password item *ID*, not its title. This is the
-      // shared `buildkite-ci-secrets` item (same ID buildkite.ts references) —
-      // we only need its TURBO_TOKEN field for the remote cache bearer token.
-      itemPath: vaultItemPath("rzk3lawpk4yspyyu5rxlz44ssi"),
+      // dedicated Turbo item shared with Buildkite's exact TURBO_TOKEN grant.
+      itemPath: vaultItemPath("mzvcz4pqqbda75ufu7l5myd4ey"),
     },
     metadata: {
-      name: "buildkite-ci-secrets",
+      name: "turbo-cache-secrets",
     },
   });
   const secretRef = Secret.fromSecretName(


### PR DESCRIPTION
## Why

Buildkite jobs currently receive one shared Kubernetes Secret. The cutover to exact per-job grants needs each issuer and rotation boundary to exist in the cluster first, without changing running CI or introducing optional fallbacks.

## What

- provisions dedicated 1Password-backed Kubernetes Secrets for GitHub, Buildkite API, Turbo cache, npm, Claude, ChartMuseum, Argo CD, SeaweedFS, Cloudflare, Tailscale, and ARR credentials
- adds a tokenless `buildkite-job` service account with no RoleBinding
- moves the Turbo cache server and maintenance worker to the dedicated Turbo credential item
- retains `buildkite-ci-secrets` for existing CI jobs until the cutover PR
- refreshes the hashed vault snapshot and adds CDK8s resource coverage

The new items initially carry the current values under semantic field names. No credential values are stored in Git, rendered in the snapshot, or included in PR output.

## Verification

- `bun run build && bun run test` in `packages/homelab/src/cdk8s`
- `bun --no-install --bun vitest --config ../../../../vitest.config.ts run src/resources/argo-applications/buildkite.test.ts`
- `bun run scripts/check-1password-items.ts`
- `bun run typecheck` in `packages/homelab/src/cdk8s`
- `bun run lint` in `packages/homelab/src/cdk8s`
- `bunx lefthook run pre-commit`

## Rollout

After merge, wait for the exact main Buildkite release and Argo reconciliation. Then verify all new Secrets expose the expected key names without reading values and confirm `system:serviceaccount:buildkite:buildkite-job` cannot read Secrets. PR 2 must not cut over jobs until those checks pass.