### PR TITLE
fix(scout-for-lol): clarify weekly parlay updates

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/open-market-view.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/open-market-view.ts
@@ -310,7 +310,11 @@ async function loadWeeklyParlayMarkets(
       subjects: subjects.map((subject) => subject.alias),
       legs: criteria.legs.map((leg) =>
         stripDiscordMarkdown(
-          legLine(leg, undefined, aliases.get(leg.subject) ?? leg.subject),
+          legLine({
+            leg,
+            current: undefined,
+            subjectAlias: aliases.get(leg.subject) ?? leg.subject,
+          }),
         ),
       ),
       qualification: mapQualification(criteria),

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import {
+  WeeklyParlayContributionSnapshotSchema,
+  WeeklyParlayDefinitionCriteriaSchema,
+} from "#src/betting/weekly-parlay-criteria.ts";
+import { evaluateWeeklyParlay } from "#src/betting/weekly-parlay-evaluator.ts";
+import { weeklyParlayDeliveryContent } from "#src/betting/weekly-parlay-discord-copy.ts";
+
+function contribution(input: { completedAt: string; win: boolean }) {
+  return WeeklyParlayContributionSnapshotSchema.parse({
+    subject: "P1",
+    puuid: "a".repeat(78),
+    queue: "solo",
+    completedAt: input.completedAt,
+    win: input.win,
+    champion: "Ahri",
+    role: "MIDDLE",
+    kills: 3,
+    deaths: 2,
+    assists: 5,
+    championDamage: 10_000,
+    creepScore: 200,
+    gold: 12_000,
+    visionScore: 20,
+    timePlayed: 1800,
+  });
+}
+
+describe("weekly parlay Discord copy", () => {
+  test("makes a NO settlement and its reason explicit", () => {
+    const criteria = WeeklyParlayDefinitionCriteriaSchema.parse({
+      version: 2,
+      qualification: { minimumGamesPerSubject: 3 },
+      legs: [
+        {
+          kind: "champion_games",
+          subject: "P1",
+          champion: "Caitlyn",
+          winsOnly: true,
+          operator: "gte",
+          threshold: 1,
+        },
+        {
+          kind: "champion_peak",
+          subject: "P1",
+          champion: "Caitlyn",
+          metric: "champion_damage",
+          operator: "gte",
+          threshold: 21_782,
+        },
+        {
+          kind: "rate",
+          subject: "P1",
+          metric: "win_rate_bps",
+          operator: "gte",
+          threshold: 5000,
+        },
+      ],
+    });
+    const evaluation = evaluateWeeklyParlay(criteria, [
+      contribution({ completedAt: "2026-08-24T10:00:00.000Z", win: true }),
+      contribution({ completedAt: "2026-08-25T10:00:00.000Z", win: true }),
+      contribution({ completedAt: "2026-08-26T10:00:00.000Z", win: false }),
+    ]);
+
+    const content = weeklyParlayDeliveryContent({
+      kind: "settlement",
+      marketState: "settled",
+      yesResult: false,
+      voidReason: null,
+      bettingClosesAt: new Date("2026-08-24T07:00:00.000Z"),
+      scoringStartsAt: new Date("2026-08-24T07:00:00.000Z"),
+      scoringEndsAt: new Date("2026-08-31T18:00:00.000Z"),
+      criteria,
+      evaluation,
+      aliases: new Map([["P1", "Zhi"]]),
+      bettorCount: 7,
+      totalStaked: 13,
+    });
+
+    expect(content).toContain("Weekly Bryan Bucks parlay: RESOLVED NO");
+    expect(content).toContain("**2 of 3 conditions failed.**");
+    expect(content).not.toContain("Refund");
+    expect(content).not.toContain("Week of");
+    expect(content).not.toContain("Historical YES estimate");
+    expect(content).not.toContain("Settlement timing");
+    expect(content).toContain("**Activity qualification:**");
+    expect(content).toContain("✅ **Zhi** — 3/3 eligible games (qualified)");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.test.ts
@@ -27,6 +27,56 @@ function contribution(input: { completedAt: string; win: boolean }) {
 }
 
 describe("weekly parlay Discord copy", () => {
+  test("keeps mutable progress legs pending until settlement", () => {
+    const criteria = WeeklyParlayDefinitionCriteriaSchema.parse({
+      version: 1,
+      legs: [
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "wins",
+          operator: "gte",
+          threshold: 1,
+        },
+        {
+          kind: "rate",
+          subject: "P1",
+          metric: "win_rate_bps",
+          operator: "gte",
+          threshold: 5000,
+        },
+        {
+          kind: "aggregate",
+          subject: "P1",
+          metric: "kills",
+          operator: "gte",
+          threshold: 1,
+        },
+      ],
+    });
+    const evaluation = evaluateWeeklyParlay(criteria, [
+      contribution({ completedAt: "2026-08-24T10:00:00.000Z", win: true }),
+    ]);
+
+    const content = weeklyParlayDeliveryContent({
+      kind: "progress",
+      marketState: "active",
+      yesResult: null,
+      voidReason: null,
+      bettingClosesAt: new Date("2026-08-24T07:00:00.000Z"),
+      scoringStartsAt: new Date("2026-08-24T07:00:00.000Z"),
+      scoringEndsAt: new Date("2026-08-31T18:00:00.000Z"),
+      criteria,
+      evaluation,
+      aliases: new Map([["P1", "Zhi"]]),
+      bettorCount: 1,
+      totalStaked: 1,
+    });
+
+    expect(content).toContain("⏳ **Zhi** — at least **50.0% win rate");
+    expect(content).not.toContain("✅ **Zhi** — at least **50.0% win rate");
+  });
+
   test("makes a NO settlement and its reason explicit", () => {
     const criteria = WeeklyParlayDefinitionCriteriaSchema.parse({
       version: 2,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.ts
@@ -1,7 +1,8 @@
 import { formatInteger } from "@scout-for-lol/data";
-import type {
-  WeeklyParlayDefinitionCriteria,
-  WeeklyParlayLeg,
+import {
+  WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES,
+  type WeeklyParlayDefinitionCriteria,
+  type WeeklyParlayLeg,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import type { WeeklyParlayEvaluation } from "#src/betting/weekly-parlay-evaluator.ts";
 
@@ -89,16 +90,29 @@ function metricValue(leg: WeeklyParlayLeg, value: number): string {
   return value.toLocaleString("en-US");
 }
 
-export function legLine(
-  leg: WeeklyParlayLeg,
-  current: number | undefined,
-  subjectAlias: string,
-): string {
+export function legLine(input: {
+  leg: WeeklyParlayLeg;
+  current: number | undefined;
+  subjectAlias: string;
+  kind?: WeeklyParlayDiscordKind;
+  passed?: boolean;
+}): string {
+  const kind = input.kind ?? "open";
+  const status =
+    input.current === undefined
+      ? "•"
+      : kind === "settlement"
+        ? input.passed === true
+          ? "✅"
+          : "❌"
+        : input.passed === true
+          ? "✅"
+          : "⏳";
   const progress =
-    current === undefined
+    input.current === undefined
       ? ""
-      : ` — **${metricValue(leg, current)} / ${metricValue(leg, leg.threshold)}**`;
-  return `• **${subjectAlias}** ${operatorCopy(leg)} **${metricValue(leg, leg.threshold)} ${metricCopy(leg)}**${progress}`;
+      : ` (${metricValue(input.leg, input.current)} / ${metricValue(input.leg, input.leg.threshold)})`;
+  return `${status} **${input.subjectAlias}** — ${operatorCopy(input.leg)} **${metricValue(input.leg, input.leg.threshold)} ${metricCopy(input.leg)}**${progress}`;
 }
 
 export function weeklyParlayQualificationCopy(
@@ -107,19 +121,19 @@ export function weeklyParlayQualificationCopy(
   if (criteria.version === 1) {
     return;
   }
-  return `Settlement qualification: **${criteria.qualification.minimumGamesPerSubject.toString()} eligible games required per player**; otherwise all bets are refunded.`;
+  return `Settlement requires **${criteria.qualification.minimumGamesPerSubject.toString()} eligible games** from every featured player.`;
 }
 
-function weeklyParlayVoidCopy(reason: string | null): string {
+function weeklyParlayVoidReasonCopy(reason: string | null): string {
   switch (reason) {
     case "insufficient_activity":
-      return "Fewer than three eligible games were played, so every wager was refunded.";
+      return `Not every featured player completed ${WEEKLY_PARLAY_SETTLEMENT_MIN_GAMES.toString()} eligible games.`;
     case "operator_cancelled":
-      return "Cancelled by an operator; every pending wager was refunded.";
+      return "An operator cancelled this market.";
     case null:
-      return "The market was voided and every pending wager was refunded.";
+      return "The market was voided without a recorded result.";
     default:
-      return `The market was voided (${reason}) and every pending wager was refunded.`;
+      return `The market was voided because of ${reason}.`;
   }
 }
 
@@ -127,27 +141,25 @@ export function deliveryTitle(input: {
   kind: WeeklyParlayDiscordKind;
   marketState: string;
   yesResult: boolean | null;
-  catchup?: boolean;
   voidReason?: string | null;
 }): string {
-  const prefix = input.catchup === true ? "Catch-up weekly" : "Weekly";
   switch (input.kind) {
     case "open":
-      return `📅 **${prefix} Bryan Bucks parlay is open**`;
+      return "📅 **Weekly Bryan Bucks parlay: OPEN FOR BETTING**";
     case "reminder":
-      return `⏰ **${prefix} parlay betting reminder**`;
+      return "⏰ **Weekly Bryan Bucks parlay: BETTING REMINDER**";
     case "progress":
-      return `📈 **${prefix} parlay progress**`;
+      return "📈 **Weekly Bryan Bucks parlay: IN PROGRESS**";
     case "settlement":
       if (input.marketState === "voided") {
         if (input.voidReason === "operator_cancelled") {
-          return `🛑 **${prefix} parlay cancelled and refunded**`;
+          return "🛑 **Weekly Bryan Bucks parlay: CANCELLED — BETS REFUNDED**";
         }
-        return `↩️ **${prefix} parlay refunded**`;
+        return "↩️ **Weekly Bryan Bucks parlay: VOIDED — BETS REFUNDED**";
       }
       return input.yesResult === true
-        ? `✅ **${prefix} parlay settled YES**`
-        : `❌ **${prefix} parlay settled NO**`;
+        ? "✅ **Weekly Bryan Bucks parlay: RESOLVED YES**"
+        : "❌ **Weekly Bryan Bucks parlay: RESOLVED NO**";
   }
 }
 
@@ -156,18 +168,81 @@ export function deliveryTimeCopy(input: {
   bettingClosesAt: Date;
   scoringEndsAt: Date;
   scoringStartsAt?: Date;
-  catchup?: boolean;
 }): string {
-  if (input.catchup === true) {
-    if (input.scoringStartsAt === undefined) {
-      throw new Error("Catch-up weekly parlay copy requires scoringStartsAt.");
-    }
-    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:F>. Scoring runs <t:${Math.floor(input.scoringStartsAt.getTime() / 1000).toString()}:F> through <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
-  }
+  const timestamp = (date: Date, style: "F" | "R"): string =>
+    `<t:${Math.floor(date.getTime() / 1000).toString()}:${style}>`;
   if (input.kind === "open" || input.kind === "reminder") {
-    return `Betting closes <t:${Math.floor(input.bettingClosesAt.getTime() / 1000).toString()}:R>. Use this message's buttons so your market is unambiguous.`;
+    return [
+      `**Betting closes:** ${timestamp(input.bettingClosesAt, "F")} (${timestamp(input.bettingClosesAt, "R")})`,
+      `**Scoring window:** ${timestamp(input.scoringStartsAt ?? input.bettingClosesAt, "F")} → ${timestamp(input.scoringEndsAt, "F")}`,
+    ].join("\n");
   }
-  return `Final cutoff <t:${Math.floor(input.scoringEndsAt.getTime() / 1000).toString()}:F>.`;
+  return `**Scoring cutoff:** ${timestamp(input.scoringEndsAt, "F")}`;
+}
+
+function qualificationLines(input: {
+  kind: WeeklyParlayDiscordKind;
+  criteria: WeeklyParlayDefinitionCriteria | undefined;
+  evaluation: WeeklyParlayEvaluation | undefined;
+  aliases: ReadonlyMap<string, string>;
+}): string[] {
+  if (input.criteria?.version !== 2) {
+    return [];
+  }
+  if (
+    input.evaluation === undefined ||
+    input.kind === "open" ||
+    input.kind === "reminder"
+  ) {
+    const requirement = weeklyParlayQualificationCopy(input.criteria);
+    if (requirement === undefined) {
+      throw new Error("Version-two weekly parlay requires qualification copy.");
+    }
+    return [`**Activity requirement:** ${requirement}`];
+  }
+  const minimumGames = input.evaluation.qualification.minimumGamesPerSubject;
+  return [
+    "**Activity qualification:**",
+    ...input.evaluation.qualification.subjects.map((subject) => {
+      const status = subject.passed
+        ? "✅"
+        : input.kind === "settlement"
+          ? "❌"
+          : "⏳";
+      const qualification = subject.passed ? " (qualified)" : "";
+      const alias = input.aliases.get(subject.subject) ?? subject.subject;
+      return `• ${status} **${alias}** — ${subject.games.toString()}/${minimumGames.toString()} eligible games${qualification}`;
+    }),
+  ];
+}
+
+function settlementLines(input: {
+  kind: WeeklyParlayDiscordKind;
+  marketState: string;
+  yesResult: boolean | null;
+  voidReason: string | null;
+  evaluation: WeeklyParlayEvaluation | undefined;
+  bettorCount: number;
+  totalStaked: number;
+}): string[] {
+  if (input.kind !== "settlement") {
+    return [];
+  }
+  if (input.marketState === "voided") {
+    return [
+      `**Why:** ${weeklyParlayVoidReasonCopy(input.voidReason)}`,
+      `**Returned:** ${formatInteger(input.bettorCount)} ${countLabel(input.bettorCount, "bettor")} · ${formatInteger(input.totalStaked)} BB`,
+    ];
+  }
+  if (input.evaluation === undefined) {
+    throw new Error("Settled weekly parlay delivery requires evaluation.");
+  }
+  const failedLegs = input.evaluation.legs.filter((leg) => !leg.passed).length;
+  const result =
+    input.yesResult === true
+      ? "All conditions passed."
+      : `${failedLegs.toString()} of ${input.evaluation.legs.length.toString()} conditions failed.`;
+  return [`**${result}**`];
 }
 
 export function weeklyParlayDeliveryContent(input: {
@@ -175,9 +250,6 @@ export function weeklyParlayDeliveryContent(input: {
   marketState: string;
   yesResult: boolean | null;
   voidReason: string | null;
-  catchup: boolean;
-  periodKey: string;
-  yesProbabilityBps: number;
   bettingClosesAt: Date;
   scoringStartsAt: Date;
   scoringEndsAt: Date;
@@ -187,64 +259,63 @@ export function weeklyParlayDeliveryContent(input: {
   bettorCount: number;
   totalStaked: number;
 }): string {
-  const isVoidedSettlement =
-    input.kind === "settlement" && input.marketState === "voided";
+  if (input.kind !== "settlement" && input.criteria === undefined) {
+    throw new Error("Weekly parlay delivery requires criteria.");
+  }
   if (
-    !isVoidedSettlement &&
+    input.kind === "settlement" &&
+    input.marketState !== "voided" &&
     (input.criteria === undefined || input.evaluation === undefined)
   ) {
-    throw new Error("Non-void weekly parlay delivery requires evaluation.");
+    throw new Error("Settled weekly parlay delivery requires evaluation.");
   }
   const legs =
-    input.evaluation?.legs.map((result) =>
-      legLine(
-        result.leg,
-        input.kind === "open" || input.kind === "reminder"
-          ? undefined
-          : result.current,
-        input.aliases.get(result.leg.subject) ?? result.leg.subject,
-      ),
-    ) ?? [];
-  const qualification =
-    input.criteria === undefined
-      ? undefined
-      : weeklyParlayQualificationCopy(input.criteria);
-  const minimumGames =
-    input.evaluation?.qualification.minimumGamesPerSubject ?? 0;
-  const qualificationProgress =
-    minimumGames === 0 ||
-    input.kind === "open" ||
-    input.kind === "reminder" ||
     input.evaluation === undefined
-      ? undefined
-      : `Qualification: ${input.evaluation.qualification.subjects
-          .map((subject) => {
-            const alias = input.aliases.get(subject.subject) ?? subject.subject;
-            return `**${alias} ${subject.games.toString()}/${minimumGames.toString()} games**`;
-          })
-          .join(" · ")}`;
-  return [
+      ? (input.criteria?.legs.map((leg) =>
+          legLine({
+            leg,
+            current: undefined,
+            subjectAlias: input.aliases.get(leg.subject) ?? leg.subject,
+            kind: input.kind,
+          }),
+        ) ?? [])
+      : input.evaluation.legs.map((result) =>
+          legLine({
+            leg: result.leg,
+            current:
+              input.kind === "open" || input.kind === "reminder"
+                ? undefined
+                : result.current,
+            subjectAlias:
+              input.aliases.get(result.leg.subject) ?? result.leg.subject,
+            kind: input.kind,
+            passed: result.passed,
+          }),
+        );
+  const sections = [
     deliveryTitle({
       kind: input.kind,
       marketState: input.marketState,
       yesResult: input.yesResult,
-      catchup: input.catchup,
       voidReason: input.voidReason,
     }),
-    ...(isVoidedSettlement ? [weeklyParlayVoidCopy(input.voidReason)] : []),
-    `Period: **${input.periodKey}** · ${(input.yesProbabilityBps / 100).toFixed(1)}% YES`,
-    ...legs,
-    qualification ?? "",
-    qualificationProgress ?? "",
-    `**${formatInteger(input.bettorCount)} ${countLabel(input.bettorCount, "bettor")} · ${formatInteger(input.totalStaked)} BB staked**`,
+    settlementLines(input).join("\n"),
+    legs.length === 0 ? "" : ["**Conditions**", ...legs].join("\n"),
+    qualificationLines({
+      kind: input.kind,
+      criteria: input.criteria,
+      evaluation: input.evaluation,
+      aliases: input.aliases,
+    }).join("\n"),
+    input.marketState === "voided" && input.kind === "settlement"
+      ? ""
+      : `**Bets:** ${formatInteger(input.bettorCount)} ${countLabel(input.bettorCount, "bettor")} · ${formatInteger(input.totalStaked)} BB staked`,
     deliveryTimeCopy({
       kind: input.kind,
       bettingClosesAt: input.bettingClosesAt,
       scoringEndsAt: input.scoringEndsAt,
       scoringStartsAt: input.scoringStartsAt,
-      catchup: input.catchup,
     }),
-  ]
-    .filter((line) => line.length > 0)
-    .join("\n");
+  ];
+  return sections.filter((section) => section.length > 0).join("\n\n");
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord-copy.ts
@@ -96,8 +96,10 @@ export function legLine(input: {
   subjectAlias: string;
   kind?: WeeklyParlayDiscordKind;
   passed?: boolean;
+  irreversiblyPassed?: boolean;
 }): string {
   const kind = input.kind ?? "open";
+  const progressPassed = input.irreversiblyPassed === true;
   const status =
     input.current === undefined
       ? "•"
@@ -105,7 +107,7 @@ export function legLine(input: {
         ? input.passed === true
           ? "✅"
           : "❌"
-        : input.passed === true
+        : progressPassed
           ? "✅"
           : "⏳";
   const progress =
@@ -290,6 +292,7 @@ export function weeklyParlayDeliveryContent(input: {
               input.aliases.get(result.leg.subject) ?? result.leg.subject,
             kind: input.kind,
             passed: result.passed,
+            irreversiblyPassed: result.irreversiblyPassed,
           }),
         );
   const sections = [

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -30,6 +30,7 @@ import {
 } from "#src/metrics/betting-weekly-parlay.ts";
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 
 export function weeklyParlaySettlementActionKey(marketId: number): string {
   return `settlement:${marketId.toString()}`;
@@ -50,6 +51,69 @@ function stableNonce(
 }
 
 const MENTIONS_PER_MESSAGE = 20;
+const DISCORD_SAFE_MESSAGE_LENGTH = 1900;
+
+function mentionChunks(mentionIds: readonly string[]): string[][] {
+  return Array.from(
+    {
+      length: Math.max(1, Math.ceil(mentionIds.length / MENTIONS_PER_MESSAGE)),
+    },
+    (_, index) =>
+      mentionIds.slice(
+        index * MENTIONS_PER_MESSAGE,
+        (index + 1) * MENTIONS_PER_MESSAGE,
+      ),
+  );
+}
+
+function weeklyParlayMessageOptions(input: {
+  marketId: number;
+  actionKey: string;
+  kind: WeeklyParlayDiscordKind;
+  content: string;
+  mentionIds: readonly string[];
+}): MessageCreateOptions[] {
+  const mentions = mentionChunks(input.mentionIds);
+  const firstMentionIds = mentions[0] ?? [];
+  const mentionPrefix = firstMentionIds.map((id) => `<@${id}>`).join(" ");
+  const contentMaxLength =
+    DISCORD_SAFE_MESSAGE_LENGTH -
+    (mentionPrefix.length > 0 ? mentionPrefix.length + 1 : 0);
+  if (contentMaxLength <= 0) {
+    throw new Error(
+      "Weekly parlay mentions leave no room for message content.",
+    );
+  }
+  const contentChunks = splitMessageIntoChunks(input.content, contentMaxLength);
+  const options: MessageCreateOptions[] = contentChunks.map(
+    (contentChunk, messageIndex) => ({
+      content:
+        messageIndex === 0 && mentionPrefix.length > 0
+          ? `${mentionPrefix}\n${contentChunk}`
+          : contentChunk,
+      allowedMentions: {
+        users: messageIndex === 0 ? firstMentionIds : [],
+      },
+      nonce: stableNonce(input.marketId, input.actionKey, messageIndex),
+      enforceNonce: true,
+      components:
+        messageIndex === 0
+          ? weeklyParlayButtons(input.kind, input.marketId)
+          : [],
+    }),
+  );
+  for (const [chunkIndex, chunk] of mentions.slice(1).entries()) {
+    const messageIndex = options.length + chunkIndex;
+    options.push({
+      content: `Weekly Bryan Bucks parlay — additional mentions: ${chunk.map((id) => `<@${id}>`).join(" ")}`,
+      allowedMentions: { users: chunk },
+      nonce: stableNonce(input.marketId, input.actionKey, messageIndex),
+      enforceNonce: true,
+      components: [],
+    });
+  }
+  return options;
+}
 
 export function weeklyParlayButtons(
   kind: WeeklyParlayDiscordKind,
@@ -166,16 +230,15 @@ export async function deliverWeeklyParlayDiscord(
   }
   const isVoidedSettlement =
     input.kind === "settlement" && market.marketState === "voided";
-  const includeFrozenSubjects =
-    !isVoidedSettlement || market.voidReason === "operator_cancelled";
-  const subjects = includeFrozenSubjects
-    ? WeeklyParlaySubjectsSchema.parse(JSON.parse(market.definition.subjects))
-    : [];
-  const criteria = isVoidedSettlement
-    ? undefined
-    : WeeklyParlayDefinitionCriteriaSchema.parse(
-        JSON.parse(market.definition.criteria),
-      );
+  const subjects = WeeklyParlaySubjectsSchema.parse(
+    JSON.parse(market.definition.subjects),
+  );
+  const criteria =
+    isVoidedSettlement && market.voidReason !== "operator_cancelled"
+      ? undefined
+      : WeeklyParlayDefinitionCriteriaSchema.parse(
+          JSON.parse(market.definition.criteria),
+        );
   const evaluation =
     criteria === undefined
       ? undefined
@@ -193,7 +256,9 @@ export async function deliverWeeklyParlayDiscord(
     subjects.map((subject) => [subject.key, subject.alias]),
   );
   const bettorIds = market.bets.map((bet) => bet.bucksAccount.discordId);
-  const mentionIds = [...new Set(bettorIds)];
+  const mentionIds = [
+    ...new Set([...subjects.map((subject) => subject.discordId), ...bettorIds]),
+  ];
   const totalStaked = market.bets.reduce((total, bet) => total + bet.stake, 0);
   const content = weeklyParlayDeliveryContent({
     kind: input.kind,
@@ -209,31 +274,13 @@ export async function deliverWeeklyParlayDiscord(
     bettorCount: market.bets.length,
     totalStaked,
   });
-  const mentionChunks = Array.from(
-    {
-      length: Math.max(1, Math.ceil(mentionIds.length / MENTIONS_PER_MESSAGE)),
-    },
-    (_, index) =>
-      mentionIds.slice(
-        index * MENTIONS_PER_MESSAGE,
-        (index + 1) * MENTIONS_PER_MESSAGE,
-      ),
-  );
-  const options: MessageCreateOptions[] = mentionChunks.map(
-    (chunk, messageIndex) => ({
-      content:
-        messageIndex === 0
-          ? [chunk.map((id) => `<@${id}>`).join(" "), content]
-              .filter((line) => line.length > 0)
-              .join("\n")
-          : `Weekly Bryan Bucks parlay — additional mentions: ${chunk.map((id) => `<@${id}>`).join(" ")}`,
-      allowedMentions: { users: chunk },
-      nonce: stableNonce(market.id, input.actionKey, messageIndex),
-      enforceNonce: true,
-      components:
-        messageIndex === 0 ? weeklyParlayButtons(input.kind, market.id) : [],
-    }),
-  );
+  const options = weeklyParlayMessageOptions({
+    marketId: market.id,
+    actionKey: input.actionKey,
+    kind: input.kind,
+    content,
+    mentionIds,
+  });
   await prismaClient.bucksWeeklyParlayDelivery.upsert({
     where: {
       marketId_actionKey: { marketId: market.id, actionKey: input.actionKey },

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -51,7 +51,7 @@ function stableNonce(
 }
 
 const MENTIONS_PER_MESSAGE = 20;
-const DISCORD_SAFE_MESSAGE_LENGTH = 1900;
+export const WEEKLY_PARLAY_DISCORD_CONTENT_MAX_LENGTH = 1400;
 
 function mentionChunks(mentionIds: readonly string[]): string[][] {
   return Array.from(
@@ -76,15 +76,10 @@ function weeklyParlayMessageOptions(input: {
   const mentions = mentionChunks(input.mentionIds);
   const firstMentionIds = mentions[0] ?? [];
   const mentionPrefix = firstMentionIds.map((id) => `<@${id}>`).join(" ");
-  const contentMaxLength =
-    DISCORD_SAFE_MESSAGE_LENGTH -
-    (mentionPrefix.length > 0 ? mentionPrefix.length + 1 : 0);
-  if (contentMaxLength <= 0) {
-    throw new Error(
-      "Weekly parlay mentions leave no room for message content.",
-    );
-  }
-  const contentChunks = splitMessageIntoChunks(input.content, contentMaxLength);
+  const contentChunks = splitMessageIntoChunks(
+    input.content,
+    WEEKLY_PARLAY_DISCORD_CONTENT_MAX_LENGTH,
+  );
   const options: MessageCreateOptions[] = contentChunks.map(
     (contentChunk, messageIndex) => ({
       content:
@@ -230,17 +225,19 @@ export async function deliverWeeklyParlayDiscord(
   }
   const isVoidedSettlement =
     input.kind === "settlement" && market.marketState === "voided";
+  const isOperatorCancelledSettlement =
+    isVoidedSettlement && market.voidReason === "operator_cancelled";
   const subjects = WeeklyParlaySubjectsSchema.parse(
     JSON.parse(market.definition.subjects),
   );
   const criteria =
-    isVoidedSettlement && market.voidReason !== "operator_cancelled"
+    isVoidedSettlement && !isOperatorCancelledSettlement
       ? undefined
       : WeeklyParlayDefinitionCriteriaSchema.parse(
           JSON.parse(market.definition.criteria),
         );
   const evaluation =
-    criteria === undefined
+    criteria === undefined || isOperatorCancelledSettlement
       ? undefined
       : evaluateWeeklyParlay(
           criteria,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -30,7 +30,6 @@ import {
 } from "#src/metrics/betting-weekly-parlay.ts";
 import { logBucksTransition } from "#src/betting/transition-log.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
-import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 
 export function weeklyParlaySettlementActionKey(marketId: number): string {
   return `settlement:${marketId.toString()}`;
@@ -124,11 +123,7 @@ export async function deliverWeeklyParlayDiscord(
         select: {
           subjects: true,
           criteria: true,
-          yesProbabilityBps: true,
-          openAt: true,
-          bettingClosesAt: true,
           scoringStartsAt: true,
-          scoringEndsAt: true,
           contributions: { select: { snapshot: true } },
         },
       },
@@ -198,25 +193,13 @@ export async function deliverWeeklyParlayDiscord(
     subjects.map((subject) => [subject.key, subject.alias]),
   );
   const bettorIds = market.bets.map((bet) => bet.bucksAccount.discordId);
-  const mentionIds = [
-    ...new Set([...subjects.map((subject) => subject.discordId), ...bettorIds]),
-  ];
+  const mentionIds = [...new Set(bettorIds)];
   const totalStaked = market.bets.reduce((total, bet) => total + bet.stake, 0);
-  const catchup = isWeeklyParlayCatchupTimeline({
-    periodKey: market.periodKey,
-    openAt: market.definition.openAt,
-    bettingClosesAt: market.definition.bettingClosesAt,
-    scoringStartsAt: market.definition.scoringStartsAt,
-    scoringEndsAt: market.definition.scoringEndsAt,
-  });
   const content = weeklyParlayDeliveryContent({
     kind: input.kind,
     marketState: market.marketState,
     yesResult: market.yesResult,
     voidReason: market.voidReason,
-    catchup,
-    periodKey: market.periodKey,
-    yesProbabilityBps: market.definition.yesProbabilityBps,
     bettingClosesAt: market.bettingClosesAt,
     scoringStartsAt: market.definition.scoringStartsAt,
     scoringEndsAt: market.scoringEndsAt,
@@ -243,7 +226,7 @@ export async function deliverWeeklyParlayDiscord(
           ? [chunk.map((id) => `<@${id}>`).join(" "), content]
               .filter((line) => line.length > 0)
               .join("\n")
-          : `Weekly parlay update mentions (continued): ${chunk.map((id) => `<@${id}>`).join(" ")}`,
+          : `Weekly Bryan Bucks parlay — additional mentions: ${chunk.map((id) => `<@${id}>`).join(" ")}`,
       allowedMentions: { users: chunk },
       nonce: stableNonce(market.id, input.actionKey, messageIndex),
       enforceNonce: true,

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-discord.ts
@@ -66,7 +66,7 @@ function mentionChunks(mentionIds: readonly string[]): string[][] {
   );
 }
 
-function weeklyParlayMessageOptions(input: {
+export function weeklyParlayMessageOptions(input: {
   marketId: number;
   actionKey: string;
   kind: WeeklyParlayDiscordKind;

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -7,7 +7,11 @@ import {
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 import { weeklyParlayDeliveryContent } from "#src/betting/weekly-parlay-discord-copy.ts";
-import { weeklyParlayButtons } from "#src/betting/weekly-parlay-discord.ts";
+import {
+  weeklyParlayButtons,
+  WEEKLY_PARLAY_DISCORD_CONTENT_MAX_LENGTH,
+} from "#src/betting/weekly-parlay-discord.ts";
+import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
@@ -121,8 +125,16 @@ async function editWeeklyParlayMessage(
       bettorCount: relevantBets.length,
       totalStaked,
     });
+    const contentChunks = splitMessageIntoChunks(
+      content,
+      WEEKLY_PARLAY_DISCORD_CONTENT_MAX_LENGTH,
+    );
     const marketIdentifier = `weekly:${marketId.toString()}`;
-    for (const ref of refs) {
+    for (const [index, ref] of refs.entries()) {
+      const contentChunk = contentChunks[index];
+      if (contentChunk === undefined) {
+        continue;
+      }
       try {
         await observeBucksDelivery(
           {
@@ -133,7 +145,7 @@ async function editWeeklyParlayMessage(
           },
           () =>
             editor(ref.channelId, ref.messageId, {
-              content,
+              content: contentChunk,
               allowedMentions: { parse: [] },
               components:
                 mode === "open" ? weeklyParlayButtons("open", marketId) : [],

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -1,20 +1,13 @@
 import * as Sentry from "@sentry/bun";
-import { BucksMessageRefsSchema, formatInteger } from "@scout-for-lol/data";
+import { BucksMessageRefsSchema } from "@scout-for-lol/data";
 import type { MessageEditOptions } from "discord.js";
 import {
   WeeklyParlayDefinitionCriteriaSchema,
   WeeklyParlaySubjectsSchema,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
-import {
-  countLabel,
-  deliveryTimeCopy,
-  deliveryTitle,
-  legLine,
-  weeklyParlayQualificationCopy,
-} from "#src/betting/weekly-parlay-discord-copy.ts";
+import { weeklyParlayDeliveryContent } from "#src/betting/weekly-parlay-discord-copy.ts";
 import { weeklyParlayButtons } from "#src/betting/weekly-parlay-discord.ts";
-import { isWeeklyParlayCatchupTimeline } from "#src/betting/weekly-parlay-period.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
@@ -55,16 +48,12 @@ async function editWeeklyParlayMessage(
         messageRefs: true,
         marketState: true,
         voidReason: true,
-        periodKey: true,
         bettingClosesAt: true,
         scoringEndsAt: true,
         definition: {
           select: {
             subjects: true,
             criteria: true,
-            yesProbabilityBps: true,
-            openAt: true,
-            bettingClosesAt: true,
             scoringStartsAt: true,
             scoringEndsAt: true,
           },
@@ -103,23 +92,15 @@ async function editWeeklyParlayMessage(
     const subjects = WeeklyParlaySubjectsSchema.parse(
       JSON.parse(market.definition.subjects),
     );
-    const criteria = WeeklyParlayDefinitionCriteriaSchema.parse(
-      JSON.parse(market.definition.criteria),
-    );
+    const criteria =
+      mode === "open"
+        ? WeeklyParlayDefinitionCriteriaSchema.parse(
+            JSON.parse(market.definition.criteria),
+          )
+        : undefined;
     const aliases = new Map(
       subjects.map((subject) => [subject.key, subject.alias]),
     );
-    const catchup = isWeeklyParlayCatchupTimeline({
-      periodKey: market.periodKey,
-      openAt: market.definition.openAt,
-      bettingClosesAt: market.definition.bettingClosesAt,
-      scoringStartsAt: market.definition.scoringStartsAt,
-      scoringEndsAt: market.definition.scoringEndsAt,
-    });
-    const legs = criteria.legs.map((leg) =>
-      legLine(leg, undefined, aliases.get(leg.subject) ?? leg.subject),
-    );
-    const qualification = weeklyParlayQualificationCopy(criteria) ?? "";
     const relevantBets = market.bets.filter((bet) =>
       mode === "open"
         ? bet.betOutcome === "pending"
@@ -129,45 +110,20 @@ async function editWeeklyParlayMessage(
       (total, bet) => total + bet.stake,
       0,
     );
-    const content =
-      mode === "open"
-        ? [
-            deliveryTitle({
-              kind: "open",
-              marketState: market.marketState,
-              yesResult: null,
-              catchup,
-            }),
-            `Period: **${market.periodKey}** · ${(market.definition.yesProbabilityBps / 100).toFixed(1)}% YES`,
-            ...legs,
-            qualification,
-            `**${formatInteger(relevantBets.length)} ${countLabel(relevantBets.length, "bettor")} · ${formatInteger(totalStaked)} BB staked**`,
-            deliveryTimeCopy({
-              kind: "open",
-              bettingClosesAt: market.bettingClosesAt,
-              scoringEndsAt: market.scoringEndsAt,
-              scoringStartsAt: market.definition.scoringStartsAt,
-              catchup,
-            }),
-          ]
-            .filter((line) => line.length > 0)
-            .join("\n")
-        : [
-            deliveryTitle({
-              kind: "settlement",
-              marketState: market.marketState,
-              yesResult: null,
-              catchup,
-              voidReason: market.voidReason,
-            }),
-            `Period: **${market.periodKey}**`,
-            ...legs,
-            qualification,
-            `**${formatInteger(relevantBets.length)} ${countLabel(relevantBets.length, "bettor")} refunded · ${formatInteger(totalStaked)} BB returned**`,
-            "This market was cancelled by an operator.",
-          ]
-            .filter((line) => line.length > 0)
-            .join("\n");
+    const content = weeklyParlayDeliveryContent({
+      kind: mode === "open" ? "open" : "settlement",
+      marketState: market.marketState,
+      yesResult: null,
+      voidReason: market.voidReason,
+      bettingClosesAt: market.bettingClosesAt,
+      scoringStartsAt: market.definition.scoringStartsAt,
+      scoringEndsAt: market.scoringEndsAt,
+      criteria,
+      evaluation: undefined,
+      aliases,
+      bettorCount: relevantBets.length,
+      totalStaked,
+    });
     const marketIdentifier = `weekly:${marketId.toString()}`;
     for (const ref of refs) {
       try {

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -92,12 +92,9 @@ async function editWeeklyParlayMessage(
     const subjects = WeeklyParlaySubjectsSchema.parse(
       JSON.parse(market.definition.subjects),
     );
-    const criteria =
-      mode === "open"
-        ? WeeklyParlayDefinitionCriteriaSchema.parse(
-            JSON.parse(market.definition.criteria),
-          )
-        : undefined;
+    const criteria = WeeklyParlayDefinitionCriteriaSchema.parse(
+      JSON.parse(market.definition.criteria),
+    );
     const aliases = new Map(
       subjects.map((subject) => [subject.key, subject.alias]),
     );

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -297,14 +297,6 @@ async function editWeeklyParlayMessage(
       where: { id: marketId },
       data: { messageRefs: JSON.stringify(updatedRefs) },
     });
-    await prismaClient.bucksWeeklyParlayDelivery.updateMany({
-      where: {
-        marketId,
-        kind: "open",
-        deliveryState: "delivered",
-      },
-      data: { messageRefs: JSON.stringify(updatedRefs) },
-    });
   });
 }
 

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-refresh.ts
@@ -1,20 +1,24 @@
 import * as Sentry from "@sentry/bun";
-import { BucksMessageRefsSchema } from "@scout-for-lol/data";
-import type { MessageEditOptions } from "discord.js";
+import {
+  BucksMessageRefsSchema,
+  DiscordGuildIdSchema,
+  type DiscordChannelId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import type { MessageCreateOptions, MessageEditOptions } from "discord.js";
 import {
   WeeklyParlayDefinitionCriteriaSchema,
   WeeklyParlaySubjectsSchema,
 } from "#src/betting/weekly-parlay-criteria.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 import { weeklyParlayDeliveryContent } from "#src/betting/weekly-parlay-discord-copy.ts";
-import {
-  weeklyParlayButtons,
-  WEEKLY_PARLAY_DISCORD_CONTENT_MAX_LENGTH,
-} from "#src/betting/weekly-parlay-discord.ts";
-import { splitMessageIntoChunks } from "#src/discord/utils/message.ts";
+import { weeklyParlayMessageOptions } from "#src/betting/weekly-parlay-discord.ts";
+import type { WeeklyParlayDiscordSender } from "#src/betting/weekly-parlay-discord.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { client } from "#src/discord/client.ts";
+import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
+import { send } from "#src/league/discord/channel.ts";
 import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("betting-weekly-parlay-refresh");
@@ -24,6 +28,52 @@ export type WeeklyParlayMessageEditor = (
   messageId: string,
   options: MessageEditOptions,
 ) => Promise<void>;
+
+type WeeklyParlayMessageRef = { channelId: string; messageId: string };
+
+type WeeklyParlayMessageDependencies = {
+  sender: WeeklyParlayDiscordSender;
+  deleter: (channelId: string, messageId: string) => Promise<void>;
+};
+
+type WeeklyParlayMessageDelivery = WeeklyParlayMessageDependencies & {
+  editor: WeeklyParlayMessageEditor;
+};
+
+type ReconcileWeeklyParlayMessageArgs = {
+  ref: WeeklyParlayMessageRef | undefined;
+  messageOptions: MessageCreateOptions | undefined;
+  marketIdentifier: string;
+  serverId: string;
+  editor: WeeklyParlayMessageEditor;
+  dependencies: WeeklyParlayMessageDependencies;
+};
+
+async function sendDiscordMessage(
+  options: MessageCreateOptions,
+  channelId: DiscordChannelId,
+  serverId: DiscordGuildId,
+): Promise<{ channelId: string; id: string }> {
+  const message = await send(
+    options,
+    channelId,
+    DiscordGuildIdSchema.parse(serverId),
+  );
+  return { channelId: message.channelId, id: message.id };
+}
+
+async function deleteDiscordMessage(
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  const channel = await client.channels.fetch(channelId);
+  if (channel?.isTextBased() !== true) {
+    throw new Error(
+      `Weekly parlay channel ${channelId} is unavailable or not text based`,
+    );
+  }
+  await channel.messages.delete(messageId);
+}
 
 async function editDiscordMessage(
   channelId: string,
@@ -39,16 +89,97 @@ async function editDiscordMessage(
   await channel.messages.edit(messageId, options);
 }
 
+async function reconcileWeeklyParlayMessage({
+  ref,
+  messageOptions,
+  marketIdentifier,
+  serverId,
+  editor,
+  dependencies,
+}: ReconcileWeeklyParlayMessageArgs): Promise<
+  WeeklyParlayMessageRef | undefined
+> {
+  if (messageOptions === undefined) {
+    if (ref === undefined) {
+      return undefined;
+    }
+    try {
+      await dependencies.deleter(ref.channelId, ref.messageId);
+      return undefined;
+    } catch (error) {
+      logger.warn(
+        `⚠️ Could not remove stale weekly Bryan Bucks parlay message ${ref.messageId} for ${marketIdentifier}:`,
+        error,
+      );
+      return ref;
+    }
+  }
+
+  const content = messageOptions.content;
+  if (content === undefined) {
+    throw new Error("Weekly parlay message content is required for refresh");
+  }
+  const editOptions: MessageEditOptions = { content };
+  if (messageOptions.allowedMentions !== undefined) {
+    editOptions.allowedMentions = messageOptions.allowedMentions;
+  }
+  if (messageOptions.components !== undefined) {
+    editOptions.components = messageOptions.components;
+  }
+  try {
+    if (ref === undefined) {
+      const message = await observeBucksDelivery(
+        {
+          surface: "weekly_parlay",
+          operation: "send",
+          matchId: marketIdentifier,
+          channelId: COMMON_DENOMINATOR_CHANNEL_ID,
+        },
+        () =>
+          dependencies.sender(
+            messageOptions,
+            COMMON_DENOMINATOR_CHANNEL_ID,
+            DiscordGuildIdSchema.parse(serverId),
+          ),
+      );
+      return { channelId: message.channelId, messageId: message.id };
+    }
+    await observeBucksDelivery(
+      {
+        surface: "weekly_parlay",
+        operation: "edit",
+        matchId: marketIdentifier,
+        channelId: ref.channelId,
+      },
+      () => editor(ref.channelId, ref.messageId, editOptions),
+    );
+    return ref;
+  } catch (error) {
+    logger.warn(
+      `⚠️ Could not refresh weekly Bryan Bucks parlay message ${ref?.messageId ?? "new chunk"} for ${marketIdentifier}:`,
+      error,
+    );
+    return ref;
+  }
+}
+
+const defaultWeeklyParlayMessageDependencies: WeeklyParlayMessageDependencies =
+  {
+    sender: sendDiscordMessage,
+    deleter: deleteDiscordMessage,
+  };
+
 async function editWeeklyParlayMessage(
   marketId: number,
   mode: "open" | "operator_cancelled",
   prismaClient: ExtendedPrismaClient,
-  editor: WeeklyParlayMessageEditor,
+  delivery: WeeklyParlayMessageDelivery,
 ): Promise<void> {
   await runSerialized(`weekly:${marketId.toString()}`, async () => {
     const market = await prismaClient.bucksWeeklyParlayMarket.findUnique({
       where: { id: marketId },
       select: {
+        serverId: true,
         messageRefs: true,
         marketState: true,
         voidReason: true,
@@ -63,7 +194,11 @@ async function editWeeklyParlayMessage(
           },
         },
         bets: {
-          select: { stake: true, betOutcome: true },
+          select: {
+            stake: true,
+            betOutcome: true,
+            bucksAccount: { select: { discordId: true } },
+          },
           orderBy: { id: "asc" },
         },
         deliveries: {
@@ -125,39 +260,51 @@ async function editWeeklyParlayMessage(
       bettorCount: relevantBets.length,
       totalStaked,
     });
-    const contentChunks = splitMessageIntoChunks(
+    const bettorIds = relevantBets.map((bet) => bet.bucksAccount.discordId);
+    const mentionIds = [
+      ...new Set([
+        ...subjects.map((subject) => subject.discordId),
+        ...bettorIds,
+      ]),
+    ];
+    const messageOptions = weeklyParlayMessageOptions({
+      marketId,
+      actionKey: `refresh:${mode}`,
+      kind: mode === "open" ? "open" : "settlement",
       content,
-      WEEKLY_PARLAY_DISCORD_CONTENT_MAX_LENGTH,
-    );
+      mentionIds,
+    });
     const marketIdentifier = `weekly:${marketId.toString()}`;
-    for (const [index, ref] of refs.entries()) {
-      const contentChunk = contentChunks[index];
-      if (contentChunk === undefined) {
-        continue;
-      }
-      try {
-        await observeBucksDelivery(
-          {
-            surface: "weekly_parlay",
-            operation: "edit",
-            matchId: marketIdentifier,
-            channelId: ref.channelId,
-          },
-          () =>
-            editor(ref.channelId, ref.messageId, {
-              content: contentChunk,
-              allowedMentions: { parse: [] },
-              components:
-                mode === "open" ? weeklyParlayButtons("open", marketId) : [],
-            }),
-        );
-      } catch (error) {
-        logger.warn(
-          `⚠️ Could not refresh weekly Bryan Bucks parlay message ${ref.messageId} for ${marketIdentifier}:`,
-          error,
-        );
+    const updatedRefs: WeeklyParlayMessageRef[] = [];
+    const operationCount = Math.max(refs.length, messageOptions.length);
+    for (const index of Array.from(
+      { length: operationCount },
+      (_, value) => value,
+    )) {
+      const updatedRef = await reconcileWeeklyParlayMessage({
+        ref: refs[index],
+        messageOptions: messageOptions[index],
+        marketIdentifier,
+        serverId: market.serverId,
+        editor: delivery.editor,
+        dependencies: delivery,
+      });
+      if (updatedRef !== undefined) {
+        updatedRefs.push(updatedRef);
       }
     }
+    await prismaClient.bucksWeeklyParlayMarket.update({
+      where: { id: marketId },
+      data: { messageRefs: JSON.stringify(updatedRefs) },
+    });
+    await prismaClient.bucksWeeklyParlayDelivery.updateMany({
+      where: {
+        marketId,
+        kind: "open",
+        deliveryState: "delivered",
+      },
+      data: { messageRefs: JSON.stringify(updatedRefs) },
+    });
   });
 }
 
@@ -173,9 +320,13 @@ export async function refreshWeeklyParlayMessage(
   marketId: number,
   prismaClient: ExtendedPrismaClient = prisma,
   editor: WeeklyParlayMessageEditor = editDiscordMessage,
+  dependencies: WeeklyParlayMessageDependencies = defaultWeeklyParlayMessageDependencies,
 ): Promise<void> {
   try {
-    await editWeeklyParlayMessage(marketId, "open", prismaClient, editor);
+    await editWeeklyParlayMessage(marketId, "open", prismaClient, {
+      editor,
+      ...dependencies,
+    });
   } catch (error) {
     logger.error(
       `❌ Could not prepare weekly Bryan Bucks parlay refresh for market ${marketId.toString()}:`,
@@ -193,13 +344,14 @@ export async function cancelWeeklyParlayMessage(
   marketId: number,
   prismaClient: ExtendedPrismaClient = prisma,
   editor: WeeklyParlayMessageEditor = editDiscordMessage,
+  dependencies: WeeklyParlayMessageDependencies = defaultWeeklyParlayMessageDependencies,
 ): Promise<void> {
   try {
     await editWeeklyParlayMessage(
       marketId,
       "operator_cancelled",
       prismaClient,
-      editor,
+      { editor, ...dependencies },
     );
   } catch (error) {
     logger.error(

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -712,6 +712,8 @@ describe("weekly parlay operator cancellation", () => {
       "Weekly Bryan Bucks parlay: CANCELLED — BETS REFUNDED",
     );
     expect(edits[0]?.[2].content).toContain("**Conditions**");
+    expect(edits[0]?.[2].content).toContain("• **jerred**");
+    expect(edits[0]?.[2].content).not.toContain("❌ **jerred**");
     expect(edits[0]?.[2].components).toEqual([]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -696,17 +696,21 @@ describe("weekly parlay operator cancellation", () => {
     ).toHaveLength(3);
     expect(ledger.reduce((total, entry) => total + entry.delta, 0)).toBe(0);
     expect(sent).toHaveLength(1);
-    expect(sent[0]?.content).toContain(`<@${featuredDiscordId}>`);
+    expect(sent[0]?.content).not.toContain(`<@${featuredDiscordId}>`);
     expect(sent[0]?.allowedMentions).toEqual({
-      users: [featuredDiscordId, BETTOR, ...otherBettors],
+      users: [BETTOR, ...otherBettors],
     });
-    expect(sent[0]?.content).toContain("cancelled and refunded");
-    expect(sent[0]?.content).toContain("every pending wager was refunded");
+    expect(sent[0]?.content).toContain(
+      "Weekly Bryan Bucks parlay: CANCELLED — BETS REFUNDED",
+    );
+    expect(sent[0]?.content).toContain("**Returned:** 3 bettors · 3 BB");
     expect(sent[0]?.components).toEqual([]);
     expect(edits).toHaveLength(2);
     expect(edits[0]?.[0]).toBe(originalRefs[0]?.channelId);
     expect(edits[0]?.[1]).toBe(originalRefs[0]?.messageId);
-    expect(edits[0]?.[2].content).toContain("cancelled and refunded");
+    expect(edits[0]?.[2].content).toContain(
+      "Weekly Bryan Bucks parlay: CANCELLED — BETS REFUNDED",
+    );
     expect(edits[0]?.[2].components).toEqual([]);
   });
 });
@@ -878,7 +882,7 @@ describe("weekly parlay version-two settlement", () => {
       },
     );
     expect(sent[0]?.content).toContain(
-      "Fewer than three eligible games were played",
+      "Not every featured player completed 3 eligible games",
     );
     expect(sent[0]?.components).toEqual([]);
   });
@@ -1343,13 +1347,17 @@ describe("weekly parlay Discord delivery", () => {
     expect(sent[0]?.content).toContain(
       `kills in one game as ${PARTICIPANT.championName}`,
     );
-    expect(sent[0]?.content).toContain("3 eligible games required per player");
+    expect(sent[0]?.content).toContain(
+      "Settlement requires **3 eligible games**",
+    );
     expect(sent[0]?.components).not.toEqual([]);
-    expect(sent[1]?.content).toContain("Qualification: **jerred 1/3 games**");
+    expect(sent[1]?.content).toContain(
+      "**Activity qualification:**\n• ⏳ **jerred** — 1/3 eligible games",
+    );
     expect(sent[1]?.components).toEqual([]);
   });
 
-  test("labels catch-up messages and renders their frozen betting and scoring clocks", async () => {
+  test("renders standard status and frozen betting and scoring clocks", async () => {
     const period = weeklyParlayPeriod(PERIOD_KEY);
     const market = await makeMarket({
       marketState: "publishing",
@@ -1378,11 +1386,14 @@ describe("weekly parlay Discord delivery", () => {
       ),
     ).resolves.toBe("sent");
     expect(sent[0]?.content).toContain(
-      "Catch-up weekly Bryan Bucks parlay is open",
+      "Weekly Bryan Bucks parlay: OPEN FOR BETTING",
     );
-    expect(sent[0]?.content).toContain("Betting closes <t:1787641200:F>");
-    expect(sent[0]?.content).toContain("Scoring runs <t:1787641200:F>");
-    expect(sent[0]?.content).toContain("through <t:1788112800:F>");
+    expect(sent[0]?.content).not.toContain("Catch-up");
+    expect(sent[0]?.content).toContain("**Betting closes:** <t:1787641200:F>");
+    expect(sent[0]?.content).toContain(
+      "**Scoring window:** <t:1787641200:F> → <t:1788112800:F>",
+    );
+    expect(sent[0]?.content).not.toContain("Settlement timing");
   });
 
   test("chunks and deduplicates private mention delivery with a stable nonce", async () => {
@@ -1430,7 +1441,7 @@ describe("weekly parlay Discord delivery", () => {
     ).resolves.toBe("sent");
     expect(sent).toHaveLength(2);
     expect(sent[0]?.content).toContain("at least **1 game**");
-    expect(sent[0]?.content).toContain("**25 bettors · 25 BB staked**");
+    expect(sent[0]?.content).toContain("**Bets:** 25 bettors · 25 BB staked");
     const mentioned = new Set(
       sent.flatMap((options) => options.allowedMentions?.users ?? []),
     );

--- a/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/weekly-parlay-runtime.integration.test.ts
@@ -696,9 +696,9 @@ describe("weekly parlay operator cancellation", () => {
     ).toHaveLength(3);
     expect(ledger.reduce((total, entry) => total + entry.delta, 0)).toBe(0);
     expect(sent).toHaveLength(1);
-    expect(sent[0]?.content).not.toContain(`<@${featuredDiscordId}>`);
+    expect(sent[0]?.content).toContain(`<@${featuredDiscordId}>`);
     expect(sent[0]?.allowedMentions).toEqual({
-      users: [BETTOR, ...otherBettors],
+      users: [featuredDiscordId, BETTOR, ...otherBettors],
     });
     expect(sent[0]?.content).toContain(
       "Weekly Bryan Bucks parlay: CANCELLED — BETS REFUNDED",
@@ -711,6 +711,7 @@ describe("weekly parlay operator cancellation", () => {
     expect(edits[0]?.[2].content).toContain(
       "Weekly Bryan Bucks parlay: CANCELLED — BETS REFUNDED",
     );
+    expect(edits[0]?.[2].content).toContain("**Conditions**");
     expect(edits[0]?.[2].components).toEqual([]);
   });
 });

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -94,8 +94,12 @@ Per eligible game, at most:
 
 Weekly parlays are separate from this per-game sequence. Scout publishes a new
 message for the market, the betting reminder, every progress update, and the
-settlement. Updates mention featured players and current bettors but expose
-only aggregate YES/NO totals—never a person's side or stake.
+settlement. Each message puts its current status or result first, then shows
+the conditions, activity qualification, bets, and relevant timing. A settlement
+explicitly says whether it resolved YES, resolved NO, or was voided and
+refunded. Public updates mention people who placed bets, not featured players
+who did not bet, and expose only aggregate YES/NO totals—never a person's side
+or stake.
 
 Bets never add messages. Placing, topping up, and cancelling all edit the
 market message in place. A successful `/bb transfer` is the exception: it adds

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -97,9 +97,9 @@ message for the market, the betting reminder, every progress update, and the
 settlement. Each message puts its current status or result first, then shows
 the conditions, activity qualification, bets, and relevant timing. A settlement
 explicitly says whether it resolved YES, resolved NO, or was voided and
-refunded. Public updates mention people who placed bets, not featured players
-who did not bet, and expose only aggregate YES/NO totals—never a person's side
-or stake.
+refunded. Public updates mention the frozen featured players and people who
+placed bets, with duplicates removed. They expose only aggregate YES/NO totals—
+never a person's side or stake.
 
 Bets never add messages. Placing, topping up, and cancelling all edit the
 market message in place. A successful `/bb transfer` is the exception: it adds

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -95,7 +95,7 @@ Per eligible game, at most:
 Weekly parlays are separate from this per-game sequence. Scout publishes a new
 message for the market, the betting reminder, every progress update, and the
 settlement. Each message puts its current status or result first, then shows
-the conditions, activity qualification, bets, and relevant timing. A settlement
+applicable conditions, activity qualification, bets, and relevant timing. A settlement
 explicitly says whether it resolved YES, resolved NO, or was voided and
 refunded. Public updates mention the frozen featured players and people who
 placed bets, with duplicates removed. They expose only aggregate YES/NO totals—

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -95,9 +95,9 @@ Per eligible game, at most:
 Weekly parlays are separate from this per-game sequence. Scout publishes a new
 message for the market, the betting reminder, every progress update, and the
 settlement. Each message puts its current status or result first, then shows
-applicable conditions, activity qualification, bets, and relevant timing. A settlement
-explicitly says whether it resolved YES, resolved NO, or was voided and
-refunded. Public updates mention the frozen featured players and people who
+applicable conditions, activity qualification, bets, and relevant timing.
+Settlements explicitly say whether they resolved YES, resolved NO, or were
+voided and refunded. Public updates mention the frozen featured players and people who
 placed bets, with duplicates removed. They expose only aggregate YES/NO totals—
 never a person's side or stake.
 


### PR DESCRIPTION
Why

Weekly parlay messages did not make the outcome, audience, and settlement details immediately clear.

What

- Put the weekly-parlay status and resolved result first.
- Simplify conditions and activity qualification copy.
- Remove catch-up labels, week metadata, historical pricing estimates, generic condition text, and settlement timing details from messages.
- Mention only bettors in public updates; keep featured players in the condition text.
- Keep refund details only for voided or cancelled markets.
- Reuse the shared copy for Discord delivery, refreshes, and the open-market view.

Verification

- `bun run test -- src/betting/weekly-parlay-discord-copy.test.ts src/betting/weekly-parlay-runtime.integration.test.ts` — 43 passed.
- `bun run test -- src/betting/weekly-parlay-runtime.integration.test.ts` — 42 passed.
- `bunx turbo run typecheck --filter=@scout-for-lol/backend` — passed.
- `bunx turbo run lint --filter=@scout-for-lol/backend` — passed with 0 errors; existing duplication warnings remain.
- Focused ESLint, Prettier, staged pre-commit checks, and `git diff --check` — passed.
- Live Discord/BETA delivery was not run.