### PR TITLE
fix(homelab): make the Temporal alerts that missed a 15-hour outage fire

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
@@ -20,6 +20,32 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
         labels: { severity: "warning" },
       },
       {
+        alert: "TemporalWorkflowPlaneStalled",
+        annotations: {
+          summary: escapePrometheusTemplate(
+            "Temporal Workflow tasks are not being picked up on {{ $labels.taskqueue }}",
+          ),
+          description: escapePrometheusTemplate(
+            "Workflow tasks have sat unclaimed on {{ $labels.taskqueue }} in {{ $labels.exported_namespace }} for over fifteen minutes. The usual cause is that the Worker Deployment's current version points at a Build ID no running pod carries, so tasks route to a queue nobody polls — pollers look healthy while nothing executes. Compare `worker deployment describe` against the Build IDs actually reporting pollers.",
+          ),
+          runbook_url:
+            "https://wiki.sjer.red/how-to/roll-out-a-temporal-worker-deployment/",
+        },
+        // Age, not count. A terminated execution can leave tombstoned tasks
+        // behind that keep a non-zero count at age 0 — the retired `default`
+        // namespace shows exactly that — whereas a genuine stall is defined by
+        // tasks getting older. This is the signal that was missing when the
+        // workflow plane was dead for fifteen hours and every existing rule
+        // stayed silent: the pollers were up, so poller alerts saw nothing,
+        // and the backlog rule was selecting a task-queue name that does not
+        // exist on the server's metrics.
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'max by (exported_namespace, taskqueue) (approximate_backlog_age_seconds{namespace="temporal",task_type="Workflow",exported_namespace=~"prod|beta"}) > 900',
+        ),
+        for: "10m",
+        labels: { severity: "critical" },
+      },
+      {
         alert: "TemporalWorkflowTaskFailing",
         annotations: {
           summary: escapePrometheusTemplate(
@@ -30,7 +56,7 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
           ),
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default",failure_reason!="NonDeterminismError"}[10m]) > 0',
+          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace=~"prod|beta",failure_reason!="NonDeterminismError"}[10m]) > 0',
         ),
         for: "2m",
         labels: { severity: "warning" },
@@ -46,7 +72,7 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
           ),
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default",failure_reason="NonDeterminismError"}[10m]) > 0 or increase(service_errors_nondeterministic[10m]) > 0',
+          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace=~"prod|beta",failure_reason="NonDeterminismError"}[10m]) > 0 or increase(service_errors_nondeterministic[10m]) > 0',
         ),
         for: "1m",
         labels: { severity: "critical" },
@@ -63,10 +89,13 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
         },
         // activity_task_fail (not activity_fail) is the series every other
         // Temporal/Scout failure rule in this repo queries (temporal.ts,
-        // scout.ts), and it carries a plain `namespace` label rather than
-        // the temporal_worker_*-prefixed metrics' `exported_namespace`.
+        // scout.ts). It comes from the Temporal server, so `namespace` is the
+        // *Kubernetes* namespace it was scraped in ("temporal") and the
+        // Temporal namespace is `exported_namespace` — the same shape as
+        // approximate_backlog_count. Selecting namespace="default" matched no
+        // series at all, so this alert could never fire.
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(activity_task_fail{namespace="default"}[15m]) > 0',
+          'increase(activity_task_fail{exported_namespace=~"prod|beta"}[15m]) > 0',
         ),
         for: "1m",
         labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -4,6 +4,24 @@ import { scoutWorkflowWorkerImageIsCapable } from "@shepherdjerred/homelab/cdk8s
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 type PrometheusRule = NonNullable<PrometheusRuleSpecGroups["rules"]>[number];
+
+/**
+ * Task-queue name as it appears on the Temporal **server's** own metrics.
+ *
+ * The server sanitizes its metric tag values, so `monorepo-workflows` is
+ * published as `monorepo_workflows`. The SDK's exporter does not, so
+ * `temporal_worker_num_pollers` keeps the hyphen. Selecting the hyphenated
+ * name against a server metric matches nothing and yields a rule that cannot
+ * fire — which is exactly how a fifteen-hour total outage of the workflow
+ * plane produced no page: seven of the eleven central queues have a hyphen,
+ * including `monorepo-workflows`.
+ *
+ * Use this for `approximate_backlog_*` only. Never for `task_queue` on SDK
+ * metrics.
+ */
+export function serverMetricTaskQueue(queue: string): string {
+  return queue.replaceAll("-", "_");
+}
 type TemporalDomainQueueDefinition = {
   queue: string;
   metricsNamespace: string;
@@ -161,6 +179,8 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
     // and hardcoding `temporal` here selected no series at all for them —
     // an alert that can never fire.
     const pollerSelector = `namespace="${definition.metricsNamespace}",exported_namespace=~"${servedNamespaces}",task_queue="${definition.queue}"`;
+    // Server metric, so the queue name is sanitized — see serverMetricTaskQueue.
+    const backlogQueue = serverMetricTaskQueue(definition.queue);
     const labels = { severity: "warning", task_queue: definition.queue };
     const candidateDeploymentPattern = definition.candidateDeploymentPattern;
     const candidateServicePattern = definition.candidateServicePattern;
@@ -207,7 +227,7 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
             "Temporal matching has reported queued workflow or activity tasks for ten minutes. Inspect pollers and schedule-to-start latency before changing capacity.",
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          `max(approximate_backlog_count{namespace="temporal",taskqueue="${definition.queue}",task_type=~"${definition.activityPoller ? "Workflow|Activity" : "Workflow"}"}) > 0`,
+          `max(approximate_backlog_count{namespace="temporal",taskqueue="${backlogQueue}",task_type=~"${definition.activityPoller ? "Workflow|Activity" : "Workflow"}"}) > 0`,
         ),
         for: "10m",
         labels,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -41,14 +41,36 @@ describe("Temporal workflow outcome rules", () => {
       'failure_reason="NonDeterminismError"',
     );
     // activity_task_fail, not activity_fail — the metric every other
-    // Temporal/Scout failure rule in this file queries, and it carries
-    // `namespace`, not the temporal_worker_*-prefixed metrics' `exported_namespace`.
+    // Temporal/Scout failure rule in this file queries. It comes from the
+    // server, so `namespace` is the Kubernetes namespace and the Temporal
+    // namespace is `exported_namespace`; selecting namespace="default"
+    // matched nothing and the alert could never fire.
     expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
       "activity_task_fail",
     );
     expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
+      'exported_namespace=~"prod|beta"',
+    );
+    expect(expressions.get("TemporalActivityRetriesExhausted")).not.toContain(
       'namespace="default"',
     );
+    // The retired drain namespace is empty, so watching it is watching nothing.
+    for (const alert of [
+      "TemporalWorkflowTaskFailing",
+      "TemporalWorkflowNondeterministic",
+    ]) {
+      expect(expressions.get(alert), alert).toContain(
+        'exported_namespace=~"prod|beta"',
+      );
+    }
+    // Tasks aging on a queue nobody polls — the shape of the outage every
+    // other rule missed, because pollers were healthy the whole time.
+    const stalled = expressions.get("TemporalWorkflowPlaneStalled");
+    expect(stalled).toContain("approximate_backlog_age_seconds");
+    expect(stalled).toContain('exported_namespace=~"prod|beta"');
+    expect(stalled).toContain("> 900");
+    // Age, not count: tombstoned tasks hold a non-zero count at age zero.
+    expect(stalled).not.toContain("approximate_backlog_count");
   });
 
   test("excludes intentional warm-morning preheat skips", () => {
@@ -130,14 +152,22 @@ describe("Temporal workflow outcome rules", () => {
           expression.includes("approximate_backlog_count"),
       ),
     ).toBe(true);
+    // The Temporal server sanitizes its metric tag values, so a hyphenated
+    // queue is published as `repo_automation` / `monorepo_workflows`. These
+    // assertions were previously inverted, which pinned a selector that
+    // matched no series: the backlog rule was silent for all seven hyphenated
+    // queues, including monorepo-workflows, throughout a fifteen-hour outage.
     expect(backlogExpressions).toContain(
-      'max(approximate_backlog_count{namespace="temporal",taskqueue="repo-automation",task_type=~"Workflow|Activity"}) > 0',
+      'max(approximate_backlog_count{namespace="temporal",taskqueue="repo_automation",task_type=~"Workflow|Activity"}) > 0',
     );
     expect(backlogExpressions).toContain(
-      'max(approximate_backlog_count{namespace="temporal",taskqueue="monorepo-workflows",task_type=~"Workflow"}) > 0',
+      'max(approximate_backlog_count{namespace="temporal",taskqueue="monorepo_workflows",task_type=~"Workflow"}) > 0',
     );
     expect(backlogExpressions.join("\n")).not.toContain(
-      'taskqueue="repo_automation"',
+      'taskqueue="repo-automation"',
+    );
+    expect(backlogExpressions.join("\n")).not.toContain(
+      'taskqueue="monorepo-workflows"',
     );
 
     const workerMetricsDown = failuresGroup.rules.find(


### PR DESCRIPTION
## Why

The Temporal workflow plane was dead for **fifteen hours** on 2026-08-31, and stalled a **second time** that evening. Neither produced a page.

Three alerts were selecting label values that match no series, so they were structurally incapable of firing. All three verified against the live cluster, not by inspection:

**1. `TemporalDomainQueueBacklog` — the big one.** The Temporal *server* sanitizes its metric tag values, so the live label is `monorepo_workflows`, not `monorepo-workflows`:

| query | series |
|---|---|
| `approximate_backlog_count{taskqueue="monorepo-workflows"}` | **0** |
| `approximate_backlog_count{taskqueue="monorepo_workflows"}` | 1 (value 42) |

Seven of the eleven central queues contain a hyphen, including the busiest. The SDK's exporter does *not* sanitize — `temporal_worker_num_pollers` keeps `task_queue="monorepo-workflows"` and matches fine — so this defect is confined to rules using a server metric.

**2. `TemporalActivityRetriesExhausted` has never been able to fire.** It selects `activity_task_fail{namespace="default"}`, but that series comes from the server, so `namespace` is the *Kubernetes* namespace and the Temporal namespace is `exported_namespace`:

```
{"activityType":"runFreshRssSync","exported_namespace":"prod",
 "namespace":"temporal","service_name":"history","taskqueue":"repo_automation"}
```

`count(activity_task_fail{namespace="default"})` → **no series**.

**3. Two alerts were blinded by the cutover.** `TemporalWorkflowTaskFailing` and `TemporalWorkflowNondeterministic` watch only `exported_namespace="default"`, which the namespace migration emptied — permanently silent.

The test suite was also **pinning the bug**: `expect(backlogExpressions).not.toContain('taskqueue="repo_automation"')` asserted the *correct* form was absent, since #2472.

**And nothing covered the actual failure.** Both stalls had the same shape — the Worker Deployment's current version pointed at a Build ID no running pod carried, so tasks routed to a queue nobody polled. Pollers stayed healthy throughout, so every poller rule stayed quiet while zero workflows executed.

## What

- `serverMetricTaskQueue()` sanitizes the queue name for `approximate_backlog_*` selectors **only**; SDK `task_queue` selectors stay hyphenated, and both forms are asserted so the distinction can't be "tidied" away.
- Repoint the three `default`-scoped rules at `prod|beta`, and fix the wrong label on `activity_task_fail`.
- **New: `TemporalWorkflowPlaneStalled`** — workflow tasks aging past 15 minutes in `prod`/`beta`, `severity: critical`, with a runbook link. It keys on `approximate_backlog_age_seconds` rather than count, because a terminated execution leaves tombstoned tasks holding a non-zero count at age 0 — the retired `default` namespace shows exactly that right now, and a count-based rule would false-positive on it.
- Invert the bug-pinning assertions and add negative ones for the hyphenated form.

`TemporalDefaultNamespaceStartAttempted` deliberately keeps its `default` selector — it's what makes "the drain namespace stays empty" enforceable.

## Verification

```
bunx turbo run typecheck test lint --filter=@homelab/cdk8s   # 679 passed, 13 skipped
```

Every expression was validated against live Prometheus:

| check | result |
|---|---|
| fixed backlog selector | returns a series where the old one returned **none** |
| new alert, right now | quiet — no series over threshold, so no false positive on the tombstoned backlog |
| new alert, replayed over the stall window | `prod monorepo_workflows = 6489s` — far past the 900s threshold |

That last row is the point: this rule would have caught **both** outages.

There is no promtool in this repo, so these Vitest assertions on `rule.expr.value` are the only thing between a typo'd label and another silent outage. Non-visual change (alert rules), so no media.