### PR TITLE
refactor(scout-for-lol): share report chart layout

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1257,12 +1257,8 @@
       "tokens": 72
     },
     "packages/scout-for-lol/packages/backend/src/reports/output-analytics.ts|packages/scout-for-lol/packages/backend/src/reports/output.ts": {
-      "clones": 4,
-      "tokens": 437
-    },
-    "packages/scout-for-lol/packages/backend/src/reports/output.ts|packages/scout-for-lol/packages/backend/src/reports/output.ts": {
-      "clones": 1,
-      "tokens": 91
+      "clones": 2,
+      "tokens": 176
     },
     "packages/scout-for-lol/packages/backend/src/reports/temporal-labels.ts|packages/scout-for-lol/packages/report/src/html/visualization-snapshot-calendar-option.ts": {
       "clones": 1,

--- a/packages/scout-for-lol/packages/backend/src/reports/output-analytics.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/output-analytics.ts
@@ -1,8 +1,4 @@
-import { type ReportRenderSpec } from "@scout-for-lol/data";
-import {
-  analyticsChartToImage,
-  type AnalyticsChartProps,
-} from "@scout-for-lol/report";
+import { analyticsChartToImage } from "@scout-for-lol/report";
 import { format, getISODay, parseISO, startOfISOWeek } from "date-fns";
 import { match } from "ts-pattern";
 import type {
@@ -20,23 +16,18 @@ import {
 import { resolveHeatmapAxes } from "#src/reports/heatmap-axes.ts";
 import { planGroupingNames } from "#src/reports/plan-columns.ts";
 import type { ScoutQlPlan } from "@scout-for-lol/data/model/scoutql/plan.ts";
+import {
+  chartBase,
+  chartRows,
+  requireFirst,
+  yColumns,
+  type AnalyticsChartBase,
+  type ReportChartRender,
+} from "#src/reports/report-chart-layout.ts";
 
-type ChartRender = Extract<
-  ReportRenderSpec,
-  {
-    kind:
-      | "STACKED_BAR"
-      | "AREA_CHART"
-      | "DONUT_CHART"
-      | "SCATTER_CHART"
-      | "HEATMAP"
-      | "RADAR_CHART"
-      | "KPI_CARD"
-      | "BUMP_CHART"
-      | "CALENDAR_HEATMAP"
-      | "HISTOGRAM"
-      | "BOX_PLOT";
-  }
+type ChartRender = Exclude<
+  ReportChartRender,
+  { kind: "BAR_CHART" | "LINE_CHART" }
 >;
 
 type AnalyticsRenderContext = {
@@ -49,11 +40,6 @@ type AnalyticsRenderContext = {
   display: MetricDisplay;
   rows: ReportResultRow[];
 };
-
-type AnalyticsChartBase = Pick<
-  AnalyticsChartProps,
-  "title" | "subtitle" | "theme" | "palette" | "colors" | "legend" | "labels"
->;
 
 export function renderLegacyAnalyticsImage(input: {
   title: string;
@@ -259,64 +245,4 @@ function renderKpiAnalytics(context: AnalyticsRenderContext): Buffer {
       value: formattedChartValue(plan, row, column),
     })),
   });
-}
-
-function chartBase(render: ChartRender, title: string): AnalyticsChartBase {
-  return {
-    title,
-    ...(render.options.subtitle === undefined
-      ? {}
-      : { subtitle: render.options.subtitle }),
-    ...(render.options.theme === undefined
-      ? {}
-      : { theme: render.options.theme }),
-    ...(render.options.palette === undefined
-      ? {}
-      : { palette: render.options.palette }),
-    ...(render.options.colors === undefined
-      ? {}
-      : { colors: render.options.colors }),
-    ...(render.options.legend === undefined
-      ? {}
-      : { legend: render.options.legend }),
-    ...(render.options.labels === undefined
-      ? {}
-      : { labels: render.options.labels }),
-  };
-}
-
-function yColumns(result: ReportQueryResult, render: ChartRender): string[] {
-  const configured = render.encoding.y;
-  if (Array.isArray(configured)) return configured;
-  if (configured !== undefined) return [configured];
-  const first = result.plan.outputs[0]?.name;
-  if (first === undefined) {
-    throw new Error("Cannot render a chart without an output column.");
-  }
-  return [first];
-}
-
-function requireFirst(columns: string[]): string {
-  const first = columns[0];
-  if (first === undefined) {
-    throw new Error("Chart requires at least one Y column.");
-  }
-  return first;
-}
-
-function chartRows(
-  plan: ScoutQlPlan,
-  rows: ReportResultRow[],
-  render: ChartRender,
-  column: string,
-): ReportResultRow[] {
-  if (render.options.sort === undefined || render.options.sort === "query") {
-    return rows;
-  }
-  const direction = render.options.sort === "asc" ? 1 : -1;
-  return rows.toSorted(
-    (left, right) =>
-      direction *
-      (chartNumber(plan, left, column) - chartNumber(plan, right, column)),
-  );
 }

--- a/packages/scout-for-lol/packages/backend/src/reports/output.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/output.ts
@@ -13,7 +13,6 @@ import type {
   ReportQueryResult,
   ReportResultRow,
 } from "#src/reports/query-types.ts";
-import type { ScoutQlPlan } from "@scout-for-lol/data/model/scoutql/plan.ts";
 import {
   formatRankedLabel,
   resolveMentionCount,
@@ -21,9 +20,15 @@ import {
 import {
   chartSeries,
   columnDisplay,
-  chartNumber,
 } from "#src/reports/report-chart-values.ts";
 import { renderLegacyAnalyticsImage } from "#src/reports/output-analytics.ts";
+import {
+  chartBase,
+  chartRows,
+  requireFirst,
+  yColumns,
+  type ReportChartRender,
+} from "#src/reports/report-chart-layout.ts";
 
 export type RenderedReportOutput = {
   content: string;
@@ -42,25 +47,7 @@ type RenderReportOutputParams = {
   playerDiscordIds?: Map<number, string>;
 };
 
-type ChartRender = Extract<
-  ReportRenderSpec,
-  {
-    kind:
-      | "BAR_CHART"
-      | "LINE_CHART"
-      | "STACKED_BAR"
-      | "AREA_CHART"
-      | "DONUT_CHART"
-      | "SCATTER_CHART"
-      | "HEATMAP"
-      | "RADAR_CHART"
-      | "KPI_CARD"
-      | "BUMP_CHART"
-      | "CALENDAR_HEATMAP"
-      | "HISTOGRAM"
-      | "BOX_PLOT";
-  }
->;
+type ChartRender = ReportChartRender;
 
 export function renderReportOutput(
   params: RenderReportOutputParams,
@@ -285,16 +272,24 @@ function hasThinRateRows(result: ReportQueryResult): boolean {
   });
 }
 
+function prepareChart(params: RenderReportOutputParams, render: ChartRender) {
+  const plan = params.result.plan;
+  const columns = yColumns(params.result, render);
+  const firstColumn = requireFirst(columns);
+  return {
+    plan,
+    columns,
+    display: columnDisplay(plan, firstColumn),
+    rows: chartRows(plan, params.result.rows, render, firstColumn),
+    title: render.options.title ?? params.title,
+  };
+}
+
 function renderBarChart(
   params: RenderReportOutputParams,
   render: Extract<ReportRenderSpec, { kind: "BAR_CHART" }>,
 ): RenderedReportOutput {
-  const plan = params.result.plan;
-  const columns = yColumns(params, render);
-  const firstColumn = requireFirst(columns);
-  const display = columnDisplay(plan, firstColumn);
-  const rows = chartRows(plan, params.result.rows, render, firstColumn);
-  const title = render.options.title ?? params.title;
+  const { plan, columns, display, rows, title } = prepareChart(params, render);
   const data = analyticsChartToImage({
     ...chartBase(render, title),
     chartType: "bar",
@@ -319,12 +314,7 @@ function renderLineChart(
   params: RenderReportOutputParams,
   render: Extract<ReportRenderSpec, { kind: "LINE_CHART" }>,
 ): RenderedReportOutput {
-  const plan = params.result.plan;
-  const columns = yColumns(params, render);
-  const firstColumn = requireFirst(columns);
-  const display = columnDisplay(plan, firstColumn);
-  const rows = chartRows(plan, params.result.rows, render, firstColumn);
-  const title = render.options.title ?? params.title;
+  const { plan, columns, display, rows, title } = prepareChart(params, render);
   const data = analyticsChartToImage({
     ...chartBase(render, title),
     chartType: "line",
@@ -362,65 +352,4 @@ function renderAnalyticsChart(
       data,
     },
   };
-}
-
-function chartBase(render: ChartRender, title: string) {
-  return {
-    title,
-    ...(render.options.subtitle === undefined
-      ? {}
-      : { subtitle: render.options.subtitle }),
-    ...(render.options.theme === undefined
-      ? {}
-      : { theme: render.options.theme }),
-    ...(render.options.palette === undefined
-      ? {}
-      : { palette: render.options.palette }),
-    ...(render.options.colors === undefined
-      ? {}
-      : { colors: render.options.colors }),
-    ...(render.options.legend === undefined
-      ? {}
-      : { legend: render.options.legend }),
-    ...(render.options.labels === undefined
-      ? {}
-      : { labels: render.options.labels }),
-  };
-}
-
-function yColumns(
-  params: RenderReportOutputParams,
-  render: ChartRender,
-): string[] {
-  const configured = render.encoding.y;
-  if (Array.isArray(configured)) return configured;
-  if (configured !== undefined) return [configured];
-  const first = params.result.plan.outputs[0]?.name;
-  if (first === undefined)
-    throw new Error("Cannot render a chart without an output column.");
-  return [first];
-}
-
-function requireFirst(columns: string[]): string {
-  const first = columns[0];
-  if (first === undefined)
-    throw new Error("Chart requires at least one Y column.");
-  return first;
-}
-
-function chartRows(
-  plan: ScoutQlPlan,
-  rows: ReportResultRow[],
-  render: ChartRender,
-  column: string,
-): ReportResultRow[] {
-  if (render.options.sort === undefined || render.options.sort === "query") {
-    return rows;
-  }
-  const direction = render.options.sort === "asc" ? 1 : -1;
-  return rows.toSorted(
-    (left, right) =>
-      direction *
-      (chartNumber(plan, left, column) - chartNumber(plan, right, column)),
-  );
 }

--- a/packages/scout-for-lol/packages/backend/src/reports/report-chart-layout.ts
+++ b/packages/scout-for-lol/packages/backend/src/reports/report-chart-layout.ts
@@ -1,0 +1,84 @@
+import type { ReportRenderSpec } from "@scout-for-lol/data";
+import type { ScoutQlPlan } from "@scout-for-lol/data/model/scoutql/plan.ts";
+import type { AnalyticsChartProps } from "@scout-for-lol/report";
+import type {
+  ReportQueryResult,
+  ReportResultRow,
+} from "#src/reports/query-types.ts";
+import { chartNumber } from "#src/reports/report-chart-values.ts";
+
+export type ReportChartRender = Extract<
+  ReportRenderSpec,
+  { encoding: unknown }
+>;
+
+export type AnalyticsChartBase = Pick<
+  AnalyticsChartProps,
+  "title" | "subtitle" | "theme" | "palette" | "colors" | "legend" | "labels"
+>;
+
+export function chartBase(
+  render: ReportChartRender,
+  title: string,
+): AnalyticsChartBase {
+  return {
+    title,
+    ...(render.options.subtitle === undefined
+      ? {}
+      : { subtitle: render.options.subtitle }),
+    ...(render.options.theme === undefined
+      ? {}
+      : { theme: render.options.theme }),
+    ...(render.options.palette === undefined
+      ? {}
+      : { palette: render.options.palette }),
+    ...(render.options.colors === undefined
+      ? {}
+      : { colors: render.options.colors }),
+    ...(render.options.legend === undefined
+      ? {}
+      : { legend: render.options.legend }),
+    ...(render.options.labels === undefined
+      ? {}
+      : { labels: render.options.labels }),
+  };
+}
+
+export function yColumns(
+  result: ReportQueryResult,
+  render: ReportChartRender,
+): string[] {
+  const configured = render.encoding.y;
+  if (Array.isArray(configured)) return configured;
+  if (configured !== undefined) return [configured];
+  const first = result.plan.outputs[0]?.name;
+  if (first === undefined) {
+    throw new Error("Cannot render a chart without an output column.");
+  }
+  return [first];
+}
+
+export function requireFirst(columns: string[]): string {
+  const first = columns[0];
+  if (first === undefined) {
+    throw new Error("Chart requires at least one Y column.");
+  }
+  return first;
+}
+
+export function chartRows(
+  plan: ScoutQlPlan,
+  rows: ReportResultRow[],
+  render: ReportChartRender,
+  column: string,
+): ReportResultRow[] {
+  if (render.options.sort === undefined || render.options.sort === "query") {
+    return rows;
+  }
+  const direction = render.options.sort === "asc" ? 1 : -1;
+  return rows.toSorted(
+    (left, right) =>
+      direction *
+      (chartNumber(plan, left, column) - chartNumber(plan, right, column)),
+  );
+}


### PR DESCRIPTION
## Why

Scout's primary and legacy chart renderers repeated chart-option projection, Y-column selection, validation, and sorting. BAR and LINE rendering also retained a redundant preparation block.

## What

- Add an internal `report-chart-layout` module for shared chart base options, column resolution, first-column validation, and row sorting.
- Route primary and legacy renderers through that module without changing their output-specific behavior.
- Share BAR and LINE preparation, eliminating the existing self-clone instead of allowing its boundary to grow.
- Reduce the stack baseline from 74,184 to 73,832 duplicated tokens, removing three clones with no new or increased pair.

## Verification

- `bun --no-install --bun vitest --config ../../../../vitest.config.ts run src/reports/output.test.ts`
- `bunx turbo run test typecheck lint --filter=@scout-for-lol/backend`
- `bun run jscpd` (reported only reduced/removed pairs before update)
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json` -> `73832`\n- `bun run jscpd`\n- `bunx lefthook run pre-commit`\n\nNo live, visual, or deployment checks were required.