### PR TITLE
Provision Buildkite analytics credential boundary

### DIFF
--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-25T00:13:59.763Z",
+  "generatedAt": "2026-08-25T04:05:43.549Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -1192,6 +1192,17 @@
         "83ff6daea8da6742347731f54dc1e95eefb86823653b4a3454e478cba0da8e73",
         "8db5423f16fe0e56a47368721bca2e3f7d4fe7b4f2dcedfac49886abb8f983d6",
         "bb5efd56efbe43b29a0339061d445354f5963ab81acd0c9ced61d8e1b06d1506"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
+      "ref": "d4ae9c22bd4a6486fa49788f1edc0203b656bdf85b076316d2ec0a7108e59e74",
+      "title": "7ff0e0123455569cbef059a0bd89a8c732e5dcb780fd651c57df438c0133e90f",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "5eda41a8d5d21999e460cda99057428e8ccb0fee8cc8bfc4e3944384d94bb330"
       ],
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.test.ts
@@ -135,6 +135,7 @@ const JobServiceAccountSchema = z
 const EXPECTED_CREDENTIAL_SECRET_NAMES = [
   "buildkite-github-credentials",
   "buildkite-api-credentials",
+  "buildkite-analytics-credentials",
   "buildkite-turbo-cache-credentials",
   "buildkite-npm-credentials",
   "buildkite-claude-credentials",

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -65,6 +65,10 @@ const BUILDKITE_CREDENTIAL_ITEMS = [
     itemId: "qtyxi2cqocze43ekdgb72uvtr4",
   },
   {
+    secretName: "buildkite-analytics-credentials",
+    itemId: "c5enc4onifzi63ig7qouhvgyaq",
+  },
+  {
     secretName: "buildkite-turbo-cache-credentials",
     itemId: "mzvcz4pqqbda75ufu7l5myd4ey",
   },


### PR DESCRIPTION
## Why

Exact-head CI on #2478 confirmed that Buildkite test collection consumes its own analytics token. The enforcement PR cannot reference that token until GitOps creates the scoped Kubernetes Secret.

## What

- declare a dedicated Buildkite analytics `OnePasswordItem` and Kubernetes Secret
- reference the existing narrowly scoped 1Password item without exposing its value
- refresh the hashed vault snapshot and extend the credential-boundary synthesis test
- leave all running CI jobs unchanged

## Verification

- `bun test src/resources/argo-applications/buildkite.test.ts src/onepassword-vault-snapshot.test.ts` — 11 passed
- `bun run check:1password` — 71 item references and 143 field references verified
- `bunx turbo run build lint typecheck --filter=@homelab/cdk8s --force` — 7 tasks passed
- `bunx lefthook run pre-commit`

After merge, Argo must reconcile `buildkite-analytics-credentials` before #2478 is rerun.