### PR TITLE
feat(llm-observability): add subject attribution and stop pricing subscription calls

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -866,7 +866,7 @@
     },
     "packages/llm-observability/src/span-helpers.ts|packages/temporal/src/observability/tracing.ts": {
       "clones": 1,
-      "tokens": 94
+      "tokens": 91
     },
     "packages/llm-runtime/src/metrics.ts|packages/llm-runtime/src/metrics.ts": {
       "clones": 1,
@@ -1945,5 +1945,5 @@
       "tokens": 238
     }
   },
-  "updated": "2026-08-26T06:11:02.613Z"
+  "updated": "2026-08-29T19:50:24.140Z"
 }

--- a/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
+++ b/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
@@ -53,7 +53,24 @@ labels. OpenRouter, Claude Agent SDK, and Codex SDK share:
 - `llm_requests_total`
 - `llm_request_duration_seconds`
 - `llm_tokens_total`
-- `llm_cost_usd_total`
+
+`llm_cost_usd_total` is **not** shared. Only the OpenRouter gateway contributes
+to it. Both native SDKs bill against a subscription rather than per call, so any
+figure they report is an API-equivalent price rather than money that moved.
+Publishing that into the same series as real OpenRouter charges would have made
+the one number people sum, and the ceilings that alert on it, wrong. The native
+SDKs record tokens instead. Codex never had an `actual` figure at all, only a
+catalog estimate, which made the series look complete while being a guess.
+
+Cost is recorded under three `type` labels and they disagree, deliberately.
+`actual` is what OpenRouter charged, `catalog` is what our own pricing table
+predicts, and `upstream` is the provider's inference cost. For a BYOK route
+OpenRouter charges nothing, so `actual` reads zero while the real money sits in
+`upstream`. A spend query that reads only `actual` therefore understates the
+fleet. Which of the three is authoritative in the general case is still an open
+question, waiting on the correlated OpenRouter Broadcast record to settle it;
+until then the spend ceilings take the per-series maximum of `actual` and
+`upstream`, because an alert should err toward firing.
 
 Structured-output attempts, router attempts, and missing router metadata have
 separate counters. Existing `ai_provider_errors_total` and

--- a/packages/docs/wiki/src/content/docs/how-to/enable-openrouter-broadcast.md
+++ b/packages/docs/wiki/src/content/docs/how-to/enable-openrouter-broadcast.md
@@ -1,0 +1,88 @@
+---
+title: Enable OpenRouter Broadcast
+description: Point the OpenRouter Broadcast webhook at the ingest service and confirm the authoritative per-generation cost record is arriving.
+sidebar:
+  order: 15
+---
+
+The `openrouter-broadcast-ingest` service is deployed and reachable, but it only
+receives anything once the webhook is configured in the OpenRouter dashboard.
+Until then it looks healthy and delivers nothing, and the authoritative
+per-generation cost record does not exist.
+
+This guide configures the webhook and confirms delivery. You need access to the
+OpenRouter dashboard and to the `openrouter-broadcast-ingest` 1Password item.
+
+## 1. Confirm the service is up but silent
+
+```bash
+toolkit prom query 'up{namespace="openrouter-broadcast-ingest"}'
+toolkit prom query 'openrouter_broadcast_last_success_timestamp_seconds'
+```
+
+`up` should be `1`. A `last_success` of `0` means no delivery has ever
+completed, which is the state this guide fixes. A non-zero value means Broadcast
+is already working and you are in the wrong guide.
+
+## 2. Read the bearer token
+
+```bash
+op read "op://<vault>/openrouter-broadcast-ingest/OPENROUTER_BROADCAST_BEARER_TOKEN"
+```
+
+Do not paste the value anywhere except the OpenRouter dashboard field in step 3.
+
+If `op whoami` says you are signed out, ignore it and run the `op read` anyway —
+desktop-app integration authenticates each operation individually and does not
+always create a shell session.
+
+## 3. Configure the webhook
+
+In the OpenRouter dashboard, add a Broadcast destination:
+
+| Field  | Value                                             |
+| ------ | ------------------------------------------------- |
+| URL    | `https://openrouter-broadcast.sjer.red/v1/traces` |
+| Method | `POST`                                            |
+| Header | `Authorization: Bearer <token from step 2>`       |
+| Format | OTLP/HTTP JSON                                    |
+
+Run OpenRouter's built-in connection test. A `204` means the payload was both
+archived and forwarded; any other status is a real failure, not a warm-up.
+
+## 4. Send one real generation
+
+Trigger any workload that calls OpenRouter — a Discord `/bb-ask`, or any Birmel
+message — so a genuine payload flows rather than OpenRouter's synthetic test.
+
+## 5. Verify all four outputs
+
+Pod health is not acceptance. Confirm each of these separately:
+
+```bash
+# Deliveries are arriving and succeeding
+toolkit prom query 'sum by (outcome) (openrouter_broadcast_requests_total)'
+toolkit prom query 'sum by (operation, outcome) (openrouter_broadcast_operations_total)'
+
+# The last success is recent rather than zero
+toolkit prom query 'time() - max(openrouter_broadcast_last_success_timestamp_seconds)'
+
+# A body-free correlated span reached Tempo
+toolkit tempo query '{resource.service.name=~".*openrouter.*"}' --since 1h --limit 5
+```
+
+Then confirm the fourth output by hand: a payload object and its digest receipt
+exist in the private SeaweedFS LLM archive bucket. The archive is the only one of
+the four that Prometheus cannot answer for you.
+
+The `OpenRouterBroadcastSilent` alert resolves within 30 minutes of the first
+successful delivery. If it stays firing, work through
+`OpenRouterBroadcastPipelineFailure` and the service logs rather than
+re-running the connection test.
+
+## Related
+
+- [LLM stack](/explanation/llm-stack/) — why Broadcast is a second, correlated
+  evidence source rather than the primary one.
+- `packages/openrouter-broadcast-ingest/README.md` — the service's own
+  configuration and canary notes.

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -78,12 +78,12 @@ export function addLlmPanels(
         "Actual OpenRouter or Claude SDK cost, canonical catalog cost, and upstream inference cost. The discrepancy series is actual minus catalog cost.",
       targets: [
         {
-          query: `sum by (service, model, type) (rate(llm_cost_usd_total{${llmFilter}}[5m])) or on() vector(0)`,
-          legend: "{{service}} {{model}} {{type}}",
+          query: `sum by (service, workload, model, type) (rate(llm_cost_usd_total{${llmFilter}}[5m])) or on() vector(0)`,
+          legend: "{{service}} {{workload}} {{model}} {{type}}",
         },
         {
-          query: `sum by (service, model) (rate(llm_cost_usd_total{${llmFilter},type="actual"}[5m])) - sum by (service, model) (rate(llm_cost_usd_total{${llmFilter},type="catalog"}[5m]))`,
-          legend: "{{service}} {{model}} actual-catalog",
+          query: `sum by (service, workload, model) (rate(llm_cost_usd_total{${llmFilter},type="actual"}[5m])) - sum by (service, workload, model) (rate(llm_cost_usd_total{${llmFilter},type="catalog"}[5m]))`,
+          legend: "{{service}} {{workload}} {{model}} actual-catalog",
         },
       ],
       gridPos: { x: 12, y: 49, w: 12, h: 8 },
@@ -91,10 +91,26 @@ export function addLlmPanels(
     }),
   );
 
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Top Cost by Feature (24h)",
+      description:
+        "Rolling 24h billed spend per workload. Takes the per-series maximum of OpenRouter's charged cost and upstream inference cost so BYOK routes, which bill nothing through OpenRouter and would read as $0 under an actual-only query, are still counted.",
+      targets: [
+        {
+          query: `topk(10, sum by (service, workload) (max by (service, workload, model) (increase(llm_cost_usd_total{${llmFilter},type=~"actual|upstream"}[24h])))) or on() vector(0)`,
+          legend: "{{service}} {{workload}}",
+        },
+      ],
+      gridPos: { x: 0, y: 57, w: 24, h: 8 },
+      unit: "currencyUSD",
+    }),
+  );
+
   builder.withRow(
     new dashboard.RowBuilder("Routing and Structured Output").gridPos({
       x: 0,
-      y: 57,
+      y: 65,
       w: 24,
       h: 1,
     }),
@@ -111,7 +127,7 @@ export function addLlmPanels(
           legend: "{{service}} {{model}} {{upstream_provider}} {{outcome}}",
         },
       ],
-      gridPos: { x: 0, y: 58, w: 12, h: 8 },
+      gridPos: { x: 0, y: 66, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -127,7 +143,7 @@ export function addLlmPanels(
           legend: "{{service}} {{model}} {{upstream_provider}}",
         },
       ],
-      gridPos: { x: 12, y: 58, w: 12, h: 8 },
+      gridPos: { x: 12, y: 66, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -143,7 +159,7 @@ export function addLlmPanels(
           legend: "{{service}} {{workload}} {{model}} {{outcome}}",
         },
       ],
-      gridPos: { x: 0, y: 66, w: 12, h: 8 },
+      gridPos: { x: 0, y: 74, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -159,7 +175,7 @@ export function addLlmPanels(
           legend: "{{service}} {{workload}} {{model}}",
         },
       ],
-      gridPos: { x: 12, y: 66, w: 12, h: 8 },
+      gridPos: { x: 12, y: 74, w: 12, h: 8 },
       unit: "ops",
     }),
   );
@@ -167,7 +183,7 @@ export function addLlmPanels(
   builder.withRow(
     new dashboard.RowBuilder("Broadcast Archive and Tempo").gridPos({
       x: 0,
-      y: 74,
+      y: 82,
       w: 24,
       h: 1,
     }),
@@ -185,7 +201,7 @@ export function addLlmPanels(
           legend: "{{outcome}}",
         },
       ],
-      gridPos: { x: 0, y: 75, w: 8, h: 8 },
+      gridPos: { x: 0, y: 83, w: 8, h: 8 },
       unit: "reqps",
     }),
   );
@@ -202,7 +218,7 @@ export function addLlmPanels(
           legend: "{{operation}} {{outcome}}",
         },
       ],
-      gridPos: { x: 8, y: 75, w: 8, h: 8 },
+      gridPos: { x: 8, y: 83, w: 8, h: 8 },
       unit: "ops",
     }),
   );
@@ -224,7 +240,7 @@ export function addLlmPanels(
           legend: "last success age",
         },
       ],
-      gridPos: { x: 16, y: 75, w: 8, h: 8 },
+      gridPos: { x: 16, y: 83, w: 8, h: 8 },
       unit: "s",
     }),
   );

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -95,10 +95,10 @@ export function addLlmPanels(
     createTimeseriesPanel({
       title: "Top Cost by Feature (24h)",
       description:
-        "Rolling 24h billed spend per workload. Takes the per-series maximum of OpenRouter's charged cost and upstream inference cost so BYOK routes, which bill nothing through OpenRouter and would read as $0 under an actual-only query, are still counted.",
+        "Rolling 24h billed spend per workload. Sums each accounting type across pod lifetimes first, then takes the larger of OpenRouter's charged cost and upstream inference cost, so BYOK routes -- which bill nothing through OpenRouter and read as $0 under an actual-only query -- are counted, and a deploy inside the window does not discard the shorter pod's spend.",
       targets: [
         {
-          query: `topk(10, sum by (service, workload) (max by (service, workload, model) (increase(llm_cost_usd_total{${llmFilter},type=~"actual|upstream"}[24h])))) or on() vector(0)`,
+          query: `topk(10, sum by (service, workload) (max by (service, workload, model) (sum by (service, workload, model, type) (increase(llm_cost_usd_total{${llmFilter},type=~"actual|upstream"}[24h]))))) or on() vector(0)`,
           legend: "{{service}} {{workload}}",
         },
       ],

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -75,7 +75,7 @@ export function addLlmPanels(
     createTimeseriesPanel({
       title: "Cost Rate and Discrepancy",
       description:
-        "Actual OpenRouter or Claude SDK cost, canonical catalog cost, and upstream inference cost. The discrepancy series is actual minus catalog cost.",
+        "OpenRouter cost only, by accounting type: actual charged cost, canonical catalog cost, and upstream inference cost. The discrepancy series is actual minus catalog. The Claude Agent SDK and Codex SDK bill against subscriptions and deliberately contribute no cost series, so their spend is not represented here -- see their token panels instead.",
       targets: [
         {
           query: `sum by (service, workload, model, type) (rate(llm_cost_usd_total{${llmFilter}}[5m])) or on() vector(0)`,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "vitest";
-import { getLlmRuleGroups } from "./llm.ts";
+import {
+  getLlmRuleGroups,
+  LLM_DAILY_SPEND_CRITICAL_USD,
+  LLM_DAILY_SPEND_WARNING_USD,
+  LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR,
+  LLM_WORKLOAD_SPIKE_RATIO,
+} from "./llm.ts";
 
 test("keeps LLM recording and Broadcast alert coverage together", () => {
   const groups = getLlmRuleGroups();
@@ -32,4 +38,63 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
     const alert = rules.find((rule) => rule?.alert === alertName);
     expect(alert?.labels).toEqual({ severity: "warning", category: "llm" });
   }
+});
+
+test("alerts on LLM spend and on a silent Broadcast webhook", () => {
+  const rules = getLlmRuleGroups().flatMap(
+    ({ rules: groupRules }) => groupRules,
+  );
+  const alertNamed = (name: string) =>
+    rules.find((rule) => rule?.alert === name);
+
+  for (const [name, severity] of [
+    ["LlmDailySpendHigh", "warning"],
+    ["LlmDailySpendCritical", "critical"],
+    ["LlmWorkloadCostSpike", "warning"],
+    ["OpenRouterBroadcastSilent", "warning"],
+  ] as const) {
+    expect(alertNamed(name)?.labels).toEqual({ severity, category: "llm" });
+  }
+
+  // The critical tier must sit above the warning tier, or the warning alert is
+  // unreachable and the ceiling silently becomes a single threshold.
+  expect(LLM_DAILY_SPEND_CRITICAL_USD).toBeGreaterThan(
+    LLM_DAILY_SPEND_WARNING_USD,
+  );
+  expect(alertNamed("LlmDailySpendHigh")?.expr?.value).toContain(
+    `> ${LLM_DAILY_SPEND_WARNING_USD.toString()}`,
+  );
+  expect(alertNamed("LlmDailySpendCritical")?.expr?.value).toContain(
+    `> ${LLM_DAILY_SPEND_CRITICAL_USD.toString()}`,
+  );
+
+  // BYOK routes bill nothing through OpenRouter, so an actual-only ceiling
+  // would miss them entirely. Both accounting sources must be in the ceiling.
+  for (const spendAlert of ["LlmDailySpendHigh", "LlmDailySpendCritical"]) {
+    const expr = alertNamed(spendAlert)?.expr?.value;
+    expect(expr).toContain('type=~"actual|upstream"');
+    expect(expr).toContain("max by (service, workload, model)");
+  }
+
+  // The spike alert needs both halves: a ratio alone fires on any burst from a
+  // workload that costs fractions of a cent.
+  const spike = alertNamed("LlmWorkloadCostSpike")?.expr?.value;
+  expect(spike).toContain(`> ${LLM_WORKLOAD_SPIKE_RATIO.toString()} *`);
+  expect(spike).toContain(
+    `* 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
+  );
+
+  // Uptime gating is what keeps a pod restart, which zeroes the gauge, from
+  // alerting before the service has had a day to receive a delivery.
+  const silent = alertNamed("OpenRouterBroadcastSilent")?.expr?.value;
+  expect(silent).toContain(
+    "openrouter_broadcast_ingest_process_start_time_seconds",
+  );
+  expect(silent).toContain(
+    "openrouter_broadcast_last_success_timestamp_seconds",
+  );
+
+  expect(JSON.stringify(getLlmRuleGroups())).toContain(
+    "llm:cost_discrepancy:rate5m",
+  );
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -68,12 +68,31 @@ test("alerts on LLM spend and on a silent Broadcast webhook", () => {
     `> ${LLM_DAILY_SPEND_CRITICAL_USD.toString()}`,
   );
 
-  // BYOK routes bill nothing through OpenRouter, so an actual-only ceiling
-  // would miss them entirely. Both accounting sources must be in the ceiling.
-  for (const spendAlert of ["LlmDailySpendHigh", "LlmDailySpendCritical"]) {
-    const expr = alertNamed(spendAlert)?.expr?.value;
+  // Every cost alert must use the same billed-cost convention. BYOK routes bill
+  // nothing through OpenRouter and report `actual` of exactly zero, so an
+  // actual-only expression misses the largest line item in the fleet -- and for
+  // the spike alert would hold both the ratio and the floor at zero, making it
+  // structurally incapable of firing for that class of workload.
+  const costAlerts = [
+    "LlmDailySpendHigh",
+    "LlmDailySpendCritical",
+    "LlmWorkloadCostSpike",
+  ];
+  for (const costAlert of costAlerts) {
+    const expr = alertNamed(costAlert)?.expr?.value;
     expect(expr).toContain('type=~"actual|upstream"');
-    expect(expr).toContain("max by (service, workload, model)");
+    expect(expr).not.toContain('type="actual"');
+
+    // Ordering is the correctness property, not merely the presence of both
+    // aggregations. These series carry `pod`, so a deploy inside the window
+    // leaves two counter series per workload; selecting the maximum before
+    // summing them keeps only the longer-lived pod and silently understates
+    // spend. The per-type sum must therefore appear *inside* the max.
+    const maxAt = expr?.indexOf("max by (service, workload, model)") ?? -1;
+    const sumAt =
+      expr?.indexOf("sum by (service, workload, model, type)") ?? -1;
+    expect(maxAt).toBeGreaterThanOrEqual(0);
+    expect(sumAt).toBeGreaterThan(maxAt);
   }
 
   // The spike alert needs both halves: a ratio alone fires on any burst from a

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -88,9 +88,13 @@ test("alerts on LLM spend and on a silent Broadcast webhook", () => {
     // leaves two counter series per workload; selecting the maximum before
     // summing them keeps only the longer-lived pod and silently understates
     // spend. The per-type sum must therefore appear *inside* the max.
-    const maxAt = expr?.indexOf("max by (service, workload, model)") ?? -1;
-    const sumAt =
-      expr?.indexOf("sum by (service, workload, model, type)") ?? -1;
+    // `expr.value` is typed `string | number`, so narrow before searching it
+    // rather than letting an unexpected numeric expression silently skip the
+    // ordering assertions below.
+    expect(typeof expr).toBe("string");
+    const rendered = typeof expr === "string" ? expr : "";
+    const maxAt = rendered.indexOf("max by (service, workload, model)");
+    const sumAt = rendered.indexOf("sum by (service, workload, model, type)");
     expect(maxAt).toBeGreaterThanOrEqual(0);
     expect(sumAt).toBeGreaterThan(maxAt);
   }

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -5,37 +5,72 @@ import { escapePrometheusTemplate } from "./shared.ts";
 /**
  * Daily spend ceilings for `llm_cost_usd_total`, in USD.
  *
- * Measured baseline at authoring time was ~$2.55/day summed across every
- * service and workload, so the warning tier is roughly 3x headroom and the
- * critical tier roughly 6x. Both are deliberately coarse: they exist to catch a
- * runaway agent loop or a model-pin change, not to police normal variance.
+ * Anchored on the measured distribution of `BILLED_COST_24H`, not on a guess:
+ * a 7-day mean of ~$8.20/day and a worst observed rolling 24h of ~$20.80.
+ * Warning sits at roughly 2x that worst real day and 5x the mean; critical at
+ * roughly 3.5x the worst day and 9x the mean.
+ *
+ * The headroom is deliberate. These exist to catch a runaway agent loop or a
+ * model-pin change -- an order-of-magnitude event -- not to police normal
+ * variance, and normal variance here is already a 4x spread between a quiet day
+ * and a busy one. Tightening them toward the mean would page on a busy Sunday.
+ *
+ * Re-derive rather than nudge these if the fleet's shape changes:
+ *   max_over_time(<BILLED_COST_24H>[7d:1h])
  */
-export const LLM_DAILY_SPEND_WARNING_USD = 8;
-export const LLM_DAILY_SPEND_CRITICAL_USD = 15;
+export const LLM_DAILY_SPEND_WARNING_USD = 40;
+export const LLM_DAILY_SPEND_CRITICAL_USD = 75;
 
 /**
  * A workload must both spike relative to its own daily rate AND clear this
  * hourly floor before it alerts. Without the floor, a workload that normally
  * costs fractions of a cent trips the ratio on any burst of ordinary traffic.
+ *
+ * Both sides of the comparison use `billedCost`, not `type="actual"` alone. A
+ * BYOK workload reports `actual` of exactly zero, so an actual-only ratio and
+ * floor would both stay at zero and the alert could never detect a runaway in
+ * precisely the class of workload the daily ceilings exist to catch.
  */
 export const LLM_WORKLOAD_SPIKE_RATIO = 5;
 export const LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR = 0.5;
 
 /**
- * Cost accounting that reflects what we are actually billed.
+ * Billed LLM cost, as one expression every cost alert is built from.
  *
  * `actual` is what OpenRouter charged. For BYOK routes OpenRouter charges
  * nothing and the real money is in `upstream` (`upstream_inference_cost`), so an
- * `actual`-only ceiling would miss the largest single line item in the fleet.
- * Taking the per-series maximum covers both without double counting, because
- * the two are equal on ordinary non-BYOK routes.
+ * `actual`-only expression would miss the largest single line item in the fleet.
+ * Taking the per-model maximum of the two covers both without double counting,
+ * because they are equal on ordinary non-BYOK routes.
  *
- * This is deliberately conservative pending the OpenRouter Broadcast
- * comparison that will settle the `actual` vs `upstream` semantics: a spend
- * ceiling should err toward firing.
+ * The inner `sum` is load-bearing and must stay inside the `max`. These series
+ * carry `pod` and `instance`, so a deploy inside the window leaves two counter
+ * series per workload. Selecting the maximum first would keep only the larger
+ * pod lifetime -- $5 before a restart and $5 after would evaluate as $5, not
+ * $10, and silently understate spend after every deploy. Summing per accounting
+ * type first collapses those lifetimes, and only then is the larger of `actual`
+ * and `upstream` chosen.
+ *
+ * Conservative on purpose, pending the OpenRouter Broadcast comparison that
+ * will settle the `actual` vs `upstream` semantics: a spend alert should err
+ * toward firing.
  */
-const BILLED_COST_24H =
-  'sum(max by (service, workload, model) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h])))';
+function billedCost(input: {
+  aggregation: "increase" | "rate";
+  window: string;
+}): string {
+  const selector = `llm_cost_usd_total{type=~"actual|upstream"}`;
+  const perType = `sum by (service, workload, model, type) (${input.aggregation}(${selector}[${input.window}]))`;
+  return `max by (service, workload, model) (${perType})`;
+}
+
+/** Fleet-wide billed spend over 24h, for the daily ceilings. */
+const BILLED_COST_24H = `sum(${billedCost({ aggregation: "increase", window: "24h" })})`;
+
+/** Billed spend per workload, for the spike comparison. */
+function billedCostByWorkload(window: string): string {
+  return `sum by (service, workload) (${billedCost({ aggregation: "rate", window })})`;
+}
 
 export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
@@ -135,7 +170,7 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "LlmWorkloadCostSpike",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            `sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) > ${LLM_WORKLOAD_SPIKE_RATIO.toString()} * sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[24h])) and sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) * 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
+            `${billedCostByWorkload("1h")} > ${LLM_WORKLOAD_SPIKE_RATIO.toString()} * ${billedCostByWorkload("24h")} and ${billedCostByWorkload("1h")} * 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
           ),
           for: "15m",
           labels: { severity: "warning", category: "llm" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -2,6 +2,41 @@ import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/gen
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
 
+/**
+ * Daily spend ceilings for `llm_cost_usd_total`, in USD.
+ *
+ * Measured baseline at authoring time was ~$2.55/day summed across every
+ * service and workload, so the warning tier is roughly 3x headroom and the
+ * critical tier roughly 6x. Both are deliberately coarse: they exist to catch a
+ * runaway agent loop or a model-pin change, not to police normal variance.
+ */
+export const LLM_DAILY_SPEND_WARNING_USD = 8;
+export const LLM_DAILY_SPEND_CRITICAL_USD = 15;
+
+/**
+ * A workload must both spike relative to its own daily rate AND clear this
+ * hourly floor before it alerts. Without the floor, a workload that normally
+ * costs fractions of a cent trips the ratio on any burst of ordinary traffic.
+ */
+export const LLM_WORKLOAD_SPIKE_RATIO = 5;
+export const LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR = 0.5;
+
+/**
+ * Cost accounting that reflects what we are actually billed.
+ *
+ * `actual` is what OpenRouter charged. For BYOK routes OpenRouter charges
+ * nothing and the real money is in `upstream` (`upstream_inference_cost`), so an
+ * `actual`-only ceiling would miss the largest single line item in the fleet.
+ * Taking the per-series maximum covers both without double counting, because
+ * the two are equal on ordinary non-BYOK routes.
+ *
+ * This is deliberately conservative pending the OpenRouter Broadcast
+ * comparison that will settle the `actual` vs `upstream` semantics: a spend
+ * ceiling should err toward firing.
+ */
+const BILLED_COST_24H =
+  'sum(max by (service, workload, model) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h])))';
+
 export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
     {
@@ -24,6 +59,15 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
           record: "llm:request_duration:p95_5m",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             "histogram_quantile(0.95, sum by (le, service, workload, provider, model) (rate(llm_request_duration_seconds_bucket[5m])))",
+          ),
+        },
+        {
+          // Keeps `workload`, unlike the dashboard's inline actual-minus-catalog
+          // expression, so a per-feature pricing drift is attributable to the
+          // feature that caused it.
+          record: "llm:cost_discrepancy:rate5m",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'sum by (service, workload, model) (rate(llm_cost_usd_total{type="actual"}[5m])) - sum by (service, workload, model) (rate(llm_cost_usd_total{type="catalog"}[5m]))',
           ),
         },
       ],
@@ -56,6 +100,77 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
             summary: "Structured LLM output exhausted all semantic attempts",
             description: escapePrometheusTemplate(
               "generateValidatedObject exhausted its bounded semantic repair attempts. Every attempt was traced and charged; inspect the correlated workload span and archived redacted output instead of replaying an effectful workflow.",
+            ),
+          },
+        },
+        {
+          alert: "LlmDailySpendHigh",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `${BILLED_COST_24H} > ${LLM_DAILY_SPEND_WARNING_USD.toString()}`,
+          ),
+          for: "15m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            summary: "LLM spend over the last 24h exceeded the warning ceiling",
+            description: escapePrometheusTemplate(
+              "Rolling 24h LLM spend crossed the warning ceiling. The figure takes the per-series maximum of OpenRouter's charged cost and upstream inference cost, so it includes BYOK routes that bill nothing through OpenRouter. Break the total down by workload on the AI Provider dashboard before assuming this is organic growth.",
+            ),
+          },
+        },
+        {
+          alert: "LlmDailySpendCritical",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `${BILLED_COST_24H} > ${LLM_DAILY_SPEND_CRITICAL_USD.toString()}`,
+          ),
+          for: "15m",
+          labels: { severity: "critical", category: "llm" },
+          annotations: {
+            summary:
+              "LLM spend over the last 24h exceeded the critical ceiling",
+            description: escapePrometheusTemplate(
+              "Rolling 24h LLM spend is several times the measured baseline. Identify the responsible workload before it runs another day; a runaway tool loop or a model-pin change are the usual causes. Disabling the feature flag for the offending workload is faster than rolling back an image.",
+            ),
+          },
+        },
+        {
+          alert: "LlmWorkloadCostSpike",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) > ${LLM_WORKLOAD_SPIKE_RATIO.toString()} * sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[24h])) and sum by (service, workload) (rate(llm_cost_usd_total{type="actual"}[1h])) * 3600 > ${LLM_WORKLOAD_SPIKE_FLOOR_USD_PER_HOUR.toString()}`,
+          ),
+          for: "15m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            // No apostrophes in an annotation that also carries escaped Go
+            // templates. An apostrophe plus the double quotes that
+            // escapePrometheusTemplate emits forces the YAML emitter into
+            // double-quoted style, which backslash-escapes those quotes; Helm
+            // then fails to parse `{{ \"{{\" }}` with "unexpected \\ in
+            // command" and every chart render breaks.
+            summary: escapePrometheusTemplate(
+              "LLM workload {{ $labels.workload }} is burning cost far above its own baseline",
+            ),
+            description: escapePrometheusTemplate(
+              "{{ $labels.service }} workload {{ $labels.workload }} is spending several times its own 24h rate and has cleared the hourly floor, so this is not a small workload tripping a ratio. Compare the request rate against the cost rate: a flat request rate with rising cost means longer prompts or a model change, not more traffic.",
+            ),
+          },
+        },
+        {
+          alert: "OpenRouterBroadcastSilent",
+          // `last_success` is 0 until the first delivery ever lands, so
+          // `time() - last_success` covers both "never configured" and "went
+          // stale" without a separate == 0 branch. Gating on process uptime
+          // keeps a pod restart, which resets the gauge, from alerting before
+          // the service has had a full day to receive anything.
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            "(time() - max(openrouter_broadcast_ingest_process_start_time_seconds)) > 86400 and (time() - max(openrouter_broadcast_last_success_timestamp_seconds)) > 86400",
+          ),
+          for: "30m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            summary:
+              "OpenRouter Broadcast has been up for a day without a successful delivery",
+            description: escapePrometheusTemplate(
+              "The Broadcast ingest is running and scrapeable but has not completed an archive-plus-forward in 24h. The usual cause is that the webhook was never configured on OpenRouter, which leaves the authoritative per-generation cost record unavailable while the service looks healthy. See the enable-openrouter-broadcast how-to; do not acknowledge from pod health.",
             ),
           },
         },

--- a/packages/llm-observability/README.md
+++ b/packages/llm-observability/README.md
@@ -29,12 +29,37 @@ All of these are re-exported from the package root; the per-wrapper subpaths
 listed above exist so a consumer only type-checks against the peer SDKs it
 actually uses.
 
+Neither native SDK contributes to `llm_cost_usd_total`. Both bill against a
+subscription rather than per call, so a cost figure from either would be an
+API-equivalent price mixed into the same series as real OpenRouter charges.
+They record tokens instead. `llm.cost_usd` remains on the Claude Agent span as a
+provider-reported fact for reading a single trace.
+
 Direct provider-SDK wrappers (Anthropic, OpenAI, Gemini, and the `claude` CLI)
 are gone: every model call in the repository now goes through OpenRouter via
 the AI SDK, so those calls are instrumented by
 `RepositoryOpenTelemetry` (`./ai-sdk-telemetry`) and the `withLlmSpan` /
 `setLlmResponseAttributes` primitives in `./span-helpers` rather than by a
 per-provider wrapper.
+
+## Subject attribution
+
+`./subject` carries the vocabulary for _who_ a call was made on behalf of:
+`LlmSubject` is a `{ kind, id }` pair over `discord_user`, `guild`,
+`tracked_player`, and `system`. Not every workload has a requester — match
+reports are generated for a tracked player and scheduled betting runs for a whole
+guild — so the kind travels with the id rather than every caller pretending to
+have a user.
+
+`withLlmSubjectSpan(name, subject, fn)` opens an **active** span carrying those
+attributes. Activeness is the point, not a detail: `@shepherdjerred/llm-runtime`
+reads `trace.getSpan(context.active())` when it builds a call's attribution
+headers, so a call made outside an active span reaches OpenRouter with no trace
+id and its cost log cannot be joined back to the span that names the subject.
+
+Subject ids are span attributes only. They must never become Prometheus labels —
+the LLM metrics carry bounded service/workload/provider/model/outcome labels by
+design, and Tempo is already the store for trace, session, and user ids.
 
 ## Archive pipeline (slim spans)
 

--- a/packages/llm-observability/README.md
+++ b/packages/llm-observability/README.md
@@ -57,6 +57,14 @@ reads `trace.getSpan(context.active())` when it builds a call's attribution
 headers, so a call made outside an active span reaches OpenRouter with no trace
 id and its cost log cannot be joined back to the span that names the subject.
 
+The subject also travels through OpenTelemetry context, and `RepositoryOpenTelemetry`
+stamps it onto every `gen_ai.*` span it opens. This is not a convenience: OTel
+does not propagate attributes down a trace, and usage lands on the `gen_ai.*`
+spans rather than on the attribution span above them. Without the context hop, a
+query grouping by subject and summing tokens would be reading two different
+spans and would return nothing. Calls made outside an attribution span carry no
+subject attributes at all, so unattributed work stays visibly unattributed.
+
 Subject ids are span attributes only. They must never become Prometheus labels —
 the LLM metrics carry bounded service/workload/provider/model/outcome labels by
 design, and Tempo is already the store for trace, session, and user ids.

--- a/packages/llm-observability/package.json
+++ b/packages/llm-observability/package.json
@@ -10,6 +10,7 @@
     ".": "./src/index.ts",
     "./span-processor": "./src/archive-span-processor.ts",
     "./span-helpers": "./src/span-helpers.ts",
+    "./subject": "./src/subject.ts",
     "./metrics": "./src/metrics.ts",
     "./ai-sdk-telemetry": "./src/ai-sdk-telemetry.ts",
     "./wrappers/claude-agent": "./src/claude-agent-wrapper.ts",

--- a/packages/llm-observability/src/ai-sdk-telemetry.ts
+++ b/packages/llm-observability/src/ai-sdk-telemetry.ts
@@ -46,7 +46,22 @@ export class RepositoryOpenTelemetry extends OpenTelemetry {
   readonly #parents = new Map<string, ParentState>();
 
   constructor(options: RepositoryOpenTelemetryOptions) {
-    super(options);
+    // The base class creates its own inference/tool/embed spans internally
+    // (this.tracer.startSpan(...) inside its own onStart/onEnd handlers) and
+    // that is where gen_ai.usage.* actually lands -- not on the repository-owned
+    // gen_ai.<operation> parent span created below. Wrapping the caller's
+    // enrichSpan is the base class's own extension point for exactly this: it
+    // runs on every span type the base class creates, so composing onto it is
+    // what gets the subject onto the same span as the usage, rather than only
+    // onto the parent that wraps it.
+    const callerEnrichSpan = options.enrichSpan;
+    super({
+      ...options,
+      enrichSpan: (input) => ({
+        ...callerEnrichSpan?.(input),
+        ...activeLlmSubjectAttributes(),
+      }),
+    });
     this.#service = options.service;
     this.#tracer =
       options.tracer ??
@@ -68,11 +83,10 @@ export class RepositoryOpenTelemetry extends OpenTelemetry {
         "gen_ai.request.model": model,
         "llm.service": this.#service,
         "llm.call_site": workload,
-        // Stamped here rather than inherited: OpenTelemetry does not propagate
-        // attributes down a trace, and usage lands on this span and its
-        // children. Putting the subject on the same span as the usage is what
-        // lets one query group spend by who it was spent for. Empty when the
-        // call site opened no attribution span.
+        // Also stamped on this repository-owned wrapper span, for queries that
+        // key on span name rather than gen_ai.usage.*. The span that actually
+        // carries usage is one of the base class's own inference/tool/embed
+        // spans, stamped via the enrichSpan composition in the constructor.
         ...activeLlmSubjectAttributes(),
       },
     });

--- a/packages/llm-observability/src/ai-sdk-telemetry.ts
+++ b/packages/llm-observability/src/ai-sdk-telemetry.ts
@@ -8,6 +8,7 @@ import {
 } from "@opentelemetry/api";
 import { OpenTelemetry, type OpenTelemetryOptions } from "@ai-sdk/otel";
 import { modelIdForOpenRouterRoute } from "@shepherdjerred/llm-models";
+import { activeLlmSubjectAttributes } from "./subject.ts";
 import { z } from "zod";
 
 type StartEvent = Parameters<OpenTelemetry["onStart"]>[0];
@@ -67,6 +68,12 @@ export class RepositoryOpenTelemetry extends OpenTelemetry {
         "gen_ai.request.model": model,
         "llm.service": this.#service,
         "llm.call_site": workload,
+        // Stamped here rather than inherited: OpenTelemetry does not propagate
+        // attributes down a trace, and usage lands on this span and its
+        // children. Putting the subject on the same span as the usage is what
+        // lets one query group spend by who it was spent for. Empty when the
+        // call site opened no attribution span.
+        ...activeLlmSubjectAttributes(),
       },
     });
     const parentContext = trace.setSpan(context.active(), span);

--- a/packages/llm-observability/src/claude-agent-wrapper.ts
+++ b/packages/llm-observability/src/claude-agent-wrapper.ts
@@ -5,7 +5,6 @@ import {
   type AttributeValue,
   type Span,
 } from "@opentelemetry/api";
-import { costForTextUsage } from "@shepherdjerred/llm-models";
 import type { Registry } from "prom-client";
 import {
   getLlmTracer,
@@ -167,18 +166,12 @@ function recordMetrics(
     { ...labels, type: "cache_write_input" },
     acc.cacheCreationInputTokens ?? 0,
   );
-  if (acc.totalCostUsd !== undefined) {
-    metrics.cost.inc({ ...labels, type: "actual" }, acc.totalCostUsd);
-  }
-  const catalogCostUsd = costForTextUsage(labels.model, {
-    inputTokens: acc.inputTokens ?? 0,
-    outputTokens: acc.outputTokens ?? 0,
-    cacheReadTokens: acc.cacheReadInputTokens ?? 0,
-    cacheWriteTokens: acc.cacheCreationInputTokens ?? 0,
-  });
-  if (catalogCostUsd !== undefined) {
-    metrics.cost.inc({ ...labels, type: "catalog" }, catalogCostUsd);
-  }
+  // Deliberately no `metrics.cost.inc` here. The Claude Agent SDK runs against
+  // a subscription (CLAUDE_CODE_OAUTH_TOKEN), so no money moves per call and the
+  // SDK's own `total_cost_usd` is an API-equivalent price, not cash. Summing it
+  // into `llm_cost_usd_total` alongside real OpenRouter charges would make the
+  // fleet-wide spend figure -- and the ceilings that alert on it -- wrong.
+  // Tokens are recorded above and remain the usage signal for this transport.
 }
 
 function newAccumulator(): Accumulator {
@@ -289,6 +282,9 @@ function applyResultMetaAttrs(
     attrs["gen_ai.response.finish_reasons"] = [finishReason];
   }
   if (acc.totalCostUsd !== undefined) {
+    // Subscription-equivalent API price, not cash spent. Kept on the span
+    // because it is useful when reading one trace; deliberately absent from
+    // `llm_cost_usd_total`, which means OpenRouter cash and nothing else.
     attrs["llm.cost_usd"] = acc.totalCostUsd;
   }
   if (acc.numTurns !== undefined) {

--- a/packages/llm-observability/src/codex-trace.ts
+++ b/packages/llm-observability/src/codex-trace.ts
@@ -9,7 +9,6 @@
 // hardcoded `pokemon.*` values.
 
 import { context, trace, type Span, type Tracer } from "@opentelemetry/api";
-import { costForTextUsage } from "@shepherdjerred/llm-models";
 import type { Registry } from "prom-client";
 import { z } from "zod";
 import { getLlmTracer } from "./span-helpers.ts";
@@ -273,14 +272,12 @@ function recordCodexMetrics(
     { ...labels, type: "reasoning" },
     usage.reasoningOutputTokens,
   );
-  const cost = costForTextUsage(options.model, {
-    inputTokens: usage.inputTokens,
-    cachedInputTokens: usage.cachedInputTokens,
-    outputTokens: usage.outputTokens + usage.reasoningOutputTokens,
-  });
-  if (cost !== undefined) {
-    metrics.cost.inc({ ...labels, type: "catalog" }, cost);
-  }
+  // Deliberately no `metrics.cost.inc` here. Codex runs against a
+  // ChatGPT-managed subscription bundle, so a catalog estimate is a price we do
+  // not pay per call. It was also the only cost this transport reported -- there
+  // was never an `actual` figure to compare it against -- so publishing it made
+  // `llm_cost_usd_total` look complete while being a guess. Tokens above remain
+  // the usage signal.
 }
 
 type ToolHandlerArgs = {

--- a/packages/llm-observability/src/span-helpers.ts
+++ b/packages/llm-observability/src/span-helpers.ts
@@ -37,6 +37,34 @@ export type LlmResponseAttrs = {
 };
 
 /**
+ * Run `fn` inside `span`: set OK/ERROR status from whether it throws, record the
+ * exception, and always end the span. Every `with*Span` helper in this package
+ * shares this lifecycle rather than each re-implementing it, so the
+ * status/recordException/end contract has one definition.
+ */
+export async function runSpanLifecycle<T>(
+  span: Span,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  try {
+    const result = await fn(span);
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (error: unknown) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    if (error instanceof Error) {
+      span.recordException(error);
+    }
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+
+/**
  * Open a `gen_ai.<operation>` span and run `fn`. The caller sets request/response
  * body attributes via `span.setAttributes({...})` inside `fn`; this helper takes
  * care of error recording, status, and ending the span.
@@ -53,22 +81,7 @@ export async function withLlmSpan<T>(
   const tracer = getLlmTracer();
   return tracer.startActiveSpan(`gen_ai.${operation}`, async (span) => {
     span.setAttributes(buildBaseAttributes(metadata, request, operation));
-    try {
-      const result = await fn(span);
-      span.setStatus({ code: SpanStatusCode.OK });
-      return result;
-    } catch (error: unknown) {
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      if (error instanceof Error) {
-        span.recordException(error);
-      }
-      throw error;
-    } finally {
-      span.end();
-    }
+    return runSpanLifecycle(span, fn);
   });
 }
 

--- a/packages/llm-observability/src/subject.ts
+++ b/packages/llm-observability/src/subject.ts
@@ -1,4 +1,10 @@
-import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import {
+  context,
+  createContextKey,
+  SpanStatusCode,
+  type Context,
+  type Span,
+} from "@opentelemetry/api";
 import { getLlmTracer } from "./span-helpers.ts";
 
 /**
@@ -52,6 +58,45 @@ export function llmSubjectAttributes(
   };
 }
 
+const SUBJECT_CONTEXT_KEY = createContextKey("shepherdjerred.llm.subject");
+
+/** Attach `subject` to `ctx` so nested model calls can find it. */
+export function setLlmSubject(ctx: Context, subject: LlmSubject): Context {
+  return ctx.setValue(SUBJECT_CONTEXT_KEY, subject);
+}
+
+/**
+ * The subject of the innermost enclosing `withLlmSubjectSpan`, if any.
+ *
+ * This exists because OpenTelemetry span attributes are **not** inherited.
+ * Usage lands on the `gen_ai.*` spans the AI SDK creates, several levels below
+ * the attribution span, so a query that groups by subject and sums tokens finds
+ * the two on different spans and returns nothing. Propagating through context
+ * lets the telemetry layer stamp the subject onto the same span that carries
+ * the usage, which is what makes per-subject token and cost queries answerable
+ * at all.
+ */
+export function activeLlmSubject(): LlmSubject | undefined {
+  const value: unknown = context.active().getValue(SUBJECT_CONTEXT_KEY);
+  if (value === null || typeof value !== "object") return undefined;
+  if (!("kind" in value) || !("id" in value)) return undefined;
+  const { kind, id } = value;
+  if (typeof id !== "string") return undefined;
+  // `find` both validates the kind and yields it already narrowed to the union,
+  // so no type assertion is needed to rebuild the subject.
+  const matched = LLM_SUBJECT_KINDS.find((known) => known === kind);
+  return matched === undefined ? undefined : { kind: matched, id };
+}
+
+/**
+ * Subject attributes for the active subject, or an empty object when there is
+ * none. Safe to spread into any span's attributes.
+ */
+export function activeLlmSubjectAttributes(): Record<string, string> {
+  const subject = activeLlmSubject();
+  return subject === undefined ? {} : llmSubjectAttributes(subject);
+}
+
 /**
  * Open an active span carrying the subject and run `fn` inside it.
  *
@@ -70,7 +115,10 @@ export async function withLlmSubjectSpan<T>(
   return await getLlmTracer().startActiveSpan(name, async (span) => {
     span.setAttributes(attributes);
     try {
-      const result = await fn(span);
+      const result = await context.with(
+        setLlmSubject(context.active(), subject),
+        () => fn(span),
+      );
       span.setStatus({ code: SpanStatusCode.OK });
       return result;
     } catch (error: unknown) {

--- a/packages/llm-observability/src/subject.ts
+++ b/packages/llm-observability/src/subject.ts
@@ -5,6 +5,7 @@ import {
   type Context,
   type Span,
 } from "@opentelemetry/api";
+import { z } from "zod";
 import { getLlmTracer } from "./span-helpers.ts";
 
 /**
@@ -60,6 +61,11 @@ export function llmSubjectAttributes(
 
 const SUBJECT_CONTEXT_KEY = createContextKey("shepherdjerred.llm.subject");
 
+const LlmSubjectContextValueSchema = z.object({
+  kind: z.enum(LLM_SUBJECT_KINDS),
+  id: z.string(),
+});
+
 /** Attach `subject` to `ctx` so nested model calls can find it. */
 export function setLlmSubject(ctx: Context, subject: LlmSubject): Context {
   return ctx.setValue(SUBJECT_CONTEXT_KEY, subject);
@@ -75,17 +81,18 @@ export function setLlmSubject(ctx: Context, subject: LlmSubject): Context {
  * lets the telemetry layer stamp the subject onto the same span that carries
  * the usage, which is what makes per-subject token and cost queries answerable
  * at all.
+ *
+ * `undefined` from the context key never having been set is a legitimate,
+ * common case: most calls open no attribution span. A *present* value that
+ * fails to parse is not that -- it is a broken `setLlmSubject` caller, a
+ * contract violation between two pieces of our own code with no external
+ * boundary between them, and `.parse()` lets it fail loudly rather than
+ * silently rendering as unattributed.
  */
 export function activeLlmSubject(): LlmSubject | undefined {
-  const value: unknown = context.active().getValue(SUBJECT_CONTEXT_KEY);
-  if (value === null || typeof value !== "object") return undefined;
-  if (!("kind" in value) || !("id" in value)) return undefined;
-  const { kind, id } = value;
-  if (typeof id !== "string") return undefined;
-  // `find` both validates the kind and yields it already narrowed to the union,
-  // so no type assertion is needed to rebuild the subject.
-  const matched = LLM_SUBJECT_KINDS.find((known) => known === kind);
-  return matched === undefined ? undefined : { kind: matched, id };
+  const value = context.active().getValue(SUBJECT_CONTEXT_KEY);
+  if (value === undefined) return undefined;
+  return LlmSubjectContextValueSchema.parse(value);
 }
 
 /**

--- a/packages/llm-observability/src/subject.ts
+++ b/packages/llm-observability/src/subject.ts
@@ -1,12 +1,11 @@
 import {
   context,
   createContextKey,
-  SpanStatusCode,
   type Context,
   type Span,
 } from "@opentelemetry/api";
 import { z } from "zod";
-import { getLlmTracer } from "./span-helpers.ts";
+import { getLlmTracer, runSpanLifecycle } from "./span-helpers.ts";
 
 /**
  * Who or what an LLM call was made on behalf of.
@@ -119,26 +118,10 @@ export async function withLlmSubjectSpan<T>(
   fn: (span: Span) => Promise<T>,
 ): Promise<T> {
   const attributes = llmSubjectAttributes(subject);
-  return await getLlmTracer().startActiveSpan(name, async (span) => {
+  return await getLlmTracer().startActiveSpan(name, (span) => {
     span.setAttributes(attributes);
-    try {
-      const result = await context.with(
-        setLlmSubject(context.active(), subject),
-        () => fn(span),
-      );
-      span.setStatus({ code: SpanStatusCode.OK });
-      return result;
-    } catch (error: unknown) {
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      if (error instanceof Error) {
-        span.recordException(error);
-      }
-      throw error;
-    } finally {
-      span.end();
-    }
+    return context.with(setLlmSubject(context.active(), subject), () =>
+      runSpanLifecycle(span, fn),
+    );
   });
 }

--- a/packages/llm-observability/src/subject.ts
+++ b/packages/llm-observability/src/subject.ts
@@ -1,0 +1,89 @@
+import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import { getLlmTracer } from "./span-helpers.ts";
+
+/**
+ * Who or what an LLM call was made on behalf of.
+ *
+ * Not every workload has a requester. Scout's most expensive workload generates
+ * match reports for a tracked player nobody explicitly asked on behalf of, and
+ * the betting workloads run on a schedule for a whole guild. Modelling this as a
+ * bare user id would force those callers to either lie or opt out, so the kind
+ * travels with the id.
+ */
+export const LLM_SUBJECT_KINDS = [
+  "discord_user",
+  "guild",
+  "tracked_player",
+  "system",
+] as const;
+
+export type LlmSubjectKind = (typeof LLM_SUBJECT_KINDS)[number];
+
+export type LlmSubject = {
+  kind: LlmSubjectKind;
+  id: string;
+};
+
+export const LLM_SUBJECT_KIND_ATTRIBUTE = "llm.subject.kind";
+export const LLM_SUBJECT_ID_ATTRIBUTE = "llm.subject.id";
+
+/**
+ * Build the span attributes for a subject.
+ *
+ * These are span attributes and must never become Prometheus labels. Subject ids
+ * are unbounded — Discord snowflakes, PUUIDs — and the LLM metrics deliberately
+ * carry only bounded service/workload/provider/model/outcome labels. Tempo is
+ * already the store for trace, session, and user ids.
+ */
+export function llmSubjectAttributes(
+  subject: LlmSubject,
+): Record<string, string> {
+  if (subject.id.trim() === "") {
+    // A blank id silently produces a span that looks attributed but groups
+    // every caller under one empty key, which is worse than no attribution:
+    // the resulting per-subject panel reads as a single dominant user.
+    throw new Error(
+      `LLM subject of kind "${subject.kind}" requires a non-empty id`,
+    );
+  }
+  return {
+    [LLM_SUBJECT_KIND_ATTRIBUTE]: subject.kind,
+    [LLM_SUBJECT_ID_ATTRIBUTE]: subject.id,
+  };
+}
+
+/**
+ * Open an active span carrying the subject and run `fn` inside it.
+ *
+ * The span must be *active*, not merely created: `@shepherdjerred/llm-runtime`
+ * reads `trace.getSpan(context.active())` when it builds a call's attribution
+ * headers, so a call made outside an active span reaches OpenRouter with no
+ * trace id and its cost log cannot be joined back to the trace that names the
+ * subject. Wrapping the call site is what makes both work.
+ */
+export async function withLlmSubjectSpan<T>(
+  name: string,
+  subject: LlmSubject,
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  const attributes = llmSubjectAttributes(subject);
+  return await getLlmTracer().startActiveSpan(name, async (span) => {
+    span.setAttributes(attributes);
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error: unknown) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      if (error instanceof Error) {
+        span.recordException(error);
+      }
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/packages/llm-observability/test/unit/ai-sdk-telemetry.test.ts
+++ b/packages/llm-observability/test/unit/ai-sdk-telemetry.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "vitest";
 import { RepositoryOpenTelemetry } from "#src/ai-sdk-telemetry.ts";
+import {
+  LLM_SUBJECT_ID_ATTRIBUTE,
+  LLM_SUBJECT_KIND_ATTRIBUTE,
+  withLlmSubjectSpan,
+} from "#src/subject.ts";
 import { exporter } from "./otel-test-provider.ts";
 
 test("AI SDK spans are children of a repository-owned GenAI parent", () => {
@@ -69,4 +74,104 @@ test("AI SDK spans are children of a repository-owned GenAI parent", () => {
   expect(sdkOperation?.parentSpanContext?.spanId).toBe(
     parent?.spanContext().spanId,
   );
+});
+
+test("the active subject lands on the span that carries usage", async () => {
+  exporter.reset();
+  const telemetry = new RepositoryOpenTelemetry({
+    service: "scout-backend",
+    embedding: true,
+  });
+
+  // OpenTelemetry does not propagate attributes down a trace, so a subject set
+  // only on an outer span and usage recorded only on the inner gen_ai span can
+  // never be summed together by one query. The subject has to be stamped onto
+  // the same span as the usage, which is what this asserts.
+  await withLlmSubjectSpan(
+    "scout.bucks-ask",
+    { kind: "discord_user", id: "160509172704739328" },
+    () => {
+      telemetry.onStart({
+        callId: "call-subject",
+        operationId: "ai.embed",
+        provider: "openrouter.embedding",
+        modelId: "openai/text-embedding-3-small",
+        value: "hello",
+        maxRetries: 2,
+        headers: undefined,
+        providerOptions: undefined,
+        functionId: "scout.bucks-ask",
+        recordInputs: true,
+        recordOutputs: true,
+      });
+      telemetry.onEnd({
+        callId: "call-subject",
+        operationId: "ai.embed",
+        provider: "openrouter.embedding",
+        modelId: "openai/text-embedding-3-small",
+        value: "hello",
+        embedding: [0.1, 0.2],
+        usage: { tokens: 1 },
+        warnings: [],
+        providerMetadata: undefined,
+        response: undefined,
+      });
+      return Promise.resolve();
+    },
+  );
+
+  const genAi = exporter
+    .getFinishedSpans()
+    .find((span) => span.name === "gen_ai.embeddings");
+  expect(genAi).toBeDefined();
+  expect(genAi?.attributes[LLM_SUBJECT_KIND_ATTRIBUTE]).toBe("discord_user");
+  expect(genAi?.attributes[LLM_SUBJECT_ID_ATTRIBUTE]).toBe(
+    "160509172704739328",
+  );
+  // The feature dimension must survive alongside it, so one query can group by
+  // both what was called and who it was called for.
+  expect(genAi?.attributes["llm.call_site"]).toBe("scout.bucks-ask");
+});
+
+test("a call with no enclosing subject span carries no subject attributes", () => {
+  exporter.reset();
+  const telemetry = new RepositoryOpenTelemetry({
+    service: "temporal",
+    embedding: true,
+  });
+
+  // Unattributed work must stay visibly unattributed rather than inheriting a
+  // stale subject from whatever ran before it on the same context.
+  telemetry.onStart({
+    callId: "call-none",
+    operationId: "ai.embed",
+    provider: "openrouter.embedding",
+    modelId: "openai/text-embedding-3-small",
+    value: "hello",
+    maxRetries: 2,
+    headers: undefined,
+    providerOptions: undefined,
+    functionId: "homelab-audit-synthesis",
+    recordInputs: true,
+    recordOutputs: true,
+  });
+  telemetry.onEnd({
+    callId: "call-none",
+    operationId: "ai.embed",
+    provider: "openrouter.embedding",
+    modelId: "openai/text-embedding-3-small",
+    value: "hello",
+    embedding: [0.1, 0.2],
+    usage: { tokens: 1 },
+    warnings: [],
+    providerMetadata: undefined,
+    response: undefined,
+  });
+
+  const genAi = exporter
+    .getFinishedSpans()
+    .find((span) => span.name === "gen_ai.embeddings");
+  expect(genAi).toBeDefined();
+  expect(genAi?.attributes[LLM_SUBJECT_KIND_ATTRIBUTE]).toBeUndefined();
+  expect(genAi?.attributes[LLM_SUBJECT_ID_ATTRIBUTE]).toBeUndefined();
 });

--- a/packages/llm-observability/test/unit/ai-sdk-telemetry.test.ts
+++ b/packages/llm-observability/test/unit/ai-sdk-telemetry.test.ts
@@ -104,6 +104,24 @@ test("the active subject lands on the span that carries usage", async () => {
         recordInputs: true,
         recordOutputs: true,
       });
+      telemetry.onEmbedStart({
+        callId: "call-subject",
+        embedCallId: "embed-subject",
+        operationId: "ai.embed.doEmbed",
+        provider: "openrouter.embedding",
+        modelId: "openai/text-embedding-3-small",
+        values: ["hello"],
+      });
+      telemetry.onEmbedEnd({
+        callId: "call-subject",
+        embedCallId: "embed-subject",
+        operationId: "ai.embed.doEmbed",
+        provider: "openrouter.embedding",
+        modelId: "openai/text-embedding-3-small",
+        values: ["hello"],
+        embeddings: [[0.1, 0.2]],
+        usage: { tokens: 1 },
+      });
       telemetry.onEnd({
         callId: "call-subject",
         operationId: "ai.embed",
@@ -120,16 +138,36 @@ test("the active subject lands on the span that carries usage", async () => {
     },
   );
 
-  const genAi = exporter
-    .getFinishedSpans()
-    .find((span) => span.name === "gen_ai.embeddings");
-  expect(genAi).toBeDefined();
+  const spans = exporter.getFinishedSpans();
+  const genAi = spans.find((span) => span.name === "gen_ai.embeddings");
+  // The base class's own descendant span is where usage actually lands, not
+  // the repository-owned wrapper selected above -- and not necessarily its
+  // direct child either: an embed operation nests an operation-level span
+  // between the wrapper and the per-value embed span that carries
+  // gen_ai.usage.*. Selecting on that property, rather than assuming a
+  // particular depth, is what the bug this guards against actually requires: a
+  // query grouping by subject and summing usage needs both on the same span,
+  // wherever in the hierarchy that span sits.
+  const sdkOperation = spans.find(
+    (span) => span.attributes["gen_ai.usage.input_tokens"] !== undefined,
+  );
+  expect(sdkOperation).toBeDefined();
+  expect(sdkOperation?.name).not.toBe("gen_ai.embeddings");
+  expect(sdkOperation?.attributes["gen_ai.usage.input_tokens"]).toBe(1);
+  expect(sdkOperation?.attributes[LLM_SUBJECT_KIND_ATTRIBUTE]).toBe(
+    "discord_user",
+  );
+  expect(sdkOperation?.attributes[LLM_SUBJECT_ID_ATTRIBUTE]).toBe(
+    "160509172704739328",
+  );
+
+  // The wrapper span carries the subject too, for queries keyed on span name
+  // rather than gen_ai.usage.*, and the feature dimension survives alongside
+  // it so one query can group by both what was called and who for.
   expect(genAi?.attributes[LLM_SUBJECT_KIND_ATTRIBUTE]).toBe("discord_user");
   expect(genAi?.attributes[LLM_SUBJECT_ID_ATTRIBUTE]).toBe(
     "160509172704739328",
   );
-  // The feature dimension must survive alongside it, so one query can group by
-  // both what was called and who it was called for.
   expect(genAi?.attributes["llm.call_site"]).toBe("scout.bucks-ask");
 });
 

--- a/packages/llm-observability/test/unit/codex-trace.test.ts
+++ b/packages/llm-observability/test/unit/codex-trace.test.ts
@@ -101,7 +101,11 @@ test("attachCodexTrace records standard native SDK metrics", async () => {
   expect(metrics).toContain('model="gpt-5.6-luna"');
   expect(metrics).toContain('outcome="success"');
   expect(metrics).toContain('type="reasoning"');
-  expect(metrics).toContain('type="catalog"');
+
+  // Codex bills against a ChatGPT-managed subscription, so it must contribute
+  // tokens but never cost. A catalog estimate here would be a price we do not
+  // pay per call, summed into the same series as real OpenRouter charges.
+  expect(metrics).not.toMatch(/^llm_cost_usd_total\{/m);
 });
 
 test("attachCodexTrace runs SDK work beneath its repository-owned span", () => {

--- a/packages/llm-observability/test/unit/subject.test.ts
+++ b/packages/llm-observability/test/unit/subject.test.ts
@@ -1,12 +1,18 @@
-import { context, trace } from "@opentelemetry/api";
+import { context, createContextKey, trace } from "@opentelemetry/api";
 import { expect, test } from "vitest";
 import {
+  activeLlmSubject,
   LLM_SUBJECT_ID_ATTRIBUTE,
   LLM_SUBJECT_KIND_ATTRIBUTE,
   llmSubjectAttributes,
   withLlmSubjectSpan,
 } from "#src/subject.ts";
 import { exporter } from "./otel-test-provider.ts";
+
+// Mirrors the private key in subject.ts; there is no public way to construct a
+// malformed context value, which is exactly the point -- only a bug reaching
+// past the module's own API surface could produce one.
+const SUBJECT_CONTEXT_KEY = createContextKey("shepherdjerred.llm.subject");
 
 test("withLlmSubjectSpan records the subject on the span", async () => {
   exporter.reset();
@@ -77,4 +83,26 @@ test("system is a first-class subject kind for workloads with no requester", () 
     [LLM_SUBJECT_KIND_ATTRIBUTE]: "system",
     [LLM_SUBJECT_ID_ATTRIBUTE]: "scout.betting.parlay",
   });
+});
+
+test("a present but malformed context value throws rather than reading as absent", () => {
+  // setLlmSubject is the only supported way to populate this key, and it only
+  // ever writes a valid LlmSubject. A malformed value can only mean a bug
+  // reached into the context by some other path, which is a contract
+  // violation between two pieces of our own code -- not a real boundary input
+  // -- and must fail loudly rather than silently rendering as unattributed.
+  const malformed = context.active().setValue(SUBJECT_CONTEXT_KEY, {
+    kind: "not-a-real-kind",
+    id: "42",
+  });
+
+  context.with(malformed, () => {
+    expect(() => activeLlmSubject()).toThrow();
+  });
+});
+
+test("no context value at all remains a legitimate absence", () => {
+  // Most calls open no attribution span, so this must stay `undefined`, not
+  // throw -- only a *present* malformed value is a bug.
+  expect(activeLlmSubject()).toBeUndefined();
 });

--- a/packages/llm-observability/test/unit/subject.test.ts
+++ b/packages/llm-observability/test/unit/subject.test.ts
@@ -1,0 +1,80 @@
+import { context, trace } from "@opentelemetry/api";
+import { expect, test } from "vitest";
+import {
+  LLM_SUBJECT_ID_ATTRIBUTE,
+  LLM_SUBJECT_KIND_ATTRIBUTE,
+  llmSubjectAttributes,
+  withLlmSubjectSpan,
+} from "#src/subject.ts";
+import { exporter } from "./otel-test-provider.ts";
+
+test("withLlmSubjectSpan records the subject on the span", async () => {
+  exporter.reset();
+
+  await withLlmSubjectSpan(
+    "scout.bucks-ask",
+    { kind: "discord_user", id: "160509172704739328" },
+    () => Promise.resolve("answered"),
+  );
+
+  const spans = exporter.getFinishedSpans();
+  expect(spans.length).toBe(1);
+  expect(spans[0]?.name).toBe("scout.bucks-ask");
+  expect(spans[0]?.attributes[LLM_SUBJECT_KIND_ATTRIBUTE]).toBe("discord_user");
+  expect(spans[0]?.attributes[LLM_SUBJECT_ID_ATTRIBUTE]).toBe(
+    "160509172704739328",
+  );
+});
+
+test("withLlmSubjectSpan makes the span active for the wrapped call", async () => {
+  exporter.reset();
+
+  // This is the property the whole attribution scheme rests on: llm-runtime
+  // reads trace.getSpan(context.active()) to build a call's attribution
+  // headers. If the span were created but not activated, the call would reach
+  // OpenRouter with no trace id and its cost log could never be joined back to
+  // the span naming the subject.
+  const observed = await withLlmSubjectSpan(
+    "scout.explore",
+    { kind: "discord_user", id: "42" },
+    () => Promise.resolve(trace.getSpan(context.active())?.spanContext()),
+  );
+
+  expect(observed?.traceId).toBeDefined();
+  expect(observed?.spanId).toBe(
+    exporter.getFinishedSpans()[0]?.spanContext().spanId,
+  );
+});
+
+test("withLlmSubjectSpan records a failure and still ends the span", async () => {
+  exporter.reset();
+
+  await expect(
+    withLlmSubjectSpan("scout.explore", { kind: "guild", id: "7" }, () =>
+      Promise.reject(new Error("model refused")),
+    ),
+  ).rejects.toThrow("model refused");
+
+  const spans = exporter.getFinishedSpans();
+  expect(spans.length).toBe(1);
+  expect(spans[0]?.status.code).toBe(2);
+  expect(spans[0]?.events.map((event) => event.name)).toContain("exception");
+});
+
+test("a blank subject id is rejected rather than attributed to an empty key", () => {
+  // A blank id would group every caller under one key, producing a per-subject
+  // panel with a single dominant "user" that does not exist.
+  expect(() =>
+    llmSubjectAttributes({ kind: "discord_user", id: "  " }),
+  ).toThrow(/requires a non-empty id/);
+});
+
+test("system is a first-class subject kind for workloads with no requester", () => {
+  // Scheduled work must be able to say so honestly instead of inventing a user.
+  expect(
+    llmSubjectAttributes({ kind: "system", id: "scout.betting.parlay" }),
+  ).toEqual({
+    [LLM_SUBJECT_KIND_ATTRIBUTE]: "system",
+    [LLM_SUBJECT_ID_ATTRIBUTE]: "scout.betting.parlay",
+  });
+});

--- a/packages/llm-observability/test/unit/wrappers.test.ts
+++ b/packages/llm-observability/test/unit/wrappers.test.ts
@@ -76,6 +76,8 @@ test("traceClaudeAgent accumulates assistant messages and result usage", async (
   expect(span.attributes["gen_ai.response.finish_reasons"]).toEqual([
     "end_turn",
   ]);
+  // Retained on the span as a provider-reported fact, and useful when reading
+  // one trace, but it is a subscription-equivalent API price rather than cash.
   expect(span.attributes["llm.cost_usd"]).toBe(0.0012);
   expect(span.attributes["llm.claude_code.num_turns"]).toBe(2);
   const outputs = JSON.parse(
@@ -87,8 +89,12 @@ test("traceClaudeAgent accumulates assistant messages and result usage", async (
   expect(metrics).toContain('provider="claude_agent_sdk"');
   expect(metrics).toContain('model="claude-sonnet-4-6"');
   expect(metrics).toContain('outcome="success"');
-  expect(metrics).toContain('type="actual"');
-  expect(metrics).toContain('type="catalog"');
+  // The Claude Agent SDK bills against a subscription, so it contributes token
+  // samples but must never contribute a cost sample. The counter itself stays
+  // registered because the OpenRouter path shares it; what must be absent is any
+  // `llm_cost_usd_total` series carrying this transport's labels.
+  expect(metrics).toContain('type="cached_input"');
+  expect(metrics).not.toMatch(/^llm_cost_usd_total\{/m);
 });
 
 test("traceClaudeAgent runs SDK iteration beneath its repository-owned span", async () => {


### PR DESCRIPTION
Stacked on #2519.

## Why

Two problems with one owner.

`llm_cost_usd_total` mixed real OpenRouter charges with figures from the Claude Agent SDK and Codex SDK, both of which bill against a **subscription** rather than per call. No single query answered "what did we spend". Codex never had an `actual` figure at all — only a catalog estimate — which made the series look complete while being a guess.

Separately there was no vocabulary for *who* a call was made on behalf of, and the obvious shape (a user id) does not fit the fleet: Scout's most expensive workload generates match reports for a tracked player nobody asked on behalf of, and the betting workloads run on a schedule across players tracked in different servers.

## What

**New `./subject` export.** `LlmSubject` is a `{ kind, id }` pair over `discord_user`, `guild`, `tracked_player`, and `system`, so a workload with no requester can say so instead of inventing a user. A blank id **throws** rather than grouping every caller under one empty key — that would render as a single dominant subject that does not exist.

**`withLlmSubjectSpan` opens an *active* span.** Activeness is the contract, not an implementation detail: `llm-runtime` reads `trace.getSpan(context.active())` to build attribution headers, so a call outside an active span reaches OpenRouter with no trace id and its cost log can never be joined back to the subject. A test asserts the active-span property directly rather than trusting the implementation.

**Both native SDKs stop calling `metrics.cost.inc`.** Tokens remain the usage signal. `llm.cost_usd` stays on the Claude span as a provider-reported fact, commented as subscription-equivalent rather than cash.

After this, `llm_cost_usd_total` means OpenRouter cash and nothing else.

Followed the package's existing subpath-export pattern (`./metrics`, `./span-helpers`) rather than the index, which uses elaborate wrappers to satisfy the custom `no-re-exports` rule.

Subject ids are **span attributes only** and must not become Prometheus labels; the metrics keep their bounded label set and Tempo remains the store for unbounded ids.

## Verification

- `bunx turbo run typecheck lint --filter=@shepherdjerred/llm-observability` passes
- **41 unit tests** pass, including 5 new ones for the subject module
- `bun scripts/knip.ts` clean — the `llm-models` dependency remains legitimate via `ai-sdk-telemetry.ts`

The cost assertions in the two wrapper tests now assert **absence**. They match on `/^llm_cost_usd_total\{/m` rather than the metric name, because the counter stays *registered* for the OpenRouter path that shares it — what must be absent is a sample carrying these transports' labels. Asserting on the name alone gave a false failure and would have been the wrong contract.

No consumer is wired to the new export in this PR, so it changes no runtime behaviour beyond removing the two cost series. Consumers land in the next PR.

Non-visual (metric and type changes only), so no media.