### PR TITLE
feat(scout): make Explore and report AI durable

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -10,7 +10,9 @@ bun = "1.4.0"
 # 1.4 does not implement. Keep the sole exception on the current LTS line.
 node = "24.19.0"
 # renovate: datasource=github-releases depName=temporalio/cli
-temporal = "1.8.1"
+# The short `temporal` registry alias still targets the archived
+# temporalio/temporal release layout, which has no Darwin arm64 artifact.
+"aqua:temporalio/cli" = "1.8.1"
 rust = "1.98.0"
 # renovate: datasource=dotnet-sdk depName=dotnet-sdk
 dotnet = "10.0.302"

--- a/bun.lock
+++ b/bun.lock
@@ -1222,6 +1222,7 @@
         "@temporalio/common": "1.22.0",
         "@temporalio/worker": "1.22.0",
         "@trpc/server": "11",
+        "@trpc/server": "11",
         "ai": "^7.0.77",
         "cron": "^4.1.4",
         "cron-parser": "^5.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
     "packages/astro-opengraph-images": {
       "name": "astro-opengraph-images",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
         "jsdom": "^30.0.0",
@@ -866,7 +866,7 @@
     },
     "packages/homelab/src/helm-types": {
       "name": "@shepherdjerred/helm-types",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "bin": {
         "helm-types": "dist/cli.js",
       },
@@ -1549,6 +1549,7 @@
       "devDependencies": {
         "@scout-for-lol/data": "workspace:*",
         "@temporalio/activity": "1.22.0",
+        "@temporalio/client": "1.22.0",
         "@temporalio/testing": "1.22.0",
         "@temporalio/worker": "1.22.0",
         "@types/node": "^26.1.1",

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
@@ -79,13 +79,68 @@ of the report-lake volume, so the extra topology is not free.
 ## Schedules are durable ownership records
 
 Fixed Scout work is declared with the rest of the
-[Temporal schedule fleet](/reference/temporal-schedules/). Each user report
-will own one strictly marked Schedule, while Postgres owns the report
-definition and revision.
+[Temporal schedule fleet](/reference/temporal-schedules/). Each enabled report
+owns one strictly marked Schedule, while Postgres owns the report definition
+and monotonic revision.
+
+A transactional outbox connects those two authorities. Report writes commit
+an upsert revision or a deletion tombstone beside the product change. A
+singleton reconciler receives an immediate Signal and also runs every minute,
+so a failed Signal cannot strand the outbox. It preserves an operator pause,
+repairs missing or drifted owned Schedules, deletes only exact ownership
+matches, and alerts on unknown prefix or memo mismatches.
+
+Scheduled report actions use `BUFFER_ONE`. The first overdue action claims the
+report's persisted local due date and advances it; older buffered actions then
+become no-ops. This preserves one run after downtime without replaying every
+missed cron occurrence.
 
 Schedules begin paused when a legacy owner still exists. A feature-family
 cutover transfers ownership explicitly; a Temporal outage never activates the
 legacy owner automatically.
+
+## Workflows match product lifecycles
+
+Post-match discovery starts one independently identified child Workflow per
+match and waits until each child is durably started. Initial-history imports
+use one quiet entity Workflow per PUUID: it processes one persisted page per
+Activity, Continues-As-New before history grows, and accepts a Signal when the
+product job is reopened after its cooldown.
+
+Explore and report-AI use one Workflow per turn or edit. A stop request is a
+Signal that cancels the Activity scope. Non-cancellable cleanup persists the
+terminal projection and releases quota. Before the provider call, the Activity
+atomically marks the attempt as ambiguous-or-started. A retry salvages partial
+output and interrupts the run instead of issuing a second billable request.
+
+The SSE broker remains a low-latency process transport. Reconnecting clients
+load persisted snapshots and terminal outcomes; Workflow history never becomes
+the public event store.
+
+## Replay and outage evidence are release gates
+
+Node-hosted Workflow tests cover Signals, cancellation cleanup, child close
+policies, Continue-As-New, overlap, staleness, and retries. A real Temporal dev
+server test also proves deterministic duplicate starts, portable replay,
+Worker restart, Worker-outage catch-up, server restart, per-report Schedule
+repair, pause preservation, and deletion tombstones.
+
+Before promotion, operators replay retained beta histories directly against
+the candidate bundles:
+
+```bash
+cd packages/scout-for-lol/packages/temporal
+TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
+  bun run replay:histories <scout-beta-workflow-id>...
+
+cd packages/temporal
+TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
+  bun run replay:scout-histories <weekly-or-bryan-workflow-id>...
+```
+
+The commands keep histories in memory and use the pinned Node runtime because
+Temporal supports Worker replay internals on Node. Production remains on the
+repository's Bun Worker runtime.
 
 ## Related
 

--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
@@ -1,0 +1,137 @@
+---
+title: Roll out Scout's Temporal workers
+description: Transfer one Scout workload family to Temporal, prove every queue, soak beta, and roll back without creating two owners.
+sidebar:
+  order: 6
+---
+
+Use this procedure separately for realtime ingestion, background maintenance,
+reports, and interactive LLM work. Never enable a legacy owner and its Temporal
+replacement at the same time.
+
+## Before the cutover
+
+Confirm each layer independently:
+
+1. The complete stack is green at its exact head in Buildkite.
+2. That image is deployed to beta and the Scout HTTP and Discord processes are
+   healthy. A green PR or built image is not deployment evidence.
+3. Fixed Scout Schedules exist in the Temporal UI and remain paused.
+4. The four temporary `scout_temporal_*_enabled` flags are off.
+5. Temporal Worker readiness, task schedule-to-start latency, Workflow and
+   Activity failures, report outbox age, schedule drift, stale projections,
+   interrupted provider attempts, and duplicate-effect claims are visible.
+
+Replay retained beta histories against both candidate Workflow bundles before
+promoting changed Workflow code:
+
+```bash
+cd packages/scout-for-lol/packages/temporal
+TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
+  bun run replay:histories <scout-workflow-id>...
+
+cd packages/temporal
+TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
+  bun run replay:scout-histories <weekly-or-bryan-workflow-id>...
+```
+
+Do not remove a replay patch until no open execution needs it and the
+namespace's 30-day retention period has elapsed.
+
+## Prove every queue
+
+Run the side-effect-free canary against the deployed Scout Workers:
+
+```bash
+cd packages/scout-for-lol/packages/temporal
+bun run canary -- \
+  --stage beta \
+  --address <beta-address> \
+  --namespace default
+```
+
+The result must name `scout-beta-realtime`, `scout-beta-interactive`,
+`scout-beta-background`, and `scout-beta-lake`. A missing result means that
+Activity Worker is not polling its declared queue; do not start a cutover.
+
+## Transfer one workload family
+
+1. Enable that family's `scout_temporal_*_enabled` flag. This first stops the
+   legacy owner and allows new durable starts.
+2. Wait for already-running legacy work to finish. Check its effects, not only
+   the process log.
+3. Unpause that family's fixed Schedules in the Temporal UI.
+4. Trigger each Schedule once. For reports, also create or update a beta report
+   and confirm its outbox row is reconciled into one owned per-report Schedule.
+5. Confirm deterministic duplicate HTTP starts return the existing execution,
+   and that effect-claim duplicate counters remain zero.
+
+Never automatically fall back to the legacy owner during a Temporal outage.
+That creates two authorities as soon as Temporal recovers.
+
+## Exercise restart and outage recovery
+
+For each family in beta:
+
+1. Start representative work, restart the Scout backend, and verify the same
+   Workflow resumes on the same ID.
+2. Stop or isolate the Worker while Temporal remains available. Confirm the
+   server keeps creating eligible Schedule actions and the next valid action
+   obeys overlap, catchup, and staleness rules when the Worker returns.
+3. Interrupt Temporal server access. Confirm Scout HTTP and Discord remain up,
+   durable starts reject clearly, and no legacy scheduler takes ownership.
+4. Restore Temporal and rerun the queue canary.
+5. Disconnect and reconnect Explore SSE. Confirm the client rebuilds from the
+   persisted snapshot and terminal outcome.
+6. Disconnect report AI after its provider-attempt marker is written. Confirm
+   the run salvages or interrupts and the provider receives no second request.
+7. Force a report Schedule cron and task-queue mismatch, reconcile it, and
+   confirm the desired definition returns while an operator pause is preserved.
+
+## Run the beta soak
+
+Record the beta image digest, deployed commit, and soak start time. Keep all
+four families enabled for at least 24 hours. The soak passes only when:
+
+- every fixed and per-report Schedule has the expected ownership and policy;
+- all four Activity queues retain pollers and acceptable schedule-to-start
+  latency;
+- the report outbox drains and no stale product projection remains;
+- interrupted provider attempts are explained and no ambiguous attempt caused
+  a second LLM call;
+- duplicate-effect claim failures remain zero;
+- raw S3 persistence continues to gate match cursor advancement; and
+- manual daily and weekly triggers complete with their expected Discord and
+  report-lake effects.
+
+Record the end time and evidence before promoting the same image to production.
+Repeat the queue canary and representative manual triggers after production is
+deployed.
+
+## Roll back a family
+
+1. Pause its Temporal Schedules.
+2. Stop accepting new starts for the family.
+3. Wait for in-flight Temporal executions and effects to settle or cancel them
+   explicitly.
+4. Disable the family flag to restore the legacy owner.
+
+Do not reverse steps 3 and 4.
+
+## Remove compatibility code
+
+After the production soak, land the prepared cleanup that removes the legacy
+cron owner, process-local run managers, temporary flags, obsolete recovery
+code, and deleted Schedule definitions.
+
+The weekly-parlay and Bryan Bucks HTTP callback boundary has a longer replay
+constraint. Keep its Activity implementation, secret, and NetworkPolicy rule
+until all pre-cutover executions are closed and 30 days of namespace retention
+have elapsed. Then remove the callback endpoint and token from Scout, the
+central Worker, 1Password resources, and network policy in one reviewed change.
+
+## Related
+
+- [Why Scout embeds Temporal Workers](/explanation/temporal/scout-orchestration/)
+- [Temporal schedule mechanics](/reference/temporal-schedules/)
+- [Pause or debug a schedule](/how-to/pause-or-debug-a-schedule/)

--- a/packages/docs/wiki/src/content/docs/reference/temporal-schedules.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-schedules.md
@@ -17,15 +17,15 @@ For the list of what runs and when, see
 
 ## Schedule properties
 
-| Property        | Value                                                                |
-| --------------- | -------------------------------------------------------------------- |
-| Timing          | Cron with an IANA timezone, or a fixed interval with optional offset |
-| Timezone        | Declared per cron schedule; interval schedules do not use a timezone |
-| Overlap policy  | `SKIP` by default; the weekly Scout parlay uses `ALLOW_ALL`          |
-| Reconciliation  | upsert of every schedule at each worker boot                         |
-| Source of truth | the `SCHEDULES` array in code; a PR is the change process            |
-| Deletion        | explicit — add the schedule ID to the deletion list                  |
-| Orphan drift    | a metric is exported for any server schedule code no longer defines  |
+| Property        | Value                                                                 |
+| --------------- | --------------------------------------------------------------------- |
+| Timing          | Cron with an IANA timezone, or a fixed interval with optional offset  |
+| Timezone        | Declared per cron schedule; interval schedules do not use a timezone  |
+| Overlap policy  | `SKIP` by default; reports use `BUFFER_ONE`; weekly parlay allows all |
+| Reconciliation  | upsert of every schedule at each worker boot                          |
+| Source of truth | the `SCHEDULES` array in code; a PR is the change process             |
+| Deletion        | explicit — add the schedule ID to the deletion list                   |
+| Orphan drift    | a metric is exported for any server schedule code no longer defines   |
 
 ## Pause behaviour
 
@@ -48,6 +48,16 @@ period key, and a delayed prior finalization must not suppress the next market.
 | Most schedules and Scout maintenance | 1 hour         |
 | Time-of-day home automation          | 5 minutes      |
 | Scout latest-state polling           | 5 minutes      |
+| Scout user reports                   | 1 hour         |
+
+Scout's fixed schedules live in the central array. Enabled product reports are
+the deliberate exception: each report owns a dynamic
+`scout-<stage>-report-<reportId>` Schedule, identified by an exact ownership
+memo. Postgres owns the cron, timezone, enabled state, and revision. The report
+outbox reconciler owns creation, closed-world updates, and tombstone deletion.
+Central orphan detection exempts only an ID whose strict memo matches that ID;
+lookalike or mismatched schedules still alert and are never deleted
+automatically.
 
 Home automation is deliberately tight: a 09:00 vacuum run should not fire at
 noon after an outage.

--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -45,6 +45,13 @@ changing model identity.
 | competition updates        | every minute                         | deterministic          | due Discord standings            |
 | weekly parlay lifecycle    | Sun, source-defined Pacific timeline | deterministic          | beta Scout market reconciliation |
 | weekly parlay catch-up     | operator, stable period/slot ID      | deterministic          | shortened beta Scout market      |
+| realtime and post-match    | fixed Schedules                      | deterministic          | match child Workflows            |
+| initial history            | reconciliation                       | deterministic          | paged S3/lake ingestion          |
+| report Schedule reconcile  | Signal + every minute                | deterministic          | per-report Schedules             |
+| report run                 | report Schedule or manual request    | deterministic          | persisted and Discord output     |
+| Explore turn               | one user turn                        | LLM with durable guard | persisted answer and SSE         |
+| report-AI edit             | one user edit                        | LLM with durable guard | persisted report revision        |
+| queue canary               | operator before/after rollout        | deterministic          | four queue-routing results       |
 
 The weekly parlay workflow uses the Pacific timeline defined by its source
 constants and reconciles each period through finalization. Its schedule remains
@@ -128,5 +135,6 @@ send. Models cannot select the status or subject.
 ## Related
 
 - [Schedule reference](/reference/temporal-schedules/) — cron mechanics
+- [Roll out Scout's Temporal workers](/how-to/roll-out-scout-temporal/) — cutover and soak procedure
 - [Agent task input](/reference/agent-task-input/) — the task schema
 - [Why Temporal](/explanation/temporal/overview/) — what the fleet is for

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout-alert-constants.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout-alert-constants.ts
@@ -1,0 +1,7 @@
+export const SCOUT_TRPC_NON_FAULT_CODES = [
+  "OK",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "NOT_FOUND",
+  "BAD_REQUEST",
+];

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.test.ts
@@ -1,6 +1,53 @@
 import { describe, expect, test } from "vitest";
 import { getScoutRuleGroups } from "./scout.ts";
 
+describe("Scout Temporal alert rules", () => {
+  const temporal = getScoutRuleGroups().find(
+    (group) => group.name === "scout-temporal",
+  );
+
+  test("covers Worker, latency, drift, projection, provider, and effect health", () => {
+    if (temporal?.rules === undefined) {
+      throw new Error("Missing scout-temporal rule group");
+    }
+    const alerts = new Set(temporal.rules.map((rule) => rule.alert));
+    expect(alerts).toEqual(
+      new Set([
+        "ScoutTemporalDisconnected",
+        "ScoutTemporalWorkerMissing",
+        "ScoutTemporalActivityFailing",
+        "ScoutTemporalTaskScheduleToStartHigh",
+        "ScoutTemporalDurabilityMetricsUnknown",
+        "ScoutTemporalReportOutboxStale",
+        "ScoutTemporalReportScheduleDrift",
+        "ScoutTemporalProductProjectionStale",
+        "ScoutTemporalProviderAttemptInterrupted",
+        "ScoutTemporalDuplicateEffectClaim",
+      ]),
+    );
+  });
+
+  test("alerts when Scout Temporal metrics are absent in either stage", () => {
+    if (temporal?.rules === undefined) {
+      throw new Error("Missing scout-temporal rule group");
+    }
+    for (const alert of [
+      "ScoutTemporalDisconnected",
+      "ScoutTemporalWorkerMissing",
+      "ScoutTemporalDurabilityMetricsUnknown",
+    ]) {
+      const rule = temporal.rules.find(
+        (candidate) => candidate.alert === alert,
+      );
+      if (rule === undefined) throw new Error(`Missing ${alert}`);
+      const expression = JSON.stringify(rule.expr);
+      expect(expression).toContain("absent(");
+      expect(expression).toContain(String.raw`environment=\"beta\"`);
+      expect(expression).toContain(String.raw`environment=\"prod\"`);
+    }
+  });
+});
+
 describe("Scout bot-health alert rules", () => {
   const botHealth = getScoutRuleGroups().find(
     (group) => group.name === "scout-bot-health",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/scout.ts
@@ -1,20 +1,13 @@
 import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
+import { SCOUT_TRPC_NON_FAULT_CODES } from "./scout-alert-constants.ts";
 
 /**
  * tRPC result codes that are ordinary traffic on a public web surface rather
  * than backend faults: anonymous page loads, permission denials, bad client
  * input, and missing rows. Alerting on these would fire continuously.
  */
-const TRPC_NON_FAULT_CODES = [
-  "OK",
-  "UNAUTHORIZED",
-  "FORBIDDEN",
-  "NOT_FOUND",
-  "BAD_REQUEST",
-];
-
 /**
  * Threshold note for the `scout-web` group.
  *
@@ -25,8 +18,152 @@ const TRPC_NON_FAULT_CODES = [
  * alert meant to catch it. These rules use absolute counts over a window
  * instead, sized to what "obviously wrong" looks like at this scale.
  */
+function getScoutTemporalRuleGroup(): PrometheusRuleSpecGroups {
+  return {
+    name: "scout-temporal",
+    rules: [
+      {
+        alert: "ScoutTemporalDisconnected",
+        annotations: {
+          summary: "Scout's embedded Temporal supervisor is disconnected",
+          message: escapePrometheusTemplate(
+            "Scout {{ $labels.environment }} has rejected durable starts because its Temporal supervisor has been disconnected for five minutes. Legacy execution must remain stopped; restore Temporal connectivity.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          '(min by (environment) (scout_temporal_connected{environment=~"beta|prod"}) == 0) or absent(scout_temporal_connected{environment="beta"}) or absent(scout_temporal_connected{environment="prod"})',
+        ),
+        for: "5m",
+        labels: { severity: "critical" },
+      },
+      {
+        alert: "ScoutTemporalWorkerMissing",
+        annotations: {
+          summary: "A Scout Temporal task-queue worker is missing",
+          message:
+            "Scout must expose workflow, realtime, interactive, background, and lake Workers after Discord readiness. Inspect the embedded Worker supervisor before changing concurrency.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          '(count by (environment) (scout_temporal_workers{environment=~"beta|prod"} == 1) < 5) or absent(scout_temporal_workers{environment="beta"}) or absent(scout_temporal_workers{environment="prod"})',
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalActivityFailing",
+        annotations: {
+          summary: "Scout Temporal Activities are failing",
+          message: escapePrometheusTemplate(
+            "Scout queue {{ $labels.task_queue }} has failed Activities in the last 30 minutes. Inspect the Workflow history and effect claims before retrying manually.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'sum by (task_queue) (increase(activity_task_fail{task_queue=~"scout-(beta|prod).*"}[30m])) > 0',
+        ),
+        for: "10m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalTaskScheduleToStartHigh",
+        annotations: {
+          summary: "Scout Temporal tasks are waiting for a Worker",
+          message:
+            "Scout task p95 schedule-to-start latency has exceeded ten seconds. Inspect the affected task queue and embedded Worker resources before tuning concurrency.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'histogram_quantile(0.95, sum by (task_queue, le) (rate(task_schedule_to_start_latency_bucket{task_queue=~"scout-(beta|prod).*"}[5m]))) > 10000',
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalDurabilityMetricsUnknown",
+        annotations: {
+          summary: "Scout Temporal durability metrics are unavailable",
+          message:
+            "Scout could not query report outbox or interactive projection state. Restore the Scout database metric query before relying on the age and drift alerts.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          '(scout_temporal_report_outbox_oldest_timestamp_seconds < 0) or (scout_temporal_stale_product_projections < 0) or absent(scout_temporal_report_outbox_oldest_timestamp_seconds{environment="beta"}) or absent(scout_temporal_report_outbox_oldest_timestamp_seconds{environment="prod"}) or absent(scout_temporal_stale_product_projections{environment="beta"}) or absent(scout_temporal_stale_product_projections{environment="prod"})',
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalReportOutboxStale",
+        annotations: {
+          summary: "Scout's report Schedule outbox is stale",
+          message: escapePrometheusTemplate(
+            "Scout {{ $labels.environment }} has an unprocessed report Schedule outbox row older than five minutes. Inspect the singleton reconciler Workflow and Temporal Schedule.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "scout_temporal_report_outbox_oldest_timestamp_seconds > 0 and (time() - scout_temporal_report_outbox_oldest_timestamp_seconds) > 300",
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalReportScheduleDrift",
+        annotations: {
+          summary: "Scout report Schedules differ from product state",
+          message:
+            "The report Schedule audit found a missing, drifted, orphaned, or ownership-mismatched Schedule. Unknown ownership mismatches are deliberately not deleted.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "scout_temporal_report_schedule_drift > 0 or scout_temporal_report_schedule_orphans > 0",
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalProductProjectionStale",
+        annotations: {
+          summary: "Scout product execution state is stale",
+          message:
+            "An Explore or report-AI projection has remained active beyond its 40-minute execution budget. Temporal remains authoritative; reconcile the product row from Workflow state.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "scout_temporal_stale_product_projections > 0",
+        ),
+        for: "5m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalProviderAttemptInterrupted",
+        annotations: {
+          summary: "Scout salvaged an ambiguous provider attempt",
+          message: escapePrometheusTemplate(
+            "Scout interrupted {{ $value }} {{ $labels.kind }} provider attempt(s) rather than risk duplicate model spend. Inspect persisted partial output and the original Worker interruption.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "sum by (kind) (increase(scout_temporal_interrupted_provider_attempts_total[30m])) > 0",
+        ),
+        for: "1m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "ScoutTemporalDuplicateEffectClaim",
+        annotations: {
+          summary: "Scout retried an ambiguous or mismatched external effect",
+          message: escapePrometheusTemplate(
+            "Scout observed {{ $value }} duplicate {{ $labels.kind }} effect claim(s) with outcome {{ $labels.outcome }}. Verify the stable Discord nonce or storage key prevented a duplicate effect.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'sum by (kind, outcome) (increase(scout_temporal_duplicate_effect_claims_total{outcome=~"ambiguous_retry|kind_mismatch"}[30m])) > 0',
+        ),
+        for: "1m",
+        labels: { severity: "warning" },
+      },
+    ],
+  };
+}
+
 export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
+    getScoutTemporalRuleGroup(),
     {
       name: "scout-riot-api",
       rules: [
@@ -384,7 +521,7 @@ export function getScoutRuleGroups(): PrometheusRuleSpecGroups[] {
             ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            `sum by (environment, procedure, code) (increase(scout_trpc_calls_total{code!~"${TRPC_NON_FAULT_CODES.join("|")}"}[30m])) > 5`,
+            `sum by (environment, procedure, code) (increase(scout_trpc_calls_total{code!~"${SCOUT_TRPC_NON_FAULT_CODES.join("|")}"}[30m])) > 5`,
           ),
           for: "5m",
           labels: {

--- a/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/durable-runs.ts
@@ -56,6 +56,7 @@ export async function reserveAndStartDurableExploreRun(input: {
       started: input.started,
       guildIds: input.guildIds,
     }),
+    database: input.database,
   });
   if (rejection !== null) return rejection;
   try {

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/http-route.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/http-route.ts
@@ -27,6 +27,8 @@ import {
   scoutReportAiRunDurationSeconds,
   scoutReportAiRunsTotal,
 } from "#src/metrics/report-ai.ts";
+import { temporalInteractiveEnabled } from "#src/config/dynamic.ts";
+import { createTemporalReportAiResponse } from "#src/reports/ai/temporal-runtime.ts";
 
 const STREAM_PATH = "/api/reports/query-agent/stream";
 const encoder = new TextEncoder();
@@ -90,6 +92,36 @@ export async function handleReportAiRoute(
     return jsonError(ticket.reason, 429, corsHeaders, {
       quota: ticket.quota,
       retryAfterSeconds: ticket.retryAfterSeconds,
+    });
+  }
+
+  if (temporalInteractiveEnabled()) {
+    const { reserveDurableReportAiRun } =
+      await import("#src/temporal/durable-quota.ts");
+    const durableRejection = await reserveDurableReportAiRun({
+      id: ticket.runId,
+      identity: authResult.identity,
+      exempt: status.exempt,
+      payload: JSON.stringify({
+        edit: parsedBody.input,
+        exempt: status.exempt,
+      }),
+    });
+    if (durableRejection !== null) {
+      ticket.finish();
+      scoutReportAiRunsTotal.inc({ status: "rate_limited" });
+      return jsonError(durableRejection.reason, 429, corsHeaders, {
+        quota: status.quota,
+        retryAfterSeconds: durableRejection.retryAfterSeconds,
+      });
+    }
+    return createTemporalReportAiResponse({
+      request,
+      edit: parsedBody.input,
+      identity: authResult.identity,
+      ticket,
+      exempt: status.exempt,
+      corsHeaders,
     });
   }
 

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/http-route.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/http-route.ts
@@ -98,15 +98,22 @@ export async function handleReportAiRoute(
   if (temporalInteractiveEnabled()) {
     const { reserveDurableReportAiRun } =
       await import("#src/temporal/durable-quota.ts");
-    const durableRejection = await reserveDurableReportAiRun({
-      id: ticket.runId,
-      identity: authResult.identity,
-      exempt: status.exempt,
-      payload: JSON.stringify({
-        edit: parsedBody.input,
-        exempt: status.exempt,
-      }),
-    });
+    const durableRejection = await (async () => {
+      try {
+        return await reserveDurableReportAiRun({
+          id: ticket.runId,
+          identity: authResult.identity,
+          exempt: status.exempt,
+          payload: JSON.stringify({
+            edit: parsedBody.input,
+            exempt: status.exempt,
+          }),
+        });
+      } catch (error) {
+        ticket.finish();
+        throw error;
+      }
+    })();
     if (durableRejection !== null) {
       ticket.finish();
       scoutReportAiRunsTotal.inc({ status: "rate_limited" });

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/temporal-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/temporal-runtime.ts
@@ -22,8 +22,10 @@ import {
   scoutReportAiRunDurationSeconds,
   scoutReportAiRunsTotal,
 } from "#src/metrics/report-ai.ts";
+import { createLogger } from "#src/logger.ts";
 
 const encoder = new TextEncoder();
+const logger = createLogger("report-ai-temporal-runtime");
 
 type ActiveReportAiRuntime = {
   abortController: AbortController;
@@ -111,6 +113,7 @@ export function createTemporalReportAiResponse(input: {
   input.request.signal.addEventListener("abort", abortFromRequest, {
     once: true,
   });
+  if (input.request.signal.aborted) abortFromRequest();
   const timeout = setTimeout(() => {
     void requestTemporalReportAiStop(input.ticket.runId);
   }, REPORT_AI_TIMEOUT_MS);
@@ -235,10 +238,21 @@ async function requestTemporalReportAiStop(runId: string): Promise<void> {
   });
   const supervisor = currentScoutTemporalSupervisor();
   if (supervisor === undefined) return;
-  await supervisor
-    .client()
-    .workflow.getHandle(
-      scoutInteractiveWorkflowId(configuration.environment, "report-ai", runId),
-    )
-    .signal(requestStopSignal);
+  try {
+    await supervisor
+      .client()
+      .workflow.getHandle(
+        scoutInteractiveWorkflowId(
+          configuration.environment,
+          "report-ai",
+          runId,
+        ),
+      )
+      .signal(requestStopSignal);
+  } catch (error) {
+    logger.warn(
+      `Persisted stop for report-AI run ${runId} before its Workflow could be signalled`,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
 }

--- a/packages/scout-for-lol/packages/backend/src/reports/schedule-reconciler.real-server.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/schedule-reconciler.real-server.integration.test.ts
@@ -1,0 +1,250 @@
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Client, Connection, ScheduleNotFoundError } from "@temporalio/client";
+import { ScoutScheduleOwnershipMemoSchema } from "@scout-for-lol/temporal";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  enqueueReportScheduleDeletion,
+  enqueueReportScheduleUpsert,
+} from "#src/reports/temporal-schedules.ts";
+import { drainReportScheduleOutbox } from "#src/reports/schedule-reconciler.ts";
+import { scheduleMatchesReport } from "#src/reports/report-schedule-drift.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+
+const { prisma } = createTestDatabase("report-schedule-real-server");
+let server: ReturnType<typeof Bun.spawn> | undefined;
+let connection: Connection | undefined;
+let client: Client | undefined;
+let directory: string | undefined;
+
+function requireClient(): Client {
+  if (client === undefined)
+    throw new Error("Temporal test Client is not ready");
+  return client;
+}
+
+async function unusedPort(): Promise<number> {
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data() {
+        return;
+      },
+    },
+  });
+  const port = listener.port;
+  listener.stop(true);
+  return port;
+}
+
+beforeAll(async () => {
+  const executableResult = Bun.spawnSync(["mise", "which", "temporal"], {
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  if (executableResult.exitCode !== 0) {
+    throw new Error("mise could not resolve the pinned Temporal CLI");
+  }
+  const executable = executableResult.stdout.toString().trim();
+  const port = await unusedPort();
+  directory = await mkdtemp(path.join(tmpdir(), "scout-report-schedules-"));
+  server = Bun.spawn(
+    [
+      executable,
+      "--disable-config-file",
+      "server",
+      "start-dev",
+      "--headless",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      port.toString(),
+      "--db-filename",
+      path.join(directory, "temporal.db"),
+    ],
+    { stdout: "ignore", stderr: "pipe" },
+  );
+  const address = `127.0.0.1:${port.toString()}`;
+  const deadline = Date.now() + 20_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) {
+      throw new Error(
+        `Temporal dev server exited with ${server.exitCode.toString()}`,
+      );
+    }
+    try {
+      connection = await Connection.connect({
+        address,
+        connectTimeout: 500,
+      });
+      client = new Client({ connection, namespace: "default" });
+      return;
+    } catch (error: unknown) {
+      lastError = error;
+      await Bun.sleep(100);
+    }
+  }
+  throw new Error("Temporal dev server did not become ready", {
+    cause: lastError,
+  });
+}, 30_000);
+
+beforeEach(async () => {
+  await prisma.reportScheduleOutbox.deleteMany();
+  await prisma.reportRun.deleteMany();
+  await prisma.report.deleteMany();
+  const temporal = requireClient();
+  for await (const summary of temporal.schedule.list()) {
+    if (summary.scheduleId.startsWith("scout-dev-report-")) {
+      await temporal.schedule.getHandle(summary.scheduleId).delete();
+    }
+  }
+});
+
+afterAll(async () => {
+  await prisma.reportScheduleOutbox.deleteMany();
+  await prisma.reportRun.deleteMany();
+  await prisma.report.deleteMany();
+  await prisma.$disconnect();
+  await connection?.close();
+  if (server?.exitCode === null) {
+    server.kill();
+    await server.exited;
+  }
+  if (directory !== undefined) await rm(directory, { recursive: true });
+});
+
+test("reconciles report Schedules closed-world while preserving a human pause", async () => {
+  const temporal = requireClient();
+  const report = await prisma.$transaction(async (tx) => {
+    const created = await tx.report.create({
+      data: {
+        serverId: testGuildId("880000000000000101"),
+        ownerId: testAccountId("880000000000000102"),
+        channelId: testChannelId("880000000000000103"),
+        title: "Real Temporal Schedule",
+        queryText:
+          "SELECT player, games FROM match GROUP BY player RENDER table",
+        cronExpression: "0 8 * * *",
+        scheduleTimezone: "America/Los_Angeles",
+        nextScheduledRunAt: new Date(Date.now() + 86_400_000),
+        createdTime: new Date(),
+        updatedTime: new Date(),
+      },
+    });
+    await enqueueReportScheduleUpsert(tx, created.id, created.revision);
+    return created;
+  });
+
+  await expect(
+    drainReportScheduleOutbox(temporal, "dev", prisma),
+  ).resolves.toEqual({ processed: 1, remaining: 0 });
+  const scheduleId = `scout-dev-report-${report.id.toString()}`;
+  const handle = temporal.schedule.getHandle(scheduleId);
+  const created = await handle.describe();
+  expect(ScoutScheduleOwnershipMemoSchema.parse(created.memo)).toEqual({
+    owner: "scout-for-lol",
+    stage: "dev",
+    reportId: report.id.toString(),
+    schemaVersion: 1,
+  });
+  expect(created.action.taskQueue).toBe("scout-dev");
+  expect(created.policies.overlap).toBe("BUFFER_ONE");
+  expect(created.policies.catchupWindow).toBe(3_600_000);
+
+  await handle.pause("operator maintenance");
+  const updated = await prisma.$transaction(async (tx) => {
+    const next = await tx.report.update({
+      where: { id: report.id },
+      data: {
+        cronExpression: "30 9 * * *",
+        revision: { increment: 1 },
+        updatedTime: new Date(),
+      },
+    });
+    await enqueueReportScheduleUpsert(tx, next.id, next.revision);
+    return next;
+  });
+  await drainReportScheduleOutbox(temporal, "dev", prisma);
+  const reconciled = await handle.describe();
+  expect(reconciled.state.paused).toBe(true);
+  expect(reconciled.action.args).toEqual([
+    {
+      stage: "dev",
+      reportId: report.id.toString(),
+      revision: updated.revision,
+      source: "schedule",
+    },
+  ]);
+
+  await handle.update((previous) => ({
+    spec: {
+      cronExpressions: ["30 9 * * 1"],
+      timezone: "America/Los_Angeles",
+    },
+    action: {
+      type: "startWorkflow",
+      workflowType: "scoutReportRunWorkflow",
+      taskQueue: "wrong-queue",
+      args: [
+        {
+          stage: "dev",
+          reportId: report.id.toString(),
+          revision: updated.revision,
+          source: "schedule",
+        },
+      ],
+      workflowExecutionTimeout: 15 * 60 * 1000,
+    },
+    policies: previous.policies,
+    state: previous.state,
+  }));
+  const drifted = await handle.describe();
+  const desired = {
+    stage: "dev" as const,
+    reportId: report.id,
+    revision: updated.revision,
+    cronExpression: "30 9 * * *",
+    timezone: "America/Los_Angeles",
+  };
+  expect(scheduleMatchesReport(drifted, desired)).toBe(false);
+  await drainReportScheduleOutbox(temporal, "dev", prisma);
+  const repaired = await handle.describe();
+  expect(scheduleMatchesReport(repaired, desired)).toBe(true);
+  expect(repaired.state.paused).toBe(true);
+
+  await prisma.$transaction(async (tx) => {
+    await enqueueReportScheduleDeletion(tx, report.id, updated.revision + 1);
+    await tx.report.delete({ where: { id: report.id } });
+  });
+  await drainReportScheduleOutbox(temporal, "dev", prisma);
+  await expect(handle.describe()).rejects.toBeInstanceOf(ScheduleNotFoundError);
+});
+
+test("alerts but does not delete a prefix match without the strict ownership memo", async () => {
+  const temporal = requireClient();
+  const scheduleId = "scout-dev-report-999999";
+  await temporal.schedule.create({
+    scheduleId,
+    spec: { intervals: [{ every: 60_000 }] },
+    action: {
+      type: "startWorkflow",
+      workflowType: "unknownWorkflow",
+      taskQueue: "unknown-queue",
+    },
+    memo: { owner: "someone-else" },
+  });
+
+  await drainReportScheduleOutbox(temporal, "dev", prisma);
+  await expect(
+    temporal.schedule.getHandle(scheduleId).describe(),
+  ).resolves.toMatchObject({ scheduleId });
+});

--- a/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
@@ -11,6 +11,7 @@ import {
   requireCompletedScoutEffectResult,
 } from "#src/temporal/effect-claims.ts";
 import {
+  durableExploreQuotaRejection,
   reserveDurableExploreRun,
   reserveDurableReportAiRun,
 } from "#src/temporal/durable-quota.ts";
@@ -77,6 +78,56 @@ describe("durable interactive reservations", () => {
 
     expect(attempts.filter((result) => result === null)).toHaveLength(1);
     expect(attempts.filter((result) => result !== null)).toHaveLength(1);
+  });
+
+  test("releases spend quota when execution fails before the provider claim", async () => {
+    const ownerId = DiscordAccountIdSchema.parse("900000000000000111");
+    const now = Date.parse("2026-08-24T12:00:00.000Z");
+    for (const index of [0, 1, 2, 3, 4]) {
+      const id = globalThis.crypto.randomUUID();
+      await expect(
+        reserveDurableExploreRun({
+          id,
+          ownerId,
+          conversationId: globalThis.crypto.randomUUID(),
+          payload: "{}",
+          now,
+          database: prisma,
+        }),
+      ).resolves.toBeNull();
+      await prisma.scoutInteractiveRun.update({
+        where: { id },
+        data: { state: "FAILED", completedAt: new Date(now + index) },
+      });
+    }
+
+    await expect(
+      durableExploreQuotaRejection(ownerId, now, prisma),
+    ).resolves.toBeNull();
+  });
+
+  test("charges spend quota after the provider claim even when execution interrupts", async () => {
+    const ownerId = DiscordAccountIdSchema.parse("900000000000000112");
+    const now = Date.parse("2026-08-24T12:00:00.000Z");
+    for (const index of [0, 1, 2, 3]) {
+      await prisma.scoutInteractiveRun.create({
+        data: {
+          id: globalThis.crypto.randomUUID(),
+          kind: "explore",
+          ownerId,
+          conversationId: globalThis.crypto.randomUUID(),
+          payload: "{}",
+          state: "INTERRUPTED",
+          providerAttemptAt: new Date(now + index),
+          completedAt: new Date(now + index),
+          createdAt: new Date(now + index),
+        },
+      });
+    }
+
+    await expect(
+      durableExploreQuotaRejection(ownerId, now + 4, prisma),
+    ).resolves.toMatchObject({ retryAfterSeconds: 60 });
   });
 
   test("interrupts an ambiguous provider attempt without opening a runtime", async () => {

--- a/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/durability.integration.test.ts
@@ -1,8 +1,43 @@
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
 } from "@scout-for-lol/data";
+import type { ReportQueryAgentParams } from "#src/reports/ai/report-query-agent.ts";
+import type { ExploreAgentParams } from "#src/explore/agent.ts";
+
+const reportAiProvider = vi.hoisted(() => ({ calls: 0 }));
+const exploreProvider = vi.hoisted(() => ({ calls: 0 }));
+vi.mock("#src/reports/ai/report-query-agent.ts", () => ({
+  streamReportQueryAgent: async (params: ReportQueryAgentParams) => {
+    reportAiProvider.calls++;
+    await params.emit({ type: "draft_delta", text: "SELECT player" });
+    return {
+      title: "Recovered draft",
+      description: null,
+      queryText: "SELECT player FROM competition_rank LIMIT 1",
+      explanation: "Recovered from its durable input.",
+      warnings: [],
+    };
+  },
+}));
+vi.mock("#src/explore/agent.ts", () => ({
+  streamExploreAgent: async (params: ExploreAgentParams) => {
+    exploreProvider.calls++;
+    await params.emit({ type: "answer_delta", text: "Recovered answer" });
+    return {
+      answer: {
+        answer: "Recovered answer",
+        title: null,
+        queryText: null,
+        caveats: [],
+        followUps: [],
+      },
+      preview: null,
+      visualization: null,
+    };
+  },
+}));
 import { createTestDatabase } from "#src/testing/test-database.ts";
 import {
   claimScoutEffect,
@@ -16,20 +51,31 @@ import {
   reserveDurableReportAiRun,
 } from "#src/temporal/durable-quota.ts";
 import {
+  executeRecoveredExplore,
+  executeRecoveredReportAi,
   persistScoutInteractiveOutcome,
   runScoutInteractiveActivity,
 } from "#src/temporal/interactive-activities.ts";
+import { startExploreTurn } from "#src/explore/store.ts";
 
 const { prisma } = createTestDatabase("temporal-durability");
 
 beforeEach(async () => {
+  reportAiProvider.calls = 0;
+  exploreProvider.calls = 0;
   await prisma.scoutEffectClaim.deleteMany();
   await prisma.scoutInteractiveRun.deleteMany();
+  await prisma.exploreMessage.deleteMany();
+  await prisma.exploreConversation.deleteMany();
+  await prisma.user.deleteMany();
 });
 
 afterAll(async () => {
   await prisma.scoutEffectClaim.deleteMany();
   await prisma.scoutInteractiveRun.deleteMany();
+  await prisma.exploreMessage.deleteMany();
+  await prisma.exploreConversation.deleteMany();
+  await prisma.user.deleteMany();
   await prisma.$disconnect();
 });
 
@@ -129,7 +175,9 @@ describe("durable interactive reservations", () => {
       durableExploreQuotaRejection(ownerId, now + 4, prisma),
     ).resolves.toMatchObject({ retryAfterSeconds: 60 });
   });
+});
 
+describe("durable interactive recovery", () => {
   test("interrupts an ambiguous provider attempt without opening a runtime", async () => {
     const runId = globalThis.crypto.randomUUID();
     await prisma.scoutInteractiveRun.create({
@@ -153,6 +201,7 @@ describe("durable interactive reservations", () => {
       status: "interrupted",
       partialOutputAvailable: true,
     });
+    expect(reportAiProvider.calls).toBe(0);
     await persistScoutInteractiveOutcome(
       { stage: "dev", kind: "report-ai", databaseRunId: runId, outcome },
       prisma,
@@ -163,6 +212,93 @@ describe("durable interactive reservations", () => {
         select: { state: true, providerAttemptAt: true },
       }),
     ).toMatchObject({ state: "INTERRUPTED" });
+  });
+
+  test("rebuilds a pending report-AI execution from its durable payload", async () => {
+    const runId = globalThis.crypto.randomUUID();
+    const guildId = DiscordGuildIdSchema.parse("900000000000000212");
+    await prisma.scoutInteractiveRun.create({
+      data: {
+        id: runId,
+        kind: "report-ai",
+        ownerId: DiscordAccountIdSchema.parse("900000000000000211"),
+        guildId,
+        payload: JSON.stringify({
+          edit: {
+            guildId,
+            instructions: "Make a compact leaderboard",
+            currentQueryText: null,
+            currentTitle: null,
+            currentDescription: null,
+            sourceCompetitionId: null,
+          },
+          exempt: false,
+        }),
+      },
+    });
+    const run = await prisma.scoutInteractiveRun.findUniqueOrThrow({
+      where: { id: runId },
+    });
+
+    await expect(
+      executeRecoveredReportAi(run, new AbortController().signal, prisma),
+    ).resolves.toEqual({
+      status: "completed",
+      partialOutputAvailable: true,
+    });
+    expect(reportAiProvider.calls).toBe(1);
+    await expect(
+      prisma.scoutInteractiveRun.findUniqueOrThrow({ where: { id: runId } }),
+    ).resolves.toMatchObject({
+      partialOutput: "SELECT player",
+    });
+  });
+
+  test("rebuilds a pending Explore turn from its durable payload", async () => {
+    const ownerId = DiscordAccountIdSchema.parse("900000000000000221");
+    await prisma.user.create({
+      data: { discordId: ownerId, discordUsername: "recovered-explorer" },
+    });
+    const started = await startExploreTurn(prisma, {
+      conversationId: null,
+      newId: globalThis.crypto.randomUUID(),
+      userId: ownerId,
+      question: "Which champion wins the most?",
+      attach: { kind: "leaf" },
+    });
+    const runId = globalThis.crypto.randomUUID();
+    await prisma.scoutInteractiveRun.create({
+      data: {
+        id: runId,
+        kind: "explore",
+        ownerId,
+        conversationId: started.conversationId,
+        payload: JSON.stringify({
+          summary: { runId },
+          started: {
+            ...started,
+            question: "Which champion wins the most?",
+          },
+          guildIds: [],
+        }),
+      },
+    });
+    const run = await prisma.scoutInteractiveRun.findUniqueOrThrow({
+      where: { id: runId },
+    });
+
+    await expect(
+      executeRecoveredExplore(run, new AbortController().signal, prisma),
+    ).resolves.toBe("succeeded");
+    expect(exploreProvider.calls).toBe(1);
+    await expect(
+      prisma.exploreMessage.findFirstOrThrow({
+        where: {
+          conversationId: started.conversationId,
+          role: "assistant",
+        },
+      }),
+    ).resolves.toMatchObject({ content: "Recovered answer" });
   });
 
   test("honors a persisted stop before claiming provider spend", async () => {

--- a/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
@@ -2,9 +2,17 @@ import { Context } from "@temporalio/activity";
 import { ApplicationFailure } from "@temporalio/common";
 import { z } from "zod";
 import {
-  ExploreActiveRunSchema,
+  DiscordGuildIdSchema,
+  EXPLORE_ANSWER_MAX_LENGTH,
+  EXPLORE_TIMEOUT_MS,
   ExploreRunOutcomeSchema,
   ExploreTraceEntrySchema,
+  ReportAiEditRequestSchema,
+  ReportAiStreamEventSchema,
+  type ExploreRunOutcome,
+  type ExploreStreamEvent,
+  type ExploreTraceEntry,
+  type ReportAiStreamEvent,
 } from "@scout-for-lol/data";
 import type {
   InteractiveOutcome,
@@ -13,11 +21,18 @@ import type {
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { exploreRunManager } from "#src/explore/run-manager.ts";
 import { persistPartialAnswer } from "#src/explore/partial-answer.ts";
+import { loadExploreTranscript } from "#src/explore/store.ts";
+import { runPersistedExploreTurn } from "#src/explore/run-turn.ts";
+import { streamExploreAgent } from "#src/explore/agent.ts";
+import type { ExploreRateLimitTicket } from "#src/explore/rate-limit.ts";
+import { recordExploreTraceEvent } from "#src/explore/trace.ts";
+import { streamReportQueryAgent } from "#src/reports/ai/report-query-agent.ts";
+import { getReportAiQuotaStatus } from "#src/reports/ai/rate-limit.ts";
 import { scoutTemporalInterruptedProviderAttempts } from "#src/metrics/temporal.ts";
 import type { ScoutInteractiveRun } from "#generated/prisma/client/index.js";
 
 const ExplorePayloadSchema = z.strictObject({
-  summary: ExploreActiveRunSchema,
+  summary: z.looseObject({ runId: z.uuid() }),
   started: z.strictObject({
     conversationId: z.uuid(),
     title: z.string(),
@@ -29,6 +44,11 @@ const ExplorePayloadSchema = z.strictObject({
     createdQuestion: z.boolean(),
   }),
   guildIds: z.array(z.string()),
+});
+
+const ReportAiPayloadSchema = z.strictObject({
+  edit: ReportAiEditRequestSchema,
+  exempt: z.boolean(),
 });
 
 function mapExploreOutcome(
@@ -129,38 +149,78 @@ async function runUntilSettled<T>(input: {
   }
 }
 
+export async function executeRecoveredReportAi(
+  run: ScoutInteractiveRun,
+  abortSignal: AbortSignal,
+  database: ExtendedPrismaClient,
+): Promise<InteractiveOutcome> {
+  const payload = ReportAiPayloadSchema.parse(JSON.parse(run.payload));
+  const guildId = DiscordGuildIdSchema.parse(run.guildId);
+  const events: ReportAiStreamEvent[] = [];
+  let partial = "";
+  const emit = async (rawEvent: ReportAiStreamEvent): Promise<void> => {
+    const event = ReportAiStreamEventSchema.parse(rawEvent);
+    events.push(event);
+    if (event.type === "draft_delta") partial += event.text;
+    await database.scoutInteractiveRun.update({
+      where: { id: run.id },
+      data: {
+        partialOutput: partial.length === 0 ? null : partial,
+        trace: JSON.stringify(events),
+      },
+    });
+  };
+  const draft = await streamReportQueryAgent({
+    runId: run.id,
+    input: payload.edit,
+    abortSignal,
+    emit,
+  });
+  await emit({
+    type: "final",
+    draft,
+    formattedQueryText: draft.queryText,
+    quota: getReportAiQuotaStatus(
+      { userId: run.ownerId, guildId },
+      Date.now(),
+      { exempt: payload.exempt },
+    ).quota,
+  });
+  return {
+    status: "completed",
+    partialOutputAvailable: partial.length > 0,
+  };
+}
+
 async function runReportAiActivity(
-  runId: string,
+  run: ScoutInteractiveRun,
   database: ExtendedPrismaClient,
 ): Promise<InteractiveOutcome> {
   const { reportAiRuntime } =
     await import("#src/reports/ai/temporal-runtime.ts");
-  const runtime = reportAiRuntime(runId);
-  if (runtime === undefined) {
-    throw new Error(
-      `Report AI run ${runId} has no live execution adapter after its provider claim`,
-    );
-  }
+  const runtime = reportAiRuntime(run.id);
+  const abortController = runtime?.abortController ?? new AbortController();
   const cancellationSignal = Context.current().cancellationSignal;
   const cancel = (): void => {
-    runtime.abortController.abort(
-      "Report AI edit cancelled by its Temporal Workflow.",
-    );
+    abortController.abort("Report AI edit cancelled by its Temporal Workflow.");
   };
   cancellationSignal.addEventListener("abort", cancel, { once: true });
   if (cancellationSignal.aborted) cancel();
   try {
     return await runUntilSettled({
-      execution: runtime.execute(),
+      execution:
+        runtime === undefined
+          ? executeRecoveredReportAi(run, abortController.signal, database)
+          : runtime.execute(),
       intervalMs: 5000,
       heartbeat: async () => {
         const snapshot = await database.scoutInteractiveRun.findUniqueOrThrow({
-          where: { id: runId },
+          where: { id: run.id },
           select: { partialOutput: true, stopRequestedAt: true },
         });
         if (snapshot.stopRequestedAt !== null) cancel();
         Context.current().heartbeat({
-          runId,
+          runId: run.id,
           partialCharacters: snapshot.partialOutput?.length ?? 0,
         });
       },
@@ -170,47 +230,134 @@ async function runReportAiActivity(
   }
 }
 
+export async function executeRecoveredExplore(
+  run: ScoutInteractiveRun,
+  abortSignal: AbortSignal,
+  database: ExtendedPrismaClient,
+): Promise<ExploreRunOutcome> {
+  const payload = ExplorePayloadSchema.parse(JSON.parse(run.payload));
+  const transcript = await loadExploreTranscript(
+    database,
+    payload.started.conversationId,
+    run.ownerId,
+    payload.started.messageId,
+  );
+  if (transcript === null) {
+    throw ApplicationFailure.nonRetryable(
+      `Explore conversation ${payload.started.conversationId} no longer exists`,
+      "MissingDomainRecord",
+    );
+  }
+  const trace: ExploreTraceEntry[] = [];
+  let partial = "";
+  const ticket: ExploreRateLimitTicket = {
+    allowed: true,
+    runId: run.id,
+    claimConversation: () => true,
+    commit: () => {
+      // The database reservation is already the authoritative quota claim.
+    },
+    finish: () => {
+      // Durable cleanup releases quota when this Activity records its outcome.
+    },
+  };
+  const emit = async (event: ExploreStreamEvent): Promise<void> => {
+    if (event.type === "answer_delta") {
+      const available = EXPLORE_ANSWER_MAX_LENGTH - partial.length;
+      if (available > 0) partial += event.text.slice(0, available);
+    } else if (event.type === "final") {
+      partial = event.message.content;
+    }
+    recordExploreTraceEvent(trace, event);
+    await database.scoutInteractiveRun.update({
+      where: { id: run.id },
+      data: {
+        partialOutput: partial.length === 0 ? null : partial,
+        trace: JSON.stringify(trace),
+        ...(event.type === "final"
+          ? { resultMessageId: event.message.id }
+          : {}),
+      },
+    });
+  };
+  const result = await runPersistedExploreTurn(
+    {
+      ticket,
+      identity: { userId: run.ownerId },
+      guildIds: payload.guildIds,
+      started: payload.started,
+      history: transcript.messages,
+      abortSignal,
+      abortOutcome: () => "stopped",
+      emit,
+    },
+    {
+      client: database,
+      executeAgent: streamExploreAgent,
+      now: Date.now,
+      timeoutMs: EXPLORE_TIMEOUT_MS,
+    },
+  );
+  return result.outcome;
+}
+
 async function runExploreActivity(
-  runId: string,
+  run: ScoutInteractiveRun,
   database: ExtendedPrismaClient,
 ): Promise<InteractiveOutcome> {
   const cancellationSignal = Context.current().cancellationSignal;
+  const recoveredAbortController = new AbortController();
+  const localRuntime = exploreRunManager.snapshot(run.id) !== undefined;
   const cancel = (): void => {
-    exploreRunManager.cancelTemporal(
-      runId,
-      "Explore turn cancelled by its Temporal Workflow.",
-    );
+    if (localRuntime) {
+      exploreRunManager.cancelTemporal(
+        run.id,
+        "Explore turn cancelled by its Temporal Workflow.",
+      );
+    } else {
+      recoveredAbortController.abort(
+        "Explore turn cancelled by its Temporal Workflow.",
+      );
+    }
   };
   cancellationSignal.addEventListener("abort", cancel, { once: true });
   if (cancellationSignal.aborted) cancel();
   try {
     const outcome = await runUntilSettled({
-      execution: exploreRunManager.executeTemporal(runId),
+      execution: localRuntime
+        ? exploreRunManager.executeTemporal(run.id)
+        : executeRecoveredExplore(
+            run,
+            recoveredAbortController.signal,
+            database,
+          ),
       intervalMs: 1000,
       heartbeat: async () => {
-        const snapshot = exploreRunManager.snapshot(runId);
+        const snapshot = exploreRunManager.snapshot(run.id);
         const control = await database.scoutInteractiveRun.findUniqueOrThrow({
-          where: { id: runId },
-          select: { stopRequestedAt: true },
+          where: { id: run.id },
+          select: { partialOutput: true, stopRequestedAt: true },
         });
         if (control.stopRequestedAt !== null) cancel();
-        if (snapshot === undefined) return;
-        await database.scoutInteractiveRun.update({
-          where: { id: runId },
-          data: {
-            partialOutput: snapshot.answer,
-            trace: JSON.stringify(snapshot.trace),
-          },
-        });
+        if (snapshot !== undefined) {
+          await database.scoutInteractiveRun.update({
+            where: { id: run.id },
+            data: {
+              partialOutput: snapshot.answer,
+              trace: JSON.stringify(snapshot.trace),
+            },
+          });
+        }
         Context.current().heartbeat({
-          runId,
-          partialCharacters: snapshot.answer.length,
-          traceEntries: snapshot.trace.length,
+          runId: run.id,
+          partialCharacters:
+            snapshot?.answer.length ?? control.partialOutput?.length ?? 0,
+          traceEntries: snapshot?.trace.length ?? 0,
         });
       },
     });
     const persisted = await database.scoutInteractiveRun.findUniqueOrThrow({
-      where: { id: runId },
+      where: { id: run.id },
       select: { partialOutput: true },
     });
     return mapExploreOutcome(
@@ -256,25 +403,6 @@ export async function runScoutInteractiveActivity(
     return await ambiguousOutcome(run, database);
   }
 
-  if (run.kind === "explore") {
-    const parsedPayload = ExplorePayloadSchema.parse(JSON.parse(run.payload));
-    await exploreRunManager.rehydrateTemporalRun({
-      summary: parsedPayload.summary,
-      identity: { userId: run.ownerId },
-      guildIds: parsedPayload.guildIds,
-      started: parsedPayload.started,
-    });
-  } else {
-    const { reportAiRuntime } =
-      await import("#src/reports/ai/temporal-runtime.ts");
-    if (reportAiRuntime(run.id) === undefined) {
-      return {
-        status: "interrupted",
-        partialOutputAvailable: (run.partialOutput?.length ?? 0) > 0,
-      };
-    }
-  }
-
   const claim = await database.scoutInteractiveRun.updateMany({
     where: { id: run.id, providerAttemptAt: null, state: "PENDING" },
     data: {
@@ -290,9 +418,9 @@ export async function runScoutInteractiveActivity(
   }
 
   if (input.kind === "report-ai") {
-    return await runReportAiActivity(run.id, database);
+    return await runReportAiActivity(run, database);
   }
-  return await runExploreActivity(run.id, database);
+  return await runExploreActivity(run, database);
 }
 
 export async function persistScoutInteractiveOutcome(

--- a/packages/scout-for-lol/packages/temporal/package.json
+++ b/packages/scout-for-lol/packages/temporal/package.json
@@ -21,6 +21,10 @@
     "format": "bun x prettier --check src package.json tsconfig.json",
     "test": "bun run test:ci",
     "test:bun": "bun --no-install --bun vitest --config ../../../../vitest.config.ts run src --exclude 'src/workflows/*.test.ts'",
+    "test:workflows": "bun scripts/test-workflows.ts",
+    "replay:histories": "bun scripts/replay-histories.ts",
+    "replay:histories:node": "node --experimental-strip-types scripts/replay-histories-node.ts",
+    "canary": "bun scripts/run-canary.ts",
     "test:ci": "bun ../../../../scripts/run-ci-test.ts",
     "test:report": "CI_TEST_COVERAGE=1 bun ../../../../scripts/run-ci-test.ts"
   },

--- a/packages/scout-for-lol/packages/temporal/package.json
+++ b/packages/scout-for-lol/packages/temporal/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@scout-for-lol/data": "workspace:*",
     "@temporalio/activity": "1.22.0",
+    "@temporalio/client": "1.22.0",
     "@temporalio/testing": "1.22.0",
     "@temporalio/worker": "1.22.0",
     "@types/node": "^26.1.1",

--- a/packages/scout-for-lol/packages/temporal/scripts/replay-histories-node.ts
+++ b/packages/scout-for-lol/packages/temporal/scripts/replay-histories-node.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+import { Client, Connection } from "@temporalio/client";
+import { Worker } from "@temporalio/worker";
+import { z } from "zod";
+
+const WorkflowIdSchema = z.string().regex(/^scout-(?:beta|prod)-[\w.:-]+$/u);
+const TlsSchema = z.enum(["true", "false"]).optional();
+
+async function main(): Promise<void> {
+  const workflowIds = process.argv
+    .slice(2)
+    .map((value) => WorkflowIdSchema.parse(value));
+  if (workflowIds.length === 0) {
+    throw new Error("Pass at least one beta or production Scout Workflow ID");
+  }
+  const address = process.env["TEMPORAL_ADDRESS"];
+  if (address === undefined) {
+    throw new Error("TEMPORAL_ADDRESS is required for live history replay");
+  }
+  const tls = TlsSchema.parse(process.env["TEMPORAL_TLS"]);
+  const connection = await Connection.connect({
+    address,
+    ...(tls === "true" ? { tls: true } : {}),
+  });
+  try {
+    const client = new Client({
+      connection,
+      namespace: process.env["TEMPORAL_NAMESPACE"] ?? "default",
+    });
+    const workflowsPath = path.resolve(
+      import.meta.dirname,
+      "../src/workflows/index.ts",
+    );
+    for (const workflowId of workflowIds) {
+      const history = await client.workflow
+        .getHandle(workflowId)
+        .fetchHistory();
+      await Worker.runReplayHistory({ workflowsPath }, history, workflowId);
+      console.warn(`Replayed ${workflowId}`);
+    }
+  } finally {
+    await connection.close();
+  }
+}
+
+await main();

--- a/packages/scout-for-lol/packages/temporal/scripts/replay-histories.ts
+++ b/packages/scout-for-lol/packages/temporal/scripts/replay-histories.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+
+const packageRoot = path.resolve(import.meta.dir, "..");
+const repositoryRoot = path.resolve(packageRoot, "../../../..");
+const result = Bun.spawnSync(["mise", "where", "node"], {
+  cwd: repositoryRoot,
+  stdout: "pipe",
+  stderr: "inherit",
+});
+if (result.exitCode !== 0) {
+  throw new Error(
+    `mise where node exited with status ${String(result.exitCode)}; run mise install.`,
+  );
+}
+const nodeExecutable = path.join(
+  new TextDecoder().decode(result.stdout).trim(),
+  "bin",
+  process.platform === "win32" ? "node.exe" : "node",
+);
+if (!(await Bun.file(nodeExecutable).exists())) {
+  throw new Error(`mise resolved Node without ${nodeExecutable}`);
+}
+
+const child = Bun.spawn(
+  [
+    nodeExecutable,
+    "--experimental-strip-types",
+    path.join(packageRoot, "scripts/replay-histories-node.ts"),
+    ...Bun.argv.slice(2),
+  ],
+  {
+    cwd: packageRoot,
+    env: Bun.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  },
+);
+process.exitCode = await child.exited;

--- a/packages/scout-for-lol/packages/temporal/scripts/run-canary.ts
+++ b/packages/scout-for-lol/packages/temporal/scripts/run-canary.ts
@@ -1,0 +1,70 @@
+import { parseArgs } from "node:util";
+import {
+  Client,
+  Connection,
+  WorkflowIdConflictPolicy,
+  WorkflowIdReusePolicy,
+} from "@temporalio/client";
+import { z } from "zod";
+import {
+  SCOUT_WORKFLOW_NAMES,
+  ScoutQueueCanaryProbeResultSchema,
+  ScoutStageSchema,
+  scoutQueueCanaryWorkflowId,
+  scoutTaskQueues,
+} from "@scout-for-lol/temporal";
+
+const TemporalTlsSchema = z.enum(["true", "false"]).optional();
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    stage: { type: "string" },
+    address: { type: "string", default: "127.0.0.1:7233" },
+    namespace: { type: "string", default: "default" },
+    "canary-id": { type: "string" },
+  },
+  strict: true,
+});
+
+const options = z
+  .strictObject({
+    stage: ScoutStageSchema,
+    address: z.string().min(1),
+    namespace: z.string().min(1),
+    "canary-id": z.string().min(1).optional(),
+  })
+  .parse(values);
+const canaryId = options["canary-id"] ?? globalThis.crypto.randomUUID();
+const temporalTls = TemporalTlsSchema.parse(process.env["TEMPORAL_TLS"]);
+const connection = await Connection.connect({
+  address: options.address,
+  ...(temporalTls === "true" ? { tls: true } : {}),
+});
+try {
+  const client = new Client({ connection, namespace: options.namespace });
+  const handle = await client.workflow.start(SCOUT_WORKFLOW_NAMES.queueCanary, {
+    workflowId: scoutQueueCanaryWorkflowId(options.stage, canaryId),
+    workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+    workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+    taskQueue: scoutTaskQueues(options.stage).workflow,
+    args: [{ stage: options.stage, canaryId }],
+  });
+  const results = z
+    .array(ScoutQueueCanaryProbeResultSchema)
+    .length(4)
+    .parse(await handle.result());
+  console.log(
+    JSON.stringify(
+      {
+        workflowId: handle.workflowId,
+        runId: handle.firstExecutionRunId,
+        results,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await connection.close();
+}

--- a/packages/scout-for-lol/packages/temporal/scripts/run-canary.ts
+++ b/packages/scout-for-lol/packages/temporal/scripts/run-canary.ts
@@ -15,6 +15,35 @@ import {
 } from "@scout-for-lol/temporal";
 
 const TemporalTlsSchema = z.enum(["true", "false"]).optional();
+const CANARY_TIMEOUT_MS = 60_000;
+
+class CanaryTimeoutError extends Error {
+  constructor() {
+    super(
+      `Scout Temporal queue canary did not complete within ${CANARY_TIMEOUT_MS.toString()}ms`,
+    );
+    this.name = "CanaryTimeoutError";
+  }
+}
+
+async function resultWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new CanaryTimeoutError());
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
 
 const { values } = parseArgs({
   args: process.argv.slice(2),
@@ -50,10 +79,19 @@ try {
     taskQueue: scoutTaskQueues(options.stage).workflow,
     args: [{ stage: options.stage, canaryId }],
   });
+  let rawResults: unknown;
+  try {
+    rawResults = await resultWithTimeout(handle.result(), CANARY_TIMEOUT_MS);
+  } catch (error: unknown) {
+    if (error instanceof CanaryTimeoutError) {
+      await handle.cancel();
+    }
+    throw error;
+  }
   const results = z
     .array(ScoutQueueCanaryProbeResultSchema)
     .length(4)
-    .parse(await handle.result());
+    .parse(rawResults);
   console.log(
     JSON.stringify(
       {

--- a/packages/scout-for-lol/packages/temporal/src/workflows/lifecycle.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/lifecycle.test.ts
@@ -287,7 +287,6 @@ test("initial history drains incomplete pages across Continue-As-New and accepts
       cursor: "cursor-100",
       pagesProcessed: 100,
       pagesInCurrentRun: 0,
-      runOnStart: true,
     },
     {
       stage: "dev",

--- a/packages/scout-for-lol/packages/temporal/src/workflows/real-server.test.ts
+++ b/packages/scout-for-lol/packages/temporal/src/workflows/real-server.test.ts
@@ -1,0 +1,387 @@
+import { afterEach, expect, test } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createServer } from "node:net";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  Client,
+  Connection,
+  ScheduleOverlapPolicy,
+  WorkflowIdConflictPolicy,
+  WorkflowIdReusePolicy,
+} from "@temporalio/client";
+import { NativeConnection, Worker } from "@temporalio/worker";
+import { SCOUT_WORKFLOW_NAMES, scoutTaskQueues } from "#src/identifiers.ts";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../../../../..");
+const workflowsPath = new URL("index.ts", import.meta.url).pathname;
+const temporalExecutable = execFileSync("mise", ["which", "temporal"], {
+  cwd: repositoryRoot,
+  encoding: "utf8",
+}).trim();
+
+type RunningWorkerSet = {
+  workers: Worker[];
+  runs: Promise<void>[];
+};
+
+type TestRuntime = {
+  server: ChildProcess;
+  connection: Connection;
+  nativeConnection: NativeConnection;
+  client: Client;
+  workers: RunningWorkerSet;
+  directory: string;
+  address: string;
+  port: number;
+};
+
+let runtime: TestRuntime | undefined;
+
+async function unusedPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Could not allocate a local Temporal test port");
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error === undefined) resolve();
+      else reject(error);
+    });
+  });
+  return address.port;
+}
+
+function startServer(port: number, databasePath: string) {
+  return spawn(
+    temporalExecutable,
+    [
+      "--disable-config-file",
+      "server",
+      "start-dev",
+      "--headless",
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      port.toString(),
+      "--db-filename",
+      databasePath,
+    ],
+    {
+      cwd: repositoryRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+}
+
+async function connectEventually(
+  address: string,
+  server: ChildProcess,
+): Promise<Connection> {
+  const deadline = Date.now() + 20_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) {
+      throw new Error(
+        `Temporal dev server exited with ${server.exitCode.toString()}`,
+      );
+    }
+    try {
+      return await Connection.connect({ address, connectTimeout: 500 });
+    } catch (error: unknown) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw new Error("Temporal dev server did not become ready", {
+    cause: lastError,
+  });
+}
+
+async function stopServer(server: ChildProcess): Promise<void> {
+  if (server.exitCode !== null) return;
+  server.kill("SIGTERM");
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("Temporal dev server did not stop after SIGTERM"));
+    }, 10_000);
+    server.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+async function startWorkers(input: {
+  connection: NativeConnection;
+  reportRuns: string[];
+  matchRuns: string[];
+  blockMatch: Promise<unknown>;
+}): Promise<RunningWorkerSet> {
+  const queues = scoutTaskQueues("dev");
+  const workers = [
+    await Worker.create({
+      connection: input.connection,
+      taskQueue: queues.workflow,
+      workflowsPath,
+    }),
+    await Worker.create({
+      connection: input.connection,
+      taskQueue: queues.realtime,
+      activities: {
+        ingestMatch: async (activityInput: { matchId: string }) => {
+          input.matchRuns.push(activityInput.matchId);
+          await input.blockMatch;
+        },
+      },
+    }),
+    await Worker.create({
+      connection: input.connection,
+      taskQueue: queues.background,
+      activities: {
+        runReport: (activityInput: { reportId: string }) => {
+          input.reportRuns.push(activityInput.reportId);
+        },
+      },
+    }),
+  ];
+  const runs = workers.map(async (worker) => {
+    await worker.run();
+  });
+  await Promise.all(
+    workers.map(async (worker) => {
+      await expect.poll(() => worker.getState()).toBe("RUNNING");
+    }),
+  );
+  return { workers, runs };
+}
+
+async function stopWorkers(workerSet: RunningWorkerSet): Promise<void> {
+  for (const worker of workerSet.workers) {
+    if (worker.getState() === "RUNNING") worker.shutdown();
+  }
+  await Promise.all(workerSet.runs);
+}
+
+afterEach(async () => {
+  const active = runtime;
+  runtime = undefined;
+  if (active === undefined) return;
+  await stopWorkers(active.workers);
+  await active.nativeConnection.close();
+  await active.connection.close();
+  await stopServer(active.server);
+  await rm(active.directory, { recursive: true });
+});
+
+test("real server preserves IDs, catches up Schedules, survives outages, and replays history", async () => {
+  const directory = await mkdtemp(
+    path.join(tmpdir(), "scout-temporal-real-server-"),
+  );
+  const port = await unusedPort();
+  const address = `127.0.0.1:${port.toString()}`;
+  const databasePath = path.join(directory, "temporal.db");
+  let server = startServer(port, databasePath);
+  let connection = await connectEventually(address, server);
+  let nativeConnection = await NativeConnection.connect({ address });
+  let client = new Client({ connection, namespace: "default" });
+  const reportRuns: string[] = [];
+  const matchRuns: string[] = [];
+  const matchGate = Promise.withResolvers<null>();
+  let workers = await startWorkers({
+    connection: nativeConnection,
+    reportRuns,
+    matchRuns,
+    blockMatch: matchGate.promise,
+  });
+  const runtimeState: TestRuntime = {
+    server,
+    connection,
+    nativeConnection,
+    client,
+    workers,
+    directory,
+    address,
+    port,
+  };
+  runtime = runtimeState;
+
+  const duplicateOptions = {
+    workflowId: "scout-dev-match-NA1_4242",
+    workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
+    workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+    taskQueue: scoutTaskQueues("dev").workflow,
+    args: [
+      {
+        stage: "dev",
+        matchId: "NA1_4242",
+        sourcePuuid: "puuid-real-server",
+        region: "AMERICA_NORTH",
+        delivery: "live",
+      },
+    ],
+  } as const;
+  const first = await client.workflow.start(
+    SCOUT_WORKFLOW_NAMES.matchIngestion,
+    duplicateOptions,
+  );
+  await expect.poll(() => matchRuns).toEqual(["NA1_4242"]);
+  const duplicate = await client.workflow.start(
+    SCOUT_WORKFLOW_NAMES.matchIngestion,
+    duplicateOptions,
+  );
+  expect(duplicate.workflowId).toBe(first.workflowId);
+  matchGate.resolve(null);
+  await expect(first.result()).resolves.toBe("completed");
+  expect(matchRuns).toEqual(["NA1_4242"]);
+
+  const replayHistory = await first.fetchHistory();
+  await Worker.runReplayHistory({ workflowsPath }, replayHistory);
+
+  await stopWorkers(workers);
+  workers = { workers: [], runs: [] };
+  runtimeState.workers = workers;
+  const pending = await client.workflow.start(SCOUT_WORKFLOW_NAMES.reportRun, {
+    workflowId: "scout-dev-manual-report-worker-restart",
+    taskQueue: scoutTaskQueues("dev").workflow,
+    args: [
+      {
+        stage: "dev",
+        reportId: "11",
+        revision: 1,
+        runId: "101",
+        source: "manual",
+      },
+    ],
+  });
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  expect(reportRuns).toEqual([]);
+  workers = await startWorkers({
+    connection: nativeConnection,
+    reportRuns,
+    matchRuns,
+    blockMatch: Promise.resolve(),
+  });
+  runtimeState.workers = workers;
+  await expect(pending.result()).resolves.toBe("completed");
+  expect(reportRuns).toEqual(["11"]);
+
+  await client.schedule.create({
+    scheduleId: "scout-dev-real-server-catchup",
+    spec: { intervals: [{ every: 1000 }] },
+    action: {
+      type: "startWorkflow",
+      workflowType: SCOUT_WORKFLOW_NAMES.reportRun,
+      taskQueue: scoutTaskQueues("dev").workflow,
+      args: [
+        {
+          stage: "dev",
+          reportId: "12",
+          revision: 1,
+          source: "schedule",
+        },
+      ],
+    },
+    policies: {
+      overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+      catchupWindow: 60_000,
+      pauseOnFailure: false,
+    },
+  });
+  await expect
+    .poll(() => reportRuns.includes("12"), { timeout: 5000 })
+    .toBe(true);
+
+  await stopWorkers(workers);
+  workers = { workers: [], runs: [] };
+  runtimeState.workers = workers;
+  const beforeWorkerOutage = reportRuns.filter((id) => id === "12").length;
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+  workers = await startWorkers({
+    connection: nativeConnection,
+    reportRuns,
+    matchRuns,
+    blockMatch: Promise.resolve(),
+  });
+  runtimeState.workers = workers;
+  await expect
+    .poll(() => reportRuns.filter((id) => id === "12").length, {
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(beforeWorkerOutage);
+  await client.schedule.getHandle("scout-dev-real-server-catchup").delete();
+
+  // Isolate server-outage catch-up from the buffered action created during the
+  // Worker-outage case above. This Schedule's complete publication window is
+  // while the server is down, so the only way its action can run is Temporal's
+  // persisted catch-up processing after restart.
+  const outageWindowStart = new Date(Date.now() + 1000);
+  await client.schedule.create({
+    scheduleId: "scout-dev-real-server-outage-catchup",
+    spec: {
+      intervals: [{ every: 1000 }],
+      startAt: outageWindowStart,
+      endAt: new Date(outageWindowStart.getTime() + 1000),
+    },
+    action: {
+      type: "startWorkflow",
+      workflowType: SCOUT_WORKFLOW_NAMES.reportRun,
+      taskQueue: scoutTaskQueues("dev").workflow,
+      args: [
+        {
+          stage: "dev",
+          reportId: "13",
+          revision: 1,
+          source: "schedule",
+        },
+      ],
+    },
+    policies: {
+      overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+      catchupWindow: 60_000,
+      pauseOnFailure: false,
+    },
+  });
+
+  await stopWorkers(workers);
+  workers = { workers: [], runs: [] };
+  runtimeState.workers = workers;
+  await nativeConnection.close();
+  await connection.close();
+  await stopServer(server);
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  server = startServer(port, databasePath);
+  connection = await connectEventually(address, server);
+  nativeConnection = await NativeConnection.connect({ address });
+  client = new Client({ connection, namespace: "default" });
+  const restoredSchedule = await client.schedule
+    .getHandle("scout-dev-real-server-outage-catchup")
+    .describe();
+  expect(restoredSchedule.state.paused).toBe(false);
+  runtimeState.server = server;
+  runtimeState.connection = connection;
+  runtimeState.nativeConnection = nativeConnection;
+  runtimeState.client = client;
+  const beforeServerOutage = reportRuns.filter((id) => id === "13").length;
+  workers = await startWorkers({
+    connection: nativeConnection,
+    reportRuns,
+    matchRuns,
+    blockMatch: Promise.resolve(),
+  });
+  runtimeState.workers = workers;
+  await expect
+    .poll(() => reportRuns.filter((id) => id === "13").length, {
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(beforeServerOutage);
+  await client.schedule
+    .getHandle("scout-dev-real-server-outage-catchup")
+    .delete();
+}, 90_000);

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -22,6 +22,8 @@
     "test": "bun run scripts/ensure-ha-schema.ts && bun run test:bun && bun run test:workflows",
     "test:bun": "bun --no-install --bun vitest --config ../../vitest.config.ts run src/activities src/event-bridge src/observability src/schedules src/shared src/lib src/workflows/agent-task.test.ts",
     "test:workflows": "bun scripts/test-workflows.ts",
+    "replay:scout-histories": "bun scripts/replay-scout-histories.ts",
+    "replay:scout-histories:node": "node --experimental-strip-types scripts/replay-scout-histories-node.ts",
     "test:integration": "bun run scripts/ensure-ha-schema.ts && bun --no-install --bun vitest --config ../../vitest.config.ts run src/integration.test.ts",
     "generate:live": "bun ../home-assistant/src/codegen/cli.ts --out src/generated/ha-schema.ts --name HaSchema",
     "docker:build": "docker buildx build --cache-from type=registry,ref=ghcr.io/shepherdjerred/temporal-worker:buildcache ${DOCKER_BUILD_EXTRA_ARGS:-} --load -t temporal-worker:dev -f Dockerfile ../..",

--- a/packages/temporal/scripts/replay-scout-histories-node.ts
+++ b/packages/temporal/scripts/replay-scout-histories-node.ts
@@ -1,0 +1,57 @@
+import path from "node:path";
+import { env } from "node:process";
+import { Client, Connection } from "@temporalio/client";
+import { Worker } from "@temporalio/worker";
+import { z } from "zod";
+
+const WorkflowIdSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      value.startsWith("scout-weekly-parlay") ||
+      value.startsWith("scout-bryan-bucks"),
+    "Only Scout Workflows with retained compatibility patches may be replayed by this command",
+  );
+const TlsSchema = z.enum(["true", "false"]).optional();
+
+async function main(): Promise<void> {
+  const workflowIds = process.argv
+    .slice(2)
+    .map((value) => WorkflowIdSchema.parse(value));
+  if (workflowIds.length === 0) {
+    throw new Error(
+      "Pass at least one beta Workflow ID for weekly parlay or Bryan Bucks replay",
+    );
+  }
+  const address = env["TEMPORAL_ADDRESS"];
+  if (address === undefined) {
+    throw new Error("TEMPORAL_ADDRESS is required for live history replay");
+  }
+  const tls = TlsSchema.parse(env["TEMPORAL_TLS"]);
+  const connection = await Connection.connect({
+    address,
+    ...(tls === "true" ? { tls: true } : {}),
+  });
+  try {
+    const client = new Client({
+      connection,
+      namespace: env["TEMPORAL_NAMESPACE"] ?? "default",
+    });
+    const workflowsPath = path.resolve(
+      import.meta.dirname,
+      "../src/workflows/index.ts",
+    );
+    for (const workflowId of workflowIds) {
+      const history = await client.workflow
+        .getHandle(workflowId)
+        .fetchHistory();
+      await Worker.runReplayHistory({ workflowsPath }, history, workflowId);
+      console.warn(`Replayed ${workflowId}`);
+    }
+  } finally {
+    await connection.close();
+  }
+}
+
+await main();

--- a/packages/temporal/scripts/replay-scout-histories.ts
+++ b/packages/temporal/scripts/replay-scout-histories.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+
+const packageRoot = path.resolve(import.meta.dir, "..");
+const repositoryRoot = path.resolve(packageRoot, "../..");
+const result = Bun.spawnSync(["mise", "where", "node"], {
+  cwd: repositoryRoot,
+  stdout: "pipe",
+  stderr: "inherit",
+});
+if (result.exitCode !== 0) {
+  throw new Error(
+    `mise where node exited with status ${String(result.exitCode)}; run mise install.`,
+  );
+}
+const nodeExecutable = path.join(
+  new TextDecoder().decode(result.stdout).trim(),
+  "bin",
+  process.platform === "win32" ? "node.exe" : "node",
+);
+if (!(await Bun.file(nodeExecutable).exists())) {
+  throw new Error(`mise resolved Node without ${nodeExecutable}`);
+}
+
+const child = Bun.spawn(
+  [
+    nodeExecutable,
+    "--experimental-strip-types",
+    path.join(packageRoot, "scripts/replay-scout-histories-node.ts"),
+    ...Bun.argv.slice(2),
+  ],
+  {
+    cwd: packageRoot,
+    env: Bun.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  },
+);
+process.exitCode = await child.exited;


### PR DESCRIPTION
## Why

Explore turns and report-AI requests can outlive an HTTP connection, consume limited model quota, and become ambiguous if Scout crashes around the provider call.

## What

- Creates one persisted Temporal execution per Explore turn and report-AI run instead of a permanent conversation Workflow.
- Signals Workflow cancellation on Explore stop or report-AI disconnect and uses non-cancellable cleanup to persist the outcome, release unspent quota, and salvage partial output.
- Atomically records `AMBIGUOUS_OR_STARTED` before model network I/O; a retry salvages instead of issuing a second provider request.
- Counts a provider attempt against spend quota once claimed, including interrupted outcomes, without charging failures that occur before the claim.
- Persists partial text and traces during streaming while retaining the public SSE event shape and in-process low-latency broker.
- Reconnects clients from durable run snapshots and terminal outcomes.
- Adds real-server restart/outage/catch-up/duplicate-start coverage, four-queue canaries, replay commands, alerts, exact networking checks, and the rollout/rollback runbook.

## Safety

A possible false interruption is preferred over duplicate model spend. Temporal history contains only opaque IDs, phases, status enums, and counters; prompts, transcripts, query results, tokens, and partial model output remain in Postgres/S3.

## Verification

- backend 269 files / 2,378 tests
- Scout Temporal typecheck/lint and 4 files / 10 tests for Signals, cancellation cleanup, provider ambiguity, failed-child restart, and Continue-As-New
- central Temporal typecheck/lint/architecture and 110 files / 940 tests
- cdk8s 584 tests plus GPU synthesis checks
- wiki 6 tests and 57-page production build
- staged pre-commit hooks

Not run: live beta history replay, deployed queue canaries, outage drill, or 24-hour soak. Those require this stack to be merged and deployed.
