### PR TITLE
feat(toolkit): add direct Bugsink issue resolver

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1812,10 +1812,6 @@
       "clones": 1,
       "tokens": 78
     },
-    "packages/temporal/src/activities/homelab-audit.test.ts|packages/toolkit/test/bugsink/client.test.ts": {
-      "clones": 1,
-      "tokens": 127
-    },
     "packages/temporal/src/activities/homelab-audit.ts|packages/temporal/src/activities/scout-season-refresh-claude.ts": {
       "clones": 4,
       "tokens": 457
@@ -1949,5 +1945,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-25T06:08:20.721Z"
+  "updated": "2026-08-26T00:57:18.743Z"
 }

--- a/packages/dotfiles/dot_agents/skills/bugsink-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/bugsink-helper/SKILL.md
@@ -201,12 +201,27 @@ curl -s -H "$AUTH" "$API/issues/$ISSUE_UUID/" | \
 
 ---
 
-## Resolving / Muting Issues (web UI only)
+## Resolving Issues (direct API only)
 
-The canonical REST API is **read-only** for issues — `PATCH`/`POST` on an issue returns `405` (Allow: GET, HEAD, OPTIONS). To resolve or mute, drive the Django + allauth web-UI bulk-action form:
+Issue triage remains read-only by default. Reviewed issue cleanup uses the
+repository's explicit UUID-only resolver, which calls the canonical REST API
+directly; never automate the Bugsink web UI and never add automatic
+classification or muting:
 
-1. **Log in:** GET `/accounts/login/` for the `csrfmiddlewaretoken` + `csrftoken` cookie, then POST `username`/`password`/`csrfmiddlewaretoken`/`next` to `/accounts/login/` **with `Origin` and `Referer` headers** (Django HTTPS CSRF requires them, else `403 CSRF verification failed`). A `sessionid` cookie means success.
-2. **Bulk action:** the issue list is at `/issues/<project_id>/` (integer id); scrape its `issueForm` for a fresh `csrfmiddlewaretoken`, then POST to `/issues/<project_id>/` with `csrfmiddlewaretoken`, `action=resolved_next` (or `mute` / `mute_for:...` / `unmute`), and one `issue_ids[]=<uuid>` per issue (batch allowed). Verify via `GET /api/canonical/0/issues/<uuid>/` → `is_resolved: true`.
+```bash
+toolkit bugsink resolve <UUID...> --dry-run
+toolkit bugsink resolve <UUID...> --confirm
+toolkit bugsink resolve --from-file issues.txt --confirm --json
+```
+
+The resolver preflights every explicit UUID with `GET
+/api/canonical/0/issues/{uuid}/`, rejects missing or muted issues before any
+mutation, skips already-resolved issues, and POSTs only eligible issues to
+`/api/canonical/0/issues/{uuid}/resolve/` with the complete current issue
+payload required by Bugsink. It verifies every successful mutation with a
+follow-up GET and stops on the first mutation or verification error without
+retrying. `--confirm` is required for mutation; without it, the command is a
+dry run. Resolution is the only supported mutation.
 
 Resolving does **not** prevent recurrence — the issue reopens as a regression on the next matching event, so resolve "fixed" issues only after the fix deploys.
 

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -12,6 +12,7 @@ bun run src/index.ts pr health             # PR health check
 bun run src/index.ts deployed scout        # Is a service/commit live on the homelab?
 bun run src/index.ts alerts list           # Alert ledger occurrences
 bun run src/index.ts bugsink issues        # Bugsink issues
+bun run src/index.ts bugsink resolve ...   # Explicit REST API resolution
 bun run src/index.ts prom query 'up == 0'  # GCX-backed Prometheus query
 bun run src/index.ts bk build list         # Native Buildkite CLI with repo defaults
 bun run src/index.ts screenshot stocks-sjer-red /   # Visually verify a frontend change
@@ -340,7 +341,7 @@ this layer.
 
 - **`src/lib/http.ts`** — `createHttpClient({ baseUrl, auth, errorLabel, headers?, normalizeUrl? })`
   returns a client with `get(endpoint, { schema, query? })`, `post(endpoint, { schema, body?, query? })`,
-  and `raw(endpoint, { query? })` (text, no JSON parse). All three return the
+  `postRaw(endpoint, { body?, query? })`, and `raw(endpoint, { query? })` (text, no JSON parse). All four return the
   standard `{ success, data?, error? }` envelope. `auth` is a discriminated shape —
   `{ scheme: "Bearer", token }` or `{ scheme: "Token token=", token }` — written
   verbatim into the `Authorization` header. Query params are `set` for scalars and
@@ -358,6 +359,13 @@ route the GitHub, Buildkite, S3, Discord, or native passthrough transports
 through it; they have different process and authentication boundaries. Unit
 tests live in `test/lib/` (`http.test.ts`, `config.test.ts`),
 wired into the `test:unit` glob.
+
+`toolkit bugsink resolve` is the one Bugsink mutation command. It accepts only
+explicit issue UUIDs (directly or from a newline-delimited file), requires
+`--confirm`, preflights every target before the first POST, and verifies every
+resolved issue with a follow-up GET. It calls the canonical REST API directly;
+it never drives the Bugsink web UI, supports no broad selectors, and cannot
+mute issues.
 
 ## Adding New Commands
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -97,8 +97,21 @@ is already occupied rather than capturing an unrelated process.
 ### Operations and local history
 
 - `toolkit alerts list|show` queries the durable alert occurrence ledger.
-- `toolkit bugsink ...` queries teams, projects, issues, events, stacktraces,
-  and releases in self-hosted Bugsink.
+- `toolkit bugsink ...` queries self-hosted Bugsink and can resolve an explicit
+  reviewed issue UUID allowlist through the canonical REST API.
+
+To preview or apply a reviewed resolution set:
+
+```bash
+toolkit bugsink resolve <ISSUE_UUID...> --dry-run
+toolkit bugsink resolve --from-file issues.txt --confirm
+```
+
+Resolution always preflights every target, refuses missing or muted issues, and
+verifies each successful REST action with a follow-up API read. `--confirm` is
+required for changes; the command never uses the Bugsink web UI and does not
+support muting or broad selector-based cleanup.
+
 - `toolkit discord ...` operates the private local Discord session daemon.
 - `toolkit history ...` searches the private, rebuildable local agent-history
   index. It never treats prior conversation as current deployment truth.

--- a/packages/toolkit/src/commands/bugsink/resolve.ts
+++ b/packages/toolkit/src/commands/bugsink/resolve.ts
@@ -1,0 +1,104 @@
+import { formatJson } from "#lib/output/formatter.ts";
+import {
+  parseBugsinkIssueIds,
+  resolveIssues,
+  type ResolveIssuesResult,
+} from "#lib/bugsink/resolver.ts";
+
+export type ResolveCommandOptions = {
+  confirm?: boolean;
+  dryRun?: boolean;
+  fromFile?: string | undefined;
+  ids: string[];
+  json?: boolean;
+};
+
+function formatIds(ids: readonly string[]): string[] {
+  return ids.map((id) => `- ${id}`);
+}
+
+export function formatResolveResult(result: ResolveIssuesResult): string {
+  const lines = [
+    "## Bugsink Issue Resolution",
+    "",
+    `Mode: ${result.dryRun ? "DRY RUN" : "APPLY"}`,
+    `Requested: ${String(result.requested.length)}`,
+    `Eligible: ${String(result.eligible.length)}`,
+    `Already resolved: ${String(result.skipped.length)}`,
+    `Resolved: ${String(result.resolved.length)}`,
+    "",
+  ];
+
+  if (result.eligible.length > 0) {
+    lines.push(result.dryRun ? "Would resolve:" : "Eligible:");
+    lines.push(...formatIds(result.eligible));
+    lines.push("");
+  }
+
+  if (result.skipped.length > 0) {
+    lines.push("Already resolved:");
+    lines.push(...formatIds(result.skipped));
+    lines.push("");
+  }
+
+  if (result.resolved.length > 0) {
+    lines.push("Resolved and verified:");
+    lines.push(...formatIds(result.resolved));
+    lines.push("");
+  }
+
+  if (result.errors.length > 0) {
+    lines.push("Errors:");
+    for (const error of result.errors) {
+      lines.push(`- ${error.id}: ${error.message}`);
+    }
+    lines.push("");
+  }
+
+  if (result.success && result.dryRun) {
+    lines.push(
+      "No changes made. Re-run with --confirm to resolve eligible issues.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export async function resolveCommand(
+  options: ResolveCommandOptions,
+): Promise<void> {
+  try {
+    if (options.confirm === true && options.dryRun === true) {
+      throw new Error("--confirm and --dry-run cannot be used together");
+    }
+
+    const fileContents =
+      options.fromFile == null
+        ? undefined
+        : await Bun.file(options.fromFile).text();
+    const issueIds = parseBugsinkIssueIds(options.ids, fileContents);
+    const result = await resolveIssues(issueIds, {
+      confirm: options.confirm,
+      dryRun: options.dryRun,
+    });
+
+    if (options.json === true) {
+      console.log(formatJson(result));
+    } else {
+      console.log(formatResolveResult(result));
+    }
+
+    if (!result.success) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error occurred";
+    if (options.json === true) {
+      console.log(formatJson({ success: false, error: message }));
+    } else {
+      console.error(`Error: ${message}`);
+    }
+    process.exitCode = 1;
+  }
+}

--- a/packages/toolkit/src/handlers/bugsink.ts
+++ b/packages/toolkit/src/handlers/bugsink.ts
@@ -6,6 +6,7 @@ import { projectsCommand, projectCommand } from "#commands/bugsink/projects.ts";
 import { eventsCommand, eventCommand } from "#commands/bugsink/events.ts";
 import { stacktraceCommand } from "#commands/bugsink/stacktrace.ts";
 import { releasesCommand, releaseCommand } from "#commands/bugsink/releases.ts";
+import { resolveCommand } from "#commands/bugsink/resolve.ts";
 
 function parseJsonFlag(args: string[]) {
   return parseArgs({
@@ -145,6 +146,26 @@ async function handleRelease(args: string[]): Promise<void> {
   await releaseCommand(uuid, { json: values.json });
 }
 
+async function handleResolve(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      confirm: { type: "boolean", default: false },
+      "dry-run": { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+      "from-file": { type: "string" },
+    },
+    allowPositionals: true,
+  });
+  await resolveCommand({
+    confirm: values.confirm,
+    dryRun: values["dry-run"],
+    fromFile: values["from-file"],
+    ids: positionals,
+    json: values.json,
+  });
+}
+
 export async function handleBugsinkCommand(
   subcommand: string | undefined,
   args: string[],
@@ -170,12 +191,16 @@ Subcommands:
   stacktrace <EVT_UUID> Get event stacktrace (markdown)
   releases              List releases
   release <UUID>        View release details
+  resolve <UUID...>     Preview or resolve explicit issue UUIDs via the REST API
 
 Options:
   --json                Output as JSON
   --project <slug|id>   (issues/releases) Filter by project
   --team <uuid>         (projects) Filter by team UUID
   --limit <n>           Maximum number of results
+  --from-file <path>    Read additional newline-delimited issue UUIDs
+  --dry-run             Preview resolution without changing Bugsink
+  --confirm             Apply resolution after preflighting every target
 
 Environment:
   BUGSINK_URL           Required. Your Bugsink instance URL.
@@ -190,6 +215,8 @@ Examples:
   tools bugsink events <issue-uuid>
   tools bugsink stacktrace <event-uuid>
   tools bugsink releases --project my-app
+  tools bugsink resolve <issue-uuid> --dry-run
+  tools bugsink resolve --from-file issues.txt --confirm
 `);
     process.exit(0);
   }
@@ -227,6 +254,9 @@ Examples:
       break;
     case "release":
       await handleRelease(args);
+      break;
+    case "resolve":
+      await handleResolve(args);
       break;
     default:
       console.error(`Unknown bugsink subcommand: ${subcommand}`);

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -36,7 +36,7 @@ Monorepo workflows:
   deployed [SELECTOR]          Trace a commit or service to the live homelab
   screenshot <PKG> [ROUTE]     Start a site and capture a browser screenshot
   alerts <list|show>           Query the durable alert ledger
-  bugsink <SUBCOMMAND>         Query self-hosted error tracking
+  bugsink <SUBCOMMAND>         Query or resolve self-hosted error tracking
   discord <SUBCOMMAND>         Use the local Discord session daemon
   history <SUBCOMMAND>         Search private local agent history
 

--- a/packages/toolkit/src/lib/bugsink/client.ts
+++ b/packages/toolkit/src/lib/bugsink/client.ts
@@ -47,6 +47,13 @@ export async function bugsinkRequestRaw(
   return client().raw(endpoint, { query: params });
 }
 
+export async function bugsinkRequestPostRaw(
+  endpoint: string,
+  body: unknown,
+): Promise<BugsinkRawResult> {
+  return client().postRaw(endpoint, { body });
+}
+
 export function buildBugsinkApiUrl(baseUrl: string, endpoint: string): URL {
   const normalizedBase = baseUrl
     .replace(/\/$/, "")

--- a/packages/toolkit/src/lib/bugsink/issues.ts
+++ b/packages/toolkit/src/lib/bugsink/issues.ts
@@ -1,4 +1,4 @@
-import { bugsinkRequest } from "./client.ts";
+import { bugsinkRequest, bugsinkRequestPostRaw } from "./client.ts";
 import {
   BugsinkIssueSchema,
   BugsinkPaginatedResponseSchema,
@@ -64,4 +64,48 @@ export async function getIssue(issueId: string): Promise<BugsinkIssue | null> {
   }
 
   return result.data ?? null;
+}
+
+export type BugsinkIssueResolvePayload = {
+  project: number;
+  digest_order: number;
+  last_seen: string;
+  first_seen: string;
+  digested_event_count: number;
+  calculated_type: string;
+  calculated_value: string;
+  transaction: string;
+  is_resolved: true;
+  is_resolved_unconditionally: false;
+  is_resolved_by_next_release: boolean;
+  is_muted: false;
+};
+
+export function buildIssueResolvePayload(
+  issue: BugsinkIssue,
+): BugsinkIssueResolvePayload {
+  return {
+    project: issue.project,
+    digest_order: issue.digest_order,
+    last_seen: issue.last_seen,
+    first_seen: issue.first_seen,
+    digested_event_count: issue.digested_event_count,
+    calculated_type: issue.calculated_type,
+    calculated_value: issue.calculated_value,
+    transaction: issue.transaction,
+    is_resolved: true,
+    is_resolved_unconditionally: false,
+    is_resolved_by_next_release: issue.is_resolved_by_next_release,
+    is_muted: false,
+  };
+}
+
+export async function resolveIssue(issue: BugsinkIssue): Promise<void> {
+  const result = await bugsinkRequestPostRaw(
+    `/issues/${issue.id}/resolve/`,
+    buildIssueResolvePayload(issue),
+  );
+  if (!result.success) {
+    throw new Error(result.error ?? "Failed to resolve issue");
+  }
 }

--- a/packages/toolkit/src/lib/bugsink/resolver.ts
+++ b/packages/toolkit/src/lib/bugsink/resolver.ts
@@ -96,6 +96,106 @@ function failureResult({
   };
 }
 
+type PreflightResult =
+  | { kind: "eligible"; issue: BugsinkIssue }
+  | { kind: "skipped" }
+  | { kind: "error"; error: { id: string; message: string } };
+
+async function preflightIssue(
+  api: BugsinkIssueResolverApi,
+  issueId: string,
+): Promise<PreflightResult> {
+  try {
+    const issue = await api.getIssue(issueId);
+    if (issue == null) {
+      return {
+        kind: "error",
+        error: { id: issueId, message: "Issue not found" },
+      };
+    }
+    if (issue.is_muted) {
+      return {
+        kind: "error",
+        error: { id: issueId, message: "Issue is muted" },
+      };
+    }
+    if (issue.is_resolved) {
+      return { kind: "skipped" };
+    }
+    return { kind: "eligible", issue };
+  } catch (error) {
+    return {
+      kind: "error",
+      error: { id: issueId, message: errorMessage(error) },
+    };
+  }
+}
+
+async function preflightIssues(
+  api: BugsinkIssueResolverApi,
+  requested: readonly string[],
+): Promise<{
+  eligibleIssues: BugsinkIssue[];
+  eligible: string[];
+  skipped: string[];
+  errors: { id: string; message: string }[];
+}> {
+  const eligibleIssues: BugsinkIssue[] = [];
+  const eligible: string[] = [];
+  const skipped: string[] = [];
+  const errors: { id: string; message: string }[] = [];
+
+  for (const issueId of requested) {
+    const result = await preflightIssue(api, issueId);
+    if (result.kind === "eligible") {
+      eligibleIssues.push(result.issue);
+      eligible.push(issueId);
+    } else if (result.kind === "skipped") {
+      skipped.push(issueId);
+    } else {
+      errors.push(result.error);
+    }
+  }
+
+  return { eligibleIssues, eligible, skipped, errors };
+}
+
+function verificationError(issue: BugsinkIssue | null): string | null {
+  if (issue == null) {
+    return "Issue disappeared during verification";
+  }
+  if (!issue.is_resolved || issue.is_muted) {
+    return "Verification failed: issue is not resolved and unmuted";
+  }
+  return null;
+}
+
+async function resolveEligibleIssues(
+  api: BugsinkIssueResolverApi,
+  issues: readonly BugsinkIssue[],
+): Promise<{
+  resolved: string[];
+  error: { id: string; message: string } | null;
+}> {
+  const resolved: string[] = [];
+  for (const issue of issues) {
+    try {
+      await api.resolveIssue(issue);
+      const error = verificationError(await api.getIssue(issue.id));
+      if (error !== null) {
+        return { resolved, error: { id: issue.id, message: error } };
+      }
+      resolved.push(issue.id);
+    } catch (error) {
+      return {
+        resolved,
+        error: { id: issue.id, message: errorMessage(error) },
+      };
+    }
+  }
+  return { resolved, error: null };
+}
+
 export async function resolveIssues(
   issueIds: readonly string[],
   options: ResolveIssuesOptions = {},
@@ -103,34 +203,16 @@ export async function resolveIssues(
   const requested = normalizeBugsinkIssueIds(issueIds);
   const dryRun = options.dryRun === true || options.confirm !== true;
   const api = options.api ?? defaultApi;
-  const eligibleIssues: BugsinkIssue[] = [];
-  const eligible: string[] = [];
-  const skipped: string[] = [];
-  const preflightErrors: { id: string; message: string }[] = [];
+  const { eligibleIssues, eligible, skipped, errors } = await preflightIssues(
+    api,
+    requested,
+  );
 
-  for (const issueId of requested) {
-    try {
-      const issue = await api.getIssue(issueId);
-      if (issue == null) {
-        preflightErrors.push({ id: issueId, message: "Issue not found" });
-      } else if (issue.is_muted) {
-        preflightErrors.push({ id: issueId, message: "Issue is muted" });
-      } else if (issue.is_resolved) {
-        skipped.push(issueId);
-      } else {
-        eligibleIssues.push(issue);
-        eligible.push(issueId);
-      }
-    } catch (error) {
-      preflightErrors.push({ id: issueId, message: errorMessage(error) });
-    }
-  }
-
-  if (preflightErrors.length > 0) {
+  if (errors.length > 0) {
     return failureResult({
       requested,
       dryRun,
-      errors: preflightErrors,
+      errors,
       eligible,
       skipped,
     });
@@ -148,49 +230,16 @@ export async function resolveIssues(
     };
   }
 
-  const resolved: string[] = [];
-  for (const issue of eligibleIssues) {
-    try {
-      await api.resolveIssue(issue);
-      const verified = await api.getIssue(issue.id);
-      if (verified == null) {
-        return failureResult({
-          requested,
-          dryRun: false,
-          errors: [
-            { id: issue.id, message: "Issue disappeared during verification" },
-          ],
-          eligible,
-          skipped,
-          resolved,
-        });
-      }
-      if (!verified.is_resolved || verified.is_muted) {
-        return failureResult({
-          requested,
-          dryRun: false,
-          errors: [
-            {
-              id: issue.id,
-              message: "Verification failed: issue is not resolved and unmuted",
-            },
-          ],
-          eligible,
-          skipped,
-          resolved,
-        });
-      }
-      resolved.push(issue.id);
-    } catch (error) {
-      return failureResult({
-        requested,
-        dryRun: false,
-        errors: [{ id: issue.id, message: errorMessage(error) }],
-        eligible,
-        skipped,
-        resolved,
-      });
-    }
+  const { resolved, error } = await resolveEligibleIssues(api, eligibleIssues);
+  if (error !== null) {
+    return failureResult({
+      requested,
+      dryRun: false,
+      errors: [error],
+      eligible,
+      skipped,
+      resolved,
+    });
   }
 
   return {

--- a/packages/toolkit/src/lib/bugsink/resolver.ts
+++ b/packages/toolkit/src/lib/bugsink/resolver.ts
@@ -1,0 +1,205 @@
+import { getIssue, resolveIssue } from "./issues.ts";
+import type { BugsinkIssue } from "./types.ts";
+import { z } from "zod";
+
+const BugsinkIssueIdSchema = z.uuid();
+
+export type BugsinkIssueResolverApi = {
+  getIssue: (issueId: string) => Promise<BugsinkIssue | null>;
+  resolveIssue: (issue: BugsinkIssue) => Promise<void>;
+};
+
+export type ResolveIssuesOptions = {
+  confirm?: boolean | undefined;
+  dryRun?: boolean | undefined;
+  api?: BugsinkIssueResolverApi;
+};
+
+export type ResolveIssuesResult = {
+  success: boolean;
+  dryRun: boolean;
+  requested: string[];
+  eligible: string[];
+  skipped: string[];
+  resolved: string[];
+  errors: { id: string; message: string }[];
+};
+
+const defaultApi: BugsinkIssueResolverApi = { getIssue, resolveIssue };
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+export function normalizeBugsinkIssueIds(values: readonly string[]): string[] {
+  if (values.length === 0) {
+    throw new Error("At least one Bugsink issue UUID is required");
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const candidate = value.trim();
+    const parsed = BugsinkIssueIdSchema.safeParse(candidate);
+    if (!parsed.success) {
+      throw new Error(`Invalid Bugsink issue UUID: ${candidate}`);
+    }
+    if (!seen.has(parsed.data)) {
+      seen.add(parsed.data);
+      normalized.push(parsed.data);
+    }
+  }
+
+  return normalized;
+}
+
+export function parseBugsinkIssueIds(
+  positionals: readonly string[],
+  fileContents?: string,
+): string[] {
+  const fileIds =
+    fileContents == null
+      ? []
+      : fileContents
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0);
+
+  return normalizeBugsinkIssueIds([...positionals, ...fileIds]);
+}
+
+type FailureResultOptions = {
+  requested: string[];
+  dryRun: boolean;
+  errors: { id: string; message: string }[];
+  eligible?: string[];
+  skipped?: string[];
+  resolved?: string[];
+};
+
+function failureResult({
+  requested,
+  dryRun,
+  errors,
+  eligible = [],
+  skipped = [],
+  resolved = [],
+}: FailureResultOptions): ResolveIssuesResult {
+  return {
+    success: false,
+    dryRun,
+    requested,
+    eligible,
+    skipped,
+    resolved,
+    errors,
+  };
+}
+
+export async function resolveIssues(
+  issueIds: readonly string[],
+  options: ResolveIssuesOptions = {},
+): Promise<ResolveIssuesResult> {
+  const requested = normalizeBugsinkIssueIds(issueIds);
+  const dryRun = options.dryRun === true || options.confirm !== true;
+  const api = options.api ?? defaultApi;
+  const eligibleIssues: BugsinkIssue[] = [];
+  const eligible: string[] = [];
+  const skipped: string[] = [];
+  const preflightErrors: { id: string; message: string }[] = [];
+
+  for (const issueId of requested) {
+    try {
+      const issue = await api.getIssue(issueId);
+      if (issue == null) {
+        preflightErrors.push({ id: issueId, message: "Issue not found" });
+      } else if (issue.is_muted) {
+        preflightErrors.push({ id: issueId, message: "Issue is muted" });
+      } else if (issue.is_resolved) {
+        skipped.push(issueId);
+      } else {
+        eligibleIssues.push(issue);
+        eligible.push(issueId);
+      }
+    } catch (error) {
+      preflightErrors.push({ id: issueId, message: errorMessage(error) });
+    }
+  }
+
+  if (preflightErrors.length > 0) {
+    return failureResult({
+      requested,
+      dryRun,
+      errors: preflightErrors,
+      eligible,
+      skipped,
+    });
+  }
+
+  if (dryRun) {
+    return {
+      success: true,
+      dryRun: true,
+      requested,
+      eligible,
+      skipped,
+      resolved: [],
+      errors: [],
+    };
+  }
+
+  const resolved: string[] = [];
+  for (const issue of eligibleIssues) {
+    try {
+      await api.resolveIssue(issue);
+      const verified = await api.getIssue(issue.id);
+      if (verified == null) {
+        return failureResult({
+          requested,
+          dryRun: false,
+          errors: [
+            { id: issue.id, message: "Issue disappeared during verification" },
+          ],
+          eligible,
+          skipped,
+          resolved,
+        });
+      }
+      if (!verified.is_resolved || verified.is_muted) {
+        return failureResult({
+          requested,
+          dryRun: false,
+          errors: [
+            {
+              id: issue.id,
+              message: "Verification failed: issue is not resolved and unmuted",
+            },
+          ],
+          eligible,
+          skipped,
+          resolved,
+        });
+      }
+      resolved.push(issue.id);
+    } catch (error) {
+      return failureResult({
+        requested,
+        dryRun: false,
+        errors: [{ id: issue.id, message: errorMessage(error) }],
+        eligible,
+        skipped,
+        resolved,
+      });
+    }
+  }
+
+  return {
+    success: true,
+    dryRun: false,
+    requested,
+    eligible,
+    skipped,
+    resolved,
+    errors: [],
+  };
+}

--- a/packages/toolkit/src/lib/http.ts
+++ b/packages/toolkit/src/lib/http.ts
@@ -108,6 +108,11 @@ export type HttpClient = {
     endpoint: string,
     options: HttpPostOptions<T> & { schema: z.ZodType<T> },
   ) => Promise<HttpResult<T>>;
+  /** POST `endpoint`, returning the raw response text. */
+  postRaw: (
+    endpoint: string,
+    options?: HttpPostOptions<string>,
+  ) => Promise<HttpResult<string>>;
   /** GET `endpoint`, return the raw text body (no JSON parse). */
   raw: (
     endpoint: string,
@@ -241,5 +246,27 @@ export function createHttpClient(
     }
   }
 
-  return { get, post, raw };
+  async function postRaw(
+    endpoint: string,
+    postOptions?: HttpPostOptions<string>,
+  ): Promise<HttpResult<string>> {
+    try {
+      const options = resolveOptions(optionsOrFactory);
+      const url = buildUrl(options, endpoint, postOptions?.query);
+      const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: jsonHeaders(options),
+        body: JSON.stringify(postOptions?.body),
+      });
+      if (!response.ok) {
+        return await errorEnvelope(options, response);
+      }
+      const text = await response.text();
+      return { success: true, data: text };
+    } catch (error) {
+      return wrapError(error);
+    }
+  }
+
+  return { get, post, postRaw, raw };
 }

--- a/packages/toolkit/test/bugsink/client.test.ts
+++ b/packages/toolkit/test/bugsink/client.test.ts
@@ -2,10 +2,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildBugsinkApiUrl } from "#lib/bugsink/client.ts";
 import { getIssues } from "#lib/bugsink/issues.ts";
 import { getReleases } from "#lib/bugsink/queries.ts";
+import { captureBugsinkEnvironment } from "./test-helpers.ts";
 
-const ORIGINAL_FETCH = globalThis.fetch;
-const ORIGINAL_URL = Bun.env["BUGSINK_URL"];
-const ORIGINAL_TOKEN = Bun.env["BUGSINK_TOKEN"];
+const bugsinkEnvironment = captureBugsinkEnvironment();
 
 type FetchInput = Parameters<typeof fetch>[0];
 
@@ -14,7 +13,7 @@ function installFetchMock(
 ): void {
   const fetchMock: typeof fetch = Object.assign(
     async (input: FetchInput) => handler(input),
-    { preconnect: ORIGINAL_FETCH.preconnect },
+    { preconnect: bugsinkEnvironment.originalFetch.preconnect },
   );
   globalThis.fetch = fetchMock;
 }
@@ -30,17 +29,7 @@ function fetchInputToUrl(input: FetchInput): string {
 }
 
 afterEach(() => {
-  globalThis.fetch = ORIGINAL_FETCH;
-  if (ORIGINAL_URL === undefined) {
-    Reflect.deleteProperty(Bun.env, "BUGSINK_URL");
-  } else {
-    Bun.env["BUGSINK_URL"] = ORIGINAL_URL;
-  }
-  if (ORIGINAL_TOKEN === undefined) {
-    Reflect.deleteProperty(Bun.env, "BUGSINK_TOKEN");
-  } else {
-    Bun.env["BUGSINK_TOKEN"] = ORIGINAL_TOKEN;
-  }
+  bugsinkEnvironment.restore();
 });
 
 function bugsinkPage(results: readonly unknown[]): Response {

--- a/packages/toolkit/test/bugsink/resolver.test.ts
+++ b/packages/toolkit/test/bugsink/resolver.test.ts
@@ -8,12 +8,11 @@ import {
   resolveIssues,
   type BugsinkIssueResolverApi,
 } from "#lib/bugsink/resolver.ts";
+import { captureBugsinkEnvironment } from "./test-helpers.ts";
 
 const ISSUE_ID = "311e191f-5e83-4524-a5b5-d1d1d08581fa";
 const SECOND_ISSUE_ID = "fa406347-79cf-4f94-8b2d-afce20eb2d41";
-const ORIGINAL_FETCH = globalThis.fetch;
-const ORIGINAL_URL = Bun.env["BUGSINK_URL"];
-const ORIGINAL_TOKEN = Bun.env["BUGSINK_TOKEN"];
+const bugsinkEnvironment = captureBugsinkEnvironment();
 type FetchInput = Parameters<typeof fetch>[0];
 
 function issue(overrides: Partial<BugsinkIssue> = {}): BugsinkIssue {
@@ -51,17 +50,7 @@ function resolverApi(
 }
 
 afterEach(() => {
-  globalThis.fetch = ORIGINAL_FETCH;
-  if (ORIGINAL_URL === undefined) {
-    Reflect.deleteProperty(Bun.env, "BUGSINK_URL");
-  } else {
-    Bun.env["BUGSINK_URL"] = ORIGINAL_URL;
-  }
-  if (ORIGINAL_TOKEN === undefined) {
-    Reflect.deleteProperty(Bun.env, "BUGSINK_TOKEN");
-  } else {
-    Bun.env["BUGSINK_TOKEN"] = ORIGINAL_TOKEN;
-  }
+  bugsinkEnvironment.restore();
 });
 
 describe("Bugsink issue target parsing", () => {
@@ -208,7 +197,7 @@ describe("Bugsink resolve API action", () => {
         });
         return new Response(null, { status: 204 });
       },
-      { preconnect: ORIGINAL_FETCH.preconnect },
+      { preconnect: bugsinkEnvironment.originalFetch.preconnect },
     );
     Bun.env["BUGSINK_URL"] = "https://bugsink.example.test";
     Bun.env["BUGSINK_TOKEN"] = "secret-token";

--- a/packages/toolkit/test/bugsink/resolver.test.ts
+++ b/packages/toolkit/test/bugsink/resolver.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildIssueResolvePayload, resolveIssue } from "#lib/bugsink/issues.ts";
+import { formatResolveResult } from "#commands/bugsink/resolve.ts";
+import type { BugsinkIssue } from "#lib/bugsink/types.ts";
+import {
+  normalizeBugsinkIssueIds,
+  parseBugsinkIssueIds,
+  resolveIssues,
+  type BugsinkIssueResolverApi,
+} from "#lib/bugsink/resolver.ts";
+
+const ISSUE_ID = "311e191f-5e83-4524-a5b5-d1d1d08581fa";
+const SECOND_ISSUE_ID = "fa406347-79cf-4f94-8b2d-afce20eb2d41";
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_URL = Bun.env["BUGSINK_URL"];
+const ORIGINAL_TOKEN = Bun.env["BUGSINK_TOKEN"];
+type FetchInput = Parameters<typeof fetch>[0];
+
+function issue(overrides: Partial<BugsinkIssue> = {}): BugsinkIssue {
+  return {
+    id: ISSUE_ID,
+    project: 3,
+    digest_order: 16,
+    last_seen: "2026-08-24T00:00:00Z",
+    first_seen: "2026-08-23T00:00:00Z",
+    digested_event_count: 4,
+    stored_event_count: 4,
+    calculated_type: "Error",
+    calculated_value: "Example failure",
+    transaction: "worker.run",
+    is_resolved: false,
+    is_resolved_by_next_release: false,
+    is_muted: false,
+    ...overrides,
+  };
+}
+
+function resolverApi(
+  issues: Map<string, BugsinkIssue | null>,
+  events: string[],
+): BugsinkIssueResolverApi {
+  return {
+    getIssue: async (issueId) => {
+      events.push(`get:${issueId}`);
+      return issues.get(issueId) ?? null;
+    },
+    resolveIssue: async (currentIssue) => {
+      events.push(`post:${currentIssue.id}`);
+    },
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_URL === undefined) {
+    Reflect.deleteProperty(Bun.env, "BUGSINK_URL");
+  } else {
+    Bun.env["BUGSINK_URL"] = ORIGINAL_URL;
+  }
+  if (ORIGINAL_TOKEN === undefined) {
+    Reflect.deleteProperty(Bun.env, "BUGSINK_TOKEN");
+  } else {
+    Bun.env["BUGSINK_TOKEN"] = ORIGINAL_TOKEN;
+  }
+});
+
+describe("Bugsink issue target parsing", () => {
+  it("validates and deduplicates UUIDs from arguments and files", () => {
+    expect(
+      parseBugsinkIssueIds([ISSUE_ID], `\n${ISSUE_ID}\n${SECOND_ISSUE_ID}\n`),
+    ).toEqual([ISSUE_ID, SECOND_ISSUE_ID]);
+    expect(normalizeBugsinkIssueIds([ISSUE_ID, ISSUE_ID])).toEqual([ISSUE_ID]);
+  });
+
+  it("rejects malformed UUIDs before any API access", () => {
+    expect(() => parseBugsinkIssueIds(["not-an-issue"])).toThrow(
+      "Invalid Bugsink issue UUID",
+    );
+  });
+});
+
+describe("Bugsink issue resolver", () => {
+  it("does not POST when any target fails preflight", async () => {
+    const events: string[] = [];
+    const result = await resolveIssues([ISSUE_ID, SECOND_ISSUE_ID], {
+      confirm: true,
+      api: resolverApi(
+        new Map([
+          [ISSUE_ID, issue()],
+          [SECOND_ISSUE_ID, null],
+        ]),
+        events,
+      ),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual([
+      { id: SECOND_ISSUE_ID, message: "Issue not found" },
+    ]);
+    expect(events).toEqual([`get:${ISSUE_ID}`, `get:${SECOND_ISSUE_ID}`]);
+  });
+
+  it("refuses muted issues without POSTing", async () => {
+    const events: string[] = [];
+    const result = await resolveIssues([ISSUE_ID], {
+      confirm: true,
+      api: resolverApi(
+        new Map([[ISSUE_ID, issue({ is_muted: true })]]),
+        events,
+      ),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0]?.message).toBe("Issue is muted");
+    expect(events).toEqual([`get:${ISSUE_ID}`]);
+  });
+
+  it("previews without confirmation and skips already resolved issues", async () => {
+    const events: string[] = [];
+    const result = await resolveIssues([ISSUE_ID, SECOND_ISSUE_ID], {
+      api: resolverApi(
+        new Map([
+          [ISSUE_ID, issue()],
+          [SECOND_ISSUE_ID, issue({ id: SECOND_ISSUE_ID, is_resolved: true })],
+        ]),
+        events,
+      ),
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      dryRun: true,
+      eligible: [ISSUE_ID],
+      skipped: [SECOND_ISSUE_ID],
+      resolved: [],
+    });
+    expect(events).toEqual([`get:${ISSUE_ID}`, `get:${SECOND_ISSUE_ID}`]);
+  });
+
+  it("verifies each POST and stops on the first runtime failure", async () => {
+    const events: string[] = [];
+    const api: BugsinkIssueResolverApi = {
+      getIssue: async (issueId) => {
+        events.push(`get:${issueId}`);
+        return issue({
+          id: issueId,
+          is_resolved: events.includes(`verified:${issueId}`),
+        });
+      },
+      resolveIssue: async (currentIssue) => {
+        events.push(`post:${currentIssue.id}`);
+        if (currentIssue.id === SECOND_ISSUE_ID) {
+          throw new Error("upstream rejected action");
+        }
+        events.push(`verified:${currentIssue.id}`);
+      },
+    };
+
+    const result = await resolveIssues([ISSUE_ID, SECOND_ISSUE_ID], {
+      confirm: true,
+      api,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.resolved).toEqual([ISSUE_ID]);
+    expect(result.errors).toEqual([
+      { id: SECOND_ISSUE_ID, message: "upstream rejected action" },
+    ]);
+    expect(events).toEqual([
+      `get:${ISSUE_ID}`,
+      `get:${SECOND_ISSUE_ID}`,
+      `post:${ISSUE_ID}`,
+      `verified:${ISSUE_ID}`,
+      `get:${ISSUE_ID}`,
+      `post:${SECOND_ISSUE_ID}`,
+    ]);
+  });
+
+  it("rejects a post whose follow-up verification is not resolved", async () => {
+    const current = issue();
+    const result = await resolveIssues([ISSUE_ID], {
+      confirm: true,
+      api: {
+        getIssue: async () => current,
+        resolveIssue: () => Promise.resolve(),
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.resolved).toEqual([]);
+    expect(result.errors[0]?.message).toContain("Verification failed");
+  });
+});
+
+describe("Bugsink resolve API action", () => {
+  it("uses the canonical REST endpoint and complete payload", async () => {
+    const requests: { url: string; init: RequestInit | undefined }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: FetchInput, init?: RequestInit) => {
+        requests.push({
+          url:
+            typeof input === "string"
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url,
+          init,
+        });
+        return new Response(null, { status: 204 });
+      },
+      { preconnect: ORIGINAL_FETCH.preconnect },
+    );
+    Bun.env["BUGSINK_URL"] = "https://bugsink.example.test";
+    Bun.env["BUGSINK_TOKEN"] = "secret-token";
+
+    const current = issue();
+    await resolveIssue(current);
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe(
+      `https://bugsink.example.test/api/canonical/0/issues/${ISSUE_ID}/resolve/`,
+    );
+    expect(requests[0]?.init?.method).toBe("POST");
+    expect(requests[0]?.init?.headers).toEqual({
+      Authorization: "Bearer secret-token",
+      "Content-Type": "application/json",
+    });
+    const requestBody = requests[0]?.init?.body;
+    expect(typeof requestBody).toBe("string");
+    if (typeof requestBody !== "string") {
+      throw new TypeError("Expected a JSON request body");
+    }
+    expect(JSON.parse(requestBody)).toEqual(buildIssueResolvePayload(current));
+  });
+});
+
+describe("Bugsink resolve output", () => {
+  it("does not include credentials in human output", () => {
+    const output = formatResolveResult({
+      success: false,
+      dryRun: false,
+      requested: [ISSUE_ID],
+      eligible: [],
+      skipped: [],
+      resolved: [],
+      errors: [{ id: ISSUE_ID, message: "Issue is muted" }],
+    });
+
+    expect(output).not.toContain("secret-token");
+    expect(output).not.toContain("Authorization");
+  });
+});

--- a/packages/toolkit/test/bugsink/test-helpers.ts
+++ b/packages/toolkit/test/bugsink/test-helpers.ts
@@ -1,0 +1,31 @@
+export type BugsinkTestEnvironment = {
+  originalFetch: typeof fetch;
+  originalUrl: string | undefined;
+  originalToken: string | undefined;
+  restore: () => void;
+};
+
+export function captureBugsinkEnvironment(): BugsinkTestEnvironment {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = Bun.env["BUGSINK_URL"];
+  const originalToken = Bun.env["BUGSINK_TOKEN"];
+
+  return {
+    originalFetch,
+    originalUrl,
+    originalToken,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) {
+        Reflect.deleteProperty(Bun.env, "BUGSINK_URL");
+      } else {
+        Bun.env["BUGSINK_URL"] = originalUrl;
+      }
+      if (originalToken === undefined) {
+        Reflect.deleteProperty(Bun.env, "BUGSINK_TOKEN");
+      } else {
+        Bun.env["BUGSINK_TOKEN"] = originalToken;
+      }
+    },
+  };
+}

--- a/packages/toolkit/test/lib/http.test.ts
+++ b/packages/toolkit/test/lib/http.test.ts
@@ -286,6 +286,23 @@ describe("createHttpClient post and raw", () => {
     expect(result).toEqual({ success: true, data: "plain body" });
   });
 
+  it("POSTs JSON and returns an empty raw success body", async () => {
+    const { requests } = installFetchMock(new Response(null, { status: 204 }));
+    const client = createHttpClient({
+      baseUrl: "https://api.example.test",
+      auth: { scheme: "Bearer", token: "t" },
+      errorLabel: "Example API",
+    });
+
+    const result = await client.postRaw("/items/resolve", {
+      body: { is_resolved: true },
+    });
+
+    expect(result).toEqual({ success: true, data: "" });
+    expect(requests[0]!.init?.method).toBe("POST");
+    expect(requests[0]!.init?.body).toBe(JSON.stringify({ is_resolved: true }));
+  });
+
   it("omits Content-Type on raw requests", async () => {
     const { requests } = installFetchMock(new Response("x", { status: 200 }));
     const client = createHttpClient({


### PR DESCRIPTION
Why: Reviewed Bugsink cleanup currently requires bespoke API calls and careful manual preflight.

What: Add an explicit UUID-only `toolkit bugsink resolve` command with dry-run previews, complete preflight before mutation, direct canonical REST resolution, follow-up verification, stable JSON/human output, tests, and operator documentation. The command never uses the Bugsink web UI and does not mute issues.

Verification:
- `bun --no-install --bun vitest --config ../../vitest.config.ts run test/lib/http.test.ts test/bugsink` — 28 passed.
- `bunx turbo run typecheck --filter=@shepherdjerred/toolkit` — passed.
- `bun run lint` — passed, including architecture checks.
- `bun run build` — passed.
- `bunx prettier --check ...` and `git diff --check` — passed.
- The broader `bun run test:unit` suite still has five unrelated history fixture failures in `test/history/cli.test.ts`; no history files changed.
- No live Bugsink mutation was performed while verifying this PR.