### PR TITLE
fix(temporal): cap weekly Glitter context spend affordably

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -110,8 +110,25 @@ request digest rather than by run, so a local run reuses everything a production
 run already paid for. Pin `--snapshot-id`/`--snapshot-sha256` to reuse the most
 cache; omit both to read the latest verified snapshot.
 
-The weekly schedule passes a $40 uncached-cost kill switch. Operator
-invocations that omit `maxEstimatedCostUsd` still default to $10. A
+The weekly schedule passes a $1 uncached-cost kill switch. Extraction and
+synthesis use Luna so one bounded generation reservation can fit under that
+cap while retaining the existing semantic retries and completion-token
+headroom. Budget exhaustion is expected bounded progress: exact current v3
+request artifacts remain available to later weekly runs, but no PR is opened
+until one run completes. Older or legacy-key artifacts are not reused unless
+their current request hash is an exact match.
+
+Each synthesis request is also capped at 600,000 serialized UTF-8 bytes, whose
+full three-attempt Luna reservation remains below $1. If all monthly summaries
+do not fit, generation deterministically omits the oldest summaries until the
+request fits, then omits the oldest direct messages while retaining at least the
+newest 30 required by the response contract. An oversized invalid repair output
+may be omitted while its validation error remains. Cards record the bounded
+strategy, actual evidence date range, and omitted chunk/message counts. If the
+reviewed card plus that minimum evidence still cannot fit, that person is
+reported as a non-retryable evidence failure instead of retrying the activity.
+
+Operator invocations that omit `maxEstimatedCostUsd` still default to $10. A
 preflight estimate, per-call authorization, and post-call ceiling enforce
 the cap. A completion that returns without usage data fails non-retryably
 rather than risk re-charging.

--- a/packages/glitter-context/python/validate_context.py
+++ b/packages/glitter-context/python/validate_context.py
@@ -192,8 +192,14 @@ class EvidenceCoverage(BaseModel):
     summarized_messages: int = Field(ge=0)
     chunks: int = Field(ge=0)
     direct_recent_messages: int = Field(ge=0)
+    omitted_summarized_messages: int = Field(default=0, ge=0)
+    omitted_chunks: int = Field(default=0, ge=0)
+    omitted_direct_recent_messages: int = Field(default=0, ge=0)
     date_range: StyleDateRange
-    strategy: Literal["all-safe-monthly-chunks-plus-latest-500"]
+    strategy: Literal[
+        "all-safe-monthly-chunks-plus-latest-500",
+        "bounded-safe-monthly-chunks-plus-latest-direct",
+    ]
 
 
 class StyleCardCoverageV2(BaseModel):

--- a/packages/glitter-context/schema/generation-state.schema.json
+++ b/packages/glitter-context/schema/generation-state.schema.json
@@ -22,6 +22,18 @@
     "relationshipRefreshedAt": {
       "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
     },
+    "relationshipEvaluationSnapshotChecksum": {
+      "oneOf": [
+        { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        { "type": "null" }
+      ]
+    },
+    "relationshipEvaluationCursor": {
+      "oneOf": [
+        { "type": "string", "pattern": "^\\d{17,20}$" },
+        { "type": "null" }
+      ]
+    },
     "people": {
       "type": "array",
       "items": {

--- a/packages/glitter-context/schema/style-card.schema.json
+++ b/packages/glitter-context/schema/style-card.schema.json
@@ -228,9 +228,27 @@
                   "type": "integer",
                   "minimum": 0
                 },
+                "omitted_summarized_messages": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
+                "omitted_chunks": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
+                "omitted_direct_recent_messages": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
                 "date_range": { "$ref": "#/$defs/dateRange" },
                 "strategy": {
-                  "const": "all-safe-monthly-chunks-plus-latest-500"
+                  "enum": [
+                    "all-safe-monthly-chunks-plus-latest-500",
+                    "bounded-safe-monthly-chunks-plus-latest-direct"
+                  ]
                 }
               }
             },

--- a/packages/glitter-context/src/schema.ts
+++ b/packages/glitter-context/src/schema.ts
@@ -186,8 +186,14 @@ export const StyleCardCoverageV2Schema = z.strictObject({
     summarized_messages: z.number().int().nonnegative(),
     chunks: z.number().int().nonnegative(),
     direct_recent_messages: z.number().int().nonnegative(),
+    omitted_summarized_messages: z.number().int().nonnegative().optional(),
+    omitted_chunks: z.number().int().nonnegative().optional(),
+    omitted_direct_recent_messages: z.number().int().nonnegative().optional(),
     date_range: StyleDateRangeSchema,
-    strategy: z.literal("all-safe-monthly-chunks-plus-latest-500"),
+    strategy: z.enum([
+      "all-safe-monthly-chunks-plus-latest-500",
+      "bounded-safe-monthly-chunks-plus-latest-direct",
+    ]),
   }),
   notes: z.string(),
 });
@@ -251,6 +257,12 @@ export const GenerationStateDocumentSchema = z.strictObject({
     .regex(/^[a-f0-9]{64}$/u)
     .nullable(),
   relationshipRefreshedAt: IsoInstantSchema.nullable(),
+  relationshipEvaluationSnapshotChecksum: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/u)
+    .nullable()
+    .default(null),
+  relationshipEvaluationCursor: DiscordIdSchema.nullable().default(null),
   people: z.array(GenerationStateEntrySchema),
 });
 export type GenerationStateDocument = z.infer<

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
@@ -7,6 +7,20 @@ import {
   inputTokenUpperBound,
   worstCaseGenerationCostUsd,
 } from "./glitter-context-refresh-budget.ts";
+import {
+  SYNTHESIS_MAX_OUTPUT_TOKENS,
+  SYNTHESIS_MODEL,
+  SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+} from "./glitter-context-refresh-style-generation-cost.ts";
+import { SYNTHESIS_INPUT_BYTE_LIMIT } from "./glitter-context-refresh-synthesis-limit.ts";
+import {
+  buildBoundedRelationshipInput,
+  estimateRelationshipGenerationCost,
+  RELATIONSHIP_INPUT_BYTE_LIMIT,
+  RELATIONSHIP_MAX_OUTPUT_TOKENS,
+  RELATIONSHIP_MODEL,
+} from "./glitter-context-refresh-generate.ts";
+import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
 
 describe("Glitter generation budget", () => {
   test("reserves every semantic attempt a single generation may bill", () => {
@@ -42,7 +56,98 @@ describe("Glitter generation budget", () => {
 
     expect(raised).toBeGreaterThan(flat);
   });
+});
 
+describe("Glitter capped requests", () => {
+  test("admits a bounded synthesis reservation under the weekly cap", () => {
+    const reservation = worstCaseGenerationCostUsd({
+      model: SYNTHESIS_MODEL,
+      inputTokenUpperBound: SYNTHESIS_INPUT_BYTE_LIMIT,
+      outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+      semanticRetryOutputTokenUpperBound:
+        SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    });
+    const weeklyBudget = new GenerationBudget(1);
+
+    expect(SYNTHESIS_MODEL).toBe("gpt-5.6-luna");
+    expect(() => {
+      weeklyBudget.authorizeUncachedCall(reservation);
+    }).not.toThrow();
+  });
+
+  test("admits a normal relationship reservation under the weekly cap", () => {
+    const reservation = worstCaseGenerationCostUsd({
+      model: RELATIONSHIP_MODEL,
+      // Conservatively covers the serialized 500-message evidence window
+      // while staying below Luna's context limit at ordinary message sizes.
+      inputTokenUpperBound: 250_000,
+      outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+    });
+    const weeklyBudget = new GenerationBudget(1);
+
+    expect(RELATIONSHIP_MODEL).toBe("gpt-5.6-luna");
+    expect(() => {
+      weeklyBudget.authorizeUncachedCall(reservation);
+    }).not.toThrow();
+  });
+
+  test("bounds max-length multibyte relationship evidence under the weekly cap", () => {
+    const evidence = Array.from({ length: 500 }, (_, index) => ({
+      personId: index % 2 === 0 ? "caitlyn" : "richard",
+      message: CurrentMessageSchema.parse({
+        schemaVersion: 1,
+        source: "discord-rest",
+        guildId: "12345678901234567",
+        guildSlug: "glitter-boys",
+        channelId: "22345678901234567",
+        messageId: String(60_000_000_000_000_000n + BigInt(index)),
+        author: {
+          id: "32345678901234567",
+          username: "person",
+          globalName: "Person",
+          discriminator: "0",
+          bot: false,
+          avatar: null,
+        },
+        content: "界".repeat(500),
+        timestamp: "2026-07-01T00:00:00.000Z",
+        editedTimestamp: null,
+        type: 0,
+        flags: "0",
+        pinned: false,
+        tts: false,
+        attachments: [],
+        referencedMessageId: null,
+        selectedObservationKey: `observation-${String(index)}`,
+        selectedObservedAt: "2026-07-01T00:00:01.000Z",
+        rawSha256: index.toString(16).padStart(64, "0"),
+      }),
+    }));
+    const input = {
+      people: [
+        { id: "caitlyn", displayName: "Caitlyn" },
+        { id: "richard", displayName: "Richard" },
+      ],
+      currentRelationships: [],
+      evidence,
+    };
+    const bounded = buildBoundedRelationshipInput(input);
+    const weeklyBudget = new GenerationBudget(1);
+
+    expect(bounded.inputBytes).toBeLessThanOrEqual(
+      RELATIONSHIP_INPUT_BYTE_LIMIT,
+    );
+    expect(bounded.evidence.length).toBeLessThan(evidence.length);
+    expect(bounded.evidence[0]).toEqual(evidence[0]);
+    expect(() => {
+      weeklyBudget.authorizeUncachedCall(
+        estimateRelationshipGenerationCost(input),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe("Glitter generation budget accounting", () => {
   test("a run that exhausts its semantic retries stays inside the reservation", () => {
     const reserved = worstCaseGenerationCostUsd({
       model: "gpt-5.6-luna",

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -148,6 +148,29 @@ const candidate = {
 };
 const firstTimestamp = CurrentMessageSchema.parse(messages[0]).timestamp;
 const lastTimestamp = CurrentMessageSchema.parse(messages.at(-1)).timestamp;
+const summarizedChunk = {
+  key: "person:2025-01",
+  month: "2025-01",
+  startTimestamp: firstTimestamp,
+  endTimestamp: lastTimestamp,
+  summary: StyleChunkSummarySchema.parse({
+    observations: [],
+    representativeMessages: [
+      {
+        messageId: messages[0]?.messageId,
+        content: messages[0]?.content,
+      },
+    ],
+  }),
+  summarizedMessageCount: 30,
+};
+const completeEvidence = {
+  chunks: [summarizedChunk],
+  directRecentMessages: messages,
+  omittedChunks: 0,
+  omittedSummarizedMessages: 0,
+  omittedDirectRecentMessages: 0,
+};
 
 describe("Glitter generated style-card schemas", () => {
   test("use strict Zod contracts for OpenRouter structured output", () => {
@@ -162,8 +185,7 @@ describe("Glitter generated style-card schemas", () => {
       candidate,
       existingCard,
       sourceSnapshotSha256: "a".repeat(64),
-      chunkCount: 1,
-      summarizedMessages: 30,
+      ...completeEvidence,
       synthesis,
     });
 
@@ -197,6 +219,9 @@ describe("Glitter generated style-card schemas", () => {
         summarized_messages: 30,
         chunks: 1,
         direct_recent_messages: 30,
+        omitted_summarized_messages: 0,
+        omitted_chunks: 0,
+        omitted_direct_recent_messages: 0,
         date_range: {
           start: firstTimestamp,
           end: lastTimestamp,
@@ -205,6 +230,50 @@ describe("Glitter generated style-card schemas", () => {
       },
       notes:
         "Generated from the checksum-verified Discord corpus; human review required.",
+    });
+  });
+
+  test("records bounded omissions and the actual synthesis evidence range", () => {
+    const olderMessage = CurrentMessageSchema.parse({
+      ...messages[0],
+      messageId: "42345678901234499",
+      timestamp: "2026-06-01T00:00:00.000Z",
+      selectedObservedAt: "2026-06-01T00:00:01.000Z",
+      selectedObservationKey: "older-observation",
+      rawSha256: "f".repeat(64),
+    });
+    const boundedCandidate = {
+      ...candidate,
+      messages: [olderMessage, ...messages],
+      safeMessages: [olderMessage, ...messages],
+      totalMessageCount: 31,
+    };
+
+    const result = finalizeStyleSynthesis({
+      candidate: boundedCandidate,
+      existingCard,
+      sourceSnapshotSha256: "a".repeat(64),
+      chunks: [],
+      directRecentMessages: messages,
+      omittedChunks: 1,
+      omittedSummarizedMessages: 1,
+      omittedDirectRecentMessages: 1,
+      synthesis,
+    });
+
+    expect(result.coverage.evidence).toMatchObject({
+      safe_messages: 31,
+      summarized_messages: 0,
+      chunks: 0,
+      direct_recent_messages: 30,
+      omitted_summarized_messages: 1,
+      omitted_chunks: 1,
+      omitted_direct_recent_messages: 1,
+      date_range: {
+        start: firstTimestamp,
+        end: lastTimestamp,
+      },
+      strategy: "bounded-safe-monthly-chunks-plus-latest-direct",
     });
   });
 
@@ -222,8 +291,7 @@ describe("Glitter generated style-card schemas", () => {
         candidate,
         existingCard,
         sourceSnapshotSha256: "a".repeat(64),
-        chunkCount: 1,
-        summarizedMessages: 30,
+        ...completeEvidence,
         synthesis: invalidSynthesis,
       }),
     ).toThrow("quotes cites unknown message IDs");
@@ -243,8 +311,7 @@ describe("Glitter generated style-card schemas", () => {
         candidate,
         existingCard,
         sourceSnapshotSha256: "a".repeat(64),
-        chunkCount: 1,
-        summarizedMessages: 30,
+        ...completeEvidence,
         synthesis: invalidSynthesis,
       }),
     ).toThrow(

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -20,9 +20,12 @@ import {
   glitterPrompt,
   useGlitterObjectArtifact,
 } from "./glitter-context-refresh-llm.ts";
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
 
-const RELATIONSHIP_MODEL = "gpt-5.6-sol";
-const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
+export const RELATIONSHIP_MODEL = "gpt-5.6-luna";
+export const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
+export const RELATIONSHIP_INPUT_BYTE_LIMIT = 600_000;
+const MINIMUM_RELATIONSHIP_EVIDENCE = 2;
 const DETERMINISTIC_SEED = 0;
 
 const RelationshipProposalSchema = z.strictObject({
@@ -88,17 +91,48 @@ function relationshipMessages(input: RelationshipGenerationInput) {
   );
 }
 
+export function buildBoundedRelationshipInput(
+  input: RelationshipGenerationInput,
+): {
+  evidence: RelationshipGenerationInput["evidence"];
+  messages: ReturnType<typeof relationshipMessages>;
+  inputBytes: number;
+} {
+  const minimumEvidence = Math.min(
+    MINIMUM_RELATIONSHIP_EVIDENCE,
+    input.evidence.length,
+  );
+  const maximumOmittedEvidence = input.evidence.length - minimumEvidence;
+  for (
+    let omittedEvidence = 0;
+    omittedEvidence <= maximumOmittedEvidence;
+    omittedEvidence += 1
+  ) {
+    const evidence = input.evidence.slice(
+      0,
+      input.evidence.length - omittedEvidence,
+    );
+    const messages = relationshipMessages({ ...input, evidence });
+    const inputBytes = inputTokenUpperBound(JSON.stringify(messages));
+    if (inputBytes <= RELATIONSHIP_INPUT_BYTE_LIMIT) {
+      return { evidence, messages, inputBytes };
+    }
+  }
+  throw new GlitterEvidenceError(
+    `fixed Glitter relationship input exceeds ${String(RELATIONSHIP_INPUT_BYTE_LIMIT)} bytes after reducing evidence to ${String(minimumEvidence)} messages`,
+  );
+}
+
 export function estimateRelationshipGenerationCost(
   input: RelationshipGenerationInput,
 ): number {
   if (input.evidence.length === 0) {
     return 0;
   }
+  const bounded = buildBoundedRelationshipInput(input);
   return worstCaseGenerationCostUsd({
     model: RELATIONSHIP_MODEL,
-    inputTokenUpperBound: inputTokenUpperBound(
-      JSON.stringify(relationshipMessages(input)),
-    ),
+    inputTokenUpperBound: bounded.inputBytes,
     outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
   });
 }
@@ -117,7 +151,8 @@ export async function proposeRelationships(input: {
     return [];
   }
   const callSite = "glitter-context-relationships";
-  const messages = relationshipMessages(input);
+  const bounded = buildBoundedRelationshipInput(input);
+  const messages = bounded.messages;
   const CompletionArtifactSchema = glitterObjectArtifactSchema(
     RelationshipProposalsSchema,
   );
@@ -139,7 +174,7 @@ export async function proposeRelationships(input: {
       input.budget.authorizeUncachedCall(
         worstCaseGenerationCostUsd({
           model: RELATIONSHIP_MODEL,
-          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(messages)),
+          inputTokenUpperBound: bounded.inputBytes,
           outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
         }),
       );
@@ -153,7 +188,7 @@ export async function proposeRelationships(input: {
         reasoningEffort: "medium",
         seed: DETERMINISTIC_SEED,
         exhaustionError:
-          "GPT-5.6 Sol did not return parsed relationship proposals",
+          "GPT-5.6 Luna did not return parsed relationship proposals",
       });
     },
   });

--- a/packages/temporal/src/activities/glitter-context-refresh-relationship-batching.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationship-batching.ts
@@ -1,0 +1,79 @@
+import {
+  type GenerationStateDocument,
+  type PeopleDocument,
+  type RelationshipsDocument,
+} from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import { buildBoundedRelationshipInput } from "./glitter-context-refresh-generate.ts";
+import { selectRelationshipEvidenceBatch } from "./glitter-context-refresh-relationships.ts";
+
+type RelationshipEvidence = ReturnType<
+  typeof selectRelationshipEvidenceBatch
+>["evidence"][number];
+
+export type PreparedRelationshipEvaluation = {
+  evaluated: boolean;
+  complete: boolean;
+  progressed: boolean;
+  cursor: string | null;
+  evidence: readonly RelationshipEvidence[];
+  generationInput: {
+    people: { id: string; displayName: string }[];
+    currentRelationships: RelationshipsDocument["events"];
+    evidence: readonly RelationshipEvidence[];
+  };
+};
+
+export function prepareRelationshipEvaluation(input: {
+  state: GenerationStateDocument;
+  people: PeopleDocument;
+  relationships: RelationshipsDocument;
+  messages: readonly CurrentMessage[];
+  snapshotSha256: string;
+}): PreparedRelationshipEvaluation {
+  const evaluated =
+    input.state.relationshipSourceSnapshotChecksum !== input.snapshotSha256;
+  const people = input.people.people.map((person) => ({
+    id: person.id,
+    displayName: person.displayName,
+  }));
+  const currentRelationships = input.relationships.events.filter(
+    (event) => event.status === "current",
+  );
+  if (!evaluated) {
+    return {
+      evaluated: false,
+      complete: false,
+      progressed: false,
+      cursor: input.state.relationshipEvaluationCursor ?? null,
+      evidence: [],
+      generationInput: { people, currentRelationships, evidence: [] },
+    };
+  }
+  const batch = selectRelationshipEvidenceBatch({
+    people: input.people.people,
+    messages: input.messages,
+    snapshotSha256: input.snapshotSha256,
+    evaluationSnapshotChecksum:
+      input.state.relationshipEvaluationSnapshotChecksum,
+    evaluationCursor: input.state.relationshipEvaluationCursor,
+  });
+  const bounded = buildBoundedRelationshipInput({
+    people,
+    currentRelationships,
+    evidence: batch.evidence,
+  });
+  const evidence = bounded.evidence;
+  const complete = batch.complete || evidence.length === batch.evidence.length;
+  return {
+    evaluated,
+    complete,
+    progressed: complete || evidence.length > 0,
+    cursor:
+      evidence.at(-1)?.message.messageId ??
+      input.state.relationshipEvaluationCursor ??
+      null,
+    evidence,
+    generationInput: { people, currentRelationships, evidence },
+  };
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-relationships.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationships.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, test } from "vitest";
 import {
+  GenerationStateDocumentSchema,
   PeopleDocumentSchema,
   RelationshipsDocumentSchema,
 } from "@shepherdjerred/glitter-context/schema";
 import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
 import type { RelationshipProposal } from "./glitter-context-refresh-generate.ts";
-import { applyRelationshipProposals } from "./glitter-context-refresh-relationships.ts";
+import {
+  applyRelationshipProposals,
+  selectRelationshipEvidenceBatch,
+} from "./glitter-context-refresh-relationships.ts";
 import {
   shouldEvaluateRelationships,
   shouldPersistRelationshipEvaluation,
+  updateGenerationState,
 } from "./glitter-context-refresh-state.ts";
 
 const people = PeopleDocumentSchema.parse({
@@ -227,10 +232,11 @@ describe("weekly relationship evaluation", () => {
     );
   });
 
-  test("does not persist a watermark-only change", () => {
+  test("requires relationship progress for a watermark-only change", () => {
     expect(
       shouldPersistRelationshipEvaluation({
         evaluated: true,
+        relationshipEvaluationProgressed: false,
         refreshedPeopleCount: 0,
         relationshipProposalCount: 0,
       }),
@@ -238,6 +244,7 @@ describe("weekly relationship evaluation", () => {
     expect(
       shouldPersistRelationshipEvaluation({
         evaluated: true,
+        relationshipEvaluationProgressed: false,
         refreshedPeopleCount: 0,
         relationshipProposalCount: 1,
       }),
@@ -245,9 +252,80 @@ describe("weekly relationship evaluation", () => {
     expect(
       shouldPersistRelationshipEvaluation({
         evaluated: true,
+        relationshipEvaluationProgressed: false,
         refreshedPeopleCount: 1,
         relationshipProposalCount: 0,
       }),
     ).toBe(true);
+  });
+
+  test("persists a partial cursor and only advances the watermark at completion", () => {
+    const state = GenerationStateDocumentSchema.parse({
+      schemaVersion: 1,
+      relationshipSourceSnapshotChecksum: "a".repeat(64),
+      relationshipRefreshedAt: "2026-07-01T00:00:00.000Z",
+      people: [],
+    });
+    const partial = updateGenerationState({
+      state,
+      refreshedPeople: new Set(),
+      candidates: [],
+      snapshotSha256: "b".repeat(64),
+      refreshedAt: "2026-07-02T00:00:00.000Z",
+      relationshipsEvaluated: true,
+      relationshipEvaluationComplete: false,
+      relationshipEvaluationProgressed: true,
+      relationshipEvaluationCursor: "60000000000000001",
+    });
+    expect(partial.relationshipSourceSnapshotChecksum).toBe("a".repeat(64));
+    expect(partial.relationshipEvaluationSnapshotChecksum).toBe("b".repeat(64));
+    expect(partial.relationshipEvaluationCursor).toBe("60000000000000001");
+
+    const complete = updateGenerationState({
+      state: partial,
+      refreshedPeople: new Set(),
+      candidates: [],
+      snapshotSha256: "b".repeat(64),
+      refreshedAt: "2026-07-03T00:00:00.000Z",
+      relationshipsEvaluated: true,
+      relationshipEvaluationComplete: true,
+      relationshipEvaluationProgressed: true,
+      relationshipEvaluationCursor: "60000000000000002",
+    });
+    expect(complete.relationshipSourceSnapshotChecksum).toBe("b".repeat(64));
+    expect(complete.relationshipEvaluationSnapshotChecksum).toBeNull();
+    expect(complete.relationshipEvaluationCursor).toBeNull();
+  });
+
+  test("continues a partial snapshot from the persisted cursor", () => {
+    const first = relationshipEvidence[0];
+    if (first === undefined) {
+      throw new Error("expected relationship evidence");
+    }
+    const result = selectRelationshipEvidenceBatch({
+      people,
+      messages: relationshipEvidence.map((entry) => entry.message),
+      snapshotSha256: "b".repeat(64),
+      evaluationSnapshotChecksum: "b".repeat(64),
+      evaluationCursor: first.message.messageId,
+    });
+    expect(result.evidence.map((entry) => entry.message.messageId)).toEqual([
+      "60000000000000002",
+    ]);
+    expect(result.complete).toBe(false);
+  });
+
+  test("continues a partial cursor when a newer snapshot arrives", () => {
+    const result = selectRelationshipEvidenceBatch({
+      people,
+      messages: relationshipEvidence.map((entry) => entry.message),
+      snapshotSha256: "b".repeat(64),
+      evaluationSnapshotChecksum: "a".repeat(64),
+      evaluationCursor: relationshipEvidence[0]?.message.messageId ?? null,
+    });
+    expect(result.evidence.map((entry) => entry.message.messageId)).toEqual([
+      "60000000000000002",
+    ]);
+    expect(result.complete).toBe(false);
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-relationships.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationships.ts
@@ -49,6 +49,13 @@ export function selectRelationshipEvidence(input: {
   people: readonly Person[];
   messages: readonly CurrentMessage[];
 }): { personId: string; message: CurrentMessage }[] {
+  return selectAllRelationshipEvidence(input).slice(-MAX_RELATIONSHIP_EVIDENCE);
+}
+
+function selectAllRelationshipEvidence(input: {
+  people: readonly Person[];
+  messages: readonly CurrentMessage[];
+}): { personId: string; message: CurrentMessage }[] {
   const personByDiscordId = new Map<string, string>();
   for (const person of input.people) {
     for (const discordId of person.discordUserIds) {
@@ -64,8 +71,34 @@ export function selectRelationshipEvidence(input: {
     })
     .toSorted((first, second) =>
       compareSnowflakes(first.message.messageId, second.message.messageId),
-    )
-    .slice(-MAX_RELATIONSHIP_EVIDENCE);
+    );
+}
+
+export function selectRelationshipEvidenceBatch(input: {
+  people: readonly Person[];
+  messages: readonly CurrentMessage[];
+  snapshotSha256: string;
+  evaluationSnapshotChecksum: string | null | undefined;
+  evaluationCursor: string | null | undefined;
+}): {
+  evidence: { personId: string; message: CurrentMessage }[];
+  complete: boolean;
+} {
+  if (input.evaluationCursor === null || input.evaluationCursor === undefined) {
+    const evidence = selectRelationshipEvidence(input);
+    return { evidence, complete: evidence.length === 0 };
+  }
+  const evidence = selectAllRelationshipEvidence(input);
+  const cursorIndex = evidence.findIndex(
+    (entry) => entry.message.messageId === input.evaluationCursor,
+  );
+  if (cursorIndex === -1) {
+    throw new Error(
+      `relationship evaluation cursor ${input.evaluationCursor} from snapshot ${input.evaluationSnapshotChecksum ?? "unknown"} is not present in snapshot ${input.snapshotSha256}`,
+    );
+  }
+  const remaining = evidence.slice(cursorIndex + 1);
+  return { evidence: remaining, complete: remaining.length === 0 };
 }
 
 function proposalId(proposal: RelationshipProposal): string {

--- a/packages/temporal/src/activities/glitter-context-refresh-state.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-state.ts
@@ -14,12 +14,15 @@ export function shouldEvaluateRelationships(
 
 export function shouldPersistRelationshipEvaluation(input: {
   evaluated: boolean;
+  relationshipEvaluationProgressed: boolean;
   refreshedPeopleCount: number;
   relationshipProposalCount: number;
 }): boolean {
   return (
     input.evaluated &&
-    (input.refreshedPeopleCount > 0 || input.relationshipProposalCount > 0)
+    (input.relationshipEvaluationProgressed ||
+      input.refreshedPeopleCount > 0 ||
+      input.relationshipProposalCount > 0)
   );
 }
 
@@ -43,6 +46,9 @@ export function updateGenerationState(input: {
   snapshotSha256: string;
   refreshedAt: string;
   relationshipsEvaluated: boolean;
+  relationshipEvaluationComplete: boolean;
+  relationshipEvaluationProgressed: boolean;
+  relationshipEvaluationCursor: string | null;
 }): GenerationStateDocument {
   const candidateByPerson = new Map(
     input.candidates.map((candidate) => [candidate.person.id, candidate]),
@@ -79,12 +85,26 @@ export function updateGenerationState(input: {
     .map((personId) => refreshedEntryFor(personId));
   return GenerationStateDocumentSchema.parse({
     ...input.state,
-    relationshipSourceSnapshotChecksum: input.relationshipsEvaluated
-      ? input.snapshotSha256
-      : input.state.relationshipSourceSnapshotChecksum,
-    relationshipRefreshedAt: input.relationshipsEvaluated
-      ? input.refreshedAt
-      : input.state.relationshipRefreshedAt,
+    relationshipSourceSnapshotChecksum:
+      input.relationshipsEvaluated && input.relationshipEvaluationComplete
+        ? input.snapshotSha256
+        : input.state.relationshipSourceSnapshotChecksum,
+    relationshipRefreshedAt:
+      input.relationshipsEvaluated && input.relationshipEvaluationComplete
+        ? input.refreshedAt
+        : input.state.relationshipRefreshedAt,
+    relationshipEvaluationSnapshotChecksum:
+      input.relationshipsEvaluated && input.relationshipEvaluationProgressed
+        ? input.relationshipEvaluationComplete
+          ? null
+          : input.snapshotSha256
+        : input.state.relationshipEvaluationSnapshotChecksum,
+    relationshipEvaluationCursor:
+      input.relationshipsEvaluated && input.relationshipEvaluationProgressed
+        ? input.relationshipEvaluationComplete
+          ? null
+          : input.relationshipEvaluationCursor
+        : input.state.relationshipEvaluationCursor,
     people: [...updatedExisting, ...appended],
   });
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
@@ -4,7 +4,9 @@ import {
   type StyleCard,
   type StyleCardV2,
 } from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import type { SummarizedChunk } from "./glitter-context-refresh-style-generation-cost.ts";
 import { requireKnownEvidence } from "./glitter-context-refresh-evidence.ts";
 import {
   STYLE_ARRAY_FIELDS,
@@ -235,20 +237,26 @@ export function finalizeStyleSynthesis(input: {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
   sourceSnapshotSha256: string;
-  chunkCount: number;
-  /**
-   * Messages that actually reached the card as evidence, summed from the chunks
-   * that yielded something. Not `safeMessages.length`: a chunk the model could
-   * not summarize contributes nothing, and counting it would let the card claim
-   * a month it silently omits.
-   */
-  summarizedMessages: number;
+  chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
+  omittedChunks: number;
+  omittedSummarizedMessages: number;
+  omittedDirectRecentMessages: number;
   synthesis: StyleSynthesis;
 }): StyleCardV2 {
   const allMessagesById = new Map(
     input.candidate.safeMessages.map((message) => [message.messageId, message]),
   );
-  const knownEvidenceIds = new Set(allMessagesById.keys());
+  const summarizedEvidenceIds = input.chunks.flatMap((chunk) => [
+    ...chunk.summary.observations.flatMap(
+      (observation) => observation.evidenceMessageIds,
+    ),
+    ...chunk.summary.representativeMessages.map((message) => message.messageId),
+  ]);
+  const knownEvidenceIds = new Set([
+    ...summarizedEvidenceIds,
+    ...input.directRecentMessages.map((message) => message.messageId),
+  ]);
   const fields = applyPatches({
     existingCard: input.existingCard,
     synthesis: input.synthesis,
@@ -281,18 +289,39 @@ export function finalizeStyleSynthesis(input: {
   );
   const firstCorpusMessage = input.candidate.messages[0];
   const lastCorpusMessage = input.candidate.messages.at(-1);
-  const firstSafeMessage = input.candidate.safeMessages[0];
-  const lastSafeMessage = input.candidate.safeMessages.at(-1);
-  if (
-    firstCorpusMessage === undefined ||
-    lastCorpusMessage === undefined ||
-    firstSafeMessage === undefined ||
-    lastSafeMessage === undefined
-  ) {
+  if (firstCorpusMessage === undefined || lastCorpusMessage === undefined) {
     throw new Error(
       `style refresh candidate ${input.candidate.person.id} lacks coverage messages`,
     );
   }
+  const summarizedMessages = input.chunks.reduce(
+    (total, chunk) => total + chunk.summarizedMessageCount,
+    0,
+  );
+  const evidenceStarts = [
+    ...input.chunks
+      .filter((chunk) => chunk.summarizedMessageCount > 0)
+      .map((chunk) => chunk.startTimestamp),
+    ...input.directRecentMessages.map((message) => message.timestamp),
+  ].toSorted();
+  const evidenceEnds = [
+    ...input.chunks
+      .filter((chunk) => chunk.summarizedMessageCount > 0)
+      .map((chunk) => chunk.endTimestamp),
+    ...input.directRecentMessages.map((message) => message.timestamp),
+  ].toSorted();
+  const firstEvidenceTimestamp = evidenceStarts[0];
+  const lastEvidenceTimestamp = evidenceEnds.at(-1);
+  if (
+    firstEvidenceTimestamp === undefined ||
+    lastEvidenceTimestamp === undefined
+  ) {
+    throw new Error(
+      `style refresh candidate ${input.candidate.person.id} has no bounded synthesis evidence`,
+    );
+  }
+  const boundedEvidence =
+    input.omittedChunks > 0 || input.omittedDirectRecentMessages > 0;
   const contentForIds = (messageIds: readonly string[]): string[] =>
     messageIds.map((messageId) => {
       const message = allMessagesById.get(messageId);
@@ -315,17 +344,23 @@ export function finalizeStyleSynthesis(input: {
       },
       evidence: {
         safe_messages: input.candidate.safeMessages.length,
-        summarized_messages: input.summarizedMessages,
-        chunks: input.chunkCount,
-        direct_recent_messages: input.candidate.directRecentMessages.length,
+        summarized_messages: summarizedMessages,
+        chunks: input.chunks.length,
+        direct_recent_messages: input.directRecentMessages.length,
+        omitted_summarized_messages: input.omittedSummarizedMessages,
+        omitted_chunks: input.omittedChunks,
+        omitted_direct_recent_messages: input.omittedDirectRecentMessages,
         date_range: {
-          start: firstSafeMessage.timestamp,
-          end: lastSafeMessage.timestamp,
+          start: firstEvidenceTimestamp,
+          end: lastEvidenceTimestamp,
         },
-        strategy: "all-safe-monthly-chunks-plus-latest-500",
+        strategy: boundedEvidence
+          ? "bounded-safe-monthly-chunks-plus-latest-direct"
+          : "all-safe-monthly-chunks-plus-latest-500",
       },
-      notes:
-        "Generated from the checksum-verified Discord corpus; human review required.",
+      notes: boundedEvidence
+        ? "Generated from byte-bounded evidence selected from the checksum-verified Discord corpus; omitted evidence is counted explicitly; human review required."
+        : "Generated from the checksum-verified Discord corpus; human review required.",
     },
     ...fields,
     summary,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -1,4 +1,5 @@
 import type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
 import {
   inputTokenUpperBound,
   worstCaseGenerationCostUsd,
@@ -12,9 +13,10 @@ import {
   type StyleChunkSummary,
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
+import { SYNTHESIS_INPUT_BYTE_LIMIT } from "./glitter-context-refresh-synthesis-limit.ts";
 
 export const EXTRACTION_MODEL = "gpt-5.6-luna";
-export const SYNTHESIS_MODEL = "gpt-5.6-sol";
+export const SYNTHESIS_MODEL = "gpt-5.6-luna";
 export const EXTRACTION_MAX_OUTPUT_TOKENS = 4000;
 export const EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 8000;
 export const SYNTHESIS_MAX_OUTPUT_TOKENS = 28_000;
@@ -25,6 +27,8 @@ export const MAX_SYNTHESIS_REPAIR_ATTEMPTS = 3;
 export type SummarizedChunk = {
   key: string;
   month: string;
+  startTimestamp: string;
+  endTimestamp: string;
   summary: StyleChunkSummary;
   /**
    * How many of this chunk's messages actually reached the card as evidence:
@@ -38,10 +42,12 @@ type StyleSynthesisPromptInput = {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
   chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
   repair: {
     previous: StyleSynthesis;
     error: string;
   } | null;
+  includeRepairPrevious: boolean;
 };
 
 type StyleCostPromptBuilders = {
@@ -87,11 +93,15 @@ export function estimateStyleGenerationCost(
     candidate: input.candidate,
     existingCard: input.existingCard,
     chunks: [],
+    directRecentMessages: input.candidate.directRecentMessages,
     repair: null,
+    includeRepairPrevious: false,
   });
-  const synthesisInputUpperBound =
+  const synthesisInputUpperBound = Math.min(
+    SYNTHESIS_INPUT_BYTE_LIMIT,
     inputTokenUpperBound(synthesisBase) +
-    chunks.length * EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS;
+      chunks.length * EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+  );
   // A truncated synthesis retries at the higher ceiling, so every semantic
   // attempt after the first is priced against that ceiling.
   const synthesisInitialCall = worstCaseGenerationCostUsd({
@@ -103,8 +113,7 @@ export function estimateStyleGenerationCost(
   });
   // A synthesis repair likewise serializes the prior synthesis (bounded by the
   // retry ceiling) plus the error into its request, and may incur the same retry.
-  const synthesisRepairInput =
-    synthesisInputUpperBound + SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS;
+  const synthesisRepairInput = SYNTHESIS_INPUT_BYTE_LIMIT;
   const synthesisRepairCall = worstCaseGenerationCostUsd({
     model: SYNTHESIS_MODEL,
     inputTokenUpperBound: synthesisRepairInput,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -42,17 +42,15 @@ import {
   sanitizeChunkSummary,
   validateChunkSummary,
 } from "./glitter-context-refresh-style-validation.ts";
+import { finalizeStyleSynthesis } from "./glitter-context-refresh-style-finalize.ts";
 import {
-  finalizeStyleSynthesis,
-  priorFieldValues,
-} from "./glitter-context-refresh-style-finalize.ts";
-import {
-  STYLE_ARRAY_FIELDS,
   StyleChunkSummarySchema,
   StyleSynthesisSchema,
   type StyleChunkSummary,
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
+import { buildBoundedSynthesisInput } from "./glitter-context-refresh-synthesis-limit.ts";
+import { synthesisPrompt } from "./glitter-context-refresh-synthesis-prompt.ts";
 
 // Names the chunk, like the exhaustion error beside it at the same call site.
 // Without the key, a run killed by one truncating chunk says only that *some*
@@ -60,14 +58,14 @@ import {
 // generation artifact out of the corpus bucket.
 const extractionTruncationError = (chunkKey: string): string =>
   `GPT-5.6 Luna extraction reached the completion-token limit for ${chunkKey}`;
-// gpt-5.6-sol is a reasoning model at `reasoning_effort: "medium"`, so its
+// gpt-5.6-luna is a reasoning model at `reasoning_effort: "medium"`, so its
 // hidden reasoning tokens share `max_completion_tokens` with the (large) style
 // synthesis output. Observed live: reasoning + output crossed the former 15k cap
 // and truncated (finish_reason=length → unparseable).
 // 28k gives comfortable headroom over the observed ~15k usage; if a call still
 // truncates, it is retried once at the ceiling below.
 const SYNTHESIS_TRUNCATION_ERROR =
-  "GPT-5.6 Sol synthesis reached the completion-token limit";
+  "GPT-5.6 Luna synthesis reached the completion-token limit";
 const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
   observations: [],
   representativeMessages: [],
@@ -308,70 +306,6 @@ async function summarizeChunk(input: {
   return best;
 }
 
-function synthesisPrompt(input: {
-  candidate: StyleRefreshCandidate;
-  existingCard: StyleCard;
-  chunks: readonly SummarizedChunk[];
-  repair: {
-    previous: StyleSynthesis;
-    error: string;
-  } | null;
-}): string {
-  const base = [
-    "Patch this human-reviewed style card from complete safe-corpus evidence.",
-    "Return one patch for every listed array field and one decision for every prior index.",
-    "Also patch every prior summary item and every prior League entry by index.",
-    "Retain prior observations unless contradicted or explicitly judged low-confidence.",
-    "Retained observations are copied by the application; do not rewrite them.",
-    "Contradicted removals require corpus evidence. Low-confidence removals must use",
-    "confidence <= 0.3 and explain the judgment.",
-    "Additions require confidence >= 0.7 and cited message IDs.",
-    "Choose 20 unique quote IDs and 30 unique sample IDs from the safe evidence.",
-    "Situational examples are synthetic and must contain exactly three per mood.",
-    "Keep descriptive prose close to the prior card; application validation enforces 85-115%.",
-    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
-    "",
-    JSON.stringify({
-      person: {
-        id: input.candidate.person.id,
-        displayName: input.candidate.person.displayName,
-      },
-      patchFields: STYLE_ARRAY_FIELDS.map((field) => ({
-        field,
-        prior: priorFieldValues(input.existingCard, field).map(
-          (value, priorIndex) => ({ priorIndex, value }),
-        ),
-      })),
-      summaryPatch: {
-        prior:
-          typeof input.existingCard.summary === "string"
-            ? [{ priorIndex: 0, value: input.existingCard.summary }]
-            : input.existingCard.summary.map((value, priorIndex) => ({
-                priorIndex,
-                value,
-              })),
-      },
-      leaguePatch: {
-        prior: Object.entries(input.existingCard.league).map(
-          ([key, value], priorIndex) => ({ priorIndex, key, value }),
-        ),
-      },
-      chunkSummaries: input.chunks,
-      directRecentMessages: input.candidate.directRecentMessages.map(
-        (message) => messageEvidence(message),
-      ),
-    }),
-  ].join("\n");
-  return input.repair === null
-    ? base
-    : [
-        base,
-        "",
-        "Repair the prior structured output so it passes deterministic validation.",
-        JSON.stringify(input.repair),
-      ].join("\n");
-}
-
 async function runSynthesis(input: {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
@@ -383,16 +317,32 @@ async function runSynthesis(input: {
     previous: StyleSynthesis;
     error: string;
   } | null;
-}): Promise<StyleSynthesis> {
-  const prompt = synthesisPrompt(input);
+}): Promise<{
+  synthesis: StyleSynthesis;
+  chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
+}> {
+  const bounded = buildBoundedSynthesisInput({
+    chunks: input.chunks,
+    directRecentMessages: input.candidate.directRecentMessages,
+    hasRepairPrevious: input.repair !== null,
+    buildMessages: ({ chunks, directRecentMessages, includeRepairPrevious }) =>
+      glitterPrompt(
+        "You synthesize evidence-grounded writing-style patches for human review.",
+        synthesisPrompt({
+          ...input,
+          chunks,
+          directRecentMessages,
+          includeRepairPrevious,
+        }),
+      ),
+    serializeMessages: JSON.stringify,
+  });
   const callSite =
     input.repair === null
       ? "glitter-style-synthesis"
       : "glitter-style-synthesis-repair";
-  const messages = glitterPrompt(
-    "You synthesize evidence-grounded writing-style patches for human review.",
-    prompt,
-  );
+  const messages = bounded.messages;
   const seed = DETERMINISTIC_SEED + input.attempt;
   const CompletionArtifactSchema =
     glitterObjectArtifactSchema(StyleSynthesisSchema);
@@ -434,11 +384,15 @@ async function runSynthesis(input: {
         reasoningEffort: "medium",
         seed,
         truncationError: SYNTHESIS_TRUNCATION_ERROR,
-        exhaustionError: `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
+        exhaustionError: `GPT-5.6 Luna did not return a parsed synthesis for ${input.candidate.person.id}`,
       });
     },
   });
-  return useGlitterObjectArtifact({ artifact, budget: input.budget });
+  return {
+    synthesis: useGlitterObjectArtifact({ artifact, budget: input.budget }),
+    chunks: bounded.chunks,
+    directRecentMessages: bounded.directRecentMessages,
+  };
 }
 
 export function estimateStyleGenerationCost(input: {
@@ -467,9 +421,16 @@ export async function generateStyleCard(input: {
       artifactStore: input.artifactStore,
       budget: input.budget,
     });
+    const firstMessage = chunk.messages[0];
+    const lastMessage = chunk.messages.at(-1);
+    if (firstMessage === undefined || lastMessage === undefined) {
+      throw new Error(`style evidence chunk ${chunk.key} is empty`);
+    }
     summarizedChunks.push({
       key: chunk.key,
       month: chunk.month,
+      startTimestamp: firstMessage.timestamp,
+      endTimestamp: lastMessage.timestamp,
       summary,
       summarizedMessageCount: summarizedMessageCount(chunk, summary),
     });
@@ -492,40 +453,51 @@ export async function generateStyleCard(input: {
       `no evidence for ${input.candidate.person.id}: ${String(chunks.length)} chunks yielded nothing and there are no direct recent messages`,
     );
   }
-  let previous = await runSynthesis({
+  const finalizeGenerated = (
+    result: Awaited<ReturnType<typeof runSynthesis>>,
+    synthesis: StyleSynthesis,
+  ): StyleCardV2 =>
+    finalizeStyleSynthesis({
+      ...input,
+      chunks: result.chunks,
+      directRecentMessages: result.directRecentMessages,
+      omittedChunks: summarizedChunks.length - result.chunks.length,
+      omittedSummarizedMessages:
+        summarizedMessages -
+        result.chunks.reduce(
+          (total, chunk) => total + chunk.summarizedMessageCount,
+          0,
+        ),
+      omittedDirectRecentMessages:
+        input.candidate.directRecentMessages.length -
+        result.directRecentMessages.length,
+      synthesis,
+    });
+  let generated = await runSynthesis({
     ...input,
     chunks: summarizedChunks,
     attempt: 0,
     repair: null,
   });
+  let previous = generated.synthesis;
   let lastError: Error;
   try {
-    return finalizeStyleSynthesis({
-      ...input,
-      chunkCount: chunks.length,
-      summarizedMessages,
-      synthesis: previous,
-    });
+    return finalizeGenerated(generated, previous);
   } catch (error: unknown) {
     lastError = z.instanceof(Error).parse(error);
   }
   for (let attempt = 1; attempt <= MAX_SYNTHESIS_REPAIR_ATTEMPTS; attempt++) {
-    const repaired = await runSynthesis({
+    generated = await runSynthesis({
       ...input,
       chunks: summarizedChunks,
       attempt,
       repair: { previous, error: lastError.message },
     });
     try {
-      return finalizeStyleSynthesis({
-        ...input,
-        chunkCount: chunks.length,
-        summarizedMessages,
-        synthesis: repaired,
-      });
+      return finalizeGenerated(generated, generated.synthesis);
     } catch (error: unknown) {
       lastError = z.instanceof(Error).parse(error);
-      previous = repaired;
+      previous = generated.synthesis;
     }
   }
   // Every bounded synthesis repair produced a card the contract rejects. That is

--- a/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildBoundedSynthesisInput,
+  SYNTHESIS_INPUT_BYTE_LIMIT,
+} from "./glitter-context-refresh-synthesis-limit.ts";
+
+describe("Glitter synthesis input bound", () => {
+  test("keeps the newest summaries inside the per-call byte ceiling", () => {
+    const chunks = Array.from({ length: 20 }, (_, index) => ({
+      key: `2025-${String(index + 1).padStart(2, "0")}`,
+      summary: "x".repeat(50_000),
+    }));
+
+    const bounded = buildBoundedSynthesisInput({
+      chunks,
+      directRecentMessages: Array.from({ length: 30 }, (_, index) => index),
+      hasRepairPrevious: false,
+      buildMessages: ({ chunks: selected, directRecentMessages }) => ({
+        prompt: JSON.stringify({ selected, directRecentMessages }),
+      }),
+      serializeMessages: JSON.stringify,
+    });
+
+    expect(bounded.inputBytes).toBeLessThanOrEqual(SYNTHESIS_INPUT_BYTE_LIMIT);
+    expect(bounded.chunks.length).toBeLessThan(chunks.length);
+    expect(bounded.chunks.at(-1)?.key).toBe(chunks.at(-1)?.key);
+    expect(bounded.chunks[0]?.key).not.toBe(chunks[0]?.key);
+    expect(bounded.directRecentMessages).toHaveLength(30);
+  });
+
+  test("reduces multibyte direct evidence after removing summaries", () => {
+    const directRecentMessages = Array.from({ length: 500 }, (_, index) => ({
+      id: String(index),
+      content: "界".repeat(500),
+    }));
+    const bounded = buildBoundedSynthesisInput({
+      chunks: [{ summary: "x".repeat(SYNTHESIS_INPUT_BYTE_LIMIT) }],
+      directRecentMessages,
+      hasRepairPrevious: false,
+      buildMessages: ({ chunks, directRecentMessages: direct }) => ({
+        prompt: JSON.stringify({ chunks, direct }),
+      }),
+      serializeMessages: JSON.stringify,
+    });
+
+    expect(bounded.inputBytes).toBeLessThanOrEqual(SYNTHESIS_INPUT_BYTE_LIMIT);
+    expect(bounded.chunks).toHaveLength(0);
+    expect(bounded.directRecentMessages.length).toBeGreaterThanOrEqual(30);
+    expect(bounded.directRecentMessages.length).toBeLessThan(500);
+    expect(bounded.directRecentMessages.at(-1)?.id).toBe("499");
+  });
+
+  test("omits an oversized previous repair before rejecting fixed content", () => {
+    const bounded = buildBoundedSynthesisInput({
+      chunks: [],
+      directRecentMessages: Array.from({ length: 30 }, (_, index) => index),
+      hasRepairPrevious: true,
+      buildMessages: ({ includeRepairPrevious }) => ({
+        prompt: includeRepairPrevious
+          ? "x".repeat(SYNTHESIS_INPUT_BYTE_LIMIT + 1)
+          : "regenerate from the validation error",
+      }),
+      serializeMessages: (messages) => messages.prompt,
+    });
+
+    expect(bounded.includeRepairPrevious).toBe(false);
+  });
+
+  test("raises a non-retryable evidence error when fixed content is impossible", () => {
+    expect(() =>
+      buildBoundedSynthesisInput({
+        chunks: [],
+        directRecentMessages: Array.from({ length: 30 }, (_, index) => index),
+        hasRepairPrevious: false,
+        buildMessages: () => ({
+          prompt: "x".repeat(SYNTHESIS_INPUT_BYTE_LIMIT + 1),
+        }),
+        serializeMessages: (messages) => messages.prompt,
+      }),
+    ).toThrow("reducing direct evidence to 30 messages");
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.ts
@@ -1,0 +1,96 @@
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
+
+export const SYNTHESIS_INPUT_BYTE_LIMIT = 600_000;
+export const MINIMUM_DIRECT_SYNTHESIS_MESSAGES = 30;
+
+export class SynthesisInputTooLargeError extends GlitterEvidenceError {
+  constructor(message: string) {
+    super(message);
+    this.name = "SynthesisInputTooLargeError";
+  }
+}
+
+type BoundedSynthesisInput<Chunk, DirectMessage, Messages> = {
+  chunks: readonly Chunk[];
+  directRecentMessages: readonly DirectMessage[];
+  hasRepairPrevious: boolean;
+  buildMessages: (input: {
+    chunks: readonly Chunk[];
+    directRecentMessages: readonly DirectMessage[];
+    includeRepairPrevious: boolean;
+  }) => Messages;
+  serializeMessages: (messages: Messages) => string;
+};
+
+/**
+ * Keep the newest evidence that fits the per-call reservation. Monthly
+ * summaries are reduced first, followed by the oldest direct messages down to
+ * the 30 messages needed by the synthesis response contract. A repair may omit
+ * its previous invalid response as a final fallback; the original card and
+ * validation error remain, so the model can regenerate the complete patch.
+ */
+export function buildBoundedSynthesisInput<Chunk, DirectMessage, Messages>(
+  input: BoundedSynthesisInput<Chunk, DirectMessage, Messages>,
+): {
+  chunks: readonly Chunk[];
+  directRecentMessages: readonly DirectMessage[];
+  includeRepairPrevious: boolean;
+  messages: Messages;
+  inputBytes: number;
+} {
+  const minimumDirectMessages = Math.min(
+    MINIMUM_DIRECT_SYNTHESIS_MESSAGES,
+    input.directRecentMessages.length,
+  );
+  const repairPreviousModes = input.hasRepairPrevious ? [true, false] : [false];
+  const buildCandidate = (candidate: {
+    chunks: readonly Chunk[];
+    directRecentMessages: readonly DirectMessage[];
+    includeRepairPrevious: boolean;
+  }) => {
+    const messages = input.buildMessages(candidate);
+    return {
+      ...candidate,
+      messages,
+      inputBytes: new TextEncoder().encode(input.serializeMessages(messages))
+        .length,
+    };
+  };
+  for (const includeRepairPrevious of repairPreviousModes) {
+    for (
+      let omittedChunks = 0;
+      omittedChunks <= input.chunks.length;
+      omittedChunks += 1
+    ) {
+      const candidate = buildCandidate({
+        chunks: input.chunks.slice(omittedChunks),
+        directRecentMessages: input.directRecentMessages,
+        includeRepairPrevious,
+      });
+      if (candidate.inputBytes <= SYNTHESIS_INPUT_BYTE_LIMIT) {
+        return candidate;
+      }
+    }
+    const maximumOmittedDirectMessages =
+      input.directRecentMessages.length - minimumDirectMessages;
+    for (
+      let omittedDirectMessages = 1;
+      omittedDirectMessages <= maximumOmittedDirectMessages;
+      omittedDirectMessages += 1
+    ) {
+      const candidate = buildCandidate({
+        chunks: [],
+        directRecentMessages: input.directRecentMessages.slice(
+          omittedDirectMessages,
+        ),
+        includeRepairPrevious,
+      });
+      if (candidate.inputBytes <= SYNTHESIS_INPUT_BYTE_LIMIT) {
+        return candidate;
+      }
+    }
+  }
+  throw new SynthesisInputTooLargeError(
+    `fixed Glitter synthesis input exceeds ${String(SYNTHESIS_INPUT_BYTE_LIMIT)} bytes after removing monthly summaries, reducing direct evidence to ${String(minimumDirectMessages)} messages, and omitting the previous repair output`,
+  );
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-synthesis-prompt.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-synthesis-prompt.ts
@@ -1,0 +1,89 @@
+import type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import type { SummarizedChunk } from "./glitter-context-refresh-style-generation-cost.ts";
+import { priorFieldValues } from "./glitter-context-refresh-style-finalize.ts";
+import {
+  STYLE_ARRAY_FIELDS,
+  type StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+
+function messageEvidence(message: CurrentMessage): {
+  messageId: string;
+  timestamp: string;
+  content: string;
+} {
+  return {
+    messageId: message.messageId,
+    timestamp: message.timestamp,
+    content: message.content,
+  };
+}
+
+export function synthesisPrompt(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
+  repair: { previous: StyleSynthesis; error: string } | null;
+  includeRepairPrevious: boolean;
+}): string {
+  const base = [
+    "Patch this human-reviewed style card from bounded safe-corpus evidence.",
+    "Return one patch for every listed array field and one decision for every prior index.",
+    "Also patch every prior summary item and every prior League entry by index.",
+    "Retain prior observations unless contradicted or explicitly judged low-confidence.",
+    "Retained observations are copied by the application; do not rewrite them.",
+    "Contradicted removals require corpus evidence. Low-confidence removals must use",
+    "confidence <= 0.3 and explain the judgment.",
+    "Additions require confidence >= 0.7 and cited message IDs.",
+    "Choose 20 unique quote IDs and 30 unique sample IDs from the safe evidence.",
+    "Situational examples are synthetic and must contain exactly three per mood.",
+    "Keep descriptive prose close to the prior card; application validation enforces 85-115%.",
+    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
+    "",
+    JSON.stringify({
+      person: {
+        id: input.candidate.person.id,
+        displayName: input.candidate.person.displayName,
+      },
+      patchFields: STYLE_ARRAY_FIELDS.map((field) => ({
+        field,
+        prior: priorFieldValues(input.existingCard, field).map(
+          (value, priorIndex) => ({ priorIndex, value }),
+        ),
+      })),
+      summaryPatch: {
+        prior:
+          typeof input.existingCard.summary === "string"
+            ? [{ priorIndex: 0, value: input.existingCard.summary }]
+            : input.existingCard.summary.map((value, priorIndex) => ({
+                priorIndex,
+                value,
+              })),
+      },
+      leaguePatch: {
+        prior: Object.entries(input.existingCard.league).map(
+          ([key, value], priorIndex) => ({ priorIndex, key, value }),
+        ),
+      },
+      chunkSummaries: input.chunks,
+      directRecentMessages: input.directRecentMessages.map((message) =>
+        messageEvidence(message),
+      ),
+    }),
+  ].join("\n");
+  return input.repair === null
+    ? base
+    : [
+        base,
+        "",
+        "Repair the prior structured output so it passes deterministic validation.",
+        JSON.stringify({
+          previous: input.includeRepairPrevious
+            ? input.repair.previous
+            : "omitted because the prior invalid response exceeded the bounded request budget",
+          error: input.repair.error,
+        }),
+      ].join("\n");
+}

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -38,10 +38,8 @@ import {
   GenerationBudget,
   type GenerationBudgetSummary,
 } from "./glitter-context-refresh-budget.ts";
-import {
-  applyRelationshipProposals,
-  selectRelationshipEvidence,
-} from "./glitter-context-refresh-relationships.ts";
+import { applyRelationshipProposals } from "./glitter-context-refresh-relationships.ts";
+import { prepareRelationshipEvaluation } from "./glitter-context-refresh-relationship-batching.ts";
 import {
   GLITTER_GENERATION_STATE_PATH,
   GLITTER_PEOPLE_PATH,
@@ -50,7 +48,6 @@ import {
 } from "./glitter-context-refresh-paths.ts";
 import { selectStyleRefreshCandidates } from "./glitter-context-refresh-selection.ts";
 import {
-  shouldEvaluateRelationships,
   shouldFailRefreshRun,
   shouldPersistRelationshipEvaluation,
   updateGenerationState,
@@ -229,26 +226,17 @@ export const glitterContextRefreshActivities = {
           ),
         );
       }
-      const relationshipsEvaluated = shouldEvaluateRelationships(
-        generationState.relationshipSourceSnapshotChecksum,
-        corpus.reference.snapshotSha256,
-      );
-      const relationshipEvidence = relationshipsEvaluated
-        ? selectRelationshipEvidence({
-            people: peopleDocument.people,
-            messages: corpus.messages,
-          })
-        : [];
-      const relationshipGenerationInput = {
-        people: peopleDocument.people.map((person) => ({
-          id: person.id,
-          displayName: person.displayName,
-        })),
-        currentRelationships: relationshipsDocument.events.filter(
-          (event) => event.status === "current",
-        ),
-        evidence: relationshipEvidence,
-      };
+      const relationshipEvaluation = prepareRelationshipEvaluation({
+        state: generationState,
+        people: peopleDocument,
+        relationships: relationshipsDocument,
+        messages: corpus.messages,
+        snapshotSha256: corpus.reference.snapshotSha256,
+      });
+      const relationshipsEvaluated = relationshipEvaluation.evaluated;
+      const relationshipEvidence = relationshipEvaluation.evidence;
+      const relationshipGenerationInput =
+        relationshipEvaluation.generationInput;
       const generationBudget = new GenerationBudget(input.maxEstimatedCostUsd);
       const stylePreflightCost = candidates.reduce((total, candidate) => {
         const existingCard = existingCards.get(candidate.person.id);
@@ -362,6 +350,7 @@ export const glitterContextRefreshActivities = {
       const persistRelationshipEvaluation = shouldPersistRelationshipEvaluation(
         {
           evaluated: relationshipsEvaluated,
+          relationshipEvaluationProgressed: relationshipEvaluation.progressed,
           refreshedPeopleCount: refreshedPeople.size,
           relationshipProposalCount,
         },
@@ -373,6 +362,9 @@ export const glitterContextRefreshActivities = {
         snapshotSha256: corpus.reference.snapshotSha256,
         refreshedAt,
         relationshipsEvaluated: persistRelationshipEvaluation,
+        relationshipEvaluationComplete: relationshipEvaluation.complete,
+        relationshipEvaluationProgressed: relationshipEvaluation.progressed,
+        relationshipEvaluationCursor: relationshipEvaluation.cursor,
       });
       await Bun.write(
         `${repoDir}/${GLITTER_GENERATION_STATE_PATH}`,

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -673,7 +673,7 @@ describe("Glitter context refresh schedule", () => {
       expression: "0 11 * * 1",
       timezone: "America/Los_Angeles",
     });
-    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 40 }]);
+    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 1 }]);
     expect(schedule.workflowExecutionTimeout).toBe("15 hours");
     expect(buildScheduleState(schedule, {}).paused).toBe(true);
     expect(

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -333,7 +333,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "glitter-context-refresh-weekly",
     workflowType: "runGlitterContextRefresh",
-    args: [{ maxEstimatedCostUsd: 40 }],
+    args: [{ maxEstimatedCostUsd: 1 }],
     // Monday 11:00 PT, isolated from Discord capture and after other PR jobs.
     timing: {
       kind: "cron",
@@ -346,7 +346,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // backoff. Keep the workflow deadline above that 14h2m retry envelope so
     // a late first-attempt failure does not strand the paid run.
     workflowExecutionTimeout: "15 hours",
-    memo: "Weekly GPT-5.6 Luna extraction and Sol synthesis of shared Glitter style cards plus evidence-backed relationship history from the verified corpus",
+    memo: "Weekly GPT-5.6 Luna extraction and synthesis of shared Glitter style cards plus evidence-backed relationship history from the verified corpus",
     initialPauseNote:
       "Awaiting credentialed dry-run against the first approved complete snapshot",
     requiredEnvironment: [


### PR DESCRIPTION
## Why

The active weekly context refresh could expose up to $40 of uncached generation spend. Lowering the cap to $1 also required every individual production request to fit below that ceiling so exact-key caching can make bounded progress instead of stalling permanently.

## What

- cap the active weekly schedule at $1 while preserving non-retryable budget exhaustion
- use Luna for extraction, synthesis, and relationship generation
- cap serialized synthesis input at 600,000 UTF-8 bytes
- deterministically omit oldest monthly summaries, then oldest direct evidence down to the newest 30 messages; omit an oversized invalid repair body while retaining its validation error
- record the actual evidence range and omitted chunk/message counts in the shared TypeScript, JSON Schema, and Python coverage contract
- treat impossible fixed synthesis input as a per-person non-retryable evidence failure
- retain only exact current request-key cache reuse; legacy keys remain untouched

## Verification

- `bun run build && bun run typecheck && bun run test && bun run lint` in `packages/glitter-context`
- `bunx turbo run build typecheck test lint --filter=@shepherdjerred/temporal --filter=@homelab/cdk8s` from the repository root
- `bun run build && bun run typecheck && bun run lint` in `packages/docs/wiki`
- `bunx lefthook run pre-commit`

Focused results at the final stacked head: 1,007 Temporal unit tests, 69 Temporal workflow tests, and 633 cdk8s tests passed. No live workflow was triggered. The docs rendered successfully; visual capture was unavailable because this session had no controllable browser surface.