### PR TITLE
Enforce active-only Temporal namespaces

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1238,7 +1238,7 @@
     },
     "packages/scout-for-lol/packages/backend/src/observability/tracing.ts|packages/temporal/src/observability/tracing.ts": {
       "clones": 3,
-      "tokens": 335
+      "tokens": 309
     },
     "packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts|packages/scout-for-lol/packages/backend/src/report-lake/report-lake.integration.test.ts": {
       "clones": 2,

--- a/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
+++ b/packages/docs/wiki/src/content/docs/explanation/temporal/overview.md
@@ -62,8 +62,9 @@ change.
 Every programmatic start and Schedule carries the same four Keyword Search
 Attributes: environment, domain, trigger, and the Git commit that initiated the
 execution. Temporal's built-in Schedule attributes remain authoritative for
-Schedule identity. This makes the UI and CLI useful across the shared
-`default` namespace without copying Schedule IDs into another attribute. The
+Schedule identity. This makes the UI and CLI useful within the
+environment-scoped `dev`, `beta`, and `prod` namespaces without copying
+Schedule IDs into another attribute. The
 [Search Attribute schema and domain derivation](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal/src/shared/execution-metadata.ts)
 live in one file; the
 [client interceptor](https://github.com/shepherdjerred/monorepo/blob/ad28b407ada3330924ba0248a7d50000f9c38178/packages/temporal/src/lib/execution-metadata-client-interceptor.ts)
@@ -102,18 +103,15 @@ implement this boundary.
 The gateway is a control process: it reconciles schedules and serves the public
 HTTP surfaces but does not poll a task queue or receive a Kubernetes token. A
 second credentialless process runs all deterministic central Workflow code.
-Every new start, schedule, and child goes to `monorepo-workflows`. Nine
+Every new central start, schedule, and child goes to `monorepo-workflows`. Nine
 Activity-only roles own `home`, `reports`, `infra`,
 `repo-automation`, `scout`, `agent-task`, `glitter-corpus`, `glitter-context`,
 and `maintenance`.
 
 Temporal executions cannot move to another Workflow task queue after they
-start. The Workflow-only process therefore polls `monorepo-workflows` plus the
-remaining legacy central queues until live visibility shows that each old queue
-has zero open executions. Continue-as-new inherits the current queue, so new
-chains stay on `monorepo-workflows`; pre-retirement default histories are no
-longer supported. A replay test generated a real history before Activity queues
-were explicit and verifies it against the new routing on every change.
+start. Continue-as-new inherits the current queue, so central chains remain on
+`monorepo-workflows`. Replay tests verify retained histories against candidate
+Workflow bundles before routing changes.
 
 The split is about authorization and failure isolation, not capacity. Queues
 isolate concurrency; **processes** isolate runtime failures, credentials, and

--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-scout-temporal.md
@@ -28,11 +28,11 @@ promoting changed Workflow code:
 
 ```bash
 cd packages/scout-for-lol/packages/temporal
-TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
+TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true TEMPORAL_NAMESPACE=beta \
   bun run replay:histories <scout-workflow-id>...
 
 cd packages/temporal
-TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true \
+TEMPORAL_ADDRESS=<beta-address> TEMPORAL_TLS=true TEMPORAL_NAMESPACE=beta \
   bun run replay:scout-histories <weekly-or-bryan-workflow-id>...
 ```
 
@@ -48,7 +48,7 @@ cd packages/scout-for-lol/packages/temporal
 bun run canary -- \
   --stage beta \
   --address <beta-address> \
-  --namespace default
+  --namespace beta
 ```
 
 The result must name `scout-beta-realtime`, `scout-beta-interactive`,

--- a/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
+++ b/packages/docs/wiki/src/content/docs/reference/temporal-workflows.md
@@ -61,7 +61,7 @@ Bootstrap configuration:
 
 | Name                              | Contract                                   |
 | --------------------------------- | ------------------------------------------ |
-| `TEMPORAL_NAMESPACE`              | non-empty; currently `default`             |
+| `TEMPORAL_NAMESPACE`              | required `dev`, `beta`, or `prod`          |
 | `TEMPORAL_WORKER_DEPLOYMENT_NAME` | paired with Build ID; central value above  |
 | `TEMPORAL_WORKER_BUILD_ID`        | exact lowercase 40-character image Git SHA |
 

--- a/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
+++ b/packages/homelab/src/cdk8s/grafana/temporal-platform-panels.ts
@@ -113,7 +113,7 @@ export function temporalDashboardLinks() {
     {
       title: "Temporal UI",
       type: "link",
-      url: "https://temporal-ui.tailnet-1a49.ts.net/namespaces/default/workflows",
+      url: "https://temporal-ui.tailnet-1a49.ts.net/namespaces/prod/workflows",
       targetBlank: true,
       keepTime: true,
     },
@@ -196,7 +196,7 @@ export function createTemporalPlatformPanels() {
         "Workflow Task execution failures by queue, type, and reason. Nondeterminism is a rollout stop condition.",
       targets: [
         {
-          expr: 'sum by (task_queue, workflow_type, failure_reason) (increase(temporal_worker_workflow_task_execution_failed{exported_namespace="default"}[10m])) or on() vector(0)',
+          expr: 'sum by (exported_namespace, task_queue, workflow_type, failure_reason) (increase(temporal_worker_workflow_task_execution_failed{exported_namespace=~"prod|beta"}[10m])) or on() vector(0)',
           legend: "{{task_queue}} {{workflow_type}} {{failure_reason}}",
         },
       ],
@@ -214,7 +214,7 @@ export function createTemporalPlatformPanels() {
         {
           // activity_task_fail, not activity_fail — see
           // TemporalActivityRetriesExhausted in temporal-platform-health.ts.
-          expr: 'sum by (taskqueue, workflowType, activityType) (increase(activity_task_fail{namespace="default"}[15m])) or on() vector(0)',
+          expr: 'sum by (exported_namespace, taskqueue, workflowType, activityType) (increase(activity_task_fail{exported_namespace=~"prod|beta"}[15m])) or on() vector(0)',
           legend: "{{taskqueue}} {{workflowType}} {{activityType}}",
         },
       ],

--- a/packages/scout-for-lol/packages/backend/src/configuration.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration.ts
@@ -3,10 +3,7 @@ import env from "env-var";
 import { z } from "zod";
 import { createLogger } from "#src/logger.ts";
 import { TournamentApiModeSchema } from "#src/configuration/tournament-mode.ts";
-import {
-  ScoutStageSchema,
-  TemporalLegacyNamespaceSchema,
-} from "@scout-for-lol/temporal";
+import { ScoutStageSchema } from "@scout-for-lol/temporal";
 
 const logger = createLogger("config");
 
@@ -191,9 +188,6 @@ function computeConfiguration() {
     temporalAddress: getOptionalEnvVar("TEMPORAL_ADDRESS"),
     temporalNamespace,
     temporalScheduleReconciliation,
-    temporalLegacyNamespace: TemporalLegacyNamespaceSchema.optional().parse(
-      getOptionalEnvVar("TEMPORAL_LEGACY_NAMESPACE"),
-    ),
     discordToken: getRequiredEnvVar("DISCORD_TOKEN"),
     applicationId: getRequiredEnvVar("APPLICATION_ID"),
     discordClientSecret: getOptionalEnvVar("DISCORD_CLIENT_SECRET"),
@@ -333,9 +327,6 @@ const configuration: Configuration = {
       );
     }
     return current.temporalNamespace;
-  },
-  get temporalLegacyNamespace() {
-    return getConfiguration().temporalLegacyNamespace;
   },
   get temporalScheduleReconciliation() {
     return getConfiguration().temporalScheduleReconciliation;

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/competition/temporal-worker.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/competition/temporal-worker.ts
@@ -49,25 +49,15 @@ export async function startScoutCompetitionActivityWorker(): Promise<
 
   const taskQueue = scoutCompetitionTaskQueue(configuration.environment);
   const connection = await NativeConnection.connect({ address });
-  const namespaces =
-    configuration.temporalLegacyNamespace === undefined
-      ? [configuration.temporalNamespace]
-      : [
-          configuration.temporalNamespace,
-          configuration.temporalLegacyNamespace,
-        ];
-  const workers = await Promise.all(
-    namespaces.map(
-      async (namespace) =>
-        await Worker.create({
-          connection,
-          namespace,
-          taskQueue,
-          activities: { runScheduledCompetitionUpdates },
-          maxConcurrentActivityTaskExecutions: 1,
-        }),
-    ),
-  );
+  const workers = [
+    await Worker.create({
+      connection,
+      namespace: configuration.temporalNamespace,
+      taskQueue,
+      activities: { runScheduledCompetitionUpdates },
+      maxConcurrentActivityTaskExecutions: 1,
+    }),
+  ];
 
   const lifecycle = { shutdownStarted: false };
   let runFailure: Error | undefined;

--- a/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
+++ b/packages/scout-for-lol/packages/backend/src/observability/tracing.ts
@@ -14,6 +14,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import { buildArchiveSpanProcessor } from "@shepherdjerred/llm-observability";
 import {
+  buildTracingInitializationFields,
   buildTracingResource,
   LoggingSpanExporter,
   type TracingResourceOptions,
@@ -123,16 +124,17 @@ export function initializeTracing(
   sdk.start();
   tracer = trace.getTracer(serviceName);
 
-  jsonLog("info", "OpenTelemetry tracing initialized", {
-    serviceName,
-    serviceVersion,
-    otlpEndpoint,
-    environment: options.environment ?? "dev",
-    domain: options.domain ?? "scout",
-    namespace: options.namespace ?? "default",
-    taskQueue: options.taskQueue ?? "unknown",
-    workerRole: options.workerRole ?? "unknown",
-  });
+  jsonLog(
+    "info",
+    "OpenTelemetry tracing initialized",
+    buildTracingInitializationFields({
+      defaultDomain: "scout",
+      otlpEndpoint,
+      resource: options,
+      serviceName,
+      serviceVersion,
+    }),
+  );
   tracingRuntime = { processor: rootProcessor, resource };
   return tracingRuntime;
 }

--- a/packages/scout-for-lol/packages/backend/src/startup.ts
+++ b/packages/scout-for-lol/packages/backend/src/startup.ts
@@ -72,7 +72,6 @@ export async function startBackendRuntime(): Promise<
       temporalSupervisor = startScoutTemporalSupervisor({
         address: configuration.temporalAddress,
         namespace: configuration.temporalNamespace,
-        legacyNamespace: configuration.temporalLegacyNamespace,
         stage: configuration.environment,
         activities: createScoutTemporalActivityGroups(),
         callGraphTracing: temporalCallGraphTracing(),

--- a/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/activities.ts
@@ -1,6 +1,5 @@
 import { Context } from "@temporalio/activity";
 import { ApplicationFailure } from "@temporalio/common";
-import { Client, Connection } from "@temporalio/client";
 import { client } from "#src/discord/client.ts";
 import configuration from "#src/configuration.ts";
 import type { ScoutTemporalActivityGroups } from "./connected-runtime.ts";
@@ -19,36 +18,9 @@ type DetachedWorkInput = Parameters<
   ScoutTemporalActivityGroups["background"]["runDetachedBackgroundWork"]
 >[0];
 
-async function scheduleReconciliationEnabled(): Promise<boolean> {
-  const activityNamespace = Context.current().info.namespace;
-  if (activityNamespace === "default") return false;
-
+function scheduleReconciliationEnabled(): boolean {
   const mode = configuration.temporalScheduleReconciliation;
-  if (mode === "enabled") return true;
-  if (mode === "disabled") return false;
-
-  const legacyNamespace = configuration.temporalLegacyNamespace;
-  if (legacyNamespace === undefined) return true;
-
-  const connection =
-    configuration.temporalAddress === undefined
-      ? await Connection.connect()
-      : await Connection.connect({ address: configuration.temporalAddress });
-  try {
-    const legacyClient = new Client({
-      connection,
-      namespace: legacyNamespace,
-    });
-    for await (const schedule of legacyClient.schedule.list()) {
-      const description = await legacyClient.schedule
-        .getHandle(schedule.scheduleId)
-        .describe();
-      if (!description.state.paused) return false;
-    }
-    return true;
-  } finally {
-    await connection.close();
-  }
+  return mode !== "disabled";
 }
 
 export function providerQuotaApplicationFailure(
@@ -380,14 +352,10 @@ function createBackgroundActivities(): ScoutTemporalActivityGroups["background"]
       };
     },
     drainReportScheduleOutbox: async (input) => {
-      const activityNamespace = Context.current().info.namespace;
-      if (!(await scheduleReconciliationEnabled())) {
+      if (!scheduleReconciliationEnabled()) {
         Context.current().heartbeat({
           phase: "skipped",
-          reason:
-            activityNamespace === "default"
-              ? "legacy-namespace-drain"
-              : "schedule-reconciliation-disabled",
+          reason: "schedule-reconciliation-disabled",
         });
         return { processed: 0, remaining: 0 };
       }

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
@@ -6,10 +6,7 @@ import {
   Runtime,
   Worker,
 } from "@temporalio/worker";
-import type {
-  ScoutStage,
-  TemporalLegacyNamespace,
-} from "@scout-for-lol/temporal";
+import type { ScoutStage } from "@scout-for-lol/temporal";
 import { scoutTaskQueues } from "@scout-for-lol/temporal";
 import type { ScoutTemporalActivities } from "@scout-for-lol/temporal/activities";
 import { createLogger } from "#src/logger.ts";
@@ -146,7 +143,6 @@ export type ScoutTemporalActivityGroups = {
 export type ScoutTemporalSupervisorOptions = {
   readonly address: string | undefined;
   readonly namespace: ScoutStage;
-  readonly legacyNamespace: TemporalLegacyNamespace | undefined;
   readonly stage: ScoutStage;
   readonly activities: ScoutTemporalActivityGroups;
   readonly callGraphTracing: boolean;
@@ -286,66 +282,6 @@ export async function createConnectedRuntime(
           maxConcurrentActivityTaskExecutions: 1,
         }),
       );
-    }
-    if (options.legacyNamespace !== undefined) {
-      const legacyOptions = {
-        ...commonOptions,
-        namespace: options.legacyNamespace,
-      };
-      // The legacy pollers exist only to let pre-cutover histories in the
-      // retired namespace finish. They are best-effort: a drain worker that
-      // cannot be created must not take the live namespace's workers down
-      // with it, which is what turned one failure here into a permanent
-      // reconnect loop that left Scout with no pollers at all.
-      try {
-        workers.push(
-          await Worker.create({
-            ...legacyOptions,
-            taskQueue: queues.workflow,
-            workflowsPath: workflowsPath(),
-            maxConcurrentWorkflowTaskExecutions: 1,
-          }),
-        );
-        workers.push(
-          await Worker.create({
-            ...legacyOptions,
-            taskQueue: queues.interactive,
-            activities: options.activities.interactive,
-            maxConcurrentActivityTaskExecutions: 1,
-          }),
-        );
-        workers.push(
-          await Worker.create({
-            ...legacyOptions,
-            taskQueue: queues.lake,
-            activities: options.activities.lake,
-            maxConcurrentActivityTaskExecutions: 1,
-          }),
-        );
-        if (discordWorkersEnabled) {
-          workers.push(
-            await Worker.create({
-              ...legacyOptions,
-              taskQueue: queues.realtime,
-              activities: options.activities.realtime,
-              maxConcurrentActivityTaskExecutions: 1,
-            }),
-          );
-          workers.push(
-            await Worker.create({
-              ...legacyOptions,
-              taskQueue: queues.background,
-              activities: options.activities.background,
-              maxConcurrentActivityTaskExecutions: 1,
-            }),
-          );
-        }
-      } catch (error: unknown) {
-        logger.warn("Legacy Temporal drain workers unavailable; continuing", {
-          namespace: options.legacyNamespace,
-          error,
-        });
-      }
     }
     return {
       workers,

--- a/packages/scout-for-lol/packages/backend/src/temporal/supervisor.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/supervisor.ts
@@ -145,7 +145,6 @@ export class ScoutTemporalSupervisor {
     logger.info("Temporal workers connected", {
       address: this.#options.address,
       namespace: this.#options.namespace,
-      legacyNamespace: this.#options.legacyNamespace,
       stage: this.#options.stage,
       workerCount: runtime.workers.length,
       discordWorkersEnabled: this.#discordWorkersEnabled,
@@ -172,7 +171,6 @@ export class ScoutTemporalSupervisor {
         attempt: this.#attempt,
         consecutiveFailures: this.#consecutiveFailures,
         namespace: this.#options.namespace,
-        legacyNamespace: this.#options.legacyNamespace,
       },
     });
     setScoutTemporalHealth({

--- a/packages/scout-for-lol/packages/backend/src/temporal/workflow-worker-config.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/workflow-worker-config.test.ts
@@ -10,13 +10,14 @@ describe("parseScoutWorkflowWorkerConfiguration", () => {
         ENVIRONMENT: "beta",
         GIT_SHA: SHA,
         TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_NAMESPACE: "beta",
         TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-beta-workflows",
       }),
     ).toEqual({
       stage: "beta",
       address: "temporal:7233",
       metricsAddress: "0.0.0.0:9464",
-      namespace: "default",
+      namespace: "beta",
       deploymentName: "scout-beta-workflows",
       buildId: SHA,
     });
@@ -28,6 +29,7 @@ describe("parseScoutWorkflowWorkerConfiguration", () => {
         ENVIRONMENT: "prod",
         GIT_SHA: SHA,
         TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_NAMESPACE: "prod",
         TEMPORAL_WORKER_BUILD_ID: SHA,
         TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-prod-workflows",
       }).buildId,
@@ -40,6 +42,7 @@ describe("parseScoutWorkflowWorkerConfiguration", () => {
         ENVIRONMENT: "prod",
         GIT_SHA: SHA,
         TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_NAMESPACE: "prod",
         TEMPORAL_WORKER_BUILD_ID: "b".repeat(40),
         TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-prod-workflows",
       }),
@@ -52,9 +55,33 @@ describe("parseScoutWorkflowWorkerConfiguration", () => {
         ENVIRONMENT: "beta",
         GIT_SHA: SHA,
         TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_NAMESPACE: "beta",
         TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-prod-workflows",
       }),
     ).toThrow("must use deployment scout-beta-workflows");
+  });
+
+  test("rejects a namespace that does not match the stage", () => {
+    expect(() =>
+      parseScoutWorkflowWorkerConfiguration({
+        ENVIRONMENT: "beta",
+        GIT_SHA: SHA,
+        TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_NAMESPACE: "prod",
+        TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-beta-workflows",
+      }),
+    ).toThrow("must match ENVIRONMENT");
+  });
+
+  test("requires an explicit namespace", () => {
+    expect(() =>
+      parseScoutWorkflowWorkerConfiguration({
+        ENVIRONMENT: "beta",
+        GIT_SHA: SHA,
+        TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-beta-workflows",
+      }),
+    ).toThrow();
   });
 
   test("rejects a non-exact image Git SHA", () => {
@@ -63,6 +90,7 @@ describe("parseScoutWorkflowWorkerConfiguration", () => {
         ENVIRONMENT: "beta",
         GIT_SHA: "unknown",
         TEMPORAL_ADDRESS: "temporal:7233",
+        TEMPORAL_NAMESPACE: "beta",
         TEMPORAL_WORKER_DEPLOYMENT_NAME: "scout-beta-workflows",
       }),
     ).toThrow("exact lowercase Git SHA");

--- a/packages/scout-for-lol/packages/backend/src/temporal/workflow-worker-config.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/workflow-worker-config.ts
@@ -10,7 +10,7 @@ const WorkflowWorkerEnvironmentSchema = z
     GIT_SHA: WorkerBuildIdSchema,
     TEMPORAL_ADDRESS: z.string().min(1),
     TEMPORAL_METRICS_ADDRESS: z.string().min(1).default("0.0.0.0:9464"),
-    TEMPORAL_NAMESPACE: z.string().min(1).default("default"),
+    TEMPORAL_NAMESPACE: z.enum(["beta", "prod"]),
     TEMPORAL_WORKER_BUILD_ID: WorkerBuildIdSchema.optional(),
     TEMPORAL_WORKER_DEPLOYMENT_NAME: z.string().min(1),
   })
@@ -25,13 +25,20 @@ const WorkflowWorkerEnvironmentSchema = z
         message: "must match the baked GIT_SHA",
       });
     }
+    if (environment.TEMPORAL_NAMESPACE !== environment.ENVIRONMENT) {
+      context.addIssue({
+        code: "custom",
+        path: ["TEMPORAL_NAMESPACE"],
+        message: "must match ENVIRONMENT",
+      });
+    }
   });
 
 export type ScoutWorkflowWorkerConfiguration = {
   stage: "beta" | "prod";
   address: string;
   metricsAddress: string;
-  namespace: string;
+  namespace: "beta" | "prod";
   deploymentName: string;
   buildId: string;
 };

--- a/packages/scout-for-lol/packages/temporal/src/contracts.ts
+++ b/packages/scout-for-lol/packages/temporal/src/contracts.ts
@@ -6,11 +6,6 @@ export type TemporalNamespace = z.infer<typeof TemporalNamespaceSchema>;
 export const ScoutStageSchema = TemporalNamespaceSchema;
 export type ScoutStage = TemporalNamespace;
 
-export const TemporalLegacyNamespaceSchema = z.literal("default");
-export type TemporalLegacyNamespace = z.infer<
-  typeof TemporalLegacyNamespaceSchema
->;
-
 export const DETACHED_WORK_MAX_ATTEMPTS = 4;
 
 const OpaqueIdentifierSchema = z

--- a/packages/scout-for-lol/packages/temporal/src/index.ts
+++ b/packages/scout-for-lol/packages/temporal/src/index.ts
@@ -22,7 +22,6 @@ export {
   ScoutReportScheduleReconcilerInputSchema,
   ScoutScheduleOwnershipMemoSchema,
   ScoutStageSchema,
-  TemporalLegacyNamespaceSchema,
   TemporalNamespaceSchema,
   ScoutWorkflowStatusSchema,
 } from "./contracts.ts";
@@ -49,7 +48,6 @@ export type {
   ScoutReportScheduleReconcilerInput,
   ScoutScheduleOwnershipMemo,
   ScoutStage,
-  TemporalLegacyNamespace,
   TemporalNamespace,
   ScoutWorkflowStatus,
 } from "./contracts.ts";

--- a/packages/temporal-observability/src/tracing-resource.ts
+++ b/packages/temporal-observability/src/tracing-resource.ts
@@ -34,6 +34,35 @@ export type TracingResourceOptions = {
   readonly workerRole?: string;
 };
 
+export type TracingInitializationFieldsOptions = {
+  readonly serviceName: string;
+  readonly serviceVersion: string;
+  readonly otlpEndpoint: string;
+  readonly defaultDomain: string;
+  readonly resource: TracingResourceOptions;
+};
+
+export function buildTracingInitializationFields({
+  serviceName,
+  serviceVersion,
+  otlpEndpoint,
+  defaultDomain,
+  resource,
+}: TracingInitializationFieldsOptions): Record<string, unknown> {
+  return {
+    serviceName,
+    serviceVersion,
+    otlpEndpoint,
+    environment: resource.environment ?? "dev",
+    domain: resource.domain ?? defaultDomain,
+    ...(resource.namespace === undefined
+      ? {}
+      : { namespace: resource.namespace }),
+    taskQueue: resource.taskQueue ?? "unknown",
+    workerRole: resource.workerRole ?? "unknown",
+  };
+}
+
 /**
  * `defaultDomain` is caller-specific (packages/temporal's shared
  * central-workflows process falls back to "platform"; Scout backend falls
@@ -51,7 +80,9 @@ export function buildTracingResource(
     [ATTR_SERVICE_VERSION]: serviceVersion,
     "deployment.environment.name": options.environment ?? "dev",
     "temporal.domain": options.domain ?? defaultDomain,
-    "temporal.namespace": options.namespace ?? "default",
+    ...(options.namespace === undefined
+      ? {}
+      : { "temporal.namespace": options.namespace }),
     "temporal.task_queue": options.taskQueue ?? "unknown",
     "temporal.worker.role": options.workerRole ?? "unknown",
   });

--- a/packages/temporal-observability/test/tracing-resource.test.ts
+++ b/packages/temporal-observability/test/tracing-resource.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildTracingInitializationFields,
+  buildTracingResource,
+} from "@shepherdjerred/temporal-observability/tracing-resource";
+
+describe("buildTracingResource", () => {
+  test("records an explicit Temporal namespace", () => {
+    const resource = buildTracingResource("worker", "sha", "platform", {
+      namespace: "prod",
+    });
+
+    expect(resource.attributes["temporal.namespace"]).toBe("prod");
+  });
+
+  test("omits the namespace for non-Temporal processes", () => {
+    const resource = buildTracingResource("service", "sha", "platform", {});
+
+    expect(resource.attributes).not.toHaveProperty("temporal.namespace");
+  });
+});
+
+describe("buildTracingInitializationFields", () => {
+  test("records an explicit Temporal namespace", () => {
+    const fields = buildTracingInitializationFields({
+      defaultDomain: "platform",
+      otlpEndpoint: "http://tempo",
+      resource: { namespace: "prod" },
+      serviceName: "worker",
+      serviceVersion: "sha",
+    });
+
+    expect(fields["namespace"]).toBe("prod");
+  });
+
+  test("omits the namespace for non-Temporal processes", () => {
+    const fields = buildTracingInitializationFields({
+      defaultDomain: "scout",
+      otlpEndpoint: "http://tempo",
+      resource: {},
+      serviceName: "backend",
+      serviceVersion: "sha",
+    });
+
+    expect(fields).not.toHaveProperty("namespace");
+  });
+});

--- a/packages/temporal-observability/test/workflow-span-sink.test.ts
+++ b/packages/temporal-observability/test/workflow-span-sink.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@shepherdjerred/temporal-observability/workflow-span-sink";
 
 const WORKFLOW_INFO = {
-  namespace: "default",
+  namespace: "prod",
   taskQueue: "monorepo-workflows",
   workflowId: "workflow-1",
   runId: "run-1",
@@ -64,7 +64,7 @@ describe("createValidatedWorkflowSpanSink", () => {
     expect(exported[0]?.parentSpanContext?.spanId).toBe("fedcba9876543210");
     expect(exported[0]?.attributes).toMatchObject({
       existing: "value",
-      "temporal.namespace": "default",
+      "temporal.namespace": "prod",
       "temporal.task_queue": "monorepo-workflows",
       "temporal.workflow_id": "workflow-1",
     });

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -20,8 +20,8 @@ Production uses the same Bun image in twelve single-replica Kubernetes
 Deployments selected by `TEMPORAL_WORKER_ROLE`. `control` owns schedule
 reconciliation and public HTTP/event surfaces without a task queue. The
 credentialless `workflows` role runs as stable and candidate Deployments on
-`monorepo-workflows` and keeps temporary pollers on every legacy central queue.
-Both use the Temporal Worker Deployment `monorepo-central-workflows`, exact
+`monorepo-workflows`. Both use the Temporal Worker Deployment
+`monorepo-central-workflows`, exact
 image Git SHA Build IDs, and default `AUTO_UPGRADE` behavior. The stable and
 candidate catalog pins must remain distinct: CI advances candidate only while
 the two pins are equal, retaining the deployed candidate throughout a rollout.
@@ -31,17 +31,16 @@ to copy stable back to candidate before the next CI image release may advance
 it; review and commit both the catalog and pin-state changes through the normal
 PR flow.
 Domain roles are Activity-only and own their registries in the typed contract
-in `src/worker-config.ts`. The default `all` role preserves the single-process local development
-behavior. Keep new queue ownership and capabilities in that contract so a
+in `src/worker-config.ts`. The explicit local `all` role preserves the
+single-process development behavior. Keep new queue ownership and capabilities in that contract so a
 provider subprocess, heavy Glitter failure, or maintenance subprocess cannot
 take down another domain or inherit its Kubernetes permissions.
 
 Every new central start, schedule, and child must target
 `TASK_QUEUES.WORKFLOWS`. Every Activity proxy must name the domain queue that
 owns the effect and must never use the Workflow queue. Continue-as-new inherits
-the current Workflow task queue; this keeps new chains on `monorepo-workflows`
-and lets remaining pre-cutover chains finish on their original queue. The
-pre-retirement default queue is no longer supported.
+the current Workflow task queue, which keeps central chains on
+`monorepo-workflows`.
 
 The bootstrap contract is `TEMPORAL_NAMESPACE` plus the paired
 `TEMPORAL_WORKER_DEPLOYMENT_NAME` and `TEMPORAL_WORKER_BUILD_ID`. The Build ID
@@ -185,7 +184,7 @@ stays at 0 and is indistinguishable from a clean "no orphans" result.
 ## Commands
 
 ```bash
-bun run start        # Start worker (connects to Temporal server)
+TEMPORAL_NAMESPACE=dev TEMPORAL_WORKER_ROLE=all bun run start # Start local worker
 bun run typecheck    # Type check (runs ensure-ha-schema first)
 bun run lint         # ESLint
 bun run test         # Run tests (incl. workflow-bundle smoke test)
@@ -238,7 +237,8 @@ Workflow:
 ## Environment Variables
 
 - `TEMPORAL_ADDRESS` — Temporal server gRPC address (default: `temporal-server.temporal.svc.cluster.local:7233`)
-- `TEMPORAL_WORKER_ROLE` — process role: `all` (default/local), `control`, `workflows`, `agent`, `backup`, `glitter`, `glitter-context`, `glitter-corpus`, `home`, `infra`, `maintenance`, `repo`, `reports`, or `scout`. Invalid values fail startup.
+- `TEMPORAL_NAMESPACE` — required active namespace: `dev`, `beta`, or `prod`.
+- `TEMPORAL_WORKER_ROLE` — required process role: `all` (local only), `control`, `workflows`, `agent`, `backup`, `glitter`, `glitter-context`, `glitter-corpus`, `home`, `infra`, `maintenance`, `repo`, `reports`, or `scout`. Missing and invalid values fail startup.
 - `HA_URL` — Home Assistant URL
 - `HA_TOKEN` — Home Assistant long-lived access token
 - `GOLINK_URL` — Golink service URL

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -10,21 +10,16 @@ homelab audit, deterministic PR-opening refresh jobs, and webhook ingress
 Production runs one image in twelve single-replica Kubernetes Deployments. The
 `control` role owns schedule reconciliation and public HTTP/event surfaces
 without a task queue. The credentialless `workflows` role owns deterministic
-Workflow execution on `monorepo-workflows` and temporarily polls the remaining
-legacy central queues so open histories can finish where they started. The domain
-roles own only Activity Workers, with separate registries, credentials, service
-accounts, and concurrency budgets. The default `all` role composes every role in
-one process for local development.
+Workflow execution on `monorepo-workflows`. The domain roles own only Activity
+Workers, with separate registries, credentials, service accounts, and
+concurrency budgets. The explicit `all` role composes every role in one process
+for local development.
 
 Temporal namespaces are environment-scoped: local servers use `dev`, Scout
 beta uses `beta`, and production plus shared control-plane jobs use `prod`.
-The `default` namespace is retired. During the migration
-`TEMPORAL_LEGACY_NAMESPACE=default` added bounded worker-only pollers so
-existing histories could finish without allowing new starts there; the
-cutover completed on 2026-08-31 and the drain was removed once `default` held
-no running executions. The namespace itself stays registered but empty, and
-`TemporalDefaultNamespaceStartAttempted` alerts if anything tries to start
-work there.
+The shared cluster contains only the active `beta` and `prod` namespaces plus
+Temporal's internal `temporal-system` namespace. Unexpected workflow starts in
+any other namespace raise `TemporalUnexpectedNamespaceStartAttempted`.
 
 The central Scout worker also polls its unchanged `scout` queue in `beta` for
 the beta-owned weekly parlay and Bryan Bucks analytics schedules; all other
@@ -56,7 +51,7 @@ above describes the final topology.
 Run from `packages/temporal`:
 
 ```bash
-TEMPORAL_NAMESPACE=dev bun run start # start the local worker
+TEMPORAL_NAMESPACE=dev TEMPORAL_WORKER_ROLE=all bun run start # start the local worker
 bun run typecheck    # tsc --noEmit (stubs the HA schema first)
 bun run test         # unit tests, including the workflow-bundle smoke test
 bun run lint         # eslint

--- a/packages/temporal/runbooks/homelab-audit.md
+++ b/packages/temporal/runbooks/homelab-audit.md
@@ -269,7 +269,7 @@ Flag: projects with no recent releases (SDK may not be reporting), large gap bet
 
 ## Section 10: Temporal Workflows
 
-Temporal runs in the `temporal` namespace (server + UI + canonical workers + PostgreSQL). The UI is at `https://temporal-ui.tailnet-1a49.ts.net`. Workflow source is in `packages/temporal/` (`good-night`, `good-morning`, `golink-sync`, `fetcher`, `dns-audit`, `deps-summary`). The retired `default` worker is intentionally absent after the retention gate.
+Temporal runs in the Kubernetes `temporal` namespace (server + UI + canonical workers + PostgreSQL). The UI is at `https://temporal-ui.tailnet-1a49.ts.net`. Workflow source is in `packages/temporal/` (`good-night`, `good-morning`, `golink-sync`, `fetcher`, `dns-audit`, `deps-summary`). Application workloads use the Temporal `beta` and `prod` namespaces.
 
 The scheduled audit worker has the Temporal CLI installed and `TEMPORAL_ADDRESS`
 points at `temporal-temporal-server-service:7233`, so run Temporal commands
@@ -290,10 +290,10 @@ Flag: any pod not Running/Ready, `CreateContainerConfigError` (missing secret â€
 
 ```bash
 toolkit temporal operator cluster health                          # gRPC ping to frontend (expect SERVING)
-toolkit temporal operator namespace list                          # expected namespaces (default)
+toolkit temporal operator namespace list                          # expected: beta, prod, temporal-system
 ```
 
-Flag: non-SERVING status, gRPC connection error despite server pods Running (NetworkPolicy change, service endpoint mismatch), missing `default` namespace.
+Flag: non-SERVING status, gRPC connection error despite server pods Running (NetworkPolicy change, service endpoint mismatch), or any namespace outside `beta`, `prod`, and `temporal-system`.
 
 ### Failed or stuck workflow executions
 
@@ -381,8 +381,8 @@ The removed `agent-task-timeout-watch` aggregate alert must not be used as a
 health signal. Query the SDK metrics instead:
 
 ```bash
-toolkit prom query 'temporal_worker_num_pollers{namespace="temporal",exported_namespace="default",task_queue="agent-task",poller_type="workflow_task"}'
-toolkit prom query 'histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace="temporal",exported_namespace="default",task_queue="agent-task"}[5m])))'
+toolkit prom query 'temporal_worker_num_pollers{namespace="temporal",exported_namespace="prod",task_queue="monorepo-workflows",poller_type="workflow_task"}'
+toolkit prom query 'histogram_quantile(0.95, sum by (le) (rate(temporal_worker_workflow_task_schedule_to_start_latency_seconds_bucket{namespace="temporal",exported_namespace="prod",task_queue="monorepo-workflows"}[5m])))'
 toolkit prom query 'up{namespace="temporal",service=~".*temporal.*worker.*metrics.*|temporal-worker-app-metrics"}'
 ```
 

--- a/packages/temporal/src/activities/agent-task-side-activities.ts
+++ b/packages/temporal/src/activities/agent-task-side-activities.ts
@@ -40,7 +40,7 @@ import {
   type ReportEnvelopeV1,
 } from "#shared/report.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
-import { parseAnyTemporalNamespace } from "#shared/temporal-namespace.ts";
+import { parseTemporalNamespace } from "#shared/temporal-namespace.ts";
 
 const COMPONENT = "agent-task";
 
@@ -443,7 +443,7 @@ export async function pauseSchedule(
   input: PauseAgentTaskScheduleInput,
 ): Promise<void> {
   const client = await createTemporalClient(
-    parseAnyTemporalNamespace(activityInfo().namespace),
+    parseTemporalNamespace(activityInfo().namespace),
   );
   const handle = client.schedule.getHandle(input.scheduleId);
   await handle.pause(input.reason);

--- a/packages/temporal/src/activities/homelab-audit-collectors.ts
+++ b/packages/temporal/src/activities/homelab-audit-collectors.ts
@@ -1,10 +1,9 @@
 import { z } from "zod/v4";
 import { createTemporalReadClient } from "#client";
 import {
-  parseLegacyTemporalNamespace,
   parseTemporalNamespace,
   temporalNamespacesForMonitoring,
-  type AnyTemporalNamespace,
+  type TemporalNamespace,
 } from "#shared/temporal-namespace.ts";
 import type {
   ReportCheckV1,
@@ -256,21 +255,21 @@ export function temporalHealthQueries(now: Date): {
 }
 
 type TemporalExecutionSummary = {
-  namespace: AnyTemporalNamespace;
+  namespace: TemporalNamespace;
   workflowId: string;
   runId: string;
   startedAt: string;
 };
 
 type TemporalNamespaceHealth = {
-  namespace: AnyTemporalNamespace;
+  namespace: TemporalNamespace;
   failed: TemporalExecutionSummary[];
   stalled: TemporalExecutionSummary[];
   scheduleCount: number;
 };
 
 async function collectTemporalNamespace(
-  namespace: AnyTemporalNamespace,
+  namespace: TemporalNamespace,
   queries: ReturnType<typeof temporalHealthQueries>,
 ): Promise<TemporalNamespaceHealth> {
   const client = await createTemporalReadClient(namespace);
@@ -329,7 +328,6 @@ async function collectTemporal(): Promise<CollectorResult> {
   try {
     const namespaces = temporalNamespacesForMonitoring(
       parseTemporalNamespace(Bun.env["TEMPORAL_NAMESPACE"]),
-      parseLegacyTemporalNamespace(Bun.env["TEMPORAL_LEGACY_NAMESPACE"]),
     );
     const namespaceHealth = await Promise.all(
       namespaces.map(

--- a/packages/temporal/src/activities/report-delivery.ts
+++ b/packages/temporal/src/activities/report-delivery.ts
@@ -28,7 +28,7 @@ import {
   type ReportEnvelopeV1,
 } from "#shared/report.ts";
 import { temporalUiExecutionUrl } from "#shared/workflow-failure-alert.ts";
-import { parseAnyTemporalNamespace } from "#shared/temporal-namespace.ts";
+import { parseTemporalNamespace } from "#shared/temporal-namespace.ts";
 
 export const ReportDeliveryReceiptV1Schema = z.object({
   schemaVersion: z.literal(1),
@@ -331,7 +331,7 @@ export function createActivityReportEnvelope(
       workflowId: execution.workflowId,
       runId: execution.runId,
       temporalUrl: temporalUiExecutionUrl(
-        parseAnyTemporalNamespace(info.namespace),
+        parseTemporalNamespace(info.namespace),
         execution.workflowId,
         execution.runId,
       ),

--- a/packages/temporal/src/activities/workflow-failure-watch-activity.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-activity.ts
@@ -12,25 +12,22 @@ import {
   type PollWorkflowFailuresResult,
 } from "./workflow-failure-watch.ts";
 import {
-  parseWorkflowFailureWatchCheckpoint,
   parseWorkflowFailureWatchCheckpoints,
   parseWorkflowFailureWatchLookbackSince,
   serializedCheckpoints,
-  serializedCheckpoint,
   type WorkflowFailureWatchCheckpoints,
   type WorkflowFailureWatchCheckpoint,
 } from "./workflow-failure-watch-checkpoint.ts";
 import {
-  parseLegacyTemporalNamespace,
   parseTemporalNamespace,
   temporalNamespacesForMonitoring,
-  type AnyTemporalNamespace,
+  type TemporalNamespace,
 } from "#shared/temporal-namespace.ts";
 
 const HEARTBEAT_INTERVAL_MS = 10_000;
 
 function checkpointForPolling(
-  checkpoint: WorkflowFailureWatchCheckpoints[AnyTemporalNamespace],
+  checkpoint: WorkflowFailureWatchCheckpoints[TemporalNamespace],
 ): WorkflowFailureWatchCheckpoint | undefined {
   if (checkpoint === undefined) return undefined;
   if ("closeTime" in checkpoint) {
@@ -43,7 +40,7 @@ async function runPollWorkflowFailuresImpl(
   checkpoints: WorkflowFailureWatchCheckpoints,
   lookbackSince: Date,
   onCheckpoint: (
-    namespace: AnyTemporalNamespace,
+    namespace: TemporalNamespace,
     checkpoint: WorkflowFailureWatchCheckpoint,
   ) => void,
 ): Promise<PollWorkflowFailuresResult> {
@@ -52,7 +49,6 @@ async function runPollWorkflowFailuresImpl(
   );
   const namespaces = temporalNamespacesForMonitoring(
     parseTemporalNamespace(Bun.env["TEMPORAL_NAMESPACE"]),
-    parseLegacyTemporalNamespace(Bun.env["TEMPORAL_LEGACY_NAMESPACE"]),
   );
   const aggregate: PollWorkflowFailuresResult = {
     scanned: 0,
@@ -91,11 +87,6 @@ export const workflowFailureWatchActivities = {
     const heartbeatDetails: unknown = Context.current().info.heartbeatDetails;
     const checkpoints: WorkflowFailureWatchCheckpoints =
       parseWorkflowFailureWatchCheckpoints(heartbeatDetails);
-    const legacyCheckpoint =
-      parseWorkflowFailureWatchCheckpoint(heartbeatDetails);
-    if (legacyCheckpoint !== undefined && checkpoints.default === undefined) {
-      checkpoints.default = legacyCheckpoint;
-    }
     let lookbackSince =
       parseWorkflowFailureWatchLookbackSince(heartbeatDetails) ??
       new Date(start - DEFAULT_LOOKBACK_MS);
@@ -104,7 +95,6 @@ export const workflowFailureWatchActivities = {
         phase: "pollWorkflowFailures",
         elapsedMs: Date.now() - start,
         lookbackSince: lookbackSince.toISOString(),
-        checkpoint: serializedCheckpoint(checkpoints.prod),
         checkpoints: serializedCheckpoints(checkpoints),
       });
     };

--- a/packages/temporal/src/activities/workflow-failure-watch-checkpoint.test.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-checkpoint.test.ts
@@ -1,23 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-  parseWorkflowFailureWatchCheckpoint,
   parseWorkflowFailureWatchCheckpoints,
   parseWorkflowFailureWatchLookbackSince,
   serializedCheckpoints,
-  serializedCheckpoint,
   workflowExecutionKey,
 } from "./workflow-failure-watch-checkpoint.ts";
 
 describe("workflow failure watch heartbeat checkpoints", () => {
-  it("accepts legacy heartbeat details without a checkpoint", () => {
-    expect(
-      parseWorkflowFailureWatchCheckpoint({
-        phase: "pollWorkflowFailures",
-        elapsedMs: 10_000,
-      }),
-    ).toBeUndefined();
-  });
-
   it("preserves a lookback boundary before the first batch checkpoint", () => {
     expect(
       parseWorkflowFailureWatchLookbackSince({
@@ -25,62 +14,6 @@ describe("workflow failure watch heartbeat checkpoints", () => {
         lookbackSince: "2026-07-29T18:00:00.000Z",
       }),
     ).toEqual(new Date("2026-07-29T18:00:00.000Z"));
-  });
-
-  it("serializes and parses a checkpoint with an ISO close time", () => {
-    const serialized = serializedCheckpoint({
-      detailedAlertsConsumed: 16,
-      cursor: {
-        closeTime: new Date("2026-07-30T17:40:00.000Z"),
-        startTime: new Date("2026-07-30T17:35:00.000Z"),
-        lookbackSince: new Date("2026-07-29T18:00:00.000Z"),
-        workflowId: "wf-new",
-        runId: "run-new",
-        processedExecutionKeys: [workflowExecutionKey("wf-new", "run-new")],
-      },
-    });
-
-    expect(
-      parseWorkflowFailureWatchCheckpoint({ checkpoint: serialized }),
-    ).toEqual({
-      detailedAlertsConsumed: 16,
-      cursor: {
-        closeTime: new Date("2026-07-30T17:40:00.000Z"),
-        startTime: new Date("2026-07-30T17:35:00.000Z"),
-        lookbackSince: new Date("2026-07-29T18:00:00.000Z"),
-        workflowId: "wf-new",
-        runId: "run-new",
-        processedExecutionKeys: [workflowExecutionKey("wf-new", "run-new")],
-      },
-    });
-  });
-
-  it("upgrades a legacy cursor with an empty consumed budget", () => {
-    expect(
-      parseWorkflowFailureWatchCheckpoint({
-        checkpoint: {
-          closeTime: "2026-07-30T17:40:00.000Z",
-          workflowId: "wf-legacy",
-          runId: "run-legacy",
-        },
-      }),
-    ).toMatchObject({
-      detailedAlertsConsumed: 0,
-      cursor: { workflowId: "wf-legacy", runId: "run-legacy" },
-    });
-  });
-
-  it("fails loudly for malformed checkpoint details", () => {
-    expect(() =>
-      parseWorkflowFailureWatchCheckpoint({
-        checkpoint: {
-          closeTime: "not-a-date",
-          startTime: "2026-07-30T17:35:00.000Z",
-          workflowId: "wf-new",
-          runId: "run-new",
-        },
-      }),
-    ).toThrow();
   });
 
   it("round-trips checkpoints independently for each monitored namespace", () => {
@@ -97,9 +30,9 @@ describe("workflow failure watch heartbeat checkpoints", () => {
       parseWorkflowFailureWatchCheckpoints({
         checkpoints: serializedCheckpoints({
           beta: checkpoint,
-          default: checkpoint,
+          prod: checkpoint,
         }),
       }),
-    ).toEqual({ beta: checkpoint, default: checkpoint });
+    ).toEqual({ beta: checkpoint, prod: checkpoint });
   });
 });

--- a/packages/temporal/src/activities/workflow-failure-watch-checkpoint.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-checkpoint.ts
@@ -1,8 +1,8 @@
 import { z } from "zod/v4";
 import type { FailedWorkflowExecution } from "#shared/workflow-failure-alert.ts";
 import {
-  AnyTemporalNamespaceSchema,
-  type AnyTemporalNamespace,
+  TemporalNamespaceSchema,
+  type TemporalNamespace,
 } from "#shared/temporal-namespace.ts";
 import type { WorkflowFailureOverflowSummary } from "./workflow-failure-watch-overflow.ts";
 
@@ -50,7 +50,7 @@ export type WorkflowFailureWatchCheckpoint = {
 };
 export type WorkflowFailureWatchCheckpoints = Partial<
   Record<
-    AnyTemporalNamespace,
+    TemporalNamespace,
     WorkflowFailureWatchCheckpoint | WorkflowFailureWatchCursor
   >
 >;
@@ -60,51 +60,6 @@ export function workflowExecutionKey(
   runId: string,
 ): string {
   return `${workflowId}\u{0000}${runId}`;
-}
-
-/**
- * Decode the last heartbeat from a retrying activity. Heartbeats from the
- * pre-checkpoint implementation have no `checkpoint` field and intentionally
- * resume from the lookback boundary; malformed checkpoint data fails loudly so
- * a broken progress contract cannot silently skip executions.
- */
-export function parseWorkflowFailureWatchCheckpoint(
-  details: unknown,
-): WorkflowFailureWatchCheckpoint | undefined {
-  if (details === undefined) {
-    return undefined;
-  }
-  const detailsRecord = z.record(z.string(), z.unknown()).parse(details);
-  const checkpoint = detailsRecord["checkpoint"];
-  if (checkpoint === undefined || checkpoint === null) {
-    return undefined;
-  }
-  const parsed = WorkflowFailureWatchCheckpointSchema.safeParse(checkpoint);
-  if (parsed.success) {
-    return {
-      detailedAlertsConsumed: parsed.data.detailedAlertsConsumed,
-      ...(parsed.data.cursor === undefined
-        ? {}
-        : { cursor: parsedCursor(parsed.data.cursor) }),
-      ...(parsed.data.overflow === undefined
-        ? {}
-        : {
-            overflow: {
-              ...parsed.data.overflow,
-              newestOmittedCloseTime: new Date(
-                parsed.data.overflow.newestOmittedCloseTime,
-              ),
-            },
-          }),
-    };
-  }
-  // Heartbeats written before the fanout budget used the cursor fields at the
-  // checkpoint root. They consumed no persisted detail budget.
-  const legacyCursor = WorkflowFailureWatchCursorSchema.parse(checkpoint);
-  return {
-    detailedAlertsConsumed: 0,
-    cursor: parsedCursor(legacyCursor),
-  };
 }
 
 function parsedCursor(
@@ -139,7 +94,7 @@ export function parseWorkflowFailureWatchLookbackSince(
   return new Date(z.iso.datetime({ offset: true }).parse(lookbackSince));
 }
 
-export function serializedCheckpoint(
+function serializedCheckpoint(
   checkpoint:
     WorkflowFailureWatchCheckpoint | WorkflowFailureWatchCursor | undefined,
 ): Record<string, unknown> | null {
@@ -208,7 +163,7 @@ export function parseWorkflowFailureWatchCheckpoints(
     .parse(rawCheckpoints);
   return Object.fromEntries(
     Object.entries(checkpointsRecord).map(([namespace, checkpoint]) => [
-      AnyTemporalNamespaceSchema.parse(namespace),
+      TemporalNamespaceSchema.parse(namespace),
       parseCheckpointValue(checkpoint),
     ]),
   );

--- a/packages/temporal/src/activities/workflow-failure-watch-overflow.test.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-overflow.test.ts
@@ -14,7 +14,7 @@ function execution(
   return {
     workflowId: `workflow-${String(index)}`,
     runId: `run-${String(index)}`,
-    temporalNamespace: "default",
+    temporalNamespace: "prod",
     workflowType,
     taskQueue: "default",
     startTime: new Date(OBSERVED_AT.getTime() - (index + 1) * 1000),

--- a/packages/temporal/src/activities/workflow-failure-watch-scan.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch-scan.ts
@@ -1,9 +1,6 @@
 import type { FailedWorkflowExecution } from "#shared/workflow-failure-alert.ts";
 import type { WorkflowVisibilityClient } from "#shared/workflow-visibility-client.ts";
-import type {
-  LegacyTemporalNamespace,
-  TemporalNamespace,
-} from "#shared/temporal-namespace.ts";
+import type { TemporalNamespace } from "#shared/temporal-namespace.ts";
 import {
   workflowExecutionKey,
   type WorkflowFailureWatchCheckpoint,
@@ -16,7 +13,7 @@ const FAILURE_STATUS_NAMES = ["FAILED", "TIMED_OUT"] as const;
 type FailureStatusName = (typeof FAILURE_STATUS_NAMES)[number];
 
 type ScanWorkflowFailureVisibilityOptions = {
-  namespace: TemporalNamespace | LegacyTemporalNamespace;
+  namespace: TemporalNamespace;
   query: string;
   checkpoint: WorkflowFailureWatchCheckpoint | undefined;
   detailedAlertsConsumed: number;

--- a/packages/temporal/src/activities/workflow-failure-watch.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch.ts
@@ -15,10 +15,7 @@ import {
 } from "./workflow-failure-watch-overflow.ts";
 import { scanWorkflowFailureVisibility } from "./workflow-failure-watch-scan.ts";
 import type { WorkflowVisibilityClient } from "#shared/workflow-visibility-client.ts";
-import type {
-  LegacyTemporalNamespace,
-  TemporalNamespace,
-} from "#shared/temporal-namespace.ts";
+import type { TemporalNamespace } from "#shared/temporal-namespace.ts";
 
 /**
  * Polls the Temporal visibility API for workflow executions that closed as
@@ -372,7 +369,7 @@ function advanceRecoveryCheckpoint(
 }
 
 export type PollWorkflowFailuresOptions = {
-  namespace?: TemporalNamespace | LegacyTemporalNamespace;
+  namespace?: TemporalNamespace;
   now: Date;
   lookbackMs: number;
   ttlMs: number;

--- a/packages/temporal/src/client.ts
+++ b/packages/temporal/src/client.ts
@@ -1,8 +1,8 @@
 import { Client, Connection } from "@temporalio/client";
 import { createTemporalClientTracingInterceptor } from "@shepherdjerred/temporal-observability/interceptors";
 import {
-  type AnyTemporalNamespace,
-  parseAnyTemporalNamespace,
+  type TemporalNamespace,
+  parseTemporalNamespace,
 } from "#shared/temporal-namespace.ts";
 import type { WorkflowVisibilityClient } from "#shared/workflow-visibility-client.ts";
 import { parseTemporalBootstrapMetadata } from "./shared/execution-metadata.ts";
@@ -10,11 +10,11 @@ import { ExecutionMetadataClientInterceptor } from "./lib/execution-metadata-cli
 
 const DEFAULT_ADDRESS = "temporal-server.temporal.svc.cluster.local:7233";
 
-const cachedClients = new Map<AnyTemporalNamespace, Client>();
-const cachedVisibilityClients = new Map<AnyTemporalNamespace, Client>();
+const cachedClients = new Map<TemporalNamespace, Client>();
+const cachedVisibilityClients = new Map<TemporalNamespace, Client>();
 
 export async function createTemporalClient(
-  namespace: AnyTemporalNamespace = parseAnyTemporalNamespace(
+  namespace: TemporalNamespace = parseTemporalNamespace(
     Bun.env["TEMPORAL_NAMESPACE"],
   ),
 ): Promise<Client> {
@@ -50,14 +50,14 @@ export async function createTemporalClient(
 }
 
 export async function createTemporalVisibilityClient(
-  namespace: AnyTemporalNamespace,
+  namespace: TemporalNamespace,
 ): Promise<WorkflowVisibilityClient> {
   const client = await createTemporalReadClient(namespace);
   return { workflow: client.workflow };
 }
 
 export async function createTemporalReadClient(
-  namespace: AnyTemporalNamespace,
+  namespace: TemporalNamespace,
 ): Promise<Client> {
   const cachedClient = cachedVisibilityClients.get(namespace);
   if (cachedClient !== undefined) {

--- a/packages/temporal/src/lib/worker-deployment-proofs.ts
+++ b/packages/temporal/src/lib/worker-deployment-proofs.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { WorkerBuildIdSchema } from "#shared/temporal-bootstrap.ts";
-import { RETAINED_WORKFLOW_TASK_QUEUES } from "#worker-config";
+import { WORKFLOW_TASK_QUEUES } from "#worker-config";
 
 const PrometheusResponseSchema = z.object({
   status: z.literal("success"),
@@ -150,9 +150,9 @@ export function rolloutPoller(
     ...options,
     ...(currentBuildId === undefined ? {} : { currentBuildId }),
     taskQueue: options.taskQueue,
-    ...(options.taskQueue === RETAINED_WORKFLOW_TASK_QUEUES[0]
+    ...(options.taskQueue === WORKFLOW_TASK_QUEUES[0]
       ? {
-          taskQueues: RETAINED_WORKFLOW_TASK_QUEUES,
+          taskQueues: WORKFLOW_TASK_QUEUES,
         }
       : {}),
   };

--- a/packages/temporal/src/lib/worker-deployment-rollout.test.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.test.ts
@@ -10,7 +10,7 @@ import {
   rolloutPoller,
   type RolloutCommandRunner,
 } from "./worker-deployment-proofs.ts";
-import { RETAINED_WORKFLOW_TASK_QUEUES } from "#worker-config";
+import { WORKFLOW_TASK_QUEUES } from "#worker-config";
 
 const CANDIDATE = "b".repeat(40);
 const STABLE = "a".repeat(40);
@@ -217,7 +217,7 @@ function describeVersionFixture(
     taskQueuesInfos: fixture.omitWorkflowQueue
       ? []
       : fixture.workflowQueue === undefined
-        ? RETAINED_WORKFLOW_TASK_QUEUES.map((name) => ({
+        ? WORKFLOW_TASK_QUEUES.map((name) => ({
             name,
             type: "workflow" as const,
           }))
@@ -301,7 +301,7 @@ async function options(
   return {
     action,
     address: "temporal.test:7233",
-    namespace: "default",
+    namespace: "prod",
     deploymentName: DEPLOYMENT,
     buildId: CANDIDATE,
     taskQueue: "monorepo-workflows",
@@ -373,7 +373,7 @@ describe("Worker Deployment rollout", () => {
       rampPercentage: 0,
       workflowPollers: 1,
       activeTemporalAlerts: 0,
-      candidateWorkflowQueues: RETAINED_WORKFLOW_TASK_QUEUES.toSorted(),
+      candidateWorkflowQueues: WORKFLOW_TASK_QUEUES.toSorted(),
     });
     expect(
       commands.some((command) => command.includes("describe-version")),

--- a/packages/temporal/src/lib/worker-deployment-rollout.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { WorkerBuildIdSchema } from "#shared/temporal-bootstrap.ts";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
-import { RETAINED_WORKFLOW_TASK_QUEUES } from "#worker-config";
+import { WORKFLOW_TASK_QUEUES } from "#worker-config";
 import {
   prepareStablePinPromotion,
   prepareStablePinStatePromotion,
@@ -119,7 +119,7 @@ function requiredWorkflowQueues(
   options: WorkerDeploymentRolloutOptions,
 ): readonly string[] {
   return options.taskQueue === TASK_QUEUES.WORKFLOWS
-    ? RETAINED_WORKFLOW_TASK_QUEUES
+    ? WORKFLOW_TASK_QUEUES
     : [options.taskQueue];
 }
 export async function readWorkerDeploymentRolloutStatus(

--- a/packages/temporal/src/observability/tracing.ts
+++ b/packages/temporal/src/observability/tracing.ts
@@ -22,6 +22,7 @@ import {
 } from "@opentelemetry/sdk-logs";
 import { buildArchiveSpanProcessor } from "@shepherdjerred/llm-observability";
 import {
+  buildTracingInitializationFields,
   buildTracingResource,
   LoggingSpanExporter,
   type TracingResourceOptions,
@@ -148,15 +149,14 @@ export function initializeTracing(
   tracer = trace.getTracer(serviceName);
 
   jsonLog("info", "OpenTelemetry tracing initialized", {
-    serviceName,
-    serviceVersion,
-    otlpEndpoint,
+    ...buildTracingInitializationFields({
+      defaultDomain: "platform",
+      otlpEndpoint,
+      resource: options,
+      serviceName,
+      serviceVersion,
+    }),
     lokiOtlpLogsEndpoint,
-    environment: options.environment ?? "dev",
-    domain: options.domain ?? "platform",
-    namespace: options.namespace ?? "default",
-    taskQueue: options.taskQueue ?? "unknown",
-    workerRole: options.workerRole ?? "unknown",
   });
   tracingRuntime = { processor: rootProcessor, resource };
   return tracingRuntime;

--- a/packages/temporal/src/shared/schedule-reconciliation.ts
+++ b/packages/temporal/src/shared/schedule-reconciliation.ts
@@ -1,4 +1,3 @@
-import type { Client } from "@temporalio/client";
 import { z } from "zod";
 
 const ScheduleReconciliationModeSchema = z.enum([
@@ -15,21 +14,4 @@ export function parseScheduleReconciliationMode(
   value: string | undefined,
 ): ScheduleReconciliationMode {
   return ScheduleReconciliationModeSchema.parse(value ?? "enabled");
-}
-
-/**
- * The migration-safe gateway mode may inspect the legacy namespace, but it
- * must not write there. Once every source schedule is paused, target
- * reconciliation is safe to enable on the next gateway restart.
- */
-export async function isScheduleNamespaceDrained(
-  client: Client,
-): Promise<boolean> {
-  for await (const schedule of client.schedule.list()) {
-    const description = await client.schedule
-      .getHandle(schedule.scheduleId)
-      .describe();
-    if (!description.state.paused) return false;
-  }
-  return true;
 }

--- a/packages/temporal/src/shared/temporal-bootstrap.test.ts
+++ b/packages/temporal/src/shared/temporal-bootstrap.test.ts
@@ -7,11 +7,8 @@ import {
 const SHA = "a".repeat(40);
 
 describe("Temporal bootstrap configuration", () => {
-  test("keeps the current default namespace without enabling versioning", () => {
-    expect(parseTemporalBootstrap({})).toEqual({
-      namespace: "default",
-      workerDeployment: undefined,
-    });
+  test("requires an active namespace", () => {
+    expect(() => parseTemporalBootstrap({})).toThrow();
   });
 
   test("parses an exact deployment identity", () => {
@@ -33,6 +30,7 @@ describe("Temporal bootstrap configuration", () => {
   test("uses immutable image provenance for a configured Workflow Deployment", () => {
     expect(
       parseTemporalBootstrap({
+        TEMPORAL_NAMESPACE: "prod",
         TEMPORAL_WORKER_DEPLOYMENT_NAME: "monorepo-central-workflows",
         GIT_SHA: SHA,
       }).workerDeployment,
@@ -43,9 +41,10 @@ describe("Temporal bootstrap configuration", () => {
   });
 
   test("does not opt Activity workers into versioning from image provenance", () => {
-    expect(parseTemporalBootstrap({ GIT_SHA: SHA }).workerDeployment).toBe(
-      undefined,
-    );
+    expect(
+      parseTemporalBootstrap({ TEMPORAL_NAMESPACE: "prod", GIT_SHA: SHA })
+        .workerDeployment,
+    ).toBe(undefined);
   });
 
   test.each([
@@ -60,12 +59,16 @@ describe("Temporal bootstrap configuration", () => {
       TEMPORAL_WORKER_BUILD_ID: "release-42",
     },
   ])("rejects partial or non-SHA identity: %o", (environment) => {
-    expect(() => parseTemporalBootstrap(environment)).toThrow();
+    expect(() =>
+      parseTemporalBootstrap({ TEMPORAL_NAMESPACE: "prod", ...environment }),
+    ).toThrow();
   });
 
   test("requires deployment identity only at the workflow-worker boundary", () => {
-    expect(() => requireWorkerDeployment(parseTemporalBootstrap({}))).toThrow(
-      "Workflow workers require",
-    );
+    expect(() =>
+      requireWorkerDeployment(
+        parseTemporalBootstrap({ TEMPORAL_NAMESPACE: "prod" }),
+      ),
+    ).toThrow("Workflow workers require");
   });
 });

--- a/packages/temporal/src/shared/temporal-bootstrap.ts
+++ b/packages/temporal/src/shared/temporal-bootstrap.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
+import {
+  TemporalNamespaceSchema,
+  type TemporalNamespace,
+} from "./temporal-namespace.ts";
 
-const NamespaceSchema = z.string().trim().min(1).max(255);
 const WorkerDeploymentNameSchema = z.string().trim().min(1).max(127);
 export const WorkerBuildIdSchema = z
   .string()
@@ -8,7 +11,7 @@ export const WorkerBuildIdSchema = z
 
 const TemporalBootstrapEnvironmentSchema = z
   .object({
-    TEMPORAL_NAMESPACE: NamespaceSchema.optional(),
+    TEMPORAL_NAMESPACE: TemporalNamespaceSchema,
     TEMPORAL_WORKER_DEPLOYMENT_NAME: WorkerDeploymentNameSchema.optional(),
     TEMPORAL_WORKER_BUILD_ID: WorkerBuildIdSchema.optional(),
     GIT_SHA: WorkerBuildIdSchema.or(z.literal("unknown")).optional(),
@@ -35,7 +38,7 @@ const TemporalBootstrapEnvironmentSchema = z
   });
 
 export type TemporalBootstrap = {
-  namespace: string;
+  namespace: TemporalNamespace;
   workerDeployment: { deploymentName: string; buildId: string } | undefined;
 };
 
@@ -50,7 +53,7 @@ export function parseTemporalBootstrap(
       ? undefined
       : parsed.GIT_SHA);
   return {
-    namespace: parsed.TEMPORAL_NAMESPACE ?? "default",
+    namespace: parsed.TEMPORAL_NAMESPACE,
     workerDeployment:
       deploymentName === undefined || buildId === undefined
         ? undefined

--- a/packages/temporal/src/shared/temporal-namespace.test.ts
+++ b/packages/temporal/src/shared/temporal-namespace.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import {
-  parseLegacyTemporalNamespace,
   parseTemporalNamespace,
   temporalNamespacesForMonitoring,
 } from "./temporal-namespace.ts";
@@ -17,30 +16,12 @@ describe("Temporal namespace contracts", () => {
     },
   );
 
-  test("allows default only for the legacy drain", () => {
-    expect(parseLegacyTemporalNamespace(undefined)).toBeUndefined();
-    expect(parseLegacyTemporalNamespace("")).toBeUndefined();
-    expect(parseLegacyTemporalNamespace("default")).toBe("default");
-    expect(() => parseLegacyTemporalNamespace("prod")).toThrow();
-  });
-
-  test("includes default monitoring only during the drain", () => {
-    expect(temporalNamespacesForMonitoring("prod", undefined)).toEqual([
-      "prod",
-      "beta",
-    ]);
-    expect(temporalNamespacesForMonitoring("prod", "default")).toEqual([
-      "prod",
-      "beta",
-      "default",
-    ]);
+  test("monitors both deployed namespaces from production", () => {
+    expect(temporalNamespacesForMonitoring("prod")).toEqual(["prod", "beta"]);
   });
 
   test("monitors the active namespace during local development", () => {
-    expect(temporalNamespacesForMonitoring("dev", undefined)).toEqual(["dev"]);
-    expect(temporalNamespacesForMonitoring("beta", "default")).toEqual([
-      "beta",
-      "default",
-    ]);
+    expect(temporalNamespacesForMonitoring("dev")).toEqual(["dev"]);
+    expect(temporalNamespacesForMonitoring("beta")).toEqual(["beta"]);
   });
 });

--- a/packages/temporal/src/shared/temporal-namespace.ts
+++ b/packages/temporal/src/shared/temporal-namespace.ts
@@ -6,45 +6,16 @@ export const TemporalNamespaceSchema = z.enum(
 );
 export type TemporalNamespace = z.infer<typeof TemporalNamespaceSchema>;
 
-export const LegacyTemporalNamespaceSchema = z.literal("default");
-export type LegacyTemporalNamespace = z.infer<
-  typeof LegacyTemporalNamespaceSchema
->;
-
-export const AnyTemporalNamespaceSchema = z.union([
-  TemporalNamespaceSchema,
-  LegacyTemporalNamespaceSchema,
-]);
-export type AnyTemporalNamespace = z.infer<typeof AnyTemporalNamespaceSchema>;
-
 export function parseTemporalNamespace(value: unknown): TemporalNamespace {
   return TemporalNamespaceSchema.parse(value);
 }
 
-export function parseLegacyTemporalNamespace(
-  value: unknown,
-): LegacyTemporalNamespace | undefined {
-  if (value === undefined || value === "") return undefined;
-  return LegacyTemporalNamespaceSchema.parse(value);
-}
-
-export function parseAnyTemporalNamespace(
-  value: unknown,
-): AnyTemporalNamespace {
-  return AnyTemporalNamespaceSchema.parse(value);
-}
-
 export function temporalNamespacesForMonitoring(
   activeNamespace: TemporalNamespace,
-  legacyNamespace: LegacyTemporalNamespace | undefined,
-): readonly (TemporalNamespace | LegacyTemporalNamespace)[] {
-  const activeNamespaces: readonly TemporalNamespace[] =
-    activeNamespace === "dev"
-      ? ["dev"]
-      : activeNamespace === "prod"
-        ? ["prod", "beta"]
-        : ["beta"];
-  return legacyNamespace === undefined
-    ? activeNamespaces
-    : [...activeNamespaces, legacyNamespace];
+): readonly TemporalNamespace[] {
+  return activeNamespace === "dev"
+    ? ["dev"]
+    : activeNamespace === "prod"
+      ? ["prod", "beta"]
+      : ["beta"];
 }

--- a/packages/temporal/src/shared/worker-namespaces.test.ts
+++ b/packages/temporal/src/shared/worker-namespaces.test.ts
@@ -17,26 +17,14 @@ describe("workerNamespaces", () => {
     );
   });
 
-  test("polls active and legacy namespaces for owned queues during drain", () => {
+  test("polls the active namespace for owned queues", () => {
     expect(
       workerNamespaces({
         queueRole: "reports",
         taskQueue: "reports",
         activeNamespace: "prod",
-        legacyNamespace: "default",
       }),
-    ).toEqual(["prod", "default"]);
-  });
-
-  test("uses only the active namespace after the drain", () => {
-    expect(
-      workerNamespaces({
-        queueRole: "reports",
-        taskQueue: "reports",
-        activeNamespace: "beta",
-        legacyNamespace: undefined,
-      }),
-    ).toEqual(["beta"]);
+    ).toEqual(["prod"]);
   });
 
   test("keeps the existing central Scout queue available to beta-owned schedules", () => {
@@ -45,9 +33,8 @@ describe("workerNamespaces", () => {
         queueRole: "scout",
         taskQueue: "scout",
         activeNamespace: "prod",
-        legacyNamespace: "default",
       }),
-    ).toEqual(["prod", "beta", "default"]);
+    ).toEqual(["prod", "beta"]);
   });
 
   test("keeps the central Workflow queue available to beta-owned schedules", () => {
@@ -56,19 +43,17 @@ describe("workerNamespaces", () => {
         queueRole: "workflows",
         taskQueue: "monorepo-workflows",
         activeNamespace: "prod",
-        legacyNamespace: "default",
       }),
-    ).toEqual(["prod", "beta", "default"]);
+    ).toEqual(["prod", "beta"]);
   });
 
-  test("does not add beta pollers for legacy workflow queues", () => {
+  test("does not add beta pollers for activity queues", () => {
     expect(
       workerNamespaces({
         queueRole: "workflows",
         taskQueue: TASK_QUEUES.HOME,
         activeNamespace: "prod",
-        legacyNamespace: "default",
       }),
-    ).toEqual(["prod", "default"]);
+    ).toEqual(["prod"]);
   });
 });

--- a/packages/temporal/src/shared/worker-namespaces.ts
+++ b/packages/temporal/src/shared/worker-namespaces.ts
@@ -1,7 +1,4 @@
-import type {
-  LegacyTemporalNamespace,
-  TemporalNamespace,
-} from "./temporal-namespace.ts";
+import type { TemporalNamespace } from "./temporal-namespace.ts";
 import { TASK_QUEUES, type TaskQueue } from "./task-queues.ts";
 import type { WorkerRole } from "./worker-role.ts";
 
@@ -21,16 +18,11 @@ export function workerNamespaces(input: {
   queueRole: WorkerRole;
   taskQueue: TaskQueue;
   activeNamespace: TemporalNamespace;
-  legacyNamespace: LegacyTemporalNamespace | undefined;
-}): readonly (TemporalNamespace | LegacyTemporalNamespace)[] {
-  const activeNamespaces: readonly TemporalNamespace[] =
-    (input.queueRole === "scout" ||
-      (input.queueRole === "workflows" &&
-        input.taskQueue === TASK_QUEUES.WORKFLOWS)) &&
+}): readonly TemporalNamespace[] {
+  return (input.queueRole === "scout" ||
+    (input.queueRole === "workflows" &&
+      input.taskQueue === TASK_QUEUES.WORKFLOWS)) &&
     input.activeNamespace === "prod"
-      ? ["prod", "beta"]
-      : [input.activeNamespace];
-  return input.legacyNamespace === undefined
-    ? activeNamespaces
-    : [...activeNamespaces, input.legacyNamespace];
+    ? ["prod", "beta"]
+    : [input.activeNamespace];
 }

--- a/packages/temporal/src/shared/workflow-failure-alert.ts
+++ b/packages/temporal/src/shared/workflow-failure-alert.ts
@@ -1,8 +1,5 @@
 import type { AlertmanagerAlert } from "#lib/alertmanager.ts";
-import type {
-  LegacyTemporalNamespace,
-  TemporalNamespace,
-} from "#shared/temporal-namespace.ts";
+import type { TemporalNamespace } from "#shared/temporal-namespace.ts";
 
 // Kept in sync manually with the Temporal Web UI Tailscale hostname
 // documented in this package's CLAUDE.md (schedule pause instructions).
@@ -12,7 +9,7 @@ const MAX_SUMMARY_MESSAGE_CHARS = 200;
 const MAX_STACK_EXCERPT_CHARS = 800;
 
 export type FailedWorkflowExecution = {
-  temporalNamespace: TemporalNamespace | LegacyTemporalNamespace;
+  temporalNamespace: TemporalNamespace;
   workflowId: string;
   runId: string;
   workflowType: string;
@@ -51,7 +48,7 @@ function truncate(value: string, maxChars: number): string {
 
 /** Direct link to the failed run's history in the Temporal UI — not just "check the UI". */
 export function temporalUiExecutionUrl(
-  namespace: TemporalNamespace | LegacyTemporalNamespace,
+  namespace: TemporalNamespace,
   workflowId: string,
   runId: string,
 ): string {

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -3,7 +3,6 @@ import { agentActivities, reportActivities } from "./activities/index.ts";
 import { TASK_QUEUES } from "./shared/task-queues.ts";
 import {
   getWorkerRoleContract,
-  LEGACY_WORKFLOW_TASK_QUEUES,
   QUEUE_WORKER_DEFINITIONS,
   type QueueWorkerRole,
 } from "./worker-config.ts";
@@ -50,14 +49,14 @@ describe("Temporal worker role contracts", () => {
     );
   });
 
-  it("polls the canonical and remaining legacy Workflow queues", () => {
+  it("polls only the canonical Workflow queue", () => {
     const workflowDefinitions = getWorkerRoleContract("workflows").workers;
     expect(
       workflowDefinitions.every((definition) => definition.kind === "workflow"),
     ).toBe(true);
     expect(
       workflowDefinitions.map((definition) => definition.taskQueue),
-    ).toEqual([TASK_QUEUES.WORKFLOWS, ...LEGACY_WORKFLOW_TASK_QUEUES]);
+    ).toEqual([TASK_QUEUES.WORKFLOWS]);
   });
 
   it("preserves the Glitter alias", () => {
@@ -98,9 +97,7 @@ describe("Temporal worker role contracts", () => {
 
   it("runs every canonical queue and control surface locally", () => {
     const contract = getWorkerRoleContract("all");
-    expect(contract.workers).toHaveLength(
-      ACTIVITY_TASK_QUEUES.length + LEGACY_WORKFLOW_TASK_QUEUES.length + 1,
-    );
+    expect(contract.workers).toHaveLength(ACTIVITY_TASK_QUEUES.length + 1);
     expect(contract.runsGateway).toBe(true);
     expect(contract.validatesScheduleEnvironmentLocally).toBe(true);
     expect(contract.runsEventBridge).toBe(true);

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -117,29 +117,6 @@ const ACTIVITY_WORKER_DEFINITIONS: readonly ActivityWorkerDefinition[] = [
   },
 ];
 
-/**
- * Existing executions never change task queues. Keep credentialless Workflow
- * pollers on every old central queue until live visibility reports no open
- * executions, while every new execution starts on WORKFLOWS.
- */
-export const LEGACY_WORKFLOW_TASK_QUEUES = [
-  TASK_QUEUES.HOME,
-  TASK_QUEUES.REPORTS,
-  TASK_QUEUES.INFRA,
-  TASK_QUEUES.REPO_AUTOMATION,
-  TASK_QUEUES.SCOUT,
-  TASK_QUEUES.AGENT_TASK,
-  TASK_QUEUES.GLITTER_CORPUS,
-  TASK_QUEUES.GLITTER_CONTEXT,
-  TASK_QUEUES.MAINTENANCE,
-  TASK_QUEUES.BACKUP,
-] as const;
-
-export const RETAINED_WORKFLOW_TASK_QUEUES = [
-  TASK_QUEUES.WORKFLOWS,
-  ...LEGACY_WORKFLOW_TASK_QUEUES,
-] as const;
-
 const WORKFLOW_WORKER_DEFINITIONS: readonly WorkflowWorkerDefinition[] = [
   {
     kind: "workflow",
@@ -147,13 +124,9 @@ const WORKFLOW_WORKER_DEFINITIONS: readonly WorkflowWorkerDefinition[] = [
     taskQueue: TASK_QUEUES.WORKFLOWS,
     maxConcurrentWorkflowTaskExecutions: 8,
   },
-  ...LEGACY_WORKFLOW_TASK_QUEUES.map((taskQueue) => ({
-    kind: "workflow" as const,
-    role: "workflows" as const,
-    taskQueue,
-    maxConcurrentWorkflowTaskExecutions: 2,
-  })),
 ];
+
+export const WORKFLOW_TASK_QUEUES = [TASK_QUEUES.WORKFLOWS] as const;
 
 export const QUEUE_WORKER_DEFINITIONS: readonly QueueWorkerDefinition[] = [
   ...ACTIVITY_WORKER_DEFINITIONS,

--- a/packages/temporal/src/worker-factory.ts
+++ b/packages/temporal/src/worker-factory.ts
@@ -2,10 +2,7 @@ import { VersioningBehavior } from "@temporalio/common";
 import { Worker } from "@temporalio/worker";
 import type { NativeConnection } from "@temporalio/worker";
 import type { createTemporalWorkerTracing } from "@shepherdjerred/temporal-observability/interceptors";
-import type {
-  LegacyTemporalNamespace,
-  TemporalNamespace,
-} from "./shared/temporal-namespace.ts";
+import type { TemporalNamespace } from "./shared/temporal-namespace.ts";
 import { WORKFLOW_TASK_POLLER_BEHAVIOR } from "./shared/worker-options.ts";
 import type { TemporalBootstrap } from "./shared/temporal-bootstrap.ts";
 import type { QueueWorkerDefinition } from "./worker-config.ts";
@@ -24,8 +21,7 @@ export type CreateQueueWorkerOptions = {
 export async function createQueueWorker(
   definition: QueueWorkerDefinition,
   options: CreateQueueWorkerOptions,
-  namespace: TemporalNamespace | LegacyTemporalNamespace,
-  legacyDrain: boolean,
+  namespace: TemporalNamespace,
 ): Promise<Worker> {
   const {
     connection,
@@ -36,9 +32,6 @@ export async function createQueueWorker(
     temporalTracing,
   } = options;
   if (definition.kind === "workflow") {
-    const workerDeployment = legacyDrain
-      ? undefined
-      : bootstrap.workerDeployment;
     return await Worker.create({
       connection,
       namespace,
@@ -56,21 +49,20 @@ export async function createQueueWorker(
         : { sinks: temporalTracing.sinks }),
       workflowTaskPollerBehavior: WORKFLOW_TASK_POLLER_BEHAVIOR,
       taskQueue: definition.taskQueue,
-      ...(workerDeployment === undefined
+      ...(bootstrap.workerDeployment === undefined
         ? {}
         : {
             workerDeploymentOptions: {
-              version: workerDeployment,
+              version: bootstrap.workerDeployment,
               useWorkerVersioning: true,
               defaultVersioningBehavior: VersioningBehavior.AUTO_UPGRADE,
             },
           }),
-      ...(!legacyDrain &&
-      definition.maxConcurrentWorkflowTaskExecutions === undefined
+      ...(definition.maxConcurrentWorkflowTaskExecutions === undefined
         ? {}
         : {
             maxConcurrentWorkflowTaskExecutions:
-              definition.maxConcurrentWorkflowTaskExecutions ?? 1,
+              definition.maxConcurrentWorkflowTaskExecutions,
           }),
     });
   }
@@ -82,12 +74,11 @@ export async function createQueueWorker(
     ...(temporalTracing === undefined
       ? {}
       : { interceptors: { activity: temporalTracing.activity } }),
-    ...(!legacyDrain &&
-    definition.maxConcurrentActivityTaskExecutions === undefined
+    ...(definition.maxConcurrentActivityTaskExecutions === undefined
       ? {}
       : {
           maxConcurrentActivityTaskExecutions:
-            definition.maxConcurrentActivityTaskExecutions ?? 1,
+            definition.maxConcurrentActivityTaskExecutions,
         }),
   });
 }

--- a/packages/temporal/src/worker.ts
+++ b/packages/temporal/src/worker.ts
@@ -38,9 +38,7 @@ import {
   shutdownCallGraphTracing,
 } from "./config/call-graph-tracing.ts";
 import {
-  parseLegacyTemporalNamespace,
   parseTemporalNamespace,
-  type LegacyTemporalNamespace,
   type TemporalNamespace,
 } from "./shared/temporal-namespace.ts";
 import {
@@ -49,7 +47,6 @@ import {
 } from "./shared/worker-namespaces.ts";
 import {
   parseScheduleReconciliationMode,
-  isScheduleNamespaceDrained,
   type ScheduleReconciliationMode,
 } from "./shared/schedule-reconciliation.ts";
 import { createQueueWorker } from "./worker-factory.ts";
@@ -185,33 +182,11 @@ type StartRoleServicesOptions = {
   readonly callGraphTracing: boolean;
   readonly namespace: TemporalNamespace;
   readonly scheduleReconciliation: ScheduleReconciliationMode;
-  readonly legacyNamespace: LegacyTemporalNamespace | undefined;
   readonly roleContract: ReturnType<typeof getWorkerRoleContract>;
 };
 
-async function shouldReconcileSchedules(
-  options: StartRoleServicesOptions,
-  connection: Connection,
-): Promise<boolean> {
-  if (options.scheduleReconciliation !== "auto") {
-    return options.scheduleReconciliation === "enabled";
-  }
-  const shouldReconcile =
-    options.legacyNamespace === undefined ||
-    (await isScheduleNamespaceDrained(
-      new Client({
-        connection,
-        namespace: options.legacyNamespace,
-      }),
-    ));
-  jsonLog(
-    "info",
-    shouldReconcile
-      ? "Legacy schedule namespace drained"
-      : "Legacy schedule namespace still active",
-    { namespace: options.legacyNamespace ?? "none" },
-  );
-  return shouldReconcile;
+function shouldReconcileSchedules(options: StartRoleServicesOptions): boolean {
+  return options.scheduleReconciliation !== "disabled";
 }
 
 async function registerGatewaySchedules(
@@ -270,10 +245,7 @@ async function startRoleServices(options: StartRoleServicesOptions): Promise<{
       ],
     },
   });
-  const shouldReconcile = await shouldReconcileSchedules(
-    options,
-    clientConnection,
-  );
+  const shouldReconcile = shouldReconcileSchedules(options);
   let httpServers: EventBridgeHandle | undefined;
   if (shouldReconcile && options.roleContract.runsGateway) {
     await registerGatewaySchedules(options, clientConnection);
@@ -342,14 +314,10 @@ async function main(): Promise<void> {
   const scheduleReconciliation = parseScheduleReconciliationMode(
     Bun.env["TEMPORAL_SCHEDULE_RECONCILIATION"],
   );
-  const legacyNamespace = parseLegacyTemporalNamespace(
-    Bun.env["TEMPORAL_LEGACY_NAMESPACE"],
-  );
   jsonLog("info", "Connecting to Temporal server", {
     address,
     role,
     namespace,
-    legacyNamespace,
   });
 
   const connection = await NativeConnection.connect({ address });
@@ -368,10 +336,8 @@ async function main(): Promise<void> {
       queueRole: definition.role,
       taskQueue: definition.taskQueue,
       activeNamespace: namespace,
-      legacyNamespace,
     });
     for (const workerNamespace of namespaces) {
-      const legacyDrain = workerNamespace === legacyNamespace;
       const worker = await createQueueWorker(
         definition,
         {
@@ -383,12 +349,10 @@ async function main(): Promise<void> {
           temporalTracing,
         },
         workerNamespace,
-        legacyDrain,
       );
       workers.push(worker);
       jsonLog("info", "Worker created", {
         namespace: workerNamespace,
-        legacyDrain,
         workerKind: definition.kind,
         queueRole: definition.role,
         taskQueue: definition.taskQueue,
@@ -411,7 +375,6 @@ async function main(): Promise<void> {
     callGraphTracing,
     namespace,
     scheduleReconciliation,
-    legacyNamespace,
     roleContract,
   });
 

--- a/scripts/temporal-replay.test.ts
+++ b/scripts/temporal-replay.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { TemporalReplayNamespaceSchema } from "./temporal-replay.ts";
+
+describe("Temporal replay namespace", () => {
+  it.each(["dev", "beta", "prod"])("accepts %s", (namespace) => {
+    expect(TemporalReplayNamespaceSchema.parse(namespace)).toBe(namespace);
+  });
+
+  it.each([undefined, "", "default", "staging"])("rejects %s", (namespace) => {
+    expect(() => TemporalReplayNamespaceSchema.parse(namespace)).toThrow();
+  });
+});

--- a/scripts/temporal-replay.ts
+++ b/scripts/temporal-replay.ts
@@ -1,5 +1,8 @@
 import { Client, Connection } from "@temporalio/client";
 import { Worker } from "@temporalio/worker";
+import { z } from "zod";
+
+export const TemporalReplayNamespaceSchema = z.enum(["dev", "beta", "prod"]);
 
 export async function replayTemporalHistories(input: {
   workflowIds: readonly string[];
@@ -19,6 +22,9 @@ export async function replayTemporalHistories(input: {
   if (tls !== undefined && tls !== "true" && tls !== "false") {
     throw new Error(`TEMPORAL_TLS must be true or false, got ${tls}`);
   }
+  const namespace = TemporalReplayNamespaceSchema.parse(
+    environment["TEMPORAL_NAMESPACE"],
+  );
   const connection = await Connection.connect({
     address,
     ...(tls === "true" ? { tls: true } : {}),
@@ -26,7 +32,7 @@ export async function replayTemporalHistories(input: {
   try {
     const client = new Client({
       connection,
-      namespace: environment["TEMPORAL_NAMESPACE"] ?? "default",
+      namespace,
     });
     for (const workflowId of input.workflowIds) {
       const history = await client.workflow


### PR DESCRIPTION
## Why

The shared Temporal cluster has completed its dev, beta, and prod namespace cutover. Keeping default-namespace worker paths would allow retired routing to return silently and makes a missing stage configuration look valid.

## What

- Require `TEMPORAL_NAMESPACE` and accept only `dev`, `beta`, or `prod`.
- Remove legacy/default worker construction, central queue pollers, drain flags, Scout supervisor workers, and schedule gates.
- Bind Scout Workflow Workers to `ENVIRONMENT` and retain `TEMPORAL_WORKER_ROLE=all` for explicit local dev.
- Keep only `monorepo-workflows` for central Workflow tasks.
- Make failure-watch checkpoints active-namespace-only and omit the namespace tracing attribute outside Temporal runtimes.

## Verification

- `bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal --filter=@shepherdjerred/temporal-observability --filter=@scout-for-lol/temporal --filter=@scout-for-lol/backend`
- `bunx turbo run typecheck lint --filter=@scout-for-lol/backend`
- `bunx lefthook run pre-commit`

## Rollout

The maintenance cleanup normalized live schedule notes and permanently deleted the shared-cluster `default` namespace after confirming no schedules, executions, pollers, backlog, post-cutover starts, or open executions on retired central queues. Deployment acceptance remains central first, then Scout beta, then Scout production with replay, queue canaries, and Worker Deployment promotion.