### PR TITLE
feat(temporal): isolate gateway home and reports

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1868,9 +1868,17 @@
       "clones": 1,
       "tokens": 91
     },
+    "packages/temporal/src/workflows/agent-task.test.ts|packages/temporal/src/workflows/agent-task.test.ts": {
+      "clones": 1,
+      "tokens": 120
+    },
+    "packages/temporal/src/workflows/data-dragon.test.ts|packages/temporal/src/workflows/data-dragon.test.ts": {
+      "clones": 1,
+      "tokens": 75
+    },
     "packages/temporal/src/workflows/deps-summary.test.ts|packages/temporal/src/workflows/deps-summary.test.ts": {
       "clones": 2,
-      "tokens": 220
+      "tokens": 235
     },
     "packages/temporal/src/workflows/glitter-corpus.test.ts|packages/temporal/src/workflows/glitter-corpus.test.ts": {
       "clones": 1,
@@ -1937,5 +1945,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-25T01:43:37.189Z"
+  "updated": "2026-08-25T02:48:09.363Z"
 }

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -446,7 +446,7 @@ export function createTemporalChart(app: App) {
       podSelector: {
         matchLabels: {
           app: "temporal-worker",
-          component: "core-worker",
+          component: "legacy-worker",
         },
       },
       policyTypes: ["Egress"],

--- a/packages/homelab/src/cdk8s/src/container-resources.test.ts
+++ b/packages/homelab/src/cdk8s/src/container-resources.test.ts
@@ -283,6 +283,18 @@ describe("Container resource requests backstop", () => {
         },
       ],
       [
+        "temporal-temporal-gateway/temporal-gateway",
+        { requests: { cpu: "100m", memory: "256Mi" } },
+      ],
+      [
+        "temporal-temporal-home-worker/temporal-home-worker",
+        { requests: { cpu: "100m", memory: "512Mi" } },
+      ],
+      [
+        "temporal-temporal-reports-worker/temporal-reports-worker",
+        { requests: { cpu: "100m", memory: "512Mi" } },
+      ],
+      [
         "temporal-temporal-glitter-corpus-worker/temporal-glitter-corpus-worker",
         {
           requests: { cpu: "250m", memory: "512Mi" },

--- a/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
@@ -29,14 +29,14 @@ const AGENT_PROVIDER_UID = 1001;
 export const TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT = "privileged";
 
 /**
- * Run provider-controlled report-only subprocesses outside the core worker.
+ * Run provider-controlled report-only subprocesses outside domain workers.
  *
  * The service account receives the audit reader ClusterRole but none of the
  * namespace-scoped exec roles required by deterministic maintenance and
  * canary activities. The deployment receives provider auth only so its
  * parent-owned loopback broker can inject it upstream; provider subprocesses
  * receive only an ephemeral broker credential. Non-secret evidence endpoints
- * remain available, email delivery runs on the core queue, and the public
+ * remain available, email delivery runs on the reports queue, and the public
  * repository checkout is unauthenticated. Provider subprocesses run as a
  * distinct uid. A NET_ADMIN init container
  * installs owner-matched firewall rules that reject Temporal gRPC and UI

--- a/packages/homelab/src/cdk8s/src/resources/temporal/domain-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/domain-worker.ts
@@ -1,0 +1,121 @@
+import type { Chart } from "cdk8s";
+import type { Size } from "cdk8s";
+import {
+  type Cpu,
+  Deployment,
+  DeploymentStrategy,
+  type EnvValue,
+  Pods,
+  Service,
+  ServiceAccount,
+  Volume,
+} from "cdk8s-plus-31";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import { temporalWorkerHealthProbes } from "./worker-health.ts";
+
+export type TemporalDomainWorkerProps = {
+  name: string;
+  component: string;
+  envVariables: Record<string, EnvValue>;
+  ports?: { number: number; name: string }[];
+  cpuRequest: Cpu;
+  memoryRequest: Size;
+  cpuLimit?: Cpu;
+  memoryLimit?: Size;
+  automountServiceAccountToken?: boolean;
+  serviceAccount?: ServiceAccount;
+};
+
+export function createTemporalDomainWorker(
+  chart: Chart,
+  props: TemporalDomainWorkerProps,
+): Deployment {
+  const serviceAccount =
+    props.serviceAccount ??
+    new ServiceAccount(chart, `${props.name}-service-account`, {
+      metadata: { name: props.name },
+    });
+  const deployment = new Deployment(chart, props.name, {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    serviceAccount,
+    automountServiceAccountToken: props.automountServiceAccountToken ?? false,
+    securityContext: { fsGroup: 1000 },
+    podMetadata: {
+      labels: { app: "temporal-worker", component: props.component },
+    },
+  });
+  setRevisionHistoryLimit(deployment, 5);
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      name: props.name,
+      image: `ghcr.io/shepherdjerred/temporal-worker:${versions["shepherdjerred/temporal-worker"]}`,
+      ports: [
+        { number: 9464, name: "metrics" },
+        { number: 9465, name: "app-metrics" },
+        ...(props.ports ?? []),
+      ],
+      securityContext: {
+        user: 1000,
+        group: 1000,
+        readOnlyRootFilesystem: false,
+      },
+      resources: {
+        cpu: {
+          request: props.cpuRequest,
+          ...(props.cpuLimit === undefined ? {} : { limit: props.cpuLimit }),
+        },
+        memory: {
+          request: props.memoryRequest,
+          ...(props.memoryLimit === undefined
+            ? {}
+            : { limit: props.memoryLimit }),
+        },
+      },
+      ...temporalWorkerHealthProbes(),
+      envVariables: props.envVariables,
+    }),
+  );
+  container.mount(
+    "/tmp",
+    Volume.fromEmptyDir(chart, `${props.name}-tmp`, `${props.component}-tmp`),
+  );
+
+  const selector = Pods.select(chart, `${props.name}-selector`, {
+    labels: { component: props.component },
+  });
+  const sdkMetricsComponent = `${props.component}-sdk-metrics`;
+  new Service(chart, `${props.name}-metrics-service`, {
+    selector,
+    metadata: { labels: { component: sdkMetricsComponent } },
+    ports: [{ port: 9464, name: "metrics" }],
+  });
+  createServiceMonitor(chart, {
+    name: `${props.name}-metrics`,
+    matchLabels: { component: sdkMetricsComponent },
+  });
+
+  const appMetricsComponent = `${props.component}-app-metrics`;
+  new Service(chart, `${props.name}-app-metrics-service`, {
+    selector,
+    metadata: {
+      name: `${props.name}-app-metrics`,
+      labels: { component: appMetricsComponent },
+    },
+    ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
+  });
+  createServiceMonitor(chart, {
+    name: `${props.name}-app-metrics`,
+    port: "app-metrics",
+    interval: "30s",
+    matchLabels: { component: appMetricsComponent },
+  });
+
+  return deployment;
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/http-services.ts
@@ -1,11 +1,11 @@
 import type { Chart } from "cdk8s";
-import type { Deployment, ISecret } from "cdk8s-plus-31";
+import type { IPodSelector, ISecret } from "cdk8s-plus-31";
 import { EnvValue, Service } from "cdk8s-plus-31";
 import { createCloudflareTunnelBinding } from "@shepherdjerred/homelab/cdk8s/src/misc/cloudflare-tunnel.ts";
 
 export function createTemporalWorkerGithubWebhookService(
   chart: Chart,
-  deployment: Deployment,
+  selector: IPodSelector,
 ) {
   // Service + Cloudflare Tunnel binding for the GitHub webhook receiver
   // (Hono server on :9466). Public URL: https://pr-bot.sjer.red — register
@@ -18,7 +18,7 @@ export function createTemporalWorkerGithubWebhookService(
         name: "temporal-worker-gh-webhook",
         labels: { app: "temporal-worker-gh-webhook" },
       },
-      selector: deployment,
+      selector,
       ports: [{ name: "gh-webhook", port: 9466, targetPort: 9466 }],
     },
   );
@@ -41,7 +41,7 @@ export function createTemporalWorkerGithubWebhookService(
 
 export function createAgentTaskApiService(
   chart: Chart,
-  deployment: Deployment,
+  selector: IPodSelector,
 ) {
   const agentTaskService = new Service(
     chart,
@@ -51,7 +51,7 @@ export function createAgentTaskApiService(
         name: "temporal-worker-agent-tasks",
         labels: { app: "temporal-worker-agent-tasks" },
       },
-      selector: deployment,
+      selector,
       ports: [{ name: "agent-tasks", port: 9467, targetPort: 9467 }],
     },
   );
@@ -71,7 +71,7 @@ export function createAgentTaskApiService(
 
 export function createSleepWebhookService(
   chart: Chart,
-  deployment: Deployment,
+  selector: IPodSelector,
 ) {
   const sleepWebhookService = new Service(
     chart,
@@ -81,7 +81,7 @@ export function createSleepWebhookService(
         name: "temporal-worker-sleep-webhook",
         labels: { app: "temporal-worker-sleep-webhook" },
       },
-      selector: deployment,
+      selector,
       ports: [{ name: "sleep-webhook", port: 9469, targetPort: 9469 }],
     },
   );
@@ -112,7 +112,7 @@ export function sleepWebhookEnv(secret: ISecret): Record<string, EnvValue> {
 
 export function createXcodeCloudWebhookService(
   chart: Chart,
-  deployment: Deployment,
+  selector: IPodSelector,
 ) {
   // Service + Cloudflare Tunnel binding for the Xcode Cloud webhook receiver
   // (Hono server on :9468). Public URL: https://xcode-cloud-webhook.sjer.red —
@@ -127,7 +127,7 @@ export function createXcodeCloudWebhookService(
         name: "temporal-worker-xcode-cloud-webhook",
         labels: { app: "temporal-worker-xcode-cloud-webhook" },
       },
-      selector: deployment,
+      selector,
       ports: [{ name: "xc-webhook", port: 9468, targetPort: 9468 }],
     },
   );

--- a/packages/homelab/src/cdk8s/src/resources/temporal/ingress-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/ingress-workers.ts
@@ -1,0 +1,154 @@
+import type { Chart } from "cdk8s";
+import { Size } from "cdk8s";
+import { Cpu, EnvValue, type ISecret, Pods } from "cdk8s-plus-31";
+import { createTemporalDomainWorker } from "./domain-worker.ts";
+import { sleepWebhookEnv } from "./http-services.ts";
+import { createTemporalWorkerHttpServices } from "./worker-http-services.ts";
+
+function runtimeEnv(
+  serverServiceName: string,
+  secret: ISecret,
+  role: "control" | "home" | "reports",
+  serviceName: string,
+): Record<string, EnvValue> {
+  return {
+    TEMPORAL_ADDRESS: EnvValue.fromValue(`${serverServiceName}:7233`),
+    TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+    TEMPORAL_WORKER_ROLE: EnvValue.fromValue(role),
+    ENVIRONMENT: EnvValue.fromValue("production"),
+    TELEMETRY_ENABLED: EnvValue.fromValue("true"),
+    OTLP_ENDPOINT: EnvValue.fromValue(
+      "http://tempo.tempo.svc.cluster.local:4318",
+    ),
+    TELEMETRY_SERVICE_NAME: EnvValue.fromValue(serviceName),
+    SENTRY_DSN: EnvValue.fromSecretValue({ secret, key: "SENTRY_DSN" }),
+  };
+}
+
+export function createTemporalIngressWorkers(
+  chart: Chart,
+  props: { serverServiceName: string; secret: ISecret },
+) {
+  const gatewayDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-gateway",
+    component: "gateway",
+    cpuRequest: Cpu.millis(100),
+    memoryRequest: Size.mebibytes(256),
+    ports: [
+      { number: 9466, name: "gh-webhook" },
+      { number: 9467, name: "agent-tasks" },
+      { number: 9468, name: "xc-webhook" },
+      { number: 9469, name: "sleep-webhook" },
+    ],
+    envVariables: {
+      ...runtimeEnv(
+        props.serverServiceName,
+        props.secret,
+        "control",
+        "temporal-gateway",
+      ),
+      GITHUB_WEBHOOK_SECRET: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "GITHUB_WEBHOOK_SECRET",
+      }),
+      GITHUB_WEBHOOK_PORT: EnvValue.fromValue("9466"),
+      AGENT_TASK_API_PORT: EnvValue.fromValue("9467"),
+      AGENT_TASK_API_TOKEN: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "AGENT_TASK_API_TOKEN",
+      }),
+      ...sleepWebhookEnv(props.secret),
+      XCODE_CLOUD_WEBHOOK_PORT: EnvValue.fromValue("9468"),
+      XCODE_CLOUD_WEBHOOK_TOKEN: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "XCODE_CLOUD_WEBHOOK_TOKEN",
+      }),
+      ALERTMANAGER_URL: EnvValue.fromValue(
+        "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
+      ),
+    },
+  });
+  createTemporalWorkerHttpServices(
+    chart,
+    Pods.select(chart, "temporal-gateway-http-selector", {
+      labels: { component: "gateway" },
+    }),
+  );
+
+  const homeDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-home-worker",
+    component: "home-worker",
+    cpuRequest: Cpu.millis(100),
+    memoryRequest: Size.mebibytes(512),
+    envVariables: {
+      ...runtimeEnv(
+        props.serverServiceName,
+        props.secret,
+        "home",
+        "temporal-home-worker",
+      ),
+      HA_URL: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "HA_URL",
+      }),
+      HA_TOKEN: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "HA_TOKEN",
+      }),
+    },
+  });
+
+  const reportsDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-reports-worker",
+    component: "reports-worker",
+    cpuRequest: Cpu.millis(100),
+    memoryRequest: Size.mebibytes(512),
+    envVariables: {
+      ...runtimeEnv(
+        props.serverServiceName,
+        props.secret,
+        "reports",
+        "temporal-reports-worker",
+      ),
+      S3_ENDPOINT: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "S3_ENDPOINT",
+      }),
+      S3_REGION: EnvValue.fromValue("us-east-1"),
+      S3_FORCE_PATH_STYLE: EnvValue.fromValue("true"),
+      AWS_ACCESS_KEY_ID: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "AWS_ACCESS_KEY_ID",
+      }),
+      AWS_SECRET_ACCESS_KEY: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "AWS_SECRET_ACCESS_KEY",
+      }),
+      POSTAL_HOST: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "POSTAL_HOST",
+      }),
+      POSTAL_HOST_HEADER: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "POSTAL_HOST_HEADER",
+      }),
+      POSTAL_API_KEY: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "POSTAL_API_KEY",
+      }),
+      RECIPIENT_EMAIL: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "RECIPIENT_EMAIL",
+      }),
+      SENDER_EMAIL: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "SENDER_EMAIL",
+      }),
+      ALERTMANAGER_URL: EnvValue.fromValue(
+        "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
+      ),
+    },
+  });
+
+  return { gatewayDeployment, homeDeployment, reportsDeployment };
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/scout-beta-network.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/scout-beta-network.ts
@@ -11,7 +11,7 @@ export function createTemporalScoutBetaNetworkPolicy(chart: Chart): void {
       podSelector: {
         matchLabels: {
           app: "temporal-worker",
-          component: "core-worker",
+          component: "legacy-worker",
         },
       },
       policyTypes: ["Egress"],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-http-services.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-http-services.ts
@@ -1,5 +1,5 @@
 import type { Chart } from "cdk8s";
-import type { Deployment } from "cdk8s-plus-31";
+import type { IPodSelector } from "cdk8s-plus-31";
 import {
   createAgentTaskApiService,
   createSleepWebhookService,
@@ -9,10 +9,10 @@ import {
 
 export function createTemporalWorkerHttpServices(
   chart: Chart,
-  deployment: Deployment,
+  selector: IPodSelector,
 ): void {
-  createTemporalWorkerGithubWebhookService(chart, deployment);
-  createAgentTaskApiService(chart, deployment);
-  createSleepWebhookService(chart, deployment);
-  createXcodeCloudWebhookService(chart, deployment);
+  createTemporalWorkerGithubWebhookService(chart, selector);
+  createAgentTaskApiService(chart, selector);
+  createSleepWebhookService(chart, selector);
+  createXcodeCloudWebhookService(chart, selector);
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -30,8 +30,8 @@ import { createTemporalWorkerCrdReaderRbac } from "./crd-rbac.ts";
 import { sleepWebhookEnv } from "./http-services.ts";
 import { glitterContextEnv, glitterCorpusEnv } from "./glitter-corpus-env.ts";
 import { createTemporalGlitterWorkers } from "./glitter-worker.ts";
+import { createTemporalIngressWorkers } from "./ingress-workers.ts";
 import { temporalWorkerHealthProbes } from "./worker-health.ts";
-import { createTemporalWorkerHttpServices } from "./worker-http-services.ts";
 import { FRESHRSS_DESIRED_JSON } from "@shepherdjerred/homelab/cdk8s/src/resources/freshrss-config.ts";
 import {
   createTemporalWorkerMaintenanceRbac,
@@ -202,7 +202,7 @@ export function createTemporalWorkerDeployment(
     podMetadata: {
       labels: {
         app: "temporal-worker",
-        component: "core-worker",
+        component: "legacy-worker",
       },
     },
   });
@@ -217,21 +217,9 @@ export function createTemporalWorkerDeployment(
       //        activity_task_fail, etc. — see installRuntime in worker.ts)
       // :9465 = application Prometheus registry (pr_*, default Bun process
       //        metrics — see observability/metrics.ts)
-      // :9466 = GitHub webhook receiver (Hono server in event-bridge/
-      //        github-webhook.ts) — exposed via Cloudflare Tunnel for PR
-      //        review/summary events.
-      // :9467 = authenticated agent-task scheduling API.
-      // :9468 = Xcode Cloud webhook receiver (Hono server in event-bridge/
-      //        xcode-cloud-webhook.ts) — exposed via Cloudflare Tunnel; POSTs
-      //        iOS build failures into Alertmanager.
-      // :9469 = authenticated iOS sleep automation webhook.
       ports: [
         { number: 9464, name: "metrics" },
         { number: 9465, name: "app-metrics" },
-        { number: 9466, name: "gh-webhook" },
-        { number: 9467, name: "agent-tasks" },
-        { number: 9468, name: "xc-webhook" },
-        { number: 9469, name: "sleep-webhook" },
       ],
       securityContext: {
         user: UID,
@@ -258,7 +246,7 @@ export function createTemporalWorkerDeployment(
       envVariables: {
         TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
         TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
-        TEMPORAL_WORKER_ROLE: EnvValue.fromValue("core"),
+        TEMPORAL_WORKER_ROLE: EnvValue.fromValue("legacy"),
         FRESHRSS_API_URL: EnvValue.fromValue(
           "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
         ),
@@ -488,6 +476,12 @@ export function createTemporalWorkerDeployment(
     },
   });
 
+  const { gatewayDeployment, homeDeployment, reportsDeployment } =
+    createTemporalIngressWorkers(chart, {
+      serverServiceName: props.serverServiceName,
+      secret,
+    });
+
   const glitterCommonEnv = {
     TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
     TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
@@ -595,11 +589,12 @@ export function createTemporalWorkerDeployment(
     matchLabels: { app: "temporal-worker-app-metrics" },
   });
 
-  createTemporalWorkerHttpServices(chart, deployment);
-
   return {
     deployment,
     agentDeployment,
+    gatewayDeployment,
+    homeDeployment,
+    reportsDeployment,
     glitterCorpusDeployment: corpusDeployment,
     glitterContextDeployment: contextDeployment,
   };

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -91,7 +91,7 @@ describe("Scout weekly parlay deployment boundary", () => {
     ).toBe(false);
   });
 
-  test("allows only the Temporal core worker to reach Beta Scout", () => {
+  test("keeps staged Scout access limited to Temporal workers", () => {
     const beta = scoutResources("beta");
     const policy = findResource(beta, "NetworkPolicy", "scout-ingress-netpol");
     expect(policy.spec).toEqual(
@@ -130,7 +130,7 @@ describe("Scout weekly parlay deployment boundary", () => {
         podSelector: {
           matchLabels: {
             app: "temporal-worker",
-            component: "core-worker",
+            component: "legacy-worker",
           },
         },
         egress: [

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -58,7 +58,12 @@ const DeploymentSchema = z.object({
             ports: z.array(z.object({ containerPort: z.number() })),
             readinessProbe: HttpProbeSchema,
             resources: z.object({
-              limits: z.object({ cpu: z.string(), memory: z.string() }),
+              limits: z
+                .object({
+                  cpu: z.string().optional(),
+                  memory: z.string().optional(),
+                })
+                .optional(),
               requests: z.object({ cpu: z.string(), memory: z.string() }),
             }),
             startupProbe: HttpProbeSchema,
@@ -166,6 +171,15 @@ describe("temporal homelab audit tooling worker topology", () => {
   it("isolates core, agent, and both Glitter queues behind event-loop health probes", async () => {
     const deployments = parseDeployments(await synthesizeApp());
     const core = requireDeployment(deployments, "temporal-temporal-worker");
+    const gateway = requireDeployment(deployments, "temporal-temporal-gateway");
+    const home = requireDeployment(
+      deployments,
+      "temporal-temporal-home-worker",
+    );
+    const reports = requireDeployment(
+      deployments,
+      "temporal-temporal-reports-worker",
+    );
     const agent = requireDeployment(
       deployments,
       "temporal-temporal-agent-worker",
@@ -179,8 +193,11 @@ describe("temporal homelab audit tooling worker topology", () => {
       "temporal-temporal-glitter-context-worker",
     );
 
-    expect(envValue(core, "TEMPORAL_WORKER_ROLE")).toBe("core");
-    expect(envValue(core, "SLEEP_WEBHOOK_PORT")).toBe("9469");
+    expect(envValue(core, "TEMPORAL_WORKER_ROLE")).toBe("legacy");
+    expect(envValue(gateway, "TEMPORAL_WORKER_ROLE")).toBe("control");
+    expect(envValue(gateway, "SLEEP_WEBHOOK_PORT")).toBe("9469");
+    expect(envValue(home, "TEMPORAL_WORKER_ROLE")).toBe("home");
+    expect(envValue(reports, "TEMPORAL_WORKER_ROLE")).toBe("reports");
     expect(envValue(agent, "TEMPORAL_WORKER_ROLE")).toBe("agent");
     expect(envValue(glitterCorpus, "TEMPORAL_WORKER_ROLE")).toBe(
       "glitter-corpus",
@@ -190,6 +207,9 @@ describe("temporal homelab audit tooling worker topology", () => {
     );
 
     const coreContainer = core.spec.template.spec.containers[0];
+    const gatewayContainer = gateway.spec.template.spec.containers[0];
+    const homeContainer = home.spec.template.spec.containers[0];
+    const reportsContainer = reports.spec.template.spec.containers[0];
     const agentContainer = agent.spec.template.spec.containers[0];
     const glitterCorpusContainer =
       glitterCorpus.spec.template.spec.containers[0];
@@ -197,6 +217,9 @@ describe("temporal homelab audit tooling worker topology", () => {
       glitterContext.spec.template.spec.containers[0];
     if (
       coreContainer === undefined ||
+      gatewayContainer === undefined ||
+      homeContainer === undefined ||
+      reportsContainer === undefined ||
       agentContainer === undefined ||
       glitterCorpusContainer === undefined ||
       glitterContextContainer === undefined
@@ -208,6 +231,15 @@ describe("temporal homelab audit tooling worker topology", () => {
       coreContainer.startupProbe,
       coreContainer.livenessProbe,
       coreContainer.readinessProbe,
+      gatewayContainer.startupProbe,
+      gatewayContainer.livenessProbe,
+      gatewayContainer.readinessProbe,
+      homeContainer.startupProbe,
+      homeContainer.livenessProbe,
+      homeContainer.readinessProbe,
+      reportsContainer.startupProbe,
+      reportsContainer.livenessProbe,
+      reportsContainer.readinessProbe,
       agentContainer.startupProbe,
       agentContainer.livenessProbe,
       agentContainer.readinessProbe,
@@ -222,7 +254,16 @@ describe("temporal homelab audit tooling worker topology", () => {
     }
 
     expect(coreContainer.ports.map((port) => port.containerPort)).toEqual([
+      9464, 9465,
+    ]);
+    expect(gatewayContainer.ports.map((port) => port.containerPort)).toEqual([
       9464, 9465, 9466, 9467, 9468, 9469,
+    ]);
+    expect(homeContainer.ports.map((port) => port.containerPort)).toEqual([
+      9464, 9465,
+    ]);
+    expect(reportsContainer.ports.map((port) => port.containerPort)).toEqual([
+      9464, 9465,
     ]);
     expect(agentContainer.ports.map((port) => port.containerPort)).toEqual([
       9464, 9465,
@@ -241,7 +282,9 @@ describe("temporal homelab audit tooling worker topology", () => {
     expect(yaml).toContain("https://temporal-sleep.sjer.red/healthz");
     expect(yaml).toContain("name: SLEEP_WEBHOOK_TOKEN");
   });
+});
 
+describe("Temporal domain worker isolation", () => {
   it("gives each Glitter worker exact resources, credentials, and token isolation", async () => {
     const deployments = parseDeployments(await synthesizeApp());
     const corpus = requireDeployment(
@@ -302,6 +345,85 @@ describe("temporal homelab audit tooling worker topology", () => {
     ]) {
       expect(contextEnv).toContain(required);
       expect(corpusEnv).not.toContain(required);
+    }
+  });
+
+  it("isolates gateway, home, and reports identities and credentials", async () => {
+    const deployments = parseDeployments(await synthesizeApp());
+    const gateway = requireDeployment(deployments, "temporal-temporal-gateway");
+    const home = requireDeployment(
+      deployments,
+      "temporal-temporal-home-worker",
+    );
+    const reports = requireDeployment(
+      deployments,
+      "temporal-temporal-reports-worker",
+    );
+    const definitions = [
+      {
+        deployment: gateway,
+        component: "gateway",
+        serviceAccountName: "temporal-gateway",
+        resources: { requests: { cpu: "100m", memory: "256Mi" } },
+      },
+      {
+        deployment: home,
+        component: "home-worker",
+        serviceAccountName: "temporal-home-worker",
+        resources: { requests: { cpu: "100m", memory: "512Mi" } },
+      },
+      {
+        deployment: reports,
+        component: "reports-worker",
+        serviceAccountName: "temporal-reports-worker",
+        resources: { requests: { cpu: "100m", memory: "512Mi" } },
+      },
+    ];
+    for (const definition of definitions) {
+      expect(definition.deployment.spec).toMatchObject({
+        replicas: 1,
+        strategy: { type: "Recreate" },
+      });
+      expect(definition.deployment.spec.template.spec).toMatchObject({
+        automountServiceAccountToken: false,
+        serviceAccountName: definition.serviceAccountName,
+      });
+      expect(
+        definition.deployment.spec.template.metadata.labels["component"],
+      ).toBe(definition.component);
+      expect(
+        definition.deployment.spec.template.spec.containers[0]?.resources,
+      ).toEqual(definition.resources);
+    }
+
+    const gatewayEnv = envNames(gateway);
+    const homeEnv = envNames(home);
+    const reportsEnv = envNames(reports);
+    for (const required of [
+      "GITHUB_WEBHOOK_SECRET",
+      "AGENT_TASK_API_TOKEN",
+      "SLEEP_WEBHOOK_TOKEN",
+      "XCODE_CLOUD_WEBHOOK_TOKEN",
+    ]) {
+      expect(gatewayEnv).toContain(required);
+      expect(homeEnv).not.toContain(required);
+      expect(reportsEnv).not.toContain(required);
+    }
+    for (const required of ["HA_URL", "HA_TOKEN"]) {
+      expect(homeEnv).toContain(required);
+      expect(gatewayEnv).not.toContain(required);
+      expect(reportsEnv).not.toContain(required);
+    }
+    for (const required of [
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "POSTAL_API_KEY",
+      "RECIPIENT_EMAIL",
+      "SENDER_EMAIL",
+    ]) {
+      expect(reportsEnv).toContain(required);
+      expect(gatewayEnv).not.toContain(required);
+      expect(homeEnv).not.toContain(required);
     }
   });
 

--- a/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
@@ -57,7 +57,7 @@ describe("Temporal FreshRSS integration", () => {
     expect(spec.itemPath).toMatch(/\/items\/freshrss-sync$/u);
   });
 
-  test("configures the core worker and scoped FreshRSS network access", () => {
+  test("configures the legacy worker and scoped FreshRSS network access", () => {
     const synthesized = resources();
     const deployment = findResource(
       synthesized,
@@ -101,11 +101,11 @@ describe("Temporal FreshRSS integration", () => {
       .parse(deployment.spec);
     const container = deploymentSpec.template.spec.containers[0];
     if (container === undefined) {
-      throw new Error("Temporal core worker container is missing");
+      throw new Error("Temporal legacy worker container is missing");
     }
     expect(deploymentSpec.template.metadata.labels).toMatchObject({
       app: "temporal-worker",
-      component: "core-worker",
+      component: "legacy-worker",
     });
     expect(container.env).toContainEqual({
       name: "FRESHRSS_API_PASSWORD_FILE",
@@ -153,7 +153,7 @@ describe("Temporal FreshRSS integration", () => {
       .parse(policy.spec);
     expect(policySpec.podSelector.matchLabels).toEqual({
       app: "temporal-worker",
-      component: "core-worker",
+      component: "legacy-worker",
     });
     expect(policySpec.egress).toContainEqual({
       ports: [{ port: 80, protocol: "TCP" }],

--- a/packages/temporal/src/activities/agent-task-report-delivery.test.ts
+++ b/packages/temporal/src/activities/agent-task-report-delivery.test.ts
@@ -226,17 +226,17 @@ describe("agent task report delivery delegation", () => {
     expect(report.limitations[0]).toContain("workdir may remain");
   });
 
-  test("targets the credentialed core queue with a stable workflow identity", () => {
+  test("targets the credentialed reports queue with a stable workflow identity", () => {
     expect(agentTaskReportDeliveryWorkflowOptions(REPORT)).toEqual({
       args: [REPORT],
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.REPORTS,
       workflowId: `report-delivery:${REPORT.reportRunId}`,
       workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
       workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
     });
   });
 
-  test("returns the validated core delivery result", async () => {
+  test("returns the validated reports delivery result", async () => {
     const observed: unknown[] = [];
     const result = await deliverAgentTaskReportWithDependencies(REPORT, {
       execute: async (options) => {

--- a/packages/temporal/src/activities/agent-task-side-activities.ts
+++ b/packages/temporal/src/activities/agent-task-side-activities.ts
@@ -227,7 +227,7 @@ function agentTaskReportInput(
 
 export type AgentTaskReportDeliveryWorkflowOptions = {
   args: [ReportEnvelopeV1];
-  taskQueue: typeof TASK_QUEUES.DEFAULT;
+  taskQueue: typeof TASK_QUEUES.REPORTS;
   workflowId: string;
   workflowIdReusePolicy: WorkflowIdReusePolicy;
   workflowIdConflictPolicy: WorkflowIdConflictPolicy;
@@ -245,7 +245,7 @@ export function agentTaskReportDeliveryWorkflowOptions(
   const report = ReportEnvelopeV1Schema.parse(rawReport);
   return {
     args: [report],
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPORTS,
     workflowId: `report-delivery:${report.reportRunId}`,
     // An activity retry after accepted delivery may start a new execution. The
     // shared sender's S3 receipt check turns it into a deterministic dedupe.

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -47,6 +47,8 @@ export const reportActivities = {
   ...reportDeliveryActivities,
   ...reportFreshnessActivities,
   ...workflowFailureWatchActivities,
+  sendAgentTaskEmail: agentTaskActivities.sendAgentTaskEmail,
+  sendAgentTaskFailureReport: agentTaskActivities.sendAgentTaskFailureReport,
 };
 
 export const infraActivities = {

--- a/packages/temporal/src/event-bridge/sleep-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/sleep-webhook.test.ts
@@ -94,7 +94,7 @@ describe("sleep webhook", () => {
     expect(start.mock.calls[0]).toEqual([
       "sleepMusic",
       {
-        taskQueue: "default",
+        taskQueue: "home",
         workflowId: "sleep-music",
         workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
         workflowExecutionTimeout: 12_600_000,

--- a/packages/temporal/src/event-bridge/sleep-webhook.ts
+++ b/packages/temporal/src/event-bridge/sleep-webhook.ts
@@ -87,7 +87,7 @@ async function startSleepWorkflow(
 ): Promise<void> {
   const input: SleepAutomationInput = { durationMinutes };
   await client.workflow.start(workflowType, {
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     workflowId,
     workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
     workflowExecutionTimeout: sleepWorkflowTimeout(durationMinutes),

--- a/packages/temporal/src/event-bridge/triggers.test.ts
+++ b/packages/temporal/src/event-bridge/triggers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from "vitest";
+import type { Client } from "@temporalio/client";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { handleIosAction } from "./triggers.ts";
+
+type WorkflowStart = (
+  workflowType: string,
+  options: { taskQueue: string; workflowId: string },
+) => Promise<unknown>;
+
+function fakeClient(start: WorkflowStart): Client {
+  const client = Object.create(null);
+  client.workflow = { start };
+  return client;
+}
+
+describe("Home Assistant event routing", () => {
+  test("starts iOS good-night actions on the home queue", async () => {
+    const start = vi.fn<WorkflowStart>(() => Promise.resolve());
+    await handleIosAction(fakeClient(start))({
+      data: { actionID: "A91A15AA-479E-416C-8F51-BD983A999266" },
+    });
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(start.mock.calls[0]?.[0]).toBe("goodNight");
+    expect(start.mock.calls[0]?.[1]).toMatchObject({
+      taskQueue: TASK_QUEUES.HOME,
+    });
+  });
+});

--- a/packages/temporal/src/event-bridge/triggers.ts
+++ b/packages/temporal/src/event-bridge/triggers.ts
@@ -65,7 +65,7 @@ const PRESENCE_CHANGED_SIGNAL = "presenceChanged";
 async function bumpLockReconciler(client: Client): Promise<void> {
   try {
     await client.workflow.signalWithStart("reconcileLock", {
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.HOME,
       workflowId: RECONCILE_LOCK_WORKFLOW_ID,
       workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
       workflowExecutionTimeout: "30 minutes",
@@ -101,7 +101,7 @@ async function startWorkflow(
 ): Promise<void> {
   try {
     await client.workflow.start(workflowType, {
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.HOME,
       workflowId,
       workflowIdReusePolicy:
         options.workflowIdReusePolicy ?? WorkflowIdReusePolicy.ALLOW_DUPLICATE,

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -45,6 +45,29 @@ describe("direct maintenance schedules", () => {
   );
 });
 
+describe("domain schedule routing", () => {
+  it.each([
+    "vacuum-9am",
+    "vacuum-12pm",
+    "vacuum-5pm",
+    "good-morning-weekday-preheat",
+    "good-morning-weekday-wake",
+    "good-morning-weekday-up",
+    "good-morning-weekend-preheat",
+    "good-morning-weekend-wake",
+    "good-morning-weekend-up",
+  ])("routes %s to the home queue", (id) => {
+    expect(findScheduleById(id).taskQueue).toBe(TASK_QUEUES.HOME);
+  });
+
+  it.each(["report-freshness-monitor", "temporal-failure-watch"])(
+    "routes %s to the reports queue",
+    (id) => {
+      expect(findScheduleById(id).taskQueue).toBe(TASK_QUEUES.REPORTS);
+    },
+  );
+});
+
 test("dependency summary timeout covers every retried report phase", () => {
   expect(findScheduleById("deps-summary-weekly").workflowExecutionTimeout).toBe(
     "3 hours",
@@ -364,6 +387,14 @@ describe("Glitter corpus schedule", () => {
     expect(buildScheduleState(schedule, configured)).toEqual({
       paused: true,
       note: "Paused automatically until required Glitter corpus credentials are configured: GLITTER_DISCORD_DENYLIST_CHANNEL_IDS",
+    });
+  });
+
+  test("lets the gateway preserve remote-worker approval state without credentials", () => {
+    const schedule = findScheduleById("glitter-corpus-daily");
+    expect(buildScheduleState(schedule, {}, undefined, false)).toEqual({
+      paused: true,
+      note: "Awaiting operator approval of first complete snapshot",
     });
   });
 

--- a/packages/temporal/src/schedules/register-schedules.ts
+++ b/packages/temporal/src/schedules/register-schedules.ts
@@ -93,8 +93,12 @@ function buildScheduleConfiguration(schedule: ScheduleDefinition) {
   };
 }
 
-export async function registerSchedules(client: Client): Promise<void> {
+export async function registerSchedules(
+  client: Client,
+  options: { validateLocalEnvironment?: boolean } = {},
+): Promise<void> {
   const scheduleClient = client.schedule;
+  const validateLocalEnvironment = options.validateLocalEnvironment ?? true;
 
   for (const scheduleId of DELETED_SCHEDULE_IDS) {
     try {
@@ -114,7 +118,12 @@ export async function registerSchedules(client: Client): Promise<void> {
       await handle.update((prev) => ({
         ...prev,
         ...buildScheduleConfiguration(schedule),
-        state: buildScheduleState(schedule, Bun.env, prev.state),
+        state: buildScheduleState(
+          schedule,
+          Bun.env,
+          prev.state,
+          validateLocalEnvironment,
+        ),
       }));
 
       console.warn(`Updated schedule: ${schedule.id}`);
@@ -127,7 +136,12 @@ export async function registerSchedules(client: Client): Promise<void> {
         scheduleId: schedule.id,
         ...buildScheduleConfiguration(schedule),
         memo: { description: schedule.memo },
-        state: buildScheduleState(schedule, Bun.env),
+        state: buildScheduleState(
+          schedule,
+          Bun.env,
+          undefined,
+          validateLocalEnvironment,
+        ),
       });
 
       console.warn(`Created schedule: ${schedule.id}`);

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -8,7 +8,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "monitorReportFreshness",
     args: [],
     cronExpression: "*/15 * * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPORTS,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "20 minutes",
     memo: "Every-15-minute accepted report heartbeat freshness monitor",

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -352,7 +352,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runVacuumIfNotHome",
     args: [],
     cronExpression: "0 9 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     // verifyState worst case = 3m delay + 3×1m inter-attempt sleeps + slack
     workflowExecutionTimeout: "15 minutes",
@@ -364,7 +364,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runVacuumIfNotHome",
     args: [],
     cronExpression: "0 12 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     // verifyState worst case = 3m delay + 3×1m inter-attempt sleeps + slack
     workflowExecutionTimeout: "15 minutes",
@@ -376,7 +376,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runVacuumIfNotHome",
     args: [],
     cronExpression: "0 17 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     // verifyState worst case = 3m delay + 3×1m inter-attempt sleeps + slack
     workflowExecutionTimeout: "15 minutes",
@@ -394,7 +394,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "goodMorningPreheat",
     args: [],
     cronExpression: "45 5 * * 1-5",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "240 minutes",
     catchupWindow: CATCHUP_TIGHT,
@@ -405,7 +405,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "goodMorningWakeUp",
     args: [],
     cronExpression: "0 8 * * 1-5",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     // goodMorningWakeUp still runs its 60-minute heat window (MORNING_HEAT_DURATION)
     // as the fallback when the preheat run was skipped; needs > 60m + slack
@@ -418,7 +418,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "goodMorningGetUp",
     args: [],
     cronExpression: "15 8 * * 1-5",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
     catchupWindow: CATCHUP_TIGHT,
@@ -430,7 +430,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "goodMorningPreheat",
     args: [],
     cronExpression: "45 6 * * 0,6",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "240 minutes",
     catchupWindow: CATCHUP_TIGHT,
@@ -441,7 +441,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "goodMorningWakeUp",
     args: [],
     cronExpression: "0 9 * * 0,6",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     // goodMorningWakeUp still runs its 60-minute heat window (MORNING_HEAT_DURATION)
     // as the fallback when the preheat run was skipped; needs > 60m + slack
@@ -454,7 +454,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "goodMorningGetUp",
     args: [],
     cronExpression: "15 9 * * 0,6",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.HOME,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
     catchupWindow: CATCHUP_TIGHT,
@@ -468,7 +468,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // be recovered by the next poll; the matching alert TTL prevents duplicate
     // pages for executions observed again after recovery.
     cronExpression: "*/5 * * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPORTS,
     overlap: ScheduleOverlapPolicy.SKIP,
     // Covers the activity's full 3-attempt retry budget (3x 2m + ~30s
     // backoff ≈ 6.5m) with margin; SKIP overlap makes the wider ceiling

--- a/packages/temporal/src/schedules/schedule-state.ts
+++ b/packages/temporal/src/schedules/schedule-state.ts
@@ -11,16 +11,21 @@ export function buildScheduleState(
   schedule: ScheduleStateDefinition,
   env: Readonly<Record<string, string | undefined>>,
   previous?: { paused: boolean; note?: string },
+  validateEnvironment = true,
 ): { paused: boolean; note?: string } {
-  const missing = (schedule.requiredEnvironment ?? []).filter((name) => {
-    const value = env[name];
-    return value === undefined || value === "";
-  });
-  missing.push(
-    ...(schedule.requiredPresentEnvironment ?? []).filter(
-      (name) => env[name] === undefined,
-    ),
-  );
+  const missing = validateEnvironment
+    ? (schedule.requiredEnvironment ?? []).filter((name) => {
+        const value = env[name];
+        return value === undefined || value === "";
+      })
+    : [];
+  if (validateEnvironment) {
+    missing.push(
+      ...(schedule.requiredPresentEnvironment ?? []).filter(
+        (name) => env[name] === undefined,
+      ),
+    );
+  }
   if (missing.length > 0) {
     return {
       paused: true,

--- a/packages/temporal/src/schedules/schedule-types.ts
+++ b/packages/temporal/src/schedules/schedule-types.ts
@@ -1,5 +1,6 @@
 import type { ScheduleOverlapPolicy } from "@temporalio/client";
 import type { Duration } from "@temporalio/common";
+import type { TaskQueue } from "#shared/task-queues.ts";
 
 export type CatchupWindow = "5 minutes" | "1 hour" | "12 hours";
 
@@ -8,7 +9,7 @@ export type ScheduleDefinition = {
   workflowType: string;
   args: unknown[];
   cronExpression: string;
-  taskQueue: string;
+  taskQueue: TaskQueue;
   overlap: ScheduleOverlapPolicy;
   memo: string;
   workflowExecutionTimeout?: Duration;

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { agentActivities, reportActivities } from "./activities/index.ts";
 import { TASK_QUEUES } from "./shared/task-queues.ts";
 import {
   getWorkerRoleContract,
@@ -87,5 +88,16 @@ describe("Temporal worker role contracts", () => {
     for (const serialRole of serialRoles) {
       expect(concurrency.get(serialRole)).toBe(1);
     }
+  });
+
+  it("keeps report delivery capabilities separate from agent execution", () => {
+    expect(reportActivities.sendAgentTaskEmail).toBe(
+      agentActivities.sendAgentTaskEmail,
+    );
+    expect(reportActivities.sendAgentTaskFailureReport).toBe(
+      agentActivities.sendAgentTaskFailureReport,
+    );
+    expect(reportActivities).not.toHaveProperty("runAgentTask");
+    expect(reportActivities).not.toHaveProperty("prepareAgentTaskWorkdir");
   });
 });

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -43,6 +43,7 @@ describe("Temporal worker role contracts", () => {
   it("keeps gateway and event-bridge ownership explicit", () => {
     expect(getWorkerRoleContract("control")).toMatchObject({
       runsGateway: true,
+      validatesScheduleEnvironmentLocally: false,
       runsEventBridge: false,
       workers: [],
     });
@@ -60,6 +61,7 @@ describe("Temporal worker role contracts", () => {
     const contract = getWorkerRoleContract("all");
     expect(contract.workers).toHaveLength(Object.values(TASK_QUEUES).length);
     expect(contract.runsGateway).toBe(true);
+    expect(contract.validatesScheduleEnvironmentLocally).toBe(true);
     expect(contract.runsEventBridge).toBe(true);
     expect(contract.restoresGlitterCorpusMetrics).toBe(true);
   });

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -126,6 +126,7 @@ function roleOwnsDefinition(
 export type WorkerRoleContract = {
   workers: readonly QueueWorkerDefinition[];
   runsGateway: boolean;
+  validatesScheduleEnvironmentLocally: boolean;
   runsEventBridge: boolean;
   restoresGlitterCorpusMetrics: boolean;
 };
@@ -136,6 +137,7 @@ export function getWorkerRoleContract(role: WorkerRole): WorkerRoleContract {
       roleOwnsDefinition(role, definition),
     ),
     runsGateway: role === "all" || role === "control" || role === "core",
+    validatesScheduleEnvironmentLocally: role === "all" || role === "core",
     runsEventBridge: role === "all" || role === "core" || role === "home",
     restoresGlitterCorpusMetrics:
       role === "all" || role === "glitter" || role === "glitter-corpus",

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -279,7 +279,10 @@ async function main(): Promise<void> {
     const client = new Client({ connection: clientConnection });
 
     if (roleContract.runsGateway) {
-      await registerSchedules(client);
+      await registerSchedules(client, {
+        validateLocalEnvironment:
+          roleContract.validatesScheduleEnvironmentLocally,
+      });
       jsonLog("info", "Schedules registered");
 
       httpServers = startHttpServers(client);

--- a/packages/temporal/src/workflows/agent-task.test.ts
+++ b/packages/temporal/src/workflows/agent-task.test.ts
@@ -144,48 +144,53 @@ describe("agent task post-report failure delivery", () => {
     const events: string[] = [];
     const failureReports: SendAgentTaskFailureReportInput[] = [];
     let followUpAttempts = 0;
+    const activities = {
+      prepareAgentTaskWorkdir: () => ({ workdir: "/tmp/agent-task-test" }),
+      runAgentTask: () => RESULT,
+      investigateAgentTask: () => RESULT,
+      finalizeAgentTask: () => RESULT,
+      sendAgentTaskEmail: () => {
+        events.push("success-report");
+        return {
+          subject: "[OK] Agent Task: Inspect production evidence",
+          messageId: "success-message",
+          recipientId: 1,
+          reportRunId: "agent-task:run-1",
+          receiptKey: "reports/receipts/agent-task/run-1.json",
+        };
+      },
+      scheduleAgentTaskFollowUp: (): never => {
+        followUpAttempts += 1;
+        events.push("follow-up-failed");
+        throw new Error("follow-up schedule unavailable");
+      },
+      sendAgentTaskFailureReport: (input: SendAgentTaskFailureReportInput) => {
+        failureReports.push(input);
+        events.push("failure-report");
+        return {
+          subject: "[FAILED] Agent Task: Inspect production evidence",
+          messageId: "failure-message",
+          recipientId: 1,
+          reportRunId: "agent-task:run-1:failed",
+          receiptKey: "reports/receipts/agent-task/run-1-failed.json",
+        };
+      },
+      cleanupAgentTaskWorkdir: () => {
+        events.push("cleanup");
+      },
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
       taskQueue: TASK_QUEUES.DEFAULT,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
-      activities: {
-        prepareAgentTaskWorkdir: () => ({ workdir: "/tmp/agent-task-test" }),
-        runAgentTask: () => RESULT,
-        investigateAgentTask: () => RESULT,
-        finalizeAgentTask: () => RESULT,
-        sendAgentTaskEmail: () => {
-          events.push("success-report");
-          return {
-            subject: "[OK] Agent Task: Inspect production evidence",
-            messageId: "success-message",
-            recipientId: 1,
-            reportRunId: "agent-task:run-1",
-            receiptKey: "reports/receipts/agent-task/run-1.json",
-          };
-        },
-        scheduleAgentTaskFollowUp: (): never => {
-          followUpAttempts += 1;
-          events.push("follow-up-failed");
-          throw new Error("follow-up schedule unavailable");
-        },
-        sendAgentTaskFailureReport: (
-          input: SendAgentTaskFailureReportInput,
-        ) => {
-          failureReports.push(input);
-          events.push("failure-report");
-          return {
-            subject: "[FAILED] Agent Task: Inspect production evidence",
-            messageId: "failure-message",
-            recipientId: 1,
-            reportRunId: "agent-task:run-1:failed",
-            receiptKey: "reports/receipts/agent-task/run-1-failed.json",
-          };
-        },
-        cleanupAgentTaskWorkdir: () => {
-          events.push("cleanup");
-        },
-      },
+      activities,
     });
+    const reportWorker = await Worker.create({
+      connection: testEnvironment.nativeConnection,
+      taskQueue: TASK_QUEUES.REPORTS,
+      activities,
+    });
+    const reportWorkerRun = reportWorker.run();
 
     let failure: unknown;
     try {
@@ -198,6 +203,9 @@ describe("agent task post-report failure delivery", () => {
       );
     } catch (error: unknown) {
       failure = error;
+    } finally {
+      reportWorker.shutdown();
+      await reportWorkerRun;
     }
 
     expect(failure).toBeInstanceOf(Error);
@@ -221,48 +229,53 @@ describe("agent task post-report failure delivery", () => {
     const events: string[] = [];
     const failureReports: SendAgentTaskFailureReportInput[] = [];
     let cleanupAttempts = 0;
+    const activities = {
+      prepareAgentTaskWorkdir: () => ({ workdir: "/tmp/agent-task-test" }),
+      runAgentTask: () => RESULT_WITHOUT_FOLLOW_UP,
+      investigateAgentTask: () => RESULT_WITHOUT_FOLLOW_UP,
+      finalizeAgentTask: () => RESULT_WITHOUT_FOLLOW_UP,
+      sendAgentTaskEmail: () => {
+        events.push("success-report");
+        return {
+          subject: "[OK] Agent Task: Inspect production evidence",
+          messageId: "success-message",
+          recipientId: 1,
+          reportRunId: "agent-task:run-2",
+          receiptKey: "reports/receipts/agent-task/run-2.json",
+        };
+      },
+      scheduleAgentTaskFollowUp: (): never => {
+        throw new Error("unexpected follow-up dispatch");
+      },
+      sendAgentTaskFailureReport: (input: SendAgentTaskFailureReportInput) => {
+        failureReports.push(input);
+        events.push("failure-report");
+        return {
+          subject: "[FAILED] Agent Task: Inspect production evidence",
+          messageId: "failure-message",
+          recipientId: 1,
+          reportRunId: "agent-task:run-2:failed",
+          receiptKey: "reports/receipts/agent-task/run-2-failed.json",
+        };
+      },
+      cleanupAgentTaskWorkdir: (): never => {
+        cleanupAttempts += 1;
+        events.push("cleanup-failed");
+        throw new Error("workdir cleanup unavailable");
+      },
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
       taskQueue: TASK_QUEUES.DEFAULT,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
-      activities: {
-        prepareAgentTaskWorkdir: () => ({ workdir: "/tmp/agent-task-test" }),
-        runAgentTask: () => RESULT_WITHOUT_FOLLOW_UP,
-        investigateAgentTask: () => RESULT_WITHOUT_FOLLOW_UP,
-        finalizeAgentTask: () => RESULT_WITHOUT_FOLLOW_UP,
-        sendAgentTaskEmail: () => {
-          events.push("success-report");
-          return {
-            subject: "[OK] Agent Task: Inspect production evidence",
-            messageId: "success-message",
-            recipientId: 1,
-            reportRunId: "agent-task:run-2",
-            receiptKey: "reports/receipts/agent-task/run-2.json",
-          };
-        },
-        scheduleAgentTaskFollowUp: (): never => {
-          throw new Error("unexpected follow-up dispatch");
-        },
-        sendAgentTaskFailureReport: (
-          input: SendAgentTaskFailureReportInput,
-        ) => {
-          failureReports.push(input);
-          events.push("failure-report");
-          return {
-            subject: "[FAILED] Agent Task: Inspect production evidence",
-            messageId: "failure-message",
-            recipientId: 1,
-            reportRunId: "agent-task:run-2:failed",
-            receiptKey: "reports/receipts/agent-task/run-2-failed.json",
-          };
-        },
-        cleanupAgentTaskWorkdir: (): never => {
-          cleanupAttempts += 1;
-          events.push("cleanup-failed");
-          throw new Error("workdir cleanup unavailable");
-        },
-      },
+      activities,
     });
+    const reportWorker = await Worker.create({
+      connection: testEnvironment.nativeConnection,
+      taskQueue: TASK_QUEUES.REPORTS,
+      activities,
+    });
+    const reportWorkerRun = reportWorker.run();
 
     let failure: unknown;
     try {
@@ -275,6 +288,9 @@ describe("agent task post-report failure delivery", () => {
       );
     } catch (error: unknown) {
       failure = error;
+    } finally {
+      reportWorker.shutdown();
+      await reportWorkerRun;
     }
 
     expect(failure).toBeInstanceOf(Error);

--- a/packages/temporal/src/workflows/agent-task.ts
+++ b/packages/temporal/src/workflows/agent-task.ts
@@ -81,8 +81,8 @@ const legacyEmailActivities = proxyActivities<AgentTaskActivities>({
   retry: RETRY,
 });
 
-const coreEmailActivities = proxyActivities<AgentTaskActivities>({
-  taskQueue: TASK_QUEUES.DEFAULT,
+const reportEmailActivities = proxyActivities<AgentTaskActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: AGENT_REPORT_DELIVERY_START_TO_CLOSE_MS,
   retry: RETRY,
 });
@@ -143,7 +143,7 @@ export async function agentTaskWorkflow(input: AgentTaskInput): Promise<void> {
     "agent-task-post-delivery-failure-report",
   );
   const emailActivities = coreEmailDelivery
-    ? coreEmailActivities
+    ? reportEmailActivities
     : legacyEmailActivities;
   await waitUntilRunAt(input.runAt);
   const startedAt = new Date().toISOString();

--- a/packages/temporal/src/workflows/agent-task.ts
+++ b/packages/temporal/src/workflows/agent-task.ts
@@ -139,10 +139,12 @@ export async function agentTaskWorkflow(input: AgentTaskInput): Promise<void> {
   const twoPhaseV2 = patched("agent-task-two-phase-v2");
   const requireV2 = patched("agent-task-require-v2");
   const coreEmailDelivery = patched("agent-task-core-email-delivery");
+  const reportsEmailDelivery =
+    coreEmailDelivery && patched("agent-task-reports-email-delivery-v1");
   const postDeliveryFailureReporting = patched(
     "agent-task-post-delivery-failure-report",
   );
-  const emailActivities = coreEmailDelivery
+  const emailActivities = reportsEmailDelivery
     ? reportEmailActivities
     : legacyEmailActivities;
   await waitUntilRunAt(input.runAt);

--- a/packages/temporal/src/workflows/agent-task.ts
+++ b/packages/temporal/src/workflows/agent-task.ts
@@ -77,6 +77,7 @@ async function executeAgentTask(
 }
 
 const legacyEmailActivities = proxyActivities<AgentTaskActivities>({
+  taskQueue: TASK_QUEUES.DEFAULT,
   startToCloseTimeout: AGENT_REPORT_DELIVERY_START_TO_CLOSE_MS,
   retry: RETRY,
 });

--- a/packages/temporal/src/workflows/ci-io-impact.ts
+++ b/packages/temporal/src/workflows/ci-io-impact.ts
@@ -7,18 +7,12 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const { collectCiIoImpact } = proxyActivities<CiIoImpactActivities>({
   startToCloseTimeout: "45 minutes",
   retry: { maximumAttempts: 2 },
 });
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  taskQueue: TASK_QUEUES.REPORTS,
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
-});
-
 type CiIoEvaluation = {
   pending: boolean;
   pendingReason: string | undefined;
@@ -329,6 +323,11 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 }
 
 export async function runCiIoImpact(): Promise<void> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportActivityTaskQueue(),
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   try {
     await deliverActivityReport(

--- a/packages/temporal/src/workflows/ci-io-impact.ts
+++ b/packages/temporal/src/workflows/ci-io-impact.ts
@@ -7,12 +7,14 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const { collectCiIoImpact } = proxyActivities<CiIoImpactActivities>({
   startToCloseTimeout: "45 minutes",
   retry: { maximumAttempts: 2 },
 });
 const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });

--- a/packages/temporal/src/workflows/data-dragon.test.ts
+++ b/packages/temporal/src/workflows/data-dragon.test.ts
@@ -8,8 +8,9 @@ import type {
   DataDragonVersionState,
 } from "#shared/data-dragon-types.ts";
 import { runScoutDataDragonWeeklyRefresh } from "./index.ts";
+import { runWithReportWorker } from "./test-support.ts";
 
-const TASK_QUEUE = "scout-data-dragon-test";
+const TASK_QUEUE_PREFIX = "scout-data-dragon-test";
 
 const VERSION_STATE: DataDragonVersionState = {
   currentVersion: "16.15.0",
@@ -39,9 +40,15 @@ async function runWithFailingUpdate(updateError: Error): Promise<{
 }> {
   const recorded: RecordFailureInput[] = [];
   const reports: unknown[] = [];
+  const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+  const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
+  const deliverActivityReport = (input: unknown) => {
+    reports.push(input);
+    return { accepted: true, duplicate: false, reportRunId: "report-1" };
+  };
   const worker = await Worker.create({
     connection: testEnvironment.nativeConnection,
-    taskQueue: TASK_QUEUE,
+    taskQueue: taskQueue,
     workflowsPath: new URL("index.ts", import.meta.url).pathname,
     activities: {
       getDataDragonVersionState: (): DataDragonVersionState => VERSION_STATE,
@@ -51,22 +58,24 @@ async function runWithFailingUpdate(updateError: Error): Promise<{
       recordDataDragonFailure: (input: RecordFailureInput): void => {
         recorded.push(input);
       },
-      deliverActivityReport: (input: unknown) => {
-        reports.push(input);
-        return { accepted: true, duplicate: false, reportRunId: "report-1" };
-      },
+      deliverActivityReport,
     },
   });
 
   let failure: unknown;
   try {
-    await worker.runUntil(
-      testEnvironment.client.workflow.execute(runScoutDataDragonWeeklyRefresh, {
-        args: [],
-        taskQueue: TASK_QUEUE,
-        workflowId: `scout-data-dragon-failure-${crypto.randomUUID()}`,
-      }),
-    );
+    await runWithReportWorker(testEnvironment, worker, deliverActivityReport, {
+      reportTaskQueue,
+      runWorkflow: () =>
+        testEnvironment.client.workflow.execute(
+          runScoutDataDragonWeeklyRefresh,
+          {
+            args: [reportTaskQueue],
+            taskQueue: taskQueue,
+            workflowId: `scout-data-dragon-failure-${crypto.randomUUID()}`,
+          },
+        ),
+    });
   } catch (error: unknown) {
     failure = error;
   }
@@ -104,9 +113,14 @@ describe("runScoutDataDragonWeeklyRefresh terminal-failure recording", () => {
 
   test("does not record an updater failure when only report delivery fails", async () => {
     const recorded: RecordFailureInput[] = [];
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
+    const deliverActivityReport = (_input: unknown): never => {
+      throw new Error("report delivery unavailable");
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         getDataDragonVersionState: (): DataDragonVersionState => VERSION_STATE,
@@ -124,23 +138,28 @@ describe("runScoutDataDragonWeeklyRefresh terminal-failure recording", () => {
         recordDataDragonFailure: (input: RecordFailureInput): void => {
           recorded.push(input);
         },
-        deliverActivityReport: (_input: unknown): never => {
-          throw new Error("report delivery unavailable");
-        },
+        deliverActivityReport,
       },
     });
 
     let failure: unknown;
     try {
-      await worker.runUntil(
-        testEnvironment.client.workflow.execute(
-          runScoutDataDragonWeeklyRefresh,
-          {
-            args: [],
-            taskQueue: TASK_QUEUE,
-            workflowId: `scout-data-dragon-delivery-${crypto.randomUUID()}`,
-          },
-        ),
+      await runWithReportWorker(
+        testEnvironment,
+        worker,
+        deliverActivityReport,
+        {
+          reportTaskQueue,
+          runWorkflow: () =>
+            testEnvironment.client.workflow.execute(
+              runScoutDataDragonWeeklyRefresh,
+              {
+                args: [reportTaskQueue],
+                taskQueue: taskQueue,
+                workflowId: `scout-data-dragon-delivery-${crypto.randomUUID()}`,
+              },
+            ),
+        },
       );
     } catch (error: unknown) {
       failure = error;

--- a/packages/temporal/src/workflows/data-dragon.ts
+++ b/packages/temporal/src/workflows/data-dragon.ts
@@ -13,6 +13,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const {
   getDataDragonVersionState,
@@ -37,11 +38,6 @@ const { updateDataDragon } = proxyActivities<DataDragonActivities>({
     backoffCoefficient: 2,
     maximumInterval: "15 minutes",
   },
-});
-
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
 });
 
 function stateEvidence(
@@ -304,7 +300,13 @@ function failureReport(
 
 export async function runScoutDataDragonUpdate(
   mode: DataDragonUpdateMode,
+  reportTaskQueue: string = TASK_QUEUES.REPORTS,
 ): Promise<DataDragonUpdateResult | undefined> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportTaskQueue,
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   let state: DataDragonVersionState | undefined;
   let result: DataDragonUpdateResult | undefined;

--- a/packages/temporal/src/workflows/data-dragon.ts
+++ b/packages/temporal/src/workflows/data-dragon.ts
@@ -13,7 +13,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const {
   getDataDragonVersionState,
@@ -300,10 +300,10 @@ function failureReport(
 
 export async function runScoutDataDragonUpdate(
   mode: DataDragonUpdateMode,
-  reportTaskQueue: string = TASK_QUEUES.REPORTS,
+  reportTaskQueue?: string,
 ): Promise<DataDragonUpdateResult | undefined> {
   const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-    taskQueue: reportTaskQueue,
+    taskQueue: reportActivityTaskQueue(reportTaskQueue),
     startToCloseTimeout: "2 minutes",
     retry: { maximumAttempts: 3 },
   });

--- a/packages/temporal/src/workflows/deps-summary.test.ts
+++ b/packages/temporal/src/workflows/deps-summary.test.ts
@@ -5,8 +5,9 @@ import type { DependencyCollectionResult } from "#activities/deps-summary.ts";
 import type { DependencyChange } from "#shared/deps-summary-types.ts";
 import type { ActivityReportInput } from "#activities/report-delivery.ts";
 import { generateDependencySummary } from "./index.ts";
+import { runWithReportWorker } from "./test-support.ts";
 
-const TASK_QUEUE = "dependency-summary-test";
+const TASK_QUEUE_PREFIX = "dependency-summary-test";
 const COMMIT_SHA = "a".repeat(40);
 const HEAD_SHA = "b".repeat(40);
 
@@ -47,11 +48,23 @@ afterAll(async () => {
 
 describe("dependency summary delivery checkpoint", () => {
   test("reports missing notes as partial before advancing the checkpoint", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     const reports: ActivityReportInput[] = [];
     const events: string[] = [];
+    const deliverActivityReport = (report: ActivityReportInput) => {
+      reports.push(report);
+      events.push(`deliver-${report.execution}`);
+      return {
+        accepted: true,
+        duplicate: false,
+        reportRunId: "dependency-summary:run-1",
+        acceptedAt: "2026-08-10T16:01:00.000Z",
+      };
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
@@ -85,29 +98,22 @@ describe("dependency summary delivery checkpoint", () => {
           ],
         }),
         synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport: (report: ActivityReportInput) => {
-          reports.push(report);
-          events.push(`deliver-${report.execution}`);
-          return {
-            accepted: true,
-            duplicate: false,
-            reportRunId: "dependency-summary:run-1",
-            acceptedAt: "2026-08-10T16:01:00.000Z",
-          };
-        },
+        deliverActivityReport,
         advanceDependencySummaryCheckpoint: (): void => {
           events.push("checkpoint");
         },
       },
     });
 
-    await worker.runUntil(
-      testEnvironment.client.workflow.execute(generateDependencySummary, {
-        args: [7],
-        taskQueue: TASK_QUEUE,
-        workflowId: `dependency-summary-partial-${crypto.randomUUID()}`,
-      }),
-    );
+    await runWithReportWorker(testEnvironment, worker, deliverActivityReport, {
+      reportTaskQueue,
+      runWorkflow: () =>
+        testEnvironment.client.workflow.execute(generateDependencySummary, {
+          args: [7, reportTaskQueue],
+          taskQueue: taskQueue,
+          workflowId: `dependency-summary-partial-${crypto.randomUUID()}`,
+        }),
+    });
 
     expect(events).toEqual(["deliver-partial", "checkpoint"]);
     expect(reports).toHaveLength(1);
@@ -119,10 +125,16 @@ describe("dependency summary delivery checkpoint", () => {
   }, 30_000);
 
   test("does not advance the checkpoint when delivery is not accepted", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     const events: string[] = [];
+    const deliverActivityReport = (): never => {
+      events.push("deliver-failed");
+      throw new Error("Postal unavailable");
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
@@ -139,10 +151,7 @@ describe("dependency summary delivery checkpoint", () => {
           missing: [],
         }),
         synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport: (): never => {
-          events.push("deliver-failed");
-          throw new Error("Postal unavailable");
-        },
+        deliverActivityReport,
         advanceDependencySummaryCheckpoint: (): void => {
           events.push("checkpoint");
         },
@@ -151,12 +160,19 @@ describe("dependency summary delivery checkpoint", () => {
 
     let failure: unknown;
     try {
-      await worker.runUntil(
-        testEnvironment.client.workflow.execute(generateDependencySummary, {
-          args: [7],
-          taskQueue: TASK_QUEUE,
-          workflowId: `dependency-summary-delivery-failure-${crypto.randomUUID()}`,
-        }),
+      await runWithReportWorker(
+        testEnvironment,
+        worker,
+        deliverActivityReport,
+        {
+          reportTaskQueue,
+          runWorkflow: () =>
+            testEnvironment.client.workflow.execute(generateDependencySummary, {
+              args: [7, reportTaskQueue],
+              taskQueue: taskQueue,
+              workflowId: `dependency-summary-delivery-failure-${crypto.randomUUID()}`,
+            }),
+        },
       );
     } catch (error: unknown) {
       failure = error;
@@ -168,11 +184,22 @@ describe("dependency summary delivery checkpoint", () => {
   }, 30_000);
 
   test("retries checkpoint persistence without redelivering the report", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     let deliveryCalls = 0;
     let checkpointCalls = 0;
+    const deliverActivityReport = () => {
+      deliveryCalls += 1;
+      return {
+        accepted: true,
+        duplicate: false,
+        reportRunId: "dependency-summary:run-retry",
+        acceptedAt: "2026-08-10T16:01:00.000Z",
+      };
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
@@ -189,15 +216,7 @@ describe("dependency summary delivery checkpoint", () => {
           missing: [],
         }),
         synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport: () => {
-          deliveryCalls += 1;
-          return {
-            accepted: true,
-            duplicate: false,
-            reportRunId: "dependency-summary:run-retry",
-            acceptedAt: "2026-08-10T16:01:00.000Z",
-          };
-        },
+        deliverActivityReport,
         advanceDependencySummaryCheckpoint: (): void => {
           checkpointCalls += 1;
           if (checkpointCalls < 3) {
@@ -207,13 +226,15 @@ describe("dependency summary delivery checkpoint", () => {
       },
     });
 
-    await worker.runUntil(
-      testEnvironment.client.workflow.execute(generateDependencySummary, {
-        args: [7],
-        taskQueue: TASK_QUEUE,
-        workflowId: `dependency-summary-checkpoint-retry-${crypto.randomUUID()}`,
-      }),
-    );
+    await runWithReportWorker(testEnvironment, worker, deliverActivityReport, {
+      reportTaskQueue,
+      runWorkflow: () =>
+        testEnvironment.client.workflow.execute(generateDependencySummary, {
+          args: [7, reportTaskQueue],
+          taskQueue: taskQueue,
+          workflowId: `dependency-summary-checkpoint-retry-${crypto.randomUUID()}`,
+        }),
+    });
 
     expect(deliveryCalls).toBe(1);
     expect(checkpointCalls).toBe(3);
@@ -222,11 +243,25 @@ describe("dependency summary delivery checkpoint", () => {
 
 describe("dependency summary checkpoint failure reporting", () => {
   test("reports a distinct failure after accepted delivery when checkpoint retries exhaust", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     const reports: ActivityReportInput[] = [];
     let checkpointCalls = 0;
+    const deliverActivityReport = (report: ActivityReportInput) => {
+      reports.push(report);
+      return {
+        accepted: true,
+        duplicate: false,
+        reportRunId:
+          report.execution === "failed"
+            ? "dependency-summary:run-exhausted:failed"
+            : "dependency-summary:run-exhausted",
+        acceptedAt: "2026-08-10T16:01:00.000Z",
+      };
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
@@ -243,18 +278,7 @@ describe("dependency summary checkpoint failure reporting", () => {
           missing: [],
         }),
         synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport: (report: ActivityReportInput) => {
-          reports.push(report);
-          return {
-            accepted: true,
-            duplicate: false,
-            reportRunId:
-              report.execution === "failed"
-                ? "dependency-summary:run-exhausted:failed"
-                : "dependency-summary:run-exhausted",
-            acceptedAt: "2026-08-10T16:01:00.000Z",
-          };
-        },
+        deliverActivityReport,
         advanceDependencySummaryCheckpoint: (): never => {
           checkpointCalls += 1;
           throw new Error("persistent checkpoint storage failure");
@@ -264,12 +288,19 @@ describe("dependency summary checkpoint failure reporting", () => {
 
     let failure: unknown;
     try {
-      await worker.runUntil(
-        testEnvironment.client.workflow.execute(generateDependencySummary, {
-          args: [7],
-          taskQueue: TASK_QUEUE,
-          workflowId: `dependency-summary-checkpoint-exhausted-${crypto.randomUUID()}`,
-        }),
+      await runWithReportWorker(
+        testEnvironment,
+        worker,
+        deliverActivityReport,
+        {
+          reportTaskQueue,
+          runWorkflow: () =>
+            testEnvironment.client.workflow.execute(generateDependencySummary, {
+              args: [7, reportTaskQueue],
+              taskQueue: taskQueue,
+              workflowId: `dependency-summary-checkpoint-exhausted-${crypto.randomUUID()}`,
+            }),
+        },
       );
     } catch (error: unknown) {
       failure = error;

--- a/packages/temporal/src/workflows/deps-summary.ts
+++ b/packages/temporal/src/workflows/deps-summary.ts
@@ -7,6 +7,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const RETRY = {
   maximumAttempts: 3,
@@ -30,11 +31,6 @@ const { advanceDependencySummaryCheckpoint } =
     startToCloseTimeout: "1 minute",
     retry: RETRY,
   });
-
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  startToCloseTimeout: "2 minutes",
-  retry: RETRY,
-});
 
 // Legacy proxies exist solely to reproduce the pre-rewrite command sequence for
 // an execution still open across the rollout. Their timeouts must stay exactly
@@ -130,7 +126,15 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
   };
 }
 
-export async function generateDependencySummary(daysBack = 7): Promise<void> {
+export async function generateDependencySummary(
+  daysBack = 7,
+  reportTaskQueue: string = TASK_QUEUES.REPORTS,
+): Promise<void> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportTaskQueue,
+    startToCloseTimeout: "2 minutes",
+    retry: RETRY,
+  });
   if (!patched("deps-summary-evidence-v1")) {
     return runLegacyDependencySummary(daysBack);
   }

--- a/packages/temporal/src/workflows/deps-summary.ts
+++ b/packages/temporal/src/workflows/deps-summary.ts
@@ -7,7 +7,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const RETRY = {
   maximumAttempts: 3,
@@ -128,10 +128,10 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 
 export async function generateDependencySummary(
   daysBack = 7,
-  reportTaskQueue: string = TASK_QUEUES.REPORTS,
+  reportTaskQueue?: string,
 ): Promise<void> {
   const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-    taskQueue: reportTaskQueue,
+    taskQueue: reportActivityTaskQueue(reportTaskQueue),
     startToCloseTimeout: "2 minutes",
     retry: RETRY,
   });

--- a/packages/temporal/src/workflows/homelab-audit.test.ts
+++ b/packages/temporal/src/workflows/homelab-audit.test.ts
@@ -4,8 +4,9 @@ import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { HomelabAuditCollection } from "#activities/homelab-audit-collectors.ts";
 import { runHomelabAuditWorkflow } from "./homelab-audit.ts";
+import { runWithReportWorker } from "./test-support.ts";
 
-const TASK_QUEUE = "homelab-audit-test";
+const TASK_QUEUE_PREFIX = "homelab-audit-test";
 const OBSERVED_AT = "2026-05-09T13:30:00.000Z";
 
 let testEnv: TestWorkflowEnvironment;
@@ -52,28 +53,33 @@ function collection(): HomelabAuditCollection {
 
 describe("runHomelabAuditWorkflow", () => {
   it("delivers one clean report after all six collectors pass", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     const reports: unknown[] = [];
+    const deliverActivityReport = (input: unknown) => {
+      reports.push(input);
+      return { accepted: true, duplicate: false, reportRunId: "report-1" };
+    };
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         collectHomelabAuditEvidence: async () => collection(),
         synthesizeHomelabAuditEvidence: async () => "All checks completed.",
-        deliverActivityReport: (input: unknown) => {
-          reports.push(input);
-          return { accepted: true, duplicate: false, reportRunId: "report-1" };
-        },
+        deliverActivityReport,
       },
     });
 
-    await worker.runUntil(
-      testEnv.client.workflow.execute(runHomelabAuditWorkflow, {
-        args: [{ date: "2026-05-09" }],
-        taskQueue: TASK_QUEUE,
-        workflowId: `test-homelab-clean-${crypto.randomUUID()}`,
-      }),
-    );
+    await runWithReportWorker(testEnv, worker, deliverActivityReport, {
+      reportTaskQueue,
+      runWorkflow: () =>
+        testEnv.client.workflow.execute(runHomelabAuditWorkflow, {
+          args: [{ date: "2026-05-09" }, reportTaskQueue],
+          taskQueue: taskQueue,
+          workflowId: `test-homelab-clean-${crypto.randomUUID()}`,
+        }),
+    });
 
     expect(reports).toHaveLength(1);
     expect(reports[0]).toMatchObject({
@@ -85,31 +91,36 @@ describe("runHomelabAuditWorkflow", () => {
   }, 30_000);
 
   it("delivers a failed report before rethrowing collector failure", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     const reports: unknown[] = [];
+    const deliverActivityReport = (input: unknown) => {
+      reports.push(input);
+      return { accepted: true, duplicate: false, reportRunId: "report-2" };
+    };
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         collectHomelabAuditEvidence: () => {
           throw new Error("collector unavailable");
         },
-        deliverActivityReport: (input: unknown) => {
-          reports.push(input);
-          return { accepted: true, duplicate: false, reportRunId: "report-2" };
-        },
+        deliverActivityReport,
       },
     });
 
     let failure: unknown;
     try {
-      await worker.runUntil(
-        testEnv.client.workflow.execute(runHomelabAuditWorkflow, {
-          args: [],
-          taskQueue: TASK_QUEUE,
-          workflowId: `test-homelab-failed-${crypto.randomUUID()}`,
-        }),
-      );
+      await runWithReportWorker(testEnv, worker, deliverActivityReport, {
+        reportTaskQueue,
+        runWorkflow: () =>
+          testEnv.client.workflow.execute(runHomelabAuditWorkflow, {
+            args: [{}, reportTaskQueue],
+            taskQueue: taskQueue,
+            workflowId: `test-homelab-failed-${crypto.randomUUID()}`,
+          }),
+      });
     } catch (error: unknown) {
       failure = error;
     }

--- a/packages/temporal/src/workflows/homelab-audit.test.ts
+++ b/packages/temporal/src/workflows/homelab-audit.test.ts
@@ -4,7 +4,7 @@ import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker } from "@temporalio/worker";
 import type { HomelabAuditCollection } from "#activities/homelab-audit-collectors.ts";
 import { runHomelabAuditWorkflow } from "./homelab-audit.ts";
-import { runWithReportWorker } from "./test-support.ts";
+import { createReportCapture, runWithReportWorker } from "./test-support.ts";
 
 const TASK_QUEUE_PREFIX = "homelab-audit-test";
 const OBSERVED_AT = "2026-05-09T13:30:00.000Z";
@@ -55,11 +55,7 @@ describe("runHomelabAuditWorkflow", () => {
   it("delivers one clean report after all six collectors pass", async () => {
     const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
     const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
-    const reports: unknown[] = [];
-    const deliverActivityReport = (input: unknown) => {
-      reports.push(input);
-      return { accepted: true, duplicate: false, reportRunId: "report-1" };
-    };
+    const { reports, deliverActivityReport } = createReportCapture("report-1");
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
       taskQueue: taskQueue,
@@ -93,11 +89,7 @@ describe("runHomelabAuditWorkflow", () => {
   it("delivers a failed report before rethrowing collector failure", async () => {
     const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
     const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
-    const reports: unknown[] = [];
-    const deliverActivityReport = (input: unknown) => {
-      reports.push(input);
-      return { accepted: true, duplicate: false, reportRunId: "report-2" };
-    };
+    const { reports, deliverActivityReport } = createReportCapture("report-2");
     const worker = await Worker.create({
       connection: testEnv.nativeConnection,
       taskQueue: taskQueue,

--- a/packages/temporal/src/workflows/homelab-audit.ts
+++ b/packages/temporal/src/workflows/homelab-audit.ts
@@ -9,7 +9,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const RETRY = {
   maximumAttempts: 3,
@@ -108,10 +108,10 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 
 export async function runHomelabAuditWorkflow(
   input: RunHomelabAuditWorkflowInput = {},
-  reportTaskQueue: string = TASK_QUEUES.REPORTS,
+  reportTaskQueue?: string,
 ): Promise<void> {
   const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-    taskQueue: reportTaskQueue,
+    taskQueue: reportActivityTaskQueue(reportTaskQueue),
     startToCloseTimeout: "2 minutes",
     retry: RETRY,
   });

--- a/packages/temporal/src/workflows/homelab-audit.ts
+++ b/packages/temporal/src/workflows/homelab-audit.ts
@@ -9,6 +9,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const RETRY = {
   maximumAttempts: 3,
@@ -44,11 +45,6 @@ const { collectHomelabAuditEvidence } =
     startToCloseTimeout: "8 minutes",
     retry: RETRY,
   });
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  startToCloseTimeout: "2 minutes",
-  retry: RETRY,
-});
-
 export type RunHomelabAuditWorkflowInput = {
   date?: string;
 };
@@ -112,7 +108,13 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 
 export async function runHomelabAuditWorkflow(
   input: RunHomelabAuditWorkflowInput = {},
+  reportTaskQueue: string = TASK_QUEUES.REPORTS,
 ): Promise<void> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportTaskQueue,
+    startToCloseTimeout: "2 minutes",
+    retry: RETRY,
+  });
   if (!patched("homelab-audit-deterministic-v1")) {
     return runLegacyHomelabAudit(input);
   }

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -144,8 +144,11 @@ export async function runFreshRssSyncWorkflow(): Promise<void> {
   return _runFreshRssSyncWorkflow();
 }
 
-export async function generateDependencySummary(daysBack = 7): Promise<void> {
-  return _generateDependencySummary(daysBack);
+export async function generateDependencySummary(
+  daysBack = 7,
+  reportTaskQueue?: string,
+): Promise<void> {
+  return _generateDependencySummary(daysBack, reportTaskQueue);
 }
 
 export async function runDnsAudit(): Promise<void> {
@@ -218,22 +221,23 @@ export async function runVeleroOrphanAuditWorkflow(): Promise<void> {
   return _runVeleroOrphanAuditWorkflow();
 }
 
-export async function runScoutDataDragonVersionCheck(): Promise<
-  DataDragonUpdateResult | undefined
-> {
-  return _runScoutDataDragonUpdate("version-check");
+export async function runScoutDataDragonVersionCheck(
+  reportTaskQueue?: string,
+): Promise<DataDragonUpdateResult | undefined> {
+  return _runScoutDataDragonUpdate("version-check", reportTaskQueue);
 }
 
-export async function runScoutDataDragonWeeklyRefresh(): Promise<
-  DataDragonUpdateResult | undefined
-> {
-  return _runScoutDataDragonUpdate("weekly-refresh");
+export async function runScoutDataDragonWeeklyRefresh(
+  reportTaskQueue?: string,
+): Promise<DataDragonUpdateResult | undefined> {
+  return _runScoutDataDragonUpdate("weekly-refresh", reportTaskQueue);
 }
 
 export async function runScoutLanePriorsWeeklyRefresh(
   input: LanePriorWorkflowInput,
+  reportTaskQueue?: string,
 ): Promise<LanePriorRefreshResult> {
-  return _runScoutLanePriorsWeeklyRefresh(input);
+  return _runScoutLanePriorsWeeklyRefresh(input, reportTaskQueue);
 }
 
 export async function runLlmCatalogRefresh(): Promise<LlmCatalogRefreshResult> {
@@ -287,8 +291,9 @@ export async function runScoutSeasonRefreshWorkflow(
 
 export async function runHomelabAuditWorkflow(
   input: RunHomelabAuditWorkflowInput = {},
+  reportTaskQueue?: string,
 ): Promise<void> {
-  return _runHomelabAuditWorkflow(input);
+  return _runHomelabAuditWorkflow(input, reportTaskQueue);
 }
 
 export async function runProtobufWatch(): Promise<void> {

--- a/packages/temporal/src/workflows/lane-prior-refresh.test.ts
+++ b/packages/temporal/src/workflows/lane-prior-refresh.test.ts
@@ -6,7 +6,7 @@ import type {
   LanePriorWorkflowInput,
 } from "#activities/lane-prior-refresh.ts";
 import { runScoutLanePriorsWeeklyRefresh } from "./index.ts";
-import { runWithReportWorker } from "./test-support.ts";
+import { createReportCapture, runWithReportWorker } from "./test-support.ts";
 
 const TASK_QUEUE_PREFIX = "scout-lane-prior-test";
 const INPUT: LanePriorWorkflowInput = {
@@ -48,11 +48,7 @@ describe("runScoutLanePriorsWeeklyRefresh", () => {
   test("publishes an independent lane-prior result and report", async () => {
     const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
     const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
-    const reports: unknown[] = [];
-    const deliverActivityReport = (input: unknown) => {
-      reports.push(input);
-      return { accepted: true, duplicate: false, reportRunId: "report-1" };
-    };
+    const { reports, deliverActivityReport } = createReportCapture("report-1");
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
       taskQueue: taskQueue,

--- a/packages/temporal/src/workflows/lane-prior-refresh.test.ts
+++ b/packages/temporal/src/workflows/lane-prior-refresh.test.ts
@@ -6,8 +6,9 @@ import type {
   LanePriorWorkflowInput,
 } from "#activities/lane-prior-refresh.ts";
 import { runScoutLanePriorsWeeklyRefresh } from "./index.ts";
+import { runWithReportWorker } from "./test-support.ts";
 
-const TASK_QUEUE = "scout-lane-prior-test";
+const TASK_QUEUE_PREFIX = "scout-lane-prior-test";
 const INPUT: LanePriorWorkflowInput = {
   lanePriors: {
     bucket: "scout-test",
@@ -45,26 +46,39 @@ afterAll(async () => {
 
 describe("runScoutLanePriorsWeeklyRefresh", () => {
   test("publishes an independent lane-prior result and report", async () => {
+    const taskQueue = `${TASK_QUEUE_PREFIX}-${crypto.randomUUID()}`;
+    const reportTaskQueue = `${TASK_QUEUE_PREFIX}-reports-${crypto.randomUUID()}`;
     const reports: unknown[] = [];
+    const deliverActivityReport = (input: unknown) => {
+      reports.push(input);
+      return { accepted: true, duplicate: false, reportRunId: "report-1" };
+    };
     const worker = await Worker.create({
       connection: testEnvironment.nativeConnection,
-      taskQueue: TASK_QUEUE,
+      taskQueue: taskQueue,
       workflowsPath: new URL("index.ts", import.meta.url).pathname,
       activities: {
         updateLanePriors: (_input: LanePriorWorkflowInput) => RESULT,
-        deliverActivityReport: (input: unknown) => {
-          reports.push(input);
-          return { accepted: true, duplicate: false, reportRunId: "report-1" };
-        },
+        deliverActivityReport,
       },
     });
 
-    const result = await worker.runUntil(
-      testEnvironment.client.workflow.execute(runScoutLanePriorsWeeklyRefresh, {
-        args: [INPUT],
-        taskQueue: TASK_QUEUE,
-        workflowId: `scout-lane-prior-${crypto.randomUUID()}`,
-      }),
+    const result = await runWithReportWorker(
+      testEnvironment,
+      worker,
+      deliverActivityReport,
+      {
+        reportTaskQueue,
+        runWorkflow: () =>
+          testEnvironment.client.workflow.execute(
+            runScoutLanePriorsWeeklyRefresh,
+            {
+              args: [INPUT, reportTaskQueue],
+              taskQueue: taskQueue,
+              workflowId: `scout-lane-prior-${crypto.randomUUID()}`,
+            },
+          ),
+      },
     );
 
     expect(result).toEqual(RESULT);

--- a/packages/temporal/src/workflows/lane-prior-refresh.ts
+++ b/packages/temporal/src/workflows/lane-prior-refresh.ts
@@ -8,6 +8,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const { updateLanePriors } = proxyActivities<LanePriorActivities>({
   startToCloseTimeout: "90 minutes",
@@ -18,11 +19,6 @@ const { updateLanePriors } = proxyActivities<LanePriorActivities>({
     backoffCoefficient: 2,
     maximumInterval: "15 minutes",
   },
-});
-
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
 });
 
 function evaluation(result: LanePriorRefreshResult): {
@@ -203,7 +199,13 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 
 export async function runScoutLanePriorsWeeklyRefresh(
   input: LanePriorWorkflowInput,
+  reportTaskQueue: string = TASK_QUEUES.REPORTS,
 ): Promise<LanePriorRefreshResult> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportTaskQueue,
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   try {
     const result = await updateLanePriors(input);

--- a/packages/temporal/src/workflows/lane-prior-refresh.ts
+++ b/packages/temporal/src/workflows/lane-prior-refresh.ts
@@ -8,7 +8,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const { updateLanePriors } = proxyActivities<LanePriorActivities>({
   startToCloseTimeout: "90 minutes",
@@ -199,10 +199,10 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 
 export async function runScoutLanePriorsWeeklyRefresh(
   input: LanePriorWorkflowInput,
-  reportTaskQueue: string = TASK_QUEUES.REPORTS,
+  reportTaskQueue?: string,
 ): Promise<LanePriorRefreshResult> {
   const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-    taskQueue: reportTaskQueue,
+    taskQueue: reportActivityTaskQueue(reportTaskQueue),
     startToCloseTimeout: "2 minutes",
     retry: { maximumAttempts: 3 },
   });

--- a/packages/temporal/src/workflows/protobuf-watch.ts
+++ b/packages/temporal/src/workflows/protobuf-watch.ts
@@ -4,18 +4,12 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const { collectProtobufWatch } = proxyActivities<ProtobufWatchActivities>({
   startToCloseTimeout: "1 minute",
   retry: { maximumAttempts: 3 },
 });
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  taskQueue: TASK_QUEUES.REPORTS,
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
-});
-
 function failureReport(startedAt: string, error: unknown): ActivityReportInput {
   const message = error instanceof Error ? error.message : String(error);
   const observedAt = new Date().toISOString();
@@ -54,6 +48,11 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 }
 
 export async function runProtobufWatch(): Promise<void> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportActivityTaskQueue(),
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   try {
     const result = await collectProtobufWatch();

--- a/packages/temporal/src/workflows/protobuf-watch.ts
+++ b/packages/temporal/src/workflows/protobuf-watch.ts
@@ -4,12 +4,14 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const { collectProtobufWatch } = proxyActivities<ProtobufWatchActivities>({
   startToCloseTimeout: "1 minute",
   retry: { maximumAttempts: 3 },
 });
 const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });

--- a/packages/temporal/src/workflows/report-activity-queue.ts
+++ b/packages/temporal/src/workflows/report-activity-queue.ts
@@ -1,0 +1,17 @@
+import { patched } from "@temporalio/workflow";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+const REPORT_ACTIVITY_QUEUE_PATCH = "report-activity-reports-queue-v1";
+
+/**
+ * Preserve the default queue for histories created before domain routing.
+ * New executions move report delivery to the credential-scoped reports worker.
+ */
+export function reportActivityTaskQueue(explicitQueue?: string): string {
+  if (explicitQueue !== undefined) {
+    return explicitQueue;
+  }
+  return patched(REPORT_ACTIVITY_QUEUE_PATCH)
+    ? TASK_QUEUES.REPORTS
+    : TASK_QUEUES.DEFAULT;
+}

--- a/packages/temporal/src/workflows/report-delivery.ts
+++ b/packages/temporal/src/workflows/report-delivery.ts
@@ -1,4 +1,4 @@
-import { proxyActivities } from "@temporalio/workflow";
+import { patched, proxyActivities } from "@temporalio/workflow";
 import type {
   ReportDeliveryActivities,
   ReportDeliveryResult,
@@ -9,6 +9,14 @@ import {
   REPORT_DELIVERY_ACTIVITY_START_TO_CLOSE_MS,
 } from "#shared/report-delivery-policy.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+const legacyReportDeliveryActivities = proxyActivities<
+  Pick<ReportDeliveryActivities, "deliverReport">
+>({
+  taskQueue: TASK_QUEUES.DEFAULT,
+  startToCloseTimeout: REPORT_DELIVERY_ACTIVITY_START_TO_CLOSE_MS,
+  retry: REPORT_DELIVERY_ACTIVITY_RETRY,
+});
 
 const reportDeliveryActivities = proxyActivities<
   Pick<ReportDeliveryActivities, "deliverReport">
@@ -28,5 +36,8 @@ const reportDeliveryActivities = proxyActivities<
 export async function deliverReportWorkflow(
   report: ReportEnvelopeV1,
 ): Promise<ReportDeliveryResult> {
-  return reportDeliveryActivities.deliverReport(report);
+  const useReportsQueue = patched("report-delivery-reports-queue-v1");
+  return (
+    useReportsQueue ? reportDeliveryActivities : legacyReportDeliveryActivities
+  ).deliverReport(report);
 }

--- a/packages/temporal/src/workflows/report-delivery.ts
+++ b/packages/temporal/src/workflows/report-delivery.ts
@@ -13,17 +13,17 @@ import { TASK_QUEUES } from "#shared/task-queues.ts";
 const reportDeliveryActivities = proxyActivities<
   Pick<ReportDeliveryActivities, "deliverReport">
 >({
-  taskQueue: TASK_QUEUES.DEFAULT,
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: REPORT_DELIVERY_ACTIVITY_START_TO_CLOSE_MS,
   retry: REPORT_DELIVERY_ACTIVITY_RETRY,
 });
 
 /**
- * Fixed credential boundary for reports assembled outside the core queue.
+ * Fixed credential boundary for reports assembled on any workflow queue.
  *
  * Replayed agent-task histories must schedule their original email activity on
  * the agent queue for Temporal determinism. That activity delegates here so
- * Postal and report-state S3 credentials remain confined to the core worker.
+ * Postal and report-state S3 credentials remain confined to the reports worker.
  */
 export async function deliverReportWorkflow(
   report: ReportEnvelopeV1,

--- a/packages/temporal/src/workflows/scout-queue-windows.ts
+++ b/packages/temporal/src/workflows/scout-queue-windows.ts
@@ -8,7 +8,7 @@ import type {
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
 import { SCOUT_QUEUE_WINDOWS_LOOKBACK_DAYS } from "#shared/scout-queue-windows-lookback.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const { refreshScoutQueueWindows } =
   proxyActivities<ScoutQueueWindowsActivities>({
@@ -26,12 +26,6 @@ const { refreshScoutQueueWindows } =
       maximumInterval: "10 minutes",
     },
   });
-
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  taskQueue: TASK_QUEUES.REPORTS,
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
-});
 
 type QueueReportState = {
   hasWarnings: boolean;
@@ -256,6 +250,11 @@ export function scoutQueueWindowsReport(
 }
 
 export async function runScoutQueueWindowsWatch(): Promise<ScoutQueueWindowsResult> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportActivityTaskQueue(),
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   try {
     const result = await refreshScoutQueueWindows();

--- a/packages/temporal/src/workflows/scout-queue-windows.ts
+++ b/packages/temporal/src/workflows/scout-queue-windows.ts
@@ -8,6 +8,7 @@ import type {
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
 import { SCOUT_QUEUE_WINDOWS_LOOKBACK_DAYS } from "#shared/scout-queue-windows-lookback.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const { refreshScoutQueueWindows } =
   proxyActivities<ScoutQueueWindowsActivities>({
@@ -27,6 +28,7 @@ const { refreshScoutQueueWindows } =
   });
 
 const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });

--- a/packages/temporal/src/workflows/scout-season-refresh.ts
+++ b/packages/temporal/src/workflows/scout-season-refresh.ts
@@ -8,6 +8,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const { runScoutSeasonRefresh } = proxyActivities<ScoutSeasonRefreshActivities>(
   {
@@ -22,6 +23,7 @@ const { runScoutSeasonRefresh } = proxyActivities<ScoutSeasonRefreshActivities>(
   },
 );
 const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });

--- a/packages/temporal/src/workflows/scout-season-refresh.ts
+++ b/packages/temporal/src/workflows/scout-season-refresh.ts
@@ -8,7 +8,7 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const { runScoutSeasonRefresh } = proxyActivities<ScoutSeasonRefreshActivities>(
   {
@@ -22,12 +22,6 @@ const { runScoutSeasonRefresh } = proxyActivities<ScoutSeasonRefreshActivities>(
     },
   },
 );
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  taskQueue: TASK_QUEUES.REPORTS,
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
-});
-
 type SeasonReportState = {
   proposalComplete: boolean;
   complete: boolean;
@@ -261,6 +255,11 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 export async function runScoutSeasonRefreshWorkflow(
   input: ScoutSeasonRefreshInput = {},
 ): Promise<ScoutSeasonRefreshResult> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportActivityTaskQueue(),
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   try {
     const result = await runScoutSeasonRefresh(input);

--- a/packages/temporal/src/workflows/tasknotes-canary.ts
+++ b/packages/temporal/src/workflows/tasknotes-canary.ts
@@ -7,18 +7,12 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
-import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { reportActivityTaskQueue } from "./report-activity-queue.ts";
 
 const activities = proxyActivities<TasknotesCanaryActivities>({
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
-  taskQueue: TASK_QUEUES.REPORTS,
-  startToCloseTimeout: "2 minutes",
-  retry: { maximumAttempts: 3 },
-});
-
 function taskCountDrop(result: TasknotesCanaryResult): number | undefined {
   if (result.baseline === undefined || result.baseline.tasks === 0) {
     return undefined;
@@ -193,6 +187,11 @@ function failureReport(startedAt: string, error: unknown): ActivityReportInput {
 }
 
 export async function runTasknotesCanary(): Promise<void> {
+  const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+    taskQueue: reportActivityTaskQueue(),
+    startToCloseTimeout: "2 minutes",
+    retry: { maximumAttempts: 3 },
+  });
   const startedAt = new Date().toISOString();
   try {
     const result = await activities.collectTasknotesCanary();

--- a/packages/temporal/src/workflows/tasknotes-canary.ts
+++ b/packages/temporal/src/workflows/tasknotes-canary.ts
@@ -7,12 +7,14 @@ import type {
   ActivityReportInput,
   ReportDeliveryActivities,
 } from "#activities/report-delivery.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 const activities = proxyActivities<TasknotesCanaryActivities>({
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });
 const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: { maximumAttempts: 3 },
 });

--- a/packages/temporal/src/workflows/test-support.ts
+++ b/packages/temporal/src/workflows/test-support.ts
@@ -1,6 +1,22 @@
 import { Worker } from "@temporalio/worker";
 import type { TestWorkflowEnvironment } from "@temporalio/testing";
 
+export function createReportCapture(reportRunId: string): {
+  reports: unknown[];
+  deliverActivityReport: (input: unknown) => {
+    accepted: true;
+    duplicate: false;
+    reportRunId: string;
+  };
+} {
+  const reports: unknown[] = [];
+  const deliverActivityReport = (input: unknown) => {
+    reports.push(input);
+    return { accepted: true, duplicate: false, reportRunId };
+  };
+  return { reports, deliverActivityReport };
+}
+
 export async function runWithReportWorker(
   testEnvironment: TestWorkflowEnvironment,
   primaryWorker: Worker,

--- a/packages/temporal/src/workflows/test-support.ts
+++ b/packages/temporal/src/workflows/test-support.ts
@@ -1,0 +1,32 @@
+import { Worker } from "@temporalio/worker";
+import type { TestWorkflowEnvironment } from "@temporalio/testing";
+
+export async function runWithReportWorker(
+  testEnvironment: TestWorkflowEnvironment,
+  primaryWorker: Worker,
+  deliverActivityReport: (input: never) => unknown,
+  options: {
+    reportTaskQueue: string;
+    runWorkflow: () => Promise<unknown>;
+  },
+): Promise<unknown> {
+  const reportWorker = await Worker.create({
+    connection: testEnvironment.nativeConnection,
+    taskQueue: options.reportTaskQueue,
+    activities: { deliverActivityReport },
+  });
+  const reportRun = reportWorker.run();
+  try {
+    const workflowResult = options.runWorkflow();
+    try {
+      return await primaryWorker.runUntil(workflowResult);
+    } catch {
+      // The SDK can report a worker-thread shutdown race after the workflow
+      // result has already settled when two workers share a test server.
+      return await workflowResult;
+    }
+  } finally {
+    reportWorker.shutdown();
+    await reportRun;
+  }
+}

--- a/packages/temporal/src/workflows/test-support.ts
+++ b/packages/temporal/src/workflows/test-support.ts
@@ -4,8 +4,8 @@ import type { TestWorkflowEnvironment } from "@temporalio/testing";
 export function createReportCapture(reportRunId: string): {
   reports: unknown[];
   deliverActivityReport: (input: unknown) => {
-    accepted: true;
-    duplicate: false;
+    accepted: boolean;
+    duplicate: boolean;
     reportRunId: string;
   };
 } {

--- a/packages/temporal/src/workflows/test-support.ts
+++ b/packages/temporal/src/workflows/test-support.ts
@@ -18,12 +18,29 @@ export async function runWithReportWorker(
   const reportRun = reportWorker.run();
   try {
     const workflowResult = options.runWorkflow();
+    const workflowState: {
+      outcome: "pending" | "fulfilled" | "rejected";
+    } = { outcome: "pending" };
+    const observedWorkflowResult = (async () => {
+      try {
+        const value = await workflowResult;
+        workflowState.outcome = "fulfilled";
+        return value;
+      } catch (error: unknown) {
+        workflowState.outcome = "rejected";
+        throw error;
+      }
+    })();
     try {
-      return await primaryWorker.runUntil(workflowResult);
-    } catch {
+      return await primaryWorker.runUntil(observedWorkflowResult);
+    } catch (error: unknown) {
       // The SDK can report a worker-thread shutdown race after the workflow
-      // result has already settled when two workers share a test server.
-      return await workflowResult;
+      // result has already settled when two workers share a test server. A
+      // worker failure before successful workflow completion must propagate.
+      if (workflowState.outcome === "fulfilled") {
+        return await observedWorkflowResult;
+      }
+      throw error;
     }
   } finally {
     reportWorker.shutdown();


### PR DESCRIPTION
## Why

Schedule reconciliation, public ingress, Home Assistant, and report delivery should not share credentials or a failure domain.

## What

- route Home Assistant schedules, sleep requests, and presence events to `home`
- route report delivery, freshness, agent email side activities, and failure watch to `reports`
- add tokenless gateway, home, and reports Deployments with dedicated identities and exact resources
- move schedule reconciliation and public HTTP services to the gateway and the HA event bridge to home
- retain the old worker temporarily as a legacy `default`-queue drain worker

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`

This is a non-visual runtime and infrastructure change; no media is required. No live deployment or representative external-effect check was run.