### PR TITLE
Keep funded Dare v2 recovery outside rollout gates

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  abandonExpiredDareProposals: vi.fn(async () => []),
+  activatePendingParlayMarkets: vi.fn(() => Promise.resolve()),
+  announceSettlements: vi.fn(() => Promise.resolve()),
+  checkActiveGames: vi.fn(() => Promise.resolve()),
+  checkMatchHistory: vi.fn(() => Promise.resolve()),
+  closeExpiredBettingWindows: vi.fn(async () => []),
+  closeExpiredParlayWindows: vi.fn(async () => []),
+  deliverDareSummaries: vi.fn(() => Promise.resolve()),
+  expireDareAcceptWindows: vi.fn(async () => []),
+  expireDareV2AcceptWindows: vi.fn(async () => [17]),
+  getPostmatchMessageIds: vi.fn(async () => new Map<string, string>()),
+  refreshClosedBucksMessages: vi.fn(() => Promise.resolve()),
+  refreshClosedParlayMessages: vi.fn(() => Promise.resolve()),
+  refreshDareV2Callouts: vi.fn(() => Promise.resolve()),
+  retryPendingBucksEarnings: vi.fn(() => Promise.resolve()),
+  settleEndedDareV2Windows: vi.fn(async () => []),
+  settleEndedDareWindows: vi.fn(async () => []),
+  voidStaleBettingPools: vi.fn(async () => ({
+    closures: [],
+    settlements: [],
+  })),
+  voidStaleParlayMarkets: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("#src/league/tasks/prematch/active-game-detection.ts", () => ({
+  checkActiveGames: mocks.checkActiveGames,
+}));
+vi.mock("#src/league/tasks/postmatch/match-history-polling.ts", () => ({
+  checkMatchHistory: mocks.checkMatchHistory,
+}));
+vi.mock("#src/betting/dare-sweep.ts", () => ({
+  abandonExpiredDareProposals: mocks.abandonExpiredDareProposals,
+  expireDareAcceptWindows: mocks.expireDareAcceptWindows,
+  settleEndedDareWindows: mocks.settleEndedDareWindows,
+}));
+vi.mock("#src/betting/dare-delivery.ts", () => ({
+  deliverDareSummaries: mocks.deliverDareSummaries,
+}));
+vi.mock("#src/betting/dare-sweep-v2.ts", () => ({
+  expireDareV2AcceptWindows: mocks.expireDareV2AcceptWindows,
+  settleEndedDareV2Windows: mocks.settleEndedDareV2Windows,
+}));
+vi.mock("#src/betting/dare-callout-v2.ts", () => ({
+  refreshDareV2Callouts: mocks.refreshDareV2Callouts,
+}));
+vi.mock("#src/betting/sweep.ts", () => ({
+  closeExpiredBettingWindows: mocks.closeExpiredBettingWindows,
+}));
+vi.mock("#src/betting/parlay-sweep.ts", () => ({
+  closeExpiredParlayWindows: mocks.closeExpiredParlayWindows,
+  voidStaleParlayMarkets: mocks.voidStaleParlayMarkets,
+}));
+vi.mock("#src/betting/parlay-publish.ts", () => ({
+  activatePendingParlayMarkets: mocks.activatePendingParlayMarkets,
+}));
+vi.mock("#src/betting/parlay-refresh.ts", () => ({
+  refreshClosedParlayMessages: mocks.refreshClosedParlayMessages,
+}));
+vi.mock("#src/betting/message-refresh.ts", () => ({
+  refreshClosedBucksMessages: mocks.refreshClosedBucksMessages,
+}));
+vi.mock("#src/betting/earnings-retry.ts", () => ({
+  retryPendingBucksEarnings: mocks.retryPendingBucksEarnings,
+}));
+vi.mock("#src/betting/announce.ts", () => ({
+  announceSettlements: mocks.announceSettlements,
+}));
+vi.mock("#src/betting/void-stale.ts", () => ({
+  voidStaleBettingPools: mocks.voidStaleBettingPools,
+}));
+vi.mock("#src/league/tasks/prematch/active-game-queries.ts", () => ({
+  getPostmatchMessageIdsForMatchIdOrEmpty: mocks.getPostmatchMessageIds,
+}));
+vi.mock("#src/configuration/flags.ts", () => ({
+  isFeatureHardDisabled: () => true,
+}));
+vi.mock("#src/logger.ts", () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn() }),
+}));
+
+import { checkPostMatch } from "#src/league/tasks/postmatch/index.ts";
+import { checkPreMatch } from "#src/league/tasks/prematch/index.ts";
+
+describe("Dare v2 recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("expires funded acceptance windows while betting is hard-disabled", async () => {
+    await expect(checkPreMatch()).resolves.toEqual({ dareSummaries: [] });
+
+    expect(mocks.checkActiveGames).toHaveBeenCalledOnce();
+    expect(mocks.expireDareV2AcceptWindows).toHaveBeenCalledOnce();
+    expect(mocks.refreshDareV2Callouts).toHaveBeenCalledWith([17]);
+    expect(mocks.abandonExpiredDareProposals).not.toHaveBeenCalled();
+    expect(mocks.closeExpiredBettingWindows).not.toHaveBeenCalled();
+  });
+
+  test("settles funded contracts while betting is hard-disabled", async () => {
+    await expect(checkPostMatch()).resolves.toEqual({ dareSummaries: [] });
+
+    expect(mocks.checkMatchHistory).toHaveBeenCalledOnce();
+    expect(mocks.settleEndedDareV2Windows).toHaveBeenCalledOnce();
+    expect(mocks.refreshDareV2Callouts).toHaveBeenCalledWith([]);
+    expect(mocks.retryPendingBucksEarnings).not.toHaveBeenCalled();
+    expect(mocks.settleEndedDareWindows).not.toHaveBeenCalled();
+    expect(mocks.voidStaleBettingPools).not.toHaveBeenCalled();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
@@ -5,7 +5,9 @@ const mocks = vi.hoisted(() => ({
   activatePendingParlayMarkets: vi.fn(() => Promise.resolve()),
   announceSettlements: vi.fn(() => Promise.resolve()),
   checkActiveGames: vi.fn(() => Promise.resolve()),
-  checkMatchHistory: vi.fn(() => Promise.resolve()),
+  checkMatchHistory: vi.fn(() =>
+    Promise.resolve({ evidenceComplete: true, evidenceWatermark: undefined }),
+  ),
   closeExpiredBettingWindows: vi.fn(async () => []),
   closeExpiredParlayWindows: vi.fn(async () => []),
   deliverDareSummaries: vi.fn(() => Promise.resolve()),

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   getPostmatchMessageIds: vi.fn(async () => new Map<string, string>()),
   refreshClosedBucksMessages: vi.fn(() => Promise.resolve()),
   refreshClosedParlayMessages: vi.fn(() => Promise.resolve()),
-  refreshDareV2Callouts: vi.fn(() => Promise.resolve()),
+  refreshPendingDareV2Callouts: vi.fn(() => Promise.resolve([])),
   retryPendingBucksEarnings: vi.fn(() => Promise.resolve()),
   settleEndedDareV2Windows: vi.fn(async () => []),
   settleEndedDareWindows: vi.fn(async () => []),
@@ -44,7 +44,7 @@ vi.mock("#src/betting/dare-sweep-v2.ts", () => ({
   settleEndedDareV2Windows: mocks.settleEndedDareV2Windows,
 }));
 vi.mock("#src/betting/dare-callout-v2.ts", () => ({
-  refreshDareV2Callouts: mocks.refreshDareV2Callouts,
+  refreshPendingDareV2Callouts: mocks.refreshPendingDareV2Callouts,
 }));
 vi.mock("#src/betting/sweep.ts", () => ({
   closeExpiredBettingWindows: mocks.closeExpiredBettingWindows,
@@ -94,7 +94,7 @@ describe("Dare v2 recovery", () => {
 
     expect(mocks.checkActiveGames).toHaveBeenCalledOnce();
     expect(mocks.expireDareV2AcceptWindows).toHaveBeenCalledOnce();
-    expect(mocks.refreshDareV2Callouts).toHaveBeenCalledWith([17]);
+    expect(mocks.refreshPendingDareV2Callouts).toHaveBeenCalledOnce();
     expect(mocks.abandonExpiredDareProposals).not.toHaveBeenCalled();
     expect(mocks.closeExpiredBettingWindows).not.toHaveBeenCalled();
   });
@@ -104,7 +104,7 @@ describe("Dare v2 recovery", () => {
 
     expect(mocks.checkMatchHistory).toHaveBeenCalledOnce();
     expect(mocks.settleEndedDareV2Windows).toHaveBeenCalledOnce();
-    expect(mocks.refreshDareV2Callouts).toHaveBeenCalledWith([]);
+    expect(mocks.refreshPendingDareV2Callouts).toHaveBeenCalledOnce();
     expect(mocks.retryPendingBucksEarnings).not.toHaveBeenCalled();
     expect(mocks.settleEndedDareWindows).not.toHaveBeenCalled();
     expect(mocks.voidStaleBettingPools).not.toHaveBeenCalled();

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/index.ts
@@ -47,18 +47,7 @@ export async function checkPostMatch(): Promise<{
         error,
       );
     }
-    if (bettingHardDisabled) {
-      if (matchHistoryError !== undefined) {
-        throw asError(matchHistoryError, "Match history polling failed");
-      }
-      const executionTime = Date.now() - startTime;
-      logger.info(
-        `✅ Post-match check completed successfully in ${executionTime.toString()}ms`,
-      );
-      return { dareSummaries: [] };
-    }
-
-    let earningsRecoveryError: unknown;
+    let maintenanceError: unknown;
     let dareSummaries: DareSettlementSummary[] = [];
     try {
       ({ dareSummaries } = await runPostMatchMaintenance({
@@ -66,23 +55,20 @@ export async function checkPostMatch(): Promise<{
         dareEvidenceWatermark: evidenceWatermark,
       }));
     } catch (error) {
-      earningsRecoveryError = error;
+      maintenanceError = error;
     }
 
-    if (
-      matchHistoryError !== undefined &&
-      earningsRecoveryError !== undefined
-    ) {
+    if (matchHistoryError !== undefined && maintenanceError !== undefined) {
       throw new AggregateError(
-        [matchHistoryError, earningsRecoveryError],
+        [matchHistoryError, maintenanceError],
         "Post-match polling and Bryan Bucks recovery both failed",
       );
     }
     if (matchHistoryError !== undefined) {
       throw asError(matchHistoryError, "Match history polling failed");
     }
-    if (earningsRecoveryError !== undefined) {
-      throw asError(earningsRecoveryError, "Bryan Bucks recovery failed");
+    if (maintenanceError !== undefined) {
+      throw asError(maintenanceError, "Bryan Bucks recovery failed");
     }
 
     const executionTime = Date.now() - startTime;
@@ -106,22 +92,14 @@ export async function runPostMatchMaintenance(options?: {
 }): Promise<{
   dareSummaries: DareSettlementSummary[];
 }> {
-  if (isFeatureHardDisabled("betting_enabled")) {
-    return { dareSummaries: [] };
-  }
-
+  const bettingHardDisabled = isFeatureHardDisabled("betting_enabled");
   let dareSummaries: DareSettlementSummary[] = [];
   const settleDareV2Deadlines = options?.settleDareV2Deadlines ?? true;
-  // Isolated per step, then re-thrown: the dare window settle is LAST, and
-  // without isolation a persistently failing earnings retry or stale-pool
-  // announce would starve those refunds while the money stayed escrowed.
-  await runMaintenanceSteps("post-match maintenance", [
-    {
-      name: "pending earnings retry",
-      run: async () => {
-        await retryPendingBucksEarnings();
-      },
-    },
+  // Dare v2 recovery is never feature-gated. Once a contract is funded its
+  // settlement and refund paths must survive both rollout revocation and the
+  // broader Bryan Bucks hard-disable. Other betting maintenance remains
+  // behind the hard-disable policy.
+  const steps = [
     {
       name: "dare v2 deadline settle",
       run: async () => {
@@ -141,30 +119,43 @@ export async function runPostMatchMaintenance(options?: {
         }
       },
     },
-    { name: "stale betting pool void", run: voidStaleAndAnnounce },
-    {
-      name: "stale parlay market void",
-      run: async () => {
-        await voidStaleParlayMarkets();
+  ];
+  if (!bettingHardDisabled) {
+    steps.push(
+      {
+        name: "pending earnings retry",
+        run: async () => {
+          await retryPendingBucksEarnings();
+        },
       },
-    },
-    {
-      // Ended dare windows settle unachieved here, beside the other post-match
-      // clocks.
-      name: "dare window settle",
-      run: async () => {
-        dareSummaries = await settleEndedDareWindows();
+      { name: "stale betting pool void", run: voidStaleAndAnnounce },
+      {
+        name: "stale parlay market void",
+        run: async () => {
+          await voidStaleParlayMarkets();
+        },
       },
-    },
-    {
-      // Delivery runs after the refunds committed and swallows per-summary, so
-      // a dead channel never blocks or re-runs a settlement.
-      name: "dare summary delivery",
-      run: async () => {
-        await deliverDareSummaries(dareSummaries);
+      {
+        // Ended dare windows settle unachieved here, beside the other post-match
+        // clocks.
+        name: "dare window settle",
+        run: async () => {
+          dareSummaries = await settleEndedDareWindows();
+        },
       },
-    },
-  ]);
+      {
+        // Delivery runs after the refunds committed and swallows per-summary, so
+        // a dead channel never blocks or re-runs a settlement.
+        name: "dare summary delivery",
+        run: async () => {
+          await deliverDareSummaries(dareSummaries);
+        },
+      },
+    );
+  }
+  // Isolated per step, then re-thrown: a persistently failing recovery path
+  // cannot starve the remaining clocks while money stays escrowed.
+  await runMaintenanceSteps("post-match maintenance", steps);
   return { dareSummaries };
 }
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/prematch/index.ts
@@ -30,14 +30,20 @@ export async function checkPreMatch(): Promise<{
 
   try {
     // Every step runs even when an earlier one throws, and the collected
-    // failures are re-thrown at the end. The dare clocks are LAST, so without
-    // this a persistently failing Riot poll or parlay refresh would starve
-    // dare refunds indefinitely while the money stayed escrowed.
+    // failures are re-thrown at the end. Dare v2 recovery is outside every
+    // feature flag so a rollout revocation cannot strand funded contracts.
     const steps: MaintenanceStep[] = [
       {
         name: "active-game detection",
         run: async () => {
           await checkActiveGames();
+        },
+      },
+      {
+        name: "dare v2 accept-window expiry",
+        run: async () => {
+          await expireDareV2AcceptWindows();
+          await refreshPendingDareV2Callouts();
         },
       },
     ];
@@ -84,13 +90,6 @@ export async function checkPreMatch(): Promise<{
           name: "dare accept-window expiry",
           run: async () => {
             dareSummaries.push(...(await expireDareAcceptWindows()));
-          },
-        },
-        {
-          name: "dare v2 accept-window expiry",
-          run: async () => {
-            await expireDareV2AcceptWindows();
-            await refreshPendingDareV2Callouts();
           },
         },
         {


### PR DESCRIPTION
Why

Funded Dare v2 contracts must continue expiring acceptance windows and settling deadlines when rollout flags or the broader Bryan Bucks hard-disable are revoked. The scheduled callers previously skipped both recovery paths under `betting_enabled`, which could strand escrowed funds.

What

- run Dare v2 acceptance-window expiry in unconditional pre-match maintenance
- run Dare v2 deadline settlement in unconditional post-match recovery
- keep all unrelated betting maintenance behind the existing hard-disable
- add hard-disable regression coverage for both scheduler paths

Verification

- `bun run test -- src/league/tasks/dare-v2-recovery.test.ts`
- `bun run typecheck`
- `bunx eslint src/league/tasks/prematch/index.ts src/league/tasks/postmatch/index.ts src/league/tasks/dare-v2-recovery.test.ts`
- `bunx turbo run build typecheck test lint --filter=@scout-for-lol/backend`
- `bunx lefthook run pre-commit`

The Dare paraphrase model eval was not run because 1Password Desktop authorization timed out before the client initialized; no model request was sent.

Media: not applicable; this layer changes scheduled recovery behavior only.