### PR TITLE
refactor(pr-fleet-controller): consolidate controller test foundations

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -860,21 +860,9 @@
       "clones": 1,
       "tokens": 74
     },
-    "packages/pr-fleet-controller/test/controller.test.ts|packages/pr-fleet-controller/test/controller.test.ts": {
-      "clones": 8,
-      "tokens": 913
-    },
     "packages/pr-fleet-controller/test/operator-question-replay.test.ts|packages/pr-fleet-controller/test/operator-question-replay.test.ts": {
       "clones": 1,
       "tokens": 74
-    },
-    "packages/pr-fleet-controller/test/operator-question-replay.test.ts|packages/pr-fleet-controller/test/replay-boundary-regressions.test.ts": {
-      "clones": 1,
-      "tokens": 115
-    },
-    "packages/pr-fleet-controller/test/operator-question-replay.test.ts|packages/pr-fleet-controller/test/run-bundle.test.ts": {
-      "clones": 2,
-      "tokens": 192
     },
     "packages/pr-fleet-controller/test/operator-question-replay.test.ts|packages/pr-fleet-controller/test/run-recorder-failure.test.ts": {
       "clones": 1,
@@ -883,10 +871,6 @@
     "packages/pr-fleet-controller/test/operator-review-regressions.test.ts|packages/pr-fleet-controller/test/operator-review-regressions.test.ts": {
       "clones": 2,
       "tokens": 160
-    },
-    "packages/pr-fleet-controller/test/operator-review-regressions.test.ts|packages/pr-fleet-controller/test/replay-boundary-regressions.test.ts": {
-      "clones": 1,
-      "tokens": 84
     },
     "packages/pr-fleet-controller/test/operator-review-regressions.test.ts|packages/pr-fleet-controller/test/worktree.test.ts": {
       "clones": 1,

--- a/packages/pr-fleet-controller/test/controller.test.ts
+++ b/packages/pr-fleet-controller/test/controller.test.ts
@@ -42,8 +42,8 @@ function cleanWorktreeContext(pr: PrIdentity): WorktreeContext {
 }
 
 class FakeEnvironment implements FleetEnvironment {
-  readonly prs: PrIdentity[];
-  readonly evidenceByPr: Map<number, ReadinessEvidence>;
+  prs: PrIdentity[];
+  evidenceByPr: Map<number, ReadinessEvidence>;
 
   constructor(prs: PrIdentity[], evidenceByPr: Map<number, ReadinessEvidence>) {
     this.prs = prs;
@@ -264,77 +264,7 @@ class AttemptRecordingRunner implements WorkerRunner {
   }
 }
 
-class MutableEnvironment implements FleetEnvironment {
-  prs: PrIdentity[];
-  evidenceByPr: Map<number, ReadinessEvidence>;
-
-  constructor(prs: PrIdentity[], evidenceByPr: Map<number, ReadinessEvidence>) {
-    this.prs = prs;
-    this.evidenceByPr = evidenceByPr;
-  }
-
-  listOpenPrs(): Promise<PrIdentity[]> {
-    return Promise.resolve(this.prs);
-  }
-
-  refreshEvidence(pr: PrIdentity): Promise<ReadinessEvidence> {
-    const current = this.evidenceByPr.get(pr.number);
-    if (current === undefined) {
-      throw new Error("Missing fake evidence");
-    }
-    return Promise.resolve(current);
-  }
-
-  findWorktree(): Promise<string | null> {
-    return Promise.resolve("/tmp/pr-fleet-fake");
-  }
-
-  provisionWorktree(): Promise<string> {
-    return Promise.resolve("/tmp/pr-fleet-fake");
-  }
-
-  assignWorktreeBranch(
-    _worktree: string,
-    pr: PrIdentity,
-  ): Promise<WorktreeContext> {
-    return Promise.resolve(cleanWorktreeContext(pr));
-  }
-
-  runLocalCommand(_request: CommandRequest): Promise<CommandResult> {
-    return Promise.resolve({
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      termination: "exit",
-    });
-  }
-
-  startRestack(): Promise<CommandResult> {
-    return Promise.resolve({
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      termination: "exit",
-    });
-  }
-
-  continueRestack(): Promise<CommandResult> {
-    return Promise.resolve({
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      termination: "exit",
-    });
-  }
-
-  publishFix() {
-    return Promise.resolve({ headSha: "a".repeat(40) });
-  }
-
-  publishRestack() {
-    return Promise.resolve({ headSha: "a".repeat(40) });
-  }
-}
+class MutableEnvironment extends FakeEnvironment {}
 
 class ControllableRunner implements WorkerRunner {
   readonly #rejects: ((error: Error) => void)[] = [];
@@ -496,6 +426,27 @@ class CorrelationEnvironment extends FakeEnvironment {
   }
 }
 
+type FleetControllerOptions = ConstructorParameters<typeof FleetController>[0];
+
+function controllerHarness(
+  overrides: Partial<FleetControllerOptions> = {},
+): FleetController {
+  return new FleetController({
+    config: {
+      model: "openai/gpt-5",
+      repo: "shepherdjerred/monorepo",
+      checkout: "/tmp/repo",
+      worktreeRoot: "/tmp/worktrees",
+      maxWorkers: 1,
+    },
+    environment: new FakeEnvironment([], new Map()),
+    workerRunner: new BlockingRunner(),
+    observer: new RecordingObserver(),
+    store: new FleetStore(1),
+    ...overrides,
+  });
+}
+
 test("a fleet tick classifies every PR and queues excess actionable work", async () => {
   const first = identity(1);
   const second = identity(2);
@@ -514,14 +465,7 @@ test("a fleet tick classifies every PR and queues excess actionable work", async
     ]),
   );
   const observer = new RecordingObserver();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: new BlockingRunner(),
     observer,
@@ -543,14 +487,7 @@ test("a PR head move defers only that PR and schedules immediate refresh", async
     new Map([[pr.number, evidence(pr)]]),
   );
   const observer = new RecordingObserver();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: new BlockingRunner(),
     observer,
@@ -570,14 +507,7 @@ test("a failed heartbeat rearms reconciliation", async () => {
   const environment = new OneFailureEnvironment([], new Map());
   const observer = new RecordingObserver();
   const scheduler = new RecordingScheduler();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: new BlockingRunner(),
     observer,
@@ -603,14 +533,7 @@ test("a heartbeat capture failure requests coordinated shutdown", async () => {
   const telemetry = new KindFailingTelemetry();
   const scheduler = new RecordingScheduler();
   const fatal = Promise.withResolvers<Error>();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment([], new Map()),
     workerRunner: new BlockingRunner(),
     observer: new RecordingObserver(),
@@ -637,14 +560,7 @@ test("a heartbeat capture failure requests coordinated shutdown", async () => {
 test("shutdown waits for an in-flight reconciliation before completing", async () => {
   const environment = new DeferredListEnvironment([], new Map());
   const telemetry = new RecordingTelemetry();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: new BlockingRunner(),
     observer: new RecordingObserver(),
@@ -672,14 +588,7 @@ test("shutdown waits for an in-flight reconciliation before completing", async (
 
 test("shutdown completion waits for the coordinated master settlement", async () => {
   const telemetry = new RecordingTelemetry();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment([], new Map()),
     workerRunner: new BlockingRunner(),
     observer: new RecordingObserver(),
@@ -712,14 +621,7 @@ test("shutdown rejects worker terminal telemetry persistence failures", async ()
     link: null,
     softFail: false,
   };
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -764,14 +666,7 @@ test("shutdown start persistence failure still aborts and settles workers", asyn
     softFail: false,
   };
   const runner = new RecordingRunner();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -814,14 +709,7 @@ test("worker completion capture failures escape settlement and stop the controll
   const runner = new DeferredSuccessfulRunner();
   const fatal = Promise.withResolvers<Error>();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -867,14 +755,7 @@ test("worker completion capture failures escape settlement and stop the controll
 });
 
 test("controller rejects ticks after shutdown starts", async () => {
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment([], new Map()),
     workerRunner: new BlockingRunner(),
     observer: new RecordingObserver(),
@@ -904,14 +785,7 @@ test("controller tick commands carry tick and PR correlation", async () => {
     [pr],
     new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
   );
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: new BlockingRunner(),
     observer: new RecordingObserver(),
@@ -950,14 +824,7 @@ test("shutdown cancels a worker dispatched by an already-running tick", async ()
   const runner = new RecordingRunner();
   const telemetry = new RecordingTelemetry();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: runner,
     observer: new RecordingObserver(),
@@ -994,14 +861,7 @@ test("pausing an active worker records cancellation instead of failure", async (
   };
   const telemetry = new RecordingTelemetry();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -1036,14 +896,7 @@ test("records worker start before the runner can emit its first attempt", async 
     softFail: false,
   };
   const telemetry = new RecordingTelemetry();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -1088,14 +941,7 @@ test("does not schedule a worker when persisting its start fails", async () => {
   };
   const runner = new RecordingRunner();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new FakeEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -1130,14 +976,7 @@ test("worktree capture failures stop the controller instead of pausing the PR", 
   };
   const runner = new RecordingRunner();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment: new WorktreeCaptureFailingEnvironment(
       [pr],
       new Map([[1, evidence(pr, { checks: [failedCheck] })]]),
@@ -1171,14 +1010,7 @@ test("aborts a worker whose assigned head changes and does not pause it", async 
   const runner = new RecordingRunner();
   const telemetry = new RecordingTelemetry();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: runner,
     observer: new RecordingObserver(),
@@ -1233,14 +1065,7 @@ test("keeps a closed PR's leases until its worker settles", async () => {
   );
   const runner = new ControllableRunner();
   const store = new FleetStore(1);
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: runner,
     observer: new RecordingObserver(),
@@ -1289,14 +1114,7 @@ test("an operator question parks only its PR, releases leases, and resumes on an
   const runner = new DeferredSuccessfulRunner();
   const store = new FleetStore(1);
   const telemetry = new RecordingTelemetry();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: runner,
     observer: new RecordingObserver(),
@@ -1416,14 +1234,7 @@ test("a head change supersedes an unanswered operator request", async () => {
   );
   const store = new FleetStore(1);
   const telemetry = new RecordingTelemetry();
-  const controller = new FleetController({
-    config: {
-      model: "openai/gpt-5",
-      repo: "shepherdjerred/monorepo",
-      checkout: "/tmp/repo",
-      worktreeRoot: "/tmp/worktrees",
-      maxWorkers: 1,
-    },
+  const controller = controllerHarness({
     environment,
     workerRunner: new BlockingRunner(),
     observer: new RecordingObserver(),

--- a/packages/pr-fleet-controller/test/fixtures.ts
+++ b/packages/pr-fleet-controller/test/fixtures.ts
@@ -3,7 +3,66 @@ import {
   ReadinessEvidenceSchema,
   type PrIdentity,
   type ReadinessEvidence,
+  type FleetSnapshot,
 } from "@shepherdjerred/pr-fleet-controller/src/domain/schemas.ts";
+import { RunRecorder } from "@shepherdjerred/pr-fleet-controller/src/bundle/run-recorder.ts";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+export const emptyFleetSnapshot: FleetSnapshot = {
+  open: 0,
+  green: 0,
+  active: 0,
+  queued: 0,
+  pending: 0,
+  waiting: 0,
+  paused: 0,
+  prs: [],
+};
+
+export class TemporaryDirectoryOwner {
+  readonly #directories: string[] = [];
+
+  async create(prefix: string): Promise<string> {
+    const directory = await mkdtemp(path.join(tmpdir(), prefix));
+    this.#directories.push(directory);
+    return directory;
+  }
+
+  own(directory: string): void {
+    this.#directories.push(directory);
+  }
+
+  async cleanup(): Promise<void> {
+    await Promise.all(
+      this.#directories
+        .splice(0)
+        .map((directory) => rm(directory, { recursive: true, force: true })),
+    );
+  }
+}
+
+export async function createRunRecorder(
+  directories: TemporaryDirectoryOwner,
+  prefix: string,
+  secretValues: readonly string[] = [],
+): Promise<RunRecorder> {
+  const stateDirectory = await directories.create(prefix);
+  return RunRecorder.create({
+    stateDirectory,
+    controllerVersion: "0.1.0",
+    controllerCommit: "a".repeat(40),
+    controllerSourceDirty: false,
+    controllerSourceFingerprint: "b".repeat(64),
+    model: "openai/gpt-5.6-terra",
+    repository: "example/repository",
+    checkout: "/tmp/checkout",
+    worktreeRoot: "/tmp/worktrees",
+    maxWorkers: 2,
+    secretValues,
+  });
+}
 
 export function identity(
   number: number,

--- a/packages/pr-fleet-controller/test/operator-question-replay.test.ts
+++ b/packages/pr-fleet-controller/test/operator-question-replay.test.ts
@@ -1,51 +1,26 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
 import { buildPrState } from "@shepherdjerred/pr-fleet-controller/src/domain/fleet-logic.ts";
 import {
   loadRunBundle,
   replayRunBundle,
 } from "@shepherdjerred/pr-fleet-controller/src/replay/run-inspection.ts";
-import { RunRecorder } from "@shepherdjerred/pr-fleet-controller/src/bundle/run-recorder.ts";
 import type { FleetSnapshot } from "@shepherdjerred/pr-fleet-controller/src/domain/schemas.ts";
-import { evidence, identity } from "./fixtures.ts";
+import {
+  createRunRecorder,
+  emptyFleetSnapshot as snapshot,
+  evidence,
+  identity,
+  TemporaryDirectoryOwner,
+} from "./fixtures.ts";
 
-const snapshot: FleetSnapshot = {
-  open: 0,
-  green: 0,
-  active: 0,
-  queued: 0,
-  pending: 0,
-  waiting: 0,
-  paused: 0,
-  prs: [],
-};
-const temporaryDirectories: string[] = [];
+const temporaryDirectories = new TemporaryDirectoryOwner();
 
 afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
-  );
+  await temporaryDirectories.cleanup();
 });
 
-async function createRecorder() {
-  const stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-run-"));
-  temporaryDirectories.push(stateDirectory);
-  return RunRecorder.create({
-    stateDirectory,
-    controllerVersion: "0.1.0",
-    controllerCommit: "a".repeat(40),
-    controllerSourceDirty: false,
-    controllerSourceFingerprint: "b".repeat(64),
-    model: "openai/gpt-5.6-terra",
-    repository: "example/repository",
-    checkout: "/tmp/checkout",
-    worktreeRoot: "/tmp/worktrees",
-    maxWorkers: 2,
-  });
+function createRecorder() {
+  return createRunRecorder(temporaryDirectories, "pr-fleet-run-");
 }
 
 describe("operator question replay", () => {

--- a/packages/pr-fleet-controller/test/replay-boundary-regressions.test.ts
+++ b/packages/pr-fleet-controller/test/replay-boundary-regressions.test.ts
@@ -1,53 +1,29 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import { writeFile } from "node:fs/promises";
 import {
   loadRunBundle,
   replayRunBundle,
 } from "@shepherdjerred/pr-fleet-controller/src/replay/run-inspection.ts";
-import { RunRecorder } from "@shepherdjerred/pr-fleet-controller/src/bundle/run-recorder.ts";
 import {
   PrStateSchema,
   type FleetSnapshot,
 } from "@shepherdjerred/pr-fleet-controller/src/domain/schemas.ts";
-import { evidence, identity } from "./fixtures.ts";
+import {
+  createRunRecorder,
+  emptyFleetSnapshot as snapshot,
+  evidence,
+  identity,
+  TemporaryDirectoryOwner,
+} from "./fixtures.ts";
 
-const snapshot: FleetSnapshot = {
-  open: 0,
-  green: 0,
-  active: 0,
-  queued: 0,
-  pending: 0,
-  waiting: 0,
-  paused: 0,
-  prs: [],
-};
-const temporaryDirectories: string[] = [];
+const temporaryDirectories = new TemporaryDirectoryOwner();
 
 afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
-  );
+  await temporaryDirectories.cleanup();
 });
 
-async function createRecorder(): Promise<RunRecorder> {
-  const stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-replay-"));
-  temporaryDirectories.push(stateDirectory);
-  return RunRecorder.create({
-    stateDirectory,
-    controllerVersion: "0.1.0",
-    controllerCommit: "a".repeat(40),
-    controllerSourceDirty: false,
-    controllerSourceFingerprint: "b".repeat(64),
-    model: "openai/gpt-5.6-terra",
-    repository: "example/repository",
-    checkout: "/tmp/checkout",
-    worktreeRoot: "/tmp/worktrees",
-    maxWorkers: 2,
-  });
+function createRecorder() {
+  return createRunRecorder(temporaryDirectories, "pr-fleet-replay-");
 }
 
 const replayOptions = {

--- a/packages/pr-fleet-controller/test/run-bundle.test.ts
+++ b/packages/pr-fleet-controller/test/run-bundle.test.ts
@@ -2,14 +2,11 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   chmod,
   mkdir,
-  mkdtemp,
   readFile,
   readdir,
-  rm,
   stat,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   inspectEvents,
@@ -23,47 +20,23 @@ import {
   RunRecorder,
 } from "@shepherdjerred/pr-fleet-controller/src/bundle/run-recorder.ts";
 import type { RecordedRunEvent } from "@shepherdjerred/pr-fleet-controller/src/domain/run-events.ts";
-import type { FleetSnapshot } from "@shepherdjerred/pr-fleet-controller/src/domain/schemas.ts";
 import { writeFileSinkSynchronously } from "@shepherdjerred/pr-fleet-controller/src/runtime/synchronous-file-sink.ts";
-import { evidence, identity } from "./fixtures.ts";
+import {
+  createRunRecorder,
+  emptyFleetSnapshot as snapshot,
+  evidence,
+  identity,
+  TemporaryDirectoryOwner,
+} from "./fixtures.ts";
 
-const snapshot: FleetSnapshot = {
-  open: 0,
-  green: 0,
-  active: 0,
-  queued: 0,
-  pending: 0,
-  waiting: 0,
-  paused: 0,
-  prs: [],
-};
-
-const temporaryDirectories: string[] = [];
+const temporaryDirectories = new TemporaryDirectoryOwner();
 
 afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories
-      .splice(0)
-      .map((directory) => rm(directory, { recursive: true, force: true })),
-  );
+  await temporaryDirectories.cleanup();
 });
 
-async function createRecorder(secretValues: readonly string[] = []) {
-  const stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-run-"));
-  temporaryDirectories.push(stateDirectory);
-  return RunRecorder.create({
-    stateDirectory,
-    controllerVersion: "0.1.0",
-    controllerCommit: "a".repeat(40),
-    controllerSourceDirty: false,
-    controllerSourceFingerprint: "b".repeat(64),
-    model: "openai/gpt-5.6-terra",
-    repository: "example/repository",
-    checkout: "/tmp/checkout",
-    worktreeRoot: "/tmp/worktrees",
-    maxWorkers: 2,
-    secretValues,
-  });
+function createRecorder(secretValues: readonly string[] = []) {
+  return createRunRecorder(temporaryDirectories, "pr-fleet-run-", secretValues);
 }
 
 async function mode(file: string): Promise<number> {
@@ -76,8 +49,7 @@ async function runCliWithImplicitCheckout(): Promise<{
   exitCode: number;
   stderr: string;
 }> {
-  const parent = await mkdtemp(path.join(tmpdir(), "pr-fleet-cli-"));
-  temporaryDirectories.push(parent);
+  const parent = await temporaryDirectories.create("pr-fleet-cli-");
   const stateDirectory = path.join(parent, "state");
   const binDirectory = path.join(parent, "bin");
   await mkdir(binDirectory);
@@ -134,8 +106,7 @@ async function runCliInterruptedDuringCheckout(): Promise<{
   exitCode: number;
   stderr: string;
 }> {
-  const parent = await mkdtemp(path.join(tmpdir(), "pr-fleet-sigint-"));
-  temporaryDirectories.push(parent);
+  const parent = await temporaryDirectories.create("pr-fleet-sigint-");
   const stateDirectory = path.join(parent, "state");
   const binDirectory = path.join(parent, "bin");
   const readyFifo = path.join(parent, "ready.fifo");
@@ -350,8 +321,7 @@ async function recordSyntheticWorkerRun(recorder: RunRecorder): Promise<void> {
 }
 
 async function testSynchronousPersistenceFailure(): Promise<void> {
-  const stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-run-"));
-  temporaryDirectories.push(stateDirectory);
+  const stateDirectory = await temporaryDirectories.create("pr-fleet-run-");
   let failNextWrite = true;
   const recorder = await RunRecorder.create({
     stateDirectory,
@@ -449,8 +419,7 @@ describe("local run bundles", () => {
   });
 
   test("resolves bootstrap metadata before recording controller data", async () => {
-    const stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-run-"));
-    temporaryDirectories.push(stateDirectory);
+    const stateDirectory = await temporaryDirectories.create("pr-fleet-run-");
     const recorder = await RunRecorder.create({
       stateDirectory,
       controllerVersion: "unresolved",
@@ -514,8 +483,7 @@ describe("local run bundles", () => {
 
 describe("local run bundle integrity", () => {
   test("fails closed when the selected state directory is group-readable", async () => {
-    const stateDirectory = await mkdtemp(path.join(tmpdir(), "pr-fleet-open-"));
-    temporaryDirectories.push(stateDirectory);
+    const stateDirectory = await temporaryDirectories.create("pr-fleet-open-");
     await chmod(stateDirectory, 0o750);
     await expect(
       RunRecorder.create({
@@ -583,8 +551,7 @@ describe("local run bundle integrity", () => {
   });
 
   test("captures a missing-tool preflight failure in a replayable bundle", async () => {
-    const parent = await mkdtemp(path.join(tmpdir(), "pr-fleet-cli-"));
-    temporaryDirectories.push(parent);
+    const parent = await temporaryDirectories.create("pr-fleet-cli-");
     const stateDirectory = path.join(parent, "state");
     const packageDirectory = path.join(import.meta.dir, "..");
     const subprocess = Bun.spawn(
@@ -641,7 +608,7 @@ describe("CLI command capture", () => {
       packageDirectory,
       `.test-xdg-state-${crypto.randomUUID()}`,
     );
-    temporaryDirectories.push(stateBase);
+    temporaryDirectories.own(stateBase);
     const subprocess = Bun.spawn(
       [
         "bun",


### PR DESCRIPTION
## Why

PR-fleet tests repeated complete environment implementations, controller dependency wiring, empty snapshots, recorder metadata, and temporary-directory cleanup. That carried 1,304 duplicated tokens in the jscpd baseline.

## What

- share mutable environment behavior through the existing fake environment
- add a typed controller dependency harness
- extend canonical fixtures with empty snapshots, recorder construction, and temporary-directory ownership
- migrate run-bundle and replay suites to the shared fixtures
- lower the cumulative jscpd baseline from 62,379 to 61,075 duplicated tokens

## Verification

- `bun --cwd packages/pr-fleet-controller --no-install --bun vitest --config ../../vitest.config.ts run test/controller.test.ts test/run-bundle.test.ts test/replay-boundary-regressions.test.ts test/operator-question-replay.test.ts`
- `bunx turbo run test typecheck lint --filter=@shepherdjerred/pr-fleet-controller`
- `bun run jscpd`
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json` → `61075`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No live GitHub, Buildkite, or controller runs were performed because this is a test-only refactor. No media is required for an internal test refactor.