### PR TITLE
fix(homelab): stop Scout beta thrashing on the retired Temporal drain

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -223,8 +223,16 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
     FLIPT_ENVIRONMENT: EnvValue.fromValue(stage),
     TEMPORAL_NAMESPACE: EnvValue.fromValue(stage),
-    TEMPORAL_LEGACY_NAMESPACE: EnvValue.fromValue("default"),
-    TEMPORAL_SCHEDULE_RECONCILIATION: EnvValue.fromValue("auto"),
+    // No TEMPORAL_LEGACY_NAMESPACE: the `default` drain is retired for Scout.
+    // The legacy namespace holds no Scout execution this backend can finish,
+    // and building its workers is what put the beta supervisor into a
+    // reconnect loop. Reconciliation stays pinned off rather than `auto`
+    // because `scheduleReconciliationEnabled()` treats an absent legacy
+    // namespace as "drained" — under `auto` this would switch on while the
+    // `default` schedules are still live and double-fire every report
+    // schedule. Restore `auto` once `migrate:namespaces cutover` has moved
+    // them into `prod`/`beta`.
+    TEMPORAL_SCHEDULE_RECONCILIATION: EnvValue.fromValue("disabled"),
     FLIPT_URL: EnvValue.fromValue(
       "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
     ),

--- a/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
@@ -93,7 +93,12 @@ describe("Scout competition Temporal boundary", () => {
         "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
       );
       expect(env.get("TEMPORAL_NAMESPACE")).toBe(stage);
-      expect(env.get("TEMPORAL_LEGACY_NAMESPACE")).toBe("default");
+      // The `default` drain is retired for Scout. The two assertions belong
+      // together: an absent legacy namespace makes `auto` resolve to enabled,
+      // so reconciliation has to be pinned off explicitly until the schedules
+      // are cut over.
+      expect(env.has("TEMPORAL_LEGACY_NAMESPACE")).toBe(false);
+      expect(env.get("TEMPORAL_SCHEDULE_RECONCILIATION")).toBe("disabled");
 
       const egressPolicy = synthesized.find(
         (resource) =>

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -48,9 +48,15 @@ describe("Scout weekly parlay deployment boundary", () => {
             value: stage,
           }),
           expect.objectContaining({
-            name: "TEMPORAL_LEGACY_NAMESPACE",
-            value: "default",
+            name: "TEMPORAL_SCHEDULE_RECONCILIATION",
+            value: "disabled",
           }),
+        ]),
+      );
+      // The `default` drain is retired for Scout; see scout-temporal.test.ts.
+      expect(deployment.template.spec.containers[0]?.env).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "TEMPORAL_LEGACY_NAMESPACE" }),
         ]),
       );
       expect(


### PR DESCRIPTION
## Why

Scout beta's Temporal supervisor has been in an infinite reconnect loop since the namespace cutover deployed at **2026-08-31 06:15 UTC**, logging `Temporal component is degraded; reconnecting` every ~6 seconds — attempt 334 by the time it was found. Each cycle rebuilds five beta workers, fails while creating the first `default`-namespace drain worker, tears the runtime down, and sleeps. The backend never holds a stable set of pollers, so `client()` rejects durable starts with "Temporal is unavailable".

The drain those workers exist for cannot do anything for Scout. `default` holds no Scout execution this backend can finish: the central workflow-track images (`stable 2.0.0-13000`, `candidate 2.0.0-13153`) predate the legacy-drain code entirely, so `default/scout-beta` has had **no workflow poller at all** since the cutover and its 17 stranded tasks are being abandoned rather than drained.

This is the config half of the fix — it deploys through GitOps without waiting for an image build. The supervisor defect itself is fixed in the PR stacked on top of this one.

## What

- Drop `TEMPORAL_LEGACY_NAMESPACE` from the Scout backend, so `createConnectedRuntime` never builds the legacy worker set.
- Pin `TEMPORAL_SCHEDULE_RECONCILIATION` to `disabled` rather than `auto`.
- Update the two manifest assertions that pinned the old values.

**The two env changes are load-bearing together.** `scheduleReconciliationEnabled()` (`packages/scout-for-lol/packages/backend/src/temporal/activities.ts:22-45`) returns `true` as soon as `legacyNamespace === undefined`:

```ts
const legacyNamespace = configuration.temporalLegacyNamespace;
if (legacyNamespace === undefined) return true;
```

So removing the legacy namespace on its own would switch Scout's report-schedule reconciliation on while the `default` schedules are still live and unpaused, and double-fire every report schedule. Pinning the mode to `disabled` holds that gate closed until `migrate:namespaces cutover` has moved the schedules into `prod`/`beta`; it returns to `auto` in the follow-up that completes the cutover.

The central Temporal workers keep their drain — this narrows the change to Scout only.

## Verification

```
bunx turbo run typecheck test lint --filter=@homelab/cdk8s
```

679 tests passed, 13 skipped. Manifest assertions updated in `scout-temporal.test.ts` and `scout-weekly-parlay-boundary.test.ts`; the central-worker assertions in `scout-temporal.test.ts:159` are deliberately unchanged, since those deployments keep `TEMPORAL_LEGACY_NAMESPACE=default`.

Not verified live: the loop stops only once this manifest reaches the cluster. Post-deploy check:

```bash
kubectl logs -n scout-beta deploy/scout-beta-scout-backend --tail=200 | grep -c "degraded; reconnecting"   # expect 0
kubectl logs -n scout-beta deploy/scout-beta-scout-backend | grep "Temporal workers connected"             # expect present
```

Non-visual change (deployment configuration), so no media.