### PR TITLE
refactor(streambot): consolidate playback test harnesses

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1445,8 +1445,8 @@
       "tokens": 175
     },
     "packages/streambot/test/command-handler.test.ts|packages/streambot/test/command-handler.test.ts": {
-      "clones": 3,
-      "tokens": 242
+      "clones": 1,
+      "tokens": 70
     },
     "packages/streambot/test/config-dynamic.test.ts|packages/streambot/test/config-dynamic.test.ts": {
       "clones": 1,
@@ -1469,36 +1469,20 @@
       "tokens": 154
     },
     "packages/streambot/test/session-manager.test.ts|packages/streambot/test/session-manager.test.ts": {
-      "clones": 8,
-      "tokens": 760
+      "clones": 4,
+      "tokens": 301
     },
     "packages/streambot/test/session-manager.test.ts|packages/streambot/test/userbot-pool.test.ts": {
       "clones": 1,
       "tokens": 91
     },
-    "packages/streambot/test/stream-observer.test.ts|packages/streambot/test/stream-observer.test.ts": {
-      "clones": 2,
-      "tokens": 193
-    },
-    "packages/streambot/test/streamer-pipeline.test.ts|packages/streambot/test/streamer-pipeline.test.ts": {
-      "clones": 3,
-      "tokens": 226
-    },
-    "packages/streambot/test/streamer-pipeline.test.ts|packages/streambot/test/streamer-position.test.ts": {
-      "clones": 1,
-      "tokens": 72
-    },
     "packages/streambot/test/streamer-position.test.ts|packages/streambot/test/streamer-position.test.ts": {
-      "clones": 5,
-      "tokens": 492
+      "clones": 1,
+      "tokens": 104
     },
     "packages/streambot/test/support/fake-realtime-transport.ts|packages/streambot/test/support/fake-realtime-transport.ts": {
       "clones": 1,
       "tokens": 90
-    },
-    "packages/streambot/test/voice-audio-lifecycle.test.ts|packages/streambot/test/voice-audio-lifecycle.test.ts": {
-      "clones": 6,
-      "tokens": 507
     },
     "packages/tasknotes-core/ci/coverage-ratchet.ts|packages/tasknotes-windows/scripts/coverage-ratchet.ts": {
       "clones": 1,

--- a/packages/streambot/test/command-handler.test.ts
+++ b/packages/streambot/test/command-handler.test.ts
@@ -984,66 +984,40 @@ describe("CommandHandler subtitles command (track picker)", () => {
     ]);
   });
 
-  test("aborts (no dispatch) if the current source's kind changed while the picker was open", async () => {
-    // The picker was built from a file source's sidecar candidate, but by the time the user
-    // picks, playback has moved on to a url source — applying the sidecar trackRef there would
-    // throw the invariant guard in the subtitle resolver, so this must be caught first. The
-    // source-id read flips from a `file:` id to a `url:` id between picker-open and dispatch.
-    const h = makeHandler({
-      view: { ...viewWithCurrent(REQUESTER), positionSeconds: 5 },
-      subtitleCandidates: [SIDECAR_CANDIDATE],
+  test.each([
+    {
+      scenario: "the source kind changed",
       currentSourceId: ["file:/movie.mkv", "url:https://youtu.be/abc"],
-    });
-    const { interaction, edits } = fakeInteraction({
-      sub: "subtitles",
-      userId: REQUESTER,
-      subtitleMenuPick: "sidecar:Movie.en.srt",
-    });
-    await h.handler.run(interaction);
-    expect(h.events).toHaveLength(0);
-    expect(edits.at(-1)).toContain("Playback changed while you were choosing");
-    expect(h.subtitleMenuPending()).toBe(false);
-  });
-
-  test("aborts (no dispatch) when playback advanced to a different item with the SAME title", async () => {
-    // Two distinct files can share a display title. If playback advances from one to the other
-    // during the picker window, a title-only guard would let the old file's sidecar trackRef be
-    // applied to the new file. The source-id read changes (different path) even though the view's
-    // title is unchanged, so the stale pick must be rejected.
-    const h = makeHandler({
-      view: { ...viewWithCurrent(REQUESTER), positionSeconds: 5 },
-      subtitleCandidates: [SIDECAR_CANDIDATE],
+    },
+    {
+      scenario: "a same-title item replaced the source",
       currentSourceId: ["file:/movies/dupe-a.mkv", "file:/movies/dupe-b.mkv"],
-    });
-    const { interaction, edits } = fakeInteraction({
-      sub: "subtitles",
-      userId: REQUESTER,
-      subtitleMenuPick: "sidecar:Movie.en.srt",
-    });
-    await h.handler.run(interaction);
-    expect(h.events).toHaveLength(0);
-    expect(edits.at(-1)).toContain("Playback changed while you were choosing");
-    expect(h.subtitleMenuPending()).toBe(false);
-  });
-
-  test("aborts (no dispatch) when playback stopped entirely while the picker was open", async () => {
-    // The item ended and nothing replaced it: the second source-id read is null, which never
-    // equals the captured id, so the pick is rejected instead of dispatched into the void.
-    const h = makeHandler({
-      view: { ...viewWithCurrent(REQUESTER), positionSeconds: 5 },
-      subtitleCandidates: [SIDECAR_CANDIDATE],
+    },
+    {
+      scenario: "playback stopped",
       currentSourceId: ["file:/movie.mkv", null],
-    });
-    const { interaction, edits } = fakeInteraction({
-      sub: "subtitles",
-      userId: REQUESTER,
-      subtitleMenuPick: "sidecar:Movie.en.srt",
-    });
-    await h.handler.run(interaction);
-    expect(h.events).toHaveLength(0);
-    expect(edits.at(-1)).toContain("Playback changed while you were choosing");
-    expect(h.subtitleMenuPending()).toBe(false);
-  });
+    },
+  ])(
+    "aborts a stale subtitle pick when $scenario",
+    async ({ currentSourceId }) => {
+      const h = makeHandler({
+        view: { ...viewWithCurrent(REQUESTER), positionSeconds: 5 },
+        subtitleCandidates: [SIDECAR_CANDIDATE],
+        currentSourceId,
+      });
+      const { interaction, edits } = fakeInteraction({
+        sub: "subtitles",
+        userId: REQUESTER,
+        subtitleMenuPick: "sidecar:Movie.en.srt",
+      });
+      await h.handler.run(interaction);
+      expect(h.events).toHaveLength(0);
+      expect(edits.at(-1)).toContain(
+        "Playback changed while you were choosing",
+      );
+      expect(h.subtitleMenuPending()).toBe(false);
+    },
+  );
 });
 
 function playedSource(strings: Record<string, string>) {

--- a/packages/streambot/test/session-manager.test.ts
+++ b/packages/streambot/test/session-manager.test.ts
@@ -274,6 +274,36 @@ function makeManager(config: Config, pool: UserbotProvider) {
   return { manager, announced, cards };
 }
 
+async function sessionHarness(poolSize: number, config?: Config) {
+  const resolvedConfig = config ?? (await makeConfig());
+  const pool = fakePool(poolSize);
+  return {
+    config: resolvedConfig,
+    pool,
+    ...makeManager(resolvedConfig, pool.provider),
+  };
+}
+
+function addFile(
+  manager: SessionManager,
+  channelId: ChannelId = CHANNEL_A,
+  file?: { path: string; title: string },
+) {
+  const source = file ?? { path: "/clip.mkv", title: "Clip" };
+  const handle = manager.ensureForPlay({
+    guildId: GUILD,
+    voiceChannelId: channelId,
+    statusChannelId: STATUS,
+  });
+  expect(handle).not.toBeNull();
+  handle?.dispatch({
+    type: "ADD",
+    source: { kind: "file", ...source },
+    requesterId: USER,
+  });
+  return handle;
+}
+
 describe("SessionManager", () => {
   test("ensureForPlay returns null when no userbot is available", async () => {
     const config = await makeConfig();
@@ -288,21 +318,8 @@ describe("SessionManager", () => {
   });
 
   test("a play starts a session that posts a player card", async () => {
-    const config = await makeConfig();
-    const pool = fakePool(1);
-    const { manager, cards } = makeManager(config, pool.provider);
-
-    const handle = manager.ensureForPlay({
-      guildId: GUILD,
-      voiceChannelId: CHANNEL_A,
-      statusChannelId: STATUS,
-    });
-    expect(handle).not.toBeNull();
-    handle?.dispatch({
-      type: "ADD",
-      source: { kind: "file", path: "/clip.mkv", title: "Clip" },
-      requesterId: USER,
-    });
+    const { manager, cards, pool } = await sessionHarness(1);
+    addFile(manager);
 
     await waitUntil(() => cards.posts.length > 0);
     expect(cards.posts[0]?.channelId).toBe(STATUS);
@@ -316,20 +333,8 @@ describe("SessionManager", () => {
   });
 
   test("a second play in the same channel reuses the session (no new userbot)", async () => {
-    const config = await makeConfig();
-    const pool = fakePool(2);
-    const { manager } = makeManager(config, pool.provider);
-
-    const first = manager.ensureForPlay({
-      guildId: GUILD,
-      voiceChannelId: CHANNEL_A,
-      statusChannelId: STATUS,
-    });
-    first?.dispatch({
-      type: "ADD",
-      source: { kind: "file", path: "/a.mkv", title: "A" },
-      requesterId: USER,
-    });
+    const { manager, pool } = await sessionHarness(2);
+    addFile(manager, CHANNEL_A, { path: "/a.mkv", title: "A" });
     const second = manager.ensureForPlay({
       guildId: GUILD,
       voiceChannelId: CHANNEL_A,
@@ -342,9 +347,7 @@ describe("SessionManager", () => {
   });
 
   test("two channels in one guild get independent sessions + userbots", async () => {
-    const config = await makeConfig();
-    const pool = fakePool(2);
-    const { manager } = makeManager(config, pool.provider);
+    const { manager, pool } = await sessionHarness(2);
 
     manager.ensureForPlay({
       guildId: GUILD,
@@ -364,20 +367,8 @@ describe("SessionManager", () => {
   });
 
   test("moveSession rekeys a live session to the new voice channel", async () => {
-    const config = await makeConfig();
-    const pool = fakePool(1);
-    const { manager } = makeManager(config, pool.provider);
-
-    const handle = manager.ensureForPlay({
-      guildId: GUILD,
-      voiceChannelId: CHANNEL_A,
-      statusChannelId: STATUS,
-    });
-    handle?.dispatch({
-      type: "ADD",
-      source: { kind: "file", path: "/clip.mkv", title: "Clip" },
-      requesterId: USER,
-    });
+    const { manager, pool } = await sessionHarness(1);
+    const handle = addFile(manager);
     await waitUntil(() => handle?.view().state === "streaming");
 
     expect(
@@ -399,20 +390,8 @@ describe("SessionManager", () => {
   });
 
   test("moveSession carries the resume-state file to the new channel path", async () => {
-    const config = await makeConfig();
-    const pool = fakePool(1);
-    const { manager } = makeManager(config, pool.provider);
-
-    const handle = manager.ensureForPlay({
-      guildId: GUILD,
-      voiceChannelId: CHANNEL_A,
-      statusChannelId: STATUS,
-    });
-    handle?.dispatch({
-      type: "ADD",
-      source: { kind: "file", path: "/clip.mkv", title: "Clip" },
-      requesterId: USER,
-    });
+    const { config, manager } = await sessionHarness(1);
+    const handle = addFile(manager);
     await waitUntil(() => handle?.view().state === "streaming");
 
     // Seed a snapshot at the OLD channel path so we can prove it follows the move (VOICE_TARGET_MOVED
@@ -447,20 +426,8 @@ describe("SessionManager", () => {
   });
 
   test("STOP tears the session down and releases the userbot", async () => {
-    const config = await makeConfig();
-    const pool = fakePool(1);
-    const { manager } = makeManager(config, pool.provider);
-
-    const handle = manager.ensureForPlay({
-      guildId: GUILD,
-      voiceChannelId: CHANNEL_A,
-      statusChannelId: STATUS,
-    });
-    handle?.dispatch({
-      type: "ADD",
-      source: { kind: "file", path: "/clip.mkv", title: "Clip" },
-      requesterId: USER,
-    });
+    const { manager, pool } = await sessionHarness(1);
+    const handle = addFile(manager);
     // Let it reach streaming, then stop.
     await waitUntil(() => manager.getExisting(GUILD, CHANNEL_A) !== null);
     handle?.dispatch({ type: "STOP" });
@@ -556,29 +523,17 @@ async function makeReconnectConfig(
 
 /** Start a session in CHANNEL_A and wait until it is streaming (its player card is posted). */
 async function startStreaming(
-  manager: SessionManager,
-  cards: { posts: { channelId: string; owner: CardOwner | null }[] },
+  harness: Awaited<ReturnType<typeof sessionHarness>>,
 ): Promise<void> {
-  const handle = manager.ensureForPlay({
-    guildId: GUILD,
-    voiceChannelId: CHANNEL_A,
-    statusChannelId: STATUS,
-  });
-  expect(handle).not.toBeNull();
-  handle?.dispatch({
-    type: "ADD",
-    source: { kind: "file", path: "/clip.mkv", title: "Clip" },
-    requesterId: USER,
-  });
-  await waitUntil(() => cards.posts.length > 0);
+  addFile(harness.manager);
+  await waitUntil(() => harness.cards.posts.length > 0);
 }
 
 describe("SessionManager voice-loss recovery", () => {
   test("transient close: state survives teardown and the session auto-resumes at position", async () => {
-    const config = await makeReconnectConfig();
-    const pool = fakePool(1);
-    const { manager, announced, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(1, await makeReconnectConfig());
+    const { config, pool, manager, announced } = harness;
+    await startStreaming(harness);
 
     const streamer = pool.streamers[0];
     if (streamer === undefined) throw new Error("missing fake streamer");
@@ -612,10 +567,9 @@ describe("SessionManager voice-loss recovery", () => {
   });
 
   test("deliberate close (fresh 4014): stays down, deletes state, announces the kick", async () => {
-    const config = await makeReconnectConfig();
-    const pool = fakePool(1);
-    const { manager, announced, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(1, await makeReconnectConfig());
+    const { config, pool, manager, announced } = harness;
+    await startStreaming(harness);
 
     pool.streamers[0]?.triggerVoiceClose({
       code: 4014,
@@ -643,10 +597,9 @@ describe("SessionManager voice-loss recovery", () => {
   });
 
   test("a late 4014 reclassifies a gateway-first detach before reconnect", async () => {
-    const config = await makeReconnectConfig();
-    const pool = fakePool(1);
-    const { manager, announced, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(1, await makeReconnectConfig());
+    const { config, pool, manager, announced } = harness;
+    await startStreaming(harness);
 
     const streamer = pool.streamers[0];
     if (streamer === undefined) throw new Error("missing fake streamer");
@@ -688,10 +641,9 @@ describe("SessionManager voice-loss recovery", () => {
 
 describe("SessionManager incident-scoped voice recovery", () => {
   test("a late 4014 stays bound to its incident after the userbot is reused", async () => {
-    const config = await makeReconnectConfig();
-    const pool = fakePool(1);
-    const { manager, announced, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(1, await makeReconnectConfig());
+    const { config, pool, manager, announced } = harness;
+    await startStreaming(harness);
 
     manager.notifyStreamerDetached({
       guildId: GUILD,
@@ -743,10 +695,12 @@ describe("SessionManager incident-scoped voice recovery", () => {
 
 describe("SessionManager voice recovery policy", () => {
   test("reconnect disabled: transient close stays down like today, but announces the reason", async () => {
-    const config = await makeReconnectConfig({ enabled: false });
-    const pool = fakePool(1);
-    const { manager, announced, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(
+      1,
+      await makeReconnectConfig({ enabled: false }),
+    );
+    const { config, pool, manager, announced } = harness;
+    await startStreaming(harness);
 
     pool.streamers[0]?.triggerVoiceClose({
       code: 4006,
@@ -771,10 +725,9 @@ describe("SessionManager voice recovery policy", () => {
   });
 
   test("manual re-play during the reconnect window wins; the timer no-ops", async () => {
-    const config = await makeReconnectConfig();
-    const pool = fakePool(1);
-    const { manager, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(1, await makeReconnectConfig());
+    const { pool, manager } = harness;
+    await startStreaming(harness);
 
     pool.streamers[0]?.triggerVoiceClose({
       code: 4006,
@@ -805,10 +758,12 @@ describe("SessionManager voice recovery policy", () => {
   });
 
   test("saturated pool: waits (without burning the reconnect budget) then resumes when a userbot frees", async () => {
-    const config = await makeReconnectConfig({ maxAttempts: 2 });
-    const pool = fakePool(1);
-    const { manager, announced, cards } = makeManager(config, pool.provider);
-    await startStreaming(manager, cards);
+    const harness = await sessionHarness(
+      1,
+      await makeReconnectConfig({ maxAttempts: 2 }),
+    );
+    const { config, pool, manager, announced } = harness;
+    await startStreaming(harness);
 
     pool.streamers[0]?.triggerVoiceClose({
       code: 4006,
@@ -842,31 +797,36 @@ describe("SessionManager voice recovery policy", () => {
   });
 });
 
+function leaveActorHarness() {
+  const pool = fakePool(1);
+  const streamer = pool.streamers[0];
+  if (streamer === undefined) throw new Error("fake pool produced no bot");
+  const left = { value: false };
+  const entry: UserbotEntry = {
+    userbot: {
+      ...streamer,
+      leaveVoice: () => {
+        left.value = true;
+        return Promise.resolve();
+      },
+    },
+    guildIds: new Set([GUILD]),
+    busy: false,
+  };
+  const hold = new TeardownHold(() => {
+    throw new Error("teardown must not run under a hold");
+  });
+  const actors = buildPlaybackActors({
+    entry,
+    resolveSource: () => Promise.resolve(RESOLVED),
+    teardownHold: () => hold,
+  });
+  return { actors, hold, left };
+}
+
 describe("playback actors", () => {
   test("the voice disconnect waits for a held assistant transaction", async () => {
-    const pool = fakePool(1);
-    const streamer = pool.streamers[0];
-    if (streamer === undefined) throw new Error("fake pool produced no bot");
-    let left = false;
-    const entry: UserbotEntry = {
-      userbot: {
-        ...streamer,
-        leaveVoice: () => {
-          left = true;
-          return Promise.resolve();
-        },
-      },
-      guildIds: new Set([GUILD]),
-      busy: false,
-    };
-    const hold = new TeardownHold(() => {
-      throw new Error("teardown must not run under a hold");
-    });
-    const actors = buildPlaybackActors({
-      entry,
-      resolveSource: () => Promise.resolve(RESOLVED),
-      teardownHold: () => hold,
-    });
+    const { actors, hold, left } = leaveActorHarness();
     const release = hold.acquire();
 
     // A voice `stop` dispatches STOP from inside its own transaction: the machine reaches `leaving`
@@ -876,37 +836,15 @@ describe("playback actors", () => {
       new AbortController().signal,
     );
     await Bun.sleep(0);
-    expect(left).toBe(false);
+    expect(left.value).toBe(false);
 
     release();
     await leaving;
-    expect(left).toBe(true);
+    expect(left.value).toBe(true);
   });
 
   test("an aborted leave stops waiting on the hold and never disconnects late", async () => {
-    const pool = fakePool(1);
-    const streamer = pool.streamers[0];
-    if (streamer === undefined) throw new Error("fake pool produced no bot");
-    let left = false;
-    const entry: UserbotEntry = {
-      userbot: {
-        ...streamer,
-        leaveVoice: () => {
-          left = true;
-          return Promise.resolve();
-        },
-      },
-      guildIds: new Set([GUILD]),
-      busy: false,
-    };
-    const hold = new TeardownHold(() => {
-      throw new Error("teardown must not run under a hold");
-    });
-    const actors = buildPlaybackActors({
-      entry,
-      resolveSource: () => Promise.resolve(RESOLVED),
-      teardownHold: () => hold,
-    });
+    const { actors, hold, left } = leaveActorHarness();
     const release = hold.acquire();
 
     // The machine's leaving-state wedge guard aborts the invoke while the voice transaction
@@ -918,10 +856,10 @@ describe("playback actors", () => {
     );
     controller.abort(new Error("leaving-state wedge guard"));
     await expect(leaving).rejects.toThrow("leaving-state wedge guard");
-    expect(left).toBe(false);
+    expect(left.value).toBe(false);
 
     release();
     await Bun.sleep(0);
-    expect(left).toBe(false);
+    expect(left.value).toBe(false);
   });
 });

--- a/packages/streambot/test/stream-observer.test.ts
+++ b/packages/streambot/test/stream-observer.test.ts
@@ -108,25 +108,43 @@ describe("createStreamObserver", () => {
 /** Let the fast (2ms) watchdog interval fire at least once. */
 const tick = () => new Promise((resolve) => setTimeout(resolve, 25));
 
+function stallWatchdogHarness() {
+  const wall = { value: 0 };
+  const stalls: (number | undefined)[] = [];
+  const streamObserver = createStreamObserver(
+    true,
+    () => wall.value,
+    (lastMediaSeconds) => stalls.push(lastMediaSeconds),
+    2,
+  );
+  streamObserver.observer.onCommand?.("ffmpeg -i in.mkv out");
+  return { ...streamObserver, wall, stalls };
+}
+
+function advanceMedia(
+  observer: ReturnType<typeof createStreamObserver>["observer"],
+  wall: { value: number },
+  wallOffset = 0,
+): void {
+  for (let second = 1; second <= 25; second++) {
+    wall.value = wallOffset + second * 1000;
+    observer.onProgress?.({
+      timemark: `00:00:${String(second).padStart(2, "0")}.00`,
+    });
+  }
+}
+
 describe("createStreamObserver stall watchdog", () => {
   test("a wedged ffmpeg emitting the SAME timemark still trips the stall watchdog and reports the last media position", async () => {
-    let wall = 0;
-    const stalls: (number | undefined)[] = [];
-    const { observer, dispose } = createStreamObserver(
-      true,
-      () => wall,
-      (lastMediaSeconds) => stalls.push(lastMediaSeconds),
-      2, // fast watchdog tick for a deterministic test
-    );
-    observer.onCommand?.("ffmpeg -i in.mkv out");
+    const { observer, dispose, wall, stalls } = stallWatchdogHarness();
     // First parseable sample arms the watchdog at wall=1000 with media at 5s.
-    wall = 1000;
+    wall.value = 1000;
     observer.onProgress?.({ timemark: "00:00:05.00" });
     // A wedged process keeps reporting the SAME media timemark — the watchdog must NOT re-arm.
-    wall = 2000;
+    wall.value = 2000;
     observer.onProgress?.({ timemark: "00:00:05.00" });
     // 21s past the last real media advance (wall=1000).
-    wall = 22_000;
+    wall.value = 22_000;
     await tick();
 
     expect(stalls.length).toBeGreaterThanOrEqual(1);
@@ -136,22 +154,9 @@ describe("createStreamObserver stall watchdog", () => {
   });
 
   test("advancing media keeps the watchdog armed (no false stall)", async () => {
-    let wall = 0;
-    const stalls: (number | undefined)[] = [];
-    const { observer, dispose } = createStreamObserver(
-      true,
-      () => wall,
-      (lastMediaSeconds) => stalls.push(lastMediaSeconds),
-      2,
-    );
-    observer.onCommand?.("ffmpeg -i in.mkv out");
+    const { observer, dispose, wall, stalls } = stallWatchdogHarness();
     // Media advances in lockstep with wall-clock across a span > STALL_AFTER_SECONDS.
-    for (let i = 1; i <= 25; i++) {
-      wall = i * 1000;
-      observer.onProgress?.({
-        timemark: `00:00:${String(i).padStart(2, "0")}.00`,
-      });
-    }
+    advanceMedia(observer, wall);
     await tick();
 
     expect(stalls).toHaveLength(0);
@@ -159,33 +164,15 @@ describe("createStreamObserver stall watchdog", () => {
   });
 
   test("a seek (new onCommand) starts a fresh epoch — healthy post-seek playback is not a false stall", async () => {
-    let wall = 0;
-    const stalls: (number | undefined)[] = [];
-    const { observer, dispose } = createStreamObserver(
-      true,
-      () => wall,
-      (lastMediaSeconds) => stalls.push(lastMediaSeconds),
-      2,
-    );
-    observer.onCommand?.("ffmpeg -i in.mkv out");
+    const { observer, dispose, wall, stalls } = stallWatchdogHarness();
     // Play healthily well past the stall threshold so the pre-seek media baseline is high (25s).
-    for (let i = 1; i <= 25; i++) {
-      wall = i * 1000;
-      observer.onProgress?.({
-        timemark: `00:00:${String(i).padStart(2, "0")}.00`,
-      });
-    }
+    advanceMedia(observer, wall);
     // A /seek restarts ffmpeg at a new -ss → new onCommand, and its output timemark restarts near
     // zero. Without an epoch reset the low post-seek timemarks stay < the old 25s baseline, never
     // re-arm the watchdog, and a false stall fires ~20s later despite healthy playback.
-    wall = 26_000;
+    wall.value = 26_000;
     observer.onCommand?.("ffmpeg -ss 120 -i in.mkv out");
-    for (let i = 1; i <= 25; i++) {
-      wall = 26_000 + i * 1000;
-      observer.onProgress?.({
-        timemark: `00:00:${String(i).padStart(2, "0")}.00`,
-      });
-    }
+    advanceMedia(observer, wall, 26_000);
     await tick();
 
     expect(stalls).toHaveLength(0);
@@ -193,18 +180,10 @@ describe("createStreamObserver stall watchdog", () => {
   });
 
   test("the stall fires once per silence (not every tick)", async () => {
-    let wall = 0;
-    const stalls: (number | undefined)[] = [];
-    const { observer, dispose } = createStreamObserver(
-      true,
-      () => wall,
-      (lastMediaSeconds) => stalls.push(lastMediaSeconds),
-      2,
-    );
-    observer.onCommand?.("ffmpeg -i in.mkv out");
-    wall = 1000;
+    const { observer, dispose, wall, stalls } = stallWatchdogHarness();
+    wall.value = 1000;
     observer.onProgress?.({ timemark: "00:00:05.00" });
-    wall = 30_000; // deep into the stall; many watchdog ticks will elapse during the wait
+    wall.value = 30_000; // deep into the stall; many watchdog ticks will elapse during the wait
     await tick();
 
     expect(stalls).toHaveLength(1);

--- a/packages/streambot/test/streamer-pipeline.test.ts
+++ b/packages/streambot/test/streamer-pipeline.test.ts
@@ -1,25 +1,18 @@
 import { describe, expect, test } from "vitest";
 import { StreambotStreamer } from "@shepherdjerred/streambot/streamer/streamer.ts";
 import type { PlayerFactory } from "@shepherdjerred/streambot/streamer/streamer-types.ts";
-import {
-  loadConfig,
-  type EnvLookup,
-} from "@shepherdjerred/streambot/config/index.ts";
+import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import type {
   ResolvedSource,
-  VoiceHandle,
+  RunStreamInput,
 } from "@shepherdjerred/streambot/machine/types.ts";
+import type { EnvLookup } from "@shepherdjerred/streambot/config/index.ts";
 import {
-  ChannelIdSchema,
-  GuildIdSchema,
-  UserTokenSchema,
-} from "@shepherdjerred/streambot/types/ids.ts";
+  STREAMER_USER_TOKEN as USER_TOKEN,
+  STREAMER_VOICE as VOICE,
+  streamerEnv as env,
+} from "./streamer-test-fixtures.ts";
 
-const USER_TOKEN = UserTokenSchema.parse("user-token");
-const VOICE: VoiceHandle = {
-  guildId: GuildIdSchema.parse("100000000000000010"),
-  channelId: ChannelIdSchema.parse("100000000000000020"),
-};
 const SUBTITLE_PATH = "/tmp/streambot-subs/test-pipeline.srt";
 const RESOLVED_HDR_WITH_SUBS: ResolvedSource = {
   title: "Movie",
@@ -28,15 +21,6 @@ const RESOLVED_HDR_WITH_SUBS: ResolvedSource = {
   subtitle: { path: SUBTITLE_PATH, cleanupPath: SUBTITLE_PATH },
   hdr: true,
 };
-
-function env(over: EnvLookup = {}): EnvLookup {
-  return {
-    BOT_TOKEN: "bot-token",
-    USER_TOKENS: "user-token",
-    VIDEOS_DIR: "/videos",
-    ...over,
-  };
-}
 
 type PrepareSnapshot = {
   hardwareAcceleratedDecoding: boolean | undefined;
@@ -95,27 +79,35 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 5));
 }
 
+async function startPipelineRun(options: {
+  pipelineMode: RunStreamInput["pipelineMode"];
+  resolved?: ResolvedSource;
+  startErrors?: (Error | undefined)[];
+}) {
+  const { factory, attempts } = makeFakeFactory(options.startErrors);
+  const streamer = new StreambotStreamer(
+    USER_TOKEN,
+    loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
+    () => 0,
+    factory,
+  );
+  const run = streamer.runStream(
+    {
+      voice: VOICE,
+      resolved: options.resolved ?? RESOLVED_HDR_WITH_SUBS,
+      volume: 100,
+      seekSeconds: 0,
+      pipelineMode: options.pipelineMode,
+    },
+    new AbortController().signal,
+  );
+  await flush();
+  return { attempts, run };
+}
+
 describe("StreambotStreamer pipeline options", () => {
   test("subtitles no longer force software: HW attempt carries subtitleBurn + inputColor hdr", async () => {
-    const { factory, attempts } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => 0,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED_HDR_WITH_SUBS,
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { attempts, run } = await startPipelineRun({ pipelineMode: "hw" });
 
     expect(attempts).toHaveLength(1);
     expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(true);
@@ -129,25 +121,9 @@ describe("StreambotStreamer pipeline options", () => {
   });
 
   test("pipelineMode hw-upload threads hardwarePipelineMode upload with the VAAPI encoder", async () => {
-    const { factory, attempts } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => 0,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED_HDR_WITH_SUBS,
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw-upload",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { attempts, run } = await startPipelineRun({
+      pipelineMode: "hw-upload",
+    });
 
     expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(true);
     expect(attempts[0]?.hardwarePipelineMode).toBe("upload");
@@ -158,25 +134,7 @@ describe("StreambotStreamer pipeline options", () => {
   });
 
   test("pipelineMode sw runs software even when hardware is enabled in config", async () => {
-    const { factory, attempts } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => 0,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED_HDR_WITH_SUBS,
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "sw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { attempts, run } = await startPipelineRun({ pipelineMode: "sw" });
 
     expect(attempts[0]?.hardwareAcceleratedDecoding).toBe(false);
     expect(attempts[0]?.hasEncoder).toBe(false);
@@ -186,27 +144,10 @@ describe("StreambotStreamer pipeline options", () => {
   });
 
   test("HW startup failure → SW retry keeps subtitleBurn and inputColor so the software graph tonemaps + burns", async () => {
-    const { factory, attempts } = makeFakeFactory([
-      new Error("overlay_vaapi unsupported"),
-    ]);
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => 0,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED_HDR_WITH_SUBS,
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { attempts, run } = await startPipelineRun({
+      pipelineMode: "hw",
+      startErrors: [new Error("overlay_vaapi unsupported")],
+    });
 
     expect(attempts).toHaveLength(2);
     expect(attempts[1]?.hardwareAcceleratedDecoding).toBe(false);
@@ -219,29 +160,14 @@ describe("StreambotStreamer pipeline options", () => {
   });
 
   test("SDR source without subtitles passes inputColor sdr and no subtitleBurn", async () => {
-    const { factory, attempts } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => 0,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: {
-          title: "Movie",
-          ffmpegInput: "/videos/m.mkv",
-          chapters: [],
-        },
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw",
+    const { attempts, run } = await startPipelineRun({
+      pipelineMode: "hw",
+      resolved: {
+        title: "Movie",
+        ffmpegInput: "/videos/m.mkv",
+        chapters: [],
       },
-      new AbortController().signal,
-    );
-    await flush();
+    });
 
     expect(attempts[0]?.subtitleBurn).toBeUndefined();
     expect(attempts[0]?.inputColor).toBe("sdr");

--- a/packages/streambot/test/streamer-position.test.ts
+++ b/packages/streambot/test/streamer-position.test.ts
@@ -5,39 +5,22 @@ import type {
   StreamObserverFactory,
 } from "@shepherdjerred/streambot/streamer/streamer-types.ts";
 import { StreamCrashError } from "@shepherdjerred/streambot/streamer/stream-errors.ts";
-import {
-  loadConfig,
-  type EnvLookup,
-} from "@shepherdjerred/streambot/config/index.ts";
+import { loadConfig } from "@shepherdjerred/streambot/config/index.ts";
 import type {
   ResolvedSource,
-  VoiceHandle,
+  RunStreamInput,
 } from "@shepherdjerred/streambot/machine/types.ts";
 import {
-  ChannelIdSchema,
-  GuildIdSchema,
-  UserTokenSchema,
-} from "@shepherdjerred/streambot/types/ids.ts";
+  STREAMER_USER_TOKEN as USER_TOKEN,
+  STREAMER_VOICE as VOICE,
+  streamerEnv as env,
+} from "./streamer-test-fixtures.ts";
 
-const USER_TOKEN = UserTokenSchema.parse("user-token");
-const VOICE: VoiceHandle = {
-  guildId: GuildIdSchema.parse("100000000000000010"),
-  channelId: ChannelIdSchema.parse("100000000000000020"),
-};
 const RESOLVED: ResolvedSource = {
   title: "Movie",
   ffmpegInput: "/videos/movie.mkv",
   chapters: [],
 };
-
-function env(over: EnvLookup = {}): EnvLookup {
-  return {
-    BOT_TOKEN: "bot-token",
-    USER_TOKENS: "user-token",
-    VIDEOS_DIR: "/videos",
-    ...over,
-  };
-}
 
 type SegmentControl = {
   resolve: () => void;
@@ -113,6 +96,47 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 5));
 }
 
+async function startPositionRun(options: {
+  clock?: { ms: number };
+  seekSeconds?: number;
+  pipelineMode?: RunStreamInput["pipelineMode"];
+  resolved?: ResolvedSource;
+  hardwareEnabled?: boolean;
+  startErrors?: (Error | undefined)[];
+  seekErrors?: (Error | undefined)[];
+  seekGates?: (Promise<void> | undefined)[];
+}) {
+  const clock = options.clock ?? { ms: 1000 };
+  const { factory, segments } = makeFakeFactory(
+    options.startErrors,
+    options.seekErrors,
+    options.seekGates,
+  );
+  const streamer = new StreambotStreamer(
+    USER_TOKEN,
+    loadConfig(
+      env({
+        STREAM_HARDWARE_ACCELERATION:
+          options.hardwareEnabled === false ? "false" : "true",
+      }),
+    ),
+    () => clock.ms,
+    factory,
+  );
+  const run = streamer.runStream(
+    {
+      voice: VOICE,
+      resolved: options.resolved ?? RESOLVED,
+      volume: 100,
+      seekSeconds: options.seekSeconds ?? 30,
+      pipelineMode: options.pipelineMode ?? "sw",
+    },
+    new AbortController().signal,
+  );
+  await flush();
+  return { clock, segments, streamer, run };
+}
+
 describe("StreambotStreamer position tracking", () => {
   test("a startup-time stall uses the new segment offset before playback starts", async () => {
     const start = createVoidDeferred();
@@ -170,28 +194,10 @@ describe("StreambotStreamer position tracking", () => {
   });
 
   test("getPosition advances with the clock from the seek offset, then clears", async () => {
-    const clock = { ms: 1000 };
-    const { factory, segments } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
-      () => clock.ms,
-      factory,
-    );
-
-    expect(streamer.getPosition()).toBeNull();
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED,
-        volume: 100,
-        seekSeconds: 30,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, streamer, run } = await startPositionRun({
+      pipelineMode: "hw",
+      hardwareEnabled: false,
+    });
 
     // The resume offset reached ffmpeg as -ss 30, and position is anchored there.
     expect(segments[0]?.startTime).toBe(30);
@@ -206,25 +212,9 @@ describe("StreambotStreamer position tracking", () => {
   });
 
   test("a successful live seek re-anchors the position before returning", async () => {
-    const clock = { ms: 1000 };
-    const { factory, segments } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
-      () => clock.ms,
-      factory,
-    );
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED,
-        volume: 100,
-        seekSeconds: 30,
-        pipelineMode: "sw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, streamer, run } = await startPositionRun({
+      hardwareEnabled: false,
+    });
 
     clock.ms = 6000;
     expect(streamer.getPosition()).toBe(35);
@@ -239,26 +229,11 @@ describe("StreambotStreamer position tracking", () => {
   });
 
   test("a live seek freezes position while its replacement attaches", async () => {
-    const clock = { ms: 1000 };
     const seekAttach = createVoidDeferred();
-    const { factory, segments } = makeFakeFactory([], [], [seekAttach.promise]);
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
-      () => clock.ms,
-      factory,
-    );
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED,
-        volume: 100,
-        seekSeconds: 30,
-        pipelineMode: "sw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, streamer, run } = await startPositionRun({
+      hardwareEnabled: false,
+      seekGates: [seekAttach.promise],
+    });
 
     clock.ms = 6000;
     const seek = streamer.seek(120);
@@ -394,26 +369,11 @@ describe("StreambotStreamer overlapping seeks", () => {
 
 describe("StreambotStreamer seek rollback", () => {
   test("a failed live seek restores the prior playback anchor", async () => {
-    const clock = { ms: 1000 };
     const seekError = new Error("seek restart failed");
-    const { factory, segments } = makeFakeFactory([], [seekError]);
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "false" })),
-      () => clock.ms,
-      factory,
-    );
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED,
-        volume: 100,
-        seekSeconds: 30,
-        pipelineMode: "sw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, streamer, run } = await startPositionRun({
+      hardwareEnabled: false,
+      seekErrors: [seekError],
+    });
 
     clock.ms = 6000;
     expect(streamer.getPosition()).toBe(35);
@@ -481,26 +441,10 @@ describe("StreambotStreamer seek failure lifecycle", () => {
 
 describe("StreambotStreamer failure position tracking", () => {
   test("a mid-stream failure surfaces as StreamCrashError with the elapsed position — no in-streamer retry", async () => {
-    const clock = { ms: 1000 };
-    const { factory, segments } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => clock.ms,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED,
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, run } = await startPositionRun({
+      seekSeconds: 0,
+      pipelineMode: "hw",
+    });
     expect(segments[0]?.startTime).toBeUndefined(); // fresh play, no -ss
 
     clock.ms = 9000; // 8s played before ffmpeg dies
@@ -519,28 +463,10 @@ describe("StreambotStreamer failure position tracking", () => {
   });
 
   test("a STARTUP failure still falls back to software in-streamer, resuming at the requested offset", async () => {
-    const clock = { ms: 1000 };
-    const { factory, segments } = makeFakeFactory([
-      new Error("vaapi device init failed"),
-    ]);
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => clock.ms,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: RESOLVED,
-        volume: 100,
-        seekSeconds: 30,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { segments, run } = await startPositionRun({
+      pipelineMode: "hw",
+      startErrors: [new Error("vaapi device init failed")],
+    });
 
     // start() rejected before playback began → the classic in-streamer software fallback, at the
     // last known position (playback never started, so the requested offset).
@@ -552,26 +478,12 @@ describe("StreambotStreamer failure position tracking", () => {
   });
 
   test("exit-0 far short of the probed duration classifies as ended-short", async () => {
-    const clock = { ms: 0 };
-    const { factory, segments } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => clock.ms,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: { ...RESOLVED, durationSeconds: 7200 },
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, run } = await startPositionRun({
+      clock: { ms: 0 },
+      seekSeconds: 0,
+      pipelineMode: "hw",
+      resolved: { ...RESOLVED, durationSeconds: 7200 },
+    });
 
     clock.ms = 40_000; // "played" 40s of a 2h movie, then ffmpeg exited 0
     segments[0]?.resolve();
@@ -586,26 +498,12 @@ describe("StreambotStreamer failure position tracking", () => {
   });
 
   test("exit-0 near the probed duration is a natural end", async () => {
-    const clock = { ms: 0 };
-    const { factory, segments } = makeFakeFactory();
-    const streamer = new StreambotStreamer(
-      USER_TOKEN,
-      loadConfig(env({ STREAM_HARDWARE_ACCELERATION: "true" })),
-      () => clock.ms,
-      factory,
-    );
-
-    const run = streamer.runStream(
-      {
-        voice: VOICE,
-        resolved: { ...RESOLVED, durationSeconds: 7200 },
-        volume: 100,
-        seekSeconds: 0,
-        pipelineMode: "hw",
-      },
-      new AbortController().signal,
-    );
-    await flush();
+    const { clock, segments, run } = await startPositionRun({
+      clock: { ms: 0 },
+      seekSeconds: 0,
+      pipelineMode: "hw",
+      resolved: { ...RESOLVED, durationSeconds: 7200 },
+    });
 
     clock.ms = 7_190_000; // within 30s of the end
     segments[0]?.resolve();

--- a/packages/streambot/test/streamer-test-fixtures.ts
+++ b/packages/streambot/test/streamer-test-fixtures.ts
@@ -1,0 +1,23 @@
+import type { EnvLookup } from "@shepherdjerred/streambot/config/index.ts";
+import type { VoiceHandle } from "@shepherdjerred/streambot/machine/types.ts";
+import {
+  ChannelIdSchema,
+  GuildIdSchema,
+  UserTokenSchema,
+} from "@shepherdjerred/streambot/types/ids.ts";
+
+export const STREAMER_USER_TOKEN = UserTokenSchema.parse("user-token");
+
+export const STREAMER_VOICE: VoiceHandle = {
+  guildId: GuildIdSchema.parse("100000000000000010"),
+  channelId: ChannelIdSchema.parse("100000000000000020"),
+};
+
+export function streamerEnv(over: EnvLookup = {}): EnvLookup {
+  return {
+    BOT_TOKEN: "bot-token",
+    USER_TOKENS: "user-token",
+    VIDEOS_DIR: "/videos",
+    ...over,
+  };
+}

--- a/packages/streambot/test/voice-audio-lifecycle.test.ts
+++ b/packages/streambot/test/voice-audio-lifecycle.test.ts
@@ -82,49 +82,75 @@ function recordingAttempt() {
   return { handle, finishes, endpoints };
 }
 
+type LifecycleOptions = ConstructorParameters<typeof VoiceAudioLifecycle>[0];
+
+function createLifecycle(
+  options: Partial<LifecycleOptions> & Pick<LifecycleOptions, "onTurn">,
+  { useProductionVerificationDelay = false } = {},
+): VoiceAudioLifecycle {
+  return new VoiceAudioLifecycle({
+    models: fakeModels(2, 4),
+    preRollMs: 1200,
+    maxUtteranceMs: 15_000,
+    ...(useProductionVerificationDelay ? {} : { verificationDelayMs: 0 }),
+    postVerificationMs: 0,
+    createDecoder: () => ({
+      decode: (opus) => new Float32Array([opus[0] ?? 0]),
+      close: () => {
+        /* fake has no decoder handle */
+      },
+    }),
+    ...options,
+  });
+}
+
 describe("VoiceAudioLifecycle", () => {
-  test("holds a typed candidate for the fallback window, rejects locally, and zeros verifier audio", async () => {
-    let nowMs = 42;
+  test("holds a typed candidate for the 1,250 ms production fallback window, rejects locally, and zeros verifier audio", async () => {
+    const nowMs = 42;
     let verificationCalls = 0;
     const verificationAudio: { value: Float32Array | null } = { value: null };
     const candidates: WakeCandidateEvidence[] = [];
     const models = fakeModels(2, 4);
-    const lifecycle = new VoiceAudioLifecycle({
-      models: {
-        ...models,
-        verifyWakePhrase: (samples) => {
-          verificationCalls += 1;
-          verificationAudio.value = samples;
-          return Promise.resolve({ accepted: false, score: 0.2 });
+    const lifecycle = createLifecycle(
+      {
+        models: {
+          ...models,
+          verifyWakePhrase: (samples) => {
+            verificationCalls += 1;
+            verificationAudio.value = samples;
+            return Promise.resolve({ accepted: false, score: 0.2 });
+          },
         },
+        preRollMs: 2000,
+        maxUtteranceMs: 15_000,
+        now: () => nowMs,
+        createDecoder: () => ({
+          decode: (opus) => {
+            const samples = new Float32Array(8000);
+            samples.fill((opus[0] ?? 0) / 10);
+            samples[0] = opus[0] ?? 0;
+            return samples;
+          },
+          close: () => {
+            /* fake has no decoder handle */
+          },
+        }),
+        onCandidate: (candidate) => {
+          candidates.push(candidate);
+        },
+        onTurn: () =>
+          Promise.reject(new Error("rejected wake reached command")),
       },
-      preRollMs: 2000,
-      maxUtteranceMs: 15_000,
-      now: () => nowMs,
-      createDecoder: () => ({
-        decode: (opus) => {
-          const samples = new Float32Array(8000);
-          samples.fill((opus[0] ?? 0) / 10);
-          samples[0] = opus[0] ?? 0;
-          return samples;
-        },
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
-      onCandidate: (candidate) => {
-        candidates.push(candidate);
-      },
-      onTurn: () => Promise.reject(new Error("rejected wake reached command")),
-    });
+      { useProductionVerificationDelay: true },
+    );
 
     lifecycle.accept(audio("speaker-a", 2));
     expect(verificationCalls).toBe(0);
     lifecycle.accept(audio("speaker-b", 4));
     lifecycle.accept(audio("speaker-a", 3));
+    expect(verificationCalls).toBe(0);
     lifecycle.accept(audio("speaker-a", 3));
     expect(verificationCalls).toBe(0);
-    nowMs = 1292;
     lifecycle.accept(audio("speaker-a", 3));
     expect(verificationCalls).toBe(1);
     await Bun.sleep(0);
@@ -149,18 +175,7 @@ describe("VoiceAudioLifecycle", () => {
 
   test("makes no command call before wake and locks the turn to its speaker", async () => {
     const turns: string[] = [];
-    const lifecycle = new VoiceAudioLifecycle({
-      models: fakeModels(2, 4),
-      preRollMs: 1200,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
+    const lifecycle = createLifecycle({
       onTurn: async (turn) => {
         turns.push(turn.userId);
       },
@@ -178,18 +193,8 @@ describe("VoiceAudioLifecycle", () => {
 
   test("allows a back-to-back wake after the prior transaction completes", async () => {
     const turns: string[] = [];
-    const lifecycle = new VoiceAudioLifecycle({
-      models: fakeModels(2, 4),
+    const lifecycle = createLifecycle({
       preRollMs: 0,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
       onTurn: async (turn) => {
         turns.push(turn.userId);
       },
@@ -208,18 +213,7 @@ describe("VoiceAudioLifecycle", () => {
   test("retains wake pre-roll and makes the completed transaction single-flight", async () => {
     const turnBarrier = Promise.withResolvers<true>();
     const delivered: number[][] = [];
-    const lifecycle = new VoiceAudioLifecycle({
-      models: fakeModels(2, 4),
-      preRollMs: 1200,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
+    const lifecycle = createLifecycle({
       onTurn: async (turn) => {
         delivered.push([...turn.pcm16k]);
         await turnBarrier.promise;
@@ -277,20 +271,13 @@ describe("VoiceAudioLifecycle endpointing and cleanup", () => {
   test("ends a locally rejected attempt exactly once with its verifier audio", async () => {
     const attempt = recordingAttempt();
     const models = fakeModels(2, 4);
-    const lifecycle = new VoiceAudioLifecycle({
+    const lifecycle = createLifecycle({
       models: {
         ...models,
         verifyWakePhrase: () =>
           Promise.resolve({ accepted: false, score: 0.1 }),
       },
       preRollMs: 0,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => null,
-      }),
       beginAttempt: () => attempt.handle,
       onTurn: () => Promise.reject(new Error("rejected wake reached turn")),
     });
@@ -306,15 +293,9 @@ describe("VoiceAudioLifecycle endpointing and cleanup", () => {
 
   test("ends a closed candidate exactly once", () => {
     const attempt = recordingAttempt();
-    const lifecycle = new VoiceAudioLifecycle({
-      models: fakeModels(2, 4),
+    const lifecycle = createLifecycle({
       preRollMs: 0,
-      maxUtteranceMs: 15_000,
       verificationDelayMs: 200,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => null,
-      }),
       beginAttempt: () => attempt.handle,
       onTurn: () => Promise.reject(new Error("closed wake reached turn")),
     });
@@ -329,16 +310,8 @@ describe("VoiceAudioLifecycle endpointing and cleanup", () => {
 
   test("ends a delivery failure exactly once", async () => {
     const attempt = recordingAttempt();
-    const lifecycle = new VoiceAudioLifecycle({
-      models: fakeModels(2, 4),
+    const lifecycle = createLifecycle({
       preRollMs: 0,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => null,
-      }),
       beginAttempt: () => attempt.handle,
       onTurn: () => Promise.reject(new Error("delivery failed")),
     });
@@ -570,21 +543,11 @@ describe("VoiceAudioLifecycle DTX endpointing", () => {
   test("endpoints on wall-clock silence when the client's DTX stops the packet stream", async () => {
     const ticker = tickerHarness();
     const turns: { userId: string; sampleCount: number }[] = [];
-    const lifecycle = new VoiceAudioLifecycle({
+    const lifecycle = createLifecycle({
       // vadEndsOn 0: the fake VAD completes on a silence chunk, like Silero after real silence.
       models: fakeModels(2, 0),
-      preRollMs: 1200,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
       now: ticker.now,
       createSilenceTicker: ticker.createSilenceTicker,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
       onTurn: async (turn) => {
         turns.push({ userId: turn.userId, sampleCount: turn.pcm16k.length });
       },
@@ -610,7 +573,7 @@ describe("VoiceAudioLifecycle DTX endpointing", () => {
     let verificationCalls = 0;
     const turns: string[] = [];
     const models = fakeModels(2, 0);
-    const lifecycle = new VoiceAudioLifecycle({
+    const lifecycle = createLifecycle({
       models: {
         ...models,
         verifyWakePhrase: (samples) => {
@@ -618,19 +581,10 @@ describe("VoiceAudioLifecycle DTX endpointing", () => {
           return models.verifyWakePhrase(samples);
         },
       },
-      preRollMs: 1200,
-      maxUtteranceMs: 15_000,
       // 200 ms of post-candidate audio required before the verifier can score.
       verificationDelayMs: 200,
-      postVerificationMs: 0,
       now: ticker.now,
       createSilenceTicker: ticker.createSilenceTicker,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
       onTurn: async (turn) => {
         turns.push(turn.userId);
       },
@@ -653,23 +607,13 @@ describe("VoiceAudioLifecycle DTX endpointing", () => {
   test("creates no ticker before a candidate and stops it on rejection and close", async () => {
     const ticker = tickerHarness();
     const models = fakeModels(2, 0);
-    const lifecycle = new VoiceAudioLifecycle({
+    const lifecycle = createLifecycle({
       models: {
         ...models,
         verifyWakePhrase: () => Promise.resolve({ accepted: false, score: 0 }),
       },
-      preRollMs: 1200,
-      maxUtteranceMs: 15_000,
-      verificationDelayMs: 0,
-      postVerificationMs: 0,
       now: ticker.now,
       createSilenceTicker: ticker.createSilenceTicker,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
       onTurn: () => Promise.reject(new Error("rejected wake reached command")),
     });
 
@@ -692,7 +636,7 @@ describe("VoiceAudioLifecycle DTX endpointing", () => {
     const ticker = tickerHarness();
     let verificationCalls = 0;
     const models = fakeModels(2, 0);
-    const lifecycle = new VoiceAudioLifecycle({
+    const lifecycle = createLifecycle({
       models: {
         ...models,
         verifyWakePhrase: (samples) => {
@@ -700,18 +644,9 @@ describe("VoiceAudioLifecycle DTX endpointing", () => {
           return models.verifyWakePhrase(samples);
         },
       },
-      preRollMs: 1200,
-      maxUtteranceMs: 15_000,
       verificationDelayMs: 200,
-      postVerificationMs: 0,
       now: ticker.now,
       createSilenceTicker: ticker.createSilenceTicker,
-      createDecoder: () => ({
-        decode: (opus) => new Float32Array([opus[0] ?? 0]),
-        close: () => {
-          /* fake has no decoder handle */
-        },
-      }),
       onTurn: () => Promise.reject(new Error("no turn should complete")),
     });
 


### PR DESCRIPTION
## Why

Streambot playback, observer, session, and voice lifecycle tests repeated substantial fixture setup. That obscured scenario-specific assertions and carried 2,017 duplicated tokens in the jscpd baseline.

## What

- Add shared typed fixtures for streamer credentials, voice handles, and configuration.
- Consolidate pipeline, position, session, lifecycle, and observer setup behind focused test harnesses.
- Exercise the unmodified 1,250 ms production verification fallback in the null-timestamp voice scenario.
- Table-drive equivalent stale subtitle picker scenarios while retaining each expected outcome.
- Lower the cumulative jscpd baseline from 66,289 to 64,272 duplicated tokens.

## Verification

- bun --cwd packages/streambot test test/voice-audio-lifecycle.test.ts
- bunx turbo run test typecheck lint --filter=@shepherdjerred/streambot
- bun run jscpd --update && bun run jscpd
- jq "[.pairs[].tokens] | add" .jscpd-baseline.json → 64,272
- bunx lefthook run pre-commit

No live Discord or ffmpeg integration checks were run because this is a test-only refactor. No media is required for an internal test refactor.