### PR TITLE
fix(homelab): re-enable Scout schedule reconciliation after the cutover

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -226,13 +226,14 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     // No TEMPORAL_LEGACY_NAMESPACE: the `default` drain is retired for Scout.
     // The legacy namespace holds no Scout execution this backend can finish,
     // and building its workers is what put the beta supervisor into a
-    // reconnect loop. Reconciliation stays pinned off rather than `auto`
-    // because `scheduleReconciliationEnabled()` treats an absent legacy
-    // namespace as "drained" — under `auto` this would switch on while the
-    // `default` schedules are still live and double-fire every report
-    // schedule. Restore `auto` once `migrate:namespaces cutover` has moved
-    // them into `prod`/`beta`.
-    TEMPORAL_SCHEDULE_RECONCILIATION: EnvValue.fromValue("disabled"),
+    // reconnect loop.
+    //
+    // `auto` is the settled state now that the schedules live in `prod`/`beta`
+    // (cutover 2026-08-31T22:15:04Z). With no legacy namespace configured,
+    // `scheduleReconciliationEnabled()` resolves `auto` to enabled, which is
+    // what Scout needs to keep its report schedules reconciled. Pinning it off
+    // only mattered while the `default` schedules were still live and firing.
+    TEMPORAL_SCHEDULE_RECONCILIATION: EnvValue.fromValue("auto"),
     FLIPT_URL: EnvValue.fromValue(
       "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
     ),

--- a/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
@@ -93,12 +93,10 @@ describe("Scout competition Temporal boundary", () => {
         "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
       );
       expect(env.get("TEMPORAL_NAMESPACE")).toBe(stage);
-      // The `default` drain is retired for Scout. The two assertions belong
-      // together: an absent legacy namespace makes `auto` resolve to enabled,
-      // so reconciliation has to be pinned off explicitly until the schedules
-      // are cut over.
+      // The `default` drain is retired for Scout, and with no legacy namespace
+      // configured `auto` resolves to enabled — the settled post-cutover state.
       expect(env.has("TEMPORAL_LEGACY_NAMESPACE")).toBe(false);
-      expect(env.get("TEMPORAL_SCHEDULE_RECONCILIATION")).toBe("disabled");
+      expect(env.get("TEMPORAL_SCHEDULE_RECONCILIATION")).toBe("auto");
 
       const egressPolicy = synthesized.find(
         (resource) =>

--- a/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-weekly-parlay-boundary.test.ts
@@ -49,7 +49,7 @@ describe("Scout weekly parlay deployment boundary", () => {
           }),
           expect.objectContaining({
             name: "TEMPORAL_SCHEDULE_RECONCILIATION",
-            value: "disabled",
+            value: "auto",
           }),
         ]),
       );

--- a/packages/temporal/src/schedules/namespace-migration.test.ts
+++ b/packages/temporal/src/schedules/namespace-migration.test.ts
@@ -4,6 +4,7 @@ import {
   classifyScheduleNamespace,
   isRootWorkflowExecution,
 } from "./namespace-migration.ts";
+import { canonicalize } from "./schedule-comparison.ts";
 import {
   cutoverTimestampForRetry,
   decodeMigrationState,
@@ -222,5 +223,70 @@ describe("Temporal namespace migration ownership", () => {
         rootExecution: { runId: "root-run" },
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * `canonicalize` is what makes a prepared target comparable to the source it
+ * was copied from. Both rules below exist because a byte-identical copy read
+ * as drifted without them, which blocks the cutover outright.
+ */
+const compare = (value: unknown) => JSON.stringify(canonicalize(value));
+
+describe("schedule comparison canonicalization", () => {
+  test("treats a server-defaulted priority as no priority at all", () => {
+    // The server materializes these zero values on a schedule it creates;
+    // schedules created before it did report the field as an empty object.
+    expect(
+      compare({
+        action: {
+          taskQueue: "monorepo-workflows",
+          priority: { priorityKey: 0, fairnessKey: "", fairnessWeight: 0 },
+        },
+      }),
+    ).toBe(
+      compare({ action: { taskQueue: "monorepo-workflows", priority: {} } }),
+    );
+  });
+
+  test("drops a defaulted priority however deeply it is nested", () => {
+    expect(compare({ a: { b: { priority: { priorityKey: 0 } } } })).toBe(
+      compare({ a: { b: {} } }),
+    );
+  });
+
+  test("still reports a schedule that genuinely sets a priority", () => {
+    expect(compare({ action: { priority: { priorityKey: 3 } } })).not.toBe(
+      compare({ action: { priority: {} } }),
+    );
+    expect(
+      compare({ action: { priority: { fairnessKey: "scout" } } }),
+    ).not.toBe(compare({ action: { priority: {} } }));
+  });
+
+  test("ignores object key order, which carries no meaning", () => {
+    expect(compare({ memo: { stage: "beta", reportId: "7" } })).toBe(
+      compare({ memo: { reportId: "7", stage: "beta" } }),
+    );
+  });
+
+  test("still reports values that differ", () => {
+    expect(compare({ memo: { stage: "beta" } })).not.toBe(
+      compare({ memo: { stage: "prod" } }),
+    );
+  });
+
+  test("preserves array order, which does carry meaning", () => {
+    expect(
+      compare({ spec: { intervals: [{ every: 60 }, { every: 30 }] } }),
+    ).not.toBe(
+      compare({ spec: { intervals: [{ every: 30 }, { every: 60 }] } }),
+    );
+  });
+
+  test("leaves primitives and null alone", () => {
+    expect(canonicalize(null)).toBe(null);
+    expect(canonicalize(7)).toBe(7);
+    expect(canonicalize("scout")).toBe("scout");
   });
 });

--- a/packages/temporal/src/schedules/namespace-migration.ts
+++ b/packages/temporal/src/schedules/namespace-migration.ts
@@ -4,7 +4,6 @@ import {
   ScoutScheduleOwnershipMemoSchema,
   scoutReportScheduleId,
 } from "@scout-for-lol/temporal";
-import { z } from "zod";
 import { DYNAMIC_AGENT_TASK_MEMO_KEY } from "#shared/agent-task-identifiers.ts";
 import { SCHEDULES } from "./schedule-definitions.ts";
 import type {
@@ -24,17 +23,10 @@ import {
   type MigrationState,
 } from "./namespace-migration-state.ts";
 import { auditNamespaceMigration as auditNamespaceMigrationImpl } from "./namespace-migration-audit.ts";
-const SearchAttributesSchema = z
-  .record(
-    z.string(),
-    z.union([
-      z.array(z.string()),
-      z.array(z.number()),
-      z.array(z.boolean()),
-      z.array(z.date()),
-    ]),
-  )
-  .optional();
+import {
+  comparableSchedule,
+  readSearchAttributes,
+} from "./schedule-comparison.ts";
 export function isRootWorkflowExecution(execution: {
   runId: string;
   rootExecution?: { runId: string | null } | null;
@@ -77,21 +69,6 @@ export function classifyScheduleNamespace(
   }
 
   throw new Error(`Unknown schedule ownership for ${scheduleId}`);
-}
-function comparableSchedule(description: ScheduleDescription): string {
-  return JSON.stringify({
-    spec: description.spec,
-    action: description.action,
-    policies: description.policies,
-    memo: description.memo,
-    searchAttributes: readSearchAttributes(description),
-    typedSearchAttributes: description.typedSearchAttributes,
-  });
-}
-function readSearchAttributes(description: ScheduleDescription) {
-  return SearchAttributesSchema.parse(
-    Reflect.get(description, "searchAttributes"),
-  );
 }
 export async function inventoryMigrationSchedules(
   sourceClient: Client,

--- a/packages/temporal/src/schedules/schedule-comparison.ts
+++ b/packages/temporal/src/schedules/schedule-comparison.ts
@@ -1,0 +1,80 @@
+import type { ScheduleDescription } from "@temporalio/client";
+import { z } from "zod";
+
+const SearchAttributesSchema = z
+  .record(
+    z.string(),
+    z.union([
+      z.array(z.string()),
+      z.array(z.number()),
+      z.array(z.boolean()),
+      z.array(z.date()),
+    ]),
+  )
+  .optional();
+/**
+ * A schedule's `priority` carrying nothing but zero values means the same
+ * thing as no priority at all. The server materializes the explicit defaults
+ * on a schedule it creates, while schedules created before it did that report
+ * an empty object, so a prepared target would otherwise read as drifted from
+ * the source it was copied from byte for byte. A schedule that genuinely sets
+ * a priority still compares as itself.
+ */
+const DefaultPrioritySchema = z.object({
+  priorityKey: z.number().optional(),
+  fairnessKey: z.string().optional(),
+  fairnessWeight: z.number().optional(),
+});
+
+function isDefaultPriority(value: unknown): boolean {
+  const parsed = DefaultPrioritySchema.safeParse(value);
+  if (!parsed.success) return false;
+  return (
+    (parsed.data.priorityKey ?? 0) === 0 &&
+    (parsed.data.fairnessKey ?? "") === "" &&
+    (parsed.data.fairnessWeight ?? 0) === 0
+  );
+}
+
+/**
+ * Put a described schedule into a form two namespaces can be compared in.
+ *
+ * `JSON.stringify` preserves insertion order, so this has to sort object keys
+ * itself: the same memo written in a different order is the same memo, and
+ * comparing the raw output reported four identical Scout report schedules as
+ * drifted. Array order is left alone — it is significant for `spec.intervals`
+ * and for a workflow's `args`.
+ */
+export function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry: unknown) => canonicalize(entry));
+  }
+  if (value === null || typeof value !== "object") return value;
+  const canonical: Record<string, unknown> = {};
+  const entries: [string, unknown][] = Object.entries(value);
+  for (const [key, entry] of entries.sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (key === "priority" && isDefaultPriority(entry)) continue;
+    canonical[key] = canonicalize(entry);
+  }
+  return canonical;
+}
+
+export function comparableSchedule(description: ScheduleDescription): string {
+  return JSON.stringify(
+    canonicalize({
+      spec: description.spec,
+      action: description.action,
+      policies: description.policies,
+      memo: description.memo,
+      searchAttributes: readSearchAttributes(description),
+      typedSearchAttributes: description.typedSearchAttributes,
+    }),
+  );
+}
+export function readSearchAttributes(description: ScheduleDescription) {
+  return SearchAttributesSchema.parse(
+    Reflect.get(description, "searchAttributes"),
+  );
+}


### PR DESCRIPTION
## Why

#2595 pinned Scout's `TEMPORAL_SCHEDULE_RECONCILIATION` to `disabled` to hold one specific window closed. With `TEMPORAL_LEGACY_NAMESPACE` removed, `scheduleReconciliationEnabled()` resolves `auto` to enabled:

```ts
const legacyNamespace = configuration.temporalLegacyNamespace;
if (legacyNamespace === undefined) return true;
```

Turning reconciliation on while the `default` schedules were still live and firing would have double-fired every Scout report schedule.

**That window closed at 2026-08-31T22:15:04Z**, when the namespace cutover completed. All 86 schedules now live in `prod`/`beta` and every `default` source is paused, so `auto` resolves to enabled for the right reason.

Left as `disabled`, Scout's report-schedule outbox would never drain again. #2595 shipped a deliberately temporary value; this is the half that was always going to follow it. It is a separate PR only because #2595 merged before the cutover finished.

## What

- Set `TEMPORAL_SCHEDULE_RECONCILIATION` back to `auto` for both Scout stages.
- Update the two manifest assertions.
- Rewrite the comment to record why `auto` is now the *settled* state, rather than leaving a value that reads as still-waiting-to-be-corrected.

## Verification

```
bunx turbo run typecheck test --filter=@homelab/cdk8s    # 679 passed, 13 skipped
```

Cutover confirmed live before making this change:

```
$ temporal --profile homelab schedule describe --namespace default --schedule-id report-freshness-monitor
  Notes    Migrated to environment-scoped Temporal namespace
  Paused   true

$ kubectl logs -n temporal deploy/temporal-temporal-gateway | grep -E "drained|registered"
  "Legacy schedule namespace drained"  {"namespace":"default"}
  "Schedules registered"               {"namespace":"prod"}
  "Schedules registered"               {"namespace":"beta"}
```

Non-visual change (deployment configuration), so no media.