### PR TITLE
fix(scout-for-lol): trust database for weekly parlay candidates

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -940,6 +940,11 @@ it cannot author thresholds, expressions, paths, SQL, or settlement behavior.
 Reject a candidate outside the empirical publication band and skip the week
 when none qualify—never weaken or clamp a gate.
 
+The database is authoritative for weekly-parlay subject membership. A player
+row in the target guild with a Discord ID and at least one linked Riot account
+is eligible for candidate evaluation; generation must not enumerate or fetch
+Discord guild members. Stale player membership is a database-cleanup concern.
+
 Only cumulative/count/distinct/max `gte` legs may become irreversible. Early
 settlement is YES-only and requires every leg irreversibly true; NO and every
 equality, upper-bound, rate, or average leg wait for finalization. Flag

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -1,9 +1,5 @@
 import { differenceInCalendarWeeks } from "date-fns";
-import {
-  DiscordGuildIdSchema,
-  LeaguePuuidSchema,
-  type DiscordGuildId,
-} from "@scout-for-lol/data";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
 import {
   WEEKLY_PARLAY_CATALOG_VERSION,
   WEEKLY_PARLAY_ELIGIBLE_QUEUES,
@@ -12,7 +8,6 @@ import {
   WEEKLY_PARLAY_SCHEMA_VERSION,
   WeeklyParlaySubjectsSchema,
   validateWeeklyParlayProposal,
-  type WeeklyParlaySubject,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { fetchWeeklyCandidateHistories } from "#src/betting/weekly-parlay-history.ts";
 import {
@@ -28,8 +23,8 @@ import {
 } from "#src/betting/weekly-parlay-period.ts";
 import { priceWeeklyParlay } from "#src/betting/weekly-parlay-pricing.ts";
 import { orderWeeklyParlayCandidates } from "#src/betting/weekly-parlay-selection.ts";
+import { loadWeeklyParlaySubjects } from "#src/betting/weekly-parlay-subjects.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
-import { client } from "#src/discord/client.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isUniqueConstraintError } from "#src/lib/player-admin/shared.ts";
 import {
@@ -122,50 +117,6 @@ function timelineKind(
   return isWeeklyParlayCatchupTimeline(period) ? "catch_up" : "standard";
 }
 
-async function linkedMemberSubjects(
-  serverId: DiscordGuildId,
-  prismaClient: ExtendedPrismaClient,
-): Promise<WeeklyParlaySubject[]> {
-  const guild = client.guilds.cache.get(serverId);
-  if (guild === undefined) {
-    return [];
-  }
-  const members = await guild.members.fetch();
-  const players = await prismaClient.player.findMany({
-    where: { serverId, discordId: { not: null }, accounts: { some: {} } },
-    select: {
-      id: true,
-      alias: true,
-      discordId: true,
-      accounts: {
-        select: { puuid: true, createdTime: true },
-        orderBy: { id: "asc" },
-      },
-    },
-    orderBy: { id: "asc" },
-  });
-  return players.flatMap((player) => {
-    if (player.discordId === null || !members.has(player.discordId)) {
-      return [];
-    }
-    return [
-      WeeklyParlaySubjectsSchema.element.parse({
-        // Candidate subjects are evaluated one at a time in V1. Keep the
-        // schema-valid market key as a placeholder; history is keyed by the
-        // immutable player ID until a subject is selected.
-        key: "P1",
-        playerId: player.id,
-        alias: player.alias,
-        discordId: player.discordId,
-        accounts: player.accounts.map((account) => ({
-          puuid: LeaguePuuidSchema.parse(account.puuid),
-          trackingStartedAt: account.createdTime.toISOString(),
-        })),
-      }),
-    ];
-  });
-}
-
 async function openWeeklyParlayInternal(
   input: OpenWeeklyParlayInput,
   prismaClient: ExtendedPrismaClient = prisma,
@@ -201,7 +152,7 @@ async function openWeeklyParlayInternal(
     return { kind: "feature_disabled" };
   }
   const startedAt = Date.now();
-  const subjects = await linkedMemberSubjects(serverId, prismaClient);
+  const subjects = await loadWeeklyParlaySubjects(serverId, prismaClient);
   if (subjects.length === 0) {
     return { kind: "no_candidate" };
   }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-subjects.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-subjects.integration.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import type {
+  DiscordAccountId,
+  DiscordGuildId,
+  LeaguePuuid,
+} from "@scout-for-lol/data";
+import { loadWeeklyParlaySubjects } from "#src/betting/weekly-parlay-subjects.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  testAccountId,
+  testGuildId,
+  testPuuid,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("weekly-parlay-subjects");
+const SERVER_ID = testGuildId("701");
+const OTHER_SERVER_ID = testGuildId("702");
+const CREATOR_ID = testAccountId("701");
+const CREATED_AT = new Date("2026-08-24T12:00:00.000Z");
+
+async function createPlayer(input: {
+  alias: string;
+  serverId: DiscordGuildId;
+  discordId?: DiscordAccountId;
+  accounts: readonly LeaguePuuid[];
+}): Promise<number> {
+  const player = await prisma.player.create({
+    data: {
+      alias: input.alias,
+      ...(input.discordId === undefined ? {} : { discordId: input.discordId }),
+      serverId: input.serverId,
+      creatorDiscordId: CREATOR_ID,
+      createdTime: CREATED_AT,
+      updatedTime: CREATED_AT,
+    },
+  });
+  for (const [index, puuid] of input.accounts.entries()) {
+    await prisma.account.create({
+      data: {
+        alias: `${input.alias}-${index.toString()}`,
+        puuid,
+        region: "AMERICA_NORTH",
+        playerId: player.id,
+        serverId: input.serverId,
+        creatorDiscordId: CREATOR_ID,
+        createdTime: new Date(CREATED_AT.getTime() + index * 60_000),
+        updatedTime: CREATED_AT,
+      },
+    });
+  }
+  return player.id;
+}
+
+beforeEach(async () => {
+  await prisma.account.deleteMany();
+  await prisma.player.deleteMany();
+});
+
+afterAll(async () => {
+  await prisma.account.deleteMany();
+  await prisma.player.deleteMany();
+  await prisma.$disconnect();
+});
+
+describe("loadWeeklyParlaySubjects", () => {
+  test("loads deterministic eligible subjects solely from database links", async () => {
+    const firstDiscordId = testAccountId("711");
+    const secondDiscordId = testAccountId("712");
+    const firstPuuid = testPuuid("weekly-first");
+    const secondPuuid = testPuuid("weekly-second");
+    const thirdPuuid = testPuuid("weekly-third");
+    const firstPlayerId = await createPlayer({
+      alias: "first",
+      serverId: SERVER_ID,
+      discordId: firstDiscordId,
+      accounts: [firstPuuid, secondPuuid],
+    });
+    await createPlayer({
+      alias: "missing-discord",
+      serverId: SERVER_ID,
+      accounts: [testPuuid("missing-discord")],
+    });
+    await createPlayer({
+      alias: "missing-account",
+      serverId: SERVER_ID,
+      discordId: testAccountId("713"),
+      accounts: [],
+    });
+    await createPlayer({
+      alias: "other-server",
+      serverId: OTHER_SERVER_ID,
+      discordId: testAccountId("714"),
+      accounts: [testPuuid("other-server")],
+    });
+    const secondPlayerId = await createPlayer({
+      alias: "second",
+      serverId: SERVER_ID,
+      discordId: secondDiscordId,
+      accounts: [thirdPuuid],
+    });
+
+    await expect(loadWeeklyParlaySubjects(SERVER_ID, prisma)).resolves.toEqual([
+      {
+        key: "P1",
+        playerId: firstPlayerId,
+        alias: "first",
+        discordId: firstDiscordId,
+        accounts: [
+          {
+            puuid: firstPuuid,
+            trackingStartedAt: CREATED_AT.toISOString(),
+          },
+          {
+            puuid: secondPuuid,
+            trackingStartedAt: new Date(
+              CREATED_AT.getTime() + 60_000,
+            ).toISOString(),
+          },
+        ],
+      },
+      {
+        key: "P1",
+        playerId: secondPlayerId,
+        alias: "second",
+        discordId: secondDiscordId,
+        accounts: [
+          {
+            puuid: thirdPuuid,
+            trackingStartedAt: CREATED_AT.toISOString(),
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-subjects.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-subjects.ts
@@ -1,0 +1,45 @@
+import { LeaguePuuidSchema, type DiscordGuildId } from "@scout-for-lol/data";
+import {
+  WeeklyParlaySubjectsSchema,
+  type WeeklyParlaySubject,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+export async function loadWeeklyParlaySubjects(
+  serverId: DiscordGuildId,
+  prismaClient: ExtendedPrismaClient,
+): Promise<WeeklyParlaySubject[]> {
+  const players = await prismaClient.player.findMany({
+    where: { serverId, discordId: { not: null }, accounts: { some: {} } },
+    select: {
+      id: true,
+      alias: true,
+      discordId: true,
+      accounts: {
+        select: { puuid: true, createdTime: true },
+        orderBy: { id: "asc" },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+  return players.flatMap((player) => {
+    if (player.discordId === null) {
+      return [];
+    }
+    return [
+      WeeklyParlaySubjectsSchema.element.parse({
+        // Candidate subjects are evaluated one at a time in V1. Keep the
+        // schema-valid market key as a placeholder; history is keyed by the
+        // immutable player ID until a subject is selected.
+        key: "P1",
+        playerId: player.id,
+        alias: player.alias,
+        discordId: player.discordId,
+        accounts: player.accounts.map((account) => ({
+          puuid: LeaguePuuidSchema.parse(account.puuid),
+          trackingStartedAt: account.createdTime.toISOString(),
+        })),
+      }),
+    ];
+  });
+}


### PR DESCRIPTION
## Why

The manual weekly-parlay catch-up exhausted all open retries while Discord.js attempted to download the full guild member list. Scout linked player records are the chosen source of truth for weekly-parlay eligibility, so generation should not depend on Discord member enumeration.

## What

- load weekly-parlay subjects directly from PostgreSQL when they belong to the guild, have a Discord ID, and have at least one linked Riot account
- preserve deterministic player and account ordering
- add integration coverage for eligible and excluded database rows without initializing Discord
- document the database-authoritative membership invariant

## Verification

- bun run --filter=@scout-for-lol/backend test -- src/betting/weekly-parlay-subjects.integration.test.ts src/betting/weekly-parlay-runtime.integration.test.ts (38 tests passed)
- bunx turbo run typecheck --filter=@scout-for-lol/backend
- bunx turbo run lint --filter=@scout-for-lol/backend
- bun run --filter=@scout-for-lol/backend format
- bunx lefthook run pre-commit

Live beta deployment and catch-up acceptance remain pending merge and rollout. This is a non-visual backend logic change, so no media artifact is required.