### PR TITLE
fix(temporal): give the workflow candidate a namespace-aware image

### DIFF
--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1443,7 +1443,7 @@
       "management": {
         "managed": false
       },
-      "value": "2.0.0-13153@sha256:557550758e5dda9f1991d9dfe5246f5f21b1a0b7cf8c84f61db30fb4bfc36c3a",
+      "value": "2.0.0-13290@sha256:839757bc2a1ffbdca5111843e6e78ea41771b6c73d486111ee993e2fda762fb5",
       "notes": [
         "Candidate central Workflow Worker image - updated by CI pipeline",
         "not managed by renovate"

--- a/scripts/pin-candidates-state.json
+++ b/scripts/pin-candidates-state.json
@@ -77,9 +77,9 @@
       "buildNumber": 13290
     },
     "shepherdjerred/temporal-worker/workflows/candidate": {
-      "version": "2.0.0-13153",
-      "digest": "sha256:557550758e5dda9f1991d9dfe5246f5f21b1a0b7cf8c84f61db30fb4bfc36c3a",
-      "buildNumber": 13153
+      "version": "2.0.0-13290",
+      "digest": "sha256:839757bc2a1ffbdca5111843e6e78ea41771b6c73d486111ee993e2fda762fb5",
+      "buildNumber": 13290
     },
     "shepherdjerred/temporal-worker/workflows/stable": {
       "version": "2.0.0-13000",


### PR DESCRIPTION
## Why

`beta/monorepo-workflows` has **no workflow poller at all**, so the two Scout beta schedules that run there cannot execute:

- `scout-weekly-parlay`
- `scout-bryan-bucks-analytics`

Both worked before today's namespace cutover. They are currently **paused** rather than left to pile up — bryan-bucks was timing out every 15 minutes and the parlay has no execution timeout, so its run would hang forever.

**This is the same root cause as the outage itself.** #2525 taught the worker to poll `["prod", "beta"]` for `monorepo-workflows`, but the workflow track has been frozen mid-ramp since 2026-08-31: `centralWorkflowPinTargets` only advances the candidate pin while stable and candidate are equal, and they have diverged since #2589. Every build from 13154 onward advanced the plain worker image and deliberately skipped both workflow pins.

So stable (`2.0.0-13000`) and candidate (`2.0.0-13153`) both predate namespace-aware polling and serve `prod` only — their `Worker created` log lines carry no `namespace` field at all, where 13290's do:

```
{"msg":"Worker created","namespace":"prod","legacyDrain":false,...}
{"msg":"Worker created","namespace":"beta","legacyDrain":false,...}
{"msg":"Worker created","namespace":"default","legacyDrain":true,...}
```

Nothing needing new worker code outside `prod` can work until the track moves. That includes the legacy `default` drain, which is why `default` never had a workflow poller either.

## What

Point the workflow **candidate** pin at `2.0.0-13290` — the image every activity worker and the gateway already run in production, and which does poll `beta`.

Deliberately the candidate track, not stable:

- the deployment's current version stays `c42ee297` (stable 13000), so **prod workflow routing is untouched**
- the candidate has no ramp and serves **0% of prod traffic**, so this needs no 24-hour soak — that gate guards promotion to *stable*, which this is not
- in `beta` the worker registers under its own deployment; in `default` it finally provides the legacy drain

Selecting the candidate image by hand deviates from CI owning that pin. It is the only way out: the admission gate that would let CI choose is itself gated on the convergence this unfreezes.

## Verification

```
bunx turbo run typecheck test --filter=@shepherdjerred/version-catalog   # 4 passed
bunx turbo run test --filter=@homelab/cdk8s                              # 679 passed, 13 skipped
vitest .buildkite/scripts/pin-candidate-images.test.ts \
       .buildkite/scripts/temporal-candidate-admission.test.ts           # 46 passed
```

The two gates that specifically govern these pins pass, including `"does not publish a Workflow pin while stable and candidate diverge"` and `"blocks admission when live main has a divergent Temporal candidate"`.

Diff is 4 lines across the catalog and its state mirror; no reformatting.

## Required follow-up before the schedules can be unpaused

Once this rolls out, `monorepo-central-workflows` needs a **current version set in the `beta` namespace** — exactly the fix `prod` needed today, where an empty `currentVersionBuildID` left every workflow task stranded on the unversioned queue:

```bash
temporal --profile homelab --namespace beta worker deployment set-current-version \
  --deployment-name monorepo-central-workflows --build-id <13290 git sha>
```

Beta has no worker deployment yet, so there is nothing to point at until this lands. Then unpause both schedules; their pause notes name this exact condition.

Non-visual change (image pin), so no media.