### PR TITLE
refactor(tasks-for-obsidian): compose the branded task schema

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1640,10 +1640,6 @@
       "clones": 1,
       "tokens": 83
     },
-    "packages/tasks-for-obsidian/src/domain/base-schemas.ts|packages/tasks-for-obsidian/src/domain/schemas.ts": {
-      "clones": 1,
-      "tokens": 404
-    },
     "packages/tasks-for-obsidian/src/domain/base-schemas.ts|packages/tasks-for-obsidian/src/domain/wire.ts": {
       "clones": 2,
       "tokens": 166

--- a/packages/tasks-for-obsidian/src/domain/schemas.test.ts
+++ b/packages/tasks-for-obsidian/src/domain/schemas.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+
+import { TaskSchema } from "./schemas";
+
+describe("TaskSchema", () => {
+  test("applies the base task defaults before branding identifiers", () => {
+    const task = TaskSchema.parse({
+      id: "inbox/first.md",
+      title: "First task",
+    });
+
+    expect(task.id).toBe("inbox/first.md");
+    expect(task.path).toBe("");
+    expect(task.title).toBe("First task");
+    expect(task.status).toBe("open");
+    expect(task.priority).toBe("normal");
+    expect(task.contexts).toEqual([]);
+    expect(task.projects).toEqual([]);
+    expect(task.tags).toEqual([]);
+    expect(task.completeInstances).toEqual([]);
+    expect(task.skippedInstances).toEqual([]);
+    expect(task.timeEntries).toEqual([]);
+    expect(task.blockedBy).toEqual([]);
+    expect(task.reminders).toEqual([]);
+    expect(task.archived).toBe(false);
+    expect(task.totalTrackedTime).toBe(0);
+    expect(task.isBlocked).toBe(false);
+    expect(task.isBlocking).toBe(false);
+    expect(task.extraFields).toEqual({});
+  });
+
+  test("preserves complete collection values through the branded schema", () => {
+    const task = TaskSchema.parse({
+      id: "projects/plan.md",
+      title: "Plan release",
+      contexts: ["work"],
+      projects: ["monorepo"],
+      tags: ["release"],
+      timeEntries: [{ startTime: "2026-09-01T00:00:00Z", duration: 30 }],
+      blockedBy: [{ uid: "dependency.md", reltype: "blocks" }],
+      reminders: [{ type: "relative", offset: "-PT15M" }],
+    });
+
+    expect(task.contexts).toEqual(["work"]);
+    expect(task.projects).toEqual(["monorepo"]);
+    expect(task.tags).toEqual(["release"]);
+    expect(task.timeEntries).toEqual([
+      { startTime: "2026-09-01T00:00:00Z", duration: 30 },
+    ]);
+    expect(task.blockedBy).toEqual([
+      { uid: "dependency.md", reltype: "blocks" },
+    ]);
+    expect(task.reminders).toEqual([{ type: "relative", offset: "-PT15M" }]);
+  });
+
+  test("rejects invalid base task fields", () => {
+    expect(() =>
+      TaskSchema.parse({
+        id: "inbox/invalid.md",
+        title: "Invalid",
+        status: "unknown",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/tasks-for-obsidian/src/domain/schemas.ts
+++ b/packages/tasks-for-obsidian/src/domain/schemas.ts
@@ -9,57 +9,20 @@ import type {
 } from "./types";
 import { contextName, projectName, tagName, taskId } from "./types";
 import {
-  PrioritySchema,
-  TaskStatusSchema as _TaskStatusSchema,
-  RecurrenceAnchorSchema,
-  BlockedByEntrySchema,
-  ReminderSchema,
-  InlineTimeEntrySchema,
+  TaskSchema as BaseTaskSchema,
   TaskStatsSchema as BaseTaskStatsSchema,
   NlpParseResultSchema as BaseNlpParseResultSchema,
 } from "./base-schemas";
 
-export const TaskStatusSchema = _TaskStatusSchema;
+export { TaskStatusSchema } from "./base-schemas";
 
-export const TaskSchema = z
-  .object({
-    id: z.string(),
-    path: z.string().default(""),
-    title: z.string(),
-    status: TaskStatusSchema.default("open"),
-    priority: PrioritySchema.default("normal"),
-    due: z.string().optional(),
-    scheduled: z.string().optional(),
-    contexts: z.array(z.string()).default([]),
-    projects: z.array(z.string()).default([]),
-    tags: z.array(z.string()).default([]),
-    recurrence: z.string().optional(),
-    recurrenceAnchor: RecurrenceAnchorSchema.optional(),
-    completeInstances: z.array(z.string()).default([]),
-    skippedInstances: z.array(z.string()).default([]),
-    completedDate: z.string().optional(),
-    dateCreated: z.string().optional(),
-    dateModified: z.string().optional(),
-    timeEstimate: z.number().optional(),
-    timeEntries: z.array(InlineTimeEntrySchema).default([]),
-    blockedBy: z.array(BlockedByEntrySchema).default([]),
-    reminders: z.array(ReminderSchema).default([]),
-    archived: z.boolean().default(false),
-    totalTrackedTime: z.number().default(0),
-    isBlocked: z.boolean().default(false),
-    isBlocking: z.boolean().default(false),
-    googleCalendarEventId: z.string().optional(),
-    icsEventId: z.string().optional(),
-    extraFields: z.record(z.string(), z.unknown()).default({}),
-    details: z.string().optional(),
-  })
-  .transform((raw): Task => ({
-    ...raw,
-    id: taskId(raw.id),
-    contexts: raw.contexts.map((c) => contextName(c)),
-    projects: raw.projects.map((p) => projectName(p)),
-    tags: raw.tags.map((t) => tagName(t)),
-  }));
+export const TaskSchema = BaseTaskSchema.transform((raw): Task => ({
+  ...raw,
+  id: taskId(raw.id),
+  contexts: raw.contexts.map((c) => contextName(c)),
+  projects: raw.projects.map((p) => projectName(p)),
+  tags: raw.tags.map((t) => tagName(t)),
+}));
 
 export const TaskStatsSchema = BaseTaskStatsSchema.transform(
   (raw): TaskStats => raw,


### PR DESCRIPTION
Why:
The branded Task schema repeats the full base task object, creating baseline duplication and two contracts that can drift.

What:
Transform the canonical base task schema into branded IDs and names, with focused contract-preservation tests.

Verification:
bun --no-install --bun vitest --config ../../vitest.config.ts run ./src/domain/schemas.test.ts
bunx turbo run typecheck test lint --filter=tasks-for-obsidian
bun run jscpd --update && bun run jscpd
bunx lefthook run pre-commit
No contract, E2E, visual, or live checks were required.