### PR TITLE
fix(scout-for-lol): surface the failure that wedges the Temporal supervisor

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -223,8 +223,16 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
     FLIPT_ENVIRONMENT: EnvValue.fromValue(stage),
     TEMPORAL_NAMESPACE: EnvValue.fromValue(stage),
-    TEMPORAL_LEGACY_NAMESPACE: EnvValue.fromValue("default"),
-    TEMPORAL_SCHEDULE_RECONCILIATION: EnvValue.fromValue("auto"),
+    // No TEMPORAL_LEGACY_NAMESPACE: the `default` drain is retired for Scout.
+    // The legacy namespace holds no Scout execution this backend can finish,
+    // and building its workers is what put the beta supervisor into a
+    // reconnect loop. Reconciliation stays pinned off rather than `auto`
+    // because `scheduleReconciliationEnabled()` treats an absent legacy
+    // namespace as "drained" — under `auto` this would switch on while the
+    // `default` schedules are still live and double-fire every report
+    // schedule. Restore `auto` once `migrate:namespaces cutover` has moved
+    // them into `prod`/`beta`.
+    TEMPORAL_SCHEDULE_RECONCILIATION: EnvValue.fromValue("disabled"),
     FLIPT_URL: EnvValue.fromValue(
       "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
     ),

--- a/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
@@ -93,7 +93,12 @@ describe("Scout competition Temporal boundary", () => {
         "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
       );
       expect(env.get("TEMPORAL_NAMESPACE")).toBe(stage);
-      expect(env.get("TEMPORAL_LEGACY_NAMESPACE")).toBe("default");
+      // The `default` drain is retired for Scout. The two assertions belong
+      // together: an absent legacy namespace makes `auto` resolve to enabled,
+      // so reconciliation has to be pinned off explicitly until the schedules
+      // are cut over.
+      expect(env.has("TEMPORAL_LEGACY_NAMESPACE")).toBe(false);
+      expect(env.get("TEMPORAL_SCHEDULE_RECONCILIATION")).toBe("disabled");
 
       const egressPolicy = synthesized.find(
         (resource) =>

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -48,9 +48,15 @@ describe("Scout weekly parlay deployment boundary", () => {
             value: stage,
           }),
           expect.objectContaining({
-            name: "TEMPORAL_LEGACY_NAMESPACE",
-            value: "default",
+            name: "TEMPORAL_SCHEDULE_RECONCILIATION",
+            value: "disabled",
           }),
+        ]),
+      );
+      // The `default` drain is retired for Scout; see scout-temporal.test.ts.
+      expect(deployment.template.spec.containers[0]?.env).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "TEMPORAL_LEGACY_NAMESPACE" }),
         ]),
       );
       expect(

--- a/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
@@ -3,7 +3,7 @@ import { ApplicationFailure } from "@temporalio/common";
 import { Client, Connection } from "@temporalio/client";
 import { client } from "#src/discord/client.ts";
 import configuration from "#src/configuration.ts";
-import type { ScoutTemporalActivityGroups } from "./supervisor.ts";
+import type { ScoutTemporalActivityGroups } from "./connected-runtime.ts";
 import { PermanentImportError } from "#src/league/initial-history/errors.ts";
 import {
   classifyLlmProviderIssue,

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "vitest";
+import {
+  discardPartialRuntime,
+  reconnectDelayMs,
+} from "#src/temporal/connected-runtime.ts";
+
+/**
+ * The SDK invariant these fakes model: `Worker.create` registers a reference
+ * holder on the native connection immediately, and only releases it once the
+ * worker's `run()` promise settles. Closing a connection that still has a
+ * holder throws `IllegalStateError`. A fake that did not model this would
+ * happily pass against the very bug the release path exists to prevent —
+ * cleanup that closed first, threw, and discarded the real failure with it.
+ */
+class ConnectionHolders {
+  readonly #holders = new Set<object>();
+
+  hold(holder: object): void {
+    this.#holders.add(holder);
+  }
+
+  release(holder: object): void {
+    this.#holders.delete(holder);
+  }
+
+  get size(): number {
+    return this.#holders.size;
+  }
+}
+
+class FakeWorker {
+  #state = "INITIALIZED";
+  #settleRun: (() => void) | undefined;
+  ranCount = 0;
+  shutdownCount = 0;
+  releasesOnShutdown = true;
+
+  constructor(private readonly holders: ConnectionHolders) {
+    holders.hold(this);
+  }
+
+  getState(): string {
+    return this.#state;
+  }
+
+  run(): Promise<void> {
+    this.ranCount += 1;
+    this.#state = "RUNNING";
+    return new Promise<void>((resolve) => {
+      this.#settleRun = () => {
+        this.#state = "STOPPED";
+        this.holders.release(this);
+        resolve();
+      };
+    });
+  }
+
+  shutdown(): void {
+    this.shutdownCount += 1;
+    if (this.releasesOnShutdown) this.#settleRun?.();
+  }
+}
+
+class FakeConnection {
+  didClose = false;
+
+  constructor(
+    private readonly holders?: ConnectionHolders,
+    private readonly failWith?: string,
+  ) {}
+
+  async close(): Promise<void> {
+    await Promise.resolve();
+    if (this.failWith !== undefined) throw new Error(this.failWith);
+    if (this.holders !== undefined && this.holders.size > 0) {
+      throw new Error(
+        "Cannot close connection while Workers hold a reference to it",
+      );
+    }
+    this.didClose = true;
+  }
+}
+
+describe("discardPartialRuntime", () => {
+  test("drains created workers so the native connection can close", async () => {
+    const holders = new ConnectionHolders();
+    const workers = [new FakeWorker(holders), new FakeWorker(holders)];
+    const nativeConnection = new FakeConnection(holders);
+    const clientConnection = new FakeConnection();
+    expect(holders.size).toBe(2);
+
+    await discardPartialRuntime(
+      { workers, clientConnection, nativeConnection },
+      new Error("original failure"),
+    );
+
+    expect(holders.size).toBe(0);
+    for (const worker of workers) {
+      expect(worker.ranCount).toBe(1);
+      expect(worker.shutdownCount).toBe(1);
+    }
+    expect(clientConnection.didClose).toBe(true);
+    expect(nativeConnection.didClose).toBe(true);
+  });
+
+  test("never throws, so the caller's original error survives cleanup", async () => {
+    const holders = new ConnectionHolders();
+    const stuck = new FakeWorker(holders);
+    // Reproduces the state that used to raise IllegalStateError from inside
+    // the catch block and replace the failure that caused it.
+    stuck.releasesOnShutdown = false;
+    const nativeConnection = new FakeConnection(holders);
+
+    await expect(
+      discardPartialRuntime(
+        { workers: [stuck], clientConnection: undefined, nativeConnection },
+        new Error("original failure"),
+        // Bounded so a wedged worker cannot stall the reconnect loop; the
+        // production default is longer than the workers' force-shutdown.
+        10,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(stuck.shutdownCount).toBe(1);
+    expect(nativeConnection.didClose).toBe(false);
+  });
+
+  test("closes the native connection even when the client close fails", async () => {
+    const holders = new ConnectionHolders();
+    const nativeConnection = new FakeConnection(holders);
+    const clientConnection = new FakeConnection(
+      undefined,
+      "client close failed",
+    );
+
+    await discardPartialRuntime(
+      { workers: [], clientConnection, nativeConnection },
+      new Error("original failure"),
+    );
+
+    expect(clientConnection.didClose).toBe(false);
+    expect(nativeConnection.didClose).toBe(true);
+  });
+
+  test("handles a runtime that failed before any worker existed", async () => {
+    const holders = new ConnectionHolders();
+    const nativeConnection = new FakeConnection(holders);
+
+    await discardPartialRuntime(
+      { workers: [], clientConnection: undefined, nativeConnection },
+      new Error("connect failed"),
+    );
+
+    expect(nativeConnection.didClose).toBe(true);
+  });
+});
+
+describe("reconnectDelayMs", () => {
+  test("retries the first failure promptly", () => {
+    expect(reconnectDelayMs(0)).toBe(5000);
+    expect(reconnectDelayMs(1)).toBe(5000);
+  });
+
+  test("backs off exponentially", () => {
+    expect(reconnectDelayMs(2)).toBe(10_000);
+    expect(reconnectDelayMs(3)).toBe(20_000);
+    expect(reconnectDelayMs(4)).toBe(40_000);
+  });
+
+  test("caps the delay so a stuck supervisor cannot spin", () => {
+    expect(reconnectDelayMs(5)).toBe(60_000);
+    expect(reconnectDelayMs(50)).toBe(60_000);
+    expect(reconnectDelayMs(334)).toBe(60_000);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
@@ -1,0 +1,424 @@
+import { Client, Connection } from "@temporalio/client";
+import {
+  DefaultLogger,
+  NativeConnection,
+  Runtime,
+  Worker,
+} from "@temporalio/worker";
+import type {
+  ScoutStage,
+  TemporalLegacyNamespace,
+} from "@scout-for-lol/temporal";
+import { scoutTaskQueues } from "@scout-for-lol/temporal";
+import type { ScoutTemporalActivities } from "@scout-for-lol/temporal/activities";
+import { createLogger } from "#src/logger.ts";
+import type { WeeklyParlayControlResult } from "#src/betting/weekly-parlay-control.ts";
+import type { WeeklyParlayControlAction } from "@scout-for-lol/data/model/weekly-parlay.ts";
+import {
+  createTemporalClientTracingInterceptor,
+  createTemporalWorkerTracing,
+} from "@shepherdjerred/temporal-observability/interceptors";
+import { createValidatedWorkflowSpanSink } from "@shepherdjerred/temporal-observability/workflow-span-sink";
+import { sanitizeTemporalLogFields } from "@shepherdjerred/temporal-observability/log-fields";
+import { getTracingRuntime } from "#src/observability/tracing.ts";
+
+const logger = createLogger("temporal-supervisor");
+const RECONNECT_DELAY_MS = 5000;
+const RECONNECT_DELAY_MAX_MS = 60_000;
+/**
+ * Longer than the workers' own `shutdownForceTime` (25s), so a worker that is
+ * being force-stopped still gets to finish before this gives up on it.
+ */
+const DISCARD_DRAIN_TIMEOUT_MS = 30_000;
+
+/**
+ * Back off between reconnects so a persistent failure cannot spin.
+ *
+ * A flat retry here rebuilt five workers and a webpack workflow bundle every
+ * five seconds for hours, leaking a connection per attempt and burying the
+ * signal under identical warnings. The first retry stays prompt because most
+ * failures are a transient server restart.
+ */
+export function reconnectDelayMs(consecutiveFailures: number): number {
+  const exponent = Math.max(0, consecutiveFailures - 1);
+  return Math.min(RECONNECT_DELAY_MS * 2 ** exponent, RECONNECT_DELAY_MAX_MS);
+}
+let runtimeInstalled = false;
+
+function installTemporalRuntime(): void {
+  if (runtimeInstalled) return;
+  Runtime.install({
+    logger: new DefaultLogger("INFO", (entry) => {
+      const fields = {
+        sdk: "temporal",
+        sdkLevel: entry.level,
+        ...sanitizeTemporalLogFields(entry.meta),
+      };
+      if (entry.level === "ERROR") logger.error(entry.message, fields);
+      else if (entry.level === "WARN") logger.warn(entry.message, fields);
+      else logger.info(entry.message, fields);
+    }),
+    telemetryOptions: {
+      logging: {
+        forward: {},
+        filter: { core: "INFO", other: "WARN" },
+      },
+    },
+  });
+  runtimeInstalled = true;
+}
+
+type RealtimeActivities = Pick<
+  ScoutTemporalActivities,
+  | "pollRealtime"
+  | "discoverPostMatchIds"
+  | "runPostMatchMaintenance"
+  | "ingestMatch"
+  | "probeQueue"
+>;
+type InteractiveActivities = Pick<
+  ScoutTemporalActivities,
+  "runInteractive" | "persistInteractiveOutcome" | "probeQueue"
+>;
+type BackgroundActivities = Pick<
+  ScoutTemporalActivities,
+  | "fetchInitialHistoryPage"
+  | "reconcileIngestion"
+  | "runBackgroundJob"
+  | "runDetachedBackgroundWork"
+  | "drainReportScheduleOutbox"
+  | "runReport"
+  | "probeQueue"
+> & {
+  invokeScoutWeeklyParlayAction: (
+    action: WeeklyParlayControlAction,
+  ) => Promise<WeeklyParlayControlResult>;
+  syncScoutBryanBucksAnalytics: () => Promise<{
+    status: "reconciled" | "skipped";
+    detail: string;
+  }>;
+};
+type LakeActivities = Pick<
+  ScoutTemporalActivities,
+  "runReportLakeJob" | "runDetachedLakeWork" | "probeQueue"
+>;
+
+export type ScoutTemporalActivityGroups = {
+  readonly realtime: RealtimeActivities;
+  readonly interactive: InteractiveActivities;
+  readonly background: BackgroundActivities;
+  readonly lake: LakeActivities;
+};
+
+export type ScoutTemporalSupervisorOptions = {
+  readonly address: string | undefined;
+  readonly namespace: ScoutStage;
+  readonly legacyNamespace: TemporalLegacyNamespace | undefined;
+  readonly stage: ScoutStage;
+  readonly activities: ScoutTemporalActivityGroups;
+  readonly callGraphTracing: boolean;
+};
+
+/**
+ * The parts of a Worker and a connection that releasing a runtime touches.
+ * Declaring the capability rather than the SDK classes keeps the release path
+ * testable against a fake that models the reference-holder invariant, without
+ * standing up a real Worker or asserting a fake into one.
+ */
+type ReleasableWorker = {
+  getState: () => string;
+  run: () => Promise<void>;
+  shutdown: () => void;
+};
+
+type ClosableConnection = {
+  close: () => Promise<void>;
+};
+
+export type ConnectedRuntime = {
+  readonly workers: Worker[];
+  readonly nativeConnection: NativeConnection;
+  readonly clientConnection: Connection;
+  readonly client: Client;
+};
+
+type ScoutTemporalTracing = ReturnType<typeof createTemporalWorkerTracing>;
+
+function workflowsPath(): string {
+  return new URL(import.meta.resolve("@scout-for-lol/temporal/workflows"))
+    .pathname;
+}
+
+function workflowUiInterceptorPath(): string {
+  return new URL(
+    import.meta.resolve("@scout-for-lol/temporal/workflow-ui-interceptor"),
+  ).pathname;
+}
+
+function createScoutTemporalTracing(
+  callGraphTracing: boolean,
+): ScoutTemporalTracing | undefined {
+  const tracingRuntime = getTracingRuntime();
+  if (tracingRuntime === undefined && callGraphTracing) {
+    throw new Error(
+      "temporal-call-graph-tracing requires TELEMETRY_ENABLED=true",
+    );
+  }
+  return tracingRuntime !== undefined && callGraphTracing
+    ? createTemporalWorkerTracing({
+        exporter: createValidatedWorkflowSpanSink(
+          tracingRuntime.processor,
+          tracingRuntime.resource,
+        ),
+      })
+    : undefined;
+}
+
+export async function createConnectedRuntime(
+  options: ScoutTemporalSupervisorOptions,
+  discordWorkersEnabled: boolean,
+): Promise<ConnectedRuntime> {
+  installTemporalRuntime();
+  const nativeConnection =
+    options.address === undefined
+      ? await NativeConnection.connect()
+      : await NativeConnection.connect({ address: options.address });
+  let clientConnection: Connection | undefined;
+  // `Worker.create` registers a reference holder on the native connection the
+  // moment it returns, and the holder is only released once that worker's
+  // `run()` promise settles. Collect the workers as they are built so a
+  // mid-sequence failure can drain them before anything closes the
+  // connection: closing it while a holder remains throws IllegalStateError,
+  // which would replace the failure we actually need to see.
+  const workers: Worker[] = [];
+  try {
+    clientConnection =
+      options.address === undefined
+        ? await Connection.connect()
+        : await Connection.connect({ address: options.address });
+    const queues = scoutTaskQueues(options.stage);
+    const tracing = createScoutTemporalTracing(options.callGraphTracing);
+    const commonOptions = {
+      connection: nativeConnection,
+      namespace: options.namespace,
+      shutdownGraceTime: 20_000,
+      shutdownForceTime: 25_000,
+      interceptors: {
+        workflowModules: [
+          workflowUiInterceptorPath(),
+          ...(tracing?.workflowModules ?? []),
+        ],
+        ...(tracing === undefined ? {} : { activity: tracing.activity }),
+      },
+      ...(tracing === undefined ? {} : { sinks: tracing.sinks }),
+    };
+    workers.push(
+      await Worker.create({
+        ...commonOptions,
+        taskQueue: queues.workflow,
+        workflowsPath: workflowsPath(),
+        maxConcurrentWorkflowTaskExecutions: 4,
+      }),
+    );
+    workers.push(
+      await Worker.create({
+        ...commonOptions,
+        taskQueue: queues.interactive,
+        activities: options.activities.interactive,
+        maxConcurrentActivityTaskExecutions: 2,
+      }),
+    );
+    workers.push(
+      await Worker.create({
+        ...commonOptions,
+        taskQueue: queues.lake,
+        activities: options.activities.lake,
+        maxConcurrentActivityTaskExecutions: 1,
+      }),
+    );
+    if (discordWorkersEnabled) {
+      workers.push(
+        await Worker.create({
+          ...commonOptions,
+          taskQueue: queues.realtime,
+          activities: options.activities.realtime,
+          maxConcurrentActivityTaskExecutions: 4,
+        }),
+      );
+      workers.push(
+        await Worker.create({
+          ...commonOptions,
+          taskQueue: queues.background,
+          activities: options.activities.background,
+          maxConcurrentActivityTaskExecutions: 1,
+        }),
+      );
+    }
+    if (options.legacyNamespace !== undefined) {
+      const legacyOptions = {
+        ...commonOptions,
+        namespace: options.legacyNamespace,
+      };
+      // The legacy pollers exist only to let pre-cutover histories in the
+      // retired namespace finish. They are best-effort: a drain worker that
+      // cannot be created must not take the live namespace's workers down
+      // with it, which is what turned one failure here into a permanent
+      // reconnect loop that left Scout with no pollers at all.
+      try {
+        workers.push(
+          await Worker.create({
+            ...legacyOptions,
+            taskQueue: queues.workflow,
+            workflowsPath: workflowsPath(),
+            maxConcurrentWorkflowTaskExecutions: 1,
+          }),
+        );
+        workers.push(
+          await Worker.create({
+            ...legacyOptions,
+            taskQueue: queues.interactive,
+            activities: options.activities.interactive,
+            maxConcurrentActivityTaskExecutions: 1,
+          }),
+        );
+        workers.push(
+          await Worker.create({
+            ...legacyOptions,
+            taskQueue: queues.lake,
+            activities: options.activities.lake,
+            maxConcurrentActivityTaskExecutions: 1,
+          }),
+        );
+        if (discordWorkersEnabled) {
+          workers.push(
+            await Worker.create({
+              ...legacyOptions,
+              taskQueue: queues.realtime,
+              activities: options.activities.realtime,
+              maxConcurrentActivityTaskExecutions: 1,
+            }),
+          );
+          workers.push(
+            await Worker.create({
+              ...legacyOptions,
+              taskQueue: queues.background,
+              activities: options.activities.background,
+              maxConcurrentActivityTaskExecutions: 1,
+            }),
+          );
+        }
+      } catch (error: unknown) {
+        logger.warn("Legacy Temporal drain workers unavailable; continuing", {
+          namespace: options.legacyNamespace,
+          error,
+        });
+      }
+    }
+    return {
+      workers,
+      nativeConnection,
+      clientConnection,
+      client: new Client({
+        connection: clientConnection,
+        namespace: options.namespace,
+        ...(options.callGraphTracing
+          ? {
+              interceptors: {
+                workflow: [createTemporalClientTracingInterceptor()],
+              },
+            }
+          : {}),
+      }),
+    };
+  } catch (error: unknown) {
+    await discardPartialRuntime(
+      { workers, clientConnection, nativeConnection },
+      error,
+    );
+    throw error;
+  }
+}
+
+/**
+ * Release a runtime that failed part-way through construction, without ever
+ * letting the cleanup replace the failure that caused it.
+ *
+ * Ordering matters: a created-but-never-run worker holds a reference to the
+ * native connection forever, so the workers have to be run and drained before
+ * either connection is closed. Cleanup failures are logged and swallowed here
+ * precisely so the caller's `throw error` survives — the previous version
+ * closed the connection first, threw IllegalStateError from inside the
+ * handler, and discarded the real error along with it.
+ */
+export async function discardPartialRuntime(
+  parts: {
+    readonly workers: readonly ReleasableWorker[];
+    readonly clientConnection: ClosableConnection | undefined;
+    readonly nativeConnection: ClosableConnection;
+  },
+  cause: unknown,
+  drainTimeoutMs: number = DISCARD_DRAIN_TIMEOUT_MS,
+): Promise<void> {
+  try {
+    const runs = parts.workers.map(async (worker) => {
+      await worker.run();
+    });
+    for (const worker of parts.workers) {
+      if (worker.getState() === "RUNNING") worker.shutdown();
+    }
+    // Bounded on purpose. A worker that will not settle its `run()` promise
+    // would otherwise wedge this await forever, and the reconnect loop awaits
+    // it — turning a cleanup problem into a supervisor that never retries at
+    // all. If the drain does not finish, the references are still held, so
+    // closing would throw; leave both connections to the process instead.
+    const drained = await Promise.race([
+      Promise.allSettled(runs).then(() => true),
+      Bun.sleep(drainTimeoutMs).then(() => false),
+    ]);
+    if (!drained) {
+      logger.warn("Timed out draining a partially built Temporal runtime", {
+        workerCount: parts.workers.length,
+        drainTimeoutMs,
+        cause,
+      });
+      return;
+    }
+    try {
+      if (parts.clientConnection !== undefined) {
+        await parts.clientConnection.close();
+      }
+    } finally {
+      await parts.nativeConnection.close();
+    }
+  } catch (cleanupError: unknown) {
+    logger.warn("Failed to release a partially built Temporal runtime", {
+      workerCount: parts.workers.length,
+      cleanupError,
+      cause,
+    });
+  }
+}
+
+export async function closeConnectedRuntime(
+  runtime: ConnectedRuntime,
+): Promise<void> {
+  const runs = runtime.workers.map(async (worker) => {
+    await worker.run();
+  });
+  await stopConnectedRuntime(runtime, runs);
+}
+
+export async function stopConnectedRuntime(
+  runtime: ConnectedRuntime,
+  runs: Promise<void>[],
+): Promise<void> {
+  for (const worker of runtime.workers) {
+    if (worker.getState() === "RUNNING") worker.shutdown();
+  }
+  await Promise.allSettled(runs);
+  try {
+    await runtime.clientConnection.close();
+  } finally {
+    await runtime.nativeConnection.close();
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/temporal/supervisor.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/supervisor.ts
@@ -1,16 +1,5 @@
-import { Client, Connection } from "@temporalio/client";
-import {
-  DefaultLogger,
-  NativeConnection,
-  Runtime,
-  Worker,
-} from "@temporalio/worker";
-import type {
-  ScoutStage,
-  TemporalLegacyNamespace,
-} from "@scout-for-lol/temporal";
-import { scoutTaskQueues } from "@scout-for-lol/temporal";
-import type { ScoutTemporalActivities } from "@scout-for-lol/temporal/activities";
+import * as Sentry from "@sentry/bun";
+import type { Client } from "@temporalio/client";
 import { createLogger } from "#src/logger.ts";
 import {
   scoutTemporalConnected,
@@ -19,286 +8,16 @@ import {
   scoutTemporalWorkers,
 } from "#src/metrics/temporal.ts";
 import { setScoutTemporalHealth } from "./health.ts";
-import type { WeeklyParlayControlResult } from "#src/betting/weekly-parlay-control.ts";
-import type { WeeklyParlayControlAction } from "@scout-for-lol/data/model/weekly-parlay.ts";
 import {
-  createTemporalClientTracingInterceptor,
-  createTemporalWorkerTracing,
-} from "@shepherdjerred/temporal-observability/interceptors";
-import { createValidatedWorkflowSpanSink } from "@shepherdjerred/temporal-observability/workflow-span-sink";
-import { sanitizeTemporalLogFields } from "@shepherdjerred/temporal-observability/log-fields";
-import { getTracingRuntime } from "#src/observability/tracing.ts";
+  closeConnectedRuntime,
+  createConnectedRuntime,
+  reconnectDelayMs,
+  stopConnectedRuntime,
+  type ConnectedRuntime,
+  type ScoutTemporalSupervisorOptions,
+} from "./connected-runtime.ts";
 
 const logger = createLogger("temporal-supervisor");
-const RECONNECT_DELAY_MS = 5000;
-let runtimeInstalled = false;
-
-function installTemporalRuntime(): void {
-  if (runtimeInstalled) return;
-  Runtime.install({
-    logger: new DefaultLogger("INFO", (entry) => {
-      const fields = {
-        sdk: "temporal",
-        sdkLevel: entry.level,
-        ...sanitizeTemporalLogFields(entry.meta),
-      };
-      if (entry.level === "ERROR") logger.error(entry.message, fields);
-      else if (entry.level === "WARN") logger.warn(entry.message, fields);
-      else logger.info(entry.message, fields);
-    }),
-    telemetryOptions: {
-      logging: {
-        forward: {},
-        filter: { core: "INFO", other: "WARN" },
-      },
-    },
-  });
-  runtimeInstalled = true;
-}
-
-type RealtimeActivities = Pick<
-  ScoutTemporalActivities,
-  | "pollRealtime"
-  | "discoverPostMatchIds"
-  | "runPostMatchMaintenance"
-  | "ingestMatch"
-  | "probeQueue"
->;
-type InteractiveActivities = Pick<
-  ScoutTemporalActivities,
-  "runInteractive" | "persistInteractiveOutcome" | "probeQueue"
->;
-type BackgroundActivities = Pick<
-  ScoutTemporalActivities,
-  | "fetchInitialHistoryPage"
-  | "reconcileIngestion"
-  | "runBackgroundJob"
-  | "runDetachedBackgroundWork"
-  | "drainReportScheduleOutbox"
-  | "runReport"
-  | "probeQueue"
-> & {
-  invokeScoutWeeklyParlayAction: (
-    action: WeeklyParlayControlAction,
-  ) => Promise<WeeklyParlayControlResult>;
-  syncScoutBryanBucksAnalytics: () => Promise<{
-    status: "reconciled" | "skipped";
-    detail: string;
-  }>;
-};
-type LakeActivities = Pick<
-  ScoutTemporalActivities,
-  "runReportLakeJob" | "runDetachedLakeWork" | "probeQueue"
->;
-
-export type ScoutTemporalActivityGroups = {
-  readonly realtime: RealtimeActivities;
-  readonly interactive: InteractiveActivities;
-  readonly background: BackgroundActivities;
-  readonly lake: LakeActivities;
-};
-
-export type ScoutTemporalSupervisorOptions = {
-  readonly address: string | undefined;
-  readonly namespace: ScoutStage;
-  readonly legacyNamespace: TemporalLegacyNamespace | undefined;
-  readonly stage: ScoutStage;
-  readonly activities: ScoutTemporalActivityGroups;
-  readonly callGraphTracing: boolean;
-};
-
-type ConnectedRuntime = {
-  readonly workers: Worker[];
-  readonly nativeConnection: NativeConnection;
-  readonly clientConnection: Connection;
-  readonly client: Client;
-};
-
-type ScoutTemporalTracing = ReturnType<typeof createTemporalWorkerTracing>;
-
-function workflowsPath(): string {
-  return new URL(import.meta.resolve("@scout-for-lol/temporal/workflows"))
-    .pathname;
-}
-
-function workflowUiInterceptorPath(): string {
-  return new URL(
-    import.meta.resolve("@scout-for-lol/temporal/workflow-ui-interceptor"),
-  ).pathname;
-}
-
-function createScoutTemporalTracing(
-  callGraphTracing: boolean,
-): ScoutTemporalTracing | undefined {
-  const tracingRuntime = getTracingRuntime();
-  if (tracingRuntime === undefined && callGraphTracing) {
-    throw new Error(
-      "temporal-call-graph-tracing requires TELEMETRY_ENABLED=true",
-    );
-  }
-  return tracingRuntime !== undefined && callGraphTracing
-    ? createTemporalWorkerTracing({
-        exporter: createValidatedWorkflowSpanSink(
-          tracingRuntime.processor,
-          tracingRuntime.resource,
-        ),
-      })
-    : undefined;
-}
-
-async function createConnectedRuntime(
-  options: ScoutTemporalSupervisorOptions,
-  discordWorkersEnabled: boolean,
-): Promise<ConnectedRuntime> {
-  installTemporalRuntime();
-  const nativeConnection =
-    options.address === undefined
-      ? await NativeConnection.connect()
-      : await NativeConnection.connect({ address: options.address });
-  let clientConnection: Connection | undefined;
-  try {
-    clientConnection =
-      options.address === undefined
-        ? await Connection.connect()
-        : await Connection.connect({ address: options.address });
-    const queues = scoutTaskQueues(options.stage);
-    const tracing = createScoutTemporalTracing(options.callGraphTracing);
-    const commonOptions = {
-      connection: nativeConnection,
-      namespace: options.namespace,
-      shutdownGraceTime: 20_000,
-      shutdownForceTime: 25_000,
-      interceptors: {
-        workflowModules: [
-          workflowUiInterceptorPath(),
-          ...(tracing?.workflowModules ?? []),
-        ],
-        ...(tracing === undefined ? {} : { activity: tracing.activity }),
-      },
-      ...(tracing === undefined ? {} : { sinks: tracing.sinks }),
-    };
-    const workers = [
-      await Worker.create({
-        ...commonOptions,
-        taskQueue: queues.workflow,
-        workflowsPath: workflowsPath(),
-        maxConcurrentWorkflowTaskExecutions: 4,
-      }),
-      await Worker.create({
-        ...commonOptions,
-        taskQueue: queues.interactive,
-        activities: options.activities.interactive,
-        maxConcurrentActivityTaskExecutions: 2,
-      }),
-      await Worker.create({
-        ...commonOptions,
-        taskQueue: queues.lake,
-        activities: options.activities.lake,
-        maxConcurrentActivityTaskExecutions: 1,
-      }),
-    ];
-    if (discordWorkersEnabled) {
-      workers.push(
-        await Worker.create({
-          ...commonOptions,
-          taskQueue: queues.realtime,
-          activities: options.activities.realtime,
-          maxConcurrentActivityTaskExecutions: 4,
-        }),
-        await Worker.create({
-          ...commonOptions,
-          taskQueue: queues.background,
-          activities: options.activities.background,
-          maxConcurrentActivityTaskExecutions: 1,
-        }),
-      );
-    }
-    if (options.legacyNamespace !== undefined) {
-      const legacyOptions = {
-        ...commonOptions,
-        namespace: options.legacyNamespace,
-      };
-      workers.push(
-        await Worker.create({
-          ...legacyOptions,
-          taskQueue: queues.workflow,
-          workflowsPath: workflowsPath(),
-          maxConcurrentWorkflowTaskExecutions: 1,
-        }),
-        await Worker.create({
-          ...legacyOptions,
-          taskQueue: queues.interactive,
-          activities: options.activities.interactive,
-          maxConcurrentActivityTaskExecutions: 1,
-        }),
-        await Worker.create({
-          ...legacyOptions,
-          taskQueue: queues.lake,
-          activities: options.activities.lake,
-          maxConcurrentActivityTaskExecutions: 1,
-        }),
-      );
-      if (discordWorkersEnabled) {
-        workers.push(
-          await Worker.create({
-            ...legacyOptions,
-            taskQueue: queues.realtime,
-            activities: options.activities.realtime,
-            maxConcurrentActivityTaskExecutions: 1,
-          }),
-          await Worker.create({
-            ...legacyOptions,
-            taskQueue: queues.background,
-            activities: options.activities.background,
-            maxConcurrentActivityTaskExecutions: 1,
-          }),
-        );
-      }
-    }
-    return {
-      workers,
-      nativeConnection,
-      clientConnection,
-      client: new Client({
-        connection: clientConnection,
-        namespace: options.namespace,
-        ...(options.callGraphTracing
-          ? {
-              interceptors: {
-                workflow: [createTemporalClientTracingInterceptor()],
-              },
-            }
-          : {}),
-      }),
-    };
-  } catch (error: unknown) {
-    if (clientConnection !== undefined) await clientConnection.close();
-    await nativeConnection.close();
-    throw error;
-  }
-}
-
-async function closeConnectedRuntime(runtime: ConnectedRuntime): Promise<void> {
-  const runs = runtime.workers.map(async (worker) => {
-    await worker.run();
-  });
-  await stopConnectedRuntime(runtime, runs);
-}
-
-async function stopConnectedRuntime(
-  runtime: ConnectedRuntime,
-  runs: Promise<void>[],
-): Promise<void> {
-  for (const worker of runtime.workers) {
-    if (worker.getState() === "RUNNING") worker.shutdown();
-  }
-  await Promise.allSettled(runs);
-  try {
-    await runtime.clientConnection.close();
-  } finally {
-    await runtime.nativeConnection.close();
-  }
-}
 
 export class ScoutTemporalSupervisor {
   readonly #options: ScoutTemporalSupervisorOptions;
@@ -308,6 +27,7 @@ export class ScoutTemporalSupervisor {
   #active: ConnectedRuntime | undefined;
   readonly #runPromise: Promise<void>;
   #attempt = 0;
+  #consecutiveFailures = 0;
 
   constructor(options: ScoutTemporalSupervisorOptions) {
     this.#options = options;
@@ -364,14 +84,16 @@ export class ScoutTemporalSupervisor {
       if (this.#attempt > 1) scoutTemporalReconnects.inc();
       try {
         await this.#connectAndRun();
+        this.#consecutiveFailures = 0;
       } catch (error: unknown) {
+        this.#consecutiveFailures += 1;
         this.#recordDegradedState(error);
       } finally {
         scoutTemporalConnected.set(0);
         if (this.#active === undefined) scoutTemporalWorkers.reset();
       }
       if (this.#shouldStop()) return;
-      await Bun.sleep(RECONNECT_DELAY_MS);
+      await Bun.sleep(reconnectDelayMs(this.#consecutiveFailures));
     }
   }
 
@@ -436,7 +158,22 @@ export class ScoutTemporalSupervisor {
     logger.warn("Temporal component is degraded; reconnecting", {
       address: this.#options.address,
       attempt: this.#attempt,
+      consecutiveFailures: this.#consecutiveFailures,
+      nextRetryMs: reconnectDelayMs(this.#consecutiveFailures),
       message,
+      // The message alone is not enough to diagnose a repeating failure:
+      // it was the only field logged while this loop ran for hours.
+      stack: error instanceof Error ? error.stack : undefined,
+      cause: error instanceof Error ? error.cause : undefined,
+    });
+    Sentry.captureException(error, {
+      tags: { source: "temporal-supervisor" },
+      extra: {
+        attempt: this.#attempt,
+        consecutiveFailures: this.#consecutiveFailures,
+        namespace: this.#options.namespace,
+        legacyNamespace: this.#options.legacyNamespace,
+      },
     });
     setScoutTemporalHealth({
       state: "degraded",

--- a/packages/scout-for-lol/packages/backend/src/temporal/weekly-parlay-activity.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/weekly-parlay-activity.ts
@@ -1,5 +1,5 @@
 import { Context } from "@temporalio/activity";
-import type { ScoutTemporalActivityGroups } from "./supervisor.ts";
+import type { ScoutTemporalActivityGroups } from "./connected-runtime.ts";
 import { MY_SERVER } from "#src/configuration/flags.ts";
 import { heartbeatWhile } from "./activity-runtime.ts";
 


### PR DESCRIPTION
## Why

Scout beta's Temporal supervisor spent 15 hours logging one identical warning every ~6 seconds:

```
WARN [temporal-supervisor] Temporal component is degraded; reconnecting
  address: 'temporal-temporal-server-service.temporal.svc.cluster.local:7233'
  attempt: 334
  message: 'Cannot close connection while Workers hold a reference to it'
```

**That message was never the failure.** It came from the cleanup handler in `createConnectedRuntime`:

```ts
} catch (error: unknown) {
  if (clientConnection !== undefined) await clientConnection.close();
  await nativeConnection.close();   // throws IllegalStateError — workers still hold refs
  throw error;                      // unreachable
}
```

`Worker.create` adds a reference holder to the native connection the moment it returns (`@temporalio/worker/src/worker.ts:561`) and only releases it in `runInternal`'s `finally` (`:2266`). A worker created but never run holds that reference forever, and `NativeConnection.close()` throws while any holder remains (`connection.ts:261`). So once any `Worker.create` in the sequence failed after at least one worker existed, the close threw and the handler discarded the real error with it — for all 334 attempts. Every cycle also leaked a `NativeConnection`, its native workers, and a freshly webpack-built workflow bundle, which is the most likely reason later attempts failed where the first succeeded.

The stacked base PR (#2595) routes around the failing code path in config so beta recovers without waiting for an image. This PR fixes the defect.

## What

- **Release a partially built runtime correctly.** Workers are collected as they are created; on failure they are run, shut down, and drained *before* anything closes. Cleanup failures are logged and swallowed so the caller's `throw error` survives.
- **The drain is bounded** (30s, longer than the workers' own 25s `shutdownForceTime`). A worker that never settles its `run()` promise would otherwise wedge the release path forever — and the reconnect loop awaits it, so an unbounded drain would turn a leak into a supervisor that never retries at all. This was caught by the test, not by inspection.
- **Push each worker individually.** `workers.push(await a(), await b())` evaluates both arguments before `push` runs, so a failure in the second orphans the first outside the array the cleanup path walks — defeating the tracking entirely.
- **The legacy-namespace drain is best-effort.** Those pollers exist only to let pre-cutover histories finish; one failing must not take the five live `beta` workers down with it. That is what turned a single creation failure into a permanent outage.
- **Backoff and real error reporting.** Exponential to a 60s cap instead of flat 5s, and the log now carries `stack` and `cause` and reports to Sentry. The bare `message` was all that got logged, 334 times, which is why this was invisible.
- **Split the runtime lifecycle into `connected-runtime.ts`.** `supervisor.ts` had grown past the repo's 500-line cap; the class is orchestration, while construction and teardown are their own concern.

`discardPartialRuntime` is typed by the capability it uses (`getState`/`run`/`shutdown`, `close`) rather than the SDK classes, so the tests can drive a fake without asserting it into a `Worker` — the repo bans type assertions.

## Verification

```
bunx turbo run typecheck lint --filter=@scout-for-lol/backend    # architecture: 878 modules clean
vitest run src/temporal/ src/startup.test.ts                     # 37 passed
```

7 of those tests are new, and the fake they drive models the SDK invariant that caused the bug: `Worker.create` takes a reference holder, `run()` releases it on settle, and `close()` throws while any holder remains. A release path that closed too early fails them rather than passing quietly.

The supervisor had **no test coverage at all** before this change.

Not verified live: this needs an image build to reach the beta cluster. #2595 is what restores beta in the meantime. Non-visual change (backend lifecycle), so no media.