### PR TITLE
feat(trmnl-dashboard): publish private plugins as code

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,6 +105,12 @@ common:
         secretKeyRef:
           name: buildkite-release-openrouter-credentials
           key: OPENROUTER_API_KEY
+  - grant_trmnl: &grant_trmnl
+      name: TRMNL_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: buildkite-trmnl-credentials
+          key: TRMNL_API_KEY
   - grant_chartmuseum_username: &grant_chartmuseum_username
       name: CHARTMUSEUM_USERNAME
       valueFrom:
@@ -1345,6 +1351,105 @@ steps:
                   # The checkout container separately requests its 1Gi tmpfs charge.
                   requests: { cpu: "1", memory: "2Gi" }
                   limits: { cpu: "2", memory: "4Gi" }
+                volumeMounts:
+                  - name: buildkite-git-mirrors
+                    mountPath: /buildkite/git-mirrors
+                    readOnly: true
+
+  - label: ":frame_with_picture: TRMNL layouts (PR)"
+    key: trmnl-validate-pr
+    timeout_in_minutes: 20
+    if: build.pull_request.id != null && (build.branch != "release-please--branches--main" || build.source != "webhook" || build.env("RUN_RELEASE_CI") == "true")
+    if_changed:
+      include:
+        - ".buildkite/pipeline.yml"
+        - ".buildkite/main-bootstrap.yml"
+        - ".buildkite/scripts/buildkite-handoff.ts"
+        - ".buildkite/scripts/ci-changed.ts"
+        - ".buildkite/scripts/migration-core.ts"
+        - ".buildkite/scripts/prepare-ci-changed-base.ts"
+        - ".buildkite/scripts/read-buildkite-handoff.ts"
+        - ".buildkite/scripts/select-main-pipeline.ts"
+        - ".buildkite/scripts/select-main-pipeline-selection.ts"
+        - ".buildkite/scripts/upload-pipeline.sh"
+        - "packages/trmnl-dashboard/**"
+        - "packages/version-catalog/**"
+    cancel_on_build_failing: true
+    depends_on: verify
+    command: |
+      packages/trmnl-dashboard/scripts/trmnlp-ci.sh self-test
+      packages/trmnl-dashboard/scripts/trmnlp-ci.sh validate
+    artifact_paths:
+      - "packages/trmnl-dashboard/trmnl/*/_build/*.html"
+      - "packages/trmnl-dashboard/trmnl/*/_build/*.png"
+    retry: *retry
+    plugins:
+      - kubernetes:
+          metadata:
+            labels:
+              ci.sjer.red/step-key: trmnl-validate-pr
+          checkout:
+            cloneFlags: "--no-tags"
+          podSpecPatch:
+            serviceAccountName: buildkite-job
+            automountServiceAccountToken: false
+            containers:
+              - *checkout_container
+              - name: container-0
+                # renovate: datasource=docker depName=trmnl/trmnlp versioning=semver
+                image: "trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973"
+                imagePullPolicy: IfNotPresent
+                securityContext:
+                  allowPrivilegeEscalation: false
+                env:
+                  - *env_buildkite_shell
+                resources:
+                  requests:
+                    { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
+                  limits: { cpu: "2", memory: "4Gi", ephemeral-storage: "8Gi" }
+                volumeMounts:
+                  - name: buildkite-git-mirrors
+                    mountPath: /buildkite/git-mirrors
+                    readOnly: true
+
+  - label: ":frame_with_picture: TRMNL publish (main)"
+    key: trmnl-publish
+    timeout_in_minutes: 20
+    if: build.branch == pipeline.default_branch
+    cancel_on_build_failing: true
+    depends_on: verify
+    concurrency: 1
+    concurrency_group: monorepo/trmnl-publish
+    command: packages/trmnl-dashboard/scripts/trmnlp-ci.sh publish
+    artifact_paths:
+      - "packages/trmnl-dashboard/trmnl/*/_build/*.html"
+      - "packages/trmnl-dashboard/trmnl/*/_build/*.png"
+    retry: *retry
+    plugins:
+      - kubernetes:
+          metadata:
+            labels:
+              ci.sjer.red/step-key: trmnl-publish
+          checkout:
+            cloneFlags: "--no-tags"
+          podSpecPatch:
+            serviceAccountName: buildkite-job
+            automountServiceAccountToken: false
+            containers:
+              - *checkout_container
+              - name: container-0
+                # renovate: datasource=docker depName=trmnl/trmnlp versioning=semver
+                image: "trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973"
+                imagePullPolicy: IfNotPresent
+                securityContext:
+                  allowPrivilegeEscalation: false
+                env:
+                  - *env_buildkite_shell
+                  - *grant_trmnl
+                resources:
+                  requests:
+                    { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }
+                  limits: { cpu: "2", memory: "4Gi", ephemeral-storage: "8Gi" }
                 volumeMounts:
                   - name: buildkite-git-mirrors
                     mountPath: /buildkite/git-mirrors
@@ -3622,6 +3727,7 @@ steps:
       - tasknotes-native-main
       - playwright-e2e-main
       - resume-build-main
+      - trmnl-publish
       - docker-e2e-main
       - images
       - sites

--- a/.buildkite/scripts/ci-changed.test.ts
+++ b/.buildkite/scripts/ci-changed.test.ts
@@ -11,6 +11,7 @@ test("all expected deployment lanes are modeled", () => {
   expect(Object.keys(lanePaths)).toContain("sites");
   expect(Object.keys(lanePaths)).toContain("ci-base");
   expect(Object.keys(lanePaths)).toContain("ci-playwright");
+  expect(Object.keys(lanePaths)).toContain("trmnl");
   expect(lanePaths["sites"]?.length).toBeGreaterThan(
     lanePaths["site-resume"]?.length ?? 0,
   );

--- a/.buildkite/scripts/ci-lane-coverage.test.ts
+++ b/.buildkite/scripts/ci-lane-coverage.test.ts
@@ -71,6 +71,7 @@ const LANE_TO_STEP: Record<string, string | readonly string[] | null> = {
   "tasknotes-native": "tasknotes-native-pr",
   playwright: "playwright-e2e-pr",
   resume: "resume-build-pr",
+  trmnl: "trmnl-validate-pr",
   "docker-e2e": "docker-e2e-pr",
   images: null,
   "ci-base": null,

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -171,6 +171,7 @@ export const summarySteps = [
   "tasknotes-native-main",
   "playwright-e2e-main",
   "resume-build-main",
+  "trmnl-publish",
   "docker-e2e-main",
   "images",
   "sites",
@@ -205,6 +206,7 @@ export const summaryLanes = [
   "tasknotes-native",
   "playwright",
   "resume",
+  "trmnl",
   "docker-e2e",
   "images",
   "sites",
@@ -359,6 +361,7 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
     ...deployScripts,
   ],
   resume: ["packages/resume", ...deployScripts],
+  trmnl: ["packages/trmnl-dashboard", "packages/version-catalog"],
   "docker-e2e": [
     ...workspacePaths,
     "packages/llm-observability",

--- a/.buildkite/scripts/select-main-pipeline.test.ts
+++ b/.buildkite/scripts/select-main-pipeline.test.ts
@@ -212,6 +212,15 @@ test("keeps native macOS lanes independently selectable", () => {
   expect(hkctlOnly.has("quotabar-macos-main")).toBe(false);
   expect(hkctlOnly.has("tasknotes-native-main")).toBe(false);
 
+});
+
+test("keeps TRMNL publication independently selectable", () => {
+  const selected = selectedKeys(steps, new Map([["trmnl", true]]));
+  expect(selected.has("trmnl-publish")).toBe(true);
+  expect(selected.has("verify")).toBe(true);
+});
+
+test("keeps QuotaBar and TaskNotes native lanes independently selectable", () => {
   const quotaOnly = selectedKeys(
     steps,
     new Map([

--- a/.buildkite/scripts/select-main-pipeline.ts
+++ b/.buildkite/scripts/select-main-pipeline.ts
@@ -62,6 +62,7 @@ const STEP_LANE_REQUIREMENTS: Readonly<Record<string, readonly string[]>> = {
   "homelab-release-admission": [],
   "playwright-e2e-main": ["playwright"],
   "resume-build-main": ["resume"],
+  "trmnl-publish": ["trmnl"],
   "docker-e2e-main": ["docker-e2e"],
   images: ["images"],
   sites: ["sites"],

--- a/.buildkite/scripts/validate-pipeline-trmnl.ts
+++ b/.buildkite/scripts/validate-pipeline-trmnl.ts
@@ -1,0 +1,65 @@
+import { fail } from "./validate-pipeline-parse.ts";
+import { containerBlock, requireIncludes } from "./validate-pipeline-lib.ts";
+
+const TRMNLP_IMAGE =
+  "trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973";
+
+export function validateTrmnlPipeline(
+  stepBlocks: ReadonlyMap<string, string>,
+): void {
+  for (const step of ["trmnl-validate-pr", "trmnl-publish"]) {
+    const command = containerBlock(step, stepBlocks.get(step), "container-0");
+    const normalizedCommand = command.replaceAll(/\s+/g, " ");
+    for (const required of [
+      `image: "${TRMNLP_IMAGE}"`,
+      "imagePullPolicy: IfNotPresent",
+      "allowPrivilegeEscalation: false",
+      'requests: { cpu: "1", memory: "2Gi", ephemeral-storage: "2Gi" }',
+      'limits: { cpu: "2", memory: "4Gi", ephemeral-storage: "8Gi" }',
+    ]) {
+      if (!normalizedCommand.includes(required)) {
+        fail(`${step} is missing pinned TRMNL container contract ${required}`);
+      }
+    }
+  }
+
+  const validationStep = stepBlocks.get("trmnl-validate-pr");
+  const validationContainer = containerBlock(
+    "trmnl-validate-pr",
+    validationStep,
+    "container-0",
+  );
+  if (validationContainer.includes("*grant_trmnl")) {
+    fail("TRMNL pull request validation must remain secretless");
+  }
+  for (const required of [
+    "packages/trmnl-dashboard/scripts/trmnlp-ci.sh self-test",
+    "packages/trmnl-dashboard/scripts/trmnlp-ci.sh validate",
+    "packages/trmnl-dashboard/trmnl/*/_build/*.html",
+    "packages/trmnl-dashboard/trmnl/*/_build/*.png",
+  ]) {
+    requireIncludes(
+      validationStep,
+      required,
+      `TRMNL PR validation is missing ${required}`,
+    );
+  }
+
+  const publishStep = stepBlocks.get("trmnl-publish");
+  requireIncludes(
+    containerBlock("trmnl-publish", publishStep, "container-0"),
+    "*grant_trmnl",
+    "TRMNL main publication must receive its dedicated account credential",
+  );
+  for (const required of [
+    "concurrency: 1",
+    "concurrency_group: monorepo/trmnl-publish",
+    "packages/trmnl-dashboard/scripts/trmnlp-ci.sh publish",
+  ]) {
+    requireIncludes(
+      publishStep,
+      required,
+      `TRMNL publication is missing ${required}`,
+    );
+  }
+}

--- a/.buildkite/scripts/validate-pipeline.ts
+++ b/.buildkite/scripts/validate-pipeline.ts
@@ -32,6 +32,7 @@ import { validateImageMigrationContracts } from "./validate-image-migration.ts";
 import { validateReleasePipelineContracts } from "./validate-pipeline-release.ts";
 import { validatePlaywrightLanes } from "./validate-pipeline-playwright.ts";
 import { validatePipelineResourceContracts } from "./validate-pipeline-resources.ts";
+import { validateTrmnlPipeline } from "./validate-pipeline-trmnl.ts";
 import { validatePipelineClarity } from "./validate-pipeline-clarity.ts";
 import { validateReportingPipeline } from "./validate-reporting-pipeline.ts";
 import { fixedCorpusMode, lanePaths, summarySteps } from "./migration-core.ts";
@@ -53,6 +54,7 @@ const PATH_GATED_PR_KEYS = new Set([
   "tasknotes-native-pr",
   "playwright-e2e-pr",
   "resume-build-pr",
+  "trmnl-validate-pr",
   "docker-e2e-pr",
   "trivy",
   "semgrep",
@@ -98,6 +100,7 @@ const { stepStarts, keys, stepBlocks } = collectStepBlocks(lines, {
 });
 
 validatePipelineResourceContracts(pipeline, stepBlocks);
+validateTrmnlPipeline(stepBlocks);
 for (const [key, block] of stepBlocks) {
   if (block.includes("command:") && !block.includes("timeout_in_minutes:")) {
     fail(`command step ${key} must declare timeout_in_minutes`);
@@ -412,7 +415,7 @@ for (const [stepKey, expectedRequests] of [
     stepBlocks.get(stepKey),
     "container-0",
   );
-  if (!commandContainer.includes(expectedRequests)) {
+  if (!commandContainer.replaceAll(/\s+/g, " ").includes(expectedRequests)) {
     fail(
       `${stepKey} must transfer the checkout tmpfs memory request to the checkout container`,
     );

--- a/.buildkite/secret-grants.json
+++ b/.buildkite/secret-grants.json
@@ -131,6 +131,14 @@
       ],
       "resume-build-pr": [],
       "resume-build-main": [],
+      "trmnl-validate-pr": [],
+      "trmnl-publish": [
+        {
+          "env": "TRMNL_API_KEY",
+          "secret": "buildkite-trmnl-credentials",
+          "key": "TRMNL_API_KEY"
+        }
+      ],
       "docker-e2e-pr": [
         {
           "env": "GITHUB_DOWNLOAD_TOKEN",

--- a/packages/homelab/src/cdk8s/src/version-map.generated.ts
+++ b/packages/homelab/src/cdk8s/src/version-map.generated.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export const VersionMapSchema = z
   .object({
     "stashapp/stash": z.string(),
+    "trmnl/trmnlp": z.string(),
     connect: z.string(),
     "argo-cd": z.string(),
     "cert-manager": z.string(),

--- a/packages/trmnl-dashboard/.gitignore
+++ b/packages/trmnl-dashboard/.gitignore
@@ -1,0 +1,1 @@
+trmnl/*/_build/

--- a/packages/trmnl-dashboard/README.md
+++ b/packages/trmnl-dashboard/README.md
@@ -57,12 +57,61 @@ bun run docker:build  # buildx image (monorepo-root context, tag trmnl-dashboard
 bun run smoke         # boots the trmnl-dashboard:dev image and asserts a clean start
 ```
 
-## TRMNL
+## Private plugins as code
 
-Create two Private Plugins and configure polling headers:
+The two existing private plugins are complete
+[`trmnlp`](https://github.com/usetrmnl/trmnlp/blob/main/README.md) projects:
 
-```text
-x-api-key={{ api_key | url_encode }}
+- `trmnl/home-assistant` — plugin ID `303046`
+- `trmnl/homelab` — plugin ID `303047`
+
+Their IDs are immutable deployment targets. Do not run `trmnlp init` or push a
+project without its committed ID: that would create a new remote plugin and
+break the relationship with the existing playlist entries.
+
+The repository pins both the `trmnlp` image and TRMNL framework version. Local
+and CI rendering uses deterministic synthetic JSON from `trmnl/fixtures`; it
+does not call the production dashboard or need its polling key.
+
+From the repository root, validate all four layouts for both plugins:
+
+```bash
+docker run --rm --entrypoint sh \
+  -v "$(pwd):/workspace" -w /workspace \
+  trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973 \
+  packages/trmnl-dashboard/scripts/trmnlp-ci.sh validate
 ```
 
-Use the Liquid templates in `trmnl/`.
+Preview one plugin at `http://localhost:4567`:
+
+```bash
+docker run --rm --entrypoint sh -p 4567:4567 \
+  -v "$(pwd):/workspace" -w /workspace \
+  trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973 \
+  packages/trmnl-dashboard/scripts/trmnlp-ci.sh serve home-assistant
+```
+
+Buildkite runs the same validation without secrets on pull requests. On main,
+the path-selected `trmnl` lane validates both projects before publishing either
+one, then pushes plugin `303046` followed by `303047`. The publisher uses the
+dedicated account-level `TRMNL_API_KEY` from
+`buildkite-trmnl-credentials`; this is intentionally separate from the
+dashboard service's polling key.
+
+For an intentional remote-to-repository refresh, provide the account key
+through the environment and pull each existing ID explicitly:
+
+```bash
+trmnlp pull --id 303046 --dir packages/trmnl-dashboard/trmnl/home-assistant
+trmnlp pull --id 303047 --dir packages/trmnl-dashboard/trmnl/homelab
+```
+
+Review every resulting diff before committing. Hosted custom-field values are
+instance state and must not be copied into Git. The `api_key` field is a
+password whose value remains stored only in TRMNL; `settings.yml` commits only
+the field definition and encoded header template.
+
+Playlist membership and ordering, schedules, mashups, and device settings
+remain managed in the TRMNL UI because the hosted API does not expose their
+complete composition. Manual edits in TRMNL's markup editor are drift and will
+be overwritten by the next successful main publication.

--- a/packages/trmnl-dashboard/scripts/trmnlp-ci.sh
+++ b/packages/trmnl-dashboard/scripts/trmnlp-ci.sh
@@ -1,0 +1,284 @@
+#!/bin/sh
+
+set -eu
+
+mode=${1:-validate}
+plugin_slug=${2:-}
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd)
+trmnl_root=${TRMNL_ROOT:-"$repo_root/packages/trmnl-dashboard/trmnl"}
+fixtures_dir="$trmnl_root/fixtures"
+fixture_log="${TMPDIR:-/tmp}/trmnlp-fixtures-$$.log"
+fixture_pid=
+build_log=
+trmnlp_command=${TRMNLP_COMMAND:-trmnlp}
+
+check_plugin_ids() {
+  ruby -ryaml -e '
+    expected = {
+      "home-assistant" => 303046,
+      "homelab" => 303047,
+    }
+    settings = expected.to_h do |slug, _expected_id|
+      path = File.join(ARGV.fetch(0), slug, "src", "settings.yml")
+      [slug, YAML.safe_load_file(path)]
+    end
+    ids = settings.map do |slug, values|
+      id = values["id"]
+      abort "#{slug}: missing committed plugin id" if id.nil?
+      id
+    end
+    abort "duplicate committed plugin ids: #{ids.join(", ")}" unless ids.uniq.length == ids.length
+    settings.each do |slug, values|
+      id = values.fetch("id")
+      expected_id = expected.fetch(slug)
+      abort "#{slug}: expected plugin id #{expected_id}, found #{id}" unless id == expected_id
+    end
+  ' "$trmnl_root"
+}
+
+cleanup() {
+  if [ -n "$fixture_pid" ] && ps -p "$fixture_pid" >/dev/null; then
+    kill "$fixture_pid"
+  fi
+  if [ -n "$build_log" ] && [ -f "$build_log" ]; then
+    rm -f "$build_log"
+  fi
+}
+
+start_fixture_server() {
+  ruby -rsocket -e '
+    root = ARGV.fetch(0)
+    server = TCPServer.new("127.0.0.1", 4568)
+    loop do
+      socket = server.accept
+      request = socket.gets
+      path = request.to_s.split.fetch(1, "")
+      while (line = socket.gets)
+        break if line == "\r\n"
+      end
+      file = File.join(root, File.basename(path))
+      if File.file?(file)
+        body = File.binread(file)
+        socket.write "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}"
+      else
+        socket.write "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+      end
+      socket.close
+    end
+  ' "$fixtures_dir" >"$fixture_log" 2>&1 &
+  fixture_pid=$!
+  trap cleanup EXIT HUP INT TERM
+
+  attempt=0
+  while [ "$attempt" -lt 30 ]; do
+    if ruby -rsocket -e '
+      begin
+        socket = TCPSocket.new("127.0.0.1", 4568)
+        socket.write "GET /home-assistant.json HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        exit(socket.read.start_with?("HTTP/1.1 200") ? 0 : 1)
+      rescue SystemCallError
+        exit 1
+      end
+    ' ; then
+      return
+    fi
+    if ! ps -p "$fixture_pid" >/dev/null; then
+      cat "$fixture_log"
+      exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+
+  cat "$fixture_log"
+  echo "fixture server did not become ready" >&2
+  exit 1
+}
+
+validate_project() {
+  project="$1"
+  if [ -d "$project/_build" ]; then
+    find "$project/_build" -type f -delete
+  fi
+
+  "$trmnlp_command" lint --dir "$project"
+  build_project "$project"
+
+  for view in full half_horizontal half_vertical quadrant; do
+    test -s "$project/_build/$view.html"
+    test -s "$project/_build/$view.png"
+  done
+}
+
+build_project() {
+  project="$1"
+  build_log=$(mktemp)
+  if "$trmnlp_command" build --png --dir "$project" >"$build_log" 2>&1; then
+    cat "$build_log"
+    rm -f "$build_log"
+    build_log=
+    return
+  fi
+
+  cat "$build_log"
+  if ! grep -Fq 'Selenium::WebDriver::Error::TimeoutError' "$build_log"; then
+    rm -f "$build_log"
+    build_log=
+    return 1
+  fi
+
+  echo "trmnlp screenshot timed out; retrying this project once" >&2
+  rm -f "$build_log"
+  build_log=
+  find "$project/_build" -type f -delete
+  "$trmnlp_command" build --png --dir "$project"
+}
+
+validate_all() {
+  start_fixture_server
+  validate_project "$trmnl_root/home-assistant"
+  validate_project "$trmnl_root/homelab"
+}
+
+self_test() {
+  self_test_dir=$(mktemp -d)
+  mkdir -p "$self_test_dir/trmnl"
+  cp -R "$trmnl_root/fixtures" "$self_test_dir/trmnl/fixtures"
+  cp -R "$trmnl_root/home-assistant" "$self_test_dir/trmnl/home-assistant"
+  cp -R "$trmnl_root/homelab" "$self_test_dir/trmnl/homelab"
+
+  ruby -ryaml -e '
+    path = ARGV.fetch(0)
+    settings = YAML.safe_load_file(path)
+    settings.delete("id")
+    File.write(path, settings.to_yaml)
+  ' "$self_test_dir/trmnl/home-assistant/src/settings.yml"
+  if TRMNL_ROOT="$self_test_dir/trmnl" "$0" check-ids; then
+    echo "missing plugin id was accepted" >&2
+    exit 1
+  fi
+
+  cp "$trmnl_root/home-assistant/src/settings.yml" "$self_test_dir/trmnl/home-assistant/src/settings.yml"
+  ruby -ryaml -e '
+    path = ARGV.fetch(0)
+    settings = YAML.safe_load_file(path)
+    settings["id"] = 303046
+    File.write(path, settings.to_yaml)
+  ' "$self_test_dir/trmnl/homelab/src/settings.yml"
+  if TRMNL_ROOT="$self_test_dir/trmnl" "$0" check-ids; then
+    echo "duplicate plugin ids were accepted" >&2
+    exit 1
+  fi
+
+  cp "$trmnl_root/homelab/src/settings.yml" "$self_test_dir/trmnl/homelab/src/settings.yml"
+  fake_trmnlp="$self_test_dir/fake-trmnlp"
+  publish_log="$self_test_dir/push.log"
+  cat >"$fake_trmnlp" <<'SCRIPT'
+#!/bin/sh
+set -eu
+command=$1
+shift
+project=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--dir" ]; then
+    project=$2
+    shift 2
+  else
+    shift
+  fi
+done
+case "$command" in
+  lint)
+    if [ "${TRMNLP_TEST_FAIL_HOMELAB:-}" = "1" ] && [ "$(basename "$project")" = "homelab" ]; then
+      exit 42
+    fi
+    ;;
+  build)
+    if [ -n "${TRMNLP_TEST_RETRY_LOG:-}" ] && [ "$(basename "$project")" = "home-assistant" ]; then
+      attempts=0
+      if [ -f "$TRMNLP_TEST_RETRY_LOG" ]; then
+        attempts=$(wc -l <"$TRMNLP_TEST_RETRY_LOG")
+      fi
+      printf 'attempt\n' >>"$TRMNLP_TEST_RETRY_LOG"
+      if [ "$attempts" -eq 0 ]; then
+        echo 'Selenium::WebDriver::Error::TimeoutError' >&2
+        exit 1
+      fi
+    fi
+    mkdir -p "$project/_build"
+    for view in full half_horizontal half_vertical quadrant; do
+      printf 'fixture\n' >"$project/_build/$view.html"
+      printf 'fixture\n' >"$project/_build/$view.png"
+    done
+    ;;
+  push)
+    echo "$project" >>"$TRMNLP_TEST_LOG"
+    ;;
+esac
+SCRIPT
+  chmod +x "$fake_trmnlp"
+  if TRMNL_ROOT="$self_test_dir/trmnl" \
+    TRMNLP_COMMAND="$fake_trmnlp" \
+    TRMNLP_TEST_LOG="$publish_log" \
+    TRMNLP_TEST_FAIL_HOMELAB=1 \
+    TRMNL_API_KEY=self-test \
+    "$0" publish; then
+    echo "publication continued after a plugin validation failure" >&2
+    exit 1
+  fi
+  if [ -s "$publish_log" ]; then
+    echo "a plugin was published before all validation completed" >&2
+    exit 1
+  fi
+
+  retry_log="$self_test_dir/retry.log"
+  TRMNL_ROOT="$self_test_dir/trmnl" \
+    TRMNLP_COMMAND="$fake_trmnlp" \
+    TRMNLP_TEST_RETRY_LOG="$retry_log" \
+    "$0" validate
+  if [ "$(wc -l <"$retry_log")" -ne 2 ]; then
+    echo "the Selenium timeout did not trigger exactly one retry" >&2
+    exit 1
+  fi
+}
+
+check_plugin_ids
+
+case "$mode" in
+  check-ids)
+    ;;
+  self-test)
+    self_test
+    ;;
+  validate)
+    validate_all
+    ;;
+  publish)
+    if [ -z "${TRMNL_API_KEY:-}" ]; then
+      echo "TRMNL_API_KEY is required for publication" >&2
+      exit 1
+    fi
+    validate_all
+    "$trmnlp_command" push --force --dir "$trmnl_root/home-assistant"
+    "$trmnlp_command" push --force --dir "$trmnl_root/homelab"
+    git -C "$repo_root" diff --exit-code -- \
+      packages/trmnl-dashboard/trmnl/home-assistant \
+      packages/trmnl-dashboard/trmnl/homelab
+    ;;
+  serve)
+    case "$plugin_slug" in
+      home-assistant | homelab)
+        ;;
+      *)
+        echo "serve requires home-assistant or homelab" >&2
+        exit 1
+        ;;
+    esac
+    start_fixture_server
+    "$trmnlp_command" serve --bind 0.0.0.0 --dir "$trmnl_root/$plugin_slug"
+    ;;
+  *)
+    echo "usage: $0 {check-ids|self-test|validate|publish|serve <home-assistant|homelab>}" >&2
+    exit 1
+    ;;
+esac

--- a/packages/trmnl-dashboard/trmnl/fixtures/home-assistant.json
+++ b/packages/trmnl-dashboard/trmnl/fixtures/home-assistant.json
@@ -1,0 +1,71 @@
+{
+  "screen": "home",
+  "generated_at": "2026-08-30T19:42:00.000Z",
+  "generated_time": "12:42 PM",
+  "status": "warning",
+  "summary": "2 items need attention",
+  "counts": {
+    "unavailable": 1,
+    "low_battery": 1
+  },
+  "presence": [
+    {
+      "entity_id": "person.resident",
+      "label": "Resident",
+      "state": "Home",
+      "status": "ok"
+    },
+    {
+      "entity_id": "device_tracker.phone",
+      "label": "Phone",
+      "state": "Home",
+      "status": "ok"
+    }
+  ],
+  "security": [
+    {
+      "entity_id": "lock.front_door",
+      "label": "Front Door",
+      "state": "Locked",
+      "status": "ok"
+    },
+    {
+      "entity_id": "binary_sensor.garage",
+      "label": "Garage",
+      "state": "Closed",
+      "status": "ok"
+    }
+  ],
+  "climate": [
+    {
+      "entity_id": "climate.downstairs",
+      "label": "Downstairs",
+      "state": "72 F",
+      "status": "ok"
+    },
+    {
+      "entity_id": "sensor.indoor_humidity",
+      "label": "Humidity",
+      "state": "44%",
+      "status": "ok"
+    }
+  ],
+  "unavailable": [
+    {
+      "entity_id": "sensor.garden_temperature",
+      "label": "Garden Sensor",
+      "state": "Unavailable",
+      "status": "warning"
+    }
+  ],
+  "low_batteries": [
+    {
+      "entity_id": "sensor.guest_remote_battery",
+      "label": "Guest Remote",
+      "state": "14",
+      "status": "warning",
+      "detail": "14%"
+    }
+  ],
+  "errors": []
+}

--- a/packages/trmnl-dashboard/trmnl/fixtures/homelab.json
+++ b/packages/trmnl-dashboard/trmnl/fixtures/homelab.json
@@ -1,0 +1,50 @@
+{
+  "screen": "homelab",
+  "generated_at": "2026-08-30T19:42:00.000Z",
+  "generated_time": "12:42 PM",
+  "status": "warning",
+  "summary": "1 warning alert",
+  "bugsink": {
+    "status": "ok",
+    "unresolved": 3,
+    "projects": [
+      { "name": "Dashboard", "unresolved": 2 },
+      { "name": "Automation", "unresolved": 1 }
+    ]
+  },
+  "kubernetes": {
+    "status": "ok",
+    "ready_nodes": 2,
+    "total_nodes": 2,
+    "unhealthy_pods": 0
+  },
+  "storage": {
+    "status": "ok",
+    "max_disk_used_percent": 67,
+    "volumes": [
+      { "name": "tank/appdata", "used_percent": 67 },
+      { "name": "tank/media", "used_percent": 54 },
+      { "name": "tank/backups", "used_percent": 41 }
+    ]
+  },
+  "hardware": {
+    "status": "ok",
+    "cpu_used_percent": 23,
+    "memory_used_percent": 61
+  },
+  "alerts": {
+    "status": "warning",
+    "open": 1,
+    "critical": 0,
+    "warning": 1,
+    "info": 0,
+    "recent": [
+      {
+        "severity": "warning",
+        "alertname": "BackupAge",
+        "summary": "Nightly backup is running late"
+      }
+    ]
+  },
+  "errors": []
+}

--- a/packages/trmnl-dashboard/trmnl/home-assistant/.trmnlp.yml
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/.trmnlp.yml
@@ -1,0 +1,11 @@
+---
+watch:
+  - .trmnlp.yml
+  - src
+custom_fields:
+  api_key: preview-only
+time_zone: America/Los_Angeles
+variables:
+  trmnl:
+    plugin_settings:
+      polling_url: http://127.0.0.1:4568/home-assistant.json

--- a/packages/trmnl-dashboard/trmnl/home-assistant/src/full.liquid
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/src/full.liquid
@@ -121,7 +121,4 @@
   {% endif %}
 </div>
 
-<div class="title_bar">
-  <span class="title">Home Assistant</span>
-  <span class="instance">{{ status | upcase }} · {{ generated_time }}</span>
-</div>
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/home-assistant/src/half_horizontal.liquid
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/src/half_horizontal.liquid
@@ -1,0 +1,56 @@
+<div class="layout layout--col gap--small">
+  <div class="grid grid--cols-3 gap--small">
+    <div class="item">
+      <div class="meta"></div>
+      <div class="content">
+        <span class="title">Home</span>
+        <span class="value value--small">{{ summary }}</span>
+      </div>
+    </div>
+    <div class="item">
+      <div class="meta"></div>
+      <div class="content">
+        <span class="title">Unavailable</span>
+        <span class="value">{{ counts.unavailable }}</span>
+      </div>
+    </div>
+    <div class="item">
+      <div class="meta"></div>
+      <div class="content">
+        <span class="title">Low Battery</span>
+        <span class="value">{{ counts.low_battery }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid grid--cols-3 gap--small">
+    <div>
+      <span class="label label--underline">Presence</span>
+      {% for entity in presence limit: 3 %}
+        <div class="flex flex--row flex--between"><span>{{ entity.label }}</span><span>{{ entity.state }}</span></div>
+      {% else %}
+        <span>No configured entities</span>
+      {% endfor %}
+    </div>
+    <div>
+      <span class="label label--underline">Security</span>
+      {% for entity in security limit: 3 %}
+        <div class="flex flex--row flex--between"><span>{{ entity.label }}</span><span>{{ entity.state }}</span></div>
+      {% else %}
+        <span>No configured entities</span>
+      {% endfor %}
+    </div>
+    <div>
+      <span class="label label--underline">Attention</span>
+      {% for entity in unavailable limit: 2 %}
+        <div>{{ entity.label }} · {{ entity.state }}</div>
+      {% endfor %}
+      {% for entity in low_batteries limit: 2 %}
+        <div>{{ entity.label }} · {{ entity.detail }}</div>
+      {% endfor %}
+      {% if counts.unavailable == 0 and counts.low_battery == 0 %}<span>All clear</span>{% endif %}
+    </div>
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/home-assistant/src/half_vertical.liquid
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/src/half_vertical.liquid
@@ -1,0 +1,39 @@
+<div class="layout layout--col gap--small">
+  <div class="item">
+    <div class="meta"></div>
+    <div class="content">
+      <span class="title">Home</span>
+      <span class="value value--small">{{ summary }}</span>
+    </div>
+  </div>
+
+  <div class="grid grid--cols-2 gap--small">
+    <div class="item">
+      <div class="meta"></div>
+      <div class="content"><span class="title">Unavailable</span><span class="value">{{ counts.unavailable }}</span></div>
+    </div>
+    <div class="item">
+      <div class="meta"></div>
+      <div class="content"><span class="title">Low Battery</span><span class="value">{{ counts.low_battery }}</span></div>
+    </div>
+  </div>
+
+  <div>
+    <span class="label label--underline">Presence & Security</span>
+    <table class="table table--condensed">
+      <tbody>
+        {% for entity in presence limit: 2 %}<tr><td>{{ entity.label }}</td><td class="text--right">{{ entity.state }}</td></tr>{% endfor %}
+        {% for entity in security limit: 2 %}<tr><td>{{ entity.label }}</td><td class="text--right">{{ entity.state }}</td></tr>{% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div>
+    <span class="label label--underline">Attention</span>
+    {% for entity in unavailable limit: 2 %}<div>{{ entity.label }} · {{ entity.state }}</div>{% endfor %}
+    {% for entity in low_batteries limit: 2 %}<div>{{ entity.label }} · {{ entity.detail }}</div>{% endfor %}
+    {% if counts.unavailable == 0 and counts.low_battery == 0 %}<div>All clear</div>{% endif %}
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/home-assistant/src/quadrant.liquid
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/src/quadrant.liquid
@@ -1,0 +1,21 @@
+<div class="layout layout--col gap--small">
+  <div class="item">
+    <div class="meta"></div>
+    <div class="content">
+      <span class="title">Home</span>
+      <span class="value value--small">{{ summary }}</span>
+    </div>
+  </div>
+  <div class="grid grid--cols-2 gap--small">
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Offline</span><span class="value">{{ counts.unavailable }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Battery</span><span class="value">{{ counts.low_battery }}</span></div></div>
+  </div>
+  <div>
+    <span class="label label--underline">Attention</span>
+    {% for entity in unavailable limit: 1 %}<div>{{ entity.label }} · {{ entity.state }}</div>{% endfor %}
+    {% for entity in low_batteries limit: 1 %}<div>{{ entity.label }} · {{ entity.detail }}</div>{% endfor %}
+    {% if counts.unavailable == 0 and counts.low_battery == 0 %}<span>All clear</span>{% endif %}
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/home-assistant/src/settings.yml
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/src/settings.yml
@@ -1,0 +1,21 @@
+#
+# Changes to this file will be overwritten by `trmnlp pull`.
+#
+---
+strategy: polling
+no_screen_padding: "no"
+dark_mode: "no"
+static_data: ""
+polling_verb: get
+framework_version: 3.1.1
+polling_url: https://trmnl.sjer.red/api/home
+polling_headers: x-api-key={{ api_key | url_encode }}
+name: Home Assistant Status
+description: Home status and device health.
+refresh_interval: 15
+id: 303046
+custom_fields:
+  - keyname: api_key
+    field_type: password
+    name: API Key
+    description: Dashboard polling key stored only in TRMNL.

--- a/packages/trmnl-dashboard/trmnl/home-assistant/src/shared.liquid
+++ b/packages/trmnl-dashboard/trmnl/home-assistant/src/shared.liquid
@@ -1,0 +1,7 @@
+{% assign dashboard_status = status | upcase %}
+{% capture dashboard_title_bar %}
+  <div class="title_bar">
+    <span class="title">Home Assistant</span>
+    <span class="instance">{{ dashboard_status }} · {{ generated_time }}</span>
+  </div>
+{% endcapture %}

--- a/packages/trmnl-dashboard/trmnl/homelab/.trmnlp.yml
+++ b/packages/trmnl-dashboard/trmnl/homelab/.trmnlp.yml
@@ -1,0 +1,11 @@
+---
+watch:
+  - .trmnlp.yml
+  - src
+custom_fields:
+  api_key: preview-only
+time_zone: America/Los_Angeles
+variables:
+  trmnl:
+    plugin_settings:
+      polling_url: http://127.0.0.1:4568/homelab.json

--- a/packages/trmnl-dashboard/trmnl/homelab/src/full.liquid
+++ b/packages/trmnl-dashboard/trmnl/homelab/src/full.liquid
@@ -12,7 +12,7 @@
     <div class="item">
       <div class="meta"></div>
       <div class="content">
-        <span class="title">Alerts</span>
+        <span class="title">Open</span>
         <span class="value">
           {% if alerts.status == "unknown" %}
             ERR
@@ -38,7 +38,7 @@
     <div class="item">
       <div class="meta"></div>
       <div class="content">
-        <span class="title">Alerts</span>
+        <span class="title">Severity</span>
         <span class="value value--small">{{ alerts.critical }} crit · {{ alerts.warning }} warn</span>
       </div>
     </div>
@@ -52,21 +52,13 @@
           <tr>
             <td>CPU</td>
             <td class="text--right">
-              {% if hardware.cpu_used_percent %}
-                {{ hardware.cpu_used_percent }}%
-              {% else %}
-                n/a
-              {% endif %}
+              {{ cpu_usage }}
             </td>
           </tr>
           <tr>
             <td>Memory</td>
             <td class="text--right">
-              {% if hardware.memory_used_percent %}
-                {{ hardware.memory_used_percent }}%
-              {% else %}
-                n/a
-              {% endif %}
+              {{ memory_usage }}
             </td>
           </tr>
           <tr>
@@ -142,7 +134,4 @@
   {% endif %}
 </div>
 
-<div class="title_bar">
-  <span class="title">Homelab</span>
-  <span class="instance">{{ status | upcase }} · {{ generated_time }}</span>
-</div>
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/homelab/src/half_horizontal.liquid
+++ b/packages/trmnl-dashboard/trmnl/homelab/src/half_horizontal.liquid
@@ -1,0 +1,25 @@
+<div class="layout layout--col gap--small">
+  <div class="grid grid--cols-4 gap--small">
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">K8s</span><span class="value value--small">{{ kubernetes.ready_nodes }}/{{ kubernetes.total_nodes }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Alerts</span><span class="value">{{ alerts.open }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Bugsink</span><span class="value">{{ bugsink.unresolved }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Storage</span><span class="value value--small">{{ disk_usage }}</span></div></div>
+  </div>
+
+  <div class="grid grid--cols-2 gap--small">
+    <div>
+      <span class="label label--underline">Open Alerts</span>
+      <table class="table table--condensed"><tbody>
+        {% for alert in alerts.recent limit: 3 %}<tr><td>{{ alert.alertname }}</td><td class="text--right">{{ alert.severity }}</td></tr>{% else %}<tr><td>No open alerts</td></tr>{% endfor %}
+      </tbody></table>
+    </div>
+    <div>
+      <span class="label label--underline">Storage</span>
+      <table class="table table--condensed"><tbody>
+        {% for volume in storage.volumes limit: 3 %}<tr><td>{{ volume.name }}</td><td class="text--right">{{ volume.used_percent }}%</td></tr>{% else %}<tr><td>No metrics</td></tr>{% endfor %}
+      </tbody></table>
+    </div>
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/homelab/src/half_vertical.liquid
+++ b/packages/trmnl-dashboard/trmnl/homelab/src/half_vertical.liquid
@@ -1,0 +1,28 @@
+<div class="layout layout--col gap--small">
+  <div class="grid grid--cols-2 gap--small">
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">K8s Nodes</span><span class="value value--small">{{ kubernetes.ready_nodes }}/{{ kubernetes.total_nodes }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Alerts</span><span class="value">{{ alerts.open }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Bugsink</span><span class="value">{{ bugsink.unresolved }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Disk</span><span class="value value--small">{{ disk_usage }}</span></div></div>
+  </div>
+
+  <div>
+    <span class="label label--underline">Recent Alert</span>
+    {% for alert in alerts.recent limit: 2 %}
+      <div>{{ alert.alertname }} · {{ alert.summary }}</div>
+    {% else %}
+      <div>No open alerts</div>
+    {% endfor %}
+  </div>
+
+  <div>
+    <span class="label label--underline">Hardware</span>
+    <table class="table table--condensed"><tbody>
+      <tr><td>CPU</td><td class="text--right">{{ cpu_usage }}</td></tr>
+      <tr><td>Memory</td><td class="text--right">{{ memory_usage }}</td></tr>
+      <tr><td>Unhealthy Pods</td><td class="text--right">{{ kubernetes.unhealthy_pods }}</td></tr>
+    </tbody></table>
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/homelab/src/quadrant.liquid
+++ b/packages/trmnl-dashboard/trmnl/homelab/src/quadrant.liquid
@@ -1,0 +1,14 @@
+<div class="layout layout--col gap--small">
+  <div class="grid grid--cols-2 gap--small">
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">K8s</span><span class="value value--small">{{ kubernetes.ready_nodes }}/{{ kubernetes.total_nodes }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Alerts</span><span class="value">{{ alerts.open }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">Bugsink</span><span class="value">{{ bugsink.unresolved }}</span></div></div>
+    <div class="item"><div class="meta"></div><div class="content"><span class="title">CPU</span><span class="value value--small">{{ cpu_usage }}</span></div></div>
+  </div>
+  <div>
+    <span class="label label--underline">Attention</span>
+    {% for alert in alerts.recent limit: 1 %}<div>{{ alert.alertname }} · {{ alert.severity }}</div>{% else %}<div>All clear</div>{% endfor %}
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/homelab/src/settings.yml
+++ b/packages/trmnl-dashboard/trmnl/homelab/src/settings.yml
@@ -1,0 +1,21 @@
+#
+# Changes to this file will be overwritten by `trmnlp pull`.
+#
+---
+strategy: polling
+no_screen_padding: "no"
+dark_mode: "no"
+static_data: ""
+polling_verb: get
+framework_version: 3.1.1
+polling_url: https://trmnl.sjer.red/api/homelab
+polling_headers: x-api-key={{ api_key | url_encode }}
+name: Homelab Status
+description: Homelab infrastructure health.
+refresh_interval: 15
+id: 303047
+custom_fields:
+  - keyname: api_key
+    field_type: password
+    name: API Key
+    description: Dashboard polling key stored only in TRMNL.

--- a/packages/trmnl-dashboard/trmnl/homelab/src/shared.liquid
+++ b/packages/trmnl-dashboard/trmnl/homelab/src/shared.liquid
@@ -1,0 +1,10 @@
+{% assign dashboard_status = status | upcase %}
+{% capture cpu_usage %}{% if hardware.cpu_used_percent %}{{ hardware.cpu_used_percent }}%{% else %}n/a{% endif %}{% endcapture %}
+{% capture memory_usage %}{% if hardware.memory_used_percent %}{{ hardware.memory_used_percent }}%{% else %}n/a{% endif %}{% endcapture %}
+{% capture disk_usage %}{% if storage.max_disk_used_percent %}{{ storage.max_disk_used_percent }}%{% else %}n/a{% endif %}{% endcapture %}
+{% capture dashboard_title_bar %}
+  <div class="title_bar">
+    <span class="title">Homelab</span>
+    <span class="instance">{{ dashboard_status }} · {{ generated_time }}</span>
+  </div>
+{% endcapture %}

--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -15,6 +15,18 @@
       "value": "v0.31.1@sha256:df744af5a0c976e2ec671052ecc1f8a9aa757fa12b8f9930b59910b7295f0da6"
     },
     {
+      "name": "trmnl/trmnlp",
+      "category": "upstream",
+      "artifactType": "image",
+      "management": {
+        "managed": true,
+        "datasource": "docker",
+        "registryUrl": "https://docker.io",
+        "versioning": "semver"
+      },
+      "value": "v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973"
+    },
+    {
       "name": "connect",
       "category": "upstream",
       "artifactType": "helm-chart",

--- a/scripts/script-migrations.json
+++ b/scripts/script-migrations.json
@@ -568,6 +568,11 @@
       ]
     },
     {
+      "source": "packages/trmnl-dashboard/scripts/trmnlp-ci.sh",
+      "disposition": "retain",
+      "reason": "The pinned upstream trmnlp image provides POSIX shell and Ruby but intentionally excludes the monorepo Bun toolchain"
+    },
+    {
       "source": "scripts/check-env-var-names.sh",
       "disposition": "port",
       "reason": "Repository checks already require Bun",


### PR DESCRIPTION
## Why

Keep the existing TRMNL private plugins reproducible, visually testable, and deployable without relying on manual markup-editor changes or production polling data.

## What

- Import plugin IDs `303046` and `303047` as complete `trmnlp` projects while preserving their hosted polling settings and custom-field definitions.
- Add all four layouts per plugin, shared markup, and deterministic synthetic preview fixtures.
- Pin TRMNL framework `3.1.1` and `trmnl/trmnlp:v0.11.0` by immutable digest in the version catalog with Renovate management.
- Add a secretless PR lane that validates failure ordering and uploads eight HTML/PNG render pairs.
- Add a path-selected, serialized main lane that validates both projects before sequential publication with only the dedicated account credential.
- Document local validate, preview, pull, and publication boundaries. Playlists, schedules, mashups, and device settings remain UI-managed.

## Verification

- `docker run --rm --entrypoint sh -v "$PWD:/workspace" -w /workspace trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973 -lc 'packages/trmnl-dashboard/scripts/trmnlp-ci.sh validate'`
- `packages/trmnl-dashboard/scripts/trmnlp-ci.sh self-test`
- `shellcheck packages/trmnl-dashboard/scripts/trmnlp-ci.sh`
- `bun .buildkite/scripts/validate-pipeline.ts`
- `bun scripts/check-ci-env.ts`
- `bun --no-install --bun vitest --config vitest.config.ts run .buildkite/scripts/ci-changed.test.ts .buildkite/scripts/ci-lane-coverage.test.ts .buildkite/scripts/select-main-pipeline.test.ts .buildkite/scripts/annotate-build-summary.test.ts` (44 tests)
- `bunx turbo run typecheck test lint --filter=@shepherdjerred/trmnl-dashboard --filter=@shepherdjerred/version-catalog` (22 tests)
- `bunx turbo run typecheck --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`

The local exhaustive `bun run verify` reached the unrelated Resume build but could not complete because this macOS host does not have `xelatex`; Buildkite remains the authoritative whole-repository gate.

## Rollout

Do not merge until the prerequisite credential PR has reconciled its Kubernetes Secret. The first main publication must be followed by a remote pull-back with a clean diff, polling-key rotation, forced slide refresh, and visual confirmation on the device. Live TRMNL publication and device verification were not run from this branch.