### PR TITLE
fix(homelab): remove migrated Home Assistant HTTP YAML

### DIFF
--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -189,10 +189,6 @@ homekit:
   # The Reolink integration and its entities remain available in HA for
   # dashboards and automations.
 
-http:
-  use_x_forwarded_for: true
-  trusted_proxies:
-    - 0.0.0.0/0
 sonos:
   media_player:
     advertise_addr: 192.168.1.81


### PR DESCRIPTION
## Why
Home Assistant now migrates HTTP integration settings to the UI and ignores the legacy YAML block, leaving a repair warning before upgrade.

## What
Remove the obsolete `http:` block from the Git-managed Home Assistant configuration. The migrated reverse-proxy settings remain UI-managed under Settings > System > Network.

## Verification
- `bun run build` from `packages/homelab/src/cdk8s`
- `bun run test` from `packages/homelab/src/cdk8s` (586 passed, 13 skipped)
- `git diff --check origin/main...HEAD`
- Live deployment not performed