### PR TITLE
refactor(temporal): consolidate remaining fixture tests

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -1564,10 +1564,6 @@
       "clones": 1,
       "tokens": 90
     },
-    "packages/temporal/src/activities/agent-task.test.ts|packages/temporal/src/activities/agent-task.test.ts": {
-      "clones": 1,
-      "tokens": 75
-    },
     "packages/temporal/src/activities/check-pr-merge-conflicts-git.ts|packages/temporal/src/activities/data-dragon.ts": {
       "clones": 1,
       "tokens": 76
@@ -1608,29 +1604,13 @@
       "clones": 1,
       "tokens": 95
     },
-    "packages/temporal/src/activities/report-delivery.test.ts|packages/temporal/src/activities/report-delivery.test.ts": {
-      "clones": 1,
-      "tokens": 70
-    },
     "packages/temporal/src/activities/report-freshness.ts|packages/temporal/src/activities/tasknotes-canary.ts": {
       "clones": 1,
       "tokens": 105
     },
-    "packages/temporal/src/activities/scout-generated-preflight.test.ts|packages/temporal/src/activities/scout-generated-preflight.test.ts": {
-      "clones": 2,
-      "tokens": 158
-    },
-    "packages/temporal/src/activities/scout-season-refresh-git.integration.test.ts|packages/temporal/src/activities/scout-season-refresh-git.integration.test.ts": {
-      "clones": 1,
-      "tokens": 100
-    },
     "packages/temporal/src/event-bridge/agent-task-api.ts|packages/temporal/src/event-bridge/sleep-webhook.ts": {
       "clones": 1,
       "tokens": 70
-    },
-    "packages/temporal/src/event-bridge/github-webhook.test.ts|packages/temporal/src/event-bridge/github-webhook.test.ts": {
-      "clones": 1,
-      "tokens": 74
     },
     "packages/temporal/src/event-bridge/sleep-webhook.ts|packages/temporal/src/event-bridge/xcode-cloud-webhook.ts": {
       "clones": 1,
@@ -1644,17 +1624,9 @@
       "clones": 1,
       "tokens": 143
     },
-    "packages/temporal/src/shared/llm-catalog-alert.test.ts|packages/temporal/src/shared/llm-catalog-alert.test.ts": {
-      "clones": 1,
-      "tokens": 91
-    },
     "packages/temporal/src/workflows/data-dragon.test.ts|packages/temporal/src/workflows/data-dragon.test.ts": {
       "clones": 1,
       "tokens": 75
-    },
-    "packages/temporal/src/workflows/glitter-corpus.test.ts|packages/temporal/src/workflows/glitter-corpus.test.ts": {
-      "clones": 1,
-      "tokens": 78
     },
     "packages/temporal/src/workflows/test-support.ts|packages/temporal/src/workflows/test-support.ts": {
       "clones": 1,

--- a/packages/temporal/src/activities/agent-task.test.ts
+++ b/packages/temporal/src/activities/agent-task.test.ts
@@ -67,6 +67,20 @@ async function testWorkdir(): Promise<string> {
   return await mkdtemp(path.join(os.tmpdir(), "agent-task-test-"));
 }
 
+async function captureRunFailure(
+  activities: ReturnType<typeof createTestAgentTaskActivities>,
+): Promise<unknown> {
+  try {
+    await activities.runAgentTask({
+      input: baseInput,
+      workdir: await testWorkdir(),
+    });
+  } catch (error: unknown) {
+    return error;
+  }
+  throw new Error("expected agent task to fail");
+}
+
 // runAgent builds a real provider environment, which fails fast without the
 // provider's OpenRouter credential.
 const originalOpenRouterCredential = Bun.env["OPENROUTER_API_KEY"];
@@ -263,15 +277,7 @@ describe("agent task runtime support", () => {
       });
     });
 
-    let caught: unknown;
-    try {
-      await activities.runAgentTask({
-        input: baseInput,
-        workdir: await testWorkdir(),
-      });
-    } catch (error: unknown) {
-      caught = error;
-    }
+    const caught = await captureRunFailure(activities);
     expect(caught).toBeInstanceOf(ApplicationFailure);
     expect(
       caught instanceof ApplicationFailure ? caught.nonRetryable : false,
@@ -286,15 +292,7 @@ describe("agent task runtime support", () => {
       Promise.resolve(sdkResult("codex", { markdown: "" })),
     );
 
-    let caught: unknown;
-    try {
-      await activities.runAgentTask({
-        input: baseInput,
-        workdir: await testWorkdir(),
-      });
-    } catch (error: unknown) {
-      caught = error;
-    }
+    const caught = await captureRunFailure(activities);
     expect(caught).toBeInstanceOf(ApplicationFailure);
     expect(
       caught instanceof ApplicationFailure ? caught.nonRetryable : false,
@@ -313,15 +311,7 @@ describe("agent task runtime support", () => {
       Promise.resolve(sdkResult("codex", undefined)),
     );
 
-    let caught: unknown;
-    try {
-      await activities.runAgentTask({
-        input: baseInput,
-        workdir: await testWorkdir(),
-      });
-    } catch (error: unknown) {
-      caught = error;
-    }
+    const caught = await captureRunFailure(activities);
     expect(caught instanceof Error ? caught.message : "").toContain(
       "missing-structured-output",
     );

--- a/packages/temporal/src/activities/report-delivery.test.ts
+++ b/packages/temporal/src/activities/report-delivery.test.ts
@@ -228,6 +228,21 @@ function heldBy(owner: string, claimedAt: string): Map<string, StoredClaim> {
   ]);
 }
 
+function installSuccessorClaim(
+  claims: Map<string, StoredClaim>,
+  claimKey: string,
+): void {
+  claims.set(claimKey, {
+    claim: {
+      schemaVersion: 1,
+      reportRunId: report().reportRunId,
+      owner: "workflow/run-1/activity-1/2",
+      claimedAt: NOW,
+    },
+    etag: "etag-successor",
+  });
+}
+
 describe("report send ownership", () => {
   test("refuses to resend while another attempt still owns the send", async () => {
     // Attempt 1 wrote `pending` and sent, then stalled past start-to-close.
@@ -383,15 +398,7 @@ describe("report send ownership", () => {
       send: async (input: PostalSendInput) => {
         const result = await owner.send(input);
         // A successor takes the lease while this attempt is still persisting.
-        claims.set(claimKey, {
-          claim: {
-            schemaVersion: 1 as const,
-            reportRunId: report().reportRunId,
-            owner: "workflow/run-1/activity-1/2",
-            claimedAt: NOW,
-          },
-          etag: "etag-successor",
-        });
+        installSuccessorClaim(claims, claimKey);
         return result;
       },
     };
@@ -421,15 +428,7 @@ describe("report send ownership", () => {
         const result = await owner.send(input);
         // The successor takes the lease AND records its delivery after this
         // attempt's ownership check has already passed.
-        claims.set(claimKey, {
-          claim: {
-            schemaVersion: 1 as const,
-            reportRunId: report().reportRunId,
-            owner: "workflow/run-1/activity-1/2",
-            claimedAt: NOW,
-          },
-          etag: "etag-successor",
-        });
+        installSuccessorClaim(claims, claimKey);
         await owner.backend.writeReceipt(receiptKey, {
           schemaVersion: 1,
           reportRunId: report().reportRunId,

--- a/packages/temporal/src/activities/scout-generated-preflight.test.ts
+++ b/packages/temporal/src/activities/scout-generated-preflight.test.ts
@@ -81,6 +81,22 @@ describe("discardFormattingOnlyChanges", () => {
     };
   }
 
+  async function discardAndReadStatus(
+    repoDir: string,
+    changedFile: string,
+  ): Promise<{ reverted: string[]; status: string }> {
+    const reverted = await discardFormattingOnlyChanges({
+      repoDir,
+      changedFiles: [changedFile],
+      runCommand: commandRunner(repoDir),
+    });
+    const status = await shellRunCommand(
+      ["git", "status", "--porcelain", "--", changedFile],
+      { cwd: repoDir, trimStdout: false },
+    );
+    return { reverted, status };
+  }
+
   test("restores the exact formatting-only union change from PR #2434", async () => {
     const repoDir = await createRepository(
       [
@@ -151,57 +167,30 @@ describe("discardFormattingOnlyChanges", () => {
       ].join("\n"),
     );
 
-    const reverted = await discardFormattingOnlyChanges({
-      repoDir,
-      changedFiles: ["item.ts"],
-      runCommand: commandRunner(repoDir),
-    });
+    const { reverted, status } = await discardAndReadStatus(repoDir, "item.ts");
 
     expect(reverted).toEqual([]);
-    expect(
-      await shellRunCommand(["git", "status", "--porcelain", "--", "item.ts"], {
-        cwd: repoDir,
-        trimStdout: false,
-      }),
-    ).toContain("item.ts");
+    expect(status).toContain("item.ts");
   });
 
   test("does not suppress a new generated text file", async () => {
     const repoDir = await createRepository("export const baseline = true;\n");
     await Bun.write(`${repoDir}/new.ts`, "export   const generated = true;\n");
 
-    const reverted = await discardFormattingOnlyChanges({
-      repoDir,
-      changedFiles: ["new.ts"],
-      runCommand: commandRunner(repoDir),
-    });
+    const { reverted, status } = await discardAndReadStatus(repoDir, "new.ts");
 
     expect(reverted).toEqual([]);
-    expect(
-      await shellRunCommand(["git", "status", "--porcelain", "--", "new.ts"], {
-        cwd: repoDir,
-        trimStdout: false,
-      }),
-    ).toContain("new.ts");
+    expect(status).toContain("new.ts");
   });
 
   test("does not suppress a deleted generated file", async () => {
     const repoDir = await createRepository("export const baseline = true;\n");
     await shellRunCommand(["rm", "item.ts"], { cwd: repoDir });
 
-    const reverted = await discardFormattingOnlyChanges({
-      repoDir,
-      changedFiles: ["item.ts"],
-      runCommand: commandRunner(repoDir),
-    });
+    const { reverted, status } = await discardAndReadStatus(repoDir, "item.ts");
 
     expect(reverted).toEqual([]);
-    expect(
-      await shellRunCommand(["git", "status", "--porcelain", "--", "item.ts"], {
-        cwd: repoDir,
-        trimStdout: false,
-      }),
-    ).toContain("item.ts");
+    expect(status).toContain("item.ts");
   });
 
   test("does not suppress binary or unsupported files", async () => {
@@ -228,6 +217,14 @@ describe("discardFormattingOnlyChanges", () => {
 describe("runScoutGeneratedPreflight", () => {
   const temporaryDirectories: string[] = [];
 
+  async function preflightScenario() {
+    const calls: string[][] = [];
+    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
+    temporaryDirectories.push(repoDir);
+    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+    return { calls, repoDir };
+  }
+
   afterEach(async () => {
     await Promise.all(
       temporaryDirectories
@@ -237,10 +234,7 @@ describe("runScoutGeneratedPreflight", () => {
   });
 
   test("formats, checks, and validates before publication", async () => {
-    const calls: string[][] = [];
-    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
-    temporaryDirectories.push(repoDir);
-    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+    const { calls, repoDir } = await preflightScenario();
 
     await runScoutGeneratedPreflight({
       repoDir,
@@ -291,10 +285,7 @@ describe("runScoutGeneratedPreflight", () => {
   });
 
   test("stops before later checks when formatting fails", async () => {
-    const calls: string[][] = [];
-    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
-    temporaryDirectories.push(repoDir);
-    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+    const { calls, repoDir } = await preflightScenario();
 
     await expect(
       runScoutGeneratedPreflight({
@@ -311,10 +302,7 @@ describe("runScoutGeneratedPreflight", () => {
   });
 
   test("stops before focused validation when git diff check fails", async () => {
-    const calls: string[][] = [];
-    const repoDir = await mkdtemp(`${tmpdir()}/scout-preflight-`);
-    temporaryDirectories.push(repoDir);
-    await Bun.write(`${repoDir}/packages/data/generated.json`, "{}\n");
+    const { calls, repoDir } = await preflightScenario();
 
     await expect(
       runScoutGeneratedPreflight({

--- a/packages/temporal/src/activities/scout-season-refresh-git.integration.test.ts
+++ b/packages/temporal/src/activities/scout-season-refresh-git.integration.test.ts
@@ -135,6 +135,33 @@ describe("assertRemoteBranchIsOurs (real remote)", () => {
   let remoteDir: string;
   let repoDir: string;
 
+  async function publishOperatorChangeAndExpectRefusal(
+    operatorClone: string,
+    force: boolean,
+  ): Promise<void> {
+    const pushFlag = force ? "-qf" : "-q";
+    await runCommand(["git", "push", pushFlag, "origin", BRANCH], {
+      cwd: operatorClone,
+    });
+    await rm(operatorClone, { recursive: true, force: true });
+    await runCommand(
+      [
+        "git",
+        "fetch",
+        "-q",
+        "origin",
+        `refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}`,
+        "--force",
+      ],
+      { cwd: repoDir },
+    );
+    await commitAs(repoDir, BOT, "catalog.json", "bot proposal");
+
+    await expect(
+      assertRemoteBranchIsOurs({ repoDir, branch: BRANCH }),
+    ).rejects.toThrow(/jerred@sjer\.red/);
+  }
+
   beforeEach(async () => {
     remoteDir = await mkdtemp(`${tmpdir()}/branch-guard-remote-`);
     await runCommand(["git", "init", "-q", "--bare", "."], { cwd: remoteDir });
@@ -221,28 +248,8 @@ describe("assertRemoteBranchIsOurs (real remote)", () => {
       "catalog.json",
       "human adjudication",
     );
-    await runCommand(["git", "push", "-q", "origin", BRANCH], {
-      cwd: operatorClone,
-    });
-    await rm(operatorClone, { recursive: true, force: true });
-
     // The bot re-fetches and regenerates, as the next scheduled run would.
-    await runCommand(
-      [
-        "git",
-        "fetch",
-        "-q",
-        "origin",
-        `refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}`,
-        "--force",
-      ],
-      { cwd: repoDir },
-    );
-    await commitAs(repoDir, BOT, "catalog.json", "bot proposal");
-
-    await expect(
-      assertRemoteBranchIsOurs({ repoDir, branch: BRANCH }),
-    ).rejects.toThrow(/jerred@sjer\.red/);
+    await publishOperatorChangeAndExpectRefusal(operatorClone, false);
   });
 
   test("refuses an amended commit, where the bot is still the author", async () => {
@@ -289,27 +296,7 @@ describe("assertRemoteBranchIsOurs (real remote)", () => {
       { cwd: operatorClone },
     );
     expect(author).toBe(BOT);
-    await runCommand(["git", "push", "-qf", "origin", BRANCH], {
-      cwd: operatorClone,
-    });
-    await rm(operatorClone, { recursive: true, force: true });
-
-    await runCommand(
-      [
-        "git",
-        "fetch",
-        "-q",
-        "origin",
-        `refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}`,
-        "--force",
-      ],
-      { cwd: repoDir },
-    );
-    await commitAs(repoDir, BOT, "catalog.json", "bot proposal");
-
-    await expect(
-      assertRemoteBranchIsOurs({ repoDir, branch: BRANCH }),
-    ).rejects.toThrow(/jerred@sjer\.red/);
+    await publishOperatorChangeAndExpectRefusal(operatorClone, true);
   });
 
   test("recognises itself when GIT_AUTHOR_EMAIL overrides the repo config", async () => {

--- a/packages/temporal/src/event-bridge/github-webhook.test.ts
+++ b/packages/temporal/src/event-bridge/github-webhook.test.ts
@@ -77,6 +77,19 @@ async function postWebhook(
   );
 }
 
+async function closedPrScenario(merged: boolean) {
+  const cancelCalls: CancelCall[] = [];
+  const cancel = vi.fn(async (input: CancelBuildkiteBuildsInput) => {
+    cancelCalls.push([input]);
+  });
+  const app = buildWebhookApp(SECRET, { startCancel: cancel });
+  const response = await postWebhook(
+    app,
+    makeBaseEvent({ action: "closed", merged }),
+  );
+  return { cancel, cancelCalls, response };
+}
+
 describe("buildWebhookApp signature verification", () => {
   it("returns 401 when X-Hub-Signature-256 is missing", async () => {
     const startPr = vi.fn(noopConflictPr);
@@ -269,17 +282,9 @@ describe("buildWebhookApp per-PR conflict check", () => {
 
 describe("buildWebhookApp PR closed", () => {
   it("starts the cancel workflow when a merged PR is closed", async () => {
-    const cancelCalls: CancelCall[] = [];
-    const cancel = vi.fn(async (input: CancelBuildkiteBuildsInput) => {
-      cancelCalls.push([input]);
-    });
-    const app = buildWebhookApp(SECRET, { startCancel: cancel });
-    const res = await postWebhook(
-      app,
-      makeBaseEvent({ action: "closed", merged: true }),
-    );
-    expect(res.status).toBe(200);
-    expect(await res.text()).toContain("cancel started");
+    const { cancel, cancelCalls, response } = await closedPrScenario(true);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("cancel started");
     expect(cancel).toHaveBeenCalledTimes(1);
     const call = cancelCalls[0];
     if (call === undefined) {
@@ -295,16 +300,8 @@ describe("buildWebhookApp PR closed", () => {
   });
 
   it("starts the cancel workflow when a PR is closed without merging", async () => {
-    const cancelCalls: CancelCall[] = [];
-    const cancel = vi.fn(async (input: CancelBuildkiteBuildsInput) => {
-      cancelCalls.push([input]);
-    });
-    const app = buildWebhookApp(SECRET, { startCancel: cancel });
-    const res = await postWebhook(
-      app,
-      makeBaseEvent({ action: "closed", merged: false }),
-    );
-    expect(res.status).toBe(200);
+    const { cancel, cancelCalls, response } = await closedPrScenario(false);
+    expect(response.status).toBe(200);
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(cancelCalls[0]?.[0].merged).toBe(false);
   });

--- a/packages/temporal/src/shared/llm-catalog-alert.test.ts
+++ b/packages/temporal/src/shared/llm-catalog-alert.test.ts
@@ -378,6 +378,24 @@ function withheldFor(field: string): string {
   );
 }
 
+function retiredContextWindowAlerts() {
+  return buildCatalogAlerts(
+    {
+      applied: [],
+      models: {
+        "claude-sonnet-5": {
+          withheld: {},
+          measured: ["input", "output"],
+          unmeasured: [],
+          retired: ["contextWindow"],
+        },
+      },
+      prUrl: undefined,
+    },
+    NOW,
+  );
+}
+
 describe("retain instructions per field", () => {
   test("a price divergence points at the acceptance pair", () => {
     for (const field of ["input", "output"]) {
@@ -408,21 +426,7 @@ describe("retired fields close their own alerts", () => {
     // removes the field from cross-checking, so before this it produced no
     // occurrence at all and the very alert they were answering stayed firing
     // for the full eight-day TTL — the advice appeared to do nothing.
-    const alerts = buildCatalogAlerts(
-      {
-        applied: [],
-        models: {
-          "claude-sonnet-5": {
-            withheld: {},
-            measured: ["input", "output"],
-            unmeasured: [],
-            retired: ["contextWindow"],
-          },
-        },
-        prUrl: undefined,
-      },
-      NOW,
-    );
+    const alerts = retiredContextWindowAlerts();
 
     const drift = alerts.find(
       (alert) =>
@@ -440,21 +444,7 @@ describe("retired fields close their own alerts", () => {
     // compared — the operator pinned it. Telling them a check passed on a
     // number nobody checked is the same class of false claim as the
     // evidence-missing alert this branch already fixed.
-    const alerts = buildCatalogAlerts(
-      {
-        applied: [],
-        models: {
-          "claude-sonnet-5": {
-            withheld: {},
-            measured: ["input", "output"],
-            unmeasured: [],
-            retired: ["contextWindow"],
-          },
-        },
-        prUrl: undefined,
-      },
-      NOW,
-    );
+    const alerts = retiredContextWindowAlerts();
     const drift = alerts.find(
       (alert) =>
         alert.labels["alertname"] === "LlmCatalogDriftWithheld" &&
@@ -468,21 +458,7 @@ describe("retired fields close their own alerts", () => {
   });
 
   test("says evidence is not expected, not that it returned", () => {
-    const alerts = buildCatalogAlerts(
-      {
-        applied: [],
-        models: {
-          "claude-sonnet-5": {
-            withheld: {},
-            measured: ["input", "output"],
-            unmeasured: [],
-            retired: ["contextWindow"],
-          },
-        },
-        prUrl: undefined,
-      },
-      NOW,
-    );
+    const alerts = retiredContextWindowAlerts();
     const evidence = alerts.find(
       (alert) =>
         alert.labels["alertname"] === "LlmCatalogEvidenceMissing" &&
@@ -556,21 +532,7 @@ describe("retired fields close their own alerts", () => {
   test("a retired field is not also reported as missing evidence", () => {
     // Nobody is checking it, so "no upstream published this" would be a
     // finding about a question we stopped asking.
-    const alerts = buildCatalogAlerts(
-      {
-        applied: [],
-        models: {
-          "claude-sonnet-5": {
-            withheld: {},
-            measured: ["input", "output"],
-            unmeasured: [],
-            retired: ["contextWindow"],
-          },
-        },
-        prUrl: undefined,
-      },
-      NOW,
-    );
+    const alerts = retiredContextWindowAlerts();
 
     expect(firingFor(alerts, "LlmCatalogEvidenceMissing")).toEqual([]);
     expect(firingFor(alerts, "LlmCatalogDriftWithheld")).toEqual([]);

--- a/packages/temporal/src/workflows/glitter-corpus.test.ts
+++ b/packages/temporal/src/workflows/glitter-corpus.test.ts
@@ -189,6 +189,22 @@ async function runGlitterWorkflow<T>(
   }
 }
 
+function verifyChannelInto(
+  verified: z.input<typeof VerifyChannelInputSchema>[],
+) {
+  return async (rawInput: z.input<typeof VerifyChannelInputSchema>) => {
+    const input = VerifyChannelInputSchema.parse(rawInput);
+    verified.push(input);
+    const manifestKey = `states/${input.snapshotId}.json`;
+    return {
+      channelId: input.channelId,
+      manifestKey,
+      manifestObject: storedObject(manifestKey),
+      uniqueMessageCount: 2,
+    };
+  };
+}
+
 describe("Glitter corpus workflows", () => {
   it("fails a traversal safety ceiling non-retryably", async () => {
     const activities = {
@@ -268,19 +284,7 @@ describe("Glitter corpus workflows", () => {
         }
         throw new Error(`unexpected direction ${input.direction}`);
       },
-      verifyGlitterCorpusChannel: async (
-        rawInput: z.input<typeof VerifyChannelInputSchema>,
-      ) => {
-        const input = VerifyChannelInputSchema.parse(rawInput);
-        verified.push(input);
-        const manifestKey = `states/${input.snapshotId}.json`;
-        return {
-          channelId: input.channelId,
-          manifestKey,
-          manifestObject: storedObject(manifestKey),
-          uniqueMessageCount: 2,
-        };
-      },
+      verifyGlitterCorpusChannel: verifyChannelInto(verified),
       finalizeGlitterCorpusSnapshot: finalSnapshot,
     };
 
@@ -494,19 +498,7 @@ describe("Glitter corpus periodic full refresh", () => {
         captured.push(input);
         return pageResult(input, [], []);
       },
-      verifyGlitterCorpusChannel: async (
-        rawInput: z.input<typeof VerifyChannelInputSchema>,
-      ) => {
-        const input = VerifyChannelInputSchema.parse(rawInput);
-        verified.push(input);
-        const manifestKey = `states/${input.snapshotId}.json`;
-        return {
-          channelId: input.channelId,
-          manifestKey,
-          manifestObject: storedObject(manifestKey),
-          uniqueMessageCount: 2,
-        };
-      },
+      verifyGlitterCorpusChannel: verifyChannelInto(verified),
       finalizeGlitterCorpusSnapshot: finalSnapshot,
     };
 


### PR DESCRIPTION
Why

The jscpd baseline still carried repeated Temporal fixture setup across scenarios, obscuring the distinct behavior each test verifies.

What

- Extract reusable scenario runners for agent-task failures, GitHub PR close events, generated preflight, and season-refresh git races.
- Share report-delivery, catalog-alert, and Glitter-corpus fixture setup while retaining scenario-specific assertions.
- Reduce the cumulative jscpd baseline from 57,703 to 57,057 duplicated tokens (646 tokens removed).

Verification

- Exact affected Vitest files: 85 tests passed
- `bun run scripts/test-workflows.ts src/workflows/glitter-corpus.test.ts`: 22 files, 69 tests passed
- `bunx tsc --noEmit --pretty false`
- `bunx eslint` on all seven affected test files
- `bunx turbo run test typecheck lint --filter=@shepherdjerred/temporal`
- `bun run jscpd` before update: only intended self-pairs removed
- `bun run jscpd --update`
- `jq '[.pairs[].tokens] | add' .jscpd-baseline.json`: 57,057
- `bun run jscpd`
- `bunx lefthook run pre-commit`

No live Temporal environment was used or required; this branch changes test fixtures only.