### PR TITLE
fix(homelab): point Scout workflow workers at their own namespace

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-platform-health.ts
@@ -20,6 +20,32 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
         labels: { severity: "warning" },
       },
       {
+        alert: "TemporalWorkflowPlaneStalled",
+        annotations: {
+          summary: escapePrometheusTemplate(
+            "Temporal Workflow tasks are not being picked up on {{ $labels.taskqueue }}",
+          ),
+          description: escapePrometheusTemplate(
+            "Workflow tasks have sat unclaimed on {{ $labels.taskqueue }} in {{ $labels.exported_namespace }} for over fifteen minutes. The usual cause is that the Worker Deployment's current version points at a Build ID no running pod carries, so tasks route to a queue nobody polls — pollers look healthy while nothing executes. Compare `worker deployment describe` against the Build IDs actually reporting pollers.",
+          ),
+          runbook_url:
+            "https://wiki.sjer.red/how-to/roll-out-a-temporal-worker-deployment/",
+        },
+        // Age, not count. A terminated execution can leave tombstoned tasks
+        // behind that keep a non-zero count at age 0 — the retired `default`
+        // namespace shows exactly that — whereas a genuine stall is defined by
+        // tasks getting older. This is the signal that was missing when the
+        // workflow plane was dead for fifteen hours and every existing rule
+        // stayed silent: the pollers were up, so poller alerts saw nothing,
+        // and the backlog rule was selecting a task-queue name that does not
+        // exist on the server's metrics.
+        expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+          'max by (exported_namespace, taskqueue) (approximate_backlog_age_seconds{namespace="temporal",task_type="Workflow",exported_namespace=~"prod|beta"}) > 900',
+        ),
+        for: "10m",
+        labels: { severity: "critical" },
+      },
+      {
         alert: "TemporalWorkflowTaskFailing",
         annotations: {
           summary: escapePrometheusTemplate(
@@ -30,7 +56,7 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
           ),
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default",failure_reason!="NonDeterminismError"}[10m]) > 0',
+          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace=~"prod|beta",failure_reason!="NonDeterminismError"}[10m]) > 0',
         ),
         for: "2m",
         labels: { severity: "warning" },
@@ -46,7 +72,7 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
           ),
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default",failure_reason="NonDeterminismError"}[10m]) > 0 or increase(service_errors_nondeterministic[10m]) > 0',
+          'increase(temporal_worker_workflow_task_execution_failed{exported_namespace=~"prod|beta",failure_reason="NonDeterminismError"}[10m]) > 0 or increase(service_errors_nondeterministic[10m]) > 0',
         ),
         for: "1m",
         labels: { severity: "critical" },
@@ -63,10 +89,13 @@ export function getTemporalPlatformHealthRuleGroup(): PrometheusRuleSpecGroups {
         },
         // activity_task_fail (not activity_fail) is the series every other
         // Temporal/Scout failure rule in this repo queries (temporal.ts,
-        // scout.ts), and it carries a plain `namespace` label rather than
-        // the temporal_worker_*-prefixed metrics' `exported_namespace`.
+        // scout.ts). It comes from the Temporal server, so `namespace` is the
+        // *Kubernetes* namespace it was scraped in ("temporal") and the
+        // Temporal namespace is `exported_namespace` — the same shape as
+        // approximate_backlog_count. Selecting namespace="default" matched no
+        // series at all, so this alert could never fire.
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          'increase(activity_task_fail{namespace="default"}[15m]) > 0',
+          'increase(activity_task_fail{exported_namespace=~"prod|beta"}[15m]) > 0',
         ),
         for: "1m",
         labels: { severity: "warning" },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -4,6 +4,24 @@ import { scoutWorkflowWorkerImageIsCapable } from "@shepherdjerred/homelab/cdk8s
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
 
 type PrometheusRule = NonNullable<PrometheusRuleSpecGroups["rules"]>[number];
+
+/**
+ * Task-queue name as it appears on the Temporal **server's** own metrics.
+ *
+ * The server sanitizes its metric tag values, so `monorepo-workflows` is
+ * published as `monorepo_workflows`. The SDK's exporter does not, so
+ * `temporal_worker_num_pollers` keeps the hyphen. Selecting the hyphenated
+ * name against a server metric matches nothing and yields a rule that cannot
+ * fire — which is exactly how a fifteen-hour total outage of the workflow
+ * plane produced no page: seven of the eleven central queues have a hyphen,
+ * including `monorepo-workflows`.
+ *
+ * Use this for `approximate_backlog_*` only. Never for `task_queue` on SDK
+ * metrics.
+ */
+export function serverMetricTaskQueue(queue: string): string {
+  return queue.replaceAll("-", "_");
+}
 type TemporalDomainQueueDefinition = {
   queue: string;
   metricsNamespace: string;
@@ -161,6 +179,8 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
     // and hardcoding `temporal` here selected no series at all for them —
     // an alert that can never fire.
     const pollerSelector = `namespace="${definition.metricsNamespace}",exported_namespace=~"${servedNamespaces}",task_queue="${definition.queue}"`;
+    // Server metric, so the queue name is sanitized — see serverMetricTaskQueue.
+    const backlogQueue = serverMetricTaskQueue(definition.queue);
     const labels = { severity: "warning", task_queue: definition.queue };
     const candidateDeploymentPattern = definition.candidateDeploymentPattern;
     const candidateServicePattern = definition.candidateServicePattern;
@@ -207,7 +227,7 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
             "Temporal matching has reported queued workflow or activity tasks for ten minutes. Inspect pollers and schedule-to-start latency before changing capacity.",
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          `max(approximate_backlog_count{namespace="temporal",taskqueue="${definition.queue}",task_type=~"${definition.activityPoller ? "Workflow|Activity" : "Workflow"}"}) > 0`,
+          `max(approximate_backlog_count{namespace="temporal",taskqueue="${backlogQueue}",task_type=~"${definition.activityPoller ? "Workflow|Activity" : "Workflow"}"}) > 0`,
         ),
         for: "10m",
         labels,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -41,14 +41,36 @@ describe("Temporal workflow outcome rules", () => {
       'failure_reason="NonDeterminismError"',
     );
     // activity_task_fail, not activity_fail — the metric every other
-    // Temporal/Scout failure rule in this file queries, and it carries
-    // `namespace`, not the temporal_worker_*-prefixed metrics' `exported_namespace`.
+    // Temporal/Scout failure rule in this file queries. It comes from the
+    // server, so `namespace` is the Kubernetes namespace and the Temporal
+    // namespace is `exported_namespace`; selecting namespace="default"
+    // matched nothing and the alert could never fire.
     expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
       "activity_task_fail",
     );
     expect(expressions.get("TemporalActivityRetriesExhausted")).toContain(
+      'exported_namespace=~"prod|beta"',
+    );
+    expect(expressions.get("TemporalActivityRetriesExhausted")).not.toContain(
       'namespace="default"',
     );
+    // The retired drain namespace is empty, so watching it is watching nothing.
+    for (const alert of [
+      "TemporalWorkflowTaskFailing",
+      "TemporalWorkflowNondeterministic",
+    ]) {
+      expect(expressions.get(alert), alert).toContain(
+        'exported_namespace=~"prod|beta"',
+      );
+    }
+    // Tasks aging on a queue nobody polls — the shape of the outage every
+    // other rule missed, because pollers were healthy the whole time.
+    const stalled = expressions.get("TemporalWorkflowPlaneStalled");
+    expect(stalled).toContain("approximate_backlog_age_seconds");
+    expect(stalled).toContain('exported_namespace=~"prod|beta"');
+    expect(stalled).toContain("> 900");
+    // Age, not count: tombstoned tasks hold a non-zero count at age zero.
+    expect(stalled).not.toContain("approximate_backlog_count");
   });
 
   test("excludes intentional warm-morning preheat skips", () => {
@@ -130,14 +152,22 @@ describe("Temporal workflow outcome rules", () => {
           expression.includes("approximate_backlog_count"),
       ),
     ).toBe(true);
+    // The Temporal server sanitizes its metric tag values, so a hyphenated
+    // queue is published as `repo_automation` / `monorepo_workflows`. These
+    // assertions were previously inverted, which pinned a selector that
+    // matched no series: the backlog rule was silent for all seven hyphenated
+    // queues, including monorepo-workflows, throughout a fifteen-hour outage.
     expect(backlogExpressions).toContain(
-      'max(approximate_backlog_count{namespace="temporal",taskqueue="repo-automation",task_type=~"Workflow|Activity"}) > 0',
+      'max(approximate_backlog_count{namespace="temporal",taskqueue="repo_automation",task_type=~"Workflow|Activity"}) > 0',
     );
     expect(backlogExpressions).toContain(
-      'max(approximate_backlog_count{namespace="temporal",taskqueue="monorepo-workflows",task_type=~"Workflow"}) > 0',
+      'max(approximate_backlog_count{namespace="temporal",taskqueue="monorepo_workflows",task_type=~"Workflow"}) > 0',
     );
     expect(backlogExpressions.join("\n")).not.toContain(
-      'taskqueue="repo_automation"',
+      'taskqueue="repo-automation"',
+    );
+    expect(backlogExpressions.join("\n")).not.toContain(
+      'taskqueue="monorepo-workflows"',
     );
 
     const workerMetricsDown = failuresGroup.rules.find(

--- a/packages/homelab/src/cdk8s/src/resources/scout/workflow-worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/workflow-worker.ts
@@ -100,7 +100,12 @@ export function createScoutWorkflowWorker(
           "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
         ),
         TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
-        TEMPORAL_NAMESPACE: EnvValue.fromValue("default"),
+        // The stage's own namespace, not the retired `default` drain. These
+        // workers do not render yet (see scoutWorkflowWorkerImageIsCapable),
+        // so this never shipped — but the next stable promotion would have
+        // deployed a worker whose only poller sat on a namespace the
+        // migration emptied, executing nothing.
+        TEMPORAL_NAMESPACE: EnvValue.fromValue(stage),
         TEMPORAL_WORKER_DEPLOYMENT_NAME: EnvValue.fromValue(
           `scout-${stage}-workflows`,
         ),

--- a/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/scout-temporal.test.ts
@@ -213,7 +213,8 @@ describe("Scout beta workflow candidate", () => {
           "temporal-temporal-server-service.temporal.svc.cluster.local:7233",
       },
       { name: "TEMPORAL_METRICS_ADDRESS", value: "0.0.0.0:9464" },
-      { name: "TEMPORAL_NAMESPACE", value: "default" },
+      // The stage's own namespace — never the retired `default` drain.
+      { name: "TEMPORAL_NAMESPACE", value: "beta" },
       {
         name: "TEMPORAL_WORKER_DEPLOYMENT_NAME",
         value: "scout-beta-workflows",


### PR DESCRIPTION
## Why

`createScoutWorkflowWorker` sets `TEMPORAL_NAMESPACE` to `default` — the namespace the migration retired and emptied:

```ts
TEMPORAL_NAMESPACE: EnvValue.fromValue("default"),
TEMPORAL_WORKER_DEPLOYMENT_NAME: EnvValue.fromValue(`scout-${stage}-workflows`),
```

A worker booted with that value polls a namespace where nothing is ever started again. It executes nothing while looking perfectly healthy.

**It has never shipped.** These workers only render once the stage's image build number exceeds `LAST_IMAGE_WITHOUT_WORKFLOW_WORKER` (12197), and the pins sit at exactly `2.0.0-12197` (beta) and `2.0.0-9495` (prod) — so `scoutWorkflowWorkerImageIsCapable` returns false and nothing synthesizes. This is latent, not live.

But the next Scout stable promotion would have deployed it, and the failure mode is identical to the outage that just cost fifteen hours: pollers up, queue served, zero execution, every existing alert quiet.

Nothing would have rejected the value at boot either. `parseScoutWorkflowWorkerConfiguration` types `namespace` as a bare `string`, unlike the central worker's `parseTemporalNamespace`, whose Zod enum would have thrown on `default`.

## What

Use the worker's own `stage` — already in scope, and already used for `ENVIRONMENT` and `TEMPORAL_WORKER_DEPLOYMENT_NAME` two lines away — and update the manifest assertion that pinned `default`.

## Verification

```
bunx turbo run typecheck test lint --filter=@homelab/cdk8s   # 679 passed, 13 skipped
```

Not observable at runtime: these deployments don't render at the current image pins, which is exactly why it had to be caught by reading rather than by watching. Non-visual change (deployment configuration), so no media.

Found while scoping the drain retirement — filed separately because it's an independent latent bug, not part of that cleanup.