### PR TITLE
fix(homelab): preserve Scout security headers on static responses

### DIFF
--- a/packages/homelab/images/caddy-s3proxy/Dockerfile
+++ b/packages/homelab/images/caddy-s3proxy/Dockerfile
@@ -8,16 +8,23 @@
 # module — keeps the import path so existing Caddyfiles work, but adds native
 # HEAD support, fixes the 304-on-index regression, and returns 206 +
 # Accept-Ranges on byte-range requests (Safari refuses to play video from
-# origins that answer 200 to Range requests).
+# origins that answer 200 to Range requests). The pinned source is patched
+# locally to flush Caddy's deferred response headers before streaming S3 data.
 
 # renovate: datasource=docker depName=caddy
 FROM caddy:2.11.4-builder-alpine@sha256:7bac9be4072f7c4db2ccc7350750e0705004bf02da2ac7d96b1469ca4f28bb7c AS builder
 
 # xcaddy --with module for the S3 proxy plugin. The fork keeps the upstream
 # import path and adds HEAD support, the 304-on-index fix, and 206/Accept-Ranges
-# on byte-range responses. Not managed by renovate — bump the tag when the fork
-# changes.
-RUN xcaddy build --with github.com/lindenlab/caddy-s3-proxy=github.com/shepherdjerred/caddy-s3-proxy@v0.5.7-head2
+# on byte-range responses. The source commit is pinned because the compatibility
+# patch below must be applied to the exact tree it was reviewed against.
+COPY caddy-s3proxy-header-flush.patch /tmp/caddy-s3proxy-header-flush.patch
+RUN git init /tmp/caddy-s3-proxy \
+  && git -C /tmp/caddy-s3-proxy remote add origin https://github.com/shepherdjerred/caddy-s3-proxy.git \
+  && git -C /tmp/caddy-s3-proxy fetch --depth 1 origin 2333a6ed263df951a2a017ef248af8c97fbf8b42 \
+  && git -C /tmp/caddy-s3-proxy checkout --detach FETCH_HEAD \
+  && git -C /tmp/caddy-s3-proxy apply --unidiff-zero /tmp/caddy-s3proxy-header-flush.patch \
+  && xcaddy build --with github.com/lindenlab/caddy-s3-proxy=/tmp/caddy-s3-proxy
 
 # renovate: datasource=docker depName=caddy
 FROM caddy:2.11.4-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648 AS runtime

--- a/packages/homelab/images/caddy-s3proxy/caddy-s3proxy-header-flush.patch
+++ b/packages/homelab/images/caddy-s3proxy/caddy-s3proxy-header-flush.patch
@@ -1,0 +1,19 @@
+diff --git a/s3proxy.go b/s3proxy.go
+index 7407b42..81a638c 100644
+--- a/s3proxy.go
++++ b/s3proxy.go
+@@ -340,5 +340,9 @@
+-	if obj.ContentRange != nil && *obj.ContentRange != "" {
+-		w.WriteHeader(http.StatusPartialContent)
+-	}
+-
+-	var err error
++	if obj.ContentRange != nil && *obj.ContentRange != "" {
++		w.WriteHeader(http.StatusPartialContent)
++	} else {
++		// io.Copy may use ResponseWriter.ReadFrom, which bypasses Caddy's
++		// deferred response-header flush unless the status is written first.
++		w.WriteHeader(http.StatusOK)
++	}
++
++	var err error

--- a/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.test.ts
@@ -7,7 +7,7 @@ describe("Scout static sites", () => {
     "scout-for-lol.com",
     "beta.scout-for-lol.com",
   ] as const) {
-    test(`${hostname} permits only the PostHog US endpoints`, () => {
+    test(`${hostname} permits Scout's required browser endpoints`, () => {
       const site = staticSites.find(
         (candidate) => candidate.hostname === hostname,
       );
@@ -16,9 +16,15 @@ describe("Scout static sites", () => {
       }
       const csp = site.responseHeaders?.["Content-Security-Policy"];
       expect(csp).toContain(
-        "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://us-assets.i.posthog.com",
+        "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://us-assets.i.posthog.com https://s.pinimg.com https://www.redditstatic.com",
       );
-      expect(csp).toContain("connect-src 'self' https://us.i.posthog.com");
+      expect(csp).toContain(
+        "img-src 'self' https://cdn.discordapp.com https://ddragon.leagueoflegends.com https://ct.pinterest.com data: blob:",
+      );
+      expect(csp).toContain(
+        "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com",
+      );
+      expect(csp).toContain("frame-src https://ct.pinterest.com");
     });
   }
 });

--- a/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.test.ts
@@ -22,7 +22,7 @@ describe("Scout static sites", () => {
         "img-src 'self' https://cdn.discordapp.com https://ddragon.leagueoflegends.com https://ct.pinterest.com data: blob:",
       );
       expect(csp).toContain(
-        "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com",
+        "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com https://events.reddit.com",
       );
       expect(csp).toContain("frame-src https://ct.pinterest.com");
     });

--- a/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
+++ b/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
@@ -7,28 +7,33 @@ import type { StaticSiteConfig } from "@shepherdjerred/homelab/cdk8s/src/misc/s3
  *   WASM search worker, so the shared release policy also allows
  *   `'unsafe-inline'` and `'wasm-unsafe-eval'`.
  * - `script-src` allows PostHog Cloud's US asset host for the marketing-site
- *   bootstrap and the SPA's session-replay worker.
+ *   bootstrap and the SPA's session-replay worker, plus the production
+ *   Pinterest and Reddit marketing pixels.
  * - `connect-src` allows PostHog Cloud's US ingestion host for pageviews,
- *   autocapture, typed events, and session replay.
- * - `img-src` allows `https://cdn.discordapp.com` for guild icons, `data:` for
- *   inlined icons + SVG report-query previews, and `blob:` for chart PNGs fetched
- *   with credentials and rendered via `URL.createObjectURL`
+ *   autocapture, typed events, and session replay, plus Bugsink Sentry
+ *   envelopes and the production Pinterest/Reddit pixels.
+ * - `img-src` allows Data Dragon champion/item art, the Pinterest conversion
+ *   beacon, `https://cdn.discordapp.com` for guild icons, `data:` for inlined
+ *   icons + SVG report-query previews, and `blob:` for chart PNGs fetched with
+ *   credentials and rendered via `URL.createObjectURL`
  *   (see `app/src/components/chart-image.tsx`).
  * - `worker-src 'self' blob:` lets the Monaco editor (report query studio) spawn
  *   its bundled, same-origin web worker (`/app/assets/editor.worker-*.js`); the
  *   `blob:` fallback covers Monaco's blob-wrapped worker path.
- * - `form-action 'self' https://discord.com` covers the
+ * - `frame-src` allows the Pinterest conversion tag's hidden frame, and
+ *   `form-action 'self' https://discord.com` covers the
  *   `/api/auth/discord/start` → `discord.com/oauth2/authorize` redirect chain.
  * - `frame-ancestors 'none'` blocks clickjacking; this matches the
  *   `X-Frame-Options: DENY` default.
  */
 const scoutCsp = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://us-assets.i.posthog.com",
+  "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://us-assets.i.posthog.com https://s.pinimg.com https://www.redditstatic.com",
   "worker-src 'self' blob:",
   "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' https://cdn.discordapp.com data: blob:",
-  "connect-src 'self' https://us.i.posthog.com",
+  "img-src 'self' https://cdn.discordapp.com https://ddragon.leagueoflegends.com https://ct.pinterest.com data: blob:",
+  "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com",
+  "frame-src https://ct.pinterest.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self' https://discord.com",

--- a/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
+++ b/packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts
@@ -11,7 +11,8 @@ import type { StaticSiteConfig } from "@shepherdjerred/homelab/cdk8s/src/misc/s3
  *   Pinterest and Reddit marketing pixels.
  * - `connect-src` allows PostHog Cloud's US ingestion host for pageviews,
  *   autocapture, typed events, and session replay, plus Bugsink Sentry
- *   envelopes and the production Pinterest/Reddit pixels.
+ *   envelopes and the production Pinterest/Reddit pixels, including Reddit's
+ *   event-ingestion host.
  * - `img-src` allows Data Dragon champion/item art, the Pinterest conversion
  *   beacon, `https://cdn.discordapp.com` for guild icons, `data:` for inlined
  *   icons + SVG report-query previews, and `blob:` for chart PNGs fetched with
@@ -32,7 +33,7 @@ const scoutCsp = [
   "worker-src 'self' blob:",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' https://cdn.discordapp.com https://ddragon.leagueoflegends.com https://ct.pinterest.com data: blob:",
-  "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com",
+  "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com https://events.reddit.com",
   "frame-src https://ct.pinterest.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/scripts/check-scout-site-runtime.ts
+++ b/scripts/check-scout-site-runtime.ts
@@ -11,7 +11,7 @@ const origin = new URL(Bun.argv[2] ?? "https://beta.scout-for-lol.com");
 origin.pathname = origin.pathname.replace(/\/$/, "");
 
 const EXPECTED_CSP_PARTS = [
-  "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com",
+  "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com https://events.reddit.com",
   "img-src 'self' https://cdn.discordapp.com https://ddragon.leagueoflegends.com https://ct.pinterest.com data: blob:",
 ];
 

--- a/scripts/check-scout-site-runtime.ts
+++ b/scripts/check-scout-site-runtime.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+
+/**
+ * Verify the public Scout static-site and reverse-proxy contract.
+ *
+ * This is intentionally a live HTTP check rather than a Caddyfile snapshot:
+ * the regression only appears when the custom S3 proxy streams an object.
+ */
+
+const origin = new URL(Bun.argv[2] ?? "https://beta.scout-for-lol.com");
+origin.pathname = origin.pathname.replace(/\/$/, "");
+
+const EXPECTED_CSP_PARTS = [
+  "connect-src 'self' https://us.i.posthog.com https://bugsink.sjer.red https://ct.pinterest.com https://pixel-config.reddit.com",
+  "img-src 'self' https://cdn.discordapp.com https://ddragon.leagueoflegends.com https://ct.pinterest.com data: blob:",
+];
+
+const EXPECTED_HEADERS: Readonly<Record<string, string>> = {
+  "content-security-policy": "required",
+  "permissions-policy":
+    "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  "referrer-policy": "strict-origin-when-cross-origin",
+  // Cloudflare may overlay its own HSTS policy on the public origin; the
+  // in-cluster Caddy response is checked for the exact configured value.
+  "strict-transport-security": "required",
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+};
+
+function urlFor(path: string): URL {
+  return new URL(path, origin);
+}
+
+async function get(path: string, init?: RequestInit): Promise<Response> {
+  const response = await fetch(urlFor(path), init);
+  if (!response.ok) {
+    throw new Error(
+      `${path} returned ${response.status.toString()} ${response.statusText}`,
+    );
+  }
+  return response;
+}
+
+function assertHeaders(path: string, response: Response): void {
+  for (const [name, expected] of Object.entries(EXPECTED_HEADERS)) {
+    const value = response.headers.get(name);
+    if (value === null) {
+      throw new Error(`${path} is missing ${name}`);
+    }
+    if (expected !== "required" && !value.startsWith(expected)) {
+      throw new Error(`${path} has unexpected ${name}: ${value}`);
+    }
+  }
+
+  const csp = response.headers.get("content-security-policy");
+  if (csp === null) {
+    throw new Error(`${path} is missing Content-Security-Policy`);
+  }
+  for (const part of EXPECTED_CSP_PARTS) {
+    if (!csp.includes(part)) {
+      throw new Error(`${path} CSP is missing: ${part}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const root = await get("/");
+  assertHeaders("/", root);
+  const rootHtml = await root.text();
+  if (origin.hostname === "beta.scout-for-lol.com") {
+    for (const placeholder of [
+      "beta-placeholder-pinterest-tag-id",
+      "beta-placeholder-reddit-pixel-id",
+    ]) {
+      if (rootHtml.includes(placeholder)) {
+        throw new Error(`beta page still contains ${placeholder}`);
+      }
+    }
+  }
+
+  for (const path of ["/app/", "/docs/"]) {
+    const response = await get(path);
+    assertHeaders(path, response);
+  }
+
+  const spaFallback = await get("/app/csp-regression-check");
+  assertHeaders("/app/csp-regression-check", spaFallback);
+
+  const appResponse = await get("/app/");
+  const appHtml = await appResponse.text();
+  const assetPath = /src="(\/app\/assets\/[^"]+\.js)"/.exec(appHtml)?.[1];
+  if (assetPath === undefined) {
+    throw new Error("/app/ did not identify a same-origin JavaScript asset");
+  }
+
+  const asset = await get(assetPath);
+  assertHeaders(assetPath, asset);
+  const range = await get(assetPath, {
+    headers: { Range: "bytes=0-31" },
+  });
+  assertHeaders(`${assetPath} (range)`, range);
+  if (range.status !== 206) {
+    throw new Error(
+      `${assetPath} range request returned ${range.status.toString()}`,
+    );
+  }
+  const contentRange = range.headers.get("content-range");
+  if (contentRange?.startsWith("bytes 0-31/") !== true) {
+    throw new Error(`${assetPath} range response is missing Content-Range`);
+  }
+
+  const healthz = await get("/api/healthz");
+  assertHeaders("/api/healthz", healthz);
+
+  const sourceMap = await get(`${assetPath}.map`);
+  if (sourceMap.status !== 200) {
+    throw new Error(`${assetPath}.map did not return 200`);
+  }
+
+  console.log(`Scout site runtime contract passed for ${origin.origin}`);
+}
+
+await main();

--- a/scripts/scout-site-release.test.ts
+++ b/scripts/scout-site-release.test.ts
@@ -247,6 +247,14 @@ test("Scout release analytics map both hosts to the shared PostHog project", () 
   });
 });
 
+test("beta release does not manufacture ad-pixel identifiers", async () => {
+  const source = await Bun.file(
+    new URL("scout-site-release.ts", import.meta.url),
+  ).text();
+  expect(source).not.toContain("beta-placeholder-pinterest-tag-id");
+  expect(source).not.toContain("beta-placeholder-reddit-pixel-id");
+});
+
 test("release state output creates its parent directory", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "scout-release-state-"));
   try {

--- a/scripts/scout-site-release.test.ts
+++ b/scripts/scout-site-release.test.ts
@@ -253,6 +253,9 @@ test("beta release does not manufacture ad-pixel identifiers", async () => {
   ).text();
   expect(source).not.toContain("beta-placeholder-pinterest-tag-id");
   expect(source).not.toContain("beta-placeholder-reddit-pixel-id");
+  expect(source).toContain(
+    'unsetEnv: flavor === "beta" ? [...MARKETING_ENV_NAMES] : [],',
+  );
 });
 
 test("release state output creates its parent directory", async () => {

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -37,10 +37,6 @@ const DIST_DIR = "packages/scout-for-lol/packages/frontend/dist";
 const IMAGE_REPO = "ghcr.io/shepherdjerred/scout-for-lol";
 const PLACEHOLDER_DIGEST =
   "sha256:0000000000000000000000000000000000000000000000000000000000000000";
-const BETA_PIXEL_PLACEHOLDERS: Readonly<Record<string, string>> = {
-  PUBLIC_PINTEREST_TAG_ID: "beta-placeholder-pinterest-tag-id",
-  PUBLIC_REDDIT_PIXEL_ID: "beta-placeholder-reddit-pixel-id",
-};
 const ANALYTICS_REGISTRY_PATH = "config/analytics-sites.json";
 const RELEASE_INPUT_PATHS = [
   "bun.lock",
@@ -206,8 +202,6 @@ async function buildSite(
     const marketing = await marketingIdentifiers();
     env["PUBLIC_PINTEREST_TAG_ID"] = marketing.pinterestTagId;
     env["PUBLIC_REDDIT_PIXEL_ID"] = marketing.redditPixelId;
-  } else {
-    Object.assign(env, BETA_PIXEL_PLACEHOLDERS);
   }
   if (dryRun) {
     console.log(`DRYRUN: would build ${flavor} site as ${identity}`);

--- a/scripts/scout-site-release.ts
+++ b/scripts/scout-site-release.ts
@@ -37,6 +37,10 @@ const DIST_DIR = "packages/scout-for-lol/packages/frontend/dist";
 const IMAGE_REPO = "ghcr.io/shepherdjerred/scout-for-lol";
 const PLACEHOLDER_DIGEST =
   "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+const MARKETING_ENV_NAMES = [
+  "PUBLIC_PINTEREST_TAG_ID",
+  "PUBLIC_REDDIT_PIXEL_ID",
+] as const;
 const ANALYTICS_REGISTRY_PATH = "config/analytics-sites.json";
 const RELEASE_INPUT_PATHS = [
   "bun.lock",
@@ -210,6 +214,7 @@ async function buildSite(
   await run(["bun", "--no-install", "run", "scripts/build-bucket.ts"], {
     cwd: `${repoRoot()}/${SITE_PACKAGE_DIR}`,
     env,
+    unsetEnv: flavor === "beta" ? [...MARKETING_ENV_NAMES] : [],
   });
 }
 


### PR DESCRIPTION
Why

Caddy's S3 streaming path omitted deferred security headers from static and SPA responses, while beta builds injected invalid marketing-pixel identifiers.

What

Apply a pinned caddy-s3-proxy response-header flush patch, expand Scout's explicit CSP for Bugsink, Data Dragon, and production Pinterest/Reddit endpoints, remove beta pixel placeholders, and add a live runtime contract checker.

Verification

- Focused Caddy static-site tests: 37 passed.
- Scout release tests: 15 passed.
- Caddyfile validation, scripts typecheck/lint, pre-commit safety checks, and `git diff --check` passed.
- The pinned proxy patch applied cleanly.
- The caddy-s3proxy image build and Caddy smoke target passed.

Public beta and production rollout checks remain pending the main release pipeline.