### PR TITLE
fix(root): narrow test-manifest runner variants

### DIFF
--- a/scripts/check-test-standardization.test.ts
+++ b/scripts/check-test-standardization.test.ts
@@ -85,5 +85,14 @@ describe("test standardization guard", () => {
         },
       ]),
     ).toHaveLength(1);
+    expect(
+      manifestStepViolations("other-package", [
+        {
+          runner: "command",
+          name: "custom test suite",
+          command: ["bun", "run", "custom-test-suite"],
+        },
+      ]),
+    ).toEqual([]);
   });
 });

--- a/scripts/check-test-standardization.ts
+++ b/scripts/check-test-standardization.ts
@@ -17,6 +17,8 @@ type PackageManifest = {
   scripts?: Record<string, string> | undefined;
 };
 
+type VitestTestStep = Extract<TestStep, { runner: "vitest" }>;
+
 const RootPackageSchema = z.object({ workspaces: z.array(z.string()) });
 const PackageManifestSchema = z.object({
   name: z.string().optional(),
@@ -70,17 +72,7 @@ export function manifestStepViolations(
 ): string[] {
   const violations: string[] = [];
   for (const step of steps) {
-    if (
-      step.runner === "vitest" &&
-      step.runtime === "node" &&
-      (packageName !== "@shepherdjerred/temporal" ||
-        step.args?.length !== 4 ||
-        step.args[0] !== "src/workflows" ||
-        step.args[1] !== "--exclude" ||
-        step.args[2] !== "src/workflows/agent-task.test.ts" ||
-        step.args[3] !== "--no-file-parallelism" ||
-        step.runtimeReason === undefined)
-    ) {
+    if (isInvalidNodeHostedVitestStep(packageName, step)) {
       violations.push(
         `scripts/ci-test-manifest.json (${packageName}): Node-hosted Vitest is restricted to Temporal SDK workflow tests with an explicit reason`,
       );
@@ -96,6 +88,29 @@ export function manifestStepViolations(
     }
   }
   return violations;
+}
+
+function isInvalidNodeHostedVitestStep(
+  packageName: string,
+  step: TestStep,
+): boolean {
+  if (step.runner !== "vitest" || step.runtime !== "node") return false;
+  return !isExpectedTemporalWorkflowStep(packageName, step);
+}
+
+function isExpectedTemporalWorkflowStep(
+  packageName: string,
+  step: VitestTestStep,
+): boolean {
+  return (
+    packageName === "@shepherdjerred/temporal" &&
+    step.args?.length === 4 &&
+    step.args[0] === "src/workflows" &&
+    step.args[1] === "--exclude" &&
+    step.args[2] === "src/workflows/agent-task.test.ts" &&
+    step.args[3] === "--no-file-parallelism" &&
+    step.runtimeReason !== undefined
+  );
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
Why:
The test-standardization guard accepted command test steps but read Vitest-only arguments from the full runner union, breaking root-scripts typecheck on main.

What:
Narrow Node-hosted Vitest validation before reading its arguments and cover a valid command test step.

Verification:
- bun --no-install --bun vitest --config vitest.config.ts run scripts/check-test-standardization.test.ts
- cd scripts && bun run typecheck
- cd scripts && bun run lint