### PR TITLE
fix(homelab): refuse an ArgoCD sync that rolls an internal image backwards

### DIFF
--- a/packages/homelab/scripts/argocd-apply-safety.test.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.test.ts
@@ -577,3 +577,185 @@ describe("ArgoCD probe handler safety", () => {
     ]);
   });
 });
+
+// An internal image pin moving backwards is how an unmerged `version
+// commit-back` bump PR silently rolls production back: the release renders from
+// the version catalog whenever a build pushes no digests of its own.
+function workload(image: string): string {
+  return state({
+    spec: {
+      template: {
+        spec: { containers: [{ name: "worker", image }] },
+      },
+    },
+  });
+}
+
+function deployment(liveImage: string, targetImage: string) {
+  return {
+    group: "apps",
+    kind: "Deployment",
+    namespace: "temporal",
+    name: "worker",
+    liveState: workload(liveImage),
+    targetState: workload(targetImage),
+  };
+}
+
+describe("ArgoCD internal image downgrades", () => {
+  const repo = "ghcr.io/shepherdjerred/temporal-worker";
+  const digestA = `@sha256:${"a".repeat(64)}`;
+  const digestB = `@sha256:${"b".repeat(64)}`;
+
+  test("refuses a build-number rollback", () => {
+    expect(
+      analyzeApplySafety([
+        deployment(
+          `${repo}:2.0.0-12684${digestA}`,
+          `${repo}:2.0.0-12368${digestB}`,
+        ),
+      ]),
+    ).toEqual([
+      "apps/Deployment temporal/worker downgrades /spec/template/spec/containers/[name=worker]/image from 2.0.0-12684 to 2.0.0-12368; the version catalog is behind the running release",
+    ]);
+  });
+
+  test("allows an upgrade, a rebuild of the same build, and a digest-only change", () => {
+    expect(
+      analyzeApplySafety([
+        deployment(
+          `${repo}:2.0.0-12368${digestA}`,
+          `${repo}:2.0.0-12684${digestB}`,
+        ),
+        deployment(
+          `${repo}:2.0.0-12684${digestA}`,
+          `${repo}:2.0.0-12684${digestB}`,
+        ),
+      ]),
+    ).toEqual([]);
+  });
+
+  // Third-party images use upstream versioning, so their tags are not
+  // comparable build numbers and must not be judged here.
+  test("ignores images that are not release-tagged", () => {
+    expect(
+      analyzeApplySafety([
+        deployment("postgres:17.2", "postgres:16.1"),
+        deployment("temporalio/server:1.29.7", "temporalio/server:1.28.0"),
+      ]),
+    ).toEqual([]);
+  });
+
+  // A repository swap is a different change with different review questions;
+  // comparing build numbers across two images would be meaningless.
+  test("ignores a repository change", () => {
+    expect(
+      analyzeApplySafety([
+        deployment(
+          `${repo}:2.0.0-12684${digestA}`,
+          `ghcr.io/shepherdjerred/birmel:2.0.0-12368${digestB}`,
+        ),
+      ]),
+    ).toEqual([]);
+  });
+
+  // Containers merge by name, so a chart that reorders or inserts one must not
+  // produce a phantom downgrade from comparing mismatched positions.
+  test("compares containers by name, not position", () => {
+    const live = state({
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              { name: "worker", image: `${repo}:2.0.0-12684${digestA}` },
+              { name: "sidecar", image: `${repo}:2.0.0-12684${digestA}` },
+            ],
+          },
+        },
+      },
+    });
+    const target = state({
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              { name: "sidecar", image: `${repo}:2.0.0-12684${digestB}` },
+              { name: "worker", image: `${repo}:2.0.0-12684${digestB}` },
+            ],
+          },
+        },
+      },
+    });
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "temporal",
+          name: "worker",
+          liveState: live,
+          targetState: target,
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("catches a rollback in an init container", () => {
+    const live = state({
+      spec: {
+        template: {
+          spec: {
+            initContainers: [
+              { name: "install", image: `${repo}:2.0.0-12684${digestA}` },
+            ],
+          },
+        },
+      },
+    });
+    const target = state({
+      spec: {
+        template: {
+          spec: {
+            initContainers: [
+              { name: "install", image: `${repo}:2.0.0-12368${digestA}` },
+            ],
+          },
+        },
+      },
+    });
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "temporal",
+          name: "agent",
+          liveState: live,
+          targetState: target,
+        },
+      ]),
+    ).toEqual([
+      "apps/Deployment temporal/agent downgrades /spec/template/spec/initContainers/[name=install]/image from 2.0.0-12684 to 2.0.0-12368; the version catalog is behind the running release",
+    ]);
+  });
+
+  // A container that does not exist live yet cannot be a downgrade.
+  test("ignores a container that is only in the target", () => {
+    const live = state({
+      spec: { template: { spec: { containers: [] } } },
+    });
+    const target = workload(`${repo}:2.0.0-12368${digestA}`);
+    expect(
+      analyzeApplySafety([
+        {
+          group: "apps",
+          kind: "Deployment",
+          namespace: "temporal",
+          name: "new",
+          liveState: live,
+          targetState: target,
+        },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/packages/homelab/scripts/argocd-apply-safety.ts
+++ b/packages/homelab/scripts/argocd-apply-safety.ts
@@ -325,6 +325,111 @@ function collectProbeHandlers(
   }
 }
 
+/**
+ * Internal images are tagged `2.0.0-<buildNumber>` by the release, so their
+ * build numbers are directly comparable. Third-party images use their upstream
+ * versioning and are deliberately not matched here.
+ */
+const RELEASE_IMAGE_PATTERN =
+  /^(?<repository>.+):2\.0\.0-(?<build>\d+)(?:@sha256:[a-f\d]{64})?$/;
+
+type ReleaseImage = { repository: string; build: number };
+
+function parseReleaseImage(value: unknown): ReleaseImage | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const match = RELEASE_IMAGE_PATTERN.exec(value);
+  const repository = match?.groups?.["repository"];
+  const build = match?.groups?.["build"];
+  if (repository === undefined || build === undefined) {
+    return null;
+  }
+  return { repository, build: Number.parseInt(build, 10) };
+}
+
+/**
+ * Walks every `image` field, keyed by the same name-stable path the probe walk
+ * uses, so a container is compared against itself on both sides.
+ */
+function collectReleaseImages(
+  value: unknown,
+  path: string,
+  output: Map<string, ReleaseImage>,
+): void {
+  if (Array.isArray(value)) {
+    const segments = arrayEntrySegments(value);
+    for (const [index, entry] of value.entries()) {
+      collectReleaseImages(
+        entry,
+        `${path}/${segments[index] ?? index.toString()}`,
+        output,
+      );
+    }
+    return;
+  }
+  const parsed = JsonObjectSchema.safeParse(value);
+  if (!parsed.success) {
+    return;
+  }
+  for (const [key, entry] of Object.entries(parsed.data)) {
+    const entryPath = `${path}/${key}`;
+    if (key === "image") {
+      const image = parseReleaseImage(entry);
+      if (image !== null) {
+        output.set(entryPath, image);
+      }
+    }
+    collectReleaseImages(entry, entryPath, output);
+  }
+}
+
+/**
+ * Refuses a sync that would move an internal image *backwards*.
+ *
+ * The release renders internal image pins from the version catalog and then
+ * overlays the digests this build actually pushed
+ * (applyCurrentBuildImageOverrides). When a build pushes nothing — a re-run of
+ * an already-published commit makes `ci-changed.ts images` skip the step, which
+ * sets the handoff to `{}` — the overlay is empty and the chart falls back to
+ * the catalog alone. The catalog only advances when the `version commit-back`
+ * bump PR merges, so a bump PR left unmerged silently rolls production back to
+ * whatever it last recorded. On 2026-08-30 that reverted all 13 temporal
+ * workers roughly 300 builds, and one crash-looped because the chart set a
+ * worker role its resurrected image predated.
+ *
+ * A rollback is legitimate sometimes, but it must be deliberate. Every path
+ * that produces one accidentally routes through here, so this is the one place
+ * that can catch the whole class rather than the single cause above.
+ */
+function imageDowngradeFindings(
+  live: Record<string, unknown>,
+  target: Record<string, unknown>,
+  resourceIdentity: string,
+): readonly string[] {
+  const liveImages = new Map<string, ReleaseImage>();
+  const targetImages = new Map<string, ReleaseImage>();
+  collectReleaseImages(live, "", liveImages);
+  collectReleaseImages(target, "", targetImages);
+  const findings: string[] = [];
+  for (const [path, liveImage] of liveImages) {
+    const targetImage = targetImages.get(path);
+    if (targetImage === undefined) {
+      continue;
+    }
+    if (targetImage.repository !== liveImage.repository) {
+      continue;
+    }
+    if (targetImage.build >= liveImage.build) {
+      continue;
+    }
+    findings.push(
+      `${resourceIdentity} downgrades ${path} from 2.0.0-${liveImage.build.toString()} to 2.0.0-${targetImage.build.toString()}; the version catalog is behind the running release`,
+    );
+  }
+  return findings;
+}
+
 function identity(resource: ManagedResource): string {
   return `${resource.group ?? ""}/${resource.kind} ${resource.namespace ?? "_cluster"}/${resource.name}`;
 }
@@ -464,6 +569,7 @@ export function analyzeApplySafety(
         ...embeddedListFindings(live, target, list, identity(resource)),
       );
     }
+    findings.push(...imageDowngradeFindings(live, target, identity(resource)));
     const liveProbes = new Map<string, string>();
     const targetProbes = new Map<string, string>();
     collectProbeHandlers(live, "", liveProbes);


### PR DESCRIPTION
## Why

The release renders internal image pins from the version catalog, then overlays the digests the current build actually pushed (`applyCurrentBuildImageOverrides`). When a build pushes nothing, the overlay is empty and applies **no** overrides at all:

```ts
if (Object.keys(digests).length === 0) { return postgresImageDigests; }
```

so the chart falls back to the catalog alone. The catalog only advances when the `version commit-back` bump PR merges, so a bump PR left unmerged lets the catalog drift arbitrarily far behind what is actually running — and the next build that pushes no digests silently redeploys that stale pin.

That happened on 2026-08-30. Re-running a main build on an already-published commit made `ci-changed.ts images` skip the images step, which deliberately sets the handoff to `{}`:

```bash
if ! bun --no-install .buildkite/scripts/ci-changed.ts images; then
  jq -n '{}' | buildkite-agent meta-data set image-digests
```

The catalog was ~300 builds behind, so all 13 temporal workers were rolled back from `2.0.0-12684` to `2.0.0-12368`, and `temporal-temporal-workflows` crash-looped:

```
Worker failed: Invalid option: expected one of "all"|"agent"|"control"|…|"scout"
```

— the chart sets `TEMPORAL_WORKER_ROLE=workflows` and the resurrected image predated that value in `WorkerRoleSchema`. Nothing warned, because an empty overlay is indistinguishable from "no image changed".

## What

`analyzeApplySafety` now reports a finding when a managed resource's target moves an internal `2.0.0-<build>` image to a **lower** build number than the live one, so `assertApplySafe` refuses the sync:

```
apps/Deployment temporal/worker downgrades /spec/template/spec/containers/[name=worker]/image
from 2.0.0-12684 to 2.0.0-12368; the version catalog is behind the running release
```

Scope was chosen to avoid false positives:

- Images are collected by the **same name-stable path** the existing probe walk uses (`arrayEntrySegments`), so a container is compared against itself even when the chart reorders or inserts entries.
- Only `2.0.0-<build>` tags are compared. Third-party images use upstream versioning and are ignored.
- A repository change is skipped — two different images have no comparable build numbers.
- A container present only in the target is ignored; it cannot be a downgrade.

Placed at the apply boundary rather than at the cause on purpose: a rollback is legitimate sometimes but must be *intentional*, and every accidental path reaches production through this preflight, so one check covers the whole class instead of the single trigger above.

## Verification

- `bunx turbo run typecheck lint test --filter=homelab` — 4/4 tasks, 28 tests, 0 lint errors.
- Proved the guard can fail: with the `imageDowngradeFindings` call removed, the two positive tests fail (2 failed | 26 passed); restored, all 28 pass.
- Not run live: this changes a CI preflight only. It was exercised against the real incident shape — the rollback test uses the exact `2.0.0-12684 → 2.0.0-12368` transition observed in production.

No media: this is a CI-side correctness guard with no user-visible surface.