### PR TITLE
feat(scout-for-lol): make Dare ScoutQL authoritatively editable

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/explore-dare-editor.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dare-editor.tsx
@@ -1,9 +1,7 @@
 import { useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
-  DareCompiledPlanV2Schema,
   DareDeadlineSpecV2Schema,
-  type DareCompiledPlanV2,
   type DareDeadlineSpecV2,
 } from "@scout-for-lol/data";
 import { Button } from "@scout-for-lol/design-system/components/button";
@@ -23,7 +21,6 @@ type EditorDare = {
   id: number;
   currentRevision: number;
   originalText: string;
-  plan: DareCompiledPlanV2;
   deadlineSpec: DareDeadlineSpecV2;
   openingStake: number;
   canonicalScoutQl: string;
@@ -34,6 +31,16 @@ type ValidatedDraft = {
   canonicalScoutQl: string;
   plainLanguage: string;
   semanticProofPlan: string;
+  scoutQlPlanHash: string;
+  scoutQlFacts: {
+    cteCount: number;
+    joinedRelations: number;
+    predicates: number;
+    maxExpressionDepth: number;
+    physicalSources: string[];
+    functions: string[];
+    targetKeys: string[];
+  };
 };
 
 export function ExploreDareEditor(props: { dare: EditorDare }) {
@@ -41,9 +48,7 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [originalText, setOriginalText] = useState(props.dare.originalText);
-  const [planText, setPlanText] = useState(
-    JSON.stringify(props.dare.plan, null, 2),
-  );
+  const [queryText, setQueryText] = useState(props.dare.canonicalScoutQl);
   const [deadlineText, setDeadlineText] = useState(
     JSON.stringify(props.dare.deadlineSpec, null, 2),
   );
@@ -79,22 +84,17 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
   }
 
   function editorInput() {
-    let rawPlan: unknown;
     let rawDeadline: unknown;
     try {
-      rawPlan = JSON.parse(planText);
       rawDeadline = JSON.parse(deadlineText);
     } catch {
-      setError("The plan and deadline must be valid JSON.");
+      setError("The deadline must be valid JSON.");
       return null;
     }
-    const plan = DareCompiledPlanV2Schema.safeParse(rawPlan);
     const deadlineSpec = DareDeadlineSpecV2Schema.safeParse(rawDeadline);
     const openingStake = Number(stakeText);
-    if (!plan.success || !deadlineSpec.success) {
-      setError(
-        "The plan or deadline does not match the Dare v2 contract schema.",
-      );
+    if (!deadlineSpec.success) {
+      setError("The deadline does not match the Dare v2 contract schema.");
       return null;
     }
     if (!Number.isSafeInteger(openingStake) || openingStake <= 0) {
@@ -105,7 +105,7 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
       dareId: props.dare.id,
       expectedRevision: props.dare.currentRevision,
       originalText,
-      plan: plan.data,
+      queryText,
       deadlineSpec: deadlineSpec.data,
       openingStake,
     };
@@ -134,6 +134,7 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
         return null;
       }
       setError(null);
+      setQueryText(result.canonicalScoutQl);
       setValidated(result);
       return result;
     } catch (error_) {
@@ -238,8 +239,9 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
         <DialogHeader>
           <DialogTitle>Edit Dare #{props.dare.id.toString()}</DialogTitle>
           <DialogDescription>
-            Edit the typed contract plan; Scout regenerates canonical ScoutQL
-            and its exact meaning. No funded contract can enter this editor.
+            Edit the authoritative ScoutQL contract; Scout validates, formats,
+            explains, and backtests it before replacing this private draft. No
+            funded contract can enter this editor.
           </DialogDescription>
         </DialogHeader>
         <fieldset disabled={revise.isPending} className="space-y-4">
@@ -258,16 +260,16 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
                 }}
               />
             </label>
-            <label htmlFor={fieldId("plan")} className="space-y-1 text-sm">
-              <span className="font-medium">Contract plan</span>
+            <label htmlFor={fieldId("scoutql")} className="space-y-1 text-sm">
+              <span className="font-medium">ScoutQL contract</span>
               <Textarea
-                id={fieldId("plan")}
+                id={fieldId("scoutql")}
                 className="min-h-80 font-mono text-xs"
                 spellCheck={false}
-                value={planText}
+                value={queryText}
                 onChange={(event) => {
                   changed();
-                  setPlanText(event.target.value);
+                  setQueryText(event.target.value);
                 }}
               />
             </label>
@@ -343,6 +345,13 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
               <ScoutQlCode queryText={validated.canonicalScoutQl} />
               <p className="whitespace-pre-wrap text-sm">
                 {validated.plainLanguage}
+              </p>
+              <p className="text-xs text-scout-muted-foreground">
+                Plan {validated.scoutQlPlanHash.slice(0, 12)} ·{" "}
+                {validated.scoutQlFacts.cteCount.toString()} CTEs ·{" "}
+                {validated.scoutQlFacts.joinedRelations.toString()} joins ·{" "}
+                {validated.scoutQlFacts.predicates.toString()} predicates ·
+                depth {validated.scoutQlFacts.maxExpressionDepth.toString()}
               </p>
             </section>
           )}

--- a/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
+++ b/packages/scout-for-lol/packages/backend/scripts/evaluate-dare-paraphrases.ts
@@ -11,7 +11,7 @@ import {
   canonicalDarePlanV2,
 } from "#src/betting/dare-plan-canonical-v2.ts";
 import { renderDarePlanV2 } from "#src/betting/dare-render-v2.ts";
-import { DareDefinitionToolInputSchema } from "#src/explore/dare-tools.ts";
+import { DareDefinitionToolInputSchema } from "#src/explore/dare-tool-schemas.ts";
 import {
   DARE_V2_EVAL_MODEL,
   DareModelEvalReportSchema,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
@@ -65,56 +65,26 @@ function arithmeticSql(
 
 function participantRateSql(
   value: Extract<DareValueV2, { kind: "participant_rate" }>,
-  gameSet: DareGameSetV2,
 ): string {
-  const alias = aliasForTarget(gameSet, value.target);
-  if (value.field === "cs_per_minute") {
-    return `(${alias}.creep_score * 60.0 / NULLIF(${alias}.time_played, 0))`;
-  }
-  if (value.field === "damage_per_minute") {
-    return `(${alias}.total_damage_dealt_to_champions * 60.0 / NULLIF(${alias}.time_played, 0))`;
-  }
-  return `((${alias}.kills + ${alias}.assists) * 1.0 / GREATEST(${alias}.deaths, 1))`;
+  return `dare_rate(${quote(value.target)}, ${quote(value.field)})`;
 }
 
 function relatedParticipantSql(
   value: Extract<DareValueV2, { kind: "related_participant_count" }>,
-  gameSet: DareGameSetV2,
 ): string {
-  const alias = aliasForTarget(gameSet, value.target);
-  const relationship =
-    value.relationship === "ally"
-      ? `rp.team_id = ${alias}.team_id AND rp.puuid <> ${alias}.puuid`
-      : `rp.team_id <> ${alias}.team_id`;
-  const champion =
-    value.championName === null
-      ? ""
-      : ` AND rp.champion_name = ${quote(normalizeChampionName(value.championName))}`;
-  return `(SELECT COUNT(*) FROM match_participants AS rp WHERE rp.match_id = p0.match_id AND ${relationship}${champion})`;
+  return `dare_related_participant_count(${quote(value.target)}, ${quote(value.relationship)}, ${value.championName === null ? "NULL" : quote(normalizeChampionName(value.championName))})`;
 }
 
 function timelineEventCountSql(
   value: Extract<DareValueV2, { kind: "timeline_event_count" }>,
-  gameSet: DareGameSetV2,
 ): string {
-  const participantJoin =
-    value.target === null
-      ? ""
-      : ` JOIN timeline_event_participants AS tep ON tep.event_id = te.event_id AND tep.puuid = ${aliasForTarget(gameSet, value.target)}.puuid${value.role === null ? "" : ` AND tep.role = ${quote(value.role)}`}`;
-  const clauses = [
-    "te.match_id = p0.match_id",
-    `te.event_type = ${quote(value.eventType)}`,
-  ];
-  if (value.afterMs !== null) {
-    clauses.push(`te.event_timestamp_ms >= ${value.afterMs.toString()}`);
-  }
-  if (value.beforeMs !== null) {
-    clauses.push(`te.event_timestamp_ms <= ${value.beforeMs.toString()}`);
-  }
-  if (value.itemId !== null) {
-    clauses.push(`te.item_id = ${value.itemId.toString()}`);
-  }
-  return `CASE WHEN EXISTS (SELECT 1 FROM timeline_coverage AS tc WHERE tc.match_id = p0.match_id AND tc.coverage_state = 'complete') THEN (SELECT COUNT(DISTINCT te.event_id) FROM timeline_events AS te${participantJoin} WHERE ${clauses.join(" AND ")}) ELSE NULL END`;
+  const argument = (argumentValue: string | number | null) =>
+    argumentValue === null
+      ? "NULL"
+      : typeof argumentValue === "number"
+        ? argumentValue.toString()
+        : quote(argumentValue);
+  return `dare_timeline_event_count(${quote(value.eventType)}, ${argument(value.target)}, ${argument(value.role)}, ${argument(value.afterMs)}, ${argument(value.beforeMs)}, ${argument(value.itemId)})`;
 }
 
 function valueSql(value: DareValueV2, gameSet: DareGameSetV2): string {
@@ -122,7 +92,7 @@ function valueSql(value: DareValueV2, gameSet: DareGameSetV2): string {
     return `${aliasForTarget(gameSet, value.target)}.${value.field}`;
   }
   if (value.kind === "participant_rate") {
-    return participantRateSql(value, gameSet);
+    return participantRateSql(value);
   }
   if (value.kind === "game") {
     return value.field === "duration_seconds"
@@ -130,12 +100,12 @@ function valueSql(value: DareValueV2, gameSet: DareGameSetV2): string {
       : "p0.queue";
   }
   if (value.kind === "related_participant_count") {
-    return relatedParticipantSql(value, gameSet);
+    return relatedParticipantSql(value);
   }
   if (value.kind === "arithmetic") {
     return arithmeticSql(value, gameSet);
   }
-  return timelineEventCountSql(value, gameSet);
+  return timelineEventCountSql(value);
 }
 
 function predicateSql(
@@ -154,18 +124,10 @@ function predicateSql(
 
 function resultSql(expression: DareResultExpressionV2): string {
   if (expression.kind === "matching_games") {
-    const comparison = comparisonOperator(expression.operator);
-    const threshold = expression.threshold.toString();
-    return `(SELECT CASE WHEN (lower_bound ${comparison} ${threshold}) = (upper_bound ${comparison} ${threshold}) THEN (lower_bound ${comparison} ${threshold}) ELSE NULL END FROM (SELECT COUNT(*) FILTER (WHERE matched IS TRUE) AS lower_bound, COUNT(*) FILTER (WHERE matched IS NOT FALSE) AS upper_bound FROM ${expression.gameSet}))`;
+    return `dare_matching_games(${quote(expression.gameSet)}, ${quote(expression.operator)}, ${expression.threshold.toString()})`;
   }
   if (expression.kind === "aggregate") {
-    const aggregate = {
-      sum: "SUM",
-      average: "AVG",
-      minimum: "MIN",
-      maximum: "MAX",
-    }[expression.function];
-    return `CASE WHEN EXISTS (SELECT 1 FROM ${expression.gameSet} WHERE matched IS NULL OR (matched IS TRUE AND ${expression.projection} IS NULL)) THEN NULL WHEN NOT EXISTS (SELECT 1 FROM ${expression.gameSet} WHERE matched IS TRUE) THEN FALSE ELSE (SELECT ${aggregate}(${expression.projection}) FROM ${expression.gameSet} WHERE matched IS TRUE) ${comparisonOperator(expression.operator)} ${expression.threshold.toString()} END`;
+    return `dare_aggregate(${quote(expression.gameSet)}, ${quote(expression.projection)}, ${quote(expression.function)}, ${quote(expression.operator)}, ${expression.threshold.toString()})`;
   }
   if (expression.kind === "not") {
     return `NOT (${resultSql(expression.operand)})`;

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contract-compiler-v2.ts
@@ -417,10 +417,17 @@ export function darePlanSemanticIssues(
     issues.push("Game set names must be unique.");
   }
   const facts = { predicates: 0, maxDepth: 0 };
+  const referencedTargetKeys = new Set<string>();
   for (const gameSet of plan.gameSets) {
     const setFacts = inspectGameSet(gameSet, targetKeys, issues);
+    for (const key of gameSet.targetKeys) referencedTargetKeys.add(key);
     facts.predicates += setFacts.predicates;
     facts.maxDepth = Math.max(facts.maxDepth, setFacts.maxDepth);
+  }
+  for (const target of targets) {
+    if (!referencedTargetKeys.has(target.key)) {
+      issues.push(`Frozen target ${target.key} is not used by any game set.`);
+    }
   }
   inspectResult(plan.result, 1, { facts, gameSets, issues });
   if (facts.predicates > DARE_V2_MAX_PREDICATES) {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evaluator-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evaluator-v2.test.ts
@@ -127,12 +127,11 @@ describe("Dare evaluator v2 same-game scope", () => {
   test("formats an explicit single game set", () => {
     const query = formatDareScoutQlV2(PLAN);
     expect(query).toContain("qualifying_game AS (");
-    expect(query).toContain("p0.creep_score * 60.0");
+    expect(query).toContain("dare_rate('virmel', 'cs_per_minute') >= 8");
     expect(query).toContain("p0.time_played >= 1200");
     expect(query).toContain(
-      "COUNT(*) FILTER (WHERE matched IS TRUE) AS lower_bound",
+      "dare_matching_games('qualifying_game', 'gte', 1) AS achieved",
     );
-    expect(query).toContain("ELSE NULL END");
     expect(query).toContain("eligible_matches AS");
     expect(query).toContain("ORDER BY game_end_at ASC, match_id ASC");
   });
@@ -406,7 +405,7 @@ describe("Dare evaluator v2 match and timeline context", () => {
       }),
     ).toBe(true);
     expect(formatDareScoutQlV2(contextualPlan)).toContain(
-      "rp.team_id <> p0.team_id AND rp.champion_name = 'Yasuo'",
+      "dare_related_participant_count('virmel', 'opponent', 'Yasuo')",
     );
   });
 
@@ -445,7 +444,9 @@ describe("Dare evaluator v2 match and timeline context", () => {
     expect(
       evaluateDareEvidenceV2({ plan: itemPlan, evidence: [itemEvidence] }),
     ).toBe(true);
-    expect(formatDareScoutQlV2(itemPlan)).toContain("te.item_id = 3089");
+    expect(formatDareScoutQlV2(itemPlan)).toContain(
+      "dare_timeline_event_count('ITEM_PURCHASED', 'virmel', 'subject', NULL, NULL, 3089)",
+    );
   });
 
   test("filters match-wide timeline events by participant role", () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-ast-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-ast-v2.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+
+export type RelationalScoutQlAstValue = unknown;
+
+const AstObjectSchema = z.record(z.string(), z.unknown());
+const AstArraySchema = z.array(z.unknown());
+const AstConstantSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+export type AstObject = z.infer<typeof AstObjectSchema>;
+
+export class DareScoutQlProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DareScoutQlProfileError";
+  }
+}
+
+export function astObject(value: unknown, label: string): AstObject {
+  const parsed = AstObjectSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new DareScoutQlProfileError(`Dare ScoutQL requires ${label}.`);
+  }
+  return parsed.data;
+}
+
+export function astArray(
+  value: unknown,
+  label: string,
+): RelationalScoutQlAstValue[] {
+  const parsed = AstArraySchema.safeParse(value);
+  if (!parsed.success) {
+    throw new DareScoutQlProfileError(`Dare ScoutQL requires ${label}.`);
+  }
+  return parsed.data;
+}
+
+export function astString(value: unknown, label: string): string {
+  const parsed = z.string().safeParse(value);
+  if (!parsed.success) {
+    throw new DareScoutQlProfileError(`Dare ScoutQL requires ${label}.`);
+  }
+  return parsed.data;
+}
+
+export function expressionClass(object: AstObject): string {
+  return astString(object["class"], "an expression class");
+}
+
+export function expressionType(object: AstObject): string {
+  return astString(object["type"], "an expression type");
+}
+
+export function constantValue(
+  expression: RelationalScoutQlAstValue,
+): string | number | boolean | null {
+  const object = astObject(expression, "a constant expression");
+  if (expressionClass(object) === "CAST") {
+    const value = constantValue(object["child"]);
+    const castType = astObject(object["cast_type"], "a cast type");
+    if (typeof value === "string" && castType["id"] === "BOOLEAN") {
+      if (value === "t" || value === "true") return true;
+      if (value === "f" || value === "false") return false;
+    }
+    return value;
+  }
+  if (expressionClass(object) !== "CONSTANT") {
+    throw new DareScoutQlProfileError(
+      "Dare ScoutQL macro arguments must be literals.",
+    );
+  }
+  const value = astObject(object["value"], "a constant value");
+  if (value["is_null"] === true) return null;
+  const parsed = AstConstantSchema.safeParse(value["value"]);
+  if (parsed.success) return parsed.data;
+  throw new DareScoutQlProfileError(
+    "Dare ScoutQL contains an unsupported literal.",
+  );
+}
+
+function requiredArgument(
+  children: readonly RelationalScoutQlAstValue[],
+  index: number,
+  macroName: string,
+): string | number | boolean | null {
+  const child = children[index];
+  if (child === undefined) {
+    throw new DareScoutQlProfileError(
+      `${macroName} is missing argument ${index.toString()}.`,
+    );
+  }
+  return constantValue(child);
+}
+
+export function requiredStringArgument(
+  children: readonly RelationalScoutQlAstValue[],
+  index: number,
+  macroName: string,
+): string {
+  const value = requiredArgument(children, index, macroName);
+  if (typeof value !== "string") {
+    throw new DareScoutQlProfileError(
+      `${macroName} argument ${index.toString()} must be text.`,
+    );
+  }
+  return value;
+}
+
+export function requiredNumberArgument(
+  children: readonly RelationalScoutQlAstValue[],
+  index: number,
+  macroName: string,
+): number {
+  const value = requiredArgument(children, index, macroName);
+  if (typeof value !== "number") {
+    throw new DareScoutQlProfileError(
+      `${macroName} argument ${index.toString()} must be numeric.`,
+    );
+  }
+  return value;
+}
+
+export function nullableStringArgument(
+  children: readonly RelationalScoutQlAstValue[],
+  index: number,
+  macroName: string,
+): string | null {
+  const value = requiredArgument(children, index, macroName);
+  if (value === null || typeof value === "string") return value;
+  throw new DareScoutQlProfileError(
+    `${macroName} argument ${index.toString()} must be text or null.`,
+  );
+}
+
+export function nullableNumberArgument(
+  children: readonly RelationalScoutQlAstValue[],
+  index: number,
+  macroName: string,
+): number | null {
+  const value = requiredArgument(children, index, macroName);
+  if (value === null || typeof value === "number") return value;
+  throw new DareScoutQlProfileError(
+    `${macroName} argument ${index.toString()} must be numeric or null.`,
+  );
+}
+
+export function functionExpression(expression: RelationalScoutQlAstValue): {
+  name: string;
+  children: RelationalScoutQlAstValue[];
+  object: AstObject;
+} {
+  const object = astObject(expression, "a function expression");
+  if (expressionClass(object) !== "FUNCTION") {
+    throw new DareScoutQlProfileError(
+      "Dare ScoutQL requires a closed Dare function.",
+    );
+  }
+  return {
+    name: astString(object["function_name"], "a function name"),
+    children: astArray(object["children"], "function arguments"),
+    object,
+  };
+}
+
+export function flattenAnd(
+  expression: RelationalScoutQlAstValue,
+): RelationalScoutQlAstValue[] {
+  const object = astObject(expression, "a WHERE predicate");
+  if (
+    expressionClass(object) === "CONJUNCTION" &&
+    expressionType(object) === "CONJUNCTION_AND"
+  ) {
+    return astArray(object["children"], "WHERE conjunctions").flatMap((child) =>
+      flattenAnd(child),
+    );
+  }
+  return [expression];
+}
+
+export function limitFromNode(node: AstObject, label: string): number {
+  const limitModifier = astArray(node["modifiers"], `${label} modifiers`)
+    .map((modifier) => astObject(modifier, `${label} modifier`))
+    .find((modifier) => modifier["type"] === "LIMIT_MODIFIER");
+  if (limitModifier === undefined) {
+    throw new DareScoutQlProfileError(`${label} requires a LIMIT.`);
+  }
+  const limit = limitModifier["limit"];
+  if (limit === undefined) {
+    throw new DareScoutQlProfileError(`${label} requires a numeric LIMIT.`);
+  }
+  const value = constantValue(limit);
+  if (typeof value !== "number") {
+    throw new DareScoutQlProfileError(`${label} LIMIT must be numeric.`);
+  }
+  return value;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-ast-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-ast-v2.ts
@@ -10,6 +10,12 @@ const AstConstantSchema = z.union([
   z.boolean(),
   z.null(),
 ]);
+const DecimalCastTypeSchema = z.object({
+  id: z.literal("DECIMAL"),
+  type_info: z.object({
+    scale: z.number().int().nonnegative(),
+  }),
+});
 
 export type AstObject = z.infer<typeof AstObjectSchema>;
 
@@ -55,18 +61,29 @@ export function expressionType(object: AstObject): string {
   return astString(object["type"], "an expression type");
 }
 
+function decimalValue(value: string | number | boolean | null, type: unknown) {
+  const decimalType = DecimalCastTypeSchema.safeParse(type);
+  return typeof value === "number" && decimalType.success
+    ? value / 10 ** decimalType.data.type_info.scale
+    : value;
+}
+
+function castConstantValue(object: AstObject) {
+  const value = constantValue(object["child"]);
+  const castType = astObject(object["cast_type"], "a cast type");
+  if (typeof value === "string" && castType["id"] === "BOOLEAN") {
+    if (value === "t" || value === "true") return true;
+    if (value === "f" || value === "false") return false;
+  }
+  return decimalValue(value, castType);
+}
+
 export function constantValue(
   expression: RelationalScoutQlAstValue,
 ): string | number | boolean | null {
   const object = astObject(expression, "a constant expression");
   if (expressionClass(object) === "CAST") {
-    const value = constantValue(object["child"]);
-    const castType = astObject(object["cast_type"], "a cast type");
-    if (typeof value === "string" && castType["id"] === "BOOLEAN") {
-      if (value === "t" || value === "true") return true;
-      if (value === "f" || value === "false") return false;
-    }
-    return value;
+    return castConstantValue(object);
   }
   if (expressionClass(object) !== "CONSTANT") {
     throw new DareScoutQlProfileError(
@@ -76,7 +93,9 @@ export function constantValue(
   const value = astObject(object["value"], "a constant value");
   if (value["is_null"] === true) return null;
   const parsed = AstConstantSchema.safeParse(value["value"]);
-  if (parsed.success) return parsed.data;
+  if (parsed.success) {
+    return decimalValue(parsed.data, value["type"]);
+  }
   throw new DareScoutQlProfileError(
     "Dare ScoutQL contains an unsupported literal.",
   );

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-expressions-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-expressions-v2.ts
@@ -1,0 +1,307 @@
+import {
+  DareAggregateFunctionV2Schema,
+  DareParticipantRateFieldV2Schema,
+  DareParticipantValueFieldV2Schema,
+  DareResultOperatorV2Schema,
+  type DareBooleanExpressionV2,
+  type DareResultExpressionV2,
+  type DareValueV2,
+} from "@scout-for-lol/data";
+import {
+  astArray,
+  astObject,
+  astString,
+  constantValue,
+  DareScoutQlProfileError,
+  expressionClass,
+  expressionType,
+  functionExpression,
+  nullableNumberArgument,
+  nullableStringArgument,
+  requiredNumberArgument,
+  requiredStringArgument,
+  type AstObject,
+  type RelationalScoutQlAstValue,
+} from "#src/betting/dare-scoutql-ast-v2.ts";
+
+function targetForAlias(alias: string, targetKeys: readonly string[]): string {
+  const match = /^p(\d+)$/.exec(alias);
+  const indexText = match?.[1];
+  if (indexText === undefined) {
+    throw new DareScoutQlProfileError(`Unknown participant alias ${alias}.`);
+  }
+  const target = targetKeys[Number(indexText)];
+  if (target === undefined) {
+    throw new DareScoutQlProfileError(
+      `Participant alias ${alias} has no target binding.`,
+    );
+  }
+  return target;
+}
+
+function columnValue(
+  expression: AstObject,
+  targetKeys: readonly string[],
+): DareValueV2 {
+  const names = astArray(
+    expression["column_names"],
+    "qualified column names",
+  ).map((name) => astString(name, "a qualified column name"));
+  if (names.length !== 2) {
+    throw new DareScoutQlProfileError("Dare value columns must be qualified.");
+  }
+  const alias = names[0] ?? "";
+  const field = names[1] ?? "";
+  if (field === "game_duration_seconds") {
+    return { kind: "game", field: "duration_seconds" };
+  }
+  if (field === "queue") return { kind: "game", field: "queue" };
+  return {
+    kind: "participant",
+    target: targetForAlias(alias, targetKeys),
+    field: DareParticipantValueFieldV2Schema.parse(field),
+  };
+}
+
+function relatedParticipantValue(
+  children: readonly RelationalScoutQlAstValue[],
+): DareValueV2 {
+  const relationship = requiredStringArgument(
+    children,
+    1,
+    "dare_related_participant_count",
+  );
+  if (relationship !== "ally" && relationship !== "opponent") {
+    throw new DareScoutQlProfileError(
+      "dare_related_participant_count relationship must be ally or opponent.",
+    );
+  }
+  return {
+    kind: "related_participant_count",
+    target: requiredStringArgument(
+      children,
+      0,
+      "dare_related_participant_count",
+    ),
+    relationship,
+    championName: nullableStringArgument(
+      children,
+      2,
+      "dare_related_participant_count",
+    ),
+  };
+}
+
+function timelineRole(
+  children: readonly RelationalScoutQlAstValue[],
+): "subject" | "killer" | "victim" | "assist" | "creator" | null {
+  const role = nullableStringArgument(children, 2, "dare_timeline_event_count");
+  if (
+    role === null ||
+    role === "subject" ||
+    role === "killer" ||
+    role === "victim" ||
+    role === "assist" ||
+    role === "creator"
+  ) {
+    return role;
+  }
+  throw new DareScoutQlProfileError("Unknown timeline participant role.");
+}
+
+function timelineValue(
+  children: readonly RelationalScoutQlAstValue[],
+): DareValueV2 {
+  return {
+    kind: "timeline_event_count",
+    eventType: requiredStringArgument(children, 0, "dare_timeline_event_count"),
+    target: nullableStringArgument(children, 1, "dare_timeline_event_count"),
+    role: timelineRole(children),
+    afterMs: nullableNumberArgument(children, 3, "dare_timeline_event_count"),
+    beforeMs: nullableNumberArgument(children, 4, "dare_timeline_event_count"),
+    itemId: nullableNumberArgument(children, 5, "dare_timeline_event_count"),
+  };
+}
+
+function arithmeticOperator(
+  functionName: string,
+): "add" | "subtract" | "multiply" | "divide" | undefined {
+  if (functionName === "+") return "add";
+  if (functionName === "-") return "subtract";
+  if (functionName === "*") return "multiply";
+  if (functionName === "/") return "divide";
+  return undefined;
+}
+
+export function dareValueFromScoutQl(
+  expression: RelationalScoutQlAstValue,
+  targetKeys: readonly string[],
+): DareValueV2 {
+  const object = astObject(expression, "a Dare value expression");
+  if (expressionClass(object) === "COLUMN_REF") {
+    return columnValue(object, targetKeys);
+  }
+  const fn = functionExpression(expression);
+  if (fn.name === "dare_rate") {
+    return {
+      kind: "participant_rate",
+      target: requiredStringArgument(fn.children, 0, fn.name),
+      field: DareParticipantRateFieldV2Schema.parse(
+        requiredStringArgument(fn.children, 1, fn.name),
+      ),
+    };
+  }
+  if (fn.name === "dare_related_participant_count") {
+    return relatedParticipantValue(fn.children);
+  }
+  if (fn.name === "dare_timeline_event_count") {
+    return timelineValue(fn.children);
+  }
+  const arithmetic = arithmeticOperator(fn.name);
+  const left = fn.children[0];
+  const right = fn.children[1];
+  if (arithmetic === undefined || left === undefined || right === undefined) {
+    throw new DareScoutQlProfileError(
+      `Unsupported Dare value function ${fn.name}.`,
+    );
+  }
+  return {
+    kind: "arithmetic",
+    operator: arithmetic,
+    left: dareValueFromScoutQl(left, targetKeys),
+    right: dareValueFromScoutQl(right, targetKeys),
+  };
+}
+
+function comparisonOperator(
+  type: string,
+): "eq" | "neq" | "gte" | "lte" | "gt" | "lt" | undefined {
+  if (type === "COMPARE_EQUAL") return "eq";
+  if (type === "COMPARE_NOTEQUAL") return "neq";
+  if (type === "COMPARE_GREATERTHANOREQUALTO") return "gte";
+  if (type === "COMPARE_LESSTHANOREQUALTO") return "lte";
+  if (type === "COMPARE_GREATERTHAN") return "gt";
+  if (type === "COMPARE_LESSTHAN") return "lt";
+  return undefined;
+}
+
+function conjunctionKind(object: AstObject): "and" | "or" | null {
+  const type = expressionType(object);
+  if (type === "CONJUNCTION_AND") return "and";
+  if (type === "CONJUNCTION_OR") return "or";
+  return null;
+}
+
+export function darePredicateFromScoutQl(
+  expression: RelationalScoutQlAstValue,
+  targetKeys: readonly string[],
+): DareBooleanExpressionV2 {
+  const object = astObject(expression, "a Dare predicate");
+  const className = expressionClass(object);
+  if (className === "COMPARISON") {
+    const operator = comparisonOperator(expressionType(object));
+    if (operator === undefined) {
+      throw new DareScoutQlProfileError(
+        "Unsupported Dare comparison operator.",
+      );
+    }
+    const threshold = constantValue(object["right"]);
+    if (threshold === null) {
+      throw new DareScoutQlProfileError(
+        "Dare comparison thresholds cannot be null.",
+      );
+    }
+    return {
+      kind: "comparison",
+      value: dareValueFromScoutQl(object["left"], targetKeys),
+      operator,
+      threshold,
+    };
+  }
+  if (className === "CONJUNCTION") {
+    const kind = conjunctionKind(object);
+    if (kind === null) {
+      throw new DareScoutQlProfileError(
+        "Unsupported Dare Boolean conjunction.",
+      );
+    }
+    return {
+      kind,
+      operands: astArray(object["children"], "Boolean operands").map(
+        (operand) => darePredicateFromScoutQl(operand, targetKeys),
+      ),
+    };
+  }
+  if (className === "OPERATOR" && expressionType(object) === "OPERATOR_NOT") {
+    const operand = astArray(object["children"], "NOT operands")[0];
+    if (operand === undefined) {
+      throw new DareScoutQlProfileError("NOT requires one operand.");
+    }
+    return {
+      kind: "not",
+      operand: darePredicateFromScoutQl(operand, targetKeys),
+    };
+  }
+  throw new DareScoutQlProfileError("Unsupported Dare predicate expression.");
+}
+
+function resultLeaf(
+  expression: RelationalScoutQlAstValue,
+): DareResultExpressionV2 {
+  const fn = functionExpression(expression);
+  if (fn.name === "dare_matching_games") {
+    return {
+      kind: "matching_games",
+      gameSet: requiredStringArgument(fn.children, 0, fn.name),
+      operator: DareResultOperatorV2Schema.parse(
+        requiredStringArgument(fn.children, 1, fn.name),
+      ),
+      threshold: requiredNumberArgument(fn.children, 2, fn.name),
+    };
+  }
+  if (fn.name === "dare_aggregate") {
+    return {
+      kind: "aggregate",
+      gameSet: requiredStringArgument(fn.children, 0, fn.name),
+      projection: requiredStringArgument(fn.children, 1, fn.name),
+      function: DareAggregateFunctionV2Schema.parse(
+        requiredStringArgument(fn.children, 2, fn.name),
+      ),
+      operator: DareResultOperatorV2Schema.parse(
+        requiredStringArgument(fn.children, 3, fn.name),
+      ),
+      threshold: requiredNumberArgument(fn.children, 4, fn.name),
+    };
+  }
+  throw new DareScoutQlProfileError(
+    `Unsupported Dare result function ${fn.name}.`,
+  );
+}
+
+export function dareResultFromScoutQl(
+  expression: RelationalScoutQlAstValue,
+): DareResultExpressionV2 {
+  const object = astObject(expression, "a Dare result expression");
+  const className = expressionClass(object);
+  if (className === "FUNCTION") return resultLeaf(expression);
+  if (className === "CONJUNCTION") {
+    const kind = conjunctionKind(object);
+    if (kind === null) {
+      throw new DareScoutQlProfileError("Unsupported Dare result conjunction.");
+    }
+    return {
+      kind,
+      operands: astArray(object["children"], "result operands").map((operand) =>
+        dareResultFromScoutQl(operand),
+      ),
+    };
+  }
+  if (className === "OPERATOR" && expressionType(object) === "OPERATOR_NOT") {
+    const operand = astArray(object["children"], "NOT operands")[0];
+    if (operand === undefined) {
+      throw new DareScoutQlProfileError("NOT requires one result operand.");
+    }
+    return { kind: "not", operand: dareResultFromScoutQl(operand) };
+  }
+  throw new DareScoutQlProfileError("Unsupported Dare result expression.");
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-expressions-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-expressions-v2.ts
@@ -133,6 +133,26 @@ function arithmeticOperator(
   return undefined;
 }
 
+function divisionRightOperand(
+  expression: RelationalScoutQlAstValue,
+): RelationalScoutQlAstValue {
+  const nullIf = functionExpression(expression);
+  const operand = nullIf.children[0];
+  const zero = nullIf.children[1];
+  if (
+    operand === undefined ||
+    zero === undefined ||
+    nullIf.children.length !== 2 ||
+    nullIf.name.toLowerCase() !== "nullif" ||
+    constantValue(zero) !== 0
+  ) {
+    throw new DareScoutQlProfileError(
+      "Dare division requires the canonical NULLIF(right, 0) denominator.",
+    );
+  }
+  return operand;
+}
+
 export function dareValueFromScoutQl(
   expression: RelationalScoutQlAstValue,
   targetKeys: readonly string[],
@@ -169,7 +189,10 @@ export function dareValueFromScoutQl(
     kind: "arithmetic",
     operator: arithmetic,
     left: dareValueFromScoutQl(left, targetKeys),
-    right: dareValueFromScoutQl(right, targetKeys),
+    right: dareValueFromScoutQl(
+      arithmetic === "divide" ? divisionRightOperand(right) : right,
+      targetKeys,
+    ),
   };
 }
 

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
@@ -2,53 +2,24 @@ import { describe, expect, test } from "vitest";
 import {
   DARE_V2_MAX_GAME_SETS,
   DareCompiledPlanV2Schema,
-  DareParaphraseCorpusSchema,
-  DiscordAccountIdSchema,
-  type DareParaphraseCorpus,
-  type DareTargetBindingV2,
 } from "@scout-for-lol/data";
 import { formatDareScoutQlV2 } from "#src/betting/dare-contract-compiler-v2.ts";
 import { canonicalDarePlanJsonV2 } from "#src/betting/dare-plan-canonical-v2.ts";
 import { compileDareScoutQlPlanV2 } from "#src/betting/dare-scoutql-plan-compiler-v2.ts";
-
-const CORPUS_URL = new URL(
-  "../../../data/src/model/dare-v2-paraphrase-corpus.json",
-  import.meta.url,
-);
-
-async function loadCorpus(): Promise<DareParaphraseCorpus> {
-  const raw: unknown = await Bun.file(CORPUS_URL).json();
-  return DareParaphraseCorpusSchema.parse(raw);
-}
-
-function targetBindings(
-  targetAliases: Readonly<Record<string, string>>,
-): DareTargetBindingV2[] {
-  return Object.entries(targetAliases).map(([key, alias], index) => ({
-    key,
-    alias,
-    discordId: DiscordAccountIdSchema.parse(
-      `1000000000000000${index.toString()}`,
-    ),
-    playerId: index + 1,
-    accounts: [
-      {
-        puuid: `${key}-frozen-puuid`,
-        trackingStartedAt: "2026-01-01T00:00:00.000Z",
-      },
-    ],
-  }));
-}
+import {
+  dareTargetBindingsForAliases,
+  loadDareParaphraseCorpus,
+} from "#src/betting/dare-v2-test-fixtures.ts";
 
 describe("Dare v2 ScoutQL plan compiler", () => {
   test("round-trips every canonical plan in the paraphrase corpus", async () => {
-    const corpus = await loadCorpus();
+    const corpus = await loadDareParaphraseCorpus();
 
     for (const entry of corpus.cases) {
       const queryText = formatDareScoutQlV2(entry.plan);
       const result = await compileDareScoutQlPlanV2({
         queryText,
-        targets: targetBindings(entry.targetAliases),
+        targets: dareTargetBindingsForAliases(entry.targetAliases),
       });
 
       expect(result.kind, `${entry.id}: ${JSON.stringify(result)}`).toBe(
@@ -60,7 +31,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
       );
       const recompiled = await compileDareScoutQlPlanV2({
         queryText: result.compilation.canonicalScoutQl,
-        targets: targetBindings(entry.targetAliases),
+        targets: dareTargetBindingsForAliases(entry.targetAliases),
       });
       expect(recompiled.kind, entry.id).toBe("valid");
       if (recompiled.kind !== "valid") continue;
@@ -71,7 +42,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
   });
 
   test("turns a threshold edit into a new immutable plan", async () => {
-    const corpus = await loadCorpus();
+    const corpus = await loadDareParaphraseCorpus();
     const example = corpus.cases.find(
       (entry) => entry.id === "twisted_fate_same_game",
     );
@@ -85,7 +56,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
     );
     const result = await compileDareScoutQlPlanV2({
       queryText: editedQuery,
-      targets: targetBindings(example.targetAliases),
+      targets: dareTargetBindingsForAliases(example.targetAliases),
     });
 
     expect(editedQuery).not.toBe(originalQuery);
@@ -104,7 +75,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
   });
 
   test("rejects an edit that drops a frozen target", async () => {
-    const corpus = await loadCorpus();
+    const corpus = await loadDareParaphraseCorpus();
     const example = corpus.cases.find(
       (entry) => entry.id === "twisted_fate_same_game",
     );
@@ -113,7 +84,10 @@ describe("Dare v2 ScoutQL plan compiler", () => {
 
     const result = await compileDareScoutQlPlanV2({
       queryText: formatDareScoutQlV2(example.plan),
-      targets: targetBindings({ ...example.targetAliases, T2: "Bryan" }),
+      targets: dareTargetBindingsForAliases({
+        ...example.targetAliases,
+        T2: "Bryan",
+      }),
     });
 
     expect(result).toEqual({
@@ -162,7 +136,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
 
     const result = await compileDareScoutQlPlanV2({
       queryText: formatDareScoutQlV2(plan),
-      targets: targetBindings({ virmel: "Virmel" }),
+      targets: dareTargetBindingsForAliases({ virmel: "Virmel" }),
     });
 
     expect(result.kind, JSON.stringify(result)).toBe("valid");
@@ -173,7 +147,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
   });
 
   test("rejects valid SQL outside the immutable Dare profile", async () => {
-    const corpus = await loadCorpus();
+    const corpus = await loadDareParaphraseCorpus();
     const example = corpus.cases[0];
     expect(example).toBeDefined();
     if (example === undefined) return;
@@ -184,7 +158,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
     );
     const result = await compileDareScoutQlPlanV2({
       queryText,
-      targets: targetBindings(example.targetAliases),
+      targets: dareTargetBindingsForAliases(example.targetAliases),
     });
 
     expect(result).toEqual({
@@ -235,7 +209,7 @@ describe("Dare v2 ScoutQL plan compiler", () => {
 
     const result = await compileDareScoutQlPlanV2({
       queryText: formatDareScoutQlV2(plan),
-      targets: targetBindings({ virmel: "Virmel" }),
+      targets: dareTargetBindingsForAliases({ virmel: "Virmel" }),
     });
 
     expect(result.kind, JSON.stringify(result)).toBe("valid");

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
@@ -103,6 +103,25 @@ describe("Dare v2 ScoutQL plan compiler", () => {
     });
   });
 
+  test("rejects an edit that drops a frozen target", async () => {
+    const corpus = await loadCorpus();
+    const example = corpus.cases.find(
+      (entry) => entry.id === "twisted_fate_same_game",
+    );
+    expect(example).toBeDefined();
+    if (example === undefined) return;
+
+    const result = await compileDareScoutQlPlanV2({
+      queryText: formatDareScoutQlV2(example.plan),
+      targets: targetBindings({ ...example.targetAliases, T2: "Bryan" }),
+    });
+
+    expect(result).toEqual({
+      kind: "invalid",
+      issues: ["Frozen target T2 is not used by any game set."],
+    });
+  });
+
   test("round-trips canonical division with its zero guard", async () => {
     const plan = DareCompiledPlanV2Schema.parse({
       version: 2,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+import {
+  DareParaphraseCorpusSchema,
+  DiscordAccountIdSchema,
+  type DareParaphraseCorpus,
+  type DareTargetBindingV2,
+} from "@scout-for-lol/data";
+import { formatDareScoutQlV2 } from "#src/betting/dare-contract-compiler-v2.ts";
+import { canonicalDarePlanJsonV2 } from "#src/betting/dare-plan-canonical-v2.ts";
+import { compileDareScoutQlPlanV2 } from "#src/betting/dare-scoutql-plan-compiler-v2.ts";
+
+const CORPUS_URL = new URL(
+  "../../../data/src/model/dare-v2-paraphrase-corpus.json",
+  import.meta.url,
+);
+
+async function loadCorpus(): Promise<DareParaphraseCorpus> {
+  const raw: unknown = await Bun.file(CORPUS_URL).json();
+  return DareParaphraseCorpusSchema.parse(raw);
+}
+
+function targetBindings(
+  targetAliases: Readonly<Record<string, string>>,
+): DareTargetBindingV2[] {
+  return Object.entries(targetAliases).map(([key, alias], index) => ({
+    key,
+    alias,
+    discordId: DiscordAccountIdSchema.parse(
+      `1000000000000000${index.toString()}`,
+    ),
+    playerId: index + 1,
+    accounts: [
+      {
+        puuid: `${key}-frozen-puuid`,
+        trackingStartedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+  }));
+}
+
+describe("Dare v2 ScoutQL plan compiler", () => {
+  test("round-trips every canonical plan in the paraphrase corpus", async () => {
+    const corpus = await loadCorpus();
+
+    for (const entry of corpus.cases) {
+      const queryText = formatDareScoutQlV2(entry.plan);
+      const result = await compileDareScoutQlPlanV2({
+        queryText,
+        targets: targetBindings(entry.targetAliases),
+      });
+
+      expect(result.kind, `${entry.id}: ${JSON.stringify(result)}`).toBe(
+        "valid",
+      );
+      if (result.kind !== "valid") continue;
+      expect(canonicalDarePlanJsonV2(result.compilation.plan), entry.id).toBe(
+        canonicalDarePlanJsonV2(entry.plan),
+      );
+      const recompiled = await compileDareScoutQlPlanV2({
+        queryText: result.compilation.canonicalScoutQl,
+        targets: targetBindings(entry.targetAliases),
+      });
+      expect(recompiled.kind, entry.id).toBe("valid");
+      if (recompiled.kind !== "valid") continue;
+      expect(recompiled.compilation.planHash, entry.id).toBe(
+        result.compilation.planHash,
+      );
+    }
+  });
+
+  test("turns a threshold edit into a new immutable plan", async () => {
+    const corpus = await loadCorpus();
+    const example = corpus.cases.find(
+      (entry) => entry.id === "twisted_fate_same_game",
+    );
+    expect(example).toBeDefined();
+    if (example === undefined) return;
+
+    const originalQuery = formatDareScoutQlV2(example.plan);
+    const editedQuery = originalQuery.replace(
+      "dare_rate('T1', 'cs_per_minute') >= 8",
+      "dare_rate('T1', 'cs_per_minute') >= 9",
+    );
+    const result = await compileDareScoutQlPlanV2({
+      queryText: editedQuery,
+      targets: targetBindings(example.targetAliases),
+    });
+
+    expect(editedQuery).not.toBe(originalQuery);
+    expect(result.kind).toBe("valid");
+    if (result.kind !== "valid") return;
+    expect(result.compilation.plan.gameSets[0]?.predicate).toMatchObject({
+      kind: "and",
+      operands: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "comparison",
+          operator: "gte",
+          threshold: 9,
+        }),
+      ]),
+    });
+  });
+
+  test("rejects valid SQL outside the immutable Dare profile", async () => {
+    const corpus = await loadCorpus();
+    const example = corpus.cases[0];
+    expect(example).toBeDefined();
+    if (example === undefined) return;
+
+    const queryText = formatDareScoutQlV2(example.plan).replace(
+      "ORDER BY game_end_at ASC, match_id ASC",
+      "ORDER BY match_id ASC, game_end_at ASC",
+    );
+    const result = await compileDareScoutQlPlanV2({
+      queryText,
+      targets: targetBindings(example.targetAliases),
+    });
+
+    expect(result).toEqual({
+      kind: "invalid",
+      issues: [
+        "Dare ScoutQL uses a valid SQL construct outside the versioned contract profile. Format the generated contract query and edit only its Dare expressions.",
+      ],
+    });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
@@ -103,6 +103,56 @@ describe("Dare v2 ScoutQL plan compiler", () => {
     });
   });
 
+  test("round-trips canonical division with its zero guard", async () => {
+    const plan = DareCompiledPlanV2Schema.parse({
+      version: 2,
+      gameSets: [
+        {
+          name: "ratio_game",
+          targetKeys: ["virmel"],
+          relationship: "independent",
+          queues: ["solo"],
+          predicate: {
+            kind: "comparison",
+            value: {
+              kind: "arithmetic",
+              operator: "divide",
+              left: {
+                kind: "participant",
+                target: "virmel",
+                field: "kills",
+              },
+              right: { kind: "game", field: "duration_seconds" },
+            },
+            operator: "gte",
+            threshold: 0.01,
+          },
+          projections: [],
+          orderBy: "game_end_at_asc_match_id_asc",
+          limit: 100,
+        },
+      ],
+      result: {
+        kind: "matching_games",
+        gameSet: "ratio_game",
+        operator: "gte",
+        threshold: 1,
+      },
+      maxEligibleGames: 100,
+    });
+
+    const result = await compileDareScoutQlPlanV2({
+      queryText: formatDareScoutQlV2(plan),
+      targets: targetBindings({ virmel: "Virmel" }),
+    });
+
+    expect(result.kind, JSON.stringify(result)).toBe("valid");
+    if (result.kind !== "valid") return;
+    expect(canonicalDarePlanJsonV2(result.compilation.plan)).toBe(
+      canonicalDarePlanJsonV2(plan),
+    );
+  });
+
   test("rejects valid SQL outside the immutable Dare profile", async () => {
     const corpus = await loadCorpus();
     const example = corpus.cases[0];

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
+  DARE_V2_MAX_GAME_SETS,
+  DareCompiledPlanV2Schema,
   DareParaphraseCorpusSchema,
   DiscordAccountIdSchema,
   type DareParaphraseCorpus,
@@ -122,5 +124,58 @@ describe("Dare v2 ScoutQL plan compiler", () => {
         "Dare ScoutQL uses a valid SQL construct outside the versioned contract profile. Format the generated contract query and edit only its Dare expressions.",
       ],
     });
+  });
+
+  test("accepts the full twenty-game-set contract limit", async () => {
+    const gameSets = Array.from(
+      { length: DARE_V2_MAX_GAME_SETS },
+      (_unused, index) => ({
+        name: `games_${index.toString()}`,
+        targetKeys: ["virmel"],
+        relationship: "independent",
+        queues: ["solo"],
+        predicate: {
+          kind: "comparison",
+          value: {
+            kind: "participant",
+            target: "virmel",
+            field: "kills",
+          },
+          operator: "gte",
+          threshold: 1,
+        },
+        projections: [],
+        orderBy: "game_end_at_asc_match_id_asc",
+        limit: 100,
+      }),
+    );
+    const plan = DareCompiledPlanV2Schema.parse({
+      version: 2,
+      gameSets,
+      result: {
+        kind: "or",
+        operands: gameSets.map((gameSet) => ({
+          kind: "matching_games",
+          gameSet: gameSet.name,
+          operator: "gte",
+          threshold: 1,
+        })),
+      },
+      maxEligibleGames: 100,
+    });
+
+    const result = await compileDareScoutQlPlanV2({
+      queryText: formatDareScoutQlV2(plan),
+      targets: targetBindings({ virmel: "Virmel" }),
+    });
+
+    expect(result.kind, JSON.stringify(result)).toBe("valid");
+    if (result.kind !== "valid") return;
+    expect(result.compilation.plan.gameSets).toHaveLength(
+      DARE_V2_MAX_GAME_SETS,
+    );
+    expect(result.compilation.facts.cteCount).toBe(
+      DARE_V2_MAX_GAME_SETS * 2 + 1,
+    );
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
@@ -1,0 +1,344 @@
+import { z } from "zod";
+import {
+  DareCompiledPlanV2Schema,
+  type DareCompiledPlanV2,
+  type DareGameSetV2,
+  type DareTargetBindingV2,
+  QueueTypeSchema,
+} from "@scout-for-lol/data";
+import {
+  astArray,
+  astObject,
+  astString,
+  constantValue,
+  DareScoutQlProfileError,
+  expressionClass,
+  expressionType,
+  flattenAnd,
+  functionExpression,
+  limitFromNode,
+  requiredStringArgument,
+  type AstObject,
+  type RelationalScoutQlAstValue,
+} from "#src/betting/dare-scoutql-ast-v2.ts";
+import {
+  darePlanSemanticIssues,
+  formatDareScoutQlV2,
+} from "#src/betting/dare-contract-compiler-v2.ts";
+import {
+  darePredicateFromScoutQl,
+  dareResultFromScoutQl,
+  dareValueFromScoutQl,
+} from "#src/betting/dare-scoutql-expressions-v2.ts";
+import {
+  relationalScoutQlStatementFromImmutableAst,
+  validateRelationalScoutQl,
+  type RelationalScoutQlCompilation,
+} from "#src/reports/duckdb/relational-scoutql.ts";
+
+function cteEntries(rootNode: AstObject): Map<string, AstObject> {
+  const cteMap = astObject(rootNode["cte_map"], "a CTE map");
+  return new Map(
+    astArray(cteMap["map"], "CTE entries").map((entryValue) => {
+      const entry = astObject(entryValue, "a CTE entry");
+      const value = astObject(entry["value"], "a CTE definition");
+      const query = astObject(value["query"], "a CTE query");
+      return [
+        astString(entry["key"], "a CTE name"),
+        astObject(query["node"], "a CTE select node"),
+      ];
+    }),
+  );
+}
+
+function targetBindingFromWhere(
+  expression: RelationalScoutQlAstValue,
+): { alias: string; target: string } | null {
+  const object = astObject(expression, "a target predicate");
+  if (expressionClass(object) !== "FUNCTION") return null;
+  const fn = functionExpression(expression);
+  if (fn.name !== "contains") return null;
+  const targetFunction = fn.children[0];
+  const columnExpression = fn.children[1];
+  if (targetFunction === undefined || columnExpression === undefined)
+    return null;
+  const target = functionExpression(targetFunction);
+  if (target.name !== "dare_target") return null;
+  const column = astObject(columnExpression, "a target PUUID column");
+  const names = astArray(column["column_names"], "a target PUUID column").map(
+    (name) => astString(name, "a target PUUID column"),
+  );
+  if (names.length !== 2 || names[1] !== "puuid") return null;
+  return {
+    alias: names[0] ?? "",
+    target: requiredStringArgument(target.children, 0, "dare_target"),
+  };
+}
+
+function queuesFromWhere(
+  expression: RelationalScoutQlAstValue,
+): string[] | null {
+  const object = astObject(expression, "a queue predicate");
+  if (
+    expressionClass(object) !== "OPERATOR" ||
+    expressionType(object) !== "COMPARE_IN"
+  ) {
+    return null;
+  }
+  const children = astArray(object["children"], "queue values");
+  const column = children[0];
+  if (column === undefined) return null;
+  const columnObject = astObject(column, "a queue column");
+  const names = astArray(columnObject["column_names"], "a queue column").map(
+    (name) => astString(name, "a queue column"),
+  );
+  if (names.length !== 2 || names[1] !== "queue") return null;
+  return children.slice(1).map((child) => {
+    const value = constantValue(child);
+    if (typeof value !== "string") {
+      throw new DareScoutQlProfileError("Queue values must be text literals.");
+    }
+    return value;
+  });
+}
+
+function gameSetScope(candidateNode: AstObject): {
+  targetKeys: string[];
+  queues: DareGameSetV2["queues"];
+} {
+  const where = candidateNode["where_clause"];
+  if (where === null || where === undefined) {
+    throw new DareScoutQlProfileError(
+      "Every game set must bind targets and queues.",
+    );
+  }
+  const targetByAlias = new Map<string, string>();
+  let queues: string[] | null = null;
+  for (const clause of flattenAnd(where)) {
+    const target = targetBindingFromWhere(clause);
+    if (target !== null) {
+      targetByAlias.set(target.alias, target.target);
+      continue;
+    }
+    const clauseQueues = queuesFromWhere(clause);
+    if (clauseQueues !== null) {
+      queues = clauseQueues;
+      continue;
+    }
+    throw new DareScoutQlProfileError(
+      "Game-set WHERE may contain only target and queue bindings.",
+    );
+  }
+  const targetKeys = [...targetByAlias.entries()]
+    .toSorted(
+      ([left], [right]) => Number(left.slice(1)) - Number(right.slice(1)),
+    )
+    .map((entry) => entry[1]);
+  if (queues === null || targetKeys.length === 0) {
+    throw new DareScoutQlProfileError(
+      "Every game set must bind targets and queues.",
+    );
+  }
+  return { targetKeys, queues: QueueTypeSchema.array().parse(queues) };
+}
+
+function collectJoinConditions(table: AstObject): RelationalScoutQlAstValue[] {
+  if (astString(table["type"], "a FROM relation type") !== "JOIN") return [];
+  const left = astObject(table["left"], "a JOIN left relation");
+  const condition = table["condition"];
+  if (condition === undefined || condition === null) {
+    throw new DareScoutQlProfileError("Target joins require an ON condition.");
+  }
+  return [...collectJoinConditions(left), condition];
+}
+
+function relationshipForCandidate(
+  candidateNode: AstObject,
+  targetCount: number,
+): DareGameSetV2["relationship"] {
+  if (targetCount === 1) return "independent";
+  const from = astObject(
+    candidateNode["from_table"],
+    "a game-set FROM relation",
+  );
+  const conditions = collectJoinConditions(from);
+  if (conditions.length !== targetCount - 1) {
+    throw new DareScoutQlProfileError(
+      "Every additional target requires one match join.",
+    );
+  }
+  const relationshipKinds = conditions.map((condition) => {
+    const clauses = flattenAnd(condition);
+    if (clauses.length === 1) return "same_match" as const;
+    const teamClause = clauses[1];
+    if (teamClause === undefined) {
+      throw new DareScoutQlProfileError(
+        "Target relationship join is incomplete.",
+      );
+    }
+    const type = expressionType(astObject(teamClause, "a team relationship"));
+    if (type === "COMPARE_EQUAL") return "same_team" as const;
+    if (type === "COMPARE_NOTEQUAL") return "opponents" as const;
+    throw new DareScoutQlProfileError("Unknown target team relationship.");
+  });
+  const relationship = relationshipKinds[0];
+  if (
+    relationship === undefined ||
+    relationshipKinds.some((candidate) => candidate !== relationship)
+  ) {
+    throw new DareScoutQlProfileError(
+      "All target joins must use the same relationship.",
+    );
+  }
+  return relationship;
+}
+
+function gameSetFromCte(input: {
+  name: string;
+  candidateNode: AstObject;
+  boundedNode: AstObject;
+}): DareGameSetV2 {
+  const scope = gameSetScope(input.candidateNode);
+  const selectList = astArray(
+    input.candidateNode["select_list"],
+    "game-set outputs",
+  );
+  const matchedIndex = selectList.findIndex((expression) => {
+    const object = astObject(expression, "a game-set output");
+    return object["alias"] === "matched";
+  });
+  if (matchedIndex === -1) {
+    throw new DareScoutQlProfileError(
+      `Game set ${input.name} requires a matched output.`,
+    );
+  }
+  const matched = selectList[matchedIndex];
+  if (matched === undefined) {
+    throw new DareScoutQlProfileError(
+      `Game set ${input.name} has an invalid matched output.`,
+    );
+  }
+  const projections = selectList.slice(matchedIndex + 1).map((expression) => {
+    const object = astObject(expression, "a game-set projection");
+    return {
+      name: astString(object["alias"], "a projection alias"),
+      value: dareValueFromScoutQl(expression, scope.targetKeys),
+    };
+  });
+  return {
+    name: input.name,
+    targetKeys: scope.targetKeys,
+    relationship: relationshipForCandidate(
+      input.candidateNode,
+      scope.targetKeys.length,
+    ),
+    queues: scope.queues,
+    predicate: darePredicateFromScoutQl(matched, scope.targetKeys),
+    projections,
+    orderBy: "game_end_at_asc_match_id_asc",
+    limit: limitFromNode(input.boundedNode, `Game set ${input.name}`),
+  };
+}
+
+function planFromCompilation(
+  compilation: RelationalScoutQlCompilation,
+): DareCompiledPlanV2 {
+  const statement = astObject(
+    relationalScoutQlStatementFromImmutableAst(compilation.immutableAst),
+    "a statement",
+  );
+  const root = astObject(statement["node"], "a SELECT statement");
+  const ctes = cteEntries(root);
+  const gameSets = [...ctes.entries()].flatMap(([name, candidateNode]) => {
+    if (!name.endsWith("_candidates")) return [];
+    const gameSetName = name.slice(0, -"_candidates".length);
+    const boundedNode = ctes.get(gameSetName);
+    if (boundedNode === undefined) {
+      throw new DareScoutQlProfileError(
+        `Game set ${gameSetName} is missing its bounded CTE.`,
+      );
+    }
+    return [gameSetFromCte({ name: gameSetName, candidateNode, boundedNode })];
+  });
+  const eligible = ctes.get("eligible_matches");
+  if (eligible === undefined) {
+    throw new DareScoutQlProfileError(
+      "Dare ScoutQL requires eligible_matches.",
+    );
+  }
+  const output = astArray(root["select_list"], "the achieved output")[0];
+  if (output === undefined) {
+    throw new DareScoutQlProfileError(
+      "Dare ScoutQL requires an achieved output.",
+    );
+  }
+  return DareCompiledPlanV2Schema.parse({
+    version: 2,
+    gameSets,
+    result: dareResultFromScoutQl(output),
+    maxEligibleGames: limitFromNode(eligible, "eligible_matches"),
+  });
+}
+
+export type DareScoutQlPlanCompilationV2 = RelationalScoutQlCompilation & {
+  plan: DareCompiledPlanV2;
+};
+
+export type DareScoutQlPlanValidationV2 =
+  | { kind: "valid"; compilation: DareScoutQlPlanCompilationV2 }
+  | { kind: "invalid"; issues: string[] };
+
+export async function compileDareScoutQlPlanV2(input: {
+  queryText: string;
+  targets: readonly DareTargetBindingV2[];
+}): Promise<DareScoutQlPlanValidationV2> {
+  const targetKeys = input.targets.map((target) => target.key);
+  const relational = await validateRelationalScoutQl({
+    queryText: input.queryText,
+    allowedTargetKeys: targetKeys,
+  });
+  if (relational.kind === "invalid") return relational;
+  try {
+    const plan = planFromCompilation(relational.compilation);
+    const semanticIssues = darePlanSemanticIssues(plan, input.targets);
+    if (semanticIssues.length > 0) {
+      return { kind: "invalid", issues: semanticIssues };
+    }
+    const regenerated = await validateRelationalScoutQl({
+      queryText: formatDareScoutQlV2(plan),
+      allowedTargetKeys: targetKeys,
+    });
+    if (regenerated.kind === "invalid") {
+      throw new Error(
+        `Dare ScoutQL formatter produced invalid output: ${regenerated.issues.join(" ")}`,
+      );
+    }
+    if (regenerated.compilation.planHash !== relational.compilation.planHash) {
+      return {
+        kind: "invalid",
+        issues: [
+          "Dare ScoutQL uses a valid SQL construct outside the versioned contract profile. Format the generated contract query and edit only its Dare expressions.",
+        ],
+      };
+    }
+    return {
+      kind: "valid",
+      compilation: { ...relational.compilation, plan },
+    };
+  } catch (error) {
+    if (
+      error instanceof DareScoutQlProfileError ||
+      error instanceof z.ZodError
+    ) {
+      return {
+        kind: "invalid",
+        issues: [
+          error instanceof DareScoutQlProfileError
+            ? error.message
+            : "Dare ScoutQL contains a value outside the versioned contract profile.",
+        ],
+      };
+    }
+    throw error;
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-scoutql-plan-compiler-v2.ts
@@ -32,7 +32,7 @@ import {
 } from "#src/betting/dare-scoutql-expressions-v2.ts";
 import {
   relationalScoutQlStatementFromImmutableAst,
-  validateRelationalScoutQl,
+  validateCanonicalDareScoutQl,
   type RelationalScoutQlCompilation,
 } from "#src/reports/duckdb/relational-scoutql.ts";
 
@@ -293,7 +293,7 @@ export async function compileDareScoutQlPlanV2(input: {
   targets: readonly DareTargetBindingV2[];
 }): Promise<DareScoutQlPlanValidationV2> {
   const targetKeys = input.targets.map((target) => target.key);
-  const relational = await validateRelationalScoutQl({
+  const relational = await validateCanonicalDareScoutQl({
     queryText: input.queryText,
     allowedTargetKeys: targetKeys,
   });
@@ -304,7 +304,7 @@ export async function compileDareScoutQlPlanV2(input: {
     if (semanticIssues.length > 0) {
       return { kind: "invalid", issues: semanticIssues };
     }
-    const regenerated = await validateRelationalScoutQl({
+    const regenerated = await validateCanonicalDareScoutQl({
       queryText: formatDareScoutQlV2(plan),
       allowedTargetKeys: targetKeys,
     });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { visibleDareScoutQlV2 } from "#src/betting/dare-view-v2.ts";
+import { TWISTED_FATE_SAME_GAME_PLAN } from "#src/betting/dare-v2-test-fixtures.ts";
+
+describe("Dare v2 draft inspection", () => {
+  test("regenerates current editable ScoutQL from a stored semantic plan", () => {
+    const query = visibleDareScoutQlV2({
+      state: "draft",
+      plan: TWISTED_FATE_SAME_GAME_PLAN,
+      storedCanonicalScoutQl: "legacy expanded ScoutQL",
+    });
+
+    expect(query).toContain("dare_rate('virmel', 'cs_per_minute') >= 8");
+    expect(query).toContain("dare_matching_games('qualifying_game', 'gte', 1)");
+    expect(query).not.toContain("legacy expanded ScoutQL");
+  });
+
+  test("preserves the immutable funded query", () => {
+    expect(
+      visibleDareScoutQlV2({
+        state: "active",
+        plan: TWISTED_FATE_SAME_GAME_PLAN,
+        storedCanonicalScoutQl: "immutable funded ScoutQL",
+      }),
+    ).toBe("immutable funded ScoutQL");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -8,6 +8,7 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { z } from "zod";
+import { formatDareScoutQlV2 } from "#src/betting/dare-contract-compiler-v2.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 
 const StoredTargetSchema = DareTargetBindingV2Schema.omit({
@@ -149,14 +150,22 @@ function listItem(row: VisibleDareRow): DareV2ListItem {
 
 function inspection(row: VisibleDareRow): DareV2Inspection {
   const revision = activeRevision(row);
+  const state = BucksDareV2StateSchema.parse(row.dareState);
+  const plan = DareCompiledPlanV2Schema.parse(
+    JSON.parse(revision.compiledPlan),
+  );
   const draftTargets = DareTargetBindingV2Schema.array().parse(
     JSON.parse(revision.targetsJson),
   );
   return DareV2InspectionSchema.parse({
     ...listItem(row),
     channelId: row.channelId,
-    canonicalScoutQl: revision.canonicalScoutQl,
-    plan: DareCompiledPlanV2Schema.parse(JSON.parse(revision.compiledPlan)),
+    canonicalScoutQl: visibleDareScoutQlV2({
+      state,
+      plan,
+      storedCanonicalScoutQl: revision.canonicalScoutQl,
+    }),
+    plan,
     semanticProofPlan: revision.semanticProofPlan,
     originalText: revision.originalText,
     deadlineSpec: DareDeadlineSpecV2Schema.parse(
@@ -189,6 +198,16 @@ function inspection(row: VisibleDareRow): DareV2Inspection {
     proof: row.proofJson === null ? null : JSON.parse(row.proofJson),
     voidReason: row.voidReason,
   });
+}
+
+export function visibleDareScoutQlV2(input: {
+  state: BucksDareV2State;
+  plan: z.infer<typeof DareCompiledPlanV2Schema>;
+  storedCanonicalScoutQl: string;
+}): string {
+  return input.state === "draft"
+    ? formatDareScoutQlV2(input.plan)
+    : input.storedCanonicalScoutQl;
 }
 
 const includeVisibleDare = {

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-editor-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-editor-v2.ts
@@ -2,9 +2,9 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import {
   BucksStakeSchema,
-  DareCompiledPlanV2Schema,
   DareDeadlineSpecV2Schema,
   DareTargetBindingV2Schema,
+  DARE_V2_MAX_QUERY_LENGTH,
   DiscordGuildIdSchema,
   type DiscordAccountId,
 } from "@scout-for-lol/data";
@@ -13,13 +13,14 @@ import {
   reviseDareDraftV2,
 } from "#src/betting/dare-draft-v2.ts";
 import { historicallyPreviewDareV2 } from "#src/betting/dare-preview-v2.ts";
+import { compileDareScoutQlPlanV2 } from "#src/betting/dare-scoutql-plan-compiler-v2.ts";
 import { prisma } from "#src/database/index.ts";
 
 export const DareDraftEditorInputSchema = z.strictObject({
   dareId: z.number().int().positive(),
   expectedRevision: z.number().int().positive(),
   originalText: z.string().min(1).max(4000),
-  plan: DareCompiledPlanV2Schema,
+  queryText: z.string().min(1).max(DARE_V2_MAX_QUERY_LENGTH),
   deadlineSpec: DareDeadlineSpecV2Schema,
   openingStake: BucksStakeSchema,
 });
@@ -84,11 +85,20 @@ async function prepareEditorDraft(
     userId,
     guildIds,
   });
+  const compilation = await compileDareScoutQlPlanV2({
+    queryText: input.queryText,
+    targets: owned.targets,
+  });
+  if (compilation.kind === "invalid") {
+    return { kind: "invalid" as const, owned, issues: compilation.issues };
+  }
   return {
+    kind: "valid" as const,
     owned,
+    compilation: compilation.compilation,
     prepared: prepareDareDraftV2({
       originalText: input.originalText,
-      plan: input.plan,
+      plan: compilation.compilation.plan,
       targets: owned.targets,
       deadlineSpec: input.deadlineSpec,
       openingStake: input.openingStake,
@@ -101,12 +111,18 @@ export async function validateDareDraftEditorV2(
   userId: DiscordAccountId,
   guildIds: string[],
 ) {
-  const { prepared } = await prepareEditorDraft(input, userId, guildIds);
+  const result = await prepareEditorDraft(input, userId, guildIds);
+  if (result.kind === "invalid") {
+    return { kind: "invalid" as const, issues: result.issues };
+  }
+  const { prepared } = result;
   return prepared.kind === "invalid"
     ? { kind: "invalid" as const, issues: prepared.issues }
     : {
         kind: "valid" as const,
         canonicalScoutQl: prepared.draft.canonicalScoutQl,
+        scoutQlPlanHash: result.compilation.planHash,
+        scoutQlFacts: result.compilation.facts,
         plainLanguage: prepared.draft.plainLanguage,
         semanticProofPlan: prepared.draft.semanticProofPlan,
       };
@@ -117,7 +133,14 @@ export async function previewDareDraftEditorV2(
   userId: DiscordAccountId,
   guildIds: string[],
 ) {
-  const { owned, prepared } = await prepareEditorDraft(input, userId, guildIds);
+  const result = await prepareEditorDraft(input, userId, guildIds);
+  if (result.kind === "invalid") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: result.issues.join(" "),
+    });
+  }
+  const { owned, prepared } = result;
   if (prepared.kind === "invalid") {
     throw new TRPCError({
       code: "BAD_REQUEST",
@@ -138,7 +161,14 @@ export async function reviseDareDraftEditorV2(
   userId: DiscordAccountId,
   guildIds: string[],
 ) {
-  const { owned, prepared } = await prepareEditorDraft(input, userId, guildIds);
+  const result = await prepareEditorDraft(input, userId, guildIds);
+  if (result.kind === "invalid") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: result.issues.join(" "),
+    });
+  }
+  const { owned, prepared } = result;
   if (prepared.kind === "invalid") {
     throw new TRPCError({
       code: "BAD_REQUEST",

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-editor-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-editor-v2.ts
@@ -128,8 +128,8 @@ export async function validateDareDraftEditorV2(
       };
 }
 
-export async function previewDareDraftEditorV2(
-  input: z.infer<typeof DareDraftPreviewInputSchema>,
+async function prepareValidEditorDraft(
+  input: EditorInput,
   userId: DiscordAccountId,
   guildIds: string[],
 ) {
@@ -140,13 +140,25 @@ export async function previewDareDraftEditorV2(
       message: result.issues.join(" "),
     });
   }
-  const { owned, prepared } = result;
-  if (prepared.kind === "invalid") {
+  if (result.prepared.kind === "invalid") {
     throw new TRPCError({
       code: "BAD_REQUEST",
-      message: prepared.issues.join(" "),
+      message: result.prepared.issues.join(" "),
     });
   }
+  return { owned: result.owned, prepared: result.prepared };
+}
+
+export async function previewDareDraftEditorV2(
+  input: z.infer<typeof DareDraftPreviewInputSchema>,
+  userId: DiscordAccountId,
+  guildIds: string[],
+) {
+  const { owned, prepared } = await prepareValidEditorDraft(
+    input,
+    userId,
+    guildIds,
+  );
   const end = new Date();
   return await historicallyPreviewDareV2({
     plan: prepared.draft.plan,
@@ -161,20 +173,11 @@ export async function reviseDareDraftEditorV2(
   userId: DiscordAccountId,
   guildIds: string[],
 ) {
-  const result = await prepareEditorDraft(input, userId, guildIds);
-  if (result.kind === "invalid") {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: result.issues.join(" "),
-    });
-  }
-  const { owned, prepared } = result;
-  if (prepared.kind === "invalid") {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: prepared.issues.join(" "),
-    });
-  }
+  const { owned, prepared } = await prepareValidEditorDraft(
+    input,
+    userId,
+    guildIds,
+  );
   return await reviseDareDraftV2({
     dareId: input.dareId,
     serverId: DiscordGuildIdSchema.parse(owned.dare.serverId),

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tool-schemas.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import {
+  BucksStakeSchema,
+  DARE_V2_MAX_HORIZON_DAYS,
+  DARE_V2_MAX_QUERY_LENGTH,
+  DARE_V2_MAX_TARGETS,
+  DareCompiledPlanV2Schema,
+  DareDeadlineSpecV2Schema,
+} from "@scout-for-lol/data";
+import { DareV2IntentPayloadSchema } from "#src/betting/dare-intent-v2.ts";
+
+export const DareToolResultSchema = z.strictObject({
+  kind: z.string().min(1),
+  message: z.string().min(1),
+  data: z.json().nullable(),
+});
+export type DareToolResult = z.infer<typeof DareToolResultSchema>;
+
+export const DareDefinitionToolInputSchema = z.strictObject({
+  originalText: z.string().min(1).max(4000),
+  targetKeys: z
+    .array(z.string().regex(/^T\d{1,2}$/))
+    .min(1)
+    .max(DARE_V2_MAX_TARGETS),
+  plan: DareCompiledPlanV2Schema,
+  deadlineSpec: DareDeadlineSpecV2Schema,
+  openingStake: BucksStakeSchema,
+});
+
+export const DareScoutQlToolInputSchema = z.strictObject({
+  queryText: z.string().min(1).max(DARE_V2_MAX_QUERY_LENGTH),
+  targetKeys: z
+    .array(z.string().regex(/^T\d{1,2}$/))
+    .min(1)
+    .max(DARE_V2_MAX_TARGETS),
+});
+
+export const ReviseDareToolInputSchema = DareDefinitionToolInputSchema.extend({
+  dareId: z.number().int().positive(),
+  expectedRevision: z.number().int().positive(),
+});
+
+export const DarePreviewToolInputSchema = DareDefinitionToolInputSchema.extend({
+  historyDays: z
+    .number()
+    .int()
+    .min(1)
+    .max(DARE_V2_MAX_HORIZON_DAYS)
+    .default(30),
+});
+
+export const DareListToolInputSchema = z.strictObject({
+  scope: z.enum(["mine", "guild"]),
+  search: z.string().min(1).max(100).optional(),
+});
+
+export const DareInspectToolInputSchema = z.strictObject({
+  dareId: z.number().int().positive(),
+});
+
+export const DareActionToolInputSchema = z.strictObject({
+  dareId: z.number().int().positive(),
+  expectedRevision: z.number().int().positive(),
+  payload: DareV2IntentPayloadSchema,
+});
+
+export const DareDeleteToolInputSchema = z.strictObject({
+  dareId: z.number().int().positive(),
+  expectedRevision: z.number().int().positive(),
+});

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-tools.ts
@@ -1,7 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
 import {
-  BucksStakeSchema,
   DARE_V2_MAX_ELIGIBLE_GAMES,
   DARE_V2_MAX_EXPRESSION_DEPTH,
   DARE_V2_MAX_GAME_SETS,
@@ -10,8 +9,6 @@ import {
   DARE_V2_MAX_PREDICATES,
   DARE_V2_MAX_QUERY_LENGTH,
   DARE_V2_MAX_TARGETS,
-  DareCompiledPlanV2Schema,
-  DareDeadlineSpecV2Schema,
   DiscordChannelIdSchema,
   type DiscordAccountId,
   type DiscordChannelId,
@@ -25,80 +22,33 @@ import {
   reviseDareDraftV2,
   type DareDraftV2Definition,
 } from "#src/betting/dare-draft-v2.ts";
-import {
-  createDareV2ConfirmationIntent,
-  DareV2IntentPayloadSchema,
-} from "#src/betting/dare-intent-v2.ts";
+import { createDareV2ConfirmationIntent } from "#src/betting/dare-intent-v2.ts";
 import {
   inspectVisibleDareV2,
   listVisibleDaresV2,
 } from "#src/betting/dare-view-v2.ts";
 import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { historicallyPreviewDareV2 } from "#src/betting/dare-preview-v2.ts";
+import {
+  renderDarePlanV2,
+  renderDareProofPlanV2,
+} from "#src/betting/dare-render-v2.ts";
+import { compileDareScoutQlPlanV2 } from "#src/betting/dare-scoutql-plan-compiler-v2.ts";
 import { prisma } from "#src/database/index.ts";
 import { COMMON_DENOMINATOR_CHANNEL_ID } from "#src/discord/channels.ts";
 import type { ToolTracker } from "#src/reports/ai/scoutql-tools.ts";
-import { validateRelationalScoutQl } from "#src/reports/duckdb/relational-scoutql.ts";
-
-export const DareToolResultSchema = z.strictObject({
-  kind: z.string().min(1),
-  message: z.string().min(1),
-  data: z.json().nullable(),
-});
-export type DareToolResult = z.infer<typeof DareToolResultSchema>;
-
-export const DareDefinitionToolInputSchema = z.strictObject({
-  originalText: z.string().min(1).max(4000),
-  targetKeys: z
-    .array(z.string().regex(/^T\d{1,2}$/))
-    .min(1)
-    .max(5),
-  plan: DareCompiledPlanV2Schema,
-  deadlineSpec: DareDeadlineSpecV2Schema,
-  openingStake: BucksStakeSchema,
-});
-
-export const DareScoutQlToolInputSchema = z.strictObject({
-  queryText: z.string().min(1).max(DARE_V2_MAX_QUERY_LENGTH),
-  targetKeys: z
-    .array(z.string().regex(/^T\d{1,2}$/))
-    .min(1)
-    .max(DARE_V2_MAX_TARGETS),
-});
-
-export const ReviseDareToolInputSchema = DareDefinitionToolInputSchema.extend({
-  dareId: z.number().int().positive(),
-  expectedRevision: z.number().int().positive(),
-});
-
-export const DarePreviewToolInputSchema = DareDefinitionToolInputSchema.extend({
-  historyDays: z
-    .number()
-    .int()
-    .min(1)
-    .max(DARE_V2_MAX_HORIZON_DAYS)
-    .default(30),
-});
-
-export const DareListToolInputSchema = z.strictObject({
-  scope: z.enum(["mine", "guild"]),
-  search: z.string().min(1).max(100).optional(),
-});
-
-export const DareInspectToolInputSchema = z.strictObject({
-  dareId: z.number().int().positive(),
-});
-
-export const DareActionToolInputSchema = z.strictObject({
-  dareId: z.number().int().positive(),
-  expectedRevision: z.number().int().positive(),
-  payload: DareV2IntentPayloadSchema,
-});
-
-export const DareDeleteToolInputSchema = z.strictObject({
-  dareId: z.number().int().positive(),
-  expectedRevision: z.number().int().positive(),
-});
+import {
+  DareActionToolInputSchema,
+  DareDefinitionToolInputSchema,
+  DareDeleteToolInputSchema,
+  DareInspectToolInputSchema,
+  DareListToolInputSchema,
+  DarePreviewToolInputSchema,
+  DareScoutQlToolInputSchema,
+  DareToolResultSchema,
+  ReviseDareToolInputSchema,
+  type DareToolResult,
+} from "#src/explore/dare-tool-schemas.ts";
 
 export type DareExploreToolsInput = {
   capability: BucksExploreCapability;
@@ -182,15 +132,15 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
     };
   };
 
-  const resolvedTargetKeys = async (requestedKeys: readonly string[]) => {
+  const resolvedTargets = async (requestedKeys: readonly string[]) => {
     const available = await shortlist();
-    const availableKeys = new Set(available.map((target) => target.key));
-    for (const key of requestedKeys) {
-      if (!availableKeys.has(key)) {
+    return [...new Set(requestedKeys)].map((key) => {
+      const target = available.find((candidate) => candidate.key === key);
+      if (target === undefined) {
         throw new Error(`Dare target ${key} is not in the current shortlist.`);
       }
-    }
-    return [...new Set(requestedKeys)];
+      return target;
+    });
   };
 
   return {
@@ -228,10 +178,10 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
     validateScoutQl: (raw: unknown) =>
       input.track("validate_dare_scoutql", async () => {
         const parsed = DareScoutQlToolInputSchema.parse(raw);
-        const targetKeys = await resolvedTargetKeys(parsed.targetKeys);
-        const validation = await validateRelationalScoutQl({
+        const targets = await resolvedTargets(parsed.targetKeys);
+        const validation = await compileDareScoutQlPlanV2({
           queryText: parsed.queryText,
-          allowedTargetKeys: targetKeys,
+          targets,
         });
         return validation.kind === "invalid"
           ? result(
@@ -246,6 +196,13 @@ export function createDareToolExecutors(input: DareExploreToolsInput) {
                 canonicalScoutQl: validation.compilation.canonicalScoutQl,
                 planHash: validation.compilation.planHash,
                 facts: validation.compilation.facts,
+                plainLanguage: renderDarePlanV2(
+                  validation.compilation.plan,
+                  targets,
+                ),
+                semanticProofPlan: renderDareProofPlanV2(
+                  validation.compilation.plan,
+                ),
               },
             );
       }),

--- a/packages/scout-for-lol/packages/backend/src/explore/prompt.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/prompt.ts
@@ -113,7 +113,7 @@ export function dareExplorePromptSection(): string {
     "You can create and manage private ScoutQL-backed dare drafts for this guild. Bryan Bucks are a joke currency, not real money.",
     "For any authoring request, call get_dare_language first and use only its target keys. Then call validate_dare_contract before create_dare_draft or revise_dare_draft.",
     "Canonical ScoutQL is the authoritative rules text, and the frozen typed plan is its evaluator representation. Never invent a target identity; the tools resolve approved target keys.",
-    "Use validate_dare_scoutql when inspecting or explaining relational ScoutQL. It parses without executing, freezes target bindings, canonicalizes the query, and enforces the closed source/function catalogs and query limits. Creation and revision still require validate_dare_contract so the evaluator plan and semantic proof remain reproducible.",
+    "Use validate_dare_scoutql when inspecting, editing, or explaining relational ScoutQL. It parses without executing, reconstructs the evaluator plan, renders its exact meaning and proof, freezes target bindings, canonicalizes the query, and enforces the closed contract profile and query limits. Model-authored creation still uses validate_dare_contract before create or revise; the web editor compiles authoritative ScoutQL directly.",
     "Scope is load-bearing:",
     "- Conditions that must occur in ONE game belong in one game set. Combine them inside that game set's predicate with AND/OR/NOT.",
     "- Conditions allowed to occur in different games belong in separate game sets. Combine their matching-game or aggregate results at the top level.",

--- a/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/tool-inspection.ts
@@ -27,7 +27,7 @@ import {
   DareScoutQlToolInputSchema,
   DareToolResultSchema,
   ReviseDareToolInputSchema,
-} from "#src/explore/dare-tools.ts";
+} from "#src/explore/dare-tool-schemas.ts";
 
 /**
  * The Bryan Bucks tools' validated shapes, keyed by tool name. They carry no

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql-limits.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql-limits.ts
@@ -1,0 +1,38 @@
+import {
+  DARE_V2_MAX_EXPRESSION_DEPTH,
+  DARE_V2_MAX_GAME_SETS,
+  DARE_V2_MAX_JOINED_RELATIONS,
+  DARE_V2_MAX_PREDICATES,
+  DARE_V2_MAX_TARGETS,
+} from "@scout-for-lol/data";
+
+export type RelationalScoutQlComplexityLimits = {
+  ctes: number;
+  joinedRelations: number;
+  predicates: number;
+  expressionDepth: number;
+};
+
+export const RAW_RELATIONAL_SCOUTQL_LIMITS: RelationalScoutQlComplexityLimits =
+  {
+    ctes: DARE_V2_MAX_GAME_SETS,
+    joinedRelations: DARE_V2_MAX_JOINED_RELATIONS,
+    predicates: DARE_V2_MAX_PREDICATES,
+    expressionDepth: DARE_V2_MAX_EXPRESSION_DEPTH,
+  };
+
+// Canonical Dare ScoutQL uses two supporting CTEs per semantic game set plus
+// one eligibility CTE. It also renders target bindings and deterministic
+// eligibility joins that are not contract predicates or joined data sources.
+// The reverse compiler accepts this larger physical envelope only when the
+// query round-trips exactly and the reconstructed plan passes the ordinary
+// semantic limits.
+export const CANONICAL_DARE_SCOUTQL_LIMITS: RelationalScoutQlComplexityLimits =
+  {
+    ctes: DARE_V2_MAX_GAME_SETS * 2 + 1,
+    joinedRelations: DARE_V2_MAX_GAME_SETS * DARE_V2_MAX_TARGETS,
+    predicates:
+      DARE_V2_MAX_PREDICATES +
+      DARE_V2_MAX_GAME_SETS * (DARE_V2_MAX_TARGETS * 3 + 2),
+    expressionDepth: DARE_V2_MAX_EXPRESSION_DEPTH + 4,
+  };

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql-output.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql-output.ts
@@ -53,7 +53,9 @@ function expressionKind(
       : "other";
   }
   if (expressionClass === "FUNCTION") {
-    return stringValue(object["function_name"]) === "contains"
+    return new Set(["contains", "dare_aggregate", "dare_matching_games"]).has(
+      stringValue(object["function_name"]) ?? "",
+    )
       ? "boolean"
       : "other";
   }

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql.test.ts
@@ -181,4 +181,24 @@ describe("relational ScoutQL compiler", () => {
 
     expect(result.kind).toBe("valid");
   });
+
+  test("keeps arbitrary relational ScoutQL at twenty CTEs", async () => {
+    const queryText = [
+      "WITH",
+      Array.from(
+        { length: 21 },
+        (_unused, index) =>
+          `cte_${index.toString()} AS (SELECT ${index.toString()} AS value)`,
+      ).join(",\n"),
+      "SELECT EXISTS (SELECT 1 FROM match_participants AS p WHERE p.puuid IN dare_target('virmel')) AS achieved",
+    ].join("\n");
+    const result = await validateRelationalScoutQl({
+      queryText,
+      allowedTargetKeys: TARGETS,
+    });
+
+    expect(result.kind).toBe("invalid");
+    if (result.kind !== "invalid") return;
+    expect(result.issues).toContain("ScoutQL may contain at most 20 CTEs.");
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql.ts
@@ -1,11 +1,5 @@
 import { z } from "zod";
-import {
-  DARE_V2_MAX_EXPRESSION_DEPTH,
-  DARE_V2_MAX_GAME_SETS,
-  DARE_V2_MAX_JOINED_RELATIONS,
-  DARE_V2_MAX_PREDICATES,
-  DARE_V2_MAX_QUERY_LENGTH,
-} from "@scout-for-lol/data";
+import { DARE_V2_MAX_QUERY_LENGTH } from "@scout-for-lol/data";
 import { withDuckDBConnection } from "#src/reports/duckdb/instance.ts";
 import {
   relationalScoutQlArrayValue as arrayValue,
@@ -13,6 +7,11 @@ import {
   relationalScoutQlStringValue as stringValue,
   type RelationalScoutQlJsonValue as JsonValue,
 } from "#src/reports/duckdb/relational-scoutql-json.ts";
+import {
+  CANONICAL_DARE_SCOUTQL_LIMITS,
+  RAW_RELATIONAL_SCOUTQL_LIMITS,
+  type RelationalScoutQlComplexityLimits,
+} from "#src/reports/duckdb/relational-scoutql-limits.ts";
 import { relationalScoutQlOutputIssues } from "#src/reports/duckdb/relational-scoutql-output.ts";
 
 const RELATIONAL_SCOUTQL_SOURCES = new Set([
@@ -259,34 +258,38 @@ function uniqueSorted(values: readonly string[]): string[] {
   return [...new Set(values)].toSorted();
 }
 
-function appendLimitIssues(facts: AstFacts, issues: string[]): void {
-  const limits = [
+function appendLimitIssues(
+  facts: AstFacts,
+  limits: RelationalScoutQlComplexityLimits,
+  issues: string[],
+): void {
+  const measuredLimits = [
     {
       actual: facts.cteCount,
-      maximum: DARE_V2_MAX_GAME_SETS,
+      maximum: limits.ctes,
       label: "CTEs",
     },
     {
       actual: facts.joinedRelations,
-      maximum: DARE_V2_MAX_JOINED_RELATIONS,
+      maximum: limits.joinedRelations,
       label: "joined relations",
     },
     {
       actual: facts.predicates,
-      maximum: DARE_V2_MAX_PREDICATES,
+      maximum: limits.predicates,
       label: "predicates",
     },
   ];
-  for (const limit of limits) {
+  for (const limit of measuredLimits) {
     if (limit.actual > limit.maximum) {
       issues.push(
         `ScoutQL may contain at most ${limit.maximum.toString()} ${limit.label}.`,
       );
     }
   }
-  if (facts.maxExpressionDepth > DARE_V2_MAX_EXPRESSION_DEPTH) {
+  if (facts.maxExpressionDepth > limits.expressionDepth) {
     issues.push(
-      `ScoutQL expressions may be at most ${DARE_V2_MAX_EXPRESSION_DEPTH.toString()} levels deep.`,
+      `ScoutQL expressions may be at most ${limits.expressionDepth.toString()} levels deep.`,
     );
   }
 }
@@ -324,6 +327,7 @@ function appendCatalogIssues(input: {
 function semanticIssues(
   statement: JsonValue,
   allowedTargetKeys: ReadonlySet<string>,
+  limits: RelationalScoutQlComplexityLimits,
 ): { issues: string[]; facts: RelationalScoutQlFacts } {
   const mutableFacts: AstFacts = {
     cteNames: new Set(),
@@ -352,7 +356,7 @@ function semanticIssues(
       `ScoutQL wall-clock reference ${wallClock} is not allowed; use immutable bound parameters.`,
     );
   }
-  appendLimitIssues(mutableFacts, issues);
+  appendLimitIssues(mutableFacts, limits, issues);
   appendCatalogIssues({
     physicalSources,
     functions,
@@ -415,10 +419,13 @@ async function canonicalSql(serializedAst: string): Promise<string> {
  * submitted query. DuckDB supplies the SQL AST; Scout then applies a strict,
  * closed-world policy before retaining the canonical AST as the immutable plan.
  */
-export async function validateRelationalScoutQl(input: {
-  queryText: string;
-  allowedTargetKeys: readonly string[];
-}): Promise<RelationalScoutQlValidation> {
+async function validateRelationalScoutQlWithLimits(
+  input: {
+    queryText: string;
+    allowedTargetKeys: readonly string[];
+  },
+  limits: RelationalScoutQlComplexityLimits,
+): Promise<RelationalScoutQlValidation> {
   if (input.queryText.length > DARE_V2_MAX_QUERY_LENGTH) {
     return {
       kind: "invalid",
@@ -449,7 +456,11 @@ export async function validateRelationalScoutQl(input: {
   if (statement === undefined) {
     throw new Error("ScoutQL statement count changed after validation.");
   }
-  const analysis = semanticIssues(statement, new Set(input.allowedTargetKeys));
+  const analysis = semanticIssues(
+    statement,
+    new Set(input.allowedTargetKeys),
+    limits,
+  );
   if (analysis.issues.length > 0) {
     return { kind: "invalid", issues: analysis.issues };
   }
@@ -467,4 +478,29 @@ export async function validateRelationalScoutQl(input: {
       facts: analysis.facts,
     },
   };
+}
+
+export async function validateRelationalScoutQl(input: {
+  queryText: string;
+  allowedTargetKeys: readonly string[];
+}): Promise<RelationalScoutQlValidation> {
+  return await validateRelationalScoutQlWithLimits(
+    input,
+    RAW_RELATIONAL_SCOUTQL_LIMITS,
+  );
+}
+
+/**
+ * Structural validation envelope for canonical Dare queries. Callers must
+ * additionally reverse-compile, semantically validate, and exact-round-trip
+ * the query before accepting it as a contract.
+ */
+export async function validateCanonicalDareScoutQl(input: {
+  queryText: string;
+  allowedTargetKeys: readonly string[];
+}): Promise<RelationalScoutQlValidation> {
+  return await validateRelationalScoutQlWithLimits(
+    input,
+    CANONICAL_DARE_SCOUTQL_LIMITS,
+  );
 }

--- a/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/duckdb/relational-scoutql.ts
@@ -33,7 +33,12 @@ const RELATIONAL_SCOUTQL_FUNCTIONS = new Set([
   "contains",
   "count",
   "count_star",
+  "dare_aggregate",
+  "dare_matching_games",
+  "dare_rate",
+  "dare_related_participant_count",
   "dare_target",
+  "dare_timeline_event_count",
   "greatest",
   "max",
   "min",
@@ -98,6 +103,25 @@ export type RelationalScoutQlValidation =
   | { kind: "valid"; compilation: RelationalScoutQlCompilation }
   | { kind: "invalid"; issues: string[] };
 
+export function relationalScoutQlStatementFromImmutableAst(
+  immutableAst: string,
+): unknown {
+  const parsedJson: unknown = JSON.parse(immutableAst);
+  const envelope = SerializedSqlSchema.parse(parsedJson);
+  if (envelope.error) {
+    throw new Error(
+      "Immutable relational ScoutQL AST contains a parser error.",
+    );
+  }
+  const statements = envelope.statements ?? [];
+  const statement = statements[0];
+  if (statement === undefined || statements.length !== 1) {
+    throw new Error(
+      "Immutable relational ScoutQL AST must contain one statement.",
+    );
+  }
+  return statement;
+}
 function collectCteNames(value: JsonValue, facts: AstFacts): void {
   if (Array.isArray(value)) {
     for (const item of value) collectCteNames(item, facts);

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -72,6 +72,36 @@ export const DareParticipantValueFieldV2Schema = z.enum([
   "penta_kills",
 ]);
 
+export const DareParticipantRateFieldV2Schema = z.enum([
+  "cs_per_minute",
+  "damage_per_minute",
+  "kda",
+]);
+
+export const DareComparisonOperatorV2Schema = z.enum([
+  "eq",
+  "neq",
+  "gte",
+  "lte",
+  "gt",
+  "lt",
+]);
+
+export const DareResultOperatorV2Schema = z.enum([
+  "eq",
+  "gte",
+  "lte",
+  "gt",
+  "lt",
+]);
+
+export const DareAggregateFunctionV2Schema = z.enum([
+  "sum",
+  "average",
+  "minimum",
+  "maximum",
+]);
+
 export type DareValueV2 =
   | {
       kind: "participant";
@@ -81,7 +111,7 @@ export type DareValueV2 =
   | {
       kind: "participant_rate";
       target: string;
-      field: "cs_per_minute" | "damage_per_minute" | "kda";
+      field: z.infer<typeof DareParticipantRateFieldV2Schema>;
     }
   | { kind: "game"; field: "duration_seconds" | "queue" }
   | {
@@ -120,7 +150,7 @@ export const DareValueV2Schema: z.ZodType<DareValueV2> = z.lazy(() =>
     z.strictObject({
       kind: z.literal("participant_rate"),
       target: z.string().min(1),
-      field: z.enum(["cs_per_minute", "damage_per_minute", "kda"]),
+      field: DareParticipantRateFieldV2Schema,
     }),
     z.strictObject({
       kind: z.literal("game"),
@@ -173,7 +203,7 @@ export const DareBooleanExpressionV2Schema: z.ZodType<DareBooleanExpressionV2> =
       z.strictObject({
         kind: z.literal("comparison"),
         value: DareValueV2Schema,
-        operator: z.enum(["eq", "neq", "gte", "lte", "gt", "lt"]),
+        operator: DareComparisonOperatorV2Schema,
         threshold: z.union([z.string(), z.number(), z.boolean()]),
       }),
       z.strictObject({
@@ -227,7 +257,7 @@ export const DareResultExpressionV2Schema: z.ZodType<DareResultExpressionV2> =
       z.strictObject({
         kind: z.literal("matching_games"),
         gameSet: z.string().min(1),
-        operator: z.enum(["eq", "gte", "lte", "gt", "lt"]),
+        operator: DareResultOperatorV2Schema,
         threshold: z
           .number()
           .int()
@@ -238,8 +268,8 @@ export const DareResultExpressionV2Schema: z.ZodType<DareResultExpressionV2> =
         kind: z.literal("aggregate"),
         gameSet: z.string().min(1),
         projection: z.string().min(1),
-        function: z.enum(["sum", "average", "minimum", "maximum"]),
-        operator: z.enum(["eq", "gte", "lte", "gt", "lt"]),
+        function: DareAggregateFunctionV2Schema,
+        operator: DareResultOperatorV2Schema,
         threshold: z.number(),
       }),
       z.strictObject({

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -3,9 +3,12 @@ import { BucksStakeSchema } from "#src/model/bryan-bucks.ts";
 import { QueueTypeSchema } from "#src/model/state.ts";
 
 export const DARE_CONTRACT_VERSION = 2;
-export const DARE_SCOUTQL_COMPILER_VERSIONS = ["dare-scoutql-1"] as const;
+export const DARE_SCOUTQL_COMPILER_VERSIONS = [
+  "dare-scoutql-1",
+  "dare-scoutql-2",
+] as const;
 export const DARE_EVALUATOR_V2_VERSIONS = ["dare-evaluator-2"] as const;
-export const DARE_SCOUTQL_COMPILER_VERSION = DARE_SCOUTQL_COMPILER_VERSIONS[0];
+export const DARE_SCOUTQL_COMPILER_VERSION = DARE_SCOUTQL_COMPILER_VERSIONS[1];
 export const DARE_EVALUATOR_V2_VERSION = DARE_EVALUATOR_V2_VERSIONS[0];
 export const DareScoutQlCompilerVersionSchema = z.enum(
   DARE_SCOUTQL_COMPILER_VERSIONS,

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
@@ -31,9 +31,11 @@ The editor syntax documented on this page is report ScoutQL: one bounded data
 source plus grouping, aggregation, ordering, and rendering. Dare v2 contracts
 use a relational profile of ScoutQL with qualified columns, aliases,
 non-recursive CTEs, bounded joins, scalar subqueries, and deterministic first-N
-game sets. Explore can parse, validate, and canonically format that profile
-without executing it; the contract authoring tools generate the query and its
-typed evaluator plan together.
+game sets. Explore can parse, validate, canonically format, explain, and
+historically preview that profile without executing submitted SQL. Model-based
+authoring generates the query and typed evaluator plan together; the advanced
+draft editor instead compiles edited ScoutQL back into that same versioned plan
+before it can save a new revision.
 
 Contract ScoutQL always returns exactly one nullable Boolean named `achieved`:
 `true` means proven, `false` means conclusively not achieved, and `null` means
@@ -43,8 +45,27 @@ funding, parameterizes values, and rejects wall-clock or dynamic player
 resolution. Validation first serializes the DuckDB AST, then applies Scout's
 closed-world source, function, target, statement, and complexity policy. A
 successful compilation returns canonical text plus the hash of its immutable
-AST; it never runs the submitted query. The ordinary report editor does not
-accept this relational profile; inspect and revise contracts through Explore.
+AST, the reconstructed evaluator plan, and its exact plain-language meaning; it
+never runs the submitted query. Only a canonical query that round-trips to the
+same immutable AST is accepted. The ordinary report editor does not accept this
+relational profile; inspect and revise contracts through Explore.
+
+The contract profile keeps participant columns qualified (`p0.kills`) and uses
+a small closed set of Dare functions for semantics that must round-trip without
+ambiguity:
+
+- `dare_target('T1')` binds the frozen accounts for target `T1`.
+- `dare_rate('T1', 'cs_per_minute')` computes a supported participant rate.
+- `dare_related_participant_count(...)` expresses ally or opponent context.
+- `dare_timeline_event_count(...)` counts covered timeline evidence, including
+  optional roles, time bounds, and item IDs.
+- `dare_matching_games(...)` and `dare_aggregate(...)` produce the final
+  three-valued `achieved` result from bounded game sets.
+
+These are contract compiler primitives, not executable user-defined functions.
+The closed compiler recognizes their AST shapes and turns them into evaluator
+nodes; adding an unrecognized function or rearranging deterministic ordering is
+rejected.
 
 This separation is deliberate. A contract must remain reproducible after a
 player rename, prompt change, or compiler upgrade, while an interactive report


### PR DESCRIPTION
Why

Dare drafts exposed generated ScoutQL, but the advanced editor still mutated an internal typed-plan JSON document. This makes ScoutQL the authoritative versioned rules text while preserving a deterministic evaluator representation.

What

- add a closed Dare macro profile and reverse compiler from immutable DuckDB ASTs into Dare v2 plans
- require canonical AST round-trips and reject SQL outside the versioned contract profile
- make Explore validation return the exact meaning, proof plan, plan hash, and complexity facts
- make the web editor validate, format, backtest, diff, and revise ScoutQL directly
- round-trip every checked-in paraphrase contract, including the same-game Twisted Fate case

Verification

- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/app --filter=@scout-for-lol/data --filter=@scout-for-lol/docs-site`
- 30/30 Turbo tasks passed; backend 317 files / 2,942 tests and data 64 files / 1,360 tests passed
- `git diff --check`
- Live model eval not run: 1Password desktop authorization timed out before the OpenRouter request
- Visual proof not captured: no in-app browser session was available