### PR TITLE
feat(temporal): add infra repo and Scout workers

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -686,7 +686,7 @@
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts": {
       "clones": 1,
-      "tokens": 129
+      "tokens": 124
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/trmnl-dashboard.ts": {
       "clones": 1,
@@ -718,15 +718,19 @@
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/openrouter-broadcast-ingest.ts|packages/homelab/src/cdk8s/src/resources/temporal/agent-worker-network-policy.ts": {
       "clones": 1,
-      "tokens": 118
+      "tokens": 117
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts": {
-      "clones": 2,
-      "tokens": 235
+      "clones": 3,
+      "tokens": 339
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts": {
-      "clones": 3,
-      "tokens": 301
+      "clones": 2,
+      "tokens": 180
+    },
+    "packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts|packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts": {
+      "clones": 1,
+      "tokens": 93
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/scout-evals.ts": {
       "clones": 1,
@@ -739,6 +743,10 @@
     "packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/tasknotes.ts": {
       "clones": 1,
       "tokens": 75
+    },
+    "packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts": {
+      "clones": 1,
+      "tokens": 106
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts|packages/homelab/src/cdk8s/src/resources/relay/index.ts": {
       "clones": 1,
@@ -815,6 +823,18 @@
     "packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts|packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts": {
       "clones": 1,
       "tokens": 79
+    },
+    "packages/homelab/src/cdk8s/src/resources/temporal/agent-worker-network-policy.ts|packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts": {
+      "clones": 1,
+      "tokens": 213
+    },
+    "packages/homelab/src/cdk8s/src/resources/temporal/ingress-workers.ts|packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts": {
+      "clones": 1,
+      "tokens": 100
+    },
+    "packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts|packages/homelab/src/cdk8s/src/resources/temporal/worker.ts": {
+      "clones": 1,
+      "tokens": 82
     },
     "packages/homelab/src/cdk8s/src/resources/torrents/radarr.ts|packages/homelab/src/cdk8s/src/resources/torrents/sonarr.ts": {
       "clones": 2,
@@ -1945,5 +1965,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-25T02:48:09.363Z"
+  "updated": "2026-08-25T02:54:39.541Z"
 }

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/freshrss.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/freshrss.ts
@@ -29,8 +29,7 @@ export async function createFreshRssChart(app: App): Promise<void> {
               },
               podSelector: {
                 matchLabels: {
-                  app: "temporal-worker",
-                  component: "core-worker",
+                  component: "repo-worker",
                 },
               },
             },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -68,6 +68,18 @@ export function createScoutChart(app: App, stage: Stage) {
                       },
                     },
                   },
+                  {
+                    namespaceSelector: {
+                      matchLabels: {
+                        "kubernetes.io/metadata.name": "temporal",
+                      },
+                    },
+                    podSelector: {
+                      matchLabels: {
+                        component: "legacy-worker",
+                      },
+                    },
+                  },
                 ]
               : []),
           ],

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -64,8 +64,7 @@ export function createScoutChart(app: App, stage: Stage) {
                     },
                     podSelector: {
                       matchLabels: {
-                        app: "temporal-worker",
-                        component: "core-worker",
+                        component: "scout-worker",
                       },
                     },
                   },

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -14,7 +14,7 @@ import { createTemporalNamespaceInitJob } from "@shepherdjerred/homelab/cdk8s/sr
 import { createTemporalWorkerDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker.ts";
 import { createTemporalAgentWorkerNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker-network-policy.ts";
 import { TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker.ts";
-import { createTemporalScoutBetaNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/scout-beta-network.ts";
+import { createTemporalWorkerNetworkPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker-network-policies.ts";
 
 function scoutCompetitionActivityIngress(): NetworkPolicyIngressRule {
   return {
@@ -114,7 +114,23 @@ export function createTemporalChart(app: App) {
           from: [
             {
               podSelector: {
-                matchLabels: { app: "temporal-worker" },
+                matchExpressions: [
+                  {
+                    key: "component",
+                    operator: "In",
+                    values: [
+                      "gateway",
+                      "home-worker",
+                      "reports-worker",
+                      "infra-worker",
+                      "repo-worker",
+                      "scout-worker",
+                      "glitter-corpus-worker",
+                      "glitter-context-worker",
+                      "legacy-worker",
+                    ],
+                  },
+                ],
               },
             },
           ],
@@ -337,136 +353,5 @@ export function createTemporalChart(app: App) {
     },
   });
 
-  // NetworkPolicy for Temporal Worker
-  // Worker needs broad egress: Temporal server, HA, GitHub, OpenAI, Postal, S3, golink
-  new KubeNetworkPolicy(chart, "temporal-worker-netpol", {
-    metadata: { name: "temporal-worker-netpol" },
-    spec: {
-      podSelector: {
-        matchLabels: { app: "temporal-worker" },
-      },
-      policyTypes: ["Ingress", "Egress"],
-      ingress: [
-        {
-          // Allow Prometheus scraping worker SDK metrics
-          from: [
-            {
-              namespaceSelector: {
-                matchLabels: {
-                  "kubernetes.io/metadata.name": "prometheus",
-                },
-              },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(9464), protocol: "TCP" }],
-        },
-        {
-          // Allow cloudflared to reach the authenticated sleep webhook.
-          from: [
-            {
-              namespaceSelector: {
-                matchLabels: {
-                  "kubernetes.io/metadata.name": "cloudflare-tunnel",
-                },
-              },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(9469), protocol: "TCP" }],
-        },
-        {
-          // Allow the blackbox exporter to probe the webhook health endpoint.
-          from: [
-            {
-              namespaceSelector: {
-                matchLabels: {
-                  "kubernetes.io/metadata.name": "prometheus",
-                },
-              },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(9469), protocol: "TCP" }],
-        },
-      ],
-      egress: [
-        // DNS
-        {
-          to: [
-            {
-              namespaceSelector: {},
-              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
-            },
-          ],
-          ports: [
-            { port: IntOrString.fromNumber(53), protocol: "UDP" },
-            { port: IntOrString.fromNumber(53), protocol: "TCP" },
-          ],
-        },
-        // Temporal Server gRPC
-        {
-          to: [
-            {
-              podSelector: {
-                matchLabels: { app: "temporal-server" },
-              },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
-        },
-        // External HTTPS (HA, GitHub, OpenAI, Postal, S3, golink, Firestore)
-        {
-          ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }],
-        },
-        // Postal internal (HTTP within cluster)
-        {
-          to: [
-            {
-              namespaceSelector: {
-                matchLabels: {
-                  "kubernetes.io/metadata.name": "postal",
-                },
-              },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(5000), protocol: "TCP" }],
-        },
-        // K8s API (for golink-sync ingress listing)
-        {
-          ports: [{ port: IntOrString.fromNumber(6443), protocol: "TCP" }],
-        },
-      ],
-    },
-  });
-
-  // FreshRSS Repo Stack reconciliation is limited to the core worker. Keep
-  // it separate from the shared worker policy because the agent and Glitter
-  // workers intentionally reuse the temporal-worker app label.
-  new KubeNetworkPolicy(chart, "temporal-worker-freshrss-netpol", {
-    metadata: { name: "temporal-worker-freshrss-netpol" },
-    spec: {
-      podSelector: {
-        matchLabels: {
-          app: "temporal-worker",
-          component: "legacy-worker",
-        },
-      },
-      policyTypes: ["Egress"],
-      egress: [
-        {
-          to: [
-            {
-              namespaceSelector: {
-                matchLabels: {
-                  "kubernetes.io/metadata.name": "freshrss",
-                },
-              },
-              podSelector: { matchLabels: { app: "freshrss" } },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(80), protocol: "TCP" }],
-        },
-      ],
-    },
-  });
-
-  createTemporalScoutBetaNetworkPolicy(chart);
+  createTemporalWorkerNetworkPolicies(chart);
 }

--- a/packages/homelab/src/cdk8s/src/container-resources.test.ts
+++ b/packages/homelab/src/cdk8s/src/container-resources.test.ts
@@ -278,7 +278,7 @@ describe("Container resource requests backstop", () => {
       [
         "temporal-temporal-worker/temporal-worker",
         {
-          requests: { cpu: "500m", memory: "3072Mi" },
+          requests: { cpu: "500m", memory: "512Mi" },
           limits: { cpu: "1500m", memory: "6144Mi" },
         },
       ],
@@ -293,6 +293,27 @@ describe("Container resource requests backstop", () => {
       [
         "temporal-temporal-reports-worker/temporal-reports-worker",
         { requests: { cpu: "100m", memory: "512Mi" } },
+      ],
+      [
+        "temporal-temporal-infra-worker/temporal-infra-worker",
+        {
+          requests: { cpu: "500m", memory: "2048Mi" },
+          limits: { cpu: "1500m", memory: "6144Mi" },
+        },
+      ],
+      [
+        "temporal-temporal-repo-worker/temporal-repo-worker",
+        {
+          requests: { cpu: "250m", memory: "512Mi" },
+          limits: { cpu: "1500m", memory: "4096Mi" },
+        },
+      ],
+      [
+        "temporal-temporal-scout-worker/temporal-scout-worker",
+        {
+          requests: { cpu: "250m", memory: "512Mi" },
+          limits: { cpu: "1500m", memory: "4096Mi" },
+        },
       ],
       [
         "temporal-temporal-glitter-corpus-worker/temporal-glitter-corpus-worker",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-maintenance-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite-maintenance-worker.ts
@@ -9,6 +9,7 @@ import {
   Node,
   NodeLabelQuery,
   PersistentVolumeClaim,
+  Pods,
   Probe,
   Secret,
   Service,
@@ -30,7 +31,10 @@ import {
 
 const NAMESPACE = "buildkite";
 const WORKER_NAME = "temporal-maintenance-worker";
-const WORKER_LABELS = { app: WORKER_NAME };
+const WORKER_LABELS = {
+  app: WORKER_NAME,
+  component: "maintenance-worker",
+};
 const WORKER_IMAGE =
   "ghcr.io/shepherdjerred/temporal-worker:" +
   versions["shepherdjerred/temporal-worker"];
@@ -345,33 +349,38 @@ export function createBuildkiteMaintenanceWorker(chart: Chart): void {
   );
   setRevisionHistoryLimit(deployment, 5);
 
+  const maintenanceSelector = Pods.select(
+    chart,
+    "temporal-maintenance-worker-selector",
+    { labels: { component: "maintenance-worker" } },
+  );
   new Service(chart, "temporal-maintenance-worker-metrics-service", {
     metadata: {
       name: "temporal-maintenance-worker-metrics",
       namespace: NAMESPACE,
-      labels: { app: "temporal-maintenance-worker-metrics" },
+      labels: { component: "maintenance-worker-metrics" },
     },
-    selector: deployment,
+    selector: maintenanceSelector,
     ports: [{ name: "metrics", port: 9464 }],
   });
   createServiceMonitor(chart, {
     name: "temporal-maintenance-worker-metrics",
     namespace: NAMESPACE,
-    matchLabels: { app: "temporal-maintenance-worker-metrics" },
+    matchLabels: { component: "maintenance-worker-metrics" },
   });
   new Service(chart, "temporal-maintenance-worker-app-metrics-service", {
     metadata: {
       name: "temporal-maintenance-worker-app-metrics",
       namespace: NAMESPACE,
-      labels: { app: "temporal-maintenance-worker-app-metrics" },
+      labels: { component: "maintenance-worker-app-metrics" },
     },
-    selector: deployment,
+    selector: maintenanceSelector,
     ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
   });
   createServiceMonitor(chart, {
     name: "temporal-maintenance-worker-app-metrics",
     namespace: NAMESPACE,
     port: "app-metrics",
-    matchLabels: { app: "temporal-maintenance-worker-app-metrics" },
+    matchLabels: { component: "maintenance-worker-app-metrics" },
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/freshrss.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/freshrss.test.ts
@@ -169,8 +169,7 @@ describe("FreshRSS chart", () => {
           },
           podSelector: {
             matchLabels: {
-              app: "temporal-worker",
-              component: "core-worker",
+              component: "repo-worker",
             },
           },
         },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -63,7 +63,6 @@ export const TEMPORAL_DOMAIN_QUEUES = [
 export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
   return TEMPORAL_DOMAIN_QUEUES.flatMap((definition) => {
     const workerSelector = `namespace="${definition.metricsNamespace}",exported_namespace="default",task_queue="${definition.queue}"`;
-    const serverQueue = definition.queue.replaceAll("-", "_");
     const labels = { severity: "warning", task_queue: definition.queue };
     return [
       {
@@ -100,7 +99,7 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
             "Temporal matching has reported queued workflow or activity tasks for ten minutes. Inspect pollers and schedule-to-start latency before changing capacity.",
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          `max(approximate_backlog_count{namespace="temporal",taskqueue="${serverQueue}",task_type=~"Workflow|Activity"}) > 0`,
+          `max(approximate_backlog_count{namespace="temporal",taskqueue="${definition.queue}",task_type=~"Workflow|Activity"}) > 0`,
         ),
         for: "10m",
         labels,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -1,0 +1,149 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+
+type PrometheusRule = NonNullable<PrometheusRuleSpecGroups["rules"]>[number];
+
+export const TEMPORAL_DOMAIN_QUEUES = [
+  {
+    queue: "home",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-home-worker",
+    servicePattern: ".*temporal-home-worker.*metrics.*",
+  },
+  {
+    queue: "reports",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-reports-worker",
+    servicePattern: ".*temporal-reports-worker.*metrics.*",
+  },
+  {
+    queue: "infra",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-infra-worker",
+    servicePattern: ".*temporal-infra-worker.*metrics.*",
+  },
+  {
+    queue: "repo-automation",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-repo-worker",
+    servicePattern: ".*temporal-repo-worker.*metrics.*",
+  },
+  {
+    queue: "scout",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-scout-worker",
+    servicePattern: ".*temporal-scout-worker.*metrics.*",
+  },
+  {
+    queue: "agent-task",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-agent-worker",
+    servicePattern: ".*temporal-agent-worker.*metrics.*",
+  },
+  {
+    queue: "glitter-corpus",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-glitter-corpus-worker",
+    servicePattern: ".*temporal-glitter-corpus-worker.*metrics.*",
+  },
+  {
+    queue: "glitter-context",
+    metricsNamespace: "temporal",
+    deployment: "temporal-temporal-glitter-context-worker",
+    servicePattern: ".*temporal-glitter-context-worker.*metrics.*",
+  },
+  {
+    queue: "maintenance",
+    metricsNamespace: "buildkite",
+    deployment: "temporal-maintenance-worker",
+    servicePattern: ".*temporal-maintenance-worker.*metrics.*",
+  },
+] as const;
+
+export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
+  return TEMPORAL_DOMAIN_QUEUES.flatMap((definition) => {
+    const workerSelector = `namespace="${definition.metricsNamespace}",exported_namespace="default",task_queue="${definition.queue}"`;
+    const serverQueue = definition.queue.replaceAll("-", "_");
+    const labels = { severity: "warning", task_queue: definition.queue };
+    return [
+      {
+        alert: "TemporalDomainWorkflowPollerUnavailable",
+        annotations: {
+          summary: `Temporal workflow poller unavailable for ${definition.queue}`,
+          description:
+            "The domain queue has had no workflow-task poller for five minutes. Inspect its worker pod and Temporal connectivity.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          `absent(temporal_worker_num_pollers{${workerSelector},poller_type="workflow_task"}) or max(temporal_worker_num_pollers{${workerSelector},poller_type="workflow_task"}) < 1`,
+        ),
+        for: "5m",
+        labels,
+      },
+      {
+        alert: "TemporalDomainActivityPollerUnavailable",
+        annotations: {
+          summary: `Temporal activity poller unavailable for ${definition.queue}`,
+          description:
+            "The domain queue has had no activity-task poller for five minutes. Inspect its worker pod and Temporal connectivity.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          `absent(temporal_worker_num_pollers{${workerSelector},poller_type="activity_task"}) or max(temporal_worker_num_pollers{${workerSelector},poller_type="activity_task"}) < 1`,
+        ),
+        for: "5m",
+        labels,
+      },
+      {
+        alert: "TemporalDomainQueueBacklog",
+        annotations: {
+          summary: `Temporal task backlog on ${definition.queue}`,
+          description:
+            "Temporal matching has reported queued workflow or activity tasks for ten minutes. Inspect pollers and schedule-to-start latency before changing capacity.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          `max(approximate_backlog_count{namespace="temporal",taskqueue="${serverQueue}",task_type=~"Workflow|Activity"}) > 0`,
+        ),
+        for: "10m",
+        labels,
+      },
+      {
+        alert: "TemporalDomainScheduleToStartHigh",
+        annotations: {
+          summary: `Temporal schedule-to-start latency is high on ${definition.queue}`,
+          description:
+            "The queue's workflow or activity schedule-to-start p95 has exceeded five seconds for five minutes.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          `histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{${workerSelector}}[5m]))) > 5 or histogram_quantile(0.95, sum by (le) (rate(temporal_worker_activity_schedule_to_start_latency_seconds_bucket{${workerSelector}}[5m]))) > 5`,
+        ),
+        for: "5m",
+        labels,
+      },
+      {
+        alert: "TemporalDomainWorkerScrapeDown",
+        annotations: {
+          summary: `Temporal metrics scrape is down for ${definition.queue}`,
+          description:
+            "Prometheus cannot scrape the domain worker. Check the component-selected Service and ServiceMonitor.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          `absent(up{namespace="${definition.metricsNamespace}",service=~"${definition.servicePattern}"}) or max(up{namespace="${definition.metricsNamespace}",service=~"${definition.servicePattern}"}) < 1`,
+        ),
+        for: "5m",
+        labels,
+      },
+      {
+        alert: "TemporalDomainWorkerPodNotReady",
+        annotations: {
+          summary: `Temporal worker pod is not ready for ${definition.queue}`,
+          description:
+            "The single domain worker Deployment has no available replica.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          `absent(kube_deployment_status_replicas_available{namespace="${definition.metricsNamespace}",deployment="${definition.deployment}"}) or max(kube_deployment_status_replicas_available{namespace="${definition.metricsNamespace}",deployment="${definition.deployment}"}) < 1`,
+        ),
+        for: "5m",
+        labels,
+      },
+    ];
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -90,6 +90,12 @@ describe("Temporal workflow outcome rules", () => {
           expression.includes("approximate_backlog_count"),
       ),
     ).toBe(true);
+    expect(backlogExpressions).toContain(
+      'max(approximate_backlog_count{namespace="temporal",taskqueue="repo-automation",task_type=~"Workflow|Activity"}) > 0',
+    );
+    expect(backlogExpressions.join("\n")).not.toContain(
+      'taskqueue="repo_automation"',
+    );
 
     const workerMetricsDown = failuresGroup.rules.find(
       (rule) => rule.alert === "TemporalWorkerMetricsDown",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { getTemporalRuleGroups } from "./temporal.ts";
+import { TEMPORAL_DOMAIN_QUEUES } from "./temporal-worker-health.ts";
 
 function findFailureRule(alertName: string): string {
   const failureGroup = getTemporalRuleGroups().find(
@@ -49,7 +50,7 @@ describe("Temporal workflow outcome rules", () => {
     expect(expression).toContain('reason!~"no-one-home|not-cold"');
   });
 
-  test("alerts on agent-task poller and schedule-to-start health", () => {
+  test("alerts on every domain queue's pollers, backlog, latency, scrape, and readiness", () => {
     const failuresGroup = getTemporalRuleGroups().find(
       (group) => group.name === "temporal-workflow-failures",
     );
@@ -57,38 +58,38 @@ describe("Temporal workflow outcome rules", () => {
       throw new Error("Missing temporal-workflow-failures rule group");
     }
 
-    const pollerUnavailable = failuresGroup.rules.find(
-      (rule) => rule.alert === "TemporalAgentTaskWorkflowPollerUnavailable",
-    );
-    if (pollerUnavailable === undefined) {
-      throw new Error(
-        "Missing TemporalAgentTaskWorkflowPollerUnavailable alert",
+    const healthAlerts = [
+      "TemporalDomainWorkflowPollerUnavailable",
+      "TemporalDomainActivityPollerUnavailable",
+      "TemporalDomainQueueBacklog",
+      "TemporalDomainScheduleToStartHigh",
+      "TemporalDomainWorkerScrapeDown",
+      "TemporalDomainWorkerPodNotReady",
+    ];
+    for (const alert of healthAlerts) {
+      const rules = failuresGroup.rules.filter((rule) => rule.alert === alert);
+      expect(rules, alert).toHaveLength(TEMPORAL_DOMAIN_QUEUES.length);
+      expect(
+        rules
+          .map((rule) => rule.labels?.["task_queue"])
+          .toSorted((left, right) => (left ?? "").localeCompare(right ?? "")),
+      ).toEqual(
+        TEMPORAL_DOMAIN_QUEUES.map((definition) => definition.queue).toSorted(
+          (left, right) => left.localeCompare(right),
+        ),
       );
     }
-    expect(pollerUnavailable.expr.value).toContain(
-      "temporal_worker_num_pollers",
-    );
-    expect(pollerUnavailable.expr.value).toContain(
-      'namespace="temporal",exported_namespace="default"',
-    );
-    expect(pollerUnavailable.for).toBe("5m");
 
-    const scheduleToStartHigh = failuresGroup.rules.find(
-      (rule) =>
-        rule.alert === "TemporalAgentTaskWorkflowTaskScheduleToStartHigh",
-    );
-    if (scheduleToStartHigh === undefined) {
-      throw new Error(
-        "Missing TemporalAgentTaskWorkflowTaskScheduleToStartHigh alert",
-      );
-    }
-    expect(scheduleToStartHigh.expr.value).toContain(
-      "temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket",
-    );
-    expect(scheduleToStartHigh.expr.value).toContain(
-      'namespace="temporal",exported_namespace="default"',
-    );
-    expect(scheduleToStartHigh.for).toBe("5m");
+    const backlogExpressions = failuresGroup.rules
+      .filter((rule) => rule.alert === "TemporalDomainQueueBacklog")
+      .map((rule) => rule.expr.value);
+    expect(
+      backlogExpressions.every(
+        (expression) =>
+          typeof expression === "string" &&
+          expression.includes("approximate_backlog_count"),
+      ),
+    ).toBe(true);
 
     const workerMetricsDown = failuresGroup.rules.find(
       (rule) => rule.alert === "TemporalWorkerMetricsDown",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -1,6 +1,7 @@
 import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
+import { buildTemporalDomainWorkerHealthRules } from "./temporal-worker-health.ts";
 
 type PrometheusRule = NonNullable<PrometheusRuleSpecGroups["rules"]>[number];
 
@@ -97,46 +98,6 @@ function buildCheckAndSkipOutcomeRules(): PrometheusRule[] {
   };
 
   return [...perWorkflow, fallback];
-}
-
-// agentTaskWorkflow timeouts are diagnosed per execution by
-// temporal-failure-watch. These queue-health rules are the independent
-// starvation signal: they tell us whether the agent-task worker is polling and
-// whether scheduled workflow tasks are waiting before any capacity change.
-function buildAgentTaskWorkerHealthRules(): PrometheusRule[] {
-  return [
-    {
-      alert: "TemporalAgentTaskWorkflowPollerUnavailable",
-      annotations: {
-        summary: "Temporal agent-task workflow poller is unavailable",
-        description: escapePrometheusTemplate(
-          "The Temporal SDK has reported no workflow-task poller for the agent-task queue for five minutes. Inspect worker pod readiness, Temporal connectivity, and the agent-task task queue before changing worker replicas or concurrency.",
-        ),
-      },
-      expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-        'absent(temporal_worker_num_pollers{namespace="temporal",exported_namespace="default",task_queue="agent-task",poller_type="workflow_task"}) or max(temporal_worker_num_pollers{namespace="temporal",exported_namespace="default",task_queue="agent-task",poller_type="workflow_task"}) < 1',
-      ),
-      for: "5m",
-      labels: {
-        severity: "warning",
-      },
-    },
-    {
-      alert: "TemporalAgentTaskWorkflowTaskScheduleToStartHigh",
-      annotations: {
-        summary: "Temporal agent-task workflow tasks are waiting",
-        description:
-          "The 95th percentile Temporal workflow-task schedule-to-start latency for agent-task has exceeded five seconds for five minutes. Inspect task-queue poll health and worker scrape availability; do not change concurrency without this evidence.",
-      },
-      expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-        'histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace="temporal",exported_namespace="default",task_queue="agent-task"}[5m]))) > 5',
-      ),
-      for: "5m",
-      labels: {
-        severity: "warning",
-      },
-    },
-  ];
 }
 
 // Scout Data Dragon updater failure alerts. Extracted from
@@ -427,7 +388,7 @@ export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
             severity: "warning",
           },
         },
-        ...buildAgentTaskWorkerHealthRules(),
+        ...buildTemporalDomainWorkerHealthRules(),
         {
           alert: "TemporalReportHeartbeatStale",
           annotations: {

--- a/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker-network-policy.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker-network-policy.ts
@@ -14,7 +14,7 @@ export function createTemporalAgentWorkerNetworkPolicy(chart: Chart): void {
     metadata: { name: "temporal-agent-worker-netpol" },
     spec: {
       podSelector: {
-        matchLabels: { app: "temporal-agent-worker" },
+        matchLabels: { component: "agent-worker" },
       },
       policyTypes: ["Ingress", "Egress"],
       ingress: [

--- a/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/agent-worker.ts
@@ -6,6 +6,7 @@ import {
   Deployment,
   DeploymentStrategy,
   type EnvValue,
+  Pods,
   Service,
   type ServiceAccount,
   Volume,
@@ -185,25 +186,28 @@ ip6tables -L OUTPUT -n`,
   );
   container.mount("/tmp", tmpVolume);
 
+  const agentSelector = Pods.select(chart, "temporal-agent-worker-selector", {
+    labels: { component: "agent-worker" },
+  });
   new Service(chart, "temporal-agent-worker-metrics-service", {
-    selector: deployment,
+    selector: agentSelector,
     metadata: {
-      labels: { app: "temporal-agent-worker-metrics" },
+      labels: { component: "agent-worker-metrics" },
     },
     ports: [{ port: 9464, name: "metrics" }],
   });
 
   createServiceMonitor(chart, {
     name: "temporal-agent-worker-metrics",
-    matchLabels: { app: "temporal-agent-worker-metrics" },
+    matchLabels: { component: "agent-worker-metrics" },
   });
 
   new Service(chart, "temporal-agent-worker-app-metrics-service", {
     metadata: {
       name: "temporal-agent-worker-app-metrics",
-      labels: { app: "temporal-agent-worker-app-metrics" },
+      labels: { component: "agent-worker-app-metrics" },
     },
-    selector: deployment,
+    selector: agentSelector,
     ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
   });
 
@@ -211,7 +215,7 @@ ip6tables -L OUTPUT -n`,
     name: "temporal-agent-worker-app-metrics",
     port: "app-metrics",
     interval: "30s",
-    matchLabels: { app: "temporal-agent-worker-app-metrics" },
+    matchLabels: { component: "agent-worker-app-metrics" },
   });
 
   return deployment;

--- a/packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts
@@ -113,7 +113,7 @@ export function createTemporalWorkerAuditRbac(
  */
 export function createTemporalWorkerTasknotesCanaryRbac(
   chart: Chart,
-  serviceAccount: ServiceAccount,
+  serviceAccounts: readonly ServiceAccount[],
 ): void {
   // The deterministic TaskNotes canary reads AUTH_TOKEN only inside the
   // tasknotes-server process and emits the typed engine-status response. The
@@ -145,13 +145,11 @@ export function createTemporalWorkerTasknotesCanaryRbac(
         kind: "Role",
         name: "temporal-worker-tasknotes-engine-status",
       },
-      subjects: [
-        {
-          kind: "ServiceAccount",
-          name: serviceAccount.name,
-          namespace: serviceAccount.metadata.namespace ?? "temporal",
-        },
-      ],
+      subjects: serviceAccounts.map((serviceAccount) => ({
+        kind: "ServiceAccount",
+        name: serviceAccount.name,
+        namespace: serviceAccount.metadata.namespace ?? "temporal",
+      })),
     },
   );
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/crd-rbac.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/crd-rbac.ts
@@ -15,7 +15,7 @@ import {
  */
 export function createTemporalWorkerCrdReaderRbac(
   chart: Chart,
-  serviceAccount: ServiceAccount,
+  serviceAccounts: readonly ServiceAccount[],
 ): void {
   new KubeClusterRole(chart, "temporal-worker-crd-reader", {
     metadata: { name: "temporal-worker-crd-reader" },
@@ -35,12 +35,10 @@ export function createTemporalWorkerCrdReaderRbac(
       kind: "ClusterRole",
       name: "temporal-worker-crd-reader",
     },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: serviceAccount.metadata.namespace ?? "temporal",
-      },
-    ],
+    subjects: serviceAccounts.map((serviceAccount) => ({
+      kind: "ServiceAccount",
+      name: serviceAccount.name,
+      namespace: serviceAccount.metadata.namespace ?? "temporal",
+    })),
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/domain-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/domain-worker.ts
@@ -29,6 +29,11 @@ export type TemporalDomainWorkerProps = {
   memoryLimit?: Size;
   automountServiceAccountToken?: boolean;
   serviceAccount?: ServiceAccount;
+  volumeMounts?: readonly {
+    path: string;
+    volume: Volume;
+    readOnly?: boolean;
+  }[];
 };
 
 export function createTemporalDomainWorker(
@@ -86,6 +91,9 @@ export function createTemporalDomainWorker(
     "/tmp",
     Volume.fromEmptyDir(chart, `${props.name}-tmp`, `${props.component}-tmp`),
   );
+  for (const mount of props.volumeMounts ?? []) {
+    container.mount(mount.path, mount.volume, { readOnly: mount.readOnly });
+  }
 
   const selector = Pods.select(chart, `${props.name}-selector`, {
     labels: { component: props.component },

--- a/packages/homelab/src/cdk8s/src/resources/temporal/legacy-worker-env.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/legacy-worker-env.ts
@@ -1,0 +1,124 @@
+import { EnvValue, type ISecret } from "cdk8s-plus-31";
+import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-archive-env.ts";
+import { glitterCorpusEnv } from "./glitter-corpus-env.ts";
+import { sleepWebhookEnv } from "./http-services.ts";
+
+function requiredSecretEnv(
+  secret: ISecret,
+  keys: readonly string[],
+): Record<string, EnvValue> {
+  const env: Record<string, EnvValue> = {};
+  for (const key of keys) {
+    env[key] = EnvValue.fromSecretValue({ secret, key });
+  }
+  return env;
+}
+
+export function homelabAuditEnv(secret: ISecret): Record<string, EnvValue> {
+  return {
+    BUGSINK_URL: EnvValue.fromValue("https://bugsink.sjer.red"),
+    BUILDKITE_ORGANIZATION_SLUG: EnvValue.fromValue("sjerred"),
+    BUILDKITE_PIPELINE_SLUG: EnvValue.fromValue("monorepo"),
+    PROMETHEUS_URL: EnvValue.fromValue(
+      "http://prometheus-kube-prometheus-prometheus.prometheus:9090",
+    ),
+    GCX_CONFIG: EnvValue.fromValue("/tmp/gcx-config.yaml"),
+    GCX_NO_UPDATE_NOTIFIER: EnvValue.fromValue("1"),
+    GCX_TELEMETRY: EnvValue.fromValue("disabled"),
+    ...requiredSecretEnv(secret, [
+      "BUGSINK_TOKEN",
+      "GRAFANA_URL",
+      "GRAFANA_API_KEY",
+      "ARGOCD_SERVER",
+      "ARGOCD_AUTH_TOKEN",
+      "CLOUDFLARE_API_TOKEN",
+      "BUILDKITE_API_TOKEN",
+    ]),
+    ALERT_DASHBOARD_URL: EnvValue.fromValue(
+      "http://alert-dashboard-alert-dashboard-service.alert-dashboard:7341",
+    ),
+    TALOSCONFIG: EnvValue.fromValue("/etc/talos/config"),
+  };
+}
+
+export function legacyWorkerEnvironment(props: {
+  serverServiceName: string;
+  secret: ISecret;
+  starlightBotSecret: ISecret;
+  scoutWeeklyParlaySecret: ISecret;
+}): Record<string, EnvValue> {
+  const secretValue = (key: string): EnvValue =>
+    EnvValue.fromSecretValue({ secret: props.secret, key });
+  return {
+    TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
+    TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+    TEMPORAL_WORKER_ROLE: EnvValue.fromValue("legacy"),
+    FRESHRSS_API_URL: EnvValue.fromValue(
+      "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
+    ),
+    FRESHRSS_USER: EnvValue.fromValue("sjerred"),
+    FRESHRSS_CATEGORY: EnvValue.fromValue("Repo Stack"),
+    FRESHRSS_MANIFEST_PATH: EnvValue.fromValue("/etc/freshrss/desired.json"),
+    FRESHRSS_API_PASSWORD_FILE: EnvValue.fromValue(
+      "/run/secrets/freshrss/password",
+    ),
+    ENVIRONMENT: EnvValue.fromValue("production"),
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: EnvValue.fromValue("1"),
+    DISABLE_AUTOUPDATER: EnvValue.fromValue("1"),
+    TELEMETRY_ENABLED: EnvValue.fromValue("true"),
+    OTLP_ENDPOINT: EnvValue.fromValue(
+      "http://tempo.tempo.svc.cluster.local:4318",
+    ),
+    TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-worker"),
+    GIT_AUTHOR_NAME: EnvValue.fromValue("temporal-worker[bot]"),
+    GIT_AUTHOR_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),
+    GIT_COMMITTER_NAME: EnvValue.fromValue("temporal-worker[bot]"),
+    GIT_COMMITTER_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),
+    NODE_EXTRA_CA_CERTS: EnvValue.fromValue(
+      "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+    ),
+    HA_URL: secretValue("HA_URL"),
+    HA_TOKEN: secretValue("HA_TOKEN"),
+    S3_BUCKET_NAME: secretValue("S3_BUCKET_NAME"),
+    S3_ENDPOINT: secretValue("S3_ENDPOINT"),
+    S3_KEY: EnvValue.fromValue("data/manifest.json"),
+    S3_REGION: EnvValue.fromValue("us-east-1"),
+    AWS_REGION: EnvValue.fromValue("us-east-1"),
+    AWS_DEFAULT_REGION: EnvValue.fromValue("us-east-1"),
+    S3_FORCE_PATH_STYLE: EnvValue.fromValue("true"),
+    ...llmArchiveEnvVars(),
+    AWS_ACCESS_KEY_ID: secretValue("AWS_ACCESS_KEY_ID"),
+    AWS_SECRET_ACCESS_KEY: secretValue("AWS_SECRET_ACCESS_KEY"),
+    ...glitterCorpusEnv(props.secret, props.starlightBotSecret),
+    GITHUB_APP_ID: secretValue("GITHUB_APP_ID"),
+    GITHUB_APP_INSTALLATION_ID: secretValue("GITHUB_APP_INSTALLATION_ID"),
+    GITHUB_APP_PRIVATE_KEY: secretValue("GITHUB_APP_PRIVATE_KEY"),
+    GITHUB_WEBHOOK_SECRET: secretValue("GITHUB_WEBHOOK_SECRET"),
+    CLAUDE_CODE_OAUTH_TOKEN: secretValue("CLAUDE_CODE_OAUTH_TOKEN"),
+    GITHUB_WEBHOOK_PORT: EnvValue.fromValue("9466"),
+    AGENT_TASK_API_PORT: EnvValue.fromValue("9467"),
+    AGENT_TASK_API_TOKEN: secretValue("AGENT_TASK_API_TOKEN"),
+    SCOUT_WEEKLY_PARLAY_CONTROL_URL: EnvValue.fromValue(
+      "http://scout-service-beta.scout-beta.svc.cluster.local:3000/api/internal/weekly-parlays/actions",
+    ),
+    SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN: EnvValue.fromSecretValue({
+      secret: props.scoutWeeklyParlaySecret,
+      key: "token",
+    }),
+    ...sleepWebhookEnv(props.secret),
+    XCODE_CLOUD_WEBHOOK_PORT: EnvValue.fromValue("9468"),
+    XCODE_CLOUD_WEBHOOK_TOKEN: secretValue("XCODE_CLOUD_WEBHOOK_TOKEN"),
+    ALERTMANAGER_URL: EnvValue.fromValue(
+      "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
+    ),
+    SENTRY_DSN: secretValue("SENTRY_DSN"),
+    OPENROUTER_API_KEY: secretValue("OPENROUTER_API_KEY"),
+    CODEX_ACCESS_TOKEN: secretValue("CODEX_ACCESS_TOKEN"),
+    POSTAL_HOST: secretValue("POSTAL_HOST"),
+    POSTAL_HOST_HEADER: secretValue("POSTAL_HOST_HEADER"),
+    POSTAL_API_KEY: secretValue("POSTAL_API_KEY"),
+    RECIPIENT_EMAIL: secretValue("RECIPIENT_EMAIL"),
+    SENDER_EMAIL: secretValue("SENDER_EMAIL"),
+    ...homelabAuditEnv(props.secret),
+  };
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/legacy-worker-metrics.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/legacy-worker-metrics.ts
@@ -1,0 +1,33 @@
+import type { Chart } from "cdk8s";
+import { Pods, Service } from "cdk8s-plus-31";
+import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
+
+export function createTemporalLegacyWorkerMetrics(chart: Chart): void {
+  const selector = Pods.select(chart, "temporal-legacy-worker-selector", {
+    labels: { component: "legacy-worker" },
+  });
+  new Service(chart, "temporal-worker-metrics-service", {
+    selector,
+    metadata: { labels: { component: "legacy-worker-metrics" } },
+    ports: [{ port: 9464, name: "metrics" }],
+  });
+  createServiceMonitor(chart, {
+    name: "temporal-worker-metrics",
+    matchLabels: { component: "legacy-worker-metrics" },
+  });
+
+  new Service(chart, "temporal-worker-app-metrics-service", {
+    metadata: {
+      name: "temporal-worker-app-metrics",
+      labels: { component: "legacy-worker-app-metrics" },
+    },
+    selector,
+    ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
+  });
+  createServiceMonitor(chart, {
+    name: "temporal-worker-app-metrics",
+    port: "app-metrics",
+    interval: "30s",
+    matchLabels: { component: "legacy-worker-app-metrics" },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
@@ -1,0 +1,222 @@
+import type { Chart } from "cdk8s";
+import { Size } from "cdk8s";
+import {
+  Cpu,
+  EnvValue,
+  type ISecret,
+  type ServiceAccount,
+  type Volume,
+} from "cdk8s-plus-31";
+import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-archive-env.ts";
+import { createTemporalDomainWorker } from "./domain-worker.ts";
+
+function runtimeEnv(
+  serverServiceName: string,
+  secret: ISecret,
+  role: "infra" | "repo" | "scout",
+  serviceName: string,
+): Record<string, EnvValue> {
+  return {
+    TEMPORAL_ADDRESS: EnvValue.fromValue(`${serverServiceName}:7233`),
+    TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+    TEMPORAL_WORKER_ROLE: EnvValue.fromValue(role),
+    ENVIRONMENT: EnvValue.fromValue("production"),
+    TELEMETRY_ENABLED: EnvValue.fromValue("true"),
+    OTLP_ENDPOINT: EnvValue.fromValue(
+      "http://tempo.tempo.svc.cluster.local:4318",
+    ),
+    TELEMETRY_SERVICE_NAME: EnvValue.fromValue(serviceName),
+    SENTRY_DSN: EnvValue.fromSecretValue({ secret, key: "SENTRY_DSN" }),
+  };
+}
+
+function s3Env(secret: ISecret): Record<string, EnvValue> {
+  return {
+    S3_ENDPOINT: EnvValue.fromSecretValue({ secret, key: "S3_ENDPOINT" }),
+    S3_REGION: EnvValue.fromValue("us-east-1"),
+    AWS_REGION: EnvValue.fromValue("us-east-1"),
+    AWS_DEFAULT_REGION: EnvValue.fromValue("us-east-1"),
+    S3_FORCE_PATH_STYLE: EnvValue.fromValue("true"),
+    AWS_ACCESS_KEY_ID: EnvValue.fromSecretValue({
+      secret,
+      key: "AWS_ACCESS_KEY_ID",
+    }),
+    AWS_SECRET_ACCESS_KEY: EnvValue.fromSecretValue({
+      secret,
+      key: "AWS_SECRET_ACCESS_KEY",
+    }),
+  };
+}
+
+function githubEnv(secret: ISecret): Record<string, EnvValue> {
+  return {
+    GITHUB_APP_ID: EnvValue.fromSecretValue({
+      secret,
+      key: "GITHUB_APP_ID",
+    }),
+    GITHUB_APP_INSTALLATION_ID: EnvValue.fromSecretValue({
+      secret,
+      key: "GITHUB_APP_INSTALLATION_ID",
+    }),
+    GITHUB_APP_PRIVATE_KEY: EnvValue.fromSecretValue({
+      secret,
+      key: "GITHUB_APP_PRIVATE_KEY",
+    }),
+    GIT_AUTHOR_NAME: EnvValue.fromValue("temporal-worker[bot]"),
+    GIT_AUTHOR_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),
+    GIT_COMMITTER_NAME: EnvValue.fromValue("temporal-worker[bot]"),
+    GIT_COMMITTER_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),
+  };
+}
+
+export type TemporalOperationsWorkerProps = {
+  serverServiceName: string;
+  secret: ISecret;
+  scoutWeeklyParlaySecret: ISecret;
+  infraServiceAccount: ServiceAccount;
+  homelabAuditEnvironment: Record<string, EnvValue>;
+  talosConfigVolume: Volume;
+  freshRssManifestVolume: Volume;
+  freshRssCredentialVolume: Volume;
+};
+
+export function createTemporalOperationsWorkers(
+  chart: Chart,
+  props: TemporalOperationsWorkerProps,
+) {
+  const infraDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-infra-worker",
+    component: "infra-worker",
+    serviceAccount: props.infraServiceAccount,
+    automountServiceAccountToken: true,
+    cpuRequest: Cpu.millis(500),
+    cpuLimit: Cpu.millis(1500),
+    memoryRequest: Size.gibibytes(2),
+    memoryLimit: Size.gibibytes(6),
+    envVariables: {
+      ...runtimeEnv(
+        props.serverServiceName,
+        props.secret,
+        "infra",
+        "temporal-infra-worker",
+      ),
+      NODE_EXTRA_CA_CERTS: EnvValue.fromValue(
+        "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+      ),
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: EnvValue.fromValue("1"),
+      DISABLE_AUTOUPDATER: EnvValue.fromValue("1"),
+      CLAUDE_CODE_OAUTH_TOKEN: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "CLAUDE_CODE_OAUTH_TOKEN",
+      }),
+      OPENROUTER_API_KEY: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "OPENROUTER_API_KEY",
+      }),
+      ...llmArchiveEnvVars(),
+      ...s3Env(props.secret),
+      ...githubEnv(props.secret),
+      ...props.homelabAuditEnvironment,
+    },
+    volumeMounts: [
+      {
+        path: "/etc/talos",
+        volume: props.talosConfigVolume,
+        readOnly: true,
+      },
+    ],
+  });
+
+  const repoDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-repo-worker",
+    component: "repo-worker",
+    cpuRequest: Cpu.millis(250),
+    cpuLimit: Cpu.millis(1500),
+    memoryRequest: Size.mebibytes(512),
+    memoryLimit: Size.gibibytes(4),
+    envVariables: {
+      ...runtimeEnv(
+        props.serverServiceName,
+        props.secret,
+        "repo",
+        "temporal-repo-worker",
+      ),
+      ...s3Env(props.secret),
+      ...githubEnv(props.secret),
+      ...llmArchiveEnvVars(),
+      OPENROUTER_API_KEY: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "OPENROUTER_API_KEY",
+      }),
+      S3_BUCKET_NAME: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "S3_BUCKET_NAME",
+      }),
+      S3_KEY: EnvValue.fromValue("data/manifest.json"),
+      BUILDKITE_API_TOKEN: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "BUILDKITE_API_TOKEN",
+      }),
+      BUILDKITE_ORGANIZATION_SLUG: EnvValue.fromValue("sjerred"),
+      BUILDKITE_PIPELINE_SLUG: EnvValue.fromValue("monorepo"),
+      ALERTMANAGER_URL: EnvValue.fromValue(
+        "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
+      ),
+      FRESHRSS_API_URL: EnvValue.fromValue(
+        "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
+      ),
+      FRESHRSS_USER: EnvValue.fromValue("sjerred"),
+      FRESHRSS_CATEGORY: EnvValue.fromValue("Repo Stack"),
+      FRESHRSS_MANIFEST_PATH: EnvValue.fromValue("/etc/freshrss/desired.json"),
+      FRESHRSS_API_PASSWORD_FILE: EnvValue.fromValue(
+        "/run/secrets/freshrss/password",
+      ),
+    },
+    volumeMounts: [
+      {
+        path: "/etc/freshrss",
+        volume: props.freshRssManifestVolume,
+        readOnly: true,
+      },
+      {
+        path: "/run/secrets/freshrss",
+        volume: props.freshRssCredentialVolume,
+        readOnly: true,
+      },
+    ],
+  });
+
+  const scoutDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-scout-worker",
+    component: "scout-worker",
+    cpuRequest: Cpu.millis(250),
+    cpuLimit: Cpu.millis(1500),
+    memoryRequest: Size.mebibytes(512),
+    memoryLimit: Size.gibibytes(4),
+    envVariables: {
+      ...runtimeEnv(
+        props.serverServiceName,
+        props.secret,
+        "scout",
+        "temporal-scout-worker",
+      ),
+      ...s3Env(props.secret),
+      ...githubEnv(props.secret),
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: EnvValue.fromValue("1"),
+      DISABLE_AUTOUPDATER: EnvValue.fromValue("1"),
+      CLAUDE_CODE_OAUTH_TOKEN: EnvValue.fromSecretValue({
+        secret: props.secret,
+        key: "CLAUDE_CODE_OAUTH_TOKEN",
+      }),
+      SCOUT_WEEKLY_PARLAY_CONTROL_URL: EnvValue.fromValue(
+        "http://scout-service-beta.scout-beta.svc.cluster.local:3000/api/internal/weekly-parlays/actions",
+      ),
+      SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN: EnvValue.fromSecretValue({
+        secret: props.scoutWeeklyParlaySecret,
+        key: "token",
+      }),
+    },
+  });
+
+  return { infraDeployment, repoDeployment, scoutDeployment };
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/scout-beta-network.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/scout-beta-network.ts
@@ -10,8 +10,7 @@ export function createTemporalScoutBetaNetworkPolicy(chart: Chart): void {
     spec: {
       podSelector: {
         matchLabels: {
-          app: "temporal-worker",
-          component: "legacy-worker",
+          component: "scout-worker",
         },
       },
       policyTypes: ["Egress"],

--- a/packages/homelab/src/cdk8s/src/resources/temporal/scout-beta-network.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/scout-beta-network.ts
@@ -5,30 +5,42 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 
 export function createTemporalScoutBetaNetworkPolicy(chart: Chart): void {
-  new KubeNetworkPolicy(chart, "temporal-worker-scout-beta-netpol", {
-    metadata: { name: "temporal-worker-scout-beta-netpol" },
-    spec: {
-      podSelector: {
-        matchLabels: {
-          component: "scout-worker",
+  const egress = (constructId: string, name: string, component: string) =>
+    new KubeNetworkPolicy(chart, constructId, {
+      metadata: { name },
+      spec: {
+        podSelector: {
+          matchLabels: { component },
         },
-      },
-      policyTypes: ["Egress"],
-      egress: [
-        {
-          to: [
-            {
-              namespaceSelector: {
-                matchLabels: {
-                  "kubernetes.io/metadata.name": "scout-beta",
+        policyTypes: ["Egress"],
+        egress: [
+          {
+            to: [
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    "kubernetes.io/metadata.name": "scout-beta",
+                  },
                 },
+                podSelector: { matchLabels: { app: "scout-backend" } },
               },
-              podSelector: { matchLabels: { app: "scout-backend" } },
-            },
-          ],
-          ports: [{ port: IntOrString.fromNumber(3000), protocol: "TCP" }],
-        },
-      ],
-    },
-  });
+            ],
+            ports: [{ port: IntOrString.fromNumber(3000), protocol: "TCP" }],
+          },
+        ],
+      },
+    });
+
+  egress(
+    "temporal-worker-scout-beta-netpol",
+    "temporal-worker-scout-beta-netpol",
+    "scout-worker",
+  );
+  // Keep legacy default-queue executions connected until the migration drain
+  // proves that no pre-routing Scout parlay lifecycle remains.
+  egress(
+    "temporal-legacy-worker-scout-beta-netpol",
+    "temporal-legacy-worker-scout-beta-netpol",
+    "legacy-worker",
+  );
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
@@ -1,0 +1,187 @@
+import type { Chart } from "cdk8s";
+import {
+  IntOrString,
+  KubeNetworkPolicy,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import { createTemporalScoutBetaNetworkPolicy } from "./scout-beta-network.ts";
+
+export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
+  new KubeNetworkPolicy(chart, "temporal-worker-netpol", {
+    metadata: { name: "temporal-worker-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "legacy-worker" } },
+      policyTypes: ["Ingress", "Egress"],
+      ingress: [
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  "kubernetes.io/metadata.name": "prometheus",
+                },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(9464), protocol: "TCP" }],
+        },
+      ],
+      egress: [
+        {
+          to: [
+            {
+              namespaceSelector: {},
+              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+            },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(53), protocol: "UDP" },
+            { port: IntOrString.fromNumber(53), protocol: "TCP" },
+          ],
+        },
+        {
+          to: [{ podSelector: { matchLabels: { app: "temporal-server" } } }],
+          ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
+        },
+        { ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }] },
+        { ports: [{ port: IntOrString.fromNumber(5000), protocol: "TCP" }] },
+        { ports: [{ port: IntOrString.fromNumber(6443), protocol: "TCP" }] },
+      ],
+    },
+  });
+
+  for (const component of [
+    "gateway",
+    "home-worker",
+    "reports-worker",
+    "infra-worker",
+    "repo-worker",
+    "scout-worker",
+    "glitter-corpus-worker",
+    "glitter-context-worker",
+  ]) {
+    new KubeNetworkPolicy(chart, `${component}-network-policy`, {
+      metadata: { name: `temporal-${component}-netpol` },
+      spec: {
+        podSelector: { matchLabels: { component } },
+        policyTypes: ["Ingress", "Egress"],
+        ingress: [
+          {
+            from: [
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    "kubernetes.io/metadata.name": "prometheus",
+                  },
+                },
+              },
+            ],
+            ports: [
+              { port: IntOrString.fromNumber(9464), protocol: "TCP" },
+              { port: IntOrString.fromNumber(9465), protocol: "TCP" },
+            ],
+          },
+        ],
+        egress: [
+          {
+            to: [
+              {
+                namespaceSelector: {},
+                podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+              },
+            ],
+            ports: [
+              { port: IntOrString.fromNumber(53), protocol: "UDP" },
+              { port: IntOrString.fromNumber(53), protocol: "TCP" },
+            ],
+          },
+          {
+            to: [{ podSelector: { matchLabels: { app: "temporal-server" } } }],
+            ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
+          },
+          { ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }] },
+          { ports: [{ port: IntOrString.fromNumber(4318), protocol: "TCP" }] },
+        ],
+      },
+    });
+  }
+
+  new KubeNetworkPolicy(chart, "temporal-gateway-ingress-netpol", {
+    metadata: { name: "temporal-gateway-ingress-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "gateway" } },
+      policyTypes: ["Ingress", "Egress"],
+      ingress: [
+        {
+          from: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  "kubernetes.io/metadata.name": "cloudflare-tunnel",
+                },
+              },
+            },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(9466), protocol: "TCP" },
+            { port: IntOrString.fromNumber(9467), protocol: "TCP" },
+            { port: IntOrString.fromNumber(9468), protocol: "TCP" },
+            { port: IntOrString.fromNumber(9469), protocol: "TCP" },
+          ],
+        },
+      ],
+      egress: [
+        { ports: [{ port: IntOrString.fromNumber(9093), protocol: "TCP" }] },
+      ],
+    },
+  });
+
+  new KubeNetworkPolicy(chart, "temporal-reports-internal-netpol", {
+    metadata: { name: "temporal-reports-internal-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "reports-worker" } },
+      policyTypes: ["Egress"],
+      egress: [
+        { ports: [{ port: IntOrString.fromNumber(5000), protocol: "TCP" }] },
+        { ports: [{ port: IntOrString.fromNumber(9093), protocol: "TCP" }] },
+      ],
+    },
+  });
+
+  new KubeNetworkPolicy(chart, "temporal-infra-api-netpol", {
+    metadata: { name: "temporal-infra-api-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "infra-worker" } },
+      policyTypes: ["Egress"],
+      egress: [
+        { ports: [{ port: IntOrString.fromNumber(6443), protocol: "TCP" }] },
+        { ports: [{ port: IntOrString.fromNumber(9090), protocol: "TCP" }] },
+        { ports: [{ port: IntOrString.fromNumber(7341), protocol: "TCP" }] },
+      ],
+    },
+  });
+
+  new KubeNetworkPolicy(chart, "temporal-worker-freshrss-netpol", {
+    metadata: { name: "temporal-worker-freshrss-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "repo-worker" } },
+      policyTypes: ["Egress"],
+      egress: [
+        {
+          to: [
+            {
+              namespaceSelector: {
+                matchLabels: {
+                  "kubernetes.io/metadata.name": "freshrss",
+                },
+              },
+              podSelector: { matchLabels: { app: "freshrss" } },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(80), protocol: "TCP" }],
+        },
+      ],
+    },
+  });
+
+  createTemporalScoutBetaNetworkPolicy(chart);
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
@@ -147,6 +147,17 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
     },
   });
 
+  new KubeNetworkPolicy(chart, "temporal-repo-alertmanager-netpol", {
+    metadata: { name: "temporal-repo-alertmanager-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "repo-worker" } },
+      policyTypes: ["Egress"],
+      egress: [
+        { ports: [{ port: IntOrString.fromNumber(9093), protocol: "TCP" }] },
+      ],
+    },
+  });
+
   new KubeNetworkPolicy(chart, "temporal-infra-api-netpol", {
     metadata: { name: "temporal-infra-api-netpol" },
     spec: {

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-rbac.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-rbac.ts
@@ -9,11 +9,17 @@ import {
 
 export function createTemporalWorkerServiceAccount(
   chart: Chart,
+  props: { constructId?: string; name?: string } = {},
 ): ServiceAccount {
-  const serviceAccount = new ServiceAccount(chart, "temporal-worker-sa", {
-    metadata: { name: "temporal-worker" },
+  return new ServiceAccount(chart, props.constructId ?? "temporal-worker-sa", {
+    metadata: { name: props.name ?? "temporal-worker" },
   });
+}
 
+export function createTemporalWorkerIngressReaderRbac(
+  chart: Chart,
+  serviceAccounts: readonly ServiceAccount[],
+): void {
   new KubeClusterRole(chart, "temporal-worker-ingress-reader", {
     metadata: { name: "temporal-worker-ingress-reader" },
     rules: [
@@ -32,21 +38,17 @@ export function createTemporalWorkerServiceAccount(
       kind: "ClusterRole",
       name: "temporal-worker-ingress-reader",
     },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: chart.namespace ?? "temporal",
-      },
-    ],
+    subjects: serviceAccounts.map((serviceAccount) => ({
+      kind: "ServiceAccount",
+      name: serviceAccount.name,
+      namespace: serviceAccount.metadata.namespace ?? "temporal",
+    })),
   });
-
-  return serviceAccount;
 }
 
 export function createTemporalWorkerMaintenanceRbac(
   chart: Chart,
-  serviceAccount: ServiceAccount,
+  serviceAccounts: readonly ServiceAccount[],
 ) {
   // Namespace-scoped RBAC for the ZFS maintenance workflow, which lists the
   // zfs-zpool-collector pods and execs into one Running and Ready pod per node
@@ -74,13 +76,11 @@ export function createTemporalWorkerMaintenanceRbac(
       kind: "Role",
       name: "temporal-worker-zfs-exec",
     },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: chart.namespace ?? "temporal",
-      },
-    ],
+    subjects: serviceAccounts.map((serviceAccount) => ({
+      kind: "ServiceAccount",
+      name: serviceAccount.name,
+      namespace: serviceAccount.metadata.namespace ?? "temporal",
+    })),
   });
 
   // Namespace-scoped RBAC for the Bugsink housekeeping workflow, which execs
@@ -108,13 +108,11 @@ export function createTemporalWorkerMaintenanceRbac(
       kind: "Role",
       name: "temporal-worker-bugsink-exec",
     },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: chart.namespace ?? "temporal",
-      },
-    ],
+    subjects: serviceAccounts.map((serviceAccount) => ({
+      kind: "ServiceAccount",
+      name: serviceAccount.name,
+      namespace: serviceAccount.metadata.namespace ?? "temporal",
+    })),
   });
 
   // Namespace-scoped RBAC for the Velero orphan-snapshot audit workflow.
@@ -144,13 +142,11 @@ export function createTemporalWorkerMaintenanceRbac(
       kind: "Role",
       name: "temporal-worker-velero-backups-read",
     },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: chart.namespace ?? "temporal",
-      },
-    ],
+    subjects: serviceAccounts.map((serviceAccount) => ({
+      kind: "ServiceAccount",
+      name: serviceAccount.name,
+      namespace: serviceAccount.metadata.namespace ?? "temporal",
+    })),
   });
 
   new KubeRole(chart, "temporal-worker-openebs-exec", {
@@ -176,12 +172,10 @@ export function createTemporalWorkerMaintenanceRbac(
       kind: "Role",
       name: "temporal-worker-openebs-exec",
     },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: serviceAccount.name,
-        namespace: chart.namespace ?? "temporal",
-      },
-    ],
+    subjects: serviceAccounts.map((serviceAccount) => ({
+      kind: "ServiceAccount",
+      name: serviceAccount.name,
+      namespace: serviceAccount.metadata.namespace ?? "temporal",
+    })),
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -6,9 +6,7 @@ import {
   Deployment,
   DeploymentStrategy,
   EnvValue,
-  type ISecret,
   Secret,
-  Service,
   ServiceAccount,
   Volume,
 } from "cdk8s-plus-31";
@@ -17,9 +15,7 @@ import {
   setRevisionHistoryLimit,
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
-import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import { vaultItemPath } from "@shepherdjerred/homelab/cdk8s/src/misc/onepassword-vault.ts";
-import { llmArchiveEnvVars } from "@shepherdjerred/homelab/cdk8s/src/misc/llm-archive-env.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 import {
   createTemporalWorkerAuditRbac,
@@ -27,88 +23,26 @@ import {
 } from "./audit-rbac.ts";
 import { createTemporalAgentWorker } from "./agent-worker.ts";
 import { createTemporalWorkerCrdReaderRbac } from "./crd-rbac.ts";
-import { sleepWebhookEnv } from "./http-services.ts";
 import { glitterContextEnv, glitterCorpusEnv } from "./glitter-corpus-env.ts";
 import { createTemporalGlitterWorkers } from "./glitter-worker.ts";
 import { createTemporalIngressWorkers } from "./ingress-workers.ts";
+import { createTemporalLegacyWorkerMetrics } from "./legacy-worker-metrics.ts";
+import {
+  homelabAuditEnv,
+  legacyWorkerEnvironment,
+} from "./legacy-worker-env.ts";
+import { createTemporalOperationsWorkers } from "./operations-workers.ts";
 import { temporalWorkerHealthProbes } from "./worker-health.ts";
 import { FRESHRSS_DESIRED_JSON } from "@shepherdjerred/homelab/cdk8s/src/resources/freshrss-config.ts";
 import {
   createTemporalWorkerMaintenanceRbac,
+  createTemporalWorkerIngressReaderRbac,
   createTemporalWorkerServiceAccount,
 } from "./worker-rbac.ts";
 
 export type CreateTemporalWorkerDeploymentProps = {
   serverServiceName: string;
 };
-
-/**
- * Build a map of `KEY: EnvValue.fromSecretValue(...)` entries for the
- * homelab-audit-daily workflow credentials. Every field is REQUIRED: if a 1P
- * field is unset the pod fails to start (CreateContainerConfigError) rather
- * than booting with a silently-missing secret. This is the fail-fast contract
- * for the whole repo — no `optional: true` on secrets. The 1P item must carry
- * every key referenced here.
- */
-function requiredSecretEnv(
-  secret: ISecret,
-  keys: readonly string[],
-): Record<string, EnvValue> {
-  const env: Record<string, EnvValue> = {};
-  for (const key of keys) {
-    env[key] = EnvValue.fromSecretValue({ secret, key });
-  }
-  return env;
-}
-
-function homelabAuditEnv(secret: ISecret): Record<string, EnvValue> {
-  return {
-    // homelab-audit-daily workflow credentials. All required — a missing 1P
-    // field crash-loops the pod (fail-fast) instead of starting with a gap.
-    BUGSINK_URL: EnvValue.fromValue("https://bugsink.sjer.red"),
-    BUILDKITE_ORGANIZATION_SLUG: EnvValue.fromValue("sjerred"),
-    BUILDKITE_PIPELINE_SLUG: EnvValue.fromValue("monorepo"),
-    PROMETHEUS_URL: EnvValue.fromValue(
-      "http://prometheus-kube-prometheus-prometheus.prometheus:9090",
-    ),
-    // gcx stores its credential in a config file, written by
-    // ensureGcxContext() (src/activities/gcx-context.ts) at audit time from the
-    // GRAFANA_URL/GRAFANA_API_KEY below. Its default location is
-    // $HOME/.config/gcx/config.yaml, which resolves to /home/bun from the
-    // oven/bun base image and is writable by uid 1000. Pinning the path anyway
-    // keeps the credential's location independent of the base image, so a bun
-    // bump that changes HOME cannot silently relocate it.
-    //
-    // The file sits directly under the /tmp mount rather than in a gcx/
-    // subdirectory: /tmp is a fresh emptyDir on every pod start, so any
-    // intermediate directory would have to be created before `gcx login` runs,
-    // and nothing does that. Keeping the path one level deep means there is no
-    // directory to create. Do not reintroduce a subdirectory here without also
-    // creating it in ensureGcxContext().
-    GCX_CONFIG: EnvValue.fromValue("/tmp/gcx-config.yaml"),
-    // Suppress gcx's outbound GitHub release check and anonymous telemetry; a
-    // homelab worker should make no unsolicited egress. ensureGcxContext()
-    // spawns gcx with an allowlisted environment, so both names must stay in
-    // its GCX_INHERITED_ENV or they never reach the process they constrain.
-    GCX_NO_UPDATE_NOTIFIER: EnvValue.fromValue("1"),
-    GCX_TELEMETRY: EnvValue.fromValue("disabled"),
-    ...requiredSecretEnv(secret, [
-      "BUGSINK_TOKEN",
-      "GRAFANA_URL",
-      "GRAFANA_API_KEY",
-      "ARGOCD_SERVER",
-      "ARGOCD_AUTH_TOKEN",
-      "CLOUDFLARE_API_TOKEN",
-      "BUILDKITE_API_TOKEN",
-    ]),
-    ALERT_DASHBOARD_URL: EnvValue.fromValue(
-      "http://alert-dashboard-alert-dashboard-service.alert-dashboard:7341",
-    ),
-    // talosctl reads its config from $TALOSCONFIG; the secret volume below
-    // projects 1P field TALOSCONFIG_YAML to this path.
-    TALOSCONFIG: EnvValue.fromValue("/etc/talos/config"),
-  };
-}
 
 export function createTemporalWorkerDeployment(
   chart: Chart,
@@ -172,6 +106,10 @@ export function createTemporalWorkerDeployment(
   });
 
   const serviceAccount = createTemporalWorkerServiceAccount(chart);
+  const infraServiceAccount = createTemporalWorkerServiceAccount(chart, {
+    constructId: "temporal-infra-worker-sa",
+    name: "temporal-infra-worker",
+  });
   const agentServiceAccount = new ServiceAccount(
     chart,
     "temporal-agent-worker-sa",
@@ -180,16 +118,33 @@ export function createTemporalWorkerDeployment(
     },
   );
 
-  createTemporalWorkerMaintenanceRbac(chart, serviceAccount);
+  createTemporalWorkerIngressReaderRbac(chart, [
+    serviceAccount,
+    infraServiceAccount,
+  ]);
+  createTemporalWorkerMaintenanceRbac(chart, [
+    serviceAccount,
+    infraServiceAccount,
+  ]);
 
   // Cluster-wide read-only RBAC for deterministic collectors and generic
   // report-only investigations. Only the core worker receives the separate
   // TaskNotes exec role; the agent worker cannot exec into any pod.
-  createTemporalWorkerAuditRbac(chart, [serviceAccount, agentServiceAccount]);
-  createTemporalWorkerTasknotesCanaryRbac(chart, serviceAccount);
+  createTemporalWorkerAuditRbac(chart, [
+    serviceAccount,
+    infraServiceAccount,
+    agentServiceAccount,
+  ]);
+  createTemporalWorkerTasknotesCanaryRbac(chart, [
+    serviceAccount,
+    infraServiceAccount,
+  ]);
 
   // Read-only CRD access for homelab-crd-imports-daily. See ./crd-rbac.ts.
-  createTemporalWorkerCrdReaderRbac(chart, serviceAccount);
+  createTemporalWorkerCrdReaderRbac(chart, [
+    serviceAccount,
+    infraServiceAccount,
+  ]);
 
   const deployment = new Deployment(chart, "temporal-worker", {
     replicas: 1,
@@ -238,177 +193,17 @@ export function createTemporalWorkerDeployment(
           limit: Cpu.millis(1500),
         },
         memory: {
-          request: Size.gibibytes(3),
+          request: Size.mebibytes(512),
           limit: Size.gibibytes(6),
         },
       },
       ...temporalWorkerHealthProbes(),
-      envVariables: {
-        TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
-        TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
-        TEMPORAL_WORKER_ROLE: EnvValue.fromValue("legacy"),
-        FRESHRSS_API_URL: EnvValue.fromValue(
-          "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
-        ),
-        FRESHRSS_USER: EnvValue.fromValue("sjerred"),
-        FRESHRSS_CATEGORY: EnvValue.fromValue("Repo Stack"),
-        FRESHRSS_MANIFEST_PATH: EnvValue.fromValue(
-          "/etc/freshrss/desired.json",
-        ),
-        FRESHRSS_API_PASSWORD_FILE: EnvValue.fromValue(
-          "/run/secrets/freshrss/password",
-        ),
-        ENVIRONMENT: EnvValue.fromValue("production"),
-        // Keep headless Claude Agent SDK sessions from starting optional traffic or updates.
-        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: EnvValue.fromValue("1"),
-        DISABLE_AUTOUPDATER: EnvValue.fromValue("1"),
-        // OpenTelemetry tracing → Tempo. initializeTracing() in worker.ts
-        // gates on TELEMETRY_ENABLED.
-        TELEMETRY_ENABLED: EnvValue.fromValue("true"),
-        OTLP_ENDPOINT: EnvValue.fromValue(
-          "http://tempo.tempo.svc.cluster.local:4318",
-        ),
-        TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-worker"),
-        // Git identity for any activity that runs `git commit`.
-        GIT_AUTHOR_NAME: EnvValue.fromValue("temporal-worker[bot]"),
-        GIT_AUTHOR_EMAIL: EnvValue.fromValue("temporal-worker@homelab.local"),
-        GIT_COMMITTER_NAME: EnvValue.fromValue("temporal-worker[bot]"),
-        GIT_COMMITTER_EMAIL: EnvValue.fromValue(
-          "temporal-worker@homelab.local",
-        ),
-        // Trust the in-cluster CA for Bun and @kubernetes/client-node TLS calls.
-        NODE_EXTRA_CA_CERTS: EnvValue.fromValue(
-          "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-        ),
-        // Home Assistant
-        HA_URL: EnvValue.fromSecretValue({ secret, key: "HA_URL" }),
-        HA_TOKEN: EnvValue.fromSecretValue({ secret, key: "HA_TOKEN" }),
-        // S3 / SeaweedFS (for fetcher)
-        S3_BUCKET_NAME: EnvValue.fromSecretValue({
-          secret,
-          key: "S3_BUCKET_NAME",
-        }),
-        S3_ENDPOINT: EnvValue.fromSecretValue({ secret, key: "S3_ENDPOINT" }),
-        S3_KEY: EnvValue.fromValue("data/manifest.json"),
-        S3_REGION: EnvValue.fromValue("us-east-1"),
-        AWS_REGION: EnvValue.fromValue("us-east-1"),
-        AWS_DEFAULT_REGION: EnvValue.fromValue("us-east-1"),
-        S3_FORCE_PATH_STYLE: EnvValue.fromValue("true"),
-        ...llmArchiveEnvVars(),
-        // The deterministic homelab audit stores typed report state and email
-        // acceptance receipts through the shared report sender. Legacy audit
-        // archive variables remain intentionally unwired for history replay.
-        AWS_ACCESS_KEY_ID: EnvValue.fromSecretValue({
-          secret,
-          key: "AWS_ACCESS_KEY_ID",
-        }),
-        AWS_SECRET_ACCESS_KEY: EnvValue.fromSecretValue({
-          secret,
-          key: "AWS_SECRET_ACCESS_KEY",
-        }),
-        ...glitterCorpusEnv(secret, starlightBotSecret),
-        // GitHub
-        GITHUB_APP_ID: EnvValue.fromSecretValue({
-          secret,
-          key: "GITHUB_APP_ID",
-        }),
-        GITHUB_APP_INSTALLATION_ID: EnvValue.fromSecretValue({
-          secret,
-          key: "GITHUB_APP_INSTALLATION_ID",
-        }),
-        GITHUB_APP_PRIVATE_KEY: EnvValue.fromSecretValue({
-          secret,
-          key: "GITHUB_APP_PRIVATE_KEY",
-        }),
-        // GitHub webhook ingest for the merge-conflict check (push +
-        // pull_request) and PR-closed Buildkite build cancellation (closed).
-        // GitHub API, clone, and commit-status operations mint short-lived
-        // installation tokens from the app credentials above.
-        GITHUB_WEBHOOK_SECRET: EnvValue.fromSecretValue({
-          secret,
-          key: "GITHUB_WEBHOOK_SECRET",
-        }),
-        // Claude Code subscription OAuth token — sole auth for every Claude
-        // Agent SDK run (homelab synthesis, generic agent-task, Scout season).
-        // All work bills against the subscription; no direct-provider
-        // inference key is wired here, so a leak cannot start direct-API
-        // billing. Ordinary inference goes through OPENROUTER_API_KEY below.
-        CLAUDE_CODE_OAUTH_TOKEN: EnvValue.fromSecretValue({
-          secret,
-          key: "CLAUDE_CODE_OAUTH_TOKEN",
-        }),
-        GITHUB_WEBHOOK_PORT: EnvValue.fromValue("9466"),
-        AGENT_TASK_API_PORT: EnvValue.fromValue("9467"),
-        AGENT_TASK_API_TOKEN: EnvValue.fromSecretValue({
-          secret,
-          key: "AGENT_TASK_API_TOKEN",
-        }),
-        SCOUT_WEEKLY_PARLAY_CONTROL_URL: EnvValue.fromValue(
-          "http://scout-service-beta.scout-beta.svc.cluster.local:3000/api/internal/weekly-parlays/actions",
-        ),
-        SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN: EnvValue.fromSecretValue({
-          secret: scoutWeeklyParlaySecret,
-          key: "token",
-        }),
-        ...sleepWebhookEnv(secret),
-        // Xcode Cloud webhook receiver (event-bridge/xcode-cloud-webhook.ts).
-        // The receiver only starts when XCODE_CLOUD_WEBHOOK_TOKEN is set; the
-        // token authenticates the unguessable URL path (Xcode Cloud webhooks
-        // carry no signature). On a FAILED/ERRORED iOS build it POSTs a
-        // `severity=warning` alert to Alertmanager, which the existing route
-        // forwards to the Alerts dashboard. Required — the 1P item carries
-        // XCODE_CLOUD_WEBHOOK_TOKEN.
-        XCODE_CLOUD_WEBHOOK_PORT: EnvValue.fromValue("9468"),
-        XCODE_CLOUD_WEBHOOK_TOKEN: EnvValue.fromSecretValue({
-          secret,
-          key: "XCODE_CLOUD_WEBHOOK_TOKEN",
-        }),
-        // In-cluster Alertmanager write API. Non-sensitive; a plain literal.
-        ALERTMANAGER_URL: EnvValue.fromValue(
-          "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
-        ),
-        // Bugsink (Sentry-compatible) error tracking. Read by initSentry()
-        // in worker.ts. Required — the 1P item carries SENTRY_DSN.
-        SENTRY_DSN: EnvValue.fromSecretValue({
-          secret,
-          key: "SENTRY_DSN",
-        }),
-        // OpenRouter ordinary inference and Codex SDK agent auth are separate,
-        // service-scoped credentials. No direct provider API key is injected.
-        OPENROUTER_API_KEY: EnvValue.fromSecretValue({
-          secret,
-          key: "OPENROUTER_API_KEY",
-        }),
-        CODEX_ACCESS_TOKEN: EnvValue.fromSecretValue({
-          secret,
-          key: "CODEX_ACCESS_TOKEN",
-        }),
-        // Postal email
-        POSTAL_HOST: EnvValue.fromSecretValue({ secret, key: "POSTAL_HOST" }),
-        POSTAL_HOST_HEADER: EnvValue.fromSecretValue({
-          secret,
-          key: "POSTAL_HOST_HEADER",
-        }),
-        POSTAL_API_KEY: EnvValue.fromSecretValue({
-          secret,
-          key: "POSTAL_API_KEY",
-        }),
-        RECIPIENT_EMAIL: EnvValue.fromSecretValue({
-          secret,
-          key: "RECIPIENT_EMAIL",
-        }),
-        // Sender domain must have valid SPF/DKIM for the recipient's mail
-        // server to accept delivery. The previous literal `updates@homelab.local`
-        // was non-routable and got silently dropped by external recipients.
-        // Sourced from 1Password (item `temporal-temporal-worker-1p`, key
-        // `SENDER_EMAIL`) so the address can rotate without code changes.
-        // Required — the 1P item carries SENDER_EMAIL.
-        SENDER_EMAIL: EnvValue.fromSecretValue({
-          secret,
-          key: "SENDER_EMAIL",
-        }),
-        ...homelabAuditEnv(secret),
-      },
+      envVariables: legacyWorkerEnvironment({
+        serverServiceName: props.serverServiceName,
+        secret,
+        starlightBotSecret,
+        scoutWeeklyParlaySecret,
+      }),
     }),
   );
 
@@ -555,39 +350,19 @@ export function createTemporalWorkerDeployment(
   );
   container.mount("/etc/talos", talosConfigVolume, { readOnly: true });
 
-  // Service + ServiceMonitor for the Temporal SDK's built-in Prometheus
-  // bridge on :9464.
-  new Service(chart, "temporal-worker-metrics-service", {
-    selector: deployment,
-    metadata: {
-      labels: { app: "temporal-worker-metrics" },
-    },
-    ports: [{ port: 9464, name: "metrics" }],
-  });
+  const { infraDeployment, repoDeployment, scoutDeployment } =
+    createTemporalOperationsWorkers(chart, {
+      serverServiceName: props.serverServiceName,
+      secret,
+      scoutWeeklyParlaySecret,
+      infraServiceAccount,
+      homelabAuditEnvironment: homelabAuditEnv(secret),
+      talosConfigVolume,
+      freshRssManifestVolume,
+      freshRssCredentialVolume,
+    });
 
-  createServiceMonitor(chart, {
-    name: "temporal-worker-metrics",
-    matchLabels: { app: "temporal-worker-metrics" },
-  });
-
-  // Service + ServiceMonitor for the application Prometheus registry on
-  // :9465 (started by observability/metrics.ts in the worker). Separate
-  // from the SDK bridge so app-level handles can evolve independently.
-  new Service(chart, "temporal-worker-app-metrics-service", {
-    metadata: {
-      name: "temporal-worker-app-metrics",
-      labels: { app: "temporal-worker-app-metrics" },
-    },
-    selector: deployment,
-    ports: [{ name: "app-metrics", port: 9465, targetPort: 9465 }],
-  });
-
-  createServiceMonitor(chart, {
-    name: "temporal-worker-app-metrics",
-    port: "app-metrics",
-    interval: "30s",
-    matchLabels: { app: "temporal-worker-app-metrics" },
-  });
+  createTemporalLegacyWorkerMetrics(chart);
 
   return {
     deployment,
@@ -595,6 +370,9 @@ export function createTemporalWorkerDeployment(
     gatewayDeployment,
     homeDeployment,
     reportsDeployment,
+    infraDeployment,
+    repoDeployment,
+    scoutDeployment,
     glitterCorpusDeployment: corpusDeployment,
     glitterContextDeployment: contextDeployment,
   };

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -91,7 +91,7 @@ describe("Scout weekly parlay deployment boundary", () => {
     ).toBe(false);
   });
 
-  test("keeps staged Scout access limited to Temporal workers", () => {
+  test("allows only the Temporal Scout worker to reach Beta Scout", () => {
     const beta = scoutResources("beta");
     const policy = findResource(beta, "NetworkPolicy", "scout-ingress-netpol");
     expect(policy.spec).toEqual(
@@ -107,8 +107,7 @@ describe("Scout weekly parlay deployment boundary", () => {
                 },
                 podSelector: {
                   matchLabels: {
-                    app: "temporal-worker",
-                    component: "core-worker",
+                    component: "scout-worker",
                   },
                 },
               },
@@ -129,8 +128,7 @@ describe("Scout weekly parlay deployment boundary", () => {
       expect.objectContaining({
         podSelector: {
           matchLabels: {
-            app: "temporal-worker",
-            component: "legacy-worker",
+            component: "scout-worker",
           },
         },
         egress: [

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -91,7 +91,7 @@ describe("Scout weekly parlay deployment boundary", () => {
     ).toBe(false);
   });
 
-  test("allows only the Temporal Scout worker to reach Beta Scout", () => {
+  test("allows the Scout and legacy Temporal workers to reach Beta Scout", () => {
     const beta = scoutResources("beta");
     const policy = findResource(beta, "NetworkPolicy", "scout-ingress-netpol");
     expect(policy.spec).toEqual(
@@ -108,6 +108,18 @@ describe("Scout weekly parlay deployment boundary", () => {
                 podSelector: {
                   matchLabels: {
                     component: "scout-worker",
+                  },
+                },
+              },
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    "kubernetes.io/metadata.name": "temporal",
+                  },
+                },
+                podSelector: {
+                  matchLabels: {
+                    component: "legacy-worker",
                   },
                 },
               },
@@ -129,6 +141,36 @@ describe("Scout weekly parlay deployment boundary", () => {
         podSelector: {
           matchLabels: {
             component: "scout-worker",
+          },
+        },
+        egress: [
+          {
+            to: [
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    "kubernetes.io/metadata.name": "scout-beta",
+                  },
+                },
+                podSelector: { matchLabels: { app: "scout-backend" } },
+              },
+            ],
+            ports: [{ port: 3000, protocol: "TCP" }],
+          },
+        ],
+      }),
+    );
+
+    const legacyEgressPolicy = findResource(
+      temporal,
+      "NetworkPolicy",
+      "temporal-legacy-worker-scout-beta-netpol",
+    );
+    expect(legacyEgressPolicy.spec).toEqual(
+      expect.objectContaining({
+        podSelector: {
+          matchLabels: {
+            component: "legacy-worker",
           },
         },
         egress: [

--- a/packages/homelab/src/cdk8s/src/temporal-agent-network-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-agent-network-boundary.test.ts
@@ -60,7 +60,8 @@ const NetworkPolicySchema = z.object({
               z.object({
                 podSelector: z
                   .object({
-                    matchLabels: z.record(z.string(), z.string()),
+                    matchLabels: z.record(z.string(), z.string()).optional(),
+                    matchExpressions: z.array(z.unknown()).optional(),
                   })
                   .optional(),
               }),
@@ -198,15 +199,18 @@ describe("Temporal agent provider network boundary", () => {
       throw new Error("Temporal worker network policies were not synthesized");
     }
 
-    expect(core.spec.podSelector.matchLabels["app"]).toBe("temporal-worker");
-    expect(agent.spec.podSelector.matchLabels["app"]).toBe(
-      "temporal-agent-worker",
+    expect(core.spec.podSelector.matchLabels["component"]).toBe(
+      "legacy-worker",
+    );
+    expect(agent.spec.podSelector.matchLabels["component"]).toBe(
+      "agent-worker",
     );
     expect(
       (server.spec.ingress ?? []).some((entry) =>
         (entry.from ?? []).some(
           (source) =>
-            source.podSelector?.matchLabels["app"] === "temporal-agent-worker",
+            source.podSelector?.matchLabels?.["app"] ===
+            "temporal-agent-worker",
         ),
       ),
     ).toBe(true);

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -426,6 +426,78 @@ describe("Temporal domain worker isolation", () => {
       expect(homeEnv).not.toContain(required);
     }
   });
+});
+
+describe("Temporal operations worker isolation", () => {
+  it("isolates infra, repo, and Scout identities, resources, and credentials", async () => {
+    const deployments = parseDeployments(await synthesizeApp());
+    const infra = requireDeployment(
+      deployments,
+      "temporal-temporal-infra-worker",
+    );
+    const repo = requireDeployment(
+      deployments,
+      "temporal-temporal-repo-worker",
+    );
+    const scout = requireDeployment(
+      deployments,
+      "temporal-temporal-scout-worker",
+    );
+
+    expect(infra.spec.template.spec).toMatchObject({
+      automountServiceAccountToken: true,
+      serviceAccountName: "temporal-infra-worker",
+    });
+    expect(repo.spec.template.spec).toMatchObject({
+      automountServiceAccountToken: false,
+      serviceAccountName: "temporal-repo-worker",
+    });
+    expect(scout.spec.template.spec).toMatchObject({
+      automountServiceAccountToken: false,
+      serviceAccountName: "temporal-scout-worker",
+    });
+    expect(infra.spec.template.spec.containers[0]?.resources).toEqual({
+      limits: { cpu: "1500m", memory: "6144Mi" },
+      requests: { cpu: "500m", memory: "2048Mi" },
+    });
+    expect(repo.spec.template.spec.containers[0]?.resources).toEqual({
+      limits: { cpu: "1500m", memory: "4096Mi" },
+      requests: { cpu: "250m", memory: "512Mi" },
+    });
+    expect(scout.spec.template.spec.containers[0]?.resources).toEqual({
+      limits: { cpu: "1500m", memory: "4096Mi" },
+      requests: { cpu: "250m", memory: "512Mi" },
+    });
+
+    const infraEnv = envNames(infra);
+    const repoEnv = envNames(repo);
+    const scoutEnv = envNames(scout);
+    for (const required of [
+      "TALOSCONFIG",
+      "GRAFANA_API_KEY",
+      "ARGOCD_AUTH_TOKEN",
+    ]) {
+      expect(infraEnv).toContain(required);
+      expect(repoEnv).not.toContain(required);
+      expect(scoutEnv).not.toContain(required);
+    }
+    for (const required of [
+      "FRESHRSS_API_PASSWORD_FILE",
+      "BUILDKITE_API_TOKEN",
+      "OPENROUTER_API_KEY",
+    ]) {
+      expect(repoEnv).toContain(required);
+      expect(scoutEnv).not.toContain(required);
+    }
+    for (const required of [
+      "SCOUT_WEEKLY_PARLAY_CONTROL_URL",
+      "SCOUT_WEEKLY_PARLAY_CONTROL_TOKEN",
+    ]) {
+      expect(scoutEnv).toContain(required);
+      expect(repoEnv).not.toContain(required);
+      expect(infraEnv).not.toContain(required);
+    }
+  });
 
   it("enables Temporal worker observability dynamic config with v1.29 key casing", async () => {
     const resources = parseResources(await synthesizeApp());
@@ -502,6 +574,7 @@ describe("temporal homelab audit tooling access boundaries", () => {
     );
     expect(auditBinding?.subjects?.map((subject) => subject.name)).toEqual([
       "temporal-worker",
+      "temporal-infra-worker",
       "temporal-agent-worker",
     ]);
   });

--- a/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
@@ -165,5 +165,25 @@ describe("Temporal FreshRSS integration", () => {
         },
       ],
     });
+
+    const alertmanagerPolicy = findResource(
+      synthesized,
+      "NetworkPolicy",
+      "temporal-repo-alertmanager-netpol",
+    );
+    const alertmanagerPolicySpec = z
+      .object({
+        podSelector: z.object({
+          matchLabels: z.record(z.string(), z.string()),
+        }),
+        egress: z.array(z.unknown()),
+      })
+      .parse(alertmanagerPolicy.spec);
+    expect(alertmanagerPolicySpec.podSelector.matchLabels).toEqual({
+      component: "repo-worker",
+    });
+    expect(alertmanagerPolicySpec.egress).toContainEqual({
+      ports: [{ port: 9093, protocol: "TCP" }],
+    });
   });
 });

--- a/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
@@ -57,12 +57,12 @@ describe("Temporal FreshRSS integration", () => {
     expect(spec.itemPath).toMatch(/\/items\/freshrss-sync$/u);
   });
 
-  test("configures the legacy worker and scoped FreshRSS network access", () => {
+  test("configures the repo worker and scoped FreshRSS network access", () => {
     const synthesized = resources();
     const deployment = findResource(
       synthesized,
       "Deployment",
-      "temporal-temporal-worker",
+      "temporal-temporal-repo-worker",
     );
     const deploymentSpec = z
       .object({
@@ -101,11 +101,11 @@ describe("Temporal FreshRSS integration", () => {
       .parse(deployment.spec);
     const container = deploymentSpec.template.spec.containers[0];
     if (container === undefined) {
-      throw new Error("Temporal legacy worker container is missing");
+      throw new Error("Temporal repo worker container is missing");
     }
     expect(deploymentSpec.template.metadata.labels).toMatchObject({
       app: "temporal-worker",
-      component: "legacy-worker",
+      component: "repo-worker",
     });
     expect(container.env).toContainEqual({
       name: "FRESHRSS_API_PASSWORD_FILE",
@@ -152,8 +152,7 @@ describe("Temporal FreshRSS integration", () => {
       })
       .parse(policy.spec);
     expect(policySpec.podSelector.matchLabels).toEqual({
-      app: "temporal-worker",
-      component: "legacy-worker",
+      component: "repo-worker",
     });
     expect(policySpec.egress).toContainEqual({
       ports: [{ port: 80, protocol: "TCP" }],

--- a/packages/temporal/scripts/trigger-homelab-audit.ts
+++ b/packages/temporal/scripts/trigger-homelab-audit.ts
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
 
   const handle = await client.workflow.start("runHomelabAuditWorkflow", {
     args: [{ date: args.date }],
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     workflowId,
     workflowExecutionTimeout: "60 minutes",
   });

--- a/packages/temporal/src/activities/golink-sync.ts
+++ b/packages/temporal/src/activities/golink-sync.ts
@@ -41,9 +41,7 @@ async function fetchXsrfToken(pageUrl: string): Promise<string> {
   return match[1];
 }
 
-export type GolinkSyncActivities = typeof golinkSyncActivities;
-
-export const golinkSyncActivities = {
+export const golinkClusterActivities = {
   async listTailscaleIngresses(): Promise<string[]> {
     const networkingApi = getK8sClient();
 
@@ -66,7 +64,11 @@ export const golinkSyncActivities = {
 
     return [...new Set(hostnames)].toSorted();
   },
+};
 
+export type GolinkClusterActivities = typeof golinkClusterActivities;
+
+export const golinkSyncActivities = {
   async getExistingGolinks(golinkUrl: string): Promise<GolinkEntry[]> {
     const response = await fetch(`${golinkUrl}/.export`, {
       headers: { "Sec-Golink": "1" },
@@ -160,3 +162,5 @@ export const golinkSyncActivities = {
     console.warn(`Deleted stale: go/${short}`);
   },
 };
+
+export type GolinkSyncActivities = typeof golinkSyncActivities;

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -64,6 +64,7 @@ export const infraActivities = {
   ...homelabCrdImportsRefreshActivities,
   ...tasknotesCanaryActivities,
   ...golinkClusterActivities,
+  ...ciIoImpactActivities,
 };
 
 export const repoActivities = {
@@ -77,7 +78,6 @@ export const repoActivities = {
   ...pokeemeraldDataRefreshActivities,
   ...observeReviewSignalsActivities,
   ...protobufWatchActivities,
-  ...ciIoImpactActivities,
   ...freshrssActivities,
 };
 

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -2,7 +2,10 @@ import { fetcherActivities } from "./fetcher.ts";
 import { depsSummaryActivities } from "./deps-summary.ts";
 import { depsSummaryLegacyActivities } from "./deps-summary-legacy.ts";
 import { dnsAuditActivities } from "./dns-audit.ts";
-import { golinkSyncActivities } from "./golink-sync.ts";
+import {
+  golinkClusterActivities,
+  golinkSyncActivities,
+} from "./golink-sync.ts";
 import { haActivities } from "./ha.ts";
 import { homelabAuditActivities } from "./homelab-audit.ts";
 import { homelabAuditCollectorActivities } from "./homelab-audit-collectors.ts";
@@ -60,6 +63,7 @@ export const infraActivities = {
   ...veleroOrphanAuditActivities,
   ...homelabCrdImportsRefreshActivities,
   ...tasknotesCanaryActivities,
+  ...golinkClusterActivities,
 };
 
 export const repoActivities = {

--- a/packages/temporal/src/event-bridge/conflict-check-starts.ts
+++ b/packages/temporal/src/event-bridge/conflict-check-starts.ts
@@ -36,7 +36,7 @@ async function startConflictCheck(
   // (Combining reuse=ALLOW_DUPLICATE with conflict=TERMINATE_EXISTING is the
   // current Temporal API for what used to be TERMINATE_IF_RUNNING.)
   await client.workflow.start("checkPrMergeConflictsWorkflow", {
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     workflowId: workflowIdFor(input),
     workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
     workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,

--- a/packages/temporal/src/event-bridge/pr-closed.ts
+++ b/packages/temporal/src/event-bridge/pr-closed.ts
@@ -49,7 +49,7 @@ export async function startCancelBuildkiteBuilds(
   // idempotent path — surface it as an info log, not a failure.
   try {
     await client.workflow.start("cancelBuildkiteBuildsWorkflow", {
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.REPO_AUTOMATION,
       workflowId: cancelBuildkiteWorkflowIdFor(input),
       workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
       args: [input],

--- a/packages/temporal/src/schedules/default-routing.test.ts
+++ b/packages/temporal/src/schedules/default-routing.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "vitest";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { SCHEDULES } from "./schedule-definitions.ts";
+
+test("no active start surface targets the migration-only default queue", async () => {
+  expect(
+    SCHEDULES.every((schedule) => schedule.taskQueue !== TASK_QUEUES.DEFAULT),
+  ).toBe(true);
+
+  const packageRoot = import.meta.dir.replace(/\/src\/schedules$/u, "");
+  const glob = new Bun.Glob("{src/event-bridge,src/workflows,scripts}/**/*.ts");
+  for await (const relativePath of glob.scan({ cwd: packageRoot })) {
+    if (relativePath.endsWith(".test.ts")) {
+      continue;
+    }
+    const source = await Bun.file(`${packageRoot}/${relativePath}`).text();
+    expect(source, relativePath).not.toContain("TASK_QUEUES.DEFAULT");
+    expect(source, relativePath).not.toMatch(/taskQueue:\s*["']default["']/u);
+  }
+});

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -337,12 +337,12 @@ describe("Scout Bryan Bucks analytics schedule config", () => {
 });
 
 describe("Scout competition update schedule", () => {
-  test("uses a Temporal-owned minute trigger on the core queue", () => {
+  test("uses a Temporal-owned minute trigger on the Scout queue", () => {
     const schedule = findScheduleById("scout-competition-updates-minute");
     expect(schedule).toMatchObject({
       workflowType: "runScoutCompetitionUpdatesWorkflow",
       cronExpression: "* * * * *",
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.SCOUT,
       catchupWindow: "5 minutes",
       workflowExecutionTimeout: "35 minutes",
     });

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -78,7 +78,7 @@ test("FreshRSS sync keeps its bounded pre-refresh schedule", () => {
   const schedule = findScheduleById("freshrss-sync-hourly");
   expect(schedule.workflowType).toBe("runFreshRssSyncWorkflow");
   expect(schedule.cronExpression).toBe("7 * * * *");
-  expect(schedule.taskQueue).toBe(TASK_QUEUES.DEFAULT);
+  expect(schedule.taskQueue).toBe(TASK_QUEUES.REPO_AUTOMATION);
   expect(schedule.catchupWindow).toBe("5 minutes");
   expect(schedule.workflowExecutionTimeout).toBe("6 minutes");
 });
@@ -309,7 +309,7 @@ describe("Scout weekly parlay schedule config", () => {
       workflowType: "runScoutWeeklyParlayWorkflow",
       args: [{}],
       cronExpression: "0 12 * * 0",
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.SCOUT,
       overlap: ScheduleOverlapPolicy.ALLOW_ALL,
       requiredEnvironment: [
         "SCOUT_WEEKLY_PARLAY_CONTROL_URL",
@@ -325,7 +325,7 @@ describe("Scout Bryan Bucks analytics schedule config", () => {
       workflowType: "runScoutBryanBucksAnalyticsWorkflow",
       args: [],
       cronExpression: "*/15 * * * *",
-      taskQueue: TASK_QUEUES.DEFAULT,
+      taskQueue: TASK_QUEUES.SCOUT,
       overlap: ScheduleOverlapPolicy.SKIP,
       workflowExecutionTimeout: "5 minutes",
       requiredEnvironment: [

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -97,7 +97,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runCiIoImpact",
     args: [],
     cronExpression: "0 9 * * *",
-    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "2 hours",
     memo: "Daily deterministic schema-v4 CI I/O impact and observability report",

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -18,7 +18,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "fetchSkillCappedManifest",
     args: [],
     cronExpression: "0 5 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "5 minutes",
     memo: "Fetch Better Skill Capped manifest from Firestore and upload to S3 (daily at 05:00 PT)",
@@ -28,7 +28,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runFreshRssSyncWorkflow",
     args: [],
     cronExpression: "7 * * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     catchupWindow: "5 minutes",
     workflowExecutionTimeout: "6 minutes",
@@ -60,7 +60,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "generateDependencySummary",
     args: [7],
     cronExpression: "0 9 * * 1",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     // Three sequential 10-minute activities can each use three attempts;
     // delivery and checkpoint persistence also retry. Keep enough headroom for
@@ -73,7 +73,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runProtobufWatch",
     args: [],
     cronExpression: "0 9 * * 1",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     // Worst case: three 1m collection attempts, three 2m primary-delivery
     // attempts, then three 2m failure-delivery attempts, plus retry delays and
@@ -87,7 +87,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runTasknotesCanary",
     args: [],
     cronExpression: "0 9 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "20 minutes",
     memo: "Daily typed TaskNotes engine, pod, skipped-file, and accepted task-count baseline check",
@@ -97,7 +97,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runCiIoImpact",
     args: [],
     cronExpression: "0 9 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "2 hours",
     memo: "Daily deterministic schema-v4 CI I/O impact and observability report",
@@ -107,7 +107,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runDnsAudit",
     args: [],
     cronExpression: "0 6 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "5 minutes",
     memo: "Daily DNS record audit (SPF, DMARC, MX)",
@@ -121,7 +121,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     // Renovate merges land), so only a schedule can see it — no CI gate runs
     // when the cluster changes.
     cronExpression: "30 5 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "45 minutes",
     memo: "Daily cdk8s CRD-import refresh — regenerates generated/imports from the live cluster CRDs and opens a PR on drift",
@@ -135,7 +135,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     // pokeemerald or knowledge source advances (hosted Renovate cannot run
     // the generators inside its own PR).
     cronExpression: "30 4 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
     memo: "Daily pokeemerald data refresh — regenerates committed species/map tables and the pinned knowledge corpus, opens a PR on drift",
@@ -147,7 +147,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     // 06:30 PT — staggered after dns-audit-daily (06:00). Lands in inbox
     // before goodMorningEarly (07:00 weekdays / 08:00 weekends) fires.
     cronExpression: "30 6 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "50 minutes",
     memo: "Deterministic daily homelab health check with evidence-backed report delivery",

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -63,7 +63,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutDataDragonVersionCheck",
     args: [],
     cronExpression: "0 6 * * 0-5",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     // Must exceed updateDataDragon's full retry budget so the final attempt's
     // catch always records the outcome="failed" metric before the workflow is
@@ -78,7 +78,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutDataDragonWeeklyRefresh",
     args: [],
     cronExpression: "0 6 * * 6",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     // See scout-data-dragon-version-check above: sized to exceed
     // updateDataDragon's full ~194m retry budget so a terminal failure is
@@ -91,7 +91,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutLanePriorsWeeklyRefresh",
     args: [SCOUT_LANE_PRIOR_UPDATE_CONFIG],
     cronExpression: "0 7 * * 6",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "4 hours",
     memo: "Weekly Scout lane-prior refresh and evaluation",
@@ -103,7 +103,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // 09:00 PT every Monday — staggered after scout-season-refresh (07:00)
     // so the weekly PR-opening jobs don't contend for the worker pod at once.
     cronExpression: "0 9 * * 1",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
     memo: "Weekly LLM model-catalog cross-check vs models.dev, LiteLLM, and OpenRouter (opens a PR on drift)",
@@ -113,7 +113,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutSeasonRefreshWorkflow",
     args: [],
     cronExpression: "0 7 * * 1",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     // Two 30-minute research attempts, their 5-minute backoff, and both
     // possible three-attempt report deliveries fit inside this bound.
@@ -129,7 +129,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // despite the scout-image-gc showcase exemption — re-curate the manifest
     // (scout AGENTS.md runbook) rather than retrying.
     cronExpression: "0 10 * * 1",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "60 minutes",
     memo: "Weekly marketing-showcase refresh — regenerates the committed showcase PNGs + asset index from scout-prod, opens a PR on drift (generatedAt-only churn suppressed)",
@@ -142,7 +142,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // 11:00 PT and owns the reminder, start, six progress updates, and final
     // reconciliation for one immutable period/slot.
     cronExpression: WEEKLY_PARLAY_CRON_EXPRESSION,
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     // Preserve the full Sunday betting window when Temporal itself is down.
     catchupWindow: CATCHUP_WEEKLY_PARLAY,
     // A delayed final reconciliation for one period must not suppress the
@@ -161,7 +161,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutBryanBucksAnalyticsWorkflow",
     args: [],
     cronExpression: "*/15 * * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "5 minutes",
     memo: "Every-15-minute committed Bryan Bucks ledger and economy analytics sync",
@@ -180,7 +180,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // for closes (a human confirms against patch notes), and emails
     // warnings-only runs. Steady state still sends a concise clear heartbeat.
     cronExpression: "45 6 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     // The two 30-minute scan attempts plus 2-minute backoff consume 62 minutes.
     // Reserve the remaining time for a failed success-report delivery and the
@@ -206,7 +206,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runZfsMaintenanceWorkflow",
     args: [],
     cronExpression: "0 3 * * 0",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
     memo: "Weekly ZFS pool scrub + autotrim (zfspv-pool-nvme, zfspv-pool-hdd)",
@@ -238,7 +238,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runBugsinkHousekeepingWorkflow",
     args: [],
     cronExpression: "0 3 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
     memo: "Daily Bugsink database housekeeping (delete old events, vacuum)",
@@ -250,7 +250,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // 04:00 PT — after the 03:00 bugsink/zfs maintenance window so the nightly
     // destructive jobs don't contend for the worker pod at once.
     cronExpression: "0 4 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     // First run sweeps ~110k objects and deletes ~38k; steady-state runs finish
     // in <1m. This workflow-level cap must fit the activity's full retry budget,
@@ -314,7 +314,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // 03:30 PT — staggered after zfs-maintenance so the audit captures a
     // stable post-backup state.
     cronExpression: "30 3 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.INFRA,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "15 minutes",
     memo: "Daily Velero orphan ZFS snapshot detection — emits Prometheus metrics for the orphan-snapshot pathology.",
@@ -326,7 +326,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // Every 6 hours — frequent enough to catch same-day review latency
     // patterns without hammering the GitHub API on every recent PR.
     cronExpression: "0 */6 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     // Must fit the activity's FULL retry budget, not one attempt: the
     // `runObserveReviewSignals` proxy allows 3 attempts at a 5m
@@ -342,7 +342,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "syncGolinks",
     args: [],
     cronExpression: "0 5 * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "4 minutes",
     memo: "Sync Tailscale ingresses to golink aliases (daily 5 AM PT)",

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -193,7 +193,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     workflowType: "runScoutCompetitionUpdatesWorkflow",
     args: [],
     cronExpression: "* * * * *",
-    taskQueue: TASK_QUEUES.DEFAULT,
+    taskQueue: TASK_QUEUES.SCOUT,
     overlap: ScheduleOverlapPolicy.SKIP,
     catchupWindow: CATCHUP_TIGHT,
     // Each stage activity may use three 10-minute attempts. They run in

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -88,6 +88,22 @@ describe("Temporal worker role contracts", () => {
     for (const serialRole of serialRoles) {
       expect(concurrency.get(serialRole)).toBe(1);
     }
+    expect(concurrency.get("legacy")).toBe(1);
+  });
+
+  it("dispatches GoLink cluster reads only through infra", () => {
+    const infra = QUEUE_WORKER_DEFINITIONS.find(
+      (definition) => definition.role === "infra",
+    );
+    const repo = QUEUE_WORKER_DEFINITIONS.find(
+      (definition) => definition.role === "repo",
+    );
+    expect(Object.keys(infra?.activities ?? {})).toContain(
+      "listTailscaleIngresses",
+    );
+    expect(Object.keys(repo?.activities ?? {})).not.toContain(
+      "listTailscaleIngresses",
+    );
   });
 
   it("keeps report delivery capabilities separate from agent execution", () => {

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -106,6 +106,19 @@ describe("Temporal worker role contracts", () => {
     );
   });
 
+  it("dispatches CI I/O observability only through infra", () => {
+    const infra = QUEUE_WORKER_DEFINITIONS.find(
+      (definition) => definition.role === "infra",
+    );
+    const repo = QUEUE_WORKER_DEFINITIONS.find(
+      (definition) => definition.role === "repo",
+    );
+    expect(Object.keys(infra?.activities ?? {})).toContain("collectCiIoImpact");
+    expect(Object.keys(repo?.activities ?? {})).not.toContain(
+      "collectCiIoImpact",
+    );
+  });
+
   it("keeps report delivery capabilities separate from agent execution", () => {
     expect(reportActivities.sendAgentTaskEmail).toBe(
       agentActivities.sendAgentTaskEmail,

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -7,6 +7,12 @@ import {
   type QueueWorkerRole,
 } from "./worker-config.ts";
 
+const DOMAIN_WORKER_QUEUES = Object.values(TASK_QUEUES).filter(
+  (taskQueue) =>
+    taskQueue !== TASK_QUEUES.SCOUT_BETA &&
+    taskQueue !== TASK_QUEUES.SCOUT_PROD,
+);
+
 describe("Temporal worker role contracts", () => {
   it("assigns every queue to exactly one canonical role", () => {
     const ownershipCounts = new Map<string, number>();
@@ -22,9 +28,9 @@ describe("Temporal worker role contracts", () => {
         left.localeCompare(right),
       ),
     ).toEqual(
-      Object.values(TASK_QUEUES)
-        .sort((left, right) => left.localeCompare(right))
-        .map((taskQueue) => [taskQueue, 1]),
+      DOMAIN_WORKER_QUEUES.sort((left, right) => left.localeCompare(right)).map(
+        (taskQueue) => [taskQueue, 1],
+      ),
     );
   });
 
@@ -60,7 +66,7 @@ describe("Temporal worker role contracts", () => {
 
   it("runs every canonical queue and control surface locally", () => {
     const contract = getWorkerRoleContract("all");
-    expect(contract.workers).toHaveLength(Object.values(TASK_QUEUES).length);
+    expect(contract.workers).toHaveLength(DOMAIN_WORKER_QUEUES.length);
     expect(contract.runsGateway).toBe(true);
     expect(contract.validatesScheduleEnvironmentLocally).toBe(true);
     expect(contract.runsEventBridge).toBe(true);

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -77,20 +77,6 @@ export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
     maxConcurrentWorkflowTaskExecutions: 2,
   },
   {
-    role: "scout",
-    taskQueue: TASK_QUEUES.SCOUT_BETA,
-    activities: scoutActivities,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  },
-  {
-    role: "scout",
-    taskQueue: TASK_QUEUES.SCOUT_PROD,
-    activities: scoutActivities,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  },
-  {
     role: "agent",
     taskQueue: TASK_QUEUES.AGENT_TASK,
     activities: agentActivities,

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -77,6 +77,20 @@ export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
     maxConcurrentWorkflowTaskExecutions: 2,
   },
   {
+    role: "scout",
+    taskQueue: TASK_QUEUES.SCOUT_BETA,
+    activities: scoutActivities,
+    maxConcurrentActivityTaskExecutions: 1,
+    maxConcurrentWorkflowTaskExecutions: 2,
+  },
+  {
+    role: "scout",
+    taskQueue: TASK_QUEUES.SCOUT_PROD,
+    activities: scoutActivities,
+    maxConcurrentActivityTaskExecutions: 1,
+    maxConcurrentWorkflowTaskExecutions: 2,
+  },
+  {
     role: "agent",
     taskQueue: TASK_QUEUES.AGENT_TASK,
     activities: agentActivities,

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -38,6 +38,8 @@ export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
     role: "legacy",
     taskQueue: TASK_QUEUES.DEFAULT,
     activities,
+    maxConcurrentActivityTaskExecutions: 1,
+    maxConcurrentWorkflowTaskExecutions: 2,
   },
   {
     role: "home",

--- a/packages/temporal/src/workflows/golink-sync.ts
+++ b/packages/temporal/src/workflows/golink-sync.ts
@@ -1,13 +1,24 @@
 import { proxyActivities } from "@temporalio/workflow";
-import type { GolinkSyncActivities } from "#activities/golink-sync.ts";
+import type {
+  GolinkClusterActivities,
+  GolinkSyncActivities,
+} from "#activities/golink-sync.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 import type { GolinkEntry } from "#shared/types.ts";
 
-const {
-  listTailscaleIngresses,
-  getExistingGolinks,
-  createOrUpdateGolink,
-  deleteStaleGolink,
-} = proxyActivities<GolinkSyncActivities>({
+const { getExistingGolinks, createOrUpdateGolink, deleteStaleGolink } =
+  proxyActivities<GolinkSyncActivities>({
+    startToCloseTimeout: "1 minute",
+    retry: {
+      maximumAttempts: 5,
+      initialInterval: "1s",
+      backoffCoefficient: 2,
+      maximumInterval: "30s",
+    },
+  });
+
+const { listTailscaleIngresses } = proxyActivities<GolinkClusterActivities>({
+  taskQueue: TASK_QUEUES.INFRA,
   startToCloseTimeout: "1 minute",
   retry: {
     maximumAttempts: 5,


### PR DESCRIPTION
## Why

Privileged homelab work, repository automation, and Scout refreshes need separate task queues, credentials, Kubernetes identities, and failure domains.

## What

- route all infra, repository, GitHub-event, and Scout starts to explicit queues
- add single-replica infra, repo, and Scout workers with exact resources and allowlisted credentials
- reserve broad audit/exec RBAC and Kubernetes token access for infra
- reduce the legacy drain worker to one activity and 512 MiB requested memory
- add per-queue poller, backlog, schedule-to-start, scrape, and pod-readiness alerts
- statically assert that no active schedule or production start site targets `default`

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal`
- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`

This is a non-visual runtime and infrastructure change; no media is required. No live deployment, representative external-effect check, or default-queue drain check was run.