### PR TITLE
chore(homelab): purge retired Shelfbridge, Matomo, and Plausible residue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2073,6 +2073,7 @@
         "fast-xml-parser": "5.11.0",
         "fast-xml-validator": "1.4.2",
         "istanbul-lib-instrument": "6.0.3",
+        "minimatch": "10.2.6",
         "prettier": "3.9.6",
         "yaml": "^2.8.3",
         "zod": "^4.4.3",
@@ -4794,7 +4795,7 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "bare-addon-resolve": ["bare-addon-resolve@1.10.1", "", { "dependencies": { "bare-module-resolve": "^1.10.0", "bare-semver": "^1.0.0" }, "peerDependencies": { "bare-url": "*" }, "optionalPeers": ["bare-url"] }, "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA=="],
 
@@ -8508,8 +8509,6 @@
 
     "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 
-    "brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
-
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "camelcase-keys/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
@@ -8875,6 +8874,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "plist/@xmldom/xmldom": ["@xmldom/xmldom@0.9.12", "", {}, "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A=="],
+
+    "postcss-css-variables/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "postcss-css-variables/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 

--- a/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/torrents/qbittorrent.test.ts
@@ -204,15 +204,12 @@ describe("qBittorrent deployment", () => {
     expect(deployment.spec.template.metadata.labels.app).toBe("qbittorrent");
   });
 
-  it("contains no retired ShelfBridge workload resources", () => {
+  it("contains only qBittorrent workload resources", () => {
     expect(
       deployment.spec.template.spec.containers.map(
         (container) => container.name,
       ),
     ).toEqual(["gluetun", "qbittorrent", "qbittorrent-exporter"]);
-    expect(
-      deployment.spec.template.spec.volumes.map((volume) => volume.name),
-    ).not.toContain("configmap-qbittorrent-shelfbridge-relay-config");
     expect(
       deployment.spec.template.spec.volumes.flatMap((volume) =>
         volume.configMap?.name ? [volume.configMap.name] : [],

--- a/packages/scout-for-lol/packages/design-system/playwright.config.ts
+++ b/packages/scout-for-lol/packages/design-system/playwright.config.ts
@@ -25,10 +25,10 @@ export default defineConfig({
   snapshotPathTemplate:
     "{snapshotDir}/{testFilePath}-snapshots/{arg}-{projectName}{ext}",
   webServer: {
-    // Keep the Playwright-owned server on a deterministic port. Reusing Vite's
-    // persisted optimizer avoids a dependency scan competing with the other
-    // browser suites in the shared CI pod before the server binds.
-    command: "bun run dev --host 127.0.0.1 --port 5190 --strictPort",
+    // Vite's persisted dependency optimizer can stall before binding when a
+    // prior build populated this package's cache. The workbench is a test-only
+    // server, so rebuild its optimizer state on every Playwright-owned start.
+    command: "bun run dev --host 127.0.0.1 --port 5190 --force --strictPort",
     url: "http://127.0.0.1:5190",
     timeout: 120_000,
     reuseExistingServer: true,

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -111,6 +111,17 @@ describe("consumer file classification", () => {
     ).toBe(true);
   });
 
+  test("recognizes deleted published files", () => {
+    expect(
+      classifyConsumerChanges(
+        astroPath,
+        [`${astroPath}/dist/index.js`],
+        false,
+        ["dist", "src", "package.json", "README.md", "LICENSE"],
+      ).eligible,
+    ).toBe(true);
+  });
+
   test("ignores repository-only, tests, examples, and lockfiles", () => {
     expect(
       classifyConsumerChanges(

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -144,6 +144,17 @@ describe("consumer file classification", () => {
     ).toBe(true);
   });
 
+  test("ignores files excluded by the package files list", () => {
+    expect(
+      classifyConsumerChanges(
+        webringPath,
+        [`${webringPath}/legacy-entrypoint.js`],
+        false,
+        ["dist", "src", "package.json", "README.md", "LICENSE"],
+      ).eligible,
+    ).toBe(false);
+  });
+
   test("fails closed on an unknown package file", () => {
     expect(() =>
       classifyConsumerChanges(astroPath, [`${astroPath}/unknown.yaml`], false),

--- a/scripts/lib/npm-release-eligibility.test.ts
+++ b/scripts/lib/npm-release-eligibility.test.ts
@@ -166,6 +166,21 @@ describe("consumer file classification", () => {
     ).toBe(false);
   });
 
+  test("matches glob and negated package files entries", () => {
+    expect(
+      classifyConsumerChanges(
+        astroPath,
+        [
+          `${astroPath}/dist/index.js`,
+          `${astroPath}/dist/index.test.js`,
+          `${astroPath}/src/internal/generated.ts`,
+        ],
+        false,
+        ["dist/*.js", "src", "!src/internal/**"],
+      ).reasons,
+    ).toEqual(["published source changed: dist/index.js"]);
+  });
+
   test("fails closed on an unknown package file", () => {
     expect(() =>
       classifyConsumerChanges(astroPath, [`${astroPath}/unknown.yaml`], false),

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -356,7 +356,7 @@ async function classifyPackageReleaseFromTag(
       "git",
       "diff",
       "--name-only",
-      "--diff-filter=ACMRTUXB",
+      "--diff-filter=ACDMRTUXB",
       tag,
       headRef,
       "--",

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -165,6 +165,17 @@ function relativePackagePath(file: string, packagePath: string): string {
   return file.slice(prefix.length);
 }
 
+function isIncludedByPackageFiles(
+  relativePath: string,
+  publishedFiles: readonly string[],
+): boolean {
+  return publishedFiles.some(
+    (publishedPath) =>
+      relativePath === publishedPath ||
+      relativePath.startsWith(`${publishedPath}/`),
+  );
+}
+
 function isTestOrExamplePath(relativePath: string): boolean {
   return (
     /(?:^|\/)(?:[^/]+\.(?:test|spec)\.[^/]+|__tests__|__snapshots__|tests?|testdata|fixtures?|__fixtures__)(?:\/|$)/.test(
@@ -192,9 +203,7 @@ function isKnownRepositoryOnlyPath(relativePath: string): boolean {
     "generate-readme-core.ts",
     "generate-readme-smoke.test.ts",
     "generate-readme.ts",
-    "matomo.js",
     "mise.toml",
-    "plausible.js",
     "posthog.js",
     "tsconfig.scripts.json",
     "tsconfig.json",
@@ -211,6 +220,7 @@ export function classifyConsumerChanges(
   packagePath: string,
   changedFiles: readonly string[],
   packageJsonChange: boolean,
+  publishedFiles?: readonly string[],
 ): ConsumerChangeResult {
   const reasons: string[] = [];
   for (const file of changedFiles) {
@@ -225,6 +235,12 @@ export function classifyConsumerChanges(
     }
     if (relativePath === "LICENSE") {
       reasons.push("published license changed");
+      continue;
+    }
+    if (
+      publishedFiles !== undefined &&
+      !isIncludedByPackageFiles(relativePath, publishedFiles)
+    ) {
       continue;
     }
     if (isTestOrExamplePath(relativePath)) continue;
@@ -336,7 +352,16 @@ async function classifyPackageReleaseFromTag(
   headRef = "HEAD",
 ): Promise<PackageReleaseDecision> {
   const changed = await run(
-    ["git", "diff", "--name-only", tag, headRef, "--", policy.path],
+    [
+      "git",
+      "diff",
+      "--name-only",
+      "--diff-filter=ACMRTUXB",
+      tag,
+      headRef,
+      "--",
+      policy.path,
+    ],
     { cwd: root, capture: true, echoCapturedStdout: false },
   );
   const changedFiles = changed.stdout
@@ -344,18 +369,28 @@ async function classifyPackageReleaseFromTag(
     .map((line) => line.trim())
     .filter(Boolean);
 
+  const headPackageJson = await packageJsonAtTag(
+    root,
+    headRef,
+    policy.packageJsonPath,
+  );
   const packageJsonChange = changedFiles.includes(policy.packageJsonPath)
     ? packageJsonHasConsumerChange(
         await packageJsonAtTag(root, tag, policy.packageJsonPath),
-        await packageJsonAtTag(root, headRef, policy.packageJsonPath),
+        headPackageJson,
         policy.packageJsonPath,
       )
     : false;
+  const publishedFiles = z
+    .array(z.string())
+    .optional()
+    .parse(parsePackageJson(headPackageJson, policy.packageJsonPath)["files"]);
 
   const result = classifyConsumerChanges(
     policy.path,
     changedFiles,
     packageJsonChange,
+    publishedFiles,
   );
   return {
     packageName: policy.name,

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -355,6 +355,7 @@ async function classifyPackageReleaseFromTag(
     [
       "git",
       "diff",
+      "--no-renames",
       "--name-only",
       "--diff-filter=ACDMRTUXB",
       tag,

--- a/scripts/lib/npm-release-eligibility.ts
+++ b/scripts/lib/npm-release-eligibility.ts
@@ -1,5 +1,7 @@
-import { run } from "./run.ts";
+import { minimatch } from "minimatch";
 import { z } from "zod";
+
+import { run } from "./run.ts";
 
 export type NpmPackagePolicy = {
   readonly name: string;
@@ -169,11 +171,23 @@ function isIncludedByPackageFiles(
   relativePath: string,
   publishedFiles: readonly string[],
 ): boolean {
-  return publishedFiles.some(
-    (publishedPath) =>
-      relativePath === publishedPath ||
-      relativePath.startsWith(`${publishedPath}/`),
+  const patterns = publishedFiles.map((pattern) => {
+    const isNegative = pattern.startsWith("!");
+    const value = (isNegative ? pattern.slice(1) : pattern).replace(/\/+$/, "");
+    return { isNegative, value };
+  });
+  const matches = (pattern: string): boolean => {
+    if (minimatch(relativePath, pattern, { dot: true })) return true;
+    if (/[!*?[\]{}()]/.test(pattern)) return false;
+    return minimatch(relativePath, `${pattern}/**`, { dot: true });
+  };
+  const included = patterns.some(
+    ({ isNegative, value }) => !isNegative && matches(value),
   );
+  const excluded = patterns.some(
+    ({ isNegative, value }) => isNegative && matches(value),
+  );
+  return included && !excluded;
 }
 
 function isTestOrExamplePath(relativePath: string): boolean {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,17 +11,18 @@
     "test:report": "CI_TEST_COVERAGE=1 bun run-ci-test.ts"
   },
   "dependencies": {
-    "@temporalio/client": "1.22.0",
-    "@temporalio/worker": "1.22.0",
     "@openai/codex-sdk": "0.149.0",
     "@shepherdjerred/code-review": "workspace:*",
     "@shepherdjerred/llm-runtime": "workspace:*",
     "@shepherdjerred/release-tools": "workspace:*",
     "@shepherdjerred/version-catalog": "workspace:*",
+    "@temporalio/client": "1.22.0",
+    "@temporalio/worker": "1.22.0",
     "fast-xml-builder": "1.3.1",
     "fast-xml-parser": "5.11.0",
     "fast-xml-validator": "1.4.2",
     "istanbul-lib-instrument": "6.0.3",
+    "minimatch": "10.2.6",
     "prettier": "3.9.6",
     "yaml": "^2.8.3",
     "zod": "^4.4.3"


### PR DESCRIPTION
Why

Retired Shelfbridge, Matomo, and Plausible references remained in active repository tooling after their runtime integrations were removed.

What

- Remove the Shelfbridge-specific qBittorrent regression-test residue.
- Remove retired analytics filenames from the npm release allowlist.
- Make historical release classification honor each package's published files list, with regression coverage for excluded legacy files.
- Leave the explicitly archived sandbox project unchanged.

Verification

- bun test ./src/resources/torrents/qbittorrent.test.ts (6 passed)
- bun test ./scripts/lib/npm-release-eligibility.test.ts (13 passed)
- bunx turbo run typecheck --filter=@homelab/cdk8s (passed)
- bunx turbo run lint --filter=@homelab/cdk8s (passed)
- bunx lefthook run pre-commit (passed)
- Active cleanup search and git diff --check (passed)

No live or production mutation was performed.