### PR TITLE
fix(dotfiles): keep Spotlight exclusions from decaying back to a full home index

### DIFF
--- a/packages/dotfiles/.chezmoidata/spotlight.yaml
+++ b/packages/dotfiles/.chezmoidata/spotlight.yaml
@@ -1,0 +1,82 @@
+# Directories excluded from macOS Spotlight indexing.
+#
+# Spotlight indexes all of $HOME by default. On a machine that runs agent
+# worktrees and polyglot toolchains that is millions of files — most of them
+# rewritten continuously by installs, builds, and worktree churn — so mds never
+# reaches a converged state. The visible symptom is Spotlight showing
+# "Indexing..." indefinitely while fseventsd and mds_stores burn CPU around the
+# clock.
+#
+# A `.metadata_never_index` file in a directory excludes that entire subtree.
+# `run_after_configure-spotlight-exclusions.sh.tmpl` places the markers.
+#
+# Paths are relative to $HOME. A directory that does not exist is skipped, so
+# listing a tool you have not installed yet is free — the marker appears on the
+# first apply after the directory shows up.
+#
+# Do NOT add directories whose contents you want to find via Spotlight or
+# Finder search. Code search here goes through ripgrep/fd, which ignore
+# Spotlight entirely, so excluding source trees costs nothing in practice.
+spotlight:
+  excludedHomeDirs:
+    # Agent worktrees and repo checkouts. The two largest contributors by far:
+    # ~2.8M and ~2.1M files respectively, both under constant rewrite.
+    - conductor
+    - git
+    - .conductor
+
+    # Package manager and toolchain caches. These are pure derived state, and
+    # several of them (.bun, .cargo, .cache) get deleted and recreated wholesale
+    # by their own tooling — which is why the markers must be re-placed on every
+    # apply rather than once.
+    - .bun
+    - .npm
+    - .cache
+    - .local
+    - .cargo
+    - .rustup
+    - go
+    - .nuget
+    - .dotnet
+    - .gradle
+    - .cocoapods
+    - .swiftpm
+    - .android
+    - .aspnet
+    - .templateengine
+
+    # Agent and dev-tool state directories. .paseo alone is ~850k files.
+    - .paseo
+    - .codex
+    - .cursor
+    - .gemini
+    - .copilot
+    - .kimi-code
+    - .voltagent
+    - .agents
+    - .claude-extra
+    - .pinchtab
+    - .maestro
+    - .devframe
+    - .herdr
+    - .buildkite-agent
+
+    # Infrastructure CLI state: caches, vendored providers, and cluster creds.
+    - .docker
+    - .orbstack
+    - .terraform.d
+    - .talos
+    - .kube
+    - .toolkit
+
+    # Library subtrees. Caches and Xcode DerivedData are derived state;
+    # com.conductor.app holds multi-gigabyte SQLite databases that are written
+    # continuously, and Spotlight re-imports the whole file on every change.
+    - Library/Caches
+    - Library/Developer
+    - Library/Application Support/com.conductor.app
+
+  # Root-owned paths needing sudo. Kept separate because an unattended apply
+  # cannot escalate and must skip these rather than block on a password prompt.
+  excludedSystemDirs:
+    - /private/var/tmp

--- a/packages/dotfiles/AGENTS.md
+++ b/packages/dotfiles/AGENTS.md
@@ -153,6 +153,28 @@ print(doc.export_to_markdown())
   or `cargo install` them — the dump records the duplicate, and the mise shim wins
   PATH, so you get a shadowed second copy that silently drifts.
 
+## Spotlight exclusions — declared in data, placed by a script
+
+- The excluded directories live in `.chezmoidata/spotlight.yaml`; the markers are
+  placed by `run_after_configure-spotlight-exclusions.sh.tmpl`. **Edit the YAML,
+  never the marker files** — add a path relative to `$HOME` and it takes effect
+  on the next `chezmoi apply`.
+- The markers are **not** chezmoi-managed files, deliberately. Tracking
+  `git/.metadata_never_index` as a target would make chezmoi create `~/git`,
+  `~/go`, `~/.gradle` and friends on a fresh machine for toolchains that may
+  never be installed. The script only marks directories that already exist.
+- It is a plain `run_after_` (every apply), not `run_once_`/`run_onchange_`,
+  because package managers delete and recreate their own cache roots and take
+  the marker with them. A state-tracked script would not notice, and the
+  exclusion would silently decay. Expect it to always show as a pending "new
+  file" in `chezmoi diff`, same as `sync-theme.sh`.
+- **Do not exclude anything you want to find in Spotlight or Finder search.**
+  Source trees are safe to exclude here only because code search goes through
+  `rg`/`fd`, which ignore the Spotlight index entirely.
+- Adding a large directory to the list does not shrink an already-built index.
+  After a significant addition, rebuild once with
+  `sudo mdutil -E /System/Volumes/Data`.
+
 ## CLI tool boundaries
 
 ### Linear and PostHog

--- a/packages/dotfiles/MACOS_FRESH_INSTALL.md
+++ b/packages/dotfiles/MACOS_FRESH_INSTALL.md
@@ -54,7 +54,12 @@ the static desktop TTF files, not OTF, WOFF2, or variable fonts.
 7. Approve the Fastmail Contacts profile in **System Settings > General >
    Device Management**, then enter a dedicated Fastmail Contacts app password
    when macOS requests it.
-8. Complete the privacy checklist below, then test each affected feature.
+8. Run `sudo touch /private/var/tmp/.metadata_never_index`. Every other
+   Spotlight exclusion is placed automatically on each `chezmoi apply` from
+   `.chezmoidata/spotlight.yaml`, but this one is root-owned, so the apply
+   script skips it rather than blocking on a password prompt and prints a
+   reminder until it exists.
+9. Complete the privacy checklist below, then test each affected feature.
 
 Syncthing and OrbStack are launched automatically and configured to start at
 login. Syncthing still requires explicit authorization from another device and

--- a/packages/dotfiles/run_after_configure-spotlight-exclusions.sh.tmpl
+++ b/packages/dotfiles/run_after_configure-spotlight-exclusions.sh.tmpl
@@ -1,0 +1,71 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+set -euo pipefail
+
+# Place `.metadata_never_index` markers so Spotlight skips the high-churn,
+# high-count directories listed in .chezmoidata/spotlight.yaml. See that file
+# for why each entry is there.
+#
+# This is a plain `run_after_` — it runs on EVERY apply, not `run_once_` or
+# `run_onchange_`, and that is the whole point. Package managers routinely
+# delete and recreate their own cache roots (`bun pm cache rm`, `cargo` cache
+# clears, `rm -rf ~/.cache`), which takes the marker file with them. A
+# state-tracked script would not notice, and the exclusion would silently decay
+# back to a fully-indexed home directory. Re-touching a few dozen paths is
+# effectively free, so correctness wins over the tracked-state optimization.
+#
+# The tradeoff: `run_after_` scripts are not state-tracked, so this always shows
+# as a pending "new file" in `chezmoi diff`. That matches the existing
+# run_after_sync-theme.sh and run_after_set-default-apps.sh.
+
+marker_dirs=(
+{{- range .spotlight.excludedHomeDirs }}
+    {{ . | quote }}
+{{- end }}
+)
+
+created=0
+for dir in "${marker_dirs[@]}"; do
+    target="$HOME/$dir"
+    marker="$target/.metadata_never_index"
+
+    # Only mark directories that already exist. Creating them here would
+    # scatter empty ~/.gradle, ~/go, ~/.nuget stubs across a fresh machine for
+    # toolchains that may never be installed.
+    if [ ! -d "$target" ]; then
+        continue
+    fi
+
+    if [ -e "$marker" ]; then
+        continue
+    fi
+
+    touch "$marker"
+    created=$((created + 1))
+done
+
+if [ "$created" -gt 0 ]; then
+    echo "spotlight: placed ${created} exclusion marker(s)"
+fi
+
+{{ range .spotlight.excludedSystemDirs -}}
+# Root-owned, so it needs sudo. `-n` goes on the touch itself rather than on a
+# separate probe command: sudoers rules are per-command, so a NOPASSWD entry
+# covering the probe but not `touch` would let the probe pass and then leave the
+# real command prompting for a password in an unattended `chezmoi apply` — the
+# exact hang this is meant to avoid. One non-interactive command, whose own
+# failure is the signal.
+#
+# Its stderr is captured and reported rather than discarded: "no cached
+# credential" is the ordinary case, but a revoked admin account or a broken
+# sudoers file produces a different message, and swallowing it would make the
+# two indistinguishable.
+if [ ! -e {{ . | quote }}/.metadata_never_index ]; then
+    if sudo_error=$(sudo -n touch {{ . | quote }}/.metadata_never_index 2>&1); then
+        echo "spotlight: placed exclusion marker in {{ . }}"
+    else
+        echo "spotlight: skipped {{ . }} (${sudo_error:-sudo unavailable}); run 'sudo touch {{ . }}/.metadata_never_index'" >&2
+    fi
+fi
+{{ end -}}
+{{- end -}}

--- a/packages/dotfiles/run_once_after_configure-spotlight-exclusions.sh.tmpl
+++ b/packages/dotfiles/run_once_after_configure-spotlight-exclusions.sh.tmpl
@@ -1,7 +1,0 @@
-{{- if eq .chezmoi.os "darwin" -}}
-#!/bin/bash
-set -euo pipefail
-
-# Exclude the shared temp directory from Spotlight indexing
-sudo touch /private/var/tmp/.metadata_never_index
-{{- end -}}


### PR DESCRIPTION
## Why

Spotlight had been stuck on "Indexing…" for weeks. The cause was volume, not corruption — roughly **7.9M files under `$HOME`** were eligible for indexing:

| Directory | Files | Size |
| --- | ---: | ---: |
| `~/conductor` | 2,791,508 | 64 G |
| `~/git` | 2,118,334 | 84 G |
| `~/.paseo` | 854,057 | 18 G |
| `~/.bun` | 625,023 | 12 G |
| `~/.local` | 474,126 | 16 G |
| `~/.cache` | 446,008 | 23 G |
| `~/.rustup` | 202,555 | 4.3 G |
| `~/Library/Caches` | 111,713 | 22 G |

That includes **7,664 `node_modules` directories**. None of it was excluded — only `~/OrbStack` had a marker, and OrbStack places that itself. These trees are rewritten continuously by agent worktrees, installs, and builds, so `mds` never reached a converged state and `fseventsd` + `mds_stores` burned CPU around the clock (load average 37.8 at diagnosis).

`run_once_after_configure-spotlight-exclusions.sh.tmpl` was supposed to cover part of this, but it only ever handled `/private/var/tmp` — **and that marker does not exist on the machine.** Because `run_once_` keys on content hash, chezmoi has considered the job done ever since. That is precisely the failure mode this PR is about: an exclusion that silently stops being true.

## What

- **`.chezmoidata/spotlight.yaml`** — the 41 excluded directories as reviewable data, grouped by category (worktrees, package caches, agent state, infra CLI state, `Library` subtrees) with the rationale for each group inline. Adding a path is a one-line edit.
- **`run_after_configure-spotlight-exclusions.sh.tmpl`** replaces the `run_once_` script and places a `.metadata_never_index` marker in each listed directory.

Three design choices worth reviewing:

1. **`run_after_` — it runs on every apply, deliberately.** Package managers delete and recreate their own cache roots (`bun pm cache rm`, cargo cache clears, `rm -rf ~/.cache`) and take the marker with them. A `run_once_`/`run_onchange_` script cannot notice, and the exclusion decays back to a fully-indexed home — which is exactly what happened to the script being replaced. Re-touching 41 paths costs nothing. The tradeoff is that it always shows as a pending "new file" in `chezmoi diff`, matching `run_after_sync-theme.sh` and `run_after_set-default-apps.sh`.
2. **Markers are script-placed, not chezmoi-managed targets.** Tracking `git/.metadata_never_index` as a target would make chezmoi create `~/git`, `~/go`, and `~/.gradle` on a fresh machine for toolchains that may never be installed. The script only marks directories that already exist, and picks up new ones on the next apply.
3. **`sudo -n` probe for the root-owned `/private/var/tmp`,** so an unattended apply never blocks on a password prompt. The probe's stderr is captured and reported rather than discarded — "no cached credential" stays distinguishable from a revoked admin account or a broken sudoers file. (The first draft used `2>/dev/null`; `check-suppressions` correctly rejected it and the fix is better than the original.)

Docs: a contract section in `AGENTS.md` (edit the YAML, never the markers; don't exclude anything you want Spotlight to find) and the one sudo step added to `MACOS_FRESH_INSTALL.md`.

**Result: eligible files under `$HOME` drop from ~7.9M to 400,738 — a 95% reduction.**

## Demo

Four consecutive applies against a scratch `$HOME`, showing placement, idempotency, self-healing, and pickup of a newly-installed toolchain:

```console
$ mkdir -p ~/git ~/.bun ~/.cargo ~/Library/Caches   # a partially-populated home

$ chezmoi apply     # run 1 - place markers
spotlight: placed 4 exclusion marker(s)
spotlight: skipped /private/var/tmp (sudo: a password is required); run 'sudo touch /private/var/tmp/.metadata_never_index'

$ find ~ -name .metadata_never_index
~/.bun/.metadata_never_index
~/.cargo/.metadata_never_index
~/git/.metadata_never_index
~/Library/Caches/.metadata_never_index

$ ls -a ~ | grep -E "gradle|paseo|^go$"    # listed, but not installed here
(no output - the script never creates directories)

$ chezmoi apply     # run 2 - idempotent
spotlight: skipped /private/var/tmp (sudo: a password is required); run 'sudo touch /private/var/tmp/.metadata_never_index'
exit=0   (no markers placed)

$ bun pm cache rm   # simulated: cache root recreated, marker lost
$ test -e ~/.bun/.metadata_never_index && echo present || echo MISSING
MISSING

$ chezmoi apply     # run 3 - self-heals what run_once_ never would
spotlight: placed 1 exclusion marker(s)
spotlight: skipped /private/var/tmp (sudo: a password is required); run 'sudo touch /private/var/tmp/.metadata_never_index'
$ test -e ~/.bun/.metadata_never_index && echo restored
restored

$ mise use -g java  # simulated: new toolchain creates ~/.gradle
$ chezmoi apply     # run 4 - picks it up automatically
spotlight: placed 1 exclusion marker(s)
spotlight: skipped /private/var/tmp (sudo: a password is required); run 'sudo touch /private/var/tmp/.metadata_never_index'
$ test -e ~/.gradle/.metadata_never_index && echo marked
marked
```

## Verification

- `shellcheck` on the rendered script — clean, 0 findings.
- Behavioral tests (above): idempotent on re-run (exit 0, nothing placed); restores a deleted marker; picks up a newly created directory; never creates a directory that does not exist.
- Ran the rendered script against the **real** `$HOME`: no-op, confirming the tracked data and live machine state agree exactly.
- `chezmoi data` parses all 41 entries; `chezmoi execute-template` renders; `chezmoi apply --dry-run` shows the script as expected for a `run_after_`.
- `bun scripts/check-suppressions.ts` — no new suppressions.
- `prettier --check` — clean on all changed files.
- Pre-commit hooks (gitleaks, env-var-names, line-endings, merge-conflicts, large-files, prettier, check-suppressions) and `validate-commit-msg` all passed.

**Not run:** `sudo mdutil -E /System/Volumes/Data`. Adding directories to the list does not shrink an already-built index, so the one-time rebuild is an operator step, to be run alongside `sudo touch /private/var/tmp/.metadata_never_index`. Neither is required for this PR to be correct.