### PR TITLE
fix(temporal): converge the workflow track on the build prod already runs

### DIFF
--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1459,7 +1459,7 @@
       "management": {
         "managed": false
       },
-      "value": "2.0.0-13000@sha256:7dcdccbfe094f8df5e0fa83809e7eeda3f6f43d2e70584b4a5207765fbb73dae",
+      "value": "2.0.0-13290@sha256:839757bc2a1ffbdca5111843e6e78ea41771b6c73d486111ee993e2fda762fb5",
       "notes": [
         "Stable central Workflow Worker image - promoted after a 24-hour clean soak",
         "not managed by renovate"

--- a/scripts/pin-candidates-state.json
+++ b/scripts/pin-candidates-state.json
@@ -82,9 +82,9 @@
       "buildNumber": 13290
     },
     "shepherdjerred/temporal-worker/workflows/stable": {
-      "version": "2.0.0-13000",
-      "digest": "sha256:7dcdccbfe094f8df5e0fa83809e7eeda3f6f43d2e70584b4a5207765fbb73dae",
-      "buildNumber": 13000
+      "version": "2.0.0-13290",
+      "digest": "sha256:839757bc2a1ffbdca5111843e6e78ea41771b6c73d486111ee993e2fda762fb5",
+      "buildNumber": 13290
     },
     "shepherdjerred/trmnl-dashboard": {
       "version": "2.0.0-13301",


### PR DESCRIPTION
## Why

Routing and configuration disagree, and the gap is load-bearing.

prod's `monorepo-central-workflows` current version is `f23505a7` (image `2.0.0-13290`) — set during incident recovery because it was the only build reporting healthy pollers. The `stable` pin still claims `2.0.0-13000`, whose baked `GIT_SHA` is `3f9be51c`:

| pod | image | baked `GIT_SHA` | serves prod's current version? |
|---|---|---|---|
| `workflows-stable` | `2.0.0-13000` | `3f9be51c` | **no** |
| `workflows-candidate` | `2.0.0-13290` | `f23505a7` | yes |

Two consequences:

- **prod has no poller redundancy.** Its workflow execution depends on the single candidate pod. The stable pod runs a different build and contributes nothing to the current version — no margin against exactly the failure that took prod down twice on 2026-08-31.
- **CI is frozen.** `centralWorkflowPinTargets` only advances the candidate while the two pins are equal, so no workflow image has advanced since #2589.

**The ramp tooling cannot fix this state.** `worker-deployment start` refuses with `"Candidate is already the current version"` (f23505a7 is already current), and `promote` requires an active 100% ramp that doesn't exist. What remains is exactly the catalog half of a promotion — `prepareStablePinPromotion` sets `stable.value = candidate.value` — so that's what this does.

**On the skipped soak:** it has effectively already happened, in the least ceremonial way possible. `2.0.0-13290` is the image every activity worker and the gateway have run since 06:15Z, it has served beta since 22:30Z, and it has served prod's entire workflow plane since the second recovery. This PR makes the configuration match what production has been running for hours.

## What

Point `workflows/stable` at `2.0.0-13290`, converging it with candidate. The stable deployment rolls onto the same build, giving prod's current version a second poller, and CI is free to advance the track again on the next main build.

4-line diff across the catalog and its state mirror.

## Verification

```
bunx turbo run typecheck test --filter=@shepherdjerred/version-catalog --filter=@homelab/cdk8s
  # 679 + 4 passed
bunx vitest run .buildkite/scripts/pin-candidate-images.test.ts \
                .buildkite/scripts/temporal-candidate-admission.test.ts
  # 66 passed
```

That second suite is the one that matters — it includes the cases gating publication on pin convergence (`"does not publish a Workflow pin while stable and candidate diverge"`, `"retains a central Workflow candidate until its pin converges with stable"`).

Post-deploy check that prod regains redundancy:

```bash
toolkit prom query 'sum by (worker_build_id) (temporal_worker_num_pollers{
  temporal_namespace="prod",task_queue="monorepo-workflows",poller_type="workflow_task"})'
# expect f23505a7 with >= 2
```

Non-visual change (image pin), so no media.