### PR TITLE
feat(temporal): audit Glitter context cache without inference

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
+++ b/packages/docs/wiki/src/content/docs/how-to/operate-glitter-corpus.md
@@ -133,6 +133,40 @@ preflight estimate, per-call authorization, and post-call ceiling enforce
 the cap. A completion that returns without usage data fails non-retryably
 rather than risk re-charging.
 
+### Audit the generation cache without inference
+
+Run the audit against a pinned snapshot before deciding whether to start a
+manual refresh. It computes the same request hashes as production, validates
+every current v3 hit, and reports misses plus synthesis stages blocked by
+missing upstream outputs. It does not call OpenRouter and does not write
+generation artifacts or spend receipts.
+
+```bash
+cd packages/temporal
+TEMPORAL_ADDRESS=<private-temporal-host>:443 TEMPORAL_TLS=true \
+  bun run glitter:operate context-audit \
+  --snapshot-id=<snapshot-id> \
+  --snapshot-sha256=<snapshot-sha256> \
+  --wait=true
+```
+
+Confirm the result names the intended snapshot, eligible people, exact hit and
+miss counts, blocked stages, artifact keys, and worst-case uncached cost.
+
+### Accept the corpus memory change after deployment
+
+Trigger one daily corpus run and inspect the fresh corpus-worker container.
+Acceptance requires completion on attempt 1, no pod restart or probe failure,
+zero integrity failures, and `memory.peak` at or below 3 GiB. If peak memory is
+higher, split graph verification into per-channel activities; do not raise the
+4 GiB limit again.
+
+Then run the pinned cache audit and confirm there are no new OpenRouter spans or
+cost metrics and no artifact or spend-receipt writes. On the next weekly
+refresh, confirm actual uncached spend is at most $1. Budget exhaustion is an
+acceptable bounded-progress result; a completed run must produce a reviewable
+PR and valid generation summary.
+
 ## Related
 
 - [Temporal workflow inventory](/reference/temporal-workflows/) — the Glitter workflows

--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -136,6 +136,7 @@ recurring schedule.
 | ------------------------- | ---------------------------- | ----------------- | -------------------- |
 | corpus capture            | daily 04:15                  | deterministic     | immutable S3 corpus  |
 | context-refresh           | Mon 11:00                    | LLM (cost-capped) | PR                   |
+| context cache audit       | operator (`glitter:operate`) | deterministic     | cache report         |
 | corpus inventory          | operator (`glitter:operate`) | deterministic     | channel-scope object |
 | corpus backfill           | operator (`glitter:operate`) | deterministic     | immutable S3 corpus  |
 | channel backfill (canary) | operator (`glitter:operate`) | deterministic     | immutable S3 corpus  |

--- a/packages/glitter-context/python/validate_context.py
+++ b/packages/glitter-context/python/validate_context.py
@@ -248,6 +248,8 @@ class GenerationStateEntry(BaseModel):
 class GenerationStateDocument(DocumentModel):
     relationshipSourceSnapshotChecksum: Checksum | None
     relationshipRefreshedAt: AwareDatetime | None
+    relationshipEvaluationSnapshotChecksum: Checksum | None = None
+    relationshipEvaluationCursor: DiscordId | None = None
     people: list[GenerationStateEntry]
 
 

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -485,6 +485,33 @@ Artifacts are cached by request digest rather than by run, so this re-reads
 whatever a production run already paid for instead of re-billing it — which is
 also why pinning a snapshot reuses more cache than reading the latest one.
 
+**Glitter context cache audit (Temporal, zero inference)** — use the operator
+workflow before a manual refresh when you need exact current cache coverage:
+
+```bash
+cd packages/temporal
+bun run glitter:operate context-audit \
+  --snapshot-id=<snapshot-id> --snapshot-sha256=<snapshot-sha256> --wait=true
+```
+
+The audit runs on `glitter-context`, constructs the same production request
+objects, fully validates current v3 artifacts, and reports exact hits, misses,
+blocked synthesis stages, artifact keys, and worst-case uncached cost. It must
+never call OpenRouter or write an artifact or spend receipt. The weekly refresh
+is capped at $1; budget exhaustion leaves exact-key artifacts for later weekly
+runs and opens no PR until a run completes. Do not add legacy-key reuse.
+The shared synthesis request builder limits serialized input to 600,000 UTF-8
+bytes, keeps the newest monthly summaries, and reports coverage only for the
+summaries included. Its full Luna semantic-retry reservation must remain below
+the weekly cap; generation and audit must both use that builder.
+
+After deploying corpus-finalization memory changes, accept them with one fresh
+daily run: attempt 1, no restart or probe failure, zero integrity failures, and
+`memory.peak <= 3 GiB`. If it exceeds that threshold, split verification into
+per-channel activities instead of increasing the 4 GiB limit. Follow with a
+pinned cache audit and verify no new OpenRouter spans/cost or artifact/receipt
+writes, then verify the next weekly run spends at most $1.
+
 **Cluster RBAC** — the infra and agent worker SAs get the cluster-wide read-only
 `temporal-worker-audit-reader` ClusterRole (see
 `packages/homelab/src/cdk8s/src/resources/temporal/audit-rbac.ts`). A separate

--- a/packages/temporal/scripts/operate-glitter-corpus.ts
+++ b/packages/temporal/scripts/operate-glitter-corpus.ts
@@ -4,6 +4,7 @@ import {
   ChannelStateResultSchema,
   InventoryResultSchema,
 } from "#shared/glitter-corpus-activity-types.ts";
+import { GlitterContextAuditResultSchema } from "#activities/glitter-context-audit-schema.ts";
 import { GlitterCorpusSnapshotPinSchema } from "#activities/glitter-context-refresh-corpus.ts";
 import { temporalConnectionOptions } from "#lib/temporal-connection.ts";
 import { GuildSnapshotSchema } from "#shared/glitter-corpus.ts";
@@ -21,6 +22,7 @@ function usage(): never {
       "  bun run glitter:operate backfill --inventory-key=<key> --inventory-sha=<sha256> [--seed-prefix=<prefix>] [--max-pages=<n>] [--wait=true]",
       "  bun run glitter:operate daily [--wait=true]",
       "  bun run glitter:operate context-refresh --dry-run=<true|false> --max-estimated-cost-usd=<usd> [--now=<iso>] [--snapshot-id=<uuid> --snapshot-sha256=<sha256>] [--wait=true]",
+      "  bun run glitter:operate context-audit [--now=<iso>] [--snapshot-id=<uuid> --snapshot-sha256=<sha256>] [--wait=true]",
     ].join("\n"),
   );
   process.exit(2);
@@ -278,6 +280,52 @@ async function runContextRefresh(
   }
 }
 
+async function runContextAudit(
+  client: Client,
+  argv: readonly string[],
+): Promise<void> {
+  const parsed = z
+    .object({
+      now: z.iso.datetime({ offset: true }).optional(),
+      "snapshot-id": z.uuid().optional(),
+      "snapshot-sha256": z
+        .string()
+        .regex(/^[0-9a-f]{64}$/)
+        .optional(),
+      wait: z.enum(["true", "false"]).default("false"),
+    })
+    .strict()
+    .parse(flags(argv));
+  const snapshot =
+    parsed["snapshot-id"] === undefined &&
+    parsed["snapshot-sha256"] === undefined
+      ? undefined
+      : GlitterCorpusSnapshotPinSchema.parse({
+          snapshotId: parsed["snapshot-id"],
+          snapshotSha256: parsed["snapshot-sha256"],
+        });
+  const handle = await startWorkflow({
+    client,
+    workflowType: "runGlitterContextAudit",
+    workflowId: `glitter-context-audit-${crypto.randomUUID()}`,
+    args: [
+      {
+        ...(parsed.now === undefined ? {} : { now: parsed.now }),
+        ...(snapshot === undefined ? {} : { snapshot }),
+      },
+    ],
+  });
+  if (parsed.wait === "true") {
+    console.warn(
+      JSON.stringify(
+        GlitterContextAuditResultSchema.parse(await handle.result()),
+        null,
+        2,
+      ),
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const [command, ...argv] = process.argv.slice(2);
   if (command === undefined) {
@@ -313,6 +361,11 @@ async function main(): Promise<void> {
     }
     case "context-refresh": {
       await runContextRefresh(client, argv);
+
+      break;
+    }
+    case "context-audit": {
+      await runContextAudit(client, argv);
 
       break;
     }

--- a/packages/temporal/src/activities/glitter-context-audit-relationships.ts
+++ b/packages/temporal/src/activities/glitter-context-audit-relationships.ts
@@ -1,0 +1,59 @@
+import { z } from "zod/v4";
+import type {
+  Person,
+  RelationshipsDocument,
+} from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import {
+  probeGenerationArtifact,
+  type GenerationArtifactReader,
+} from "./glitter-context-refresh-cache.ts";
+import {
+  buildRelationshipGenerationRequest,
+  type RelationshipGenerationInput,
+} from "./glitter-context-refresh-requests.ts";
+import { applyRelationshipProposals } from "./glitter-context-refresh-relationships.ts";
+
+export async function auditRelationshipGenerationCache(input: {
+  generationInput: RelationshipGenerationInput;
+  artifactReader: GenerationArtifactReader;
+  document: RelationshipsDocument;
+  people: readonly Person[];
+  evidence: readonly { personId: string; message: CurrentMessage }[];
+  snapshotSha256: string;
+  recordedAt: string;
+}) {
+  const request = buildRelationshipGenerationRequest(input.generationInput);
+  const probe = await probeGenerationArtifact({
+    store: input.artifactReader,
+    model: request.model,
+    callSite: request.callSite,
+    request: request.request,
+    responseSchema: request.responseSchema,
+  });
+  if (probe.status === "miss") {
+    return { probe, blockedReason: `missing ${probe.key}` };
+  }
+  if (probe.response.outcome === "failure") {
+    return {
+      probe,
+      blockedReason: `cached generation failure: ${probe.response.error}`,
+    };
+  }
+  try {
+    applyRelationshipProposals({
+      document: input.document,
+      proposals: probe.response.value.proposals,
+      people: input.people,
+      evidence: input.evidence,
+      snapshotSha256: input.snapshotSha256,
+      recordedAt: input.recordedAt,
+    });
+    return { probe, blockedReason: null };
+  } catch (error: unknown) {
+    return {
+      probe,
+      blockedReason: `cached proposal validation failed: ${z.instanceof(Error).parse(error).message}`,
+    };
+  }
+}

--- a/packages/temporal/src/activities/glitter-context-audit-schema.ts
+++ b/packages/temporal/src/activities/glitter-context-audit-schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod/v4";
+import { GlitterCorpusSnapshotPinSchema } from "./glitter-context-refresh-corpus.ts";
+
+export const GlitterContextAuditInputSchema = z
+  .object({
+    now: z.iso.datetime({ offset: true }).optional(),
+    snapshot: GlitterCorpusSnapshotPinSchema.optional(),
+  })
+  .strict();
+export type GlitterContextAuditInput = z.input<
+  typeof GlitterContextAuditInputSchema
+>;
+
+const GlitterContextAuditBlockedStageSchema = z.discriminatedUnion("stage", [
+  z
+    .object({
+      stage: z.literal("style-synthesis"),
+      personId: z.string().min(1),
+      reason: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      stage: z.literal("relationships"),
+      reason: z.string().min(1),
+    })
+    .strict(),
+]);
+export type GlitterContextAuditBlockedStage = z.infer<
+  typeof GlitterContextAuditBlockedStageSchema
+>;
+
+export const GlitterContextAuditResultSchema = z
+  .object({
+    snapshotId: z.uuid(),
+    snapshotSha256: z.string().regex(/^[0-9a-f]{64}$/),
+    eligiblePeople: z.array(z.string().min(1)),
+    cacheHits: z.number().int().nonnegative(),
+    cacheMisses: z.number().int().nonnegative(),
+    blockedStages: z.array(GlitterContextAuditBlockedStageSchema),
+    artifactKeys: z.array(z.string().min(1)),
+    worstCaseUncachedCostUsd: z.number().nonnegative(),
+  })
+  .strict();
+export type GlitterContextAuditResult = z.infer<
+  typeof GlitterContextAuditResultSchema
+>;

--- a/packages/temporal/src/activities/glitter-context-audit.test.ts
+++ b/packages/temporal/src/activities/glitter-context-audit.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  GenerationStateDocumentSchema,
+  PeopleDocumentSchema,
+  RelationshipsDocumentSchema,
+  StyleCardSchema,
+} from "@shepherdjerred/glitter-context/schema";
+import {
+  CurrentMessageSchema,
+  GuildSnapshotSchema,
+  StoredObjectSchema,
+  type CurrentMessage,
+} from "#shared/glitter-corpus.ts";
+import { generationRequestSha256 } from "./glitter-context-refresh-cache.ts";
+import { auditGlitterContextGenerationCache } from "./glitter-context-audit.ts";
+import * as glitterLlm from "./glitter-context-refresh-llm.ts";
+import {
+  STYLE_ARRAY_FIELDS,
+  StyleSynthesisSchema,
+} from "./glitter-context-refresh-style-schemas.ts";
+
+const SNAPSHOT_SHA = "a".repeat(64);
+const CREATED_AT = "2026-08-30T12:00:00.000Z";
+const PERSON_ID = "aaron";
+const DISCORD_ID = String(10n ** 17n);
+
+function message(index: number): CurrentMessage {
+  const messageId = String(100_000_000_000_000_000n + BigInt(index));
+  return CurrentMessageSchema.parse({
+    schemaVersion: 1,
+    source: "discord-rest",
+    selectedObservationKey: `raw/${messageId}`,
+    selectedObservedAt: CREATED_AT,
+    rawSha256: SNAPSHOT_SHA,
+    guildId: "1000",
+    guildSlug: "glitter-boys",
+    channelId: "2000",
+    messageId,
+    author: {
+      id: DISCORD_ID,
+      username: "aaron",
+      globalName: "Aaron",
+      discriminator: "0",
+      bot: false,
+      avatar: null,
+    },
+    content: `safe message ${String(index)}`,
+    timestamp: CREATED_AT,
+    editedTimestamp: null,
+    type: 0,
+    flags: "0",
+    pinned: false,
+    tts: false,
+    attachments: [],
+    referencedMessageId: null,
+  });
+}
+
+function corpus(messages: CurrentMessage[]) {
+  const inventoryObject = StoredObjectSchema.parse({
+    key: "inventory.json",
+    sha256: SNAPSHOT_SHA,
+    receipt: {
+      store: "seaweedfs",
+      bucket: "corpus",
+      key: "inventory.json",
+      sha256: SNAPSHOT_SHA,
+      etag: "etag",
+      writtenAt: CREATED_AT,
+    },
+  });
+  return {
+    reference: {
+      snapshotId: "00000000-0000-4000-8000-000000000999",
+      snapshotKey: "snapshot.json",
+      snapshotSha256: SNAPSHOT_SHA,
+    },
+    snapshot: GuildSnapshotSchema.parse({
+      schemaVersion: 1,
+      snapshotId: "00000000-0000-4000-8000-000000000999",
+      guildId: "1000",
+      createdAt: CREATED_AT,
+      inventoryObject,
+      channelManifestObjects: [],
+      expectedChannelIds: [],
+      completeChannelIds: [],
+      uniqueMessageCount: messages.length,
+      complete: true,
+    }),
+    messages,
+  };
+}
+
+async function existingCard() {
+  return StyleCardSchema.parse(
+    await Bun.file(
+      `${import.meta.dir}/../../../glitter-context/data/style-cards/aaron_style.json`,
+    ).json(),
+  );
+}
+
+function commonDocuments(relationshipSnapshot: string | null) {
+  return {
+    peopleDocument: PeopleDocumentSchema.parse({
+      schemaVersion: 1,
+      people: [
+        {
+          id: PERSON_ID,
+          displayName: "Aaron",
+          kind: "person",
+          aliases: [],
+          discordUserIds: [DISCORD_ID],
+        },
+      ],
+    }),
+    relationshipsDocument: RelationshipsDocumentSchema.parse({
+      schemaVersion: 1,
+      events: [],
+    }),
+    generationState: GenerationStateDocumentSchema.parse({
+      schemaVersion: 1,
+      relationshipSourceSnapshotChecksum: relationshipSnapshot,
+      relationshipRefreshedAt: null,
+      people: [],
+    }),
+  };
+}
+
+function storedArtifact(input: {
+  key: string;
+  model: string;
+  callSite: string;
+  response: unknown;
+}) {
+  const requestSha256 = input.key.split("/").at(-1)?.replace(".json", "");
+  if (requestSha256 === undefined) {
+    throw new Error(`invalid artifact key ${input.key}`);
+  }
+  return {
+    schemaVersion: 3,
+    ownerRunId: "00000000-0000-4000-8000-000000000001",
+    model: input.model,
+    callSite: input.callSite,
+    requestSha256,
+    responseSha256: generationRequestSha256(input.response),
+    response: input.response,
+    usage: {
+      inputTokens: 10,
+      outputTokens: 2,
+      cachedInputTokens: 0,
+      costUsd: 0.01,
+    },
+  };
+}
+
+describe("Glitter context zero-inference audit", () => {
+  test("reports extraction misses and blocks dependent synthesis", async () => {
+    const messages = Array.from({ length: 30 }, (_, index) => message(index));
+    const result = await auditGlitterContextGenerationCache({
+      corpus: corpus(messages),
+      ...commonDocuments(SNAPSHOT_SHA),
+      existingCards: new Map([[PERSON_ID, await existingCard()]]),
+      artifactReader: { read: () => Promise.resolve() },
+      now: new Date(CREATED_AT),
+    });
+
+    expect(result.eligiblePeople).toEqual([PERSON_ID]);
+    expect(result.cacheHits).toBe(0);
+    expect(result.cacheMisses).toBe(1);
+    expect(result.blockedStages).toEqual([
+      expect.objectContaining({
+        stage: "style-synthesis",
+        personId: PERSON_ID,
+        reason: expect.stringContaining("missing upstream chunk artifacts"),
+      }),
+    ]);
+    expect(result.artifactKeys).toHaveLength(1);
+    expect(result.worstCaseUncachedCostUsd).toBeGreaterThan(0);
+  });
+
+  test("continues to synthesis only after an exact upstream hit", async () => {
+    const messages = Array.from({ length: 30 }, (_, index) => message(index));
+    const firstMessage = messages[0];
+    if (firstMessage === undefined) {
+      throw new Error("missing fixture message");
+    }
+    const generate = vi.spyOn(glitterLlm, "generateGlitterObject");
+    const result = await auditGlitterContextGenerationCache({
+      corpus: corpus(messages),
+      ...commonDocuments(SNAPSHOT_SHA),
+      existingCards: new Map([[PERSON_ID, await existingCard()]]),
+      artifactReader: {
+        read: async (key) => {
+          if (key.includes("/glitter-style-chunk/")) {
+            return storedArtifact({
+              key,
+              model: "gpt-5.6-luna",
+              callSite: "glitter-style-chunk",
+              response: {
+                outcome: "success",
+                value: {
+                  observations: [
+                    {
+                      field: "voice",
+                      claim: "Uses concise messages",
+                      confidence: 0.9,
+                      evidenceMessageIds: [firstMessage.messageId],
+                    },
+                  ],
+                  representativeMessages: [],
+                },
+              },
+            });
+          }
+          return;
+        },
+      },
+      now: new Date(CREATED_AT),
+    });
+
+    expect(result.cacheHits).toBe(1);
+    expect(result.cacheMisses).toBe(1);
+    expect(result.artifactKeys[1]).toContain("glitter-style-synthesis");
+    expect(result.blockedStages[0]?.reason).toContain("missing");
+    expect(generate).not.toHaveBeenCalled();
+    generate.mockRestore();
+  });
+
+  test("validates an exact relationship artifact without model calls", async () => {
+    const generate = vi.spyOn(glitterLlm, "generateGlitterObject");
+    const result = await auditGlitterContextGenerationCache({
+      corpus: corpus([message(1)]),
+      ...commonDocuments(null),
+      existingCards: new Map(),
+      artifactReader: {
+        read: async (key) =>
+          storedArtifact({
+            key,
+            model: "gpt-5.6-luna",
+            callSite: "glitter-context-relationships",
+            response: { outcome: "success", value: { proposals: [] } },
+          }),
+      },
+      now: new Date(CREATED_AT),
+    });
+
+    expect(result.eligiblePeople).toEqual([]);
+    expect(result.cacheHits).toBe(1);
+    expect(result.cacheMisses).toBe(0);
+    expect(result.blockedStages).toEqual([]);
+    expect(generate).not.toHaveBeenCalled();
+    generate.mockRestore();
+  });
+});
+
+describe("Glitter context audit failure parity", () => {
+  test("reports cached relationship failures and invalid proposals", async () => {
+    const failed = await auditGlitterContextGenerationCache({
+      corpus: corpus([message(1)]),
+      ...commonDocuments(null),
+      existingCards: new Map(),
+      artifactReader: {
+        read: async (key) =>
+          storedArtifact({
+            key,
+            model: "gpt-5.6-luna",
+            callSite: "glitter-context-relationships",
+            response: {
+              outcome: "failure",
+              error: "cached parse failure",
+              rawContent: null,
+            },
+          }),
+      },
+      now: new Date(CREATED_AT),
+    });
+    expect(failed.blockedStages).toEqual([
+      {
+        stage: "relationships",
+        reason: "cached generation failure: cached parse failure",
+      },
+    ]);
+
+    const invalid = await auditGlitterContextGenerationCache({
+      corpus: corpus([message(1), message(2)]),
+      ...commonDocuments(null),
+      existingCards: new Map(),
+      artifactReader: {
+        read: async (key) =>
+          storedArtifact({
+            key,
+            model: "gpt-5.6-luna",
+            callSite: "glitter-context-relationships",
+            response: {
+              outcome: "success",
+              value: {
+                proposals: [
+                  {
+                    sourceId: PERSON_ID,
+                    targetId: "unknown-person",
+                    kind: "friendship",
+                    label: "friends",
+                    direction: "undirected",
+                    effectiveAt: null,
+                    evidenceMessageIds: [
+                      message(1).messageId,
+                      message(2).messageId,
+                    ],
+                    confidence: 0.99,
+                    rationale: "Explicitly stated friendship",
+                  },
+                ],
+              },
+            },
+          }),
+      },
+      now: new Date(CREATED_AT),
+    });
+    expect(invalid.blockedStages[0]?.reason).toContain(
+      "cached proposal validation failed",
+    );
+  });
+
+  test("reports exhaustion of all cached synthesis repairs", async () => {
+    const messages = Array.from({ length: 30 }, (_, index) => message(index));
+    const invalidSynthesis = StyleSynthesisSchema.parse({
+      patches: STYLE_ARRAY_FIELDS.map((field) => ({
+        field,
+        priorDecisions: [],
+        additions: [],
+      })),
+      summaryPatch: { priorDecisions: [], additions: [] },
+      leaguePatch: { priorDecisions: [], additions: [] },
+      quoteMessageIds: messages.slice(0, 20).map((entry) => entry.messageId),
+      sampleMessageIds: messages.map((entry) => entry.messageId),
+      situational_examples: {
+        provenance: "synthetic",
+        happy_or_excited: ["one", "two", "three"],
+        angry_or_frustrated: ["one", "two", "three"],
+        sad_or_disappointed: ["one", "two", "three"],
+        supportive_or_caring: ["one", "two", "three"],
+        playful_or_teasing: ["one", "two", "three"],
+        neutral_or_logistical: ["one", "two", "three"],
+      },
+    });
+    const firstMessage = messages[0];
+    if (firstMessage === undefined) {
+      throw new Error("missing first message fixture");
+    }
+    const result = await auditGlitterContextGenerationCache({
+      corpus: corpus(messages),
+      ...commonDocuments(SNAPSHOT_SHA),
+      existingCards: new Map([[PERSON_ID, await existingCard()]]),
+      artifactReader: {
+        read: async (key) =>
+          key.includes("/glitter-style-chunk/")
+            ? storedArtifact({
+                key,
+                model: "gpt-5.6-luna",
+                callSite: "glitter-style-chunk",
+                response: {
+                  outcome: "success",
+                  value: {
+                    observations: [
+                      {
+                        field: "voice",
+                        claim: "Uses concise messages",
+                        confidence: 0.9,
+                        evidenceMessageIds: [firstMessage.messageId],
+                      },
+                    ],
+                    representativeMessages: [],
+                  },
+                },
+              })
+            : storedArtifact({
+                key,
+                model: "gpt-5.6-luna",
+                callSite: key.includes("synthesis-repair")
+                  ? "glitter-style-synthesis-repair"
+                  : "glitter-style-synthesis",
+                response: { outcome: "success", value: invalidSynthesis },
+              }),
+      },
+      now: new Date(CREATED_AT),
+    });
+
+    expect(result.cacheHits).toBe(5);
+    expect(result.blockedStages[0]?.reason).toContain(
+      "cached synthesis exhausted all repairs",
+    );
+  });
+
+  test("fails closed on a malformed artifact", async () => {
+    const messages = Array.from({ length: 30 }, (_, index) => message(index));
+    await expect(
+      auditGlitterContextGenerationCache({
+        corpus: corpus(messages),
+        ...commonDocuments(SNAPSHOT_SHA),
+        existingCards: new Map([[PERSON_ID, await existingCard()]]),
+        artifactReader: {
+          read: async () => ({ schemaVersion: 3, response: {} }),
+        },
+        now: new Date(CREATED_AT),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/temporal/src/activities/glitter-context-audit.ts
+++ b/packages/temporal/src/activities/glitter-context-audit.ts
@@ -1,0 +1,466 @@
+import { mkdir, rm } from "node:fs/promises";
+import { Context } from "@temporalio/activity";
+import { simpleGit } from "simple-git";
+import { z } from "zod/v4";
+import {
+  GenerationStateDocumentSchema,
+  PeopleDocumentSchema,
+  RelationshipsDocumentSchema,
+  StyleCardSchema,
+  type GenerationStateDocument,
+  type PeopleDocument,
+  type RelationshipsDocument,
+  type StyleCard,
+} from "@shepherdjerred/glitter-context/schema";
+import {
+  loadVerifiedGlitterCorpus,
+  type VerifiedGlitterCorpus,
+} from "./glitter-context-refresh-corpus.ts";
+import {
+  createCorpusGenerationArtifactReader,
+  probeGenerationArtifact,
+  type GenerationArtifactProbe,
+  type GenerationArtifactReader,
+} from "./glitter-context-refresh-cache.ts";
+import { estimateRelationshipGenerationCost } from "./glitter-context-refresh-generate.ts";
+import {
+  buildStyleChunkGenerationRequest,
+  buildStyleSynthesisGenerationRequest,
+  type ChunkExtractionRepair,
+  type RelationshipGenerationInput,
+} from "./glitter-context-refresh-requests.ts";
+import { estimateStyleGenerationCost } from "./glitter-context-refresh-style-generation.ts";
+import { SynthesisInputTooLargeError } from "./glitter-context-refresh-synthesis-limit.ts";
+import {
+  buildStyleEvidenceChunks,
+  type StyleEvidenceChunk,
+} from "./glitter-context-refresh-chunks.ts";
+import { auditRelationshipGenerationCache } from "./glitter-context-audit-relationships.ts";
+import { prepareRelationshipEvaluation } from "./glitter-context-refresh-relationship-batching.ts";
+import {
+  selectStyleRefreshCandidates,
+  type StyleRefreshCandidate,
+} from "./glitter-context-refresh-selection.ts";
+import {
+  MAX_EXTRACTION_REPAIR_ATTEMPTS,
+  MAX_SYNTHESIS_REPAIR_ATTEMPTS,
+  type SummarizedChunk,
+} from "./glitter-context-refresh-style-generation-cost.ts";
+import { finalizeStyleSynthesis } from "./glitter-context-refresh-style-finalize.ts";
+import {
+  sanitizeChunkSummary,
+  validateChunkSummary,
+} from "./glitter-context-refresh-style-validation.ts";
+import type {
+  StyleChunkSummary,
+  StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+import { createCorpusStoreFromEnv } from "./glitter-corpus-store.ts";
+import {
+  GlitterContextAuditInputSchema,
+  GlitterContextAuditResultSchema,
+  type GlitterContextAuditBlockedStage,
+  type GlitterContextAuditInput,
+  type GlitterContextAuditResult,
+} from "./glitter-context-audit-schema.ts";
+
+const REPO_URL = "https://github.com/shepherdjerred/monorepo.git";
+const MAIN_BRANCH = "main";
+const PACKAGE_PATH = "packages/glitter-context";
+const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
+  observations: [],
+  representativeMessages: [],
+};
+
+type AuditState = {
+  cacheHits: number;
+  cacheMisses: number;
+  artifactKeys: string[];
+  blockedStages: GlitterContextAuditBlockedStage[];
+};
+
+type AuditInputs = {
+  corpus: VerifiedGlitterCorpus;
+  peopleDocument: PeopleDocument;
+  relationshipsDocument: RelationshipsDocument;
+  generationState: GenerationStateDocument;
+  existingCards: ReadonlyMap<string, StyleCard>;
+  artifactReader: GenerationArtifactReader;
+  now: Date;
+};
+
+function recordProbe<Response>(
+  state: AuditState,
+  probe: GenerationArtifactProbe<Response>,
+): void {
+  state.artifactKeys.push(probe.key);
+  if (probe.status === "hit") {
+    state.cacheHits += 1;
+  } else {
+    state.cacheMisses += 1;
+  }
+}
+
+function verifiableContent(summary: StyleChunkSummary): number {
+  return summary.observations.length + summary.representativeMessages.length;
+}
+
+function summarizedMessageCount(
+  chunk: StyleEvidenceChunk,
+  summary: StyleChunkSummary,
+): number {
+  return verifiableContent(summary) === 0 ? 0 : chunk.messages.length;
+}
+
+function nextParseFailureRepair(
+  prior: ChunkExtractionRepair | null,
+  error: string,
+  rawContent: string | null,
+): ChunkExtractionRepair {
+  if (prior === null || prior.previous === EMPTY_CHUNK_SUMMARY) {
+    return { previous: EMPTY_CHUNK_SUMMARY, error, rawContent };
+  }
+  return { previous: prior.previous, error: prior.error, rawContent: null };
+}
+
+async function auditChunk(input: {
+  candidate: StyleRefreshCandidate;
+  chunk: StyleEvidenceChunk;
+  artifactReader: GenerationArtifactReader;
+  state: AuditState;
+}): Promise<StyleChunkSummary | undefined> {
+  const attempts: StyleChunkSummary[] = [];
+  let repair: ChunkExtractionRepair | null = null;
+  for (let attempt = 0; attempt <= MAX_EXTRACTION_REPAIR_ATTEMPTS; attempt++) {
+    const request = buildStyleChunkGenerationRequest({
+      candidate: input.candidate,
+      chunk: input.chunk,
+      attempt,
+      repair: attempt === 0 ? null : repair,
+    });
+    const probe = await probeGenerationArtifact({
+      store: input.artifactReader,
+      model: request.model,
+      callSite: request.callSite,
+      request: request.request,
+      responseSchema: request.responseSchema,
+    });
+    recordProbe(input.state, probe);
+    if (probe.status === "miss") {
+      return undefined;
+    }
+    if (probe.response.outcome === "failure") {
+      repair = nextParseFailureRepair(
+        repair,
+        probe.response.error,
+        probe.response.rawContent,
+      );
+      continue;
+    }
+    attempts.push(probe.response.value);
+    try {
+      validateChunkSummary(input.chunk, probe.response.value);
+      return probe.response.value;
+    } catch (error: unknown) {
+      repair = {
+        previous: probe.response.value,
+        error: z.instanceof(Error).parse(error).message,
+        rawContent: null,
+      };
+    }
+  }
+  if (attempts.length === 0) {
+    return EMPTY_CHUNK_SUMMARY;
+  }
+  const best = attempts
+    .map((attempt) => sanitizeChunkSummary(input.chunk, attempt))
+    .reduce((strongest, candidate) =>
+      verifiableContent(candidate) > verifiableContent(strongest)
+        ? candidate
+        : strongest,
+    );
+  validateChunkSummary(input.chunk, best);
+  return best;
+}
+
+async function auditSynthesis(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  sourceSnapshotSha256: string;
+  artifactReader: GenerationArtifactReader;
+  state: AuditState;
+}): Promise<void> {
+  let repair: { previous: StyleSynthesis; error: string } | null = null;
+  for (let attempt = 0; attempt <= MAX_SYNTHESIS_REPAIR_ATTEMPTS; attempt++) {
+    let request: ReturnType<typeof buildStyleSynthesisGenerationRequest>;
+    try {
+      request = buildStyleSynthesisGenerationRequest({
+        candidate: input.candidate,
+        existingCard: input.existingCard,
+        chunks: input.chunks,
+        attempt,
+        repair,
+      });
+    } catch (error: unknown) {
+      if (!(error instanceof SynthesisInputTooLargeError)) {
+        throw error;
+      }
+      input.state.blockedStages.push({
+        stage: "style-synthesis",
+        personId: input.candidate.person.id,
+        reason: error.message,
+      });
+      return;
+    }
+    const probe = await probeGenerationArtifact({
+      store: input.artifactReader,
+      model: request.model,
+      callSite: request.callSite,
+      request: request.request,
+      responseSchema: request.responseSchema,
+    });
+    recordProbe(input.state, probe);
+    if (probe.status === "miss") {
+      input.state.blockedStages.push({
+        stage: "style-synthesis",
+        personId: input.candidate.person.id,
+        reason: `missing ${probe.key}`,
+      });
+      return;
+    }
+    if (probe.response.outcome === "failure") {
+      input.state.blockedStages.push({
+        stage: "style-synthesis",
+        personId: input.candidate.person.id,
+        reason: `cached generation failure: ${probe.response.error}`,
+      });
+      return;
+    }
+    try {
+      finalizeStyleSynthesis({
+        candidate: input.candidate,
+        existingCard: input.existingCard,
+        sourceSnapshotSha256: input.sourceSnapshotSha256,
+        chunks: request.chunks,
+        directRecentMessages: request.directRecentMessages,
+        omittedChunks: input.chunks.length - request.chunks.length,
+        omittedSummarizedMessages:
+          input.chunks.reduce(
+            (total, chunk) => total + chunk.summarizedMessageCount,
+            0,
+          ) -
+          request.chunks.reduce(
+            (total, chunk) => total + chunk.summarizedMessageCount,
+            0,
+          ),
+        omittedDirectRecentMessages:
+          input.candidate.directRecentMessages.length -
+          request.directRecentMessages.length,
+        synthesis: probe.response.value,
+      });
+      return;
+    } catch (error: unknown) {
+      repair = {
+        previous: probe.response.value,
+        error: z.instanceof(Error).parse(error).message,
+      };
+    }
+  }
+  input.state.blockedStages.push({
+    stage: "style-synthesis",
+    personId: input.candidate.person.id,
+    reason: `cached synthesis exhausted all repairs: ${repair?.error ?? "no deterministic validation error was recorded"}`,
+  });
+}
+
+async function auditCandidate(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  sourceSnapshotSha256: string;
+  artifactReader: GenerationArtifactReader;
+  state: AuditState;
+}): Promise<void> {
+  const summarizedChunks: SummarizedChunk[] = [];
+  const missingChunkKeys: string[] = [];
+  for (const chunk of buildStyleEvidenceChunks(input.candidate.safeMessages)) {
+    const summary = await auditChunk({ ...input, chunk });
+    if (summary === undefined) {
+      missingChunkKeys.push(chunk.key);
+      continue;
+    }
+    const firstMessage = chunk.messages[0];
+    const lastMessage = chunk.messages.at(-1);
+    if (firstMessage === undefined || lastMessage === undefined) {
+      throw new Error(`style evidence chunk ${chunk.key} is empty`);
+    }
+    summarizedChunks.push({
+      key: chunk.key,
+      month: chunk.month,
+      startTimestamp: firstMessage.timestamp,
+      endTimestamp: lastMessage.timestamp,
+      summary,
+      summarizedMessageCount: summarizedMessageCount(chunk, summary),
+    });
+  }
+  if (missingChunkKeys.length > 0) {
+    input.state.blockedStages.push({
+      stage: "style-synthesis",
+      personId: input.candidate.person.id,
+      reason: `missing upstream chunk artifacts for ${missingChunkKeys.join(", ")}`,
+    });
+    return;
+  }
+  await auditSynthesis({
+    ...input,
+    chunks: summarizedChunks,
+  });
+}
+
+export async function auditGlitterContextGenerationCache(
+  input: AuditInputs,
+): Promise<GlitterContextAuditResult> {
+  const candidates = selectStyleRefreshCandidates({
+    people: input.peopleDocument.people,
+    state: input.generationState.people,
+    messages: input.corpus.messages,
+    now: input.now,
+  });
+  const relationshipEvaluation = prepareRelationshipEvaluation({
+    state: input.generationState,
+    people: input.peopleDocument,
+    relationships: input.relationshipsDocument,
+    messages: input.corpus.messages,
+    snapshotSha256: input.corpus.reference.snapshotSha256,
+  });
+  const relationshipInput: RelationshipGenerationInput =
+    relationshipEvaluation.generationInput;
+  const relationshipEvidence = relationshipEvaluation.evidence;
+  const state: AuditState = {
+    cacheHits: 0,
+    cacheMisses: 0,
+    artifactKeys: [],
+    blockedStages: [],
+  };
+  let worstCaseUncachedCostUsd = 0;
+  for (const candidate of candidates) {
+    const existingCard = input.existingCards.get(candidate.person.id);
+    if (existingCard === undefined) {
+      throw new Error(`missing existing style card for ${candidate.person.id}`);
+    }
+    worstCaseUncachedCostUsd += estimateStyleGenerationCost({
+      candidate,
+      existingCard,
+    });
+    await auditCandidate({
+      candidate,
+      existingCard,
+      sourceSnapshotSha256: input.corpus.reference.snapshotSha256,
+      artifactReader: input.artifactReader,
+      state,
+    });
+  }
+  worstCaseUncachedCostUsd +=
+    estimateRelationshipGenerationCost(relationshipInput);
+  if (relationshipInput.evidence.length > 0) {
+    const relationshipAudit = await auditRelationshipGenerationCache({
+      generationInput: relationshipInput,
+      artifactReader: input.artifactReader,
+      document: input.relationshipsDocument,
+      people: input.peopleDocument.people,
+      evidence: relationshipEvidence,
+      snapshotSha256: input.corpus.reference.snapshotSha256,
+      recordedAt: input.now.toISOString(),
+    });
+    recordProbe(state, relationshipAudit.probe);
+    if (relationshipAudit.blockedReason !== null) {
+      state.blockedStages.push({
+        stage: "relationships",
+        reason: relationshipAudit.blockedReason,
+      });
+    }
+  }
+  return GlitterContextAuditResultSchema.parse({
+    snapshotId: input.corpus.reference.snapshotId,
+    snapshotSha256: input.corpus.reference.snapshotSha256,
+    eligiblePeople: candidates.map((candidate) => candidate.person.id),
+    cacheHits: state.cacheHits,
+    cacheMisses: state.cacheMisses,
+    blockedStages: state.blockedStages,
+    artifactKeys: state.artifactKeys,
+    worstCaseUncachedCostUsd,
+  });
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return await Bun.file(path).json();
+}
+
+export const glitterContextAuditActivities = {
+  async auditGlitterContext(
+    rawInput: GlitterContextAuditInput = {},
+  ): Promise<GlitterContextAuditResult> {
+    const input = GlitterContextAuditInputSchema.parse(rawInput);
+    const execution = Context.current().info.workflowExecution;
+    if (execution === undefined) {
+      throw new Error("Glitter context audit requires a Temporal execution");
+    }
+    const tempDir = `/tmp/glitter-context-audit-${execution.runId}`;
+    const repoDir = `${tempDir}/monorepo`;
+    const heartbeat = setInterval(() => {
+      Context.current().heartbeat({ phase: "glitter-context-audit" });
+    }, 10_000);
+    try {
+      const corpus = await loadVerifiedGlitterCorpus(input.snapshot);
+      await mkdir(tempDir, { recursive: true });
+      await simpleGit().clone(REPO_URL, repoDir, [
+        "--branch",
+        MAIN_BRANCH,
+        "--single-branch",
+        "--filter=blob:none",
+        "--depth=1",
+      ]);
+      const peopleDocument = PeopleDocumentSchema.parse(
+        await readJson(`${repoDir}/${PACKAGE_PATH}/data/people.json`),
+      );
+      const relationshipsDocument = RelationshipsDocumentSchema.parse(
+        await readJson(`${repoDir}/${PACKAGE_PATH}/data/relationships.json`),
+      );
+      const generationState = GenerationStateDocumentSchema.parse(
+        await readJson(`${repoDir}/${PACKAGE_PATH}/data/generation-state.json`),
+      );
+      const existingCards = new Map<string, StyleCard>();
+      const now = new Date(input.now ?? new Date().toISOString());
+      const candidates = selectStyleRefreshCandidates({
+        people: peopleDocument.people,
+        state: generationState.people,
+        messages: corpus.messages,
+        now,
+      });
+      for (const candidate of candidates) {
+        existingCards.set(
+          candidate.person.id,
+          StyleCardSchema.parse(
+            await readJson(
+              `${repoDir}/${PACKAGE_PATH}/data/style-cards/${candidate.person.id}_style.json`,
+            ),
+          ),
+        );
+      }
+      return await auditGlitterContextGenerationCache({
+        corpus,
+        peopleDocument,
+        relationshipsDocument,
+        generationState,
+        existingCards,
+        artifactReader: createCorpusGenerationArtifactReader(
+          createCorpusStoreFromEnv(),
+        ),
+        now,
+      });
+    } finally {
+      clearInterval(heartbeat);
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  },
+};

--- a/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-budget.test.ts
@@ -13,13 +13,13 @@ import {
   SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
 } from "./glitter-context-refresh-style-generation-cost.ts";
 import { SYNTHESIS_INPUT_BYTE_LIMIT } from "./glitter-context-refresh-synthesis-limit.ts";
+import { estimateRelationshipGenerationCost } from "./glitter-context-refresh-generate.ts";
 import {
   buildBoundedRelationshipInput,
-  estimateRelationshipGenerationCost,
   RELATIONSHIP_INPUT_BYTE_LIMIT,
   RELATIONSHIP_MAX_OUTPUT_TOKENS,
   RELATIONSHIP_MODEL,
-} from "./glitter-context-refresh-generate.ts";
+} from "./glitter-context-refresh-requests.ts";
 import { CurrentMessageSchema } from "#shared/glitter-corpus.ts";
 
 describe("Glitter generation budget", () => {

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.test.ts
@@ -5,7 +5,9 @@ import {
   generationArtifactKey,
   generationRequestSha256,
   generationSpendReceiptKey,
+  probeGenerationArtifact,
   readOrCreateGenerationArtifact,
+  type GenerationArtifactReader,
   type GenerationArtifactStore,
 } from "./glitter-context-refresh-cache.ts";
 import { GenerationBudget } from "./glitter-context-refresh-budget.ts";
@@ -222,6 +224,79 @@ describe("Glitter context generation artifacts", () => {
     expect(failure.type).toBe("BilledGenerationFinalizationError");
     expect(failure.nonRetryable).toBe(true);
     expect(createCount).toBe(1);
+  });
+});
+
+describe("Glitter context generation artifact probes", () => {
+  test("fully validates an exact current artifact without writes or generation", async () => {
+    const request = { prompt: "stable prompt", seed: 0 };
+    const response = { value: "cached" };
+    const key = generationArtifactKey({
+      callSite: "style-card",
+      requestSha256: generationRequestSha256(request),
+    });
+    const reader: GenerationArtifactReader = {
+      read: async (receivedKey) =>
+        receivedKey === key
+          ? {
+              schemaVersion: 3,
+              ownerRunId: OTHER_RUN_ID,
+              model: "test-model",
+              callSite: "style-card",
+              requestSha256: generationRequestSha256(request),
+              responseSha256: generationRequestSha256(response),
+              response,
+              usage: {
+                inputTokens: 10,
+                outputTokens: 2,
+                cachedInputTokens: 0,
+                costUsd: 0.01,
+              },
+            }
+          : undefined,
+    };
+
+    await expect(
+      probeGenerationArtifact({
+        store: reader,
+        model: "test-model",
+        callSite: "style-card",
+        request,
+        responseSchema: ResponseSchema,
+      }),
+    ).resolves.toMatchObject({ status: "hit", key, response });
+  });
+
+  test("reports a changed request hash as a miss", async () => {
+    const reader: GenerationArtifactReader = {
+      read: () => Promise.resolve(),
+    };
+    const probe = await probeGenerationArtifact({
+      store: reader,
+      model: "test-model",
+      callSite: "style-card",
+      request: { prompt: "changed" },
+      responseSchema: ResponseSchema,
+    });
+    expect(probe.status).toBe("miss");
+    expect(probe.requestSha256).toBe(
+      generationRequestSha256({ prompt: "changed" }),
+    );
+  });
+
+  test("rejects malformed current artifacts", async () => {
+    const reader: GenerationArtifactReader = {
+      read: async () => ({ schemaVersion: 3, response: { value: "bad" } }),
+    };
+    await expect(
+      probeGenerationArtifact({
+        store: reader,
+        model: "test-model",
+        callSite: "style-card",
+        request: { prompt: "stable" },
+        responseSchema: ResponseSchema,
+      }),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/temporal/src/activities/glitter-context-refresh-cache.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-cache.ts
@@ -59,9 +59,12 @@ const GenerationSpendReceiptSchema = z.strictObject({
   usage: GenerationUsageSchema,
 });
 
-export type GenerationArtifactStore = {
-  ownerRunId: string;
+export type GenerationArtifactReader = {
   read: (key: string) => Promise<unknown>;
+};
+
+export type GenerationArtifactStore = GenerationArtifactReader & {
+  ownerRunId: string;
   create: (key: string, value: unknown) => Promise<void>;
 };
 
@@ -175,6 +178,55 @@ function parseStoredResponse<Response>(input: {
     cacheStatus: input.cacheStatus,
     billedToCurrentRun: artifact.ownerRunId === input.ownerRunId,
     usage: artifact.usage,
+  };
+}
+
+export type GenerationArtifactProbe<Response> =
+  | {
+      status: "hit";
+      key: string;
+      requestSha256: string;
+      response: Response;
+      usage: GenerationUsage;
+    }
+  | {
+      status: "miss";
+      key: string;
+      requestSha256: string;
+    };
+
+export async function probeGenerationArtifact<Response>(input: {
+  store: GenerationArtifactReader;
+  model: string;
+  callSite: string;
+  request: unknown;
+  responseSchema: z.ZodType<Response>;
+}): Promise<GenerationArtifactProbe<Response>> {
+  const requestSha256 = generationRequestSha256(input.request);
+  const key = generationArtifactKey({
+    callSite: input.callSite,
+    requestSha256,
+  });
+  const stored = await input.store.read(key);
+  if (stored === undefined) {
+    return { status: "miss", key, requestSha256 };
+  }
+  const parsed = parseStoredResponse({
+    stored,
+    key,
+    cacheStatus: "hit",
+    model: input.model,
+    callSite: input.callSite,
+    ownerRunId: "00000000-0000-4000-8000-000000000000",
+    requestSha256,
+    responseSchema: input.responseSchema,
+  });
+  return {
+    status: "hit",
+    key,
+    requestSha256,
+    response: parsed.response,
+    usage: parsed.usage,
   };
 }
 
@@ -405,6 +457,23 @@ export function createCorpusGenerationArtifactStore(
           throw error;
         }
       }
+    },
+  };
+}
+
+export function createCorpusGenerationArtifactReader(
+  store: CorpusStore,
+): GenerationArtifactReader {
+  const guildId = z
+    .string()
+    .regex(/^\d+$/u)
+    .parse(Bun.env["GLITTER_DISCORD_GUILD_ID"]);
+  return {
+    read: async (key) => {
+      const bytes = await getObjectBytes(store, `guilds/${guildId}/${key}`);
+      return bytes === undefined
+        ? undefined
+        : (JSON.parse(new TextDecoder().decode(bytes)) as unknown);
     },
   };
 }

--- a/packages/temporal/src/activities/glitter-context-refresh-generate.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-generate.ts
@@ -1,13 +1,8 @@
 import { z } from "zod/v4";
-import {
-  RelationshipDirectionSchema,
-  RelationshipKindSchema,
-  type RelationshipEvent,
-} from "@shepherdjerred/glitter-context/schema";
+import { type RelationshipEvent } from "@shepherdjerred/glitter-context/schema";
 import type { CurrentMessage } from "#shared/glitter-corpus.ts";
 import {
   type GenerationBudget,
-  inputTokenUpperBound,
   worstCaseGenerationCostUsd,
 } from "./glitter-context-refresh-budget.ts";
 import {
@@ -16,112 +11,15 @@ import {
 } from "./glitter-context-refresh-cache.ts";
 import {
   generateGlitterObject,
-  glitterObjectArtifactSchema,
-  glitterPrompt,
   useGlitterObjectArtifact,
 } from "./glitter-context-refresh-llm.ts";
-import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
-
-export const RELATIONSHIP_MODEL = "gpt-5.6-luna";
-export const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
-export const RELATIONSHIP_INPUT_BYTE_LIMIT = 600_000;
-const MINIMUM_RELATIONSHIP_EVIDENCE = 2;
-const DETERMINISTIC_SEED = 0;
-
-const RelationshipProposalSchema = z.strictObject({
-  sourceId: z.string(),
-  targetId: z.string(),
-  kind: RelationshipKindSchema,
-  label: z.string(),
-  direction: RelationshipDirectionSchema,
-  effectiveAt: z.iso.date().nullable(),
-  evidenceMessageIds: z.array(z.string().regex(/^\d+$/u)).min(2).max(8),
-  confidence: z.number().min(0.9).max(1),
-  rationale: z.string().min(1).max(500),
-});
-
-const RelationshipProposalsSchema = z.strictObject({
-  proposals: z.array(RelationshipProposalSchema).max(20),
-});
+import {
+  buildRelationshipGenerationRequest,
+  RelationshipProposalSchema,
+  type RelationshipGenerationInput,
+} from "./glitter-context-refresh-requests.ts";
 
 export type RelationshipProposal = z.infer<typeof RelationshipProposalSchema>;
-
-function messageEvidence(message: CurrentMessage): {
-  messageId: string;
-  timestamp: string;
-  content: string;
-} {
-  return {
-    messageId: message.messageId,
-    timestamp: message.timestamp,
-    content: message.content,
-  };
-}
-
-type RelationshipGenerationInput = {
-  people: readonly { id: string; displayName: string }[];
-  currentRelationships: readonly RelationshipEvent[];
-  evidence: readonly {
-    personId: string;
-    message: CurrentMessage;
-  }[];
-};
-
-function relationshipMessages(input: RelationshipGenerationInput) {
-  const prompt = [
-    "Propose relationship updates only when the supplied Discord messages",
-    "contain explicit, high-confidence evidence. Return no proposal when",
-    "evidence is ambiguous, joking, hearsay, or merely stylistic.",
-    "Each proposal needs 2-8 supplied message IDs. IDs must be copied exactly.",
-    "Do not repeat a relationship that is already current.",
-    "These proposals will be committed only to a human-reviewed PR.",
-    "",
-    JSON.stringify({
-      people: input.people,
-      currentRelationships: input.currentRelationships,
-      evidence: input.evidence.map((entry) => ({
-        personId: entry.personId,
-        ...messageEvidence(entry.message),
-      })),
-    }),
-  ].join("\n");
-  return glitterPrompt(
-    "You identify explicit relationship changes conservatively and cite corpus evidence.",
-    prompt,
-  );
-}
-
-export function buildBoundedRelationshipInput(
-  input: RelationshipGenerationInput,
-): {
-  evidence: RelationshipGenerationInput["evidence"];
-  messages: ReturnType<typeof relationshipMessages>;
-  inputBytes: number;
-} {
-  const minimumEvidence = Math.min(
-    MINIMUM_RELATIONSHIP_EVIDENCE,
-    input.evidence.length,
-  );
-  const maximumOmittedEvidence = input.evidence.length - minimumEvidence;
-  for (
-    let omittedEvidence = 0;
-    omittedEvidence <= maximumOmittedEvidence;
-    omittedEvidence += 1
-  ) {
-    const evidence = input.evidence.slice(
-      0,
-      input.evidence.length - omittedEvidence,
-    );
-    const messages = relationshipMessages({ ...input, evidence });
-    const inputBytes = inputTokenUpperBound(JSON.stringify(messages));
-    if (inputBytes <= RELATIONSHIP_INPUT_BYTE_LIMIT) {
-      return { evidence, messages, inputBytes };
-    }
-  }
-  throw new GlitterEvidenceError(
-    `fixed Glitter relationship input exceeds ${String(RELATIONSHIP_INPUT_BYTE_LIMIT)} bytes after reducing evidence to ${String(minimumEvidence)} messages`,
-  );
-}
 
 export function estimateRelationshipGenerationCost(
   input: RelationshipGenerationInput,
@@ -129,11 +27,11 @@ export function estimateRelationshipGenerationCost(
   if (input.evidence.length === 0) {
     return 0;
   }
-  const bounded = buildBoundedRelationshipInput(input);
+  const generationRequest = buildRelationshipGenerationRequest(input);
   return worstCaseGenerationCostUsd({
-    model: RELATIONSHIP_MODEL,
-    inputTokenUpperBound: bounded.inputBytes,
-    outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+    model: generationRequest.model,
+    inputTokenUpperBound: generationRequest.inputBytes,
+    outputTokenUpperBound: generationRequest.maxOutputTokens,
   });
 }
 
@@ -150,43 +48,32 @@ export async function proposeRelationships(input: {
   if (input.evidence.length === 0) {
     return [];
   }
-  const callSite = "glitter-context-relationships";
-  const bounded = buildBoundedRelationshipInput(input);
-  const messages = bounded.messages;
-  const CompletionArtifactSchema = glitterObjectArtifactSchema(
-    RelationshipProposalsSchema,
-  );
+  const generationRequest = buildRelationshipGenerationRequest(input);
   const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
-    model: RELATIONSHIP_MODEL,
-    callSite,
-    request: {
-      schemaVersion: 3,
-      model: RELATIONSHIP_MODEL,
-      messages,
-      maxCompletionTokens: RELATIONSHIP_MAX_OUTPUT_TOKENS,
-      reasoningEffort: "medium",
-      seed: DETERMINISTIC_SEED,
-      responseSchema: "relationship-proposals-v2",
-    },
-    responseSchema: CompletionArtifactSchema,
+    model: generationRequest.model,
+    callSite: generationRequest.callSite,
+    request: generationRequest.request,
+    responseSchema: generationRequest.responseSchema,
     generate: async () => {
       input.budget.authorizeUncachedCall(
         worstCaseGenerationCostUsd({
-          model: RELATIONSHIP_MODEL,
-          inputTokenUpperBound: bounded.inputBytes,
-          outputTokenUpperBound: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+          model: generationRequest.model,
+          inputTokenUpperBound: generationRequest.inputBytes,
+          outputTokenUpperBound: generationRequest.maxOutputTokens,
         }),
       );
       return await generateGlitterObject({
-        model: RELATIONSHIP_MODEL,
-        schema: RelationshipProposalsSchema,
+        model: generationRequest.model,
+        schema: z.strictObject({
+          proposals: z.array(RelationshipProposalSchema).max(20),
+        }),
         schemaName: "relationship_proposals",
-        ...messages,
-        workload: callSite,
-        maxOutputTokens: RELATIONSHIP_MAX_OUTPUT_TOKENS,
-        reasoningEffort: "medium",
-        seed: DETERMINISTIC_SEED,
+        ...generationRequest.messages,
+        workload: generationRequest.callSite,
+        maxOutputTokens: generationRequest.maxOutputTokens,
+        reasoningEffort: generationRequest.reasoningEffort,
+        seed: generationRequest.seed,
         exhaustionError:
           "GPT-5.6 Luna did not return parsed relationship proposals",
       });

--- a/packages/temporal/src/activities/glitter-context-refresh-relationship-batching.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-relationship-batching.ts
@@ -4,7 +4,7 @@ import {
   type RelationshipsDocument,
 } from "@shepherdjerred/glitter-context/schema";
 import type { CurrentMessage } from "#shared/glitter-corpus.ts";
-import { buildBoundedRelationshipInput } from "./glitter-context-refresh-generate.ts";
+import { buildBoundedRelationshipInput } from "./glitter-context-refresh-requests.ts";
 import { selectRelationshipEvidenceBatch } from "./glitter-context-refresh-relationships.ts";
 
 type RelationshipEvidence = ReturnType<

--- a/packages/temporal/src/activities/glitter-context-refresh-requests.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-requests.ts
@@ -1,0 +1,299 @@
+import { z } from "zod/v4";
+import {
+  RelationshipDirectionSchema,
+  RelationshipKindSchema,
+  type RelationshipEvent,
+  type StyleCard,
+} from "@shepherdjerred/glitter-context/schema";
+import type { CurrentMessage } from "#shared/glitter-corpus.ts";
+import type { StyleEvidenceChunk } from "./glitter-context-refresh-chunks.ts";
+import {
+  glitterObjectArtifactSchema,
+  glitterPrompt,
+} from "./glitter-context-refresh-llm.ts";
+import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
+import {
+  EXTRACTION_MAX_OUTPUT_TOKENS,
+  EXTRACTION_MODEL,
+  EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+  SYNTHESIS_MAX_OUTPUT_TOKENS,
+  SYNTHESIS_MODEL,
+  SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+  type SummarizedChunk,
+} from "./glitter-context-refresh-style-generation-cost.ts";
+import {
+  StyleChunkSummarySchema,
+  StyleSynthesisSchema,
+  type StyleChunkSummary,
+  type StyleSynthesis,
+} from "./glitter-context-refresh-style-schemas.ts";
+import { buildBoundedSynthesisInput } from "./glitter-context-refresh-synthesis-limit.ts";
+import { synthesisPrompt } from "./glitter-context-refresh-synthesis-prompt.ts";
+import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
+
+export const RELATIONSHIP_MODEL = "gpt-5.6-luna";
+export const RELATIONSHIP_MAX_OUTPUT_TOKENS = 6000;
+export const RELATIONSHIP_INPUT_BYTE_LIMIT = 600_000;
+const MINIMUM_RELATIONSHIP_EVIDENCE = 2;
+const DETERMINISTIC_SEED = 0;
+
+export const RelationshipProposalSchema = z.strictObject({
+  sourceId: z.string(),
+  targetId: z.string(),
+  kind: RelationshipKindSchema,
+  label: z.string(),
+  direction: RelationshipDirectionSchema,
+  effectiveAt: z.iso.date().nullable(),
+  evidenceMessageIds: z.array(z.string().regex(/^\d+$/u)).min(2).max(8),
+  confidence: z.number().min(0.9).max(1),
+  rationale: z.string().min(1).max(500),
+});
+
+const RelationshipProposalsSchema = z.strictObject({
+  proposals: z.array(RelationshipProposalSchema).max(20),
+});
+
+export type RelationshipGenerationInput = {
+  people: readonly { id: string; displayName: string }[];
+  currentRelationships: readonly RelationshipEvent[];
+  evidence: readonly { personId: string; message: CurrentMessage }[];
+};
+
+export type ChunkExtractionRepair = {
+  previous: StyleChunkSummary;
+  error: string;
+  rawContent: string | null;
+};
+
+export type SynthesisRepair = {
+  previous: StyleSynthesis;
+  error: string;
+};
+
+function messageEvidence(message: CurrentMessage): {
+  messageId: string;
+  timestamp: string;
+  content: string;
+} {
+  return {
+    messageId: message.messageId,
+    timestamp: message.timestamp,
+    content: message.content,
+  };
+}
+
+function relationshipMessages(input: RelationshipGenerationInput) {
+  const prompt = [
+    "Propose relationship updates only when the supplied Discord messages",
+    "contain explicit, high-confidence evidence. Return no proposal when",
+    "evidence is ambiguous, joking, hearsay, or merely stylistic.",
+    "Each proposal needs 2-8 supplied message IDs. IDs must be copied exactly.",
+    "Do not repeat a relationship that is already current.",
+    "These proposals will be committed only to a human-reviewed PR.",
+    "",
+    JSON.stringify({
+      people: input.people,
+      currentRelationships: input.currentRelationships,
+      evidence: input.evidence.map((entry) => ({
+        personId: entry.personId,
+        ...messageEvidence(entry.message),
+      })),
+    }),
+  ].join("\n");
+  return glitterPrompt(
+    "You identify explicit relationship changes conservatively and cite corpus evidence.",
+    prompt,
+  );
+}
+
+export function buildBoundedRelationshipInput(
+  input: RelationshipGenerationInput,
+): {
+  evidence: RelationshipGenerationInput["evidence"];
+  messages: ReturnType<typeof relationshipMessages>;
+  inputBytes: number;
+} {
+  const minimumEvidence = Math.min(
+    MINIMUM_RELATIONSHIP_EVIDENCE,
+    input.evidence.length,
+  );
+  const maximumOmittedEvidence = input.evidence.length - minimumEvidence;
+  for (
+    let omittedEvidence = 0;
+    omittedEvidence <= maximumOmittedEvidence;
+    omittedEvidence += 1
+  ) {
+    const evidence = input.evidence.slice(
+      0,
+      input.evidence.length - omittedEvidence,
+    );
+    const messages = relationshipMessages({ ...input, evidence });
+    const inputBytes = new TextEncoder().encode(
+      JSON.stringify(messages),
+    ).length;
+    if (inputBytes <= RELATIONSHIP_INPUT_BYTE_LIMIT) {
+      return { evidence, messages, inputBytes };
+    }
+  }
+  throw new GlitterEvidenceError(
+    `fixed Glitter relationship input exceeds ${String(RELATIONSHIP_INPUT_BYTE_LIMIT)} bytes after reducing evidence to ${String(minimumEvidence)} messages`,
+  );
+}
+
+export function buildRelationshipGenerationRequest(
+  input: RelationshipGenerationInput,
+) {
+  const bounded = buildBoundedRelationshipInput(input);
+  const messages = bounded.messages;
+  return {
+    model: RELATIONSHIP_MODEL,
+    callSite: "glitter-context-relationships",
+    messages,
+    maxOutputTokens: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+    reasoningEffort: "medium" as const,
+    seed: DETERMINISTIC_SEED,
+    evidence: bounded.evidence,
+    inputBytes: bounded.inputBytes,
+    responseSchema: glitterObjectArtifactSchema(RelationshipProposalsSchema),
+    request: {
+      schemaVersion: 3,
+      model: RELATIONSHIP_MODEL,
+      messages,
+      maxCompletionTokens: RELATIONSHIP_MAX_OUTPUT_TOKENS,
+      reasoningEffort: "medium",
+      seed: DETERMINISTIC_SEED,
+      responseSchema: "relationship-proposals-v2",
+    },
+  };
+}
+
+export function styleChunkPrompt(input: {
+  candidate: StyleRefreshCandidate;
+  chunk: StyleEvidenceChunk;
+}): string {
+  return [
+    "Extract evidence-grounded writing-style observations from this one UTC-month chunk.",
+    "Cite exact supplied message IDs for every observation.",
+    "Representative messages must copy both messageId and content byte-for-byte.",
+    "Focus on voice, phrasing, topics, relationships, behavior, personality,",
+    "humor/tone, likes/dislikes, games, mimic guidance, and review concerns.",
+    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
+    "",
+    JSON.stringify({
+      person: {
+        id: input.candidate.person.id,
+        displayName: input.candidate.person.displayName,
+      },
+      chunk: {
+        key: input.chunk.key,
+        month: input.chunk.month,
+        messages: input.chunk.messages.map((message) =>
+          messageEvidence(message),
+        ),
+      },
+    }),
+  ].join("\n");
+}
+
+export function buildStyleChunkGenerationRequest(input: {
+  candidate: StyleRefreshCandidate;
+  chunk: StyleEvidenceChunk;
+  attempt: number;
+  repair: ChunkExtractionRepair | null;
+}) {
+  const basePrompt = styleChunkPrompt(input);
+  const prompt =
+    input.repair === null
+      ? basePrompt
+      : [
+          basePrompt,
+          "",
+          "Repair the prior structured output so it satisfies the evidence contract.",
+          JSON.stringify(input.repair),
+        ].join("\n");
+  const callSite =
+    input.repair === null
+      ? "glitter-style-chunk"
+      : "glitter-style-chunk-repair";
+  const messages = glitterPrompt(
+    "You extract compact, cited style evidence for later synthesis.",
+    prompt,
+  );
+  const seed = DETERMINISTIC_SEED + input.attempt;
+  return {
+    model: EXTRACTION_MODEL,
+    callSite,
+    messages,
+    maxOutputTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+    semanticRetryMaxOutputTokens: EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    reasoningEffort: "none" as const,
+    seed,
+    responseSchema: glitterObjectArtifactSchema(StyleChunkSummarySchema),
+    request: {
+      schemaVersion: 3,
+      model: EXTRACTION_MODEL,
+      messages,
+      maxCompletionTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+      semanticRetryMaxCompletionTokens:
+        EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+      reasoningEffort: "none",
+      seed,
+      responseSchema: "style-chunk-summary-v2",
+    },
+  };
+}
+
+export function buildStyleSynthesisGenerationRequest(input: {
+  candidate: StyleRefreshCandidate;
+  existingCard: StyleCard;
+  chunks: readonly SummarizedChunk[];
+  attempt: number;
+  repair: SynthesisRepair | null;
+}) {
+  const bounded = buildBoundedSynthesisInput({
+    chunks: input.chunks,
+    directRecentMessages: input.candidate.directRecentMessages,
+    hasRepairPrevious: input.repair !== null,
+    buildMessages: ({ chunks, directRecentMessages, includeRepairPrevious }) =>
+      glitterPrompt(
+        "You synthesize evidence-grounded writing-style patches for human review.",
+        synthesisPrompt({
+          ...input,
+          chunks,
+          directRecentMessages,
+          includeRepairPrevious,
+        }),
+      ),
+    serializeMessages: JSON.stringify,
+  });
+  const callSite =
+    input.repair === null
+      ? "glitter-style-synthesis"
+      : "glitter-style-synthesis-repair";
+  const messages = bounded.messages;
+  const seed = DETERMINISTIC_SEED + input.attempt;
+  return {
+    model: SYNTHESIS_MODEL,
+    callSite,
+    messages,
+    maxOutputTokens: SYNTHESIS_MAX_OUTPUT_TOKENS,
+    semanticRetryMaxOutputTokens: SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+    reasoningEffort: "medium" as const,
+    seed,
+    chunks: bounded.chunks,
+    directRecentMessages: bounded.directRecentMessages,
+    includeRepairPrevious: bounded.includeRepairPrevious,
+    responseSchema: glitterObjectArtifactSchema(StyleSynthesisSchema),
+    request: {
+      schemaVersion: 4,
+      model: SYNTHESIS_MODEL,
+      messages,
+      maxCompletionTokens: SYNTHESIS_MAX_OUTPUT_TOKENS,
+      semanticRetryMaxCompletionTokens:
+        SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+      reasoningEffort: "medium",
+      seed,
+      responseSchema: "style-card-synthesis-v2",
+    },
+  };
+}

--- a/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
+++ b/packages/temporal/src/activities/glitter-context-refresh-style-generation.ts
@@ -20,22 +20,20 @@ import {
 import { GlitterEvidenceError } from "./glitter-context-refresh-evidence-error.ts";
 import {
   generateGlitterObject,
-  glitterObjectArtifactSchema,
-  glitterPrompt,
   readGlitterObjectArtifact,
   useGlitterObjectArtifact,
 } from "./glitter-context-refresh-llm.ts";
+import {
+  buildStyleChunkGenerationRequest,
+  buildStyleSynthesisGenerationRequest,
+  styleChunkPrompt,
+  type ChunkExtractionRepair,
+} from "./glitter-context-refresh-requests.ts";
 import type { StyleRefreshCandidate } from "./glitter-context-refresh-selection.ts";
 import {
   estimateStyleGenerationCost as estimateStyleGenerationCostInternal,
-  EXTRACTION_MAX_OUTPUT_TOKENS,
-  EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-  EXTRACTION_MODEL,
   MAX_EXTRACTION_REPAIR_ATTEMPTS,
   MAX_SYNTHESIS_REPAIR_ATTEMPTS,
-  SYNTHESIS_MAX_OUTPUT_TOKENS,
-  SYNTHESIS_MODEL,
-  SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
   type SummarizedChunk,
 } from "./glitter-context-refresh-style-generation-cost.ts";
 import {
@@ -49,7 +47,6 @@ import {
   type StyleChunkSummary,
   type StyleSynthesis,
 } from "./glitter-context-refresh-style-schemas.ts";
-import { buildBoundedSynthesisInput } from "./glitter-context-refresh-synthesis-limit.ts";
 import { synthesisPrompt } from "./glitter-context-refresh-synthesis-prompt.ts";
 
 // Names the chunk, like the exhaustion error beside it at the same call site.
@@ -71,12 +68,6 @@ const EMPTY_CHUNK_SUMMARY: StyleChunkSummary = {
   representativeMessages: [],
 };
 
-type ChunkExtractionRepair = {
-  previous: StyleChunkSummary;
-  error: string;
-  rawContent: string | null;
-};
-
 function nextParseFailureRepair(
   prior: ChunkExtractionRepair | null,
   error: string,
@@ -95,8 +86,6 @@ function nextParseFailureRepair(
     rawContent: null,
   };
 }
-const DETERMINISTIC_SEED = 0;
-
 // Completions are cached before validation, so repairs use distinct seeds
 // (`DETERMINISTIC_SEED + attempt`) and cache keys. Attempt 0 is the initial call;
 // attempts 1..N are repairs, and a rerun reuses the first passing attempt.
@@ -104,46 +93,6 @@ const DETERMINISTIC_SEED = 0;
 // Sanitization is the convergence guarantee when a model repeatedly cites an ID
 // found inside content but not in the top-level chunk: unverifiable evidence is
 // dropped at the boundary instead of failing the run.
-function messageEvidence(message: CurrentMessage): {
-  messageId: string;
-  timestamp: string;
-  content: string;
-} {
-  return {
-    messageId: message.messageId,
-    timestamp: message.timestamp,
-    content: message.content,
-  };
-}
-
-function chunkPrompt(input: {
-  candidate: StyleRefreshCandidate;
-  chunk: StyleEvidenceChunk;
-}): string {
-  return [
-    "Extract evidence-grounded writing-style observations from this one UTC-month chunk.",
-    "Cite exact supplied message IDs for every observation.",
-    "Representative messages must copy both messageId and content byte-for-byte.",
-    "Focus on voice, phrasing, topics, relationships, behavior, personality,",
-    "humor/tone, likes/dislikes, games, mimic guidance, and review concerns.",
-    "Do not infer sensitive traits, diagnoses, identity, or private facts.",
-    "",
-    JSON.stringify({
-      person: {
-        id: input.candidate.person.id,
-        displayName: input.candidate.person.displayName,
-      },
-      chunk: {
-        key: input.chunk.key,
-        month: input.chunk.month,
-        messages: input.chunk.messages.map((message) =>
-          messageEvidence(message),
-        ),
-      },
-    }),
-  ].join("\n");
-}
-
 async function runChunkExtraction(input: {
   candidate: StyleRefreshCandidate;
   chunk: StyleEvidenceChunk;
@@ -152,65 +101,36 @@ async function runChunkExtraction(input: {
   attempt: number;
   repair: ChunkExtractionRepair | null;
 }) {
-  const basePrompt = chunkPrompt(input);
-  const prompt =
-    input.repair === null
-      ? basePrompt
-      : [
-          basePrompt,
-          "",
-          "Repair the prior structured output so it satisfies the evidence contract.",
-          JSON.stringify(input.repair),
-        ].join("\n");
-  const callSite =
-    input.repair === null
-      ? "glitter-style-chunk"
-      : "glitter-style-chunk-repair";
-  const messages = glitterPrompt(
-    "You extract compact, cited style evidence for later synthesis.",
-    prompt,
-  );
-  const seed = DETERMINISTIC_SEED + input.attempt;
-  const CompletionArtifactSchema = glitterObjectArtifactSchema(
-    StyleChunkSummarySchema,
-  );
+  const generationRequest = buildStyleChunkGenerationRequest(input);
   const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
-    model: EXTRACTION_MODEL,
-    callSite,
-    request: {
-      schemaVersion: 3,
-      model: EXTRACTION_MODEL,
-      messages,
-      maxCompletionTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
-      semanticRetryMaxCompletionTokens:
-        EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-      reasoningEffort: "none",
-      seed,
-      responseSchema: "style-chunk-summary-v2",
-    },
-    responseSchema: CompletionArtifactSchema,
+    model: generationRequest.model,
+    callSite: generationRequest.callSite,
+    request: generationRequest.request,
+    responseSchema: generationRequest.responseSchema,
     generate: async () => {
       input.budget.authorizeUncachedCall(
         worstCaseGenerationCostUsd({
-          model: EXTRACTION_MODEL,
-          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(messages)),
-          outputTokenUpperBound: EXTRACTION_MAX_OUTPUT_TOKENS,
+          model: generationRequest.model,
+          inputTokenUpperBound: inputTokenUpperBound(
+            JSON.stringify(generationRequest.messages),
+          ),
+          outputTokenUpperBound: generationRequest.maxOutputTokens,
           semanticRetryOutputTokenUpperBound:
-            EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+            generationRequest.semanticRetryMaxOutputTokens,
         }),
       );
       return await generateGlitterObject({
-        model: EXTRACTION_MODEL,
+        model: generationRequest.model,
         schema: StyleChunkSummarySchema,
         schemaName: "style_chunk_summary",
-        ...messages,
-        workload: callSite,
-        maxOutputTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+        ...generationRequest.messages,
+        workload: generationRequest.callSite,
+        maxOutputTokens: generationRequest.maxOutputTokens,
         semanticRetryMaxOutputTokens:
-          EXTRACTION_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-        reasoningEffort: "none",
-        seed,
+          generationRequest.semanticRetryMaxOutputTokens,
+        reasoningEffort: generationRequest.reasoningEffort,
+        seed: generationRequest.seed,
         truncationError: extractionTruncationError(input.chunk.key),
         exhaustionError: `GPT-5.6 Luna did not return a parsed summary for ${input.chunk.key}`,
       });
@@ -322,67 +242,36 @@ async function runSynthesis(input: {
   chunks: readonly SummarizedChunk[];
   directRecentMessages: readonly CurrentMessage[];
 }> {
-  const bounded = buildBoundedSynthesisInput({
-    chunks: input.chunks,
-    directRecentMessages: input.candidate.directRecentMessages,
-    hasRepairPrevious: input.repair !== null,
-    buildMessages: ({ chunks, directRecentMessages, includeRepairPrevious }) =>
-      glitterPrompt(
-        "You synthesize evidence-grounded writing-style patches for human review.",
-        synthesisPrompt({
-          ...input,
-          chunks,
-          directRecentMessages,
-          includeRepairPrevious,
-        }),
-      ),
-    serializeMessages: JSON.stringify,
-  });
-  const callSite =
-    input.repair === null
-      ? "glitter-style-synthesis"
-      : "glitter-style-synthesis-repair";
-  const messages = bounded.messages;
-  const seed = DETERMINISTIC_SEED + input.attempt;
-  const CompletionArtifactSchema =
-    glitterObjectArtifactSchema(StyleSynthesisSchema);
+  const generationRequest = buildStyleSynthesisGenerationRequest(input);
   const artifact = await readOrCreateGenerationArtifact({
     store: input.artifactStore,
-    model: SYNTHESIS_MODEL,
-    callSite,
-    request: {
-      schemaVersion: 4,
-      model: SYNTHESIS_MODEL,
-      messages,
-      maxCompletionTokens: SYNTHESIS_MAX_OUTPUT_TOKENS,
-      semanticRetryMaxCompletionTokens:
-        SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-      reasoningEffort: "medium",
-      seed,
-      responseSchema: "style-card-synthesis-v2",
-    },
-    responseSchema: CompletionArtifactSchema,
+    model: generationRequest.model,
+    callSite: generationRequest.callSite,
+    request: generationRequest.request,
+    responseSchema: generationRequest.responseSchema,
     generate: async () => {
       input.budget.authorizeUncachedCall(
         worstCaseGenerationCostUsd({
-          model: SYNTHESIS_MODEL,
-          inputTokenUpperBound: inputTokenUpperBound(JSON.stringify(messages)),
-          outputTokenUpperBound: SYNTHESIS_MAX_OUTPUT_TOKENS,
+          model: generationRequest.model,
+          inputTokenUpperBound: inputTokenUpperBound(
+            JSON.stringify(generationRequest.messages),
+          ),
+          outputTokenUpperBound: generationRequest.maxOutputTokens,
           semanticRetryOutputTokenUpperBound:
-            SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
+            generationRequest.semanticRetryMaxOutputTokens,
         }),
       );
       return await generateGlitterObject({
-        model: SYNTHESIS_MODEL,
+        model: generationRequest.model,
         schema: StyleSynthesisSchema,
         schemaName: "style_card_synthesis",
-        ...messages,
-        workload: callSite,
-        maxOutputTokens: SYNTHESIS_MAX_OUTPUT_TOKENS,
+        ...generationRequest.messages,
+        workload: generationRequest.callSite,
+        maxOutputTokens: generationRequest.maxOutputTokens,
         semanticRetryMaxOutputTokens:
-          SYNTHESIS_TRUNCATION_RETRY_MAX_OUTPUT_TOKENS,
-        reasoningEffort: "medium",
-        seed,
+          generationRequest.semanticRetryMaxOutputTokens,
+        reasoningEffort: generationRequest.reasoningEffort,
+        seed: generationRequest.seed,
         truncationError: SYNTHESIS_TRUNCATION_ERROR,
         exhaustionError: `GPT-5.6 Luna did not return a parsed synthesis for ${input.candidate.person.id}`,
       });
@@ -390,8 +279,8 @@ async function runSynthesis(input: {
   });
   return {
     synthesis: useGlitterObjectArtifact({ artifact, budget: input.budget }),
-    chunks: bounded.chunks,
-    directRecentMessages: bounded.directRecentMessages,
+    chunks: generationRequest.chunks,
+    directRecentMessages: generationRequest.directRecentMessages,
   };
 }
 
@@ -400,7 +289,7 @@ export function estimateStyleGenerationCost(input: {
   existingCard: StyleCard;
 }): number {
   return estimateStyleGenerationCostInternal(input, {
-    chunkPrompt,
+    chunkPrompt: styleChunkPrompt,
     synthesisPrompt,
   });
 }

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -27,6 +27,7 @@ import { scoutShowcaseRefreshActivities } from "./scout-showcase-refresh.ts";
 import { scoutQueueWindowsActivities } from "./scout-queue-windows.ts";
 import { glitterCorpusActivities } from "./glitter-corpus.ts";
 import { glitterContextRefreshActivities } from "./glitter-context-refresh.ts";
+import { glitterContextAuditActivities } from "./glitter-context-audit.ts";
 import { weatherActivities } from "./weather.ts";
 import { workflowFailureWatchActivities } from "./workflow-failure-watch-activity.ts";
 import { maintenanceActivities } from "./maintenance.ts";
@@ -108,6 +109,7 @@ export const glitterCorpusWorkerActivities = {
 
 export const glitterContextWorkerActivities = {
   ...glitterContextRefreshActivities,
+  ...glitterContextAuditActivities,
 };
 
 export const maintenanceWorkerActivities = {

--- a/packages/temporal/src/workflows/glitter-context-audit.test.ts
+++ b/packages/temporal/src/workflows/glitter-context-audit.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import type { GlitterContextAuditResult } from "#activities/glitter-context-audit-schema.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { runGlitterContextAudit } from "./glitter-context-audit.ts";
+
+const TASK_QUEUE = TASK_QUEUES.GLITTER_CONTEXT;
+let testEnvironment: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+  testEnvironment = await TestWorkflowEnvironment.createTimeSkipping();
+}, 60_000);
+
+afterAll(async () => {
+  await testEnvironment.teardown();
+});
+
+describe("runGlitterContextAudit", () => {
+  test("routes the pinned read-only audit to the context queue", async () => {
+    const expected: GlitterContextAuditResult = {
+      snapshotId: "00000000-0000-4000-8000-000000000001",
+      snapshotSha256: "a".repeat(64),
+      eligiblePeople: ["virmel"],
+      cacheHits: 12,
+      cacheMisses: 2,
+      blockedStages: [
+        {
+          stage: "style-synthesis",
+          personId: "virmel",
+          reason: "missing upstream chunk artifact",
+        },
+      ],
+      artifactKeys: ["artifact-a", "artifact-b"],
+      worstCaseUncachedCostUsd: 25,
+    };
+    const inputs: unknown[] = [];
+    const worker = await Worker.create({
+      connection: testEnvironment.nativeConnection,
+      taskQueue: TASK_QUEUE,
+      workflowsPath: new URL("index.ts", import.meta.url).pathname,
+      activities: {
+        auditGlitterContext: (input: unknown) => {
+          inputs.push(input);
+          return expected;
+        },
+      },
+    });
+    const auditInput = {
+      now: "2026-08-30T12:00:00.000Z",
+      snapshot: {
+        snapshotId: expected.snapshotId,
+        snapshotSha256: expected.snapshotSha256,
+      },
+    };
+    const result = await worker.runUntil(
+      testEnvironment.client.workflow.execute(runGlitterContextAudit, {
+        args: [auditInput],
+        taskQueue: TASK_QUEUE,
+        workflowId: `glitter-context-audit-${crypto.randomUUID()}`,
+      }),
+    );
+    expect(result).toEqual(expected);
+    expect(inputs).toEqual([auditInput]);
+  }, 30_000);
+});

--- a/packages/temporal/src/workflows/glitter-context-audit.ts
+++ b/packages/temporal/src/workflows/glitter-context-audit.ts
@@ -1,0 +1,27 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type {
+  GlitterContextAuditInput,
+  GlitterContextAuditResult,
+} from "#activities/glitter-context-audit-schema.ts";
+import type { glitterContextAuditActivities } from "#activities/glitter-context-audit.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+const { auditGlitterContext } = proxyActivities<
+  typeof glitterContextAuditActivities
+>({
+  taskQueue: TASK_QUEUES.GLITTER_CONTEXT,
+  startToCloseTimeout: "1 hour",
+  heartbeatTimeout: "60 seconds",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "10 seconds",
+    backoffCoefficient: 2,
+    maximumInterval: "2 minutes",
+  },
+});
+
+export async function runGlitterContextAudit(
+  input: GlitterContextAuditInput = {},
+): Promise<GlitterContextAuditResult> {
+  return await auditGlitterContext(input);
+}

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -102,6 +102,11 @@ import type {
   GlitterContextRefreshInput,
   GlitterContextRefreshResult,
 } from "#activities/glitter-context-refresh.ts";
+import { runGlitterContextAudit as _runGlitterContextAudit } from "./glitter-context-audit.ts";
+import type {
+  GlitterContextAuditInput,
+  GlitterContextAuditResult,
+} from "#activities/glitter-context-audit-schema.ts";
 import { runMainVulnScanWorkflow as runMainVulnScanWorkflowImplementation } from "./main-vuln-scan.ts";
 import { runLinkRotScanWorkflow as runLinkRotScanWorkflowImplementation } from "./link-rot-scan.ts";
 import {
@@ -368,6 +373,12 @@ export async function runGlitterContextRefresh(
   input: GlitterContextRefreshInput = {},
 ): Promise<GlitterContextRefreshResult> {
   return _runGlitterContextRefresh(input);
+}
+
+export async function runGlitterContextAudit(
+  input: GlitterContextAuditInput = {},
+): Promise<GlitterContextAuditResult> {
+  return _runGlitterContextAudit(input);
 }
 
 export async function runGlitterCorpusBackfill(


### PR DESCRIPTION
## Why

The context refresh needs an exact, zero-cost way to establish current v3 cache coverage before an operator risks an inference run. Existing generation logic constructed request identities inside billable paths, so a separate audit could drift from production.

## What

- Extract pure relationship, chunk, and synthesis request builders shared by generation and audit.
- Add fully validated, read-only v3 artifact probing with exact production request hashes.
- Add `runGlitterContextAudit` on the context queue and `glitter:operate context-audit` for pinned or latest snapshots.
- Report snapshot identity, eligible people, exact hits/misses, blocked synthesis stages, artifact keys, and worst-case uncached cost.
- Prove the audit never calls generation and never writes artifacts or spend receipts.
- Document the audit, the weekly $1 bounded-progress contract, exact-key-only reuse, and live post-deploy acceptance.

## Verification

- `bunx turbo run build typecheck test lint --filter=@shepherdjerred/temporal`
- `bun run test:workflows` — 22 files, 69 tests
- focused audit/cache/generation Vitest suite — 3 files, 27 tests
- `bun run build`, `bun run typecheck`, and `bun run lint` in `packages/docs/wiki`
- `bunx lefthook run pre-commit`

Live Temporal audit and post-deploy acceptance were not run because this stack is not deployed. Documentation visual proof was not captured because no connected browser surface was available in this environment.

## Rollout

After the stack deploys, run the pinned cache audit and confirm no new OpenRouter spans/cost metrics and no artifact or spend-receipt writes. Then observe the next weekly context run and require actual uncached spend at or below $1.