### PR TITLE
fix(homelab): scope the scout queue's workflow poller alert to where it polls

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -31,6 +31,18 @@ type TemporalDomainQueueDefinition = {
   candidateServicePattern?: string;
   activityPoller: boolean;
   servedNamespaces: readonly string[];
+  /**
+   * Namespaces that carry *workflow* pollers, when they differ from the
+   * activity ones.
+   *
+   * `workerNamespaces()` gives the `scout` role's activity workers `beta`,
+   * but the `workflows` role only gets `beta` for `monorepo-workflows`. So
+   * `scout` receives activity tasks in `beta` while its workflows run on
+   * `beta/monorepo-workflows` — no workflow poller belongs on `beta/scout`.
+   * Driving both rules from one list made the workflow rule permanently short
+   * by one namespace, so it fired continuously and meant nothing.
+   */
+  workflowServedNamespaces?: readonly string[];
 };
 
 // Do not install these rules until both tracks can render. A capable
@@ -127,6 +139,7 @@ export const TEMPORAL_DOMAIN_QUEUES: readonly TemporalDomainQueueDefinition[] =
       servicePattern: ".*temporal-scout-worker.*metrics.*",
       activityPoller: true,
       servedNamespaces: ["prod", "beta"],
+      workflowServedNamespaces: ["prod"],
     },
     {
       queue: "agent-task",
@@ -179,6 +192,9 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
     // and hardcoding `temporal` here selected no series at all for them —
     // an alert that can never fire.
     const pollerSelector = `namespace="${definition.metricsNamespace}",exported_namespace=~"${servedNamespaces}",task_queue="${definition.queue}"`;
+    const workflowNamespaces =
+      definition.workflowServedNamespaces ?? definition.servedNamespaces;
+    const workflowPollerSelector = `namespace="${definition.metricsNamespace}",exported_namespace=~"${workflowNamespaces.join("|")}",task_queue="${definition.queue}"`;
     // Server metric, so the queue name is sanitized — see serverMetricTaskQueue.
     const backlogQueue = serverMetricTaskQueue(definition.queue);
     const labels = { severity: "warning", task_queue: definition.queue };
@@ -213,7 +229,7 @@ export function buildTemporalDomainWorkerHealthRules(): PrometheusRule[] {
             "The domain queue has had no workflow-task poller for five minutes. Inspect its worker pod and Temporal connectivity.",
         },
         expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-          `count(sum by (exported_namespace) (temporal_worker_num_pollers{${pollerSelector},poller_type="workflow_task"})) < ${String(definition.servedNamespaces.length)}`,
+          `count(sum by (exported_namespace) (temporal_worker_num_pollers{${workflowPollerSelector},poller_type="workflow_task"})) < ${String(workflowNamespaces.length)}`,
         ),
         for: "5m",
         labels,

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal.test.ts
@@ -240,6 +240,39 @@ describe("Temporal workflow outcome rules", () => {
   });
 });
 
+describe("Temporal domain poller scoping", () => {
+  test("scopes the scout queue's workflow and activity pollers separately", () => {
+    // `scout` takes activity tasks in beta but runs its workflows on
+    // beta/monorepo-workflows, so no workflow poller belongs on beta/scout.
+    // Driving both rules from one namespace list left the workflow rule
+    // permanently short by one and firing continuously, which is how a poller
+    // alert comes to mean nothing.
+    const rules =
+      getTemporalRuleGroups().find(
+        (group) => group.name === "temporal-workflow-failures",
+      )?.rules ?? [];
+    const expressionsFor = (alert: string, queue: string): string[] =>
+      rules
+        .filter((rule) => rule.alert === alert)
+        .flatMap((rule) => {
+          const expression: unknown = rule.expr.value;
+          return typeof expression === "string" &&
+            expression.includes(`task_queue="${queue}"`)
+            ? [expression]
+            : [];
+        });
+
+    expect(
+      expressionsFor("TemporalDomainWorkflowPollerUnavailable", "scout"),
+    ).toEqual([
+      'count(sum by (exported_namespace) (temporal_worker_num_pollers{namespace="temporal",exported_namespace=~"prod",task_queue="scout",poller_type="workflow_task"})) < 1',
+    ]);
+    expect(
+      expressionsFor("TemporalDomainActivityPollerUnavailable", "scout")[0],
+    ).toContain('exported_namespace=~"prod|beta"');
+  });
+});
+
 describe("Scout Data Dragon failure rules", () => {
   test("ScoutDataDragonAutoMergeFailed alerts on the last-failure recency gauge", () => {
     const expression = findFailureRule("ScoutDataDragonAutoMergeFailed");


### PR DESCRIPTION
## Why

`TemporalDomainWorkflowPollerUnavailable` has been **firing continuously** on the `scout` queue, and it is wrong.

The queue takes activity tasks in `beta` but runs its workflows on `beta/monorepo-workflows`, so no workflow poller ever belongs on `beta/scout`. `workerNamespaces()` is the source of the asymmetry — the `scout` role's activity workers get `["prod","beta"]`, while the `workflows` role only gets `beta` for `monorepo-workflows` itself:

```ts
(queueRole === "scout" || (queueRole === "workflows" && taskQueue === TASK_QUEUES.WORKFLOWS))
  && activeNamespace === "prod" ? ["prod", "beta"] : [activeNamespace]
```

Live pollers confirm it:

| poller type | namespaces |
|---|---|
| `workflow_task` | `prod` |
| `activity_task` | `prod`, `beta` |

The generator drove **both** the workflow and activity rules from one `servedNamespaces` list, and the threshold *is* that list's length. So the workflow rule always expected one more namespace than could exist, and fired forever — whichever way the drain retirement went.

**That matters beyond the noise.** This is the alert family meant to catch a queue losing its pollers — the failure that stalled prod twice on 2026-08-31. A member of it that fires permanently trains everyone to ignore the rest, which is exactly how the original outage went unnoticed for fifteen hours.

## What

Give a queue an optional `workflowServedNamespaces`, defaulting to `servedNamespaces`, and set it to `["prod"]` for `scout`. The activity rule keeps `prod|beta`.

## Verification

```
bunx turbo run typecheck test lint --filter=@homelab/cdk8s   # 679 passed
```

Checked against live Prometheus rather than by inspection:

| expression | result |
|---|---|
| current (`prod\|beta\|default`, `< 3`) | **matches — firing** |
| new (`prod`, `< 1`) | **quiet — alert resolves** |

So this clears a firing alert rather than hiding one.

A new test asserts the workflow and activity rules are scoped *differently*, so a future edit can't silently re-merge them. It lives in its own `describe` because the existing block is at the 200-line function cap.

Found while verifying the drain retirement (#2615) wouldn't leave alerts firing — it wouldn't have fixed this, since the threshold and the poller count both drop by one.

Non-visual change (alert rules), so no media.