### PR TITLE
refactor(scout-for-lol): share S3 test harness

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1192,14 +1192,6 @@
       "clones": 3,
       "tokens": 272
     },
-    "packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/get-image.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-image.test.ts": {
-      "clones": 1,
-      "tokens": 72
-    },
-    "packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/get-image.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-svg.test.ts": {
-      "clones": 1,
-      "tokens": 89
-    },
     "packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-classic.test.ts|packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-report-classic.test.ts": {
       "clones": 1,
       "tokens": 76
@@ -1280,14 +1272,6 @@
       "clones": 2,
       "tokens": 161
     },
-    "packages/scout-for-lol/packages/backend/src/storage/s3-image.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-image.test.ts": {
-      "clones": 5,
-      "tokens": 382
-    },
-    "packages/scout-for-lol/packages/backend/src/storage/s3-image.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-svg.test.ts": {
-      "clones": 2,
-      "tokens": 312
-    },
     "packages/scout-for-lol/packages/backend/src/storage/s3-leaderboard-image.ts|packages/scout-for-lol/packages/backend/src/storage/s3-leaderboard.ts": {
       "clones": 1,
       "tokens": 79
@@ -1319,10 +1303,6 @@
     "packages/scout-for-lol/packages/backend/src/storage/s3-report-run.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3-report-run.test.ts": {
       "clones": 1,
       "tokens": 83
-    },
-    "packages/scout-for-lol/packages/backend/src/storage/s3.test.ts|packages/scout-for-lol/packages/backend/src/storage/s3.test.ts": {
-      "clones": 13,
-      "tokens": 1080
     },
     "packages/scout-for-lol/packages/backend/src/trpc/router/event.router.ts|packages/scout-for-lol/packages/backend/src/trpc/router/event.router.ts": {
       "clones": 1,

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-image.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-image.test.ts
@@ -1,420 +1,188 @@
-/**
- * S3 Image Storage Tests using aws-sdk-client-mock
- *
- * These tests use in-memory mocking via aws-sdk-client-mock instead of real S3.
- * This makes them fast, reliable, and doesn't require AWS credentials.
- *
- * Environment setup is handled automatically by test-setup.ts (preloaded via bunfig.toml)
- */
-
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { mockClient } from "aws-sdk-client-mock";
-import { z } from "zod";
-import { saveImageToS3 } from "#src/storage/s3.ts";
-import { resetConfigurationForTests } from "#src/configuration.ts";
 import { MatchIdSchema } from "@scout-for-lol/data";
+import { saveImageToS3 } from "#src/storage/s3.ts";
+import {
+  currentUtcDatePath,
+  getValidatedPutCommand,
+  mockFailedPut,
+  mockSuccessfulPut,
+  resetS3TestState,
+  s3Mock,
+  setS3TestBucket,
+} from "#src/storage/s3-test-helpers.ts";
 
-// Create S3 mock
-const s3Mock = mockClient(S3Client);
-
-// Zod schema for validating PutObjectCommand structure from mocks
-const PutObjectCommandSchema = z.object({
-  input: z.object({
-    Bucket: z.string(),
-    Key: z.string(),
-    Body: z.union([z.instanceof(Uint8Array), z.string()]),
-    ContentType: z.string(),
-    Metadata: z
-      .object({
-        matchId: z.string(),
-        queueType: z.string(),
-        uploadedAt: z.string(),
-      })
-      .optional(),
-  }),
-});
-
-// Helper to safely get and validate command from mock call
-function getValidatedCommand(callIndex: number) {
-  const call = s3Mock.call(callIndex);
-  const command = call?.args?.[0];
-  return PutObjectCommandSchema.parse(command);
+async function uploadImage(
+  matchIdValue: string,
+  queueType = "solo",
+  body = new TextEncoder().encode(`${queueType}-image-data`),
+) {
+  return saveImageToS3(MatchIdSchema.parse(matchIdValue), body, queueType, []);
 }
 
-beforeEach(() => {
-  // Ensure S3_BUCKET_NAME is set for tests, then force the configuration
-  // singleton to re-read it (values are memoized behind lazy getters).
-  Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-  resetConfigurationForTests();
-  // Reset mock before each test
-  s3Mock.reset();
-});
+beforeEach(resetS3TestState);
+afterEach(resetS3TestState);
 
-afterEach(() => {
-  // Restore the default bucket for subsequent files and drop any per-test
-  // configuration override.
-  Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-  resetConfigurationForTests();
-  // Reset mock after each test
-  s3Mock.reset();
-});
+describe("saveImageToS3 success cases", () => {
+  test("uploads an image with the expected parameters and URL", async () => {
+    mockSuccessfulPut();
 
-// ============================================================================
-// Success Cases
-// ============================================================================
+    const result = await uploadImage("NA1_1234567890");
+    const command = getValidatedPutCommand();
 
-describe("saveImageToS3 - Success Cases", () => {
-  test("uploads image with correct parameters", async () => {
-    const matchId = MatchIdSchema.parse("NA1_1234567890");
-    const imageBuffer = new TextEncoder().encode("fake-png-data");
-    const queueType = "solo";
-
-    // Mock successful S3 upload
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    // Verify S3 command was called once with valid structure
-    expect(s3Mock.calls().length).toBe(1);
-    const command = getValidatedCommand(0);
+    expect(s3Mock.calls()).toHaveLength(1);
     expect(command.input.Bucket).toBe("test-bucket");
-
-    // Verify return value format
+    expect(command.input.ContentType).toBe("image/png");
     expect(result).toMatch(
       /^s3:\/\/test-bucket\/games\/\d{4}\/\d{2}\/\d{2}\/NA1_1234567890\/report\.png$/,
     );
-    expect(result).toContain(matchId);
+    expect(result).toContain("NA1_1234567890");
   });
 
-  test("handles arena queue type", async () => {
-    const matchId = MatchIdSchema.parse("NA1_9999999999");
-    const imageBuffer = new TextEncoder().encode("arena-image-data");
-    const queueType = "arena";
+  test.each([
+    {
+      name: "arena",
+      matchId: "NA1_9999999999",
+      expectedKeyFragment: "NA1_9999999999",
+    },
+    {
+      name: "flex",
+      matchId: "EUW1_5555555555",
+      expectedKeyFragment: "EUW1_5555555555",
+    },
+    {
+      name: "unknown",
+      matchId: "KR_1111111111",
+      expectedKeyFragment: "KR_1111111111",
+    },
+  ])(
+    "handles the $name queue",
+    async ({ name, matchId, expectedKeyFragment }) => {
+      mockSuccessfulPut();
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+      const result = await uploadImage(matchId, name);
+      const command = getValidatedPutCommand();
 
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
+      expect(s3Mock.calls()).toHaveLength(1);
+      expect(command.input.Key).toContain(expectedKeyFragment);
+      expect(command.input.Metadata?.["queueType"]).toBe(name);
+      expect(result).toBeDefined();
+    },
+  );
 
-    expect(s3Mock.calls().length).toBe(1);
-    const command = getValidatedCommand(0);
-    expect(command.input.ContentType).toBe("image/png");
-
-    expect(result).toBeDefined();
-    expect(result).toContain("s3://test-bucket/games/");
-  });
-
-  test("handles flex queue type", async () => {
-    const matchId = MatchIdSchema.parse("EUW1_5555555555");
-    const imageBuffer = new TextEncoder().encode("flex-image-data");
-    const queueType = "flex";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-    const command = getValidatedCommand(0);
-    expect(command.input.Bucket).toBe("test-bucket");
-
-    expect(result).toBeDefined();
-  });
-
-  test("handles unknown queue type", async () => {
-    const matchId = MatchIdSchema.parse("KR_1111111111");
-    const imageBuffer = new TextEncoder().encode("unknown-image-data");
-    const queueType = "unknown";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-    const command = getValidatedCommand(0);
-    expect(command.input.Key).toContain("KR_1111111111");
-
-    expect(result).toBeDefined();
-  });
-
-  test("handles large image buffers", async () => {
-    const matchId = MatchIdSchema.parse("NA1_LARGE");
-    // Create a 5MB buffer
+  test("preserves a large image buffer", async () => {
     const imageBuffer = new Uint8Array(5 * 1024 * 1024);
-    const queueType = "solo";
+    mockSuccessfulPut();
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+    await uploadImage("NA1_LARGE", "solo", imageBuffer);
 
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-
-    const command = getValidatedCommand(0);
-    expect(command.input.Body).toBeInstanceOf(Uint8Array);
-    if (command.input.Body instanceof Uint8Array) {
-      expect(command.input.Body.length).toBe(5 * 1024 * 1024);
+    const body = getValidatedPutCommand().input.Body;
+    expect(body).toBeInstanceOf(Uint8Array);
+    if (body instanceof Uint8Array) {
+      expect(body).toHaveLength(5 * 1024 * 1024);
     }
-
-    expect(result).toBeDefined();
   });
 
-  test("handles match IDs with special characters", async () => {
-    const matchId = MatchIdSchema.parse("NA1_1234567890_SPECIAL");
-    const imageBuffer = new TextEncoder().encode("special-image-data");
-    const queueType = "solo";
+  test("retains special characters in the key, metadata, and URL", async () => {
+    const matchId = "NA1_1234567890_SPECIAL";
+    mockSuccessfulPut();
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+    const result = await uploadImage(matchId);
+    const command = getValidatedPutCommand();
 
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-
-    const command = getValidatedCommand(0);
     expect(command.input.Key).toContain(matchId);
-    expect(command.input.Metadata?.matchId).toBe(matchId);
-
+    expect(command.input.Metadata?.["matchId"]).toBe(matchId);
     expect(result).toContain(matchId);
   });
 });
 
-// ============================================================================
-// Configuration Cases
-// ============================================================================
+describe("saveImageToS3 configuration", () => {
+  test.each([
+    { name: "missing", bucket: undefined, matchId: "NA1_NO_BUCKET" },
+    { name: "empty", bucket: "", matchId: "NA1_EMPTY_BUCKET" },
+  ])(
+    "skips upload when S3_BUCKET_NAME is $name",
+    async ({ bucket, matchId }) => {
+      setS3TestBucket(bucket);
+      mockSuccessfulPut();
 
-describe("saveImageToS3 - Configuration", () => {
-  test("returns undefined when S3_BUCKET_NAME is not configured", async () => {
-    delete Bun.env["S3_BUCKET_NAME"];
-    resetConfigurationForTests();
+      await expect(uploadImage(matchId)).resolves.toBeUndefined();
+      expect(s3Mock.calls()).toHaveLength(0);
+    },
+  );
+});
 
-    const matchId = MatchIdSchema.parse("NA1_NO_BUCKET");
-    const imageBuffer = new TextEncoder().encode("image-data");
+describe("saveImageToS3 error handling", () => {
+  test.each([
+    {
+      matchId: "NA1_ERROR_CASE",
+      failure: "S3 upload failed",
+      expected: "Failed to save PNG NA1_ERROR_CASE to S3",
+    },
+    {
+      matchId: "EUW1_SPECIFIC_ERROR",
+      failure: "Network timeout",
+      expected: "Failed to save PNG EUW1_SPECIFIC_ERROR to S3",
+    },
+  ])(
+    "reports $matchId when upload fails",
+    async ({ matchId, failure, expected }) => {
+      mockFailedPut(failure);
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+      await expect(uploadImage(matchId)).rejects.toThrow(expected);
+      expect(s3Mock.calls()).toHaveLength(3);
+    },
+  );
 
-    const result = await saveImageToS3(matchId, imageBuffer, "solo", []);
+  test("returns a URL when the SDK resolves a non-200 response", async () => {
+    mockSuccessfulPut(500);
 
-    // No bucket → no upload attempted, undefined returned.
-    expect(result).toBeUndefined();
-    expect(s3Mock.calls().length).toBe(0);
+    await expect(uploadImage("NA1_BAD_STATUS")).resolves.toBeDefined();
   });
 
-  test("returns undefined when S3_BUCKET_NAME is empty string", async () => {
-    Bun.env["S3_BUCKET_NAME"] = "";
-    resetConfigurationForTests();
+  test("preserves the original error details", async () => {
+    const matchId = "NA1_DETAILED_ERROR";
+    mockFailedPut("Access Denied");
 
-    const matchId = MatchIdSchema.parse("NA1_EMPTY_BUCKET");
-    const imageBuffer = new TextEncoder().encode("image-data");
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveImageToS3(matchId, imageBuffer, "solo", []);
-
-    // getOptionalEnvVar treats an empty string as "not configured".
-    expect(result).toBeUndefined();
-    expect(s3Mock.calls().length).toBe(0);
+    await expect(uploadImage(matchId)).rejects.toThrow(
+      "Failed to save PNG NA1_DETAILED_ERROR to S3: Access Denied",
+    );
   });
 });
 
-// ============================================================================
-// Error Cases
-// ============================================================================
+describe("saveImageToS3 key and URL format", () => {
+  test("uses today's date, a PNG extension, and an s3 URL", async () => {
+    mockSuccessfulPut();
 
-describe("saveImageToS3 - Error Handling", () => {
-  test("throws error when S3 upload fails", async () => {
-    const matchId = MatchIdSchema.parse("NA1_ERROR_CASE");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
+    const result = await uploadImage("NA1_DATE_TEST");
+    const key = getValidatedPutCommand().input.Key;
 
-    // Mock S3 error
-    s3Mock.on(PutObjectCommand).rejects(new Error("S3 upload failed"));
-
-    await expect(
-      saveImageToS3(matchId, imageBuffer, queueType, []),
-    ).rejects.toThrow("Failed to save PNG NA1_ERROR_CASE to S3");
-
-    // Retried MAX_PUT_ATTEMPTS (3) times before throwing.
-    expect(s3Mock.calls().length).toBe(3);
-  });
-
-  test("throws error with match ID in error message", async () => {
-    const matchId = MatchIdSchema.parse("EUW1_SPECIFIC_ERROR");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "flex";
-
-    s3Mock.on(PutObjectCommand).rejects(new Error("Network timeout"));
-
-    await expect(
-      saveImageToS3(matchId, imageBuffer, queueType, []),
-    ).rejects.toThrow("Failed to save PNG EUW1_SPECIFIC_ERROR to S3");
-  });
-
-  test("throws error when S3 returns non-200 status", async () => {
-    const matchId = MatchIdSchema.parse("NA1_BAD_STATUS");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 500 },
-    });
-
-    // Note: AWS SDK typically throws for non-200, but if it doesn't,
-    // our code should still handle it. This test documents expected behavior.
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    // Current implementation returns the URL even if status is not 200
-    // This is acceptable since AWS SDK will throw on actual errors
-    expect(result).toBeDefined();
-  });
-
-  test("preserves original error details", async () => {
-    const matchId = MatchIdSchema.parse("NA1_DETAILED_ERROR");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    const originalError = new Error("Access Denied");
-    s3Mock.on(PutObjectCommand).rejects(originalError);
-
-    try {
-      await saveImageToS3(matchId, imageBuffer, queueType, []);
-      expect(true).toBe(false); // Should not reach here
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      if (error instanceof Error) {
-        expect(error.message).toContain("Failed to save PNG");
-        expect(error.message).toContain(matchId);
-        expect(error.message).toContain("Access Denied");
-      }
-    }
-  });
-});
-
-// ============================================================================
-// S3 Key Format Tests
-// ============================================================================
-
-describe("saveImageToS3 - S3 Key Format", () => {
-  test("uses current date in S3 key", async () => {
-    const matchId = MatchIdSchema.parse("NA1_DATE_TEST");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    const command = getValidatedCommand(0);
-
-    // Verify key structure
-    const key = command.input.Key;
     expect(key).toMatch(
       /^games\/\d{4}\/\d{2}\/\d{2}\/NA1_DATE_TEST\/report\.png$/,
     );
-
-    // Verify it uses today's date
-    const now = new Date();
-    const year = now.getUTCFullYear();
-    const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(now.getUTCDate()).padStart(2, "0");
-
-    expect(key).toContain(`games/${year.toString()}/${month}/${day}/`);
-  });
-
-  test("uses .png extension", async () => {
-    const matchId = MatchIdSchema.parse("NA1_PNG_EXT");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    const command = getValidatedCommand(0);
-
-    expect(command.input.Key.endsWith(".png")).toBe(true);
-  });
-
-  test("returns s3:// URL format", async () => {
-    const matchId = MatchIdSchema.parse("NA1_URL_FORMAT");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    if (result === undefined) throw new Error("Expected an uploaded image URL");
-    expect(result.startsWith("s3://test-bucket/")).toBe(true);
-    expect(result).toContain("games/");
-    expect(result.endsWith(".png")).toBe(true);
+    expect(key).toContain(`games/${currentUtcDatePath()}/`);
+    expect(key.endsWith(".png")).toBe(true);
+    expect(result).toMatch(/^s3:\/\/test-bucket\/games\/.+\.png$/);
   });
 });
 
-// ============================================================================
-// Metadata Tests
-// ============================================================================
-
-describe("saveImageToS3 - Metadata", () => {
-  test("includes all required metadata fields", async () => {
-    const matchId = MatchIdSchema.parse("NA1_METADATA");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-    const command = getValidatedCommand(0);
-    expect(command.input.Metadata?.matchId).toBe(matchId);
-    expect(command.input.Metadata?.queueType).toBe(queueType);
-    expect(command.input.Metadata?.uploadedAt).toBeDefined();
-  });
-
-  test("uploadedAt timestamp is recent", async () => {
-    const matchId = MatchIdSchema.parse("NA1_TIMESTAMP");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
+describe("saveImageToS3 metadata", () => {
+  test("records match, queue, and a recent upload timestamp", async () => {
     const beforeUpload = new Date();
-    await saveImageToS3(matchId, imageBuffer, queueType, []);
+    mockSuccessfulPut();
+
+    await uploadImage("NA1_METADATA");
     const afterUpload = new Date();
+    const metadata = getValidatedPutCommand().input.Metadata;
+    const uploadedAt = metadata?.["uploadedAt"];
 
-    const command = getValidatedCommand(0);
-    const uploadedAtStr = command.input.Metadata?.uploadedAt;
-    expect(uploadedAtStr).toBeDefined();
+    expect(metadata?.["matchId"]).toBe("NA1_METADATA");
+    expect(metadata?.["queueType"]).toBe("solo");
+    expect(uploadedAt).toBeDefined();
 
-    if (uploadedAtStr) {
-      const uploadedAt = new Date(uploadedAtStr);
-      expect(uploadedAt.getTime()).toBeGreaterThanOrEqual(
-        beforeUpload.getTime(),
-      );
-      expect(uploadedAt.getTime()).toBeLessThanOrEqual(afterUpload.getTime());
+    if (uploadedAt !== undefined) {
+      const timestamp = new Date(uploadedAt).getTime();
+      expect(timestamp).toBeGreaterThanOrEqual(beforeUpload.getTime());
+      expect(timestamp).toBeLessThanOrEqual(afterUpload.getTime());
     }
   });
 });

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-svg.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-svg.test.ts
@@ -1,373 +1,176 @@
-/**
- * S3 SVG Storage Tests using aws-sdk-client-mock
- *
- * These tests verify SVG storage functionality using in-memory mocking.
- */
-
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { mockClient } from "aws-sdk-client-mock";
-import { z } from "zod";
-import { saveSvgToS3 } from "#src/storage/s3.ts";
-import { resetConfigurationForTests } from "#src/configuration.ts";
 import { MatchIdSchema } from "@scout-for-lol/data";
+import { saveSvgToS3 } from "#src/storage/s3.ts";
+import {
+  currentUtcDatePath,
+  getValidatedPutCommand,
+  mockFailedPut,
+  mockSuccessfulPut,
+  resetS3TestState,
+  s3Mock,
+  setS3TestBucket,
+} from "#src/storage/s3-test-helpers.ts";
 
-// Create S3 mock
-const s3Mock = mockClient(S3Client);
-
-// Zod schema for validating PutObjectCommand structure from mocks
-const PutObjectCommandSchema = z.object({
-  input: z.object({
-    Bucket: z.string(),
-    Key: z.string(),
-    Body: z.union([z.instanceof(Uint8Array), z.string()]),
-    ContentType: z.string(),
-    Metadata: z
-      .object({
-        matchId: z.string(),
-        queueType: z.string(),
-        uploadedAt: z.string(),
-      })
-      .optional(),
-  }),
-});
-
-// Helper to safely get and validate command from mock call
-function getValidatedCommand(callIndex: number) {
-  const call = s3Mock.call(callIndex);
-  const command = call?.args?.[0];
-  return PutObjectCommandSchema.parse(command);
+async function uploadSvg(
+  matchIdValue: string,
+  queueType = "solo",
+  svgContent = "<svg></svg>",
+) {
+  return saveSvgToS3(
+    MatchIdSchema.parse(matchIdValue),
+    svgContent,
+    queueType,
+    [],
+  );
 }
 
-beforeEach(() => {
-  // Ensure S3_BUCKET_NAME is set for tests, then re-read the memoized config.
-  Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-  resetConfigurationForTests();
-  // Reset mock before each test
-  s3Mock.reset();
-});
+beforeEach(resetS3TestState);
+afterEach(resetS3TestState);
 
-afterEach(() => {
-  // Restore the default bucket and drop any per-test configuration override.
-  Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-  resetConfigurationForTests();
-  // Reset mock after each test
-  s3Mock.reset();
-});
+describe("saveSvgToS3 success cases", () => {
+  test("uploads SVG with the expected parameters and URL", async () => {
+    mockSuccessfulPut();
 
-// ============================================================================
-// Success Cases
-// ============================================================================
+    const result = await uploadSvg(
+      "NA1_1234567890",
+      "solo",
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>',
+    );
+    const command = getValidatedPutCommand();
 
-describe("saveSvgToS3 - Success Cases", () => {
-  test("uploads SVG with correct parameters", async () => {
-    const matchId = MatchIdSchema.parse("NA1_1234567890");
-    const svgContent =
-      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>';
-    const queueType = "solo";
-
-    // Mock successful S3 upload
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    // Verify S3 command was called once
-    expect(s3Mock.calls().length).toBe(1);
-
-    // Get and validate the command that was called
-    const command = getValidatedCommand(0);
+    expect(s3Mock.calls()).toHaveLength(1);
     expect(command.input.Bucket).toBe("test-bucket");
     expect(command.input.ContentType).toBe("image/svg+xml");
-
-    // Verify return value format
     expect(result).toMatch(
       /^s3:\/\/test-bucket\/games\/\d{4}\/\d{2}\/\d{2}\/NA1_1234567890\/report\.svg$/,
     );
   });
 
-  test("handles arena queue type", async () => {
-    const matchId = MatchIdSchema.parse("NA1_ARENA");
-    const svgContent = "<svg></svg>";
-    const queueType = "arena";
+  test("handles the arena queue", async () => {
+    mockSuccessfulPut();
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+    const result = await uploadSvg("NA1_ARENA", "arena");
+    const command = getValidatedPutCommand();
 
-    const result = await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-
-    const command = getValidatedCommand(0);
+    expect(s3Mock.calls()).toHaveLength(1);
     expect(command.input.Key).toContain("NA1_ARENA");
-
+    expect(command.input.Metadata?.["queueType"]).toBe("arena");
     expect(result).toBeDefined();
   });
 
   test("handles large SVG content", async () => {
-    const matchId = MatchIdSchema.parse("NA1_LARGE_SVG");
-    // Create a large SVG (simulating complex match report)
-    const largeSvgContent = "<svg>" + "x".repeat(100_000) + "</svg>";
-    const queueType = "solo";
+    mockSuccessfulPut();
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+    await uploadSvg(
+      "NA1_LARGE_SVG",
+      "solo",
+      `<svg>${"x".repeat(100_000)}</svg>`,
+    );
 
-    const result = await saveSvgToS3(matchId, largeSvgContent, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-
-    const command = getValidatedCommand(0);
-    // Body should be Uint8Array or string
-    expect(command.input.Body).toBeDefined();
-    const isValidBody =
-      command.input.Body instanceof Uint8Array ||
-      typeof command.input.Body === "string";
-    expect(isValidBody).toBe(true);
-
-    expect(result).toBeDefined();
+    const body = getValidatedPutCommand().input.Body;
+    expect(body).toBeDefined();
+    expect(body instanceof Uint8Array || typeof body === "string").toBe(true);
   });
 
-  test("handles SVG with special XML characters", async () => {
-    const matchId = MatchIdSchema.parse("NA1_SPECIAL_CHARS");
-    const svgContent =
-      '<svg xmlns="http://www.w3.org/2000/svg"><text>&lt;&gt;&amp;&quot;&#x27;</text></svg>';
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    expect(s3Mock.calls().length).toBe(1);
-    expect(result).toBeDefined();
-  });
-});
-
-// ============================================================================
-// Configuration Cases
-// ============================================================================
-
-describe("saveSvgToS3 - Configuration", () => {
-  test("returns undefined when S3_BUCKET_NAME is not configured", async () => {
-    delete Bun.env["S3_BUCKET_NAME"];
-    resetConfigurationForTests();
-
-    const matchId = MatchIdSchema.parse("NA1_SVG_NO_BUCKET");
-    const svgContent = "<svg></svg>";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveSvgToS3(matchId, svgContent, "solo", []);
-
-    expect(result).toBeUndefined();
-    expect(s3Mock.calls().length).toBe(0);
-  });
-});
-
-// ============================================================================
-// Error Cases
-// ============================================================================
-
-describe("saveSvgToS3 - Error Handling", () => {
-  test("throws error when S3 upload fails", async () => {
-    const matchId = MatchIdSchema.parse("NA1_ERROR");
-    const svgContent = "<svg></svg>";
-    const queueType = "solo";
-
-    // Mock S3 error
-    s3Mock.on(PutObjectCommand).rejects(new Error("S3 upload failed"));
+  test("handles SVG XML entities", async () => {
+    mockSuccessfulPut();
 
     await expect(
-      saveSvgToS3(matchId, svgContent, queueType, []),
-    ).rejects.toThrow("Failed to save SVG NA1_ERROR to S3");
-
-    // Retried MAX_PUT_ATTEMPTS (3) times before throwing.
-    expect(s3Mock.calls().length).toBe(3);
-  });
-
-  test("throws error with match ID in error message", async () => {
-    const matchId = MatchIdSchema.parse("EUW1_NETWORK_ERROR");
-    const svgContent = "<svg></svg>";
-    const queueType = "flex";
-
-    s3Mock.on(PutObjectCommand).rejects(new Error("Network timeout"));
-
-    await expect(
-      saveSvgToS3(matchId, svgContent, queueType, []),
-    ).rejects.toThrow("Failed to save SVG EUW1_NETWORK_ERROR to S3");
+      uploadSvg(
+        "NA1_SPECIAL_CHARS",
+        "solo",
+        "<svg><text>&lt;&gt;&amp;&quot;&#x27;</text></svg>",
+      ),
+    ).resolves.toBeDefined();
+    expect(s3Mock.calls()).toHaveLength(1);
   });
 });
 
-// ============================================================================
-// S3 Key Format Tests
-// ============================================================================
+describe("saveSvgToS3 configuration", () => {
+  test("skips upload when the bucket is absent", async () => {
+    setS3TestBucket(undefined);
+    mockSuccessfulPut();
 
-describe("saveSvgToS3 - S3 Key Format", () => {
-  test("uses current date in S3 key", async () => {
-    const matchId = MatchIdSchema.parse("NA1_DATE_TEST");
-    const svgContent = "<svg></svg>";
-    const queueType = "solo";
+    await expect(uploadSvg("NA1_SVG_NO_BUCKET")).resolves.toBeUndefined();
+    expect(s3Mock.calls()).toHaveLength(0);
+  });
+});
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+describe("saveSvgToS3 error handling", () => {
+  test.each([
+    {
+      matchId: "NA1_ERROR",
+      failure: "S3 upload failed",
+      expected: "Failed to save SVG NA1_ERROR to S3",
+    },
+    {
+      matchId: "EUW1_NETWORK_ERROR",
+      failure: "Network timeout",
+      expected: "Failed to save SVG EUW1_NETWORK_ERROR to S3",
+    },
+  ])(
+    "reports $matchId when upload fails",
+    async ({ matchId, failure, expected }) => {
+      mockFailedPut(failure);
 
-    await saveSvgToS3(matchId, svgContent, queueType, []);
+      await expect(uploadSvg(matchId)).rejects.toThrow(expected);
+      expect(s3Mock.calls()).toHaveLength(3);
+    },
+  );
+});
 
-    const command = getValidatedCommand(0);
+describe("saveSvgToS3 key and URL format", () => {
+  test("uses today's date, an SVG extension, and an s3 URL", async () => {
+    mockSuccessfulPut();
 
-    // Verify key structure
-    const key = command.input.Key;
+    const result = await uploadSvg("NA1_DATE_TEST");
+    const key = getValidatedPutCommand().input.Key;
+
     expect(key).toMatch(
       /^games\/\d{4}\/\d{2}\/\d{2}\/NA1_DATE_TEST\/report\.svg$/,
     );
-
-    // Verify it uses today's date
-    const now = new Date();
-    const year = now.getUTCFullYear();
-    const month = String(now.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(now.getUTCDate()).padStart(2, "0");
-
-    expect(key).toContain(`games/${year.toString()}/${month}/${day}/`);
-  });
-
-  test("uses .svg extension", async () => {
-    const matchId = MatchIdSchema.parse("NA1_SVG_EXT");
-    const svgContent = "<svg></svg>";
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    const command = getValidatedCommand(0);
-
-    expect(command.input.Key.endsWith(".svg")).toBe(true);
-  });
-
-  test("returns s3:// URL format", async () => {
-    const matchId = MatchIdSchema.parse("NA1_URL_FORMAT");
-    const svgContent = "<svg></svg>";
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    const result = await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    if (result === undefined) throw new Error("Expected an uploaded SVG URL");
-    expect(result.startsWith("s3://test-bucket/")).toBe(true);
-    expect(result).toContain("games/");
-    expect(result.endsWith(".svg")).toBe(true);
+    expect(key).toContain(`games/${currentUtcDatePath()}/`);
+    expect(key.endsWith(".svg")).toBe(true);
+    expect(result).toMatch(/^s3:\/\/test-bucket\/games\/.+\.svg$/);
   });
 });
 
-// ============================================================================
-// Content Type and Metadata Tests
-// ============================================================================
+describe("saveSvgToS3 content and metadata", () => {
+  test("records content type, match, queue, and upload time", async () => {
+    mockSuccessfulPut();
 
-describe("saveSvgToS3 - Content Type and Metadata", () => {
-  test("sets correct ContentType for SVG", async () => {
-    const matchId = MatchIdSchema.parse("NA1_CONTENT_TYPE");
-    const svgContent = "<svg></svg>";
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    const command = getValidatedCommand(0);
+    await uploadSvg("NA1_METADATA");
+    const command = getValidatedPutCommand();
 
     expect(command.input.ContentType).toBe("image/svg+xml");
+    expect(command.input.Metadata?.["matchId"]).toBe("NA1_METADATA");
+    expect(command.input.Metadata?.["queueType"]).toBe("solo");
+    expect(command.input.Metadata?.["uploadedAt"]).toBeDefined();
   });
 
-  test("includes all required metadata fields", async () => {
-    const matchId = MatchIdSchema.parse("NA1_METADATA");
-    const svgContent = "<svg></svg>";
-    const queueType = "solo";
+  test("encodes Unicode SVG content", async () => {
+    mockSuccessfulPut();
 
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+    await uploadSvg("NA1_UTF8", "solo", "<svg><text>Hello 世界</text></svg>");
 
-    await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    const command = getValidatedCommand(0);
-    expect(command.input.Metadata?.matchId).toBe(matchId);
-    expect(command.input.Metadata?.queueType).toBe(queueType);
-    expect(command.input.Metadata?.uploadedAt).toBeDefined();
-  });
-
-  test("converts SVG string to UTF-8 buffer", async () => {
-    const matchId = MatchIdSchema.parse("NA1_UTF8");
-    const svgContent = "<svg><text>Hello 世界</text></svg>";
-    const queueType = "solo";
-
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
-
-    await saveSvgToS3(matchId, svgContent, queueType, []);
-
-    const command = getValidatedCommand(0);
-    expect(command.input.Body).toBeDefined();
-    // Body should be a Uint8Array (UTF-8 encoded)
-    expect(
-      command.input.Body instanceof Uint8Array ||
-        typeof command.input.Body === "string",
-    ).toBe(true);
+    const body = getValidatedPutCommand().input.Body;
+    expect(body).toBeDefined();
+    expect(body instanceof Uint8Array || typeof body === "string").toBe(true);
   });
 });
 
-// ============================================================================
-// Concurrent Operations
-// ============================================================================
+describe("saveSvgToS3 concurrent operations", () => {
+  test("handles multiple concurrent uploads", async () => {
+    mockSuccessfulPut();
 
-describe("saveSvgToS3 - Concurrent Operations", () => {
-  test("handles multiple concurrent SVG uploads", async () => {
-    s3Mock.on(PutObjectCommand).resolves({
-      $metadata: { httpStatusCode: 200 },
-    });
+    const results = await Promise.all([
+      uploadSvg("NA1_CONCURRENT_1", "solo", "<svg>1</svg>"),
+      uploadSvg("NA1_CONCURRENT_2", "flex", "<svg>2</svg>"),
+      uploadSvg("NA1_CONCURRENT_3", "arena", "<svg>3</svg>"),
+    ]);
 
-    const uploads = [
-      saveSvgToS3(
-        MatchIdSchema.parse("NA1_CONCURRENT_1"),
-        "<svg>1</svg>",
-        "solo",
-        [],
-      ),
-      saveSvgToS3(
-        MatchIdSchema.parse("NA1_CONCURRENT_2"),
-        "<svg>2</svg>",
-        "flex",
-        [],
-      ),
-      saveSvgToS3(
-        MatchIdSchema.parse("NA1_CONCURRENT_3"),
-        "<svg>3</svg>",
-        "arena",
-        [],
-      ),
-    ];
-
-    const results = await Promise.all(uploads);
-
-    expect(s3Mock.calls().length).toBe(3);
+    expect(s3Mock.calls()).toHaveLength(3);
     expect(results).toHaveLength(3);
-
-    // Verify each result is unique
     expect(results[0]).toContain("NA1_CONCURRENT_1");
     expect(results[1]).toContain("NA1_CONCURRENT_2");
     expect(results[2]).toContain("NA1_CONCURRENT_3");

--- a/packages/scout-for-lol/packages/backend/src/storage/s3-test-helpers.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3-test-helpers.ts
@@ -1,0 +1,51 @@
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { mockClient } from "aws-sdk-client-mock";
+import { z } from "zod";
+import { resetConfigurationForTests } from "#src/configuration.ts";
+
+const PutObjectCommandSchema = z.object({
+  input: z.object({
+    Bucket: z.string(),
+    Key: z.string(),
+    Body: z.union([z.instanceof(Uint8Array), z.string()]),
+    ContentType: z.string(),
+    Metadata: z.record(z.string(), z.string()).optional(),
+  }),
+});
+
+export const s3Mock = mockClient(S3Client);
+
+export function resetS3TestState(): void {
+  Bun.env["S3_BUCKET_NAME"] = "test-bucket";
+  resetConfigurationForTests();
+  s3Mock.reset();
+}
+
+export function setS3TestBucket(bucket: string | undefined): void {
+  if (bucket === undefined) {
+    delete Bun.env["S3_BUCKET_NAME"];
+  } else {
+    Bun.env["S3_BUCKET_NAME"] = bucket;
+  }
+  resetConfigurationForTests();
+}
+
+export function mockSuccessfulPut(httpStatusCode = 200): void {
+  s3Mock.on(PutObjectCommand).resolves({ $metadata: { httpStatusCode } });
+}
+
+export function mockFailedPut(message: string): void {
+  s3Mock.on(PutObjectCommand).rejects(new Error(message));
+}
+
+export function getValidatedPutCommand(callIndex = 0) {
+  return PutObjectCommandSchema.parse(s3Mock.call(callIndex).args[0]);
+}
+
+export function currentUtcDatePath(now = new Date()): string {
+  return [
+    now.getUTCFullYear().toString(),
+    String(now.getUTCMonth() + 1).padStart(2, "0"),
+    String(now.getUTCDate()).padStart(2, "0"),
+  ].join("/");
+}

--- a/packages/scout-for-lol/packages/backend/src/storage/s3.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/storage/s3.test.ts
@@ -1,32 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { mockClient } from "aws-sdk-client-mock";
-import { z } from "zod";
+import { RawMatchSchema, type RawMatch } from "@scout-for-lol/data";
+import { saveMatchToS3 } from "#src/storage/s3.ts";
 import {
-  MatchIdSchema,
-  RawMatchSchema,
-  type RawMatch,
-} from "@scout-for-lol/data";
-import { saveImageToS3, saveMatchToS3 } from "#src/storage/s3.ts";
-import { resetConfigurationForTests } from "#src/configuration.ts";
-
-const s3Mock = mockClient(S3Client);
-
-// Zod schema for validating PutObjectCommand structure captured by the mock.
-const PutCommandSchema = z.object({
-  input: z.object({
-    Bucket: z.string(),
-    Key: z.string(),
-    Body: z.union([z.instanceof(Uint8Array), z.string()]),
-    ContentType: z.string(),
-    Metadata: z.record(z.string(), z.string()).optional(),
-  }),
-});
-
-function getValidatedPutCommand(callIndex: number) {
-  const call = s3Mock.call(callIndex);
-  return PutCommandSchema.parse(call?.args?.[0]);
-}
+  getValidatedPutCommand,
+  mockFailedPut,
+  mockSuccessfulPut,
+  resetS3TestState,
+  s3Mock,
+  setS3TestBucket,
+} from "#src/storage/s3-test-helpers.ts";
 
 async function loadMatchFixture(): Promise<RawMatch> {
   const fixtureUrl = new URL(
@@ -37,182 +19,155 @@ async function loadMatchFixture(): Promise<RawMatch> {
   return RawMatchSchema.parse(json);
 }
 
-// ============================================================================
-// S3 Key Generation Tests (unit tests for the logic)
-// ============================================================================
+type KeyCase = {
+  name: string;
+  date: string;
+  matchId: string;
+  filename: string;
+  expected: string;
+};
 
-describe("S3 Key Generation Logic for Matches", () => {
-  test("match key follows game-centric hierarchical date structure", () => {
-    const matchId = "NA1_1234567890";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
+const keyCases: KeyCase[] = [
+  {
+    name: "match key follows the game hierarchy",
+    date: "2025-10-16T14:30:45Z",
+    matchId: "NA1_1234567890",
+    filename: "match.json",
+    expected: "games/2025/10/16/NA1_1234567890/match.json",
+  },
+  {
+    name: "match key pads single-digit dates",
+    date: "2025-01-05T08:15:30Z",
+    matchId: "EUW1_9876543210",
+    filename: "match.json",
+    expected: "games/2025/01/05/EUW1_9876543210/match.json",
+  },
+  {
+    name: "match key retains its JSON extension",
+    date: "2025-12-31T23:59:59Z",
+    matchId: "KR_1111111111",
+    filename: "match.json",
+    expected: "games/2025/12/31/KR_1111111111/match.json",
+  },
+  {
+    name: "image key follows the game hierarchy",
+    date: "2025-10-16T14:30:45Z",
+    matchId: "NA1_1234567890",
+    filename: "report.png",
+    expected: "games/2025/10/16/NA1_1234567890/report.png",
+  },
+  {
+    name: "image key pads single-digit dates",
+    date: "2025-01-05T08:15:30Z",
+    matchId: "EUW1_9876543210",
+    filename: "report.png",
+    expected: "games/2025/01/05/EUW1_9876543210/report.png",
+  },
+  {
+    name: "image key retains its PNG extension",
+    date: "2025-12-31T23:59:59Z",
+    matchId: "KR_1111111111",
+    filename: "report.png",
+    expected: "games/2025/12/31/KR_1111111111/report.png",
+  },
+  {
+    name: "SVG key follows the game hierarchy",
+    date: "2025-10-16T14:30:45Z",
+    matchId: "NA1_1234567890",
+    filename: "report.svg",
+    expected: "games/2025/10/16/NA1_1234567890/report.svg",
+  },
+  {
+    name: "SVG key pads single-digit dates",
+    date: "2025-01-05T08:15:30Z",
+    matchId: "EUW1_9876543210",
+    filename: "report.svg",
+    expected: "games/2025/01/05/EUW1_9876543210/report.svg",
+  },
+  {
+    name: "SVG key retains its SVG extension",
+    date: "2025-12-31T23:59:59Z",
+    matchId: "KR_1111111111",
+    filename: "report.svg",
+    expected: "games/2025/12/31/KR_1111111111/report.svg",
+  },
+  {
+    name: "match key retains special match-id characters",
+    date: "2025-10-16T14:30:45Z",
+    matchId: "NA1_1234567890_SPECIAL",
+    filename: "match.json",
+    expected: "games/2025/10/16/NA1_1234567890_SPECIAL/match.json",
+  },
+  {
+    name: "image key retains special match-id characters",
+    date: "2025-10-16T14:30:45Z",
+    matchId: "EUW1_9876543210_TEST",
+    filename: "report.png",
+    expected: "games/2025/10/16/EUW1_9876543210_TEST/report.png",
+  },
+];
 
-    const expectedKey = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-    expect(expectedKey).toBe("games/2025/10/16/NA1_1234567890/match.json");
+function buildFixtureKey({
+  date,
+  matchId,
+  filename,
+}: Omit<KeyCase, "name" | "expected">): string {
+  const parsed = new Date(date);
+  const year = parsed.getUTCFullYear().toString();
+  const month = String(parsed.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(parsed.getUTCDate()).padStart(2, "0");
+  return `games/${year}/${month}/${day}/${matchId}/${filename}`;
+}
+
+beforeEach(resetS3TestState);
+afterEach(resetS3TestState);
+
+describe("S3 key generation logic", () => {
+  test.each(keyCases)("$name", ({ expected, ...input }) => {
+    expect(buildFixtureKey(input)).toBe(expected);
   });
 
-  test("match key pads single digit months and days", () => {
-    const matchId = "EUW1_9876543210";
-    const date = new Date("2025-01-05T08:15:30Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
+  test("match, PNG, and SVG keys share one game directory", () => {
+    const input = {
+      date: "2025-10-16T14:30:45Z",
+      matchId: "NA1_1234567890",
+    };
+    const matchKey = buildFixtureKey({ ...input, filename: "match.json" });
+    const pngKey = buildFixtureKey({ ...input, filename: "report.png" });
+    const svgKey = buildFixtureKey({ ...input, filename: "report.svg" });
+    const directory = "games/2025/10/16/NA1_1234567890/";
 
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-    expect(key).toBe("games/2025/01/05/EUW1_9876543210/match.json");
-  });
-
-  test("match key uses .json extension", () => {
-    const matchId = "KR_1111111111";
-    const date = new Date("2025-12-31T23:59:59Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-    expect(key.endsWith(".json")).toBe(true);
-  });
-});
-
-describe("S3 Key Generation Logic for Images", () => {
-  test("image key follows game-centric hierarchical date structure", () => {
-    const matchId = "NA1_1234567890";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const expectedKey = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-    expect(expectedKey).toBe("games/2025/10/16/NA1_1234567890/report.png");
-  });
-
-  test("image key pads single digit months and days", () => {
-    const matchId = "EUW1_9876543210";
-    const date = new Date("2025-01-05T08:15:30Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-    expect(key).toBe("games/2025/01/05/EUW1_9876543210/report.png");
-  });
-
-  test("image key uses .png extension", () => {
-    const matchId = "KR_1111111111";
-    const date = new Date("2025-12-31T23:59:59Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-    expect(key.endsWith(".png")).toBe(true);
-  });
-
-  test("image and match keys share same game directory", () => {
-    const matchId = "NA1_1234567890";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const matchKey = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-    const imageKey = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-
-    // Both should share the same game directory
-    const gameDir = `games/${year.toString()}/${month}/${day}/${matchId}/`;
-    expect(matchKey.startsWith(gameDir)).toBe(true);
-    expect(imageKey.startsWith(gameDir)).toBe(true);
-    expect(matchKey).not.toBe(imageKey);
-  });
-});
-
-describe("S3 Key Generation Logic for SVG Images", () => {
-  test("SVG key follows game-centric hierarchical date structure", () => {
-    const matchId = "NA1_1234567890";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const expectedKey = `games/${year.toString()}/${month}/${day}/${matchId}/report.svg`;
-    expect(expectedKey).toBe("games/2025/10/16/NA1_1234567890/report.svg");
-  });
-
-  test("SVG key pads single digit months and days", () => {
-    const matchId = "EUW1_9876543210";
-    const date = new Date("2025-01-05T08:15:30Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/report.svg`;
-    expect(key).toBe("games/2025/01/05/EUW1_9876543210/report.svg");
-  });
-
-  test("SVG key uses .svg extension", () => {
-    const matchId = "KR_1111111111";
-    const date = new Date("2025-12-31T23:59:59Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/report.svg`;
-    expect(key.endsWith(".svg")).toBe(true);
-  });
-
-  test("PNG and SVG keys share game directory structure", () => {
-    const matchId = "NA1_1234567890";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const pngKey = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-    const svgKey = `games/${year.toString()}/${month}/${day}/${matchId}/report.svg`;
-
-    // Both should use the same game directory path
-    const gameDir = `games/${year.toString()}/${month}/${day}/${matchId}/`;
-    expect(pngKey.startsWith(gameDir)).toBe(true);
-    expect(svgKey.startsWith(gameDir)).toBe(true);
-
-    // Only extension should differ
+    expect(matchKey.startsWith(directory)).toBe(true);
+    expect(pngKey.startsWith(directory)).toBe(true);
+    expect(svgKey.startsWith(directory)).toBe(true);
+    expect(matchKey).not.toBe(pngKey);
     expect(pngKey.replace(".png", ".svg")).toBe(svgKey);
   });
+
+  test.each([
+    ["2025-01-01T00:00:00Z", "games/2025/01/01/TEST_123/match.json"],
+    ["2025-06-15T12:00:00Z", "games/2025/06/15/TEST_123/match.json"],
+    ["2025-12-31T23:59:59Z", "games/2025/12/31/TEST_123/match.json"],
+  ])("formats every date component for %s", (date, expected) => {
+    expect(
+      buildFixtureKey({ date, matchId: "TEST_123", filename: "match.json" }),
+    ).toBe(expected);
+  });
 });
 
-// ============================================================================
-// S3 Storage Tests (aws-sdk-client-mock — in-memory, no real S3)
-// ============================================================================
-
-describe("S3 Match Storage", () => {
-  beforeEach(() => {
-    Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-    resetConfigurationForTests();
-    s3Mock.reset();
-  });
-
-  afterEach(() => {
-    Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-    resetConfigurationForTests();
-    s3Mock.reset();
-  });
-
-  test("saveMatchToS3 uploads JSON with correct content type", async () => {
+describe("S3 match storage", () => {
+  test("uploads JSON with the expected key, body, and metadata", async () => {
     const match = await loadMatchFixture();
-    s3Mock
-      .on(PutObjectCommand)
-      .resolves({ $metadata: { httpStatusCode: 200 } });
+    mockSuccessfulPut();
 
     await saveMatchToS3(match, ["Lord ARKΞV", "H6 Hadès"]);
 
-    expect(s3Mock.calls().length).toBe(1);
-    const command = getValidatedPutCommand(0);
+    expect(s3Mock.calls()).toHaveLength(1);
+    const command = getValidatedPutCommand();
+    const matchId = match.metadata.matchId;
+
     expect(command.input.Bucket).toBe("test-bucket");
     expect(command.input.ContentType).toBe("application/json");
-    // Key is dated off gameCreation and ends in match.json.
-    const matchId = match.metadata.matchId;
     expect(command.input.Key).toMatch(
       new RegExp(String.raw`^games/\d{4}/\d{2}/\d{2}/${matchId}/match\.json$`),
     );
@@ -220,215 +175,45 @@ describe("S3 Match Storage", () => {
     expect(command.input.Metadata?.["gameMode"]).toBe(match.info.gameMode);
     expect(command.input.Metadata?.["trackedPlayerCount"]).toBe("2");
     expect(command.input.Metadata).not.toHaveProperty("trackedPlayers");
+    expect(command.input.Body).toBeInstanceOf(Uint8Array);
 
-    // saveToS3 encodes string bodies to a Uint8Array before upload; decode it
-    // back and confirm it round-trips to the original match JSON.
-    const body = command.input.Body;
-    expect(body).toBeInstanceOf(Uint8Array);
-    if (body instanceof Uint8Array) {
-      const parsed: unknown = JSON.parse(new TextDecoder().decode(body));
+    if (command.input.Body instanceof Uint8Array) {
+      const parsed: unknown = JSON.parse(
+        new TextDecoder().decode(command.input.Body),
+      );
       expect(RawMatchSchema.parse(parsed).metadata.matchId).toBe(matchId);
     }
   });
 
-  test("saveMatchToS3 handles missing S3_BUCKET_NAME gracefully", async () => {
-    // Load the fixture before clearing the bucket so there is no await between
-    // the env mutation and the call under test.
+  test("skips upload when the bucket is absent", async () => {
     const match = await loadMatchFixture();
-    delete Bun.env["S3_BUCKET_NAME"];
-    resetConfigurationForTests();
-    s3Mock
-      .on(PutObjectCommand)
-      .resolves({ $metadata: { httpStatusCode: 200 } });
+    setS3TestBucket(undefined);
+    mockSuccessfulPut();
 
     await expect(saveMatchToS3(match, [])).resolves.toBe("skipped_no_bucket");
-    expect(s3Mock.calls().length).toBe(0);
+    expect(s3Mock.calls()).toHaveLength(0);
   });
 
-  test("saveMatchToS3 throws error on S3 failure", async () => {
+  test("retries and reports match context when upload fails", async () => {
     const match = await loadMatchFixture();
-    s3Mock.on(PutObjectCommand).rejects(new Error("S3 upload failed"));
+    mockFailedPut("S3 upload failed");
 
     await expect(saveMatchToS3(match, [])).rejects.toThrow(
       `Failed to save match ${match.metadata.matchId} to S3`,
     );
-    // A network-shaped error is retried MAX_PUT_ATTEMPTS (3) times before throwing.
-    expect(s3Mock.calls().length).toBe(3);
+    expect(s3Mock.calls()).toHaveLength(3);
   });
 });
 
-describe("S3 Image Storage", () => {
-  beforeEach(() => {
-    Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-    resetConfigurationForTests();
-    s3Mock.reset();
-  });
+describe("S3 URL format", () => {
+  test("uses a parseable s3 URL with the expected bucket and key", () => {
+    const url = "s3://my-bucket/games/2025/10/16/NA1_1234567890/report.png";
+    const parts = url.replace("s3://", "").split("/");
 
-  afterEach(() => {
-    Bun.env["S3_BUCKET_NAME"] = "test-bucket";
-    resetConfigurationForTests();
-    s3Mock.reset();
-  });
-
-  test("saveImageToS3 uploads PNG with correct content type", async () => {
-    const matchId = MatchIdSchema.parse("NA1_1234567890");
-    const imageBuffer = new TextEncoder().encode("fake-png-data");
-    s3Mock
-      .on(PutObjectCommand)
-      .resolves({ $metadata: { httpStatusCode: 200 } });
-
-    const result = await saveImageToS3(matchId, imageBuffer, "solo", []);
-
-    expect(s3Mock.calls().length).toBe(1);
-    const command = getValidatedPutCommand(0);
-    expect(command.input.Bucket).toBe("test-bucket");
-    expect(command.input.ContentType).toBe("image/png");
-    expect(command.input.Key).toMatch(
-      /^games\/\d{4}\/\d{2}\/\d{2}\/NA1_1234567890\/report\.png$/,
-    );
-    expect(command.input.Metadata?.["matchId"]).toBe(matchId);
-    expect(command.input.Metadata?.["queueType"]).toBe("solo");
-    if (result === undefined) throw new Error("Expected an uploaded image URL");
-    expect(result.startsWith("s3://test-bucket/")).toBe(true);
-    expect(result.endsWith(".png")).toBe(true);
-  });
-
-  test("saveImageToS3 returns undefined when S3_BUCKET_NAME not configured", async () => {
-    delete Bun.env["S3_BUCKET_NAME"];
-    resetConfigurationForTests();
-
-    const matchId = MatchIdSchema.parse("NA1_NO_BUCKET");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    s3Mock
-      .on(PutObjectCommand)
-      .resolves({ $metadata: { httpStatusCode: 200 } });
-
-    const result = await saveImageToS3(matchId, imageBuffer, "solo", []);
-
-    expect(result).toBeUndefined();
-    expect(s3Mock.calls().length).toBe(0);
-  });
-
-  test("saveImageToS3 throws error on S3 failure", async () => {
-    const matchId = MatchIdSchema.parse("NA1_ERROR_CASE");
-    const imageBuffer = new TextEncoder().encode("image-data");
-    s3Mock.on(PutObjectCommand).rejects(new Error("Access Denied"));
-
-    await expect(
-      saveImageToS3(matchId, imageBuffer, "solo", []),
-    ).rejects.toThrow(`Failed to save PNG ${matchId} to S3`);
-    // "Access Denied" here is a raw Error (no 4xx metadata) → treated as
-    // transient and retried MAX_PUT_ATTEMPTS (3) times before throwing.
-    expect(s3Mock.calls().length).toBe(3);
-  });
-
-  test("saveImageToS3 handles different queue types in metadata", async () => {
-    s3Mock
-      .on(PutObjectCommand)
-      .resolves({ $metadata: { httpStatusCode: 200 } });
-
-    for (const queueType of ["solo", "flex", "arena", "unknown"]) {
-      s3Mock.reset();
-      s3Mock
-        .on(PutObjectCommand)
-        .resolves({ $metadata: { httpStatusCode: 200 } });
-
-      const matchId = MatchIdSchema.parse(`NA1_${queueType.toUpperCase()}`);
-      const imageBuffer = new TextEncoder().encode(`${queueType}-image`);
-
-      await saveImageToS3(matchId, imageBuffer, queueType, []);
-
-      const command = getValidatedPutCommand(0);
-      expect(command.input.Metadata?.["queueType"]).toBe(queueType);
-    }
-  });
-});
-
-// ============================================================================
-// Edge Cases and Error Handling
-// ============================================================================
-
-describe("Edge Cases for S3 Storage", () => {
-  test("match key handles special characters in match IDs", () => {
-    const matchId = "NA1_1234567890_SPECIAL";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-    expect(key).toContain(matchId);
-    expect(key).toBe("games/2025/10/16/NA1_1234567890_SPECIAL/match.json");
-  });
-
-  test("image key handles special characters in match IDs", () => {
-    const matchId = "EUW1_9876543210_TEST";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const key = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-    expect(key).toContain(matchId);
-    expect(key).toBe("games/2025/10/16/EUW1_9876543210_TEST/report.png");
-  });
-
-  test("keys use consistent date formatting across months", () => {
-    const matchId = "TEST_123";
-    const dates = [
-      new Date("2025-01-01T00:00:00Z"),
-      new Date("2025-06-15T12:00:00Z"),
-      new Date("2025-12-31T23:59:59Z"),
-    ];
-
-    for (const date of dates) {
-      const year = date.getUTCFullYear();
-      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-      const day = String(date.getUTCDate()).padStart(2, "0");
-
-      const key = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-
-      // Verify all date parts are 2 digits (except year which is 4)
-      const parts = key.split("/");
-      expect(parts[1]?.length).toBe(4); // year
-      expect(parts[2]?.length).toBe(2); // month
-      expect(parts[3]?.length).toBe(2); // day
-    }
-  });
-
-  test("match and image keys for same match share game directory", () => {
-    const matchId = "NA1_1234567890";
-    const date = new Date("2025-10-16T14:30:45Z");
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-    const day = String(date.getUTCDate()).padStart(2, "0");
-
-    const matchKey = `games/${year.toString()}/${month}/${day}/${matchId}/match.json`;
-    const imageKey = `games/${year.toString()}/${month}/${day}/${matchId}/report.png`;
-
-    // Both should use the same game directory
-    const gameDir = `games/${year.toString()}/${month}/${day}/${matchId}/`;
-    expect(matchKey.startsWith(gameDir)).toBe(true);
-    expect(imageKey.startsWith(gameDir)).toBe(true);
-  });
-});
-
-describe("S3 URL Format", () => {
-  test("saveImageToS3 returns s3:// URL format", () => {
-    const bucket = "my-bucket";
-    const key = "games/2025/10/16/NA1_1234567890/report.png";
-    const expectedUrl = `s3://${bucket}/${key}`;
-
-    expect(expectedUrl).toBe(
+    expect(url).toBe(
       "s3://my-bucket/games/2025/10/16/NA1_1234567890/report.png",
     );
-  });
-
-  test("s3 URL format is parseable", () => {
-    const url = "s3://my-bucket/games/2025/10/16/NA1_1234567890/report.png";
-
     expect(url.startsWith("s3://")).toBe(true);
-    const parts = url.replace("s3://", "").split("/");
     expect(parts[0]).toBe("my-bucket");
     expect(parts.at(-1)).toBe("report.png");
   });


### PR DESCRIPTION
Why

The Scout S3 suites repeated AWS mock setup, command validation, and equivalent key, URL, metadata, and failure scenarios.

What

- Add a typed shared AWS SDK mock harness for Scout S3 storage tests.
- Table-drive independent key, URL, metadata, missing-configuration, and failure expectations.
- Preserve storage behavior coverage while reducing the cumulative jscpd baseline from 70,846 to 68,911 duplicated tokens.

Verification

- `DATABASE_URL=postgres://scout@127.0.0.1:5471/scout_test_unbound bun --no-install --bun vitest --config ../../../../vitest.config.ts run src/storage/s3.test.ts src/storage/s3-image.test.ts src/storage/s3-svg.test.ts --testTimeout 20000`
- `bunx eslint src/storage/s3.test.ts src/storage/s3-image.test.ts src/storage/s3-svg.test.ts src/storage/s3-test-helpers.ts`
- `bunx turbo run test typecheck lint --filter=@scout-for-lol/backend`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No live AWS, beta, or production checks were run. This internal test refactor needs no media.