### PR TITLE
refactor(scout-for-lol): share competition integration fixtures

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1032,13 +1032,9 @@
       "clones": 3,
       "tokens": 329
     },
-    "packages/scout-for-lol/packages/backend/src/database/competition.integration.test.ts|packages/scout-for-lol/packages/backend/src/database/competition.integration.test.ts": {
-      "clones": 3,
-      "tokens": 304
-    },
     "packages/scout-for-lol/packages/backend/src/database/competition/participants.integration.test.ts|packages/scout-for-lol/packages/backend/src/database/competition/participants.integration.test.ts": {
-      "clones": 6,
-      "tokens": 547
+      "clones": 4,
+      "tokens": 309
     },
     "packages/scout-for-lol/packages/backend/src/database/competition/permissions.integration.test.ts|packages/scout-for-lol/packages/backend/src/database/competition/permissions.integration.test.ts": {
       "clones": 1,
@@ -1117,8 +1113,8 @@
       "tokens": 127
     },
     "packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.integration.test.ts|packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.integration.test.ts": {
-      "clones": 3,
-      "tokens": 542
+      "clones": 1,
+      "tokens": 72
     },
     "packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.test.ts|packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.test.ts": {
       "clones": 1,
@@ -1131,14 +1127,6 @@
     "packages/scout-for-lol/packages/backend/src/league/competition/processors/processors.integration.test.ts|packages/scout-for-lol/packages/backend/src/league/competition/processors/processors.integration.test.ts": {
       "clones": 1,
       "tokens": 117
-    },
-    "packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts|packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts": {
-      "clones": 1,
-      "tokens": 76
-    },
-    "packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts|packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.integration.test.ts": {
-      "clones": 1,
-      "tokens": 161
     },
     "packages/scout-for-lol/packages/backend/src/league/initial-history/enqueue.integration.test.ts|packages/scout-for-lol/packages/backend/src/league/initial-history/enqueue.integration.test.ts": {
       "clones": 1,
@@ -1177,8 +1165,8 @@
       "tokens": 76
     },
     "packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.integration.test.ts|packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.integration.test.ts": {
-      "clones": 5,
-      "tokens": 557
+      "clones": 1,
+      "tokens": 75
     },
     "packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/get-image.test.ts|packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/get-image.test.ts": {
       "clones": 3,

--- a/packages/scout-for-lol/packages/backend/src/database/competition.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition.integration.test.ts
@@ -1,10 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
 import { PermissionsBitField, PermissionFlagsBits } from "discord.js";
 import {
-  createCompetition,
-  type CreateCompetitionInput,
-} from "#src/database/competition/queries.ts";
-import {
   addParticipant,
   getParticipantStatus,
 } from "#src/database/competition/participants.ts";
@@ -24,15 +20,13 @@ import type {
   PlayerId,
 } from "@scout-for-lol/data";
 
+import { testGuildId, testAccountId } from "#src/testing/test-ids.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
 import {
-  testGuildId,
-  testAccountId,
-  testChannelId,
-} from "#src/testing/test-ids.ts";
-import {
-  createTestDatabase,
-  deleteIfExists,
-} from "#src/testing/test-database.ts";
+  createCompetitionFixture,
+  createCompetitionPlayerFixture,
+  resetCompetitionFixtures,
+} from "#src/testing/competition-fixtures.ts";
 
 // ============================================================================
 // Test Database Setup
@@ -41,14 +35,7 @@ import {
 const { prisma } = createTestDatabase("competition-business-logic-test");
 
 beforeEach(async () => {
-  // Clean up database before each test
-  await deleteIfExists(() => prisma.competitionSnapshot.deleteMany());
-  await deleteIfExists(() => prisma.competitionParticipant.deleteMany());
-  await deleteIfExists(() => prisma.competition.deleteMany());
-  await deleteIfExists(() => prisma.serverPermission.deleteMany());
-  await deleteIfExists(() => prisma.subscription.deleteMany());
-  await deleteIfExists(() => prisma.account.deleteMany());
-  await deleteIfExists(() => prisma.player.deleteMany());
+  await resetCompetitionFixtures(prisma);
   clearAllRateLimits();
 });
 afterAll(async () => {
@@ -64,16 +51,11 @@ async function createTestPlayer(
   discordId: DiscordAccountId,
   alias: string,
 ): Promise<{ playerId: PlayerId }> {
-  const now = new Date();
-  const player = await prisma.player.create({
-    data: {
-      alias,
-      discordId,
-      serverId,
-      creatorDiscordId: discordId,
-      createdTime: now,
-      updatedTime: now,
-    },
+  const player = await createCompetitionPlayerFixture(prisma, {
+    alias,
+    discordId,
+    serverId,
+    creatorDiscordId: discordId,
   });
   return { playerId: player.id };
 }
@@ -95,36 +77,79 @@ async function createTestCompetition(
   const nextWeek = new Date(now);
   nextWeek.setDate(nextWeek.getDate() + 7);
 
-  const input: CreateCompetitionInput = {
+  const competition = await createCompetitionFixture(prisma, {
     serverId,
     ownerId,
-    channelId: testChannelId("123456789012345678"),
     title: "Test Competition",
     description: "A test competition",
-    visibility: options?.visibility ?? "OPEN",
-    maxParticipants: options?.maxParticipants ?? 50,
-    dates: {
-      type: "FIXED_DATES",
-      startDate: options?.startDate ?? tomorrow,
-      endDate: options?.endDate ?? nextWeek,
-    },
-    criteria: {
-      type: "MOST_GAMES_PLAYED",
-      queues: ["solo"],
-    },
-  };
-
-  const competition = await createCompetition(prisma, input);
-
-  // If cancelled, update it
-  if (options?.isCancelled) {
-    await prisma.competition.update({
-      where: { id: competition.id },
-      data: { isCancelled: true },
-    });
-  }
+    ...(options?.visibility === undefined
+      ? {}
+      : { visibility: options.visibility }),
+    ...(options?.maxParticipants === undefined
+      ? {}
+      : { maxParticipants: options.maxParticipants }),
+    startDate: options?.startDate ?? tomorrow,
+    endDate: options?.endDate ?? nextWeek,
+    ...(options?.isCancelled === undefined
+      ? {}
+      : { cancelled: options.isCancelled }),
+  });
 
   return { competitionId: competition.id };
+}
+
+async function createCompetitionAtLimit() {
+  const serverId = testGuildId("123456789012345678");
+  const ownerId = testAccountId("12300000123");
+  const { competitionId } = await createTestCompetition(serverId, ownerId, {
+    maxParticipants: 2,
+  });
+  const { playerId: player1Id } = await createTestPlayer(
+    serverId,
+    testAccountId("100000000010"),
+    "Player1",
+  );
+  const { playerId: player2Id } = await createTestPlayer(
+    serverId,
+    testAccountId("200000000020"),
+    "Player2",
+  );
+  await addParticipant({
+    prisma,
+    competitionId,
+    playerId: player1Id,
+    status: "JOINED",
+  });
+  await addParticipant({
+    prisma,
+    competitionId,
+    playerId: player2Id,
+    status: "JOINED",
+  });
+  return { serverId, ownerId, competitionId, player1Id };
+}
+
+async function createJoinedParticipantScenario() {
+  const serverId = testGuildId("123456789012345678");
+  const ownerId = testAccountId("12300000123");
+  const { competitionId } = await createTestCompetition(serverId, ownerId);
+  const { playerId } = await createTestPlayer(
+    serverId,
+    testAccountId("456000004560"),
+    "TestPlayer",
+  );
+  await addParticipant({ prisma, competitionId, playerId, status: "JOINED" });
+  return { competitionId, playerId };
+}
+
+async function markParticipantLeft(
+  competitionId: Parameters<typeof getParticipantStatus>[1],
+  playerId: Parameters<typeof getParticipantStatus>[2],
+): Promise<void> {
+  await prisma.competitionParticipant.update({
+    where: { competitionId_playerId: { competitionId, playerId } },
+    data: { status: "LEFT", leftAt: new Date() },
+  });
 }
 
 // ============================================================================
@@ -200,35 +225,7 @@ describe("Participant Management - Cannot join inactive competition", () => {
 
 describe("Participant Management - Participant limit enforcement", () => {
   test("cannot join when participant limit is reached", async () => {
-    const serverId = testGuildId("123456789012345678");
-    const ownerId = testAccountId("12300000123");
-    const { competitionId } = await createTestCompetition(serverId, ownerId, {
-      maxParticipants: 2,
-    });
-
-    // Add 2 participants (reaches limit)
-    const { playerId: player1Id } = await createTestPlayer(
-      serverId,
-      testAccountId("100000000010"),
-      "Player1",
-    );
-    const { playerId: player2Id } = await createTestPlayer(
-      serverId,
-      testAccountId("200000000020"),
-      "Player2",
-    );
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: player1Id,
-      status: "JOINED",
-    });
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: player2Id,
-      status: "JOINED",
-    });
+    const { serverId, competitionId } = await createCompetitionAtLimit();
 
     // Try to add 3rd participant
     const { playerId: player3Id } = await createTestPlayer(
@@ -282,49 +279,11 @@ describe("Participant Management - Participant limit enforcement", () => {
   });
 
   test("LEFT participants do not count toward limit", async () => {
-    const serverId = testGuildId("123456789012345678");
-    const ownerId = testAccountId("12300000123");
-    const { competitionId } = await createTestCompetition(serverId, ownerId, {
-      maxParticipants: 2,
-    });
-
-    // Add 2 participants
-    const { playerId: player1Id } = await createTestPlayer(
-      serverId,
-      testAccountId("100000000010"),
-      "Player1",
-    );
-    const { playerId: player2Id } = await createTestPlayer(
-      serverId,
-      testAccountId("200000000020"),
-      "Player2",
-    );
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: player1Id,
-      status: "JOINED",
-    });
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: player2Id,
-      status: "JOINED",
-    });
+    const { serverId, competitionId, player1Id } =
+      await createCompetitionAtLimit();
 
     // Player1 leaves
-    await prisma.competitionParticipant.update({
-      where: {
-        competitionId_playerId: {
-          competitionId,
-          playerId: player1Id,
-        },
-      },
-      data: {
-        status: "LEFT",
-        leftAt: new Date(),
-      },
-    });
+    await markParticipantLeft(competitionId, player1Id);
 
     // Now player3 can join (only 1 active participant)
     const { playerId: player3Id } = await createTestPlayer(
@@ -344,29 +303,8 @@ describe("Participant Management - Participant limit enforcement", () => {
 
 describe("Participant Management - Cannot rejoin after leaving", () => {
   test("cannot rejoin competition after leaving", async () => {
-    const serverId = testGuildId("123456789012345678");
-    const ownerId = testAccountId("12300000123");
-    const { competitionId } = await createTestCompetition(serverId, ownerId);
-    const { playerId } = await createTestPlayer(
-      serverId,
-      testAccountId("456000004560"),
-      "TestPlayer",
-    );
-
-    // Join and then leave
-    await addParticipant({ prisma, competitionId, playerId, status: "JOINED" });
-    await prisma.competitionParticipant.update({
-      where: {
-        competitionId_playerId: {
-          competitionId,
-          playerId,
-        },
-      },
-      data: {
-        status: "LEFT",
-        leftAt: new Date(),
-      },
-    });
+    const { competitionId, playerId } = await createJoinedParticipantScenario();
+    await markParticipantLeft(competitionId, playerId);
 
     // Try to rejoin
     await expect(
@@ -375,28 +313,8 @@ describe("Participant Management - Cannot rejoin after leaving", () => {
   });
 
   test("participant status is LEFT after leaving", async () => {
-    const serverId = testGuildId("123456789012345678");
-    const ownerId = testAccountId("12300000123");
-    const { competitionId } = await createTestCompetition(serverId, ownerId);
-    const { playerId } = await createTestPlayer(
-      serverId,
-      testAccountId("456000004560"),
-      "TestPlayer",
-    );
-
-    await addParticipant({ prisma, competitionId, playerId, status: "JOINED" });
-    await prisma.competitionParticipant.update({
-      where: {
-        competitionId_playerId: {
-          competitionId,
-          playerId,
-        },
-      },
-      data: {
-        status: "LEFT",
-        leftAt: new Date(),
-      },
-    });
+    const { competitionId, playerId } = await createJoinedParticipantScenario();
+    await markParticipantLeft(competitionId, playerId);
 
     const status = await getParticipantStatus(prisma, competitionId, playerId);
     expect(status).toBe("LEFT");
@@ -483,16 +401,7 @@ describe("Participant Management - Invitation system", () => {
   });
 
   test("cannot add duplicate participant", async () => {
-    const serverId = testGuildId("123456789012345678");
-    const ownerId = testAccountId("12300000123");
-    const { competitionId } = await createTestCompetition(serverId, ownerId);
-    const { playerId } = await createTestPlayer(
-      serverId,
-      testAccountId("456000004560"),
-      "TestPlayer",
-    );
-
-    await addParticipant({ prisma, competitionId, playerId, status: "JOINED" });
+    const { competitionId, playerId } = await createJoinedParticipantScenario();
 
     // Try to add same participant again
     await expect(

--- a/packages/scout-for-lol/packages/backend/src/database/competition/participants.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/database/competition/participants.integration.test.ts
@@ -12,76 +12,98 @@ import {
   type CreateCompetitionInput,
 } from "#src/database/competition/queries.ts";
 import { ErrorSchema } from "#src/utils/errors.ts";
-import type {
-  CompetitionId,
-  DiscordAccountId,
-  PlayerId,
-} from "@scout-for-lol/data";
+import type { DiscordAccountId } from "@scout-for-lol/data";
 import { DiscordAccountIdSchema } from "@scout-for-lol/data";
 import {
   testGuildId,
   testAccountId,
   testChannelId,
 } from "#src/testing/test-ids.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
 import {
-  createTestDatabase,
-  deleteIfExists,
-} from "#src/testing/test-database.ts";
+  createCompetitionFixture,
+  createCompetitionPlayerFixture,
+  resetCompetitionFixtures,
+} from "#src/testing/competition-fixtures.ts";
 
 // Create a test database
 const { prisma } = createTestDatabase("participants-test");
 
 // Test helpers
-async function createTestCompetition(
-  maxParticipants = 50,
-): Promise<{ competitionId: CompetitionId }> {
-  const now = new Date();
-  const input: CreateCompetitionInput = {
-    serverId: testGuildId("123456789012345678"),
-    ownerId: testAccountId("987654321098765432"),
-    channelId: testChannelId("111222333444555666"),
-    title: "Test Competition",
-    description: "Test",
-    visibility: "OPEN",
+async function createTestCompetition(maxParticipants = 50) {
+  const competition = await createCompetitionFixture(prisma, {
     maxParticipants,
-    dates: {
-      type: "FIXED_DATES",
-      startDate: now,
-      endDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
-    },
-    criteria: {
-      type: "MOST_GAMES_PLAYED",
-      queues: ["solo"],
-    },
-  };
-
-  const competition = await createCompetition(prisma, input);
+  });
   return { competitionId: competition.id };
 }
 
-async function createTestPlayer(
-  alias: string,
-  discordId: DiscordAccountId,
-): Promise<{ playerId: PlayerId }> {
-  const now = new Date();
-  const player = await prisma.player.create({
-    data: {
-      alias,
-      discordId,
-      serverId: testGuildId("123456789012345678"),
-      creatorDiscordId: testAccountId("987654321098765432"),
-      createdTime: now,
-      updatedTime: now,
-    },
+async function createTestPlayer(alias: string, discordId: DiscordAccountId) {
+  const player = await createCompetitionPlayerFixture(prisma, {
+    alias,
+    discordId,
   });
   return { playerId: player.id };
 }
 
+async function fillCompetition(
+  competitionId: Parameters<typeof addParticipant>[0]["competitionId"],
+  count: number,
+) {
+  const discordIds = [
+    testAccountId("111111111111111111"),
+    testAccountId("111111111111111112"),
+    testAccountId("111111111111111113"),
+  ];
+  for (const [index, discordId] of discordIds.slice(0, count).entries()) {
+    const { playerId } = await createTestPlayer(
+      `Player${index.toString()}`,
+      discordId,
+    );
+    await addParticipant({ prisma, competitionId, playerId, status: "JOINED" });
+  }
+}
+
+async function createMixedParticipants(leaveThird = false) {
+  const { competitionId } = await createTestCompetition();
+  const { playerId: joinedPlayerId } = await createTestPlayer(
+    "Player1",
+    testAccountId("111111111111111111"),
+  );
+  const { playerId: invitedPlayerId } = await createTestPlayer(
+    "Player2",
+    testAccountId("222222222222222222"),
+  );
+  const { playerId: thirdPlayerId } = await createTestPlayer(
+    "Player3",
+    testAccountId("333333333333333333"),
+  );
+  await addParticipant({
+    prisma,
+    competitionId,
+    playerId: joinedPlayerId,
+    status: "JOINED",
+  });
+  await addParticipant({
+    prisma,
+    competitionId,
+    playerId: invitedPlayerId,
+    status: "INVITED",
+    invitedBy: testAccountId("444444444444444444"),
+  });
+  await addParticipant({
+    prisma,
+    competitionId,
+    playerId: thirdPlayerId,
+    status: "JOINED",
+  });
+  if (leaveThird) {
+    await removeParticipant(prisma, competitionId, thirdPlayerId);
+  }
+  return competitionId;
+}
+
 beforeEach(async () => {
-  // Clean up before each test
-  await deleteIfExists(() => prisma.competitionParticipant.deleteMany());
-  await deleteIfExists(() => prisma.competition.deleteMany());
-  await deleteIfExists(() => prisma.player.deleteMany());
+  await resetCompetitionFixtures(prisma);
 });
 afterAll(async () => {
   await prisma.$disconnect();
@@ -275,24 +297,7 @@ describe("addParticipant - duplicate prevention", () => {
 describe("addParticipant - max participants", () => {
   test("allows adding up to maxParticipants", async () => {
     const { competitionId } = await createTestCompetition(3);
-
-    const discordIds = [
-      "111111111111111111",
-      "111111111111111112",
-      "111111111111111113",
-    ];
-    for (let i = 0; i < 3; i++) {
-      const { playerId } = await createTestPlayer(
-        `Player${i.toString()}`,
-        DiscordAccountIdSchema.parse(discordIds[i] ?? "111111111111111111"),
-      );
-      await addParticipant({
-        prisma,
-        competitionId: competitionId,
-        playerId: playerId,
-        status: "JOINED",
-      });
-    }
+    await fillCompetition(competitionId, 3);
 
     const participants = await getParticipants(prisma, competitionId);
     expect(participants).toHaveLength(3);
@@ -300,24 +305,7 @@ describe("addParticipant - max participants", () => {
 
   test("throws error when exceeding maxParticipants", async () => {
     const { competitionId } = await createTestCompetition(3);
-
-    const discordIds = [
-      "111111111111111111",
-      "111111111111111112",
-      "111111111111111113",
-    ];
-    for (let i = 0; i < 3; i++) {
-      const { playerId } = await createTestPlayer(
-        `Player${i.toString()}`,
-        DiscordAccountIdSchema.parse(discordIds[i] ?? "111111111111111111"),
-      );
-      await addParticipant({
-        prisma,
-        competitionId: competitionId,
-        playerId: playerId,
-        status: "JOINED",
-      });
-    }
+    await fillCompetition(competitionId, 3);
 
     const { playerId } = await createTestPlayer(
       "Player4",
@@ -495,41 +483,7 @@ describe("removeParticipant", () => {
 
 describe("getParticipants - filtering", () => {
   test("returns all participants by default", async () => {
-    const { competitionId } = await createTestCompetition();
-
-    const { playerId: p1 } = await createTestPlayer(
-      "Player1",
-      testAccountId("111111111111111111"),
-    );
-    const { playerId: p2 } = await createTestPlayer(
-      "Player2",
-      testAccountId("222222222222222222"),
-    );
-    const { playerId: p3 } = await createTestPlayer(
-      "Player3",
-      testAccountId("333333333333333333"),
-    );
-
-    await addParticipant({
-      prisma,
-      competitionId: competitionId,
-      playerId: p1,
-      status: "JOINED",
-    });
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: p2,
-      status: "INVITED",
-      invitedBy: testAccountId("444444444444444444"),
-    });
-    await addParticipant({
-      prisma,
-      competitionId: competitionId,
-      playerId: p3,
-      status: "JOINED",
-    });
-    await removeParticipant(prisma, competitionId, p3);
+    const competitionId = await createMixedParticipants(true);
 
     const all = await getParticipants(prisma, competitionId);
 
@@ -537,40 +491,7 @@ describe("getParticipants - filtering", () => {
   });
 
   test("filters by status=JOINED", async () => {
-    const { competitionId } = await createTestCompetition();
-
-    const { playerId: p1 } = await createTestPlayer(
-      "Player1",
-      testAccountId("111111111111111111"),
-    );
-    const { playerId: p2 } = await createTestPlayer(
-      "Player2",
-      testAccountId("222222222222222222"),
-    );
-    const { playerId: p3 } = await createTestPlayer(
-      "Player3",
-      testAccountId("333333333333333333"),
-    );
-
-    await addParticipant({
-      prisma,
-      competitionId: competitionId,
-      playerId: p1,
-      status: "JOINED",
-    });
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: p2,
-      status: "INVITED",
-      invitedBy: testAccountId("444444444444444444"),
-    });
-    await addParticipant({
-      prisma,
-      competitionId: competitionId,
-      playerId: p3,
-      status: "JOINED",
-    });
+    const competitionId = await createMixedParticipants();
 
     const joined = await getParticipants(prisma, competitionId, "JOINED");
 
@@ -579,30 +500,7 @@ describe("getParticipants - filtering", () => {
   });
 
   test("filters by status=INVITED", async () => {
-    const { competitionId } = await createTestCompetition();
-
-    const { playerId: p1 } = await createTestPlayer(
-      "Player1",
-      testAccountId("111111111111111111"),
-    );
-    const { playerId: p2 } = await createTestPlayer(
-      "Player2",
-      testAccountId("222222222222222222"),
-    );
-
-    await addParticipant({
-      prisma,
-      competitionId: competitionId,
-      playerId: p1,
-      status: "JOINED",
-    });
-    await addParticipant({
-      prisma,
-      competitionId,
-      playerId: p2,
-      status: "INVITED",
-      invitedBy: testAccountId("444444444444444444"),
-    });
+    const competitionId = await createMixedParticipants();
 
     const invited = await getParticipants(prisma, competitionId, "INVITED");
 

--- a/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/leaderboard.integration.test.ts
@@ -24,6 +24,10 @@ import {
   testPuuid,
 } from "#src/testing/test-ids.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  createCompetitionPlayerFixture,
+  resetCompetitionFixtures,
+} from "#src/testing/competition-fixtures.ts";
 
 // ============================================================================
 // S3 Mock Setup
@@ -48,13 +52,7 @@ afterAll(async () => {
 
 // Helper to reset database between tests
 async function resetDatabase() {
-  await prisma.competitionSnapshot.deleteMany();
-  await prisma.competitionParticipant.deleteMany();
-  await prisma.competition.deleteMany();
-  await prisma.serverPermission.deleteMany();
-  await prisma.subscription.deleteMany();
-  await prisma.account.deleteMany();
-  await prisma.player.deleteMany();
+  await resetCompetitionFixtures(prisma);
 }
 
 // Helper to create active competition dates
@@ -74,29 +72,20 @@ async function createTestPlayer(
   serverId: DiscordGuildId,
   puuid: string,
 ) {
-  return prisma.player.create({
-    data: {
-      discordId: testAccountId(discordId),
-      alias,
-      serverId,
-      creatorDiscordId: testAccountId(discordId),
-      createdTime: new Date(),
-      updatedTime: new Date(),
-      accounts: {
-        create: [
-          {
-            puuid: testPuuid(puuid),
-            alias,
-            region: "AMERICA_NORTH",
-            serverId,
-            creatorDiscordId: testAccountId(discordId),
-            createdTime: new Date(),
-            updatedTime: new Date(),
-          },
-        ],
-      },
-    },
+  return createCompetitionPlayerFixture(prisma, {
+    discordId: testAccountId(discordId),
+    alias,
+    serverId,
+    creatorDiscordId: testAccountId(discordId),
+    puuid: testPuuid(puuid),
   });
+}
+
+async function createLeaderboardPlayers() {
+  const serverId = testGuildId("000000");
+  const player1 = await createTestPlayer("100000000", "Player1", serverId, "1");
+  const player2 = await createTestPlayer("200000000", "Player2", serverId, "2");
+  return { player1, player2 };
 }
 
 beforeEach(async () => {
@@ -188,54 +177,7 @@ describe("calculateLeaderboard integration tests", () => {
 
 describe("calculateLeaderboard integration tests - Scoring", () => {
   test("should calculate leaderboard with participants but no matches", async () => {
-    // Create players
-    const player1 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("100000000"),
-        alias: "Player1",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("100000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("1"),
-              alias: "Player1",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("100000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
-
-    const player2 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("200000000"),
-        alias: "Player2",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("200000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("2"),
-              alias: "Player2",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("200000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
+    const { player1, player2 } = await createLeaderboardPlayers();
 
     // Create competition with current dates (active)
     const now = new Date();
@@ -399,54 +341,7 @@ describe("calculateLeaderboard - HIGHEST_RANK Criteria", () => {
 
 describe("calculateLeaderboard - MOST_RANK_CLIMB Criteria", () => {
   test("should handle MOST_RANK_CLIMB criteria with START and END snapshots", async () => {
-    // Create players
-    const player1 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("100000000"),
-        alias: "Player1",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("100000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("1"),
-              alias: "Player1",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("100000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
-
-    const player2 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("200000000"),
-        alias: "Player2",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("200000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("2"),
-              alias: "Player2",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("200000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
+    const { player1, player2 } = await createLeaderboardPlayers();
 
     // Create competition with MOST_RANK_CLIMB criteria
     const competition = await createCompetition(prisma, {
@@ -634,78 +529,13 @@ describe("calculateLeaderboard integration tests - rank history", () => {
 
 describe("calculateLeaderboard integration tests - Filters", () => {
   test("should include ever-joined participants and exclude invited-never-joined players", async () => {
-    // Create players
-    const player1 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("100000000"),
-        alias: "Player1",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("100000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("1"),
-              alias: "Player1",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("100000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
-
-    const player2 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("200000000"),
-        alias: "Player2",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("200000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("2"),
-              alias: "Player2",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("200000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
-
-    const player3 = await prisma.player.create({
-      data: {
-        discordId: testAccountId("300000000"),
-        alias: "Player3",
-        serverId: testGuildId("000000"),
-        creatorDiscordId: testAccountId("300000000"),
-        createdTime: new Date(),
-        updatedTime: new Date(),
-        accounts: {
-          create: [
-            {
-              puuid: testPuuid("3"),
-              alias: "Player3",
-              region: "AMERICA_NORTH",
-              serverId: testGuildId("000000"),
-              creatorDiscordId: testAccountId("300000000"),
-              createdTime: new Date(),
-              updatedTime: new Date(),
-            },
-          ],
-        },
-      },
-    });
+    const { player1, player2 } = await createLeaderboardPlayers();
+    const player3 = await createTestPlayer(
+      "300000000",
+      "Player3",
+      testGuildId("000000"),
+      "3",
+    );
 
     // Create competition
     const dates = getActiveCompetitionDates();

--- a/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/competition/snapshots.integration.test.ts
@@ -4,22 +4,15 @@ import {
   createSnapshotsForAllParticipants,
 } from "#src/league/competition/snapshots.ts";
 import { getSnapshot } from "#src/league/competition/snapshot-store.ts";
-import {
-  createCompetition,
-  type CreateCompetitionInput,
-} from "#src/database/competition/queries.ts";
 import { addParticipant } from "#src/database/competition/participants.ts";
 import {
   testGuildId,
   testAccountId,
-  testChannelId,
   testPuuid,
 } from "#src/testing/test-ids.ts";
 import type {
-  CompetitionId,
   CompetitionCriteria,
   LeaguePuuid,
-  PlayerId,
   Region,
 } from "@scout-for-lol/data";
 import {
@@ -29,32 +22,18 @@ import {
   PlayerIdSchema,
 } from "@scout-for-lol/data";
 import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  createCompetitionFixture,
+  createCompetitionPlayerFixture,
+  resetCompetitionFixtures,
+} from "#src/testing/competition-fixtures.ts";
 
 // Create a test database
 const { prisma } = createTestDatabase("snapshots-test");
 
 // Test helpers
-async function createTestCompetition(
-  criteria: CompetitionCriteria,
-): Promise<{ competitionId: CompetitionId }> {
-  const now = new Date();
-  const input: CreateCompetitionInput = {
-    serverId: testGuildId("123456789012345678"),
-    ownerId: testAccountId("987654321098765432"),
-    channelId: testChannelId("111222333444555666"),
-    title: "Test Competition",
-    description: "Test",
-    visibility: "OPEN",
-    maxParticipants: 50,
-    dates: {
-      type: "FIXED_DATES",
-      startDate: now,
-      endDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
-    },
-    criteria,
-  };
-
-  const competition = await createCompetition(prisma, input);
+async function createTestCompetition(criteria: CompetitionCriteria) {
+  const competition = await createCompetitionFixture(prisma, { criteria });
   return { competitionId: competition.id };
 }
 
@@ -62,41 +41,38 @@ async function createTestPlayer(
   alias: string,
   puuid: LeaguePuuid,
   region: Region,
-): Promise<{ playerId: PlayerId }> {
-  const now = new Date();
-  const player = await prisma.player.create({
-    data: {
-      alias,
-      discordId: null,
-      serverId: testGuildId("123456789012345678"),
-      creatorDiscordId: testAccountId("987654321098765432"),
-      createdTime: now,
-      updatedTime: now,
-      accounts: {
-        create: [
-          {
-            alias,
-            puuid,
-            region,
-            serverId: testGuildId("123456789012345678"),
-            creatorDiscordId: testAccountId("987654321098765432"),
-            createdTime: now,
-            updatedTime: now,
-          },
-        ],
-      },
-    },
+) {
+  const player = await createCompetitionPlayerFixture(prisma, {
+    alias,
+    puuid,
+    region,
   });
   return { playerId: player.id };
 }
 
+async function createAndReadStartSnapshot(
+  alias: string,
+  puuid: LeaguePuuid,
+  criteria: CompetitionCriteria,
+) {
+  const { competitionId } = await createTestCompetition(criteria);
+  const { playerId } = await createTestPlayer(alias, puuid, "AMERICA_NORTH");
+  await createSnapshot(prisma, {
+    competitionId: CompetitionIdSchema.parse(competitionId),
+    playerId: PlayerIdSchema.parse(playerId),
+    snapshotType: "START",
+    criteria,
+  });
+  return getSnapshot(prisma, {
+    competitionId,
+    playerId,
+    snapshotType: "START",
+    criteria,
+  });
+}
+
 beforeEach(async () => {
-  // Clean up before each test
-  await prisma.competitionSnapshot.deleteMany();
-  await prisma.competitionParticipant.deleteMany();
-  await prisma.competition.deleteMany();
-  await prisma.account.deleteMany();
-  await prisma.player.deleteMany();
+  await resetCompetitionFixtures(prisma);
 });
 afterAll(async () => {
   await prisma.$disconnect();
@@ -589,28 +565,14 @@ describe("createSnapshot - Different criteria types", () => {
       queues: ["solo"],
     };
 
-    const { competitionId } = await createTestCompetition(criteria);
     const puuid = LeaguePuuidSchema.parse("f".repeat(78));
-    const { playerId } = await createTestPlayer(
-      "RankPlayer",
-      puuid,
-      "AMERICA_NORTH",
-    );
 
     try {
-      await createSnapshot(prisma, {
-        competitionId: CompetitionIdSchema.parse(competitionId),
-        playerId: PlayerIdSchema.parse(playerId),
-        snapshotType: "START",
+      const snapshot = await createAndReadStartSnapshot(
+        "RankPlayer",
+        puuid,
         criteria,
-      });
-
-      const snapshot = await getSnapshot(prisma, {
-        competitionId,
-        playerId,
-        snapshotType: "START",
-        criteria,
-      });
+      );
       if (snapshot) {
         // Should have rank structure
         expect(snapshot).toHaveProperty("solo");
@@ -627,28 +589,14 @@ describe("createSnapshot - Different criteria types", () => {
       queues: ["solo"],
     };
 
-    const { competitionId } = await createTestCompetition(criteria);
     const puuid = LeaguePuuidSchema.parse("g".repeat(78));
-    const { playerId } = await createTestPlayer(
-      "ChampionPlayer",
-      puuid,
-      "AMERICA_NORTH",
-    );
 
     try {
-      await createSnapshot(prisma, {
-        competitionId: CompetitionIdSchema.parse(competitionId),
-        playerId: PlayerIdSchema.parse(playerId),
-        snapshotType: "START",
+      const snapshot = await createAndReadStartSnapshot(
+        "ChampionPlayer",
+        puuid,
         criteria,
-      });
-
-      const snapshot = await getSnapshot(prisma, {
-        competitionId: CompetitionIdSchema.parse(competitionId),
-        playerId: PlayerIdSchema.parse(playerId),
-        snapshotType: "START",
-        criteria,
-      });
+      );
       if (snapshot) {
         // Should have wins structure
         expect(snapshot).toHaveProperty("wins");
@@ -666,28 +614,14 @@ describe("createSnapshot - Different criteria types", () => {
       minGames: 10,
     };
 
-    const { competitionId } = await createTestCompetition(criteria);
     const puuid = LeaguePuuidSchema.parse("h".repeat(78));
-    const { playerId } = await createTestPlayer(
-      "WinRatePlayer",
-      puuid,
-      "AMERICA_NORTH",
-    );
 
     try {
-      await createSnapshot(prisma, {
-        competitionId: CompetitionIdSchema.parse(competitionId),
-        playerId: PlayerIdSchema.parse(playerId),
-        snapshotType: "START",
+      const snapshot = await createAndReadStartSnapshot(
+        "WinRatePlayer",
+        puuid,
         criteria,
-      });
-
-      const snapshot = await getSnapshot(prisma, {
-        competitionId,
-        playerId,
-        snapshotType: "START",
-        criteria,
-      });
+      );
       if (snapshot) {
         // Should have wins structure
         expect(snapshot).toHaveProperty("wins");

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/competition/lifecycle.integration.test.ts
@@ -1,22 +1,17 @@
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
-import {
-  createCompetition,
-  type CreateCompetitionInput,
-} from "#src/database/competition/queries.ts";
 import type {
   CompetitionCriteria,
-  CompetitionId,
   LeaguePuuid,
-  PlayerId,
   Region,
 } from "@scout-for-lol/data";
-import {
-  testGuildId,
-  testAccountId,
-  testChannelId,
-  testPuuid,
-} from "#src/testing/test-ids.ts";
+import { testPuuid } from "#src/testing/test-ids.ts";
 import { createTestDatabase } from "#src/testing/test-database.ts";
+import {
+  addCompetitionParticipantFixture,
+  createCompetitionFixture,
+  createCompetitionPlayerFixture,
+  resetCompetitionFixtures,
+} from "#src/testing/competition-fixtures.ts";
 
 let sendShouldFail = false;
 let sentMessages: { channelId: string; content: string }[] = [];
@@ -57,24 +52,12 @@ async function createTestCompetition(
   criteria: CompetitionCriteria,
   startDate: Date,
   endDate: Date,
-): Promise<{ competitionId: CompetitionId }> {
-  const input: CreateCompetitionInput = {
-    serverId: testGuildId("123456789012345678"),
-    ownerId: testAccountId("987654321098765432"),
-    channelId: testChannelId("111222333444555666"),
-    title: "Test Competition",
-    description: "Test Description",
-    visibility: "OPEN",
-    maxParticipants: 50,
-    dates: {
-      type: "FIXED_DATES",
-      startDate,
-      endDate,
-    },
+) {
+  const competition = await createCompetitionFixture(prisma, {
     criteria,
-  };
-
-  const competition = await createCompetition(prisma, input);
+    startDate,
+    endDate,
+  });
   return { competitionId: competition.id };
 }
 
@@ -82,58 +65,71 @@ async function createTestPlayer(
   alias: string,
   puuid: LeaguePuuid,
   region: Region,
-): Promise<{ playerId: PlayerId }> {
-  const now = new Date();
-  const player = await prisma.player.create({
-    data: {
-      alias,
-      discordId: null,
-      serverId: testGuildId("123456789012345678"),
-      creatorDiscordId: testAccountId("987654321098765432"),
-      createdTime: now,
-      updatedTime: now,
-      accounts: {
-        create: [
-          {
-            alias,
-            puuid,
-            region,
-            serverId: testGuildId("123456789012345678"),
-            creatorDiscordId: testAccountId("987654321098765432"),
-            createdTime: now,
-            updatedTime: now,
-          },
-        ],
-      },
-    },
+) {
+  const player = await createCompetitionPlayerFixture(prisma, {
+    alias,
+    puuid,
+    region,
   });
   return { playerId: player.id };
 }
 
 async function addTestParticipant(
-  competitionId: CompetitionId,
-  playerId: PlayerId,
+  competitionId: Parameters<typeof addCompetitionParticipantFixture>[1],
+  playerId: Parameters<typeof addCompetitionParticipantFixture>[2],
 ): Promise<void> {
-  const now = new Date();
-  await prisma.competitionParticipant.create({
+  await addCompetitionParticipantFixture(prisma, competitionId, playerId);
+}
+
+function findCompetitionsToStart(now: Date) {
+  return prisma.competition.findMany({
+    where: {
+      isCancelled: false,
+      startDate: { lte: now },
+      snapshots: { none: { snapshotType: "START" } },
+    },
+  });
+}
+
+function findCompetitionsToEnd(now: Date) {
+  return prisma.competition.findMany({
+    where: {
+      isCancelled: false,
+      endDate: { lte: now },
+      snapshots: { some: { snapshotType: "START" } },
+      NOT: { snapshots: { some: { snapshotType: "END" } } },
+    },
+  });
+}
+
+async function createStartedCompetition(startDate: Date, endDate: Date) {
+  const { competitionId } = await createTestCompetition(
+    mostSoloGamesCriteria,
+    startDate,
+    endDate,
+  );
+  const { playerId } = await createTestPlayer(
+    "Player1",
+    testPuuid("lifecycle-player1"),
+    "AMERICA_NORTH",
+  );
+  await addTestParticipant(competitionId, playerId);
+  await prisma.competitionSnapshot.create({
     data: {
       competitionId,
       playerId,
-      status: "JOINED",
-      joinedAt: now,
+      snapshotType: "START",
+      snapshotData: JSON.stringify({ soloGames: 10 }),
+      snapshotTime: startDate,
     },
   });
+  return { competitionId, playerId };
 }
 
 beforeEach(async () => {
   sendShouldFail = false;
   sentMessages = [];
-  // Clean up before each test
-  await prisma.competitionSnapshot.deleteMany();
-  await prisma.competitionParticipant.deleteMany();
-  await prisma.competition.deleteMany();
-  await prisma.account.deleteMany();
-  await prisma.player.deleteMany();
+  await resetCompetitionFixtures(prisma);
 });
 afterAll(async () => {
   await prisma.$disconnect();
@@ -157,20 +153,7 @@ describe("Competition Lifecycle - Query for Starting", () => {
       endDate,
     );
 
-    // Query for competitions to start
-    const competitionsToStart = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        startDate: {
-          lte: now,
-        },
-        snapshots: {
-          none: {
-            snapshotType: "START",
-          },
-        },
-      },
-    });
+    const competitionsToStart = await findCompetitionsToStart(now);
 
     expect(competitionsToStart.length).toBe(1);
     expect(competitionsToStart[0]?.id).toBe(competitionId);
@@ -185,20 +168,7 @@ describe("Competition Lifecycle - Query for Starting", () => {
 
     await createTestCompetition(criteria, startDate, endDate);
 
-    // Query for competitions to start
-    const competitionsToStart = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        startDate: {
-          lte: now,
-        },
-        snapshots: {
-          none: {
-            snapshotType: "START",
-          },
-        },
-      },
-    });
+    const competitionsToStart = await findCompetitionsToStart(now);
 
     expect(competitionsToStart.length).toBe(0);
   });
@@ -222,69 +192,19 @@ describe("Competition Lifecycle - Query for Starting", () => {
       data: { isCancelled: true },
     });
 
-    // Query for competitions to start
-    const competitionsToStart = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        startDate: {
-          lte: now,
-        },
-        snapshots: {
-          none: {
-            snapshotType: "START",
-          },
-        },
-      },
-    });
+    const competitionsToStart = await findCompetitionsToStart(now);
 
     expect(competitionsToStart.length).toBe(0);
   });
 
   test("does not find competition that already has START snapshots", async () => {
-    const criteria = mostSoloGamesCriteria;
-
     const now = new Date("2025-01-15T12:00:00Z");
     const startDate = new Date("2025-01-15T10:00:00Z");
     const endDate = new Date("2025-01-20T12:00:00Z");
 
-    const { competitionId } = await createTestCompetition(
-      criteria,
-      startDate,
-      endDate,
-    );
+    await createStartedCompetition(startDate, endDate);
 
-    // Add a player and create START snapshot
-    const { playerId } = await createTestPlayer(
-      "Player1",
-      testPuuid("lifecycle-player1"),
-      "AMERICA_NORTH",
-    );
-    await addTestParticipant(competitionId, playerId);
-
-    await prisma.competitionSnapshot.create({
-      data: {
-        competitionId,
-        playerId,
-        snapshotType: "START",
-        snapshotData: JSON.stringify({ soloGames: 10 }),
-        snapshotTime: startDate,
-      },
-    });
-
-    // Query for competitions to start
-    const competitionsToStart = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        startDate: {
-          lte: now,
-        },
-        snapshots: {
-          none: {
-            snapshotType: "START",
-          },
-        },
-      },
-    });
+    const competitionsToStart = await findCompetitionsToStart(now);
 
     expect(competitionsToStart.length).toBe(0);
   });
@@ -366,84 +286,20 @@ describe("Competition Lifecycle - Query for Ending", () => {
       },
     });
 
-    // Query for competitions to end
-    const competitionsToEnd = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        endDate: {
-          lte: now,
-        },
-        snapshots: {
-          some: {
-            snapshotType: "START",
-          },
-        },
-        NOT: {
-          snapshots: {
-            some: {
-              snapshotType: "END",
-            },
-          },
-        },
-      },
-    });
+    const competitionsToEnd = await findCompetitionsToEnd(now);
 
     expect(competitionsToEnd.length).toBe(1);
     expect(competitionsToEnd[0]?.id).toBe(competitionId);
   });
 
   test("does not find competition with future end date", async () => {
-    const criteria = mostSoloGamesCriteria;
-
     const now = new Date("2025-01-18T12:00:00Z");
     const startDate = new Date("2025-01-15T10:00:00Z");
     const endDate = new Date("2025-01-20T10:00:00Z"); // Future
 
-    const { competitionId } = await createTestCompetition(
-      criteria,
-      startDate,
-      endDate,
-    );
+    await createStartedCompetition(startDate, endDate);
 
-    // Add START snapshot
-    const { playerId } = await createTestPlayer(
-      "Player1",
-      testPuuid("lifecycle-player1"),
-      "AMERICA_NORTH",
-    );
-    await addTestParticipant(competitionId, playerId);
-
-    await prisma.competitionSnapshot.create({
-      data: {
-        competitionId,
-        playerId,
-        snapshotType: "START",
-        snapshotData: JSON.stringify({ soloGames: 10 }),
-        snapshotTime: startDate,
-      },
-    });
-
-    // Query for competitions to end
-    const competitionsToEnd = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        endDate: {
-          lte: now,
-        },
-        snapshots: {
-          some: {
-            snapshotType: "START",
-          },
-        },
-        NOT: {
-          snapshots: {
-            some: {
-              snapshotType: "END",
-            },
-          },
-        },
-      },
-    });
+    const competitionsToEnd = await findCompetitionsToEnd(now);
 
     expect(competitionsToEnd.length).toBe(0);
   });
@@ -457,61 +313,20 @@ describe("Competition Lifecycle - Query for Ending", () => {
 
     await createTestCompetition(criteria, startDate, endDate);
 
-    // Query for competitions to end (no START snapshot exists)
-    const competitionsToEnd = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        endDate: {
-          lte: now,
-        },
-        snapshots: {
-          some: {
-            snapshotType: "START",
-          },
-        },
-        NOT: {
-          snapshots: {
-            some: {
-              snapshotType: "END",
-            },
-          },
-        },
-      },
-    });
+    const competitionsToEnd = await findCompetitionsToEnd(now);
 
     expect(competitionsToEnd.length).toBe(0);
   });
 
   test("does not find competition that already has END snapshots", async () => {
-    const criteria = mostSoloGamesCriteria;
-
     const now = new Date("2025-01-20T12:00:00Z");
     const startDate = new Date("2025-01-15T10:00:00Z");
     const endDate = new Date("2025-01-20T10:00:00Z");
 
-    const { competitionId } = await createTestCompetition(
-      criteria,
+    const { competitionId, playerId } = await createStartedCompetition(
       startDate,
       endDate,
     );
-
-    // Add START and END snapshots
-    const { playerId } = await createTestPlayer(
-      "Player1",
-      testPuuid("lifecycle-player1"),
-      "AMERICA_NORTH",
-    );
-    await addTestParticipant(competitionId, playerId);
-
-    await prisma.competitionSnapshot.create({
-      data: {
-        competitionId,
-        playerId,
-        snapshotType: "START",
-        snapshotData: JSON.stringify({ soloGames: 10 }),
-        snapshotTime: startDate,
-      },
-    });
 
     await prisma.competitionSnapshot.create({
       data: {
@@ -523,27 +338,7 @@ describe("Competition Lifecycle - Query for Ending", () => {
       },
     });
 
-    // Query for competitions to end
-    const competitionsToEnd = await prisma.competition.findMany({
-      where: {
-        isCancelled: false,
-        endDate: {
-          lte: now,
-        },
-        snapshots: {
-          some: {
-            snapshotType: "START",
-          },
-        },
-        NOT: {
-          snapshots: {
-            some: {
-              snapshotType: "END",
-            },
-          },
-        },
-      },
-    });
+    const competitionsToEnd = await findCompetitionsToEnd(now);
 
     expect(competitionsToEnd.length).toBe(0);
   });

--- a/packages/scout-for-lol/packages/backend/src/testing/competition-fixtures.ts
+++ b/packages/scout-for-lol/packages/backend/src/testing/competition-fixtures.ts
@@ -1,0 +1,142 @@
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+import { createCompetition } from "#src/database/competition/queries.ts";
+import type { addParticipant } from "#src/database/competition/participants.ts";
+import {
+  testAccountId,
+  testChannelId,
+  testGuildId,
+} from "#src/testing/test-ids.ts";
+import type {
+  CompetitionCriteria,
+  DiscordAccountId,
+  DiscordGuildId,
+  LeaguePuuid,
+  ParticipantStatus,
+  Region,
+} from "@scout-for-lol/data";
+
+const fixtureServerId = testGuildId("123456789012345678");
+const fixtureOwnerId = testAccountId("987654321098765432");
+
+type CompetitionFixtureOptions = {
+  serverId?: DiscordGuildId;
+  ownerId?: DiscordAccountId;
+  startDate?: Date;
+  endDate?: Date;
+  criteria?: CompetitionCriteria;
+  visibility?: "OPEN" | "INVITE_ONLY" | "SERVER_WIDE";
+  maxParticipants?: number;
+  title?: string;
+  description?: string;
+  cancelled?: boolean;
+};
+
+type PlayerFixtureOptions = {
+  alias: string;
+  discordId?: DiscordAccountId | null;
+  serverId?: DiscordGuildId;
+  creatorDiscordId?: DiscordAccountId;
+  puuid?: LeaguePuuid;
+  region?: Region;
+};
+
+export async function createCompetitionFixture(
+  prisma: ExtendedPrismaClient,
+  options: CompetitionFixtureOptions = {},
+) {
+  const startDate = options.startDate ?? new Date();
+  const competition = await createCompetition(prisma, {
+    serverId: options.serverId ?? fixtureServerId,
+    ownerId: options.ownerId ?? fixtureOwnerId,
+    channelId: testChannelId("111222333444555666"),
+    title: options.title ?? "Test Competition",
+    description: options.description ?? "Test Description",
+    visibility: options.visibility ?? "OPEN",
+    maxParticipants: options.maxParticipants ?? 50,
+    dates: {
+      type: "FIXED_DATES",
+      startDate,
+      endDate:
+        options.endDate ?? new Date(startDate.getTime() + 7 * 86_400_000),
+    },
+    criteria: options.criteria ?? {
+      type: "MOST_GAMES_PLAYED",
+      queues: ["solo"],
+    },
+  });
+  if (options.cancelled === true) {
+    return prisma.competition.update({
+      where: { id: competition.id },
+      data: { isCancelled: true },
+    });
+  }
+  return competition;
+}
+
+export async function createCompetitionPlayerFixture(
+  prisma: ExtendedPrismaClient,
+  options: PlayerFixtureOptions,
+) {
+  const now = new Date();
+  const serverId = options.serverId ?? fixtureServerId;
+  const creatorDiscordId = options.creatorDiscordId ?? fixtureOwnerId;
+  const basePlayer = {
+    alias: options.alias,
+    discordId: options.discordId ?? null,
+    serverId,
+    creatorDiscordId,
+    createdTime: now,
+    updatedTime: now,
+  };
+  if (options.puuid === undefined) {
+    return prisma.player.create({ data: basePlayer });
+  }
+  return prisma.player.create({
+    data: {
+      ...basePlayer,
+      accounts: {
+        create: [
+          {
+            alias: options.alias,
+            puuid: options.puuid,
+            region: options.region ?? "AMERICA_NORTH",
+            serverId,
+            creatorDiscordId,
+            createdTime: now,
+            updatedTime: now,
+          },
+        ],
+      },
+    },
+  });
+}
+
+export async function addCompetitionParticipantFixture(
+  prisma: ExtendedPrismaClient,
+  competitionId: Parameters<typeof addParticipant>[0]["competitionId"],
+  playerId: Parameters<typeof addParticipant>[0]["playerId"],
+  status: ParticipantStatus = "JOINED",
+) {
+  const now = new Date();
+  return prisma.competitionParticipant.create({
+    data: {
+      competitionId,
+      playerId,
+      status,
+      joinedAt: status === "JOINED" ? now : null,
+      invitedAt: status === "INVITED" ? now : null,
+    },
+  });
+}
+
+export async function resetCompetitionFixtures(
+  prisma: ExtendedPrismaClient,
+): Promise<void> {
+  await prisma.competitionSnapshot.deleteMany();
+  await prisma.competitionParticipant.deleteMany();
+  await prisma.competition.deleteMany();
+  await prisma.serverPermission.deleteMany();
+  await prisma.subscription.deleteMany();
+  await prisma.account.deleteMany();
+  await prisma.player.deleteMany();
+}


### PR DESCRIPTION
Why

Scout competition integration suites repeated database cleanup, competition and player creation, participant setup, lifecycle queries, and snapshot scenarios.

What

- Add typed database-backed competition, player, participant, and cleanup fixtures.
- Reuse focused lifecycle-query, participant-limit, leaderboard, and snapshot scenario helpers.
- Preserve all 82 focused scenarios while reducing the cumulative jscpd baseline from 68,911 to 67,180 duplicated tokens.

Verification

- `DATABASE_URL=postgres://scout@127.0.0.1:5471/scout_test_unbound bun --no-install --bun vitest --config ../../../../vitest.config.ts run src/database/competition.integration.test.ts src/database/competition/participants.integration.test.ts src/league/competition/leaderboard.integration.test.ts src/league/competition/snapshots.integration.test.ts src/league/tasks/competition/lifecycle.integration.test.ts --testTimeout 20000`
- `bunx eslint src/testing/competition-fixtures.ts src/database/competition.integration.test.ts src/database/competition/participants.integration.test.ts src/league/competition/leaderboard.integration.test.ts src/league/competition/snapshots.integration.test.ts src/league/tasks/competition/lifecycle.integration.test.ts`
- `bunx turbo run test typecheck lint --filter=@scout-for-lol/backend`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No beta, live database, or production checks were run. This internal test refactor needs no media.