### PR TITLE
Route new Temporal scan reports to the reports worker

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1860,6 +1860,14 @@
       "clones": 1,
       "tokens": 78
     },
+    "packages/temporal/src/workflows/link-rot-scan.test.ts|packages/temporal/src/workflows/main-vuln-scan.test.ts": {
+      "clones": 1,
+      "tokens": 132
+    },
+    "packages/temporal/src/workflows/link-rot-scan.ts|packages/temporal/src/workflows/main-vuln-scan.ts": {
+      "clones": 1,
+      "tokens": 81
+    },
     "packages/toolkit/src/commands/history/history.ts|packages/toolkit/src/commands/history/history.ts": {
       "clones": 1,
       "tokens": 107
@@ -1917,5 +1925,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-30T00:17:09.532Z"
+  "updated": "2026-08-30T00:35:50.330Z"
 }

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
@@ -92,10 +92,9 @@ credentials that can publish that change or mutate the operational APIs.
 Report delivery crosses back into the credentialed reports queue. New workflow
 histories schedule their email activity there directly. Histories replayed from
 before that queue migration must preserve the original agent-queue activity for
-Temporal determinism; the activity contains no Postal or S3 credentials and
-delegates a fixed `deliverReportWorkflow` to the default queue until retention
-expires. Both paths therefore use the shared sender without restoring delivery
-secrets to the agent pod.
+Temporal determinism; that credential-free compatibility activity delegates a
+fixed `deliverReportWorkflow` to the reports queue. Both paths therefore use
+the shared sender without restoring delivery secrets to the agent pod.
 
 ## Why it is built this way anyway
 

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/agent-task-boundary.md
@@ -26,7 +26,7 @@ flowchart TD
   BKR -->|long-lived auth| PAPI[Fixed provider<br>inference API]
   I --> R[Redacted evidence<br>receipt catalog]
   R --> FNL[Receipt-only<br>finalization agent]
-  FNL --> CQ[Core worker queue]
+  FNL --> CQ[Reports worker queue]
   CQ --> E[Shared email report]
   E -.-> F[Optional follow-up task]
 ```
@@ -49,7 +49,7 @@ allowlisted environment. The runtime boundary consists of:
 - a provider-only uid, for the deterministic evidence collectors, whose
   pod-local firewall rejects Temporal gRPC and UI traffic while leaving the
   worker poller connected,
-- email delivery dispatched to the core worker queue, outside the agent pod.
+- email delivery dispatched to the reports worker queue, outside the agent pod.
 
 What does **not** constrain it is a schema that makes mutation unrepresentable,
 or a filesystem that refuses writes. Codex investigation threads run with
@@ -89,13 +89,13 @@ So local filesystem writes are still possible. A sufficiently confused or
 prompt-injected run can corrupt only its disposable workdir; it does not receive
 credentials that can publish that change or mutate the operational APIs.
 
-Report delivery crosses back into the credentialed core queue. New workflow
+Report delivery crosses back into the credentialed reports queue. New workflow
 histories schedule their email activity there directly. Histories replayed from
 before that queue migration must preserve the original agent-queue activity for
 Temporal determinism; the activity contains no Postal or S3 credentials and
-delegates a fixed `deliverReportWorkflow` to the core queue instead. Both paths
-therefore use the shared sender without restoring delivery secrets to the agent
-pod.
+delegates a fixed `deliverReportWorkflow` to the default queue until retention
+expires. Both paths therefore use the shared sender without restoring delivery
+secrets to the agent pod.
 
 ## Why it is built this way anyway
 

--- a/packages/docs/wiki/src/content/docs/reference/agent-task-input.md
+++ b/packages/docs/wiki/src/content/docs/reference/agent-task-input.md
@@ -159,7 +159,7 @@ inheriting the worker environment.
 | `HOME`                                      | the throwaway workdir, not the worker image home         |
 | Prometheus and alert-dashboard URLs         | present without API credentials                          |
 | Kubernetes service address and mounted SA   | present; the dedicated identity has read-only audit RBAC |
-| Postal, S3, GitHub App, and ingress secrets | absent; delivery executes on the core worker queue       |
+| Postal, S3, GitHub App, and ingress secrets | absent; delivery executes on the reports worker queue    |
 | ArgoCD, Grafana, Buildkite, HA, Cloudflare  | absent                                                   |
 
 The trusted, source-controlled agents are the exception. The homelab audit and

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -464,9 +464,8 @@ clones of this public repository are unauthenticated, and
 new agent email delivery activities execute on `TASK_QUEUES.REPORTS`. Replayed
 histories preserve their original agent-queue activity command for Temporal
 determinism; that credential-free compatibility activity delegates a fixed
-`deliverReportWorkflow` to `TASK_QUEUES.DEFAULT` until the retention window
-expires. Postal and report-state S3 credentials therefore remain in the reports
-worker in both paths. The outer email
+`deliverReportWorkflow` to `TASK_QUEUES.REPORTS`. Postal and report-state S3
+credentials therefore remain in the reports worker in both paths. The outer email
 activity budget must exceed the complete delegated delivery retry window; both
 durations are defined in `src/shared/report-delivery-policy.ts`.
 

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -185,7 +185,7 @@ Workflow:
 ## Environment Variables
 
 - `TEMPORAL_ADDRESS` — Temporal server gRPC address (default: `temporal-server.temporal.svc.cluster.local:7233`)
-- `TEMPORAL_WORKER_ROLE` — process role: `all` (default/local), `core`, `agent`, `glitter`, or `maintenance`. Invalid values fail startup.
+- `TEMPORAL_WORKER_ROLE` — process role: `all` (default/local), `control`, `core`, `agent`, `glitter`, `glitter-context`, `glitter-corpus`, `home`, `infra`, `legacy`, `maintenance`, `repo`, `reports`, or `scout`. Invalid values fail startup.
 - `HA_URL` — Home Assistant URL
 - `HA_TOKEN` — Home Assistant long-lived access token
 - `GOLINK_URL` — Golink service URL
@@ -274,7 +274,7 @@ Do not add this workflow to `SCHEDULES`. The ordinary
 ## Homelab audit (daily)
 
 `homelab-audit-daily` (cron `30 6 * * *` PT) runs the deterministic
-`runHomelabAuditWorkflow` on the default queue. Typed collectors own the six
+`runHomelabAuditWorkflow` on the infra queue. Typed collectors own the six
 required checks: Prometheus alerts, durable alert occurrences, Temporal
 failures/stalls, Kubernetes workload health, ArgoCD state, and Buildkite main
 failures with failed-job logs. An optional OpenRouter call may write only the
@@ -286,7 +286,7 @@ delivered through the shared reporter as partial.
 
 ## Temporal workflow failure → Alerts occurrences
 
-`temporal-failure-watch` (cron `*/5 * * * *`, `pollWorkflowFailuresWorkflow` on `TASK_QUEUES.DEFAULT`) sends an Alerts occurrence through Alertmanager with the specific error for **every** Temporal workflow execution that fails or times out — not just the workflows/thresholds covered by the hand-maintained Prometheus rules in `packages/homelab/.../monitoring/rules/temporal.ts`. The activity (`src/activities/workflow-failure-watch.ts`) heartbeats a best-effort batch checkpoint and conservatively rescans the full lookback on retry so the public visibility iterator cannot skip failures:
+`temporal-failure-watch` (cron `*/5 * * * *`, `pollWorkflowFailuresWorkflow` on `TASK_QUEUES.REPORTS`) sends an Alerts occurrence through Alertmanager with the specific error for **every** Temporal workflow execution that fails or times out — not just the workflows/thresholds covered by the hand-maintained Prometheus rules in `packages/homelab/.../monitoring/rules/temporal.ts`. The activity (`src/activities/workflow-failure-watch.ts`) heartbeats a best-effort batch checkpoint and conservatively rescans the full lookback on retry so the public visibility iterator cannot skip failures:
 
 1. Queries the Temporal visibility API for `ExecutionStatus IN ("Failed", "TimedOut")` closed in the last 24 hours so a worker outage can be recovered by the next poll (safe to overlap because Alertmanager dedups alerts by label set and each alert expires from the execution's close time, not from the latest poll).
 2. For each match, calls `getHandle(workflowId, runId).fetchHistory()` and then `.result()`, with bounded concurrency and Alertmanager batches so recovery can page partial progress before the activity deadline. The history classifies timeouts as `workflow-task`, `activity`, `execution`, or `unknown`; an agent-task timeout before any `ACTIVITY_TASK_STARTED` event is explicitly a worker/task-queue availability failure, including scheduled-but-undispatched activities. The closed `result()` rejects immediately with `WorkflowFailedError`, whose `.cause` carries the same failure type/message/stack the Temporal UI shows.
@@ -423,10 +423,10 @@ Artifacts are cached by request digest rather than by run, so this re-reads
 whatever a production run already paid for instead of re-billing it — which is
 also why pinning a snapshot reuses more cache than reading the latest one.
 
-**Cluster RBAC** — the core and agent worker SAs get the cluster-wide read-only
+**Cluster RBAC** — the infra and agent worker SAs get the cluster-wide read-only
 `temporal-worker-audit-reader` ClusterRole (see
 `packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts`). A separate
-TaskNotes namespace Role grants `pods/exec` only to the core worker so the
+TaskNotes namespace Role grants `pods/exec` only to the infra worker so the
 engine-status token never leaves that pod. The agent worker is intentionally
 absent from every pod-exec RoleBinding; the agent therefore cannot
 exec into TaskNotes or deterministic maintenance targets even if it disregards
@@ -461,11 +461,12 @@ policy-capable CNI but is not treated as current enforcement. Restoring uid and
 credential isolation for the native SDK agent itself is tracked in
 `packages/docs/todos/agent-sdk-provider-isolation.md`. Generic agent
 clones of this public repository are unauthenticated, and
-new agent email delivery activities execute on `TASK_QUEUES.DEFAULT`. Replayed
+new agent email delivery activities execute on `TASK_QUEUES.REPORTS`. Replayed
 histories preserve their original agent-queue activity command for Temporal
 determinism; that credential-free compatibility activity delegates a fixed
-`deliverReportWorkflow` to `TASK_QUEUES.DEFAULT`. Postal and report-state S3
-credentials therefore remain in the core worker in both paths. The outer email
+`deliverReportWorkflow` to `TASK_QUEUES.DEFAULT` until the retention window
+expires. Postal and report-state S3 credentials therefore remain in the reports
+worker in both paths. The outer email
 activity budget must exceed the complete delegated delivery retry window; both
 durations are defined in `src/shared/report-delivery-policy.ts`.
 
@@ -647,7 +648,7 @@ PR-closed build cancellation.
 
 ### Durable review-signal collector (`review-signals-collect`)
 
-Separate from the CI gate above: `review-signals-collect` (cron `0 */6 * * *` PT, `observeReviewSignalsWorkflow` on `TASK_QUEUES.DEFAULT`) is a scheduled job, not a per-PR gate. Every 6 hours it lists the most-recently-updated PRs (`GET /repos/{repo}/pulls?state=all&sort=updated&direction=desc`, `ObserveReviewSignalsInput.limit`, default 30) and, for each, builds the same provider-neutral `ReviewSignalEvent` the gate computes (`src/activities/observe-review-signals.ts`, mirroring `scripts/probe-review-signal.ts` / `scripts/wait-for-review.ts` including the head-commit latency guard). It records `review_*` Prometheus metrics (`src/observability/metrics.ts`) and writes the batch as NDJSON to S3 at `review-signals/<temporal-run-id>.ndjson` in `REVIEW_SIGNAL_ARCHIVE_BUCKET` (default `llm-archive`; same shared `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`S3_ENDPOINT` credentials as every other S3 writer in this package — see `homelab-audit-archive.ts` for the pattern this follows) — a durable, queryable "what did the review bot do and when" dataset independent of ephemeral CI logs. The object is keyed by the workflow run id (not a wall-clock timestamp) so an activity retry overwrites the same object idempotently; each event carries its own `ts` for time-filtering. A single PR's fetch failing is logged + skipped (`errored` in the result); a token-mint or PR-listing failure fails the whole run. The pure aggregation helper (`src/shared/review-signals.ts`, `summarizeReviewSignals`) is unit-tested and safe to import from workflow code — no I/O, no Sentry.
+Separate from the CI gate above: `review-signals-collect` (cron `0 */6 * * *` PT, `observeReviewSignalsWorkflow` on `TASK_QUEUES.REPO_AUTOMATION`) is a scheduled job, not a per-PR gate. Every 6 hours it lists the most-recently-updated PRs (`GET /repos/{repo}/pulls?state=all&sort=updated&direction=desc`, `ObserveReviewSignalsInput.limit`, default 30) and, for each, builds the same provider-neutral `ReviewSignalEvent` the gate computes (`src/activities/observe-review-signals.ts`, mirroring `scripts/probe-review-signal.ts` / `scripts/wait-for-review.ts` including the head-commit latency guard). It records `review_*` Prometheus metrics (`src/observability/metrics.ts`) and writes the batch as NDJSON to S3 at `review-signals/<temporal-run-id>.ndjson` in `REVIEW_SIGNAL_ARCHIVE_BUCKET` (default `llm-archive`; same shared `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` credentials as every other S3 writer in this package — see `homelab-audit-archive.ts` for the pattern this follows) — a durable, queryable "what did the review bot do and when" dataset independent of ephemeral CI logs. The object is keyed by the workflow run id (not a wall-clock timestamp) so an activity retry overwrites the same object idempotently; each NDJSON event carries its own `ts` for time-filtering. A single PR's fetch failing is logged + skipped (`errored` in the result); a token-mint or PR-listing failure fails the whole run. The pure aggregation helper (`src/shared/review-signals.ts`, `summarizeReviewSignals`) is unit-tested and safe to import from workflow code — no I/O, no Sentry.
 
 ## GitHub webhook (merge-conflict check + PR-closed build cancel)
 

--- a/packages/temporal/src/activities/link-rot-scan.ts
+++ b/packages/temporal/src/activities/link-rot-scan.ts
@@ -122,8 +122,8 @@ const LYCHEE_SCAN_COMMAND = [
 /**
  * Shallow-clones current `main` (public repo — no credentials) and runs lychee
  * over the tracked markdown per the root lychee.toml. Runs on
- * TASK_QUEUES.DEFAULT: unlike the Trivy scan there is no warm cache to reuse,
- * and the core worker image carries the pinned lychee binary.
+ * TASK_QUEUES.MAINTENANCE: unlike the Trivy scan there is no warm cache to
+ * reuse, and the maintenance worker image carries the pinned lychee binary.
  */
 async function scanMainForLinkRot(
   hooks: MaintenanceCommandHooks = maintenanceActivityHooks(),

--- a/packages/temporal/src/activities/main-vuln-scan.ts
+++ b/packages/temporal/src/activities/main-vuln-scan.ts
@@ -12,7 +12,7 @@ import {
  * The warm Trivy database PVC mounted into the maintenance worker — kept fresh
  * every six hours by `buildkite-trivy-db-refresh`, which is why the scan runs
  * with `--skip-db-update` on the maintenance queue instead of downloading a
- * database per run on the default queue.
+ * database per run on an unscoped worker.
  */
 const TRIVY_CACHE_DIR = "/buildkite/trivy-db";
 const EXCERPT_LIMIT = 2000;

--- a/packages/temporal/src/schedules/default-routing.test.ts
+++ b/packages/temporal/src/schedules/default-routing.test.ts
@@ -2,6 +2,14 @@ import { expect, test } from "vitest";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 import { SCHEDULES } from "./schedule-definitions.ts";
 
+const DEFAULT_QUEUE_COMPATIBILITY_PATHS = new Map([
+  ["src/workflows/agent-task.ts", "agent-task-reports-email-delivery-v1"],
+  ["src/workflows/link-rot-scan.ts", "link-rot-scan-reports-queue-v1"],
+  ["src/workflows/main-vuln-scan.ts", "main-vuln-scan-reports-queue-v1"],
+  ["src/workflows/report-activity-queue.ts", "REPORT_ACTIVITY_QUEUE_PATCH"],
+  ["src/workflows/report-delivery.ts", "report-delivery-reports-queue-v1"],
+]);
+
 test("no active start surface targets the migration-only default queue", async () => {
   expect(
     SCHEDULES.every((schedule) => schedule.taskQueue !== TASK_QUEUES.DEFAULT),
@@ -14,7 +22,20 @@ test("no active start surface targets the migration-only default queue", async (
       continue;
     }
     const source = await Bun.file(`${packageRoot}/${relativePath}`).text();
-    expect(source, relativePath).not.toContain("TASK_QUEUES.DEFAULT");
-    expect(source, relativePath).not.toMatch(/taskQueue:\s*["']default["']/u);
+    const usesDefaultQueue =
+      source.includes("TASK_QUEUES.DEFAULT") ||
+      /taskQueue:\s*["']default["']/u.test(source);
+    if (!usesDefaultQueue) {
+      continue;
+    }
+    const compatibilityPatch =
+      DEFAULT_QUEUE_COMPATIBILITY_PATHS.get(relativePath);
+    if (compatibilityPatch === undefined) {
+      throw new Error(
+        `undocumented default queue reference in ${relativePath}`,
+      );
+    }
+    expect(source, relativePath).toContain(compatibilityPatch);
+    expect(source, relativePath).toMatch(/legacy|pre-migration|replay/u);
   }
 });

--- a/packages/temporal/src/workflows/link-rot-scan.test.ts
+++ b/packages/temporal/src/workflows/link-rot-scan.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { Worker } from "@temporalio/worker";
+import type { PatchActivationCallback } from "@temporalio/worker";
 import type { DeadLink, LinkRotScanResult } from "#activities/link-rot-scan.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 import { runLinkRotScanWorkflow } from "./link-rot-scan.ts";
@@ -6,8 +8,8 @@ import * as scannerTest from "./scanner-workflow-test-support.ts";
 
 // The workflow deliberately splits queues: the git/lychee scan runs on the
 // serial MAINTENANCE queue while delivery and the Alertmanager publish stay on
-// the credentialed core queue. The test mirrors that with one worker per queue,
-// which also proves the routing — a single-queue harness would hang.
+// the credentialed REPORTS queue. The test mirrors that with one worker per
+// queue, which also proves the routing — a single-queue harness would hang.
 const REPO_SHA = "d9ea9584e0123456789abcdef0123456789abcde";
 
 const getTestEnv = scannerTest.setupScannerWorkflowTestEnvironment();
@@ -41,15 +43,25 @@ async function runWorkflow(
     publish?: () => Promise<void>;
   },
   deadLinks: DeadLink[] = [],
+  options: {
+    workflowId?: string;
+    reportTaskQueue?: typeof TASK_QUEUES.DEFAULT | typeof TASK_QUEUES.REPORTS;
+    patchActivationCallback?: PatchActivationCallback;
+  } = {},
 ): Promise<{ harness: scannerTest.ScannerWorkflowHarness; failure: unknown }> {
   const harness = scannerTest.createScannerWorkflowHarness();
+  const workflowId =
+    options.workflowId ?? `test-link-rot-scan-${crypto.randomUUID()}`;
   const failure = await scannerTest.runScannerWorkflow(getTestEnv(), {
     workflow: runLinkRotScanWorkflow,
-    workflowId: `test-link-rot-scan-${crypto.randomUUID()}`,
+    workflowId,
     taskQueue: TASK_QUEUES.MAINTENANCE,
+    ...(options.patchActivationCallback === undefined
+      ? {}
+      : { patchActivationCallback: options.patchActivationCallback }),
     workers: [
       {
-        taskQueue: TASK_QUEUES.REPORTS,
+        taskQueue: options.reportTaskQueue ?? TASK_QUEUES.REPORTS,
         activities: {
           deliverActivityReport: scannerTest.deliverScannerReport(harness),
           publishLinkRotScanAlerts: scannerTest.publishScannerAlert(
@@ -110,4 +122,26 @@ describe("runLinkRotScanWorkflow", () => {
     expect(failure).toBeInstanceOf(Error);
     scannerTest.expectNoContradictoryFailureReport(harness, "attention");
   }, 120_000);
+
+  it("replays a pre-migration history that used the default report queue", async () => {
+    const workflowId = `test-link-rot-scan-legacy-${crypto.randomUUID()}`;
+    const { harness, failure } = await runWorkflow({}, [], {
+      workflowId,
+      reportTaskQueue: TASK_QUEUES.DEFAULT,
+      patchActivationCallback: () => false,
+    });
+    expect(failure).toBeUndefined();
+    scannerTest.expectCompleteScannerReport(harness, "clear", 0, REPO_SHA);
+
+    const history = await getTestEnv()
+      .client.workflow.getHandle(workflowId)
+      .fetchHistory();
+    await expect(
+      Worker.runReplayHistory(
+        { workflowsPath: new URL("index.ts", import.meta.url).pathname },
+        history,
+        workflowId,
+      ),
+    ).resolves.toBeUndefined();
+  }, 60_000);
 });

--- a/packages/temporal/src/workflows/link-rot-scan.ts
+++ b/packages/temporal/src/workflows/link-rot-scan.ts
@@ -1,4 +1,4 @@
-import { proxyActivities } from "@temporalio/workflow";
+import { patched, proxyActivities } from "@temporalio/workflow";
 import type {
   LinkRotScanActivities,
   LinkRotScanResult,
@@ -35,19 +35,31 @@ const { scanMainForLinkRot } = proxyActivities<LinkRotScanActivities>({
   heartbeatTimeout: "90 seconds",
   retry: RETRY,
 });
-// Delivery and alert publication stay on the reports queue, which owns Postal,
-// report-state S3, and ALERTMANAGER_URL credentials.
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+// Delivery and alert publication run on the reports queue, which owns the
+// Postal, report-state S3, and ALERTMANAGER_URL credentials. The legacy branch
+// is retained only for histories created before this queue migration.
+const legacyDeliveryActivities = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.DEFAULT,
+  startToCloseTimeout: "2 minutes",
+  retry: RETRY,
+});
+const reportsDeliveryActivities = proxyActivities<ReportDeliveryActivities>({
   taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: RETRY,
 });
-const { publishLinkRotScanAlerts } =
-  proxyActivities<LinkRotScanAlertActivities>({
-    taskQueue: TASK_QUEUES.REPORTS,
-    startToCloseTimeout: "1 minute",
-    retry: RETRY,
-  });
+const legacyAlertActivities = proxyActivities<LinkRotScanAlertActivities>({
+  taskQueue: TASK_QUEUES.DEFAULT,
+  startToCloseTimeout: "1 minute",
+  retry: RETRY,
+});
+const reportsAlertActivities = proxyActivities<LinkRotScanAlertActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
+  startToCloseTimeout: "1 minute",
+  retry: RETRY,
+});
+
+const REPORTS_QUEUE_PATCH = "link-rot-scan-reports-queue-v1";
 
 /**
  * Weekly lychee link-rot scan of current `main`.
@@ -58,6 +70,13 @@ const { publishLinkRotScanAlerts } =
  * vulnerability scan and pages only if a critical finding ever appears.
  */
 export async function runLinkRotScanWorkflow(): Promise<void> {
+  const useReportsQueue = patched(REPORTS_QUEUE_PATCH);
+  const deliveryActivities = useReportsQueue
+    ? reportsDeliveryActivities
+    : legacyDeliveryActivities;
+  const alertActivities = useReportsQueue
+    ? reportsAlertActivities
+    : legacyAlertActivities;
   const startedAt = new Date().toISOString();
   // Only a clone/scan failure produces the failure report. Wrapping the
   // delivery and alert calls too would let an Alertmanager outage — after the
@@ -69,12 +88,14 @@ export async function runLinkRotScanWorkflow(): Promise<void> {
   try {
     result = await scanMainForLinkRot();
   } catch (error) {
-    await deliverActivityReport(buildLinkRotFailureReport(startedAt, error));
+    await deliveryActivities.deliverActivityReport(
+      buildLinkRotFailureReport(startedAt, error),
+    );
     throw error;
   }
   const report = buildLinkRotReport(startedAt, result);
-  await deliverActivityReport(report);
-  await publishLinkRotScanAlerts({
+  await deliveryActivities.deliverActivityReport(report);
+  await alertActivities.publishLinkRotScanAlerts({
     criticalCount: countCriticalReportFindings(report),
     repoSha: result.repoSha,
   });

--- a/packages/temporal/src/workflows/main-vuln-scan.test.ts
+++ b/packages/temporal/src/workflows/main-vuln-scan.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { Worker } from "@temporalio/worker";
+import type { PatchActivationCallback } from "@temporalio/worker";
 import type { MainVulnScanResult } from "#activities/main-vuln-scan.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 import { runMainVulnScanWorkflow } from "./main-vuln-scan.ts";
@@ -35,15 +37,25 @@ async function runWorkflow(
     publish?: () => Promise<void>;
   },
   vulnerabilities: MainVulnScanResult["vulnerabilities"] = [],
+  options: {
+    workflowId?: string;
+    reportTaskQueue?: typeof TASK_QUEUES.DEFAULT | typeof TASK_QUEUES.REPORTS;
+    patchActivationCallback?: PatchActivationCallback;
+  } = {},
 ): Promise<{ harness: scannerTest.ScannerWorkflowHarness; failure: unknown }> {
   const harness = scannerTest.createScannerWorkflowHarness();
+  const workflowId =
+    options.workflowId ?? `test-main-vuln-scan-${crypto.randomUUID()}`;
   const failure = await scannerTest.runScannerWorkflow(getTestEnv(), {
     workflow: runMainVulnScanWorkflow,
-    workflowId: `test-main-vuln-scan-${crypto.randomUUID()}`,
+    workflowId,
     taskQueue: TASK_QUEUES.MAINTENANCE,
+    ...(options.patchActivationCallback === undefined
+      ? {}
+      : { patchActivationCallback: options.patchActivationCallback }),
     workers: [
       {
-        taskQueue: TASK_QUEUES.REPORTS,
+        taskQueue: options.reportTaskQueue ?? TASK_QUEUES.REPORTS,
         activities: {
           deliverActivityReport: scannerTest.deliverScannerReport(harness),
           publishMainVulnScanAlerts: scannerTest.publishScannerAlert(
@@ -106,4 +118,26 @@ describe("runMainVulnScanWorkflow", () => {
     expect(failure).toBeInstanceOf(Error);
     scannerTest.expectNoContradictoryFailureReport(harness, "attention");
   }, 120_000);
+
+  it("replays a pre-migration history that used the default report queue", async () => {
+    const workflowId = `test-main-vuln-scan-legacy-${crypto.randomUUID()}`;
+    const { harness, failure } = await runWorkflow({}, [], {
+      workflowId,
+      reportTaskQueue: TASK_QUEUES.DEFAULT,
+      patchActivationCallback: () => false,
+    });
+    expect(failure).toBeUndefined();
+    scannerTest.expectCompleteScannerReport(harness, "clear", 0, REPO_SHA);
+
+    const history = await getTestEnv()
+      .client.workflow.getHandle(workflowId)
+      .fetchHistory();
+    await expect(
+      Worker.runReplayHistory(
+        { workflowsPath: new URL("index.ts", import.meta.url).pathname },
+        history,
+        workflowId,
+      ),
+    ).resolves.toBeUndefined();
+  }, 60_000);
 });

--- a/packages/temporal/src/workflows/main-vuln-scan.ts
+++ b/packages/temporal/src/workflows/main-vuln-scan.ts
@@ -1,4 +1,4 @@
-import { proxyActivities } from "@temporalio/workflow";
+import { patched, proxyActivities } from "@temporalio/workflow";
 import type {
   MainVulnScanActivities,
   MainVulnScanResult,
@@ -29,19 +29,32 @@ const { scanMainForVulnerabilities } = proxyActivities<MainVulnScanActivities>({
   retry: RETRY,
 });
 
-// Delivery and alert publication run on the reports worker: Postal, report-state
-// S3, and ALERTMANAGER_URL deliberately never reach the maintenance pod.
-const { deliverActivityReport } = proxyActivities<ReportDeliveryActivities>({
+// Delivery and alert publication run on the reports worker: Postal,
+// report-state S3, and ALERTMANAGER_URL deliberately never reach the
+// maintenance pod. The legacy branch is retained only for histories created
+// before the reports queue migration.
+const legacyDeliveryActivities = proxyActivities<ReportDeliveryActivities>({
+  taskQueue: TASK_QUEUES.DEFAULT,
+  startToCloseTimeout: "2 minutes",
+  retry: RETRY,
+});
+const reportsDeliveryActivities = proxyActivities<ReportDeliveryActivities>({
   taskQueue: TASK_QUEUES.REPORTS,
   startToCloseTimeout: "2 minutes",
   retry: RETRY,
 });
-const { publishMainVulnScanAlerts } =
-  proxyActivities<MainVulnScanAlertActivities>({
-    taskQueue: TASK_QUEUES.REPORTS,
-    startToCloseTimeout: "1 minute",
-    retry: RETRY,
-  });
+const legacyAlertActivities = proxyActivities<MainVulnScanAlertActivities>({
+  taskQueue: TASK_QUEUES.DEFAULT,
+  startToCloseTimeout: "1 minute",
+  retry: RETRY,
+});
+const reportsAlertActivities = proxyActivities<MainVulnScanAlertActivities>({
+  taskQueue: TASK_QUEUES.REPORTS,
+  startToCloseTimeout: "1 minute",
+  retry: RETRY,
+});
+
+const REPORTS_QUEUE_PATCH = "main-vuln-scan-reports-queue-v1";
 
 /**
  * Weekly Trivy HIGH/CRITICAL scan of current `main`.
@@ -51,6 +64,13 @@ const { publishMainVulnScanAlerts } =
  * CRITICAL finding exists, resolving as soon as a run comes back clean.
  */
 export async function runMainVulnScanWorkflow(): Promise<void> {
+  const useReportsQueue = patched(REPORTS_QUEUE_PATCH);
+  const deliveryActivities = useReportsQueue
+    ? reportsDeliveryActivities
+    : legacyDeliveryActivities;
+  const alertActivities = useReportsQueue
+    ? reportsAlertActivities
+    : legacyAlertActivities;
   const startedAt = new Date().toISOString();
   // Only a clone/scan failure produces the failure report. Wrapping the
   // delivery and alert calls too would let an Alertmanager outage — after the
@@ -62,13 +82,15 @@ export async function runMainVulnScanWorkflow(): Promise<void> {
   try {
     result = await scanMainForVulnerabilities();
   } catch (error) {
-    await deliverActivityReport(
+    await deliveryActivities.deliverActivityReport(
       buildMainVulnScanFailureReport(startedAt, error),
     );
     throw error;
   }
-  await deliverActivityReport(buildMainVulnScanReport(startedAt, result));
-  await publishMainVulnScanAlerts({
+  await deliveryActivities.deliverActivityReport(
+    buildMainVulnScanReport(startedAt, result),
+  );
+  await alertActivities.publishMainVulnScanAlerts({
     criticalCount: countCriticalVulnerabilities(result),
     repoSha: result.repoSha,
   });

--- a/packages/temporal/src/workflows/scanner-workflow-test-support.ts
+++ b/packages/temporal/src/workflows/scanner-workflow-test-support.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, expect } from "vitest";
 import { z } from "zod/v4";
 import { Worker } from "@temporalio/worker";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
+import type { PatchActivationCallback } from "@temporalio/worker";
 import type { TaskQueue } from "#shared/task-queues.ts";
 
 const DeliveredReportSchema = z.object({
@@ -80,30 +81,66 @@ export async function runScannerWorkflow(
     workflowId: string;
     taskQueue: TaskQueue;
     workers: readonly ScannerWorkerDefinition[];
+    patchActivationCallback?: PatchActivationCallback;
   },
 ): Promise<unknown> {
   const workers = await Promise.all(
-    input.workers.map(async (definition) =>
-      Worker.create({
+    input.workers.map(async (definition) => ({
+      definition,
+      worker: await Worker.create({
         connection: testEnv.nativeConnection,
         taskQueue: definition.taskQueue,
         activities: definition.activities,
         ...(definition.runsWorkflow === true
           ? { workflowsPath: new URL("index.ts", import.meta.url).pathname }
           : {}),
+        ...(input.patchActivationCallback === undefined
+          ? {}
+          : { patchActivationCallback: input.patchActivationCallback }),
       }),
-    ),
+    })),
   );
+  const workflowWorker = workers.find(
+    ({ definition }) => definition.runsWorkflow === true,
+  );
+  if (workflowWorker === undefined) {
+    throw new Error("scanner workflow harness requires a workflow worker");
+  }
+  const activityWorkers = workers.filter(
+    ({ definition }) => definition.runsWorkflow !== true,
+  );
+  const activityRuns = activityWorkers.map(({ worker }) => worker.run());
   const execution = testEnv.client.workflow.execute(input.workflow, {
     args: [],
     taskQueue: input.taskQueue,
     workflowId: input.workflowId,
   });
+  const workflowState: { outcome: "pending" | "fulfilled" | "rejected" } = {
+    outcome: "pending",
+  };
+  const observedExecution = (async () => {
+    try {
+      await execution;
+      workflowState.outcome = "fulfilled";
+    } catch (error: unknown) {
+      workflowState.outcome = "rejected";
+      throw error;
+    }
+  })();
   try {
-    await Promise.all(workers.map((worker) => worker.runUntil(execution)));
+    await workflowWorker.worker.runUntil(observedExecution);
     return undefined;
   } catch (error: unknown) {
+    if (workflowState.outcome === "fulfilled") {
+      await observedExecution;
+      return undefined;
+    }
     return error;
+  } finally {
+    for (const { worker } of activityWorkers) {
+      worker.shutdown();
+    }
+    await Promise.all(activityRuns);
   }
 }
 


### PR DESCRIPTION
## Why

PR #2473 was documentation-only. The legacy default worker still polls during Temporal history retention, but new scan report and alert activities should no longer depend on it.

## What

- Route new main vulnerability and link-rot delivery and Alertmanager activities to the canonical `reports` queue.
- Keep explicit `patched()` branches that preserve `default` for pre-migration histories until retention expires.
- Add real execution and replay coverage for both canonical and pre-migration routing.
- Reject undocumented default-queue references in start surfaces and document the drain-only legacy period.

## Verification

- `bun install --frozen-lockfile`
- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal` (typecheck/tests pass; lint has existing duplication warnings only)
- `bunx turbo run typecheck test lint --filter=homelab` (91 tests pass; lint has an existing duplication warning only)
- Focused scan routing/replay suite: 11 tests pass
- `bunx lefthook run pre-commit`

## Rollout

This is the migration stage. The default worker and compatibility branches remain in place. Live audit on 2026-08-28 found no open default workflows and zero task backlog, but retained histories still make deletion unsafe. Remove the default queue and legacy Kubernetes resources in a follow-up PR only after approximately 2026-09-27 and a fresh live audit.