### PR TITLE
perf(scout-for-lol): stop rewriting unchanged guild commands every minute

### DIFF
--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -984,6 +984,20 @@ from `guildCreate`; a guild the running bot cannot access is skipped only for
 Discord's `MISSING_ACCESS`, while every other registration failure remains
 fatal during startup.
 
+**The reconcile recomputes every minute but only writes on a change.** The
+dynamic-config poll fires every 60 seconds and this is its only listener, so an
+unconditional PUT meant 1,440 no-op bulk-overwrites a day and 1,440 log lines
+that made the one reporting a real change worthless. Recomputing is not
+skippable — `betting_enabled` and `tournament_lobbies_enabled` are evaluated
+per guild against Flipt rather than carried in the config snapshot, so nothing
+short of rebuilding the payload notices an operator flipping one. `rest.ts`
+therefore keeps the serialized payload it last wrote per guild and skips an
+identical write, recording it only after the PUT lands so a failure retries on
+the next poll. Startup and `guildCreate` pass `force`, because neither knows
+what Discord currently holds and a rejoined guild has had its commands dropped
+while a cached entry survives. The accepted cost is that this process will not
+repair guild commands edited out of band until it restarts.
+
 The feature scope remains enforced by the flag and guild-scoped registration;
 user-facing betting surfaces should not advertise the allowlist. `/bb prizes`
 is the deliberate exception: it displays the existing 1:10 catalog and

--- a/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/bootstrap.ts
@@ -91,7 +91,9 @@ async function registerConnectedGuildCommands(
 
 async function handleNewGuild(guild: Guild): Promise<void> {
   try {
-    await reconcileGuildScopedCommands([guild.id]);
+    // Forced: Discord drops a guild's commands when the bot is removed, so a
+    // rejoin must write even if this process still remembers the old payload.
+    await reconcileGuildScopedCommands([guild.id], undefined, { force: true });
   } catch (error) {
     logger.error(
       `[Guild Create] Failed to reconcile commands for ${guild.id}:`,

--- a/packages/scout-for-lol/packages/backend/src/discord/rest.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/rest.test.ts
@@ -5,6 +5,7 @@ import { guildCommandPayload } from "#src/discord/commands/definitions.ts";
 import {
   reconcileGuildScopedCommands,
   registerDiscordCommands,
+  resetGuildCommandWriteCacheForTests,
   type DiscordCommandPut,
 } from "#src/discord/rest.ts";
 
@@ -12,6 +13,7 @@ const originalAllowlist = Bun.env["EXPLORE_GUILD_ALLOWLIST"];
 const originalEnvironment = Bun.env["ENVIRONMENT"];
 
 afterEach(() => {
+  resetGuildCommandWriteCacheForTests();
   if (originalAllowlist === undefined) {
     delete Bun.env["EXPLORE_GUILD_ALLOWLIST"];
   } else {
@@ -114,5 +116,88 @@ describe("Discord command reconciliation", () => {
     await expect(
       reconcileGuildScopedCommands(["100000000000000095"], missingAccessPut),
     ).resolves.toBeUndefined();
+  });
+
+  test("skips the write when the guild payload has not changed", async () => {
+    // The dynamic-config poll calls this every 60 seconds and the payload
+    // almost never differs, so an unconditional PUT was 1,440 no-op
+    // bulk-overwrites a day — and 1,440 log lines that hid the one real one.
+    Bun.env["ENVIRONMENT"] = "beta";
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000094";
+    resetConfigurationForTests();
+    const payloads: string[][] = [];
+    const put: DiscordCommandPut = (_route, body) => {
+      payloads.push(body.map((command) => command.name));
+      return Promise.resolve(undefined);
+    };
+
+    await reconcileGuildScopedCommands(["100000000000000094"], put);
+    await reconcileGuildScopedCommands(["100000000000000094"], put);
+    await reconcileGuildScopedCommands(["100000000000000094"], put);
+
+    expect(payloads).toEqual([["scout"]]);
+  });
+
+  test("writes again as soon as the payload actually changes", async () => {
+    Bun.env["ENVIRONMENT"] = "beta";
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000093";
+    resetConfigurationForTests();
+    const payloads: string[][] = [];
+    const put: DiscordCommandPut = (_route, body) => {
+      payloads.push(body.map((command) => command.name));
+      return Promise.resolve(undefined);
+    };
+
+    await reconcileGuildScopedCommands(["100000000000000093"], put);
+    await reconcileGuildScopedCommands(["100000000000000093"], put);
+
+    // An operator removing the guild from the allowlist must still clear its
+    // commands on the very next poll.
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "";
+    resetConfigurationForTests();
+    await reconcileGuildScopedCommands(["100000000000000093"], put);
+
+    expect(payloads).toEqual([["scout"], []]);
+  });
+
+  test("does not cache a payload whose write failed", async () => {
+    // Caching an unsent payload would strand the guild until the pod restarts.
+    Bun.env["ENVIRONMENT"] = "beta";
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000092";
+    resetConfigurationForTests();
+    let attempts = 0;
+    const failThenSucceed: DiscordCommandPut = () => {
+      attempts += 1;
+      return attempts === 1
+        ? Promise.reject(new Error("Discord is down"))
+        : Promise.resolve(undefined);
+    };
+
+    await expect(
+      reconcileGuildScopedCommands(["100000000000000092"], failThenSucceed),
+    ).rejects.toThrow("Failed to reconcile guild-scoped commands");
+    await reconcileGuildScopedCommands(["100000000000000092"], failThenSucceed);
+
+    expect(attempts).toBe(2);
+  });
+
+  test("a forced reconcile writes even when nothing changed", async () => {
+    // Startup and `guildCreate` cannot know what Discord currently holds — a
+    // rejoined guild has had its commands dropped while the entry survives.
+    Bun.env["ENVIRONMENT"] = "beta";
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000091";
+    resetConfigurationForTests();
+    let writes = 0;
+    const put: DiscordCommandPut = () => {
+      writes += 1;
+      return Promise.resolve(undefined);
+    };
+
+    await reconcileGuildScopedCommands(["100000000000000091"], put);
+    await reconcileGuildScopedCommands(["100000000000000091"], put, {
+      force: true,
+    });
+
+    expect(writes).toBe(2);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/rest.ts
@@ -31,6 +31,42 @@ function discordErrorCode(error: unknown): number | undefined {
   return parsed.success ? parsed.data.code : undefined;
 }
 
+/**
+ * The payload this process last wrote to each guild, serialized.
+ *
+ * The dynamic-config poll fires every 60 seconds and the only listener is the
+ * guild-command reconcile, so beta was sending Discord an unconditional
+ * bulk-overwrite 1,440 times a day and logging every one of them — which made
+ * the log line that reports a *real* command change worthless, since it was
+ * indistinguishable from the 1,439 that changed nothing.
+ *
+ * The poll itself has to keep running: `betting_enabled` and
+ * `tournament_lobbies_enabled` are evaluated per guild against Flipt, not
+ * carried in the config snapshot, so nothing short of recomputing the payload
+ * can notice an operator flipping one. What is skippable is the write. The
+ * payload is deterministic — a fixed group order over static `toJSON()`
+ * output — so an identical serialization means an identical request.
+ *
+ * The trade-off, stated plainly: while this process lives, it will not repair
+ * guild commands changed out of band (someone editing them through the API
+ * directly). That is not a normal operation, `registerDiscordCommands` and
+ * `guildCreate` both force a write, and a deploy clears this map — so the
+ * exposure is one pod lifetime for an event that should not happen.
+ */
+const lastWrittenGuildPayloads = new Map<string, string>();
+
+export type ReconcileGuildCommandOptions = {
+  /**
+   * Write even when the payload matches the last one written.
+   *
+   * Startup and `guildCreate` both pass this, because neither knows what
+   * Discord currently holds: at startup the map is empty anyway, and a guild
+   * Scout rejoined has had its commands dropped by Discord while an entry for
+   * it may still be cached from before it was removed.
+   */
+  readonly force?: boolean;
+};
+
 /** Register the unchanged global command surface and every connected guild. */
 export async function registerDiscordCommands(
   connectedGuildIds: Iterable<string>,
@@ -44,7 +80,7 @@ export async function registerDiscordCommands(
     Routes.applicationCommands(configuration.applicationId),
     commandPayload,
   );
-  await reconcileGuildScopedCommands(connectedGuildIds, put);
+  await reconcileGuildScopedCommands(connectedGuildIds, put, { force: true });
 }
 
 /**
@@ -57,15 +93,26 @@ export async function registerDiscordCommands(
 export async function reconcileGuildScopedCommands(
   guildIds: Iterable<string>,
   put: DiscordCommandPut = putCommands,
+  options: ReconcileGuildCommandOptions = {},
 ): Promise<void> {
   for (const guildId of new Set(guildIds)) {
     const payload = await guildCommandPayload(guildId);
     const names = payload.map((command) => command.name).join(", ");
+    const serialized = JSON.stringify(payload);
+    if (
+      options.force !== true &&
+      lastWrittenGuildPayloads.get(guildId) === serialized
+    ) {
+      continue;
+    }
     try {
       await put(
         Routes.applicationGuildCommands(configuration.applicationId, guildId),
         payload,
       );
+      // Recorded only after the write lands, so a failed PUT is retried on the
+      // next poll rather than cached as if it had succeeded.
+      lastWrittenGuildPayloads.set(guildId, serialized);
       logger.info(
         payload.length === 0
           ? `🧹 Cleared guild-scoped commands in guild ${guildId}`
@@ -82,4 +129,9 @@ export async function reconcileGuildScopedCommands(
       );
     }
   }
+}
+
+/** Test-only reset; the map is a process-wide singleton otherwise. */
+export function resetGuildCommandWriteCacheForTests(): void {
+  lastWrittenGuildPayloads.clear();
 }


### PR DESCRIPTION
## Why

The dynamic-config poll fires every 60 seconds and the guild-command reconcile
is its **only** listener, so beta sent Discord an unconditional
`applicationGuildCommands` bulk-overwrite 1,440 times a day and logged every
one:

```
23:14:51 ✅ Reconciled [bb, scout, lobby] in guild 1337623164146155593
23:15:51 ✅ Reconciled [bb, scout, lobby] in guild 1337623164146155593
23:16:51 ✅ Reconciled [bb, scout, lobby] in guild 1337623164146155593
… once a minute, forever
```

The wasted requests are minor. The log damage is not: the line that reports a
**real** command change is indistinguishable from the 1,439 that changed
nothing. That was the dominant noise while reading pod logs during the gateway
outage in #2611.

Recomputing is not skippable — `betting_enabled` and
`tournament_lobbies_enabled` are evaluated per guild against Flipt rather than
carried in the config snapshot, so nothing short of rebuilding the payload
notices an operator flipping one. Only the **write** is skippable.

## What

- `reconcileGuildScopedCommands` keeps the serialized payload it last wrote per
  guild and skips an identical write. The payload is deterministic (a fixed
  group order over static `toJSON()` output), so an identical serialization
  means an identical request.
- The entry is recorded **after** the PUT resolves, so a failed write retries on
  the next poll instead of being cached as if it had succeeded.
- New `force` option, passed by `registerDiscordCommands` (startup) and
  `guildCreate`. Neither knows what Discord currently holds, and a rejoined
  guild has had its commands dropped by Discord while a cached entry may
  survive.

**Accepted cost, stated in the module and in AGENTS.md:** while a process
lives, it will not repair guild commands edited out of band through the Discord
API directly. That is not a normal operation, both forced paths cover the
ordinary ones, and a deploy clears the map.

## Verification

```
bun run lint          # in packages/backend — 0 errors, "architecture: 920 modules clean"
bunx turbo run typecheck test --filter=@scout-for-lol/backend
```

Four new cases in `rest.test.ts`: repeated reconciles write once; removing a
guild from `EXPLORE_GUILD_ALLOWLIST` still clears its commands on the very next
poll; a failed write is not cached; a forced reconcile writes anyway.

**Not verified:** the reduced write rate has not been observed against deployed
beta — that shows up as the per-minute log line disappearing after the next
deploy.

Non-visual change (no user-facing Discord output changes), so no media.