### PR TITLE
Bootstrap the Scout beta workflow candidate

### DIFF
--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -253,6 +253,39 @@ test("leaves the legacy Scout beta stable pin untouched", () => {
     },
   });
 });
+test("bootstraps the legacy Scout beta stable and candidate pins", () => {
+  const digest = `sha256:${"b".repeat(64)}`;
+  const workflowPin = `2.0.0-42@sha256:${"c".repeat(64)}`;
+  expect(
+    pinCandidatesForDigests(
+      { "shepherdjerred/scout-for-lol/beta": digest },
+      "43",
+      versionCatalogSource([
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
+          value: workflowPin,
+        },
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
+          value: workflowPin,
+        },
+      ]),
+    ),
+  ).toEqual({
+    "shepherdjerred/scout-for-lol/beta": {
+      version: "2.0.0-43",
+      digest,
+    },
+    "shepherdjerred/scout-for-lol/beta/workflows/stable": {
+      version: "2.0.0-43",
+      digest,
+    },
+    "shepherdjerred/scout-for-lol/beta/workflows/candidate": {
+      version: "2.0.0-43",
+      digest,
+    },
+  });
+});
 function versionCatalogSource(
   entries: readonly { readonly name: string; readonly value: string }[],
 ): string {

--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -224,31 +224,6 @@ test("retains a central Workflow candidate until its pin converges with stable",
     },
   });
 });
-test("leaves the legacy Scout beta stable pin untouched", () => {
-  const digest = `sha256:${"b".repeat(64)}`;
-  const workflowPin = `2.0.0-42@sha256:${"c".repeat(64)}`;
-  expect(
-    pinCandidatesForDigests(
-      { "shepherdjerred/scout-for-lol/beta": digest },
-      "43",
-      versionCatalogSource([
-        {
-          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
-          value: workflowPin,
-        },
-        {
-          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
-          value: workflowPin,
-        },
-      ]),
-    ),
-  ).toEqual({
-    "shepherdjerred/scout-for-lol/beta": {
-      version: "2.0.0-43",
-      digest,
-    },
-  });
-});
 test("bootstraps the legacy Scout beta stable and candidate pins", () => {
   const digest = `sha256:${"b".repeat(64)}`;
   const legacy = `2.0.0-12197@sha256:${"c".repeat(64)}`;
@@ -264,39 +239,6 @@ test("bootstraps the legacy Scout beta stable and candidate pins", () => {
         {
           name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
           value: legacy,
-        },
-      ]),
-    ),
-  ).toEqual({
-    "shepherdjerred/scout-for-lol/beta": {
-      version: "2.0.0-43",
-      digest,
-    },
-    "shepherdjerred/scout-for-lol/beta/workflows/stable": {
-      version: "2.0.0-43",
-      digest,
-    },
-    "shepherdjerred/scout-for-lol/beta/workflows/candidate": {
-      version: "2.0.0-43",
-      digest,
-    },
-  });
-});
-test("bootstraps the legacy Scout beta stable and candidate pins", () => {
-  const digest = `sha256:${"b".repeat(64)}`;
-  const workflowPin = `2.0.0-42@sha256:${"c".repeat(64)}`;
-  expect(
-    pinCandidatesForDigests(
-      { "shepherdjerred/scout-for-lol/beta": digest },
-      "43",
-      versionCatalogSource([
-        {
-          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
-          value: workflowPin,
-        },
-        {
-          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
-          value: workflowPin,
         },
       ]),
     ),

--- a/.buildkite/scripts/bake-images.test.ts
+++ b/.buildkite/scripts/bake-images.test.ts
@@ -247,6 +247,35 @@ test("leaves the legacy Scout beta stable pin untouched", () => {
       version: "2.0.0-43",
       digest,
     },
+  });
+});
+test("bootstraps the legacy Scout beta stable and candidate pins", () => {
+  const digest = `sha256:${"b".repeat(64)}`;
+  const legacy = `2.0.0-12197@sha256:${"c".repeat(64)}`;
+  expect(
+    pinCandidatesForDigests(
+      { "shepherdjerred/scout-for-lol/beta": digest },
+      "43",
+      versionCatalogSource([
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
+          value: legacy,
+        },
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
+          value: legacy,
+        },
+      ]),
+    ),
+  ).toEqual({
+    "shepherdjerred/scout-for-lol/beta": {
+      version: "2.0.0-43",
+      digest,
+    },
+    "shepherdjerred/scout-for-lol/beta/workflows/stable": {
+      version: "2.0.0-43",
+      digest,
+    },
     "shepherdjerred/scout-for-lol/beta/workflows/candidate": {
       version: "2.0.0-43",
       digest,

--- a/.buildkite/scripts/pin-candidate-images.test.ts
+++ b/.buildkite/scripts/pin-candidate-images.test.ts
@@ -155,3 +155,53 @@ test("bootstraps stable and candidate before the first Scout beta rollout", () =
     },
   });
 });
+
+test("publishes only a Scout beta candidate after stable bootstrap", () => {
+  const digest = `sha256:${"a".repeat(64)}`;
+  const legacy = `2.0.0-12197@sha256:${"b".repeat(64)}`;
+  const stable = `2.0.0-12300@sha256:${"c".repeat(64)}`;
+  expect(
+    pinCandidatesForDigests(
+      { "shepherdjerred/scout-for-lol/beta": digest },
+      "43",
+      versionCatalogSource([
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
+          value: stable,
+        },
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
+          value: legacy,
+        },
+      ]),
+    ),
+  ).toEqual({
+    "shepherdjerred/scout-for-lol/beta": { version: "2.0.0-43", digest },
+    "shepherdjerred/scout-for-lol/beta/workflows/candidate": {
+      version: "2.0.0-43",
+      digest,
+    },
+  });
+});
+
+test("does not publish a Scout beta pin while tracks diverge", () => {
+  const digest = `sha256:${"a".repeat(64)}`;
+  expect(
+    pinCandidatesForDigests(
+      { "shepherdjerred/scout-for-lol/beta": digest },
+      "44",
+      versionCatalogSource([
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
+          value: `2.0.0-12300@sha256:${"b".repeat(64)}`,
+        },
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
+          value: `2.0.0-12301@sha256:${"c".repeat(64)}`,
+        },
+      ]),
+    ),
+  ).toEqual({
+    "shepherdjerred/scout-for-lol/beta": { version: "2.0.0-44", digest },
+  });
+});

--- a/.buildkite/scripts/pin-candidate-images.test.ts
+++ b/.buildkite/scripts/pin-candidate-images.test.ts
@@ -124,3 +124,34 @@ test("publishes a central Workflow candidate after stable bootstrap", () => {
     },
   });
 });
+
+test("bootstraps stable and candidate before the first Scout beta rollout", () => {
+  const digest = `sha256:${"a".repeat(64)}`;
+  const legacy = `2.0.0-12197@sha256:${"b".repeat(64)}`;
+  expect(
+    pinCandidatesForDigests(
+      { "shepherdjerred/scout-for-lol/beta": digest },
+      "42",
+      versionCatalogSource([
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/stable",
+          value: legacy,
+        },
+        {
+          name: "shepherdjerred/scout-for-lol/beta/workflows/candidate",
+          value: legacy,
+        },
+      ]),
+    ),
+  ).toEqual({
+    "shepherdjerred/scout-for-lol/beta": { version: "2.0.0-42", digest },
+    "shepherdjerred/scout-for-lol/beta/workflows/stable": {
+      version: "2.0.0-42",
+      digest,
+    },
+    "shepherdjerred/scout-for-lol/beta/workflows/candidate": {
+      version: "2.0.0-42",
+      digest,
+    },
+  });
+});

--- a/.buildkite/scripts/pin-candidate-images.ts
+++ b/.buildkite/scripts/pin-candidate-images.ts
@@ -1,13 +1,14 @@
-import {
-  catalogImagePinsMatch,
-  requireCatalogImageValue,
-} from "../../scripts/lib/image-pin-catalog.ts";
+import { requireCatalogImageValue } from "../../scripts/lib/image-pin-catalog.ts";
 
 const LAST_IMAGE_WITHOUT_WORKFLOW_WORKER = 12_197;
 const CENTRAL_WORKFLOW_STABLE =
   "shepherdjerred/temporal-worker/workflows/stable";
 const CENTRAL_WORKFLOW_CANDIDATE =
   "shepherdjerred/temporal-worker/workflows/candidate";
+const SCOUT_BETA_WORKFLOW_STABLE =
+  "shepherdjerred/scout-for-lol/beta/workflows/stable";
+const SCOUT_BETA_WORKFLOW_CANDIDATE =
+  "shepherdjerred/scout-for-lol/beta/workflows/candidate";
 
 function isLegacyWorkflowPin(value: string): boolean {
   const match = /^2\.0\.0-(\d+)@sha256:[a-f\d]{64}$/.exec(value);
@@ -39,6 +40,29 @@ function centralWorkflowPinTargets(
   return [];
 }
 
+function scoutBetaWorkflowPinTargets(
+  versionCatalogSource: string,
+): readonly string[] {
+  const stable = requireCatalogImageValue(
+    versionCatalogSource,
+    SCOUT_BETA_WORKFLOW_STABLE,
+  );
+  const candidate = requireCatalogImageValue(
+    versionCatalogSource,
+    SCOUT_BETA_WORKFLOW_CANDIDATE,
+  );
+  if (stable === candidate && isLegacyWorkflowPin(stable)) {
+    return [SCOUT_BETA_WORKFLOW_STABLE, SCOUT_BETA_WORKFLOW_CANDIDATE];
+  }
+  if (
+    stable === candidate ||
+    (!isLegacyWorkflowPin(stable) && isLegacyWorkflowPin(candidate))
+  ) {
+    return [SCOUT_BETA_WORKFLOW_CANDIDATE];
+  }
+  return [];
+}
+
 export function pinCandidatesForDigests(
   digests: Readonly<Record<string, string>>,
   buildNumber: string,
@@ -53,16 +77,10 @@ export function pinCandidatesForDigests(
         candidates[target] = candidate;
       }
     }
-    if (
-      key === "shepherdjerred/scout-for-lol/beta" &&
-      catalogImagePinsMatch(
-        versionCatalogSource,
-        "shepherdjerred/scout-for-lol/beta/workflows/candidate",
-        "shepherdjerred/scout-for-lol/beta/workflows/stable",
-      )
-    ) {
-      candidates["shepherdjerred/scout-for-lol/beta/workflows/candidate"] =
-        candidate;
+    if (key === "shepherdjerred/scout-for-lol/beta") {
+      for (const target of scoutBetaWorkflowPinTargets(versionCatalogSource)) {
+        candidates[target] = candidate;
+      }
     }
   }
   return candidates;

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/scout-orchestration.md
@@ -1,25 +1,34 @@
 ---
-title: Why Scout embeds Temporal Workers
-description: Why Scout keeps orchestration durable while product state remains in Postgres and effects remain in the backend.
+title: How Scout separates Temporal workflows from effects
+description: Why deterministic orchestration can run without product credentials while Scout effects remain in the backend.
 sidebar:
   order: 6
 ---
 
-Scout embeds its Temporal Workers because durable orchestration needs the same
-Discord gateway, database, credentials, and report-lake volume as the backend.
+Scout's deterministic Workflow code needs only a Temporal connection. Its
+Activities need the Discord gateway, database, credentials, and report-lake
+volume, so those effectful Workers stay in the backend.
 
-This topology avoids a second Discord client and a private control API. It also
-means old and new Worker versions cannot coexist during Scout's `Recreate`
-deployment, so Workflow changes use replay-safe patches instead of Worker
-Versioning.
+Workflow-only pods can therefore be credentialless and independently
+versioned without introducing a second Discord client or a private control API.
+The split is staged: beta first registers a capable stable version, then a
+distinct candidate. The embedded poller drains old unversioned histories; it
+cannot serve as a Worker Deployment rollback version. It is removed only after
+replay, a version-targeted canary, ramp, soak, stable-pin promotion, and healthy
+versioned pollers. Production follows after beta acceptance.
 
 ```mermaid
 flowchart LR
   accTitle: Scout Temporal ownership and queue boundaries
-  accDescr: Temporal owns durable execution and dispatches workflow tasks to one orchestration queue. The embedded Scout backend consumes four activity queues, while Postgres and S3 retain product data and idempotent effects.
+  accDescr: Temporal dispatches deterministic workflow tasks to credentialless stable and candidate pollers and effectful activity tasks to the Scout backend. During bootstrap the embedded workflow poller drains old unversioned histories.
 
   T[Temporal server] --> W[Workflow queue]
-  W --> R[Realtime activities]
+  W --> S[Credentialless stable workflow poller]
+  W --> C[Credentialless candidate workflow poller]
+  W --> E[Embedded drain poller during bootstrap]
+  S --> R[Realtime activities]
+  C --> R
+  E --> R
   W --> I[Interactive activities]
   W --> B[Background activities]
   W --> L[Serial lake activities]
@@ -55,26 +64,26 @@ Activities use separate realtime, interactive, background, and lake queues.
 The separation preserves responsive polling under slow model work. It also
 serializes every mutation of the report-lake volume.
 
-The Workers share one Temporal connection inside the
+The Activity Workers share one Temporal connection inside the
 [`scout-for-lol`](https://github.com/shepherdjerred/monorepo/tree/main/packages/scout-for-lol)
-backend. A Temporal outage degrades this component without taking down HTTP or
-Discord. Scout does not silently return durable work to its legacy scheduler,
-because two owners would make duplicate effects possible.
+backend. Workflow-only pods have a separate connection and no product
+credentials or data volumes. A Temporal outage degrades this component without
+taking down HTTP or Discord. Scout does not silently return durable work to its
+legacy scheduler, because two schedulers would make duplicate effects possible.
 
 ## Replay compatibility follows the deployment topology
 
-Temporal normally prefers Worker Versioning. Scout cannot use it while one
-`Recreate` replica embeds every Worker, because compatible Worker versions
-cannot overlap during a deployment.
+The workflow-only role registers an exact image Git SHA under
+`scout-beta-workflows` or `scout-prod-workflows` and uses `AUTO_UPGRADE`.
+Candidate and stable images can coexist without duplicating Discord or
+report-lake ownership because neither version runs Activities.
 
-Potentially open Workflows therefore protect command or control-flow changes
-with replay patches. Sanitized histories exercise those patches before
-promotion. Continue-As-New bounds long histories, but it is not a compatibility
-escape hatch for the history that already exists.
-
-Independently deploying the Workers would make Worker Versioning practical. It
-would also require a durable boundary for Discord access and careful ownership
-of the report-lake volume, so the extra topology is not free.
+Potentially open Workflows still protect command or control-flow changes with
+replay patches. Retained histories exercise those patches before promotion.
+Continue-As-New bounds long histories, but it is not a compatibility escape
+hatch for the history that already exists. During the one-time bootstrap, the
+unversioned embedded poller remains available until the first stable versioned
+poller is healthy.
 
 ## Schedules are durable ownership records
 

--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-a-temporal-worker-deployment.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-a-temporal-worker-deployment.md
@@ -18,6 +18,14 @@ Choose a target and keep it on every command. Omit `--target` only for central:
 
 Complete Scout beta acceptance before starting Scout production.
 
+Scout's initial extraction requires two workflow-capable image releases. The
+checked-in pre-entrypoint pin creates no pod. After the prerequisite code lands,
+copy the first capable candidate pin to stable through a reviewed pin PR; this
+creates only the stable pod. Let the next image release advance candidate to a
+distinct Build ID; that creates the ramp target. The embedded backend poller
+drains old histories but is not the versioned stable fallback. Repeat the same
+sequence for production only after beta acceptance.
+
 ## Before starting
 
 Confirm that the candidate image pin is deployed and copy the exact 40-character
@@ -30,6 +38,10 @@ checks the candidate poller before changing routing.
 Set `TEMPORAL_ADDRESS` (and `TEMPORAL_TLS=true` for the private TLS endpoint) in
 the operator shell. The package command uses the existing `toolkit temporal`
 passthrough and never falls back to Kubernetes-only service DNS.
+
+During Scout bootstrap, verify that stable and candidate are both capable,
+distinct images and both exact versions have registered pollers. Pass the
+stable image SHA with `--stable-build-id` on the first `start` command.
 
 Inspect the candidate without changing routing:
 

--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -48,9 +48,14 @@ determinism boundary.
 | `scout-beta` | `scout-beta`         | `scout-beta-workflows`       | `shepherdjerred/scout-for-lol/beta/workflows/` |
 | `scout-prod` | `scout-prod`         | `scout-prod-workflows`       | `shepherdjerred/scout-for-lol/prod/workflows/` |
 
-The Scout targets become operable after the corresponding workflow-only
-deployment is installed. Until that staged extraction, its backend continues
-to poll the stage Workflow queue.
+Scout beta requires two workflow-capable image releases. Pins at or before build
+12197 create no workflow-only pods. Copying the first capable candidate pin to
+stable creates only the stable pod; a later distinct candidate pin creates the
+ramp target. Both pods have only Temporal and DNS egress, expose SDK metrics to
+Prometheus, and carry no Discord, PostgreSQL, Riot, S3, or report-lake access.
+The embedded backend poller drains old unversioned histories but is not a
+Worker Deployment rollback version. Scout production repeats the sequence only
+after beta acceptance.
 
 Bootstrap configuration:
 

--- a/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.test.ts
@@ -93,6 +93,7 @@ describe("applyApplicationReleasePolicy", () => {
       ["1password", "-20"],
       ["argocd", "-18"],
       ["tailscale", "-18"],
+      ["temporal", "-17"],
       ["kueue", "1"],
       ["buildkite", "3"],
       ["worker", "4"],

--- a/packages/homelab/src/cdk8s/src/application-release-policy.ts
+++ b/packages/homelab/src/cdk8s/src/application-release-policy.ts
@@ -17,6 +17,7 @@ export const APPLICATION_SYNC_WAVES = {
   provider: "-18",
   certificateIssuer: "-4",
   certificate: "-3",
+  temporal: "-17",
   structural: "0",
   kueue: "1",
   dependentConfiguration: "2",
@@ -67,6 +68,9 @@ function applicationSyncWave(name: string): string {
   }
   if (PROVIDER_APPLICATIONS.has(name)) {
     return APPLICATION_SYNC_WAVES.provider;
+  }
+  if (name === "temporal") {
+    return APPLICATION_SYNC_WAVES.temporal;
   }
   if (name === "kueue") {
     return APPLICATION_SYNC_WAVES.kueue;

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -42,18 +42,20 @@ export function createScoutChart(
   const candidateImage =
     workflowWorkerImageOverrides?.candidate ??
     versions[`shepherdjerred/scout-for-lol/${stage}/workflows/candidate`];
-  const stableWorkflowWorker =
-    stage === "beta"
-      ? createScoutWorkflowWorker(chart, stage, "stable", stableImage)
-      : undefined;
+  const stableWorkflowWorker = createScoutWorkflowWorker(
+    chart,
+    stage,
+    "stable",
+    stableImage,
+  );
   // The embedded backend poller is unversioned and cannot be a rollback target.
   // Bootstrap a capable stable version first. Keep the candidate Deployment
   // rendered even when its pin equals stable so promotion does not leave
   // unmanaged candidate resources behind when pruning is disabled.
   const candidateWorkflowWorker =
-    stage === "beta" && stableWorkflowWorker !== undefined
-      ? createScoutWorkflowWorker(chart, stage, "candidate", candidateImage)
-      : undefined;
+    stableWorkflowWorker === undefined
+      ? undefined
+      : createScoutWorkflowWorker(chart, stage, "candidate", candidateImage);
   const workflowWorkerCreated =
     stableWorkflowWorker !== undefined || candidateWorkflowWorker !== undefined;
 
@@ -186,7 +188,7 @@ export function createScoutChart(
       },
       spec: {
         podSelector: {
-          matchLabels: { "worker-family": "scout-beta-workflows" },
+          matchLabels: { "worker-family": `scout-${stage}-workflows` },
         },
         policyTypes: ["Ingress", "Egress"],
         ingress: [

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -8,10 +8,21 @@ import {
   IntOrString,
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { FLIPT_PORT } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
+import { createScoutWorkflowWorker } from "@shepherdjerred/homelab/cdk8s/src/resources/scout/workflow-worker.ts";
+import { createDnsEgressRule } from "@shepherdjerred/homelab/cdk8s/src/resources/temporal/worker-network-policies.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 export type Stage = "prod" | "beta";
+type WorkflowWorkerImageOverrides = {
+  stable?: string;
+  candidate?: string;
+};
 
-export function createScoutChart(app: App, stage: Stage) {
+export function createScoutChart(
+  app: App,
+  stage: Stage,
+  workflowWorkerImageOverrides?: WorkflowWorkerImageOverrides,
+) {
   const chart = new Chart(app, `scout-${stage}`, {
     namespace: `scout-${stage}`,
     disableResourceNameHashes: true,
@@ -25,6 +36,28 @@ export function createScoutChart(app: App, stage: Stage) {
 
   createScoutPostgreSQLDatabase(chart, stage);
   createScoutDeployment(chart, stage);
+  const stableImage =
+    workflowWorkerImageOverrides?.stable ??
+    versions[`shepherdjerred/scout-for-lol/${stage}/workflows/stable`];
+  const candidateImage =
+    workflowWorkerImageOverrides?.candidate ??
+    versions[`shepherdjerred/scout-for-lol/${stage}/workflows/candidate`];
+  const stableWorkflowWorker =
+    stage === "beta"
+      ? createScoutWorkflowWorker(chart, stage, "stable", stableImage)
+      : undefined;
+  // The embedded backend poller is unversioned and cannot be a rollback target.
+  // Bootstrap a capable stable version first. Keep the candidate Deployment
+  // rendered even when its pin equals stable so promotion does not leave
+  // unmanaged candidate resources behind when pruning is disabled.
+  const candidateWorkflowWorker =
+    stage === "beta" &&
+    stableWorkflowWorker !== undefined &&
+    candidateImage !== undefined
+      ? createScoutWorkflowWorker(chart, stage, "candidate", candidateImage)
+      : undefined;
+  const workflowWorkerCreated =
+    stableWorkflowWorker !== undefined || candidateWorkflowWorker !== undefined;
 
   // NetworkPolicy: Allow ingress from Prometheus (scrapes scout-backend
   // metrics on :3000), in-namespace pods, and the shared s3-static-sites
@@ -146,4 +179,49 @@ export function createScoutChart(app: App, stage: Stage) {
       ],
     },
   });
+
+  if (workflowWorkerCreated) {
+    new KubeNetworkPolicy(chart, "scout-workflow-worker-netpol", {
+      metadata: {
+        name: "scout-workflow-worker-netpol",
+        annotations: { "argocd.argoproj.io/sync-wave": "-2" },
+      },
+      spec: {
+        podSelector: {
+          matchLabels: { "worker-family": "scout-beta-workflows" },
+        },
+        policyTypes: ["Ingress", "Egress"],
+        ingress: [
+          {
+            from: [
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    "kubernetes.io/metadata.name": "prometheus",
+                  },
+                },
+              },
+            ],
+            ports: [{ port: IntOrString.fromNumber(9464), protocol: "TCP" }],
+          },
+        ],
+        egress: [
+          createDnsEgressRule(),
+          {
+            to: [
+              {
+                namespaceSelector: {
+                  matchLabels: {
+                    "kubernetes.io/metadata.name": "temporal",
+                  },
+                },
+                podSelector: { matchLabels: { app: "temporal-server" } },
+              },
+            ],
+            ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
+          },
+        ],
+      },
+    });
+  }
 }

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/scout.ts
@@ -51,9 +51,7 @@ export function createScoutChart(
   // rendered even when its pin equals stable so promotion does not leave
   // unmanaged candidate resources behind when pruning is disabled.
   const candidateWorkflowWorker =
-    stage === "beta" &&
-    stableWorkflowWorker !== undefined &&
-    candidateImage !== undefined
+    stage === "beta" && stableWorkflowWorker !== undefined
       ? createScoutWorkflowWorker(chart, stage, "candidate", candidateImage)
       : undefined;
   const workflowWorkerCreated =

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/temporal.ts
@@ -31,6 +31,22 @@ function scoutCompetitionActivityIngress(): NetworkPolicyIngressRule {
   };
 }
 
+function scoutWorkflowWorkerIngress(): NetworkPolicyIngressRule {
+  return {
+    from: ["scout-beta", "scout-prod"].map((namespace) => ({
+      namespaceSelector: {
+        matchLabels: { "kubernetes.io/metadata.name": namespace },
+      },
+      podSelector: {
+        matchLabels: {
+          "worker-family": `${namespace}-workflows`,
+        },
+      },
+    })),
+    ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
+  };
+}
+
 export function createTemporalChart(app: App) {
   const chart = new Chart(app, "temporal", {
     namespace: "temporal",
@@ -180,6 +196,7 @@ export function createTemporalChart(app: App) {
           ports: [{ port: IntOrString.fromNumber(7233), protocol: "TCP" }],
         },
         scoutCompetitionActivityIngress(),
+        scoutWorkflowWorkerIngress(),
         {
           // Scout embeds its Workflow and Activity Workers in the sole
           // stage backend pod so activities can use the live Discord gateway,

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/temporal.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/temporal.ts
@@ -5,6 +5,7 @@ export function createTemporalApp(chart: Chart) {
   return new Application(chart, "temporal-app", {
     metadata: {
       name: "temporal",
+      annotations: { "argocd.argoproj.io/sync-wave": "-1" },
     },
     spec: {
       revisionHistoryLimit: 5,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -18,10 +18,6 @@ type TemporalDomainQueueDefinition = {
 // candidate alone is insufficient: Scout's chart bootstraps the stable worker
 // first, so candidate-only alerts would fire on absent pods.
 const scoutBetaWorkflowQueue: TemporalDomainQueueDefinition[] =
-  versions["shepherdjerred/scout-for-lol/beta/workflows/stable"] !==
-    undefined &&
-  versions["shepherdjerred/scout-for-lol/beta/workflows/candidate"] !==
-    undefined &&
   scoutWorkflowWorkerImageIsCapable(
     versions["shepherdjerred/scout-for-lol/beta/workflows/stable"],
   ) &&

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -14,6 +14,9 @@ type TemporalDomainQueueDefinition = {
   activityPoller: boolean;
 };
 
+// Do not install these rules until both tracks can render. A capable
+// candidate alone is insufficient: Scout's chart bootstraps the stable worker
+// first, so candidate-only alerts would fire on absent pods.
 const scoutBetaWorkflowQueue: TemporalDomainQueueDefinition[] =
   scoutWorkflowWorkerImageIsCapable(
     versions["shepherdjerred/scout-for-lol/beta/workflows/stable"],

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -1,86 +1,125 @@
 import type { PrometheusRuleSpecGroups } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
 import { PrometheusRuleSpecGroupsRulesExpr } from "@shepherdjerred/homelab/cdk8s/generated/imports/monitoring.coreos.com";
+import { scoutWorkflowWorkerImageIsCapable } from "@shepherdjerred/homelab/cdk8s/src/resources/scout/workflow-worker.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 type PrometheusRule = NonNullable<PrometheusRuleSpecGroups["rules"]>[number];
+type TemporalDomainQueueDefinition = {
+  queue: string;
+  metricsNamespace: string;
+  deploymentPattern: string;
+  servicePattern: string;
+  candidateDeploymentPattern?: string;
+  candidateServicePattern?: string;
+  activityPoller: boolean;
+};
 
-export const TEMPORAL_DOMAIN_QUEUES = [
-  {
-    queue: "monorepo-workflows",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-workflows.*",
-    servicePattern: ".*temporal-workflows.*metrics.*",
-    activityPoller: false,
-  },
-  {
-    queue: "home",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-home-worker",
-    servicePattern: ".*temporal-home-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "reports",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-reports-worker",
-    servicePattern: ".*temporal-reports-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "infra",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-infra-worker",
-    servicePattern: ".*temporal-infra-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "repo-automation",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-repo-worker",
-    servicePattern: ".*temporal-repo-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "scout",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-scout-worker",
-    servicePattern: ".*temporal-scout-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "agent-task",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-agent-worker",
-    servicePattern: ".*temporal-agent-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "glitter-corpus",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-glitter-corpus-worker",
-    servicePattern: ".*temporal-glitter-corpus-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "glitter-context",
-    metricsNamespace: "temporal",
-    deploymentPattern: "temporal-temporal-glitter-context-worker",
-    servicePattern: ".*temporal-glitter-context-worker.*metrics.*",
-    activityPoller: true,
-  },
-  {
-    queue: "maintenance",
-    metricsNamespace: "buildkite",
-    deploymentPattern: "temporal-maintenance-worker",
-    servicePattern: ".*temporal-maintenance-worker.*metrics.*",
-    activityPoller: true,
-  },
-] as const;
+const scoutBetaWorkflowQueue: TemporalDomainQueueDefinition[] =
+  scoutWorkflowWorkerImageIsCapable(
+    versions["shepherdjerred/scout-for-lol/beta/workflows/stable"],
+  ) &&
+  scoutWorkflowWorkerImageIsCapable(
+    versions["shepherdjerred/scout-for-lol/beta/workflows/candidate"],
+  )
+    ? [
+        {
+          queue: "scout-beta",
+          metricsNamespace: "scout-beta",
+          deploymentPattern: "scout-beta-scout-workflow-worker.*",
+          servicePattern: ".*scout-workflow-worker.*metrics.*",
+          candidateDeploymentPattern:
+            "scout-beta-scout-workflow-worker-candidate",
+          candidateServicePattern:
+            ".*scout-workflow-worker-candidate.*metrics.*",
+          activityPoller: false,
+        },
+      ]
+    : [];
+
+export const TEMPORAL_DOMAIN_QUEUES: readonly TemporalDomainQueueDefinition[] =
+  [
+    {
+      queue: "monorepo-workflows",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-workflows.*",
+      servicePattern: ".*temporal-workflows.*metrics.*",
+      candidateDeploymentPattern: "temporal-temporal-workflows-candidate",
+      candidateServicePattern: ".*temporal-workflows-candidate.*metrics.*",
+      activityPoller: false,
+    },
+    ...scoutBetaWorkflowQueue,
+    {
+      queue: "home",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-home-worker",
+      servicePattern: ".*temporal-home-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "reports",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-reports-worker",
+      servicePattern: ".*temporal-reports-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "infra",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-infra-worker",
+      servicePattern: ".*temporal-infra-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "repo-automation",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-repo-worker",
+      servicePattern: ".*temporal-repo-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "scout",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-scout-worker",
+      servicePattern: ".*temporal-scout-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "agent-task",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-agent-worker",
+      servicePattern: ".*temporal-agent-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "glitter-corpus",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-glitter-corpus-worker",
+      servicePattern: ".*temporal-glitter-corpus-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "glitter-context",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-glitter-context-worker",
+      servicePattern: ".*temporal-glitter-context-worker.*metrics.*",
+      activityPoller: true,
+    },
+    {
+      queue: "maintenance",
+      metricsNamespace: "buildkite",
+      deploymentPattern: "temporal-maintenance-worker",
+      servicePattern: ".*temporal-maintenance-worker.*metrics.*",
+      activityPoller: true,
+    },
+  ];
 
 export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
   return TEMPORAL_DOMAIN_QUEUES.flatMap((definition) => {
-    const workflowSelector = `namespace="temporal",exported_namespace="default",task_queue="${definition.queue}"`;
+    const workflowSelector = `namespace="${definition.metricsNamespace}",exported_namespace="default",task_queue="${definition.queue}"`;
     const activitySelector = `namespace="${definition.metricsNamespace}",exported_namespace="default",task_queue="${definition.queue}"`;
     const labels = { severity: "warning", task_queue: definition.queue };
+    const candidateDeploymentPattern = definition.candidateDeploymentPattern;
+    const candidateServicePattern = definition.candidateServicePattern;
     const activityRules: PrometheusRule[] = definition.activityPoller
       ? [
           {
@@ -166,6 +205,24 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
         for: "5m",
         labels,
       },
+      ...(typeof candidateDeploymentPattern !== "string" ||
+      typeof candidateServicePattern !== "string"
+        ? []
+        : [
+            {
+              alert: "TemporalDomainWorkflowCandidateUnavailable",
+              annotations: {
+                summary: `Temporal candidate Workflow worker unavailable for ${definition.queue}`,
+                description:
+                  "The candidate Workflow Worker has no available replica or scrape. Check the candidate Deployment before advancing the ramp.",
+              },
+              expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+                `absent(kube_deployment_status_replicas_available{namespace="${definition.metricsNamespace}",deployment="${candidateDeploymentPattern}"}) or max(kube_deployment_status_replicas_available{namespace="${definition.metricsNamespace}",deployment="${candidateDeploymentPattern}"}) < 1 or absent(up{namespace="${definition.metricsNamespace}",service=~"${candidateServicePattern}"}) or max(up{namespace="${definition.metricsNamespace}",service=~"${candidateServicePattern}"}) < 1 or count(temporal_worker_num_pollers{${workflowSelector},poller_type="workflow_task"}) < 2 or min(temporal_worker_num_pollers{${workflowSelector},poller_type="workflow_task"}) < 1`,
+              ),
+              for: "5m",
+              labels: { ...labels, track: "candidate" },
+            },
+          ]),
     ];
   });
 }

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -18,6 +18,10 @@ type TemporalDomainQueueDefinition = {
 // candidate alone is insufficient: Scout's chart bootstraps the stable worker
 // first, so candidate-only alerts would fire on absent pods.
 const scoutBetaWorkflowQueue: TemporalDomainQueueDefinition[] =
+  versions["shepherdjerred/scout-for-lol/beta/workflows/stable"] !==
+    undefined &&
+  versions["shepherdjerred/scout-for-lol/beta/workflows/candidate"] !==
+    undefined &&
   scoutWorkflowWorkerImageIsCapable(
     versions["shepherdjerred/scout-for-lol/beta/workflows/stable"],
   ) &&

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -17,27 +17,43 @@ type TemporalDomainQueueDefinition = {
 // Do not install these rules until both tracks can render. A capable
 // candidate alone is insufficient: Scout's chart bootstraps the stable worker
 // first, so candidate-only alerts would fire on absent pods.
-const scoutBetaWorkflowQueue: TemporalDomainQueueDefinition[] =
-  scoutWorkflowWorkerImageIsCapable(
+function scoutWorkflowQueue(
+  stage: "beta" | "prod",
+  stableImage: string,
+  candidateImage: string,
+): TemporalDomainQueueDefinition[] {
+  if (
+    !scoutWorkflowWorkerImageIsCapable(stableImage) ||
+    !scoutWorkflowWorkerImageIsCapable(candidateImage)
+  ) {
+    return [];
+  }
+  const queue = `scout-${stage}`;
+  return [
+    {
+      queue,
+      metricsNamespace: queue,
+      deploymentPattern: `${queue}-scout-workflow-worker.*`,
+      servicePattern: ".*scout-workflow-worker.*metrics.*",
+      candidateDeploymentPattern: `${queue}-scout-workflow-worker-candidate`,
+      candidateServicePattern: ".*scout-workflow-worker-candidate.*metrics.*",
+      activityPoller: false,
+    },
+  ];
+}
+
+const scoutWorkflowQueues = [
+  ...scoutWorkflowQueue(
+    "beta",
     versions["shepherdjerred/scout-for-lol/beta/workflows/stable"],
-  ) &&
-  scoutWorkflowWorkerImageIsCapable(
     versions["shepherdjerred/scout-for-lol/beta/workflows/candidate"],
-  )
-    ? [
-        {
-          queue: "scout-beta",
-          metricsNamespace: "scout-beta",
-          deploymentPattern: "scout-beta-scout-workflow-worker.*",
-          servicePattern: ".*scout-workflow-worker.*metrics.*",
-          candidateDeploymentPattern:
-            "scout-beta-scout-workflow-worker-candidate",
-          candidateServicePattern:
-            ".*scout-workflow-worker-candidate.*metrics.*",
-          activityPoller: false,
-        },
-      ]
-    : [];
+  ),
+  ...scoutWorkflowQueue(
+    "prod",
+    versions["shepherdjerred/scout-for-lol/prod/workflows/stable"],
+    versions["shepherdjerred/scout-for-lol/prod/workflows/candidate"],
+  ),
+];
 
 export const TEMPORAL_DOMAIN_QUEUES: readonly TemporalDomainQueueDefinition[] =
   [
@@ -50,7 +66,7 @@ export const TEMPORAL_DOMAIN_QUEUES: readonly TemporalDomainQueueDefinition[] =
       candidateServicePattern: ".*temporal-workflows-candidate.*metrics.*",
       activityPoller: false,
     },
-    ...scoutBetaWorkflowQueue,
+    ...scoutWorkflowQueues,
     {
       queue: "home",
       metricsNamespace: "temporal",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -128,8 +128,10 @@ describe("Temporal workflow outcome rules", () => {
     expect(workflowPollerExpressions).toContain(
       'absent(temporal_worker_num_pollers{namespace="buildkite",exported_namespace="default",task_queue="maintenance",poller_type="workflow_task"}) or max(temporal_worker_num_pollers{namespace="buildkite",exported_namespace="default",task_queue="maintenance",poller_type="workflow_task"}) < 1',
     );
-    const scoutBetaExpression = workflowPollerExpressions.find((expression) =>
-      expression.includes('task_queue="scout-beta"'),
+    const scoutBetaExpression = workflowPollerExpressions.find(
+      (expression) =>
+        typeof expression === "string" &&
+        expression.includes('task_queue="scout-beta"'),
     );
     if (scoutBetaExpression !== undefined) {
       expect(scoutBetaExpression).toBe(

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -126,8 +126,16 @@ describe("Temporal workflow outcome rules", () => {
       )
       .map((rule) => rule.expr.value);
     expect(workflowPollerExpressions).toContain(
-      'absent(temporal_worker_num_pollers{namespace="temporal",exported_namespace="default",task_queue="maintenance",poller_type="workflow_task"}) or max(temporal_worker_num_pollers{namespace="temporal",exported_namespace="default",task_queue="maintenance",poller_type="workflow_task"}) < 1',
+      'absent(temporal_worker_num_pollers{namespace="buildkite",exported_namespace="default",task_queue="maintenance",poller_type="workflow_task"}) or max(temporal_worker_num_pollers{namespace="buildkite",exported_namespace="default",task_queue="maintenance",poller_type="workflow_task"}) < 1',
     );
+    const scoutBetaExpression = workflowPollerExpressions.find((expression) =>
+      expression.includes('task_queue="scout-beta"'),
+    );
+    if (scoutBetaExpression !== undefined) {
+      expect(scoutBetaExpression).toBe(
+        'absent(temporal_worker_num_pollers{namespace="scout-beta",exported_namespace="default",task_queue="scout-beta",poller_type="workflow_task"}) or max(temporal_worker_num_pollers{namespace="scout-beta",exported_namespace="default",task_queue="scout-beta",poller_type="workflow_task"}) < 1',
+      );
+    }
 
     const reportHeartbeat = failuresGroup.rules.find(
       (rule) => rule.alert === "TemporalReportHeartbeatStale",

--- a/packages/homelab/src/cdk8s/src/resources/scout/workflow-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/workflow-worker.ts
@@ -1,0 +1,128 @@
+import type { Chart } from "cdk8s";
+import { Size } from "cdk8s";
+import { z } from "zod";
+import {
+  Cpu,
+  Deployment,
+  DeploymentStrategy,
+  EnvValue,
+  Protocol,
+  Service,
+  Volume,
+} from "cdk8s-plus-31";
+import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
+import {
+  setRevisionHistoryLimit,
+  withCommonProps,
+} from "@shepherdjerred/homelab/cdk8s/src/misc/common.ts";
+import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import type { Stage } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/scout.ts";
+
+export type ScoutWorkflowWorkerTrack = "stable" | "candidate";
+
+// Build 12197 predates the workflow-only entrypoint. The main image release
+// overrides the candidate pin while rendering, so the first capable build can
+// create the pod in the same release without ever attempting to boot 12197.
+const LAST_IMAGE_WITHOUT_WORKFLOW_WORKER = 12_197;
+const WorkflowImageVersionSchema = z
+  .string()
+  .regex(/^2\.0\.0-(\d+)@sha256:[0-9a-f]{64}$/);
+
+export function scoutWorkflowWorkerImageIsCapable(
+  imageVersion: string,
+): boolean {
+  const parsed = WorkflowImageVersionSchema.parse(imageVersion);
+  const buildText = parsed.split("@", 1)[0]?.split("-", 2)[1];
+  const build = z.coerce.number().int().positive().parse(buildText);
+  return build > LAST_IMAGE_WITHOUT_WORKFLOW_WORKER;
+}
+
+export function createScoutWorkflowWorker(
+  chart: Chart,
+  stage: Stage,
+  track: ScoutWorkflowWorkerTrack,
+  imageVersionOverride?: string,
+): Deployment | undefined {
+  const component = `scout-${stage}-workflows-${track}`;
+  const name = `scout-workflow-worker-${track}`;
+  const imageKey = `shepherdjerred/scout-for-lol/${stage}/workflows/${track}`;
+  const imageVersion = imageVersionOverride ?? versions[imageKey];
+  if (imageVersion === undefined) {
+    throw new Error(`Missing Scout Workflow Worker image pin ${imageKey}`);
+  }
+  if (!scoutWorkflowWorkerImageIsCapable(imageVersion)) {
+    return undefined;
+  }
+
+  const deployment = new Deployment(chart, name, {
+    replicas: 1,
+    strategy: DeploymentStrategy.recreate(),
+    automountServiceAccountToken: false,
+    securityContext: { fsGroup: 1000 },
+    metadata: {
+      annotations: {
+        // The candidate poller must be healthy before a later backend release
+        // is allowed to stop its embedded Workflow poller.
+        "argocd.argoproj.io/sync-wave": "-1",
+      },
+    },
+    podMetadata: {
+      labels: {
+        app: "scout-workflow-worker",
+        component,
+        "worker-family": `scout-${stage}-workflows`,
+        track,
+      },
+    },
+  });
+  setRevisionHistoryLimit(deployment, 5);
+
+  const container = deployment.addContainer(
+    withCommonProps({
+      name,
+      image: `ghcr.io/shepherdjerred/scout-for-lol:${imageVersion}`,
+      command: ["bun"],
+      args: ["run", "src/temporal/workflow-worker.ts"],
+      ports: [{ name: "metrics", number: 9464, protocol: Protocol.TCP }],
+      securityContext: {
+        user: 1000,
+        group: 1000,
+        ensureNonRoot: true,
+        readOnlyRootFilesystem: true,
+      },
+      resources: {
+        cpu: { request: Cpu.millis(100), limit: Cpu.millis(500) },
+        memory: { request: Size.mebibytes(256), limit: Size.gibibytes(1) },
+      },
+      envVariables: {
+        ENVIRONMENT: EnvValue.fromValue(stage),
+        TEMPORAL_ADDRESS: EnvValue.fromValue(
+          "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
+        ),
+        TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+        TEMPORAL_NAMESPACE: EnvValue.fromValue("default"),
+        TEMPORAL_WORKER_DEPLOYMENT_NAME: EnvValue.fromValue(
+          `scout-${stage}-workflows`,
+        ),
+      },
+    }),
+  );
+  container.mount(
+    "/tmp",
+    Volume.fromEmptyDir(chart, `${name}-tmp`, `${component}-tmp`),
+  );
+
+  new Service(chart, `${name}-metrics-service`, {
+    metadata: {
+      labels: { component },
+    },
+    selector: deployment,
+    ports: [{ name: "metrics", port: 9464 }],
+  });
+  createServiceMonitor(chart, {
+    name: `${name}-metrics`,
+    matchLabels: { component },
+  });
+
+  return deployment;
+}

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
@@ -23,7 +23,7 @@ function metricsIngress(ports: readonly number[]) {
   ];
 }
 
-function dnsEgress() {
+export function createDnsEgressRule() {
   return {
     to: [
       {
@@ -53,7 +53,7 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
       policyTypes: ["Ingress", "Egress"],
       ingress: metricsIngress([9464, 9465]),
       egress: [
-        dnsEgress(),
+        createDnsEgressRule(),
         temporalServerEgress(),
         {
           to: [
@@ -86,7 +86,7 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
         policyTypes: ["Ingress", "Egress"],
         ingress: metricsIngress([9464, 9465]),
         egress: [
-          dnsEgress(),
+          createDnsEgressRule(),
           temporalServerEgress(),
           { ports: [{ port: IntOrString.fromNumber(443), protocol: "TCP" }] },
           { ports: [{ port: IntOrString.fromNumber(4318), protocol: "TCP" }] },

--- a/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
@@ -1,6 +1,49 @@
 import { describe, expect, test } from "vitest";
+import { App } from "cdk8s";
 import { z } from "zod";
-import { allScoutTemporalResources } from "./scout-test-resources.ts";
+import { createScoutChart } from "./cdk8s-charts/scout.ts";
+import {
+  allScoutTemporalResources,
+  resourcesFor,
+} from "./scout-test-resources.ts";
+import { scoutWorkflowWorkerImageIsCapable } from "./resources/scout/workflow-worker.ts";
+
+const CAPABLE_STABLE_IMAGE = `2.0.0-12198@sha256:${"a".repeat(64)}`;
+const CAPABLE_CANDIDATE_IMAGE = `2.0.0-12199@sha256:${"b".repeat(64)}`;
+
+function betaResourcesWithWorkflowCandidate() {
+  const app = new App();
+  createScoutChart(app, "beta", {
+    stable: CAPABLE_STABLE_IMAGE,
+    candidate: CAPABLE_CANDIDATE_IMAGE,
+  });
+  return resourcesFor(app);
+}
+
+const WorkflowDeploymentSpecSchema = z.object({
+  template: z.object({
+    spec: z.object({
+      automountServiceAccountToken: z.boolean(),
+      containers: z.array(
+        z.object({
+          args: z.array(z.string()),
+          command: z.array(z.string()),
+          env: z.array(
+            z.object({
+              name: z.string(),
+              value: z.string().optional(),
+              valueFrom: z.unknown().optional(),
+            }),
+          ),
+          volumeMounts: z.array(
+            z.object({ mountPath: z.string(), name: z.string() }),
+          ),
+        }),
+      ),
+      volumes: z.array(z.object({ name: z.string() }).loose()),
+    }),
+  }),
+});
 
 describe("Scout competition Temporal boundary", () => {
   test.each(["beta", "prod"] as const)(
@@ -65,6 +108,123 @@ describe("Scout competition Temporal boundary", () => {
     expect(serialized).toContain('"kubernetes.io/metadata.name":"scout-beta"');
     expect(serialized).toContain('"kubernetes.io/metadata.name":"scout-prod"');
     expect(serialized).toContain('"app":"scout-backend"');
+    expect(serialized).toContain('"worker-family":"scout-beta-workflows"');
+    expect(serialized).toContain('"worker-family":"scout-prod-workflows"');
     expect(serialized).toContain('"port":7233');
+  });
+
+  test("bootstraps a credentialless beta candidate without cutting over", () => {
+    const synthesized = betaResourcesWithWorkflowCandidate();
+    const deployment = synthesized.find(
+      (resource) =>
+        resource.kind === "Deployment" &&
+        resource.metadata.namespace === "scout-beta" &&
+        resource.metadata.name === "scout-beta-scout-workflow-worker-candidate",
+    );
+    const spec = WorkflowDeploymentSpecSchema.parse(deployment?.spec);
+    expect(deployment?.metadata["annotations"]).toEqual({
+      "argocd.argoproj.io/sync-wave": "-1",
+    });
+    expect(spec.template.spec.automountServiceAccountToken).toBe(false);
+    expect(spec.template.spec.containers).toHaveLength(1);
+    const container = spec.template.spec.containers[0];
+    expect(container?.command).toEqual(["bun"]);
+    expect(container?.args).toEqual(["run", "src/temporal/workflow-worker.ts"]);
+    expect(container?.env).toEqual([
+      { name: "TZ", value: "America/Los_Angeles" },
+      { name: "ENVIRONMENT", value: "beta" },
+      {
+        name: "TEMPORAL_ADDRESS",
+        value:
+          "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
+      },
+      { name: "TEMPORAL_METRICS_ADDRESS", value: "0.0.0.0:9464" },
+      { name: "TEMPORAL_NAMESPACE", value: "default" },
+      {
+        name: "TEMPORAL_WORKER_DEPLOYMENT_NAME",
+        value: "scout-beta-workflows",
+      },
+    ]);
+    expect(container?.env.every((entry) => entry.valueFrom === undefined)).toBe(
+      true,
+    );
+    expect(container?.volumeMounts).toEqual([
+      {
+        mountPath: "/tmp",
+        name: "scout-beta-workflows-candidate-tmp",
+      },
+    ]);
+    expect(spec.template.spec.volumes).toEqual([
+      expect.objectContaining({ name: "scout-beta-workflows-candidate-tmp" }),
+    ]);
+
+    expect(
+      synthesized.some(
+        (resource) =>
+          resource.kind === "Deployment" &&
+          resource.metadata.namespace === "scout-prod" &&
+          resource.metadata.name.includes("scout-workflow-worker"),
+      ),
+    ).toBe(false);
+  });
+
+  test("restricts the beta candidate to DNS, Temporal, and metrics", () => {
+    const policy = betaResourcesWithWorkflowCandidate().find(
+      (resource) =>
+        resource.kind === "NetworkPolicy" &&
+        resource.metadata.namespace === "scout-beta" &&
+        resource.metadata.name === "scout-workflow-worker-netpol",
+    );
+    const serialized = JSON.stringify(policy?.spec);
+    expect(policy?.metadata["annotations"]).toEqual({
+      "argocd.argoproj.io/sync-wave": "-2",
+    });
+    expect(serialized).toContain('"worker-family":"scout-beta-workflows"');
+    expect(serialized).toContain('"port":53');
+    expect(serialized).toContain('"port":7233');
+    expect(serialized).toContain('"port":9464');
+    expect(serialized).not.toContain('"port":5432');
+    expect(serialized).not.toContain('"port":443');
+  });
+
+  test("does not boot the pre-entrypoint candidate pin", () => {
+    expect(
+      scoutWorkflowWorkerImageIsCapable(`2.0.0-12197@sha256:${"a".repeat(64)}`),
+    ).toBe(false);
+    expect(scoutWorkflowWorkerImageIsCapable(CAPABLE_STABLE_IMAGE)).toBe(true);
+    expect(
+      allScoutTemporalResources().some(
+        (resource) =>
+          resource.kind === "Deployment" &&
+          resource.metadata.name.includes("scout-workflow-worker"),
+      ),
+    ).toBe(false);
+  });
+
+  test("requires a stable capable build before creating the candidate", () => {
+    const onlyCandidateApp = new App();
+    createScoutChart(onlyCandidateApp, "beta", {
+      candidate: CAPABLE_CANDIDATE_IMAGE,
+    });
+    expect(
+      resourcesFor(onlyCandidateApp).some((resource) =>
+        resource.metadata.name.includes("workflow-worker"),
+      ),
+    ).toBe(false);
+
+    const stableOnlyApp = new App();
+    createScoutChart(stableOnlyApp, "beta", {
+      stable: CAPABLE_STABLE_IMAGE,
+      candidate: CAPABLE_STABLE_IMAGE,
+    });
+    const deployments = resourcesFor(stableOnlyApp).filter(
+      (resource) =>
+        resource.kind === "Deployment" &&
+        resource.metadata.name.includes("workflow-worker"),
+    );
+    expect(deployments.map((deployment) => deployment.metadata.name)).toEqual([
+      "scout-beta-scout-workflow-worker-stable",
+      "scout-beta-scout-workflow-worker-candidate",
+    ]);
   });
 });

--- a/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
@@ -20,6 +20,15 @@ function betaResourcesWithWorkflowCandidate() {
   return resourcesFor(app);
 }
 
+function prodResourcesWithWorkflowCandidate() {
+  const app = new App();
+  createScoutChart(app, "prod", {
+    stable: CAPABLE_STABLE_IMAGE,
+    candidate: CAPABLE_CANDIDATE_IMAGE,
+  });
+  return resourcesFor(app);
+}
+
 const WorkflowDeploymentSpecSchema = z.object({
   template: z.object({
     spec: z.object({
@@ -186,7 +195,6 @@ describe("Scout competition Temporal boundary", () => {
     expect(serialized).not.toContain('"port":5432');
     expect(serialized).not.toContain('"port":443');
   });
-
   test("does not boot the pre-entrypoint candidate pin", () => {
     expect(
       scoutWorkflowWorkerImageIsCapable(`2.0.0-12197@sha256:${"a".repeat(64)}`),
@@ -200,7 +208,6 @@ describe("Scout competition Temporal boundary", () => {
       ),
     ).toBe(false);
   });
-
   test("requires a stable capable build before creating the candidate", () => {
     const onlyCandidateApp = new App();
     createScoutChart(onlyCandidateApp, "beta", {
@@ -227,4 +234,30 @@ describe("Scout competition Temporal boundary", () => {
       "scout-beta-scout-workflow-worker-candidate",
     ]);
   });
+});
+
+test("renders capable production Workflow tracks", () => {
+  const synthesized = prodResourcesWithWorkflowCandidate();
+  expect(
+    synthesized.some(
+      (resource) =>
+        resource.kind === "Deployment" &&
+        resource.metadata.name === "scout-prod-scout-workflow-worker-stable",
+    ),
+  ).toBe(true);
+  expect(
+    synthesized.some(
+      (resource) =>
+        resource.kind === "Deployment" &&
+        resource.metadata.name === "scout-prod-scout-workflow-worker-candidate",
+    ),
+  ).toBe(true);
+  const workerPolicy = synthesized.find(
+    (resource) =>
+      resource.kind === "NetworkPolicy" &&
+      resource.metadata.name === "scout-workflow-worker-netpol",
+  );
+  expect(JSON.stringify(workerPolicy?.spec)).toContain(
+    '"worker-family":"scout-prod-workflows"',
+  );
 });

--- a/packages/scout-for-lol/README.md
+++ b/packages/scout-for-lol/README.md
@@ -105,6 +105,10 @@ are one-shot and each command starts a new saved conversation.
   scheduled/user-authored report queries
 - Temporal schedules handle recurring maintenance (queue-window drift
   detection, marketing showcase refresh, image GC)
+- Scout beta bootstraps deterministic Workflow versioning with a capable stable
+  image followed by a distinct credentialless candidate; the backend retains
+  its embedded drain poller and all effectful Activity Workers until the
+  candidate is promoted and soaked
 - PostHog for privacy-scoped server-side product analytics
 - Docker image built and deployed from CI; beta deploys continuously and prod
   is promoted via a Renovate image-pin PR

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -81,6 +81,13 @@ rollout is running.
 Roll out Scout beta before Scout production. Mutating Scout production actions
 verify that the same Build ID is already the current, unramped beta version with
 a healthy beta Workflow poller; rollback remains available independently.
+Scout bootstrap requires two capable image releases because the unversioned
+embedded poller cannot be a Worker Deployment rollback version. A pin at or
+before build 12197 creates no workflow-only pod. Copy the first capable
+candidate pin to stable to create only the stable poller; a later distinct
+candidate pin creates the ramp target. Never remove the embedded poller before
+candidate replay, canary, soak, stable-pin promotion, and a healthy stable
+poller. Repeat the sequence for production only after beta runtime acceptance.
 
 ## Structure
 

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -73,6 +73,12 @@ checks or alert windows are failing.
 The target defaults to `central`; `--target scout-beta` and `--target
 scout-prod` select the stage-local Scout deployment, queue, replay bundle,
 pinned canary, image repository, and catalog pins.
+Scout extraction uses two capable image releases. The pre-entrypoint pin creates
+no pod. Copy the first capable candidate pin to stable; that creates only the
+credentialless stable poller. A later distinct candidate pin creates the ramp
+target, and `start --stable-build-id` establishes stable before sending 10% to
+candidate. The embedded poller remains only to drain old unversioned histories.
+Production remains embedded until beta acceptance completes.
 
 ## Documentation
 

--- a/packages/temporal/src/lib/worker-deployment-rollout.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.ts
@@ -296,6 +296,7 @@ async function requireRegisteredWorkflowVersion(
     ),
   );
 }
+
 async function executeStart(
   options: WorkerDeploymentRolloutOptions,
   status: WorkerDeploymentRolloutStatus,

--- a/packages/temporal/src/lib/worker-deployment-rollout.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.ts
@@ -296,7 +296,6 @@ async function requireRegisteredWorkflowVersion(
     ),
   );
 }
-
 async function executeStart(
   options: WorkerDeploymentRolloutOptions,
   status: WorkerDeploymentRolloutStatus,


### PR DESCRIPTION
## Why

Scout beta needs a credentialless workflow-only candidate poller before its credentialed backend can safely stop polling deterministic Workflow tasks. The current stable image predates the new entrypoint, so deploying both tracks or disabling the embedded poller in the same release would create an unsafe cutover.

## What

- deploy only the `scout-beta-workflows` candidate from its immutable workflow candidate pin
- run the workflow-only Bun entrypoint with no service-account token, credentials, or product-data volumes
- restrict the pod to DNS and Temporal egress plus Prometheus metrics ingress
- allow the stage Worker Deployment identity through the Temporal server NetworkPolicy
- order the candidate before any later backend cutover with Argo sync wave `-1`
- keep the beta embedded poller and all Scout production polling unchanged
- document the replay, canary, soak, stable-pin promotion, and later extraction boundary

## Verification

- `bunx turbo run lint typecheck --filter=@homelab/cdk8s`
- `bun test packages/homelab/src/cdk8s/src/scout-temporal.test.ts packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts packages/homelab/src/cdk8s/src/container-resources.test.ts` (15 tests)
- `bun run --cwd packages/docs/wiki build` (59 pages)
- `bunx lefthook run pre-commit`

Live beta rollout was not run.

## Rollout

Keep this PR draft and do not sync it until PR #2542 is merged, its Scout image is baked, and the beta workflow candidate pin references that image. After sync, require registered poller, retained-history replay, version-targeted canary, clean ramp, and 24-hour soak. Promote the stable pin before a separate release installs the stable pod and removes embedded beta polling. Scout production remains blocked on beta acceptance.