### PR TITLE
feat(feature-flags): isolate Flipt consumers by deployment stage

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -21,10 +21,14 @@ layered resolver in front of it.
 > and bootstrap**. Everything else is a **feature flag**.
 
 Bootstrap is the part that cannot be a flag because it is needed to construct
-the thing that reads flags: `FLIPT_URL` obviously, but also `ENVIRONMENT` (it is
-the attribute Flipt targets _on_), `PORT` (it binds a listener), `DATABASE_URL`,
-and `TEMPORAL_WORKER_ROLE` (bound one-to-one to a ServiceAccount, so a running
-process cannot rebind).
+the thing that reads flags. `FLIPT_URL` locates the provider, while
+`FLIPT_ENVIRONMENT` selects its isolated storage environment. Every Flipt client
+sets that selector explicitly so a missing deployment value fails loudly.
+
+The application `ENVIRONMENT` remains separate. It describes the application
+stage and may be passed as a targeting attribute. It does not choose where Flipt
+stores or reads flags. Other bootstrap values include `PORT`, `DATABASE_URL`,
+and `TEMPORAL_WORKER_ROLE`.
 
 ## Which layer?
 
@@ -106,10 +110,12 @@ If Flipt ever gains authentication, both of those are worth revisiting.
 ## Durability
 
 Flipt v2 defaults to **in-memory storage**. It accepts flag writes, serves them
-back, and silently loses every one on restart. The deployment therefore
-configures an explicit local git backend on a ZFS PVC, which is backed up by
-Velero. A regression test asserts that configuration is present, because losing
-it produces a service that looks like it works.
+back, and silently loses every one on restart. The deployment therefore gives
+beta and production separate local git backends on a ZFS PVC backed up by
+Velero. Environment isolation prevents a beta model or rollout change from
+altering production. Regression tests assert the storage and client selectors,
+because either omission produces a service that looks healthy while reading the
+wrong contract.
 
 ## Analytics has a different ownership boundary
 

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -66,6 +66,21 @@ inventory. A failed snapshot request does not resolve an existing alert; the
 workflow fails so the Temporal failure watcher can report the unavailable
 check separately.
 
+## 4. Change one environment
+
+Select the intended environment in the Flipt UI before editing a flag. The
+`beta` and `prod` repositories are independent; changing one never updates the
+other.
+
+After the edit, check that environment first:
+
+```bash
+bun run check-flipt-flag-inventory -- --environment prod
+```
+
+Then run the unfiltered command. This catches accidental drift in every managed
+environment before the operator change is considered complete.
+
 :::caution
 Flipt has no authentication. Network reachability is the authorization
 boundary, so keep the endpoint private and do not expose it publicly.

--- a/packages/dotfiles/dot_agents/skills/feature-flags/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/feature-flags/SKILL.md
@@ -24,7 +24,10 @@ ramp, then remove the flag. That is the default path, not an exception.
 
 1. Is it a secret? → 1Password → Kubernetes Secret.
 2. Is it needed before the flag client exists? → **bootstrap env**
-   (`FLIPT_URL`, `ENVIRONMENT`, `PORT`, `DATABASE_URL`, `TEMPORAL_WORKER_ROLE`).
+   (`FLIPT_URL`, `FLIPT_ENVIRONMENT`, application `ENVIRONMENT`, `PORT`,
+   `DATABASE_URL`, `TEMPORAL_WORKER_ROLE`). `ENVIRONMENT` describes the
+   application deployment; `FLIPT_ENVIRONMENT` selects Flipt's isolated
+   storage environment and is required whenever `FEATURE_FLAGS_MODE=flipt`.
 3. Does an end user own it? → a database row.
 4. Shared across packages or languages? → JSON catalog + JSON Schema.
 5. Changes only when code changes? → a constant.
@@ -58,7 +61,8 @@ Flags of your own also need:
 - the consuming namespace added to `CONSUMER_NAMESPACES` in
   `packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts` — Flipt has no auth, so
   that list is the access control;
-- `FEATURE_FLAGS_MODE` and `FLIPT_URL` on the service's cdk8s Deployment;
+- `FEATURE_FLAGS_MODE`, `FLIPT_URL`, and `FLIPT_ENVIRONMENT` on the service's
+  cdk8s Deployment when the mode is `flipt`;
 - `FEATURE_FLAGS_MODE=disabled` wherever tests run.
 
 ## Rules

--- a/packages/feature-flags/src/config/load.test.ts
+++ b/packages/feature-flags/src/config/load.test.ts
@@ -36,6 +36,15 @@ describe("loadFeatureFlagConfiguration", () => {
     ).toThrow(/FLIPT_URL is required/);
   });
 
+  test("flipt mode requires an explicit environment", () => {
+    expect(() =>
+      loadFeatureFlagConfiguration({
+        FEATURE_FLAGS_MODE: "flipt",
+        FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+      }),
+    ).toThrow(/FLIPT_ENVIRONMENT is required/);
+  });
+
   test("flipt mode rejects a malformed URL as a config error", () => {
     expect(() =>
       loadFeatureFlagConfiguration({
@@ -53,12 +62,13 @@ describe("loadFeatureFlagConfiguration", () => {
       loadFeatureFlagConfiguration({
         FEATURE_FLAGS_MODE: "flipt",
         FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+        FLIPT_ENVIRONMENT: "beta",
       }),
     ).toEqual({
       mode: "flipt",
       url: "http://flipt.flipt.svc.cluster.local:8080",
       namespace: "default",
-      environment: "default",
+      environment: "beta",
       pollIntervalSeconds: 300,
     });
   });
@@ -68,6 +78,7 @@ describe("loadFeatureFlagConfiguration", () => {
       loadFeatureFlagConfiguration({
         FEATURE_FLAGS_MODE: "flipt",
         FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+        FLIPT_ENVIRONMENT: "beta",
         FLIPT_POLL_INTERVAL_SECONDS: "0",
       }),
     ).toThrow();

--- a/packages/feature-flags/src/config/load.ts
+++ b/packages/feature-flags/src/config/load.ts
@@ -60,7 +60,7 @@ export function loadFeatureFlagConfiguration(
     mode,
     url: requireVariable(environment, "FLIPT_URL"),
     namespace: environment["FLIPT_NAMESPACE"] ?? "default",
-    environment: environment["FLIPT_ENVIRONMENT"] ?? "default",
+    environment: requireVariable(environment, "FLIPT_ENVIRONMENT"),
     pollIntervalSeconds:
       rawPoll === undefined || rawPoll.length === 0
         ? DEFAULT_POLL_INTERVAL_SECONDS

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -338,7 +338,7 @@
       "source": "scout-dynamic",
       "purpose": "Select the Scout Explore AI model.",
       "type": "variant",
-      "default": "gpt-5.6-sol",
+      "default": "gpt-5.6-luna",
       "rollouts": [],
       "rules": [],
       "thresholdRollouts": []
@@ -809,7 +809,16 @@
   "environments": [
     {
       "key": "default",
-      "overrides": []
+      "overrides": [
+        {
+          "key": "scout-explore-model",
+          "type": "variant",
+          "default": "gpt-5.6-sol",
+          "rollouts": [],
+          "rules": [],
+          "thresholdRollouts": []
+        }
+      ]
     },
     {
       "key": "beta",

--- a/packages/feature-flags/src/managed-flag-inventory.test.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   ManagedFlagInventorySchema,
+  managedFlagInventory,
   materializeManagedEnvironment,
 } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 
@@ -38,7 +39,19 @@ const fullOverride = {
   thresholdRollouts: [],
 };
 
+function exploreModel(environment: string) {
+  return materializeManagedEnvironment(managedFlagInventory, environment).find(
+    (flag) => flag.key === "scout-explore-model",
+  )?.default;
+}
+
 describe("ManagedFlagInventorySchema", () => {
+  test("keeps legacy default on Sol while beta and prod use Luna", () => {
+    expect(exploreModel("default")).toBe("gpt-5.6-sol");
+    expect(exploreModel("beta")).toBe("gpt-5.6-luna");
+    expect(exploreModel("prod")).toBe("gpt-5.6-luna");
+  });
+
   test("materializes a full-state environment override", () => {
     const parsed = ManagedFlagInventorySchema.parse(inventory([fullOverride]));
     expect(materializeManagedEnvironment(parsed, "beta")[0]?.default).toBe(

--- a/packages/feature-flags/src/providers/flipt.test.ts
+++ b/packages/feature-flags/src/providers/flipt.test.ts
@@ -187,7 +187,7 @@ describe("createFliptFetcher", () => {
         // Trailing slash must be normalised away.
         url: "http://flipt.flipt.svc.cluster.local:8080/",
         namespace: "default",
-        environment: "default",
+        environment: "beta",
       });
       await fetcher({ etag: "previous-etag" });
     } finally {
@@ -204,7 +204,7 @@ describe("createFliptFetcher", () => {
     expect(calls[0]?.headers).toEqual({
       Accept: "application/json",
       "x-flipt-accept-server-version": "1.47.0",
-      "x-flipt-environment": "default",
+      "x-flipt-environment": "beta",
       "If-None-Match": "previous-etag",
     });
   });

--- a/packages/homelab/src/cdk8s/src/feature-flag-environments.test.ts
+++ b/packages/homelab/src/cdk8s/src/feature-flag-environments.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import { App, Testing } from "cdk8s";
+import { z } from "zod";
+import { createBirmelChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/birmel.ts";
+import { createMediaChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/media.ts";
+import { createScoutChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/scout.ts";
+import { createStarlightKarmaBotChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/starlight-karma-bot.ts";
+
+const ManifestSchema = z
+  .object({
+    kind: z.string(),
+    metadata: z.object({ name: z.string() }).loose(),
+    spec: z
+      .object({
+        template: z.object({
+          spec: z.object({
+            containers: z.array(
+              z.object({
+                env: z
+                  .array(
+                    z.object({
+                      name: z.string(),
+                      value: z.string().optional(),
+                    }),
+                  )
+                  .optional(),
+              }),
+            ),
+          }),
+        }),
+      })
+      .optional(),
+  })
+  .loose();
+
+async function fliptConsumers(
+  createChart: (app: App) => void | Promise<void>,
+): Promise<{ name: string; environment: string | undefined }[]> {
+  const app = new App();
+  await createChart(app);
+  return app.charts.flatMap((chart) =>
+    z
+      .array(z.unknown())
+      .parse(Testing.synth(chart))
+      .flatMap((manifest) => {
+        const parsed = ManifestSchema.safeParse(manifest);
+        if (!parsed.success || parsed.data.kind !== "Deployment") return [];
+        return (parsed.data.spec?.template.spec.containers ?? []).flatMap(
+          (container) => {
+            const env = new Map(
+              (container.env ?? []).map((entry) => [entry.name, entry.value]),
+            );
+            if (env.get("FEATURE_FLAGS_MODE") !== "flipt") return [];
+            return [
+              {
+                name: parsed.data.metadata.name,
+                environment: env.get("FLIPT_ENVIRONMENT"),
+              },
+            ];
+          },
+        );
+      }),
+  );
+}
+
+describe("Flipt consumer environments", () => {
+  const cases: [string, string, (app: App) => void | Promise<void>][] = [
+    ["Scout beta", "beta", (app: App) => createScoutChart(app, "beta")],
+    ["Scout prod", "prod", (app: App) => createScoutChart(app, "prod")],
+    [
+      "Karma beta",
+      "beta",
+      (app: App) => createStarlightKarmaBotChart(app, "beta"),
+    ],
+    [
+      "Karma prod",
+      "prod",
+      (app: App) => createStarlightKarmaBotChart(app, "prod"),
+    ],
+    ["Birmel", "prod", (app: App) => createBirmelChart(app)],
+    ["Streambot", "prod", (app: App) => createMediaChart(app)],
+  ];
+
+  test.each(cases)(
+    "sets %s to %s",
+    async (_name, expectedEnvironment, createChart) => {
+      const consumers = await fliptConsumers(createChart);
+      expect(consumers).toHaveLength(1);
+      expect(consumers[0]?.environment).toBe(expectedEnvironment);
+    },
+  );
+});

--- a/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
@@ -144,6 +144,7 @@ export function createBirmelDeployment(chart: Chart) {
         // OpenRouter ordinary inference
         // Bootstrap for the flag client — these cannot come from a flag.
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+        FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -221,6 +221,7 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     ENVIRONMENT: EnvValue.fromValue(stage),
     // Bootstrap for the flag client — these cannot come from a flag.
     FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+    FLIPT_ENVIRONMENT: EnvValue.fromValue(stage),
     TEMPORAL_NAMESPACE: EnvValue.fromValue("default"),
     FLIPT_URL: EnvValue.fromValue(
       "http://flipt-flipt-service.flipt.svc.cluster.local:8080",

--- a/packages/homelab/src/cdk8s/src/resources/starlight-karma-bot/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/starlight-karma-bot/index.ts
@@ -133,6 +133,7 @@ export function createStarlightKarmaBotDeployment(chart: Chart, stage: Stage) {
         KARMA_ADMIN_USER_ID: EnvValue.fromValue("160509172704739328"),
         // Bootstrap for the flag client itself — it cannot come from a flag.
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+        FLIPT_ENVIRONMENT: EnvValue.fromValue(stage),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/homelab/src/cdk8s/src/resources/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.ts
@@ -139,6 +139,7 @@ export function createStreambotDeployment(
         // last human exits. Sourced from the canonical map in resources/userbot-ids.ts.
         // Bootstrap for the flag client — cannot come from a flag.
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+        FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/scout-for-lol/packages/design-system/playwright.config.ts
+++ b/packages/scout-for-lol/packages/design-system/playwright.config.ts
@@ -25,10 +25,10 @@ export default defineConfig({
   snapshotPathTemplate:
     "{snapshotDir}/{testFilePath}-snapshots/{arg}-{projectName}{ext}",
   webServer: {
-    // Vite's persisted dependency optimizer can stall before binding when a
-    // prior build populated this package's cache. The workbench is a test-only
-    // server, so rebuild its optimizer state on every Playwright-owned start.
-    command: "bun run dev --host 127.0.0.1 --port 5190 --force --strictPort",
+    // Keep the Playwright-owned server on a deterministic port. Reusing Vite's
+    // persisted optimizer avoids a dependency scan competing with the other
+    // browser suites in the shared CI pod before the server binds.
+    command: "bun run dev --host 127.0.0.1 --port 5190 --strictPort",
     url: "http://127.0.0.1:5190",
     timeout: 120_000,
     reuseExistingServer: true,


### PR DESCRIPTION
Why

Prepared beta and production repositories are only isolated if every client selects one explicitly. The cutover must also move Scout Explore to Luna without changing any other model flag or moving legacy clients early.

What

- requires FLIPT_ENVIRONMENT whenever FEATURE_FLAGS_MODE is flipt
- maps Scout beta and Karma beta to beta
- maps Scout prod, Karma prod, Birmel, and Streambot to prod
- records gpt-5.6-luna as the shared scout-explore-model baseline with a temporary Sol override for default
- documents the difference between application ENVIRONMENT and Flipt storage selection
- tests the request header, required configuration, model materialization, and every deployed consumer mapping

Verification

- feature-flags typecheck, tests, and lint
- root checker focused tests
- cdk8s consumer-environment test, typecheck, and lint
- wiki typecheck, tests, build, and lint
- bunx lefthook run pre-commit

Rollout

Blocked until PR #2515 is deployed, beta/prod are changed to Luna in live Flipt, and the complete three-environment drift check passes. Deploy Flipt/provider resources before consumers. Then verify pod environments, fresh snapshots, private Explore and Scout ask behavior, and the Luna resolution/token metrics. No live cutover was performed from this branch.