### PR TITLE
feat(scout-for-lol): add Western Union Bryan Bucks transfers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1123,7 +1123,10 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
         "@eslint/js": "^10.0.1",
+        "@scout-for-lol/backend": "workspace:*",
+        "@scout-for-lol/data": "workspace:*",
         "@shepherdjerred/eslint-config": "workspace:*",
+        "@shepherdjerred/toolkit": "workspace:*",
         "@total-typescript/ts-reset": "^0.6.1",
         "@types/bun": "1.4.0",
         "@types/eslint-plugin-jsx-a11y": "^6.10.1",

--- a/packages/dotfiles/dot_agents/skills/scout-development/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/scout-development/SKILL.md
@@ -54,10 +54,21 @@ This preset uses `DISCORD_BOT_TOKEN` with Derrej application
 `1542993271477899294`, keeps local Temporal, and disables background jobs,
 report-lake preparation, Vite, and backend watch. Scenario flags are applied by
 the dev-only backend entrypoint to the one explicit fixture guild. Use the
-operator-only `test:discord:smoke` command for repeatable acceptance; it
-preflights Discord and the `scout-discord-smoke` PinchTab profile before any
-database mutation and stores resumable evidence under `.context/discord-smoke/`.
-Never substitute the BETA token or guild for this workflow.
+operator-only `test:discord:smoke` command for repeatable acceptance:
+
+```bash
+bun run --filter='./packages/scout-for-lol' test:discord:smoke -- \
+  --scenario bb-transfer
+```
+
+It preflights Discord, recipient membership, and the signed-in
+`scout-discord-smoke` PinchTab profile before any database mutation. The
+transfer scenario seeds an isolated local database, verifies the exact 3 BB
+Western Union receipt and `-3/+1/+2` ledger/outbox state, saves real-client
+evidence under `.context/discord-smoke/`, and drops only successful databases.
+If a failure happens after invocation starts, use `--resume <run-id>`; the
+manifest forbids reinvocation. Never substitute the BETA token or guild for
+this workflow.
 
 Each copy can use isolated ports and an isolated Postgres database on the
 shared local dev server (port 5471, `SCOUT_PG_PORT` overrides):

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -154,7 +154,9 @@
           ],
           "result": true
         }
-      ]
+      ],
+      "rules": [],
+      "thresholdRollouts": []
     },
     {
       "key": "betting_settlement_dm_enabled",

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -133,6 +133,30 @@
       "thresholdRollouts": []
     },
     {
+      "key": "bucks_transfers_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable fee-bearing Bryan Bucks wallet transfers.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
+          "result": true
+        }
+      ]
+    },
+    {
       "key": "betting_settlement_dm_enabled",
       "owner": "scout",
       "source": "scout-policy",

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -209,15 +209,22 @@ The operator-only smoke command is never a CI task:
 
 ```bash
 bun run --filter='./packages/scout-for-lol' test:discord:smoke -- \
-  --scenario gateway
+  --scenario bb-transfer
 ```
 
 It validates the tracked public fixture, both Discord credentials, guild and
-channel membership, application identity, and the dedicated running PinchTab
-profile before creating an isolated `scout_test_*` database. Runs write an
-atomic manifest under the workspace `.context/discord-smoke/<run-id>/`; failed
-databases are preserved, successful databases are dropped, and `--resume`
-never invokes Discord again. Stop every local gateway process after testing.
+channel membership (including the recipient), application identity, and the
+dedicated signed-in PinchTab profile before creating an isolated
+`scout_test_*` database. The `bb-transfer` scenario seeds both wallets through
+`ensureBucksAccount`, registers `/bb` only in the fixture guild, invokes a 3 BB
+transfer, and asserts the exact private reply, public receipt, two-user mention
+allowlist, `-3/+1/+2` ledger split, stored balances, conservation, and three
+analytics outbox rows. Runs write an atomic manifest under the workspace
+`.context/discord-smoke/<run-id>/`; the invocation timestamp is durable before
+the slash command begins, so a failed post-commit run must use `--resume
+<run-id>` for database verification and real-client screenshot capture without
+another transfer. Failed databases are preserved and successful databases are
+dropped. Stop every local gateway process after testing.
 
 ### Shared report-lake seed (multiple checkouts / parallel agents)
 
@@ -953,9 +960,11 @@ fatal during startup.
 The feature scope remains enforced by the flag and guild-scoped registration;
 user-facing betting surfaces should not advertise the allowlist. `/bb prizes`
 is the deliberate exception: it displays the existing 1:10 catalog and
-in-person-with-Bryan footer as joke copy only. There is no command or accounting
-path to redeem, donate, burn, or claim Bucks, and nothing transfers to real
-goods. `/bb rules` says so explicitly, because for a while it claimed "no cash
+in-person-with-Bryan footer as joke copy only. `/bb transfer` is the sole
+user-to-user movement: an immediate, irreversible, fee-bearing transfer between
+existing wallets in the same guild. There is no command or accounting path to
+redeem, freely donate, burn, or claim Bucks, and nothing transfers to real goods.
+`/bb rules` says so explicitly, because for a while it claimed "no cash
 value" while `/bb prizes` printed CAD figures to $1,000,000 with no
 cross-reference.
 
@@ -1216,6 +1225,16 @@ current UTC timestamp for relative date filters, and uses `BB_ASK_MODEL`
   The stored `BucksBet.payout` is net; settlement summaries retain gross
   payout, cut, net payout, and net winnings so Discord copy never has to
   reconstruct the arithmetic from ledger rows.
+- **Western Union transfers conserve one debit across two credits.** The domain
+  requires both `betting_enabled` and `bucks_transfers_enabled`, resolves the
+  sender, recipient, and guild house before opening the transaction, and makes
+  the guarded sender debit its first statement. It then credits the recipient
+  `floor(amount / 2)` and the house `ceil(amount / 2)` through
+  `applyBucksDelta`; all three rows carry one UUID and the full split. Any later
+  credit failure rolls the whole transaction back. After commit, `/bb transfer`
+  privately acknowledges the sender and posts one public Western Union receipt
+  with restricted mentions and no balances. Delivery failure is observed and
+  reported privately but never rolls back or retries the completed transfer.
 - **A peek pass spends aged balance, not pending stakes.** Remaining balance is
   reconstructed from the ledger as FIFO credit lots after every debit consumes
   the oldest lot. The price is
@@ -1279,7 +1298,8 @@ current UTC timestamp for relative date filters, and uses `BB_ASK_MODEL`
     extra post-match message, and it beats the old chunked send that could
     deliver chunk 1 and drop chunk 2.
 - **Successful mutations refresh the prematch message instead of posting a
-  receipt.** Button and `/bb` placement or cancellation confirmations remain
+  receipt.** `/bb transfer` is the explicit exception described above. Button
+  and `/bb` placement or cancellation confirmations remain
   ephemeral. After the ledger transaction commits, a queue serialized per market
   (`refresh-queue.ts`, keyed `pool:` or `parlay:`) re-reads current offers and
   best-effort edits every stored message. At close the same message becomes the

--- a/packages/scout-for-lol/package.json
+++ b/packages/scout-for-lol/package.json
@@ -20,9 +20,11 @@
   },
   "devDependencies": {
     "@scout-for-lol/backend": "workspace:*",
+    "@scout-for-lol/data": "workspace:*",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
     "@eslint/js": "^10.0.1",
     "@shepherdjerred/eslint-config": "workspace:*",
+    "@shepherdjerred/toolkit": "workspace:*",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/bun": "1.4.0",
     "@types/eslint-plugin-jsx-a11y": "^6.10.1",

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -885,7 +885,8 @@ model BucksLedgerEntry {
   // BucksLedgerKind (@scout-for-lol/data): seed | earn_* | bet_stake |
   // bet_payout | bet_*_refund | winner_fee | house_match | cancel_fee |
   // parlay_stake | parlay_reserve | parlay_payout | parlay_refund |
-  // parlay_release | peek_pass | legacy bet_refund/house_rake | adjustment.
+  // parlay_release | peek_pass | transfer_sent | transfer_received |
+  // transfer_fee | legacy bet_refund/house_rake | adjustment.
   // Not a Prisma enum (kept a plain string through the Postgres migration).
   // Zod-validated on write
   // and on read.

--- a/packages/scout-for-lol/packages/backend/src/analytics/bryan-bucks-events.ts
+++ b/packages/scout-for-lol/packages/backend/src/analytics/bryan-bucks-events.ts
@@ -32,7 +32,9 @@ export type BucksLifecycleTransition =
   | "bucks.weekly_parlay_bet.settled"
   | "bucks.weekly_parlay.contribution_recorded"
   | "bucks.earning.awarded"
-  | "bucks.peek_pass.purchased";
+  | "bucks.peek_pass.purchased"
+  | "bucks.transfer.completed"
+  | "bucks.transfer.rejected";
 
 type BucksPendingOutcome = {
   stake: number;

--- a/packages/scout-for-lol/packages/backend/src/betting/constants.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/constants.ts
@@ -80,6 +80,7 @@ export const HOUSE_ACCOUNT_DISCORD_ID =
 export const BUTTON_STAKES = [1, 5] as const;
 
 export const MIN_STAKE = 1;
+export const MINIMUM_BUCKS_TRANSFER = 2;
 
 /**
  * Below this, a game is a remake: no Bucks are earned and every stake is

--- a/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/delivery-observability.ts
@@ -34,6 +34,7 @@ export type BucksMessageSurface =
   | "parlay_preparation"
   | "parlay_market"
   | "settlement"
+  | "transfer_receipt"
   | "weekly_parlay"
   | "weekly_leaderboard";
 

--- a/packages/scout-for-lol/packages/backend/src/betting/ledger.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/ledger.ts
@@ -72,6 +72,26 @@ export type RefundableBucksAccount = {
 };
 
 /**
+ * Lock credit targets before loading their refundable headroom.
+ *
+ * Callers must perform their guarded first mutation before using this helper.
+ * Sorting keeps multi-account credit flows from taking these locks in different
+ * orders. A concurrent stake that already owns one of the rows must commit its
+ * pending position before the following headroom query can observe it.
+ */
+export async function lockBucksAccountsForCredit(
+  tx: Db,
+  bucksAccountIds: readonly number[],
+): Promise<void> {
+  const sortedAccountIds = [...new Set(bucksAccountIds)].toSorted(
+    (left, right) => left - right,
+  );
+  for (const bucksAccountId of sortedAccountIds) {
+    await tx.$queryRaw`SELECT "id" FROM "BucksAccount" WHERE "id" = ${bucksAccountId} FOR UPDATE`;
+  }
+}
+
+/**
  * Load refundable headroom for many accounts with a fixed number of queries.
  * Human accounts hold their own pending stakes. A guild house instead holds
  * every pending fixed-odds reserve in that guild.

--- a/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/navigation.ts
@@ -44,6 +44,9 @@ const LEDGER_KIND_LABELS = {
   weekly_parlay_refund: "weekly parlay refund",
   weekly_parlay_release: "weekly parlay reserve release",
   peek_pass: `${PEEK_PASS_DURATION_LABEL} peek pass`,
+  transfer_sent: "transfer sent",
+  transfer_received: "transfer received",
+  transfer_fee: "transfer fee",
   adjustment: "adjustment",
 } satisfies Record<BucksLedgerKind, string>;
 

--- a/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.test.ts
@@ -158,6 +158,7 @@ function fakeNotificationsInteraction(input: {
       getString: (name: string) =>
         name === "your_bets" ? input.yourBets : input.betsOnYou,
       getInteger: () => 1,
+      getUser: () => ({ id: USER, bot: false }),
     },
     replied: false,
     deferred: false,

--- a/packages/scout-for-lol/packages/backend/src/betting/transfer.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transfer.integration.test.ts
@@ -7,9 +7,14 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { HOUSE_ACCOUNT_DISCORD_ID } from "#src/betting/constants.ts";
+import { applyBucksDelta } from "#src/betting/ledger.ts";
 import { transferBucks } from "#src/betting/transfer.ts";
 import type { isPolicyEnabled } from "#src/configuration/flags.ts";
-import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+import {
+  bucksTestDiscordId,
+  bucksTestPuuid,
+  bucksTestRoster,
+} from "#src/testing/bucks-fixtures.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
 
 const { prisma: db } = createTestDatabase("bucks-transfer");
@@ -102,6 +107,9 @@ function runTransfer(input: {
 beforeEach(async () => {
   await db.bucksAnalyticsLedgerOutbox.deleteMany();
   await db.bucksLedgerEntry.deleteMany();
+  await db.bucksOpenPosition.deleteMany();
+  await db.bucksBet.deleteMany();
+  await db.bucksMatchPool.deleteMany();
   await db.bucksAccount.deleteMany();
 });
 
@@ -329,5 +337,84 @@ describe("transferBucks policy and transaction safety", () => {
         where: { kind: { startsWith: "transfer_" } },
       }),
     ).toBe(3);
+  });
+
+  test("waits for a concurrent stake before calculating recipient headroom", async () => {
+    const { senderId, recipientId } = await createStandardWallets(2);
+    await db.bucksAccount.update({
+      where: { id: recipientId },
+      data: { balance: BUCKS_INT32_MAX },
+    });
+    const pool = await db.bucksMatchPool.create({
+      data: {
+        matchId: "NA1_5000009082",
+        serverId: SERVER,
+        detectedAt: new Date(Date.now() - 60_000),
+        peekAvailableAt: new Date(Date.now() + 60_000),
+        closesAt: new Date(Date.now() + 5 * 60_000),
+        queueType: "solo",
+        roster: JSON.stringify({ participants: bucksTestRoster() }),
+      },
+    });
+    const recipientLocked = Promise.withResolvers<undefined>();
+    const allowStakeCommit = Promise.withResolvers<undefined>();
+    const stake = db.$transaction(async (tx) => {
+      const bet = await tx.bucksBet.create({
+        data: {
+          poolId: pool.id,
+          bucksAccountId: recipientId,
+          predictedTeamId: 100,
+          subjectPuuid: bucksTestPuuid(0),
+          stake: 1,
+        },
+      });
+      await applyBucksDelta(tx, {
+        bucksAccountId: recipientId,
+        delta: -1,
+        kind: "bet_stake",
+        matchId: pool.matchId,
+        betId: bet.id,
+        predictedTeamId: 100,
+        context: {
+          type: "stake",
+          subjectAlias: "Aaron",
+          subjectPuuid: bucksTestPuuid(0),
+          backedAliases: ["Aaron"],
+          opposingAliases: ["Bryan"],
+        },
+      });
+      recipientLocked.resolve(undefined);
+      await allowStakeCommit.promise;
+    });
+    await recipientLocked.promise;
+
+    const transfer = runTransfer({ amount: 2 });
+    try {
+      const statusBeforeStakeCommit = await Promise.race([
+        transfer.then(
+          () => "finished",
+          () => "finished",
+        ),
+        Bun.sleep(250).then(() => "blocked"),
+      ]);
+      expect(statusBeforeStakeCommit).toBe("blocked");
+    } finally {
+      allowStakeCommit.resolve(undefined);
+      await stake;
+    }
+    await expect(transfer).resolves.toEqual({ kind: "storage_limit" });
+    await expect(
+      db.bucksAccount.findUniqueOrThrow({ where: { id: recipientId } }),
+    ).resolves.toEqual(
+      expect.objectContaining({ balance: BUCKS_INT32_MAX - 1 }),
+    );
+    await expect(
+      db.bucksAccount.findUniqueOrThrow({ where: { id: senderId } }),
+    ).resolves.toEqual(expect.objectContaining({ balance: 2 }));
+    expect(
+      await db.bucksLedgerEntry.count({
+        where: { kind: { startsWith: "transfer_" } },
+      }),
+    ).toBe(0);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/transfer.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transfer.integration.test.ts
@@ -1,0 +1,333 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  BUCKS_INT32_MAX,
+  BucksLedgerContextSchema,
+  DiscordGuildIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { HOUSE_ACCOUNT_DISCORD_ID } from "#src/betting/constants.ts";
+import { transferBucks } from "#src/betting/transfer.ts";
+import type { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+
+const { prisma: db } = createTestDatabase("bucks-transfer");
+const SERVER = DiscordGuildIdSchema.parse("1337623164146155593");
+const OTHER_SERVER = DiscordGuildIdSchema.parse("2337623164146155593");
+const SENDER = bucksTestDiscordId(81);
+const RECIPIENT = bucksTestDiscordId(82);
+const OTHER_RECIPIENT = bucksTestDiscordId(83);
+const TRANSFER_ID = "df505f9c-0f98-45e5-9e32-cf5e2b6eb2e0";
+
+const enabled: typeof isPolicyEnabled = () => Promise.resolve(true);
+
+async function createWallet(input: {
+  serverId?: DiscordGuildId;
+  discordId: DiscordAccountId;
+  balance: number;
+  isHouse?: boolean;
+}): Promise<number> {
+  const account = await db.bucksAccount.create({
+    data: {
+      serverId: input.serverId ?? SERVER,
+      discordId: input.discordId,
+      balance: input.balance,
+      isHouse: input.isHouse ?? false,
+    },
+  });
+  if (input.balance > 0) {
+    await db.bucksLedgerEntry.create({
+      data: {
+        bucksAccountId: account.id,
+        delta: input.balance,
+        balanceAfter: input.balance,
+        kind: "adjustment",
+        context: JSON.stringify({
+          type: "adjustment",
+          note: "test wallet",
+          actorDiscordId: SENDER,
+        }),
+      },
+    });
+  }
+  return account.id;
+}
+
+async function createStandardWallets(senderBalance = 10): Promise<{
+  senderId: number;
+  recipientId: number;
+  houseId: number;
+}> {
+  const senderId = await createWallet({
+    discordId: SENDER,
+    balance: senderBalance,
+  });
+  const recipientId = await createWallet({
+    discordId: RECIPIENT,
+    balance: 4,
+  });
+  const houseId = await createWallet({
+    discordId: HOUSE_ACCOUNT_DISCORD_ID,
+    balance: 100,
+    isHouse: true,
+  });
+  return { senderId, recipientId, houseId };
+}
+
+function runTransfer(input: {
+  senderDiscordId?: DiscordAccountId;
+  recipientDiscordId?: DiscordAccountId;
+  recipientIsBot?: boolean;
+  amount?: number;
+  serverId?: DiscordGuildId;
+  isEnabled?: typeof isPolicyEnabled;
+}) {
+  return transferBucks(
+    {
+      serverId: input.serverId ?? SERVER,
+      senderDiscordId: input.senderDiscordId ?? SENDER,
+      recipientDiscordId: input.recipientDiscordId ?? RECIPIENT,
+      recipientIsBot: input.recipientIsBot ?? false,
+      amount: input.amount ?? 3,
+    },
+    {
+      prismaClient: db,
+      isPolicyEnabled: input.isEnabled ?? enabled,
+      createTransferId: () => TRANSFER_ID,
+    },
+  );
+}
+
+beforeEach(async () => {
+  await db.bucksAnalyticsLedgerOutbox.deleteMany();
+  await db.bucksLedgerEntry.deleteMany();
+  await db.bucksAccount.deleteMany();
+});
+
+afterAll(async () => {
+  await db.bucksAccount.deleteMany();
+  await db.$disconnect();
+});
+
+describe("transferBucks", () => {
+  test("writes three correlated ledger and outbox rows while conserving balances", async () => {
+    const accounts = await createStandardWallets();
+    const before = await db.bucksAccount.aggregate({
+      where: { serverId: SERVER },
+      _sum: { balance: true },
+    });
+
+    await expect(runTransfer({ amount: 3 })).resolves.toEqual({
+      kind: "transferred",
+      transferId: TRANSFER_ID,
+      totalAmount: 3,
+      recipientAmount: 1,
+      feeAmount: 2,
+      balanceAfter: 7,
+    });
+
+    const balances = await db.bucksAccount.findMany({
+      where: { id: { in: Object.values(accounts) } },
+      orderBy: { id: "asc" },
+      select: { balance: true },
+    });
+    expect(balances.map((account) => account.balance)).toEqual([7, 5, 102]);
+    const entries = await db.bucksLedgerEntry.findMany({
+      where: { kind: { startsWith: "transfer_" } },
+      orderBy: { id: "asc" },
+    });
+    expect(entries.map((entry) => [entry.kind, entry.delta])).toEqual([
+      ["transfer_sent", -3],
+      ["transfer_received", 1],
+      ["transfer_fee", 2],
+    ]);
+    const contexts = entries.map((entry) =>
+      BucksLedgerContextSchema.parse(JSON.parse(entry.context)),
+    );
+    expect(contexts.map((context) => context.type)).toEqual([
+      "transfer",
+      "transfer",
+      "transfer",
+    ]);
+    expect(contexts).toEqual(
+      expect.arrayContaining([
+        {
+          type: "transfer",
+          transferId: TRANSFER_ID,
+          senderAccountId: accounts.senderId,
+          recipientAccountId: accounts.recipientId,
+          houseAccountId: accounts.houseId,
+          totalAmount: 3,
+          recipientAmount: 1,
+          feeAmount: 2,
+          role: "sender",
+        },
+        {
+          type: "transfer",
+          transferId: TRANSFER_ID,
+          senderAccountId: accounts.senderId,
+          recipientAccountId: accounts.recipientId,
+          houseAccountId: accounts.houseId,
+          totalAmount: 3,
+          recipientAmount: 1,
+          feeAmount: 2,
+          role: "recipient",
+        },
+        {
+          type: "transfer",
+          transferId: TRANSFER_ID,
+          senderAccountId: accounts.senderId,
+          recipientAccountId: accounts.recipientId,
+          houseAccountId: accounts.houseId,
+          totalAmount: 3,
+          recipientAmount: 1,
+          feeAmount: 2,
+          role: "house",
+        },
+      ]),
+    );
+    expect(entries.reduce((sum, entry) => sum + entry.delta, 0)).toBe(0);
+    expect(await db.bucksAnalyticsLedgerOutbox.count()).toBe(3);
+    const after = await db.bucksAccount.aggregate({
+      where: { serverId: SERVER },
+      _sum: { balance: true },
+    });
+    expect(after._sum.balance).toBe(before._sum.balance);
+  });
+
+  test("rejects insufficient funds without any movement", async () => {
+    await createStandardWallets(2);
+    await expect(runTransfer({ amount: 3 })).resolves.toEqual({
+      kind: "insufficient",
+      balance: 2,
+      needed: 3,
+    });
+    expect(
+      await db.bucksLedgerEntry.count({
+        where: { kind: { startsWith: "transfer_" } },
+      }),
+    ).toBe(0);
+  });
+
+  test("requires both existing wallets in the same guild", async () => {
+    await createWallet({
+      serverId: OTHER_SERVER,
+      discordId: RECIPIENT,
+      balance: 4,
+    });
+    await createWallet({ discordId: SENDER, balance: 10 });
+    await createWallet({
+      discordId: HOUSE_ACCOUNT_DISCORD_ID,
+      balance: 100,
+      isHouse: true,
+    });
+    await expect(runTransfer({})).resolves.toEqual({
+      kind: "recipient_not_found",
+    });
+    expect(
+      await db.bucksAccount.findUniqueOrThrow({
+        where: {
+          serverId_discordId: {
+            serverId: OTHER_SERVER,
+            discordId: RECIPIENT,
+          },
+        },
+      }),
+    ).toEqual(expect.objectContaining({ balance: 4 }));
+
+    await db.bucksAccount.delete({
+      where: { serverId_discordId: { serverId: SERVER, discordId: SENDER } },
+    });
+    await expect(runTransfer({})).resolves.toEqual({
+      kind: "sender_not_found",
+    });
+  });
+});
+
+describe("transferBucks policy and transaction safety", () => {
+  test("rejects self, bot, and house recipients", async () => {
+    await createStandardWallets();
+    await expect(runTransfer({ recipientDiscordId: SENDER })).resolves.toEqual({
+      kind: "same_user",
+    });
+    await expect(runTransfer({ recipientIsBot: true })).resolves.toEqual({
+      kind: "recipient_bot",
+    });
+    await expect(
+      runTransfer({ recipientDiscordId: HOUSE_ACCOUNT_DISCORD_ID }),
+    ).resolves.toEqual({ kind: "recipient_is_house" });
+  });
+
+  test("rejects a house wallet acting as the sender", async () => {
+    await createStandardWallets();
+    await db.bucksAccount.update({
+      where: { serverId_discordId: { serverId: SERVER, discordId: SENDER } },
+      data: { isHouse: true },
+    });
+    await expect(runTransfer({})).resolves.toEqual({
+      kind: "sender_not_found",
+    });
+  });
+
+  test("rolls back the sender debit and recipient credit when the house credit overflows", async () => {
+    const { senderId, recipientId } = await createStandardWallets();
+    await db.bucksAccount.update({
+      where: {
+        serverId_discordId: {
+          serverId: SERVER,
+          discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        },
+      },
+      data: { balance: BUCKS_INT32_MAX },
+    });
+    await expect(runTransfer({ amount: 2 })).resolves.toEqual({
+      kind: "storage_limit",
+    });
+    expect(
+      await db.bucksAccount.findUniqueOrThrow({ where: { id: senderId } }),
+    ).toEqual(expect.objectContaining({ balance: 10 }));
+    expect(
+      await db.bucksAccount.findUniqueOrThrow({ where: { id: recipientId } }),
+    ).toEqual(expect.objectContaining({ balance: 4 }));
+    expect(
+      await db.bucksLedgerEntry.count({
+        where: { kind: { startsWith: "transfer_" } },
+      }),
+    ).toBe(0);
+  });
+
+  test("honors flag revocation at the domain boundary", async () => {
+    await createStandardWallets();
+    const calls: string[] = [];
+    const isEnabled: typeof isPolicyEnabled = (name) => {
+      calls.push(name);
+      return Promise.resolve(name === "betting_enabled");
+    };
+    await expect(runTransfer({ isEnabled })).resolves.toEqual({
+      kind: "feature_disabled",
+    });
+    expect(calls.toSorted()).toEqual([
+      "betting_enabled",
+      "bucks_transfers_enabled",
+    ]);
+  });
+
+  test("serializes concurrent debits so only one can spend", async () => {
+    await createStandardWallets(3);
+    await createWallet({ discordId: OTHER_RECIPIENT, balance: 1 });
+    const results = await Promise.all([
+      runTransfer({ amount: 2 }),
+      runTransfer({ recipientDiscordId: OTHER_RECIPIENT, amount: 2 }),
+    ]);
+    expect(results.map((result) => result.kind).toSorted()).toEqual([
+      "insufficient",
+      "transferred",
+    ]);
+    expect(
+      await db.bucksLedgerEntry.count({
+        where: { kind: { startsWith: "transfer_" } },
+      }),
+    ).toBe(3);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/transfer.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transfer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { BUCKS_INT32_MAX } from "@scout-for-lol/data";
+import {
+  BucksTransferAmountSchema,
+  splitBucksTransferAmount,
+} from "#src/betting/transfer.ts";
+
+describe("splitBucksTransferAmount", () => {
+  test.each([
+    [2, 1, 1],
+    [3, 1, 2],
+    [10, 5, 5],
+  ])(
+    "splits %i BB into %i for the recipient and %i for the house",
+    (amount, recipientAmount, feeAmount) => {
+      expect(splitBucksTransferAmount(amount)).toEqual({
+        recipientAmount,
+        feeAmount,
+      });
+    },
+  );
+
+  test("accepts the Int32 maximum and favors the house", () => {
+    expect(splitBucksTransferAmount(BUCKS_INT32_MAX)).toEqual({
+      recipientAmount: 1_073_741_823,
+      feeAmount: 1_073_741_824,
+    });
+  });
+
+  test.each([1, 2.5, BUCKS_INT32_MAX + 1])(
+    "rejects invalid amount %s",
+    (amount) => {
+      expect(BucksTransferAmountSchema.safeParse(amount).success).toBe(false);
+    },
+  );
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/transfer.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transfer.ts
@@ -13,6 +13,7 @@ import {
   applyBucksDelta,
   BucksStorageOverflowError,
   InsufficientBucksError,
+  lockBucksAccountsForCredit,
 } from "#src/betting/ledger.ts";
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
@@ -222,6 +223,7 @@ export async function transferBucks(
             role: "sender",
           }),
         });
+        await lockBucksAccountsForCredit(tx, [recipient.id, house.id]);
         await applyBucksDelta(tx, {
           bucksAccountId: recipient.id,
           delta: recipientAmount,

--- a/packages/scout-for-lol/packages/backend/src/betting/transfer.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transfer.ts
@@ -1,0 +1,278 @@
+import {
+  BUCKS_INT32_MAX,
+  BucksLedgerContextSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import {
+  HOUSE_ACCOUNT_DISCORD_ID,
+  MINIMUM_BUCKS_TRANSFER,
+} from "#src/betting/constants.ts";
+import {
+  applyBucksDelta,
+  BucksStorageOverflowError,
+  InsufficientBucksError,
+} from "#src/betting/ledger.ts";
+import { logBucksTransition } from "#src/betting/transition-log.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { bettingTransfersTotal } from "#src/metrics/betting.ts";
+
+export const BucksTransferAmountSchema = z
+  .number()
+  .int()
+  .min(MINIMUM_BUCKS_TRANSFER)
+  .max(BUCKS_INT32_MAX);
+
+export type BucksTransferSplit = {
+  recipientAmount: number;
+  feeAmount: number;
+};
+
+export function splitBucksTransferAmount(amount: number): BucksTransferSplit {
+  const totalAmount = BucksTransferAmountSchema.parse(amount);
+  return {
+    recipientAmount: Math.floor(totalAmount / 2),
+    feeAmount: Math.ceil(totalAmount / 2),
+  };
+}
+
+export type TransferBucksInput = {
+  serverId: DiscordGuildId;
+  senderDiscordId: DiscordAccountId;
+  recipientDiscordId: DiscordAccountId;
+  recipientIsBot: boolean;
+  amount: number;
+};
+
+export type TransferBucksResult =
+  | {
+      kind: "transferred";
+      transferId: string;
+      totalAmount: number;
+      recipientAmount: number;
+      feeAmount: number;
+      balanceAfter: number;
+    }
+  | { kind: "feature_disabled" }
+  | { kind: "invalid_amount" }
+  | { kind: "same_user" }
+  | { kind: "recipient_bot" }
+  | { kind: "sender_not_found" }
+  | { kind: "recipient_not_found" }
+  | { kind: "recipient_is_house" }
+  | { kind: "insufficient"; balance: number; needed: number }
+  | { kind: "storage_limit" };
+
+type TransferBucksDependencies = {
+  prismaClient: ExtendedPrismaClient;
+  isPolicyEnabled: typeof isPolicyEnabled;
+  createTransferId: () => string;
+};
+
+const defaultDependencies: TransferBucksDependencies = {
+  prismaClient: prisma,
+  isPolicyEnabled,
+  createTransferId: () => crypto.randomUUID(),
+};
+
+function observeTransfer(
+  input: TransferBucksInput,
+  result: TransferBucksResult,
+): void {
+  bettingTransfersTotal.inc({ result: result.kind });
+  if (result.kind === "transferred") {
+    logBucksTransition({
+      event: "bucks.transfer.completed",
+      serverId: input.serverId,
+      actorDiscordId: input.senderDiscordId,
+      recipientDiscordId: input.recipientDiscordId,
+      stake: result.totalAmount,
+      payout: result.recipientAmount,
+      fee: result.feeAmount,
+      balanceAfter: result.balanceAfter,
+      surface: "command",
+    });
+    return;
+  }
+  logBucksTransition({
+    event: "bucks.transfer.rejected",
+    serverId: input.serverId,
+    actorDiscordId: input.senderDiscordId,
+    recipientDiscordId: input.recipientDiscordId,
+    stake: input.amount,
+    reason: result.kind,
+    surface: "command",
+  });
+}
+
+export async function transferBucks(
+  input: TransferBucksInput,
+  dependencies: TransferBucksDependencies = defaultDependencies,
+): Promise<TransferBucksResult> {
+  const [bettingEnabled, transfersEnabled] = await Promise.all([
+    dependencies.isPolicyEnabled("betting_enabled", {
+      server: input.serverId,
+    }),
+    dependencies.isPolicyEnabled("bucks_transfers_enabled", {
+      server: input.serverId,
+    }),
+  ]);
+  if (!bettingEnabled || !transfersEnabled) {
+    const result = { kind: "feature_disabled" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+
+  const amountResult = BucksTransferAmountSchema.safeParse(input.amount);
+  if (!amountResult.success) {
+    const result = { kind: "invalid_amount" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+  if (input.senderDiscordId === input.recipientDiscordId) {
+    const result = { kind: "same_user" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+  if (input.recipientIsBot) {
+    const result = { kind: "recipient_bot" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+
+  const [sender, recipient, house] = await Promise.all([
+    dependencies.prismaClient.bucksAccount.findUnique({
+      where: {
+        serverId_discordId: {
+          serverId: input.serverId,
+          discordId: input.senderDiscordId,
+        },
+      },
+      select: { id: true, balance: true, isHouse: true },
+    }),
+    dependencies.prismaClient.bucksAccount.findUnique({
+      where: {
+        serverId_discordId: {
+          serverId: input.serverId,
+          discordId: input.recipientDiscordId,
+        },
+      },
+      select: { id: true, isHouse: true },
+    }),
+    dependencies.prismaClient.bucksAccount.findUnique({
+      where: {
+        serverId_discordId: {
+          serverId: input.serverId,
+          discordId: HOUSE_ACCOUNT_DISCORD_ID,
+        },
+      },
+      select: { id: true, isHouse: true },
+    }),
+  ]);
+
+  if (sender === null || sender.isHouse) {
+    const result = { kind: "sender_not_found" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+  if (recipient === null) {
+    const result = { kind: "recipient_not_found" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+  if (recipient.isHouse) {
+    const result = { kind: "recipient_is_house" } as const;
+    observeTransfer(input, result);
+    return result;
+  }
+  if (house?.isHouse !== true) {
+    throw new Error(
+      `Bryan Bucks house wallet is missing for ${input.serverId}`,
+    );
+  }
+
+  const totalAmount = amountResult.data;
+  const { recipientAmount, feeAmount } = splitBucksTransferAmount(totalAmount);
+  if (recipientAmount + feeAmount !== totalAmount) {
+    throw new Error("Bryan Bucks transfer split does not conserve value");
+  }
+  const transferId = z.uuid().parse(dependencies.createTransferId());
+  const baseContext = {
+    type: "transfer",
+    transferId,
+    senderAccountId: sender.id,
+    recipientAccountId: recipient.id,
+    houseAccountId: house.id,
+    totalAmount,
+    recipientAmount,
+    feeAmount,
+  } as const;
+
+  try {
+    const balanceAfter = await dependencies.prismaClient.$transaction(
+      async (tx) => {
+        const senderBalance = await applyBucksDelta(tx, {
+          bucksAccountId: sender.id,
+          delta: -totalAmount,
+          kind: "transfer_sent",
+          context: BucksLedgerContextSchema.parse({
+            ...baseContext,
+            role: "sender",
+          }),
+        });
+        await applyBucksDelta(tx, {
+          bucksAccountId: recipient.id,
+          delta: recipientAmount,
+          kind: "transfer_received",
+          context: BucksLedgerContextSchema.parse({
+            ...baseContext,
+            role: "recipient",
+          }),
+        });
+        await applyBucksDelta(tx, {
+          bucksAccountId: house.id,
+          delta: feeAmount,
+          kind: "transfer_fee",
+          context: BucksLedgerContextSchema.parse({
+            ...baseContext,
+            role: "house",
+          }),
+        });
+        return senderBalance;
+      },
+    );
+    const result: TransferBucksResult = {
+      kind: "transferred",
+      transferId,
+      totalAmount,
+      recipientAmount,
+      feeAmount,
+      balanceAfter,
+    };
+    observeTransfer(input, result);
+    return result;
+  } catch (error) {
+    if (error instanceof InsufficientBucksError) {
+      const current =
+        await dependencies.prismaClient.bucksAccount.findUniqueOrThrow({
+          where: { id: sender.id },
+          select: { balance: true },
+        });
+      const result: TransferBucksResult = {
+        kind: "insufficient",
+        balance: current.balance,
+        needed: totalAmount,
+      };
+      observeTransfer(input, result);
+      return result;
+    }
+    if (error instanceof BucksStorageOverflowError) {
+      const result = { kind: "storage_limit" } as const;
+      observeTransfer(input, result);
+      return result;
+    }
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/transition-log.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transition-log.test.ts
@@ -47,6 +47,8 @@ describe("logBucksTransition", () => {
       "bucks.parlay.settled",
       "bucks.earning.awarded",
       "bucks.peek_pass.purchased",
+      "bucks.transfer.completed",
+      "bucks.transfer.rejected",
     ] as const;
     for (const event of events) {
       expect(() => {
@@ -88,6 +90,8 @@ describe("BucksTransitionEvent coverage", () => {
       "bucks.parlay_bet.settled",
       "bucks.earning.awarded",
       "bucks.peek_pass.purchased",
+      "bucks.transfer.completed",
+      "bucks.transfer.rejected",
     ];
 
     const glob = new Bun.Glob("*.ts");

--- a/packages/scout-for-lol/packages/backend/src/betting/transition-log.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/transition-log.ts
@@ -46,6 +46,7 @@ export type BucksTransitionFields = {
   slot?: number;
   bucksAccountId?: number;
   actorDiscordId?: string;
+  recipientDiscordId?: string;
   fromState?: string;
   toState?: string;
   teamId?: number;
@@ -56,6 +57,7 @@ export type BucksTransitionFields = {
   grossPayout?: number;
   houseCut?: number;
   payout?: number;
+  fee?: number;
   balanceAfter?: number;
   reason?: string;
   surface?: "button" | "command" | "sweep" | "postmatch" | "cron" | "prematch";

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
@@ -27,6 +27,7 @@ const PRODUCTION_DENIED_FLAGS = [
   "ai_reports_unlimited",
   "ai_reviews_enabled",
   "betting_enabled",
+  "bucks_transfers_enabled",
   "betting_player_bet_outcome_dm_enabled",
   "betting_settlement_dm_enabled",
   "competition_builder_v2_enabled",
@@ -76,6 +77,7 @@ describe("production hard-disable policy", () => {
         ai_reports_unlimited: true,
         ai_reviews_enabled: true,
         betting_enabled: true,
+        bucks_transfers_enabled: true,
         betting_player_bet_outcome_dm_enabled: true,
         betting_settlement_dm_enabled: true,
         tournament_lobbies_enabled: true,
@@ -107,6 +109,17 @@ describe("Bryan Bucks settlement DM flags", () => {
     expect(
       getFlag("betting_player_bet_outcome_dm_enabled", { server: MY_SERVER }),
     ).toBe(true);
+  });
+});
+
+describe("Bryan Bucks transfer flag", () => {
+  test("is off by default and enabled only for the beta guild", () => {
+    expect(getFlag("bucks_transfers_enabled", { server: OTHER_GUILD })).toBe(
+      false,
+    );
+    expect(getFlag("bucks_transfers_enabled", { server: MY_SERVER })).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -143,6 +143,7 @@ export type FlagName =
   | "ai_reports_unlimited"
   | "ai_reviews_enabled"
   | "betting_enabled"
+  | "bucks_transfers_enabled"
   | "weekly_parlays_enabled"
   | "betting_player_bet_outcome_dm_enabled"
   | "betting_settlement_dm_enabled"
@@ -168,6 +169,7 @@ const PRODUCTION_HARD_DISABLED_FLAGS: ReadonlySet<FlagName> = new Set<FlagName>(
     "ai_reports_unlimited",
     "ai_reviews_enabled",
     "betting_enabled",
+    "bucks_transfers_enabled",
     "weekly_parlays_enabled",
     "betting_player_bet_outcome_dm_enabled",
     "betting_settlement_dm_enabled",
@@ -239,6 +241,13 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
         attributes: { server: MY_SERVER },
       },
     ],
+  },
+  // Fee-bearing Bryan Bucks wallet transfers. This is narrower than the
+  // betting economy itself, so the domain requires both flags. Production's
+  // hard-disable policy remains authoritative over local and Flipt values.
+  bucks_transfers_enabled: {
+    default: false,
+    overrides: [{ value: true, attributes: { server: MY_SERVER } }],
   },
   // Week-spanning Bryan Bucks markets remain a narrower private-beta rollout
   // than the betting economy itself. New positions require both flags;

--- a/packages/scout-for-lol/packages/backend/src/discord-smoke-scenarios.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord-smoke-scenarios.test.ts
@@ -1,0 +1,44 @@
+import { DiscordGuildIdSchema } from "@scout-for-lol/data";
+import { afterEach, expect, test } from "vitest";
+import {
+  addFlagOverride,
+  clearFlagOverrides,
+  getFlag,
+  resetFlagOverrides,
+} from "#src/configuration/flags.ts";
+import { applyDiscordSmokeScenario } from "#src/discord-smoke-scenarios.ts";
+
+const SMOKE_GUILD = DiscordGuildIdSchema.parse("100000000000000001");
+const OTHER_GUILD = DiscordGuildIdSchema.parse("100000000000000002");
+
+afterEach(() => {
+  resetFlagOverrides("betting_enabled");
+  resetFlagOverrides("bucks_transfers_enabled");
+});
+
+test("enables only transfer flags in the explicit smoke guild", () => {
+  clearFlagOverrides("betting_enabled");
+  clearFlagOverrides("bucks_transfers_enabled");
+  applyDiscordSmokeScenario("bb-transfer", SMOKE_GUILD);
+
+  expect(getFlag("betting_enabled", { server: SMOKE_GUILD })).toBe(true);
+  expect(getFlag("bucks_transfers_enabled", { server: SMOKE_GUILD })).toBe(
+    true,
+  );
+  expect(getFlag("betting_enabled", { server: OTHER_GUILD })).toBe(false);
+  expect(getFlag("bucks_transfers_enabled", { server: OTHER_GUILD })).toBe(
+    false,
+  );
+});
+
+test("gateway scenario adds no feature overrides", () => {
+  clearFlagOverrides("betting_enabled");
+  clearFlagOverrides("bucks_transfers_enabled");
+  addFlagOverride("betting_enabled", false, { server: SMOKE_GUILD });
+  applyDiscordSmokeScenario("gateway", SMOKE_GUILD);
+
+  expect(getFlag("betting_enabled", { server: SMOKE_GUILD })).toBe(false);
+  expect(getFlag("bucks_transfers_enabled", { server: SMOKE_GUILD })).toBe(
+    false,
+  );
+});

--- a/packages/scout-for-lol/packages/backend/src/discord-smoke-scenarios.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord-smoke-scenarios.ts
@@ -1,17 +1,26 @@
 import type { DiscordGuildId } from "@scout-for-lol/data";
 import { z } from "zod";
+import { addFlagOverride } from "#src/configuration/flags.ts";
 
-export const DiscordSmokeScenarioNameSchema = z.enum(["gateway"]);
+export const DiscordSmokeScenarioNameSchema = z.enum([
+  "gateway",
+  "bb-transfer",
+]);
 export type DiscordSmokeScenarioName = z.infer<
   typeof DiscordSmokeScenarioNameSchema
 >;
 
 export function applyDiscordSmokeScenario(
-  _scenario: DiscordSmokeScenarioName,
-  _guildId: DiscordGuildId,
+  scenario: DiscordSmokeScenarioName,
+  guildId: DiscordGuildId,
 ): void {
-  void _scenario;
-  void _guildId;
+  switch (scenario) {
+    case "gateway":
+      return;
+    case "bb-transfer":
+      addFlagOverride("betting_enabled", true, { server: guildId });
+      addFlagOverride("bucks_transfers_enabled", true, { server: guildId });
+  }
 }
 
 export function discordSmokeStaticOverrides(

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-ask.e2e.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-ask.e2e.test.ts
@@ -302,6 +302,7 @@ function fakeAskCommand() {
       getSubcommand: () => "ask",
       getString: () => QUESTION,
       getInteger: () => 10,
+      getUser: () => ({ id: ASKER, bot: false }),
     },
     replied: false,
     deferred: false,

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
@@ -1,5 +1,6 @@
 import { SlashCommandBuilder } from "discord.js";
-import { MIN_STAKE } from "#src/betting/constants.ts";
+import { BUCKS_INT32_MAX } from "@scout-for-lol/data";
+import { MINIMUM_BUCKS_TRANSFER, MIN_STAKE } from "#src/betting/constants.ts";
 import { BB_ASK_MAX_QUESTION_LENGTH } from "#src/discord/commands/bb-ask.ts";
 import { addBbPeekSubcommands } from "#src/discord/commands/bb-peek.ts";
 
@@ -20,6 +21,25 @@ export const bbCommand = addBbPeekSubcommands(
       sub
         .setName("history")
         .setDescription("How you earned and spent your Bryan Bucks"),
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName("transfer")
+        .setDescription("Send Bryan Bucks through Western Union")
+        .addUserOption((option) =>
+          option
+            .setName("recipient")
+            .setDescription("Who receives half of the amount")
+            .setRequired(true),
+        )
+        .addIntegerOption((option) =>
+          option
+            .setName("amount")
+            .setDescription("Your total whole-BB spend")
+            .setRequired(true)
+            .setMinValue(MINIMUM_BUCKS_TRANSFER)
+            .setMaxValue(BUCKS_INT32_MAX),
+        ),
     )
     .addSubcommand((sub) =>
       sub.setName("open").setDescription("Games you can still bet on"),

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-history.test.ts
@@ -20,6 +20,15 @@ describe("/bb history labels", () => {
     expect(ledgerKindLabel(BucksLedgerKindSchema.parse("peek_pass"))).toBe(
       "24-hour peek pass",
     );
+    expect(ledgerKindLabel(BucksLedgerKindSchema.parse("transfer_sent"))).toBe(
+      "transfer sent",
+    );
+    expect(
+      ledgerKindLabel(BucksLedgerKindSchema.parse("transfer_received")),
+    ).toBe("transfer received");
+    expect(ledgerKindLabel(BucksLedgerKindSchema.parse("transfer_fee"))).toBe(
+      "transfer fee",
+    );
 
     const rendered = renderBucksHistory(bucksTestDiscordId(1), {
       entries: [

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-interaction.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-interaction.ts
@@ -11,7 +11,9 @@ export type BbCommandInteraction = {
   options: Pick<
     ChatInputCommandInteraction["options"],
     "getSubcommand" | "getString" | "getInteger"
-  >;
+  > & {
+    getUser: (name: string, required: true) => { id: string; bot: boolean };
+  };
   replied: boolean;
   deferred: boolean;
   reply: CommandReply;

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-overview.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-overview.ts
@@ -1,0 +1,27 @@
+import type { DiscordAccountId, DiscordGuildId } from "@scout-for-lol/data";
+import { getLedgerPage } from "#src/betting/accounts.ts";
+import { renderBucksHistory } from "#src/betting/navigation.ts";
+import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
+import { buildBbPrizesEmbed } from "#src/discord/commands/bb-prizes.ts";
+import { buildBbRulesEmbed } from "#src/discord/commands/bb-rules.ts";
+
+export async function replyBbPrizes(
+  interaction: BbCommandInteraction,
+): Promise<void> {
+  await interaction.editReply({ embeds: [buildBbPrizesEmbed()] });
+}
+
+export async function replyBbRules(
+  interaction: BbCommandInteraction,
+): Promise<void> {
+  await interaction.editReply({ embeds: [buildBbRulesEmbed()] });
+}
+
+export async function replyBbHistory(
+  interaction: BbCommandInteraction,
+  serverId: DiscordGuildId,
+  discordId: DiscordAccountId,
+): Promise<void> {
+  const page = await getLedgerPage({ serverId, discordId, page: 0 });
+  await interaction.editReply(renderBucksHistory(discordId, page));
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-rules.ts
@@ -3,6 +3,7 @@ import {
   BETTING_WINDOW_MS,
   BUCKS_EARNING_QUEUES,
   HOUSE_MATCH_LIMIT,
+  MINIMUM_BUCKS_TRANSFER,
   PARLAY_BETTING_WINDOW_MS,
   SEED_GRANT,
 } from "#src/betting/constants.ts";
@@ -120,6 +121,13 @@ export function buildBbRulesEmbed(): EmbedBuilder {
         value:
           "Remakes, unsupported modes, and games that never resolve return every matched stake with no fee. " +
           "Unmatched BB are always refunded free. Parlay voids also release the reserved house payout.",
+      },
+      {
+        name: "Western Union transfers",
+        value:
+          `\`/bb transfer\` spends at least **${formatInteger(MINIMUM_BUCKS_TRANSFER)} BB** from your wallet. ` +
+          "The recipient gets half, rounded down, and the house gets half, rounded up. " +
+          "Both people need existing wallets in this server. Transfers are immediate, irreversible, and post a public receipt with the exact split but no balances.",
       },
       {
         name: "Peek passes",

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-transfer.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-transfer.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { bbCommand } from "#src/discord/commands/bb-definition.ts";
+import { isPublicBbSubcommand } from "#src/discord/commands/bb.ts";
+import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
+import {
+  buildTransferReceipt,
+  replyBbTransfer,
+} from "#src/discord/commands/bb-transfer.ts";
+
+const SERVER = DiscordGuildIdSchema.parse("1337623164146155593");
+const SENDER = DiscordAccountIdSchema.parse("160509172704739328");
+const RECIPIENT = DiscordAccountIdSchema.parse("160509172704739329");
+
+function fakeInteraction(input?: {
+  recipientBot?: boolean;
+  followUpRejects?: boolean;
+}): BbCommandInteraction {
+  return {
+    id: "bb-transfer-test",
+    guildId: SERVER,
+    user: { id: SENDER },
+    options: {
+      getSubcommand: () => "transfer",
+      getString: () => "",
+      getInteger: () => 3,
+      getUser: () => ({ id: RECIPIENT, bot: input?.recipientBot ?? false }),
+    },
+    replied: false,
+    deferred: true,
+    reply: vi.fn(() => Promise.resolve(undefined)),
+    deferReply: vi.fn(() => Promise.resolve(undefined)),
+    editReply: vi.fn(() => Promise.resolve(undefined)),
+    followUp: vi.fn(() =>
+      input?.followUpRejects === true
+        ? Promise.reject(new Error("Discord unavailable"))
+        : Promise.resolve(undefined),
+    ),
+  };
+}
+
+describe("/bb transfer", () => {
+  test("registers required recipient and bounded whole-BB amount options", () => {
+    const transfer = bbCommand
+      .toJSON()
+      .options?.find((option) => option.name === "transfer");
+    if (transfer === undefined || !("options" in transfer)) {
+      throw new Error("/bb transfer should be a subcommand with options");
+    }
+    expect(transfer.options).toEqual([
+      expect.objectContaining({ name: "recipient", required: true, type: 6 }),
+      expect.objectContaining({
+        name: "amount",
+        required: true,
+        type: 4,
+        min_value: 2,
+        max_value: 2_147_483_647,
+      }),
+    ]);
+    expect(isPublicBbSubcommand("transfer")).toBe(false);
+  });
+
+  test("posts the exact public receipt with only both users mentionable", async () => {
+    const interaction = fakeInteraction();
+    const runTransfer = vi.fn(() =>
+      Promise.resolve({
+        kind: "transferred" as const,
+        transferId: "df505f9c-0f98-45e5-9e32-cf5e2b6eb2e0",
+        totalAmount: 3,
+        recipientAmount: 1,
+        feeAmount: 2,
+        balanceAfter: 97,
+      }),
+    );
+    await replyBbTransfer(interaction, SERVER, SENDER, { runTransfer });
+
+    expect(runTransfer).toHaveBeenCalledWith({
+      serverId: SERVER,
+      senderDiscordId: SENDER,
+      recipientDiscordId: RECIPIENT,
+      recipientIsBot: false,
+      amount: 3,
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content:
+        "Transfer complete. 1 BB went to <@160509172704739329> and 2 BB went to the house.",
+      allowedMentions: { parse: [] },
+    });
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      content:
+        "💸 **Bryan Bucks Western Union**\n<@160509172704739328> spent **3 BB** to send <@160509172704739329> **1 BB**. The house collected **2 BB**.",
+      allowedMentions: {
+        parse: [],
+        users: [SENDER, RECIPIENT],
+        repliedUser: false,
+      },
+    });
+    expect(
+      JSON.stringify(vi.mocked(interaction.followUp).mock.calls),
+    ).not.toContain("97");
+  });
+
+  test("keeps validation failures private and sends no receipt", async () => {
+    const interaction = fakeInteraction({ recipientBot: true });
+    await replyBbTransfer(interaction, SERVER, SENDER, {
+      runTransfer: () => Promise.resolve({ kind: "recipient_bot" }),
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: "Bots cannot receive Bryan Bucks transfers.",
+    });
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  test("reports post-commit receipt failure without rerunning the transfer", async () => {
+    const interaction = fakeInteraction({ followUpRejects: true });
+    const runTransfer = vi.fn(() =>
+      Promise.resolve({
+        kind: "transferred" as const,
+        transferId: "df505f9c-0f98-45e5-9e32-cf5e2b6eb2e0",
+        totalAmount: 3,
+        recipientAmount: 1,
+        feeAmount: 2,
+        balanceAfter: 97,
+      }),
+    );
+    await expect(
+      replyBbTransfer(interaction, SERVER, SENDER, { runTransfer }),
+    ).resolves.toBeUndefined();
+    expect(runTransfer).toHaveBeenCalledTimes(1);
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content:
+        "Transfer complete, but I could not post the public receipt. The transfer was not reversed; please do not retry it.",
+    });
+  });
+
+  test("formats an even transfer without exposing balances", () => {
+    const receipt = buildTransferReceipt({
+      senderDiscordId: SENDER,
+      recipientDiscordId: RECIPIENT,
+      totalAmount: 10,
+      recipientAmount: 5,
+      feeAmount: 5,
+    });
+    expect(receipt).toContain("spent **10 BB**");
+    expect(receipt).toContain("**5 BB**");
+    expect(receipt).not.toContain("balance");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-transfer.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-transfer.ts
@@ -1,0 +1,114 @@
+import {
+  DiscordAccountIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import {
+  transferBucks,
+  type TransferBucksResult,
+} from "#src/betting/transfer.ts";
+import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
+import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
+import { formatInteger } from "#src/betting/display-format.ts";
+
+export type BbTransferCommandDependencies = {
+  runTransfer?: typeof transferBucks;
+  observeTransferReceipt?: typeof observeBucksDelivery;
+};
+
+function describeTransferFailure(result: TransferBucksResult): string {
+  switch (result.kind) {
+    case "feature_disabled":
+      return "Bryan Bucks transfers are not enabled here.";
+    case "invalid_amount":
+      return "Transfer at least 2 whole BB.";
+    case "same_user":
+      return "You cannot transfer Bryan Bucks to yourself.";
+    case "recipient_bot":
+      return "Bots cannot receive Bryan Bucks transfers.";
+    case "sender_not_found":
+      return "You need an existing Bryan Bucks wallet before you can transfer.";
+    case "recipient_not_found":
+      return "That recipient needs an existing Bryan Bucks wallet first.";
+    case "recipient_is_house":
+      return "The house cannot receive a user transfer.";
+    case "insufficient":
+      return `You need ${formatInteger(result.needed)} BB for this transfer, but only ${formatInteger(result.balance)} BB are available.`;
+    case "storage_limit":
+      return "This transfer would exceed Bryan Bucks storage limits.";
+    case "transferred":
+      throw new Error("A completed transfer is not a failure");
+  }
+}
+
+export function buildTransferReceipt(input: {
+  senderDiscordId: DiscordAccountId;
+  recipientDiscordId: DiscordAccountId;
+  totalAmount: number;
+  recipientAmount: number;
+  feeAmount: number;
+}): string {
+  return (
+    "💸 **Bryan Bucks Western Union**\n" +
+    `<@${input.senderDiscordId}> spent **${formatInteger(input.totalAmount)} BB** to send ` +
+    `<@${input.recipientDiscordId}> **${formatInteger(input.recipientAmount)} BB**. ` +
+    `The house collected **${formatInteger(input.feeAmount)} BB**.`
+  );
+}
+
+export async function replyBbTransfer(
+  interaction: BbCommandInteraction,
+  serverId: DiscordGuildId,
+  senderDiscordId: DiscordAccountId,
+  dependencies: BbTransferCommandDependencies = {},
+): Promise<void> {
+  const recipient = interaction.options.getUser("recipient", true);
+  const recipientDiscordId = DiscordAccountIdSchema.parse(recipient.id);
+  const amount = interaction.options.getInteger("amount", true);
+  const result = await (dependencies.runTransfer ?? transferBucks)({
+    serverId,
+    senderDiscordId,
+    recipientDiscordId,
+    recipientIsBot: recipient.bot,
+    amount,
+  });
+  if (result.kind !== "transferred") {
+    await interaction.editReply({ content: describeTransferFailure(result) });
+    return;
+  }
+
+  await interaction.editReply({
+    content: `Transfer complete. ${formatInteger(result.recipientAmount)} BB went to <@${recipientDiscordId}> and ${formatInteger(result.feeAmount)} BB went to the house.`,
+    allowedMentions: { parse: [] },
+  });
+
+  try {
+    await (dependencies.observeTransferReceipt ?? observeBucksDelivery)(
+      {
+        surface: "transfer_receipt",
+        operation: "send",
+        serverId,
+      },
+      async () =>
+        interaction.followUp({
+          content: buildTransferReceipt({
+            senderDiscordId,
+            recipientDiscordId,
+            totalAmount: result.totalAmount,
+            recipientAmount: result.recipientAmount,
+            feeAmount: result.feeAmount,
+          }),
+          allowedMentions: {
+            parse: [],
+            users: [senderDiscordId, recipientDiscordId],
+            repliedUser: false,
+          },
+        }),
+    );
+  } catch {
+    await interaction.editReply({
+      content:
+        "Transfer complete, but I could not post the public receipt. The transfer was not reversed; please do not retry it.",
+    });
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb.ts
@@ -4,7 +4,6 @@ import {
   DiscordGuildIdSchema,
 } from "@scout-for-lol/data/index.ts";
 import {
-  getLedgerPage,
   getPersonalBucksView,
   type PersonalBucksView,
 } from "#src/betting/accounts.ts";
@@ -16,7 +15,6 @@ import {
   BUCKS_NOT_ENABLED,
   withRulesHint,
 } from "#src/betting/copy.ts";
-import { renderBucksHistory } from "#src/betting/navigation.ts";
 import { getOpenMarketAggregates } from "#src/betting/open-market.ts";
 import {
   BucksOutcomeChoiceSchema,
@@ -36,7 +34,6 @@ import { selectParlayMarketForAlias } from "#src/betting/parlay-market-selection
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
 import { replyError } from "#src/discord/commands/define-command.ts";
-import { buildBbPrizesEmbed } from "#src/discord/commands/bb-prizes.ts";
 import type { BbCommandInteraction } from "#src/discord/commands/bb-interaction.ts";
 import {
   replyBucksAsk,
@@ -49,12 +46,21 @@ import {
   resolveOpenGameByAlias,
   trackedGameAliases,
 } from "#src/discord/commands/bb-market.ts";
-import { buildBbRulesEmbed as createBbRulesEmbed } from "#src/discord/commands/bb-rules.ts";
 import { replyBbPeekCommand } from "#src/discord/commands/bb-peek.ts";
 import {
   replyBbNotifications,
   type BbNotificationCommandDependencies,
 } from "#src/discord/commands/bb-notifications.ts";
+import {
+  replyBbHistory,
+  replyBbPrizes,
+  replyBbRules,
+} from "#src/discord/commands/bb-overview.ts";
+import { buildBbRulesEmbed as createBbRulesEmbed } from "#src/discord/commands/bb-rules.ts";
+import {
+  replyBbTransfer,
+  type BbTransferCommandDependencies,
+} from "#src/discord/commands/bb-transfer.ts";
 import {
   splitMessageIntoChunks,
   truncateEmbedFieldValue,
@@ -93,7 +99,8 @@ const BUCKS_COLOR = 0x2e_cc_71;
 type BbCommandDependencies = {
   runAskAgent?: BucksAskAgentRunner;
   isPolicyEnabled?: typeof isPolicyEnabled;
-} & BbNotificationCommandDependencies;
+} & BbNotificationCommandDependencies &
+  BbTransferCommandDependencies;
 
 export function isPublicBbSubcommand(subcommand: string): boolean {
   return subcommand === "rules" || subcommand === "prizes";
@@ -166,23 +173,6 @@ async function replyBalance(
   await interaction.editReply({
     embeds: [buildPersonalBucksEmbed(view)],
   });
-}
-
-async function replyPrizes(interaction: BbCommandInteraction): Promise<void> {
-  await interaction.editReply({ embeds: [buildBbPrizesEmbed()] });
-}
-
-async function replyRules(interaction: BbCommandInteraction): Promise<void> {
-  await interaction.editReply({ embeds: [buildBbRulesEmbed()] });
-}
-
-async function replyHistory(
-  interaction: BbCommandInteraction,
-  serverId: ReturnType<typeof DiscordGuildIdSchema.parse>,
-  discordId: ReturnType<typeof DiscordAccountIdSchema.parse>,
-): Promise<void> {
-  const page = await getLedgerPage({ serverId, discordId, page: 0 });
-  await interaction.editReply(renderBucksHistory(discordId, page));
 }
 
 async function editReplyInChunks(
@@ -473,13 +463,16 @@ export async function executeBb(
         await replyBalance(interaction, serverId, discordId);
         break;
       case "prizes":
-        await replyPrizes(interaction);
+        await replyBbPrizes(interaction);
         break;
       case "rules":
-        await replyRules(interaction);
+        await replyBbRules(interaction);
         break;
       case "history":
-        await replyHistory(interaction, serverId, discordId);
+        await replyBbHistory(interaction, serverId, discordId);
+        break;
+      case "transfer":
+        await replyBbTransfer(interaction, serverId, discordId, dependencies);
         break;
       case "open":
         await replyOpen(interaction, serverId);

--- a/packages/scout-for-lol/packages/backend/src/metrics/betting.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/betting.ts
@@ -131,6 +131,15 @@ export const bettingPeekPassesTotal = new Counter({
   registers: [registry],
 });
 
+/* ----------------------------------------------------------- transfers -- */
+
+export const bettingTransfersTotal = new Counter({
+  name: "betting_transfers_total",
+  help: "Bryan Bucks wallet transfer attempts, by result.",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
 /* --------------------------------------------------- message delivery -- */
 
 export const bettingMessageOperationsTotal = new Counter({

--- a/packages/scout-for-lol/packages/backend/src/testing/test-database.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/test-database.ts
@@ -19,6 +19,21 @@ function extendClient(client: PrismaClient): ExtendedPrismaClient {
   });
 }
 
+export function connectTestDatabase(databaseUrl: string): ExtendedPrismaClient {
+  const parsed = new URL(databaseUrl);
+  if (
+    parsed.protocol !== "postgres:" ||
+    !/^scout_test_[a-z0-9_]+$/u.test(parsed.pathname.slice(1))
+  ) {
+    throw new Error(`Refusing to connect to non-test database ${databaseUrl}`);
+  }
+  return extendClient(
+    new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    }),
+  );
+}
+
 /** Postgres identifiers cap at 63 bytes; the name encodes its creation time. */
 function testDatabaseName(testName: string): string {
   const sanitized = testName
@@ -75,14 +90,10 @@ export function createTestDatabase(testName: string): {
   }
 
   const dbUrl = devDatabaseUrl(dbName);
-  const basePrisma = new PrismaClient({
+  return {
     // Must mirror src/database/index.ts so tests exercise the same adapter
     // as production.
-    adapter: new PrismaPg({ connectionString: dbUrl }),
-  });
-
-  return {
-    prisma: extendClient(basePrisma),
+    prisma: connectTestDatabase(dbUrl),
     dbPath: dbName,
     dbUrl,
   };

--- a/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
+++ b/packages/scout-for-lol/packages/data/src/model/bryan-bucks.ts
@@ -72,6 +72,9 @@ export const BucksLedgerKindSchema = z.enum([
   "weekly_parlay_refund",
   "weekly_parlay_release",
   "peek_pass",
+  "transfer_sent",
+  "transfer_received",
+  "transfer_fee",
   "adjustment",
 ]);
 
@@ -475,6 +478,17 @@ export const BucksLedgerContextSchema = z.discriminatedUnion("type", [
     balanceBefore: z.number().int().nonnegative(),
     weightedAgeWeeks: z.number().int().nonnegative(),
     expiresAt: z.iso.datetime(),
+  }),
+  z.strictObject({
+    type: z.literal("transfer"),
+    transferId: z.uuid(),
+    senderAccountId: z.number().int().positive(),
+    recipientAccountId: z.number().int().positive(),
+    houseAccountId: z.number().int().positive(),
+    totalAmount: BucksStakeSchema,
+    recipientAmount: BucksStakeSchema,
+    feeAmount: BucksStakeSchema,
+    role: z.enum(["sender", "recipient", "house"]),
   }),
   z.strictObject({
     type: z.literal("adjustment"),

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/bryan-bucks-privacy.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/explanation/bryan-bucks-privacy.md
@@ -50,13 +50,19 @@ deliberately omit.
 
 ## What is public
 
-Three things, all of them about the market rather than about people:
+Four things are public. Three are about the market:
 
 - **Side totals while the market is open**, plus the names of who is on each
   side. Positions are not secret — they are part of the market.
 - **The final matched amounts at close**, on the same message, which becomes
   the receipt.
 - **The settlement**, with each bettor's gross, fee, and net.
+
+The fourth is an explicit social action: a successful `/bb transfer` posts a
+Western Union-style receipt that names and mentions the sender and recipient.
+It shows the sender's total spend, the recipient's share, and the house fee so
+the movement is transparent. It never shows either person's balance. Failed
+transfers remain private.
 
 Cancelled bets disappear from the public digest, though they remain in
 `/bb history`. A withdrawn offer is not a position, and leaving it on screen

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -14,6 +14,7 @@ Bryan Bucks is enabled.
 | ------------------- | ----------------------------------------------------- | --------------------------------- |
 | `/bb balance`       | Available Bucks, Bucks at risk, and pending positions | Private                           |
 | `/bb history`       | Paged transaction ledger with running balances        | Private                           |
+| `/bb transfer`      | Send half of a total spend to another wallet          | Private result, public receipt    |
 | `/bb open`          | Match and weekly markets still taking bets            | Private                           |
 | `/bb bet`           | Place or top up an outcome bet                        | Private                           |
 | `/bb parlay`        | Place or top up a match or weekly parlay bet          | Private                           |
@@ -24,8 +25,10 @@ Bryan Bucks is enabled.
 | `/bb rules`         | The complete rulebook                                 | **Public**                        |
 | `/bb prizes`        | The joke prize catalogue                              | **Public**                        |
 
-Everything except `rules` and `prizes` answers only to you. Balances, positions,
-and estimates are never posted to the channel by Scout.
+Every command starts privately except `rules` and `prizes`. A successful
+`transfer` then posts its sender, recipient, total spend, received amount, and
+house fee publicly. Balances, positions, and estimates are never posted to the
+channel by Scout.
 
 ## Options
 
@@ -55,6 +58,17 @@ If one player appears in several open parlays, the alias is intentionally
 ambiguous. Use the buttons on the specific market message you want instead of
 letting Scout guess. The same rule lets weekly parlays support several subjects
 and several concurrent markets without changing the command.
+
+### `/bb transfer`
+
+| Option      | Required | Values                                   |
+| ----------- | -------- | ---------------------------------------- |
+| `recipient` | yes      | A non-bot member with an existing wallet |
+| `amount`    | yes      | Your total whole-BB spend, at least 2 BB |
+
+The recipient receives half rounded down; the house receives half rounded up.
+The transfer is immediate and irreversible. Both wallets must already exist in
+this server, and you cannot transfer to yourself.
 
 ### `/bb peek`
 
@@ -119,4 +133,6 @@ settlement. Updates mention featured players and current bettors but expose
 only aggregate YES/NO totals—never a person's side or stake.
 
 Bets never add messages. Placing, topping up, and cancelling all edit the
-market message in place.
+market message in place. A successful `/bb transfer` is the exception: it adds
+one Western Union-style public receipt that mentions only the sender and
+recipient and never shows either balance.

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
@@ -11,6 +11,7 @@ import {
   BUTTON_STAKES,
   HOUSE_BANKROLL,
   HOUSE_MATCH_LIMIT,
+  MINIMUM_BUCKS_TRANSFER,
   MIN_STAKE,
   PARLAY_BETTING_WINDOW_MS,
   REMAKE_MAX_DURATION_SECONDS,
@@ -155,10 +156,24 @@ for a new wallet is transferred from the house bankroll, not created.
 | Cancelling an outcome bet      | {HOUSE_CUT_PERCENT}% of the **offer**, rounded to the nearest BB |
 | Cancelling a parlay            | none                                                             |
 | Any void or remake refund      | none                                                             |
+| Western Union transfer         | Half the total spend, rounded up                                 |
 
 The two {HOUSE_CUT_PERCENT}% figures use different bases and different
 rounding, and that is deliberate: the winner fee rounds down so a winning 1 BB
 match still profits.
+
+## Transfers
+
+`/bb transfer` is the only user-to-user Bryan Bucks movement. The sender spends
+at least {MINIMUM_BUCKS_TRANSFER} whole BB. The recipient receives half rounded
+down, and the house receives half rounded up, so an odd amount favors the house
+by one BB. Both people must already have non-house wallets in the same server;
+bots and self-transfers are refused.
+
+Transfers commit immediately with no confirmation and cannot be reversed. A
+successful transfer posts a public receipt naming both people and showing the
+total, recipient share, and house fee, but never either balance. There is no
+free donation, redemption, burn, or claim path.
 
 ## Matching
 

--- a/packages/scout-for-lol/scripts/dev-discord.test.ts
+++ b/packages/scout-for-lol/scripts/dev-discord.test.ts
@@ -55,3 +55,11 @@ test("refuses missing credentials, guilds, and unknown scenarios", () => {
     buildDevDiscordLaunch(["--scenario", "unknown"], environment),
   ).toThrow();
 });
+
+test("leaves provider overrides empty so guild-scoped registry flags decide", () => {
+  const launch = buildDevDiscordLaunch(
+    ["--scenario", "bb-transfer"],
+    environment,
+  );
+  expect(launch.environment["FEATURE_FLAGS_STATIC_OVERRIDES"]).toBe("{}");
+});

--- a/packages/scout-for-lol/scripts/discord-smoke-bb-transfer.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-bb-transfer.ts
@@ -1,0 +1,330 @@
+import path from "node:path";
+import {
+  BucksLedgerContextSchema,
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { DirectSlashResponseSchema } from "@shepherdjerred/toolkit/lib/discord/ipc.ts";
+import { ensureBucksAccount } from "@scout-for-lol/backend/betting/accounts.ts";
+import { HOUSE_ACCOUNT_DISCORD_ID } from "@scout-for-lol/backend/betting/constants.ts";
+import type { connectTestDatabase } from "@scout-for-lol/backend/testing/test-database.ts";
+import { z } from "zod";
+import { captureDiscordMessage } from "./discord-smoke-browser.ts";
+import type {
+  DiscordSmokeFixture,
+  DiscordSmokeManifest,
+  DiscordSmokePreflightDependencies,
+} from "./discord-smoke-core.ts";
+import { readPipedProcess } from "./discord-smoke-process.ts";
+
+const TRANSFER_AMOUNT = 3;
+type SmokeDatabase = ReturnType<typeof connectTestDatabase>;
+export type SeededAccounts = NonNullable<
+  DiscordSmokeManifest["seededAccounts"]
+>;
+
+const DiscordReceiptMessageSchema = z.object({
+  id: z.string().regex(/^\d{17,20}$/u),
+  content: z.string(),
+  author: z.object({ id: z.string() }),
+  timestamp: z.string().refine((value) => Number.isFinite(Date.parse(value))),
+});
+
+export async function seedTransferAccounts(
+  database: SmokeDatabase,
+  fixture: DiscordSmokeFixture,
+): Promise<SeededAccounts> {
+  const serverId = DiscordGuildIdSchema.parse(fixture.guildId);
+  const sender = await ensureBucksAccount(
+    {
+      serverId,
+      discordId: DiscordAccountIdSchema.parse(fixture.invokingUserId),
+    },
+    database,
+  );
+  const recipient = await ensureBucksAccount(
+    {
+      serverId,
+      discordId: DiscordAccountIdSchema.parse(fixture.recipientUserId),
+    },
+    database,
+  );
+  const house = await database.bucksAccount.findUniqueOrThrow({
+    where: {
+      serverId_discordId: {
+        serverId,
+        discordId: HOUSE_ACCOUNT_DISCORD_ID,
+      },
+    },
+    select: { id: true, balance: true },
+  });
+  return {
+    senderId: sender.id,
+    senderBalance: sender.balance,
+    recipientId: recipient.id,
+    recipientBalance: recipient.balance,
+    houseId: house.id,
+    houseBalance: house.balance,
+  };
+}
+
+export function expectedPrivateReply(fixture: DiscordSmokeFixture): string {
+  return `Transfer complete. 1 BB went to <@${fixture.recipientUserId}> and 2 BB went to the house.`;
+}
+
+export function expectedPublicReceipt(fixture: DiscordSmokeFixture): string {
+  return (
+    "💸 **Bryan Bucks Western Union**\n" +
+    `<@${fixture.invokingUserId}> spent **3 BB** to send ` +
+    `<@${fixture.recipientUserId}> **1 BB**. The house collected **2 BB**.`
+  );
+}
+
+export async function invokeTransfer(
+  fixture: DiscordSmokeFixture,
+  toolkitEntrypoint: string,
+  workspaceRoot: string,
+) {
+  const child = Bun.spawn(
+    [
+      "bun",
+      toolkitEntrypoint,
+      "discord",
+      "slash",
+      fixture.channelId,
+      fixture.applicationId,
+      "bb",
+      "transfer",
+      `recipient:${fixture.recipientUserId}`,
+      `amount:${TRANSFER_AMOUNT.toString()}`,
+      "--direct",
+      "--wait-public",
+      "--contains",
+      "Bryan Bucks Western Union",
+      "--timeout",
+      "60",
+      "--json",
+    ],
+    { cwd: workspaceRoot, stdout: "pipe", stderr: "pipe", env: Bun.env },
+  );
+  const stdout = await readPipedProcess(
+    child,
+    "Direct Discord invocation failed",
+  );
+  const parsed: unknown = JSON.parse(stdout);
+  return DirectSlashResponseSchema.parse(parsed);
+}
+
+function assertPrivateReply(
+  fixture: DiscordSmokeFixture,
+  response: ReturnType<typeof DirectSlashResponseSchema.parse>,
+): void {
+  if (response.invokingUserId !== fixture.invokingUserId) {
+    throw new Error(
+      `Slash invocation used Discord user ${response.invokingUserId}, expected ${fixture.invokingUserId}`,
+    );
+  }
+  if (response.reply === null) {
+    throw new Error("Western Union smoke did not receive a private reply");
+  }
+  if (response.reply.content !== expectedPrivateReply(fixture)) {
+    throw new Error(
+      `Western Union private reply changed: ${response.reply.content}`,
+    );
+  }
+}
+
+function assertPublicReceipt(
+  fixture: DiscordSmokeFixture,
+  response: ReturnType<typeof DirectSlashResponseSchema.parse>,
+): void {
+  const receipt = response.publicResponse;
+  if (receipt === null) {
+    if (response.publicResponseTimedOut) return;
+    throw new Error("Western Union smoke returned no public receipt state");
+  }
+  if (
+    receipt.authorId !== fixture.applicationId ||
+    receipt.content !== expectedPublicReceipt(fixture)
+  ) {
+    throw new Error("Western Union public receipt identity or copy changed");
+  }
+  const userMentions = [...receipt.mentionUserIds].sort();
+  const expectedMentions = [
+    fixture.invokingUserId,
+    fixture.recipientUserId,
+  ].sort();
+  if (
+    userMentions.join(",") !== expectedMentions.join(",") ||
+    receipt.mentionRoleIds.length > 0 ||
+    receipt.mentionsEveryone
+  ) {
+    throw new Error(
+      "Western Union receipt must mention only the sender and recipient",
+    );
+  }
+}
+
+export function assertTransferResponse(
+  fixture: DiscordSmokeFixture,
+  response: ReturnType<typeof DirectSlashResponseSchema.parse>,
+): void {
+  assertPrivateReply(fixture, response);
+  assertPublicReceipt(fixture, response);
+}
+
+function validateTransferContexts(
+  entries: readonly { context: string }[],
+  seeded: SeededAccounts,
+): void {
+  const contexts = entries.map((entry) =>
+    BucksLedgerContextSchema.parse(JSON.parse(entry.context)),
+  );
+  if (contexts.some((context) => context.type !== "transfer")) {
+    throw new Error("Transfer ledger row used a non-transfer context");
+  }
+  const transferIds = new Set(
+    contexts.flatMap((context) =>
+      context.type === "transfer" ? [context.transferId] : [],
+    ),
+  );
+  const roles = contexts.flatMap((context) =>
+    context.type === "transfer" ? [context.role] : [],
+  );
+  if (transferIds.size !== 1 || roles.join(",") !== "sender,recipient,house") {
+    throw new Error("Transfer ledger correlation or row roles changed");
+  }
+  for (const context of contexts) {
+    if (
+      context.type === "transfer" &&
+      (context.senderAccountId !== seeded.senderId ||
+        context.recipientAccountId !== seeded.recipientId ||
+        context.houseAccountId !== seeded.houseId ||
+        context.totalAmount !== 3 ||
+        context.recipientAmount !== 1 ||
+        context.feeAmount !== 2)
+    ) {
+      throw new Error("Transfer ledger context does not match the smoke run");
+    }
+  }
+}
+
+export async function verifyTransferDatabase(
+  database: SmokeDatabase,
+  fixture: DiscordSmokeFixture,
+  seeded: SeededAccounts,
+): Promise<void> {
+  const entries = await database.bucksLedgerEntry.findMany({
+    where: { kind: { startsWith: "transfer_" } },
+    orderBy: { id: "asc" },
+  });
+  if (entries.length !== 3) {
+    throw new Error(
+      `Expected three transfer ledger rows, found ${entries.length.toString()}`,
+    );
+  }
+  const movements = entries.map((entry) => [entry.kind, entry.delta].join(":"));
+  if (
+    movements.join(",") !==
+    "transfer_sent:-3,transfer_received:1,transfer_fee:2"
+  ) {
+    throw new Error(`Unexpected transfer movements: ${movements.join(",")}`);
+  }
+  validateTransferContexts(entries, seeded);
+
+  const accounts = await database.bucksAccount.findMany({
+    where: {
+      id: { in: [seeded.senderId, seeded.recipientId, seeded.houseId] },
+      serverId: DiscordGuildIdSchema.parse(fixture.guildId),
+    },
+    orderBy: { id: "asc" },
+    select: { id: true, balance: true },
+  });
+  const balanceById = new Map(
+    accounts.map((account) => [account.id, account.balance]),
+  );
+  if (
+    balanceById.get(seeded.senderId) !== seeded.senderBalance - 3 ||
+    balanceById.get(seeded.recipientId) !== seeded.recipientBalance + 1 ||
+    balanceById.get(seeded.houseId) !== seeded.houseBalance + 2
+  ) {
+    throw new Error("Stored Bryan Bucks balances do not match the 3/1/2 split");
+  }
+  const balanceBefore =
+    seeded.senderBalance + seeded.recipientBalance + seeded.houseBalance;
+  const balanceAfter = accounts.reduce(
+    (total, account) => total + account.balance,
+    0,
+  );
+  if (balanceAfter !== balanceBefore) {
+    throw new Error("Western Union smoke did not conserve Bryan Bucks");
+  }
+  const outboxCount = await database.bucksAnalyticsLedgerOutbox.count({
+    where: { ledgerEntryId: { in: entries.map((entry) => entry.id) } },
+  });
+  if (outboxCount !== 3) {
+    throw new Error(
+      `Expected three analytics outbox rows, found ${outboxCount.toString()}`,
+    );
+  }
+}
+
+export async function findReceiptMessageId(
+  fixture: DiscordSmokeFixture,
+  botToken: string,
+  invocationStartedAt: string,
+  fetcher: DiscordSmokePreflightDependencies["fetch"] = fetch,
+): Promise<string> {
+  const response = await fetcher(
+    `https://discord.com/api/v10/channels/${fixture.channelId}/messages?limit=100`,
+    { headers: { authorization: `Bot ${botToken}` } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Discord receipt lookup returned HTTP ${response.status.toString()}`,
+    );
+  }
+  const messages = z
+    .array(DiscordReceiptMessageSchema)
+    .parse(await response.json());
+  const invocationStartedAtMilliseconds = Date.parse(invocationStartedAt);
+  if (!Number.isFinite(invocationStartedAtMilliseconds)) {
+    throw new TypeError(
+      `Invalid smoke invocation timestamp: ${invocationStartedAt}`,
+    );
+  }
+  const receipt = messages.find(
+    (message) =>
+      message.author.id === fixture.applicationId &&
+      message.content === expectedPublicReceipt(fixture) &&
+      Date.parse(message.timestamp) >= invocationStartedAtMilliseconds,
+  );
+  if (receipt === undefined) {
+    throw new Error(
+      "Committed transfer exists but its public receipt was not found",
+    );
+  }
+  return receipt.id;
+}
+
+export async function captureReceipt(
+  fixture: DiscordSmokeFixture,
+  publicMessageId: string,
+  runDirectory: string,
+): Promise<string> {
+  const screenshotPath = path.join(runDirectory, "bb-transfer.png");
+  await captureDiscordMessage({
+    profileName: fixture.pinchTabProfile,
+    guildId: fixture.guildId,
+    channelId: fixture.channelId,
+    messageId: publicMessageId,
+    expectedVisibleFragments: [
+      "Bryan Bucks Western Union",
+      "spent 3 BB",
+      "1 BB",
+      "The house collected 2 BB",
+    ],
+    outputPath: screenshotPath,
+  });
+  return screenshotPath;
+}

--- a/packages/scout-for-lol/scripts/discord-smoke-browser.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-browser.ts
@@ -1,4 +1,7 @@
 import { z } from "zod";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { readPipedProcess } from "./discord-smoke-process.ts";
 
 const ProfileSchema = z.object({
   id: z.string().min(1),
@@ -15,29 +18,26 @@ const InstanceSchema = z.object({
 const BrowserLocationSchema = z.object({
   url: z.url(),
 });
+const BrowserTextSchema = z.object({ text: z.string() });
 
 async function runPinchTabJson(args: readonly string[]): Promise<unknown> {
-  const child = Bun.spawn(["pinchtab", ...args], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    child.exited,
-    new Response(child.stdout).text(),
-    new Response(child.stderr).text(),
-  ]);
-  if (exitCode !== 0) {
-    throw new Error(`PinchTab preflight failed: ${stderr.trim()}`);
-  }
+  const stdout = await runPinchTab(args);
   const parsed: unknown = JSON.parse(stdout);
   return parsed;
 }
 
-export async function verifyPinchTabProfile(
-  profileName: string,
-  guildId: string,
-  channelId: string,
-): Promise<void> {
+async function runPinchTab(args: readonly string[]): Promise<string> {
+  const child = Bun.spawn(["pinchtab", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return readPipedProcess(child, "PinchTab command failed");
+}
+
+async function resolveRunningInstance(profileName: string): Promise<{
+  readonly profile: z.infer<typeof ProfileSchema>;
+  readonly instance: z.infer<typeof InstanceSchema>;
+}> {
   const profiles = z
     .array(ProfileSchema)
     .parse(await runPinchTabJson(["profiles", "--json"]));
@@ -64,6 +64,15 @@ export async function verifyPinchTabProfile(
       `PinchTab profile ${profileName} has no running browser instance`,
     );
   }
+  return { profile, instance };
+}
+
+export async function verifyPinchTabProfile(
+  profileName: string,
+  guildId: string,
+  channelId: string,
+): Promise<void> {
+  const { instance } = await resolveRunningInstance(profileName);
 
   const channelUrl = `https://discord.com/channels/${guildId}/${channelId}`;
   await runPinchTabJson([
@@ -86,4 +95,59 @@ export async function verifyPinchTabProfile(
       `PinchTab profile ${profileName} could not open the smoke channel; reached ${location.url}`,
     );
   }
+}
+
+export async function captureDiscordMessage(input: {
+  readonly profileName: string;
+  readonly guildId: string;
+  readonly channelId: string;
+  readonly messageId: string;
+  readonly expectedVisibleFragments: readonly string[];
+  readonly outputPath: string;
+}): Promise<void> {
+  const { instance } = await resolveRunningInstance(input.profileName);
+  const messageUrl = `https://discord.com/channels/${input.guildId}/${input.channelId}/${input.messageId}`;
+  await runPinchTabJson([
+    "nav",
+    "--server",
+    instance.url,
+    messageUrl,
+    "--json",
+  ]);
+  await runPinchTabJson([
+    "wait",
+    "--server",
+    instance.url,
+    "--text",
+    input.expectedVisibleFragments[0] ?? "",
+    "--timeout",
+    "30000",
+    "--json",
+  ]);
+  const page = BrowserTextSchema.parse(
+    await runPinchTabJson([
+      "text",
+      "--server",
+      instance.url,
+      "--full",
+      "--json",
+    ]),
+  );
+  for (const fragment of input.expectedVisibleFragments) {
+    if (!page.text.includes(fragment)) {
+      throw new Error(
+        `Discord client did not visibly render expected receipt text: ${fragment}`,
+      );
+    }
+  }
+  await mkdir(path.dirname(input.outputPath), { recursive: true });
+  await runPinchTab([
+    "screenshot",
+    "--server",
+    instance.url,
+    "--output",
+    input.outputPath,
+    "--format",
+    "png",
+  ]);
 }

--- a/packages/scout-for-lol/scripts/discord-smoke-core.test.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-core.test.ts
@@ -6,6 +6,7 @@ import {
   preflightDiscordSmoke,
   raceRuntimeOperation,
   waitForRuntimeReadiness,
+  waitForDiscordCommand,
 } from "./discord-smoke-core.ts";
 
 const fixture = DiscordSmokeFixtureSchema.parse({
@@ -103,6 +104,7 @@ describe("invocation guard", () => {
     createdAt: "2026-08-29T00:00:00.000Z",
     databaseName: null,
     databaseUrl: null,
+    seededAccounts: null,
     invocationStartedAt: null,
     privateReplyId: null,
     publicMessageId: null,
@@ -173,4 +175,35 @@ describe("runtime readiness", () => {
       ),
     ).rejects.toThrow("before command registration");
   });
+});
+
+test("waits for the exact registered subcommand", async () => {
+  const fetcher = vi
+    .fn()
+    .mockResolvedValueOnce(
+      response([{ id: "100000000000000010", name: "bb", options: [] }]),
+    )
+    .mockResolvedValueOnce(
+      response([
+        {
+          id: "100000000000000010",
+          name: "bb",
+          options: [{ type: 1, name: "transfer" }],
+        },
+      ]),
+    );
+
+  await waitForDiscordCommand(
+    {
+      fixture,
+      botToken: "bot",
+      commandName: "bb",
+      subcommandName: "transfer",
+      guildScoped: true,
+      timeoutMilliseconds: 2000,
+    },
+    fetcher,
+  );
+
+  expect(fetcher).toHaveBeenCalledTimes(2);
 });

--- a/packages/scout-for-lol/scripts/discord-smoke-core.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-core.ts
@@ -26,6 +26,16 @@ export const DiscordSmokeManifestSchema = z.object({
     .regex(/^scout_test_[a-z0-9_]+$/u)
     .nullable(),
   databaseUrl: z.url().nullable(),
+  seededAccounts: z
+    .object({
+      senderId: z.number().int().positive(),
+      senderBalance: z.number().int(),
+      recipientId: z.number().int().positive(),
+      recipientBalance: z.number().int(),
+      houseId: z.number().int().positive(),
+      houseBalance: z.number().int(),
+    })
+    .nullable(),
   invocationStartedAt: z.iso.datetime().nullable(),
   privateReplyId: SnowflakeSchema.nullable(),
   publicMessageId: SnowflakeSchema.nullable(),
@@ -47,7 +57,14 @@ const DiscordGuildMemberSchema = z.object({
 const DiscordCommandSchema = z.object({
   id: SnowflakeSchema,
   name: z.string(),
-  options: z.array(z.unknown()).optional(),
+  options: z
+    .array(
+      z.object({
+        type: z.number().int(),
+        name: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 export type DiscordSmokePreflightDependencies = {
@@ -257,6 +274,7 @@ export async function waitForDiscordCommand(
     readonly fixture: DiscordSmokeFixture;
     readonly botToken: string;
     readonly commandName: string;
+    readonly subcommandName?: string | undefined;
     readonly guildScoped: boolean;
     readonly timeoutMilliseconds?: number | undefined;
   },
@@ -273,13 +291,23 @@ export async function waitForDiscordCommand(
       .array(DiscordCommandSchema)
       .parse(await discordJson(fetcher, pathname, `Bot ${params.botToken}`));
     lastNames = commands.map((command) => command.name);
-    if (commands.some((command) => command.name === params.commandName)) {
+    if (
+      commands.some(
+        (command) =>
+          command.name === params.commandName &&
+          (params.subcommandName === undefined ||
+            command.options?.some(
+              (option) =>
+                option.type === 1 && option.name === params.subcommandName,
+            ) === true),
+      )
+    ) {
       return;
     }
     await Bun.sleep(500);
   }
   throw new Error(
-    `Discord did not expose /${params.commandName} before timeout; observed [${lastNames.join(", ")}]`,
+    `Discord did not expose /${params.commandName}${params.subcommandName === undefined ? "" : ` ${params.subcommandName}`} before timeout; observed [${lastNames.join(", ")}]`,
   );
 }
 

--- a/packages/scout-for-lol/scripts/discord-smoke-process.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke-process.ts
@@ -1,0 +1,18 @@
+export async function readPipedProcess(
+  child: {
+    readonly exited: Promise<number>;
+    readonly stdout: ReadableStream<Uint8Array>;
+    readonly stderr: ReadableStream<Uint8Array>;
+  },
+  failurePrefix: string,
+): Promise<string> {
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`${failurePrefix}: ${stderr.trim()}`);
+  }
+  return stdout;
+}

--- a/packages/scout-for-lol/scripts/discord-smoke.fixture.json
+++ b/packages/scout-for-lol/scripts/discord-smoke.fixture.json
@@ -3,7 +3,7 @@
   "botUserId": "1542993271477899294",
   "invokingUserId": "1515150733660520496",
   "recipientUserId": "160509172704739328",
-  "guildId": "1543374394598887484",
-  "channelId": "1543374398902243398",
+  "guildId": "1092210479755178054",
+  "channelId": "1176684904923279390",
   "pinchTabProfile": "scout-discord-smoke"
 }

--- a/packages/scout-for-lol/scripts/discord-smoke.test.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke.test.ts
@@ -1,0 +1,146 @@
+import { DirectSlashResponseSchema } from "@shepherdjerred/toolkit/lib/discord/ipc.ts";
+import { describe, expect, test } from "vitest";
+import {
+  assertTransferResponse,
+  expectedPrivateReply,
+  expectedPublicReceipt,
+  findReceiptMessageId,
+} from "./discord-smoke-bb-transfer.ts";
+import { DiscordSmokeFixtureSchema } from "./discord-smoke-core.ts";
+import { parseDiscordSmokeArguments } from "./discord-smoke.ts";
+
+const fixture = DiscordSmokeFixtureSchema.parse({
+  applicationId: "1542993271477899294",
+  botUserId: "1542993271477899294",
+  invokingUserId: "1515150733660520496",
+  recipientUserId: "160509172704739328",
+  guildId: "100000000000000001",
+  channelId: "100000000000000002",
+  pinchTabProfile: "scout-discord-smoke",
+});
+
+function message(input: {
+  readonly id: string;
+  readonly content: string;
+  readonly mentionUserIds?: string[] | undefined;
+}) {
+  return {
+    id: input.id,
+    channelId: fixture.channelId,
+    authorId: fixture.applicationId,
+    authorTag: "Derrej",
+    authorIsBot: true,
+    content: input.content,
+    createdAt: "2026-08-29T00:00:00.000Z",
+    embeds: [],
+    attachments: [],
+    mentionUserIds: input.mentionUserIds ?? [],
+    mentionRoleIds: [],
+    mentionsEveryone: false,
+  };
+}
+
+describe("Discord smoke arguments", () => {
+  test("accepts fresh gateway and transfer runs", () => {
+    expect(parseDiscordSmokeArguments(["--scenario", "gateway"])).toEqual({
+      kind: "fresh",
+      scenario: "gateway",
+    });
+    expect(parseDiscordSmokeArguments(["--scenario", "bb-transfer"])).toEqual({
+      kind: "fresh",
+      scenario: "bb-transfer",
+    });
+  });
+
+  test("accepts resume without selecting a scenario", () => {
+    expect(parseDiscordSmokeArguments(["--resume", "run-1"])).toEqual({
+      kind: "resume",
+      runId: "run-1",
+    });
+    expect(() => parseDiscordSmokeArguments(["--scenario", "other"])).toThrow(
+      "Unknown Discord smoke scenario",
+    );
+  });
+});
+
+describe("Western Union receipt contract", () => {
+  test("accepts exact private and public copy with two user mentions", () => {
+    const response = DirectSlashResponseSchema.parse({
+      invoked: true,
+      invokingUserId: fixture.invokingUserId,
+      reply: message({
+        id: "100000000000000011",
+        content: expectedPrivateReply(fixture),
+      }),
+      publicResponse: message({
+        id: "100000000000000012",
+        content: expectedPublicReceipt(fixture),
+        mentionUserIds: [fixture.invokingUserId, fixture.recipientUserId],
+      }),
+      publicResponseTimedOut: false,
+    });
+
+    expect(() => assertTransferResponse(fixture, response)).not.toThrow();
+  });
+
+  test("ignores an identical receipt from before this invocation", async () => {
+    const fetcher = () =>
+      Promise.resolve(
+        Response.json([
+          {
+            id: "100000000000000011",
+            content: expectedPublicReceipt(fixture),
+            author: { id: fixture.applicationId },
+            timestamp: "2026-08-29T00:00:00.000Z",
+          },
+          {
+            id: "100000000000000012",
+            content: expectedPublicReceipt(fixture),
+            author: { id: fixture.applicationId },
+            timestamp: "2026-08-29T00:02:00.000Z",
+          },
+        ]),
+      );
+
+    await expect(
+      findReceiptMessageId(fixture, "bot", "2026-08-29T00:01:00.000Z", fetcher),
+    ).resolves.toBe("100000000000000012");
+  });
+
+  test("rejects changed copy and broadened mentions", () => {
+    const changedCopy = DirectSlashResponseSchema.parse({
+      invoked: true,
+      invokingUserId: fixture.invokingUserId,
+      reply: message({
+        id: "100000000000000011",
+        content: "Transfer complete.",
+      }),
+      publicResponse: null,
+      publicResponseTimedOut: true,
+    });
+    expect(() => assertTransferResponse(fixture, changedCopy)).toThrow(
+      "private reply changed",
+    );
+
+    const broadenedMentions = DirectSlashResponseSchema.parse({
+      invoked: true,
+      invokingUserId: fixture.invokingUserId,
+      reply: message({
+        id: "100000000000000011",
+        content: expectedPrivateReply(fixture),
+      }),
+      publicResponse: {
+        ...message({
+          id: "100000000000000012",
+          content: expectedPublicReceipt(fixture),
+          mentionUserIds: [fixture.invokingUserId, fixture.recipientUserId],
+        }),
+        mentionRoleIds: ["100000000000000013"],
+      },
+      publicResponseTimedOut: false,
+    });
+    expect(() => assertTransferResponse(fixture, broadenedMentions)).toThrow(
+      "mention only",
+    );
+  });
+});

--- a/packages/scout-for-lol/scripts/discord-smoke.ts
+++ b/packages/scout-for-lol/scripts/discord-smoke.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  connectTestDatabase,
   createTestDatabase,
   dropTestDatabase,
 } from "@scout-for-lol/backend/testing/test-database.ts";
@@ -9,7 +10,18 @@ import {
 } from "@scout-for-lol/backend/testing/test-template.ts";
 import { verifyPinchTabProfile } from "./discord-smoke-browser.ts";
 import {
+  assertTransferResponse,
+  captureReceipt,
+  findReceiptMessageId,
+  invokeTransfer,
+  seedTransferAccounts,
+  verifyTransferDatabase,
+} from "./discord-smoke-bb-transfer.ts";
+import {
+  type DiscordSmokeFixture,
+  type DiscordSmokeManifest,
   DiscordSmokeManifestSchema,
+  assertInvocationAllowed,
   loadDiscordSmokeFixture,
   loadDiscordSmokeManifest,
   preflightDiscordSmoke,
@@ -22,11 +34,27 @@ import { requireCliValue } from "./migration-core.ts";
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dir, "../../..");
 const SCOUT_ROOT = path.resolve(import.meta.dir, "..");
+const TOOLKIT_ENTRYPOINT = path.join(
+  WORKSPACE_ROOT,
+  "packages",
+  "toolkit",
+  "src",
+  "index.ts",
+);
 const FIXTURE_PATH = path.join(import.meta.dir, "discord-smoke.fixture.json");
 
 type SmokeArguments =
-  | { readonly kind: "fresh"; readonly scenario: "gateway" }
+  | { readonly kind: "fresh"; readonly scenario: "gateway" | "bb-transfer" }
   | { readonly kind: "resume"; readonly runId: string };
+
+type SmokeDatabase = ReturnType<typeof connectTestDatabase>;
+
+type FreshSmokeRun = {
+  readonly database: Awaited<ReturnType<typeof createIsolatedDatabase>>;
+  readonly manifest: DiscordSmokeManifest;
+  readonly manifestPath: string;
+  readonly runId: string;
+};
 
 export function parseDiscordSmokeArguments(
   args: readonly string[],
@@ -36,13 +64,13 @@ export function parseDiscordSmokeArguments(
   }
   if (args[0] === "--scenario") {
     const scenario = requireCliValue(args, 0, "--scenario");
-    if (scenario !== "gateway") {
+    if (scenario !== "gateway" && scenario !== "bb-transfer") {
       throw new Error(`Unknown Discord smoke scenario: ${scenario}`);
     }
     return { kind: "fresh", scenario };
   }
   throw new Error(
-    "Usage: test:discord:smoke -- --scenario gateway | --resume <run-id>",
+    "Usage: test:discord:smoke -- --scenario gateway|bb-transfer | --resume <run-id>",
   );
 }
 
@@ -50,85 +78,191 @@ function runDirectory(runId: string): string {
   return path.join(WORKSPACE_ROOT, ".context", "discord-smoke", runId);
 }
 
-async function stopChild(child: Bun.Subprocess | null): Promise<void> {
-  if (child?.exitCode !== null) {
-    return;
-  }
-  child.kill("SIGTERM");
-  await child.exited;
-}
-
-async function runGatewaySmoke(): Promise<void> {
-  const fixture = await loadDiscordSmokeFixture(FIXTURE_PATH);
-  await preflightDiscordSmoke(fixture, Bun.env, {
-    fetch,
-    verifyPinchTabProfile,
-  });
-
-  const runId = `${new Date()
+function createRunId(): string {
+  return `${new Date()
     .toISOString()
     .replaceAll(/\D/gu, "")
     .slice(0, 14)}-${crypto.randomUUID().slice(0, 8)}`;
-  const manifestPath = path.join(runDirectory(runId), "manifest.json");
-  const runtimeReadyPath = path.join(runDirectory(runId), "runtime-ready.json");
-  let manifest = DiscordSmokeManifestSchema.parse({
+}
+
+function createManifest(
+  runId: string,
+  scenario: "gateway" | "bb-transfer",
+): DiscordSmokeManifest {
+  return DiscordSmokeManifestSchema.parse({
     runId,
-    scenario: "gateway",
+    scenario,
     createdAt: new Date().toISOString(),
     databaseName: null,
     databaseUrl: null,
+    seededAccounts: null,
     invocationStartedAt: null,
     privateReplyId: null,
     publicMessageId: null,
     verifiedAt: null,
     screenshotPath: null,
   });
-  await writeDiscordSmokeManifest(manifestPath, manifest);
+}
 
+function requireEnvironment(name: string): string {
+  const value = Bun.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Discord smoke lost ${name} after preflight`);
+  }
+  return value;
+}
+
+async function stopChild(child: Bun.Subprocess | null): Promise<void> {
+  if (child === null) return;
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  const stopped = await Promise.race([
+    child.exited.then(() => true),
+    Bun.sleep(5000).then(() => false),
+  ]);
+  if (!stopped) {
+    child.kill("SIGKILL");
+    await child.exited;
+  }
+}
+
+function startRuntime(
+  fixture: DiscordSmokeFixture,
+  scenario: "gateway" | "bb-transfer",
+  databaseUrl: string,
+  readyPath: string,
+): Bun.Subprocess {
+  return Bun.spawn(
+    [
+      "bun",
+      "scripts/dev-discord.ts",
+      "--scenario",
+      scenario,
+      "--database-url",
+      databaseUrl,
+    ],
+    {
+      cwd: SCOUT_ROOT,
+      env: {
+        ...Bun.env,
+        SCOUT_DISCORD_SMOKE_GUILD_ID: fixture.guildId,
+        SCOUT_DISCORD_SMOKE_READY_PATH: readyPath,
+      },
+      stdin: "ignore",
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+}
+
+async function createIsolatedDatabase(runId: string): Promise<{
+  readonly prisma: SmokeDatabase;
+  readonly dbPath: string;
+  readonly dbUrl: string;
+}> {
   await ensureTestTemplate();
   sweepStaleTestDatabases();
-  const database = createTestDatabase(`discord_smoke_${runId}`);
+  return createTestDatabase(`discord_smoke_${runId}`);
+}
+
+async function loadPreflightFixture(): Promise<DiscordSmokeFixture> {
+  const fixture = await loadDiscordSmokeFixture(FIXTURE_PATH);
+  await preflightDiscordSmoke(fixture, Bun.env, {
+    fetch,
+    verifyPinchTabProfile,
+  });
+  return fixture;
+}
+
+async function prepareFreshRun(
+  scenario: "gateway" | "bb-transfer",
+): Promise<FreshSmokeRun> {
+  const runId = createRunId();
+  const manifestPath = path.join(runDirectory(runId), "manifest.json");
+  let manifest = createManifest(runId, scenario);
+  await writeDiscordSmokeManifest(manifestPath, manifest);
+  const database = await createIsolatedDatabase(runId);
   manifest = {
     ...manifest,
     databaseName: database.dbPath,
     databaseUrl: database.dbUrl,
   };
   await writeDiscordSmokeManifest(manifestPath, manifest);
+  return { database, manifest, manifestPath, runId };
+}
+
+async function closeSmokeDatabase(
+  successful: boolean,
+  database: SmokeDatabase,
+  databaseName: string,
+): Promise<void> {
+  if (successful) {
+    await dropTestDatabase(database, databaseName);
+  } else {
+    await database.$disconnect();
+  }
+}
+
+async function verifyAndCaptureTransfer(
+  database: SmokeDatabase,
+  fixture: DiscordSmokeFixture,
+  manifest: DiscordSmokeManifest,
+  manifestPath: string,
+): Promise<DiscordSmokeManifest> {
+  if (manifest.seededAccounts === null) {
+    throw new Error(`Smoke run ${manifest.runId} has no seeded accounts`);
+  }
+  if (manifest.invocationStartedAt === null) {
+    throw new Error(`Smoke run ${manifest.runId} has no invocation boundary`);
+  }
+  await verifyTransferDatabase(database, fixture, manifest.seededAccounts);
+  const publicMessageId =
+    manifest.publicMessageId ??
+    (await findReceiptMessageId(
+      fixture,
+      requireEnvironment("DISCORD_BOT_TOKEN"),
+      manifest.invocationStartedAt,
+    ));
+  const screenshotPath = await captureReceipt(
+    fixture,
+    publicMessageId,
+    runDirectory(manifest.runId),
+  );
+  const verifiedManifest = {
+    ...manifest,
+    publicMessageId,
+    verifiedAt: new Date().toISOString(),
+    screenshotPath,
+  };
+  await writeDiscordSmokeManifest(manifestPath, verifiedManifest);
+  return verifiedManifest;
+}
+
+async function runGatewaySmoke(): Promise<void> {
+  const fixture = await loadPreflightFixture();
+  const { database, manifestPath, runId, ...prepared } =
+    await prepareFreshRun("gateway");
+  let { manifest } = prepared;
 
   let runtime: Bun.Subprocess | null = null;
   let successful = false;
   try {
-    runtime = Bun.spawn(
-      [
-        "bun",
-        "scripts/dev-discord.ts",
-        "--scenario",
-        "gateway",
-        "--database-url",
-        database.dbUrl,
-      ],
-      {
-        cwd: SCOUT_ROOT,
-        env: {
-          ...Bun.env,
-          SCOUT_DISCORD_SMOKE_GUILD_ID: fixture.guildId,
-          SCOUT_DISCORD_SMOKE_READY_PATH: runtimeReadyPath,
-        },
-        stdin: "ignore",
-        stdout: "inherit",
-        stderr: "inherit",
-      },
+    const runtimeReadyPath = path.join(
+      runDirectory(runId),
+      "runtime-ready.json",
     );
-    const botToken = Bun.env["DISCORD_BOT_TOKEN"];
-    if (botToken === undefined) {
-      throw new Error("Discord smoke lost DISCORD_BOT_TOKEN after preflight");
-    }
+    runtime = startRuntime(
+      fixture,
+      "gateway",
+      database.dbUrl,
+      runtimeReadyPath,
+    );
     await waitForRuntimeReadiness(runtime, runtimeReadyPath);
     await raceRuntimeOperation(
       runtime,
       waitForDiscordCommand({
         fixture,
-        botToken,
+        botToken: requireEnvironment("DISCORD_BOT_TOKEN"),
         commandName: "help",
         guildScoped: false,
       }),
@@ -139,22 +273,118 @@ async function runGatewaySmoke(): Promise<void> {
     successful = true;
   } finally {
     await stopChild(runtime);
-    if (successful) {
-      await dropTestDatabase(database.prisma, database.dbPath);
-    } else {
-      await database.prisma.$disconnect();
-    }
+    await closeSmokeDatabase(successful, database.prisma, database.dbPath);
   }
   console.log(`Discord gateway smoke passed: ${runId}`);
+}
+
+async function runTransferSmoke(): Promise<void> {
+  const fixture = await loadPreflightFixture();
+  const { database, manifestPath, runId, ...prepared } =
+    await prepareFreshRun("bb-transfer");
+  let { manifest } = prepared;
+  const seededAccounts = await seedTransferAccounts(database.prisma, fixture);
+  manifest = {
+    ...manifest,
+    seededAccounts,
+  };
+  await writeDiscordSmokeManifest(manifestPath, manifest);
+
+  let runtime: Bun.Subprocess | null = null;
+  let successful = false;
+  try {
+    const runtimeReadyPath = path.join(
+      runDirectory(runId),
+      "runtime-ready.json",
+    );
+    runtime = startRuntime(
+      fixture,
+      "bb-transfer",
+      database.dbUrl,
+      runtimeReadyPath,
+    );
+    await waitForRuntimeReadiness(runtime, runtimeReadyPath);
+    await raceRuntimeOperation(
+      runtime,
+      waitForDiscordCommand({
+        fixture,
+        botToken: requireEnvironment("DISCORD_BOT_TOKEN"),
+        commandName: "bb",
+        subcommandName: "transfer",
+        guildScoped: true,
+        timeoutMilliseconds: 60_000,
+      }),
+      "before exposing /bb transfer",
+    );
+    assertInvocationAllowed(manifest);
+    manifest = { ...manifest, invocationStartedAt: new Date().toISOString() };
+    await writeDiscordSmokeManifest(manifestPath, manifest);
+
+    const response = await invokeTransfer(
+      fixture,
+      TOOLKIT_ENTRYPOINT,
+      WORKSPACE_ROOT,
+    );
+    manifest = {
+      ...manifest,
+      privateReplyId: response.reply?.id ?? null,
+      publicMessageId: response.publicResponse?.id ?? null,
+    };
+    await writeDiscordSmokeManifest(manifestPath, manifest);
+    assertTransferResponse(fixture, response);
+    await stopChild(runtime);
+    runtime = null;
+    manifest = await verifyAndCaptureTransfer(
+      database.prisma,
+      fixture,
+      manifest,
+      manifestPath,
+    );
+    successful = true;
+  } finally {
+    await stopChild(runtime);
+    await closeSmokeDatabase(successful, database.prisma, database.dbPath);
+  }
+  console.log(`Western Union Discord smoke passed: ${runId}`);
+}
+
+async function resumeTransferSmoke(runId: string): Promise<void> {
+  const fixture = await loadPreflightFixture();
+  const manifestPath = path.join(runDirectory(runId), "manifest.json");
+  let manifest = await loadDiscordSmokeManifest(manifestPath);
+  if (manifest.scenario !== "bb-transfer") {
+    throw new Error(`Smoke run ${runId} is not a bb-transfer run`);
+  }
+  if (
+    manifest.databaseName === null ||
+    manifest.databaseUrl === null ||
+    manifest.seededAccounts === null
+  ) {
+    throw new Error(`Smoke run ${runId} has no seeded transfer database`);
+  }
+  const databaseName = manifest.databaseName;
+  const database = connectTestDatabase(manifest.databaseUrl);
+  let successful = false;
+  try {
+    manifest = await verifyAndCaptureTransfer(
+      database,
+      fixture,
+      manifest,
+      manifestPath,
+    );
+    successful = true;
+  } finally {
+    await closeSmokeDatabase(successful, database, databaseName);
+  }
+  console.log(`Western Union Discord smoke resumed and verified: ${runId}`);
 }
 
 if (import.meta.main) {
   const args = parseDiscordSmokeArguments(Bun.argv.slice(2));
   if (args.kind === "resume") {
-    const manifest = await loadDiscordSmokeManifest(
-      path.join(runDirectory(args.runId), "manifest.json"),
-    );
-    console.log(JSON.stringify(manifest, null, 2));
+    await resumeTransferSmoke(args.runId);
+  } else if (args.scenario === "bb-transfer") {
+    await runTransferSmoke();
   } else {
     await runGatewaySmoke();
   }


### PR DESCRIPTION
## Why

Bryan Bucks needs a single, explicit user-to-user movement that is safe to test without connecting the beta bot, mutating beta data, or starting the report lake.

## What

- Add beta-only `/bb transfer` with atomic sender, recipient, and house ledger movements and correlated analytics.
- Split whole-BB spends evenly, with odd BB favoring the house, and publish a balance-free receipt with restricted mentions.
- Extend the isolated Discord smoke runner with a resumable `bb-transfer` scenario, local wallet seeding, exact database and message assertions, and real-client PinchTab capture.
- Document the command, privacy contract, feature flag, and operator workflow.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/toolkit --filter=scout-for-lol --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/docs-site --filter=@shepherdjerred/docs-wiki` — 36/36 tasks passed.
- `bunx lefthook run pre-commit` — passed.
- `bun run check-flipt-flag-inventory -- --url https://flipt.tailnet-1a49.ts.net` — reached live Flipt and reported only the intentionally unreconciled `bucks_transfers_enabled` flag.
- Live Discord smoke — not yet run. The dedicated guild still needs the private Derrej application installed, recipient joined, and the `scout-discord-smoke` PinchTab profile signed in. No beta gateway, wallet, report lake, or live Flipt state was mutated.

## Rollout notes

Live Flipt reconciliation is a separate operator-authorized mutation. This PR remains draft until the dedicated-guild receipt screenshot is captured and attached.