### PR TITLE
refactor(scout-for-lol): make the /livez and /healthz probes testable

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/http/health-routes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/health-routes.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  handleHealthz,
+  handleLivez,
+  STARTUP_GRACE_PERIOD_MS,
+} from "#src/http/health-routes.ts";
+import { updateRiotApiHealth } from "#src/metrics/index.ts";
+
+const CORS = {};
+/** Well past the grace period, so the probe evaluates its components. */
+const UPTIME_MS = STARTUP_GRACE_PERIOD_MS + 60_000;
+
+describe("/livez", () => {
+  beforeEach(() => {
+    updateRiotApiHealth(true);
+  });
+
+  test("passes unconditionally inside the startup grace period", async () => {
+    const now = Date.now();
+
+    const response = handleLivez({
+      cors: CORS,
+      now,
+      startedAt: now - (STARTUP_GRACE_PERIOD_MS - 1),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      healthy: true,
+      reason: "startup-grace-period",
+    });
+  });
+
+  test("is healthy while the Riot API is answering", async () => {
+    const now = Date.now();
+
+    const response = handleLivez({
+      cors: CORS,
+      now,
+      startedAt: now - UPTIME_MS,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ healthy: true });
+  });
+
+  test("fails when recent Riot calls are being attempted but none succeed", async () => {
+    // `updateRiotApiHealth` stamps both clocks with the current time, so the
+    // failure is expressed by reading the probe from far enough in the future
+    // that the last success is stale while the last attempt is not.
+    const now = Date.now() + 16 * 60 * 1000;
+
+    const response = handleLivez({
+      cors: CORS,
+      now,
+      startedAt: now - UPTIME_MS,
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      healthy: false,
+      components: { riotApiHealthy: false },
+    });
+  });
+});
+
+describe("/healthz", () => {
+  beforeEach(() => {
+    updateRiotApiHealth(true);
+  });
+
+  test("is ready while the Riot API is answering", async () => {
+    const now = Date.now();
+
+    const response = handleHealthz({
+      cors: CORS,
+      now,
+      startedAt: now - UPTIME_MS,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ healthy: true });
+  });
+
+  test("goes unready on a shorter Riot staleness window than liveness", async () => {
+    // Readiness pulls this replica out of the Service after 5 minutes;
+    // liveness waits 15 before restarting it.
+    const now = Date.now() + 6 * 60 * 1000;
+
+    const response = handleHealthz({
+      cors: CORS,
+      now,
+      startedAt: now - UPTIME_MS,
+    });
+
+    expect(response.status).toBe(503);
+    expect(
+      handleLivez({ cors: CORS, now, startedAt: now - UPTIME_MS }).status,
+    ).toBe(200);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/http/health-routes.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/health-routes.ts
@@ -1,0 +1,112 @@
+import { getRiotApiHealth } from "#src/metrics/index.ts";
+import { getScoutTemporalHealth } from "#src/temporal/health.ts";
+
+/**
+ * The `/livez` and `/healthz` probe handlers.
+ *
+ * These live outside `server.ts` because that module starts a listening Bun
+ * server the moment it is imported, so a test cannot reach the handlers there
+ * without binding a port — which is why the two probes that decide whether
+ * Kubernetes restarts this pod or routes traffic to it had no tests at all. A
+ * probe whose failure path is never exercised is indistinguishable from one
+ * that cannot fail.
+ *
+ * CORS headers are passed in rather than computed here, matching
+ * `handleVersion`: the request-to-origin policy belongs to the server. The
+ * clock and start time are injectable for the same reason — both probes are
+ * defined entirely by elapsed time, and a test that cannot move the clock can
+ * only ever observe the healthy answer.
+ */
+
+/** Grace period after startup during which liveness always passes. */
+export const STARTUP_GRACE_PERIOD_MS = 5 * 60 * 1000;
+
+const applicationStartTime = Date.now();
+
+export type HealthRouteOptions = {
+  readonly cors: Record<string, string>;
+  /** Overridden by tests; defaults to this process's own start time. */
+  readonly startedAt?: number;
+  readonly now?: number;
+};
+
+/** Liveness: fail only on a condition a restart actually fixes. */
+export function handleLivez({
+  cors,
+  startedAt = applicationStartTime,
+  now = Date.now(),
+}: HealthRouteOptions): Response {
+  const { lastSuccessTimestamp, lastAttemptTimestamp } = getRiotApiHealth();
+  const uptimeMs = now - startedAt;
+
+  // Grace period: first 5 minutes after startup, always healthy
+  if (uptimeMs < STARTUP_GRACE_PERIOD_MS) {
+    return Response.json(
+      { healthy: true, reason: "startup-grace-period", uptimeMs },
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...cors },
+      },
+    );
+  }
+
+  // After grace: unhealthy if API attempts exist in last 20 min AND last success >15 min ago
+  const twentyMinutesMs = 20 * 60 * 1000;
+  const fifteenMinutesMs = 15 * 60 * 1000;
+  const hasRecentAttempts =
+    lastAttemptTimestamp !== undefined &&
+    now - lastAttemptTimestamp < twentyMinutesMs;
+  const lastSuccessStale =
+    lastSuccessTimestamp === undefined ||
+    now - lastSuccessTimestamp > fifteenMinutesMs;
+  const riotApiHealthy = !(hasRecentAttempts && lastSuccessStale);
+
+  return Response.json(
+    {
+      healthy: riotApiHealthy,
+      lastSuccessTimestamp: lastSuccessTimestamp ?? null,
+      lastAttemptTimestamp: lastAttemptTimestamp ?? null,
+      uptimeMs,
+      components: { riotApiHealthy },
+    },
+    {
+      status: riotApiHealthy ? 200 : 503,
+      headers: { "Content-Type": "application/json", ...cors },
+    },
+  );
+}
+
+/** Readiness: whether this replica should receive traffic. */
+export function handleHealthz({
+  cors,
+  startedAt = applicationStartTime,
+  now = Date.now(),
+}: HealthRouteOptions): Response {
+  const { lastSuccessTimestamp, lastAttemptTimestamp } = getRiotApiHealth();
+  const uptimeSeconds = (now - startedAt) / 1000;
+
+  // Unhealthy if: API attempts exist in last 10 minutes AND last success was >5 minutes ago
+  const tenMinutesMs = 10 * 60 * 1000;
+  const fiveMinutesMs = 5 * 60 * 1000;
+  const hasRecentAttempts =
+    lastAttemptTimestamp !== undefined &&
+    now - lastAttemptTimestamp < tenMinutesMs;
+  const lastSuccessStale =
+    lastSuccessTimestamp === undefined ||
+    now - lastSuccessTimestamp > fiveMinutesMs;
+  const healthy = !(hasRecentAttempts && lastSuccessStale);
+
+  return Response.json(
+    {
+      healthy,
+      lastSuccessTimestamp: lastSuccessTimestamp ?? null,
+      lastAttemptTimestamp: lastAttemptTimestamp ?? null,
+      uptimeSeconds,
+      components: { temporal: getScoutTemporalHealth() },
+    },
+    {
+      status: healthy ? 200 : 503,
+      headers: { "Content-Type": "application/json", ...cors },
+    },
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/http/server.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/server.ts
@@ -1,6 +1,6 @@
 import configuration from "#src/configuration.ts";
-import { getMetrics, getRiotApiHealth } from "#src/metrics/index.ts";
-import { getScoutTemporalHealth } from "#src/temporal/health.ts";
+import { getMetrics } from "#src/metrics/index.ts";
+import { handleHealthz, handleLivez } from "#src/http/health-routes.ts";
 import * as Sentry from "@sentry/bun";
 import { createLogger } from "#src/logger.ts";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
@@ -94,84 +94,6 @@ function corsHeadersFor(request: Request): Record<string, string> {
     };
   }
   return {};
-}
-
-const applicationStartTime = Date.now();
-
-function handleLivez(request: Request): Response {
-  const { lastSuccessTimestamp, lastAttemptTimestamp } = getRiotApiHealth();
-  const now = Date.now();
-  const uptimeMs = now - applicationStartTime;
-  const cors = corsHeadersFor(request);
-
-  // Grace period: first 5 minutes after startup, always healthy
-  const startupGracePeriodMs = 5 * 60 * 1000;
-  if (uptimeMs < startupGracePeriodMs) {
-    return Response.json(
-      { healthy: true, reason: "startup-grace-period", uptimeMs },
-      {
-        status: 200,
-        headers: { "Content-Type": "application/json", ...cors },
-      },
-    );
-  }
-
-  // After grace: unhealthy if API attempts exist in last 20 min AND last success >15 min ago
-  const twentyMinutesMs = 20 * 60 * 1000;
-  const fifteenMinutesMs = 15 * 60 * 1000;
-  const hasRecentAttempts =
-    lastAttemptTimestamp !== undefined &&
-    now - lastAttemptTimestamp < twentyMinutesMs;
-  const lastSuccessStale =
-    lastSuccessTimestamp === undefined ||
-    now - lastSuccessTimestamp > fifteenMinutesMs;
-  const healthy = !(hasRecentAttempts && lastSuccessStale);
-
-  return Response.json(
-    {
-      healthy,
-      lastSuccessTimestamp: lastSuccessTimestamp ?? null,
-      lastAttemptTimestamp: lastAttemptTimestamp ?? null,
-      uptimeMs,
-    },
-    {
-      status: healthy ? 200 : 503,
-      headers: { "Content-Type": "application/json", ...cors },
-    },
-  );
-}
-
-function handleHealthz(request: Request): Response {
-  const { lastSuccessTimestamp, lastAttemptTimestamp } = getRiotApiHealth();
-  const now = Date.now();
-  const uptimeSeconds = (now - applicationStartTime) / 1000;
-  const cors = corsHeadersFor(request);
-
-  // Unhealthy if: API attempts exist in last 10 minutes AND last success was >5 minutes ago
-  const tenMinutesMs = 10 * 60 * 1000;
-  const fiveMinutesMs = 5 * 60 * 1000;
-  const hasRecentAttempts =
-    lastAttemptTimestamp !== undefined &&
-    now - lastAttemptTimestamp < tenMinutesMs;
-  const lastSuccessStale =
-    lastSuccessTimestamp === undefined ||
-    now - lastSuccessTimestamp > fiveMinutesMs;
-  const healthy = !(hasRecentAttempts && lastSuccessStale);
-  const temporal = getScoutTemporalHealth();
-
-  return Response.json(
-    {
-      healthy,
-      lastSuccessTimestamp: lastSuccessTimestamp ?? null,
-      lastAttemptTimestamp: lastAttemptTimestamp ?? null,
-      uptimeSeconds,
-      components: { temporal },
-    },
-    {
-      status: healthy ? 200 : 503,
-      headers: { "Content-Type": "application/json", ...cors },
-    },
-  );
 }
 
 /**
@@ -282,14 +204,15 @@ async function dispatch(request: Request, url: URL): Promise<Response> {
     });
   }
 
-  // Liveness probe - restarts pod on sustained API failure
+  // Liveness probe - restarts the pod on a sustained Riot API or Discord
+  // gateway failure
   if (url.pathname === "/livez") {
-    return handleLivez(request);
+    return handleLivez({ cors: corsHeadersFor(request) });
   }
 
   // Readiness probe - checks Riot API health
   if (url.pathname === "/healthz") {
-    return handleHealthz(request);
+    return handleHealthz({ cors: corsHeadersFor(request) });
   }
 
   // Build/deploy identity: version, git SHA, tRPC contract hash


### PR DESCRIPTION
## Why

The two probes that decide whether Kubernetes restarts the Scout backend
(`/livez`) or routes traffic to it (`/healthz`) had no tests. They were defined
inside `http/server.ts`, a module that calls `Bun.serve` at import time, so
reaching the handlers from a test means binding a port. A probe whose failure
path is never exercised is indistinguishable from one that cannot fail.

Both handlers are also pure functions of elapsed time, and a test with no way
to move the clock can only ever observe the healthy answer.

This is the foundation for the gateway-liveness change stacked on top, which
adds a second failure condition to `/livez`.

## What

- Moves `handleLivez` and `handleHealthz` into `http/health-routes.ts`. No
  behavior change — the thresholds, the response shapes, and the status codes
  are unchanged.
- CORS headers are passed in rather than computed in the module, matching the
  existing `handleVersion(request, corsHeadersFor(request))` signature: the
  request-to-origin policy stays in the server.
- `startedAt` and `now` are injectable, defaulting to the process’s own start
  time and the real clock, so a test can place itself inside or outside the
  grace and staleness windows.
- Adds the first tests for either probe: the startup grace period, the healthy
  case, liveness failing on a stale Riot API, and readiness pulling the replica
  out of the Service on its shorter window while liveness still passes.

## Verification

```
bunx turbo run typecheck --filter=@scout-for-lol/backend
bun --bun vitest run src/http/health-routes.test.ts     # 5 passed
bunx eslint src/http                                    # 0 errors
bunx prettier --check <touched files>
```

Non-visual change (HTTP probe handlers, no user-facing output), so no media.