### PR TITLE
feat(dotfiles): provision Discord agent identities

### DIFF
--- a/packages/dotfiles/dot_agents/skills/discord/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/discord/SKILL.md
@@ -7,22 +7,40 @@ description: |
 
 # Discord Agent Access
 
-Two ways to act on Discord, both verified live on 2026-06-12:
+Two ways to act on Discord, both verified live on 2026-08-29:
 
 1. **`toolkit discord`** (recommended for common ops) — a session daemon that logs in once, holds the gateway connections in memory, and exposes one-shot CLI commands. One `op` call per session; no boilerplate; voice presence persists between commands.
 2. **Write a Bun/TypeScript script** (escape hatch) — for anything the CLI doesn't cover. Same libraries underneath.
 
-## Credentials — ask the user
+## Credentials
 
-**Do not assume which Discord credentials to use.** Ask the user which 1Password item (or env vars) holds the right tokens, and which server/channels to target. Different bots and tasks use different identities.
+On Jerred's managed local Mac, Chezmoi exports both dedicated test identities:
 
-There is a **default test identity** (a throwaway Discord user account, userbot only) for quick checks:
+- `DISCORD_USER_TOKEN`: the throwaway Derrej user (`derrej_`), for userbot-only actions.
+- `DISCORD_BOT_TOKEN`: the Derrej bot (`Derrej#8685`), for bot actions.
+
+If those variables are already present, use them without calling `op` or asking
+the user to unlock 1Password. Never print their values. Start the daemon
+directly:
 
 ```bash
-export DISCORD_USER_TOKEN=$(op read "op://Personal/sskm6skq3mwnyqnhrmqwji6dne/TOKEN")
+toolkit discord daemon start --ttl 30m
 ```
 
-For a bot identity (needed for `voice states` and for reading message content reliably), ask the user for the bot token and export it as `DISCORD_BOT_TOKEN`. Never write tokens to files or print them to logs — env vars only, loaded in the same command that starts the daemon.
+An existing Conductor session may have captured its environment before the
+latest Chezmoi apply. In that case, start the daemon through a fresh Fish login
+shell (or use a newly launched Conductor session) instead of falling back to
+another `op` read:
+
+```bash
+fish -lc 'toolkit discord daemon start --ttl 30m'
+```
+
+In other environments, or when the managed variables are absent, do not assume
+which credentials to use. Ask the user which 1Password items or environment
+variables hold the right tokens and which server/channels to target. Load
+tokens into the daemon environment without printing them or passing them on the
+command line. Never commit the rendered Fish config or token values.
 
 ## Identities: userbot vs bot
 
@@ -35,11 +53,12 @@ A bot **cannot** invoke another bot's slash commands or appear as a user in voic
 
 ## `toolkit discord` — the daemon
 
-Start it once per session with the tokens in env (one `op` call). The daemon prints the logged-in identities and stays up until you stop it or it idles out (default 4h, `--ttl 30m` to shorten):
+Start it once per session with the managed tokens already in the environment.
+The daemon prints the logged-in identities and stays up until you stop it or it
+idles out (default 4h, `--ttl 30m` to shorten):
 
 ```bash
-bash -c 'export DISCORD_USER_TOKEN=$(op read "op://Personal/sskm6skq3mwnyqnhrmqwji6dne/TOKEN") \
-  && toolkit discord daemon start --ttl 30m'
+toolkit discord daemon start --ttl 30m
 ```
 
 Then every other command talks to the running daemon over a unix socket (no token, no login cost):

--- a/packages/dotfiles/private_dot_config/private_fish/config.fish.tmpl
+++ b/packages/dotfiles/private_dot_config/private_fish/config.fish.tmpl
@@ -64,6 +64,11 @@ set -gx ARGOCD_AUTH_TOKEN '{{ onepasswordRead "op://yx6je6mgj2oiss6z5bm42h3cxy/n
 set -gx HASS_TOKEN '{{ onepasswordRead "op://yx6je6mgj2oiss6z5bm42h3cxy/y4c2gno3yrxcdcudaofbirmi4u/password" }}'
 set -gx HASS_BASE_URL 'https://homeassistant.sjer.red'
 set -gx LINEAR_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/iixelnobjabehkgxhl3ekacdy4/LINEAR_API_KEY" }}'
+# Dedicated local agent identities for toolkit discord. The user identity can
+# invoke other bots and join voice; the bot identity provides reliable message
+# content and voice-state access.
+set -gx DISCORD_USER_TOKEN '{{ onepasswordRead "op://Personal/sskm6skq3mwnyqnhrmqwji6dne/TOKEN" }}'
+set -gx DISCORD_BOT_TOKEN '{{ onepasswordRead "op://Personal/ytv272dyktkeipt347f2yf5kue/BOT_TOKEN" }}'
 # posthog-cli reads POSTHOG_CLI_*, not the POSTHOG_API_KEY label the value is
 # stored under. The dedicated item also supplies the encrypted state passphrase.
 set -gx POSTHOG_CLI_API_KEY '{{ onepasswordRead "op://v64ocnykdqju4ui6j6pua56xw4/yh3xvqemmr4ic2up5zluo2rkcq/POSTHOG_API_KEY" }}'


### PR DESCRIPTION
## Why

Local agents had to unlock 1Password and manually select Discord credentials before starting each toolkit daemon session. Existing Conductor sessions also retain the environment captured before a Chezmoi apply.

## What

- Render the dedicated Derrej user and bot tokens into the managed Fish environment through stable 1Password references.
- Teach the Discord skill to use the ambient identities without another `op` call.
- Document the fresh-Fish fallback for already-running Conductor sessions.
- Keep non-managed environments explicit: agents still ask which identity and server/channel to use.

## Verification

- `bunx prettier --check packages/dotfiles/dot_agents/skills/discord/SKILL.md`
- `chezmoi --source "$PWD/packages/dotfiles" cat "$HOME/.config/fish/config.fish" | fish -n`
- `fish -n "$HOME/.config/fish/config.fish"`
- `bunx lefthook run pre-commit`
- Applied only the managed Fish and Discord-skill targets and confirmed live/source parity.
- Live local acceptance: a fresh Fish shell exposed both variable names; `toolkit discord` authenticated bot `Derrej#8685` and user `derrej_` without another 1Password call. No Discord messages were sent.

## Security

The repository contains only 1Password references. Token values are absent from the diff and the staged Gitleaks check passed.