### PR TITLE
fix(homelab,temporal): resolve infra health-sweep findings

### DIFF
--- a/packages/homelab/src/cdk8s/grafana/alert-dashboard.test.ts
+++ b/packages/homelab/src/cdk8s/grafana/alert-dashboard.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { createAlertDashboardGrafanaDashboard } from "./alert-dashboard.ts";
+import {
+  createAlertDashboardGrafanaDashboard,
+  exportAlertDashboardJson,
+} from "./alert-dashboard.ts";
 
 const DashboardSchema = z.object({
   panels: z.array(
@@ -42,5 +45,25 @@ describe("alert ledger Grafana dashboard", () => {
     expect(servicePanel.targets?.[0]?.expr).toContain(
       'service="alert-dashboard-alert-dashboard-service"',
     );
+  });
+
+  it("exports a built dashboard with a title, not the builder instance", () => {
+    // Guards the export path itself: exportAlertDashboardJson once serialized
+    // the DashboardBuilder (missing .build()), producing a titleless JSON blob
+    // Grafana rejected every 30s ("Dashboard title cannot be empty") while the
+    // builder-based tests above stayed green. Helm escapes ({{ print "{{" }})
+    // are reverted before parsing since they only become valid JSON post-Helm.
+    const exported = exportAlertDashboardJson()
+      .replaceAll('{{ print "{{" }}', "{{")
+      .replaceAll('{{ print "}}" }}', "}}");
+    const dashboard = z
+      .object({
+        title: z.string().min(1),
+        panels: z.array(z.unknown()).nonempty(),
+      })
+      .loose()
+      .parse(JSON.parse(exported));
+
+    expect(dashboard.title).toBe("Alerts — Ledger Health");
   });
 });

--- a/packages/homelab/src/cdk8s/grafana/alert-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/alert-dashboard.ts
@@ -86,6 +86,6 @@ export function createAlertDashboardGrafanaDashboard() {
 
 export function exportAlertDashboardJson(): string {
   return exportDashboardWithHelmEscaping(
-    createAlertDashboardGrafanaDashboard(),
+    createAlertDashboardGrafanaDashboard().build(),
   );
 }

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/media.ts
@@ -31,8 +31,12 @@ export async function createMediaChart(app: App) {
   const downloadsVolume = new ZfsSataVolume(chart, "qbittorrent-hdd-pvc", {
     storage: Size.tebibytes(2),
   });
+  // 8 TiB, up from 6: steadily growing library hit 77% with a 21–64 day
+  // projection to full (PVCProjectedFullWithin14Days, 2026-08-28). tv and
+  // downloads stay as-is — the qbittorrent projection was a download-burst
+  // artifact, not trend.
   const moviesVolume = new ZfsSataVolume(chart, "plex-movies-hdd-pvc", {
-    storage: Size.tebibytes(6),
+    storage: Size.tebibytes(8),
   });
   // Media services that share volumes
   createBazarrDeployment(chart, {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-shuxin.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-shuxin.ts
@@ -26,13 +26,22 @@ export function createMinecraftShuxinApp(chart: Chart) {
     service: "minecraft-shuxin-bluemap",
     port: 8100,
     hosts: ["minecraft-shuxin-bluemap"],
+    // The server statefulset hibernates at 0 replicas (mc-router wake-on-join),
+    // so a synthetic probe only measures sleep: 60s failures around the clock.
+    disableProbe: true,
   });
 
   createCloudflareTunnelBinding(chart, "minecraft-shuxin-bluemap-cf-tunnel", {
     serviceName: "minecraft-shuxin-bluemap",
-    subdomain: "shuxin.bluemap",
+    // First-level subdomain: Cloudflare Universal SSL covers only *.sjer.red,
+    // so the former shuxin.bluemap.sjer.red could never complete a TLS
+    // handshake. Must match the tofu DNS record in
+    // src/tofu/cloudflare/sjer-red.tf.
+    subdomain: "shuxin-bluemap",
     namespace: "minecraft-shuxin",
     port: 8100,
+    // Hibernates at 0 replicas (see above).
+    disableProbe: true,
   });
 
   const minecraftValues: HelmValuesForChart<"minecraft"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-sjerred.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-sjerred.ts
@@ -49,13 +49,22 @@ export function createMinecraftSjerredApp(chart: Chart) {
     service: "minecraft-sjerred-bluemap",
     port: 8100,
     hosts: ["minecraft-sjerred-bluemap"],
+    // The server statefulset hibernates at 0 replicas (mc-router wake-on-join),
+    // so a synthetic probe only measures sleep: 60s failures around the clock.
+    disableProbe: true,
   });
 
   createCloudflareTunnelBinding(chart, "minecraft-sjerred-bluemap-cf-tunnel", {
     serviceName: "minecraft-sjerred-bluemap",
-    subdomain: "sjerred.bluemap",
+    // First-level subdomain: Cloudflare Universal SSL covers only *.sjer.red,
+    // so the former sjerred.bluemap.sjer.red could never complete a TLS
+    // handshake. Must match the tofu DNS record in
+    // src/tofu/cloudflare/sjer-red.tf.
+    subdomain: "sjerred-bluemap",
     namespace: "minecraft-sjerred",
     port: 8100,
+    // Hibernates at 0 replicas (see above).
+    disableProbe: true,
   });
 
   const minecraftValues: HelmValuesForChart<"minecraft"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-tsmc.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/minecraft-tsmc.ts
@@ -50,6 +50,9 @@ export function createMinecraftTsmcApp(chart: Chart) {
     port: 8100,
     hosts: ["minecraft-tsmc-bluemap"],
     proxyClass: "medium",
+    // The server statefulset hibernates at 0 replicas (mc-router wake-on-join),
+    // so a synthetic probe only measures sleep: 60s failures around the clock.
+    disableProbe: true,
   });
 
   createCloudflareTunnelBinding(chart, "minecraft-tsmc-bluemap-cf-tunnel", {
@@ -58,6 +61,9 @@ export function createMinecraftTsmcApp(chart: Chart) {
     namespace: "minecraft-tsmc",
     disableDnsUpdates: true,
     port: 8100,
+    // Hibernates at 0 replicas (see above); the public probe additionally made
+    // cloudflared log an unreachable-origin error every minute.
+    disableProbe: true,
   });
 
   const minecraftValues: HelmValuesForChart<"minecraft"> = {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/seaweedfs.ts
@@ -153,7 +153,15 @@ export function createSeaweedfsApp(chart: Chart) {
         {
           name: "data",
           type: "persistentVolumeClaim",
-          size: Size.gibibytes(384).asString(),
+          // 512, up from 384: legitimate retained growth (PR assets carry a
+          // 365-day TTL that cannot expire anything until the bucket is a
+          // year old) put the volume on a ~43-day projection to full
+          // (2026-08-28). This renders into a StatefulSet volumeClaimTemplate
+          // — an immutable field — so the live PVC must be expanded first
+          // (kubectl patch pvc data-seaweedfs-volume-0 -n seaweedfs) and the
+          // StatefulSet recreated with --cascade=orphan if the apply is
+          // rejected.
+          size: Size.gibibytes(512).asString(),
           storageClass: NVME_STORAGE_CLASS,
           // Volume-slot cap. With master.volumeSizeLimitMB at 30 GiB, 88 GiB of
           // data packs into a few dozen volumes, so this is generous headroom, not

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/tempo.ts
@@ -113,7 +113,15 @@ export function createTempoApp(chart: Chart) {
         namespace: "tempo",
       },
       syncPolicy: {
-        automated: { enabled: true },
+        // selfHeal (velero/seaweedfs precedent): without it, automated sync
+        // runs once per revision, so a renderer change under a fixed chart
+        // revision strands the app OutOfSync forever. Exactly that happened
+        // 2026-08-23: the ArgoCD 10.4.0 bump swapped bundled Helm 3→4, Helm 4
+        // drops null-valued default keys during coalesce, and tempo's chart
+        // declares `opencensus:` (null) in its default receivers — the desired
+        // ConfigMap render changed under 1.24.4 and nothing ever re-converged
+        // it, pinning the root app at Progressing.
+        automated: { enabled: true, selfHeal: true },
         syncOptions: ["CreateNamespace=true", "Replace=true"],
       },
     },

--- a/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
+++ b/packages/homelab/src/cdk8s/src/resources/turbo-cache.ts
@@ -32,7 +32,11 @@ import {
 
 // ducktors/turborepo-remote-cache listens on 3000 by default (PORT env).
 const PORT = 3000;
-const CACHE_PVC_SIZE = Size.gibibytes(256);
+// 512, not 256: ingest reached ~13 GiB/day and the 256 GiB PVC projected full
+// within 14 days (2026-08-28). Paired with the daily clean's olderThan=14
+// retention (packages/temporal cleanTurboCache) this leaves ~2x headroom over
+// the expected steady state. liskov's nvme pool has >1.4 TiB free.
+const CACHE_PVC_SIZE = Size.gibibytes(512);
 // The ducktors image runs as uid/gid 1001 (`app`). A fresh PVC's root is
 // created root:root 0755, so the non-root process can't `mkdir /cache/<team>`
 // and every artifact upload 412s. fsGroup makes the kubelet chgrp the volume

--- a/packages/homelab/src/talos/liskov/patches/kubelet.yaml
+++ b/packages/homelab/src/talos/liskov/patches/kubelet.yaml
@@ -35,6 +35,13 @@ machine:
       evictionSoftGracePeriod:
         memory.available: "2m"
         nodefs.available: "2m"
+      # Age-based image GC — same rationale and values as torvalds (see its
+      # 2026-08-28 comment): CI image churn accrues here too (imageFs was 265 GiB
+      # at 33 days old), and the default threshold-only GC first fires at the
+      # same 85% line as nodefs soft eviction above.
+      imageMaximumGCAge: "720h"
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 60
       # CI is the fork-storm workload this cap was designed against (Dagger
       # goroutines 24 -> 1164 in <60s during the 2026-07 freeze investigation).
       # Watch for PIDPressure under real heavy-concurrency load.

--- a/packages/homelab/src/talos/torvalds/patches/kubelet.yaml
+++ b/packages/homelab/src/talos/torvalds/patches/kubelet.yaml
@@ -73,6 +73,17 @@ machine:
       evictionSoftGracePeriod:
         memory.available: "2m"
         nodefs.available: "2m"
+      # Age-based image GC (2026-08-28 /var capacity investigation): kubelet's
+      # default is threshold-only GC (85/80) with imageMaximumGCAge disabled, so
+      # image history accrued ~13 GiB/day for 465 days — 2.7 TiB of images with
+      # 99.1% of the bytes unreferenced (~16 GiB in use by running pods) — and
+      # the first GC would have fired at 85%, the exact nodefs soft-eviction
+      # line above, so GC churn and eviction pressure would arrive together.
+      # Expire images unused for 30 days and keep threshold GC (70/60) well
+      # below the eviction band. Worst case for an expired image is a re-pull.
+      imageMaximumGCAge: "720h"
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 60
       # 2026-07 CI-freeze hardening. podPidsLimit: cluster-wide (single node, so
       # effectively node-wide — Kubernetes has no per-pod override) cgroup
       # pids.max cap. 4096 is the standard Kubernetes-documented default for

--- a/packages/homelab/src/tofu/cloudflare/sjer-red.tf
+++ b/packages/homelab/src/tofu/cloudflare/sjer-red.tf
@@ -278,10 +278,14 @@ resource "cloudflare_dns_record" "sjer_red_cname_resume" {
 #   - Operator ~/.aws/config default + seaweedfs profiles (packages/dotfiles/)
 #   - Tofu state backends (already used seaweedfs-s3.tailnet-1a49.ts.net)
 
+# First-level hosts on purpose: Universal SSL covers only *.sjer.red, so the
+# former second-level names (shuxin.bluemap.sjer.red / sjerred.bluemap.sjer.red)
+# could never complete a TLS handshake. Must match the `subdomain:` props in
+# the minecraft-{shuxin,sjerred} cloudflare tunnel bindings (cdk8s).
 resource "cloudflare_dns_record" "sjer_red_cname_shuxin_bluemap" {
   zone_id = cloudflare_zone.sjer_red.id
   ttl     = 1
-  name    = "shuxin.bluemap"
+  name    = "shuxin-bluemap"
   type    = "CNAME"
   content = "3cbdc9a6-9e79-412d-8fe1-60117fecd4d3.cfargotunnel.com"
   proxied = true
@@ -290,7 +294,7 @@ resource "cloudflare_dns_record" "sjer_red_cname_shuxin_bluemap" {
 resource "cloudflare_dns_record" "sjer_red_cname_sjerred_bluemap" {
   zone_id = cloudflare_zone.sjer_red.id
   ttl     = 1
-  name    = "sjerred.bluemap"
+  name    = "sjerred-bluemap"
   type    = "CNAME"
   content = "3cbdc9a6-9e79-412d-8fe1-60117fecd4d3.cfargotunnel.com"
   proxied = true

--- a/packages/homelab/src/tofu/tailscale/acl.tf
+++ b/packages/homelab/src/tofu/tailscale/acl.tf
@@ -84,7 +84,13 @@ resource "tailscale_acl" "homelab" {
       # here, every worker joined after torvalds is invisible to node-level
       # monitoring (verified: liskov's node-exporter timed out for its first
       # ~18h while kubelet on 10250 scraped fine — NodeExporterDown, 2026-07-26).
-      { action = "accept", src = ["tag:k8s"], dst = ["tag:k8s:6443", "tag:k8s:10250", "tag:k8s:9100"] },
+      # 50000 is Talos apid: the committed talosconfig endpoint is torvalds, so
+      # every `talosctl -n <worker>` call is torvalds' apid dialing the worker's
+      # apid over the tailnet. Same gap class as 9100 above — without it,
+      # `talosctl health` and any discovery-addressed fleet operation time out
+      # against every worker (verified against liskov, 2026-08-28). trustd
+      # (50001) is deliberately absent: workers correctly refuse it.
+      { action = "accept", src = ["tag:k8s"], dst = ["tag:k8s:6443", "tag:k8s:10250", "tag:k8s:9100", "tag:k8s:50000"] },
 
       # A dedicated CI runner tagged tag:ci (none today — CI currently runs on the
       # tag:k8s node above) would also need the tofu-state backend on 443.
@@ -151,11 +157,13 @@ resource "tailscale_acl" "homelab" {
       },
       # CRITICAL: the cluster node + proxies (tag:k8s) MUST reach tailnet ingresses
       # on 443, the control-plane API endpoint on 6443, worker kubelets on 10250,
-      # and node-exporter on 9100 (cross-node InternalIP scrapes). A future edit
-      # that drops any path fails here before it can break cluster operations.
+      # node-exporter on 9100 (cross-node InternalIP scrapes), and Talos apid on
+      # 50000 (talosctl proxies worker calls through the endpoint node's apid).
+      # A future edit that drops any path fails here before it can break cluster
+      # operations.
       {
         src    = "tag:k8s"
-        accept = ["tag:k8s:443", "tag:k8s:6443", "tag:k8s:10250", "tag:k8s:9100"]
+        accept = ["tag:k8s:443", "tag:k8s:6443", "tag:k8s:10250", "tag:k8s:9100", "tag:k8s:50000"]
         deny   = ["tag:k8s:22"]
       },
       # NOTE: the "non-admin members reach only the published web apps" invariant

--- a/packages/temporal/Dockerfile
+++ b/packages/temporal/Dockerfile
@@ -126,6 +126,11 @@ ARG TRIVY_VERSION=0.72.0
 ARG LYCHEE_VERSION=lychee-v0.24.2
 # renovate: datasource=github-releases depName=Kometa-Team/Kometa
 ARG KOMETA_VERSION=2.4.5
+# Shared local/CI Postgres pin — keep in lockstep with .mise.toml's
+# "ubi:theseus-rs/postgresql-binaries" entry: the bot-clone backend tests must
+# run against the same server binaries here as on dev/CI machines.
+# renovate: datasource=github-releases depName=theseus-rs/postgresql-binaries
+ARG POSTGRESQL_BINARIES_VERSION=16.15.0
 ARG KOMETA_COMMIT=4ea818399a458f9e791ca04b4a02458751cf2a46
 
 # --- Base system deps: ca-certificates, curl, git, and the pod-local agent firewall ---
@@ -357,6 +362,36 @@ RUN set -e; \
     printf '%s\n' '#!/bin/sh' 'exec /opt/kometa/venv/bin/python /opt/kometa/kometa.py "$@"' > /usr/local/bin/kometa; \
     chmod +x /usr/local/bin/kometa; \
     kometa --help >/dev/null
+
+# --- PostgreSQL server binaries (per-arch tarball, SHA256-verified) ---
+# The Data Dragon updater's snapshot step runs scout-backend tests, and since
+# the SQLite→Postgres migration (PR #2310) every backend test boots a local
+# Postgres via ensureDevPostgres (pg_isready/psql/postgres/initdb/pg_ctl/
+# createdb — packages/scout-for-lol/packages/backend/src/testing/
+# postgres-server.ts). Dev/CI machines get these from mise; this image must
+# carry them itself or the daily data-dragon workflow fails at its final step
+# (ScoutDataDragonUpdateFailed, 2026-08-26). The full tree stays under
+# /opt/postgresql because initdb resolves share/ relative to its prefix.
+RUN set -e; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64) pgarch=x86_64 ;; arm64) pgarch=aarch64 ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; esac; \
+    base="https://github.com/theseus-rs/postgresql-binaries/releases/download/${POSTGRESQL_BINARIES_VERSION}"; \
+    tarball="postgresql-${POSTGRESQL_BINARIES_VERSION}-${pgarch}-unknown-linux-gnu.tar.gz"; \
+    curl -fsSL "$base/$tarball" -o /tmp/postgresql.tar.gz; \
+    curl -fsSL "$base/$tarball.sha256" -o /tmp/postgresql.sha256; \
+    expected="$(awk '{print $1}' /tmp/postgresql.sha256)"; \
+    [ -n "$expected" ] || { echo "no checksum for $tarball" >&2; exit 1; }; \
+    actual="$(sha256sum /tmp/postgresql.tar.gz | awk '{print $1}')"; \
+    [ "$expected" = "$actual" ] || { echo "postgresql-binaries checksum mismatch (expected $expected, got $actual)" >&2; exit 1; }; \
+    mkdir -p /opt/postgresql; \
+    tar -xzf /tmp/postgresql.tar.gz -C /opt/postgresql --strip-components=1; \
+    for bin in pg_isready psql postgres initdb pg_ctl createdb dropdb; do \
+      ln -s "/opt/postgresql/bin/$bin" "/usr/local/bin/$bin"; \
+    done; \
+    rm /tmp/postgresql.tar.gz /tmp/postgresql.sha256; \
+    pg_isready --version; \
+    initdb --version
 
 # Production node_modules + workspace manifests. The isolated-linker tree uses
 # relative symlinks (store at node_modules/.bun), so copying the whole install

--- a/packages/temporal/scripts/smoke.ts
+++ b/packages/temporal/scripts/smoke.ts
@@ -59,6 +59,16 @@ const CLI_CHECKS: readonly { name: string; args: readonly string[] }[] = [
   { name: "trivy", args: ["trivy", "version"] },
   { name: "lychee", args: ["lychee", "--version"] },
   { name: "kometa", args: ["kometa", "--help"] },
+  // Postgres server binaries: the data-dragon bot clone runs scout-backend
+  // tests, which boot a local Postgres (ensureDevPostgres). check:rehearsal
+  // runs on mise-equipped agents and cannot detect these missing from the
+  // image — this smoke is the only gate that proves the image has them.
+  { name: "pg_isready", args: ["pg_isready", "--version"] },
+  { name: "psql", args: ["psql", "--version"] },
+  { name: "postgres", args: ["postgres", "--version"] },
+  { name: "initdb", args: ["initdb", "--version"] },
+  { name: "pg_ctl", args: ["pg_ctl", "--version"] },
+  { name: "createdb", args: ["createdb", "--version"] },
 ];
 // Reaching this log line proves the worker booted through runtime install,
 // Sentry, tracing, and the metrics server, and is attempting the connection.

--- a/packages/temporal/src/activities/maintenance.test.ts
+++ b/packages/temporal/src/activities/maintenance.test.ts
@@ -201,7 +201,7 @@ describe("Turbo cache cleanup", () => {
     });
     expect(requestUrl).toContain("/v8/clean");
     expect(requestUrl).toContain("slug=monorepo");
-    expect(requestUrl).toContain("olderThan=30");
+    expect(requestUrl).toContain("olderThan=14");
     expect(authorization).toBe("Bearer turbo-secret-for-test");
     const exposition = await register.metrics();
     expect(exposition).toContain(

--- a/packages/temporal/src/activities/maintenance.ts
+++ b/packages/temporal/src/activities/maintenance.ts
@@ -425,7 +425,11 @@ export async function cleanTurboCache(
     Bun.env["TURBO_CACHE_CLEAN_URL"] ?? TURBO_CACHE_CLEAN_URL,
   );
   url.searchParams.set("slug", "monorepo");
-  url.searchParams.set("olderThan", "30");
+  // Days. 14, not 30: at the observed ~13 GiB/day ingest a 30-day window's
+  // steady state (~390 GiB) exceeds even the 512 GiB PVC's comfort zone, and
+  // CI cache hits older than two weeks are vanishingly rare
+  // (PVCProjectedFullWithin14Days, 2026-08-28).
+  url.searchParams.set("olderThan", "14");
 
   try {
     const response = await fetcher(url, {

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -73,7 +73,7 @@ export const EARLY_SCHEDULES: ScheduleDefinition[] = [
     taskQueue: TASK_QUEUES.MAINTENANCE,
     overlap: ScheduleOverlapPolicy.SKIP,
     workflowExecutionTimeout: "30 minutes",
-    memo: "Daily deletion of monorepo Turbo cache artifacts unused for 30 days",
+    memo: "Daily deletion of monorepo Turbo cache artifacts unused for 14 days",
   },
   {
     id: "deps-summary-weekly",


### PR DESCRIPTION
## Why

A six-checker parallel health investigation root-caused every open infra issue. The urgent drivers: torvalds' /var was ~1 week from the 85% image-GC/soft-eviction line (2.7 TiB of container images, 99.1% of bytes unreferenced, accruing ~13 GiB/day with age-GC disabled); the turbo-cache PVC was ~8 days from full; the Data Dragon updater has failed daily since 2026-08-26 (Scout game data stuck at 16.16.1 vs live 16.17.1); and the tempo app's Helm 3→4 render drift pinned root `apps` at Progressing.

## What

One PR, seven independent fixes as separate commits:

1. **kubelet image GC (both nodes)** — `imageMaximumGCAge: 720h`, thresholds 70/60, so image history expires after 30 days and threshold GC stays clear of the eviction band.
2. **Tailscale ACL** — add `tag:k8s:50000` (Talos apid) to the intra-cluster rule + ACL test. talosctl proxies worker calls through the endpoint node's apid; the missing port made `talosctl health` time out against liskov (same gap class as the 2026-07-26 9100 incident).
3. **Temporal worker image** — bake theseus-rs/postgresql-binaries 16.15.0 (mise pin, arch-guarded, SHA256-verified) + smoke-test assertions. Since #2310 the scout-backend tests the Data Dragon updater runs need `pg_isready`; the rehearsal runs on mise-equipped agents and could never catch the image gap.
4. **Grafana alert dashboard** — `exportAlertDashboardJson` serialized the DashboardBuilder instance (missing `.build()`), so Grafana rejected the ConfigMap every 30s ('Dashboard title cannot be empty'). Fixed + export-path test.
5. **Bluemap probes/hosts** — `disableProbe` on all six bluemap call sites (statefulsets hibernate at 0 replicas by design; probes only measured sleep and self-inflicted 1/min cloudflared origin errors), and the two second-level public hosts move to first-level (`shuxin-bluemap.sjer.red`, `sjerred-bluemap.sjer.red`) since Universal SSL cannot serve `*.bluemap.sjer.red` — a latent ServiceProbeDown page once a server stays awake.
6. **Capacity** — turbo-cache retention 30→14d + PVC 256→512 GiB, seaweedfs data 384→512 GiB, plex-movies 6→8 TiB. qbittorrent deliberately untouched (burst artifact, not trend).
7. **tempo selfHeal** — automated-without-selfHeal syncs once per revision, so the ArgoCD 10.4.0 Helm-renderer change stranded tempo OutOfSync for 16 days. selfHeal per velero/seaweedfs precedent; deliberately not fleet-wide.

## Verification

- `bunx turbo run typecheck test lint --filter=homelab --filter=@homelab/cdk8s --filter=@shepherdjerred/temporal` — green
- `bunx turbo run build --filter=@homelab/cdk8s` (cdk8s synth) — green
- Repo-wide grep: no remaining references to the old bluemap hostnames
- postgresql-binaries 16.15.0 release assets + sha256 siblings verified live against GitHub
- **Already done operationally (this session):** `argocd app sync tempo` (tempo Synced/Healthy, root `apps` Healthy again); torvalds node cleanup (19 orphaned kubelet pod dirs + 174 GiB dead Dagger BuildKit state removed via privileged debug pod, kubelet restarted) — openebs ZFSVolume-not-found errors now 0/5min (was ~14/min for 14 months), 74/74 PVs/ZFSVolumes intact
- **Not run from this branch (deploy-time):** talos config apply (kubelet restarts, ~seconds NotReady per node), tofu applies (ACL, DNS), seaweedfs live-PVC expansion before its StatefulSet claim-template change lands (`kubectl patch pvc`, then `--cascade=orphan` recreate if the apply is rejected)

## Rollout notes

- The seaweedfs volumeClaimTemplate change is immutable on the live StatefulSet — expand the PVC first (see commit body).
- After the worker image ships, the next 13:00 UTC `scout-data-dragon-version-check` run should self-heal and open the 16.17.1 PR unattended.
- The next completed `release-root` on main also restores auto-sync on the 34 children left frozen by the terminated 2026-08-26 release op.