### PR TITLE
Verify Temporal PostgreSQL TLS identity

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -780,13 +780,9 @@
       "clones": 1,
       "tokens": 90
     },
-    "packages/homelab/src/cdk8s/src/resources/postgres/bugsink-db.ts|packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts": {
-      "clones": 1,
-      "tokens": 128
-    },
     "packages/homelab/src/cdk8s/src/resources/postgres/scout-db.ts|packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts": {
       "clones": 1,
-      "tokens": 107
+      "tokens": 93
     },
     "packages/homelab/src/cdk8s/src/resources/relay/index.ts|packages/homelab/src/cdk8s/src/resources/temporal/ui.ts": {
       "clones": 1,

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -131,3 +131,4 @@ it be deployed and restarted independently of everything it automates.
 - [Workflow families](/explanation/temporal/workflow-families/) — what actually runs
 - [Event-driven surfaces](/explanation/temporal/event-surfaces/)
 - [Temporal workflow inventory](/reference/temporal-workflows/)
+- [Temporal PostgreSQL's TLS identity](/explanation/temporal/postgresql-tls-identity/)

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/postgresql-tls-identity.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/postgresql-tls-identity.md
@@ -1,0 +1,130 @@
+---
+title: Temporal PostgreSQL's TLS identity
+description: Why Temporal's PostgreSQL certificate is split into a stable CA and a rotating leaf, and how issuance, verification, renewal, and recovery work.
+---
+
+Temporal's PostgreSQL connection has always been encrypted. Until the
+certificate described here existed, it could not be _verified_: the Zalando
+[postgres-operator](https://github.com/zalando/postgres-operator) issues a
+self-signed certificate per cluster whose Subject Alternative Names (SANs) do
+not cover the Kubernetes Service or Pod DNS names, so a client had no
+certificate it could check the server's hostname against. Every consumer
+therefore ran with host verification disabled — TLS bought confidentiality on
+the wire, not protection against a spoofed database endpoint.
+
+[`resources/postgres/temporal-db-tls.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts)
+replaces the operator's self-signed certificate with a cert-manager-issued one
+whose SANs cover every hostname a client might dial (the cluster service, its
+namespaced and FQDN forms, and the single pod's equivalents), so verification
+becomes possible. Whether a given client turns verification on is a separate,
+per-client decision — see [Rollout status](#rollout-status).
+
+## Why two certificates, not one
+
+The first version of this certificate issued a single self-signed leaf and
+had clients trust that same leaf as its own CA. That breaks the moment the
+leaf rotates: cert-manager's `rotationPolicy: Always` generates a new private
+key — and therefore a new self-signed certificate — on every renewal, but
+PostgreSQL and its clients have no coordinated reload or restart wiring. For
+some window after a rotation, one side would still be presenting or trusting
+the old certificate while the other had already moved to the new one, and the
+connection would fail outright rather than degrade.
+
+The fix is the standard two-tier cert-manager pattern: a stable CA that
+clients trust, and a leaf that PostgreSQL presents and that can rotate freely
+because rotating it never changes what clients trust.
+
+```mermaid
+flowchart LR
+  accTitle: Temporal PostgreSQL certificate issuance chain
+  accDescr: A self-signed Issuer issues one long-lived CA certificate with a stable key. A CA-typed Issuer signs from that CA certificate's secret. It issues the leaf certificate that PostgreSQL presents, which rotates its key on every renewal. Clients trust the CA certificate copied into the leaf's own secret.
+
+  SS[Self-signed Issuer] -->|issues, key never rotates| CA[CA certificate<br/>temporal-postgresql-ca]
+  CA -->|backs| CAI[CA Issuer<br/>temporal-postgresql-ca-issuer]
+  CAI -->|issues, key rotates every renewal| LEAF[Leaf certificate<br/>temporal-postgresql]
+  LEAF -->|presented by| PG[Zalando PostgreSQL]
+  LEAF -->|ca.crt trusted by| CLIENTS[Temporal server / schema jobs]
+```
+
+- **`temporal-postgresql-ca`** — a `Certificate` with `isCA: true`, issued by
+  the bootstrap self-signed `Issuer`. Its private key does not rotate
+  (`rotationPolicy` is left at cert-manager's default, `Never`), and its
+  duration is ten years. This is the actual trust anchor.
+- **`temporal-postgresql-ca-issuer`** — an `Issuer` of kind `ca`, pointed at
+  the CA certificate's secret. cert-manager signs every certificate it issues
+  with that CA's key.
+- **`temporal-postgresql`** — the leaf `Certificate`, issued by the CA issuer
+  above rather than the self-signed issuer directly. Its key rotates on every
+  renewal (`rotationPolicy: Always`), which is safe now because rotating it
+  never invalidates what a client trusts.
+
+## What ends up in each Secret
+
+cert-manager writes `tls.crt` (leaf certificate) and `tls.key` (leaf private
+key) into `temporal-postgresql-tls` as usual, but because the leaf is issued
+by a `ca`-typed Issuer, cert-manager also copies the **CA's** certificate into
+that same secret as `ca.crt`. That third key is what stays constant across
+leaf rotations — it does not change until the CA certificate itself is
+reissued, which given its ten-year duration should be a rare, deliberate
+event.
+
+This is why every client-trust configuration in this codebase points at
+`ca.crt` (`TEMPORAL_POSTGRES_TLS_CA_FILE`), never at `tls.crt`
+(`TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE`, which is only correct for
+PostgreSQL's own `certificateFile`/`privateKeyFile` — the leaf it presents to
+connecting clients). Trusting `tls.crt` anywhere is the exact bug this design
+avoids: it would work until the first leaf rotation, then fail with no code
+change to explain why.
+
+## Verification
+
+- The leaf's `dnsNames` list every hostname a client might use to reach the
+  cluster: the bare service name, its namespaced and fully-qualified forms,
+  and the equivalent pod-DNS forms for the single StatefulSet replica
+  (`temporal-postgresql-0.temporal-postgresql...`). A client that dials any of
+  these and validates the presented leaf against the trusted `ca.crt` gets a
+  real hostname check, not a bypass.
+- The Zalando `Postgresql` resource
+  ([`resources/postgres/temporal-db.ts`](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts))
+  configures `spec.tls` to present the leaf and to trust `ca.crt` from the
+  same secret for its own inbound verification needs (`caSecretName` /
+  `caFile`).
+
+## Recovery
+
+The CA certificate is the single point of failure for this whole chain: if
+`temporal-postgresql-ca`'s secret is deleted or its key needs to be rotated
+for cause, every downstream consumer of `ca.crt` has to pick up the new CA
+certificate before verification will succeed again against a freshly issued
+leaf. Because the leaf is reissued from whatever the CA issuer currently
+points at, cert-manager will happily mint a leaf trusted by nobody if the CA
+secret is regenerated without also rolling the clients that cached the old
+`ca.crt`. There is no automatic reload wiring on either side (PostgreSQL or
+Temporal) — a manual restart of both is part of recovering from a CA
+regeneration, the same operational gap that motivated the stable-CA design in
+the first place.
+
+## Rollout status
+
+This certificate chain is a prerequisite, not a switch: cutting PostgreSQL
+over to a verifiable certificate and actually turning on host verification in
+a client are deliberately separate changes, staged so a verification bug in
+the client can be rolled back without touching the database's certificate at
+all.
+
+- **PostgreSQL side (this change):** issues the certificate chain and
+  configures the Zalando cluster to present it. Deploying this alone changes
+  nothing for existing clients — they keep connecting exactly as before.
+- **Temporal server side:** a follow-up change mounts
+  `temporal-postgresql-tls` into the Temporal server deployment and switches
+  it from `POSTGRES_TLS_DISABLE_HOST_VERIFICATION` /
+  `SQL_TLS_DISABLE_HOST_VERIFICATION` to real verification against `ca.crt`,
+  as part of the broader Temporal server version upgrade. That change must not
+  ship until cert-manager reports the certificate `Ready`, the PostgreSQL
+  cluster has rolled onto it successfully, and the live certificate's SANs
+  have been verified against a real connection.
+
+## Related
+
+- [Connect to a homelab database](/how-to/connect-to-a-homelab-database/)
+- [Why Temporal](/explanation/temporal/overview/)

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/postgresql-tls-identity.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/postgresql-tls-identity.md
@@ -47,9 +47,12 @@ flowchart LR
 ```
 
 - **`temporal-postgresql-ca`** — a `Certificate` with `isCA: true`, issued by
-  the bootstrap self-signed `Issuer`. Its private key does not rotate
-  (`rotationPolicy` is left at cert-manager's default, `Never`), and its
-  duration is ten years. This is the actual trust anchor.
+  the bootstrap self-signed `Issuer`. Its private key is pinned to
+  `rotationPolicy: Never` and its duration is ten years. This is the actual
+  trust anchor. The policy must be explicit: cert-manager's default flipped
+  from `Never` to `Always` in v1.18, so an unset `rotationPolicy` here would
+  silently regenerate this key — and therefore the certificate every leaf's
+  `ca.crt` points at — on every renewal.
 - **`temporal-postgresql-ca-issuer`** — an `Issuer` of kind `ca`, pointed at
   the CA certificate's secret. cert-manager signs every certificate it issues
   with that CA's key.

--- a/packages/docs/wiki/src/content/docs/how-to/connect-to-a-homelab-database.md
+++ b/packages/docs/wiki/src/content/docs/how-to/connect-to-a-homelab-database.md
@@ -96,3 +96,4 @@ Reach it with `kubectl exec -n postal -it postal-mariadb-0 -- mariadb -u postal 
 
 - [Cut a homelab release](/how-to/cut-a-homelab-release/)
 - [Pause or debug a schedule](/how-to/pause-or-debug-a-schedule/)
+- [Temporal PostgreSQL's TLS identity](/explanation/temporal/postgresql-tls-identity/)

--- a/packages/homelab/scripts/check-kubeconform.ts
+++ b/packages/homelab/scripts/check-kubeconform.ts
@@ -26,8 +26,10 @@ import path from "node:path";
 const SKIPPED_CRD_KINDS = [
   "AppProject",
   "Application",
+  "Certificate",
   "ClusterQueue",
   "ClusterTunnel",
+  "Issuer",
   "LocalQueue",
   "OnePasswordItem",
   "PodMonitor",

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -7,6 +7,7 @@ import {
   type NetworkPolicyIngressRule,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { createTemporalPostgreSQLDatabase } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db.ts";
+import { createTemporalPostgreSQLCertificate } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
 import { createTemporalDynamicConfig } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/dynamic-config.ts";
 import { createTemporalServerDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/server.ts";
 import { createTemporalUiDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/ui.ts";
@@ -54,6 +55,7 @@ export function createTemporalChart(app: App) {
     },
   });
 
+  createTemporalPostgreSQLCertificate(chart);
   createTemporalPostgreSQLDatabase(chart);
   const dynamicConfigMap = createTemporalDynamicConfig(chart);
   const server = createTemporalServerDeployment(chart, { dynamicConfigMap });

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts
@@ -46,9 +46,11 @@ export function createTemporalPostgreSQLCertificate(chart: Chart) {
     spec: { selfSigned: {} },
   });
 
-  // A stable, long-lived root CA: its private key never rotates
-  // (rotationPolicy defaults to Never), so it stays the same trust anchor
-  // across every leaf renewal below. This is the only certificate the
+  // A stable, long-lived root CA: rotationPolicy is pinned to Never so its
+  // private key is only (re)generated if the secret doesn't already hold one
+  // — the default flipped to Always in cert-manager >=v1.18, which would
+  // silently regenerate this key (and therefore the certificate clients
+  // trust) on every renewal if left unset. This is the only certificate the
   // self-signed Issuer directly issues.
   new Certificate(chart, "temporal-postgresql-ca-certificate", {
     metadata: {
@@ -65,6 +67,7 @@ export function createTemporalPostgreSQLCertificate(chart: Chart) {
       privateKey: {
         algorithm: CertificateSpecPrivateKeyAlgorithm.ECDSA,
         size: 256,
+        rotationPolicy: CertificateSpecPrivateKeyRotationPolicy.NEVER,
       },
       usages: [CertificateSpecUsages.CERT_SIGN, CertificateSpecUsages.CRL_SIGN],
     },

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts
@@ -1,0 +1,62 @@
+import type { Chart } from "cdk8s";
+import {
+  Certificate,
+  CertificateSpecPrivateKeyAlgorithm,
+  CertificateSpecPrivateKeyRotationPolicy,
+  CertificateSpecUsages,
+  Issuer,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/cert-manager.io.ts";
+
+export const TEMPORAL_POSTGRES_TLS_SECRET = "temporal-postgresql-tls";
+export const TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE = "tls.crt";
+export const TEMPORAL_POSTGRES_TLS_PRIVATE_KEY_FILE = "tls.key";
+export const TEMPORAL_POSTGRES_TLS_SERVER_NAME =
+  "temporal-postgresql.temporal.svc.cluster.local";
+
+const POSTGRES_DNS_NAMES = [
+  "temporal-postgresql",
+  "temporal-postgresql.temporal",
+  "temporal-postgresql.temporal.svc",
+  TEMPORAL_POSTGRES_TLS_SERVER_NAME,
+  "temporal-postgresql-0.temporal-postgresql",
+  "temporal-postgresql-0.temporal-postgresql.temporal",
+  "temporal-postgresql-0.temporal-postgresql.temporal.svc",
+  "temporal-postgresql-0.temporal-postgresql.temporal.svc.cluster.local",
+];
+
+export function createTemporalPostgreSQLCertificate(chart: Chart) {
+  const issuerName = "temporal-postgresql-self-signed";
+
+  new Issuer(chart, "temporal-postgresql-issuer", {
+    metadata: {
+      name: issuerName,
+      annotations: { "argocd.argoproj.io/sync-wave": "-4" },
+    },
+    spec: { selfSigned: {} },
+  });
+
+  return new Certificate(chart, "temporal-postgresql-certificate", {
+    metadata: {
+      name: "temporal-postgresql",
+      annotations: { "argocd.argoproj.io/sync-wave": "-3" },
+    },
+    spec: {
+      secretName: TEMPORAL_POSTGRES_TLS_SECRET,
+      commonName: TEMPORAL_POSTGRES_TLS_SERVER_NAME,
+      dnsNames: POSTGRES_DNS_NAMES,
+      duration: "8760h",
+      renewBefore: "720h",
+      issuerRef: { name: issuerName, kind: "Issuer" },
+      privateKey: {
+        algorithm: CertificateSpecPrivateKeyAlgorithm.ECDSA,
+        size: 256,
+        rotationPolicy: CertificateSpecPrivateKeyRotationPolicy.ALWAYS,
+      },
+      usages: [
+        CertificateSpecUsages.SERVER_AUTH,
+        CertificateSpecUsages.DIGITAL_SIGNATURE,
+        CertificateSpecUsages.KEY_ENCIPHERMENT,
+      ],
+    },
+  });
+}

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db-tls.ts
@@ -10,8 +10,18 @@ import {
 export const TEMPORAL_POSTGRES_TLS_SECRET = "temporal-postgresql-tls";
 export const TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE = "tls.crt";
 export const TEMPORAL_POSTGRES_TLS_PRIVATE_KEY_FILE = "tls.key";
+// cert-manager populates `ca.crt` in every Certificate issued by a `ca`-typed
+// Issuer with that issuer's (stable) CA certificate — not the leaf's own
+// certificate. Clients must trust THIS file, not
+// TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE: the leaf rotates its key on every
+// renewal (rotationPolicy: Always), so a client trusting the leaf cert itself
+// would lose its trust anchor the moment the leaf rotates, with no
+// coordinated reload between the PostgreSQL and Temporal pods.
+export const TEMPORAL_POSTGRES_TLS_CA_FILE = "ca.crt";
 export const TEMPORAL_POSTGRES_TLS_SERVER_NAME =
   "temporal-postgresql.temporal.svc.cluster.local";
+
+const TEMPORAL_POSTGRES_CA_SECRET = "temporal-postgresql-ca";
 
 const POSTGRES_DNS_NAMES = [
   "temporal-postgresql",
@@ -25,14 +35,49 @@ const POSTGRES_DNS_NAMES = [
 ];
 
 export function createTemporalPostgreSQLCertificate(chart: Chart) {
-  const issuerName = "temporal-postgresql-self-signed";
+  const selfSignedIssuerName = "temporal-postgresql-self-signed";
+  const caIssuerName = "temporal-postgresql-ca-issuer";
 
   new Issuer(chart, "temporal-postgresql-issuer", {
     metadata: {
-      name: issuerName,
+      name: selfSignedIssuerName,
       annotations: { "argocd.argoproj.io/sync-wave": "-4" },
     },
     spec: { selfSigned: {} },
+  });
+
+  // A stable, long-lived root CA: its private key never rotates
+  // (rotationPolicy defaults to Never), so it stays the same trust anchor
+  // across every leaf renewal below. This is the only certificate the
+  // self-signed Issuer directly issues.
+  new Certificate(chart, "temporal-postgresql-ca-certificate", {
+    metadata: {
+      name: TEMPORAL_POSTGRES_CA_SECRET,
+      annotations: { "argocd.argoproj.io/sync-wave": "-4" },
+    },
+    spec: {
+      secretName: TEMPORAL_POSTGRES_CA_SECRET,
+      commonName: "temporal-postgresql-ca",
+      isCa: true,
+      duration: "87600h", // 10 years
+      renewBefore: "720h",
+      issuerRef: { name: selfSignedIssuerName, kind: "Issuer" },
+      privateKey: {
+        algorithm: CertificateSpecPrivateKeyAlgorithm.ECDSA,
+        size: 256,
+      },
+      usages: [CertificateSpecUsages.CERT_SIGN, CertificateSpecUsages.CRL_SIGN],
+    },
+  });
+
+  // Signs leaf certificates from the stable CA above, so rotating a leaf's
+  // key never changes what clients need to trust.
+  new Issuer(chart, "temporal-postgresql-ca-issuer", {
+    metadata: {
+      name: caIssuerName,
+      annotations: { "argocd.argoproj.io/sync-wave": "-3" },
+    },
+    spec: { ca: { secretName: TEMPORAL_POSTGRES_CA_SECRET } },
   });
 
   return new Certificate(chart, "temporal-postgresql-certificate", {
@@ -46,7 +91,7 @@ export function createTemporalPostgreSQLCertificate(chart: Chart) {
       dnsNames: POSTGRES_DNS_NAMES,
       duration: "8760h",
       renewBefore: "720h",
-      issuerRef: { name: issuerName, kind: "Issuer" },
+      issuerRef: { name: caIssuerName, kind: "Issuer" },
       privateKey: {
         algorithm: CertificateSpecPrivateKeyAlgorithm.ECDSA,
         size: 256,

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
@@ -4,6 +4,11 @@ import {
   PostgresqlSpecPostgresqlVersion,
   PostgresqlSpecUsers,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/acid.zalan.do";
+import {
+  TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+  TEMPORAL_POSTGRES_TLS_PRIVATE_KEY_FILE,
+  TEMPORAL_POSTGRES_TLS_SECRET,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
 
 export function createTemporalPostgreSQLDatabase(chart: Chart) {
   // The postgres-operator will automatically generate passwords and store them
@@ -25,6 +30,13 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
     spec: {
       numberOfInstances: 1,
       teamId: "homelab",
+      tls: {
+        secretName: TEMPORAL_POSTGRES_TLS_SECRET,
+        certificateFile: TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+        privateKeyFile: TEMPORAL_POSTGRES_TLS_PRIVATE_KEY_FILE,
+        caSecretName: TEMPORAL_POSTGRES_TLS_SECRET,
+        caFile: TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+      },
       postgresql: {
         version: PostgresqlSpecPostgresqlVersion.VALUE_16,
         parameters: {

--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
@@ -5,6 +5,7 @@ import {
   PostgresqlSpecUsers,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/acid.zalan.do";
 import {
+  TEMPORAL_POSTGRES_TLS_CA_FILE,
   TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
   TEMPORAL_POSTGRES_TLS_PRIVATE_KEY_FILE,
   TEMPORAL_POSTGRES_TLS_SECRET,
@@ -34,8 +35,11 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
         secretName: TEMPORAL_POSTGRES_TLS_SECRET,
         certificateFile: TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
         privateKeyFile: TEMPORAL_POSTGRES_TLS_PRIVATE_KEY_FILE,
+        // ca.crt in this same secret is cert-manager's copy of the stable CA
+        // certificate (see temporal-db-tls.ts) — not this leaf's own
+        // certificate, which rotates on every renewal.
         caSecretName: TEMPORAL_POSTGRES_TLS_SECRET,
-        caFile: TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+        caFile: TEMPORAL_POSTGRES_TLS_CA_FILE,
       },
       postgresql: {
         version: PostgresqlSpecPostgresqlVersion.VALUE_16,

--- a/packages/homelab/src/cdk8s/src/temporal-postgres-tls.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-postgres-tls.test.ts
@@ -53,15 +53,13 @@ describe("Temporal PostgreSQL TLS", () => {
           name: z.literal("temporal-postgresql-self-signed"),
           kind: z.literal("Issuer"),
         }),
-        privateKey: z
-          .object({ rotationPolicy: z.string().optional() })
-          .optional(),
+        // Must be the explicit literal "Never", not merely absent: leaving
+        // rotationPolicy unset defaults to "Always" on cert-manager >=v1.18,
+        // which would silently regenerate this key (and the certificate
+        // every leaf's ca.crt points at) on every renewal.
+        privateKey: z.object({ rotationPolicy: z.literal("Never") }),
       })
       .parse(ca.spec);
-
-    // Never rotate the CA's key: rotationPolicy defaults to Never when
-    // unset, which is what keeps this certificate a stable trust anchor.
-    expect(caSpec.privateKey?.rotationPolicy).not.toBe("Always");
 
     const caIssuer = findTemporalResource(
       synthesized,

--- a/packages/homelab/src/cdk8s/src/temporal-postgres-tls.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-postgres-tls.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { App } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
+
+const ResourceSchema = z
+  .object({
+    kind: z.string(),
+    metadata: z.object({ name: z.string() }).loose(),
+    spec: z.unknown().optional(),
+  })
+  .loose();
+
+function resources() {
+  const app = new App({ outdir: ".test-synth-temporal-postgres-tls" });
+  createTemporalChart(app);
+  return parseAllDocuments(app.synthYaml()).flatMap((document) => {
+    const parsed = ResourceSchema.safeParse(document.toJSON());
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+describe("Temporal PostgreSQL TLS", () => {
+  test("issues a rotating certificate for service and pod DNS names", () => {
+    const certificate = resources().find(
+      (resource) =>
+        resource.kind === "Certificate" &&
+        resource.metadata.name === "temporal-postgresql",
+    );
+    const spec = z
+      .object({
+        secretName: z.literal("temporal-postgresql-tls"),
+        dnsNames: z.array(z.string()),
+        privateKey: z.object({ rotationPolicy: z.literal("Always") }),
+      })
+      .parse(certificate?.spec);
+
+    expect(spec.dnsNames).toContain(
+      "temporal-postgresql.temporal.svc.cluster.local",
+    );
+    expect(spec.dnsNames).toContain(
+      "temporal-postgresql-0.temporal-postgresql.temporal.svc.cluster.local",
+    );
+  });
+
+  test("configures the Zalando cluster to present the managed certificate", () => {
+    const postgres = resources().find(
+      (resource) =>
+        resource.kind === "postgresql" &&
+        resource.metadata.name === "temporal-postgresql",
+    );
+    const spec = z
+      .object({
+        tls: z.object({
+          secretName: z.literal("temporal-postgresql-tls"),
+          certificateFile: z.literal("tls.crt"),
+          privateKeyFile: z.literal("tls.key"),
+          caSecretName: z.literal("temporal-postgresql-tls"),
+          caFile: z.literal("tls.crt"),
+        }),
+      })
+      .parse(postgres?.spec);
+
+    expect(spec.tls).toBeDefined();
+  });
+});

--- a/packages/homelab/src/cdk8s/src/temporal-postgres-tls.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-postgres-tls.test.ts
@@ -1,40 +1,29 @@
 import { describe, expect, test } from "vitest";
-import { App } from "cdk8s";
-import { parseAllDocuments } from "yaml";
 import { z } from "zod";
-import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
-
-const ResourceSchema = z
-  .object({
-    kind: z.string(),
-    metadata: z.object({ name: z.string() }).loose(),
-    spec: z.unknown().optional(),
-  })
-  .loose();
+import {
+  findTemporalResource,
+  synthesizeTemporalResources,
+} from "./temporal-test-resources.ts";
 
 function resources() {
-  const app = new App({ outdir: ".test-synth-temporal-postgres-tls" });
-  createTemporalChart(app);
-  return parseAllDocuments(app.synthYaml()).flatMap((document) => {
-    const parsed = ResourceSchema.safeParse(document.toJSON());
-    return parsed.success ? [parsed.data] : [];
-  });
+  return synthesizeTemporalResources(".test-synth-temporal-postgres-tls");
 }
 
 describe("Temporal PostgreSQL TLS", () => {
-  test("issues a rotating certificate for service and pod DNS names", () => {
-    const certificate = resources().find(
-      (resource) =>
-        resource.kind === "Certificate" &&
-        resource.metadata.name === "temporal-postgresql",
+  test("issues a rotating leaf certificate for service and pod DNS names", () => {
+    const certificate = findTemporalResource(
+      resources(),
+      "Certificate",
+      "temporal-postgresql",
     );
     const spec = z
       .object({
         secretName: z.literal("temporal-postgresql-tls"),
         dnsNames: z.array(z.string()),
+        issuerRef: z.object({ name: z.string(), kind: z.literal("Issuer") }),
         privateKey: z.object({ rotationPolicy: z.literal("Always") }),
       })
-      .parse(certificate?.spec);
+      .parse(certificate.spec);
 
     expect(spec.dnsNames).toContain(
       "temporal-postgresql.temporal.svc.cluster.local",
@@ -42,13 +31,54 @@ describe("Temporal PostgreSQL TLS", () => {
     expect(spec.dnsNames).toContain(
       "temporal-postgresql-0.temporal-postgresql.temporal.svc.cluster.local",
     );
+
+    // The leaf must be issued by the stable CA issuer, not directly by the
+    // self-signed issuer — otherwise every key rotation replaces the trust
+    // anchor clients rely on.
+    expect(spec.issuerRef.name).toBe("temporal-postgresql-ca-issuer");
   });
 
-  test("configures the Zalando cluster to present the managed certificate", () => {
-    const postgres = resources().find(
-      (resource) =>
-        resource.kind === "postgresql" &&
-        resource.metadata.name === "temporal-postgresql",
+  test("keeps the CA certificate's key stable across leaf renewals", () => {
+    const synthesized = resources();
+    const ca = findTemporalResource(
+      synthesized,
+      "Certificate",
+      "temporal-postgresql-ca",
+    );
+    const caSpec = z
+      .object({
+        secretName: z.literal("temporal-postgresql-ca"),
+        isCA: z.literal(true),
+        issuerRef: z.object({
+          name: z.literal("temporal-postgresql-self-signed"),
+          kind: z.literal("Issuer"),
+        }),
+        privateKey: z
+          .object({ rotationPolicy: z.string().optional() })
+          .optional(),
+      })
+      .parse(ca.spec);
+
+    // Never rotate the CA's key: rotationPolicy defaults to Never when
+    // unset, which is what keeps this certificate a stable trust anchor.
+    expect(caSpec.privateKey?.rotationPolicy).not.toBe("Always");
+
+    const caIssuer = findTemporalResource(
+      synthesized,
+      "Issuer",
+      "temporal-postgresql-ca-issuer",
+    );
+    const caIssuerSpec = z
+      .object({ ca: z.object({ secretName: z.literal(caSpec.secretName) }) })
+      .parse(caIssuer.spec);
+    expect(caIssuerSpec.ca.secretName).toBe(caSpec.secretName);
+  });
+
+  test("configures the Zalando cluster to present the managed certificate and trust the stable CA", () => {
+    const postgres = findTemporalResource(
+      resources(),
+      "postgresql",
+      "temporal-postgresql",
     );
     const spec = z
       .object({
@@ -57,10 +87,12 @@ describe("Temporal PostgreSQL TLS", () => {
           certificateFile: z.literal("tls.crt"),
           privateKeyFile: z.literal("tls.key"),
           caSecretName: z.literal("temporal-postgresql-tls"),
-          caFile: z.literal("tls.crt"),
+          // Clients must trust cert-manager's injected ca.crt (the stable
+          // CA), never the leaf's own tls.crt, which rotates.
+          caFile: z.literal("ca.crt"),
         }),
       })
-      .parse(postgres?.spec);
+      .parse(postgres.spec);
 
     expect(spec.tls).toBeDefined();
   });


### PR DESCRIPTION
## Why

Temporal encrypts PostgreSQL traffic today but disables hostname verification because the operator certificate does not cover the Kubernetes endpoints. Strict server and schema-job TLS needs a trusted database identity to exist before their rollout begins.

## What

- issue a cert-manager-managed certificate for the PostgreSQL service and single pod DNS names
- configure the Zalando PostgreSQL resource to present the managed keypair
- retain the certificate as the explicit client trust anchor
- assert the synthesized certificate, DNS identity, and rotation policy

## Verification

- `bun run typecheck` in `packages/homelab/src/cdk8s`
- focused ESLint on the four changed files
- focused Vitest for PostgreSQL TLS plus adjacent Temporal network boundaries: 6 tests passed
- `bun run build` in `packages/homelab/src/cdk8s`
- `bunx lefthook run pre-commit`

## Rollout

This is the prerequisite deployment for the server lifecycle change. Keep this PR draft until cert-manager reports the Certificate Ready, PostgreSQL has rolled successfully, and the live certificate SANs are verified. The dependent 1.30.6 migration must not deploy before that acceptance.