### PR TITLE
feat(feature-flags): reconcile runtime inventory with Flipt

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "check-floating-deps": "bun scripts/check-floating-deps.ts",
     "check-patched-deps": "bun scripts/check-patched-deps.ts",
     "check-ci-env": "bun scripts/check-ci-env.ts",
+    "check-flipt-flag-inventory": "bun scripts/check-flipt-flag-inventory.ts",
     "check-script-migrations": "bun scripts/check-script-migrations.ts",
     "check-test-standardization": "bun scripts/check-test-standardization.ts",
     "script-coverage": "bun scripts/check-script-coverage.ts"

--- a/packages/birmel/src/config/dynamic.ts
+++ b/packages/birmel/src/config/dynamic.ts
@@ -7,6 +7,7 @@ import {
   type InitFeatureFlagsOptions,
 } from "@shepherdjerred/feature-flags";
 import { createFlagConfigSource } from "@shepherdjerred/feature-flags/config-source.ts";
+import { prepareDefinition } from "@shepherdjerred/config/definition.ts";
 import { z } from "zod";
 import { featureFlagMetrics } from "@shepherdjerred/birmel/observability/metrics.ts";
 import { getConfig } from "./index.ts";
@@ -170,6 +171,10 @@ const DEFINITION = {
     },
   },
 } as const;
+
+export const DYNAMIC_FLAG_NAMES = Object.entries(DEFINITION).map(
+  ([key, definition]) => prepareDefinition(key, definition).names.flag,
+);
 
 type Snapshot = ReturnType<typeof createSnapshot>["snapshot"];
 

--- a/packages/birmel/tests/config/dynamic.test.ts
+++ b/packages/birmel/tests/config/dynamic.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 import { loadConfigFromEnvironment } from "@shepherdjerred/birmel/config/index.ts";
 import {
+  DYNAMIC_FLAG_NAMES,
   initializeDynamicConfig,
   shutdownDynamicConfig,
 } from "@shepherdjerred/birmel/config/dynamic.ts";
@@ -18,6 +20,14 @@ afterEach(async () => {
 });
 
 describe("Birmel dynamic config", () => {
+  test("covers exactly the Birmel entries in the managed inventory", () => {
+    const expected = managedFlagInventory.flags
+      .filter((flag) => flag.owner === "birmel")
+      .map((flag) => flag.key)
+      .sort();
+    expect([...DYNAMIC_FLAG_NAMES].sort()).toEqual(expected);
+  });
+
   test("applies typed flag values without changing bootstrap config", async () => {
     const config = loadConfigFromEnvironment(VALID_ENVIRONMENT);
     await initializeDynamicConfig({

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -108,13 +108,9 @@ boot-wired startup choices, observability enablement, and CI or automation
 deciders. They need lifecycle or authorization changes before they can be
 runtime flags. The repository-owned
 `packages/feature-flags/src/managed-flag-inventory.json`
-records those exemptions alongside the 53 managed keys.
-
-The operator-only `bun run check-flipt-flag-inventory` command compares that
-inventory with Flipt's evaluation snapshot. It checks the exact key set, flag
-types, defaults, and targeting constraints. Run it with `FLIPT_URL` set to the
-Flipt endpoint; it is deliberately not part of service startup or CI because
-the live endpoint is an operational dependency, not a build input.
+records those exemptions alongside the 53 managed keys. Operators can use the
+[Flipt inventory check](/how-to/check-flipt-flag-inventory/) to compare it with
+the live evaluation snapshot.
 
 ## Durability
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -103,6 +103,19 @@ consequences worth stating rather than leaving implicit in a policy file:
 
 If Flipt ever gains authentication, both of those are worth revisiting.
 
+The same boundary keeps several controls outside Flipt: capability grants,
+boot-wired startup choices, observability enablement, and CI or automation
+deciders. They need lifecycle or authorization changes before they can be
+runtime flags. The repository-owned
+`packages/feature-flags/src/managed-flag-inventory.json`
+records those exemptions alongside the 53 managed keys.
+
+The operator-only `bun run check-flipt-flag-inventory` command compares that
+inventory with Flipt's evaluation snapshot. It checks the exact key set, flag
+types, defaults, and targeting constraints. Run it with `FLIPT_URL` set to the
+Flipt endpoint; it is deliberately not part of service startup or CI because
+the live endpoint is an operational dependency, not a build input.
+
 ## Durability
 
 Flipt v2 defaults to **in-memory storage**. It accepts flag writes, serves them

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -1,0 +1,52 @@
+---
+title: Check the Flipt flag inventory
+description: Compare the repository-managed runtime flag contract with the live Flipt evaluation snapshot.
+sidebar:
+  order: 9
+---
+
+Run the operator-only inventory check when you change Flipt state or need to
+diagnose runtime flag drift.
+
+## 1. Set the endpoint
+
+Set `FLIPT_URL` to the reachable Flipt endpoint. The checker never guesses an
+endpoint and does not run during service startup or CI.
+
+```bash
+export FLIPT_URL="https://flipt.example.internal"
+```
+
+## 2. Run the check
+
+Run the repository command from the monorepo root:
+
+```bash
+bun run check-flipt-flag-inventory
+```
+
+The command compares the `default/default` namespace and environment unless
+`FLIPT_NAMESPACE` or `FLIPT_ENVIRONMENT` overrides them.
+
+## 3. Interpret failures
+
+The check fails when Flipt differs from the inventory in any of these areas:
+
+- managed key set;
+- boolean or variant type;
+- default value;
+- segment constraints and operators;
+- variant rules and distributions;
+- percentage threshold rollouts.
+
+Fix the repository inventory or the audited Flipt state, then run the command
+again until it reports alignment.
+
+:::caution
+Flipt has no authentication. Network reachability is the authorization
+boundary, so keep the endpoint private and do not expose it publicly.
+:::
+
+## Related
+
+- [Configuration layers](/explanation/homelab/configuration/)

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -13,8 +13,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -29,8 +37,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-user-160509172704739328",
-          "property": "user",
-          "value": "160509172704739328",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "user",
+              "operator": "eq",
+              "value": "160509172704739328"
+            }
+          ],
           "result": true
         }
       ]
@@ -45,8 +61,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -61,8 +85,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -77,8 +109,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -93,8 +133,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -109,8 +157,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -125,8 +181,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-user-160509172704739328",
-          "property": "user",
-          "value": "160509172704739328",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "user",
+              "operator": "eq",
+              "value": "160509172704739328"
+            }
+          ],
           "result": true
         }
       ]
@@ -159,8 +223,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]
@@ -175,8 +247,16 @@
       "rollouts": [
         {
           "segmentKey": "scout-guild-1337623164146155593",
-          "property": "server",
-          "value": "1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
           "result": true
         }
       ]

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -1,0 +1,598 @@
+{
+  "version": 1,
+  "namespace": "default",
+  "environment": "default",
+  "flags": [
+    {
+      "key": "ai_reports_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout AI report generation.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "ai_reports_unlimited",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Grant the beta user unlimited AI reports.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-user-160509172704739328",
+          "property": "user",
+          "value": "160509172704739328",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "ai_reviews_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout post-match AI reviews.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "betting_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable the Scout Bryan Bucks betting economy.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "betting_player_bet_outcome_dm_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Send players a direct message with their bet outcome.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "betting_settlement_dm_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Send betting settlement direct messages.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "competition_builder_v2_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout competition builder version two.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "debug",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout debug surfaces for the beta operator.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-user-160509172704739328",
+          "property": "user",
+          "value": "160509172704739328",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "initial_match_history_import_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable the initial Scout match-history import.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": []
+    },
+    {
+      "key": "scout-consumer-player-profiles-enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout consumer player profiles.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": []
+    },
+    {
+      "key": "tournament_lobbies_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout tournament lobbies.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "weekly_parlays_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Scout weekly parlays.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "property": "server",
+          "value": "1337623164146155593",
+          "result": true
+        }
+      ]
+    },
+    {
+      "key": "scout-betting-parlay-ai-model",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Select the Scout parlay AI model.",
+      "type": "variant",
+      "default": "gpt-5.6-sol",
+      "rollouts": []
+    },
+    {
+      "key": "scout-bucks-ask-model",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Select the Scout Bryan Bucks ask model.",
+      "type": "variant",
+      "default": "gpt-5.6-luna",
+      "rollouts": []
+    },
+    {
+      "key": "scout-explore-model",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Select the Scout Explore AI model.",
+      "type": "variant",
+      "default": "gpt-5.6-sol",
+      "rollouts": []
+    },
+    {
+      "key": "scout-report-ai-model",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Select the Scout report AI model.",
+      "type": "variant",
+      "default": "gpt-5.6-sol",
+      "rollouts": []
+    },
+    {
+      "key": "scout-tournament-api-mode",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Select the Scout tournament API mode.",
+      "type": "variant",
+      "default": "stub",
+      "rollouts": []
+    },
+    {
+      "key": "scout-tournament-max-open-lobbies",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Bound the number of concurrently open Scout tournament lobbies.",
+      "type": "variant",
+      "default": "10",
+      "rollouts": []
+    },
+    {
+      "key": "explore-guild-allowlist",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Select the Scout guilds allowed to use Explore.",
+      "type": "variant",
+      "default": "1337623164146155593",
+      "rollouts": []
+    },
+    {
+      "key": "llm-daily-token-budget",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Bound Scout daily LLM token usage.",
+      "type": "variant",
+      "default": "20000000",
+      "rollouts": []
+    },
+    {
+      "key": "llm-hourly-token-budget",
+      "owner": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Bound Scout hourly LLM token usage.",
+      "type": "variant",
+      "default": "2000000",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-activity-tracking-enabled",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Enable Birmel activity tracking and role aggregation.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "birmel-agent-max-steps",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound Birmel agent steps.",
+      "type": "variant",
+      "default": "8",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-agent-response-timeout-ms",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound Birmel agent response time.",
+      "type": "variant",
+      "default": "120000",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-agent-router-timeout-ms",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound Birmel agent router time.",
+      "type": "variant",
+      "default": "30000",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-birthdays-enabled",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Enable Birmel birthday announcements and roles.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "birmel-daily-posts-enabled",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Enable Birmel daily posts.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "birmel-elections-enabled",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Enable Birmel elections.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "birmel-llm-classifier-model",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Select the Birmel classifier model.",
+      "type": "variant",
+      "default": "gpt-5.4-nano",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-llm-embedding-model",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Select the Birmel embedding model.",
+      "type": "variant",
+      "default": "text-embedding-3-small",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-llm-max-output-tokens",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound Birmel LLM output tokens.",
+      "type": "variant",
+      "default": "4096",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-llm-memory-model",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Select the Birmel memory model.",
+      "type": "variant",
+      "default": "gpt-5.4-nano",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-llm-model",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Select the Birmel primary LLM model.",
+      "type": "variant",
+      "default": "gpt-5.6-sol",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-llm-reasoning-effort",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Select Birmel reasoning effort.",
+      "type": "variant",
+      "default": "medium",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-persona-enabled",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Enable Birmel persona projection.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "birmel-persona-style-model",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Select the Birmel persona style model.",
+      "type": "variant",
+      "default": "gpt-5.4-nano",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-responder-enabled",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Enable the Birmel conversational responder.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "birmel-responder-engagement-window-ms",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound the Birmel responder engagement window.",
+      "type": "variant",
+      "default": "180000",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-responder-transcript-max-messages",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound Birmel responder transcript messages.",
+      "type": "variant",
+      "default": "50",
+      "rollouts": []
+    },
+    {
+      "key": "birmel-responder-transcript-window-ms",
+      "owner": "birmel",
+      "source": "birmel-dynamic",
+      "purpose": "Bound the Birmel responder transcript window.",
+      "type": "variant",
+      "default": "3600000",
+      "rollouts": []
+    },
+    {
+      "key": "karma-admin-user-id",
+      "owner": "starlight-karma-bot",
+      "source": "karma-dynamic",
+      "purpose": "Select the Karma administrator user.",
+      "type": "variant",
+      "default": "160509172704739328",
+      "rollouts": []
+    },
+    {
+      "key": "karma-emoji",
+      "owner": "starlight-karma-bot",
+      "source": "karma-dynamic",
+      "purpose": "Select the emoji that awards karma.",
+      "type": "variant",
+      "default": "⭐",
+      "rollouts": []
+    },
+    {
+      "key": "player-card-enabled",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Enable Streambot player cards.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "streambot-idle-timeout-seconds",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Bound Streambot idle timeout.",
+      "type": "variant",
+      "default": "300",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-player-card-repost-after-messages",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Set Streambot player-card repost interval.",
+      "type": "variant",
+      "default": "5",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-player-card-tick-ms",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Set Streambot player-card refresh interval.",
+      "type": "variant",
+      "default": "10000",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-playlist-limit",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Bound the Streambot playlist.",
+      "type": "variant",
+      "default": "100",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-reconnect-delay-seconds",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Set Streambot reconnect delay.",
+      "type": "variant",
+      "default": "5",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-reconnect-enabled",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Enable Streambot reconnects after transient voice disconnects.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "streambot-reconnect-max-attempts",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Bound Streambot reconnect attempts.",
+      "type": "variant",
+      "default": "3",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-subtitle-languages",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Select Streambot subtitle languages.",
+      "type": "variant",
+      "default": "en",
+      "rollouts": []
+    },
+    {
+      "key": "streambot-subtitles-include-auto-generated",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Use auto-generated captions when human subtitles are unavailable.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    },
+    {
+      "key": "subtitles-enabled",
+      "owner": "streambot",
+      "source": "streambot-dynamic",
+      "purpose": "Enable Streambot subtitles.",
+      "type": "boolean",
+      "default": true,
+      "rollouts": []
+    }
+  ],
+  "exemptions": [
+    {
+      "category": "capability-security",
+      "controls": [
+        "Birmel editor",
+        "Birmel shell",
+        "Birmel browser",
+        "Birmel scheduler",
+        "Streambot voice capture"
+      ],
+      "reason": "These controls grant capabilities or persist human audio. Flipt has no authentication, so moving them would widen authorization without a lifecycle redesign."
+    },
+    {
+      "category": "boot-wired",
+      "controls": [
+        "Streambot voice assistant",
+        "Mario Kart driver feed",
+        "Alert Dashboard email"
+      ],
+      "reason": "These controls select startup wiring or fatal asset and credential paths. Runtime evaluation cannot safely replace their boot lifecycle."
+    },
+    {
+      "category": "observability",
+      "controls": ["telemetry", "Sentry", "LLM archive"],
+      "reason": "Observability initialization is boot-scoped and must not disappear behind an unauthenticated runtime toggle."
+    },
+    {
+      "category": "ci-automation",
+      "controls": [
+        "Temporal merge-conflict kill switch",
+        "Temporal merge-conflict dry run"
+      ],
+      "reason": "CI and automation deciders must remain explicit environment or workflow controls, not remotely mutable product flags."
+    },
+    {
+      "category": "bootstrap",
+      "controls": [
+        "FEATURE_FLAGS_MODE",
+        "FLIPT_URL",
+        "equivalent startup configuration"
+      ],
+      "reason": "The service needs these values before a flag provider can initialize, so they cannot be sourced from Flipt."
+    }
+  ]
+}

--- a/packages/feature-flags/src/managed-flag-inventory.schema.json
+++ b/packages/feature-flags/src/managed-flag-inventory.schema.json
@@ -31,12 +31,96 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["segmentKey", "property", "value", "result"],
+              "required": [
+                "segmentKey",
+                "segmentOperator",
+                "matchType",
+                "constraints",
+                "result"
+              ],
               "properties": {
                 "segmentKey": { "type": "string", "minLength": 1 },
-                "property": { "type": "string", "minLength": 1 },
-                "value": { "type": "string", "minLength": 1 },
-                "result": {}
+                "segmentOperator": { "type": "string", "minLength": 1 },
+                "matchType": { "type": "string", "minLength": 1 },
+                "constraints": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["type", "property", "operator", "value"],
+                    "properties": {
+                      "type": { "type": "string", "minLength": 1 },
+                      "property": { "type": "string", "minLength": 1 },
+                      "operator": { "type": "string", "minLength": 1 },
+                      "value": { "type": "string", "minLength": 1 }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "result": { "type": "boolean" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "rank",
+                "segmentOperator",
+                "segments",
+                "distributions"
+              ],
+              "properties": {
+                "rank": { "type": "integer", "minimum": 0 },
+                "segmentOperator": { "type": "string", "minLength": 1 },
+                "segments": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["key", "matchType", "constraints"],
+                    "properties": {
+                      "key": { "type": "string", "minLength": 1 },
+                      "matchType": { "type": "string", "minLength": 1 },
+                      "constraints": { "type": "array" }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "distributions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["variantKey", "rollout", "variantAttachment"],
+                    "properties": {
+                      "variantKey": { "type": "string", "minLength": 1 },
+                      "rollout": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "variantAttachment": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "thresholdRollouts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["rank", "percentage", "result"],
+              "properties": {
+                "rank": { "type": "integer", "minimum": 0 },
+                "percentage": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 100
+                },
+                "result": { "type": "boolean" }
               },
               "additionalProperties": false
             }

--- a/packages/feature-flags/src/managed-flag-inventory.schema.json
+++ b/packages/feature-flags/src/managed-flag-inventory.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["version", "namespace", "environment", "flags", "exemptions"],
+  "properties": {
+    "version": { "const": 1 },
+    "namespace": { "type": "string", "minLength": 1 },
+    "environment": { "type": "string", "minLength": 1 },
+    "flags": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "key",
+          "owner",
+          "source",
+          "purpose",
+          "type",
+          "default",
+          "rollouts"
+        ],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "owner": { "type": "string", "minLength": 1 },
+          "source": { "type": "string", "minLength": 1 },
+          "purpose": { "type": "string", "minLength": 1 },
+          "type": { "enum": ["boolean", "variant"] },
+          "default": {},
+          "rollouts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["segmentKey", "property", "value", "result"],
+              "properties": {
+                "segmentKey": { "type": "string", "minLength": 1 },
+                "property": { "type": "string", "minLength": 1 },
+                "value": { "type": "string", "minLength": 1 },
+                "result": {}
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "exemptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category", "controls", "reason"],
+        "properties": {
+          "category": { "type": "string", "minLength": 1 },
+          "controls": { "type": "array", "items": { "type": "string" } },
+          "reason": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/feature-flags/src/managed-flag-inventory.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.ts
@@ -1,0 +1,17 @@
+import inventory from "@shepherdjerred/feature-flags/managed-flag-inventory.json" with { type: "json" };
+
+export type ManagedFlagType = "boolean" | "variant";
+
+export type ManagedFlagRollout = {
+  readonly segmentKey: string;
+  readonly property: string;
+  readonly value: string;
+  readonly result: boolean;
+};
+
+const managedFlagInventory = inventory;
+export { managedFlagInventory };
+
+export const managedFlagNames = managedFlagInventory.flags.map(
+  (flag) => flag.key,
+);

--- a/packages/feature-flags/src/managed-flag-inventory.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.ts
@@ -1,16 +1,100 @@
 import inventory from "@shepherdjerred/feature-flags/managed-flag-inventory.json" with { type: "json" };
+import { z } from "zod";
 
 export type ManagedFlagType = "boolean" | "variant";
 
-export type ManagedFlagRollout = {
-  readonly segmentKey: string;
-  readonly property: string;
-  readonly value: string;
-  readonly result: boolean;
+const ManagedFlagConstraintSchema = z.object({
+  type: z.string().min(1),
+  property: z.string().min(1),
+  operator: z.string().min(1),
+  value: z.string().min(1),
+});
+
+const ManagedFlagSegmentSchema = z.object({
+  key: z.string().min(1),
+  matchType: z.string().min(1),
+  constraints: z.array(ManagedFlagConstraintSchema),
+});
+
+const ManagedFlagRuleSchema = z.object({
+  rank: z.number().int().nonnegative(),
+  segmentOperator: z.string().min(1),
+  segments: z.array(ManagedFlagSegmentSchema),
+  distributions: z.array(
+    z.object({
+      variantKey: z.string().min(1),
+      rollout: z.number().min(0).max(100),
+      variantAttachment: z.string(),
+    }),
+  ),
+});
+
+const ManagedFlagThresholdRolloutSchema = z.object({
+  rank: z.number().int().nonnegative(),
+  percentage: z.number().min(0).max(100),
+  result: z.boolean(),
+});
+
+export const ManagedFlagRolloutSchema = z.object({
+  segmentKey: z.string().min(1),
+  segmentOperator: z.string().min(1),
+  matchType: z.string().min(1),
+  constraints: z.array(ManagedFlagConstraintSchema),
+  result: z.boolean(),
+});
+
+const ManagedFlagFields = {
+  key: z.string().min(1),
+  owner: z.string().min(1),
+  source: z.string().min(1),
+  purpose: z.string().min(1),
+  rollouts: z.array(ManagedFlagRolloutSchema),
+  rules: z.array(ManagedFlagRuleSchema).default([]),
+  thresholdRollouts: z.array(ManagedFlagThresholdRolloutSchema).default([]),
 };
 
-const managedFlagInventory = inventory;
-export { managedFlagInventory };
+const ManagedFlagSchema = z.discriminatedUnion("type", [
+  z.object({
+    ...ManagedFlagFields,
+    type: z.literal("boolean"),
+    default: z.boolean(),
+  }),
+  z.object({
+    ...ManagedFlagFields,
+    type: z.literal("variant"),
+    default: z.string(),
+  }),
+]);
+
+export const ManagedFlagInventorySchema = z
+  .object({
+    version: z.literal(1),
+    namespace: z.string().min(1),
+    environment: z.string().min(1),
+    flags: z.array(ManagedFlagSchema).min(1),
+    exemptions: z.array(
+      z.object({
+        category: z.string().min(1),
+        controls: z.array(z.string().min(1)),
+        reason: z.string().min(1),
+      }),
+    ),
+  })
+  .superRefine((value, context) => {
+    const seen = new Set<string>();
+    for (const [index, flag] of value.flags.entries()) {
+      if (seen.has(flag.key)) {
+        context.addIssue({
+          code: "custom",
+          message: `duplicate managed flag key: ${flag.key}`,
+          path: ["flags", index, "key"],
+        });
+      }
+      seen.add(flag.key);
+    }
+  });
+
+export const managedFlagInventory = ManagedFlagInventorySchema.parse(inventory);
 
 export const managedFlagNames = managedFlagInventory.flags.map(
   (flag) => flag.key,

--- a/packages/scout-for-lol/packages/backend/src/config/dynamic.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/config/dynamic.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 import {
   exploreGuildAllowlist,
   exploreModel,
@@ -7,7 +8,9 @@ import {
   isDynamicConfigReady,
   llmHourlyTokenBudget,
   shutdownDynamicConfig,
+  tournamentMaxOpenLobbies,
   tournamentApiMode,
+  DYNAMIC_FLAG_NAMES,
   type DynamicConfigSeed,
 } from "#src/config/dynamic.ts";
 
@@ -27,6 +30,16 @@ afterEach(async () => {
 });
 
 describe("scout dynamic config", () => {
+  test("covers exactly the Scout dynamic entries in the managed inventory", () => {
+    const expected = managedFlagInventory.flags
+      .filter(
+        (flag) => flag.owner === "scout" && flag.source === "scout-dynamic",
+      )
+      .map((flag) => flag.key)
+      .sort();
+    expect([...DYNAMIC_FLAG_NAMES].sort()).toEqual(expected);
+  });
+
   test("resolves to the seed when neither a flag nor env supplies a value", async () => {
     await initializeDynamicConfig({
       environment: DISABLED,
@@ -155,6 +168,16 @@ describe("tournament api mode", () => {
       provider: new StaticProvider({ "scout-tournament-api-mode": "live" }),
     });
     expect(tournamentApiMode()).toBe("live");
+  });
+
+  test("resolves the lobby limit through the variant flag", async () => {
+    await initializeDynamicConfig({
+      environment: { ...DISABLED, TOURNAMENT_MAX_OPEN_LOBBIES: "3" },
+      seed: SEED,
+      startPolling: false,
+      provider: new StaticProvider({ "scout-tournament-max-open-lobbies": 7 }),
+    });
+    expect(tournamentMaxOpenLobbies()).toBe(7);
   });
 
   test("an unparseable value keeps the seed rather than guessing", async () => {

--- a/packages/scout-for-lol/packages/backend/src/config/dynamic.ts
+++ b/packages/scout-for-lol/packages/backend/src/config/dynamic.ts
@@ -9,6 +9,7 @@ import {
   type InitFeatureFlagsOptions,
 } from "@shepherdjerred/feature-flags";
 import { createFlagConfigSource } from "@shepherdjerred/feature-flags/config-source.ts";
+import { prepareDefinition } from "@shepherdjerred/config/definition.ts";
 import { createLogger } from "#src/logger.ts";
 import { featureFlagMetrics } from "#src/metrics/feature-flags.ts";
 import configuration from "#src/configuration.ts";
@@ -137,6 +138,10 @@ const DEFINITION = {
     },
   },
 } as const;
+
+export const DYNAMIC_FLAG_NAMES = Object.entries(DEFINITION).map(
+  ([key, definition]) => prepareDefinition(key, definition).names.flag,
+);
 
 /**
  * The values the snapshot starts from, so a read before the first refresh is

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
@@ -8,6 +8,7 @@ import {
   shutdownFeatureFlags,
 } from "@shepherdjerred/feature-flags";
 import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 import {
   addFlagOverride,
@@ -16,6 +17,7 @@ import {
   listGuildsWithFlagDeclared,
   listGuildsWithFlagEnabled,
   MY_SERVER,
+  POLICY_FLAG_NAMES,
   resetFlagOverrides,
 } from "#src/configuration/flags.ts";
 
@@ -55,6 +57,16 @@ afterEach(() => {
 });
 
 describe("production hard-disable policy", () => {
+  test("covers exactly the Scout policy entries in the managed inventory", () => {
+    const expected = managedFlagInventory.flags
+      .filter(
+        (flag) => flag.owner === "scout" && flag.source === "scout-policy",
+      )
+      .map((flag) => flag.key)
+      .sort();
+    expect([...POLICY_FLAG_NAMES].sort()).toEqual(expected);
+  });
+
   test("wins over local overrides and guild enumeration", () => {
     Bun.env["ENVIRONMENT"] = "prod";
     resetConfigurationForTests();

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -278,6 +278,8 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
   },
 };
 
+export const POLICY_FLAG_NAMES = Object.keys(FLAG_REGISTRY);
+
 /**
  * The overrides each flag was declared with, captured at module load.
  *

--- a/packages/starlight-karma-bot/src/config.test.ts
+++ b/packages/starlight-karma-bot/src/config.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 import {
+  DYNAMIC_FLAG_NAMES,
   describeDynamicConfig,
   initializeConfig,
   karmaAdminUserId,
@@ -15,6 +17,14 @@ afterEach(async () => {
 });
 
 describe("dynamic config", () => {
+  test("covers exactly the Karma entries in the managed inventory", () => {
+    const expected = managedFlagInventory.flags
+      .filter((flag) => flag.owner === "starlight-karma-bot")
+      .map((flag) => flag.key)
+      .sort();
+    expect([...DYNAMIC_FLAG_NAMES].sort()).toEqual(expected);
+  });
+
   test("falls back to the declared default with no flag and no env", async () => {
     await initializeConfig({ environment: DISABLED });
     await expect(karmaEmoji("guild-1")).resolves.toBe("⭐");

--- a/packages/starlight-karma-bot/src/config.ts
+++ b/packages/starlight-karma-bot/src/config.ts
@@ -8,6 +8,7 @@ import {
   type InitFeatureFlagsOptions,
 } from "@shepherdjerred/feature-flags";
 import { createFlagConfigSource } from "@shepherdjerred/feature-flags/config-source.ts";
+import { prepareDefinition } from "@shepherdjerred/config/definition.ts";
 import type { ConfigSource } from "@shepherdjerred/config/source.ts";
 import { featureFlagMetrics } from "#src/metrics.ts";
 
@@ -46,6 +47,10 @@ const DEFINITION = {
     targeted: true,
   },
 } as const;
+
+export const DYNAMIC_FLAG_NAMES = Object.entries(DEFINITION).map(
+  ([key, definition]) => prepareDefinition(key, definition).names.flag,
+);
 
 let resolver: ReturnType<typeof buildResolver> | undefined;
 

--- a/packages/streambot/src/config/dynamic.ts
+++ b/packages/streambot/src/config/dynamic.ts
@@ -9,6 +9,7 @@ import {
   type InitFeatureFlagsOptions,
 } from "@shepherdjerred/feature-flags";
 import { createFlagConfigSource } from "@shepherdjerred/feature-flags/config-source.ts";
+import { prepareDefinition } from "@shepherdjerred/config/definition.ts";
 import type { Config } from "@shepherdjerred/streambot/config/schema.ts";
 
 /**
@@ -149,6 +150,10 @@ const DEFINITION = {
     names: { flag: "streambot-playlist-limit", env: "PLAYLIST_LIMIT" },
   },
 } as const;
+
+export const DYNAMIC_FLAG_NAMES = Object.entries(DEFINITION).map(
+  ([key, definition]) => prepareDefinition(key, definition).names.flag,
+);
 
 const REFRESH_INTERVAL_MS = 60_000;
 

--- a/packages/streambot/test/config-dynamic.test.ts
+++ b/packages/streambot/test/config-dynamic.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import {
+  DYNAMIC_FLAG_NAMES,
   initializeDynamicConfig,
   isDynamicConfigReady,
   playerCardEnabled,
@@ -23,6 +25,14 @@ afterEach(async () => {
 });
 
 describe("streambot dynamic config", () => {
+  test("covers exactly the Streambot entries in the managed inventory", () => {
+    const expected = managedFlagInventory.flags
+      .filter((flag) => flag.owner === "streambot")
+      .map((flag) => flag.key)
+      .sort();
+    expect([...DYNAMIC_FLAG_NAMES].sort()).toEqual(expected);
+  });
+
   test("returns the caller's value before initialization", () => {
     // No window where a toggle flips because config was not ready. The call
     // sites pass what they already had.

--- a/scripts/check-flipt-flag-inventory.ts
+++ b/scripts/check-flipt-flag-inventory.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import { managedFlagInventory } from "../packages/feature-flags/src/managed-flag-inventory.ts";
+
+const SegmentConstraintSchema = z.object({
+  property: z.string(),
+  value: z.string(),
+});
+
+const SegmentRolloutSchema = z.object({
+  type: z.literal("SEGMENT_ROLLOUT_TYPE"),
+  segment: z.object({
+    value: z.boolean(),
+    segments: z.array(
+      z.object({
+        key: z.string(),
+        constraints: z.array(SegmentConstraintSchema),
+      }),
+    ),
+  }),
+});
+
+const SnapshotFlagSchema = z.object({
+  key: z.string(),
+  enabled: z.boolean(),
+  type: z.enum(["BOOLEAN_FLAG_TYPE", "VARIANT_FLAG_TYPE"]),
+  rollouts: z.array(SegmentRolloutSchema),
+  defaultVariant: z.object({ key: z.string() }).optional(),
+});
+
+const SnapshotSchema = z.object({ flags: z.array(SnapshotFlagSchema) });
+
+function argument(name: string): string | undefined {
+  const index = Bun.argv.indexOf(name);
+  const value = Bun.argv[index + 1];
+  return index >= 0 && value !== undefined ? value : undefined;
+}
+
+function requiredUrl(): string {
+  const url = argument("--url") ?? Bun.env.FLIPT_URL;
+  if (url === undefined || url.length === 0) {
+    throw new Error(
+      "FLIPT_URL or --url is required; this operator-only check never guesses a Flipt endpoint",
+    );
+  }
+  return url.replace(/\/$/, "");
+}
+
+function normalizeRollouts(
+  rollouts: z.infer<typeof SegmentRolloutSchema>[],
+): { segmentKey: string; property: string; value: string; result: boolean }[] {
+  return rollouts.flatMap((rollout) =>
+    rollout.segment.segments.flatMap((segment) =>
+      segment.constraints.map((constraint) => ({
+        segmentKey: segment.key,
+        property: constraint.property,
+        value: constraint.value,
+        result: rollout.segment.value,
+      })),
+    ),
+  );
+}
+
+function expectedDefault(flag: (typeof managedFlagInventory.flags)[number]) {
+  return flag.default;
+}
+
+async function main(): Promise<void> {
+  const namespace =
+    argument("--namespace") ??
+    Bun.env.FLIPT_NAMESPACE ??
+    managedFlagInventory.namespace;
+  const environment =
+    argument("--environment") ??
+    Bun.env.FLIPT_ENVIRONMENT ??
+    managedFlagInventory.environment;
+  const url = requiredUrl();
+  const response = await fetch(
+    `${url}/internal/v1/evaluation/snapshot/namespace/${encodeURIComponent(namespace)}`,
+    {
+      headers: {
+        Accept: "application/json",
+        "x-flipt-accept-server-version": "1.47.0",
+        "x-flipt-environment": environment,
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Flipt snapshot request failed: ${response.status.toString()} ${response.statusText}`,
+    );
+  }
+
+  const snapshot = SnapshotSchema.parse(await response.json());
+  const expectedByKey = new Map(
+    managedFlagInventory.flags.map((flag) => [flag.key, flag]),
+  );
+  const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
+  const errors: string[] = [];
+
+  const expectedKeys = [...expectedByKey.keys()].sort();
+  const actualKeys = [...actualByKey.keys()].sort();
+  if (JSON.stringify(expectedKeys) !== JSON.stringify(actualKeys)) {
+    errors.push(
+      `key set mismatch: expected ${expectedKeys.length}, got ${actualKeys.length}; missing=${expectedKeys.filter((key) => !actualByKey.has(key)).join(",") || "none"}; unexpected=${actualKeys.filter((key) => !expectedByKey.has(key)).join(",") || "none"}`,
+    );
+  }
+
+  for (const expected of managedFlagInventory.flags) {
+    const actual = actualByKey.get(expected.key);
+    if (actual === undefined) continue;
+    const actualType =
+      actual.type === "BOOLEAN_FLAG_TYPE" ? "boolean" : "variant";
+    if (actualType !== expected.type) {
+      errors.push(
+        `${expected.key}: expected type ${expected.type}, got ${actualType}`,
+      );
+      continue;
+    }
+    const actualDefault =
+      expected.type === "boolean" ? actual.enabled : actual.defaultVariant?.key;
+    if (actualDefault !== expectedDefault(expected)) {
+      errors.push(
+        `${expected.key}: expected default ${JSON.stringify(expectedDefault(expected))}, got ${JSON.stringify(actualDefault)}`,
+      );
+    }
+    const actualRollouts = normalizeRollouts(actual.rollouts);
+    if (JSON.stringify(actualRollouts) !== JSON.stringify(expected.rollouts)) {
+      errors.push(
+        `${expected.key}: rollout contract mismatch; expected ${JSON.stringify(expected.rollouts)}, got ${JSON.stringify(actualRollouts)}`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Flipt managed-flag drift detected:\n- ${errors.join("\n- ")}`,
+    );
+  }
+  console.log(
+    `Flipt managed-flag inventory is aligned: ${expectedKeys.length.toString()} keys in ${namespace}/${environment}`,
+  );
+}
+
+await main();

--- a/scripts/check-flipt-flag-inventory.ts
+++ b/scripts/check-flipt-flag-inventory.ts
@@ -32,11 +32,11 @@ const SnapshotSchema = z.object({ flags: z.array(SnapshotFlagSchema) });
 function argument(name: string): string | undefined {
   const index = Bun.argv.indexOf(name);
   const value = Bun.argv[index + 1];
-  return index >= 0 && value !== undefined ? value : undefined;
+  return index !== -1 && value !== undefined ? value : undefined;
 }
 
 function requiredUrl(): string {
-  const url = argument("--url") ?? Bun.env.FLIPT_URL;
+  const url = argument("--url") ?? Bun.env["FLIPT_URL"];
   if (url === undefined || url.length === 0) {
     throw new Error(
       "FLIPT_URL or --url is required; this operator-only check never guesses a Flipt endpoint",
@@ -60,18 +60,72 @@ function normalizeRollouts(
   );
 }
 
-function expectedDefault(flag: (typeof managedFlagInventory.flags)[number]) {
-  return flag.default;
+type ManagedFlag = (typeof managedFlagInventory.flags)[number];
+type SnapshotFlag = z.infer<typeof SnapshotFlagSchema>;
+
+function keySetError(
+  expectedByKey: Map<string, ManagedFlag>,
+  actualByKey: Map<string, SnapshotFlag>,
+): string | undefined {
+  const expectedKeys = [...expectedByKey.keys()].sort();
+  const actualKeys = [...actualByKey.keys()].sort();
+  if (JSON.stringify(expectedKeys) === JSON.stringify(actualKeys)) {
+    return undefined;
+  }
+  const missing = expectedKeys.filter((key) => !actualByKey.has(key));
+  const unexpected = actualKeys.filter((key) => !expectedByKey.has(key));
+  return `key set mismatch: expected ${expectedKeys.length.toString()}, got ${actualKeys.length.toString()}; missing=${missing.join(",") || "none"}; unexpected=${unexpected.join(",") || "none"}`;
+}
+
+function flagErrors(expected: ManagedFlag, actual: SnapshotFlag): string[] {
+  const actualType =
+    actual.type === "BOOLEAN_FLAG_TYPE" ? "boolean" : "variant";
+  if (actualType !== expected.type) {
+    return [
+      `${expected.key}: expected type ${expected.type}, got ${actualType}`,
+    ];
+  }
+
+  const actualDefault =
+    expected.type === "boolean" ? actual.enabled : actual.defaultVariant?.key;
+  const errors: string[] = [];
+  if (actualDefault !== expected.default) {
+    errors.push(
+      `${expected.key}: expected default ${JSON.stringify(expected.default)}, got ${JSON.stringify(actualDefault)}`,
+    );
+  }
+  const actualRollouts = normalizeRollouts(actual.rollouts);
+  if (JSON.stringify(actualRollouts) !== JSON.stringify(expected.rollouts)) {
+    errors.push(
+      `${expected.key}: rollout contract mismatch; expected ${JSON.stringify(expected.rollouts)}, got ${JSON.stringify(actualRollouts)}`,
+    );
+  }
+  return errors;
+}
+
+function compareSnapshot(snapshot: z.infer<typeof SnapshotSchema>): string[] {
+  const expectedByKey = new Map(
+    managedFlagInventory.flags.map((flag) => [flag.key, flag]),
+  );
+  const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
+  const errors = keySetError(expectedByKey, actualByKey);
+  return [
+    ...(errors === undefined ? [] : [errors]),
+    ...managedFlagInventory.flags.flatMap((expected) => {
+      const actual = actualByKey.get(expected.key);
+      return actual === undefined ? [] : flagErrors(expected, actual);
+    }),
+  ];
 }
 
 async function main(): Promise<void> {
   const namespace =
     argument("--namespace") ??
-    Bun.env.FLIPT_NAMESPACE ??
+    Bun.env["FLIPT_NAMESPACE"] ??
     managedFlagInventory.namespace;
   const environment =
     argument("--environment") ??
-    Bun.env.FLIPT_ENVIRONMENT ??
+    Bun.env["FLIPT_ENVIRONMENT"] ??
     managedFlagInventory.environment;
   const url = requiredUrl();
   const response = await fetch(
@@ -91,53 +145,14 @@ async function main(): Promise<void> {
   }
 
   const snapshot = SnapshotSchema.parse(await response.json());
-  const expectedByKey = new Map(
-    managedFlagInventory.flags.map((flag) => [flag.key, flag]),
-  );
-  const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
-  const errors: string[] = [];
-
-  const expectedKeys = [...expectedByKey.keys()].sort();
-  const actualKeys = [...actualByKey.keys()].sort();
-  if (JSON.stringify(expectedKeys) !== JSON.stringify(actualKeys)) {
-    errors.push(
-      `key set mismatch: expected ${expectedKeys.length}, got ${actualKeys.length}; missing=${expectedKeys.filter((key) => !actualByKey.has(key)).join(",") || "none"}; unexpected=${actualKeys.filter((key) => !expectedByKey.has(key)).join(",") || "none"}`,
-    );
-  }
-
-  for (const expected of managedFlagInventory.flags) {
-    const actual = actualByKey.get(expected.key);
-    if (actual === undefined) continue;
-    const actualType =
-      actual.type === "BOOLEAN_FLAG_TYPE" ? "boolean" : "variant";
-    if (actualType !== expected.type) {
-      errors.push(
-        `${expected.key}: expected type ${expected.type}, got ${actualType}`,
-      );
-      continue;
-    }
-    const actualDefault =
-      expected.type === "boolean" ? actual.enabled : actual.defaultVariant?.key;
-    if (actualDefault !== expectedDefault(expected)) {
-      errors.push(
-        `${expected.key}: expected default ${JSON.stringify(expectedDefault(expected))}, got ${JSON.stringify(actualDefault)}`,
-      );
-    }
-    const actualRollouts = normalizeRollouts(actual.rollouts);
-    if (JSON.stringify(actualRollouts) !== JSON.stringify(expected.rollouts)) {
-      errors.push(
-        `${expected.key}: rollout contract mismatch; expected ${JSON.stringify(expected.rollouts)}, got ${JSON.stringify(actualRollouts)}`,
-      );
-    }
-  }
-
+  const errors = compareSnapshot(snapshot);
   if (errors.length > 0) {
     throw new Error(
       `Flipt managed-flag drift detected:\n- ${errors.join("\n- ")}`,
     );
   }
   console.log(
-    `Flipt managed-flag inventory is aligned: ${expectedKeys.length.toString()} keys in ${namespace}/${environment}`,
+    `Flipt managed-flag inventory is aligned: ${managedFlagInventory.flags.length.toString()} keys in ${namespace}/${environment}`,
   );
 }
 

--- a/scripts/check-flipt-flag-inventory.ts
+++ b/scripts/check-flipt-flag-inventory.ts
@@ -2,28 +2,56 @@ import { z } from "zod";
 import { managedFlagInventory } from "../packages/feature-flags/src/managed-flag-inventory.ts";
 
 const SegmentConstraintSchema = z.object({
-  property: z.string(),
+  type: z.string().min(1),
+  property: z.string().min(1),
+  operator: z.string().min(1),
   value: z.string(),
+});
+
+const SegmentSchema = z.object({
+  key: z.string().min(1),
+  matchType: z.string().min(1),
+  constraints: z.array(SegmentConstraintSchema),
 });
 
 const SegmentRolloutSchema = z.object({
   type: z.literal("SEGMENT_ROLLOUT_TYPE"),
+  rank: z.number().int().nonnegative(),
   segment: z.object({
     value: z.boolean(),
-    segments: z.array(
-      z.object({
-        key: z.string(),
-        constraints: z.array(SegmentConstraintSchema),
-      }),
-    ),
+    segmentOperator: z.string().min(1),
+    segments: z.array(SegmentSchema),
   }),
+});
+
+const ThresholdRolloutSchema = z.object({
+  type: z.literal("THRESHOLD_ROLLOUT_TYPE"),
+  rank: z.number().int().nonnegative(),
+  threshold: z.object({
+    percentage: z.number().min(0).max(100),
+    value: z.boolean(),
+  }),
+});
+
+const DistributionSchema = z.object({
+  variantKey: z.string().min(1),
+  variantAttachment: z.string(),
+  rollout: z.number().min(0).max(100),
+});
+
+const RuleSchema = z.object({
+  rank: z.number().int().nonnegative(),
+  segmentOperator: z.string().min(1),
+  segments: z.array(SegmentSchema),
+  distributions: z.array(DistributionSchema),
 });
 
 const SnapshotFlagSchema = z.object({
   key: z.string(),
   enabled: z.boolean(),
   type: z.enum(["BOOLEAN_FLAG_TYPE", "VARIANT_FLAG_TYPE"]),
-  rollouts: z.array(SegmentRolloutSchema),
+  rules: z.array(RuleSchema),
+  rollouts: z.array(z.union([SegmentRolloutSchema, ThresholdRolloutSchema])),
   defaultVariant: z.object({ key: z.string() }).optional(),
 });
 
@@ -45,23 +73,76 @@ function requiredUrl(): string {
   return url.replace(/\/$/, "");
 }
 
-function normalizeRollouts(
-  rollouts: z.infer<typeof SegmentRolloutSchema>[],
-): { segmentKey: string; property: string; value: string; result: boolean }[] {
-  return rollouts.flatMap((rollout) =>
-    rollout.segment.segments.flatMap((segment) =>
-      segment.constraints.map((constraint) => ({
-        segmentKey: segment.key,
-        property: constraint.property,
-        value: constraint.value,
-        result: rollout.segment.value,
-      })),
-    ),
-  );
-}
-
 type ManagedFlag = (typeof managedFlagInventory.flags)[number];
 type SnapshotFlag = z.infer<typeof SnapshotFlagSchema>;
+
+function normalizeConstraint(
+  constraint: z.infer<typeof SegmentConstraintSchema>,
+): ManagedFlag["rollouts"][number]["constraints"][number] {
+  return {
+    type: constraint.type,
+    property: constraint.property,
+    operator: constraint.operator,
+    value: constraint.value,
+  };
+}
+
+function normalizeSegments(
+  segments: z.infer<typeof SegmentSchema>[],
+): ManagedFlag["rules"][number]["segments"] {
+  return segments.map((segment) => ({
+    key: segment.key,
+    matchType: segment.matchType,
+    constraints: segment.constraints.map((constraint) =>
+      normalizeConstraint(constraint),
+    ),
+  }));
+}
+
+function normalizeRollouts(
+  rollouts: SnapshotFlag["rollouts"],
+): ManagedFlag["rollouts"] {
+  return rollouts.flatMap((rollout) => {
+    if (rollout.type !== "SEGMENT_ROLLOUT_TYPE") return [];
+    return rollout.segment.segments.map((segment) => ({
+      segmentKey: segment.key,
+      segmentOperator: rollout.segment.segmentOperator,
+      matchType: segment.matchType,
+      constraints: segment.constraints.map((constraint) =>
+        normalizeConstraint(constraint),
+      ),
+      result: rollout.segment.value,
+    }));
+  });
+}
+
+function normalizeThresholdRollouts(
+  rollouts: SnapshotFlag["rollouts"],
+): ManagedFlag["thresholdRollouts"] {
+  return rollouts.flatMap((rollout) => {
+    if (rollout.type !== "THRESHOLD_ROLLOUT_TYPE") return [];
+    return [
+      {
+        rank: rollout.rank,
+        percentage: rollout.threshold.percentage,
+        result: rollout.threshold.value,
+      },
+    ];
+  });
+}
+
+function normalizeRules(rules: SnapshotFlag["rules"]): ManagedFlag["rules"] {
+  return rules.map((rule) => ({
+    rank: rule.rank,
+    segmentOperator: rule.segmentOperator,
+    segments: normalizeSegments(rule.segments),
+    distributions: rule.distributions.map((distribution) => ({
+      variantKey: distribution.variantKey,
+      rollout: distribution.rollout,
+      variantAttachment: distribution.variantAttachment,
+    })),
+  }));
+}
 
 function keySetError(
   expectedByKey: Map<string, ManagedFlag>,
@@ -98,6 +179,21 @@ function flagErrors(expected: ManagedFlag, actual: SnapshotFlag): string[] {
   if (JSON.stringify(actualRollouts) !== JSON.stringify(expected.rollouts)) {
     errors.push(
       `${expected.key}: rollout contract mismatch; expected ${JSON.stringify(expected.rollouts)}, got ${JSON.stringify(actualRollouts)}`,
+    );
+  }
+  const actualThresholdRollouts = normalizeThresholdRollouts(actual.rollouts);
+  if (
+    JSON.stringify(actualThresholdRollouts) !==
+    JSON.stringify(expected.thresholdRollouts)
+  ) {
+    errors.push(
+      `${expected.key}: threshold rollout mismatch; expected ${JSON.stringify(expected.thresholdRollouts)}, got ${JSON.stringify(actualThresholdRollouts)}`,
+    );
+  }
+  const actualRules = normalizeRules(actual.rules);
+  if (JSON.stringify(actualRules) !== JSON.stringify(expected.rules)) {
+    errors.push(
+      `${expected.key}: variant rule mismatch; expected ${JSON.stringify(expected.rules)}, got ${JSON.stringify(actualRules)}`,
     );
   }
   return errors;


### PR DESCRIPTION
Why:\nKeep repository runtime declarations aligned with the live Flipt control plane while preserving fail-closed local registries and explicit non-runtime exemptions.\n\nWhat:\n- add the 53-key inventory, JSON Schema, source-alignment tests, and operator drift checker\n- register the nine missing Scout flags and variant controls\n- document the no-auth Flipt boundary and exemption policy\n\nVerification:\n- feature-flags Turbo typecheck, test, and lint passed\n- direct changed-surface tests passed for Scout, Birmel, Streambot, and Karma\n- live Flipt snapshot and evaluation checks passed for 53 keys\n- Flipt state survived a controlled pod restart\n- Scout beta refreshed; Scout prod refresh remains blocked by node memory capacity\n- full Scout Turbo typecheck/lint requires generated Prisma artifacts not present in this checkout\n\nLive rollout note:\nThe separately audited Flipt Git-backed state update is commit 1eccb4e22b6b7a9480e6a258c70901c4562cf3dd; it is not part of this repository diff.