### PR TITLE
refactor(temporal): share subprocess capture

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1640,10 +1640,6 @@
       "clones": 1,
       "tokens": 75
     },
-    "packages/temporal/src/activities/data-dragon-shell.ts|packages/temporal/src/activities/scout-season-refresh-git.ts": {
-      "clones": 1,
-      "tokens": 232
-    },
     "packages/temporal/src/activities/data-dragon.ts|packages/temporal/src/activities/lane-prior-refresh.ts": {
       "clones": 1,
       "tokens": 71

--- a/packages/temporal/src/activities/command-runner.test.ts
+++ b/packages/temporal/src/activities/command-runner.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { captureCommand, mergeCommandEnvironment } from "./command-runner.ts";
+
+describe("mergeCommandEnvironment", () => {
+  test("inherits, overrides, adds, and explicitly clears variables", () => {
+    expect(
+      mergeCommandEnvironment(
+        { INHERITED: "kept", OVERRIDDEN: "old", CLEARED: "secret" },
+        { OVERRIDDEN: "new", ADDED: "value", CLEARED: undefined },
+      ),
+    ).toEqual({
+      INHERITED: "kept",
+      OVERRIDDEN: "new",
+      ADDED: "value",
+    });
+  });
+});
+
+describe("captureCommand", () => {
+  test("returns raw output and a nonzero exit code to the caller", async () => {
+    const result = await captureCommand(
+      [
+        "bun",
+        "-e",
+        String.raw`process.stdout.write(process.env.COMMAND_VALUE ?? ""); process.stderr.write("problem\n"); process.exit(7)`,
+      ],
+      { cwd: "/tmp", env: { COMMAND_VALUE: "raw output\n" } },
+    );
+
+    expect(result).toEqual({
+      stdout: "raw output\n",
+      stderr: "problem\n",
+      exitCode: 7,
+    });
+  });
+});

--- a/packages/temporal/src/activities/command-runner.ts
+++ b/packages/temporal/src/activities/command-runner.ts
@@ -1,0 +1,46 @@
+export type RawCommandOptions = {
+  cwd: string;
+  env?: Record<string, string | undefined>;
+};
+
+export type CommandCapture = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+export function mergeCommandEnvironment(
+  environment: Record<string, string | undefined>,
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(environment)) {
+    if (value !== undefined && !(key in overrides)) {
+      merged[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+export async function captureCommand(
+  command: string[],
+  options: RawCommandOptions,
+): Promise<CommandCapture> {
+  const process = Bun.spawn(command, {
+    cwd: options.cwd,
+    env: mergeCommandEnvironment(Bun.env, options.env),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}

--- a/packages/temporal/src/activities/data-dragon-shell.ts
+++ b/packages/temporal/src/activities/data-dragon-shell.ts
@@ -1,3 +1,5 @@
+import { captureCommand } from "./command-runner.ts";
+
 export async function runCommand(
   command: string[],
   options: {
@@ -7,35 +9,7 @@ export async function runCommand(
     trimStdout?: boolean;
   },
 ): Promise<string> {
-  const clearedEnvKeys = new Set(
-    Object.entries(options.env ?? {})
-      .filter(([, value]) => value === undefined)
-      .map(([key]) => key),
-  );
-  const childEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(Bun.env)) {
-    if (value !== undefined && !clearedEnvKeys.has(key)) {
-      childEnv[key] = value;
-    }
-  }
-  for (const [key, value] of Object.entries(options.env ?? {})) {
-    if (value !== undefined) {
-      childEnv[key] = value;
-    }
-  }
-
-  const proc = Bun.spawn(command, {
-    cwd: options.cwd,
-    env: childEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  const { stdout, stderr, exitCode } = await captureCommand(command, options);
 
   if (exitCode !== 0) {
     const output =

--- a/packages/temporal/src/activities/scout-season-refresh-git.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.ts
@@ -1,5 +1,6 @@
 import { parsePorcelainPaths } from "#shared/porcelain.ts";
 import { disarmGitHooks } from "./bot-clone.ts";
+import { captureCommand } from "./command-runner.ts";
 
 type GitRunBaseOptions = {
   cwd: string;
@@ -21,35 +22,7 @@ export async function runCommand(
   command: string[],
   options: GitRunOptions,
 ): Promise<string> {
-  const clearedEnvKeys = new Set(
-    Object.entries(options.env ?? {})
-      .filter(([, value]) => value === undefined)
-      .map(([key]) => key),
-  );
-  const childEnv: Record<string, string> = {};
-  for (const [key, value] of Object.entries(Bun.env)) {
-    if (value !== undefined && !clearedEnvKeys.has(key)) {
-      childEnv[key] = value;
-    }
-  }
-  for (const [key, value] of Object.entries(options.env ?? {})) {
-    if (value !== undefined) {
-      childEnv[key] = value;
-    }
-  }
-
-  const proc = Bun.spawn(command, {
-    cwd: options.cwd,
-    env: childEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+  const { stdout, stderr, exitCode } = await captureCommand(command, options);
 
   if (exitCode !== 0) {
     const rawOutput = `${stdout}\n${stderr}`.trim();


### PR DESCRIPTION
Why

Temporal shell and Git command wrappers independently rebuilt environment merging and subprocess output capture.

What

- Extract raw environment merging and Bun subprocess capture into an activity-only module.
- Retain each caller's trimming, redaction, failure labeling, and error policy.
- Add coverage for inheritance, overrides, explicit clearing, raw streams, and nonzero exits.
- Reduce the cumulative jscpd baseline from 67,180 to 66,948 duplicated tokens.

Verification

- `bun --no-install --bun vitest --config ../../vitest.config.ts run src/activities/command-runner.test.ts src/activities/scout-season-refresh-git.test.ts`
- `bunx eslint src/activities/command-runner.ts src/activities/command-runner.test.ts src/activities/data-dragon-shell.ts src/activities/scout-season-refresh-git.ts`
- `bunx turbo run test typecheck lint --filter=@shepherdjerred/temporal`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No live Temporal service, workflow mutation, or production check was run. This internal runtime refactor needs no media.