### PR TITLE
refactor(s3-signed-request): centralize signing and restore TaskNotes UI flow

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1522,6 +1522,7 @@ steps:
         - "patches/**"
         - "turbo.json"
         - "packages/llm-observability/**"
+        - "packages/s3-signed-request/**"
         - "packages/eslint-config/**"
     cancel_on_build_failing: true
     command: |
@@ -2521,6 +2522,7 @@ steps:
         - "packages/homelab/src/cdk8s/src/resources/s3-static-sites/sites.ts"
         - "packages/llm-models/**"
         - "packages/llm-observability/**"
+        - "packages/s3-signed-request/**"
         - "packages/scout-for-lol/packages/backend/**"
         - "packages/scout-for-lol/packages/data/**"
         - "packages/scout-for-lol/packages/report/**"

--- a/.buildkite/scripts/migration-core.ts
+++ b/.buildkite/scripts/migration-core.ts
@@ -295,6 +295,7 @@ export const lanePaths: Readonly<Record<string, readonly string[]>> = {
   "docker-e2e": [
     ...workspacePaths,
     "packages/llm-observability",
+    "packages/s3-signed-request",
     "packages/eslint-config",
   ],
   "helm-types": [

--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -788,14 +788,6 @@
       "clones": 1,
       "tokens": 237
     },
-    "packages/llm-observability/src/archive-uploader.ts|packages/llm-observability/test/e2e/signed-fetch.ts": {
-      "clones": 1,
-      "tokens": 91
-    },
-    "packages/llm-observability/src/archive-uploader.ts|packages/temporal/src/shared/s3.ts": {
-      "clones": 4,
-      "tokens": 447
-    },
     "packages/llm-observability/src/span-helpers.ts|packages/temporal/src/observability/tracing.ts": {
       "clones": 1,
       "tokens": 91

--- a/bun.lock
+++ b/bun.lock
@@ -939,6 +939,7 @@
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@shepherdjerred/llm-models": "workspace:*",
+        "@shepherdjerred/s3-signed-request": "workspace:*",
         "prom-client": "^15.1.3",
         "zod": "^4.4.3",
       },
@@ -1110,6 +1111,22 @@
     "packages/resume": {
       "name": "@shepherdjerred/resume",
       "version": "1.0.0",
+    },
+    "packages/s3-signed-request": {
+      "name": "@shepherdjerred/s3-signed-request",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@shepherdjerred/eslint-config": "workspace:*",
+        "@tsconfig/node-lts": "^24.0.0",
+        "@tsconfig/recommended": "^1.0.13",
+        "@tsconfig/strictest": "^2.0.8",
+        "@types/bun": "1.4.0",
+        "@typescript/native": "npm:typescript@7.0.2",
+        "eslint": "^10.7.0",
+        "jiti": "^2.7.0",
+        "typescript": "^6.0.0",
+        "vitest": "4.1.10",
+      },
     },
     "packages/scout-for-lol": {
       "name": "scout-for-lol",
@@ -1956,6 +1973,7 @@
         "@shepherdjerred/llm-models": "workspace:*",
         "@shepherdjerred/llm-observability": "workspace:*",
         "@shepherdjerred/llm-runtime": "workspace:*",
+        "@shepherdjerred/s3-signed-request": "workspace:*",
         "@shepherdjerred/seaweedfs-backup": "workspace:*",
         "@shepherdjerred/temporal-observability": "workspace:*",
         "@temporalio/activity": "1.22.0",
@@ -3959,6 +3977,8 @@
     "@shepherdjerred/resume": ["@shepherdjerred/resume@workspace:packages/resume"],
 
     "@shepherdjerred/root-scripts": ["@shepherdjerred/root-scripts@workspace:scripts"],
+
+    "@shepherdjerred/s3-signed-request": ["@shepherdjerred/s3-signed-request@workspace:packages/s3-signed-request"],
 
     "@shepherdjerred/seaweedfs-backup": ["@shepherdjerred/seaweedfs-backup@workspace:packages/seaweedfs-backup"],
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "packages/scout-for-lol/packages/report",
     "packages/scout-for-lol/packages/temporal",
     "packages/scout-for-lol/packages/ui",
+    "packages/s3-signed-request",
     "packages/sjer.red",
     "packages/starlight-karma-bot",
     "packages/stocks-sjer-red",

--- a/packages/birmel/Dockerfile
+++ b/packages/birmel/Dockerfile
@@ -132,6 +132,7 @@ COPY --parents \
   packages/feature-flags \
   packages/llm-models \
   packages/llm-observability \
+  packages/s3-signed-request \
   packages/llm-runtime \
   ./
 # Bake Prisma's migration engines into the production dependency tree. Bun's

--- a/packages/discord-plays-pokemon/Dockerfile
+++ b/packages/discord-plays-pokemon/Dockerfile
@@ -116,6 +116,7 @@ COPY --parents \
   packages/discord-video-stream \
   packages/llm-models \
   packages/llm-observability \
+  packages/s3-signed-request \
   ./
 # Build the workspace deps whose package `main`/exports resolve to a gitignored
 # `dist/` — consumers crash at startup with `Cannot find module` otherwise.
@@ -197,6 +198,7 @@ COPY --parents \
   packages/discord-video-stream \
   packages/llm-models \
   packages/llm-observability \
+  packages/s3-signed-request \
   ./
 
 # Keep the deployed Codex instruction surface identical to the benchmark

--- a/packages/llm-observability/package.json
+++ b/packages/llm-observability/package.json
@@ -38,6 +38,7 @@
     "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@shepherdjerred/llm-models": "workspace:*",
+    "@shepherdjerred/s3-signed-request": "workspace:*",
     "prom-client": "^15.1.3",
     "zod": "^4.4.3"
   },

--- a/packages/llm-observability/src/archive-uploader.ts
+++ b/packages/llm-observability/src/archive-uploader.ts
@@ -1,5 +1,6 @@
-import { createHash, createHmac } from "node:crypto";
+import { createHash } from "node:crypto";
 import { gunzipSync, gzipSync } from "node:zlib";
+import { createSignedS3Request } from "@shepherdjerred/s3-signed-request";
 
 export type ArchiveConfig = {
   bucket: string;
@@ -101,7 +102,7 @@ export async function archiveObjectExists(
   config: ArchiveConfig,
   key: string,
 ): Promise<boolean> {
-  const response = await signedS3Request(config, key, "HEAD");
+  const response = await signedS3Request(config, { key, method: "HEAD" });
   if (response.ok) return true;
   if (response.status === 404) return false;
   throw new Error(
@@ -120,7 +121,7 @@ export async function readArchiveObject(
   config: ArchiveConfig,
   key: string,
 ): Promise<string | undefined> {
-  const response = await signedS3Request(config, key, "GET");
+  const response = await signedS3Request(config, { key, method: "GET" });
   if (response.status === 404) return undefined;
   if (!response.ok) {
     throw new Error(
@@ -134,39 +135,12 @@ function sha256Hex(value: string | Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function hmacSha256(key: Uint8Array | string, value: string): Buffer {
-  return createHmac("sha256", key).update(value).digest();
-}
-
-function formatAmzDate(date: Date): string {
-  return date.toISOString().replaceAll(/[:-]|\.\d{3}/g, "");
-}
-
-function buildS3Url(config: ArchiveConfig, key: string): URL {
-  const endpointUrl = new URL(config.endpoint);
-  const basePath = endpointUrl.pathname.replace(/\/$/, "");
-  const encodedKey = key
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-
-  if (config.forcePathStyle) {
-    return new URL(
-      `${endpointUrl.origin}${basePath}/${config.bucket}/${encodedKey}`,
-    );
-  }
-
-  const url = new URL(`${endpointUrl.origin}${basePath}/${encodedKey}`);
-  url.hostname = `${config.bucket}.${endpointUrl.hostname}`;
-  return url;
-}
-
 async function putS3Object(
   config: ArchiveConfig,
   key: string,
   body: Buffer,
 ): Promise<void> {
-  const response = await signedS3Request(config, key, "PUT", body);
+  const response = await signedS3Request(config, { key, method: "PUT", body });
 
   if (!response.ok) {
     const responseBody = await response.text();
@@ -176,85 +150,36 @@ async function putS3Object(
   }
 }
 
+type ArchiveRequestInput =
+  | { key: string; method: "GET" | "HEAD" }
+  | { key: string; method: "PUT"; body: Buffer };
+
 async function signedS3Request(
   config: ArchiveConfig,
-  key: string,
-  method: "GET" | "HEAD" | "PUT",
-  body?: Buffer,
+  input: ArchiveRequestInput,
 ): Promise<Response> {
-  const url = buildS3Url(config, key);
-  const payloadHash = sha256Hex(body ?? "");
-  const amzDate = formatAmzDate(new Date());
-  const dateStamp = amzDate.slice(0, 8);
-
-  const headers: Record<string, string> = {
-    host: url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-  };
-
-  if (config.sessionToken !== undefined && config.sessionToken !== "") {
-    headers["x-amz-security-token"] = config.sessionToken;
+  // A hung S3 endpoint must not stall span export or Broadcast ingestion
+  // indefinitely: the span processor awaits uploads before forwarding, and
+  // ingest awaits receipt reads in its request handler. Upload callers treat
+  // the abort as a failed (best-effort) upload; exists/read callers let it
+  // propagate so "unavailable" is never read as "missing".
+  const signal = AbortSignal.timeout(S3_REQUEST_TIMEOUT_MS);
+  if (input.method === "PUT") {
+    return fetch(
+      createSignedS3Request(config, {
+        method: input.method,
+        key: input.key,
+        body: new Uint8Array(input.body),
+        contentType: "application/gzip",
+        signal,
+      }),
+    );
   }
-
-  const sortedHeaderEntries = Object.entries(headers).toSorted(
-    ([left], [right]) => left.localeCompare(right),
+  return fetch(
+    createSignedS3Request(config, {
+      method: input.method,
+      key: input.key,
+      signal,
+    }),
   );
-  const canonicalHeaders = sortedHeaderEntries
-    .map(([k, v]) => `${k}:${v}\n`)
-    .join("");
-  const signedHeaders = sortedHeaderEntries.map(([k]) => k).join(";");
-  const canonicalRequest = [
-    method,
-    url.pathname,
-    url.searchParams.toString(),
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-
-  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    credentialScope,
-    sha256Hex(canonicalRequest),
-  ].join("\n");
-
-  const signingKey = hmacSha256(
-    hmacSha256(
-      hmacSha256(
-        hmacSha256(`AWS4${config.secretAccessKey}`, dateStamp),
-        config.region,
-      ),
-      "s3",
-    ),
-    "aws4_request",
-  );
-  const signature = createHmac("sha256", signingKey)
-    .update(stringToSign)
-    .digest("hex");
-
-  const authorization = [
-    `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}`,
-    `SignedHeaders=${signedHeaders}`,
-    `Signature=${signature}`,
-  ].join(", ");
-
-  const response = await fetch(url, {
-    method,
-    headers: {
-      ...headers,
-      Authorization: authorization,
-      ...(body === undefined ? {} : { "Content-Type": "application/gzip" }),
-    },
-    ...(body === undefined ? {} : { body: new Uint8Array(body) }),
-    // A hung S3 endpoint must not stall span export or Broadcast ingestion
-    // indefinitely: the span processor awaits uploads before forwarding, and
-    // ingest awaits receipt reads in its request handler. Upload callers treat
-    // the abort as a failed (best-effort) upload; exists/read callers let it
-    // propagate so "unavailable" is never read as "missing".
-    signal: AbortSignal.timeout(S3_REQUEST_TIMEOUT_MS),
-  });
-  return response;
 }

--- a/packages/llm-observability/test/unit/archive-uploader.test.ts
+++ b/packages/llm-observability/test/unit/archive-uploader.test.ts
@@ -1,5 +1,12 @@
-import { test, expect } from "vitest";
-import { buildArchiveKey, type ArchiveConfig } from "#src/archive-uploader.ts";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  archiveObjectExists,
+  buildArchiveKey,
+  readArchiveObject,
+  uploadArchive,
+  type ArchiveConfig,
+} from "#src/archive-uploader.ts";
 
 const config: ArchiveConfig = {
   bucket: "llm-archive",
@@ -39,4 +46,105 @@ test("buildArchiveKey honours the configured prefix", () => {
   expect(key).toBe(
     "custom/path/birmel/claude_code_sdk/2026/01/02/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb.json.gz",
   );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function requireRequest(input: unknown): Request {
+  if (!(input instanceof Request)) {
+    throw new TypeError("Expected fetch to receive a Request");
+  }
+  return input;
+}
+
+describe("archive S3 wrappers", () => {
+  test("uploads a gzip body and retains best-effort failure semantics", async () => {
+    const requests: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        requests.push(requireRequest(input));
+        return new Response("storage unavailable", { status: 503 });
+      }),
+    );
+
+    const result = await uploadArchive(
+      config,
+      "archive/object.json.gz",
+      '{"ok":true}',
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("S3 upload failed (503): storage unavailable");
+    const request = requests[0];
+    if (request === undefined) throw new Error("Expected one S3 request");
+    expect(request.method).toBe("PUT");
+    expect(request.headers.get("content-type")).toBe("application/gzip");
+    expect(request.signal).toBeInstanceOf(AbortSignal);
+    expect(
+      gunzipSync(Buffer.from(await request.arrayBuffer())).toString(),
+    ).toBe('{"ok":true}');
+  });
+
+  test.each([
+    { status: 200, expected: true },
+    { status: 404, expected: false },
+  ])("maps HEAD status $status to $expected", async ({ status, expected }) => {
+    const requests: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        requests.push(requireRequest(input));
+        return new Response(undefined, { status });
+      }),
+    );
+
+    await expect(
+      archiveObjectExists(config, "archive/object.json.gz"),
+    ).resolves.toBe(expected);
+    expect(requests[0]?.method).toBe("HEAD");
+  });
+
+  test("rejects HEAD storage failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(undefined, { status: 500, statusText: "Server Error" }),
+      ),
+    );
+
+    await expect(
+      archiveObjectExists(config, "archive/object.json.gz"),
+    ).rejects.toThrow("S3 archive existence check failed (500): Server Error");
+  });
+
+  test("downloads and decompresses archive objects", async () => {
+    const requests: Request[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        requests.push(requireRequest(input));
+        return new Response(gzipSync('{"stored":true}'), { status: 200 });
+      }),
+    );
+
+    await expect(
+      readArchiveObject(config, "archive/object.json.gz"),
+    ).resolves.toBe('{"stored":true}');
+    expect(requests[0]?.method).toBe("GET");
+  });
+
+  test("returns undefined for missing archive objects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(undefined, { status: 404 })),
+    );
+
+    await expect(
+      readArchiveObject(config, "missing.json.gz"),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/openrouter-broadcast-ingest/Dockerfile
+++ b/packages/openrouter-broadcast-ingest/Dockerfile
@@ -19,6 +19,7 @@ COPY --parents \
   tsconfig.base.json \
   packages/llm-models \
   packages/llm-observability \
+  packages/s3-signed-request \
   packages/openrouter-broadcast-ingest \
   ./
 # llm-observability imports the catalog package whose runtime export points at

--- a/packages/s3-signed-request/eslint.config.ts
+++ b/packages/s3-signed-request/eslint.config.ts
@@ -1,0 +1,4 @@
+import { recommended } from "@shepherdjerred/eslint-config";
+
+const config = [...recommended({ tsconfigRootDir: import.meta.dirname })];
+export default config;

--- a/packages/s3-signed-request/package.json
+++ b/packages/s3-signed-request/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@shepherdjerred/s3-signed-request",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "bun --no-install build src/index.ts --outdir dist --target bun",
+    "typecheck": "PATH=node_modules/@typescript/native/bin:$PATH tsc --noEmit",
+    "lint": "bunx eslint --cache .",
+    "test": "bun --no-install --bun vitest --config ../../vitest.config.ts run test",
+    "test:ci": "bun ../../scripts/run-ci-test.ts",
+    "test:report": "CI_TEST_COVERAGE=1 bun ../../scripts/run-ci-test.ts"
+  },
+  "devDependencies": {
+    "@shepherdjerred/eslint-config": "workspace:*",
+    "@tsconfig/node-lts": "^24.0.0",
+    "@tsconfig/recommended": "^1.0.13",
+    "@tsconfig/strictest": "^2.0.8",
+    "@types/bun": "1.4.0",
+    "@typescript/native": "npm:typescript@7.0.2",
+    "eslint": "^10.7.0",
+    "jiti": "^2.7.0",
+    "typescript": "^6.0.0",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/s3-signed-request/src/index.ts
+++ b/packages/s3-signed-request/src/index.ts
@@ -1,0 +1,131 @@
+import { createHash, createHmac } from "node:crypto";
+
+export type SignedS3RequestConfig = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string | undefined;
+  endpoint: string;
+  bucket: string;
+  region: string;
+  forcePathStyle: boolean;
+};
+
+type ReadRequestInput = {
+  method: "GET" | "HEAD";
+  key: string;
+  signingTime?: Date;
+  signal?: AbortSignal;
+};
+
+type PutRequestInput = {
+  method: "PUT";
+  key: string;
+  body: string | Uint8Array;
+  contentType: string;
+  signingTime?: Date;
+  signal?: AbortSignal;
+};
+
+export type SignedS3RequestInput = ReadRequestInput | PutRequestInput;
+
+function sha256Hex(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hmacSha256(key: Uint8Array | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function buildS3Url(config: SignedS3RequestConfig, key: string): URL {
+  const endpoint = new URL(config.endpoint);
+  const basePath = endpoint.pathname.replace(/\/$/, "");
+  const encodedKey = key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  if (config.forcePathStyle) {
+    return new URL(
+      `${endpoint.origin}${basePath}/${config.bucket}/${encodedKey}`,
+    );
+  }
+  const url = new URL(`${endpoint.origin}${basePath}/${encodedKey}`);
+  url.hostname = `${config.bucket}.${endpoint.hostname}`;
+  return url;
+}
+
+export function createSignedS3Request(
+  config: SignedS3RequestConfig,
+  input: SignedS3RequestInput,
+): Request {
+  const url = buildS3Url(config, input.key);
+  const body = input.method === "PUT" ? input.body : undefined;
+  const requestBody =
+    body === undefined
+      ? undefined
+      : typeof body === "string"
+        ? body
+        : new Uint8Array(body);
+  const payloadHash = sha256Hex(body ?? "");
+  const amzDate = (input.signingTime ?? new Date())
+    .toISOString()
+    .replaceAll(/[:-]|\.\d{3}/g, "");
+  const dateStamp = amzDate.slice(0, 8);
+  const signedHeaderValues: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+  if (config.sessionToken !== undefined && config.sessionToken !== "") {
+    signedHeaderValues["x-amz-security-token"] = config.sessionToken;
+  }
+  const headerEntries = Object.entries(signedHeaderValues).toSorted(
+    ([left], [right]) => left.localeCompare(right),
+  );
+  const canonicalHeaders = headerEntries
+    .map(([key, value]) => `${key}:${value}\n`)
+    .join("");
+  const signedHeaders = headerEntries.map(([key]) => key).join(";");
+  const canonicalRequest = [
+    input.method,
+    url.pathname,
+    url.searchParams.toString(),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = hmacSha256(
+    hmacSha256(
+      hmacSha256(
+        hmacSha256(`AWS4${config.secretAccessKey}`, dateStamp),
+        config.region,
+      ),
+      "s3",
+    ),
+    "aws4_request",
+  );
+  const signature = createHmac("sha256", signingKey)
+    .update(stringToSign)
+    .digest("hex");
+  const authorization = [
+    `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}`,
+    `SignedHeaders=${signedHeaders}`,
+    `Signature=${signature}`,
+  ].join(", ");
+  return new Request(url.toString(), {
+    method: input.method,
+    headers: {
+      ...signedHeaderValues,
+      Authorization: authorization,
+      ...(input.method === "PUT" ? { "Content-Type": input.contentType } : {}),
+    },
+    ...(requestBody === undefined ? {} : { body: requestBody }),
+    ...(input.signal === undefined ? {} : { signal: input.signal }),
+  });
+}

--- a/packages/s3-signed-request/test/index.test.ts
+++ b/packages/s3-signed-request/test/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import {
+  createSignedS3Request,
+  type SignedS3RequestConfig,
+} from "@shepherdjerred/s3-signed-request";
+
+const signingTime = new Date("2026-05-19T15:30:00.000Z");
+const config: SignedS3RequestConfig = {
+  accessKeyId: "example-access-key",
+  secretAccessKey: "example-secret-key",
+  endpoint: "https://s3.example.com/api/",
+  bucket: "archive-bucket",
+  region: "us-west-2",
+  forcePathStyle: true,
+};
+
+describe("createSignedS3Request", () => {
+  test("creates a deterministic path-style GET signature and encodes each key segment", () => {
+    const request = createSignedS3Request(config, {
+      method: "GET",
+      key: "folder/space + snowman ☃.json",
+      signingTime,
+    });
+
+    expect(request.url).toBe(
+      "https://s3.example.com/api/archive-bucket/folder/space%20%2B%20snowman%20%E2%98%83.json",
+    );
+    expect(request.method).toBe("GET");
+    expect(request.headers.get("x-amz-date")).toBe("20260519T153000Z");
+    expect(request.headers.get("x-amz-content-sha256")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+    expect(request.headers.get("authorization")).toBe(
+      "AWS4-HMAC-SHA256 Credential=example-access-key/20260519/us-west-2/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=9e8ea204b0ccfdb181df4574352bedf74a099270e3eab536616c01ee2fd2c6a1",
+    );
+    expect(request.headers.get("content-type")).toBeNull();
+    expect(request.body).toBeNull();
+  });
+
+  test("supports virtual-host addressing and HEAD requests", () => {
+    const request = createSignedS3Request(
+      { ...config, forcePathStyle: false },
+      { method: "HEAD", key: "health/check", signingTime },
+    );
+
+    expect(request.url).toBe(
+      "https://archive-bucket.s3.example.com/api/health/check",
+    );
+    expect(request.method).toBe("HEAD");
+    expect(request.body).toBeNull();
+  });
+
+  test("signs session credentials", () => {
+    const request = createSignedS3Request(
+      { ...config, sessionToken: "temporary-session-token" },
+      { method: "GET", key: "object.json", signingTime },
+    );
+
+    expect(request.headers.get("x-amz-security-token")).toBe(
+      "temporary-session-token",
+    );
+    expect(request.headers.get("authorization")).toContain(
+      "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+    );
+  });
+
+  test("includes PUT bodies and content types in the request", async () => {
+    const request = createSignedS3Request(config, {
+      method: "PUT",
+      key: "archive.json.gz",
+      body: "compressed-content",
+      contentType: "application/gzip",
+      signingTime,
+    });
+
+    expect(request.method).toBe("PUT");
+    expect(request.headers.get("content-type")).toBe("application/gzip");
+    expect(request.headers.get("x-amz-content-sha256")).toBe(
+      "ea6a59ec73d91dcb6daa77b067775b713751cd7991a63e8bbb36ffbccdf17841",
+    );
+    expect(await request.text()).toBe("compressed-content");
+  });
+
+  test("retains the caller-owned abort signal", () => {
+    const controller = new AbortController();
+    const request = createSignedS3Request(config, {
+      method: "GET",
+      key: "object.json",
+      signingTime,
+      signal: controller.signal,
+    });
+
+    expect(request.signal.aborted).toBe(false);
+    controller.abort();
+    expect(request.signal.aborted).toBe(true);
+  });
+});

--- a/packages/s3-signed-request/tsconfig.json
+++ b/packages/s3-signed-request/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json",
+    "@tsconfig/node-lts/tsconfig.json",
+    "@tsconfig/recommended/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "types": ["@types/bun"],
+    "moduleResolution": "Node16",
+    "module": "Node16",
+    "target": "ES2022",
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  }
+}

--- a/packages/scout-for-lol/packages/backend/Dockerfile
+++ b/packages/scout-for-lol/packages/backend/Dockerfile
@@ -89,6 +89,7 @@ COPY --parents \
   packages/feature-flags \
   packages/llm-models \
   packages/llm-observability \
+  packages/s3-signed-request \
   packages/llm-runtime \
   packages/temporal-observability \
   ./

--- a/packages/tasknotes-macos/Sources/TaskNotesMac/Detail/RecurrenceEditor.swift
+++ b/packages/tasknotes-macos/Sources/TaskNotesMac/Detail/RecurrenceEditor.swift
@@ -107,6 +107,7 @@ struct RecurrenceEditorSheet: View {
                 }
             }
             .formStyle(.grouped)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Divider()
             HStack {
@@ -119,9 +120,14 @@ struct RecurrenceEditorSheet: View {
                     .accessibilityIdentifier(AccessibilityIdentifier.Inspector.recurrenceApply)
             }
             .padding()
+            .fixedSize(horizontal: false, vertical: true)
         }
         .frame(width: 480, height: 610)
         .interactiveDismissDisabled()
+        // Keep the sheet identifier on this container. Without `.contain`,
+        // SwiftUI pushes it down and replaces the Apply button identifier when
+        // the form changes shape (for example, Daily to Weekly).
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityIdentifier.Inspector.recurrenceSheet)
     }
 }

--- a/packages/tasknotes-macos/Tests/Support/TaskNotesServerProcess.swift
+++ b/packages/tasknotes-macos/Tests/Support/TaskNotesServerProcess.swift
@@ -50,7 +50,11 @@ public final class TaskNotesServerProcess {
     public let authToken: String
 
     private let process: Process
-    private let output: Pipe
+    // A Pipe can keep Process.waitUntilExit() blocked after the child exits if
+    // nobody drains it. A file preserves startup diagnostics without coupling
+    // server shutdown to a reader.
+    private let output: FileHandle
+    private let outputURL: URL
 
     /// Start a server, or report why it could not be started.
     ///
@@ -69,6 +73,20 @@ public final class TaskNotesServerProcess {
         vault = FileManager.default.temporaryDirectory
             .appending(path: "tasknotes-e2e-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: vault, withIntermediateDirectories: true)
+        outputURL = vault.appending(path: "server.log")
+        guard
+            FileManager.default.createFile(
+                atPath: outputURL.path(percentEncoded: false),
+                contents: nil
+            )
+        else {
+            throw ServerUnavailable(reason: "could not create the server log")
+        }
+        do {
+            output = try FileHandle(forWritingTo: outputURL)
+        } catch {
+            throw ServerUnavailable(reason: "could not open the server log: \(error)")
+        }
 
         let port = try Self.reserveEphemeralPort()
         guard let url = URL(string: "http://127.0.0.1:\(port)") else {
@@ -91,7 +109,6 @@ public final class TaskNotesServerProcess {
         environment["SENTRY_DSN"] = ""
         process.environment = environment
 
-        output = Pipe()
         process.standardOutput = output
         process.standardError = output
 
@@ -108,6 +125,7 @@ public final class TaskNotesServerProcess {
         if process.isRunning {
             process.terminate()
         }
+        _ = Result { try output.close() }
         // Best-effort, and explicitly so. `deinit` cannot propagate, `try?` is
         // banned repository-wide for hiding the error, and a leftover
         // directory under `/tmp` is not a test failure — `Result` makes the
@@ -121,6 +139,7 @@ public final class TaskNotesServerProcess {
             process.terminate()
             process.waitUntilExit()
         }
+        _ = Result { try output.close() }
     }
 
     /// Everything the server has written to stdout and stderr so far.
@@ -128,8 +147,13 @@ public final class TaskNotesServerProcess {
     /// Read on failure, so a timeout reports what the server said rather than
     /// just that it never answered.
     public func log() -> String {
-        let data = output.fileHandleForReading.availableData
-        return String(bytes: data, encoding: .utf8) ?? "<non-UTF-8 server output>"
+        _ = Result { try output.synchronize() }
+        switch Result(catching: { try Data(contentsOf: outputURL) }) {
+        case .success(let data):
+            return String(bytes: data, encoding: .utf8) ?? "<non-UTF-8 server output>"
+        case .failure(let error):
+            return "<unreadable server output: \(error)>"
+        }
     }
 
     // ── The vault, as a user would see it ──────────────────────────────────

--- a/packages/tasknotes-macos/UITests/InspectorEditingUITests.swift
+++ b/packages/tasknotes-macos/UITests/InspectorEditingUITests.swift
@@ -60,7 +60,8 @@ final class InspectorEditingUITests: XCTestCase {
             in: app
         ).click()
         element(AccessibilityIdentifier.Inspector.recurrenceApply, in: app).click()
-        try waitForVault(server, containing: "recurrence: FREQ=WEEKLY;BYDAY=")
+        try waitForVault(server, containing: "recurrence: DTSTART:")
+        try waitForVault(server, containing: ";FREQ=WEEKLY;BYDAY=")
         try waitForVault(server, containing: "recurrence_anchor: scheduled")
     }
 
@@ -76,7 +77,8 @@ final class InspectorEditingUITests: XCTestCase {
         // Selection changes commit and then restore the same stored body.
         selectTask("Selection target", id: "TaskNotes/Selection target.md", in: app)
         selectTask("Inspector journey", id: "TaskNotes/Inspector journey.md", in: app)
-        XCTAssertTrue(app.staticTexts["Saved through Done."].waitForExistence(timeout: 5))
+        openBodyEditor(in: app)
+        XCTAssertEqual(bodyEditor(in: app).value as? String, "Saved through Done.")
 
         // Inspector closure follows the same capture path.
         openBodyEditor(in: app)
@@ -94,22 +96,42 @@ final class InspectorEditingUITests: XCTestCase {
         ) { addTeardownBlock($0) }
         selectTask("Inspector journey", id: "TaskNotes/Inspector journey.md", in: app)
         openBodyEditor(in: app)
-        let editor = element(AccessibilityIdentifier.Inspector.detailsSource, in: app)
+        let editor = bodyEditor(in: app)
         editor.click()
-        editor.typeText(" shortcut")
+        app.typeText(" shortcut")
         app.typeKey("z", modifierFlags: [.command])
-        XCTAssertEqual(editor.value as? String, "Saved through inspector closure.")
+        XCTAssertEqual(
+            bodyEditor(in: app).value as? String,
+            "Saved through inspector closure."
+        )
 
-        editor.typeText(" menu")
-        app.menuBars.menuBarItems["Edit"].click()
-        app.menuItems.matching(NSPredicate(format: "label BEGINSWITH 'Undo'")).firstMatch.click()
-        XCTAssertEqual(editor.value as? String, "Saved through inspector closure.")
+        app.typeText(" menu")
+        let editMenuItem = app.menuBars.menuBarItems["Edit"]
+        editMenuItem.click()
+        let undoItem = editMenuItem.menus.menuItems
+            .matching(identifier: "undo:")
+            .firstMatch
+        XCTAssertTrue(undoItem.waitForExistence(timeout: 5))
+        undoItem.click()
+        XCTAssertEqual(
+            bodyEditor(in: app).value as? String,
+            "Saved through inspector closure."
+        )
     }
 
     private func selectTask(_ title: String, id: String, in app: XCUIApplication) {
         let row = element(AccessibilityIdentifier.TaskList.row(id), in: app)
         XCTAssertTrue(row.waitForExistence(timeout: 15), "missing row \(title)")
-        row.click()
+        // Clicking the contained accessibility group invokes its context-menu
+        // action under XCTest on macOS 26. Select through the native outline
+        // row instead, which is the table-row interaction a user performs.
+        let nativeRow = app.outlines[AccessibilityIdentifier.TaskList.list]
+            .outlineRows.containing(.staticText, identifier: title).firstMatch
+        XCTAssertTrue(nativeRow.waitForExistence(timeout: 5), "missing native row \(title)")
+        // `XCUIElement.click()` chooses the trailing edge of this outline row,
+        // where the hover actions live. The leading cell inset is owned by the
+        // native table and therefore exercises selection directly.
+        nativeRow.coordinate(withNormalizedOffset: CGVector(dx: 0.02, dy: 0.5)).click()
         XCTAssertTrue(
             element(AccessibilityIdentifier.Inspector.title, in: app).waitForExistence(timeout: 5))
     }
@@ -129,10 +151,21 @@ final class InspectorEditingUITests: XCTestCase {
     }
 
     private func replaceBody(with text: String, in app: XCUIApplication) {
-        let source = element(AccessibilityIdentifier.Inspector.detailsSource, in: app)
-        source.click()
+        let editor = bodyEditor(in: app)
+        editor.click()
         app.typeKey("a", modifierFlags: [.command])
-        source.typeText(text)
+        // The identifier belongs to the representable's scroll view. Clicking
+        // that wrapper leaves the task list as first responder, where typing
+        // performs row selection. Click its real NSTextView child, then send
+        // the keystrokes through the focused application responder.
+        app.typeText(text)
+    }
+
+    private func bodyEditor(in app: XCUIApplication) -> XCUIElement {
+        let source = element(AccessibilityIdentifier.Inspector.detailsSource, in: app)
+        let editor = source.descendants(matching: .textView).firstMatch
+        XCTAssertTrue(editor.waitForExistence(timeout: 5))
+        return editor
     }
 
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {

--- a/packages/tasknotes-windows/tests/TaskNotes.Windows.Tests/TaskNotesStoreTests.cs
+++ b/packages/tasknotes-windows/tests/TaskNotes.Windows.Tests/TaskNotesStoreTests.cs
@@ -210,13 +210,14 @@ namespace TaskNotes.Windows.Tests
                 },
                 TestContext.CancellationToken
             );
+            TaskItem[] visibleTasks = [.. store.State.VisibleTasks];
             Assert.AreSequenceEqual(
                 ["Beta task", "Alpha task"],
-                [.. store.State.VisibleTasks.Select(task => task.Title)]
+                [.. visibleTasks.Select(task => task.Title)]
             );
-            Assert.IsTrue(store.State.VisibleTasks.All(task => task.GroupLabel == "Windows"));
+            Assert.IsTrue(visibleTasks.All(task => task.GroupLabel == "Windows"));
 
-            string[] ids = [.. store.State.VisibleTasks.Select(task => task.Id)];
+            string[] ids = [.. visibleTasks.Select(task => task.Id)];
             await store.CompleteTasksAsync(ids, TestContext.CancellationToken);
             Assert.IsTrue(
                 ids.All(id => store.State.AllTasks.Single(task => task.Id == id).IsCompleted)

--- a/packages/temporal/Dockerfile
+++ b/packages/temporal/Dockerfile
@@ -417,6 +417,7 @@ COPY --parents \
   packages/home-assistant \
   packages/llm-models \
   packages/llm-observability \
+  packages/s3-signed-request \
   packages/llm-runtime \
   packages/scout-for-lol/packages/data \
   packages/scout-for-lol/packages/temporal \

--- a/packages/temporal/package.json
+++ b/packages/temporal/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@shepherdjerred/seaweedfs-backup": "workspace:*",
+    "@shepherdjerred/s3-signed-request": "workspace:*",
     "@aws-sdk/client-s3": "^3.1001.0",
     "@kubernetes/client-node": "^2.0.0",
     "@octokit/webhooks-methods": "^6.0.0",

--- a/packages/temporal/src/shared/s3.test.ts
+++ b/packages/temporal/src/shared/s3.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { putS3Object, type S3PutObjectConfig } from "./s3.ts";
+
+const config: S3PutObjectConfig = {
+  accessKeyId: "access-key",
+  secretAccessKey: "secret-key",
+  sessionToken: "session-token",
+  endpoint: "https://s3.example.com",
+  bucket: "archive",
+  key: "matches/one.json",
+  region: "us-east-1",
+  forcePathStyle: true,
+  contentType: "application/json",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("putS3Object", () => {
+  test("uploads a signed request with the configured content type", async () => {
+    const fetchMock = vi.fn(
+      async (_input: Request) => new Response(undefined, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await putS3Object(config, '{"match":1}');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const input = fetchMock.mock.calls[0]?.[0];
+    if (!(input instanceof Request)) {
+      throw new TypeError("Expected fetch to receive a Request");
+    }
+    expect(input.url).toBe("https://s3.example.com/archive/matches/one.json");
+    expect(input.method).toBe("PUT");
+    expect(input.headers.get("content-type")).toBe("application/json");
+    expect(input.headers.get("x-amz-security-token")).toBe("session-token");
+    expect(await input.text()).toBe('{"match":1}');
+  });
+
+  test("preserves the response body in upload failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("storage unavailable", {
+            status: 503,
+            statusText: "Service Unavailable",
+          }),
+      ),
+    );
+
+    await expect(putS3Object(config, "payload")).rejects.toThrow(
+      "S3 upload failed (503): storage unavailable",
+    );
+  });
+});

--- a/packages/temporal/src/shared/s3.ts
+++ b/packages/temporal/src/shared/s3.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac } from "node:crypto";
+import { createSignedS3Request } from "@shepherdjerred/s3-signed-request";
 
 export type S3PutObjectConfig = {
   accessKeyId: string;
@@ -12,109 +12,17 @@ export type S3PutObjectConfig = {
   contentType: string;
 };
 
-function sha256Hex(value: string | Uint8Array): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function hmacSha256(key: Uint8Array | string, value: string): Buffer {
-  return createHmac("sha256", key).update(value).digest();
-}
-
-function formatAmzDate(date: Date): string {
-  return date.toISOString().replaceAll(/[:-]|\.\d{3}/g, "");
-}
-
-function buildS3Url(config: S3PutObjectConfig): URL {
-  const endpointUrl = new URL(config.endpoint);
-  const basePath = endpointUrl.pathname.replace(/\/$/, "");
-  const encodedKey = config.key
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-
-  if (config.forcePathStyle) {
-    return new URL(
-      `${endpointUrl.origin}${basePath}/${config.bucket}/${encodedKey}`,
-    );
-  }
-
-  const url = new URL(`${endpointUrl.origin}${basePath}/${encodedKey}`);
-  url.hostname = `${config.bucket}.${endpointUrl.hostname}`;
-  return url;
-}
-
 export async function putS3Object(
   config: S3PutObjectConfig,
   body: string,
 ): Promise<void> {
-  const url = buildS3Url(config);
-  const payloadHash = sha256Hex(body);
-  const amzDate = formatAmzDate(new Date());
-  const dateStamp = amzDate.slice(0, 8);
-
-  const headers: Record<string, string> = {
-    host: url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-  };
-
-  if (config.sessionToken !== undefined && config.sessionToken !== "") {
-    headers["x-amz-security-token"] = config.sessionToken;
-  }
-
-  const sortedHeaderEntries = Object.entries(headers).toSorted(
-    ([left], [right]) => left.localeCompare(right),
-  );
-  const canonicalHeaders = sortedHeaderEntries
-    .map(([key, value]) => `${key}:${value}\n`)
-    .join("");
-  const signedHeaders = sortedHeaderEntries.map(([key]) => key).join(";");
-  const canonicalRequest = [
-    "PUT",
-    url.pathname,
-    url.searchParams.toString(),
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-
-  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    credentialScope,
-    sha256Hex(canonicalRequest),
-  ].join("\n");
-
-  const signingKey = hmacSha256(
-    hmacSha256(
-      hmacSha256(
-        hmacSha256(`AWS4${config.secretAccessKey}`, dateStamp),
-        config.region,
-      ),
-      "s3",
-    ),
-    "aws4_request",
-  );
-  const signature = createHmac("sha256", signingKey)
-    .update(stringToSign)
-    .digest("hex");
-
-  const authorization = [
-    `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}`,
-    `SignedHeaders=${signedHeaders}`,
-    `Signature=${signature}`,
-  ].join(", ");
-
-  const response = await fetch(url, {
+  const request = createSignedS3Request(config, {
     method: "PUT",
-    headers: {
-      ...headers,
-      Authorization: authorization,
-      "Content-Type": config.contentType,
-    },
+    key: config.key,
     body,
+    contentType: config.contentType,
   });
+  const response = await fetch(request);
 
   if (!response.ok) {
     const responseBody = await response.text();

--- a/scripts/ci-test-manifest.json
+++ b/scripts/ci-test-manifest.json
@@ -341,6 +341,16 @@
       ]
     },
     {
+      "package": "@shepherdjerred/s3-signed-request",
+      "directory": "packages/s3-signed-request",
+      "steps": [
+        {
+          "runner": "vitest",
+          "args": ["test"]
+        }
+      ]
+    },
+    {
       "package": "@shepherdjerred/openrouter-broadcast-ingest",
       "directory": "packages/openrouter-broadcast-ingest",
       "steps": [


### PR DESCRIPTION
## Why

The shared S3 signing wrappers duplicated SigV4 behavior, and the hard TaskNotes native gate exposed several independent recurrence-lifecycle failures: unreachable Apply controls, row clicks that opened a context menu, incomplete persisted-data assertions, a real-server harness that could deadlock on unread process output, an editor test that clicked the scroll wrapper rather than its NSTextView, a rendered Markdown lookup that assumed body text remained a generic static-text label, and an Undo lookup that assumed the visible menu title was also an accessibility label.

## What

- Centralize signed S3 request construction in the shared internal package while preserving wrapper behavior.
- Keep the recurrence action row and descendant accessibility identifiers reachable.
- Select tasks through the native outline row.
- Assert DTSTART, weekly BYDAY, and the scheduled recurrence anchor independently.
- Capture server output in a file so Process.waitUntilExit cannot deadlock on an unread Pipe.
- Focus the real NSTextView child before typing.
- Verify selection restoration through the editor value rather than a nonexistent generic static-text label.
- Resolve Undo through the observed Edit → Menu hierarchy using AppKit’s stable `undo:` selector, while retaining the click and post-undo editor assertion.

## Verification

- `bun run mac:verify`
- `xcodebuild build-for-testing -quiet -project TaskNotes.xcodeproj -scheme TaskNotes -configuration Debug -derivedDataPath .build/xcode -destination platform=macOS`
- `bun run jscpd`
- `bunx lefthook run pre-commit`
- Buildkite #13976: all seven UI tests executed unattended; isolated row selection.
- Buildkite #13991: reached Weekly selection; isolated accessibility identifier propagation.
- Buildkite #13993: Apply succeeded and the CI vault retained the weekly recurrence.
- Buildkite #13994: Linux verify and review passed; live process sampling isolated the server-harness pipe deadlock before cancellation for the fix.
- Buildkite #14003: all seven UI tests executed unattended; isolated stale wrapper re-resolution.
- Buildkite #14015: Linux verify and review passed; proved the scroll wrapper had not focused its NSTextView child.
- Buildkite #14023: Linux verify and review passed; persisted the edited body, switched away and back, then isolated the rendered static-text lookup.
- Buildkite #14041: Linux verify, Codex review, QuotaBar, and hkctl passed; all seven TaskNotes UI tests ran unattended and the recurrence test isolated the application-wide menu-item lookup.
- Buildkite #14061: Linux verify, Codex review, QuotaBar, and hkctl passed; the captured CI hierarchy proved Edit was open and exposed an enabled menu item with identifier `undo:` and title `Undo`, but no accessibility label.

Exact-head native CI for `d6250c6c7f29e486ab529b0bda85129c24563fdc` is pending. No live AWS service was used.