### PR TITLE
feat(homelab): replace Flipt default namespace with product catalogs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -739,6 +739,7 @@
       "dependencies": {
         "@flipt-io/flipt-client-js": "^0.5.0",
         "@openfeature/server-sdk": "^1.23.0",
+        "yaml": "^2.8.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -840,6 +841,7 @@
       "name": "@homelab/cdk8s",
       "dependencies": {
         "@grafana/grafana-foundation-sdk": "11.6.0-cogv0.0.x.1769699379",
+        "@shepherdjerred/feature-flags": "workspace:*",
         "@shepherdjerred/helm-types": "workspace:*",
         "@shepherdjerred/version-catalog": "workspace:*",
         "cdk8s": "^2.70.58",

--- a/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
+++ b/packages/docs/wiki/src/content/docs/explanation/homelab/configuration.md
@@ -21,9 +21,18 @@ layered resolver in front of it.
 > and bootstrap**. Everything else is a **feature flag**.
 
 Bootstrap is the part that cannot be a flag because it is needed to construct
-the thing that reads flags. `FLIPT_URL` locates the provider, while
-`FLIPT_ENVIRONMENT` selects its isolated storage environment. Every Flipt client
-sets that selector explicitly so a missing deployment value fails loudly.
+the thing that reads flags. `FLIPT_URL` locates the provider,
+`FLIPT_ENVIRONMENT` selects an isolated stage repository (`beta` or `prod`),
+and `FLIPT_NAMESPACE` selects the product-owned keyspace inside that
+environment. Every Flipt client sets both selectors explicitly so a missing
+deployment value fails loudly.
+
+A Flipt namespace is not a Kubernetes namespace. The Kubernetes namespace is a
+network and workload boundary; the Flipt namespace is a flag-catalog boundary.
+For example, Scout beta runs against Flipt environment `beta` and namespace
+`scout`, while Temporal runs against environment `prod` and namespace
+`temporal`. Both Flipt environments contain the same six product namespaces so
+the inventory remains uniform even when a product has no beta consumer.
 
 The application `ENVIRONMENT` remains separate. It describes the application
 stage and may be passed as a targeting attribute. It does not choose where Flipt
@@ -112,11 +121,13 @@ If Flipt ever gains authentication, both of those are worth revisiting.
 Flipt v2 defaults to **in-memory storage**. It accepts flag writes, serves them
 back, and silently loses every one on restart. The deployment therefore gives
 beta and production separate local git backends on a ZFS PVC backed up by
-Velero. Environment isolation prevents a beta model or rollout change from
-altering production. Regression tests assert the storage and client selectors,
-because either omission produces a service that looks healthy while reading the
-wrong contract. The retired single-environment repository remains unreferenced
-on the PVC as a rollback artifact; removing it is a separate lifecycle decision.
+Velero. Each repository begins from a validated declarative seed with all six
+product namespaces; subsequent restarts validate existing repositories and do
+not overwrite operator changes. Environment isolation prevents a beta model or
+rollout change from altering production, while namespaces keep product flag
+catalogs separate within a stage. Regression tests assert the storage and both
+client selectors, because any omission produces a service that looks healthy
+while reading the wrong contract.
 
 ## Analytics has a different ownership boundary
 

--- a/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
+++ b/packages/docs/wiki/src/content/docs/how-to/check-flipt-flag-inventory.md
@@ -7,8 +7,9 @@ sidebar:
 
 Run the operator-only inventory check when you change Flipt state or need to
 diagnose runtime flag drift. A daily Temporal workflow performs the same
-key-set check and publishes a `FliptManagedFlagDrift` warning to Alertmanager;
-the alert resolves after a later verified aligned snapshot.
+contract check and publishes one independently labelled
+`FliptManagedFlagDrift` warning per environment and namespace; each alert
+resolves after that pair returns to an aligned snapshot.
 
 ## 1. Set the endpoint
 
@@ -27,17 +28,20 @@ Run the repository command from the monorepo root:
 bun run check-flipt-flag-inventory
 ```
 
-The command checks every environment declared in the managed inventory. That
-means `beta` and `prod` in the `default` namespace.
+The command checks every environment and product namespace declared in the
+managed inventory: `beta` and `prod`, each containing `scout`, `birmel`,
+`streambot`, `starlight-karma-bot`, `trmnl-dashboard`, and `temporal`.
 
-To check one exact environment, pass a filter:
+Filter either dimension independently:
 
 ```bash
 bun run check-flipt-flag-inventory -- --environment beta
+bun run check-flipt-flag-inventory -- --namespace scout
+bun run check-flipt-flag-inventory -- --environment beta --namespace scout
 ```
 
-`FLIPT_NAMESPACE` changes the namespace. `FLIPT_ENVIRONMENT` is also accepted
-as the exact environment filter.
+`FLIPT_ENVIRONMENT` and `FLIPT_NAMESPACE` are also accepted as exact filters.
+Without filters, the command always checks the complete twelve-pair matrix.
 
 ## 3. Interpret failures
 
@@ -51,8 +55,8 @@ The check fails when Flipt differs from the inventory in any of these areas:
 - percentage threshold rollouts.
 
 Each diagnostic names the failing namespace and environment. Fix the repository
-inventory or that environment's audited Flipt state, then run the complete
-check again until every environment reports alignment.
+inventory or that pair's audited Flipt state, then run the complete check again
+until all twelve pairs report alignment.
 
 When environments intentionally differ, record a full behavioral override in
 the environment's inventory entry. An override replaces the flag's default,
@@ -65,16 +69,16 @@ inventory. A failed snapshot request does not resolve an existing alert; the
 workflow fails so the Temporal failure watcher can report the unavailable
 check separately.
 
-## 4. Change one environment
+## 4. Change one namespace in one environment
 
-Select the intended environment in the Flipt UI before editing a flag. The
-`beta` and `prod` repositories are independent; changing one never updates the
-other.
+Select both the intended environment and product namespace in the Flipt UI
+before editing a flag. The `beta` and `prod` repositories are independent, and
+each namespace has its own flag keyspace inside that repository.
 
 After the edit, check that environment first:
 
 ```bash
-bun run check-flipt-flag-inventory -- --environment prod
+bun run check-flipt-flag-inventory -- --environment prod --namespace scout
 ```
 
 Then run the unfiltered command. This catches accidental drift in every managed

--- a/packages/dotfiles/dot_agents/skills/feature-flags/SKILL.md
+++ b/packages/dotfiles/dot_agents/skills/feature-flags/SKILL.md
@@ -24,10 +24,12 @@ ramp, then remove the flag. That is the default path, not an exception.
 
 1. Is it a secret? → 1Password → Kubernetes Secret.
 2. Is it needed before the flag client exists? → **bootstrap env**
-   (`FLIPT_URL`, `FLIPT_ENVIRONMENT`, application `ENVIRONMENT`, `PORT`,
-   `DATABASE_URL`, `TEMPORAL_WORKER_ROLE`). `ENVIRONMENT` describes the
-   application deployment; `FLIPT_ENVIRONMENT` selects Flipt's isolated
-   storage environment and is required whenever `FEATURE_FLAGS_MODE=flipt`.
+   (`FLIPT_URL`, `FLIPT_ENVIRONMENT`, `FLIPT_NAMESPACE`, application
+   `ENVIRONMENT`, `PORT`, `DATABASE_URL`, `TEMPORAL_WORKER_ROLE`).
+   `ENVIRONMENT` describes the application deployment;
+   `FLIPT_ENVIRONMENT` selects Flipt's isolated stage repository and
+   `FLIPT_NAMESPACE` selects the product flag keyspace inside it. Both Flipt
+   selectors are required whenever `FEATURE_FLAGS_MODE=flipt`.
 3. Does an end user own it? → a database row.
 4. Shared across packages or languages? → JSON catalog + JSON Schema.
 5. Changes only when code changes? → a constant.
@@ -61,8 +63,8 @@ Flags of your own also need:
 - the consuming namespace added to `CONSUMER_NAMESPACES` in
   `packages/homelab/src/cdk8s/src/cdk8s-charts/flipt.ts` — Flipt has no auth, so
   that list is the access control;
-- `FEATURE_FLAGS_MODE`, `FLIPT_URL`, and `FLIPT_ENVIRONMENT` on the service's
-  cdk8s Deployment when the mode is `flipt`;
+- `FEATURE_FLAGS_MODE`, `FLIPT_URL`, `FLIPT_ENVIRONMENT`, and the exact product
+  `FLIPT_NAMESPACE` on the service's cdk8s Deployment when the mode is `flipt`;
 - `FEATURE_FLAGS_MODE=disabled` wherever tests run.
 
 ## Rules
@@ -108,6 +110,10 @@ values, refreshed in the background, never empty before the first refresh.
 
 ## Flipt gotchas (learned by running it, not from docs)
 
+- **Environment and namespace are separate selectors.** Environments isolate
+  stage repositories (`beta`, `prod`); namespaces isolate product flag catalogs
+  (`scout`, `temporal`, and so on). A Flipt namespace is unrelated to a
+  Kubernetes namespace.
 - **v2 defaults to IN-MEMORY storage.** Without an explicit local backend it
   accepts writes and loses them on restart.
 - **`enabled` is the flag's default; rollouts override it.** A 30% rollout to

--- a/packages/feature-flags/AGENTS.md
+++ b/packages/feature-flags/AGENTS.md
@@ -29,10 +29,10 @@ layer.
 
 ## Two failure classes, deliberately different
 
-| Class                  | Examples                                                                          | Behavior                                                         |
-| ---------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Config error**       | missing/unknown `FEATURE_FLAGS_MODE`, malformed `FLIPT_URL`, non-scalar attribute | **Throws** from `initFeatureFlags`. A deploy bug should be loud. |
-| **Availability error** | backend unreachable, provider not ready, flag undefined                           | **Never throws.** Returns the call-site default with a reason.   |
+| Class                  | Examples                                                                                                                  | Behavior                                                         |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Config error**       | missing/unknown `FEATURE_FLAGS_MODE`, malformed `FLIPT_URL`, missing Flipt environment or namespace, non-scalar attribute | **Throws** from `initFeatureFlags`. A deploy bug should be loud. |
+| **Availability error** | backend unreachable, provider not ready, flag undefined                                                                   | **Never throws.** Returns the call-site default with a reason.   |
 
 This is a deliberate carve-out from the repo's fail-fast default, recorded here
 so review does not re-litigate it on every PR. A flag system that throws during
@@ -55,6 +55,9 @@ same reason: a flag backend must never stop a service from booting.
   hidden environment fork is the silent fallback this repo bans. Consumers set
   `FEATURE_FLAGS_MODE=disabled` explicitly in test environments — including in
   their `scripts/ci-test-manifest.json` entry.
+- **Flipt mode requires both `FLIPT_ENVIRONMENT` and `FLIPT_NAMESPACE`.** The
+  environment selects the stage repository; the namespace selects the product
+  flag catalog inside it. Neither selector has a fallback.
 - **Attributes are scalars only.** Flipt's evaluation context is
   `Record<string, string>`; an object would target on `"[object Object]"`.
 - **No logging dependency.** `onInitializationFailure` is injected so each

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@flipt-io/flipt-client-js": "^0.5.0",
     "@openfeature/server-sdk": "^1.23.0",
+    "yaml": "^2.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/feature-flags/src/config/load.test.ts
+++ b/packages/feature-flags/src/config/load.test.ts
@@ -41,8 +41,19 @@ describe("loadFeatureFlagConfiguration", () => {
       loadFeatureFlagConfiguration({
         FEATURE_FLAGS_MODE: "flipt",
         FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+        FLIPT_NAMESPACE: "scout",
       }),
     ).toThrow(/FLIPT_ENVIRONMENT is required/);
+  });
+
+  test("flipt mode requires an explicit namespace", () => {
+    expect(() =>
+      loadFeatureFlagConfiguration({
+        FEATURE_FLAGS_MODE: "flipt",
+        FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+        FLIPT_ENVIRONMENT: "beta",
+      }),
+    ).toThrow(/FLIPT_NAMESPACE is required/);
   });
 
   test("flipt mode rejects a malformed URL as a config error", () => {
@@ -50,6 +61,8 @@ describe("loadFeatureFlagConfiguration", () => {
       loadFeatureFlagConfiguration({
         FEATURE_FLAGS_MODE: "flipt",
         FLIPT_URL: "not-a-url",
+        FLIPT_NAMESPACE: "scout",
+        FLIPT_ENVIRONMENT: "beta",
       }),
     ).toThrow();
   });
@@ -62,12 +75,13 @@ describe("loadFeatureFlagConfiguration", () => {
       loadFeatureFlagConfiguration({
         FEATURE_FLAGS_MODE: "flipt",
         FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+        FLIPT_NAMESPACE: "scout",
         FLIPT_ENVIRONMENT: "beta",
       }),
     ).toEqual({
       mode: "flipt",
       url: "http://flipt.flipt.svc.cluster.local:8080",
-      namespace: "default",
+      namespace: "scout",
       environment: "beta",
       pollIntervalSeconds: 300,
     });
@@ -78,6 +92,7 @@ describe("loadFeatureFlagConfiguration", () => {
       loadFeatureFlagConfiguration({
         FEATURE_FLAGS_MODE: "flipt",
         FLIPT_URL: "http://flipt.flipt.svc.cluster.local:8080",
+        FLIPT_NAMESPACE: "scout",
         FLIPT_ENVIRONMENT: "beta",
         FLIPT_POLL_INTERVAL_SECONDS: "0",
       }),

--- a/packages/feature-flags/src/config/load.ts
+++ b/packages/feature-flags/src/config/load.ts
@@ -59,7 +59,7 @@ export function loadFeatureFlagConfiguration(
   return FeatureFlagConfigurationSchema.parse({
     mode,
     url: requireVariable(environment, "FLIPT_URL"),
-    namespace: environment["FLIPT_NAMESPACE"] ?? "default",
+    namespace: requireVariable(environment, "FLIPT_NAMESPACE"),
     environment: requireVariable(environment, "FLIPT_ENVIRONMENT"),
     pollIntervalSeconds:
       rawPoll === undefined || rawPoll.length === 0

--- a/packages/feature-flags/src/flipt-features-renderer.test.ts
+++ b/packages/feature-flags/src/flipt-features-renderer.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "vitest";
+import YAML from "yaml";
+import { z } from "zod";
+import { renderFliptFeatures } from "./flipt-features-renderer.ts";
+import { ManagedFlagInventorySchema } from "./managed-flag-inventory.ts";
+
+const RenderedFeaturesSchema = z.object({
+  version: z.literal("1.6"),
+  namespace: z.object({
+    key: z.string(),
+    name: z.string(),
+    description: z.string(),
+  }),
+  flags: z.array(z.record(z.string(), z.unknown())),
+  segments: z.array(
+    z.object({
+      key: z.string(),
+      match_type: z.string(),
+      constraints: z.array(
+        z.object({
+          type: z.string(),
+          property: z.string(),
+          operator: z.string(),
+          value: z.string(),
+        }),
+      ),
+    }),
+  ),
+});
+
+function parseRendered(environment: string, namespace: string) {
+  const parsed: unknown = YAML.parse(
+    renderFliptFeatures(environment, namespace),
+  );
+  return RenderedFeaturesSchema.parse(parsed);
+}
+
+function testInventory(flags: unknown[]) {
+  return ManagedFlagInventorySchema.parse({
+    version: 3,
+    namespaces: [{ key: "test", name: "Test", description: "Test namespace." }],
+    environments: [
+      { key: "beta", overrides: [] },
+      { key: "prod", overrides: [] },
+    ],
+    flags,
+    exemptions: [],
+  });
+}
+
+const behavior = {
+  rollouts: [],
+  rules: [],
+  thresholdRollouts: [],
+};
+
+function metadata(key: string) {
+  return {
+    key,
+    owner: "test",
+    namespace: "test",
+    source: "test",
+    purpose: `Test ${key}.`,
+  };
+}
+
+function booleanRollouts(value: string) {
+  return [
+    {
+      segmentKey: "shared",
+      segmentOperator: "OR_SEGMENT_OPERATOR",
+      matchType: "ALL_SEGMENT_MATCH_TYPE",
+      constraints: [
+        {
+          type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+          property: "role",
+          operator: "eq",
+          value,
+        },
+      ],
+      result: true,
+    },
+  ];
+}
+
+describe("renderFliptFeatures", () => {
+  test("renders every managed namespace in both environments", () => {
+    const namespaces = [
+      "scout",
+      "birmel",
+      "streambot",
+      "starlight-karma-bot",
+      "trmnl-dashboard",
+      "temporal",
+    ];
+    for (const environment of ["beta", "prod"]) {
+      for (const namespace of namespaces) {
+        const rendered = parseRendered(environment, namespace);
+        expect(rendered.namespace.key).toBe(namespace);
+        expect(rendered.flags.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("renders intended Scout defaults and declarative segment enums", () => {
+    const rendered = parseRendered("beta", "scout");
+    expect(rendered.flags).toContainEqual(
+      expect.objectContaining({
+        key: "scout-explore-model",
+        type: "VARIANT_FLAG_TYPE",
+        variants: [
+          {
+            default: true,
+            key: "gpt-5.6-luna",
+            name: "gpt-5.6-luna",
+            attachment: {},
+          },
+        ],
+      }),
+    );
+    expect(rendered.segments).toContainEqual(
+      expect.objectContaining({
+        key: "scout-guild-1337623164146155593",
+        match_type: "ALL_MATCH_TYPE",
+        constraints: [
+          expect.objectContaining({ type: "STRING_COMPARISON_TYPE" }),
+        ],
+      }),
+    );
+  });
+
+  test("renders rules, variants, attachments, and threshold ranks", () => {
+    const inventory = testInventory([
+      {
+        ...metadata("variant"),
+        type: "variant",
+        default: "blue",
+        rollouts: [],
+        thresholdRollouts: [],
+        rules: [
+          {
+            rank: 0,
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+            segments: [
+              {
+                key: "operators",
+                matchType: "ALL_SEGMENT_MATCH_TYPE",
+                constraints: [
+                  {
+                    type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+                    property: "role",
+                    operator: "eq",
+                    value: "operator",
+                  },
+                ],
+              },
+            ],
+            distributions: [
+              {
+                variantKey: "green",
+                rollout: 100,
+                variantAttachment: '{"color":"green"}',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        ...metadata("boolean"),
+        type: "boolean",
+        default: false,
+        rollouts: [
+          {
+            segmentKey: "operators",
+            segmentOperator: "OR_SEGMENT_OPERATOR",
+            matchType: "ALL_SEGMENT_MATCH_TYPE",
+            constraints: [
+              {
+                type: "STRING_CONSTRAINT_COMPARISON_TYPE",
+                property: "role",
+                operator: "eq",
+                value: "operator",
+              },
+            ],
+            result: true,
+          },
+        ],
+        rules: [],
+        thresholdRollouts: [{ rank: 0, percentage: 25, result: true }],
+      },
+    ]);
+    const parsed: unknown = YAML.parse(
+      renderFliptFeatures("prod", "test", inventory),
+    );
+    const rendered = RenderedFeaturesSchema.parse(parsed);
+
+    expect(rendered.flags).toContainEqual(
+      expect.objectContaining({
+        key: "variant",
+        rules: [
+          expect.objectContaining({
+            rank: 0,
+            distributions: [{ variant: "green", rollout: 100 }],
+          }),
+        ],
+        variants: expect.arrayContaining([
+          expect.objectContaining({
+            key: "green",
+            attachment: { color: "green" },
+          }),
+        ]),
+      }),
+    );
+    expect(rendered.flags).toContainEqual(
+      expect.objectContaining({
+        key: "boolean",
+        rollouts: [
+          expect.objectContaining({
+            threshold: { percentage: 25, value: true },
+          }),
+          expect.objectContaining({
+            segment: expect.objectContaining({ keys: ["operators"] }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  test("fails on conflicting segment definitions", () => {
+    expect(() =>
+      testInventory([
+        {
+          ...metadata("first"),
+          type: "boolean",
+          default: false,
+          ...behavior,
+          rollouts: booleanRollouts("first"),
+        },
+        {
+          ...metadata("second"),
+          type: "boolean",
+          default: false,
+          ...behavior,
+          rollouts: booleanRollouts("second"),
+        },
+      ]),
+    ).toThrow(/conflicting managed segment definition/);
+  });
+});

--- a/packages/feature-flags/src/flipt-features-renderer.ts
+++ b/packages/feature-flags/src/flipt-features-renderer.ts
@@ -1,0 +1,278 @@
+import YAML from "yaml";
+import {
+  managedFlagInventory,
+  materializeManagedNamespaceEnvironment,
+  type ManagedFlag,
+  type ManagedFlagInventory,
+  type ManagedNamespace,
+} from "./managed-flag-inventory.ts";
+
+type DeclarativeSegment = {
+  readonly key: string;
+  readonly name: string;
+  readonly description: string;
+  readonly constraints: readonly {
+    readonly type: string;
+    readonly property: string;
+    readonly operator: string;
+    readonly value: string;
+    readonly description: string;
+  }[];
+  readonly match_type: string;
+};
+
+function declarativeConstraintType(type: string): string {
+  if (!type.includes("_CONSTRAINT_")) {
+    throw new Error(`unsupported Flipt snapshot constraint type: ${type}`);
+  }
+  return type.replace("_CONSTRAINT_", "_");
+}
+
+function declarativeMatchType(type: string): string {
+  if (!type.includes("_SEGMENT_")) {
+    throw new Error(`unsupported Flipt snapshot match type: ${type}`);
+  }
+  return type.replace("_SEGMENT_", "_");
+}
+
+function segmentDefinition(input: {
+  readonly key: string;
+  readonly matchType: string;
+  readonly constraints: ManagedFlag["rollouts"][number]["constraints"];
+}): DeclarativeSegment {
+  return {
+    key: input.key,
+    name: input.key,
+    description: `Managed segment ${input.key}.`,
+    constraints: input.constraints.map((constraint) => ({
+      type: declarativeConstraintType(constraint.type),
+      property: constraint.property,
+      operator: constraint.operator,
+      value: constraint.value,
+      description: `Match ${constraint.property}.`,
+    })),
+    match_type: declarativeMatchType(input.matchType),
+  };
+}
+
+function collectSegments(flags: readonly ManagedFlag[]): DeclarativeSegment[] {
+  const definitions = new Map<string, DeclarativeSegment>();
+  const addDefinition = (definition: DeclarativeSegment): void => {
+    const existing = definitions.get(definition.key);
+    if (
+      existing !== undefined &&
+      JSON.stringify(existing) !== JSON.stringify(definition)
+    ) {
+      throw new Error(
+        `conflicting managed segment definition: ${definition.key}`,
+      );
+    }
+    definitions.set(definition.key, definition);
+  };
+
+  for (const flag of flags) {
+    for (const rollout of flag.rollouts) {
+      addDefinition(
+        segmentDefinition({
+          key: rollout.segmentKey,
+          matchType: rollout.matchType,
+          constraints: rollout.constraints,
+        }),
+      );
+    }
+    for (const rule of flag.rules) {
+      for (const segment of rule.segments) {
+        addDefinition(
+          segmentDefinition({
+            key: segment.key,
+            matchType: segment.matchType,
+            constraints: segment.constraints,
+          }),
+        );
+      }
+    }
+  }
+
+  return [...definitions.values()].sort((left, right) =>
+    left.key.localeCompare(right.key),
+  );
+}
+
+function parseAttachment(attachment: string, variantKey: string): unknown {
+  try {
+    const value: unknown = JSON.parse(attachment);
+    return value;
+  } catch (error) {
+    throw new Error(`invalid attachment JSON for variant ${variantKey}`, {
+      cause: error,
+    });
+  }
+}
+
+function variantDefinitions(flag: Extract<ManagedFlag, { type: "variant" }>) {
+  const attachments = new Map<string, string>();
+  for (const rule of flag.rules) {
+    for (const distribution of rule.distributions) {
+      const existing = attachments.get(distribution.variantKey);
+      if (
+        existing !== undefined &&
+        existing !== distribution.variantAttachment
+      ) {
+        throw new Error(
+          `conflicting variant attachment: ${flag.key}/${distribution.variantKey}`,
+        );
+      }
+      attachments.set(distribution.variantKey, distribution.variantAttachment);
+    }
+  }
+
+  const keys = new Set<string>([flag.default, ...attachments.keys()]);
+  return [...keys]
+    .sort((left, right) => left.localeCompare(right))
+    .map((key) => ({
+      default: key === flag.default,
+      key,
+      name: key,
+      attachment: parseAttachment(attachments.get(key) ?? "{}", key),
+    }));
+}
+
+function declarativeRules(flag: ManagedFlag) {
+  const ranks = new Set<number>();
+  return [...flag.rules]
+    .sort((left, right) => left.rank - right.rank)
+    .map((rule) => {
+      if (ranks.has(rule.rank)) {
+        throw new Error(
+          `duplicate rule rank for ${flag.key}: ${rule.rank.toString()}`,
+        );
+      }
+      ranks.add(rule.rank);
+      return {
+        segment: {
+          keys: rule.segments.map((segment) => segment.key),
+          operator: rule.segmentOperator,
+        },
+        rank: rule.rank,
+        distributions: rule.distributions.map((distribution) => ({
+          variant: distribution.variantKey,
+          rollout: distribution.rollout,
+        })),
+      };
+    });
+}
+
+function declarativeBooleanRollouts(
+  flag: Extract<ManagedFlag, { type: "boolean" }>,
+) {
+  const thresholdByRank = new Map(
+    flag.thresholdRollouts.map((rollout) => [rollout.rank, rollout]),
+  );
+  if (thresholdByRank.size !== flag.thresholdRollouts.length) {
+    throw new Error(`duplicate threshold rollout rank for ${flag.key}`);
+  }
+
+  const segmentRollouts = flag.rollouts.map((rollout) => ({
+    description: `Managed segment rollout for ${rollout.segmentKey}.`,
+    segment: {
+      keys: [rollout.segmentKey],
+      operator: rollout.segmentOperator,
+      value: rollout.result,
+    },
+  }));
+  const total = segmentRollouts.length + thresholdByRank.size;
+  for (const rank of thresholdByRank.keys()) {
+    if (rank >= total) {
+      throw new Error(
+        `threshold rollout rank out of range for ${flag.key}: ${rank.toString()}`,
+      );
+    }
+  }
+
+  const rendered = [];
+  let segmentIndex = 0;
+  for (let rank = 0; rank < total; rank += 1) {
+    const threshold = thresholdByRank.get(rank);
+    if (threshold !== undefined) {
+      rendered.push({
+        description: `Managed threshold rollout at rank ${rank.toString()}.`,
+        threshold: {
+          percentage: threshold.percentage,
+          value: threshold.result,
+        },
+      });
+      continue;
+    }
+    const segment = segmentRollouts[segmentIndex];
+    if (segment === undefined) {
+      throw new Error(
+        `missing segment rollout for ${flag.key} at rank ${rank.toString()}`,
+      );
+    }
+    rendered.push(segment);
+    segmentIndex += 1;
+  }
+  return rendered;
+}
+
+function declarativeFlag(flag: ManagedFlag) {
+  const common = {
+    key: flag.key,
+    name: flag.key,
+    description: flag.purpose,
+    enabled: flag.type === "boolean" ? flag.default : true,
+    metadata: {
+      owner: flag.owner,
+      source: flag.source,
+      namespace: flag.namespace,
+    },
+  };
+  if (flag.type === "boolean") {
+    return {
+      ...common,
+      type: "BOOLEAN_FLAG_TYPE",
+      rollouts: declarativeBooleanRollouts(flag),
+    };
+  }
+  return {
+    ...common,
+    type: "VARIANT_FLAG_TYPE",
+    variants: variantDefinitions(flag),
+    rules: declarativeRules(flag),
+  };
+}
+
+function findNamespace(
+  inventory: ManagedFlagInventory,
+  namespaceKey: string,
+): ManagedNamespace {
+  const namespace = inventory.namespaces.find(
+    (candidate) => candidate.key === namespaceKey,
+  );
+  if (namespace === undefined)
+    throw new Error(`unknown managed namespace: ${namespaceKey}`);
+  return namespace;
+}
+
+export function renderFliptFeatures(
+  environmentKey: string,
+  namespaceKey: string,
+  inventory: ManagedFlagInventory = managedFlagInventory,
+): string {
+  const namespace = findNamespace(inventory, namespaceKey);
+  const flags = materializeManagedNamespaceEnvironment(
+    inventory,
+    environmentKey,
+    namespaceKey,
+  );
+  return YAML.stringify({
+    version: "1.6",
+    namespace: {
+      key: namespace.key,
+      name: namespace.name,
+      description: namespace.description,
+    },
+    flags: flags.map((flag) => declarativeFlag(flag)),
+    segments: collectSegments(flags),
+  });
+}

--- a/packages/feature-flags/src/managed-flag-drift.test.ts
+++ b/packages/feature-flags/src/managed-flag-drift.test.ts
@@ -62,7 +62,9 @@ function withFlags(flags: FliptSnapshot["flags"]): FliptSnapshot {
 
 describe("managed Flipt flag drift", () => {
   test("recognizes an aligned snapshot", () => {
-    expect(compareManagedFlagInventory(snapshot)).toEqual({
+    expect(
+      compareManagedFlagInventory(snapshot, managedFlagInventory.flags),
+    ).toEqual({
       missingInFlipt: [],
       undeclaredInInventory: [],
       contractMismatches: [],
@@ -74,6 +76,7 @@ describe("managed Flipt flag drift", () => {
     if (missing === undefined) throw new Error("aligned snapshot is empty");
     const result = compareManagedFlagInventory(
       withFlags(snapshot.flags.filter((flag) => flag.key !== missing)),
+      managedFlagInventory.flags,
     );
 
     expect(result.missingInFlipt).toEqual([missing]);
@@ -84,6 +87,7 @@ describe("managed Flipt flag drift", () => {
     const unexpected = { ...flagAt(0), key: "unexpected-test-flag" };
     const result = compareManagedFlagInventory(
       withFlags([...snapshot.flags, unexpected]),
+      managedFlagInventory.flags,
     );
 
     expect(result.missingInFlipt).toEqual([]);
@@ -99,6 +103,7 @@ describe("managed Flipt flag drift", () => {
         ...snapshot.flags.filter((flag) => flag.key !== missing),
         ...unexpectedKeys.map((key) => ({ ...flagAt(0), key })),
       ]),
+      managedFlagInventory.flags,
     );
 
     expect(result.missingInFlipt).toEqual([missing]);
@@ -113,6 +118,7 @@ describe("managed Flipt flag drift", () => {
     const changed = { ...flagAt(0), enabled: !flagAt(0).enabled };
     const result = compareManagedFlagInventory(
       withFlags([changed, ...snapshot.flags.slice(1)]),
+      managedFlagInventory.flags,
     );
 
     expect(result.missingInFlipt).toEqual([]);
@@ -151,6 +157,7 @@ describe("fetchFliptSnapshot", () => {
     await expect(
       fetchFliptSnapshot({
         url: "http://flipt.test",
+        namespace: "scout",
         environment: "default",
         fetcher: async () =>
           new Response("unavailable", {
@@ -165,6 +172,7 @@ describe("fetchFliptSnapshot", () => {
     await expect(
       fetchFliptSnapshot({
         url: "http://flipt.test",
+        namespace: "scout",
         environment: "default",
         fetcher: async () => {
           throw new Error("connection refused");
@@ -177,6 +185,7 @@ describe("fetchFliptSnapshot", () => {
     await expect(
       fetchFliptSnapshot({
         url: "http://flipt.test",
+        namespace: "scout",
         environment: "default",
         fetcher: async () =>
           Response.json({ flags: [{ key: "broken" }] }, { status: 200 }),

--- a/packages/feature-flags/src/managed-flag-drift.ts
+++ b/packages/feature-flags/src/managed-flag-drift.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
-import {
-  managedFlagInventory,
-  type ManagedFlag,
-} from "./managed-flag-inventory.ts";
+import type { ManagedFlag } from "./managed-flag-inventory.ts";
 
 const SegmentConstraintSchema = z.object({
   type: z.string().min(1),
@@ -78,7 +75,7 @@ export type FliptFetcher = (
 
 export type FetchFliptSnapshotOptions = {
   readonly url: string;
-  readonly namespace?: string;
+  readonly namespace: string;
   readonly environment: string;
   readonly fetcher?: FliptFetcher;
 };
@@ -194,7 +191,7 @@ function contractErrors(expected: ManagedFlag, actual: SnapshotFlag): string[] {
 
 export function compareManagedFlagInventory(
   snapshot: FliptSnapshot,
-  expectedFlags: readonly ManagedFlag[] = managedFlagInventory.flags,
+  expectedFlags: readonly ManagedFlag[],
 ): ManagedFlagDrift {
   const expectedByKey = new Map(expectedFlags.map((flag) => [flag.key, flag]));
   const actualByKey = new Map(snapshot.flags.map((flag) => [flag.key, flag]));
@@ -230,7 +227,7 @@ export function formatManagedFlagDrift(drift: ManagedFlagDrift): string[] {
 export async function fetchFliptSnapshot(
   options: FetchFliptSnapshotOptions,
 ): Promise<FliptSnapshot> {
-  const namespace = options.namespace ?? managedFlagInventory.namespace;
+  const namespace = options.namespace;
   const environment = options.environment;
   const url = `${options.url.replace(/\/$/u, "")}/internal/v1/evaluation/snapshot/namespace/${encodeURIComponent(namespace)}`;
   const fetcher: FliptFetcher =

--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -1,10 +1,42 @@
 {
-  "version": 2,
-  "namespace": "default",
+  "version": 3,
+  "namespaces": [
+    {
+      "key": "scout",
+      "name": "Scout",
+      "description": "Scout for League of Legends feature flags."
+    },
+    {
+      "key": "birmel",
+      "name": "Birmel",
+      "description": "Birmel feature flags."
+    },
+    {
+      "key": "streambot",
+      "name": "Streambot",
+      "description": "Discord Plays Pokemon streambot feature flags."
+    },
+    {
+      "key": "starlight-karma-bot",
+      "name": "Starlight Karma Bot",
+      "description": "Starlight Karma Bot feature flags."
+    },
+    {
+      "key": "trmnl-dashboard",
+      "name": "TRMNL Dashboard",
+      "description": "TRMNL dashboard feature flags."
+    },
+    {
+      "key": "temporal",
+      "name": "Temporal",
+      "description": "Shared Temporal platform feature flags."
+    }
+  ],
   "flags": [
     {
       "key": "ai_reports_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout AI report generation.",
       "type": "boolean",
@@ -31,6 +63,7 @@
     {
       "key": "ai_reports_unlimited",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Grant the beta user unlimited AI reports.",
       "type": "boolean",
@@ -57,6 +90,7 @@
     {
       "key": "ai_reviews_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout post-match AI reviews.",
       "type": "boolean",
@@ -83,6 +117,7 @@
     {
       "key": "betting_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable the Scout Bryan Bucks betting economy.",
       "type": "boolean",
@@ -109,6 +144,7 @@
     {
       "key": "betting_player_bet_outcome_dm_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Send players a direct message with their bet outcome.",
       "type": "boolean",
@@ -135,6 +171,7 @@
     {
       "key": "bucks_dares_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Bryan Bucks free-text dare bounties.",
       "type": "boolean",
@@ -161,6 +198,7 @@
     {
       "key": "dare_v2",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable funding ScoutQL-backed Bryan Bucks Dare v2 contracts.",
       "type": "boolean",
@@ -187,6 +225,7 @@
     {
       "key": "bucks_transfers_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable fee-bearing Bryan Bucks wallet transfers.",
       "type": "boolean",
@@ -213,6 +252,7 @@
     {
       "key": "scoutql_relational_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable relational and timeline ScoutQL sources.",
       "type": "boolean",
@@ -239,6 +279,7 @@
     {
       "key": "betting_settlement_dm_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Send betting settlement direct messages.",
       "type": "boolean",
@@ -265,6 +306,7 @@
     {
       "key": "competition_builder_v2_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout competition builder version two.",
       "type": "boolean",
@@ -291,6 +333,7 @@
     {
       "key": "custom_nights_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable the beta-only Scout custom-night Activity.",
       "type": "boolean",
@@ -317,6 +360,7 @@
     {
       "key": "debug",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout debug surfaces for the beta operator.",
       "type": "boolean",
@@ -343,6 +387,7 @@
     {
       "key": "initial_match_history_import_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable the initial Scout match-history import.",
       "type": "boolean",
@@ -354,6 +399,7 @@
     {
       "key": "scout-consumer-player-profiles-enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout consumer player profiles.",
       "type": "boolean",
@@ -365,6 +411,7 @@
     {
       "key": "tournament_lobbies_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout tournament lobbies.",
       "type": "boolean",
@@ -391,6 +438,7 @@
     {
       "key": "weekly_parlays_enabled",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-policy",
       "purpose": "Enable Scout weekly parlays.",
       "type": "boolean",
@@ -417,6 +465,7 @@
     {
       "key": "scout-betting-parlay-ai-model",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Select the Scout parlay AI model.",
       "type": "variant",
@@ -428,6 +477,7 @@
     {
       "key": "scout-bucks-ask-model",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Select the Scout Bryan Bucks ask model.",
       "type": "variant",
@@ -439,6 +489,7 @@
     {
       "key": "scout-explore-model",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Select the Scout Explore AI model.",
       "type": "variant",
@@ -450,6 +501,7 @@
     {
       "key": "scout-report-ai-model",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Select the Scout report AI model.",
       "type": "variant",
@@ -461,6 +513,7 @@
     {
       "key": "scout-tournament-api-mode",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Select the Scout tournament API mode.",
       "type": "variant",
@@ -472,6 +525,7 @@
     {
       "key": "scout-tournament-max-open-lobbies",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Bound the number of concurrently open Scout tournament lobbies.",
       "type": "variant",
@@ -481,8 +535,21 @@
       "thresholdRollouts": []
     },
     {
+      "key": "scout-temporal-call-graph-tracing",
+      "owner": "scout",
+      "namespace": "scout",
+      "source": "scout-dynamic",
+      "purpose": "Enable Temporal client call-graph tracing in the Scout backend on restart.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
       "key": "temporal-call-graph-tracing",
       "owner": "platform",
+      "namespace": "temporal",
       "source": "temporal-workers",
       "purpose": "Enable Temporal client, Workflow, and Activity call-graph tracing on worker restart.",
       "type": "boolean",
@@ -494,6 +561,7 @@
     {
       "key": "explore-guild-allowlist",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Select the Scout guilds allowed to use Explore.",
       "type": "variant",
@@ -505,6 +573,7 @@
     {
       "key": "llm-daily-token-budget",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Bound Scout daily LLM token usage.",
       "type": "variant",
@@ -516,6 +585,7 @@
     {
       "key": "llm-hourly-token-budget",
       "owner": "scout",
+      "namespace": "scout",
       "source": "scout-dynamic",
       "purpose": "Bound Scout hourly LLM token usage.",
       "type": "variant",
@@ -527,6 +597,7 @@
     {
       "key": "birmel-activity-tracking-enabled",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Enable Birmel activity tracking and role aggregation.",
       "type": "boolean",
@@ -538,6 +609,7 @@
     {
       "key": "birmel-agent-max-steps",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound Birmel agent steps.",
       "type": "variant",
@@ -549,6 +621,7 @@
     {
       "key": "birmel-agent-response-timeout-ms",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound Birmel agent response time.",
       "type": "variant",
@@ -560,6 +633,7 @@
     {
       "key": "birmel-agent-router-timeout-ms",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound Birmel agent router time.",
       "type": "variant",
@@ -571,6 +645,7 @@
     {
       "key": "birmel-birthdays-enabled",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Enable Birmel birthday announcements and roles.",
       "type": "boolean",
@@ -582,6 +657,7 @@
     {
       "key": "birmel-daily-posts-enabled",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Enable Birmel daily posts.",
       "type": "boolean",
@@ -593,6 +669,7 @@
     {
       "key": "birmel-elections-enabled",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Enable Birmel elections.",
       "type": "boolean",
@@ -604,6 +681,7 @@
     {
       "key": "birmel-llm-classifier-model",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Select the Birmel classifier model.",
       "type": "variant",
@@ -615,6 +693,7 @@
     {
       "key": "birmel-llm-embedding-model",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Select the Birmel embedding model.",
       "type": "variant",
@@ -626,6 +705,7 @@
     {
       "key": "birmel-llm-max-output-tokens",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound Birmel LLM output tokens.",
       "type": "variant",
@@ -637,6 +717,7 @@
     {
       "key": "birmel-llm-memory-model",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Select the Birmel memory model.",
       "type": "variant",
@@ -648,6 +729,7 @@
     {
       "key": "birmel-llm-model",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Select the Birmel primary LLM model.",
       "type": "variant",
@@ -659,6 +741,7 @@
     {
       "key": "birmel-llm-reasoning-effort",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Select Birmel reasoning effort.",
       "type": "variant",
@@ -670,6 +753,7 @@
     {
       "key": "birmel-persona-enabled",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Enable Birmel persona projection.",
       "type": "boolean",
@@ -681,6 +765,7 @@
     {
       "key": "birmel-persona-style-model",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Select the Birmel persona style model.",
       "type": "variant",
@@ -692,6 +777,7 @@
     {
       "key": "birmel-responder-enabled",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Enable the Birmel conversational responder.",
       "type": "boolean",
@@ -703,6 +789,7 @@
     {
       "key": "birmel-responder-engagement-window-ms",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound the Birmel responder engagement window.",
       "type": "variant",
@@ -714,6 +801,7 @@
     {
       "key": "birmel-responder-transcript-max-messages",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound Birmel responder transcript messages.",
       "type": "variant",
@@ -725,6 +813,7 @@
     {
       "key": "birmel-responder-transcript-window-ms",
       "owner": "birmel",
+      "namespace": "birmel",
       "source": "birmel-dynamic",
       "purpose": "Bound the Birmel responder transcript window.",
       "type": "variant",
@@ -736,6 +825,7 @@
     {
       "key": "karma-admin-user-id",
       "owner": "starlight-karma-bot",
+      "namespace": "starlight-karma-bot",
       "source": "karma-dynamic",
       "purpose": "Select the Karma administrator user.",
       "type": "variant",
@@ -747,6 +837,7 @@
     {
       "key": "karma-emoji",
       "owner": "starlight-karma-bot",
+      "namespace": "starlight-karma-bot",
       "source": "karma-dynamic",
       "purpose": "Select the emoji that awards karma.",
       "type": "variant",
@@ -758,6 +849,7 @@
     {
       "key": "player-card-enabled",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Enable Streambot player cards.",
       "type": "boolean",
@@ -769,6 +861,7 @@
     {
       "key": "pet-dashboard-enabled",
       "owner": "trmnl-dashboard",
+      "namespace": "trmnl-dashboard",
       "source": "trmnl-dashboard",
       "purpose": "Expose the authenticated pet-care TRMNL dashboard payload after deployment verification.",
       "type": "boolean",
@@ -780,6 +873,7 @@
     {
       "key": "streambot-idle-timeout-seconds",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Bound Streambot idle timeout.",
       "type": "variant",
@@ -791,6 +885,7 @@
     {
       "key": "streambot-player-card-repost-after-messages",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Set Streambot player-card repost interval.",
       "type": "variant",
@@ -802,6 +897,7 @@
     {
       "key": "streambot-player-card-tick-ms",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Set Streambot player-card refresh interval.",
       "type": "variant",
@@ -813,6 +909,7 @@
     {
       "key": "streambot-playlist-limit",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Bound the Streambot playlist.",
       "type": "variant",
@@ -824,6 +921,7 @@
     {
       "key": "streambot-reconnect-delay-seconds",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Set Streambot reconnect delay.",
       "type": "variant",
@@ -835,6 +933,7 @@
     {
       "key": "streambot-reconnect-enabled",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Enable Streambot reconnects after transient voice disconnects.",
       "type": "boolean",
@@ -846,6 +945,7 @@
     {
       "key": "streambot-reconnect-max-attempts",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Bound Streambot reconnect attempts.",
       "type": "variant",
@@ -857,6 +957,7 @@
     {
       "key": "streambot-subtitle-languages",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Select Streambot subtitle languages.",
       "type": "variant",
@@ -868,6 +969,7 @@
     {
       "key": "streambot-subtitles-include-auto-generated",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Use auto-generated captions when human subtitles are unavailable.",
       "type": "boolean",
@@ -879,6 +981,7 @@
     {
       "key": "subtitles-enabled",
       "owner": "streambot",
+      "namespace": "streambot",
       "source": "streambot-dynamic",
       "purpose": "Enable Streambot subtitles.",
       "type": "boolean",

--- a/packages/feature-flags/src/managed-flag-inventory.schema.json
+++ b/packages/feature-flags/src/managed-flag-inventory.schema.json
@@ -119,10 +119,11 @@
         { "$ref": "#/$defs/behavior" },
         {
           "type": "object",
-          "required": ["key", "owner", "source", "purpose"],
+          "required": ["key", "owner", "namespace", "source", "purpose"],
           "properties": {
             "key": { "type": "string", "minLength": 1 },
             "owner": { "type": "string", "minLength": 1 },
+            "namespace": { "type": "string", "minLength": 1 },
             "source": { "type": "string", "minLength": 1 },
             "purpose": { "type": "string", "minLength": 1 }
           }
@@ -132,10 +133,23 @@
     }
   },
   "type": "object",
-  "required": ["version", "namespace", "environments", "flags", "exemptions"],
+  "required": ["version", "namespaces", "environments", "flags", "exemptions"],
   "properties": {
-    "version": { "const": 2 },
-    "namespace": { "type": "string", "minLength": 1 },
+    "version": { "const": 3 },
+    "namespaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["key", "name", "description"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
     "environments": {
       "type": "array",
       "minItems": 1,

--- a/packages/feature-flags/src/managed-flag-inventory.test.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.test.ts
@@ -2,13 +2,20 @@ import { describe, expect, test } from "vitest";
 import {
   ManagedFlagInventorySchema,
   managedFlagInventory,
-  materializeManagedEnvironment,
+  managedFlagNamespaces,
+  materializeManagedNamespaceEnvironment,
 } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 
 function inventory(overrides: unknown[] = []) {
   return {
-    version: 2,
-    namespace: "default",
+    version: 3,
+    namespaces: [
+      {
+        key: "test",
+        name: "Test",
+        description: "Test namespace.",
+      },
+    ],
     environments: [
       { key: "beta", overrides },
       { key: "prod", overrides: [] },
@@ -17,6 +24,7 @@ function inventory(overrides: unknown[] = []) {
       {
         key: "example",
         owner: "test",
+        namespace: "test",
         source: "test",
         purpose: "Exercise environment overrides.",
         type: "variant",
@@ -40,9 +48,11 @@ const fullOverride = {
 };
 
 function exploreModel(environment: string) {
-  return materializeManagedEnvironment(managedFlagInventory, environment).find(
-    (flag) => flag.key === "scout-explore-model",
-  )?.default;
+  return materializeManagedNamespaceEnvironment(
+    managedFlagInventory,
+    environment,
+    "scout",
+  ).find((flag) => flag.key === "scout-explore-model")?.default;
 }
 
 describe("ManagedFlagInventorySchema", () => {
@@ -50,18 +60,73 @@ describe("ManagedFlagInventorySchema", () => {
     expect(exploreModel("beta")).toBe("gpt-5.6-luna");
     expect(exploreModel("prod")).toBe("gpt-5.6-luna");
     expect(() =>
-      materializeManagedEnvironment(managedFlagInventory, "default"),
+      materializeManagedNamespaceEnvironment(
+        managedFlagInventory,
+        "default",
+        "scout",
+      ),
     ).toThrow(/unknown managed environment/);
+    expect(managedFlagNamespaces).toEqual([
+      "scout",
+      "birmel",
+      "streambot",
+      "starlight-karma-bot",
+      "trmnl-dashboard",
+      "temporal",
+    ]);
+    expect(
+      materializeManagedNamespaceEnvironment(
+        managedFlagInventory,
+        "prod",
+        "scout",
+      ).map((flag) => flag.key),
+    ).toContain("scout-temporal-call-graph-tracing");
+    expect(
+      materializeManagedNamespaceEnvironment(
+        managedFlagInventory,
+        "prod",
+        "temporal",
+      ).map((flag) => flag.key),
+    ).toContain("temporal-call-graph-tracing");
   });
 
   test("materializes a full-state environment override", () => {
     const parsed = ManagedFlagInventorySchema.parse(inventory([fullOverride]));
-    expect(materializeManagedEnvironment(parsed, "beta")[0]?.default).toBe(
-      "luna",
-    );
-    expect(materializeManagedEnvironment(parsed, "prod")[0]?.default).toBe(
-      "sol",
-    );
+    expect(
+      materializeManagedNamespaceEnvironment(parsed, "beta", "test")[0]
+        ?.default,
+    ).toBe("luna");
+    expect(
+      materializeManagedNamespaceEnvironment(parsed, "prod", "test")[0]
+        ?.default,
+    ).toBe("sol");
+    expect(() =>
+      materializeManagedNamespaceEnvironment(parsed, "prod", "unknown"),
+    ).toThrow(/unknown managed namespace/);
+  });
+
+  test("rejects duplicate, unknown, and empty namespaces", () => {
+    const duplicate = inventory();
+    duplicate.namespaces.push({
+      key: "test",
+      name: "Duplicate",
+      description: "Duplicate namespace.",
+    });
+    expect(ManagedFlagInventorySchema.safeParse(duplicate).success).toBe(false);
+
+    const unknown = inventory();
+    const unknownFlag = unknown.flags[0];
+    if (unknownFlag === undefined) throw new Error("test inventory is empty");
+    unknownFlag.namespace = "unknown";
+    expect(ManagedFlagInventorySchema.safeParse(unknown).success).toBe(false);
+
+    const empty = inventory();
+    empty.namespaces.push({
+      key: "empty",
+      name: "Empty",
+      description: "Empty namespace.",
+    });
+    expect(ManagedFlagInventorySchema.safeParse(empty).success).toBe(false);
   });
 
   test("rejects duplicate environments", () => {

--- a/packages/feature-flags/src/managed-flag-inventory.ts
+++ b/packages/feature-flags/src/managed-flag-inventory.ts
@@ -52,6 +52,7 @@ const ManagedFlagBehaviorFields = {
 const ManagedFlagMetadataFields = {
   key: z.string().min(1),
   owner: z.string().min(1),
+  namespace: z.string().min(1),
   source: z.string().min(1),
   purpose: z.string().min(1),
 };
@@ -91,9 +92,15 @@ const ManagedEnvironmentSchema = z.object({
   overrides: z.array(ManagedFlagOverrideSchema),
 });
 
+const ManagedNamespaceSchema = z.object({
+  key: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+});
+
 const ManagedFlagInventoryBaseSchema = z.object({
-  version: z.literal(2),
-  namespace: z.string().min(1),
+  version: z.literal(3),
+  namespaces: z.array(ManagedNamespaceSchema).min(1),
   environments: z.array(ManagedEnvironmentSchema).min(1),
   flags: z.array(ManagedFlagSchema).min(1),
   exemptions: z.array(
@@ -105,101 +112,201 @@ const ManagedFlagInventoryBaseSchema = z.object({
   ),
 });
 
-export const ManagedFlagInventorySchema =
-  ManagedFlagInventoryBaseSchema.superRefine((value, context) => {
-    const flagsByKey = new Map(value.flags.map((flag) => [flag.key, flag]));
-    if (flagsByKey.size !== value.flags.length) {
+type ManagedFlagInventoryValue = z.infer<typeof ManagedFlagInventoryBaseSchema>;
+type InventoryRefinementContext =
+  z.core.$RefinementCtx<ManagedFlagInventoryValue>;
+
+function validateNamespaces(
+  value: ManagedFlagInventoryValue,
+  context: InventoryRefinementContext,
+): Set<string> {
+  const namespaceKeys = new Set<string>();
+  for (const [namespaceIndex, namespace] of value.namespaces.entries()) {
+    if (namespaceKeys.has(namespace.key)) {
       context.addIssue({
         code: "custom",
-        message: "duplicate managed flag key",
-        path: ["flags"],
+        message: `duplicate managed namespace: ${namespace.key}`,
+        path: ["namespaces", namespaceIndex, "key"],
       });
     }
+    namespaceKeys.add(namespace.key);
+  }
+  return namespaceKeys;
+}
 
-    const environmentKeys = new Set<string>();
-    for (const [
-      environmentIndex,
-      environment,
-    ] of value.environments.entries()) {
-      if (environmentKeys.has(environment.key)) {
+function flagSegments(flag: ManagedFlagInventoryValue["flags"][number]) {
+  return [
+    ...flag.rollouts.map((rollout) => ({
+      key: rollout.segmentKey,
+      matchType: rollout.matchType,
+      constraints: rollout.constraints,
+    })),
+    ...flag.rules.flatMap((rule) => rule.segments),
+  ];
+}
+
+function validateFlags(
+  value: ManagedFlagInventoryValue,
+  namespaceKeys: ReadonlySet<string>,
+  context: InventoryRefinementContext,
+): Map<string, ManagedFlagInventoryValue["flags"][number]> {
+  const flagsByKey = new Map(value.flags.map((flag) => [flag.key, flag]));
+  if (flagsByKey.size !== value.flags.length) {
+    context.addIssue({
+      code: "custom",
+      message: "duplicate managed flag key",
+      path: ["flags"],
+    });
+  }
+
+  const namespacesWithFlags = new Set<string>();
+  const segmentDefinitions = new Map<string, string>();
+  for (const [flagIndex, flag] of value.flags.entries()) {
+    if (!namespaceKeys.has(flag.namespace)) {
+      context.addIssue({
+        code: "custom",
+        message: `unknown managed namespace: ${flag.namespace}`,
+        path: ["flags", flagIndex, "namespace"],
+      });
+    }
+    namespacesWithFlags.add(flag.namespace);
+    for (const segment of flagSegments(flag)) {
+      const identity = `${flag.namespace}/${segment.key}`;
+      const definition = JSON.stringify({
+        matchType: segment.matchType,
+        constraints: segment.constraints,
+      });
+      const existing = segmentDefinitions.get(identity);
+      if (existing !== undefined && existing !== definition) {
         context.addIssue({
           code: "custom",
-          message: `duplicate managed environment: ${environment.key}`,
-          path: ["environments", environmentIndex, "key"],
+          message: `conflicting managed segment definition: ${identity}`,
+          path: ["flags", flagIndex],
         });
       }
-      environmentKeys.add(environment.key);
+      segmentDefinitions.set(identity, definition);
+    }
+  }
+  for (const [namespaceIndex, namespace] of value.namespaces.entries()) {
+    if (!namespacesWithFlags.has(namespace.key)) {
+      context.addIssue({
+        code: "custom",
+        message: `managed namespace has no flags: ${namespace.key}`,
+        path: ["namespaces", namespaceIndex, "key"],
+      });
+    }
+  }
+  return flagsByKey;
+}
 
-      const overrideKeys = new Set<string>();
-      for (const [overrideIndex, override] of environment.overrides.entries()) {
-        const path = [
-          "environments",
-          environmentIndex,
-          "overrides",
-          overrideIndex,
-          "key",
-        ];
-        if (overrideKeys.has(override.key)) {
-          context.addIssue({
-            code: "custom",
-            message: `duplicate override key: ${override.key}`,
-            path,
-          });
-        }
-        overrideKeys.add(override.key);
+function validateEnvironments(
+  value: ManagedFlagInventoryValue,
+  flagsByKey: ReadonlyMap<string, ManagedFlagInventoryValue["flags"][number]>,
+  context: InventoryRefinementContext,
+): void {
+  const environmentKeys = new Set<string>();
+  for (const [environmentIndex, environment] of value.environments.entries()) {
+    if (environmentKeys.has(environment.key)) {
+      context.addIssue({
+        code: "custom",
+        message: `duplicate managed environment: ${environment.key}`,
+        path: ["environments", environmentIndex, "key"],
+      });
+    }
+    environmentKeys.add(environment.key);
 
-        const baseline = flagsByKey.get(override.key);
-        if (baseline === undefined) {
-          context.addIssue({
-            code: "custom",
-            message: `unknown override key: ${override.key}`,
-            path,
-          });
-        } else if (baseline.type !== override.type) {
-          context.addIssue({
-            code: "custom",
-            message: `override type mismatch for ${override.key}: expected ${baseline.type}, got ${override.type}`,
-            path: [
-              "environments",
-              environmentIndex,
-              "overrides",
-              overrideIndex,
-              "type",
-            ],
-          });
-        }
+    const overrideKeys = new Set<string>();
+    for (const [overrideIndex, override] of environment.overrides.entries()) {
+      const path = [
+        "environments",
+        environmentIndex,
+        "overrides",
+        overrideIndex,
+        "key",
+      ];
+      if (overrideKeys.has(override.key)) {
+        context.addIssue({
+          code: "custom",
+          message: `duplicate override key: ${override.key}`,
+          path,
+        });
+      }
+      overrideKeys.add(override.key);
+
+      const baseline = flagsByKey.get(override.key);
+      if (baseline === undefined) {
+        context.addIssue({
+          code: "custom",
+          message: `unknown override key: ${override.key}`,
+          path,
+        });
+      } else if (baseline.type !== override.type) {
+        context.addIssue({
+          code: "custom",
+          message: `override type mismatch for ${override.key}: expected ${baseline.type}, got ${override.type}`,
+          path: [
+            "environments",
+            environmentIndex,
+            "overrides",
+            overrideIndex,
+            "type",
+          ],
+        });
       }
     }
+  }
+}
+
+export const ManagedFlagInventorySchema =
+  ManagedFlagInventoryBaseSchema.superRefine((value, context) => {
+    const namespaceKeys = validateNamespaces(value, context);
+    const flagsByKey = validateFlags(value, namespaceKeys, context);
+    validateEnvironments(value, flagsByKey, context);
   });
 
 export type ManagedFlag = z.infer<typeof ManagedFlagSchema>;
 export type ManagedEnvironment = z.infer<typeof ManagedEnvironmentSchema>;
+export type ManagedNamespace = z.infer<typeof ManagedNamespaceSchema>;
+export type ManagedFlagInventory = ManagedFlagInventoryValue;
 
-export function materializeManagedEnvironment(
-  inventoryValue: z.infer<typeof ManagedFlagInventoryBaseSchema>,
+export function materializeManagedNamespaceEnvironment(
+  inventoryValue: ManagedFlagInventory,
   environmentKey: string,
+  namespaceKey: string,
 ): ManagedFlag[] {
   const environment = inventoryValue.environments.find(
     (candidate) => candidate.key === environmentKey,
   );
   if (environment === undefined)
     throw new Error(`unknown managed environment: ${environmentKey}`);
+  if (
+    !inventoryValue.namespaces.some(
+      (namespace) => namespace.key === namespaceKey,
+    )
+  )
+    throw new Error(`unknown managed namespace: ${namespaceKey}`);
 
   const overridesByKey = new Map(
     environment.overrides.map((override) => [override.key, override]),
   );
-  return inventoryValue.flags.map((flag) => {
-    const override = overridesByKey.get(flag.key);
-    if (override === undefined) return flag;
-    if (flag.type === "boolean" && override.type === "boolean")
-      return { ...flag, ...override };
-    if (flag.type === "variant" && override.type === "variant")
-      return { ...flag, ...override };
-    throw new Error(`override type mismatch for ${flag.key}`);
-  });
+  return inventoryValue.flags
+    .map((flag) => {
+      const override = overridesByKey.get(flag.key);
+      if (override === undefined) return flag;
+      if (flag.type === "boolean" && override.type === "boolean")
+        return { ...flag, ...override };
+      if (flag.type === "variant" && override.type === "variant")
+        return { ...flag, ...override };
+      throw new Error(`override type mismatch for ${flag.key}`);
+    })
+    .filter((flag) => flag.namespace === namespaceKey);
 }
 
 export const managedFlagInventory = ManagedFlagInventorySchema.parse(inventory);
+
+export const managedFlagNamespaces = managedFlagInventory.namespaces.map(
+  (namespace) => namespace.key,
+);
 
 export const managedFlagNames = managedFlagInventory.flags.map(
   (flag) => flag.key,

--- a/packages/homelab/src/cdk8s/package.json
+++ b/packages/homelab/src/cdk8s/package.json
@@ -40,6 +40,7 @@
     "ts-pattern": "^5.9.0",
     "zod": "^4.4.3",
     "@shepherdjerred/helm-types": "workspace:*",
+    "@shepherdjerred/feature-flags": "workspace:*",
     "@shepherdjerred/version-catalog": "workspace:*",
     "@grafana/grafana-foundation-sdk": "11.6.0-cogv0.0.x.1769699379"
   },

--- a/packages/homelab/src/cdk8s/src/feature-flag-environments.test.ts
+++ b/packages/homelab/src/cdk8s/src/feature-flag-environments.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "vitest";
-import { App, Testing } from "cdk8s";
+import { App, Chart, Testing } from "cdk8s";
 import { z } from "zod";
 import { createBirmelChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/birmel.ts";
 import { createMediaChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/media.ts";
 import { createScoutChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/scout.ts";
 import { createStarlightKarmaBotChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/starlight-karma-bot.ts";
+import { createTemporalChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/temporal.ts";
+import { createTrmnlDashboardChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/trmnl-dashboard.ts";
+import { createBuildkiteApp } from "@shepherdjerred/homelab/cdk8s/src/resources/argo-applications/buildkite.ts";
 
 const ManifestSchema = z
   .object({
@@ -35,7 +38,13 @@ const ManifestSchema = z
 
 async function fliptConsumers(
   createChart: (app: App) => void | Promise<void>,
-): Promise<{ name: string; environment: string | undefined }[]> {
+): Promise<
+  {
+    name: string;
+    environment: string | undefined;
+    namespace: string | undefined;
+  }[]
+> {
   const app = new App();
   await createChart(app);
   return app.charts.flatMap((chart) =>
@@ -55,6 +64,7 @@ async function fliptConsumers(
               {
                 name: parsed.data.metadata.name,
                 environment: env.get("FLIPT_ENVIRONMENT"),
+                namespace: env.get("FLIPT_NAMESPACE"),
               },
             ];
           },
@@ -64,29 +74,86 @@ async function fliptConsumers(
 }
 
 describe("Flipt consumer environments", () => {
-  const cases: [string, string, (app: App) => void | Promise<void>][] = [
-    ["Scout beta", "beta", (app: App) => createScoutChart(app, "beta")],
-    ["Scout prod", "prod", (app: App) => createScoutChart(app, "prod")],
-    [
-      "Karma beta",
-      "beta",
-      (app: App) => createStarlightKarmaBotChart(app, "beta"),
-    ],
-    [
-      "Karma prod",
-      "prod",
-      (app: App) => createStarlightKarmaBotChart(app, "prod"),
-    ],
-    ["Birmel", "prod", (app: App) => createBirmelChart(app)],
-    ["Streambot", "prod", (app: App) => createMediaChart(app)],
+  const cases = [
+    {
+      name: "Scout beta",
+      environment: "beta",
+      namespace: "scout",
+      count: 1,
+      createChart: (app: App) => createScoutChart(app, "beta"),
+    },
+    {
+      name: "Scout prod",
+      environment: "prod",
+      namespace: "scout",
+      count: 1,
+      createChart: (app: App) => createScoutChart(app, "prod"),
+    },
+    {
+      name: "Karma beta",
+      environment: "beta",
+      namespace: "starlight-karma-bot",
+      count: 1,
+      createChart: (app: App) => createStarlightKarmaBotChart(app, "beta"),
+    },
+    {
+      name: "Karma prod",
+      environment: "prod",
+      namespace: "starlight-karma-bot",
+      count: 1,
+      createChart: (app: App) => createStarlightKarmaBotChart(app, "prod"),
+    },
+    {
+      name: "Birmel",
+      environment: "prod",
+      namespace: "birmel",
+      count: 1,
+      createChart: (app: App) => createBirmelChart(app),
+    },
+    {
+      name: "Streambot",
+      environment: "prod",
+      namespace: "streambot",
+      count: 1,
+      createChart: (app: App) => createMediaChart(app),
+    },
+    {
+      name: "TRMNL dashboard",
+      environment: "prod",
+      namespace: "trmnl-dashboard",
+      count: 1,
+      createChart: (app: App) => createTrmnlDashboardChart(app),
+    },
+    {
+      name: "Temporal",
+      environment: "prod",
+      namespace: "temporal",
+      count: 12,
+      createChart: (app: App) => createTemporalChart(app),
+    },
+    {
+      name: "Buildkite maintenance",
+      environment: "prod",
+      namespace: "temporal",
+      count: 1,
+      createChart: (app: App) => {
+        const chart = new Chart(app, "buildkite-feature-flags", {
+          disableResourceNameHashes: true,
+        });
+        createBuildkiteApp(chart);
+      },
+    },
   ];
 
   test.each(cases)(
-    "sets %s to %s",
-    async (_name, expectedEnvironment, createChart) => {
+    "sets $name to $environment/$namespace",
+    async ({ environment, namespace, count, createChart }) => {
       const consumers = await fliptConsumers(createChart);
-      expect(consumers).toHaveLength(1);
-      expect(consumers[0]?.environment).toBe(expectedEnvironment);
+      expect(consumers).toHaveLength(count);
+      for (const consumer of consumers) {
+        expect(consumer.environment).toBe(environment);
+        expect(consumer.namespace).toBe(namespace);
+      }
     },
   );
 });

--- a/packages/homelab/src/cdk8s/src/flipt-application-order.test.ts
+++ b/packages/homelab/src/cdk8s/src/flipt-application-order.test.ts
@@ -1,0 +1,37 @@
+import { App, Chart, Testing } from "cdk8s";
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { createFliptApp } from "./resources/argo-applications/flipt.ts";
+import { createTemporalApp } from "./resources/argo-applications/temporal.ts";
+
+const ApplicationSchema = z.object({
+  metadata: z.object({
+    name: z.string(),
+    annotations: z.record(z.string(), z.string()),
+  }),
+});
+
+describe("Flipt application ordering", () => {
+  test("places Flipt before Temporal", () => {
+    const app = new App();
+    const chart = new Chart(app, "applications", {
+      disableResourceNameHashes: true,
+    });
+    createFliptApp(chart);
+    createTemporalApp(chart);
+
+    const applications = z.array(ApplicationSchema).parse(Testing.synth(chart));
+    const waves = new Map(
+      applications.map((application) => [
+        application.metadata.name,
+        Number(
+          application.metadata.annotations["argocd.argoproj.io/sync-wave"],
+        ),
+      ]),
+    );
+
+    expect(waves.get("flipt")).toBe(-2);
+    expect(waves.get("temporal")).toBe(-1);
+    expect(waves.get("flipt")).toBeLessThan(waves.get("temporal") ?? -1);
+  });
+});

--- a/packages/homelab/src/cdk8s/src/resources/argo-applications/flipt.ts
+++ b/packages/homelab/src/cdk8s/src/resources/argo-applications/flipt.ts
@@ -3,7 +3,10 @@ import { Application } from "@shepherdjerred/homelab/cdk8s/generated/imports/arg
 
 export function createFliptApp(chart: Chart) {
   return new Application(chart, "flipt-app", {
-    metadata: { name: "flipt" },
+    metadata: {
+      name: "flipt",
+      annotations: { "argocd.argoproj.io/sync-wave": "-2" },
+    },
     spec: {
       revisionHistoryLimit: 5,
       project: "default",

--- a/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/birmel/index.ts
@@ -145,6 +145,7 @@ export function createBirmelDeployment(chart: Chart) {
         // Bootstrap for the flag client — these cannot come from a flag.
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
         FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
+        FLIPT_NAMESPACE: EnvValue.fromValue("birmel"),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { App } from "cdk8s";
 import { z } from "zod";
 import { createFliptChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/flipt.ts";
-import { createEnvironmentValidationScript } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
+import { createEnvironmentInitializationScript } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
 
 const ManifestSchema = z
   .object({
@@ -77,11 +77,6 @@ function findManifest(
   return manifest;
 }
 
-async function run(command: string[]): Promise<number> {
-  const subprocess = Bun.spawn(command, { stdout: "ignore", stderr: "ignore" });
-  return subprocess.exited;
-}
-
 describe("Flipt chart", () => {
   it("emits the namespace, deployment, config, storage, service, and policy resources", () => {
     const manifests = synthesize();
@@ -95,6 +90,7 @@ describe("Flipt chart", () => {
     expect(names).toContain("Namespace/flipt");
     expect(names).toContain("Deployment/flipt");
     expect(names).toContain("ConfigMap/flipt-flipt-config");
+    expect(names).toContain("ConfigMap/flipt-flipt-seed");
     expect(names).toContain("PersistentVolumeClaim/flipt-data");
     expect(names).toContain("Service/flipt-flipt-service");
     expect(names).toContain("NetworkPolicy/flipt-ingress-netpol");
@@ -141,8 +137,10 @@ describe("Flipt chart", () => {
     expect(yaml).toContain('version: "2.0"');
     expect(yaml).toContain("type: local");
     expect(yaml).not.toContain("path: /var/opt/flipt/data\n");
-    expect(yaml).toContain("path: /var/opt/flipt/data-beta");
-    expect(yaml).toContain("path: /var/opt/flipt/data-prod");
+    expect(yaml).not.toContain("path: /var/opt/flipt/data-beta");
+    expect(yaml).not.toContain("path: /var/opt/flipt/data-prod");
+    expect(yaml).toContain("path: /var/opt/flipt/environments/beta");
+    expect(yaml).toContain("path: /var/opt/flipt/environments/prod");
     expect(yaml).toContain("name: beta");
     expect(yaml).toContain("name: prod");
     expect(yaml).toMatch(/prod:\n {4}name: prod\n {4}default: true/);
@@ -160,52 +158,66 @@ describe("Flipt chart", () => {
     ).toMatch(/^[a-f\d]{12}$/);
   });
 
-  it("validates beta and prod without referencing the legacy repository", () => {
+  it("validates and initializes both environments without overwriting repositories", () => {
     const deployment = DeploymentSchema.parse(
       findManifest(synthesize(), "Deployment", "flipt"),
     );
-    const validator = deployment.spec.template.spec.initContainers.find(
-      (container) => container.name === "validate-environments",
+    const initializer = deployment.spec.template.spec.initContainers.find(
+      (container) => container.name === "initialize-environments",
     );
-    expect(validator?.command).toEqual(["/bin/sh", "-c"]);
-    const script = validator?.args?.[0] ?? "";
-    expect(script).toContain('validate_repo "/var/opt/flipt/data-beta"');
-    expect(script).toContain('validate_repo "/var/opt/flipt/data-prod"');
-    expect(script).not.toContain("cp -a");
-    expect(script).not.toContain('validate_repo "/var/opt/flipt/data"');
-    expect(validator?.volumeMounts?.map((mount) => mount.mountPath)).toContain(
-      "/var/opt/flipt",
+    expect(initializer?.command).toEqual(["/bin/sh", "-c"]);
+    const script = initializer?.args?.[0] ?? "";
+    expect(script).toContain('/flipt validate --work-dir "$seed"');
+    expect(script).toContain('repo="/var/opt/flipt/environments/$environment"');
+    expect(script).toContain(
+      'cp "/etc/flipt-seed/beta.scout.yaml" "$work_root/beta/scout/features.yaml"',
+    );
+    expect(script).toContain('if [ ! -e "$repo" ]');
+    expect(script).not.toContain("data-beta");
+    expect(script).not.toContain("data-prod");
+    expect(initializer?.volumeMounts?.map((mount) => mount.mountPath)).toEqual(
+      expect.arrayContaining(["/var/opt/flipt", "/etc/flipt-seed", "/tmp"]),
     );
   });
 
-  it("fails fast for missing or partial managed repositories", async () => {
-    const root = `/tmp/flipt-validation-test-${crypto.randomUUID()}`;
-    expect(await run(["mkdir", "-p", root])).toBe(0);
-    expect(
-      await run(["/bin/sh", "-c", createEnvironmentValidationScript(root)]),
-    ).not.toBe(0);
+  it("seeds every product namespace into both environments", () => {
+    const seed = ConfigMapSchema.parse(
+      findManifest(synthesize(), "ConfigMap", "flipt-flipt-seed"),
+    );
+    expect(Object.keys(seed.data).toSorted()).toEqual(
+      ["beta", "prod"]
+        .flatMap((environment) =>
+          [
+            "scout",
+            "birmel",
+            "streambot",
+            "starlight-karma-bot",
+            "trmnl-dashboard",
+            "temporal",
+          ].map((namespace) => `${environment}.${namespace}.yaml`),
+        )
+        .toSorted(),
+    );
+    for (const [filename, yaml] of Object.entries(seed.data)) {
+      const namespace = filename.split(".")[1];
+      if (namespace === undefined) {
+        throw new Error(`seed filename has no namespace: ${filename}`);
+      }
+      expect(yaml).toContain(`key: ${namespace}`);
+      expect(yaml).not.toContain("key: default");
+    }
+  });
 
-    expect(
-      await run([
-        "mkdir",
-        "-p",
-        `${root}/data-beta/objects`,
-        `${root}/data-prod`,
-      ]),
-    ).toBe(0);
-    await Bun.write(`${root}/data-beta/HEAD`, "ref: refs/heads/main\n");
-    await Bun.write(`${root}/data-beta/config`, "[core]\n\tbare = true\n");
-    expect(
-      await run(["/bin/sh", "-c", createEnvironmentValidationScript(root)]),
-    ).not.toBe(0);
-
-    expect(await run(["mkdir", "-p", `${root}/data-prod/objects`])).toBe(0);
-    await Bun.write(`${root}/data-prod/HEAD`, "ref: refs/heads/main\n");
-    await Bun.write(`${root}/data-prod/config`, "[core]\n\tbare = true\n");
-    expect(
-      await run(["/bin/sh", "-c", createEnvironmentValidationScript(root)]),
-    ).toBe(0);
-    expect(await run(["rm", "-rf", root])).toBe(0);
+  it("generates a fail-fast initialization script", () => {
+    const script = createEnvironmentInitializationScript("/data", ["scout"]);
+    expect(script).toContain('validate_repo "$repo"');
+    expect(script).toContain('/flipt validate --work-dir "$repo"');
+    expect(script).toContain('repo="/data/environments/$environment"');
+    expect(script).toContain(
+      'cp "/etc/flipt-seed/prod.scout.yaml" "$work_root/prod/scout/features.yaml"',
+    );
+    expect(script).not.toContain("data-beta");
+    expect(script).not.toContain("data-prod");
   });
 
   it("restricts egress to DNS only", () => {

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
@@ -20,6 +20,11 @@ import { createServiceMonitor } from "@shepherdjerred/homelab/cdk8s/src/misc/ser
 import { TailscaleIngress } from "@shepherdjerred/homelab/cdk8s/src/misc/tailscale.ts";
 import { ZfsNvmeVolume } from "@shepherdjerred/homelab/cdk8s/src/misc/zfs-nvme-volume.ts";
 import versions from "@shepherdjerred/homelab/cdk8s/src/versions.ts";
+import { renderFliptFeatures } from "@shepherdjerred/feature-flags/flipt-features-renderer.ts";
+import {
+  managedFlagInventory,
+  managedFlagNamespaces,
+} from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 
 export const FLIPT_PORT = 8080;
 
@@ -40,6 +45,16 @@ const FLIPT_UID = 100;
 const FLIPT_GID = 1000;
 
 const DATA_PATH = "/var/opt/flipt";
+const ENVIRONMENT_DATA_PATH = `${DATA_PATH}/environments`;
+
+const FLIPT_SEED_DATA = Object.fromEntries(
+  managedFlagInventory.environments.flatMap((environment) =>
+    managedFlagNamespaces.map((namespace) => [
+      `${environment.key}.${namespace}.yaml`,
+      renderFliptFeatures(environment.key, namespace),
+    ]),
+  ),
+);
 
 // `version: "2.0"` is required — Flipt v2 rejects "1.0" with
 // `loading configuration: invalid version: 1.0` and refuses to start.
@@ -49,8 +64,9 @@ const DATA_PATH = "/var/opt/flipt";
 // silently loses every one of them on restart. Verified by creating a flag,
 // restarting the container, and getting a 404 from the evaluation snapshot.
 // With this config the same test round-trips, and each managed environment has
-// its own bare git repository. The retired `${DATA_PATH}/data` repository stays
-// on the PVC as an unreferenced rollback artifact.
+// its own bare git repository. The product namespace seed is validated before
+// first boot into the clean environment paths below; existing repositories are
+// never overwritten on later restarts.
 //
 // check_for_updates and telemetry_enabled both default to true and would fail
 // continuously against the DNS-only egress policy below.
@@ -65,11 +81,11 @@ storage:
   beta:
     backend:
       type: local
-      path: ${DATA_PATH}/data-beta
+      path: ${ENVIRONMENT_DATA_PATH}/beta
   prod:
     backend:
       type: local
-      path: ${DATA_PATH}/data-prod
+      path: ${ENVIRONMENT_DATA_PATH}/prod
 environments:
   beta:
     name: beta
@@ -91,7 +107,16 @@ meta:
   state_directory: ${DATA_PATH}/state
 `;
 
-export function createEnvironmentValidationScript(dataPath: string): string {
+export function createEnvironmentInitializationScript(
+  dataPath: string,
+  namespaces: readonly string[],
+): string {
+  const copyCommands = ["beta", "prod"].flatMap((environment) =>
+    namespaces.map(
+      (namespace) =>
+        `mkdir -p "$work_root/${environment}/${namespace}"\ncp "/etc/flipt-seed/${environment}.${namespace}.yaml" "$work_root/${environment}/${namespace}/features.yaml"`,
+    ),
+  );
   return `set -eu
 
 validate_repo() {
@@ -102,13 +127,41 @@ validate_repo() {
   fi
 }
 
-validate_repo "${dataPath}/data-beta"
-validate_repo "${dataPath}/data-prod"
+work_root="/tmp/flipt-seed"
+mkdir -p "$work_root/beta" "$work_root/prod"
+${copyCommands.join("\n")}
+
+initialize_environment() {
+  environment="$1"
+  repo="${dataPath}/environments/$environment"
+  seed="$work_root/$environment"
+
+  /flipt validate --work-dir "$seed"
+  if [ ! -e "$repo" ]; then
+    mkdir -p "$repo"
+    cp -R "$seed/." "$repo/"
+    return
+  fi
+
+  if [ -f "$repo/HEAD" ] || [ -f "$repo/config" ] || [ -d "$repo/objects" ]; then
+    validate_repo "$repo"
+    return
+  fi
+
+  # A failed first Flipt boot may leave the validated source tree in place.
+  # Keep it intact so the local backend can retry repository initialization.
+  /flipt validate --work-dir "$repo"
+}
+
+initialize_environment beta
+initialize_environment prod
 `;
 }
 
-const VALIDATE_ENVIRONMENTS_SCRIPT =
-  createEnvironmentValidationScript(DATA_PATH);
+const INITIALIZE_ENVIRONMENTS_SCRIPT = createEnvironmentInitializationScript(
+  DATA_PATH,
+  managedFlagNamespaces,
+);
 
 export function createFliptDeployment(chart: Chart) {
   const deployment = new Deployment(chart, "flipt", {
@@ -123,11 +176,14 @@ export function createFliptDeployment(chart: Chart) {
   const config = new ConfigMap(chart, "flipt-config", {
     data: { "config.yml": FLIPT_CONFIG },
   });
+  const seed = new ConfigMap(chart, "flipt-seed", {
+    data: FLIPT_SEED_DATA,
+  });
 
   deployment.podMetadata.addAnnotation(
     "config-hash",
     new Bun.CryptoHasher("sha256")
-      .update(FLIPT_CONFIG)
+      .update(`${FLIPT_CONFIG}\n${JSON.stringify(FLIPT_SEED_DATA)}`)
       .digest("hex")
       .slice(0, 12),
   );
@@ -141,13 +197,15 @@ export function createFliptDeployment(chart: Chart) {
     "flipt-data-volume",
     dataVolume.claim,
   );
+  const scratchVolume = Volume.fromEmptyDir(chart, "flipt-tmp-volume", "tmp");
+  const seedVolume = Volume.fromConfigMap(chart, "flipt-seed-volume", seed);
 
   deployment.addInitContainer(
     withCommonProps({
-      name: "validate-environments",
+      name: "initialize-environments",
       image: `flipt/flipt:${versions["flipt-io/flipt"]}`,
       command: ["/bin/sh", "-c"],
-      args: [VALIDATE_ENVIRONMENTS_SCRIPT],
+      args: [INITIALIZE_ENVIRONMENTS_SCRIPT],
       resources: {
         cpu: { request: Cpu.millis(5), limit: Cpu.millis(50) },
         memory: { request: Size.mebibytes(8), limit: Size.mebibytes(32) },
@@ -162,7 +220,11 @@ export function createFliptDeployment(chart: Chart) {
         capabilities: { drop: [Capability.ALL] },
         seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
       },
-      volumeMounts: [{ path: DATA_PATH, volume: persistentDataVolume }],
+      volumeMounts: [
+        { path: DATA_PATH, volume: persistentDataVolume },
+        { path: "/etc/flipt-seed", volume: seedVolume, readOnly: true },
+        { path: "/tmp", volume: scratchVolume },
+      ],
     }),
   );
 
@@ -217,7 +279,7 @@ export function createFliptDeployment(chart: Chart) {
         },
         {
           path: "/tmp",
-          volume: Volume.fromEmptyDir(chart, "flipt-tmp-volume", "tmp"),
+          volume: scratchVolume,
         },
       ],
     }),

--- a/packages/homelab/src/cdk8s/src/resources/scout/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/scout/index.ts
@@ -222,6 +222,7 @@ export function createScoutDeployment(chart: Chart, stage: Stage) {
     // Bootstrap for the flag client — these cannot come from a flag.
     FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
     FLIPT_ENVIRONMENT: EnvValue.fromValue(stage),
+    FLIPT_NAMESPACE: EnvValue.fromValue("scout"),
     TEMPORAL_NAMESPACE: EnvValue.fromValue(stage),
     // No TEMPORAL_LEGACY_NAMESPACE: the `default` drain is retired.
     // The legacy namespace holds no Scout execution this backend can finish,

--- a/packages/homelab/src/cdk8s/src/resources/starlight-karma-bot/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/starlight-karma-bot/index.ts
@@ -134,6 +134,7 @@ export function createStarlightKarmaBotDeployment(chart: Chart, stage: Stage) {
         // Bootstrap for the flag client itself — it cannot come from a flag.
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
         FLIPT_ENVIRONMENT: EnvValue.fromValue(stage),
+        FLIPT_NAMESPACE: EnvValue.fromValue("starlight-karma-bot"),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/homelab/src/cdk8s/src/resources/streambot.ts
+++ b/packages/homelab/src/cdk8s/src/resources/streambot.ts
@@ -140,6 +140,7 @@ export function createStreambotDeployment(
         // Bootstrap for the flag client — cannot come from a flag.
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
         FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
+        FLIPT_NAMESPACE: EnvValue.fromValue("streambot"),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/homelab/src/cdk8s/src/resources/temporal/feature-flags.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/feature-flags.ts
@@ -6,7 +6,7 @@ export function temporalFeatureFlagEnvironment(): Record<string, EnvValue> {
     FLIPT_URL: EnvValue.fromValue(
       "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
     ),
-    FLIPT_NAMESPACE: EnvValue.fromValue("default"),
+    FLIPT_NAMESPACE: EnvValue.fromValue("temporal"),
     FLIPT_ENVIRONMENT: EnvValue.fromValue("prod"),
   };
 }

--- a/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/trmnl-dashboard/index.ts
@@ -99,6 +99,7 @@ export function createTrmnlDashboardDeployment(chart: Chart) {
         }),
         DISPLAY_TIME_ZONE: EnvValue.fromValue("America/Los_Angeles"),
         FEATURE_FLAGS_MODE: EnvValue.fromValue("flipt"),
+        FLIPT_NAMESPACE: EnvValue.fromValue("trmnl-dashboard"),
         FLIPT_URL: EnvValue.fromValue(
           "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
         ),

--- a/packages/homelab/src/cdk8s/src/temporal-feature-flags.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-feature-flags.test.ts
@@ -90,6 +90,8 @@ describe("Temporal feature-flag boundary", () => {
       expect(environment.get("FLIPT_URL")).toBe(
         "http://flipt-flipt-service.flipt.svc.cluster.local:8080",
       );
+      expect(environment.get("FLIPT_NAMESPACE")).toBe("temporal");
+      expect(environment.get("FLIPT_ENVIRONMENT")).toBe("prod");
       configuredComponents.add(component);
     }
     expect(configuredComponents).toEqual(expectedComponents);

--- a/packages/scout-for-lol/packages/backend/src/config/dynamic.ts
+++ b/packages/scout-for-lol/packages/backend/src/config/dynamic.ts
@@ -134,7 +134,7 @@ const DEFINITION = {
     schema: z.boolean(),
     sources: ["flag", "default"],
     default: false,
-    names: { flag: "temporal-call-graph-tracing" },
+    names: { flag: "scout-temporal-call-graph-tracing" },
   },
 } as const;
 

--- a/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
+++ b/packages/scout-for-lol/packages/backend/src/temporal/connected-runtime.ts
@@ -194,7 +194,7 @@ function createScoutTemporalTracing(
   const tracingRuntime = getTracingRuntime();
   if (tracingRuntime === undefined && callGraphTracing) {
     throw new Error(
-      "temporal-call-graph-tracing requires TELEMETRY_ENABLED=true",
+      "scout-temporal-call-graph-tracing requires TELEMETRY_ENABLED=true",
     );
   }
   return tracingRuntime !== undefined && callGraphTracing

--- a/packages/temporal/src/activities/flipt-flag-inventory.ts
+++ b/packages/temporal/src/activities/flipt-flag-inventory.ts
@@ -3,7 +3,11 @@ import {
   compareManagedFlagInventory,
   fetchFliptSnapshot,
 } from "@shepherdjerred/feature-flags/managed-flag-drift.ts";
-import { managedFlagInventory } from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
+import {
+  managedFlagInventory,
+  managedFlagNamespaces,
+  materializeManagedNamespaceEnvironment,
+} from "@shepherdjerred/feature-flags/managed-flag-inventory.ts";
 import {
   buildFliptFlagDriftAlert,
   type FliptFlagDriftAlertInput,
@@ -24,24 +28,38 @@ function requiredEnvironment(name: string): string {
 export type FliptFlagInventoryActivities = typeof fliptFlagInventoryActivities;
 
 export const fliptFlagInventoryActivities = {
-  async checkFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
-    const environment = requiredEnvironment("FLIPT_ENVIRONMENT");
-    const snapshot = await fetchFliptSnapshot({
-      url: requiredEnvironment("FLIPT_URL"),
-      namespace: managedFlagInventory.namespace,
-      environment,
-    });
-    const drift = compareManagedFlagInventory(snapshot);
-    const result: FliptFlagInventoryResult = {
-      namespace: managedFlagInventory.namespace,
-      environment,
-      missingInFlipt: drift.missingInFlipt,
-      undeclaredInInventory: drift.undeclaredInInventory,
-      observedAt: new Date().toISOString(),
-    };
-    await createAlertmanagerPoster(requiredEnvironment("ALERTMANAGER_URL"))([
-      buildFliptFlagDriftAlert(result, new Date()),
-    ]);
-    return result;
+  async checkFliptFlagInventory(): Promise<FliptFlagInventoryResult[]> {
+    const url = requiredEnvironment("FLIPT_URL");
+    const observedAt = new Date().toISOString();
+    const results = await Promise.all(
+      managedFlagInventory.environments.flatMap((environment) =>
+        managedFlagNamespaces.map(async (namespace) => {
+          const expectedFlags = materializeManagedNamespaceEnvironment(
+            managedFlagInventory,
+            environment.key,
+            namespace,
+          );
+          const snapshot = await fetchFliptSnapshot({
+            url,
+            namespace,
+            environment: environment.key,
+          });
+          const drift = compareManagedFlagInventory(snapshot, expectedFlags);
+          return {
+            namespace,
+            environment: environment.key,
+            missingInFlipt: drift.missingInFlipt,
+            undeclaredInInventory: drift.undeclaredInInventory,
+            contractMismatches: drift.contractMismatches,
+            observedAt,
+          };
+        }),
+      ),
+    );
+    const alertTime = new Date();
+    await createAlertmanagerPoster(requiredEnvironment("ALERTMANAGER_URL"))(
+      results.map((result) => buildFliptFlagDriftAlert(result, alertTime)),
+    );
+    return results;
   },
 };

--- a/packages/temporal/src/shared/flipt-flag-drift-alert.test.ts
+++ b/packages/temporal/src/shared/flipt-flag-drift-alert.test.ts
@@ -10,10 +10,11 @@ describe("buildFliptFlagDriftAlert", () => {
   test("fires one stable alert containing both mismatch directions", () => {
     const alert = buildFliptFlagDriftAlert(
       {
-        namespace: "default",
-        environment: "default",
+        namespace: "scout",
+        environment: "beta",
         missingInFlipt: ["declared-flag"],
         undeclaredInInventory: ["manual-flag"],
+        contractMismatches: ["model: expected Luna, got Sol"],
       },
       NOW,
     );
@@ -22,8 +23,8 @@ describe("buildFliptFlagDriftAlert", () => {
       alertname: "FliptManagedFlagDrift",
       severity: "warning",
       component: "feature-flags",
-      namespace: "default",
-      environment: "default",
+      namespace: "scout",
+      environment: "beta",
     });
     expect(alert.annotations["description"]).toContain(
       "Declared keys missing from Flipt: declared-flag",
@@ -31,6 +32,10 @@ describe("buildFliptFlagDriftAlert", () => {
     expect(alert.annotations["description"]).toContain(
       "Flipt keys absent from the inventory: manual-flag",
     );
+    expect(alert.annotations["description"]).toContain(
+      "Behavior contract mismatches: model: expected Luna, got Sol",
+    );
+    expect(alert.annotations["summary"]).toContain("beta/scout");
     expect(alert.endsAt).toBe(
       new Date(NOW.getTime() + FLIPT_FLAG_DRIFT_ALERT_TTL_MS).toISOString(),
     );
@@ -39,19 +44,21 @@ describe("buildFliptFlagDriftAlert", () => {
   test("resolves with the exact same labels when aligned", () => {
     const firing = buildFliptFlagDriftAlert(
       {
-        namespace: "default",
-        environment: "default",
+        namespace: "scout",
+        environment: "beta",
         missingInFlipt: ["declared-flag"],
         undeclaredInInventory: [],
+        contractMismatches: [],
       },
       NOW,
     );
     const alert = buildFliptFlagDriftAlert(
       {
-        namespace: "default",
-        environment: "default",
+        namespace: "scout",
+        environment: "beta",
         missingInFlipt: [],
         undeclaredInInventory: [],
+        contractMismatches: [],
       },
       NOW,
     );

--- a/packages/temporal/src/shared/flipt-flag-drift-alert.ts
+++ b/packages/temporal/src/shared/flipt-flag-drift-alert.ts
@@ -7,6 +7,7 @@ export type FliptFlagDriftAlertInput = {
   readonly environment: string;
   readonly missingInFlipt: readonly string[];
   readonly undeclaredInInventory: readonly string[];
+  readonly contractMismatches: readonly string[];
 };
 
 function formatKeys(keys: readonly string[]): string {
@@ -18,19 +19,22 @@ export function buildFliptFlagDriftAlert(
   now: Date,
 ): AlertmanagerAlert {
   const hasDrift =
-    input.missingInFlipt.length > 0 || input.undeclaredInInventory.length > 0;
+    input.missingInFlipt.length > 0 ||
+    input.undeclaredInInventory.length > 0 ||
+    input.contractMismatches.length > 0;
   const startsAt = now.toISOString();
   const summary = hasDrift
-    ? `Flipt managed flag inventory drift in ${input.namespace}/${input.environment}`
-    : `Flipt managed flag inventory aligned in ${input.namespace}/${input.environment}`;
+    ? `Flipt managed flag inventory drift in ${input.environment}/${input.namespace}`
+    : `Flipt managed flag inventory aligned in ${input.environment}/${input.namespace}`;
   const description = hasDrift
     ? [
-        `The repository inventory and Flipt differ in ${input.namespace}/${input.environment}.`,
+        `The repository inventory and Flipt differ in ${input.environment}/${input.namespace}.`,
         `Declared keys missing from Flipt: ${formatKeys(input.missingInFlipt)}`,
         `Flipt keys absent from the inventory: ${formatKeys(input.undeclaredInInventory)}`,
+        `Behavior contract mismatches: ${formatKeys(input.contractMismatches)}`,
         "Reconcile the reviewed inventory and Flipt state, then run the operator check again.",
       ].join("\n")
-    : `The repository inventory and Flipt are aligned in ${input.namespace}/${input.environment}.`;
+    : `The repository inventory and Flipt are aligned in ${input.environment}/${input.namespace}.`;
 
   return {
     labels: {

--- a/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
+++ b/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
@@ -34,13 +34,16 @@ describe("runFliptFlagInventory", () => {
     const observed: unknown[] = [];
     const activities = {
       checkFliptFlagInventory: async () => {
-        const result = {
-          namespace: "default",
-          environment: "default",
-          missingInFlipt: [],
-          undeclaredInInventory: [],
-          observedAt: "2026-08-28T15:00:00.000Z",
-        };
+        const result = [
+          {
+            namespace: "scout",
+            environment: "beta",
+            missingInFlipt: [],
+            undeclaredInInventory: [],
+            contractMismatches: [],
+            observedAt: "2026-08-28T15:00:00.000Z",
+          },
+        ];
         observed.push(result);
         return result;
       },

--- a/packages/temporal/src/workflows/flipt-flag-inventory.ts
+++ b/packages/temporal/src/workflows/flipt-flag-inventory.ts
@@ -17,6 +17,8 @@ const { checkFliptFlagInventory } =
     },
   });
 
-export async function runFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
+export async function runFliptFlagInventory(): Promise<
+  FliptFlagInventoryResult[]
+> {
   return await checkFliptFlagInventory();
 }

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -173,7 +173,9 @@ export async function runFreshRssSyncWorkflow(): Promise<void> {
   return _runFreshRssSyncWorkflow();
 }
 
-export async function runFliptFlagInventory(): Promise<FliptFlagInventoryResult> {
+export async function runFliptFlagInventory(): Promise<
+  FliptFlagInventoryResult[]
+> {
   return _runFliptFlagInventory();
 }
 

--- a/scripts/check-flipt-flag-inventory.test.ts
+++ b/scripts/check-flipt-flag-inventory.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "vitest";
 import {
   managedFlagInventory,
-  materializeManagedEnvironment,
+  managedFlagNamespaces,
+  materializeManagedNamespaceEnvironment,
   type ManagedFlag,
 } from "../packages/feature-flags/src/managed-flag-inventory.ts";
 import {
-  checkManagedEnvironments,
+  checkManagedFlagMatrix,
   selectedManagedEnvironments,
+  selectedManagedNamespaces,
 } from "./check-flipt-flag-inventory.ts";
 
 function snapshotFlag(flag: ManagedFlag) {
@@ -44,60 +46,85 @@ function snapshotFlag(flag: ManagedFlag) {
   };
 }
 
-function alignedSnapshot(environment: string) {
+function alignedSnapshot(environment: string, namespace: string) {
   return {
-    flags: materializeManagedEnvironment(managedFlagInventory, environment).map(
-      (flag) => snapshotFlag(flag),
-    ),
+    flags: materializeManagedNamespaceEnvironment(
+      managedFlagInventory,
+      environment,
+      namespace,
+    ).map((flag) => snapshotFlag(flag)),
   };
 }
 
 describe("check-flipt-flag-inventory", () => {
-  test("checks every managed environment by default", async () => {
+  test("checks the complete environment and namespace matrix by default", async () => {
     const loaded: string[] = [];
-    const messages = await checkManagedEnvironments({
-      namespace: "default",
-      loadSnapshot: (_namespace, environment) => {
-        loaded.push(environment);
-        return Promise.resolve(alignedSnapshot(environment));
+    const messages = await checkManagedFlagMatrix({
+      loadSnapshot: (environment, namespace) => {
+        loaded.push(`${environment}/${namespace}`);
+        return Promise.resolve(alignedSnapshot(environment, namespace));
       },
     });
 
-    expect(loaded).toEqual(["beta", "prod"]);
-    expect(messages).toHaveLength(2);
+    expect(loaded).toEqual(
+      ["beta", "prod"].flatMap((environment) =>
+        managedFlagNamespaces.map((namespace) => `${environment}/${namespace}`),
+      ),
+    );
+    expect(messages).toHaveLength(12);
   });
 
-  test("checks only an exact environment filter", async () => {
+  test("checks only exact environment and namespace filters", async () => {
     const loaded: string[] = [];
-    await checkManagedEnvironments({
-      namespace: "default",
+    await checkManagedFlagMatrix({
+      namespaceFilter: "scout",
       environmentFilter: "beta",
-      loadSnapshot: (_namespace, environment) => {
-        loaded.push(environment);
-        return Promise.resolve(alignedSnapshot(environment));
+      loadSnapshot: (environment, namespace) => {
+        loaded.push(`${environment}/${namespace}`);
+        return Promise.resolve(alignedSnapshot(environment, namespace));
       },
     });
-    expect(loaded).toEqual(["beta"]);
+    expect(loaded).toEqual(["beta/scout"]);
     expect(() => selectedManagedEnvironments("staging")).toThrow(
       /unknown managed environment filter: staging/,
     );
+    expect(() => selectedManagedNamespaces("default")).toThrow(
+      /unknown managed namespace filter: default/,
+    );
   });
 
-  test("names the failing environment for malformed snapshots and drift", async () => {
+  test("names the failing namespace and environment for malformed snapshots and drift", async () => {
     await expect(
-      checkManagedEnvironments({
-        namespace: "default",
+      checkManagedFlagMatrix({
+        namespaceFilter: "scout",
         environmentFilter: "prod",
         loadSnapshot: () => Promise.resolve({ flags: [] }),
       }),
-    ).rejects.toThrow(/default\/prod/);
+    ).rejects.toThrow(/prod\/scout/);
 
     await expect(
-      checkManagedEnvironments({
-        namespace: "default",
+      checkManagedFlagMatrix({
+        namespaceFilter: "temporal",
         environmentFilter: "beta",
         loadSnapshot: () => Promise.resolve({ invalid: true }),
       }),
-    ).rejects.toThrow(/default\/beta/);
+    ).rejects.toThrow(/beta\/temporal/);
+  });
+
+  test("checks the remaining matrix after one pair fails", async () => {
+    const loaded: string[] = [];
+    await expect(
+      checkManagedFlagMatrix({
+        loadSnapshot: (environment, namespace) => {
+          loaded.push(`${environment}/${namespace}`);
+          return Promise.resolve(
+            environment === "beta" && namespace === "scout"
+              ? { flags: [] }
+              : alignedSnapshot(environment, namespace),
+          );
+        },
+      }),
+    ).rejects.toThrow(/beta\/scout/);
+    expect(loaded).toHaveLength(12);
   });
 });

--- a/scripts/check-flipt-flag-inventory.ts
+++ b/scripts/check-flipt-flag-inventory.ts
@@ -6,7 +6,8 @@ import {
 } from "../packages/feature-flags/src/managed-flag-drift.ts";
 import {
   managedFlagInventory,
-  materializeManagedEnvironment,
+  managedFlagNamespaces,
+  materializeManagedNamespaceEnvironment,
 } from "../packages/feature-flags/src/managed-flag-inventory.ts";
 
 function argument(name: string): string | undefined {
@@ -38,63 +39,82 @@ export function selectedManagedEnvironments(
   return [environmentFilter];
 }
 
+export function selectedManagedNamespaces(
+  namespaceFilter: string | undefined,
+): string[] {
+  if (namespaceFilter === undefined) return managedFlagNamespaces;
+  if (!managedFlagNamespaces.includes(namespaceFilter)) {
+    throw new Error(`unknown managed namespace filter: ${namespaceFilter}`);
+  }
+  return [namespaceFilter];
+}
+
 export type SnapshotLoader = (
-  namespace: string,
   environment: string,
+  namespace: string,
 ) => Promise<unknown>;
 
-export async function checkManagedEnvironments(options: {
-  namespace: string;
+export async function checkManagedFlagMatrix(options: {
+  namespaceFilter?: string | undefined;
   environmentFilter?: string | undefined;
   loadSnapshot: SnapshotLoader;
 }): Promise<string[]> {
   const messages: string[] = [];
+  const failures: string[] = [];
   for (const environment of selectedManagedEnvironments(
     options.environmentFilter,
   )) {
-    const expectedFlags = materializeManagedEnvironment(
-      managedFlagInventory,
-      environment,
-    );
-    let snapshot: Awaited<ReturnType<typeof fetchFliptSnapshot>>;
-    try {
-      snapshot = FliptSnapshotSchema.parse(
-        await options.loadSnapshot(options.namespace, environment),
+    for (const namespace of selectedManagedNamespaces(
+      options.namespaceFilter,
+    )) {
+      const expectedFlags = materializeManagedNamespaceEnvironment(
+        managedFlagInventory,
+        environment,
+        namespace,
       );
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      throw new Error(
-        `Flipt snapshot validation failed in ${options.namespace}/${environment}: ${detail}`,
-        { cause: error },
+      let snapshot: Awaited<ReturnType<typeof fetchFliptSnapshot>>;
+      try {
+        snapshot = FliptSnapshotSchema.parse(
+          await options.loadSnapshot(environment, namespace),
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        failures.push(
+          `Flipt snapshot validation failed in ${environment}/${namespace}: ${detail}`,
+        );
+        continue;
+      }
+      const errors = formatManagedFlagDrift(
+        compareManagedFlagInventory(snapshot, expectedFlags),
+      );
+      if (errors.length > 0) {
+        failures.push(
+          `Flipt managed-flag drift detected in ${environment}/${namespace}:\n  - ${errors.join("\n  - ")}`,
+        );
+        continue;
+      }
+      messages.push(
+        `Flipt managed-flag inventory is aligned: ${expectedFlags.length.toString()} keys in ${environment}/${namespace}`,
       );
     }
-    const errors = formatManagedFlagDrift(
-      compareManagedFlagInventory(snapshot, expectedFlags),
-    );
-    if (errors.length > 0) {
-      throw new Error(
-        `Flipt managed-flag drift detected in ${options.namespace}/${environment}:\n- ${errors.join("\n- ")}`,
-      );
-    }
-    messages.push(
-      `Flipt managed-flag inventory is aligned: ${expectedFlags.length.toString()} keys in ${options.namespace}/${environment}`,
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Flipt managed-flag matrix check failed:\n- ${failures.join("\n- ")}`,
     );
   }
   return messages;
 }
 
 async function main(): Promise<void> {
-  const namespace =
-    argument("--namespace") ??
-    Bun.env["FLIPT_NAMESPACE"] ??
-    managedFlagInventory.namespace;
+  const namespaceFilter = argument("--namespace") ?? Bun.env["FLIPT_NAMESPACE"];
   const environmentFilter =
     argument("--environment") ?? Bun.env["FLIPT_ENVIRONMENT"];
   const url = requiredUrl();
-  const messages = await checkManagedEnvironments({
-    namespace,
+  const messages = await checkManagedFlagMatrix({
+    namespaceFilter,
     environmentFilter,
-    loadSnapshot: (selectedNamespace, environment) =>
+    loadSnapshot: (environment, selectedNamespace) =>
       fetchFliptSnapshot({ url, namespace: selectedNamespace, environment }),
   });
   for (const message of messages) {


### PR DESCRIPTION
Why

Flipt currently puts every managed flag in one default namespace, so product catalogs share a keyspace and clients depend on an implicit namespace fallback. The namespace cutover must move server storage, seed state, consumers, and drift monitoring together.

What

- Upgrade the managed inventory to version 3 with six product namespaces in both beta and prod.
- Render and validate twelve deterministic Flipt features.yaml seeds, initialize clean environment repositories once, and preserve live state on later restarts.
- Require FLIPT_NAMESPACE in Flipt mode and wire every Scout, Karma, Birmel, Streambot, TRMNL, Temporal, and maintenance consumer to its exact catalog.
- Check and alert on the complete environment/namespace matrix, including behavioral contract mismatches.
- Move Flipt to Argo wave -2 and document the distinction between Flipt environments, Flipt namespaces, and Kubernetes namespaces.

Verification

- bunx turbo run build typecheck test lint --filter=@shepherdjerred/feature-flags --force
- bunx turbo run typecheck test lint --filter=@shepherdjerred/temporal --force
- CDK8s build/typecheck and all 698 tests passed; bunx eslint . passed after fixing two new-test findings
- bunx turbo run build typecheck test lint --filter=@shepherdjerred/docs-wiki --force
- bun --no-install --bun vitest --config vitest.config.ts run scripts/check-flipt-flag-inventory.test.ts
- bunx lefthook run pre-commit
- Both generated seed trees validated with the pinned Flipt v2.11.0 binary

Rollout

Release atomically through the exact-revision root workflow. Before release, create and verify a Flipt-only Velero backup. After rollout, verify all twelve pairs, restart persistence, consumer evaluation, and the daily drift workflow before deleting only the three explicitly named legacy data directories.

Live cutover, cleanup, and post-cutover checks have not run. The docs build passed, but visual proof is still pending because no browser is connected to this session.