### PR TITLE
refactor(temporal): consolidate failure test scenarios

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1612,10 +1612,6 @@
       "clones": 2,
       "tokens": 194
     },
-    "packages/temporal/src/activities/ha.test.ts|packages/temporal/src/activities/ha.test.ts": {
-      "clones": 6,
-      "tokens": 518
-    },
     "packages/temporal/src/activities/homelab-audit-buildkite.ts|packages/temporal/src/activities/homelab-audit-collectors.ts": {
       "clones": 1,
       "tokens": 78
@@ -1644,10 +1640,6 @@
       "clones": 1,
       "tokens": 100
     },
-    "packages/temporal/src/activities/workflow-failure-watch.test.ts|packages/temporal/src/activities/workflow-failure-watch.test.ts": {
-      "clones": 3,
-      "tokens": 253
-    },
     "packages/temporal/src/event-bridge/agent-task-api.ts|packages/temporal/src/event-bridge/sleep-webhook.ts": {
       "clones": 1,
       "tokens": 70
@@ -1675,10 +1667,6 @@
     "packages/temporal/src/workflows/data-dragon.test.ts|packages/temporal/src/workflows/data-dragon.test.ts": {
       "clones": 1,
       "tokens": 75
-    },
-    "packages/temporal/src/workflows/deps-summary.test.ts|packages/temporal/src/workflows/deps-summary.test.ts": {
-      "clones": 2,
-      "tokens": 235
     },
     "packages/temporal/src/workflows/glitter-corpus.test.ts|packages/temporal/src/workflows/glitter-corpus.test.ts": {
       "clones": 1,

--- a/packages/temporal/src/activities/ha.test.ts
+++ b/packages/temporal/src/activities/ha.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ApplicationFailure } from "@temporalio/common";
 import { HaApiError } from "@shepherdjerred/home-assistant";
 import {
@@ -7,211 +7,129 @@ import {
 } from "#shared/ha-errors.ts";
 import { haActivities } from "./ha.ts";
 
+let originalUrl: string | undefined;
+let originalToken: string | undefined;
+let originalFetch: typeof globalThis.fetch;
+
+function restoreEnvironmentValue(name: "HA_TOKEN" | "HA_URL", value?: string) {
+  if (value === undefined) {
+    if (name === "HA_TOKEN") {
+      delete Bun.env["HA_TOKEN"];
+    } else {
+      delete Bun.env["HA_URL"];
+    }
+  } else {
+    Bun.env[name] = value;
+  }
+}
+
+function configureHaFetch(response: Response): void {
+  Bun.env["HA_URL"] = "http://localhost:8123";
+  Bun.env["HA_TOKEN"] = "test-token";
+  // Bun's fetch carries a `preconnect` member, so the stub has to be widened
+  // with it to satisfy the global's type.
+  globalThis.fetch = Object.assign(
+    (): Promise<Response> => Promise.resolve(response),
+    { preconnect: originalFetch.preconnect.bind(originalFetch) },
+  );
+}
+
 describe("haActivities", () => {
+  beforeEach(() => {
+    originalUrl = Bun.env["HA_URL"];
+    originalToken = Bun.env["HA_TOKEN"];
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreEnvironmentValue("HA_URL", originalUrl);
+    restoreEnvironmentValue("HA_TOKEN", originalToken);
+  });
+
   it("throws when HA_URL is not set", async () => {
-    const originalUrl = Bun.env["HA_URL"];
-    const originalToken = Bun.env["HA_TOKEN"];
     delete Bun.env["HA_URL"];
     delete Bun.env["HA_TOKEN"];
 
-    try {
-      await expect(haActivities.getEntityState("person.test")).rejects.toThrow(
-        "HA_URL environment variable is required",
-      );
-    } finally {
-      if (originalUrl !== undefined) {
-        Bun.env["HA_URL"] = originalUrl;
-      }
-      if (originalToken !== undefined) {
-        Bun.env["HA_TOKEN"] = originalToken;
-      }
-    }
+    await expect(haActivities.getEntityState("person.test")).rejects.toThrow(
+      "HA_URL environment variable is required",
+    );
   });
 
   it("throws when HA_TOKEN is not set", async () => {
-    const originalUrl = Bun.env["HA_URL"];
-    const originalToken = Bun.env["HA_TOKEN"];
     Bun.env["HA_URL"] = "http://localhost:8123";
     delete Bun.env["HA_TOKEN"];
 
-    try {
-      await expect(haActivities.getEntityState("person.test")).rejects.toThrow(
-        "HA_TOKEN environment variable is required",
-      );
-    } finally {
-      if (originalUrl === undefined) {
-        delete Bun.env["HA_URL"];
-      } else {
-        Bun.env["HA_URL"] = originalUrl;
-      }
-      if (originalToken !== undefined) {
-        Bun.env["HA_TOKEN"] = originalToken;
-      }
-    }
+    await expect(haActivities.getEntityState("person.test")).rejects.toThrow(
+      "HA_TOKEN environment variable is required",
+    );
   });
 
   // A bare HaNotFoundError would reach the workflow as an untyped failure. It
   // must stay retryable: HA serves this endpoint before every integration has
   // registered its entities, so a startup/reload 404 is routinely transient.
   it("raises a typed retryable failure for an entity HA does not have", async () => {
-    const originalUrl = Bun.env["HA_URL"];
-    const originalToken = Bun.env["HA_TOKEN"];
-    const originalFetch = globalThis.fetch;
-    Bun.env["HA_URL"] = "http://localhost:8123";
-    Bun.env["HA_TOKEN"] = "test-token";
-    // Bun's fetch carries a `preconnect` member, so the stub has to be widened
-    // with it to satisfy the global's type.
-    globalThis.fetch = Object.assign(
-      (): Promise<Response> =>
-        Promise.resolve(new Response("Entity not found.", { status: 404 })),
-      { preconnect: originalFetch.preconnect.bind(originalFetch) },
-    );
+    configureHaFetch(new Response("Entity not found.", { status: 404 }));
 
+    let failure: unknown;
     try {
-      let failure: unknown;
-      try {
-        await haActivities.getEntityState("sensor.master_bathroom_temperature");
-      } catch (error: unknown) {
-        failure = error;
-      }
-      if (!(failure instanceof ApplicationFailure)) {
-        throw new TypeError("Expected a typed ApplicationFailure");
-      }
-      expect(failure.type).toBe(HA_ENTITY_NOT_FOUND_ERROR_TYPE);
-      expect(failure.nonRetryable).toBe(false);
-      expect(failure.message).toBe(
-        "Home Assistant has no entity sensor.master_bathroom_temperature",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-      if (originalUrl === undefined) {
-        delete Bun.env["HA_URL"];
-      } else {
-        Bun.env["HA_URL"] = originalUrl;
-      }
-      if (originalToken === undefined) {
-        delete Bun.env["HA_TOKEN"];
-      } else {
-        Bun.env["HA_TOKEN"] = originalToken;
-      }
+      await haActivities.getEntityState("sensor.master_bathroom_temperature");
+    } catch (error: unknown) {
+      failure = error;
     }
+    if (!(failure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a typed ApplicationFailure");
+    }
+    expect(failure.type).toBe(HA_ENTITY_NOT_FOUND_ERROR_TYPE);
+    expect(failure.nonRetryable).toBe(false);
+    expect(failure.message).toBe(
+      "Home Assistant has no entity sensor.master_bathroom_temperature",
+    );
   });
 
   it("raises a typed retryable failure for an unavailable optional media player", async () => {
-    const originalUrl = Bun.env["HA_URL"];
-    const originalToken = Bun.env["HA_TOKEN"];
-    const originalFetch = globalThis.fetch;
-    Bun.env["HA_URL"] = "http://localhost:8123";
-    Bun.env["HA_TOKEN"] = "test-token";
-    globalThis.fetch = Object.assign(
-      (): Promise<Response> =>
-        Promise.resolve(
-          new Response(
-            "Sonos entity media_player.master_bathroom unavailable.",
-            { status: 500 },
-          ),
-        ),
-      { preconnect: originalFetch.preconnect.bind(originalFetch) },
+    configureHaFetch(
+      new Response("Sonos entity media_player.master_bathroom unavailable.", {
+        status: 500,
+      }),
     );
 
+    let failure: unknown;
     try {
-      let failure: unknown;
-      try {
-        await haActivities.callOptionalMediaPlayerService("join", {
-          entity_id: "media_player.bedroom",
-          group_members: ["media_player.master_bathroom"],
-        });
-      } catch (error: unknown) {
-        failure = error;
-      }
-      if (!(failure instanceof ApplicationFailure)) {
-        throw new TypeError("Expected a typed ApplicationFailure");
-      }
-      expect(failure.type).toBe(HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE);
-      expect(failure.nonRetryable).toBe(false);
-      expect(failure.message).toBe(
-        "Home Assistant media_player.join is unavailable (500)",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-      if (originalUrl === undefined) {
-        delete Bun.env["HA_URL"];
-      } else {
-        Bun.env["HA_URL"] = originalUrl;
-      }
-      if (originalToken === undefined) {
-        delete Bun.env["HA_TOKEN"];
-      } else {
-        Bun.env["HA_TOKEN"] = originalToken;
-      }
+      await haActivities.callOptionalMediaPlayerService("join", {
+        entity_id: "media_player.bedroom",
+        group_members: ["media_player.master_bathroom"],
+      });
+    } catch (error: unknown) {
+      failure = error;
     }
+    if (!(failure instanceof ApplicationFailure)) {
+      throw new TypeError("Expected a typed ApplicationFailure");
+    }
+    expect(failure.type).toBe(HA_OPTIONAL_MEDIA_PLAYER_ERROR_TYPE);
+    expect(failure.nonRetryable).toBe(false);
+    expect(failure.message).toBe(
+      "Home Assistant media_player.join is unavailable (500)",
+    );
   });
 
-  it("keeps generic missing-entity media-player failures terminal", async () => {
-    const originalUrl = Bun.env["HA_URL"];
-    const originalToken = Bun.env["HA_TOKEN"];
-    const originalFetch = globalThis.fetch;
-    Bun.env["HA_URL"] = "http://localhost:8123";
-    Bun.env["HA_TOKEN"] = "test-token";
-    globalThis.fetch = Object.assign(
-      (): Promise<Response> =>
-        Promise.resolve(new Response("Entity not found.", { status: 404 })),
-      { preconnect: originalFetch.preconnect.bind(originalFetch) },
-    );
+  it.each([
+    {
+      name: "missing-entity",
+      response: new Response("Entity not found.", { status: 404 }),
+    },
+    {
+      name: "generic API",
+      response: new Response("Internal Server Error", { status: 500 }),
+    },
+  ])("keeps $name media-player failures terminal", async ({ response }) => {
+    configureHaFetch(response);
 
-    try {
-      await expect(
-        haActivities.callOptionalMediaPlayerService("join", {
-          entity_id: "media_player.bedroom",
-          group_members: ["media_player.master_bathroom"],
-        }),
-      ).rejects.toBeInstanceOf(HaApiError);
-    } finally {
-      globalThis.fetch = originalFetch;
-      if (originalUrl === undefined) {
-        delete Bun.env["HA_URL"];
-      } else {
-        Bun.env["HA_URL"] = originalUrl;
-      }
-      if (originalToken === undefined) {
-        delete Bun.env["HA_TOKEN"];
-      } else {
-        Bun.env["HA_TOKEN"] = originalToken;
-      }
-    }
-  });
-
-  it("keeps generic media-player API failures terminal", async () => {
-    const originalUrl = Bun.env["HA_URL"];
-    const originalToken = Bun.env["HA_TOKEN"];
-    const originalFetch = globalThis.fetch;
-    Bun.env["HA_URL"] = "http://localhost:8123";
-    Bun.env["HA_TOKEN"] = "test-token";
-    globalThis.fetch = Object.assign(
-      (): Promise<Response> =>
-        Promise.resolve(new Response("Internal Server Error", { status: 500 })),
-      { preconnect: originalFetch.preconnect.bind(originalFetch) },
-    );
-
-    try {
-      await expect(
-        haActivities.callOptionalMediaPlayerService("join", {
-          entity_id: "media_player.bedroom",
-          group_members: ["media_player.master_bathroom"],
-        }),
-      ).rejects.toBeInstanceOf(HaApiError);
-    } finally {
-      globalThis.fetch = originalFetch;
-      if (originalUrl === undefined) {
-        delete Bun.env["HA_URL"];
-      } else {
-        Bun.env["HA_URL"] = originalUrl;
-      }
-      if (originalToken === undefined) {
-        delete Bun.env["HA_TOKEN"];
-      } else {
-        Bun.env["HA_TOKEN"] = originalToken;
-      }
-    }
+    await expect(
+      haActivities.callOptionalMediaPlayerService("join", {
+        entity_id: "media_player.bedroom",
+        group_members: ["media_player.master_bathroom"],
+      }),
+    ).rejects.toBeInstanceOf(HaApiError);
   });
 });

--- a/packages/temporal/src/activities/workflow-failure-watch.test.ts
+++ b/packages/temporal/src/activities/workflow-failure-watch.test.ts
@@ -13,6 +13,7 @@ import {
   buildVisibilityQuery,
   parseAlertTtlMs,
   pollWorkflowFailuresOnce,
+  type PollWorkflowFailuresOptions,
 } from "./workflow-failure-watch.ts";
 import type { WorkflowVisibilityClient } from "#shared/workflow-visibility-client.ts";
 import {
@@ -201,6 +202,39 @@ function capturingPoster(): {
     return Promise.resolve();
   };
   return { poster, calls };
+}
+
+function pollingScenario(client: WorkflowVisibilityClient) {
+  const { poster, calls } = capturingPoster();
+  return {
+    calls,
+    run: (
+      options: Pick<
+        PollWorkflowFailuresOptions,
+        "checkpoint" | "onCheckpoint"
+      > = {},
+    ) =>
+      pollWorkflowFailuresOnce(client, poster, {
+        now: NOW,
+        lookbackMs: LOOKBACK_MS,
+        ttlMs: TTL_MS,
+        ...options,
+      }),
+  };
+}
+
+async function runCheckpointRecovery(
+  executions: ExecutionInfo[],
+  resolverFor: (index: number) => () => Promise<unknown>,
+) {
+  const checkpoints: WorkflowFailureWatchCheckpoint[] = [];
+  const scenario = pollingScenario(
+    clientForExecutions(executions, resolverFor),
+  );
+  const result = await scenario.run({
+    onCheckpoint: (checkpoint) => checkpoints.push(checkpoint),
+  });
+  return { result, calls: scenario.calls, checkpoints };
 }
 
 async function captureFirstFailureDescription(
@@ -1047,13 +1081,9 @@ describe("pollWorkflowFailuresOnce", () => {
       ],
       {},
     );
-    const { poster, calls } = capturingPoster();
+    const scenario = pollingScenario(client);
 
-    const result = await pollWorkflowFailuresOnce(client, poster, {
-      now: NOW,
-      lookbackMs: LOOKBACK_MS,
-      ttlMs: TTL_MS,
-    });
+    const result = await scenario.run();
 
     expect(result).toEqual({
       scanned: 0,
@@ -1061,7 +1091,7 @@ describe("pollWorkflowFailuresOnce", () => {
       errored: 0,
       overflowed: false,
     });
-    expect(calls.length).toBe(0);
+    expect(scenario.calls.length).toBe(0);
   });
 });
 
@@ -1091,13 +1121,9 @@ describe("pollWorkflowFailuresOnce failure handling", () => {
         "wf-2/run-2": rejectWithApplicationFailure("golink 500"),
       },
     );
-    const { poster, calls } = capturingPoster();
+    const scenario = pollingScenario(client);
 
-    const result = await pollWorkflowFailuresOnce(client, poster, {
-      now: NOW,
-      lookbackMs: LOOKBACK_MS,
-      ttlMs: TTL_MS,
-    });
+    const result = await scenario.run();
 
     expect(result).toEqual({
       scanned: 2,
@@ -1105,8 +1131,8 @@ describe("pollWorkflowFailuresOnce failure handling", () => {
       errored: 1,
       overflowed: false,
     });
-    expect(calls[0]?.alerts.length).toBe(1);
-    expect(calls[0]?.alerts[0]?.labels["workflowId"]).toBe("wf-2");
+    expect(scenario.calls[0]?.alerts.length).toBe(1);
+    expect(scenario.calls[0]?.alerts[0]?.labels["workflowId"]).toBe("wf-2");
   });
 
   it("throws when every execution in a non-empty batch fails detail extraction", async () => {
@@ -1125,27 +1151,17 @@ describe("pollWorkflowFailuresOnce failure handling", () => {
         "wf-1/run-1": () => Promise.reject(new Error("gRPC unavailable")),
       },
     );
-    const { poster, calls } = capturingPoster();
+    const scenario = pollingScenario(client);
 
-    await expect(
-      pollWorkflowFailuresOnce(client, poster, {
-        now: NOW,
-        lookbackMs: LOOKBACK_MS,
-        ttlMs: TTL_MS,
-      }),
-    ).rejects.toThrow(/systematic failure/);
-    expect(calls.length).toBe(0);
+    await expect(scenario.run()).rejects.toThrow(/systematic failure/);
+    expect(scenario.calls.length).toBe(0);
   });
 
   it("does not call the poster when nothing failed", async () => {
     const client = fakeClient([], {});
-    const { poster, calls } = capturingPoster();
+    const scenario = pollingScenario(client);
 
-    const result = await pollWorkflowFailuresOnce(client, poster, {
-      now: NOW,
-      lookbackMs: LOOKBACK_MS,
-      ttlMs: TTL_MS,
-    });
+    const result = await scenario.run();
 
     expect(result).toEqual({
       scanned: 0,
@@ -1153,7 +1169,7 @@ describe("pollWorkflowFailuresOnce failure handling", () => {
       errored: 0,
       overflowed: false,
     });
-    expect(calls.length).toBe(0);
+    expect(scenario.calls.length).toBe(0);
   });
 });
 
@@ -1274,61 +1290,43 @@ describe("workflow failure overflow", () => {
 });
 
 describe("bounded workflow failure recovery", () => {
-  it("posts a bounded batch before requesting the rest of the visibility scan", async () => {
-    const executions = closedExecutions(25);
+  it.each([
+    {
+      name: "posts a bounded batch before requesting the rest of the visibility scan",
+      executionCount: 25,
+      expectedBatchSizes: [16, 9],
+    },
+    {
+      name: "posts a partial batch before propagating a visibility scan error",
+      executionCount: 3,
+      expectedBatchSizes: [3],
+    },
+  ])("$name", async ({ executionCount, expectedBatchSizes }) => {
+    const executions = closedExecutions(executionCount);
     const client = clientForExecutions(executions, () =>
       rejectWithApplicationFailure("recovery failure"),
     );
     failListAfterCurrentPage(client, "next visibility page timed out");
-    const { poster, calls } = capturingPoster();
+    const scenario = pollingScenario(client);
 
-    await expect(
-      pollWorkflowFailuresOnce(client, poster, {
-        now: NOW,
-        lookbackMs: LOOKBACK_MS,
-        ttlMs: TTL_MS,
-      }),
-    ).rejects.toThrow("next visibility page timed out");
-
-    expect(calls.map((call) => call.alerts.length)).toEqual([16, 9]);
-  });
-
-  it("posts a partial batch before propagating a visibility scan error", async () => {
-    const executions = closedExecutions(3);
-    const client = clientForExecutions(executions, () =>
-      rejectWithApplicationFailure("recovery failure"),
+    await expect(scenario.run()).rejects.toThrow(
+      "next visibility page timed out",
     );
-    failListAfterCurrentPage(client, "next visibility page timed out");
-    const { poster, calls } = capturingPoster();
 
-    await expect(
-      pollWorkflowFailuresOnce(client, poster, {
-        now: NOW,
-        lookbackMs: LOOKBACK_MS,
-        ttlMs: TTL_MS,
-      }),
-    ).rejects.toThrow("next visibility page timed out");
-
-    expect(calls.length).toBe(1);
-    expect(calls[0]?.alerts.length).toBe(3);
+    expect(scenario.calls.map((call) => call.alerts.length)).toEqual(
+      expectedBatchSizes,
+    );
   });
 
   it("does not checkpoint past an unresolved detail extraction", async () => {
     const executions = closedExecutions(26);
-    const client = clientForExecutions(executions, (index) =>
-      index === 0
-        ? () => Promise.reject(new Error("detail extraction failed"))
-        : rejectWithApplicationFailure("recovery failure"),
+    const { result, calls, checkpoints } = await runCheckpointRecovery(
+      executions,
+      (index) =>
+        index === 0
+          ? () => Promise.reject(new Error("detail extraction failed"))
+          : rejectWithApplicationFailure("recovery failure"),
     );
-    const { poster, calls } = capturingPoster();
-    const checkpoints: WorkflowFailureWatchCheckpoint[] = [];
-
-    const result = await pollWorkflowFailuresOnce(client, poster, {
-      now: NOW,
-      lookbackMs: LOOKBACK_MS,
-      ttlMs: TTL_MS,
-      onCheckpoint: (checkpoint) => checkpoints.push(checkpoint),
-    });
 
     expect(result).toEqual({
       scanned: 26,
@@ -1345,20 +1343,13 @@ describe("bounded workflow failure recovery", () => {
       workflowIdPrefix: "wf-chunk",
       runIdPrefix: "run-chunk",
     });
-    const client = clientForExecutions(executions, (index) =>
-      index === 20
-        ? () => Promise.reject(new Error("detail extraction failed"))
-        : rejectWithApplicationFailure("recovery failure"),
+    const { result, calls, checkpoints } = await runCheckpointRecovery(
+      executions,
+      (index) =>
+        index === 20
+          ? () => Promise.reject(new Error("detail extraction failed"))
+          : rejectWithApplicationFailure("recovery failure"),
     );
-    const { poster, calls } = capturingPoster();
-    const checkpoints: WorkflowFailureWatchCheckpoint[] = [];
-
-    const result = await pollWorkflowFailuresOnce(client, poster, {
-      now: NOW,
-      lookbackMs: LOOKBACK_MS,
-      ttlMs: TTL_MS,
-      onCheckpoint: (checkpoint) => checkpoints.push(checkpoint),
-    });
 
     expect(result).toEqual({
       scanned: 25,

--- a/packages/temporal/src/workflows/deps-summary.test.ts
+++ b/packages/temporal/src/workflows/deps-summary.test.ts
@@ -10,6 +10,7 @@ import { runWithReportWorker } from "./test-support.ts";
 
 const COMMIT_SHA = "a".repeat(40);
 const HEAD_SHA = "b".repeat(40);
+const TASK_QUEUE = TASK_QUEUES.REPO_AUTOMATION;
 
 const CHANGE: DependencyChange = {
   name: "owner/tool",
@@ -36,6 +37,25 @@ const COLLECTION: DependencyCollectionResult = {
   changes: [CHANGE],
 };
 
+const COMPLETE_RELEASE_NOTES = {
+  notes: [
+    {
+      dependency: CHANGE.name,
+      version: CHANGE.newVersion,
+      notes: "Authoritative release notes",
+      url: "https://github.com/owner/tool/releases/tag/2.0.0",
+      source: "github-release",
+    },
+  ],
+  missing: [],
+} as const;
+
+type DependencySummaryTestActivities = {
+  fetchDependencyReleaseNotes: () => unknown;
+  deliverActivityReport: (input: never) => unknown;
+  advanceDependencySummaryCheckpoint: () => unknown;
+};
+
 let testEnvironment: TestWorkflowEnvironment;
 
 beforeAll(async () => {
@@ -46,10 +66,43 @@ afterAll(async () => {
   await testEnvironment.teardown();
 });
 
+async function runDependencySummaryScenario(
+  workflowIdPrefix: string,
+  activities: DependencySummaryTestActivities,
+): Promise<unknown> {
+  const reportTaskQueue = `dependency-summary-test-reports-${crypto.randomUUID()}`;
+  const worker = await Worker.create({
+    connection: testEnvironment.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowsPath: new URL("index.ts", import.meta.url).pathname,
+    activities: {
+      collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
+      fetchDependencyReleaseNotes: activities.fetchDependencyReleaseNotes,
+      synthesizeDependencyChanges: (): undefined => undefined,
+      deliverActivityReport: activities.deliverActivityReport,
+      advanceDependencySummaryCheckpoint:
+        activities.advanceDependencySummaryCheckpoint,
+    },
+  });
+
+  return await runWithReportWorker(
+    testEnvironment,
+    worker,
+    activities.deliverActivityReport,
+    {
+      reportTaskQueue,
+      runWorkflow: () =>
+        testEnvironment.client.workflow.execute(generateDependencySummary, {
+          args: [7, reportTaskQueue],
+          taskQueue: TASK_QUEUE,
+          workflowId: `${workflowIdPrefix}-${crypto.randomUUID()}`,
+        }),
+    },
+  );
+}
+
 describe("dependency summary delivery checkpoint", () => {
   test("reports missing notes as partial before advancing the checkpoint", async () => {
-    const taskQueue = TASK_QUEUES.REPO_AUTOMATION;
-    const reportTaskQueue = `dependency-summary-test-reports-${crypto.randomUUID()}`;
     const reports: ActivityReportInput[] = [];
     const events: string[] = [];
     const deliverActivityReport = (report: ActivityReportInput) => {
@@ -62,57 +115,40 @@ describe("dependency summary delivery checkpoint", () => {
         acceptedAt: "2026-08-10T16:01:00.000Z",
       };
     };
-    const worker = await Worker.create({
-      connection: testEnvironment.nativeConnection,
-      taskQueue: taskQueue,
-      workflowsPath: new URL("index.ts", import.meta.url).pathname,
-      activities: {
-        collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
-        fetchDependencyReleaseNotes: () => ({
-          notes: [],
-          missing: [
-            {
-              dependency: CHANGE.name,
-              commitSha: CHANGE.commitSha,
-              attempts: [
-                {
-                  source: "merged-pr",
-                  url: "https://api.github.com/example",
-                  outcome: "unavailable",
-                  detail: "No associated merged PR",
-                },
-                {
-                  source: "github-release",
-                  url: "https://github.com/owner/tool/releases",
-                  outcome: "unavailable",
-                  detail: "No release body",
-                },
-                {
-                  source: "catalog-override",
-                  url: undefined,
-                  outcome: "unavailable",
-                  detail: "No explicit override",
-                },
-              ],
-            },
-          ],
-        }),
-        synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport,
-        advanceDependencySummaryCheckpoint: (): void => {
-          events.push("checkpoint");
-        },
+    await runDependencySummaryScenario("dependency-summary-partial", {
+      fetchDependencyReleaseNotes: () => ({
+        notes: [],
+        missing: [
+          {
+            dependency: CHANGE.name,
+            commitSha: CHANGE.commitSha,
+            attempts: [
+              {
+                source: "merged-pr",
+                url: "https://api.github.com/example",
+                outcome: "unavailable",
+                detail: "No associated merged PR",
+              },
+              {
+                source: "github-release",
+                url: "https://github.com/owner/tool/releases",
+                outcome: "unavailable",
+                detail: "No release body",
+              },
+              {
+                source: "catalog-override",
+                url: undefined,
+                outcome: "unavailable",
+                detail: "No explicit override",
+              },
+            ],
+          },
+        ],
+      }),
+      deliverActivityReport,
+      advanceDependencySummaryCheckpoint: (): void => {
+        events.push("checkpoint");
       },
-    });
-
-    await runWithReportWorker(testEnvironment, worker, deliverActivityReport, {
-      reportTaskQueue,
-      runWorkflow: () =>
-        testEnvironment.client.workflow.execute(generateDependencySummary, {
-          args: [7, reportTaskQueue],
-          taskQueue: taskQueue,
-          workflowId: `dependency-summary-partial-${crypto.randomUUID()}`,
-        }),
     });
 
     expect(events).toEqual(["deliver-partial", "checkpoint"]);
@@ -125,53 +161,21 @@ describe("dependency summary delivery checkpoint", () => {
   }, 30_000);
 
   test("does not advance the checkpoint when delivery is not accepted", async () => {
-    const taskQueue = TASK_QUEUES.REPO_AUTOMATION;
-    const reportTaskQueue = `dependency-summary-test-reports-${crypto.randomUUID()}`;
     const events: string[] = [];
     const deliverActivityReport = (): never => {
       events.push("deliver-failed");
       throw new Error("Postal unavailable");
     };
-    const worker = await Worker.create({
-      connection: testEnvironment.nativeConnection,
-      taskQueue: taskQueue,
-      workflowsPath: new URL("index.ts", import.meta.url).pathname,
-      activities: {
-        collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
-        fetchDependencyReleaseNotes: () => ({
-          notes: [
-            {
-              dependency: CHANGE.name,
-              version: CHANGE.newVersion,
-              notes: "Authoritative release notes",
-              url: "https://github.com/owner/tool/releases/tag/2.0.0",
-              source: "github-release",
-            },
-          ],
-          missing: [],
-        }),
-        synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport,
-        advanceDependencySummaryCheckpoint: (): void => {
-          events.push("checkpoint");
-        },
-      },
-    });
-
     let failure: unknown;
     try {
-      await runWithReportWorker(
-        testEnvironment,
-        worker,
-        deliverActivityReport,
+      await runDependencySummaryScenario(
+        "dependency-summary-delivery-failure",
         {
-          reportTaskQueue,
-          runWorkflow: () =>
-            testEnvironment.client.workflow.execute(generateDependencySummary, {
-              args: [7, reportTaskQueue],
-              taskQueue: taskQueue,
-              workflowId: `dependency-summary-delivery-failure-${crypto.randomUUID()}`,
-            }),
+          fetchDependencyReleaseNotes: () => COMPLETE_RELEASE_NOTES,
+          deliverActivityReport,
+          advanceDependencySummaryCheckpoint: (): void => {
+            events.push("checkpoint");
+          },
         },
       );
     } catch (error: unknown) {
@@ -184,8 +188,6 @@ describe("dependency summary delivery checkpoint", () => {
   }, 30_000);
 
   test("retries checkpoint persistence without redelivering the report", async () => {
-    const taskQueue = TASK_QUEUES.REPO_AUTOMATION;
-    const reportTaskQueue = `dependency-summary-test-reports-${crypto.randomUUID()}`;
     let deliveryCalls = 0;
     let checkpointCalls = 0;
     const deliverActivityReport = () => {
@@ -197,43 +199,15 @@ describe("dependency summary delivery checkpoint", () => {
         acceptedAt: "2026-08-10T16:01:00.000Z",
       };
     };
-    const worker = await Worker.create({
-      connection: testEnvironment.nativeConnection,
-      taskQueue: taskQueue,
-      workflowsPath: new URL("index.ts", import.meta.url).pathname,
-      activities: {
-        collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
-        fetchDependencyReleaseNotes: () => ({
-          notes: [
-            {
-              dependency: CHANGE.name,
-              version: CHANGE.newVersion,
-              notes: "Authoritative release notes",
-              url: "https://github.com/owner/tool/releases/tag/2.0.0",
-              source: "github-release",
-            },
-          ],
-          missing: [],
-        }),
-        synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport,
-        advanceDependencySummaryCheckpoint: (): void => {
-          checkpointCalls += 1;
-          if (checkpointCalls < 3) {
-            throw new Error("temporary checkpoint storage failure");
-          }
-        },
+    await runDependencySummaryScenario("dependency-summary-checkpoint-retry", {
+      fetchDependencyReleaseNotes: () => COMPLETE_RELEASE_NOTES,
+      deliverActivityReport,
+      advanceDependencySummaryCheckpoint: (): void => {
+        checkpointCalls += 1;
+        if (checkpointCalls < 3) {
+          throw new Error("temporary checkpoint storage failure");
+        }
       },
-    });
-
-    await runWithReportWorker(testEnvironment, worker, deliverActivityReport, {
-      reportTaskQueue,
-      runWorkflow: () =>
-        testEnvironment.client.workflow.execute(generateDependencySummary, {
-          args: [7, reportTaskQueue],
-          taskQueue: taskQueue,
-          workflowId: `dependency-summary-checkpoint-retry-${crypto.randomUUID()}`,
-        }),
     });
 
     expect(deliveryCalls).toBe(1);
@@ -243,8 +217,6 @@ describe("dependency summary delivery checkpoint", () => {
 
 describe("dependency summary checkpoint failure reporting", () => {
   test("reports a distinct failure after accepted delivery when checkpoint retries exhaust", async () => {
-    const taskQueue = TASK_QUEUES.REPO_AUTOMATION;
-    const reportTaskQueue = `dependency-summary-test-reports-${crypto.randomUUID()}`;
     const reports: ActivityReportInput[] = [];
     let checkpointCalls = 0;
     const deliverActivityReport = (report: ActivityReportInput) => {
@@ -259,47 +231,17 @@ describe("dependency summary checkpoint failure reporting", () => {
         acceptedAt: "2026-08-10T16:01:00.000Z",
       };
     };
-    const worker = await Worker.create({
-      connection: testEnvironment.nativeConnection,
-      taskQueue: taskQueue,
-      workflowsPath: new URL("index.ts", import.meta.url).pathname,
-      activities: {
-        collectDependencyChanges: (): DependencyCollectionResult => COLLECTION,
-        fetchDependencyReleaseNotes: () => ({
-          notes: [
-            {
-              dependency: CHANGE.name,
-              version: CHANGE.newVersion,
-              notes: "Authoritative release notes",
-              url: "https://github.com/owner/tool/releases/tag/2.0.0",
-              source: "github-release",
-            },
-          ],
-          missing: [],
-        }),
-        synthesizeDependencyChanges: (): undefined => undefined,
-        deliverActivityReport,
-        advanceDependencySummaryCheckpoint: (): never => {
-          checkpointCalls += 1;
-          throw new Error("persistent checkpoint storage failure");
-        },
-      },
-    });
-
     let failure: unknown;
     try {
-      await runWithReportWorker(
-        testEnvironment,
-        worker,
-        deliverActivityReport,
+      await runDependencySummaryScenario(
+        "dependency-summary-checkpoint-exhausted",
         {
-          reportTaskQueue,
-          runWorkflow: () =>
-            testEnvironment.client.workflow.execute(generateDependencySummary, {
-              args: [7, reportTaskQueue],
-              taskQueue: taskQueue,
-              workflowId: `dependency-summary-checkpoint-exhausted-${crypto.randomUUID()}`,
-            }),
+          fetchDependencyReleaseNotes: () => COMPLETE_RELEASE_NOTES,
+          deliverActivityReport,
+          advanceDependencySummaryCheckpoint: (): never => {
+            checkpointCalls += 1;
+            throw new Error("persistent checkpoint storage failure");
+          },
         },
       );
     } catch (error: unknown) {


### PR DESCRIPTION
## Why

Temporal activity and workflow tests repeated environment restoration, polling setup, and worker construction across equivalent scenarios. The duplication consumed 1,006 tokens in the jscpd baseline and made test setup changes error-prone.

## What

- Centralize Home Assistant environment and fetch cleanup.
- Share workflow-failure polling, recovery, and checkpoint test helpers.
- Extract the dependency-summary worker harness and canonical release-note fixture.
- Preserve scenario-specific assertions while removing all eleven targeted clones.
- Lower the cumulative jscpd baseline from 59,915 to 58,909 duplicated tokens.

## Verification

- `bun --bun vitest run src/activities/ha.test.ts src/activities/workflow-failure-watch.test.ts`
- `bun run scripts/test-workflows.ts src/workflows/deps-summary.test.ts`
- `bunx turbo run test typecheck lint --filter=@shepherdjerred/temporal`
- `bun run jscpd` before update reported only the three removed self-pairs
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json` → `58909`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No live Temporal service verification was run; these are test-only refactors. No media is required for this non-visual change.