### PR TITLE
fix(scout-for-lol): enforce Dare limits on semantic plans

### DIFF
--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-rules.mdx
@@ -127,7 +127,7 @@ the condition is unknown rather than false.
 | Targets                | 1–{DARE_V2_MAX_TARGETS}                                               |
 | Horizon                | at most {DARE_V2_MAX_HORIZON_DAYS} days                               |
 | Eligible games         | at most {DARE_V2_MAX_ELIGIBLE_GAMES}                                  |
-| Game sets / CTEs       | at most {DARE_V2_MAX_GAME_SETS}                                       |
+| Game sets              | at most {DARE_V2_MAX_GAME_SETS}                                       |
 | Joined relations       | at most {DARE_V2_MAX_JOINED_RELATIONS}                                |
 | Predicates             | at most {DARE_V2_MAX_PREDICATES}                                      |
 | Boolean depth          | at most {DARE_V2_MAX_EXPRESSION_DEPTH}                                |
@@ -139,6 +139,13 @@ when Scout can classify it reliably. A timeline condition is rejected for a
 queue whose timelines Scout cannot supply. Scout does not call Riot solely to
 backfill a dare: historical previews and settlement use retained lake data and
 future ingestion.
+
+The relational ScoutQL parser also caps an arbitrary query at 20 CTEs. A
+canonical Dare query may display compiler-generated candidate, eligibility, and
+bounded-set CTEs in addition to its game sets. Those supporting nodes do not
+increase the contract's semantic game-set, join, or predicate counts; the
+reverse compiler reconstructs and validates those limits before accepting the
+query.
 
 ## Weekly parlays
 

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
@@ -50,6 +50,14 @@ never runs the submitted query. Only a canonical query that round-trips to the
 same immutable AST is accepted. The ordinary report editor does not accept this
 relational profile; inspect and revise contracts through Explore.
 
+An arbitrary relational query is limited to 20 CTEs, 8 joined relations, 60
+predicates, and expression depth 12. Canonical Dare text contains mechanical
+candidate, eligibility, and bounded-set CTEs and joins. The compiler allows
+that exact physical envelope only long enough to reverse-compile it, then
+enforces the same limits on the reconstructed semantic plan and requires an
+immutable-AST round trip. Renaming the supporting structure or using the wider
+envelope for another SQL shape is rejected.
+
 The contract profile keeps participant columns qualified (`p0.kills`) and uses
 a small closed set of Dare functions for semantics that must round-trip without
 ambiguity:

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/scoutql.mdx
@@ -54,9 +54,10 @@ An arbitrary relational query is limited to 20 CTEs, 8 joined relations, 60
 predicates, and expression depth 12. Canonical Dare text contains mechanical
 candidate, eligibility, and bounded-set CTEs and joins. The compiler allows
 that exact physical envelope only long enough to reverse-compile it, then
-enforces the same limits on the reconstructed semantic plan and requires an
-immutable-AST round trip. Renaming the supporting structure or using the wider
-envelope for another SQL shape is rejected.
+requires an immutable-AST round trip and enforces the semantic limits: at most
+20 game sets, 8 joined relations within each game set, 60 predicates across the
+contract, and expression depth 12. Renaming the supporting structure or using
+the wider envelope for another SQL shape is rejected.
 
 The contract profile keeps participant columns qualified (`p0.kills`) and uses
 a small closed set of Dare functions for semantics that must round-trip without


### PR DESCRIPTION
Why

Canonical Dare ScoutQL renders compiler-only candidate, eligibility, and bounded-set structure. Charging those nodes against user contract limits made valid plans fail before the advertised twenty-game-set ceiling.

What

- Keep arbitrary relational ScoutQL on the strict physical limits.
- Admit the bounded canonical compiler envelope only inside the reverse compiler.
- Continue requiring semantic validation and an exact immutable-AST round trip before a query becomes a contract.
- Add boundary coverage for twenty semantic game sets and twenty arbitrary CTEs.
- Clarify the semantic/physical distinction in the public rules and ScoutQL reference.

Verification

- `bun run test -- src/reports/duckdb/relational-scoutql.test.ts src/betting/dare-scoutql-plan-compiler-v2.test.ts` (15 tests passed)
- `bunx turbo run typecheck lint test --filter=@scout-for-lol/backend --filter=@scout-for-lol/docs-site` (backend 317 files / 2,944 tests; the first lint pass identified the source-file split subsequently fixed)
- `bunx turbo run lint --filter=@scout-for-lol/backend --filter=@scout-for-lol/docs-site` (18/18 tasks passed; architecture 977 modules clean)
- backend TypeScript typecheck passed
- `git diff --check`
- Pre-commit formatting, suppression, line-ending, merge-marker, large-file, environment-name, and Gitleaks checks passed.