### PR TITLE
feat(temporal): expose platform health telemetry

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -302,6 +302,12 @@ const commands: Record<
       TEMPORAL_METRICS_ADDRESS: "127.0.0.1:0",
       APP_METRICS_PORT: "0",
       SENTRY_DSN: "",
+      // main() calls initializeCallGraphTracing() -> initFeatureFlags()
+      // before it ever gets to "Connecting to Temporal server", and that has
+      // no default mode on purpose (see FEATURE_FLAGS_MODE's own error
+      // message). Matches the "disabled" value every other smoke target
+      // that reaches feature-flag init already sets.
+      FEATURE_FLAGS_MODE: "disabled",
     },
   },
   "trmnl-dashboard": {

--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1282,7 +1282,7 @@
     },
     "packages/scout-for-lol/packages/backend/src/observability/tracing.ts|packages/temporal/src/observability/tracing.ts": {
       "clones": 3,
-      "tokens": 347
+      "tokens": 335
     },
     "packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts|packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts": {
       "clones": 2,

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -57,6 +57,32 @@ Pause state is the deliberate exception: it is runtime state, preserved across
 reconciliation, because pausing is an operational act rather than a design
 change.
 
+## Visibility is an operational index, not a data store
+
+Every programmatic start and Schedule carries the same four Keyword Search
+Attributes: environment, domain, trigger, and the Git commit that initiated the
+execution. Temporal's built-in Schedule attributes remain authoritative for
+Schedule identity. This makes the UI and CLI useful across the shared
+`default` namespace without copying Schedule IDs into another attribute.
+
+Static summaries explain the execution or Schedule in one line. Static details
+and current Workflow details expose only bounded phase and ownership metadata.
+They deliberately exclude credentials, task tokens, Activity arguments,
+prompts, report bodies, player data, and model output. Those belong in their
+existing systems of record, not in Temporal visibility or logs.
+
+Call-graph tracing is a boot-time rollout flag. The official Temporal client,
+Workflow, and Activity interceptors propagate trace context; a repository-owned
+sink validates the replayed Workflow spans and forwards their recorded trace
+and span IDs into the existing OpenTelemetry 2 processor. The Worker does not
+install a second provider. Activity-owned `gen_ai.*` spans therefore appear
+beneath the Activity span rather than as unrelated traces.
+
+SDK, Workflow, and Activity logs use Temporal context and structured fields.
+Workflow logs remain replay-suppressed, and the Runtime logging boundary strips
+payload-like fields and the SDK's base64 Activity task token before stdout or
+OTLP export.
+
 ## Workflow code and effects run apart
 
 The gateway is a control process: it reconciles schedules and serves the public

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -63,25 +63,39 @@ Every programmatic start and Schedule carries the same four Keyword Search
 Attributes: environment, domain, trigger, and the Git commit that initiated the
 execution. Temporal's built-in Schedule attributes remain authoritative for
 Schedule identity. This makes the UI and CLI useful across the shared
-`default` namespace without copying Schedule IDs into another attribute.
+`default` namespace without copying Schedule IDs into another attribute. The
+[Search Attribute schema and domain derivation](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal/src/shared/execution-metadata.ts)
+live in one file; the
+[client interceptor](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal/src/lib/execution-metadata-client-interceptor.ts)
+attaches them to every programmatic start.
 
 Static summaries explain the execution or Schedule in one line. Static details
 and current Workflow details expose only bounded phase and ownership metadata.
 They deliberately exclude credentials, task tokens, Activity arguments,
 prompts, report bodies, player data, and model output. Those belong in their
-existing systems of record, not in Temporal visibility or logs.
+existing systems of record, not in Temporal visibility or logs. The same
+[client interceptor](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal/src/lib/execution-metadata-client-interceptor.ts)
+computes the static summary and details text.
 
 Call-graph tracing is a boot-time rollout flag. The official Temporal client,
 Workflow, and Activity interceptors propagate trace context; a repository-owned
 sink validates the replayed Workflow spans and forwards their recorded trace
 and span IDs into the existing OpenTelemetry 2 processor. The Worker does not
 install a second provider. Activity-owned `gen_ai.*` spans therefore appear
-beneath the Activity span rather than as unrelated traces.
+beneath the Activity span rather than as unrelated traces. The
+[tracing interceptors](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal-observability/src/interceptors.ts)
+and the
+[Workflow span validation sink](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal-observability/src/workflow-span-sink.ts)
+implement this.
 
 SDK, Workflow, and Activity logs use Temporal context and structured fields.
 Workflow logs remain replay-suppressed, and the Runtime logging boundary strips
 payload-like fields and the SDK's base64 Activity task token before stdout or
-OTLP export.
+OTLP export. The
+[sensitive-field sanitizer](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal-observability/src/log-fields.ts)
+and the
+[stdout-plus-OTLP log emitter](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal/src/observability/log.ts)
+implement this boundary.
 
 ## Workflow code and effects run apart
 

--- a/packages/docs/wiki/src/content/docs/how-to/pause-or-debug-a-schedule.md
+++ b/packages/docs/wiki/src/content/docs/how-to/pause-or-debug-a-schedule.md
@@ -24,7 +24,54 @@ Find the execution in the UI. `temporal-failure-watch` sends one Alerts
 occurrence for any execution that failed or timed out in the last 24 hours, so
 an occurrence usually means there is a real execution to read.
 
-## 3. Classify a timeout
+The UI summary names the workflow's purpose. Its details show only bounded
+operational metadata: environment, domain, trigger, release commit, and current
+phase. They never contain Activity arguments, prompts, report bodies, player
+data, credentials, or task tokens. Treat a UI field containing any of those as
+a data-handling defect.
+
+Use the native CLI when you need an exact state or history. Start with bounded
+descriptions and open a full history only for the one execution under
+investigation:
+
+```bash
+toolkit temporal workflow list \
+  --query "ExecutionStatus='Running' AND Environment='beta'"
+toolkit temporal workflow list \
+  --query "ExecutionStatus='Failed' AND Domain='scout'"
+toolkit temporal workflow describe --workflow-id <WORKFLOW_ID>
+toolkit temporal workflow show --workflow-id <WORKFLOW_ID>
+```
+
+Do not paste or print a history during routine diagnosis. Histories can contain
+payloads even though the enriched UI fields and logs do not.
+
+## 3. Follow one execution through traces and logs
+
+When call-graph tracing is enabled for the deployed Worker, look for one trace
+containing the client or Schedule start, Workflow, child or Continue-As-New
+edge, Activity, and nested `gen_ai.*` spans:
+
+```bash
+toolkit tempo query \
+  '{ resource.deployment.environment.name = "beta" && resource.temporal.domain = "scout" }' \
+  --since 1h --limit 20
+```
+
+Use the trace ID from that result to retrieve correlated structured logs:
+
+```bash
+toolkit loki query \
+  '{service_name=~"temporal-worker|scout-backend"} | trace_id="<TRACE_ID>"' \
+  --since 1h --limit 50
+```
+
+The Temporal dashboard exposes the same environment/domain filters and links
+between Temporal UI, Tempo, and Loki. An absent client-to-Activity edge means
+the instrumentation or propagation path is incomplete; an absent log link
+means the logger ran outside the active span or OTLP delivery failed.
+
+## 4. Classify a timeout
 
 `temporal-failure-watch` fetches the failed execution's history and classifies
 the timeout as workflow-task, activity, execution, or unknown.
@@ -36,13 +83,13 @@ infrastructure problem, not a bug in the workflow.
 SDK metrics alert after five minutes on missing agent-task workflow pollers,
 high schedule-to-start latency, or worker scrape loss.
 
-## 4. Check it was not auto-paused
+## 5. Check it was not auto-paused
 
 A schedule whose required environment variables are missing is auto-paused at
 boot with a note. This looks identical to "it never ran" until you read the
 schedule.
 
-## 5. Check the catchup window
+## 6. Check the catchup window
 
 After a server outage, most schedules replay up to an hour. Time-of-day home
 automation gets five minutes only, deliberately — a 09:00 vacuum run should not
@@ -50,7 +97,7 @@ fire at noon.
 
 A missed run outside the window is gone and will not replay.
 
-## 6. Check for overlap
+## 7. Check for overlap
 
 Overlap policy is normally `SKIP`. A slow run does not stack a second one; the
 next tick is skipped instead. A job that appears to have "missed" a run may have

--- a/packages/homelab/src/cdk8s/grafana/temporal-dashboard.test.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-dashboard.test.ts
@@ -8,7 +8,11 @@ describe("Temporal dashboard", () => {
     expect(dashboard).toContain('"name":"environment"');
     expect(dashboard).toContain('"name":"domain"');
     expect(dashboard).toContain("resource.deployment.environment.name");
-    expect(dashboard).toContain("resource.temporal.domain");
+    // Unscoped, not `resource.`: the shared central Workflow process cannot
+    // hold a single domain as a process-wide Resource attribute, so
+    // workflow-domain-interceptor.ts stamps it onto each RunWorkflow span
+    // instead — see createTemporalTracePanel's comment.
+    expect(dashboard).toContain(".temporal.domain");
     expect(dashboard).toContain("deployment_environment_name");
     expect(dashboard).toContain("temporal_domain");
   });
@@ -28,7 +32,7 @@ describe("Temporal dashboard", () => {
     expect(dashboard).toContain(
       "temporal_worker_workflow_task_execution_failed",
     );
-    expect(dashboard).toContain("activity_fail");
+    expect(dashboard).toContain("activity_task_fail");
     expect(dashboard).toContain("Schedule to Workflow to Activity traces");
   });
 });

--- a/packages/homelab/src/cdk8s/grafana/temporal-dashboard.test.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-dashboard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { createTemporalDashboard } from "./temporal-dashboard.ts";
+
+describe("Temporal dashboard", () => {
+  const dashboard = JSON.stringify(createTemporalDashboard());
+
+  test("filters traces and logs by the execution metadata dimensions", () => {
+    expect(dashboard).toContain('"name":"environment"');
+    expect(dashboard).toContain('"name":"domain"');
+    expect(dashboard).toContain("resource.deployment.environment.name");
+    expect(dashboard).toContain("resource.temporal.domain");
+    expect(dashboard).toContain("deployment_environment_name");
+    expect(dashboard).toContain("temporal_domain");
+  });
+
+  test("links the dashboard, logs, and traces to native diagnostic surfaces", () => {
+    expect(dashboard).toContain("Temporal UI");
+    expect(dashboard).toContain("Tempo Explore");
+    expect(dashboard).toContain("Loki Explore");
+    expect(dashboard).toContain("Trace in Tempo");
+    expect(decodeURIComponent(dashboard)).toContain(
+      "${__data.fields.trace_id}",
+    );
+  });
+
+  test("covers schedule delay, Workflow Task failures, and retry exhaustion", () => {
+    expect(dashboard).toContain("schedule_action_delay_bucket");
+    expect(dashboard).toContain(
+      "temporal_worker_workflow_task_execution_failed",
+    );
+    expect(dashboard).toContain("activity_fail");
+    expect(dashboard).toContain("Schedule to Workflow to Activity traces");
+  });
+});

--- a/packages/homelab/src/cdk8s/grafana/temporal-dashboard.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-dashboard.ts
@@ -1,5 +1,10 @@
 import { exportDashboardWithHelmEscaping } from "./dashboard-export.ts";
 import { statPanel, timeseriesPanel } from "./dashboard-panels.ts";
+import {
+  createTemporalPlatformPanels,
+  temporalDashboardLinks,
+  temporalDashboardVariables,
+} from "./temporal-platform-panels.ts";
 
 function createGlitterContextPanels() {
   return [
@@ -48,6 +53,8 @@ export function createTemporalDashboard() {
     version: 1,
     refresh: "1m",
     time: { from: "now-7d", to: "now" },
+    links: temporalDashboardLinks(),
+    templating: temporalDashboardVariables(),
     panels: [
       statPanel({
         id: 1,
@@ -149,6 +156,7 @@ export function createTemporalDashboard() {
         w: 12,
         h: 8,
       }),
+      ...createTemporalPlatformPanels(),
       // -----------------------------------------------------------------
       // GitHub webhook row (y >= 48) — the merge-conflict check + PR-closed
       // Buildkite build-cancellation ingress. Metrics emitted by

--- a/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
@@ -35,8 +35,21 @@ function createTemporalTracePanel() {
     targets: [
       {
         refId: "A",
+        // Span names come from the official Temporal OpenTelemetry
+        // interceptors (@temporalio/interceptors-opentelemetry), which are
+        // PascalCase (StartWorkflow, RunWorkflow, StartChildWorkflow,
+        // ContinueAsNew, RunActivity) — not the lowercase/snake_case
+        // predicate this started with, which matched nothing.
+        //
+        // `.temporal.domain` is deliberately unscoped (not `resource.`):
+        // most worker roles set it once as a process-wide Resource
+        // attribute, but the shared central Workflow process (worker.ts's
+        // "workflows" role, which drains every legacy per-domain queue) has
+        // no single domain for that attribute to hold — that role's own
+        // workflow-domain-interceptor.ts stamps the real domain onto each
+        // RunWorkflow span instead. Unscoped `.` matches either.
         query:
-          '{ resource.deployment.environment.name =~ "$environment" && resource.temporal.domain =~ "$domain" && name =~ "(workflow|activity|child_workflow|continue_as_new).*" }',
+          '{ resource.deployment.environment.name =~ "$environment" && .temporal.domain =~ "$domain" && name =~ "(StartWorkflow|RunWorkflow|StartChildWorkflow|ContinueAsNew|RunActivity).*" }',
         queryType: "traceql",
         tableType: "traces",
       },
@@ -77,7 +90,7 @@ function createTemporalLogPanel() {
     targets: [
       {
         refId: "A",
-        expr: '{service_name=~"temporal-worker|scout-backend"} | deployment_environment_name =~ "$environment" | temporal_domain =~ "$domain"',
+        expr: '{service_name=~"temporal-.*|scout-backend"} | deployment_environment_name =~ "$environment" | temporal_domain =~ "$domain"',
         maxLines: 200,
       },
     ],
@@ -98,7 +111,7 @@ export function temporalDashboardLinks() {
       type: "link",
       url: exploreUrl("tempo", {
         query:
-          '{ resource.deployment.environment.name =~ "$environment" && resource.temporal.domain =~ "$domain" }',
+          '{ resource.deployment.environment.name =~ "$environment" && .temporal.domain =~ "$domain" }',
         queryType: "traceql",
       }),
       targetBlank: true,
@@ -108,7 +121,7 @@ export function temporalDashboardLinks() {
       title: "Loki Explore",
       type: "link",
       url: exploreUrl("loki", {
-        expr: '{service_name=~"temporal-worker|scout-backend"}',
+        expr: '{service_name=~"temporal-.*|scout-backend"}',
       }),
       targetBlank: true,
       keepTime: true,
@@ -188,7 +201,9 @@ export function createTemporalPlatformPanels() {
         "Activities that reached a terminal failure after retry policy exhaustion.",
       targets: [
         {
-          expr: 'sum by (taskqueue, workflowType, activityType) (increase(activity_fail{exported_namespace="default"}[15m])) or on() vector(0)',
+          // activity_task_fail, not activity_fail — see
+          // TemporalActivityRetriesExhausted in temporal-platform-health.ts.
+          expr: 'sum by (taskqueue, workflowType, activityType) (increase(activity_task_fail{namespace="default"}[15m])) or on() vector(0)',
           legend: "{{taskqueue}} {{workflowType}} {{activityType}}",
         },
       ],

--- a/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
@@ -90,7 +90,18 @@ function createTemporalLogPanel() {
     targets: [
       {
         refId: "A",
-        expr: '{service_name=~"temporal-.*|scout-backend"} | deployment_environment_name =~ "$environment" | temporal_domain =~ "$domain"',
+        // `| json` parses each line's stdout JSON body so
+        // deployment_environment_name/temporal_domain resolve for logs that
+        // only ever reach Loki via Promtail's stdout scrape (most Activity
+        // and Workflow call sites still use the package's plain JSON
+        // stdout loggers). It's a harmless extra stage for logs ingested
+        // through Loki's OTLP endpoint instead (worker.ts's own SDK/boot
+        // logs, via observability/log.ts): those two fields already exist
+        // as queryable structured metadata from the shared tracing Resource,
+        // and LogQL folds json-extracted and structured-metadata fields into
+        // the same filterable set, so the filter below matches either
+        // source without a second query path.
+        expr: '{service_name=~"temporal-.*|scout-backend"} | json | deployment_environment_name =~ "$environment" | temporal_domain =~ "$domain"',
         maxLines: 200,
       },
     ],

--- a/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
@@ -1,0 +1,203 @@
+import { timeseriesPanel } from "./dashboard-panels.ts";
+
+const TEMPO_DATASOURCE = { type: "tempo", uid: "tempo" };
+const LOKI_DATASOURCE = { type: "loki", uid: "loki" };
+
+function exploreUrl(
+  datasource: "loki" | "tempo",
+  query: Record<string, string>,
+): string {
+  return `/explore?schemaVersion=1&panes=${encodeURIComponent(
+    JSON.stringify({
+      temporal: {
+        datasource,
+        queries: [{ refId: "A", ...query }],
+        range: { from: "now-1h", to: "now" },
+      },
+    }),
+  )}`;
+}
+
+const TRACE_BY_ID_URL = exploreUrl("tempo", {
+  query: "${__data.fields.trace_id}",
+  queryType: "traceql",
+});
+
+function createTemporalTracePanel() {
+  return {
+    id: 8,
+    type: "traces",
+    title: "Schedule to Workflow to Activity traces",
+    description:
+      "End-to-end Temporal call graphs. Filter by environment and domain, then expand a trace to verify client, Workflow, child/Continue-As-New, Activity, and nested gen_ai spans.",
+    datasource: TEMPO_DATASOURCE,
+    gridPos: { x: 0, y: 28, w: 24, h: 10 },
+    targets: [
+      {
+        refId: "A",
+        query:
+          '{ resource.deployment.environment.name =~ "$environment" && resource.temporal.domain =~ "$domain" && name =~ "(workflow|activity|child_workflow|continue_as_new).*" }',
+        queryType: "traceql",
+        tableType: "traces",
+      },
+    ],
+  };
+}
+
+function createTemporalLogPanel() {
+  return {
+    id: 9,
+    type: "logs",
+    title: "Correlated Temporal logs",
+    description:
+      "Structured SDK, Workflow, and Activity logs. Expand a record and follow trace_id into Tempo; payloads and sensitive UI fields are prohibited.",
+    datasource: LOKI_DATASOURCE,
+    gridPos: { x: 0, y: 38, w: 24, h: 10 },
+    fieldConfig: {
+      defaults: {
+        links: [
+          {
+            title: "Trace in Tempo",
+            url: TRACE_BY_ID_URL,
+            targetBlank: true,
+          },
+        ],
+      },
+      overrides: [],
+    },
+    options: {
+      showTime: true,
+      showLabels: false,
+      showCommonLabels: false,
+      wrapLogMessage: true,
+      enableLogDetails: true,
+      dedupStrategy: "none",
+      sortOrder: "Descending",
+    },
+    targets: [
+      {
+        refId: "A",
+        expr: '{service_name=~"temporal-worker|scout-backend"} | deployment_environment_name =~ "$environment" | temporal_domain =~ "$domain"',
+        maxLines: 200,
+      },
+    ],
+  };
+}
+
+export function temporalDashboardLinks() {
+  return [
+    {
+      title: "Temporal UI",
+      type: "link",
+      url: "https://temporal-ui.tailnet-1a49.ts.net/namespaces/default/workflows",
+      targetBlank: true,
+      keepTime: true,
+    },
+    {
+      title: "Tempo Explore",
+      type: "link",
+      url: exploreUrl("tempo", {
+        query:
+          '{ resource.deployment.environment.name =~ "$environment" && resource.temporal.domain =~ "$domain" }',
+        queryType: "traceql",
+      }),
+      targetBlank: true,
+      keepTime: true,
+    },
+    {
+      title: "Loki Explore",
+      type: "link",
+      url: exploreUrl("loki", {
+        expr: '{service_name=~"temporal-worker|scout-backend"}',
+      }),
+      targetBlank: true,
+      keepTime: true,
+    },
+  ];
+}
+
+export function temporalDashboardVariables() {
+  return {
+    list: [
+      {
+        name: "environment",
+        label: "Environment",
+        type: "custom",
+        query: "dev,beta,prod",
+        includeAll: true,
+        multi: true,
+        allValue: ".*",
+        current: { text: "All", value: "$__all", selected: true },
+        options: [],
+      },
+      {
+        name: "domain",
+        label: "Domain",
+        type: "custom",
+        query:
+          "home,reports,infra,repo,scout,agent,glitter,maintenance,platform",
+        includeAll: true,
+        multi: true,
+        allValue: ".*",
+        current: { text: "All", value: "$__all", selected: true },
+        options: [],
+      },
+    ],
+  };
+}
+
+export function createTemporalPlatformPanels() {
+  return [
+    timeseriesPanel({
+      id: 10,
+      title: "Schedule action delay",
+      description:
+        "Temporal scheduler delay between the nominal action time and start. The alert threshold is p95 above 60 seconds for ten minutes.",
+      targets: [
+        {
+          expr: "histogram_quantile(0.95, sum by (le) (rate(schedule_action_delay_bucket[10m]))) or on() vector(0)",
+          legend: "p95",
+        },
+      ],
+      x: 0,
+      y: 20,
+      w: 8,
+      h: 8,
+      unit: "s",
+    }),
+    timeseriesPanel({
+      id: 11,
+      title: "Workflow Task failures",
+      description:
+        "Workflow Task execution failures by queue, type, and reason. Nondeterminism is a rollout stop condition.",
+      targets: [
+        {
+          expr: 'sum by (task_queue, workflow_type, failure_reason) (increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default"}[10m])) or on() vector(0)',
+          legend: "{{task_queue}} {{workflow_type}} {{failure_reason}}",
+        },
+      ],
+      x: 8,
+      y: 20,
+      w: 8,
+      h: 8,
+    }),
+    timeseriesPanel({
+      id: 12,
+      title: "Terminal Activity failures",
+      description:
+        "Activities that reached a terminal failure after retry policy exhaustion.",
+      targets: [
+        {
+          expr: 'sum by (taskqueue, workflowType, activityType) (increase(activity_fail{exported_namespace="default"}[15m])) or on() vector(0)',
+          legend: "{{taskqueue}} {{workflowType}} {{activityType}}",
+        },
+      ],
+      x: 16,
+      y: 20,
+      w: 8,
+      h: 8,
+    }),
+    createTemporalTracePanel(),
+    createTemporalLogPanel(),
+  ];
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
@@ -61,8 +61,12 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
             "Activity {{ $labels.activityType }} in {{ $labels.workflowType }} reached a terminal failure on {{ $labels.taskqueue }}. Inspect its execution, trace, and Activity logs.",
           ),
         },
+        // activity_task_fail (not activity_fail) is the series every other
+        // Temporal/Scout failure rule in this repo queries (temporal.ts,
+        // scout.ts), and it carries a plain `namespace` label rather than
+        // the temporal_worker_*-prefixed metrics' `exported_namespace`.
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(activity_fail{exported_namespace="default"}[15m]) > 0',
+          'increase(activity_task_fail{namespace="default"}[15m]) > 0',
         ),
         for: "1m",
         labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
@@ -1,0 +1,72 @@
+import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { escapePrometheusTemplate } from "./shared.ts";
+
+export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
+  return {
+    name: "temporal-platform-health",
+    rules: [
+      {
+        alert: "TemporalScheduleActionDelayed",
+        annotations: {
+          summary: "Temporal schedule actions are starting late",
+          description:
+            "Temporal's schedule-action p95 delay has exceeded 60 seconds for ten minutes. Check the scheduler Workflow, server health, and Workflow pollers before changing catchup windows.",
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          "histogram_quantile(0.95, sum by (le) (rate(schedule_action_delay_bucket[10m]))) > 60",
+        ),
+        for: "10m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "TemporalWorkflowTaskFailing",
+        annotations: {
+          summary: escapePrometheusTemplate(
+            "Temporal Workflow Tasks are failing on {{ $labels.task_queue }}",
+          ),
+          description: escapePrometheusTemplate(
+            "Workflow Task execution failures increased for {{ $labels.workflow_type }} on {{ $labels.task_queue }}. Inspect the execution history and correlated Worker logs before restarting a poller.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default",failure_reason!="NonDeterminismError"}[10m]) > 0',
+        ),
+        for: "2m",
+        labels: { severity: "warning" },
+      },
+      {
+        alert: "TemporalWorkflowNondeterministic",
+        annotations: {
+          summary: escapePrometheusTemplate(
+            "Temporal Workflow {{ $labels.workflow_type }} is nondeterministic",
+          ),
+          description: escapePrometheusTemplate(
+            "A nondeterminism failure occurred on {{ $labels.task_queue }}. Stop the rollout, retain the failing history, and replay it against the candidate bundle before changing code.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default",failure_reason="NonDeterminismError"}[10m]) > 0 or increase(service_errors_nondeterministic[10m]) > 0',
+        ),
+        for: "1m",
+        labels: { severity: "critical" },
+      },
+      {
+        alert: "TemporalActivityRetriesExhausted",
+        annotations: {
+          summary: escapePrometheusTemplate(
+            "Temporal Activity {{ $labels.activityType }} exhausted retries",
+          ),
+          description: escapePrometheusTemplate(
+            "Activity {{ $labels.activityType }} in {{ $labels.workflowType }} reached a terminal failure on {{ $labels.taskqueue }}. Inspect its execution, trace, and Activity logs.",
+          ),
+        },
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'increase(activity_fail{exported_namespace="default"}[15m]) > 0',
+        ),
+        for: "1m",
+        labels: { severity: "warning" },
+      },
+    ],
+  };
+}

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -40,11 +40,14 @@ describe("Temporal workflow outcome rules", () => {
     expect(expressions.get("TemporalWorkflowNondeterministic")).toContain(
       'failure_reason="NonDeterminismError"',
     );
+    // activity_task_fail, not activity_fail — the metric every other
+    // Temporal/Scout failure rule in this file queries, and it carries
+    // `namespace`, not the temporal_worker_*-prefixed metrics' `exported_namespace`.
     expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
-      "activity_fail",
-    );
-    expect(expressions.get("TemporalActivityRetriesExhausted")).not.toContain(
       "activity_task_fail",
+    );
+    expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
+      'namespace="default"',
     );
   });
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -21,6 +21,33 @@ function findFailureRule(alertName: string): string {
 }
 
 describe("Temporal workflow outcome rules", () => {
+  test("alerts on schedule delay, Workflow Task failures, nondeterminism, and exhausted Activity retries", () => {
+    const healthGroup = getTemporalRuleGroups().find(
+      (group) => group.name === "temporal-platform-health",
+    );
+    if (healthGroup?.rules === undefined) {
+      throw new Error("Missing temporal-platform-health rule group");
+    }
+    const expressions = new Map(
+      healthGroup.rules.map((rule) => [rule.alert, rule.expr.value]),
+    );
+    expect(expressions.get("TemporalScheduleActionDelayed")).toContain(
+      "schedule_action_delay_bucket",
+    );
+    expect(expressions.get("TemporalWorkflowTaskFailing")).toContain(
+      "temporal_worker_workflow_task_execution_failed",
+    );
+    expect(expressions.get("TemporalWorkflowNondeterministic")).toContain(
+      'failure_reason="NonDeterminismError"',
+    );
+    expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
+      "activity_fail",
+    );
+    expect(expressions.get("TemporalActivityRetriesExhausted")).not.toContain(
+      "activity_task_fail",
+    );
+  });
+
   test("excludes intentional warm-morning preheat skips", () => {
     const outcomeGroup = getTemporalRuleGroups().find(
       (group) => group.name === "temporal-workflow-outcomes",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.ts
@@ -1,6 +1,7 @@
 import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { escapePrometheusTemplate } from "./shared.ts";
+import { getTemporalPlatformHealthRuleGroup } from "./temporal-platform-health.ts";
 import { buildTemporalDomainWorkerHealthRules } from "./temporal-worker-health.ts";
 
 type PrometheusRule = NonNullable<PrometheusRuleSpecGroups["rules"]>[number];
@@ -195,6 +196,7 @@ const SCOUT_DATA_DRAGON_FAILURE_RULES: PrometheusRule[] = [
 
 export function getTemporalRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
+    getTemporalPlatformHealthRuleGroup(),
     {
       name: "temporal-workflow-failures",
       rules: [

--- a/packages/scout-for-lol/packages/backend/src/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/index.ts
@@ -83,6 +83,7 @@ await initializeDynamicConfig({
 });
 
 initializeTracing({
+  domain: "scout",
   environment: configuration.environment,
   namespace: configuration.temporalNamespace,
   taskQueue: `scout-${configuration.environment}-workflows`,

--- a/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
+++ b/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
@@ -79,7 +79,12 @@ export function initializeTracing(
   const otlpEndpoint = Bun.env["OTLP_ENDPOINT"] ?? DEFAULT_OTLP_ENDPOINT;
   const serviceName = Bun.env["TELEMETRY_SERVICE_NAME"] ?? DEFAULT_SERVICE_NAME;
   const serviceVersion = Bun.env["GIT_SHA"] ?? Bun.env["VERSION"] ?? "dev";
-  const resource = buildTracingResource(serviceName, serviceVersion, options);
+  const resource = buildTracingResource(
+    serviceName,
+    serviceVersion,
+    "scout",
+    options,
+  );
 
   // AsyncLocalStorage-backed context manager so OTel active span propagates
   // across awaits — required for the LLM wrappers to see the current span.
@@ -123,6 +128,7 @@ export function initializeTracing(
     serviceVersion,
     otlpEndpoint,
     environment: options.environment ?? "dev",
+    domain: options.domain ?? "scout",
     namespace: options.namespace ?? "default",
     taskQueue: options.taskQueue ?? "unknown",
     workerRole: options.workerRole ?? "unknown",

--- a/packages/scout-for-lol/packages/backend/src/temporal/supervisor.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/supervisor.ts
@@ -23,6 +23,7 @@ import {
   createTemporalWorkerTracing,
 } from "@shepherdjerred/temporal-observability/interceptors";
 import { createValidatedWorkflowSpanSink } from "@shepherdjerred/temporal-observability/workflow-span-sink";
+import { sanitizeTemporalLogFields } from "@shepherdjerred/temporal-observability/log-fields";
 import { getTracingRuntime } from "#src/observability/tracing.ts";
 
 const logger = createLogger("temporal-supervisor");
@@ -36,7 +37,7 @@ function installTemporalRuntime(): void {
       const fields = {
         sdk: "temporal",
         sdkLevel: entry.level,
-        metadata: entry.meta,
+        ...sanitizeTemporalLogFields(entry.meta),
       };
       if (entry.level === "ERROR") logger.error(entry.message, fields);
       else if (entry.level === "WARN") logger.warn(entry.message, fields);

--- a/packages/temporal-observability/package.json
+++ b/packages/temporal-observability/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "exports": {
     "./interceptors": "./src/interceptors.ts",
-    "./workflow-span-sink": "./src/workflow-span-sink.ts",
-    "./tracing-resource": "./src/tracing-resource.ts"
+    "./log-fields": "./src/log-fields.ts",
+    "./tracing-resource": "./src/tracing-resource.ts",
+    "./workflow-span-sink": "./src/workflow-span-sink.ts"
   },
   "scripts": {
     "lint": "bunx eslint --cache .",

--- a/packages/temporal-observability/src/interceptors.ts
+++ b/packages/temporal-observability/src/interceptors.ts
@@ -1,8 +1,18 @@
 import { trace, type Tracer } from "@opentelemetry/api";
+// Import the client interceptor from its specific subpath rather than the
+// package root. The root barrel (`lib/index.js`) eagerly re-exports
+// `./workflow`, which patches the Workflow sandbox isolate runtime and pulls
+// in @temporalio/interceptors-opentelemetry's own `@opentelemetry/sdk-trace-base`
+// (pinned ^1.25.1). That collides with this repo's root `overrides` pin of
+// `@opentelemetry/core` to 2.10.0 (sdk-trace-base@1.x expects core@1.x's
+// `TracesSamplerValues` export, which core@2.x removed), crashing module load
+// in any process — including this one — that imports the bare package name.
+// `lib/client` only needs `@opentelemetry/api` and `@temporalio/common`, so
+// importing it directly avoids the incompatible transitive chain entirely.
 import {
   OpenTelemetryWorkflowClientInterceptor,
   type InterceptorOptions,
-} from "@temporalio/interceptors-opentelemetry";
+} from "@temporalio/interceptors-opentelemetry/lib/client/index.js";
 import {
   OpenTelemetryActivityInboundInterceptor,
   OpenTelemetryActivityOutboundInterceptor,

--- a/packages/temporal-observability/src/log-fields.ts
+++ b/packages/temporal-observability/src/log-fields.ts
@@ -1,0 +1,46 @@
+const SENSITIVE_FIELD_SEGMENTS = [
+  "args",
+  "apikey",
+  "authorization",
+  "cookie",
+  "credential",
+  "input",
+  "password",
+  "payload",
+  "playerdata",
+  "prompt",
+  "reportbody",
+  "result",
+  "secret",
+  "tasktoken",
+  "token",
+] as const;
+
+function normalizedFieldName(field: string): string {
+  return field.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+}
+
+export function isSensitiveTemporalLogField(field: string): boolean {
+  const normalized = normalizedFieldName(field);
+  return SENSITIVE_FIELD_SEGMENTS.some((segment) =>
+    normalized.includes(segment),
+  );
+}
+
+/**
+ * Remove fields that can contain Temporal payloads or application credentials.
+ *
+ * Temporal's default Activity log attributes include the base64 task token.
+ * Runtime log callbacks must apply this filter before serializing SDK metadata;
+ * values are never inspected or included in diagnostics.
+ */
+export function sanitizeTemporalLogFields(
+  fields: Readonly<Record<string, unknown>> | undefined,
+): Record<string, unknown> {
+  if (fields === undefined) return {};
+  return Object.fromEntries(
+    Object.entries(fields).filter(
+      ([field]) => !isSensitiveTemporalLogField(field),
+    ),
+  );
+}

--- a/packages/temporal-observability/src/tracing-resource.ts
+++ b/packages/temporal-observability/src/tracing-resource.ts
@@ -27,21 +27,30 @@ export type TracingRuntime = {
 };
 
 export type TracingResourceOptions = {
+  readonly domain?: string;
   readonly environment?: string;
   readonly namespace?: string;
   readonly taskQueue?: string;
   readonly workerRole?: string;
 };
 
+/**
+ * `defaultDomain` is caller-specific (packages/temporal's shared
+ * central-workflows process falls back to "platform"; Scout backend falls
+ * back to "scout") so it's a required argument here rather than baked into
+ * one shared default.
+ */
 export function buildTracingResource(
   serviceName: string,
   serviceVersion: string,
+  defaultDomain: string,
   options: TracingResourceOptions,
 ): Resource {
   return resourceFromAttributes({
     [ATTR_SERVICE_NAME]: serviceName,
     [ATTR_SERVICE_VERSION]: serviceVersion,
     "deployment.environment.name": options.environment ?? "dev",
+    "temporal.domain": options.domain ?? defaultDomain,
     "temporal.namespace": options.namespace ?? "default",
     "temporal.task_queue": options.taskQueue ?? "unknown",
     "temporal.worker.role": options.workerRole ?? "unknown",

--- a/packages/temporal-observability/test/log-fields.test.ts
+++ b/packages/temporal-observability/test/log-fields.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import {
+  isSensitiveTemporalLogField,
+  sanitizeTemporalLogFields,
+} from "@shepherdjerred/temporal-observability/log-fields";
+
+describe("Temporal log field safety", () => {
+  test.each([
+    "taskToken",
+    "authorization",
+    "api_key",
+    "workflow.payload",
+    "reportBody",
+    "player-data",
+    "systemPrompt",
+    "activityArgs",
+    "activityResult",
+  ])("rejects %s", (field) => {
+    expect(isSensitiveTemporalLogField(field)).toBe(true);
+  });
+
+  test("keeps safe execution context without reading sensitive values", () => {
+    const fields = sanitizeTemporalLogFields({
+      activityType: "refresh",
+      taskQueue: "reports",
+      workflowId: "report-refresh-2026-08-28",
+      taskToken: "must-not-escape",
+      reportBody: "must-not-escape",
+    });
+
+    expect(fields).toEqual({
+      activityType: "refresh",
+      taskQueue: "reports",
+      workflowId: "report-refresh-2026-08-28",
+    });
+  });
+});

--- a/packages/temporal/src/client.ts
+++ b/packages/temporal/src/client.ts
@@ -1,4 +1,5 @@
 import { Client, Connection } from "@temporalio/client";
+import { createTemporalClientTracingInterceptor } from "@shepherdjerred/temporal-observability/interceptors";
 import { parseTemporalBootstrap } from "#shared/temporal-bootstrap.ts";
 import { parseTemporalBootstrapMetadata } from "./shared/execution-metadata.ts";
 import { ExecutionMetadataClientInterceptor } from "./lib/execution-metadata-client-interceptor.ts";
@@ -19,11 +20,20 @@ export async function createTemporalClient(): Promise<Client> {
     Bun.env["ENVIRONMENT"],
     Bun.env["GIT_SHA"],
   );
+  // worker.ts's main() sets this once at boot from the same
+  // temporal-call-graph-tracing decision its own Worker uses, so an Activity
+  // that calls createTemporalClient() to start another workflow (e.g.
+  // deliverAgentTaskReport -> deliverReportWorkflow) propagates the active
+  // trace context into it instead of silently starting a disconnected trace.
+  const callGraphTracing = Bun.env["TEMPORAL_CALL_GRAPH_TRACING"] === "true";
   cachedClient = new Client({
     connection,
     namespace: bootstrap.namespace,
     interceptors: {
-      workflow: [new ExecutionMetadataClientInterceptor(bootstrapMetadata)],
+      workflow: [
+        new ExecutionMetadataClientInterceptor(bootstrapMetadata),
+        ...(callGraphTracing ? [createTemporalClientTracingInterceptor()] : []),
+      ],
     },
   });
   return cachedClient;

--- a/packages/temporal/src/lib/workflow-domain-interceptor.test.ts
+++ b/packages/temporal/src/lib/workflow-domain-interceptor.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, vi } from "vitest";
+
+const setAttribute = vi.fn();
+const getActiveSpan = vi.fn(
+  (): { setAttribute: typeof setAttribute } | undefined => ({ setAttribute }),
+);
+const workflowInfo = vi.fn();
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: { getActiveSpan },
+}));
+vi.mock("@temporalio/workflow", () => ({ workflowInfo }));
+
+const { WorkflowDomainTaggingInterceptor, interceptors } =
+  await import("./workflow-domain-interceptor.ts");
+
+describe("WorkflowDomainTaggingInterceptor", () => {
+  test("tags the active span with the execution domain derived from workflowType", async () => {
+    workflowInfo.mockReturnValue({
+      workflowType: "goodMorningWakeUp",
+      taskQueue: "monorepo-workflows",
+    });
+    const interceptor = new WorkflowDomainTaggingInterceptor();
+    const next = vi.fn(async () => "workflow result");
+
+    const result = await interceptor.execute({ headers: {}, args: [] }, next);
+
+    expect(result).toBe("workflow result");
+    expect(setAttribute).toHaveBeenCalledWith("temporal.domain", "home");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the taskQueue mapping for an unlisted workflowType", async () => {
+    workflowInfo.mockReturnValue({
+      workflowType: "someFutureWorkflow",
+      taskQueue: "home",
+    });
+    const interceptor = new WorkflowDomainTaggingInterceptor();
+
+    await interceptor.execute(
+      { headers: {}, args: [] },
+      vi.fn((): Promise<unknown> => Promise.resolve()),
+    );
+
+    expect(setAttribute).toHaveBeenCalledWith("temporal.domain", "home");
+  });
+
+  test("does not throw when no span is active", async () => {
+    getActiveSpan.mockReturnValueOnce(undefined);
+    workflowInfo.mockReturnValue({
+      workflowType: "goodMorningWakeUp",
+      taskQueue: "monorepo-workflows",
+    });
+    const interceptor = new WorkflowDomainTaggingInterceptor();
+
+    await expect(
+      interceptor.execute(
+        { headers: {}, args: [] },
+        vi.fn((): Promise<unknown> => Promise.resolve()),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  test("exports a WorkflowInterceptorsFactory that registers the interceptor inbound", () => {
+    const result = interceptors();
+    expect(result.inbound).toHaveLength(1);
+    expect(result.inbound?.[0]).toBeInstanceOf(
+      WorkflowDomainTaggingInterceptor,
+    );
+  });
+});

--- a/packages/temporal/src/lib/workflow-domain-interceptor.ts
+++ b/packages/temporal/src/lib/workflow-domain-interceptor.ts
@@ -1,0 +1,46 @@
+import { trace } from "@opentelemetry/api";
+import { workflowInfo } from "@temporalio/workflow";
+import type {
+  Next,
+  WorkflowExecuteInput,
+  WorkflowInboundCallsInterceptor,
+  WorkflowInterceptors,
+  WorkflowInterceptorsFactory,
+} from "@temporalio/workflow";
+import { executionDomainForWorkflow } from "#shared/execution-metadata.ts";
+import { TaskQueueSchema } from "#shared/task-queues.ts";
+
+/**
+ * The central Workflow-only process (worker.ts's "workflows" role) is shared
+ * across every domain — it polls TASK_QUEUES.WORKFLOWS plus every legacy
+ * per-domain queue it drains — so the OpenTelemetry Resource attribute set
+ * once at worker boot (installRuntime/initializeTracing) can only ever read
+ * "platform" for it: Resource attributes are process-wide and cannot vary
+ * per execution. Tag the RunWorkflow span itself with the real per-execution
+ * domain instead, so the temporal-platform-health dashboard's unscoped
+ * `.temporal.domain =~ "$domain"` TraceQL filter can still find the
+ * home/reports/etc. traces this shared process actually hosts.
+ *
+ * Registered in worker.ts's workflowModules list AFTER the official
+ * @temporalio/interceptors-opentelemetry module, so trace.getActiveSpan()
+ * here is the RunWorkflow span that interceptor already opened (interceptor
+ * composition runs modules' inbound interceptors in list order, each
+ * wrapping the next — see @temporalio/common's composeInterceptorsWith).
+ */
+export class WorkflowDomainTaggingInterceptor implements WorkflowInboundCallsInterceptor {
+  async execute(
+    input: WorkflowExecuteInput,
+    next: Next<WorkflowInboundCallsInterceptor, "execute">,
+  ): Promise<unknown> {
+    const info = workflowInfo();
+    const taskQueue = TaskQueueSchema.parse(info.taskQueue);
+    const domain = executionDomainForWorkflow(info.workflowType, taskQueue);
+    trace.getActiveSpan()?.setAttribute("temporal.domain", domain);
+    return await next(input);
+  }
+}
+
+export const interceptors: WorkflowInterceptorsFactory =
+  (): WorkflowInterceptors => ({
+    inbound: [new WorkflowDomainTaggingInterceptor()],
+  });

--- a/packages/temporal/src/observability/tracing.ts
+++ b/packages/temporal/src/observability/tracing.ts
@@ -75,7 +75,12 @@ export function initializeTracing(
   const otlpEndpoint = Bun.env["OTLP_ENDPOINT"] ?? DEFAULT_OTLP_ENDPOINT;
   const serviceName = Bun.env["TELEMETRY_SERVICE_NAME"] ?? DEFAULT_SERVICE_NAME;
   const serviceVersion = Bun.env["GIT_SHA"] ?? Bun.env["VERSION"] ?? "dev";
-  const resource = buildTracingResource(serviceName, serviceVersion, options);
+  const resource = buildTracingResource(
+    serviceName,
+    serviceVersion,
+    "platform",
+    options,
+  );
 
   const exporter = new LoggingSpanExporter(
     new OTLPTraceExporter({
@@ -148,6 +153,7 @@ export function initializeTracing(
     otlpEndpoint,
     lokiOtlpLogsEndpoint,
     environment: options.environment ?? "dev",
+    domain: options.domain ?? "platform",
     namespace: options.namespace ?? "default",
     taskQueue: options.taskQueue ?? "unknown",
     workerRole: options.workerRole ?? "unknown",

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -137,6 +137,7 @@ type CreateQueueWorkerOptions = {
   readonly connection: NativeConnection;
   readonly workflowsPath: string;
   readonly workflowUiInterceptorPath: string;
+  readonly domainTaggingInterceptorPath: string;
   readonly bootstrap: TemporalBootstrap;
   readonly temporalTracing: TemporalWorkerTracing | undefined;
 };
@@ -149,6 +150,7 @@ async function createQueueWorker(
     connection,
     workflowsPath,
     workflowUiInterceptorPath,
+    domainTaggingInterceptorPath,
     bootstrap,
     temporalTracing,
   } = options;
@@ -159,9 +161,14 @@ async function createQueueWorker(
       namespace: bootstrap.namespace,
       workflowsPath,
       interceptors: {
+        // domainTaggingInterceptorPath must stay after every tracing module:
+        // it tags the RunWorkflow span the official OpenTelemetry interceptor
+        // just opened (see workflow-domain-interceptor.ts), so it needs that
+        // span to already be active in context when its execute() runs.
         workflowModules: [
           workflowUiInterceptorPath,
           ...(temporalTracing?.workflowModules ?? []),
+          domainTaggingInterceptorPath,
         ],
       },
       ...(temporalTracing === undefined
@@ -370,6 +377,12 @@ async function main(): Promise<void> {
     bootstrap.namespace,
     bootstrapMetadata,
   );
+  // Boot-time-only, resolved once here rather than re-queried per call:
+  // client.ts's createTemporalClient() (used by Activities that start other
+  // workflows, e.g. deliverAgentTaskReport) reads this so its client carries
+  // the same tracing interceptor decision as this process's own Worker,
+  // instead of silently never tracing the workflows it starts.
+  Bun.env["TEMPORAL_CALL_GRAPH_TRACING"] = callGraphTracing ? "true" : "false";
 
   const address = Bun.env["TEMPORAL_ADDRESS"] ?? DEFAULT_ADDRESS;
   jsonLog("info", "Connecting to Temporal server", { address, role });
@@ -380,12 +393,17 @@ async function main(): Promise<void> {
   const workflowUiInterceptorPath = new URL(
     import.meta.resolve("@scout-for-lol/temporal/workflow-ui-interceptor"),
   ).pathname;
+  const domainTaggingInterceptorPath = new URL(
+    "lib/workflow-domain-interceptor.ts",
+    import.meta.url,
+  ).pathname;
   const workers: Worker[] = [];
   for (const definition of roleContract.workers) {
     const worker = await createQueueWorker(definition, {
       connection,
       workflowsPath,
       workflowUiInterceptorPath,
+      domainTaggingInterceptorPath,
       bootstrap,
       temporalTracing,
     });

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -18,7 +18,16 @@ import {
   startMetricsServer,
   stopMetricsServer,
 } from "./observability/metrics.ts";
-import { createStructuredLogger } from "./observability/logging.ts";
+// log() writes the same stdout JSON line the old createStructuredLogger()
+// jsonLog always has, then also emits an OTLP LogRecord through the
+// LoggerProvider initializeTracing() installs below. That's what lets the
+// platform dashboard's log panel filter SDK/worker-boot logs by
+// deployment_environment_name/temporal_domain (Resource attributes shared
+// with tracing) instead of only ever seeing them on stdout. Before tracing
+// initializes (or when TELEMETRY_ENABLED=false), the OTel logs API's default
+// no-op provider makes the emit() call a harmless no-op, same as the trace
+// API before NodeSDK.start().
+import { log as jsonLog } from "./observability/log.ts";
 import { restoreGlitterCorpusSnapshotMetrics } from "./activities/glitter-corpus-snapshot.ts";
 import { isTransientCorpusStorageError } from "./activities/glitter-corpus-store.ts";
 import { WORKFLOW_TASK_POLLER_BEHAVIOR } from "./shared/worker-options.ts";
@@ -52,8 +61,6 @@ import {
 
 const DEFAULT_ADDRESS = "temporal-server.temporal.svc.cluster.local:7233";
 const DEFAULT_METRICS_ADDRESS = "0.0.0.0:9464";
-
-const jsonLog = createStructuredLogger();
 
 function installRuntime(role: WorkerRole, bootstrap: TemporalBootstrap): void {
   const metricsAddress =

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -34,13 +34,17 @@ import {
   getWorkerRoleContract,
   type QueueWorkerDefinition,
 } from "./worker-config.ts";
-import { parseTemporalBootstrapMetadata } from "./shared/execution-metadata.ts";
+import {
+  executionDomainForTaskQueue,
+  parseTemporalBootstrapMetadata,
+} from "./shared/execution-metadata.ts";
 import { ExecutionMetadataClientInterceptor } from "./lib/execution-metadata-client-interceptor.ts";
 import {
   createTemporalClientTracingInterceptor,
   createTemporalWorkerTracing,
 } from "@shepherdjerred/temporal-observability/interceptors";
 import { createValidatedWorkflowSpanSink } from "@shepherdjerred/temporal-observability/workflow-span-sink";
+import { sanitizeTemporalLogFields } from "@shepherdjerred/temporal-observability/log-fields";
 import {
   initializeCallGraphTracing,
   shutdownCallGraphTracing,
@@ -66,7 +70,7 @@ function installRuntime(role: WorkerRole, bootstrap: TemporalBootstrap): void {
       jsonLog(level, entry.message, {
         sdk: "temporal",
         sdkLevel: entry.level,
-        metadata: entry.meta,
+        ...sanitizeTemporalLogFields(entry.meta),
       });
     }),
     telemetryOptions: {
@@ -245,11 +249,19 @@ async function initializeTemporalTracing(
   bootstrapMetadata: ReturnType<typeof parseTemporalBootstrapMetadata>,
 ) {
   const taskQueues = roleContract.workers.map((worker) => worker.taskQueue);
+  const soleWorker = roleContract.workers.at(0);
+  if (soleWorker === undefined && roleContract.workers.length === 1) {
+    throw new Error("Single-worker Temporal role has no Worker configuration");
+  }
   const callGraphTracing = await initializeCallGraphTracing({
     environment: bootstrapMetadata.environment,
     workerRole: role,
   });
   const tracingRuntime = initializeTracing({
+    domain:
+      soleWorker !== undefined && roleContract.workers.length === 1
+        ? executionDomainForTaskQueue(soleWorker.taskQueue)
+        : "platform",
     environment: bootstrapMetadata.environment,
     namespace,
     taskQueue: taskQueues.join(","),


### PR DESCRIPTION
## Why

Temporal call graphs, logs, and health signals were available only as disconnected sources. Operators also lacked one documented native-CLI path from an execution to its trace and correlated logs, while Temporal SDK Activity metadata can include the base64 task token.

## What

- add environment and domain resource attributes to central and Scout OpenTelemetry resources;
- add a Temporal Grafana surface with environment/domain filters, Temporal UI/Loki/Tempo links, call-graph traces, correlated logs, schedule delay, Workflow Task failures, nondeterminism, and terminal Activity failures;
- add matching Prometheus alerts;
- strip task tokens and payload-like fields at both Temporal Runtime logging boundaries before stdout or OTLP emission;
- document safe UI fields and the existing toolkit temporal, toolkit tempo, and toolkit loki diagnostic path without adding another toolkit command.

## Verification

- temporal-observability test, typecheck, and lint
- focused CDK8s dashboard and alert tests
- CDK8s typecheck and lint
- docs wiki build and lint
- central Temporal typecheck and focused lint
- focused Scout lint
- pre-commit hook
- Temporal UI URL returned HTTP 200 to a GET request

The full Scout backend typecheck currently fails across its generated branded-ID surface, including files untouched by this branch; this draft does not claim that gate is green.

## Rollout evidence still required

Keep this PR draft until a deployed beta worker proves the complete schedule/client to Workflow to Activity call graph, correlated Loki logs, and the rendered dashboard. Attach the Temporal UI, Grafana/Tempo, and rendered wiki screenshots before review. No live mutation or deployment was performed from this workspace.