### PR TITLE
chore(feature-flags): retire the transitional Flipt environment

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -115,7 +115,8 @@ beta and production separate local git backends on a ZFS PVC backed up by
 Velero. Environment isolation prevents a beta model or rollout change from
 altering production. Regression tests assert the storage and client selectors,
 because either omission produces a service that looks healthy while reading the
-wrong contract.
+wrong contract. The retired single-environment repository remains unreferenced
+on the PVC as a rollback artifact; removing it is a separate lifecycle decision.
 
 ## Analytics has a different ownership boundary
 

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -27,9 +27,8 @@ Run the repository command from the monorepo root:
 bun run check-flipt-flag-inventory
 ```
 
-The command checks every environment declared in the managed inventory. During
-the migration, that means `default`, `beta`, and `prod` in the `default`
-namespace.
+The command checks every environment declared in the managed inventory. That
+means `beta` and `prod` in the `default` namespace.
 
 To check one exact environment, pass a filter:
 

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -845,19 +845,6 @@
   ],
   "environments": [
     {
-      "key": "default",
-      "overrides": [
-        {
-          "key": "scout-explore-model",
-          "type": "variant",
-          "default": "gpt-5.6-sol",
-          "rollouts": [],
-          "rules": [],
-          "thresholdRollouts": []
-        }
-      ]
-    },
-    {
       "key": "beta",
       "overrides": []
     },

--- a/packages/feature-flags/src/managed-flag-inventory.test.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.test.ts
@@ -46,10 +46,12 @@ function exploreModel(environment: string) {
 }
 
 describe("ManagedFlagInventorySchema", () => {
-  test("keeps legacy default on Sol while beta and prod use Luna", () => {
-    expect(exploreModel("default")).toBe("gpt-5.6-sol");
+  test("uses Luna in both managed environments", () => {
     expect(exploreModel("beta")).toBe("gpt-5.6-luna");
     expect(exploreModel("prod")).toBe("gpt-5.6-luna");
+    expect(() =>
+      materializeManagedEnvironment(managedFlagInventory, "default"),
+    ).toThrow(/unknown managed environment/);
   });
 
   test("materializes a full-state environment override", () => {

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { App } from "cdk8s";
 import { z } from "zod";
 import { createFliptChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/flipt.ts";
-import { createEnvironmentMigrationScript } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
+import { createEnvironmentValidationScript } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
 
 const ManifestSchema = z
   .object({
@@ -140,11 +140,12 @@ describe("Flipt chart", () => {
     const yaml = config.data["config.yml"] ?? "";
     expect(yaml).toContain('version: "2.0"');
     expect(yaml).toContain("type: local");
-    expect(yaml).toContain("path: /var/opt/flipt/data");
+    expect(yaml).not.toContain("path: /var/opt/flipt/data\n");
     expect(yaml).toContain("path: /var/opt/flipt/data-beta");
     expect(yaml).toContain("path: /var/opt/flipt/data-prod");
     expect(yaml).toContain("name: beta");
     expect(yaml).toContain("name: prod");
+    expect(yaml).toMatch(/prod:\n {4}name: prod\n {4}default: true/);
     // Both default to true and would fail continuously against DNS-only egress.
     expect(yaml).toContain("check_for_updates: false");
     expect(yaml).toContain("telemetry_enabled: false");
@@ -159,62 +160,51 @@ describe("Flipt chart", () => {
     ).toMatch(/^[a-f\d]{12}$/);
   });
 
-  it("copies only absent environment repositories and rejects partial state", () => {
+  it("validates beta and prod without referencing the legacy repository", () => {
     const deployment = DeploymentSchema.parse(
       findManifest(synthesize(), "Deployment", "flipt"),
     );
-    const migration = deployment.spec.template.spec.initContainers.find(
-      (container) => container.name === "migrate-environments",
+    const validator = deployment.spec.template.spec.initContainers.find(
+      (container) => container.name === "validate-environments",
     );
-    expect(migration?.command).toEqual(["/bin/sh", "-c"]);
-    const script = migration?.args?.[0] ?? "";
-    expect(script).toContain('validate_repo "$source_repo"');
-    expect(script).toContain('if [ -e "$destination" ]');
-    expect(script).toContain('temporary="${destination}.migrating"');
-    expect(script).toContain('cp -a "$source_repo" "$temporary"');
-    expect(script).toContain('diff -qr "$source_repo" "$temporary"');
-    expect(script).toContain('mv "$temporary" "$destination"');
-    expect(script).toContain('copy_environment "/var/opt/flipt/data-beta"');
-    expect(script).toContain('copy_environment "/var/opt/flipt/data-prod"');
-    expect(migration?.volumeMounts?.map((mount) => mount.mountPath)).toContain(
+    expect(validator?.command).toEqual(["/bin/sh", "-c"]);
+    const script = validator?.args?.[0] ?? "";
+    expect(script).toContain('validate_repo "/var/opt/flipt/data-beta"');
+    expect(script).toContain('validate_repo "/var/opt/flipt/data-prod"');
+    expect(script).not.toContain("cp -a");
+    expect(script).not.toContain('validate_repo "/var/opt/flipt/data"');
+    expect(validator?.volumeMounts?.map((mount) => mount.mountPath)).toContain(
       "/var/opt/flipt",
     );
   });
 
-  it("fails fast for an invalid source or partial destination repository", async () => {
-    const root = `/tmp/flipt-migration-test-${crypto.randomUUID()}`;
-    expect(await run(["mkdir", "-p", `${root}/data/objects`])).toBe(0);
+  it("fails fast for missing or partial managed repositories", async () => {
+    const root = `/tmp/flipt-validation-test-${crypto.randomUUID()}`;
+    expect(await run(["mkdir", "-p", root])).toBe(0);
     expect(
-      await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
+      await run(["/bin/sh", "-c", createEnvironmentValidationScript(root)]),
     ).not.toBe(0);
 
-    await Bun.write(`${root}/data/HEAD`, "ref: refs/heads/main\n");
-    await Bun.write(`${root}/data/config`, "[core]\n\tbare = true\n");
-    expect(await run(["mkdir", "-p", `${root}/data-beta`])).toBe(0);
     expect(
-      await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
-    ).not.toBe(0);
-    expect(await run(["rm", "-rf", root])).toBe(0);
-  });
-
-  it("preserves an already initialized environment with different content", async () => {
-    const root = `/tmp/flipt-migration-test-${crypto.randomUUID()}`;
-    expect(await run(["mkdir", "-p", `${root}/data/objects`])).toBe(0);
-    await Bun.write(`${root}/data/HEAD`, "ref: refs/heads/main\n");
-    await Bun.write(`${root}/data/config`, "[core]\n\tbare = true\n");
-    expect(await run(["mkdir", "-p", `${root}/data-beta/objects`])).toBe(0);
-    await Bun.write(`${root}/data-beta/HEAD`, "ref: refs/heads/luna\n");
-    await Bun.write(`${root}/data-beta/config`, "[core]\n\tbare = false\n");
-
-    expect(
-      await run(["/bin/sh", "-c", createEnvironmentMigrationScript(root)]),
+      await run([
+        "mkdir",
+        "-p",
+        `${root}/data-beta/objects`,
+        `${root}/data-prod`,
+      ]),
     ).toBe(0);
-    expect(await Bun.file(`${root}/data-prod/HEAD`).text()).toBe(
-      "ref: refs/heads/main\n",
-    );
-    expect(await Bun.file(`${root}/data-beta/HEAD`).text()).toBe(
-      "ref: refs/heads/luna\n",
-    );
+    await Bun.write(`${root}/data-beta/HEAD`, "ref: refs/heads/main\n");
+    await Bun.write(`${root}/data-beta/config`, "[core]\n\tbare = true\n");
+    expect(
+      await run(["/bin/sh", "-c", createEnvironmentValidationScript(root)]),
+    ).not.toBe(0);
+
+    expect(await run(["mkdir", "-p", `${root}/data-prod/objects`])).toBe(0);
+    await Bun.write(`${root}/data-prod/HEAD`, "ref: refs/heads/main\n");
+    await Bun.write(`${root}/data-prod/config`, "[core]\n\tbare = true\n");
+    expect(
+      await run(["/bin/sh", "-c", createEnvironmentValidationScript(root)]),
+    ).toBe(0);
     expect(await run(["rm", "-rf", root])).toBe(0);
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
@@ -48,8 +48,9 @@ const DATA_PATH = "/var/opt/flipt";
 // storage: without an explicit local backend it happily accepts flag writes and
 // silently loses every one of them on restart. Verified by creating a flag,
 // restarting the container, and getting a 404 from the evaluation snapshot.
-// With this config the same test round-trips, and a bare git repo materialises
-// at `${DATA_PATH}/data`.
+// With this config the same test round-trips, and each managed environment has
+// its own bare git repository. The retired `${DATA_PATH}/data` repository stays
+// on the PVC as an unreferenced rollback artifact.
 //
 // check_for_updates and telemetry_enabled both default to true and would fail
 // continuously against the DNS-only egress policy below.
@@ -61,10 +62,6 @@ server:
   host: 0.0.0.0
   http_port: ${FLIPT_PORT.toString()}
 storage:
-  default:
-    backend:
-      type: local
-      path: ${DATA_PATH}/data
   beta:
     backend:
       type: local
@@ -74,15 +71,12 @@ storage:
       type: local
       path: ${DATA_PATH}/data-prod
 environments:
-  default:
-    name: default
-    default: true
-    storage: default
   beta:
     name: beta
     storage: beta
   prod:
     name: prod
+    default: true
     storage: prod
 authentication:
   required: false
@@ -97,10 +91,8 @@ meta:
   state_directory: ${DATA_PATH}/state
 `;
 
-export function createEnvironmentMigrationScript(dataPath: string): string {
+export function createEnvironmentValidationScript(dataPath: string): string {
   return `set -eu
-
-source_repo="${dataPath}/data"
 
 validate_repo() {
   repo="$1"
@@ -110,30 +102,13 @@ validate_repo() {
   fi
 }
 
-copy_environment() {
-  destination="$1"
-  if [ -e "$destination" ]; then
-    validate_repo "$destination"
-    return
-  fi
-
-  temporary="\${destination}.migrating"
-  if [ -e "$temporary" ]; then
-    echo "Flipt migration has an incomplete temporary repository: $temporary" >&2
-    exit 1
-  fi
-  cp -a "$source_repo" "$temporary"
-  diff -qr "$source_repo" "$temporary"
-  mv "$temporary" "$destination"
-}
-
-validate_repo "$source_repo"
-copy_environment "${dataPath}/data-beta"
-copy_environment "${dataPath}/data-prod"
+validate_repo "${dataPath}/data-beta"
+validate_repo "${dataPath}/data-prod"
 `;
 }
 
-const MIGRATE_ENVIRONMENTS_SCRIPT = createEnvironmentMigrationScript(DATA_PATH);
+const VALIDATE_ENVIRONMENTS_SCRIPT =
+  createEnvironmentValidationScript(DATA_PATH);
 
 export function createFliptDeployment(chart: Chart) {
   const deployment = new Deployment(chart, "flipt", {
@@ -169,10 +144,10 @@ export function createFliptDeployment(chart: Chart) {
 
   deployment.addInitContainer(
     withCommonProps({
-      name: "migrate-environments",
+      name: "validate-environments",
       image: `flipt/flipt:${versions["flipt-io/flipt"]}`,
       command: ["/bin/sh", "-c"],
-      args: [MIGRATE_ENVIRONMENTS_SCRIPT],
+      args: [VALIDATE_ENVIRONMENTS_SCRIPT],
       resources: {
         cpu: { request: Cpu.millis(5), limit: Cpu.millis(50) },
         memory: { request: Size.mebibytes(8), limit: Size.mebibytes(32) },

--- a/packages/homelab/src/cdk8s/src/resources/temporal/feature-flags.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/feature-flags.ts
@@ -7,6 +7,6 @@ export function temporalFeatureFlagEnvironment(): Record<string, EnvValue> {
       "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
     ),
     FLIPT_NAMESPACE: EnvValue.fromValue("default"),
-    FLIPT_ENVIRONMENT: EnvValue.fromValue("default"),
+    FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
   };
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
@@ -160,7 +160,7 @@ export function createTemporalOperationsWorkers(
       FLIPT_URL: EnvValue.fromValue(
         "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
       ),
-      FLIPT_ENVIRONMENT: EnvValue.fromValue("default"),
+      FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
       FRESHRSS_API_URL: EnvValue.fromValue(
         "http://freshrss-service.freshrss.svc.cluster.local/api/greader.php",
       ),

--- a/scripts/check-flipt-flag-inventory.test.ts
+++ b/scripts/check-flipt-flag-inventory.test.ts
@@ -63,8 +63,8 @@ describe("check-flipt-flag-inventory", () => {
       },
     });
 
-    expect(loaded).toEqual(["default", "beta", "prod"]);
-    expect(messages).toHaveLength(3);
+    expect(loaded).toEqual(["beta", "prod"]);
+    expect(messages).toHaveLength(2);
   });
 
   test("checks only an exact environment filter", async () => {


### PR DESCRIPTION
Why

After beta and production clients have soaked, the migration copy path and legacy default environment should no longer remain active. Permanent startup must fail if either managed repository is unavailable.

What

- removes default from the managed inventory and Flipt server configuration
- keeps beta and prod on the Luna Explore baseline
- makes prod the Flipt UI and server default while clients remain explicit
- replaces one-time cloning with permanent structural validation of both repositories
- leaves the old data directory unreferenced on the PVC as a rollback artifact
- updates focused tests and operator documentation for the final state

Verification

- feature-flags typecheck, tests, and lint
- root checker focused tests
- focused Flipt and consumer cdk8s tests, typecheck, and lint
- wiki typecheck, tests, build, and lint
- bunx lefthook run pre-commit

Rollout

Do not deploy until PR #2516 has been healthy for 24 hours. Re-run complete live drift and runtime acceptance first. The legacy directory is intentionally preserved; deletion is outside this PR. No live cleanup or deletion was performed.