### PR TITLE
refactor(discord-plays-pokemon): consolidate goal controller fixtures

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -357,20 +357,16 @@
       "tokens": 71
     },
     "packages/discord-plays-pokemon/packages/backend/src/goal/game-battle-control.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/game-battle-control.test.ts": {
-      "clones": 6,
-      "tokens": 565
+      "clones": 2,
+      "tokens": 143
     },
     "packages/discord-plays-pokemon/packages/backend/src/goal/game-battle-control.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/game-controller-interact.test.ts": {
       "clones": 1,
       "tokens": 98
     },
-    "packages/discord-plays-pokemon/packages/backend/src/goal/game-battle-control.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.test.ts": {
-      "clones": 1,
-      "tokens": 125
-    },
     "packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.test.ts": {
-      "clones": 9,
-      "tokens": 1148
+      "clones": 1,
+      "tokens": 72
     },
     "packages/discord-plays-pokemon/packages/backend/src/goal/game-exit-navigation-blocks.ts|packages/discord-plays-pokemon/packages/backend/src/goal/game-exit-navigation.ts": {
       "clones": 1,
@@ -383,10 +379,6 @@
     "packages/discord-plays-pokemon/packages/backend/src/goal/goal-input-lease.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts": {
       "clones": 1,
       "tokens": 129
-    },
-    "packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts": {
-      "clones": 4,
-      "tokens": 391
     },
     "packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts|packages/discord-plays-pokemon/packages/backend/src/goal/knowledge.test.ts": {
       "clones": 2,

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/game-battle-control.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/game-battle-control.test.ts
@@ -30,6 +30,68 @@ type BattlePortOptions = Readonly<{
   runAllowed?: boolean;
 }>;
 
+const DEFAULT_MOVES: BattleState["moves"] = [
+  {
+    slot: 1,
+    moveId: 33,
+    move: "TACKLE",
+    currentPp: 35,
+    maxPp: 35,
+    usable: true,
+  },
+];
+
+const DEFAULT_BATTLERS: BattleState["battlers"] = [
+  {
+    battler: 0,
+    side: "player",
+    position: 0,
+    active: true,
+    speciesId: 258,
+    species: "Mudkip",
+    hp: 20,
+    maxHp: 20,
+    partyIndex: 0,
+    status: 0,
+  },
+  {
+    battler: 1,
+    side: "opponent",
+    position: 1,
+    active: true,
+    speciesId: 263,
+    species: "Zigzagoon",
+    hp: 15,
+    maxHp: 15,
+    partyIndex: 0,
+    status: 0,
+  },
+  {
+    battler: 2,
+    side: "player",
+    position: 2,
+    active: true,
+    speciesId: 252,
+    species: "Treecko",
+    hp: 19,
+    maxHp: 19,
+    partyIndex: 1,
+    status: 0,
+  },
+  {
+    battler: 3,
+    side: "opponent",
+    position: 3,
+    active: true,
+    speciesId: 261,
+    species: "Poochyena",
+    hp: 14,
+    maxHp: 14,
+    partyIndex: 1,
+    status: 0,
+  },
+];
+
 function observation(input: BattleInput): GameObservationV2 {
   return {
     schemaVersion: 2,
@@ -68,44 +130,10 @@ function observation(input: BattleInput): GameObservationV2 {
       currentMove: 0,
       chosenMove: 0,
       switchAllowed: input.switchAllowed ?? true,
-      moves: input.moves ?? [
-        {
-          slot: 1,
-          moveId: 33,
-          move: "TACKLE",
-          currentPp: 35,
-          maxPp: 35,
-          usable: true,
-        },
-      ],
+      moves: input.moves ?? DEFAULT_MOVES,
       bag: input.bag ?? null,
       party: input.battleParty ?? null,
-      battlers: input.battlers ?? [
-        {
-          battler: 0,
-          side: "player",
-          position: 0,
-          active: true,
-          speciesId: 258,
-          species: "Mudkip",
-          hp: 20,
-          maxHp: 20,
-          partyIndex: 0,
-          status: 0,
-        },
-        {
-          battler: 1,
-          side: "opponent",
-          position: 1,
-          active: true,
-          speciesId: 263,
-          species: "Zigzagoon",
-          hp: 15,
-          maxHp: 15,
-          partyIndex: 0,
-          status: 0,
-        },
-      ],
+      battlers: input.battlers ?? DEFAULT_BATTLERS.slice(0, 2),
     },
     world: null,
     game: {
@@ -266,6 +294,29 @@ const X_ATTACK_INVENTORY: GameState["inventory"] = [
   { itemId: 75, item: "X ATTACK", quantity: 1, pocket: "items" },
 ];
 
+function twoMonParty(leadHp = 20): GameState["party"] {
+  return [
+    {
+      speciesId: 258,
+      species: "Mudkip",
+      nickname: "Mudkip",
+      level: 5,
+      hp: leadHp,
+      maxHp: 20,
+      isEgg: false,
+    },
+    {
+      speciesId: 252,
+      species: "Treecko",
+      nickname: "Treecko",
+      level: 5,
+      hp: 19,
+      maxHp: 19,
+      isEgg: false,
+    },
+  ];
+}
+
 describe("GameBattleControl move actions", () => {
   test("selects an ordinary first-turn move before opening Fight", async () => {
     const port = new BattlePort(observation({ frame: 10, actionCursor: 1 }), [
@@ -385,44 +436,7 @@ describe("GameBattleControl move actions", () => {
         frame: 10,
         menu: "target",
         typeFlags: 1,
-        battlers: [
-          {
-            battler: 0,
-            side: "player",
-            position: 0,
-            active: true,
-            speciesId: 258,
-            species: "Mudkip",
-            hp: 20,
-            maxHp: 20,
-            partyIndex: 0,
-            status: 0,
-          },
-          {
-            battler: 1,
-            side: "opponent",
-            position: 1,
-            active: true,
-            speciesId: 263,
-            species: "Zigzagoon",
-            hp: 15,
-            maxHp: 15,
-            partyIndex: 0,
-            status: 0,
-          },
-          {
-            battler: 2,
-            side: "player",
-            position: 2,
-            active: true,
-            speciesId: 252,
-            species: "Treecko",
-            hp: 19,
-            maxHp: 19,
-            partyIndex: 1,
-            status: 0,
-          },
-        ],
+        battlers: DEFAULT_BATTLERS.slice(0, 3),
       }),
       [],
     );
@@ -661,56 +675,7 @@ describe("GameBattleControl forced replacement settlement", () => {
 });
 
 describe("GameBattleControl target navigation", () => {
-  const battlers: BattleState["battlers"] = [
-    {
-      battler: 0,
-      side: "player",
-      position: 0,
-      active: true,
-      speciesId: 258,
-      species: "Mudkip",
-      hp: 20,
-      maxHp: 20,
-      partyIndex: 0,
-      status: 0,
-    },
-    {
-      battler: 1,
-      side: "opponent",
-      position: 1,
-      active: true,
-      speciesId: 263,
-      species: "Zigzagoon",
-      hp: 15,
-      maxHp: 15,
-      partyIndex: 0,
-      status: 0,
-    },
-    {
-      battler: 2,
-      side: "player",
-      position: 2,
-      active: true,
-      speciesId: 252,
-      species: "Treecko",
-      hp: 19,
-      maxHp: 19,
-      partyIndex: 1,
-      status: 0,
-    },
-    {
-      battler: 3,
-      side: "opponent",
-      position: 3,
-      active: true,
-      speciesId: 261,
-      species: "Poochyena",
-      hp: 14,
-      maxHp: 14,
-      partyIndex: 1,
-      status: 0,
-    },
-  ];
+  const battlers = DEFAULT_BATTLERS;
 
   async function expectTargetNavigation(
     targetBattler: number,
@@ -763,26 +728,7 @@ describe("GameBattleControl target navigation", () => {
 
 describe("GameBattleControl party actions", () => {
   test("rejects a trapped switch before sending input", async () => {
-    const gameParty: GameState["party"] = [
-      {
-        speciesId: 258,
-        species: "Mudkip",
-        nickname: "Mudkip",
-        level: 5,
-        hp: 20,
-        maxHp: 20,
-        isEgg: false,
-      },
-      {
-        speciesId: 252,
-        species: "Treecko",
-        nickname: "Treecko",
-        level: 5,
-        hp: 19,
-        maxHp: 19,
-        isEgg: false,
-      },
-    ];
+    const gameParty = twoMonParty();
     const port = new BattlePort(
       observation({ frame: 10, gameParty, switchAllowed: false }),
       [],
@@ -795,26 +741,7 @@ describe("GameBattleControl party actions", () => {
   });
 
   test("selects an input-ready forced replacement without reopening the party", async () => {
-    const gameParty: GameState["party"] = [
-      {
-        speciesId: 258,
-        species: "Mudkip",
-        nickname: "Mudkip",
-        level: 5,
-        hp: 0,
-        maxHp: 20,
-        isEgg: false,
-      },
-      {
-        speciesId: 252,
-        species: "Treecko",
-        nickname: "Treecko",
-        level: 5,
-        hp: 19,
-        maxHp: 19,
-        isEgg: false,
-      },
-    ];
+    const gameParty = twoMonParty(0);
     const initial = observation({
       frame: 10,
       menu: "party",
@@ -885,26 +812,7 @@ describe("GameBattleControl party actions", () => {
   });
 
   test("confirms Shift after selecting a voluntary switch target", async () => {
-    const gameParty: GameState["party"] = [
-      {
-        speciesId: 258,
-        species: "Mudkip",
-        nickname: "Mudkip",
-        level: 5,
-        hp: 20,
-        maxHp: 20,
-        isEgg: false,
-      },
-      {
-        speciesId: 252,
-        species: "Treecko",
-        nickname: "Treecko",
-        level: 5,
-        hp: 19,
-        maxHp: 19,
-        isEgg: false,
-      },
-    ];
+    const gameParty = twoMonParty();
     const port = new BattlePort(observation({ frame: 10, gameParty }), [
       observation({ frame: 12, actionCursor: 2, gameParty }),
       observation({

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/game-controller.test.ts
@@ -27,6 +27,24 @@ type ObservationInput = Readonly<{
   nearby?: NonNullable<GameObservationV2["world"]>["nearby"];
 }>;
 
+type BattleParticipant = NonNullable<
+  GameObservationV2["battle"]
+>["battlers"][number];
+type BattleParticipantInput = Pick<
+  BattleParticipant,
+  "battler" | "side" | "speciesId" | "species" | "hp" | "partyIndex"
+>;
+
+function battleParticipant(input: BattleParticipantInput): BattleParticipant {
+  return {
+    ...input,
+    position: input.battler,
+    active: true,
+    maxHp: input.hp,
+    status: 0,
+  };
+}
+
 function observation(input: ObservationInput = {}): GameObservationV2 {
   const frame = input.frame ?? 10;
   const dialogVisible = input.dialogVisible === true;
@@ -134,54 +152,38 @@ function targetObservation(
         },
       ],
       battlers: [
-        {
+        battleParticipant({
           battler: 0,
           side: "player",
-          position: 0,
-          active: true,
           speciesId: 258,
           species: "Mudkip",
           hp: 20,
-          maxHp: 20,
           partyIndex: 0,
-          status: 0,
-        },
-        {
+        }),
+        battleParticipant({
           battler: 1,
           side: "opponent",
-          position: 1,
-          active: true,
           speciesId: 263,
           species: "Zigzagoon",
           hp: 15,
-          maxHp: 15,
           partyIndex: 0,
-          status: 0,
-        },
-        {
+        }),
+        battleParticipant({
           battler: 2,
           side: "player",
-          position: 2,
-          active: true,
           speciesId: 252,
           species: "Treecko",
           hp: 19,
-          maxHp: 19,
           partyIndex: allyPartyIndex,
-          status: 0,
-        },
-        {
+        }),
+        battleParticipant({
           battler: 3,
           side: "opponent",
-          position: 3,
-          active: true,
           speciesId: 261,
           species: "Poochyena",
           hp: 14,
-          maxHp: 14,
           partyIndex: 1,
-          status: 0,
-        },
+        }),
       ],
     },
   };
@@ -231,6 +233,72 @@ function sameMapWarpTopology(triggerElevation = 0): EngineMapTopologyV1 {
       },
     ],
   });
+}
+
+function pairedWarpTopology(
+  selectedTriggerX: number,
+  otherTriggerX: number,
+  otherActivation: "step" | "east",
+): EngineMapTopologyV1 {
+  return mapTopology({
+    warps: [
+      {
+        version: 1,
+        size: 24,
+        index: 3,
+        trigger: { x: selectedTriggerX, y: 9, elevation: 0, behavior: 0 },
+        activation: "step",
+        destination: {
+          mapGroup: 1,
+          mapNum: 2,
+          warpId: 0,
+          dynamic: false,
+          landing: { x: 7, y: 7 },
+        },
+      },
+      {
+        version: 1,
+        size: 24,
+        index: 4,
+        trigger: { x: otherTriggerX, y: 9, elevation: 0, behavior: 0 },
+        activation: otherActivation,
+        destination: {
+          mapGroup: 1,
+          mapNum: 3,
+          warpId: 0,
+          dynamic: false,
+          landing: { x: 8, y: 8 },
+        },
+      },
+    ],
+  });
+}
+
+function corridorBlocks(): ReadonlySet<string> {
+  const corridor = new Set(["7,9", "8,9", "9,9", "10,9", "11,9"]);
+  const blocked = new Set<string>();
+  for (let x = 7; x <= 12; x += 1) {
+    for (let y = 7; y <= 12; y += 1) {
+      const key = `${String(x)},${String(y)}`;
+      if (!corridor.has(key)) blocked.add(key);
+    }
+  }
+  return blocked;
+}
+
+function blockedOutside(
+  allowed: ReadonlySet<string>,
+  minimum: number,
+  maximum: number,
+): ReadonlySet<string> {
+  const blocked = new Set<string>();
+  for (let x = minimum; x <= maximum; x += 1) {
+    for (let y = minimum; y <= maximum; y += 1) {
+      const key = `${String(x)},${String(y)}`;
+      if (!allowed.has(key)) blocked.add(key);
+    }
+  }
+  return blocked;
 }
 
 class FakeControlPort implements GameControlPort {
@@ -311,6 +379,27 @@ class FakeControlPort implements GameControlPort {
   canRunFromBattle(): boolean {
     return true;
   }
+}
+
+async function expectUnselectedWarpBlocked(
+  otherActivation: "step" | "east",
+): Promise<void> {
+  const port = new FakeControlPort(
+    observation({ x: 7, y: 9, facing: "east" }),
+    [],
+    {
+      topology: pairedWarpTopology(11, 9, otherActivation),
+      blocked: corridorBlocks(),
+    },
+  );
+
+  const result = await new GameController(port).navigateExit("warp:3", 5);
+
+  expect(result.status).toBe("stopped");
+  expect(result.stopReason).toBe("no-route");
+  expect(result.attemptsMade).toBe(0);
+  expect(result.stepsTaken).toBe(0);
+  expect(port.presses).toEqual([]);
 }
 
 function renderedFrame(changedPixels = 0): Uint8Array {
@@ -680,13 +769,6 @@ describe("GameController navigation", () => {
 
   test("recomputes moving-object blocks after every navigation step", async () => {
     const allowed = new Set(["5,5", "5,4", "6,4", "7,4", "6,5", "7,5"]);
-    const blocked = new Set<string>();
-    for (let x = 1; x <= 9; x += 1) {
-      for (let y = 1; y <= 9; y += 1) {
-        const key = `${String(x)},${String(y)}`;
-        if (!allowed.has(key)) blocked.add(key);
-      }
-    }
     const start = observation({
       x: 5,
       y: 5,
@@ -715,7 +797,7 @@ describe("GameController navigation", () => {
         }),
         observation({ frame: 48, x: 7, y: 5 }),
       ],
-      { blocked },
+      { blocked: blockedOutside(allowed, 1, 9) },
     );
     const controller = new GameController(port);
 
@@ -734,13 +816,6 @@ describe("GameController navigation", () => {
 
   test("revalidates a failed corridor tile after a transient blocker moves", async () => {
     const allowed = new Set(["5,5", "6,5", "7,5"]);
-    const blocked = new Set<string>();
-    for (let x = 1; x <= 9; x += 1) {
-      for (let y = 1; y <= 9; y += 1) {
-        const key = `${String(x)},${String(y)}`;
-        if (!allowed.has(key)) blocked.add(key);
-      }
-    }
     const start = observation({ x: 5, y: 5, facing: "east" });
     const port = new FakeControlPort(
       start,
@@ -753,7 +828,7 @@ describe("GameController navigation", () => {
         observation({ frame: 36, x: 6, y: 5, facing: "east" }),
         observation({ frame: 48, x: 7, y: 5, facing: "east" }),
       ],
-      { blocked },
+      { blocked: blockedOutside(allowed, 1, 9) },
     );
     const controller = new GameController(port);
 
@@ -773,15 +848,10 @@ describe("GameController navigation", () => {
 
   test("bounds revalidation when an unobserved blocker never moves", async () => {
     const allowed = new Set(["5,5", "6,5"]);
-    const blocked = new Set<string>();
-    for (let x = 1; x <= 9; x += 1) {
-      for (let y = 1; y <= 9; y += 1) {
-        const key = `${String(x)},${String(y)}`;
-        if (!allowed.has(key)) blocked.add(key);
-      }
-    }
     const start = observation({ x: 5, y: 5, facing: "east" });
-    const port = new FakeControlPort(start, [], { blocked });
+    const port = new FakeControlPort(start, [], {
+      blocked: blockedOutside(allowed, 1, 9),
+    });
     const controller = new GameController(port);
 
     const result = await controller.navigate({ x: 6, y: 5 }, 3, 4);
@@ -872,94 +942,11 @@ describe("GameController exit navigation", () => {
   });
 
   test("does not route across an unselected automatic warp trigger", async () => {
-    const topology = mapTopology({
-      warps: [
-        {
-          version: 1,
-          size: 24,
-          index: 3,
-          trigger: { x: 11, y: 9, elevation: 0, behavior: 0 },
-          activation: "step",
-          destination: {
-            mapGroup: 1,
-            mapNum: 2,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 7, y: 7 },
-          },
-        },
-        {
-          version: 1,
-          size: 24,
-          index: 4,
-          trigger: { x: 9, y: 9, elevation: 0, behavior: 0 },
-          activation: "step",
-          destination: {
-            mapGroup: 1,
-            mapNum: 3,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 8, y: 8 },
-          },
-        },
-      ],
-    });
-    const corridor = new Set(["7,9", "8,9", "9,9", "10,9", "11,9"]);
-    const blocked = new Set<string>();
-    for (let x = 7; x <= 12; x += 1) {
-      for (let y = 7; y <= 12; y += 1) {
-        const key = `${String(x)},${String(y)}`;
-        if (!corridor.has(key)) blocked.add(key);
-      }
-    }
-    const port = new FakeControlPort(
-      observation({ x: 7, y: 9, facing: "east" }),
-      [],
-      { topology, blocked },
-    );
-
-    const result = await new GameController(port).navigateExit("warp:3", 5);
-
-    expect(result.status).toBe("stopped");
-    expect(result.stopReason).toBe("no-route");
-    expect(result.attemptsMade).toBe(0);
-    expect(result.stepsTaken).toBe(0);
-    expect(port.presses).toEqual([]);
+    await expectUnselectedWarpBlocked("step");
   });
 
   test("activates only the selected warp and stops without choosing a next route", async () => {
-    const topology = mapTopology({
-      warps: [
-        {
-          version: 1,
-          size: 24,
-          index: 3,
-          trigger: { x: 10, y: 9, elevation: 0, behavior: 0 },
-          activation: "step",
-          destination: {
-            mapGroup: 1,
-            mapNum: 2,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 7, y: 7 },
-          },
-        },
-        {
-          version: 1,
-          size: 24,
-          index: 4,
-          trigger: { x: 11, y: 9, elevation: 0, behavior: 0 },
-          activation: "step",
-          destination: {
-            mapGroup: 1,
-            mapNum: 3,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 8, y: 8 },
-          },
-        },
-      ],
-    });
+    const topology = pairedWarpTopology(10, 11, "step");
     const port = new FakeControlPort(
       observation({ x: 10, y: 10, facing: "north" }),
       [
@@ -1087,105 +1074,73 @@ describe("GameController directed exit replanning", () => {
   });
 });
 
+type SameMapWarpCase = Readonly<{
+  name: string;
+  start: ObservationInput;
+  next: ObservationInput;
+  status: "traversed" | "triggered" | "stopped";
+  stopReason: "exit-traversed" | "exit-triggered" | "activation-no-effect";
+  stepsTaken: number;
+}>;
+
+const sameMapWarpCases: readonly SameMapWarpCase[] = [
+  {
+    name: "reports the exported destination landing as traversed despite elevation mismatch",
+    start: { x: 10, y: 10, facing: "north" },
+    next: { frame: 12, x: 8, y: 8, elevation: 1, facing: "south" },
+    status: "traversed",
+    stopReason: "exit-traversed",
+    stepsTaken: 4,
+  },
+  {
+    name: "reports matching trigger coordinates and elevation as triggered",
+    start: { x: 10, y: 10, facing: "north" },
+    next: { frame: 12, x: 10, y: 9, elevation: 2, facing: "north" },
+    status: "triggered",
+    stopReason: "exit-triggered",
+    stepsTaken: 1,
+  },
+  {
+    name: "does not report trigger coordinates at the wrong elevation as triggered",
+    start: { x: 10, y: 10, elevation: 1, facing: "north" },
+    next: { frame: 12, x: 10, y: 9, elevation: 1, facing: "north" },
+    status: "stopped",
+    stopReason: "activation-no-effect",
+    stepsTaken: 1,
+  },
+  {
+    name: "keeps a map change authoritative despite trigger elevation mismatch",
+    start: { x: 10, y: 10, elevation: 1, facing: "north" },
+    next: {
+      frame: 12,
+      x: 10,
+      y: 9,
+      elevation: 1,
+      facing: "north",
+      mapNum: 1,
+    },
+    status: "traversed",
+    stopReason: "exit-traversed",
+    stepsTaken: 0,
+  },
+];
+
 describe("GameController same-map warp traversal", () => {
-  test("reports the exported destination landing as traversed despite elevation mismatch", async () => {
-    const topology = sameMapWarpTopology(2);
+  test.each(sameMapWarpCases)("$name", async (scenario) => {
     const port = new FakeControlPort(
-      observation({ x: 10, y: 10, facing: "north" }),
-      [
-        observation({
-          frame: 12,
-          x: 8,
-          y: 8,
-          elevation: 1,
-          facing: "south",
-        }),
-      ],
-      { topology },
+      observation(scenario.start),
+      [observation(scenario.next)],
+      {
+        topology: sameMapWarpTopology(2),
+      },
     );
 
     const result = await new GameController(port).navigateExit("warp:3", 1);
 
-    expect(result.status).toBe("traversed");
-    expect(result.stopReason).toBe("exit-traversed");
+    expect(result.status).toBe(scenario.status);
+    expect(result.stopReason).toBe(scenario.stopReason);
     expect(result.attemptsMade).toBe(1);
-    expect(result.stepsTaken).toBe(4);
-    expect(port.presses.map((press) => press.command)).toEqual(["up"]);
-  });
-
-  test("reports matching trigger coordinates and elevation as triggered", async () => {
-    const topology = sameMapWarpTopology(2);
-    const port = new FakeControlPort(
-      observation({ x: 10, y: 10, facing: "north" }),
-      [
-        observation({
-          frame: 12,
-          x: 10,
-          y: 9,
-          elevation: 2,
-          facing: "north",
-        }),
-      ],
-      { topology },
-    );
-
-    const result = await new GameController(port).navigateExit("warp:3", 1);
-
-    expect(result.status).toBe("triggered");
-    expect(result.stopReason).toBe("exit-triggered");
-    expect(result.attemptsMade).toBe(1);
-    expect(result.stepsTaken).toBe(1);
-    expect(port.presses.map((press) => press.command)).toEqual(["up"]);
-  });
-
-  test("does not report trigger coordinates at the wrong elevation as triggered", async () => {
-    const topology = sameMapWarpTopology(2);
-    const port = new FakeControlPort(
-      observation({ x: 10, y: 10, elevation: 1, facing: "north" }),
-      [
-        observation({
-          frame: 12,
-          x: 10,
-          y: 9,
-          elevation: 1,
-          facing: "north",
-        }),
-      ],
-      { topology },
-    );
-
-    const result = await new GameController(port).navigateExit("warp:3", 1);
-
-    expect(result.status).toBe("stopped");
-    expect(result.stopReason).toBe("activation-no-effect");
-    expect(result.attemptsMade).toBe(1);
-    expect(result.stepsTaken).toBe(1);
-    expect(port.presses.map((press) => press.command)).toEqual(["up"]);
-  });
-
-  test("keeps a map change authoritative despite trigger elevation mismatch", async () => {
-    const topology = sameMapWarpTopology(2);
-    const port = new FakeControlPort(
-      observation({ x: 10, y: 10, elevation: 1, facing: "north" }),
-      [
-        observation({
-          frame: 12,
-          x: 10,
-          y: 9,
-          elevation: 1,
-          facing: "north",
-          mapNum: 1,
-        }),
-      ],
-      { topology },
-    );
-
-    const result = await new GameController(port).navigateExit("warp:3", 1);
-
-    expect(result.status).toBe("traversed");
-    expect(result.stopReason).toBe("exit-traversed");
-    expect(result.attemptsMade).toBe(1);
-    expect(result.stepsTaken).toBe(0);
+    expect(result.stepsTaken).toBe(scenario.stepsTaken);
     expect(port.presses.map((press) => press.command)).toEqual(["up"]);
   });
 
@@ -1206,102 +1161,11 @@ describe("GameController same-map warp traversal", () => {
 
 describe("GameController directional warp exclusion", () => {
   test("does not enter an unselected directional warp from its triggering edge", async () => {
-    const topology = mapTopology({
-      warps: [
-        {
-          version: 1,
-          size: 24,
-          index: 3,
-          trigger: { x: 11, y: 9, elevation: 0, behavior: 0 },
-          activation: "step",
-          destination: {
-            mapGroup: 1,
-            mapNum: 2,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 7, y: 7 },
-          },
-        },
-        {
-          version: 1,
-          size: 24,
-          index: 4,
-          trigger: { x: 9, y: 9, elevation: 0, behavior: 0 },
-          activation: "east",
-          destination: {
-            mapGroup: 1,
-            mapNum: 3,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 8, y: 8 },
-          },
-        },
-      ],
-    });
-    const corridor = new Set(["7,9", "8,9", "9,9", "10,9", "11,9"]);
-    const blocked = new Set<string>();
-    for (let x = 7; x <= 12; x += 1) {
-      for (let y = 7; y <= 12; y += 1) {
-        const key = `${String(x)},${String(y)}`;
-        if (!corridor.has(key)) blocked.add(key);
-      }
-    }
-    const port = new FakeControlPort(
-      observation({ x: 7, y: 9, facing: "east" }),
-      [],
-      { topology, blocked },
-    );
-
-    const result = await new GameController(port).navigateExit("warp:3", 5);
-
-    expect(result.status).toBe("stopped");
-    expect(result.stopReason).toBe("no-route");
-    expect(result.attemptsMade).toBe(0);
-    expect(result.stepsTaken).toBe(0);
-    expect(port.presses).toEqual([]);
+    await expectUnselectedWarpBlocked("east");
   });
 
   test("can cross a directional warp trigger from a non-triggering side", async () => {
-    const topology = mapTopology({
-      warps: [
-        {
-          version: 1,
-          size: 24,
-          index: 3,
-          trigger: { x: 7, y: 9, elevation: 0, behavior: 0 },
-          activation: "step",
-          destination: {
-            mapGroup: 1,
-            mapNum: 2,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 7, y: 7 },
-          },
-        },
-        {
-          version: 1,
-          size: 24,
-          index: 4,
-          trigger: { x: 9, y: 9, elevation: 0, behavior: 0 },
-          activation: "east",
-          destination: {
-            mapGroup: 1,
-            mapNum: 3,
-            warpId: 0,
-            dynamic: false,
-            landing: { x: 8, y: 8 },
-          },
-        },
-      ],
-    });
-    const corridor = new Set(["7,9", "8,9", "9,9", "10,9", "11,9"]);
-    const blocked = new Set<string>();
-    for (let x = 7; x <= 12; x += 1) {
-      for (let y = 7; y <= 12; y += 1) {
-        const key = `${String(x)},${String(y)}`;
-        if (!corridor.has(key)) blocked.add(key);
-      }
-    }
+    const topology = pairedWarpTopology(7, 9, "east");
     const port = new FakeControlPort(
       observation({ x: 11, y: 9, facing: "west" }),
       [
@@ -1310,7 +1174,7 @@ describe("GameController directional warp exclusion", () => {
         observation({ frame: 36, x: 8, y: 9, facing: "west" }),
         observation({ frame: 48, x: 7, y: 9, facing: "west" }),
       ],
-      { topology, blocked },
+      { topology, blocked: corridorBlocks() },
     );
 
     const result = await new GameController(port).navigateExit("warp:3", 4);

--- a/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
+++ b/packages/discord-plays-pokemon/packages/backend/src/goal/goal-manager.test.ts
@@ -68,6 +68,64 @@ async function noopSendMessage(): Promise<void> {
   await Bun.sleep(0);
 }
 
+type GoalManagerOptions = ConstructorParameters<typeof GoalManager>[0];
+
+async function managerHarness(
+  overrides: Partial<GoalManagerOptions> = {},
+): Promise<{
+  manager: GoalManager;
+  messages: GoalDiscordMessage[];
+  process: ReturnType<typeof makeProcess>;
+  runtimeDirectory: string;
+}> {
+  const runtimeDirectory = await createRuntimeDirectory();
+  const process = makeProcess();
+  const messages: GoalDiscordMessage[] = [];
+  const manager = new GoalManager({
+    config: makeGoalConfig(runtimeDirectory),
+    controlToken: "token",
+    spawner: () => process,
+    sendMessage: async (message) => {
+      messages.push(message);
+    },
+    now: () => new Date("2026-06-13T00:00:00.000Z"),
+    ...overrides,
+  });
+  return { manager, messages, process, runtimeDirectory };
+}
+
+async function waitForMessage(
+  messages: readonly GoalDiscordMessage[],
+): Promise<void> {
+  for (let attempt = 0; attempt < 50 && messages.length === 0; attempt += 1) {
+    await Bun.sleep(1);
+  }
+}
+
+async function environmentHarness(): Promise<{
+  environment: () => Record<string, string> | undefined;
+  manager: GoalManager;
+}> {
+  const process = makeProcess();
+  let spawnedEnvironment: Record<string, string> | undefined;
+  const { manager } = await managerHarness({
+    spawner: (_args, options) => {
+      spawnedEnvironment = options.env;
+      return process;
+    },
+    sendMessage: noopSendMessage,
+  });
+  return { environment: () => spawnedEnvironment, manager };
+}
+
+function startDefaultGoal(manager: GoalManager) {
+  return manager.startGoal({
+    goal: "Reach Petalburg",
+    requesterId: "user-a",
+    channelId: "channel",
+  });
+}
+
 function codePointLength(value: string): number {
   let length = 0;
   for (const _codePoint of value) {
@@ -163,30 +221,14 @@ describe("GoalManager", () => {
   });
 
   test("passes the Codex access token to the SDK runtime", async () => {
-    const runtimeDirectory = await createRuntimeDirectory();
-    const process = makeProcess();
-    let spawnedEnvironment: Record<string, string> | undefined;
-    const manager = new GoalManager({
-      config: makeGoalConfig(runtimeDirectory),
-      controlToken: "token",
-      spawner: (_args, options) => {
-        spawnedEnvironment = options.env;
-        return process;
-      },
-      sendMessage: noopSendMessage,
-      now: () => new Date("2026-06-13T00:00:00.000Z"),
-    });
+    const { environment, manager } = await environmentHarness();
 
-    const result = await manager.startGoal({
-      goal: "Reach Petalburg",
-      requesterId: "user-a",
-      channelId: "channel",
-    });
+    const result = await startDefaultGoal(manager);
 
     expect(result.kind).toBe("started");
-    expect(spawnedEnvironment?.CODEX_ACCESS_TOKEN).toBe("test-key");
-    expect(spawnedEnvironment?.CODEX_API_KEY).toBeUndefined();
-    expect(spawnedEnvironment?.OPENAI_API_KEY).toBeUndefined();
+    expect(environment()?.CODEX_ACCESS_TOKEN).toBe("test-key");
+    expect(environment()?.CODEX_API_KEY).toBeUndefined();
+    expect(environment()?.OPENAI_API_KEY).toBeUndefined();
     await manager.shutdown();
   });
 
@@ -194,31 +236,15 @@ describe("GoalManager", () => {
     const originalDiscordToken = Bun.env.DISCORD_TOKEN;
     Bun.env.DISCORD_TOKEN = "super-secret-discord-token";
     try {
-      const runtimeDirectory = await createRuntimeDirectory();
-      const process = makeProcess();
-      let spawnedEnvironment: Record<string, string> | undefined;
-      const manager = new GoalManager({
-        config: makeGoalConfig(runtimeDirectory),
-        controlToken: "token",
-        spawner: (_args, options) => {
-          spawnedEnvironment = options.env;
-          return process;
-        },
-        sendMessage: noopSendMessage,
-        now: () => new Date("2026-06-13T00:00:00.000Z"),
-      });
+      const { environment, manager } = await environmentHarness();
 
-      const result = await manager.startGoal({
-        goal: "Reach Petalburg",
-        requesterId: "user-a",
-        channelId: "channel",
-      });
+      const result = await startDefaultGoal(manager);
 
       expect(result.kind).toBe("started");
       // The credential the SDK runtime legitimately needs is still present.
-      expect(spawnedEnvironment?.CODEX_ACCESS_TOKEN).toBe("test-key");
+      expect(environment()?.CODEX_ACCESS_TOKEN).toBe("test-key");
       // The bot token (and any other non-allowlisted secret) must not leak.
-      expect(spawnedEnvironment?.DISCORD_TOKEN).toBeUndefined();
+      expect(environment()?.DISCORD_TOKEN).toBeUndefined();
       await manager.shutdown();
     } finally {
       if (originalDiscordToken === undefined) {
@@ -388,18 +414,8 @@ describe("GoalManager final report", () => {
   });
 
   test("checkpoints the game save when a goal finishes", async () => {
-    const runtimeDirectory = await createRuntimeDirectory();
-    const process = makeProcess();
-    const messages: GoalDiscordMessage[] = [];
     let checkpoints = 0;
-    const manager = new GoalManager({
-      config: makeGoalConfig(runtimeDirectory),
-      controlToken: "token",
-      spawner: () => process,
-      sendMessage: async (message) => {
-        messages.push(message);
-      },
-      now: () => new Date("2026-06-13T00:00:00.000Z"),
+    const { manager, messages, process } = await managerHarness({
       checkpointGame: async () => {
         checkpoints += 1;
         await Bun.sleep(0);
@@ -414,9 +430,7 @@ describe("GoalManager final report", () => {
     expect(start.kind).toBe("started");
 
     process.finish(0);
-    for (let attempt = 0; attempt < 50 && messages.length === 0; attempt += 1) {
-      await Bun.sleep(1);
-    }
+    await waitForMessage(messages);
 
     expect(messages).toHaveLength(1);
     expect(checkpoints).toBe(1);
@@ -424,22 +438,12 @@ describe("GoalManager final report", () => {
   });
 
   test("holds the input lease until the checkpoint save completes", async () => {
-    const runtimeDirectory = await createRuntimeDirectory();
-    const process = makeProcess();
-    const messages: GoalDiscordMessage[] = [];
     let leaseReleased = false;
     let leaseHeldAtCheckpoint: boolean | undefined;
     const releaseInputLease = () => {
       leaseReleased = true;
     };
-    const manager = new GoalManager({
-      config: makeGoalConfig(runtimeDirectory),
-      controlToken: "token",
-      spawner: () => process,
-      sendMessage: async (message) => {
-        messages.push(message);
-      },
-      now: () => new Date("2026-06-13T00:00:00.000Z"),
+    const { manager, messages, process } = await managerHarness({
       acquireInputLease: () => releaseInputLease,
       checkpointGame: () => {
         leaseHeldAtCheckpoint = !leaseReleased;
@@ -455,9 +459,7 @@ describe("GoalManager final report", () => {
     expect(start.kind).toBe("started");
 
     process.finish(0);
-    for (let attempt = 0; attempt < 50 && messages.length === 0; attempt += 1) {
-      await Bun.sleep(1);
-    }
+    await waitForMessage(messages);
 
     expect(leaseHeldAtCheckpoint).toBe(true);
     expect(leaseReleased).toBe(true);
@@ -465,18 +467,8 @@ describe("GoalManager final report", () => {
   });
 
   test("still finishes a goal when the checkpoint save fails", async () => {
-    const runtimeDirectory = await createRuntimeDirectory();
-    const process = makeProcess();
-    const messages: GoalDiscordMessage[] = [];
     let checkpoints = 0;
-    const manager = new GoalManager({
-      config: makeGoalConfig(runtimeDirectory),
-      controlToken: "token",
-      spawner: () => process,
-      sendMessage: async (message) => {
-        messages.push(message);
-      },
-      now: () => new Date("2026-06-13T00:00:00.000Z"),
+    const { manager, messages, process } = await managerHarness({
       // Emerald rejects a save outside the overworld/battle — teardown must not
       // fail because of it, but it should retry to let a transient state clear.
       checkpointGame: () => {
@@ -494,9 +486,7 @@ describe("GoalManager final report", () => {
     expect(start.kind).toBe("started");
 
     process.finish(0);
-    for (let attempt = 0; attempt < 50 && messages.length === 0; attempt += 1) {
-      await Bun.sleep(1);
-    }
+    await waitForMessage(messages);
 
     // Retried the configured number of times, then finished teardown anyway.
     expect(checkpoints).toBe(3);


### PR DESCRIPTION
## Why

Pokémon goal-controller tests repeated battle participants, navigation topology, collision grids, process setup, and terminal-goal polling. That obscured scenario intent and carried 2,014 duplicated tokens in the jscpd baseline.

## What

- add typed helpers for observations, battle participants, party state, and paired warp topology
- centralize collision-grid, no-route, and GoalManager process/message harness setup
- table-drive same-map warp outcomes while retaining independent expected values
- lower the cumulative jscpd baseline from 64,393 to 62,379 duplicated tokens

## Verification

- `bun --cwd packages/discord-plays-pokemon/packages/backend --no-install --bun vitest --config ../../../../vitest.config.ts run src/goal/game-controller.test.ts src/goal/game-battle-control.test.ts src/goal/goal-manager.test.ts`
- `bunx turbo run test typecheck lint --filter=@discord-plays-pokemon/backend`
- `bun run jscpd`
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json` → `62379`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No live emulator, Discord, or goal-model checks were run because this is a test-only refactor. No media is required for an internal test refactor.