### PR TITLE
feat(homelab): isolate TRMNL publishing credentials

### DIFF
--- a/.buildkite/secret-grants.json
+++ b/.buildkite/secret-grants.json
@@ -19,6 +19,9 @@
     "buildkite-release-openrouter-credentials": {
       "itemId": "2r6nqphyvaegtnbjgcg4avff3m"
     },
+    "buildkite-trmnl-credentials": {
+      "itemId": "p7th6tqeel7k2sm47mrrto7oca"
+    },
     "buildkite-chartmuseum-credentials": {
       "itemId": "cnutkdwa7uka5hk3wx5gimyfom"
     },

--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-29T19:55:15.916Z",
+  "generatedAt": "2026-08-30T20:29:26.771Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -881,6 +881,31 @@
       ]
     },
     {
+      "ref": "9515342f8fa5c09af3db1e90bac7e4e748f88477df728147399e96b7cf4c12bb",
+      "title": "f8ccba5f564a2bec3f07ee2db501209b7f2817d7c2b9ede22730853d09ef4de8",
+      "fields": [
+        "1303c06b0b014d0ce7b988ab173a13f31227d417058ff4bbe6f8c222b4ad913c",
+        "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "59e8e0eda8ddd8c3d448db5552f418eb91c1e826b3926fc7b474b0e4984d288e",
+        "7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682",
+        "ab8a2845f16cb2ffb5b694dd6786fcc51f00b855881712215f57066c8e050cfe",
+        "ccc25e919758d7df1145046902e88e041e180330b64041271fc92468c339b198",
+        "e265b6f564601a1fe8dc42785cd18a868bd8013eb5899560e79248767a683e6b",
+        "f974a07ea4988c92d27cf645c46bc533075d4dd5a8059c03fe460a4aa9d4dd5a"
+      ],
+      "blankFields": [
+        "1303c06b0b014d0ce7b988ab173a13f31227d417058ff4bbe6f8c222b4ad913c",
+        "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "59e8e0eda8ddd8c3d448db5552f418eb91c1e826b3926fc7b474b0e4984d288e",
+        "7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682",
+        "ab8a2845f16cb2ffb5b694dd6786fcc51f00b855881712215f57066c8e050cfe",
+        "e265b6f564601a1fe8dc42785cd18a868bd8013eb5899560e79248767a683e6b",
+        "f974a07ea4988c92d27cf645c46bc533075d4dd5a8059c03fe460a4aa9d4dd5a"
+      ]
+    },
+    {
       "ref": "997c6aa38c7abd7a96adf5ed9d4984a3ae3fac0800fd8a769baefa28e29a8d2c",
       "title": "d72d2b4ed9b478770c1e0cb3b3a10cd725eb1e1aae398ee904231674dea6aec8",
       "fields": [
@@ -923,6 +948,24 @@
       ],
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
+      ]
+    },
+    {
+      "ref": "a08070fddcf4286154368c9f6468f6ceb37debd28d0ab1cb97277edaf0507009",
+      "title": "ceff74c2a4227ddf89fde7851cc8d7e94d1e8f6ac470dde1570286f7c2544408",
+      "fields": [
+        "1303c06b0b014d0ce7b988ab173a13f31227d417058ff4bbe6f8c222b4ad913c",
+        "16f78a7d6317f102bbd95fc9a4f3ff2e3249287690b8bdad6b7810f82b34ace3",
+        "3e04437d1554b510f4cc07f620755255fdebb1bc72bd50e2ffe3b7926dab63bd",
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "59e8e0eda8ddd8c3d448db5552f418eb91c1e826b3926fc7b474b0e4984d288e",
+        "7063dece7cccf374d9fa1ee30ff23300fa42477e064e69be7bb6d01c0cfff682",
+        "ab8a2845f16cb2ffb5b694dd6786fcc51f00b855881712215f57066c8e050cfe",
+        "f974a07ea4988c92d27cf645c46bc533075d4dd5a8059c03fe460a4aa9d4dd5a"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "f974a07ea4988c92d27cf645c46bc533075d4dd5a8059c03fe460a4aa9d4dd5a"
       ]
     },
     {

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts
@@ -81,6 +81,10 @@ const BUILDKITE_CREDENTIAL_ITEMS = [
     itemId: "2r6nqphyvaegtnbjgcg4avff3m",
   },
   {
+    secretName: "buildkite-trmnl-credentials",
+    itemId: "p7th6tqeel7k2sm47mrrto7oca",
+  },
+  {
     secretName: "buildkite-chartmuseum-credentials",
     itemId: "cnutkdwa7uka5hk3wx5gimyfom",
   },


### PR DESCRIPTION
## Why

TRMNL private-plugin publication needs an account-level credential with a distinct lifecycle and grant boundary from the dashboard service polling key.

## What

- Add the dedicated `buildkite-trmnl-credentials` 1Password item to the Buildkite namespace.
- Commit the hashed Homelab/Kubernetes vault snapshot shape for its `TRMNL_API_KEY` field.
- Declare the secret in the Buildkite credential catalog without granting it to any existing step.

## Verification

- `bun scripts/check-ci-env.ts`
- `bunx turbo run typecheck --filter=homelab`
- `bunx prettier --check .buildkite/secret-grants.json packages/homelab/src/cdk8s/onepassword-vault-snapshot.json packages/homelab/src/cdk8s/src/resources/argo-applications/buildkite.ts`
- `bunx lefthook run pre-commit`

## Rollout

Merge and reconcile this prerequisite before merging the stacked plugin-publication PR. Production reconciliation was not run from this branch.