### PR TITLE
refactor(tasks-for-obsidian): consolidate task store test setup

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1493,16 +1493,16 @@
       "tokens": 110
     },
     "packages/tasks-for-obsidian/src/data/api/TaskNotesClient.test.ts|packages/tasks-for-obsidian/src/data/api/TaskNotesClient.test.ts": {
-      "clones": 3,
-      "tokens": 305
+      "clones": 1,
+      "tokens": 87
     },
     "packages/tasks-for-obsidian/src/data/preferences/saved-view-repository.ts|packages/tasks-for-obsidian/src/data/store/TaskStore.ts": {
       "clones": 1,
       "tokens": 139
     },
     "packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts|packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts": {
-      "clones": 14,
-      "tokens": 1383
+      "clones": 5,
+      "tokens": 441
     },
     "packages/tasks-for-obsidian/src/data/sync/__tests__/harness.ts|packages/tasks-for-obsidian/src/data/sync/commands.test.ts": {
       "clones": 1,

--- a/packages/tasks-for-obsidian/src/data/api/TaskNotesClient.test.ts
+++ b/packages/tasks-for-obsidian/src/data/api/TaskNotesClient.test.ts
@@ -58,62 +58,51 @@ function scripted(pages: Page[]): {
   };
 }
 
+async function listScriptedTasks(pages: Page[]) {
+  const transport = scripted(pages);
+  const client = new TaskNotesClient({ baseUrl: BASE, fetch: transport.fetch });
+  return { offsets: transport.offsets, result: await client.listTasks() };
+}
+
 describe("listTasks", () => {
   test("pages until hasMore is false, advancing by what it received", async () => {
-    const transport = scripted([
+    const { offsets, result } = await listScriptedTasks([
       { total: 2, paths: ["TaskNotes/a.md"], hasMore: true },
       { total: 2, paths: ["TaskNotes/b.md"], hasMore: false },
     ]);
-    const client = new TaskNotesClient({
-      baseUrl: BASE,
-      fetch: transport.fetch,
-    });
 
-    const result = await client.listTasks();
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.map((task) => String(task.id))).toEqual([
       "TaskNotes/a.md",
       "TaskNotes/b.md",
     ]);
-    expect(transport.offsets()).toEqual(["0", "1"]);
+    expect(offsets()).toEqual(["0", "1"]);
   });
 
   test("a total that moves between pages restarts the pull from the beginning", async () => {
-    const transport = scripted([
+    const { offsets, result } = await listScriptedTasks([
       { total: 2, paths: ["TaskNotes/a.md"], hasMore: true },
       { total: 3, paths: ["TaskNotes/b.md"], hasMore: true },
       { total: 2, paths: ["TaskNotes/a.md"], hasMore: true },
       { total: 2, paths: ["TaskNotes/b.md"], hasMore: false },
     ]);
-    const client = new TaskNotesClient({
-      baseUrl: BASE,
-      fetch: transport.fetch,
-    });
-
-    const result = await client.listTasks();
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value).toHaveLength(2);
-    expect(transport.offsets()).toEqual(["0", "1", "0", "1"]);
+    expect(offsets()).toEqual(["0", "1", "0", "1"]);
   });
 
   test("a task arriving on two pages discards the pass", async () => {
     // A delete ahead of the offset pulls the array back by one, so an item
     // already collected slides into the next page — and the one between them is
     // never seen. The repeat is the only evidence.
-    const transport = scripted([
+    const { result } = await listScriptedTasks([
       { total: 2, paths: ["TaskNotes/a.md"], hasMore: true },
       { total: 2, paths: ["TaskNotes/a.md"], hasMore: false },
       { total: 2, paths: ["TaskNotes/a.md"], hasMore: true },
       { total: 2, paths: ["TaskNotes/b.md"], hasMore: false },
     ]);
-    const client = new TaskNotesClient({
-      baseUrl: BASE,
-      fetch: transport.fetch,
-    });
-
-    const result = await client.listTasks();
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.map((task) => String(task.id))).toEqual([
@@ -126,16 +115,11 @@ describe("listTasks", () => {
     // Every pass ends one task short of the count the server itself declared.
     // Returning it would delete a live task from the app.
     const short: Page = { total: 3, paths: ["TaskNotes/a.md"], hasMore: false };
-    const transport = scripted([short, short, short]);
-    const client = new TaskNotesClient({
-      baseUrl: BASE,
-      fetch: transport.fetch,
-    });
+    const { offsets, result } = await listScriptedTasks([short, short, short]);
 
-    const result = await client.listTasks();
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.message).toContain("changed underneath");
-    expect(transport.offsets()).toHaveLength(3);
+    expect(offsets()).toHaveLength(3);
   });
 });

--- a/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
+++ b/packages/tasks-for-obsidian/src/data/store/TaskStore.test.ts
@@ -33,6 +33,57 @@ function makeStore(
   return { store, queueStorage, storeStorage, queue };
 }
 
+const OCCURRENCE_DATE = "2026-08-08";
+
+type CompletionHarnessOptions = Readonly<{
+  task?: Task;
+  queueStorage?: MemoryQueueStorage;
+  storeStorage?: MemoryStoreStorage;
+}>;
+
+function recurringTask(overrides: Partial<Task> = {}): Task {
+  return makeTask({
+    recurrence: "FREQ=WEEKLY",
+    scheduled: OCCURRENCE_DATE,
+    ...overrides,
+  });
+}
+
+function completionRestore(task: Task) {
+  return {
+    scheduled: task.scheduled ?? null,
+    due: task.due ?? null,
+    recurrence: task.recurrence ?? "",
+    skipped: false,
+  };
+}
+
+async function acknowledgedCompletion(options?: CompletionHarnessOptions) {
+  const task = options?.task ?? recurringTask();
+  const queueStorage = options?.queueStorage ?? memoryQueueStorage();
+  const storeStorage =
+    options?.storeStorage ?? memoryStoreStorage({ tasks: [task] });
+  const harness = makeStore(queueStorage, storeStorage);
+  await harness.store.restore();
+  const restore = completionRestore(task);
+  await harness.store.dispatch({
+    type: "set_instance_complete",
+    taskId: task.id,
+    date: OCCURRENCE_DATE,
+    completed: true,
+    restore,
+  });
+  const command = harness.queue.head();
+  if (command?.type !== "set_instance_complete") {
+    throw new Error("expected completion command");
+  }
+  await harness.store.applyServerAck(command, {
+    ...task,
+    completeInstances: [OCCURRENCE_DATE],
+  });
+  return { ...harness, restore, task };
+}
+
 function commandIds(queue: CommandQueue): string[] {
   return queue.pending.map((c) => c.id);
 }
@@ -289,96 +340,40 @@ describe("TaskStore full pulls", () => {
   });
 
   test("invalidates acknowledged restores after an external recurrence edit", async () => {
-    const task = makeTask({
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
-    });
-    const { store, queue } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore: {
-        scheduled: "2026-08-08",
-        due: null,
-        recurrence: "FREQ=WEEKLY",
-        skipped: false,
-      },
-    });
-    const command = queue.head();
-    if (command?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(command, {
-      ...task,
-      completeInstances: ["2026-08-08"],
-    });
+    const { store, task } = await acknowledgedCompletion();
 
     await store.replaceBase(
       [
         {
           ...task,
           recurrence: "FREQ=MONTHLY",
-          completeInstances: ["2026-08-08"],
+          completeInstances: [OCCURRENCE_DATE],
         },
       ],
       now,
     );
 
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(undefined);
   });
 
   test("invalidates acknowledged restores after an external skip edit", async () => {
-    const task = makeTask({
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
-    });
-    const { store, queue } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore: {
-        scheduled: "2026-08-08",
-        due: null,
-        recurrence: "FREQ=WEEKLY",
-        skipped: false,
-      },
-    });
-    const command = queue.head();
-    if (command?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(command, {
-      ...task,
-      completeInstances: ["2026-08-08"],
-    });
+    const { store, task } = await acknowledgedCompletion();
 
     await store.replaceBase(
       [
         {
           ...task,
-          completeInstances: ["2026-08-08"],
-          skippedInstances: ["2026-08-08"],
+          completeInstances: [OCCURRENCE_DATE],
+          skippedInstances: [OCCURRENCE_DATE],
         },
       ],
       now,
     );
 
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(undefined);
   });
 
@@ -600,40 +595,11 @@ describe("TaskStore restore ordering", () => {
 
 describe("TaskStore restore retention", () => {
   test("retains a restore for an update with unchanged schedule fields", async () => {
-    const task = makeTask({
-      due: "2026-08-10",
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
+    const { store, queue, restore, task } = await acknowledgedCompletion({
+      task: recurringTask({ due: "2026-08-10" }),
     });
-    const { store, queue } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
     const scheduled = task.scheduled ?? null;
     const due = task.due ?? null;
-    const recurrence = task.recurrence ?? "";
-    const restore = {
-      scheduled,
-      due,
-      recurrence,
-      skipped: false,
-    };
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore,
-    });
-    const completion = queue.head();
-    if (completion?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(completion, {
-      ...task,
-      completeInstances: ["2026-08-08"],
-    });
 
     await store.dispatch({
       type: "update",
@@ -641,44 +607,21 @@ describe("TaskStore restore retention", () => {
       payload: { title: "Renamed", due, scheduled },
     });
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(restore);
 
     const edit = queue.head();
     if (edit?.type !== "update") throw new Error("expected edit command");
     await store.applyServerAck(edit, { ...task, title: "Renamed" });
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(restore);
   });
 
   test("treats null and undefined schedule fields as unchanged", async () => {
     const task = makeTask({ recurrence: "FREQ=WEEKLY" });
-    const { store, queue } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
-    const restore = {
-      scheduled: null,
-      due: null,
-      recurrence: "FREQ=WEEKLY",
-      skipped: false,
-    };
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore,
-    });
-    const completion = queue.head();
-    if (completion?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(completion, {
-      ...task,
-      completeInstances: ["2026-08-08"],
+    const { store, queue, restore } = await acknowledgedCompletion({
+      task,
     });
 
     await store.dispatch({
@@ -687,48 +630,19 @@ describe("TaskStore restore retention", () => {
       payload: { title: "Renamed", due: null, scheduled: null },
     });
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(restore);
 
     const edit = queue.head();
     if (edit?.type !== "update") throw new Error("expected edit command");
     await store.applyServerAck(edit, { ...task, title: "Renamed" });
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(restore);
   });
 
   test("retains a restore when a later occurrence edit is dead-lettered", async () => {
-    const task = makeTask({
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
-    });
-    const { store, queue } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
-    const restore = {
-      scheduled: "2026-08-08",
-      due: null,
-      recurrence: "FREQ=WEEKLY",
-      skipped: false,
-    };
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore,
-    });
-    const completion = queue.head();
-    if (completion?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(completion, {
-      ...task,
-      completeInstances: ["2026-08-08"],
-    });
+    const { store, queue, restore, task } = await acknowledgedCompletion();
 
     await store.dispatch({
       type: "update",
@@ -740,7 +654,7 @@ describe("TaskStore restore retention", () => {
     await store.deadLetterCommand(edit.id, new ApiError("invalid", 422));
 
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(restore);
   });
 });
@@ -942,34 +856,12 @@ describe("TaskStore pending restores", () => {
 
   test("persists an acknowledged restore across relaunch", async () => {
     const queueStorage = memoryQueueStorage();
-    const storeStorage = memoryStoreStorage();
-    const task = makeTask({
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
-    });
-    const { store, queue } = makeStore(queueStorage, storeStorage);
-    await store.restore();
-    await store.replaceBase([task], now);
-    const restore = {
-      scheduled: "2026-08-08",
-      due: null,
-      recurrence: "FREQ=WEEKLY",
-      skipped: false,
-    };
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore,
-    });
-    const command = queue.head();
-    if (command?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(command, {
-      ...task,
-      completeInstances: ["2026-08-08"],
+    const task = recurringTask();
+    const storeStorage = memoryStoreStorage({ tasks: [task] });
+    const { restore } = await acknowledgedCompletion({
+      queueStorage,
+      storeStorage,
+      task,
     });
 
     const relaunchedQueue = new CommandQueue(queueStorage.clone(), clock);
@@ -980,41 +872,12 @@ describe("TaskStore pending restores", () => {
     );
     await relaunched.restore();
     await expect(
-      relaunched.getPendingCompletionRestore(task.id, "2026-08-08"),
+      relaunched.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(restore);
   });
 
   test("invalidates an acknowledged restore after recurrence edits", async () => {
-    const task = makeTask({
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
-    });
-    const { store, queue } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
-    const restore = {
-      scheduled: "2026-08-08",
-      due: null,
-      recurrence: "FREQ=WEEKLY",
-      skipped: false,
-    };
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore,
-    });
-    const completionCommand = queue.head();
-    if (completionCommand?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(completionCommand, {
-      ...task,
-      completeInstances: ["2026-08-08"],
-    });
+    const { store, queue, task } = await acknowledgedCompletion();
 
     await store.dispatch({
       type: "update",
@@ -1022,7 +885,7 @@ describe("TaskStore pending restores", () => {
       payload: { recurrence: "FREQ=MONTHLY" },
     });
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(undefined);
     const updateCommand = queue.head();
     if (updateCommand?.type !== "update") {
@@ -1035,47 +898,18 @@ describe("TaskStore pending restores", () => {
     });
 
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(undefined);
   });
 });
 
 describe("TaskStore restore expiry", () => {
   test("prunes acknowledged restores after their occurrence day", async () => {
-    const task = makeTask({
-      recurrence: "FREQ=WEEKLY",
-      scheduled: "2026-08-08",
-    });
-    const { store, queue, storeStorage } = makeStore(
-      memoryQueueStorage(),
-      memoryStoreStorage({ tasks: [task] }),
-    );
-    await store.restore();
-    const restore = {
-      scheduled: "2026-08-08",
-      due: null,
-      recurrence: "FREQ=WEEKLY",
-      skipped: false,
-    };
-    await store.dispatch({
-      type: "set_instance_complete",
-      taskId: task.id,
-      date: "2026-08-08",
-      completed: true,
-      restore,
-    });
-    const command = queue.head();
-    if (command?.type !== "set_instance_complete") {
-      throw new Error("expected completion command");
-    }
-    await store.applyServerAck(command, {
-      ...task,
-      completeInstances: ["2026-08-08"],
-    });
+    const { store, storeStorage, task } = await acknowledgedCompletion();
     now = Date.parse("2026-08-09T12:00:00.000Z");
 
     await expect(
-      store.getPendingCompletionRestore(task.id, "2026-08-08"),
+      store.getPendingCompletionRestore(task.id, OCCURRENCE_DATE),
     ).resolves.toEqual(undefined);
     expect(await storeStorage.getAcknowledgedCompletionRestores()).toBe("{}");
   });


### PR DESCRIPTION
## Why

TaskStore recurrence, completion acknowledgement, relaunch, and TaskNotes paging tests repeated durable setup and command handling. That obscured crash-ordering assertions and carried 1,160 duplicated tokens in the jscpd baseline.

## What

- add typed recurring-task and acknowledged-completion harnesses
- centralize occurrence date and restore construction
- share scripted TaskNotes list execution and response capture
- preserve crash ordering, durability, aliasing, and independent paging expectations
- lower the cumulative jscpd baseline from 61,075 to 59,915 duplicated tokens

## Verification

- `bun --cwd packages/tasks-for-obsidian --no-install --bun vitest --config ../../vitest.config.ts run src/data/store/TaskStore.test.ts src/data/api/TaskNotesClient.test.ts`
- `bunx turbo run test typecheck lint --filter=tasks-for-obsidian`
- `bun run jscpd`
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json` → `59915`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

Native iOS, contract, and live server checks were not run because this is a TypeScript test-only refactor. No media is required for an internal test refactor.