### PR TITLE
feat(trmnl-dashboard): add flagged pet-care screen

### DIFF
--- a/.buildkite/scripts/smoke-app-in-image.ts
+++ b/.buildkite/scripts/smoke-app-in-image.ts
@@ -323,6 +323,7 @@ const commands: Record<
       TRMNL_API_KEY: "smoke-test-dummy",
       HA_TOKEN: "smoke-test-dummy",
       HA_URL: "http://127.0.0.1:9999",
+      FEATURE_FLAGS_MODE: "disabled",
       PORT: "18790",
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -1965,6 +1965,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@sentry/bun": "^10.70.0",
+        "@shepherdjerred/config": "workspace:*",
+        "@shepherdjerred/feature-flags": "workspace:*",
         "@shepherdjerred/home-assistant": "workspace:*",
         "zod": "^4.4.3",
       },
@@ -1975,6 +1977,7 @@
         "@vitest/coverage-istanbul": "4.1.10",
         "eslint": "^10.3.0",
         "jiti": "^2.7.0",
+        "liquidjs": "^10.29.0",
         "typescript": "^6.0.3",
         "vitest": "4.1.10",
       },
@@ -6146,6 +6149,8 @@
 
     "linkify-it": ["linkify-it@6.1.0", "", { "dependencies": { "uc.micro": "^3.0.0" } }, "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw=="],
 
+    "liquidjs": ["liquidjs@10.29.0", "", { "dependencies": { "commander": "^10.0.0" }, "bin": { "liquid": "bin/liquid.js", "liquidjs": "bin/liquid.js" } }, "sha512-pCVOhs6FLAR8su3ItJ07diN26t6W5dHQRnmTMy8HPyTFuv1+oSCVJIGp5pGjfQyOZfh50KswvKtMTp6p4JEIdw=="],
+
     "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
     "local-pkg": ["local-pkg@1.2.1", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q=="],
@@ -8703,6 +8708,8 @@
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
+    "liquidjs/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -678,6 +678,17 @@
       "thresholdRollouts": []
     },
     {
+      "key": "pet-dashboard-enabled",
+      "owner": "trmnl-dashboard",
+      "source": "trmnl-dashboard",
+      "purpose": "Expose the authenticated pet-care TRMNL dashboard payload after deployment verification.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
       "key": "streambot-idle-timeout-seconds",
       "owner": "streambot",
       "source": "streambot-dynamic",

--- a/packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts
+++ b/packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts
@@ -25,6 +25,7 @@ const CONSUMER_NAMESPACES = [
   "scout-prod",
   "birmel",
   "temporal",
+  "trmnl-dashboard",
   // streambot is deployed inside the `media` chart, not its own namespace.
   "media",
 ] as const;

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -98,6 +98,11 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
           key: "HA_TOKEN",
         }),
         DISPLAY_TIME_ZONE: EnvValue.fromValue("America/Los_Angeles"),
+        FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+        FLIPT_URL: EnvValue.fromValue(
+          "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
+        ),
+        FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
         BUGSINK_URL: EnvValue.fromValue(
           "http://bugsink-bugsink-service.bugsink:8000/api/canonical/0",
         ),
@@ -199,9 +204,9 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
   return { deployment, service };
 }
 
-export const trmnlDashboardPorts = [53, 80, 443, 8000, 8123, 9090, 9093].map(
-  (port) => ({
-    port: IntOrString.fromNumber(port),
-    protocol: port === 53 ? "UDP" : "TCP",
-  }),
-);
+export const trmnlDashboardPorts = [
+  53, 80, 443, 8000, 8080, 8123, 9090, 9093,
+].map((port) => ({
+  port: IntOrString.fromNumber(port),
+  protocol: port === 53 ? "UDP" : "TCP",
+}));

--- a/packages/trmnl-dashboard/Dockerfile
+++ b/packages/trmnl-dashboard/Dockerfile
@@ -12,8 +12,8 @@ FROM oven/bun:1.4.0@sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f
 WORKDIR /app
 
 # ── prod-deps: production-only node_modules, cached on manifests ────────────
-# The trmnl-dashboard filter includes home-assistant through its workspace
-# dependency closure. `--frozen-lockfile` requires every workspace member's
+# The trmnl-dashboard filter includes config, feature-flags, and home-assistant
+# through its workspace dependency closure. `--frozen-lockfile` requires every workspace member's
 # package.json present, so the globs enumerate every member (top-level, nested
 # packages/*/packages/*, homelab/src/*, the desktop src-tauri crate, and the
 # `scripts` dir).
@@ -39,6 +39,8 @@ COPY --from=prod-deps /app/ /app/
 COPY --parents \
   tsconfig.base.json \
   packages/trmnl-dashboard \
+  packages/config \
+  packages/feature-flags \
   packages/home-assistant \
   ./
 

--- a/packages/trmnl-dashboard/README.md
+++ b/packages/trmnl-dashboard/README.md
@@ -9,6 +9,7 @@ Plugins.
 - `GET /healthz` - configuration health
 - `GET /api/home` - Home Assistant status payload
 - `GET /api/homelab` - homelab status payload
+- `GET /api/pets` - pet-care status and daily activity payload (feature flagged)
 - `GET /metrics` - internal Prometheus metrics, including fresh LR5 diagnostics
 - `GET /api/diagnostics` - per-source fetch diagnostics for both payloads
 
@@ -23,6 +24,11 @@ Pet-care collection reads ordinary PetLibro and Roborock entities plus a
 strictly validated Whisker diagnostics payload for LR5 and hopper data. It
 discovers the Whisker config entry through Home Assistant's entity registry;
 the internal ID and raw diagnostics are never returned or exported as labels.
+
+`/api/pets` is controlled by the managed `pet-dashboard-enabled` flag and is
+absent (404) by default. The internal metrics endpoint remains available to the
+restricted Prometheus ServiceMonitor so alerts can be verified before the TRMNL
+screen is enabled.
 
 ## Configuration
 

--- a/packages/trmnl-dashboard/package.json
+++ b/packages/trmnl-dashboard/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@sentry/bun": "^10.70.0",
+    "@shepherdjerred/config": "workspace:*",
+    "@shepherdjerred/feature-flags": "workspace:*",
     "@shepherdjerred/home-assistant": "workspace:*",
     "zod": "^4.4.3"
   },
@@ -30,6 +32,7 @@
     "@types/bun": "1.4.0",
     "eslint": "^10.3.0",
     "jiti": "^2.7.0",
+    "liquidjs": "^10.29.0",
     "typescript": "^6.0.3",
     "@typescript/native": "npm:typescript@7.0.2",
     "vitest": "4.1.10",

--- a/packages/trmnl-dashboard/scripts/smoke.ts
+++ b/packages/trmnl-dashboard/scripts/smoke.ts
@@ -42,6 +42,8 @@ async function main(): Promise<void> {
     "HA_TOKEN=smoke-test-dummy",
     "-e",
     "HA_URL=http://127.0.0.1:9999",
+    "-e",
+    "FEATURE_FLAGS_MODE=disabled",
     IMAGE,
   ]);
   if (run.code !== 0) {

--- a/packages/trmnl-dashboard/src/__tests__/app.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/app.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createHandler } from "../app.ts";
 import type { AppConfig } from "../config.ts";
-import type { HomePayload, HomelabPayload } from "../types.ts";
+import type { HomePayload, HomelabPayload, PetCarePayload } from "../types.ts";
 
 const config: AppConfig = {
   port: 3000,
@@ -67,6 +67,38 @@ const homelabPayload: HomelabPayload = {
   errors: [],
 };
 
+const petPayload: PetCarePayload = {
+  screen: "pets",
+  generated_at: "2026-08-30T08:30:00.000Z",
+  generated_time: "1:30 AM",
+  status: "ok",
+  summary: "Pet systems healthy",
+  problems: [],
+  fountain: {
+    status: "ok",
+    water_percent: 100,
+    water_ounces: 90,
+    cleaning_days: 12,
+    filter_days: 12,
+    dispensing: true,
+    dispensing_mode: "Flowing Water (Constant)",
+    wifi: true,
+    drinking_ounces_today: 4,
+    drinking_visits_today: 9,
+  },
+  feeders: [],
+  litter_robot: null,
+  vacuums: [],
+  activity: {
+    drinking_ounces: 4,
+    drinking_visits: 9,
+    feedings: 2,
+    food_grams: 20,
+    litter_cycles: 1,
+  },
+  errors: [],
+};
+
 describe("createHandler", () => {
   it("serves liveness without auth", async () => {
     const handler = createHandler(config);
@@ -118,6 +150,51 @@ describe("createHandler", () => {
     );
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(homelabPayload);
+  });
+
+  it("hides the pets route while the feature flag is off", async () => {
+    const handler = createHandler(config, {
+      collectPets: async () => petPayload,
+      petDashboardEnabled: async () => false,
+    });
+    const response = await handler(
+      new Request("http://localhost/api/pets", {
+        headers: { "x-api-key": "secret" },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("serves the authenticated pets payload while the feature flag is on", async () => {
+    const handler = createHandler(config, {
+      collectPets: async () => petPayload,
+      petDashboardEnabled: async () => true,
+    });
+    const response = await handler(
+      new Request("http://localhost/api/pets", {
+        headers: { "x-api-key": "secret" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(petPayload);
+  });
+
+  it("authenticates the pets route before evaluating its feature flag", async () => {
+    let evaluated = false;
+    const handler = createHandler(config, {
+      collectPets: async () => petPayload,
+      petDashboardEnabled: async () => {
+        evaluated = true;
+        return true;
+      },
+    });
+
+    const response = await handler(new Request("http://localhost/api/pets"));
+
+    expect(response.status).toBe(401);
+    expect(evaluated).toBe(false);
   });
 
   it("serves authenticated diagnostics", async () => {

--- a/packages/trmnl-dashboard/src/__tests__/dynamic-config.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/dynamic-config.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { StaticProvider } from "@shepherdjerred/feature-flags/providers/static.ts";
+import {
+  initializeDynamicConfig,
+  petDashboardEnabled,
+  shutdownDynamicConfig,
+} from "../dynamic-config.ts";
+
+const DISABLED_ENVIRONMENT = { FEATURE_FLAGS_MODE: "disabled" } as const;
+
+afterEach(async () => {
+  await shutdownDynamicConfig();
+});
+
+describe("pet dashboard feature flag", () => {
+  it("defaults off when the flag backend has no opinion", async () => {
+    await initializeDynamicConfig({ environment: DISABLED_ENVIRONMENT });
+
+    await expect(petDashboardEnabled()).resolves.toBe(false);
+  });
+
+  it("enables the route from the managed flag", async () => {
+    await initializeDynamicConfig({
+      environment: DISABLED_ENVIRONMENT,
+      provider: new StaticProvider({ "pet-dashboard-enabled": true }),
+    });
+
+    await expect(petDashboardEnabled()).resolves.toBe(true);
+  });
+});

--- a/packages/trmnl-dashboard/src/__tests__/pets-template.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pets-template.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { Liquid } from "liquidjs";
+import type { PetCarePayload, PetProblem } from "../types.ts";
+
+const templatePath = new URL("../../trmnl/pets.liquid", import.meta.url)
+  .pathname;
+const liquid = new Liquid({ strictVariables: true, strictFilters: true });
+
+describe("pets.liquid", () => {
+  it.each([
+    ["healthy", fixture("ok")],
+    ["warning", fixture("warning")],
+    ["critical", fixture("error")],
+  ])("renders the %s fixture", async (_name, payload) => {
+    const template = await Bun.file(templatePath).text();
+    const html = await liquid.parseAndRender(template, payload);
+
+    expect(html).toContain("Pet Care");
+    expect(html).toContain("Globe litter");
+    expect(html).toContain("Hopper");
+    expect(html).toContain("Roborock Fleet");
+    expect(html).toContain("Litter cycles");
+    if (payload.status === "ok") {
+      expect(html).not.toContain("ACTIVE PROBLEMS");
+    } else {
+      expect(html).toContain("ACTIVE PROBLEMS");
+    }
+  });
+});
+
+function fixture(status: "ok" | "warning" | "error"): PetCarePayload {
+  const problem: PetProblem[] =
+    status === "ok"
+      ? []
+      : [
+          {
+            severity: status === "error" ? "critical" : "warning",
+            alert:
+              status === "error"
+                ? "LitterRobotWasteCritical"
+                : "RoborockConsumableDue",
+            summary:
+              status === "error"
+                ? "Storage LR5 waste drawer critical"
+                : "2nd Floor dock strainer due",
+          },
+        ];
+  return {
+    screen: "pets",
+    generated_at: "2026-08-30T08:30:00.000Z",
+    generated_time: "1:30 AM",
+    status,
+    summary:
+      problem.length === 0
+        ? "Pet systems healthy"
+        : "1 active pet-care problem",
+    problems: problem,
+    fountain: {
+      status: "ok",
+      water_percent: 82,
+      water_ounces: 71,
+      cleaning_days: 12,
+      filter_days: 12,
+      dispensing: true,
+      dispensing_mode: "Flowing Water (Constant)",
+      wifi: true,
+      drinking_ounces_today: 4.1,
+      drinking_visits_today: 9,
+    },
+    feeders: [
+      feeder("living-room", "Living Room"),
+      feeder("guest-room", "Guest Room"),
+    ],
+    litter_robot: {
+      status: status === "error" ? "error" : "ok",
+      name: "Storage",
+      online: true,
+      ready: true,
+      litter_percent: 90.7,
+      waste_percent: status === "error" ? 84 : 33,
+      hopper_status: "Ready",
+      hopper_level_raw: 1,
+      hopper_installed: true,
+      hopper_enabled: true,
+      last_seen_at: "2026-08-30T08:21:53Z",
+      filter_due_at: "2026-09-26T03:00:32Z",
+      cycles_today: 2,
+    },
+    vacuums: [
+      vacuum("1st-floor", "1st Floor", status === "warning" ? "warning" : "ok"),
+      vacuum("2nd-floor", "2nd Floor", "ok"),
+      vacuum("3rd-floor", "3rd Floor", "ok"),
+    ],
+    activity: {
+      drinking_ounces: 4.1,
+      drinking_visits: 9,
+      feedings: 4,
+      food_grams: 40,
+      litter_cycles: 2,
+    },
+    errors: [],
+  };
+}
+
+function feeder(
+  id: "living-room" | "guest-room",
+  label: string,
+): PetCarePayload["feeders"][number] {
+  return {
+    id,
+    label,
+    status: "ok",
+    food_low: false,
+    dispenser_problem: false,
+    battery_problem: false,
+    wifi: true,
+    desiccant_days: 9,
+    last_feed_at: "2026-08-30T14:00:10Z",
+    feedings_today: 2,
+    food_grams_today: 20,
+  };
+}
+
+function vacuum(
+  id: "1st-floor" | "2nd-floor" | "3rd-floor",
+  label: string,
+  status: "ok" | "warning",
+): PetCarePayload["vacuums"][number] {
+  return {
+    id,
+    label,
+    status,
+    state: "docked",
+    battery_percent: 100,
+    last_clean_at: "2026-08-29T22:29:17Z",
+    consumable_hours: 40,
+    clean_water_empty: false,
+    dirty_water_full: false,
+    cleaning_fluid_low: false,
+    water_shortage: false,
+    dust_bag: null,
+  };
+}

--- a/packages/trmnl-dashboard/src/app.ts
+++ b/packages/trmnl-dashboard/src/app.ts
@@ -2,13 +2,16 @@ import type { AppConfig } from "./config.ts";
 import { collectHomePayload } from "./collectors/home.ts";
 import { collectHomelabPayload } from "./collectors/homelab.ts";
 import { PetCareService } from "./pet-care-service.ts";
+import { petDashboardEnabled } from "./dynamic-config.ts";
 import { worstStatus } from "./status.ts";
-import type { HomePayload, HomelabPayload } from "./types.ts";
+import type { HomePayload, HomelabPayload, PetCarePayload } from "./types.ts";
 
 export type AppDeps = {
   collectHome?: () => Promise<HomePayload>;
   collectHomelab?: () => Promise<HomelabPayload>;
   getPetMetrics?: () => Promise<string>;
+  collectPets?: () => Promise<PetCarePayload>;
+  petDashboardEnabled?: () => Promise<boolean>;
 };
 
 export function createHandler(config: AppConfig, deps: AppDeps = {}) {
@@ -18,6 +21,8 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
   const petCareService = new PetCareService(config);
   const getPetMetrics =
     deps.getPetMetrics ?? (() => petCareService.getMetrics());
+  const collectPets = deps.collectPets ?? (() => petCareService.getPayload());
+  const isPetDashboardEnabled = deps.petDashboardEnabled ?? petDashboardEnabled;
 
   return async function handleRequest(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -50,6 +55,13 @@ export function createHandler(config: AppConfig, deps: AppDeps = {}) {
 
     if (url.pathname === "/api/homelab") {
       return json(await collectHomelab());
+    }
+
+    if (url.pathname === "/api/pets") {
+      if (!(await isPetDashboardEnabled())) {
+        return json({ error: "not found" }, 404);
+      }
+      return json(await collectPets());
     }
 
     if (url.pathname === "/api/diagnostics") {

--- a/packages/trmnl-dashboard/src/collectors/pets.ts
+++ b/packages/trmnl-dashboard/src/collectors/pets.ts
@@ -11,7 +11,7 @@ import type { PetCarePayload, PetProblem } from "../types.ts";
 
 const FOUNTAIN = "dockstream_2_smart_fountain";
 const FEEDER = "granary_smart_camera_feeder";
-const PET_ALERT_PATTERN = /^(?:PetLibro|LitterRobot|Roborock)/;
+const PET_ALERT_PATTERN = /^(?:PetCare|PetLibro|LitterRobot|Roborock)/;
 
 const VACUUMS = [
   { id: "1st-floor", label: "1st Floor", prefix: "1st_floor" },
@@ -168,8 +168,11 @@ function buildFountain(
     ),
   };
   return {
-    status: componentStatus(alerts, (alert) =>
-      alert.alertname.startsWith("PetLibroFountain"),
+    status: componentStatus(
+      alerts,
+      (alert) =>
+        alert.alertname.startsWith("PetLibroFountain") ||
+        isAvailabilityAlertFor(alert, "dockstream_2_smart_fountain"),
     ),
     ...fields,
   };
@@ -181,11 +184,22 @@ function buildFeeder(
   feeder: (typeof FEEDERS)[number],
 ): PetCarePayload["feeders"][number] {
   const alertToken = feeder.id === "living-room" ? "LivingRoom" : "GuestRoom";
+  const feederEntities = [
+    `binary_sensor.${FEEDER}_battery_status${feeder.suffix}`,
+    `binary_sensor.${FEEDER}_food_dispenser${feeder.suffix}`,
+    `binary_sensor.${FEEDER}_food_status${feeder.suffix}`,
+    `binary_sensor.${FEEDER}_wi_fi${feeder.suffix}`,
+    `sensor.${FEEDER}_desiccant_remaining_days${feeder.suffix}`,
+    `sensor.${FEEDER}_last_feed_time${feeder.suffix}`,
+  ];
   return {
     id: feeder.id,
     label: feeder.label,
-    status: componentStatus(alerts, (alert) =>
-      alert.alertname.includes(`Feeder${alertToken}`),
+    status: componentStatus(
+      alerts,
+      (alert) =>
+        alert.alertname.includes(`Feeder${alertToken}`) ||
+        feederEntities.some((entity) => isAvailabilityAlertFor(alert, entity)),
     ),
     food_low: booleanState(
       states,
@@ -262,8 +276,9 @@ function buildVacuum(
     status: componentStatus(
       alerts,
       (alert) =>
-        alert.alertname.startsWith("Roborock") &&
-        alert.summary.toLowerCase().includes(vacuum.label.toLowerCase()),
+        (alert.alertname.startsWith("Roborock") &&
+          alert.summary.toLowerCase().includes(vacuum.label.toLowerCase())) ||
+        isAvailabilityAlertFor(alert, vacuum.prefix),
     ),
     state: stringState(states, `vacuum.${vacuum.prefix}`),
     battery_percent: numberState(states, `sensor.${vacuum.prefix}_battery`),
@@ -363,6 +378,16 @@ function componentStatus(
     return "error";
   }
   return matching.length > 0 ? "warning" : "ok";
+}
+
+function isAvailabilityAlertFor(
+  alert: AlertSummaryItem,
+  entityToken: string,
+): boolean {
+  return (
+    alert.alertname === "PetCareEntityUnavailable" &&
+    alert.summary.includes(entityToken)
+  );
 }
 
 function stateValue(

--- a/packages/trmnl-dashboard/src/dynamic-config.ts
+++ b/packages/trmnl-dashboard/src/dynamic-config.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { defineConfig } from "@shepherdjerred/config";
+import { createFlagConfigSource } from "@shepherdjerred/feature-flags/config-source.ts";
+import {
+  initFeatureFlags,
+  shutdownFeatureFlags,
+  type InitFeatureFlagsOptions,
+} from "@shepherdjerred/feature-flags";
+
+const DEFINITION = {
+  petDashboardEnabled: {
+    schema: z.boolean(),
+    sources: ["flag", "default"],
+    default: false,
+    names: { flag: "pet-dashboard-enabled" },
+  },
+} as const;
+
+let resolver: ReturnType<typeof createResolver> | undefined;
+
+function createResolver() {
+  return defineConfig({
+    definition: DEFINITION,
+    sources: {
+      flag: createFlagConfigSource({
+        targetingKey: "trmnl-dashboard",
+        kinds: { petDashboardEnabled: "boolean" },
+      }),
+    },
+    hooks: {
+      onSourceError: (key, source, message) => {
+        console.warn(`[Config] ${key} ${source}: ${message}`);
+      },
+    },
+  });
+}
+
+export async function initializeDynamicConfig(
+  options: {
+    environment?: InitFeatureFlagsOptions["environment"];
+    provider?: InitFeatureFlagsOptions["provider"];
+  } = {},
+): Promise<void> {
+  await initFeatureFlags({
+    ...(options.environment === undefined
+      ? {}
+      : { environment: options.environment }),
+    ...(options.provider === undefined ? {} : { provider: options.provider }),
+    onInitializationFailure: (message) => {
+      console.warn(`[Config] ${message}`);
+    },
+  });
+  resolver = createResolver();
+}
+
+export async function petDashboardEnabled(): Promise<boolean> {
+  if (resolver === undefined) {
+    throw new Error(
+      "dynamic config read before initializeDynamicConfig(); call it during startup",
+    );
+  }
+  return resolver.value("petDashboardEnabled", {
+    targetingKey: "trmnl-dashboard",
+  });
+}
+
+export async function shutdownDynamicConfig(): Promise<void> {
+  resolver = undefined;
+  await shutdownFeatureFlags();
+}

--- a/packages/trmnl-dashboard/src/index.ts
+++ b/packages/trmnl-dashboard/src/index.ts
@@ -1,9 +1,12 @@
 import { createHandler } from "./app.ts";
 import { loadConfig } from "./config.ts";
 import { initializeSentry } from "./sentry.ts";
+import { initializeDynamicConfig } from "./dynamic-config.ts";
 
 // Initialize before anything else so early failures are captured.
 initializeSentry();
+
+await initializeDynamicConfig({ environment: Bun.env });
 
 const config = loadConfig(Bun.env);
 const handler = createHandler(config);

--- a/packages/trmnl-dashboard/trmnl/pets.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets.liquid
@@ -1,0 +1,90 @@
+<div class="layout layout--col gap--small">
+  {% if problems.size > 0 %}
+    <div class="item item--emphasis">
+      <div class="meta"></div>
+      <div class="content">
+        <span class="label">ACTIVE PROBLEMS</span>
+        <span class="value value--small">
+          {% for problem in problems limit: 2 %}
+            {{ problem.severity | upcase }} · {{ problem.summary }}{% unless forloop.last %}<br>{% endunless %}
+          {% endfor %}
+        </span>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="grid grid--cols-3 gap--small">
+    <div>
+      <span class="label label--underline">Fountain · {{ fountain.status | upcase }}</span>
+      <table class="table table--condensed">
+        <tbody>
+          <tr><td>Water</td><td class="text--right">{% if fountain.water_percent %}{{ fountain.water_percent }}%{% else %}n/a{% endif %}</td></tr>
+          <tr><td>Clean / Filter</td><td class="text--right">{{ fountain.cleaning_days | default: "n/a" }}d / {{ fountain.filter_days | default: "n/a" }}d</td></tr>
+          <tr><td>Flow</td><td class="text--right">{% if fountain.dispensing %}constant{% else %}check{% endif %}</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <span class="label label--underline">Feeders</span>
+      <table class="table table--condensed">
+        <tbody>
+          {% for feeder in feeders %}
+            <tr>
+              <td>{{ feeder.label }}</td>
+              <td class="text--right">{{ feeder.status | upcase }} · {{ feeder.desiccant_days | default: "n/a" }}d</td>
+            </tr>
+          {% endfor %}
+          <tr><td>Food today</td><td class="text--right">{{ activity.food_grams | default: "n/a" }}g</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <span class="label label--underline">LR5 Pro · {{ litter_robot.status | default: "unknown" | upcase }}</span>
+      <table class="table table--condensed">
+        <tbody>
+          {% if litter_robot %}
+            <tr><td>Globe litter</td><td class="text--right">{{ litter_robot.litter_percent }}%</td></tr>
+            <tr><td>Waste</td><td class="text--right">{{ litter_robot.waste_percent }}%</td></tr>
+            <tr><td>Hopper</td><td class="text--right">{{ litter_robot.hopper_status }} · raw {{ litter_robot.hopper_level_raw | default: "n/a" }}</td></tr>
+          {% else %}
+            <tr><td>Diagnostics unavailable</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div>
+    <span class="label label--underline">Roborock Fleet</span>
+    <table class="table table--condensed">
+      <thead>
+        <tr><th>Floor</th><th>Status</th><th class="text--right">Battery</th><th class="text--right">Consumable</th><th class="text--right">Tanks / Fluid</th></tr>
+      </thead>
+      <tbody>
+        {% for vacuum in vacuums %}
+          <tr>
+            <td>{{ vacuum.label }}</td>
+            <td>{{ vacuum.status | upcase }} · {{ vacuum.state | default: "unavailable" }}</td>
+            <td class="text--right">{% if vacuum.battery_percent %}{{ vacuum.battery_percent }}%{% else %}n/a{% endif %}</td>
+            <td class="text--right">{% if vacuum.consumable_hours %}{{ vacuum.consumable_hours | round }}h{% else %}n/a{% endif %}</td>
+            <td class="text--right">{% if vacuum.clean_water_empty or vacuum.dirty_water_full or vacuum.cleaning_fluid_low or vacuum.water_shortage %}CHECK{% else %}OK{% endif %}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="grid grid--cols-4 gap--small">
+    <div class="item"><div class="content"><span class="title">Drank</span><span class="value value--small">{{ activity.drinking_ounces | default: "n/a" }} oz</span></div></div>
+    <div class="item"><div class="content"><span class="title">Drinks</span><span class="value value--small">{{ activity.drinking_visits | default: "n/a" }}</span></div></div>
+    <div class="item"><div class="content"><span class="title">Feedings</span><span class="value value--small">{{ activity.feedings | default: "n/a" }}</span></div></div>
+    <div class="item"><div class="content"><span class="title">Litter cycles</span><span class="value value--small">{{ activity.litter_cycles | default: "n/a" }}</span></div></div>
+  </div>
+</div>
+
+<div class="title_bar">
+  <span class="title">Pet Care</span>
+  <span class="instance">{{ status | upcase }} · {{ generated_time }}</span>
+</div>


### PR DESCRIPTION
## Why

TRMNL needs a compact, e-ink-oriented view of pet supplies, maintenance, activity, and active alerts without duplicating Alertmanager threshold decisions in the UI.

## What

- Add the authenticated `GET /api/pets` typed payload and keep it unavailable unless `pet-dashboard-enabled` resolves true.
- Register the default-off feature flag and grant the production TRMNL deployment narrowly scoped Flipt access.
- Add `trmnl/pets.liquid` with an active-problem banner, fountain and feeder cards, explicit LR5 globe/hopper rows, three compact Roborock rows, and daily activity.
- Include runtime dependency closure, flag-safe image smoke tests, and healthy/warning/critical Liquid rendering fixtures.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/trmnl-dashboard` (37 tests passed)
- `bun run docker:build` and `bun run smoke` from `packages/trmnl-dashboard`
- Focused feature-flag and homelab typecheck/lint/build checks
- `bunx lefthook run pre-commit`

## Rollout

The flag remains off by default. Merge and deployment must precede enabling it, creating the live TRMNL plugin, adding it to the playlist, and force-refreshing the device.
