### PR TITLE
feat(dotfiles): add Temporal development skill

### DIFF
--- a/packages/dotfiles/dot_agents/skills/THIRD_PARTY_NOTICES.md
+++ b/packages/dotfiles/dot_agents/skills/THIRD_PARTY_NOTICES.md
@@ -41,5 +41,16 @@ in [`public-sources.json`](public-sources.json).
 - Integrated content: vendored `security-audit`, including its six-phase
   workflow, references, `report-schema.json`, and `validate-findings.cjs`.
 
+## Temporal developer skill
+
+- Source: <https://github.com/temporalio/skill-temporal-developer/tree/5de78ea2a3775abfc0802926ead357afb53f2258>
+- License: MIT; the applicable license text is retained at
+  `third-party-licenses/temporalio-skill-temporal-developer.MIT`.
+- Integrated content: adapted the verified core execution model and TypeScript
+  topic structure into `temporal-helper`. The local skill corrects stale or
+  unsafe upstream examples, uses current Worker Deployments, distinguishes
+  authentic Node support from the repository's Bun exception, and adds an
+  explicit live-operation authorization boundary.
+
 The Swift community skill repository was intentionally not copied because its
 PolyForm Perimeter license is not suitable for this public skill SOT.

--- a/packages/dotfiles/dot_agents/skills/public-sources.json
+++ b/packages/dotfiles/dot_agents/skills/public-sources.json
@@ -155,6 +155,20 @@
           "notes": "Preserved the six phases, bundled references, report schema, and validator; added only local output/tool boundaries."
         }
       ]
+    },
+    {
+      "repository": "https://github.com/temporalio/skill-temporal-developer",
+      "commit": "5de78ea2a3775abfc0802926ead357afb53f2258",
+      "license": "MIT",
+      "reviewDate": "2026-08-28",
+      "imports": [
+        {
+          "upstreamSkillPath": ".",
+          "localSkillPath": "temporal-helper",
+          "integration": "adapted",
+          "notes": "Audited the complete upstream core and TypeScript material, then independently rewrote verified execution, failure, testing, deployment, Worker, and runtime guidance with repository-specific Node/Bun and live-operation safety boundaries."
+        }
+      ]
     }
   ]
 }

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: temporal-helper
+description: Safely design, implement, test, deploy, debug, and operate Temporal durable applications, with current TypeScript SDK, Workflow, Activity, Worker, Task Queue, Schedule, CLI, Cloud/server, replay, versioning, observability, and repository-specific Node/Bun guidance. Use for Temporal code or architecture, nondeterminism, retries/timeouts/heartbeats/cancellation, Signals/Queries/Updates, schedules, worker performance, production incidents, SDK upgrades, or live inspection and operations.
+---
+
+# Temporal Helper
+
+Treat Event History as the durable source of truth, replay as the compatibility
+oracle, and every live mutation as an explicitly authorized operation. Load only
+the references needed for the request; verify current version/stage details
+before using a drift-prone API.
+
+## Route the request
+
+1. **Establish the target.** Inspect repository instructions, installed
+   `@temporalio/*` versions, runtime, Namespace configuration, and relevant
+   Workflow/Activity/Worker code. Distinguish generic Temporal guidance from a
+   repository exception.
+2. **Classify the work.** Decide whether this is design/implementation, failure
+   semantics, messaging/schedules, testing/deployment, Worker/capacity,
+   TypeScript/runtime, read-only inspection, or a live mutation.
+3. **Load the focused references.** Use the table below; do not load every file
+   reflexively.
+4. **Trace the durable boundary.** Identify which values and Commands enter
+   Event History, which effects can repeat, and what must remain replay-compatible.
+5. **Verify at the right layer.** A unit test, new-history integration test,
+   replay test, bundle smoke test, live Service check, and downstream-effect
+   check prove different things. Use independent evidence for the stated claim.
+
+| Request | Read |
+|---|---|
+| Replay, determinism, histories, durable timers | [core execution model](references/core-execution-model.md) |
+| Workflow/Activity boundary, idempotency, Local Activities | [Workflow and Activity design](references/workflow-activity-design.md) |
+| Retries, timeouts, heartbeats, cancellation, failures | [failure semantics](references/failure-semantics.md) |
+| Signals, Queries, Updates, children, Continue-As-New, Schedules | [messaging and Schedules](references/messaging-and-schedules.md) |
+| Unit/integration/time-skipping/replay tests, patching, rollout | [testing, versioning, and deployment](references/testing-versioning-deployment.md) |
+| Task Queues, routing, sticky execution, slots, pollers, shutdown | [Workers and Task Queues](references/workers-and-task-queues.md) |
+| TypeScript packages, bundling, converters, Node/Bun | [TypeScript and runtime boundaries](references/typescript-runtime-boundaries.md) |
+| Logs, metrics, traces, Visibility, security, Cloud/self-hosting | [operations and observability](references/operations-observability.md) |
+| Incident triage and common anti-patterns | [troubleshooting](references/troubleshooting.md) |
+| Current primary sources and feature-stage notes | [curated source map](references/sources.md) |
+
+## Preserve the execution model
+
+- Workflow code makes deterministic durable decisions. Put network, database,
+  filesystem, secret, LLM, and other external effects in Activities.
+- Replay reruns Workflow code and consumes recorded Activity results. A
+  completed Activity is not rerun by replay; Activity attempts can repeat
+  because of retry or ambiguous completion.
+- Make every retriable Activity effect idempotent at the downstream boundary.
+  Use a stable business key or Workflow Run ID plus Activity ID; never include
+  attempt number in a deduplication key.
+- Keep payloads small. Event History is an orchestration log, not object storage
+  or a general query database.
+- Any command-producing Workflow change needs replay analysis and, when
+  incompatible, patching, current Worker Versioning, or a new Workflow type.
+
+## TypeScript runtime boundary
+
+Authentic Node 20, 22, or 24 is the officially supported Worker baseline. Client
+portability to another JavaScript runtime does not imply Worker support.
+
+This repository deliberately pins aligned `@temporalio/*` 1.22.0 packages and
+runs production under Bun 1.4.0, while authentic Node runs real Workflow Worker
+tests and replay. Upstream 1.23.0 added experimental Bun 1.4 VM, microtask, and
+shutdown fixes, but did not make Bun an officially supported Worker runtime.
+Preserve this as a tested repository exception. On every Bun or SDK upgrade,
+revalidate Bun startup/bundling plus the complete authentic-Node Workflow and
+representative replay suites.
+
+## Separate inspection from mutation
+
+Read-only inspection includes list/describe/history/Visibility, Task Queue and
+Worker status, Schedule describe/list, and a Query known to be side-effect free.
+Do not print sensitive payloads, headers, failure messages, or stacks.
+
+Starts, Signals, Updates, cancellation, termination, reset, Schedule
+create/update/pause/unpause/trigger/backfill/delete, and Workflow-version moves
+change live state. Before any mutation:
+
+1. Obtain user authorization for the exact action.
+2. Resolve and state the exact Namespace plus Workflow ID and Run ID where
+   applicable, or exact Schedule ID. Never infer a target from a similar name.
+3. Describe current state and explain the state transition and duplicate-effect
+   risk. Cancellation, termination, and reset are not interchangeable.
+4. Preserve request identity/idempotency, use the narrowest operation, and do
+   not expose credentials in commands or output.
+5. Re-read the target, execution/history, Schedule, and relevant health or
+   downstream state after the change.
+
+If exact targeting, authorization, or version-specific semantics are missing,
+continue read-only and ask for the missing authority rather than guessing.
+
+## Repository rules
+
+- All recurring work belongs in `packages/temporal` as a Workflow plus a
+  declarative Schedule; do not add Kubernetes CronJobs, host crontabs, or
+  in-process recurring timers.
+- Existing executions stay on their recorded Task Queue. A new queue does not
+  migrate them; retain old pollers or use a deliberate migration/versioning path.
+- Use Bun for repository scripts and ordinary tests. Preserve authentic Node for
+  native Workflow Worker, time-skipping, bundle, and replay acceptance.
+- Keep the full `@temporalio/*` package family on one exact version. Confirm
+  current examples against the repository pin or installed declarations.
+- Never export `TEMPORAL_ADDRESS` globally. Use the repository's scoped profile
+  and scripts so a local command cannot silently target production.
+- Follow repository fail-fast and type-safety rules: no swallowed catches,
+  assertion-based parsing, unvalidated heartbeat details, or hidden cleanup
+  failures.
+
+## Completion check
+
+State what was proved: source review, unit behavior, real Worker execution,
+time-skipping, production bundle, history replay, live Service state, downstream
+effect, or deployment health. Report omitted live/production checks explicitly.
+Do not collapse source correctness, replay compatibility, Worker readiness,
+Service availability, and end-to-end business acceptance into one claim.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/agents/openai.yaml
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Temporal Helper"
+  short_description: "Design, test, deploy, and operate Temporal safely"
+  default_prompt: "Use $temporal-helper to diagnose or implement this Temporal request with safe runtime and live-operation boundaries."

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/core-execution-model.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/core-execution-model.md
@@ -1,0 +1,76 @@
+# Core execution model
+
+## History and replay
+
+Temporal persists orchestration facts as an append-only Event History. A
+Workflow object's in-memory state and sticky cache are performance optimizations;
+after restart, eviction, reassignment, or sticky fallback, the SDK reruns the
+Workflow from its beginning and regenerates Commands.
+
+Replay must produce a command sequence compatible with the recorded Events. It
+does not restore a heap snapshot and it does not re-execute an Activity whose
+completion is already recorded.
+
+Distinguish these layers precisely:
+
+- **Workflow function:** may execute many times during replay.
+- **Workflow progress:** durable through recorded Events and Commands.
+- **Activity function/effect:** can execute more than once before one completion
+  is recorded.
+- **Recorded Activity result:** supplied from history during replay.
+- **External system:** owns its own state and idempotency guarantees.
+
+Never summarize this as “Temporal runs everything exactly once.”
+
+## Determinism
+
+Determinism means that the same Event History leads to a compatible command
+sequence. Internal computations can change when they do not alter future
+Commands. Changes that can require compatibility handling include adding,
+removing, reordering, or changing the conditions around:
+
+- Activities and Local Activities;
+- Timers and timeout-producing waits;
+- Child Workflows and external Workflow handles;
+- Signals, cancellation, completion, failure, and Continue-As-New;
+- Search Attribute, Memo, and version/patch marker Commands.
+
+TypeScript Workflows run in a separate bundled sandbox. The SDK supplies
+replay-aware time, random, UUID, timer, and logging behavior. Node/DOM APIs and
+external I/O do not belong there. `workflowInfo().unsafe.isReplaying` may gate
+duplicate diagnostics; it must not change business decisions.
+
+## Durable time and waiting
+
+Temporal Timers are persisted and do not retain a process thread while waiting.
+Worker or Service downtime may delay when work resumes, but the wait remains
+part of durable execution. Use Workflow Timers/conditions, not host timers or an
+Activity sleeping for the duration of a long business wait.
+
+## Workflow Task failure versus Workflow failure
+
+In TypeScript, an ordinary Workflow exception normally fails the Workflow Task.
+The Service retries that Task so a corrected Worker can recover the same
+execution. A deterministic bug can therefore loop on replay, consume capacity,
+and leave the execution status `Running` while progress is stopped.
+
+An explicit Temporal failure can close the Workflow Run. A configured Workflow
+Retry Policy may then create another Run, but Workflows do not retry by default.
+Do not confuse Workflow Task retry, Activity retry, and Workflow Execution retry.
+
+## History growth
+
+History size affects persistence, transfer, replay latency, and Worker memory.
+Use `continueAsNewSuggested` before hard limits, carry only required state into
+the next Run, and store large domain payloads externally. Hard event/size limits
+are safety ceilings, not design targets; confirm current Namespace limits when a
+number matters.
+
+## Review questions
+
+1. Which operations emit Commands or durable Events?
+2. Which values come from history and which come from process/external state?
+3. Can this branch produce a different command sequence for an old history?
+4. Is a cached/sticky execution hiding a replay-only failure?
+5. Does the validation replay representative open and closed histories with the
+   actual production bundle, converters, and interceptors?

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/failure-semantics.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/failure-semantics.md
@@ -1,0 +1,90 @@
+# Failure semantics
+
+## Retry and timeout model
+
+Activities retry by default with exponential backoff; Workflows do not retry by
+default. Prefer a Schedule-To-Close elapsed-time budget over a folklore attempt
+count, then tune backoff and maximum interval to downstream behavior.
+
+| Control | Meaning |
+|---|---|
+| Start-To-Close | Maximum duration of one Activity attempt; principal lost/hung attempt detector. |
+| Schedule-To-Close | Total logical Activity duration across attempts and backoff. |
+| Schedule-To-Start | Queue-wait diagnostic bound; non-retryable because returning to the same queue does not fix starvation. |
+| Heartbeat Timeout | Maximum silence for a progressing long attempt; enables fast liveness detection and checkpoints. |
+
+Set Start-To-Close or Schedule-To-Close as required by the SDK. Do not “fix” an
+incident by increasing a timeout before identifying which scope is failing.
+
+Keep library-internal retries narrow and intentional. They hide attempt/failure
+visibility from Temporal and extend the required Start-To-Close budget. Use an
+error-provided next retry delay only when the Activity has authoritative timing
+such as a downstream `Retry-After`.
+
+## Heartbeats
+
+Heartbeat long work at meaningful progress points and set a Heartbeat Timeout.
+Heartbeat details can seed the next attempt; parse them as untrusted persisted
+data. In TypeScript, observe cancellation through Activity Context,
+cancellation-aware sleep, or an `AbortSignal`.
+
+The SDK may throttle heartbeat delivery. Cancellation is not instantaneous. A
+detached auto-heartbeat can hide deadlocked work; if a background heartbeat is
+unavoidable, own its lifecycle and surface failures instead of using an empty
+catch.
+
+## Failure types and wrapping
+
+Workflow code awaiting an Activity receives `ActivityFailure`. Its `cause` can
+be `ApplicationFailure`, `TimeoutFailure`, cancellation, or another Temporal
+failure. Do not catch `ApplicationFailure` directly around the Activity call and
+assume it is the outer error.
+
+Ordinary Activity exceptions become retryable Application Failures. For a
+permanent business failure, use a stable Application Failure type marked
+non-retryable or listed in Retry Policy. Match stable types, not messages.
+Classification is domain-specific: authentication, not-found, and validation
+errors are not universally permanent when refresh or eventual consistency is
+possible.
+
+Retryability follows the outermost failure information. Wrapping a
+non-retryable Temporal failure in a generic `Error` can make it retryable again.
+
+## Cancellation
+
+Cancellation is cooperative and structured. Workflow Cancellation Scopes form
+a tree; cancelable Timers, Activities, children, and child scopes observe the
+request according to their cancellation options.
+
+- Timers/Triggers generally throw `CancelledFailure` directly.
+- Activity and Child Workflow calls generally throw a wrapper whose cause is
+  cancellation.
+- Cleanup that must run after root cancellation belongs in a non-cancellable
+  scope.
+- Rethrow cancellation when the intended terminal state is canceled; swallowing
+  it can record a misleading completion or failure.
+
+Activity cancellation reaches a normal Activity through heartbeats. Local
+Activity cancellation is in-process. Confirm the installed SDK's cancellation
+type (`TRY_CANCEL`, wait requested/completed, abandon) before choosing behavior.
+
+## Reset, termination, and failure privacy
+
+Reset creates a new Run from a history point and discards later progress; it can
+re-execute external effects. Fix the cause before reset. Termination closes
+immediately and skips cooperative cleanup. Cancellation requests cooperative
+handling. All three are live mutations requiring exact targets and authorization.
+
+Failure messages and stacks are durable and may be visible in history, UI, and
+CLI. Avoid secrets. A normal Payload Codec does not automatically protect common
+failure fields; use a compatible Failure Converter plus codec when encryption
+is required.
+
+## Review questions
+
+1. Is this a Workflow Task, Activity attempt, Activity Execution, or Workflow
+   Execution failure?
+2. Which timeout fired, and what does that scope actually diagnose?
+3. Is the outer failure type preserving retryability and the real cause?
+4. Can cancellation reach the work, and is cleanup non-cancellable where needed?
+5. Do retry and timeout settings bound duplicate effects, cost, and elapsed time?

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/messaging-and-schedules.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/messaging-and-schedules.md
@@ -1,0 +1,99 @@
+# Messaging and Schedules
+
+## Choose the message contract
+
+| Type | Contract |
+|---|---|
+| Signal | Asynchronous, durable, no result. Service can accept it without a Worker response. |
+| Query | Synchronous and read-only, not written to history. Requires a compatible Worker. |
+| Update | Trackable mutation that can return a result. Requires a Worker through acceptance. |
+
+TypeScript Query handlers cannot be async and must not mutate Workflow state.
+Signal and Update handlers may be async, so each `await` is an interleaving
+point. Protect invariants with Workflow-safe synchronization or enqueue commands
+for the main Workflow loop.
+
+Register handlers after required state initialization and before messages can
+arrive. Signal-With-Start can deliver early. Before completion or
+Continue-As-New, wait for `allHandlersFinished` unless abandoning unfinished
+handlers is a deliberate protocol decision.
+
+Update validators are synchronous and side-effect free. Rejection before
+acceptance can avoid an accepted-Update history entry, but validation does not
+replace authorization or handler state checks because state can change after
+validation.
+
+Update ID deduplication is scoped to a Workflow Run. Give Signals an application
+idempotency key when duplicate business delivery matters. Carry cross-run
+deduplication state through Continue-As-New.
+
+## Start-with-message behavior
+
+Signal-With-Start couples start and Signal delivery. Update-With-Start has a
+weaker boundary: a new Workflow may start even if the Update is not delivered.
+The Workflow's initialization must therefore be valid without the Update.
+
+Treat Signal and Update calls as live mutations. Preserve a stable request ID,
+handle terminal client-call failure, and reconcile delivery rather than assuming
+SDK retries prove success.
+
+## Child Workflows
+
+Use a Child Workflow for a separate execution identity/lifecycle, service or
+Task Queue ownership, independent retry/cancellation boundary, or history
+partition. Use ordinary Workflow functions or Activities for code reuse.
+
+- Await `startChild` until `ChildWorkflowExecutionStarted` is recorded before a
+  parent can close. Use `executeChild` when the parent needs the result.
+- Parent Close Policy defaults to terminate. Request-cancel cooperates; abandon
+  transfers ownership and observability elsewhere.
+- A child's Continue-As-New chain remains one child execution from the parent
+  perspective. A parent's new Run does not automatically re-parent existing
+  children.
+- Child lifecycle Events still consume parent history. Bound fan-out and use a
+  hierarchy or Continue-As-New for very large workloads.
+
+## Continue-As-New
+
+Continue-As-New keeps Workflow ID and starts a new Run with fresh Event History.
+Pass current durable state as ordinary input. Prefer `continueAsNewSuggested`
+over a fixed threshold and do not approach hard limits as a normal target.
+
+Call Continue-As-New from the main Workflow after async handlers finish. Design
+message draining and deduplication across the Run boundary. Do not use it as an
+after-the-fact rescue for a knowingly unbounded coordinator.
+
+## Schedule semantics
+
+A Schedule is an independent named Service resource for recurring calendars,
+intervals, pause/resume, backfill, overlap, and catchup. Use a Workflow start
+delay for one future start.
+
+Overlap policies express business concurrency:
+
+- **Skip**: default; omit a new action while one is open.
+- **BufferOne / BufferAll**: retain one or every missed action.
+- **CancelOther**: request cancellation and wait for closure before starting.
+- **TerminateOther**: terminate the open execution, then start.
+- **AllowAll**: permit overlap.
+
+Pausing affects future scheduled actions, not executions already started. A
+paused Schedule may still be manually triggered. Deleting a Schedule does not
+terminate its existing Workflows. List/count use Visibility and are eventually
+consistent.
+
+Catchup Window covers actions missed while the Temporal Service was down. It
+does not discard work merely because Workers were unavailable: the Service may
+have created the Workflow and queued its task. Expiring work needs a Workflow
+staleness/deadline check. Backfill is a separate explicit mutation.
+
+## Live Schedule boundary
+
+Describe and list are read-only. Create, update, pause, unpause, trigger,
+backfill, and delete are live mutations. Require the exact Namespace and
+Schedule ID, describe current state first, obtain authorization for the precise
+change, then verify the Schedule and any started Workflows.
+
+In this repository, schedule definitions are declarative and reconciliation
+preserves operator-owned live pause state. Follow package code and tests rather
+than overwriting pause state from desired configuration.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/operations-observability.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/operations-observability.md
@@ -1,0 +1,108 @@
+# Operations, observability, and security
+
+## Use complementary signals
+
+Temporal Cloud/Service metrics and SDK metrics are separate:
+
+- Service metrics show what Temporal accepted, persisted, throttled, limited,
+  replicated, or observed.
+- SDK metrics show Client/Worker polling, task execution, slots, cache, replay,
+  failures, and local latency.
+
+Collect both. A healthy Service endpoint does not prove Worker telemetry or
+business progress; a live Worker process does not prove queue progress.
+
+Read request count, configured limit, and throttle together. One-minute averages
+can hide bursts. SDK retries can expire, so an unhandled failed start/Signal/
+Update is not delivered merely because the SDK retried it.
+
+Cloud-side latency is not end-to-end latency. The path can include network,
+proxy, Codec Server, lock contention, Task Queue wait, Workflow/Activity code,
+and downstream systems.
+
+## Logs and traces
+
+Temporal UI is an execution/history inspection surface, not an application-log
+store. Emit structured replay-aware Workflow logs, Activity logs, metrics, and
+traces to the normal observability system.
+
+Include stable context such as Namespace, Task Queue, Workflow Type, Workflow
+ID, Run ID, Activity Type/ID, and attempt where appropriate. Do not place
+high-cardinality identifiers in metric labels without a bounded design. Do not
+log payloads or failure data that can contain credentials, PII, prompts, or
+business secrets.
+
+Workflow logging is replay-aware. Sinks are not durable/retried orchestration
+effects and can add Workflow Task latency; do not use a Sink for business state.
+
+## Visibility and application reads
+
+Visibility and Search Attributes support operational discovery/listing. They
+are eventually consistent for listing/count paths, have separate limits, and
+remain plaintext so the Service can filter/order. ID-specific describe/history
+uses the execution path and has different semantics.
+
+Use a Query for a compatible live Workflow's read-only state. Do not make Query
+availability a durable reporting contract after old Workers retire. Build an
+external projection/read model for application reporting and retained reads.
+
+## Audit and export
+
+Cloud Audit Logs cover supported control-plane operations, not Workflow starts,
+terminations, or Schedule creation. Acceptance of an async control-plane request
+is not final success; follow the asynchronous operation.
+
+Workflow History Export is delayed at-least-once export of closed histories. It
+is not Cloud Archival, real-time incident telemetry, or automatic regional
+failover. Deduplicate exported objects and account for configured-region outage.
+
+## Encryption and credentials
+
+Payload encryption is client-side. Payload Codecs do not protect Search
+Attributes and ordinary configuration does not necessarily protect failure
+messages/stacks. Use a compatible Failure Converter when failure fields need
+encryption.
+
+A Codec Server is a decryption oracle. Authenticate/authorize it, verify tokens,
+restrict network access, use narrow CORS, and keep encrypted payloads encrypted
+outside authorized clients. Never expose it as a public convenience endpoint.
+
+API keys authenticate an identity; RBAC authorizes it. Prefer service identities
+for Workers, store credentials outside source/history, and rotate by validating
+the replacement before removing the old credential. Deleting a live Worker
+credential can disconnect pollers and strand work until replacement capacity
+authenticates.
+
+## Cloud recovery
+
+Temporal Cloud multi-region recovery does not make the application multi-region
+by itself. Test Worker availability, credentials, customer databases, network
+paths, Codec Servers, and downstream dependencies in the failover region. Check
+replication lag and the current plan/SLA before a failover claim.
+
+## Self-hosting
+
+Self-hosting moves durability obligations down a layer. Production requires:
+
+- strongly consistent supported persistence and backups;
+- separate Visibility health and compatible store versions;
+- capacity/shard/load proof with representative failure testing;
+- TLS, authentication, authorization, and UI/API access controls;
+- Service and SDK metrics, alerting, and restore/recovery exercises;
+- schema-first sequential minor upgrades, rehearsed under load;
+- end-to-end regional recovery including Workers and dependencies.
+
+Update persistence schemas before the matching server binary and follow
+documented sequential upgrade rules. A healthy process probe is not proof of
+Task Queue or Workflow progress.
+
+## Operational evidence
+
+After an incident or change, report separately:
+
+1. Service/control-plane state;
+2. Worker pollers/version and Task Queue health;
+3. Workflow Task/Activity failures and replay behavior;
+4. execution/history progress;
+5. downstream idempotency/effect state;
+6. user-visible/business acceptance.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/sources.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/sources.md
@@ -1,0 +1,119 @@
+# Curated source map
+
+Reviewed 2026-08-28. Use these primary sources for normative claims and re-open
+drift-prone pages before an implementation or live operation. Community incident
+material informed troubleshooting patterns but is intentionally not a normative
+source map.
+
+## Execution model and failures
+
+- [Workflow Execution](https://docs.temporal.io/workflow-execution) — durable
+  execution, replay, caching, Runs.
+- [Events and Event History](https://docs.temporal.io/workflow-execution/event) —
+  durable history contents and replay role.
+- [Workflow Definition](https://docs.temporal.io/workflow-definition) —
+  determinism and command-producing changes.
+- [Activity Definition](https://docs.temporal.io/activity-definition) —
+  at-least-once execution, ambiguous completion, stable idempotency keys.
+- [Retry Policies](https://docs.temporal.io/encyclopedia/retry-policies) — default
+  Activity and Workflow retry behavior.
+- [Application failures](https://docs.temporal.io/encyclopedia/application-failures) —
+  failure types, wrapping, retryability.
+- [Failure Converter](https://docs.temporal.io/failure-converter) — failure-field
+  privacy and codec integration.
+
+## Messages, histories, and Schedules
+
+- [Sending Signals, Queries, and Updates](https://docs.temporal.io/sending-messages) —
+  caller-side contracts and start-with-message behavior.
+- [Handling Signals, Queries, and Updates](https://docs.temporal.io/handling-messages) —
+  handlers, validators, concurrency, deduplication.
+- [Continue-As-New](https://docs.temporal.io/workflow-execution/continue-as-new) —
+  Run chains and history reset.
+- [Child Workflows](https://docs.temporal.io/child-workflows) — child identity,
+  lifecycle, and boundaries.
+- [Schedules](https://docs.temporal.io/schedule) — overlap, catchup, pause,
+  backfill, deletion, and Visibility semantics.
+
+## Deployment, Workers, and Task Queues
+
+- [Worker Versioning](https://docs.temporal.io/production-deployment/worker-deployments/worker-versioning) —
+  current Worker Deployment model, Pinned/Auto-Upgrade, Current/Ramping.
+- [Safely deploying Workflow code](https://docs.temporal.io/develop/safe-deployments) —
+  replay gates and compatible rollout.
+- [Temporal Server 1.31 release](https://github.com/temporalio/temporal/releases/tag/v1.31.0) —
+  Worker Deployments GA; legacy V1/V2 sunset with removal scheduled for 1.32;
+  Priority/Fairness GA.
+- [Task Queues](https://docs.temporal.io/task-queue) — dispatch, partitions,
+  pollers, and persistence.
+- [Task Queue Priority and Fairness](https://docs.temporal.io/develop/task-queue-priority-fairness) —
+  current partition/product scope and limitations.
+- [Sticky Execution](https://docs.temporal.io/sticky-execution) — cache routing
+  and fallback.
+- [Worker performance](https://docs.temporal.io/develop/worker-performance) —
+  slots, pollers, tuners, eager behavior, metrics.
+- [Worker capacity troubleshooting](https://docs.temporal.io/troubleshooting/worker-capacity) —
+  backlog, latency, pollers, slots, crash/OOM interpretation.
+
+## TypeScript SDK and testing
+
+- [TypeScript Workflow basics](https://docs.temporal.io/develop/typescript/workflows/basics) —
+  sandbox, imports, replay-aware APIs.
+- [TypeScript Activity timeouts](https://docs.temporal.io/develop/typescript/activities/timeouts) —
+  timeout scopes, heartbeat, cancellation, next retry delay.
+- [TypeScript message passing](https://docs.temporal.io/develop/typescript/workflows/message-passing) —
+  typed handlers, concurrency, unfinished handlers.
+- [TypeScript testing](https://docs.temporal.io/develop/typescript/best-practices/testing-suite) —
+  Activity, time-skipping, integration, and replay layers.
+- [TypeScript data conversion](https://docs.temporal.io/develop/typescript/best-practices/data-handling/data-conversion) —
+  converters and compatibility.
+- [SDK README at repository pin 1.22.0](https://github.com/temporalio/sdk-typescript/blob/v1.22.0/README.md) —
+  package alignment and official Node support for the pinned release.
+- [SDK 1.23.0 release](https://github.com/temporalio/sdk-typescript/releases/tag/v1.23.0) —
+  experimental Bun 1.4 fixes and protobufjs v8 breaking changes.
+- [Bun 1.4 compatibility change](https://github.com/temporalio/sdk-typescript/pull/2349) —
+  VM, microtask, shutdown, CI, and stack-trace-query limitations.
+
+## Operations and security
+
+- [TypeScript observability](https://docs.temporal.io/develop/typescript/platform/observability) —
+  logs, metrics, tracing, Sinks.
+- [Monitor Temporal Cloud](https://docs.temporal.io/cloud/monitor) — Service,
+  SDK, and audit signal boundaries.
+- [Monitor Worker health](https://docs.temporal.io/cloud/worker-health) — queue,
+  poller, slot, and cache signals.
+- [Payload encryption](https://docs.temporal.io/production-deployment/data-encryption) —
+  codecs, failure conversion, Codec Server security.
+- [Temporal Cloud security](https://docs.temporal.io/cloud/security) — execution
+  boundary, identity, transport, and payload encryption responsibilities.
+- [Self-hosted production checklist](https://docs.temporal.io/self-hosted-guide/production-checklist) —
+  persistence, scale, HA, security, and load proof.
+- [Server upgrade procedure](https://docs.temporal.io/self-hosted-guide/upgrade-server) —
+  schema-first sequential upgrades and staging/load validation.
+
+## Dated feature/runtime notes
+
+| Area | Status at review | Required behavior |
+|---|---|---|
+| Authentic Node Worker | Node 20/22/24 officially supported | Default generic TypeScript Worker baseline. |
+| Bun Worker | 1.23.0 compatibility fixes labeled experimental; upstream still discourages non-Node Workers | Repository's Bun 1.4/SDK 1.22 path is a tested exception; revalidate every upgrade. |
+| Worker Deployments | GA in Server 1.31 | Use current model; check Server/Cloud/SDK minimums and installed options. |
+| Legacy Version Sets / Assignment Rules | Sunset in Server 1.31; scheduled for removal in 1.32 | Do not teach for new deployments; recheck after 1.32 ships. |
+| Priority and Fairness | GA in Server 1.31; Cloud Fairness has enablement/entitlement constraints | Recheck product scope; never assume global FIFO. |
+| External Storage | Pre-release in TypeScript docs | Do not recommend as a transparent default; verify lifecycle, drivers, encryption ordering. |
+| Standalone Activities | Public Preview in reviewed docs/Server release | Version- and flag-gate; all management operations are live mutations. |
+
+## Upstream skill provenance
+
+The official Temporal developer skill was audited as an input, not copied
+wholesale:
+
+- Repository: [temporalio/skill-temporal-developer](https://github.com/temporalio/skill-temporal-developer)
+- Audited commit: [`5de78ea2a3775abfc0802926ead357afb53f2258`](https://github.com/temporalio/skill-temporal-developer/commit/5de78ea2a3775abfc0802926ead357afb53f2258)
+- License: [MIT at the audited commit](https://github.com/temporalio/skill-temporal-developer/blob/5de78ea2a3775abfc0802926ead357afb53f2258/LICENSE)
+
+The local skill independently corrects failure wrapping/idempotency, current
+Worker Versioning, feature stages, typed Search Attributes, Node/Bun support,
+repository type/fail-fast rules, and live-operation authorization. Exact
+provenance and retained license text live in the repository's public-skill
+provenance system.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/testing-versioning-deployment.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/testing-versioning-deployment.md
@@ -1,0 +1,108 @@
+# Testing, versioning, and deployment
+
+## Layer tests by the contract they prove
+
+1. **Pure tests:** deterministic helpers and context-free Activity logic.
+2. **Activity context tests:** `MockActivityEnvironment` for Activity info,
+   heartbeat content, and cancellation behavior. Mock heartbeats are not
+   production-throttled.
+3. **Workflow integration:** a real Worker with mocked Activities for sandbox,
+   Commands, handlers, and Worker lifecycle. `Worker.runUntil()` should surface
+   Worker and Workflow promise failures; always tear down the environment.
+4. **Time-skipping:** timer-heavy paths, retry backoff, long sleeps, and
+   intermediate state. One environment has one global clock; do not use it
+   concurrently.
+5. **Local/existing Service:** features and failure behavior requiring closer
+   server fidelity. The time-skipping Java test server has incomplete parity.
+6. **Bundle smoke:** build the exact production Workflow entry graph and catch
+   prohibited/transitive Node imports.
+7. **History replay:** representative retained histories for every changed
+   Workflow Type and relevant Task Queue.
+8. **Failure/deployment exercises:** Worker loss/restart, graceful shutdown,
+   downstream outage, rate limit, duplicate effects, backlog growth/drain, and
+   version rollout.
+
+A direct Workflow function call does not test Temporal sandbox, Commands,
+history, replay, or Worker lifecycle. A test starting only new histories cannot
+prove backward compatibility.
+
+## Replay acceptance
+
+Use the same Workflow bundle, Payload/Failure Converters, codecs, interceptors,
+and Workflow ID-dependent configuration as production. In TypeScript,
+`Worker.runReplayHistory()` distinguishes a determinism violation from other
+replay errors. Supply the real Workflow ID when logic depends on it because
+history alone does not contain that value.
+
+Sample recent open and closed executions for each changed type/queue. Generated
+fixtures provide quick feedback; retained production histories provide realism.
+Do not commit histories containing private or encrypted payloads without the
+appropriate data/security approval and key-access design.
+
+## Decide whether a change is compatible
+
+Pure computation and refactoring are compatible only when they preserve future
+Commands for every retained/open history. A command-producing change needs one
+of:
+
+- a TypeScript patch marker lifecycle;
+- current Worker Deployment Versioning with an appropriate per-Workflow behavior;
+- a new Workflow Type/identity boundary.
+
+Patching lifecycle:
+
+1. Introduce `patched(id)` with old and new branches.
+2. After no execution needs the old branch, remove it but retain
+   `deprecatePatch(id)`.
+3. Remove the deprecated marker only after retained/replayed histories cannot
+   require it.
+
+Patch IDs and call ordering are part of compatibility.
+
+## Current Worker Deployments
+
+Use the current Worker Deployment model, not V1 compatibility sets or V2
+assignment rules. Those legacy APIs are deprecated/sunset in Server 1.31 and
+scheduled for removal in 1.32.
+
+A Deployment Version combines deployment name and Build ID. Each execution of a
+Pinned Workflow Type stays on the version where it started; new executions can
+start on Current or Ramping. Auto-Upgrade can route to Current/Ramping but still
+requires replay-safe code and patching when needed.
+
+Confirm current Server/Cloud/SDK minimums and TypeScript options, including
+`defaultVersioningBehavior` when Worker-wide versioning is enabled. Feature
+stages and commands are drift-prone; use current docs and installed CLI help.
+
+Rollouts must account for Current, Ramping, draining versions, closed-execution
+Queries, sleeping/idle Workflows, Continue-As-New policy, and retained old
+capacity. Moving/pinning/resetting executions is a live mutation requiring exact
+targets and authorization.
+
+## Repository acceptance matrix
+
+| Layer | Runtime | Proves |
+|---|---|---|
+| Unit/Activity/Schedule/shared tests | Bun 1.4.0 | Repository logic and non-Worker Bun behavior. |
+| Real Workflow/time-skipping tests | Authentic Node 24 | Supported native Worker, sandbox, commands, handlers. |
+| Bundle smoke and retained-history replay | Authentic Node 24 | Entry graph and replay compatibility against the supported oracle. |
+| Production Worker | Bun 1.4.0 | Repository-specific deployed exception only. |
+
+On an SDK/Bun upgrade, keep exact package alignment and run all four layers.
+Inspect Core, Webpack/bundler, converter, protobuf, test-server, and runtime
+release notes. SDK 1.23.0 also includes a protobufjs v8 breaking surface, so it
+is not a Bun-only version bump.
+
+## Deployment proof
+
+Distinguish:
+
+- source/tests pass;
+- the production bundle builds;
+- representative histories replay;
+- the intended version is polling the intended queue;
+- backlog and failures remain healthy through rollout;
+- live Workflows progress;
+- downstream effects and user-visible outcomes are correct.
+
+Do not report these as one undifferentiated “deployed successfully” claim.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/troubleshooting.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/troubleshooting.md
@@ -1,0 +1,107 @@
+# Troubleshooting
+
+## Start with the layer that stopped progressing
+
+1. Identify Namespace, Workflow ID, Run ID, Workflow Type, Task Queue, Worker
+   Deployment Version, and relevant Activity ID/attempt.
+2. Read describe/history and Worker logs without mutating state or printing
+   sensitive payloads.
+3. Classify the failure: client request, Workflow Task/replay, Activity attempt,
+   queue capacity, Worker lifecycle, Service/persistence, Visibility, or
+   downstream effect.
+4. Reproduce with the smallest independent oracle: bundle, replay, real Worker,
+   local Service, or downstream idempotency check.
+5. Fix the cause before considering cancel, reset, terminate, version move, or
+   Schedule changes.
+
+## Nondeterminism or repeated Workflow Task failure
+
+Symptoms include `Running` executions without progress, repeated Workflow Task
+failures, cache-eviction-only incidents, or “no command scheduled” mismatches.
+
+- Replay the exact history against the exact production bundle and converters.
+- Compare command-producing code paths and patch/version markers.
+- Check Query handlers for state mutation and code for unrecorded external/time
+  values.
+- Restore replay-compatible code or route through current Worker Versioning.
+- Do not automatically restart/reset every affected Workflow. Reset can replay
+  side effects and requires exact targeting after the code is fixed.
+
+Sticky cache can mask a replay-only bug for hours. Treat replay tests and
+Workflow Task failure metrics as independent evidence.
+
+## Activity retry storm or duplicate effect
+
+- Inspect the outer `ActivityFailure` and its cause; verify the failure type did
+  not lose non-retryable classification through wrapping.
+- Check Start-To-Close, Schedule-To-Close, backoff, maximum attempts, and any
+  hidden library retry loop.
+- Verify downstream idempotency with the stable operation key and durable result.
+- Check whether success was ambiguous before the Worker failed.
+- Heartbeat/checkpoint long work and parse details safely.
+
+Do not mark a transient dependency error permanent merely to stop the storm.
+Bound elapsed time/cost and fix classification or the dependency.
+
+## Cancellation appears stuck
+
+Normal Activity cancellation is delivered through heartbeats. Check that the
+Activity heartbeats or waits on cancellation-aware APIs and that the Worker is
+still connected. Heartbeat throttling means delivery is not instantaneous.
+
+Confirm the configured Activity cancellation type and wrapper/cause. Verify
+cleanup runs in a non-cancellable scope and cancellation is rethrown. Do not
+replace cooperative cancellation with termination without explaining the lost
+cleanup and obtaining authorization.
+
+## Worker backlog or latency
+
+High Schedule-To-Start/backlog points toward poller/slot/routing/crash capacity.
+High execution latency points toward code, replay, resource, or dependency cost.
+Low poll success with low latency and idle resources can mean over-polling.
+
+Correlate slots, pollers, cache, CPU, memory, OOM/restarts, task completion,
+sticky misses, and downstream limits. Scale or tune the measured bottleneck; do
+not raise every concurrency setting.
+
+Existing executions do not follow a renamed/new Task Queue. If new Workers look
+healthy while old executions stall, verify old queue pollers before changing
+history or terminating runs.
+
+## Schedule surprise
+
+- Pause/delete does not stop Workflows already started.
+- A paused Schedule may still be manually triggered.
+- Catchup covers Service downtime, not Worker unavailability.
+- Overlap is evaluated against open executions; choose the business policy.
+- List/count are eventually consistent; describe the exact Schedule.
+
+Trigger, backfill, pause/unpause, update, and delete are live mutations. Require
+the exact Namespace/Schedule ID and authorization.
+
+## Bundle/runtime failure
+
+For Workflow bundle errors, trace transitive imports of Node built-ins, Activity
+implementations, Client/Worker packages, and runtime-only libraries. Do not use
+`ignoreModules` until runtime unreachability is proved.
+
+For Bun-only Worker failures, remember the repository is on SDK 1.22.0 and Bun
+1.4.0, before upstream's experimental 1.23 fixes. Reproduce Bun startup,
+registration, Workflow execution, shutdown, and bundle behavior, then run the
+authentic-Node Worker/replay oracle. Do not describe a Bun workaround as general
+Temporal support.
+
+## Operational anti-patterns
+
+- “Temporal guarantees exactly-once Activities.”
+- Idempotency keys containing attempt number.
+- External I/O or mutable Query handlers in Workflow code.
+- A background heartbeat whose failure is swallowed.
+- One timeout or retry policy for every error/domain.
+- Using history as bulk object storage or the application database.
+- Treating `Running` as proof of progress.
+- Teaching legacy Build-ID assignment rules as current Worker Versioning.
+- Assuming a new Task Queue migrates existing executions.
+- Increasing capacity from one metric without identifying the queueing stage.
+- Using reset/terminate/Schedule mutations as action-ready diagnostics.
+- Logging or exporting payloads, failure stacks, or credentials during triage.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/typescript-runtime-boundaries.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/typescript-runtime-boundaries.md
@@ -1,0 +1,95 @@
+# TypeScript and runtime boundaries
+
+## Package alignment
+
+Keep every `@temporalio/*` package in one project on the same exact version:
+Activity, Client, Common, Worker, Workflow, Testing, and any converter/extension
+packages. The sandbox, native Core bridge, protocol types, converter behavior,
+and test environment evolve together.
+
+Use the installed declarations or version-tagged source for implementation.
+The live TypeScript API can reflect a newer release than the repository pin.
+
+This repository pins `@temporalio/activity`, `client`, `common`, `worker`,
+`workflow`, and `testing` to 1.22.0. Do not copy a latest-API example without
+checking it against 1.22.0.
+
+## Workflow bundle boundary
+
+Workflow code runs in a separate deterministic VM/context and is bundled with
+Webpack. Register `workflowsPath` or a bundle created by
+`bundleWorkflowCode()`; never import Workflow implementations into the ordinary
+Worker process as if they were Activities.
+
+The Workflow graph must not import Node built-ins, Activity implementations, or
+Client/Worker/Testing packages at runtime. Import Activity types only and call
+typed proxies. An `ignoreModules` escape is safe only when the module is proven
+unreachable during Workflow execution; it does not make nondeterministic code
+safe.
+
+Prebuild and smoke-test the real production entry graph. Use the same Workflow
+interceptors and Payload Converter configuration during bundle/replay as when
+the histories were created.
+
+## Data conversion and privacy
+
+- **Payload Converter:** maps TypeScript values to/from Temporal Payloads.
+- **Payload Codec:** transforms Payload bytes, commonly compression/encryption.
+- **Failure Converter:** maps failures and can cooperate with a codec to protect
+  failure messages/stacks.
+
+Configure compatible converters/codecs on every Client and Worker and retain
+decoding support for old history payloads. Converter changes are replay/data
+compatibility changes, not presentation changes.
+
+The default TypeScript converter handles normal JSON-serializable values plus
+supported special cases such as `undefined` and byte arrays. Protobuf conversion
+is opt-in; confirm the exact version behavior. SDK 1.23.0 upgrades protobufjs to
+v8 and includes a public-type/JSON compatibility surface.
+
+Search Attributes remain plaintext/indexable and do not pass through the normal
+Payload Codec. Use `TypedSearchAttributes` and typed keys; old untyped
+array-valued maps are deprecated. Never put secrets or PII in Search Attributes.
+
+## Authentic Node support
+
+The SDK officially supports Workers on Node 20, 22, and 24. Worker execution
+depends on native modules, Worker Threads, VM contexts, AsyncLocalStorage, and
+promise/async hooks. Use an authentic supported Node release and supported libc
+image as the generic production baseline.
+
+Client packages may work on Bun, Deno, or edge runtimes, but upstream does not
+extend that portability claim to Worker-level Workflow/Activity execution.
+
+## Bun boundary
+
+SDK 1.23.0 added **experimental** Bun 1.4 fixes for reusable VM context
+switching, microtasks, and Worker shutdown and expanded Bun CI. Bun still lacks
+the V8 promise-hook APIs used for Workflow stack-trace queries. The current SDK
+README continues to strongly discourage non-Node Workers.
+
+This repository's Bun 1.4.0 production Worker on SDK 1.22.0 predates those
+fixes. Treat it as a locally tested exception, not general Bun support. Do not
+expand it to other services or recommend it for a new project.
+
+On every Bun or Temporal SDK change:
+
+1. keep the complete SDK family aligned;
+2. build the production Workflow bundle;
+3. start/run the Bun Worker path with representative registration and shutdown;
+4. run the full authentic-Node Workflow/time-skipping suite serially;
+5. replay representative histories under authentic Node using the production
+   bundle/converters;
+6. inspect release notes for Core, bundler, runtime, test-server, converter, and
+   protobuf changes.
+
+Passing only the Node bundle test does not prove the Bun Worker starts. Passing
+only Bun unit tests does not prove the native supported Worker/replay path.
+
+## Type safety
+
+Do not copy upstream snippets that use type assertions, non-null assertions,
+unvalidated `JSON.parse`, or unparsed heartbeat details. Validate external,
+history, and persisted boundaries with control-flow narrowing or a runtime
+schema. Do not end a process with `run().catch(console.error)`; surface a failing
+exit status and cleanup errors.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/workers-and-task-queues.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/workers-and-task-queues.md
@@ -1,0 +1,89 @@
+# Workers and Task Queues
+
+## Task Queue model
+
+Task Queues are dynamic pull-based dispatch contracts. Workers register the
+Workflow Types or Activities they can run and poll named queues. Workflow and
+Activity Tasks are persisted when no compatible poller is available; Query and
+some other task kinds require a live responder.
+
+An execution's queue is recorded in history. Deploying Workers on a new queue
+does not migrate existing executions. Keep old pollers until the old queue
+drains, or use a deliberate supported migration/versioning mechanism.
+
+Choose queue boundaries for service ownership, incompatible dependencies,
+resource isolation, routing, or rate limits. Uncontrolled queue proliferation
+fragments capacity and operations. A shared string name does not make every
+internal task kind interchangeable.
+
+## Ordering, priority, and fairness
+
+Temporal does not guarantee global FIFO across queue partitions. Current
+Priority and Fairness behavior is partition-scoped; Fairness is dispatch
+fairness, not a cost or in-flight resource guarantee. Cloud enablement and
+entitlement can differ from self-hosted feature availability.
+
+Treat priority and fairness as overload policy. Preserve capacity for critical
+work, but do not use priority as a correctness dependency or assume higher
+priority can preempt already running Activities.
+
+## Sticky execution and cache
+
+Sticky execution routes follow-up Workflow Tasks toward a Worker with cached
+state to avoid full replay. It applies to Workflow Tasks only and is an
+optimization:
+
+- cache eviction or Worker loss must remain correct;
+- sticky fallback can force cold replay;
+- high replay cost can cause Workflow Task timeouts and a feedback loop;
+- process-local state and host affinity must never be correctness requirements.
+
+Replay-only bugs may stay hidden while a Workflow remains cached. Include replay
+tests and monitor Workflow Task failures, not only execution status.
+
+## Capacity diagnosis
+
+Correlate signals before tuning:
+
+| Signal | Likely layer to investigate |
+|---|---|
+| Rising Schedule-To-Start/backlog | Poller/slot capacity, crashes, resource limits, queue routing. |
+| High task execution latency | Workflow/Activity code, replay, CPU/memory, downstream dependency. |
+| Low poll success with low latency and idle hosts | Over-polling, not necessarily insufficient Workers. |
+| Frequent sticky misses/cold replay | Cache sizing, churn, histories, deployment behavior. |
+| OOM/restarts | Cache/slot concurrency, payload/history size, process topology. |
+
+Slots, pollers, cache, CPU, memory, and downstream concurrency interact. Tune
+from metrics and bounded load tests. Defaults and example percentages are
+starting points, not universal recommendations. Do not combine resource tuners
+with mutually exclusive legacy max-concurrency options.
+
+Rate limits can exist per Worker, Task Queue, Namespace, account, or downstream
+dependency. Confirm the scope before changing a number.
+
+## Worker topology
+
+Separate Worker deployments/queues when workloads need different runtime
+dependencies, resources, ownership, availability, or rate limits. Multiple
+processes/replicas provide resilience. One process running many independent
+resource tuners can create contention; confirm pinned SDK behavior rather than
+generalizing a historical issue.
+
+Prebuild the Workflow bundle for predictable production startup when practical.
+Worker creation by `workflowsPath` is supported; ahead-of-time bundling is a
+startup/deployment practice, not a claim that `workflowsPath` is incorrect.
+
+## Graceful shutdown
+
+On shutdown, stop polling new work and give in-flight tasks the configured grace
+period. Activities should cooperate with cancellation and heartbeat so the
+Service can detect/retry lost attempts. Do not add arbitrary sleeps copied from
+historical SDK issues.
+
+Verify:
+
+1. pollers for the intended version and queue are present;
+2. backlog and Schedule-To-Start drain after rollout;
+3. Workflow Task failures and replay latency remain healthy;
+4. Activities finish, checkpoint, cancel, or retry as intended;
+5. old versions/queues are retained until no execution needs them.

--- a/packages/dotfiles/dot_agents/skills/temporal-helper/references/workflow-activity-design.md
+++ b/packages/dotfiles/dot_agents/skills/temporal-helper/references/workflow-activity-design.md
@@ -1,0 +1,86 @@
+# Workflow and Activity design
+
+## Choose the boundary
+
+Workflows own durable decisions, state derived from recorded values, Timers,
+message coordination, and recovery policy. Activities own network, database,
+filesystem, subprocess, secret, LLM, and other nondeterministic side effects.
+
+In TypeScript, a Workflow imports Activity types and calls `proxyActivities`;
+the Worker registers implementations. Never import an Activity implementation
+into the Workflow bundle or call it as an ordinary function.
+
+Keep deterministic business logic in the Workflow when it benefits durable
+state and replay. “Workflow code only orchestrates” does not require every pure
+calculation to become an Activity.
+
+## Idempotency and ambiguous completion
+
+An Activity is retriable by default. If its external effect succeeds and the
+Worker dies before Temporal records completion, another attempt may run.
+Temporal cannot prove whether the external side committed.
+
+Make idempotency atomic at the effect boundary:
+
+- pass a stable business operation/request ID to a downstream idempotency API;
+- use an atomic unique constraint or conditional write;
+- keep a durable operation ledger with a stable result;
+- when appropriate, use Workflow Run ID plus Activity ID, which stays stable
+  across attempts and is unique to that Activity Execution.
+
+Do not use attempt number in an idempotency key. A check-then-create sequence
+without a lock/constraint is racy. A maximum of one attempt reduces duplicate
+execution but permits zero recorded completion after an ambiguous success.
+
+## Granularity
+
+Choose one cohesive idempotent recovery boundary per Activity. Split work when
+an earlier successful/expensive effect should not repeat with a later failure,
+or when effects need different timeouts, retry classifications, queues, or
+ownership. Keep small cohesive operations together when splitting would only
+inflate history.
+
+Avoid one Activity that fetches, transforms, writes, charges, and notifies under
+one generic retry policy. Avoid the opposite extreme of an Activity for trivial
+pure computation.
+
+## Regular and Local Activities
+
+Use regular Activities by default. They provide durable scheduling, Task Queue
+routing, rate limits, heartbeats, and independent retry visibility.
+
+Use a Local Activity only for short, in-process, idempotent work when avoiding a
+Service round trip is worth the tradeoff. Its completion becomes durable when
+the enclosing Workflow Task records the marker; Worker failure before then can
+run it again. Local Activities do not provide normal Activity heartbeats,
+routing, or global rate limiting.
+
+## Long external jobs and callbacks
+
+Prefer a short request Activity followed by a durable Workflow wait for a
+Signal/Update when an external system completes asynchronously. This avoids
+holding an Activity open for hours and makes correlation, timeout, cancellation,
+and human intervention explicit. Register handlers before the callback can
+arrive and deduplicate the message at the business layer.
+
+For genuinely long Worker-owned computation, use a normal Activity with a
+Start-To-Close budget, Heartbeat Timeout, meaningful checkpoint details, and
+cancellation-aware APIs.
+
+## Payloads and dependencies
+
+Activity arguments and results enter history. Pass small serializable values
+and stable references/checksums; keep large objects in durable external storage.
+Inject reusable clients/connections into Activity implementations, but do not
+rely on process memory as durable business state.
+
+Validate external input, heartbeat details, and deserialized data at runtime.
+Type annotations and type assertions do not validate persisted or remote values.
+
+## Review questions
+
+1. What is the external side effect and can ambiguous completion repeat it?
+2. Where is idempotency enforced atomically?
+3. Does each Activity have one coherent retry/recovery boundary?
+4. Are payload size and sensitive-data exposure acceptable in history?
+5. Would a durable callback message be safer than a long-held Activity?

--- a/packages/dotfiles/dot_agents/skills/third-party-licenses/temporalio-skill-temporal-developer.MIT
+++ b/packages/dotfiles/dot_agents/skills/third-party-licenses/temporalio-skill-temporal-developer.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Temporal Technologies Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Why

Temporal is a repository-wide runtime boundary, but the public agent skill set lacked durable, current guidance for replay, failure semantics, schedules, deployment, TypeScript runtime support, and safe operations.

## What

- add the repository-owned `temporal-helper` skill, its `Temporal Helper` agent interface, and ten progressive references
- distinguish official authentic-Node Worker support from this repository's tested Bun 1.4.0 and Temporal 1.22.0 exception
- separate read-only Temporal inspection from explicitly authorized, exactly targeted live mutations
- adapt independently verified material from Temporal's official developer skill and record its exact commit and MIT license in the public-skill provenance system
- condense an adversarially reviewed 196-page research corpus; the complete Markdown, Typst, and PDF report remains private and untracked as planned

## Verification

- `uv run --with pyyaml python3 /Users/jerred/.codex/skills/.system/skill-creator/scripts/quick_validate.py packages/dotfiles/dot_agents/skills/temporal-helper`
- `bunx prettier --check packages/dotfiles/dot_agents/skills/temporal-helper packages/dotfiles/dot_agents/skills/public-sources.json packages/dotfiles/dot_agents/skills/THIRD_PARTY_NOTICES.md packages/dotfiles/dot_agents/skills/third-party-licenses/temporalio-skill-temporal-developer.MIT`
- `cd packages/dotfiles && bun test`
- `cd packages/dotfiles && bun run typecheck`
- `cd packages/dotfiles && bun run lint`
- `bunx lefthook run pre-commit`
- `chezmoi --source packages/dotfiles cat ~/.agents/skills/temporal-helper/SKILL.md`
- `git diff --check`
- 48/48 committed URLs returned HTTP 200 via GET
- five fresh-context answer-only scenarios passed: nondeterminism, failure design, Schedule semantics, deployment, and Node/Bun troubleshooting
- no live or production Temporal operations were run

This is a nonvisual agent-knowledge and provenance change; no media is required.