### PR TITLE
Make weekly parlays champion-driven and challenging

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1128,17 +1128,9 @@
       "clones": 1,
       "tokens": 70
     },
-    "packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts|packages/temporal/src/activities/scout-weekly-parlay.ts": {
-      "clones": 1,
-      "tokens": 136
-    },
     "packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-period.ts|packages/temporal/src/activities/scout-weekly-parlay.ts": {
       "clones": 3,
       "tokens": 329
-    },
-    "packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts|packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts": {
-      "clones": 2,
-      "tokens": 159
     },
     "packages/scout-for-lol/packages/backend/src/database/competition.integration.test.ts|packages/scout-for-lol/packages/backend/src/database/competition.integration.test.ts": {
       "clones": 3,

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -934,24 +934,43 @@ polling intervals for Match-V5 ingestion; the guarded market-row write then
 serializes the last valid contribution against settlement.
 
 Weekly generation is deterministic around a closed model boundary. Candidate
-order, coverage/cooldown gates, aligned zero-game windows, threshold search, and
-joint replay pricing are code-owned. The model chooses only 3–5 catalog shapes;
-it cannot author thresholds, expressions, paths, SQL, or settlement behavior.
-Reject a candidate outside the empirical publication band and skip the week
-when none qualify—never weaken or clamp a gate.
+order, coverage/cooldown gates, aligned windows, champion shortlists,
+qualification, threshold search, and joint replay pricing are code-owned. The
+trailing-eight-window shortlist requires three games across two windows, sorts
+by windows played, games played, then champion name, and retains at most five.
+The model returns exactly five distinct 3–5-leg proposals, each containing a
+`champion_peak` leg, and cannot author thresholds, expressions, paths, SQL, or
+settlement behavior. Generation may use rates, wins, win streaks, best-game
+metrics, named-champion wins, and named-champion peak kills, assists, champion
+damage, or vision score. It must not generate plain games, time played,
+distinct counts, role games, raw cumulative statistics, or champion plays
+without a win. Reject a candidate outside the closed catalog or shortlist and
+skip the week when none qualify—never weaken or clamp a gate.
+
+Weekly pricing uses only windows where every subject completed at least three
+eligible games and persists total, qualified, and excluded evidence. Require at
+least 15 qualified windows, a 20–70% standalone hit rate for every displayed
+leg, and a 20–30% joint hit rate nearest 25%. The trailing eight qualified
+windows need at least one joint hit and at most 50% joint success.
 
 The database is authoritative for weekly-parlay subject membership. A player
 row in the target guild with a Discord ID and at least one linked Riot account
 is eligible for candidate evaluation; generation must not enumerate or fetch
 Discord guild members. Stale player membership is a database-cleanup concern.
 
-Only cumulative/count/distinct/max `gte` legs may become irreversible. Early
-settlement is YES-only and requires every leg irreversibly true; NO and every
-equality, upper-bound, rate, or average leg wait for finalization. Flag
-revocation stops creation and new stakes but, like all Bryan Bucks controls,
-must never block settlement, reserve release, voids, or refunds. Every Discord
-publication is a new nonce-guarded message, mentions deduplicated frozen
-subjects plus pending bettors, and exposes aggregate positions only.
+Version-two activity is a settlement qualification, never a displayed leg.
+Every subject needs three eligible games; insufficient final activity voids and
+refunds the market. Early settlement is YES-only and requires qualification
+plus every leg irreversibly true; NO and every equality, upper-bound, rate, or
+average leg wait for finalization. Keep version-one criteria/evaluator parsing
+and settlement compatible. Flag revocation stops creation and new stakes but,
+like all Bryan Bucks controls, must never block settlement, reserve release,
+voids, refunds, or authenticated operator cancellation. Cancellation is
+idempotent, refunds all pending bets atomically, sends the bettor-mentioned
+settlement notice, and edits the original publication to cancelled with no
+components. Every Discord publication is a new nonce-guarded message, mentions
+deduplicated frozen subjects plus pending bettors, and exposes aggregate
+positions only.
 
 The `scout-weekly-parlay` Temporal schedule is the sole recurring coordinator.
 It calls the beta-only authenticated control endpoint with stable period/action
@@ -964,9 +983,10 @@ closed `catch_up` window. Scout validates the minimum betting duration and
 Sunday cutoff, freezes the clocks on the definition, and rejects a retry whose
 period/slot already has different clocks. Every later action derives reminder,
 progress, and settlement timing from that stored definition. Historical replay
-uses the same Pacific weekday/hour shape as the shortened live window,
-including zero-game windows. Catch-up execution never edits or replaces the
-recurring schedule.
+uses the same Pacific weekday/hour shape as the shortened live window. Preserve
+zero-game windows in the history snapshot, then exclude all under-qualified
+windows from version-two pricing with explicit evidence. Catch-up execution
+never edits or replaces the recurring schedule.
 
 League Classic (`queueType: "classic"`, Riot queue 4310) is not a betting or
 parlay queue because this integration has no supported post-game payload. A

--- a/packages/scout-for-lol/packages/backend/scripts/test-weekly-parlay-live.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/test-weekly-parlay-live.ts
@@ -3,7 +3,7 @@ import {
   validateWeeklyParlayProposal,
   WeeklyParlaySubjectSchema,
 } from "#src/betting/weekly-parlay-criteria.ts";
-import { generateWeeklyParlayProposal } from "#src/betting/weekly-parlay-model.ts";
+import { generateWeeklyParlayProposals } from "#src/betting/weekly-parlay-model.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("test-weekly-parlay-live");
@@ -23,28 +23,33 @@ const subject = WeeklyParlaySubjectSchema.parse({
     },
   ],
 });
-const champions = new Set(["Ahri", "Jinx", "Lee Sin", "Nautilus", "Ornn"]);
-const roles = new Set([
-  "TOP",
-  "JUNGLE",
-  "MIDDLE",
-  "BOTTOM",
-  "UTILITY",
-] as const);
-const generated = await generateWeeklyParlayProposal({
+const championShortlist = ["Ahri", "Jinx", "Lee Sin", "Nautilus", "Ornn"].map(
+  (champion, index) => ({
+    champion,
+    windowsPlayed: 8 - index,
+    gamesPlayed: 12 - index,
+    wins: 6 - index,
+    bestKills: 12 - index,
+    bestAssists: 18 - index,
+    bestChampionDamage: 30_000 - index * 1000,
+    bestVisionScore: 50 - index,
+  }),
+);
+const generated = await generateWeeklyParlayProposals({
   periodKey: "2026-08-24",
   subjects: [subject],
-  observedChampions: new Map([[subject.key, champions]]),
-  observedRoles: new Map([[subject.key, roles]]),
-  recentEligibleGames: new Map([[subject.key, 6]]),
+  championShortlists: new Map([[subject.key, championShortlist]]),
   historyWindows: 30,
 });
-const issues = validateWeeklyParlayProposal({
-  proposal: generated.proposal,
-  subjects: [subject],
-  observedChampions: new Map([[subject.key, champions]]),
-  observedRoles: new Map([[subject.key, roles]]),
-});
+const issues = generated.proposals.flatMap((proposal) =>
+  validateWeeklyParlayProposal({
+    proposal,
+    subjects: [subject],
+    eligibleChampions: new Map([
+      [subject.key, new Set(championShortlist.map((entry) => entry.champion))],
+    ]),
+  }),
+);
 if (issues.length > 0) {
   throw new Error(
     `Weekly prompt failed semantic validation: ${issues.join("; ")}`,
@@ -52,5 +57,7 @@ if (issues.length > 0) {
 }
 logger.info("Weekly parlay live prompt accepted", {
   model: generated.resolvedModel ?? generated.model,
-  legs: generated.proposal.legs.length,
+  proposals: generated.proposals.length,
+  legs: generated.proposals.map((proposal) => proposal.legs.length),
 });
+process.exit(0);

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-cancel.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-cancel.ts
@@ -1,0 +1,92 @@
+import {
+  deliverWeeklyParlayDiscord,
+  weeklyParlaySettlementActionKey,
+} from "#src/betting/weekly-parlay-discord.ts";
+import { cancelWeeklyParlayMessage } from "#src/betting/weekly-parlay-refresh.ts";
+import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+export type WeeklyParlayCancellationDependencies = {
+  prismaClient: ExtendedPrismaClient;
+  deliverDiscord?: typeof deliverWeeklyParlayDiscord;
+  cancelMessage?: typeof cancelWeeklyParlayMessage;
+};
+
+export type WeeklyParlayCancellationResult = {
+  status: "reconciled" | "skipped";
+  detail: string;
+  marketId: number;
+};
+
+export async function cancelWeeklyParlayMarket(
+  input: {
+    marketId: number;
+    marketState: string;
+    voidReason: string | null;
+    now: Date;
+  },
+  dependencies: WeeklyParlayCancellationDependencies,
+): Promise<WeeklyParlayCancellationResult> {
+  if (input.marketState === "settled") {
+    return {
+      status: "skipped",
+      detail: "market_already_settled",
+      marketId: input.marketId,
+    };
+  }
+  if (
+    input.marketState === "voided" &&
+    input.voidReason !== "operator_cancelled"
+  ) {
+    return {
+      status: "skipped",
+      detail: "market_already_voided",
+      marketId: input.marketId,
+    };
+  }
+  const settlement =
+    input.marketState === "voided"
+      ? undefined
+      : await settleWeeklyParlayMarket(
+          {
+            marketId: input.marketId,
+            mode: "void",
+            voidReason: "operator_cancelled",
+            now: input.now,
+          },
+          dependencies.prismaClient,
+        );
+  const cancelled =
+    await dependencies.prismaClient.bucksWeeklyParlayMarket.findUniqueOrThrow({
+      where: { id: input.marketId },
+      select: { marketState: true, voidReason: true },
+    });
+  if (
+    cancelled.marketState !== "voided" ||
+    cancelled.voidReason !== "operator_cancelled"
+  ) {
+    return {
+      status: "skipped",
+      detail: "market_not_cancelled",
+      marketId: input.marketId,
+    };
+  }
+  await (dependencies.deliverDiscord ?? deliverWeeklyParlayDiscord)(
+    {
+      marketId: input.marketId,
+      actionKey: weeklyParlaySettlementActionKey(input.marketId),
+      kind: "settlement",
+      scheduledAt: input.now,
+    },
+    dependencies.prismaClient,
+  );
+  await (dependencies.cancelMessage ?? cancelWeeklyParlayMessage)(
+    input.marketId,
+    dependencies.prismaClient,
+  );
+  return {
+    status: "reconciled",
+    detail: settlement === undefined ? "already_cancelled" : "cancelled",
+    marketId: input.marketId,
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-control.ts
@@ -1,17 +1,21 @@
-import { z } from "zod";
 import { DiscordGuildIdSchema } from "@scout-for-lol/data";
 import {
-  WEEKLY_PARLAY_LIFECYCLE,
   WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS,
+  WEEKLY_PARLAY_LIFECYCLE,
   WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS,
+  WeeklyParlayControlActionSchema,
+  type WeeklyParlayControlAction,
 } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import {
   deliverWeeklyParlayDiscord,
   weeklyParlaySettlementActionKey,
 } from "#src/betting/weekly-parlay-discord.ts";
+import {
+  cancelWeeklyParlayMarket,
+  type WeeklyParlayCancellationDependencies,
+} from "#src/betting/weekly-parlay-cancel.ts";
 import { openWeeklyParlay } from "#src/betting/weekly-parlay-open.ts";
 import {
-  WEEKLY_PARLAY_SLOT,
   weeklyParlayScoringShape,
   weeklyParlayScoringWindowForPeriod,
   weeklyParlayTimelineFromWindow,
@@ -24,64 +28,8 @@ import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { bettingWeeklyParlayControlActionsTotal } from "#src/metrics/betting-weekly-parlay.ts";
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { syncBucksAnalytics } from "#src/analytics/bryan-bucks-sync.ts";
-
 export const WEEKLY_PARLAY_CONTROL_PATH =
   "/api/internal/weekly-parlays/actions";
-
-export const WeeklyParlayCatchupWindowSchema = z.strictObject({
-  kind: z.literal("catch_up"),
-  openAt: z.iso.datetime(),
-  bettingClosesAt: z.iso.datetime(),
-  scoringStartsAt: z.iso.datetime(),
-  scoringEndsAt: z.iso.datetime(),
-});
-
-export const WeeklyParlayControlActionSchema = z
-  .strictObject({
-    periodKey: z.iso.date(),
-    slot: z.number().int().nonnegative().default(WEEKLY_PARLAY_SLOT),
-    action: z.enum([
-      "open",
-      "reminder",
-      "start",
-      "progress",
-      "finalize",
-      "analytics_sync",
-    ]),
-    updateIndex: z
-      .number()
-      .int()
-      .min(0)
-      .max(WEEKLY_PARLAY_LIFECYCLE.updateCount - 1)
-      .optional(),
-    window: WeeklyParlayCatchupWindowSchema.optional(),
-  })
-  .superRefine((action, context) => {
-    if (action.action === "progress" && action.updateIndex === undefined) {
-      context.addIssue({
-        code: "custom",
-        path: ["updateIndex"],
-        message: "Progress actions require an update index.",
-      });
-    }
-    if (action.action !== "progress" && action.updateIndex !== undefined) {
-      context.addIssue({
-        code: "custom",
-        path: ["updateIndex"],
-        message: "Only progress actions accept an update index.",
-      });
-    }
-    if (action.action !== "open" && action.window !== undefined) {
-      context.addIssue({
-        code: "custom",
-        path: ["window"],
-        message: "Only open actions accept a catch-up window.",
-      });
-    }
-  });
-export type WeeklyParlayControlAction = z.infer<
-  typeof WeeklyParlayControlActionSchema
->;
 
 export type WeeklyParlayControlResult = {
   status: "reconciled" | "skipped";
@@ -97,12 +45,23 @@ type ControlContext = {
   serverId: string;
   now: Date;
   prismaClient: ExtendedPrismaClient;
+  cancellation: Omit<WeeklyParlayCancellationDependencies, "prismaClient">;
+  signal?: AbortSignal;
+};
+
+type WeeklyParlayControlOptions = {
+  serverId: string;
+  now?: Date;
+  prismaClient?: ExtendedPrismaClient;
+  deliverDiscord?: WeeklyParlayCancellationDependencies["deliverDiscord"];
+  cancelMessage?: WeeklyParlayCancellationDependencies["cancelMessage"];
   signal?: AbortSignal;
 };
 
 type PersistedMarket = {
   id: number;
   marketState: string;
+  voidReason: string | null;
   definition: {
     openAt: Date;
     bettingClosesAt: Date;
@@ -392,12 +351,7 @@ async function reconcileProgress(
 
 async function runWeeklyParlayControlActionInternal(
   input: WeeklyParlayControlAction,
-  options: {
-    serverId: string;
-    now?: Date;
-    prismaClient?: ExtendedPrismaClient;
-    signal?: AbortSignal;
-  },
+  options: WeeklyParlayControlOptions,
 ): Promise<WeeklyParlayControlResult> {
   const action = WeeklyParlayControlActionSchema.parse(input);
   const serverId = DiscordGuildIdSchema.parse(options.serverId);
@@ -407,6 +361,14 @@ async function runWeeklyParlayControlActionInternal(
     serverId,
     prismaClient,
     now,
+    cancellation: {
+      ...(options.deliverDiscord === undefined
+        ? {}
+        : { deliverDiscord: options.deliverDiscord }),
+      ...(options.cancelMessage === undefined
+        ? {}
+        : { cancelMessage: options.cancelMessage }),
+    },
     ...(options.signal === undefined ? {} : { signal: options.signal }),
   };
   if (action.action === "analytics_sync") {
@@ -430,6 +392,7 @@ async function runWeeklyParlayControlActionInternal(
     select: {
       id: true,
       marketState: true,
+      voidReason: true,
       definition: {
         select: {
           openAt: true,
@@ -442,6 +405,17 @@ async function runWeeklyParlayControlActionInternal(
   });
   if (market === null) {
     return { status: "skipped", detail: "no_market" };
+  }
+  if (action.action === "cancel") {
+    return await cancelWeeklyParlayMarket(
+      {
+        marketId: market.id,
+        marketState: market.marketState,
+        voidReason: market.voidReason,
+        now: context.now,
+      },
+      { prismaClient, ...context.cancellation },
+    );
   }
   if (action.action === "start") {
     return await reconcileStart(action, market, context);
@@ -457,12 +431,7 @@ async function runWeeklyParlayControlActionInternal(
 
 export async function runWeeklyParlayControlAction(
   input: WeeklyParlayControlAction,
-  options: {
-    serverId: string;
-    now?: Date;
-    prismaClient?: ExtendedPrismaClient;
-    signal?: AbortSignal;
-  },
+  options: WeeklyParlayControlOptions,
 ): Promise<WeeklyParlayControlResult> {
   try {
     const result = await runWeeklyParlayControlActionInternal(input, options);

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION,
   WEEKLY_PARLAY_SCHEMA_VERSION,
   WeeklyParlayDefinitionCriteriaSchema,
   WeeklyParlayProposalSchema,
@@ -19,60 +20,93 @@ const subject = WeeklyParlaySubjectSchema.parse({
 });
 
 describe("weekly parlay closed criteria", () => {
-  test("rejects model-authored settlement logic and pings", () => {
+  test("retains version-one definition parsing", () => {
     expect(
-      WeeklyParlayProposalSchema.safeParse({
-        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+      WeeklyParlayDefinitionCriteriaSchema.parse({
+        version: WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION,
         legs: [
           {
             kind: "aggregate",
             subject: "P1",
             metric: "games",
             operator: "gte",
+            threshold: 3,
           },
           {
             kind: "aggregate",
             subject: "P1",
-            metric: "champion_damage",
+            metric: "distinct_champions",
             operator: "gte",
+            threshold: 2,
           },
           {
-            kind: "rate",
+            kind: "role_games",
             subject: "P1",
-            metric: "win_rate_bps",
+            role: "MIDDLE",
+            winsOnly: false,
             operator: "gte",
-            expression: "SELECT * FROM matches",
+            threshold: 1,
           },
         ],
-      }).success,
-    ).toBe(false);
+      }).version,
+    ).toBe(1);
+  });
+
+  test("accepts version-two champion peaks and rejects boring catalog entries", () => {
     expect(
-      WeeklyParlayProposalSchema.safeParse({
+      WeeklyParlayProposalSchema.parse({
         version: WEEKLY_PARLAY_SCHEMA_VERSION,
         legs: [
           {
-            kind: "aggregate",
+            kind: "champion_peak",
             subject: "P1",
-            metric: "games",
-            operator: "gte",
-          },
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "pings",
+            champion: "Twisted Fate",
+            metric: "kills",
             operator: "gte",
           },
           { kind: "aggregate", subject: "P1", metric: "wins", operator: "gte" },
+          {
+            kind: "rate",
+            subject: "P1",
+            metric: "average_assists_x100",
+            operator: "gte",
+          },
+        ],
+      }).version,
+    ).toBe(2);
+    expect(
+      WeeklyParlayProposalSchema.safeParse({
+        version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        legs: [
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "games",
+            operator: "gte",
+          },
+          {
+            kind: "aggregate",
+            subject: "P1",
+            metric: "kills",
+            operator: "gte",
+          },
+          {
+            kind: "champion_games",
+            subject: "P1",
+            champion: "Ahri",
+            winsOnly: false,
+            operator: "gte",
+          },
         ],
       }).success,
     ).toBe(false);
   });
 
-  test("requires every subject and an explicit participation leg", () => {
+  test("requires a champion peak and enforces the subject shortlist", () => {
     const proposal = WeeklyParlayProposalSchema.parse({
       version: WEEKLY_PARLAY_SCHEMA_VERSION,
       legs: [
-        { kind: "aggregate", subject: "P1", metric: "kills", operator: "gte" },
+        { kind: "aggregate", subject: "P1", metric: "wins", operator: "gte" },
         {
           kind: "champion_games",
           subject: "P1",
@@ -81,10 +115,9 @@ describe("weekly parlay closed criteria", () => {
           operator: "gte",
         },
         {
-          kind: "role_games",
+          kind: "rate",
           subject: "P1",
-          role: "MIDDLE",
-          winsOnly: false,
+          metric: "win_rate_bps",
           operator: "gte",
         },
       ],
@@ -93,66 +126,34 @@ describe("weekly parlay closed criteria", () => {
       validateWeeklyParlayProposal({
         proposal,
         subjects: [subject],
-        observedChampions: new Map([["P1", new Set(["Lux"])]]),
-        observedRoles: new Map([["P1", new Set(["MIDDLE"])]]),
+        eligibleChampions: new Map([["P1", new Set(["Lux"])]]),
       }),
     ).toEqual([
-      "Subject P1 needs a visible games participation leg.",
-      "Ahri was not historically observed for P1.",
+      "Every weekly parlay proposal needs a champion_peak leg.",
+      "Ahri is not in the champion shortlist for P1.",
     ]);
   });
 
-  test("rejects duplicate targets and zero-game participation", () => {
+  test("rejects duplicate champion peak targets", () => {
     expect(
       WeeklyParlayProposalSchema.safeParse({
         version: WEEKLY_PARLAY_SCHEMA_VERSION,
         legs: [
           {
-            kind: "aggregate",
+            kind: "champion_peak",
             subject: "P1",
-            metric: "games",
-            operator: "gte",
-          },
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "games",
-            operator: "lte",
-          },
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "games",
-            operator: "eq",
-          },
-        ],
-      }).success,
-    ).toBe(false);
-    expect(
-      WeeklyParlayDefinitionCriteriaSchema.safeParse({
-        version: WEEKLY_PARLAY_SCHEMA_VERSION,
-        legs: [
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "games",
-            operator: "gte",
-            threshold: 0,
-          },
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "wins",
-            operator: "gte",
-            threshold: 1,
-          },
-          {
-            kind: "aggregate",
-            subject: "P1",
+            champion: "Ahri",
             metric: "kills",
             operator: "gte",
-            threshold: 1,
           },
+          {
+            kind: "champion_peak",
+            subject: "P1",
+            champion: "Ahri",
+            metric: "kills",
+            operator: "gte",
+          },
+          { kind: "aggregate", subject: "P1", metric: "wins", operator: "gte" },
         ],
       }).success,
     ).toBe(false);

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-criteria.ts
@@ -1,19 +1,31 @@
-import { z } from "zod";
 import { LeaguePuuidSchema } from "@scout-for-lol/data";
+import { z } from "zod";
 
-export const WEEKLY_PARLAY_SCHEMA_VERSION = 1;
-export const WEEKLY_PARLAY_CATALOG_VERSION = "2026-08-23";
-export const WEEKLY_PARLAY_EVALUATOR_VERSION = "1";
-export const WEEKLY_PARLAY_PRICING_VERSION = "1";
+export const WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION = 1;
+export const WEEKLY_PARLAY_SCHEMA_VERSION = 2;
+export const WEEKLY_PARLAY_CATALOG_VERSION = "2026-08-25";
+export const WEEKLY_PARLAY_LEGACY_EVALUATOR_VERSION = "1";
+export const WEEKLY_PARLAY_EVALUATOR_VERSION = "2";
+export const WEEKLY_PARLAY_PRICING_VERSION = "2";
 export const WEEKLY_PARLAY_MIN_LEGS = 3;
 export const WEEKLY_PARLAY_MAX_LEGS = 5;
+export const WEEKLY_PARLAY_PROPOSAL_COUNT = 5;
 export const WEEKLY_PARLAY_MIN_HISTORY_WINDOWS = 15;
 export const WEEKLY_PARLAY_HISTORY_WINDOW_COUNT = 52;
 export const WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS = 4;
 export const WEEKLY_PARLAY_MIN_RECENT_GAMES = 3;
-export const WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS = 4000;
-export const WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS = 6000;
-export const WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS = 5000;
+export const WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES = 3;
+export const WEEKLY_PARLAY_CHAMPION_HISTORY_WINDOWS = 8;
+export const WEEKLY_PARLAY_CHAMPION_MIN_GAMES = 3;
+export const WEEKLY_PARLAY_CHAMPION_MIN_WINDOWS = 2;
+export const WEEKLY_PARLAY_CHAMPION_SHORTLIST_LIMIT = 5;
+export const WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS = 2000;
+export const WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS = 7000;
+export const WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS = 2000;
+export const WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS = 3000;
+export const WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS = 2500;
+export const WEEKLY_PARLAY_RECENT_QUALIFIED_WINDOWS = 8;
+export const WEEKLY_PARLAY_MAX_RECENT_YES_PROBABILITY_BPS = 5000;
 
 export const WEEKLY_PARLAY_ELIGIBLE_QUEUES = [
   "solo",
@@ -50,7 +62,7 @@ export const WeeklyParlaySubjectsSchema = z
   .max(5);
 export type WeeklyParlaySubject = z.infer<typeof WeeklyParlaySubjectSchema>;
 
-export const WeeklyParlayAggregateMetricSchema = z.enum([
+const WeeklyParlayLegacyAggregateMetricSchema = z.enum([
   "games",
   "wins",
   "kills",
@@ -68,6 +80,13 @@ export const WeeklyParlayAggregateMetricSchema = z.enum([
   "best_game_assists",
   "best_game_damage",
 ]);
+export const WeeklyParlayAggregateMetricSchema = z.enum([
+  "wins",
+  "longest_win_streak",
+  "best_game_kills",
+  "best_game_assists",
+  "best_game_damage",
+]);
 export const WeeklyParlayRateMetricSchema = z.enum([
   "win_rate_bps",
   "average_kills_x100",
@@ -77,8 +96,20 @@ export const WeeklyParlayRateMetricSchema = z.enum([
   "average_champion_damage",
   "average_vision_score_x100",
 ]);
+export const WeeklyParlayChampionPeakMetricSchema = z.enum([
+  "kills",
+  "assists",
+  "champion_damage",
+  "vision_score",
+]);
 export const WeeklyParlayNumericOperatorSchema = z.enum(["gte", "lte", "eq"]);
 
+const WeeklyParlayLegacyAggregateShapeSchema = z.strictObject({
+  kind: z.literal("aggregate"),
+  subject: WeeklyParlaySubjectKeySchema,
+  metric: WeeklyParlayLegacyAggregateMetricSchema,
+  operator: WeeklyParlayNumericOperatorSchema,
+});
 const WeeklyParlayAggregateShapeSchema = z.strictObject({
   kind: z.literal("aggregate"),
   subject: WeeklyParlaySubjectKeySchema,
@@ -91,12 +122,19 @@ const WeeklyParlayRateShapeSchema = z.strictObject({
   metric: WeeklyParlayRateMetricSchema,
   operator: WeeklyParlayNumericOperatorSchema,
 });
-const WeeklyParlayChampionShapeSchema = z.strictObject({
+const WeeklyParlayLegacyChampionShapeSchema = z.strictObject({
   kind: z.literal("champion_games"),
   subject: WeeklyParlaySubjectKeySchema,
   champion: z.string().min(1).max(50),
   winsOnly: z.boolean(),
   operator: WeeklyParlayNumericOperatorSchema,
+});
+const WeeklyParlayChampionShapeSchema = z.strictObject({
+  kind: z.literal("champion_games"),
+  subject: WeeklyParlaySubjectKeySchema,
+  champion: z.string().min(1).max(50),
+  winsOnly: z.literal(true),
+  operator: z.literal("gte"),
 });
 const WeeklyParlayRoleShapeSchema = z.strictObject({
   kind: z.literal("role_games"),
@@ -105,15 +143,34 @@ const WeeklyParlayRoleShapeSchema = z.strictObject({
   winsOnly: z.boolean(),
   operator: WeeklyParlayNumericOperatorSchema,
 });
+const WeeklyParlayChampionPeakShapeSchema = z.strictObject({
+  kind: z.literal("champion_peak"),
+  subject: WeeklyParlaySubjectKeySchema,
+  champion: z.string().min(1).max(50),
+  metric: WeeklyParlayChampionPeakMetricSchema,
+  operator: z.literal("gte"),
+});
+
+export const WeeklyParlayLegacyLegShapeSchema = z.discriminatedUnion("kind", [
+  WeeklyParlayLegacyAggregateShapeSchema,
+  WeeklyParlayRateShapeSchema,
+  WeeklyParlayLegacyChampionShapeSchema,
+  WeeklyParlayRoleShapeSchema,
+]);
 export const WeeklyParlayLegShapeSchema = z.discriminatedUnion("kind", [
   WeeklyParlayAggregateShapeSchema,
   WeeklyParlayRateShapeSchema,
   WeeklyParlayChampionShapeSchema,
-  WeeklyParlayRoleShapeSchema,
+  WeeklyParlayChampionPeakShapeSchema,
 ]);
+export type WeeklyParlayLegacyLegShape = z.infer<
+  typeof WeeklyParlayLegacyLegShapeSchema
+>;
 export type WeeklyParlayLegShape = z.infer<typeof WeeklyParlayLegShapeSchema>;
+export type WeeklyParlayAnyLegShape =
+  WeeklyParlayLegacyLegShape | WeeklyParlayLegShape;
 
-function weeklyParlayLegTargetKey(leg: WeeklyParlayLegShape): string {
+function weeklyParlayLegTargetKey(leg: WeeklyParlayAnyLegShape): string {
   switch (leg.kind) {
     case "aggregate":
     case "rate":
@@ -122,11 +179,13 @@ function weeklyParlayLegTargetKey(leg: WeeklyParlayLegShape): string {
       return `${leg.subject}:${leg.kind}:${leg.champion}:${String(leg.winsOnly)}`;
     case "role_games":
       return `${leg.subject}:${leg.kind}:${leg.role}:${String(leg.winsOnly)}`;
+    case "champion_peak":
+      return `${leg.subject}:${leg.kind}:${leg.champion}:${leg.metric}`;
   }
 }
 
 function rejectDuplicateLegTargets(
-  legs: readonly WeeklyParlayLegShape[],
+  legs: readonly WeeklyParlayAnyLegShape[],
   context: z.RefinementCtx,
 ): void {
   const seen = new Set<string>();
@@ -143,6 +202,14 @@ function rejectDuplicateLegTargets(
   }
 }
 
+export const WeeklyParlayLegacyProposalSchema = z.strictObject({
+  version: z.literal(WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION),
+  legs: z
+    .array(WeeklyParlayLegacyLegShapeSchema)
+    .min(WEEKLY_PARLAY_MIN_LEGS)
+    .max(WEEKLY_PARLAY_MAX_LEGS)
+    .superRefine(rejectDuplicateLegTargets),
+});
 export const WeeklyParlayProposalSchema = z.strictObject({
   version: z.literal(WEEKLY_PARLAY_SCHEMA_VERSION),
   legs: z
@@ -153,15 +220,15 @@ export const WeeklyParlayProposalSchema = z.strictObject({
 });
 export type WeeklyParlayProposal = z.infer<typeof WeeklyParlayProposalSchema>;
 
-export const WeeklyParlayLegSchema = z
+const WeeklyParlayLegacyLegSchema = z
   .discriminatedUnion("kind", [
-    WeeklyParlayAggregateShapeSchema.extend({
+    WeeklyParlayLegacyAggregateShapeSchema.extend({
       threshold: z.number().int().nonnegative(),
     }),
     WeeklyParlayRateShapeSchema.extend({
       threshold: z.number().int().nonnegative(),
     }),
-    WeeklyParlayChampionShapeSchema.extend({
+    WeeklyParlayLegacyChampionShapeSchema.extend({
       threshold: z.number().int().nonnegative(),
     }),
     WeeklyParlayRoleShapeSchema.extend({
@@ -182,15 +249,50 @@ export const WeeklyParlayLegSchema = z
       });
     }
   });
-export type WeeklyParlayLeg = z.infer<typeof WeeklyParlayLegSchema>;
-export const WeeklyParlayDefinitionCriteriaSchema = z.strictObject({
+export const WeeklyParlayLegSchema = z.discriminatedUnion("kind", [
+  WeeklyParlayAggregateShapeSchema.extend({
+    threshold: z.number().int().nonnegative(),
+  }),
+  WeeklyParlayRateShapeSchema.extend({
+    threshold: z.number().int().nonnegative(),
+  }),
+  WeeklyParlayChampionShapeSchema.extend({
+    threshold: z.number().int().positive(),
+  }),
+  WeeklyParlayChampionPeakShapeSchema.extend({
+    threshold: z.number().int().positive(),
+  }),
+]);
+export type WeeklyParlayCurrentLeg = z.infer<typeof WeeklyParlayLegSchema>;
+export type WeeklyParlayLegacyLeg = z.infer<typeof WeeklyParlayLegacyLegSchema>;
+export type WeeklyParlayLeg = WeeklyParlayLegacyLeg | WeeklyParlayCurrentLeg;
+
+const WeeklyParlayLegacyDefinitionCriteriaSchema = z.strictObject({
+  version: z.literal(WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION),
+  legs: z
+    .array(WeeklyParlayLegacyLegSchema)
+    .min(WEEKLY_PARLAY_MIN_LEGS)
+    .max(WEEKLY_PARLAY_MAX_LEGS)
+    .superRefine(rejectDuplicateLegTargets),
+});
+export const WeeklyParlayCurrentDefinitionCriteriaSchema = z.strictObject({
   version: z.literal(WEEKLY_PARLAY_SCHEMA_VERSION),
+  qualification: z.strictObject({
+    minimumGamesPerSubject: z.literal(WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES),
+  }),
   legs: z
     .array(WeeklyParlayLegSchema)
     .min(WEEKLY_PARLAY_MIN_LEGS)
     .max(WEEKLY_PARLAY_MAX_LEGS)
     .superRefine(rejectDuplicateLegTargets),
 });
+export const WeeklyParlayDefinitionCriteriaSchema = z.union([
+  WeeklyParlayLegacyDefinitionCriteriaSchema,
+  WeeklyParlayCurrentDefinitionCriteriaSchema,
+]);
+export type WeeklyParlayCurrentDefinitionCriteria = z.infer<
+  typeof WeeklyParlayCurrentDefinitionCriteriaSchema
+>;
 export type WeeklyParlayDefinitionCriteria = z.infer<
   typeof WeeklyParlayDefinitionCriteriaSchema
 >;
@@ -219,49 +321,28 @@ export type WeeklyParlayContributionSnapshot = z.infer<
 export function validateWeeklyParlayProposal(input: {
   proposal: WeeklyParlayProposal;
   subjects: readonly WeeklyParlaySubject[];
-  observedChampions: ReadonlyMap<string, ReadonlySet<string>>;
-  observedRoles: ReadonlyMap<string, ReadonlySet<string>>;
+  eligibleChampions: ReadonlyMap<string, ReadonlySet<string>>;
 }): string[] {
   const issues: string[] = [];
   const subjectKeys = new Set(input.subjects.map((subject) => subject.key));
   for (const subject of input.subjects) {
-    const subjectLegs = input.proposal.legs.filter(
-      (leg) => leg.subject === subject.key,
-    );
-    if (subjectLegs.length === 0) {
+    if (!input.proposal.legs.some((leg) => leg.subject === subject.key)) {
       issues.push(`Subject ${subject.key} has no leg.`);
     }
-    if (
-      !subjectLegs.some(
-        (leg) =>
-          leg.kind === "aggregate" &&
-          leg.metric === "games" &&
-          leg.operator === "gte",
-      )
-    ) {
-      issues.push(
-        `Subject ${subject.key} needs a visible games participation leg.`,
-      );
-    }
+  }
+  if (!input.proposal.legs.some((leg) => leg.kind === "champion_peak")) {
+    issues.push("Every weekly parlay proposal needs a champion_peak leg.");
   }
   for (const leg of input.proposal.legs) {
     if (!subjectKeys.has(leg.subject)) {
       issues.push(`Leg references unknown subject ${leg.subject}.`);
     }
     if (
-      leg.kind === "champion_games" &&
-      input.observedChampions.get(leg.subject)?.has(leg.champion) !== true
+      (leg.kind === "champion_games" || leg.kind === "champion_peak") &&
+      input.eligibleChampions.get(leg.subject)?.has(leg.champion) !== true
     ) {
       issues.push(
-        `${leg.champion} was not historically observed for ${leg.subject}.`,
-      );
-    }
-    if (
-      leg.kind === "role_games" &&
-      input.observedRoles.get(leg.subject)?.has(leg.role) !== true
-    ) {
-      issues.push(
-        `${leg.role} was not historically observed for ${leg.subject}.`,
+        `${leg.champion} is not in the champion shortlist for ${leg.subject}.`,
       );
     }
   }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.ts
@@ -1,0 +1,249 @@
+import type {
+  WeeklyParlayDefinitionCriteria,
+  WeeklyParlayLeg,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import type { WeeklyParlayEvaluation } from "#src/betting/weekly-parlay-evaluator.ts";
+
+export type WeeklyParlayDiscordKind =
+  "open" | "reminder" | "progress" | "settlement";
+
+function operatorCopy(leg: WeeklyParlayLeg): string {
+  switch (leg.operator) {
+    case "gte":
+      return "at least";
+    case "lte":
+      return "at most";
+    case "eq":
+      return "exactly";
+  }
+}
+
+export function countLabel(
+  value: number,
+  singular: string,
+  plural = `${singular}s`,
+): string {
+  return value === 1 ? singular : plural;
+}
+
+function aggregateMetricCopy(
+  metric: Extract<WeeklyParlayLeg, { kind: "aggregate" }>["metric"],
+  threshold: number,
+): string {
+  switch (metric) {
+    case "games":
+    case "wins":
+    case "kills":
+    case "deaths":
+    case "assists":
+      return countLabel(threshold, metric.slice(0, -1), metric);
+    case "distinct_champions":
+      return `distinct ${countLabel(threshold, "champion")}`;
+    case "distinct_roles":
+      return `distinct ${countLabel(threshold, "role")}`;
+    case "longest_win_streak":
+      return "wins in a row";
+    case "best_game_kills":
+      return "kills in one game";
+    case "best_game_assists":
+      return "assists in one game";
+    case "best_game_damage":
+      return "champion damage in one game";
+    case "champion_damage":
+    case "creep_score":
+    case "gold":
+    case "vision_score":
+    case "time_played":
+      return metric.replaceAll("_", " ");
+  }
+}
+
+function metricCopy(leg: WeeklyParlayLeg): string {
+  switch (leg.kind) {
+    case "aggregate":
+      return aggregateMetricCopy(leg.metric, leg.threshold);
+    case "rate":
+      return leg.metric
+        .replaceAll("_x100", "")
+        .replaceAll("_bps", "")
+        .replaceAll("_", " ");
+    case "champion_games":
+      return `${countLabel(leg.threshold, leg.winsOnly ? "win" : "game")} on ${leg.champion}`;
+    case "role_games":
+      return `${countLabel(leg.threshold, leg.winsOnly ? "win" : "game")} as ${leg.role.toLowerCase()}`;
+    case "champion_peak":
+      return `${leg.metric.replaceAll("_", " ")} in one game as ${leg.champion}`;
+  }
+}
+
+function metricValue(leg: WeeklyParlayLeg, value: number): string {
+  if (leg.kind === "rate") {
+    if (leg.metric === "win_rate_bps") {
+      return `${(value / 100).toFixed(1)}%`;
+    }
+    if (leg.metric.endsWith("_x100")) {
+      return (value / 100).toFixed(2);
+    }
+  }
+  return value.toLocaleString("en-US");
+}
+
+export function legLine(
+  leg: WeeklyParlayLeg,
+  current: number | undefined,
+  subjectAlias: string,
+): string {
+  const progress =
+    current === undefined
+      ? ""
+      : ` — **${metricValue(leg, current)} / ${metricValue(leg, leg.threshold)}**`;
+  return `• **${subjectAlias}** ${operatorCopy(leg)} **${metricValue(leg, leg.threshold)} ${metricCopy(leg)}**${progress}`;
+}
+
+export function weeklyParlayQualificationCopy(
+  criteria: WeeklyParlayDefinitionCriteria,
+): string | undefined {
+  if (criteria.version === 1) {
+    return;
+  }
+  return `Settlement qualification: **${criteria.qualification.minimumGamesPerSubject.toString()} eligible games required per player**; otherwise all bets are refunded.`;
+}
+
+function weeklyParlayVoidCopy(reason: string | null): string {
+  switch (reason) {
+    case "insufficient_activity":
+      return "Fewer than three eligible games were played, so every wager was refunded.";
+    case "operator_cancelled":
+      return "Cancelled by an operator; every pending wager was refunded.";
+    case null:
+      return "The market was voided and every pending wager was refunded.";
+    default:
+      return `The market was voided (${reason}) and every pending wager was refunded.`;
+  }
+}
+
+export function deliveryTitle(input: {
+  kind: WeeklyParlayDiscordKind;
+  marketState: string;
+  yesResult: boolean | null;
+  catchup?: boolean;
+  voidReason?: string | null;
+}): string {
+  const prefix = input.catchup === true ? "Catch-up weekly" : "Weekly";
+  switch (input.kind) {
+    case "open":
+      return `📅 **${prefix} Bryan Bucks parlay is open**`;
+    case "reminder":
+      return `⏰ **${prefix} parlay betting reminder**`;
+    case "progress":
+      return `📈 **${prefix} parlay progress**`;
+    case "settlement":
+      if (input.marketState === "voided") {
+        if (input.voidReason === "operator_cancelled") {
+          return `🛑 **${prefix} parlay cancelled and refunded**`;
+        }
+        return `↩️ **${prefix} parlay refunded**`;
+      }
+      return input.yesResult === true
+        ? `✅ **${prefix} parlay settled YES**`
+        : `❌ **${prefix} parlay settled NO**`;
+  }
+}
+
+export function deliveryTimeCopy(input: {
+  kind: WeeklyParlayDiscordKind;
+  bettingClosesAt: Date;
+  scoringEndsAt: Date;
+  scoringStartsAt?: Date;
+  catchup?: boolean;
+}): string {
+  if (input.catchup === true) {
+    if (input.scoringStartsAt === undefined) {
+      throw new Error("Catch-up weekly parlay copy requires scoringStartsAt.");
+    }
+    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:F>. Scoring runs <t:${Math.floor(input.scoringStartsAt.getTime() / 1000).toString()}:F> through <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
+  }
+  if (input.kind === "open" || input.kind === "reminder") {
+    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:R>. Use this message's buttons so your market is unambiguous.`;
+  }
+  return `Final cutoff <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
+}
+
+export function weeklyParlayDeliveryContent(input: {
+  kind: WeeklyParlayDiscordKind;
+  marketState: string;
+  yesResult: boolean | null;
+  voidReason: string | null;
+  catchup: boolean;
+  periodKey: string;
+  yesProbabilityBps: number;
+  bettingClosesAt: Date;
+  scoringStartsAt: Date;
+  scoringEndsAt: Date;
+  criteria: WeeklyParlayDefinitionCriteria | undefined;
+  evaluation: WeeklyParlayEvaluation | undefined;
+  aliases: ReadonlyMap<string, string>;
+  bettorCount: number;
+  totalStaked: number;
+}): string {
+  const isVoidedSettlement =
+    input.kind === "settlement" && input.marketState === "voided";
+  if (
+    !isVoidedSettlement &&
+    (input.criteria === undefined || input.evaluation === undefined)
+  ) {
+    throw new Error("Non-void weekly parlay delivery requires evaluation.");
+  }
+  const legs =
+    input.evaluation?.legs.map((result) =>
+      legLine(
+        result.leg,
+        input.kind === "open" || input.kind === "reminder"
+          ? undefined
+          : result.current,
+        input.aliases.get(result.leg.subject) ?? result.leg.subject,
+      ),
+    ) ?? [];
+  const qualification =
+    input.criteria === undefined
+      ? undefined
+      : weeklyParlayQualificationCopy(input.criteria);
+  const minimumGames =
+    input.evaluation?.qualification.minimumGamesPerSubject ?? 0;
+  const qualificationProgress =
+    minimumGames === 0 ||
+    input.kind === "open" ||
+    input.kind === "reminder" ||
+    input.evaluation === undefined
+      ? undefined
+      : `Qualification: ${input.evaluation.qualification.subjects
+          .map((subject) => {
+            const alias = input.aliases.get(subject.subject) ?? subject.subject;
+            return `**${alias} ${subject.games.toString()}/${minimumGames.toString()} games**`;
+          })
+          .join(" · ")}`;
+  return [
+    deliveryTitle({
+      kind: input.kind,
+      marketState: input.marketState,
+      yesResult: input.yesResult,
+      catchup: input.catchup,
+      voidReason: input.voidReason,
+    }),
+    ...(isVoidedSettlement ? [weeklyParlayVoidCopy(input.voidReason)] : []),
+    `Period: **${input.periodKey}** · ${(input.yesProbabilityBps / 100).toFixed(1)}% YES`,
+    ...legs,
+    qualification ?? "",
+    qualificationProgress ?? "",
+    `**${input.bettorCount.toString()} ${countLabel(input.bettorCount, "bettor")} · ${input.totalStaked.toString()} BB staked**`,
+    deliveryTimeCopy({
+      kind: input.kind,
+      bettingClosesAt: input.bettingClosesAt,
+      scoringEndsAt: input.scoringEndsAt,
+      scoringStartsAt: input.scoringStartsAt,
+      catchup: input.catchup,
+    }),
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -14,9 +14,12 @@ import {
   WeeklyParlayContributionSnapshotSchema,
   WeeklyParlayDefinitionCriteriaSchema,
   WeeklyParlaySubjectsSchema,
-  type WeeklyParlayLeg,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { evaluateWeeklyParlay } from "#src/betting/weekly-parlay-evaluator.ts";
+import {
+  weeklyParlayDeliveryContent,
+  type WeeklyParlayDiscordKind,
+} from "#src/betting/weekly-parlay-discord-copy.ts";
 import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
 import { send } from "#src/league/discord/channel.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -29,9 +32,6 @@ import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 
-export type WeeklyParlayDiscordKind =
-  "open" | "reminder" | "progress" | "settlement";
-
 export function weeklyParlaySettlementActionKey(marketId: number): string {
   return `settlement:${marketId.toString()}`;
 }
@@ -42,97 +42,6 @@ export type WeeklyParlayDiscordSender = (
   serverId: DiscordGuildId,
 ) => Promise<{ channelId: string; id: string }>;
 
-function operatorCopy(leg: WeeklyParlayLeg): string {
-  switch (leg.operator) {
-    case "gte":
-      return "at least";
-    case "lte":
-      return "at most";
-    case "eq":
-      return "exactly";
-  }
-}
-
-export function countLabel(
-  value: number,
-  singular: string,
-  plural = `${singular}s`,
-): string {
-  return value === 1 ? singular : plural;
-}
-
-function aggregateMetricCopy(
-  metric: Extract<WeeklyParlayLeg, { kind: "aggregate" }>["metric"],
-  threshold: number,
-): string {
-  switch (metric) {
-    case "games":
-    case "wins":
-    case "kills":
-    case "deaths":
-    case "assists":
-      return countLabel(threshold, metric.slice(0, -1), metric);
-    case "distinct_champions":
-      return `distinct ${countLabel(threshold, "champion")}`;
-    case "distinct_roles":
-      return `distinct ${countLabel(threshold, "role")}`;
-    case "longest_win_streak":
-      return "wins in a row";
-    case "best_game_kills":
-      return "kills in one game";
-    case "best_game_assists":
-      return "assists in one game";
-    case "best_game_damage":
-      return "champion damage in one game";
-    case "champion_damage":
-    case "creep_score":
-    case "gold":
-    case "vision_score":
-    case "time_played":
-      return metric.replaceAll("_", " ");
-  }
-}
-
-function metricCopy(leg: WeeklyParlayLeg): string {
-  switch (leg.kind) {
-    case "aggregate":
-      return aggregateMetricCopy(leg.metric, leg.threshold);
-    case "rate":
-      return leg.metric
-        .replaceAll("_x100", "")
-        .replaceAll("_bps", "")
-        .replaceAll("_", " ");
-    case "champion_games":
-      return `${countLabel(leg.threshold, leg.winsOnly ? "win" : "game")} on ${leg.champion}`;
-    case "role_games":
-      return `${countLabel(leg.threshold, leg.winsOnly ? "win" : "game")} as ${leg.role.toLowerCase()}`;
-  }
-}
-
-function metricValue(leg: WeeklyParlayLeg, value: number): string {
-  if (leg.kind === "rate") {
-    if (leg.metric === "win_rate_bps") {
-      return `${(value / 100).toFixed(1)}%`;
-    }
-    if (leg.metric.endsWith("_x100")) {
-      return (value / 100).toFixed(2);
-    }
-  }
-  return value.toLocaleString("en-US");
-}
-
-export function legLine(
-  leg: WeeklyParlayLeg,
-  current: number | undefined,
-  subjectAlias: string,
-): string {
-  const progress =
-    current === undefined
-      ? ""
-      : ` — **${metricValue(leg, current)} / ${metricValue(leg, leg.threshold)}**`;
-  return `• **${subjectAlias}** ${operatorCopy(leg)} **${metricValue(leg, leg.threshold)} ${metricCopy(leg)}**${progress}`;
-}
-
 function stableNonce(
   marketId: number,
   actionKey: string,
@@ -142,56 +51,6 @@ function stableNonce(
 }
 
 const MENTIONS_PER_MESSAGE = 20;
-
-export function deliveryTitle(
-  kind: WeeklyParlayDiscordKind,
-  marketState: string,
-  yesResult: boolean | null,
-  catchup = false,
-): string {
-  const prefix = catchup ? "Catch-up weekly" : "Weekly";
-  switch (kind) {
-    case "open":
-      return `📅 **${prefix} Bryan Bucks parlay is open**`;
-    case "reminder":
-      return `⏰ **${prefix} parlay betting reminder**`;
-    case "progress":
-      return `📈 **${prefix} parlay progress**`;
-    case "settlement":
-      if (marketState === "voided") {
-        return `↩️ **${prefix} parlay refunded**`;
-      }
-      return yesResult === true
-        ? `✅ **${prefix} parlay settled YES**`
-        : `❌ **${prefix} parlay settled NO**`;
-  }
-}
-
-function currentLegValue(
-  kind: WeeklyParlayDiscordKind,
-  current: number,
-): number | undefined {
-  return kind === "open" || kind === "reminder" ? undefined : current;
-}
-
-export function deliveryTimeCopy(input: {
-  kind: WeeklyParlayDiscordKind;
-  bettingClosesAt: Date;
-  scoringEndsAt: Date;
-  scoringStartsAt?: Date;
-  catchup?: boolean;
-}): string {
-  if (input.catchup === true) {
-    if (input.scoringStartsAt === undefined) {
-      throw new Error("Catch-up weekly parlay copy requires scoringStartsAt.");
-    }
-    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:F>. Scoring runs <t:${Math.floor(input.scoringStartsAt.getTime() / 1000).toString()}:F> through <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
-  }
-  if (input.kind === "open" || input.kind === "reminder") {
-    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:R>. Use this message's buttons so your market is unambiguous.`;
-  }
-  return `Final cutoff <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
-}
 
 export function weeklyParlayButtons(
   kind: WeeklyParlayDiscordKind,
@@ -312,34 +171,32 @@ export async function deliverWeeklyParlayDiscord(
   }
   const isVoidedSettlement =
     input.kind === "settlement" && market.marketState === "voided";
-  const subjects = isVoidedSettlement
-    ? []
-    : WeeklyParlaySubjectsSchema.parse(JSON.parse(market.definition.subjects));
-  const evaluation = isVoidedSettlement
+  const includeFrozenSubjects =
+    !isVoidedSettlement || market.voidReason === "operator_cancelled";
+  const subjects = includeFrozenSubjects
+    ? WeeklyParlaySubjectsSchema.parse(JSON.parse(market.definition.subjects))
+    : [];
+  const criteria = isVoidedSettlement
     ? undefined
-    : evaluateWeeklyParlay(
-        WeeklyParlayDefinitionCriteriaSchema.parse(
-          JSON.parse(market.definition.criteria),
-        ),
-        z
-          .array(WeeklyParlayContributionSnapshotSchema)
-          .parse(
-            market.definition.contributions.map((row) =>
-              JSON.parse(row.snapshot),
-            ),
-          ),
+    : WeeklyParlayDefinitionCriteriaSchema.parse(
+        JSON.parse(market.definition.criteria),
       );
+  const evaluation =
+    criteria === undefined
+      ? undefined
+      : evaluateWeeklyParlay(
+          criteria,
+          z
+            .array(WeeklyParlayContributionSnapshotSchema)
+            .parse(
+              market.definition.contributions.map((row) =>
+                JSON.parse(row.snapshot),
+              ),
+            ),
+        );
   const aliases = new Map(
     subjects.map((subject) => [subject.key, subject.alias]),
   );
-  const legs =
-    evaluation?.legs.map((result) =>
-      legLine(
-        result.leg,
-        currentLegValue(input.kind, result.current),
-        aliases.get(result.leg.subject) ?? result.leg.subject,
-      ),
-    ) ?? [];
   const bettorIds = market.bets.map((bet) => bet.bucksAccount.discordId);
   const mentionIds = [
     ...new Set([...subjects.map((subject) => subject.discordId), ...bettorIds]),
@@ -352,24 +209,23 @@ export async function deliverWeeklyParlayDiscord(
     scoringStartsAt: market.definition.scoringStartsAt,
     scoringEndsAt: market.definition.scoringEndsAt,
   });
-  const content = [
-    deliveryTitle(input.kind, market.marketState, market.yesResult, catchup),
-    ...(isVoidedSettlement
-      ? [`Reason: **${market.voidReason ?? "unknown"}**`]
-      : []),
-    `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
-    ...legs,
-    `**${market.bets.length.toString()} ${countLabel(market.bets.length, "bettor")} · ${totalStaked.toString()} BB staked**`,
-    deliveryTimeCopy({
-      kind: input.kind,
-      bettingClosesAt: market.bettingClosesAt,
-      scoringEndsAt: market.scoringEndsAt,
-      scoringStartsAt: market.definition.scoringStartsAt,
-      catchup,
-    }),
-  ]
-    .filter((line) => line.length > 0)
-    .join("\n");
+  const content = weeklyParlayDeliveryContent({
+    kind: input.kind,
+    marketState: market.marketState,
+    yesResult: market.yesResult,
+    voidReason: market.voidReason,
+    catchup,
+    periodKey: market.periodKey,
+    yesProbabilityBps: market.definition.yesProbabilityBps,
+    bettingClosesAt: market.bettingClosesAt,
+    scoringStartsAt: market.definition.scoringStartsAt,
+    scoringEndsAt: market.scoringEndsAt,
+    criteria,
+    evaluation,
+    aliases,
+    bettorCount: market.bets.length,
+    totalStaked,
+  });
   const mentionChunks = Array.from(
     {
       length: Math.max(1, Math.ceil(mentionIds.length / MENTIONS_PER_MESSAGE)),

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION,
   WEEKLY_PARLAY_SCHEMA_VERSION,
   WeeklyParlayContributionSnapshotSchema,
   type WeeklyParlayDefinitionCriteria,
@@ -7,44 +8,92 @@ import {
 import { evaluateWeeklyParlay } from "#src/betting/weekly-parlay-evaluator.ts";
 
 function contribution(input: {
-  puuid: string;
   completedAt: string;
-  win: boolean;
   champion?: string;
+  win?: boolean;
   kills?: number;
-  deaths?: number;
+  assists?: number;
   damage?: number;
+  visionScore?: number;
 }) {
   return WeeklyParlayContributionSnapshotSchema.parse({
     subject: "P1",
-    puuid: input.puuid,
+    puuid: "a".repeat(78),
     queue: "solo",
     completedAt: input.completedAt,
-    win: input.win,
+    win: input.win ?? true,
     champion: input.champion ?? "Ahri",
     role: "MIDDLE",
     kills: input.kills ?? 3,
-    deaths: input.deaths ?? 2,
-    assists: 5,
+    deaths: 2,
+    assists: input.assists ?? 5,
     championDamage: input.damage ?? 20_000,
     creepScore: 200,
     gold: 12_000,
-    visionScore: 20,
+    visionScore: input.visionScore ?? 20,
     timePlayed: 1800,
   });
 }
 
 describe("weekly parlay evaluator", () => {
-  test("aggregates every frozen account and can prove monotonic YES early", () => {
+  test("retains version-one evaluation semantics", () => {
     const criteria: WeeklyParlayDefinitionCriteria = {
-      version: WEEKLY_PARLAY_SCHEMA_VERSION,
+      version: WEEKLY_PARLAY_LEGACY_SCHEMA_VERSION,
       legs: [
         {
           kind: "aggregate",
           subject: "P1",
           metric: "games",
           operator: "gte",
-          threshold: 2,
+          threshold: 1,
+        },
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "wins",
+          operator: "gte",
+          threshold: 1,
+        },
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "champion_damage",
+          operator: "gte",
+          threshold: 10_000,
+        },
+      ],
+    };
+    const result = evaluateWeeklyParlay(criteria, [
+      contribution({ completedAt: "2026-08-24T10:00:00.000Z" }),
+    ]);
+    expect(result.qualification).toMatchObject({
+      minimumGamesPerSubject: 0,
+      passed: true,
+    });
+    expect(result.yesResult).toBe(true);
+    expect(result.irreversiblyYes).toBe(true);
+  });
+
+  test("filters champion peak stats and qualifies after three games", () => {
+    const criteria: WeeklyParlayDefinitionCriteria = {
+      version: WEEKLY_PARLAY_SCHEMA_VERSION,
+      qualification: { minimumGamesPerSubject: 3 },
+      legs: [
+        {
+          kind: "champion_peak",
+          subject: "P1",
+          champion: "Twisted Fate",
+          metric: "kills",
+          operator: "gte",
+          threshold: 9,
+        },
+        {
+          kind: "champion_peak",
+          subject: "P1",
+          champion: "Twisted Fate",
+          metric: "assists",
+          operator: "gte",
+          threshold: 12,
         },
         {
           kind: "aggregate",
@@ -53,87 +102,45 @@ describe("weekly parlay evaluator", () => {
           operator: "gte",
           threshold: 2,
         },
-        {
-          kind: "aggregate",
-          subject: "P1",
-          metric: "champion_damage",
-          operator: "gte",
-          threshold: 30_000,
-        },
       ],
     };
     const result = evaluateWeeklyParlay(criteria, [
       contribution({
-        puuid: "a".repeat(78),
         completedAt: "2026-08-24T10:00:00.000Z",
-        win: true,
+        champion: "Twisted Fate",
+        kills: 9,
+        assists: 12,
       }),
       contribution({
-        puuid: "b".repeat(78),
         completedAt: "2026-08-25T10:00:00.000Z",
-        win: true,
+        champion: "Ahri",
+        kills: 20,
+        assists: 20,
+      }),
+      contribution({
+        completedAt: "2026-08-26T10:00:00.000Z",
+        champion: "Twisted Fate",
       }),
     ]);
+    expect(result.legs.map((leg) => leg.current)).toEqual([9, 12, 3]);
+    expect(result.qualification.passed).toBe(true);
     expect(result.yesResult).toBe(true);
     expect(result.irreversiblyYes).toBe(true);
   });
 
-  test("keeps rate and upper-bound legs final-only", () => {
+  test("does not settle YES before activity qualification", () => {
     const result = evaluateWeeklyParlay(
       {
         version: WEEKLY_PARLAY_SCHEMA_VERSION,
+        qualification: { minimumGamesPerSubject: 3 },
         legs: [
           {
-            kind: "aggregate",
+            kind: "champion_peak",
             subject: "P1",
-            metric: "games",
+            champion: "Twisted Fate",
+            metric: "kills",
             operator: "gte",
-            threshold: 1,
-          },
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "deaths",
-            operator: "lte",
-            threshold: 3,
-          },
-          {
-            kind: "rate",
-            subject: "P1",
-            metric: "win_rate_bps",
-            operator: "gte",
-            threshold: 5000,
-          },
-        ],
-      },
-      [
-        contribution({
-          puuid: "a".repeat(78),
-          completedAt: "2026-08-24T10:00:00.000Z",
-          win: true,
-        }),
-      ],
-    );
-    expect(result.yesResult).toBe(true);
-    expect(result.irreversiblyYes).toBe(false);
-    expect(result.legs.map((leg) => leg.irreversiblyPassed)).toEqual([
-      true,
-      false,
-      false,
-    ]);
-  });
-
-  test("zero games is an ordinary evaluated result", () => {
-    const result = evaluateWeeklyParlay(
-      {
-        version: WEEKLY_PARLAY_SCHEMA_VERSION,
-        legs: [
-          {
-            kind: "aggregate",
-            subject: "P1",
-            metric: "games",
-            operator: "gte",
-            threshold: 1,
+            threshold: 9,
           },
           {
             kind: "aggregate",
@@ -143,17 +150,25 @@ describe("weekly parlay evaluator", () => {
             threshold: 1,
           },
           {
-            kind: "rate",
+            kind: "aggregate",
             subject: "P1",
-            metric: "win_rate_bps",
+            metric: "best_game_assists",
             operator: "gte",
-            threshold: 5000,
+            threshold: 5,
           },
         ],
       },
-      [],
+      [
+        contribution({
+          completedAt: "2026-08-24T10:00:00.000Z",
+          champion: "Twisted Fate",
+          kills: 9,
+        }),
+      ],
     );
+    expect(result.legs.every((leg) => leg.passed)).toBe(true);
+    expect(result.qualification.passed).toBe(false);
     expect(result.yesResult).toBe(false);
-    expect(result.legs.map((leg) => leg.current)).toEqual([0, 0, 0]);
+    expect(result.irreversiblyYes).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-evaluator.ts
@@ -1,8 +1,8 @@
 import type {
+  WeeklyParlayAnyLegShape,
   WeeklyParlayContributionSnapshot,
   WeeklyParlayDefinitionCriteria,
   WeeklyParlayLeg,
-  WeeklyParlayLegShape,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { WeeklyParlayDefinitionCriteriaSchema } from "#src/betting/weekly-parlay-criteria.ts";
 
@@ -15,6 +15,15 @@ export type WeeklyParlayLegResult = {
 
 export type WeeklyParlayEvaluation = {
   legs: WeeklyParlayLegResult[];
+  qualification: {
+    minimumGamesPerSubject: number;
+    subjects: {
+      subject: string;
+      games: number;
+      passed: boolean;
+    }[];
+    passed: boolean;
+  };
   yesResult: boolean;
   irreversiblyYes: boolean;
 };
@@ -70,7 +79,7 @@ function longestWinStreak(
 }
 
 function aggregateValue(
-  leg: Extract<WeeklyParlayLegShape, { kind: "aggregate" }>,
+  leg: Extract<WeeklyParlayAnyLegShape, { kind: "aggregate" }>,
   contributions: readonly WeeklyParlayContributionSnapshot[],
 ): number {
   switch (leg.metric) {
@@ -119,7 +128,7 @@ function average(total: number, count: number): number {
 }
 
 function rateValue(
-  leg: Extract<WeeklyParlayLegShape, { kind: "rate" }>,
+  leg: Extract<WeeklyParlayAnyLegShape, { kind: "rate" }>,
   contributions: readonly WeeklyParlayContributionSnapshot[],
 ): number {
   const games = contributions.length;
@@ -171,7 +180,7 @@ function rateValue(
 }
 
 export function weeklyParlayLegValue(
-  leg: WeeklyParlayLegShape,
+  leg: WeeklyParlayAnyLegShape,
   allContributions: readonly WeeklyParlayContributionSnapshot[],
 ): number {
   const contributions = allContributions.filter(
@@ -193,6 +202,33 @@ export function weeklyParlayLegValue(
         (contribution) =>
           contribution.role === leg.role && (!leg.winsOnly || contribution.win),
       ).length;
+    case "champion_peak": {
+      const championContributions = contributions.filter(
+        (contribution) => contribution.champion === leg.champion,
+      );
+      switch (leg.metric) {
+        case "kills":
+          return maximum(
+            championContributions,
+            (contribution) => contribution.kills,
+          );
+        case "assists":
+          return maximum(
+            championContributions,
+            (contribution) => contribution.assists,
+          );
+        case "champion_damage":
+          return maximum(
+            championContributions,
+            (contribution) => contribution.championDamage,
+          );
+        case "vision_score":
+          return maximum(
+            championContributions,
+            (contribution) => contribution.visionScore,
+          );
+      }
+    }
   }
 }
 
@@ -215,9 +251,30 @@ export function evaluateWeeklyParlay(
       irreversiblyPassed: passed && isMonotonicGte(leg),
     };
   });
+  const minimumGamesPerSubject =
+    criteria.version === 1 ? 0 : criteria.qualification.minimumGamesPerSubject;
+  const subjects = [...new Set(criteria.legs.map((leg) => leg.subject))]
+    .toSorted((left, right) => left.localeCompare(right))
+    .map((subject) => {
+      const games = contributions.filter(
+        (contribution) => contribution.subject === subject,
+      ).length;
+      return {
+        subject,
+        games,
+        passed: games >= minimumGamesPerSubject,
+      };
+    });
+  const qualification = {
+    minimumGamesPerSubject,
+    subjects,
+    passed: subjects.every((subject) => subject.passed),
+  };
   return {
     legs,
-    yesResult: legs.every((leg) => leg.passed),
-    irreversiblyYes: legs.every((leg) => leg.irreversiblyPassed),
+    qualification,
+    yesResult: qualification.passed && legs.every((leg) => leg.passed),
+    irreversiblyYes:
+      qualification.passed && legs.every((leg) => leg.irreversiblyPassed),
   };
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, test } from "vitest";
 import { WeeklyParlayContributionSnapshotSchema } from "#src/betting/weekly-parlay-criteria.ts";
-import { buildObservedWeeklyReplayWindows } from "#src/betting/weekly-parlay-history.ts";
+import {
+  buildObservedWeeklyReplayWindows,
+  buildWeeklyChampionShortlist,
+} from "#src/betting/weekly-parlay-history.ts";
+
+function championContribution(name: string, index: number) {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: "P1",
+    puuid: "p".repeat(78),
+    queue: "solo",
+    completedAt: new Date(Date.UTC(2026, 6, index + 1)).toISOString(),
+    win: index % 2 === 0,
+    champion: name,
+    role: "MIDDLE",
+    kills: index,
+    deaths: 2,
+    assists: index + 2,
+    championDamage: 20_000 + index,
+    creepScore: 180,
+    gold: 12_000,
+    visionScore: 18 + index,
+    timePlayed: 1800,
+  });
+}
 
 describe("weekly parlay historical window alignment", () => {
   test("preserves zero-game windows for the shortened Pacific scoring shape", () => {
@@ -55,6 +78,56 @@ describe("weekly parlay historical window alignment", () => {
       "2026-08-03",
       "2026-08-10",
       "2026-08-17",
+    ]);
+  });
+
+  test("builds a deterministic champion shortlist from the trailing eight windows", () => {
+    const windows = Array.from({ length: 10 }, (_value, index) => ({
+      periodKey: `window-${index.toString()}`,
+      contributions:
+        index < 2
+          ? [championContribution("Ignored", index)]
+          : [
+              ...(index === 2 || index === 3 || index === 4
+                ? [championContribution("Ahri", index)]
+                : []),
+              ...(index === 2 || index === 3
+                ? [
+                    championContribution("Twisted Fate", index),
+                    championContribution("Twisted Fate", index + 10),
+                  ]
+                : []),
+              ...(index === 4 || index === 5 || index === 6
+                ? [championContribution("Bard", index)]
+                : []),
+              ...(index === 6
+                ? [championContribution("Bard", index + 10)]
+                : []),
+              ...(index === 7
+                ? [
+                    championContribution("Lux", index),
+                    championContribution("Lux", index + 10),
+                    championContribution("Lux", index + 20),
+                  ]
+                : []),
+              ...(index === 8 || index === 9
+                ? [championContribution("Jinx", index)]
+                : []),
+              ...(index === 3
+                ? [championContribution("Twisted Fate", index + 20)]
+                : []),
+            ],
+    }));
+    expect(
+      buildWeeklyChampionShortlist(windows).map((entry) => ({
+        champion: entry.champion,
+        windowsPlayed: entry.windowsPlayed,
+        gamesPlayed: entry.gamesPlayed,
+      })),
+    ).toEqual([
+      { champion: "Bard", windowsPlayed: 3, gamesPlayed: 4 },
+      { champion: "Ahri", windowsPlayed: 3, gamesPlayed: 3 },
+      { champion: "Twisted Fate", windowsPlayed: 2, gamesPlayed: 5 },
     ]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-history.ts
@@ -2,6 +2,10 @@ import { addWeeks, formatISO, parseISO } from "date-fns";
 import { z } from "zod";
 import { LeaguePuuidSchema } from "@scout-for-lol/data";
 import {
+  WEEKLY_PARLAY_CHAMPION_HISTORY_WINDOWS,
+  WEEKLY_PARLAY_CHAMPION_MIN_GAMES,
+  WEEKLY_PARLAY_CHAMPION_MIN_WINDOWS,
+  WEEKLY_PARLAY_CHAMPION_SHORTLIST_LIMIT,
   WEEKLY_PARLAY_HISTORY_WINDOW_COUNT,
   WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
   WeeklyParlayContributionSnapshotSchema,
@@ -49,9 +53,81 @@ export type WeeklyParlayCandidateHistory = {
   windows: WeeklyParlayReplayWindow[];
   fullyObservedWindows: number;
   recentEligibleGames: number;
-  observedChampions: Set<string>;
-  observedRoles: Set<string>;
+  championShortlist: WeeklyParlayChampionSummary[];
 };
+
+export type WeeklyParlayChampionSummary = {
+  champion: string;
+  windowsPlayed: number;
+  gamesPlayed: number;
+  wins: number;
+  bestKills: number;
+  bestAssists: number;
+  bestChampionDamage: number;
+  bestVisionScore: number;
+};
+
+export function buildWeeklyChampionShortlist(
+  windows: readonly WeeklyParlayReplayWindow[],
+): WeeklyParlayChampionSummary[] {
+  const recentWindows = windows.slice(-WEEKLY_PARLAY_CHAMPION_HISTORY_WINDOWS);
+  const summaries = new Map<
+    string,
+    WeeklyParlayChampionSummary & { periodKeys: Set<string> }
+  >();
+  for (const window of recentWindows) {
+    for (const contribution of window.contributions) {
+      const current = summaries.get(contribution.champion) ?? {
+        champion: contribution.champion,
+        windowsPlayed: 0,
+        gamesPlayed: 0,
+        wins: 0,
+        bestKills: 0,
+        bestAssists: 0,
+        bestChampionDamage: 0,
+        bestVisionScore: 0,
+        periodKeys: new Set<string>(),
+      };
+      current.periodKeys.add(window.periodKey);
+      current.gamesPlayed += 1;
+      current.wins += contribution.win ? 1 : 0;
+      current.bestKills = Math.max(current.bestKills, contribution.kills);
+      current.bestAssists = Math.max(current.bestAssists, contribution.assists);
+      current.bestChampionDamage = Math.max(
+        current.bestChampionDamage,
+        contribution.championDamage,
+      );
+      current.bestVisionScore = Math.max(
+        current.bestVisionScore,
+        contribution.visionScore,
+      );
+      summaries.set(contribution.champion, current);
+    }
+  }
+  return [...summaries.values()]
+    .map((summary) => ({
+      champion: summary.champion,
+      windowsPlayed: summary.periodKeys.size,
+      gamesPlayed: summary.gamesPlayed,
+      wins: summary.wins,
+      bestKills: summary.bestKills,
+      bestAssists: summary.bestAssists,
+      bestChampionDamage: summary.bestChampionDamage,
+      bestVisionScore: summary.bestVisionScore,
+    }))
+    .filter(
+      (summary) =>
+        summary.gamesPlayed >= WEEKLY_PARLAY_CHAMPION_MIN_GAMES &&
+        summary.windowsPlayed >= WEEKLY_PARLAY_CHAMPION_MIN_WINDOWS,
+    )
+    .toSorted(
+      (left, right) =>
+        right.windowsPlayed - left.windowsPlayed ||
+        right.gamesPlayed - left.gamesPlayed ||
+        left.champion.localeCompare(right.champion),
+    )
+    .slice(0, WEEKLY_PARLAY_CHAMPION_SHORTLIST_LIMIT);
+}
 
 function periodKeysBefore(periodKey: string): string[] {
   const current = parseISO(periodKey);
@@ -222,9 +298,6 @@ export async function fetchWeeklyCandidateHistories(input: {
         trackingStartedAt: new Date(trackingStartedAt),
         contributions: snapshots,
       });
-      const alignedSnapshots = windows.flatMap(
-        (window) => window.contributions,
-      );
       const recentPeriod = weeklyParlayScoringWindowForPeriod(
         keys.at(-1) ?? "",
         shape,
@@ -245,12 +318,7 @@ export async function fetchWeeklyCandidateHistories(input: {
         windows,
         fullyObservedWindows: windows.length,
         recentEligibleGames: recentMatchIds.size,
-        observedChampions: new Set(
-          alignedSnapshots.map((snapshot) => snapshot.champion),
-        ),
-        observedRoles: new Set(
-          alignedSnapshots.map((snapshot) => snapshot.role),
-        ),
+        championShortlist: buildWeeklyChampionShortlist(windows),
       };
     })
     .filter(

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-model.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-model.ts
@@ -1,31 +1,34 @@
-import { z } from "zod";
 import { generateValidatedObject } from "@shepherdjerred/llm-runtime";
-import { bettingParlayAiModel } from "#src/config/dynamic.ts";
+import { z } from "zod";
 import {
   PARLAY_INITIAL_OUTPUT_TOKENS,
   PARLAY_RETRY_OUTPUT_TOKENS,
 } from "#src/betting/constants.ts";
 import {
+  WEEKLY_PARLAY_PROPOSAL_COUNT,
   WEEKLY_PARLAY_SCHEMA_VERSION,
   WeeklyParlayAggregateMetricSchema,
+  WeeklyParlayChampionPeakMetricSchema,
   WeeklyParlayProposalSchema,
   WeeklyParlayRateMetricSchema,
-  WeeklyParlayRoleSchema,
   WeeklyParlaySubjectKeySchema,
+  validateWeeklyParlayProposal,
   type WeeklyParlayProposal,
   type WeeklyParlaySubject,
 } from "#src/betting/weekly-parlay-criteria.ts";
+import type { WeeklyParlayChampionSummary } from "#src/betting/weekly-parlay-history.ts";
+import { bettingParlayAiModel } from "#src/config/dynamic.ts";
 import { getOpenRouterRuntime } from "#src/league/review/ai-clients.ts";
 
-export const WEEKLY_PARLAY_PROMPT_VERSION = "1";
+export const WEEKLY_PARLAY_PROMPT_VERSION = "2";
 
 const ModelWeeklyLegSchema = z.strictObject({
-  kind: z.enum(["aggregate", "rate", "champion_games", "role_games"]),
+  kind: z.enum(["aggregate", "rate", "champion_games", "champion_peak"]),
   subject: WeeklyParlaySubjectKeySchema,
   aggregateMetric: WeeklyParlayAggregateMetricSchema.nullable(),
   rateMetric: WeeklyParlayRateMetricSchema.nullable(),
+  championPeakMetric: WeeklyParlayChampionPeakMetricSchema.nullable(),
   champion: z.string().min(1).max(50).nullable(),
-  role: WeeklyParlayRoleSchema.nullable(),
   winsOnly: z.boolean().nullable(),
   operator: z.enum(["gte", "lte", "eq"]),
 });
@@ -34,10 +37,10 @@ const ModelWeeklyProposalSchema = z.strictObject({
   legs: z.array(ModelWeeklyLegSchema).min(3).max(5),
 });
 
-function canonicalProposal(
+function canonicalProposalInput(
   model: z.infer<typeof ModelWeeklyProposalSchema>,
-): WeeklyParlayProposal {
-  return WeeklyParlayProposalSchema.parse({
+) {
+  return {
     version: model.version,
     legs: model.legs.map((leg) => {
       switch (leg.kind) {
@@ -63,29 +66,125 @@ function canonicalProposal(
             winsOnly: leg.winsOnly,
             operator: leg.operator,
           };
-        case "role_games":
+        case "champion_peak":
           return {
             kind: leg.kind,
             subject: leg.subject,
-            role: leg.role,
-            winsOnly: leg.winsOnly,
+            champion: leg.champion,
+            metric: leg.championPeakMetric,
             operator: leg.operator,
           };
       }
     }),
+  };
+}
+
+function proposalShapeKey(proposal: WeeklyParlayProposal): string {
+  return JSON.stringify(
+    proposal.legs
+      .map((leg) => JSON.stringify(leg))
+      .toSorted((left, right) => left.localeCompare(right)),
+  );
+}
+
+const ModelWeeklyProposalsSchema = z
+  .strictObject({
+    version: z.literal(WEEKLY_PARLAY_SCHEMA_VERSION),
+    proposals: z
+      .array(ModelWeeklyProposalSchema)
+      .length(WEEKLY_PARLAY_PROPOSAL_COUNT),
+  })
+  .superRefine((output, context) => {
+    const seen = new Set<string>();
+    for (const [index, proposal] of output.proposals.entries()) {
+      const canonical = WeeklyParlayProposalSchema.safeParse(
+        canonicalProposalInput(proposal),
+      );
+      if (!canonical.success) {
+        context.addIssue({
+          code: "custom",
+          path: ["proposals", index],
+          message: canonical.error.message,
+        });
+        continue;
+      }
+      const key = proposalShapeKey(canonical.data);
+      if (seen.has(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["proposals", index],
+          message: "Weekly parlay proposals must be distinct.",
+        });
+      }
+      seen.add(key);
+    }
+  });
+
+function modelWeeklyProposalsSchema(input: {
+  subjects: readonly WeeklyParlaySubject[];
+  championShortlists: ReadonlyMap<
+    string,
+    readonly WeeklyParlayChampionSummary[]
+  >;
+}) {
+  const eligibleChampions = new Map(
+    input.subjects.map((subject) => [
+      subject.key,
+      new Set(
+        (input.championShortlists.get(subject.key) ?? []).map(
+          (summary) => summary.champion,
+        ),
+      ),
+    ]),
+  );
+  return ModelWeeklyProposalsSchema.superRefine((output, context) => {
+    for (const [index, proposal] of output.proposals.entries()) {
+      const canonical = WeeklyParlayProposalSchema.safeParse(
+        canonicalProposalInput(proposal),
+      );
+      if (!canonical.success) {
+        continue;
+      }
+      for (const issue of validateWeeklyParlayProposal({
+        proposal: canonical.data,
+        subjects: input.subjects,
+        eligibleChampions,
+      })) {
+        context.addIssue({
+          code: "custom",
+          path: ["proposals", index],
+          message: issue,
+        });
+      }
+    }
   });
 }
 
-export async function generateWeeklyParlayProposal(input: {
+function canonicalProposal(
+  model: z.infer<typeof ModelWeeklyProposalSchema>,
+): WeeklyParlayProposal {
+  const proposal = WeeklyParlayProposalSchema.parse(
+    canonicalProposalInput(model),
+  );
+  return {
+    ...proposal,
+    legs: proposal.legs.toSorted((left, right) =>
+      JSON.stringify(left).localeCompare(JSON.stringify(right)),
+    ),
+  };
+}
+
+export async function generateWeeklyParlayProposals(input: {
   periodKey: string;
   subjects: readonly WeeklyParlaySubject[];
-  observedChampions: ReadonlyMap<string, ReadonlySet<string>>;
-  observedRoles: ReadonlyMap<string, ReadonlySet<string>>;
-  recentEligibleGames: ReadonlyMap<string, number>;
+  championShortlists: ReadonlyMap<
+    string,
+    readonly WeeklyParlayChampionSummary[]
+  >;
   historyWindows: number;
   abortSignal?: AbortSignal;
 }): Promise<{
-  proposal: WeeklyParlayProposal;
+  proposals: WeeklyParlayProposal[];
   model: string;
   resolvedModel: string | null;
   usage: unknown;
@@ -97,30 +196,30 @@ export async function generateWeeklyParlayProposal(input: {
     );
   }
   const model = bettingParlayAiModel();
+  const OutputSchema = modelWeeklyProposalsSchema(input);
   const result = await generateValidatedObject(runtime, {
     model,
-    schema: ModelWeeklyProposalSchema,
-    schemaName: "bryan_bucks_weekly_parlay_proposal",
+    schema: OutputSchema,
+    schemaName: "bryan_bucks_weekly_parlay_proposals",
     schemaDescription:
-      "Three to five weekly AND legs from Scout's closed catalog, with no thresholds or odds.",
+      "Exactly five distinct weekly AND proposals from Scout's closed interesting catalog, with no thresholds or odds.",
     system:
-      "Choose a coherent, fun weekly League of Legends parlay. Use only the schema. " +
-      "Include every subject and a games gte participation leg for every subject. " +
-      "Never invent thresholds, odds, fields, paths, expressions, or settlement logic.",
+      "Choose five distinct, coherent, challenging weekly League of Legends parlays. Use only the schema. " +
+      "Every proposal must include every subject and at least one champion_peak leg. " +
+      "Use only champions in that subject's shortlist. Champion games always means winsOnly true and gte. " +
+      "Champion peak always means gte. Never invent thresholds, odds, fields, paths, expressions, participation legs, or settlement logic.",
     prompt: JSON.stringify({
       periodKey: input.periodKey,
       subjects: input.subjects.map((subject) => ({
         key: subject.key,
         alias: subject.alias,
-        recentEligibleGames: input.recentEligibleGames.get(subject.key),
-        historicallyObservedChampions: [
-          ...(input.observedChampions.get(subject.key) ?? []),
-        ].toSorted(),
-        historicallyObservedRoles: [
-          ...(input.observedRoles.get(subject.key) ?? []),
-        ].toSorted(),
+        championShortlist: input.championShortlists.get(subject.key) ?? [],
       })),
       fullyObservedHistoryWindows: input.historyWindows,
+      settlementQualification: {
+        minimumEligibleGamesPerSubject: 3,
+        note: "Qualification is not a displayed betting leg.",
+      },
     }),
     workload: "scout.betting.weekly-parlay.generate",
     sessionId: `${input.periodKey}:${input.subjects.map((subject) => subject.playerId).join("-")}`,
@@ -131,9 +230,18 @@ export async function generateWeeklyParlayProposal(input: {
       ? {}
       : { abortSignal: input.abortSignal }),
   });
-  const parsed = ModelWeeklyProposalSchema.parse(result.object);
+  const parsed = OutputSchema.parse(result.object);
+  const proposals = parsed.proposals.map((proposal) =>
+    canonicalProposal(proposal),
+  );
+  if (
+    new Set(proposals.map((proposal) => proposalShapeKey(proposal))).size !==
+    WEEKLY_PARLAY_PROPOSAL_COUNT
+  ) {
+    throw new Error("Weekly parlay proposals were not distinct after parsing.");
+  }
   return {
-    proposal: canonicalProposal(parsed),
+    proposals,
     model,
     resolvedModel: result.metadata.at(-1)?.resolvedModel ?? null,
     usage: result.usage,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-open.ts
@@ -9,9 +9,12 @@ import {
   WeeklyParlaySubjectsSchema,
   validateWeeklyParlayProposal,
 } from "#src/betting/weekly-parlay-criteria.ts";
-import { fetchWeeklyCandidateHistories } from "#src/betting/weekly-parlay-history.ts";
 import {
-  generateWeeklyParlayProposal,
+  fetchWeeklyCandidateHistories,
+  type WeeklyParlayCandidateHistory,
+} from "#src/betting/weekly-parlay-history.ts";
+import {
+  generateWeeklyParlayProposals,
   WEEKLY_PARLAY_PROMPT_VERSION,
 } from "#src/betting/weekly-parlay-model.ts";
 import {
@@ -21,7 +24,10 @@ import {
   weeklyParlayPeriod,
   type WeeklyParlayFrozenWindow,
 } from "#src/betting/weekly-parlay-period.ts";
-import { priceWeeklyParlay } from "#src/betting/weekly-parlay-pricing.ts";
+import {
+  priceWeeklyParlayProposals,
+  type WeeklyParlayPricing,
+} from "#src/betting/weekly-parlay-pricing.ts";
 import { orderWeeklyParlayCandidates } from "#src/betting/weekly-parlay-selection.ts";
 import { loadWeeklyParlaySubjects } from "#src/betting/weekly-parlay-subjects.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
@@ -117,6 +123,55 @@ function timelineKind(
   return isWeeklyParlayCatchupTimeline(period) ? "catch_up" : "standard";
 }
 
+async function generatePricedCandidate(input: {
+  periodKey: string;
+  history: WeeklyParlayCandidateHistory;
+  signal?: AbortSignal;
+}): Promise<
+  | {
+      generated: Awaited<ReturnType<typeof generateWeeklyParlayProposals>>;
+      priced: WeeklyParlayPricing;
+    }
+  | undefined
+> {
+  if (input.history.championShortlist.length === 0) {
+    return;
+  }
+  const championShortlists = new Map([
+    [input.history.subject.key, input.history.championShortlist],
+  ]);
+  const eligibleChampions = new Map([
+    [
+      input.history.subject.key,
+      new Set(
+        input.history.championShortlist.map((summary) => summary.champion),
+      ),
+    ],
+  ]);
+  const generated = await generateWeeklyParlayProposals({
+    periodKey: input.periodKey,
+    subjects: [input.history.subject],
+    championShortlists,
+    historyWindows: input.history.fullyObservedWindows,
+    ...(input.signal === undefined ? {} : { abortSignal: input.signal }),
+  });
+  const issues = generated.proposals.flatMap((proposal, index) =>
+    validateWeeklyParlayProposal({
+      proposal,
+      subjects: [input.history.subject],
+      eligibleChampions,
+    }).map((issue) => `Proposal ${String(index + 1)}: ${issue}`),
+  );
+  if (issues.length > 0) {
+    return;
+  }
+  const priced = priceWeeklyParlayProposals({
+    proposals: generated.proposals,
+    windows: input.history.windows,
+  });
+  return priced === undefined ? undefined : { generated, priced };
+}
+
 async function openWeeklyParlayInternal(
   input: OpenWeeklyParlayInput,
   prismaClient: ExtendedPrismaClient = prisma,
@@ -206,37 +261,15 @@ async function openWeeklyParlayInternal(
     if (history === undefined) {
       throw new Error("Ordered weekly candidate lost its history snapshot.");
     }
-    const generated = await generateWeeklyParlayProposal({
+    const candidateResult = await generatePricedCandidate({
       periodKey: input.periodKey,
-      subjects: [history.subject],
-      observedChampions: new Map([
-        [history.subject.key, history.observedChampions],
-      ]),
-      observedRoles: new Map([[history.subject.key, history.observedRoles]]),
-      recentEligibleGames: new Map([
-        [history.subject.key, history.recentEligibleGames],
-      ]),
-      historyWindows: history.fullyObservedWindows,
-      ...(input.signal === undefined ? {} : { abortSignal: input.signal }),
+      history,
+      ...(input.signal === undefined ? {} : { signal: input.signal }),
     });
-    const issues = validateWeeklyParlayProposal({
-      proposal: generated.proposal,
-      subjects: [history.subject],
-      observedChampions: new Map([
-        [history.subject.key, history.observedChampions],
-      ]),
-      observedRoles: new Map([[history.subject.key, history.observedRoles]]),
-    });
-    if (issues.length > 0) {
+    if (candidateResult === undefined) {
       continue;
     }
-    const priced = priceWeeklyParlay({
-      proposal: generated.proposal,
-      windows: history.windows,
-    });
-    if (priced === undefined) {
-      continue;
-    }
+    const { generated, priced } = candidateResult;
     if (!openActionIsActive(period, input.signal, input.generationDeadline)) {
       return { kind: "too_late" };
     }
@@ -253,14 +286,21 @@ async function openWeeklyParlayInternal(
             scoringEndsAt: period.scoringEndsAt,
             subjects: JSON.stringify([history.subject]),
             eligibleQueues: JSON.stringify(WEEKLY_PARLAY_ELIGIBLE_QUEUES),
-            proposal: JSON.stringify(generated.proposal),
+            proposal: JSON.stringify(priced.proposal),
             criteria: JSON.stringify(priced.criteria),
             historySample: JSON.stringify(history.windows),
             pricing: JSON.stringify({
               yesProbabilityBps: priced.yesProbabilityBps,
               yesWindows: priced.yesWindows,
-              sampleSize: priced.sampleSize,
-              periodKeys: priced.periodKeys,
+              totalWindows: priced.totalWindows,
+              qualifiedWindows: priced.qualifiedWindows,
+              excludedWindows: priced.excludedWindows,
+              qualifiedPeriodKeys: priced.qualifiedPeriodKeys,
+              excludedPeriodKeys: priced.excludedPeriodKeys,
+              recentQualifiedWindows: priced.recentQualifiedWindows,
+              recentYesWindows: priced.recentYesWindows,
+              recentYesProbabilityBps: priced.recentYesProbabilityBps,
+              legEvidence: priced.legEvidence,
             }),
             yesProbabilityBps: priced.yesProbabilityBps,
             promptVersion: WEEKLY_PARLAY_PROMPT_VERSION,
@@ -271,8 +311,8 @@ async function openWeeklyParlayInternal(
             generationContext: JSON.stringify({
               candidateOrder: ordered.map((entry) => entry.playerId),
               selectedPlayerId: history.subject.playerId,
-              observedChampions: [...history.observedChampions].toSorted(),
-              observedRoles: [...history.observedRoles].toSorted(),
+              championShortlist: history.championShortlist,
+              generatedProposals: generated.proposals,
               recentEligibleGames: history.recentEligibleGames,
               fullyObservedWindows: history.fullyObservedWindows,
               timelineKind: timelineKind(period),

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.test.ts
@@ -6,80 +6,160 @@ import {
 } from "#src/betting/weekly-parlay-criteria.ts";
 import {
   priceWeeklyParlay,
+  priceWeeklyParlayProposals,
   type WeeklyParlayReplayWindow,
 } from "#src/betting/weekly-parlay-pricing.ts";
 
 const proposal: WeeklyParlayProposal = {
   version: WEEKLY_PARLAY_SCHEMA_VERSION,
   legs: [
-    { kind: "aggregate", subject: "P1", metric: "games", operator: "gte" },
-    { kind: "aggregate", subject: "P1", metric: "wins", operator: "gte" },
     {
-      kind: "aggregate",
+      kind: "champion_peak",
       subject: "P1",
-      metric: "champion_damage",
+      champion: "Twisted Fate",
+      metric: "kills",
+      operator: "gte",
+    },
+    {
+      kind: "champion_peak",
+      subject: "P1",
+      champion: "Twisted Fate",
+      metric: "assists",
+      operator: "gte",
+    },
+    {
+      kind: "champion_games",
+      subject: "P1",
+      champion: "Twisted Fate",
+      winsOnly: true,
       operator: "gte",
     },
   ],
 };
 
-function windows(count: number): WeeklyParlayReplayWindow[] {
+function contribution(input: {
+  windowIndex: number;
+  gameIndex: number;
+  score: number;
+  win: boolean;
+}) {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: "P1",
+    puuid: "a".repeat(78),
+    queue: "solo",
+    completedAt: new Date(
+      Date.UTC(2025, 0, 1 + input.windowIndex, input.gameIndex),
+    ).toISOString(),
+    win: input.win,
+    champion: "Twisted Fate",
+    role: "MIDDLE",
+    kills: Math.max(0, input.score + 1 - input.gameIndex),
+    deaths: 2,
+    assists: input.score + 2 - input.gameIndex,
+    championDamage: 10_000 + input.score * 1000,
+    creepScore: 200,
+    gold: 12_000,
+    visionScore: input.score + 3 - input.gameIndex,
+    timePlayed: 1800,
+  });
+}
+
+function qualifiedWindows(count: number): WeeklyParlayReplayWindow[] {
+  return Array.from({ length: count }, (_window, windowIndex) => {
+    const score = (windowIndex * 7) % 20;
+    return {
+      periodKey: `qualified-${windowIndex.toString().padStart(2, "0")}`,
+      contributions: Array.from({ length: 3 }, (_game, gameIndex) =>
+        contribution({
+          windowIndex,
+          gameIndex,
+          score,
+          win: gameIndex === 0 || (gameIndex === 1 && score >= 10),
+        }),
+      ),
+    };
+  });
+}
+
+function excludedWindows(count: number): WeeklyParlayReplayWindow[] {
   return Array.from({ length: count }, (_window, windowIndex) => ({
-    periodKey: `window-${windowIndex.toString().padStart(2, "0")}`,
-    contributions:
-      windowIndex % 4 === 0
-        ? []
-        : Array.from({ length: (windowIndex % 5) + 1 }, (_game, gameIndex) =>
-            WeeklyParlayContributionSnapshotSchema.parse({
-              subject: "P1",
-              puuid: gameIndex % 2 === 0 ? "a".repeat(78) : "b".repeat(78),
-              queue: gameIndex % 3 === 0 ? "ranked 5s" : "solo",
-              completedAt: new Date(
-                Date.UTC(2025, 0, 1 + windowIndex, gameIndex),
-              ).toISOString(),
-              win: (windowIndex + gameIndex) % 2 === 0,
-              champion: "Ahri",
-              role: "MIDDLE",
-              kills: 3,
-              deaths: 2,
-              assists: 5,
-              championDamage: 10_000 + windowIndex * 1000,
-              creepScore: 200,
-              gold: 12_000,
-              visionScore: 20,
-              timePlayed: 1800,
-            }),
-          ),
+    periodKey: `excluded-${windowIndex.toString().padStart(2, "0")}`,
+    contributions: [
+      contribution({ windowIndex, gameIndex: 0, score: 19, win: true }),
+      contribution({ windowIndex, gameIndex: 1, score: 19, win: true }),
+    ],
   }));
 }
 
 describe("weekly parlay replay pricing", () => {
-  test("jointly replays aligned windows including zero-game weeks", () => {
-    const first = priceWeeklyParlay({ proposal, windows: windows(20) });
-    const second = priceWeeklyParlay({ proposal, windows: windows(20) });
+  test("prices only qualified windows and persists probability evidence", () => {
+    const windows = [...excludedWindows(4), ...qualifiedWindows(20)];
+    const first = priceWeeklyParlay({ proposal, windows });
+    const second = priceWeeklyParlay({ proposal, windows });
     expect(first).toEqual(second);
-    expect(first?.sampleSize).toBe(20);
-    expect(first?.periodKeys).toContain("window-00");
-    expect(first?.yesProbabilityBps).toBeGreaterThanOrEqual(4000);
-    expect(first?.yesProbabilityBps).toBeLessThanOrEqual(6000);
-    expect(first?.criteria.legs[0]?.threshold).toBeGreaterThan(0);
+    expect(first).toMatchObject({
+      totalWindows: 24,
+      qualifiedWindows: 20,
+      excludedWindows: 4,
+      recentQualifiedWindows: 8,
+    });
+    expect(first?.excludedPeriodKeys).toEqual([
+      "excluded-00",
+      "excluded-01",
+      "excluded-02",
+      "excluded-03",
+    ]);
+    expect(first?.yesProbabilityBps).toBeGreaterThanOrEqual(2000);
+    expect(first?.yesProbabilityBps).toBeLessThanOrEqual(3000);
+    expect(first?.recentYesWindows).toBeGreaterThan(0);
+    expect(first?.recentYesProbabilityBps).toBeLessThanOrEqual(5000);
+    expect(
+      first?.legEvidence.every(
+        (leg) => leg.probabilityBps >= 2000 && leg.probabilityBps <= 7000,
+      ),
+    ).toBe(true);
   });
 
-  test("rejects a market when history only offers zero participation", () => {
+  test("rejects history without fifteen qualified windows", () => {
     expect(
       priceWeeklyParlay({
         proposal,
-        windows: windows(20).map((window) => ({
-          ...window,
-          contributions: [],
-        })),
+        windows: [...excludedWindows(20), ...qualifiedWindows(14)],
       }),
     ).toBeUndefined();
   });
 
-  test("rejects an under-covered history sample", () => {
-    expect(
-      priceWeeklyParlay({ proposal, windows: windows(14) }),
-    ).toBeUndefined();
+  test("enforces the recent joint-hit guard", () => {
+    const windows = qualifiedWindows(20).map((window, index) => ({
+      ...window,
+      contributions: window.contributions.map((snapshot) => ({
+        ...snapshot,
+        kills: index < 6 ? 20 : 0,
+        assists: index < 6 ? 20 : 0,
+        win: index < 6,
+      })),
+    }));
+    expect(priceWeeklyParlay({ proposal, windows })).toBeUndefined();
+  });
+
+  test("selects deterministically across proposal order", () => {
+    const visionProposal: WeeklyParlayProposal = {
+      ...proposal,
+      legs: proposal.legs.map((leg, index) =>
+        index === 1 && leg.kind === "champion_peak"
+          ? { ...leg, metric: "vision_score" }
+          : leg,
+      ),
+    };
+    const windows = qualifiedWindows(20);
+    const forward = priceWeeklyParlayProposals({
+      proposals: [proposal, visionProposal],
+      windows,
+    });
+    const reverse = priceWeeklyParlayProposals({
+      proposals: [visionProposal, proposal],
+      windows,
+    });
+    expect(forward).toEqual(reverse);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-pricing.ts
@@ -1,11 +1,16 @@
 import {
+  WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS,
+  WEEKLY_PARLAY_MAX_RECENT_YES_PROBABILITY_BPS,
   WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS,
   WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
+  WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS,
   WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS,
+  WEEKLY_PARLAY_RECENT_QUALIFIED_WINDOWS,
+  WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES,
   WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
   type WeeklyParlayContributionSnapshot,
-  type WeeklyParlayDefinitionCriteria,
-  type WeeklyParlayLeg,
+  type WeeklyParlayCurrentDefinitionCriteria,
+  type WeeklyParlayCurrentLeg,
   type WeeklyParlayLegShape,
   type WeeklyParlayProposal,
 } from "#src/betting/weekly-parlay-criteria.ts";
@@ -22,11 +27,23 @@ export type WeeklyParlayReplayWindow = {
 };
 
 export type WeeklyParlayPricing = {
-  criteria: WeeklyParlayDefinitionCriteria;
+  proposal: WeeklyParlayProposal;
+  criteria: WeeklyParlayCurrentDefinitionCriteria;
   yesProbabilityBps: number;
   yesWindows: number;
-  sampleSize: number;
-  periodKeys: string[];
+  totalWindows: number;
+  qualifiedWindows: number;
+  excludedWindows: number;
+  qualifiedPeriodKeys: string[];
+  excludedPeriodKeys: string[];
+  recentQualifiedWindows: number;
+  recentYesWindows: number;
+  recentYesProbabilityBps: number;
+  legEvidence: {
+    leg: WeeklyParlayCurrentLeg;
+    yesWindows: number;
+    probabilityBps: number;
+  }[];
 };
 
 function stableThresholdCandidates(values: readonly number[]): number[] {
@@ -51,10 +68,29 @@ function stableThresholdCandidates(values: readonly number[]): number[] {
   ];
 }
 
+function comparisonPassed(
+  value: number,
+  operator: WeeklyParlayLegShape["operator"],
+  threshold: number,
+): boolean {
+  switch (operator) {
+    case "gte":
+      return value >= threshold;
+    case "lte":
+      return value <= threshold;
+    case "eq":
+      return value === threshold;
+  }
+}
+
+function probabilityBps(hits: number, sampleSize: number): number {
+  return Math.round((hits * 10_000) / sampleSize);
+}
+
 function legWithThreshold(
   shape: WeeklyParlayLegShape,
   threshold: number,
-): WeeklyParlayLeg {
+): WeeklyParlayCurrentLeg {
   return { ...shape, threshold };
 }
 
@@ -74,27 +110,55 @@ function thresholdTieKey(thresholds: readonly number[]): string {
     .join(":");
 }
 
+function qualifiedWindow(
+  proposal: WeeklyParlayProposal,
+  window: WeeklyParlayReplayWindow,
+): boolean {
+  const subjects = new Set(proposal.legs.map((leg) => leg.subject));
+  return [...subjects].every(
+    (subject) =>
+      window.contributions.filter(
+        (contribution) => contribution.subject === subject,
+      ).length >= WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES,
+  );
+}
+
 export function priceWeeklyParlay(input: {
   proposal: WeeklyParlayProposal;
   windows: readonly WeeklyParlayReplayWindow[];
 }): WeeklyParlayPricing | undefined {
-  if (input.windows.length < WEEKLY_PARLAY_MIN_HISTORY_WINDOWS) {
+  const qualified = input.windows.filter((window) =>
+    qualifiedWindow(input.proposal, window),
+  );
+  if (qualified.length < WEEKLY_PARLAY_MIN_HISTORY_WINDOWS) {
     return;
   }
-  const candidates = input.proposal.legs.map((leg) =>
-    stableThresholdCandidates(
-      input.windows.map((window) =>
-        weeklyParlayLegValue(leg, window.contributions),
-      ),
-    ).filter(
-      (threshold) =>
-        !(
-          leg.kind === "aggregate" &&
-          leg.metric === "games" &&
-          leg.operator === "gte"
-        ) || threshold > 0,
-    ),
+  const excluded = input.windows.filter(
+    (window) => !qualifiedWindow(input.proposal, window),
   );
+  const legValues = input.proposal.legs.map((leg) =>
+    qualified.map((window) => weeklyParlayLegValue(leg, window.contributions)),
+  );
+  const candidates = input.proposal.legs.map((leg, legIndex) => {
+    const values = legValues[legIndex];
+    if (values === undefined) {
+      throw new Error("Missing weekly parlay leg history values.");
+    }
+    return stableThresholdCandidates(values).filter((threshold) => {
+      const hits = values.filter((value) =>
+        comparisonPassed(value, leg.operator, threshold),
+      ).length;
+      const probability = probabilityBps(hits, qualified.length);
+      return (
+        probability >= WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS &&
+        probability <= WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS
+      );
+    });
+  });
+  if (candidates.some((legCandidates) => legCandidates.length === 0)) {
+    return;
+  }
+  const recent = qualified.slice(-WEEKLY_PARLAY_RECENT_QUALIFIED_WINDOWS);
   const priced = thresholdCombinations(candidates).flatMap((thresholds) => {
     const legs = input.proposal.legs.map((shape, index) => {
       const threshold = thresholds[index];
@@ -103,30 +167,65 @@ export function priceWeeklyParlay(input: {
       }
       return legWithThreshold(shape, threshold);
     });
-    const criteria: WeeklyParlayDefinitionCriteria = {
+    const criteria: WeeklyParlayCurrentDefinitionCriteria = {
       version: input.proposal.version,
+      qualification: {
+        minimumGamesPerSubject: WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES,
+      },
       legs,
     };
-    const yesWindows = input.windows.filter(
-      (window) =>
-        evaluateWeeklyParlay(criteria, window.contributions).yesResult,
-    ).length;
-    const yesProbabilityBps = Math.round(
-      (yesWindows * 10_000) / input.windows.length,
+    const evaluations = qualified.map((window) =>
+      evaluateWeeklyParlay(criteria, window.contributions),
     );
+    const yesWindows = evaluations.filter(
+      (evaluation) => evaluation.yesResult,
+    ).length;
+    const yesProbabilityBps = probabilityBps(yesWindows, qualified.length);
     if (
       yesProbabilityBps < WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS ||
       yesProbabilityBps > WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS
     ) {
       return [];
     }
+    const recentYesWindows = recent.filter(
+      (window) =>
+        evaluateWeeklyParlay(criteria, window.contributions).yesResult,
+    ).length;
+    const recentYesProbabilityBps = probabilityBps(
+      recentYesWindows,
+      recent.length,
+    );
+    if (
+      recentYesWindows === 0 ||
+      recentYesProbabilityBps > WEEKLY_PARLAY_MAX_RECENT_YES_PROBABILITY_BPS
+    ) {
+      return [];
+    }
+    const legEvidence = legs.map((leg, index) => {
+      const yesWindowsForLeg = evaluations.filter(
+        (evaluation) => evaluation.legs[index]?.passed === true,
+      ).length;
+      return {
+        leg,
+        yesWindows: yesWindowsForLeg,
+        probabilityBps: probabilityBps(yesWindowsForLeg, qualified.length),
+      };
+    });
     return [
       {
+        proposal: input.proposal,
         criteria,
         yesProbabilityBps,
         yesWindows,
-        sampleSize: input.windows.length,
-        periodKeys: input.windows.map((window) => window.periodKey),
+        totalWindows: input.windows.length,
+        qualifiedWindows: qualified.length,
+        excludedWindows: excluded.length,
+        qualifiedPeriodKeys: qualified.map((window) => window.periodKey),
+        excludedPeriodKeys: excluded.map((window) => window.periodKey),
+        recentQualifiedWindows: recent.length,
+        recentYesWindows,
+        recentYesProbabilityBps,
+        legEvidence,
         targetDistance: Math.abs(
           yesProbabilityBps - WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
         ),
@@ -142,11 +241,36 @@ export function priceWeeklyParlay(input: {
   if (selected === undefined) {
     return;
   }
-  return {
-    criteria: selected.criteria,
-    yesProbabilityBps: selected.yesProbabilityBps,
-    yesWindows: selected.yesWindows,
-    sampleSize: selected.sampleSize,
-    periodKeys: selected.periodKeys,
-  };
+  const {
+    targetDistance: _targetDistance,
+    tieKey: _tieKey,
+    ...result
+  } = selected;
+  return result;
+}
+
+export function priceWeeklyParlayProposals(input: {
+  proposals: readonly WeeklyParlayProposal[];
+  windows: readonly WeeklyParlayReplayWindow[];
+}): WeeklyParlayPricing | undefined {
+  return input.proposals
+    .flatMap((proposal) => {
+      const priced = priceWeeklyParlay({ proposal, windows: input.windows });
+      return priced === undefined ? [] : [priced];
+    })
+    .toSorted(
+      (left, right) =>
+        Math.abs(
+          left.yesProbabilityBps - WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
+        ) -
+          Math.abs(
+            right.yesProbabilityBps - WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
+          ) ||
+        JSON.stringify(left.proposal).localeCompare(
+          JSON.stringify(right.proposal),
+        ) ||
+        JSON.stringify(left.criteria).localeCompare(
+          JSON.stringify(right.criteria),
+        ),
+    )[0];
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -1,5 +1,5 @@
-import type { MessageEditOptions } from "discord.js";
 import { BucksMessageRefsSchema } from "@scout-for-lol/data";
+import type { MessageEditOptions } from "discord.js";
 import {
   WeeklyParlayDefinitionCriteriaSchema,
   WeeklyParlaySubjectsSchema,
@@ -9,17 +9,39 @@ import {
   deliveryTimeCopy,
   deliveryTitle,
   legLine,
-  weeklyParlayButtons,
-} from "#src/betting/weekly-parlay-discord.ts";
+  weeklyParlayQualificationCopy,
+} from "#src/betting/weekly-parlay-discord-copy.ts";
+import { weeklyParlayButtons } from "#src/betting/weekly-parlay-discord.ts";
+import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
-import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 
-/** Edit the original open-market message after a bet or cancellation. */
-export async function refreshWeeklyParlayMessage(
+export type WeeklyParlayMessageEditor = (
+  channelId: string,
+  messageId: string,
+  options: MessageEditOptions,
+) => Promise<void>;
+
+async function editDiscordMessage(
+  channelId: string,
+  messageId: string,
+  options: MessageEditOptions,
+): Promise<void> {
+  const channel = await client.channels.fetch(channelId);
+  if (channel?.isTextBased() !== true) {
+    throw new Error(
+      `Weekly parlay channel ${channelId} is unavailable or not text based`,
+    );
+  }
+  await channel.messages.edit(messageId, options);
+}
+
+async function editWeeklyParlayMessage(
   marketId: number,
-  prismaClient: ExtendedPrismaClient = prisma,
+  mode: "open" | "operator_cancelled",
+  prismaClient: ExtendedPrismaClient,
+  editor: WeeklyParlayMessageEditor,
 ): Promise<void> {
   await runSerialized(`weekly:${marketId.toString()}`, async () => {
     const market = await prismaClient.bucksWeeklyParlayMarket.findUnique({
@@ -27,6 +49,7 @@ export async function refreshWeeklyParlayMessage(
       select: {
         messageRefs: true,
         marketState: true,
+        voidReason: true,
         periodKey: true,
         bettingClosesAt: true,
         scoringEndsAt: true,
@@ -42,14 +65,36 @@ export async function refreshWeeklyParlayMessage(
           },
         },
         bets: {
-          where: { betOutcome: "pending" },
-          select: { stake: true },
+          select: { stake: true, betOutcome: true },
+          orderBy: { id: "asc" },
+        },
+        deliveries: {
+          where: { kind: "open", deliveryState: "delivered" },
+          select: { messageRefs: true },
+          orderBy: { id: "asc" },
+          take: 1,
         },
       },
     });
-    if (market?.marketState !== "open") return;
-    const refs = BucksMessageRefsSchema.parse(JSON.parse(market.messageRefs));
-    if (refs.length === 0) return;
+    if (market === null) {
+      return;
+    }
+    if (
+      (mode === "open" && market.marketState !== "open") ||
+      (mode === "operator_cancelled" &&
+        (market.marketState !== "voided" ||
+          market.voidReason !== "operator_cancelled"))
+    ) {
+      return;
+    }
+    const refsJson =
+      mode === "open"
+        ? market.messageRefs
+        : (market.deliveries[0]?.messageRefs ?? "[]");
+    const refs = BucksMessageRefsSchema.parse(JSON.parse(refsJson));
+    if (refs.length === 0) {
+      return;
+    }
     const subjects = WeeklyParlaySubjectsSchema.parse(
       JSON.parse(market.definition.subjects),
     );
@@ -66,34 +111,88 @@ export async function refreshWeeklyParlayMessage(
       scoringStartsAt: market.definition.scoringStartsAt,
       scoringEndsAt: market.definition.scoringEndsAt,
     });
-    const content = [
-      deliveryTitle("open", market.marketState, null, catchup),
-      `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
-      ...criteria.legs.map((leg) =>
-        legLine(leg, undefined, aliases.get(leg.subject) ?? leg.subject),
-      ),
-      `**${market.bets.length.toString()} ${countLabel(market.bets.length, "bettor")} · ${market.bets.reduce((total, bet) => total + bet.stake, 0).toString()} BB staked**`,
-      deliveryTimeCopy({
-        kind: "open",
-        bettingClosesAt: market.bettingClosesAt,
-        scoringEndsAt: market.scoringEndsAt,
-        scoringStartsAt: market.definition.scoringStartsAt,
-        catchup,
-      }),
-    ].join("\n");
-    for (const [index, ref] of refs.entries()) {
-      const channel = await client.channels.fetch(ref.channelId);
-      if (channel?.isTextBased() !== true) {
-        throw new Error(
-          `Weekly parlay channel ${ref.channelId} is unavailable or not text based`,
-        );
-      }
-      const options: MessageEditOptions = {
+    const legs = criteria.legs.map((leg) =>
+      legLine(leg, undefined, aliases.get(leg.subject) ?? leg.subject),
+    );
+    const qualification = weeklyParlayQualificationCopy(criteria) ?? "";
+    const relevantBets = market.bets.filter((bet) =>
+      mode === "open"
+        ? bet.betOutcome === "pending"
+        : bet.betOutcome === "refunded",
+    );
+    const totalStaked = relevantBets.reduce(
+      (total, bet) => total + bet.stake,
+      0,
+    );
+    const content =
+      mode === "open"
+        ? [
+            deliveryTitle({
+              kind: "open",
+              marketState: market.marketState,
+              yesResult: null,
+              catchup,
+            }),
+            `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
+            ...legs,
+            qualification,
+            `**${relevantBets.length.toString()} ${countLabel(relevantBets.length, "bettor")} · ${totalStaked.toString()} BB staked**`,
+            deliveryTimeCopy({
+              kind: "open",
+              bettingClosesAt: market.bettingClosesAt,
+              scoringEndsAt: market.scoringEndsAt,
+              scoringStartsAt: market.definition.scoringStartsAt,
+              catchup,
+            }),
+          ]
+            .filter((line) => line.length > 0)
+            .join("\n")
+        : [
+            deliveryTitle({
+              kind: "settlement",
+              marketState: market.marketState,
+              yesResult: null,
+              catchup,
+              voidReason: market.voidReason,
+            }),
+            `Period: **${market.periodKey}**`,
+            ...legs,
+            qualification,
+            `**${relevantBets.length.toString()} ${countLabel(relevantBets.length, "bettor")} refunded · ${totalStaked.toString()} BB returned**`,
+            "This market was cancelled by an operator.",
+          ]
+            .filter((line) => line.length > 0)
+            .join("\n");
+    for (const ref of refs) {
+      await editor(ref.channelId, ref.messageId, {
         content,
         allowedMentions: { parse: [] },
-        components: index === 0 ? weeklyParlayButtons("open", marketId) : [],
-      };
-      await channel.messages.edit(ref.messageId, options);
+        components:
+          mode === "open" ? weeklyParlayButtons("open", marketId) : [],
+      });
     }
   });
+}
+
+/** Edit the original open-market message after a bet or wager cancellation. */
+export async function refreshWeeklyParlayMessage(
+  marketId: number,
+  prismaClient: ExtendedPrismaClient = prisma,
+  editor: WeeklyParlayMessageEditor = editDiscordMessage,
+): Promise<void> {
+  await editWeeklyParlayMessage(marketId, "open", prismaClient, editor);
+}
+
+/** Mark the original publication as operator-cancelled and remove all controls. */
+export async function cancelWeeklyParlayMessage(
+  marketId: number,
+  prismaClient: ExtendedPrismaClient = prisma,
+  editor: WeeklyParlayMessageEditor = editDiscordMessage,
+): Promise<void> {
+  await editWeeklyParlayMessage(
+    marketId,
+    "operator_cancelled",
+    prismaClient,
+    editor,
+  );
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -35,7 +35,14 @@ import {
   weeklyParlayPeriod,
 } from "#src/betting/weekly-parlay-period.ts";
 import { settleWeeklyParlayMarket } from "#src/betting/weekly-parlay-settle.ts";
-import { WeeklyParlaySubjectSchema } from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  WeeklyParlayContributionSnapshotSchema,
+  WeeklyParlaySubjectSchema,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import {
+  cancelWeeklyParlayMessage,
+  type WeeklyParlayMessageEditor,
+} from "#src/betting/weekly-parlay-refresh.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
@@ -65,16 +72,16 @@ function participant() {
 const PARTICIPANT = participant();
 const PARTICIPANT_PUUID = LeaguePuuidSchema.parse(PARTICIPANT.puuid);
 const COMPLETED_AT = new Date(fixture.info.gameEndTimestamp);
-
 function subject(
   playerId: number,
   puuids: readonly string[] = [PARTICIPANT_PUUID],
+  discordId = BETTOR,
 ) {
   return WeeklyParlaySubjectSchema.parse({
     key: "P1",
     playerId,
     alias: "jerred",
-    discordId: BETTOR,
+    discordId,
     accounts: puuids.map((puuid) => ({
       puuid: LeaguePuuidSchema.parse(puuid),
       trackingStartedAt: new Date(
@@ -113,6 +120,39 @@ function hitCriteria() {
   };
 }
 
+function challengingCriteria() {
+  return {
+    version: 2,
+    qualification: { minimumGamesPerSubject: 3 },
+    legs: [
+      {
+        kind: "champion_peak",
+        subject: "P1",
+        champion: PARTICIPANT.championName,
+        metric: "kills",
+        operator: "gte",
+        threshold: PARTICIPANT.kills,
+      },
+      {
+        kind: "champion_peak",
+        subject: "P1",
+        champion: PARTICIPANT.championName,
+        metric: "assists",
+        operator: "gte",
+        threshold: PARTICIPANT.assists,
+      },
+      {
+        kind: "champion_games",
+        subject: "P1",
+        champion: PARTICIPANT.championName,
+        winsOnly: true,
+        operator: "gte",
+        threshold: 1,
+      },
+    ],
+  };
+}
+
 async function clearAll(): Promise<void> {
   await db.bucksLedgerEntry.deleteMany();
   await db.bucksWeeklyParlayDelivery.deleteMany();
@@ -128,9 +168,12 @@ async function clearAll(): Promise<void> {
 }
 
 async function makeMarket(input?: {
-  criteria?: ReturnType<typeof hitCriteria>;
+  criteria?: unknown;
+  evaluatorVersion?: string;
+  schemaVersion?: number;
   marketState?: "publishing" | "open" | "active";
   slot?: number;
+  subjectDiscordId?: typeof BETTOR;
   timeline?: {
     openAt: Date;
     bettingClosesAt: Date;
@@ -157,7 +200,9 @@ async function makeMarket(input?: {
       bettingClosesAt,
       scoringStartsAt,
       scoringEndsAt,
-      subjects: JSON.stringify([subject(player.id)]),
+      subjects: JSON.stringify([
+        subject(player.id, [PARTICIPANT_PUUID], input?.subjectDiscordId),
+      ]),
       eligibleQueues: JSON.stringify(["solo", "flex", "ranked 5s"]),
       proposal: JSON.stringify({ version: 1, legs: [] }),
       criteria: JSON.stringify(input?.criteria ?? hitCriteria()),
@@ -166,8 +211,8 @@ async function makeMarket(input?: {
       yesProbabilityBps: 5000,
       promptVersion: "test",
       catalogVersion: "test",
-      schemaVersion: 1,
-      evaluatorVersion: "1",
+      schemaVersion: input?.schemaVersion ?? 1,
+      evaluatorVersion: input?.evaluatorVersion ?? "1",
       pricingVersion: "1",
       generationContext: "{}",
       requestedModel: "test",
@@ -201,6 +246,88 @@ function place(marketId: number, side: "YES" | "NO", stake: number) {
       now: new Date(COMPLETED_AT.getTime() - 150 * 60_000),
     },
     db,
+  );
+}
+
+function challengingSnapshot(index: number) {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: "P1",
+    puuid: PARTICIPANT_PUUID,
+    queue: "solo",
+    completedAt: new Date(
+      COMPLETED_AT.getTime() + index * 60_000,
+    ).toISOString(),
+    win: true,
+    champion: PARTICIPANT.championName,
+    role: "MIDDLE",
+    kills: PARTICIPANT.kills,
+    deaths: PARTICIPANT.deaths,
+    assists: PARTICIPANT.assists,
+    championDamage: PARTICIPANT.totalDamageDealtToChampions,
+    creepScore: PARTICIPANT.totalMinionsKilled,
+    gold: PARTICIPANT.goldEarned,
+    visionScore: PARTICIPANT.visionScore,
+    timePlayed: fixture.info.gameDuration,
+  });
+}
+
+async function appendChallengingSnapshots(
+  definitionId: number,
+  count: number,
+): Promise<void> {
+  const existing = await db.bucksWeeklyParlayContribution.count({
+    where: { definitionId },
+  });
+  for (const index of Array.from(
+    { length: count },
+    (_value, item) => existing + item,
+  )) {
+    const snapshot = challengingSnapshot(index);
+    await db.bucksWeeklyParlayContribution.create({
+      data: {
+        definitionId,
+        matchId: `weekly-v2-${index.toString()}`,
+        subjectKey: snapshot.subject,
+        completedAt: new Date(snapshot.completedAt),
+        ingestedAt: COMPLETED_AT,
+        queueType: snapshot.queue,
+        snapshot: JSON.stringify(snapshot),
+      },
+    });
+  }
+}
+
+async function makeActiveChallengingMarket() {
+  const market = await makeMarket({
+    criteria: challengingCriteria(),
+    evaluatorVersion: "2",
+    schemaVersion: 2,
+    marketState: "open",
+  });
+  await place(market.id, "YES", 10);
+  await db.bucksWeeklyParlayMarket.update({
+    where: { id: market.id },
+    data: { marketState: "active" },
+  });
+  return market;
+}
+
+function runCatchupOpen(openAt: Date, now = openAt) {
+  const period = weeklyParlayPeriod(PERIOD_KEY);
+  return runWeeklyParlayControlAction(
+    {
+      periodKey: PERIOD_KEY,
+      action: "open",
+      slot: 0,
+      window: {
+        kind: "catch_up",
+        openAt: openAt.toISOString(),
+        bettingClosesAt: "2026-08-25T07:00:00.000Z",
+        scoringStartsAt: "2026-08-25T07:00:00.000Z",
+        scoringEndsAt: period.scoringEndsAt.toISOString(),
+      },
+    },
+    { serverId: SERVER_ID, now, prismaClient: db },
   );
 }
 
@@ -410,6 +537,151 @@ describe("weekly parlay ledger and settlement", () => {
   });
 });
 
+describe("weekly parlay operator cancellation", () => {
+  test("operator cancellation refunds every bettor exactly once with balanced ledger entries", async () => {
+    const featuredDiscordId = bucksTestDiscordId(703);
+    const market = await makeMarket({
+      marketState: "open",
+      subjectDiscordId: featuredDiscordId,
+    });
+    const otherBettors = [bucksTestDiscordId(701), bucksTestDiscordId(702)];
+    await db.player.createMany({
+      data: otherBettors.map((discordId, index) => ({
+        alias: `bettor-${index.toString()}`,
+        discordId,
+        serverId: SERVER_ID,
+        creatorDiscordId: BETTOR,
+        createdTime: COMPLETED_AT,
+        updatedTime: COMPLETED_AT,
+      })),
+    });
+    await db.bucksAccount.createMany({
+      data: otherBettors.map((discordId) => ({
+        serverId: SERVER_ID,
+        discordId,
+        balance: 100,
+      })),
+    });
+    for (const [index, discordId] of [BETTOR, ...otherBettors].entries()) {
+      await placeWeeklyParlayBet(
+        {
+          marketId: market.id,
+          serverId: SERVER_ID,
+          discordId,
+          side: index % 2 === 0 ? "YES" : "NO",
+          stake: 1,
+          now: new Date(COMPLETED_AT.getTime() - 150 * 60_000),
+        },
+        db,
+      );
+    }
+    const originalRefs = [
+      { channelId: "160509172704739999", messageId: "original-open" },
+    ];
+    await db.bucksWeeklyParlayMarket.update({
+      where: { id: market.id },
+      data: { messageRefs: JSON.stringify(originalRefs) },
+    });
+    await db.bucksWeeklyParlayDelivery.create({
+      data: {
+        marketId: market.id,
+        actionKey: "open",
+        kind: "open",
+        scheduledAt: market.definition.openAt,
+        attemptedAt: market.definition.openAt,
+        deliveredAt: market.definition.openAt,
+        deliveryState: "delivered",
+        messageRefs: JSON.stringify(originalRefs),
+      },
+    });
+    clearFlagOverrides("betting_enabled");
+    clearFlagOverrides("weekly_parlays_enabled");
+    addFlagOverride("betting_enabled", false, { server: SERVER_ID });
+    addFlagOverride("weekly_parlays_enabled", false, { server: SERVER_ID });
+    const sent: Parameters<WeeklyParlayDiscordSender>[0][] = [];
+    const sender: WeeklyParlayDiscordSender = async (options) => {
+      sent.push(options);
+      return { channelId: "160509172704739999", id: "refund-notice" };
+    };
+    const edits: Parameters<WeeklyParlayMessageEditor>[] = [];
+    const editor: WeeklyParlayMessageEditor = async (...parameters) => {
+      edits.push(parameters);
+    };
+    const options = {
+      serverId: SERVER_ID,
+      now: COMPLETED_AT,
+      prismaClient: db,
+      deliverDiscord: async (
+        input: Parameters<typeof deliverWeeklyParlayDiscord>[0],
+        prismaClient: Parameters<typeof deliverWeeklyParlayDiscord>[1],
+      ) => await deliverWeeklyParlayDiscord(input, prismaClient, sender),
+      cancelMessage: async (
+        marketId: number,
+        prismaClient: Parameters<typeof cancelWeeklyParlayMessage>[1],
+      ) => await cancelWeeklyParlayMessage(marketId, prismaClient, editor),
+    };
+    await expect(
+      runWeeklyParlayControlAction(
+        { periodKey: PERIOD_KEY, slot: 0, action: "cancel" },
+        options,
+      ),
+    ).resolves.toMatchObject({ status: "reconciled", detail: "cancelled" });
+    await expect(
+      runWeeklyParlayControlAction(
+        { periodKey: PERIOD_KEY, slot: 0, action: "cancel" },
+        options,
+      ),
+    ).resolves.toMatchObject({
+      status: "reconciled",
+      detail: "already_cancelled",
+    });
+    const [cancelled, bets, accounts] = await Promise.all([
+      db.bucksWeeklyParlayMarket.findUniqueOrThrow({
+        where: { id: market.id },
+      }),
+      db.bucksWeeklyParlayBet.findMany({
+        where: { marketId: market.id },
+        orderBy: { id: "asc" },
+      }),
+      db.bucksAccount.findMany({
+        where: {
+          serverId: SERVER_ID,
+          discordId: { in: [BETTOR, ...otherBettors] },
+        },
+      }),
+    ]);
+    const ledger = await db.bucksLedgerEntry.findMany({
+      where: { weeklyParlayBetId: { in: bets.map((bet) => bet.id) } },
+    });
+    expect(cancelled).toMatchObject({
+      marketState: "voided",
+      voidReason: "operator_cancelled",
+    });
+    expect(bets.every((bet) => bet.betOutcome === "refunded")).toBe(true);
+    expect(accounts.every((account) => account.balance === 100)).toBe(true);
+    expect(
+      ledger.filter((entry) => entry.kind === "weekly_parlay_refund"),
+    ).toHaveLength(3);
+    expect(
+      ledger.filter((entry) => entry.kind === "weekly_parlay_release"),
+    ).toHaveLength(3);
+    expect(ledger.reduce((total, entry) => total + entry.delta, 0)).toBe(0);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.content).toContain(`<@${featuredDiscordId}>`);
+    expect(sent[0]?.allowedMentions).toEqual({
+      users: [featuredDiscordId, BETTOR, ...otherBettors],
+    });
+    expect(sent[0]?.content).toContain("cancelled and refunded");
+    expect(sent[0]?.content).toContain("every pending wager was refunded");
+    expect(sent[0]?.components).toEqual([]);
+    expect(edits).toHaveLength(2);
+    expect(edits[0]?.[0]).toBe(originalRefs[0]?.channelId);
+    expect(edits[0]?.[1]).toBe(originalRefs[0]?.messageId);
+    expect(edits[0]?.[2].content).toContain("cancelled and refunded");
+    expect(edits[0]?.[2].components).toEqual([]);
+  });
+});
+
 describe("weekly parlay settlement", () => {
   test("never settles NO early and finalizes NO after ingestion reconciliation", async () => {
     const market = await makeMarket();
@@ -523,7 +795,67 @@ describe("weekly parlay settlement", () => {
       ),
     ).resolves.toMatchObject({ yesResult: true });
   });
+});
 
+describe("weekly parlay version-two settlement", () => {
+  test("requires three eligible games before version-two early YES", async () => {
+    const market = await makeActiveChallengingMarket();
+    await appendChallengingSnapshots(market.definitionId, 2);
+    await expect(
+      settleWeeklyParlayMarket(
+        { marketId: market.id, mode: "early_yes", now: COMPLETED_AT },
+        db,
+      ),
+    ).resolves.toBeUndefined();
+    await appendChallengingSnapshots(market.definitionId, 1);
+    await expect(
+      settleWeeklyParlayMarket(
+        { marketId: market.id, mode: "early_yes", now: COMPLETED_AT },
+        db,
+      ),
+    ).resolves.toMatchObject({ yesResult: true });
+  });
+
+  test("voids and refunds version-two markets with insufficient activity", async () => {
+    const market = await makeActiveChallengingMarket();
+    await appendChallengingSnapshots(market.definitionId, 2);
+    await expect(
+      settleWeeklyParlayMarket(
+        {
+          marketId: market.id,
+          mode: "final",
+          now: weeklyParlayFinalSettlementAt(market.scoringEndsAt),
+        },
+        db,
+      ),
+    ).resolves.toMatchObject({ voidReason: "insufficient_activity" });
+    await expect(
+      db.bucksWeeklyParlayBet.findFirstOrThrow({
+        where: { marketId: market.id },
+      }),
+    ).resolves.toMatchObject({ betOutcome: "refunded", payout: 10 });
+    const sent: Parameters<WeeklyParlayDiscordSender>[0][] = [];
+    await deliverWeeklyParlayDiscord(
+      {
+        marketId: market.id,
+        actionKey: weeklyParlaySettlementActionKey(market.id),
+        kind: "settlement",
+        scheduledAt: market.scoringEndsAt,
+      },
+      db,
+      async (options) => {
+        sent.push(options);
+        return { channelId: "160509172704739999", id: "insufficient" };
+      },
+    );
+    expect(sent[0]?.content).toContain(
+      "Fewer than three eligible games were played",
+    );
+    expect(sent[0]?.components).toEqual([]);
+  });
+});
+
+describe("weekly parlay settlement failures", () => {
   test("voids and refunds every reserved position on evaluator failure", async () => {
     const market = await makeMarket();
     await place(market.id, "YES", 10);
@@ -650,80 +982,23 @@ describe("weekly parlay contributions and control actions", () => {
 describe("weekly parlay catch-up controls", () => {
   test("rejects an open retry whose catch-up clocks conflict with the stored definition", async () => {
     await makeMarket({ marketState: "open" });
-    const period = weeklyParlayPeriod(PERIOD_KEY);
     const openAt = new Date("2026-08-24T19:00:00.000Z");
-    await expect(
-      runWeeklyParlayControlAction(
-        {
-          periodKey: PERIOD_KEY,
-          action: "open",
-          slot: 0,
-          window: {
-            kind: "catch_up",
-            openAt: openAt.toISOString(),
-            bettingClosesAt: "2026-08-25T07:00:00.000Z",
-            scoringStartsAt: "2026-08-25T07:00:00.000Z",
-            scoringEndsAt: period.scoringEndsAt.toISOString(),
-          },
-        },
-        {
-          serverId: SERVER_ID,
-          now: openAt,
-          prismaClient: db,
-        },
-      ),
-    ).rejects.toThrow("conflicting timeline");
+    await expect(runCatchupOpen(openAt)).rejects.toThrow(
+      "conflicting timeline",
+    );
   });
 
   test("rejects catch-up clocks that do not preserve the minimum betting window", async () => {
-    const period = weeklyParlayPeriod(PERIOD_KEY);
     const openAt = new Date("2026-08-25T02:30:00.000Z");
-    await expect(
-      runWeeklyParlayControlAction(
-        {
-          periodKey: PERIOD_KEY,
-          action: "open",
-          slot: 0,
-          window: {
-            kind: "catch_up",
-            openAt: openAt.toISOString(),
-            bettingClosesAt: "2026-08-25T07:00:00.000Z",
-            scoringStartsAt: "2026-08-25T07:00:00.000Z",
-            scoringEndsAt: period.scoringEndsAt.toISOString(),
-          },
-        },
-        {
-          serverId: SERVER_ID,
-          now: openAt,
-          prismaClient: db,
-        },
-      ),
-    ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
+    await expect(runCatchupOpen(openAt)).rejects.toThrow(
+      "Invalid weekly parlay catch-up timeline",
+    );
   });
 
   test("rechecks the minimum betting window from the retry time", async () => {
-    const period = weeklyParlayPeriod(PERIOD_KEY);
     const openAt = new Date("2026-08-24T19:00:00.000Z");
     await expect(
-      runWeeklyParlayControlAction(
-        {
-          periodKey: PERIOD_KEY,
-          action: "open",
-          slot: 0,
-          window: {
-            kind: "catch_up",
-            openAt: openAt.toISOString(),
-            bettingClosesAt: "2026-08-25T07:00:00.000Z",
-            scoringStartsAt: "2026-08-25T07:00:00.000Z",
-            scoringEndsAt: period.scoringEndsAt.toISOString(),
-          },
-        },
-        {
-          serverId: SERVER_ID,
-          now: new Date("2026-08-25T02:00:00.000Z"),
-          prismaClient: db,
-        },
-      ),
+      runCatchupOpen(openAt, new Date("2026-08-25T02:00:00.000Z")),
     ).rejects.toThrow("Invalid weekly parlay catch-up timeline");
   });
 
@@ -994,6 +1269,55 @@ describe("weekly parlay ingestion boundaries", () => {
 describe("weekly parlay Discord delivery", () => {
   test("uses one settlement delivery key across settlement origins", () => {
     expect(weeklyParlaySettlementActionKey(42)).toBe("settlement:42");
+  });
+
+  test("renders champion criteria and activity qualification for open and progress", async () => {
+    const market = await makeMarket({
+      criteria: challengingCriteria(),
+      evaluatorVersion: "2",
+      schemaVersion: 2,
+      marketState: "publishing",
+    });
+    const sent: Parameters<WeeklyParlayDiscordSender>[0][] = [];
+    const sender: WeeklyParlayDiscordSender = async (options) => {
+      sent.push(options);
+      return {
+        channelId: "160509172704739999",
+        id: `challenging-${sent.length.toString()}`,
+      };
+    };
+    await deliverWeeklyParlayDiscord(
+      {
+        marketId: market.id,
+        actionKey: "open",
+        kind: "open",
+        scheduledAt: market.definition.openAt,
+      },
+      db,
+      sender,
+    );
+    await appendChallengingSnapshots(market.definitionId, 1);
+    await db.bucksWeeklyParlayMarket.update({
+      where: { id: market.id },
+      data: { marketState: "active" },
+    });
+    await deliverWeeklyParlayDiscord(
+      {
+        marketId: market.id,
+        actionKey: "progress:0",
+        kind: "progress",
+        scheduledAt: COMPLETED_AT,
+      },
+      db,
+      sender,
+    );
+    expect(sent[0]?.content).toContain(
+      `kills in one game as ${PARTICIPANT.championName}`,
+    );
+    expect(sent[0]?.content).toContain("3 eligible games required per player");
+    expect(sent[0]?.components).not.toEqual([]);
+    expect(sent[1]?.content).toContain("Qualification: **jerred 1/3 games**");
+    expect(sent[1]?.components).toEqual([]);
   });
 
   test("labels catch-up messages and renders their frozen betting and scoring clocks", async () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-settle.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-settle.ts
@@ -13,6 +13,7 @@ import {
 } from "#src/betting/ledger.ts";
 import {
   WEEKLY_PARLAY_EVALUATOR_VERSION,
+  WEEKLY_PARLAY_LEGACY_EVALUATOR_VERSION,
   WeeklyParlayContributionSnapshotSchema,
   WeeklyParlayDefinitionCriteriaSchema,
 } from "#src/betting/weekly-parlay-criteria.ts";
@@ -67,7 +68,10 @@ function decisionFor(input: {
       reason: BucksWeeklyParlayVoidReasonSchema.parse(input.voidReason),
     };
   }
-  if (input.evaluatorVersion !== WEEKLY_PARLAY_EVALUATOR_VERSION) {
+  if (
+    input.evaluatorVersion !== WEEKLY_PARLAY_LEGACY_EVALUATOR_VERSION &&
+    input.evaluatorVersion !== WEEKLY_PARLAY_EVALUATOR_VERSION
+  ) {
     return { kind: "void", reason: "unknown_evaluator" };
   }
   const parsedCriteria = parseJson(input.criteria);
@@ -78,6 +82,14 @@ function decisionFor(input: {
     parsedCriteria.value,
   );
   if (!criteria.success) {
+    return { kind: "void", reason: "invalid_definition" };
+  }
+  if (
+    (input.evaluatorVersion === WEEKLY_PARLAY_LEGACY_EVALUATOR_VERSION &&
+      criteria.data.version !== 1) ||
+    (input.evaluatorVersion === WEEKLY_PARLAY_EVALUATOR_VERSION &&
+      criteria.data.version !== 2)
+  ) {
     return { kind: "void", reason: "invalid_definition" };
   }
   const parsedSnapshots = input.snapshots.map((snapshot) =>
@@ -104,6 +116,9 @@ function decisionFor(input: {
   }
   if (input.mode === "early_yes" && !evaluation.irreversiblyYes) {
     return;
+  }
+  if (input.mode === "final" && !evaluation.qualification.passed) {
+    return { kind: "void", reason: "insufficient_activity" };
   }
   return {
     kind: "result",

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-prizes.test.ts
@@ -250,6 +250,9 @@ describe("/bb command contract", () => {
       "Cancelling before close costs **20%** of the offer, rounded to the nearest BB",
     );
     expect(rendered).toContain("Cancelling a parlay is free");
+    expect(rendered).toContain("Activity is not a leg");
+    expect(rendered).toContain("one-game peak on a named champion");
+    expect(rendered).toContain("full parlay at **20-30%**");
   });
 
   // Gaps that existed while these facts lived only on market messages, or not

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -17,7 +17,12 @@ import {
 import {
   WEEKLY_PARLAY_ELIGIBLE_QUEUES,
   WEEKLY_PARLAY_MAX_LEGS,
+  WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS,
+  WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS,
   WEEKLY_PARLAY_MIN_LEGS,
+  WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS,
+  WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS,
+  WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import {
   WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
@@ -103,6 +108,8 @@ export function buildBbRulesEmbed(): EmbedBuilder {
           `A ${WEEKLY_PARLAY_MIN_LEGS.toString()}-${WEEKLY_PARLAY_MAX_LEGS.toString()} leg YES/NO market across one or more tracked players. ` +
           `It opens Sunday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_OPEN_HOUR)} and betting closes Monday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_BETTING_CLOSE_HOUR)} in ${WEEKLY_PARLAY_TIMEZONE}. ` +
           `Only completed ${WEEKLY_PARLAY_ELIGIBLE_QUEUES.join(", ")} games count, through Sunday at ${weeklyParlayWallClockLabel(WEEKLY_PARLAY_FINAL_HOUR)}. ` +
+          `Activity is not a leg: every featured player must complete **${WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES.toString()} eligible games**, or everyone is refunded. ` +
+          `Every proposal includes a one-game peak on a named champion. Each leg must replay at **${(WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS / 100).toString()}-${(WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS / 100).toString()}%**, and the full parlay at **${(WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS / 100).toString()}-${(WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS / 100).toString()}%**, in qualified history. ` +
           `Scout waits **${WEEKLY_PARLAY_INGESTION_GRACE_MINUTES.toString()} minutes** after that cutoff for completed games to ingest. ` +
           `If Sunday opening is missed, an exceptional catch-up market may open midweek with at least **${WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS.toString()} hours** to bet before the next eligible Pacific midnight. ` +
           "Its message shows the exact betting and scoring timestamps, and games completed before betting closes never count. " +

--- a/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/weekly-parlay-control.ts
@@ -1,9 +1,9 @@
 import { timingSafeEqual } from "node:crypto";
+import { WeeklyParlayControlActionSchema } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import configuration from "#src/configuration.ts";
 import {
   runWeeklyParlayControlAction,
   WEEKLY_PARLAY_CONTROL_PATH,
-  WeeklyParlayControlActionSchema,
 } from "#src/betting/weekly-parlay-control.ts";
 import { MY_SERVER } from "#src/configuration/flags.ts";
 

--- a/packages/scout-for-lol/packages/backend/src/testing/weekly-parlay-control.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/weekly-parlay-control.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { WeeklyParlayControlActionSchema } from "#src/betting/weekly-parlay-control.ts";
+import { WeeklyParlayControlActionSchema } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 import { handleWeeklyParlayControl } from "#src/http/weekly-parlay-control.ts";
 
@@ -39,6 +39,13 @@ describe("weekly parlay control action schema", () => {
         updateIndex: 5,
       }),
     ).toMatchObject({ slot: 0, updateIndex: 5 });
+    expect(
+      WeeklyParlayControlActionSchema.parse({
+        periodKey: "2026-08-24",
+        slot: 2,
+        action: "cancel",
+      }),
+    ).toMatchObject({ action: "cancel", slot: 2 });
   });
 
   test("accepts catch-up clocks only on open actions", () => {

--- a/packages/scout-for-lol/packages/data/dist/model/weekly-parlay.js
+++ b/packages/scout-for-lol/packages/data/dist/model/weekly-parlay.js
@@ -12,7 +12,15 @@ var weekly_parlay_default = {
   finalHour: 11,
   updateHour: 19,
   updateCount: 6,
-  actions: ["open", "reminder", "start", "progress", "finalize"]
+  actions: [
+    "open",
+    "reminder",
+    "start",
+    "progress",
+    "finalize",
+    "cancel",
+    "analytics_sync"
+  ]
 };
 
 // src/model/weekly-parlay.ts
@@ -31,14 +39,54 @@ var WeeklyParlayLifecycleSchema = z.strictObject({
     z.literal("reminder"),
     z.literal("start"),
     z.literal("progress"),
-    z.literal("finalize")
+    z.literal("finalize"),
+    z.literal("cancel"),
+    z.literal("analytics_sync")
   ])
 });
 var WEEKLY_PARLAY_LIFECYCLE = WeeklyParlayLifecycleSchema.parse(weekly_parlay_default);
 var WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS = WEEKLY_PARLAY_LIFECYCLE.openActionBudgetMinutes * 60 * 1000;
 var WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS = WEEKLY_PARLAY_LIFECYCLE.catchupMinimumBettingHours * 60 * 60 * 1000;
+var WeeklyParlayCatchupWindowSchema = z.strictObject({
+  kind: z.literal("catch_up"),
+  openAt: z.iso.datetime(),
+  bettingClosesAt: z.iso.datetime(),
+  scoringStartsAt: z.iso.datetime(),
+  scoringEndsAt: z.iso.datetime()
+});
+var WeeklyParlayControlActionSchema = z.strictObject({
+  periodKey: z.iso.date(),
+  slot: z.number().int().nonnegative().default(WEEKLY_PARLAY_LIFECYCLE.slot),
+  action: z.enum(WEEKLY_PARLAY_LIFECYCLE.actions),
+  updateIndex: z.number().int().min(0).max(WEEKLY_PARLAY_LIFECYCLE.updateCount - 1).optional(),
+  window: WeeklyParlayCatchupWindowSchema.optional()
+}).superRefine((action, context) => {
+  if (action.action === "progress" && action.updateIndex === undefined) {
+    context.addIssue({
+      code: "custom",
+      path: ["updateIndex"],
+      message: "Progress actions require an update index."
+    });
+  }
+  if (action.action !== "progress" && action.updateIndex !== undefined) {
+    context.addIssue({
+      code: "custom",
+      path: ["updateIndex"],
+      message: "Only progress actions accept an update index."
+    });
+  }
+  if (action.action !== "open" && action.window !== undefined) {
+    context.addIssue({
+      code: "custom",
+      path: ["window"],
+      message: "Only open actions accept a catch-up window."
+    });
+  }
+});
 export {
   WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS,
   WEEKLY_PARLAY_LIFECYCLE,
-  WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS
+  WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS,
+  WeeklyParlayCatchupWindowSchema,
+  WeeklyParlayControlActionSchema
 };

--- a/packages/scout-for-lol/packages/data/dist/weekly-parlay.d.ts
+++ b/packages/scout-for-lol/packages/data/dist/weekly-parlay.d.ts
@@ -9,7 +9,7 @@ declare const WeeklyParlayLifecycleSchema: z.ZodObject<{
     finalHour: z.ZodNumber;
     updateHour: z.ZodNumber;
     updateCount: z.ZodNumber;
-    actions: z.ZodTuple<[z.ZodLiteral<"open">, z.ZodLiteral<"reminder">, z.ZodLiteral<"start">, z.ZodLiteral<"progress">, z.ZodLiteral<"finalize">], null>;
+    actions: z.ZodTuple<[z.ZodLiteral<"open">, z.ZodLiteral<"reminder">, z.ZodLiteral<"start">, z.ZodLiteral<"progress">, z.ZodLiteral<"finalize">, z.ZodLiteral<"cancel">, z.ZodLiteral<"analytics_sync">], null>;
 }, z.core.$strict>;
 export declare const WEEKLY_PARLAY_LIFECYCLE: {
     timezone: string;
@@ -21,9 +21,38 @@ export declare const WEEKLY_PARLAY_LIFECYCLE: {
     finalHour: number;
     updateHour: number;
     updateCount: number;
-    actions: ["open", "reminder", "start", "progress", "finalize"];
+    actions: ["open", "reminder", "start", "progress", "finalize", "cancel", "analytics_sync"];
 };
 export type WeeklyParlayLifecycle = z.infer<typeof WeeklyParlayLifecycleSchema>;
 export declare const WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS: number;
 export declare const WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS: number;
+export declare const WeeklyParlayCatchupWindowSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"catch_up">;
+    openAt: z.ZodISODateTime;
+    bettingClosesAt: z.ZodISODateTime;
+    scoringStartsAt: z.ZodISODateTime;
+    scoringEndsAt: z.ZodISODateTime;
+}, z.core.$strict>;
+export declare const WeeklyParlayControlActionSchema: z.ZodObject<{
+    periodKey: z.ZodISODate;
+    slot: z.ZodDefault<z.ZodNumber>;
+    action: z.ZodEnum<{
+        analytics_sync: "analytics_sync";
+        cancel: "cancel";
+        finalize: "finalize";
+        open: "open";
+        progress: "progress";
+        reminder: "reminder";
+        start: "start";
+    }>;
+    updateIndex: z.ZodOptional<z.ZodNumber>;
+    window: z.ZodOptional<z.ZodObject<{
+        kind: z.ZodLiteral<"catch_up">;
+        openAt: z.ZodISODateTime;
+        bettingClosesAt: z.ZodISODateTime;
+        scoringStartsAt: z.ZodISODateTime;
+        scoringEndsAt: z.ZodISODateTime;
+    }, z.core.$strict>>;
+}, z.core.$strict>;
+export type WeeklyParlayControlAction = z.infer<typeof WeeklyParlayControlActionSchema>;
 export {};

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -133,6 +133,8 @@ export type BucksWeeklyParlayVoidReason = z.infer<
 >;
 export const BucksWeeklyParlayVoidReasonSchema = z.enum([
   "infrastructure_failure",
+  "insufficient_activity",
+  "operator_cancelled",
   "unknown_evaluator",
   "invalid_definition",
   "missing_data",

--- a/packages/scout-for-lol/packages/data/src/model/weekly-parlay.json
+++ b/packages/scout-for-lol/packages/data/src/model/weekly-parlay.json
@@ -8,5 +8,13 @@
   "finalHour": 11,
   "updateHour": 19,
   "updateCount": 6,
-  "actions": ["open", "reminder", "start", "progress", "finalize"]
+  "actions": [
+    "open",
+    "reminder",
+    "start",
+    "progress",
+    "finalize",
+    "cancel",
+    "analytics_sync"
+  ]
 }

--- a/packages/scout-for-lol/packages/data/src/model/weekly-parlay.schema.json
+++ b/packages/scout-for-lol/packages/data/src/model/weekly-parlay.schema.json
@@ -42,10 +42,12 @@
         { "const": "reminder" },
         { "const": "start" },
         { "const": "progress" },
-        { "const": "finalize" }
+        { "const": "finalize" },
+        { "const": "cancel" },
+        { "const": "analytics_sync" }
       ],
-      "minItems": 5,
-      "maxItems": 5,
+      "minItems": 7,
+      "maxItems": 7,
       "items": false
     }
   }

--- a/packages/scout-for-lol/packages/data/src/model/weekly-parlay.ts
+++ b/packages/scout-for-lol/packages/data/src/model/weekly-parlay.ts
@@ -17,6 +17,8 @@ const WeeklyParlayLifecycleSchema = z.strictObject({
     z.literal("start"),
     z.literal("progress"),
     z.literal("finalize"),
+    z.literal("cancel"),
+    z.literal("analytics_sync"),
   ]),
 });
 
@@ -28,3 +30,52 @@ export const WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS =
   WEEKLY_PARLAY_LIFECYCLE.openActionBudgetMinutes * 60 * 1000;
 export const WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS =
   WEEKLY_PARLAY_LIFECYCLE.catchupMinimumBettingHours * 60 * 60 * 1000;
+
+export const WeeklyParlayCatchupWindowSchema = z.strictObject({
+  kind: z.literal("catch_up"),
+  openAt: z.iso.datetime(),
+  bettingClosesAt: z.iso.datetime(),
+  scoringStartsAt: z.iso.datetime(),
+  scoringEndsAt: z.iso.datetime(),
+});
+
+export const WeeklyParlayControlActionSchema = z
+  .strictObject({
+    periodKey: z.iso.date(),
+    slot: z.number().int().nonnegative().default(WEEKLY_PARLAY_LIFECYCLE.slot),
+    action: z.enum(WEEKLY_PARLAY_LIFECYCLE.actions),
+    updateIndex: z
+      .number()
+      .int()
+      .min(0)
+      .max(WEEKLY_PARLAY_LIFECYCLE.updateCount - 1)
+      .optional(),
+    window: WeeklyParlayCatchupWindowSchema.optional(),
+  })
+  .superRefine((action, context) => {
+    if (action.action === "progress" && action.updateIndex === undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["updateIndex"],
+        message: "Progress actions require an update index.",
+      });
+    }
+    if (action.action !== "progress" && action.updateIndex !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["updateIndex"],
+        message: "Only progress actions accept an update index.",
+      });
+    }
+    if (action.action !== "open" && action.window !== undefined) {
+      context.addIssue({
+        code: "custom",
+        path: ["window"],
+        message: "Only open actions accept a catch-up window.",
+      });
+    }
+  });
+
+export type WeeklyParlayControlAction = z.infer<
+  typeof WeeklyParlayControlActionSchema
+>;

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/bryan-bucks-parlay-odds.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/bryan-bucks-parlay-odds.md
@@ -47,11 +47,23 @@ correlation exactly.
 The model never sees a probability field it could fill in. It does not exist in
 the schema it answers.
 
-Weekly parlays use the same principle over aligned Pacific scoring windows.
-Every historical week participates—including a week with zero eligible games—
-so the replay measures the proposed legs together instead of multiplying their
-individual rates. Threshold search is deterministic and the market is rejected
-unless the measured joint YES rate is inside the publication band in
+Weekly parlays use the same replay principle over aligned Pacific scoring
+windows, with one important separation: activity qualifies a window for
+pricing but is not displayed as a betting leg. Scout excludes a historical
+window unless every featured player completed at least three eligible games.
+It stores the total, qualified, and excluded windows so the quoted probability
+can be audited. The live market uses the same rule: fewer than three games
+voids the market and refunds everyone rather than turning predictable activity
+into a leg.
+
+The model returns five distinct proposal shapes, each with a one-game peak on a
+shortlisted champion. Code chooses thresholds and rejects any shape outside the
+interesting catalogue. Each individual leg must have landed 20–70% of the time
+in qualified history, while the complete parlay must have landed 20–30%, as
+close to 25% as possible. The latest eight qualified windows must include a hit
+without exceeding 50% joint success. These guards keep a parlay plausible and
+recently relevant without making "the player logs on" the wager. The exact
+publication bands live in
 [the rules reference](/docs/reference/bryan-bucks-rules/).
 
 ## No history, no parlay

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
@@ -19,15 +19,25 @@ import {
 } from "@scout-for-lol/backend/betting/constants.ts";
 import { HOUSE_CUT_PERCENT } from "@scout-for-lol/backend/betting/house-cut.ts";
 import {
+  WEEKLY_PARLAY_CHAMPION_HISTORY_WINDOWS,
+  WEEKLY_PARLAY_CHAMPION_MIN_GAMES,
+  WEEKLY_PARLAY_CHAMPION_MIN_WINDOWS,
+  WEEKLY_PARLAY_CHAMPION_SHORTLIST_LIMIT,
   WEEKLY_PARLAY_ELIGIBLE_QUEUES,
   WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS,
   WEEKLY_PARLAY_HISTORY_WINDOW_COUNT,
   WEEKLY_PARLAY_MAX_LEGS,
+  WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS,
+  WEEKLY_PARLAY_MAX_RECENT_YES_PROBABILITY_BPS,
   WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS,
   WEEKLY_PARLAY_MIN_HISTORY_WINDOWS,
   WEEKLY_PARLAY_MIN_LEGS,
+  WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS,
   WEEKLY_PARLAY_MIN_RECENT_GAMES,
   WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS,
+  WEEKLY_PARLAY_RECENT_QUALIFIED_WINDOWS,
+  WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES,
+  WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS,
 } from "@scout-for-lol/backend/betting/weekly-parlay-criteria.ts";
 import {
   WEEKLY_PARLAY_BETTING_CLOSE_HOUR,
@@ -75,21 +85,53 @@ final settlement, which begins {WEEKLY_PARLAY_INGESTION_GRACE_MINUTES} minutes
 after the scoring cutoff so a completed game has two worst-case polling
 intervals to ingest.
 
+Activity is a settlement qualification, not a betting leg. Every featured
+player must complete at least {WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES} eligible
+games during the scoring window. If anyone falls short, Scout voids the whole
+market and refunds every wager. Once that qualification is met, a parlay can
+settle YES early only when every displayed leg is permanently satisfied.
+
 Scout selects a linked active player with at least {WEEKLY_PARLAY_MIN_RECENT_GAMES}
 eligible games, at least {WEEKLY_PARLAY_MIN_HISTORY_WINDOWS} fully observed
 weekly windows among the trailing {WEEKLY_PARLAY_HISTORY_WINDOW_COUNT}, and no
 feature during the previous {WEEKLY_PARLAY_FEATURE_COOLDOWN_PERIODS} periods.
 The market has {WEEKLY_PARLAY_MIN_LEGS}–{WEEKLY_PARLAY_MAX_LEGS} legs and is
-published only when replaying aligned historical weeks measures a YES rate
-between {WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS / 100}% and{" "}
-{WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS / 100}%. If no candidate clears every
-gate, Scout publishes no weekly parlay.
+generated from an interesting closed catalogue: wins, rates, win streaks,
+best-game statistics, wins on a named champion, and one-game peak kills,
+assists, champion damage, or vision score on a named champion. Every generated
+proposal includes at least one champion-specific peak. Plain game counts, time
+played, distinct counts, role counts, raw cumulative statistics, and champion
+plays without a win are not generated as betting legs.
+
+Named champions come from the trailing {WEEKLY_PARLAY_CHAMPION_HISTORY_WINDOWS}
+calendar windows. A champion needs at least {WEEKLY_PARLAY_CHAMPION_MIN_GAMES}
+games across {WEEKLY_PARLAY_CHAMPION_MIN_WINDOWS} windows; Scout ranks eligible
+champions by windows played, games played, then name, and keeps at most{" "}
+{WEEKLY_PARLAY_CHAMPION_SHORTLIST_LIMIT}.
+
+Pricing uses only historical windows in which every featured player met the{" "}
+{WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES}-game qualification. At least{" "}
+{WEEKLY_PARLAY_MIN_HISTORY_WINDOWS} qualified windows are required. Each
+displayed leg must have landed between{" "}
+{WEEKLY_PARLAY_MIN_LEG_PROBABILITY_BPS / 100}% and{" "}
+{WEEKLY_PARLAY_MAX_LEG_PROBABILITY_BPS / 100}% on its own. The complete parlay
+must have landed between {WEEKLY_PARLAY_MIN_YES_PROBABILITY_BPS / 100}% and{" "}
+{WEEKLY_PARLAY_MAX_YES_PROBABILITY_BPS / 100}%, with the closest result to{" "}
+{WEEKLY_PARLAY_TARGET_YES_PROBABILITY_BPS / 100}% preferred. Across the latest{" "}
+{WEEKLY_PARLAY_RECENT_QUALIFIED_WINDOWS} qualified windows, the complete parlay
+must have hit at least once but no more than{" "}
+{WEEKLY_PARLAY_MAX_RECENT_YES_PROBABILITY_BPS / 100}% of the time. If no
+candidate clears every gate, Scout publishes no weekly parlay.
 
 If the standard Sunday opening is missed, an operator may start a catch-up
 market for that period. Betting remains open for at least{" "}
 {WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_HOURS} hours before scoring starts at a
 Pacific midnight. The market message shows the frozen betting and scoring
 timestamps. Games completed before betting closes do not count.
+
+An operator may cancel an open or active weekly market. Cancellation refunds
+every pending wager, posts a bettor-mentioned refund notice, and marks the
+original market message as cancelled with its betting buttons removed.
 
 ## Stakes
 

--- a/packages/scout-for-lol/packages/report/src/html/classic/classic-visuals.test.ts
+++ b/packages/scout-for-lol/packages/report/src/html/classic/classic-visuals.test.ts
@@ -66,6 +66,8 @@ describe("Classic report renders with committed fonts", () => {
     },
   );
 
+  // Four production renders run alongside the other raster suites in CI, so
+  // this integration case needs a budget above Vitest's unit-test default.
   test("Classic ARAM Mayhem prematch and postmatch render SVG and PNG", async () => {
     const loadingScreen = classicLoadingScreenFixture(
       5,
@@ -91,7 +93,7 @@ describe("Classic report renders with committed fonts", () => {
     ]);
     expect([...loadingPng.subarray(0, 8)]).toEqual(PNG_SIGNATURE);
     expect([...matchPng.subarray(0, 8)]).toEqual(PNG_SIGNATURE);
-  });
+  }, 30_000);
 
   test("Victory, Defeat, and Surrender produce distinct reports", async () => {
     const outcomes = ["Victory", "Defeat", "Surrender"] as const;

--- a/packages/temporal/src/activities/scout-weekly-parlay.test.ts
+++ b/packages/temporal/src/activities/scout-weekly-parlay.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest";
+import { WeeklyParlayControlActionSchema as ScoutWeeklyParlayActionSchema } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import {
   buildScoutWeeklyParlayCatchupTimeline,
   buildScoutWeeklyParlayTimeline,
-  ScoutWeeklyParlayActionSchema,
   scoutWeeklyParlayActionKey,
 } from "./scout-weekly-parlay.ts";
 

--- a/packages/temporal/src/activities/scout-weekly-parlay.ts
+++ b/packages/temporal/src/activities/scout-weekly-parlay.ts
@@ -3,6 +3,8 @@ import {
   WEEKLY_PARLAY_CATCHUP_MINIMUM_BETTING_MS,
   WEEKLY_PARLAY_LIFECYCLE,
   WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS,
+  WeeklyParlayControlActionSchema as ScoutWeeklyParlayActionSchema,
+  type WeeklyParlayControlAction as ScoutWeeklyParlayAction,
 } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import {
   scoutWeeklyParlayActionDurationSeconds,
@@ -20,54 +22,6 @@ const UPDATE_HOUR = WEEKLY_PARLAY_LIFECYCLE.updateHour;
 const UPDATE_COUNT = WEEKLY_PARLAY_LIFECYCLE.updateCount;
 const OPEN_ACTION_TIMEOUT_MS = WEEKLY_PARLAY_OPEN_ACTION_BUDGET_MS;
 const STANDARD_ACTION_TIMEOUT_MS = 20 * 1000;
-
-export const ScoutWeeklyParlayCatchupWindowSchema = z.strictObject({
-  kind: z.literal("catch_up"),
-  openAt: z.iso.datetime(),
-  bettingClosesAt: z.iso.datetime(),
-  scoringStartsAt: z.iso.datetime(),
-  scoringEndsAt: z.iso.datetime(),
-});
-
-export const ScoutWeeklyParlayActionSchema = z
-  .strictObject({
-    periodKey: z.iso.date(),
-    slot: z.number().int().nonnegative().default(0),
-    action: z.enum(WEEKLY_PARLAY_LIFECYCLE.actions),
-    updateIndex: z
-      .number()
-      .int()
-      .min(0)
-      .max(UPDATE_COUNT - 1)
-      .optional(),
-    window: ScoutWeeklyParlayCatchupWindowSchema.optional(),
-  })
-  .superRefine((action, context) => {
-    if (action.action === "progress" && action.updateIndex === undefined) {
-      context.addIssue({
-        code: "custom",
-        path: ["updateIndex"],
-        message: "Progress actions require an update index.",
-      });
-    }
-    if (action.action !== "progress" && action.updateIndex !== undefined) {
-      context.addIssue({
-        code: "custom",
-        path: ["updateIndex"],
-        message: "Only progress actions accept an update index.",
-      });
-    }
-    if (action.action !== "open" && action.window !== undefined) {
-      context.addIssue({
-        code: "custom",
-        path: ["window"],
-        message: "Only open actions accept a catch-up window.",
-      });
-    }
-  });
-export type ScoutWeeklyParlayAction = z.infer<
-  typeof ScoutWeeklyParlayActionSchema
->;
 
 export const ScoutWeeklyParlayTimelineSchema = z.strictObject({
   periodKey: z.iso.date(),

--- a/packages/temporal/src/workflows/scout-weekly-parlay.test.ts
+++ b/packages/temporal/src/workflows/scout-weekly-parlay.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { Worker, type WorkerOptions } from "@temporalio/worker";
-import type {
-  ScoutWeeklyParlayAction,
-  ScoutWeeklyParlayTimeline,
-} from "#activities/scout-weekly-parlay.ts";
+import type { WeeklyParlayControlAction as ScoutWeeklyParlayAction } from "@scout-for-lol/data/model/weekly-parlay.ts";
+import type { ScoutWeeklyParlayTimeline } from "#activities/scout-weekly-parlay.ts";
 import {
   runScoutWeeklyParlayCatchupWorkflow,
   runScoutWeeklyParlayWorkflow,

--- a/packages/temporal/src/workflows/scout-weekly-parlay.ts
+++ b/packages/temporal/src/workflows/scout-weekly-parlay.ts
@@ -6,9 +6,11 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 import { z } from "zod";
-import { WEEKLY_PARLAY_LIFECYCLE } from "@scout-for-lol/data/model/weekly-parlay.ts";
+import {
+  WEEKLY_PARLAY_LIFECYCLE,
+  type WeeklyParlayControlAction as ScoutWeeklyParlayAction,
+} from "@scout-for-lol/data/model/weekly-parlay.ts";
 import type {
-  ScoutWeeklyParlayAction,
   ScoutWeeklyParlayActivities,
   ScoutWeeklyParlayTimeline,
 } from "#activities/scout-weekly-parlay.ts";


### PR DESCRIPTION
## Why

Weekly parlays could select routine participation criteria with effectively certain outcomes. The market needs meaningful, champion-specific legs and a historically challenging joint result.

## What

- Introduces version-two criteria with champion peak kills, assists, champion damage, and vision score while preserving version-one evaluation and settlement.
- Treats three eligible games per subject as settlement qualification; insufficient activity voids and refunds the market.
- Builds deterministic champion shortlists from eight windows and requires five distinct model proposals drawn from the interesting catalog.
- Prices only qualified history with 20 to 70 percent leg bands, a 20 to 30 percent joint band, and recent-history guards; persists complete evidence.
- Adds authenticated, idempotent operator cancellation with atomic refunds, bettor notifications, and button-free cancellation edits.
- Updates Bryan Bucks rules, odds explanation, slash-command copy, and Scout agent invariants.
- Gives the four-render Classic visual integration case an explicit 30-second budget after exact-head CI proved Vitest’s unit-test default too short under concurrent raster load.

## Verification

- Focused weekly-parlay suite: 74 tests passed.
- PostgreSQL cancellation integration proves three bettors are refunded exactly once with balanced refund and release ledger entries.
- Package suites: backend 266 files and 2,371 tests passed; data and docs tests passed; report 26 files and 149 tests passed.
- Backend, data, docs, and report typecheck and lint passed.
- Changed-file Prettier check and staged lefthook pre-commit checks passed.
- Live OpenRouter weekly prompt contract accepted five distinct three-leg proposals.
- No weekly-parlay Discord guild-member discovery dependency remains.

Rendered docs screenshots are pending because no browser connection was available in this Conductor session. The inert beta Discord fixture is pending confirmation of the beta bot identity and channel.

## Rollout

After merge, deploy only the Scout beta backend. Re-read and cancel period 2026-08-24 slot 1, verify PostgreSQL and Discord refunds, terminate only the slot-1 catch-up workflow, then start slot 2 with Fail and RejectDuplicate policies. Leave slot 0 and the paused recurring schedule untouched. If slot 2 returns no_price, diagnose persisted evidence and fix forward without weakening gates.