### PR TITLE
fix(alerting): preserve overflow state and notify truncated deliveries

### DIFF
--- a/packages/alert-dashboard/integration/sqlite.integration.test.ts
+++ b/packages/alert-dashboard/integration/sqlite.integration.test.ts
@@ -233,7 +233,7 @@ describe("SQLite alert ledger", () => {
       truncatedAlerts: 37,
     });
     await repository.ingestWebhook(
-      input(payload, "2026-08-08T18:00:01Z", false),
+      input(payload, "2026-08-08T18:00:01Z", true),
     );
     const alerts = await repository.listAlerts({ limit: 10 });
     const id = alerts.items[0]?.id;
@@ -242,6 +242,15 @@ describe("SQLite alert ledger", () => {
     const detail = await repository.getAlert({ id, limit: 10 });
 
     expect(detail?.deliveries[0]?.truncatedAlerts).toBe(37);
+    await repository.ingestWebhook(
+      input(payload, "2026-08-08T18:00:02Z", true),
+    );
+    const outbox = await prisma.emailOutbox.findMany({
+      orderBy: { createdAtNs: "asc" },
+      select: { occurrenceIds: true },
+    });
+    expect(outbox).toHaveLength(2);
+    expect(outbox[1]?.occurrenceIds).toEqual([]);
   });
 
   it("serializes concurrent snapshot and webhook discovery", async () => {

--- a/packages/alert-dashboard/src/domain/alert.ts
+++ b/packages/alert-dashboard/src/domain/alert.ts
@@ -155,6 +155,16 @@ export function openingEmail(
   };
 }
 
+export function truncationEmail(truncatedAlerts: number): {
+  subject: string;
+  htmlBody: string;
+} {
+  return {
+    subject: "[Alerts] Alertmanager delivery truncated",
+    htmlBody: `<h1>Alertmanager delivery truncated</h1><p>Alertmanager omitted ${truncatedAlerts.toString()} additional alert${truncatedAlerts === 1 ? "" : "s"} from this webhook delivery.</p><p><a href="https://alerts.tailnet-1a49.ts.net/">Open Alerts</a></p>`,
+  };
+}
+
 function escapeHtml(value: string): string {
   return sanitizeHtml(value, {
     allowedAttributes: {},

--- a/packages/alert-dashboard/src/infrastructure/prisma-email-cancellation.ts
+++ b/packages/alert-dashboard/src/infrastructure/prisma-email-cancellation.ts
@@ -4,7 +4,7 @@ import type { Prisma } from "#generated/prisma/client/index.js";
 import { AlertOccurrenceIdSchema } from "#shared/schema";
 import { EMAIL_SEND_CLAIM_LEASE_NS } from "#infrastructure/prisma-email-claim";
 
-const OccurrenceIdsSchema = z.array(AlertOccurrenceIdSchema).min(1);
+const OccurrenceIdsSchema = z.array(AlertOccurrenceIdSchema);
 
 export type CancelPendingEmailsInput = {
   alertname: string;
@@ -40,10 +40,12 @@ export async function cancelPendingEmails(
     select: { id: true, occurrenceIds: true },
     orderBy: { createdAtNs: "asc" },
   });
-  const occurrenceIdsByOutbox = pending.map((message) => ({
-    id: message.id,
-    occurrenceIds: OccurrenceIdsSchema.parse(message.occurrenceIds),
-  }));
+  const occurrenceIdsByOutbox = pending
+    .map((message) => ({
+      id: message.id,
+      occurrenceIds: OccurrenceIdsSchema.parse(message.occurrenceIds),
+    }))
+    .filter((message) => message.occurrenceIds.length > 0);
   const occurrenceIds = [
     ...new Set(
       occurrenceIdsByOutbox.flatMap((message) => message.occurrenceIds),

--- a/packages/alert-dashboard/src/infrastructure/prisma-repository.ts
+++ b/packages/alert-dashboard/src/infrastructure/prisma-repository.ts
@@ -17,6 +17,7 @@ import {
   normalizeGeneratorUrl,
   occurrenceId,
   openingEmail,
+  truncationEmail,
   severityFromLabels,
   snapshotStartNs,
   summaryFromMetadata,
@@ -120,11 +121,15 @@ export class PrismaAlertLedgerRepository implements AlertLedgerRepository {
         });
 
         let emailQueued = false;
-        if (input.emailEnabled && newlyNotified.length > 0) {
-          const message = openingEmail(
-            newlyNotified,
-            input.payload.truncatedAlerts,
-          );
+        const truncationOnly =
+          newlyNotified.length === 0 && input.payload.truncatedAlerts > 0;
+        if (
+          input.emailEnabled &&
+          (truncationOnly || newlyNotified.length > 0)
+        ) {
+          const message = truncationOnly
+            ? truncationEmail(input.payload.truncatedAlerts)
+            : openingEmail(newlyNotified, input.payload.truncatedAlerts);
           await transaction.emailOutbox.create({
             data: {
               id: OutboxIdSchema.parse(crypto.randomUUID()),

--- a/packages/temporal/src/activities/workflow-failure-watch-checkpoint.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-checkpoint.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import type { FailedWorkflowExecution } from "#shared/workflow-failure-alert.ts";
+import type { WorkflowFailureOverflowSummary } from "./workflow-failure-watch-overflow.ts";
 
 const WorkflowFailureWatchCursorSchema = z.object({
   closeTime: z.iso.datetime({ offset: true }),
@@ -20,6 +21,13 @@ const WorkflowFailureWatchCursorSchema = z.object({
 const WorkflowFailureWatchCheckpointSchema = z.object({
   detailedAlertsConsumed: z.number().int().nonnegative(),
   cursor: WorkflowFailureWatchCursorSchema.optional(),
+  overflow: z
+    .object({
+      omitted: z.number().int().positive(),
+      counts: z.record(z.string(), z.number().int().positive()),
+      newestOmittedCloseTime: z.iso.datetime({ offset: true }),
+    })
+    .optional(),
 });
 
 export type WorkflowFailureWatchCursor = {
@@ -34,6 +42,7 @@ export type WorkflowFailureWatchCursor = {
 export type WorkflowFailureWatchCheckpoint = {
   detailedAlertsConsumed: number;
   cursor?: WorkflowFailureWatchCursor;
+  overflow?: WorkflowFailureOverflowSummary;
 };
 
 export function workflowExecutionKey(
@@ -67,6 +76,16 @@ export function parseWorkflowFailureWatchCheckpoint(
       ...(parsed.data.cursor === undefined
         ? {}
         : { cursor: parsedCursor(parsed.data.cursor) }),
+      ...(parsed.data.overflow === undefined
+        ? {}
+        : {
+            overflow: {
+              ...parsed.data.overflow,
+              newestOmittedCloseTime: new Date(
+                parsed.data.overflow.newestOmittedCloseTime,
+              ),
+            },
+          }),
     };
   }
   // Heartbeats written before the fanout budget used the cursor fields at the
@@ -117,6 +136,15 @@ export function serializedCheckpoint(
     ? null
     : {
         detailedAlertsConsumed: checkpoint.detailedAlertsConsumed,
+        ...(checkpoint.overflow === undefined
+          ? {}
+          : {
+              overflow: {
+                ...checkpoint.overflow,
+                newestOmittedCloseTime:
+                  checkpoint.overflow.newestOmittedCloseTime.toISOString(),
+              },
+            }),
         ...(checkpoint.cursor === undefined
           ? {}
           : {

--- a/packages/temporal/src/activities/workflow-failure-watch-overflow.test.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-overflow.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { FailedWorkflowExecution } from "#shared/workflow-failure-alert.ts";
+import {
+  addWorkflowFailureOverflowBatch,
+  buildWorkflowFailureOverflowAlert,
+} from "./workflow-failure-watch-overflow.ts";
+
+const OBSERVED_AT = new Date("2026-07-30T18:00:00.000Z");
+
+function execution(
+  index: number,
+  workflowType: string,
+): FailedWorkflowExecution {
+  return {
+    workflowId: `workflow-${String(index)}`,
+    runId: `run-${String(index)}`,
+    workflowType,
+    taskQueue: "default",
+    startTime: new Date(OBSERVED_AT.getTime() - (index + 1) * 1000),
+    closeTime: new Date(OBSERVED_AT.getTime() - index * 1000),
+    status: index % 2 === 0 ? "FAILED" : "TIMED_OUT",
+  };
+}
+
+describe("workflow failure overflow summary", () => {
+  it("retains totals and counts when omitted executions arrive in batches", () => {
+    const firstBatch = Array.from({ length: 25 }, (_, index) =>
+      execution(index, "syncGolinks"),
+    );
+    const secondBatch = Array.from({ length: 26 }, (_, index) =>
+      execution(index + 25, "agentTaskWorkflow"),
+    );
+
+    const summary = addWorkflowFailureOverflowBatch(
+      addWorkflowFailureOverflowBatch(undefined, firstBatch),
+      secondBatch,
+    );
+    const alert = buildWorkflowFailureOverflowAlert(
+      summary,
+      new Date("2026-07-29T18:00:00.000Z"),
+      OBSERVED_AT,
+      86_400_000,
+    );
+
+    expect(summary).toMatchObject({
+      omitted: 51,
+      newestOmittedCloseTime: firstBatch[0]?.closeTime,
+    });
+    expect(summary.counts).toEqual({
+      "agentTaskWorkflow / TIMED_OUT": 13,
+      "agentTaskWorkflow / FAILED": 13,
+      "syncGolinks / FAILED": 13,
+      "syncGolinks / TIMED_OUT": 12,
+    });
+    expect(alert.annotations["description"]).toContain(
+      "51 failed Temporal workflow executions were omitted",
+    );
+  });
+});

--- a/packages/temporal/src/activities/workflow-failure-watch-overflow.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-overflow.ts
@@ -3,27 +3,51 @@ import type { FailedWorkflowExecution } from "#shared/workflow-failure-alert.ts"
 
 export const MAX_DETAILED_FAILURE_ALERTS = 100;
 
-export function buildWorkflowFailureOverflowAlert(
+export type WorkflowFailureOverflowSummary = {
+  omitted: number;
+  counts: Readonly<Record<string, number>>;
+  newestOmittedCloseTime: Date;
+};
+
+export function addWorkflowFailureOverflowBatch(
+  summary: WorkflowFailureOverflowSummary | undefined,
   executions: readonly FailedWorkflowExecution[],
+): WorkflowFailureOverflowSummary {
+  const counts = summary === undefined ? {} : { ...summary.counts };
+  for (const execution of executions) {
+    const key = `${execution.workflowType} / ${execution.status}`;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  const firstCloseTime = executions[0]?.closeTime;
+  if (firstCloseTime === undefined) {
+    throw new Error("overflow batch must contain an execution");
+  }
+  let newestOmittedCloseTime =
+    summary?.newestOmittedCloseTime ?? firstCloseTime;
+  for (const execution of executions) {
+    if (execution.closeTime > newestOmittedCloseTime) {
+      newestOmittedCloseTime = execution.closeTime;
+    }
+  }
+  return {
+    omitted: (summary?.omitted ?? 0) + executions.length,
+    counts,
+    newestOmittedCloseTime,
+  };
+}
+
+export function buildWorkflowFailureOverflowAlert(
+  summary: WorkflowFailureOverflowSummary,
   since: Date,
   observedAt: Date,
   ttlMs: number,
 ): AlertmanagerAlert {
-  const counts = new Map<string, number>();
-  for (const execution of executions) {
-    const key = `${execution.workflowType} / ${execution.status}`;
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  const countLines = [...counts.entries()]
+  const countLines = Object.entries(summary.counts)
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([key, count]) => `${key}: ${count.toString()}`)
     .join("\n");
-  const omitted = executions.length;
-  const newestOmittedCloseTime = executions.reduce((latest, execution) =>
-    execution.closeTime > latest.closeTime ? execution : latest,
-  ).closeTime;
   const description = [
-    `${omitted.toString()} failed Temporal workflow executions were omitted after the ${MAX_DETAILED_FAILURE_ALERTS.toString()}-execution detail budget was consumed.`,
+    `${summary.omitted.toString()} failed Temporal workflow executions were omitted after the ${MAX_DETAILED_FAILURE_ALERTS.toString()}-execution detail budget was consumed.`,
     `lookbackSince ${since.toISOString()}`,
     "Counts by workflow type / status:",
     countLines,
@@ -35,11 +59,13 @@ export function buildWorkflowFailureOverflowAlert(
       severity: "critical",
     },
     annotations: {
-      summary: `Temporal workflow failure detail limit exceeded: ${omitted.toString()} omitted`,
+      summary: `Temporal workflow failure detail limit exceeded: ${summary.omitted.toString()} omitted`,
       description,
       message: description,
     },
     startsAt: observedAt.toISOString(),
-    endsAt: new Date(newestOmittedCloseTime.getTime() + ttlMs).toISOString(),
+    endsAt: new Date(
+      summary.newestOmittedCloseTime.getTime() + ttlMs,
+    ).toISOString(),
   };
 }

--- a/packages/temporal/src/activities/workflow-failure-watch-scan.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-scan.ts
@@ -23,6 +23,16 @@ type ScanWorkflowFailureVisibilityOptions = {
   ) => Promise<void>;
 };
 
+type WorkflowVisibilityInfo = {
+  workflowId: string;
+  runId: string;
+  type: string;
+  taskQueue: string;
+  startTime: Date;
+  closeTime?: Date;
+  status: { name: string };
+};
+
 export type WorkflowFailureVisibilityScan = {
   pendingDetails: FailedWorkflowExecution[];
   overflowed: boolean;
@@ -53,6 +63,78 @@ function isAfterVisibilityCursor(
   );
 }
 
+function failureExecutionFromVisibilityInfo(
+  info: WorkflowVisibilityInfo,
+): FailedWorkflowExecution | undefined {
+  const status = toFailureStatusName(info.status.name);
+  if (status === undefined || info.closeTime === undefined) return undefined;
+  return {
+    workflowId: info.workflowId,
+    runId: info.runId,
+    workflowType: info.type,
+    taskQueue: info.taskQueue,
+    startTime: info.startTime,
+    closeTime: info.closeTime,
+    status,
+  } satisfies FailedWorkflowExecution;
+}
+
+async function flushBatch(
+  batch: FailedWorkflowExecution[],
+  callback: (executions: readonly FailedWorkflowExecution[]) => Promise<void>,
+  setProcessing: (processing: boolean) => void,
+): Promise<void> {
+  if (batch.length === 0) return;
+  setProcessing(true);
+  await callback(batch);
+  setProcessing(false);
+  batch.length = 0;
+}
+
+type QueueExecutionResult = {
+  detailedAlertsSelected: number;
+  overflowed: boolean;
+};
+
+type QueueExecutionInput = {
+  execution: FailedWorkflowExecution;
+  detailedAlertsSelected: number;
+  pendingDetails: FailedWorkflowExecution[];
+  overflowBatch: FailedWorkflowExecution[];
+  options: ScanWorkflowFailureVisibilityOptions;
+  setProcessing: (processing: boolean) => void;
+};
+
+async function queueExecution(
+  input: QueueExecutionInput,
+): Promise<QueueExecutionResult> {
+  const {
+    execution,
+    detailedAlertsSelected,
+    pendingDetails,
+    overflowBatch,
+    options,
+    setProcessing,
+  } = input;
+  if (detailedAlertsSelected >= MAX_DETAILED_FAILURE_ALERTS) {
+    overflowBatch.push(execution);
+    if (overflowBatch.length === ALERT_BATCH_SIZE) {
+      await flushBatch(overflowBatch, options.onOverflowBatch, setProcessing);
+      return { detailedAlertsSelected, overflowed: true };
+    }
+    return { detailedAlertsSelected, overflowed: false };
+  }
+  pendingDetails.push(execution);
+  const nextDetailedAlertsSelected = detailedAlertsSelected + 1;
+  if (pendingDetails.length === ALERT_BATCH_SIZE) {
+    await flushBatch(pendingDetails, options.onDetailBatch, setProcessing);
+  }
+  return {
+    detailedAlertsSelected: nextDetailedAlertsSelected,
+    overflowed: false,
+  };
+}
+
 export async function scanWorkflowFailureVisibility(
   client: WorkflowVisibilityClient,
   options: ScanWorkflowFailureVisibilityOptions,
@@ -62,59 +144,42 @@ export async function scanWorkflowFailureVisibility(
   let scanned = 0;
   let detailedAlertsSelected = options.detailedAlertsConsumed;
   let listingError: Error | undefined;
-  let processingBatch = false;
+  const processingState = { active: false };
   let overflowed = false;
   try {
     for await (const info of client.workflow.list({
       query: options.query,
       pageSize: VISIBILITY_PAGE_SIZE,
     })) {
-      const status = toFailureStatusName(info.status.name);
-      if (status === undefined || info.closeTime === undefined) continue;
-      const execution = {
-        workflowId: info.workflowId,
-        runId: info.runId,
-        workflowType: info.type,
-        taskQueue: info.taskQueue,
-        startTime: info.startTime,
-        closeTime: info.closeTime,
-        status,
-      } satisfies FailedWorkflowExecution;
+      const execution = failureExecutionFromVisibilityInfo(info);
+      if (execution === undefined) continue;
       if (
         options.checkpoint !== undefined &&
         !isAfterVisibilityCursor(execution, options.checkpoint)
-      ) {
+      )
         continue;
-      }
       scanned += 1;
-      if (detailedAlertsSelected >= MAX_DETAILED_FAILURE_ALERTS) {
-        overflowBatch.push(execution);
-        if (overflowBatch.length === ALERT_BATCH_SIZE) {
-          processingBatch = true;
-          await options.onOverflowBatch(overflowBatch);
-          processingBatch = false;
-          overflowed = true;
-          overflowBatch.length = 0;
-        }
-        continue;
-      }
-      pendingDetails.push(execution);
-      detailedAlertsSelected += 1;
-      if (pendingDetails.length === ALERT_BATCH_SIZE) {
-        processingBatch = true;
-        await options.onDetailBatch(pendingDetails);
-        processingBatch = false;
-        pendingDetails.length = 0;
-      }
+      const queueResult = await queueExecution({
+        execution,
+        detailedAlertsSelected,
+        pendingDetails,
+        overflowBatch,
+        options,
+        setProcessing: (processing) => {
+          processingState.active = processing;
+        },
+      });
+      detailedAlertsSelected = queueResult.detailedAlertsSelected;
+      overflowed ||= queueResult.overflowed;
     }
     if (overflowBatch.length > 0) {
-      processingBatch = true;
-      await options.onOverflowBatch(overflowBatch);
-      processingBatch = false;
+      await flushBatch(overflowBatch, options.onOverflowBatch, (processing) => {
+        processingState.active = processing;
+      });
       overflowed = true;
     }
   } catch (error) {
-    if (processingBatch) throw error;
+    if (processingState.active) throw error;
     listingError = error instanceof Error ? error : new Error(String(error));
   }
   return {

--- a/packages/temporal/src/activities/workflow-failure-watch.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch.ts
@@ -8,8 +8,10 @@ import {
 } from "./workflow-failure-watch-checkpoint.ts";
 import { buildFailureAlertForExecution } from "./workflow-failure-watch-detail.ts";
 import {
+  addWorkflowFailureOverflowBatch,
   buildWorkflowFailureOverflowAlert,
   MAX_DETAILED_FAILURE_ALERTS,
+  type WorkflowFailureOverflowSummary,
 } from "./workflow-failure-watch-overflow.ts";
 import { scanWorkflowFailureVisibility } from "./workflow-failure-watch-scan.ts";
 import type { WorkflowVisibilityClient } from "#shared/workflow-visibility-client.ts";
@@ -290,6 +292,7 @@ type AdvanceRecoveryCheckpointInput = {
     ((checkpoint: WorkflowFailureWatchCheckpoint) => void) | undefined;
   lookbackSince: Date;
   detailedAlertsConsumed: number;
+  overflow?: WorkflowFailureOverflowSummary;
 };
 
 function advanceRecoveryCheckpoint(
@@ -297,6 +300,11 @@ function advanceRecoveryCheckpoint(
 ): RecoveryCheckpointProgress {
   const budgetCheckpoint = {
     detailedAlertsConsumed: input.detailedAlertsConsumed,
+    ...(input.overflow === undefined
+      ? input.checkpoint?.overflow === undefined
+        ? {}
+        : { overflow: input.checkpoint.overflow }
+      : { overflow: input.overflow }),
     ...(input.checkpoint?.cursor === undefined
       ? {}
       : { cursor: input.checkpoint.cursor }),
@@ -348,6 +356,7 @@ function advanceRecoveryCheckpoint(
     throw new Error("execution checkpoint cursor was not created");
   }
   const nextCheckpoint = {
+    ...budgetCheckpoint,
     ...baseCheckpoint,
     cursor: {
       ...baseCursor,
@@ -383,6 +392,8 @@ export async function pollWorkflowFailuresOnce(
   let alerted = 0;
   let checkpointBlocked = false;
   let recoveryCheckpoint = checkpoint;
+  let overflowSummary: WorkflowFailureOverflowSummary | undefined =
+    checkpoint?.overflow;
   const postDetails = async (
     executions: readonly FailedWorkflowExecution[],
   ): Promise<void> => {
@@ -405,9 +416,13 @@ export async function pollWorkflowFailuresOnce(
   const postOverflowBatch = async (
     executions: readonly FailedWorkflowExecution[],
   ): Promise<void> => {
+    overflowSummary = addWorkflowFailureOverflowBatch(
+      overflowSummary,
+      executions,
+    );
     await poster([
       buildWorkflowFailureOverflowAlert(
-        executions,
+        overflowSummary,
         since,
         options.now,
         options.ttlMs,
@@ -419,6 +434,7 @@ export async function pollWorkflowFailuresOnce(
       executions,
       checkpointBlocked,
       checkpoint: recoveryCheckpoint,
+      overflow: overflowSummary,
       onCheckpoint: options.onCheckpoint,
       lookbackSince: since,
       detailedAlertsConsumed:


### PR DESCRIPTION
Why\nThe merged incident remediation bounded alert fanout, but two post-merge edge cases remained: overflow checkpoints could lose accumulated totals during cursor advancement, and a delivery containing only Alertmanager-truncated alerts could be silently ignored after ledger deduplication.\n\nWhat\n- Accumulate omitted workflow counts and newest close time across bounded scan batches, persist the summary in heartbeats, and retain it while advancing the visibility cursor.\n- Notify operators when Alertmanager truncates a delivery even when no new occurrence is opened, while keeping the notification auditable with an empty occurrence list.\n\nVerification\n- bunx turbo run test lint typecheck --filter=@shepherdjerred/temporal\n- bunx turbo run typecheck test lint --filter=@shepherdjerred/alert-dashboard\n- DATABASE_URL="file:/Users/jerred/.paseo/worktrees/0o6hsa5c/cute-yak/data/alert-dashboard-ci.db" bun run --cwd packages/alert-dashboard test:sqlite\n- bunx lefthook pre-commit checks passed on both commits\n\nRollout\nThis follow-up is based on current main, which contains merged PRs #2581-#2583. Full-repository Buildkite verification is required and will be monitored before calling the follow-up green.