### PR TITLE
feat(scout-for-lol): attribute LLM calls to a subject and repair memory extraction

### DIFF
--- a/packages/birmel/src/agent-runtime/memory-extraction.ts
+++ b/packages/birmel/src/agent-runtime/memory-extraction.ts
@@ -63,7 +63,20 @@ const VerifiedToolExperienceMemorySchema = z.strictObject({
   validUntil: z.iso.datetime().nullable(),
 });
 
-export const SelfMemorySchema = z.discriminatedUnion("kind", [
+// z.union, not z.discriminatedUnion, and the difference is load-bearing: Zod
+// emits `oneOf` for a discriminated union and `anyOf` for a plain one, and
+// OpenAI-style strict structured outputs permit only `anyOf`. Azure rejected
+// every extraction outright with "In context=('properties', 'selfMemories',
+// 'items'), 'oneOf' is not permitted", so post-response memory extraction failed
+// on every delivered turn while the reply itself succeeded.
+//
+// This is routing-dependent, which is what made it survive review: providers
+// that tolerate `oneOf` pass the same schema happily, so the failure only
+// appears once OpenRouter routes the workload to Azure.
+//
+// The `kind` literals stay disjoint, so parsing behaviour is unchanged; only
+// the failure message for invalid input is less specific.
+export const SelfMemorySchema = z.union([
   AcceptedAliasMemorySchema,
   CommitmentMemorySchema,
   VerifiedToolExperienceMemorySchema,

--- a/packages/birmel/src/observability/tracing.ts
+++ b/packages/birmel/src/observability/tracing.ts
@@ -32,6 +32,7 @@ import {
   logger,
   setOtlpLogsEnabled,
 } from "@shepherdjerred/birmel/utils/logger.ts";
+import { llmSubjectAttributes } from "@shepherdjerred/llm-observability/subject";
 
 let nodeSdk: NodeSDK | null = null;
 let tracer: Tracer | null = null;
@@ -330,6 +331,23 @@ export type DiscordSpanAttributes = {
 };
 
 /**
+ * Repository-wide subject attributes for a Discord user, emitted alongside
+ * `discord.user_id` rather than instead of it: existing queries and saved views
+ * key on the Discord attribute, while cross-service dashboards group by the
+ * shared vocabulary.
+ *
+ * Returns nothing when there is no id. An empty subject would collapse every
+ * unattributed span onto one key and render as a single dominant user.
+ *
+ * Kept out of `withSpan` so its attribute literal stays a flat list; inlining
+ * the conditional pushed that function past the cognitive-complexity limit.
+ */
+function subjectAttributes(userId: string | undefined): Record<string, string> {
+  if (userId === undefined || userId === "") return {};
+  return llmSubjectAttributes({ kind: "discord_user", id: userId });
+}
+
+/**
  * Create a span with Discord context attributes.
  */
 export async function withSpan<T>(
@@ -356,6 +374,7 @@ export async function withSpan<T>(
         "discord.guild_id": attributes.guildId ?? "",
         "discord.channel_id": attributes.channelId ?? "",
         "discord.user_id": attributes.userId ?? "",
+        ...subjectAttributes(attributes.userId),
         "discord.message_id": attributes.messageId ?? "",
         "operation.name": attributes.operation ?? name,
         "birmel.route": attributes.route ?? "",

--- a/packages/birmel/src/observability/tracing.ts
+++ b/packages/birmel/src/observability/tracing.ts
@@ -1,6 +1,7 @@
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
 import {
+  context as otelContext,
   trace,
   diag,
   DiagLogLevel,
@@ -32,7 +33,10 @@ import {
   logger,
   setOtlpLogsEnabled,
 } from "@shepherdjerred/birmel/utils/logger.ts";
-import { llmSubjectAttributes } from "@shepherdjerred/llm-observability/subject";
+import {
+  llmSubjectAttributes,
+  setLlmSubject,
+} from "@shepherdjerred/llm-observability/subject";
 
 let nodeSdk: NodeSDK | null = null;
 let tracer: Tracer | null = null;
@@ -348,6 +352,26 @@ function subjectAttributes(userId: string | undefined): Record<string, string> {
 }
 
 /**
+ * Run `fn` with the turn's user established as the ambient LLM subject, so the
+ * `gen_ai.*` spans the runtime opens beneath this one carry it too.
+ *
+ * Setting the attributes on this span alone is not enough: OpenTelemetry does
+ * not inherit attributes down a trace, and token usage is recorded on the
+ * `gen_ai.*` spans rather than here, so a per-subject token query reading this
+ * span would find no usage to sum.
+ */
+function withSubjectContext<T>(
+  userId: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (userId === undefined || userId === "") return fn();
+  return otelContext.with(
+    setLlmSubject(otelContext.active(), { kind: "discord_user", id: userId }),
+    fn,
+  );
+}
+
+/**
  * Create a span with Discord context attributes.
  */
 export async function withSpan<T>(
@@ -389,7 +413,9 @@ export async function withSpan<T>(
         "birmel.job_payload_kind": attributes.payloadKind ?? "",
       });
 
-      const result = await fn(span);
+      const result = await withSubjectContext(attributes.userId, () =>
+        fn(span),
+      );
       span.setStatus({ code: SpanStatusCode.OK });
       return result;
     } catch (error) {

--- a/packages/birmel/tests/memory/memory-extraction.test.ts
+++ b/packages/birmel/tests/memory/memory-extraction.test.ts
@@ -7,8 +7,10 @@ import { attachExtractionProvenance } from "@shepherdjerred/birmel/agent-runtime
 import {
   attachSelfMemoryProvenance,
   buildExtractionTranscript,
+  ExtractionSchema,
   SelfMemorySchema,
 } from "@shepherdjerred/birmel/agent-runtime/memory-extraction.ts";
+import { z } from "zod";
 
 const turn = TurnInputSchema.parse({
   discordMessageId: "3000",
@@ -562,5 +564,54 @@ describe("verified tool self-memory", () => {
 
     expect(rejectedSelfMemory).toEqual({ candidates: [], rejectedCount: 1 });
     expect([...humanClaims, ...rejectedSelfMemory.candidates]).toHaveLength(1);
+  });
+});
+
+describe("structured-output compatibility", () => {
+  test("the extraction schema emits no oneOf", () => {
+    // Azure rejects `oneOf` in a strict response_format and returns a 400 before
+    // any tokens are billed, which took down post-response memory extraction on
+    // every delivered turn. Zod emits `oneOf` for z.discriminatedUnion and
+    // `anyOf` for z.union, so this asserts the union stays plain.
+    //
+    // A unit test is the only place this can be caught. The failure is
+    // routing-dependent -- providers that tolerate `oneOf` accept the identical
+    // schema -- so it does not reproduce until OpenRouter happens to pick Azure.
+    const jsonSchema = JSON.stringify(
+      z.toJSONSchema(ExtractionSchema, { io: "output" }),
+    );
+
+    expect(jsonSchema).not.toContain('"oneOf"');
+    expect(jsonSchema).toContain('"anyOf"');
+  });
+
+  test("every self-memory variant still parses through the union", () => {
+    // Swapping discriminatedUnion for union must not change what validates.
+    const variants = [
+      {
+        kind: "accepted-alias",
+        alias: "jerred",
+        confidence: 0.9,
+        salience: 0.8,
+      },
+      {
+        kind: "commitment",
+        scope: "guild",
+        targetUserId: null,
+        commitment: "I will start the stream at 8",
+        topic: "stream",
+        confidence: 0.9,
+        salience: 0.8,
+        validFrom: null,
+        validUntil: null,
+      },
+    ];
+
+    for (const variant of variants) {
+      expect(SelfMemorySchema.parse(variant)).toMatchObject({
+        kind: variant.kind,
+      });
+    }
+    expect(() => SelfMemorySchema.parse({ kind: "not-a-variant" })).toThrow();
   });
 });

--- a/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
+++ b/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
@@ -72,6 +72,45 @@ question, waiting on the correlated OpenRouter Broadcast record to settle it;
 until then the spend ceilings take the per-series maximum of `actual` and
 `upstream`, because an alert should err toward firing.
 
+## Attribution
+
+Spans carry who a call was made on behalf of, as a `(kind, id)` pair over
+`discord_user`, `guild`, `tracked_player`, and `system`. A bare user ID would
+not have fitted: match reviews are generated for a tracked player nobody asked
+on behalf of, and the betting workloads run on a schedule across players tracked
+in different servers, so they belong to no single guild. Those workloads declare
+`system` rather than borrowing an arbitrary user, which keeps unattributed spend
+visible as unattributed rather than misfiled.
+
+The attribution span must be _active_, not merely created. The runtime reads the
+ambient span when it builds a call's attribution headers, so a call made outside
+one reaches OpenRouter with no trace ID, and its cost log can never be joined
+back to the span naming the subject. This is why Scout's cost logs carried a null
+trace ID before the call sites were wrapped: its `gen_ai.chat` spans were trace
+roots with no enclosing application span.
+
+The subject then travels through OpenTelemetry context onto each `gen_ai.*`
+span. Attributes are not inherited down a trace and usage is recorded on those
+spans rather than on the attribution span above them, so without that hop a
+query grouping by subject and summing tokens would be reading two different
+spans and would find nothing.
+
+Because subject IDs are unbounded they stay span attributes and never become
+metric labels. That choice sets the horizon on every per-subject question:
+
+| Store      | Retention | Answers                      |
+| ---------- | --------- | ---------------------------- |
+| Prometheus | 365 days  | per-feature cost             |
+| Loki       | 90 days   | per-call cost, generation ID |
+| Tempo      | 30 days   | per-subject attribution      |
+
+Tempo is the binding constraint, and Tempo additionally caps a metrics query at
+a three-hour range. Per-subject spend is therefore a recent-window question
+answered by a join rather than a long-range aggregate; see
+[Attribute LLM spend](/how-to/attribute-llm-spend/). A durable per-user ledger
+would need its own store, which is deliberately not built until a chargeback or
+quota requirement justifies it.
+
 Structured-output attempts, router attempts, and missing router metadata have
 separate counters. Existing `ai_provider_errors_total` and
 `ai_provider_issue_active` series remain queryable across the cutover.

--- a/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
+++ b/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
@@ -15,12 +15,16 @@ Tempo retention limit.
 ## 1. Find spend for the feature you care about
 
 ```bash
-toolkit prom query 'topk(10, sum by (service, workload) (max by (service, workload, model) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h]))))'
+toolkit prom query 'topk(10, sum by (service, workload) (max by (service, workload, model) (sum by (service, workload, model, type) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h])))))'
 ```
 
 Take the per-series maximum of `actual` and `upstream`, not `actual` alone: a BYOK
 route bills nothing through OpenRouter and reads as `$0` under an actual-only query
 while still costing real money upstream.
+
+The inner `sum` must stay inside the `max`. These series carry `pod`, so a deploy
+inside the window leaves two counter series per workload, and taking the maximum
+first would keep only the longer-lived pod's spend.
 
 ## 2. Pull the per-call cost records with their trace IDs
 
@@ -45,15 +49,18 @@ toolkit tempo get <traceId> --jq '.trace.resourceSpans[].scopeSpans[].spans[]
 
 Sum the cost records sharing a trace ID to get that subject's total for the
 interaction. A trace is one interaction, so every workload inside it — routing,
-embedding, the answer itself — belongs to the same subject even though only the
-top-level span carries the subject attributes.
+embedding, the answer itself — belongs to the same subject.
+
+Filter on `gen_ai.operation.name` when you want one row per model call. The
+subject is stamped onto every `gen_ai.*` span as well as the attribution span
+above them, so matching without that filter counts the interaction twice.
 
 ## Alternative: recent activity, without the join
 
 For "who is active right now" rather than exact dollars, query Tempo directly:
 
 ```bash
-toolkit tempo metrics '{span.llm.subject.id != ""} | count_over_time() by (span.llm.subject.kind)' --since 3h
+toolkit tempo metrics '{span.gen_ai.operation.name != "" && span.llm.subject.id != ""} | count_over_time() by (span.llm.subject.kind)' --since 3h
 ```
 
 Tempo caps metrics queries at a three-hour range, so this cannot replace the join

--- a/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
+++ b/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
@@ -1,0 +1,75 @@
+---
+title: Attribute LLM spend to a user
+description: Join Loki's per-call cost records to the Tempo spans that name the subject, to find what one person or one tracked player cost.
+sidebar:
+  order: 16
+---
+
+Per-feature spend is a single Prometheus query. Per-_subject_ spend is not: subject
+IDs are span attributes rather than metric labels, so the dollars live in Loki and
+the identity lives in Tempo, joined on `traceId`.
+
+This guide answers "what did this user cost". It works over the last 30 days, the
+Tempo retention limit.
+
+## 1. Find spend for the feature you care about
+
+```bash
+toolkit prom query 'topk(10, sum by (service, workload) (max by (service, workload, model) (increase(llm_cost_usd_total{type=~"actual|upstream"}[24h]))))'
+```
+
+Take the per-series maximum of `actual` and `upstream`, not `actual` alone: a BYOK
+route bills nothing through OpenRouter and reads as `$0` under an actual-only query
+while still costing real money upstream.
+
+## 2. Pull the per-call cost records with their trace IDs
+
+Each successful call logs one JSON record carrying `workload`, `model`,
+`generationId`, `traceId`, and all three cost figures.
+
+```bash
+toolkit loki query '{namespace="scout-beta"} |= "llm.openrouter.response"' --since 24h --limit 200
+```
+
+Namespaces are `scout-beta`, `birmel`, and `temporal`. A record whose `traceId` is
+null was made outside an active attribution span and cannot be attributed — that is
+a bug in the call site, not a gap in this procedure.
+
+## 3. Resolve each trace to its subject
+
+```bash
+toolkit tempo get <traceId> --jq '.trace.resourceSpans[].scopeSpans[].spans[]
+  | {name, a: [.attributes[]? | select(.key|test("llm.subject")) | {(.key): (.value|to_entries[0].value)}]}
+  | select(.a|length>0)'
+```
+
+Sum the cost records sharing a trace ID to get that subject's total for the
+interaction. A trace is one interaction, so every workload inside it — routing,
+embedding, the answer itself — belongs to the same subject even though only the
+top-level span carries the subject attributes.
+
+## Alternative: recent activity, without the join
+
+For "who is active right now" rather than exact dollars, query Tempo directly:
+
+```bash
+toolkit tempo metrics '{span.llm.subject.id != ""} | count_over_time() by (span.llm.subject.kind)' --since 3h
+```
+
+Tempo caps metrics queries at a three-hour range, so this cannot replace the join
+for anything longer. The AI Provider dashboard's Attribution row runs the same
+queries.
+
+## If a call has no subject
+
+Workloads with no requester declare `system` on purpose — scheduled betting runs
+and match reviews are not made on behalf of a person who asked. Those are
+attributed, just not to a human. A span with _no_ subject attributes at all is an
+unwrapped call site.
+
+## Related
+
+- [LLM stack](/explanation/llm-stack/) — why subject IDs stay out of Prometheus,
+  and why the 30-day horizon exists.
+- [Enable OpenRouter Broadcast](/how-to/enable-openrouter-broadcast/) — the
+  correlated per-generation record from OpenRouter itself.

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -276,13 +276,13 @@ export function addLlmPanels(
  * `actualCostUsd` and join them to these spans on `traceId`.
  */
 const ATTRIBUTION_NOTE =
-  "Subject ids are span attributes, never metric labels, so this panel reads Tempo and inherits Tempo's 30-day retention and 3h metrics-query cap. For spend over a longer window, join Loki's llm.openrouter.response cost records to these spans on traceId.";
+  "Selects gen_ai.* spans, which carry both the subject and the usage: OpenTelemetry does not inherit attributes down a trace, so a query matching the attribution span above them would find no tokens to sum, and would count one span per interaction rather than one per model call. Subject ids are span attributes, never metric labels, so this panel reads Tempo and inherits Tempo's 30-day retention and 3h metrics-query cap. For spend over a longer window, join Loki's llm.openrouter.response cost records to these spans on traceId.";
 
 function createSubjectTokenPanel() {
   return new timeseries.PanelBuilder()
     .title("Output Tokens by Subject")
     .description(
-      `Output tokens grouped by who the call was made on behalf of. ${ATTRIBUTION_NOTE}`,
+      `Output tokens per model call, grouped by who the call was made on behalf of. ${ATTRIBUTION_NOTE}`,
     )
     .datasource(TEMPO_DATASOURCE)
     .withTarget(
@@ -290,7 +290,7 @@ function createSubjectTokenPanel() {
         .queryType("traceql")
         .metricsQueryType(tempo.MetricsQueryType.Range)
         .query(
-          '{span.llm.subject.id != ""} | sum_over_time(span.gen_ai.usage.output_tokens) by (span.llm.subject.kind, span.llm.subject.id)',
+          '{span.gen_ai.operation.name != "" && span.llm.subject.id != ""} | sum_over_time(span.gen_ai.usage.output_tokens) by (span.llm.subject.kind, span.llm.subject.id)',
         ),
     )
     .unit("short")
@@ -303,7 +303,7 @@ function createSubjectCallPanel() {
   return new timeseries.PanelBuilder()
     .title("Attributed Calls by Subject Kind")
     .description(
-      `Span counts by subject kind. A rising \`system\` share means spend is shifting to scheduled work with no requester, which is expected for match reviews and betting but not for interactive features. ${ATTRIBUTION_NOTE}`,
+      `Model calls by subject kind. A rising \`system\` share means spend is shifting to scheduled work with no requester, which is expected for match reviews and betting but not for interactive features. ${ATTRIBUTION_NOTE}`,
     )
     .datasource(TEMPO_DATASOURCE)
     .withTarget(
@@ -311,7 +311,7 @@ function createSubjectCallPanel() {
         .queryType("traceql")
         .metricsQueryType(tempo.MetricsQueryType.Range)
         .query(
-          '{span.llm.subject.kind != ""} | count_over_time() by (span.llm.subject.kind)',
+          '{span.gen_ai.operation.name != "" && span.llm.subject.kind != ""} | count_over_time() by (span.llm.subject.kind)',
         ),
     )
     .unit("short")

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -1,5 +1,9 @@
 import * as dashboard from "@grafana/grafana-foundation-sdk/dashboard";
+import * as tempo from "@grafana/grafana-foundation-sdk/tempo";
+import * as timeseries from "@grafana/grafana-foundation-sdk/timeseries";
 import { createTimeseriesPanel } from "./ai-provider-dashboard-panels.ts";
+
+const TEMPO_DATASOURCE = { type: "tempo", uid: "tempo" };
 
 export function addLlmPanels(
   builder: dashboard.DashboardBuilder,
@@ -244,4 +248,74 @@ export function addLlmPanels(
       unit: "s",
     }),
   );
+
+  builder.withRow(
+    new dashboard.RowBuilder("Attribution").gridPos({
+      x: 0,
+      y: 91,
+      w: 24,
+      h: 1,
+    }),
+  );
+
+  builder.withPanel(createSubjectTokenPanel());
+  builder.withPanel(createSubjectCallPanel());
+}
+
+/**
+ * Attribution reads from Tempo, not Prometheus, and that is deliberate.
+ *
+ * Subject ids are unbounded -- Discord snowflakes, PUUIDs -- so they are span
+ * attributes and never metric labels. That puts a hard 30-day horizon on every
+ * per-subject question, because Tempo's retention is 30 days while Loki keeps
+ * per-call cost for 90 days and Prometheus keeps per-feature cost for 365.
+ *
+ * Tempo also caps a metrics query at a 3h range server-side, so these panels
+ * answer "who is spending right now", not "who spent this month". For a longer
+ * window, query Loki for `llm.openrouter.response` records carrying
+ * `actualCostUsd` and join them to these spans on `traceId`.
+ */
+const ATTRIBUTION_NOTE =
+  "Subject ids are span attributes, never metric labels, so this panel reads Tempo and inherits Tempo's 30-day retention and 3h metrics-query cap. For spend over a longer window, join Loki's llm.openrouter.response cost records to these spans on traceId.";
+
+function createSubjectTokenPanel() {
+  return new timeseries.PanelBuilder()
+    .title("Output Tokens by Subject")
+    .description(
+      `Output tokens grouped by who the call was made on behalf of. ${ATTRIBUTION_NOTE}`,
+    )
+    .datasource(TEMPO_DATASOURCE)
+    .withTarget(
+      new tempo.TempoQueryBuilder()
+        .queryType("traceql")
+        .metricsQueryType(tempo.MetricsQueryType.Range)
+        .query(
+          '{span.llm.subject.id != ""} | sum_over_time(span.gen_ai.usage.output_tokens) by (span.llm.subject.kind, span.llm.subject.id)',
+        ),
+    )
+    .unit("short")
+    .lineWidth(2)
+    .fillOpacity(10)
+    .gridPos({ x: 0, y: 92, w: 12, h: 8 });
+}
+
+function createSubjectCallPanel() {
+  return new timeseries.PanelBuilder()
+    .title("Attributed Calls by Subject Kind")
+    .description(
+      `Span counts by subject kind. A rising \`system\` share means spend is shifting to scheduled work with no requester, which is expected for match reviews and betting but not for interactive features. ${ATTRIBUTION_NOTE}`,
+    )
+    .datasource(TEMPO_DATASOURCE)
+    .withTarget(
+      new tempo.TempoQueryBuilder()
+        .queryType("traceql")
+        .metricsQueryType(tempo.MetricsQueryType.Range)
+        .query(
+          '{span.llm.subject.kind != ""} | count_over_time() by (span.llm.subject.kind)',
+        ),
+    )
+    .unit("short")
+    .lineWidth(2)
+    .fillOpacity(10)
+    .gridPos({ x: 12, y: 92, w: 12, h: 8 });
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/ask-agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/ask-agent.ts
@@ -33,6 +33,7 @@ import {
   scoutBucksAskTokensUsedTotal,
   scoutBucksAskToolCallsTotal,
 } from "#src/metrics/bucks-ask.ts";
+import { withLlmSubjectSpan } from "@shepherdjerred/llm-observability/subject";
 
 export const BUCKS_ASK_MODEL_LIMITS = {
   steps: 4,
@@ -131,7 +132,14 @@ export async function runBucksAskAgent(
   },
   dependencies: BucksAskAgentDependencies = {},
 ): Promise<BucksAskAgentResult> {
-  return await runBucksAskAgentInternal(params, dependencies);
+  // The span wraps the whole run, not just the model call, so every OpenRouter
+  // request the agent makes -- including tool-loop steps -- is a descendant and
+  // inherits the trace id that the cost log needs to be joinable to this asker.
+  return await withLlmSubjectSpan(
+    "scout.bucks-ask",
+    { kind: "discord_user", id: params.discordId },
+    () => runBucksAskAgentInternal(params, dependencies),
+  );
 }
 
 async function runBucksAskAgentInternal(

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
@@ -60,6 +60,7 @@ import {
 import { createLogger } from "#src/logger.ts";
 import { enqueueParlayGeneration } from "#src/temporal/work-store.ts";
 import type { StartParlayGenerationInput } from "#src/betting/parlay-generation-types.ts";
+import { withLlmSubjectSpan } from "@shepherdjerred/llm-observability/subject";
 
 const logger = createLogger("betting-parlay-generate");
 
@@ -384,6 +385,22 @@ export async function runParlayGeneration(
   input: StartParlayGenerationInput,
   prismaClient: ExtendedPrismaClient = prisma,
   execution: "legacy" | "temporal" = "legacy",
+): Promise<void> {
+  // `system`, not `guild`: a parlay covers whichever tracked players happen to
+  // be in one live game, and those players can be tracked in different servers,
+  // so there is no single guild this spend belongs to. Marking it explicitly
+  // unattributed is honest; picking an arbitrary guild would not be.
+  return await withLlmSubjectSpan(
+    "scout.betting.parlay",
+    { kind: "system", id: "scout.betting.parlay" },
+    () => runParlayGenerationInternal(input, prismaClient, execution),
+  );
+}
+
+async function runParlayGenerationInternal(
+  input: StartParlayGenerationInput,
+  prismaClient: ExtendedPrismaClient,
+  execution: "legacy" | "temporal",
 ): Promise<void> {
   const startedAt = Date.now();
   const deadline = AbortSignal.timeout(PARLAY_GENERATION_DEADLINE_MS);

--- a/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/parlay-generate.ts
@@ -390,7 +390,7 @@ export async function runParlayGeneration(
   // be in one live game, and those players can be tracked in different servers,
   // so there is no single guild this spend belongs to. Marking it explicitly
   // unattributed is honest; picking an arbitrary guild would not be.
-  return await withLlmSubjectSpan(
+  await withLlmSubjectSpan(
     "scout.betting.parlay",
     { kind: "system", id: "scout.betting.parlay" },
     () => runParlayGenerationInternal(input, prismaClient, execution),

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-model.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-model.ts
@@ -19,6 +19,7 @@ import {
 import type { WeeklyParlayChampionSummary } from "#src/betting/weekly-parlay-history.ts";
 import { bettingParlayAiModel } from "#src/config/dynamic.ts";
 import { getOpenRouterRuntime } from "#src/league/review/ai-clients.ts";
+import { withLlmSubjectSpan } from "@shepherdjerred/llm-observability/subject";
 
 export const WEEKLY_PARLAY_PROMPT_VERSION = "2";
 
@@ -175,6 +176,29 @@ function canonicalProposal(
 }
 
 export async function generateWeeklyParlayProposals(input: {
+  periodKey: string;
+  subjects: readonly WeeklyParlaySubject[];
+  championShortlists: ReadonlyMap<
+    string,
+    readonly WeeklyParlayChampionSummary[]
+  >;
+  historyWindows: number;
+  abortSignal?: AbortSignal;
+}): Promise<{
+  proposals: WeeklyParlayProposal[];
+  model: string;
+  resolvedModel: string | null;
+  usage: unknown;
+}> {
+  // Periodic, fleet-wide work with no requester and no owning guild.
+  return await withLlmSubjectSpan(
+    "scout.betting.weekly-parlay",
+    { kind: "system", id: "scout.betting.weekly-parlay" },
+    () => generateWeeklyParlayProposalsInternal(input),
+  );
+}
+
+async function generateWeeklyParlayProposalsInternal(input: {
   periodKey: string;
   subjects: readonly WeeklyParlaySubject[];
   championShortlists: ReadonlyMap<

--- a/packages/scout-for-lol/packages/backend/src/explore/agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/agent.ts
@@ -44,11 +44,21 @@ import { reportQueryPreviewSummary } from "#src/reports/ai/report-query-preview-
 import { GLOBAL_SCOPE } from "#src/reports/duckdb/scope.ts";
 import { executeReportQuery } from "#src/reports/query-engine.ts";
 import { resolvePlayerIdentities } from "#src/reports/identity.ts";
+import {
+  withLlmSubjectSpan,
+  type LlmSubject,
+} from "@shepherdjerred/llm-observability/subject";
 
 const logger = createLogger("explore-agent");
 
 export type ExploreAgentParams = {
   runId: string;
+  /**
+   * Who this turn is being answered for. Required rather than optional: an
+   * Explore turn always has an asker, and an optional field would quietly
+   * produce unattributed spend the first time a caller forgot it.
+   */
+  subject: LlmSubject;
   question: string;
   /** Prior turns of this conversation, oldest first. */
   history: ExploreMessage[];
@@ -78,6 +88,16 @@ type RunState = {
 };
 
 export async function streamExploreAgent(
+  params: ExploreAgentParams,
+): Promise<ExploreAgentResult> {
+  // Wraps the whole turn so the nested report-query agent, which opens no span
+  // of its own, is attributed to the same asker as its parent explore turn.
+  return await withLlmSubjectSpan("scout.explore", params.subject, () =>
+    streamExploreAgentInternal(params),
+  );
+}
+
+async function streamExploreAgentInternal(
   params: ExploreAgentParams,
 ): Promise<ExploreAgentResult> {
   const model = exploreModel();

--- a/packages/scout-for-lol/packages/backend/src/explore/run-turn.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/run-turn.ts
@@ -156,6 +156,7 @@ export async function runPersistedExploreTurn(
     throwIfAborted(abortController.signal);
     const result = await dependencies.executeAgent({
       runId: input.ticket.runId,
+      subject: { kind: "discord_user", id: input.identity.userId },
       question: input.started.question,
       // The last history item is the question being answered. The agent gets
       // that separately as its current turn, so replaying it duplicates it.

--- a/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/review/generator.ts
@@ -44,6 +44,7 @@ import {
   resolveProviderIssue,
 } from "#src/alerts/provider-metrics.ts";
 import { PROVIDER_ISSUE_KINDS } from "#src/alerts/provider-issue-kinds.ts";
+import { withLlmSubjectSpan } from "@shepherdjerred/llm-observability/subject";
 
 const logger = createLogger("generator");
 
@@ -349,15 +350,30 @@ export async function generateMatchReview(
   }
 
   try {
-    pipelineOutput = await generateFullMatchReview({
-      match: matchInput,
-      player: {
-        index: playerIndex,
+    // Wrapping the pipeline rather than each stage: withLlmSubjectSpan opens an
+    // *active* span, so every text and image call the pipeline makes inherits
+    // the subject through context. That keeps @scout-for-lol/data
+    // provider-neutral -- no subject parameter has to be threaded through
+    // TextGenerationClient, ImageGenerationClient, and every stage between.
+    // The subject is the tracked player, not a requester: nobody asks for a
+    // match report, it is generated because this player is tracked.
+    pipelineOutput = await withLlmSubjectSpan(
+      "scout.review",
+      {
+        kind: "tracked_player",
+        id: selectedPlayer.playerConfig.league.leagueAccount.puuid,
       },
-      prompts: promptsInput,
-      clients: clientsInput,
-      stages,
-    });
+      () =>
+        generateFullMatchReview({
+          match: matchInput,
+          player: {
+            index: playerIndex,
+          },
+          prompts: promptsInput,
+          clients: clientsInput,
+          stages,
+        }),
+    );
   } catch (error) {
     if (
       didReportLlmProviderIssue(error, {

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/report-query-agent.ts
@@ -40,9 +40,20 @@ import {
   validateQuery,
   type ToolTracker,
 } from "#src/reports/ai/scoutql-tools.ts";
+import {
+  withLlmSubjectSpan,
+  type LlmSubject,
+} from "@shepherdjerred/llm-observability/subject";
 
 export type ReportQueryAgentParams = {
   runId: string;
+  /**
+   * Who this edit is being drafted for. Explore invokes the report-query agent
+   * inside its own subject span and would inherit it through context, but the
+   * Temporal interactive-run paths enter here directly with no ambient span, so
+   * the subject is a parameter rather than something assumed from the caller.
+   */
+  subject: LlmSubject;
   input: ReportAiEditRequest;
   abortSignal: AbortSignal;
   emit: (event: ReportAiStreamEvent) => void | Promise<void>;
@@ -54,6 +65,14 @@ type RunState = {
 };
 
 export async function streamReportQueryAgent(
+  params: ReportQueryAgentParams,
+): Promise<ReportAiFinalDraft> {
+  return await withLlmSubjectSpan("scout.report-query", params.subject, () =>
+    streamReportQueryAgentInternal(params),
+  );
+}
+
+async function streamReportQueryAgentInternal(
   params: ReportQueryAgentParams,
 ): Promise<ReportAiFinalDraft> {
   const model = reportAiModel();

--- a/packages/scout-for-lol/packages/backend/src/reports/ai/temporal-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/ai/temporal-runtime.ts
@@ -123,6 +123,7 @@ export function createTemporalReportAiResponse(input: {
     execute: async () => {
       const draft = await streamReportQueryAgent({
         runId: input.ticket.runId,
+        subject: { kind: "discord_user", id: input.identity.userId },
         input: input.edit,
         abortSignal: abortController.signal,
         emit,

--- a/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/interactive-activities.ts
@@ -2,6 +2,7 @@ import { Context } from "@temporalio/activity";
 import { ApplicationFailure } from "@temporalio/common";
 import { z } from "zod";
 import {
+  DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   EXPLORE_ANSWER_MAX_LENGTH,
   EXPLORE_TIMEOUT_MS,
@@ -172,6 +173,10 @@ export async function executeRecoveredReportAi(
   };
   const draft = await streamReportQueryAgent({
     runId: run.id,
+    subject: {
+      kind: "discord_user",
+      id: DiscordAccountIdSchema.parse(run.ownerId),
+    },
     input: payload.edit,
     abortSignal,
     emit,


### PR DESCRIPTION
Stacked on #2520.

## Why

Scout could not answer "which user did this cost". Its cost logs carried a **null `traceId`**, so there was nothing to join spend to, and no span named who a call was made for.

The root cause turned out to be **one thing, not two**: Scout's `gen_ai.chat` spans were trace *roots* with no enclosing application span, so `trace.getSpan(context.active())` was empty when `llm-runtime` built each call's attribution headers, and no trace id ever reached OpenRouter.

Birmel already worked end-to-end and served as the reference — one real trace resolves a Discord user to a summed dollar figure across four workloads.

## What

Wrapping the call sites in `withLlmSubjectSpan` fixes **attribution and the null `traceId` together**, because the helper opens an *active* span.

| Workload | Subject | Source |
| --- | --- | --- |
| `scout.bucks-ask` | `discord_user` | `params.discordId` |
| `scout.explore` | `discord_user` | `run.identity.userId` |
| `scout.report-query` | `discord_user` | `run.ownerId` / rate-limit identity |
| `scout.review.*` | `tracked_player` | selected player's PUUID |
| `scout.betting.*` | `system` | no owning guild — see below |

Two deviations from the plan, both driven by what the code actually showed:

- **Betting is `system`, not `guild`.** A parlay covers whichever tracked players are in one live game, and those players can be tracked in *different* servers, so no single guild owns that spend. Marking it unattributed is honest; picking an arbitrary guild would not be.
- **The review pipeline needed no contract change.** The plan called for widening `TextGenerationClient.generate`. Wrapping `generateFullMatchReview` instead lets every stage inherit the subject through context, so `@scout-for-lol/data` stays provider-neutral and no subject parameter threads through two client interfaces and every stage.

Birmel emits `llm.subject.{kind,id}` **alongside** its existing `discord.user_id` so current queries keep working.

Also: an Attribution dashboard row reading Tempo, an explanation of why subject ids stay out of Prometheus, and a how-to for the Loki→Tempo join.

## Also: `birmel.memory.extract` was failing on every turn

Found while verifying the above — **3/3 errors, zero tokens billed**, silently, because the Discord reply itself succeeded:

```
[Azure] Invalid schema for response_format 'birmel_memory_candidates':
In context=('properties', 'selfMemories', 'items'), 'oneOf' is not permitted.
```

Zod emits `oneOf` for `z.discriminatedUnion` and `anyOf` for `z.union`; OpenAI-style strict structured outputs permit only `anyOf`. Switching to `z.union` leaves parsing behaviour unchanged since the `kind` literals stay disjoint.

The failure is **routing-dependent** — providers that tolerate `oneOf` accept the identical schema — so it does not reproduce until OpenRouter happens to pick Azure. A unit test asserting the emitted JSON Schema is the only place it can be caught. Scout's `ExploreAnswerWireSchema` was checked and already emits `anyOf`.

## Verification

`bunx turbo run typecheck lint test` passes for all three packages:

| Package | Tests |
| --- | --- |
| `@scout-for-lol/backend` | 2625 passed |
| `@shepherdjerred/birmel` | 377 passed |
| `@homelab/cdk8s` | 587 passed (dist re-synthed) |

The new `oneOf` regression test was **confirmed to fail** when reverted to `z.discriminatedUnion` and pass when restored — a regression test that cannot catch its regression is worthless.

Birmel's `withSpan` needed a helper extraction: inlining the conditional pushed it to cognitive complexity 21 against a limit of 20. Refactored under the threshold rather than baselined.

### Caveats

- **Runtime attribution is not yet verified against the live cluster.** That needs a deploy plus a real `/bb-ask`, following the new `attribute-llm-spend` how-to. Local evidence is types + tests only.
- One birmel test (`durable-jobs` → "rejects an unregistered tool") failed **once** in a full-suite run and passed both in isolation (40/40) and on an identical-tree rerun (377/377). Order-dependent flake, unrelated to this change — flagging rather than claiming fixed.
- Dashboard panel screenshots need the dashboard deployed; the Attribution row queries Tempo for `llm.subject.*`, which no span carries until this ships.