### PR TITLE
fix(scout-for-lol): suppress empty Bryan Bucks settlements

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.test.ts
@@ -483,9 +483,10 @@ function parlaySummary(serverId: string) {
 }
 
 describe("buildAnnouncements", () => {
-  test("attaches a parlay to the guild's own outcome announcement", () => {
+  test("attaches a parlay to a visible outcome announcement", () => {
     const announcements = buildAnnouncements({
       closures: [],
+      earnings: [],
       settlements: [
         {
           matchId: "NA1_1",
@@ -495,7 +496,25 @@ describe("buildAnnouncements", () => {
           winnersPool: 5,
           losersPool: 5,
           houseCut: 1,
-          bets: [],
+          bets: [
+            {
+              betId: 1,
+              bucksAccountId: 1,
+              discordId: bucksTestDiscordId(1),
+              isHouse: false,
+              predictedTeamId: 100,
+              submittedStake: 5,
+              matchedStake: 5,
+              unmatchedStake: 0,
+              grossPayout: 10,
+              houseCut: 0,
+              payout: 10,
+              winnings: 5,
+              won: true,
+              refunded: false,
+              subjectPuuid: "winner-puuid",
+            },
+          ],
         },
       ],
       parlaySettlements: [parlaySummary(SERVER_ID)],
@@ -512,6 +531,7 @@ describe("buildAnnouncements", () => {
   test("carries a parlay whose pool this pass did not settle", () => {
     const announcements = buildAnnouncements({
       closures: [],
+      earnings: [],
       settlements: [],
       parlaySettlements: [parlaySummary(SERVER_ID)],
     });
@@ -544,6 +564,7 @@ describe("buildAnnouncements", () => {
           ],
         },
       ],
+      earnings: [],
       settlements: [],
       parlaySettlements: [parlaySummary(SERVER_ID)],
     });
@@ -557,10 +578,88 @@ describe("buildAnnouncements", () => {
     expect(
       buildAnnouncements({
         closures: [],
+        earnings: [],
         settlements: [],
         parlaySettlements: [],
       }),
     ).toEqual([]);
+  });
+
+  test("does not announce a settlement with no player-visible outcome", () => {
+    expect(
+      buildAnnouncements({
+        closures: [],
+        earnings: [],
+        settlements: [
+          {
+            matchId: "NA1_1",
+            serverId: SERVER_ID,
+            winningTeamId: 100,
+            voidReason: undefined,
+            winnersPool: 0,
+            losersPool: 0,
+            houseCut: 0,
+            bets: [],
+          },
+        ],
+        parlaySettlements: [],
+      }),
+    ).toEqual([]);
+  });
+
+  test("keeps an earnings-only settlement visible", () => {
+    const announcements = buildAnnouncements({
+      closures: [],
+      earnings: [
+        {
+          serverId: SERVER_ID,
+          discordId: bucksTestDiscordId(1),
+          alias: "Sean",
+          reasons: ["played"],
+          total: 1,
+        },
+      ],
+      settlements: [
+        {
+          matchId: "NA1_1",
+          serverId: SERVER_ID,
+          winningTeamId: 100,
+          voidReason: undefined,
+          winnersPool: 0,
+          losersPool: 0,
+          houseCut: 0,
+          bets: [],
+        },
+      ],
+      parlaySettlements: [],
+    });
+
+    expect(announcements).toHaveLength(1);
+    expect(announcements[0]?.includeOutcome).toBe(true);
+  });
+
+  test("carries a parlay without an empty outcome section", () => {
+    const announcements = buildAnnouncements({
+      closures: [],
+      earnings: [],
+      settlements: [
+        {
+          matchId: "NA1_1",
+          serverId: SERVER_ID,
+          winningTeamId: 100,
+          voidReason: undefined,
+          winnersPool: 0,
+          losersPool: 0,
+          houseCut: 0,
+          bets: [],
+        },
+      ],
+      parlaySettlements: [parlaySummary(SERVER_ID)],
+    });
+
+    expect(announcements).toHaveLength(1);
+    expect(announcements[0]?.includeOutcome).toBe(false);
+    expect(announcements[0]?.parlay).toBeDefined();
   });
 });
 

--- a/packages/scout-for-lol/packages/backend/src/betting/announce.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/announce.ts
@@ -332,13 +332,19 @@ function reportUndeliverableSettlement(input: {
  */
 export function buildAnnouncements(input: {
   closures: readonly ClosedPool[];
+  earnings: readonly EarnedAward[];
   settlements: readonly SettlementSummary[];
   parlaySettlements: readonly ParlaySettlementSummary[];
 }): Announcement[] {
-  const settlementServerIds = new Set(
-    input.settlements.map((summary) => summary.serverId),
+  const outcomeSettlements = input.settlements.filter(
+    (summary) =>
+      summary.bets.some((bet) => !bet.isHouse) ||
+      input.earnings.some((award) => award.serverId === summary.serverId),
   );
-  const announcements: Announcement[] = input.settlements.map((summary) => ({
+  const settlementServerIds = new Set(
+    outcomeSettlements.map((summary) => summary.serverId),
+  );
+  const announcements: Announcement[] = outcomeSettlements.map((summary) => ({
     summary,
     includeOutcome: true,
     parlay: undefined,


### PR DESCRIPTION
## Why

Settled outcome pools with no player-visible bet, refund, earning, or parlay data currently post a title-only Bryan Bucks embed.

## What

- Send outcome settlement embeds only when a human bet or guild earning is visible.
- Preserve unmatched-refund and parlay-only settlement carriers.
- Add regression coverage for empty, earnings-only, visible-outcome, and parlay-only cases.

## Verification

- `bun run --cwd packages/scout-for-lol/packages/backend test -- src/betting/announce.test.ts`
- `bunx turbo run typecheck --filter=@scout-for-lol/backend`
- `bunx turbo run lint --filter=@scout-for-lol/backend`

No live Discord delivery was performed; the behavior is covered by the backend announcement-selection suite.