### PR TITLE
feat(scout-for-lol): add Dare v2 web lifecycle and guidance

### DIFF
--- a/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
+++ b/packages/docs/wiki/src/content/docs/explanation/scout-report-lake.md
@@ -29,7 +29,7 @@ lake is the wrong place to look.
 ```mermaid
 flowchart LR
   accTitle: Scout report lake read and write flow
-  accDescr: Live ingest crons write raw JSON to S3 and stage lake rows as best effort. A quiet first-run import snapshots twenty Match-V5 IDs and requires both writes before checkpointing. A fold compaction every fifteen minutes and a nightly rebuild from S3 both publish immutable Parquet builds behind a CURRENT pointer. Readers union the published Parquet with the staging files, so DuckDB queries see a match seconds after ingest. Competition standings bypass the lake and read raw match JSON and leaderboard snapshots from S3 directly.
+  accDescr: Live ingest crons write raw JSON to S3 and stage match and supported timeline rows as best effort. A quiet first-run import snapshots twenty Match-V5 IDs and requires both match writes before checkpointing. A fold compaction every fifteen minutes and a nightly rebuild from already-retained S3 objects both publish immutable Parquet builds behind a CURRENT pointer. Readers union the published Parquet with the staging files, so DuckDB queries see evidence seconds after ingest. Competition standings bypass the lake and read raw match JSON and leaderboard snapshots from S3 directly.
 
   I[Ingest crons] -->|must succeed| S3[(S3 durable objects)]
   I -->|best effort| ST[NDJSON staging]
@@ -53,8 +53,9 @@ Raw match, timeline, prematch, and leaderboard JSON lands in S3
 That store is append-only and authoritative.
 
 The lake is a directory on the pod's own volume: Hive-partitioned Parquet
-(`month=YYYY-MM/`) for four tables — matches, prematch, accounts, and
-competition rank history — laid out per
+(`month=YYYY-MM/`) for matches, prematch, accounts, competition rank history,
+timeline events, timeline event participants, timeline participant frames, and
+timeline coverage — laid out per
 [paths.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/paths.ts).
 It is derived data. Losing the volume costs one nightly rebuild, not any
 history.
@@ -67,9 +68,9 @@ raw JSON, so the new column simply appears the next morning.
 
 Ingest makes two writes with deliberately different contracts, spelled out in
 [store.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-store/store.ts).
-The S3 put throws on failure, because raw data is unrecoverable. The lake
-staging write never throws, because a lost staging row is re-derived from S3
-that night anyway.
+The S3 put throws on failure, because raw data is unrecoverable. Match and
+timeline lake staging writes never throw, because a lost staging row is
+re-derived from S3 that night anyway.
 
 The quiet first-run import tightens that contract. It snapshots exactly 20
 Match-V5 IDs once, imports newest first, and checkpoints a match only when the
@@ -113,8 +114,20 @@ failure mid-write can leave a truncated file on disk. That is why compaction
 validates every staged line and skips the whole file when one fails, and why
 the nightly rebuild re-derives the row from S3 regardless.
 
-Timelines go to S3 only. No query surface reads them, so flattening them into
-the lake would be pure cost.
+Supported timelines are normalized into four relations. `timeline_events` gives
+each event a stable ID; `timeline_event_participants` records semantic roles;
+`timeline_participant_frames` records participant snapshots; and
+`timeline_coverage` marks a retained, supported timeline as completely
+normalized. Absence of that marker is missing evidence, while unsupported queue
+choices are rejected before a timeline contract can be funded. That last
+relation is essential for contracts: no event in a complete timeline is false
+evidence, while a timeline Scout never retained must remain unknown.
+
+Live ingest stages all four relations next to the match. Rebuild enumerates only
+timeline objects already retained in S3; it does not call Riot or expand the raw
+history solely to backfill a dare. Event and frame IDs are derived from match,
+frame, event, participant, and role coordinates so replaying the same raw object
+is idempotent.
 
 All row shapes come from one place:
 [flatten.ts](https://github.com/shepherdjerred/monorepo/blob/main/packages/scout-for-lol/packages/backend/src/report-lake/flatten.ts)
@@ -128,7 +141,7 @@ and DuckDB never infers types from a sparse first line.
 ```mermaid
 flowchart TB
   accTitle: Two compaction tiers, one publish protocol
-  accDescr: The fold tier hardlinks the previous build's files and converts staged NDJSON into small per-month Parquet files. The nightly rebuild flattens every raw object in S3 into a fresh build. Both tiers produce an immutable build directory, atomically swap the CURRENT pointer to it, and then garbage collection keeps only the two newest builds.
+  accDescr: The fold tier hardlinks the previous build's files and converts staged match and timeline NDJSON into small per-month Parquet files. The nightly rebuild flattens every retained raw match and timeline object in S3 into a fresh build. Both tiers produce an immutable build directory, atomically swap the CURRENT pointer to it, and then garbage collection keeps only the two newest builds.
 
   subgraph fold ["Fold — every 15 minutes"]
     PB[Previous build] -->|hardlink files| NB[New build]
@@ -149,8 +162,9 @@ the staged NDJSON into small per-month Parquet files, and deletes only the
 staging files it provably folded. Hardlinking makes fold cost proportional to
 the backlog, not to the size of the lake.
 
-A rebuild runs nightly. It enumerates all of S3, streams every raw document
-through the same flatteners, and writes each table fresh. The rebuild is
+A rebuild runs nightly. It enumerates the supported raw prefixes in S3, streams
+every retained match and timeline through the same flatteners, and writes each
+table fresh. The rebuild is
 simultaneously the defragmenter (folds leave one small file per touched
 month), the backfill mechanism, and the recovery path.
 

--- a/packages/scout-for-lol/packages/app/src/components/explore-dare-cards.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dare-cards.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, CircleX, Clock3, FilePenLine } from "lucide-react";
 import { z } from "zod";
 import type { ExploreTraceEntry } from "@scout-for-lol/data";
@@ -113,6 +113,58 @@ function DraftCard(props: { draft: z.infer<typeof DraftDataSchema> }) {
   );
 }
 
+function persistedConfirmationOutcome(
+  action: z.infer<typeof IntentDataSchema>["action"],
+  status:
+    { state: "consumed" | "expired" | "pending"; result: unknown } | undefined,
+): DareIntentConfirmationOutcome | null {
+  if (status?.state === "consumed") {
+    return classifyDareIntentConfirmation(action, {
+      kind: "already_consumed",
+      result: status.result,
+    });
+  }
+  if (status?.state === "expired") {
+    return classifyDareIntentConfirmation(action, { kind: "intent_expired" });
+  }
+  return null;
+}
+
+function IntentOutcomeIcon(props: {
+  outcome: DareIntentConfirmationOutcome | null;
+}) {
+  if (props.outcome === null) {
+    return <Clock3 className="size-4 text-scout-primary" />;
+  }
+  return props.outcome.status === "confirmed" ? (
+    <CheckCircle2 className="size-4 text-scout-primary" />
+  ) : (
+    <CircleX className="size-4 text-scout-danger" />
+  );
+}
+
+function intentHeading(
+  action: z.infer<typeof IntentDataSchema>["action"],
+  outcome: DareIntentConfirmationOutcome | null,
+): string {
+  if (outcome === null) return `Confirm ${action}`;
+  return outcome.status === "confirmed"
+    ? "Action confirmed"
+    : "Action was not confirmed";
+}
+
+function IntentOutcomeMessage(props: {
+  outcome: DareIntentConfirmationOutcome;
+}) {
+  return (
+    <p
+      className={`text-sm capitalize ${props.outcome.status === "failed" ? "text-scout-danger" : ""}`}
+    >
+      {props.outcome.message}
+    </p>
+  );
+}
+
 function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -122,24 +174,24 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
   const mutation = useMutation(
     trpc.explore.confirmDareIntent.mutationOptions(),
   );
+  const persisted = useQuery(
+    trpc.explore.dareIntentStatus.queryOptions({
+      intentId: props.intent.intentId,
+    }),
+  );
   const expires = new Date(props.intent.expiresAt);
+  const persistedOutcome = persistedConfirmationOutcome(
+    props.intent.action,
+    persisted.data,
+  );
+  const displayedOutcome = outcome ?? persistedOutcome;
 
   return (
     <section className="space-y-3 rounded-lg border border-scout-primary/40 bg-scout-primary/5 p-4">
       <div className="flex items-center gap-2">
-        {outcome === null ? (
-          <Clock3 className="size-4 text-scout-primary" />
-        ) : outcome.status === "confirmed" ? (
-          <CheckCircle2 className="size-4 text-scout-primary" />
-        ) : (
-          <CircleX className="size-4 text-scout-danger" />
-        )}
+        <IntentOutcomeIcon outcome={displayedOutcome} />
         <h3 className="font-medium">
-          {outcome === null
-            ? `Confirm ${props.intent.action}`
-            : outcome.status === "confirmed"
-              ? "Action confirmed"
-              : "Action was not confirmed"}
+          {intentHeading(props.intent.action, displayedOutcome)}
         </h3>
       </div>
       <p className="text-sm text-scout-subtle">
@@ -147,7 +199,7 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
         {props.intent.revision.toString()}. This single-use confirmation expires{" "}
         {expires.toLocaleTimeString()}.
       </p>
-      {outcome === null || outcome.retryable ? (
+      {displayedOutcome === null || displayedOutcome.retryable ? (
         <div className="flex gap-2">
           <Button
             type="button"
@@ -167,6 +219,14 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
                     void queryClient.invalidateQueries({
                       queryKey: trpc.explore.dareList.pathKey(),
                     });
+                    void queryClient.invalidateQueries({
+                      queryKey: trpc.explore.dareInspect.pathKey(),
+                    });
+                    void queryClient.invalidateQueries({
+                      queryKey: trpc.explore.dareIntentStatus.queryKey({
+                        intentId: props.intent.intentId,
+                      }),
+                    });
                   },
                 },
               );
@@ -174,22 +234,21 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
           >
             {mutation.isPending
               ? "Confirming…"
-              : outcome === null
+              : displayedOutcome === null
                 ? "Confirm"
                 : "Try again"}
           </Button>
         </div>
       ) : (
-        <p
-          className={`text-sm capitalize ${outcome.status === "failed" ? "text-scout-danger" : ""}`}
-        >
-          {outcome.message}
+        <IntentOutcomeMessage outcome={displayedOutcome} />
+      )}
+      {displayedOutcome?.status === "failed" && displayedOutcome.retryable && (
+        <p className="text-sm capitalize text-scout-danger">
+          {displayedOutcome.message}
         </p>
       )}
-      {outcome?.status === "failed" && outcome.retryable && (
-        <p className="text-sm capitalize text-scout-danger">
-          {outcome.message}
-        </p>
+      {persisted.error !== null && (
+        <p className="text-sm text-scout-danger">{persisted.error.message}</p>
       )}
       {outcome?.deliveryWarning !== null &&
         outcome?.deliveryWarning !== undefined && (

--- a/packages/scout-for-lol/packages/app/src/components/explore-dare-editor.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dare-editor.tsx
@@ -1,0 +1,338 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  DareCompiledPlanV2Schema,
+  DareDeadlineSpecV2Schema,
+  type DareCompiledPlanV2,
+  type DareDeadlineSpecV2,
+} from "@scout-for-lol/data";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@scout-for-lol/design-system/components/dialog";
+import { Input } from "@scout-for-lol/design-system/components/input";
+import { Textarea } from "@scout-for-lol/design-system/components/textarea";
+import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+type EditorDare = {
+  id: number;
+  currentRevision: number;
+  originalText: string;
+  plan: DareCompiledPlanV2;
+  deadlineSpec: DareDeadlineSpecV2;
+  openingStake: number;
+  canonicalScoutQl: string;
+  plainLanguage: string;
+};
+
+type ValidatedDraft = {
+  canonicalScoutQl: string;
+  plainLanguage: string;
+  semanticProofPlan: string;
+};
+
+export function ExploreDareEditor(props: { dare: EditorDare }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [originalText, setOriginalText] = useState(props.dare.originalText);
+  const [planText, setPlanText] = useState(
+    JSON.stringify(props.dare.plan, null, 2),
+  );
+  const [deadlineText, setDeadlineText] = useState(
+    JSON.stringify(props.dare.deadlineSpec, null, 2),
+  );
+  const [stakeText, setStakeText] = useState(
+    props.dare.openingStake.toString(),
+  );
+  const [historyDays, setHistoryDays] = useState("30");
+  const [error, setError] = useState<string | null>(null);
+  const [validated, setValidated] = useState<ValidatedDraft | null>(null);
+  const [preview, setPreview] = useState<{
+    achieved: boolean | null;
+    eligibleGames: number;
+    coverageComplete: boolean;
+  } | null>(null);
+  const [reviewing, setReviewing] = useState(false);
+  const revise = useMutation(trpc.explore.dareReviseDraft.mutationOptions());
+  const fieldId = (name: string) =>
+    `dare-${props.dare.id.toString()}-editor-${name}`;
+
+  function changed(): void {
+    setValidated(null);
+    setPreview(null);
+    setReviewing(false);
+    setError(null);
+  }
+
+  function editorInput() {
+    let rawPlan: unknown;
+    let rawDeadline: unknown;
+    try {
+      rawPlan = JSON.parse(planText);
+      rawDeadline = JSON.parse(deadlineText);
+    } catch {
+      setError("The plan and deadline must be valid JSON.");
+      return null;
+    }
+    const plan = DareCompiledPlanV2Schema.safeParse(rawPlan);
+    const deadlineSpec = DareDeadlineSpecV2Schema.safeParse(rawDeadline);
+    const openingStake = Number(stakeText);
+    if (!plan.success || !deadlineSpec.success) {
+      setError(
+        "The plan or deadline does not match the Dare v2 contract schema.",
+      );
+      return null;
+    }
+    if (!Number.isSafeInteger(openingStake) || openingStake <= 0) {
+      setError("Opening stake must be a positive whole number of BB.");
+      return null;
+    }
+    return {
+      dareId: props.dare.id,
+      expectedRevision: props.dare.currentRevision,
+      originalText,
+      plan: plan.data,
+      deadlineSpec: deadlineSpec.data,
+      openingStake,
+    };
+  }
+
+  async function validate(): Promise<ValidatedDraft | null> {
+    const input = editorInput();
+    if (input === null) return null;
+    try {
+      const result = await queryClient.query(
+        trpc.explore.dareValidateDraft.queryOptions(input),
+      );
+      if (result.kind === "invalid") {
+        setError(result.issues.join(" "));
+        setValidated(null);
+        return null;
+      }
+      setError(null);
+      setValidated(result);
+      return result;
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : String(error_));
+      return null;
+    }
+  }
+
+  async function runPreview(): Promise<void> {
+    const input = editorInput();
+    if (input === null) return;
+    const days = Number(historyDays);
+    if (!Number.isSafeInteger(days) || days < 1 || days > 90) {
+      setError("Historical preview must cover 1-90 days.");
+      return;
+    }
+    try {
+      const result = await queryClient.query(
+        trpc.explore.darePreviewDraft.queryOptions({
+          ...input,
+          historyDays: days,
+        }),
+      );
+      setPreview(result);
+      setError(null);
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : String(error_));
+    }
+  }
+
+  async function reviewOrSave(): Promise<void> {
+    const input = editorInput();
+    if (input === null) return;
+    if (!reviewing) {
+      const result = await validate();
+      if (result !== null) setReviewing(true);
+      return;
+    }
+    try {
+      const outcome = await revise.mutateAsync(input);
+      if (outcome.kind !== "revised") {
+        setError(
+          `Draft was not revised (${outcome.kind.replaceAll("_", " ")}).`,
+        );
+        return;
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: trpc.explore.dareList.pathKey(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: trpc.explore.dareInspect.pathKey(),
+        }),
+      ]);
+      setOpen(false);
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : String(error_));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        Advanced editor
+      </Button>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit Dare #{props.dare.id.toString()}</DialogTitle>
+          <DialogDescription>
+            Edit the typed contract plan; Scout regenerates canonical ScoutQL
+            and its exact meaning. No funded contract can enter this editor.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <label
+            htmlFor={fieldId("request")}
+            className="space-y-1 text-sm lg:col-span-2"
+          >
+            <span className="font-medium">Original request</span>
+            <Textarea
+              id={fieldId("request")}
+              value={originalText}
+              onChange={(event) => {
+                changed();
+                setOriginalText(event.target.value);
+              }}
+            />
+          </label>
+          <label htmlFor={fieldId("plan")} className="space-y-1 text-sm">
+            <span className="font-medium">Contract plan</span>
+            <Textarea
+              id={fieldId("plan")}
+              className="min-h-80 font-mono text-xs"
+              spellCheck={false}
+              value={planText}
+              onChange={(event) => {
+                changed();
+                setPlanText(event.target.value);
+              }}
+            />
+          </label>
+          <div className="space-y-4">
+            <label htmlFor={fieldId("deadline")} className="space-y-1 text-sm">
+              <span className="font-medium">Deadline specification</span>
+              <Textarea
+                id={fieldId("deadline")}
+                className="font-mono text-xs"
+                spellCheck={false}
+                value={deadlineText}
+                onChange={(event) => {
+                  changed();
+                  setDeadlineText(event.target.value);
+                }}
+              />
+            </label>
+            <label htmlFor={fieldId("stake")} className="space-y-1 text-sm">
+              <span className="font-medium">Opening stake</span>
+              <Input
+                id={fieldId("stake")}
+                inputMode="numeric"
+                value={stakeText}
+                onChange={(event) => {
+                  changed();
+                  setStakeText(event.target.value);
+                }}
+              />
+            </label>
+            <div className="flex items-end gap-2">
+              <label
+                htmlFor={fieldId("history-days")}
+                className="grow space-y-1 text-sm"
+              >
+                <span className="font-medium">Backtest days</span>
+                <Input
+                  id={fieldId("history-days")}
+                  inputMode="numeric"
+                  value={historyDays}
+                  onChange={(event) => {
+                    setHistoryDays(event.target.value);
+                  }}
+                />
+              </label>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void runPreview()}
+              >
+                Preview history
+              </Button>
+            </div>
+            {preview !== null && (
+              <p className="rounded-md border border-scout-border p-3 text-sm">
+                Historical result: <strong>{String(preview.achieved)}</strong> ·{" "}
+                {preview.eligibleGames.toString()} eligible games · timeline{" "}
+                {preview.coverageComplete ? "complete" : "incomplete"}
+              </p>
+            )}
+          </div>
+        </div>
+        {validated !== null && (
+          <section className="space-y-3">
+            <h3 className="font-medium">Generated ScoutQL</h3>
+            <ScoutQlCode queryText={validated.canonicalScoutQl} />
+            <p className="whitespace-pre-wrap text-sm">
+              {validated.plainLanguage}
+            </p>
+          </section>
+        )}
+        {reviewing && validated !== null && (
+          <section className="grid gap-3 rounded-md border border-scout-border p-3 text-sm md:grid-cols-2">
+            <div>
+              <h3 className="font-medium">
+                Before · revision {props.dare.currentRevision.toString()}
+              </h3>
+              <p className="mt-2 whitespace-pre-wrap">
+                {props.dare.plainLanguage}
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium">
+                After · revision {(props.dare.currentRevision + 1).toString()}
+              </h3>
+              <p className="mt-2 whitespace-pre-wrap">
+                {validated.plainLanguage}
+              </p>
+            </div>
+          </section>
+        )}
+        {error !== null && (
+          <p role="alert" className="text-sm text-scout-danger">
+            {error}
+          </p>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void validate()}
+          >
+            Validate and format
+          </Button>
+          <Button
+            type="button"
+            disabled={revise.isPending}
+            onClick={() => void reviewOrSave()}
+          >
+            {reviewing ? "Save revision" : "Review diff"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/explore-dare-editor.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dare-editor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   DareCompiledPlanV2Schema,
@@ -59,11 +59,19 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
     coverageComplete: boolean;
   } | null>(null);
   const [reviewing, setReviewing] = useState(false);
+  const [validationPending, setValidationPending] = useState(false);
+  const [previewPending, setPreviewPending] = useState(false);
+  const inputVersion = useRef(0);
+  const validationRequest = useRef(0);
+  const previewRequest = useRef(0);
   const revise = useMutation(trpc.explore.dareReviseDraft.mutationOptions());
   const fieldId = (name: string) =>
     `dare-${props.dare.id.toString()}-editor-${name}`;
 
   function changed(): void {
+    inputVersion.current += 1;
+    previewRequest.current += 1;
+    setPreviewPending(false);
     setValidated(null);
     setPreview(null);
     setReviewing(false);
@@ -106,10 +114,20 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
   async function validate(): Promise<ValidatedDraft | null> {
     const input = editorInput();
     if (input === null) return null;
+    const version = inputVersion.current;
+    const request = validationRequest.current + 1;
+    validationRequest.current = request;
+    setValidationPending(true);
     try {
       const result = await queryClient.query(
         trpc.explore.dareValidateDraft.queryOptions(input),
       );
+      if (
+        version !== inputVersion.current ||
+        request !== validationRequest.current
+      ) {
+        return null;
+      }
       if (result.kind === "invalid") {
         setError(result.issues.join(" "));
         setValidated(null);
@@ -119,8 +137,17 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
       setValidated(result);
       return result;
     } catch (error_) {
-      setError(error_ instanceof Error ? error_.message : String(error_));
+      if (
+        version === inputVersion.current &&
+        request === validationRequest.current
+      ) {
+        setError(error_ instanceof Error ? error_.message : String(error_));
+      }
       return null;
+    } finally {
+      if (request === validationRequest.current) {
+        setValidationPending(false);
+      }
     }
   }
 
@@ -132,6 +159,10 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
       setError("Historical preview must cover 1-90 days.");
       return;
     }
+    const version = inputVersion.current;
+    const request = previewRequest.current + 1;
+    previewRequest.current = request;
+    setPreviewPending(true);
     try {
       const result = await queryClient.query(
         trpc.explore.darePreviewDraft.queryOptions({
@@ -139,10 +170,25 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
           historyDays: days,
         }),
       );
+      if (
+        version !== inputVersion.current ||
+        request !== previewRequest.current
+      ) {
+        return;
+      }
       setPreview(result);
       setError(null);
     } catch (error_) {
-      setError(error_ instanceof Error ? error_.message : String(error_));
+      if (
+        version === inputVersion.current &&
+        request === previewRequest.current
+      ) {
+        setError(error_ instanceof Error ? error_.message : String(error_));
+      }
+    } finally {
+      if (request === previewRequest.current) {
+        setPreviewPending(false);
+      }
     }
   }
 
@@ -196,143 +242,183 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
             and its exact meaning. No funded contract can enter this editor.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <label
-            htmlFor={fieldId("request")}
-            className="space-y-1 text-sm lg:col-span-2"
-          >
-            <span className="font-medium">Original request</span>
-            <Textarea
-              id={fieldId("request")}
-              value={originalText}
-              onChange={(event) => {
-                changed();
-                setOriginalText(event.target.value);
-              }}
-            />
-          </label>
-          <label htmlFor={fieldId("plan")} className="space-y-1 text-sm">
-            <span className="font-medium">Contract plan</span>
-            <Textarea
-              id={fieldId("plan")}
-              className="min-h-80 font-mono text-xs"
-              spellCheck={false}
-              value={planText}
-              onChange={(event) => {
-                changed();
-                setPlanText(event.target.value);
-              }}
-            />
-          </label>
-          <div className="space-y-4">
-            <label htmlFor={fieldId("deadline")} className="space-y-1 text-sm">
-              <span className="font-medium">Deadline specification</span>
+        <fieldset disabled={revise.isPending} className="space-y-4">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <label
+              htmlFor={fieldId("request")}
+              className="space-y-1 text-sm lg:col-span-2"
+            >
+              <span className="font-medium">Original request</span>
               <Textarea
-                id={fieldId("deadline")}
-                className="font-mono text-xs"
+                id={fieldId("request")}
+                value={originalText}
+                onChange={(event) => {
+                  changed();
+                  setOriginalText(event.target.value);
+                }}
+              />
+            </label>
+            <label htmlFor={fieldId("plan")} className="space-y-1 text-sm">
+              <span className="font-medium">Contract plan</span>
+              <Textarea
+                id={fieldId("plan")}
+                className="min-h-80 font-mono text-xs"
                 spellCheck={false}
-                value={deadlineText}
+                value={planText}
                 onChange={(event) => {
                   changed();
-                  setDeadlineText(event.target.value);
+                  setPlanText(event.target.value);
                 }}
               />
             </label>
-            <label htmlFor={fieldId("stake")} className="space-y-1 text-sm">
-              <span className="font-medium">Opening stake</span>
-              <Input
-                id={fieldId("stake")}
-                inputMode="numeric"
-                value={stakeText}
-                onChange={(event) => {
-                  changed();
-                  setStakeText(event.target.value);
-                }}
-              />
-            </label>
-            <div className="flex items-end gap-2">
+            <div className="space-y-4">
               <label
-                htmlFor={fieldId("history-days")}
-                className="grow space-y-1 text-sm"
+                htmlFor={fieldId("deadline")}
+                className="space-y-1 text-sm"
               >
-                <span className="font-medium">Backtest days</span>
-                <Input
-                  id={fieldId("history-days")}
-                  inputMode="numeric"
-                  value={historyDays}
+                <span className="font-medium">Deadline specification</span>
+                <Textarea
+                  id={fieldId("deadline")}
+                  className="font-mono text-xs"
+                  spellCheck={false}
+                  value={deadlineText}
                   onChange={(event) => {
-                    setHistoryDays(event.target.value);
+                    changed();
+                    setDeadlineText(event.target.value);
                   }}
                 />
               </label>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => void runPreview()}
-              >
-                Preview history
-              </Button>
+              <label htmlFor={fieldId("stake")} className="space-y-1 text-sm">
+                <span className="font-medium">Opening stake</span>
+                <Input
+                  id={fieldId("stake")}
+                  inputMode="numeric"
+                  value={stakeText}
+                  onChange={(event) => {
+                    changed();
+                    setStakeText(event.target.value);
+                  }}
+                />
+              </label>
+              <div className="flex items-end gap-2">
+                <label
+                  htmlFor={fieldId("history-days")}
+                  className="grow space-y-1 text-sm"
+                >
+                  <span className="font-medium">Backtest days</span>
+                  <Input
+                    id={fieldId("history-days")}
+                    inputMode="numeric"
+                    value={historyDays}
+                    onChange={(event) => {
+                      previewRequest.current += 1;
+                      setPreviewPending(false);
+                      setPreview(null);
+                      setError(null);
+                      setHistoryDays(event.target.value);
+                    }}
+                  />
+                </label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={previewPending}
+                  onClick={() => void runPreview()}
+                >
+                  {previewPending ? "Previewing…" : "Preview history"}
+                </Button>
+              </div>
+              {preview !== null && (
+                <p className="rounded-md border border-scout-border p-3 text-sm">
+                  Historical result: <strong>{String(preview.achieved)}</strong>{" "}
+                  · {preview.eligibleGames.toString()} eligible games · timeline{" "}
+                  {preview.coverageComplete ? "complete" : "incomplete"}
+                </p>
+              )}
             </div>
-            {preview !== null && (
-              <p className="rounded-md border border-scout-border p-3 text-sm">
-                Historical result: <strong>{String(preview.achieved)}</strong> ·{" "}
-                {preview.eligibleGames.toString()} eligible games · timeline{" "}
-                {preview.coverageComplete ? "complete" : "incomplete"}
-              </p>
-            )}
           </div>
-        </div>
-        {validated !== null && (
-          <section className="space-y-3">
-            <h3 className="font-medium">Generated ScoutQL</h3>
-            <ScoutQlCode queryText={validated.canonicalScoutQl} />
-            <p className="whitespace-pre-wrap text-sm">
-              {validated.plainLanguage}
-            </p>
-          </section>
-        )}
-        {reviewing && validated !== null && (
-          <section className="grid gap-3 rounded-md border border-scout-border p-3 text-sm md:grid-cols-2">
-            <div>
-              <h3 className="font-medium">
-                Before · revision {props.dare.currentRevision.toString()}
-              </h3>
-              <p className="mt-2 whitespace-pre-wrap">
-                {props.dare.plainLanguage}
-              </p>
-            </div>
-            <div>
-              <h3 className="font-medium">
-                After · revision {(props.dare.currentRevision + 1).toString()}
-              </h3>
-              <p className="mt-2 whitespace-pre-wrap">
+          {validated !== null && (
+            <section className="space-y-3">
+              <h3 className="font-medium">Generated ScoutQL</h3>
+              <ScoutQlCode queryText={validated.canonicalScoutQl} />
+              <p className="whitespace-pre-wrap text-sm">
                 {validated.plainLanguage}
               </p>
-            </div>
-          </section>
-        )}
-        {error !== null && (
-          <p role="alert" className="text-sm text-scout-danger">
-            {error}
-          </p>
-        )}
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => void validate()}
-          >
-            Validate and format
-          </Button>
-          <Button
-            type="button"
-            disabled={revise.isPending}
-            onClick={() => void reviewOrSave()}
-          >
-            {reviewing ? "Save revision" : "Review diff"}
-          </Button>
-        </div>
+            </section>
+          )}
+          {reviewing && validated !== null && (
+            <section className="grid gap-3 rounded-md border border-scout-border p-3 text-sm md:grid-cols-2">
+              <div>
+                <h3 className="font-medium">
+                  Before · revision {props.dare.currentRevision.toString()}
+                </h3>
+                <p className="mt-2 whitespace-pre-wrap">
+                  {props.dare.plainLanguage}
+                </p>
+                <ReviewValue
+                  label="Original request"
+                  value={props.dare.originalText}
+                />
+                <ReviewValue
+                  label="Deadline"
+                  value={JSON.stringify(props.dare.deadlineSpec, null, 2)}
+                />
+                <ReviewValue
+                  label="Opening stake"
+                  value={`${props.dare.openingStake.toString()} BB`}
+                />
+              </div>
+              <div>
+                <h3 className="font-medium">
+                  After · revision {(props.dare.currentRevision + 1).toString()}
+                </h3>
+                <p className="mt-2 whitespace-pre-wrap">
+                  {validated.plainLanguage}
+                </p>
+                <ReviewValue label="Original request" value={originalText} />
+                <ReviewValue label="Deadline" value={deadlineText} />
+                <ReviewValue
+                  label="Opening stake"
+                  value={`${Number(stakeText).toString()} BB`}
+                />
+              </div>
+            </section>
+          )}
+          {error !== null && (
+            <p role="alert" className="text-sm text-scout-danger">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={validationPending}
+              onClick={() => void validate()}
+            >
+              {validationPending ? "Validating…" : "Validate and format"}
+            </Button>
+            <Button
+              type="button"
+              disabled={validationPending}
+              onClick={() => void reviewOrSave()}
+            >
+              {reviewing ? "Save revision" : "Review diff"}
+            </Button>
+          </div>
+        </fieldset>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function ReviewValue(props: { label: string; value: string }) {
+  return (
+    <div className="mt-3">
+      <h4 className="text-xs font-medium text-scout-subtle">{props.label}</h4>
+      <p className="mt-1 whitespace-pre-wrap font-mono text-xs">
+        {props.value}
+      </p>
+    </div>
   );
 }

--- a/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
@@ -20,6 +20,7 @@ import {
 } from "@scout-for-lol/design-system/components/tabs";
 import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
 import { ExploreDareEditor } from "#src/components/explore-dare-editor.tsx";
+import { dareDeadlineDescription } from "#src/lib/dare-deadline.ts";
 import { dareEditorInstanceKey } from "#src/lib/dare-editor-state.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
 
@@ -237,7 +238,7 @@ function DareDetail(props: {
           label="Evidence"
           value={`${props.dare.evidenceGames.toString()} games`}
         />
-        <Fact label="Deadline" value={deadlineDescription(props.dare)} />
+        <Fact label="Deadline" value={dareDeadlineDescription(props.dare)} />
         {props.dare.acceptDeadline !== null && (
           <Fact
             label="Accept by"
@@ -270,24 +271,6 @@ function DareDetail(props: {
       )}
     </div>
   );
-}
-
-function deadlineDescription(dare: {
-  deadlineAt: string | null;
-  deadlineSpec: DareDeadlineSpecV2;
-}): string {
-  if (dare.deadlineAt !== null) {
-    return new Date(dare.deadlineAt).toLocaleString();
-  }
-  if (dare.deadlineSpec.kind === "absolute") {
-    return new Intl.DateTimeFormat(undefined, {
-      dateStyle: "medium",
-      timeStyle: "short",
-      timeZone: dare.deadlineSpec.timezone,
-      timeZoneName: "short",
-    }).format(new Date(dare.deadlineSpec.deadlineAt));
-  }
-  return `${dare.deadlineSpec.days.toString()} days after every target accepts`;
 }
 
 function Fact(props: { label: string; value: string }) {

--- a/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
@@ -20,6 +20,7 @@ import {
 } from "@scout-for-lol/design-system/components/tabs";
 import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
 import { ExploreDareEditor } from "#src/components/explore-dare-editor.tsx";
+import { dareEditorInstanceKey } from "#src/lib/dare-editor-state.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
 
 export function ExploreDaresDrawer() {
@@ -185,7 +186,12 @@ function DareDetail(props: {
         <h3 className="font-medium">Dare #{props.dare.id.toString()}</h3>
         <StatePill state={props.dare.state} />
       </div>
-      {props.dare.state === "draft" && <ExploreDareEditor dare={props.dare} />}
+      {props.dare.state === "draft" && (
+        <ExploreDareEditor
+          key={dareEditorInstanceKey(props.dare)}
+          dare={props.dare}
+        />
+      )}
       <p className="whitespace-pre-wrap text-sm">{props.dare.plainLanguage}</p>
       <dl className="grid grid-cols-2 gap-3 text-sm">
         <Fact label="Revision" value={revision.toString()} />

--- a/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
@@ -80,20 +80,50 @@ export function ExploreDaresDrawer() {
           />
         </div>
 
-        {detail.data === undefined ? (
+        {selectedId === null ? (
           <DareList
             loading={list.isLoading}
             error={list.error}
             dares={list.data ?? []}
             onSelect={setSelectedId}
           />
+        ) : detail.isLoading ? (
+          <p className="mt-6 text-sm text-scout-subtle">Loading dare…</p>
+        ) : detail.error === null ? (
+          detail.data === undefined ? null : (
+            <DareDetail
+              dare={detail.data}
+              onBack={() => {
+                setSelectedId(null);
+              }}
+            />
+          )
         ) : (
-          <DareDetail
-            dare={detail.data}
-            onBack={() => {
-              setSelectedId(null);
-            }}
-          />
+          <div className="mt-6 space-y-3">
+            <p className="text-sm text-scout-danger">{detail.error.message}</p>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  void detail.refetch();
+                }}
+              >
+                Try again
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setSelectedId(null);
+                }}
+              >
+                Back to dares
+              </Button>
+            </div>
+          </div>
         )}
       </SheetContent>
     </Sheet>
@@ -170,8 +200,10 @@ function DareDetail(props: {
     openingStake: number;
     potTotal: number;
     evidenceGames: number;
+    acceptDeadline: string | null;
     deadlineAt: string | null;
     finalValue: boolean | null;
+    proof: unknown;
     voidReason: string | null;
   };
   onBack: () => void;
@@ -205,19 +237,26 @@ function DareDetail(props: {
           label="Evidence"
           value={`${props.dare.evidenceGames.toString()} games`}
         />
-        <Fact
-          label="Deadline"
-          value={
-            props.dare.deadlineAt === null
-              ? "Starts after acceptance"
-              : new Date(props.dare.deadlineAt).toLocaleString()
-          }
-        />
+        <Fact label="Deadline" value={deadlineDescription(props.dare)} />
+        {props.dare.acceptDeadline !== null && (
+          <Fact
+            label="Accept by"
+            value={new Date(props.dare.acceptDeadline).toLocaleString()}
+          />
+        )}
       </dl>
       <section className="space-y-2">
         <h4 className="text-sm font-medium">ScoutQL</h4>
         <ScoutQlCode queryText={props.dare.canonicalScoutQl} />
       </section>
+      {props.dare.proof !== null && (
+        <section className="space-y-2">
+          <h4 className="text-sm font-medium">Settlement proof</h4>
+          <pre className="max-h-96 overflow-auto rounded-md border border-scout-border bg-scout-surface p-3 text-xs whitespace-pre-wrap">
+            {JSON.stringify(props.dare.proof, null, 2)}
+          </pre>
+        </section>
+      )}
       <section className="space-y-2">
         <h4 className="text-sm font-medium">Proof plan</h4>
         <p className="whitespace-pre-wrap text-xs text-scout-subtle">
@@ -231,6 +270,24 @@ function DareDetail(props: {
       )}
     </div>
   );
+}
+
+function deadlineDescription(dare: {
+  deadlineAt: string | null;
+  deadlineSpec: DareDeadlineSpecV2;
+}): string {
+  if (dare.deadlineAt !== null) {
+    return new Date(dare.deadlineAt).toLocaleString();
+  }
+  if (dare.deadlineSpec.kind === "absolute") {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: dare.deadlineSpec.timezone,
+      timeZoneName: "short",
+    }).format(new Date(dare.deadlineSpec.deadlineAt));
+  }
+  return `${dare.deadlineSpec.days.toString()} days after every target accepts`;
 }
 
 function Fact(props: { label: string; value: string }) {

--- a/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
@@ -1,0 +1,245 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Search, Target } from "lucide-react";
+import type {
+  DareCompiledPlanV2,
+  DareDeadlineSpecV2,
+} from "@scout-for-lol/data";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import { Input } from "@scout-for-lol/design-system/components/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@scout-for-lol/design-system/components/sheet";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@scout-for-lol/design-system/components/tabs";
+import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
+import { ExploreDareEditor } from "#src/components/explore-dare-editor.tsx";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+export function ExploreDaresDrawer() {
+  const trpc = useTRPC();
+  const [open, setOpen] = useState(false);
+  const [scope, setScope] = useState<"mine" | "guild">("mine");
+  const [search, setSearch] = useState("");
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const list = useQuery({
+    ...trpc.explore.dareList.queryOptions({
+      scope,
+      ...(search.trim().length === 0 ? {} : { search: search.trim() }),
+    }),
+    enabled: open,
+  });
+  const detail = useQuery({
+    ...trpc.explore.dareInspect.queryOptions({ dareId: selectedId ?? 0 }),
+    enabled: open && selectedId !== null,
+  });
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <Target className="size-4" />
+          Dares
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetTitle className="text-base font-semibold">Scout dares</SheetTitle>
+        <Tabs
+          value={scope}
+          onValueChange={(next) => {
+            if (next === "mine" || next === "guild") {
+              setScope(next);
+              setSelectedId(null);
+            }
+          }}
+          className="mt-4"
+        >
+          <TabsList>
+            <TabsTrigger value="mine">My Dares</TabsTrigger>
+            <TabsTrigger value="guild">Guild Dares</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        <div className="relative mt-4">
+          <Search className="absolute top-1/2 left-2 size-4 -translate-y-1/2 text-scout-subtle" />
+          <Input
+            aria-label="Search dares"
+            placeholder="Search dares or targets"
+            value={search}
+            className="pl-8"
+            onChange={(event) => {
+              setSearch(event.target.value);
+            }}
+          />
+        </div>
+
+        {detail.data === undefined ? (
+          <DareList
+            loading={list.isLoading}
+            error={list.error}
+            dares={list.data ?? []}
+            onSelect={setSelectedId}
+          />
+        ) : (
+          <DareDetail
+            dare={detail.data}
+            onBack={() => {
+              setSelectedId(null);
+            }}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function DareList(props: {
+  loading: boolean;
+  error: { message: string } | null;
+  dares: {
+    id: number;
+    state: string;
+    plainLanguage: string;
+    targetAliases: string[];
+    potTotal: number;
+    evidenceGames: number;
+    updatedAt: string;
+  }[];
+  onSelect: (dareId: number) => void;
+}) {
+  if (props.loading) {
+    return <p className="mt-6 text-sm text-scout-subtle">Loading dares…</p>;
+  }
+  if (props.error !== null) {
+    return (
+      <p className="mt-6 text-sm text-scout-danger">{props.error.message}</p>
+    );
+  }
+  if (props.dares.length === 0) {
+    return <p className="mt-6 text-sm text-scout-subtle">No dares match.</p>;
+  }
+  return (
+    <ul className="mt-4 space-y-2">
+      {props.dares.map((dare) => (
+        <li key={dare.id}>
+          <button
+            type="button"
+            className="w-full space-y-2 rounded-lg border border-scout-border p-3 text-left hover:bg-scout-hover"
+            onClick={() => {
+              props.onSelect(dare.id);
+            }}
+          >
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="font-medium">Dare #{dare.id.toString()}</span>
+              <StatePill state={dare.state} />
+            </div>
+            <p className="line-clamp-3 whitespace-pre-wrap text-sm">
+              {dare.plainLanguage}
+            </p>
+            <p className="text-xs text-scout-subtle">
+              {dare.targetAliases.join(", ")} · {dare.potTotal.toString()} BB ·{" "}
+              {dare.evidenceGames.toString()} evidence games
+            </p>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DareDetail(props: {
+  dare: {
+    id: number;
+    state: string;
+    currentRevision: number;
+    fundedRevision: number | null;
+    plainLanguage: string;
+    canonicalScoutQl: string;
+    plan: DareCompiledPlanV2;
+    semanticProofPlan: string;
+    originalText: string;
+    deadlineSpec: DareDeadlineSpecV2;
+    targetAliases: string[];
+    openingStake: number;
+    potTotal: number;
+    evidenceGames: number;
+    deadlineAt: string | null;
+    finalValue: boolean | null;
+    voidReason: string | null;
+  };
+  onBack: () => void;
+}) {
+  const revision = props.dare.fundedRevision ?? props.dare.currentRevision;
+  return (
+    <div className="mt-4 space-y-4">
+      <Button type="button" variant="ghost" size="sm" onClick={props.onBack}>
+        ← Back to dares
+      </Button>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="font-medium">Dare #{props.dare.id.toString()}</h3>
+        <StatePill state={props.dare.state} />
+      </div>
+      {props.dare.state === "draft" && <ExploreDareEditor dare={props.dare} />}
+      <p className="whitespace-pre-wrap text-sm">{props.dare.plainLanguage}</p>
+      <dl className="grid grid-cols-2 gap-3 text-sm">
+        <Fact label="Revision" value={revision.toString()} />
+        <Fact label="Targets" value={props.dare.targetAliases.join(", ")} />
+        <Fact
+          label="Opening stake"
+          value={`${props.dare.openingStake.toString()} BB`}
+        />
+        <Fact label="Pot" value={`${props.dare.potTotal.toString()} BB`} />
+        <Fact
+          label="Evidence"
+          value={`${props.dare.evidenceGames.toString()} games`}
+        />
+        <Fact
+          label="Deadline"
+          value={
+            props.dare.deadlineAt === null
+              ? "Starts after acceptance"
+              : new Date(props.dare.deadlineAt).toLocaleString()
+          }
+        />
+      </dl>
+      <section className="space-y-2">
+        <h4 className="text-sm font-medium">ScoutQL</h4>
+        <ScoutQlCode queryText={props.dare.canonicalScoutQl} />
+      </section>
+      <section className="space-y-2">
+        <h4 className="text-sm font-medium">Proof plan</h4>
+        <p className="whitespace-pre-wrap text-xs text-scout-subtle">
+          {props.dare.semanticProofPlan}
+        </p>
+      </section>
+      {props.dare.voidReason !== null && (
+        <p className="text-sm text-scout-danger">
+          Voided: {props.dare.voidReason.replaceAll("_", " ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Fact(props: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs text-scout-subtle">{props.label}</dt>
+      <dd>{props.value}</dd>
+    </div>
+  );
+}
+
+function StatePill(props: { state: string }) {
+  return (
+    <span className="rounded-full border border-scout-border px-2 py-0.5 text-xs capitalize">
+      {props.state.replaceAll("_", " ")}
+    </span>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/explore-header.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-header.tsx
@@ -18,6 +18,7 @@ export function ExploreHeader(props: {
   drawerOpen: boolean;
   onDrawerOpenChange: (open: boolean) => void;
   sidebar: ReactNode;
+  extraActions?: ReactNode;
   actions?: {
     shared: boolean;
     sharing: boolean;
@@ -66,37 +67,42 @@ export function ExploreHeader(props: {
         </h1>
       </div>
 
-      {props.actions !== undefined && (
+      {(props.actions !== undefined || props.extraActions !== undefined) && (
         <div className="flex shrink-0 items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label="Export as markdown"
-            onClick={props.actions.onExport}
-          >
-            <Download className="size-4" />
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-            disabled={props.actions.sharing}
-            onClick={props.actions.onShare}
-          >
-            <Share2 className="size-4" />
-            {props.actions.shared ? "Copy link" : "Share"}
-          </Button>
-          {props.actions.shared && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Stop sharing"
-              title="Stop sharing"
-              disabled={props.actions.revoking}
-              onClick={props.actions.onRevoke}
-            >
-              <Link2Off className="size-4" />
-            </Button>
+          {props.extraActions}
+          {props.actions !== undefined && (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label="Export as markdown"
+                onClick={props.actions.onExport}
+              >
+                <Download className="size-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                disabled={props.actions.sharing}
+                onClick={props.actions.onShare}
+              >
+                <Share2 className="size-4" />
+                {props.actions.shared ? "Copy link" : "Share"}
+              </Button>
+              {props.actions.shared && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Stop sharing"
+                  title="Stop sharing"
+                  disabled={props.actions.revoking}
+                  onClick={props.actions.onRevoke}
+                >
+                  <Link2Off className="size-4" />
+                </Button>
+              )}
+            </>
           )}
         </div>
       )}

--- a/packages/scout-for-lol/packages/app/src/lib/dare-deadline.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/dare-deadline.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { dareDeadlineDescription } from "#src/lib/dare-deadline.ts";
+
+describe("dareDeadlineDescription", () => {
+  test("renders an absolute deadline with its explicit timezone", () => {
+    const rendered = dareDeadlineDescription({
+      deadlineAt: null,
+      deadlineSpec: {
+        kind: "absolute",
+        deadlineAt: "2026-09-08T19:00:00.000Z",
+        timezone: "America/Los_Angeles",
+      },
+    });
+
+    expect(rendered).toContain("2026");
+    expect(rendered).toMatch(/P[DS]T/);
+  });
+
+  test("describes a relative deadline before activation", () => {
+    expect(
+      dareDeadlineDescription({
+        deadlineAt: null,
+        deadlineSpec: { kind: "relative", days: 7 },
+      }),
+    ).toBe("7 days after every target accepts");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/dare-deadline.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/dare-deadline.ts
@@ -1,0 +1,22 @@
+import type { DareDeadlineSpecV2 } from "@scout-for-lol/data";
+
+export function dareDeadlineDescription(dare: {
+  deadlineAt: string | null;
+  deadlineSpec: DareDeadlineSpecV2;
+}): string {
+  if (dare.deadlineAt !== null) {
+    return new Date(dare.deadlineAt).toLocaleString();
+  }
+  if (dare.deadlineSpec.kind === "absolute") {
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: dare.deadlineSpec.timezone,
+      timeZoneName: "short",
+    }).format(new Date(dare.deadlineSpec.deadlineAt));
+  }
+  return `${dare.deadlineSpec.days.toString()} days after every target accepts`;
+}

--- a/packages/scout-for-lol/packages/app/src/lib/dare-editor-state.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/dare-editor-state.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { dareEditorInstanceKey } from "#src/lib/dare-editor-state.ts";
+
+describe("Dare editor instance state", () => {
+  test("changes the editor instance when the fetched revision changes", () => {
+    expect(dareEditorInstanceKey({ id: 7, currentRevision: 1 })).not.toBe(
+      dareEditorInstanceKey({ id: 7, currentRevision: 2 }),
+    );
+  });
+
+  test("changes the editor instance when another dare is selected", () => {
+    expect(dareEditorInstanceKey({ id: 7, currentRevision: 1 })).not.toBe(
+      dareEditorInstanceKey({ id: 8, currentRevision: 1 }),
+    );
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/lib/dare-editor-state.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/dare-editor-state.ts
@@ -1,0 +1,6 @@
+export function dareEditorInstanceKey(dare: {
+  id: number;
+  currentRevision: number;
+}): string {
+  return `${dare.id.toString()}:${dare.currentRevision.toString()}`;
+}

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -5,6 +5,7 @@ import type { ExploreConversation } from "@scout-for-lol/data";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import { ExploreComposer } from "#src/components/explore-composer.tsx";
 import { ExploreHeader } from "#src/components/explore-header.tsx";
+import { ExploreDaresDrawer } from "#src/components/explore-dares-drawer.tsx";
 import { ExploreShareRow } from "#src/components/explore-share.tsx";
 import { ExploreSidebar } from "#src/components/explore-sidebar.tsx";
 import {
@@ -311,6 +312,7 @@ export function Explore() {
           drawerOpen={drawerOpen}
           onDrawerOpenChange={setDrawerOpen}
           sidebar={sidebar}
+          extraActions={<ExploreDaresDrawer />}
           {...(headerActions === undefined ? {} : { actions: headerActions })}
         />
 

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -63,6 +63,7 @@ export function Explore() {
     status,
     enabled,
     quota,
+    daresEnabled,
     conversations,
     transcript,
     messages,
@@ -312,7 +313,7 @@ export function Explore() {
           drawerOpen={drawerOpen}
           onDrawerOpenChange={setDrawerOpen}
           sidebar={sidebar}
-          extraActions={<ExploreDaresDrawer />}
+          extraActions={daresEnabled ? <ExploreDaresDrawer /> : undefined}
           {...(headerActions === undefined ? {} : { actions: headerActions })}
         />
 
@@ -459,6 +460,7 @@ function useExploreConversation(conversationId: string | null) {
   const trpc = useTRPC();
   const status = useQuery(trpc.explore.status.queryOptions());
   const enabled = status.data?.enabled === true;
+  const daresEnabled = status.data?.daresEnabled === true;
   const conversations = useQuery({
     ...trpc.explore.list.queryOptions(),
     enabled,
@@ -471,6 +473,7 @@ function useExploreConversation(conversationId: string | null) {
   return {
     status,
     enabled,
+    daresEnabled,
     quota: status.data?.quota ?? [],
     conversations,
     transcript,

--- a/packages/scout-for-lol/packages/backend/package.json
+++ b/packages/scout-for-lol/packages/backend/package.json
@@ -44,6 +44,7 @@
     "test:report": "CI_TEST_COVERAGE=1 bun ../../../../scripts/run-ci-test.ts",
     "test:parlay:live": "bun run scripts/test-parlay-live.ts",
     "test:weekly-parlay:live": "bun run scripts/test-weekly-parlay-live.ts",
+    "test:dare-v2:model-eval": "bun run scripts/evaluate-dare-paraphrases.ts",
     "analytics:backfill-bryan-bucks": "bun run scripts/backfill-bryan-bucks-analytics.ts",
     "customs:anonymize": "bun run scripts/anonymize-customs-participant.ts"
   },

--- a/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
@@ -1,0 +1,194 @@
+import { Output, generateText } from "ai";
+import {
+  DareParaphraseCorpusSchema,
+  DiscordAccountIdSchema,
+  type DareParaphraseCorpus,
+  type DareTargetBindingV2,
+} from "@scout-for-lol/data";
+import { createOpenRouterRuntime } from "@shepherdjerred/llm-runtime";
+import { darePlanSemanticIssues } from "#src/betting/dare-contract-compiler-v2.ts";
+import { prepareDareDraftV2 } from "#src/betting/dare-draft-v2.ts";
+import {
+  canonicalDarePlanJsonV2,
+  canonicalDarePlanV2,
+} from "#src/betting/dare-plan-canonical-v2.ts";
+import { renderDarePlanV2 } from "#src/betting/dare-render-v2.ts";
+import { DareDefinitionToolInputSchema } from "#src/explore/dare-tools.ts";
+import {
+  DARE_V2_EVAL_MODEL,
+  DareModelEvalReportSchema,
+  dareModelEvalSha256,
+} from "#src/explore/dare-model-eval-v2.ts";
+import { dareExplorePromptSection } from "#src/explore/prompt.ts";
+
+const CORPUS_URL = new URL(
+  "../../data/src/model/dare-v2-paraphrase-corpus.json",
+  import.meta.url,
+);
+const REPORT_URL = new URL(
+  "../src/explore/dare-v2-model-eval-report.json",
+  import.meta.url,
+);
+const FIXED_NOW = new Date("2026-09-01T00:00:00.000Z");
+
+async function loadCorpus(): Promise<{
+  corpus: DareParaphraseCorpus;
+  raw: string;
+}> {
+  const raw = await Bun.file(CORPUS_URL).text();
+  const parsed: unknown = JSON.parse(raw);
+  return { corpus: DareParaphraseCorpusSchema.parse(parsed), raw };
+}
+
+function targetBindings(
+  aliases: Readonly<Record<string, string>>,
+): DareTargetBindingV2[] {
+  return Object.entries(aliases).map(([key, alias], index) => ({
+    key,
+    alias,
+    discordId: DiscordAccountIdSchema.parse(
+      `2000000000000000${index.toString()}`,
+    ),
+    playerId: index + 1,
+    accounts: [
+      {
+        puuid: `${key}-eval-puuid`,
+        trackingStartedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+  }));
+}
+
+function evalPrompt(input: {
+  paraphrase: string;
+  targetAliases: Readonly<Record<string, string>>;
+  openingStake: number;
+}): string {
+  return [
+    "Translate this dare request into the required structured contract.",
+    `Current time: ${FIXED_NOW.toISOString()}`,
+    `Available frozen targets: ${Object.entries(input.targetAliases)
+      .map(([key, alias]) => `${key}=${alias}`)
+      .join(", ")}`,
+    `Set targetKeys to exactly: ${Object.keys(input.targetAliases).join(", ")}. Use those exact keys in every plan target reference.`,
+    `Set openingStake to exactly ${input.openingStake.toString()} BB.`,
+    "If the request has no deadline, set deadlineSpec to exactly 7 relative days. If it names an absolute deadline, translate that date and preserve its explicit IANA timezone.",
+    "Preserve the user's exact request in originalText.",
+    "Request:",
+    input.paraphrase,
+  ].join("\n");
+}
+
+async function evaluateParaphrase(
+  runtime: ReturnType<typeof createOpenRouterRuntime>,
+  entry: DareParaphraseCorpus["cases"][number],
+  paraphrase: string,
+) {
+  try {
+    const result = await generateText({
+      model: runtime.languageModel(DARE_V2_EVAL_MODEL),
+      system: dareExplorePromptSection(),
+      prompt: evalPrompt({
+        paraphrase,
+        targetAliases: entry.targetAliases,
+        openingStake: entry.openingStake,
+      }),
+      output: Output.object({ schema: DareDefinitionToolInputSchema }),
+      maxOutputTokens: 8000,
+      ...runtime.callOptions({ workload: "scout.dare-v2-eval" }),
+    });
+    const output = DareDefinitionToolInputSchema.parse(result.output);
+    const targets = targetBindings(entry.targetAliases);
+    const issues = darePlanSemanticIssues(output.plan, targets);
+    const prepared = prepareDareDraftV2(
+      {
+        originalText: output.originalText,
+        plan: output.plan,
+        targets,
+        deadlineSpec: output.deadlineSpec,
+        openingStake: output.openingStake,
+      },
+      FIXED_NOW,
+    );
+    if (prepared.kind === "invalid") issues.push(...prepared.issues);
+    const actualCanonicalPlan = canonicalDarePlanV2(output.plan);
+    const actualCanonicalSha256 = dareModelEvalSha256(
+      canonicalDarePlanJsonV2(actualCanonicalPlan),
+    );
+    const actualMeaning = renderDarePlanV2(output.plan, targets);
+    if (actualCanonicalSha256 !== entry.expectedCanonicalSha256) {
+      issues.push("Canonical plan drifted.");
+    }
+    if (actualMeaning !== entry.expectedMeaning) {
+      issues.push("Rendered meaning drifted.");
+    }
+    const metadataMatches =
+      JSON.stringify(output.deadlineSpec) ===
+        JSON.stringify(entry.deadlineSpec) &&
+      output.openingStake === entry.openingStake;
+    if (!metadataMatches) issues.push("Deadline or opening stake drifted.");
+    const passed =
+      issues.length === 0 &&
+      actualCanonicalSha256 === entry.expectedCanonicalSha256;
+    return {
+      id: entry.id,
+      paraphrase,
+      passed,
+      expectedCanonicalSha256: entry.expectedCanonicalSha256,
+      actualCanonicalSha256,
+      actualCanonicalPlan,
+      expectedMeaning: entry.expectedMeaning,
+      actualMeaning,
+      issues,
+    };
+  } catch (error) {
+    return {
+      id: entry.id,
+      paraphrase,
+      passed: false,
+      expectedCanonicalSha256: entry.expectedCanonicalSha256,
+      actualCanonicalSha256: null,
+      actualCanonicalPlan: null,
+      expectedMeaning: entry.expectedMeaning,
+      actualMeaning: null,
+      issues: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const apiKey = Bun.env["OPENROUTER_API_KEY"];
+  if (apiKey === undefined || apiKey.trim() === "") {
+    throw new Error("OPENROUTER_API_KEY is required for Dare v2 model evals.");
+  }
+  const { corpus, raw } = await loadCorpus();
+  const runtime = createOpenRouterRuntime({
+    apiKey,
+    service: "scout-dare-v2-evals",
+    appName: "Scout Dare v2 Evals",
+  });
+  const cases = [];
+  for (const entry of corpus.cases) {
+    for (const paraphrase of entry.paraphrases) {
+      cases.push(await evaluateParaphrase(runtime, entry, paraphrase));
+    }
+  }
+  const report = DareModelEvalReportSchema.parse({
+    version: 2,
+    corpusVersion: corpus.version,
+    promptVersion: corpus.promptVersion,
+    promptSha256: dareModelEvalSha256(dareExplorePromptSection()),
+    corpusSha256: dareModelEvalSha256(raw),
+    model: DARE_V2_EVAL_MODEL,
+    generatedAt: new Date().toISOString(),
+    passed: cases.every((entry) => entry.passed),
+    cases,
+  });
+  if (Bun.argv.includes("--write")) {
+    await Bun.write(REPORT_URL, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (!report.passed) process.exitCode = 1;
+}
+
+await main();

--- a/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
@@ -1,9 +1,7 @@
 import { Output, generateText } from "ai";
 import {
   DareParaphraseCorpusSchema,
-  DiscordAccountIdSchema,
   type DareParaphraseCorpus,
-  type DareTargetBindingV2,
 } from "@scout-for-lol/data";
 import { createOpenRouterRuntime } from "@shepherdjerred/llm-runtime";
 import { darePlanSemanticIssues } from "#src/betting/dare-contract-compiler-v2.ts";
@@ -18,6 +16,7 @@ import {
   DARE_V2_EVAL_MODEL,
   DareModelEvalReportSchema,
   dareModelEvalSha256,
+  resolveDareModelEvalTargets,
 } from "#src/explore/dare-model-eval-v2.ts";
 import { dareExplorePromptSection } from "#src/explore/prompt.ts";
 
@@ -38,25 +37,6 @@ async function loadCorpus(): Promise<{
   const raw = await Bun.file(CORPUS_URL).text();
   const parsed: unknown = JSON.parse(raw);
   return { corpus: DareParaphraseCorpusSchema.parse(parsed), raw };
-}
-
-function targetBindings(
-  aliases: Readonly<Record<string, string>>,
-): DareTargetBindingV2[] {
-  return Object.entries(aliases).map(([key, alias], index) => ({
-    key,
-    alias,
-    discordId: DiscordAccountIdSchema.parse(
-      `2000000000000000${index.toString()}`,
-    ),
-    playerId: index + 1,
-    accounts: [
-      {
-        puuid: `${key}-eval-puuid`,
-        trackingStartedAt: "2026-01-01T00:00:00.000Z",
-      },
-    ],
-  }));
 }
 
 function evalPrompt(input: {
@@ -98,8 +78,15 @@ async function evaluateParaphrase(
       ...runtime.callOptions({ workload: "scout.dare-v2-eval" }),
     });
     const output = DareDefinitionToolInputSchema.parse(result.output);
-    const targets = targetBindings(entry.targetAliases);
-    const issues = darePlanSemanticIssues(output.plan, targets);
+    const resolvedTargets = resolveDareModelEvalTargets({
+      targetKeys: output.targetKeys,
+      targetAliases: entry.targetAliases,
+    });
+    const targets = resolvedTargets.targets;
+    const issues = [
+      ...resolvedTargets.issues,
+      ...darePlanSemanticIssues(output.plan, targets),
+    ];
     const prepared = prepareDareDraftV2(
       {
         originalText: output.originalText,

--- a/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
@@ -29,6 +29,17 @@ const REPORT_URL = new URL(
   import.meta.url,
 );
 const FIXED_NOW = new Date("2026-09-01T00:00:00.000Z");
+const EVAL_PROMPT_TEMPLATE = [
+  "Translate this dare request into the required structured contract.",
+  `Current time: ${FIXED_NOW.toISOString()}`,
+  "Available frozen targets: {{TARGETS}}",
+  "Set targetKeys to exactly: {{TARGET_KEYS}}. Use those exact keys in every plan target reference.",
+  "Set openingStake to exactly {{OPENING_STAKE}} BB.",
+  "If the request has no deadline, set deadlineSpec to exactly 7 relative days. If it names an absolute deadline, translate that date and preserve its explicit IANA timezone.",
+  "Preserve the user's exact request in originalText.",
+  "Request:",
+  "{{REQUEST}}",
+].join("\n");
 
 async function loadCorpus(): Promise<{
   corpus: DareParaphraseCorpus;
@@ -44,19 +55,15 @@ function evalPrompt(input: {
   targetAliases: Readonly<Record<string, string>>;
   openingStake: number;
 }): string {
-  return [
-    "Translate this dare request into the required structured contract.",
-    `Current time: ${FIXED_NOW.toISOString()}`,
-    `Available frozen targets: ${Object.entries(input.targetAliases)
+  return EVAL_PROMPT_TEMPLATE.replace(
+    "{{TARGETS}}",
+    Object.entries(input.targetAliases)
       .map(([key, alias]) => `${key}=${alias}`)
-      .join(", ")}`,
-    `Set targetKeys to exactly: ${Object.keys(input.targetAliases).join(", ")}. Use those exact keys in every plan target reference.`,
-    `Set openingStake to exactly ${input.openingStake.toString()} BB.`,
-    "If the request has no deadline, set deadlineSpec to exactly 7 relative days. If it names an absolute deadline, translate that date and preserve its explicit IANA timezone.",
-    "Preserve the user's exact request in originalText.",
-    "Request:",
-    input.paraphrase,
-  ].join("\n");
+      .join(", "),
+  )
+    .replace("{{TARGET_KEYS}}", Object.keys(input.targetAliases).join(", "))
+    .replace("{{OPENING_STAKE}}", input.openingStake.toString())
+    .replace("{{REQUEST}}", input.paraphrase);
 }
 
 async function evaluateParaphrase(
@@ -114,6 +121,9 @@ async function evaluateParaphrase(
         JSON.stringify(entry.deadlineSpec) &&
       output.openingStake === entry.openingStake;
     if (!metadataMatches) issues.push("Deadline or opening stake drifted.");
+    if (output.originalText !== paraphrase) {
+      issues.push("Original request text drifted.");
+    }
     const passed =
       issues.length === 0 &&
       actualCanonicalSha256 === entry.expectedCanonicalSha256;
@@ -164,7 +174,9 @@ async function main(): Promise<void> {
     version: 2,
     corpusVersion: corpus.version,
     promptVersion: corpus.promptVersion,
-    promptSha256: dareModelEvalSha256(dareExplorePromptSection()),
+    promptSha256: dareModelEvalSha256(
+      `${dareExplorePromptSection()}\n${EVAL_PROMPT_TEMPLATE}`,
+    ),
     corpusSha256: dareModelEvalSha256(raw),
     model: DARE_V2_EVAL_MODEL,
     generatedAt: new Date().toISOString(),

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-paraphrase-corpus.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-paraphrase-corpus.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import {
+  DareParaphraseCategorySchema,
+  DareParaphraseCorpusSchema,
+  DiscordAccountIdSchema,
+  type DareParaphraseCorpus,
+  type DareTargetBindingV2,
+} from "@scout-for-lol/data";
+import { darePlanSemanticIssues } from "#src/betting/dare-contract-compiler-v2.ts";
+import { prepareDareDraftV2 } from "#src/betting/dare-draft-v2.ts";
+import { renderDarePlanV2 } from "#src/betting/dare-render-v2.ts";
+import { canonicalDarePlanJsonV2 } from "#src/betting/dare-plan-canonical-v2.ts";
+
+const CORPUS_URL = new URL(
+  "../../../data/src/model/dare-v2-paraphrase-corpus.json",
+  import.meta.url,
+);
+const FIXED_NOW = new Date("2026-09-01T00:00:00.000Z");
+
+async function loadCorpus(): Promise<DareParaphraseCorpus> {
+  const raw: unknown = await Bun.file(CORPUS_URL).json();
+  return DareParaphraseCorpusSchema.parse(raw);
+}
+
+function targetBindings(
+  targetAliases: Readonly<Record<string, string>>,
+): DareTargetBindingV2[] {
+  return Object.entries(targetAliases).map(([key, alias], index) => ({
+    key,
+    alias,
+    discordId: DiscordAccountIdSchema.parse(
+      `1000000000000000${index.toString()}`,
+    ),
+    playerId: index + 1,
+    accounts: [
+      {
+        puuid: `${key}-frozen-puuid`,
+        trackingStartedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+  }));
+}
+
+function sha256(value: string): string {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+describe("Dare v2 paraphrase corpus", () => {
+  test("covers every required semantic category", async () => {
+    const corpus = await loadCorpus();
+    const covered = new Set(corpus.cases.flatMap((entry) => entry.categories));
+
+    expect([...covered].sort()).toEqual(
+      [...DareParaphraseCategorySchema.options].sort(),
+    );
+  });
+
+  test("pins canonical plans and rendered meanings", async () => {
+    const corpus = await loadCorpus();
+
+    for (const entry of corpus.cases) {
+      const targets = targetBindings(entry.targetAliases);
+      expect(darePlanSemanticIssues(entry.plan, targets), entry.id).toEqual([]);
+      expect(sha256(canonicalDarePlanJsonV2(entry.plan)), entry.id).toBe(
+        entry.expectedCanonicalSha256,
+      );
+      expect(renderDarePlanV2(entry.plan, targets), entry.id).toBe(
+        entry.expectedMeaning,
+      );
+
+      const prepared = prepareDareDraftV2(
+        {
+          originalText: entry.paraphrases[0] ?? "",
+          plan: entry.plan,
+          targets,
+          deadlineSpec: entry.deadlineSpec,
+          openingStake: entry.openingStake,
+        },
+        FIXED_NOW,
+      );
+      expect(prepared.kind, entry.id).toBe("valid");
+    }
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-paraphrase-corpus.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-paraphrase-corpus.test.ts
@@ -1,45 +1,14 @@
 import { describe, expect, test } from "vitest";
-import {
-  DareParaphraseCategorySchema,
-  DareParaphraseCorpusSchema,
-  DiscordAccountIdSchema,
-  type DareParaphraseCorpus,
-  type DareTargetBindingV2,
-} from "@scout-for-lol/data";
+import { DareParaphraseCategorySchema } from "@scout-for-lol/data";
 import { darePlanSemanticIssues } from "#src/betting/dare-contract-compiler-v2.ts";
 import { prepareDareDraftV2 } from "#src/betting/dare-draft-v2.ts";
 import { renderDarePlanV2 } from "#src/betting/dare-render-v2.ts";
 import { canonicalDarePlanJsonV2 } from "#src/betting/dare-plan-canonical-v2.ts";
-
-const CORPUS_URL = new URL(
-  "../../../data/src/model/dare-v2-paraphrase-corpus.json",
-  import.meta.url,
-);
+import {
+  dareTargetBindingsForAliases,
+  loadDareParaphraseCorpus,
+} from "#src/betting/dare-v2-test-fixtures.ts";
 const FIXED_NOW = new Date("2026-09-01T00:00:00.000Z");
-
-async function loadCorpus(): Promise<DareParaphraseCorpus> {
-  const raw: unknown = await Bun.file(CORPUS_URL).json();
-  return DareParaphraseCorpusSchema.parse(raw);
-}
-
-function targetBindings(
-  targetAliases: Readonly<Record<string, string>>,
-): DareTargetBindingV2[] {
-  return Object.entries(targetAliases).map(([key, alias], index) => ({
-    key,
-    alias,
-    discordId: DiscordAccountIdSchema.parse(
-      `1000000000000000${index.toString()}`,
-    ),
-    playerId: index + 1,
-    accounts: [
-      {
-        puuid: `${key}-frozen-puuid`,
-        trackingStartedAt: "2026-01-01T00:00:00.000Z",
-      },
-    ],
-  }));
-}
 
 function sha256(value: string): string {
   return new Bun.CryptoHasher("sha256").update(value).digest("hex");
@@ -47,7 +16,7 @@ function sha256(value: string): string {
 
 describe("Dare v2 paraphrase corpus", () => {
   test("covers every required semantic category", async () => {
-    const corpus = await loadCorpus();
+    const corpus = await loadDareParaphraseCorpus();
     const covered = new Set(corpus.cases.flatMap((entry) => entry.categories));
 
     expect([...covered].sort()).toEqual(
@@ -56,10 +25,10 @@ describe("Dare v2 paraphrase corpus", () => {
   });
 
   test("pins canonical plans and rendered meanings", async () => {
-    const corpus = await loadCorpus();
+    const corpus = await loadDareParaphraseCorpus();
 
     for (const entry of corpus.cases) {
-      const targets = targetBindings(entry.targetAliases);
+      const targets = dareTargetBindingsForAliases(entry.targetAliases);
       expect(darePlanSemanticIssues(entry.plan, targets), entry.id).toEqual([]);
       expect(sha256(canonicalDarePlanJsonV2(entry.plan)), entry.id).toBe(
         entry.expectedCanonicalSha256,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -364,6 +364,53 @@ describe("Dare v2 draft and lifecycle", () => {
     ).resolves.toEqual([]);
   });
 
+  test("searches only the active revision's visible text and aliases", async () => {
+    const dareId = await makeDraft();
+    const revised = await reviseDareDraftV2(
+      {
+        dareId,
+        serverId: SERVER,
+        challengerDiscordId: CHALLENGER,
+        expectedRevision: 1,
+        definition: {
+          originalText: "same-game farming challenge for the current target",
+          plan: PLAN,
+          targets: [{ ...TARGET_BINDING, alias: "CurrentAlias" }],
+          deadlineSpec: { kind: "relative", days: 7 },
+          openingStake: 20,
+        },
+      },
+      deps,
+      T0,
+    );
+    expect(revised.kind).toBe("revised");
+
+    await expect(
+      listVisibleDaresV2(
+        {
+          serverId: SERVER,
+          viewerDiscordId: CHALLENGER,
+          scope: "mine",
+          search: "currentalias",
+        },
+        db,
+      ),
+    ).resolves.toHaveLength(1);
+    for (const hiddenSearch of ["Virmel", "virmel-puuid", "virmel"] as const) {
+      await expect(
+        listVisibleDaresV2(
+          {
+            serverId: SERVER,
+            viewerDiscordId: CHALLENGER,
+            scope: "mine",
+            search: hiddenSearch,
+          },
+          db,
+        ),
+      ).resolves.toEqual([]);
+    }
+  });
+
   test("funds once, freezes the revision, and binds the deadline on acceptance", async () => {
     const dareId = await makeDraft();
     const fundIntent = await intent({

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -327,6 +327,17 @@ describe("Dare v2 draft and lifecycle", () => {
     );
     expect(mine).toHaveLength(1);
     expect(mine[0]?.targetAliases).toEqual(["Virmel"]);
+    await expect(
+      listVisibleDaresV2(
+        {
+          serverId: SERVER,
+          viewerDiscordId: CHALLENGER,
+          scope: "mine",
+          search: "Virmel",
+        },
+        db,
+      ),
+    ).resolves.toHaveLength(1);
     const inspected = await inspectVisibleDareV2(
       {
         dareId,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -197,6 +197,34 @@ const includeVisibleDare = {
   _count: { select: { evidence: true } },
 };
 
+const VISIBLE_DARE_PAGE_SIZE = 100;
+
+function matchesVisibleDareSearch(
+  row: VisibleDareRow,
+  item: DareV2ListItem,
+  search: string | undefined,
+): boolean {
+  if (search === undefined || search.length === 0) return true;
+  const normalizedSearch = search.toLocaleLowerCase();
+  const revision = activeRevision(row);
+  return (
+    revision.originalText.toLocaleLowerCase().includes(normalizedSearch) ||
+    item.targetAliases.some((alias) =>
+      alias.toLocaleLowerCase().includes(normalizedSearch),
+    )
+  );
+}
+
+function matchingVisibleDareItems(
+  rows: VisibleDareRow[],
+  search: string | undefined,
+): DareV2ListItem[] {
+  return rows
+    .map((row) => ({ row, item: listItem(row) }))
+    .filter(({ row, item }) => matchesVisibleDareSearch(row, item, search))
+    .map(({ item }) => item);
+}
+
 function visibleState(state: BucksDareV2State): boolean {
   return state !== "draft" && state !== "deleted";
 }
@@ -211,50 +239,45 @@ export async function listVisibleDaresV2(
   prisma: ExtendedPrismaClient,
 ): Promise<DareV2ListItem[]> {
   const search = input.search?.trim();
-  const rows = await prisma.bucksDareV2.findMany({
-    where: {
-      serverId: input.serverId,
-      AND: [
-        input.scope === "guild"
-          ? { dareState: { notIn: ["draft", "deleted"] } }
-          : {
-              dareState: { not: "deleted" },
-              OR: [
-                { challengerDiscordId: input.viewerDiscordId },
-                { targets: { some: { discordId: input.viewerDiscordId } } },
-                {
-                  contributions: {
-                    some: { discordId: input.viewerDiscordId },
-                  },
-                },
-              ],
-            },
-        ...(search === undefined || search.length === 0
-          ? []
-          : [
-              {
+  const matches: DareV2ListItem[] = [];
+  let cursorId: number | undefined;
+  while (matches.length < VISIBLE_DARE_PAGE_SIZE) {
+    const rows = await prisma.bucksDareV2.findMany({
+      where: {
+        serverId: input.serverId,
+        AND: [
+          input.scope === "guild"
+            ? { dareState: { notIn: ["draft", "deleted"] } }
+            : {
+                dareState: { not: "deleted" },
                 OR: [
+                  { challengerDiscordId: input.viewerDiscordId },
+                  { targets: { some: { discordId: input.viewerDiscordId } } },
                   {
-                    revisions: {
-                      some: { originalText: { contains: search } },
+                    contributions: {
+                      some: { discordId: input.viewerDiscordId },
                     },
                   },
-                  {
-                    revisions: {
-                      some: { targetsJson: { contains: search } },
-                    },
-                  },
-                  { targets: { some: { alias: { contains: search } } } },
                 ],
               },
-            ]),
-      ],
-    },
-    include: includeVisibleDare,
-    orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
-    take: 100,
-  });
-  return rows.map((row) => listItem(row));
+        ],
+      },
+      include: includeVisibleDare,
+      orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
+      take: VISIBLE_DARE_PAGE_SIZE,
+      ...(cursorId === undefined ? {} : { cursor: { id: cursorId }, skip: 1 }),
+    });
+    matches.push(...matchingVisibleDareItems(rows, search));
+    if (matches.length >= VISIBLE_DARE_PAGE_SIZE) {
+      return matches.slice(0, VISIBLE_DARE_PAGE_SIZE);
+    }
+    const lastRow = rows.at(-1);
+    if (lastRow === undefined || rows.length < VISIBLE_DARE_PAGE_SIZE) {
+      return matches;
+    }
+    cursorId = lastRow.id;
+  }
+  return matches;
 }
 
 export async function inspectVisibleDareV2(

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -239,6 +239,11 @@ export async function listVisibleDaresV2(
                       some: { originalText: { contains: search } },
                     },
                   },
+                  {
+                    revisions: {
+                      some: { targetsJson: { contains: search } },
+                    },
+                  },
                   { targets: { some: { alias: { contains: search } } } },
                 ],
               },

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-model-eval-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-model-eval-v2.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { resolveDareModelEvalTargets } from "#src/explore/dare-model-eval-v2.ts";
+
+const TARGET_ALIASES = { T1: "Virmel", T2: "Bryan" };
+
+describe("Dare v2 model eval target resolution", () => {
+  test("uses the target keys emitted by the model", () => {
+    const resolved = resolveDareModelEvalTargets({
+      targetKeys: ["T1"],
+      targetAliases: TARGET_ALIASES,
+    });
+
+    expect(resolved.targets.map((target) => target.key)).toEqual(["T1"]);
+    expect(resolved.issues).toContain(
+      "Emitted target keys drifted from the expected frozen targets.",
+    );
+  });
+
+  test("accepts the exact frozen target binding sequence", () => {
+    const resolved = resolveDareModelEvalTargets({
+      targetKeys: ["T1", "T2"],
+      targetAliases: TARGET_ALIASES,
+    });
+
+    expect(resolved.targets.map((target) => target.key)).toEqual(["T1", "T2"]);
+    expect(resolved.issues).toEqual([]);
+  });
+
+  test("rejects duplicate and unavailable emitted target keys", () => {
+    const resolved = resolveDareModelEvalTargets({
+      targetKeys: ["T3", "T3"],
+      targetAliases: TARGET_ALIASES,
+    });
+
+    expect(resolved.targets).toEqual([]);
+    expect(resolved.issues).toEqual([
+      "Emitted target keys contain duplicates.",
+      "Emitted target keys drifted from the expected frozen targets.",
+      "Emitted target key T3 is not available.",
+      "Emitted target key T3 is not available.",
+    ]);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-model-eval-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-model-eval-v2.ts
@@ -3,6 +3,8 @@ import {
   DareCompiledPlanV2Schema,
   DARE_V2_PARAPHRASE_CORPUS_VERSION,
   DARE_V2_PROMPT_VERSION,
+  DiscordAccountIdSchema,
+  type DareTargetBindingV2,
 } from "@scout-for-lol/data";
 
 export const DARE_V2_EVAL_MODEL = "gpt-5.6-luna";
@@ -33,4 +35,46 @@ export const DareModelEvalReportSchema = z.strictObject({
 
 export function dareModelEvalSha256(value: string): string {
   return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+export function resolveDareModelEvalTargets(input: {
+  targetKeys: string[];
+  targetAliases: Readonly<Record<string, string>>;
+}): { targets: DareTargetBindingV2[]; issues: string[] } {
+  const available = Object.entries(input.targetAliases).map(
+    ([key, alias], index) => ({
+      key,
+      alias,
+      discordId: DiscordAccountIdSchema.parse(
+        `2000000000000000${index.toString()}`,
+      ),
+      playerId: index + 1,
+      accounts: [
+        {
+          puuid: `${key}-eval-puuid`,
+          trackingStartedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    }),
+  );
+  const expectedKeys = available.map((target) => target.key);
+  const issues: string[] = [];
+  if (new Set(input.targetKeys).size !== input.targetKeys.length) {
+    issues.push("Emitted target keys contain duplicates.");
+  }
+  if (JSON.stringify(input.targetKeys) !== JSON.stringify(expectedKeys)) {
+    issues.push(
+      "Emitted target keys drifted from the expected frozen targets.",
+    );
+  }
+  const targets: DareTargetBindingV2[] = [];
+  for (const key of input.targetKeys) {
+    const target = available.find((candidate) => candidate.key === key);
+    if (target === undefined) {
+      issues.push(`Emitted target key ${key} is not available.`);
+    } else {
+      targets.push(target);
+    }
+  }
+  return { targets, issues };
 }

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-model-eval-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-model-eval-v2.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import {
+  DareCompiledPlanV2Schema,
+  DARE_V2_PARAPHRASE_CORPUS_VERSION,
+  DARE_V2_PROMPT_VERSION,
+} from "@scout-for-lol/data";
+
+export const DARE_V2_EVAL_MODEL = "gpt-5.6-luna";
+
+const DareModelEvalCaseSchema = z.strictObject({
+  id: z.string(),
+  paraphrase: z.string(),
+  passed: z.boolean(),
+  expectedCanonicalSha256: z.string(),
+  actualCanonicalSha256: z.string().nullable(),
+  actualCanonicalPlan: DareCompiledPlanV2Schema.nullable(),
+  expectedMeaning: z.string(),
+  actualMeaning: z.string().nullable(),
+  issues: z.array(z.string()),
+});
+
+export const DareModelEvalReportSchema = z.strictObject({
+  version: z.literal(2),
+  corpusVersion: z.literal(DARE_V2_PARAPHRASE_CORPUS_VERSION),
+  promptVersion: z.literal(DARE_V2_PROMPT_VERSION),
+  promptSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  corpusSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  model: z.literal(DARE_V2_EVAL_MODEL),
+  generatedAt: z.iso.datetime(),
+  passed: z.boolean(),
+  cases: z.array(DareModelEvalCaseSchema).min(1),
+});
+
+export function dareModelEvalSha256(value: string): string {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
@@ -102,12 +102,14 @@ export type DareExploreToolsInput = {
 export async function dareExploreEnabled(
   capability: BucksExploreCapability | null,
 ): Promise<boolean> {
-  return (
-    capability !== null &&
-    (await isPolicyEnabled("dare_v2", {
+  if (capability === null) return false;
+  const [dareEnabled, relationalEnabled] = await Promise.all([
+    isPolicyEnabled("dare_v2", { server: capability.serverId }),
+    isPolicyEnabled("scoutql_relational_enabled", {
       server: capability.serverId,
-    }))
-  );
+    }),
+  ]);
+  return dareEnabled && relationalEnabled;
 }
 
 function result(kind: string, message: string, data: unknown): DareToolResult {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.test.ts
@@ -1,7 +1,11 @@
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 import { createOfflineTrpcHarness } from "#src/testing/test-trpc-caller.ts";
-import { testAccountId, testGuildId } from "#src/testing/test-ids.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
 
 /**
  * The harness installs module mocks, so it must run before anything imports
@@ -9,6 +13,7 @@ import { testAccountId, testGuildId } from "#src/testing/test-ids.ts";
  */
 const ALLOWED_GUILD = testGuildId("111111");
 const OTHER_GUILD = testGuildId("222222");
+const DARE_CHANNEL = testChannelId("333333");
 
 const trpc = await createOfflineTrpcHarness("explore-router-test");
 
@@ -41,6 +46,8 @@ async function seedUsers(): Promise<void> {
 }
 
 beforeEach(async () => {
+  await trpc.prisma.bucksDareV2ConfirmationIntent.deleteMany();
+  await trpc.prisma.bucksDareV2.deleteMany();
   await trpc.prisma.exploreMessage.deleteMany();
   await trpc.prisma.exploreConversation.deleteMany();
   await seedUsers();
@@ -64,6 +71,7 @@ describe("explore router", () => {
 
     expect(await caller.explore.status()).toEqual({
       enabled: false,
+      daresEnabled: false,
       quota: [],
     });
     await expect(caller.explore.list()).rejects.toThrow(/not enabled/i);
@@ -75,6 +83,7 @@ describe("explore router", () => {
 
     const status = await caller.explore.status();
     expect(status.enabled).toBe(false);
+    expect(status.daresEnabled).toBe(false);
     await expect(caller.explore.list()).rejects.toThrow(/limited to a few/i);
   });
 
@@ -83,8 +92,72 @@ describe("explore router", () => {
 
     const status = await caller.explore.status();
     expect(status.enabled).toBe(true);
+    expect(status.daresEnabled).toBe(false);
     expect(status.quota.length).toBeGreaterThan(0);
     expect(await caller.explore.list()).toEqual([]);
+  });
+
+  test("exposes the Dare surface only for a relevant private draft", async () => {
+    await trpc.prisma.bucksDareV2.create({
+      data: {
+        serverId: ALLOWED_GUILD,
+        channelId: DARE_CHANNEL,
+        challengerDiscordId: OWNER,
+        openingStake: 20,
+      },
+    });
+
+    const ownerStatus = await trpc.authedCaller(OWNER).explore.status();
+    const strangerStatus = await trpc.authedCaller(STRANGER).explore.status();
+    expect(ownerStatus.daresEnabled).toBe(true);
+    expect(strangerStatus.daresEnabled).toBe(false);
+  });
+
+  test("reloads a confirmation intent's durable outcome for its actor", async () => {
+    const dare = await trpc.prisma.bucksDareV2.create({
+      data: {
+        serverId: ALLOWED_GUILD,
+        channelId: DARE_CHANNEL,
+        challengerDiscordId: OWNER,
+        openingStake: 20,
+      },
+    });
+    const intent = await trpc.prisma.bucksDareV2ConfirmationIntent.create({
+      data: {
+        dareId: dare.id,
+        revision: 1,
+        actorDiscordId: OWNER,
+        action: "fund",
+        actionPayload: JSON.stringify({ action: "fund" }),
+        idempotencyKey: "explore-router-durable-intent",
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    });
+    const owner = trpc.authedCaller(OWNER);
+
+    expect(
+      await owner.explore.dareIntentStatus({ intentId: intent.id }),
+    ).toMatchObject({ state: "pending", action: "fund", result: null });
+
+    await trpc.prisma.bucksDareV2ConfirmationIntent.update({
+      where: { id: intent.id },
+      data: {
+        consumedAt: new Date(),
+        resultJson: JSON.stringify({ kind: "funded" }),
+      },
+    });
+    expect(
+      await owner.explore.dareIntentStatus({ intentId: intent.id }),
+    ).toMatchObject({
+      state: "consumed",
+      action: "fund",
+      result: { kind: "funded" },
+    });
+    await expect(
+      trpc
+        .authedCaller(STRANGER)
+        .explore.dareIntentStatus({ intentId: intent.id }),
+    ).rejects.toThrow(/not found/i);
   });
 
   test("a conversation is not visible to another signed-in user", async () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
@@ -18,6 +18,8 @@ import {
 } from "#src/betting/dare-view-v2.ts";
 import { consumeDareV2ConfirmationIntent } from "#src/betting/dare-intent-consume-v2.ts";
 import { tryEnsureDareV2Callout } from "#src/betting/dare-callout-v2.ts";
+import { DareV2IntentActionSchema } from "#src/betting/dare-intent-v2.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
 import {
   assertExploreAccess,
@@ -95,6 +97,50 @@ async function requireExploreUserAndGuilds(
   };
 }
 
+async function dareSurfaceEnabled(
+  userId: DiscordAccountId,
+  guildIds: string[],
+): Promise<boolean> {
+  const [enabledByGuild, existingDare] = await Promise.all([
+    Promise.all(
+      guildIds.map(async (guildId) => {
+        const serverId = DiscordGuildIdSchema.parse(guildId);
+        const [dareEnabled, relationalEnabled] = await Promise.all([
+          isPolicyEnabled("dare_v2", { server: serverId }),
+          isPolicyEnabled("scoutql_relational_enabled", { server: serverId }),
+        ]);
+        return dareEnabled && relationalEnabled;
+      }),
+    ),
+    prisma.bucksDareV2.findFirst({
+      where: {
+        serverId: { in: guildIds },
+        dareState: { not: "deleted" },
+        OR: [{ dareState: { not: "draft" } }, { challengerDiscordId: userId }],
+      },
+      select: { id: true },
+    }),
+  ]);
+  return enabledByGuild.some(Boolean) || existingDare !== null;
+}
+
+async function requireGuildDareIntent(intentId: string, guildIds: string[]) {
+  const intent = await prisma.bucksDareV2ConfirmationIntent.findUnique({
+    where: { id: intentId },
+    include: { dare: { select: { serverId: true } } },
+  });
+  if (!guildIds.includes(intent?.dare.serverId ?? "")) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Confirmation not found.",
+    });
+  }
+  if (intent === null) {
+    throw new Error("A visible Dare confirmation unexpectedly disappeared.");
+  }
+  return intent;
+}
+
 const exploreProcedure = protectedProcedure;
 
 export const exploreRouter = router({
@@ -105,17 +151,18 @@ export const exploreRouter = router({
    */
   status: exploreProcedure.query(async ({ ctx }) => {
     if (!isExploreConfigured()) {
-      return { enabled: false, quota: [] };
+      return { enabled: false, daresEnabled: false, quota: [] };
     }
     try {
-      const userId = await requireExploreUser(ctx.user);
+      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
       return {
         enabled: true,
+        daresEnabled: await dareSurfaceEnabled(userId, guildIds),
         quota: getExploreQuotaStatus({ userId }).quota,
       };
     } catch (error) {
       if (error instanceof TRPCError && error.code === "FORBIDDEN") {
-        return { enabled: false, quota: [] };
+        return { enabled: false, daresEnabled: false, quota: [] };
       }
       throw error;
     }
@@ -196,20 +243,38 @@ export const exploreRouter = router({
       return await reviseDareDraftEditorV2(input, userId, guildIds);
     }),
 
-  confirmDareIntent: webMutationProcedure
+  dareIntentStatus: exploreProcedure
     .input(z.strictObject({ intentId: z.uuid() }))
-    .mutation(async ({ ctx, input }) => {
+    .query(async ({ ctx, input }) => {
       const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      const intent = await prisma.bucksDareV2ConfirmationIntent.findUnique({
-        where: { id: input.intentId },
-        include: { dare: { select: { serverId: true } } },
-      });
-      if (intent === null || !guildIds.includes(intent.dare.serverId)) {
+      const intent = await requireGuildDareIntent(input.intentId, guildIds);
+      if (intent.actorDiscordId !== userId) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: "Confirmation not found.",
         });
       }
+      return {
+        state:
+          intent.consumedAt === null
+            ? intent.expiresAt.getTime() <= Date.now()
+              ? ("expired" as const)
+              : ("pending" as const)
+            : ("consumed" as const),
+        action: DareV2IntentActionSchema.parse(intent.action),
+        expiresAt: intent.expiresAt.toISOString(),
+        result:
+          intent.resultJson === null
+            ? null
+            : z.json().parse(JSON.parse(intent.resultJson)),
+      };
+    }),
+
+  confirmDareIntent: webMutationProcedure
+    .input(z.strictObject({ intentId: z.uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
+      const intent = await requireGuildDareIntent(input.intentId, guildIds);
       const outcome = await consumeDareV2ConfirmationIntent({
         intentId: input.intentId,
         serverId: DiscordGuildIdSchema.parse(intent.dare.serverId),

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -18,6 +18,7 @@ Most of what `/bb` does — except `/bb ask` — is also available on the
 | `/bb history`       | Paged transaction ledger with running balances        | Private                        |
 | `/bb transfer`      | Send half of a total spend to another wallet          | Private result, public receipt |
 | `/bb notifications` | Choose settlement DMs about your bets and bets on you | Private                        |
+| `/bb dare`          | Draft a ScoutQL-backed challenge from plain language  | Private preview, then public   |
 | `/bb rules`         | The complete rulebook                                 | **Public**                     |
 | `/bb prizes`        | The joke prize catalogue                              | **Public**                     |
 
@@ -34,6 +35,13 @@ server the Explore agent also carries the bounded Bucks analytics tools, so a
 question like "how have I done on parlays this month?" is asked there. Answers
 are saved to your private Explore conversation in the web app, where you can
 continue, publish, or share them.
+
+`/bb dare` also starts a new private Explore conversation. Scout translates the
+request into a versioned contract, saves an unfunded draft, and returns a
+preview that spells out same-game or cross-game scope, target relationships,
+queues, game and time bounds, stake, and generated contract ScoutQL. Funding is
+never automatic: use **Confirm and fund**, **Revise in Explore**, or **Cancel
+draft** from that preview.
 
 ## Options
 
@@ -65,6 +73,25 @@ several delivered DMs so it stays discoverable without becoming noise.
 `bets_on_you` controls settlement DMs about other users betting on your tracked
 player. Settings are independent and scoped to this server.
 
+### `/bb dare`
+
+| Option   | Required | Values                                        |
+| -------- | -------- | --------------------------------------------- |
+| `dare`   | yes      | Plain-language contract, up to 400 characters |
+| `amount` | yes      | Positive whole-BB opening stake               |
+
+Name one to five linked Scout players. Conditions inside one game set must all
+hold in the same match; conditions allowed to occur in different matches use
+separate game sets. The contract can combine those sets with nested AND, OR,
+and NOT expressions, count matching games, aggregate projected values, bind a
+queue, select the first N games, and require targets to play in the same match,
+on the same team, or against one another.
+
+If Scout cannot represent the request without guessing—most importantly an
+absolute deadline without an IANA timezone—the draft stays private so it can be
+clarified in Explore. Nothing is debited until a ten-minute confirmation intent
+is confirmed.
+
 ## Buttons
 
 The pre-match message carries the outcome market's controls. Match and weekly
@@ -76,6 +103,8 @@ than posting a receipt for each bet.
 | Pre-match card | `WIN · 1 BB`, `WIN · 5 BB`, `LOSE · 1 BB`, `LOSE · 5 BB`, `Cancel` |
 | Match parlay   | `YES 1`, `YES 5`, `NO 1`, `NO 5`, `Cancel`                         |
 | Weekly parlay  | `YES · 1 BB`, `NO · 1 BB`, `Cancel`                                |
+| Dare draft     | `Confirm and fund`, `Revise in Explore`, `Cancel draft`            |
+| Funded dare    | `Accept`, `Decline`, `Cancel and refund`, `Pile on` denominations  |
 | `/bb history`  | `Previous`, `Next`                                                 |
 
 On a mixed lobby the pre-match buttons read `Blue`/`Red` instead of

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
@@ -6,9 +6,21 @@ sidebar:
 ---
 
 import {
+  DARE_V2_MAX_ELIGIBLE_GAMES,
+  DARE_V2_MAX_EXPRESSION_DEPTH,
+  DARE_V2_MAX_GAME_SETS,
+  DARE_V2_MAX_HORIZON_DAYS,
+  DARE_V2_MAX_JOINED_RELATIONS,
+  DARE_V2_MAX_PREDICATES,
+  DARE_V2_MAX_QUERY_LENGTH,
+  DARE_V2_MAX_TARGETS,
+} from "@scout-for-lol/data";
+import {
   BETTING_WINDOW_MS,
   BUCKS_EARNING_QUEUES,
   BUTTON_STAKES,
+  DARE_ACCEPT_WINDOW_MS,
+  DARE_V2_INTENT_TTL_MS,
   HOUSE_BANKROLL,
   HOUSE_MATCH_LIMIT,
   MINIMUM_BUCKS_TRANSFER,
@@ -73,6 +85,60 @@ detection cannot silently extend it.
 
 A market that never receives a result is voided and fully refunded after{" "}
 {VOID_GRACE_MS / 3_600_000} hours.
+
+## Scout dares
+
+A Dare v2 draft is private and unfunded. It can be revised repeatedly in
+Explore, historically previewed against data Scout already has, or deleted.
+Funding freezes that exact revision, debits the opening stake, publishes the
+contract in the server, and opens a {DARE_ACCEPT_WINDOW_MS / 3_600_000}-hour
+acceptance window. Every target must accept. A decline, acceptance expiry, or
+challenger cancellation during that window returns every contribution in full.
+
+After all targets accept, relative deadlines are bound to immutable timestamps
+and the dare becomes active. Active contracts cannot be edited or cancelled.
+Scout evaluates evidence in match-end-time then match-ID order and may settle
+early only when the result cannot reverse. At the deadline or game cap, `true`
+pays the proving targets, `false` refunds contributors with the normal
+cancellation cut, and an unknowable result caused by missing evidence voids
+with full refunds.
+
+Targets risk no BB. Anyone who contributes funds the pot. A successful proof
+splits the pot among only the targets required by the decisive Boolean branch,
+then applies the normal winner house cut. An unsuccessful dare returns each
+contributor's stake less the normal cancellation cut. Declines, acceptance
+expiry, cancellation before activation, and missing-evidence voids are full,
+fee-free refunds.
+
+Conditions may nest `AND`, `OR`, and `NOT`, and numeric values may be added,
+subtracted, multiplied, or divided inside a condition. For example, two named
+opponents can be required to combine for at least 20 kills in the same match;
+that is one game set, not two independent achievements.
+
+A game-set condition can also count a named champion among a target's allies
+or opponents, so “against Yasuo” is bound to the same qualifying match. Retained
+timeline events may be filtered by event type, participant role, elapsed-time
+range, and item ID; for example, an `ITEM_PURCHASED` event for item `3089`
+proves a Rabadon's Deathcap purchase. If Scout did not retain that timeline,
+the condition is unknown rather than false.
+
+| Dare contract limit    | Value                                                                 |
+| ---------------------- | --------------------------------------------------------------------- |
+| Targets                | 1–{DARE_V2_MAX_TARGETS}                                               |
+| Horizon                | at most {DARE_V2_MAX_HORIZON_DAYS} days                               |
+| Eligible games         | at most {DARE_V2_MAX_ELIGIBLE_GAMES}                                  |
+| Game sets / CTEs       | at most {DARE_V2_MAX_GAME_SETS}                                       |
+| Joined relations       | at most {DARE_V2_MAX_JOINED_RELATIONS}                                |
+| Predicates             | at most {DARE_V2_MAX_PREDICATES}                                      |
+| Boolean depth          | at most {DARE_V2_MAX_EXPRESSION_DEPTH}                                |
+| Canonical query length | at most {DARE_V2_MAX_QUERY_LENGTH.toLocaleString("en-US")} characters |
+| Action confirmation    | {DARE_V2_INTENT_TTL_MS / 60_000} minutes, single use                  |
+
+Contract queues default to ranked solo and flex, and may use another queue only
+when Scout can classify it reliably. A timeline condition is rejected for a
+queue whose timelines Scout cannot supply. Scout does not call Riot solely to
+backfill a dare: historical previews and settlement use retained lake data and
+future ingestion.
 
 ## Weekly parlays
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/dashboard.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/dashboard.md
@@ -15,12 +15,32 @@ A beta deployment of the same dashboard runs at
 
 ## Top level
 
-| Route                  | Contents                                    |
-| ---------------------- | ------------------------------------------- |
-| `/app/`                | Server picker — the servers you can manage  |
-| `/app/welcome`         | Guided onboarding wizard                    |
-| `/app/installed`       | Landing page after adding Scout to a server |
-| `/app/g/<server id>/…` | The workspace for one server                |
+| Route                  | Contents                                          |
+| ---------------------- | ------------------------------------------------- |
+| `/app/`                | Server picker — the servers you can manage        |
+| `/app/welcome`         | Guided onboarding wizard                          |
+| `/app/installed`       | Landing page after adding Scout to a server       |
+| `/app/explore`         | Persistent Explore conversations and dare drawers |
+| `/app/g/<server id>/…` | The workspace for one server                      |
+
+## Explore
+
+Explore keeps private, branching conversations over Scout's recorded match
+corpus. When Dare v2 is enabled for one of your Bryan Bucks servers, the header
+also opens searchable **My Dares** and **Guild Dares** drawers.
+
+**My Dares** includes your private unfunded drafts and every visible funded
+contract. **Guild Dares** includes funded contracts in servers you currently
+share; it never exposes another member's draft. A dare card shows its stable ID,
+revision, lifecycle state, explicit same-game or cross-game meaning, targets,
+queue and time bounds, current pot, evidence progress, and reproducible proof
+after settlement.
+
+Draft owners can validate, historically preview, revise, or delete a draft.
+The advanced editor exposes the typed contract plan and generated ScoutQL with
+diagnostics, semantic explanation, and a meaning diff before revision. Funding,
+acceptance, decline, contribution, and cancellation first create a revision-
+bound, single-use confirmation; merely opening or sharing a card never moves BB.
 
 ## Server workspace sections
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql-sources.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql-sources.mdx
@@ -98,6 +98,27 @@ a leaderboard of numbers.
 `match_participants` is the right source for almost every report: one row per
 tracked player per finished match.
 
+### Dare contract timeline relations
+
+Dare v2's generated contract profile can additionally read four normalized
+relations that are not available as top-level report-editor sources:
+
+| Relation                      | Contents                                                                          |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| `timeline_events`             | Stable event IDs, match IDs, event types, timestamps, item IDs, and event context |
+| `timeline_event_participants` | A timeline event's participant PUUID and semantic role, such as killer or victim  |
+| `timeline_participant_frames` | Per-participant frame values at a timeline timestamp                              |
+| `timeline_coverage`           | A complete-coverage marker for each retained, supported match timeline            |
+
+Coverage is evidence, not a convenience flag. A coverage row means Scout
+retained and completely normalized the supported timeline. No row means the
+required evidence is missing and propagates `null`; unsupported queue choices
+are rejected before a contract can be funded. A complete timeline with no
+matching event evaluates to zero. That distinction prevents “Scout did not
+retain this timeline” from being treated as “the event did not happen.” These
+relations are joined only through the generated, bounded contract compiler and
+inherit the same guild/player scope as the match rows.
+
 ### The time column
 
 A source's time column is the one a [time

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
@@ -25,6 +25,26 @@ conveniences layered on top: `AVG(win)` is an error in DuckDB and an error
 here, aggregates are always written out, and a name in `WITH (...)` has to be a
 name the `SELECT` produced.
 
+## Report ScoutQL and contract ScoutQL
+
+The editor syntax documented on this page is report ScoutQL: one bounded data
+source plus grouping, aggregation, ordering, and rendering. Dare v2 contracts
+use a generated relational profile of ScoutQL. The authoring tools—not raw user
+SQL—produce its qualified columns, aliases, non-recursive CTEs, bounded joins,
+scalar subqueries, and deterministic first-N game sets.
+
+Contract ScoutQL always returns exactly one nullable Boolean named `achieved`:
+`true` means proven, `false` means conclusively not achieved, and `null` means
+the bounded evidence is insufficient. Its compiler accepts only the closed
+match and timeline catalog, freezes every `dare_target('Tn')` binding at
+funding, parameterizes values, and rejects wall-clock or dynamic player
+resolution. The ordinary report editor does not accept this relational profile;
+inspect and revise it through the dare card in Explore.
+
+This separation is deliberate. A contract must remain reproducible after a
+player rename, prompt change, or compiler upgrade, while an interactive report
+is allowed to resolve today's player aliases and render rows for exploration.
+
 ## Clause order
 
 ```text

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-explore-conversation.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-explore-conversation.md
@@ -63,6 +63,21 @@ shows.
 You have completed an Explore conversation: one question, one evidence-aware
 answer, and one useful refinement.
 
+## Optional: continue a Discord dare
+
+In a Bryan Bucks server with Dare v2 enabled, `/bb dare` creates a separate
+private Explore conversation and an unfunded draft. Open **Revise in Explore**
+from Discord, then tell Scout what was wrong in ordinary language—for example,
+“the CS and duration conditions must happen in the same game.”
+
+Before replacing the draft, inspect the card's explicit scope, targets,
+participation relationship, queues, first-N or game cap, deadline, stake, plain
+meaning, and canonical ScoutQL. Historical preview uses only matches and
+timelines already present in Scout's lake; missing timeline coverage is shown as
+unknown rather than as a failed condition. Save the revision only when the diff
+matches the intended dare, then prepare and confirm funding. The confirmation
+is single-use and expires after ten minutes.
+
 ## Next steps
 
 - [Find and interpret a player profile](/docs/how-to/find-player-profile/)

--- a/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
+++ b/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 layout: "../layouts/ContentLayout.astro"
 title: "Privacy Policy"
-subtitle: "Last updated: August 24, 2026"
+subtitle: "Last updated: September 1, 2026"
 description: "How Scout for League of Legends collects, uses, and protects your data. We never sell your data."
 ---
 
@@ -83,6 +83,23 @@ to share one. Sharing creates a link to a frozen copy of the selected
 conversation branch, including its question, answer, caveats, and presentation.
 Anyone with an active share link may view that frozen copy. Later follow-ups do
 not change it, and the owner can revoke the link.
+
+Scout dares use Explore conversations and separate contract records. Unfunded
+drafts, revisions, generated ScoutQL, historical previews, and action
+confirmations are visible only to the challenger. Funding freezes one revision
+and makes the contract, target aliases, stake and contribution totals, progress,
+and final proof visible to members of that Discord server. Targets must accept
+before scoring begins; they do not stake Bryan Bucks. Server administrators may
+inspect a funded contract but cannot rewrite it.
+
+Dare contracts freeze the selected Scout player and Riot account identities so
+a later rename does not change the agreement. Settlement retains normalized
+per-match evidence, timeline coverage state, source references, evaluation
+trace, and qualifying match timestamps needed to reproduce the result. Scout
+uses timelines already retained for normal ingestion and future supported
+timelines; it does not request Riot match history solely to backfill a dare.
+Shared Explore transcripts redact raw tool payloads, including dare mutation
+inputs and internal account identifiers.
 
 ### Usage Data
 

--- a/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
+++ b/packages/scout-for-lol/packages/frontend/src/pages/privacy.mdx
@@ -85,8 +85,8 @@ Anyone with an active share link may view that frozen copy. Later follow-ups do
 not change it, and the owner can revoke the link.
 
 Scout dares use Explore conversations and separate contract records. Unfunded
-drafts, revisions, generated ScoutQL, historical previews, and action
-confirmations are visible only to the challenger. Funding freezes one revision
+drafts, revisions, generated ScoutQL, and historical previews are visible only
+to the challenger. Action confirmations are private to the acting user. Funding freezes one revision
 and makes the contract, target aliases, stake and contribution totals, progress,
 and final proof visible to members of that Discord server. Targets must accept
 before scoring begins; they do not stake Bryan Bucks. Server administrators may


### PR DESCRIPTION
## Why

Dare v2 needs a durable web surface for revision, progress, advanced inspection, and discoverability, plus product tests that make natural-language translation changes reviewable.

## What

- Adds searchable My Dares and Guild Dares drawers with draft, confirmation, action, and progress cards.
- Adds an advanced contract-plan editor with diagnostics, canonical formatting, semantic explanation, historical preview, and a diff before draft replacement.
- Updates Explore trace presentation while keeping raw tool payloads private.
- Adds the checked-in paraphrase corpus and deterministic/model evaluation harness for same-game wording, separate branches, nested booleans, target relationships, first-N, queues, dates, aggregates, and timeline events.
- Updates command reference, public rules, ScoutQL/timeline docs, Explore tutorial, privacy and limits references, and the human wiki.

## Verification

- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/data --filter=@scout-for-lol/backend --filter=@scout-for-lol/app --filter=@scout-for-lol/docs-site --filter=@scout-for-lol/frontend --filter=@shepherdjerred/docs-wiki` (39/39 tasks)
- `bunx prisma validate`
- `git diff --check`

Live model evaluation was attempted through the exact 1Password reference but Desktop authorization timed out before the request ran. Browser and Discord visual demos remain pending because no in-app browser session is available.