### PR TITLE
Document the Temporal namespace cutover

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -92,9 +92,9 @@ plane. Local servers use `dev`, which never exists in the cluster.
 
 The central `scout` queue has one deliberate exception: its worker polls both
 `prod` and `beta` because the beta-owned weekly parlay and Bryan Bucks
-analytics workflows remain in the central workflow bundle. This preserves the
-existing queue contract; clients and shared Scout schedules still start only
-in `prod`.
+analytics workflows remain in the central workflow bundle. This behavior is
+implemented by [`worker-namespaces.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/shared/worker-namespaces.ts)
+and wired at [`worker.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/worker.ts). Clients and shared Scout schedules still start only in `prod`.
 
 Existing histories cannot move between namespaces. The migration therefore
 keeps bounded worker-only pollers in `default` until those histories close.

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -9,6 +9,10 @@ sidebar:
 bot, scheduled agent, Glitter refresh, and home-automation routine runs here as
 a durable workflow.
 
+The fleet uses `dev`, `beta`, and `prod` namespaces as execution trust
+boundaries. A namespace separates workflow IDs, schedules, histories, and task
+queues even when queue names match.
+
 ```mermaid
 flowchart LR
   accTitle: Temporal worker system map
@@ -80,6 +84,21 @@ The split is about authorization and failure isolation, not capacity. Queues
 isolate concurrency; **processes** isolate runtime failures, credentials, and
 Kubernetes identities. Home and reports can each run four activities. Infra,
 repo, Scout, agent, both Glitter domains, and maintenance remain serial.
+
+Namespace isolation adds the deployment-stage boundary that queues cannot
+provide. Scout beta and prod keep identical queue contracts without consuming
+each other's work. Shared and cross-stage jobs belong to the `prod` control
+plane. Local servers use `dev`, which never exists in the cluster.
+
+The central `scout` queue has one deliberate exception: its worker polls both
+`prod` and `beta` because the beta-owned weekly parlay and Bryan Bucks
+analytics workflows remain in the central workflow bundle. This preserves the
+existing queue contract; clients and shared Scout schedules still start only
+in `prod`.
+
+Existing histories cannot move between namespaces. The migration therefore
+keeps bounded worker-only pollers in `default` until those histories close.
+Clients and schedule reconcilers never target that drain namespace.
 
 Infra and the temporary legacy worker receive the broad audit and pod-exec
 roles. Agent receives read-only audit access but cannot exec into pods. Gateway,

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -69,8 +69,9 @@ second credentialless process runs all deterministic central Workflow code.
 Every new start, schedule, and child goes to `monorepo-workflows`. Ten
 Activity-only roles own `default`, `home`, `reports`, `infra`,
 `repo-automation`, `scout`, `agent-task`, `glitter-corpus`, `glitter-context`,
-and `maintenance`. The `default` Activity Worker exists only to drain commands
-already scheduled by pre-cutover histories; no new root targets it.
+and `maintenance`. The bounded `default` Activity Worker drains commands
+already scheduled by pre-cutover histories and serves the compatibility email
+delivery path; no new root targets it, and it is removed after the drain.
 
 Temporal executions cannot move to another Workflow task queue after they
 start. The Workflow-only process therefore polls `monorepo-workflows` plus all
@@ -90,11 +91,15 @@ provide. Scout beta and prod keep identical queue contracts without consuming
 each other's work. Shared and cross-stage jobs belong to the `prod` control
 plane. Local servers use `dev`, which never exists in the cluster.
 
-The central `scout` queue has one deliberate exception: its worker polls both
-`prod` and `beta` because the beta-owned weekly parlay and Bryan Bucks
-analytics workflows remain in the central workflow bundle. This behavior is
-implemented by [`worker-namespaces.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/shared/worker-namespaces.ts)
-and wired at [`worker.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/worker.ts). Clients and shared Scout schedules still start only in `prod`.
+The central `workflows` and `scout` roles have one deliberate exception: both
+poll `prod` and `beta` because the beta-owned weekly parlay and Bryan Bucks
+analytics workflows remain in the central workflow bundle while their Scout
+activities use the Scout queue. This behavior is implemented by
+[`worker-namespaces.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/shared/worker-namespaces.ts),
+selected by the central definitions in
+[`worker-config.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/worker-config.ts),
+and wired at [`worker.ts`](https://github.com/shepherdjerred/monorepo/blob/2b612ab307be00ee7bbf30aba24a9e0665defb7c/packages/temporal/src/worker.ts).
+Clients and shared Scout schedules still start only in `prod`.
 
 Existing histories cannot move between namespaces. The migration therefore
 keeps bounded worker-only pollers in `default` until those histories close.

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
@@ -51,6 +51,11 @@ Every stage has one Workflow task queue. The Workflow bundle is registered
 once, which prevents queue-specific Workers from drifting into different
 orchestration capabilities.
 
+Each stage also has its own Temporal namespace. Queue names describe workload
+classes, while the `beta` and `prod` namespaces prevent either deployment from
+consuming the other's work. Shared Scout maintenance remains in the `prod`
+control plane.
+
 Activities use separate realtime, interactive, background, and lake queues.
 The separation preserves responsive polling under slow model work. It also
 serializes every mutation of the report-lake volume.
@@ -98,6 +103,10 @@ missed cron occurrence.
 Schedules begin paused when a legacy owner still exists. A feature-family
 cutover transfers ownership explicitly; a Temporal outage never activates the
 legacy owner automatically.
+
+During namespace migration, worker-only pollers continue serving retained
+histories in `default`. New starts and schedule reconciliation target only the
+stage namespace.
 
 ## Workflows match product lifecycles
 

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
@@ -52,9 +52,9 @@ once, which prevents queue-specific Workers from drifting into different
 orchestration capabilities.
 
 Each stage also has its own Temporal namespace. Queue names describe workload
-classes, while the `beta` and `prod` namespaces prevent either deployment from
-consuming the other's work. Shared Scout maintenance remains in the `prod`
-control plane.
+classes, while namespace ownership is defined by the
+[Temporal schedule reference](/reference/temporal-schedules/). Shared and
+cross-stage Scout maintenance follows that same reference.
 
 Activities use separate realtime, interactive, background, and lake queues.
 The separation preserves responsive polling under slow model work. It also

--- a/packages/docs/wiki/src/content/docs/how-to/pause-or-debug-a-schedule.md
+++ b/packages/docs/wiki/src/content/docs/how-to/pause-or-debug-a-schedule.md
@@ -7,13 +7,17 @@ sidebar:
 
 Work down this list in order. Each step rules out a class of cause.
 
-The Temporal Web UI is tailnet-gated and lives in the `temporal` namespace.
+The Temporal Web UI is tailnet-gated. Select `prod` for shared and production
+jobs, or `beta` for Scout beta jobs, before inspecting a schedule.
 
 ## 1. Pause it, if that is all you need
 
 Pause the schedule in the Temporal UI. Pause state is runtime state: it is
 preserved across worker restarts and across reconciliation, so a boot will not
 silently resume it.
+
+Confirm the namespace before pausing. The same queue name can exist in both
+`beta` and `prod`, while schedules and histories remain isolated.
 
 This is the right move for a noisy or misbehaving job. It is not how you remove
 one — see the last section.

--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
@@ -164,6 +164,29 @@ and new production starts appear only in `prod`. Existing `default` executions
 must keep pollers until they close; do not cancel or replay them merely to
 finish the migration.
 
+## Retire the drain namespace
+
+After the last `default` execution closes, wait the additional 30-day retention
+window. Re-read live state immediately before cleanup and run the migration
+audit with the recorded cutover timestamp. The audit must show schedule parity,
+no active source schedules, no `default` workflow starts after cutover, and no
+remaining `default` executions.
+
+Only after those checks pass, delete every paused source schedule from the
+drain namespace. List the schedules first, then delete each exact ID; do not
+use a wildcard or delete a target schedule in `prod` or `beta`:
+
+```bash
+toolkit temporal --namespace default schedule list
+toolkit temporal --namespace default schedule delete --schedule-id <SCHED_ID>
+```
+
+Remove `TEMPORAL_LEGACY_NAMESPACE` from the worker and client deployment
+configuration in the same reviewed GitOps change, restart the affected
+deployments, and run the audit again against `prod` and `beta`. Keep the
+built-in `default` namespace present but guarded and empty; this is the only
+post-drain operation that targets it.
+
 ## Roll back a family
 
 1. Pause its Temporal Schedules.

--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
@@ -39,6 +39,53 @@ TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
 Do not remove a replay patch until no open execution needs it and the
 namespace's 30-day retention period has elapsed.
 
+## Move schedules into the stage namespaces
+
+Provision `prod` and `beta` before deploying any process whose active namespace
+has changed. While every existing application still starts work in `default`,
+run the migration inventory from the candidate revision:
+
+```bash
+cd packages/temporal
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true \
+  bun run migrate:namespaces -- prepare
+```
+
+The inventory must account for every live schedule. Resolve unknown ownership
+instead of excluding it, and re-read the live count rather than comparing it to
+a count copied from an earlier rollout. Then create the target copies in their
+paused migration state:
+
+```bash
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true \
+  bun run migrate:namespaces -- prepare --confirm
+```
+
+Do this before deploying the namespace-switching gateway. Gateway
+reconciliation updates existing schedules and preserves their pause state; it
+must not be the process that first creates an active target copy. Deploy the
+new workers and clients, prove pollers and empty target backlogs, and immediately
+re-run the read-only `prepare` inventory. Re-read both sides one final time,
+then cut over:
+
+```bash
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true \
+  bun run migrate:namespaces -- cutover --confirm
+```
+
+Record the printed cutover timestamp. Audit parity and the absence of later
+starts in `default` with that exact timestamp:
+
+```bash
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true \
+  bun run migrate:namespaces -- audit --cutover-at <ISO timestamp>
+```
+
+Rollback is available only while no prepared target has started a Workflow.
+After the first target start, recover forward. Leave source schedules paused in
+`default`; they remain rollback and audit evidence until the drain and the
+additional 30-day retention window have both completed.
+
 ## Prove every queue
 
 Run the side-effect-free canary against the deployed Scout Workers:
@@ -48,7 +95,7 @@ cd packages/scout-for-lol/packages/temporal
 bun run canary -- \
   --stage beta \
   --address <beta-address> \
-  --namespace default
+  --namespace beta
 ```
 
 The result must name `scout-beta-realtime`, `scout-beta-interactive`,
@@ -110,7 +157,12 @@ four families enabled for at least 24 hours. The soak passes only when:
 
 Record the end time and evidence before promoting the same image to production.
 Repeat the queue canary and representative manual triggers after production is
-deployed.
+deployed, using `--stage prod --namespace prod`.
+
+During the namespace drain, verify that new beta starts appear only in `beta`
+and new production starts appear only in `prod`. Existing `default` executions
+must keep pollers until they close; do not cancel or replay them merely to
+finish the migration.
 
 ## Roll back a family
 

--- a/packages/docs/wiki/src/content/docs/how-to/schedule-an-agent-task.md
+++ b/packages/docs/wiki/src/content/docs/how-to/schedule-an-agent-task.md
@@ -57,7 +57,7 @@ failed.
 
 ```bash
 cd packages/temporal
-TEMPORAL_ADDRESS=localhost:7233 \
+TEMPORAL_ADDRESS=localhost:7233 TEMPORAL_NAMESPACE=dev \
   bun run scripts/schedule-agent-task.ts --from-doc /tmp/agent-task.md
 ```
 

--- a/packages/docs/wiki/src/content/docs/reference/agent-task-input.md
+++ b/packages/docs/wiki/src/content/docs/reference/agent-task-input.md
@@ -57,11 +57,11 @@ immediately. Cron expressions are evaluated in `America/Los_Angeles`.
 
 ## Submission surfaces
 
-| Surface      | Entry point                                                | Auth                                          |
-| ------------ | ---------------------------------------------------------- | --------------------------------------------- |
-| Doc block    | `<!-- temporal-agent-task { … } -->` in any Markdown file  | none — operator runs the CLI                  |
-| Operator CLI | `bun run scripts/schedule-agent-task.ts --from-doc <path>` | port-forwarded Temporal                       |
-| HTTP API     | `POST /agent-tasks` on `temporal-agent-tasks.sjer.red`     | `Authorization: Bearer $AGENT_TASK_API_TOKEN` |
+| Surface      | Entry point                                                                       | Auth                                          |
+| ------------ | --------------------------------------------------------------------------------- | --------------------------------------------- |
+| Doc block    | `<!-- temporal-agent-task { … } -->` in any Markdown file                         | none — operator runs the CLI                  |
+| Operator CLI | `TEMPORAL_NAMESPACE=dev bun run scripts/schedule-agent-task.ts --from-doc <path>` | port-forwarded Temporal                       |
+| HTTP API     | `POST /agent-tasks` on `temporal-agent-tasks.sjer.red`                            | `Authorization: Bearer $AGENT_TASK_API_TOKEN` |
 
 One document may contain multiple task blocks. The CLI validates every block as
 v2 before connecting and schedules them in document order. It also accepts

--- a/packages/docs/wiki/src/content/docs/reference/temporal-schedules.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-schedules.md
@@ -7,7 +7,7 @@ sidebar:
 
 All recurring automation is a single `SCHEDULES` array in
 [`schedule-definitions.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/schedules/schedule-definitions.ts).
-Every worker boot upserts the whole fleet.
+The gateway upserts the schedules owned by each active namespace.
 
 [`register-schedules.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/temporal/src/schedules/register-schedules.ts)
 owns reconciliation and the explicit `DELETED_SCHEDULE_IDS` allowlist.
@@ -26,6 +26,18 @@ For the list of what runs and when, see
 | Source of truth | the `SCHEDULES` array in code; a PR is the change process             |
 | Deletion        | explicit — add the schedule ID to the deletion list                   |
 | Orphan drift    | a metric is exported for any server schedule code no longer defines   |
+
+## Namespace ownership
+
+| Namespace | Ownership                                                                                    |
+| --------- | -------------------------------------------------------------------------------------------- |
+| `dev`     | Local Temporal servers only. Local reconciliation overlays the complete source inventory.    |
+| `beta`    | Scout beta fixed schedules, beta report schedules, weekly parlay, and Bryan Bucks analytics. |
+| `prod`    | Production automation, Scout prod, dynamic agent tasks, and shared Scout maintenance.        |
+| `default` | Migration drain only. No reconciler or start surface targets it.                             |
+
+Every source schedule carries a target namespace. Dynamic Scout report memos
+must match that namespace. Dynamic agent schedules are valid only in `prod`.
 
 ## Pause behaviour
 

--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -28,6 +28,9 @@ Schedules, programmatic roots, and child Workflows name
 Every Activity proxy explicitly names one of the domain queues and the source
 guard rejects missing queues or effects routed to `monorepo-workflows`.
 
+Unless a Scout row is explicitly beta-owned, workflows run in `prod`. Scout
+beta workflows and reports run in `beta`; local development uses `dev`.
+
 ## Repo upkeep
 
 | Workflow            | Trigger     | Brain                            | Output                                                                      |

--- a/packages/docs/wiki/src/content/docs/tutorials/first-agent-task.md
+++ b/packages/docs/wiki/src/content/docs/tutorials/first-agent-task.md
@@ -55,11 +55,19 @@ Notice also `"mode": "report-only"`. That is the only mode.
 
 ## 3. Dispatch it
 
-Port-forward Temporal, then run the scheduler against your document:
+Port-forward the homelab Temporal frontend, then run the scheduler against your
+document. The port-forward reaches the production control plane, so target its
+`prod` namespace:
+
+```bash
+kubectl -n temporal port-forward svc/temporal-temporal-server-service 7233:7233
+```
+
+In another terminal:
 
 ```bash
 cd packages/temporal
-TEMPORAL_ADDRESS=localhost:7233 TEMPORAL_NAMESPACE=dev \
+TEMPORAL_ADDRESS=localhost:7233 TEMPORAL_NAMESPACE=prod \
   bun run scripts/schedule-agent-task.ts --from-doc /tmp/agent-task-tutorial-scratch.md
 ```
 
@@ -71,7 +79,8 @@ conflict, you have run the same input twice — change the title and try again.
 
 ## 4. Watch it in the Temporal UI
 
-Open the Temporal Web UI over the tailnet and find your execution by title.
+Open the Temporal Web UI over the tailnet, select the `prod` namespace, and find
+your execution by title.
 
 Because we set a future `runAt`, the workflow defers using Temporal's
 `startDelay`. It will sit waiting rather than running — that wait does not

--- a/packages/docs/wiki/src/content/docs/tutorials/first-agent-task.md
+++ b/packages/docs/wiki/src/content/docs/tutorials/first-agent-task.md
@@ -59,7 +59,7 @@ Port-forward Temporal, then run the scheduler against your document:
 
 ```bash
 cd packages/temporal
-TEMPORAL_ADDRESS=localhost:7233 \
+TEMPORAL_ADDRESS=localhost:7233 TEMPORAL_NAMESPACE=dev \
   bun run scripts/schedule-agent-task.ts --from-doc /tmp/agent-task-tutorial-scratch.md
 ```
 

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -185,6 +185,8 @@ Workflow:
 ## Environment Variables
 
 - `TEMPORAL_ADDRESS` — Temporal server gRPC address (default: `temporal-server.temporal.svc.cluster.local:7233`)
+- `TEMPORAL_NAMESPACE` — required active namespace: `dev`, `beta`, or `prod`. `default` is rejected for clients and active workers.
+- `TEMPORAL_LEGACY_NAMESPACE` — optional migration-only worker namespace. The only accepted value is `default`; remove it after the drain and retention window.
 - `TEMPORAL_WORKER_ROLE` — process role: `all` (default/local), `core`, `agent`, `glitter`, or `maintenance`. Invalid values fail startup.
 - `HA_URL` — Home Assistant URL
 - `HA_TOKEN` — Home Assistant long-lived access token
@@ -290,7 +292,7 @@ delivered through the shared reporter as partial.
 
 1. Queries the Temporal visibility API for `ExecutionStatus IN ("Failed", "TimedOut")` closed in the last 24 hours so a worker outage can be recovered by the next poll (safe to overlap because Alertmanager dedups alerts by label set and each alert expires from the execution's close time, not from the latest poll).
 2. For each match, calls `getHandle(workflowId, runId).fetchHistory()` and then `.result()`, with bounded concurrency and Alertmanager batches so recovery can page partial progress before the activity deadline. The history classifies timeouts as `workflow-task`, `activity`, `execution`, or `unknown`; an agent-task timeout before any `ACTIVITY_TASK_STARTED` event is explicitly a worker/task-queue availability failure, including scheduled-but-undispatched activities. The closed `result()` rejects immediately with `WorkflowFailedError`, whose `.cause` carries the same failure type/message/stack the Temporal UI shows.
-3. Builds one `AlertmanagerAlert` per execution via the pure `buildWorkflowFailureAlert` helper (`src/shared/workflow-failure-alert.ts`) — labels `{alertname: "TemporalWorkflowFailed", workflowType, taskQueue, workflowId, runId}` for identity/dedup, plus a summary/description with the actual error, timeout classification/diagnosis, and a direct link to the failed run in the Temporal UI (`temporalUiExecutionUrl`).
+3. Builds one `AlertmanagerAlert` per execution via the pure `buildWorkflowFailureAlert` helper (`src/shared/workflow-failure-alert.ts`) — labels `{alertname: "TemporalWorkflowFailed", temporalNamespace, workflowType, taskQueue, workflowId, runId}` for identity/dedup, plus a summary/description with the actual error, timeout classification/diagnosis, and a namespace-correct direct link to the failed run in the Temporal UI (`temporalUiExecutionUrl`).
 4. Posts the batch via `createAlertmanagerPoster` (`src/lib/alertmanager.ts`, shared with the Xcode Cloud webhook), which routes through the existing Alertmanager Alerts receiver.
 
 No exclusion list — every workflow type produces an occurrence on any failure, including per-PR bots (`prReview`/`prSummary`) that the older threshold-based rules deliberately exclude. Revisit with an exclusion list if that proves too noisy.
@@ -303,7 +305,8 @@ Create/update a task from a doc block locally as an operator:
 
 ```bash
 cd packages/temporal
-TEMPORAL_ADDRESS=localhost:7233 bun run scripts/schedule-agent-task.ts --from-doc /tmp/agent-task.md
+TEMPORAL_ADDRESS=localhost:7233 TEMPORAL_NAMESPACE=dev \
+  bun run scripts/schedule-agent-task.ts --from-doc /tmp/agent-task.md
 ```
 
 `--from-doc` validates every `temporal-agent-task` block before connecting and
@@ -365,7 +368,7 @@ the in-cluster service name is only resolvable inside Kubernetes:
 
 ```bash
 cd packages/temporal
-TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true \
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 TEMPORAL_TLS=true TEMPORAL_NAMESPACE=prod \
   bun run canary:agent-task
 ```
 

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -56,6 +56,7 @@ bun run test         # unit tests, including the workflow-bundle smoke test
 bun run lint         # eslint
 export TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443
 export TEMPORAL_TLS=true
+export TEMPORAL_NAMESPACE=prod
 bun run migrate:namespaces -- prepare # read-only inventory
 bun run migrate:namespaces -- prepare --confirm # create paused targets
 bun run migrate:namespaces -- cutover --confirm # pause default, activate targets

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -17,6 +17,14 @@ active namespace and by a bounded drain worker in `default`; it has no
 production start site. The default `all` role runs everything in one process
 for local development.
 
+Temporal namespaces are environment-scoped: local servers use `dev`, Scout
+beta uses `beta`, and production plus shared control-plane jobs use `prod`.
+During migration, `TEMPORAL_LEGACY_NAMESPACE=default` adds bounded worker-only
+pollers so existing histories can finish without allowing new starts there.
+The central Scout worker also polls its unchanged `scout` queue in `beta` for
+the beta-owned weekly parlay and Bryan Bucks analytics schedules; all other
+central queues remain `prod` plus the temporary `default` drain.
+
 | Role              | Queue or surface        | Activity concurrency |
 | ----------------- | ----------------------- | -------------------: |
 | `control`         | schedules and HTTP APIs |                 none |
@@ -42,10 +50,15 @@ above describes the final topology.
 Run from `packages/temporal`:
 
 ```bash
-bun run start        # start the worker (connects to the Temporal server)
+TEMPORAL_NAMESPACE=dev bun run start # start a local worker
 bun run typecheck    # tsc --noEmit (stubs the HA schema first)
 bun run test         # unit tests, including the workflow-bundle smoke test
 bun run lint         # eslint
+TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 bun run migrate:namespaces -- prepare # read-only inventory
+bun run migrate:namespaces -- prepare --confirm # create paused targets
+bun run migrate:namespaces -- cutover --confirm # pause default, activate targets
+bun run migrate:namespaces -- rollback --confirm # only before a target workflow starts
+bun run migrate:namespaces -- audit --cutover-at <ISO timestamp>
 ```
 
 During the namespace migration, inventory and prepare schedules before
@@ -65,6 +78,10 @@ TEMPORAL_ADDRESS=<private-temporal-host>:443 TEMPORAL_TLS=true TEMPORAL_NAMESPAC
 
 Record the cutover timestamp and use it for the final audit. Rollback is
 allowed only before a target workflow starts; after that, recover forward.
+
+The migration command always reads its source from `default` and writes only to
+`prod` or `beta`; it intentionally ignores `TEMPORAL_NAMESPACE`. The other
+clients and operator scripts require `TEMPORAL_NAMESPACE=dev|beta|prod`.
 
 ## Documentation
 

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -86,6 +86,16 @@ The migration command always reads its source from `default` and writes only to
 `prod` or `beta`; it intentionally ignores `TEMPORAL_NAMESPACE`. The other
 clients and operator scripts require `TEMPORAL_NAMESPACE=dev|beta|prod`.
 
+The migration command always inventories `default`. `prepare --confirm` writes
+paused copies to `prod` and `beta`; `cutover --confirm` also pauses the source
+schedules in `default` and activates their targets; `rollback --confirm` can
+restore source pause state in `default` and deletes the prepared targets, but
+only before any target workflow starts. `TEMPORAL_NAMESPACE` is ignored by the
+migration command itself, but is still exported above because the read-only
+inventory step shares the required namespace contract. The other clients and
+operator scripts require
+`TEMPORAL_NAMESPACE=dev|beta|prod`.
+
 ## Documentation
 
 The complete reference is [AGENTS.md](AGENTS.md):

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -54,7 +54,9 @@ TEMPORAL_NAMESPACE=dev bun run start # start a local worker
 bun run typecheck    # tsc --noEmit (stubs the HA schema first)
 bun run test         # unit tests, including the workflow-bundle smoke test
 bun run lint         # eslint
-TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443 bun run migrate:namespaces -- prepare # read-only inventory
+export TEMPORAL_ADDRESS=temporal.tailnet-1a49.ts.net:443
+export TEMPORAL_TLS=true
+bun run migrate:namespaces -- prepare # read-only inventory
 bun run migrate:namespaces -- prepare --confirm # create paused targets
 bun run migrate:namespaces -- cutover --confirm # pause default, activate targets
 bun run migrate:namespaces -- rollback --confirm # only before a target workflow starts

--- a/packages/temporal/runbooks/homelab-audit.md
+++ b/packages/temporal/runbooks/homelab-audit.md
@@ -290,10 +290,13 @@ Flag: any pod not Running/Ready, `CreateContainerConfigError` (missing secret â€
 
 ```bash
 toolkit temporal operator cluster health                          # gRPC ping to frontend (expect SERVING)
-toolkit temporal operator namespace list                          # expected namespaces (default)
+toolkit temporal operator namespace list                          # expected active namespaces (prod, beta); default is drain-only
 ```
 
-Flag: non-SERVING status, gRPC connection error despite server pods Running (NetworkPolicy change, service endpoint mismatch), missing `default` namespace.
+Flag: non-SERVING status, gRPC connection error despite server pods Running
+(NetworkPolicy change, service endpoint mismatch), or missing `prod`/`beta`
+namespaces. During migration, flag workflow starts or active schedules in
+`default`; after drain, it must remain empty.
 
 ### Failed or stuck workflow executions
 
@@ -367,8 +370,8 @@ The removed `agent-task-timeout-watch` aggregate alert must not be used as a
 health signal. Query the SDK metrics instead:
 
 ```bash
-toolkit prom query 'temporal_worker_num_pollers{namespace="temporal",exported_namespace="default",task_queue="agent-task",poller_type="workflow_task"}'
-toolkit prom query 'histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace="temporal",exported_namespace="default",task_queue="agent-task"}[5m])))'
+toolkit prom query 'temporal_worker_num_pollers{namespace="temporal",exported_namespace="prod",task_queue="agent-task",poller_type="workflow_task"}'
+toolkit prom query 'histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace="temporal",exported_namespace="prod",task_queue="agent-task"}[5m])))'
 toolkit prom query 'up{namespace="temporal",service=~".*temporal.*worker.*metrics.*|temporal-worker-app-metrics"}'
 ```
 

--- a/packages/temporal/runbooks/homelab-audit.md
+++ b/packages/temporal/runbooks/homelab-audit.md
@@ -375,7 +375,11 @@ The removed `agent-task-timeout-watch` aggregate alert must not be used as a
 health signal. Query the SDK metrics instead:
 
 ```bash
-for TEMPORAL_NAMESPACE in prod beta; do
+TEMPORAL_POLLING_NAMESPACES=prod
+if [ -n "${TEMPORAL_LEGACY_NAMESPACE:-}" ]; then
+  TEMPORAL_POLLING_NAMESPACES="${TEMPORAL_POLLING_NAMESPACES} default"
+fi
+for TEMPORAL_NAMESPACE in ${TEMPORAL_POLLING_NAMESPACES}; do
   toolkit prom query "temporal_worker_num_pollers{namespace=\"temporal\",exported_namespace=\"${TEMPORAL_NAMESPACE}\",task_queue=\"agent-task\",poller_type=\"workflow_task\"}"
   toolkit prom query "histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace=\"temporal\",exported_namespace=\"${TEMPORAL_NAMESPACE}\",task_queue=\"agent-task\"}[5m])))"
 done

--- a/packages/temporal/runbooks/homelab-audit.md
+++ b/packages/temporal/runbooks/homelab-audit.md
@@ -309,8 +309,14 @@ The Temporal CLI requires RFC3339 timestamps in query clauses. Compute them inli
 # 24h ago, RFC3339 UTC. macOS uses -v; GNU date uses -d.
 DAY_AGO="$(date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
 
-# Run each query in both active namespaces.
-for TEMPORAL_NAMESPACE in prod beta; do
+# Run each query in both active namespaces. During the drain, include the
+# legacy namespace explicitly so failures and stalled executions there remain
+# visible; after the legacy setting is removed this stays prod/beta-only.
+TEMPORAL_AUDIT_NAMESPACES="prod beta"
+if [ "${TEMPORAL_LEGACY_NAMESPACE:-}" = "default" ]; then
+  TEMPORAL_AUDIT_NAMESPACES="${TEMPORAL_AUDIT_NAMESPACES} default"
+fi
+for TEMPORAL_NAMESPACE in ${TEMPORAL_AUDIT_NAMESPACES}; do
   echo "== ${TEMPORAL_NAMESPACE} =="
   toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" workflow list --query "ExecutionStatus='Failed' AND CloseTime > '${DAY_AGO}'"
   toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" workflow list --query "ExecutionStatus='Running' AND StartTime < '${DAY_AGO}'"
@@ -327,7 +333,7 @@ Flag: any recently-failed workflow, Running executions older than a day, Termina
 ### Schedule health
 
 ```bash
-for TEMPORAL_NAMESPACE in prod beta; do
+for TEMPORAL_NAMESPACE in ${TEMPORAL_AUDIT_NAMESPACES}; do
   echo "== ${TEMPORAL_NAMESPACE} schedules =="
   toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" schedule list
 done

--- a/packages/temporal/runbooks/homelab-audit.md
+++ b/packages/temporal/runbooks/homelab-audit.md
@@ -296,7 +296,10 @@ toolkit temporal operator namespace list                          # expected act
 Flag: non-SERVING status, gRPC connection error despite server pods Running
 (NetworkPolicy change, service endpoint mismatch), or missing `prod`/`beta`
 namespaces. During migration, flag workflow starts or active schedules in
-`default`; after drain, it must remain empty.
+`default`. After the last default execution closes, continue checking for new
+starts and active schedules there through the retention window; histories and
+paused schedules may remain until the window ends, after which `default` must
+be empty.
 
 ### Failed or stuck workflow executions
 
@@ -306,18 +309,17 @@ The Temporal CLI requires RFC3339 timestamps in query clauses. Compute them inli
 # 24h ago, RFC3339 UTC. macOS uses -v; GNU date uses -d.
 DAY_AGO="$(date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
 
-# Workflows that failed in the last 24h
-toolkit temporal workflow list --query "ExecutionStatus='Failed' AND CloseTime > '${DAY_AGO}'"
+# Run each query in both active namespaces.
+for TEMPORAL_NAMESPACE in prod beta; do
+  echo "== ${TEMPORAL_NAMESPACE} =="
+  toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" workflow list --query "ExecutionStatus='Failed' AND CloseTime > '${DAY_AGO}'"
+  toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" workflow list --query "ExecutionStatus='Running' AND StartTime < '${DAY_AGO}'"
+  toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" workflow list --query "ExecutionStatus IN ('Terminated','Canceled','TimedOut') AND CloseTime > '${DAY_AGO}'"
+done
 
-# Running executions older than a day (possible stuck)
-toolkit temporal workflow list --query "ExecutionStatus='Running' AND StartTime < '${DAY_AGO}'"
-
-# Terminated / Canceled / TimedOut recently
-toolkit temporal workflow list --query "ExecutionStatus IN ('Terminated','Canceled','TimedOut') AND CloseTime > '${DAY_AGO}'"
-
-# Drill into a specific execution
-toolkit temporal workflow describe --workflow-id <WF_ID>
-toolkit temporal workflow show     --workflow-id <WF_ID>         # full event history
+# Drill into a specific execution in its owning namespace.
+toolkit temporal --namespace prod workflow describe --workflow-id <WF_ID>
+toolkit temporal --namespace prod workflow show --workflow-id <WF_ID> # full event history
 ```
 
 Flag: any recently-failed workflow, Running executions older than a day, Terminated executions not initiated by a known deploy/rotation.
@@ -325,8 +327,11 @@ Flag: any recently-failed workflow, Running executions older than a day, Termina
 ### Schedule health
 
 ```bash
-toolkit temporal schedule list                                    # one row per scheduled workflow
-toolkit temporal schedule describe --schedule-id <SCHED_ID>       # recent actions + next fire time
+for TEMPORAL_NAMESPACE in prod beta; do
+  echo "== ${TEMPORAL_NAMESPACE} schedules =="
+  toolkit temporal --namespace "${TEMPORAL_NAMESPACE}" schedule list
+done
+toolkit temporal --namespace prod schedule describe --schedule-id <SCHED_ID> # recent actions + next fire time
 ```
 
 Flag: schedules with empty recent actions (never fired), paused without a documented reason, next fire time in the past.
@@ -370,8 +375,10 @@ The removed `agent-task-timeout-watch` aggregate alert must not be used as a
 health signal. Query the SDK metrics instead:
 
 ```bash
-toolkit prom query 'temporal_worker_num_pollers{namespace="temporal",exported_namespace="prod",task_queue="agent-task",poller_type="workflow_task"}'
-toolkit prom query 'histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace="temporal",exported_namespace="prod",task_queue="agent-task"}[5m])))'
+for TEMPORAL_NAMESPACE in prod beta; do
+  toolkit prom query "temporal_worker_num_pollers{namespace=\"temporal\",exported_namespace=\"${TEMPORAL_NAMESPACE}\",task_queue=\"agent-task\",poller_type=\"workflow_task\"}"
+  toolkit prom query "histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace=\"temporal\",exported_namespace=\"${TEMPORAL_NAMESPACE}\",task_queue=\"agent-task\"}[5m])))"
+done
 toolkit prom query 'up{namespace="temporal",service=~".*temporal.*worker.*metrics.*|temporal-worker-app-metrics"}'
 ```
 


### PR DESCRIPTION
## Why

The environment namespace migration is safe only if operators prepare paused targets before the switching gateway deploys, preserve existing operator pauses, and keep `default` as a drain-only namespace through the retention gate. That sequence must be durable documentation rather than PR-only context.

## What

- Define `dev`, `beta`, `prod`, and migration-only `default` ownership in the Temporal package instructions and README.
- Add the exact dry-run prepare, confirmed prepare, deploy, cutover, audit, rollback, and cleanup order to the Scout rollout guide.
- Make schedule debugging, workflow reference, schedule reference, Scout orchestration, and homelab audit examples namespace-explicit.
- Document namespace-aware monitoring, CLI profiles, and the no-cancel/no-replay drain boundary.

## Verification

- `bunx turbo run typecheck test lint build --filter=@shepherdjerred/docs-wiki --concurrency=1` (6 tests)
- `bunx prettier --check <changed documentation>`
- `bunx lefthook run pre-commit`

The wiki rendered successfully. The in-app browser was unavailable in this Conductor session, so screenshot media could not be captured. No live migration, deployment, or production acceptance was run.

## Rollout

This PR is stacked on #2525 and should land with it. Follow the documented prepare-before-deploy ordering; do not merge the later default-worker retirement until the namespace drain and additional 30-day window pass a fresh live audit.