### PR TITLE
feat(scout-for-lol): control Bryan Bucks settlement DMs

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -334,7 +334,7 @@ const commands: Record<
       // BuildKit can reuse a smoke network namespace while another image is
       // probing its worker. Reserve ephemeral ports for this invocation so a
       // concurrent Scout smoke cannot collide with the fixed service ports.
-      String.raw`ports="$(bun -e 'const listeners = [0, 0].map(() => Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } })); console.log(listeners.map((listener) => listener.port).join(" ")); for (const listener of listeners) listener.stop();')"`,
+      `ports="$(bun -e 'const listeners = [0, 0].map(() => Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } })); console.log(listeners.map((listener) => listener.port).join(" ")); for (const listener of listeners) listener.stop();')"`,
       "set -- $ports",
       'pg_port="$1"',
       'http_port="$2"',

--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -331,18 +331,21 @@ const commands: Record<
     command: [
       "set -eu",
       "cd /app/packages/scout-for-lol/packages/backend",
+      // BuildKit can reuse a smoke network namespace while another image is
+      // probing its worker. Reserve ephemeral ports for this invocation so a
+      // concurrent Scout smoke cannot collide with the fixed service ports.
+      String.raw`ports="$(bun -e 'const listeners = [0, 0].map(() => Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } })); console.log(listeners.map((listener) => listener.port).join(" ")); for (const listener of listeners) listener.stop();')"`,
+      "set -- $ports",
+      'pg_port="$1"',
+      'http_port="$2"',
+      'export DATABASE_URL="postgres://postgres@127.0.0.1:${pg_port}/postgres"',
+      'export PORT="$http_port"',
       // Throwaway Postgres inside the smoke stage (apt postgresql). Resolve
       // the installed major version through pg_config; Debian's package
       // version is independent of the runtime image's base distribution.
       'postgres_bin="$(pg_config --bindir)"',
       '"$postgres_bin/initdb" -D /tmp/smoke-pg -U postgres --auth=trust --no-locale >/dev/null',
-      // Remote BuildKit can run multiple smoke stages on one builder. Retry a
-      // bounded port range so another concurrent smoke cannot make this
-      // otherwise isolated database fail before the app starts.
-      'smoke_pg_port=""',
-      'for candidate_port in $(seq 18732 18742); do if "$postgres_bin/pg_ctl" -D /tmp/smoke-pg -w -t 5 -l /tmp/smoke-pg.log -o "-p $candidate_port -c listen_addresses=127.0.0.1 -c unix_socket_directories=/tmp" start; then smoke_pg_port="$candidate_port"; break; fi; done',
-      '[ -n "$smoke_pg_port" ] || { cat /tmp/smoke-pg.log; exit 1; }',
-      'export DATABASE_URL="postgres://postgres@127.0.0.1:${smoke_pg_port}/postgres"',
+      'if ! "$postgres_bin/pg_ctl" -D /tmp/smoke-pg -w -t 30 -l /tmp/smoke-pg.log -o "-p ${pg_port} -c listen_addresses=127.0.0.1 -c unix_socket_directories=/tmp" start; then cat /tmp/smoke-pg.log; exit 1; fi',
       "set +e",
       // Mirror the full image CMD: migrate → legacy import (which must take
       // its fresh-install marker path here) → report audit → boot.
@@ -364,6 +367,8 @@ const commands: Record<
       ENABLE_DISCORD_GATEWAY: "false",
       ENABLE_BACKGROUND_JOBS: "false",
       REPORT_LAKE_DIR: "/tmp/report-lake",
+      // Keep an explicit contract port for CI migration validation; the
+      // command above overrides it with a per-invocation ephemeral port.
       PORT: "18791",
     },
   },

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260824040000_bucks_notification_preferences/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260824040000_bucks_notification_preferences/migration.sql
@@ -1,0 +1,16 @@
+-- Per-user Bryan Bucks settlement DM preferences default to the current
+-- behavior so existing users continue receiving both categories.
+CREATE TABLE "BucksNotificationPreference" (
+    "id" SERIAL NOT NULL,
+    "serverId" TEXT NOT NULL,
+    "discordId" TEXT NOT NULL,
+    "ownBetSettlementDms" BOOLEAN NOT NULL DEFAULT true,
+    "betsOnPlayerSettlementDms" BOOLEAN NOT NULL DEFAULT true,
+    "settlementDmHintShownAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "BucksNotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "BucksNotificationPreference_serverId_discordId_key"
+ON "BucksNotificationPreference"("serverId", "discordId");

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -812,6 +812,22 @@ model BucksAccount {
   @@index([serverId, balance])
 }
 
+// Per-user Bryan Bucks settlement DM preferences. Missing rows intentionally
+// resolve to both settings enabled so adding this table preserves the existing
+// beta behavior for users who have not visited `/bb notifications` yet.
+model BucksNotificationPreference {
+  id                        Int      @id @default(autoincrement())
+  serverId                  String
+  discordId                 String
+  ownBetSettlementDms       Boolean  @default(true)
+  betsOnPlayerSettlementDms Boolean  @default(true)
+  settlementDmHintShownAt   DateTime?
+  createdAt                 DateTime @default(now())
+  updatedAt                 DateTime @updatedAt
+
+  @@unique([serverId, discordId])
+}
+
 // Durable reservation for a Bryan Bucks PostHog event. PostHog's event UUID is
 // deterministic for replay, while this beta database is the idempotency
 // boundary for both the historical backfill and the post-commit live sync.

--- a/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { executeBb } from "#src/discord/commands/bb.ts";
+import { formatBucksNotificationPreferences } from "#src/discord/commands/bb-notifications.ts";
+import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
+import {
+  getBucksNotificationPreferences,
+  markBucksSettlementDmHintShown,
+  updateBucksNotificationPreferences,
+} from "#src/betting/notification-preferences.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+
+const { prisma: db } = createTestDatabase("bucks-notification-preferences");
+const SERVER = DiscordGuildIdSchema.parse("1337623164146155593");
+const USER = bucksTestDiscordId(20);
+
+beforeEach(async () => {
+  await db.bucksNotificationPreference.deleteMany();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+});
+
+describe("Bryan Bucks notification preferences", () => {
+  test("defaults both categories to enabled without a row", async () => {
+    await expect(
+      getBucksNotificationPreferences(
+        { serverId: SERVER, discordId: USER },
+        db,
+      ),
+    ).resolves.toEqual({
+      ownBetSettlementDms: true,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: null,
+    });
+  });
+
+  test("records the settlement hint without changing notification settings", async () => {
+    await markBucksSettlementDmHintShown(
+      { serverId: SERVER, discordId: USER },
+      db,
+    );
+
+    const preferences = await getBucksNotificationPreferences(
+      { serverId: SERVER, discordId: USER },
+      db,
+    );
+    expect(preferences.ownBetSettlementDms).toBe(true);
+    expect(preferences.betsOnPlayerSettlementDms).toBe(true);
+    expect(preferences.settlementDmHintShownAt).toEqual(expect.any(Date));
+  });
+
+  test("updates one category without changing the other", async () => {
+    await expect(
+      updateBucksNotificationPreferences(
+        {
+          serverId: SERVER,
+          discordId: USER,
+          updates: { ownBetSettlementDms: false },
+        },
+        db,
+      ),
+    ).resolves.toEqual({
+      ownBetSettlementDms: false,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: null,
+    });
+
+    await expect(
+      updateBucksNotificationPreferences(
+        {
+          serverId: SERVER,
+          discordId: USER,
+          updates: { betsOnPlayerSettlementDms: false },
+        },
+        db,
+      ),
+    ).resolves.toEqual({
+      ownBetSettlementDms: false,
+      betsOnPlayerSettlementDms: false,
+      settlementDmHintShownAt: null,
+    });
+  });
+
+  test("formats status-only and changed responses", () => {
+    expect(
+      formatBucksNotificationPreferences(
+        {
+          ownBetSettlementDms: true,
+          betsOnPlayerSettlementDms: false,
+          settlementDmHintShownAt: null,
+        },
+        {},
+      ),
+    ).toContain("Use `your_bets` or `bets_on_you`");
+    expect(
+      formatBucksNotificationPreferences(
+        {
+          ownBetSettlementDms: false,
+          betsOnPlayerSettlementDms: true,
+          settlementDmHintShownAt: null,
+        },
+        { ownBetSettlementDms: false },
+      ),
+    ).toContain("Updated: your bets off.");
+  });
+
+  test("runs /bb notifications privately and updates independent settings", async () => {
+    const values = new Map<string, boolean>([
+      ["your_bets", false],
+      ["bets_on_you", true],
+    ]);
+    const interaction = fakeNotificationsInteraction({
+      yourBets: "off",
+      betsOnYou: "on",
+    });
+    await executeBb(interaction, {
+      isPolicyEnabled: async () => true,
+      getNotificationPreferences: async () => ({
+        ownBetSettlementDms: values.get("your_bets") ?? true,
+        betsOnPlayerSettlementDms: values.get("bets_on_you") ?? true,
+        settlementDmHintShownAt: null,
+      }),
+      updateNotificationPreferences: async ({ updates }) => {
+        if (updates.ownBetSettlementDms !== undefined) {
+          values.set("your_bets", updates.ownBetSettlementDms);
+        }
+        if (updates.betsOnPlayerSettlementDms !== undefined) {
+          values.set("bets_on_you", updates.betsOnPlayerSettlementDms);
+        }
+        return {
+          ownBetSettlementDms: values.get("your_bets") ?? true,
+          betsOnPlayerSettlementDms: values.get("bets_on_you") ?? true,
+          settlementDmHintShownAt: null,
+        };
+      },
+    });
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining("Updated: your bets off"),
+    });
+  });
+});
+
+function fakeNotificationsInteraction(input: {
+  yourBets: string;
+  betsOnYou: string;
+}): BbCommandInteraction {
+  return {
+    id: "bb-notifications-test",
+    guildId: SERVER,
+    user: { id: USER },
+    options: {
+      getSubcommand: () => "notifications",
+      getString: (name: string) =>
+        name === "your_bets" ? input.yourBets : input.betsOnYou,
+      getInteger: () => 1,
+    },
+    replied: false,
+    deferred: false,
+    reply: vi.fn(() => Promise.resolve(undefined)),
+    deferReply: vi.fn(() => Promise.resolve(undefined)),
+    editReply: vi.fn(() => Promise.resolve(undefined)),
+    followUp: vi.fn(() => Promise.resolve(undefined)),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.ts
@@ -1,0 +1,158 @@
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+
+export type BucksNotificationPreferences = {
+  ownBetSettlementDms: boolean;
+  betsOnPlayerSettlementDms: boolean;
+  settlementDmHintShownAt: Date | null;
+};
+
+export type BucksNotificationPreferenceUpdates = {
+  ownBetSettlementDms?: boolean;
+  betsOnPlayerSettlementDms?: boolean;
+};
+
+const DEFAULT_PREFERENCES: BucksNotificationPreferences = {
+  ownBetSettlementDms: true,
+  betsOnPlayerSettlementDms: true,
+  settlementDmHintShownAt: null,
+};
+
+function parseIds(input: { serverId: string; discordIds: readonly string[] }): {
+  serverId: DiscordGuildId;
+  discordIds: DiscordAccountId[];
+} {
+  return {
+    serverId: DiscordGuildIdSchema.parse(input.serverId),
+    discordIds: input.discordIds.map((discordId) =>
+      DiscordAccountIdSchema.parse(discordId),
+    ),
+  };
+}
+
+function preferencesFromRow(
+  row: {
+    ownBetSettlementDms: boolean;
+    betsOnPlayerSettlementDms: boolean;
+    settlementDmHintShownAt: Date | null;
+  } | null,
+): BucksNotificationPreferences {
+  return row === null
+    ? { ...DEFAULT_PREFERENCES }
+    : {
+        ownBetSettlementDms: row.ownBetSettlementDms,
+        betsOnPlayerSettlementDms: row.betsOnPlayerSettlementDms,
+        settlementDmHintShownAt: row.settlementDmHintShownAt,
+      };
+}
+
+export async function getBucksNotificationPreferences(
+  input: { serverId: string; discordId: string },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<BucksNotificationPreferences> {
+  const serverId = DiscordGuildIdSchema.parse(input.serverId);
+  const discordId = DiscordAccountIdSchema.parse(input.discordId);
+  const row = await prismaClient.bucksNotificationPreference.findUnique({
+    where: { serverId_discordId: { serverId, discordId } },
+    select: {
+      ownBetSettlementDms: true,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: true,
+    },
+  });
+  return preferencesFromRow(row);
+}
+
+export async function getBucksNotificationPreferencesForUsers(
+  input: { serverId: string; discordIds: readonly string[] },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<ReadonlyMap<string, BucksNotificationPreferences>> {
+  const { serverId, discordIds } = parseIds(input);
+  if (discordIds.length === 0) {
+    return new Map();
+  }
+
+  const rows = await prismaClient.bucksNotificationPreference.findMany({
+    where: { serverId, discordId: { in: discordIds } },
+    select: {
+      discordId: true,
+      ownBetSettlementDms: true,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: true,
+    },
+  });
+  return new Map(rows.map((row) => [row.discordId, preferencesFromRow(row)]));
+}
+
+export async function updateBucksNotificationPreferences(
+  input: {
+    serverId: string;
+    discordId: string;
+    updates: BucksNotificationPreferenceUpdates;
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<BucksNotificationPreferences> {
+  const serverId = DiscordGuildIdSchema.parse(input.serverId);
+  const discordId = DiscordAccountIdSchema.parse(input.discordId);
+  if (
+    input.updates.ownBetSettlementDms === undefined &&
+    input.updates.betsOnPlayerSettlementDms === undefined
+  ) {
+    return await getBucksNotificationPreferences(
+      { serverId, discordId },
+      prismaClient,
+    );
+  }
+
+  const row = await prismaClient.bucksNotificationPreference.upsert({
+    where: { serverId_discordId: { serverId, discordId } },
+    create: {
+      serverId,
+      discordId,
+      ownBetSettlementDms: input.updates.ownBetSettlementDms ?? true,
+      betsOnPlayerSettlementDms:
+        input.updates.betsOnPlayerSettlementDms ?? true,
+    },
+    update: {
+      ...(input.updates.ownBetSettlementDms === undefined
+        ? {}
+        : { ownBetSettlementDms: input.updates.ownBetSettlementDms }),
+      ...(input.updates.betsOnPlayerSettlementDms === undefined
+        ? {}
+        : {
+            betsOnPlayerSettlementDms: input.updates.betsOnPlayerSettlementDms,
+          }),
+    },
+    select: {
+      ownBetSettlementDms: true,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: true,
+    },
+  });
+  return preferencesFromRow(row);
+}
+
+export async function markBucksSettlementDmHintShown(
+  input: { serverId: string; discordId: string },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  const serverId = DiscordGuildIdSchema.parse(input.serverId);
+  const discordId = DiscordAccountIdSchema.parse(input.discordId);
+  await prismaClient.bucksNotificationPreference.upsert({
+    where: { serverId_discordId: { serverId, discordId } },
+    create: {
+      serverId,
+      discordId,
+      ownBetSettlementDms: true,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: new Date(),
+    },
+    update: { settlementDmHintShownAt: new Date() },
+    select: { id: true },
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm-delivery.ts
@@ -17,6 +17,10 @@ import type { SettlementSummary } from "#src/betting/settle.ts";
 import type { ClosedPosition } from "#src/betting/sweep-types.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  getBucksNotificationPreferencesForUsers,
+  markBucksSettlementDmHintShown,
+} from "#src/betting/notification-preferences.ts";
 import { client } from "#src/discord/client.ts";
 import { sendDM, type DmStatus } from "#src/discord/utils/dm.ts";
 import { createLogger } from "#src/logger.ts";
@@ -37,6 +41,8 @@ class SettlementDmStatusError extends Error {
 export type SettlementDmDeliveryDependencies = {
   client: Client;
   isPolicyEnabled: typeof isPolicyEnabled;
+  getNotificationPreferencesForUsers: typeof getBucksNotificationPreferencesForUsers;
+  markNotificationHintShown: typeof markBucksSettlementDmHintShown;
   sendDm: typeof sendDM;
   observeBucksDelivery: typeof observeBucksDelivery;
 };
@@ -45,6 +51,8 @@ const defaultSettlementDmDeliveryDependencies: SettlementDmDeliveryDependencies 
   {
     client,
     isPolicyEnabled,
+    getNotificationPreferencesForUsers: getBucksNotificationPreferencesForUsers,
+    markNotificationHintShown: markBucksSettlementDmHintShown,
     sendDm: sendDM,
     observeBucksDelivery,
   };
@@ -126,6 +134,38 @@ export async function deliverSettlementDms(
         prismaClient,
       })
     : [];
+  const preferenceRecipientIds = [
+    ...input.summary.bets.map((bet) => bet.discordId),
+    ...(input.parlay?.bets.map((bet) => bet.discordId) ?? []),
+    ...input.unmatchedPositions.map((position) => position.discordId),
+    ...playerRecipients.map((recipient) => recipient.discordId),
+  ];
+  const preferences = await dependencies.getNotificationPreferencesForUsers(
+    { serverId: guildId, discordIds: [...new Set(preferenceRecipientIds)] },
+    prismaClient,
+  );
+  const preferenceFor = (discordId: string) =>
+    preferences.get(discordId) ?? {
+      ownBetSettlementDms: true,
+      betsOnPlayerSettlementDms: true,
+      settlementDmHintShownAt: null,
+    };
+  const receiptRecipientIds = new Set(
+    preferenceRecipientIds.filter(
+      (discordId) => preferenceFor(discordId).ownBetSettlementDms,
+    ),
+  );
+  const enabledPlayerRecipients = playerRecipients.filter(
+    (recipient) => preferenceFor(recipient.discordId).betsOnPlayerSettlementDms,
+  );
+  const hintRecipientIds = new Set(
+    [
+      ...receiptRecipientIds,
+      ...enabledPlayerRecipients.map((recipient) => recipient.discordId),
+    ].filter(
+      (discordId) => preferenceFor(discordId).settlementDmHintShownAt === null,
+    ),
+  );
   const anchor = bettingAnchor(input.roster);
   const messages = buildSettlementDmMessages({
     summary: input.summary,
@@ -134,8 +174,10 @@ export async function deliverSettlementDms(
     unmatchedPositions: input.unmatchedPositions,
     framing: anchor === undefined ? undefined : subjectFraming(anchor),
     receiptsEnabled,
+    receiptRecipientIds,
     playerBetOutcomesEnabled,
-    playerRecipients,
+    playerRecipients: enabledPlayerRecipients,
+    hintRecipientIds,
   });
   for (const message of messages) {
     let status: DmStatus | undefined;
@@ -168,6 +210,25 @@ export async function deliverSettlementDms(
           message.kind === "betting_settlement_receipt" ? "bettor" : "player",
         result: "sent",
       });
+      if (hintRecipientIds.has(message.recipientId)) {
+        try {
+          await dependencies.markNotificationHintShown(
+            { serverId: guildId, discordId: message.recipientId },
+            prismaClient,
+          );
+        } catch (error) {
+          logger.error(
+            `❌ Could not record Bryan Bucks notification hint for ${message.recipientId}:`,
+            error,
+          );
+          Sentry.captureException(error, {
+            tags: {
+              source: "betting-settlement-dm-hint",
+              matchId: input.summary.matchId,
+            },
+          });
+        }
+      }
     } catch (error) {
       // `sendDM` handles expected Discord failures. The observer still needs
       // a rejection to count those statuses, but they are not Sentry errors.

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
@@ -77,6 +77,8 @@ function build(input: {
   playerRecipients?: TeamRecipient[];
   unmatchedPositions?: ClosedPosition[];
   parlay?: ParlaySettlementSummary;
+  receiptRecipientIds?: ReadonlySet<string>;
+  hintRecipientIds?: ReadonlySet<string>;
   playerBetOutcomesEnabled?: boolean;
   voidReason?: SettlementSummary["voidReason"];
 }) {
@@ -87,8 +89,14 @@ function build(input: {
     unmatchedPositions: input.unmatchedPositions ?? [],
     framing,
     receiptsEnabled: true,
+    ...(input.receiptRecipientIds === undefined
+      ? {}
+      : { receiptRecipientIds: input.receiptRecipientIds }),
     playerBetOutcomesEnabled: input.playerBetOutcomesEnabled ?? false,
     playerRecipients: input.playerRecipients ?? [],
+    ...(input.hintRecipientIds === undefined
+      ? {}
+      : { hintRecipientIds: input.hintRecipientIds }),
   });
 }
 
@@ -118,7 +126,6 @@ describe("Bryan Bucks settlement DMs", () => {
     expect(messages[0]?.content).toContain("Blue 10 BB → won 10 BB.");
     expect(messages[0]?.content).not.toContain("Bets on your team");
   });
-
   test("sends a player team-relative results for other human bettors", () => {
     const messages = build({
       bets: [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
@@ -140,7 +147,6 @@ describe("Bryan Bucks settlement DMs", () => {
       `<@${blueBettor}> bet against your team and won 10 BB.`,
     );
   });
-
   test("does not create a team notice for an unlinked tracked player", () => {
     const messages = build({
       bets: [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
@@ -152,7 +158,6 @@ describe("Bryan Bucks settlement DMs", () => {
     expect(messages).toHaveLength(1);
     expect(messages[0]?.recipientId).toBe(blueBettor);
   });
-
   test("combines a playing bettor's receipt and other bettors' lines once", () => {
     const messages = build({
       bets: [
@@ -266,38 +271,16 @@ describe("Bryan Bucks settlement DMs", () => {
     expect(messages[0]?.content.endsWith("...")).toBe(true);
   });
 
-  test("continues after one DM delivery fails", async () => {
-    let sends = 0;
-    const dependencies: SettlementDmDeliveryDependencies = {
-      client: mockClient(),
-      isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
-      observeBucksDelivery: async (_input, run) => run(),
-      sendDm: async () => {
-        sends++;
-        if (sends === 1) {
-          throw new Error("first DM failed");
-        }
-        return "sent";
-      },
-    };
-
-    await deliverSettlementDms(
-      deliveryInput("4", [
-        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
-        bet({ id: 2, discordId: redBettor, teamId: 200 }),
-      ]),
-      dependencies,
-    );
-
-    expect(sends).toBe(2);
-  });
-
   test("observes settlement DMs and translates non-sent statuses into failures", async () => {
     let observed = 0;
     let rejected = 0;
     const dependencies: SettlementDmDeliveryDependencies = {
       client: mockClient(),
       isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      getNotificationPreferencesForUsers: async () => new Map(),
+      markNotificationHintShown: async () => {
+        await Promise.resolve();
+      },
       observeBucksDelivery: async (_input, run) => {
         observed++;
         try {
@@ -319,5 +302,207 @@ describe("Bryan Bucks settlement DMs", () => {
 
     expect(observed).toBe(1);
     expect(rejected).toBe(1);
+  });
+});
+
+describe("Bryan Bucks settlement DM delivery failures", () => {
+  test("continues after one DM delivery fails", async () => {
+    let sends = 0;
+    const dependencies: SettlementDmDeliveryDependencies = {
+      client: mockClient(),
+      isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      getNotificationPreferencesForUsers: async () => new Map(),
+      markNotificationHintShown: async () => {
+        await Promise.resolve();
+      },
+      observeBucksDelivery: async (_input, run) => run(),
+      sendDm: async () => {
+        sends++;
+        if (sends === 1) {
+          throw new Error("first DM failed");
+        }
+        return "sent";
+      },
+    };
+
+    await deliverSettlementDms(
+      deliveryInput("4", [
+        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+        bet({ id: 2, discordId: redBettor, teamId: 200 }),
+      ]),
+      dependencies,
+    );
+
+    expect(sends).toBe(2);
+  });
+});
+
+describe("Bryan Bucks settlement DM notification hint", () => {
+  test("shows the hint once and records it after successful delivery", async () => {
+    let hintShownAt: Date | null = null;
+    let markCount = 0;
+    const sentMessages: string[] = [];
+    const dependencies: SettlementDmDeliveryDependencies = {
+      client: mockClient(),
+      isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      getNotificationPreferencesForUsers: async () =>
+        new Map([
+          [
+            blueBettor,
+            {
+              ownBetSettlementDms: true,
+              betsOnPlayerSettlementDms: true,
+              settlementDmHintShownAt: hintShownAt,
+            },
+          ],
+        ]),
+      markNotificationHintShown: async () => {
+        markCount++;
+        hintShownAt = new Date();
+      },
+      observeBucksDelivery: async (_input, run) => run(),
+      sendDm: async ({ message }) => {
+        sentMessages.push(message);
+        return "sent";
+      },
+    };
+
+    await deliverSettlementDms(
+      deliveryInput("6", [
+        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+      ]),
+      dependencies,
+    );
+    await deliverSettlementDms(
+      deliveryInput("6", [
+        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+      ]),
+      dependencies,
+    );
+
+    expect(sentMessages).toHaveLength(2);
+    expect(sentMessages[0]).toContain(
+      "You can manage these DMs with `/bb notifications`.",
+    );
+    expect(sentMessages[1]).not.toContain(
+      "You can manage these DMs with `/bb notifications`.",
+    );
+    expect(markCount).toBe(1);
+  });
+
+  test("does not record the hint when DM delivery fails", async () => {
+    let markCount = 0;
+    const dependencies: SettlementDmDeliveryDependencies = {
+      client: mockClient(),
+      isPolicyEnabled: async (name) => name === "betting_settlement_dm_enabled",
+      getNotificationPreferencesForUsers: async () =>
+        new Map([
+          [
+            blueBettor,
+            {
+              ownBetSettlementDms: true,
+              betsOnPlayerSettlementDms: true,
+              settlementDmHintShownAt: null,
+            },
+          ],
+        ]),
+      markNotificationHintShown: async () => {
+        markCount++;
+      },
+      observeBucksDelivery: async (_input, run) => run(),
+      sendDm: async () => "dm_disabled",
+    };
+
+    await deliverSettlementDms(
+      deliveryInput("7", [
+        bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+      ]),
+      dependencies,
+    );
+
+    expect(markCount).toBe(0);
+  });
+});
+
+describe("Bryan Bucks settlement DM preferences", () => {
+  test("appends the notification hint to an eligible settlement DM", () => {
+    const messages = build({
+      bets: [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
+      hintRecipientIds: new Set([blueBettor]),
+    });
+
+    expect(messages[0]?.content).toContain(
+      "You can manage these DMs with `/bb notifications`.",
+    );
+  });
+
+  test("reserves space so a truncated settlement keeps the hint", () => {
+    const messages = build({
+      bets: Array.from({ length: 300 }, (_, index) =>
+        bet({ id: index + 1, discordId: blueBettor, teamId: 100, won: true }),
+      ),
+      hintRecipientIds: new Set([blueBettor]),
+    });
+
+    expect(messages[0]?.content.length).toBeLessThanOrEqual(1900);
+    expect(
+      messages[0]?.content.endsWith(
+        "You can manage these DMs with `/bb notifications`.",
+      ),
+    ).toBe(true);
+  });
+
+  test("applies own-bet and bets-on-player preferences independently", () => {
+    const messages = buildSettlementDmMessages({
+      summary: summary(
+        [
+          bet({ id: 1, discordId: blueBettor, teamId: 100, won: true }),
+          bet({ id: 2, discordId: redBettor, teamId: 200 }),
+        ],
+        "server-1",
+      ),
+      includeOutcome: true,
+      parlay: undefined,
+      unmatchedPositions: [],
+      framing,
+      receiptsEnabled: true,
+      receiptRecipientIds: new Set([redBettor]),
+      playerBetOutcomesEnabled: true,
+      playerRecipients: [{ discordId: bluePlayer, teamId: 100 }],
+      hintRecipientIds: new Set([redBettor, bluePlayer]),
+    });
+
+    expect(messages.map((message) => message.recipientId)).toEqual([
+      redBettor,
+      bluePlayer,
+    ]);
+    expect(messages.find((message) => message.recipientId === blueBettor)).toBe(
+      undefined,
+    );
+    expect(
+      messages.find((message) => message.recipientId === bluePlayer)?.content,
+    ).toContain(`<@${blueBettor}> bet for your team and won 10 BB.`);
+    expect(
+      messages.find((message) => message.recipientId === bluePlayer)?.content,
+    ).toContain("You can manage these DMs with `/bb notifications`.");
+  });
+
+  test("does not build a DM when both categories are disabled", () => {
+    const messages = buildSettlementDmMessages({
+      summary: summary(
+        [bet({ id: 1, discordId: blueBettor, teamId: 100, won: true })],
+        "server-1",
+      ),
+      includeOutcome: true,
+      parlay: undefined,
+      unmatchedPositions: [],
+      framing,
+      receiptsEnabled: true,
+      receiptRecipientIds: new Set(),
+      playerBetOutcomesEnabled: true,
+      playerRecipients: [],
+    });
+
+    expect(messages).toEqual([]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.ts
@@ -7,6 +7,8 @@ import { truncateDiscordMessage } from "#src/discord/utils/message.ts";
 
 const MAX_SETTLEMENT_DM_LENGTH = 1900;
 const TRUNCATION_SUFFIX = "...";
+export const SETTLEMENT_DM_NOTIFICATION_HINT =
+  "You can manage these DMs with `/bb notifications`.";
 
 export type SettlementDmKind =
   "betting_settlement_receipt" | "betting_player_bet_outcome";
@@ -145,19 +147,33 @@ export function buildSettlementDmMessages(input: {
   unmatchedPositions: readonly ClosedPosition[];
   framing: OutcomeFraming | undefined;
   receiptsEnabled: boolean;
+  receiptRecipientIds?: ReadonlySet<string>;
   playerBetOutcomesEnabled: boolean;
   playerRecipients: readonly TeamRecipient[];
+  hintRecipientIds?: ReadonlySet<string>;
 }): SettlementDmMessage[] {
   const drafts = new Map<string, RecipientDraft>();
   const outcomes = outcomePositions(input);
 
   if (input.receiptsEnabled) {
     for (const position of outcomes) {
+      if (
+        input.receiptRecipientIds !== undefined &&
+        !input.receiptRecipientIds.has(position.bettorId)
+      ) {
+        continue;
+      }
       draftFor(drafts, position.bettorId).ownLines.push(
         ownOutcomeLine(position, input.framing),
       );
     }
     for (const bet of input.parlay?.bets ?? []) {
+      if (
+        input.receiptRecipientIds !== undefined &&
+        !input.receiptRecipientIds.has(bet.discordId)
+      ) {
+        continue;
+      }
       draftFor(drafts, bet.discordId).ownLines.push(ownParlayLine(bet));
     }
   }
@@ -186,6 +202,12 @@ export function buildSettlementDmMessages(input: {
     if (draft.teamLines.length > 0) {
       sections.push(["**Bets on your team**", ...draft.teamLines].join("\n"));
     }
+    const hint =
+      input.hintRecipientIds?.has(recipientId) === true
+        ? `\n\n${SETTLEMENT_DM_NOTIFICATION_HINT}`
+        : "";
+    const maxSettlementContentLength =
+      MAX_SETTLEMENT_DM_LENGTH - TRUNCATION_SUFFIX.length - hint.length;
     return [
       {
         recipientId,
@@ -193,10 +215,10 @@ export function buildSettlementDmMessages(input: {
           draft.ownLines.length > 0
             ? "betting_settlement_receipt"
             : "betting_player_bet_outcome",
-        content: truncateDiscordMessage(
+        content: `${truncateDiscordMessage(
           sections.join("\n\n"),
-          MAX_SETTLEMENT_DM_LENGTH - TRUNCATION_SUFFIX.length,
-        ),
+          maxSettlementContentLength,
+        )}${hint}`,
       },
     ];
   });

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
@@ -39,6 +39,29 @@ export const bbCommand = addBbPeekSubcommands(
     )
     .addSubcommand((sub) =>
       sub
+        .setName("notifications")
+        .setDescription("Choose which Bryan Bucks settlement DMs you receive")
+        .addStringOption((option) =>
+          option
+            .setName("your_bets")
+            .setDescription("DMs about bets you placed")
+            .addChoices(
+              { name: "On", value: "on" },
+              { name: "Off", value: "off" },
+            ),
+        )
+        .addStringOption((option) =>
+          option
+            .setName("bets_on_you")
+            .setDescription("DMs about bets other users placed on you")
+            .addChoices(
+              { name: "On", value: "on" },
+              { name: "Off", value: "off" },
+            ),
+        ),
+    )
+    .addSubcommand((sub) =>
+      sub
         .setName("bet")
         .setDescription("Bet on a tracked player's game")
         .addStringOption((option) =>

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-notifications.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-notifications.ts
@@ -1,0 +1,86 @@
+import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import {
+  getBucksNotificationPreferences,
+  updateBucksNotificationPreferences,
+  type BucksNotificationPreferenceUpdates,
+  type BucksNotificationPreferences,
+} from "#src/betting/notification-preferences.ts";
+import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
+
+export type BbNotificationCommandDependencies = {
+  getNotificationPreferences?: typeof getBucksNotificationPreferences;
+  updateNotificationPreferences?: typeof updateBucksNotificationPreferences;
+};
+
+function notificationToggle(value: string | null): boolean | undefined {
+  if (value === null) return undefined;
+  if (value === "on") return true;
+  if (value === "off") return false;
+  throw new Error(`Unknown notification toggle: ${value}`);
+}
+
+function notificationStatusLine(label: string, enabled: boolean): string {
+  return `${label}: **${enabled ? "On" : "Off"}**`;
+}
+
+export function formatBucksNotificationPreferences(
+  preferences: BucksNotificationPreferences,
+  updates: BucksNotificationPreferenceUpdates,
+): string {
+  const changed = [
+    updates.ownBetSettlementDms === undefined
+      ? undefined
+      : `your bets ${updates.ownBetSettlementDms ? "on" : "off"}`,
+    updates.betsOnPlayerSettlementDms === undefined
+      ? undefined
+      : `bets on you ${updates.betsOnPlayerSettlementDms ? "on" : "off"}`,
+  ].filter((value) => value !== undefined);
+  return [
+    "🔔 **Bryan Bucks notifications**",
+    notificationStatusLine("Bets I placed", preferences.ownBetSettlementDms),
+    notificationStatusLine(
+      "Bets other users placed on me",
+      preferences.betsOnPlayerSettlementDms,
+    ),
+    changed.length === 0
+      ? "Use `your_bets` or `bets_on_you` with `on` or `off` to change these settings."
+      : `Updated: ${changed.join(", ")}.`,
+  ].join("\n");
+}
+
+export async function replyBbNotifications(
+  interaction: BbCommandInteraction,
+  serverId: DiscordGuildId,
+  discordId: DiscordAccountId,
+  dependencies: BbNotificationCommandDependencies,
+): Promise<void> {
+  const ownBetSettlementDms = notificationToggle(
+    interaction.options.getString("your_bets"),
+  );
+  const betsOnPlayerSettlementDms = notificationToggle(
+    interaction.options.getString("bets_on_you"),
+  );
+  const updates: BucksNotificationPreferenceUpdates = {
+    ...(ownBetSettlementDms === undefined ? {} : { ownBetSettlementDms }),
+    ...(betsOnPlayerSettlementDms === undefined
+      ? {}
+      : { betsOnPlayerSettlementDms }),
+  };
+  const preferences =
+    ownBetSettlementDms === undefined && betsOnPlayerSettlementDms === undefined
+      ? await (
+          dependencies.getNotificationPreferences ??
+          getBucksNotificationPreferences
+        )({ serverId, discordId })
+      : await (
+          dependencies.updateNotificationPreferences ??
+          updateBucksNotificationPreferences
+        )({
+          serverId,
+          discordId,
+          updates,
+        });
+  await interaction.editReply({
+    content: formatBucksNotificationPreferences(preferences, updates),
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -52,6 +52,10 @@ import {
 import { buildBbRulesEmbed as createBbRulesEmbed } from "#src/discord/commands/bb-rules.ts";
 import { replyBbPeekCommand } from "#src/discord/commands/bb-peek.ts";
 import {
+  replyBbNotifications,
+  type BbNotificationCommandDependencies,
+} from "#src/discord/commands/bb-notifications.ts";
+import {
   splitMessageIntoChunks,
   truncateEmbedFieldValue,
 } from "#src/discord/utils/message.ts";
@@ -59,7 +63,6 @@ import { createLogger } from "#src/logger.ts";
 import { formatInteger } from "#src/betting/display-format.ts";
 
 const logger = createLogger("command-bb");
-
 export function buildBbRulesEmbed(): EmbedBuilder {
   return createBbRulesEmbed();
 }
@@ -86,6 +89,11 @@ export function buildBbRulesEmbed(): EmbedBuilder {
  */
 
 const BUCKS_COLOR = 0x2e_cc_71;
+
+type BbCommandDependencies = {
+  runAskAgent?: BucksAskAgentRunner;
+  isPolicyEnabled?: typeof isPolicyEnabled;
+} & BbNotificationCommandDependencies;
 
 export function isPublicBbSubcommand(subcommand: string): boolean {
   return subcommand === "rules" || subcommand === "prizes";
@@ -425,7 +433,7 @@ async function replyBet(
 
 export async function executeBb(
   interaction: BbCommandInteraction,
-  dependencies: { runAskAgent?: BucksAskAgentRunner } = {},
+  dependencies: BbCommandDependencies = {},
 ): Promise<void> {
   const subcommand = interaction.options.getSubcommand();
 
@@ -439,7 +447,12 @@ export async function executeBb(
     }
 
     const serverId = DiscordGuildIdSchema.parse(interaction.guildId);
-    if (!(await isPolicyEnabled("betting_enabled", { server: serverId }))) {
+    if (
+      !(await (dependencies.isPolicyEnabled ?? isPolicyEnabled)(
+        "betting_enabled",
+        { server: serverId },
+      ))
+    ) {
       // Reachable only if the flag was turned off after registration, since
       // the command is not registered anywhere the flag is off.
       await interaction.reply({
@@ -453,7 +466,6 @@ export async function executeBb(
     // can be explicitly published by its asker.
     const ephemeral = !isPublicBbSubcommand(subcommand);
     await interaction.deferReply({ ephemeral });
-
     const discordId = DiscordAccountIdSchema.parse(interaction.user.id);
 
     switch (subcommand) {
@@ -480,6 +492,14 @@ export async function executeBb(
           dependencies.runAskAgent === undefined
             ? {}
             : { runAgent: dependencies.runAskAgent },
+        );
+        break;
+      case "notifications":
+        await replyBbNotifications(
+          interaction,
+          serverId,
+          discordId,
+          dependencies,
         );
         break;
       case "bet":

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
@@ -145,6 +145,41 @@ describe("registered Discord commands", () => {
     expect(isPublicBbSubcommand("prizes")).toBe(true);
   });
 
+  test("registers private /bb notifications toggles", () => {
+    const notifications = bbCommand
+      .toJSON()
+      .options?.find((option) => option.name === "notifications");
+    if (notifications === undefined || !("options" in notifications)) {
+      throw new Error("/bb notifications should be a subcommand");
+    }
+
+    expect(notifications).toEqual(
+      expect.objectContaining({
+        name: "notifications",
+        description: "Choose which Bryan Bucks settlement DMs you receive",
+      }),
+    );
+    expect(notifications.options).toEqual([
+      expect.objectContaining({
+        name: "your_bets",
+        required: false,
+        choices: [
+          { name: "On", value: "on" },
+          { name: "Off", value: "off" },
+        ],
+      }),
+      expect.objectContaining({
+        name: "bets_on_you",
+        required: false,
+        choices: [
+          { name: "On", value: "on" },
+          { name: "Off", value: "off" },
+        ],
+      }),
+    ]);
+    expect(isPublicBbSubcommand("notifications")).toBe(false);
+  });
+
   test("does not register autocomplete options", () => {
     expect(
       baseCommandDefinitions.flatMap((command) =>

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/reconcile-removed-guilds.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/reconcile-removed-guilds.test.ts
@@ -41,6 +41,12 @@ async function seedGuild(
       consecutiveErrorCount: 3,
     },
   });
+  await db.bucksNotificationPreference.create({
+    data: {
+      serverId,
+      discordId: testAccountId("802"),
+    },
+  });
 }
 
 function unknownGuildError(): DiscordAPIError {
@@ -87,6 +93,7 @@ const justAfterMidnight = new Date("2026-07-02T00:05:00.000Z");
 beforeEach(async () => {
   await prisma.player.deleteMany();
   await prisma.guildPermissionError.deleteMany();
+  await prisma.bucksNotificationPreference.deleteMany();
   await prisma.guildRemovalCandidate.deleteMany();
 });
 
@@ -95,6 +102,33 @@ afterAll(async () => {
 });
 
 describe("reconcileRemovedGuilds", () => {
+  test("discovers a removed guild whose only residual data is notification preferences", async () => {
+    await prisma.bucksNotificationPreference.create({
+      data: {
+        serverId: removedGuild,
+        discordId: testAccountId("803"),
+      },
+    });
+
+    await reconcileRemovedGuilds(clientWithMembers([memberGuild]), prisma, {
+      now: day1,
+    });
+    expect(
+      await prisma.bucksNotificationPreference.count({
+        where: { serverId: removedGuild },
+      }),
+    ).toBe(1);
+
+    await reconcileRemovedGuilds(clientWithMembers([memberGuild]), prisma, {
+      now: day2,
+    });
+    expect(
+      await prisma.bucksNotificationPreference.count({
+        where: { serverId: removedGuild },
+      }),
+    ).toBe(0);
+  });
+
   test("does not clean up on the first day a guild is seen missing - only records a candidate", async () => {
     await seedGuild(prisma, removedGuild);
 
@@ -148,6 +182,11 @@ describe("reconcileRemovedGuilds", () => {
       }),
     ).toBe(0);
     expect(
+      await prisma.bucksNotificationPreference.count({
+        where: { serverId: removedGuild },
+      }),
+    ).toBe(0);
+    expect(
       await prisma.guildRemovalCandidate.count({
         where: { serverId: removedGuild },
       }),
@@ -169,6 +208,11 @@ describe("reconcileRemovedGuilds", () => {
     // Nothing removed — we couldn't trust the (empty) membership snapshot.
     expect(
       await prisma.player.count({ where: { serverId: removedGuild } }),
+    ).toBe(1);
+    expect(
+      await prisma.bucksNotificationPreference.count({
+        where: { serverId: removedGuild },
+      }),
     ).toBe(1);
   });
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/reconcile-removed-guilds.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/reconcile-removed-guilds.ts
@@ -81,30 +81,43 @@ export async function reconcileRemovedGuilds(
     // Distinct serverIds that still have data across the tables cleanup removes.
     // Querying the cleaned tables (not GuildInstall) means a reconciled guild
     // stops appearing here once cleaned, so the sweep converges.
-    const [players, competitions, reports, permissionErrors] =
-      await Promise.all([
-        db.player.findMany({
-          select: { serverId: true },
-          distinct: ["serverId"],
-        }),
-        db.competition.findMany({
-          select: { serverId: true },
-          distinct: ["serverId"],
-        }),
-        db.report.findMany({
-          select: { serverId: true },
-          distinct: ["serverId"],
-        }),
-        db.guildPermissionError.findMany({
-          select: { serverId: true },
-          distinct: ["serverId"],
-        }),
-      ]);
+    const [
+      players,
+      competitions,
+      reports,
+      permissionErrors,
+      notificationPreferences,
+    ] = await Promise.all([
+      db.player.findMany({
+        select: { serverId: true },
+        distinct: ["serverId"],
+      }),
+      db.competition.findMany({
+        select: { serverId: true },
+        distinct: ["serverId"],
+      }),
+      db.report.findMany({
+        select: { serverId: true },
+        distinct: ["serverId"],
+      }),
+      db.guildPermissionError.findMany({
+        select: { serverId: true },
+        distinct: ["serverId"],
+      }),
+      db.bucksNotificationPreference.findMany({
+        select: { serverId: true },
+        distinct: ["serverId"],
+      }),
+    ]);
 
     const dbServerIds = new Set(
-      [...players, ...competitions, ...reports, ...permissionErrors].map(
-        (row) => row.serverId,
-      ),
+      [
+        ...players,
+        ...competitions,
+        ...reports,
+        ...permissionErrors,
+        ...notificationPreferences,
+      ].map((row) => row.serverId),
     );
 
     const candidateServerIds = [...dbServerIds].filter(

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.test.ts
@@ -112,6 +112,14 @@ async function seedGuild(
     },
   });
 
+  await db.bucksNotificationPreference.create({
+    data: {
+      serverId,
+      discordId: owner,
+      ownBetSettlementDms: false,
+    },
+  });
+
   await recordPermissionError(db, {
     serverId,
     channelId,
@@ -131,6 +139,9 @@ async function countGuild(
     subscriptions: await db.subscription.count({ where: { serverId } }),
     competitions: await db.competition.count({ where: { serverId } }),
     reports: await db.report.count({ where: { serverId } }),
+    notificationPreferences: await db.bucksNotificationPreference.count({
+      where: { serverId },
+    }),
     serverPermissions: await db.serverPermission.count({ where: { serverId } }),
     permissionErrors: await db.guildPermissionError.count({
       where: { serverId },
@@ -153,6 +164,7 @@ beforeEach(async () => {
   await prisma.player.deleteMany();
   await prisma.serverPermission.deleteMany();
   await prisma.guildPermissionError.deleteMany();
+  await prisma.bucksNotificationPreference.deleteMany();
 });
 
 afterAll(async () => {
@@ -171,6 +183,7 @@ describe("cleanupRemovedGuild", () => {
       competitions: 1,
       reports: 1,
       subscriptions: 1,
+      notificationPreferences: 1,
       serverPermissions: 1,
       accounts: 1,
       players: 1,
@@ -185,6 +198,7 @@ describe("cleanupRemovedGuild", () => {
       subscriptions: 0,
       competitions: 0,
       reports: 0,
+      notificationPreferences: 0,
       serverPermissions: 0,
       permissionErrors: 0,
     });
@@ -200,6 +214,7 @@ describe("cleanupRemovedGuild", () => {
       subscriptions: 1,
       competitions: 1,
       reports: 1,
+      notificationPreferences: 1,
       serverPermissions: 1,
       permissionErrors: 1,
     });
@@ -211,6 +226,7 @@ describe("cleanupRemovedGuild", () => {
       competitions: 0,
       reports: 0,
       subscriptions: 0,
+      notificationPreferences: 0,
       serverPermissions: 0,
       accounts: 0,
       players: 0,

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/cleanup/remove-guild.ts
@@ -24,6 +24,7 @@ export type RemovedGuildCleanupSummary = {
   competitions: number;
   reports: number;
   subscriptions: number;
+  notificationPreferences: number;
   serverPermissions: number;
   accounts: number;
   players: number;
@@ -104,6 +105,10 @@ export async function cleanupRemovedGuild(
       const subscriptions = await tx.subscription.deleteMany({
         where: { serverId },
       });
+      const notificationPreferences =
+        await tx.bucksNotificationPreference.deleteMany({
+          where: { serverId },
+        });
       const serverPermissions = await tx.serverPermission.deleteMany({
         where: { serverId },
       });
@@ -117,6 +122,7 @@ export async function cleanupRemovedGuild(
         competitions: competitions.count,
         reports: reports.count,
         subscriptions: subscriptions.count,
+        notificationPreferences: notificationPreferences.count,
         serverPermissions: serverPermissions.count,
         accounts: accounts.count,
         players: players.count,

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -10,18 +10,19 @@ Bryan Bucks is enabled.
 
 ## Subcommands
 
-| Command       | What it does                                          | Reply                             |
-| ------------- | ----------------------------------------------------- | --------------------------------- |
-| `/bb balance` | Available Bucks, Bucks at risk, and pending positions | Private                           |
-| `/bb history` | Paged transaction ledger with running balances        | Private                           |
-| `/bb open`    | Match and weekly markets still taking bets            | Private                           |
-| `/bb bet`     | Place or top up an outcome bet                        | Private                           |
-| `/bb parlay`  | Place or top up a match or weekly parlay bet          | Private                           |
-| `/bb pass`    | Quote and buy a 24-hour peek pass                     | Private                           |
-| `/bb peek`    | Reveal one live game's pre-game estimate              | Private                           |
-| `/bb ask`     | One-shot analysis over this server's Bryan Bucks data | Private, publishable by the asker |
-| `/bb rules`   | The complete rulebook                                 | **Public**                        |
-| `/bb prizes`  | The joke prize catalogue                              | **Public**                        |
+| Command             | What it does                                          | Reply                             |
+| ------------------- | ----------------------------------------------------- | --------------------------------- |
+| `/bb balance`       | Available Bucks, Bucks at risk, and pending positions | Private                           |
+| `/bb history`       | Paged transaction ledger with running balances        | Private                           |
+| `/bb open`          | Match and weekly markets still taking bets            | Private                           |
+| `/bb bet`           | Place or top up an outcome bet                        | Private                           |
+| `/bb parlay`        | Place or top up a match or weekly parlay bet          | Private                           |
+| `/bb pass`          | Quote and buy a 24-hour peek pass                     | Private                           |
+| `/bb peek`          | Reveal one live game's pre-game estimate              | Private                           |
+| `/bb ask`           | One-shot analysis over this server's Bryan Bucks data | Private, publishable by the asker |
+| `/bb notifications` | Choose settlement DMs about your bets and bets on you | Private                           |
+| `/bb rules`         | The complete rulebook                                 | **Public**                        |
+| `/bb prizes`        | The joke prize catalogue                              | **Public**                        |
 
 Everything except `rules` and `prizes` answers only to you. Balances, positions,
 and estimates are never posted to the channel by Scout.
@@ -66,6 +67,22 @@ and several concurrent markets without changing the command.
 | Option     | Required | Values                                 |
 | ---------- | -------- | -------------------------------------- |
 | `question` | yes      | Free text, up to the documented length |
+
+### `/bb notifications`
+
+Both options are optional. With neither option, Scout reports the current
+settings. New users default to receiving both categories.
+After your first eligible settlement DM, Scout shows a one-time reminder that
+you can manage these messages with `/bb notifications`.
+
+| Option        | Required | Values      |
+| ------------- | -------- | ----------- |
+| `your_bets`   | no       | `On`, `Off` |
+| `bets_on_you` | no       | `On`, `Off` |
+
+`your_bets` controls settlement DMs for outcome and parlay bets you placed.
+`bets_on_you` controls settlement DMs about other users betting on your tracked
+player. Settings are independent and scoped to this server.
 
 ## Buttons
 


### PR DESCRIPTION
Why:
Give beta Bryan Bucks users independent control over settlement DMs while preserving current default delivery behavior and explaining the new control surface.

What:
- Add server-scoped per-user notification preferences for own bets and bets on tracked players.
- Add private `/bb notifications` with status reporting and independent on/off choices.
- Apply preferences in bulk during settlement DM delivery without changing settlement accounting or global policy flags.
- Show a one-time `/bb notifications` hint after each user’s first successful eligible settlement DM.
- Document the command and hint behavior.

Verification:
- `bunx turbo run generate --filter=@scout-for-lol/backend`
- `bunx turbo run typecheck test lint --filter=@scout-for-lol/backend`
- `bunx turbo run typecheck lint --filter=@scout-for-lol/docs-site`
- Full backend suite: 2,321 tests passed.
- No BETA deployment or live Discord runtime check run.