### PR TITLE
fix(scout-for-lol): drop a guild's cached payload when its write hits MISSING_ACCESS

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1080,10 +1080,6 @@
       "clones": 1,
       "tokens": 92
     },
-    "packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts|packages/scout-for-lol/packages/backend/src/discord/rest.test.ts": {
-      "clones": 1,
-      "tokens": 90
-    },
     "packages/scout-for-lol/packages/backend/src/discord/embeds/competition.ts|packages/scout-for-lol/packages/backend/src/discord/embeds/competition.ts": {
       "clones": 1,
       "tokens": 96

--- a/packages/scout-for-lol/AGENTS.md
+++ b/packages/scout-for-lol/AGENTS.md
@@ -993,9 +993,14 @@ per guild against Flipt rather than carried in the config snapshot, so nothing
 short of rebuilding the payload notices an operator flipping one. `rest.ts`
 therefore keeps the serialized payload it last wrote per guild and skips an
 identical write, recording it only after the PUT lands so a failure retries on
-the next poll. Startup and `guildCreate` pass `force`, because neither knows
-what Discord currently holds and a rejoined guild has had its commands dropped
-while a cached entry survives. The accepted cost is that this process will not
+the next poll, and **dropping the entry on `MISSING_ACCESS`** — that error is
+the one that means the cache is wrong, because Discord clears a guild's
+commands when the bot is removed. Startup and `guildCreate` pass `force`,
+because neither knows what Discord currently holds and a rejoined guild has had
+its commands dropped while a cached entry survives; forcing alone is not
+enough, since a rejoin can race `guildCreate` and hit `MISSING_ACCESS` before
+access is restored, which is exactly why that path invalidates rather than
+merely skipping. The accepted cost is that this process will not
 repair guild commands edited out of band until it restarts.
 
 The feature scope remains enforced by the flag and guild-scoped registration;

--- a/packages/scout-for-lol/packages/backend/src/discord/rest.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/rest.test.ts
@@ -200,4 +200,30 @@ describe("Discord command reconciliation", () => {
 
     expect(writes).toBe(2);
   });
+
+  test("forgets a guild after MISSING_ACCESS so a rejoin is rewritten", async () => {
+    // A removal drops that guild's commands on Discord's side, so the cached
+    // entry stops describing reality. `guildCreate` forces a write, but a
+    // rejoin can race it and hit MISSING_ACCESS before access is restored — if
+    // the entry survived that, every later poll would skip an identical
+    // payload and leave the guild commandless until the process restarts.
+    Bun.env["ENVIRONMENT"] = "beta";
+    Bun.env["EXPLORE_GUILD_ALLOWLIST"] = "100000000000000090";
+    resetConfigurationForTests();
+    const payloads: string[][] = [];
+    const put: DiscordCommandPut = (_route, body) => {
+      payloads.push(body.map((command) => command.name));
+      return Promise.resolve(undefined);
+    };
+
+    await reconcileGuildScopedCommands(["100000000000000090"], put);
+    await reconcileGuildScopedCommands(
+      ["100000000000000090"],
+      missingAccessPut,
+      { force: true },
+    );
+    await reconcileGuildScopedCommands(["100000000000000090"], put);
+
+    expect(payloads).toEqual([["scout"], ["scout"]]);
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/discord/rest.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/rest.ts
@@ -120,6 +120,13 @@ export async function reconcileGuildScopedCommands(
       );
     } catch (error) {
       if (discordErrorCode(error) === MISSING_ACCESS) {
+        // Forget what was written, because this error is the one that means
+        // the cached entry is wrong: Discord drops a guild's commands when the
+        // bot is removed, and a rejoin can race `guildCreate` so even the
+        // forced write lands before access is restored. Keeping the entry
+        // would make every later poll skip an identical payload and leave that
+        // guild commandless until the process restarts.
+        lastWrittenGuildPayloads.delete(guildId);
         logger.info(`⏭️  Skipping guild ${guildId} — this bot is not in it`);
         continue;
       }


### PR DESCRIPTION
## Why

Follow-up to #2614, which merged before these two problems were addressed.

**1. A real hole in the new cache (Codex P2 on #2614, correct).** A removal
clears that guild’s commands on Discord’s side, so the cached entry stops
describing reality. `guildCreate` forces a write on rejoin — but the rejoin can
race it and hit the explicitly tolerated `MISSING_ACCESS` before access is
restored, and that path skipped **without invalidating**. Every later poll then
matched the stale entry, skipped an identical payload, and left the guild
commandless until the process restarted. `MISSING_ACCESS` is precisely the
signal that membership changed, which is the one condition under which the
cache is known to be wrong.

**2. `main` is red on the jscpd ratchet.** #2614 removed the duplication
between `definitions.test.ts` and `rest.test.ts`, so the baseline claims a
clone pair that no longer exists:

```
FAIL: …/discord/commands/definitions.test.ts|…/discord/rest.test.ts
      has 0 clones but 1 allowed — run `bun run jscpd --update` to tighten the baseline
```

That was the `turborepo: verify` failure on build #13393, which #2614 was
merged past.

## What

- `reconcileGuildScopedCommands` deletes the guild’s entry before `continue` on
  `MISSING_ACCESS`.
- Regression test: a successful write, then a **forced** write that hits
  `MISSING_ACCESS`, then a third reconcile — must produce two writes, not one.
- Tightens `.jscpd-baseline.json` by the one dead pair (`bun run jscpd
  --update`). The baseline only shrinks; no pair is added.
- AGENTS.md records why forcing alone is not enough.

## Verification

```
bun run jscpd            # ratchet passed, 468 pairs
bun run lint             # in packages/backend — 0 errors, "architecture: 920 modules clean"
bunx turbo run typecheck test --filter=@scout-for-lol/backend
```

`rest.test.ts` is now 10 cases. Not verified against deployed beta — the
invalidation path needs a real removal/rejoin race to observe.

Non-visual change, so no media.