### PR TITLE
feat(scout-for-lol): add the PostgreSQL custom-night domain

### DIFF
--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -211,6 +211,32 @@
       "thresholdRollouts": []
     },
     {
+      "key": "custom_nights_enabled",
+      "owner": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable the beta-only Scout custom-night Activity.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [
+        {
+          "segmentKey": "scout-guild-1337623164146155593",
+          "segmentOperator": "OR_SEGMENT_OPERATOR",
+          "matchType": "ALL_SEGMENT_MATCH_TYPE",
+          "constraints": [
+            {
+              "type": "STRING_CONSTRAINT_COMPARISON_TYPE",
+              "property": "server",
+              "operator": "eq",
+              "value": "1337623164146155593"
+            }
+          ],
+          "result": true
+        }
+      ],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
       "key": "debug",
       "owner": "scout",
       "source": "scout-policy",

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260829010000_custom_nights/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260829010000_custom_nights/migration.sql
@@ -1,0 +1,150 @@
+CREATE TABLE "CustomNight" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "guildName" TEXT NOT NULL,
+    "launchChannelId" TEXT NOT NULL,
+    "voiceLobbyChannelId" TEXT NOT NULL,
+    "hostDiscordId" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "revision" INTEGER NOT NULL DEFAULT 0,
+    "recruitmentMessageId" TEXT,
+    "teamAVoiceChannelId" TEXT,
+    "teamBVoiceChannelId" TEXT,
+    "lastActivityAt" TIMESTAMP(3) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "endedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CustomNight_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CustomActiveNight" (
+    "guildId" TEXT NOT NULL,
+    "nightId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CustomActiveNight_pkey" PRIMARY KEY ("guildId")
+);
+
+CREATE TABLE "CustomNightCohost" (
+    "nightId" TEXT NOT NULL,
+    "discordId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CustomNightCohost_pkey" PRIMARY KEY ("nightId", "discordId")
+);
+
+CREATE TABLE "CustomConsent" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "discordId" TEXT NOT NULL,
+    "disclosureVersion" TEXT NOT NULL,
+    "acceptedAt" TIMESTAMP(3) NOT NULL,
+    "anonymizedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CustomConsent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CustomNightParticipant" (
+    "id" TEXT NOT NULL,
+    "nightId" TEXT NOT NULL,
+    "discordId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "avatarUrl" TEXT,
+    "role" TEXT NOT NULL,
+    "availability" TEXT NOT NULL,
+    "readyAt" TIMESTAMP(3),
+    "awayUntil" TIMESTAMP(3),
+    "held" BOOLEAN NOT NULL DEFAULT false,
+    "consentedAt" TIMESTAMP(3) NOT NULL,
+    "playerId" INTEGER,
+    "playerAlias" TEXT,
+    "selectedAccountId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CustomNightParticipant_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CustomGame" (
+    "id" TEXT NOT NULL,
+    "nightId" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "state" TEXT NOT NULL,
+    "rosterMode" TEXT NOT NULL,
+    "map" TEXT NOT NULL,
+    "pickMode" TEXT NOT NULL,
+    "activeCaptain" TEXT,
+    "tournamentLobbyId" INTEGER,
+    "voiceState" TEXT NOT NULL DEFAULT 'IDLE',
+    "voiceReady" BOOLEAN NOT NULL DEFAULT false,
+    "voiceOverride" BOOLEAN NOT NULL DEFAULT false,
+    "voiceError" TEXT,
+    "winner" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CustomGame_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CustomGameParticipant" (
+    "id" TEXT NOT NULL,
+    "gameId" TEXT NOT NULL,
+    "discordId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "playerId" INTEGER NOT NULL,
+    "playerAlias" TEXT NOT NULL,
+    "accountId" INTEGER NOT NULL,
+    "puuid" TEXT NOT NULL,
+    "riotGameName" TEXT,
+    "riotTagLine" TEXT,
+    "rosterOrder" INTEGER NOT NULL,
+    "benchOrder" INTEGER,
+    "team" TEXT,
+    "side" TEXT,
+    "captain" BOOLEAN NOT NULL DEFAULT false,
+    "pickOrder" INTEGER,
+    "championId" INTEGER,
+    "won" BOOLEAN,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CustomGameParticipant_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CustomAuditEvent" (
+    "id" TEXT NOT NULL,
+    "nightId" TEXT NOT NULL,
+    "gameId" TEXT,
+    "revision" INTEGER NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'ACTIVITY',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "CustomAuditEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "CustomActiveNight_nightId_key" ON "CustomActiveNight"("nightId");
+CREATE INDEX "CustomNight_guildId_createdAt_idx" ON "CustomNight"("guildId", "createdAt");
+CREATE INDEX "CustomNight_state_expiresAt_idx" ON "CustomNight"("state", "expiresAt");
+CREATE INDEX "CustomConsent_discordId_acceptedAt_idx" ON "CustomConsent"("discordId", "acceptedAt");
+CREATE UNIQUE INDEX "CustomConsent_guildId_discordId_disclosureVersion_key" ON "CustomConsent"("guildId", "discordId", "disclosureVersion");
+CREATE INDEX "CustomNightParticipant_nightId_availability_readyAt_idx" ON "CustomNightParticipant"("nightId", "availability", "readyAt");
+CREATE UNIQUE INDEX "CustomNightParticipant_nightId_discordId_key" ON "CustomNightParticipant"("nightId", "discordId");
+CREATE UNIQUE INDEX "CustomGame_tournamentLobbyId_key" ON "CustomGame"("tournamentLobbyId");
+CREATE UNIQUE INDEX "CustomGame_nightId_sequence_key" ON "CustomGame"("nightId", "sequence");
+CREATE INDEX "CustomGame_nightId_state_idx" ON "CustomGame"("nightId", "state");
+CREATE INDEX "CustomGame_voiceState_updatedAt_idx" ON "CustomGame"("voiceState", "updatedAt");
+CREATE UNIQUE INDEX "CustomGameParticipant_gameId_discordId_key" ON "CustomGameParticipant"("gameId", "discordId");
+CREATE INDEX "CustomGameParticipant_gameId_team_pickOrder_idx" ON "CustomGameParticipant"("gameId", "team", "pickOrder");
+CREATE INDEX "CustomGameParticipant_puuid_idx" ON "CustomGameParticipant"("puuid");
+CREATE INDEX "CustomAuditEvent_nightId_revision_idx" ON "CustomAuditEvent"("nightId", "revision");
+CREATE INDEX "CustomAuditEvent_gameId_createdAt_idx" ON "CustomAuditEvent"("gameId", "createdAt");
+CREATE INDEX "CustomAuditEvent_actorId_createdAt_idx" ON "CustomAuditEvent"("actorId", "createdAt");
+
+ALTER TABLE "CustomActiveNight" ADD CONSTRAINT "CustomActiveNight_nightId_fkey" FOREIGN KEY ("nightId") REFERENCES "CustomNight"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "CustomNightCohost" ADD CONSTRAINT "CustomNightCohost_nightId_fkey" FOREIGN KEY ("nightId") REFERENCES "CustomNight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CustomNightParticipant" ADD CONSTRAINT "CustomNightParticipant_nightId_fkey" FOREIGN KEY ("nightId") REFERENCES "CustomNight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CustomGame" ADD CONSTRAINT "CustomGame_nightId_fkey" FOREIGN KEY ("nightId") REFERENCES "CustomNight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CustomGame" ADD CONSTRAINT "CustomGame_tournamentLobbyId_fkey" FOREIGN KEY ("tournamentLobbyId") REFERENCES "TournamentLobby"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "CustomGameParticipant" ADD CONSTRAINT "CustomGameParticipant_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "CustomGame"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CustomAuditEvent" ADD CONSTRAINT "CustomAuditEvent_nightId_fkey" FOREIGN KEY ("nightId") REFERENCES "CustomNight"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "CustomAuditEvent" ADD CONSTRAINT "CustomAuditEvent_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "CustomGame"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -152,13 +152,13 @@ model InitialMatchHistoryImport {
 // Current rank is not a per-match observation. Keeping it separate prevents
 // imported games from fabricating historical LP deltas.
 model CurrentRankSnapshot {
-  puuid         String   @id
-  soloRank      String?
-  flexRank      String?
-  ranked5sRank  String?
-  fetchedAt     DateTime
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  puuid        String   @id
+  soloRank     String?
+  flexRank     String?
+  ranked5sRank String?
+  fetchedAt    DateTime
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 }
 
 model Report {
@@ -227,14 +227,14 @@ model ReportRun {
   querySnapshot         String?
   visualizationS3Key    String?
   visualizationByteSize Int?
-  deliveryState         String                  @default("NOT_REQUESTED")
+  deliveryState         String    @default("NOT_REQUESTED")
   // Snapshot the destination selected for this occurrence. Report edits must
   // not redirect an already-rendered delivery during replay/reconciliation.
   deliveryChannelId     String?
   deliveryServerId      String?
   deliveryError         String?
   deliveredAt           DateTime?
-  temporalWorkflowRunId String?                 @unique
+  temporalWorkflowRunId String?   @unique
   createdAt             DateTime  @default(now())
 
   report Report @relation(fields: [reportId], references: [id], onDelete: Cascade)
@@ -844,14 +844,14 @@ model BucksAccount {
 // resolve to both settings enabled so adding this table preserves the existing
 // beta behavior for users who have not visited `/bb notifications` yet.
 model BucksNotificationPreference {
-  id                        Int      @id @default(autoincrement())
+  id                        Int       @id @default(autoincrement())
   serverId                  String
   discordId                 String
-  ownBetSettlementDms       Boolean  @default(true)
-  betsOnPlayerSettlementDms Boolean  @default(true)
+  ownBetSettlementDms       Boolean   @default(true)
+  betsOnPlayerSettlementDms Boolean   @default(true)
   settlementDmHintShownAt   DateTime?
-  createdAt                 DateTime @default(now())
-  updatedAt                 DateTime @updatedAt
+  createdAt                 DateTime  @default(now())
+  updatedAt                 DateTime  @updatedAt
 
   @@unique([serverId, discordId])
 }
@@ -927,11 +927,11 @@ model BucksLedgerEntry {
 // Created atomically with each live ledger entry. Temporal consumes the
 // committed ledger row after the transaction and sends the PostHog event.
 model BucksAnalyticsLedgerOutbox {
-  id            Int             @id @default(autoincrement())
-  ledgerEntryId Int             @unique
+  id            Int              @id @default(autoincrement())
+  ledgerEntryId Int              @unique
   ledgerEntry   BucksLedgerEntry @relation(fields: [ledgerEntryId], references: [id], onDelete: Cascade)
-  eventId       String          @unique
-  createdAt     DateTime        @default(now())
+  eventId       String           @unique
+  createdAt     DateTime         @default(now())
 
   @@index([createdAt])
 }
@@ -1511,7 +1511,8 @@ model TournamentLobby {
   /// The durable request claim that minted this credential. A lobby can be
   /// created by `/lobby` or by Customs, but every path goes through the same
   /// claim-before-Riot provisioning service.
-  provision TournamentLobbyProvision?
+  provision  TournamentLobbyProvision?
+  customGame CustomGame?
 
   @@index([state, expiresAt])
   @@index([serverId, state])
@@ -1525,19 +1526,188 @@ model TournamentLobby {
 /// request hash also prevents an idempotency key from being reused for a
 /// different roster or lobby policy.
 model TournamentLobbyProvision {
-  id          String   @id
+  id          String           @id
   requestHash String
-  state       String   @default("PENDING")
-  lobbyId     Int?     @unique
+  state       String           @default("PENDING")
+  lobbyId     Int?             @unique
   lobby       TournamentLobby? @relation(fields: [lobbyId], references: [id], onDelete: Restrict)
   lastError   String?
-  claimedAt   DateTime @default(now())
+  claimedAt   DateTime         @default(now())
   completedAt DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
 
   @@index([state, claimedAt])
   @@index([requestHash, state])
+}
+
+// =============================================================================
+// Scout Customs — beta-only, guild-scoped custom-game nights
+// =============================================================================
+
+/// A separate pointer makes the one-active-night constraint a PostgreSQL
+/// invariant while ended nights remain immutable history.
+model CustomActiveNight {
+  guildId   String      @id
+  nightId   String      @unique
+  night     CustomNight @relation(fields: [nightId], references: [id], onDelete: Restrict)
+  createdAt DateTime    @default(now())
+}
+
+model CustomNight {
+  id                   String    @id @default(uuid())
+  guildId              String
+  guildName            String
+  launchChannelId      String
+  voiceLobbyChannelId  String
+  hostDiscordId        String
+  state                String
+  revision             Int       @default(0)
+  recruitmentMessageId String?
+  teamAVoiceChannelId  String?
+  teamBVoiceChannelId  String?
+  lastActivityAt       DateTime
+  expiresAt            DateTime
+  endedAt              DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
+
+  activePointer CustomActiveNight?
+  cohosts       CustomNightCohost[]
+  participants  CustomNightParticipant[]
+  games         CustomGame[]
+  auditEvents   CustomAuditEvent[]
+
+  @@index([guildId, createdAt])
+  @@index([state, expiresAt])
+}
+
+model CustomNightCohost {
+  nightId   String
+  discordId String
+  createdAt DateTime    @default(now())
+  night     CustomNight @relation(fields: [nightId], references: [id], onDelete: Cascade)
+
+  @@id([nightId, discordId])
+}
+
+/// Consent is append-preserving and guild-scoped. Operator anonymization
+/// replaces identifiers; it never deletes the fact that consent was recorded.
+model CustomConsent {
+  id                String    @id @default(uuid())
+  guildId           String
+  discordId         String
+  disclosureVersion String
+  acceptedAt        DateTime
+  anonymizedAt      DateTime?
+  createdAt         DateTime  @default(now())
+
+  @@unique([guildId, discordId, disclosureVersion])
+  @@index([discordId, acceptedAt])
+}
+
+model CustomNightParticipant {
+  id                String    @id @default(uuid())
+  nightId           String
+  discordId         String
+  displayName       String
+  avatarUrl         String?
+  role              String
+  availability      String
+  readyAt           DateTime?
+  awayUntil         DateTime?
+  held              Boolean   @default(false)
+  consentedAt       DateTime
+  playerId          Int?
+  playerAlias       String?
+  selectedAccountId Int?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  night CustomNight @relation(fields: [nightId], references: [id], onDelete: Cascade)
+
+  @@unique([nightId, discordId])
+  @@index([nightId, availability, readyAt])
+}
+
+model CustomGame {
+  id                String    @id @default(uuid())
+  nightId           String
+  sequence          Int
+  state             String
+  rosterMode        String
+  map               String
+  pickMode          String
+  activeCaptain     String?
+  tournamentLobbyId Int?      @unique
+  voiceState        String    @default("IDLE")
+  voiceReady        Boolean   @default(false)
+  voiceOverride     Boolean   @default(false)
+  voiceError        String?
+  winner            String?
+  createdAt         DateTime  @default(now())
+  startedAt         DateTime?
+  completedAt       DateTime?
+  updatedAt         DateTime  @updatedAt
+
+  night           CustomNight             @relation(fields: [nightId], references: [id], onDelete: Cascade)
+  tournamentLobby TournamentLobby?        @relation(fields: [tournamentLobbyId], references: [id], onDelete: Restrict)
+  participants    CustomGameParticipant[]
+  auditEvents     CustomAuditEvent[]
+
+  @@unique([nightId, sequence])
+  @@index([nightId, state])
+  @@index([voiceState, updatedAt])
+}
+
+model CustomGameParticipant {
+  id           String   @id @default(uuid())
+  gameId       String
+  discordId    String
+  displayName  String
+  playerId     Int
+  playerAlias  String
+  accountId    Int
+  puuid        String
+  riotGameName String?
+  riotTagLine  String?
+  rosterOrder  Int
+  benchOrder   Int?
+  team         String?
+  side         String?
+  captain      Boolean  @default(false)
+  pickOrder    Int?
+  championId   Int?
+  won          Boolean?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  game CustomGame @relation(fields: [gameId], references: [id], onDelete: Cascade)
+
+  @@unique([gameId, discordId])
+  @@index([gameId, team, pickOrder])
+  @@index([puuid])
+}
+
+/// Append-only command and integration ledger. Random choices are recorded in
+/// payload at the same revision as the mutation that accepted them.
+model CustomAuditEvent {
+  id        String   @id @default(uuid())
+  nightId   String
+  gameId    String?
+  revision  Int
+  actorId   String
+  action    String
+  payload   String
+  source    String   @default("ACTIVITY")
+  createdAt DateTime @default(now())
+
+  night CustomNight @relation(fields: [nightId], references: [id], onDelete: Restrict)
+  game  CustomGame? @relation(fields: [gameId], references: [id], onDelete: Restrict)
+
+  @@index([nightId, revision])
+  @@index([gameId, createdAt])
+  @@index([actorId, createdAt])
 }
 
 /// Durable handoff for work created by request/gateway code before Temporal

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.test.ts
@@ -31,6 +31,7 @@ const PRODUCTION_DENIED_FLAGS = [
   "betting_player_bet_outcome_dm_enabled",
   "betting_settlement_dm_enabled",
   "competition_builder_v2_enabled",
+  "custom_nights_enabled",
   "tournament_lobbies_enabled",
 ] as const;
 
@@ -80,6 +81,7 @@ describe("production hard-disable policy", () => {
         bucks_transfers_enabled: true,
         betting_player_bet_outcome_dm_enabled: true,
         betting_settlement_dm_enabled: true,
+        custom_nights_enabled: true,
         tournament_lobbies_enabled: true,
       }),
     });

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -148,6 +148,7 @@ export type FlagName =
   | "betting_player_bet_outcome_dm_enabled"
   | "betting_settlement_dm_enabled"
   | "competition_builder_v2_enabled"
+  | "custom_nights_enabled"
   | "debug"
   | "initial_match_history_import_enabled"
   | "scout-consumer-player-profiles-enabled"
@@ -174,6 +175,7 @@ const PRODUCTION_HARD_DISABLED_FLAGS: ReadonlySet<FlagName> = new Set<FlagName>(
     "betting_player_bet_outcome_dm_enabled",
     "betting_settlement_dm_enabled",
     "competition_builder_v2_enabled",
+    "custom_nights_enabled",
     "tournament_lobbies_enabled",
   ],
 );
@@ -188,6 +190,10 @@ export function isFeatureHardDisabled(name: FlagName): boolean {
  * Central registry for all boolean flags
  */
 const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
+  custom_nights_enabled: {
+    default: false,
+    overrides: [{ value: true, attributes: { server: MY_SERVER } }],
+  },
   competition_builder_v2_enabled: {
     default: false,
     overrides: [{ value: true, attributes: { server: MY_SERVER } }],

--- a/packages/scout-for-lol/packages/backend/src/customs/authorization.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/authorization.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import type {
+  CustomGameParticipant,
+  CustomNightSnapshot,
+} from "@scout-for-lol/data";
+import {
+  canDraftForTeam,
+  canManageCustomNight,
+  customRoleFor,
+} from "#src/customs/authorization.ts";
+
+const SNAPSHOT: CustomNightSnapshot = {
+  id: "018f173a-6f4a-7d19-b731-963d62a2e1bd",
+  guildId: "guild",
+  guildName: "Guild",
+  launchChannelId: "launch",
+  voiceLobbyChannelId: "voice",
+  hostDiscordId: "host",
+  cohostDiscordIds: ["cohost"],
+  state: "RECRUITING",
+  revision: 0,
+  participants: [],
+  currentGame: null,
+  recruitmentCounts: { ready: 0, maybe: 0, away: 0, held: 0, remaining: 10 },
+  recruitmentMessageId: null,
+  teamAVoiceChannelId: null,
+  teamBVoiceChannelId: null,
+  lastActivityAt: "2026-08-29T12:00:00.000Z",
+  expiresAt: "2026-08-30T00:00:00.000Z",
+  endedAt: null,
+};
+
+const CAPTAIN: CustomGameParticipant = {
+  discordId: "captain",
+  displayName: "Captain",
+  playerId: 1,
+  playerAlias: "captain",
+  accountId: 1,
+  puuid: "puuid",
+  riotGameName: null,
+  riotTagLine: null,
+  rosterOrder: 0,
+  benchOrder: null,
+  team: "A",
+  side: "BLUE",
+  captain: true,
+  pickOrder: null,
+  championId: null,
+  won: null,
+};
+
+describe("custom authorization", () => {
+  test("host, cohost, and administrator can manage", () => {
+    expect(canManageCustomNight(customRoleFor(SNAPSHOT, "host", false))).toBe(
+      true,
+    );
+    expect(canManageCustomNight(customRoleFor(SNAPSHOT, "cohost", false))).toBe(
+      true,
+    );
+    expect(
+      canManageCustomNight(customRoleFor(SNAPSHOT, "outsider", true)),
+    ).toBe(true);
+    expect(canManageCustomNight(customRoleFor(SNAPSHOT, "member", false))).toBe(
+      false,
+    );
+  });
+
+  test("captains draft only for their active team", () => {
+    expect(canDraftForTeam("CAPTAIN", "captain", [CAPTAIN], "A")).toBe(true);
+    expect(canDraftForTeam("CAPTAIN", "captain", [CAPTAIN], "B")).toBe(false);
+    expect(canDraftForTeam("HOST", "host", [CAPTAIN], "B")).toBe(true);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/customs/authorization.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/authorization.ts
@@ -1,0 +1,39 @@
+import type {
+  CustomGameParticipant,
+  CustomNightSnapshot,
+  CustomRole,
+} from "@scout-for-lol/data";
+
+export function customRoleFor(
+  snapshot: CustomNightSnapshot,
+  discordId: string,
+  administrator: boolean,
+): CustomRole {
+  if (administrator) return "ADMIN";
+  if (snapshot.hostDiscordId === discordId) return "HOST";
+  if (snapshot.cohostDiscordIds.includes(discordId)) return "COHOST";
+  const participant = snapshot.participants.find(
+    (candidate) => candidate.discordId === discordId,
+  );
+  if (participant?.role === "CAPTAIN") return "CAPTAIN";
+  return "MEMBER";
+}
+
+export function canManageCustomNight(role: CustomRole): boolean {
+  return role === "HOST" || role === "COHOST" || role === "ADMIN";
+}
+
+export function canDraftForTeam(
+  role: CustomRole,
+  actorDiscordId: string,
+  participants: readonly CustomGameParticipant[],
+  activeTeam: "A" | "B",
+): boolean {
+  if (canManageCustomNight(role)) return true;
+  return participants.some(
+    (participant) =>
+      participant.discordId === actorDiscordId &&
+      participant.captain &&
+      participant.team === activeTeam,
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/customs/game-machine.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/game-machine.ts
@@ -1,0 +1,45 @@
+import {
+  CustomGameStateSchema,
+  type CustomGameState,
+} from "@scout-for-lol/data";
+
+export type CustomGameEvent =
+  | "CAPTAINS_SELECTED"
+  | "START_DRAFT"
+  | "TEAMS_LOCKED"
+  | "CODE_CREATED"
+  | "GAME_STARTED"
+  | "AWAIT_RIOT"
+  | "RIOT_RESULT"
+  | "VOID_GAME";
+
+const TRANSITIONS: Readonly<
+  Partial<Record<CustomGameState, Partial<Record<CustomGameEvent, string>>>>
+> = {
+  ROSTER_OPEN: { CAPTAINS_SELECTED: "CAPTAINS_SET", VOID_GAME: "VOID" },
+  CAPTAINS_SET: {
+    START_DRAFT: "DRAFTING",
+    TEAMS_LOCKED: "CODE_PENDING",
+    VOID_GAME: "VOID",
+  },
+  DRAFTING: { TEAMS_LOCKED: "CODE_PENDING", VOID_GAME: "VOID" },
+  CODE_PENDING: { CODE_CREATED: "LOBBY_READY", VOID_GAME: "VOID" },
+  LOBBY_READY: { GAME_STARTED: "PLAYING", VOID_GAME: "VOID" },
+  PLAYING: {
+    AWAIT_RIOT: "RESULT_PENDING",
+    RIOT_RESULT: "VERIFIED",
+    VOID_GAME: "VOID",
+  },
+  RESULT_PENDING: { RIOT_RESULT: "VERIFIED", VOID_GAME: "VOID" },
+};
+
+export function transitionCustomGame(
+  state: CustomGameState,
+  event: CustomGameEvent,
+): CustomGameState {
+  const next = TRANSITIONS[state]?.[event];
+  if (next === undefined) {
+    throw new Error(`Invalid custom game transition: ${state} + ${event}`);
+  }
+  return CustomGameStateSchema.parse(next);
+}

--- a/packages/scout-for-lol/packages/backend/src/customs/machines.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/machines.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { transitionCustomGame } from "#src/customs/game-machine.ts";
+import { transitionCustomNight } from "#src/customs/night-machine.ts";
+
+describe("custom night state", () => {
+  test("opens intermission only for the Riot result transition", () => {
+    expect(transitionCustomNight("PLAYING", "RIOT_RESULT")).toBe(
+      "INTERMISSION",
+    );
+    expect(() => transitionCustomNight("PLAYING", "PREPARE_NEXT_GAME")).toThrow(
+      "Invalid custom night transition",
+    );
+  });
+
+  test("supports the complete multi-game lifecycle", () => {
+    expect(transitionCustomNight("RECRUITING", "START_PREPARING")).toBe(
+      "PREPARING",
+    );
+    expect(transitionCustomNight("PREPARING", "START_DRAFT")).toBe("DRAFTING");
+    expect(transitionCustomNight("DRAFTING", "TEAMS_LOCKED")).toBe(
+      "LOBBY_READY",
+    );
+    expect(transitionCustomNight("LOBBY_READY", "GAME_STARTED")).toBe(
+      "PLAYING",
+    );
+    expect(transitionCustomNight("INTERMISSION", "PREPARE_NEXT_GAME")).toBe(
+      "PREPARING",
+    );
+  });
+});
+
+describe("custom game state", () => {
+  test("has no manual result transition", () => {
+    expect(transitionCustomGame("PLAYING", "AWAIT_RIOT")).toBe(
+      "RESULT_PENDING",
+    );
+    expect(transitionCustomGame("RESULT_PENDING", "RIOT_RESULT")).toBe(
+      "VERIFIED",
+    );
+  });
+
+  test("supports retaining assigned teams", () => {
+    expect(transitionCustomGame("CAPTAINS_SET", "TEAMS_LOCKED")).toBe(
+      "CODE_PENDING",
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/customs/night-machine.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/night-machine.ts
@@ -1,0 +1,39 @@
+import {
+  CustomNightStateSchema,
+  type CustomNightState,
+} from "@scout-for-lol/data";
+
+export type CustomNightEvent =
+  | "START_PREPARING"
+  | "START_DRAFT"
+  | "TEAMS_LOCKED"
+  | "GAME_STARTED"
+  | "RIOT_RESULT"
+  | "PREPARE_NEXT_GAME"
+  | "END_NIGHT";
+
+const TRANSITIONS: Readonly<
+  Partial<Record<CustomNightState, Partial<Record<CustomNightEvent, string>>>>
+> = {
+  RECRUITING: { START_PREPARING: "PREPARING", END_NIGHT: "ENDED" },
+  PREPARING: {
+    START_DRAFT: "DRAFTING",
+    TEAMS_LOCKED: "LOBBY_READY",
+    END_NIGHT: "ENDED",
+  },
+  DRAFTING: { TEAMS_LOCKED: "LOBBY_READY", END_NIGHT: "ENDED" },
+  LOBBY_READY: { GAME_STARTED: "PLAYING", END_NIGHT: "ENDED" },
+  PLAYING: { RIOT_RESULT: "INTERMISSION", END_NIGHT: "ENDED" },
+  INTERMISSION: { PREPARE_NEXT_GAME: "PREPARING", END_NIGHT: "ENDED" },
+};
+
+export function transitionCustomNight(
+  state: CustomNightState,
+  event: CustomNightEvent,
+): CustomNightState {
+  const next = TRANSITIONS[state]?.[event];
+  if (next === undefined) {
+    throw new Error(`Invalid custom night transition: ${state} + ${event}`);
+  }
+  return CustomNightStateSchema.parse(next);
+}

--- a/packages/scout-for-lol/packages/backend/src/customs/repository.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/repository.integration.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  createCustomNight,
+  mutateCustomNight,
+  type CreateCustomNightInput,
+} from "#src/customs/repository.ts";
+import { clearCustomsTestData } from "#src/customs/test-database.ts";
+
+const { prisma: testPrisma } = createTestDatabase("customs-repository");
+const NOW = new Date("2026-08-29T12:00:00.000Z");
+const CREATE_INPUT: CreateCustomNightInput = {
+  guildId: DiscordGuildIdSchema.parse("1337623164146155593"),
+  guildName: "Beta Guild",
+  launchChannelId: DiscordChannelIdSchema.parse("1337623164146155594"),
+  voiceLobbyChannelId: DiscordChannelIdSchema.parse("1337623164146155595"),
+  hostDiscordId: DiscordAccountIdSchema.parse("160509172704739328"),
+  hostDisplayName: "Host",
+  hostAvatarUrl: undefined,
+  disclosureVersion: "2026-08-29",
+  now: NOW,
+};
+
+beforeEach(async () => {
+  await clearCustomsTestData(testPrisma);
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+describe("custom night persistence", () => {
+  test("PostgreSQL enforces one active night per guild", async () => {
+    await createCustomNight(testPrisma, CREATE_INPUT);
+
+    await expect(createCustomNight(testPrisma, CREATE_INPUT)).rejects.toThrow(
+      "already has an active custom night",
+    );
+  });
+
+  test("revision and audit event commit together", async () => {
+    const night = await createCustomNight(testPrisma, CREATE_INPUT);
+    const revision = await mutateCustomNight(testPrisma, {
+      nightId: night.id,
+      expectedRevision: 0,
+      actorId: CREATE_INPUT.hostDiscordId,
+      action: "RECRUITMENT_UPDATED",
+      payload: { availability: "READY" },
+      source: "ACTIVITY",
+      now: NOW,
+    });
+
+    expect(revision).toBe(1);
+    await expect(
+      testPrisma.customAuditEvent.findMany({
+        where: { nightId: night.id },
+        orderBy: { revision: "asc" },
+      }),
+    ).resolves.toMatchObject([
+      { revision: 0, action: "NIGHT_CREATED" },
+      { revision: 1, action: "RECRUITMENT_UPDATED" },
+    ]);
+  });
+
+  test("a stale revision changes neither state nor audit", async () => {
+    const night = await createCustomNight(testPrisma, CREATE_INPUT);
+    await mutateCustomNight(testPrisma, {
+      nightId: night.id,
+      expectedRevision: 0,
+      actorId: CREATE_INPUT.hostDiscordId,
+      action: "START_PREPARING",
+      payload: {},
+      source: "ACTIVITY",
+      state: "PREPARING",
+      now: NOW,
+    });
+
+    await expect(
+      mutateCustomNight(testPrisma, {
+        nightId: night.id,
+        expectedRevision: 0,
+        actorId: CREATE_INPUT.hostDiscordId,
+        action: "STALE",
+        payload: {},
+        source: "ACTIVITY",
+        now: NOW,
+      }),
+    ).rejects.toThrow("is stale or ended");
+    await expect(
+      testPrisma.customAuditEvent.count({ where: { nightId: night.id } }),
+    ).resolves.toBe(2);
+  });
+
+  test("ending removes the active pointer but retains history", async () => {
+    const night = await createCustomNight(testPrisma, CREATE_INPUT);
+    await mutateCustomNight(testPrisma, {
+      nightId: night.id,
+      expectedRevision: 0,
+      actorId: CREATE_INPUT.hostDiscordId,
+      action: "NIGHT_ENDED",
+      payload: {},
+      source: "ACTIVITY",
+      state: "ENDED",
+      now: NOW,
+    });
+
+    await expect(
+      testPrisma.customActiveNight.findUnique({
+        where: { guildId: CREATE_INPUT.guildId },
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      testPrisma.customNight.findUniqueOrThrow({ where: { id: night.id } }),
+    ).resolves.toMatchObject({ state: "ENDED", revision: 1 });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/customs/repository.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/repository.ts
@@ -1,0 +1,167 @@
+import { z } from "zod";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import {
+  CustomNightStateSchema,
+  type DiscordAccountId,
+  type DiscordChannelId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+
+const UniqueViolationSchema = z.object({ code: z.literal("P2002") });
+const AuditSourceSchema = z.enum(["ACTIVITY", "DISCORD", "RIOT", "OPERATOR"]);
+const JsonPayloadSchema = z.json();
+
+export const CUSTOM_NIGHT_TTL_MS = 12 * 60 * 60 * 1000;
+
+export type CreateCustomNightInput = {
+  readonly guildId: DiscordGuildId;
+  readonly guildName: string;
+  readonly launchChannelId: DiscordChannelId;
+  readonly voiceLobbyChannelId: DiscordChannelId;
+  readonly hostDiscordId: DiscordAccountId;
+  readonly hostDisplayName: string;
+  readonly hostAvatarUrl: string | undefined;
+  readonly disclosureVersion: string;
+  readonly now: Date;
+};
+
+export async function createCustomNight(
+  client: ExtendedPrismaClient,
+  input: CreateCustomNightInput,
+): Promise<{ id: string; revision: number }> {
+  try {
+    return await client.$transaction(async (transaction) => {
+      const night = await transaction.customNight.create({
+        data: {
+          guildId: input.guildId,
+          guildName: input.guildName,
+          launchChannelId: input.launchChannelId,
+          voiceLobbyChannelId: input.voiceLobbyChannelId,
+          hostDiscordId: input.hostDiscordId,
+          state: "RECRUITING",
+          lastActivityAt: input.now,
+          expiresAt: new Date(input.now.getTime() + CUSTOM_NIGHT_TTL_MS),
+        },
+      });
+      await transaction.customActiveNight.create({
+        data: { guildId: input.guildId, nightId: night.id },
+      });
+      await transaction.customConsent.upsert({
+        where: {
+          guildId_discordId_disclosureVersion: {
+            guildId: input.guildId,
+            discordId: input.hostDiscordId,
+            disclosureVersion: input.disclosureVersion,
+          },
+        },
+        create: {
+          guildId: input.guildId,
+          discordId: input.hostDiscordId,
+          disclosureVersion: input.disclosureVersion,
+          acceptedAt: input.now,
+        },
+        update: {},
+      });
+      await transaction.customNightParticipant.create({
+        data: {
+          nightId: night.id,
+          discordId: input.hostDiscordId,
+          displayName: input.hostDisplayName,
+          avatarUrl: input.hostAvatarUrl ?? null,
+          role: "HOST",
+          availability: "READY",
+          readyAt: input.now,
+          consentedAt: input.now,
+        },
+      });
+      await transaction.customAuditEvent.create({
+        data: {
+          nightId: night.id,
+          revision: 0,
+          actorId: input.hostDiscordId,
+          action: "NIGHT_CREATED",
+          payload: JSON.stringify({
+            disclosureVersion: input.disclosureVersion,
+          }),
+          source: "ACTIVITY",
+        },
+      });
+      return { id: night.id, revision: night.revision };
+    });
+  } catch (error) {
+    if (UniqueViolationSchema.safeParse(error).success) {
+      throw new Error(
+        `Guild ${input.guildId} already has an active custom night`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
+export type CustomNightMutation = {
+  readonly nightId: string;
+  readonly expectedRevision: number;
+  readonly actorId: DiscordAccountId;
+  readonly action: string;
+  readonly payload: unknown;
+  readonly source: z.infer<typeof AuditSourceSchema>;
+  readonly state?: z.infer<typeof CustomNightStateSchema>;
+  readonly now: Date;
+};
+
+/**
+ * Advances a night revision and writes its audit event in one transaction.
+ * Feature services perform their normalized row mutations in the same pattern;
+ * this helper owns lifecycle-only transitions and the active pointer.
+ */
+export async function mutateCustomNight(
+  client: ExtendedPrismaClient,
+  input: CustomNightMutation,
+): Promise<number> {
+  const source = AuditSourceSchema.parse(input.source);
+  const state =
+    input.state === undefined
+      ? undefined
+      : CustomNightStateSchema.parse(input.state);
+  const payload = JsonPayloadSchema.parse(input.payload);
+  const revision = input.expectedRevision + 1;
+
+  return client.$transaction(async (transaction) => {
+    const updated = await transaction.customNight.updateMany({
+      where: {
+        id: input.nightId,
+        revision: input.expectedRevision,
+        state: { not: "ENDED" },
+      },
+      data: {
+        revision: { increment: 1 },
+        lastActivityAt: input.now,
+        ...(state === undefined ? {} : { state }),
+        ...(state === "ENDED" ? { endedAt: input.now } : {}),
+      },
+    });
+    if (updated.count !== 1) {
+      throw new Error(
+        `Custom night ${input.nightId} revision ${input.expectedRevision.toString()} is stale or ended`,
+      );
+    }
+
+    await transaction.customAuditEvent.create({
+      data: {
+        nightId: input.nightId,
+        revision,
+        actorId: input.actorId,
+        action: input.action,
+        payload: JSON.stringify(payload),
+        source,
+      },
+    });
+    if (state === "ENDED") {
+      await transaction.customActiveNight.delete({
+        where: { nightId: input.nightId },
+      });
+    }
+    return revision;
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/customs/riot-results.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/riot-results.integration.test.ts
@@ -1,0 +1,251 @@
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import {
+  AccountIdSchema,
+  DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  LeaguePuuidSchema,
+  PlayerIdSchema,
+  RawMatchSchema,
+} from "@scout-for-lol/data";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  createLobby,
+  updateLobby,
+} from "#src/league/tournament/lobby-store.ts";
+import { finalizeTournamentResult } from "#src/customs/riot-results.ts";
+import { clearCustomsTestData } from "#src/customs/test-database.ts";
+
+const { prisma: testPrisma } = createTestDatabase("customs-riot-results");
+const fixture = RawMatchSchema.parse(
+  await Bun.file(
+    new URL("../../../../testdata/rift.json", import.meta.url),
+  ).json(),
+);
+const tournamentFixture = RawMatchSchema.parse({
+  ...fixture,
+  info: { ...fixture.info, tournamentCode: "TEST-CODE" },
+});
+const GUILD_ID = DiscordGuildIdSchema.parse("1337623164146155593");
+const CHANNEL_ID = DiscordChannelIdSchema.parse("1337623164146155594");
+const HOST_ID = DiscordAccountIdSchema.parse("160509172704739328");
+
+async function seedPendingResult(
+  options: {
+    lobbyState?: "resolved" | "expired" | "in_game";
+    linkMatch?: boolean;
+    nightState?: "PLAYING" | "ENDED";
+  } = {},
+): Promise<{
+  nightId: string;
+  gameId: string;
+  lobbyId: number;
+}> {
+  const night = await testPrisma.customNight.create({
+    data: {
+      guildId: GUILD_ID,
+      guildName: "Beta Guild",
+      launchChannelId: CHANNEL_ID,
+      voiceLobbyChannelId: CHANNEL_ID,
+      hostDiscordId: HOST_ID,
+      state: options.nightState ?? "PLAYING",
+      lastActivityAt: new Date(fixture.info.gameCreation),
+      expiresAt: new Date(fixture.info.gameCreation + 12 * 60 * 60 * 1000),
+    },
+  });
+  await testPrisma.customActiveNight.create({
+    data: { guildId: GUILD_ID, nightId: night.id },
+  });
+  const blue = fixture.info.participants.filter(
+    (participant) => participant.teamId === 100,
+  );
+  const red = fixture.info.participants.filter(
+    (participant) => participant.teamId === 200,
+  );
+  const lobby = await createLobby(testPrisma, {
+    code: "TEST-CODE",
+    apiMode: "live",
+    providerId: 1,
+    tournamentId: 2,
+    region: "AMERICA_NORTH",
+    platformId: "NA1",
+    serverId: GUILD_ID,
+    channelId: CHANNEL_ID,
+    creatorDiscordId: HOST_ID,
+    bluePuuids: blue.map((participant) => participant.puuid),
+    redPuuids: red.map((participant) => participant.puuid),
+    blueAliases: blue.map(
+      (participant) => participant.riotIdGameName ?? participant.puuid,
+    ),
+    redAliases: red.map(
+      (participant) => participant.riotIdGameName ?? participant.puuid,
+    ),
+    teamSize: 5,
+    pickType: "TOURNAMENT_DRAFT",
+    mapType: "SUMMONERS_RIFT",
+    spectatorType: "ALL",
+    lobbyName: undefined,
+    password: undefined,
+    expiresAt: new Date(fixture.info.gameCreation + 3 * 60 * 60 * 1000),
+  });
+  await updateLobby(testPrisma, lobby.id, {
+    state: options.lobbyState ?? "resolved",
+    ...(options.linkMatch === false
+      ? {}
+      : { matchId: fixture.metadata.matchId }),
+  });
+  const game = await testPrisma.customGame.create({
+    data: {
+      nightId: night.id,
+      sequence: 1,
+      state: "RESULT_PENDING",
+      rosterMode: "FIRST_TEN",
+      map: "SUMMONERS_RIFT",
+      pickMode: "TOURNAMENT_DRAFT",
+      tournamentLobbyId: lobby.id,
+    },
+  });
+  for (const [index, participant] of fixture.info.participants.entries()) {
+    const blueSide = participant.teamId === 100;
+    await testPrisma.customGameParticipant.create({
+      data: {
+        gameId: game.id,
+        discordId: DiscordAccountIdSchema.parse(
+          (160_509_172_704_739_400n + BigInt(index)).toString(),
+        ),
+        displayName: participant.riotIdGameName ?? participant.puuid,
+        playerId: PlayerIdSchema.parse(index + 1),
+        playerAlias: participant.riotIdGameName ?? participant.puuid,
+        accountId: AccountIdSchema.parse(index + 1),
+        puuid: LeaguePuuidSchema.parse(participant.puuid),
+        riotGameName: participant.riotIdGameName ?? null,
+        riotTagLine: participant.riotIdTagline,
+        rosterOrder: index,
+        team: blueSide ? "A" : "B",
+        side: blueSide ? "BLUE" : "RED",
+        captain: index === 0 || index === 5,
+      },
+    });
+  }
+  return { nightId: night.id, gameId: game.id, lobbyId: lobby.id };
+}
+
+beforeEach(async () => {
+  await clearCustomsTestData(testPrisma);
+});
+
+afterAll(async () => {
+  await testPrisma.$disconnect();
+});
+
+async function expectReportedAndVerified(seeded: {
+  readonly lobbyId: number;
+  readonly gameId: string;
+}): Promise<void> {
+  await expect(
+    testPrisma.tournamentLobby.findUniqueOrThrow({
+      where: { id: seeded.lobbyId },
+    }),
+  ).resolves.toMatchObject({ state: "reported" });
+  await expect(
+    testPrisma.customGame.findUniqueOrThrow({ where: { id: seeded.gameId } }),
+  ).resolves.toMatchObject({ state: "VERIFIED" });
+}
+
+describe("Riot-only Customs results", () => {
+  test("projects Match-V5 and opens intermission in one transaction", async () => {
+    const seeded = await seedPendingResult();
+
+    await finalizeTournamentResult(testPrisma, tournamentFixture);
+
+    await expectReportedAndVerified(seeded);
+    await expect(
+      testPrisma.customNight.findUniqueOrThrow({
+        where: { id: seeded.nightId },
+      }),
+    ).resolves.toMatchObject({ state: "INTERMISSION", revision: 1 });
+    await expect(
+      testPrisma.customGameParticipant.count({
+        where: { gameId: seeded.gameId, championId: { not: null } },
+      }),
+    ).resolves.toBe(10);
+    await expect(
+      testPrisma.customAuditEvent.findFirstOrThrow({
+        where: { nightId: seeded.nightId },
+      }),
+    ).resolves.toMatchObject({
+      source: "RIOT",
+      action: "RIOT_RESULT_VERIFIED",
+      revision: 1,
+    });
+  });
+
+  test("a projection error rolls back before lobby and cursor completion", async () => {
+    const seeded = await seedPendingResult();
+    await testPrisma.customGameParticipant.deleteMany({
+      where: { gameId: seeded.gameId, rosterOrder: 9 },
+    });
+
+    await expect(
+      finalizeTournamentResult(testPrisma, tournamentFixture),
+    ).rejects.toThrow("must have 10 participants");
+    await expect(
+      testPrisma.tournamentLobby.findUniqueOrThrow({
+        where: { id: seeded.lobbyId },
+      }),
+    ).resolves.toMatchObject({ state: "resolved" });
+    await expect(
+      testPrisma.customGame.findUniqueOrThrow({ where: { id: seeded.gameId } }),
+    ).resolves.toMatchObject({ state: "RESULT_PENDING" });
+    await expect(
+      testPrisma.customAuditEvent.count({ where: { nightId: seeded.nightId } }),
+    ).resolves.toBe(0);
+  });
+
+  test("preserves an ended night while recording its authoritative result", async () => {
+    const seeded = await seedPendingResult({ nightState: "ENDED" });
+    await testPrisma.customActiveNight.delete({ where: { guildId: GUILD_ID } });
+
+    await finalizeTournamentResult(testPrisma, tournamentFixture);
+
+    await expect(
+      testPrisma.customNight.findUniqueOrThrow({
+        where: { id: seeded.nightId },
+      }),
+    ).resolves.toMatchObject({ state: "ENDED", revision: 1 });
+    await expect(
+      testPrisma.customGame.findUniqueOrThrow({ where: { id: seeded.gameId } }),
+    ).resolves.toMatchObject({ state: "VERIFIED" });
+    await expect(
+      testPrisma.tournamentLobby.findUniqueOrThrow({
+        where: { id: seeded.lobbyId },
+      }),
+    ).resolves.toMatchObject({ state: "reported" });
+  });
+
+  test("finalizes by tournament code before poller linkage", async () => {
+    const seeded = await seedPendingResult({
+      lobbyState: "in_game",
+      linkMatch: false,
+    });
+
+    await finalizeTournamentResult(testPrisma, tournamentFixture);
+
+    await expect(
+      testPrisma.tournamentLobby.findUniqueOrThrow({
+        where: { id: seeded.lobbyId },
+      }),
+    ).resolves.toMatchObject({
+      matchId: fixture.metadata.matchId,
+      state: "reported",
+    });
+  });
+
+  test("recovers an expired linked lobby when Match-V5 is delayed", async () => {
+    const seeded = await seedPendingResult({ lobbyState: "expired" });
+
+    await finalizeTournamentResult(testPrisma, tournamentFixture);
+
+    await expectReportedAndVerified(seeded);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/customs/riot-results.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/riot-results.ts
@@ -1,0 +1,185 @@
+import {
+  CustomGameStateSchema,
+  CustomNightStateSchema,
+  CustomTeamSchema,
+  CustomWinnerSchema,
+  MatchIdSchema,
+  type RawMatch,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+function tournamentLobbyIdentity(
+  matchId: string,
+  tournamentCode: string | undefined,
+) {
+  return tournamentCode === undefined || tournamentCode.length === 0
+    ? { matchId }
+    : { code: tournamentCode };
+}
+
+function resultDisposition(
+  rawState: string,
+  gameId: string,
+): "PROJECT" | "VOID" {
+  const state = CustomGameStateSchema.parse(rawState);
+  if (state === "VOID") return "VOID";
+  if (state === "PLAYING" || state === "RESULT_PENDING") return "PROJECT";
+  throw new Error(
+    `Custom game ${gameId} reached Match-V5 in unexpected state ${state}`,
+  );
+}
+
+function requireCompleteRoster(participantCount: number, gameId: string): void {
+  if (participantCount !== 10) {
+    throw new Error(
+      `Custom game ${gameId} must have 10 participants before Riot finalization`,
+    );
+  }
+}
+
+function requireWinner(winningTeams: ReadonlySet<string>, matchId: string) {
+  const values = [...winningTeams];
+  if (values.length !== 1) {
+    throw new Error(
+      `Match ${matchId} did not produce exactly one winning custom team`,
+    );
+  }
+  return CustomWinnerSchema.parse(values[0]);
+}
+
+function nightResultTransition(rawState: string, nightId: string) {
+  const state = CustomNightStateSchema.parse(rawState);
+  if (state === "PLAYING") {
+    return {
+      current: state,
+      next: "INTERMISSION",
+      updateActivity: true,
+    } as const;
+  }
+  if (state === "ENDED") {
+    return { current: state, next: "ENDED", updateActivity: false } as const;
+  }
+  throw new Error(
+    `Custom night ${nightId} reached Match-V5 in unexpected state ${state}`,
+  );
+}
+
+/**
+ * Finalizes the Tournament lobby and its optional Customs game atomically.
+ * Called only after authoritative S3 ingestion and before player cursors move.
+ */
+export async function finalizeTournamentResult(
+  client: ExtendedPrismaClient,
+  match: RawMatch,
+): Promise<string | undefined> {
+  const matchId = MatchIdSchema.parse(match.metadata.matchId);
+
+  return client.$transaction(async (transaction) => {
+    const lobby = await transaction.tournamentLobby.findFirst({
+      where: tournamentLobbyIdentity(matchId, match.info.tournamentCode),
+      include: {
+        customGame: {
+          include: { participants: true, night: true },
+        },
+      },
+    });
+    if (lobby === null) return;
+    if (lobby.state === "reported") return lobby.customGame?.nightId;
+
+    const game = lobby.customGame;
+    if (game === null) {
+      await transaction.tournamentLobby.update({
+        where: { id: lobby.id },
+        data: { matchId, state: "reported" },
+      });
+      return;
+    }
+
+    if (resultDisposition(game.state, game.id) === "VOID") {
+      await transaction.tournamentLobby.update({
+        where: { id: lobby.id },
+        data: { matchId, state: "reported" },
+      });
+      return;
+    }
+    requireCompleteRoster(game.participants.length, game.id);
+
+    const winningTeams = new Set<string>();
+    for (const participant of game.participants) {
+      const riotParticipant = match.info.participants.find(
+        (candidate) => candidate.puuid === participant.puuid,
+      );
+      if (riotParticipant === undefined) {
+        throw new Error(
+          `Match ${matchId} is missing custom participant ${participant.puuid}`,
+        );
+      }
+      const team = CustomTeamSchema.parse(participant.team);
+      if (riotParticipant.win) winningTeams.add(team);
+      await transaction.customGameParticipant.update({
+        where: { id: participant.id },
+        data: {
+          championId: riotParticipant.championId,
+          won: riotParticipant.win,
+        },
+      });
+    }
+    const winner = requireWinner(winningTeams, matchId);
+    const completedAt = new Date(match.info.gameEndTimestamp);
+
+    const gameUpdated = await transaction.customGame.updateMany({
+      where: {
+        id: game.id,
+        state: { in: ["PLAYING", "RESULT_PENDING"] },
+      },
+      data: { state: "VERIFIED", winner, completedAt },
+    });
+    if (gameUpdated.count !== 1) {
+      throw new Error(
+        `Custom game ${game.id} changed during Riot finalization`,
+      );
+    }
+
+    const nightTransition = nightResultTransition(
+      game.night.state,
+      game.nightId,
+    );
+    const nextRevision = game.night.revision + 1;
+    const nightUpdated = await transaction.customNight.updateMany({
+      where: {
+        id: game.nightId,
+        state: nightTransition.current,
+        revision: game.night.revision,
+      },
+      data: {
+        state: nightTransition.next,
+        revision: { increment: 1 },
+        ...(nightTransition.updateActivity
+          ? { lastActivityAt: completedAt }
+          : {}),
+      },
+    });
+    if (nightUpdated.count !== 1) {
+      throw new Error(
+        `Custom night ${game.nightId} changed during Riot finalization`,
+      );
+    }
+    await transaction.customAuditEvent.create({
+      data: {
+        nightId: game.nightId,
+        gameId: game.id,
+        revision: nextRevision,
+        actorId: "riot:match-v5",
+        action: "RIOT_RESULT_VERIFIED",
+        payload: JSON.stringify({ matchId, winner }),
+        source: "RIOT",
+        createdAt: completedAt,
+      },
+    });
+    await transaction.tournamentLobby.update({
+      where: { id: lobby.id },
+      data: { matchId, state: "reported" },
+    });
+    return game.nightId;
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/customs/snapshot.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/snapshot.ts
@@ -1,0 +1,211 @@
+import {
+  CustomAvailabilitySchema,
+  CustomGameSnapshotSchema,
+  CustomGameStateSchema,
+  CustomMapSchema,
+  CustomNightSnapshotSchema,
+  CustomNightStateSchema,
+  CustomPickModeSchema,
+  CustomRoleSchema,
+  CustomRosterModeSchema,
+  CustomSideSchema,
+  CustomTeamSchema,
+  CustomVoiceStateSchema,
+  CustomWinnerSchema,
+  type CustomAccount,
+  type CustomGameSnapshot,
+  type CustomNightParticipant,
+  type CustomNightSnapshot,
+} from "@scout-for-lol/data";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { TournamentLobbyStateSchema } from "#src/league/tournament/lifecycle.ts";
+
+async function loadNight(client: ExtendedPrismaClient, nightId: string) {
+  return client.customNight.findUnique({
+    where: { id: nightId },
+    include: {
+      cohosts: { orderBy: { createdAt: "asc" } },
+      participants: { orderBy: { createdAt: "asc" } },
+      games: {
+        orderBy: { sequence: "asc" },
+        include: {
+          participants: { orderBy: { rosterOrder: "asc" } },
+          tournamentLobby: true,
+        },
+      },
+    },
+  });
+}
+
+type NightRow = NonNullable<Awaited<ReturnType<typeof loadNight>>>;
+type GameRow = NightRow["games"][number];
+
+function accountMap(
+  accounts: Awaited<ReturnType<ExtendedPrismaClient["account"]["findMany"]>>,
+): Map<number, CustomAccount[]> {
+  const byPlayer = new Map<number, CustomAccount[]>();
+  for (const account of accounts) {
+    const values = byPlayer.get(account.playerId) ?? [];
+    values.push({
+      accountId: account.id,
+      puuid: account.puuid,
+      region: account.region,
+      riotGameName: account.riotGameName,
+      riotTagLine: account.riotTagLine,
+    });
+    byPlayer.set(account.playerId, values);
+  }
+  return byPlayer;
+}
+
+function participantSnapshot(
+  participant: NightRow["participants"][number],
+  accounts: ReadonlyMap<number, CustomAccount[]>,
+  now: Date,
+): CustomNightParticipant {
+  const awayOverdue =
+    participant.awayUntil !== null &&
+    participant.awayUntil.getTime() <= now.getTime();
+  return {
+    discordId: participant.discordId,
+    displayName: participant.displayName,
+    avatarUrl: participant.avatarUrl,
+    role: CustomRoleSchema.parse(participant.role),
+    availability: CustomAvailabilitySchema.parse(participant.availability),
+    readyAt: participant.readyAt?.toISOString() ?? null,
+    awayUntil: participant.awayUntil?.toISOString() ?? null,
+    awayOverdue,
+    held: participant.held,
+    consentedAt: participant.consentedAt.toISOString(),
+    playerId: participant.playerId,
+    playerAlias: participant.playerAlias,
+    accounts:
+      participant.playerId === null
+        ? []
+        : (accounts.get(participant.playerId) ?? []),
+    selectedAccountId: participant.selectedAccountId,
+  };
+}
+
+function gameSnapshot(game: GameRow, revealCode: boolean): CustomGameSnapshot {
+  return CustomGameSnapshotSchema.parse({
+    id: game.id,
+    sequence: game.sequence,
+    state: CustomGameStateSchema.parse(game.state),
+    rosterMode: CustomRosterModeSchema.parse(game.rosterMode),
+    map: CustomMapSchema.parse(game.map),
+    pickMode: CustomPickModeSchema.parse(game.pickMode),
+    participants: game.participants.map((participant) => ({
+      discordId: participant.discordId,
+      displayName: participant.displayName,
+      playerId: participant.playerId,
+      playerAlias: participant.playerAlias,
+      accountId: participant.accountId,
+      puuid: participant.puuid,
+      riotGameName: participant.riotGameName,
+      riotTagLine: participant.riotTagLine,
+      rosterOrder: participant.rosterOrder,
+      benchOrder: participant.benchOrder,
+      team:
+        participant.team === null
+          ? null
+          : CustomTeamSchema.parse(participant.team),
+      side:
+        participant.side === null
+          ? null
+          : CustomSideSchema.parse(participant.side),
+      captain: participant.captain,
+      pickOrder: participant.pickOrder,
+      championId: participant.championId,
+      won: participant.won,
+    })),
+    activeCaptain:
+      game.activeCaptain === null
+        ? null
+        : CustomTeamSchema.parse(game.activeCaptain),
+    tournamentLobby:
+      game.tournamentLobby === null
+        ? null
+        : {
+            state: TournamentLobbyStateSchema.parse(game.tournamentLobby.state),
+            code: revealCode ? game.tournamentLobby.code : null,
+          },
+    winner: game.winner === null ? null : CustomWinnerSchema.parse(game.winner),
+    voiceState: CustomVoiceStateSchema.parse(game.voiceState),
+    voiceReady: game.voiceReady,
+    voiceOverride: game.voiceOverride,
+    voiceError: game.voiceError,
+    createdAt: game.createdAt.toISOString(),
+    startedAt: game.startedAt?.toISOString() ?? null,
+    completedAt: game.completedAt?.toISOString() ?? null,
+  });
+}
+
+function recruitmentCounts(participants: readonly CustomNightParticipant[]) {
+  const ready = participants.filter(
+    (participant) =>
+      participant.availability === "READY" &&
+      participant.awayUntil === null &&
+      !participant.awayOverdue,
+  ).length;
+  return {
+    ready,
+    maybe: participants.filter(
+      (participant) => participant.availability === "MAYBE",
+    ).length,
+    away: participants.filter((participant) => participant.awayUntil !== null)
+      .length,
+    held: participants.filter((participant) => participant.held).length,
+    remaining: Math.max(0, 10 - ready),
+  };
+}
+
+/** Builds the client contract from normalized rows; no stored snapshot exists. */
+export async function buildCustomNightSnapshot(
+  client: ExtendedPrismaClient,
+  nightId: string,
+  viewerDiscordId: string,
+  now: Date = new Date(),
+): Promise<CustomNightSnapshot | undefined> {
+  const night = await loadNight(client, nightId);
+  if (night === null) return undefined;
+
+  const playerIds = night.participants.flatMap((participant) =>
+    participant.playerId === null ? [] : [participant.playerId],
+  );
+  const accounts = await client.account.findMany({
+    where: { playerId: { in: playerIds } },
+    orderBy: { id: "asc" },
+  });
+  const participants = night.participants.map((participant) =>
+    participantSnapshot(participant, accountMap(accounts), now),
+  );
+  const canRevealCode =
+    viewerDiscordId === night.hostDiscordId ||
+    night.cohosts.some((cohost) => cohost.discordId === viewerDiscordId);
+  const currentGame = night.games.at(-1);
+
+  return CustomNightSnapshotSchema.parse({
+    id: night.id,
+    guildId: night.guildId,
+    guildName: night.guildName,
+    launchChannelId: night.launchChannelId,
+    voiceLobbyChannelId: night.voiceLobbyChannelId,
+    hostDiscordId: night.hostDiscordId,
+    cohostDiscordIds: night.cohosts.map((cohost) => cohost.discordId),
+    state: CustomNightStateSchema.parse(night.state),
+    revision: night.revision,
+    participants,
+    currentGame:
+      currentGame === undefined
+        ? null
+        : gameSnapshot(currentGame, canRevealCode),
+    recruitmentCounts: recruitmentCounts(participants),
+    recruitmentMessageId: night.recruitmentMessageId,
+    teamAVoiceChannelId: night.teamAVoiceChannelId,
+    teamBVoiceChannelId: night.teamBVoiceChannelId,
+    lastActivityAt: night.lastActivityAt.toISOString(),
+    expiresAt: night.expiresAt.toISOString(),
+    endedAt: night.endedAt?.toISOString() ?? null,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/customs/test-database.ts
+++ b/packages/scout-for-lol/packages/backend/src/customs/test-database.ts
@@ -1,0 +1,17 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { deleteIfExists } from "#src/testing/test-database.ts";
+
+export async function clearCustomsTestData(
+  client: ExtendedPrismaClient,
+): Promise<void> {
+  await deleteIfExists(() => client.customAuditEvent.deleteMany());
+  await deleteIfExists(() => client.customGameParticipant.deleteMany());
+  await deleteIfExists(() => client.customGame.deleteMany());
+  await deleteIfExists(() => client.customNightParticipant.deleteMany());
+  await deleteIfExists(() => client.customNightCohost.deleteMany());
+  await deleteIfExists(() => client.customActiveNight.deleteMany());
+  await deleteIfExists(() => client.customNight.deleteMany());
+  await deleteIfExists(() => client.customConsent.deleteMany());
+  await deleteIfExists(() => client.tournamentLobbyProvision.deleteMany());
+  await deleteIfExists(() => client.tournamentLobby.deleteMany());
+}

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -65,7 +65,7 @@ import {
   completeScoutEffect,
   recordScoutEffectFailure,
 } from "#src/temporal/effect-claims.ts";
-import { completeTournamentLobbyForMatch } from "#src/league/tournament/lobby-store.ts";
+import { finalizeTournamentResult } from "#src/customs/riot-results.ts";
 
 const logger = createLogger("postmatch-match-history-polling");
 
@@ -319,11 +319,7 @@ export async function processMatchAndUpdatePlayers(
   // past the match. Tournament lobbies — and linked Customs games — finalize
   // here, after authoritative S3 ingest and post-match side effects. A failure
   // therefore leaves the cursors in place and retries the same match.
-  await completeTournamentLobbyForMatch(
-    prisma,
-    matchId,
-    matchData.info.tournamentCode,
-  );
+  await finalizeTournamentResult(prisma, matchData);
 
   // Mark as processed
   processedMatchIds.add(matchId);

--- a/packages/scout-for-lol/packages/data/generated/permission-catalog.ts
+++ b/packages/scout-for-lol/packages/data/generated/permission-catalog.ts
@@ -1,167 +1,180 @@
 // Generated from permission-catalog.json. Do not edit by hand.
 export const PERMISSION_CATALOG = {
-  "subscriptions": {
-    "label": "Subscriptions",
-    "actions": [
+  subscriptions: {
+    label: "Subscriptions",
+    actions: [
       {
-        "name": "read",
-        "label": "View subscriptions"
+        name: "read",
+        label: "View subscriptions",
       },
       {
-        "name": "create",
-        "label": "Add subscriptions"
+        name: "create",
+        label: "Add subscriptions",
       },
       {
-        "name": "update",
-        "label": "Edit subscriptions (filters, mute, move)"
+        name: "update",
+        label: "Edit subscriptions (filters, mute, move)",
       },
       {
-        "name": "delete",
-        "label": "Remove subscriptions"
-      }
-    ]
+        name: "delete",
+        label: "Remove subscriptions",
+      },
+    ],
   },
-  "players": {
-    "label": "Players",
-    "actions": [
+  players: {
+    label: "Players",
+    actions: [
       {
-        "name": "read",
-        "label": "View players"
+        name: "read",
+        label: "View players",
       },
       {
-        "name": "update",
-        "label": "Rename players"
+        name: "update",
+        label: "Rename players",
       },
       {
-        "name": "delete",
-        "label": "Delete players"
+        name: "delete",
+        label: "Delete players",
       },
       {
-        "name": "merge",
-        "label": "Merge players"
+        name: "merge",
+        label: "Merge players",
       },
       {
-        "name": "link",
-        "label": "Link / unlink Discord accounts"
-      }
-    ]
+        name: "link",
+        label: "Link / unlink Discord accounts",
+      },
+    ],
   },
-  "accounts": {
-    "label": "Riot accounts",
-    "actions": [
+  accounts: {
+    label: "Riot accounts",
+    actions: [
       {
-        "name": "read",
-        "label": "Look up Riot accounts"
+        name: "read",
+        label: "Look up Riot accounts",
       },
       {
-        "name": "create",
-        "label": "Add Riot accounts"
+        name: "create",
+        label: "Add Riot accounts",
       },
       {
-        "name": "update",
-        "label": "Edit Riot accounts"
+        name: "update",
+        label: "Edit Riot accounts",
       },
       {
-        "name": "delete",
-        "label": "Remove Riot accounts"
+        name: "delete",
+        label: "Remove Riot accounts",
       },
       {
-        "name": "transfer",
-        "label": "Transfer accounts between players"
-      }
-    ]
+        name: "transfer",
+        label: "Transfer accounts between players",
+      },
+    ],
   },
-  "competitions": {
-    "label": "Competitions",
-    "actions": [
+  competitions: {
+    label: "Competitions",
+    actions: [
       {
-        "name": "read",
-        "label": "View competitions & leaderboards"
+        name: "read",
+        label: "View competitions & leaderboards",
       },
       {
-        "name": "create",
-        "label": "Create competitions"
+        name: "create",
+        label: "Create competitions",
       },
       {
-        "name": "update",
-        "label": "Edit competitions"
+        name: "update",
+        label: "Edit competitions",
       },
       {
-        "name": "cancel",
-        "label": "Cancel competitions"
+        name: "cancel",
+        label: "Cancel competitions",
       },
       {
-        "name": "invite",
-        "label": "Manage participants"
+        name: "invite",
+        label: "Manage participants",
       },
       {
-        "name": "schedule",
-        "label": "Change update schedule"
+        name: "schedule",
+        label: "Change update schedule",
       },
       {
-        "name": "refresh",
-        "label": "Force-refresh leaderboards"
-      }
-    ]
+        name: "refresh",
+        label: "Force-refresh leaderboards",
+      },
+    ],
   },
-  "reports": {
-    "label": "Reports",
-    "actions": [
+  reports: {
+    label: "Reports",
+    actions: [
       {
-        "name": "read",
-        "label": "View & preview reports"
+        name: "read",
+        label: "View & preview reports",
       },
       {
-        "name": "create",
-        "label": "Create reports"
+        name: "create",
+        label: "Create reports",
       },
       {
-        "name": "update",
-        "label": "Edit reports"
+        name: "update",
+        label: "Edit reports",
       },
       {
-        "name": "delete",
-        "label": "Delete reports"
+        name: "delete",
+        label: "Delete reports",
       },
       {
-        "name": "run",
-        "label": "Run & post reports"
-      }
-    ]
+        name: "run",
+        label: "Run & post reports",
+      },
+    ],
   },
-  "channels": {
-    "label": "Channels",
-    "actions": [
+  channels: {
+    label: "Channels",
+    actions: [
       {
-        "name": "read",
-        "label": "List postable channels"
-      }
-    ]
+        name: "read",
+        label: "List postable channels",
+      },
+    ],
   },
-  "audit": {
-    "label": "Audit log",
-    "actions": [
+  customs: {
+    label: "Custom nights",
+    actions: [
       {
-        "name": "read",
-        "label": "View the audit log"
-      }
-    ]
-  },
-  "roles": {
-    "label": "Roles & access",
-    "actions": [
-      {
-        "name": "read",
-        "label": "View who has access"
+        name: "read",
+        label: "View custom-night history",
       },
       {
-        "name": "grant",
-        "label": "Grant access"
+        name: "manage",
+        label: "Manage custom nights",
+      },
+    ],
+  },
+  audit: {
+    label: "Audit log",
+    actions: [
+      {
+        name: "read",
+        label: "View the audit log",
+      },
+    ],
+  },
+  roles: {
+    label: "Roles & access",
+    actions: [
+      {
+        name: "read",
+        label: "View who has access",
       },
       {
-        "name": "revoke",
-        "label": "Revoke access"
-      }
-    ]
-  }
+        name: "grant",
+        label: "Grant access",
+      },
+      {
+        name: "revoke",
+        label: "Revoke access",
+      },
+    ],
+  },
 } as const;

--- a/packages/scout-for-lol/packages/data/permission-catalog.json
+++ b/packages/scout-for-lol/packages/data/permission-catalog.json
@@ -66,6 +66,13 @@
     "label": "Channels",
     "actions": [{ "name": "read", "label": "List postable channels" }]
   },
+  "customs": {
+    "label": "Custom nights",
+    "actions": [
+      { "name": "read", "label": "View custom-night history" },
+      { "name": "manage", "label": "Manage custom nights" }
+    ]
+  },
   "audit": {
     "label": "Audit log",
     "actions": [{ "name": "read", "label": "View the audit log" }]

--- a/packages/scout-for-lol/packages/data/src/customs/customs.schema.test.ts
+++ b/packages/scout-for-lol/packages/data/src/customs/customs.schema.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import {
+  CustomAuthExchangeInputSchema,
+  CustomGameStateSchema,
+  CustomNightSnapshotSchema,
+  CustomRevisionInputSchema,
+} from "#src/customs/customs.schema.ts";
+
+describe("Customs contracts", () => {
+  test("manual result state is not part of the game contract", () => {
+    expect(CustomGameStateSchema.safeParse("MANUAL").success).toBe(false);
+  });
+
+  test("mutations always carry an expected revision", () => {
+    expect(
+      CustomRevisionInputSchema.safeParse({
+        nightId: "018f173a-6f4a-7d19-b731-963d62a2e1bd",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("Activity exchange rejects extra identity claims", () => {
+    expect(
+      CustomAuthExchangeInputSchema.safeParse({
+        code: "code",
+        guildId: "guild",
+        channelId: "channel",
+        instanceId: "instance",
+        userId: "untrusted-client-claim",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("night snapshots reject stored-provider duplication", () => {
+    const result = CustomNightSnapshotSchema.safeParse({
+      id: "018f173a-6f4a-7d19-b731-963d62a2e1bd",
+      guildId: "guild",
+      guildName: "Guild",
+      launchChannelId: "launch",
+      voiceLobbyChannelId: "voice",
+      hostDiscordId: "host",
+      cohostDiscordIds: [],
+      state: "RECRUITING",
+      revision: 0,
+      participants: [],
+      currentGame: null,
+      recruitmentCounts: {
+        ready: 0,
+        maybe: 0,
+        away: 0,
+        held: 0,
+        remaining: 10,
+      },
+      recruitmentMessageId: null,
+      riotTournamentId: "duplicated-provider-state",
+      teamAVoiceChannelId: null,
+      teamBVoiceChannelId: null,
+      lastActivityAt: "2026-08-29T12:00:00.000Z",
+      expiresAt: "2026-08-30T00:00:00.000Z",
+      endedAt: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/customs/customs.schema.ts
+++ b/packages/scout-for-lol/packages/data/src/customs/customs.schema.ts
@@ -1,0 +1,314 @@
+import { z } from "zod";
+import { RegionSchema } from "#src/model/league-account.ts";
+
+export const CustomNightStateSchema = z.enum([
+  "RECRUITING",
+  "PREPARING",
+  "DRAFTING",
+  "LOBBY_READY",
+  "PLAYING",
+  "INTERMISSION",
+  "ENDED",
+]);
+export type CustomNightState = z.infer<typeof CustomNightStateSchema>;
+
+export const CustomGameStateSchema = z.enum([
+  "ROSTER_OPEN",
+  "CAPTAINS_SET",
+  "DRAFTING",
+  "CODE_PENDING",
+  "LOBBY_READY",
+  "PLAYING",
+  "RESULT_PENDING",
+  "VERIFIED",
+  "VOID",
+]);
+export type CustomGameState = z.infer<typeof CustomGameStateSchema>;
+
+export const CustomAvailabilitySchema = z.enum([
+  "READY",
+  "MAYBE",
+  "SITTING_OUT",
+  "DONE",
+]);
+export type CustomAvailability = z.infer<typeof CustomAvailabilitySchema>;
+
+export const CustomRosterModeSchema = z.enum([
+  "FIRST_TEN",
+  "HOST_SELECTED",
+  "RANDOM_TEN",
+]);
+export type CustomRosterMode = z.infer<typeof CustomRosterModeSchema>;
+
+export const CustomTeamSchema = z.enum(["A", "B"]);
+export type CustomTeam = z.infer<typeof CustomTeamSchema>;
+export const CustomSideSchema = z.enum(["BLUE", "RED"]);
+export type CustomSide = z.infer<typeof CustomSideSchema>;
+export const CustomWinnerSchema = CustomTeamSchema;
+export type CustomWinner = z.infer<typeof CustomWinnerSchema>;
+
+export const CustomMapSchema = z.enum(["SUMMONERS_RIFT", "HOWLING_ABYSS"]);
+export type CustomMap = z.infer<typeof CustomMapSchema>;
+export const CustomPickModeSchema = z.enum([
+  "TOURNAMENT_DRAFT",
+  "BLIND_PICK",
+  "DRAFT_MODE",
+  "ALL_RANDOM",
+]);
+export type CustomPickMode = z.infer<typeof CustomPickModeSchema>;
+
+export const CustomIntermissionChoiceSchema = z.enum([
+  "KEEP_TEAMS_AND_CAPTAINS",
+  "KEEP_TEAMS_REROLL_CAPTAINS",
+  "REDRAFT_SAME_CAPTAINS",
+  "REDRAFT_NEW_CAPTAINS",
+]);
+export type CustomIntermissionChoice = z.infer<
+  typeof CustomIntermissionChoiceSchema
+>;
+
+export const CustomRoleSchema = z.enum([
+  "MEMBER",
+  "CAPTAIN",
+  "COHOST",
+  "HOST",
+  "ADMIN",
+]);
+export type CustomRole = z.infer<typeof CustomRoleSchema>;
+
+export const CustomVoiceStateSchema = z.enum([
+  "IDLE",
+  "PROVISIONING",
+  "READY",
+  "RETURNING",
+  "CLEANING_UP",
+  "FAILED",
+]);
+export type CustomVoiceState = z.infer<typeof CustomVoiceStateSchema>;
+
+export const CustomAccountSchema = z.strictObject({
+  accountId: z.number().int().positive(),
+  puuid: z.string().min(1),
+  region: RegionSchema,
+  riotGameName: z.string().min(1).nullable(),
+  riotTagLine: z.string().min(1).nullable(),
+});
+export type CustomAccount = z.infer<typeof CustomAccountSchema>;
+
+export const CustomNightParticipantSchema = z.strictObject({
+  discordId: z.string().min(1),
+  displayName: z.string().min(1),
+  avatarUrl: z.url().nullable(),
+  role: CustomRoleSchema,
+  availability: CustomAvailabilitySchema,
+  readyAt: z.iso.datetime().nullable(),
+  awayUntil: z.iso.datetime().nullable(),
+  awayOverdue: z.boolean(),
+  held: z.boolean(),
+  consentedAt: z.iso.datetime(),
+  playerId: z.number().int().positive().nullable(),
+  playerAlias: z.string().min(1).nullable(),
+  accounts: z.array(CustomAccountSchema),
+  selectedAccountId: z.number().int().positive().nullable(),
+});
+export type CustomNightParticipant = z.infer<
+  typeof CustomNightParticipantSchema
+>;
+
+export const CustomGameParticipantSchema = z.strictObject({
+  discordId: z.string().min(1),
+  displayName: z.string().min(1),
+  playerId: z.number().int().positive(),
+  playerAlias: z.string().min(1),
+  accountId: z.number().int().positive(),
+  puuid: z.string().min(1),
+  riotGameName: z.string().min(1).nullable(),
+  riotTagLine: z.string().min(1).nullable(),
+  rosterOrder: z.number().int().nonnegative(),
+  benchOrder: z.number().int().nonnegative().nullable(),
+  team: CustomTeamSchema.nullable(),
+  side: CustomSideSchema.nullable(),
+  captain: z.boolean(),
+  pickOrder: z.number().int().min(1).max(8).nullable(),
+  championId: z.number().int().positive().nullable(),
+  won: z.boolean().nullable(),
+});
+export type CustomGameParticipant = z.infer<typeof CustomGameParticipantSchema>;
+
+export const CustomTournamentLobbySnapshotSchema = z.strictObject({
+  state: z.enum([
+    "created",
+    "lobby_open",
+    "champ_select",
+    "allocating",
+    "in_game",
+    "resolved",
+    "reported",
+    "cancelled",
+    "abandoned",
+    "expired",
+  ]),
+  code: z.string().min(1).nullable(),
+});
+
+export const CustomGameSnapshotSchema = z.strictObject({
+  id: z.uuid(),
+  sequence: z.number().int().positive(),
+  state: CustomGameStateSchema,
+  rosterMode: CustomRosterModeSchema,
+  map: CustomMapSchema,
+  pickMode: CustomPickModeSchema,
+  participants: z.array(CustomGameParticipantSchema),
+  activeCaptain: CustomTeamSchema.nullable(),
+  tournamentLobby: CustomTournamentLobbySnapshotSchema.nullable(),
+  winner: CustomWinnerSchema.nullable(),
+  voiceState: CustomVoiceStateSchema,
+  voiceReady: z.boolean(),
+  voiceOverride: z.boolean(),
+  voiceError: z.string().min(1).nullable(),
+  createdAt: z.iso.datetime(),
+  startedAt: z.iso.datetime().nullable(),
+  completedAt: z.iso.datetime().nullable(),
+});
+export type CustomGameSnapshot = z.infer<typeof CustomGameSnapshotSchema>;
+
+export const CustomRecruitmentCountsSchema = z.strictObject({
+  ready: z.number().int().nonnegative(),
+  maybe: z.number().int().nonnegative(),
+  away: z.number().int().nonnegative(),
+  held: z.number().int().nonnegative(),
+  remaining: z.number().int().min(0).max(10),
+});
+
+export const CustomNightSnapshotSchema = z.strictObject({
+  id: z.uuid(),
+  guildId: z.string().min(1),
+  guildName: z.string().min(1),
+  launchChannelId: z.string().min(1),
+  voiceLobbyChannelId: z.string().min(1),
+  hostDiscordId: z.string().min(1),
+  cohostDiscordIds: z.array(z.string().min(1)),
+  state: CustomNightStateSchema,
+  revision: z.number().int().nonnegative(),
+  participants: z.array(CustomNightParticipantSchema),
+  currentGame: CustomGameSnapshotSchema.nullable(),
+  recruitmentCounts: CustomRecruitmentCountsSchema,
+  recruitmentMessageId: z.string().min(1).nullable(),
+  teamAVoiceChannelId: z.string().min(1).nullable(),
+  teamBVoiceChannelId: z.string().min(1).nullable(),
+  lastActivityAt: z.iso.datetime(),
+  expiresAt: z.iso.datetime(),
+  endedAt: z.iso.datetime().nullable(),
+});
+export type CustomNightSnapshot = z.infer<typeof CustomNightSnapshotSchema>;
+
+export const CustomSnapshotEnvelopeSchema = z.strictObject({
+  kind: z.literal("snapshot"),
+  sequence: z.number().int().nonnegative(),
+  snapshot: CustomNightSnapshotSchema.nullable(),
+});
+export type CustomSnapshotEnvelope = z.infer<
+  typeof CustomSnapshotEnvelopeSchema
+>;
+
+export const CustomRevisionInputSchema = z.strictObject({
+  nightId: z.uuid(),
+  expectedRevision: z.number().int().nonnegative(),
+});
+export const CustomGuildInputSchema = z.strictObject({
+  guildId: z.string().min(1),
+});
+export const CustomCreateNightInputSchema = z.strictObject({
+  guildId: z.string().min(1),
+  guildName: z.string().min(1),
+  launchChannelId: z.string().min(1),
+  voiceLobbyChannelId: z.string().min(1),
+  disclosureVersion: z.string().min(1),
+});
+export const CustomJoinNightInputSchema = CustomRevisionInputSchema.extend({
+  displayName: z.string().trim().min(1).max(80),
+  avatarUrl: z.url().nullable(),
+  disclosureVersion: z.string().min(1),
+});
+export const CustomSetAvailabilityInputSchema =
+  CustomRevisionInputSchema.extend({ availability: CustomAvailabilitySchema });
+export const CustomSetAwayInputSchema = CustomRevisionInputSchema.extend({
+  awayUntil: z.iso.datetime().nullable(),
+});
+export const CustomTargetParticipantInputSchema =
+  CustomRevisionInputSchema.extend({ discordId: z.string().min(1) });
+export const CustomSetHeldInputSchema =
+  CustomTargetParticipantInputSchema.extend({ held: z.boolean() });
+export const CustomSelectAccountInputSchema = CustomRevisionInputSchema.extend({
+  accountId: z.number().int().positive(),
+  targetDiscordId: z.string().min(1).optional(),
+});
+export const CustomPrepareGameInputSchema = CustomRevisionInputSchema.extend({
+  rosterMode: CustomRosterModeSchema,
+  selectedDiscordIds: z.array(z.string().min(1)).max(10),
+  map: CustomMapSchema,
+  pickMode: CustomPickModeSchema,
+});
+export const CustomPickPlayerInputSchema = CustomTargetParticipantInputSchema;
+export const CustomSubstituteInputSchema = CustomRevisionInputSchema.extend({
+  outgoingDiscordId: z.string().min(1),
+  incomingDiscordId: z.string().min(1),
+});
+export const CustomAssignTeamInputSchema =
+  CustomTargetParticipantInputSchema.extend({ team: CustomTeamSchema });
+export const CustomSetCohostInputSchema =
+  CustomTargetParticipantInputSchema.extend({ cohost: z.boolean() });
+export const CustomVoiceOverrideInputSchema = CustomRevisionInputSchema.extend({
+  enabled: z.boolean(),
+});
+export const CustomIntermissionInputSchema = CustomRevisionInputSchema.extend({
+  choice: CustomIntermissionChoiceSchema,
+});
+
+export const CustomAuditEventSchema = z.strictObject({
+  id: z.uuid(),
+  nightId: z.uuid(),
+  gameId: z.uuid().nullable(),
+  revision: z.number().int().nonnegative(),
+  actorId: z.string().min(1),
+  action: z.string().min(1),
+  payload: z.unknown(),
+  source: z.enum(["ACTIVITY", "DISCORD", "RIOT", "OPERATOR"]),
+  createdAt: z.iso.datetime(),
+});
+export type CustomAuditEvent = z.infer<typeof CustomAuditEventSchema>;
+export const CustomHistorySchema = z.strictObject({
+  night: CustomNightSnapshotSchema,
+  games: z.array(CustomGameSnapshotSchema),
+  audit: z.array(CustomAuditEventSchema),
+});
+export type CustomHistory = z.infer<typeof CustomHistorySchema>;
+
+export const CustomActivityClaimsSchema = z.strictObject({
+  sub: z.string().min(1),
+  guildId: z.string().min(1),
+  channelId: z.string().min(1),
+  instanceId: z.string().min(1),
+  applicationId: z.string().min(1),
+  type: z.literal("customs_activity"),
+});
+export type CustomActivityClaims = z.infer<typeof CustomActivityClaimsSchema>;
+export const CustomAuthExchangeInputSchema = z.strictObject({
+  code: z.string().min(1),
+  guildId: z.string().min(1),
+  channelId: z.string().min(1),
+  instanceId: z.string().min(1),
+});
+export const CustomAuthRefreshInputSchema = z.strictObject({
+  activityToken: z.string().min(1),
+  discordRefreshToken: z.string().min(1),
+});
+export const CustomAuthResponseSchema = z.strictObject({
+  discordAccessToken: z.string().min(1),
+  discordRefreshToken: z.string().min(1),
+  activityToken: z.string().min(1),
+  expiresAt: z.iso.datetime(),
+  refreshUntil: z.iso.datetime(),
+  contractHash: z.string().min(1),
+});
+export type CustomAuthResponse = z.infer<typeof CustomAuthResponseSchema>;

--- a/packages/scout-for-lol/packages/data/src/index.ts
+++ b/packages/scout-for-lol/packages/data/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./model/index.ts";
+export * from "./customs/customs.schema.ts";
 export {
   friendGroupHistory,
   getPerson,

--- a/packages/scout-for-lol/packages/data/src/model/permissions/catalog.ts
+++ b/packages/scout-for-lol/packages/data/src/model/permissions/catalog.ts
@@ -64,6 +64,10 @@ const MEMBER_SCHEMAS = {
     resource: z.literal("channels"),
     action: z.enum(PERMISSION_CATALOG.channels.actions.map((a) => a.name)),
   }),
+  customs: z.object({
+    resource: z.literal("customs"),
+    action: z.enum(PERMISSION_CATALOG.customs.actions.map((a) => a.name)),
+  }),
   audit: z.object({
     resource: z.literal("audit"),
     action: z.enum(PERMISSION_CATALOG.audit.actions.map((a) => a.name)),
@@ -81,6 +85,7 @@ export const PermissionSchema = z.discriminatedUnion("resource", [
   MEMBER_SCHEMAS.competitions,
   MEMBER_SCHEMAS.reports,
   MEMBER_SCHEMAS.channels,
+  MEMBER_SCHEMAS.customs,
   MEMBER_SCHEMAS.audit,
   MEMBER_SCHEMAS.roles,
 ]);

--- a/packages/scout-for-lol/packages/data/src/model/permissions/permissions.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/permissions/permissions.test.ts
@@ -36,8 +36,8 @@ describe("catalog", () => {
       0,
     );
     expect(ALL_PERMISSIONS.length).toBe(expected);
-    expect(ALL_PERMISSIONS.length).toBe(31);
-    expect(Object.keys(PERMISSION_CATALOG).length).toBe(8);
+    expect(ALL_PERMISSIONS.length).toBe(33);
+    expect(Object.keys(PERMISSION_CATALOG).length).toBe(9);
   });
 
   test("every catalog pair round-trips through the DB key form", () => {

--- a/packages/scout-for-lol/packages/data/src/model/permissions/roles.ts
+++ b/packages/scout-for-lol/packages/data/src/model/permissions/roles.ts
@@ -34,6 +34,7 @@ const VIEWER = reads(
   "competitions",
   "reports",
   "channels",
+  "customs",
 );
 const MANAGER = everythingExcept("roles");
 const ADMIN = [...ALL_PERMISSIONS];


### PR DESCRIPTION
## Why

The retired Customs branch stored a second copy of Tournament and result state in SQLite. Main now has a PostgreSQL Tournament foundation and Match-V5 ingestion pipeline, so the durable domain must share those authorities.

## What

- adds normalized night, participant, consent, game participant, active pointer, and append-only audit models
- links each game to at most one Tournament lobby without copying provider identifiers, codes, callbacks, or match IDs
- exposes Zod snapshots and revision-bound contracts with explicit Customs permissions
- projects authoritative Match-V5 results and lobby reporting atomically before player cursor advancement
- adds `custom_nights_enabled`, default off and hard-disabled in production

## Verification

- PostgreSQL repository and Riot-result integration tests
- Customs state machine, authorization, and schema unit tests
- backend/data typecheck and lint
- `bunx lefthook run pre-commit`

No abandoned SQLite data was imported. This is stack 2 of 4.