### PR TITLE
feat(homelab): alert on LLM spend and on a silent Broadcast webhook

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/enable-openrouter-broadcast.md
+++ b/packages/docs/wiki/src/content/docs/how-to/enable-openrouter-broadcast.md
@@ -1,0 +1,88 @@
+---
+title: Enable OpenRouter Broadcast
+description: Point the OpenRouter Broadcast webhook at the ingest service and confirm the authoritative per-generation cost record is arriving.
+sidebar:
+  order: 15
+---
+
+The `openrouter-broadcast-ingest` service is deployed and reachable, but it only
+receives anything once the webhook is configured in the OpenRouter dashboard.
+Until then it looks healthy and delivers nothing, and the authoritative
+per-generation cost record does not exist.
+
+This guide configures the webhook and confirms delivery. You need access to the
+OpenRouter dashboard and to the `openrouter-broadcast-ingest` 1Password item.
+
+## 1. Confirm the service is up but silent
+
+```bash
+toolkit prom query 'up{namespace="openrouter-broadcast-ingest"}'
+toolkit prom query 'openrouter_broadcast_last_success_timestamp_seconds'
+```
+
+`up` should be `1`. A `last_success` of `0` means no delivery has ever
+completed, which is the state this guide fixes. A non-zero value means Broadcast
+is already working and you are in the wrong guide.
+
+## 2. Read the bearer token
+
+```bash
+op read "op://<vault>/openrouter-broadcast-ingest/OPENROUTER_BROADCAST_BEARER_TOKEN"
+```
+
+Do not paste the value anywhere except the OpenRouter dashboard field in step 3.
+
+If `op whoami` says you are signed out, ignore it and run the `op read` anyway —
+desktop-app integration authenticates each operation individually and does not
+always create a shell session.
+
+## 3. Configure the webhook
+
+In the OpenRouter dashboard, add a Broadcast destination:
+
+| Field  | Value                                             |
+| ------ | ------------------------------------------------- |
+| URL    | `https://openrouter-broadcast.sjer.red/v1/traces` |
+| Method | `POST`                                            |
+| Header | `Authorization: Bearer <token from step 2>`       |
+| Format | OTLP/HTTP JSON                                    |
+
+Run OpenRouter's built-in connection test. A `204` means the payload was both
+archived and forwarded; any other status is a real failure, not a warm-up.
+
+## 4. Send one real generation
+
+Trigger any workload that calls OpenRouter — a Discord `/bb-ask`, or any Birmel
+message — so a genuine payload flows rather than OpenRouter's synthetic test.
+
+## 5. Verify all four outputs
+
+Pod health is not acceptance. Confirm each of these separately:
+
+```bash
+# Deliveries are arriving and succeeding
+toolkit prom query 'sum by (outcome) (openrouter_broadcast_requests_total)'
+toolkit prom query 'sum by (operation, outcome) (openrouter_broadcast_operations_total)'
+
+# The last success is recent rather than zero
+toolkit prom query 'time() - max(openrouter_broadcast_last_success_timestamp_seconds)'
+
+# A body-free correlated span reached Tempo
+toolkit tempo query '{resource.service.name=~".*openrouter.*"}' --since 1h --limit 5
+```
+
+Then confirm the fourth output by hand: a payload object and its digest receipt
+exist in the private SeaweedFS LLM archive bucket. The archive is the only one of
+the four that Prometheus cannot answer for you.
+
+The `OpenRouterBroadcastSilent` alert resolves within 30 minutes of the first
+successful delivery. If it stays firing, work through
+`OpenRouterBroadcastPipelineFailure` and the service logs rather than
+re-running the connection test.
+
+## Related
+
+- [LLM stack](/explanation/llm-stack/) — why Broadcast is a second, correlated
+  evidence source rather than the primary one.
+- `packages/openrouter-broadcast-ingest/README.md` — the service's own
+  configuration and canary notes.

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -78,12 +78,12 @@ export function addLlmPanels(
         "Actual OpenRouter or Claude SDK cost, canonical catalog cost, and upstream inference cost. The discrepancy series is actual minus catalog cost.",
       targets: [
         {
-          query: `sum by (service, model, type) (rate(llm_cost_usd_total{${llmFilter}}[5m])) or on() vector(0)`,
-          legend: "{{service}} {{model}} {{type}}",
+          query: `sum by (service, workload, model, type) (rate(llm_cost_usd_total{${llmFilter}}[5m])) or on() vector(0)`,
+          legend: "{{service}} {{workload}} {{model}} {{type}}",
         },
         {
-          query: `sum by (service, model) (rate(llm_cost_usd_total{${llmFilter},type="actual"}[5m])) - sum by (service, model) (rate(llm_cost_usd_total{${llmFilter},type="catalog"}[5m]))`,
-          legend: "{{service}} {{model}} actual-catalog",
+          query: `sum by (service, workload, model) (rate(llm_cost_usd_total{${llmFilter},type="actual"}[5m])) - sum by (service, workload, model) (rate(llm_cost_usd_total{${llmFilter},type="catalog"}[5m]))`,
+          legend: "{{service}} {{workload}} {{model}} actual-catalog",
         },
       ],
       gridPos: { x: 12, y: 49, w: 12, h: 8 },
@@ -91,10 +91,26 @@ export function addLlmPanels(
     }),
   );
 
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Top Cost by Feature (24h)",
+      description:
+        "Rolling 24h billed spend per workload. Takes the per-series maximum of OpenRouter's charged cost and upstream inference cost so BYOK routes, which bill nothing through OpenRouter and would read as $0 under an actual-only query, are still counted.",
+      targets: [
+        {
+          query: `topk(10, sum by (service, workload) (max by (service, workload, model) (increase(llm_cost_usd_total{${llmFilter},type=~"actual|upstream"}[24h])))) or on() vector(0)`,
+          legend: "{{service}} {{workload}}",
+        },
+      ],
+      gridPos: { x: 0, y: 57, w: 24, h: 8 },
+      unit: "currencyUSD",
+    }),
+  );
+
   builder.withRow(
     new dashboard.RowBuilder("Routing and Structured Output").gridPos({
       x: 0,
-      y: 57,
+      y: 65,
       w: 24,
       h: 1,
     }),
@@ -111,7 +127,7 @@ export function addLlmPanels(
           legend: "{{service}} {{model}} {{upstream_provider}} {{outcome}}",
         },
       ],
-      gridPos: { x: 0, y: 58, w: 12, h: 8 },
+      gridPos: { x: 0, y: 66, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -127,7 +143,7 @@ export function addLlmPanels(
           legend: "{{service}} {{model}} {{upstream_provider}}",
         },
       ],
-      gridPos: { x: 12, y: 58, w: 12, h: 8 },
+      gridPos: { x: 12, y: 66, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -143,7 +159,7 @@ export function addLlmPanels(
           legend: "{{service}} {{workload}} {{model}} {{outcome}}",
         },
       ],
-      gridPos: { x: 0, y: 66, w: 12, h: 8 },
+      gridPos: { x: 0, y: 74, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -159,7 +175,7 @@ export function addLlmPanels(
           legend: "{{service}} {{workload}} {{model}}",
         },
       ],
-      gridPos: { x: 12, y: 66, w: 12, h: 8 },
+      gridPos: { x: 12, y: 74, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -167,7 +183,7 @@ export function addLlmPanels(
   builder.withRow(
     new dashboard.RowBuilder("Broadcast Archive and Tempo").gridPos({
       x: 0,
-      y: 74,
+      y: 82,
       w: 24,
       h: 1,
     }),
@@ -185,7 +201,7 @@ export function addLlmPanels(
           legend: "{{outcome}}",
         },
       ],
-      gridPos: { x: 0, y: 75, w: 8, h: 8 },
+      gridPos: { x: 0, y: 83, w: 8, h: 8 },
       unit: "reqps",
     }),
   );
@@ -202,7 +218,7 @@ export function addLlmPanels(
           legend: "{{operation}} {{outcome}}",
         },
       ],
-      gridPos: { x: 8, y: 75, w: 8, h: 8 },
+      gridPos: { x: 8, y: 83, w: 8, h: 8 },
       unit: "ops",
     }),
   );
@@ -224,7 +240,7 @@ export function addLlmPanels(
           legend: "last success age",
         },
       ],
-      gridPos: { x: 16, y: 75, w: 8, h: 8 },
+      gridPos: { x: 16, y: 83, w: 8, h: 8 },
       unit: "s",
     }),
   );

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -95,10 +95,10 @@ export function addLlmPanels(
     createTimeseriesPanel({
       title: "Top Cost by Feature (24h)",
       description:
-        "Rolling 24h billed spend per workload. Takes the per-series maximum of OpenRouter's charged cost and upstream inference cost so BYOK routes, which bill nothing through OpenRouter and would read as $0 under an actual-only query, are still counted.",
+        "Rolling 24h billed spend per workload. Sums each accounting type across pod lifetimes first, then takes the larger of OpenRouter's charged cost and upstream inference cost, so BYOK routes -- which bill nothing through OpenRouter and read as $0 under an actual-only query -- are counted, and a deploy inside the window does not discard the shorter pod's spend.",
       targets: [
         {
-          query: `topk(10, sum by (service, workload) (max by (service, workload, model) (increase(llm_cost_usd_total{${llmFilter},type=~"actual|upstream"}[24h])))) or on() vector(0)`,
+          query: `topk(10, sum by (service, workload) (max by (service, workload, model) (sum by (service, workload, model, type) (increase(llm_cost_usd_total{${llmFilter},type=~"actual|upstream"}[24h]))))) or on() vector(0)`,
           legend: "{{service}} {{workload}}",
         },
       ],

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "vitest";
-import { getLlmRuleGroups } from "./llm.ts";
+import {
+  getLlmRuleGroups,
+  LLM_DAILY_SPEND_CRITICAL_USD,
+  LLM_DAILY_SPEND_WARNING_USD,
+  LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR,
+  LLM_WORKLOAD_SPIKE_RATIO,
+} from "./llm.ts";
 
 test("keeps LLM recording and Broadcast alert coverage together", () => {
   const groups = getLlmRuleGroups();
@@ -32,4 +38,63 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
     const alert = rules.find((rule) => rule?.alert === alertName);
     expect(alert?.labels).toEqual({ severity: "warning", category: "llm" });
   }
+});
+
+test("alerts on LLM spend and on a silent Broadcast webhook", () => {
+  const rules = getLlmRuleGroups().flatMap(
+    ({ rules: groupRules }) => groupRules,
+  );
+  const alertNamed = (name: string) =>
+    rules.find((rule) => rule?.alert === name);
+
+  for (const [name, severity] of [
+    ["LlmDailySpendHigh", "warning"],
+    ["LlmDailySpendCritical", "critical"],
+    ["LlmWorkloadCostSpike", "warning"],
+    ["OpenRouterBroadcastSilent", "warning"],
+  ] as const) {
+    expect(alertNamed(name)?.labels).toEqual({ severity, category: "llm" });
+  }
+
+  // The critical tier must sit above the warning tier, or the warning alert is
+  // unreachable and the ceiling silently becomes a single threshold.
+  expect(LLM_DAILY_SPEND_CRITICAL_USD).toBeGreaterThan(
+    LLM_DAILY_SPEND_WARNING_USD,
+  );
+  expect(alertNamed("LlmDailySpendHigh")?.expr?.value).toContain(
+    `> ${LLM_DAILY_SPEND_WARNING_USD.toString()}`,
+  );
+  expect(alertNamed("LlmDailySpendCritical")?.expr?.value).toContain(
+    `> ${LLM_DAILY_SPEND_CRITICAL_USD.toString()}`,
+  );
+
+  // BYOK routes bill nothing through OpenRouter, so an actual-only ceiling
+  // would miss them entirely. Both accounting sources must be in the ceiling.
+  for (const spendAlert of ["LlmDailySpendHigh", "LlmDailySpendCritical"]) {
+    const expr = alertNamed(spendAlert)?.expr?.value;
+    expect(expr).toContain('type=~"actual|upstream"');
+    expect(expr).toContain("max by (service, workload, model)");
+  }
+
+  // The spike alert needs both halves: a ratio alone fires on any burst from a
+  // workload that costs fractions of a cent.
+  const spike = alertNamed("LlmWorkloadCostSpike")?.expr?.value;
+  expect(spike).toContain(`> ${LLM_WORKLOAD_SPIKE_RATIO.toString()} *`);
+  expect(spike).toContain(
+    `* 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
+  );
+
+  // Uptime gating is what keeps a pod restart, which zeroes the gauge, from
+  // alerting before the service has had a day to receive a delivery.
+  const silent = alertNamed("OpenRouterBroadcastSilent")?.expr?.value;
+  expect(silent).toContain(
+    "openrouter_broadcast_ingest_process_start_time_seconds",
+  );
+  expect(silent).toContain(
+    "openrouter_broadcast_last_success_timestamp_seconds",
+  );
+
+  expect(JSON.stringify(getLlmRuleGroups())).toContain(
+    "llm:cost_discrepancy:rate5m",
+  );
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -68,12 +68,31 @@ test("alerts on LLM spend and on a silent Broadcast webhook", () => {
     `> ${LLM_DAILY_SPEND_CRITICAL_USD.toString()}`,
   );
 
-  // BYOK routes bill nothing through OpenRouter, so an actual-only ceiling
-  // would miss them entirely. Both accounting sources must be in the ceiling.
-  for (const spendAlert of ["LlmDailySpendHigh", "LlmDailySpendCritical"]) {
-    const expr = alertNamed(spendAlert)?.expr?.value;
+  // Every cost alert must use the same billed-cost convention. BYOK routes bill
+  // nothing through OpenRouter and report `actual` of exactly zero, so an
+  // actual-only expression misses the largest line item in the fleet -- and for
+  // the spike alert would hold both the ratio and the floor at zero, making it
+  // structurally incapable of firing for that class of workload.
+  const costAlerts = [
+    "LlmDailySpendHigh",
+    "LlmDailySpendCritical",
+    "LlmWorkloadCostSpike",
+  ];
+  for (const costAlert of costAlerts) {
+    const expr = alertNamed(costAlert)?.expr?.value;
     expect(expr).toContain('type=~"actual|upstream"');
-    expect(expr).toContain("max by (service, workload, model)");
+    expect(expr).not.toContain('type="actual"');
+
+    // Ordering is the correctness property, not merely the presence of both
+    // aggregations. These series carry `pod`, so a deploy inside the window
+    // leaves two counter series per workload; selecting the maximum before
+    // summing them keeps only the longer-lived pod and silently understates
+    // spend. The per-type sum must therefore appear *inside* the max.
+    const maxAt = expr?.indexOf("max by (service, workload, model)") ?? -1;
+    const sumAt =
+      expr?.indexOf("sum by (service, workload, model, type)") ?? -1;
+    expect(maxAt).toBeGreaterThanOrEqual(0);
+    expect(sumAt).toBeGreaterThan(maxAt);
   }
 
   // The spike alert needs both halves: a ratio alone fires on any burst from a

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -88,9 +88,13 @@ test("alerts on LLM spend and on a silent Broadcast webhook", () => {
     // leaves two counter series per workload; selecting the maximum before
     // summing them keeps only the longer-lived pod and silently understates
     // spend. The per-type sum must therefore appear *inside* the max.
-    const maxAt = expr?.indexOf("max by (service, workload, model)") ?? -1;
-    const sumAt =
-      expr?.indexOf("sum by (service, workload, model, type)") ?? -1;
+    // `expr.value` is typed `string | number`, so narrow before searching it
+    // rather than letting an unexpected numeric expression silently skip the
+    // ordering assertions below.
+    expect(typeof expr).toBe("string");
+    const rendered = typeof expr === "string" ? expr : "";
+    const maxAt = rendered.indexOf("max by (service, workload, model)");
+    const sumAt = rendered.indexOf("sum by (service, workload, model, type)");
     expect(maxAt).toBeGreaterThanOrEqual(0);
     expect(sumAt).toBeGreaterThan(maxAt);
   }

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -5,37 +5,72 @@ import { escapePrometheusTemplate } from "./shared.ts";
 /**
  * Daily spend ceilings for `llm_cost_usd_total`, in USD.
  *
- * Measured baseline at authoring time was ~$2.55/day summed across every
- * service and workload, so the warning tier is roughly 3x headroom and the
- * critical tier roughly 6x. Both are deliberately coarse: they exist to catch a
- * runaway agent loop or a model-pin change, not to police normal variance.
+ * Anchored on the measured distribution of `BILLED_COST_24H`, not on a guess:
+ * a 7-day mean of ~$8.20/day and a worst observed rolling 24h of ~$20.80.
+ * Warning sits at roughly 2x that worst real day and 5x the mean; critical at
+ * roughly 3.5x the worst day and 9x the mean.
+ *
+ * The headroom is deliberate. These exist to catch a runaway agent loop or a
+ * model-pin change -- an order-of-magnitude event -- not to police normal
+ * variance, and normal variance here is already a 4x spread between a quiet day
+ * and a busy one. Tightening them toward the mean would page on a busy Sunday.
+ *
+ * Re-derive rather than nudge these if the fleet's shape changes:
+ *   max_over_time(<BILLED_COST_24H>[7d:1h])
  */
-export const LLM_DAILY_SPEND_WARNING_USD = 8;
-export const LLM_DAILY_SPEND_CRITICAL_USD = 15;
+export const LLM_DAILY_SPEND_WARNING_USD = 40;
+export const LLM_DAILY_SPEND_CRITICAL_USD = 75;
 
 /**
  * A workload must both spike relative to its own daily rate AND clear this
  * hourly floor before it alerts. Without the floor, a workload that normally
  * costs fractions of a cent trips the ratio on any burst of ordinary traffic.
+ *
+ * Both sides of the comparison use `billedCost`, not `type="actual"` alone. A
+ * BYOK workload reports `actual` of exactly zero, so an actual-only ratio and
+ * floor would both stay at zero and the alert could never detect a runaway in
+ * precisely the class of workload the daily ceilings exist to catch.
  */
 export const LLM_WORKLOAD_SPIKE_RATIO = 5;
 export const LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR = 0.5;
 
 /**
- * Cost accounting that reflects what we are actually billed.
+ * Billed LLM cost, as one expression every cost alert is built from.
  *
  * `actual` is what OpenRouter charged. For BYOK routes OpenRouter charges
  * nothing and the real money is in `upstream` (`upstream_inference_cost`), so an
- * `actual`-only ceiling would miss the largest single line item in the fleet.
- * Taking the per-series maximum covers both without double counting, because
- * the two are equal on ordinary non-BYOK routes.
+ * `actual`-only expression would miss the largest single line item in the fleet.
+ * Taking the per-model maximum of the two covers both without double counting,
+ * because they are equal on ordinary non-BYOK routes.
  *
- * This is deliberately conservative pending the OpenRouter Broadcast
- * comparison that will settle the `actual` vs `upstream` semantics: a spend
- * ceiling should err toward firing.
+ * The inner `sum` is load-bearing and must stay inside the `max`. These series
+ * carry `pod` and `instance`, so a deploy inside the window leaves two counter
+ * series per workload. Selecting the maximum first would keep only the larger
+ * pod lifetime -- $5 before a restart and $5 after would evaluate as $5, not
+ * $10, and silently understate spend after every deploy. Summing per accounting
+ * type first collapses those lifetimes, and only then is the larger of `actual`
+ * and `upstream` chosen.
+ *
+ * Conservative on purpose, pending the OpenRouter Broadcast comparison that
+ * will settle the `actual` vs `upstream` semantics: a spend alert should err
+ * toward firing.
  */
-const BILLED_COST_24H =
-  'sum(max by (service, workload, model) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h])))';
+function billedCost(input: {
+  aggregation: "increase" | "rate";
+  window: string;
+}): string {
+  const selector = `llm_cost_usd_total{type=~"actual|upstream"}`;
+  const perType = `sum by (service, workload, model, type) (${input.aggregation}(${selector}[${input.window}]))`;
+  return `max by (service, workload, model) (${perType})`;
+}
+
+/** Fleet-wide billed spend over 24h, for the daily ceilings. */
+const BILLED_COST_24H = `sum(${billedCost({ aggregation: "increase", window: "24h" })})`;
+
+/** Billed spend per workload, for the spike comparison. */
+function billedCostByWorkload(window: string): string {
+  return `sum by (service, workload) (${billedCost({ aggregation: "rate", window })})`;
+}
 
 export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
@@ -135,7 +170,7 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "LlmWorkloadCostSpike",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            `sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) > ${LLM_WORKLOAD_SPIKE_RATIO.toString()} * sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[24h])) and sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) * 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
+            `${billedCostByWorkload("1h")} > ${LLM_WORKLOAD_SPIKE_RATIO.toString()} * ${billedCostByWorkload("24h")} and ${billedCostByWorkload("1h")} * 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
           ),
           for: "15m",
           labels: { severity: "warning", category: "llm" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -2,6 +2,41 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
 
+/**
+ * Daily spend ceilings for `llm_cost_usd_total`, in USD.
+ *
+ * Measured baseline at authoring time was ~$2.55/day summed across every
+ * service and workload, so the warning tier is roughly 3x headroom and the
+ * critical tier roughly 6x. Both are deliberately coarse: they exist to catch a
+ * runaway agent loop or a model-pin change, not to police normal variance.
+ */
+export const LLM_DAILY_SPEND_WARNING_USD = 8;
+export const LLM_DAILY_SPEND_CRITICAL_USD = 15;
+
+/**
+ * A workload must both spike relative to its own daily rate AND clear this
+ * hourly floor before it alerts. Without the floor, a workload that normally
+ * costs fractions of a cent trips the ratio on any burst of ordinary traffic.
+ */
+export const LLM_WORKLOAD_SPIKE_RATIO = 5;
+export const LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR = 0.5;
+
+/**
+ * Cost accounting that reflects what we are actually billed.
+ *
+ * `actual` is what OpenRouter charged. For BYOK routes OpenRouter charges
+ * nothing and the real money is in `upstream` (`upstream_inference_cost`), so an
+ * `actual`-only ceiling would miss the largest single line item in the fleet.
+ * Taking the per-series maximum covers both without double counting, because
+ * the two are equal on ordinary non-BYOK routes.
+ *
+ * This is deliberately conservative pending the OpenRouter Broadcast
+ * comparison that will settle the `actual` vs `upstream` semantics: a spend
+ * ceiling should err toward firing.
+ */
+const BILLED_COST_24H =
+  'sum(max by (service, workload, model) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h])))';
+
 export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     {
@@ -24,6 +59,15 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
           record: "llm:request_duration:p95_5m",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             "histogram_quantile(0.95, sum by (le, service, workload, provider, model) (rate(llm_request_duration_seconds_bucket[5m])))",
+          ),
+        },
+        {
+          // Keeps `workload`, unlike the dashboard's inline actual-minus-catalog
+          // expression, so a per-feature pricing drift is attributable to the
+          // feature that caused it.
+          record: "llm:cost_discrepancy:rate5m",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'sum by (service, workload, model) (rate(llm_cost_usd_total{type="actual"}[5m])) - sum by (service, workload, model) (rate(llm_cost_usd_total{type="catalog"}[5m]))',
           ),
         },
       ],
@@ -56,6 +100,77 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
             summary: "Structured LLM output exhausted all semantic attempts",
             description: escapePrometheusTemplate(
               "generateValidatedObject exhausted its bounded semantic repair attempts. Every attempt was traced and charged; inspect the correlated workload span and archived redacted output instead of replaying an effectful workflow.",
+            ),
+          },
+        },
+        {
+          alert: "LlmDailySpendHigh",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `${BILLED_COST_24H} > ${LLM_DAILY_SPEND_WARNING_USD.toString()}`,
+          ),
+          for: "15m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            summary: "LLM spend over the last 24h exceeded the warning ceiling",
+            description: escapePrometheusTemplate(
+              "Rolling 24h LLM spend crossed the warning ceiling. The figure takes the per-series maximum of OpenRouter's charged cost and upstream inference cost, so it includes BYOK routes that bill nothing through OpenRouter. Break the total down by workload on the AI Provider dashboard before assuming this is organic growth.",
+            ),
+          },
+        },
+        {
+          alert: "LlmDailySpendCritical",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `${BILLED_COST_24H} > ${LLM_DAILY_SPEND_CRITICAL_USD.toString()}`,
+          ),
+          for: "15m",
+          labels: { severity: "critical", category: "llm" },
+          annotations: {
+            summary:
+              "LLM spend over the last 24h exceeded the critical ceiling",
+            description: escapePrometheusTemplate(
+              "Rolling 24h LLM spend is several times the measured baseline. Identify the responsible workload before it runs another day; a runaway tool loop or a model-pin change are the usual causes. Disabling the feature flag for the offending workload is faster than rolling back an image.",
+            ),
+          },
+        },
+        {
+          alert: "LlmWorkloadCostSpike",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) > ${LLM_WORKLOAD_SPIKE_RATIO.toString()} * sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[24h])) and sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) * 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
+          ),
+          for: "15m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            // No apostrophes in an annotation that also carries escaped Go
+            // templates. An apostrophe plus the double quotes that
+            // escapePrometheusTemplate emits forces the YAML emitter into
+            // double-quoted style, which backslash-escapes those quotes; Helm
+            // then fails to parse `{{ \"{{\" }}` with "unexpected \\ in
+            // command" and every chart render breaks.
+            summary: escapePrometheusTemplate(
+              "LLM workload {{ $labels.workload }} is burning cost far above its own baseline",
+            ),
+            description: escapePrometheusTemplate(
+              "{{ $labels.service }} workload {{ $labels.workload }} is spending several times its own 24h rate and has cleared the hourly floor, so this is not a small workload tripping a ratio. Compare the request rate against the cost rate: a flat request rate with rising cost means longer prompts or a model change, not more traffic.",
+            ),
+          },
+        },
+        {
+          alert: "OpenRouterBroadcastSilent",
+          // `last_success` is 0 until the first delivery ever lands, so
+          // `time() - last_success` covers both "never configured" and "went
+          // stale" without a separate == 0 branch. Gating on process uptime
+          // keeps a pod restart, which resets the gauge, from alerting before
+          // the service has had a full day to receive anything.
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "(time() - max(openrouter_broadcast_ingest_process_start_time_seconds)) > 86400 and (time() - max(openrouter_broadcast_last_success_timestamp_seconds)) > 86400",
+          ),
+          for: "30m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            summary:
+              "OpenRouter Broadcast has been up for a day without a successful delivery",
+            description: escapePrometheusTemplate(
+              "The Broadcast ingest is running and scrapeable but has not completed an archive-plus-forward in 24h. The usual cause is that the webhook was never configured on OpenRouter, which leaves the authoritative per-generation cost record unavailable while the service looks healthy. See the enable-openrouter-broadcast how-to; do not acknowledge from pod health.",
             ),
           },
         },


### PR DESCRIPTION
## Why

Nothing in the monitoring stack watched LLM cost. A runaway tool loop, a model-pin bump, or a prompt that doubled in size would bill silently until someone happened to open a dashboard — we have alerts for *metadata missing* and *structured-output exhausted*, both cheaper failures than this.

Separately, `openrouter-broadcast-ingest` has been deployed, healthy and publicly probed for 11 days **without ever receiving a delivery**. The webhook was never configured, so the authoritative per-generation cost record does not exist while the service looks fine:

```
openrouter_broadcast_last_success_timestamp_seconds = 0
openrouter_broadcast_requests_total                 = (never incremented)
```

## What

**Spend ceilings** — `LlmDailySpendHigh` ($8/day, warning) and `LlmDailySpendCritical` ($15/day, critical) against a measured **$2.55/day** baseline.

Both take the per-series **maximum of `actual` and `upstream`** cost. BYOK routes bill nothing through OpenRouter: glitter reports `actual=$0` against **$10.25/7d** of upstream inference cost — the largest single line item in the fleet — which an `actual`-only ceiling would miss entirely. The two are equal on ordinary routes, so the max double counts nothing.

**`LlmWorkloadCostSpike`** — gated on *both* a 5x ratio against the workload's own 24h rate *and* a $0.50/hour absolute floor, so workloads costing fractions of a cent cannot trip it on an ordinary burst.

**`OpenRouterBroadcastSilent`** — covers "never configured" and "went stale" in one expression (`last_success` is 0 until the first delivery, so `time() - last_success` subsumes both), gated on process uptime so a pod restart, which zeroes the gauge, does not alert prematurely.

**Dashboard** — the Cost panel now groups by `workload` instead of aggregating the feature dimension away, plus a "Top Cost by Feature (24h)" panel.

**How-to** — configuring the webhook and verifying all four outputs.

The **effective-cost convention is deliberately not settled here.** The data contradicts the simple readings: `actual == upstream` for Birmel, but `$11.55` vs `$25.27` for `scout.review.text`, and `$0` vs `$10.25` for glitter. That waits on the Broadcast comparison; `llm:cost_discrepancy:rate5m` ships now so the disagreement is at least visible.

## Verification

`bunx turbo run typecheck lint --filter=@homelab/cdk8s` passes; the full cdk8s suite is **587 passed** after `bun run build` re-synths `dist/`.

Every new expression was executed against **live Prometheus**:

| Expression | Result |
| --- | --- |
| `LlmDailySpendHigh` (>8) | empty — baseline is 2.47 ✅ |
| `LlmWorkloadCostSpike` | parses, 0 series — quiet ✅ |
| `OpenRouterBroadcastSilent` | **returns a value** — correctly identifies the dark service ✅ |
| `llm:cost_discrepancy:rate5m` | 6 series ✅ |

The new "Top Cost by Feature" panel query, run live — this is the per-feature breakdown that was previously aggregated away:

```
scout-service-beta    scout.review.text               1.7209
scout-service-beta    scout.betting.parlay.generate   0.7453
birmel                birmel.route                    0
temporal-infra-worker homelab-audit-synthesis         0
```

Panel screenshots need the dashboard deployed, so the live query output above stands as the evidence that the panels will render correct data.

### Not done

**`OpenRouterBroadcastSilent` will fire on merge** and stay firing until the webhook is configured. That is the intent — but the webhook is an OpenRouter dashboard action I cannot perform. Land this and flip it in the same session, following the new how-to.

One sharp edge worth knowing: an apostrophe in an annotation that also contains escaped Go templates forces the YAML emitter into double-quoted style, which backslash-escapes the quotes inside `{{ "{{" }}` and breaks Helm's parser for **every** chart. Caught by the existing helm-template tests; a comment now records it.