### PR TITLE
Bound Glitter corpus finalization memory and retries

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -110,8 +110,25 @@ request digest rather than by run, so a local run reuses everything a production
 run already paid for. Pin `--snapshot-id`/`--snapshot-sha256` to reuse the most
 cache; omit both to read the latest verified snapshot.
 
-The weekly schedule passes a $40 uncached-cost kill switch. Operator
-invocations that omit `maxEstimatedCostUsd` still default to $10. A
+The weekly schedule passes a $1 uncached-cost kill switch. Extraction and
+synthesis use Luna so one bounded generation reservation can fit under that
+cap while retaining the existing semantic retries and completion-token
+headroom. Budget exhaustion is expected bounded progress: exact current v3
+request artifacts remain available to later weekly runs, but no PR is opened
+until one run completes. Older or legacy-key artifacts are not reused unless
+their current request hash is an exact match.
+
+Each synthesis request is also capped at 600,000 serialized UTF-8 bytes, whose
+full three-attempt Luna reservation remains below $1. If all monthly summaries
+do not fit, generation deterministically omits the oldest summaries until the
+request fits, then omits the oldest direct messages while retaining at least the
+newest 30 required by the response contract. An oversized invalid repair output
+may be omitted while its validation error remains. Cards record the bounded
+strategy, actual evidence date range, and omitted chunk/message counts. If the
+reviewed card plus that minimum evidence still cannot fit, that person is
+reported as a non-retryable evidence failure instead of retrying the activity.
+
+Operator invocations that omit `maxEstimatedCostUsd` still default to $10. A
 preflight estimate, per-call authorization, and post-call ceiling enforce
 the cap. A completion that returns without usage data fails non-retryably
 rather than risk re-charging.

--- a/packages/glitter-context/python/validate_context.py
+++ b/packages/glitter-context/python/validate_context.py
@@ -192,8 +192,14 @@ class EvidenceCoverage(BaseModel):
     summarized_messages: int = Field(ge=0)
     chunks: int = Field(ge=0)
     direct_recent_messages: int = Field(ge=0)
+    omitted_summarized_messages: int = Field(default=0, ge=0)
+    omitted_chunks: int = Field(default=0, ge=0)
+    omitted_direct_recent_messages: int = Field(default=0, ge=0)
     date_range: StyleDateRange
-    strategy: Literal["all-safe-monthly-chunks-plus-latest-500"]
+    strategy: Literal[
+        "all-safe-monthly-chunks-plus-latest-500",
+        "bounded-safe-monthly-chunks-plus-latest-direct",
+    ]
 
 
 class StyleCardCoverageV2(BaseModel):

--- a/packages/glitter-context/schema/generation-state.schema.json
+++ b/packages/glitter-context/schema/generation-state.schema.json
@@ -22,6 +22,18 @@
     "relationshipRefreshedAt": {
       "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
     },
+    "relationshipEvaluationSnapshotChecksum": {
+      "oneOf": [
+        { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        { "type": "null" }
+      ]
+    },
+    "relationshipEvaluationCursor": {
+      "oneOf": [
+        { "type": "string", "pattern": "^\\d{17,20}$" },
+        { "type": "null" }
+      ]
+    },
     "people": {
       "type": "array",
       "items": {

--- a/packages/glitter-context/schema/style-card.schema.json
+++ b/packages/glitter-context/schema/style-card.schema.json
@@ -228,9 +228,27 @@
                   "type": "integer",
                   "minimum": 0
                 },
+                "omitted_summarized_messages": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
+                "omitted_chunks": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
+                "omitted_direct_recent_messages": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
                 "date_range": { "$ref": "#/$defs/dateRange" },
                 "strategy": {
-                  "const": "all-safe-monthly-chunks-plus-latest-500"
+                  "enum": [
+                    "all-safe-monthly-chunks-plus-latest-500",
+                    "bounded-safe-monthly-chunks-plus-latest-direct"
+                  ]
                 }
               }
             },

--- a/packages/glitter-context/src/schema.ts
+++ b/packages/glitter-context/src/schema.ts
@@ -186,8 +186,14 @@ export const StyleCardCoverageV2Schema = z.strictObject({
     summarized_messages: z.number().int().nonnegative(),
     chunks: z.number().int().nonnegative(),
     direct_recent_messages: z.number().int().nonnegative(),
+    omitted_summarized_messages: z.number().int().nonnegative().optional(),
+    omitted_chunks: z.number().int().nonnegative().optional(),
+    omitted_direct_recent_messages: z.number().int().nonnegative().optional(),
     date_range: StyleDateRangeSchema,
-    strategy: z.literal("all-safe-monthly-chunks-plus-latest-500"),
+    strategy: z.enum([
+      "all-safe-monthly-chunks-plus-latest-500",
+      "bounded-safe-monthly-chunks-plus-latest-direct",
+    ]),
   }),
   notes: z.string(),
 });
@@ -251,6 +257,12 @@ export const GenerationStateDocumentSchema = z.strictObject({
     .regex(/^[a-f0-9]{64}$/u)
     .nullable(),
   relationshipRefreshedAt: IsoInstantSchema.nullable(),
+  relationshipEvaluationSnapshotChecksum: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/u)
+    .nullable()
+    .default(null),
+  relationshipEvaluationCursor: DiscordIdSchema.nullable().default(null),
   people: z.array(GenerationStateEntrySchema),
 });
 export type GenerationStateDocument = z.infer<

--- a/packages/homelab/src/cdk8s/src/container-resources.test.ts
+++ b/packages/homelab/src/cdk8s/src/container-resources.test.ts
@@ -325,8 +325,8 @@ describe("Container resource requests backstop", () => {
       [
         "temporal-temporal-glitter-corpus-worker/temporal-glitter-corpus-worker",
         {
-          requests: { cpu: "250m", memory: "512Mi" },
-          limits: { cpu: "1", memory: "3072Mi" },
+          requests: { cpu: "250m", memory: "2048Mi" },
+          limits: { cpu: "1", memory: "4096Mi" },
         },
       ],
       [

--- a/packages/homelab/src/cdk8s/src/resources/temporal/glitter-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/glitter-worker.ts
@@ -138,8 +138,8 @@ export function createTemporalGlitterWorkers(
       envVariables: props.corpusEnvVariables,
       cpuRequest: Cpu.millis(250),
       cpuLimit: Cpu.units(1),
-      memoryRequest: Size.mebibytes(512),
-      memoryLimit: Size.gibibytes(3),
+      memoryRequest: Size.gibibytes(2),
+      memoryLimit: Size.gibibytes(4),
     }),
     contextDeployment: createGlitterWorker(chart, {
       name: "temporal-glitter-context-worker",

--- a/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-audit-tooling.test.ts
@@ -388,8 +388,8 @@ describe("Temporal domain worker isolation", () => {
       "glitter-context-worker",
     );
     expect(corpus.spec.template.spec.containers[0]?.resources).toEqual({
-      limits: { cpu: "1", memory: "3072Mi" },
-      requests: { cpu: "250m", memory: "512Mi" },
+      limits: { cpu: "1", memory: "4096Mi" },
+      requests: { cpu: "250m", memory: "2048Mi" },
     });
     expect(context.spec.template.spec.containers[0]?.resources).toEqual({
       limits: { cpu: "2", memory: "6144Mi" },

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
@@ -7,6 +7,20 @@ import {
   inputTokenUpperBound,
   worstCaseGenerationCostUsd,
 } from "./glitter-context-refresh-budget.ts";
+import {
+  SYNTHESIS_MAX_OUTPUT_TOKENS,
+  SYNTHESIS_MODEL,
+  SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+} from "./glitter-context-refresh-style-generation-cost.ts";
+import { SYNTHESIS_INPUT_BYTE_LIMIT } from "./glitter-context-refresh-synthesis-limit.ts";
+import {
+  buildBoundedRelationshipInput,
+  estimateRelationshipGenerationCost,
+  RELATIONSHIP_INPUT_BYTE_LIMIT,
+  RELATIONSHIP_MAX_OUTPUT_TOKENS,
+  RELATIONSHIP_MODEL,
+} from "./glitter-context-refresh-generate.ts";
+import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
 
 describe("Glitter generation budget", () => {
   test("reserves every semantic attempt a single generation may bill", () => {
@@ -42,7 +56,98 @@ describe("Glitter generation budget", () => {
 
     expect(raised).toBeGreaterThan(flat);
   });
+});
 
+describe("Glitter capped requests", () => {
+  test("admits a bounded synthesis reservation under the weekly cap", () => {
+    const reservation = worstCaseGenerationCostUsd({
+      model: SYNTHESIS_MODEL,
+      inputTokenUpperBound: SYNTHESIS_INPUT_BYTE_LIMIT,
+      outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+      semanticRetryOutputTokenUpperBound:
+        SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    });
+    const weeklyBudget = new GenerationBudget(1);
+
+    expect(SYNTHESIS_MODEL).toBe("gpt-5.6-luna");
+    expect(() => {
+      weeklyBudget.authorizeUncachedCall(reservation);
+    }).not.toThrow();
+  });
+
+  test("admits a normal relationship reservation under the weekly cap", () => {
+    const reservation = worstCaseGenerationCostUsd({
+      model: RELATIONSHIP_MODEL,
+      // Conservatively covers the serialized 500-message evidence window
+      // while staying below Luna's context limit at ordinary message sizes.
+      inputTokenUpperBound: 250_000,
+      outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+    });
+    const weeklyBudget = new GenerationBudget(1);
+
+    expect(RELATIONSHIP_MODEL).toBe("gpt-5.6-luna");
+    expect(() => {
+      weeklyBudget.authorizeUncachedCall(reservation);
+    }).not.toThrow();
+  });
+
+  test("bounds max-length multibyte relationship evidence under the weekly cap", () => {
+    const evidence = Array.from({ length: 500 }, (_, index) => ({
+      personId: index % 2 === 0 ? "caitlyn" : "richard",
+      message: CurrentMessageSchema.parse({
+        schemaVersion: 1,
+        source: "discord-rest",
+        guildId: "12345678901234567",
+        guildSlug: "glitter-boys",
+        channelId: "22345678901234567",
+        messageId: String(60_000_000_000_000_000n + BigInt(index)),
+        author: {
+          id: "32345678901234567",
+          username: "person",
+          globalName: "Person",
+          discriminator: "0",
+          bot: false,
+          avatar: null,
+        },
+        content: "界".repeat(500),
+        timestamp: "2026-07-01T00:00:00.000Z",
+        editedTimestamp: null,
+        type: 0,
+        flags: "0",
+        pinned: false,
+        tts: false,
+        attachments: [],
+        referencedMessageId: null,
+        selectedObservationKey: `observation-${String(index)}`,
+        selectedObservedAt: "2026-07-01T00:00:01.000Z",
+        rawSha256: index.toString(16).padStart(64, "0"),
+      }),
+    }));
+    const input = {
+      people: [
+        { id: "caitlyn", displayName: "Caitlyn" },
+        { id: "richard", displayName: "Richard" },
+      ],
+      currentRelationships: [],
+      evidence,
+    };
+    const bounded = buildBoundedRelationshipInput(input);
+    const weeklyBudget = new GenerationBudget(1);
+
+    expect(bounded.inputBytes).toBeLessThanOrEqual(
+      RELATIONSHIP_INPUT_BYTE_LIMIT,
+    );
+    expect(bounded.evidence.length).toBeLessThan(evidence.length);
+    expect(bounded.evidence[0]).toEqual(evidence[0]);
+    expect(() => {
+      weeklyBudget.authorizeUncachedCall(
+        estimateRelationshipGenerationCost(input),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe("Glitter generation budget accounting", () => {
   test("a run that exhausts its semantic retries stays inside the reservation", () => {
     const reserved = worstCaseGenerationCostUsd({
       model: "gpt-5.6-luna",

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.test.ts
@@ -148,6 +148,29 @@ const candidate = {
 };
 const firstTimestamp = CurrentMessageSchema.parse(messages[0]).timestamp;
 const lastTimestamp = CurrentMessageSchema.parse(messages.at(-1)).timestamp;
+const summarizedChunk = {
+  key: "person:2025-01",
+  month: "2025-01",
+  startTimestamp: firstTimestamp,
+  endTimestamp: lastTimestamp,
+  summary: StyleChunkSummarySchema.parse({
+    observations: [],
+    representativeMessages: [
+      {
+        messageId: messages[0]?.messageId,
+        content: messages[0]?.content,
+      },
+    ],
+  }),
+  summarizedMessageCount: 30,
+};
+const completeEvidence = {
+  chunks: [summarizedChunk],
+  directRecentMessages: messages,
+  omittedChunks: 0,
+  omittedSummarizedMessages: 0,
+  omittedDirectRecentMessages: 0,
+};
 
 describe("Glitter generated style-card schemas", () => {
   test("use strict Zod contracts for OpenRouter structured output", () => {
@@ -162,8 +185,7 @@ describe("Glitter generated style-card schemas", () => {
       candidate,
       existingCard,
       sourceSnapshotSha256: "a".repeat(64),
-      chunkCount: 1,
-      summarizedMessages: 30,
+      ...completeEvidence,
       synthesis,
     });
 
@@ -197,6 +219,9 @@ describe("Glitter generated style-card schemas", () => {
         summarized_messages: 30,
         chunks: 1,
         direct_recent_messages: 30,
+        omitted_summarized_messages: 0,
+        omitted_chunks: 0,
+        omitted_direct_recent_messages: 0,
         date_range: {
           start: firstTimestamp,
           end: lastTimestamp,
@@ -205,6 +230,50 @@ describe("Glitter generated style-card schemas", () => {
       },
       notes:
         "Generated from the checksum-verified Discord corpus; human review required.",
+    });
+  });
+
+  test("records bounded omissions and the actual synthesis evidence range", () => {
+    const olderMessage = CurrentMessageSchema.parse({
+      ...messages[0],
+      messageId: "42345678901234499",
+      timestamp: "2026-06-01T00:00:00.000Z",
+      selectedObservedAt: "2026-06-01T00:00:01.000Z",
+      selectedObservationKey: "older-observation",
+      rawSha256: "f".repeat(64),
+    });
+    const boundedCandidate = {
+      ...candidate,
+      messages: [olderMessage, ...messages],
+      safeMessages: [olderMessage, ...messages],
+      totalMessageCount: 31,
+    };
+
+    const result = finalizeStyleSynthesis({
+      candidate: boundedCandidate,
+      existingCard,
+      sourceSnapshotSha256: "a".repeat(64),
+      chunks: [],
+      directRecentMessages: messages,
+      omittedChunks: 1,
+      omittedSummarizedMessages: 1,
+      omittedDirectRecentMessages: 1,
+      synthesis,
+    });
+
+    expect(result.coverage.evidence).toMatchObject({
+      safe_messages: 31,
+      summarized_messages: 0,
+      chunks: 0,
+      direct_recent_messages: 30,
+      omitted_summarized_messages: 1,
+      omitted_chunks: 1,
+      omitted_direct_recent_messages: 1,
+      date_range: {
+        start: firstTimestamp,
+        end: lastTimestamp,
+      },
+      strategy: "bounded-safe-monthly-chunks-plus-latest-direct",
     });
   });
 
@@ -222,8 +291,7 @@ describe("Glitter generated style-card schemas", () => {
         candidate,
         existingCard,
         sourceSnapshotSha256: "a".repeat(64),
-        chunkCount: 1,
-        summarizedMessages: 30,
+        ...completeEvidence,
         synthesis: invalidSynthesis,
       }),
     ).toThrow("quotes cites unknown message IDs");
@@ -243,8 +311,7 @@ describe("Glitter generated style-card schemas", () => {
         candidate,
         existingCard,
         sourceSnapshotSha256: "a".repeat(64),
-        chunkCount: 1,
-        summarizedMessages: 30,
+        ...completeEvidence,
         synthesis: invalidSynthesis,
       }),
     ).toThrow(

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -20,9 +20,12 @@ import {
   glitterPrompt,
   useGlitterObjectArtifact,
 } from "./glitter-context-refresh-llm.ts";
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
 
-const RELATIONSHIP_MODEL = "gpt-5.6-sol";
-const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
+export const RELATIONSHIP_MODEL = "gpt-5.6-luna";
+export const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
+export const RELATIONSHIP_INPUT_BYTE_LIMIT = 600_000;
+const MINIMUM_RELATIONSHIP_EVIDENCE = 2;
 const DETERMINISTIC_SEED = 0;
 
 const RelationshipProposalSchema = z.strictObject({
@@ -88,17 +91,48 @@ function relationshipMessages(input: RelationshipGenerationInput) {
   );
 }
 
+export function buildBoundedRelationshipInput(
+  input: RelationshipGenerationInput,
+): {
+  evidence: RelationshipGenerationInput["evidence"];
+  messages: ReturnType<typeof relationshipMessages>;
+  inputBytes: number;
+} {
+  const minimumEvidence = Math.min(
+    MINIMUM_RELATIONSHIP_EVIDENCE,
+    input.evidence.length,
+  );
+  const maximumOmittedEvidence = input.evidence.length - minimumEvidence;
+  for (
+    let omittedEvidence = 0;
+    omittedEvidence <= maximumOmittedEvidence;
+    omittedEvidence += 1
+  ) {
+    const evidence = input.evidence.slice(
+      0,
+      input.evidence.length - omittedEvidence,
+    );
+    const messages = relationshipMessages({ ...input, evidence });
+    const inputBytes = inputTokenUpperBound(JSON.stringify(messages));
+    if (inputBytes <= RELATIONSHIP_INPUT_BYTE_LIMIT) {
+      return { evidence, messages, inputBytes };
+    }
+  }
+  throw new GlitterEvidenceError(
+    `fixed Glitter relationship input exceeds ${String(RELATIONSHIP_INPUT_BYTE_LIMIT)} bytes after reducing evidence to ${String(minimumEvidence)} messages`,
+  );
+}
+
 export function estimateRelationshipGenerationCost(
   input: RelationshipGenerationInput,
 ): number {
   if (input.evidence.length === 0) {
     return 0;
   }
+  const bounded = buildBoundedRelationshipInput(input);
   return worstCaseGenerationCostUsd({
     model: RELATIONSHIP_MODEL,
-    inputTokenUpperBound: inputTokenUpperBound(
-      JSON.stringify(relationshipMessages(input)),
-    ),
+    inputTokenUpperBound: bounded.inputBytes,
     outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
   });
 }
@@ -117,7 +151,8 @@ export async function proposeRelationships(input: {
     return [];
   }
   const callSite = "glitter-context-relationships";
-  const messages = relationshipMessages(input);
+  const bounded = buildBoundedRelationshipInput(input);
+  const messages = bounded.messages;
   const CompletionArtifactSchema = glitterObjectArtifactSchema(
     RelationshipProposalsSchema,
   );
@@ -139,7 +174,7 @@ export async function proposeRelationships(input: {
       input.budget.authorizeUncachedCall(
         worstCaseGenerationCostUsd({
           model: RELATIONSHIP_MODEL,
-          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(messages)),
+          inputTokenUpperBound: bounded.inputBytes,
           outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
         }),
       );
@@ -153,7 +188,7 @@ export async function proposeRelationships(input: {
         reasoningEffort: "medium",
         seed: DETERMINISTIC_SEED,
         exhaustionError:
-          "GPT-5.6 Sol did not return parsed relationship proposals",
+          "GPT-5.6 Luna did not return parsed relationship proposals",
       });
     },
   });

--- a/packages/temporal/src/activities/glitter-context-refresh-relationship-batching.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationship-batching.ts
@@ -1,0 +1,79 @@
+import {
+  type GenerationStateDocument,
+  type PeopleDocument,
+  type RelationshipsDocument,
+} from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import { buildBoundedRelationshipInput } from "./glitter-context-refresh-generate.ts";
+import { selectRelationshipEvidenceBatch } from "./glitter-context-refresh-relationships.ts";
+
+type RelationshipEvidence = ReturnType<
+  typeof selectRelationshipEvidenceBatch
+>["evidence"][number];
+
+export type PreparedRelationshipEvaluation = {
+  evaluated: boolean;
+  complete: boolean;
+  progressed: boolean;
+  cursor: string | null;
+  evidence: readonly RelationshipEvidence[];
+  generationInput: {
+    people: { id: string; displayName: string }[];
+    currentRelationships: RelationshipsDocument["events"];
+    evidence: readonly RelationshipEvidence[];
+  };
+};
+
+export function prepareRelationshipEvaluation(input: {
+  state: GenerationStateDocument;
+  people: PeopleDocument;
+  relationships: RelationshipsDocument;
+  messages: readonly CurrentMessage[];
+  snapshotSha256: string;
+}): PreparedRelationshipEvaluation {
+  const evaluated =
+    input.state.relationshipSourceSnapshotChecksum !== input.snapshotSha256;
+  const people = input.people.people.map((person) => ({
+    id: person.id,
+    displayName: person.displayName,
+  }));
+  const currentRelationships = input.relationships.events.filter(
+    (event) => event.status === "current",
+  );
+  if (!evaluated) {
+    return {
+      evaluated: false,
+      complete: false,
+      progressed: false,
+      cursor: input.state.relationshipEvaluationCursor ?? null,
+      evidence: [],
+      generationInput: { people, currentRelationships, evidence: [] },
+    };
+  }
+  const batch = selectRelationshipEvidenceBatch({
+    people: input.people.people,
+    messages: input.messages,
+    snapshotSha256: input.snapshotSha256,
+    evaluationSnapshotChecksum:
+      input.state.relationshipEvaluationSnapshotChecksum,
+    evaluationCursor: input.state.relationshipEvaluationCursor,
+  });
+  const bounded = buildBoundedRelationshipInput({
+    people,
+    currentRelationships,
+    evidence: batch.evidence,
+  });
+  const evidence = bounded.evidence;
+  const complete = batch.complete || evidence.length === batch.evidence.length;
+  return {
+    evaluated,
+    complete,
+    progressed: complete || evidence.length > 0,
+    cursor:
+      evidence.at(-1)?.message.messageId ??
+      input.state.relationshipEvaluationCursor ??
+      null,
+    evidence,
+    generationInput: { people, currentRelationships, evidence },
+  };
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-relationships.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationships.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, test } from "vitest";
 import {
+  GenerationStateDocumentSchema,
   PeopleDocumentSchema,
   RelationshipsDocumentSchema,
 } from "@shepherdjerred/glitter-context/schema";
 import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
 import type { RelationshipProposal } from "./glitter-context-refresh-generate.ts";
-import { applyRelationshipProposals } from "./glitter-context-refresh-relationships.ts";
+import {
+  applyRelationshipProposals,
+  selectRelationshipEvidenceBatch,
+} from "./glitter-context-refresh-relationships.ts";
 import {
   shouldEvaluateRelationships,
   shouldPersistRelationshipEvaluation,
+  updateGenerationState,
 } from "./glitter-context-refresh-state.ts";
 
 const people = PeopleDocumentSchema.parse({
@@ -227,10 +232,11 @@ describe("weekly relationship evaluation", () => {
     );
   });
 
-  test("does not persist a watermark-only change", () => {
+  test("requires relationship progress for a watermark-only change", () => {
     expect(
       shouldPersistRelationshipEvaluation({
         evaluated: true,
+        relationshipEvaluationProgressed: false,
         refreshedPeopleCount: 0,
         relationshipProposalCount: 0,
       }),
@@ -238,6 +244,7 @@ describe("weekly relationship evaluation", () => {
     expect(
       shouldPersistRelationshipEvaluation({
         evaluated: true,
+        relationshipEvaluationProgressed: false,
         refreshedPeopleCount: 0,
         relationshipProposalCount: 1,
       }),
@@ -245,9 +252,80 @@ describe("weekly relationship evaluation", () => {
     expect(
       shouldPersistRelationshipEvaluation({
         evaluated: true,
+        relationshipEvaluationProgressed: false,
         refreshedPeopleCount: 1,
         relationshipProposalCount: 0,
       }),
     ).toBe(true);
+  });
+
+  test("persists a partial cursor and only advances the watermark at completion", () => {
+    const state = GenerationStateDocumentSchema.parse({
+      schemaVersion: 1,
+      relationshipSourceSnapshotChecksum: "a".repeat(64),
+      relationshipRefreshedAt: "2026-07-01T00:00:00.000Z",
+      people: [],
+    });
+    const partial = updateGenerationState({
+      state,
+      refreshedPeople: new Set(),
+      candidates: [],
+      snapshotSha256: "b".repeat(64),
+      refreshedAt: "2026-07-02T00:00:00.000Z",
+      relationshipsEvaluated: true,
+      relationshipEvaluationComplete: false,
+      relationshipEvaluationProgressed: true,
+      relationshipEvaluationCursor: "60000000000000001",
+    });
+    expect(partial.relationshipSourceSnapshotChecksum).toBe("a".repeat(64));
+    expect(partial.relationshipEvaluationSnapshotChecksum).toBe("b".repeat(64));
+    expect(partial.relationshipEvaluationCursor).toBe("60000000000000001");
+
+    const complete = updateGenerationState({
+      state: partial,
+      refreshedPeople: new Set(),
+      candidates: [],
+      snapshotSha256: "b".repeat(64),
+      refreshedAt: "2026-07-03T00:00:00.000Z",
+      relationshipsEvaluated: true,
+      relationshipEvaluationComplete: true,
+      relationshipEvaluationProgressed: true,
+      relationshipEvaluationCursor: "60000000000000002",
+    });
+    expect(complete.relationshipSourceSnapshotChecksum).toBe("b".repeat(64));
+    expect(complete.relationshipEvaluationSnapshotChecksum).toBeNull();
+    expect(complete.relationshipEvaluationCursor).toBeNull();
+  });
+
+  test("continues a partial snapshot from the persisted cursor", () => {
+    const first = relationshipEvidence[0];
+    if (first === undefined) {
+      throw new Error("expected relationship evidence");
+    }
+    const result = selectRelationshipEvidenceBatch({
+      people,
+      messages: relationshipEvidence.map((entry) => entry.message),
+      snapshotSha256: "b".repeat(64),
+      evaluationSnapshotChecksum: "b".repeat(64),
+      evaluationCursor: first.message.messageId,
+    });
+    expect(result.evidence.map((entry) => entry.message.messageId)).toEqual([
+      "60000000000000002",
+    ]);
+    expect(result.complete).toBe(false);
+  });
+
+  test("continues a partial cursor when a newer snapshot arrives", () => {
+    const result = selectRelationshipEvidenceBatch({
+      people,
+      messages: relationshipEvidence.map((entry) => entry.message),
+      snapshotSha256: "b".repeat(64),
+      evaluationSnapshotChecksum: "a".repeat(64),
+      evaluationCursor: relationshipEvidence[0]?.message.messageId ?? null,
+    });
+    expect(result.evidence.map((entry) => entry.message.messageId)).toEqual([
+      "60000000000000002",
+    ]);
+    expect(result.complete).toBe(false);
   });
 });

--- a/packages/temporal/src/activities/glitter-context-refresh-relationships.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationships.ts
@@ -49,6 +49,13 @@ export function selectRelationshipEvidence(input: {
   people: readonly Person[];
   messages: readonly CurrentMessage[];
 }): { personId: string; message: CurrentMessage }[] {
+  return selectAllRelationshipEvidence(input).slice(-MAX_RELATIONSHIP_EVIDENCE);
+}
+
+function selectAllRelationshipEvidence(input: {
+  people: readonly Person[];
+  messages: readonly CurrentMessage[];
+}): { personId: string; message: CurrentMessage }[] {
   const personByDiscordId = new Map<string, string>();
   for (const person of input.people) {
     for (const discordId of person.discordUserIds) {
@@ -64,8 +71,34 @@ export function selectRelationshipEvidence(input: {
     })
     .toSorted((first, second) =>
       compareSnowflakes(first.message.messageId, second.message.messageId),
-    )
-    .slice(-MAX_RELATIONSHIP_EVIDENCE);
+    );
+}
+
+export function selectRelationshipEvidenceBatch(input: {
+  people: readonly Person[];
+  messages: readonly CurrentMessage[];
+  snapshotSha256: string;
+  evaluationSnapshotChecksum: string | null | undefined;
+  evaluationCursor: string | null | undefined;
+}): {
+  evidence: { personId: string; message: CurrentMessage }[];
+  complete: boolean;
+} {
+  if (input.evaluationCursor === null || input.evaluationCursor === undefined) {
+    const evidence = selectRelationshipEvidence(input);
+    return { evidence, complete: evidence.length === 0 };
+  }
+  const evidence = selectAllRelationshipEvidence(input);
+  const cursorIndex = evidence.findIndex(
+    (entry) => entry.message.messageId === input.evaluationCursor,
+  );
+  if (cursorIndex === -1) {
+    throw new Error(
+      `relationship evaluation cursor ${input.evaluationCursor} from snapshot ${input.evaluationSnapshotChecksum ?? "unknown"} is not present in snapshot ${input.snapshotSha256}`,
+    );
+  }
+  const remaining = evidence.slice(cursorIndex + 1);
+  return { evidence: remaining, complete: remaining.length === 0 };
 }
 
 function proposalId(proposal: RelationshipProposal): string {

--- a/packages/temporal/src/activities/glitter-context-refresh-state.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-state.ts
@@ -14,12 +14,15 @@ export function shouldEvaluateRelationships(
 
 export function shouldPersistRelationshipEvaluation(input: {
   evaluated: boolean;
+  relationshipEvaluationProgressed: boolean;
   refreshedPeopleCount: number;
   relationshipProposalCount: number;
 }): boolean {
   return (
     input.evaluated &&
-    (input.refreshedPeopleCount > 0 || input.relationshipProposalCount > 0)
+    (input.relationshipEvaluationProgressed ||
+      input.refreshedPeopleCount > 0 ||
+      input.relationshipProposalCount > 0)
   );
 }
 
@@ -43,6 +46,9 @@ export function updateGenerationState(input: {
   snapshotSha256: string;
   refreshedAt: string;
   relationshipsEvaluated: boolean;
+  relationshipEvaluationComplete: boolean;
+  relationshipEvaluationProgressed: boolean;
+  relationshipEvaluationCursor: string | null;
 }): GenerationStateDocument {
   const candidateByPerson = new Map(
     input.candidates.map((candidate) => [candidate.person.id, candidate]),
@@ -79,12 +85,26 @@ export function updateGenerationState(input: {
     .map((personId) => refreshedEntryFor(personId));
   return GenerationStateDocumentSchema.parse({
     ...input.state,
-    relationshipSourceSnapshotChecksum: input.relationshipsEvaluated
-      ? input.snapshotSha256
-      : input.state.relationshipSourceSnapshotChecksum,
-    relationshipRefreshedAt: input.relationshipsEvaluated
-      ? input.refreshedAt
-      : input.state.relationshipRefreshedAt,
+    relationshipSourceSnapshotChecksum:
+      input.relationshipsEvaluated && input.relationshipEvaluationComplete
+        ? input.snapshotSha256
+        : input.state.relationshipSourceSnapshotChecksum,
+    relationshipRefreshedAt:
+      input.relationshipsEvaluated && input.relationshipEvaluationComplete
+        ? input.refreshedAt
+        : input.state.relationshipRefreshedAt,
+    relationshipEvaluationSnapshotChecksum:
+      input.relationshipsEvaluated && input.relationshipEvaluationProgressed
+        ? input.relationshipEvaluationComplete
+          ? null
+          : input.snapshotSha256
+        : input.state.relationshipEvaluationSnapshotChecksum,
+    relationshipEvaluationCursor:
+      input.relationshipsEvaluated && input.relationshipEvaluationProgressed
+        ? input.relationshipEvaluationComplete
+          ? null
+          : input.relationshipEvaluationCursor
+        : input.state.relationshipEvaluationCursor,
     people: [...updatedExisting, ...appended],
   });
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-finalize.ts
@@ -4,7 +4,9 @@ import {
   type StyleCard,
   type StyleCardV2,
 } from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import type { SummarizedChunk } from "./glitter-context-refresh-style-generation-cost.ts";
 import { requireKnownEvidence } from "./glitter-context-refresh-evidence.ts";
 import {
   STYLE_ARRAY_FIELDS,
@@ -235,20 +237,26 @@ export function finalizeStyleSynthesis(input: {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
   sourceSnapshotSha256: string;
-  chunkCount: number;
-  /**
-   * Messages that actually reached the card as evidence, summed from the chunks
-   * that yielded something. Not `safeMessages.length`: a chunk the model could
-   * not summarize contributes nothing, and counting it would let the card claim
-   * a month it silently omits.
-   */
-  summarizedMessages: number;
+  chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
+  omittedChunks: number;
+  omittedSummarizedMessages: number;
+  omittedDirectRecentMessages: number;
   synthesis: StyleSynthesis;
 }): StyleCardV2 {
   const allMessagesById = new Map(
     input.candidate.safeMessages.map((message) => [message.messageId, message]),
   );
-  const knownEvidenceIds = new Set(allMessagesById.keys());
+  const summarizedEvidenceIds = input.chunks.flatMap((chunk) => [
+    ...chunk.summary.observations.flatMap(
+      (observation) => observation.evidenceMessageIds,
+    ),
+    ...chunk.summary.representativeMessages.map((message) => message.messageId),
+  ]);
+  const knownEvidenceIds = new Set([
+    ...summarizedEvidenceIds,
+    ...input.directRecentMessages.map((message) => message.messageId),
+  ]);
   const fields = applyPatches({
     existingCard: input.existingCard,
     synthesis: input.synthesis,
@@ -281,18 +289,39 @@ export function finalizeStyleSynthesis(input: {
   );
   const firstCorpusMessage = input.candidate.messages[0];
   const lastCorpusMessage = input.candidate.messages.at(-1);
-  const firstSafeMessage = input.candidate.safeMessages[0];
-  const lastSafeMessage = input.candidate.safeMessages.at(-1);
-  if (
-    firstCorpusMessage === undefined ||
-    lastCorpusMessage === undefined ||
-    firstSafeMessage === undefined ||
-    lastSafeMessage === undefined
-  ) {
+  if (firstCorpusMessage === undefined || lastCorpusMessage === undefined) {
     throw new Error(
       `style refresh candidate ${input.candidate.person.id} lacks coverage messages`,
     );
   }
+  const summarizedMessages = input.chunks.reduce(
+    (total, chunk) => total + chunk.summarizedMessageCount,
+    0,
+  );
+  const evidenceStarts = [
+    ...input.chunks
+      .filter((chunk) => chunk.summarizedMessageCount > 0)
+      .map((chunk) => chunk.startTimestamp),
+    ...input.directRecentMessages.map((message) => message.timestamp),
+  ].toSorted();
+  const evidenceEnds = [
+    ...input.chunks
+      .filter((chunk) => chunk.summarizedMessageCount > 0)
+      .map((chunk) => chunk.endTimestamp),
+    ...input.directRecentMessages.map((message) => message.timestamp),
+  ].toSorted();
+  const firstEvidenceTimestamp = evidenceStarts[0];
+  const lastEvidenceTimestamp = evidenceEnds.at(-1);
+  if (
+    firstEvidenceTimestamp === undefined ||
+    lastEvidenceTimestamp === undefined
+  ) {
+    throw new Error(
+      `style refresh candidate ${input.candidate.person.id} has no bounded synthesis evidence`,
+    );
+  }
+  const boundedEvidence =
+    input.omittedChunks > 0 || input.omittedDirectRecentMessages > 0;
   const contentForIds = (messageIds: readonly string[]): string[] =>
     messageIds.map((messageId) => {
       const message = allMessagesById.get(messageId);
@@ -315,17 +344,23 @@ export function finalizeStyleSynthesis(input: {
       },
       evidence: {
         safe_messages: input.candidate.safeMessages.length,
-        summarized_messages: input.summarizedMessages,
-        chunks: input.chunkCount,
-        direct_recent_messages: input.candidate.directRecentMessages.length,
+        summarized_messages: summarizedMessages,
+        chunks: input.chunks.length,
+        direct_recent_messages: input.directRecentMessages.length,
+        omitted_summarized_messages: input.omittedSummarizedMessages,
+        omitted_chunks: input.omittedChunks,
+        omitted_direct_recent_messages: input.omittedDirectRecentMessages,
         date_range: {
-          start: firstSafeMessage.timestamp,
-          end: lastSafeMessage.timestamp,
+          start: firstEvidenceTimestamp,
+          end: lastEvidenceTimestamp,
         },
-        strategy: "all-safe-monthly-chunks-plus-latest-500",
+        strategy: boundedEvidence
+          ? "bounded-safe-monthly-chunks-plus-latest-direct"
+          : "all-safe-monthly-chunks-plus-latest-500",
       },
-      notes:
-        "Generated from the checksum-verified Discord corpus; human review required.",
+      notes: boundedEvidence
+        ? "Generated from byte-bounded evidence selected from the checksum-verified Discord corpus; omitted evidence is counted explicitly; human review required."
+        : "Generated from the checksum-verified Discord corpus; human review required.",
     },
     ...fields,
     summary,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation-cost.ts
@@ -1,4 +1,5 @@
 import type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
 import {
   inputTokenUpperBound,
   worstCaseGenerationCostUsd,
@@ -12,9 +13,10 @@ import {
   type StyleChunkSummary,
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
+import { SYNTHESIS_INPUT_BYTE_LIMIT } from "./glitter-context-refresh-synthesis-limit.ts";
 
 export const EXTRACTION_MODEL = "gpt-5.6-luna";
-export const SYNTHESIS_MODEL = "gpt-5.6-sol";
+export const SYNTHESIS_MODEL = "gpt-5.6-luna";
 export const EXTRACTION_MAX_OUTPUT_TOKENS = 4000;
 export const EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS = 8000;
 export const SYNTHESIS_MAX_OUTPUT_TOKENS = 28_000;
@@ -25,6 +27,8 @@ export const MAX_SYNTHESIS_REPAIR_ATTEMPTS = 3;
 export type SummarizedChunk = {
   key: string;
   month: string;
+  startTimestamp: string;
+  endTimestamp: string;
   summary: StyleChunkSummary;
   /**
    * How many of this chunk's messages actually reached the card as evidence:
@@ -38,10 +42,12 @@ type StyleSynthesisPromptInput = {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
   chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
   repair: {
     previous: StyleSynthesis;
     error: string;
   } | null;
+  includeRepairPrevious: boolean;
 };
 
 type StyleCostPromptBuilders = {
@@ -87,11 +93,15 @@ export function estimateStyleGenerationCost(
     candidate: input.candidate,
     existingCard: input.existingCard,
     chunks: [],
+    directRecentMessages: input.candidate.directRecentMessages,
     repair: null,
+    includeRepairPrevious: false,
   });
-  const synthesisInputUpperBound =
+  const synthesisInputUpperBound = Math.min(
+    SYNTHESIS_INPUT_BYTE_LIMIT,
     inputTokenUpperBound(synthesisBase) +
-    chunks.length * EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS;
+      chunks.length * EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+  );
   // A truncated synthesis retries at the higher ceiling, so every semantic
   // attempt after the first is priced against that ceiling.
   const synthesisInitialCall = worstCaseGenerationCostUsd({
@@ -103,8 +113,7 @@ export function estimateStyleGenerationCost(
   });
   // A synthesis repair likewise serializes the prior synthesis (bounded by the
   // retry ceiling) plus the error into its request, and may incur the same retry.
-  const synthesisRepairInput =
-    synthesisInputUpperBound + SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS;
+  const synthesisRepairInput = SYNTHESIS_INPUT_BYTE_LIMIT;
   const synthesisRepairCall = worstCaseGenerationCostUsd({
     model: SYNTHESIS_MODEL,
     inputTokenUpperBound: synthesisRepairInput,

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -42,17 +42,15 @@ import {
   sanitizeChunkSummary,
   validateChunkSummary,
 } from "./glitter-context-refresh-style-validation.ts";
+import { finalizeStyleSynthesis } from "./glitter-context-refresh-style-finalize.ts";
 import {
-  finalizeStyleSynthesis,
-  priorFieldValues,
-} from "./glitter-context-refresh-style-finalize.ts";
-import {
-  STYLE_ARRAY_FIELDS,
   StyleChunkSummarySchema,
   StyleSynthesisSchema,
   type StyleChunkSummary,
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
+import { buildBoundedSynthesisInput } from "./glitter-context-refresh-synthesis-limit.ts";
+import { synthesisPrompt } from "./glitter-context-refresh-synthesis-prompt.ts";
 
 // Names the chunk, like the exhaustion error beside it at the same call site.
 // Without the key, a run killed by one truncating chunk says only that *some*
@@ -60,14 +58,14 @@ import {
 // generation artifact out of the corpus bucket.
 const extractionTruncationError = (chunkKey: string): string =>
   `GPT-5.6 Luna extraction reached the completion-token limit for ${chunkKey}`;
-// gpt-5.6-sol is a reasoning model at `reasoning_effort: "medium"`, so its
+// gpt-5.6-luna is a reasoning model at `reasoning_effort: "medium"`, so its
 // hidden reasoning tokens share `max_completion_tokens` with the (large) style
 // synthesis output. Observed live: reasoning + output crossed the former 15k cap
 // and truncated (finish_reason=length → unparseable).
 // 28k gives comfortable headroom over the observed ~15k usage; if a call still
 // truncates, it is retried once at the ceiling below.
 const SYNTHESIS_TRUNCATION_ERROR =
-  "GPT-5.6 Sol synthesis reached the completion-token limit";
+  "GPT-5.6 Luna synthesis reached the completion-token limit";
 const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
   observations: [],
   representativeMessages: [],
@@ -308,70 +306,6 @@ async function summarizeChunk(input: {
   return best;
 }
 
-function synthesisPrompt(input: {
-  candidate: StyleRefreshCandidate;
-  existingCard: StyleCard;
-  chunks: readonly SummarizedChunk[];
-  repair: {
-    previous: StyleSynthesis;
-    error: string;
-  } | null;
-}): string {
-  const base = [
-    "Patch this human-reviewed style card from complete safe-corpus evidence.",
-    "Return one patch for every listed array field and one decision for every prior index.",
-    "Also patch every prior summary item and every prior League entry by index.",
-    "Retain prior observations unless contradicted or explicitly judged low-confidence.",
-    "Retained observations are copied by the application; do not rewrite them.",
-    "Contradicted removals require corpus evidence. Low-confidence removals must use",
-    "confidence <= 0.3 and explain the judgment.",
-    "Additions require confidence >= 0.7 and cited message IDs.",
-    "Choose 20 unique quote IDs and 30 unique sample IDs from the safe evidence.",
-    "Situational examples are synthetic and must contain exactly three per mood.",
-    "Keep descriptive prose close to the prior card; application validation enforces 85-115%.",
-    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
-    "",
-    JSON.stringify({
-      person: {
-        id: input.candidate.person.id,
-        displayName: input.candidate.person.displayName,
-      },
-      patchFields: STYLE_ARRAY_FIELDS.map((field) => ({
-        field,
-        prior: priorFieldValues(input.existingCard, field).map(
-          (value, priorIndex) => ({ priorIndex, value }),
-        ),
-      })),
-      summaryPatch: {
-        prior:
-          typeof input.existingCard.summary === "string"
-            ? [{ priorIndex: 0, value: input.existingCard.summary }]
-            : input.existingCard.summary.map((value, priorIndex) => ({
-                priorIndex,
-                value,
-              })),
-      },
-      leaguePatch: {
-        prior: Object.entries(input.existingCard.league).map(
-          ([key, value], priorIndex) => ({ priorIndex, key, value }),
-        ),
-      },
-      chunkSummaries: input.chunks,
-      directRecentMessages: input.candidate.directRecentMessages.map(
-        (message) => messageEvidence(message),
-      ),
-    }),
-  ].join("\n");
-  return input.repair === null
-    ? base
-    : [
-        base,
-        "",
-        "Repair the prior structured output so it passes deterministic validation.",
-        JSON.stringify(input.repair),
-      ].join("\n");
-}
-
 async function runSynthesis(input: {
   candidate: StyleRefreshCandidate;
   existingCard: StyleCard;
@@ -383,16 +317,32 @@ async function runSynthesis(input: {
     previous: StyleSynthesis;
     error: string;
   } | null;
-}): Promise<StyleSynthesis> {
-  const prompt = synthesisPrompt(input);
+}): Promise<{
+  synthesis: StyleSynthesis;
+  chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
+}> {
+  const bounded = buildBoundedSynthesisInput({
+    chunks: input.chunks,
+    directRecentMessages: input.candidate.directRecentMessages,
+    hasRepairPrevious: input.repair !== null,
+    buildMessages: ({ chunks, directRecentMessages, includeRepairPrevious }) =>
+      glitterPrompt(
+        "You synthesize evidence-grounded writing-style patches for human review.",
+        synthesisPrompt({
+          ...input,
+          chunks,
+          directRecentMessages,
+          includeRepairPrevious,
+        }),
+      ),
+    serializeMessages: JSON.stringify,
+  });
   const callSite =
     input.repair === null
       ? "glitter-style-synthesis"
       : "glitter-style-synthesis-repair";
-  const messages = glitterPrompt(
-    "You synthesize evidence-grounded writing-style patches for human review.",
-    prompt,
-  );
+  const messages = bounded.messages;
   const seed = DETERMINISTIC_SEED + input.attempt;
   const CompletionArtifactSchema =
     glitterObjectArtifactSchema(StyleSynthesisSchema);
@@ -434,11 +384,15 @@ async function runSynthesis(input: {
         reasoningEffort: "medium",
         seed,
         truncationError: SYNTHESIS_TRUNCATION_ERROR,
-        exhaustionError: `GPT-5.6 Sol did not return a parsed synthesis for ${input.candidate.person.id}`,
+        exhaustionError: `GPT-5.6 Luna did not return a parsed synthesis for ${input.candidate.person.id}`,
       });
     },
   });
-  return useGlitterObjectArtifact({ artifact, budget: input.budget });
+  return {
+    synthesis: useGlitterObjectArtifact({ artifact, budget: input.budget }),
+    chunks: bounded.chunks,
+    directRecentMessages: bounded.directRecentMessages,
+  };
 }
 
 export function estimateStyleGenerationCost(input: {
@@ -467,9 +421,16 @@ export async function generateStyleCard(input: {
       artifactStore: input.artifactStore,
       budget: input.budget,
     });
+    const firstMessage = chunk.messages[0];
+    const lastMessage = chunk.messages.at(-1);
+    if (firstMessage === undefined || lastMessage === undefined) {
+      throw new Error(`style evidence chunk ${chunk.key} is empty`);
+    }
     summarizedChunks.push({
       key: chunk.key,
       month: chunk.month,
+      startTimestamp: firstMessage.timestamp,
+      endTimestamp: lastMessage.timestamp,
       summary,
       summarizedMessageCount: summarizedMessageCount(chunk, summary),
     });
@@ -492,40 +453,51 @@ export async function generateStyleCard(input: {
       `no evidence for ${input.candidate.person.id}: ${String(chunks.length)} chunks yielded nothing and there are no direct recent messages`,
     );
   }
-  let previous = await runSynthesis({
+  const finalizeGenerated = (
+    result: Awaited<ReturnType<typeof runSynthesis>>,
+    synthesis: StyleSynthesis,
+  ): StyleCardV2 =>
+    finalizeStyleSynthesis({
+      ...input,
+      chunks: result.chunks,
+      directRecentMessages: result.directRecentMessages,
+      omittedChunks: summarizedChunks.length - result.chunks.length,
+      omittedSummarizedMessages:
+        summarizedMessages -
+        result.chunks.reduce(
+          (total, chunk) => total + chunk.summarizedMessageCount,
+          0,
+        ),
+      omittedDirectRecentMessages:
+        input.candidate.directRecentMessages.length -
+        result.directRecentMessages.length,
+      synthesis,
+    });
+  let generated = await runSynthesis({
     ...input,
     chunks: summarizedChunks,
     attempt: 0,
     repair: null,
   });
+  let previous = generated.synthesis;
   let lastError: Error;
   try {
-    return finalizeStyleSynthesis({
-      ...input,
-      chunkCount: chunks.length,
-      summarizedMessages,
-      synthesis: previous,
-    });
+    return finalizeGenerated(generated, previous);
   } catch (error: unknown) {
     lastError = z.instanceof(Error).parse(error);
   }
   for (let attempt = 1; attempt <= MAX_SYNTHESIS_REPAIR_ATTEMPTS; attempt++) {
-    const repaired = await runSynthesis({
+    generated = await runSynthesis({
       ...input,
       chunks: summarizedChunks,
       attempt,
       repair: { previous, error: lastError.message },
     });
     try {
-      return finalizeStyleSynthesis({
-        ...input,
-        chunkCount: chunks.length,
-        summarizedMessages,
-        synthesis: repaired,
-      });
+      return finalizeGenerated(generated, generated.synthesis);
     } catch (error: unknown) {
       lastError = z.instanceof(Error).parse(error);
-      previous = repaired;
+      previous = generated.synthesis;
     }
   }
   // Every bounded synthesis repair produced a card the contract rejects. That is

--- a/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildBoundedSynthesisInput,
+  SYNTHESIS_INPUT_BYTE_LIMIT,
+} from "./glitter-context-refresh-synthesis-limit.ts";
+
+describe("Glitter synthesis input bound", () => {
+  test("keeps the newest summaries inside the per-call byte ceiling", () => {
+    const chunks = Array.from({ length: 20 }, (_, index) => ({
+      key: `2025-${String(index + 1).padStart(2, "0")}`,
+      summary: "x".repeat(50_000),
+    }));
+
+    const bounded = buildBoundedSynthesisInput({
+      chunks,
+      directRecentMessages: Array.from({ length: 30 }, (_, index) => index),
+      hasRepairPrevious: false,
+      buildMessages: ({ chunks: selected, directRecentMessages }) => ({
+        prompt: JSON.stringify({ selected, directRecentMessages }),
+      }),
+      serializeMessages: JSON.stringify,
+    });
+
+    expect(bounded.inputBytes).toBeLessThanOrEqual(SYNTHESIS_INPUT_BYTE_LIMIT);
+    expect(bounded.chunks.length).toBeLessThan(chunks.length);
+    expect(bounded.chunks.at(-1)?.key).toBe(chunks.at(-1)?.key);
+    expect(bounded.chunks[0]?.key).not.toBe(chunks[0]?.key);
+    expect(bounded.directRecentMessages).toHaveLength(30);
+  });
+
+  test("reduces multibyte direct evidence after removing summaries", () => {
+    const directRecentMessages = Array.from({ length: 500 }, (_, index) => ({
+      id: String(index),
+      content: "界".repeat(500),
+    }));
+    const bounded = buildBoundedSynthesisInput({
+      chunks: [{ summary: "x".repeat(SYNTHESIS_INPUT_BYTE_LIMIT) }],
+      directRecentMessages,
+      hasRepairPrevious: false,
+      buildMessages: ({ chunks, directRecentMessages: direct }) => ({
+        prompt: JSON.stringify({ chunks, direct }),
+      }),
+      serializeMessages: JSON.stringify,
+    });
+
+    expect(bounded.inputBytes).toBeLessThanOrEqual(SYNTHESIS_INPUT_BYTE_LIMIT);
+    expect(bounded.chunks).toHaveLength(0);
+    expect(bounded.directRecentMessages.length).toBeGreaterThanOrEqual(30);
+    expect(bounded.directRecentMessages.length).toBeLessThan(500);
+    expect(bounded.directRecentMessages.at(-1)?.id).toBe("499");
+  });
+
+  test("omits an oversized previous repair before rejecting fixed content", () => {
+    const bounded = buildBoundedSynthesisInput({
+      chunks: [],
+      directRecentMessages: Array.from({ length: 30 }, (_, index) => index),
+      hasRepairPrevious: true,
+      buildMessages: ({ includeRepairPrevious }) => ({
+        prompt: includeRepairPrevious
+          ? "x".repeat(SYNTHESIS_INPUT_BYTE_LIMIT + 1)
+          : "regenerate from the validation error",
+      }),
+      serializeMessages: (messages) => messages.prompt,
+    });
+
+    expect(bounded.includeRepairPrevious).toBe(false);
+  });
+
+  test("raises a non-retryable evidence error when fixed content is impossible", () => {
+    expect(() =>
+      buildBoundedSynthesisInput({
+        chunks: [],
+        directRecentMessages: Array.from({ length: 30 }, (_, index) => index),
+        hasRepairPrevious: false,
+        buildMessages: () => ({
+          prompt: "x".repeat(SYNTHESIS_INPUT_BYTE_LIMIT + 1),
+        }),
+        serializeMessages: (messages) => messages.prompt,
+      }),
+    ).toThrow("reducing direct evidence to 30 messages");
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-synthesis-limit.ts
@@ -1,0 +1,96 @@
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
+
+export const SYNTHESIS_INPUT_BYTE_LIMIT = 600_000;
+export const MINIMUM_DIRECT_SYNTHESIS_MESSAGES = 30;
+
+export class SynthesisInputTooLargeError extends GlitterEvidenceError {
+  constructor(message: string) {
+    super(message);
+    this.name = "SynthesisInputTooLargeError";
+  }
+}
+
+type BoundedSynthesisInput<Chunk, DirectMessage, Messages> = {
+  chunks: readonly Chunk[];
+  directRecentMessages: readonly DirectMessage[];
+  hasRepairPrevious: boolean;
+  buildMessages: (input: {
+    chunks: readonly Chunk[];
+    directRecentMessages: readonly DirectMessage[];
+    includeRepairPrevious: boolean;
+  }) => Messages;
+  serializeMessages: (messages: Messages) => string;
+};
+
+/**
+ * Keep the newest evidence that fits the per-call reservation. Monthly
+ * summaries are reduced first, followed by the oldest direct messages down to
+ * the 30 messages needed by the synthesis response contract. A repair may omit
+ * its previous invalid response as a final fallback; the original card and
+ * validation error remain, so the model can regenerate the complete patch.
+ */
+export function buildBoundedSynthesisInput<Chunk, DirectMessage, Messages>(
+  input: BoundedSynthesisInput<Chunk, DirectMessage, Messages>,
+): {
+  chunks: readonly Chunk[];
+  directRecentMessages: readonly DirectMessage[];
+  includeRepairPrevious: boolean;
+  messages: Messages;
+  inputBytes: number;
+} {
+  const minimumDirectMessages = Math.min(
+    MINIMUM_DIRECT_SYNTHESIS_MESSAGES,
+    input.directRecentMessages.length,
+  );
+  const repairPreviousModes = input.hasRepairPrevious ? [true, false] : [false];
+  const buildCandidate = (candidate: {
+    chunks: readonly Chunk[];
+    directRecentMessages: readonly DirectMessage[];
+    includeRepairPrevious: boolean;
+  }) => {
+    const messages = input.buildMessages(candidate);
+    return {
+      ...candidate,
+      messages,
+      inputBytes: new TextEncoder().encode(input.serializeMessages(messages))
+        .length,
+    };
+  };
+  for (const includeRepairPrevious of repairPreviousModes) {
+    for (
+      let omittedChunks = 0;
+      omittedChunks <= input.chunks.length;
+      omittedChunks += 1
+    ) {
+      const candidate = buildCandidate({
+        chunks: input.chunks.slice(omittedChunks),
+        directRecentMessages: input.directRecentMessages,
+        includeRepairPrevious,
+      });
+      if (candidate.inputBytes <= SYNTHESIS_INPUT_BYTE_LIMIT) {
+        return candidate;
+      }
+    }
+    const maximumOmittedDirectMessages =
+      input.directRecentMessages.length - minimumDirectMessages;
+    for (
+      let omittedDirectMessages = 1;
+      omittedDirectMessages <= maximumOmittedDirectMessages;
+      omittedDirectMessages += 1
+    ) {
+      const candidate = buildCandidate({
+        chunks: [],
+        directRecentMessages: input.directRecentMessages.slice(
+          omittedDirectMessages,
+        ),
+        includeRepairPrevious,
+      });
+      if (candidate.inputBytes <= SYNTHESIS_INPUT_BYTE_LIMIT) {
+        return candidate;
+      }
+    }
+  }
+  throw new SynthesisInputTooLargeError(
+    `fixed Glitter synthesis input exceeds ${String(SYNTHESIS_INPUT_BYTE_LIMIT)} bytes after removing monthly summaries, reducing direct evidence to ${String(minimumDirectMessages)} messages, and omitting the previous repair output`,
+  );
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-synthesis-prompt.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-synthesis-prompt.ts
@@ -1,0 +1,89 @@
+import type { StyleCard } from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import type { SummarizedChunk } from "./glitter-context-refresh-style-generation-cost.ts";
+import { priorFieldValues } from "./glitter-context-refresh-style-finalize.ts";
+import {
+  STYLE_ARRAY_FIELDS,
+  type StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+
+function messageEvidence(message: CurrentMessage): {
+  messageId: string;
+  timestamp: string;
+  content: string;
+} {
+  return {
+    messageId: message.messageId,
+    timestamp: message.timestamp,
+    content: message.content,
+  };
+}
+
+export function synthesisPrompt(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  directRecentMessages: readonly CurrentMessage[];
+  repair: { previous: StyleSynthesis; error: string } | null;
+  includeRepairPrevious: boolean;
+}): string {
+  const base = [
+    "Patch this human-reviewed style card from bounded safe-corpus evidence.",
+    "Return one patch for every listed array field and one decision for every prior index.",
+    "Also patch every prior summary item and every prior League entry by index.",
+    "Retain prior observations unless contradicted or explicitly judged low-confidence.",
+    "Retained observations are copied by the application; do not rewrite them.",
+    "Contradicted removals require corpus evidence. Low-confidence removals must use",
+    "confidence <= 0.3 and explain the judgment.",
+    "Additions require confidence >= 0.7 and cited message IDs.",
+    "Choose 20 unique quote IDs and 30 unique sample IDs from the safe evidence.",
+    "Situational examples are synthetic and must contain exactly three per mood.",
+    "Keep descriptive prose close to the prior card; application validation enforces 85-115%.",
+    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
+    "",
+    JSON.stringify({
+      person: {
+        id: input.candidate.person.id,
+        displayName: input.candidate.person.displayName,
+      },
+      patchFields: STYLE_ARRAY_FIELDS.map((field) => ({
+        field,
+        prior: priorFieldValues(input.existingCard, field).map(
+          (value, priorIndex) => ({ priorIndex, value }),
+        ),
+      })),
+      summaryPatch: {
+        prior:
+          typeof input.existingCard.summary === "string"
+            ? [{ priorIndex: 0, value: input.existingCard.summary }]
+            : input.existingCard.summary.map((value, priorIndex) => ({
+                priorIndex,
+                value,
+              })),
+      },
+      leaguePatch: {
+        prior: Object.entries(input.existingCard.league).map(
+          ([key, value], priorIndex) => ({ priorIndex, key, value }),
+        ),
+      },
+      chunkSummaries: input.chunks,
+      directRecentMessages: input.directRecentMessages.map((message) =>
+        messageEvidence(message),
+      ),
+    }),
+  ].join("\n");
+  return input.repair === null
+    ? base
+    : [
+        base,
+        "",
+        "Repair the prior structured output so it passes deterministic validation.",
+        JSON.stringify({
+          previous: input.includeRepairPrevious
+            ? input.repair.previous
+            : "omitted because the prior invalid response exceeded the bounded request budget",
+          error: input.repair.error,
+        }),
+      ].join("\n");
+}

--- a/packages/temporal/src/activities/glitter-context-refresh.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh.ts
@@ -38,10 +38,8 @@ import {
   GenerationBudget,
   type GenerationBudgetSummary,
 } from "./glitter-context-refresh-budget.ts";
-import {
-  applyRelationshipProposals,
-  selectRelationshipEvidence,
-} from "./glitter-context-refresh-relationships.ts";
+import { applyRelationshipProposals } from "./glitter-context-refresh-relationships.ts";
+import { prepareRelationshipEvaluation } from "./glitter-context-refresh-relationship-batching.ts";
 import {
   GLITTER_GENERATION_STATE_PATH,
   GLITTER_PEOPLE_PATH,
@@ -50,7 +48,6 @@ import {
 } from "./glitter-context-refresh-paths.ts";
 import { selectStyleRefreshCandidates } from "./glitter-context-refresh-selection.ts";
 import {
-  shouldEvaluateRelationships,
   shouldFailRefreshRun,
   shouldPersistRelationshipEvaluation,
   updateGenerationState,
@@ -229,26 +226,17 @@ export const glitterContextRefreshActivities = {
           ),
         );
       }
-      const relationshipsEvaluated = shouldEvaluateRelationships(
-        generationState.relationshipSourceSnapshotChecksum,
-        corpus.reference.snapshotSha256,
-      );
-      const relationshipEvidence = relationshipsEvaluated
-        ? selectRelationshipEvidence({
-            people: peopleDocument.people,
-            messages: corpus.messages,
-          })
-        : [];
-      const relationshipGenerationInput = {
-        people: peopleDocument.people.map((person) => ({
-          id: person.id,
-          displayName: person.displayName,
-        })),
-        currentRelationships: relationshipsDocument.events.filter(
-          (event) => event.status === "current",
-        ),
-        evidence: relationshipEvidence,
-      };
+      const relationshipEvaluation = prepareRelationshipEvaluation({
+        state: generationState,
+        people: peopleDocument,
+        relationships: relationshipsDocument,
+        messages: corpus.messages,
+        snapshotSha256: corpus.reference.snapshotSha256,
+      });
+      const relationshipsEvaluated = relationshipEvaluation.evaluated;
+      const relationshipEvidence = relationshipEvaluation.evidence;
+      const relationshipGenerationInput =
+        relationshipEvaluation.generationInput;
       const generationBudget = new GenerationBudget(input.maxEstimatedCostUsd);
       const stylePreflightCost = candidates.reduce((total, candidate) => {
         const existingCard = existingCards.get(candidate.person.id);
@@ -362,6 +350,7 @@ export const glitterContextRefreshActivities = {
       const persistRelationshipEvaluation = shouldPersistRelationshipEvaluation(
         {
           evaluated: relationshipsEvaluated,
+          relationshipEvaluationProgressed: relationshipEvaluation.progressed,
           refreshedPeopleCount: refreshedPeople.size,
           relationshipProposalCount,
         },
@@ -373,6 +362,9 @@ export const glitterContextRefreshActivities = {
         snapshotSha256: corpus.reference.snapshotSha256,
         refreshedAt,
         relationshipsEvaluated: persistRelationshipEvaluation,
+        relationshipEvaluationComplete: relationshipEvaluation.complete,
+        relationshipEvaluationProgressed: relationshipEvaluation.progressed,
+        relationshipEvaluationCursor: relationshipEvaluation.cursor,
       });
       await Bun.write(
         `${repoDir}/${GLITTER_GENERATION_STATE_PATH}`,

--- a/packages/temporal/src/activities/glitter-corpus-baseline.ts
+++ b/packages/temporal/src/activities/glitter-corpus-baseline.ts
@@ -1,14 +1,15 @@
 import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
 import { loadStateManifest } from "./glitter-corpus-io.ts";
-import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
+import type { CorpusStore } from "./glitter-corpus-store.ts";
 import { readVerifiedObject } from "./glitter-corpus-storage.ts";
 
 export async function readBaselineProjection(input: {
+  store: CorpusStore;
   manifestKey: string;
   guildId: string;
   channelId: string;
 }) {
-  const baseline = await loadStateManifest(input.manifestKey);
+  const baseline = await loadStateManifest(input.store, input.manifestKey);
   if (
     baseline.guildId !== input.guildId ||
     baseline.channelId !== input.channelId
@@ -16,7 +17,7 @@ export async function readBaselineProjection(input: {
     throw new Error(`baseline state identity mismatch for ${input.channelId}`);
   }
   const bytes = await readVerifiedObject({
-    store: createCorpusStoreFromEnv(),
+    store: input.store,
     key: baseline.projectionObjectKey,
     expectedSha256: baseline.projectionSha256,
   });

--- a/packages/temporal/src/activities/glitter-corpus-io.ts
+++ b/packages/temporal/src/activities/glitter-corpus-io.ts
@@ -18,7 +18,7 @@ import {
   assertDiscordPageOrder,
   nextTraversalCursor,
 } from "./glitter-corpus-page-order.ts";
-import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
+import type { CorpusStore } from "./glitter-corpus-store.ts";
 import {
   putImmutableObject,
   readObject,
@@ -36,12 +36,11 @@ export function requireGlitterCorpusEnv(name: string): string {
 }
 
 function parseDenylist(value: string): string[] {
-  if (value.trim() === "") {
-    return [];
-  }
-  return z
-    .array(z.string().regex(/^\d+$/))
-    .parse(value.split(",").map((entry) => entry.trim()));
+  return value.trim() === ""
+    ? []
+    : z
+        .array(z.string().regex(/^\d+$/))
+        .parse(value.split(",").map((entry) => entry.trim()));
 }
 
 export function glitterCorpusRuntimeConfig(): {
@@ -83,28 +82,28 @@ function parseNdjson(
 }
 
 export async function readCorpusJson<T>(
+  store: CorpusStore,
   key: string,
   schema: z.ZodType<T>,
 ): Promise<T> {
-  const store = createCorpusStoreFromEnv();
   const bytes = await readRequiredObject({ store, key });
   return schema.parse(JSON.parse(new TextDecoder().decode(bytes)));
 }
 
 export async function readCorpusPage(
+  store: CorpusStore,
   key: string,
   expectedDirection: "backward" | "forward" | "daily-overlap",
 ): Promise<{
   manifest: PageManifest;
   messages: z.infer<typeof DiscordApiMessageSchema>[];
 }> {
-  const manifest = await readCorpusJson(key, PageManifestSchema);
+  const manifest = await readCorpusJson(store, key, PageManifestSchema);
   if (manifest.direction !== expectedDirection) {
     throw new Error(
       `page manifest ${key} has direction ${manifest.direction}, expected ${expectedDirection}`,
     );
   }
-  const store = createCorpusStoreFromEnv();
   const bytes = await readVerifiedObject({
     store,
     key: manifest.rawObjectKey,
@@ -196,6 +195,7 @@ function traversalTerminalReason(input: {
 }
 
 export async function readTraversal(input: {
+  store: CorpusStore;
   guildId: string;
   guildSlug: string;
   channelId: string;
@@ -222,7 +222,7 @@ export async function readTraversal(input: {
   let reachedUpperBound = false;
   let expectedCursor = input.initialAfter;
   for (const key of input.pageManifestKeys) {
-    const page = await readCorpusPage(key, input.direction);
+    const page = await readCorpusPage(input.store, key, input.direction);
     assertTraversalPage({
       key,
       page,
@@ -291,6 +291,7 @@ export async function readTraversal(input: {
 }
 
 export async function readOverlapTraversal(input: {
+  store: CorpusStore;
   guildId: string;
   guildSlug: string;
   channelId: string;
@@ -307,7 +308,7 @@ export async function readOverlapTraversal(input: {
   let terminal: PageManifest | undefined;
   let expectedBefore: string | undefined;
   for (const key of input.pageManifestKeys) {
-    const page = await readCorpusPage(key, "daily-overlap");
+    const page = await readCorpusPage(input.store, key, "daily-overlap");
     if (
       page.manifest.guildId !== input.guildId ||
       page.manifest.channelId !== input.channelId
@@ -343,16 +344,16 @@ export async function readOverlapTraversal(input: {
 }
 
 export async function readSeedChannelObservations(input: {
+  store: CorpusStore;
   seedPrefix: string | undefined;
   channelId: string;
 }): Promise<CorpusObservation[]> {
   if (input.seedPrefix === undefined) {
     return [];
   }
-  const store = createCorpusStoreFromEnv();
   const manifestKey = `${input.seedPrefix}/manifest.json`;
   const manifestBytes = await readRequiredObject({
-    store,
+    store: input.store,
     key: manifestKey,
   });
   const manifest = SeedImportManifestSchema.parse(
@@ -366,8 +367,8 @@ export async function readSeedChannelObservations(input: {
   const key = `${input.seedPrefix}/channels/${input.channelId}/observations.ndjson`;
   const shouldExist = manifest.channelIds.includes(input.channelId);
   const bytes = shouldExist
-    ? await readRequiredObject({ store, key })
-    : await readObject({ store, key });
+    ? await readRequiredObject({ store: input.store, key })
+    : await readObject({ store: input.store, key });
   if (!shouldExist && bytes !== undefined) {
     throw new Error(
       `seed channel partition presence disagrees with ${manifestKey}: ${key}`,
@@ -392,12 +393,14 @@ export async function readSeedChannelObservations(input: {
 }
 
 export async function validateSeedForApprovedInventory(input: {
+  store: CorpusStore;
   seedPrefix: string;
   guildId: string;
   guildSlug: string;
   approvedChannelIds: readonly string[];
 }): Promise<void> {
   const manifest = await readCorpusJson(
+    input.store,
     `${input.seedPrefix}/manifest.json`,
     SeedImportManifestSchema,
   );
@@ -414,9 +417,8 @@ export async function validateSeedForApprovedInventory(input: {
       `trusted seed guild ${manifest.guildId}/${manifest.guildSlug} does not match approved inventory ${input.guildId}/${input.guildSlug}`,
     );
   }
-  const store = createCorpusStoreFromEnv();
   const archiveBytes = await readVerifiedObject({
-    store,
+    store: input.store,
     key: `${input.seedPrefix}/archive.zip`,
     expectedSha256: manifest.archiveSha256,
   });
@@ -426,7 +428,7 @@ export async function validateSeedForApprovedInventory(input: {
     );
   }
   await readVerifiedObject({
-    store,
+    store: input.store,
     key: `${input.seedPrefix}/projection.ndjson`,
     expectedSha256: manifest.projectionSha256,
   });
@@ -442,12 +444,14 @@ export async function validateSeedForApprovedInventory(input: {
 }
 
 export async function loadStateManifest(
+  store: CorpusStore,
   key: string,
 ): Promise<ChannelStateManifest> {
-  return await readCorpusJson(key, ChannelStateManifestSchema);
+  return await readCorpusJson(store, key, ChannelStateManifestSchema);
 }
 
 export async function writeChannelProjection(input: {
+  store: CorpusStore;
   guildId: string;
   channelId: string;
   snapshotId: string;
@@ -459,7 +463,7 @@ export async function writeChannelProjection(input: {
     `${input.snapshotId}.ndjson`;
   const body = new TextEncoder().encode(input.projectionNdjson);
   await putImmutableObject({
-    store: createCorpusStoreFromEnv(),
+    store: input.store,
     key,
     body,
     contentType: "application/x-ndjson",
@@ -469,6 +473,7 @@ export async function writeChannelProjection(input: {
 }
 
 export async function writeChannelState(input: {
+  store: CorpusStore;
   guildId: string;
   channelId: string;
   snapshotId: string;
@@ -480,7 +485,7 @@ export async function writeChannelState(input: {
     `guilds/${input.guildId}/channels/${input.channelId}/states/` +
     `${input.snapshotId}.json`;
   const manifestObject = await putImmutableObject({
-    store: createCorpusStoreFromEnv(),
+    store: input.store,
     key: manifestKey,
     body: jsonBytes(input.manifest),
     contentType: "application/json",

--- a/packages/temporal/src/activities/glitter-corpus-recovery.test.ts
+++ b/packages/temporal/src/activities/glitter-corpus-recovery.test.ts
@@ -1,0 +1,454 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ChannelCompletenessManifestSchema,
+  ChannelOverlapManifestSchema,
+  CorpusObservationSchema,
+  GuildSnapshotSchema,
+  PageManifestSchema,
+  StoredObjectSchema,
+  type ChannelStateManifest,
+  type CorpusObservation,
+  type CurrentMessage,
+} from "#shared/glitter-corpus.ts";
+import {
+  mergeCurrentProjection,
+  projectionChecksum,
+  serializeProjection,
+} from "#shared/glitter-corpus-projection.ts";
+import {
+  loadStateManifest,
+  readOverlapTraversal,
+  readSeedChannelObservations,
+  readTraversal,
+} from "./glitter-corpus-io.ts";
+import { readVerifiedObject } from "./glitter-corpus-storage.ts";
+import type * as GlitterCorpusStorage from "./glitter-corpus-storage.ts";
+import type { CorpusStore } from "./glitter-corpus-store.ts";
+import { verifyGlitterCorpusSnapshotGraph } from "./glitter-corpus-recovery.ts";
+
+vi.mock("./glitter-corpus-io.ts", () => ({
+  loadStateManifest: vi.fn(),
+  readOverlapTraversal: vi.fn(),
+  readSeedChannelObservations: vi.fn(),
+  readTraversal: vi.fn(),
+}));
+
+vi.mock("./glitter-corpus-storage.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof GlitterCorpusStorage>();
+  return { ...actual, readVerifiedObject: vi.fn() };
+});
+
+const CREATED_AT = "2026-08-30T12:00:00.000Z";
+const GUILD_ID = "1000";
+const SHA256 = "a".repeat(64);
+
+function observation(channelId: string, messageId: string): CorpusObservation {
+  return CorpusObservationSchema.parse({
+    schemaVersion: 1,
+    source: "discord-rest",
+    sourceKey: `raw/${channelId}/${messageId}`,
+    observedAt: CREATED_AT,
+    guildId: GUILD_ID,
+    guildSlug: "glitter-boys",
+    channelId,
+    messageId,
+    author: {
+      id: "2000",
+      username: "tester",
+      globalName: "Tester",
+      discriminator: "0",
+      bot: false,
+      avatar: null,
+    },
+    content: `message-${messageId}`,
+    timestamp: CREATED_AT,
+    editedTimestamp: null,
+    type: 0,
+    flags: "0",
+    pinned: false,
+    tts: false,
+    attachments: [],
+    referencedMessageId: null,
+    raw: { id: messageId },
+  });
+}
+
+function storedObject(key: string) {
+  return StoredObjectSchema.parse({
+    key,
+    sha256: SHA256,
+    receipt: {
+      store: "seaweedfs",
+      bucket: "corpus",
+      key,
+      sha256: SHA256,
+      etag: "etag",
+      writtenAt: CREATED_AT,
+    },
+  });
+}
+
+function terminalPage(input: {
+  channelId: string;
+  direction: "backward" | "forward" | "daily-overlap";
+  responseCount: 0 | 1;
+  messageId: string;
+}) {
+  const hasMessage = input.responseCount === 1;
+  return PageManifestSchema.parse({
+    schemaVersion: 1,
+    requestId: `00000000-0000-4000-8000-${input.channelId.padStart(12, "0")}`,
+    guildId: GUILD_ID,
+    channelId: input.channelId,
+    direction: input.direction,
+    before: null,
+    after: input.direction === "forward" ? "0" : null,
+    requestedAt: CREATED_AT,
+    completedAt: CREATED_AT,
+    responseCount: input.responseCount,
+    firstMessageId: hasMessage ? input.messageId : null,
+    lastMessageId: hasMessage ? input.messageId : null,
+    rawObjectKey: `raw/${input.channelId}/${input.direction}`,
+    rawSha256: SHA256,
+    retryCount: 0,
+    rateLimit: {
+      limit: 100,
+      remaining: 99,
+      resetAfterSeconds: 0,
+      bucket: "test",
+    },
+  });
+}
+
+function completeManifest(input: {
+  channelId: string;
+  messageId: string;
+  projection: readonly CurrentMessage[];
+  mismatch?: "count" | "checksum";
+}): ChannelStateManifest {
+  const backwardKey = `pages/${input.channelId}/backward`;
+  const forwardKey = `pages/${input.channelId}/forward`;
+  return ChannelCompletenessManifestSchema.parse({
+    schemaVersion: 1,
+    snapshotId: `00000000-0000-4000-8001-${input.channelId.padStart(12, "0")}`,
+    guildId: GUILD_ID,
+    channelId: input.channelId,
+    verifiedAt: CREATED_AT,
+    lineageDepth: 0,
+    seedPrefix: null,
+    retainedBaselineManifestKey: null,
+    retainedBaselineMessageCount: 0,
+    backwardProof: {
+      direction: "backward",
+      pageManifestKeys: [backwardKey],
+      terminalPageManifestKey: backwardKey,
+      terminalResponseCount: 0,
+      terminalReason: "empty-channel",
+      upperBoundMessageId: null,
+    },
+    forwardProof: {
+      direction: "forward",
+      pageManifestKeys: [forwardKey],
+      terminalPageManifestKey: forwardKey,
+      terminalResponseCount: 1,
+      terminalReason: "reached-upper-bound",
+      upperBoundMessageId: input.messageId,
+    },
+    observationCount: 2,
+    seedObservationCount: 0,
+    duplicateObservationCount: 1,
+    uniqueMessageCount:
+      input.mismatch === "count" ? 2 : input.projection.length,
+    oldestMessageId: input.messageId,
+    newestMessageId: input.messageId,
+    projectionObjectKey: `projections/${input.channelId}/base.ndjson`,
+    projectionSha256:
+      input.mismatch === "checksum"
+        ? "b".repeat(64)
+        : projectionChecksum(input.projection),
+    complete: true,
+  });
+}
+
+function overlapManifest(input: {
+  channelId: string;
+  messageId: string;
+  baselineKey: string;
+  projection: readonly CurrentMessage[];
+}): ChannelStateManifest {
+  return ChannelOverlapManifestSchema.parse({
+    schemaVersion: 1,
+    snapshotId: `00000000-0000-4000-8002-${input.channelId.padStart(12, "0")}`,
+    guildId: GUILD_ID,
+    channelId: input.channelId,
+    verifiedAt: CREATED_AT,
+    lineageDepth: 1,
+    seedPrefix: null,
+    baselineManifestKey: input.baselineKey,
+    overlapPageManifestKeys: [`pages/${input.channelId}/overlap`],
+    overlapCutoff: CREATED_AT,
+    baselineNewestMessageId: input.messageId,
+    oldestObservedTimestamp: CREATED_AT,
+    oldestObservedMessageId: input.messageId,
+    stoppedBecause: "cutoff-reached",
+    observationCount: 1,
+    uniqueMessageCount: input.projection.length,
+    oldestMessageId: input.messageId,
+    newestMessageId: input.messageId,
+    projectionObjectKey: `projections/${input.channelId}/overlap.ndjson`,
+    projectionSha256: projectionChecksum(input.projection),
+    complete: true,
+  });
+}
+
+function snapshot(channelIds: readonly string[], uniqueMessageCount: number) {
+  return GuildSnapshotSchema.parse({
+    schemaVersion: 1,
+    snapshotId: "00000000-0000-4000-8000-000000000999",
+    guildId: GUILD_ID,
+    createdAt: CREATED_AT,
+    inventoryObject: storedObject("inventory.json"),
+    channelManifestObjects: channelIds.map((channelId) =>
+      storedObject(`states/${channelId}/top.json`),
+    ),
+    expectedChannelIds: channelIds,
+    completeChannelIds: channelIds,
+    uniqueMessageCount,
+    complete: true,
+  });
+}
+
+function testStore(): CorpusStore {
+  return {
+    name: "seaweedfs",
+    bucket: "corpus",
+    client: new S3Client({
+      region: "us-east-1",
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    }),
+  };
+}
+
+function recoveryFixtures() {
+  const observations = new Map([
+    ["10", observation("10", "110")],
+    ["20", observation("20", "220")],
+  ]);
+  const projections = new Map(
+    [...observations].map(([channelId, value]) => [
+      channelId,
+      mergeCurrentProjection([], [value]),
+    ]),
+  );
+  const manifests = new Map<string, ChannelStateManifest>();
+  for (const channelId of observations.keys()) {
+    const message = observations.get(channelId);
+    const projection = projections.get(channelId);
+    if (message === undefined || projection === undefined) {
+      throw new Error(`missing fixture for ${channelId}`);
+    }
+    const baselineKey = `states/${channelId}/base.json`;
+    manifests.set(
+      baselineKey,
+      completeManifest({
+        channelId,
+        messageId: message.messageId,
+        projection,
+      }),
+    );
+    manifests.set(
+      `states/${channelId}/top.json`,
+      overlapManifest({
+        channelId,
+        messageId: message.messageId,
+        baselineKey,
+        projection,
+      }),
+    );
+  }
+  return { observations, projections, manifests };
+}
+
+function installRecoveryReaderMocks(input: {
+  store: CorpusStore;
+  observations: ReadonlyMap<string, CorpusObservation>;
+  projections: ReadonlyMap<string, readonly CurrentMessage[]>;
+  manifests: ReadonlyMap<string, ChannelStateManifest>;
+}): void {
+  vi.mocked(loadStateManifest).mockImplementation(async (store, key) => {
+    expect(store).toBe(input.store);
+    const manifest = input.manifests.get(key);
+    if (manifest === undefined) {
+      throw new Error(`unexpected manifest ${key}`);
+    }
+    return manifest;
+  });
+  vi.mocked(readTraversal).mockImplementation(async (traversalInput) => {
+    expect(traversalInput.store).toBe(input.store);
+    const message = input.observations.get(traversalInput.channelId);
+    if (message === undefined) {
+      throw new Error(`unexpected channel ${traversalInput.channelId}`);
+    }
+    return traversalInput.direction === "backward"
+      ? {
+          observations: [message],
+          messageIds: [message.messageId],
+          terminal: terminalPage({
+            channelId: traversalInput.channelId,
+            direction: "backward",
+            responseCount: 0,
+            messageId: message.messageId,
+          }),
+          terminalReason: "empty-channel" as const,
+        }
+      : {
+          observations: [message],
+          messageIds: [message.messageId],
+          terminal: terminalPage({
+            channelId: traversalInput.channelId,
+            direction: "forward",
+            responseCount: 1,
+            messageId: message.messageId,
+          }),
+          terminalReason: "reached-upper-bound" as const,
+        };
+  });
+  vi.mocked(readOverlapTraversal).mockImplementation(async (overlapInput) => {
+    expect(overlapInput.store).toBe(input.store);
+    const message = input.observations.get(overlapInput.channelId);
+    if (message === undefined) {
+      throw new Error(`unexpected channel ${overlapInput.channelId}`);
+    }
+    return {
+      observations: [message],
+      messageIds: [message.messageId],
+      timestamps: [message.timestamp],
+      terminal: terminalPage({
+        channelId: overlapInput.channelId,
+        direction: "daily-overlap",
+        responseCount: 1,
+        messageId: message.messageId,
+      }),
+    };
+  });
+  vi.mocked(readSeedChannelObservations).mockImplementation(
+    async (seedInput) => {
+      expect(seedInput.store).toBe(input.store);
+      return [];
+    },
+  );
+  vi.mocked(readVerifiedObject).mockImplementation(async (objectInput) => {
+    expect(objectInput.store).toBe(input.store);
+    const channelId = objectInput.key.split("/")[1];
+    const projection =
+      channelId === undefined ? undefined : input.projections.get(channelId);
+    return new TextEncoder().encode(
+      projection === undefined ? "" : serializeProjection(projection),
+    );
+  });
+}
+
+describe("Glitter corpus snapshot recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("isolates each channel lineage while reusing one store and reporting progress", async () => {
+    const store = testStore();
+    const fixtures = recoveryFixtures();
+    installRecoveryReaderMocks({ store, ...fixtures });
+
+    const progress: unknown[] = [];
+    await expect(
+      verifyGlitterCorpusSnapshotGraph({
+        snapshot: snapshot(["10", "20"], 2),
+        guildSlug: "glitter-boys",
+        store,
+        onProgress: (value) => progress.push(value),
+      }),
+    ).resolves.toBe(2);
+
+    expect(progress).toEqual([
+      {
+        manifestKey: "states/10/top.json",
+        verifiedChannels: 1,
+        totalChannels: 2,
+        lineageStateCount: 2,
+      },
+      {
+        manifestKey: "states/20/top.json",
+        verifiedChannels: 2,
+        totalChannels: 2,
+        lineageStateCount: 2,
+      },
+    ]);
+    expect(
+      new Set(
+        vi.mocked(readVerifiedObject).mock.calls.map(([input]) => input.store),
+      ),
+    ).toEqual(new Set([store]));
+    store.client.destroy();
+  });
+
+  it.each(["count", "checksum"] as const)(
+    "rejects a projection %s mismatch",
+    async (mismatch) => {
+      const store = {
+        name: "seaweedfs",
+        bucket: "corpus",
+        client: new S3Client({
+          region: "us-east-1",
+          credentials: { accessKeyId: "test", secretAccessKey: "test" },
+        }),
+      } as const;
+      const message = observation("10", "110");
+      const projection = mergeCurrentProjection([], [message]);
+      const manifest = completeManifest({
+        channelId: "10",
+        messageId: message.messageId,
+        projection,
+        mismatch,
+      });
+      vi.mocked(loadStateManifest).mockResolvedValue(manifest);
+      vi.mocked(readTraversal).mockImplementation(async (input) =>
+        input.direction === "backward"
+          ? {
+              observations: [message],
+              messageIds: [message.messageId],
+              terminal: terminalPage({
+                channelId: "10",
+                direction: "backward",
+                responseCount: 0,
+                messageId: message.messageId,
+              }),
+              terminalReason: "empty-channel" as const,
+            }
+          : {
+              observations: [message],
+              messageIds: [message.messageId],
+              terminal: terminalPage({
+                channelId: "10",
+                direction: "forward",
+                responseCount: 1,
+                messageId: message.messageId,
+              }),
+              terminalReason: "reached-upper-bound" as const,
+            },
+      );
+      vi.mocked(readSeedChannelObservations).mockResolvedValue([]);
+      vi.mocked(readVerifiedObject).mockResolvedValue(
+        new TextEncoder().encode(serializeProjection(projection)),
+      );
+
+      await expect(
+        verifyGlitterCorpusSnapshotGraph({
+          snapshot: snapshot(["10"], mismatch === "count" ? 2 : 1),
+          guildSlug: "glitter-boys",
+          store,
+        }),
+      ).rejects.toThrow("rebuilt projection does not match state");
+      store.client.destroy();
+    },
+  );
+});

--- a/packages/temporal/src/activities/glitter-corpus-recovery.ts
+++ b/packages/temporal/src/activities/glitter-corpus-recovery.ts
@@ -17,7 +17,10 @@ import {
   readSeedChannelObservations,
   readTraversal,
 } from "./glitter-corpus-io.ts";
-import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
+import {
+  createCorpusStoreFromEnv,
+  type CorpusStore,
+} from "./glitter-corpus-store.ts";
 import {
   LatestSnapshotPointerSchema,
   readRequiredObject,
@@ -26,8 +29,16 @@ import {
 
 type RebuildContext = {
   guildSlug: string;
+  store: CorpusStore;
   cache: Map<string, CurrentMessage[]>;
   active: Set<string>;
+};
+
+export type GlitterCorpusVerificationProgress = {
+  manifestKey: string;
+  verifiedChannels: number;
+  totalChannels: number;
+  lineageStateCount: number;
 };
 
 function immediatelyBefore(messageId: string): string {
@@ -57,11 +68,12 @@ function assertProjectionMatchesManifest(
 }
 
 async function readRetainedBaselineProjection(input: {
+  store: CorpusStore;
   manifestKey: string;
   guildId: string;
   channelId: string;
 }): Promise<CurrentMessage[]> {
-  const manifest = await loadStateManifest(input.manifestKey);
+  const manifest = await loadStateManifest(input.store, input.manifestKey);
   if (
     manifest.guildId !== input.guildId ||
     manifest.channelId !== input.channelId
@@ -71,7 +83,7 @@ async function readRetainedBaselineProjection(input: {
     );
   }
   const bytes = await readVerifiedObject({
-    store: createCorpusStoreFromEnv(),
+    store: input.store,
     key: manifest.projectionObjectKey,
     expectedSha256: manifest.projectionSha256,
   });
@@ -89,6 +101,7 @@ async function rebuildCompleteState(
   context: RebuildContext,
 ): Promise<CurrentMessage[]> {
   const backward = await readTraversal({
+    store: context.store,
     guildId: manifest.guildId,
     guildSlug: context.guildSlug,
     channelId: manifest.channelId,
@@ -97,6 +110,7 @@ async function rebuildCompleteState(
   });
   const oldestMessageId = backward.messageIds.toSorted(compareSnowflakes)[0];
   const forward = await readTraversal({
+    store: context.store,
     guildId: manifest.guildId,
     guildSlug: context.guildSlug,
     channelId: manifest.channelId,
@@ -137,6 +151,7 @@ async function rebuildCompleteState(
     );
   }
   const seed = await readSeedChannelObservations({
+    store: context.store,
     seedPrefix: manifest.seedPrefix ?? undefined,
     channelId: manifest.channelId,
   });
@@ -158,6 +173,7 @@ async function rebuildCompleteState(
     manifest.retainedBaselineManifestKey === null
       ? []
       : await readRetainedBaselineProjection({
+          store: context.store,
           manifestKey: manifest.retainedBaselineManifestKey,
           guildId: manifest.guildId,
           channelId: manifest.channelId,
@@ -183,22 +199,33 @@ async function rebuildCompleteState(
 export async function verifyGlitterCorpusSnapshotGraph(input: {
   snapshot: GuildSnapshot;
   guildSlug: string;
+  store: CorpusStore;
+  onProgress?: (progress: GlitterCorpusVerificationProgress) => void;
 }): Promise<number> {
-  const store = createCorpusStoreFromEnv();
-  const context: RebuildContext = {
-    guildSlug: input.guildSlug,
-    cache: new Map(),
-    active: new Set(),
-  };
   let uniqueMessageCount = 0;
-  for (const manifestObject of input.snapshot.channelManifestObjects) {
+  for (const [
+    index,
+    manifestObject,
+  ] of input.snapshot.channelManifestObjects.entries()) {
     await readVerifiedObject({
-      store,
+      store: input.store,
       key: manifestObject.key,
       expectedSha256: manifestObject.sha256,
     });
+    const context: RebuildContext = {
+      guildSlug: input.guildSlug,
+      store: input.store,
+      cache: new Map(),
+      active: new Set(),
+    };
     const projection = await rebuildState(manifestObject.key, context);
     uniqueMessageCount += projection.length;
+    input.onProgress?.({
+      manifestKey: manifestObject.key,
+      verifiedChannels: index + 1,
+      totalChannels: input.snapshot.channelManifestObjects.length,
+      lineageStateCount: context.cache.size,
+    });
   }
   if (uniqueMessageCount !== input.snapshot.uniqueMessageCount) {
     throw new Error(
@@ -215,6 +242,7 @@ async function rebuildOverlapState(
   const baseline = await rebuildState(manifest.baselineManifestKey, context);
   const { observations, messageIds, timestamps, terminal } =
     await readOverlapTraversal({
+      store: context.store,
       guildId: manifest.guildId,
       guildSlug: context.guildSlug,
       channelId: manifest.channelId,
@@ -259,14 +287,14 @@ async function rebuildState(
     throw new Error(`cycle in corpus state chain at ${manifestKey}`);
   }
   context.active.add(manifestKey);
-  const manifest = await loadStateManifest(manifestKey);
+  const manifest = await loadStateManifest(context.store, manifestKey);
   const projection =
     "backwardProof" in manifest
       ? await rebuildCompleteState(manifest, context)
       : await rebuildOverlapState(manifest, context);
   assertProjectionMatchesManifest(manifest, projection);
   await readVerifiedObject({
-    store: createCorpusStoreFromEnv(),
+    store: context.store,
     key: manifest.projectionObjectKey,
     expectedSha256: manifest.projectionSha256,
   });
@@ -314,6 +342,7 @@ export async function verifyLatestGlitterCorpusSnapshot(): Promise<{
   const uniqueMessageCount = await verifyGlitterCorpusSnapshotGraph({
     snapshot,
     guildSlug: inventory.guildSlug,
+    store,
   });
   return {
     guildId,

--- a/packages/temporal/src/activities/glitter-corpus-snapshot.test.ts
+++ b/packages/temporal/src/activities/glitter-corpus-snapshot.test.ts
@@ -1,0 +1,148 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GuildInventorySchema,
+  StoredObjectSchema,
+} from "#shared/glitter-corpus.ts";
+import { FinalizeSnapshotInputSchema } from "#shared/glitter-corpus-activity-types.ts";
+import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
+import {
+  publishLatestSnapshotPointer,
+  putImmutableObject,
+  readVerifiedObject,
+} from "./glitter-corpus-storage.ts";
+import type * as GlitterCorpusStorage from "./glitter-corpus-storage.ts";
+import { verifyGlitterCorpusSnapshotGraph } from "./glitter-corpus-recovery.ts";
+import { finalizeGlitterCorpusSnapshot } from "./glitter-corpus-snapshot.ts";
+
+const activityMocks = vi.hoisted(() => ({ heartbeat: vi.fn() }));
+
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: () => ({ heartbeat: activityMocks.heartbeat }),
+  },
+}));
+
+vi.mock("./glitter-corpus-store.ts", () => ({
+  createCorpusStoreFromEnv: vi.fn(),
+}));
+
+vi.mock("./glitter-corpus-storage.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof GlitterCorpusStorage>();
+  return {
+    ...actual,
+    publishLatestSnapshotPointer: vi.fn(),
+    putImmutableObject: vi.fn(),
+    readVerifiedObject: vi.fn(),
+  };
+});
+
+vi.mock("./glitter-corpus-recovery.ts", () => ({
+  verifyGlitterCorpusSnapshotGraph: vi.fn(),
+}));
+
+const CREATED_AT = "2026-08-30T12:00:00.000Z";
+const SHA256 = "a".repeat(64);
+
+function storedObject(key: string) {
+  return StoredObjectSchema.parse({
+    key,
+    sha256: SHA256,
+    receipt: {
+      store: "seaweedfs",
+      bucket: "corpus",
+      key,
+      sha256: SHA256,
+      etag: "etag",
+      writtenAt: CREATED_AT,
+    },
+  });
+}
+
+describe("Glitter corpus snapshot finalization", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("uses one store and clears periodic heartbeats after publication", async () => {
+    vi.useFakeTimers();
+    const store = {
+      name: "seaweedfs",
+      bucket: "corpus",
+      client: new S3Client({
+        region: "us-east-1",
+        credentials: { accessKeyId: "test", secretAccessKey: "test" },
+      }),
+    } as const;
+    const inventory = GuildInventorySchema.parse({
+      schemaVersion: 1,
+      guildId: "1000",
+      guildSlug: "glitter-boys",
+      guildName: "Glitter Boys",
+      discoveredAt: CREATED_AT,
+      denylistedChannelIds: [],
+      entries: [],
+      sha256: SHA256,
+    });
+    const inventoryObject = storedObject("inventory.json");
+    const manifestObject = storedObject("states/10/top.json");
+    const input = FinalizeSnapshotInputSchema.parse({
+      snapshotId: "00000000-0000-4000-8000-000000000999",
+      guildId: "1000",
+      createdAt: CREATED_AT,
+      inventoryObject,
+      expectedChannelIds: ["10"],
+      channelStates: [
+        {
+          channelId: "10",
+          manifestKey: manifestObject.key,
+          manifestObject,
+          uniqueMessageCount: 1,
+        },
+      ],
+    });
+
+    vi.mocked(createCorpusStoreFromEnv).mockReturnValue(store);
+    vi.mocked(readVerifiedObject).mockResolvedValue(
+      new TextEncoder().encode(JSON.stringify(inventory)),
+    );
+    vi.mocked(verifyGlitterCorpusSnapshotGraph).mockImplementation(
+      async (verificationInput) => {
+        expect(verificationInput.store).toBe(store);
+        verificationInput.onProgress?.({
+          manifestKey: manifestObject.key,
+          verifiedChannels: 1,
+          totalChannels: 1,
+          lineageStateCount: 2,
+        });
+        return 1;
+      },
+    );
+    vi.mocked(putImmutableObject).mockImplementation(async (writeInput) => {
+      expect(writeInput.store).toBe(store);
+      return storedObject(writeInput.key);
+    });
+    vi.mocked(publishLatestSnapshotPointer).mockImplementation(
+      async (publishInput) => {
+        expect(publishInput.store).toBe(store);
+      },
+    );
+
+    const result = await finalizeGlitterCorpusSnapshot(input);
+
+    expect(result.snapshot.uniqueMessageCount).toBe(1);
+    expect(createCorpusStoreFromEnv).toHaveBeenCalledTimes(1);
+    expect(activityMocks.heartbeat).toHaveBeenCalledWith({
+      phase: "verify-snapshot",
+      manifestKey: manifestObject.key,
+      verifiedChannels: 1,
+      totalChannels: 1,
+      lineageStateCount: 2,
+    });
+    const heartbeatCount = activityMocks.heartbeat.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(activityMocks.heartbeat).toHaveBeenCalledTimes(heartbeatCount);
+    store.client.destroy();
+  });
+});

--- a/packages/temporal/src/activities/glitter-corpus-snapshot.ts
+++ b/packages/temporal/src/activities/glitter-corpus-snapshot.ts
@@ -1,3 +1,4 @@
+import { Context } from "@temporalio/activity";
 import type { z } from "zod/v4";
 import {
   GuildInventorySchema,
@@ -37,6 +38,8 @@ const SNAPSHOT_METRICS_ENVIRONMENT = [
   "GLITTER_CORPUS_S3_ACCESS_KEY_ID",
   "GLITTER_CORPUS_S3_SECRET_ACCESS_KEY",
 ] as const;
+
+const FINALIZATION_HEARTBEAT_INTERVAL_MS = 10_000;
 
 export async function restoreGlitterCorpusSnapshotMetrics(): Promise<void> {
   const configured = SNAPSHOT_METRICS_ENVIRONMENT.every((name) => {
@@ -101,45 +104,71 @@ export async function finalizeGlitterCorpusSnapshot(
     complete: true,
   });
   const store = createCorpusStoreFromEnv();
-  const inventoryBytes = await readVerifiedObject({
-    store,
-    key: snapshot.inventoryObject.key,
-    expectedSha256: snapshot.inventoryObject.sha256,
-  });
-  const inventory = GuildInventorySchema.parse(
-    JSON.parse(new TextDecoder().decode(inventoryBytes)),
-  );
-  if (inventory.guildId !== snapshot.guildId) {
-    throw new Error("snapshot inventory belongs to a different guild");
+  const activityContext = Context.current();
+  let progress: {
+    phase: string;
+    manifestKey: string | null;
+    verifiedChannels: number;
+    totalChannels: number;
+    lineageStateCount?: number;
+  } = {
+    phase: "verify-snapshot",
+    manifestKey: null,
+    verifiedChannels: 0,
+    totalChannels: snapshot.channelManifestObjects.length,
+  };
+  activityContext.heartbeat(progress);
+  const heartbeatTimer = setInterval(() => {
+    activityContext.heartbeat(progress);
+  }, FINALIZATION_HEARTBEAT_INTERVAL_MS);
+  try {
+    const inventoryBytes = await readVerifiedObject({
+      store,
+      key: snapshot.inventoryObject.key,
+      expectedSha256: snapshot.inventoryObject.sha256,
+    });
+    const inventory = GuildInventorySchema.parse(
+      JSON.parse(new TextDecoder().decode(inventoryBytes)),
+    );
+    if (inventory.guildId !== snapshot.guildId) {
+      throw new Error("snapshot inventory belongs to a different guild");
+    }
+    await verifyGlitterCorpusSnapshotGraph({
+      snapshot,
+      guildSlug: inventory.guildSlug,
+      store,
+      onProgress: (verificationProgress) => {
+        progress = { phase: "verify-snapshot", ...verificationProgress };
+        activityContext.heartbeat(progress);
+      },
+    });
+    const snapshotKey = `guilds/${input.guildId}/snapshots/${input.snapshotId}.json`;
+    const snapshotObject = await putImmutableObject({
+      store,
+      key: snapshotKey,
+      body: jsonBytes(snapshot),
+      contentType: "application/json",
+      writtenAt: input.createdAt,
+    });
+    await publishLatestSnapshotPointer({
+      store,
+      pointer: {
+        schemaVersion: 1,
+        guildId: input.guildId,
+        snapshotId: input.snapshotId,
+        snapshotKey,
+        snapshotSha256: snapshotObject.sha256,
+        publishedAt: input.createdAt,
+      },
+    });
+    glitterCorpusSnapshotMessages.set(snapshot.uniqueMessageCount);
+    glitterCorpusLastSnapshotTimestampSeconds.set(
+      Date.parse(input.createdAt) / 1000,
+    );
+    return { snapshot, snapshotKey, snapshotObject };
+  } finally {
+    clearInterval(heartbeatTimer);
   }
-  await verifyGlitterCorpusSnapshotGraph({
-    snapshot,
-    guildSlug: inventory.guildSlug,
-  });
-  const snapshotKey = `guilds/${input.guildId}/snapshots/${input.snapshotId}.json`;
-  const snapshotObject = await putImmutableObject({
-    store,
-    key: snapshotKey,
-    body: jsonBytes(snapshot),
-    contentType: "application/json",
-    writtenAt: input.createdAt,
-  });
-  await publishLatestSnapshotPointer({
-    store,
-    pointer: {
-      schemaVersion: 1,
-      guildId: input.guildId,
-      snapshotId: input.snapshotId,
-      snapshotKey,
-      snapshotSha256: snapshotObject.sha256,
-      publishedAt: input.createdAt,
-    },
-  });
-  glitterCorpusSnapshotMessages.set(snapshot.uniqueMessageCount);
-  glitterCorpusLastSnapshotTimestampSeconds.set(
-    Date.parse(input.createdAt) / 1000,
-  );
-  return { snapshot, snapshotKey, snapshotObject };
 }
 
 export async function loadGlitterCorpusDailyBaseline(): Promise<DailyBaseline> {
@@ -168,7 +197,7 @@ export async function loadGlitterCorpusDailyBaseline(): Promise<DailyBaseline> {
   );
   const states: DailyBaseline["states"] = {};
   for (const object of snapshot.channelManifestObjects) {
-    const manifest = await loadStateManifest(object.key);
+    const manifest = await loadStateManifest(store, object.key);
     states[manifest.channelId] = {
       manifestKey: object.key,
       manifestObject: object,

--- a/packages/temporal/src/activities/glitter-corpus-state.ts
+++ b/packages/temporal/src/activities/glitter-corpus-state.ts
@@ -5,6 +5,7 @@ import type {
 import { projectionChecksum } from "#shared/glitter-corpus-projection.ts";
 import type { ChannelStateResult } from "#shared/glitter-corpus-activity-types.ts";
 import { writeChannelState } from "./glitter-corpus-io.ts";
+import type { CorpusStore } from "./glitter-corpus-store.ts";
 
 export function projectionStateFields(input: {
   projection: readonly CurrentMessage[];
@@ -28,6 +29,7 @@ export function projectionStateFields(input: {
 }
 
 export async function persistProjectionState(input: {
+  store: CorpusStore;
   identity: {
     guildId: string;
     channelId: string;
@@ -38,6 +40,7 @@ export async function persistProjectionState(input: {
   projection: readonly CurrentMessage[];
 }): Promise<ChannelStateResult> {
   return await writeChannelState({
+    store: input.store,
     guildId: input.identity.guildId,
     channelId: input.identity.channelId,
     snapshotId: input.identity.snapshotId,

--- a/packages/temporal/src/activities/glitter-corpus.ts
+++ b/packages/temporal/src/activities/glitter-corpus.ts
@@ -93,6 +93,7 @@ async function inventoryGlitterGuild(input: {
   baselineInventory?: z.input<typeof GuildInventorySchema>;
 }): Promise<InventoryResult> {
   const config = glitterCorpusRuntimeConfig();
+  const store = createCorpusStoreFromEnv();
   const baselineInventory =
     input.baselineInventory === undefined
       ? undefined
@@ -138,7 +139,7 @@ async function inventoryGlitterGuild(input: {
   }
   const inventoryKey = `guilds/${config.guildId}/inventory/${inventory.sha256}.json`;
   const inventoryObject = await putImmutableObject({
-    store: createCorpusStoreFromEnv(),
+    store,
     key: inventoryKey,
     body: jsonBytes(inventory),
     contentType: "application/json",
@@ -155,7 +156,9 @@ async function loadApprovedGlitterInventory(input: {
   inventoryKey: string;
   expectedSha256: string;
 }): Promise<InventoryResult> {
+  const store = createCorpusStoreFromEnv();
   const inventory = await readCorpusJson(
+    store,
     input.inventoryKey,
     GuildInventorySchema,
   );
@@ -179,11 +182,11 @@ async function loadApprovedGlitterInventory(input: {
     );
   }
   const bytes = await readRequiredObject({
-    store: createCorpusStoreFromEnv(),
+    store,
     key: input.inventoryKey,
   });
   const inventoryObject = await putImmutableObject({
-    store: createCorpusStoreFromEnv(),
+    store,
     key: input.inventoryKey,
     body: bytes,
     contentType: "application/json",
@@ -202,7 +205,10 @@ async function validateApprovedGlitterSeed(input: {
   guildSlug: string;
   approvedChannelIds: string[];
 }): Promise<void> {
-  await validateSeedForApprovedInventory(input);
+  await validateSeedForApprovedInventory({
+    store: createCorpusStoreFromEnv(),
+    ...input,
+  });
 }
 
 async function captureGlitterCorpusPage(
@@ -288,7 +294,9 @@ async function verifyGlitterCorpusChannel(
   rawInput: z.input<typeof VerifyChannelInputSchema>,
 ): Promise<ChannelStateResult> {
   const input = VerifyChannelInputSchema.parse(rawInput);
+  const store = createCorpusStoreFromEnv();
   const backward = await readTraversal({
+    store,
     guildId: input.guildId,
     guildSlug: input.guildSlug,
     channelId: input.channelId,
@@ -311,6 +319,7 @@ async function verifyGlitterCorpusChannel(
     throw new Error("Discord snowflake cannot be zero");
   }
   const forward = await readTraversal({
+    store,
     guildId: input.guildId,
     guildSlug: input.guildSlug,
     channelId: input.channelId,
@@ -340,6 +349,7 @@ async function verifyGlitterCorpusChannel(
     ...backward.observations,
     ...forward.observations,
     ...(await readSeedChannelObservations({
+      store,
       seedPrefix: input.seedPrefix,
       channelId: input.channelId,
     })),
@@ -347,6 +357,7 @@ async function verifyGlitterCorpusChannel(
   let retainedBaseline: CurrentMessage[] = [];
   if (input.retainedBaselineManifestKey !== undefined) {
     const retainedState = await readBaselineProjection({
+      store,
       manifestKey: input.retainedBaselineManifestKey,
       guildId: input.guildId,
       channelId: input.channelId,
@@ -355,6 +366,7 @@ async function verifyGlitterCorpusChannel(
   }
   const projection = mergeCurrentProjection(retainedBaseline, observations);
   const projectionObject = await writeChannelProjection({
+    store,
     guildId: input.guildId,
     channelId: input.channelId,
     snapshotId: input.snapshotId,
@@ -400,6 +412,7 @@ async function verifyGlitterCorpusChannel(
     }),
   });
   return await persistProjectionState({
+    store,
     identity: input,
     manifest,
     projection,
@@ -410,7 +423,9 @@ async function applyGlitterCorpusOverlap(
   rawInput: z.input<typeof ApplyOverlapInputSchema>,
 ): Promise<ChannelStateResult> {
   const input = ApplyOverlapInputSchema.parse(rawInput);
+  const store = createCorpusStoreFromEnv();
   const { baseline, messages: existing } = await readBaselineProjection({
+    store,
     manifestKey: input.baselineManifestKey,
     guildId: input.guildId,
     channelId: input.channelId,
@@ -422,6 +437,7 @@ async function applyGlitterCorpusOverlap(
   }
   const { observations, messageIds, timestamps, terminal } =
     await readOverlapTraversal({
+      store,
       guildId: input.guildId,
       guildSlug: input.guildSlug,
       channelId: input.channelId,
@@ -439,6 +455,7 @@ async function applyGlitterCorpusOverlap(
     messageIds.toSorted(compareSnowflakes)[0] ?? null;
   const projection = mergeCurrentProjection(existing, observations);
   const projectionObject = await writeChannelProjection({
+    store,
     guildId: input.guildId,
     channelId: input.channelId,
     snapshotId: input.snapshotId,
@@ -467,6 +484,7 @@ async function applyGlitterCorpusOverlap(
     }),
   });
   return await persistProjectionState({
+    store,
     identity: input,
     manifest,
     projection,

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -673,7 +673,7 @@ describe("Glitter context refresh schedule", () => {
       expression: "0 11 * * 1",
       timezone: "America/Los_Angeles",
     });
-    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 40 }]);
+    expect(schedule.args).toEqual([{ maxEstimatedCostUsd: 1 }]);
     expect(schedule.workflowExecutionTimeout).toBe("15 hours");
     expect(buildScheduleState(schedule, {}).paused).toBe(true);
     expect(

--- a/packages/temporal/src/schedules/schedule-definitions.ts
+++ b/packages/temporal/src/schedules/schedule-definitions.ts
@@ -333,7 +333,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
   {
     id: "glitter-context-refresh-weekly",
     workflowType: "runGlitterContextRefresh",
-    args: [{ maxEstimatedCostUsd: 40 }],
+    args: [{ maxEstimatedCostUsd: 1 }],
     // Monday 11:00 PT, isolated from Discord capture and after other PR jobs.
     timing: {
       kind: "cron",
@@ -346,7 +346,7 @@ export const SCHEDULES: ScheduleDefinition[] = [
     // backoff. Keep the workflow deadline above that 14h2m retry envelope so
     // a late first-attempt failure does not strand the paid run.
     workflowExecutionTimeout: "15 hours",
-    memo: "Weekly GPT-5.6 Luna extraction and Sol synthesis of shared Glitter style cards plus evidence-backed relationship history from the verified corpus",
+    memo: "Weekly GPT-5.6 Luna extraction and synthesis of shared Glitter style cards plus evidence-backed relationship history from the verified corpus",
     initialPauseNote:
       "Awaiting credentialed dry-run against the first approved complete snapshot",
     requiredEnvironment: [

--- a/packages/temporal/src/workflows/glitter-corpus-activity-options.ts
+++ b/packages/temporal/src/workflows/glitter-corpus-activity-options.ts
@@ -1,0 +1,19 @@
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+export const glitterCorpusActivityRetry = {
+  maximumAttempts: 3,
+  initialInterval: "10 seconds",
+  backoffCoefficient: 2,
+  maximumInterval: "2 minutes",
+} as const;
+
+export const glitterCorpusActivityOptions = {
+  taskQueue: TASK_QUEUES.GLITTER_CORPUS,
+  startToCloseTimeout: "1 hour",
+  retry: glitterCorpusActivityRetry,
+} as const;
+
+export const glitterCorpusFinalizerActivityOptions = {
+  ...glitterCorpusActivityOptions,
+  heartbeatTimeout: "60 seconds",
+} as const;

--- a/packages/temporal/src/workflows/glitter-corpus.test.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.test.ts
@@ -18,6 +18,10 @@ import {
 } from "#shared/glitter-corpus.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 import {
+  glitterCorpusActivityRetry,
+  glitterCorpusFinalizerActivityOptions,
+} from "./glitter-corpus-activity-options.ts";
+import {
   runGlitterCorpusBackfill,
   runGlitterCorpusChannelBackfill,
   runGlitterCorpusDaily,
@@ -27,6 +31,23 @@ const GUILD_ID = "1000";
 const CREATED_AT = "2026-07-26T12:00:00.000Z";
 const SHA256 = "a".repeat(64);
 let testEnvironment: TestWorkflowEnvironment;
+
+describe("Glitter corpus activity policy", () => {
+  it("gives finalization a heartbeat timeout without changing retries", () => {
+    expect(glitterCorpusFinalizerActivityOptions.heartbeatTimeout).toBe(
+      "60 seconds",
+    );
+    expect(glitterCorpusFinalizerActivityOptions.retry).toEqual(
+      glitterCorpusActivityRetry,
+    );
+    expect(glitterCorpusActivityRetry).toEqual({
+      maximumAttempts: 3,
+      initialInterval: "10 seconds",
+      backoffCoefficient: 2,
+      maximumInterval: "2 minutes",
+    });
+  });
+});
 
 beforeAll(async () => {
   testEnvironment = await TestWorkflowEnvironment.createTimeSkipping();

--- a/packages/temporal/src/workflows/glitter-corpus.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.ts
@@ -7,6 +7,10 @@ import type {
   InventoryResult,
 } from "#shared/glitter-corpus-activity-types.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
+import {
+  glitterCorpusActivityRetry,
+  glitterCorpusFinalizerActivityOptions,
+} from "./glitter-corpus-activity-options.ts";
 import * as glitterFailures from "./glitter-corpus-failures.ts";
 import {
   largestSnowflake,
@@ -26,17 +30,18 @@ const {
   captureGlitterCorpusPage,
   verifyGlitterCorpusChannel,
   applyGlitterCorpusOverlap,
-  finalizeGlitterCorpusSnapshot,
   loadGlitterCorpusDailyBaseline,
 } = proxyActivities<typeof glitterCorpusActivities>({
   taskQueue: TASK_QUEUES.GLITTER_CORPUS,
   startToCloseTimeout: "1 hour",
-  retry: {
-    maximumAttempts: 3,
-    initialInterval: "10 seconds",
-    backoffCoefficient: 2,
-    maximumInterval: "2 minutes",
-  },
+  retry: glitterCorpusActivityRetry,
+});
+
+const { finalizeGlitterCorpusSnapshot } = proxyActivities<
+  typeof glitterCorpusActivities
+>({
+  ...glitterCorpusFinalizerActivityOptions,
+  taskQueue: glitterCorpusFinalizerActivityOptions.taskQueue,
 });
 
 export type GlitterCorpusBackfillInput = {


### PR DESCRIPTION
Why

Glitter corpus finalization retained every channel projection simultaneously. The dedicated worker repeatedly reached its 3 GiB limit, and an OOM could leave Temporal waiting up to the one-hour start-to-close timeout before retrying.

What

- scope rebuild caches to one top-level channel while retaining baseline-lineage reuse within that channel
- construct one corpus store/client per activity and thread it through all manifest, traversal, projection, and seed reads
- heartbeat finalization every 10 seconds and after each verified channel behind a dedicated 60-second heartbeat timeout
- raise the corpus worker request to 2 GiB and limit to 4 GiB, with cdk8s assertions
- add multi-channel recovery, integrity, store reuse, progress, and heartbeat cleanup coverage

Snapshot schemas, immutable object writes, and latest-pointer publication semantics are unchanged.

Verification

- `bunx turbo run build typecheck test lint --filter=@shepherdjerred/temporal --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`

Live post-deployment acceptance is intentionally pending: the next corpus run must complete on attempt 1 without a restart or probe failure, with zero integrity failures and fresh-container `memory.peak` at or below 3 GiB.