### PR TITLE
fix(scout-for-lol): detect and recover a silently dead Discord gateway

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -654,6 +654,33 @@ module owns command dispatch only. It previously owned the event too and
 early-returned on anything that was not a chat-input command, which silently
 dropped every message component.
 
+**Gateway liveness is the heartbeat clock, not a boolean.** On 2026-09-01 beta
+answered every slash command with "The application did not respond" for 34
+minutes while looking healthy: the pod ran, REST kept working (match polling
+and the per-minute guild command reconcile both succeeded),
+`discord_connection_status` read 1, and no line was logged. Discord was
+dispatching `INTERACTION_CREATE` — a second gateway session on the same token
+received it — but the deployed shard had gone silent, and only a restart
+recovered it. Two things now prevent a repeat:
+
+- `discord/bootstrap.ts` listens to `Events.Shard*`. It previously listened for
+  `"disconnect"` and `"reconnecting"`, which are discord.js **v12** client
+  events — in v14 they belong to the sharding manager's `Shard`. `Client#on`
+  accepts any string, so they compiled, registered, counted as installed by the
+  bootstrap test, and could never fire. `DISCORD_EVENT_NAMES` holds `Events`
+  members so a non-event is a type error, and `bootstrap.test.ts` checks each
+  name against the enum.
+- `discord/gateway-health.ts` tracks the newest
+  `WebSocketShard#lastPingTimestamp` and `/livez` fails when it is more than
+  three heartbeat intervals stale, so Kubernetes restarts the pod. Staleness
+  alone is the verdict — an ordinary reconnect passes through `disconnected`
+  for seconds and must not restart anything, while a reconnect that never
+  completes stops the clock and trips the same threshold. `dev:web
+--no-discord-gateway` and `NODE_ENV=test` mark the gateway `disabled` and are
+  exempt. `discord_gateway_heartbeat_age_seconds` is the alertable form;
+  `discord_latency_ms` is not, because a frozen shard reports its last healthy
+  latency forever.
+
 Definitions are collected in `packages/backend/src/discord/commands/definitions.ts`
 and registered with a full global `applicationCommands` replacement in
 `discord/rest.ts`. After the gateway connects, every guild in the client's

--- a/packages/scout-for-lol/packages/backend/src/discord/bootstrap.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { Client, GatewayIntentBits } from "discord.js";
+import { Client, Events, GatewayIntentBits, ShardEvents } from "discord.js";
 import {
   DISCORD_EVENT_NAMES,
   registerDiscordEventHandlers,
@@ -21,6 +21,41 @@ function listenerCounts(client: Client): Record<string, number> {
 }
 
 describe("discord bootstrap", () => {
+  test("every handled event is a real Client event", () => {
+    // The listener-count assertions below cannot catch a misspelled or
+    // wrong-class event: `Client` is an `AsyncEventEmitter` whose key type
+    // accepts any string, so `client.on("disconnect", …)` compiles, registers,
+    // counts as installed — and never fires. That is exactly what happened:
+    // the list carried discord.js v12's `disconnect` and `reconnecting`, which
+    // in v14 belong to the sharding manager's `Shard`, so the beta bot lost
+    // its gateway for 34 minutes without logging a line or moving
+    // `discord_connection_status` off 1.
+    const clientEvents = new Set<string>(Object.values(Events));
+    const shardManagerEvents = new Set<string>(Object.values(ShardEvents));
+
+    for (const event of DISCORD_EVENT_NAMES) {
+      expect(clientEvents).toContain(event);
+    }
+    // `ShardEvents.Disconnect` and `ShardEvents.Reconnecting` collide by name
+    // with nothing on `Client`, which is why the mistake was invisible.
+    expect(shardManagerEvents).not.toContain(Events.ShardDisconnect);
+  });
+
+  test("reports gateway loss on the shard events discord.js actually emits", () => {
+    const client = newClient();
+    registerDiscordEventHandlers(client);
+
+    for (const event of [
+      Events.ShardDisconnect,
+      Events.ShardReconnecting,
+      Events.ShardError,
+      Events.ShardReady,
+      Events.ShardResume,
+    ]) {
+      expect(client.listenerCount(event)).toBeGreaterThan(0);
+    }
+  });
+
   test("installs exactly one handler for every gateway event the bot handles", () => {
     const client = newClient();
     const before = listenerCounts(client);

--- a/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
@@ -1,5 +1,5 @@
 import configuration from "#src/configuration.ts";
-import type { Client, Guild } from "discord.js";
+import { Events, type Client, type Guild } from "discord.js";
 import * as Sentry from "@sentry/bun";
 import { client } from "#src/discord/client.ts";
 import { handleInteractions } from "#src/discord/interactions.ts";
@@ -15,6 +15,12 @@ import {
   discordUsersGauge,
   discordLatency,
 } from "#src/metrics/index.ts";
+import { discordGatewayHeartbeatAge } from "#src/metrics/discord-gateway.ts";
+import {
+  getDiscordGatewayHealth,
+  recordDiscordGatewayHeartbeat,
+  setDiscordGatewayState,
+} from "#src/discord/gateway-health.ts";
 import { voiceManager } from "#src/voice/index.ts";
 import { createLogger } from "#src/logger.ts";
 import { addDynamicConfigRefreshListener } from "#src/config/dynamic.ts";
@@ -25,21 +31,48 @@ let removeDynamicConfigRefreshListener: (() => void) | undefined;
 let metricsInterval: ReturnType<typeof setInterval> | undefined;
 
 /**
+ * Clients that already carry an `interactionCreate` listener.
+ *
+ * Keyed by client rather than a module flag because `Client#destroy` leaves
+ * listeners attached: a flag reset on shutdown would double-register on the
+ * next start, and a flag left set would leave a second client with no
+ * interaction handling at all.
+ */
+const clientsWithInteractionsInstalled = new WeakSet<Client>();
+
+/** How often the gateway's heartbeat clock and cache gauges are sampled. */
+const GATEWAY_SAMPLE_INTERVAL_MS = 30_000;
+
+/**
  * Every gateway event this bot handles.
  *
  * Exported so the bootstrap test can assert that all of them are installed,
- * and installed *before* login — a fast gateway connection can emit `ready`
- * immediately, and a handler registered after that point never runs.
+ * and installed *before* login — a fast gateway connection can emit
+ * `clientReady` immediately, and a handler registered after that point never
+ * runs.
+ *
+ * These are `Events` members rather than string literals on purpose. The list
+ * used to carry `"disconnect"` and `"reconnecting"`, which are discord.js v12
+ * client events; in v14 they belong to `ShardEventTypes` on the sharding
+ * manager's `Shard`, not to `Client`. `Client#on` is an `AsyncEventEmitter`
+ * whose key type accepts any string, so both compiled, both were asserted as
+ * "installed" by the bootstrap test, and neither could ever fire — which is
+ * why a dead gateway produced no log line and left
+ * `discord_connection_status` reading 1. Naming the enum member makes an
+ * event that does not exist a type error.
  */
 export const DISCORD_EVENT_NAMES = [
-  "error",
-  "warn",
-  "debug",
-  "disconnect",
-  "reconnecting",
-  "ready",
-  "guildCreate",
-  "guildDelete",
+  Events.Error,
+  Events.Warn,
+  Events.Debug,
+  Events.ShardReady,
+  Events.ShardResume,
+  Events.ShardDisconnect,
+  Events.ShardReconnecting,
+  Events.ShardError,
+  Events.ClientReady,
+  Events.GuildCreate,
+  Events.GuildDelete,
 ] as const;
 
 async function registerConnectedGuildCommands(
@@ -72,44 +105,101 @@ async function handleNewGuild(guild: Guild): Promise<void> {
 }
 
 /**
+ * Copy the shards' heartbeat clock into the health state and its gauge.
+ *
+ * `WebSocketShard#lastPingTimestamp` is written only when Discord
+ * acknowledges a heartbeat, so its age is the one signal that separates a
+ * live gateway from a zombie one. `discord_latency_ms` carries the same
+ * information but only implicitly — a frozen connection freezes the reported
+ * latency on whatever value it last measured, which reads as a healthy number
+ * on every dashboard.
+ */
+function sampleGatewayHeartbeat(target: Client): void {
+  for (const shard of target.ws.shards.values()) {
+    recordDiscordGatewayHeartbeat(shard.lastPingTimestamp);
+  }
+  const { lastHeartbeatAckTimestamp } = getDiscordGatewayHealth();
+  if (lastHeartbeatAckTimestamp !== undefined) {
+    discordGatewayHeartbeatAge.set(
+      (Date.now() - lastHeartbeatAckTimestamp) / 1000,
+    );
+  }
+}
+
+/**
  * Install every gateway event handler on `target`.
  *
  * Takes the client as a parameter rather than closing over the module
  * singleton so the bootstrap test can exercise it against its own client.
  */
 export function registerDiscordEventHandlers(target: Client): void {
-  target.on("error", (error) => {
+  target.on(Events.Error, (error) => {
     logger.error("❌ Discord client error:", error);
     Sentry.captureException(error, {
       tags: {
         source: "discord-client",
       },
     });
-    discordConnectionStatus.set(0);
   });
 
-  target.on("warn", (warning) => {
+  target.on(Events.Warn, (warning) => {
     logger.warn("⚠️  Discord client warning:", warning);
   });
 
-  target.on("debug", (info) => {
+  target.on(Events.Debug, (info) => {
     // Only log debug info in dev environment to avoid spam
     if (configuration.environment === "dev") {
       logger.debug("🔍 Discord debug:", info);
     }
   });
 
-  target.on("disconnect", () => {
-    logger.info("🔌 Discord client disconnected");
+  // The shard events below are what actually report gateway state in v14, and
+  // losing the gateway is the difference between a bot that works and one that
+  // answers every interaction with "The application did not respond" — so each
+  // loss is logged at warn or above rather than left to a debug stream nobody
+  // reads.
+  target.on(Events.ShardReady, (shardId) => {
+    logger.info(`🔌 Discord shard ${shardId.toString()} ready`);
+    setDiscordGatewayState("connected");
+    discordConnectionStatus.set(1);
+  });
+
+  target.on(Events.ShardResume, (shardId, replayedEvents) => {
+    logger.info(
+      `🔄 Discord shard ${shardId.toString()} resumed (${replayedEvents.toString()} replayed events)`,
+    );
+    setDiscordGatewayState("connected");
+    discordConnectionStatus.set(1);
+  });
+
+  target.on(Events.ShardDisconnect, (closeEvent, shardId) => {
+    // `closeEvent.reason` is deprecated and always empty under @discordjs/ws,
+    // so the close code is the whole diagnosis.
+    const reason = `close ${closeEvent.code.toString()}`;
+    logger.warn(
+      `🔌 Discord shard ${shardId.toString()} disconnected: ${reason}`,
+    );
+    setDiscordGatewayState("disconnected", reason);
     discordConnectionStatus.set(0);
   });
 
-  target.on("reconnecting", () => {
-    logger.info("🔄 Discord client reconnecting");
+  target.on(Events.ShardReconnecting, (shardId) => {
+    logger.warn(`🔄 Discord shard ${shardId.toString()} reconnecting`);
+    setDiscordGatewayState("connecting");
     discordConnectionStatus.set(0);
   });
 
-  target.on("ready", (readyClient) => {
+  target.on(Events.ShardError, (error, shardId) => {
+    logger.error(`❌ Discord shard ${shardId.toString()} error:`, error);
+    Sentry.captureException(error, {
+      tags: { source: "discord-shard" },
+      extra: { shardId },
+    });
+    setDiscordGatewayState("disconnected", error.message);
+    discordConnectionStatus.set(0);
+  });
+
+  target.on(Events.ClientReady, (readyClient) => {
     logger.info(`✅ Discord bot ready! Logged in as ${readyClient.user.tag}`);
     logger.info(
       `🏢 Bot is in ${readyClient.guilds.cache.size.toString()} guilds`,
@@ -119,6 +209,7 @@ export function registerDiscordEventHandlers(target: Client): void {
     );
 
     // Update connection status metric
+    setDiscordGatewayState("connected");
     discordConnectionStatus.set(1);
 
     // Update guild and user count metrics
@@ -130,14 +221,21 @@ export function registerDiscordEventHandlers(target: Client): void {
     logger.info("🔊 Voice manager initialized");
 
     // Update metrics periodically
+    sampleGatewayHeartbeat(readyClient);
     metricsInterval ??= setInterval(() => {
       discordGuildsGauge.set(readyClient.guilds.cache.size);
       discordUsersGauge.set(readyClient.users.cache.size);
       discordLatency.set(readyClient.ws.ping);
-    }, 30_000); // Update every 30 seconds
+      sampleGatewayHeartbeat(readyClient);
+    }, GATEWAY_SAMPLE_INTERVAL_MS);
 
-    handleInteractions(readyClient);
-    logger.info("⚡ Discord command handler initialized");
+    // `clientReady` fires again after a full re-identify, and a second
+    // `interactionCreate` listener would run every command twice.
+    if (!clientsWithInteractionsInstalled.has(readyClient)) {
+      handleInteractions(readyClient);
+      clientsWithInteractionsInstalled.add(readyClient);
+      logger.info("⚡ Discord command handler initialized");
+    }
 
     removeDynamicConfigRefreshListener ??= addDynamicConfigRefreshListener(
       async () => {
@@ -149,14 +247,14 @@ export function registerDiscordEventHandlers(target: Client): void {
   });
 
   // Handle bot being added to new servers
-  target.on("guildCreate", (guild) => {
+  target.on(Events.GuildCreate, (guild) => {
     logger.info(`[Guild Create] Bot added to new server: ${guild.name}`);
     discordGuildsGauge.set(target.guilds.cache.size);
     void handleNewGuild(guild);
   });
 
   // Handle bot being removed from servers (kicked, banned, or guild deleted)
-  target.on("guildDelete", (guild) => {
+  target.on(Events.GuildDelete, (guild) => {
     logger.info(`[Guild Delete] Bot removed from server: ${guild.name}`);
     discordGuildsGauge.set(target.guilds.cache.size);
     void handleGuildDelete(guild);
@@ -171,6 +269,7 @@ export function stopDiscordGateway(target: Client = client): void {
     metricsInterval = undefined;
   }
   void target.destroy();
+  setDiscordGatewayState("disabled");
   discordConnectionStatus.set(0);
 }
 
@@ -178,17 +277,22 @@ export function stopDiscordGateway(target: Client = client): void {
  * Wire the gateway client up and connect it.
  *
  * Handlers are installed before login so a fast gateway connection cannot emit
- * `ready` before command reconciliation is listening for it.
+ * `clientReady` before command reconciliation is listening for it.
  */
 export async function startDiscordGateway(target: Client = client) {
   registerDiscordEventHandlers(target);
 
+  // A process that never logs in must not fail its liveness probe for a
+  // heartbeat it was never going to receive: `dev:web --no-discord-gateway`
+  // and the test runner both take these branches deliberately.
   if (Bun.env.NODE_ENV === "test") {
     logger.info("🧪 NODE_ENV=test — skipping Discord login");
+    setDiscordGatewayState("disabled");
     return;
   }
   if (!configuration.enableDiscordGateway) {
     logger.warn("⏭️  Discord gateway disabled — skipping Discord login");
+    setDiscordGatewayState("disabled");
     return;
   }
 

--- a/packages/scout-for-lol/packages/backend/src/discord/gateway-health.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/gateway-health.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  GATEWAY_HEARTBEAT_STALE_AFTER_MS,
+  evaluateDiscordGatewayLiveness,
+  getDiscordGatewayHealth,
+  recordDiscordGatewayHeartbeat,
+  resetDiscordGatewayHealthForTest,
+  setDiscordGatewayState,
+  type DiscordGatewayHealth,
+} from "#src/discord/gateway-health.ts";
+
+const NOW = 1_800_000_000_000;
+const GRACE_MS = 5 * 60 * 1000;
+
+function health(
+  overrides: Partial<DiscordGatewayHealth> = {},
+): DiscordGatewayHealth {
+  return {
+    state: "connected",
+    lastHeartbeatAckTimestamp: NOW,
+    lastCloseReason: undefined,
+    ...overrides,
+  };
+}
+
+describe("gateway heartbeat state", () => {
+  beforeEach(() => {
+    resetDiscordGatewayHealthForTest();
+  });
+
+  test("keeps the newest acknowledgement across shards", () => {
+    recordDiscordGatewayHeartbeat(NOW);
+    recordDiscordGatewayHeartbeat(NOW - 10_000);
+
+    expect(getDiscordGatewayHealth().lastHeartbeatAckTimestamp).toBe(NOW);
+  });
+
+  test("ignores discord.js's -1 placeholder for a shard that never beat", () => {
+    // WebSocketShard#lastPingTimestamp starts at -1. Treating that as a real
+    // timestamp would report an acknowledgement from 1970 and fail liveness
+    // the instant the grace period ended.
+    recordDiscordGatewayHeartbeat(-1);
+
+    expect(getDiscordGatewayHealth().lastHeartbeatAckTimestamp).toBeUndefined();
+  });
+
+  test("records the close reason alongside the state", () => {
+    setDiscordGatewayState("disconnected", "close 1006 ");
+
+    expect(getDiscordGatewayHealth()).toMatchObject({
+      state: "disconnected",
+      lastCloseReason: "close 1006 ",
+    });
+  });
+});
+
+describe("evaluateDiscordGatewayLiveness", () => {
+  test("passes when the gateway was never started", () => {
+    // `dev:web --no-discord-gateway` and NODE_ENV=test never log in, and must
+    // not be restarted for a heartbeat they were never going to receive.
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: 24 * 60 * 60 * 1000,
+        startupGraceMs: GRACE_MS,
+        health: health({
+          state: "disabled",
+          lastHeartbeatAckTimestamp: undefined,
+        }),
+      }),
+    ).toEqual({
+      live: true,
+      reason: "gateway-disabled",
+      heartbeatAgeMs: undefined,
+    });
+  });
+
+  test("passes while connecting inside the startup grace period", () => {
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: GRACE_MS - 1,
+        startupGraceMs: GRACE_MS,
+        health: health({
+          state: "connecting",
+          lastHeartbeatAckTimestamp: undefined,
+        }),
+      }),
+    ).toMatchObject({ live: true, reason: "startup-grace-period" });
+  });
+
+  test("fails when the grace period elapsed without a single acknowledgement", () => {
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: GRACE_MS,
+        startupGraceMs: GRACE_MS,
+        health: health({
+          state: "connecting",
+          lastHeartbeatAckTimestamp: undefined,
+        }),
+      }),
+    ).toMatchObject({ live: false, reason: "heartbeat-never-received" });
+  });
+
+  test("passes on a fresh acknowledgement", () => {
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: 60 * 60 * 1000,
+        startupGraceMs: GRACE_MS,
+        health: health({ lastHeartbeatAckTimestamp: NOW - 40_000 }),
+      }),
+    ).toEqual({
+      live: true,
+      reason: "heartbeat-fresh",
+      heartbeatAgeMs: 40_000,
+    });
+  });
+
+  test("fails once acknowledgements stop, even while the client reports connected", () => {
+    // This is the beta outage: shard state stayed `connected` and REST kept
+    // working while every interaction timed out.
+    const stale = GATEWAY_HEARTBEAT_STALE_AFTER_MS + 1;
+
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: 2 * 60 * 60 * 1000,
+        startupGraceMs: GRACE_MS,
+        health: health({ lastHeartbeatAckTimestamp: NOW - stale }),
+      }),
+    ).toEqual({
+      live: false,
+      reason: "heartbeat-stale",
+      heartbeatAgeMs: stale,
+    });
+  });
+
+  test("tolerates an ordinary reconnect that is still beating", () => {
+    // A shard passes through `disconnected` for a few seconds on every
+    // resume; restarting the pod for that would be worse than waiting.
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: 2 * 60 * 60 * 1000,
+        startupGraceMs: GRACE_MS,
+        health: health({
+          state: "disconnected",
+          lastHeartbeatAckTimestamp: NOW - 5000,
+        }),
+      }),
+    ).toMatchObject({ live: true, reason: "heartbeat-fresh" });
+  });
+
+  test("is not tripped by a clock that moved backwards", () => {
+    expect(
+      evaluateDiscordGatewayLiveness({
+        now: NOW,
+        uptimeMs: 2 * 60 * 60 * 1000,
+        startupGraceMs: GRACE_MS,
+        health: health({ lastHeartbeatAckTimestamp: NOW + 5000 }),
+      }),
+    ).toEqual({ live: true, reason: "heartbeat-fresh", heartbeatAgeMs: 0 });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/discord/gateway-health.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/gateway-health.ts
@@ -1,0 +1,145 @@
+/**
+ * Liveness state for the Discord gateway connection.
+ *
+ * ## Why this exists
+ *
+ * On 2026-09-01 the beta bot answered every slash command with "The
+ * application did not respond" for over half an hour while looking completely
+ * healthy: the pod was running, REST calls kept succeeding (match polling,
+ * guild command reconciliation), `discord_connection_status` read 1, and
+ * nothing was logged. Discord was dispatching `INTERACTION_CREATE` — a second
+ * gateway session opened with the same token received it — but the deployed
+ * client's shard had silently stopped receiving anything. Its heartbeat
+ * acknowledgements had stopped at 00:50 UTC, which was visible only as
+ * `discord_latency_ms` freezing on the exact same value forever, because
+ * discord.js only writes `WebSocketShard#ping` when an acknowledgement
+ * arrives.
+ *
+ * A zombie gateway is indistinguishable from a healthy one unless something
+ * watches the heartbeat clock, so that clock is what this module owns. The
+ * age of the newest acknowledgement — not a boolean the client reports about
+ * itself — is the liveness signal, and `/livez` fails on it so Kubernetes
+ * restarts the pod instead of leaving a bot that is up but deaf.
+ *
+ * Staleness alone is the verdict. Shard state is recorded for logs and
+ * metrics but deliberately does not gate liveness: an ordinary reconnect
+ * passes through `disconnected` for a few seconds, and restarting the pod for
+ * that would be worse than waiting. A reconnect that never completes stops
+ * advancing the heartbeat clock anyway, so it trips the same threshold.
+ */
+
+/** Discord's gateway heartbeat interval is 41.25s; this is three missed beats. */
+export const GATEWAY_HEARTBEAT_STALE_AFTER_MS = 3 * 60 * 1000;
+
+export type DiscordGatewayState =
+  "disabled" | "connecting" | "connected" | "disconnected";
+
+export type DiscordGatewayHealth = {
+  readonly state: DiscordGatewayState;
+  /** When the newest heartbeat acknowledgement was sent, or undefined before the first. */
+  readonly lastHeartbeatAckTimestamp: number | undefined;
+  readonly lastCloseReason: string | undefined;
+};
+
+let state: DiscordGatewayState = "connecting";
+let lastHeartbeatAckTimestamp: number | undefined;
+let lastCloseReason: string | undefined;
+
+export function setDiscordGatewayState(
+  next: DiscordGatewayState,
+  closeReason?: string,
+): void {
+  state = next;
+  lastCloseReason = closeReason;
+}
+
+/**
+ * Record the newest heartbeat acknowledgement.
+ *
+ * discord.js seeds `WebSocketShard#lastPingTimestamp` with -1 and only
+ * overwrites it on an acknowledgement, so a non-positive sample means "no beat
+ * yet" rather than "a beat at the epoch", and must not be mistaken for one.
+ */
+export function recordDiscordGatewayHeartbeat(timestamp: number): void {
+  if (timestamp <= 0) return;
+  if (
+    lastHeartbeatAckTimestamp === undefined ||
+    timestamp > lastHeartbeatAckTimestamp
+  ) {
+    lastHeartbeatAckTimestamp = timestamp;
+  }
+}
+
+export function getDiscordGatewayHealth(): DiscordGatewayHealth {
+  return { state, lastHeartbeatAckTimestamp, lastCloseReason };
+}
+
+/** Test-only reset; the module state is a process-wide singleton otherwise. */
+export function resetDiscordGatewayHealthForTest(): void {
+  state = "connecting";
+  lastHeartbeatAckTimestamp = undefined;
+  lastCloseReason = undefined;
+}
+
+export type GatewayLiveness = {
+  readonly live: boolean;
+  readonly reason:
+    | "gateway-disabled"
+    | "startup-grace-period"
+    | "heartbeat-fresh"
+    | "heartbeat-never-received"
+    | "heartbeat-stale";
+  readonly heartbeatAgeMs: number | undefined;
+};
+
+export type EvaluateGatewayLivenessInput = {
+  readonly now: number;
+  readonly uptimeMs: number;
+  readonly startupGraceMs: number;
+  readonly health: DiscordGatewayHealth;
+  readonly staleAfterMs?: number;
+};
+
+/**
+ * Decide whether the gateway is live, as a pure function of recorded state.
+ *
+ * Kept separate from the module singleton so the thresholds can be exercised
+ * directly rather than through a fake clock and a live `Client`.
+ */
+export function evaluateDiscordGatewayLiveness({
+  now,
+  uptimeMs,
+  startupGraceMs,
+  health,
+  staleAfterMs = GATEWAY_HEARTBEAT_STALE_AFTER_MS,
+}: EvaluateGatewayLivenessInput): GatewayLiveness {
+  if (health.state === "disabled") {
+    return {
+      live: true,
+      reason: "gateway-disabled",
+      heartbeatAgeMs: undefined,
+    };
+  }
+
+  const { lastHeartbeatAckTimestamp: lastAck } = health;
+  if (lastAck === undefined) {
+    // Connecting takes a few seconds; a process that has been up for the whole
+    // grace period without one acknowledgement never connected at all.
+    return uptimeMs < startupGraceMs
+      ? {
+          live: true,
+          reason: "startup-grace-period",
+          heartbeatAgeMs: undefined,
+        }
+      : {
+          live: false,
+          reason: "heartbeat-never-received",
+          heartbeatAgeMs: undefined,
+        };
+  }
+
+  const heartbeatAgeMs = Math.max(0, now - lastAck);
+  return heartbeatAgeMs > staleAfterMs
+    ? { live: false, reason: "heartbeat-stale", heartbeatAgeMs }
+    : { live: true, reason: "heartbeat-fresh", heartbeatAgeMs };
+}

--- a/packages/scout-for-lol/packages/backend/src/http/health-routes.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/health-routes.test.ts
@@ -5,18 +5,37 @@ import {
   STARTUP_GRACE_PERIOD_MS,
 } from "#src/http/health-routes.ts";
 import { updateRiotApiHealth } from "#src/metrics/index.ts";
+import {
+  GATEWAY_HEARTBEAT_STALE_AFTER_MS,
+  recordDiscordGatewayHeartbeat,
+  resetDiscordGatewayHealthForTest,
+  setDiscordGatewayState,
+} from "#src/discord/gateway-health.ts";
 
 const CORS = {};
 /** Well past the grace period, so the probe evaluates its components. */
 const UPTIME_MS = STARTUP_GRACE_PERIOD_MS + 60_000;
 
+function livez(now: number): Response {
+  return handleLivez({ cors: CORS, now, startedAt: now - UPTIME_MS });
+}
+
+/** Put both non-gateway components in their healthy state. */
+function healthyBaseline(now: number): void {
+  updateRiotApiHealth(true);
+  resetDiscordGatewayHealthForTest();
+  setDiscordGatewayState("connected");
+  recordDiscordGatewayHeartbeat(now - 30_000);
+}
+
 describe("/livez", () => {
   beforeEach(() => {
-    updateRiotApiHealth(true);
+    healthyBaseline(Date.now());
   });
 
   test("passes unconditionally inside the startup grace period", async () => {
     const now = Date.now();
+    setDiscordGatewayState("connecting");
 
     const response = handleLivez({
       cors: CORS,
@@ -31,17 +50,17 @@ describe("/livez", () => {
     });
   });
 
-  test("is healthy while the Riot API is answering", async () => {
-    const now = Date.now();
-
-    const response = handleLivez({
-      cors: CORS,
-      now,
-      startedAt: now - UPTIME_MS,
-    });
+  test("is healthy while the Riot API answers and the gateway beats", async () => {
+    const response = livez(Date.now());
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({ healthy: true });
+    await expect(response.json()).resolves.toMatchObject({
+      healthy: true,
+      components: {
+        riotApiHealthy: true,
+        discordGateway: { live: true, reason: "heartbeat-fresh" },
+      },
+    });
   });
 
   test("fails when recent Riot calls are being attempted but none succeed", async () => {
@@ -49,12 +68,9 @@ describe("/livez", () => {
     // failure is expressed by reading the probe from far enough in the future
     // that the last success is stale while the last attempt is not.
     const now = Date.now() + 16 * 60 * 1000;
+    recordDiscordGatewayHeartbeat(now - 30_000);
 
-    const response = handleLivez({
-      cors: CORS,
-      now,
-      startedAt: now - UPTIME_MS,
-    });
+    const response = livez(now);
 
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toMatchObject({
@@ -62,11 +78,48 @@ describe("/livez", () => {
       components: { riotApiHealthy: false },
     });
   });
+
+  test("fails once the gateway stops acknowledging heartbeats", async () => {
+    // The beta outage in one assertion: nothing else about the process is
+    // wrong, and the pod must still be restarted — a zombie gateway answers
+    // every slash command with "The application did not respond" and never
+    // recovers on its own.
+    const now = Date.now();
+    resetDiscordGatewayHealthForTest();
+    setDiscordGatewayState("connected");
+    recordDiscordGatewayHeartbeat(now - GATEWAY_HEARTBEAT_STALE_AFTER_MS - 1);
+
+    const response = livez(now);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      healthy: false,
+      components: {
+        riotApiHealthy: true,
+        discordGateway: { live: false, reason: "heartbeat-stale" },
+      },
+    });
+  });
+
+  test("stays healthy when the gateway was never started", async () => {
+    // `dev:web --no-discord-gateway` and NODE_ENV=test never log in.
+    const now = Date.now();
+    resetDiscordGatewayHealthForTest();
+    setDiscordGatewayState("disabled");
+
+    const response = livez(now);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      healthy: true,
+      components: { discordGateway: { reason: "gateway-disabled" } },
+    });
+  });
 });
 
 describe("/healthz", () => {
   beforeEach(() => {
-    updateRiotApiHealth(true);
+    healthyBaseline(Date.now());
   });
 
   test("is ready while the Riot API is answering", async () => {
@@ -86,6 +139,7 @@ describe("/healthz", () => {
     // Readiness pulls this replica out of the Service after 5 minutes;
     // liveness waits 15 before restarting it.
     const now = Date.now() + 6 * 60 * 1000;
+    recordDiscordGatewayHeartbeat(now - 30_000);
 
     const response = handleHealthz({
       cors: CORS,
@@ -94,8 +148,24 @@ describe("/healthz", () => {
     });
 
     expect(response.status).toBe(503);
-    expect(
-      handleLivez({ cors: CORS, now, startedAt: now - UPTIME_MS }).status,
-    ).toBe(200);
+    expect(livez(now).status).toBe(200);
+  });
+
+  test("stays ready with a dead gateway, which liveness alone acts on", async () => {
+    // Removing the only replica from the Service would take the web app and
+    // tRPC down with the bot; a restart is the narrower remedy.
+    const now = Date.now();
+    resetDiscordGatewayHealthForTest();
+    setDiscordGatewayState("connected");
+    recordDiscordGatewayHeartbeat(now - GATEWAY_HEARTBEAT_STALE_AFTER_MS - 1);
+
+    const response = handleHealthz({
+      cors: CORS,
+      now,
+      startedAt: now - UPTIME_MS,
+    });
+
+    expect(response.status).toBe(200);
+    expect(livez(now).status).toBe(503);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/http/health-routes.ts
+++ b/packages/scout-for-lol/packages/backend/src/http/health-routes.ts
@@ -1,5 +1,9 @@
 import { getRiotApiHealth } from "#src/metrics/index.ts";
 import { getScoutTemporalHealth } from "#src/temporal/health.ts";
+import {
+  evaluateDiscordGatewayLiveness,
+  getDiscordGatewayHealth,
+} from "#src/discord/gateway-health.ts";
 
 /**
  * The `/livez` and `/healthz` probe handlers.
@@ -30,7 +34,16 @@ export type HealthRouteOptions = {
   readonly now?: number;
 };
 
-/** Liveness: fail only on a condition a restart actually fixes. */
+/**
+ * Liveness: fail only on a condition a restart actually fixes.
+ *
+ * Two such conditions exist. The Riot client can wedge in a way that only a
+ * fresh process clears, and — since 2026-09-01 — so can the Discord gateway:
+ * a shard that stops receiving heartbeat acknowledgements keeps every other
+ * signal green (REST works, `discord_connection_status` reads 1, the reported
+ * latency freezes on its last healthy value) while every slash command in
+ * every guild answers "The application did not respond".
+ */
 export function handleLivez({
   cors,
   startedAt = applicationStartTime,
@@ -61,22 +74,37 @@ export function handleLivez({
     now - lastSuccessTimestamp > fifteenMinutesMs;
   const riotApiHealthy = !(hasRecentAttempts && lastSuccessStale);
 
+  const discordGateway = evaluateDiscordGatewayLiveness({
+    now,
+    uptimeMs,
+    startupGraceMs: STARTUP_GRACE_PERIOD_MS,
+    health: getDiscordGatewayHealth(),
+  });
+
+  const healthy = riotApiHealthy && discordGateway.live;
+
   return Response.json(
     {
-      healthy: riotApiHealthy,
+      healthy,
       lastSuccessTimestamp: lastSuccessTimestamp ?? null,
       lastAttemptTimestamp: lastAttemptTimestamp ?? null,
       uptimeMs,
-      components: { riotApiHealthy },
+      components: { riotApiHealthy, discordGateway },
     },
     {
-      status: riotApiHealthy ? 200 : 503,
+      status: healthy ? 200 : 503,
       headers: { "Content-Type": "application/json", ...cors },
     },
   );
 }
 
-/** Readiness: whether this replica should receive traffic. */
+/**
+ * Readiness: whether this replica should receive traffic.
+ *
+ * The gateway is reported here but deliberately does not gate the status.
+ * Removing the only replica from the Service would take the web app and tRPC
+ * down as well, which is strictly worse than a bot that cannot hear Discord.
+ */
 export function handleHealthz({
   cors,
   startedAt = applicationStartTime,
@@ -102,7 +130,10 @@ export function handleHealthz({
       lastSuccessTimestamp: lastSuccessTimestamp ?? null,
       lastAttemptTimestamp: lastAttemptTimestamp ?? null,
       uptimeSeconds,
-      components: { temporal: getScoutTemporalHealth() },
+      components: {
+        temporal: getScoutTemporalHealth(),
+        discordGateway: getDiscordGatewayHealth(),
+      },
     },
     {
       status: healthy ? 200 : 503,

--- a/packages/scout-for-lol/packages/backend/src/metrics/discord-gateway.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/discord-gateway.ts
@@ -1,0 +1,19 @@
+import { Gauge } from "prom-client";
+import { registry } from "#src/metrics/registry.ts";
+
+/**
+ * Age of the newest Discord gateway heartbeat acknowledgement, in seconds.
+ *
+ * This is the alertable form of a signal `discord_latency_ms` hides. A zombie
+ * gateway keeps reporting its last measured latency forever, so that series
+ * still looks healthy while the bot receives nothing and every slash command
+ * answers "The application did not respond". The *age* of the acknowledgement
+ * that produced the number climbs without bound instead, so an alert on this
+ * gauge fires where an alert on latency never could. Normal operation keeps it
+ * below Discord's 41.25s heartbeat interval.
+ */
+export const discordGatewayHeartbeatAge = new Gauge({
+  name: "discord_gateway_heartbeat_age_seconds",
+  help: "Seconds since the newest Discord gateway heartbeat acknowledgement",
+  registers: [registry],
+});

--- a/packages/scout-for-lol/packages/backend/src/metrics/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/metrics/index.ts
@@ -7,6 +7,7 @@ import { seedProviderIssueMetrics } from "#src/metrics/provider-issue-seeds.ts";
 import "#src/metrics/season-schedule.ts";
 import "#src/metrics/product-analytics.ts";
 import "#src/metrics/feature-flags.ts";
+import "#src/metrics/discord-gateway.ts";
 
 const logger = createLogger("metrics");
 


### PR DESCRIPTION
## Why

On 2026-09-01 the beta bot answered every slash command with **“The
application did not respond”** for 34 minutes, and nothing in the system said
so:

| Signal | What it showed |
| --- | --- |
| Pod | `Running`, 0 restarts |
| Riot polling / guild command reconcile (REST) | working |
| `discord_connection_status` | `1` |
| Logs | not one line about the gateway |
| `discord_commands_total` | **no samples at all** for the pod’s whole 2h life |
| `discord_latency_ms` | frozen on exactly `96` from 00:50 UTC onward |

Discord was dispatching `INTERACTION_CREATE` the whole time — a second gateway
session opened with the same token received `/help` immediately — but the
deployed shard had gone silent. The frozen latency was the only trace, because
discord.js writes `WebSocketShard#ping` **only** when a heartbeat is
acknowledged, so a dead shard reports its last healthy number forever. Prod’s
series fluctuated normally over the same window. Only a pod restart recovered
it.

Two defects made that invisible and unrecoverable:

1. `registerDiscordEventHandlers` listened for `"disconnect"` and
   `"reconnecting"` — discord.js **v12** client events. In v14 they belong to
   `ShardEventTypes` on the sharding manager’s `Shard`, not to `Client`.
   `Client#on` is an `AsyncEventEmitter` whose key type accepts any string, so
   both compiled, both registered, both were asserted as “installed” by
   `bootstrap.test.ts`, and neither could ever fire.
2. Nothing watched the heartbeat clock, so no probe, alert, or log could tell a
   live gateway from a zombie one.

## What

- **`DISCORD_EVENT_NAMES` now holds `Events` enum members**, so an event that
  does not exist on `Client` is a type error. The dead pair is replaced with
  the real `ShardReady`, `ShardResume`, `ShardDisconnect`, `ShardReconnecting`
  and `ShardError` handlers, each logging and moving
  `discord_connection_status`. `"ready"` becomes `Events.ClientReady`, which
  also clears the v15 deprecation warning the pod logs on boot.
  `bootstrap.test.ts` now checks every name against the enum — the mechanical
  guard that would have caught the original bug.
- **New `discord/gateway-health.ts`** records the newest
  `WebSocketShard#lastPingTimestamp` (sampled every 30s alongside the existing
  gauges) and exposes a pure `evaluateDiscordGatewayLiveness`. **`/livez` fails
  when the newest acknowledgement is more than three heartbeat intervals
  (3 min) old**, so Kubernetes restarts the pod via the probe that is already
  configured. Staleness alone is the verdict: an ordinary reconnect passes
  through `disconnected` for seconds and must not restart anything, while a
  reconnect that never completes stops the clock and trips the same threshold.
  A gateway that was never started — `dev:web --no-discord-gateway`,
  `NODE_ENV=test` — is marked `disabled` and exempt. `/healthz` reports the
  gateway but does **not** gate on it: removing the only replica from the
  Service would take the web app and tRPC down too.
- **New `discord_gateway_heartbeat_age_seconds` gauge** — the alertable form of
  the signal `discord_latency_ms` hides. A frozen shard’s latency looks
  healthy; the age behind it climbs without bound.
- **`handleInteractions` is installed once per client** (a `WeakSet`, not a
  module flag, because `Client#destroy` leaves listeners attached). A full
  re-identify re-emits `clientReady`, and a second `interactionCreate` listener
  would run every command twice.
- Documents the invariant in `packages/scout-for-lol/AGENTS.md`.

## Verification

```
bunx turbo run typecheck test --filter=@scout-for-lol/backend   # 2869 tests passed
bunx eslint .            # in packages/backend — 0 errors
bunx prettier --check <touched files>
bunx markdownlint-cli2 packages/scout-for-lol/AGENTS.md
```

**Live, against beta.** The outage was diagnosed on the running deployment:
reproduced with `toolkit discord slash … help` (`No response from Application`,
and no `📥 Command received` in the pod logs), confirmed Discord *was*
dispatching by opening a second gateway session that received
`INTERACTION_CREATE type=2 name=help`, ruled out an interactions-endpoint URL
and a session-start-limit exhaustion via the Discord API, and compared beta’s
frozen `discord_latency_ms` against prod’s. Beta was then restored by deleting
the pod, after which `/help` answered normally:

> **Scout (beta)#9846** — embed: **Scout for League of Legends** — “Scout
> watches tracked League matches and posts notifications and reports in
> Discord…”

**Not verified:** the new liveness path has not been observed firing against a
real zombie gateway in a deployed environment. That can only be confirmed the
next time one occurs; the decision logic itself is unit-tested, including the
exact stale/fresh/never-connected/disabled cases.

No new user-facing Discord output, so no message examples to attach.