### PR TITLE
fix(scout-for-lol): make Tournament lobbies retry-safe

### DIFF
--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260829000000_tournament_lobby_provisioning/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260829000000_tournament_lobby_provisioning/migration.sql
@@ -1,0 +1,37 @@
+-- A durable claim is written before Tournament-V5 code creation. If the POST
+-- has an ambiguous outcome, the claim prevents an automatic second mint.
+CREATE TABLE "TournamentLobbyProvision" (
+    "id" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'PENDING',
+    "lobbyId" INTEGER,
+    "lastError" TEXT,
+    "claimedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TournamentLobbyProvision_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "TournamentLobbyProvision_lobbyId_key"
+ON "TournamentLobbyProvision"("lobbyId");
+
+CREATE INDEX "TournamentLobbyProvision_state_claimedAt_idx"
+ON "TournamentLobbyProvision"("state", "claimedAt");
+
+CREATE INDEX "TournamentLobbyProvision_requestHash_state_idx"
+ON "TournamentLobbyProvision"("requestHash", "state");
+
+-- Discord assigns a new interaction ID when a user repeats a slash command.
+-- Keep equivalent unresolved work globally unique so a retry cannot mint a
+-- second Riot credential after an ambiguous first response. COMPLETED claims
+-- are excluded so a genuinely new lobby with the same roster remains valid.
+CREATE UNIQUE INDEX "TournamentLobbyProvision_unresolved_requestHash_key"
+ON "TournamentLobbyProvision"("requestHash")
+WHERE "state" IN ('PENDING', 'AMBIGUOUS');
+
+ALTER TABLE "TournamentLobbyProvision"
+ADD CONSTRAINT "TournamentLobbyProvision_lobbyId_fkey"
+FOREIGN KEY ("lobbyId") REFERENCES "TournamentLobby"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -1480,9 +1480,36 @@ model TournamentLobby {
   expiresAt    DateTime
   updatedAt    DateTime  @updatedAt
 
+  /// The durable request claim that minted this credential. A lobby can be
+  /// created by `/lobby` or by Customs, but every path goes through the same
+  /// claim-before-Riot provisioning service.
+  provision TournamentLobbyProvision?
+
   @@index([state, expiresAt])
   @@index([serverId, state])
   @@index([matchId])
+}
+
+/// Claim for one Tournament-V5 code-creation request.
+///
+/// A timeout after the POST may mean Riot minted a credential, so any request
+/// that did not durably reach COMPLETED is intentionally not retried. The
+/// request hash also prevents an idempotency key from being reused for a
+/// different roster or lobby policy.
+model TournamentLobbyProvision {
+  id          String   @id
+  requestHash String
+  state       String   @default("PENDING")
+  lobbyId     Int?     @unique
+  lobby       TournamentLobby? @relation(fields: [lobbyId], references: [id], onDelete: Restrict)
+  lastError   String?
+  claimedAt   DateTime @default(now())
+  completedAt DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([state, claimedAt])
+  @@index([requestHash, state])
 }
 
 /// Durable handoff for work created by request/gateway code before Temporal

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/lobby.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/lobby.ts
@@ -10,25 +10,18 @@ import {
 import { prisma } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { getFlag } from "#src/configuration/flags.ts";
-import { createTournamentCodes } from "#src/league/api/tournament/client.ts";
-import {
-  toPlatformId,
-  toTournamentRegion,
-} from "#src/league/api/tournament/regions.ts";
 import {
   tournamentApiMode,
   tournamentMaxOpenLobbies,
 } from "#src/config/dynamic.ts";
-import { requireTournamentRegistration } from "#src/league/tournament/registration.ts";
 import { resolveLobbyRosters } from "#src/league/tournament/roster-resolution.ts";
 import {
-  LOBBY_ABANDON_TTL_MS,
   countOpenLobbiesForGuild,
-  createLobby,
   findLobbyByCode,
   listLobbiesForGuild,
   updateLobby,
 } from "#src/league/tournament/lobby-store.ts";
+import { provisionTournamentLobby } from "#src/league/tournament/provision-lobby.ts";
 import { describeLobby } from "#src/league/tournament/prematch-card.ts";
 import { isTerminal } from "#src/league/tournament/lifecycle.ts";
 import { tournamentLobbiesTotal } from "#src/metrics/tournament.ts";
@@ -81,67 +74,25 @@ async function executeCreate(
 
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-  const mode = tournamentApiMode();
-  const region = rosters.blue.region;
-  const tournamentRegion = toTournamentRegion(region);
-  const registration = await requireTournamentRegistration(
-    prisma,
-    mode,
-    tournamentRegion,
-  );
-
   const teamSize = Math.max(
     rosters.blue.puuids.length,
     rosters.red.puuids.length,
   );
 
-  const codes = await createTournamentCodes(
-    { mode },
-    registration.tournamentId,
-    1,
-    {
-      teamSize,
-      pickType,
-      mapType,
-      // ALL by default: if custom-lobby visibility in Spectator correlates with
-      // this at all, it maximises the chance the prematch card gets upgraded
-      // with a real loading screen. It costs nothing otherwise.
-      spectatorType: "ALL",
-      enoughPlayers: false,
-      // Riot enforces the allow-list in aggregate, not per team, so both sides
-      // go in together.
-      allowedParticipants: [...rosters.blue.puuids, ...rosters.red.puuids],
-    },
-  );
-
-  const code = codes[0];
-  if (code === undefined) {
-    await replyPrivate(interaction, "Riot did not return a tournament code.");
-    return;
-  }
-
-  await createLobby(prisma, {
-    code,
-    apiMode: mode,
-    providerId: registration.providerId,
-    tournamentId: registration.tournamentId,
-    region,
-    platformId: toPlatformId(region),
+  const mode = tournamentApiMode();
+  const lobby = await provisionTournamentLobby(prisma, {
+    requestId: `discord:${interaction.id}`,
+    mode,
     serverId,
     channelId: DiscordChannelIdSchema.parse(interaction.channelId),
     creatorDiscordId: DiscordAccountIdSchema.parse(interaction.user.id),
-    bluePuuids: [...rosters.blue.puuids],
-    redPuuids: [...rosters.red.puuids],
-    blueAliases: [...rosters.blue.aliases],
-    redAliases: [...rosters.red.aliases],
-    teamSize,
+    blue: rosters.blue,
+    red: rosters.red,
     pickType,
     mapType,
     spectatorType: "ALL",
-    lobbyName: undefined,
-    password: undefined,
-    expiresAt: new Date(Date.now() + LOBBY_ABANDON_TTL_MS),
   });
+  const code = lobby.code;
 
   tournamentLobbiesTotal.inc({ action: "created" });
   logger.info(`🏟️ Created lobby ${code} for ${serverId}`);

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -65,6 +65,7 @@ import {
   completeScoutEffect,
   recordScoutEffectFailure,
 } from "#src/temporal/effect-claims.ts";
+import { completeTournamentLobbyForMatch } from "#src/league/tournament/lobby-store.ts";
 
 const logger = createLogger("postmatch-match-history-polling");
 
@@ -313,6 +314,16 @@ export async function processMatchAndUpdatePlayers(
       postmatchMessageIds,
     });
   }
+
+  // This is the last transactional extension point before player cursors move
+  // past the match. Tournament lobbies — and linked Customs games — finalize
+  // here, after authoritative S3 ingest and post-match side effects. A failure
+  // therefore leaves the cursors in place and retries the same match.
+  await completeTournamentLobbyForMatch(
+    prisma,
+    matchId,
+    matchData.info.tournamentCode,
+  );
 
   // Mark as processed
   processedMatchIds.add(matchId);

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/lifecycle.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/lifecycle.ts
@@ -35,7 +35,7 @@ export const TournamentLobbyStateSchema = z.enum([
   "in_game",
   /** We know the match ID and have written the ActiveGame row. */
   "resolved",
-  /** The post-match report was delivered. */
+  /** Match-V5 was durably ingested and post-match processing may advance. */
   "reported",
   /** An operator cancelled the lobby. */
   "cancelled",

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/lobby-store.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/lobby-store.ts
@@ -119,7 +119,7 @@ export async function claimLobbiesToPoll(
   limit: number,
 ): Promise<TournamentLobbyRecord[]> {
   const active = TournamentLobbyStateSchema.options.filter(
-    (state) => !isTerminal(state),
+    (state) => !isTerminal(state) && state !== "resolved",
   );
   const rows = await client.tournamentLobby.findMany({
     where: { state: { in: active } },
@@ -127,6 +127,21 @@ export async function claimLobbiesToPoll(
     take: limit,
   });
   return rows.map((row) => parseLobbyRow(row));
+}
+
+/**
+ * Resolve-state lobbies wait for Match-V5, not Tournament-V5. Sweep their
+ * recovery deadline without placing them back on the Tournament API poll path.
+ */
+export async function expireResolvedLobbies(
+  client: ExtendedPrismaClient,
+  now: Date,
+): Promise<number> {
+  const result = await client.tournamentLobby.updateMany({
+    where: { state: "resolved", expiresAt: { lte: now } },
+    data: { state: "expired" },
+  });
+  return result.count;
 }
 
 export async function countOpenLobbiesForGuild(
@@ -192,37 +207,65 @@ export type CreateLobbyInput = {
   expiresAt: Date;
 };
 
+export function lobbyCreateData(input: CreateLobbyInput) {
+  return {
+    code: input.code,
+    apiMode: input.apiMode,
+    providerId: input.providerId,
+    tournamentId: input.tournamentId,
+    region: input.region,
+    platformId: input.platformId,
+    serverId: input.serverId,
+    channelId: input.channelId,
+    creatorDiscordId: input.creatorDiscordId,
+    bluePuuids: JSON.stringify(input.bluePuuids),
+    redPuuids: JSON.stringify(input.redPuuids),
+    blueAliases: JSON.stringify(input.blueAliases),
+    redAliases: JSON.stringify(input.redAliases),
+    teamSize: input.teamSize,
+    pickType: input.pickType,
+    mapType: input.mapType,
+    spectatorType: input.spectatorType,
+    lobbyName: input.lobbyName ?? null,
+    password: input.password ?? null,
+    state: "created",
+    joinedPuuids: "[]",
+    expiresAt: input.expiresAt,
+  };
+}
+
 export async function createLobby(
   client: ExtendedPrismaClient,
   input: CreateLobbyInput,
 ): Promise<TournamentLobbyRecord> {
   const row = await client.tournamentLobby.create({
-    data: {
-      code: input.code,
-      apiMode: input.apiMode,
-      providerId: input.providerId,
-      tournamentId: input.tournamentId,
-      region: input.region,
-      platformId: input.platformId,
-      serverId: input.serverId,
-      channelId: input.channelId,
-      creatorDiscordId: input.creatorDiscordId,
-      bluePuuids: JSON.stringify(input.bluePuuids),
-      redPuuids: JSON.stringify(input.redPuuids),
-      blueAliases: JSON.stringify(input.blueAliases),
-      redAliases: JSON.stringify(input.redAliases),
-      teamSize: input.teamSize,
-      pickType: input.pickType,
-      mapType: input.mapType,
-      spectatorType: input.spectatorType,
-      lobbyName: input.lobbyName ?? null,
-      password: input.password ?? null,
-      state: "created",
-      joinedPuuids: "[]",
-      expiresAt: input.expiresAt,
-    },
+    data: lobbyCreateData(input),
   });
   return parseLobbyRow(row);
+}
+
+/**
+ * Marks the Tournament handoff complete at the same boundary that allows
+ * player cursors to advance. Match-V5 plus the authoritative S3 write is the
+ * result authority; Discord delivery is deliberately not part of this state.
+ */
+export async function completeTournamentLobbyForMatch(
+  client: ExtendedPrismaClient,
+  matchId: string,
+  tournamentCode: string | undefined,
+): Promise<number> {
+  const identity =
+    tournamentCode === undefined || tournamentCode.length === 0
+      ? { matchId }
+      : { code: tournamentCode };
+  const result = await client.tournamentLobby.updateMany({
+    where: { ...identity, state: { not: "reported" } },
+    data: { matchId, state: "reported" },
+  });
+  if (result.count > 1) {
+    throw new Error(`Multiple Tournament lobbies resolved to match ${matchId}`);
+  }
+  return result.count;
 }
 
 export type LobbyUpdate = {

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/poller.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/poller.integration.test.ts
@@ -13,6 +13,7 @@ import {
 const { prisma: testPrisma } = createTestDatabase("tournament-poller");
 
 let lobbyEvents: RawLobbyEvent[] | undefined = [];
+let lobbyEventCalls = 0;
 let prematchSends = 0;
 let activeGameUpserts: string[] = [];
 
@@ -22,7 +23,10 @@ vi.doMock("#src/database/index.ts", async (importOriginal) => ({
 }));
 
 vi.doMock("#src/league/api/tournament/client.ts", () => ({
-  getLobbyEvents: () => Promise.resolve(lobbyEvents),
+  getLobbyEvents: () => {
+    lobbyEventCalls += 1;
+    return Promise.resolve(lobbyEvents);
+  },
   getGamesByCode: () =>
     Promise.resolve([
       {
@@ -97,6 +101,7 @@ async function seedLobby() {
 beforeEach(async () => {
   await deleteIfExists(() => testPrisma.tournamentLobby.deleteMany());
   lobbyEvents = [];
+  lobbyEventCalls = 0;
   prematchSends = 0;
   activeGameUpserts = [];
 });
@@ -202,5 +207,37 @@ describe("checkTournamentLobbies", () => {
     expect(prematchSends).toBe(0);
     const untouched = await findLobbyByCode(testPrisma, "TEST-CODE");
     expect(untouched?.state).toBe("cancelled");
+  });
+
+  test("a resolved lobby waits for Match-V5 without another Tournament call", async () => {
+    const lobby = await seedLobby();
+    await testPrisma.tournamentLobby.update({
+      where: { id: lobby.id },
+      data: { state: "resolved", matchId: "NA1_5421167767" },
+    });
+
+    await checkTournamentLobbies();
+
+    expect(lobbyEventCalls).toBe(0);
+    const waiting = await findLobbyByCode(testPrisma, "TEST-CODE");
+    expect(waiting?.state).toBe("resolved");
+  });
+
+  test("an expired resolved lobby is swept without a Tournament call", async () => {
+    const lobby = await seedLobby();
+    await testPrisma.tournamentLobby.update({
+      where: { id: lobby.id },
+      data: {
+        state: "resolved",
+        matchId: "NA1_5421167767",
+        expiresAt: new Date(Date.now() - 1),
+      },
+    });
+
+    await checkTournamentLobbies();
+
+    expect(lobbyEventCalls).toBe(0);
+    const expired = await findLobbyByCode(testPrisma, "TEST-CODE");
+    expect(expired?.state).toBe("expired");
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/poller.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/poller.ts
@@ -21,6 +21,7 @@ import {
 import {
   claimLobbiesToPoll,
   countLobbiesByState,
+  expireResolvedLobbies,
   updateLobby,
   type TournamentLobbyRecord,
 } from "#src/league/tournament/lobby-store.ts";
@@ -245,6 +246,11 @@ export async function checkTournamentLobbies(): Promise<void> {
   try {
     const mode = tournamentApiMode();
     tournamentApiModeGauge.set(mode === "live" ? 1 : 0);
+
+    const expiredResolved = await expireResolvedLobbies(prisma, new Date());
+    if (expiredResolved > 0) {
+      tournamentLobbiesTotal.inc({ action: "expired" }, expiredResolved);
+    }
 
     const lobbies = await claimLobbiesToPoll(
       prisma,

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/provision-lobby.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/provision-lobby.integration.test.ts
@@ -1,0 +1,229 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  RegionSchema,
+} from "@scout-for-lol/data/index.ts";
+import type { createTournamentCodes } from "#src/league/api/tournament/client.ts";
+import {
+  createTestDatabase,
+  deleteIfExists,
+} from "#src/testing/test-database.ts";
+import {
+  completeTournamentLobbyForMatch,
+  updateLobby,
+} from "#src/league/tournament/lobby-store.ts";
+import {
+  PROVISION_PENDING_TTL_MS,
+  provisionTournamentLobby,
+  type ProvisionTournamentLobbyInput,
+} from "#src/league/tournament/provision-lobby.ts";
+
+const { prisma: testPrisma } = createTestDatabase("tournament-provisioning");
+const NOW = new Date("2026-08-29T12:00:00.000Z");
+let codeRequests = 0;
+
+const createTestCode: typeof createTournamentCodes = () => {
+  codeRequests += 1;
+  return Promise.resolve(["TEST-CODE"]);
+};
+
+const failAfterSend: typeof createTournamentCodes = () => {
+  codeRequests += 1;
+  return Promise.reject(new Error("connection reset after send"));
+};
+
+const stopFirstProcess: typeof createTournamentCodes = () =>
+  Promise.reject(new Error("first process stopped"));
+
+const createSecondCode: typeof createTournamentCodes = () => {
+  codeRequests += 1;
+  return Promise.resolve(["SECOND-CODE"]);
+};
+
+const BASE_INPUT: ProvisionTournamentLobbyInput = {
+  requestId: "discord:interaction-1",
+  mode: "live",
+  serverId: DiscordGuildIdSchema.parse("1337623164146155593"),
+  channelId: DiscordChannelIdSchema.parse("1337623164146155594"),
+  creatorDiscordId: DiscordAccountIdSchema.parse("160509172704739328"),
+  blue: {
+    aliases: ["Blue One"],
+    puuids: ["blue-puuid"],
+    region: RegionSchema.parse("AMERICA_NORTH"),
+  },
+  red: {
+    aliases: ["Red One"],
+    puuids: ["red-puuid"],
+    region: RegionSchema.parse("AMERICA_NORTH"),
+  },
+  pickType: "TOURNAMENT_DRAFT",
+  mapType: "SUMMONERS_RIFT",
+  spectatorType: "ALL",
+};
+
+async function seedRegistration(): Promise<void> {
+  await testPrisma.tournamentRegistration.create({
+    data: {
+      apiMode: "live",
+      tournamentRegion: "NA",
+      providerId: 10,
+      tournamentId: 20,
+      callbackUrl: "https://example.com/callback",
+      name: "test",
+    },
+  });
+}
+
+beforeEach(async () => {
+  codeRequests = 0;
+  await deleteIfExists(() => testPrisma.tournamentLobbyProvision.deleteMany());
+  await deleteIfExists(() => testPrisma.tournamentLobby.deleteMany());
+  await deleteIfExists(() => testPrisma.tournamentRegistration.deleteMany());
+  await seedRegistration();
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+describe("provisionTournamentLobby", () => {
+  test("returns the durable lobby on an idempotent completed retry", async () => {
+    const dependencies = { createCodes: createTestCode, now: () => NOW };
+
+    const first = await provisionTournamentLobby(
+      testPrisma,
+      BASE_INPUT,
+      dependencies,
+    );
+    const retried = await provisionTournamentLobby(
+      testPrisma,
+      BASE_INPUT,
+      dependencies,
+    );
+
+    expect(retried.id).toBe(first.id);
+    expect(retried.code).toBe("TEST-CODE");
+    expect(codeRequests).toBe(1);
+  });
+
+  test("refuses to reuse an idempotency key for different inputs", async () => {
+    const dependencies = { createCodes: createTestCode, now: () => NOW };
+    await provisionTournamentLobby(testPrisma, BASE_INPUT, dependencies);
+
+    await expect(
+      provisionTournamentLobby(
+        testPrisma,
+        { ...BASE_INPUT, mapType: "HOWLING_ABYSS" },
+        dependencies,
+      ),
+    ).rejects.toThrow("reused with different lobby inputs");
+  });
+
+  test("never retries an ambiguous Riot response", async () => {
+    const dependencies = { createCodes: failAfterSend, now: () => NOW };
+
+    await expect(
+      provisionTournamentLobby(testPrisma, BASE_INPUT, dependencies),
+    ).rejects.toThrow("connection reset after send");
+    await expect(
+      provisionTournamentLobby(testPrisma, BASE_INPUT, dependencies),
+    ).rejects.toThrow("ambiguous Riot outcome");
+
+    expect(codeRequests).toBe(1);
+    await expect(
+      testPrisma.tournamentLobbyProvision.findUniqueOrThrow({
+        where: { id: BASE_INPUT.requestId },
+      }),
+    ).resolves.toMatchObject({ state: "AMBIGUOUS" });
+  });
+
+  test("blocks an equivalent slash-command retry with a new interaction ID", async () => {
+    const dependencies = { createCodes: failAfterSend, now: () => NOW };
+
+    await expect(
+      provisionTournamentLobby(testPrisma, BASE_INPUT, dependencies),
+    ).rejects.toThrow("connection reset after send");
+    await expect(
+      provisionTournamentLobby(
+        testPrisma,
+        { ...BASE_INPUT, requestId: "discord:interaction-2" },
+        dependencies,
+      ),
+    ).rejects.toThrow("ambiguous Riot outcome");
+
+    expect(codeRequests).toBe(1);
+  });
+
+  test("turns a stale pending claim into an ambiguous recovery case", async () => {
+    await expect(
+      provisionTournamentLobby(testPrisma, BASE_INPUT, {
+        createCodes: stopFirstProcess,
+        now: () => new Date(NOW.getTime() - PROVISION_PENDING_TTL_MS - 2),
+      }),
+    ).rejects.toThrow("first process stopped");
+    await testPrisma.tournamentLobbyProvision.update({
+      where: { id: BASE_INPUT.requestId },
+      data: {
+        state: "PENDING",
+        claimedAt: new Date(NOW.getTime() - PROVISION_PENDING_TTL_MS - 1),
+      },
+    });
+
+    await expect(
+      provisionTournamentLobby(testPrisma, BASE_INPUT, {
+        createCodes: createSecondCode,
+        now: () => NOW,
+      }),
+    ).rejects.toThrow("expired with an ambiguous Riot outcome");
+    expect(codeRequests).toBe(0);
+  });
+
+  test("marks a resolved lobby reported idempotently", async () => {
+    const lobby = await provisionTournamentLobby(testPrisma, BASE_INPUT, {
+      createCodes: createTestCode,
+      now: () => NOW,
+    });
+    await updateLobby(testPrisma, lobby.id, {
+      state: "resolved",
+      matchId: "NA1_123",
+    });
+
+    await expect(
+      completeTournamentLobbyForMatch(testPrisma, "NA1_123", "TEST-CODE"),
+    ).resolves.toBe(1);
+    await expect(
+      completeTournamentLobbyForMatch(testPrisma, "NA1_123", "TEST-CODE"),
+    ).resolves.toBe(0);
+  });
+
+  test("reports a lobby when Match-V5 wins the linkage race", async () => {
+    const lobby = await provisionTournamentLobby(testPrisma, BASE_INPUT, {
+      createCodes: createTestCode,
+      now: () => NOW,
+    });
+
+    await expect(
+      completeTournamentLobbyForMatch(testPrisma, "NA1_456", lobby.code),
+    ).resolves.toBe(1);
+    await expect(
+      testPrisma.tournamentLobby.findUniqueOrThrow({ where: { id: lobby.id } }),
+    ).resolves.toMatchObject({ matchId: "NA1_456", state: "reported" });
+  });
+
+  test("recovers an expired resolved lobby when Match-V5 arrives", async () => {
+    const lobby = await provisionTournamentLobby(testPrisma, BASE_INPUT, {
+      createCodes: createTestCode,
+      now: () => NOW,
+    });
+    await updateLobby(testPrisma, lobby.id, { state: "expired" });
+
+    await expect(
+      completeTournamentLobbyForMatch(testPrisma, "NA1_789", lobby.code),
+    ).resolves.toBe(1);
+    await expect(
+      testPrisma.tournamentLobby.findUniqueOrThrow({ where: { id: lobby.id } }),
+    ).resolves.toMatchObject({ matchId: "NA1_789", state: "reported" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tournament/provision-lobby.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tournament/provision-lobby.ts
@@ -1,0 +1,265 @@
+import { z } from "zod";
+import type {
+  DiscordAccountId,
+  DiscordChannelId,
+  DiscordGuildId,
+  RawTournamentCodeParameters,
+  TournamentMapType,
+  TournamentPickType,
+  TournamentSpectatorType,
+} from "@scout-for-lol/data/index.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import type { TournamentApiMode } from "#src/configuration/tournament-mode.ts";
+import { createTournamentCodes } from "#src/league/api/tournament/client.ts";
+import {
+  toPlatformId,
+  toTournamentRegion,
+} from "#src/league/api/tournament/regions.ts";
+import { requireTournamentRegistration } from "#src/league/tournament/registration.ts";
+import type { ResolvedSide } from "#src/league/tournament/roster-resolution.ts";
+import {
+  LOBBY_ABANDON_TTL_MS,
+  lobbyCreateData,
+  parseLobbyRow,
+  type TournamentLobbyRecord,
+} from "#src/league/tournament/lobby-store.ts";
+
+const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
+const ProvisionStateSchema = z.enum(["PENDING", "AMBIGUOUS", "COMPLETED"]);
+
+/**
+ * A PENDING claim this old belongs to a process that can no longer prove
+ * whether Riot accepted its POST. It becomes AMBIGUOUS instead of being
+ * leased to a retry, because a second POST could mint a second credential.
+ */
+export const PROVISION_PENDING_TTL_MS = 5 * 60 * 1000;
+
+export type ProvisionTournamentLobbyInput = {
+  readonly requestId: string;
+  readonly mode: TournamentApiMode;
+  readonly serverId: DiscordGuildId;
+  readonly channelId: DiscordChannelId;
+  readonly creatorDiscordId: DiscordAccountId;
+  readonly blue: ResolvedSide;
+  readonly red: ResolvedSide;
+  readonly pickType: TournamentPickType;
+  readonly mapType: TournamentMapType;
+  readonly spectatorType: TournamentSpectatorType;
+  readonly lobbyName?: string;
+  readonly password?: string;
+};
+
+type ProvisionDependencies = {
+  readonly createCodes: typeof createTournamentCodes;
+  readonly now: () => Date;
+};
+
+const DEFAULT_DEPENDENCIES: ProvisionDependencies = {
+  createCodes: createTournamentCodes,
+  now: () => new Date(),
+};
+
+function requestHash(input: ProvisionTournamentLobbyInput): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(
+    JSON.stringify({
+      mode: input.mode,
+      serverId: input.serverId,
+      channelId: input.channelId,
+      creatorDiscordId: input.creatorDiscordId,
+      blue: input.blue,
+      red: input.red,
+      pickType: input.pickType,
+      mapType: input.mapType,
+      spectatorType: input.spectatorType,
+      lobbyName: input.lobbyName,
+      password: input.password,
+    }),
+  );
+  return hasher.digest("hex");
+}
+
+async function markAmbiguous(
+  client: ExtendedPrismaClient,
+  requestId: string,
+  error: unknown,
+): Promise<void> {
+  await client.tournamentLobbyProvision.updateMany({
+    where: { id: requestId, state: "PENDING" },
+    data: {
+      state: "AMBIGUOUS",
+      lastError: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
+async function claimProvision(
+  client: ExtendedPrismaClient,
+  input: ProvisionTournamentLobbyInput,
+  hash: string,
+  now: Date,
+): Promise<TournamentLobbyRecord | undefined> {
+  try {
+    await client.tournamentLobbyProvision.create({
+      data: { id: input.requestId, requestHash: hash, claimedAt: now },
+    });
+    return undefined;
+  } catch (error) {
+    if (!UniqueViolationSchema.safeParse(error).success) throw error;
+  }
+
+  const sameRequest = await client.tournamentLobbyProvision.findUnique({
+    where: { id: input.requestId },
+    include: { lobby: true },
+  });
+  const existing =
+    sameRequest ??
+    (await client.tournamentLobbyProvision.findFirstOrThrow({
+      where: {
+        requestHash: hash,
+        state: { in: ["PENDING", "AMBIGUOUS"] },
+      },
+      include: { lobby: true },
+    }));
+  if (existing.requestHash !== hash) {
+    throw new Error(
+      `Tournament provisioning request ${input.requestId} was reused with different lobby inputs`,
+    );
+  }
+
+  const state = ProvisionStateSchema.parse(existing.state);
+  if (state === "COMPLETED") {
+    if (existing.lobby === null) {
+      throw new Error(
+        `Completed tournament provisioning request ${input.requestId} has no lobby`,
+      );
+    }
+    return parseLobbyRow(existing.lobby);
+  }
+  if (state === "AMBIGUOUS") {
+    throw new Error(
+      `Equivalent tournament provisioning request ${existing.id} has an ambiguous Riot outcome and requires operator recovery`,
+    );
+  }
+
+  const ageMs = now.getTime() - existing.claimedAt.getTime();
+  if (ageMs <= PROVISION_PENDING_TTL_MS) {
+    throw new Error(
+      `Equivalent tournament provisioning request ${existing.id} is already in progress`,
+    );
+  }
+
+  await markAmbiguous(
+    client,
+    existing.id,
+    new Error("Provisioning process ended before recording Riot's response"),
+  );
+  throw new Error(
+    `Equivalent tournament provisioning request ${existing.id} expired with an ambiguous Riot outcome and requires operator recovery`,
+  );
+}
+
+/**
+ * The single code-provisioning path for `/lobby` and Customs.
+ *
+ * The registration lookup is read-only and happens before the durable claim.
+ * Everything after the claim is ambiguity-sensitive: no failure path makes a
+ * second Tournament-V5 request for the same operation.
+ */
+export async function provisionTournamentLobby(
+  client: ExtendedPrismaClient,
+  input: ProvisionTournamentLobbyInput,
+  dependencies: ProvisionDependencies = DEFAULT_DEPENDENCIES,
+): Promise<TournamentLobbyRecord> {
+  if (input.blue.region !== input.red.region) {
+    throw new Error("Tournament lobby teams must use the same Riot region");
+  }
+
+  const tournamentRegion = toTournamentRegion(input.blue.region);
+  const registration = await requireTournamentRegistration(
+    client,
+    input.mode,
+    tournamentRegion,
+  );
+  const hash = requestHash(input);
+  const existing = await claimProvision(
+    client,
+    input,
+    hash,
+    dependencies.now(),
+  );
+  if (existing !== undefined) return existing;
+
+  const teamSize = Math.max(input.blue.puuids.length, input.red.puuids.length);
+  const parameters: RawTournamentCodeParameters = {
+    teamSize,
+    pickType: input.pickType,
+    mapType: input.mapType,
+    spectatorType: input.spectatorType,
+    enoughPlayers: false,
+    allowedParticipants: [...input.blue.puuids, ...input.red.puuids],
+  };
+
+  let code: string;
+  try {
+    const codes = await dependencies.createCodes(
+      { mode: input.mode },
+      registration.tournamentId,
+      1,
+      parameters,
+    );
+    const returnedCode = codes[0];
+    if (returnedCode === undefined) {
+      throw new Error("Riot returned no tournament code");
+    }
+    code = returnedCode;
+  } catch (error) {
+    await markAmbiguous(client, input.requestId, error);
+    throw error;
+  }
+
+  try {
+    const row = await client.$transaction(async (transaction) => {
+      const lobby = await transaction.tournamentLobby.create({
+        data: lobbyCreateData({
+          code,
+          apiMode: input.mode,
+          providerId: registration.providerId,
+          tournamentId: registration.tournamentId,
+          region: input.blue.region,
+          platformId: toPlatformId(input.blue.region),
+          serverId: input.serverId,
+          channelId: input.channelId,
+          creatorDiscordId: input.creatorDiscordId,
+          bluePuuids: [...input.blue.puuids],
+          redPuuids: [...input.red.puuids],
+          blueAliases: [...input.blue.aliases],
+          redAliases: [...input.red.aliases],
+          teamSize,
+          pickType: input.pickType,
+          mapType: input.mapType,
+          spectatorType: input.spectatorType,
+          lobbyName: input.lobbyName,
+          password: input.password,
+          expiresAt: new Date(
+            dependencies.now().getTime() + LOBBY_ABANDON_TTL_MS,
+          ),
+        }),
+      });
+      await transaction.tournamentLobbyProvision.update({
+        where: { id: input.requestId },
+        data: {
+          state: "COMPLETED",
+          lobbyId: lobby.id,
+          completedAt: dependencies.now(),
+          lastError: null,
+        },
+      });
+      return lobby;
+    });
+    return parseLobbyRow(row);
+  } catch (error) {
+    await markAmbiguous(client, input.requestId, error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Why

Custom nights and `/lobby create` need one durable Tournament-V5 provisioning path. The existing command could retry an ambiguous Riot response by requesting another code, and resolved lobbies continued polling while Match-V5 ingestion had not yet advanced player cursors.

## What

- extracts lobby creation into a reusable service with durable provisioning claims
- makes ambiguous Riot responses recoverable without silently minting a second code
- stops resolved lobbies from repeated Tournament-V5 polling
- marks lobbies reported only after authoritative S3/Match-V5 post-match processing, before cursor advancement

## Verification

- focused backend Tournament and post-match tests
- backend typecheck and lint
- `bunx lefthook run pre-commit`

No live Riot Tournament calls were made. This is stack 1 of 4.