### PR TITLE
feat(feature-flags): alert on managed Flipt inventory drift

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1894,6 +1894,7 @@
         "@scout-for-lol/temporal": "workspace:*",
         "@sentry/bun": "^10.70.0",
         "@shepherdjerred/code-review": "workspace:*",
+        "@shepherdjerred/feature-flags": "workspace:*",
         "@shepherdjerred/glitter-context": "workspace:*",
         "@shepherdjerred/home-assistant": "workspace:*",
         "@shepherdjerred/llm-models": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "verify": "bun scripts/verify.ts",
+    "check-flipt-flag-inventory": "bun scripts/check-flipt-flag-inventory.ts",
     "pr:fleet": "bunx turbo run build --filter=@shepherdjerred/pr-fleet-web && bun run --cwd packages/pr-fleet-controller start",
     "pr:fleet:inspect": "bun run --cwd packages/pr-fleet-controller inspect",
     "pr:fleet:replay": "bun run --cwd packages/pr-fleet-controller replay",

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -6,7 +6,9 @@ sidebar:
 ---
 
 Run the operator-only inventory check when you change Flipt state or need to
-diagnose runtime flag drift.
+diagnose runtime flag drift. A daily Temporal workflow performs the same
+key-set check and publishes a `FliptManagedFlagDrift` warning to Alertmanager;
+the alert resolves after a later verified aligned snapshot.
 
 ## 1. Set the endpoint
 
@@ -41,6 +43,11 @@ The check fails when Flipt differs from the inventory in any of these areas:
 
 Fix the repository inventory or the audited Flipt state, then run the command
 again until it reports alignment.
+
+The scheduled alert is read-only. It never deletes Flipt flags or edits the
+inventory. A failed snapshot request does not resolve an existing alert; the
+workflow fails so the Temporal failure watcher can report the unavailable
+check separately.
 
 :::caution
 Flipt has no authentication. Network reachability is the authorization

--- a/packages/feature-flags/src/managed-flag-drift.test.ts
+++ b/packages/feature-flags/src/managed-flag-drift.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "vitest";
+import fixture from "./providers/fixtures/flipt-snapshot.default.json" with { type: "json" };
+import { managedFlagInventory } from "./managed-flag-inventory.ts";
+import {
+  compareManagedFlagInventory,
+  fetchFliptSnapshot,
+  FliptSnapshotSchema,
+  formatManagedFlagDrift,
+  type FliptSnapshot,
+} from "./managed-flag-drift.ts";
+
+const fixtureSnapshot = FliptSnapshotSchema.parse({ flags: fixture.flags });
+
+const snapshot = FliptSnapshotSchema.parse({
+  flags: managedFlagInventory.flags.map((flag) => ({
+    key: flag.key,
+    enabled: flag.type === "boolean" ? flag.default : false,
+    type: flag.type === "boolean" ? "BOOLEAN_FLAG_TYPE" : "VARIANT_FLAG_TYPE",
+    rules: flag.rules,
+    rollouts: [
+      ...flag.rollouts.map((rollout, index) => ({
+        type: "SEGMENT_ROLLOUT_TYPE" as const,
+        rank: index,
+        segment: {
+          value: rollout.result,
+          segmentOperator: rollout.segmentOperator,
+          segments: [
+            {
+              key: rollout.segmentKey,
+              matchType: rollout.matchType,
+              constraints: rollout.constraints,
+            },
+          ],
+        },
+      })),
+      ...flag.thresholdRollouts.map((rollout) => ({
+        type: "THRESHOLD_ROLLOUT_TYPE" as const,
+        rank: rollout.rank,
+        threshold: {
+          percentage: rollout.percentage,
+          value: rollout.result,
+        },
+      })),
+    ],
+    ...(flag.type === "variant"
+      ? { defaultVariant: { key: flag.default } }
+      : {}),
+  })),
+});
+
+function flagAt(index: number): FliptSnapshot["flags"][number] {
+  const flag = snapshot.flags[index];
+  if (flag === undefined) {
+    throw new Error(`fixture flag ${index.toString()} is missing`);
+  }
+  return flag;
+}
+
+function withFlags(flags: FliptSnapshot["flags"]): FliptSnapshot {
+  return FliptSnapshotSchema.parse({ flags });
+}
+
+describe("managed Flipt flag drift", () => {
+  test("recognizes an aligned snapshot", () => {
+    expect(compareManagedFlagInventory(snapshot)).toEqual({
+      missingInFlipt: [],
+      undeclaredInInventory: [],
+      contractMismatches: [],
+    });
+  });
+
+  test("reports inventory keys missing from Flipt", () => {
+    const missing = snapshot.flags[0]?.key;
+    if (missing === undefined) throw new Error("aligned snapshot is empty");
+    const result = compareManagedFlagInventory(
+      withFlags(snapshot.flags.filter((flag) => flag.key !== missing)),
+    );
+
+    expect(result.missingInFlipt).toEqual([missing]);
+    expect(result.undeclaredInInventory).toEqual([]);
+  });
+
+  test("reports Flipt keys absent from the inventory", () => {
+    const unexpected = { ...flagAt(0), key: "unexpected-test-flag" };
+    const result = compareManagedFlagInventory(
+      withFlags([...snapshot.flags, unexpected]),
+    );
+
+    expect(result.missingInFlipt).toEqual([]);
+    expect(result.undeclaredInInventory).toEqual(["unexpected-test-flag"]);
+  });
+
+  test("reports both mismatch directions in deterministic order", () => {
+    const missing = snapshot.flags[0]?.key;
+    if (missing === undefined) throw new Error("aligned snapshot is empty");
+    const unexpectedKeys = ["zeta-test-flag", "alpha-test-flag"];
+    const result = compareManagedFlagInventory(
+      withFlags([
+        ...snapshot.flags.filter((flag) => flag.key !== missing),
+        ...unexpectedKeys.map((key) => ({ ...flagAt(0), key })),
+      ]),
+    );
+
+    expect(result.missingInFlipt).toEqual([missing]);
+    expect(result.undeclaredInInventory).toEqual(unexpectedKeys.toSorted());
+    expect(formatManagedFlagDrift(result)).toEqual([
+      `declared keys missing from Flipt: ${missing}`,
+      "Flipt keys absent from the inventory: alpha-test-flag,zeta-test-flag",
+    ]);
+  });
+
+  test("keeps contract mismatches separate from key membership drift", () => {
+    const changed = { ...flagAt(0), enabled: !flagAt(0).enabled };
+    const result = compareManagedFlagInventory(
+      withFlags([changed, ...snapshot.flags.slice(1)]),
+    );
+
+    expect(result.missingInFlipt).toEqual([]);
+    expect(result.undeclaredInInventory).toEqual([]);
+    expect(result.contractMismatches).toHaveLength(1);
+  });
+});
+
+describe("fetchFliptSnapshot", () => {
+  test("requests the configured namespace and environment", async () => {
+    let request:
+      | { input: string | Request | URL; init: RequestInit | undefined }
+      | undefined;
+    const result = await fetchFliptSnapshot({
+      url: "http://flipt.test/",
+      namespace: "custom namespace",
+      environment: "staging",
+      fetcher: async (input, init) => {
+        request = { input, init };
+        return Response.json(fixtureSnapshot, { status: 200 });
+      },
+    });
+
+    expect(result).toEqual(fixtureSnapshot);
+    expect(request?.input).toBe(
+      "http://flipt.test/internal/v1/evaluation/snapshot/namespace/custom%20namespace",
+    );
+    expect(request?.init?.headers).toEqual({
+      Accept: "application/json",
+      "x-flipt-accept-server-version": "1.47.0",
+      "x-flipt-environment": "staging",
+    });
+  });
+
+  test("fails on an unsuccessful response", async () => {
+    await expect(
+      fetchFliptSnapshot({
+        url: "http://flipt.test",
+        fetcher: async () =>
+          new Response("unavailable", {
+            status: 503,
+            statusText: "Service Unavailable",
+          }),
+      }),
+    ).rejects.toThrow("Flipt snapshot request failed: 503 Service Unavailable");
+  });
+
+  test("propagates connectivity failures", async () => {
+    await expect(
+      fetchFliptSnapshot({
+        url: "http://flipt.test",
+        fetcher: async () => {
+          throw new Error("connection refused");
+        },
+      }),
+    ).rejects.toThrow("connection refused");
+  });
+
+  test("fails on a malformed snapshot", async () => {
+    await expect(
+      fetchFliptSnapshot({
+        url: "http://flipt.test",
+        fetcher: async () =>
+          Response.json({ flags: [{ key: "broken" }] }, { status: 200 }),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/feature-flags/src/managed-flag-drift.ts
+++ b/packages/feature-flags/src/managed-flag-drift.ts
@@ -1,0 +1,252 @@
+import { z } from "zod";
+import {
+  managedFlagInventory,
+  type ManagedFlag,
+} from "./managed-flag-inventory.ts";
+
+const SegmentConstraintSchema = z.object({
+  type: z.string().min(1),
+  property: z.string().min(1),
+  operator: z.string().min(1),
+  value: z.string(),
+});
+
+const SegmentSchema = z.object({
+  key: z.string().min(1),
+  matchType: z.string().min(1),
+  constraints: z.array(SegmentConstraintSchema),
+});
+
+const SegmentRolloutSchema = z.object({
+  type: z.literal("SEGMENT_ROLLOUT_TYPE"),
+  rank: z.number().int().nonnegative(),
+  segment: z.object({
+    value: z.boolean(),
+    segmentOperator: z.string().min(1),
+    segments: z.array(SegmentSchema),
+  }),
+});
+
+const ThresholdRolloutSchema = z.object({
+  type: z.literal("THRESHOLD_ROLLOUT_TYPE"),
+  rank: z.number().int().nonnegative(),
+  threshold: z.object({
+    percentage: z.number().min(0).max(100),
+    value: z.boolean(),
+  }),
+});
+
+const DistributionSchema = z.object({
+  variantKey: z.string().min(1),
+  variantAttachment: z.string(),
+  rollout: z.number().min(0).max(100),
+});
+
+const RuleSchema = z.object({
+  rank: z.number().int().nonnegative(),
+  segmentOperator: z.string().min(1),
+  segments: z.array(SegmentSchema),
+  distributions: z.array(DistributionSchema),
+});
+
+const SnapshotFlagSchema = z.object({
+  key: z.string(),
+  enabled: z.boolean(),
+  type: z.enum(["BOOLEAN_FLAG_TYPE", "VARIANT_FLAG_TYPE"]),
+  rules: z.array(RuleSchema),
+  rollouts: z.array(z.union([SegmentRolloutSchema, ThresholdRolloutSchema])),
+  defaultVariant: z.object({ key: z.string() }).optional(),
+});
+
+export const FliptSnapshotSchema = z.object({
+  flags: z.array(SnapshotFlagSchema),
+});
+
+export type FliptSnapshot = z.infer<typeof FliptSnapshotSchema>;
+export type SnapshotFlag = z.infer<typeof SnapshotFlagSchema>;
+
+export type ManagedFlagDrift = {
+  readonly missingInFlipt: readonly string[];
+  readonly undeclaredInInventory: readonly string[];
+  readonly contractMismatches: readonly string[];
+};
+
+export type FliptFetcher = (
+  input: string | Request | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type FetchFliptSnapshotOptions = {
+  readonly url: string;
+  readonly namespace?: string;
+  readonly environment?: string;
+  readonly fetcher?: FliptFetcher;
+};
+
+function normalizeConstraint(
+  constraint: z.infer<typeof SegmentConstraintSchema>,
+): ManagedFlag["rollouts"][number]["constraints"][number] {
+  return {
+    type: constraint.type,
+    property: constraint.property,
+    operator: constraint.operator,
+    value: constraint.value,
+  };
+}
+
+function normalizeSegments(
+  segments: z.infer<typeof SegmentSchema>[],
+): ManagedFlag["rules"][number]["segments"] {
+  return segments.map((segment) => ({
+    key: segment.key,
+    matchType: segment.matchType,
+    constraints: segment.constraints.map((constraint) =>
+      normalizeConstraint(constraint),
+    ),
+  }));
+}
+
+function normalizeRollouts(
+  rollouts: SnapshotFlag["rollouts"],
+): ManagedFlag["rollouts"] {
+  return rollouts.flatMap((rollout) => {
+    if (rollout.type !== "SEGMENT_ROLLOUT_TYPE") return [];
+    return rollout.segment.segments.map((segment) => ({
+      segmentKey: segment.key,
+      segmentOperator: rollout.segment.segmentOperator,
+      matchType: segment.matchType,
+      constraints: segment.constraints.map((constraint) =>
+        normalizeConstraint(constraint),
+      ),
+      result: rollout.segment.value,
+    }));
+  });
+}
+
+function normalizeThresholdRollouts(
+  rollouts: SnapshotFlag["rollouts"],
+): ManagedFlag["thresholdRollouts"] {
+  return rollouts.flatMap((rollout) => {
+    if (rollout.type !== "THRESHOLD_ROLLOUT_TYPE") return [];
+    return [
+      {
+        rank: rollout.rank,
+        percentage: rollout.threshold.percentage,
+        result: rollout.threshold.value,
+      },
+    ];
+  });
+}
+
+function normalizeRules(rules: SnapshotFlag["rules"]): ManagedFlag["rules"] {
+  return rules.map((rule) => ({
+    rank: rule.rank,
+    segmentOperator: rule.segmentOperator,
+    segments: normalizeSegments(rule.segments),
+    distributions: rule.distributions.map((distribution) => ({
+      variantKey: distribution.variantKey,
+      rollout: distribution.rollout,
+      variantAttachment: distribution.variantAttachment,
+    })),
+  }));
+}
+
+function contractErrors(expected: ManagedFlag, actual: SnapshotFlag): string[] {
+  const actualType =
+    actual.type === "BOOLEAN_FLAG_TYPE" ? "boolean" : "variant";
+  if (actualType !== expected.type) {
+    return [
+      `${expected.key}: expected type ${expected.type}, got ${actualType}`,
+    ];
+  }
+
+  const actualDefault =
+    expected.type === "boolean" ? actual.enabled : actual.defaultVariant?.key;
+  const errors: string[] = [];
+  if (actualDefault !== expected.default) {
+    errors.push(
+      `${expected.key}: expected default ${JSON.stringify(expected.default)}, got ${JSON.stringify(actualDefault)}`,
+    );
+  }
+  const actualRollouts = normalizeRollouts(actual.rollouts);
+  if (JSON.stringify(actualRollouts) !== JSON.stringify(expected.rollouts)) {
+    errors.push(
+      `${expected.key}: rollout contract mismatch; expected ${JSON.stringify(expected.rollouts)}, got ${JSON.stringify(actualRollouts)}`,
+    );
+  }
+  const actualThresholdRollouts = normalizeThresholdRollouts(actual.rollouts);
+  if (
+    JSON.stringify(actualThresholdRollouts) !==
+    JSON.stringify(expected.thresholdRollouts)
+  ) {
+    errors.push(
+      `${expected.key}: threshold rollout mismatch; expected ${JSON.stringify(expected.thresholdRollouts)}, got ${JSON.stringify(actualThresholdRollouts)}`,
+    );
+  }
+  const actualRules = normalizeRules(actual.rules);
+  if (JSON.stringify(actualRules) !== JSON.stringify(expected.rules)) {
+    errors.push(
+      `${expected.key}: variant rule mismatch; expected ${JSON.stringify(expected.rules)}, got ${JSON.stringify(actualRules)}`,
+    );
+  }
+  return errors;
+}
+
+export function compareManagedFlagInventory(
+  snapshot: FliptSnapshot,
+): ManagedFlagDrift {
+  const expectedByKey = new Map(
+    managedFlagInventory.flags.map((flag) => [flag.key, flag]),
+  );
+  const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
+  const expectedKeys = [...expectedByKey.keys()].sort();
+  const actualKeys = [...actualByKey.keys()].sort();
+
+  return {
+    missingInFlipt: expectedKeys.filter((key) => !actualByKey.has(key)),
+    undeclaredInInventory: actualKeys.filter((key) => !expectedByKey.has(key)),
+    contractMismatches: managedFlagInventory.flags.flatMap((expected) => {
+      const actual = actualByKey.get(expected.key);
+      return actual === undefined ? [] : contractErrors(expected, actual);
+    }),
+  };
+}
+
+export function formatManagedFlagDrift(drift: ManagedFlagDrift): string[] {
+  return [
+    ...(drift.missingInFlipt.length === 0
+      ? []
+      : [
+          `declared keys missing from Flipt: ${drift.missingInFlipt.join(",")}`,
+        ]),
+    ...(drift.undeclaredInInventory.length === 0
+      ? []
+      : [
+          `Flipt keys absent from the inventory: ${drift.undeclaredInInventory.join(",")}`,
+        ]),
+    ...drift.contractMismatches,
+  ];
+}
+
+export async function fetchFliptSnapshot(
+  options: FetchFliptSnapshotOptions,
+): Promise<FliptSnapshot> {
+  const namespace = options.namespace ?? managedFlagInventory.namespace;
+  const environment = options.environment ?? managedFlagInventory.environment;
+  const url = `${options.url.replace(/\/$/u, "")}/internal/v1/evaluation/snapshot/namespace/${encodeURIComponent(namespace)}`;
+  const fetcher: FliptFetcher =
+    options.fetcher ?? ((input, init) => fetch(input, init));
+  const response = await fetcher(url, {
+    headers: {
+      Accept: "application/json",
+      "x-flipt-accept-server-version": "1.47.0",
+      "x-flipt-environment": environment,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Flipt snapshot request failed: ${response.status.toString()} ${response.statusText}`,
+    );
+  }
+  return FliptSnapshotSchema.parse(await response.json());
+}

--- a/packages/feature-flags/src/managed-flag-inventory.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.ts
@@ -66,6 +66,8 @@ const ManagedFlagSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
+export type ManagedFlag = z.infer<typeof ManagedFlagSchema>;
+
 export const ManagedFlagInventorySchema = z
   .object({
     version: z.literal(1),

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts
@@ -24,6 +24,7 @@ const CONSUMER_NAMESPACES = [
   "scout-beta",
   "scout-prod",
   "birmel",
+  "temporal",
   // streambot is deployed inside the `media` chart, not its own namespace.
   "media",
 ] as const;

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -145,4 +145,28 @@ describe("Flipt chart", () => {
     // and update checks and telemetry are off, so nothing else is legitimate.
     expect(policy.spec.egress).toHaveLength(1);
   });
+
+  it("allows the Temporal repo worker to read the managed snapshot", () => {
+    const policy = z
+      .object({
+        spec: z.object({
+          ingress: z.array(z.unknown()),
+        }),
+      })
+      .loose()
+      .parse(
+        findManifest(synthesize(), "NetworkPolicy", "flipt-ingress-netpol"),
+      );
+    expect(policy.spec.ingress).toContainEqual(
+      expect.objectContaining({
+        from: expect.arrayContaining([
+          {
+            namespaceSelector: {
+              matchLabels: { "kubernetes.io/metadata.name": "temporal" },
+            },
+          },
+        ]),
+      }),
+    );
+  });
 });

--- a/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
@@ -162,6 +162,9 @@ export function createTemporalOperationsWorkers(
       ALERTMANAGER_URL: EnvValue.fromValue(
         "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
       ),
+      FLIPT_URL: EnvValue.fromValue(
+        "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
+      ),
       FRESHRSS_API_URL: EnvValue.fromValue(
         "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
       ),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
@@ -158,6 +158,26 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
     },
   });
 
+  new KubeNetworkPolicy(chart, "temporal-repo-flipt-netpol", {
+    metadata: { name: "temporal-repo-flipt-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "repo-worker" } },
+      policyTypes: ["Egress"],
+      egress: [
+        {
+          to: [
+            {
+              namespaceSelector: {
+                matchLabels: { "kubernetes.io/metadata.name": "flipt" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(8080), protocol: "TCP" }],
+        },
+      ],
+    },
+  });
+
   new KubeNetworkPolicy(chart, "temporal-infra-api-netpol", {
     metadata: { name: "temporal-infra-api-netpol" },
     spec: {

--- a/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-freshrss.test.ts
@@ -111,6 +111,10 @@ describe("Temporal FreshRSS integration", () => {
       name: "FRESHRSS_API_PASSWORD_FILE",
       value: "/run/secrets/freshrss/password",
     });
+    expect(container.env).toContainEqual({
+      name: "FLIPT_URL",
+      value: "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
+    });
     expect(container.volumeMounts).toContainEqual(
       expect.objectContaining({
         mountPath: "/etc/freshrss",
@@ -184,6 +188,33 @@ describe("Temporal FreshRSS integration", () => {
     });
     expect(alertmanagerPolicySpec.egress).toContainEqual({
       ports: [{ port: 9093, protocol: "TCP" }],
+    });
+
+    const fliptPolicy = findResource(
+      synthesized,
+      "NetworkPolicy",
+      "temporal-repo-flipt-netpol",
+    );
+    const fliptPolicySpec = z
+      .object({
+        podSelector: z.object({
+          matchLabels: z.record(z.string(), z.string()),
+        }),
+        egress: z.array(z.unknown()),
+      })
+      .parse(fliptPolicy.spec);
+    expect(fliptPolicySpec.podSelector.matchLabels).toEqual({
+      component: "repo-worker",
+    });
+    expect(fliptPolicySpec.egress).toContainEqual({
+      ports: [{ port: 8080, protocol: "TCP" }],
+      to: [
+        {
+          namespaceSelector: {
+            matchLabels: { "kubernetes.io/metadata.name": "flipt" },
+          },
+        },
+      ],
     });
   });
 });

--- a/packages/temporal/Dockerfile
+++ b/packages/temporal/Dockerfile
@@ -48,6 +48,7 @@ COPY --parents \
   tsconfig.base.json \
   packages/scout-for-lol/tsconfig.base.json \
   packages/temporal \
+  packages/feature-flags \
   packages/code-review \
   packages/glitter-context \
   packages/llm-models \
@@ -368,6 +369,7 @@ COPY --from=prod-deps /app/ /app/
 COPY --parents \
   tsconfig.base.json \
   packages/temporal \
+  packages/feature-flags \
   packages/code-review \
   packages/glitter-context \
   packages/home-assistant \

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -64,6 +64,7 @@
     "@shepherdjerred/llm-runtime": "workspace:*",
     "@scout-for-lol/data": "workspace:*",
     "@scout-for-lol/temporal": "workspace:*",
+    "@shepherdjerred/feature-flags": "workspace:*",
     "@temporalio/activity": "1.22.0",
     "@temporalio/client": "1.22.0",
     "@temporalio/common": "1.22.0",

--- a/packages/temporal/src/activities/flipt-flag-inventory.ts
+++ b/packages/temporal/src/activities/flipt-flag-inventory.ts
@@ -1,0 +1,46 @@
+import { createAlertmanagerPoster } from "#lib/alertmanager.ts";
+import {
+  compareManagedFlagInventory,
+  fetchFliptSnapshot,
+} from "@shepherdjerred/feature-flags/managed-flag-drift.ts";
+import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
+import {
+  buildFliptFlagDriftAlert,
+  type FliptFlagDriftAlertInput,
+} from "#shared/flipt-flag-drift-alert.ts";
+
+export type FliptFlagInventoryResult = FliptFlagDriftAlertInput & {
+  readonly observedAt: string;
+};
+
+function requiredEnvironment(name: string): string {
+  const value = Bun.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required for the Flipt inventory check`);
+  }
+  return value;
+}
+
+export type FliptFlagInventoryActivities = typeof fliptFlagInventoryActivities;
+
+export const fliptFlagInventoryActivities = {
+  async checkFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
+    const snapshot = await fetchFliptSnapshot({
+      url: requiredEnvironment("FLIPT_URL"),
+      namespace: managedFlagInventory.namespace,
+      environment: managedFlagInventory.environment,
+    });
+    const drift = compareManagedFlagInventory(snapshot);
+    const result: FliptFlagInventoryResult = {
+      namespace: managedFlagInventory.namespace,
+      environment: managedFlagInventory.environment,
+      missingInFlipt: drift.missingInFlipt,
+      undeclaredInInventory: drift.undeclaredInInventory,
+      observedAt: new Date().toISOString(),
+    };
+    await createAlertmanagerPoster(requiredEnvironment("ALERTMANAGER_URL"))([
+      buildFliptFlagDriftAlert(result, new Date()),
+    ]);
+    return result;
+  },
+};

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -43,6 +43,7 @@ import { ciIoImpactActivities } from "./ci-io-impact.ts";
 import { freshrssActivities } from "./freshrss.ts";
 import { scoutWeeklyParlayActivities } from "./scout-weekly-parlay.ts";
 import { scoutBryanBucksActivities } from "./scout-bryan-bucks.ts";
+import { fliptFlagInventoryActivities } from "./flipt-flag-inventory.ts";
 
 export const homeActivities = {
   ...haActivities,
@@ -85,6 +86,7 @@ export const repoActivities = {
   ...observeReviewSignalsActivities,
   ...protobufWatchActivities,
   ...freshrssActivities,
+  ...fliptFlagInventoryActivities,
 };
 
 export const scoutActivities = {

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -118,6 +118,21 @@ test("FreshRSS sync keeps its bounded pre-refresh schedule", () => {
   expect(schedule.workflowExecutionTimeout).toBe("6 minutes");
 });
 
+test("Flipt inventory drift runs daily on the repo automation queue", () => {
+  expect(findScheduleById("flipt-flag-inventory-daily")).toMatchObject({
+    workflowType: "runFliptFlagInventory",
+    args: [],
+    timing: {
+      kind: "cron",
+      expression: "15 6 * * *",
+      timezone: "America/Los_Angeles",
+    },
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "15 minutes",
+  });
+});
+
 test("protobuf watch timeout covers collection and both delivery paths", () => {
   const timeout = findScheduleById(
     "protobufjs-v8-watch-weekly",
@@ -193,6 +208,7 @@ const WORKFLOWS_WITHOUT_EXECUTION_TIMEOUT = new Set([
 const WORKFLOWS_WITHOUT_LONG_SLEEPS = new Set([
   "fetchSkillCappedManifest",
   "runFreshRssSyncWorkflow",
+  "runFliptFlagInventory",
   // These workflows await one direct maintenance activity; the activity
   // timeout and retry policy are the relevant execution budget.
   "runBunCacheGcWorkflow",

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -47,6 +47,20 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     memo: "Hourly FreshRSS Repo Stack reconciliation before feed refresh",
   },
   {
+    id: "flipt-flag-inventory-daily",
+    workflowType: "runFliptFlagInventory",
+    args: [],
+    timing: {
+      kind: "cron",
+      expression: "15 6 * * *",
+      timezone: "America/Los_Angeles",
+    },
+    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "15 minutes",
+    memo: "Daily Flipt managed-flag inventory drift check with Alertmanager fire/resolve",
+  },
+  {
     id: "buildkite-bun-cache-gc",
     workflowType: "runBunCacheGcWorkflow",
     args: [],

--- a/packages/temporal/src/shared/flipt-flag-drift-alert.test.ts
+++ b/packages/temporal/src/shared/flipt-flag-drift-alert.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildFliptFlagDriftAlert,
+  FLIPT_FLAG_DRIFT_ALERT_TTL_MS,
+} from "#shared/flipt-flag-drift-alert.ts";
+
+const NOW = new Date("2026-08-28T15:00:00.000Z");
+
+describe("buildFliptFlagDriftAlert", () => {
+  test("fires one stable alert containing both mismatch directions", () => {
+    const alert = buildFliptFlagDriftAlert(
+      {
+        namespace: "default",
+        environment: "default",
+        missingInFlipt: ["declared-flag"],
+        undeclaredInInventory: ["manual-flag"],
+      },
+      NOW,
+    );
+
+    expect(alert.labels).toEqual({
+      alertname: "FliptManagedFlagDrift",
+      severity: "warning",
+      component: "feature-flags",
+      namespace: "default",
+      environment: "default",
+    });
+    expect(alert.annotations["description"]).toContain(
+      "Declared keys missing from Flipt: declared-flag",
+    );
+    expect(alert.annotations["description"]).toContain(
+      "Flipt keys absent from the inventory: manual-flag",
+    );
+    expect(alert.endsAt).toBe(
+      new Date(NOW.getTime() + FLIPT_FLAG_DRIFT_ALERT_TTL_MS).toISOString(),
+    );
+  });
+
+  test("resolves with the exact same labels when aligned", () => {
+    const firing = buildFliptFlagDriftAlert(
+      {
+        namespace: "default",
+        environment: "default",
+        missingInFlipt: ["declared-flag"],
+        undeclaredInInventory: [],
+      },
+      NOW,
+    );
+    const alert = buildFliptFlagDriftAlert(
+      {
+        namespace: "default",
+        environment: "default",
+        missingInFlipt: [],
+        undeclaredInInventory: [],
+      },
+      NOW,
+    );
+
+    expect(alert.labels).toEqual(firing.labels);
+    expect(alert.endsAt).toBe(alert.startsAt);
+    expect(alert.annotations["summary"]).toContain("aligned");
+  });
+});

--- a/packages/temporal/src/shared/flipt-flag-drift-alert.ts
+++ b/packages/temporal/src/shared/flipt-flag-drift-alert.ts
@@ -1,0 +1,49 @@
+import type { AlertmanagerAlert } from "#lib/alertmanager.ts";
+
+export const FLIPT_FLAG_DRIFT_ALERT_TTL_MS = 2 * 24 * 60 * 60 * 1000;
+
+export type FliptFlagDriftAlertInput = {
+  readonly namespace: string;
+  readonly environment: string;
+  readonly missingInFlipt: readonly string[];
+  readonly undeclaredInInventory: readonly string[];
+};
+
+function formatKeys(keys: readonly string[]): string {
+  return keys.length === 0 ? "none" : keys.join(", ");
+}
+
+export function buildFliptFlagDriftAlert(
+  input: FliptFlagDriftAlertInput,
+  now: Date,
+): AlertmanagerAlert {
+  const hasDrift =
+    input.missingInFlipt.length > 0 || input.undeclaredInInventory.length > 0;
+  const startsAt = now.toISOString();
+  const summary = hasDrift
+    ? `Flipt managed flag inventory drift in ${input.namespace}/${input.environment}`
+    : `Flipt managed flag inventory aligned in ${input.namespace}/${input.environment}`;
+  const description = hasDrift
+    ? [
+        `The repository inventory and Flipt differ in ${input.namespace}/${input.environment}.`,
+        `Declared keys missing from Flipt: ${formatKeys(input.missingInFlipt)}`,
+        `Flipt keys absent from the inventory: ${formatKeys(input.undeclaredInInventory)}`,
+        "Reconcile the reviewed inventory and Flipt state, then run the operator check again.",
+      ].join("\n")
+    : `The repository inventory and Flipt are aligned in ${input.namespace}/${input.environment}.`;
+
+  return {
+    labels: {
+      alertname: "FliptManagedFlagDrift",
+      severity: "warning",
+      component: "feature-flags",
+      namespace: input.namespace,
+      environment: input.environment,
+    },
+    annotations: { summary, description, message: description },
+    startsAt,
+    endsAt: new Date(
+      now.getTime() + (hasDrift ? FLIPT_FLAG_DRIFT_ALERT_TTL_MS : 0),
+    ).toISOString(),
+  };
+}

--- a/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
+++ b/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { runFliptFlagInventory } from "./flipt-flag-inventory.ts";
+import { Worker } from "@temporalio/worker";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+
+describe("runFliptFlagInventory", () => {
+  test("routes the check to the repo automation queue", async () => {
+    const environment = await TestWorkflowEnvironment.createTimeSkipping();
+    const observed: unknown[] = [];
+    const worker = await Worker.create({
+      connection: environment.nativeConnection,
+      taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        checkFliptFlagInventory: async () => {
+          const result = {
+            namespace: "default",
+            environment: "default",
+            missingInFlipt: [],
+            undeclaredInInventory: [],
+            observedAt: "2026-08-28T15:00:00.000Z",
+          };
+          observed.push(result);
+          return result;
+        },
+      },
+    });
+
+    const execution = environment.client.workflow.execute(
+      runFliptFlagInventory,
+      {
+        args: [],
+        taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+        workflowId: `test-flipt-flag-inventory-${crypto.randomUUID()}`,
+      },
+    );
+    try {
+      await worker.runUntil(execution);
+      expect(observed).toHaveLength(1);
+    } finally {
+      await environment.teardown();
+    }
+  }, 60_000);
+
+  test("propagates an inventory check failure", async () => {
+    const environment = await TestWorkflowEnvironment.createTimeSkipping();
+    const worker = await Worker.create({
+      connection: environment.nativeConnection,
+      taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        checkFliptFlagInventory: async () => {
+          throw new Error("Flipt snapshot unavailable");
+        },
+      },
+    });
+
+    const execution = environment.client.workflow.execute(
+      runFliptFlagInventory,
+      {
+        args: [],
+        taskQueue: TASK_QUEUES.REPO_AUTOMATION,
+        workflowId: `test-flipt-flag-inventory-failure-${crypto.randomUUID()}`,
+      },
+    );
+    try {
+      await expect(worker.runUntil(execution)).rejects.toThrow(
+        "Workflow execution failed",
+      );
+    } finally {
+      await environment.teardown();
+    }
+  }, 60_000);
+});

--- a/packages/temporal/src/workflows/flipt-flag-inventory.ts
+++ b/packages/temporal/src/workflows/flipt-flag-inventory.ts
@@ -1,0 +1,20 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type {
+  FliptFlagInventoryActivities,
+  FliptFlagInventoryResult,
+} from "#activities/flipt-flag-inventory.ts";
+
+const { checkFliptFlagInventory } =
+  proxyActivities<FliptFlagInventoryActivities>({
+    startToCloseTimeout: "2 minutes",
+    retry: {
+      maximumAttempts: 3,
+      initialInterval: "1 minute",
+      backoffCoefficient: 2,
+      maximumInterval: "5 minutes",
+    },
+  });
+
+export async function runFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
+  return await checkFliptFlagInventory();
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -117,6 +117,8 @@ import {
   runTurboCacheCleanWorkflow as runTurboCacheCleanWorkflowImplementation,
 } from "./maintenance.ts";
 import { runFreshRssSyncWorkflow as _runFreshRssSyncWorkflow } from "./freshrss.ts";
+import { runFliptFlagInventory as _runFliptFlagInventory } from "./flipt-flag-inventory.ts";
+import type { FliptFlagInventoryResult } from "#activities/flipt-flag-inventory.ts";
 
 export async function fetchSkillCappedManifest(): Promise<void> {
   return _fetchSkillCappedManifest();
@@ -152,6 +154,10 @@ export async function runTurboCacheCleanWorkflow(): Promise<void> {
 
 export async function runFreshRssSyncWorkflow(): Promise<void> {
   return _runFreshRssSyncWorkflow();
+}
+
+export async function runFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
+  return _runFliptFlagInventory();
 }
 
 export async function generateDependencySummary(

--- a/packages/temporal/tsconfig.json
+++ b/packages/temporal/tsconfig.json
@@ -6,8 +6,8 @@
   ],
   "compilerOptions": {
     "types": ["@types/bun"],
-    "moduleResolution": "Node16",
-    "module": "Node16",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
     "target": "ES2022",
     "noEmit": true,
     "allowImportingTsExtensions": true,

--- a/scripts/check-flipt-flag-inventory.ts
+++ b/scripts/check-flipt-flag-inventory.ts
@@ -1,61 +1,9 @@
-import { z } from "zod";
+import {
+  compareManagedFlagInventory,
+  fetchFliptSnapshot,
+  formatManagedFlagDrift,
+} from "../packages/feature-flags/src/managed-flag-drift.ts";
 import { managedFlagInventory } from "../packages/feature-flags/src/managed-flag-inventory.ts";
-
-const SegmentConstraintSchema = z.object({
-  type: z.string().min(1),
-  property: z.string().min(1),
-  operator: z.string().min(1),
-  value: z.string(),
-});
-
-const SegmentSchema = z.object({
-  key: z.string().min(1),
-  matchType: z.string().min(1),
-  constraints: z.array(SegmentConstraintSchema),
-});
-
-const SegmentRolloutSchema = z.object({
-  type: z.literal("SEGMENT_ROLLOUT_TYPE"),
-  rank: z.number().int().nonnegative(),
-  segment: z.object({
-    value: z.boolean(),
-    segmentOperator: z.string().min(1),
-    segments: z.array(SegmentSchema),
-  }),
-});
-
-const ThresholdRolloutSchema = z.object({
-  type: z.literal("THRESHOLD_ROLLOUT_TYPE"),
-  rank: z.number().int().nonnegative(),
-  threshold: z.object({
-    percentage: z.number().min(0).max(100),
-    value: z.boolean(),
-  }),
-});
-
-const DistributionSchema = z.object({
-  variantKey: z.string().min(1),
-  variantAttachment: z.string(),
-  rollout: z.number().min(0).max(100),
-});
-
-const RuleSchema = z.object({
-  rank: z.number().int().nonnegative(),
-  segmentOperator: z.string().min(1),
-  segments: z.array(SegmentSchema),
-  distributions: z.array(DistributionSchema),
-});
-
-const SnapshotFlagSchema = z.object({
-  key: z.string(),
-  enabled: z.boolean(),
-  type: z.enum(["BOOLEAN_FLAG_TYPE", "VARIANT_FLAG_TYPE"]),
-  rules: z.array(RuleSchema),
-  rollouts: z.array(z.union([SegmentRolloutSchema, ThresholdRolloutSchema])),
-  defaultVariant: z.object({ key: z.string() }).optional(),
-});
-
-const SnapshotSchema = z.object({ flags: z.array(SnapshotFlagSchema) });
 
 function argument(name: string): string | undefined {
   const index = Bun.argv.indexOf(name);
@@ -73,147 +21,6 @@ function requiredUrl(): string {
   return url.replace(/\/$/, "");
 }
 
-type ManagedFlag = (typeof managedFlagInventory.flags)[number];
-type SnapshotFlag = z.infer<typeof SnapshotFlagSchema>;
-
-function normalizeConstraint(
-  constraint: z.infer<typeof SegmentConstraintSchema>,
-): ManagedFlag["rollouts"][number]["constraints"][number] {
-  return {
-    type: constraint.type,
-    property: constraint.property,
-    operator: constraint.operator,
-    value: constraint.value,
-  };
-}
-
-function normalizeSegments(
-  segments: z.infer<typeof SegmentSchema>[],
-): ManagedFlag["rules"][number]["segments"] {
-  return segments.map((segment) => ({
-    key: segment.key,
-    matchType: segment.matchType,
-    constraints: segment.constraints.map((constraint) =>
-      normalizeConstraint(constraint),
-    ),
-  }));
-}
-
-function normalizeRollouts(
-  rollouts: SnapshotFlag["rollouts"],
-): ManagedFlag["rollouts"] {
-  return rollouts.flatMap((rollout) => {
-    if (rollout.type !== "SEGMENT_ROLLOUT_TYPE") return [];
-    return rollout.segment.segments.map((segment) => ({
-      segmentKey: segment.key,
-      segmentOperator: rollout.segment.segmentOperator,
-      matchType: segment.matchType,
-      constraints: segment.constraints.map((constraint) =>
-        normalizeConstraint(constraint),
-      ),
-      result: rollout.segment.value,
-    }));
-  });
-}
-
-function normalizeThresholdRollouts(
-  rollouts: SnapshotFlag["rollouts"],
-): ManagedFlag["thresholdRollouts"] {
-  return rollouts.flatMap((rollout) => {
-    if (rollout.type !== "THRESHOLD_ROLLOUT_TYPE") return [];
-    return [
-      {
-        rank: rollout.rank,
-        percentage: rollout.threshold.percentage,
-        result: rollout.threshold.value,
-      },
-    ];
-  });
-}
-
-function normalizeRules(rules: SnapshotFlag["rules"]): ManagedFlag["rules"] {
-  return rules.map((rule) => ({
-    rank: rule.rank,
-    segmentOperator: rule.segmentOperator,
-    segments: normalizeSegments(rule.segments),
-    distributions: rule.distributions.map((distribution) => ({
-      variantKey: distribution.variantKey,
-      rollout: distribution.rollout,
-      variantAttachment: distribution.variantAttachment,
-    })),
-  }));
-}
-
-function keySetError(
-  expectedByKey: Map<string, ManagedFlag>,
-  actualByKey: Map<string, SnapshotFlag>,
-): string | undefined {
-  const expectedKeys = [...expectedByKey.keys()].sort();
-  const actualKeys = [...actualByKey.keys()].sort();
-  if (JSON.stringify(expectedKeys) === JSON.stringify(actualKeys)) {
-    return undefined;
-  }
-  const missing = expectedKeys.filter((key) => !actualByKey.has(key));
-  const unexpected = actualKeys.filter((key) => !expectedByKey.has(key));
-  return `key set mismatch: expected ${expectedKeys.length.toString()}, got ${actualKeys.length.toString()}; missing=${missing.join(",") || "none"}; unexpected=${unexpected.join(",") || "none"}`;
-}
-
-function flagErrors(expected: ManagedFlag, actual: SnapshotFlag): string[] {
-  const actualType =
-    actual.type === "BOOLEAN_FLAG_TYPE" ? "boolean" : "variant";
-  if (actualType !== expected.type) {
-    return [
-      `${expected.key}: expected type ${expected.type}, got ${actualType}`,
-    ];
-  }
-
-  const actualDefault =
-    expected.type === "boolean" ? actual.enabled : actual.defaultVariant?.key;
-  const errors: string[] = [];
-  if (actualDefault !== expected.default) {
-    errors.push(
-      `${expected.key}: expected default ${JSON.stringify(expected.default)}, got ${JSON.stringify(actualDefault)}`,
-    );
-  }
-  const actualRollouts = normalizeRollouts(actual.rollouts);
-  if (JSON.stringify(actualRollouts) !== JSON.stringify(expected.rollouts)) {
-    errors.push(
-      `${expected.key}: rollout contract mismatch; expected ${JSON.stringify(expected.rollouts)}, got ${JSON.stringify(actualRollouts)}`,
-    );
-  }
-  const actualThresholdRollouts = normalizeThresholdRollouts(actual.rollouts);
-  if (
-    JSON.stringify(actualThresholdRollouts) !==
-    JSON.stringify(expected.thresholdRollouts)
-  ) {
-    errors.push(
-      `${expected.key}: threshold rollout mismatch; expected ${JSON.stringify(expected.thresholdRollouts)}, got ${JSON.stringify(actualThresholdRollouts)}`,
-    );
-  }
-  const actualRules = normalizeRules(actual.rules);
-  if (JSON.stringify(actualRules) !== JSON.stringify(expected.rules)) {
-    errors.push(
-      `${expected.key}: variant rule mismatch; expected ${JSON.stringify(expected.rules)}, got ${JSON.stringify(actualRules)}`,
-    );
-  }
-  return errors;
-}
-
-function compareSnapshot(snapshot: z.infer<typeof SnapshotSchema>): string[] {
-  const expectedByKey = new Map(
-    managedFlagInventory.flags.map((flag) => [flag.key, flag]),
-  );
-  const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
-  const errors = keySetError(expectedByKey, actualByKey);
-  return [
-    ...(errors === undefined ? [] : [errors]),
-    ...managedFlagInventory.flags.flatMap((expected) => {
-      const actual = actualByKey.get(expected.key);
-      return actual === undefined ? [] : flagErrors(expected, actual);
-    }),
-  ];
-}
-
 async function main(): Promise<void> {
   const namespace =
     argument("--namespace") ??
@@ -223,25 +30,12 @@ async function main(): Promise<void> {
     argument("--environment") ??
     Bun.env["FLIPT_ENVIRONMENT"] ??
     managedFlagInventory.environment;
-  const url = requiredUrl();
-  const response = await fetch(
-    `${url}/internal/v1/evaluation/snapshot/namespace/${encodeURIComponent(namespace)}`,
-    {
-      headers: {
-        Accept: "application/json",
-        "x-flipt-accept-server-version": "1.47.0",
-        "x-flipt-environment": environment,
-      },
-    },
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Flipt snapshot request failed: ${response.status.toString()} ${response.statusText}`,
-    );
-  }
-
-  const snapshot = SnapshotSchema.parse(await response.json());
-  const errors = compareSnapshot(snapshot);
+  const snapshot = await fetchFliptSnapshot({
+    url: requiredUrl(),
+    namespace,
+    environment,
+  });
+  const errors = formatManagedFlagDrift(compareManagedFlagInventory(snapshot));
   if (errors.length > 0) {
     throw new Error(
       `Flipt managed-flag drift detected:\n- ${errors.join("\n- ")}`,


### PR DESCRIPTION
## Why

The reviewed managed-flag inventory and live Flipt configuration can drift in either direction without a durable, automated finding.

## What

- Extract shared, typed Flipt snapshot fetching and key-set comparison for the operator CLI and Temporal.
- Restore the root command bun run check-flipt-flag-inventory while keeping it operator-only.
- Add the flipt-flag-inventory-daily Temporal workflow on the repo-automation queue at 06:15 PT.
- Publish one stable-label FliptManagedFlagDrift Alertmanager alert with both mismatch directions, a two-day firing TTL, and identical-label resolution.
- Fail the workflow on HTTP, schema, or connectivity errors so verification failures never resolve an active alert.
- Configure repo-worker access to Flipt through FLIPT_URL, Flipt ingress, and a port-8080 egress policy while preserving Alertmanager access.
- Add focused comparison, alert, workflow, schedule, and cdk8s synthesis tests.
- Document scheduled alert behavior and remediation commands.

## Verification

- bunx --no-install turbo run typecheck test lint --filter=@shepherdjerred/feature-flags --output-logs=errors-only
- bunx --no-install turbo run typecheck test lint --filter=@shepherdjerred/temporal --output-logs=errors-only
- bunx --no-install turbo run typecheck test lint --filter=@homelab/cdk8s
- bunx --no-install turbo run typecheck test lint --filter=@shepherdjerred/docs-wiki
- bunx --no-install prettier --check on all changed parsable files
- git diff --check
- The operator CLI guard was verified without a live endpoint.
- Live Flipt verification was not run because the cluster endpoint is not available from this workspace.
- Root bun run verify was not part of focused verification.

## Rollout notes

The schedule is declarative and will run after the Temporal schedule definitions are deployed. The recurring alert checks key membership drift only; the operator CLI continues to report contract drift such as type, default, and rollout differences.