### PR TITLE
feat(trmnl-dashboard): add pet-care monitoring and dashboard

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -323,6 +323,7 @@ const commands: Record<
       TRMNL_API_KEY: "smoke-test-dummy",
       HA_TOKEN: "smoke-test-dummy",
       HA_URL: "http://127.0.0.1:9999",
+      FEATURE_FLAGS_MODE: "disabled",
       PORT: "18790",
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -1996,6 +1996,7 @@
         "@shepherdjerred/config": "workspace:*",
         "@shepherdjerred/feature-flags": "workspace:*",
         "@shepherdjerred/home-assistant": "workspace:*",
+        "prom-client": "^15.1.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -1993,6 +1993,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@sentry/bun": "^10.70.0",
+        "@shepherdjerred/config": "workspace:*",
+        "@shepherdjerred/feature-flags": "workspace:*",
         "@shepherdjerred/home-assistant": "workspace:*",
         "zod": "^4.4.3",
       },
@@ -2003,6 +2005,7 @@
         "@vitest/coverage-istanbul": "4.1.10",
         "eslint": "^10.3.0",
         "jiti": "^2.7.0",
+        "liquidjs": "^10.29.0",
         "typescript": "^6.0.3",
         "vitest": "4.1.10",
       },
@@ -6180,6 +6183,8 @@
 
     "linkify-it": ["linkify-it@6.1.0", "", { "dependencies": { "uc.micro": "^3.0.0" } }, "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw=="],
 
+    "liquidjs": ["liquidjs@10.29.0", "", { "dependencies": { "commander": "^10.0.0" }, "bin": { "liquid": "bin/liquid.js", "liquidjs": "bin/liquid.js" } }, "sha512-pCVOhs6FLAR8su3ItJ07diN26t6W5dHQRnmTMy8HPyTFuv1+oSCVJIGp5pGjfQyOZfh50KswvKtMTp6p4JEIdw=="],
+
     "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
     "local-pkg": ["local-pkg@1.2.1", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q=="],
@@ -8741,6 +8746,8 @@
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
+    "liquidjs/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -689,6 +689,17 @@
       "thresholdRollouts": []
     },
     {
+      "key": "pet-dashboard-enabled",
+      "owner": "trmnl-dashboard",
+      "source": "trmnl-dashboard",
+      "purpose": "Expose the authenticated pet-care TRMNL dashboard payload after deployment verification.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
       "key": "streambot-idle-timeout-seconds",
       "owner": "streambot",
       "source": "streambot-dynamic",

--- a/packages/home-assistant/README.md
+++ b/packages/home-assistant/README.md
@@ -2,6 +2,11 @@
 
 TypeScript client for the [Home Assistant](https://www.home-assistant.io/) REST and WebSocket APIs. Zod-validated responses, works under both Bun and Node.js (standard global `fetch` and `WebSocket`). Workspace-internal package — consumed by other packages in this monorepo via `"@shepherdjerred/home-assistant": "workspace:*"`; not published to npm.
 
+The REST client also exposes authenticated config-entry diagnostics with a
+caller-supplied Zod schema. The event client can list the entity registry, which
+lets consumers discover a config-entry ID from an entity instead of persisting
+Home Assistant's internal identifier.
+
 ## Quick start
 
 Everything exports from `src/index.ts`:

--- a/packages/home-assistant/src/index.ts
+++ b/packages/home-assistant/src/index.ts
@@ -9,6 +9,7 @@ export type {
   ServiceCallWithResponse,
   HistoryResponse,
   FireEventResponse,
+  ConfigEntryDiagnostics,
 } from "./rest/schemas.ts";
 export {
   EntityState as EntityStateSchema,
@@ -18,6 +19,7 @@ export {
   ServiceCallWithResponse as ServiceCallWithResponseSchema,
   HistoryResponse as HistoryResponseSchema,
   FireEventResponse as FireEventResponseSchema,
+  ConfigEntryDiagnostics as ConfigEntryDiagnosticsSchema,
 } from "./rest/schemas.ts";
 export { HomeAssistantEventClient } from "./ws/client.ts";
 export type {
@@ -30,8 +32,15 @@ export {
   HaWebSocketClosedError,
   HaWebSocketResultError,
 } from "./ws/errors.ts";
-export type { EventEnvelope, EventMessage } from "./ws/messages.ts";
-export { StateChangedEventData as StateChangedEventDataSchema } from "./ws/messages.ts";
+export type {
+  EntityRegistryEntry,
+  EventEnvelope,
+  EventMessage,
+} from "./ws/messages.ts";
+export {
+  EntityRegistryEntry as EntityRegistryEntrySchema,
+  StateChangedEventData as StateChangedEventDataSchema,
+} from "./ws/messages.ts";
 export type { EventHandler, Subscription } from "./ws/subscriptions.ts";
 export type { HomeAssistantConfig } from "./shared/config.ts";
 export type {

--- a/packages/home-assistant/src/rest/client.ts
+++ b/packages/home-assistant/src/rest/client.ts
@@ -14,6 +14,7 @@ import { normalizeBaseUrl } from "#shared/config.ts";
 import { HaApiError, HaAuthError, HaNotFoundError } from "./errors.ts";
 import {
   EntityState,
+  ConfigEntryDiagnostics,
   FireEventResponse,
   HaConfig,
   HistoryResponse,
@@ -122,6 +123,15 @@ export class HomeAssistantRestClient<S extends HaSchema = DefaultHaSchema> {
     const path = `/api/history/period/${start.toISOString()}?${params.toString()}`;
     const body = await this.request("GET", path);
     return HistoryResponse.parse(body);
+  }
+
+  public async getConfigEntryDiagnostics<T>(
+    configEntryId: string,
+    dataSchema: z.ZodType<T>,
+  ): Promise<T> {
+    const path = `/api/diagnostics/config_entry/${encodeURIComponent(configEntryId)}`;
+    const body = ConfigEntryDiagnostics.parse(await this.request("GET", path));
+    return dataSchema.parse(body.data);
   }
 
   private buildServicePath(

--- a/packages/home-assistant/src/rest/schemas.ts
+++ b/packages/home-assistant/src/rest/schemas.ts
@@ -72,3 +72,16 @@ export type FireEventResponse = z.infer<typeof FireEventResponse>;
 export const HistoryResponse = z.array(z.array(EntityState));
 
 export type HistoryResponse = z.infer<typeof HistoryResponse>;
+
+export const ConfigEntryDiagnostics = z
+  .object({
+    home_assistant: z.record(z.string(), z.unknown()),
+    custom_components: z.record(z.string(), z.unknown()),
+    integration_manifest: z.record(z.string(), z.unknown()),
+    setup_times: z.record(z.string(), z.unknown()),
+    data: z.unknown(),
+    issues: z.array(z.unknown()),
+  })
+  .loose();
+
+export type ConfigEntryDiagnostics = z.infer<typeof ConfigEntryDiagnostics>;

--- a/packages/home-assistant/src/ws/client.ts
+++ b/packages/home-assistant/src/ws/client.ts
@@ -17,7 +17,8 @@ import {
   HaWebSocketResultError,
 } from "./errors.ts";
 import type { EventMessage, ResultMessage } from "./messages.ts";
-import { AuthMessage, ServerMessage } from "./messages.ts";
+import { AuthMessage, EntityRegistryEntry, ServerMessage } from "./messages.ts";
+import type { EntityRegistryEntry as EntityRegistryEntryType } from "./messages.ts";
 import type { WebSocketLike, WebSocketLikeCtor } from "./socket-helpers.ts";
 import {
   buildWsUrl,
@@ -174,6 +175,13 @@ export class HomeAssistantEventClient<S extends HaSchema = DefaultHaSchema> {
   public async getStates(): Promise<EntityState[]> {
     const { result } = this.sendRequest({ type: "get_states" });
     return z.array(EntityStateSchema).parse(await result);
+  }
+
+  public async getEntityRegistry(): Promise<EntityRegistryEntryType[]> {
+    const { result } = this.sendRequest({
+      type: "config/entity_registry/list",
+    });
+    return z.array(EntityRegistryEntry).parse(await result);
   }
 
   private async openAndAuth(): Promise<void> {

--- a/packages/home-assistant/src/ws/messages.ts
+++ b/packages/home-assistant/src/ws/messages.ts
@@ -84,6 +84,22 @@ export type StateChangedEvent = {
   old_state: unknown;
 };
 
+export const EntityRegistryEntry = z
+  .object({
+    entity_id: z.string().min(1),
+    unique_id: z.string().min(1),
+    platform: z.string().min(1),
+    config_entry_id: z.string().min(1).nullable(),
+    device_id: z.string().min(1).nullable(),
+    area_id: z.string().min(1).nullable(),
+    name: z.string().nullable(),
+    original_name: z.string().nullable(),
+    disabled_by: z.string().nullable(),
+  })
+  .loose();
+
+export type EntityRegistryEntry = z.infer<typeof EntityRegistryEntry>;
+
 export const StateChangedEventData = z
   .object({
     entity_id: z.string(),

--- a/packages/home-assistant/test/rest.test.ts
+++ b/packages/home-assistant/test/rest.test.ts
@@ -151,6 +151,56 @@ describe("HomeAssistantRestClient", () => {
       "http://ha.local:8123/api/services/weather/get_forecast?return_response",
     );
   });
+
+  it("fetches and validates config-entry diagnostics with a caller schema", async () => {
+    const DiagnosticsData = z.object({
+      device: z.object({ status: z.literal("ready") }),
+    });
+    const { fn, calls } = makeFetch(() =>
+      Response.json({
+        home_assistant: {},
+        custom_components: {},
+        integration_manifest: {},
+        setup_times: {},
+        data: { device: { status: "ready" } },
+        issues: [],
+      }),
+    );
+    globalThis.fetch = fn;
+
+    const client = new HomeAssistantRestClient({
+      baseUrl: "http://ha.local:8123",
+      token: "secret",
+    });
+
+    const result = await client.getConfigEntryDiagnostics(
+      "entry-123",
+      DiagnosticsData,
+    );
+
+    expect(result.device.status).toBe("ready");
+    expect(calls[0]?.args.url).toBe(
+      "http://ha.local:8123/api/diagnostics/config_entry/entry-123",
+    );
+  });
+
+  it("rejects malformed diagnostics envelopes", async () => {
+    const { fn } = makeFetch(() =>
+      Response.json({
+        data: {},
+      }),
+    );
+    globalThis.fetch = fn;
+
+    const client = new HomeAssistantRestClient({
+      baseUrl: "http://ha.local:8123",
+      token: "secret",
+    });
+
+    await expect(
+      client.getConfigEntryDiagnostics("entry-123", z.object({})),
+    ).rejects.toThrow();
+  });
 });
 
 describe("HomeAssistantRestClient service-response mode", () => {

--- a/packages/home-assistant/test/ws.test.ts
+++ b/packages/home-assistant/test/ws.test.ts
@@ -144,6 +144,57 @@ describe("HomeAssistantEventClient", () => {
     await client.close();
   });
 
+  it("lists and validates entity-registry entries", async () => {
+    const { Impl, instances } = createFakeWebSocketFactory();
+    const client = new HomeAssistantEventClient(
+      { baseUrl: "http://ha.local:8123", token: "t" },
+      { webSocketImpl: Impl, reconnect: false },
+    );
+
+    const connectPromise = client.connect();
+    await flush();
+    const socket = instances[0];
+    expect(socket).toBeDefined();
+    if (socket === undefined) {
+      return;
+    }
+    socket.pushServerMessage({ type: "auth_required" });
+    await flush();
+    socket.pushServerMessage({ type: "auth_ok" });
+    await connectPromise;
+
+    const registryPromise = client.getEntityRegistry();
+    await flush();
+    const message = parseSent(socket.sent[1], GenericMessage);
+    expect(message.type).toBe("config/entity_registry/list");
+    socket.pushServerMessage({
+      id: message.id,
+      type: "result",
+      success: true,
+      result: [
+        {
+          entity_id: "vacuum.storage_litter_box",
+          unique_id: "robot-123",
+          platform: "litterrobot",
+          config_entry_id: "entry-123",
+          device_id: "device-123",
+          area_id: "storage",
+          name: null,
+          original_name: "Litter Box",
+          disabled_by: null,
+        },
+      ],
+    });
+
+    await expect(registryPromise).resolves.toEqual([
+      expect.objectContaining({
+        entity_id: "vacuum.storage_litter_box",
+        config_entry_id: "entry-123",
+      }),
+    ]);
+    await client.close();
+  });
+
   it("callService resolves with the result payload and rejects on error", async () => {
     const { Impl, instances } = createFakeWebSocketFactory();
     const client = new HomeAssistantEventClient(

--- a/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
+++ b/packages/homelab/src/cdk8s/config/homeassistant/configuration.yaml
@@ -54,7 +54,7 @@ homekit:
       exclude_entities:
         - binary_sensor.remote_ui
         - sensor.800_series_long_range_usb_controller_status
-        - sensor.petlibro_petlibro_sjer_red
+        - sensor.petlibro_petlibro_ha_sjer_red
         - switch.hacs_pre_release
         # Sonos "buttons lock" config toggle, not a real door lock (same device
         # cluster as the already-excluded auto_brightness/proximity_mode switches)
@@ -236,6 +236,18 @@ script: !include scripts.yaml
 # Template binary sensors for monitoring
 # Note: Jinja2 templates are escaped for Helm compatibility ({{ "{{" }} ... {{ "}}" }})
 template:
+  # PetLibro Dockstream 2 should run continuously. The enum selector itself has
+  # no numeric Prometheus series, so collapse Wi-Fi, mode, and dispensing into
+  # one problem sensor. The Prometheus rule holds it for five minutes before
+  # alerting so brief integration refreshes do not page.
+  - binary_sensor:
+      - name: "PetLibro Fountain Operation Problem"
+        unique_id: petlibro_fountain_operation_problem
+        device_class: problem
+        state: >
+          {{ "{{" }} states('binary_sensor.dockstream_2_smart_fountain_wi_fi') != 'on'
+             or states('binary_sensor.dockstream_2_smart_fountain_water_dispensing_state') != 'on'
+             or states('select.dockstream_2_smart_fountain_water_dispensing_mode') != 'Flowing Water (Constant)' {{ "}}" }}
   # Roborock Saros 10R per-floor "problem" bridges. The vacuum/status/error enum
   # sensors carry no numeric Prometheus metric, so HA's exporter can't alert on
   # them directly; these device_class:problem template binary_sensors collapse the

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts
@@ -25,6 +25,7 @@ const CONSUMER_NAMESPACES = [
   "scout-prod",
   "birmel",
   "temporal",
+  "trmnl-dashboard",
   // streambot is deployed inside the `media` chart, not its own namespace.
   "media",
   // The Buildkite maintenance worker runs the shared temporal-worker image

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts
@@ -31,6 +31,81 @@ async function collectWorkflowEntityIds(): Promise<Set<string>> {
 }
 
 describe("Home Assistant rules", () => {
+  test("uses the requested pet-care threshold boundaries without overlap", () => {
+    const groups = getHomeAssistantRuleGroups();
+    const litterRules = groups.find(
+      (group) => group.name === "homeassistant-litter-robot",
+    )?.rules;
+    const fountainRules = groups.find(
+      (group) => group.name === "homeassistant-petlibro-fountain",
+    )?.rules;
+    if (litterRules === undefined || fountainRules === undefined) {
+      throw new Error("Missing pet-care rule groups");
+    }
+
+    expect(
+      fountainRules.find((rule) => rule.alert === "PetLibroFountainWaterLow")
+        ?.expr.value,
+    ).toContain(" < 60");
+    expect(
+      litterRules.find((rule) => rule.alert === "LitterRobotLitterLow")?.expr
+        .value,
+    ).toBe("trmnl_petcare_litter_percent < 60");
+    expect(
+      litterRules.find((rule) => rule.alert === "LitterRobotWasteHigh")?.expr
+        .value,
+    ).toBe(
+      "trmnl_petcare_litter_waste_percent > 60 and trmnl_petcare_litter_waste_percent <= 80",
+    );
+    expect(
+      litterRules.find((rule) => rule.alert === "LitterRobotWasteCritical")
+        ?.expr.value,
+    ).toBe("trmnl_petcare_litter_waste_percent > 80");
+  });
+
+  test("monitors both PetLibro feeders and all three Roborocks for missing entities", () => {
+    const groups = getHomeAssistantRuleGroups();
+    const feederRules = groups.find(
+      (group) => group.name === "homeassistant-petlibro-feeders",
+    )?.rules;
+    const availabilityRules = groups.find(
+      (group) => group.name === "homeassistant-availability",
+    )?.rules;
+    if (feederRules === undefined || availabilityRules === undefined) {
+      throw new Error("Missing feeder or availability rules");
+    }
+
+    expect(
+      feederRules.some((rule) =>
+        rule.alert?.startsWith("PetLibroFeederLivingRoom"),
+      ),
+    ).toBe(true);
+    expect(
+      feederRules.some((rule) =>
+        rule.alert?.startsWith("PetLibroFeederGuestRoom"),
+      ),
+    ).toBe(true);
+    const petAvailability = availabilityRules.filter(
+      (rule) => rule.alert === "PetCareEntityUnavailable",
+    );
+    for (const floor of ["1st", "2nd", "3rd"]) {
+      expect(
+        petAvailability.some(
+          (rule) => rule.labels?.["entity"] === `vacuum.${floor}_floor`,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("uses diagnostics metrics for LR5 and never retains LR4 or PetKit rules", () => {
+    const serialized = JSON.stringify(getHomeAssistantRuleGroups());
+
+    expect(serialized).toContain("trmnl_petcare_litter_hopper_status");
+    expect(serialized).toContain("trmnl_petcare_litter_ha_mismatch");
+    expect(serialized).not.toContain("litter_robot_4");
+    expect(serialized).not.toContain("Eversweet");
+  });
+
   test("alerts when the master bathroom temperature is unavailable or absent", () => {
     const availabilityGroup = getHomeAssistantRuleGroups().find(
       (group) => group.name === "homeassistant-availability",
@@ -145,6 +220,7 @@ describe("Home Assistant rules", () => {
     }
     expect(expression).toContain("delta(");
     expect(expression).not.toContain("increase(");
+    expect(rule.annotations?.["summary"]).toContain("$labels.friendly_name");
   });
 
   test("treats every missing Roborock template dependency as a problem", async () => {
@@ -169,5 +245,8 @@ describe("Home Assistant rules", () => {
         `states('sensor.${floor}_floor_dock_dock_error') != 'ok'`,
       );
     }
+    expect(configuration).toContain(
+      "select.dockstream_2_smart_fountain_water_dispensing_mode') != 'Flowing Water (Constant)'",
+    );
   });
 });

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.ts
@@ -40,105 +40,242 @@ const masterBathroomTemperatureAvailability =
 // the `absent()` arm is what catches a total integration failure.
 const masterBathroomTemperatureUnavailableExpr = `${masterBathroomTemperatureAvailability} == 0 or absent(${masterBathroomTemperatureAvailability})`;
 
+const PET_CARE_ENTITY_IDS = [
+  "binary_sensor.dockstream_2_smart_fountain_water_dispensing_state",
+  "binary_sensor.dockstream_2_smart_fountain_wi_fi",
+  "sensor.dockstream_2_smart_fountain_remaining_cleaning_days",
+  "sensor.dockstream_2_smart_fountain_remaining_filter_day",
+  "sensor.dockstream_2_smart_fountain_remaining_water_2",
+  "select.dockstream_2_smart_fountain_water_dispensing_mode",
+  ...["", "_2"].flatMap((suffix) => [
+    `binary_sensor.granary_smart_camera_feeder_battery_status${suffix}`,
+    `binary_sensor.granary_smart_camera_feeder_food_dispenser${suffix}`,
+    `binary_sensor.granary_smart_camera_feeder_food_status${suffix}`,
+    `binary_sensor.granary_smart_camera_feeder_wi_fi${suffix}`,
+    `sensor.granary_smart_camera_feeder_desiccant_remaining_days${suffix}`,
+    `sensor.granary_smart_camera_feeder_last_feed_time${suffix}`,
+  ]),
+  ...["1st", "2nd", "3rd"].flatMap((floor) => [
+    `vacuum.${floor}_floor`,
+    `sensor.${floor}_floor_battery`,
+    `sensor.${floor}_floor_status`,
+    `sensor.${floor}_floor_vacuum_error`,
+    `sensor.${floor}_floor_dock_dock_error`,
+    `sensor.${floor}_floor_main_brush_time_left`,
+    `sensor.${floor}_floor_side_brush_time_left`,
+    `sensor.${floor}_floor_filter_time_left`,
+    `sensor.${floor}_floor_dock_strainer_time_left`,
+    `binary_sensor.${floor}_floor_dock_clean_water_box`,
+    `binary_sensor.${floor}_floor_dock_dirty_water_box`,
+    `binary_sensor.${floor}_floor_dock_cleaning_fluid`,
+    `binary_sensor.${floor}_floor_water_shortage`,
+    `binary_sensor.${floor}_floor_vacuum_problem`,
+  ]),
+] as const;
+
+function expressionAlert(options: {
+  name: string;
+  expression: string;
+  summary: string;
+  description: string;
+  duration?: string;
+  severity?: "warning" | "critical";
+}) {
+  return {
+    alert: options.name,
+    annotations: {
+      description: escapePrometheusTemplate(options.description),
+      summary: options.summary,
+    },
+    expr: PrometheusRuleSpecGroupsRulesExpr.fromString(options.expression),
+    for: options.duration ?? "10m",
+    labels: { severity: options.severity ?? "warning" },
+  };
+}
+
+function feederRules(
+  id: "LivingRoom" | "GuestRoom",
+  label: string,
+  suffix: "" | "_2",
+) {
+  const prefix = "granary_smart_camera_feeder";
+  return [
+    createBinarySensorAlert({
+      name: `PetLibroFeeder${id}FoodLow`,
+      entity: `binary_sensor.${prefix}_food_status${suffix}`,
+      description: `${label} PetLibro feeder reports low food.`,
+      summary: `${label} PetLibro feeder food low`,
+    }),
+    createBinarySensorAlert({
+      name: `PetLibroFeeder${id}DispenserProblem`,
+      entity: `binary_sensor.${prefix}_food_dispenser${suffix}`,
+      description: `${label} PetLibro feeder reports a dispenser failure.`,
+      summary: `${label} PetLibro feeder dispenser problem`,
+    }),
+    createBinarySensorAlert({
+      name: `PetLibroFeeder${id}BatteryProblem`,
+      entity: `binary_sensor.${prefix}_battery_status${suffix}`,
+      description: `${label} PetLibro feeder reports a battery problem.`,
+      summary: `${label} PetLibro feeder battery problem`,
+    }),
+    expressionAlert({
+      name: `PetLibroFeeder${id}WifiDisconnected`,
+      expression: `homeassistant_binary_sensor_state{entity="binary_sensor.${prefix}_wi_fi${suffix}"} == 0`,
+      description: `${label} PetLibro feeder Wi-Fi is disconnected.`,
+      summary: `${label} PetLibro feeder offline`,
+      duration: "5m",
+    }),
+    createSensorAlert({
+      name: `PetLibroFeeder${id}DesiccantDue`,
+      entity: `homeassistant_sensor_duration_d{entity="sensor.${prefix}_desiccant_remaining_days${suffix}"}`,
+      condition: "<=",
+      threshold: 0,
+      description: `${label} PetLibro feeder desiccant is due: {{ $value }} days remaining.`,
+      summary: `${label} PetLibro feeder desiccant due`,
+      duration: "1h",
+    }),
+    expressionAlert({
+      name: `PetLibroFeeder${id}NotDispensing`,
+      expression: `time() - homeassistant_sensor_timestamp_seconds{entity="sensor.${prefix}_last_feed_time${suffix}"} > 50400`,
+      description: `${label} PetLibro feeder has not dispensed food in over 14 hours.`,
+      summary: `${label} PetLibro feeder not dispensing`,
+      duration: "30m",
+    }),
+  ];
+}
+
 export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
   return [
-    // Litter Robot monitoring
+    {
+      name: "homeassistant-petlibro-fountain",
+      rules: [
+        createSensorAlert({
+          name: "PetLibroFountainWaterLow",
+          entity:
+            'homeassistant_sensor_unit_percent{entity="sensor.dockstream_2_smart_fountain_remaining_water_2"}',
+          condition: "<",
+          threshold: 60,
+          description: "PetLibro fountain water is below 60%: {{ $value }}%.",
+          summary: "PetLibro fountain water low",
+        }),
+        createSensorAlert({
+          name: "PetLibroFountainCleaningDue",
+          entity:
+            'homeassistant_sensor_duration_d{entity="sensor.dockstream_2_smart_fountain_remaining_cleaning_days"}',
+          condition: "<=",
+          threshold: 0,
+          description:
+            "PetLibro fountain cleaning is due: {{ $value }} days remaining.",
+          summary: "PetLibro fountain cleaning due",
+        }),
+        createSensorAlert({
+          name: "PetLibroFountainFilterDue",
+          entity:
+            'homeassistant_sensor_duration_d{entity="sensor.dockstream_2_smart_fountain_remaining_filter_day"}',
+          condition: "<=",
+          threshold: 0,
+          description:
+            "PetLibro fountain filter is due: {{ $value }} days remaining.",
+          summary: "PetLibro fountain filter due",
+        }),
+        createBinarySensorAlert({
+          name: "PetLibroFountainOperationProblem",
+          entity: "binary_sensor.petlibro_fountain_operation_problem",
+          description:
+            "PetLibro fountain is offline, not in Flowing Water (Constant) mode, or has not dispensed for five minutes.",
+          summary: "PetLibro fountain operation problem",
+          duration: "5m",
+        }),
+      ],
+    },
+    {
+      name: "homeassistant-petlibro-feeders",
+      rules: [
+        ...feederRules("LivingRoom", "Living Room", ""),
+        ...feederRules("GuestRoom", "Guest Room", "_2"),
+      ],
+    },
     {
       name: "homeassistant-litter-robot",
       rules: [
         createSensorAlert({
           name: "LitterRobotLitterLow",
-          entity:
-            'homeassistant_sensor_unit_percent{entity="sensor.litter_robot_4_litter_level"}',
+          entity: "trmnl_petcare_litter_percent",
           condition: "<",
-          threshold: 90,
-          description:
-            "Litter Robot litter is low: {{ $value }}% ({{ $labels.entity }}).",
-          summary: "Litter Robot litter low",
+          threshold: 60,
+          description: "LR5 globe litter is below 60%: {{ $value }}%.",
+          summary: "Storage LR5 globe litter low",
         }),
-        createSensorAlert({
+        expressionAlert({
           name: "LitterRobotWasteHigh",
-          entity:
-            'homeassistant_sensor_unit_percent{entity="sensor.litter_robot_4_waste_drawer"}',
-          condition: ">",
-          threshold: 70,
-          description:
-            "Litter Robot waste drawer is high: {{ $value }}% ({{ $labels.entity }}).",
-          summary: "Litter Robot waste high",
-          duration: "1h", // Increased from default 10m to reduce flapping from sensor variance
-        }),
-        {
-          alert: "LitterRobotNotCyclingRecently",
-          annotations: {
-            description:
-              'Litter Robot has not cycled in the last 12 hours ({{ "{{" }} $value {{ "}}" }} cycles).',
-            summary: "Litter Robot not cycling",
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'increase(homeassistant_sensor_unit_cycles{entity="sensor.litter_robot_4_total_cycles"}[12h]) == 0', // Extended from 6h to account for overnight
-          ),
-          for: "30m",
-          labels: { severity: "warning" },
-        },
-      ],
-    },
-
-    // Binary sensor monitoring
-    {
-      name: "homeassistant-binary-sensors",
-      rules: [
-        createBinarySensorAlert({
-          name: "EversweetWaterLevelBad",
-          entity: "binary_sensor.eversweet_3_pro_water_level",
-          description:
-            "Binary sensor {{ $labels.entity }} reports low state ({{ $value }}).",
-          summary: "Eversweet water level low",
-        }),
-        createBinarySensorAlert({
-          name: "GranaryFeederBatteryStatusBad",
-          entity: "binary_sensor.granary_smart_camera_feeder_battery_status",
-          description:
-            "Binary sensor {{ $labels.entity }} reports low state ({{ $value }}).",
-          summary: "Granary feeder battery status low",
-        }),
-        createBinarySensorAlert({
-          name: "GranaryFeederFoodDispenserBad",
-          entity: "binary_sensor.granary_smart_camera_feeder_food_dispenser",
-          description:
-            "Binary sensor {{ $labels.entity }} reports bad state ({{ $value }}).",
-          summary: "Granary feeder food dispenser bad",
-        }),
-        createBinarySensorAlert({
-          name: "GranaryFeederFoodStatusBad",
-          entity: "binary_sensor.granary_smart_camera_feeder_food_status",
-          description:
-            "Binary sensor {{ $labels.entity }} reports low state ({{ $value }}).",
-          summary: "Granary feeder low food",
+          expression:
+            "trmnl_petcare_litter_waste_percent > 60 and trmnl_petcare_litter_waste_percent <= 80",
+          description: "LR5 waste drawer is above 60%: {{ $value }}%.",
+          summary: "Storage LR5 waste drawer high",
+          duration: "30m",
         }),
         createSensorAlert({
-          name: "GranaryFeederDesiccantRemainingDays",
-          entity:
-            'homeassistant_sensor_duration_d{entity="sensor.granary_smart_camera_feeder_desiccant_remaining_days"}',
-          condition: "<=",
-          threshold: 0,
-          description:
-            "Granary feeder desiccant is overdue: {{ $value }} days remaining ({{ $labels.entity }}).",
-          summary: "Granary feeder desiccant remaining days",
-          duration: "24h", // Alert once per day instead of every 10m to reduce noise
+          name: "LitterRobotWasteCritical",
+          entity: "trmnl_petcare_litter_waste_percent",
+          condition: ">",
+          threshold: 80,
+          description: "LR5 waste drawer is above 80%: {{ $value }}%.",
+          summary: "Storage LR5 waste drawer critical",
+          duration: "10m",
+          severity: "critical",
         }),
-        {
-          alert: "GranaryFeederNotDispensing",
-          annotations: {
-            description:
-              'Granary feeder has not dispensed food in over 14 hours. Time since last feed: {{ "{{" }} $value | humanizeDuration {{ "}}" }}.',
-            summary: "Granary feeder not dispensing",
-          },
-          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'time() - homeassistant_sensor_timestamp_seconds{entity="sensor.granary_smart_camera_feeder_last_feed_time"} > 50400',
-          ),
-          for: "30m",
-          labels: { severity: "warning" },
-        },
+        expressionAlert({
+          name: "LitterRobotHopperLowOrDisconnected",
+          expression:
+            'trmnl_petcare_litter_hopper_status{status=~"low|empty|disconnected|unknown"} == 1',
+          description:
+            "LR5 hopper is low, empty, disconnected, or reporting an unknown state.",
+          summary: "Storage LR5 hopper needs attention",
+        }),
+        expressionAlert({
+          name: "LitterRobotHopperFault",
+          expression:
+            'trmnl_petcare_litter_hopper_status{status=~"jammed|motor-fault|fault"} == 1',
+          description: "LR5 hopper reports a jam or explicit fault.",
+          summary: "Storage LR5 hopper fault",
+          severity: "critical",
+          duration: "5m",
+        }),
+        expressionAlert({
+          name: "LitterRobotFault",
+          expression:
+            "trmnl_petcare_litter_fault == 1 or trmnl_petcare_litter_online == 0 or trmnl_petcare_litter_hopper_installed == 0 or trmnl_petcare_litter_hopper_enabled == 0",
+          description:
+            "LR5 reports a robot fault, dirty laser, removed bonnet/drawer, offline state, or disabled/missing hopper.",
+          summary: "Storage LR5 fault",
+          duration: "5m",
+        }),
+        expressionAlert({
+          name: "LitterRobotDiagnosticsStale",
+          expression:
+            'trmnl_petcare_source_up{source="whisker"} == 0 or trmnl_petcare_litter_source_fresh == 0 or absent(trmnl_petcare_litter_source_fresh)',
+          description:
+            "Fresh Whisker diagnostics are unavailable or the LR5 has not been seen for 15 minutes.",
+          summary: "Storage LR5 diagnostics stale",
+          duration: "10m",
+        }),
+        expressionAlert({
+          name: "LitterRobotEntitiesStale",
+          expression:
+            "trmnl_petcare_litter_ha_mismatch == 1 or absent(trmnl_petcare_litter_ha_mismatch)",
+          description:
+            "Ordinary Home Assistant LR5 entities disagree with fresh Whisker diagnostics.",
+          summary: "Storage LR5 Home Assistant entities stale",
+          duration: "10m",
+        }),
+        expressionAlert({
+          name: "LitterRobotFilterOverdue",
+          expression:
+            "time() > trmnl_petcare_litter_filter_due_timestamp_seconds",
+          description: "The LR5 filter replacement date has passed.",
+          summary: "Storage LR5 filter overdue",
+          duration: "1h",
+        }),
       ],
     },
 
@@ -172,6 +309,18 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           annotations: {
             description: `Home Assistant entity ${entity}, required by a Temporal home automation, has been unavailable or absent from metrics for 15 minutes.`,
             summary: `Home automation dependency unavailable: ${entity}`,
+          },
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            `homeassistant_entity_available{entity="${entity}"} == 0 or absent(homeassistant_entity_available{entity="${entity}"})`,
+          ),
+          for: "15m",
+          labels: { severity: "warning", entity },
+        })),
+        ...PET_CARE_ENTITY_IDS.map((entity) => ({
+          alert: "PetCareEntityUnavailable",
+          annotations: {
+            description: `Pet-care entity ${entity} has been unavailable or absent from Home Assistant metrics for 15 minutes.`,
+            summary: `Pet-care entity unavailable: ${entity}`,
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             `homeassistant_entity_available{entity="${entity}"} == 0 or absent(homeassistant_entity_available{entity="${entity}"})`,
@@ -222,7 +371,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           threshold: 1,
           description:
             "Roborock {{ $labels.friendly_name }} reports a problem (stuck / robot error / dock error). Check the vacuum.",
-          summary: "Roborock vacuum problem",
+          summary: escapePrometheusTemplate(
+            "Roborock {{ $labels.friendly_name }} vacuum problem",
+          ),
           duration: "5m",
         }),
         createSensorAlert({
@@ -233,7 +384,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           threshold: 1,
           description:
             "Roborock {{ $labels.friendly_name }} dock dirty-water tank is full — empty it.",
-          summary: "Roborock dirty-water tank full",
+          summary: escapePrometheusTemplate(
+            "Roborock {{ $labels.friendly_name }} dirty-water tank full",
+          ),
           duration: "5m",
         }),
         createSensorAlert({
@@ -244,7 +397,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           threshold: 1,
           description:
             "Roborock {{ $labels.friendly_name }} dock clean-water tank is empty — refill it.",
-          summary: "Roborock clean-water tank empty",
+          summary: escapePrometheusTemplate(
+            "Roborock {{ $labels.friendly_name }} clean-water tank empty",
+          ),
           duration: "5m",
         }),
         createSensorAlert({
@@ -255,7 +410,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           threshold: 1,
           description:
             "Roborock {{ $labels.friendly_name }} dock cleaning fluid is low — refill it.",
-          summary: "Roborock cleaning fluid low",
+          summary: escapePrometheusTemplate(
+            "Roborock {{ $labels.friendly_name }} cleaning fluid low",
+          ),
           duration: "5m",
         }),
         createSensorAlert({
@@ -266,7 +423,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           threshold: 1,
           description:
             "Roborock {{ $labels.friendly_name }} reports a water shortage.",
-          summary: "Roborock water shortage",
+          summary: escapePrometheusTemplate(
+            "Roborock {{ $labels.friendly_name }} water shortage",
+          ),
           duration: "5m",
         }),
         // Consumables (main/side brush, filter, dock strainer) — the friendly_name
@@ -280,7 +439,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
           threshold: 10,
           description:
             "Roborock consumable {{ $labels.friendly_name }} has under 10h of life left ({{ $value }}h) — replace/clean it soon.",
-          summary: "Roborock consumable due",
+          summary: escapePrometheusTemplate(
+            "Roborock {{ $labels.friendly_name }} consumable due",
+          ),
           duration: "1h",
         }),
         // Battery low AND not charging. Self-join on the same battery series: a
@@ -293,7 +454,9 @@ export function getHomeAssistantRuleGroups(): PrometheusRuleSpecGroups[] {
             description: escapePrometheusTemplate(
               "Roborock {{ $labels.friendly_name }} battery is low and not charging: {{ $value }}%.",
             ),
-            summary: "Roborock battery low and not charging",
+            summary: escapePrometheusTemplate(
+              "Roborock {{ $labels.friendly_name }} battery low and not charging",
+            ),
           },
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             'homeassistant_sensor_battery_percent{entity=~"sensor[.](1st|2nd|3rd)_floor_battery"} < 20 and delta(homeassistant_sensor_battery_percent{entity=~"sensor[.](1st|2nd|3rd)_floor_battery"}[30m]) <= 0',

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -98,6 +98,11 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
           key: "HA_TOKEN",
         }),
         DISPLAY_TIME_ZONE: EnvValue.fromValue("America/Los_Angeles"),
+        FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+        FLIPT_URL: EnvValue.fromValue(
+          "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
+        ),
+        FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
         BUGSINK_URL: EnvValue.fromValue(
           "http://bugsink-bugsink-service.bugsink:8000/api/canonical/0",
         ),
@@ -199,9 +204,9 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
   return { deployment, service };
 }
 
-export const trmnlDashboardPorts = [53, 80, 443, 8000, 8123, 9090, 9093].map(
-  (port) => ({
-    port: IntOrString.fromNumber(port),
-    protocol: port === 53 ? "UDP" : "TCP",
-  }),
-);
+export const trmnlDashboardPorts = [
+  53, 80, 443, 8000, 8080, 8123, 9090, 9093,
+].map((port) => ({
+  port: IntOrString.fromNumber(port),
+  protocol: port === 53 ? "UDP" : "TCP",
+}));

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -17,6 +17,7 @@ import {
 } from "@shepherdjerred/homelab/cdk8s/generated/imports/k8s.ts";
 import { OnePasswordItem } from "@shepherdjerred/homelab/cdk8s/generated/imports/onepassword.com.ts";
 import { createCloudflareTunnelBinding } from "@shepherdjerred/homelab/cdk8s/src/misc/cloudflare-tunnel.ts";
+import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/service-monitor.ts";
 import {
   setRevisionHistoryLimit,
   withCommonProps,
@@ -172,8 +173,17 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
   setRevisionHistoryLimit(deployment, 5);
 
   const service = new Service(chart, "trmnl-dashboard-service", {
+    metadata: { labels: { app: "trmnl-dashboard" } },
     selector: deployment,
     ports: [{ port: 3000, name: "http" }],
+  });
+
+  createServiceMonitor(chart, {
+    name: "trmnl-dashboard",
+    namespace: "trmnl-dashboard",
+    port: "http",
+    interval: "30s",
+    matchLabels: { app: "trmnl-dashboard" },
   });
 
   createCloudflareTunnelBinding(chart, "trmnl-dashboard-cf-tunnel", {

--- a/packages/homelab/src/cdk8s/src/trmnl-dashboard-config.test.ts
+++ b/packages/homelab/src/cdk8s/src/trmnl-dashboard-config.test.ts
@@ -24,4 +24,13 @@ describe("trmnl-dashboard configuration", () => {
     expect(yaml).toContain("bugsink-bugsink-service.bugsink");
     expect(yaml).toContain("bugsink-bugsink-service.bugsink.svc.cluster.local");
   });
+
+  it("exposes pet metrics only through the Prometheus-selected service", async () => {
+    const yaml = await synthesizeApp();
+
+    expect(yaml).toContain("kind: ServiceMonitor");
+    expect(yaml).toContain("name: trmnl-dashboard-service-monitor");
+    expect(yaml).toContain("path: /metrics");
+    expect(yaml).toContain("kubernetes.io/metadata.name: prometheus");
+  });
 });

--- a/packages/trmnl-dashboard/Dockerfile
+++ b/packages/trmnl-dashboard/Dockerfile
@@ -12,8 +12,8 @@ FROM oven/bun:1.4.0@sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f
 WORKDIR /app
 
 # ── prod-deps: production-only node_modules, cached on manifests ────────────
-# The trmnl-dashboard filter includes home-assistant through its workspace
-# dependency closure. `--frozen-lockfile` requires every workspace member's
+# The trmnl-dashboard filter includes config, feature-flags, and home-assistant
+# through its workspace dependency closure. `--frozen-lockfile` requires every workspace member's
 # package.json present, so the globs enumerate every member (top-level, nested
 # packages/*/packages/*, homelab/src/*, the desktop src-tauri crate, and the
 # `scripts` dir).
@@ -39,6 +39,8 @@ COPY --from=prod-deps /app/ /app/
 COPY --parents \
   tsconfig.base.json \
   packages/trmnl-dashboard \
+  packages/config \
+  packages/feature-flags \
   packages/home-assistant \
   ./
 

--- a/packages/trmnl-dashboard/README.md
+++ b/packages/trmnl-dashboard/README.md
@@ -9,6 +9,7 @@ Plugins.
 - `GET /healthz` - configuration health
 - `GET /api/home` - Home Assistant status payload
 - `GET /api/homelab` - homelab status payload
+- `GET /metrics` - internal Prometheus metrics, including fresh LR5 diagnostics
 - `GET /api/diagnostics` - per-source fetch diagnostics for both payloads
 
 Protected endpoints require `x-api-key` to match `TRMNL_API_KEY`.
@@ -17,6 +18,11 @@ Protected endpoints require `x-api-key` to match `TRMNL_API_KEY`.
 
 Payloads are assembled from five clients in `src/clients/`: `alerts`,
 `bugsink`, `home-assistant`, `kubernetes`, and `prometheus`.
+
+Pet-care collection reads ordinary PetLibro and Roborock entities plus a
+strictly validated Whisker diagnostics payload for LR5 and hopper data. It
+discovers the Whisker config entry through Home Assistant's entity registry;
+the internal ID and raw diagnostics are never returned or exported as labels.
 
 ## Configuration
 

--- a/packages/trmnl-dashboard/README.md
+++ b/packages/trmnl-dashboard/README.md
@@ -9,6 +9,7 @@ Plugins.
 - `GET /healthz` - configuration health
 - `GET /api/home` - Home Assistant status payload
 - `GET /api/homelab` - homelab status payload
+- `GET /api/pets` - pet-care status and daily activity payload (feature flagged)
 - `GET /metrics` - internal Prometheus metrics, including fresh LR5 diagnostics
 - `GET /api/diagnostics` - per-source fetch diagnostics for both payloads
 
@@ -23,6 +24,11 @@ Pet-care collection reads ordinary PetLibro and Roborock entities plus a
 strictly validated Whisker diagnostics payload for LR5 and hopper data. It
 discovers the Whisker config entry through Home Assistant's entity registry;
 the internal ID and raw diagnostics are never returned or exported as labels.
+
+`/api/pets` is controlled by the managed `pet-dashboard-enabled` flag and is
+absent (404) by default. The internal metrics endpoint remains available to the
+restricted Prometheus ServiceMonitor so alerts can be verified before the TRMNL
+screen is enabled.
 
 ## Configuration
 

--- a/packages/trmnl-dashboard/package.json
+++ b/packages/trmnl-dashboard/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@sentry/bun": "^10.70.0",
+    "@shepherdjerred/config": "workspace:*",
+    "@shepherdjerred/feature-flags": "workspace:*",
     "@shepherdjerred/home-assistant": "workspace:*",
     "zod": "^4.4.3"
   },
@@ -30,6 +32,7 @@
     "@types/bun": "1.4.0",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
+    "liquidjs": "^10.29.0",
     "typescript": "^6.0.3",
     "@typescript/native": "npm:typescript@7.0.2",
     "vitest": "4.1.10",

--- a/packages/trmnl-dashboard/package.json
+++ b/packages/trmnl-dashboard/package.json
@@ -25,6 +25,7 @@
     "@shepherdjerred/config": "workspace:*",
     "@shepherdjerred/feature-flags": "workspace:*",
     "@shepherdjerred/home-assistant": "workspace:*",
+    "prom-client": "^15.1.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/trmnl-dashboard/scripts/smoke.ts
+++ b/packages/trmnl-dashboard/scripts/smoke.ts
@@ -42,6 +42,8 @@ async function main(): Promise<void> {
     "HA_TOKEN=smoke-test-dummy",
     "-e",
     "HA_URL=http://127.0.0.1:9999",
+    "-e",
+    "FEATURE_FLAGS_MODE=disabled",
     IMAGE,
   ]);
   if (run.code !== 0) {

--- a/packages/trmnl-dashboard/src/__tests__/app.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/app.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createHandler } from "../app.ts";
 import type { AppConfig } from "../config.ts";
-import type { HomePayload, HomelabPayload, PetCarePayload } from "../types.ts";
+import type { HomePayload, HomelabPayload } from "../types.ts";
+import { healthyPetPayload } from "./pet-care-fixtures.ts";
 
 const config: AppConfig = {
   port: 3000,
@@ -67,37 +68,7 @@ const homelabPayload: HomelabPayload = {
   errors: [],
 };
 
-const petPayload: PetCarePayload = {
-  screen: "pets",
-  generated_at: "2026-08-30T08:30:00.000Z",
-  generated_time: "1:30 AM",
-  status: "ok",
-  summary: "Pet systems healthy",
-  problems: [],
-  fountain: {
-    status: "ok",
-    water_percent: 100,
-    water_ounces: 90,
-    cleaning_days: 12,
-    filter_days: 12,
-    dispensing: true,
-    dispensing_mode: "Flowing Water (Constant)",
-    wifi: true,
-    drinking_ounces_today: 4,
-    drinking_visits_today: 9,
-  },
-  feeders: [],
-  litter_robot: null,
-  vacuums: [],
-  activity: {
-    drinking_ounces: 4,
-    drinking_visits: 9,
-    feedings: 2,
-    food_grams: 20,
-    litter_cycles: 1,
-  },
-  errors: [],
-};
+const petPayload = healthyPetPayload();
 
 describe("createHandler", () => {
   it("serves liveness without auth", async () => {

--- a/packages/trmnl-dashboard/src/__tests__/app.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/app.test.ts
@@ -110,12 +110,16 @@ describe("createHandler", () => {
   it("serves Prometheus pet metrics without public API authentication", async () => {
     const handler = createHandler(config, {
       getPetMetrics: async () => "trmnl_petcare_source_up 1\n",
+      getFeatureFlagMetrics: async () =>
+        "feature_flag_snapshot_age_seconds 12\n",
     });
     const response = await handler(new Request("http://localhost/metrics"));
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/plain");
-    expect(await response.text()).toBe("trmnl_petcare_source_up 1\n");
+    expect(await response.text()).toBe(
+      "feature_flag_snapshot_age_seconds 12\ntrmnl_petcare_source_up 1\n",
+    );
   });
 
   it("rejects protected routes without an API key", async () => {

--- a/packages/trmnl-dashboard/src/__tests__/app.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/app.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createHandler } from "../app.ts";
 import type { AppConfig } from "../config.ts";
-import type { HomePayload, HomelabPayload } from "../types.ts";
+import type { HomePayload, HomelabPayload, PetCarePayload } from "../types.ts";
 
 const config: AppConfig = {
   port: 3000,
@@ -67,6 +67,38 @@ const homelabPayload: HomelabPayload = {
   errors: [],
 };
 
+const petPayload: PetCarePayload = {
+  screen: "pets",
+  generated_at: "2026-08-30T08:30:00.000Z",
+  generated_time: "1:30 AM",
+  status: "ok",
+  summary: "Pet systems healthy",
+  problems: [],
+  fountain: {
+    status: "ok",
+    water_percent: 100,
+    water_ounces: 90,
+    cleaning_days: 12,
+    filter_days: 12,
+    dispensing: true,
+    dispensing_mode: "Flowing Water (Constant)",
+    wifi: true,
+    drinking_ounces_today: 4,
+    drinking_visits_today: 9,
+  },
+  feeders: [],
+  litter_robot: null,
+  vacuums: [],
+  activity: {
+    drinking_ounces: 4,
+    drinking_visits: 9,
+    feedings: 2,
+    food_grams: 20,
+    litter_cycles: 1,
+  },
+  errors: [],
+};
+
 describe("createHandler", () => {
   it("serves liveness without auth", async () => {
     const handler = createHandler(config);
@@ -118,6 +150,51 @@ describe("createHandler", () => {
     );
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(homelabPayload);
+  });
+
+  it("hides the pets route while the feature flag is off", async () => {
+    const handler = createHandler(config, {
+      collectPets: async () => petPayload,
+      petDashboardEnabled: async () => false,
+    });
+    const response = await handler(
+      new Request("http://localhost/api/pets", {
+        headers: { "x-api-key": "secret" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("serves the authenticated pets payload while the feature flag is on", async () => {
+    const handler = createHandler(config, {
+      collectPets: async () => petPayload,
+      petDashboardEnabled: async () => true,
+    });
+    const response = await handler(
+      new Request("http://localhost/api/pets", {
+        headers: { "x-api-key": "secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(petPayload);
+  });
+
+  it("authenticates the pets route before evaluating its feature flag", async () => {
+    let evaluated = false;
+    const handler = createHandler(config, {
+      collectPets: async () => petPayload,
+      petDashboardEnabled: async () => {
+        evaluated = true;
+        return true;
+      },
+    });
+
+    const response = await handler(new Request("http://localhost/api/pets"));
+
+    expect(response.status).toBe(401);
+    expect(evaluated).toBe(false);
   });
 
   it("serves authenticated diagnostics", async () => {

--- a/packages/trmnl-dashboard/src/__tests__/app.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/app.test.ts
@@ -75,6 +75,17 @@ describe("createHandler", () => {
     expect(await response.text()).toBe("ok");
   });
 
+  it("serves Prometheus pet metrics without public API authentication", async () => {
+    const handler = createHandler(config, {
+      getPetMetrics: async () => "trmnl_petcare_source_up 1\n",
+    });
+    const response = await handler(new Request("http://localhost/metrics"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(await response.text()).toBe("trmnl_petcare_source_up 1\n");
+  });
+
   it("rejects protected routes without an API key", async () => {
     const handler = createHandler(config, {
       collectHome: async () => homePayload,

--- a/packages/trmnl-dashboard/src/__tests__/dynamic-config.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/dynamic-config.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import {
+  initializeDynamicConfig,
+  petDashboardEnabled,
+  shutdownDynamicConfig,
+} from "../dynamic-config.ts";
+
+const DISABLED_ENVIRONMENT = { FEATURE_FLAGS_MODE: "disabled" } as const;
+
+afterEach(async () => {
+  await shutdownDynamicConfig();
+});
+
+describe("pet dashboard feature flag", () => {
+  it("defaults off when the flag backend has no opinion", async () => {
+    await initializeDynamicConfig({ environment: DISABLED_ENVIRONMENT });
+
+    await expect(petDashboardEnabled()).resolves.toBe(false);
+  });
+
+  it("enables the route from the managed flag", async () => {
+    await initializeDynamicConfig({
+      environment: DISABLED_ENVIRONMENT,
+      provider: new StaticProvider({ "pet-dashboard-enabled": true }),
+    });
+
+    await expect(petDashboardEnabled()).resolves.toBe(true);
+  });
+});

--- a/packages/trmnl-dashboard/src/__tests__/feature-flag-metrics.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/feature-flag-metrics.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createFeatureFlagMetrics } from "../feature-flag-metrics.ts";
+
+describe("feature flag metrics", () => {
+  it("exports evaluation, error, and snapshot-age signals", async () => {
+    const metrics = createFeatureFlagMetrics();
+
+    metrics.recorder.countEvaluation({
+      flag: "pet-dashboard-enabled",
+      reason: "STATIC",
+      errorCode: undefined,
+    });
+    metrics.recorder.countError("refresh");
+    metrics.recorder.observeSnapshotAge(42);
+
+    await expect(metrics.render()).resolves.toContain(
+      'feature_flag_evaluations_total{flag="pet-dashboard-enabled",reason="STATIC"} 1',
+    );
+    await expect(metrics.render()).resolves.toContain(
+      'feature_flag_errors_total{operation="refresh"} 1',
+    );
+    await expect(metrics.render()).resolves.toContain(
+      "feature_flag_snapshot_age_seconds 42",
+    );
+  });
+});

--- a/packages/trmnl-dashboard/src/__tests__/pet-care-fixtures.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pet-care-fixtures.ts
@@ -1,0 +1,35 @@
+import type { PetCarePayload } from "../types.ts";
+
+export function healthyPetPayload(): PetCarePayload {
+  return {
+    screen: "pets",
+    generated_at: "2026-08-30T08:30:00.000Z",
+    generated_time: "1:30 AM",
+    status: "ok",
+    summary: "Pet systems healthy",
+    problems: [],
+    fountain: {
+      status: "ok",
+      water_percent: 100,
+      water_ounces: 90,
+      cleaning_days: 12,
+      filter_days: 12,
+      dispensing: true,
+      dispensing_mode: "Flowing Water (Constant)",
+      wifi: true,
+      drinking_ounces_today: 4,
+      drinking_visits_today: 9,
+    },
+    feeders: [],
+    litter_robot: null,
+    vacuums: [],
+    activity: {
+      drinking_ounces: 4,
+      drinking_visits: 9,
+      feedings: 2,
+      food_grams: 20,
+      litter_cycles: 1,
+    },
+    errors: [],
+  };
+}

--- a/packages/trmnl-dashboard/src/__tests__/pet-care.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pet-care.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../clients/pet-care.ts";
 import { renderPetCareMetrics } from "../pet-care-service.ts";
 import type { PetCareCollection } from "../collectors/pets.ts";
-import type { PetCarePayload } from "../types.ts";
+import { healthyPetPayload } from "./pet-care-fixtures.ts";
 
 const NOW = new Date("2026-08-30T08:30:00Z");
 
@@ -167,7 +167,7 @@ describe("pet-care metrics", () => {
   it("exports safe LR5 values without calling the hopper level a percentage", () => {
     const robot = parseRobot(readyRobot());
     const collection: PetCareCollection = {
-      payload: emptyPayload(),
+      payload: healthyPetPayload(),
       metrics: {
         sourceUp: { homeAssistant: true, whisker: true, alerts: true },
         litterRobot: robot,
@@ -185,37 +185,3 @@ describe("pet-care metrics", () => {
     expect(metrics).not.toContain("hopper_percent");
   });
 });
-
-function emptyPayload(): PetCarePayload {
-  return {
-    screen: "pets",
-    generated_at: NOW.toISOString(),
-    generated_time: "1:30 AM",
-    status: "ok",
-    summary: "Pet systems healthy",
-    problems: [],
-    fountain: {
-      status: "ok",
-      water_percent: 100,
-      water_ounces: 90,
-      cleaning_days: 12,
-      filter_days: 12,
-      dispensing: true,
-      dispensing_mode: "Flowing Water (Constant)",
-      wifi: true,
-      drinking_ounces_today: 4,
-      drinking_visits_today: 9,
-    },
-    feeders: [],
-    litter_robot: null,
-    vacuums: [],
-    activity: {
-      drinking_ounces: 4,
-      drinking_visits: 9,
-      feedings: 2,
-      food_grams: 20,
-      litter_cycles: 1,
-    },
-    errors: [],
-  };
-}

--- a/packages/trmnl-dashboard/src/__tests__/pet-care.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pet-care.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  PetCareHomeAssistantClient,
   parseLitterRobotDiagnostics,
   WhiskerDiagnosticsSchema,
 } from "../clients/pet-care.ts";
@@ -8,6 +9,10 @@ import type { PetCareCollection } from "../collectors/pets.ts";
 import type { PetCarePayload } from "../types.ts";
 
 const NOW = new Date("2026-08-30T08:30:00Z");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function readyRobot() {
   return {
@@ -50,6 +55,36 @@ function parseRobot(robot: unknown) {
 }
 
 describe("LR5 Pro diagnostics", () => {
+  it("requests full history records for litter activity", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([
+        [
+          {
+            entity_id: "sensor.storage_scoops_saved",
+            state: "37",
+            attributes: {},
+          },
+        ],
+      ]),
+    );
+    const client = new PetCareHomeAssistantClient("http://ha.local", "token");
+
+    await client.getHistory("sensor.storage_scoops_saved", NOW);
+
+    const input = fetch.mock.calls[0]?.[0];
+    if (input === undefined) {
+      throw new Error("Expected Home Assistant history request");
+    }
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    expect(url).toContain("significant_changes_only=true");
+    expect(url).not.toContain("minimal_response");
+  });
+
   it("parses the healthy Ready payload and preserves the raw hopper indicator", () => {
     const robot = parseRobot(readyRobot());
 

--- a/packages/trmnl-dashboard/src/__tests__/pet-care.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pet-care.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseLitterRobotDiagnostics,
+  WhiskerDiagnosticsSchema,
+} from "../clients/pet-care.ts";
+import { renderPetCareMetrics } from "../pet-care-service.ts";
+import type { PetCareCollection } from "../collectors/pets.ts";
+import type { PetCarePayload } from "../types.ts";
+
+const NOW = new Date("2026-08-30T08:30:00Z");
+
+function readyRobot() {
+  return {
+    type: "LR5_PRO",
+    name: "Storage",
+    updatedAt: "2026-08-30T08:22:06Z",
+    nextFilterReplacementDate: "2026-09-26T03:00:32Z",
+    hopperSettings: { mode: "Enabled" },
+    state: {
+      isOnline: true,
+      lastSeen: "2026-08-30T08:21:53Z",
+      statusIndicator: { title: "Ready", type: "READY" },
+      dfiLevelPercent: 33,
+      litterLevelPercent: 90.7,
+      hopperLitterLevel: 1,
+      hopperFault: null,
+      hopperStatusIndicator: { title: "Ready", value: "READY" },
+      isHopperInstalled: true,
+      hopperStateLastUpdated: "2026-08-30T08:22:06Z",
+      isLaserDirty: false,
+      isBonnetRemoved: false,
+      isDrawerRemoved: false,
+      isDrawerFull: false,
+      globeMotorFaultStatus: "MtrFaultClear",
+      globeMotorRetractFaultStatus: "MtrFaultClear",
+      pinchStatus: "Clear",
+      isUsbFaultDetected: false,
+      isGasSensorFaultDetected: false,
+      displayCode: "DcModeIdle",
+      odometerCleanCycles: 39,
+    },
+  };
+}
+
+function parseRobot(robot: unknown) {
+  return parseLitterRobotDiagnostics(
+    WhiskerDiagnosticsSchema.parse({ robots: [robot], pets: [] }),
+    NOW,
+  );
+}
+
+describe("LR5 Pro diagnostics", () => {
+  it("parses the healthy Ready payload and preserves the raw hopper indicator", () => {
+    const robot = parseRobot(readyRobot());
+
+    expect(robot).toMatchObject({
+      ready: true,
+      sourceFresh: true,
+      litterPercent: 90.7,
+      wastePercent: 33,
+      hopperHealth: "ready",
+      hopperLevelRaw: 1,
+      faulted: false,
+    });
+  });
+
+  it.each([
+    ["LOW", "Low", "low"],
+    ["EMPTY", "Empty", "empty"],
+    ["DISCONNECTED", "Disconnected", "disconnected"],
+    ["JAMMED", "Jammed", "jammed"],
+  ])("classifies hopper %s as %s", (value, title, expected) => {
+    const base = readyRobot();
+    const robot = parseRobot({
+      ...base,
+      state: {
+        ...base.state,
+        hopperStatusIndicator: { value, title },
+      },
+    });
+
+    expect(robot.hopperHealth).toBe(expected);
+  });
+
+  it("classifies explicit hopper motor faults as critical state data", () => {
+    const base = readyRobot();
+    const robot = parseRobot({
+      ...base,
+      state: {
+        ...base.state,
+        hopperFault: "Hopper motor fault",
+        hopperStatusIndicator: null,
+      },
+    });
+
+    expect(robot.hopperHealth).toBe("motor-fault");
+  });
+
+  it("keeps an unavailable hopper payload explicit", () => {
+    const base = readyRobot();
+    const robot = parseRobot({
+      ...base,
+      state: {
+        ...base.state,
+        hopperLitterLevel: null,
+        hopperStatusIndicator: null,
+      },
+    });
+
+    expect(robot.hopperHealth).toBe("unknown");
+    expect(robot.hopperLevelRaw).toBeNull();
+  });
+
+  it("marks old last-seen data stale", () => {
+    const base = readyRobot();
+    const robot = parseRobot({
+      ...base,
+      state: { ...base.state, lastSeen: "2026-08-30T07:00:00Z" },
+    });
+
+    expect(robot.sourceFresh).toBe(false);
+  });
+
+  it("fails closed on malformed LR5 payloads", () => {
+    expect(() => parseRobot({ type: "LR5_PRO", name: "Storage" })).toThrow(
+      "Expected one valid LR5 Pro diagnostics record",
+    );
+  });
+});
+
+describe("pet-care metrics", () => {
+  it("exports safe LR5 values without calling the hopper level a percentage", () => {
+    const robot = parseRobot(readyRobot());
+    const collection: PetCareCollection = {
+      payload: emptyPayload(),
+      metrics: {
+        sourceUp: { homeAssistant: true, whisker: true, alerts: true },
+        litterRobot: robot,
+        litterHaMismatch: false,
+      },
+    };
+
+    const metrics = renderPetCareMetrics(collection);
+
+    expect(metrics).toContain("trmnl_petcare_litter_percent 90.7");
+    expect(metrics).toContain(
+      'trmnl_petcare_litter_hopper_status{status="ready"} 1',
+    );
+    expect(metrics).toContain("trmnl_petcare_litter_hopper_level_raw 1");
+    expect(metrics).not.toContain("hopper_percent");
+  });
+});
+
+function emptyPayload(): PetCarePayload {
+  return {
+    screen: "pets",
+    generated_at: NOW.toISOString(),
+    generated_time: "1:30 AM",
+    status: "ok",
+    summary: "Pet systems healthy",
+    problems: [],
+    fountain: {
+      status: "ok",
+      water_percent: 100,
+      water_ounces: 90,
+      cleaning_days: 12,
+      filter_days: 12,
+      dispensing: true,
+      dispensing_mode: "Flowing Water (Constant)",
+      wifi: true,
+      drinking_ounces_today: 4,
+      drinking_visits_today: 9,
+    },
+    feeders: [],
+    litter_robot: null,
+    vacuums: [],
+    activity: {
+      drinking_ounces: 4,
+      drinking_visits: 9,
+      feedings: 2,
+      food_grams: 20,
+      litter_cycles: 1,
+    },
+    errors: [],
+  };
+}

--- a/packages/trmnl-dashboard/src/__tests__/pets-template.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pets-template.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { Liquid } from "liquidjs";
+import type { PetCarePayload, PetProblem } from "../types.ts";
+
+const templatePath = new URL("../../trmnl/pets.liquid", import.meta.url)
+  .pathname;
+const liquid = new Liquid({ strictVariables: true, strictFilters: true });
+
+describe("pets.liquid", () => {
+  it.each([
+    ["healthy", fixture("ok")],
+    ["warning", fixture("warning")],
+    ["critical", fixture("error")],
+  ])("renders the %s fixture", async (_name, payload) => {
+    const template = await Bun.file(templatePath).text();
+    const html = await liquid.parseAndRender(template, payload);
+
+    expect(html).toContain("Pet Care");
+    expect(html).toContain("Globe litter");
+    expect(html).toContain("Hopper");
+    expect(html).toContain("Roborock Fleet");
+    expect(html).toContain("Litter cycles");
+    if (payload.status === "ok") {
+      expect(html).not.toContain("ACTIVE PROBLEMS");
+    } else {
+      expect(html).toContain("ACTIVE PROBLEMS");
+    }
+  });
+});
+
+function fixture(status: "ok" | "warning" | "error"): PetCarePayload {
+  const problem: PetProblem[] =
+    status === "ok"
+      ? []
+      : [
+          {
+            severity: status === "error" ? "critical" : "warning",
+            alert:
+              status === "error"
+                ? "LitterRobotWasteCritical"
+                : "RoborockConsumableDue",
+            summary:
+              status === "error"
+                ? "Storage LR5 waste drawer critical"
+                : "2nd Floor dock strainer due",
+          },
+        ];
+  return {
+    screen: "pets",
+    generated_at: "2026-08-30T08:30:00.000Z",
+    generated_time: "1:30 AM",
+    status,
+    summary:
+      problem.length === 0
+        ? "Pet systems healthy"
+        : "1 active pet-care problem",
+    problems: problem,
+    fountain: {
+      status: "ok",
+      water_percent: 82,
+      water_ounces: 71,
+      cleaning_days: 12,
+      filter_days: 12,
+      dispensing: true,
+      dispensing_mode: "Flowing Water (Constant)",
+      wifi: true,
+      drinking_ounces_today: 4.1,
+      drinking_visits_today: 9,
+    },
+    feeders: [
+      feeder("living-room", "Living Room"),
+      feeder("guest-room", "Guest Room"),
+    ],
+    litter_robot: {
+      status: status === "error" ? "error" : "ok",
+      name: "Storage",
+      online: true,
+      ready: true,
+      litter_percent: 90.7,
+      waste_percent: status === "error" ? 84 : 33,
+      hopper_status: "Ready",
+      hopper_level_raw: 1,
+      hopper_installed: true,
+      hopper_enabled: true,
+      last_seen_at: "2026-08-30T08:21:53Z",
+      filter_due_at: "2026-09-26T03:00:32Z",
+      cycles_today: 2,
+    },
+    vacuums: [
+      vacuum("1st-floor", "1st Floor", status === "warning" ? "warning" : "ok"),
+      vacuum("2nd-floor", "2nd Floor", "ok"),
+      vacuum("3rd-floor", "3rd Floor", "ok"),
+    ],
+    activity: {
+      drinking_ounces: 4.1,
+      drinking_visits: 9,
+      feedings: 4,
+      food_grams: 40,
+      litter_cycles: 2,
+    },
+    errors: [],
+  };
+}
+
+function feeder(
+  id: "living-room" | "guest-room",
+  label: string,
+): PetCarePayload["feeders"][number] {
+  return {
+    id,
+    label,
+    status: "ok",
+    food_low: false,
+    dispenser_problem: false,
+    battery_problem: false,
+    wifi: true,
+    desiccant_days: 9,
+    last_feed_at: "2026-08-30T14:00:10Z",
+    feedings_today: 2,
+    food_grams_today: 20,
+  };
+}
+
+function vacuum(
+  id: "1st-floor" | "2nd-floor" | "3rd-floor",
+  label: string,
+  status: "ok" | "warning",
+): PetCarePayload["vacuums"][number] {
+  return {
+    id,
+    label,
+    status,
+    state: "docked",
+    battery_percent: 100,
+    last_clean_at: "2026-08-29T22:29:17Z",
+    consumable_hours: 40,
+    clean_water_empty: false,
+    dirty_water_full: false,
+    cleaning_fluid_low: false,
+    water_shortage: false,
+    dust_bag: null,
+  };
+}

--- a/packages/trmnl-dashboard/src/app.ts
+++ b/packages/trmnl-dashboard/src/app.ts
@@ -3,6 +3,7 @@ import { collectHomePayload } from "./collectors/home.ts";
 import { collectHomelabPayload } from "./collectors/homelab.ts";
 import { PetCareService } from "./pet-care-service.ts";
 import { petDashboardEnabled } from "./dynamic-config.ts";
+import { featureFlagMetrics } from "./feature-flag-metrics.ts";
 import { worstStatus } from "./status.ts";
 import type { HomePayload, HomelabPayload, PetCarePayload } from "./types.ts";
 
@@ -10,6 +11,7 @@ export type AppDeps = {
   collectHome?: () => Promise<HomePayload>;
   collectHomelab?: () => Promise<HomelabPayload>;
   getPetMetrics?: () => Promise<string>;
+  getFeatureFlagMetrics?: () => Promise<string>;
   collectPets?: () => Promise<PetCarePayload>;
   petDashboardEnabled?: () => Promise<boolean>;
 };
@@ -21,6 +23,8 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
   const petCareService = new PetCareService(config);
   const getPetMetrics =
     deps.getPetMetrics ?? (() => petCareService.getMetrics());
+  const getFeatureFlagMetrics =
+    deps.getFeatureFlagMetrics ?? featureFlagMetrics.render;
   const collectPets = deps.collectPets ?? (() => petCareService.getPayload());
   const isPetDashboardEnabled = deps.petDashboardEnabled ?? petDashboardEnabled;
 
@@ -40,7 +44,11 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
     }
 
     if (url.pathname === "/metrics") {
-      return new Response(await getPetMetrics(), {
+      const [flagMetrics, petMetrics] = await Promise.all([
+        getFeatureFlagMetrics(),
+        getPetMetrics(),
+      ]);
+      return new Response(`${flagMetrics}${petMetrics}`, {
         headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
       });
     }

--- a/packages/trmnl-dashboard/src/app.ts
+++ b/packages/trmnl-dashboard/src/app.ts
@@ -2,13 +2,16 @@ import type { AppConfig } from "./config.ts";
 import { collectHomePayload } from "./collectors/home.ts";
 import { collectHomelabPayload } from "./collectors/homelab.ts";
 import { PetCareService } from "./pet-care-service.ts";
+import { petDashboardEnabled } from "./dynamic-config.ts";
 import { worstStatus } from "./status.ts";
-import type { HomePayload, HomelabPayload } from "./types.ts";
+import type { HomePayload, HomelabPayload, PetCarePayload } from "./types.ts";
 
 export type AppDeps = {
   collectHome?: () => Promise<HomePayload>;
   collectHomelab?: () => Promise<HomelabPayload>;
   getPetMetrics?: () => Promise<string>;
+  collectPets?: () => Promise<PetCarePayload>;
+  petDashboardEnabled?: () => Promise<boolean>;
 };
 
 export function createHandler(config: AppConfig, deps: AppDeps = {}) {
@@ -18,6 +21,8 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
   const petCareService = new PetCareService(config);
   const getPetMetrics =
     deps.getPetMetrics ?? (() => petCareService.getMetrics());
+  const collectPets = deps.collectPets ?? (() => petCareService.getPayload());
+  const isPetDashboardEnabled = deps.petDashboardEnabled ?? petDashboardEnabled;
 
   return async function handleRequest(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -50,6 +55,13 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
 
     if (url.pathname === "/api/homelab") {
       return json(await collectHomelab());
+    }
+
+    if (url.pathname === "/api/pets") {
+      if (!(await isPetDashboardEnabled())) {
+        return json({ error: "not found" }, 404);
+      }
+      return json(await collectPets());
     }
 
     if (url.pathname === "/api/diagnostics") {

--- a/packages/trmnl-dashboard/src/app.ts
+++ b/packages/trmnl-dashboard/src/app.ts
@@ -1,18 +1,23 @@
 import type { AppConfig } from "./config.ts";
 import { collectHomePayload } from "./collectors/home.ts";
 import { collectHomelabPayload } from "./collectors/homelab.ts";
+import { PetCareService } from "./pet-care-service.ts";
 import { worstStatus } from "./status.ts";
 import type { HomePayload, HomelabPayload } from "./types.ts";
 
 export type AppDeps = {
   collectHome?: () => Promise<HomePayload>;
   collectHomelab?: () => Promise<HomelabPayload>;
+  getPetMetrics?: () => Promise<string>;
 };
 
 export function createHandler(config: AppConfig, deps: AppDeps = {}) {
   const collectHome = deps.collectHome ?? (() => collectHomePayload(config));
   const collectHomelab =
     deps.collectHomelab ?? (() => collectHomelabPayload(config));
+  const petCareService = new PetCareService(config);
+  const getPetMetrics =
+    deps.getPetMetrics ?? (() => petCareService.getMetrics());
 
   return async function handleRequest(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -27,6 +32,12 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
 
     if (url.pathname === "/healthz") {
       return json({ status: "ok" });
+    }
+
+    if (url.pathname === "/metrics") {
+      return new Response(await getPetMetrics(), {
+        headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
+      });
     }
 
     if (!isAuthorized(request, config.trmnlApiKey)) {

--- a/packages/trmnl-dashboard/src/clients/alerts.ts
+++ b/packages/trmnl-dashboard/src/clients/alerts.ts
@@ -30,9 +30,9 @@ export class AlertsClient {
     return SummarySchema.parse(response);
   }
 
-  async listOpen(): Promise<AlertSummaryItem[]> {
+  async listOpen(limit = 6): Promise<AlertSummaryItem[]> {
     const response = await this.fetchJson(
-      "/api/v1/alerts?lifecycleState=open&limit=6",
+      `/api/v1/alerts?lifecycleState=open&limit=${limit.toString()}`,
     );
     return AlertListSchema.parse(response).items;
   }

--- a/packages/trmnl-dashboard/src/clients/pet-care.ts
+++ b/packages/trmnl-dashboard/src/clients/pet-care.ts
@@ -1,0 +1,249 @@
+import { z } from "zod";
+import {
+  HomeAssistantEventClient,
+  HomeAssistantRestClient,
+  type EntityState,
+} from "@shepherdjerred/home-assistant";
+
+const DateTimeSchema = z.iso.datetime({ offset: true });
+
+const HopperIndicatorSchema = z
+  .object({
+    title: z.string().min(1),
+    value: z.string().min(1),
+  })
+  .nullable();
+
+const LitterRobotStateSchema = z
+  .object({
+    isOnline: z.boolean(),
+    lastSeen: DateTimeSchema,
+    statusIndicator: z.object({
+      title: z.string().min(1),
+      type: z.string().min(1),
+    }),
+    dfiLevelPercent: z.number().min(0).max(100),
+    litterLevelPercent: z.number().min(0).max(100),
+    hopperLitterLevel: z.number().nullable(),
+    hopperFault: z.string().nullable(),
+    hopperStatusIndicator: HopperIndicatorSchema,
+    isHopperInstalled: z.boolean(),
+    hopperStateLastUpdated: DateTimeSchema.nullable(),
+    isLaserDirty: z.boolean(),
+    isBonnetRemoved: z.boolean(),
+    isDrawerRemoved: z.boolean(),
+    isDrawerFull: z.boolean(),
+    globeMotorFaultStatus: z.string().min(1),
+    globeMotorRetractFaultStatus: z.string().min(1),
+    pinchStatus: z.string().min(1),
+    isUsbFaultDetected: z.boolean(),
+    isGasSensorFaultDetected: z.boolean(),
+    displayCode: z.string().min(1),
+    odometerCleanCycles: z.number().int().nonnegative(),
+  })
+  .loose();
+
+const LitterRobotSchema = z
+  .object({
+    type: z.literal("LR5_PRO"),
+    name: z.string().min(1),
+    updatedAt: DateTimeSchema,
+    state: LitterRobotStateSchema,
+    nextFilterReplacementDate: DateTimeSchema.nullable(),
+    hopperSettings: z.object({ mode: z.string().min(1) }),
+  })
+  .loose();
+
+export const WhiskerDiagnosticsSchema = z.object({
+  robots: z.array(z.unknown()),
+  pets: z.array(z.unknown()),
+});
+
+export type HopperHealth =
+  | "ready"
+  | "low"
+  | "empty"
+  | "disconnected"
+  | "jammed"
+  | "motor-fault"
+  | "fault"
+  | "unknown";
+
+export type LitterRobotSnapshot = {
+  name: string;
+  online: boolean;
+  ready: boolean;
+  litterPercent: number;
+  wastePercent: number;
+  hopperHealth: HopperHealth;
+  hopperLabel: string;
+  hopperLevelRaw: number | null;
+  hopperInstalled: boolean;
+  hopperEnabled: boolean;
+  lastSeenAt: string;
+  filterDueAt: string | null;
+  totalCycles: number;
+  sourceFresh: boolean;
+  faulted: boolean;
+};
+
+export class PetCareHomeAssistantClient {
+  private readonly rest: HomeAssistantRestClient;
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private configEntryId: string | undefined;
+
+  public constructor(baseUrl: string, token: string) {
+    this.baseUrl = baseUrl;
+    this.token = token;
+    this.rest = new HomeAssistantRestClient({ baseUrl, token });
+  }
+
+  public getStates(): Promise<EntityState[]> {
+    return this.rest.getStates();
+  }
+
+  public getHistory(entityId: string, start: Date): Promise<EntityState[][]> {
+    return this.rest.getHistory([entityId], {
+      start,
+      minimalResponse: true,
+      significantChangesOnly: true,
+    });
+  }
+
+  public async getLitterRobot(now = new Date()): Promise<LitterRobotSnapshot> {
+    const configEntryId =
+      this.configEntryId ?? (await this.discoverLitterRobotConfigEntry());
+    this.configEntryId = configEntryId;
+    const diagnostics = await this.rest.getConfigEntryDiagnostics(
+      configEntryId,
+      WhiskerDiagnosticsSchema,
+    );
+    return parseLitterRobotDiagnostics(diagnostics, now);
+  }
+
+  private async discoverLitterRobotConfigEntry(): Promise<string> {
+    const client = new HomeAssistantEventClient(
+      { baseUrl: this.baseUrl, token: this.token },
+      { reconnect: false },
+    );
+    try {
+      await client.connect();
+      const registry = await client.getEntityRegistry();
+      const ids = new Set(
+        registry
+          .filter((entry) => entry.platform === "litterrobot")
+          .filter((entry) => entry.entity_id.startsWith("vacuum."))
+          .flatMap((entry) =>
+            entry.config_entry_id == null ? [] : [entry.config_entry_id],
+          ),
+      );
+      if (ids.size !== 1) {
+        throw new Error(
+          `Expected one Whisker config entry for a litterrobot vacuum, found ${ids.size.toString()}`,
+        );
+      }
+      const [id] = ids;
+      if (id === undefined) {
+        throw new Error("Whisker config entry discovery returned no ID");
+      }
+      return id;
+    } finally {
+      await client.close();
+    }
+  }
+}
+
+export function parseLitterRobotDiagnostics(
+  diagnostics: z.infer<typeof WhiskerDiagnosticsSchema>,
+  now = new Date(),
+): LitterRobotSnapshot {
+  const robots = diagnostics.robots.flatMap((value) => {
+    const parsed = LitterRobotSchema.safeParse(value);
+    return parsed.success ? [parsed.data] : [];
+  });
+  if (robots.length !== 1) {
+    throw new Error(
+      `Expected one valid LR5 Pro diagnostics record, found ${robots.length.toString()}`,
+    );
+  }
+  const robot = robots[0];
+  if (robot === undefined) {
+    throw new Error("LR5 Pro diagnostics record disappeared after validation");
+  }
+  const state = robot.state;
+  const hopper = classifyHopper(
+    state.hopperStatusIndicator?.value,
+    state.hopperStatusIndicator?.title,
+    state.hopperFault,
+  );
+  const ready = state.statusIndicator.type.toUpperCase() === "READY";
+  const faulted =
+    !ready ||
+    state.isLaserDirty ||
+    state.isBonnetRemoved ||
+    state.isDrawerRemoved ||
+    state.isDrawerFull ||
+    state.globeMotorFaultStatus !== "MtrFaultClear" ||
+    state.globeMotorRetractFaultStatus !== "MtrFaultClear" ||
+    state.pinchStatus !== "Clear" ||
+    state.isUsbFaultDetected ||
+    state.isGasSensorFaultDetected;
+
+  return {
+    name: robot.name,
+    online: state.isOnline,
+    ready,
+    litterPercent: state.litterLevelPercent,
+    wastePercent: state.dfiLevelPercent,
+    hopperHealth: hopper.health,
+    hopperLabel: hopper.label,
+    hopperLevelRaw: state.hopperLitterLevel,
+    hopperInstalled: state.isHopperInstalled,
+    hopperEnabled: robot.hopperSettings.mode.toLowerCase() === "enabled",
+    lastSeenAt: state.lastSeen,
+    filterDueAt: robot.nextFilterReplacementDate,
+    totalCycles: state.odometerCleanCycles,
+    sourceFresh:
+      now.getTime() - new Date(state.lastSeen).getTime() <= 15 * 60 * 1000,
+    faulted,
+  };
+}
+
+function classifyHopper(
+  value: string | undefined,
+  title: string | undefined,
+  fault: string | null,
+): { health: HopperHealth; label: string } {
+  const label = title ?? value ?? fault ?? "Unavailable";
+  const combined = [value, title, fault]
+    .filter((part) => part != null)
+    .join(" ")
+    .toLowerCase();
+  if (combined.includes("jam")) {
+    return { health: "jammed", label };
+  }
+  if (combined.includes("motor")) {
+    return { health: "motor-fault", label };
+  }
+  if (
+    fault != null ||
+    combined.includes("fault") ||
+    combined.includes("error")
+  ) {
+    return { health: "fault", label };
+  }
+  if (combined.includes("disconnect") || combined.includes("not connected")) {
+    return { health: "disconnected", label };
+  }
+  if (combined.includes("empty")) {
+    return { health: "empty", label };
+  }
+  if (combined.includes("low")) {
+    return { health: "low", label };
+  }
+  if (combined.includes("ready")) {
+    return { health: "ready", label };
+  }
+  return { health: "unknown", label };
+}

--- a/packages/trmnl-dashboard/src/clients/pet-care.ts
+++ b/packages/trmnl-dashboard/src/clients/pet-care.ts
@@ -106,7 +106,6 @@ export class PetCareHomeAssistantClient {
   public getHistory(entityId: string, start: Date): Promise<EntityState[][]> {
     return this.rest.getHistory([entityId], {
       start,
-      minimalResponse: true,
       significantChangesOnly: true,
     });
   }

--- a/packages/trmnl-dashboard/src/collectors/pets.ts
+++ b/packages/trmnl-dashboard/src/collectors/pets.ts
@@ -1,0 +1,426 @@
+import type { EntityState } from "@shepherdjerred/home-assistant";
+import type { AppConfig } from "../config.ts";
+import { AlertsClient, type AlertSummaryItem } from "../clients/alerts.ts";
+import {
+  PetCareHomeAssistantClient,
+  type LitterRobotSnapshot,
+} from "../clients/pet-care.ts";
+import { isUnavailableState, worstStatus, type Status } from "../status.ts";
+import { formatDisplayTime, startOfDisplayDay } from "../time.ts";
+import type { PetCarePayload, PetProblem } from "../types.ts";
+
+const FOUNTAIN = "dockstream_2_smart_fountain";
+const FEEDER = "granary_smart_camera_feeder";
+const PET_ALERT_PATTERN = /^(?:PetLibro|LitterRobot|Roborock)/;
+
+const VACUUMS = [
+  { id: "1st-floor", label: "1st Floor", prefix: "1st_floor" },
+  { id: "2nd-floor", label: "2nd Floor", prefix: "2nd_floor" },
+  { id: "3rd-floor", label: "3rd Floor", prefix: "3rd_floor" },
+] as const;
+
+const FEEDERS = [
+  { id: "living-room", label: "Living Room", suffix: "" },
+  { id: "guest-room", label: "Guest Room", suffix: "_2" },
+] as const;
+
+export type PetCareClients = {
+  homeAssistant: Pick<
+    PetCareHomeAssistantClient,
+    "getStates" | "getLitterRobot" | "getHistory"
+  >;
+  alerts: Pick<AlertsClient, "listOpen">;
+};
+
+export type PetCareCollection = {
+  payload: PetCarePayload;
+  metrics: PetCareMetricSnapshot;
+};
+
+export type PetCareMetricSnapshot = {
+  sourceUp: { homeAssistant: boolean; whisker: boolean; alerts: boolean };
+  litterRobot: LitterRobotSnapshot | null;
+  litterHaMismatch: boolean | null;
+};
+
+export function createPetCareClients(config: AppConfig): PetCareClients {
+  return {
+    homeAssistant: new PetCareHomeAssistantClient(
+      config.homeAssistant.url,
+      config.homeAssistant.token,
+    ),
+    alerts: new AlertsClient(config.homelab.alertDashboardUrl),
+  };
+}
+
+export async function collectPetCare(
+  config: AppConfig,
+  clients = createPetCareClients(config),
+  now = new Date(),
+): Promise<PetCareCollection> {
+  const errors: string[] = [];
+  const [statesResult, litterResult, alertsResult] = await Promise.allSettled([
+    clients.homeAssistant.getStates(),
+    clients.homeAssistant.getLitterRobot(now),
+    clients.alerts.listOpen(100),
+  ]);
+  const states = resultOrNull(statesResult, "Home Assistant states", errors);
+  const litterRobot = resultOrNull(litterResult, "Whisker diagnostics", errors);
+  const openAlerts =
+    resultOrNull(alertsResult, "Alertmanager alerts", errors) ?? [];
+  const petAlerts = openAlerts.filter((alert) =>
+    PET_ALERT_PATTERN.test(alert.alertname),
+  );
+  const cyclesToday = await collectLitterCycles({
+    client: clients.homeAssistant,
+    states,
+    robot: litterRobot,
+    start: startOfDisplayDay(now, config.displayTimeZone),
+    errors,
+  });
+  const fountain = buildFountain(states, petAlerts);
+  const feeders = FEEDERS.map((feeder) =>
+    buildFeeder(states, petAlerts, feeder),
+  );
+  const litter = buildLitterRobot(litterRobot, petAlerts, cyclesToday);
+  const vacuums = VACUUMS.map((vacuum) =>
+    buildVacuum(states, petAlerts, vacuum),
+  );
+  const problems = toProblems(petAlerts);
+  const generatedAt = now.toISOString();
+  const activity = {
+    drinking_ounces: fountain.drinking_ounces_today,
+    drinking_visits: fountain.drinking_visits_today,
+    feedings: sumOptional(feeders.map((feeder) => feeder.feedings_today)),
+    food_grams: sumOptional(feeders.map((feeder) => feeder.food_grams_today)),
+    litter_cycles: cyclesToday,
+  };
+  const sourceStatus: Status = errors.length > 0 ? "unknown" : "ok";
+  const payload: PetCarePayload = {
+    screen: "pets",
+    generated_at: generatedAt,
+    generated_time: formatDisplayTime(now, config.displayTimeZone),
+    status: worstStatus([
+      fountain.status,
+      ...feeders.map((feeder) => feeder.status),
+      litter?.status ?? "unknown",
+      ...vacuums.map((vacuum) => vacuum.status),
+      sourceStatus,
+    ]),
+    summary:
+      problems.length === 0
+        ? "Pet systems healthy"
+        : `${problems.length.toString()} active pet-care problem${problems.length === 1 ? "" : "s"}`,
+    problems,
+    fountain,
+    feeders,
+    litter_robot: litter,
+    vacuums,
+    activity,
+    errors,
+  };
+
+  return {
+    payload,
+    metrics: {
+      sourceUp: {
+        homeAssistant: statesResult.status === "fulfilled",
+        whisker: litterResult.status === "fulfilled",
+        alerts: alertsResult.status === "fulfilled",
+      },
+      litterRobot,
+      litterHaMismatch:
+        states == null || litterRobot == null
+          ? null
+          : litterValuesMismatch(states, litterRobot),
+    },
+  };
+}
+
+function buildFountain(
+  states: EntityState[] | null,
+  alerts: AlertSummaryItem[],
+): PetCarePayload["fountain"] {
+  const fields = {
+    water_percent: numberState(states, `sensor.${FOUNTAIN}_remaining_water_2`),
+    water_ounces: numberState(states, `sensor.${FOUNTAIN}_remaining_water`),
+    cleaning_days: numberState(
+      states,
+      `sensor.${FOUNTAIN}_remaining_cleaning_days`,
+    ),
+    filter_days: numberState(states, `sensor.${FOUNTAIN}_remaining_filter_day`),
+    dispensing: booleanState(
+      states,
+      `binary_sensor.${FOUNTAIN}_water_dispensing_state`,
+    ),
+    dispensing_mode: stringState(
+      states,
+      `select.${FOUNTAIN}_water_dispensing_mode`,
+    ),
+    wifi: booleanState(states, `binary_sensor.${FOUNTAIN}_wi_fi`),
+    drinking_ounces_today: numberState(
+      states,
+      `sensor.${FOUNTAIN}_today_s_water_consumption`,
+    ),
+    drinking_visits_today: numberState(
+      states,
+      `sensor.${FOUNTAIN}_today_s_total_drinking_times`,
+    ),
+  };
+  return {
+    status: componentStatus(alerts, (alert) =>
+      alert.alertname.startsWith("PetLibroFountain"),
+    ),
+    ...fields,
+  };
+}
+
+function buildFeeder(
+  states: EntityState[] | null,
+  alerts: AlertSummaryItem[],
+  feeder: (typeof FEEDERS)[number],
+): PetCarePayload["feeders"][number] {
+  const alertToken = feeder.id === "living-room" ? "LivingRoom" : "GuestRoom";
+  return {
+    id: feeder.id,
+    label: feeder.label,
+    status: componentStatus(alerts, (alert) =>
+      alert.alertname.includes(`Feeder${alertToken}`),
+    ),
+    food_low: booleanState(
+      states,
+      `binary_sensor.${FEEDER}_food_status${feeder.suffix}`,
+    ),
+    dispenser_problem: booleanState(
+      states,
+      `binary_sensor.${FEEDER}_food_dispenser${feeder.suffix}`,
+    ),
+    battery_problem: booleanState(
+      states,
+      `binary_sensor.${FEEDER}_battery_status${feeder.suffix}`,
+    ),
+    wifi: booleanState(states, `binary_sensor.${FEEDER}_wi_fi${feeder.suffix}`),
+    desiccant_days: numberState(
+      states,
+      `sensor.${FEEDER}_desiccant_remaining_days${feeder.suffix}`,
+    ),
+    last_feed_at: stringState(
+      states,
+      `sensor.${FEEDER}_last_feed_time${feeder.suffix}`,
+    ),
+    feedings_today: numberState(
+      states,
+      `sensor.${FEEDER}_today_s_feeding_times${feeder.suffix}`,
+    ),
+    food_grams_today: numberState(
+      states,
+      `sensor.${FEEDER}_today_s_feeding_quantity_weight${feeder.suffix}`,
+    ),
+  };
+}
+
+function buildLitterRobot(
+  robot: LitterRobotSnapshot | null,
+  alerts: AlertSummaryItem[],
+  cyclesToday: number | null,
+): PetCarePayload["litter_robot"] {
+  if (robot == null) {
+    return null;
+  }
+  return {
+    status: componentStatus(alerts, (alert) =>
+      alert.alertname.startsWith("LitterRobot"),
+    ),
+    name: "Storage",
+    online: robot.online,
+    ready: robot.ready,
+    litter_percent: robot.litterPercent,
+    waste_percent: robot.wastePercent,
+    hopper_status: robot.hopperLabel,
+    hopper_level_raw: robot.hopperLevelRaw,
+    hopper_installed: robot.hopperInstalled,
+    hopper_enabled: robot.hopperEnabled,
+    last_seen_at: robot.lastSeenAt,
+    filter_due_at: robot.filterDueAt,
+    cycles_today: cyclesToday,
+  };
+}
+
+function buildVacuum(
+  states: EntityState[] | null,
+  alerts: AlertSummaryItem[],
+  vacuum: (typeof VACUUMS)[number],
+): PetCarePayload["vacuums"][number] {
+  const hours = ["main_brush", "side_brush", "filter", "dock_strainer"]
+    .map((part) =>
+      numberState(states, `sensor.${vacuum.prefix}_${part}_time_left`),
+    )
+    .filter((value) => value != null);
+  return {
+    id: vacuum.id,
+    label: vacuum.label,
+    status: componentStatus(
+      alerts,
+      (alert) =>
+        alert.alertname.startsWith("Roborock") &&
+        alert.summary.toLowerCase().includes(vacuum.label.toLowerCase()),
+    ),
+    state: stringState(states, `vacuum.${vacuum.prefix}`),
+    battery_percent: numberState(states, `sensor.${vacuum.prefix}_battery`),
+    last_clean_at: stringState(
+      states,
+      `sensor.${vacuum.prefix}_last_clean_end`,
+    ),
+    consumable_hours: hours.length === 0 ? null : Math.min(...hours),
+    clean_water_empty: booleanState(
+      states,
+      `binary_sensor.${vacuum.prefix}_dock_clean_water_box`,
+    ),
+    dirty_water_full: booleanState(
+      states,
+      `binary_sensor.${vacuum.prefix}_dock_dirty_water_box`,
+    ),
+    cleaning_fluid_low: booleanState(
+      states,
+      `binary_sensor.${vacuum.prefix}_dock_cleaning_fluid`,
+    ),
+    water_shortage: booleanState(
+      states,
+      `binary_sensor.${vacuum.prefix}_water_shortage`,
+    ),
+    dust_bag: null,
+  };
+}
+
+async function collectLitterCycles(options: {
+  client: PetCareClients["homeAssistant"];
+  states: EntityState[] | null;
+  robot: LitterRobotSnapshot | null;
+  start: Date;
+  errors: string[];
+}): Promise<number | null> {
+  const { client, states, robot, start, errors } = options;
+  if (states == null || robot == null) {
+    return null;
+  }
+  const entity = states.find((state) =>
+    state.entity_id.endsWith("_scoops_saved"),
+  );
+  if (entity === undefined) {
+    errors.push("Home Assistant litter activity entity is missing");
+    return null;
+  }
+  try {
+    const history = await client.getHistory(entity.entity_id, start);
+    const first = history[0]?.map((state) => Number(state.state))[0];
+    return first == null || !Number.isFinite(first)
+      ? null
+      : Math.max(0, robot.totalCycles - first);
+  } catch (error) {
+    errors.push(errorMessage("Home Assistant litter activity", error));
+    return null;
+  }
+}
+
+function litterValuesMismatch(
+  states: EntityState[],
+  robot: LitterRobotSnapshot,
+): boolean {
+  const litter = states.find((state) =>
+    state.entity_id.endsWith("_litter_level"),
+  );
+  const waste = states.find((state) =>
+    state.entity_id.endsWith("_waste_drawer"),
+  );
+  const status = states.find((state) =>
+    state.entity_id.endsWith("_status_code"),
+  );
+  if (litter === undefined || waste === undefined || status === undefined) {
+    return true;
+  }
+  return (
+    Math.abs(Number(litter.state) - robot.litterPercent) > 1 ||
+    Math.abs(Number(waste.state) - robot.wastePercent) > 1 ||
+    (robot.ready && !["rdy", "ready"].includes(status.state.toLowerCase()))
+  );
+}
+
+function toProblems(alerts: AlertSummaryItem[]): PetProblem[] {
+  return alerts.map((alert) => ({
+    severity:
+      alert.severity.toLowerCase() === "critical" ? "critical" : "warning",
+    alert: alert.alertname,
+    summary: alert.summary,
+  }));
+}
+
+function componentStatus(
+  alerts: AlertSummaryItem[],
+  matches: (alert: AlertSummaryItem) => boolean,
+): Status {
+  const matching = alerts.filter((alert) => matches(alert));
+  if (matching.some((alert) => alert.severity.toLowerCase() === "critical")) {
+    return "error";
+  }
+  return matching.length > 0 ? "warning" : "ok";
+}
+
+function stateValue(
+  states: EntityState[] | null,
+  entityId: string,
+): string | null {
+  const state = states?.find((candidate) => candidate.entity_id === entityId);
+  return state === undefined || isUnavailableState(state.state)
+    ? null
+    : state.state;
+}
+
+function stringState(
+  states: EntityState[] | null,
+  entityId: string,
+): string | null {
+  return stateValue(states, entityId);
+}
+
+function numberState(
+  states: EntityState[] | null,
+  entityId: string,
+): number | null {
+  const state = stateValue(states, entityId);
+  if (state === null) {
+    return null;
+  }
+  const value = Number(state);
+  return Number.isFinite(value) ? value : null;
+}
+
+function booleanState(
+  states: EntityState[] | null,
+  entityId: string,
+): boolean | null {
+  const value = stateValue(states, entityId);
+  return value == null ? null : value === "on";
+}
+
+function sumOptional(values: (number | null)[]): number | null {
+  return values.some((value) => value == null)
+    ? null
+    : values.reduce<number>((sum, value) => sum + (value ?? 0), 0);
+}
+
+function resultOrNull<T>(
+  result: PromiseSettledResult<T>,
+  label: string,
+  errors: string[],
+): T | null {
+  if (result.status === "fulfilled") {
+    return result.value;
+  }
+  errors.push(errorMessage(label, result.reason));
+  return null;
+}
+
+function errorMessage(area: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${area}: ${message}`;
+}

--- a/packages/trmnl-dashboard/src/collectors/pets.ts
+++ b/packages/trmnl-dashboard/src/collectors/pets.ts
@@ -11,7 +11,7 @@ import type { PetCarePayload, PetProblem } from "../types.ts";
 
 const FOUNTAIN = "dockstream_2_smart_fountain";
 const FEEDER = "granary_smart_camera_feeder";
-const PET_ALERT_PATTERN = /^(?:PetLibro|LitterRobot|Roborock)/;
+const PET_ALERT_PATTERN = /^(?:PetCare|PetLibro|LitterRobot|Roborock)/;
 
 const VACUUMS = [
   { id: "1st-floor", label: "1st Floor", prefix: "1st_floor" },
@@ -168,8 +168,11 @@ function buildFountain(
     ),
   };
   return {
-    status: componentStatus(alerts, (alert) =>
-      alert.alertname.startsWith("PetLibroFountain"),
+    status: componentStatus(
+      alerts,
+      (alert) =>
+        alert.alertname.startsWith("PetLibroFountain") ||
+        isAvailabilityAlertFor(alert, "dockstream_2_smart_fountain"),
     ),
     ...fields,
   };
@@ -181,11 +184,22 @@ function buildFeeder(
   feeder: (typeof FEEDERS)[number],
 ): PetCarePayload["feeders"][number] {
   const alertToken = feeder.id === "living-room" ? "LivingRoom" : "GuestRoom";
+  const feederEntities = [
+    `binary_sensor.${FEEDER}_battery_status${feeder.suffix}`,
+    `binary_sensor.${FEEDER}_food_dispenser${feeder.suffix}`,
+    `binary_sensor.${FEEDER}_food_status${feeder.suffix}`,
+    `binary_sensor.${FEEDER}_wi_fi${feeder.suffix}`,
+    `sensor.${FEEDER}_desiccant_remaining_days${feeder.suffix}`,
+    `sensor.${FEEDER}_last_feed_time${feeder.suffix}`,
+  ];
   return {
     id: feeder.id,
     label: feeder.label,
-    status: componentStatus(alerts, (alert) =>
-      alert.alertname.includes(`Feeder${alertToken}`),
+    status: componentStatus(
+      alerts,
+      (alert) =>
+        alert.alertname.includes(`Feeder${alertToken}`) ||
+        feederEntities.some((entity) => isAvailabilityAlertFor(alert, entity)),
     ),
     food_low: booleanState(
       states,
@@ -262,8 +276,9 @@ function buildVacuum(
     status: componentStatus(
       alerts,
       (alert) =>
-        alert.alertname.startsWith("Roborock") &&
-        alert.summary.toLowerCase().includes(vacuum.label.toLowerCase()),
+        (alert.alertname.startsWith("Roborock") &&
+          alert.summary.toLowerCase().includes(vacuum.label.toLowerCase())) ||
+        isAvailabilityAlertFor(alert, vacuum.prefix),
     ),
     state: stringState(states, `vacuum.${vacuum.prefix}`),
     battery_percent: numberState(states, `sensor.${vacuum.prefix}_battery`),
@@ -363,6 +378,16 @@ function componentStatus(
     return "error";
   }
   return matching.length > 0 ? "warning" : "ok";
+}
+
+function isAvailabilityAlertFor(
+  alert: AlertSummaryItem,
+  entityToken: string,
+): boolean {
+  return (
+    alert.alertname === "PetCareEntityUnavailable" &&
+    alert.summary.includes(entityToken)
+  );
 }
 
 function stateValue(

--- a/packages/trmnl-dashboard/src/dynamic-config.ts
+++ b/packages/trmnl-dashboard/src/dynamic-config.ts
@@ -6,6 +6,7 @@ import {
   shutdownFeatureFlags,
   type InitFeatureFlagsOptions,
 } from "@shepherdjerred/feature-flags";
+import { featureFlagMetrics } from "./feature-flag-metrics.ts";
 
 const DEFINITION = {
   petDashboardEnabled: {
@@ -46,6 +47,7 @@ export async function initializeDynamicConfig(
       ? {}
       : { environment: options.environment }),
     ...(options.provider === undefined ? {} : { provider: options.provider }),
+    metrics: featureFlagMetrics.recorder,
     onInitializationFailure: (message) => {
       console.warn(`[Config] ${message}`);
     },

--- a/packages/trmnl-dashboard/src/dynamic-config.ts
+++ b/packages/trmnl-dashboard/src/dynamic-config.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { defineConfig } from "@shepherdjerred/config";
+import { createFlagConfigSource } from "@shepherdjerred/feature-flags/config-source.ts";
+import {
+  initFeatureFlags,
+  shutdownFeatureFlags,
+  type InitFeatureFlagsOptions,
+} from "@shepherdjerred/feature-flags";
+
+const DEFINITION = {
+  petDashboardEnabled: {
+    schema: z.boolean(),
+    sources: ["flag", "default"],
+    default: false,
+    names: { flag: "pet-dashboard-enabled" },
+  },
+} as const;
+
+let resolver: ReturnType<typeof createResolver> | undefined;
+
+function createResolver() {
+  return defineConfig({
+    definition: DEFINITION,
+    sources: {
+      flag: createFlagConfigSource({
+        targetingKey: "trmnl-dashboard",
+        kinds: { petDashboardEnabled: "boolean" },
+      }),
+    },
+    hooks: {
+      onSourceError: (key, source, message) => {
+        console.warn(`[Config] ${key} ${source}: ${message}`);
+      },
+    },
+  });
+}
+
+export async function initializeDynamicConfig(
+  options: {
+    environment?: InitFeatureFlagsOptions["environment"];
+    provider?: InitFeatureFlagsOptions["provider"];
+  } = {},
+): Promise<void> {
+  await initFeatureFlags({
+    ...(options.environment === undefined
+      ? {}
+      : { environment: options.environment }),
+    ...(options.provider === undefined ? {} : { provider: options.provider }),
+    onInitializationFailure: (message) => {
+      console.warn(`[Config] ${message}`);
+    },
+  });
+  resolver = createResolver();
+}
+
+export async function petDashboardEnabled(): Promise<boolean> {
+  if (resolver === undefined) {
+    throw new Error(
+      "dynamic config read before initializeDynamicConfig(); call it during startup",
+    );
+  }
+  return resolver.value("petDashboardEnabled", {
+    targetingKey: "trmnl-dashboard",
+  });
+}
+
+export async function shutdownDynamicConfig(): Promise<void> {
+  resolver = undefined;
+  await shutdownFeatureFlags();
+}

--- a/packages/trmnl-dashboard/src/feature-flag-metrics.ts
+++ b/packages/trmnl-dashboard/src/feature-flag-metrics.ts
@@ -1,0 +1,48 @@
+import { Counter, Gauge, Registry } from "prom-client";
+import {
+  FEATURE_FLAG_METRICS,
+  type FlagMetricsRecorder,
+} from "@shepherdjerred/feature-flags/observability.ts";
+
+export type FeatureFlagMetrics = {
+  recorder: FlagMetricsRecorder;
+  render: () => Promise<string>;
+};
+
+export function createFeatureFlagMetrics(): FeatureFlagMetrics {
+  const registry = new Registry();
+  const evaluations = new Counter({
+    name: FEATURE_FLAG_METRICS.evaluations,
+    help: "Feature flag evaluations by flag and resolution reason",
+    labelNames: ["flag", "reason"] as const,
+    registers: [registry],
+  });
+  const errors = new Counter({
+    name: FEATURE_FLAG_METRICS.errors,
+    help: "Feature flag provider errors by operation",
+    labelNames: ["operation"] as const,
+    registers: [registry],
+  });
+  const snapshotAge = new Gauge({
+    name: FEATURE_FLAG_METRICS.snapshotAge,
+    help: "Seconds since the feature flag snapshot refreshed successfully",
+    registers: [registry],
+  });
+
+  return {
+    recorder: {
+      countEvaluation: (event) => {
+        evaluations.inc({ flag: event.flag, reason: event.reason });
+      },
+      countError: (operation) => {
+        errors.inc({ operation });
+      },
+      observeSnapshotAge: (seconds) => {
+        snapshotAge.set(seconds);
+      },
+    },
+    render: () => registry.metrics(),
+  };
+}
+
+export const featureFlagMetrics = createFeatureFlagMetrics();

--- a/packages/trmnl-dashboard/src/index.ts
+++ b/packages/trmnl-dashboard/src/index.ts
@@ -1,9 +1,12 @@
 import { createHandler } from "./app.ts";
 import { loadConfig } from "./config.ts";
 import { initializeSentry } from "./sentry.ts";
+import { initializeDynamicConfig } from "./dynamic-config.ts";
 
 // Initialize before anything else so early failures are captured.
 initializeSentry();
+
+await initializeDynamicConfig({ environment: Bun.env });
 
 const config = loadConfig(Bun.env);
 const handler = createHandler(config);

--- a/packages/trmnl-dashboard/src/pet-care-service.ts
+++ b/packages/trmnl-dashboard/src/pet-care-service.ts
@@ -1,0 +1,153 @@
+import type { AppConfig } from "./config.ts";
+import {
+  collectPetCare,
+  createPetCareClients,
+  type PetCareClients,
+  type PetCareCollection,
+} from "./collectors/pets.ts";
+import type { PetCarePayload } from "./types.ts";
+
+const CACHE_DURATION_MS = 20_000;
+
+export class PetCareService {
+  private readonly config: AppConfig;
+  private readonly clients: PetCareClients;
+  private cached: { expiresAt: number; value: PetCareCollection } | undefined;
+  private pending: Promise<PetCareCollection> | undefined;
+
+  public constructor(
+    config: AppConfig,
+    clients = createPetCareClients(config),
+  ) {
+    this.config = config;
+    this.clients = clients;
+  }
+
+  public async getPayload(): Promise<PetCarePayload> {
+    const collection = await this.getCollection();
+    return collection.payload;
+  }
+
+  public async getMetrics(): Promise<string> {
+    return renderPetCareMetrics(await this.getCollection());
+  }
+
+  private async getCollection(): Promise<PetCareCollection> {
+    const now = Date.now();
+    if (this.cached !== undefined && this.cached.expiresAt > now) {
+      return this.cached.value;
+    }
+    if (this.pending !== undefined) {
+      return this.pending;
+    }
+    const pending = collectPetCare(this.config, this.clients);
+    this.pending = pending;
+    try {
+      const value = await pending;
+      this.cached = { expiresAt: now + CACHE_DURATION_MS, value };
+      return value;
+    } finally {
+      this.pending = undefined;
+    }
+  }
+}
+
+export function renderPetCareMetrics(collection: PetCareCollection): string {
+  const lines = [
+    "# HELP trmnl_petcare_source_up Whether a pet-care source was read successfully.",
+    "# TYPE trmnl_petcare_source_up gauge",
+    metric(
+      "trmnl_petcare_source_up",
+      bool(collection.metrics.sourceUp.homeAssistant),
+      { source: "home_assistant" },
+    ),
+    metric(
+      "trmnl_petcare_source_up",
+      bool(collection.metrics.sourceUp.whisker),
+      { source: "whisker" },
+    ),
+    metric(
+      "trmnl_petcare_source_up",
+      bool(collection.metrics.sourceUp.alerts),
+      { source: "alertmanager" },
+    ),
+  ];
+  const robot = collection.metrics.litterRobot;
+  if (robot !== null) {
+    lines.push(
+      "# HELP trmnl_petcare_litter_percent Fresh LR5 globe litter percentage.",
+      "# TYPE trmnl_petcare_litter_percent gauge",
+      metric("trmnl_petcare_litter_percent", robot.litterPercent),
+      "# HELP trmnl_petcare_litter_waste_percent Fresh LR5 waste drawer percentage.",
+      "# TYPE trmnl_petcare_litter_waste_percent gauge",
+      metric("trmnl_petcare_litter_waste_percent", robot.wastePercent),
+      "# HELP trmnl_petcare_litter_hopper_status Fresh LR5 hopper categorical state.",
+      "# TYPE trmnl_petcare_litter_hopper_status gauge",
+      metric("trmnl_petcare_litter_hopper_status", 1, {
+        status: robot.hopperHealth,
+      }),
+      metric("trmnl_petcare_litter_online", bool(robot.online)),
+      metric("trmnl_petcare_litter_ready", bool(robot.ready)),
+      metric("trmnl_petcare_litter_source_fresh", bool(robot.sourceFresh)),
+      metric("trmnl_petcare_litter_fault", bool(robot.faulted)),
+      metric(
+        "trmnl_petcare_litter_hopper_installed",
+        bool(robot.hopperInstalled),
+      ),
+      metric("trmnl_petcare_litter_hopper_enabled", bool(robot.hopperEnabled)),
+    );
+    if (robot.hopperLevelRaw !== null) {
+      lines.push(
+        "# HELP trmnl_petcare_litter_hopper_level_raw Raw Whisker hopper-level indicator; its scale is not established.",
+        "# TYPE trmnl_petcare_litter_hopper_level_raw gauge",
+        metric("trmnl_petcare_litter_hopper_level_raw", robot.hopperLevelRaw),
+      );
+    }
+    if (robot.filterDueAt !== null) {
+      lines.push(
+        "# HELP trmnl_petcare_litter_filter_due_timestamp_seconds LR5 filter replacement due time as a Unix timestamp.",
+        "# TYPE trmnl_petcare_litter_filter_due_timestamp_seconds gauge",
+        metric(
+          "trmnl_petcare_litter_filter_due_timestamp_seconds",
+          new Date(robot.filterDueAt).getTime() / 1000,
+        ),
+      );
+    }
+  }
+  if (collection.metrics.litterHaMismatch !== null) {
+    lines.push(
+      "# HELP trmnl_petcare_litter_ha_mismatch Whether ordinary HA LR5 entities disagree with fresh Whisker diagnostics.",
+      "# TYPE trmnl_petcare_litter_ha_mismatch gauge",
+      metric(
+        "trmnl_petcare_litter_ha_mismatch",
+        bool(collection.metrics.litterHaMismatch),
+      ),
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function bool(value: boolean): number {
+  return value ? 1 : 0;
+}
+
+function metric(
+  name: string,
+  value: number,
+  labels: Record<string, string> = {},
+): string {
+  const entries = Object.entries(labels);
+  const renderedLabels =
+    entries.length === 0
+      ? ""
+      : `{${entries.map(([key, label]) => `${key}="${escapeLabel(label)}"`).join(",")}}`;
+  return `${name}${renderedLabels} ${value.toString()}`;
+}
+
+function escapeLabel(value: string): string {
+  const slash = String.fromCodePoint(92);
+  return value
+    .replaceAll(slash, slash.repeat(2))
+    .replaceAll("\n", `${slash}n`)
+    .replaceAll('"', `${slash}"`);
+}

--- a/packages/trmnl-dashboard/src/time.ts
+++ b/packages/trmnl-dashboard/src/time.ts
@@ -5,3 +5,50 @@ export function formatDisplayTime(date: Date, timeZone: string): string {
     minute: "2-digit",
   }).format(date);
 }
+
+export function startOfDisplayDay(date: Date, timeZone: string): Date {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  const year = Number(values.get("year"));
+  const month = Number(values.get("month"));
+  const day = Number(values.get("day"));
+  if (![year, month, day].every((value) => Number.isFinite(value))) {
+    throw new Error(`Unable to calculate start of day for ${timeZone}`);
+  }
+  const localMidnightAsUtc = Date.UTC(year, month - 1, day);
+  const offsetAtMidnight = timeZoneOffsetMs(
+    new Date(localMidnightAsUtc),
+    timeZone,
+  );
+  const firstPass = new Date(localMidnightAsUtc - offsetAtMidnight);
+  const correctedOffset = timeZoneOffsetMs(firstPass, timeZone);
+  return new Date(localMidnightAsUtc - correctedOffset);
+}
+
+function timeZoneOffsetMs(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  const represented = Date.UTC(
+    Number(values.get("year")),
+    Number(values.get("month")) - 1,
+    Number(values.get("day")),
+    Number(values.get("hour")),
+    Number(values.get("minute")),
+    Number(values.get("second")),
+  );
+  return represented - date.getTime();
+}

--- a/packages/trmnl-dashboard/src/types.ts
+++ b/packages/trmnl-dashboard/src/types.ts
@@ -1,6 +1,6 @@
 import type { Status } from "./status.ts";
 
-export type TrmnlPayload = HomePayload | HomelabPayload;
+export type TrmnlPayload = HomePayload | HomelabPayload | PetCarePayload;
 
 export type EntitySummary = {
   entity_id: string;
@@ -74,4 +74,81 @@ export type AlertsSection = {
   warning: number;
   info: number;
   recent: { severity: string; alertname: string; summary: string }[];
+};
+
+export type PetProblem = {
+  severity: "warning" | "critical";
+  alert: string;
+  summary: string;
+};
+
+export type PetCarePayload = {
+  screen: "pets";
+  generated_at: string;
+  generated_time: string;
+  status: Status;
+  summary: string;
+  problems: PetProblem[];
+  fountain: {
+    status: Status;
+    water_percent: number | null;
+    water_ounces: number | null;
+    cleaning_days: number | null;
+    filter_days: number | null;
+    dispensing: boolean | null;
+    dispensing_mode: string | null;
+    wifi: boolean | null;
+    drinking_ounces_today: number | null;
+    drinking_visits_today: number | null;
+  };
+  feeders: {
+    id: "living-room" | "guest-room";
+    label: string;
+    status: Status;
+    food_low: boolean | null;
+    dispenser_problem: boolean | null;
+    battery_problem: boolean | null;
+    wifi: boolean | null;
+    desiccant_days: number | null;
+    last_feed_at: string | null;
+    feedings_today: number | null;
+    food_grams_today: number | null;
+  }[];
+  litter_robot: {
+    status: Status;
+    name: string;
+    online: boolean;
+    ready: boolean;
+    litter_percent: number;
+    waste_percent: number;
+    hopper_status: string;
+    hopper_level_raw: number | null;
+    hopper_installed: boolean;
+    hopper_enabled: boolean;
+    last_seen_at: string;
+    filter_due_at: string | null;
+    cycles_today: number | null;
+  } | null;
+  vacuums: {
+    id: "1st-floor" | "2nd-floor" | "3rd-floor";
+    label: string;
+    status: Status;
+    state: string | null;
+    battery_percent: number | null;
+    last_clean_at: string | null;
+    consumable_hours: number | null;
+    clean_water_empty: boolean | null;
+    dirty_water_full: boolean | null;
+    cleaning_fluid_low: boolean | null;
+    water_shortage: boolean | null;
+    dust_bag: null;
+  }[];
+  activity: {
+    drinking_ounces: number | null;
+    drinking_visits: number | null;
+    feedings: number | null;
+    food_grams: number | null;
+    litter_cycles: number | null;
+  };
+  errors: string[];
 };

--- a/packages/trmnl-dashboard/trmnl/pets.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets.liquid
@@ -1,0 +1,90 @@
+<div class="layout layout--col gap--small">
+  {% if problems.size > 0 %}
+    <div class="item item--emphasis">
+      <div class="meta"></div>
+      <div class="content">
+        <span class="label">ACTIVE PROBLEMS</span>
+        <span class="value value--small">
+          {% for problem in problems limit: 2 %}
+            {{ problem.severity | upcase }} · {{ problem.summary }}{% unless forloop.last %}<br>{% endunless %}
+          {% endfor %}
+        </span>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="grid grid--cols-3 gap--small">
+    <div>
+      <span class="label label--underline">Fountain · {{ fountain.status | upcase }}</span>
+      <table class="table table--condensed">
+        <tbody>
+          <tr><td>Water</td><td class="text--right">{% if fountain.water_percent %}{{ fountain.water_percent }}%{% else %}n/a{% endif %}</td></tr>
+          <tr><td>Clean / Filter</td><td class="text--right">{{ fountain.cleaning_days | default: "n/a" }}d / {{ fountain.filter_days | default: "n/a" }}d</td></tr>
+          <tr><td>Flow</td><td class="text--right">{% if fountain.dispensing %}constant{% else %}check{% endif %}</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <span class="label label--underline">Feeders</span>
+      <table class="table table--condensed">
+        <tbody>
+          {% for feeder in feeders %}
+            <tr>
+              <td>{{ feeder.label }}</td>
+              <td class="text--right">{{ feeder.status | upcase }} · {{ feeder.desiccant_days | default: "n/a" }}d</td>
+            </tr>
+          {% endfor %}
+          <tr><td>Food today</td><td class="text--right">{{ activity.food_grams | default: "n/a" }}g</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <span class="label label--underline">LR5 Pro · {{ litter_robot.status | default: "unknown" | upcase }}</span>
+      <table class="table table--condensed">
+        <tbody>
+          {% if litter_robot %}
+            <tr><td>Globe litter</td><td class="text--right">{{ litter_robot.litter_percent }}%</td></tr>
+            <tr><td>Waste</td><td class="text--right">{{ litter_robot.waste_percent }}%</td></tr>
+            <tr><td>Hopper</td><td class="text--right">{{ litter_robot.hopper_status }} · raw {{ litter_robot.hopper_level_raw | default: "n/a" }}</td></tr>
+          {% else %}
+            <tr><td>Diagnostics unavailable</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div>
+    <span class="label label--underline">Roborock Fleet</span>
+    <table class="table table--condensed">
+      <thead>
+        <tr><th>Floor</th><th>Status</th><th class="text--right">Battery</th><th class="text--right">Consumable</th><th class="text--right">Tanks / Fluid</th></tr>
+      </thead>
+      <tbody>
+        {% for vacuum in vacuums %}
+          <tr>
+            <td>{{ vacuum.label }}</td>
+            <td>{{ vacuum.status | upcase }} · {{ vacuum.state | default: "unavailable" }}</td>
+            <td class="text--right">{% if vacuum.battery_percent %}{{ vacuum.battery_percent }}%{% else %}n/a{% endif %}</td>
+            <td class="text--right">{% if vacuum.consumable_hours %}{{ vacuum.consumable_hours | round }}h{% else %}n/a{% endif %}</td>
+            <td class="text--right">{% if vacuum.clean_water_empty or vacuum.dirty_water_full or vacuum.cleaning_fluid_low or vacuum.water_shortage %}CHECK{% else %}OK{% endif %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="grid grid--cols-4 gap--small">
+    <div class="item"><div class="content"><span class="title">Drank</span><span class="value value--small">{{ activity.drinking_ounces | default: "n/a" }} oz</span></div></div>
+    <div class="item"><div class="content"><span class="title">Drinks</span><span class="value value--small">{{ activity.drinking_visits | default: "n/a" }}</span></div></div>
+    <div class="item"><div class="content"><span class="title">Feedings</span><span class="value value--small">{{ activity.feedings | default: "n/a" }}</span></div></div>
+    <div class="item"><div class="content"><span class="title">Litter cycles</span><span class="value value--small">{{ activity.litter_cycles | default: "n/a" }}</span></div></div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Pet Care</span>
+  <span class="instance">{{ status | upcase }} · {{ generated_time }}</span>
+</div>


### PR DESCRIPTION
## Why

The pet-care fleet now includes a PetLibro fountain, two feeders, an LR5 Pro with LitterHopper, and three Roborocks. Existing monitoring retained retired PetKit/LR4 assumptions, Home Assistant omitted LR5 hopper status, and there was no single TRMNL view for supply, maintenance, activity, and active alerts.

## What

- Add strictly validated Home Assistant entity-registry and authenticated config-entry diagnostics reads.
- Discover the Whisker config entry from the LR5 entity instead of hardcoding it, then expose only a safe diagnostics subset.
- Collect PetLibro, LR5/hopper, and Roborock health and export Prometheus metrics through a restricted ServiceMonitor.
- Alert on the requested fountain, feeder, litter/waste, hopper, robot, consumable, tank, fluid, freshness, missing-series, and HA/diagnostics inconsistency conditions.
- Use exact non-overlapping boundaries: litter below 60%, waste warning above 60% through 80%, and waste critical above 80%.
- Add authenticated `GET /api/pets` behind the default-off `pet-dashboard-enabled` feature flag.
- Add the TRMNL Liquid screen with an active-problem banner, fountain/feeders/LR5 cards, explicit globe and hopper rows, three Roborock rows, and daily activity.
- Remove retired PetKit/LR4 monitoring. Dust-bag state remains explicitly unavailable until a real entity appears.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/home-assistant` (21 tests passed)
- `bunx turbo run typecheck test lint --filter=@shepherdjerred/trmnl-dashboard` (37 tests passed)
- `bun test packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/homeassistant.test.ts` (9 tests passed)
- `bunx turbo run typecheck lint --filter=@homelab/cdk8s`
- `bun run docker:build` and `bun run smoke` from `packages/trmnl-dashboard`
- `bunx lefthook run pre-commit`
- Live read-only HA validation confirmed current PetLibro, LR5 diagnostics/hopper, and Roborock entity shapes; raw diagnostics were not persisted or exposed.
- Live HA registry verification confirmed the LR5 device is in Storage and all 47 Whisker robot entities use `storage_*` IDs.

## Visual proof

[Open the 800 × 480 monochrome pet-care demo](https://public.sjer.red/pr/assets/2564/pet-preview/index.html)

The same Liquid template is exercised by healthy, warning, and critical render fixtures. A physical e-ink screenshot remains a post-deployment rollout gate because the in-app browser runtime had no browser available.

## Rollout

The feature flag remains off by default. Merge and deployment must precede enabling it, configuring the live TRMNL Private Plugin, adding it to the playlist, force-refreshing the device, and verifying the physical display.
