### PR TITLE
Add an isolated Scout Discord smoke runtime

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -16,7 +16,7 @@ Set `FLIPT_URL` to the reachable Flipt endpoint. The checker never guesses an
 endpoint and does not run during service startup or CI.
 
 ```bash
-export FLIPT_URL="https://flipt.example.internal"
+export FLIPT_URL="https://flipt.tailnet-1a49.ts.net"
 ```
 
 ## 2. Run the check

--- a/packages/dotfiles/dot_agents/skills/discord/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/discord/SKILL.md
@@ -9,7 +9,7 @@ description: |
 
 Two ways to act on Discord, both verified live on 2026-08-29:
 
-1. **`toolkit discord`** (recommended for common ops) — a session daemon that logs in once, holds the gateway connections in memory, and exposes one-shot CLI commands. One `op` call per session; no boilerplate; voice presence persists between commands.
+1. **`toolkit discord`** (recommended for common ops) — use its session daemon for interactive work, or `discord slash --direct` for an isolated invocation that must not disturb a running daemon.
 2. **Write a Bun/TypeScript script** (escape hatch) — for anything the CLI doesn't cover. Same libraries underneath.
 
 ## Credentials
@@ -76,6 +76,21 @@ toolkit discord voice states <guildId>          # who's in VC + streaming/video 
 toolkit discord voice leave
 toolkit discord daemon stop
 ```
+
+For an isolated smoke test, skip the daemon entirely. Direct mode logs in only
+the user identity, subscribes before invoking, and destroys that gateway at the
+deadline even when login, invocation, or response waiting fails:
+
+```bash
+toolkit discord slash <channelId> <botId> bb transfer recipient:<userId> amount:3 \
+  --direct --wait-public --contains "Bryan Bucks Western Union" \
+  --timeout 45 --json
+```
+
+The JSON contains `reply` and `publicResponse` message objects. Each carries
+`mentionUserIds`, `mentionRoleIds`, and `mentionsEveryone`, so a smoke runner can
+verify allowed mentions exactly. Direct mode requires `DISCORD_USER_TOKEN`; it
+does not read `DISCORD_BOT_TOKEN` or connect to the shared daemon.
 
 All commands print markdown by default; add `--json` for machine-readable output. The streambot test loop is just: `voice states <guild>` and check whose `streaming` flag is set.
 

--- a/packages/dotfiles/dot_agents/skills/scout-development/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/scout-development/SKILL.md
@@ -42,6 +42,23 @@ bun run --filter='./packages/scout-for-lol' dev:web -- \
 starts the backend with the BETA Discord bot token, starts the Vite SPA, and
 proxies `/api` and `/trpc` from `:5180` to `:3000`.
 
+For bot-command work, use the dedicated Derrej runtime instead of starting the
+BETA gateway or report lake:
+
+```bash
+SCOUT_DISCORD_SMOKE_GUILD_ID=<dedicated-guild-id> \
+bun run --filter='./packages/scout-for-lol' dev:discord -- --scenario gateway
+```
+
+This preset uses `DISCORD_BOT_TOKEN` with Derrej application
+`1542993271477899294`, keeps local Temporal, and disables background jobs,
+report-lake preparation, Vite, and backend watch. Scenario flags are applied by
+the dev-only backend entrypoint to the one explicit fixture guild. Use the
+operator-only `test:discord:smoke` command for repeatable acceptance; it
+preflights Discord and the `scout-discord-smoke` PinchTab profile before any
+database mutation and stores resumable evidence under `.context/discord-smoke/`.
+Never substitute the BETA token or guild for this workflow.
+
 Each copy can use isolated ports and an isolated Postgres database on the
 shared local dev server (port 5471, `SCOUT_PG_PORT` overrides):
 

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -189,6 +189,36 @@ operation you need; Desktop integration may authenticate per command even when
 - The bot only sees guilds it has been invited to. To populate the guild
   picker, make sure your test guild has the BETA bot in it.
 
+### Discord-only development and smoke tests
+
+Use the Derrej-only runtime when testing Discord behavior. It never uses the
+BETA token, BETA guild, BETA database, or report lake:
+
+```bash
+SCOUT_DISCORD_SMOKE_GUILD_ID=<dedicated-guild-id> \
+bun run --filter='./packages/scout-for-lol' dev:discord -- --scenario gateway
+```
+
+`dev:discord` maps `DISCORD_BOT_TOKEN` to Scout's `DISCORD_TOKEN`, pins Derrej's
+application id, runs the normal backend through `src/dev-discord.ts`, and keeps
+the gateway plus local Temporal while disabling background jobs, report-lake
+seed adoption/folding, Vite, and backend watch. Its scenario registry is closed
+and the entrypoint refuses non-development environments.
+
+The operator-only smoke command is never a CI task:
+
+```bash
+bun run --filter='./packages/scout-for-lol' test:discord:smoke -- \
+  --scenario gateway
+```
+
+It validates the tracked public fixture, both Discord credentials, guild and
+channel membership, application identity, and the dedicated running PinchTab
+profile before creating an isolated `scout_test_*` database. Runs write an
+atomic manifest under the workspace `.context/discord-smoke/<run-id>/`; failed
+databases are preserved, successful databases are dropped, and `--resume`
+never invokes Discord again. Stop every local gateway process after testing.
+
 ### Shared report-lake seed (multiple checkouts / parallel agents)
 
 `REPORT_LAKE_DIR` defaults to `./report-lake` **relative to the backend's

--- a/packages/scout-for-lol/package.json
+++ b/packages/scout-for-lol/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint scripts",
     "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit -p tsconfig.scripts.json",
     "dev:web": "op run --env-file=./dev-web.env.tpl -- bun scripts/dev-web.ts",
+    "dev:discord": "op run --env-file=./dev-web.env.tpl -- bun scripts/dev-discord.ts",
+    "test:discord:smoke": "op run --env-file=./dev-web.env.tpl -- bun scripts/discord-smoke.ts",
     "dev:design-audit": "bun scripts/dev-web.ts",
     "dev:seed": "bun scripts/dev-seed.ts",
     "dev:login": "bun scripts/dev-login.ts",
@@ -17,6 +19,7 @@
     "test:report": "CI_TEST_COVERAGE=1 bun ../../scripts/run-ci-test.ts"
   },
   "devDependencies": {
+    "@scout-for-lol/backend": "workspace:*",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
     "@eslint/js": "^10.0.1",
     "@shepherdjerred/eslint-config": "workspace:*",

--- a/packages/scout-for-lol/packages/backend/src/dev-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/dev-discord.ts
@@ -1,0 +1,34 @@
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import { resolveEnvironment } from "#src/configuration.ts";
+import { createLogger } from "#src/logger.ts";
+import {
+  applyDiscordSmokeScenario,
+  DiscordSmokeScenarioNameSchema,
+} from "#src/discord-smoke-scenarios.ts";
+
+const logger = createLogger("discord-smoke");
+
+if (resolveEnvironment() !== "dev") {
+  throw new Error(
+    "The Discord smoke entrypoint may run only in ENVIRONMENT=dev",
+  );
+}
+
+const scenario = DiscordSmokeScenarioNameSchema.parse(
+  Bun.env["SCOUT_DISCORD_SMOKE_SCENARIO"],
+);
+const guildId = DiscordGuildIdSchema.parse(
+  Bun.env["SCOUT_DISCORD_SMOKE_GUILD_ID"],
+);
+applyDiscordSmokeScenario(scenario, guildId);
+
+await import("#src/index.ts");
+
+const readyPath = Bun.env["SCOUT_DISCORD_SMOKE_READY_PATH"];
+if (readyPath !== undefined && readyPath.length > 0) {
+  await Bun.write(
+    readyPath,
+    `${JSON.stringify({ guildId, processId: process.pid, scenario })}\n`,
+  );
+  logger.info(`Scout Discord smoke runtime ready: ${readyPath}`);
+}

--- a/packages/scout-for-lol/packages/backend/src/discord-smoke-scenarios.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord-smoke-scenarios.ts
@@ -1,0 +1,21 @@
+import type { DiscordGuildId } from "@scout-for-lol/data";
+import { z } from "zod";
+
+export const DiscordSmokeScenarioNameSchema = z.enum(["gateway"]);
+export type DiscordSmokeScenarioName = z.infer<
+  typeof DiscordSmokeScenarioNameSchema
+>;
+
+export function applyDiscordSmokeScenario(
+  _scenario: DiscordSmokeScenarioName,
+  _guildId: DiscordGuildId,
+): void {
+  void _scenario;
+  void _guildId;
+}
+
+export function discordSmokeStaticOverrides(
+  _scenario: DiscordSmokeScenarioName,
+): Record<string, boolean> {
+  return {};
+}

--- a/packages/scout-for-lol/packages/backend/src/testing/test-database.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-database.ts
@@ -88,6 +88,35 @@ export function createTestDatabase(testName: string): {
   };
 }
 
+export async function dropTestDatabase(
+  prismaClient: ExtendedPrismaClient,
+  databaseName: string,
+): Promise<void> {
+  if (!/^scout_test_[a-z0-9_]+$/u.test(databaseName)) {
+    throw new Error(`Refusing to drop non-test database ${databaseName}`);
+  }
+  await prismaClient.$disconnect();
+  const result = Bun.spawnSync(
+    [
+      "dropdb",
+      "-h",
+      "127.0.0.1",
+      "-p",
+      devPostgresPort().toString(),
+      "-U",
+      "scout",
+      "--force",
+      databaseName,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `dropdb ${databaseName} failed: ${result.stderr.toString()}`,
+    );
+  }
+}
+
 /**
  * Helper function to safely delete from tables that might not exist.
  * Useful in beforeEach/afterEach hooks for cleanup.

--- a/packages/scout-for-lol/scripts/dev-discord.test.ts
+++ b/packages/scout-for-lol/scripts/dev-discord.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "vitest";
+import { buildDevDiscordLaunch } from "./dev-discord.ts";
+
+const environment = {
+  DISCORD_BOT_TOKEN: "derrej-bot-token",
+  SCOUT_DISCORD_SMOKE_GUILD_ID: "100000000000000001",
+  RIOT_API_KEY: "riot-token",
+};
+
+test("builds a stable Discord-only development runtime", () => {
+  expect(
+    buildDevDiscordLaunch(
+      [
+        "--scenario",
+        "gateway",
+        "--database-url",
+        "postgres://scout@127.0.0.1:5471/scout_test_smoke",
+      ],
+      environment,
+    ),
+  ).toEqual({
+    args: [
+      "bun",
+      "scripts/dev-web.ts",
+      "--no-background-jobs",
+      "--no-web",
+      "--no-backend-watch",
+      "--database-url",
+      "postgres://scout@127.0.0.1:5471/scout_test_smoke",
+    ],
+    environment: {
+      ...environment,
+      APPLICATION_ID: "1542993271477899294",
+      DISCORD_TOKEN: "derrej-bot-token",
+      ENVIRONMENT: "dev",
+      FEATURE_FLAGS_MODE: "static",
+      FEATURE_FLAGS_STATIC_OVERRIDES: "{}",
+      SCOUT_DEV_BACKEND_ENTRYPOINT: "src/dev-discord.ts",
+      SCOUT_DEV_CONSUMER_PREVIEW: "false",
+      SCOUT_DISCORD_SMOKE_SCENARIO: "gateway",
+    },
+  });
+});
+
+test("refuses missing credentials, guilds, and unknown scenarios", () => {
+  expect(() => buildDevDiscordLaunch(["--scenario", "gateway"], {})).toThrow(
+    "DISCORD_BOT_TOKEN",
+  );
+  expect(() =>
+    buildDevDiscordLaunch(["--scenario", "gateway"], {
+      DISCORD_BOT_TOKEN: "token",
+    }),
+  ).toThrow("SCOUT_DISCORD_SMOKE_GUILD_ID");
+  expect(() =>
+    buildDevDiscordLaunch(["--scenario", "unknown"], environment),
+  ).toThrow();
+});

--- a/packages/scout-for-lol/scripts/dev-discord.ts
+++ b/packages/scout-for-lol/scripts/dev-discord.ts
@@ -1,0 +1,93 @@
+import {
+  DiscordSmokeScenarioNameSchema,
+  discordSmokeStaticOverrides,
+} from "@scout-for-lol/backend/discord-smoke-scenarios.ts";
+import { requireCliValue } from "./migration-core.ts";
+
+const DERREJ_APPLICATION_ID = "1542993271477899294";
+
+export type DevDiscordLaunch = {
+  readonly args: string[];
+  readonly environment: Record<string, string | undefined>;
+};
+
+export function buildDevDiscordLaunch(
+  args: readonly string[],
+  environment: Readonly<Record<string, string | undefined>>,
+): DevDiscordLaunch {
+  const forwarded: string[] = [];
+  let scenarioRaw: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--scenario") {
+      scenarioRaw = requireCliValue(args, index, argument);
+      index += 1;
+      continue;
+    }
+    if (argument !== undefined) {
+      forwarded.push(argument);
+    }
+  }
+  const scenario = DiscordSmokeScenarioNameSchema.parse(scenarioRaw);
+  const botToken = environment["DISCORD_BOT_TOKEN"];
+  if (botToken === undefined || botToken.length === 0) {
+    throw new Error("dev:discord requires DISCORD_BOT_TOKEN");
+  }
+  const guildId = environment["SCOUT_DISCORD_SMOKE_GUILD_ID"];
+  if (guildId === undefined || !/^\d{17,20}$/u.test(guildId)) {
+    throw new Error("dev:discord requires SCOUT_DISCORD_SMOKE_GUILD_ID");
+  }
+
+  return {
+    args: [
+      "bun",
+      "scripts/dev-web.ts",
+      "--no-background-jobs",
+      "--no-web",
+      "--no-backend-watch",
+      ...forwarded,
+    ],
+    environment: {
+      ...environment,
+      APPLICATION_ID: DERREJ_APPLICATION_ID,
+      DISCORD_TOKEN: botToken,
+      ENVIRONMENT: "dev",
+      FEATURE_FLAGS_MODE: "static",
+      FEATURE_FLAGS_STATIC_OVERRIDES: JSON.stringify(
+        discordSmokeStaticOverrides(scenario),
+      ),
+      SCOUT_DEV_BACKEND_ENTRYPOINT: "src/dev-discord.ts",
+      SCOUT_DEV_CONSUMER_PREVIEW: "false",
+      SCOUT_DISCORD_SMOKE_SCENARIO: scenario,
+    },
+  };
+}
+
+if (import.meta.main) {
+  const launch = buildDevDiscordLaunch(Bun.argv.slice(2), Bun.env);
+  console.log(
+    [
+      "Scout Discord-only runtime",
+      `Scenario: ${launch.environment["SCOUT_DISCORD_SMOKE_SCENARIO"] ?? "unset"}`,
+      `Guild: ${launch.environment["SCOUT_DISCORD_SMOKE_GUILD_ID"] ?? "unset"}`,
+      "Gateway: enabled",
+      "Background jobs: disabled",
+      "Report lake: disabled",
+      "Vite: disabled",
+      "Backend watch: disabled",
+    ].join("\n"),
+  );
+  const child = Bun.spawn(launch.args, {
+    cwd: import.meta.dir.replace(/\/scripts$/u, ""),
+    env: launch.environment,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const stop = (): void => {
+    child.kill();
+  };
+  process.on("SIGINT", stop);
+  process.on("SIGTERM", stop);
+  process.exitCode = await child.exited;
+}

--- a/packages/scout-for-lol/scripts/dev-web-args.test.ts
+++ b/packages/scout-for-lol/scripts/dev-web-args.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "vitest";
 import { parseDevWebArgs } from "./dev-web.ts";
+import {
+  resolveBackendEntrypoint,
+  shouldPrepareReportLake,
+} from "./dev-web.ts";
 import { buildDevEnvironment } from "./dev-web-environment.ts";
 
 test("parses isolated ports and database URL", () => {
@@ -24,6 +28,8 @@ test("parses isolated ports and database URL", () => {
       temporalUiPort: 8234,
       databaseUrl: "postgres://scout@127.0.0.1:5471/agent_one",
       discordGatewayEnabled: true,
+      backgroundJobsEnabled: true,
+      webEnabled: true,
       backendWatchEnabled: true,
       marketingOrigin: "http://localhost:4321",
       docsOrigin: "http://localhost:4322",
@@ -48,6 +54,8 @@ test("derives an isolated database for a non-default backend port", () => {
       temporalUiPort: 8234,
       databaseUrl: "postgres://scout@127.0.0.1:5471/scout_dev_3001",
       discordGatewayEnabled: true,
+      backgroundJobsEnabled: true,
+      webEnabled: true,
       backendWatchEnabled: true,
       marketingOrigin: "http://localhost:4321",
       docsOrigin: "http://localhost:4322",
@@ -82,6 +90,8 @@ test("supports a stable secondary copy without the BETA gateway", () => {
       temporalUiPort: 8234,
       databaseUrl: "postgres://scout@127.0.0.1:5471/scout_dev_3001",
       discordGatewayEnabled: false,
+      backgroundJobsEnabled: true,
+      webEnabled: true,
       backendWatchEnabled: false,
       marketingOrigin: "http://localhost:4321",
       docsOrigin: "http://localhost:4322",
@@ -112,6 +122,8 @@ test("configures alternate surface origins for a second stack", () => {
       temporalUiPort: 8233,
       databaseUrl: "postgres://scout@127.0.0.1:5471/scout_dev_3000",
       discordGatewayEnabled: true,
+      backgroundJobsEnabled: true,
+      webEnabled: true,
       backendWatchEnabled: true,
       marketingOrigin: "http://localhost:4324",
       docsOrigin: "http://localhost:4325",
@@ -187,4 +199,39 @@ test("preserves explicit local access and auth overrides", () => {
     FEATURE_FLAGS_STATIC_OVERRIDES:
       '{"scout-consumer-player-profiles-enabled":false}',
   });
+});
+
+test("supports a gateway-only runtime without jobs, lake preparation, or Vite", () => {
+  const parsed = parseDevWebArgs(
+    ["--no-background-jobs", "--no-web", "--no-backend-watch"],
+    {},
+  );
+  expect(parsed.kind).toBe("options");
+  if (parsed.kind !== "options") return;
+
+  expect(parsed.options).toMatchObject({
+    discordGatewayEnabled: true,
+    backgroundJobsEnabled: false,
+    webEnabled: false,
+    backendWatchEnabled: false,
+  });
+  expect(shouldPrepareReportLake(parsed.options, false)).toBe(false);
+  expect(
+    buildDevEnvironment({}, parsed.options, "/unused/report-lake", false),
+  ).toMatchObject({
+    ENABLE_DISCORD_GATEWAY: "true",
+    ENABLE_BACKGROUND_JOBS: "false",
+  });
+});
+
+test("allows only the normal and Discord smoke backend entrypoints", () => {
+  expect(resolveBackendEntrypoint({})).toBe("src/index.ts");
+  expect(
+    resolveBackendEntrypoint({
+      SCOUT_DEV_BACKEND_ENTRYPOINT: "src/dev-discord.ts",
+    }),
+  ).toBe("src/dev-discord.ts");
+  expect(() =>
+    resolveBackendEntrypoint({ SCOUT_DEV_BACKEND_ENTRYPOINT: "src/other.ts" }),
+  ).toThrow("must be src/index.ts or src/dev-discord.ts");
 });

--- a/packages/scout-for-lol/scripts/dev-web-environment.ts
+++ b/packages/scout-for-lol/scripts/dev-web-environment.ts
@@ -7,6 +7,8 @@ export type DevWebOptions = {
   readonly temporalUiPort: number;
   readonly databaseUrl: string;
   readonly discordGatewayEnabled: boolean;
+  readonly backgroundJobsEnabled: boolean;
+  readonly webEnabled: boolean;
   readonly backendWatchEnabled: boolean;
   readonly marketingOrigin: string;
   readonly docsOrigin: string;
@@ -108,7 +110,11 @@ export function buildDevEnvironment(
     VITE_MARKETING_ORIGIN: options.marketingOrigin,
     VITE_DOCS_ORIGIN: options.docsOrigin,
     ENABLE_BACKGROUND_JOBS:
-      isDesignAuditBoot || !options.discordGatewayEnabled ? "false" : "true",
+      isDesignAuditBoot ||
+      !options.discordGatewayEnabled ||
+      !options.backgroundJobsEnabled
+        ? "false"
+        : "true",
     ENABLE_DISCORD_GATEWAY:
       isDesignAuditBoot || !options.discordGatewayEnabled ? "false" : "true",
     WEB_APP_ORIGIN: `http://localhost:${options.webPort.toString()}`,

--- a/packages/scout-for-lol/scripts/dev-web-options.ts
+++ b/packages/scout-for-lol/scripts/dev-web-options.ts
@@ -24,6 +24,8 @@ type CliOverrides = {
   readonly temporalPort: number | undefined;
   readonly temporalUiPort: number | undefined;
   readonly discordGatewayEnabled: boolean | undefined;
+  readonly backgroundJobsEnabled: boolean | undefined;
+  readonly webEnabled: boolean | undefined;
   readonly backendWatchEnabled: boolean | undefined;
   readonly marketingOrigin: string | undefined;
   readonly docsOrigin: string | undefined;
@@ -131,6 +133,8 @@ function parseCliOverrides(args: readonly string[]): CliOverrides | undefined {
     if (argument === "--help" || argument === "-h") return undefined;
     if (
       argument === "--no-discord-gateway" ||
+      argument === "--no-background-jobs" ||
+      argument === "--no-web" ||
       argument === "--no-backend-watch"
     ) {
       flags.add(argument);
@@ -159,6 +163,10 @@ function parseCliOverrides(args: readonly string[]): CliOverrides | undefined {
     discordGatewayEnabled: flags.has("--no-discord-gateway")
       ? false
       : undefined,
+    backgroundJobsEnabled: flags.has("--no-background-jobs")
+      ? false
+      : undefined,
+    webEnabled: flags.has("--no-web") ? false : undefined,
     backendWatchEnabled: flags.has("--no-backend-watch") ? false : undefined,
     marketingOrigin: parseOptionalValue(values, "--marketing-origin", (value) =>
       parseDevOrigin(value, "--marketing-origin"),
@@ -244,6 +252,10 @@ export function parseDevWebArgs(
       discordGatewayEnabled:
         cli.discordGatewayEnabled ??
         environment["SCOUT_DEV_NO_GATEWAY"] !== "true",
+      backgroundJobsEnabled:
+        cli.backgroundJobsEnabled ??
+        environment["SCOUT_DEV_NO_BACKGROUND_JOBS"] !== "true",
+      webEnabled: cli.webEnabled ?? environment["SCOUT_DEV_NO_WEB"] !== "true",
       backendWatchEnabled:
         cli.backendWatchEnabled ??
         environment["SCOUT_DEV_NO_BACKEND_WATCH"] !== "true",

--- a/packages/scout-for-lol/scripts/dev-web.ts
+++ b/packages/scout-for-lol/scripts/dev-web.ts
@@ -37,6 +37,8 @@ Options:
   --temporal-port <port> Temporal gRPC port (default: backend port + 4233)
   --temporal-ui-port <port> Temporal UI port (default: backend port + 5233)
   --no-discord-gateway   Run as a secondary UI/API copy without BETA gateway
+  --no-background-jobs   Skip scheduled workers and report-lake preparation
+  --no-web               Skip the Vite SPA
   --no-backend-watch     Keep the backend stable until this command is restarted
   --marketing-origin <url>  Marketing site origin for cross-surface links
   --docs-origin <url>       Docs site origin for cross-surface links
@@ -80,6 +82,28 @@ async function waitForBackend(
   );
 }
 
+export function shouldPrepareReportLake(
+  options: { readonly backgroundJobsEnabled: boolean },
+  isDesignAuditBoot: boolean,
+): boolean {
+  return isDesignAuditBoot || options.backgroundJobsEnabled;
+}
+
+export function resolveBackendEntrypoint(
+  environment: Readonly<Record<string, string | undefined>>,
+): "src/index.ts" | "src/dev-discord.ts" {
+  const configured = environment["SCOUT_DEV_BACKEND_ENTRYPOINT"];
+  if (configured === undefined || configured === "src/index.ts") {
+    return "src/index.ts";
+  }
+  if (configured === "src/dev-discord.ts") {
+    return configured;
+  }
+  throw new Error(
+    "SCOUT_DEV_BACKEND_ENTRYPOINT must be src/index.ts or src/dev-discord.ts",
+  );
+}
+
 if (import.meta.main) {
   const root = import.meta.dir.replace(/\/scripts$/, "");
   const isDesignAuditBoot = Bun.env["SCOUT_DESIGN_AUDIT_LOCAL_BOOT"] === "true";
@@ -104,7 +128,13 @@ if (import.meta.main) {
         ? DEFAULT_DESIGN_AUDIT_LAKE_DIR
         : Bun.env["REPORT_LAKE_DIR"],
     );
-    console.log(await adoptSeedIfUnseeded(lakeDir));
+    if (shouldPrepareReportLake(options, isDesignAuditBoot)) {
+      console.log(await adoptSeedIfUnseeded(lakeDir));
+    } else {
+      console.log(
+        "Report lake: skipped (background jobs are disabled for this runtime)",
+      );
+    }
 
     const environment = buildDevEnvironment(
       Bun.env,
@@ -198,10 +228,11 @@ if (import.meta.main) {
       }
     }
 
+    const backendEntrypoint = resolveBackendEntrypoint(Bun.env);
     const backendCommand =
       !isDesignAuditBoot && options.backendWatchEnabled
-        ? ["bun", "--watch", "src/index.ts"]
-        : ["bun", "src/index.ts"];
+        ? ["bun", "--watch", backendEntrypoint]
+        : ["bun", backendEntrypoint];
     const backend = Bun.spawn(backendCommand, {
       cwd: backendCwd,
       env: {
@@ -222,35 +253,42 @@ if (import.meta.main) {
         throw error;
       }
     }
-    const app = Bun.spawn(
-      [
-        "bun",
-        "run",
-        "dev",
-        "--",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        options.webPort.toString(),
-        "--strictPort",
-        ...(isDesignAuditBoot ? ["--force"] : []),
-      ],
-      {
-        cwd: path.join(root, "packages", "app"),
-        env: environment,
-        stdin: "inherit",
-        stdout: "inherit",
-        stderr: "inherit",
-      },
-    );
+    const app = options.webEnabled
+      ? Bun.spawn(
+          [
+            "bun",
+            "run",
+            "dev",
+            "--",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            options.webPort.toString(),
+            "--strictPort",
+            ...(isDesignAuditBoot ? ["--force"] : []),
+          ],
+          {
+            cwd: path.join(root, "packages", "app"),
+            env: environment,
+            stdin: "inherit",
+            stdout: "inherit",
+            stderr: "inherit",
+          },
+        )
+      : null;
     const devLoginUrl = `${webOrigin}/api/dev/login?returnTo=${encodeURIComponent("/app/")}`;
     console.log(
       [
         "Scout local dev is starting",
         `SPA: ${webOrigin}/app/`,
         `Backend: ${backendOrigin}/trpc/`,
+        `Backend entrypoint: ${backendEntrypoint}`,
         `Temporal UI: http://127.0.0.1:${options.temporalUiPort.toString()}/`,
         `Database: ${options.databaseUrl}`,
+        `Discord gateway: ${options.discordGatewayEnabled ? "enabled" : "disabled"}`,
+        `Background jobs: ${options.backgroundJobsEnabled ? "enabled" : "disabled"}`,
+        `Report lake preparation: ${shouldPrepareReportLake(options, isDesignAuditBoot) ? "enabled" : "skipped"}`,
+        `Vite: ${options.webEnabled ? webOrigin : "disabled"}`,
         `Backend watch: ${options.backendWatchEnabled ? "enabled" : "disabled"}`,
         `Auth: ${options.authMode}`,
         `Consumer preview: ${options.consumerPreview ? (options.consumerGuildId ?? "unset") : "disabled"}`,
@@ -263,18 +301,22 @@ if (import.meta.main) {
     );
     const stop = (): void => {
       backend.kill();
-      app.kill();
+      app?.kill();
       temporal.kill();
     };
     process.on("SIGINT", stop);
     process.on("SIGTERM", stop);
     const exitCode = await Promise.race([
       backend.exited,
-      app.exited,
+      ...(app === null ? [] : [app.exited]),
       temporal.exited,
     ]);
     stop();
-    await Promise.all([backend.exited, app.exited, temporal.exited]);
+    await Promise.all([
+      backend.exited,
+      ...(app === null ? [] : [app.exited]),
+      temporal.exited,
+    ]);
     process.exitCode = exitCode;
   }
 }

--- a/packages/scout-for-lol/scripts/discord-smoke-browser.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-browser.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+const ProfileSchema = z.object({
+  id: z.string().min(1),
+  name: z.string(),
+  running: z.boolean(),
+});
+const InstanceSchema = z.object({
+  id: z.string().min(1),
+  profileId: z.string().min(1),
+  profileName: z.string().min(1),
+  url: z.url(),
+  status: z.string(),
+});
+const BrowserLocationSchema = z.object({
+  url: z.url(),
+});
+
+async function runPinchTabJson(args: readonly string[]): Promise<unknown> {
+  const child = Bun.spawn(["pinchtab", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`PinchTab preflight failed: ${stderr.trim()}`);
+  }
+  const parsed: unknown = JSON.parse(stdout);
+  return parsed;
+}
+
+export async function verifyPinchTabProfile(
+  profileName: string,
+  guildId: string,
+  channelId: string,
+): Promise<void> {
+  const profiles = z
+    .array(ProfileSchema)
+    .parse(await runPinchTabJson(["profiles", "--json"]));
+  const profile = profiles.find((candidate) => candidate.name === profileName);
+  if (profile === undefined) {
+    throw new Error(
+      `PinchTab profile ${profileName} does not exist; create it and sign into Discord once`,
+    );
+  }
+  if (!profile.running) {
+    throw new Error(
+      `PinchTab profile ${profileName} is not running; start its signed-in instance before smoke testing`,
+    );
+  }
+  const instances = z
+    .array(InstanceSchema)
+    .parse(await runPinchTabJson(["instance", "list", "--json"]));
+  const instance = instances.find(
+    (candidate) =>
+      candidate.profileId === profile.id && candidate.status === "running",
+  );
+  if (instance === undefined) {
+    throw new Error(
+      `PinchTab profile ${profileName} has no running browser instance`,
+    );
+  }
+
+  const channelUrl = `https://discord.com/channels/${guildId}/${channelId}`;
+  await runPinchTabJson([
+    "nav",
+    "--server",
+    instance.url,
+    channelUrl,
+    "--json",
+  ]);
+  const location = BrowserLocationSchema.parse(
+    await runPinchTabJson(["url", "--server", instance.url, "--json"]),
+  );
+  if (new URL(location.url).pathname.startsWith("/login")) {
+    throw new Error(
+      `PinchTab profile ${profileName} is not signed into Discord; complete the one-time browser login before smoke testing`,
+    );
+  }
+  if (location.url !== channelUrl) {
+    throw new Error(
+      `PinchTab profile ${profileName} could not open the smoke channel; reached ${location.url}`,
+    );
+  }
+}

--- a/packages/scout-for-lol/scripts/discord-smoke-core.test.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-core.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  assertInvocationAllowed,
+  DiscordSmokeFixtureSchema,
+  DiscordSmokeManifestSchema,
+  preflightDiscordSmoke,
+  raceRuntimeOperation,
+  waitForRuntimeReadiness,
+} from "./discord-smoke-core.ts";
+
+const fixture = DiscordSmokeFixtureSchema.parse({
+  applicationId: "1542993271477899294",
+  botUserId: "1542993271477899294",
+  invokingUserId: "1515150733660520496",
+  recipientUserId: "160509172704739328",
+  guildId: "100000000000000001",
+  channelId: "100000000000000002",
+  pinchTabProfile: "scout-discord-smoke",
+});
+
+function response(body: unknown): Response {
+  return Response.json(body);
+}
+
+function neverSettles<Value>(): Promise<Value> {
+  return new Promise(() => {
+    // Deliberately pending so the competing runtime-exit promise wins.
+  });
+}
+
+test("preflight validates both identities, guild/channel access, app, and profile", async () => {
+  const fetcher = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const authorization = new Headers(init?.headers).get("authorization");
+    if (url.endsWith("/users/@me")) {
+      return Promise.resolve(
+        response({
+          id:
+            authorization?.startsWith("Bot ") === true
+              ? fixture.botUserId
+              : fixture.invokingUserId,
+        }),
+      );
+    }
+    if (url.endsWith("/users/@me/guilds")) {
+      return Promise.resolve(response([{ id: fixture.guildId }]));
+    }
+    if (url.includes("/channels/")) {
+      return Promise.resolve(
+        response({ id: fixture.channelId, guild_id: fixture.guildId }),
+      );
+    }
+    if (url.includes("/members/")) {
+      return Promise.resolve(
+        response({ user: { id: fixture.recipientUserId } }),
+      );
+    }
+    return Promise.resolve(response({ id: fixture.applicationId }));
+  });
+  const verifyPinchTabProfile = vi.fn(() => Promise.resolve());
+
+  await preflightDiscordSmoke(
+    fixture,
+    { DISCORD_BOT_TOKEN: "bot", DISCORD_USER_TOKEN: "user" },
+    { fetch: fetcher, verifyPinchTabProfile },
+  );
+
+  expect(fetcher).toHaveBeenCalledTimes(8);
+  expect(verifyPinchTabProfile).toHaveBeenCalledWith(
+    "scout-discord-smoke",
+    fixture.guildId,
+    fixture.channelId,
+  );
+});
+
+test("preflight refuses missing credentials before network or browser work", async () => {
+  const fetcher = vi.fn(fetch);
+  const verifyPinchTabProfile = vi.fn(() => Promise.resolve());
+
+  await expect(
+    preflightDiscordSmoke(
+      fixture,
+      {},
+      {
+        fetch: fetcher,
+        verifyPinchTabProfile,
+      },
+    ),
+  ).rejects.toThrow("DISCORD_BOT_TOKEN");
+  expect(fetcher).not.toHaveBeenCalled();
+  expect(verifyPinchTabProfile).not.toHaveBeenCalled();
+});
+
+describe("invocation guard", () => {
+  const base = DiscordSmokeManifestSchema.parse({
+    runId: "run-1",
+    scenario: "bb-transfer",
+    createdAt: "2026-08-29T00:00:00.000Z",
+    databaseName: null,
+    databaseUrl: null,
+    invocationStartedAt: null,
+    privateReplyId: null,
+    publicMessageId: null,
+    verifiedAt: null,
+    screenshotPath: null,
+  });
+
+  test("allows a pristine run", () => {
+    expect(() => assertInvocationAllowed(base)).not.toThrow();
+  });
+
+  test("requires resume once invocation or any response is recorded", () => {
+    expect(() =>
+      assertInvocationAllowed({
+        ...base,
+        invocationStartedAt: "2026-08-29T00:01:00.000Z",
+      }),
+    ).toThrow("may not invoke again");
+    expect(() =>
+      assertInvocationAllowed({
+        ...base,
+        publicMessageId: "100000000000000009",
+      }),
+    ).toThrow("may not invoke again");
+  });
+});
+
+describe("runtime readiness", () => {
+  test("waits for a readiness file written by the spawned backend", async () => {
+    let probes = 0;
+    await waitForRuntimeReadiness(
+      { exitCode: null, exited: neverSettles<number>() },
+      "/tmp/scout-ready",
+      1000,
+      {
+        fileExists: () => {
+          probes += 1;
+          return Promise.resolve(probes === 2);
+        },
+        now: () => 0,
+        sleep: () => Promise.resolve(),
+      },
+    );
+    expect(probes).toBe(2);
+  });
+
+  test("fails when the spawned runtime exits before readiness", async () => {
+    await expect(
+      waitForRuntimeReadiness(
+        { exitCode: 12, exited: Promise.resolve(12) },
+        "/tmp/scout-ready",
+        1000,
+        {
+          fileExists: () => Promise.resolve(false),
+          now: () => 0,
+          sleep: () => neverSettles<undefined>(),
+        },
+      ),
+    ).rejects.toThrow("exited with code 12");
+  });
+
+  test("fails if the runtime exits while another readiness check runs", async () => {
+    await expect(
+      raceRuntimeOperation(
+        { exitCode: 7, exited: Promise.resolve(7) },
+        neverSettles<undefined>(),
+        "before command registration",
+      ),
+    ).rejects.toThrow("before command registration");
+  });
+});

--- a/packages/scout-for-lol/scripts/discord-smoke-core.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-core.ts
@@ -1,0 +1,309 @@
+import { mkdir, rename } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+const SnowflakeSchema = z.string().regex(/^\d{17,20}$/u);
+const DERREJ_APPLICATION_ID = "1542993271477899294";
+const DERREJ_USER_ID = "1515150733660520496";
+
+export const DiscordSmokeFixtureSchema = z.object({
+  applicationId: z.literal(DERREJ_APPLICATION_ID),
+  botUserId: z.literal(DERREJ_APPLICATION_ID),
+  invokingUserId: z.literal(DERREJ_USER_ID),
+  recipientUserId: SnowflakeSchema,
+  guildId: SnowflakeSchema,
+  channelId: SnowflakeSchema,
+  pinchTabProfile: z.literal("scout-discord-smoke"),
+});
+export type DiscordSmokeFixture = z.infer<typeof DiscordSmokeFixtureSchema>;
+
+export const DiscordSmokeManifestSchema = z.object({
+  runId: z.string().min(1),
+  scenario: z.string().min(1),
+  createdAt: z.iso.datetime(),
+  databaseName: z
+    .string()
+    .regex(/^scout_test_[a-z0-9_]+$/u)
+    .nullable(),
+  databaseUrl: z.url().nullable(),
+  invocationStartedAt: z.iso.datetime().nullable(),
+  privateReplyId: SnowflakeSchema.nullable(),
+  publicMessageId: SnowflakeSchema.nullable(),
+  verifiedAt: z.iso.datetime().nullable(),
+  screenshotPath: z.string().nullable(),
+});
+export type DiscordSmokeManifest = z.infer<typeof DiscordSmokeManifestSchema>;
+
+const DiscordIdentitySchema = z.object({ id: SnowflakeSchema });
+const DiscordGuildSchema = z.object({ id: SnowflakeSchema });
+const DiscordChannelSchema = z.object({
+  id: SnowflakeSchema,
+  guild_id: SnowflakeSchema,
+});
+const DiscordApplicationSchema = z.object({ id: SnowflakeSchema });
+const DiscordGuildMemberSchema = z.object({
+  user: z.object({ id: SnowflakeSchema }),
+});
+const DiscordCommandSchema = z.object({
+  id: SnowflakeSchema,
+  name: z.string(),
+  options: z.array(z.unknown()).optional(),
+});
+
+export type DiscordSmokePreflightDependencies = {
+  readonly fetch: (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  readonly verifyPinchTabProfile: (
+    profileName: string,
+    guildId: string,
+    channelId: string,
+  ) => Promise<void>;
+};
+
+export type DiscordSmokeRuntime = {
+  readonly exited: Promise<number>;
+  readonly exitCode: number | null;
+};
+
+type RuntimeReadinessDependencies = {
+  readonly fileExists: (filePath: string) => Promise<boolean>;
+  readonly now: () => number;
+  readonly sleep: (milliseconds: number) => Promise<void>;
+};
+
+const runtimeReadinessDependencies: RuntimeReadinessDependencies = {
+  fileExists: async (filePath) => await Bun.file(filePath).exists(),
+  now: Date.now,
+  sleep: async (milliseconds) => {
+    await Bun.sleep(milliseconds);
+  },
+};
+
+export async function raceRuntimeOperation<Value>(
+  runtime: DiscordSmokeRuntime,
+  operation: Promise<Value>,
+  description: string,
+): Promise<Value> {
+  const outcome = await Promise.race([
+    operation.then((value) => ({ kind: "completed", value }) as const),
+    runtime.exited.then((exitCode) => ({ kind: "exited", exitCode }) as const),
+  ]);
+  if (outcome.kind === "exited") {
+    throw new Error(
+      `Scout Discord runtime exited with code ${outcome.exitCode.toString()} ${description}`,
+    );
+  }
+  if (runtime.exitCode !== null) {
+    throw new Error(
+      `Scout Discord runtime exited with code ${runtime.exitCode.toString()} ${description}`,
+    );
+  }
+  return outcome.value;
+}
+
+export async function waitForRuntimeReadiness(
+  runtime: DiscordSmokeRuntime,
+  readyPath: string,
+  timeoutMilliseconds = 60_000,
+  dependencies: RuntimeReadinessDependencies = runtimeReadinessDependencies,
+): Promise<void> {
+  const deadline = dependencies.now() + timeoutMilliseconds;
+  const waitForFile = async (): Promise<void> => {
+    while (dependencies.now() < deadline) {
+      if (await dependencies.fileExists(readyPath)) {
+        return;
+      }
+      await dependencies.sleep(100);
+    }
+    throw new Error(
+      `Scout Discord runtime did not write readiness file ${readyPath} before timeout`,
+    );
+  };
+  await raceRuntimeOperation(
+    runtime,
+    waitForFile(),
+    "before reporting gateway readiness",
+  );
+}
+
+async function discordJson(
+  fetcher: DiscordSmokePreflightDependencies["fetch"],
+  pathname: string,
+  authorization: string,
+): Promise<unknown> {
+  const response = await fetcher(`https://discord.com/api/v10${pathname}`, {
+    headers: { authorization },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Discord preflight ${pathname} returned HTTP ${response.status.toString()}`,
+    );
+  }
+  return response.json();
+}
+
+async function verifyIdentityAccess(
+  dependencies: DiscordSmokePreflightDependencies,
+  authorization: string,
+  expectedUserId: string,
+  fixture: DiscordSmokeFixture,
+): Promise<void> {
+  const identity = DiscordIdentitySchema.parse(
+    await discordJson(dependencies.fetch, "/users/@me", authorization),
+  );
+  if (identity.id !== expectedUserId) {
+    throw new Error(
+      `Discord credential resolved user ${identity.id}, expected ${expectedUserId}`,
+    );
+  }
+  const guilds = z
+    .array(DiscordGuildSchema)
+    .parse(
+      await discordJson(dependencies.fetch, "/users/@me/guilds", authorization),
+    );
+  if (!guilds.some((guild) => guild.id === fixture.guildId)) {
+    throw new Error(
+      `Discord user ${expectedUserId} is not in smoke guild ${fixture.guildId}`,
+    );
+  }
+  const channel = DiscordChannelSchema.parse(
+    await discordJson(
+      dependencies.fetch,
+      `/channels/${fixture.channelId}`,
+      authorization,
+    ),
+  );
+  if (channel.guild_id !== fixture.guildId) {
+    throw new Error(
+      `Smoke channel ${fixture.channelId} is not in guild ${fixture.guildId}`,
+    );
+  }
+}
+
+export async function preflightDiscordSmoke(
+  fixture: DiscordSmokeFixture,
+  environment: Readonly<Record<string, string | undefined>>,
+  dependencies: DiscordSmokePreflightDependencies,
+): Promise<void> {
+  const botToken = environment["DISCORD_BOT_TOKEN"];
+  const userToken = environment["DISCORD_USER_TOKEN"];
+  if (botToken === undefined || botToken.length === 0) {
+    throw new Error("Discord smoke requires DISCORD_BOT_TOKEN");
+  }
+  if (userToken === undefined || userToken.length === 0) {
+    throw new Error("Discord smoke requires DISCORD_USER_TOKEN");
+  }
+
+  const botAuthorization = `Bot ${botToken}`;
+  await verifyIdentityAccess(
+    dependencies,
+    botAuthorization,
+    fixture.botUserId,
+    fixture,
+  );
+  await verifyIdentityAccess(
+    dependencies,
+    userToken,
+    fixture.invokingUserId,
+    fixture,
+  );
+  const application = DiscordApplicationSchema.parse(
+    await discordJson(
+      dependencies.fetch,
+      "/oauth2/applications/@me",
+      botAuthorization,
+    ),
+  );
+  if (application.id !== fixture.applicationId) {
+    throw new Error(
+      `Discord bot token belongs to application ${application.id}, expected ${fixture.applicationId}`,
+    );
+  }
+  const recipientMember = DiscordGuildMemberSchema.parse(
+    await discordJson(
+      dependencies.fetch,
+      `/guilds/${fixture.guildId}/members/${fixture.recipientUserId}`,
+      botAuthorization,
+    ),
+  );
+  if (recipientMember.user.id !== fixture.recipientUserId) {
+    throw new Error(
+      `Discord smoke recipient resolved user ${recipientMember.user.id}, expected ${fixture.recipientUserId}`,
+    );
+  }
+  await dependencies.verifyPinchTabProfile(
+    fixture.pinchTabProfile,
+    fixture.guildId,
+    fixture.channelId,
+  );
+}
+
+export function assertInvocationAllowed(manifest: DiscordSmokeManifest): void {
+  if (
+    manifest.invocationStartedAt !== null ||
+    manifest.privateReplyId !== null ||
+    manifest.publicMessageId !== null
+  ) {
+    throw new Error(
+      `Smoke run ${manifest.runId} may not invoke again; use --resume ${manifest.runId}`,
+    );
+  }
+}
+
+export async function waitForDiscordCommand(
+  params: {
+    readonly fixture: DiscordSmokeFixture;
+    readonly botToken: string;
+    readonly commandName: string;
+    readonly guildScoped: boolean;
+    readonly timeoutMilliseconds?: number | undefined;
+  },
+  fetcher: DiscordSmokePreflightDependencies["fetch"] = fetch,
+): Promise<void> {
+  const pathname = params.guildScoped
+    ? `/applications/${params.fixture.applicationId}/guilds/${params.fixture.guildId}/commands`
+    : `/applications/${params.fixture.applicationId}/commands`;
+  const timeoutMilliseconds = params.timeoutMilliseconds ?? 45_000;
+  const deadline = Date.now() + timeoutMilliseconds;
+  let lastNames: string[] = [];
+  while (Date.now() < deadline) {
+    const commands = z
+      .array(DiscordCommandSchema)
+      .parse(await discordJson(fetcher, pathname, `Bot ${params.botToken}`));
+    lastNames = commands.map((command) => command.name);
+    if (commands.some((command) => command.name === params.commandName)) {
+      return;
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(
+    `Discord did not expose /${params.commandName} before timeout; observed [${lastNames.join(", ")}]`,
+  );
+}
+
+export async function loadDiscordSmokeFixture(
+  fixturePath: string,
+): Promise<DiscordSmokeFixture> {
+  const parsed: unknown = JSON.parse(await Bun.file(fixturePath).text());
+  return DiscordSmokeFixtureSchema.parse(parsed);
+}
+
+export async function loadDiscordSmokeManifest(
+  manifestPath: string,
+): Promise<DiscordSmokeManifest> {
+  const parsed: unknown = JSON.parse(await Bun.file(manifestPath).text());
+  return DiscordSmokeManifestSchema.parse(parsed);
+}
+
+export async function writeDiscordSmokeManifest(
+  manifestPath: string,
+  manifest: DiscordSmokeManifest,
+): Promise<void> {
+  const validated = DiscordSmokeManifestSchema.parse(manifest);
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  const temporaryPath = `${manifestPath}.tmp`;
+  await Bun.write(temporaryPath, `${JSON.stringify(validated, null, 2)}\n`);
+  await rename(temporaryPath, manifestPath);
+}

--- a/packages/scout-for-lol/scripts/discord-smoke.fixture.json
+++ b/packages/scout-for-lol/scripts/discord-smoke.fixture.json
@@ -1,0 +1,9 @@
+{
+  "applicationId": "1542993271477899294",
+  "botUserId": "1542993271477899294",
+  "invokingUserId": "1515150733660520496",
+  "recipientUserId": "160509172704739328",
+  "guildId": "1543374394598887484",
+  "channelId": "1543374398902243398",
+  "pinchTabProfile": "scout-discord-smoke"
+}

--- a/packages/scout-for-lol/scripts/discord-smoke.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke.ts
@@ -1,0 +1,161 @@
+import path from "node:path";
+import {
+  createTestDatabase,
+  dropTestDatabase,
+} from "@scout-for-lol/backend/testing/test-database.ts";
+import {
+  ensureTestTemplate,
+  sweepStaleTestDatabases,
+} from "@scout-for-lol/backend/testing/test-template.ts";
+import { verifyPinchTabProfile } from "./discord-smoke-browser.ts";
+import {
+  DiscordSmokeManifestSchema,
+  loadDiscordSmokeFixture,
+  loadDiscordSmokeManifest,
+  preflightDiscordSmoke,
+  raceRuntimeOperation,
+  waitForRuntimeReadiness,
+  waitForDiscordCommand,
+  writeDiscordSmokeManifest,
+} from "./discord-smoke-core.ts";
+import { requireCliValue } from "./migration-core.ts";
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dir, "../../..");
+const SCOUT_ROOT = path.resolve(import.meta.dir, "..");
+const FIXTURE_PATH = path.join(import.meta.dir, "discord-smoke.fixture.json");
+
+type SmokeArguments =
+  | { readonly kind: "fresh"; readonly scenario: "gateway" }
+  | { readonly kind: "resume"; readonly runId: string };
+
+export function parseDiscordSmokeArguments(
+  args: readonly string[],
+): SmokeArguments {
+  if (args[0] === "--resume") {
+    return { kind: "resume", runId: requireCliValue(args, 0, "--resume") };
+  }
+  if (args[0] === "--scenario") {
+    const scenario = requireCliValue(args, 0, "--scenario");
+    if (scenario !== "gateway") {
+      throw new Error(`Unknown Discord smoke scenario: ${scenario}`);
+    }
+    return { kind: "fresh", scenario };
+  }
+  throw new Error(
+    "Usage: test:discord:smoke -- --scenario gateway | --resume <run-id>",
+  );
+}
+
+function runDirectory(runId: string): string {
+  return path.join(WORKSPACE_ROOT, ".context", "discord-smoke", runId);
+}
+
+async function stopChild(child: Bun.Subprocess | null): Promise<void> {
+  if (child?.exitCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  await child.exited;
+}
+
+async function runGatewaySmoke(): Promise<void> {
+  const fixture = await loadDiscordSmokeFixture(FIXTURE_PATH);
+  await preflightDiscordSmoke(fixture, Bun.env, {
+    fetch,
+    verifyPinchTabProfile,
+  });
+
+  const runId = `${new Date()
+    .toISOString()
+    .replaceAll(/\D/gu, "")
+    .slice(0, 14)}-${crypto.randomUUID().slice(0, 8)}`;
+  const manifestPath = path.join(runDirectory(runId), "manifest.json");
+  const runtimeReadyPath = path.join(runDirectory(runId), "runtime-ready.json");
+  let manifest = DiscordSmokeManifestSchema.parse({
+    runId,
+    scenario: "gateway",
+    createdAt: new Date().toISOString(),
+    databaseName: null,
+    databaseUrl: null,
+    invocationStartedAt: null,
+    privateReplyId: null,
+    publicMessageId: null,
+    verifiedAt: null,
+    screenshotPath: null,
+  });
+  await writeDiscordSmokeManifest(manifestPath, manifest);
+
+  await ensureTestTemplate();
+  sweepStaleTestDatabases();
+  const database = createTestDatabase(`discord_smoke_${runId}`);
+  manifest = {
+    ...manifest,
+    databaseName: database.dbPath,
+    databaseUrl: database.dbUrl,
+  };
+  await writeDiscordSmokeManifest(manifestPath, manifest);
+
+  let runtime: Bun.Subprocess | null = null;
+  let successful = false;
+  try {
+    runtime = Bun.spawn(
+      [
+        "bun",
+        "scripts/dev-discord.ts",
+        "--scenario",
+        "gateway",
+        "--database-url",
+        database.dbUrl,
+      ],
+      {
+        cwd: SCOUT_ROOT,
+        env: {
+          ...Bun.env,
+          SCOUT_DISCORD_SMOKE_GUILD_ID: fixture.guildId,
+          SCOUT_DISCORD_SMOKE_READY_PATH: runtimeReadyPath,
+        },
+        stdin: "ignore",
+        stdout: "inherit",
+        stderr: "inherit",
+      },
+    );
+    const botToken = Bun.env["DISCORD_BOT_TOKEN"];
+    if (botToken === undefined) {
+      throw new Error("Discord smoke lost DISCORD_BOT_TOKEN after preflight");
+    }
+    await waitForRuntimeReadiness(runtime, runtimeReadyPath);
+    await raceRuntimeOperation(
+      runtime,
+      waitForDiscordCommand({
+        fixture,
+        botToken,
+        commandName: "help",
+        guildScoped: false,
+      }),
+      "before exposing /help",
+    );
+    manifest = { ...manifest, verifiedAt: new Date().toISOString() };
+    await writeDiscordSmokeManifest(manifestPath, manifest);
+    successful = true;
+  } finally {
+    await stopChild(runtime);
+    if (successful) {
+      await dropTestDatabase(database.prisma, database.dbPath);
+    } else {
+      await database.prisma.$disconnect();
+    }
+  }
+  console.log(`Discord gateway smoke passed: ${runId}`);
+}
+
+if (import.meta.main) {
+  const args = parseDiscordSmokeArguments(Bun.argv.slice(2));
+  if (args.kind === "resume") {
+    const manifest = await loadDiscordSmokeManifest(
+      path.join(runDirectory(args.runId), "manifest.json"),
+    );
+    console.log(JSON.stringify(manifest, null, 2));
+  } else {
+    await runGatewaySmoke();
+  }
+}

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -188,6 +188,8 @@ export DISCORD_USER_TOKEN=$(op read "op://Personal/<item-id>/TOKEN")
 toolkit discord daemon start --ttl 30m      # also reads DISCORD_BOT_TOKEN if set
 toolkit discord send <channelId> "hello"
 toolkit discord slash <channelId> <botId> <command> [args...]   # userbot only
+toolkit discord slash <channelId> <botId> <command> [args...] \
+  --direct --wait-public --contains "receipt text" --timeout 45 --json
 toolkit discord voice join <channelId>      # presence persists between commands
 toolkit discord voice states <guildId>      # streaming flags (needs a bot token)
 toolkit discord daemon stop
@@ -198,6 +200,12 @@ Design notes encoded in the code:
 - **At least one of `DISCORD_BOT_TOKEN` / `DISCORD_USER_TOKEN`** must be set; each
   client is optional and commands route to the identity they need (slash + voice
   join are userbot-only; voice states is bot-only).
+- `discord slash --direct` is the isolated automation path. It never contacts or
+  disturbs the session daemon, logs in only `DISCORD_USER_TOKEN`, installs its
+  public-response listener before invoking, and always destroys the gateway at
+  its deadline. `--wait-public` filters to the target bot; `--contains` narrows
+  the response. JSON includes the immediate interaction reply, the public
+  response, and exact user, role, and everyone mentions for each message.
 - Tokens are passed to the detached daemon via **env, never argv** (not visible in
   `ps`) and never written to the state file or logs.
 - State dir `~/.toolkit/discord/`: `daemon.sock` (0600), `state.json` (pid +

--- a/packages/toolkit/src/commands/discord/slash.ts
+++ b/packages/toolkit/src/commands/discord/slash.ts
@@ -1,5 +1,9 @@
 import { daemonRequest } from "#lib/discord/client.ts";
-import { SlashResponseSchema } from "#lib/discord/ipc.ts";
+import { invokeSlashDirect } from "#lib/discord/direct-slash.ts";
+import {
+  DirectSlashResponseSchema,
+  SlashResponseSchema,
+} from "#lib/discord/ipc.ts";
 import { renderMessage } from "#lib/discord/render.ts";
 
 export async function slashCommand(params: {
@@ -8,13 +12,42 @@ export async function slashCommand(params: {
   command: string;
   args: string[];
   json: boolean;
+  direct: boolean;
+  waitForPublicResponse: boolean;
+  publicResponseContains?: string | undefined;
+  timeoutSeconds: number;
 }): Promise<void> {
+  if (params.direct) {
+    const result = DirectSlashResponseSchema.parse(
+      await invokeSlashDirect({
+        token: requireUserToken(),
+        channelId: params.channelId,
+        botId: params.botId,
+        command: params.command,
+        args: params.args,
+        waitForPublicResponse: params.waitForPublicResponse,
+        publicResponseContains: params.publicResponseContains,
+        timeoutSeconds: params.timeoutSeconds,
+      }),
+    );
+    renderResult(result, params);
+    return;
+  }
   const result = await daemonRequest(SlashResponseSchema, "/slash", {
     channelId: params.channelId,
     botId: params.botId,
     command: params.command,
     args: params.args,
   });
+  renderResult(result, params);
+}
+
+function renderResult(
+  result:
+    | ReturnType<typeof SlashResponseSchema.parse>
+    | ReturnType<typeof DirectSlashResponseSchema.parse>,
+  params: { json: boolean; command: string; botId: string },
+): void {
   if (params.json) {
     console.log(JSON.stringify(result, null, 2));
     return;
@@ -24,4 +57,21 @@ export async function slashCommand(params: {
     console.log("\nReply:");
     console.log(renderMessage(result.reply));
   }
+  if (DirectSlashResponseSchema.safeParse(result).success) {
+    const directResult = DirectSlashResponseSchema.parse(result);
+    if (directResult.publicResponse !== null) {
+      console.log("\nPublic response:");
+      console.log(renderMessage(directResult.publicResponse));
+    } else if (directResult.publicResponseTimedOut) {
+      console.log("\nNo matching public response arrived before the timeout.");
+    }
+  }
+}
+
+function requireUserToken(): string {
+  const token = Bun.env["DISCORD_USER_TOKEN"];
+  if (token == null || token.length === 0) {
+    throw new Error("--direct requires DISCORD_USER_TOKEN");
+  }
+  return token;
 }

--- a/packages/toolkit/src/handlers/discord.ts
+++ b/packages/toolkit/src/handlers/discord.ts
@@ -38,6 +38,7 @@ Commands (talk to the running daemon):
   toolkit discord read <channelId> [-n 20] [--json]      Recent messages (incl. embeds)
   toolkit discord wait <channelId> [--from <userId>] [--contains <str>] [--timeout 30]
   toolkit discord slash <channelId> <botId> <command> [args…]   Invoke another bot's slash command (userbot)
+    --direct [--wait-public] [--contains <str>] [--timeout 30]   Use an isolated one-shot user gateway
   toolkit discord voice join <channelId>                 Userbot joins VC; presence persists
   toolkit discord voice leave
   toolkit discord voice states <guildId> [--json]        Who's in VC, streaming flags
@@ -168,17 +169,46 @@ async function handleWait(args: string[]): Promise<void> {
 }
 
 async function handleSlash(args: string[]): Promise<void> {
-  const { values, positionals } = parseJsonFlag(args);
-  const usage = "toolkit discord slash <channelId> <botId> <command> [args…]";
+  const { values, positionals } = parseArgs({
+    args,
+    options: {
+      json: { type: "boolean", default: false },
+      direct: { type: "boolean", default: false },
+      "wait-public": { type: "boolean", default: false },
+      contains: { type: "string" },
+      timeout: { type: "string" },
+    },
+    allowPositionals: true,
+  });
+  const usage =
+    "toolkit discord slash <channelId> <botId> <command> [args…] [--direct --wait-public --contains <str> --timeout 30]";
   const channelId = requirePositional(positionals, 0, "channel id", usage);
   const botId = requirePositional(positionals, 1, "bot id", usage);
   const command = requirePositional(positionals, 2, "command name", usage);
+  const timeoutSeconds = Number.parseInt(values.timeout ?? "30", 10);
+  if (
+    !Number.isInteger(timeoutSeconds) ||
+    timeoutSeconds < 1 ||
+    timeoutSeconds > 600
+  ) {
+    throw new Error("--timeout must be a whole number from 1 through 600");
+  }
+  if (values["wait-public"] && !values.direct) {
+    throw new Error("--wait-public requires --direct");
+  }
+  if (values.contains != null && !values["wait-public"]) {
+    throw new Error("--contains requires --wait-public");
+  }
   await slashCommand({
     channelId,
     botId,
     command,
     args: positionals.slice(3),
     json: values.json,
+    direct: values.direct,
+    waitForPublicResponse: values["wait-public"],
+    publicResponseContains: values.contains,
+    timeoutSeconds,
   });
 }
 

--- a/packages/toolkit/src/lib/discord/direct-slash.ts
+++ b/packages/toolkit/src/lib/discord/direct-slash.ts
@@ -1,0 +1,189 @@
+import {
+  Client as UserClient,
+  Message as UserMessage,
+} from "discord.js-selfbot-v13";
+import { mapUserMessage, messageMatches } from "#lib/discord/handlers.ts";
+import type { DirectSlashResponse, IpcMessage } from "#lib/discord/ipc.ts";
+
+export type DirectSlashGateway = {
+  connect: (
+    token: string,
+    onMessage: (message: IpcMessage) => void,
+  ) => Promise<string>;
+  invoke: (params: {
+    channelId: string;
+    botId: string;
+    command: string;
+    args: string[];
+  }) => Promise<IpcMessage | null>;
+  close: () => void;
+};
+
+export type DirectSlashParameters = {
+  token: string;
+  channelId: string;
+  botId: string;
+  command: string;
+  args: string[];
+  waitForPublicResponse: boolean;
+  publicResponseContains?: string | undefined;
+  timeoutSeconds: number;
+};
+
+async function rejectAfter<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+  message: string,
+): Promise<T> {
+  const timeout = Promise.withResolvers<T>();
+  const timer = setTimeout(() => {
+    timeout.reject(new Error(message));
+  }, milliseconds);
+  try {
+    return await Promise.race([promise, timeout.promise]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function nullAfter<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+): Promise<T | null> {
+  const timeout = Promise.withResolvers<null>();
+  const timer = setTimeout(() => {
+    timeout.resolve(null);
+  }, milliseconds);
+  try {
+    return await Promise.race([promise, timeout.promise]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function remainingMilliseconds(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class SelfbotDirectSlashGateway implements DirectSlashGateway {
+  readonly #client = new UserClient();
+  #messageListener: ((message: UserMessage) => void) | null = null;
+
+  async connect(
+    token: string,
+    onMessage: (message: IpcMessage) => void,
+  ): Promise<string> {
+    this.#messageListener = (message: UserMessage): void => {
+      onMessage(mapUserMessage(message));
+    };
+    this.#client.on("messageCreate", this.#messageListener);
+
+    const ready = new Promise<void>((resolve, reject) => {
+      const onReady = (): void => {
+        this.#client.off("error", onError);
+        resolve();
+      };
+      const onError = (error: Error): void => {
+        this.#client.off("ready", onReady);
+        reject(error);
+      };
+      this.#client.once("ready", onReady);
+      this.#client.once("error", onError);
+    });
+    await this.#client.login(token);
+    await ready;
+    const user = this.#client.user;
+    if (user === null) {
+      throw new Error("Discord user gateway became ready without a user");
+    }
+    return user.id;
+  }
+
+  async invoke(params: {
+    channelId: string;
+    botId: string;
+    command: string;
+    args: string[];
+  }): Promise<IpcMessage | null> {
+    const channel = await this.#client.channels.fetch(params.channelId);
+    if (channel?.isText() !== true) {
+      throw new Error(`Channel ${params.channelId} is not a user text channel`);
+    }
+    const result = await channel.sendSlash(
+      params.botId,
+      params.command,
+      ...params.args,
+    );
+    return result instanceof UserMessage ? mapUserMessage(result) : null;
+  }
+
+  close(): void {
+    if (this.#messageListener !== null) {
+      this.#client.off("messageCreate", this.#messageListener);
+      this.#messageListener = null;
+    }
+    try {
+      this.#client.destroy();
+    } catch (error) {
+      console.error(
+        `Discord user gateway teardown failed: ${errorMessage(error)}`,
+      );
+    }
+  }
+}
+
+export async function invokeSlashDirect(
+  params: DirectSlashParameters,
+  gateway: DirectSlashGateway = new SelfbotDirectSlashGateway(),
+): Promise<DirectSlashResponse> {
+  const deadline = Date.now() + params.timeoutSeconds * 1000;
+  let resolvePublicResponse: ((message: IpcMessage) => void) | null = null;
+  const publicResponsePromise = new Promise<IpcMessage>((resolve) => {
+    resolvePublicResponse = resolve;
+  });
+  const onMessage = (message: IpcMessage): void => {
+    if (
+      params.waitForPublicResponse &&
+      messageMatches(message, {
+        channelId: params.channelId,
+        fromUserId: params.botId,
+        contains: params.publicResponseContains,
+      })
+    ) {
+      resolvePublicResponse?.(message);
+    }
+  };
+
+  try {
+    if (params.token.length === 0) {
+      throw new Error("Direct Discord slash invocation requires a user token");
+    }
+    const invokingUserId = await rejectAfter(
+      gateway.connect(params.token, onMessage),
+      remainingMilliseconds(deadline),
+      `Discord user gateway did not become ready within ${String(params.timeoutSeconds)} seconds`,
+    );
+    const reply = await rejectAfter(
+      gateway.invoke(params),
+      remainingMilliseconds(deadline),
+      `Discord slash invocation did not finish within ${String(params.timeoutSeconds)} seconds`,
+    );
+    const publicResponse = params.waitForPublicResponse
+      ? await nullAfter(publicResponsePromise, remainingMilliseconds(deadline))
+      : null;
+    return {
+      invoked: true,
+      invokingUserId,
+      reply,
+      publicResponse,
+      publicResponseTimedOut:
+        params.waitForPublicResponse && publicResponse === null,
+    };
+  } finally {
+    gateway.close();
+  }
+}

--- a/packages/toolkit/src/lib/discord/handlers.ts
+++ b/packages/toolkit/src/lib/discord/handlers.ts
@@ -43,7 +43,19 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function mapBotMessage(message: BotMessage): IpcMessage {
+export function mapMessageMentions(
+  userIds: Iterable<string>,
+  roleIds: Iterable<string>,
+  everyone: boolean,
+): Pick<IpcMessage, "mentionUserIds" | "mentionRoleIds" | "mentionsEveryone"> {
+  return {
+    mentionUserIds: [...userIds].toSorted(),
+    mentionRoleIds: [...roleIds].toSorted(),
+    mentionsEveryone: everyone,
+  };
+}
+
+export function mapBotMessage(message: BotMessage): IpcMessage {
   return {
     id: message.id,
     channelId: message.channelId,
@@ -64,10 +76,15 @@ function mapBotMessage(message: BotMessage): IpcMessage {
       name: attachment.name,
       url: attachment.url,
     })),
+    ...mapMessageMentions(
+      message.mentions.users.keys(),
+      message.mentions.roles.keys(),
+      message.mentions.everyone,
+    ),
   };
 }
 
-function mapUserMessage(message: UserMessage): IpcMessage {
+export function mapUserMessage(message: UserMessage): IpcMessage {
   return {
     id: message.id,
     channelId: message.channelId,
@@ -88,6 +105,11 @@ function mapUserMessage(message: UserMessage): IpcMessage {
       name: attachment.name ?? "attachment",
       url: attachment.url,
     })),
+    ...mapMessageMentions(
+      message.mentions.users.keys(),
+      message.mentions.roles.keys(),
+      message.mentions.everyone,
+    ),
   };
 }
 
@@ -175,7 +197,7 @@ async function handleRead(ctx: DaemonContext, body: unknown): Promise<unknown> {
   return { messages };
 }
 
-function messageMatches(
+export function messageMatches(
   message: IpcMessage,
   request: {
     channelId: string;

--- a/packages/toolkit/src/lib/discord/ipc.ts
+++ b/packages/toolkit/src/lib/discord/ipc.ts
@@ -58,6 +58,11 @@ export const MessageSchema = z.object({
   createdAt: z.string(),
   embeds: z.array(EmbedSchema),
   attachments: z.array(z.object({ name: z.string(), url: z.string() })),
+  // Daemons started before direct slash support omit mention metadata. Defaults
+  // keep their read/wait/slash responses usable until their normal TTL restart.
+  mentionUserIds: z.array(z.string()).default([]),
+  mentionRoleIds: z.array(z.string()).default([]),
+  mentionsEveryone: z.boolean().default(false),
 });
 export type IpcMessage = z.infer<typeof MessageSchema>;
 
@@ -113,6 +118,15 @@ export const SlashResponseSchema = z.object({
   invoked: z.boolean(),
   reply: MessageSchema.nullable(),
 });
+
+export const DirectSlashResponseSchema = z.object({
+  invoked: z.boolean(),
+  invokingUserId: z.string(),
+  reply: MessageSchema.nullable(),
+  publicResponse: MessageSchema.nullable(),
+  publicResponseTimedOut: z.boolean(),
+});
+export type DirectSlashResponse = z.infer<typeof DirectSlashResponseSchema>;
 
 export const VoiceJoinRequestSchema = z.object({
   channelId: z.string(),

--- a/packages/toolkit/test/discord/ipc.test.ts
+++ b/packages/toolkit/test/discord/ipc.test.ts
@@ -42,8 +42,29 @@ describe("ipc schemas", () => {
         },
       ],
       attachments: [{ name: "a.png", url: "https://example.com/a.png" }],
+      mentionUserIds: ["4"],
+      mentionRoleIds: ["5"],
+      mentionsEveryone: false,
     };
     expect(MessageSchema.parse(message)).toEqual(message);
+  });
+
+  test("adds mention metadata omitted by an older running daemon", () => {
+    const parsed = MessageSchema.parse({
+      id: "1",
+      channelId: "2",
+      authorId: "3",
+      authorTag: "someone#0",
+      authorIsBot: false,
+      content: "hello",
+      createdAt: "2026-06-12T00:00:00.000Z",
+      embeds: [],
+      attachments: [],
+    });
+
+    expect(parsed.mentionUserIds).toEqual([]);
+    expect(parsed.mentionRoleIds).toEqual([]);
+    expect(parsed.mentionsEveryone).toBe(false);
   });
 
   test("status response requires voice to be present (nullable)", () => {

--- a/packages/toolkit/test/discord/render.test.ts
+++ b/packages/toolkit/test/discord/render.test.ts
@@ -22,6 +22,9 @@ const message: IpcMessage = {
     },
   ],
   attachments: [],
+  mentionUserIds: [],
+  mentionRoleIds: [],
+  mentionsEveryone: false,
 };
 
 describe("renderMessages", () => {

--- a/packages/toolkit/test/history/cli.test.ts
+++ b/packages/toolkit/test/history/cli.test.ts
@@ -14,6 +14,8 @@ import type { HistorySourceResult } from "#lib/history/types.ts";
 
 let fixtureHome = "";
 let recordId = 0;
+const fixtureUpdatedAt = new Date().toISOString();
+const fixtureCreatedAt = new Date(Date.now() - 60_000).toISOString();
 
 function unavailable(
   source: "cursor" | "claude",
@@ -43,15 +45,31 @@ beforeAll(async () => {
       full_message TEXT, created_at TEXT
     );
   `);
-  database.run(
-    "INSERT INTO sessions VALUES ('current-session', 'Synthetic history', '2026-08-18T00:00:00Z', '2026-08-18T00:02:00Z', 'model', 'agent', '/fixture')",
-  );
-  database.run(
-    "INSERT INTO session_messages VALUES ('m1', 'current-session', 'user', 'Investigate synthetic history ranking', NULL, '2026-08-18T00:00:00Z')",
-  );
-  database.run(
-    "INSERT INTO session_messages VALUES ('m2', 'current-session', 'assistant', 'Synthetic history answer', NULL, '2026-08-18T00:01:00Z')",
-  );
+  database.run("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, ?)", [
+    "current-session",
+    "Synthetic history",
+    fixtureCreatedAt,
+    fixtureUpdatedAt,
+    "model",
+    "agent",
+    "/fixture",
+  ]);
+  database.run("INSERT INTO session_messages VALUES (?, ?, ?, ?, ?, ?)", [
+    "m1",
+    "current-session",
+    "user",
+    "Investigate synthetic history ranking",
+    null,
+    fixtureCreatedAt,
+  ]);
+  database.run("INSERT INTO session_messages VALUES (?, ?, ?, ?, ?, ?)", [
+    "m2",
+    "current-session",
+    "assistant",
+    "Synthetic history answer",
+    null,
+    fixtureUpdatedAt,
+  ]);
   database.close();
 
   const conductor = createHistorySources().find(
@@ -77,8 +95,8 @@ beforeAll(async () => {
           path: "/fixture/codex-collision",
           workspace: "/fixture",
           agent: "fixture",
-          createdAt: "2026-08-18T00:00:00Z",
-          updatedAt: "2026-08-18T00:01:00Z",
+          createdAt: fixtureCreatedAt,
+          updatedAt: fixtureUpdatedAt,
           runtimeId: "current-session",
           openingPromptHash: null,
           dialogueText: "Unique collisionterm dialogue",

--- a/packages/toolkit/test/lib/discord-direct-slash.test.ts
+++ b/packages/toolkit/test/lib/discord-direct-slash.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  type DirectSlashGateway,
+  invokeSlashDirect,
+} from "#lib/discord/direct-slash.ts";
+import { mapMessageMentions } from "#lib/discord/handlers.ts";
+import type { IpcMessage } from "#lib/discord/ipc.ts";
+
+function message(overrides: Partial<IpcMessage> = {}): IpcMessage {
+  return {
+    id: "message-1",
+    channelId: "channel-1",
+    authorId: "bot-1",
+    authorTag: "Derrej#8685",
+    authorIsBot: true,
+    content: "public receipt",
+    createdAt: "2026-08-29T00:00:00.000Z",
+    embeds: [],
+    attachments: [],
+    mentionUserIds: ["recipient", "sender"],
+    mentionRoleIds: [],
+    mentionsEveryone: false,
+    ...overrides,
+  };
+}
+
+class FakeGateway implements DirectSlashGateway {
+  closed = false;
+  invoked = false;
+  onInvoke: ((onMessage: (message: IpcMessage) => void) => void) | null = null;
+  #onMessage: ((message: IpcMessage) => void) | null = null;
+
+  async connect(
+    _token: string,
+    onMessage: (message: IpcMessage) => void,
+  ): Promise<string> {
+    this.#onMessage = onMessage;
+    return "user-1";
+  }
+
+  async invoke(): Promise<IpcMessage> {
+    this.invoked = true;
+    if (this.#onMessage === null) {
+      throw new Error("Fake gateway was invoked before connection");
+    }
+    this.onInvoke?.(this.#onMessage);
+    return message({ id: "private-reply", content: "private acknowledgement" });
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+const parameters = {
+  token: "user-token",
+  channelId: "channel-1",
+  botId: "bot-1",
+  command: "bb",
+  args: ["transfer", "recipient", "3"],
+  waitForPublicResponse: true,
+  publicResponseContains: "receipt",
+  timeoutSeconds: 30,
+};
+
+describe("invokeSlashDirect", () => {
+  test("returns the private reply and matching public response", async () => {
+    const gateway = new FakeGateway();
+    gateway.onInvoke = (onMessage) => {
+      onMessage(message({ id: "ignored", content: "something else" }));
+      onMessage(message({ id: "public-receipt" }));
+    };
+
+    const result = await invokeSlashDirect(parameters, gateway);
+
+    expect(result).toEqual({
+      invoked: true,
+      invokingUserId: "user-1",
+      reply: message({
+        id: "private-reply",
+        content: "private acknowledgement",
+      }),
+      publicResponse: message({ id: "public-receipt" }),
+      publicResponseTimedOut: false,
+    });
+    expect(gateway.invoked).toBe(true);
+    expect(gateway.closed).toBe(true);
+  });
+
+  test("returns a structured timeout and closes the gateway", async () => {
+    vi.useFakeTimers();
+    try {
+      const gateway = new FakeGateway();
+      const resultPromise = invokeSlashDirect(
+        { ...parameters, timeoutSeconds: 1 },
+        gateway,
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        publicResponse: null,
+        publicResponseTimedOut: true,
+      });
+      expect(gateway.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects a missing credential before invocation and still closes", async () => {
+    const gateway = new FakeGateway();
+
+    await expect(
+      invokeSlashDirect({ ...parameters, token: "" }, gateway),
+    ).rejects.toThrow("requires a user token");
+    expect(gateway.invoked).toBe(false);
+    expect(gateway.closed).toBe(true);
+  });
+
+  test("closes the gateway when invocation fails", async () => {
+    const gateway = new FakeGateway();
+    gateway.invoke = () => Promise.reject(new Error("Discord rejected it"));
+
+    await expect(invokeSlashDirect(parameters, gateway)).rejects.toThrow(
+      "Discord rejected it",
+    );
+    expect(gateway.closed).toBe(true);
+  });
+
+  test("a hanging invocation hits the watchdog and closes the gateway", async () => {
+    vi.useFakeTimers();
+    try {
+      const gateway = new FakeGateway();
+      gateway.invoke = () =>
+        new Promise(() => {
+          // Deliberately pending so the invocation watchdog owns teardown.
+        });
+      const resultPromise = invokeSlashDirect(
+        { ...parameters, timeoutSeconds: 1 },
+        gateway,
+      );
+      const expectation = expect(resultPromise).rejects.toThrow(
+        "slash invocation did not finish",
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expectation;
+      expect(gateway.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+test("mention extraction preserves exact users, roles, and everyone", () => {
+  expect(
+    mapMessageMentions(["user-2", "user-1"], ["role-2", "role-1"], true),
+  ).toEqual({
+    mentionUserIds: ["user-1", "user-2"],
+    mentionRoleIds: ["role-1", "role-2"],
+    mentionsEveryone: true,
+  });
+});


### PR DESCRIPTION
## Why

Scout Discord acceptance previously started the full local web stack, so an unrelated report-lake rebuild could block gateway testing and the beta bot boundary was too easy to cross.

## What

- add independent background-job and Vite controls while preserving `dev:web` defaults
- add a stable Derrej-only `dev:discord` preset and closed dev scenario entrypoint
- preflight the exact bot application, guild, channel, invoking user, recipient, and signed-in PinchTab profile before database creation
- create isolated `scout_test_*` databases with atomic resumable manifests, success cleanup, and failed-run preservation
- document the reusable runtime and replace the Flipt operator URL placeholder

## Verification

- `bunx turbo run typecheck test lint --filter=scout-for-lol --filter=@scout-for-lol/backend --filter=@shepherdjerred/docs-wiki`
- `bunx lefthook run pre-commit`
- `curl -sI https://flipt.tailnet-1a49.ts.net` returned HTTP 200

Live Discord mutation was not run on this PR: the dedicated bot install, recipient guild join, and one-time PinchTab Discord login remain manual prerequisites. No beta gateway, beta database, or report lake was touched.