### PR TITLE
Add isolated Discord slash invocation to Toolkit

### DIFF
--- a/packages/dotfiles/dot_agents/skills/discord/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/discord/SKILL.md
@@ -9,7 +9,7 @@ description: |
 
 Two ways to act on Discord, both verified live on 2026-08-29:
 
-1. **`toolkit discord`** (recommended for common ops) — a session daemon that logs in once, holds the gateway connections in memory, and exposes one-shot CLI commands. One `op` call per session; no boilerplate; voice presence persists between commands.
+1. **`toolkit discord`** (recommended for common ops) — use its session daemon for interactive work, or `discord slash --direct` for an isolated invocation that must not disturb a running daemon.
 2. **Write a Bun/TypeScript script** (escape hatch) — for anything the CLI doesn't cover. Same libraries underneath.
 
 ## Credentials
@@ -76,6 +76,21 @@ toolkit discord voice states <guildId>          # who's in VC + streaming/video 
 toolkit discord voice leave
 toolkit discord daemon stop
 ```
+
+For an isolated smoke test, skip the daemon entirely. Direct mode logs in only
+the user identity, subscribes before invoking, and destroys that gateway at the
+deadline even when login, invocation, or response waiting fails:
+
+```bash
+toolkit discord slash <channelId> <botId> bb transfer recipient:<userId> amount:3 \
+  --direct --wait-public --contains "Bryan Bucks Western Union" \
+  --timeout 45 --json
+```
+
+The JSON contains `reply` and `publicResponse` message objects. Each carries
+`mentionUserIds`, `mentionRoleIds`, and `mentionsEveryone`, so a smoke runner can
+verify allowed mentions exactly. Direct mode requires `DISCORD_USER_TOKEN`; it
+does not read `DISCORD_BOT_TOKEN` or connect to the shared daemon.
 
 All commands print markdown by default; add `--json` for machine-readable output. The streambot test loop is just: `voice states <guild>` and check whose `streaming` flag is set.
 

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -188,6 +188,8 @@ export DISCORD_USER_TOKEN=$(op read "op://Personal/<item-id>/TOKEN")
 toolkit discord daemon start --ttl 30m      # also reads DISCORD_BOT_TOKEN if set
 toolkit discord send <channelId> "hello"
 toolkit discord slash <channelId> <botId> <command> [args...]   # userbot only
+toolkit discord slash <channelId> <botId> <command> [args...] \
+  --direct --wait-public --contains "receipt text" --timeout 45 --json
 toolkit discord voice join <channelId>      # presence persists between commands
 toolkit discord voice states <guildId>      # streaming flags (needs a bot token)
 toolkit discord daemon stop
@@ -198,6 +200,12 @@ Design notes encoded in the code:
 - **At least one of `DISCORD_BOT_TOKEN` / `DISCORD_USER_TOKEN`** must be set; each
   client is optional and commands route to the identity they need (slash + voice
   join are userbot-only; voice states is bot-only).
+- `discord slash --direct` is the isolated automation path. It never contacts or
+  disturbs the session daemon, logs in only `DISCORD_USER_TOKEN`, installs its
+  public-response listener before invoking, and always destroys the gateway at
+  its deadline. `--wait-public` filters to the target bot; `--contains` narrows
+  the response. JSON includes the immediate interaction reply, the public
+  response, and exact user, role, and everyone mentions for each message.
 - Tokens are passed to the detached daemon via **env, never argv** (not visible in
   `ps`) and never written to the state file or logs.
 - State dir `~/.toolkit/discord/`: `daemon.sock` (0600), `state.json` (pid +

--- a/packages/toolkit/src/commands/discord/slash.ts
+++ b/packages/toolkit/src/commands/discord/slash.ts
@@ -1,5 +1,9 @@
 import { daemonRequest } from "#lib/discord/client.ts";
-import { SlashResponseSchema } from "#lib/discord/ipc.ts";
+import { invokeSlashDirect } from "#lib/discord/direct-slash.ts";
+import {
+  DirectSlashResponseSchema,
+  SlashResponseSchema,
+} from "#lib/discord/ipc.ts";
 import { renderMessage } from "#lib/discord/render.ts";
 
 export async function slashCommand(params: {
@@ -8,13 +12,42 @@ export async function slashCommand(params: {
   command: string;
   args: string[];
   json: boolean;
+  direct: boolean;
+  waitForPublicResponse: boolean;
+  publicResponseContains?: string | undefined;
+  timeoutSeconds: number;
 }): Promise<void> {
+  if (params.direct) {
+    const result = DirectSlashResponseSchema.parse(
+      await invokeSlashDirect({
+        token: requireUserToken(),
+        channelId: params.channelId,
+        botId: params.botId,
+        command: params.command,
+        args: params.args,
+        waitForPublicResponse: params.waitForPublicResponse,
+        publicResponseContains: params.publicResponseContains,
+        timeoutSeconds: params.timeoutSeconds,
+      }),
+    );
+    renderResult(result, params);
+    return;
+  }
   const result = await daemonRequest(SlashResponseSchema, "/slash", {
     channelId: params.channelId,
     botId: params.botId,
     command: params.command,
     args: params.args,
   });
+  renderResult(result, params);
+}
+
+function renderResult(
+  result:
+    | ReturnType<typeof SlashResponseSchema.parse>
+    | ReturnType<typeof DirectSlashResponseSchema.parse>,
+  params: { json: boolean; command: string; botId: string },
+): void {
   if (params.json) {
     console.log(JSON.stringify(result, null, 2));
     return;
@@ -24,4 +57,21 @@ export async function slashCommand(params: {
     console.log("\nReply:");
     console.log(renderMessage(result.reply));
   }
+  if (DirectSlashResponseSchema.safeParse(result).success) {
+    const directResult = DirectSlashResponseSchema.parse(result);
+    if (directResult.publicResponse !== null) {
+      console.log("\nPublic response:");
+      console.log(renderMessage(directResult.publicResponse));
+    } else if (directResult.publicResponseTimedOut) {
+      console.log("\nNo matching public response arrived before the timeout.");
+    }
+  }
+}
+
+function requireUserToken(): string {
+  const token = Bun.env["DISCORD_USER_TOKEN"];
+  if (token == null || token.length === 0) {
+    throw new Error("--direct requires DISCORD_USER_TOKEN");
+  }
+  return token;
 }

--- a/packages/toolkit/src/handlers/discord.ts
+++ b/packages/toolkit/src/handlers/discord.ts
@@ -38,6 +38,7 @@ Commands (talk to the running daemon):
   toolkit discord read <channelId> [-n 20] [--json]      Recent messages (incl. embeds)
   toolkit discord wait <channelId> [--from <userId>] [--contains <str>] [--timeout 30]
   toolkit discord slash <channelId> <botId> <command> [args…]   Invoke another bot's slash command (userbot)
+    --direct [--wait-public] [--contains <str>] [--timeout 30]   Use an isolated one-shot user gateway
   toolkit discord voice join <channelId>                 Userbot joins VC; presence persists
   toolkit discord voice leave
   toolkit discord voice states <guildId> [--json]        Who's in VC, streaming flags
@@ -168,17 +169,46 @@ async function handleWait(args: string[]): Promise<void> {
 }
 
 async function handleSlash(args: string[]): Promise<void> {
-  const { values, positionals } = parseJsonFlag(args);
-  const usage = "toolkit discord slash <channelId> <botId> <command> [args…]";
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      json: { type: "boolean", default: false },
+      direct: { type: "boolean", default: false },
+      "wait-public": { type: "boolean", default: false },
+      contains: { type: "string" },
+      timeout: { type: "string" },
+    },
+    allowPositionals: true,
+  });
+  const usage =
+    "toolkit discord slash <channelId> <botId> <command> [args…] [--direct --wait-public --contains <str> --timeout 30]";
   const channelId = requirePositional(positionals, 0, "channel id", usage);
   const botId = requirePositional(positionals, 1, "bot id", usage);
   const command = requirePositional(positionals, 2, "command name", usage);
+  const timeoutSeconds = Number.parseInt(values.timeout ?? "30", 10);
+  if (
+    !Number.isInteger(timeoutSeconds) ||
+    timeoutSeconds < 1 ||
+    timeoutSeconds > 600
+  ) {
+    throw new Error("--timeout must be a whole number from 1 through 600");
+  }
+  if (values["wait-public"] && !values.direct) {
+    throw new Error("--wait-public requires --direct");
+  }
+  if (values.contains != null && !values["wait-public"]) {
+    throw new Error("--contains requires --wait-public");
+  }
   await slashCommand({
     channelId,
     botId,
     command,
     args: positionals.slice(3),
     json: values.json,
+    direct: values.direct,
+    waitForPublicResponse: values["wait-public"],
+    publicResponseContains: values.contains,
+    timeoutSeconds,
   });
 }
 

--- a/packages/toolkit/src/lib/discord/direct-slash.ts
+++ b/packages/toolkit/src/lib/discord/direct-slash.ts
@@ -1,0 +1,189 @@
+import {
+  Client as UserClient,
+  Message as UserMessage,
+} from "discord.js-selfbot-v13";
+import { mapUserMessage, messageMatches } from "#lib/discord/handlers.ts";
+import type { DirectSlashResponse, IpcMessage } from "#lib/discord/ipc.ts";
+
+export type DirectSlashGateway = {
+  connect: (
+    token: string,
+    onMessage: (message: IpcMessage) => void,
+  ) => Promise<string>;
+  invoke: (params: {
+    channelId: string;
+    botId: string;
+    command: string;
+    args: string[];
+  }) => Promise<IpcMessage | null>;
+  close: () => void;
+};
+
+export type DirectSlashParameters = {
+  token: string;
+  channelId: string;
+  botId: string;
+  command: string;
+  args: string[];
+  waitForPublicResponse: boolean;
+  publicResponseContains?: string | undefined;
+  timeoutSeconds: number;
+};
+
+async function rejectAfter<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+  message: string,
+): Promise<T> {
+  const timeout = Promise.withResolvers<T>();
+  const timer = setTimeout(() => {
+    timeout.reject(new Error(message));
+  }, milliseconds);
+  try {
+    return await Promise.race([promise, timeout.promise]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function nullAfter<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+): Promise<T | null> {
+  const timeout = Promise.withResolvers<null>();
+  const timer = setTimeout(() => {
+    timeout.resolve(null);
+  }, milliseconds);
+  try {
+    return await Promise.race([promise, timeout.promise]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function remainingMilliseconds(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class SelfbotDirectSlashGateway implements DirectSlashGateway {
+  readonly #client = new UserClient();
+  #messageListener: ((message: UserMessage) => void) | null = null;
+
+  async connect(
+    token: string,
+    onMessage: (message: IpcMessage) => void,
+  ): Promise<string> {
+    this.#messageListener = (message: UserMessage): void => {
+      onMessage(mapUserMessage(message));
+    };
+    this.#client.on("messageCreate", this.#messageListener);
+
+    const ready = new Promise<void>((resolve, reject) => {
+      const onReady = (): void => {
+        this.#client.off("error", onError);
+        resolve();
+      };
+      const onError = (error: Error): void => {
+        this.#client.off("ready", onReady);
+        reject(error);
+      };
+      this.#client.once("ready", onReady);
+      this.#client.once("error", onError);
+    });
+    await this.#client.login(token);
+    await ready;
+    const user = this.#client.user;
+    if (user === null) {
+      throw new Error("Discord user gateway became ready without a user");
+    }
+    return user.id;
+  }
+
+  async invoke(params: {
+    channelId: string;
+    botId: string;
+    command: string;
+    args: string[];
+  }): Promise<IpcMessage | null> {
+    const channel = await this.#client.channels.fetch(params.channelId);
+    if (channel?.isText() !== true) {
+      throw new Error(`Channel ${params.channelId} is not a user text channel`);
+    }
+    const result = await channel.sendSlash(
+      params.botId,
+      params.command,
+      ...params.args,
+    );
+    return result instanceof UserMessage ? mapUserMessage(result) : null;
+  }
+
+  close(): void {
+    if (this.#messageListener !== null) {
+      this.#client.off("messageCreate", this.#messageListener);
+      this.#messageListener = null;
+    }
+    try {
+      this.#client.destroy();
+    } catch (error) {
+      console.error(
+        `Discord user gateway teardown failed: ${errorMessage(error)}`,
+      );
+    }
+  }
+}
+
+export async function invokeSlashDirect(
+  params: DirectSlashParameters,
+  gateway: DirectSlashGateway = new SelfbotDirectSlashGateway(),
+): Promise<DirectSlashResponse> {
+  const deadline = Date.now() + params.timeoutSeconds * 1000;
+  let resolvePublicResponse: ((message: IpcMessage) => void) | null = null;
+  const publicResponsePromise = new Promise<IpcMessage>((resolve) => {
+    resolvePublicResponse = resolve;
+  });
+  const onMessage = (message: IpcMessage): void => {
+    if (
+      params.waitForPublicResponse &&
+      messageMatches(message, {
+        channelId: params.channelId,
+        fromUserId: params.botId,
+        contains: params.publicResponseContains,
+      })
+    ) {
+      resolvePublicResponse?.(message);
+    }
+  };
+
+  try {
+    if (params.token.length === 0) {
+      throw new Error("Direct Discord slash invocation requires a user token");
+    }
+    const invokingUserId = await rejectAfter(
+      gateway.connect(params.token, onMessage),
+      remainingMilliseconds(deadline),
+      `Discord user gateway did not become ready within ${String(params.timeoutSeconds)} seconds`,
+    );
+    const reply = await rejectAfter(
+      gateway.invoke(params),
+      remainingMilliseconds(deadline),
+      `Discord slash invocation did not finish within ${String(params.timeoutSeconds)} seconds`,
+    );
+    const publicResponse = params.waitForPublicResponse
+      ? await nullAfter(publicResponsePromise, remainingMilliseconds(deadline))
+      : null;
+    return {
+      invoked: true,
+      invokingUserId,
+      reply,
+      publicResponse,
+      publicResponseTimedOut:
+        params.waitForPublicResponse && publicResponse === null,
+    };
+  } finally {
+    gateway.close();
+  }
+}

--- a/packages/toolkit/src/lib/discord/handlers.ts
+++ b/packages/toolkit/src/lib/discord/handlers.ts
@@ -43,7 +43,19 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function mapBotMessage(message: BotMessage): IpcMessage {
+export function mapMessageMentions(
+  userIds: Iterable<string>,
+  roleIds: Iterable<string>,
+  everyone: boolean,
+): Pick<IpcMessage, "mentionUserIds" | "mentionRoleIds" | "mentionsEveryone"> {
+  return {
+    mentionUserIds: [...userIds].toSorted(),
+    mentionRoleIds: [...roleIds].toSorted(),
+    mentionsEveryone: everyone,
+  };
+}
+
+export function mapBotMessage(message: BotMessage): IpcMessage {
   return {
     id: message.id,
     channelId: message.channelId,
@@ -64,10 +76,15 @@ function mapBotMessage(message: BotMessage): IpcMessage {
       name: attachment.name,
       url: attachment.url,
     })),
+    ...mapMessageMentions(
+      message.mentions.users.keys(),
+      message.mentions.roles.keys(),
+      message.mentions.everyone,
+    ),
   };
 }
 
-function mapUserMessage(message: UserMessage): IpcMessage {
+export function mapUserMessage(message: UserMessage): IpcMessage {
   return {
     id: message.id,
     channelId: message.channelId,
@@ -88,6 +105,11 @@ function mapUserMessage(message: UserMessage): IpcMessage {
       name: attachment.name ?? "attachment",
       url: attachment.url,
     })),
+    ...mapMessageMentions(
+      message.mentions.users.keys(),
+      message.mentions.roles.keys(),
+      message.mentions.everyone,
+    ),
   };
 }
 
@@ -175,7 +197,7 @@ async function handleRead(ctx: DaemonContext, body: unknown): Promise<unknown> {
   return { messages };
 }
 
-function messageMatches(
+export function messageMatches(
   message: IpcMessage,
   request: {
     channelId: string;

--- a/packages/toolkit/src/lib/discord/ipc.ts
+++ b/packages/toolkit/src/lib/discord/ipc.ts
@@ -58,6 +58,11 @@ export const MessageSchema = z.object({
   createdAt: z.string(),
   embeds: z.array(EmbedSchema),
   attachments: z.array(z.object({ name: z.string(), url: z.string() })),
+  // Daemons started before direct slash support omit mention metadata. Defaults
+  // keep their read/wait/slash responses usable until their normal TTL restart.
+  mentionUserIds: z.array(z.string()).default([]),
+  mentionRoleIds: z.array(z.string()).default([]),
+  mentionsEveryone: z.boolean().default(false),
 });
 export type IpcMessage = z.infer<typeof MessageSchema>;
 
@@ -113,6 +118,15 @@ export const SlashResponseSchema = z.object({
   invoked: z.boolean(),
   reply: MessageSchema.nullable(),
 });
+
+export const DirectSlashResponseSchema = z.object({
+  invoked: z.boolean(),
+  invokingUserId: z.string(),
+  reply: MessageSchema.nullable(),
+  publicResponse: MessageSchema.nullable(),
+  publicResponseTimedOut: z.boolean(),
+});
+export type DirectSlashResponse = z.infer<typeof DirectSlashResponseSchema>;
 
 export const VoiceJoinRequestSchema = z.object({
   channelId: z.string(),

--- a/packages/toolkit/test/discord/ipc.test.ts
+++ b/packages/toolkit/test/discord/ipc.test.ts
@@ -42,8 +42,29 @@ describe("ipc schemas", () => {
         },
       ],
       attachments: [{ name: "a.png", url: "https://example.com/a.png" }],
+      mentionUserIds: ["4"],
+      mentionRoleIds: ["5"],
+      mentionsEveryone: false,
     };
     expect(MessageSchema.parse(message)).toEqual(message);
+  });
+
+  test("adds mention metadata omitted by an older running daemon", () => {
+    const parsed = MessageSchema.parse({
+      id: "1",
+      channelId: "2",
+      authorId: "3",
+      authorTag: "someone#0",
+      authorIsBot: false,
+      content: "hello",
+      createdAt: "2026-06-12T00:00:00.000Z",
+      embeds: [],
+      attachments: [],
+    });
+
+    expect(parsed.mentionUserIds).toEqual([]);
+    expect(parsed.mentionRoleIds).toEqual([]);
+    expect(parsed.mentionsEveryone).toBe(false);
   });
 
   test("status response requires voice to be present (nullable)", () => {

--- a/packages/toolkit/test/discord/render.test.ts
+++ b/packages/toolkit/test/discord/render.test.ts
@@ -22,6 +22,9 @@ const message: IpcMessage = {
     },
   ],
   attachments: [],
+  mentionUserIds: [],
+  mentionRoleIds: [],
+  mentionsEveryone: false,
 };
 
 describe("renderMessages", () => {

--- a/packages/toolkit/test/history/cli.test.ts
+++ b/packages/toolkit/test/history/cli.test.ts
@@ -14,6 +14,8 @@ import type { HistorySourceResult } from "#lib/history/types.ts";
 
 let fixtureHome = "";
 let recordId = 0;
+const fixtureUpdatedAt = new Date().toISOString();
+const fixtureCreatedAt = new Date(Date.now() - 60_000).toISOString();
 
 function unavailable(
   source: "cursor" | "claude",
@@ -43,15 +45,31 @@ beforeAll(async () => {
       full_message TEXT, created_at TEXT
     );
   `);
-  database.run(
-    "INSERT INTO sessions VALUES ('current-session', 'Synthetic history', '2026-08-18T00:00:00Z', '2026-08-18T00:02:00Z', 'model', 'agent', '/fixture')",
-  );
-  database.run(
-    "INSERT INTO session_messages VALUES ('m1', 'current-session', 'user', 'Investigate synthetic history ranking', NULL, '2026-08-18T00:00:00Z')",
-  );
-  database.run(
-    "INSERT INTO session_messages VALUES ('m2', 'current-session', 'assistant', 'Synthetic history answer', NULL, '2026-08-18T00:01:00Z')",
-  );
+  database.run("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)", [
+    "current-session",
+    "Synthetic history",
+    fixtureCreatedAt,
+    fixtureUpdatedAt,
+    "model",
+    "agent",
+    "/fixture",
+  ]);
+  database.run("INSERT INTO session_messages VALUES (?, ?, ?, ?, ?, ?)", [
+    "m1",
+    "current-session",
+    "user",
+    "Investigate synthetic history ranking",
+    null,
+    fixtureCreatedAt,
+  ]);
+  database.run("INSERT INTO session_messages VALUES (?, ?, ?, ?, ?, ?)", [
+    "m2",
+    "current-session",
+    "assistant",
+    "Synthetic history answer",
+    null,
+    fixtureUpdatedAt,
+  ]);
   database.close();
 
   const conductor = createHistorySources().find(
@@ -77,8 +95,8 @@ beforeAll(async () => {
           path: "/fixture/codex-collision",
           workspace: "/fixture",
           agent: "fixture",
-          createdAt: "2026-08-18T00:00:00Z",
-          updatedAt: "2026-08-18T00:01:00Z",
+          createdAt: fixtureCreatedAt,
+          updatedAt: fixtureUpdatedAt,
           runtimeId: "current-session",
           openingPromptHash: null,
           dialogueText: "Unique collisionterm dialogue",

--- a/packages/toolkit/test/lib/discord-direct-slash.test.ts
+++ b/packages/toolkit/test/lib/discord-direct-slash.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  type DirectSlashGateway,
+  invokeSlashDirect,
+} from "#lib/discord/direct-slash.ts";
+import { mapMessageMentions } from "#lib/discord/handlers.ts";
+import type { IpcMessage } from "#lib/discord/ipc.ts";
+
+function message(overrides: Partial<IpcMessage> = {}): IpcMessage {
+  return {
+    id: "message-1",
+    channelId: "channel-1",
+    authorId: "bot-1",
+    authorTag: "Derrej#8685",
+    authorIsBot: true,
+    content: "public receipt",
+    createdAt: "2026-08-29T00:00:00.000Z",
+    embeds: [],
+    attachments: [],
+    mentionUserIds: ["recipient", "sender"],
+    mentionRoleIds: [],
+    mentionsEveryone: false,
+    ...overrides,
+  };
+}
+
+class FakeGateway implements DirectSlashGateway {
+  closed = false;
+  invoked = false;
+  onInvoke: ((onMessage: (message: IpcMessage) => void) => void) | null = null;
+  #onMessage: ((message: IpcMessage) => void) | null = null;
+
+  async connect(
+    _token: string,
+    onMessage: (message: IpcMessage) => void,
+  ): Promise<string> {
+    this.#onMessage = onMessage;
+    return "user-1";
+  }
+
+  async invoke(): Promise<IpcMessage> {
+    this.invoked = true;
+    if (this.#onMessage === null) {
+      throw new Error("Fake gateway was invoked before connection");
+    }
+    this.onInvoke?.(this.#onMessage);
+    return message({ id: "private-reply", content: "private acknowledgement" });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+const parameters = {
+  token: "user-token",
+  channelId: "channel-1",
+  botId: "bot-1",
+  command: "bb",
+  args: ["transfer", "recipient", "3"],
+  waitForPublicResponse: true,
+  publicResponseContains: "receipt",
+  timeoutSeconds: 30,
+};
+
+describe("invokeSlashDirect", () => {
+  test("returns the private reply and matching public response", async () => {
+    const gateway = new FakeGateway();
+    gateway.onInvoke = (onMessage) => {
+      onMessage(message({ id: "ignored", content: "something else" }));
+      onMessage(message({ id: "public-receipt" }));
+    };
+
+    const result = await invokeSlashDirect(parameters, gateway);
+
+    expect(result).toEqual({
+      invoked: true,
+      invokingUserId: "user-1",
+      reply: message({
+        id: "private-reply",
+        content: "private acknowledgement",
+      }),
+      publicResponse: message({ id: "public-receipt" }),
+      publicResponseTimedOut: false,
+    });
+    expect(gateway.invoked).toBe(true);
+    expect(gateway.closed).toBe(true);
+  });
+
+  test("returns a structured timeout and closes the gateway", async () => {
+    vi.useFakeTimers();
+    try {
+      const gateway = new FakeGateway();
+      const resultPromise = invokeSlashDirect(
+        { ...parameters, timeoutSeconds: 1 },
+        gateway,
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        publicResponse: null,
+        publicResponseTimedOut: true,
+      });
+      expect(gateway.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects a missing credential before invocation and still closes", async () => {
+    const gateway = new FakeGateway();
+
+    await expect(
+      invokeSlashDirect({ ...parameters, token: "" }, gateway),
+    ).rejects.toThrow("requires a user token");
+    expect(gateway.invoked).toBe(false);
+    expect(gateway.closed).toBe(true);
+  });
+
+  test("closes the gateway when invocation fails", async () => {
+    const gateway = new FakeGateway();
+    gateway.invoke = () => Promise.reject(new Error("Discord rejected it"));
+
+    await expect(invokeSlashDirect(parameters, gateway)).rejects.toThrow(
+      "Discord rejected it",
+    );
+    expect(gateway.closed).toBe(true);
+  });
+
+  test("a hanging invocation hits the watchdog and closes the gateway", async () => {
+    vi.useFakeTimers();
+    try {
+      const gateway = new FakeGateway();
+      gateway.invoke = () =>
+        new Promise(() => {
+          // Deliberately pending so the invocation watchdog owns teardown.
+        });
+      const resultPromise = invokeSlashDirect(
+        { ...parameters, timeoutSeconds: 1 },
+        gateway,
+      );
+      const expectation = expect(resultPromise).rejects.toThrow(
+        "slash invocation did not finish",
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expectation;
+      expect(gateway.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+test("mention extraction preserves exact users, roles, and everyone", () => {
+  expect(
+    mapMessageMentions(["user-2", "user-1"], ["role-2", "role-1"], true),
+  ).toEqual({
+    mentionUserIds: ["user-1", "user-2"],
+    mentionRoleIds: ["role-1", "role-2"],
+    mentionsEveryone: true,
+  });
+});


### PR DESCRIPTION
## Why

Bot smoke tests need to invoke Discord commands without connecting the shared session daemon to the same application token as the bot under test. The one-shot path also needs machine-readable evidence and a hard lifetime so failed automation cannot leave a user gateway running.

## What

- add `toolkit discord slash --direct` using only `DISCORD_USER_TOKEN`
- optionally wait for a filtered public response while retaining the immediate interaction reply
- return exact user, role, and everyone mention data in JSON
- enforce a shared login/invocation/response deadline and always destroy the isolated gateway
- document the direct workflow in Toolkit and the tracked Discord skill
- make the history CLI fixture use rolling timestamps so its seven-day test remains stable

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/toolkit`
- focused Discord tests: 17 passed
- Toolkit suite: 212 passed
- `bunx lefthook run pre-commit`

Live Discord invocation is intentionally deferred to the Scout smoke-runner PR above this foundation.