### PR TITLE
fix(scout-for-lol): let the Temporal runtime be reclaimed after it shuts down

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.test.ts
@@ -1,6 +1,8 @@
+import { IllegalStateError } from "@temporalio/common";
 import { describe, expect, test } from "vitest";
 import {
   discardPartialRuntime,
+  isRuntimeAlreadyInstalled,
   reconnectDelayMs,
 } from "#src/temporal/connected-runtime.ts";
 
@@ -171,5 +173,42 @@ describe("reconnectDelayMs", () => {
     expect(reconnectDelayMs(5)).toBe(60_000);
     expect(reconnectDelayMs(50)).toBe(60_000);
     expect(reconnectDelayMs(334)).toBe(60_000);
+  });
+});
+
+describe("isRuntimeAlreadyInstalled", () => {
+  // The two messages the SDK actually raises, from
+  // @temporalio/worker/lib/runtime.js Runtime.install().
+  test("recognises a singleton installed by install()", () => {
+    expect(
+      isRuntimeAlreadyInstalled(
+        new IllegalStateError("Runtime singleton has already been installed"),
+      ),
+    ).toBe(true);
+  });
+
+  test("recognises a singleton the SDK built for an earlier Worker", () => {
+    expect(
+      isRuntimeAlreadyInstalled(
+        new IllegalStateError(
+          "Runtime singleton has already been instantiated. Did you start a Worker before calling `install`?",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not swallow an unrelated IllegalStateError", () => {
+    expect(
+      isRuntimeAlreadyInstalled(
+        new IllegalStateError("Not running. Current state: DRAINING"),
+      ),
+    ).toBe(false);
+  });
+
+  test("does not swallow an ordinary error", () => {
+    expect(isRuntimeAlreadyInstalled(new Error("connection refused"))).toBe(
+      false,
+    );
+    expect(isRuntimeAlreadyInstalled(undefined)).toBe(false);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
@@ -1,4 +1,5 @@
 import { Client, Connection } from "@temporalio/client";
+import { IllegalStateError } from "@temporalio/common";
 import {
   DefaultLogger,
   NativeConnection,
@@ -43,10 +44,43 @@ export function reconnectDelayMs(consecutiveFailures: number): number {
   const exponent = Math.max(0, consecutiveFailures - 1);
   return Math.min(RECONNECT_DELAY_MS * 2 ** exponent, RECONNECT_DELAY_MAX_MS);
 }
-let runtimeInstalled = false;
-
+/**
+ * Install the SDK Runtime, tolerating the case where it is already installed.
+ *
+ * This deliberately does not memoise. `Runtime.shutdown()` deletes the
+ * singleton when it goes idle, and the SDK then silently rebuilds a *default*
+ * Runtime on the next `Worker.create` — losing the logger that forwards SDK
+ * output into our logger and the telemetry filter below. A one-shot boolean
+ * made that unrecoverable: it reported "already installed" for a Runtime that
+ * no longer existed. Re-attempting is the only way to reclaim it, and
+ * `install()` throws only while a singleton is actually present.
+ */
 function installTemporalRuntime(): void {
-  if (runtimeInstalled) return;
+  try {
+    installConfiguredRuntime();
+  } catch (error: unknown) {
+    // Narrow on purpose: an already-present singleton is the one benign
+    // outcome. Anything else is a real failure and must not be swallowed.
+    if (isRuntimeAlreadyInstalled(error)) return;
+    throw error;
+  }
+}
+
+/**
+ * The SDK raises `IllegalStateError` for two shapes of "a singleton is already
+ * here" — one for `install()` and one for a Runtime the SDK built itself on a
+ * prior `Worker.create` — and reuses the same class for unrelated faults.
+ * Match the message so a genuine failure still propagates.
+ */
+export function isRuntimeAlreadyInstalled(error: unknown): boolean {
+  return (
+    error instanceof IllegalStateError &&
+    (error.message.includes("already been installed") ||
+      error.message.includes("already been instantiated"))
+  );
+}
+
+function installConfiguredRuntime(): void {
   Runtime.install({
     logger: new DefaultLogger("INFO", (entry) => {
       const fields = {
@@ -65,7 +99,6 @@ function installTemporalRuntime(): void {
       },
     },
   });
-  runtimeInstalled = true;
 }
 
 type RealtimeActivities = Pick<


### PR DESCRIPTION
## Why

`installTemporalRuntime` memoised on a module-level boolean:

```ts
let runtimeInstalled = false;
function installTemporalRuntime(): void {
  if (runtimeInstalled) return;
  Runtime.install({ /* logger + telemetry filter */ });
  runtimeInstalled = true;
}
```

So it installed the configured Runtime once per process and reported success forever after. But the SDK deletes its own singleton when the Runtime goes idle — `@temporalio/worker/lib/runtime.js`:

```js
async shutdown() {
  if (Runtime._instance === this) delete Runtime._instance;
```

and the next `Worker.create` then silently builds a **default** Runtime instead.

Everything that configuration carries is lost at that point: the `DefaultLogger` that forwards SDK output into our logger with sanitized fields, and the telemetry filter. The process keeps running and looks healthy — it just stops reporting the way it was set up to. The boolean made it unrecoverable, because it answered "already installed" for a Runtime that no longer existed.

Same class of bug as the reconnect loop it sits beside: state tracked in a local flag rather than read from the thing it describes.

## What

Drop the boolean and attempt the install every time, swallowing only the "already present" `IllegalStateError`. `install()` throws *exclusively* while a singleton actually exists:

```js
static install(options) {
  if (this._instance !== undefined) {
    if (this.instantiator === 'install')  throw new IllegalStateError('Runtime singleton has already been installed');
    if (this.instantiator === 'instance') throw new IllegalStateError('Runtime singleton has already been instantiated. …');
  }
  return this.create(options, 'install');
}
```

so this is idempotent when one is installed, and reclaims the configured Runtime when the SDK has torn one down.

**The catch is deliberately narrow.** The SDK reuses `IllegalStateError` for unrelated faults — `"Not running. Current state: DRAINING"` is one this codebase already hits — so `isRuntimeAlreadyInstalled` matches on the message and lets everything else propagate rather than turning a real failure into a silent no-op.

## Verification

```
bunx turbo run typecheck lint --filter=@scout-for-lol/backend        # 0 errors
vitest run src/temporal/connected-runtime.test.ts                    # 11 passed
```

4 of those are new, asserting the predicate against the **exact** strings in `@temporalio/worker/lib/runtime.js` rather than paraphrases, plus two errors that must *not* be swallowed (a `DRAINING` `IllegalStateError` and an ordinary `Error`).

Not directly observable at runtime — it only manifests after the SDK Runtime goes idle and is rebuilt, which is exactly why it survived unnoticed. Non-visual change (backend lifecycle), so no media.