### PR TITLE
feat(feature-flags): prepare isolated Flipt environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "check-floating-deps": "bun scripts/check-floating-deps.ts",
     "check-patched-deps": "bun scripts/check-patched-deps.ts",
     "check-ci-env": "bun scripts/check-ci-env.ts",
+    "check-flipt-flag-inventory": "bun scripts/check-flipt-flag-inventory.ts",
     "check-script-migrations": "bun scripts/check-script-migrations.ts",
     "check-test-standardization": "bun scripts/check-test-standardization.ts",
     "script-coverage": "bun scripts/check-script-coverage.ts"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "check-floating-deps": "bun scripts/check-floating-deps.ts",
     "check-patched-deps": "bun scripts/check-patched-deps.ts",
     "check-ci-env": "bun scripts/check-ci-env.ts",
-    "check-flipt-flag-inventory": "bun scripts/check-flipt-flag-inventory.ts",
     "check-script-migrations": "bun scripts/check-script-migrations.ts",
     "check-test-standardization": "bun scripts/check-test-standardization.ts",
     "script-coverage": "bun scripts/check-script-coverage.ts"

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -27,8 +27,18 @@ Run the repository command from the monorepo root:
 bun run check-flipt-flag-inventory
 ```
 
-The command compares the `default/default` namespace and environment unless
-`FLIPT_NAMESPACE` or `FLIPT_ENVIRONMENT` overrides them.
+The command checks every environment declared in the managed inventory. During
+the migration, that means `default`, `beta`, and `prod` in the `default`
+namespace.
+
+To check one exact environment, pass a filter:
+
+```bash
+bun run check-flipt-flag-inventory -- --environment beta
+```
+
+`FLIPT_NAMESPACE` changes the namespace. `FLIPT_ENVIRONMENT` is also accepted
+as the exact environment filter.
 
 ## 3. Interpret failures
 
@@ -41,8 +51,15 @@ The check fails when Flipt differs from the inventory in any of these areas:
 - variant rules and distributions;
 - percentage threshold rollouts.
 
-Fix the repository inventory or the audited Flipt state, then run the command
-again until it reports alignment.
+Each diagnostic names the failing namespace and environment. Fix the repository
+inventory or that environment's audited Flipt state, then run the complete
+check again until every environment reports alignment.
+
+When environments intentionally differ, record a full behavioral override in
+the environment's inventory entry. An override replaces the flag's default,
+segment rollouts, variant rules, and threshold rollouts together. Partial
+overrides are rejected so an environment cannot inherit an accidental mixture
+of old and new behavior.
 
 The scheduled alert is read-only. It never deletes Flipt flags or edits the
 inventory. A failed snapshot request does not resolve an existing alert; the

--- a/packages/feature-flags/src/managed-flag-drift.test.ts
+++ b/packages/feature-flags/src/managed-flag-drift.test.ts
@@ -151,6 +151,7 @@ describe("fetchFliptSnapshot", () => {
     await expect(
       fetchFliptSnapshot({
         url: "http://flipt.test",
+        environment: "default",
         fetcher: async () =>
           new Response("unavailable", {
             status: 503,
@@ -164,6 +165,7 @@ describe("fetchFliptSnapshot", () => {
     await expect(
       fetchFliptSnapshot({
         url: "http://flipt.test",
+        environment: "default",
         fetcher: async () => {
           throw new Error("connection refused");
         },
@@ -175,6 +177,7 @@ describe("fetchFliptSnapshot", () => {
     await expect(
       fetchFliptSnapshot({
         url: "http://flipt.test",
+        environment: "default",
         fetcher: async () =>
           Response.json({ flags: [{ key: "broken" }] }, { status: 200 }),
       }),

--- a/packages/feature-flags/src/managed-flag-drift.ts
+++ b/packages/feature-flags/src/managed-flag-drift.ts
@@ -79,7 +79,7 @@ export type FliptFetcher = (
 export type FetchFliptSnapshotOptions = {
   readonly url: string;
   readonly namespace?: string;
-  readonly environment?: string;
+  readonly environment: string;
   readonly fetcher?: FliptFetcher;
 };
 
@@ -194,9 +194,10 @@ function contractErrors(expected: ManagedFlag, actual: SnapshotFlag): string[] {
 
 export function compareManagedFlagInventory(
   snapshot: FliptSnapshot,
+  expectedFlags: readonly ManagedFlag[] = managedFlagInventory.flags,
 ): ManagedFlagDrift {
   const expectedByKey = new Map(
-    managedFlagInventory.flags.map((flag) => [flag.key, flag]),
+    expectedFlags.map((flag) => [flag.key, flag]),
   );
   const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
   const expectedKeys = [...expectedByKey.keys()].sort();
@@ -205,7 +206,7 @@ export function compareManagedFlagInventory(
   return {
     missingInFlipt: expectedKeys.filter((key) => !actualByKey.has(key)),
     undeclaredInInventory: actualKeys.filter((key) => !expectedByKey.has(key)),
-    contractMismatches: managedFlagInventory.flags.flatMap((expected) => {
+    contractMismatches: expectedFlags.flatMap((expected) => {
       const actual = actualByKey.get(expected.key);
       return actual === undefined ? [] : contractErrors(expected, actual);
     }),
@@ -232,7 +233,7 @@ export async function fetchFliptSnapshot(
   options: FetchFliptSnapshotOptions,
 ): Promise<FliptSnapshot> {
   const namespace = options.namespace ?? managedFlagInventory.namespace;
-  const environment = options.environment ?? managedFlagInventory.environment;
+  const environment = options.environment;
   const url = `${options.url.replace(/\/$/u, "")}/internal/v1/evaluation/snapshot/namespace/${encodeURIComponent(namespace)}`;
   const fetcher: FliptFetcher =
     options.fetcher ?? ((input, init) => fetch(input, init));

--- a/packages/feature-flags/src/managed-flag-drift.ts
+++ b/packages/feature-flags/src/managed-flag-drift.ts
@@ -196,9 +196,7 @@ export function compareManagedFlagInventory(
   snapshot: FliptSnapshot,
   expectedFlags: readonly ManagedFlag[] = managedFlagInventory.flags,
 ): ManagedFlagDrift {
-  const expectedByKey = new Map(
-    expectedFlags.map((flag) => [flag.key, flag]),
-  );
+  const expectedByKey = new Map(expectedFlags.map((flag) => [flag.key, flag]));
   const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
   const expectedKeys = [...expectedByKey.keys()].sort();
   const actualKeys = [...actualByKey.keys()].sort();

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -1,7 +1,6 @@
 {
-  "version": 1,
+  "version": 2,
   "namespace": "default",
-  "environment": "default",
   "flags": [
     {
       "key": "ai_reports_enabled",
@@ -25,7 +24,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "ai_reports_unlimited",
@@ -49,7 +50,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "ai_reviews_enabled",
@@ -73,7 +76,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "betting_enabled",
@@ -97,7 +102,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "betting_player_bet_outcome_dm_enabled",
@@ -121,7 +128,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "betting_settlement_dm_enabled",
@@ -145,7 +154,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "competition_builder_v2_enabled",
@@ -169,7 +180,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "debug",
@@ -193,7 +206,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "initial_match_history_import_enabled",
@@ -202,7 +217,9 @@
       "purpose": "Enable the initial Scout match-history import.",
       "type": "boolean",
       "default": false,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-consumer-player-profiles-enabled",
@@ -211,7 +228,9 @@
       "purpose": "Enable Scout consumer player profiles.",
       "type": "boolean",
       "default": false,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "tournament_lobbies_enabled",
@@ -235,7 +254,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "weekly_parlays_enabled",
@@ -259,7 +280,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-betting-parlay-ai-model",
@@ -268,7 +291,9 @@
       "purpose": "Select the Scout parlay AI model.",
       "type": "variant",
       "default": "gpt-5.6-sol",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-bucks-ask-model",
@@ -277,7 +302,9 @@
       "purpose": "Select the Scout Bryan Bucks ask model.",
       "type": "variant",
       "default": "gpt-5.6-luna",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-explore-model",
@@ -286,7 +313,9 @@
       "purpose": "Select the Scout Explore AI model.",
       "type": "variant",
       "default": "gpt-5.6-sol",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-report-ai-model",
@@ -295,7 +324,9 @@
       "purpose": "Select the Scout report AI model.",
       "type": "variant",
       "default": "gpt-5.6-sol",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-tournament-api-mode",
@@ -304,7 +335,9 @@
       "purpose": "Select the Scout tournament API mode.",
       "type": "variant",
       "default": "stub",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "scout-tournament-max-open-lobbies",
@@ -313,7 +346,9 @@
       "purpose": "Bound the number of concurrently open Scout tournament lobbies.",
       "type": "variant",
       "default": "10",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "explore-guild-allowlist",
@@ -322,7 +357,9 @@
       "purpose": "Select the Scout guilds allowed to use Explore.",
       "type": "variant",
       "default": "1337623164146155593",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "llm-daily-token-budget",
@@ -331,7 +368,9 @@
       "purpose": "Bound Scout daily LLM token usage.",
       "type": "variant",
       "default": "20000000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "llm-hourly-token-budget",
@@ -340,7 +379,9 @@
       "purpose": "Bound Scout hourly LLM token usage.",
       "type": "variant",
       "default": "2000000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-activity-tracking-enabled",
@@ -349,7 +390,9 @@
       "purpose": "Enable Birmel activity tracking and role aggregation.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-agent-max-steps",
@@ -358,7 +401,9 @@
       "purpose": "Bound Birmel agent steps.",
       "type": "variant",
       "default": "8",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-agent-response-timeout-ms",
@@ -367,7 +412,9 @@
       "purpose": "Bound Birmel agent response time.",
       "type": "variant",
       "default": "120000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-agent-router-timeout-ms",
@@ -376,7 +423,9 @@
       "purpose": "Bound Birmel agent router time.",
       "type": "variant",
       "default": "30000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-birthdays-enabled",
@@ -385,7 +434,9 @@
       "purpose": "Enable Birmel birthday announcements and roles.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-daily-posts-enabled",
@@ -394,7 +445,9 @@
       "purpose": "Enable Birmel daily posts.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-elections-enabled",
@@ -403,7 +456,9 @@
       "purpose": "Enable Birmel elections.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-llm-classifier-model",
@@ -412,7 +467,9 @@
       "purpose": "Select the Birmel classifier model.",
       "type": "variant",
       "default": "gpt-5.4-nano",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-llm-embedding-model",
@@ -421,7 +478,9 @@
       "purpose": "Select the Birmel embedding model.",
       "type": "variant",
       "default": "text-embedding-3-small",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-llm-max-output-tokens",
@@ -430,7 +489,9 @@
       "purpose": "Bound Birmel LLM output tokens.",
       "type": "variant",
       "default": "4096",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-llm-memory-model",
@@ -439,7 +500,9 @@
       "purpose": "Select the Birmel memory model.",
       "type": "variant",
       "default": "gpt-5.4-nano",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-llm-model",
@@ -448,7 +511,9 @@
       "purpose": "Select the Birmel primary LLM model.",
       "type": "variant",
       "default": "gpt-5.6-sol",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-llm-reasoning-effort",
@@ -457,7 +522,9 @@
       "purpose": "Select Birmel reasoning effort.",
       "type": "variant",
       "default": "medium",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-persona-enabled",
@@ -466,7 +533,9 @@
       "purpose": "Enable Birmel persona projection.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-persona-style-model",
@@ -475,7 +544,9 @@
       "purpose": "Select the Birmel persona style model.",
       "type": "variant",
       "default": "gpt-5.4-nano",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-responder-enabled",
@@ -484,7 +555,9 @@
       "purpose": "Enable the Birmel conversational responder.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-responder-engagement-window-ms",
@@ -493,7 +566,9 @@
       "purpose": "Bound the Birmel responder engagement window.",
       "type": "variant",
       "default": "180000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-responder-transcript-max-messages",
@@ -502,7 +577,9 @@
       "purpose": "Bound Birmel responder transcript messages.",
       "type": "variant",
       "default": "50",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "birmel-responder-transcript-window-ms",
@@ -511,7 +588,9 @@
       "purpose": "Bound the Birmel responder transcript window.",
       "type": "variant",
       "default": "3600000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "karma-admin-user-id",
@@ -520,7 +599,9 @@
       "purpose": "Select the Karma administrator user.",
       "type": "variant",
       "default": "160509172704739328",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "karma-emoji",
@@ -529,7 +610,9 @@
       "purpose": "Select the emoji that awards karma.",
       "type": "variant",
       "default": "⭐",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "player-card-enabled",
@@ -538,7 +621,9 @@
       "purpose": "Enable Streambot player cards.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-idle-timeout-seconds",
@@ -547,7 +632,9 @@
       "purpose": "Bound Streambot idle timeout.",
       "type": "variant",
       "default": "300",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-player-card-repost-after-messages",
@@ -556,7 +643,9 @@
       "purpose": "Set Streambot player-card repost interval.",
       "type": "variant",
       "default": "5",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-player-card-tick-ms",
@@ -565,7 +654,9 @@
       "purpose": "Set Streambot player-card refresh interval.",
       "type": "variant",
       "default": "10000",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-playlist-limit",
@@ -574,7 +665,9 @@
       "purpose": "Bound the Streambot playlist.",
       "type": "variant",
       "default": "100",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-reconnect-delay-seconds",
@@ -583,7 +676,9 @@
       "purpose": "Set Streambot reconnect delay.",
       "type": "variant",
       "default": "5",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-reconnect-enabled",
@@ -592,7 +687,9 @@
       "purpose": "Enable Streambot reconnects after transient voice disconnects.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-reconnect-max-attempts",
@@ -601,7 +698,9 @@
       "purpose": "Bound Streambot reconnect attempts.",
       "type": "variant",
       "default": "3",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-subtitle-languages",
@@ -610,7 +709,9 @@
       "purpose": "Select Streambot subtitle languages.",
       "type": "variant",
       "default": "en",
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "streambot-subtitles-include-auto-generated",
@@ -619,7 +720,9 @@
       "purpose": "Use auto-generated captions when human subtitles are unavailable.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "subtitles-enabled",
@@ -628,7 +731,9 @@
       "purpose": "Enable Streambot subtitles.",
       "type": "boolean",
       "default": true,
-      "rollouts": []
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
     }
   ],
   "exemptions": [
@@ -673,6 +778,20 @@
         "equivalent startup configuration"
       ],
       "reason": "The service needs these values before a flag provider can initialize, so they cannot be sourced from Flipt."
+    }
+  ],
+  "environments": [
+    {
+      "key": "default",
+      "overrides": []
+    },
+    {
+      "key": "beta",
+      "overrides": []
+    },
+    {
+      "key": "prod",
+      "overrides": []
     }
   ]
 }

--- a/packages/feature-flags/src/managed-flag-inventory.schema.json
+++ b/packages/feature-flags/src/managed-flag-inventory.schema.json
@@ -1,133 +1,161 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "constraint": {
+      "type": "object",
+      "required": ["type", "property", "operator", "value"],
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "property": { "type": "string", "minLength": 1 },
+        "operator": { "type": "string", "minLength": 1 },
+        "value": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "rollout": {
+      "type": "object",
+      "required": [
+        "segmentKey",
+        "segmentOperator",
+        "matchType",
+        "constraints",
+        "result"
+      ],
+      "properties": {
+        "segmentKey": { "type": "string", "minLength": 1 },
+        "segmentOperator": { "type": "string", "minLength": 1 },
+        "matchType": { "type": "string", "minLength": 1 },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/constraint" }
+        },
+        "result": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "segment": {
+      "type": "object",
+      "required": ["key", "matchType", "constraints"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "matchType": { "type": "string", "minLength": 1 },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/constraint" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "rule": {
+      "type": "object",
+      "required": ["rank", "segmentOperator", "segments", "distributions"],
+      "properties": {
+        "rank": { "type": "integer", "minimum": 0 },
+        "segmentOperator": { "type": "string", "minLength": 1 },
+        "segments": { "type": "array", "items": { "$ref": "#/$defs/segment" } },
+        "distributions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["variantKey", "rollout", "variantAttachment"],
+            "properties": {
+              "variantKey": { "type": "string", "minLength": 1 },
+              "rollout": { "type": "number", "minimum": 0, "maximum": 100 },
+              "variantAttachment": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "thresholdRollout": {
+      "type": "object",
+      "required": ["rank", "percentage", "result"],
+      "properties": {
+        "rank": { "type": "integer", "minimum": 0 },
+        "percentage": { "type": "number", "minimum": 0, "maximum": 100 },
+        "result": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "behavior": {
+      "type": "object",
+      "required": ["type", "default", "rollouts", "rules", "thresholdRollouts"],
+      "properties": {
+        "type": { "enum": ["boolean", "variant"] },
+        "default": {},
+        "rollouts": { "type": "array", "items": { "$ref": "#/$defs/rollout" } },
+        "rules": { "type": "array", "items": { "$ref": "#/$defs/rule" } },
+        "thresholdRollouts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/thresholdRollout" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "boolean" } } },
+          "then": { "properties": { "default": { "type": "boolean" } } }
+        },
+        {
+          "if": { "properties": { "type": { "const": "variant" } } },
+          "then": { "properties": { "default": { "type": "string" } } }
+        }
+      ]
+    },
+    "override": {
+      "allOf": [
+        { "$ref": "#/$defs/behavior" },
+        {
+          "type": "object",
+          "required": ["key"],
+          "properties": { "key": { "type": "string", "minLength": 1 } }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "flag": {
+      "allOf": [
+        { "$ref": "#/$defs/behavior" },
+        {
+          "type": "object",
+          "required": ["key", "owner", "source", "purpose"],
+          "properties": {
+            "key": { "type": "string", "minLength": 1 },
+            "owner": { "type": "string", "minLength": 1 },
+            "source": { "type": "string", "minLength": 1 },
+            "purpose": { "type": "string", "minLength": 1 }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    }
+  },
   "type": "object",
-  "required": ["version", "namespace", "environment", "flags", "exemptions"],
+  "required": ["version", "namespace", "environments", "flags", "exemptions"],
   "properties": {
-    "version": { "const": 1 },
+    "version": { "const": 2 },
     "namespace": { "type": "string", "minLength": 1 },
-    "environment": { "type": "string", "minLength": 1 },
-    "flags": {
+    "environments": {
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": [
-          "key",
-          "owner",
-          "source",
-          "purpose",
-          "type",
-          "default",
-          "rollouts"
-        ],
+        "required": ["key", "overrides"],
         "properties": {
           "key": { "type": "string", "minLength": 1 },
-          "owner": { "type": "string", "minLength": 1 },
-          "source": { "type": "string", "minLength": 1 },
-          "purpose": { "type": "string", "minLength": 1 },
-          "type": { "enum": ["boolean", "variant"] },
-          "default": {},
-          "rollouts": {
+          "overrides": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "segmentKey",
-                "segmentOperator",
-                "matchType",
-                "constraints",
-                "result"
-              ],
-              "properties": {
-                "segmentKey": { "type": "string", "minLength": 1 },
-                "segmentOperator": { "type": "string", "minLength": 1 },
-                "matchType": { "type": "string", "minLength": 1 },
-                "constraints": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["type", "property", "operator", "value"],
-                    "properties": {
-                      "type": { "type": "string", "minLength": 1 },
-                      "property": { "type": "string", "minLength": 1 },
-                      "operator": { "type": "string", "minLength": 1 },
-                      "value": { "type": "string", "minLength": 1 }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "result": { "type": "boolean" }
-              },
-              "additionalProperties": false
-            }
-          },
-          "rules": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "rank",
-                "segmentOperator",
-                "segments",
-                "distributions"
-              ],
-              "properties": {
-                "rank": { "type": "integer", "minimum": 0 },
-                "segmentOperator": { "type": "string", "minLength": 1 },
-                "segments": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["key", "matchType", "constraints"],
-                    "properties": {
-                      "key": { "type": "string", "minLength": 1 },
-                      "matchType": { "type": "string", "minLength": 1 },
-                      "constraints": { "type": "array" }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "distributions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["variantKey", "rollout", "variantAttachment"],
-                    "properties": {
-                      "variantKey": { "type": "string", "minLength": 1 },
-                      "rollout": {
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 100
-                      },
-                      "variantAttachment": { "type": "string" }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "thresholdRollouts": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": ["rank", "percentage", "result"],
-              "properties": {
-                "rank": { "type": "integer", "minimum": 0 },
-                "percentage": {
-                  "type": "number",
-                  "minimum": 0,
-                  "maximum": 100
-                },
-                "result": { "type": "boolean" }
-              },
-              "additionalProperties": false
-            }
+            "items": { "$ref": "#/$defs/override" }
           }
         },
         "additionalProperties": false
       }
+    },
+    "flags": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/flag" }
     },
     "exemptions": {
       "type": "array",
@@ -136,7 +164,10 @@
         "required": ["category", "controls", "reason"],
         "properties": {
           "category": { "type": "string", "minLength": 1 },
-          "controls": { "type": "array", "items": { "type": "string" } },
+          "controls": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
           "reason": { "type": "string", "minLength": 1 }
         },
         "additionalProperties": false

--- a/packages/feature-flags/src/managed-flag-inventory.test.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import {
+  ManagedFlagInventorySchema,
+  materializeManagedEnvironment,
+} from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
+
+function inventory(overrides: unknown[] = []) {
+  return {
+    version: 2,
+    namespace: "default",
+    environments: [
+      { key: "beta", overrides },
+      { key: "prod", overrides: [] },
+    ],
+    flags: [
+      {
+        key: "example",
+        owner: "test",
+        source: "test",
+        purpose: "Exercise environment overrides.",
+        type: "variant",
+        default: "sol",
+        rollouts: [],
+        rules: [],
+        thresholdRollouts: [],
+      },
+    ],
+    exemptions: [],
+  };
+}
+
+const fullOverride = {
+  key: "example",
+  type: "variant",
+  default: "luna",
+  rollouts: [],
+  rules: [],
+  thresholdRollouts: [],
+};
+
+describe("ManagedFlagInventorySchema", () => {
+  test("materializes a full-state environment override", () => {
+    const parsed = ManagedFlagInventorySchema.parse(inventory([fullOverride]));
+    expect(materializeManagedEnvironment(parsed, "beta")[0]?.default).toBe(
+      "luna",
+    );
+    expect(materializeManagedEnvironment(parsed, "prod")[0]?.default).toBe(
+      "sol",
+    );
+  });
+
+  test("rejects duplicate environments", () => {
+    const value = inventory();
+    value.environments[1] = { key: "beta", overrides: [] };
+    expect(ManagedFlagInventorySchema.safeParse(value).success).toBe(false);
+  });
+
+  test("rejects unknown and duplicate override keys", () => {
+    expect(
+      ManagedFlagInventorySchema.safeParse(
+        inventory([{ ...fullOverride, key: "unknown" }]),
+      ).success,
+    ).toBe(false);
+    expect(
+      ManagedFlagInventorySchema.safeParse(
+        inventory([fullOverride, fullOverride]),
+      ).success,
+    ).toBe(false);
+  });
+
+  test("rejects type mismatches and partial behavioral overrides", () => {
+    expect(
+      ManagedFlagInventorySchema.safeParse(
+        inventory([{ ...fullOverride, type: "boolean", default: true }]),
+      ).success,
+    ).toBe(false);
+    expect(
+      ManagedFlagInventorySchema.safeParse(
+        inventory([{ key: "example", type: "variant", default: "luna" }]),
+      ).success,
+    ).toBe(false);
+  });
+});

--- a/packages/feature-flags/src/managed-flag-inventory.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.ts
@@ -43,58 +43,161 @@ export const ManagedFlagRolloutSchema = z.object({
   result: z.boolean(),
 });
 
-const ManagedFlagFields = {
+const ManagedFlagBehaviorFields = {
+  rollouts: z.array(ManagedFlagRolloutSchema),
+  rules: z.array(ManagedFlagRuleSchema),
+  thresholdRollouts: z.array(ManagedFlagThresholdRolloutSchema),
+};
+
+const ManagedFlagMetadataFields = {
   key: z.string().min(1),
   owner: z.string().min(1),
   source: z.string().min(1),
   purpose: z.string().min(1),
-  rollouts: z.array(ManagedFlagRolloutSchema),
-  rules: z.array(ManagedFlagRuleSchema).default([]),
-  thresholdRollouts: z.array(ManagedFlagThresholdRolloutSchema).default([]),
 };
 
 const ManagedFlagSchema = z.discriminatedUnion("type", [
   z.object({
-    ...ManagedFlagFields,
+    ...ManagedFlagMetadataFields,
+    ...ManagedFlagBehaviorFields,
     type: z.literal("boolean"),
     default: z.boolean(),
   }),
   z.object({
-    ...ManagedFlagFields,
+    ...ManagedFlagMetadataFields,
+    ...ManagedFlagBehaviorFields,
     type: z.literal("variant"),
     default: z.string(),
   }),
 ]);
 
-export type ManagedFlag = z.infer<typeof ManagedFlagSchema>;
+const ManagedFlagOverrideSchema = z.discriminatedUnion("type", [
+  z.object({
+    key: z.string().min(1),
+    ...ManagedFlagBehaviorFields,
+    type: z.literal("boolean"),
+    default: z.boolean(),
+  }),
+  z.object({
+    key: z.string().min(1),
+    ...ManagedFlagBehaviorFields,
+    type: z.literal("variant"),
+    default: z.string(),
+  }),
+]);
 
-export const ManagedFlagInventorySchema = z
-  .object({
-    version: z.literal(1),
-    namespace: z.string().min(1),
-    environment: z.string().min(1),
-    flags: z.array(ManagedFlagSchema).min(1),
-    exemptions: z.array(
-      z.object({
-        category: z.string().min(1),
-        controls: z.array(z.string().min(1)),
-        reason: z.string().min(1),
-      }),
-    ),
-  })
-  .superRefine((value, context) => {
-    const seen = new Set<string>();
-    for (const [index, flag] of value.flags.entries()) {
-      if (seen.has(flag.key)) {
+const ManagedEnvironmentSchema = z.object({
+  key: z.string().min(1),
+  overrides: z.array(ManagedFlagOverrideSchema),
+});
+
+const ManagedFlagInventoryBaseSchema = z.object({
+  version: z.literal(2),
+  namespace: z.string().min(1),
+  environments: z.array(ManagedEnvironmentSchema).min(1),
+  flags: z.array(ManagedFlagSchema).min(1),
+  exemptions: z.array(
+    z.object({
+      category: z.string().min(1),
+      controls: z.array(z.string().min(1)),
+      reason: z.string().min(1),
+    }),
+  ),
+});
+
+export const ManagedFlagInventorySchema =
+  ManagedFlagInventoryBaseSchema.superRefine((value, context) => {
+    const flagsByKey = new Map(value.flags.map((flag) => [flag.key, flag]));
+    if (flagsByKey.size !== value.flags.length) {
+      context.addIssue({
+        code: "custom",
+        message: "duplicate managed flag key",
+        path: ["flags"],
+      });
+    }
+
+    const environmentKeys = new Set<string>();
+    for (const [
+      environmentIndex,
+      environment,
+    ] of value.environments.entries()) {
+      if (environmentKeys.has(environment.key)) {
         context.addIssue({
           code: "custom",
-          message: `duplicate managed flag key: ${flag.key}`,
-          path: ["flags", index, "key"],
+          message: `duplicate managed environment: ${environment.key}`,
+          path: ["environments", environmentIndex, "key"],
         });
       }
-      seen.add(flag.key);
+      environmentKeys.add(environment.key);
+
+      const overrideKeys = new Set<string>();
+      for (const [overrideIndex, override] of environment.overrides.entries()) {
+        const path = [
+          "environments",
+          environmentIndex,
+          "overrides",
+          overrideIndex,
+          "key",
+        ];
+        if (overrideKeys.has(override.key)) {
+          context.addIssue({
+            code: "custom",
+            message: `duplicate override key: ${override.key}`,
+            path,
+          });
+        }
+        overrideKeys.add(override.key);
+
+        const baseline = flagsByKey.get(override.key);
+        if (baseline === undefined) {
+          context.addIssue({
+            code: "custom",
+            message: `unknown override key: ${override.key}`,
+            path,
+          });
+        } else if (baseline.type !== override.type) {
+          context.addIssue({
+            code: "custom",
+            message: `override type mismatch for ${override.key}: expected ${baseline.type}, got ${override.type}`,
+            path: [
+              "environments",
+              environmentIndex,
+              "overrides",
+              overrideIndex,
+              "type",
+            ],
+          });
+        }
+      }
     }
   });
+
+export type ManagedFlag = z.infer<typeof ManagedFlagSchema>;
+export type ManagedEnvironment = z.infer<typeof ManagedEnvironmentSchema>;
+
+export function materializeManagedEnvironment(
+  inventoryValue: z.infer<typeof ManagedFlagInventoryBaseSchema>,
+  environmentKey: string,
+): ManagedFlag[] {
+  const environment = inventoryValue.environments.find(
+    (candidate) => candidate.key === environmentKey,
+  );
+  if (environment === undefined)
+    throw new Error(`unknown managed environment: ${environmentKey}`);
+
+  const overridesByKey = new Map(
+    environment.overrides.map((override) => [override.key, override]),
+  );
+  return inventoryValue.flags.map((flag) => {
+    const override = overridesByKey.get(flag.key);
+    if (override === undefined) return flag;
+    if (flag.type === "boolean" && override.type === "boolean")
+      return { ...flag, ...override };
+    if (flag.type === "variant" && override.type === "variant")
+      return { ...flag, ...override };
+    throw new Error(`override type mismatch for ${flag.key}`);
+  });
+}
 
 export const managedFlagInventory = ManagedFlagInventorySchema.parse(inventory);
 

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { App } from "cdk8s";
 import { z } from "zod";
 import { createFliptChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/flipt.ts";
+import { createEnvironmentMigrationScript } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
 
 const ManifestSchema = z
   .object({
@@ -15,6 +16,10 @@ const ContainerSchema = z
     name: z.string(),
     image: z.string(),
     command: z.array(z.string()).optional(),
+    args: z.array(z.string()).optional(),
+    volumeMounts: z
+      .array(z.object({ name: z.string(), mountPath: z.string() }).loose())
+      .optional(),
     securityContext: z
       .object({
         runAsUser: z.number().optional(),
@@ -30,7 +35,15 @@ const DeploymentSchema = z
   .object({
     spec: z.object({
       template: z.object({
-        spec: z.object({ containers: z.array(ContainerSchema) }).loose(),
+        metadata: z
+          .object({ annotations: z.record(z.string(), z.string()) })
+          .loose(),
+        spec: z
+          .object({
+            containers: z.array(ContainerSchema),
+            initContainers: z.array(ContainerSchema),
+          })
+          .loose(),
       }),
     }),
   })
@@ -62,6 +75,11 @@ function findManifest(
   if (manifest === undefined)
     throw new Error(`Missing ${kind}/${name} manifest`);
   return manifest;
+}
+
+async function run(command: string[]): Promise<number> {
+  const subprocess = Bun.spawn(command, { stdout: "ignore", stderr: "ignore" });
+  return subprocess.exited;
 }
 
 describe("Flipt chart", () => {
@@ -123,9 +141,58 @@ describe("Flipt chart", () => {
     expect(yaml).toContain('version: "2.0"');
     expect(yaml).toContain("type: local");
     expect(yaml).toContain("path: /var/opt/flipt/data");
+    expect(yaml).toContain("path: /var/opt/flipt/data-beta");
+    expect(yaml).toContain("path: /var/opt/flipt/data-prod");
+    expect(yaml).toContain("name: beta");
+    expect(yaml).toContain("name: prod");
     // Both default to true and would fail continuously against DNS-only egress.
     expect(yaml).toContain("check_for_updates: false");
     expect(yaml).toContain("telemetry_enabled: false");
+  });
+
+  it("restarts when the complete Flipt configuration changes", () => {
+    const deployment = DeploymentSchema.parse(
+      findManifest(synthesize(), "Deployment", "flipt"),
+    );
+    expect(
+      deployment.spec.template.metadata.annotations["config-hash"],
+    ).toMatch(/^[a-f\d]{12}$/);
+  });
+
+  it("copies only absent environment repositories and rejects partial state", () => {
+    const deployment = DeploymentSchema.parse(
+      findManifest(synthesize(), "Deployment", "flipt"),
+    );
+    const migration = deployment.spec.template.spec.initContainers.find(
+      (container) => container.name === "migrate-environments",
+    );
+    expect(migration?.command).toEqual(["/bin/sh", "-c"]);
+    const script = migration?.args?.[0] ?? "";
+    expect(script).toContain('validate_repo "$source_repo"');
+    expect(script).toContain('if [ -e "$destination" ]');
+    expect(script).toContain('cp -a "$source_repo" "$destination"');
+    expect(script).toContain('diff -qr "$source_repo" "$destination"');
+    expect(script).toContain('copy_environment "/var/opt/flipt/data-beta"');
+    expect(script).toContain('copy_environment "/var/opt/flipt/data-prod"');
+    expect(migration?.volumeMounts?.map((mount) => mount.mountPath)).toContain(
+      "/var/opt/flipt",
+    );
+  });
+
+  it("fails fast for an invalid source or partial destination repository", async () => {
+    const root = `/tmp/flipt-migration-test-${crypto.randomUUID()}`;
+    expect(await run(["mkdir", "-p", `${root}/data/objects`])).toBe(0);
+    expect(
+      await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
+    ).not.toBe(0);
+
+    await Bun.write(`${root}/data/HEAD`, "ref: refs/heads/main\n");
+    await Bun.write(`${root}/data/config`, "[core]\n\tbare = true\n");
+    expect(await run(["mkdir", "-p", `${root}/data-beta`])).toBe(0);
+    expect(
+      await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
+    ).not.toBe(0);
+    expect(await run(["rm", "-rf", root])).toBe(0);
   });
 
   it("restricts egress to DNS only", () => {

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -170,7 +170,6 @@ describe("Flipt chart", () => {
     const script = migration?.args?.[0] ?? "";
     expect(script).toContain('validate_repo "$source_repo"');
     expect(script).toContain('if [ -e "$destination" ]');
-    expect(script).toContain('diff -qr "$source_repo" "$destination"');
     expect(script).toContain('temporary="${destination}.migrating"');
     expect(script).toContain('cp -a "$source_repo" "$temporary"');
     expect(script).toContain('diff -qr "$source_repo" "$temporary"');
@@ -195,6 +194,27 @@ describe("Flipt chart", () => {
     expect(
       await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
     ).not.toBe(0);
+    expect(await run(["rm", "-rf", root])).toBe(0);
+  });
+
+  it("preserves an already initialized environment with different content", async () => {
+    const root = `/tmp/flipt-migration-test-${crypto.randomUUID()}`;
+    expect(await run(["mkdir", "-p", `${root}/data/objects`])).toBe(0);
+    await Bun.write(`${root}/data/HEAD`, "ref: refs/heads/main\n");
+    await Bun.write(`${root}/data/config`, "[core]\n\tbare = true\n");
+    expect(await run(["mkdir", "-p", `${root}/data-beta/objects`])).toBe(0);
+    await Bun.write(`${root}/data-beta/HEAD`, "ref: refs/heads/luna\n");
+    await Bun.write(`${root}/data-beta/config`, "[core]\n\tbare = false\n");
+
+    expect(
+      await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
+    ).toBe(0);
+    expect(await Bun.file(`${root}/data-prod/HEAD`).text()).toBe(
+      "ref: refs/heads/main\n",
+    );
+    expect(await Bun.file(`${root}/data-beta/HEAD`).text()).toBe(
+      "ref: refs/heads/luna\n",
+    );
     expect(await run(["rm", "-rf", root])).toBe(0);
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -170,8 +170,11 @@ describe("Flipt chart", () => {
     const script = migration?.args?.[0] ?? "";
     expect(script).toContain('validate_repo "$source_repo"');
     expect(script).toContain('if [ -e "$destination" ]');
-    expect(script).toContain('cp -a "$source_repo" "$destination"');
     expect(script).toContain('diff -qr "$source_repo" "$destination"');
+    expect(script).toContain('temporary="${destination}.migrating"');
+    expect(script).toContain('cp -a "$source_repo" "$temporary"');
+    expect(script).toContain('diff -qr "$source_repo" "$temporary"');
+    expect(script).toContain('mv "$temporary" "$destination"');
     expect(script).toContain('copy_environment "/var/opt/flipt/data-beta"');
     expect(script).toContain('copy_environment "/var/opt/flipt/data-prod"');
     expect(migration?.volumeMounts?.map((mount) => mount.mountPath)).toContain(

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
@@ -114,11 +114,18 @@ copy_environment() {
   destination="$1"
   if [ -e "$destination" ]; then
     validate_repo "$destination"
+    diff -qr "$source_repo" "$destination"
     return
   fi
 
-  cp -a "$source_repo" "$destination"
-  diff -qr "$source_repo" "$destination"
+  temporary="\${destination}.migrating"
+  if [ -e "$temporary" ]; then
+    echo "Flipt migration has an incomplete temporary repository: $temporary" >&2
+    exit 1
+  fi
+  cp -a "$source_repo" "$temporary"
+  diff -qr "$source_repo" "$temporary"
+  mv "$temporary" "$destination"
 }
 
 validate_repo "$source_repo"

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
@@ -114,7 +114,6 @@ copy_environment() {
   destination="$1"
   if [ -e "$destination" ]; then
     validate_repo "$destination"
-    diff -qr "$source_repo" "$destination"
     return
   fi
 

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
@@ -65,11 +65,25 @@ storage:
     backend:
       type: local
       path: ${DATA_PATH}/data
+  beta:
+    backend:
+      type: local
+      path: ${DATA_PATH}/data-beta
+  prod:
+    backend:
+      type: local
+      path: ${DATA_PATH}/data-prod
 environments:
   default:
     name: default
     default: true
     storage: default
+  beta:
+    name: beta
+    storage: beta
+  prod:
+    name: prod
+    storage: prod
 authentication:
   required: false
 metrics:
@@ -82,6 +96,38 @@ meta:
   telemetry_enabled: false
   state_directory: ${DATA_PATH}/state
 `;
+
+export function createEnvironmentMigrationScript(dataPath: string): string {
+  return `set -eu
+
+source_repo="${dataPath}/data"
+
+validate_repo() {
+  repo="$1"
+  if [ ! -f "$repo/HEAD" ] || [ ! -f "$repo/config" ] || [ ! -d "$repo/objects" ]; then
+    echo "Flipt repository is missing or structurally invalid: $repo" >&2
+    exit 1
+  fi
+}
+
+copy_environment() {
+  destination="$1"
+  if [ -e "$destination" ]; then
+    validate_repo "$destination"
+    return
+  fi
+
+  cp -a "$source_repo" "$destination"
+  diff -qr "$source_repo" "$destination"
+}
+
+validate_repo "$source_repo"
+copy_environment "${dataPath}/data-beta"
+copy_environment "${dataPath}/data-prod"
+`;
+}
+
+const MIGRATE_ENVIRONMENTS_SCRIPT = createEnvironmentMigrationScript(DATA_PATH);
 
 export function createFliptDeployment(chart: Chart) {
   const deployment = new Deployment(chart, "flipt", {
@@ -97,9 +143,47 @@ export function createFliptDeployment(chart: Chart) {
     data: { "config.yml": FLIPT_CONFIG },
   });
 
+  deployment.podMetadata.addAnnotation(
+    "config-hash",
+    new Bun.CryptoHasher("sha256")
+      .update(FLIPT_CONFIG)
+      .digest("hex")
+      .slice(0, 12),
+  );
+
   const dataVolume = new ZfsNvmeVolume(chart, "flipt-data", {
     storage: Size.gibibytes(2),
   });
+
+  const persistentDataVolume = Volume.fromPersistentVolumeClaim(
+    chart,
+    "flipt-data-volume",
+    dataVolume.claim,
+  );
+
+  deployment.addInitContainer(
+    withCommonProps({
+      name: "migrate-environments",
+      image: `flipt/flipt:${versions["flipt-io/flipt"]}`,
+      command: ["/bin/sh", "-c"],
+      args: [MIGRATE_ENVIRONMENTS_SCRIPT],
+      resources: {
+        cpu: { request: Cpu.millis(5), limit: Cpu.millis(50) },
+        memory: { request: Size.mebibytes(8), limit: Size.mebibytes(32) },
+      },
+      securityContext: {
+        user: FLIPT_UID,
+        group: FLIPT_GID,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+        allowPrivilegeEscalation: false,
+        privileged: false,
+        capabilities: { drop: [Capability.ALL] },
+        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
+      },
+      volumeMounts: [{ path: DATA_PATH, volume: persistentDataVolume }],
+    }),
+  );
 
   deployment.addContainer(
     withCommonProps({
@@ -144,11 +228,7 @@ export function createFliptDeployment(chart: Chart) {
       volumeMounts: [
         {
           path: DATA_PATH,
-          volume: Volume.fromPersistentVolumeClaim(
-            chart,
-            "flipt-data-volume",
-            dataVolume.claim,
-          ),
+          volume: persistentDataVolume,
         },
         {
           path: "/etc/flipt",

--- a/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
@@ -165,6 +165,7 @@ export function createTemporalOperationsWorkers(
       FLIPT_URL: EnvValue.fromValue(
         "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
       ),
+      FLIPT_ENVIRONMENT: EnvValue.fromValue("default"),
       FRESHRSS_API_URL: EnvValue.fromValue(
         "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
       ),

--- a/packages/temporal/src/activities/flipt-flag-inventory.ts
+++ b/packages/temporal/src/activities/flipt-flag-inventory.ts
@@ -25,15 +25,16 @@ export type FliptFlagInventoryActivities = typeof fliptFlagInventoryActivities;
 
 export const fliptFlagInventoryActivities = {
   async checkFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
+    const environment = requiredEnvironment("FLIPT_ENVIRONMENT");
     const snapshot = await fetchFliptSnapshot({
       url: requiredEnvironment("FLIPT_URL"),
       namespace: managedFlagInventory.namespace,
-      environment: managedFlagInventory.environment,
+      environment,
     });
     const drift = compareManagedFlagInventory(snapshot);
     const result: FliptFlagInventoryResult = {
       namespace: managedFlagInventory.namespace,
-      environment: managedFlagInventory.environment,
+      environment,
       missingInFlipt: drift.missingInFlipt,
       undeclaredInInventory: drift.undeclaredInInventory,
       observedAt: new Date().toISOString(),

--- a/scripts/check-flipt-flag-inventory.test.ts
+++ b/scripts/check-flipt-flag-inventory.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import {
+  managedFlagInventory,
+  materializeManagedEnvironment,
+  type ManagedFlag,
+} from "../packages/feature-flags/src/managed-flag-inventory.ts";
+import {
+  checkManagedEnvironments,
+  selectedManagedEnvironments,
+} from "./check-flipt-flag-inventory.ts";
+
+function snapshotFlag(flag: ManagedFlag) {
+  return {
+    key: flag.key,
+    enabled: flag.type === "boolean" ? flag.default : true,
+    type: flag.type === "boolean" ? "BOOLEAN_FLAG_TYPE" : "VARIANT_FLAG_TYPE",
+    defaultVariant: flag.type === "variant" ? { key: flag.default } : undefined,
+    rules: flag.rules,
+    rollouts: [
+      ...flag.rollouts.map((rollout, rank) => ({
+        type: "SEGMENT_ROLLOUT_TYPE",
+        rank,
+        segment: {
+          value: rollout.result,
+          segmentOperator: rollout.segmentOperator,
+          segments: [
+            {
+              key: rollout.segmentKey,
+              matchType: rollout.matchType,
+              constraints: rollout.constraints,
+            },
+          ],
+        },
+      })),
+      ...flag.thresholdRollouts.map((rollout) => ({
+        type: "THRESHOLD_ROLLOUT_TYPE",
+        rank: rollout.rank,
+        threshold: {
+          percentage: rollout.percentage,
+          value: rollout.result,
+        },
+      })),
+    ],
+  };
+}
+
+function alignedSnapshot(environment: string) {
+  return {
+    flags: materializeManagedEnvironment(managedFlagInventory, environment).map(
+      (flag) => snapshotFlag(flag),
+    ),
+  };
+}
+
+describe("check-flipt-flag-inventory", () => {
+  test("checks every managed environment by default", async () => {
+    const loaded: string[] = [];
+    const messages = await checkManagedEnvironments({
+      namespace: "default",
+      loadSnapshot: (_namespace, environment) => {
+        loaded.push(environment);
+        return Promise.resolve(alignedSnapshot(environment));
+      },
+    });
+
+    expect(loaded).toEqual(["default", "beta", "prod"]);
+    expect(messages).toHaveLength(3);
+  });
+
+  test("checks only an exact environment filter", async () => {
+    const loaded: string[] = [];
+    await checkManagedEnvironments({
+      namespace: "default",
+      environmentFilter: "beta",
+      loadSnapshot: (_namespace, environment) => {
+        loaded.push(environment);
+        return Promise.resolve(alignedSnapshot(environment));
+      },
+    });
+    expect(loaded).toEqual(["beta"]);
+    expect(() => selectedManagedEnvironments("staging")).toThrow(
+      /unknown managed environment filter: staging/,
+    );
+  });
+
+  test("names the failing environment for malformed snapshots and drift", async () => {
+    await expect(
+      checkManagedEnvironments({
+        namespace: "default",
+        environmentFilter: "prod",
+        loadSnapshot: () => Promise.resolve({ flags: [] }),
+      }),
+    ).rejects.toThrow(/default\/prod/);
+
+    await expect(
+      checkManagedEnvironments({
+        namespace: "default",
+        environmentFilter: "beta",
+        loadSnapshot: () => Promise.resolve({ invalid: true }),
+      }),
+    ).rejects.toThrow(/default\/beta/);
+  });
+});

--- a/scripts/check-flipt-flag-inventory.ts
+++ b/scripts/check-flipt-flag-inventory.ts
@@ -1,9 +1,13 @@
 import {
   compareManagedFlagInventory,
   fetchFliptSnapshot,
+  FliptSnapshotSchema,
   formatManagedFlagDrift,
 } from "../packages/feature-flags/src/managed-flag-drift.ts";
-import { managedFlagInventory } from "../packages/feature-flags/src/managed-flag-inventory.ts";
+import {
+  managedFlagInventory,
+  materializeManagedEnvironment,
+} from "../packages/feature-flags/src/managed-flag-inventory.ts";
 
 function argument(name: string): string | undefined {
   const index = Bun.argv.indexOf(name);
@@ -18,7 +22,65 @@ function requiredUrl(): string {
       "FLIPT_URL or --url is required; this operator-only check never guesses a Flipt endpoint",
     );
   }
-  return url.replace(/\/$/, "");
+  return url.replace(/\/$/u, "");
+}
+
+export function selectedManagedEnvironments(
+  environmentFilter: string | undefined,
+): string[] {
+  const keys = managedFlagInventory.environments.map(
+    (environment) => environment.key,
+  );
+  if (environmentFilter === undefined) return keys;
+  if (!keys.includes(environmentFilter)) {
+    throw new Error(`unknown managed environment filter: ${environmentFilter}`);
+  }
+  return [environmentFilter];
+}
+
+export type SnapshotLoader = (
+  namespace: string,
+  environment: string,
+) => Promise<unknown>;
+
+export async function checkManagedEnvironments(options: {
+  namespace: string;
+  environmentFilter?: string | undefined;
+  loadSnapshot: SnapshotLoader;
+}): Promise<string[]> {
+  const messages: string[] = [];
+  for (const environment of selectedManagedEnvironments(
+    options.environmentFilter,
+  )) {
+    const expectedFlags = materializeManagedEnvironment(
+      managedFlagInventory,
+      environment,
+    );
+    let snapshot: Awaited<ReturnType<typeof fetchFliptSnapshot>>;
+    try {
+      snapshot = FliptSnapshotSchema.parse(
+        await options.loadSnapshot(options.namespace, environment),
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Flipt snapshot validation failed in ${options.namespace}/${environment}: ${detail}`,
+        { cause: error },
+      );
+    }
+    const errors = formatManagedFlagDrift(
+      compareManagedFlagInventory(snapshot, expectedFlags),
+    );
+    if (errors.length > 0) {
+      throw new Error(
+        `Flipt managed-flag drift detected in ${options.namespace}/${environment}:\n- ${errors.join("\n- ")}`,
+      );
+    }
+    messages.push(
+      `Flipt managed-flag inventory is aligned: ${expectedFlags.length.toString()} keys in ${options.namespace}/${environment}`,
+    );
+  }
+  return messages;
 }
 
 async function main(): Promise<void> {
@@ -26,24 +88,18 @@ async function main(): Promise<void> {
     argument("--namespace") ??
     Bun.env["FLIPT_NAMESPACE"] ??
     managedFlagInventory.namespace;
-  const environment =
-    argument("--environment") ??
-    Bun.env["FLIPT_ENVIRONMENT"] ??
-    managedFlagInventory.environment;
-  const snapshot = await fetchFliptSnapshot({
-    url: requiredUrl(),
+  const environmentFilter =
+    argument("--environment") ?? Bun.env["FLIPT_ENVIRONMENT"];
+  const url = requiredUrl();
+  const messages = await checkManagedEnvironments({
     namespace,
-    environment,
+    environmentFilter,
+    loadSnapshot: (selectedNamespace, environment) =>
+      fetchFliptSnapshot({ url, namespace: selectedNamespace, environment }),
   });
-  const errors = formatManagedFlagDrift(compareManagedFlagInventory(snapshot));
-  if (errors.length > 0) {
-    throw new Error(
-      `Flipt managed-flag drift detected:\n- ${errors.join("\n- ")}`,
-    );
+  for (const message of messages) {
+    console.log(message);
   }
-  console.log(
-    `Flipt managed-flag inventory is aligned: ${managedFlagInventory.flags.length.toString()} keys in ${namespace}/${environment}`,
-  );
 }
 
-await main();
+if (import.meta.main) await main();


### PR DESCRIPTION
Why

Beta and production need isolated Flipt state before any consumer changes environments. The current single repository must remain the source for existing clients throughout preparation.

What

- upgrades the 53-flag inventory to schema v2 with managed environments and complete behavioral overrides
- checks default, beta, and prod by default, with an exact single-environment filter
- restores the root inventory-check command
- configures three durable local Flipt backends
- clones the validated legacy repository only into absent destinations and verifies each copy
- restarts Flipt deterministically when its ConfigMap changes
- updates the operator how-to and adds focused schema, checker, and cdk8s coverage

Verification

- bunx turbo run typecheck test lint --filter=@shepherdjerred/feature-flags
- bunx turbo run typecheck test lint --filter=@shepherdjerred/root-scripts
- focused Flipt cdk8s test, typecheck, and lint
- wiki typecheck, tests, build, and lint
- bunx lefthook run pre-commit

Rollout

Before deployment, create and verify a scoped backup of the flipt-data PVC. After deployment, verify all three snapshots match and survive a Flipt restart. Existing consumers remain on default. Live backup, deployment, restart, and drift acceptance were not run from this branch.