### PR TITLE
feat(scout-for-lol): freeze compiled Dare ScoutQL artifacts

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dares-drawer.tsx
@@ -195,6 +195,9 @@ function DareDetail(props: {
     canonicalScoutQl: string;
     plan: DareCompiledPlanV2;
     semanticProofPlan: string;
+    compilerVersion: string;
+    evaluatorVersion: string;
+    scoutQlPlanHash: string | null;
     originalText: string;
     deadlineSpec: DareDeadlineSpecV2;
     targetAliases: string[];
@@ -228,6 +231,10 @@ function DareDetail(props: {
       <p className="whitespace-pre-wrap text-sm">{props.dare.plainLanguage}</p>
       <dl className="grid grid-cols-2 gap-3 text-sm">
         <Fact label="Revision" value={revision.toString()} />
+        <Fact
+          label="Compiler"
+          value={`${props.dare.compilerVersion} / ${props.dare.evaluatorVersion}`}
+        />
         <Fact label="Targets" value={props.dare.targetAliases.join(", ")} />
         <Fact
           label="Opening stake"
@@ -249,6 +256,11 @@ function DareDetail(props: {
       <section className="space-y-2">
         <h4 className="text-sm font-medium">ScoutQL</h4>
         <ScoutQlCode queryText={props.dare.canonicalScoutQl} />
+        {props.dare.scoutQlPlanHash !== null && (
+          <p className="font-mono text-xs text-scout-subtle">
+            Immutable plan {props.dare.scoutQlPlanHash}
+          </p>
+        )}
       </section>
       {props.dare.proof !== null && (
         <section className="space-y-2">

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260901010000_dare_v2_compiled_scoutql/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260901010000_dare_v2_compiled_scoutql/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "BucksDareV2Revision"
+ADD COLUMN "scoutQlImmutableAst" TEXT,
+ADD COLUMN "scoutQlPlanHash" TEXT;

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -1513,22 +1513,24 @@ model BucksDareV2 {
 // Immutable history of draft iterations. Replacing a draft appends a revision;
 // it never mutates the ScoutQL/plan the challenger previously reviewed.
 model BucksDareV2Revision {
-  id                Int         @id @default(autoincrement())
-  dareId            Int
-  dare              BucksDareV2 @relation(fields: [dareId], references: [id], onDelete: Cascade)
-  revision          Int
-  originalText      String
-  canonicalScoutQl  String
-  compiledPlan      String
-  compilerVersion   String
-  evaluatorVersion  String
-  targetsJson       String
-  deadlineSpecJson  String
-  openingStake      Int
-  plainLanguage     String
-  semanticProofPlan String
-  translationJson   String?
-  createdAt         DateTime    @default(now())
+  id                  Int         @id @default(autoincrement())
+  dareId              Int
+  dare                BucksDareV2 @relation(fields: [dareId], references: [id], onDelete: Cascade)
+  revision            Int
+  originalText        String
+  canonicalScoutQl    String
+  compiledPlan        String
+  scoutQlImmutableAst String?
+  scoutQlPlanHash     String?
+  compilerVersion     String
+  evaluatorVersion    String
+  targetsJson         String
+  deadlineSpecJson    String
+  openingStake        Int
+  plainLanguage       String
+  semanticProofPlan   String
+  translationJson     String?
+  createdAt           DateTime    @default(now())
 
   @@unique([dareId, revision])
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
@@ -31,6 +31,7 @@ import {
   renderDarePlanV2,
   renderDareProofPlanV2,
 } from "#src/betting/dare-render-v2.ts";
+import { compileDareScoutQlPlanV2 } from "#src/betting/dare-scoutql-plan-compiler-v2.ts";
 import { dareValueNeedsTimeline } from "#src/betting/dare-value-v2.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -204,12 +205,43 @@ export function prepareDareDraftV2(
   };
 }
 
-function revisionData(draft: PreparedDareDraftV2, revision: number) {
+type CompiledScoutQlArtifacts = {
+  scoutQlImmutableAst: string;
+  scoutQlPlanHash: string;
+};
+
+async function compileDraftScoutQl(
+  draft: PreparedDareDraftV2,
+): Promise<
+  | { kind: "valid"; artifacts: CompiledScoutQlArtifacts }
+  | { kind: "invalid"; issues: string[] }
+> {
+  const validation = await compileDareScoutQlPlanV2({
+    queryText: draft.canonicalScoutQl,
+    targets: draft.targets,
+  });
+  if (validation.kind === "invalid") return validation;
+  return {
+    kind: "valid",
+    artifacts: {
+      scoutQlImmutableAst: validation.compilation.immutableAst,
+      scoutQlPlanHash: validation.compilation.planHash,
+    },
+  };
+}
+
+function revisionData(
+  draft: PreparedDareDraftV2,
+  artifacts: CompiledScoutQlArtifacts,
+  revision: number,
+) {
   return {
     revision,
     originalText: draft.originalText,
     canonicalScoutQl: draft.canonicalScoutQl,
     compiledPlan: JSON.stringify(draft.plan),
+    scoutQlImmutableAst: artifacts.scoutQlImmutableAst,
+    scoutQlPlanHash: artifacts.scoutQlPlanHash,
     compilerVersion: DARE_SCOUTQL_COMPILER_VERSION,
     evaluatorVersion: DARE_EVALUATOR_V2_VERSION,
     targetsJson: JSON.stringify(draft.targets),
@@ -231,6 +263,8 @@ export async function createDareDraftV2(
   }
   const prepared = prepareDareDraftV2(input, now);
   if (prepared.kind === "invalid") return prepared;
+  const compiled = await compileDraftScoutQl(prepared.draft);
+  if (compiled.kind === "invalid") return compiled;
   const created = await dependencies.prismaClient.bucksDareV2.create({
     data: {
       serverId: input.serverId,
@@ -238,7 +272,9 @@ export async function createDareDraftV2(
       challengerDiscordId: input.challengerDiscordId,
       originConversationId: input.originConversationId ?? null,
       openingStake: prepared.draft.openingStake,
-      revisions: { create: revisionData(prepared.draft, 1) },
+      revisions: {
+        create: revisionData(prepared.draft, compiled.artifacts, 1),
+      },
     },
     select: { id: true, currentRevision: true },
   });
@@ -266,6 +302,8 @@ export async function reviseDareDraftV2(
   }
   const prepared = prepareDareDraftV2(input.definition, now);
   if (prepared.kind === "invalid") return prepared;
+  const compiled = await compileDraftScoutQl(prepared.draft);
+  if (compiled.kind === "invalid") return compiled;
   return await dependencies.prismaClient.$transaction(async (tx) => {
     const updated = await tx.bucksDareV2.updateManyAndReturn({
       where: {
@@ -305,7 +343,11 @@ export async function reviseDareDraftV2(
     await tx.bucksDareV2Revision.create({
       data: {
         dareId: input.dareId,
-        ...revisionData(prepared.draft, row.currentRevision),
+        ...revisionData(
+          prepared.draft,
+          compiled.artifacts,
+          row.currentRevision,
+        ),
       },
     });
     return {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -21,6 +21,40 @@ import {
 } from "#src/betting/dare-v2-common.ts";
 import type { Db } from "#src/database/index.ts";
 
+function contractCompilerFields(revision: {
+  compilerVersion: string;
+  scoutQlImmutableAst: string | null;
+  scoutQlPlanHash: string | null;
+}):
+  | { compilerVersion: "dare-scoutql-1" }
+  | {
+      compilerVersion: "dare-scoutql-2";
+      scoutQlImmutableAst: string;
+      scoutQlPlanHash: string;
+    } {
+  if (revision.compilerVersion === "dare-scoutql-1") {
+    return { compilerVersion: "dare-scoutql-1" };
+  }
+  if (revision.compilerVersion !== "dare-scoutql-2") {
+    throw new Error(
+      `Unknown Dare ScoutQL compiler ${revision.compilerVersion}.`,
+    );
+  }
+  if (
+    revision.scoutQlImmutableAst === null ||
+    revision.scoutQlPlanHash === null
+  ) {
+    throw new Error(
+      "Dare ScoutQL compiler v2 revision is missing its immutable artifact.",
+    );
+  }
+  return {
+    compilerVersion: "dare-scoutql-2",
+    scoutQlImmutableAst: revision.scoutQlImmutableAst,
+    scoutQlPlanHash: revision.scoutQlPlanHash,
+  };
+}
+
 export async function fundDareV2InTransaction(
   tx: Db,
   input: {
@@ -209,7 +243,7 @@ export async function acceptDareV2InTransaction(
     version: DARE_CONTRACT_VERSION,
     canonicalScoutQl: revision.canonicalScoutQl,
     compiledPlan: plan,
-    compilerVersion: revision.compilerVersion,
+    ...contractCompilerFields(revision),
     evaluatorVersion: revision.evaluatorVersion,
     targets,
     openingStake: revision.openingStake,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -27,6 +27,7 @@ function contractCompilerFields(revision: {
   scoutQlPlanHash: string | null;
 }):
   | { compilerVersion: "dare-scoutql-1" }
+  | { compilerVersion: "dare-scoutql-2" }
   | {
       compilerVersion: "dare-scoutql-2";
       scoutQlImmutableAst: string;
@@ -41,11 +42,17 @@ function contractCompilerFields(revision: {
     );
   }
   if (
+    revision.scoutQlImmutableAst === null &&
+    revision.scoutQlPlanHash === null
+  ) {
+    return { compilerVersion: "dare-scoutql-2" };
+  }
+  if (
     revision.scoutQlImmutableAst === null ||
     revision.scoutQlPlanHash === null
   ) {
     throw new Error(
-      "Dare ScoutQL compiler v2 revision is missing its immutable artifact.",
+      "Dare ScoutQL compiler v2 revision has an incomplete immutable artifact.",
     );
   }
   return {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -21,20 +21,13 @@ import {
 } from "#src/betting/dare-v2-common.ts";
 import type { Db } from "#src/database/index.ts";
 
-function contractCompilerFields(revision: {
+function contractCompilerVersion(revision: {
   compilerVersion: string;
   scoutQlImmutableAst: string | null;
   scoutQlPlanHash: string | null;
-}):
-  | { compilerVersion: "dare-scoutql-1" }
-  | { compilerVersion: "dare-scoutql-2" }
-  | {
-      compilerVersion: "dare-scoutql-2";
-      scoutQlImmutableAst: string;
-      scoutQlPlanHash: string;
-    } {
+}): "dare-scoutql-1" | "dare-scoutql-2" {
   if (revision.compilerVersion === "dare-scoutql-1") {
-    return { compilerVersion: "dare-scoutql-1" };
+    return "dare-scoutql-1";
   }
   if (revision.compilerVersion !== "dare-scoutql-2") {
     throw new Error(
@@ -45,7 +38,7 @@ function contractCompilerFields(revision: {
     revision.scoutQlImmutableAst === null &&
     revision.scoutQlPlanHash === null
   ) {
-    return { compilerVersion: "dare-scoutql-2" };
+    return "dare-scoutql-2";
   }
   if (
     revision.scoutQlImmutableAst === null ||
@@ -55,11 +48,7 @@ function contractCompilerFields(revision: {
       "Dare ScoutQL compiler v2 revision has an incomplete immutable artifact.",
     );
   }
-  return {
-    compilerVersion: "dare-scoutql-2",
-    scoutQlImmutableAst: revision.scoutQlImmutableAst,
-    scoutQlPlanHash: revision.scoutQlPlanHash,
-  };
+  return "dare-scoutql-2";
 }
 
 export async function fundDareV2InTransaction(
@@ -250,7 +239,7 @@ export async function acceptDareV2InTransaction(
     version: DARE_CONTRACT_VERSION,
     canonicalScoutQl: revision.canonicalScoutQl,
     compiledPlan: plan,
-    ...contractCompilerFields(revision),
+    compilerVersion: contractCompilerVersion(revision),
     evaluatorVersion: revision.evaluatorVersion,
     targets,
     openingStake: revision.openingStake,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-proof-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-proof-v2.ts
@@ -23,6 +23,9 @@ export type DareFinalityV2 = {
 
 export type DareProofV2 = {
   planVersion: number;
+  compilerVersion: string;
+  evaluatorVersion: string;
+  scoutQlPlanHash: string | null;
   value: boolean;
   booleanBranch: string;
   decisiveAt: string;
@@ -301,6 +304,9 @@ export function buildDareProofV2(input: {
   evidence: readonly DareMatchEvidenceV2[];
   value: boolean;
   settledAt: string;
+  compilerVersion: string;
+  evaluatorVersion: string;
+  scoutQlPlanHash: string | null;
 }): DareProofV2 {
   const evidence = orderedEvidence(input.plan, input.evidence);
   const part = proofPart(
@@ -315,6 +321,9 @@ export function buildDareProofV2(input: {
   );
   return {
     planVersion: input.plan.version,
+    compilerVersion: input.compilerVersion,
+    evaluatorVersion: input.evaluatorVersion,
+    scoutQlPlanHash: input.scoutQlPlanHash,
     value: input.value,
     booleanBranch: part.branch,
     decisiveAt: part.decisiveAt,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-properties-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-properties-v2.test.ts
@@ -15,6 +15,11 @@ import {
 } from "#src/betting/dare-proof-v2.ts";
 
 const VALUES: readonly DareTruthValue[] = [false, null, true];
+const PROOF_ARTIFACT = {
+  compilerVersion: "dare-scoutql-2",
+  evaluatorVersion: "dare-evaluator-2",
+  scoutQlPlanHash: "0".repeat(64),
+};
 
 function gameSet(name: string, target: string, limit = 100) {
   return {
@@ -181,6 +186,7 @@ describe("Dare v2 evaluator properties", () => {
 
     expect(
       buildDareProofV2({
+        ...PROOF_ARTIFACT,
         plan: bounded,
         evidence: [],
         value: false,
@@ -205,6 +211,7 @@ describe("Dare v2 evaluator properties", () => {
     ];
     expect(
       buildDareProofV2({
+        ...PROOF_ARTIFACT,
         plan: orPlan,
         evidence: earlierB,
         value: true,
@@ -215,6 +222,7 @@ describe("Dare v2 evaluator properties", () => {
     const tied = [evidence({ id: "AB", endSecond: 1, a: true, b: true })];
     expect(
       buildDareProofV2({
+        ...PROOF_ARTIFACT,
         plan: orPlan,
         evidence: tied,
         value: true,
@@ -231,6 +239,7 @@ describe("Dare v2 proof bounds", () => {
 
     expect(
       buildDareProofV2({
+        ...PROOF_ARTIFACT,
         plan: notPlan,
         evidence: [],
         value: true,
@@ -284,6 +293,7 @@ describe("Dare v2 proof bounds", () => {
 
     expect(
       buildDareProofV2({
+        ...PROOF_ARTIFACT,
         plan: aggregateOrPlan,
         evidence: rows,
         value: true,
@@ -311,6 +321,7 @@ describe("Dare v2 proof bounds", () => {
       ).toBe(true);
       expect(
         buildDareProofV2({
+          ...PROOF_ARTIFACT,
           plan: bounded,
           evidence: candidate,
           value: true,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { dareV2EvidencePlanVersion } from "#src/betting/dare-settle-evidence-v2.ts";
+
+describe("Dare v2 evidence plan versions", () => {
+  test("preserves the existing two-part tag for compiler-v1 evidence", () => {
+    expect(
+      dareV2EvidencePlanVersion({
+        compilerVersion: "dare-scoutql-1",
+        evaluatorVersion: "dare-evaluator-2",
+      }),
+    ).toBe("dare-scoutql-1:dare-evaluator-2");
+  });
+
+  test("binds compiler-v2 evidence to its immutable plan hash", () => {
+    expect(
+      dareV2EvidencePlanVersion({
+        compilerVersion: "dare-scoutql-2",
+        evaluatorVersion: "dare-evaluator-2",
+        scoutQlPlanHash: "plan-hash",
+      }),
+    ).toBe("dare-scoutql-2:dare-evaluator-2:plan-hash");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.test.ts
@@ -20,4 +20,13 @@ describe("Dare v2 evidence plan versions", () => {
       }),
     ).toBe("dare-scoutql-2:dare-evaluator-2:plan-hash");
   });
+
+  test("preserves the two-part tag for pre-artifact compiler-v2 evidence", () => {
+    expect(
+      dareV2EvidencePlanVersion({
+        compilerVersion: "dare-scoutql-2",
+        evaluatorVersion: "dare-evaluator-2",
+      }),
+    ).toBe("dare-scoutql-2:dare-evaluator-2");
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.ts
@@ -61,6 +61,7 @@ export function dareV2EvidenceCreateData(
 
 type DareV2EvidenceVersionContract =
   | { compilerVersion: "dare-scoutql-1"; evaluatorVersion: string }
+  | { compilerVersion: "dare-scoutql-2"; evaluatorVersion: string }
   | {
       compilerVersion: "dare-scoutql-2";
       evaluatorVersion: string;
@@ -71,7 +72,7 @@ export function dareV2EvidencePlanVersion(
   contract: DareV2EvidenceVersionContract,
 ): string {
   const versions = `${contract.compilerVersion}:${contract.evaluatorVersion}`;
-  return contract.compilerVersion === "dare-scoutql-1"
-    ? versions
-    : `${versions}:${contract.scoutQlPlanHash}`;
+  return "scoutQlPlanHash" in contract
+    ? `${versions}:${contract.scoutQlPlanHash}`
+    : versions;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-evidence-v2.ts
@@ -58,3 +58,20 @@ export function dareV2EvidenceCreateData(
     planVersion,
   };
 }
+
+type DareV2EvidenceVersionContract =
+  | { compilerVersion: "dare-scoutql-1"; evaluatorVersion: string }
+  | {
+      compilerVersion: "dare-scoutql-2";
+      evaluatorVersion: string;
+      scoutQlPlanHash: string;
+    };
+
+export function dareV2EvidencePlanVersion(
+  contract: DareV2EvidenceVersionContract,
+): string {
+  const versions = `${contract.compilerVersion}:${contract.evaluatorVersion}`;
+  return contract.compilerVersion === "dare-scoutql-1"
+    ? versions
+    : `${versions}:${contract.scoutQlPlanHash}`;
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
@@ -22,6 +22,7 @@ import type {
 import { collectDareV2Batch } from "#src/betting/dare-settle-batch-v2.ts";
 import {
   dareV2EvidenceCreateData,
+  dareV2EvidencePlanVersion,
   storedDareV2Evidence,
 } from "#src/betting/dare-settle-evidence-v2.ts";
 import {
@@ -171,7 +172,7 @@ async function captureOneDareV2(
       dareV2EvidenceCreateData(
         input.dare.id,
         input.matchEvidence,
-        `${input.contract.compilerVersion}:${input.contract.evaluatorVersion}:${dareV2ScoutQlPlanHash(input.contract) ?? "legacy"}`,
+        dareV2EvidencePlanVersion(input.contract),
       ),
     ],
     skipDuplicates: true,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
@@ -35,6 +35,7 @@ import {
   loadDareTimelineEvidenceV2,
 } from "#src/betting/dare-timeline-evidence-v2.ts";
 import {
+  dareV2ScoutQlPlanHash,
   parseDareV2Contract,
   readableDareV2Contract,
 } from "#src/betting/dare-v2-common.ts";
@@ -170,7 +171,7 @@ async function captureOneDareV2(
       dareV2EvidenceCreateData(
         input.dare.id,
         input.matchEvidence,
-        `${input.contract.compilerVersion}:${input.contract.evaluatorVersion}`,
+        `${input.contract.compilerVersion}:${input.contract.evaluatorVersion}:${dareV2ScoutQlPlanHash(input.contract) ?? "legacy"}`,
       ),
     ],
     skipDuplicates: true,
@@ -196,6 +197,9 @@ async function captureOneDareV2(
           evidence,
           value: finality.value,
           settledAt: input.now.toISOString(),
+          compilerVersion: input.contract.compilerVersion,
+          evaluatorVersion: input.contract.evaluatorVersion,
+          scoutQlPlanHash: dareV2ScoutQlPlanHash(input.contract),
         })
       : null;
   const resolution = finality.final
@@ -465,6 +469,9 @@ export async function settleActiveDareV2AtBound(
                 evidence,
                 value: finality.value,
                 settledAt: now.toISOString(),
+                compilerVersion: contract.compilerVersion,
+                evaluatorVersion: contract.evaluatorVersion,
+                scoutQlPlanHash: dareV2ScoutQlPlanHash(contract),
               });
         const resolution = await resolveFinalDareV2(tx, {
           dare,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2-common.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2-common.ts
@@ -70,6 +70,12 @@ export function readableDareV2Contract(
   }
 }
 
+export function dareV2ScoutQlPlanHash(contract: DareContractV2): string | null {
+  return contract.compilerVersion === "dare-scoutql-2"
+    ? contract.scoutQlPlanHash
+    : null;
+}
+
 export async function currentDareV2State(
   reader: {
     bucksDareV2: {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2-common.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2-common.ts
@@ -71,9 +71,7 @@ export function readableDareV2Contract(
 }
 
 export function dareV2ScoutQlPlanHash(contract: DareContractV2): string | null {
-  return contract.compilerVersion === "dare-scoutql-2"
-    ? contract.scoutQlPlanHash
-    : null;
+  return "scoutQlPlanHash" in contract ? contract.scoutQlPlanHash : null;
 }
 
 export async function currentDareV2State(

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -41,6 +41,7 @@ import {
 } from "#src/betting/dare-view-v2.ts";
 import { consumeDareV2ConfirmationIntent } from "#src/betting/dare-intent-consume-v2.ts";
 import { createDareV2ConfirmationIntent } from "#src/betting/dare-intent-v2.ts";
+import { parseDareV2Contract } from "#src/betting/dare-v2-common.ts";
 import {
   addFlagOverride,
   clearFlagOverrides,
@@ -445,6 +446,15 @@ describe("Dare v2 draft and lifecycle", () => {
     expect(active.fundedRevision).toBe(1);
     expect(active.deadlineAt?.toISOString()).toBe("2026-09-08T12:00:00.000Z");
     expect(active.contractJson).not.toBeNull();
+    if (active.contractJson === null) return;
+    const contract = parseDareV2Contract(active.contractJson);
+    expect(contract.compilerVersion).toBe("dare-scoutql-2");
+    if (contract.compilerVersion !== "dare-scoutql-2") return;
+    expect(contract.scoutQlPlanHash).toBe(
+      new Bun.CryptoHasher("sha256")
+        .update(contract.scoutQlImmutableAst)
+        .digest("hex"),
+    );
     await expect(reconcileBucksBalances(db)).resolves.toEqual([]);
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -449,11 +449,15 @@ describe("Dare v2 draft and lifecycle", () => {
     if (active.contractJson === null) return;
     const contract = parseDareV2Contract(active.contractJson);
     expect(contract.compilerVersion).toBe("dare-scoutql-2");
-    expect("scoutQlPlanHash" in contract).toBe(true);
-    if (!("scoutQlPlanHash" in contract)) return;
-    expect(contract.scoutQlPlanHash).toBe(
+    expect("scoutQlPlanHash" in contract).toBe(false);
+    const revision = await db.bucksDareV2Revision.findUniqueOrThrow({
+      where: { dareId_revision: { dareId, revision: 1 } },
+    });
+    expect(revision.scoutQlImmutableAst).not.toBeNull();
+    if (revision.scoutQlImmutableAst === null) return;
+    expect(revision.scoutQlPlanHash).toBe(
       new Bun.CryptoHasher("sha256")
-        .update(contract.scoutQlImmutableAst)
+        .update(revision.scoutQlImmutableAst)
         .digest("hex"),
     );
     await expect(reconcileBucksBalances(db)).resolves.toEqual([]);

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -449,7 +449,8 @@ describe("Dare v2 draft and lifecycle", () => {
     if (active.contractJson === null) return;
     const contract = parseDareV2Contract(active.contractJson);
     expect(contract.compilerVersion).toBe("dare-scoutql-2");
-    if (contract.compilerVersion !== "dare-scoutql-2") return;
+    expect("scoutQlPlanHash" in contract).toBe(true);
+    if (!("scoutQlPlanHash" in contract)) return;
     expect(contract.scoutQlPlanHash).toBe(
       new Bun.CryptoHasher("sha256")
         .update(contract.scoutQlImmutableAst)

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -458,6 +458,44 @@ describe("Dare v2 draft and lifecycle", () => {
     );
     await expect(reconcileBucksBalances(db)).resolves.toEqual([]);
   });
+
+  test("activates a pre-artifact compiler-v2 revision", async () => {
+    const dareId = await makeDraft();
+    await db.bucksDareV2Revision.update({
+      where: { dareId_revision: { dareId, revision: 1 } },
+      data: { scoutQlImmutableAst: null, scoutQlPlanHash: null },
+    });
+
+    const fundIntent = await intent({
+      dareId,
+      actor: CHALLENGER,
+      action: "fund",
+      key: "fund-pre-artifact",
+    });
+    expect(await consume(fundIntent, CHALLENGER)).toMatchObject({
+      kind: "funded",
+    });
+    const acceptIntent = await intent({
+      dareId,
+      actor: TARGET,
+      action: "accept",
+      key: "accept-pre-artifact",
+    });
+    expect(await consume(acceptIntent, TARGET)).toMatchObject({
+      kind: "accepted",
+      activated: true,
+    });
+
+    const active = await db.bucksDareV2.findUniqueOrThrow({
+      where: { id: dareId },
+    });
+    expect(active.contractJson).not.toBeNull();
+    if (active.contractJson === null) return;
+    const contract = parseDareV2Contract(active.contractJson);
+    expect(contract.compilerVersion).toBe("dare-scoutql-2");
+    expect("scoutQlPlanHash" in contract).toBe(false);
+    await expect(reconcileBucksBalances(db)).resolves.toEqual([]);
+  });
 });
 
 describe("Dare v2 absolute deadlines", () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -50,6 +50,10 @@ export const DareV2InspectionSchema = DareV2ListItemSchema.extend({
   originalText: z.string().min(1),
   deadlineSpec: DareDeadlineSpecV2Schema,
   compilerVersion: z.string().min(1),
+  scoutQlPlanHash: z
+    .string()
+    .regex(/^[a-f\d]{64}$/)
+    .nullable(),
   evaluatorVersion: z.string().min(1),
   targets: z.array(StoredTargetSchema),
   proof: z.json().nullable(),
@@ -81,6 +85,7 @@ type VisibleDareRow = {
     originalText: string;
     canonicalScoutQl: string;
     compiledPlan: string;
+    scoutQlPlanHash: string | null;
     compilerVersion: string;
     evaluatorVersion: string;
     targetsJson: string;
@@ -172,6 +177,7 @@ function inspection(row: VisibleDareRow): DareV2Inspection {
       JSON.parse(revision.deadlineSpecJson),
     ),
     compilerVersion: revision.compilerVersion,
+    scoutQlPlanHash: revision.scoutQlPlanHash,
     evaluatorVersion: revision.evaluatorVersion,
     targets:
       row.targets.length === 0

--- a/packages/scout-for-lol/packages/backend/src/explore/dare-editor-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/explore/dare-editor-v2.ts
@@ -106,6 +106,30 @@ async function prepareEditorDraft(
   };
 }
 
+async function prepareValidEditorDraft(
+  input: EditorInput,
+  userId: DiscordAccountId,
+  guildIds: string[],
+) {
+  const result = await prepareEditorDraft(input, userId, guildIds);
+  if (result.kind === "invalid") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: result.issues.join(" "),
+    });
+  }
+  if (result.prepared.kind === "invalid") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: result.prepared.issues.join(" "),
+    });
+  }
+  return {
+    owned: result.owned,
+    prepared: result.prepared,
+  };
+}
+
 export async function validateDareDraftEditorV2(
   input: EditorInput,
   userId: DiscordAccountId,
@@ -126,27 +150,6 @@ export async function validateDareDraftEditorV2(
         plainLanguage: prepared.draft.plainLanguage,
         semanticProofPlan: prepared.draft.semanticProofPlan,
       };
-}
-
-async function prepareValidEditorDraft(
-  input: EditorInput,
-  userId: DiscordAccountId,
-  guildIds: string[],
-) {
-  const result = await prepareEditorDraft(input, userId, guildIds);
-  if (result.kind === "invalid") {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: result.issues.join(" "),
-    });
-  }
-  if (result.prepared.kind === "invalid") {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: result.prepared.issues.join(" "),
-    });
-  }
-  return { owned: result.owned, prepared: result.prepared };
 }
 
 export async function previewDareDraftEditorV2(

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-limits.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2-limits.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "vitest";
 import { BUCKS_INT32_MAX } from "./bryan-bucks.ts";
 import {
+  DARE_V2_TEST_CONTRACT_BASE,
+  DARE_V2_TEST_GAME_SET,
+  DARE_V2_TEST_PLAN,
+  DARE_V2_TEST_PREDICATE,
+} from "./dare-contract-v2.test-fixtures.ts";
+import {
   DARE_V2_MAX_EXPRESSION_DEPTH,
   DARE_V2_MAX_PREDICATES,
   DareCompiledPlanV2Schema,
@@ -8,70 +14,14 @@ import {
   type DareBooleanExpressionV2,
 } from "./dare-contract-v2.ts";
 
-const PREDICATE: DareBooleanExpressionV2 = {
-  kind: "comparison",
-  value: { kind: "participant", target: "T1", field: "kills" },
-  operator: "gte",
-  threshold: 1,
-};
-
-const GAME_SET = {
-  name: "games",
-  targetKeys: ["T1"],
-  relationship: "independent",
-  queues: ["solo"],
-  predicate: PREDICATE,
-  projections: [],
-  orderBy: "game_end_at_asc_match_id_asc",
-  limit: 1,
-};
-
-const PLAN = {
-  version: 2,
-  maxEligibleGames: 1,
-  gameSets: [GAME_SET],
-  result: {
-    kind: "matching_games",
-    gameSet: "games",
-    operator: "gte",
-    threshold: 1,
-  },
-};
-
 const CONTRACT = {
-  version: 2,
-  canonicalScoutQl: "SELECT TRUE AS achieved",
-  compiledPlan: PLAN,
+  ...DARE_V2_TEST_CONTRACT_BASE,
   compilerVersion: "dare-scoutql-1",
-  evaluatorVersion: "dare-evaluator-2",
-  targets: [
-    {
-      key: "T1",
-      discordId: "100000000000000001",
-      playerId: 1,
-      alias: "Virmel",
-      accounts: [
-        {
-          puuid: "frozen-puuid",
-          trackingStartedAt: "2026-01-01T00:00:00.000Z",
-        },
-      ],
-    },
-  ],
-  openingStake: 20,
-  serverId: "100000000000000002",
-  channelId: "100000000000000003",
-  revision: 1,
-  activationAt: "2026-09-01T00:00:00.000Z",
-  deadlineAt: "2026-09-08T00:00:00.000Z",
-  deadlineSpec: { kind: "relative", days: 7 },
-  plainLanguage: "Virmel gets at least one kill.",
-  semanticProofPlan: "Count one matching game.",
 };
 
 function nestedNotExpression(depth: number): DareBooleanExpressionV2 {
   return depth === 1
-    ? PREDICATE
+    ? DARE_V2_TEST_PREDICATE
     : { kind: "not", operand: nestedNotExpression(depth - 1) };
 }
 
@@ -88,15 +38,15 @@ describe("Dare v2 durable contract limits", () => {
   test("rejects plans with more than the maximum predicate count", () => {
     expect(
       DareCompiledPlanV2Schema.safeParse({
-        ...PLAN,
+        ...DARE_V2_TEST_PLAN,
         gameSets: [
           {
-            ...GAME_SET,
+            ...DARE_V2_TEST_GAME_SET,
             predicate: {
               kind: "and",
               operands: Array.from(
                 { length: DARE_V2_MAX_PREDICATES },
-                () => PREDICATE,
+                () => DARE_V2_TEST_PREDICATE,
               ),
             },
           },
@@ -108,10 +58,10 @@ describe("Dare v2 durable contract limits", () => {
   test("rejects plans deeper than the expression-depth cap", () => {
     expect(
       DareCompiledPlanV2Schema.safeParse({
-        ...PLAN,
+        ...DARE_V2_TEST_PLAN,
         gameSets: [
           {
-            ...GAME_SET,
+            ...DARE_V2_TEST_GAME_SET,
             predicate: nestedNotExpression(DARE_V2_MAX_EXPRESSION_DEPTH),
           },
         ],
@@ -122,10 +72,10 @@ describe("Dare v2 durable contract limits", () => {
   test("rejects game sets that exceed the joined-relation cap", () => {
     expect(
       DareCompiledPlanV2Schema.safeParse({
-        ...PLAN,
+        ...DARE_V2_TEST_PLAN,
         gameSets: [
           {
-            ...GAME_SET,
+            ...DARE_V2_TEST_GAME_SET,
             projections: Array.from({ length: 8 }, (_, index) => ({
               name: `related_${index.toString()}`,
               value: {

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test-fixtures.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test-fixtures.ts
@@ -1,0 +1,61 @@
+import type { DareBooleanExpressionV2 } from "./dare-contract-v2.ts";
+
+export const DARE_V2_TEST_PREDICATE: DareBooleanExpressionV2 = {
+  kind: "comparison",
+  value: { kind: "participant", target: "T1", field: "kills" },
+  operator: "gte",
+  threshold: 1,
+};
+
+export const DARE_V2_TEST_GAME_SET = {
+  name: "games",
+  targetKeys: ["T1"],
+  relationship: "independent",
+  queues: ["solo"],
+  predicate: DARE_V2_TEST_PREDICATE,
+  projections: [],
+  orderBy: "game_end_at_asc_match_id_asc",
+  limit: 1,
+};
+
+export const DARE_V2_TEST_PLAN = {
+  version: 2,
+  maxEligibleGames: 1,
+  gameSets: [DARE_V2_TEST_GAME_SET],
+  result: {
+    kind: "matching_games",
+    gameSet: "games",
+    operator: "gte",
+    threshold: 1,
+  },
+};
+
+export const DARE_V2_TEST_CONTRACT_BASE = {
+  version: 2,
+  canonicalScoutQl: "SELECT TRUE AS achieved",
+  compiledPlan: DARE_V2_TEST_PLAN,
+  evaluatorVersion: "dare-evaluator-2",
+  targets: [
+    {
+      key: "T1",
+      discordId: "100000000000000001",
+      playerId: 1,
+      alias: "Virmel",
+      accounts: [
+        {
+          puuid: "frozen-puuid",
+          trackingStartedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    },
+  ],
+  openingStake: 20,
+  serverId: "100000000000000002",
+  channelId: "100000000000000003",
+  revision: 1,
+  activationAt: "2026-09-01T00:00:00.000Z",
+  deadlineAt: "2026-09-08T00:00:00.000Z",
+  deadlineSpec: { kind: "relative", days: 7 },
+  plainLanguage: "Virmel gets at least one kill.",
+  semanticProofPlan: "Count one matching game.",
+};

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test.ts
@@ -1,67 +1,12 @@
 import { describe, expect, test } from "vitest";
+import { DARE_V2_TEST_CONTRACT_BASE } from "./dare-contract-v2.test-fixtures.ts";
 import { DareContractV2Schema } from "./dare-contract-v2.ts";
-
-const CONTRACT_BASE = {
-  version: 2,
-  canonicalScoutQl: "SELECT TRUE AS achieved",
-  compiledPlan: {
-    version: 2,
-    maxEligibleGames: 1,
-    gameSets: [
-      {
-        name: "games",
-        targetKeys: ["T1"],
-        relationship: "independent",
-        queues: ["solo"],
-        predicate: {
-          kind: "comparison",
-          value: { kind: "participant", target: "T1", field: "kills" },
-          operator: "gte",
-          threshold: 1,
-        },
-        projections: [],
-        orderBy: "game_end_at_asc_match_id_asc",
-        limit: 1,
-      },
-    ],
-    result: {
-      kind: "matching_games",
-      gameSet: "games",
-      operator: "gte",
-      threshold: 1,
-    },
-  },
-  evaluatorVersion: "dare-evaluator-2",
-  targets: [
-    {
-      key: "T1",
-      discordId: "100000000000000001",
-      playerId: 1,
-      alias: "Virmel",
-      accounts: [
-        {
-          puuid: "frozen-puuid",
-          trackingStartedAt: "2026-01-01T00:00:00.000Z",
-        },
-      ],
-    },
-  ],
-  openingStake: 20,
-  serverId: "100000000000000002",
-  channelId: "100000000000000003",
-  revision: 1,
-  activationAt: "2026-09-01T00:00:00.000Z",
-  deadlineAt: "2026-09-08T00:00:00.000Z",
-  deadlineSpec: { kind: "relative", days: 7 },
-  plainLanguage: "Virmel gets at least one kill.",
-  semanticProofPlan: "Count one matching game.",
-};
 
 describe("Dare v2 compiler artifact compatibility", () => {
   test("keeps compiler v1 contracts parseable without relational artifacts", () => {
     expect(
       DareContractV2Schema.parse({
-        ...CONTRACT_BASE,
+        ...DARE_V2_TEST_CONTRACT_BASE,
         compilerVersion: "dare-scoutql-1",
       }).compilerVersion,
     ).toBe("dare-scoutql-1");
@@ -70,13 +15,13 @@ describe("Dare v2 compiler artifact compatibility", () => {
   test("requires immutable artifacts for compiler v2 contracts", () => {
     expect(
       DareContractV2Schema.safeParse({
-        ...CONTRACT_BASE,
+        ...DARE_V2_TEST_CONTRACT_BASE,
         compilerVersion: "dare-scoutql-2",
       }).success,
     ).toBe(false);
 
     const contract = DareContractV2Schema.parse({
-      ...CONTRACT_BASE,
+      ...DARE_V2_TEST_CONTRACT_BASE,
       compilerVersion: "dare-scoutql-2",
       scoutQlImmutableAst: "immutable-ast",
       scoutQlPlanHash: "0".repeat(64),

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test.ts
@@ -12,14 +12,23 @@ describe("Dare v2 compiler artifact compatibility", () => {
     ).toBe("dare-scoutql-1");
   });
 
-  test("requires immutable artifacts for compiler v2 contracts", () => {
+  test("keeps pre-artifact compiler v2 contracts parseable", () => {
+    const contract = DareContractV2Schema.parse({
+      ...DARE_V2_TEST_CONTRACT_BASE,
+      compilerVersion: "dare-scoutql-2",
+    });
+    expect(contract.compilerVersion).toBe("dare-scoutql-2");
+    expect("scoutQlPlanHash" in contract).toBe(false);
+  });
+
+  test("requires both immutable artifacts on artifact-bound contracts", () => {
     expect(
       DareContractV2Schema.safeParse({
         ...DARE_V2_TEST_CONTRACT_BASE,
         compilerVersion: "dare-scoutql-2",
+        scoutQlImmutableAst: "immutable-ast",
       }).success,
     ).toBe(false);
-
     const contract = DareContractV2Schema.parse({
       ...DARE_V2_TEST_CONTRACT_BASE,
       compilerVersion: "dare-scoutql-2",
@@ -27,5 +36,6 @@ describe("Dare v2 compiler artifact compatibility", () => {
       scoutQlPlanHash: "0".repeat(64),
     });
     expect(contract.compilerVersion).toBe("dare-scoutql-2");
+    expect("scoutQlPlanHash" in contract).toBe(true);
   });
 });

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import { DareContractV2Schema } from "./dare-contract-v2.ts";
+
+const CONTRACT_BASE = {
+  version: 2,
+  canonicalScoutQl: "SELECT TRUE AS achieved",
+  compiledPlan: {
+    version: 2,
+    maxEligibleGames: 1,
+    gameSets: [
+      {
+        name: "games",
+        targetKeys: ["T1"],
+        relationship: "independent",
+        queues: ["solo"],
+        predicate: {
+          kind: "comparison",
+          value: { kind: "participant", target: "T1", field: "kills" },
+          operator: "gte",
+          threshold: 1,
+        },
+        projections: [],
+        orderBy: "game_end_at_asc_match_id_asc",
+        limit: 1,
+      },
+    ],
+    result: {
+      kind: "matching_games",
+      gameSet: "games",
+      operator: "gte",
+      threshold: 1,
+    },
+  },
+  evaluatorVersion: "dare-evaluator-2",
+  targets: [
+    {
+      key: "T1",
+      discordId: "100000000000000001",
+      playerId: 1,
+      alias: "Virmel",
+      accounts: [
+        {
+          puuid: "frozen-puuid",
+          trackingStartedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    },
+  ],
+  openingStake: 20,
+  serverId: "100000000000000002",
+  channelId: "100000000000000003",
+  revision: 1,
+  activationAt: "2026-09-01T00:00:00.000Z",
+  deadlineAt: "2026-09-08T00:00:00.000Z",
+  deadlineSpec: { kind: "relative", days: 7 },
+  plainLanguage: "Virmel gets at least one kill.",
+  semanticProofPlan: "Count one matching game.",
+};
+
+describe("Dare v2 compiler artifact compatibility", () => {
+  test("keeps compiler v1 contracts parseable without relational artifacts", () => {
+    expect(
+      DareContractV2Schema.parse({
+        ...CONTRACT_BASE,
+        compilerVersion: "dare-scoutql-1",
+      }).compilerVersion,
+    ).toBe("dare-scoutql-1");
+  });
+
+  test("requires immutable artifacts for compiler v2 contracts", () => {
+    expect(
+      DareContractV2Schema.safeParse({
+        ...CONTRACT_BASE,
+        compilerVersion: "dare-scoutql-2",
+      }).success,
+    ).toBe(false);
+
+    const contract = DareContractV2Schema.parse({
+      ...CONTRACT_BASE,
+      compilerVersion: "dare-scoutql-2",
+      scoutQlImmutableAst: "immutable-ast",
+      scoutQlPlanHash: "0".repeat(64),
+    });
+    expect(contract.compilerVersion).toBe("dare-scoutql-2");
+  });
+});

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -8,7 +8,7 @@ export const DARE_SCOUTQL_COMPILER_VERSIONS = [
   "dare-scoutql-2",
 ] as const;
 export const DARE_EVALUATOR_V2_VERSIONS = ["dare-evaluator-2"] as const;
-export const DARE_SCOUTQL_COMPILER_VERSION = DARE_SCOUTQL_COMPILER_VERSIONS[1];
+export const DARE_SCOUTQL_COMPILER_VERSION = "dare-scoutql-2" as const;
 export const DARE_EVALUATOR_V2_VERSION = DARE_EVALUATOR_V2_VERSIONS[0];
 export const DareScoutQlCompilerVersionSchema = z.enum(
   DARE_SCOUTQL_COMPILER_VERSIONS,
@@ -438,11 +438,10 @@ export const DareDeadlineSpecV2Schema = z.union([
 ]);
 export type DareDeadlineSpecV2 = z.infer<typeof DareDeadlineSpecV2Schema>;
 
-export const DareContractV2Schema = z.strictObject({
+const DareContractV2BaseSchema = z.strictObject({
   version: z.literal(DARE_CONTRACT_VERSION),
   canonicalScoutQl: z.string().min(1).max(DARE_V2_MAX_QUERY_LENGTH),
   compiledPlan: DareCompiledPlanV2Schema,
-  compilerVersion: DareScoutQlCompilerVersionSchema,
   evaluatorVersion: DareEvaluatorV2VersionSchema,
   targets: z.array(DareTargetBindingV2Schema).min(1).max(DARE_V2_MAX_TARGETS),
   openingStake: BucksStakeSchema,
@@ -455,4 +454,15 @@ export const DareContractV2Schema = z.strictObject({
   plainLanguage: z.string().min(1),
   semanticProofPlan: z.string().min(1),
 });
+
+export const DareContractV2Schema = z.discriminatedUnion("compilerVersion", [
+  DareContractV2BaseSchema.extend({
+    compilerVersion: z.literal("dare-scoutql-1"),
+  }),
+  DareContractV2BaseSchema.extend({
+    compilerVersion: z.literal("dare-scoutql-2"),
+    scoutQlImmutableAst: z.string().min(1),
+    scoutQlPlanHash: z.string().regex(/^[a-f\d]{64}$/),
+  }),
+]);
 export type DareContractV2 = z.infer<typeof DareContractV2Schema>;

--- a/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-contract-v2.ts
@@ -455,9 +455,12 @@ const DareContractV2BaseSchema = z.strictObject({
   semanticProofPlan: z.string().min(1),
 });
 
-export const DareContractV2Schema = z.discriminatedUnion("compilerVersion", [
+export const DareContractV2Schema = z.union([
   DareContractV2BaseSchema.extend({
     compilerVersion: z.literal("dare-scoutql-1"),
+  }),
+  DareContractV2BaseSchema.extend({
+    compilerVersion: z.literal("dare-scoutql-2"),
   }),
   DareContractV2BaseSchema.extend({
     compilerVersion: z.literal("dare-scoutql-2"),

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
@@ -70,6 +70,11 @@ rejected.
 This separation is deliberate. A contract must remain reproducible after a
 player rename, prompt change, or compiler upgrade, while an interactive report
 is allowed to resolve today's player aliases and render rows for exploration.
+Each saved revision records the compiler and evaluator versions. Compiler v2
+also stores the immutable DuckDB AST and its SHA-256 plan hash; activation copies
+those artifacts into the funded contract, and settlement records the same
+identity in evidence rows and the final proof. Compiler v1 contracts remain
+readable so funded work never depends on a rollout flag or migration rewrite.
 
 ## Clause order
 


### PR DESCRIPTION
Why

Funded Dare v2 contracts need a compiler artifact that can be re-evaluated and proven independently of future compiler changes.

What

- Persist the immutable relational ScoutQL AST and SHA-256 plan hash with every compiler-v2 draft revision.
- Copy those artifacts into funded contracts and bind evidence/proofs to compiler, evaluator, and plan identity.
- Preserve parser compatibility for compiler-v1 contracts and expose the frozen identity in Explore.
- Add the additive Prisma migration and contract/integration coverage.

Verification

- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/app --filter=@scout-for-lol/data --filter=@scout-for-lol/docs-site` (30/30 tasks passed)
- `bunx prisma validate --schema packages/scout-for-lol/packages/backend/prisma/schema.prisma`
- `git diff --check`
- Pre-commit formatting, suppression, line-ending, merge-marker, large-file, environment-name, and Gitleaks checks passed.

Live model evaluation and browser demonstration were not required for this persistence and proof layer.