### PR TITLE
docs(temporal): put the migration audit where it can actually pass

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
@@ -120,13 +120,29 @@ finish the migration.
 ## Retire the drain namespace
 
 After the last `default` execution closes, wait the additional 30-day retention
-window. Re-read live state immediately before cleanup and run the migration
-audit with the recorded cutover timestamp while the source inventory still
-exists. The audit must show schedule parity, no active source schedules, no
-`default` workflow starts after cutover, and no remaining `default` executions.
-This is the final `migrate:namespaces -- audit` run; it must happen before the
-source schedules are deleted because the command inventories its source
-schedules on every invocation.
+window, then re-read live state immediately before cleanup.
+
+Schedule parity is **not** verifiable at this point, and expecting it here is a
+trap. `migrate:namespaces -- audit` compares each target against its source
+byte for byte, but the gateway's first reconciliation after cutover adds
+`Environment`, `Domain`, `Trigger`, and `ReleaseCommit` search attributes plus
+static summaries to every target. The frozen sources never had those, so the
+comparison reports `does not match source` for a migration that was correct.
+Parity is checked once, immediately after `cutover --confirm` and **before**
+the gateway is restarted; see `packages/temporal/README.md`.
+
+What must still be confirmed before deleting anything is quiescence, and the
+source inventory has to exist to confirm it — the command re-inventories its
+sources on every invocation, so it is vacuous rather than passing once the
+sources are gone:
+
+- every source schedule is paused;
+- no `default` workflow starts after the cutover timestamp; and
+- no remaining `default` executions.
+
+That paused check is the only guard in the system against deleting a live
+schedule — `schedule delete` has none of its own — so run it immediately
+before the deletions and let nothing pause or unpause in between.
 
 Only after those checks pass, delete every paused source schedule from the
 drain namespace. List the schedules first, then delete each exact ID; do not

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -36,8 +36,7 @@ central queues remain `prod` plus the temporary `default` drain.
 | `glitter-corpus`  | `glitter-corpus`        |                    1 |
 | `glitter-context` | `glitter-context`       |                    1 |
 | `maintenance`     | `maintenance`           |                    1 |
-| `workflows`       | `workflows`             |                 none |
-| `legacy`          | `default` drain         |                    1 |
+| `workflows`       | `monorepo-workflows`    |                 none |
 
 The production manifests land in layers. In the Glitter layer, the existing
 legacy core and agent Deployments remain in place while the combined Glitter
@@ -105,8 +104,27 @@ TEMPORAL_ADDRESS=<private-temporal-host>:443 TEMPORAL_TLS=true TEMPORAL_NAMESPAC
   bun run migrate:namespaces -- cutover --confirm
 ```
 
-Record the cutover timestamp and use it for the final audit. Rollback is
-allowed only before a target workflow starts; after that, recover forward.
+Record the cutover timestamp. **Run `migrate:namespaces -- audit` with it
+before restarting the gateway**, not later:
+
+```bash
+TEMPORAL_ADDRESS=<private-temporal-host>:443 TEMPORAL_TLS=true TEMPORAL_NAMESPACE=prod \
+  bun run migrate:namespaces -- audit --cutover-at <recorded-timestamp>
+```
+
+The audit compares each target against its source byte for byte. The gateway's
+first reconciliation adds `Environment`, `Domain`, `Trigger`, and
+`ReleaseCommit` search attributes plus static summaries to every target, which
+the frozen sources never had, so that comparison can never match again once the
+gateway has run. Auditing after the restart reports `does not match source` for
+a migration that was in fact correct.
+
+After the restart, the remaining invariants are still checkable directly:
+every source paused, every target carrying the recorded `cutoverAt`, and no
+executions or new starts in the legacy namespace.
+
+Rollback is allowed only before a target workflow starts; after that, recover
+forward.
 
 ## Documentation
 


### PR DESCRIPTION
## Why

Both runbooks tell an operator to run `migrate:namespaces -- audit` at drain retirement, 30+ days after cutover. **That audit can never pass at that point**, and following the instruction produces `does not match source` for a migration that was correct.

The audit compares each target schedule against its source byte for byte. The gateway's first reconciliation after cutover adds `Environment`, `Domain`, `Trigger`, and `ReleaseCommit` search attributes plus static summaries to every target — which the frozen sources never had:

```
source: {...,"searchAttributes":{},"typedSearchAttributes":[]}
target: {...,"searchAttributes":{"Environment":["prod"],"Domain":["infra"],
         "Trigger":["schedule"],"ReleaseCommit":["f23505a7…"]},…}
```

Parity is therefore only checkable between `cutover --confirm` and the gateway restart. The restart is itself a required cutover step, so **the documented order guarantees the audit runs too late.**

Observed live during the 2026-08-31 cutover: the audit failed on `Target prod/bugsink-housekeeping does not match source` purely because of reconciliation-added attributes. I did not weaken the check to make it pass — the check is right, the instruction was in the wrong place.

Two smaller README errors found alongside:

- a `legacy` role row that doesn't exist. `WorkerRoleSchema` has no such member, and `temporal-audit-tooling.test.ts` actively asserts no `legacy-worker` resources synthesize.
- the `workflows` role's queue given as `workflows` rather than `monorepo-workflows`.

## What

- **README:** run the audit immediately after cutover and *before* the gateway restart, with the command and the reason. State which invariants remain checkable afterwards (sources paused, targets carrying `cutoverAt`, no executions or new starts in the legacy namespace).
- **Retirement runbook:** stop asking for parity there. Keep the checks that do hold *and* still need the source inventory — every source paused, no starts after cutover, no remaining executions — and record that the paused check is the only guard against deleting a live schedule, since `schedule delete` has none of its own.
- Drop the `legacy` row; correct the `workflows` queue name.

## Verification

```
bunx markdownlint-cli2 packages/temporal/README.md \
  packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md   # 0 issues
```

Role and queue names checked against `packages/temporal/src/shared/worker-role.ts` and `shared/task-queues.ts` rather than assumed.

Documentation only, no behavior change — so no media. The wiki pages render from the same markdown; this edits prose and a table row, with no new components or layout.