### PR TITLE
feat(homelab): split Glitter Temporal workers

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Why Temporal
-description: What durability buys for household automation and repo upkeep, and why the fleet runs as two processes rather than one.
+description: What durability buys for household automation and repo upkeep, and why each workload domain has its own worker.
 sidebar:
   order: 1
 ---
@@ -12,18 +12,22 @@ a durable workflow.
 ```mermaid
 flowchart LR
   accTitle: Temporal worker system map
-  accDescr: The Temporal server dispatches general and agent work to the core Bun worker and Glitter corpus and context work to a separate Bun worker. Webhooks, APIs, and Home Assistant events enter through the core worker. Both workers expose independent health and metrics endpoints.
+  accDescr: A tokenless gateway reconciles schedules and receives public requests. Temporal dispatches each workflow and activity to one of nine domain queues. Home Assistant events enter through the home worker. Every domain has independent health and metrics endpoints.
 
-  S[Cron schedules] --> T[Temporal server]
-  T --> C[Core Bun worker<br/>default + agent-task]
-  T --> G[Glitter Bun worker<br/>corpus + context]
-  W[GitHub and Xcode webhooks] --> C
-  H[Home Assistant events] --> C
-  A[Agent-task API] --> C
-  C --> O[PRs, reports, HA actions]
-  G --> D[Discord corpus and context PRs]
-  C --> M[Health and metrics]
-  G --> M
+  S[Schedule definitions] --> G[Gateway<br/>control role]
+  W[Public webhooks and APIs] --> G
+  G --> T[Temporal server]
+  E[Home Assistant events] --> H[Home worker]
+  H --> T
+  T --> H
+  T --> R[Reports worker]
+  T --> I[Infra worker]
+  T --> P[Repo worker]
+  T --> C[Scout worker]
+  T --> A[Agent worker]
+  T --> D[Glitter corpus worker]
+  T --> X[Glitter context worker]
+  T --> M[Maintenance worker]
 ```
 
 ## Durability is the point
@@ -51,25 +55,26 @@ Pause state is the deliberate exception: it is runtime state, preserved across
 reconciliation, because pausing is an operational act rather than a design
 change.
 
-## Four processes, five queues
+## Ten processes, nine queues
 
-The core deployment owns `default`. A dedicated report-only agent deployment
-owns `agent-task`, and a separate Glitter deployment owns `glitter-corpus` and
-`glitter-context`. A fourth, tokenless maintenance deployment in the Buildkite
-namespace owns the serial `maintenance` queue. All four run the same image and
-workflow bundle, selected by a strict process role.
+The gateway is a control process: it reconciles schedules and serves the public
+HTTP surfaces but does not poll a task queue or receive a Kubernetes token.
+Nine workers own `home`, `reports`, `infra`, `repo-automation`, `scout`,
+`agent-task`, `glitter-corpus`, `glitter-context`, and `maintenance`. All ten
+run the same image and deterministic workflow bundle, selected by a strict
+process role. The old `default` queue has no worker or start site.
 
 The split is about authorization and failure isolation, not capacity. Queues
-isolate concurrency; **processes** isolate runtime failures and Kubernetes
-identities. The agent service account can collect read-only cluster evidence but
-has none of the pod-exec roles used by deterministic canaries and maintenance.
-Glitter's work is long, memory-hungry, and rate-limited against Discord —
-exactly the profile that would otherwise starve or destabilise ordinary jobs
-sharing a process.
+isolate concurrency; **processes** isolate runtime failures, credentials, and
+Kubernetes identities. Home and reports can each run four activities. Infra,
+repo, Scout, agent, both Glitter domains, and maintenance remain serial.
 
-Each process serves `/healthz` from Bun's event loop only after its workers
-finish startup, and independent startup, readiness, and liveness probes restart a
-wedged role without taking down the other one. Metrics are scraped per role.
+Only infra receives the broad audit and pod-exec roles. Gateway, home, reports,
+repo, Scout, and both Glitter workers disable service-account token mounting.
+Each Deployment receives an allowlisted environment. Network policies, Services,
+and ServiceMonitors select the unique `component` label rather than the shared
+image label. Each process serves `/healthz` after startup, with independent
+probes and per-queue metrics.
 
 ## Batteries in the image
 

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -76,6 +76,13 @@ and ServiceMonitors select the unique `component` label rather than the shared
 image label. Each process serves `/healthz` after startup, with independent
 probes and per-queue metrics.
 
+The topology is delivered as a staged migration. The Glitter layer first
+replaces the combined Glitter Deployment with separate corpus and context
+workers while the legacy core and agent Deployments still serve the remaining
+queues. The gateway, home, reports, infra, repo, and Scout Deployments arrive
+in the later ingress and operations layers, before the default queue is
+retired.
+
 ## Batteries in the image
 
 The worker image bakes `gh`, `claude`, `codex`, `kubectl`, `talosctl`, `tofu`,

--- a/packages/homelab/src/cdk8s/src/container-resources.test.ts
+++ b/packages/homelab/src/cdk8s/src/container-resources.test.ts
@@ -283,9 +283,16 @@ describe("Container resource requests backstop", () => {
         },
       ],
       [
-        "temporal-temporal-glitter-worker/temporal-glitter-worker",
+        "temporal-temporal-glitter-corpus-worker/temporal-glitter-corpus-worker",
         {
-          requests: { cpu: "1", memory: "3072Mi" },
+          requests: { cpu: "250m", memory: "512Mi" },
+          limits: { cpu: "1", memory: "3072Mi" },
+        },
+      ],
+      [
+        "temporal-temporal-glitter-context-worker/temporal-glitter-context-worker",
+        {
+          requests: { cpu: "750m", memory: "2560Mi" },
           limits: { cpu: "2", memory: "6144Mi" },
         },
       ],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/glitter-corpus-env.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/glitter-corpus-env.ts
@@ -1,19 +1,10 @@
 import { EnvValue, type ISecret } from "cdk8s-plus-31";
 
-export function glitterCorpusEnv(
+function glitterCorpusStorageEnv(
   workerSecret: ISecret,
-  starlightBotSecret: ISecret,
 ): Record<string, EnvValue> {
   return {
-    GLITTER_DISCORD_TOKEN: EnvValue.fromSecretValue({
-      secret: starlightBotSecret,
-      key: "DISCORD_TOKEN",
-    }),
     GLITTER_DISCORD_GUILD_ID: EnvValue.fromValue("208425771172102144"),
-    GLITTER_DISCORD_GUILD_SLUG: EnvValue.fromValue("glitter-boys"),
-    // Inventory approval is the scope authority. Keep exclusions explicit so
-    // the runtime fails if this value is ever accidentally removed.
-    GLITTER_DISCORD_DENYLIST_CHANNEL_IDS: EnvValue.fromValue(""),
     GLITTER_CORPUS_S3_ENDPOINT: EnvValue.fromSecretValue({
       secret: workerSecret,
       key: "S3_ENDPOINT",
@@ -29,4 +20,27 @@ export function glitterCorpusEnv(
     }),
     GLITTER_CORPUS_S3_REGION: EnvValue.fromValue("us-east-1"),
   };
+}
+
+export function glitterCorpusEnv(
+  workerSecret: ISecret,
+  starlightBotSecret: ISecret,
+): Record<string, EnvValue> {
+  return {
+    ...glitterCorpusStorageEnv(workerSecret),
+    GLITTER_DISCORD_TOKEN: EnvValue.fromSecretValue({
+      secret: starlightBotSecret,
+      key: "DISCORD_TOKEN",
+    }),
+    GLITTER_DISCORD_GUILD_SLUG: EnvValue.fromValue("glitter-boys"),
+    // Inventory approval is the scope authority. Keep exclusions explicit so
+    // the runtime fails if this value is ever accidentally removed.
+    GLITTER_DISCORD_DENYLIST_CHANNEL_IDS: EnvValue.fromValue(""),
+  };
+}
+
+export function glitterContextEnv(
+  workerSecret: ISecret,
+): Record<string, EnvValue> {
+  return glitterCorpusStorageEnv(workerSecret);
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/glitter-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/glitter-worker.ts
@@ -5,8 +5,9 @@ import {
   Deployment,
   DeploymentStrategy,
   type EnvValue,
+  Pods,
   Service,
-  type ServiceAccount,
+  ServiceAccount,
   Volume,
 } from "cdk8s-plus-31";
 import {
@@ -17,27 +18,35 @@ import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/ser
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import { temporalWorkerHealthProbes } from "./worker-health.ts";
 
-type CreateTemporalGlitterWorkerProps = {
-  serviceAccount: ServiceAccount;
+type GlitterWorkerDefinition = {
+  name: "temporal-glitter-context-worker" | "temporal-glitter-corpus-worker";
+  component: "glitter-context-worker" | "glitter-corpus-worker";
   envVariables: Record<string, EnvValue>;
+  cpuRequest: Cpu;
+  cpuLimit: Cpu;
+  memoryRequest: Size;
+  memoryLimit: Size;
 };
 
-export function createTemporalGlitterWorker(
+function createGlitterWorker(
   chart: Chart,
-  props: CreateTemporalGlitterWorkerProps,
+  definition: GlitterWorkerDefinition,
 ): Deployment {
-  const deployment = new Deployment(chart, "temporal-glitter-worker", {
+  const serviceAccount = new ServiceAccount(
+    chart,
+    `${definition.name}-service-account`,
+    { metadata: { name: definition.name } },
+  );
+  const deployment = new Deployment(chart, definition.name, {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
-    serviceAccount: props.serviceAccount,
-    automountServiceAccountToken: true,
-    securityContext: {
-      fsGroup: 1000,
-    },
+    serviceAccount,
+    automountServiceAccountToken: false,
+    securityContext: { fsGroup: 1000 },
     podMetadata: {
       labels: {
         app: "temporal-worker",
-        component: "glitter-worker",
+        component: definition.component,
       },
     },
   });
@@ -46,7 +55,7 @@ export function createTemporalGlitterWorker(
 
   const container = deployment.addContainer(
     withCommonProps({
-      name: "temporal-glitter-worker",
+      name: definition.name,
       image: `ghcr.io/shepherdjerred/temporal-worker:${versions["shepherdjerred/temporal-worker"]}`,
       ports: [
         { number: 9464, name: "metrics" },
@@ -59,54 +68,87 @@ export function createTemporalGlitterWorker(
       },
       resources: {
         cpu: {
-          request: Cpu.units(1),
-          limit: Cpu.units(2),
+          request: definition.cpuRequest,
+          limit: definition.cpuLimit,
         },
         memory: {
-          request: Size.gibibytes(3),
-          limit: Size.gibibytes(6),
+          request: definition.memoryRequest,
+          limit: definition.memoryLimit,
         },
       },
       ...temporalWorkerHealthProbes(),
-      envVariables: props.envVariables,
+      envVariables: definition.envVariables,
     }),
   );
 
   const tmpVolume = Volume.fromEmptyDir(
     chart,
-    "temporal-glitter-worker-tmp",
-    "glitter-tmp",
+    `${definition.name}-tmp`,
+    `${definition.component}-tmp`,
   );
   container.mount("/tmp", tmpVolume);
 
-  new Service(chart, "temporal-glitter-worker-metrics-service", {
-    selector: deployment,
-    metadata: {
-      labels: { app: "temporal-glitter-worker-metrics" },
-    },
+  const selector = Pods.select(chart, `${definition.name}-selector`, {
+    labels: { component: definition.component },
+  });
+  const sdkMetricsComponent = `${definition.component}-sdk-metrics`;
+  new Service(chart, `${definition.name}-metrics-service`, {
+    selector,
+    metadata: { labels: { component: sdkMetricsComponent } },
     ports: [{ port: 9464, name: "metrics" }],
   });
-
   createServiceMonitor(chart, {
-    name: "temporal-glitter-worker-metrics",
-    matchLabels: { app: "temporal-glitter-worker-metrics" },
+    name: `${definition.name}-metrics`,
+    matchLabels: { component: sdkMetricsComponent },
   });
 
-  new Service(chart, "temporal-glitter-worker-app-metrics-service", {
+  const appMetricsComponent = `${definition.component}-app-metrics`;
+  new Service(chart, `${definition.name}-app-metrics-service`, {
     metadata: {
-      name: "temporal-glitter-worker-app-metrics",
-      labels: { app: "temporal-glitter-worker-app-metrics" },
+      name: `${definition.name}-app-metrics`,
+      labels: { component: appMetricsComponent },
     },
-    selector: deployment,
+    selector,
     ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
   });
-
   createServiceMonitor(chart, {
-    name: "temporal-glitter-worker-app-metrics",
+    name: `${definition.name}-app-metrics`,
     port: "app-metrics",
     interval: "30s",
-    matchLabels: { app: "temporal-glitter-worker-app-metrics" },
+    matchLabels: { component: appMetricsComponent },
   });
 
   return deployment;
+}
+
+export function createTemporalGlitterWorkers(
+  chart: Chart,
+  props: {
+    corpusEnvVariables: Record<string, EnvValue>;
+    contextEnvVariables: Record<string, EnvValue>;
+  },
+): {
+  corpusDeployment: Deployment;
+  contextDeployment: Deployment;
+} {
+  return {
+    corpusDeployment: createGlitterWorker(chart, {
+      name: "temporal-glitter-corpus-worker",
+      component: "glitter-corpus-worker",
+      envVariables: props.corpusEnvVariables,
+      cpuRequest: Cpu.millis(250),
+      cpuLimit: Cpu.units(1),
+      memoryRequest: Size.mebibytes(512),
+      memoryLimit: Size.gibibytes(3),
+    }),
+    contextDeployment: createGlitterWorker(chart, {
+      name: "temporal-glitter-context-worker",
+      component: "glitter-context-worker",
+      envVariables: props.contextEnvVariables,
+      cpuRequest: Cpu.millis(750),
+      cpuLimit: Cpu.units(2),
+      memoryRequest: Size.mebibytes(2560),
+      memoryLimit: Size.gibibytes(6),
+    }),
+  };
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -28,8 +28,8 @@ import {
 import { createTemporalAgentWorker } from "./agent-worker.ts";
 import { createTemporalWorkerCrdReaderRbac } from "./crd-rbac.ts";
 import { sleepWebhookEnv } from "./http-services.ts";
-import { glitterCorpusEnv } from "./glitter-corpus-env.ts";
-import { createTemporalGlitterWorker } from "./glitter-worker.ts";
+import { glitterContextEnv, glitterCorpusEnv } from "./glitter-corpus-env.ts";
+import { createTemporalGlitterWorkers } from "./glitter-worker.ts";
 import { temporalWorkerHealthProbes } from "./worker-health.ts";
 import { createTemporalWorkerHttpServices } from "./worker-http-services.ts";
 import { FRESHRSS_DESIRED_JSON } from "@shepherdjerred/homelab/cdk8s/src/resources/freshrss-config.ts";
@@ -488,21 +488,59 @@ export function createTemporalWorkerDeployment(
     },
   });
 
-  // Glitter's corpus and context-refresh queues perform the heaviest Bun-side
-  // work. Keep them in a separate process and pod so a runtime wedge or
-  // resource spike cannot stop schedules, webhooks, or the general queues.
-  const glitterDeployment = createTemporalGlitterWorker(chart, {
-    serviceAccount,
-    envVariables: {
-      ...Object.fromEntries(
-        Object.entries(container.env.variables).filter(
-          ([name]) => name !== "SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN",
+  const glitterCommonEnv = {
+    TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
+    TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+    ENVIRONMENT: EnvValue.fromValue("production"),
+    TELEMETRY_ENABLED: EnvValue.fromValue("true"),
+    OTLP_ENDPOINT: EnvValue.fromValue(
+      "http://tempo.tempo.svc.cluster.local:4318",
+    ),
+    SENTRY_DSN: EnvValue.fromSecretValue({ secret, key: "SENTRY_DSN" }),
+  };
+  const { corpusDeployment, contextDeployment } = createTemporalGlitterWorkers(
+    chart,
+    {
+      corpusEnvVariables: {
+        ...glitterCommonEnv,
+        TEMPORAL_WORKER_ROLE: EnvValue.fromValue("glitter-corpus"),
+        TELEMETRY_SERVICE_NAME: EnvValue.fromValue(
+          "temporal-glitter-corpus-worker",
         ),
-      ),
-      TEMPORAL_WORKER_ROLE: EnvValue.fromValue("glitter"),
-      TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-glitter-worker"),
+        ...glitterCorpusEnv(secret, starlightBotSecret),
+      },
+      contextEnvVariables: {
+        ...glitterCommonEnv,
+        TEMPORAL_WORKER_ROLE: EnvValue.fromValue("glitter-context"),
+        TELEMETRY_SERVICE_NAME: EnvValue.fromValue(
+          "temporal-glitter-context-worker",
+        ),
+        OPENROUTER_API_KEY: EnvValue.fromSecretValue({
+          secret,
+          key: "OPENROUTER_API_KEY",
+        }),
+        GITHUB_APP_ID: EnvValue.fromSecretValue({
+          secret,
+          key: "GITHUB_APP_ID",
+        }),
+        GITHUB_APP_INSTALLATION_ID: EnvValue.fromSecretValue({
+          secret,
+          key: "GITHUB_APP_INSTALLATION_ID",
+        }),
+        GITHUB_APP_PRIVATE_KEY: EnvValue.fromSecretValue({
+          secret,
+          key: "GITHUB_APP_PRIVATE_KEY",
+        }),
+        GIT_AUTHOR_NAME: EnvValue.fromValue("temporal-worker[bot]"),
+        GIT_AUTHOR_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),
+        GIT_COMMITTER_NAME: EnvValue.fromValue("temporal-worker[bot]"),
+        GIT_COMMITTER_EMAIL: EnvValue.fromValue(
+          "temporal-worker@homelab.local",
+        ),
+        ...glitterContextEnv(secret),
+      },
     },
-  });
+  );
 
   // Project the talosconfig YAML from 1Password into a file at
   // /etc/talos/config. The homelab-audit-daily workflow's §1 commands
@@ -559,5 +597,10 @@ export function createTemporalWorkerDeployment(
 
   createTemporalWorkerHttpServices(chart, deployment);
 
-  return { deployment, agentDeployment, glitterDeployment };
+  return {
+    deployment,
+    agentDeployment,
+    glitterCorpusDeployment: corpusDeployment,
+    glitterContextDeployment: contextDeployment,
+  };
 }

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -93,15 +93,19 @@ describe("Scout weekly parlay deployment boundary", () => {
       ]),
     );
 
-    const glitterDeployment = DeploymentSpecSchema.parse(
-      findResource(temporal, "Deployment", "temporal-temporal-glitter-worker")
-        .spec,
-    );
-    expect(
-      glitterDeployment.template.spec.containers[0]?.env.some(
-        (entry) => entry.name === "SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN",
-      ),
-    ).toBe(false);
+    for (const deploymentName of [
+      "temporal-temporal-glitter-corpus-worker",
+      "temporal-temporal-glitter-context-worker",
+    ]) {
+      const glitterDeployment = DeploymentSpecSchema.parse(
+        findResource(temporal, "Deployment", deploymentName).spec,
+      );
+      expect(
+        glitterDeployment.template.spec.containers[0]?.env.some(
+          (entry) => entry.name === "SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN",
+        ),
+      ).toBe(false);
+    }
   });
 
   test("keeps the private control endpoint absent from production Scout", () => {

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -42,8 +42,12 @@ const DeploymentSchema = z.object({
   kind: z.literal("Deployment"),
   metadata: z.object({ name: z.string() }),
   spec: z.object({
+    replicas: z.number(),
+    strategy: z.object({ type: z.string() }),
     template: z.object({
+      metadata: z.object({ labels: z.record(z.string(), z.string()) }),
       spec: z.object({
+        automountServiceAccountToken: z.boolean(),
         containers: z.array(
           z.object({
             env: z.array(
@@ -53,9 +57,14 @@ const DeploymentSchema = z.object({
             name: z.string(),
             ports: z.array(z.object({ containerPort: z.number() })),
             readinessProbe: HttpProbeSchema,
+            resources: z.object({
+              limits: z.object({ cpu: z.string(), memory: z.string() }),
+              requests: z.object({ cpu: z.string(), memory: z.string() }),
+            }),
             startupProbe: HttpProbeSchema,
           }),
         ),
+        serviceAccountName: z.string(),
       }),
     }),
   }),
@@ -154,30 +163,43 @@ describe("temporal homelab audit tooling configuration", () => {
 });
 
 describe("temporal homelab audit tooling worker topology", () => {
-  it("isolates core, agent, and Glitter queues behind event-loop health probes", async () => {
+  it("isolates core, agent, and both Glitter queues behind event-loop health probes", async () => {
     const deployments = parseDeployments(await synthesizeApp());
     const core = requireDeployment(deployments, "temporal-temporal-worker");
     const agent = requireDeployment(
       deployments,
       "temporal-temporal-agent-worker",
     );
-    const glitter = requireDeployment(
+    const glitterCorpus = requireDeployment(
       deployments,
-      "temporal-temporal-glitter-worker",
+      "temporal-temporal-glitter-corpus-worker",
+    );
+    const glitterContext = requireDeployment(
+      deployments,
+      "temporal-temporal-glitter-context-worker",
     );
 
     expect(envValue(core, "TEMPORAL_WORKER_ROLE")).toBe("core");
     expect(envValue(core, "SLEEP_WEBHOOK_PORT")).toBe("9469");
     expect(envValue(agent, "TEMPORAL_WORKER_ROLE")).toBe("agent");
-    expect(envValue(glitter, "TEMPORAL_WORKER_ROLE")).toBe("glitter");
+    expect(envValue(glitterCorpus, "TEMPORAL_WORKER_ROLE")).toBe(
+      "glitter-corpus",
+    );
+    expect(envValue(glitterContext, "TEMPORAL_WORKER_ROLE")).toBe(
+      "glitter-context",
+    );
 
     const coreContainer = core.spec.template.spec.containers[0];
     const agentContainer = agent.spec.template.spec.containers[0];
-    const glitterContainer = glitter.spec.template.spec.containers[0];
+    const glitterCorpusContainer =
+      glitterCorpus.spec.template.spec.containers[0];
+    const glitterContextContainer =
+      glitterContext.spec.template.spec.containers[0];
     if (
       coreContainer === undefined ||
       agentContainer === undefined ||
-      glitterContainer === undefined
+      glitterCorpusContainer === undefined ||
+      glitterContextContainer === undefined
     ) {
       throw new Error("Temporal worker Deployments require one container");
     }
@@ -189,9 +211,12 @@ describe("temporal homelab audit tooling worker topology", () => {
       agentContainer.startupProbe,
       agentContainer.livenessProbe,
       agentContainer.readinessProbe,
-      glitterContainer.startupProbe,
-      glitterContainer.livenessProbe,
-      glitterContainer.readinessProbe,
+      glitterCorpusContainer.startupProbe,
+      glitterCorpusContainer.livenessProbe,
+      glitterCorpusContainer.readinessProbe,
+      glitterContextContainer.startupProbe,
+      glitterContextContainer.livenessProbe,
+      glitterContextContainer.readinessProbe,
     ]) {
       expect(probe.httpGet).toEqual({ path: "/healthz", port: 9465 });
     }
@@ -202,14 +227,82 @@ describe("temporal homelab audit tooling worker topology", () => {
     expect(agentContainer.ports.map((port) => port.containerPort)).toEqual([
       9464, 9465,
     ]);
-    expect(glitterContainer.ports.map((port) => port.containerPort)).toEqual([
-      9464, 9465,
-    ]);
+    for (const glitterContainer of [
+      glitterCorpusContainer,
+      glitterContextContainer,
+    ]) {
+      expect(glitterContainer.ports.map((port) => port.containerPort)).toEqual([
+        9464, 9465,
+      ]);
+    }
 
     const yaml = await synthesizeApp();
     expect(yaml).toContain("name: temporal-worker-sleep-webhook");
     expect(yaml).toContain("https://temporal-sleep.sjer.red/healthz");
     expect(yaml).toContain("name: SLEEP_WEBHOOK_TOKEN");
+  });
+
+  it("gives each Glitter worker exact resources, credentials, and token isolation", async () => {
+    const deployments = parseDeployments(await synthesizeApp());
+    const corpus = requireDeployment(
+      deployments,
+      "temporal-temporal-glitter-corpus-worker",
+    );
+    const context = requireDeployment(
+      deployments,
+      "temporal-temporal-glitter-context-worker",
+    );
+
+    expect(corpus.spec).toMatchObject({
+      replicas: 1,
+      strategy: { type: "Recreate" },
+    });
+    expect(context.spec).toMatchObject({
+      replicas: 1,
+      strategy: { type: "Recreate" },
+    });
+    expect(corpus.spec.template.spec).toMatchObject({
+      automountServiceAccountToken: false,
+      serviceAccountName: "temporal-glitter-corpus-worker",
+    });
+    expect(context.spec.template.spec).toMatchObject({
+      automountServiceAccountToken: false,
+      serviceAccountName: "temporal-glitter-context-worker",
+    });
+    expect(corpus.spec.template.metadata.labels["component"]).toBe(
+      "glitter-corpus-worker",
+    );
+    expect(context.spec.template.metadata.labels["component"]).toBe(
+      "glitter-context-worker",
+    );
+    expect(corpus.spec.template.spec.containers[0]?.resources).toEqual({
+      limits: { cpu: "1", memory: "3072Mi" },
+      requests: { cpu: "250m", memory: "512Mi" },
+    });
+    expect(context.spec.template.spec.containers[0]?.resources).toEqual({
+      limits: { cpu: "2", memory: "6144Mi" },
+      requests: { cpu: "750m", memory: "2560Mi" },
+    });
+
+    const corpusEnv = envNames(corpus);
+    const contextEnv = envNames(context);
+    for (const required of [
+      "GLITTER_DISCORD_TOKEN",
+      "GLITTER_DISCORD_GUILD_SLUG",
+      "GLITTER_DISCORD_DENYLIST_CHANNEL_IDS",
+    ]) {
+      expect(corpusEnv).toContain(required);
+      expect(contextEnv).not.toContain(required);
+    }
+    for (const required of [
+      "OPENROUTER_API_KEY",
+      "GITHUB_APP_ID",
+      "GITHUB_APP_INSTALLATION_ID",
+      "GITHUB_APP_PRIVATE_KEY",
+    ]) {
+      expect(contextEnv).toContain(required);
+      expect(corpusEnv).not.toContain(required);
+    }
   });
 
   it("enables Temporal worker observability dynamic config with v1.29 key casing", async () => {

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -28,6 +28,13 @@ default `all` role runs everything in one process for local development.
 | `glitter-context` | `glitter-context`       |                    1 |
 | `maintenance`     | `maintenance`           |                    1 |
 
+The production manifests land in layers. In the Glitter layer, the existing
+legacy core and agent Deployments remain in place while the combined Glitter
+Deployment is replaced by `temporal-glitter-corpus-worker` and
+`temporal-glitter-context-worker`. The gateway, home, reports, infra, repo, and
+Scout Deployments arrive in the later ingress and operations layers; the table
+above describes the final topology.
+
 ## Quick start
 
 Run from `packages/temporal`:

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -7,11 +7,26 @@ generic report-only agent tasks (Claude/Codex subprocesses) including the daily
 homelab audit, deterministic PR-opening refresh jobs, and webhook ingress
 (GitHub merge-conflict check and build cancel, Xcode Cloud, iOS sleep).
 
-Production runs one image as three Kubernetes Deployments selected by
-`TEMPORAL_WORKER_ROLE`: `core` (the `default` and `agent-task` queues plus
-schedules and HTTP/event surfaces), `glitter` (the `glitter-corpus` and
-`glitter-context` queues), and `maintenance` (the serial `maintenance` queue).
-The default `all` role runs everything in one process for local development.
+Production runs one image in ten single-replica Kubernetes Deployments. The
+`control` role owns schedule reconciliation and public HTTP/event surfaces
+without a task queue. `home`, `reports`, `infra`, `repo`, `scout`, `agent`,
+`glitter-corpus`, `glitter-context`, and `maintenance` each own one queue with
+their own activity registry, credentials, service account, and concurrency
+budget. The retired `default` queue has no production owner or start site. The
+default `all` role runs everything in one process for local development.
+
+| Role              | Queue or surface        | Activity concurrency |
+| ----------------- | ----------------------- | -------------------: |
+| `control`         | schedules and HTTP APIs |                 none |
+| `home`            | `home`                  |                    4 |
+| `reports`         | `reports`               |                    4 |
+| `infra`           | `infra`                 |                    1 |
+| `repo`            | `repo-automation`       |                    1 |
+| `scout`           | `scout`                 |                    1 |
+| `agent`           | `agent-task`            |                    1 |
+| `glitter-corpus`  | `glitter-corpus`        |                    1 |
+| `glitter-context` | `glitter-context`       |                    1 |
+| `maintenance`     | `maintenance`           |                    1 |
 
 ## Quick start
 


### PR DESCRIPTION
## Why

Discord corpus capture and context generation have different credentials, memory profiles, and failure modes despite previously sharing one process.

## What

- repurpose the existing Glitter Deployment for context generation
- add a dedicated serial corpus-capture Deployment
- isolate credentials, service accounts, token automount, metrics, and component-selected network policy
- preserve the combined 3 GiB requested memory budget across both pods

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`

This is a non-visual worker isolation change; no media is required. No live deployment or external-effect check was run.