### PR TITLE
fix(scout-for-lol): complete safe Temporal cutover

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1441,8 +1441,8 @@
       "tokens": 81
     },
     "packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts|packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts": {
-      "clones": 2,
-      "tokens": 153
+      "clones": 1,
+      "tokens": 70
     },
     "packages/scout-for-lol/packages/data/src/model/competition.test.ts|packages/scout-for-lol/packages/data/src/model/competition.test.ts": {
       "clones": 14,
@@ -1945,5 +1945,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-26T03:29:21.520Z"
+  "updated": "2026-08-26T06:11:02.613Z"
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from "vitest";
 import {
+  BucksLedgerContextSchema,
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   LeaguePuuidSchema,
@@ -169,6 +170,7 @@ async function clearAll(): Promise<void> {
 
 async function makeMarket(input?: {
   criteria?: unknown;
+  yesProbabilityBps?: number;
   evaluatorVersion?: string;
   schemaVersion?: number;
   marketState?: "publishing" | "open" | "active";
@@ -208,7 +210,7 @@ async function makeMarket(input?: {
       criteria: JSON.stringify(input?.criteria ?? hitCriteria()),
       historySample: "[]",
       pricing: "{}",
-      yesProbabilityBps: 5000,
+      yesProbabilityBps: input?.yesProbabilityBps ?? 5000,
       promptVersion: "test",
       catalogVersion: "test",
       schemaVersion: input?.schemaVersion ?? 1,
@@ -440,6 +442,33 @@ describe("weekly parlay match eligibility", () => {
 });
 
 describe("weekly parlay ledger and settlement", () => {
+  test("accepts current weekly prices below the legacy ledger range", async () => {
+    const market = await makeMarket({
+      yesProbabilityBps: 2273,
+      schemaVersion: 2,
+      evaluatorVersion: "2",
+    });
+
+    await expect(place(market.id, "YES", 10)).resolves.toMatchObject({
+      kind: "placed",
+      grossPayout: 44,
+    });
+
+    const entries = await db.bucksLedgerEntry.findMany({
+      where: { weeklyParlayBetId: { not: null } },
+    });
+    expect(entries).toHaveLength(2);
+    expect(
+      entries.map((entry) =>
+        BucksLedgerContextSchema.parse(JSON.parse(entry.context)),
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ yesProbabilityBps: 2273 }),
+      ]),
+    );
+  });
+
   test("reprices top-ups and cancels for free with ledger conservation", async () => {
     const market = await makeMarket();
     await expect(place(market.id, "YES", 10)).resolves.toMatchObject({

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/competition/temporal-worker.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/competition/temporal-worker.ts
@@ -23,8 +23,9 @@ export function scoutCompetitionTaskQueue(
 
 /**
  * Start the stage-local activity worker used by the declarative Temporal
- * minute schedule. The core Temporal worker owns workflow execution; this
- * activity-only worker keeps database and Discord access inside Scout.
+ * minute schedule. Scout's embedded worker owns stage Workflow execution; this
+ * activity-only worker preserves the competition schedule contract while
+ * keeping database and Discord access inside Scout.
  */
 export async function startScoutCompetitionActivityWorker(): Promise<
   ScoutCompetitionActivityWorker | undefined

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -313,6 +313,13 @@ const MvpContextSchema = z.strictObject({
  * meaning of an existing one.
  */
 export type BucksLedgerContext = z.infer<typeof BucksLedgerContextSchema>;
+// Weekly v2 pricing uses a challenging 20–30% YES range. Keep the original
+// 40–60% range readable for v1 ledger entries because ledger history is
+// append-only and the context does not carry the weekly schema version.
+export const BucksWeeklyParlayYesProbabilityBpsSchema = z.union([
+  z.number().int().min(2000).max(3000),
+  z.number().int().min(4000).max(6000),
+]);
 export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
   z.strictObject({
     type: z.literal("seed"),
@@ -431,7 +438,7 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     periodKey: z.iso.date(),
     slot: z.number().int().nonnegative(),
     side: BucksParlaySideSchema,
-    yesProbabilityBps: z.number().int().min(4000).max(6000),
+    yesProbabilityBps: BucksWeeklyParlayYesProbabilityBpsSchema,
     totalStake: BucksStakeSchema,
     quotedGrossPayout: BucksStakeSchema,
   }),
@@ -442,7 +449,7 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     periodKey: z.iso.date(),
     slot: z.number().int().nonnegative(),
     side: BucksParlaySideSchema,
-    yesProbabilityBps: z.number().int().min(4000).max(6000),
+    yesProbabilityBps: BucksWeeklyParlayYesProbabilityBpsSchema,
     totalStake: BucksStakeSchema,
     totalReserve: z.number().int().nonnegative().max(BUCKS_INT32_MAX),
     quotedGrossPayout: BucksStakeSchema,

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -20,7 +20,7 @@
     "typecheck": "bun run scripts/ensure-ha-schema.ts && PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit",
     "lint": "bunx eslint --cache . && check-architecture",
     "test": "bun run scripts/ensure-ha-schema.ts && bun run test:bun && bun run test:workflows",
-    "test:bun": "bun --no-install --bun vitest --config ../../vitest.config.ts run src/activities src/event-bridge src/observability src/schedules src/shared src/lib src/workflows/agent-task.test.ts",
+    "test:bun": "bun --no-install --bun vitest --config ../../vitest.config.ts run src/activities src/event-bridge src/observability src/schedules src/shared src/lib src/workflows/agent-task.test.ts src/worker-config.test.ts",
     "test:workflows": "bun scripts/test-workflows.ts",
     "replay:scout-histories": "bun scripts/replay-scout-histories.ts",
     "replay:scout-histories:node": "node --experimental-strip-types scripts/replay-scout-histories-node.ts",

--- a/packages/temporal/src/activities/workflow-failure-history.ts
+++ b/packages/temporal/src/activities/workflow-failure-history.ts
@@ -19,6 +19,10 @@ const ProtobufLongSchema = z.object({
   high: z.number().int(),
   unsigned: z.boolean(),
 });
+const UnknownRecordSchema = z.object({}).catchall(z.unknown());
+const HistorySchema = z.object({
+  events: z.array(z.unknown()).optional(),
+});
 
 const TIMEOUT_CLASSIFICATIONS: Readonly<
   Record<string, WorkflowTimeoutClassification>
@@ -32,7 +36,7 @@ function eventRecord(event: unknown): Record<string, unknown> | undefined {
   if (typeof event !== "object" || event === null) {
     return undefined;
   }
-  return z.record(z.string(), z.unknown()).parse(event);
+  return UnknownRecordSchema.parse(event);
 }
 
 function eventId(value: unknown): string | undefined {
@@ -178,9 +182,7 @@ function historyEvents(history: unknown): readonly unknown[] {
   if (typeof history !== "object" || history === null) {
     return [];
   }
-  const record = z.record(z.string(), z.unknown()).parse(history);
-  const events = record["events"];
-  return Array.isArray(events) ? events : [];
+  return HistorySchema.parse(history).events ?? [];
 }
 
 function eventTypeName(value: unknown): string | undefined {

--- a/packages/temporal/src/activities/workflow-failure-watch.test.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch.test.ts
@@ -6,6 +6,7 @@ import {
   TimeoutFailure,
   TimeoutType,
 } from "@temporalio/common";
+import { historyFromJSON } from "@temporalio/common/lib/proto-utils.js";
 import type { AlertmanagerAlert, AlertPoster } from "#lib/alertmanager.ts";
 import { classifyWorkflowTimeoutHistory } from "./workflow-failure-history.ts";
 import {
@@ -148,6 +149,18 @@ function capturingPoster(): {
   return { poster, calls };
 }
 
+async function captureFirstFailureDescription(
+  client: WorkflowVisibilityClient,
+): Promise<string | undefined> {
+  const capture = capturingPoster();
+  await pollWorkflowFailuresOnce(client, capture.poster, {
+    now: NOW,
+    lookbackMs: LOOKBACK_MS,
+    ttlMs: TTL_MS,
+  });
+  return capture.calls.at(0)?.alerts.at(0)?.annotations["description"];
+}
+
 describe("buildVisibilityQuery", () => {
   it("filters to Failed/TimedOut closed after the lookback boundary", () => {
     const since = new Date("2026-07-30T17:45:00.000Z");
@@ -210,6 +223,59 @@ describe("workflow timeout history classification", () => {
     expect(calls[0]?.alerts[0]?.annotations["description"]).toContain(
       "no activity reached execution",
     );
+  });
+
+  it("classifies an SDK History instance without a parser error", async () => {
+    const history = historyFromJSON({
+      events: [
+        {
+          eventId: "1",
+          eventType: "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+          activityTaskScheduledEventAttributes: {
+            activityId: "activity-1",
+            activityType: { name: "someActivity" },
+            taskQueue: { name: "scout" },
+            workflowTaskCompletedEventId: "0",
+          },
+        },
+        {
+          eventId: "2",
+          eventType: "EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT",
+          activityTaskTimedOutEventAttributes: {
+            scheduledEventId: "1",
+            startedEventId: "0",
+            retryState: "RETRY_STATE_TIMEOUT",
+            failure: {
+              message: "activity dispatch timed out",
+              timeoutFailureInfo: {
+                timeoutType: "TIMEOUT_TYPE_SCHEDULE_TO_START",
+              },
+            },
+          },
+        },
+      ],
+    });
+    const client = fakeClient(
+      [
+        {
+          workflowId: "sdk-history-timeout",
+          runId: "run-timeout",
+          type: "agentTaskWorkflow",
+          taskQueue: "scout",
+          closeTime: new Date("2026-07-30T17:50:00.000Z"),
+          status: { name: "TIMED_OUT" },
+        },
+      ],
+      {
+        "sdk-history-timeout/run-timeout": () =>
+          rejectWithActivityTimeoutFailure(TimeoutType.SCHEDULE_TO_START),
+      },
+      { "sdk-history-timeout/run-timeout": history },
+    );
+    const description = await captureFirstFailureDescription(client);
+    expect(description).toContain("timeoutClassification activity");
+    expect(description).toContain("timeoutDispatchState pre-dispatch");
+    expect(description).not.toContain("historyError");
   });
 });
 

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -47,6 +47,21 @@ describe("Temporal worker role contracts", () => {
     ).toEqual([TASK_QUEUES.GLITTER_CORPUS, TASK_QUEUES.GLITTER_CONTEXT]);
   });
 
+  it("keeps embedded Scout Workflow queues out of central workers", () => {
+    expect(
+      getWorkerRoleContract("scout").workers.map(
+        (definition) => definition.taskQueue,
+      ),
+    ).toEqual([TASK_QUEUES.SCOUT]);
+    expect(
+      QUEUE_WORKER_DEFINITIONS.some(
+        (definition) =>
+          definition.taskQueue === TASK_QUEUES.SCOUT_BETA ||
+          definition.taskQueue === TASK_QUEUES.SCOUT_PROD,
+      ),
+    ).toBe(false);
+  });
+
   it("keeps gateway and event-bridge ownership explicit", () => {
     expect(getWorkerRoleContract("control")).toMatchObject({
       runsGateway: true,

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -77,20 +77,6 @@ export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
     maxConcurrentWorkflowTaskExecutions: 2,
   },
   {
-    role: "scout",
-    taskQueue: TASK_QUEUES.SCOUT_BETA,
-    activities: scoutActivities,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  },
-  {
-    role: "scout",
-    taskQueue: TASK_QUEUES.SCOUT_PROD,
-    activities: scoutActivities,
-    maxConcurrentActivityTaskExecutions: 1,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  },
-  {
     role: "agent",
     taskQueue: TASK_QUEUES.AGENT_TASK,
     activities: agentActivities,

--- a/scripts/pin-candidates-state.json
+++ b/scripts/pin-candidates-state.json
@@ -2,14 +2,14 @@
   "schema": "pin-candidates-state/v1",
   "pins": {
     "shepherdjerred/alert-dashboard": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:8947dbebf8e78b2834530fad3c5956bebf2d40ae57cc03e266b3db2001f472f0"
+      "digest": "sha256:8947dbebf8e78b2834530fad3c5956bebf2d40ae57cc03e266b3db2001f472f0",
+      "buildNumber": 11978
     },
     "shepherdjerred/birmel": {
-      "buildNumber": 11978,
-      "version": "2.0.0-11978",
-      "digest": "sha256:513d78a5797ed3b04fce2ff6c6a34bdf5592a66b9077597de271e3e5d265e729"
+      "buildNumber": 12064,
+      "version": "2.0.0-12064",
+      "digest": "sha256:9585b3d2ee36789c9dc01c772f27acdc9c0951bb598b7f68170dba115b0395e9"
     },
     "shepherdjerred/caddy-s3proxy": {
       "version": "2.0.0-10989",
@@ -17,14 +17,14 @@
       "buildNumber": 10989
     },
     "shepherdjerred/discord-plays-mario-kart": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:1b1e3d06e2f5cca0aafcc03786882d3adefa70e0f846f9a2e6bcaae32cfd78a3"
+      "digest": "sha256:1b1e3d06e2f5cca0aafcc03786882d3adefa70e0f846f9a2e6bcaae32cfd78a3",
+      "buildNumber": 11978
     },
     "shepherdjerred/discord-plays-pokemon": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:1566644a2a774dcc50fce166e00a1240cadc03ae7f6a4c4543be163fc3651c74"
+      "digest": "sha256:1566644a2a774dcc50fce166e00a1240cadc03ae7f6a4c4543be163fc3651c74",
+      "buildNumber": 11978
     },
     "shepherdjerred/obsidian-headless": {
       "version": "2.0.0-10760",
@@ -32,9 +32,9 @@
       "buildNumber": 10760
     },
     "shepherdjerred/openrouter-broadcast-ingest": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:651c4d7a32eee8432c855fbfdad4b0974a0b021cb1e781b7283bfb4c92d86d11"
+      "digest": "sha256:651c4d7a32eee8432c855fbfdad4b0974a0b021cb1e781b7283bfb4c92d86d11",
+      "buildNumber": 11978
     },
     "shepherdjerred/redlib": {
       "version": "2.0.0-11934",
@@ -42,39 +42,39 @@
       "buildNumber": 11934
     },
     "shepherdjerred/scout-evals": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:17bcb1a2bef8b69ede18d47f1ed712d8958aae794857f506494605a41741949d"
+      "digest": "sha256:17bcb1a2bef8b69ede18d47f1ed712d8958aae794857f506494605a41741949d",
+      "buildNumber": 11978
     },
     "shepherdjerred/scout-for-lol/beta": {
-      "buildNumber": 11978,
-      "version": "2.0.0-11978",
-      "digest": "sha256:c013e18a543e7036d48d056a7452df3038fe3bf9328f3dafc17f0ad8d8ed526a"
+      "buildNumber": 12064,
+      "version": "2.0.0-12064",
+      "digest": "sha256:0cbe9488a2d19a211a3b8c2c86a824fa78fce9db71ff74ac60d11ffabbc97687"
     },
     "shepherdjerred/starlight-karma-bot/beta": {
-      "buildNumber": 11978,
-      "version": "2.0.0-11978",
-      "digest": "sha256:cf9bade75e20ac5edc38e7ca87093599b0a7c9a92ffcf22eb49c1030fd362198"
+      "buildNumber": 12064,
+      "version": "2.0.0-12064",
+      "digest": "sha256:f276799eaa44730e6a0ac3b90ce0b4f12dc2ee5ef4b7f85a83c62314e424773a"
     },
     "shepherdjerred/streambot": {
-      "buildNumber": 11978,
-      "version": "2.0.0-11978",
-      "digest": "sha256:8a844214fad5c12a6f66b75e2c88655efa37376a9151b2a51734fb3de33e8399"
+      "buildNumber": 12064,
+      "version": "2.0.0-12064",
+      "digest": "sha256:eac7b450a90a53ab7bb2299fb7476ab32ad4381cabb70a1a49077b75ff8d3e49"
     },
     "shepherdjerred/tasknotes-server": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:3de8c4fb190299dfb642610193119811e6ced374be95c4fe363cfee0fc9432e9"
+      "digest": "sha256:3de8c4fb190299dfb642610193119811e6ced374be95c4fe363cfee0fc9432e9",
+      "buildNumber": 11978
     },
     "shepherdjerred/temporal-worker": {
-      "buildNumber": 11978,
-      "version": "2.0.0-11978",
-      "digest": "sha256:6baed459b7dffd78f988ccd0d3348e22c6eaf57b6d4a83b0fe387221b9b942b1"
+      "buildNumber": 12065,
+      "version": "2.0.0-12065",
+      "digest": "sha256:b60bc6a24001848784a677371e1ef8dc689879770f30245fb794ea7944aef9d9"
     },
     "shepherdjerred/trmnl-dashboard": {
-      "buildNumber": 11978,
       "version": "2.0.0-11978",
-      "digest": "sha256:14df41e46faaaa283203efe05e40cc51fd48e65f9c01b90d9c09346e7c82470d"
+      "digest": "sha256:14df41e46faaaa283203efe05e40cc51fd48e65f9c01b90d9c09346e7c82470d",
+      "buildNumber": 11978
     }
   }
 }

--- a/scripts/update-versions.test.ts
+++ b/scripts/update-versions.test.ts
@@ -258,6 +258,25 @@ describe("version catalog integrity", () => {
     ).toThrow("pin state drift");
   });
 
+  test("keeps the committed candidate state aligned with the committed catalog", async () => {
+    const [stateSource, catalogSourceText] = await Promise.all([
+      Bun.file(new URL("pin-candidates-state.json", import.meta.url)).text(),
+      Bun.file(
+        new URL(
+          "../packages/version-catalog/src/catalog.json",
+          import.meta.url,
+        ),
+      ).text(),
+    ]);
+
+    expect(() =>
+      validateStateAgainstVersions(
+        parsePinCandidatesState(stateSource),
+        parseVersionCatalogSource(catalogSourceText),
+      ),
+    ).not.toThrow();
+  });
+
   test("rejects duplicate source keys", () => {
     expect(() =>
       parseVersionCatalogSource(


### PR DESCRIPTION
## Why

The merged Scout-to-Temporal migration is not deployed. Main build 12151 built new images, but version commit-back failed after `pin-candidates-state.json` was rewound. Those candidates are also unsafe to deploy because the central Temporal worker can poll Scout stage Workflow queues with a bundle that does not contain Scout workflows.

Weekly parlay placement additionally rejects current persisted 20–30% prices, and timeout alerts fail to inspect Temporal SDK `History` instances.

## What

- accept both legacy 40–60% and current 20–30% weekly-parlay prices in the append-only Bryan Bucks ledger schema, with a persisted 2273-bps placement regression
- parse Temporal SDK History and HistoryEvent instances structurally, with a real `historyFromJSON` timeout-classification test
- make queue ownership explicit: the central Scout role polls only `scout`; embedded Scout backends own `scout-beta` and `scout-prod` workflows and their activity queues
- retain stage queue constants and the stage-local competition activity worker for compatibility
- include worker ownership coverage in the package's normal test command
- restore the complete pin-candidate state from the last catalog-consistent revision
- validate the committed candidate state against the committed version catalog during PR CI

This keeps the final cleanup architecture: no temporary feature flags or legacy schedulers are restored.

## Verification

- `bun install --frozen-lockfile`
- `bunx turbo run generate --filter=@scout-for-lol/backend --force`
- `bun test packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts` through the backend package command, which supplies its required preload
- `bun test packages/temporal/src/activities/workflow-failure-watch.test.ts packages/temporal/src/worker-config.test.ts`
- `bun test scripts/update-versions.test.ts`
- `bunx turbo run build typecheck lint test --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/temporal --filter=@shepherdjerred/temporal --filter=@shepherdjerred/root-scripts --output-logs=errors-only` (30/30 tasks)
- `bunx lefthook run pre-commit`

This is a non-visual logic and deployment-safety change; no media is required.

## Rollout

Do not deploy or reuse build 12151's candidates. Require an exact-head green PR build, then a fresh main build whose image push and version commit-back both pass.

Per owner direction, skip the normal 24-hour beta soak. Keep the beta-first cutover, four-queue canary, explicit poller ownership checks, Scout backlog drain, representative effect checks, and same-release production promotion. Pause schedules targeting `scout` before deployment and verify the new stage schedules remain paused. Resume schedules individually only after the backlog and queue ownership are understood.

The final weekly-parlay acceptance remains user-driven: the bot must not place a real bet on the user's behalf.