### PR TITLE
Gate the Temporal 1.30 server upgrade

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -656,10 +656,6 @@
       "clones": 1,
       "tokens": 126
     },
-    "packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts": {
-      "clones": 1,
-      "tokens": 124
-    },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/birmel.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/trmnl-dashboard.ts": {
       "clones": 1,
       "tokens": 99
@@ -690,15 +686,11 @@
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/openrouter-broadcast-ingest.ts|packages/homelab/src/cdk8s/src/resources/temporal/agent-worker-network-policy.ts": {
       "clones": 1,
-      "tokens": 117
+      "tokens": 87
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts": {
       "clones": 3,
       "tokens": 339
-    },
-    "packages/homelab/src/cdk8s/src/cdk8s-charts/postal.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts": {
-      "clones": 2,
-      "tokens": 180
     },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/redlib.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/scout-evals.ts": {
       "clones": 1,
@@ -712,13 +704,9 @@
       "clones": 1,
       "tokens": 75
     },
-    "packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts|packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts": {
-      "clones": 1,
-      "tokens": 106
-    },
     "packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts|packages/homelab/src/cdk8s/src/resources/relay/index.ts": {
       "clones": 1,
-      "tokens": 108
+      "tokens": 88
     },
     "packages/homelab/src/cdk8s/src/misc/zfs-nvme-volume.ts|packages/homelab/src/cdk8s/src/misc/zfs-sata-volume.ts": {
       "clones": 1,

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -126,9 +126,28 @@ receives webhooks, and dispatches activities over named task queues.
 The rest of the repo talks to it only through its surfaces, which is what lets
 it be deployed and restarted independently of everything it automates.
 
+## Persistence changes happen before server changes
+
+The server process never creates or migrates its PostgreSQL schemas. An Argo
+PreSync hook runs the schema tools from the same Temporal release before the
+Deployment changes, after a separate hook proves a fresh successful Velero
+backup exists. If either hook fails, Argo leaves the currently running server
+in place.
+
+PostgreSQL presents a cert-manager certificate covering its Kubernetes service
+and pod names. Server and schema connections trust that certificate and verify
+the hostname; encryption without identity verification is not treated as a
+security boundary.
+
+This ordering makes a release recoverable: schemas move forward first because
+an older server can continue against a newer compatible schema, while a newer
+server on an older schema is unsafe. Each server version therefore gets its own
+deployment and runtime acceptance window.
+
 ## Related
 
 - [Workflow families](/explanation/temporal/workflow-families/) — what actually runs
 - [Event-driven surfaces](/explanation/temporal/event-surfaces/)
 - [Temporal workflow inventory](/reference/temporal-workflows/)
 - [Temporal PostgreSQL's TLS identity](/explanation/temporal/postgresql-tls-identity/)
+- [Upgrade the Temporal server](/how-to/upgrade-temporal-server/)

--- a/packages/docs/wiki/src/content/docs/how-to/upgrade-temporal-server.md
+++ b/packages/docs/wiki/src/content/docs/how-to/upgrade-temporal-server.md
@@ -1,0 +1,126 @@
+---
+title: Upgrade the Temporal server
+description: Stage a schema-first Temporal server upgrade, prove the database backup and TLS gates, and roll back the binary safely.
+sidebar:
+  order: 6
+---
+
+Temporal server releases are sequential production changes. Never combine two
+server versions into one rollout: deploy one version, collect runtime
+acceptance, and only then prepare the next pull request.
+
+## Before the first schema-managed release
+
+Deploy the PostgreSQL certificate change by itself. Wait for the
+`temporal-postgresql` Certificate to become Ready and for the single PostgreSQL
+pod to complete its rolling restart.
+
+```sh
+kubectl --namespace temporal wait \
+  --for=condition=Ready certificate/temporal-postgresql \
+  --timeout=5m
+
+kubectl --namespace temporal get certificate temporal-postgresql
+kubectl --namespace temporal rollout status statefulset/temporal-postgresql
+```
+
+Read the live certificate from the Secret and verify that its subject
+alternative names cover both the service and pod endpoints. Do not print the
+private key.
+
+```sh
+kubectl --namespace temporal get secret temporal-postgresql-tls \
+  --output jsonpath='{.data.tls\.crt}' |
+  base64 --decode |
+  openssl x509 -noout -subject -issuer -dates -ext subjectAltName
+```
+
+The service name
+`temporal-postgresql.temporal.svc.cluster.local` and the pod name
+`temporal-postgresql-0.temporal-postgresql.temporal.svc.cluster.local` must
+both appear.
+
+## Deploy one server version
+
+Confirm the pull request pins `temporalio/server` and
+`temporalio/admin-tools` to the same release. The first migration is 1.30.6.
+The 1.31.2 change is a separate future release and must not merge until the
+1.30.6 acceptance below is recorded.
+
+Argo runs two ordered PreSync hooks before touching the server Deployment:
+
+1. `temporal-backup-preflight` requires the newest `6hourly-backup` to be less
+   than seven hours old, completed without errors, and to have completed every
+   attempted volume snapshot.
+2. `temporal-schema-migration` runs the matching admin-tools image and updates
+   both the core and visibility PostgreSQL schemas over verified TLS.
+
+A failed hook fails the Argo sync, so the old server stays running. Do not skip
+or delete a failed hook to force the rollout. Repair the backup, certificate,
+database, or schema problem and retry the same release.
+
+Watch the gates and the Deployment:
+
+```sh
+kubectl --namespace temporal get jobs,pods --watch
+kubectl --namespace temporal logs job/temporal-backup-preflight
+kubectl --namespace temporal logs job/temporal-schema-migration
+kubectl --namespace temporal rollout status deployment/temporal-temporal-server
+```
+
+Successful hooks are deleted after completion. Read their logs while the sync
+is running or use Loki afterward.
+
+## Prove runtime acceptance
+
+Check the native server surfaces before considering the release complete:
+
+```sh
+toolkit temporal operator cluster health
+toolkit temporal operator namespace describe --namespace default
+toolkit temporal schedule list
+toolkit temporal workflow list --query "ExecutionStatus='Running'"
+```
+
+Then verify all of the following:
+
+- namespace retention remains 720 hours;
+- schedules retain their paused state and next-action times;
+- every expected workflow and Activity task queue has a poller;
+- one central canary and one Scout beta canary complete;
+- no Temporal server, workflow-task, nondeterminism, retry-exhaustion, or
+  poller alerts are active;
+- server and workflow-task error rates remain at their pre-release baseline;
+- PostgreSQL connections show certificate verification failures neither in
+  the server logs nor in Loki.
+
+Record the deployed server digest, both schema-hook results, canary execution
+IDs, alert state, and the acceptance window on the pull request or its Linear
+issue. Do not create a repository-local rollout journal.
+
+## Roll back the server binary
+
+Do not roll a database schema backward. Temporal supports deploying the older
+server binary against the already-upgraded schema during rollback.
+
+Revert only the server image pin to the last accepted release, keep the newer
+schema in place, and run the same backup and schema hooks. The schema update is
+idempotent and should report no pending migrations. After the old Deployment
+is healthy, repeat the runtime acceptance checks above.
+
+If the database or its certificate is unhealthy, stop. A server-image rollback
+does not repair persistence and must not be used to bypass a failed backup or
+TLS gate.
+
+## Advance to the next release
+
+Prepare 1.31.2 only after 1.30.6 has passed runtime acceptance. Update the
+server and admin-tools pins together, obtain another current successful Velero
+backup, and repeat the complete procedure. Never stack the unverified second
+upgrade on the first release branch.
+
+## Related
+
+- [Why Temporal](/explanation/temporal/overview/)
+- [Pause or debug a schedule](/how-to/pause-or-debug-a-schedule/)
+- [Temporal schedule mechanics](/reference/temporal-schedules/)

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -8,10 +8,12 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { createTemporalPostgreSQLDatabase } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db.ts";
 import { createTemporalPostgreSQLCertificate } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
+import { createTemporalBackupPreflightJob } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/backup-preflight.ts";
 import { createTemporalDynamicConfig } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/dynamic-config.ts";
 import { createTemporalServerDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/server.ts";
 import { createTemporalUiDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/ui.ts";
 import { createTemporalNamespaceInitJob } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/namespace-init.ts";
+import { createTemporalSchemaMigrationJob } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/schema-migration.ts";
 import { createTemporalWorkerDeployment } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker.ts";
 import { createTemporalAgentWorkerNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker-network-policy.ts";
 import { TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker.ts";
@@ -73,6 +75,8 @@ export function createTemporalChart(app: App) {
 
   createTemporalPostgreSQLCertificate(chart);
   createTemporalPostgreSQLDatabase(chart);
+  createTemporalBackupPreflightJob(chart);
+  createTemporalSchemaMigrationJob(chart);
   const dynamicConfigMap = createTemporalDynamicConfig(chart);
   const server = createTemporalServerDeployment(chart, { dynamicConfigMap });
   createTemporalUiDeployment(chart, { serverService: server.service });
@@ -344,7 +348,7 @@ export function createTemporalChart(app: App) {
     },
   });
 
-  // NetworkPolicy for PostgreSQL - only allow Temporal Server
+  // NetworkPolicy for PostgreSQL - only allow the server and schema hook.
   new KubeNetworkPolicy(chart, "temporal-postgresql-netpol", {
     metadata: { name: "temporal-postgresql-netpol" },
     spec: {
@@ -360,9 +364,73 @@ export function createTemporalChart(app: App) {
                 matchLabels: { app: "temporal-server" },
               },
             },
+            {
+              podSelector: {
+                matchLabels: { app: "temporal-schema-migration" },
+              },
+            },
           ],
           ports: [{ port: IntOrString.fromNumber(5432), protocol: "TCP" }],
         },
+      ],
+    },
+  });
+
+  new KubeNetworkPolicy(chart, "temporal-schema-migration-netpol", {
+    metadata: { name: "temporal-schema-migration-netpol" },
+    spec: {
+      podSelector: {
+        matchLabels: { app: "temporal-schema-migration" },
+      },
+      policyTypes: ["Egress"],
+      egress: [
+        {
+          to: [
+            {
+              namespaceSelector: {},
+              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+            },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(53), protocol: "UDP" },
+            { port: IntOrString.fromNumber(53), protocol: "TCP" },
+          ],
+        },
+        {
+          to: [
+            {
+              podSelector: {
+                matchLabels: { cluster_name: "temporal-postgresql" },
+              },
+            },
+          ],
+          ports: [{ port: IntOrString.fromNumber(5432), protocol: "TCP" }],
+        },
+      ],
+    },
+  });
+
+  new KubeNetworkPolicy(chart, "temporal-backup-preflight-netpol", {
+    metadata: { name: "temporal-backup-preflight-netpol" },
+    spec: {
+      podSelector: {
+        matchLabels: { app: "temporal-backup-preflight" },
+      },
+      policyTypes: ["Egress"],
+      egress: [
+        {
+          to: [
+            {
+              namespaceSelector: {},
+              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+            },
+          ],
+          ports: [
+            { port: IntOrString.fromNumber(53), protocol: "UDP" },
+            { port: IntOrString.fromNumber(53), protocol: "TCP" },
+          ],
+        },
+        { ports: [{ port: IntOrString.fromNumber(6443), protocol: "TCP" }] },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -4,6 +4,7 @@ import { Namespace } from "cdk8s-plus-31";
 import {
   IntOrString,
   KubeNetworkPolicy,
+  type NetworkPolicyEgressRule,
   type NetworkPolicyIngressRule,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { createTemporalPostgreSQLDatabase } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db.ts";
@@ -18,6 +19,23 @@ import { createTemporalWorkerDeployment } from "@shepherdjerred/homelab/cdk8s/sr
 import { createTemporalAgentWorkerNetworkPolicy } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker-network-policy.ts";
 import { TEMPORAL_AGENT_POD_SECURITY_ENFORCEMENT } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/agent-worker.ts";
 import { createTemporalWorkerNetworkPolicies } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker-network-policies.ts";
+
+// Every Temporal-namespace workload egresses to cluster DNS the same way;
+// shared here so it is declared once instead of drifting per-policy.
+function dnsEgressRule(): NetworkPolicyEgressRule {
+  return {
+    to: [
+      {
+        namespaceSelector: {},
+        podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
+      },
+    ],
+    ports: [
+      { port: IntOrString.fromNumber(53), protocol: "UDP" },
+      { port: IntOrString.fromNumber(53), protocol: "TCP" },
+    ],
+  };
+}
 
 function scoutCompetitionActivityIngress(): NetworkPolicyIngressRule {
   return {
@@ -250,19 +268,7 @@ export function createTemporalChart(app: App) {
         },
       ],
       egress: [
-        // DNS
-        {
-          to: [
-            {
-              namespaceSelector: {},
-              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
-            },
-          ],
-          ports: [
-            { port: IntOrString.fromNumber(53), protocol: "UDP" },
-            { port: IntOrString.fromNumber(53), protocol: "TCP" },
-          ],
-        },
+        dnsEgressRule(),
         // PostgreSQL within namespace
         {
           to: [
@@ -320,19 +326,7 @@ export function createTemporalChart(app: App) {
         },
       ],
       egress: [
-        // DNS
-        {
-          to: [
-            {
-              namespaceSelector: {},
-              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
-            },
-          ],
-          ports: [
-            { port: IntOrString.fromNumber(53), protocol: "UDP" },
-            { port: IntOrString.fromNumber(53), protocol: "TCP" },
-          ],
-        },
+        dnsEgressRule(),
         // Temporal Server gRPC
         {
           to: [
@@ -384,18 +378,7 @@ export function createTemporalChart(app: App) {
       },
       policyTypes: ["Egress"],
       egress: [
-        {
-          to: [
-            {
-              namespaceSelector: {},
-              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
-            },
-          ],
-          ports: [
-            { port: IntOrString.fromNumber(53), protocol: "UDP" },
-            { port: IntOrString.fromNumber(53), protocol: "TCP" },
-          ],
-        },
+        dnsEgressRule(),
         {
           to: [
             {
@@ -418,18 +401,7 @@ export function createTemporalChart(app: App) {
       },
       policyTypes: ["Egress"],
       egress: [
-        {
-          to: [
-            {
-              namespaceSelector: {},
-              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
-            },
-          ],
-          ports: [
-            { port: IntOrString.fromNumber(53), protocol: "UDP" },
-            { port: IntOrString.fromNumber(53), protocol: "TCP" },
-          ],
-        },
+        dnsEgressRule(),
         { ports: [{ port: IntOrString.fromNumber(6443), protocol: "TCP" }] },
       ],
     },
@@ -444,19 +416,7 @@ export function createTemporalChart(app: App) {
       },
       policyTypes: ["Egress"],
       egress: [
-        // DNS
-        {
-          to: [
-            {
-              namespaceSelector: {},
-              podSelector: { matchLabels: { "k8s-app": "kube-dns" } },
-            },
-          ],
-          ports: [
-            { port: IntOrString.fromNumber(53), protocol: "UDP" },
-            { port: IntOrString.fromNumber(53), protocol: "TCP" },
-          ],
-        },
+        dnsEgressRule(),
         // Temporal Server gRPC
         {
           to: [

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -343,8 +343,25 @@ export function createTemporalChart(app: App) {
   });
 
   // NetworkPolicy for PostgreSQL - only allow the server and schema hook.
+  //
+  // This must itself be a PreSync hook, staged ahead of the schema-migration
+  // Job's own PreSync wave (-1): PreSync hooks run in a phase that completes
+  // in full before ANY ordinary (non-hook) resource is applied, regardless of
+  // sync-wave. Left as a plain resource, ArgoCD would only add the
+  // temporal-schema-migration ingress rule below during the later Sync
+  // phase — after the schema-migration Job has already run (and had its
+  // PostgreSQL connection dropped by the netpol that predates this rule).
+  // No hook-delete-policy is set, so this persists as an ordinary tracked
+  // resource after creation and simply keeps being reconciled in PreSync on
+  // every subsequent sync.
   new KubeNetworkPolicy(chart, "temporal-postgresql-netpol", {
-    metadata: { name: "temporal-postgresql-netpol" },
+    metadata: {
+      name: "temporal-postgresql-netpol",
+      annotations: {
+        "argocd.argoproj.io/hook": "PreSync",
+        "argocd.argoproj.io/sync-wave": "-3",
+      },
+    },
     spec: {
       podSelector: {
         matchLabels: { cluster_name: "temporal-postgresql" },

--- a/packages/homelab/src/cdk8s/src/maintenance-worker-network-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/maintenance-worker-network-policy.test.ts
@@ -111,8 +111,15 @@ describe("maintenance worker network boundary", () => {
       return result.success ? [result.data] : [];
     });
     const jobs = namedResources.filter((resource) => resource.kind === "Job");
-    expect(jobs).toHaveLength(1);
-    expect(jobs[0]?.metadata?.name).toBe("temporal-namespace-init");
+    expect(
+      jobs
+        .map((job) => job.metadata?.name)
+        .sort((left, right) => (left ?? "").localeCompare(right ?? "")),
+    ).toEqual([
+      "temporal-backup-preflight",
+      "temporal-namespace-init",
+      "temporal-schema-migration",
+    ]);
     expect(
       namedResources.filter((resource) => resource.kind === "CronJob"),
     ).toHaveLength(0);

--- a/packages/homelab/src/cdk8s/src/resources/temporal/backup-preflight.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/backup-preflight.ts
@@ -1,0 +1,144 @@
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import { Cpu, Job, ServiceAccount } from "cdk8s-plus-31";
+import {
+  KubeRole,
+  KubeRoleBinding,
+} from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
+import { withCommonProps } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+const BACKUP_SCHEDULE_NAME = "6hourly-backup";
+const MAXIMUM_BACKUP_AGE_SECONDS = 7 * 60 * 60;
+
+const BACKUP_PREFLIGHT_SCRIPT = String.raw`
+set -eu -o pipefail
+
+backup_name=$(kubectl get backups.velero.io \
+  --namespace velero \
+  --selector velero.io/schedule-name=${BACKUP_SCHEDULE_NAME} \
+  --sort-by=.status.completionTimestamp \
+  --output jsonpath='{.items[-1:].metadata.name}')
+
+if [ -z "$backup_name" ]; then
+  echo "No completed candidate exists for ${BACKUP_SCHEDULE_NAME}" >&2
+  exit 1
+fi
+
+phase=$(kubectl get backup.velero.io "$backup_name" --namespace velero --output jsonpath='{.status.phase}')
+completed_at=$(kubectl get backup.velero.io "$backup_name" --namespace velero --output jsonpath='{.status.completionTimestamp}')
+errors=$(kubectl get backup.velero.io "$backup_name" --namespace velero --output jsonpath='{.status.errors}')
+snapshots_attempted=$(kubectl get backup.velero.io "$backup_name" --namespace velero --output jsonpath='{.status.volumeSnapshotsAttempted}')
+snapshots_completed=$(kubectl get backup.velero.io "$backup_name" --namespace velero --output jsonpath='{.status.volumeSnapshotsCompleted}')
+selector=$(kubectl get backup.velero.io "$backup_name" --namespace velero --output jsonpath='{.spec.labelSelector.matchLabels.velero\.io/backup}')
+
+if [ "$phase" != "Completed" ]; then
+  echo "Backup $backup_name is not completed" >&2
+  exit 1
+fi
+
+if [ "$selector" != "enabled" ]; then
+  echo "Backup $backup_name does not select backup-enabled resources" >&2
+  exit 1
+fi
+
+case "$errors:$snapshots_attempted:$snapshots_completed" in
+  *[!0-9:]*|::*|*::|:*)
+    echo "Backup $backup_name has incomplete numeric status" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$errors" -ne 0 ]; then
+  echo "Backup $backup_name contains errors" >&2
+  exit 1
+fi
+
+if [ "$snapshots_attempted" -le 0 ] || [ "$snapshots_completed" -ne "$snapshots_attempted" ]; then
+  echo "Backup $backup_name did not complete every volume snapshot" >&2
+  exit 1
+fi
+
+completed_epoch=$(date -d "$completed_at" +%s)
+current_epoch=$(date +%s)
+age_seconds=$((current_epoch - completed_epoch))
+
+if [ "$age_seconds" -lt 0 ] || [ "$age_seconds" -gt ${MAXIMUM_BACKUP_AGE_SECONDS} ]; then
+  echo "Backup $backup_name is outside the seven-hour release window" >&2
+  exit 1
+fi
+
+echo "Backup $backup_name satisfies the Temporal server upgrade preflight"
+`.trim();
+
+export function createTemporalBackupPreflightJob(chart: Chart) {
+  const serviceAccount = new ServiceAccount(
+    chart,
+    "temporal-backup-preflight-service-account",
+    { metadata: { name: "temporal-backup-preflight" } },
+  );
+
+  new KubeRole(chart, "temporal-backup-preflight-role", {
+    metadata: { name: "temporal-backup-preflight", namespace: "velero" },
+    rules: [
+      {
+        apiGroups: ["velero.io"],
+        resources: ["backups"],
+        verbs: ["get", "list"],
+      },
+    ],
+  });
+
+  new KubeRoleBinding(chart, "temporal-backup-preflight-role-binding", {
+    metadata: { name: "temporal-backup-preflight", namespace: "velero" },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "Role",
+      name: "temporal-backup-preflight",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: serviceAccount.name,
+        namespace: "temporal",
+      },
+    ],
+  });
+
+  const job = new Job(chart, "temporal-backup-preflight", {
+    metadata: {
+      name: "temporal-backup-preflight",
+      annotations: {
+        "argocd.argoproj.io/hook": "PreSync",
+        "argocd.argoproj.io/sync-wave": "-2",
+        "argocd.argoproj.io/hook-delete-policy":
+          "BeforeHookCreation,HookSucceeded",
+      },
+    },
+    serviceAccount,
+    backoffLimit: 1,
+    activeDeadline: Duration.minutes(2),
+    podMetadata: { labels: { app: "temporal-backup-preflight" } },
+  });
+
+  job.addContainer(
+    withCommonProps({
+      name: "backup-preflight",
+      image: `bitnamilegacy/kubectl:${versions["bitnamilegacy/kubectl"]}`,
+      command: ["/bin/bash", "-c"],
+      args: [BACKUP_PREFLIGHT_SCRIPT],
+      securityContext: {
+        user: 1001,
+        group: 1001,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+      },
+      resources: {
+        cpu: { request: Cpu.millis(10), limit: Cpu.millis(100) },
+        memory: { request: Size.mebibytes(32), limit: Size.mebibytes(128) },
+      },
+    }),
+  );
+
+  return job;
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/backup-preflight.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/backup-preflight.ts
@@ -2,6 +2,8 @@ import type { Chart } from "cdk8s";
 import { Duration, Size } from "cdk8s";
 import { Cpu, Job, ServiceAccount } from "cdk8s-plus-31";
 import {
+  KubeClusterRole,
+  KubeClusterRoleBinding,
   KubeRole,
   KubeRoleBinding,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
@@ -10,6 +12,9 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 const BACKUP_SCHEDULE_NAME = "6hourly-backup";
 const MAXIMUM_BACKUP_AGE_SECONDS = 7 * 60 * 60;
+const TEMPORAL_POSTGRES_PVC_NAMESPACE = "temporal";
+const TEMPORAL_POSTGRES_PVC_NAME = "pgdata-temporal-postgresql-0";
+const BACKUP_ENABLED_LABEL = "velero.io/backup";
 
 const BACKUP_PREFLIGHT_SCRIPT = String.raw`
 set -eu -o pipefail
@@ -59,6 +64,37 @@ if [ "$snapshots_attempted" -le 0 ] || [ "$snapshots_completed" -ne "$snapshots_
   exit 1
 fi
 
+# The aggregate counters above are cluster-wide: they can be positive and
+# equal purely because OTHER backup-enabled PVCs succeeded, even if this
+# specific Temporal PVC was never selected or its snapshot silently failed to
+# attempt. The openebs zfs-localpv plugin (per-PVC "zfs send", not Velero's
+# CSI DataUpload machinery) records no separate per-PVC status object we can
+# query, so instead prove the Temporal PVC's snapshot specifically by
+# cross-referencing against the live PVC inventory: first confirm it still
+# carries the label the backup selected on, then confirm the counters equal
+# the CURRENT count of backup-enabled PVCs cluster-wide. If every
+# backup-enabled PVC that exists right now was attempted and completed, the
+# Temporal PVC — already confirmed to be one of them — cannot have been
+# omitted or have failed silently.
+temporal_pvc_label=$(kubectl get persistentvolumeclaim ${TEMPORAL_POSTGRES_PVC_NAME} \
+  --namespace ${TEMPORAL_POSTGRES_PVC_NAMESPACE} \
+  --output jsonpath='{.metadata.labels.velero\.io/backup}')
+
+if [ "$temporal_pvc_label" != "enabled" ]; then
+  echo "${TEMPORAL_POSTGRES_PVC_NAME} in namespace ${TEMPORAL_POSTGRES_PVC_NAMESPACE} is not labeled ${BACKUP_ENABLED_LABEL}=enabled" >&2
+  exit 1
+fi
+
+enabled_pvc_count=$(kubectl get persistentvolumeclaims \
+  --all-namespaces \
+  --selector ${BACKUP_ENABLED_LABEL}=enabled \
+  --output jsonpath='{.items[*].metadata.name}' | wc -w | tr -d ' ')
+
+if [ "$enabled_pvc_count" -le 0 ] || [ "$snapshots_attempted" -ne "$enabled_pvc_count" ]; then
+  echo "Backup $backup_name attempted $snapshots_attempted snapshot(s) but $enabled_pvc_count PVC(s) are currently backup-enabled — cannot prove ${TEMPORAL_POSTGRES_PVC_NAME} was included" >&2
+  exit 1
+fi
+
 completed_epoch=$(date -d "$completed_at" +%s)
 current_epoch=$(date +%s)
 age_seconds=$((current_epoch - completed_epoch))
@@ -71,15 +107,35 @@ fi
 echo "Backup $backup_name satisfies the Temporal server upgrade preflight"
 `.trim();
 
+// PreSync hooks run in their own hook phase, strictly before ANY ordinary
+// (non-hook) resource is applied — sync-wave only orders resources within the
+// same phase. Without a hook annotation of their own, this RBAC would be a
+// plain Sync-phase resource that ArgoCD only applies AFTER the PreSync Job
+// below has already tried (and failed, on a first sync) to run as that
+// ServiceAccount. -3 puts it a full wave ahead of the Job's own -2.
+const RBAC_HOOK_ANNOTATIONS = {
+  "argocd.argoproj.io/hook": "PreSync",
+  "argocd.argoproj.io/sync-wave": "-3",
+};
+
 export function createTemporalBackupPreflightJob(chart: Chart) {
   const serviceAccount = new ServiceAccount(
     chart,
     "temporal-backup-preflight-service-account",
-    { metadata: { name: "temporal-backup-preflight" } },
+    {
+      metadata: {
+        name: "temporal-backup-preflight",
+        annotations: RBAC_HOOK_ANNOTATIONS,
+      },
+    },
   );
 
   new KubeRole(chart, "temporal-backup-preflight-role", {
-    metadata: { name: "temporal-backup-preflight", namespace: "velero" },
+    metadata: {
+      name: "temporal-backup-preflight",
+      namespace: "velero",
+      annotations: RBAC_HOOK_ANNOTATIONS,
+    },
     rules: [
       {
         apiGroups: ["velero.io"],
@@ -90,7 +146,11 @@ export function createTemporalBackupPreflightJob(chart: Chart) {
   });
 
   new KubeRoleBinding(chart, "temporal-backup-preflight-role-binding", {
-    metadata: { name: "temporal-backup-preflight", namespace: "velero" },
+    metadata: {
+      name: "temporal-backup-preflight",
+      namespace: "velero",
+      annotations: RBAC_HOOK_ANNOTATIONS,
+    },
     roleRef: {
       apiGroup: "rbac.authorization.k8s.io",
       kind: "Role",
@@ -104,6 +164,47 @@ export function createTemporalBackupPreflightJob(chart: Chart) {
       },
     ],
   });
+
+  // Cluster-wide, read-only: proving the Temporal PVC's snapshot specifically
+  // succeeded (see BACKUP_PREFLIGHT_SCRIPT) needs the current count of every
+  // backup-enabled PVC across every namespace, not only the temporal
+  // namespace's own PVC.
+  new KubeClusterRole(chart, "temporal-backup-preflight-pvc-reader", {
+    metadata: {
+      name: "temporal-backup-preflight-pvc-reader",
+      annotations: RBAC_HOOK_ANNOTATIONS,
+    },
+    rules: [
+      {
+        apiGroups: [""],
+        resources: ["persistentvolumeclaims"],
+        verbs: ["get", "list"],
+      },
+    ],
+  });
+
+  new KubeClusterRoleBinding(
+    chart,
+    "temporal-backup-preflight-pvc-reader-binding",
+    {
+      metadata: {
+        name: "temporal-backup-preflight-pvc-reader",
+        annotations: RBAC_HOOK_ANNOTATIONS,
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "ClusterRole",
+        name: "temporal-backup-preflight-pvc-reader",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: serviceAccount.name,
+          namespace: "temporal",
+        },
+      ],
+    },
+  );
 
   const job = new Job(chart, "temporal-backup-preflight", {
     metadata: {

--- a/packages/homelab/src/cdk8s/src/resources/temporal/namespace-init.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/namespace-init.ts
@@ -1,7 +1,7 @@
 import type { Chart } from "cdk8s";
 import { Size } from "cdk8s";
 import type { Service } from "cdk8s-plus-31";
-import { Cpu, Job, Secret, Volume } from "cdk8s-plus-31";
+import { Cpu, Job } from "cdk8s-plus-31";
 import { withCommonProps } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
@@ -49,22 +49,6 @@ export function createTemporalNamespaceInitJob(
     },
   });
 
-  // Mount postgres secret for admin-tools DB access
-  const postgresSecretName =
-    "temporal.temporal-postgresql.credentials.postgresql.acid.zalan.do";
-  const pgSecretVolume = Volume.fromSecret(
-    chart,
-    "namespace-init-pg-secret-volume",
-    Secret.fromSecretName(
-      chart,
-      "namespace-init-pg-secret",
-      postgresSecretName,
-    ),
-    {
-      name: "pg-secret",
-    },
-  );
-
   job.addContainer(
     withCommonProps({
       name: "namespace-init",
@@ -97,15 +81,8 @@ export function createTemporalNamespaceInitJob(
         user: UID,
         group: GID,
         ensureNonRoot: true,
-        readOnlyRootFilesystem: false,
+        readOnlyRootFilesystem: true,
       },
-      volumeMounts: [
-        {
-          path: "/pg-secret",
-          volume: pgSecretVolume,
-          readOnly: true,
-        },
-      ],
       resources: {
         cpu: {
           request: Cpu.millis(50),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/schema-migration.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/schema-migration.ts
@@ -3,7 +3,7 @@ import { Duration, Size } from "cdk8s";
 import { Cpu, EnvValue, Job, Secret, Volume } from "cdk8s-plus-31";
 import { withCommonProps } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import {
-  TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+  TEMPORAL_POSTGRES_TLS_CA_FILE,
   TEMPORAL_POSTGRES_TLS_SECRET,
   TEMPORAL_POSTGRES_TLS_SERVER_NAME,
 } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
@@ -12,7 +12,11 @@ import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 const POSTGRES_SECRET_NAME =
   "temporal.temporal-postgresql.credentials.postgresql.acid.zalan.do";
 const POSTGRES_TLS_DIRECTORY = "/etc/temporal/postgres-tls";
-const POSTGRES_TLS_CA_FILE = `${POSTGRES_TLS_DIRECTORY}/${TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE}`;
+// Trust the stable CA (see temporal-db-tls.ts), not the rotating leaf's own
+// tls.crt — this Job is short-lived and re-reads the mounted secret fresh on
+// every run, but a leaf rotation between runs would still make tls.crt
+// untrustworthy the moment cert-manager regenerates it.
+const POSTGRES_TLS_CA_FILE_PATH = `${POSTGRES_TLS_DIRECTORY}/${TEMPORAL_POSTGRES_TLS_CA_FILE}`;
 
 const SCHEMA_MIGRATION_SCRIPT = String.raw`
 set -eu -o pipefail
@@ -110,7 +114,7 @@ export function createTemporalSchemaMigrationJob(chart: Chart) {
           secret: postgresSecret,
           key: "password",
         }),
-        POSTGRES_TLS_CA_FILE: EnvValue.fromValue(POSTGRES_TLS_CA_FILE),
+        POSTGRES_TLS_CA_FILE: EnvValue.fromValue(POSTGRES_TLS_CA_FILE_PATH),
         POSTGRES_TLS_SERVER_NAME: EnvValue.fromValue(
           TEMPORAL_POSTGRES_TLS_SERVER_NAME,
         ),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/schema-migration.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/schema-migration.ts
@@ -1,0 +1,139 @@
+import type { Chart } from "cdk8s";
+import { Duration, Size } from "cdk8s";
+import { Cpu, EnvValue, Job, Secret, Volume } from "cdk8s-plus-31";
+import { withCommonProps } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import {
+  TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+  TEMPORAL_POSTGRES_TLS_SECRET,
+  TEMPORAL_POSTGRES_TLS_SERVER_NAME,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+
+const POSTGRES_SECRET_NAME =
+  "temporal.temporal-postgresql.credentials.postgresql.acid.zalan.do";
+const POSTGRES_TLS_DIRECTORY = "/etc/temporal/postgres-tls";
+const POSTGRES_TLS_CA_FILE = `${POSTGRES_TLS_DIRECTORY}/${TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE}`;
+
+const SCHEMA_MIGRATION_SCRIPT = String.raw`
+set -eu -o pipefail
+
+temporal-sql-tool \\
+  --plugin postgres12 \\
+  --ep ${TEMPORAL_POSTGRES_TLS_SERVER_NAME} \\
+  -p 5432 \\
+  -u "$POSTGRES_USER" \\
+  --db temporal \\
+  --tls=true \\
+  --tls-ca-file "$POSTGRES_TLS_CA_FILE" \\
+  --tls-server-name "$POSTGRES_TLS_SERVER_NAME" \\
+  setup-schema -v 0.0
+
+temporal-sql-tool \\
+  --plugin postgres12 \\
+  --ep ${TEMPORAL_POSTGRES_TLS_SERVER_NAME} \\
+  -p 5432 \\
+  -u "$POSTGRES_USER" \\
+  --db temporal \\
+  --tls=true \\
+  --tls-ca-file "$POSTGRES_TLS_CA_FILE" \\
+  --tls-server-name "$POSTGRES_TLS_SERVER_NAME" \\
+  update-schema -d /etc/temporal/schema/postgresql/v12/temporal/versioned
+
+temporal-sql-tool \\
+  --plugin postgres12 \\
+  --ep ${TEMPORAL_POSTGRES_TLS_SERVER_NAME} \\
+  -p 5432 \\
+  -u "$POSTGRES_USER" \\
+  --db temporal_visibility \\
+  --tls=true \\
+  --tls-ca-file "$POSTGRES_TLS_CA_FILE" \\
+  --tls-server-name "$POSTGRES_TLS_SERVER_NAME" \\
+  setup-schema -v 0.0
+
+temporal-sql-tool \\
+  --plugin postgres12 \\
+  --ep ${TEMPORAL_POSTGRES_TLS_SERVER_NAME} \\
+  -p 5432 \\
+  -u "$POSTGRES_USER" \\
+  --db temporal_visibility \\
+  --tls=true \\
+  --tls-ca-file "$POSTGRES_TLS_CA_FILE" \\
+  --tls-server-name "$POSTGRES_TLS_SERVER_NAME" \\
+  update-schema -d /etc/temporal/schema/postgresql/v12/visibility/versioned
+`.trim();
+
+export function createTemporalSchemaMigrationJob(chart: Chart) {
+  const postgresSecret = Secret.fromSecretName(
+    chart,
+    "temporal-schema-postgres-secret",
+    POSTGRES_SECRET_NAME,
+  );
+  const tlsVolume = Volume.fromSecret(
+    chart,
+    "temporal-schema-postgres-tls-volume",
+    Secret.fromSecretName(
+      chart,
+      "temporal-schema-postgres-tls-secret",
+      TEMPORAL_POSTGRES_TLS_SECRET,
+    ),
+    { name: "postgres-tls" },
+  );
+
+  const job = new Job(chart, "temporal-schema-migration", {
+    metadata: {
+      name: "temporal-schema-migration",
+      annotations: {
+        "argocd.argoproj.io/hook": "PreSync",
+        "argocd.argoproj.io/sync-wave": "-1",
+        "argocd.argoproj.io/hook-delete-policy":
+          "BeforeHookCreation,HookSucceeded",
+      },
+    },
+    automountServiceAccountToken: false,
+    backoffLimit: 1,
+    activeDeadline: Duration.seconds(900),
+    podMetadata: { labels: { app: "temporal-schema-migration" } },
+  });
+
+  job.addContainer(
+    withCommonProps({
+      name: "schema-migration",
+      image: `temporalio/admin-tools:${versions["temporalio/admin-tools"]}`,
+      command: ["/bin/bash", "-c"],
+      args: [SCHEMA_MIGRATION_SCRIPT],
+      envVariables: {
+        POSTGRES_USER: EnvValue.fromSecretValue({
+          secret: postgresSecret,
+          key: "username",
+        }),
+        SQL_PASSWORD: EnvValue.fromSecretValue({
+          secret: postgresSecret,
+          key: "password",
+        }),
+        POSTGRES_TLS_CA_FILE: EnvValue.fromValue(POSTGRES_TLS_CA_FILE),
+        POSTGRES_TLS_SERVER_NAME: EnvValue.fromValue(
+          TEMPORAL_POSTGRES_TLS_SERVER_NAME,
+        ),
+      },
+      securityContext: {
+        user: 1000,
+        group: 1000,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+      },
+      volumeMounts: [
+        {
+          path: POSTGRES_TLS_DIRECTORY,
+          volume: tlsVolume,
+          readOnly: true,
+        },
+      ],
+      resources: {
+        cpu: { request: Cpu.millis(25), limit: Cpu.millis(250) },
+        memory: { request: Size.mebibytes(64), limit: Size.mebibytes(256) },
+      },
+    }),
+  );
+
+  return job;
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
@@ -17,6 +17,11 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
 import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
+import {
+  TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+  TEMPORAL_POSTGRES_TLS_SECRET,
+  TEMPORAL_POSTGRES_TLS_SERVER_NAME,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 export type CreateTemporalServerDeploymentProps = {
@@ -30,21 +35,20 @@ export function createTemporalServerDeployment(
   const UID = 1000;
   const GID = 1000;
 
-  // PostgreSQL credentials from postgres-operator
+  // PostgreSQL credentials from postgres-operator.
   const postgresSecretName =
     "temporal.temporal-postgresql.credentials.postgresql.acid.zalan.do";
+  const postgresSecret = Secret.fromSecretName(
+    chart,
+    "temporal-server-postgres-secret",
+    postgresSecretName,
+  );
 
   const deployment = new Deployment(chart, "temporal-server", {
     replicas: 1,
     strategy: DeploymentStrategy.recreate(),
     securityContext: {
       fsGroup: GID,
-    },
-    metadata: {
-      annotations: {
-        "ignore-check.kube-linter.io/no-read-only-root-fs":
-          "Temporal auto-setup requires writable filesystem for schema migrations",
-      },
     },
     podMetadata: {
       labels: {
@@ -53,14 +57,25 @@ export function createTemporalServerDeployment(
     },
   });
 
-  // Mount postgres-operator secret as volume
-  const pgSecretVolume = Volume.fromSecret(
+  const postgresTlsVolume = Volume.fromSecret(
     chart,
-    "temporal-pg-secret-volume",
-    Secret.fromSecretName(chart, "temporal-pg-secret", postgresSecretName),
-    {
-      name: "pg-secret",
-    },
+    "temporal-server-postgres-tls-volume",
+    Secret.fromSecretName(
+      chart,
+      "temporal-server-postgres-tls-secret",
+      TEMPORAL_POSTGRES_TLS_SECRET,
+    ),
+    { name: "postgres-tls" },
+  );
+  const configVolume = Volume.fromEmptyDir(
+    chart,
+    "temporal-server-config-volume",
+    "config",
+  );
+  const tmpVolume = Volume.fromEmptyDir(
+    chart,
+    "temporal-server-tmp-volume",
+    "tmp",
   );
 
   // Mount dynamic config as volume
@@ -76,7 +91,7 @@ export function createTemporalServerDeployment(
   deployment.addContainer(
     withCommonProps({
       name: "temporal-server",
-      image: `temporalio/auto-setup:${versions["temporalio/auto-setup"]}`,
+      image: `temporalio/server:${versions["temporalio/server"]}`,
       ports: [
         { name: "grpc", number: 7233 },
         { name: "metrics", number: 9090 },
@@ -85,16 +100,30 @@ export function createTemporalServerDeployment(
         // Database configuration
         DB: EnvValue.fromValue("postgres12"),
         DB_PORT: EnvValue.fromValue("5432"),
-        POSTGRES_SEEDS: EnvValue.fromValue("temporal-postgresql"),
+        POSTGRES_SEEDS: EnvValue.fromValue(TEMPORAL_POSTGRES_TLS_SERVER_NAME),
+        POSTGRES_USER: EnvValue.fromSecretValue({
+          secret: postgresSecret,
+          key: "username",
+        }),
+        POSTGRES_PWD: EnvValue.fromSecretValue({
+          secret: postgresSecret,
+          key: "password",
+        }),
         DBNAME: EnvValue.fromValue("temporal"),
         VISIBILITY_DBNAME: EnvValue.fromValue("temporal_visibility"),
-        // Zalando postgres-operator issues self-signed certs whose SANs do not
-        // include the Kubernetes service hostname, so Temporal can encrypt the
-        // connection but cannot verify the host without a separately mounted CA.
         POSTGRES_TLS_ENABLED: EnvValue.fromValue("true"),
-        POSTGRES_TLS_DISABLE_HOST_VERIFICATION: EnvValue.fromValue("true"),
+        POSTGRES_TLS_CA_FILE: EnvValue.fromValue(
+          `/etc/temporal/postgres-tls/${TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE}`,
+        ),
+        POSTGRES_TLS_SERVER_NAME: EnvValue.fromValue(
+          TEMPORAL_POSTGRES_TLS_SERVER_NAME,
+        ),
         SQL_TLS_ENABLED: EnvValue.fromValue("true"),
-        SQL_TLS_DISABLE_HOST_VERIFICATION: EnvValue.fromValue("true"),
+        SQL_CA: EnvValue.fromValue(
+          `/etc/temporal/postgres-tls/${TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE}`,
+        ),
+        SQL_HOST_VERIFICATION: EnvValue.fromValue("true"),
+        SQL_HOST_NAME: EnvValue.fromValue(TEMPORAL_POSTGRES_TLS_SERVER_NAME),
 
         // All-in-one mode: run all 4 services in one process
         SERVICES: EnvValue.fromValue("frontend,history,matching,worker"),
@@ -113,25 +142,16 @@ export function createTemporalServerDeployment(
         // Prometheus metrics endpoint
         PROMETHEUS_ENDPOINT: EnvValue.fromValue("0.0.0.0:9090"),
       },
-      command: ["/bin/sh", "-c"],
-      args: [
-        // Read credentials from postgres-operator secret, export as env vars, then start
-        [
-          "export POSTGRES_USER=$(cat /pg-secret/username)",
-          "export POSTGRES_PWD=$(cat /pg-secret/password)",
-          "exec /etc/temporal/entrypoint.sh autosetup",
-        ].join(" && "),
-      ],
       securityContext: {
         user: UID,
         group: GID,
         ensureNonRoot: true,
-        readOnlyRootFilesystem: false,
+        readOnlyRootFilesystem: true,
       },
       volumeMounts: [
         {
-          path: "/pg-secret",
-          volume: pgSecretVolume,
+          path: "/etc/temporal/postgres-tls",
+          volume: postgresTlsVolume,
           readOnly: true,
         },
         {
@@ -139,6 +159,8 @@ export function createTemporalServerDeployment(
           volume: dynamicConfigVolume,
           readOnly: true,
         },
+        { path: "/etc/temporal/config", volume: configVolume },
+        { path: "/tmp", volume: tmpVolume },
       ],
       resources: {
         cpu: {
@@ -162,8 +184,7 @@ export function createTemporalServerDeployment(
       }),
       startup: Probe.fromTcpSocket({
         port: 7233,
-        // Auto-setup runs schema migrations on first start — allow up to 5 minutes
-        failureThreshold: 30,
+        failureThreshold: 18,
         periodSeconds: Duration.seconds(10),
       }),
     }),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/server.ts
@@ -18,7 +18,7 @@ import {
 import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
 import {
-  TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE,
+  TEMPORAL_POSTGRES_TLS_CA_FILE,
   TEMPORAL_POSTGRES_TLS_SECRET,
   TEMPORAL_POSTGRES_TLS_SERVER_NAME,
 } from "@shepherdjerred/homelab/cdk8s/src/resources/postgres/temporal-db-tls.ts";
@@ -88,10 +88,41 @@ export function createTemporalServerDeployment(
     },
   );
 
+  // The image's own entrypoint renders /etc/temporal/config/docker.yaml from
+  // /etc/temporal/config/config_template.yaml (baked into the image) via
+  // `dockerize`. Mounting configVolume straight onto /etc/temporal/config in
+  // the main container would completely shadow that directory — including
+  // the template the entrypoint depends on — leaving nothing for dockerize
+  // to render and crash-looping every pod before port 7233 ever opens. Copy
+  // the template into the (still-empty) shared volume first, from the same
+  // image, so the main container's mount already contains it.
+  const configTemplateImage = `temporalio/server:${versions["temporalio/server"]}`;
+  deployment.addInitContainer(
+    withCommonProps({
+      name: "temporal-server-config-template",
+      image: configTemplateImage,
+      command: ["/bin/sh", "-c"],
+      args: [
+        "cp /etc/temporal/config/config_template.yaml /new-config/config_template.yaml",
+      ],
+      securityContext: {
+        user: UID,
+        group: GID,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+      },
+      volumeMounts: [{ path: "/new-config", volume: configVolume }],
+      resources: {
+        cpu: { request: Cpu.millis(10), limit: Cpu.millis(100) },
+        memory: { request: Size.mebibytes(16), limit: Size.mebibytes(64) },
+      },
+    }),
+  );
+
   deployment.addContainer(
     withCommonProps({
       name: "temporal-server",
-      image: `temporalio/server:${versions["temporalio/server"]}`,
+      image: configTemplateImage,
       ports: [
         { name: "grpc", number: 7233 },
         { name: "metrics", number: 9090 },
@@ -112,15 +143,20 @@ export function createTemporalServerDeployment(
         DBNAME: EnvValue.fromValue("temporal"),
         VISIBILITY_DBNAME: EnvValue.fromValue("temporal_visibility"),
         POSTGRES_TLS_ENABLED: EnvValue.fromValue("true"),
+        // Trust the stable CA (see temporal-db-tls.ts), not the rotating
+        // leaf's own tls.crt: the leaf's key rotates on every cert-manager
+        // renewal, but this long-running server only re-reads its trust
+        // file on pod restart. Trusting tls.crt would work until the first
+        // rotation, then silently break every new connection.
         POSTGRES_TLS_CA_FILE: EnvValue.fromValue(
-          `/etc/temporal/postgres-tls/${TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE}`,
+          `/etc/temporal/postgres-tls/${TEMPORAL_POSTGRES_TLS_CA_FILE}`,
         ),
         POSTGRES_TLS_SERVER_NAME: EnvValue.fromValue(
           TEMPORAL_POSTGRES_TLS_SERVER_NAME,
         ),
         SQL_TLS_ENABLED: EnvValue.fromValue("true"),
         SQL_CA: EnvValue.fromValue(
-          `/etc/temporal/postgres-tls/${TEMPORAL_POSTGRES_TLS_CERTIFICATE_FILE}`,
+          `/etc/temporal/postgres-tls/${TEMPORAL_POSTGRES_TLS_CA_FILE}`,
         ),
         SQL_HOST_VERIFICATION: EnvValue.fromValue("true"),
         SQL_HOST_NAME: EnvValue.fromValue(TEMPORAL_POSTGRES_TLS_SERVER_NAME),

--- a/packages/homelab/src/cdk8s/src/temporal-server-lifecycle.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-server-lifecycle.test.ts
@@ -56,21 +56,29 @@ const ContainerSchema = z.object({
     .optional(),
 });
 
+const PodSpecSchema = z.object({
+  containers: z.array(ContainerSchema),
+  initContainers: z.array(ContainerSchema).optional(),
+});
+
 // Every synthesized Job/Deployment here has exactly one container; find it
 // and fail with a resource-specific message if the shape ever changes.
 function firstContainer(resourceSpec: unknown, description: string) {
   const spec = z
-    .object({
-      template: z.object({
-        spec: z.object({ containers: z.array(ContainerSchema) }),
-      }),
-    })
+    .object({ template: z.object({ spec: PodSpecSchema }) })
     .parse(resourceSpec);
   const container = spec.template.spec.containers[0];
   if (container === undefined) {
     throw new Error(`${description} container was not synthesized`);
   }
   return container;
+}
+
+function initContainers(resourceSpec: unknown) {
+  const spec = z
+    .object({ template: z.object({ spec: PodSpecSchema }) })
+    .parse(resourceSpec);
+  return spec.template.spec.initContainers ?? [];
 }
 
 describe("Temporal server lifecycle", () => {
@@ -90,6 +98,51 @@ describe("Temporal server lifecycle", () => {
     expect(command).toContain('errors" -ne 0');
     expect(command).toContain('snapshots_attempted" -le 0');
     expect(command).toContain('age_seconds" -gt 25200');
+
+    // Aggregate counters alone can be positive purely because OTHER
+    // backup-enabled PVCs succeeded; the preflight must specifically confirm
+    // the Temporal PVC's own snapshot, not just any completed snapshot.
+    expect(command).toContain("pgdata-temporal-postgresql-0");
+    expect(command).toContain("velero.io/backup=enabled");
+    expect(command).toContain("enabled_pvc_count");
+    expect(command).toContain('snapshots_attempted" -ne "$enabled_pvc_count');
+  });
+
+  test("stages backup-preflight RBAC as an earlier PreSync hook than the Job it serves", () => {
+    const rbacAnnotations = {
+      "argocd.argoproj.io/hook": "PreSync",
+      "argocd.argoproj.io/sync-wave": "-3",
+    };
+
+    expect(
+      findResource("ServiceAccount", "temporal-backup-preflight").metadata
+        .annotations,
+    ).toMatchObject(rbacAnnotations);
+    expect(
+      findResource("Role", "temporal-backup-preflight").metadata.annotations,
+    ).toMatchObject(rbacAnnotations);
+    expect(
+      findResource("RoleBinding", "temporal-backup-preflight").metadata
+        .annotations,
+    ).toMatchObject(rbacAnnotations);
+    expect(
+      findResource("ClusterRole", "temporal-backup-preflight-pvc-reader")
+        .metadata.annotations,
+    ).toMatchObject(rbacAnnotations);
+    expect(
+      findResource("ClusterRoleBinding", "temporal-backup-preflight-pvc-reader")
+        .metadata.annotations,
+    ).toMatchObject(rbacAnnotations);
+
+    // The RBAC's wave (-3) must sort strictly before the Job's own wave (-2)
+    // within the shared PreSync hook phase.
+    const rbacWave = Number(rbacAnnotations["argocd.argoproj.io/sync-wave"]);
+    const jobWave = Number(
+      findResource("Job", "temporal-backup-preflight").metadata.annotations?.[
+        "argocd.argoproj.io/sync-wave"
+      ],
+    );
+    expect(rbacWave).toBeLessThan(jobWave);
   });
 
   test("migrates both schemas in a blocking PreSync hook", () => {
@@ -113,6 +166,36 @@ describe("Temporal server lifecycle", () => {
     expect(command).toContain("--tls-server-name");
     expect(command).not.toContain("disable-host-verification");
     expect(container.securityContext.readOnlyRootFilesystem).toBe(true);
+
+    // Must trust the stable CA (ca.crt), not the rotating leaf's own
+    // certificate (tls.crt) — trusting the leaf would work until its next
+    // cert-manager renewal, then silently fail.
+    const caFileEnv = container.env?.find(
+      (entry) => entry.name === "POSTGRES_TLS_CA_FILE",
+    );
+    expect(caFileEnv?.value).toBe("/etc/temporal/postgres-tls/ca.crt");
+  });
+
+  test("stages the PostgreSQL ingress netpol as an earlier PreSync hook than the schema migration Job", () => {
+    const netpol = findResource("NetworkPolicy", "temporal-postgresql-netpol");
+    expect(netpol.metadata.annotations).toMatchObject({
+      "argocd.argoproj.io/hook": "PreSync",
+      "argocd.argoproj.io/sync-wave": "-3",
+    });
+
+    const netpolWave = Number(
+      netpol.metadata.annotations?.["argocd.argoproj.io/sync-wave"],
+    );
+    const schemaJobWave = Number(
+      findResource("Job", "temporal-schema-migration").metadata.annotations?.[
+        "argocd.argoproj.io/sync-wave"
+      ],
+    );
+    expect(netpolWave).toBeLessThan(schemaJobWave);
+
+    const serialized = JSON.stringify(netpol.spec);
+    expect(serialized).toContain('"app":"temporal-server"');
+    expect(serialized).toContain('"app":"temporal-schema-migration"');
   });
 
   test("starts the server without schema setup and verifies PostgreSQL identity", () => {
@@ -135,6 +218,32 @@ describe("Temporal server lifecycle", () => {
       expect.arrayContaining([
         expect.objectContaining({ mountPath: "/etc/temporal/postgres-tls" }),
         expect.objectContaining({ mountPath: "/etc/temporal/config" }),
+      ]),
+    );
+
+    // Must trust the stable CA (ca.crt), not the rotating leaf's own
+    // certificate (tls.crt) — see the schema-migration equivalent above.
+    expect(env.get("POSTGRES_TLS_CA_FILE")).toBe(
+      "/etc/temporal/postgres-tls/ca.crt",
+    );
+    expect(env.get("SQL_CA")).toBe("/etc/temporal/postgres-tls/ca.crt");
+
+    // The image's entrypoint renders docker.yaml from config_template.yaml,
+    // which is baked into the image at /etc/temporal/config — mounting an
+    // empty volume straight over that path would hide the template and
+    // crash-loop every pod. An init container using the same image must
+    // copy the template into the shared volume first.
+    const [configInit] = initContainers(deployment.spec);
+    if (configInit === undefined) {
+      throw new Error(
+        "Temporal server has no init container to seed config_template.yaml",
+      );
+    }
+    expect(configInit.image).toBe(container.image);
+    expect(configInit.args?.join(" ") ?? "").toContain("config_template.yaml");
+    expect(configInit.volumeMounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ mountPath: "/new-config" }),
       ]),
     );
   });

--- a/packages/homelab/src/cdk8s/src/temporal-server-lifecycle.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-server-lifecycle.test.ts
@@ -56,6 +56,23 @@ const ContainerSchema = z.object({
     .optional(),
 });
 
+// Every synthesized Job/Deployment here has exactly one container; find it
+// and fail with a resource-specific message if the shape ever changes.
+function firstContainer(resourceSpec: unknown, description: string) {
+  const spec = z
+    .object({
+      template: z.object({
+        spec: z.object({ containers: z.array(ContainerSchema) }),
+      }),
+    })
+    .parse(resourceSpec);
+  const container = spec.template.spec.containers[0];
+  if (container === undefined) {
+    throw new Error(`${description} container was not synthesized`);
+  }
+  return container;
+}
+
 describe("Temporal server lifecycle", () => {
   test("requires a fresh successful volume backup before migration", () => {
     const job = findResource("Job", "temporal-backup-preflight");
@@ -64,17 +81,7 @@ describe("Temporal server lifecycle", () => {
       "argocd.argoproj.io/sync-wave": "-2",
     });
 
-    const spec = z
-      .object({
-        template: z.object({
-          spec: z.object({ containers: z.array(ContainerSchema) }),
-        }),
-      })
-      .parse(job.spec);
-    const container = spec.template.spec.containers[0];
-    if (container === undefined) {
-      throw new Error("Backup preflight container was not synthesized");
-    }
+    const container = firstContainer(job.spec, "Backup preflight");
     const command = container.args?.join("\n") ?? "";
 
     expect(container.image).toContain("bitnamilegacy/kubectl:1.33.4@sha256:");
@@ -93,17 +100,7 @@ describe("Temporal server lifecycle", () => {
         "BeforeHookCreation,HookSucceeded",
     });
 
-    const spec = z
-      .object({
-        template: z.object({
-          spec: z.object({ containers: z.array(ContainerSchema) }),
-        }),
-      })
-      .parse(job.spec);
-    const container = spec.template.spec.containers[0];
-    if (container === undefined) {
-      throw new Error("Schema migration container was not synthesized");
-    }
+    const container = firstContainer(job.spec, "Schema migration");
     const command = container.args?.join("\n") ?? "";
 
     expect(container.image).toContain("temporalio/admin-tools:1.30.6@sha256:");
@@ -120,17 +117,7 @@ describe("Temporal server lifecycle", () => {
 
   test("starts the server without schema setup and verifies PostgreSQL identity", () => {
     const deployment = findResource("Deployment", "temporal-temporal-server");
-    const spec = z
-      .object({
-        template: z.object({
-          spec: z.object({ containers: z.array(ContainerSchema) }),
-        }),
-      })
-      .parse(deployment.spec);
-    const container = spec.template.spec.containers[0];
-    if (container === undefined) {
-      throw new Error("Temporal server container was not synthesized");
-    }
+    const container = firstContainer(deployment.spec, "Temporal server");
     const env = new Map(
       (container.env ?? []).map((entry) => [entry.name, entry.value]),
     );

--- a/packages/homelab/src/cdk8s/src/temporal-server-lifecycle.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-server-lifecycle.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "vitest";
+import { App } from "cdk8s";
+import { parseAllDocuments } from "yaml";
+import { z } from "zod";
+import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
+
+const ResourceSchema = z
+  .object({
+    kind: z.string(),
+    metadata: z
+      .object({
+        name: z.string(),
+        annotations: z.record(z.string(), z.string()).optional(),
+      })
+      .loose(),
+    spec: z.unknown().optional(),
+  })
+  .loose();
+
+function resources() {
+  const app = new App({ outdir: ".test-synth-temporal-server-lifecycle" });
+  createTemporalChart(app);
+  return parseAllDocuments(app.synthYaml()).flatMap((document) => {
+    const parsed = ResourceSchema.safeParse(document.toJSON());
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+function findResource(kind: string, name: string) {
+  const resource = resources().find(
+    (candidate) => candidate.kind === kind && candidate.metadata.name === name,
+  );
+  if (resource === undefined) {
+    throw new Error(`Missing ${kind}/${name}`);
+  }
+  return resource;
+}
+
+const ContainerSchema = z.object({
+  name: z.string(),
+  image: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z
+    .array(
+      z
+        .object({
+          name: z.string(),
+          value: z.string().optional(),
+        })
+        .loose(),
+    )
+    .optional(),
+  securityContext: z.object({ readOnlyRootFilesystem: z.boolean() }).loose(),
+  volumeMounts: z
+    .array(z.object({ name: z.string(), mountPath: z.string() }).loose())
+    .optional(),
+});
+
+describe("Temporal server lifecycle", () => {
+  test("requires a fresh successful volume backup before migration", () => {
+    const job = findResource("Job", "temporal-backup-preflight");
+    expect(job.metadata.annotations).toMatchObject({
+      "argocd.argoproj.io/hook": "PreSync",
+      "argocd.argoproj.io/sync-wave": "-2",
+    });
+
+    const spec = z
+      .object({
+        template: z.object({
+          spec: z.object({ containers: z.array(ContainerSchema) }),
+        }),
+      })
+      .parse(job.spec);
+    const container = spec.template.spec.containers[0];
+    if (container === undefined) {
+      throw new Error("Backup preflight container was not synthesized");
+    }
+    const command = container.args?.join("\n") ?? "";
+
+    expect(container.image).toContain("bitnamilegacy/kubectl:1.33.4@sha256:");
+    expect(command).toContain("velero.io/schedule-name=6hourly-backup");
+    expect(command).toContain('phase" != "Completed');
+    expect(command).toContain('errors" -ne 0');
+    expect(command).toContain('snapshots_attempted" -le 0');
+    expect(command).toContain('age_seconds" -gt 25200');
+  });
+
+  test("migrates both schemas in a blocking PreSync hook", () => {
+    const job = findResource("Job", "temporal-schema-migration");
+    expect(job.metadata.annotations).toMatchObject({
+      "argocd.argoproj.io/hook": "PreSync",
+      "argocd.argoproj.io/hook-delete-policy":
+        "BeforeHookCreation,HookSucceeded",
+    });
+
+    const spec = z
+      .object({
+        template: z.object({
+          spec: z.object({ containers: z.array(ContainerSchema) }),
+        }),
+      })
+      .parse(job.spec);
+    const container = spec.template.spec.containers[0];
+    if (container === undefined) {
+      throw new Error("Schema migration container was not synthesized");
+    }
+    const command = container.args?.join("\n") ?? "";
+
+    expect(container.image).toContain("temporalio/admin-tools:1.30.6@sha256:");
+    expect(command).toContain(
+      "update-schema -d /etc/temporal/schema/postgresql/v12/temporal/versioned",
+    );
+    expect(command).toContain(
+      "update-schema -d /etc/temporal/schema/postgresql/v12/visibility/versioned",
+    );
+    expect(command).toContain("--tls-server-name");
+    expect(command).not.toContain("disable-host-verification");
+    expect(container.securityContext.readOnlyRootFilesystem).toBe(true);
+  });
+
+  test("starts the server without schema setup and verifies PostgreSQL identity", () => {
+    const deployment = findResource("Deployment", "temporal-temporal-server");
+    const spec = z
+      .object({
+        template: z.object({
+          spec: z.object({ containers: z.array(ContainerSchema) }),
+        }),
+      })
+      .parse(deployment.spec);
+    const container = spec.template.spec.containers[0];
+    if (container === undefined) {
+      throw new Error("Temporal server container was not synthesized");
+    }
+    const env = new Map(
+      (container.env ?? []).map((entry) => [entry.name, entry.value]),
+    );
+
+    expect(container.image).toContain("temporalio/server:1.30.6@sha256:");
+    expect(container.args?.join(" ") ?? "").not.toContain("autosetup");
+    expect(env.get("POSTGRES_TLS_SERVER_NAME")).toBe(
+      "temporal-postgresql.temporal.svc.cluster.local",
+    );
+    expect(env.get("SQL_HOST_VERIFICATION")).toBe("true");
+    expect(env.has("POSTGRES_TLS_DISABLE_HOST_VERIFICATION")).toBe(false);
+    expect(env.has("SQL_TLS_DISABLE_HOST_VERIFICATION")).toBe(false);
+    expect(container.securityContext.readOnlyRootFilesystem).toBe(true);
+    expect(container.volumeMounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ mountPath: "/etc/temporal/postgres-tls" }),
+        expect.objectContaining({ mountPath: "/etc/temporal/config" }),
+      ]),
+    );
+  });
+
+  test("limits the schema hook to DNS and PostgreSQL egress", () => {
+    const policy = findResource(
+      "NetworkPolicy",
+      "temporal-schema-migration-netpol",
+    );
+    const serialized = JSON.stringify(policy.spec);
+
+    expect(serialized).toContain('"app":"temporal-schema-migration"');
+    expect(serialized).toContain('"port":53');
+    expect(serialized).toContain('"port":5432');
+    expect(serialized).not.toContain('"port":7233');
+  });
+});

--- a/packages/homelab/src/cdk8s/src/version-map.generated.ts
+++ b/packages/homelab/src/cdk8s/src/version-map.generated.ts
@@ -109,7 +109,7 @@ export const VersionMapSchema = z
     "shepherdjerred/caddy-s3proxy": z.string(),
     "shepherdjerred/tasknotes-server": z.string(),
     "shepherdjerred/obsidian-headless": z.string(),
-    "temporalio/auto-setup": z.string(),
+    "temporalio/server": z.string(),
     "temporalio/ui": z.string(),
     "temporalio/admin-tools": z.string(),
     "shepherdjerred/temporal-worker": z.string(),

--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1372,7 +1372,7 @@
       ]
     },
     {
-      "name": "temporalio/auto-setup",
+      "name": "temporalio/server",
       "category": "upstream",
       "artifactType": "image",
       "management": {
@@ -1381,7 +1381,7 @@
         "registryUrl": "https://docker.io",
         "versioning": "semver"
       },
-      "value": "1.29.7@sha256:f14912b699cf73015ad5c4fc18d522d4b014db90e794039214dfb7c022c2644f"
+      "value": "1.30.6@sha256:c8ade0075f9d9da43c206de2b255c80be49db384045bd1ff76bd58d0f408a314"
     },
     {
       "name": "temporalio/ui",
@@ -1405,7 +1405,7 @@
         "registryUrl": "https://docker.io",
         "versioning": "semver"
       },
-      "value": "1.31.2@sha256:dbc5fcd6ee8f0f4d808bf765af9a87dea9d8a283abfdcfbd2fc148496ba66107"
+      "value": "1.30.6@sha256:d6218349ac4468ea97877dedaa5351b16364983946dbde49811d93011da649c6"
     },
     {
       "name": "shepherdjerred/temporal-worker",


### PR DESCRIPTION
## Why

Temporal server startup currently uses the deprecated auto-setup image, owns schema mutation, and disables PostgreSQL hostname verification. The first server upgrade needs a recoverable, schema-first boundary before the binary changes.

## What

- replace auto-setup 1.29.7 with the production server 1.30.6 image
- pin admin-tools to the matching 1.30.6 release
- require a fresh, completed, error-free six-hourly Velero backup with successful volume snapshots in an earlier PreSync hook
- update core and visibility schemas explicitly in a blocking PreSync hook
- mount the prerequisite PostgreSQL certificate and enable hostname verification for server and schema connections
- run the server without schema setup using direct Secret-backed credentials and a read-only root filesystem
- restrict hook egress and PostgreSQL ingress with NetworkPolicies
- document the sequential upgrade, acceptance, rollback, and 1.31.2 gate

## Verification

- `bun run typecheck` in `packages/homelab/src/cdk8s`
- focused ESLint on changed CDK8s files
- `bun run test` in `packages/homelab/src/cdk8s`: 592 passed, 13 skipped
- `bun run build` in `packages/homelab/src/cdk8s`
- `bash -n` on both synthesized PreSync scripts
- `bun run build` and `bun run lint` in `packages/docs/wiki`
- `bunx lefthook run pre-commit`

## Rollout

This PR depends on the PostgreSQL TLS identity PR and must stay draft until that certificate is Ready, the PostgreSQL rollover is healthy, and its live SANs are verified.

Deploy 1.30.6 alone. Record backup, schema, cluster health, retention, schedules, pollers, central and Scout canaries, and alert/error-rate evidence before preparing 1.31.2. The second server upgrade is deliberately not included or stacked here.

## Visual proof

The wiki build passed. A rendered upgrade-page screenshot and the live Temporal/Grafana acceptance screenshots are still required before review.