### PR TITLE
fix(temporal): compare migrated schedules canonically

### DIFF
--- a/packages/temporal/src/schedules/namespace-migration.test.ts
+++ b/packages/temporal/src/schedules/namespace-migration.test.ts
@@ -4,6 +4,7 @@ import {
   classifyScheduleNamespace,
   isRootWorkflowExecution,
 } from "./namespace-migration.ts";
+import { canonicalize } from "./schedule-comparison.ts";
 import {
   cutoverTimestampForRetry,
   decodeMigrationState,
@@ -222,5 +223,70 @@ describe("Temporal namespace migration ownership", () => {
         rootExecution: { runId: "root-run" },
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * `canonicalize` is what makes a prepared target comparable to the source it
+ * was copied from. Both rules below exist because a byte-identical copy read
+ * as drifted without them, which blocks the cutover outright.
+ */
+const compare = (value: unknown) => JSON.stringify(canonicalize(value));
+
+describe("schedule comparison canonicalization", () => {
+  test("treats a server-defaulted priority as no priority at all", () => {
+    // The server materializes these zero values on a schedule it creates;
+    // schedules created before it did report the field as an empty object.
+    expect(
+      compare({
+        action: {
+          taskQueue: "monorepo-workflows",
+          priority: { priorityKey: 0, fairnessKey: "", fairnessWeight: 0 },
+        },
+      }),
+    ).toBe(
+      compare({ action: { taskQueue: "monorepo-workflows", priority: {} } }),
+    );
+  });
+
+  test("drops a defaulted priority however deeply it is nested", () => {
+    expect(compare({ a: { b: { priority: { priorityKey: 0 } } } })).toBe(
+      compare({ a: { b: {} } }),
+    );
+  });
+
+  test("still reports a schedule that genuinely sets a priority", () => {
+    expect(compare({ action: { priority: { priorityKey: 3 } } })).not.toBe(
+      compare({ action: { priority: {} } }),
+    );
+    expect(
+      compare({ action: { priority: { fairnessKey: "scout" } } }),
+    ).not.toBe(compare({ action: { priority: {} } }));
+  });
+
+  test("ignores object key order, which carries no meaning", () => {
+    expect(compare({ memo: { stage: "beta", reportId: "7" } })).toBe(
+      compare({ memo: { reportId: "7", stage: "beta" } }),
+    );
+  });
+
+  test("still reports values that differ", () => {
+    expect(compare({ memo: { stage: "beta" } })).not.toBe(
+      compare({ memo: { stage: "prod" } }),
+    );
+  });
+
+  test("preserves array order, which does carry meaning", () => {
+    expect(
+      compare({ spec: { intervals: [{ every: 60 }, { every: 30 }] } }),
+    ).not.toBe(
+      compare({ spec: { intervals: [{ every: 30 }, { every: 60 }] } }),
+    );
+  });
+
+  test("leaves primitives and null alone", () => {
+    expect(canonicalize(null)).toBe(null);
+    expect(canonicalize(7)).toBe(7);
+    expect(canonicalize("scout")).toBe("scout");
   });
 });

--- a/packages/temporal/src/schedules/namespace-migration.ts
+++ b/packages/temporal/src/schedules/namespace-migration.ts
@@ -4,7 +4,6 @@ import {
   ScoutScheduleOwnershipMemoSchema,
   scoutReportScheduleId,
 } from "@scout-for-lol/temporal";
-import { z } from "zod";
 import { DYNAMIC_AGENT_TASK_MEMO_KEY } from "#shared/agent-task-identifiers.ts";
 import { SCHEDULES } from "./schedule-definitions.ts";
 import type {
@@ -24,17 +23,10 @@ import {
   type MigrationState,
 } from "./namespace-migration-state.ts";
 import { auditNamespaceMigration as auditNamespaceMigrationImpl } from "./namespace-migration-audit.ts";
-const SearchAttributesSchema = z
-  .record(
-    z.string(),
-    z.union([
-      z.array(z.string()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-      z.array(z.date()),
-    ]),
-  )
-  .optional();
+import {
+  comparableSchedule,
+  readSearchAttributes,
+} from "./schedule-comparison.ts";
 export function isRootWorkflowExecution(execution: {
   runId: string;
   rootExecution?: { runId: string | null } | null;
@@ -77,21 +69,6 @@ export function classifyScheduleNamespace(
   }
 
   throw new Error(`Unknown schedule ownership for ${scheduleId}`);
-}
-function comparableSchedule(description: ScheduleDescription): string {
-  return JSON.stringify({
-    spec: description.spec,
-    action: description.action,
-    policies: description.policies,
-    memo: description.memo,
-    searchAttributes: readSearchAttributes(description),
-    typedSearchAttributes: description.typedSearchAttributes,
-  });
-}
-function readSearchAttributes(description: ScheduleDescription) {
-  return SearchAttributesSchema.parse(
-    Reflect.get(description, "searchAttributes"),
-  );
 }
 export async function inventoryMigrationSchedules(
   sourceClient: Client,

--- a/packages/temporal/src/schedules/schedule-comparison.ts
+++ b/packages/temporal/src/schedules/schedule-comparison.ts
@@ -1,0 +1,80 @@
+import type { ScheduleDescription } from "@temporalio/client";
+import { z } from "zod";
+
+const SearchAttributesSchema = z
+  .record(
+    z.string(),
+    z.union([
+      z.array(z.string()),
+      z.array(z.number()),
+      z.array(z.boolean()),
+      z.array(z.date()),
+    ]),
+  )
+  .optional();
+/**
+ * A schedule's `priority` carrying nothing but zero values means the same
+ * thing as no priority at all. The server materializes the explicit defaults
+ * on a schedule it creates, while schedules created before it did that report
+ * an empty object, so a prepared target would otherwise read as drifted from
+ * the source it was copied from byte for byte. A schedule that genuinely sets
+ * a priority still compares as itself.
+ */
+const DefaultPrioritySchema = z.object({
+  priorityKey: z.number().optional(),
+  fairnessKey: z.string().optional(),
+  fairnessWeight: z.number().optional(),
+});
+
+function isDefaultPriority(value: unknown): boolean {
+  const parsed = DefaultPrioritySchema.safeParse(value);
+  if (!parsed.success) return false;
+  return (
+    (parsed.data.priorityKey ?? 0) === 0 &&
+    (parsed.data.fairnessKey ?? "") === "" &&
+    (parsed.data.fairnessWeight ?? 0) === 0
+  );
+}
+
+/**
+ * Put a described schedule into a form two namespaces can be compared in.
+ *
+ * `JSON.stringify` preserves insertion order, so this has to sort object keys
+ * itself: the same memo written in a different order is the same memo, and
+ * comparing the raw output reported four identical Scout report schedules as
+ * drifted. Array order is left alone — it is significant for `spec.intervals`
+ * and for a workflow's `args`.
+ */
+export function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry: unknown) => canonicalize(entry));
+  }
+  if (value === null || typeof value !== "object") return value;
+  const canonical: Record<string, unknown> = {};
+  const entries: [string, unknown][] = Object.entries(value);
+  for (const [key, entry] of entries.sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (key === "priority" && isDefaultPriority(entry)) continue;
+    canonical[key] = canonicalize(entry);
+  }
+  return canonical;
+}
+
+export function comparableSchedule(description: ScheduleDescription): string {
+  return JSON.stringify(
+    canonicalize({
+      spec: description.spec,
+      action: description.action,
+      policies: description.policies,
+      memo: description.memo,
+      searchAttributes: readSearchAttributes(description),
+      typedSearchAttributes: description.typedSearchAttributes,
+    }),
+  );
+}
+export function readSearchAttributes(description: ScheduleDescription) {
+  return SearchAttributesSchema.parse(
+    Reflect.get(description, "searchAttributes"),
+  );
+}


### PR DESCRIPTION
## Why

`migrate:namespaces cutover` refused every schedule it was asked to move:

```
error: Target prod/bugsink-housekeeping drifted after prepare
```

Nothing had drifted. `comparableSchedule` claims to produce a canonical form and doesn't, so a target that `prepare` had just created byte-for-byte from its source compared as different. Two independent causes, both false positives, and between them they blocked the cutover outright:

- **Server-defaulted `priority`.** The server materializes `{"priorityKey":0,"fairnessKey":"","fairnessWeight":0}` on a schedule it creates, while the schedules already in `default` report the field as `{}`. Same meaning, different bytes. **All 86 schedules hit this.**
- **Key order.** `JSON.stringify` preserves insertion order, so the same memo written in a different order compared as drift:
  ```
  src: {"stage":"beta","reportId":"7","schemaVersion":1,"owner":"scout-for-lol"}
  tgt: {"reportId":"7","schemaVersion":1,"owner":"scout-for-lol","stage":"beta"}
  ```
  **Four Scout report schedules hit this.**

This is the drift oracle for the whole migration — `prepare`, `cutover`, and `audit` all route through it — so neither false positive could be worked around.

## What

- `canonicalize` recursively before stringifying: sort object keys, and drop a `priority` carrying nothing but defaults. Array order is deliberately preserved — it is significant for `spec.intervals` and for a workflow's `args`.
- Extract the comparison into `schedule-comparison.ts`. `namespace-migration.ts` had grown past the 500-line cap, and how two schedules are compared is a separate concern from the migration consuming it.

**The check keeps its teeth.** A schedule that genuinely sets a priority, or whose memo *values* differ, still compares as drifted — both directions are covered by tests, along with array-order significance.

## Verification

```
bunx turbo run typecheck lint --filter=@shepherdjerred/temporal
vitest run src/schedules/     # 187 passed, 8 new
```

Validated against the live homelab Temporal server, which is the part that matters: all 86 prepared targets compared **clean** under the fixed canonicalization, where every one of them had compared as **drifted** before it. The cutover then ran to completion — `cutoverAt 2026-08-31T22:15:04.207Z`, 86 sources paused, 86 targets activated, and the gateway logged `Legacy schedule namespace drained` → `Schedules registered` for both `prod` and `beta`.

Non-visual change (a comparison function), so no media.