### PR TITLE
fix(homelab): restore Bryan Bucks PostHog dashboard queries

### DIFF
--- a/packages/homelab/src/tofu/posthog/generated.tf
+++ b/packages/homelab/src/tofu/posthog/generated.tf
@@ -1476,7 +1476,7 @@ resource "posthog_insight" "insight_11297203" {
     kind    = "DataVisualizationNode"
     source = {
       kind  = "HogQLQuery"
-      query = "SELECT day, sum(-delta) AS stake_volume FROM (SELECT uuid, toStartOfDay(timestamp) AS day, argMax(toFloat(properties[delta_bucks]), timestamp) AS delta FROM events WHERE event = bryan_bucks_economy AND properties[movement] IN (bet_stake, parlay_stake) GROUP BY uuid, day) GROUP BY day ORDER BY day"
+      query = "SELECT day, sum(-delta) AS stake_volume FROM (SELECT uuid, toStartOfDay(timestamp) AS day, argMax(toFloat(properties.delta_bucks), timestamp) AS delta FROM events WHERE event = 'bryan_bucks_economy' AND properties.movement IN ('bet_stake', 'parlay_stake') AND {filters} GROUP BY uuid, day) GROUP BY day ORDER BY day"
     }
   })
   query_sql = null
@@ -2821,7 +2821,7 @@ resource "posthog_insight" "insight_11297206" {
     kind    = "DataVisualizationNode"
     source = {
       kind  = "HogQLQuery"
-      query = "SELECT day, sumIf(delta, movement IN (earn_game, earn_win, earn_mvp, earn_ranked_5s_bonus)) AS earnings, sumIf(delta, movement IN (bet_payout, parlay_payout)) AS payouts FROM (SELECT uuid, toStartOfDay(timestamp) AS day, properties[movement] AS movement, argMax(toFloat(properties[delta_bucks]), timestamp) AS delta FROM events WHERE event = bryan_bucks_economy GROUP BY uuid, day, movement) GROUP BY day ORDER BY day"
+      query = "SELECT day, sumIf(delta, movement IN ('earn_game', 'earn_win', 'earn_mvp', 'earn_ranked_5s_bonus')) AS earnings, sumIf(delta, movement IN ('bet_payout', 'parlay_payout')) AS payouts FROM (SELECT uuid, toStartOfDay(timestamp) AS day, properties.movement AS movement, argMax(toFloat(properties.delta_bucks), timestamp) AS delta FROM events WHERE event = 'bryan_bucks_economy' AND {filters} GROUP BY uuid, day, movement) GROUP BY day ORDER BY day"
     }
   })
   query_sql = null


### PR DESCRIPTION
## Why

The Bryan Bucks stake-volume and earnings/payouts tiles currently fail with PostHog validation errors because their imported HogQL treats event names, property names, and movement values as unresolved identifiers.

## What

- Quote the event and movement literals.
- Use valid dot notation for the economy event properties.
- Apply PostHog's `{filters}` placeholder so dashboard date filters bound both event scans.

## Verification

- `toolkit posthog api call --json execute-sql <stake-query>` — returned the current daily stake-volume series.
- `toolkit posthog api call --json execute-sql <earnings-query>` — returned the current daily earnings and payouts series.
- `bun --no-install packages/homelab/scripts/tofu-stack.ts posthog validate`
- `bunx lefthook run pre-commit`

This is a non-visual query/IaC repair, so no media artifact is needed.

## Rollout

The live PostHog definitions were inspected read-only. The main-only `tofu-posthog` lane will plan and apply the two insight updates after merge; production was not mutated locally.