### PR TITLE
fix(root): make link-rot results actionable

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -5,7 +5,8 @@
 #
 # Scope: tracked Markdown documentation. This automates the rot-detection half
 # of the root AGENTS.md "Verify link liveness" rule; the commit-time check for
-# NEW URLs remains manual.
+# NEW URLs remains manual. Site-root-relative links are validated by the
+# owning site's build checks because this repository contains multiple sites.
 
 # The scheduled activity is non-interactive; keep local runs identical.
 no_progress = true

--- a/packages/astro-opengraph-images/README.md
+++ b/packages/astro-opengraph-images/README.md
@@ -249,9 +249,9 @@ Use `pathFilter` when excluded pages may not have the required Open Graph metada
 
 ## Custom Renderers
 
-You can create your own custom images with a render function. Take a look at how [a preset](https://github.com/shepherdjerred/monorepo/blob/main/packages/astro-opengraph-images/src/presets/blackAndWhite.tsx) works.
+You can create your own custom images with a render function. Take a look at how [a preset](https://github.com/shepherdjerred/monorepo/blob/main/packages/astro-opengraph-images/src/presets/black-and-white.tsx) works.
 
-Renderers have access to the page's DOM using [jsdom](https://github.com/jsdom/jsdom). You can use this to render your Open Graph image using any of the content from the associated HTML page. An example of this is shown in the [custom property preset](https://github.com/shepherdjerred/monorepo/blob/main/packages/astro-opengraph-images/src/presets/customProperty.tsx) which shows a preview of the page's body text in the Open Graph image.
+Renderers have access to the page's DOM using [jsdom](https://github.com/jsdom/jsdom). You can use this to render your Open Graph image using any of the content from the associated HTML page. An example of this is shown in the [custom property preset](https://github.com/shepherdjerred/monorepo/blob/main/packages/astro-opengraph-images/src/presets/custom-property.tsx) which shows a preview of the page's body text in the Open Graph image.
 
 This library uses [Satori](https://github.com/vercel/satori) to convert React components to SVG. The SVG is then converted to a PNG using [resvg-js](https://github.com/yisibl/resvg-js).
 

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/release-safety.md
@@ -121,9 +121,8 @@ while the missing-Secret Ready condition can remain unchanged. A different
 false Ready reason or failed issuance stays `Degraded`. The
 [five-minute release operation timeout](https://github.com/shepherdjerred/monorepo/blob/main/.buildkite/pipeline.yml#L1547-L1556)
 still fails a Certificate that never becomes ready. Ignoring Certificate health
-would let the
-[later CA, database, and workload waves](https://github.com/shepherdjerred/monorepo/blob/main/packages/homelab/src/cdk8s/src/resources/postgres/alert-dashboard-tls.ts)
-race a missing trust Secret, so the release does not use that shortcut.
+would let later CA and workload waves race a missing trust Secret, so the
+release does not use that shortcut.
 
 Both request shapes remain isolated by numeric sync wave and exact resource
 identity. After explicit child reconciliation completes, the

--- a/packages/scout-for-lol/packages/desktop/AUTO_UPDATER.md
+++ b/packages/scout-for-lol/packages/desktop/AUTO_UPDATER.md
@@ -171,5 +171,5 @@ Upload your `.json`, `.sig`, and installer files to GitHub Releases.
 ## References
 
 - [Tauri Updater Documentation](https://v2.tauri.app/plugin/updater/)
-- [Tauri Signing Guide](https://v2.tauri.app/distribute/sign/)
+- [Tauri Distribution and Signing](https://v2.tauri.app/distribute/)
 - [Update Server Setup](https://v2.tauri.app/plugin/updater/#update-server)

--- a/packages/sjer.red/package.json
+++ b/packages/sjer.red/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit && astro build",
+    "build": "astro check && PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit && astro build && bun ../../scripts/check-built-internal-links.ts sjer.red",
     "preview": "astro preview",
     "astro": "astro",
     "test:update": "bun run build && bun --no-install --bun playwright test --update-snapshots=all",

--- a/packages/sjer.red/src/pages/projects.md
+++ b/packages/sjer.red/src/pages/projects.md
@@ -170,7 +170,7 @@ A Discord bot that tracks your friends' League of Legends matches. I've learnt a
 
 ## 2023
 
-### [macOS cross compiler](https://github.com/shepherdjerred/monorepo/tree/main/archive/macos-cross-compiler)
+### [macOS cross compiler](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/macos-cross-compiler)
 
 A C/C++/Fortran/Rust cross-compiler targeting amd64/aarch64 macOS from a Linux host.
 
@@ -188,8 +188,8 @@ Multi-player Pokémon (or any Gameboy game) via Discord w/ video streaming & gam
 
 Start/stop an EC2 instance. I created this to host game servers on EC2 while allowing friends to start/stop the server as needed, so that on-demand costs could be kept down.
 
-- <https://github.com/shepherdjerred/monorepo/tree/main/ec2-instance-restart>
-- <https://github.com/shepherdjerred/monorepo/tree/main/ec2-instance-restart-frontend>
+- <https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/ec2-instance-restart>
+- <https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/ec2-instance-restart-frontend>
 
 ## 2020
 
@@ -205,7 +205,7 @@ In my first two years of college I was running a Minecraft server. I shut it dow
 
 ### 2018/2019 (senior year)
 
-#### [Castle Casters](https://github.com/shepherdjerred/monorepo/tree/main/archive/castle-casters)
+#### [Castle Casters](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/castle-casters)
 
 A game/game engine I wrote from scratch.
 
@@ -213,35 +213,35 @@ A game/game engine I wrote from scratch.
 
 I wrote a paper over 3D Graphics Rendering with OpenGL. I also published it as a [blog post on OpenGL rendering](/blog/2019/opengl/).
 
-#### [Hue Saber](https://github.com/shepherdjerred/monorepo/tree/main/hue-saber)
+#### [Hue Saber](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/hue-saber)
 
 Synchronize Hue lights to the game Beat Saber. The latency was, surprisingly, quite okay.
 
-#### [Usher](https://github.com/shepherdjerred/monorepo/tree/main/usher)
+#### [Usher](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/usher)
 
 Sign up for a chapel seat before selection opens.
 
-#### [Cashly](https://github.com/shepherdjerred/monorepo/tree/main/cashly)
+#### [Cashly](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/cashly)
 
 A personal finance simulator. [ProjectionLab](https://projectionlab.com/) does it better than I ever could.
 
 ### 2017/2018 (junior year)
 
-#### [Easely](https://github.com/shepherdjerred/monorepo/tree/main/easely)
+#### [Easely](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/easely)
 
 Alternative interface for Harding's computer science grading platform.
 
-#### [Siphon](https://github.com/shepherdjerred/monorepo/tree/main/siphon)
+#### [Siphon](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/siphon)
 
 Alternative interface for Harding's Pipeline web portal.
 
-#### [Funsheet](https://github.com/shepherdjerred/monorepo/tree/main/funsheet)
+#### [Funsheet](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/funsheet)
 
 Track and find fun things to do.
 
 ### 2016/2017 (sophomore year)
 
-#### [Raspastat](https://github.com/shepherdjerred/monorepo/tree/main/raspastat)
+#### [Raspastat](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/raspastat)
 
 A thermostat for my dorm using a Raspberry Pi. It looked like a bomb stuck to the wall.
 
@@ -261,15 +261,15 @@ Responsive homepage for Minecraft servers
 
 Allow players to fairly teleport around
 
-#### [The Button](https://github.com/shepherdjerred/monorepo/tree/main/the-button)
+#### [The Button](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/the-button)
 
 Press a button and make a counter go up.
 
-#### [Maze Game](https://github.com/shepherdjerred/monorepo/tree/main/practice/maze-game)
+#### [Maze Game](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/practice/maze-game)
 
 Pacman-esque game.
 
-#### [RSI Hackathon](https://github.com/shepherdjerred/monorepo/tree/main/rsi-hackathon-2016)
+#### [RSI Hackathon](https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/rsi-hackathon-2016)
 
 I have no idea how, but my team won this.
 
@@ -340,7 +340,7 @@ My Minecraft server that taught me everything I know from server administration,
 My surviving code is in a few places:
 
 - <https://github.com/ShepherdJerred-minecraft>
-- <https://github.com/shepherdjerred/monorepo/tree/main/ts-mc>
+- <https://github.com/shepherdjerred/monorepo/tree/main/sandbox/archive/ts-mc>
 - <https://github.com/the-storm-mc>
 - <https://www.spigotmc.org/resources/authors/riotshielder.51/>
 

--- a/packages/temporal/src/activities/link-rot-scan-report.ts
+++ b/packages/temporal/src/activities/link-rot-scan-report.ts
@@ -51,7 +51,12 @@ export function buildLinkRotReport(
 ): ActivityReportInput {
   const dead = result.deadLinks.length;
   const timedOut = result.timedOutLinks.length;
+  const ignoredRootRelative = result.ignoredRootRelativeLinks;
   const clean = dead === 0 && timedOut === 0;
+  const internalLinkSummary =
+    ignoredRootRelative === 0
+      ? ""
+      : ` ${String(ignoredRootRelative)} site-root-relative ${ignoredRootRelative === 1 ? "link was" : "links were"} delegated to their owning site checks.`;
   return {
     reportType: LINK_ROT_REPORT_TYPE,
     title: LINK_ROT_TITLE,
@@ -68,7 +73,7 @@ export function buildLinkRotReport(
         label: "lychee link scan of main completed",
         required: true,
         status: "passed",
-        summary: `Checked ${String(result.totalLinks)} links (${String(result.successfulLinks)} alive, ${String(result.excludedLinks)} excluded) on main@${result.repoSha.slice(0, 12)}.`,
+        summary: `Checked ${String(result.totalLinks)} links (${String(result.successfulLinks)} alive, ${String(result.excludedLinks)} excluded) on main@${result.repoSha.slice(0, 12)}.${internalLinkSummary}`,
         evidenceReceiptIds: [SCAN_RECEIPT_ID],
       },
     ],
@@ -102,7 +107,7 @@ export function buildLinkRotReport(
       })),
     ],
     limitations: [
-      "Scope: tracked Markdown, web links only, verbatim/code-block URLs skipped; 403/429 responses count as alive (bot-hostile hosts). See root lychee.toml.",
+      "Scope: tracked Markdown, web links only, verbatim/code-block URLs skipped; 403/429 responses count as alive (bot-hostile hosts). Site-root-relative links are validated by the owning site's build checks. See root lychee.toml.",
     ],
     actions: [
       ...(dead === 0

--- a/packages/temporal/src/activities/link-rot-scan.test.ts
+++ b/packages/temporal/src/activities/link-rot-scan.test.ts
@@ -45,6 +45,15 @@ const LYCHEE_FIXTURE = JSON.stringify({
         span: { line: 3, column: 1 },
         duration: { secs: 2, nanos: 0 },
       },
+      {
+        url: "error:",
+        status: {
+          text: "Error building URL for \"/docs/overview/\": Cannot resolve root-relative link '/docs/overview/'",
+          details:
+            "Cannot resolve root-relative link '/docs/overview/': To resolve root-relative links in local files, provide a root dir",
+        },
+        span: { line: 8, column: 1 },
+      },
     ],
   },
   timeout_map: {
@@ -70,6 +79,7 @@ describe("parseLycheeReport", () => {
     expect(parsed.totalLinks).toBe(120);
     expect(parsed.successfulLinks).toBe(115);
     expect(parsed.excludedLinks).toBe(2);
+    expect(parsed.ignoredRootRelativeLinks).toBe(1);
     expect(parsed.deadLinks).toEqual([
       {
         url: "https://github.com/shepherdjerred/definitely-missing",
@@ -108,6 +118,7 @@ describe("parseLycheeReport", () => {
       }),
     );
     expect(parsed.deadLinks).toEqual([]);
+    expect(parsed.ignoredRootRelativeLinks).toBe(0);
     expect(parsed.timedOutLinks).toEqual([]);
   });
 
@@ -143,6 +154,7 @@ describe("buildLinkRotReport", () => {
         totalLinks: 10,
         successfulLinks: 10,
         excludedLinks: 0,
+        ignoredRootRelativeLinks: 0,
         deadLinks: [],
         timedOutLinks: [],
       }),
@@ -172,6 +184,9 @@ describe("buildLinkRotReport", () => {
     expect(report.findings[0]?.detail).toContain(
       "packages/docs/wiki/src/content/docs/reference/homelab.md:12",
     );
+    expect(report.checks[0]?.summary).toContain(
+      "1 site-root-relative link was delegated",
+    );
     expect(report.findings[2]?.section).toBe("Timed-out links");
     expect(report.findings[2]?.detail).toContain(
       "Retry the link or investigate its reachability",
@@ -197,6 +212,7 @@ describe("buildLinkRotReport", () => {
         totalLinks: 1,
         successfulLinks: 0,
         excludedLinks: 0,
+        ignoredRootRelativeLinks: 0,
         deadLinks: [],
         timedOutLinks: [
           {

--- a/packages/temporal/src/activities/link-rot-scan.test.ts
+++ b/packages/temporal/src/activities/link-rot-scan.test.ts
@@ -35,7 +35,7 @@ const LYCHEE_FIXTURE = JSON.stringify({
         duration: { secs: 0, nanos: 5 },
       },
     ],
-    "README.md": [
+    "packages/docs/wiki/src/content/docs/index.md": [
       {
         url: "https://gone.example-registry.dev/pkg",
         status: {
@@ -90,7 +90,7 @@ describe("parseLycheeReport", () => {
       },
       {
         url: "https://gone.example-registry.dev/pkg",
-        source: "README.md",
+        source: "packages/docs/wiki/src/content/docs/index.md",
         status: "Network error: Connection failed.",
         line: 3,
       },
@@ -120,6 +120,40 @@ describe("parseLycheeReport", () => {
     expect(parsed.deadLinks).toEqual([]);
     expect(parsed.ignoredRootRelativeLinks).toBe(0);
     expect(parsed.timedOutLinks).toEqual([]);
+  });
+
+  test("keeps root-relative diagnostics from unchecked sources actionable", () => {
+    const source =
+      "packages/dotfiles/dot_agents/skills/apple-hig-helper/markdown/action-sheets.md";
+    const status =
+      "Error building URL for \"/design/human-interface-guidelines/action-sheets\": Cannot resolve root-relative link '/design/human-interface-guidelines/action-sheets'";
+    const parsed = parseLycheeReport(
+      JSON.stringify({
+        total: 1,
+        successful: 0,
+        errors: 1,
+        timeouts: 0,
+        excludes: 0,
+        error_map: {
+          [source]: [
+            {
+              url: "error:",
+              status: { text: status },
+            },
+          ],
+        },
+        timeout_map: {},
+      }),
+    );
+
+    expect(parsed.ignoredRootRelativeLinks).toBe(0);
+    expect(parsed.deadLinks).toEqual([
+      {
+        url: "error:",
+        source,
+        status,
+      },
+    ]);
   });
 
   test("rejects non-JSON output instead of returning empty", () => {

--- a/packages/temporal/src/activities/link-rot-scan.ts
+++ b/packages/temporal/src/activities/link-rot-scan.ts
@@ -9,8 +9,12 @@ import {
   withMainRepositoryScan,
 } from "./main-repository-scan.ts";
 const EXCERPT_LIMIT = 2000;
+const ROOT_RELATIVE_LINK_DIAGNOSTIC = "Cannot resolve root-relative link";
 /** lychee reserves exit 2 for "broken links found" — a finding, not a crash. */
 const LYCHEE_FINDINGS_EXIT_CODE = 2;
+
+const isIgnoredRootRelativeLink = (link: DeadLink): boolean =>
+  link.url === "error:" && link.status.includes(ROOT_RELATIVE_LINK_DIAGNOSTIC);
 
 /**
  * Minimal schema for the slice of lychee's `--format json` output this scan
@@ -56,6 +60,7 @@ export type LinkRotScanResult = {
   totalLinks: number;
   successfulLinks: number;
   excludedLinks: number;
+  ignoredRootRelativeLinks: number;
   deadLinks: DeadLink[];
   timedOutLinks: DeadLink[];
   /** Bounded evidence excerpt (dead link per source). */
@@ -82,25 +87,37 @@ export type ParsedLycheeReport = {
   totalLinks: number;
   successfulLinks: number;
   excludedLinks: number;
+  ignoredRootRelativeLinks: number;
   deadLinks: DeadLink[];
   timedOutLinks: DeadLink[];
 };
 
-/** Pure: lychee JSON text → typed dead/timed-out link lists. */
+/**
+ * Pure: lychee JSON text → typed dead/timed-out link lists.
+ *
+ * lychee cannot resolve site-root-relative URLs from a repository containing
+ * multiple sites, so it emits these as synthetic `error:` records. The owning
+ * site builds validate those links against their actual roots.
+ */
 export function parseLycheeReport(json: string): ParsedLycheeReport {
   const report = LycheeReportSchema.parse(JSON.parse(json));
+  const allDeadLinks = flattenLinkMap(report.error_map);
+  const ignoredRootRelativeLinks = allDeadLinks.filter((link) =>
+    isIgnoredRootRelativeLink(link),
+  ).length;
   return {
     totalLinks: report.total,
     successfulLinks: report.successful,
     excludedLinks: report.excludes,
-    deadLinks: flattenLinkMap(report.error_map),
+    ignoredRootRelativeLinks,
+    deadLinks: allDeadLinks.filter((link) => !isIgnoredRootRelativeLink(link)),
     timedOutLinks: flattenLinkMap(report.timeout_map),
   };
 }
 
 /** Pure: bounded plain-text evidence excerpt for the report receipt. */
 export function buildLinkRotExcerpt(parsed: ParsedLycheeReport): string {
-  const summary = `${String(parsed.totalLinks)} links checked, ${String(parsed.deadLinks.length)} dead, ${String(parsed.timedOutLinks.length)} timed out, ${String(parsed.excludedLinks)} excluded`;
+  const summary = `${String(parsed.totalLinks)} links checked, ${String(parsed.deadLinks.length)} dead, ${String(parsed.timedOutLinks.length)} timed out, ${String(parsed.excludedLinks)} excluded, ${String(parsed.ignoredRootRelativeLinks)} root-relative delegated`;
   const lines = parsed.deadLinks.map(
     (link) => `${link.status}: ${link.url} (${link.source})`,
   );

--- a/packages/temporal/src/activities/link-rot-scan.ts
+++ b/packages/temporal/src/activities/link-rot-scan.ts
@@ -10,11 +10,26 @@ import {
 } from "./main-repository-scan.ts";
 const EXCERPT_LIMIT = 2000;
 const ROOT_RELATIVE_LINK_DIAGNOSTIC = "Cannot resolve root-relative link";
+const ROOT_RELATIVE_LINK_OWNER_PREFIXES = [
+  "packages/docs/wiki/src/content/docs/",
+  "packages/scout-for-lol/packages/docs-site/src/content/docs/",
+  "packages/sjer.red/src/pages/",
+  "packages/webring/example/src/content/",
+] as const;
 /** lychee reserves exit 2 for "broken links found" — a finding, not a crash. */
 const LYCHEE_FINDINGS_EXIT_CODE = 2;
 
+const hasOwningSiteCheck = (source: string): boolean => {
+  const normalizedSource = source.startsWith("./") ? source.slice(2) : source;
+  return ROOT_RELATIVE_LINK_OWNER_PREFIXES.some((prefix) =>
+    normalizedSource.startsWith(prefix),
+  );
+};
+
 const isIgnoredRootRelativeLink = (link: DeadLink): boolean =>
-  link.url === "error:" && link.status.includes(ROOT_RELATIVE_LINK_DIAGNOSTIC);
+  link.url === "error:" &&
+  link.status.includes(ROOT_RELATIVE_LINK_DIAGNOSTIC) &&
+  hasOwningSiteCheck(link.source);
 
 /**
  * Minimal schema for the slice of lychee's `--format json` output this scan
@@ -96,8 +111,10 @@ export type ParsedLycheeReport = {
  * Pure: lychee JSON text → typed dead/timed-out link lists.
  *
  * lychee cannot resolve site-root-relative URLs from a repository containing
- * multiple sites, so it emits these as synthetic `error:` records. The owning
- * site builds validate those links against their actual roots.
+ * multiple sites, so it emits these as synthetic `error:` records. The wiki,
+ * Scout docs, sjer.red, and webring example builds validate their links
+ * against their actual roots; root-relative diagnostics elsewhere remain
+ * actionable findings.
  */
 export function parseLycheeReport(json: string): ParsedLycheeReport {
   const report = LycheeReportSchema.parse(JSON.parse(json));

--- a/packages/temporal/src/workflows/link-rot-scan.test.ts
+++ b/packages/temporal/src/workflows/link-rot-scan.test.ts
@@ -29,6 +29,7 @@ function scanResult(deadLinks: DeadLink[]): LinkRotScanResult {
     totalLinks: 120,
     successfulLinks: 120 - deadLinks.length,
     excludedLinks: 2,
+    ignoredRootRelativeLinks: 0,
     deadLinks,
     timedOutLinks: [],
     excerpt: "fixture",

--- a/packages/webring/example/package.json
+++ b/packages/webring/example/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build && bun ../../../scripts/check-built-internal-links.ts webring/example",
     "preview": "astro preview",
     "astro": "astro",
     "postinstall": "bun run ../../../scripts/copy-example-deps.ts ../ webring ."

--- a/scripts/check-built-internal-links.ts
+++ b/scripts/check-built-internal-links.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+
+const siteName = Bun.argv[2];
+if (siteName !== "sjer.red" && siteName !== "webring/example") {
+  throw new Error(
+    `Expected a supported site name, received ${siteName ?? "nothing"}`,
+  );
+}
+
+const distDirectory = path.join(process.cwd(), "dist");
+const htmlFiles = [
+  ...new Bun.Glob("**/*.html").scanSync({
+    cwd: distDirectory,
+    onlyFiles: true,
+  }),
+].sort();
+
+if (htmlFiles.length === 0) {
+  throw new Error(`No built HTML files found in ${distDirectory}`);
+}
+
+function outputPaths(target: string): string[] {
+  const relativeTarget = decodeURIComponent(target.slice(1));
+  const filePath = path.join(distDirectory, relativeTarget);
+  if (relativeTarget.endsWith("/")) {
+    return [path.join(filePath, "index.html")];
+  }
+  return [filePath, path.join(filePath, "index.html")];
+}
+
+const broken: string[] = [];
+let checked = 0;
+const attributePattern =
+  /(?:href|src)=(['"])(\/[^'"#?\s>]*)(?:[?#][^'"]*)?\1/gu;
+
+function siteOwnedMarkup(html: string): string {
+  if (siteName !== "sjer.red") {
+    return html;
+  }
+
+  // Webring previews are sanitized HTML fetched from other sites. A relative
+  // link in that content belongs to the source site, not sjer.red.
+  return html.replaceAll(
+    /<p\s[^>]*class=(['"])[^'"]*summary[^'"]*\1[^>]*>[\s\S]*?<\/p>(?:\s*<\/p>)?/gu,
+    "",
+  );
+}
+
+for (const htmlFile of htmlFiles) {
+  const html = siteOwnedMarkup(
+    await Bun.file(path.join(distDirectory, htmlFile)).text(),
+  );
+  for (const match of html.matchAll(attributePattern)) {
+    const target = match[2];
+    if (target === undefined || target.startsWith("//")) {
+      continue;
+    }
+    checked += 1;
+    const candidateResults = await Promise.all(
+      outputPaths(target).map((candidate) => Bun.file(candidate).exists()),
+    );
+    const exists = candidateResults.some(Boolean);
+    if (!exists) {
+      broken.push(`${htmlFile} -> ${target}`);
+    }
+  }
+}
+
+if (broken.length > 0) {
+  throw new Error(
+    `${siteName} has ${String(broken.length)} broken internal link(s):\n${broken.join("\n")}`,
+  );
+}
+
+console.log(
+  `${siteName}: checked ${String(checked)} built internal page and asset links`,
+);


### PR DESCRIPTION
## Why

The weekly lychee report treated site-root-relative links as dead because one repository contains multiple site roots, obscuring genuine dead links and making the report difficult to act on.

## What

- Filter only lychee's exact synthetic root-relative diagnostic and preserve HTTP 404s, network failures, and other malformed-link errors.
- Record delegated root-relative counts in report evidence and document the owning-site validation boundary.
- Add generated-output page and asset checks to the `sjer.red` and `webring/example` builds.
- Repair the 19 confirmed dead links, including renamed Astro preset paths, archived project paths, the Tauri distribution link, and the obsolete PostgreSQL TLS reference.

## Verification

- `bun test src/activities/link-rot-scan.test.ts` and `bun test src/workflows/link-rot-scan.test.ts`: 12 passed.
- Wiki and Scout docs test/build checks passed.
- `sjer.red` build and generated-output check passed: 2,386 links.
- `webring/example` build and generated-output check passed: 73 links.
- All 17 rewritten external URLs returned HTTP 200.
- Current lychee scan: 900 links, 272 delegated root-relative diagnostics, 0 timeouts, and 1 unrelated Web Archive 503.
- Focused ESLint completed with zero errors; `git diff --check` passed.

The live weekly Temporal schedule was not rerun because this branch was not yet published; it should be rerun after merge.