### PR TITLE
refactor(scout-for-lol): share visualization test fixtures

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1352,18 +1352,6 @@
       "clones": 1,
       "tokens": 97
     },
-    "packages/scout-for-lol/packages/report/src/html/visualization-snapshot-distribution-option.test.ts|packages/scout-for-lol/packages/report/src/html/visualization-snapshot-distribution-option.test.ts": {
-      "clones": 1,
-      "tokens": 97
-    },
-    "packages/scout-for-lol/packages/report/src/html/visualization-snapshot-distribution-option.test.ts|packages/scout-for-lol/packages/report/src/html/visualization-snapshot-special-options.test.ts": {
-      "clones": 1,
-      "tokens": 83
-    },
-    "packages/scout-for-lol/packages/report/src/html/visualization-snapshot-option.test.ts|packages/scout-for-lol/packages/report/src/html/visualization-snapshot-option.test.ts": {
-      "clones": 4,
-      "tokens": 326
-    },
     "packages/scout-for-lol/packages/ui/src/components/sound-pack-editor/rule-editor.tsx|packages/scout-for-lol/packages/ui/src/components/sound-pack-editor/sound-pool-editor.tsx": {
       "clones": 1,
       "tokens": 75

--- a/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-distribution-option.test.ts
+++ b/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-distribution-option.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import {
-  VisualizationSnapshotSchema,
   type TemporalSeries,
   type VisualizationSnapshot,
 } from "@scout-for-lol/data";
@@ -9,6 +8,7 @@ import {
   histogramOption,
 } from "#src/html/visualization-snapshot-distribution-option.ts";
 import { visualizationSnapshotToOption } from "#src/html/visualization-snapshot-option.ts";
+import { visualizationSnapshotFixture } from "#src/html/visualization-snapshot-test-fixtures.ts";
 
 describe("histogram visualization options", () => {
   test("renders bucket labels and counts as gapless bars in query order", () => {
@@ -129,13 +129,24 @@ describe("distribution rendering modes", () => {
     expect(JSON.stringify(boxPlot)).toContain('"type":"boxplot"');
   });
 
-  test("keeps histogram data identical across interactive and static modes", () => {
-    const input = snapshot("HISTOGRAM", [
-      series("duration", "Games", [
-        ["b0", "0–299", 4],
-        ["b1", "300–599", 11],
+  test.each([
+    {
+      name: "histogram",
+      input: snapshot("HISTOGRAM", [
+        series("duration", "Games", [
+          ["b0", "0–299", 4],
+          ["b1", "300–599", 11],
+        ]),
       ]),
-    ]);
+    },
+    {
+      name: "box plot",
+      input: boxPlotSnapshot([
+        ["b1", "Ahri", 1],
+        ["b2", "Garen", 10],
+      ]),
+    },
+  ])("keeps $name data identical across rendering modes", ({ input }) => {
     const staticOption = visualizationSnapshotToOption(input, "static");
     const interactiveOption = visualizationSnapshotToOption(
       input,
@@ -151,27 +162,6 @@ describe("distribution rendering modes", () => {
     expect(interactiveOption.dataZoom).toBeDefined();
     expect(staticOption.dataZoom).toBeUndefined();
     expect(staticOption.toolbox).toBeUndefined();
-  });
-
-  test("keeps box plot data identical across interactive and static modes", () => {
-    const input = boxPlotSnapshot([
-      ["b1", "Ahri", 1],
-      ["b2", "Garen", 10],
-    ]);
-    const staticOption = visualizationSnapshotToOption(input, "static");
-    const interactiveOption = visualizationSnapshotToOption(
-      input,
-      "interactive",
-    );
-
-    expect(JSON.stringify(interactiveOption.series)).toBe(
-      JSON.stringify(staticOption.series),
-    );
-    expect(JSON.stringify(interactiveOption.xAxis)).toBe(
-      JSON.stringify(staticOption.xAxis),
-    );
-    expect(interactiveOption.dataZoom).toBeDefined();
-    expect(staticOption.dataZoom).toBeUndefined();
   });
 });
 
@@ -205,29 +195,10 @@ function boxPlotSnapshot(
 }
 
 function snapshot(
-  kind: string,
+  kind: VisualizationSnapshot["kind"],
   seriesItems: TemporalSeries[],
 ): VisualizationSnapshot {
-  return VisualizationSnapshotSchema.parse({
-    version: 1,
-    generatedAt: "2026-08-08T00:00:00.000Z",
-    kind,
-    title: null,
-    temporal: null,
-    bucket: null,
-    display: {
-      theme: null,
-      palette: null,
-      smooth: false,
-      stack: "none",
-      rollingWindow: null,
-      cumulative: false,
-      sparkline: false,
-    },
-    series: seriesItems,
-    annotations: [],
-    trends: [],
-  });
+  return visualizationSnapshotFixture({ kind, series: seriesItems });
 }
 
 function series(

--- a/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-option.test.ts
+++ b/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-option.test.ts
@@ -9,29 +9,18 @@ import {
   formatSnapshotAxisValue,
   usesPercentageAxis,
 } from "#src/html/visualization-value-format.ts";
+import { visualizationSnapshotFixture as snapshotFixture } from "#src/html/visualization-snapshot-test-fixtures.ts";
 
 describe("visualizationSnapshotToOption", () => {
   test("does not add a baseline series without a comparison", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "LINE_CHART",
-      title: null,
       temporal: {
         window: { kind: "relative", days: 30 },
         bucket: "day",
         timezone: "UTC",
       },
       bucket: "day",
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [
         {
           id: "games",
@@ -53,8 +42,6 @@ describe("visualizationSnapshotToOption", () => {
           ],
         },
       ],
-      annotations: [],
-      trends: [],
     });
 
     expect(
@@ -75,11 +62,8 @@ describe("visualizationSnapshotToOption", () => {
       evidence: { sampleSize: 2, confidenceInterval: null },
       comparisonEvidence: { sampleSize: 1, confidenceInterval: null },
     };
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "LINE_CHART",
-      title: null,
       temporal: {
         window: { kind: "relative", days: 30 },
         bucket: "day",
@@ -87,15 +71,6 @@ describe("visualizationSnapshotToOption", () => {
         timezone: "UTC",
       },
       bucket: "day",
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [
         {
           id: "games",
@@ -112,8 +87,6 @@ describe("visualizationSnapshotToOption", () => {
           points: [point],
         },
       ],
-      annotations: [],
-      trends: [],
     });
 
     const option = JSON.stringify(
@@ -263,11 +236,8 @@ describe("temporal chart rendering", () => {
   });
 
   test("formats rate values and absolute deltas as percentages", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "LINE_CHART",
-      title: null,
       temporal: {
         window: { kind: "relative", days: 30 },
         bucket: "day",
@@ -275,15 +245,6 @@ describe("temporal chart rendering", () => {
         timezone: "UTC",
       },
       bucket: "day",
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [
         {
           id: "win-rate",
@@ -310,8 +271,6 @@ describe("temporal chart rendering", () => {
           ],
         },
       ],
-      annotations: [],
-      trends: [],
     });
 
     const tooltip = tooltipText(snapshot, { dataIndex: 0 });
@@ -325,26 +284,14 @@ describe("temporal chart rendering", () => {
   });
 
   test("places annotations only in the bucket containing their timestamp", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "LINE_CHART",
-      title: null,
       temporal: {
         window: { kind: "relative", days: 2 },
         bucket: "day",
         timezone: "UTC",
       },
       bucket: "day",
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [
         {
           id: "games",
@@ -368,7 +315,6 @@ describe("temporal chart rendering", () => {
           label: "Outside range",
         },
       ],
-      trends: [],
     });
 
     const option = JSON.stringify(
@@ -437,22 +383,8 @@ describe("archived chart presentation", () => {
 
 describe("scatter chart rendering", () => {
   test("omits points whose configured x output is null or missing", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "SCATTER_CHART",
-      title: null,
-      temporal: null,
-      bucket: null,
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [
         {
           id: "damage",
@@ -466,8 +398,6 @@ describe("scatter chart rendering", () => {
           ],
         },
       ],
-      annotations: [],
-      trends: [],
     });
 
     const option = JSON.stringify(
@@ -479,22 +409,8 @@ describe("scatter chart rendering", () => {
   });
 
   test("resolves tooltips through the hovered series data order", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "SCATTER_CHART",
-      title: null,
-      temporal: null,
-      bucket: null,
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [
         {
           id: "alpha",
@@ -514,8 +430,6 @@ describe("scatter chart rendering", () => {
           ],
         },
       ],
-      annotations: [],
-      trends: [],
     });
 
     const tooltip = tooltipText(snapshot, {
@@ -544,22 +458,9 @@ test("adds a thin-data subtitle to rate charts", () => {
 });
 
 function rateSnapshot(games: number) {
-  return VisualizationSnapshotSchema.parse({
-    version: 1,
-    generatedAt: "2026-08-08T00:00:00.000Z",
+  return snapshotFixture({
     kind: "LINE_CHART",
     title: "Win rate",
-    temporal: null,
-    bucket: null,
-    display: {
-      theme: null,
-      palette: null,
-      smooth: false,
-      stack: "none",
-      rollingWindow: null,
-      cumulative: false,
-      sparkline: false,
-    },
     series: [
       {
         id: "win-rate",
@@ -578,8 +479,6 @@ function rateSnapshot(games: number) {
         ],
       },
     ],
-    annotations: [],
-    trends: [],
   });
 }
 
@@ -626,11 +525,9 @@ function patchSeries(id: string, labels: string[]) {
 
 describe("calendar visualization options", () => {
   test("uses the archived temporal range for an empty calendar", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
+    const snapshot = snapshotFixture({
       generatedAt: "2027-08-08T00:00:00.000Z",
       kind: "CALENDAR_HEATMAP",
-      title: null,
       temporal: {
         window: {
           kind: "calendar",
@@ -641,18 +538,7 @@ describe("calendar visualization options", () => {
         timezone: "UTC",
       },
       bucket: "day",
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [],
-      annotations: [],
-      trends: [],
     });
 
     expect(
@@ -661,11 +547,8 @@ describe("calendar visualization options", () => {
   });
 
   test("shows calendar baselines and deltas in comparison tooltips", () => {
-    const snapshot = VisualizationSnapshotSchema.parse({
-      version: 1,
-      generatedAt: "2026-08-08T00:00:00.000Z",
+    const snapshot = snapshotFixture({
       kind: "CALENDAR_HEATMAP",
-      title: null,
       temporal: {
         window: { kind: "relative", days: 30 },
         bucket: "day",
@@ -673,18 +556,7 @@ describe("calendar visualization options", () => {
         timezone: "UTC",
       },
       bucket: "day",
-      display: {
-        theme: null,
-        palette: null,
-        smooth: false,
-        stack: "none",
-        rollingWindow: null,
-        cumulative: false,
-        sparkline: false,
-      },
       series: [],
-      annotations: [],
-      trends: [],
     });
 
     const tooltip = calendarTooltipText(snapshot, {

--- a/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-special-options.test.ts
+++ b/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-special-options.test.ts
@@ -1,20 +1,21 @@
 import { describe, expect, test } from "vitest";
-import {
-  VisualizationSnapshotSchema,
-  type TemporalSeries,
-} from "@scout-for-lol/data";
+import { type TemporalSeries } from "@scout-for-lol/data";
 import {
   donutOption,
   radarOption,
 } from "#src/html/visualization-snapshot-special-options.ts";
+import { visualizationSnapshotFixture as snapshot } from "#src/html/visualization-snapshot-test-fixtures.ts";
 
 describe("visualization snapshot special options", () => {
   test("renders every multidimensional donut series", () => {
     const option = donutOption(
-      snapshot("DONUT_CHART", [
-        series("solo — games", "games", [["Ahri", 3]]),
-        series("flex — games", "games", [["Garen", 2]]),
-      ]),
+      snapshot({
+        kind: "DONUT_CHART",
+        series: [
+          series("solo — games", "games", [["Ahri", 3]]),
+          series("flex — games", "games", [["Garen", 2]]),
+        ],
+      }),
     );
     const json = JSON.stringify(option);
 
@@ -24,20 +25,23 @@ describe("visualization snapshot special options", () => {
 
   test("uses selected metrics as radar axes and grouped rows as polygons", () => {
     const option = radarOption(
-      snapshot("RADAR_CHART", [
-        series("games", "games", [
-          ["Alpha", 10],
-          ["Beta", 5],
-        ]),
-        series("wins", "wins", [
-          ["Alpha", 7],
-          ["Beta", 2],
-        ]),
-        series("win_rate", "win_rate", [
-          ["Alpha", 0.7],
-          ["Beta", 0.4],
-        ]),
-      ]),
+      snapshot({
+        kind: "RADAR_CHART",
+        series: [
+          series("games", "games", [
+            ["Alpha", 10],
+            ["Beta", 5],
+          ]),
+          series("wins", "wins", [
+            ["Alpha", 7],
+            ["Beta", 2],
+          ]),
+          series("win_rate", "win_rate", [
+            ["Alpha", 0.7],
+            ["Beta", 0.4],
+          ]),
+        ],
+      }),
     );
     const json = JSON.stringify(option);
 
@@ -48,29 +52,6 @@ describe("visualization snapshot special options", () => {
     expect(json).toContain('"name":"Beta","value":[5,2,0.4]');
   });
 });
-
-function snapshot(kind: string, seriesItems: TemporalSeries[]) {
-  return VisualizationSnapshotSchema.parse({
-    version: 1,
-    generatedAt: "2026-08-08T00:00:00.000Z",
-    kind,
-    title: null,
-    temporal: null,
-    bucket: null,
-    display: {
-      theme: null,
-      palette: null,
-      smooth: false,
-      stack: "none",
-      rollingWindow: null,
-      cumulative: false,
-      sparkline: false,
-    },
-    series: seriesItems,
-    annotations: [],
-    trends: [],
-  });
-}
 
 function series(
   label: string,

--- a/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-test-fixtures.ts
+++ b/packages/scout-for-lol/packages/report/src/html/visualization-snapshot-test-fixtures.ts
@@ -1,0 +1,32 @@
+import {
+  VisualizationSnapshotSchema,
+  type VisualizationSnapshot,
+} from "@scout-for-lol/data";
+
+type SnapshotFixtureInput = Pick<VisualizationSnapshot, "kind" | "series"> &
+  Partial<Omit<VisualizationSnapshot, "kind" | "series" | "version">>;
+
+export function visualizationSnapshotFixture(
+  input: SnapshotFixtureInput,
+): VisualizationSnapshot {
+  return VisualizationSnapshotSchema.parse({
+    version: 1,
+    generatedAt: "2026-08-08T00:00:00.000Z",
+    title: null,
+    temporal: null,
+    bucket: null,
+    annotations: [],
+    trends: [],
+    ...input,
+    display: {
+      theme: null,
+      palette: null,
+      smooth: false,
+      stack: "none",
+      rollingWindow: null,
+      cumulative: false,
+      sparkline: false,
+      ...input.display,
+    },
+  });
+}


### PR DESCRIPTION
## Why

Visualization option tests repeated complete snapshot envelopes and identical rendering-mode comparison scenarios. Those six clones accounted for 506 duplicated tokens in the jscpd baseline.

## What

- Add a typed, test-only visualization snapshot fixture.
- Reuse it across temporal, scatter, calendar, distribution, donut, and radar scenarios.
- Table-drive the common static-versus-interactive distribution assertions while retaining independent expected inputs.
- Lower the cumulative jscpd baseline from 58,408 to 57,902 duplicated tokens.

## Verification

- `bun --no-install --bun vitest --config ../../../../vitest.config.ts run src/html/visualization-snapshot-option.test.ts src/html/visualization-snapshot-distribution-option.test.ts src/html/visualization-snapshot-special-options.test.ts`
- `bunx turbo run test typecheck lint --filter=@scout-for-lol/report`
- `bun run jscpd` before update reported only the three removed visualization test pairs
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json` → `57902`
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No rendered output or production behavior changes. No media is required for this test-only refactor.