### PR TITLE
feat(scout-for-lol): move Dare management to Bryan Bucks

### DIFF
--- a/packages/scout-for-lol/packages/app/src/components/bucks-dare-editor.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-dare-editor.tsx
@@ -43,7 +43,7 @@ type ValidatedDraft = {
   };
 };
 
-export function ExploreDareEditor(props: { dare: EditorDare }) {
+export function BucksDareEditor(props: { dare: EditorDare; guildId: string }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
@@ -69,7 +69,7 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
   const inputVersion = useRef(0);
   const validationRequest = useRef(0);
   const previewRequest = useRef(0);
-  const revise = useMutation(trpc.explore.dareReviseDraft.mutationOptions());
+  const revise = useMutation(trpc.bucks.dareReviseDraft.mutationOptions());
   const fieldId = (name: string) =>
     `dare-${props.dare.id.toString()}-editor-${name}`;
 
@@ -120,7 +120,10 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
     setValidationPending(true);
     try {
       const result = await queryClient.query(
-        trpc.explore.dareValidateDraft.queryOptions(input),
+        trpc.bucks.dareValidateDraft.queryOptions({
+          guildId: props.guildId,
+          ...input,
+        }),
       );
       if (
         version !== inputVersion.current ||
@@ -166,7 +169,8 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
     setPreviewPending(true);
     try {
       const result = await queryClient.query(
-        trpc.explore.darePreviewDraft.queryOptions({
+        trpc.bucks.darePreviewDraft.queryOptions({
+          guildId: props.guildId,
           ...input,
           historyDays: days,
         }),
@@ -202,7 +206,10 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
       return;
     }
     try {
-      const outcome = await revise.mutateAsync(input);
+      const outcome = await revise.mutateAsync({
+        guildId: props.guildId,
+        ...input,
+      });
       if (outcome.kind !== "revised") {
         setError(
           `Draft was not revised (${outcome.kind.replaceAll("_", " ")}).`,
@@ -211,10 +218,10 @@ export function ExploreDareEditor(props: { dare: EditorDare }) {
       }
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: trpc.explore.dareList.pathKey(),
+          queryKey: trpc.bucks.dareList.pathKey(),
         }),
         queryClient.invalidateQueries({
-          queryKey: trpc.explore.dareInspect.pathKey(),
+          queryKey: trpc.bucks.dareInspect.pathKey(),
         }),
       ]);
       setOpen(false);

--- a/packages/scout-for-lol/packages/app/src/components/explore-dare-cards.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/explore-dare-cards.tsx
@@ -217,10 +217,10 @@ function IntentCard(props: { intent: z.infer<typeof IntentDataSchema> }) {
                       ),
                     );
                     void queryClient.invalidateQueries({
-                      queryKey: trpc.explore.dareList.pathKey(),
+                      queryKey: trpc.bucks.dareList.pathKey(),
                     });
                     void queryClient.invalidateQueries({
-                      queryKey: trpc.explore.dareInspect.pathKey(),
+                      queryKey: trpc.bucks.dareInspect.pathKey(),
                     });
                     void queryClient.invalidateQueries({
                       queryKey: trpc.explore.dareIntentStatus.queryKey({

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.test.ts
@@ -198,6 +198,11 @@ describe("normalizePath", () => {
     );
     expect(normalizePath("/explore/s")).toBe("/not-found");
   });
+
+  test("templates Bryan Bucks Dare ids", () => {
+    expect(normalizePath("/bucks/dares")).toBe("/bucks/dares");
+    expect(normalizePath("/bucks/dares/42")).toBe("/bucks/dares/:dareId");
+  });
 });
 
 describe("privacy settings", () => {

--- a/packages/scout-for-lol/packages/app/src/lib/analytics.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/analytics.ts
@@ -454,13 +454,14 @@ export function normalizePath(pathname: string): string {
       /\/reports\/(?!new(?:\/|$)|help(?:\/|$))[^/]+/,
       "/reports/:reportId",
     )
+    .replace(/^\/bucks\/dares\/[^/]+/, "/bucks/dares/:dareId")
     // Share token first, so the conversation rule's lookahead then sees the
     // already-templated `s` segment. The token is the share credential — it
     // is templated away before anything reaches PostHog.
     .replace(/^\/explore\/s\/[^/]+/, "/explore/s/:shareToken")
     .replace(/^\/explore\/(?!s(?:\/|$))[^/]+/, "/explore/:conversationId");
   const knownRoute =
-    /^(?:\/|\/(?:login|welcome|installed|manage)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/players(?:\/:playerId)?|\/bucks(?:\/(?:history|leaderboard|settings))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
+    /^(?:\/|\/(?:login|welcome|installed|manage)|\/explore(?:\/(?::conversationId|s\/:shareToken))?|\/players(?:\/:playerId)?|\/bucks(?:\/(?:dares(?:\/:dareId)?|history|leaderboard|settings))?|\/g\/:guildId(?:\/(?:access|audit|subscriptions|players(?:\/:alias(?:\/manage)?)?|competitions(?:\/(?:new|:competitionId(?:\/edit)?))?|reports(?:\/(?:new|help|:reportId(?:\/edit)?))?)?)?)$/;
   return knownRoute.test(normalized) ? normalized : "/not-found";
 }
 

--- a/packages/scout-for-lol/packages/app/src/router.test.ts
+++ b/packages/scout-for-lol/packages/app/src/router.test.ts
@@ -22,6 +22,8 @@ const KNOWN_URLS = [
   "/players",
   "/players/42",
   "/bucks",
+  "/bucks/dares",
+  "/bucks/dares/42",
   "/bucks/history",
   "/bucks/leaderboard",
   "/bucks/settings",

--- a/packages/scout-for-lol/packages/app/src/router.tsx
+++ b/packages/scout-for-lol/packages/app/src/router.tsx
@@ -28,6 +28,7 @@ import { ConsumerPlayerProfile } from "#src/routes/consumer-player-profile.tsx";
 import { ConsumerWorkspace } from "#src/routes/consumer-workspace.tsx";
 import { BucksWorkspace } from "#src/routes/bucks-workspace.tsx";
 import { BucksOverview } from "#src/routes/bucks-overview.tsx";
+import { BucksDares } from "#src/routes/bucks-dares.tsx";
 import { BucksHistory } from "#src/routes/bucks-history.tsx";
 import { BucksLeaderboard } from "#src/routes/bucks-leaderboard.tsx";
 import { BucksSettings } from "#src/routes/bucks-settings.tsx";
@@ -229,6 +230,11 @@ export const routes: RouteObject[] = [
                   {
                     index: true,
                     element: <BucksOverview />,
+                    errorElement: <RouteErrorPanel />,
+                  },
+                  {
+                    path: "dares/:dareId?",
+                    element: <BucksDares />,
                     errorElement: <RouteErrorPanel />,
                   },
                   {

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-dares.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-dares.test.tsx
@@ -100,6 +100,7 @@ describe("DareDetail", () => {
           dare={{
             id: 42,
             state: "settled",
+            originConversationId: null,
             currentRevision: 2,
             fundedRevision: 1,
             plainLanguage: "Virmel wins three games",
@@ -129,6 +130,6 @@ describe("DareDetail", () => {
     expect(html).toContain("3 games");
     expect(html).toContain("Settlement proof");
     expect(html).toContain("eligibleGames");
-    expect(html).toContain("Revise in Explore");
+    expect(html).not.toContain("Revise in Explore");
   });
 });

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-dares.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-dares.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, test, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import {
+  DareDetail,
+  DareList,
+  parseBucksDareId,
+} from "#src/routes/bucks-dares.tsx";
+
+const noAction = vi.fn();
+
+describe("parseBucksDareId", () => {
+  test("selects the list when the optional route segment is absent", () => {
+    expect(parseBucksDareId(undefined)).toEqual({ kind: "list" });
+  });
+
+  test("selects a positive integer Dare deep link", () => {
+    expect(parseBucksDareId("42")).toEqual({ kind: "detail", dareId: 42 });
+  });
+
+  test.each(["", "0", "-1", "1.5", "not-a-dare"])(
+    "rejects invalid Dare id %s",
+    (value) => {
+      expect(parseBucksDareId(value)).toEqual({ kind: "invalid" });
+    },
+  );
+});
+
+describe("DareList", () => {
+  test("renders loading, error, and empty states", () => {
+    expect(
+      renderToStaticMarkup(
+        <DareList
+          loading
+          error={null}
+          dares={[]}
+          onRetry={noAction}
+          onSelect={noAction}
+        />,
+      ),
+    ).toContain("Loading dares");
+    expect(
+      renderToStaticMarkup(
+        <DareList
+          loading={false}
+          error={{ message: "Dares could not load" }}
+          dares={[]}
+          onRetry={noAction}
+          onSelect={noAction}
+        />,
+      ),
+    ).toContain("Dares could not load");
+    expect(
+      renderToStaticMarkup(
+        <DareList
+          loading={false}
+          error={null}
+          dares={[]}
+          onRetry={noAction}
+          onSelect={noAction}
+        />,
+      ),
+    ).toContain("No dares match");
+  });
+
+  test("renders searchable list results with lifecycle and evidence", () => {
+    const html = renderToStaticMarkup(
+      <DareList
+        loading={false}
+        error={null}
+        dares={[
+          {
+            id: 42,
+            state: "active",
+            plainLanguage: "Virmel wins three games",
+            targetAliases: ["Virmel"],
+            potTotal: 40,
+            evidenceGames: 2,
+            updatedAt: "2026-09-01T00:00:00.000Z",
+          },
+        ]}
+        onRetry={noAction}
+        onSelect={noAction}
+      />,
+    );
+    expect(html).toContain("Dare #42");
+    expect(html).toContain("active");
+    expect(html).toContain("Virmel wins three games");
+    expect(html).toContain("40 BB");
+    expect(html).toContain("2 evidence games");
+  });
+});
+
+describe("DareDetail", () => {
+  test("renders contract metadata, ScoutQL, evidence, and proof", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <DareDetail
+          guildId="100000000000000061"
+          dare={{
+            id: 42,
+            state: "settled",
+            currentRevision: 2,
+            fundedRevision: 1,
+            plainLanguage: "Virmel wins three games",
+            canonicalScoutQl: "FROM matches RETURN count(*) >= 3",
+            semanticProofPlan: "Count qualifying wins.",
+            compilerVersion: "2",
+            evaluatorVersion: "2",
+            scoutQlPlanHash: "a".repeat(64),
+            originalText: "Virmel wins three games",
+            deadlineSpec: { kind: "relative", days: 7 },
+            targetAliases: ["Virmel"],
+            openingStake: 20,
+            potTotal: 40,
+            evidenceGames: 3,
+            acceptDeadline: "2026-09-01T00:00:00.000Z",
+            deadlineAt: "2026-09-08T00:00:00.000Z",
+            finalValue: true,
+            proof: { eligibleGames: 3 },
+            voidReason: null,
+          }}
+        />
+      </MemoryRouter>,
+    );
+    expect(html).toContain("Dare #42");
+    expect(html).toContain("settled");
+    expect(html).toContain("Revision");
+    expect(html).toContain("3 games");
+    expect(html).toContain("Settlement proof");
+    expect(html).toContain("eligibleGames");
+    expect(html).toContain("Revise in Explore");
+  });
+});

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-dares.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-dares.tsx
@@ -1,74 +1,108 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Search, Target } from "lucide-react";
-import type {
-  DareCompiledPlanV2,
-  DareDeadlineSpecV2,
-} from "@scout-for-lol/data";
+import { Search } from "lucide-react";
+import { Link, useNavigate, useParams } from "react-router";
+import { z } from "zod";
+import type { DareDeadlineSpecV2 } from "@scout-for-lol/data";
+import { BucksDareEditor } from "#src/components/bucks-dare-editor.tsx";
+import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import { Input } from "@scout-for-lol/design-system/components/input";
-import {
-  Sheet,
-  SheetContent,
-  SheetTitle,
-  SheetTrigger,
-} from "@scout-for-lol/design-system/components/sheet";
 import {
   Tabs,
   TabsList,
   TabsTrigger,
 } from "@scout-for-lol/design-system/components/tabs";
-import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
-import { ExploreDareEditor } from "#src/components/explore-dare-editor.tsx";
+import {
+  ErrorState,
+  LoadingState,
+} from "@scout-for-lol/design-system/domain/states";
+import { EmptyState } from "@scout-for-lol/design-system/layout";
 import { dareDeadlineDescription } from "#src/lib/dare-deadline.ts";
 import { dareEditorInstanceKey } from "#src/lib/dare-editor-state.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
+import { useBucksGuild } from "#src/routes/bucks-workspace.tsx";
 
-export function ExploreDaresDrawer() {
+const DareIdSchema = z.coerce.number().int().positive();
+
+export function parseBucksDareId(
+  value: string | undefined,
+): { kind: "list" } | { kind: "detail"; dareId: number } | { kind: "invalid" } {
+  if (value === undefined) return { kind: "list" };
+  const parsed = DareIdSchema.safeParse(value);
+  return parsed.success
+    ? { kind: "detail", dareId: parsed.data }
+    : { kind: "invalid" };
+}
+
+export function BucksDares() {
+  const { guildId, guildName, daresAvailable } = useBucksGuild();
+  const { dareId: dareIdParam } = useParams();
+  const route = parseBucksDareId(dareIdParam);
+
+  if (!daresAvailable) {
+    return (
+      <EmptyState>
+        <h2>Dares aren&apos;t available here</h2>
+        <p>This server doesn&apos;t currently have Dares to manage.</p>
+        <Button asChild variant="outline">
+          <Link to="/bucks">Back to Bryan Bucks</Link>
+        </Button>
+      </EmptyState>
+    );
+  }
+  if (route.kind === "invalid") {
+    return <ErrorState message="This Dare link isn't valid." />;
+  }
+  return route.kind === "detail" ? (
+    <DareDetailPage guildId={guildId} dareId={route.dareId} />
+  ) : (
+    <DareListPage guildId={guildId} guildName={guildName} />
+  );
+}
+
+function DareListPage(props: { guildId: string; guildName: string }) {
   const trpc = useTRPC();
-  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
   const [scope, setScope] = useState<"mine" | "guild">("mine");
   const [search, setSearch] = useState("");
-  const [selectedId, setSelectedId] = useState<number | null>(null);
-  const list = useQuery({
-    ...trpc.explore.dareList.queryOptions({
+  const trimmedSearch = search.trim();
+  const list = useQuery(
+    trpc.bucks.dareList.queryOptions({
+      guildId: props.guildId,
       scope,
-      ...(search.trim().length === 0 ? {} : { search: search.trim() }),
+      ...(trimmedSearch.length === 0 ? {} : { search: trimmedSearch }),
     }),
-    enabled: open,
-  });
-  const detail = useQuery({
-    ...trpc.explore.dareInspect.queryOptions({ dareId: selectedId ?? 0 }),
-    enabled: open && selectedId !== null,
-  });
+  );
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-1.5">
-          <Target className="size-4" />
-          Dares
+    <div className="space-y-6">
+      <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Dares</h1>
+          <p className="text-sm text-scout-subtle">
+            Find and manage Dare contracts for {props.guildName}. Create or
+            revise one conversationally in Explore.
+          </p>
+        </div>
+        <Button asChild>
+          <Link to="/explore">Create in Explore</Link>
         </Button>
-      </SheetTrigger>
-      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
-        <SheetTitle className="text-base font-semibold">Scout dares</SheetTitle>
+      </header>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <Tabs
           value={scope}
           onValueChange={(next) => {
-            if (next === "mine" || next === "guild") {
-              setScope(next);
-              setSelectedId(null);
-            }
+            if (next === "mine" || next === "guild") setScope(next);
           }}
-          className="mt-4"
         >
           <TabsList>
             <TabsTrigger value="mine">My Dares</TabsTrigger>
             <TabsTrigger value="guild">Guild Dares</TabsTrigger>
           </TabsList>
         </Tabs>
-
-        <div className="relative mt-4">
+        <div className="relative sm:w-80">
           <Search className="absolute top-1/2 left-2 size-4 -translate-y-1/2 text-scout-subtle" />
           <Input
             aria-label="Search dares"
@@ -80,58 +114,24 @@ export function ExploreDaresDrawer() {
             }}
           />
         </div>
+      </div>
 
-        {selectedId === null ? (
-          <DareList
-            loading={list.isLoading}
-            error={list.error}
-            dares={list.data ?? []}
-            onSelect={setSelectedId}
-          />
-        ) : detail.isLoading ? (
-          <p className="mt-6 text-sm text-scout-subtle">Loading dare…</p>
-        ) : detail.error === null ? (
-          detail.data === undefined ? null : (
-            <DareDetail
-              dare={detail.data}
-              onBack={() => {
-                setSelectedId(null);
-              }}
-            />
-          )
-        ) : (
-          <div className="mt-6 space-y-3">
-            <p className="text-sm text-scout-danger">{detail.error.message}</p>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  void detail.refetch();
-                }}
-              >
-                Try again
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setSelectedId(null);
-                }}
-              >
-                Back to dares
-              </Button>
-            </div>
-          </div>
-        )}
-      </SheetContent>
-    </Sheet>
+      <DareList
+        loading={list.isPending}
+        error={list.error}
+        dares={list.data ?? []}
+        onRetry={() => {
+          void list.refetch();
+        }}
+        onSelect={(dareId) => {
+          void navigate(`/bucks/dares/${dareId.toString()}`);
+        }}
+      />
+    </div>
   );
 }
 
-function DareList(props: {
+export function DareList(props: {
   loading: boolean;
   error: { message: string } | null;
   dares: {
@@ -143,26 +143,28 @@ function DareList(props: {
     evidenceGames: number;
     updatedAt: string;
   }[];
+  onRetry: () => void;
   onSelect: (dareId: number) => void;
 }) {
-  if (props.loading) {
-    return <p className="mt-6 text-sm text-scout-subtle">Loading dares…</p>;
-  }
+  if (props.loading) return <LoadingState label="Loading dares…" />;
   if (props.error !== null) {
-    return (
-      <p className="mt-6 text-sm text-scout-danger">{props.error.message}</p>
-    );
+    return <ErrorState message={props.error.message} onRetry={props.onRetry} />;
   }
   if (props.dares.length === 0) {
-    return <p className="mt-6 text-sm text-scout-subtle">No dares match.</p>;
+    return (
+      <EmptyState>
+        <h2>No dares match</h2>
+        <p>Try another search or create a Dare in Explore.</p>
+      </EmptyState>
+    );
   }
   return (
-    <ul className="mt-4 space-y-2">
+    <ul className="grid gap-3 lg:grid-cols-2">
       {props.dares.map((dare) => (
         <li key={dare.id}>
           <button
             type="button"
-            className="w-full space-y-2 rounded-lg border border-scout-border p-3 text-left hover:bg-scout-hover"
+            className="h-full w-full space-y-3 rounded-lg border border-scout-border p-4 text-left hover:bg-scout-hover"
             onClick={() => {
               props.onSelect(dare.id);
             }}
@@ -185,7 +187,30 @@ function DareList(props: {
   );
 }
 
-function DareDetail(props: {
+function DareDetailPage(props: { guildId: string; dareId: number }) {
+  const trpc = useTRPC();
+  const detail = useQuery(
+    trpc.bucks.dareInspect.queryOptions({
+      guildId: props.guildId,
+      dareId: props.dareId,
+    }),
+  );
+  if (detail.isPending) return <LoadingState label="Loading dare…" />;
+  if (detail.isError) {
+    return (
+      <ErrorState
+        message={detail.error.message}
+        onRetry={() => {
+          void detail.refetch();
+        }}
+      />
+    );
+  }
+  return <DareDetail guildId={props.guildId} dare={detail.data} />;
+}
+
+export function DareDetail(props: {
+  guildId: string;
   dare: {
     id: number;
     state: string;
@@ -193,7 +218,6 @@ function DareDetail(props: {
     fundedRevision: number | null;
     plainLanguage: string;
     canonicalScoutQl: string;
-    plan: DareCompiledPlanV2;
     semanticProofPlan: string;
     compilerVersion: string;
     evaluatorVersion: string;
@@ -210,26 +234,33 @@ function DareDetail(props: {
     proof: unknown;
     voidReason: string | null;
   };
-  onBack: () => void;
 }) {
   const revision = props.dare.fundedRevision ?? props.dare.currentRevision;
   return (
-    <div className="mt-4 space-y-4">
-      <Button type="button" variant="ghost" size="sm" onClick={props.onBack}>
-        ← Back to dares
-      </Button>
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/bucks/dares">← Back to dares</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/explore">Revise in Explore</Link>
+        </Button>
+      </div>
       <div className="flex items-center justify-between gap-2">
-        <h3 className="font-medium">Dare #{props.dare.id.toString()}</h3>
+        <h1 className="text-2xl font-semibold">
+          Dare #{props.dare.id.toString()}
+        </h1>
         <StatePill state={props.dare.state} />
       </div>
       {props.dare.state === "draft" && (
-        <ExploreDareEditor
+        <BucksDareEditor
           key={dareEditorInstanceKey(props.dare)}
+          guildId={props.guildId}
           dare={props.dare}
         />
       )}
       <p className="whitespace-pre-wrap text-sm">{props.dare.plainLanguage}</p>
-      <dl className="grid grid-cols-2 gap-3 text-sm">
+      <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
         <Fact label="Revision" value={revision.toString()} />
         <Fact
           label="Compiler"
@@ -254,7 +285,7 @@ function DareDetail(props: {
         )}
       </dl>
       <section className="space-y-2">
-        <h4 className="text-sm font-medium">ScoutQL</h4>
+        <h2 className="text-sm font-medium">ScoutQL</h2>
         <ScoutQlCode queryText={props.dare.canonicalScoutQl} />
         {props.dare.scoutQlPlanHash !== null && (
           <p className="font-mono text-xs text-scout-subtle">
@@ -264,14 +295,14 @@ function DareDetail(props: {
       </section>
       {props.dare.proof !== null && (
         <section className="space-y-2">
-          <h4 className="text-sm font-medium">Settlement proof</h4>
+          <h2 className="text-sm font-medium">Settlement proof</h2>
           <pre className="max-h-96 overflow-auto rounded-md border border-scout-border bg-scout-surface p-3 text-xs whitespace-pre-wrap">
             {JSON.stringify(props.dare.proof, null, 2)}
           </pre>
         </section>
       )}
       <section className="space-y-2">
-        <h4 className="text-sm font-medium">Proof plan</h4>
+        <h2 className="text-sm font-medium">Proof plan</h2>
         <p className="whitespace-pre-wrap text-xs text-scout-subtle">
           {props.dare.semanticProofPlan}
         </p>

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-dares.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-dares.tsx
@@ -214,6 +214,7 @@ export function DareDetail(props: {
   dare: {
     id: number;
     state: string;
+    originConversationId: string | null;
     currentRevision: number;
     fundedRevision: number | null;
     plainLanguage: string;
@@ -242,9 +243,14 @@ export function DareDetail(props: {
         <Button asChild variant="ghost" size="sm">
           <Link to="/bucks/dares">← Back to dares</Link>
         </Button>
-        <Button asChild variant="outline" size="sm">
-          <Link to="/explore">Revise in Explore</Link>
-        </Button>
+        {props.dare.state === "draft" &&
+          props.dare.originConversationId !== null && (
+            <Button asChild variant="outline" size="sm">
+              <Link to={`/explore/${props.dare.originConversationId}`}>
+                Revise in Explore
+              </Link>
+            </Button>
+          )}
       </div>
       <div className="flex items-center justify-between gap-2">
         <h1 className="text-2xl font-semibold">

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-workspace.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-workspace.test.tsx
@@ -5,9 +5,19 @@ import {
 } from "#src/routes/bucks-workspace.tsx";
 
 describe("bucksSectionItems", () => {
-  test("lists the four sections with an exact-match overview", () => {
-    expect(bucksSectionItems()).toEqual([
+  test("hides Dares when the selected guild has no Dare access", () => {
+    expect(bucksSectionItems(false)).toEqual([
       { label: "Overview", to: "/bucks", end: true },
+      { label: "History", to: "/bucks/history", end: false },
+      { label: "Leaderboard", to: "/bucks/leaderboard", end: false },
+      { label: "Settings", to: "/bucks/settings", end: false },
+    ]);
+  });
+
+  test("adds Dares for a guild with the feature or an existing Dare", () => {
+    expect(bucksSectionItems(true)).toEqual([
+      { label: "Overview", to: "/bucks", end: true },
+      { label: "Dares", to: "/bucks/dares", end: false },
       { label: "History", to: "/bucks/history", end: false },
       { label: "Leaderboard", to: "/bucks/leaderboard", end: false },
       { label: "Settings", to: "/bucks/settings", end: false },

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-workspace.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-workspace.tsx
@@ -24,19 +24,23 @@ import { useTRPC } from "#src/lib/trpc.ts";
 export type BucksOutletContext = {
   guildId: string;
   guildName: string;
+  daresAvailable: boolean;
 };
 
 export function useBucksGuild(): BucksOutletContext {
   return useOutletContext<BucksOutletContext>();
 }
 
-export function bucksSectionItems(): {
+export function bucksSectionItems(daresAvailable: boolean): {
   label: string;
   to: string;
   end: boolean;
 }[] {
   return [
     { label: "Overview", to: "/bucks", end: true },
+    ...(daresAvailable
+      ? [{ label: "Dares", to: "/bucks/dares", end: false }]
+      : []),
     { label: "History", to: "/bucks/history", end: false },
     { label: "Leaderboard", to: "/bucks/leaderboard", end: false },
     { label: "Settings", to: "/bucks/settings", end: false },
@@ -77,10 +81,10 @@ export function resolveBucksGuildSelection(input: {
   };
 }
 
-function SectionNav() {
+function SectionNav(props: { daresAvailable: boolean }) {
   return (
     <nav className="flex gap-1">
-      {bucksSectionItems().map((item) => (
+      {bucksSectionItems(props.daresAvailable).map((item) => (
         <NavLink
           key={item.to}
           to={item.to}
@@ -226,10 +230,11 @@ export function BucksWorkspace() {
   const context: BucksOutletContext = {
     guildId: guild.id,
     guildName: guild.name,
+    daresAvailable: guild.daresAvailable,
   };
   return (
     <BucksPage>
-      <SectionNav />
+      <SectionNav daresAvailable={guild.daresAvailable} />
       <Outlet context={context} />
     </BucksPage>
   );

--- a/packages/scout-for-lol/packages/app/src/routes/explore.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/explore.tsx
@@ -5,7 +5,6 @@ import type { ExploreConversation } from "@scout-for-lol/data";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import { ExploreComposer } from "#src/components/explore-composer.tsx";
 import { ExploreHeader } from "#src/components/explore-header.tsx";
-import { ExploreDaresDrawer } from "#src/components/explore-dares-drawer.tsx";
 import { ExploreShareRow } from "#src/components/explore-share.tsx";
 import { ExploreSidebar } from "#src/components/explore-sidebar.tsx";
 import {
@@ -63,7 +62,6 @@ export function Explore() {
     status,
     enabled,
     quota,
-    daresEnabled,
     conversations,
     transcript,
     messages,
@@ -313,7 +311,6 @@ export function Explore() {
           drawerOpen={drawerOpen}
           onDrawerOpenChange={setDrawerOpen}
           sidebar={sidebar}
-          extraActions={daresEnabled ? <ExploreDaresDrawer /> : undefined}
           {...(headerActions === undefined ? {} : { actions: headerActions })}
         />
 
@@ -460,7 +457,6 @@ function useExploreConversation(conversationId: string | null) {
   const trpc = useTRPC();
   const status = useQuery(trpc.explore.status.queryOptions());
   const enabled = status.data?.enabled === true;
-  const daresEnabled = status.data?.daresEnabled === true;
   const conversations = useQuery({
     ...trpc.explore.list.queryOptions(),
     enabled,
@@ -473,7 +469,6 @@ function useExploreConversation(conversationId: string | null) {
   return {
     status,
     enabled,
-    daresEnabled,
     quota: status.data?.quota ?? [],
     conversations,
     transcript,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -44,6 +44,7 @@ export type DareV2ListItem = z.infer<typeof DareV2ListItemSchema>;
 
 export const DareV2InspectionSchema = DareV2ListItemSchema.extend({
   channelId: z.string().min(1),
+  originConversationId: z.string().min(1).nullable(),
   canonicalScoutQl: z.string().min(1),
   plan: DareCompiledPlanV2Schema,
   semanticProofPlan: z.string().min(1),
@@ -65,6 +66,7 @@ type VisibleDareRow = {
   id: number;
   serverId: string;
   channelId: string;
+  originConversationId: string | null;
   challengerDiscordId: string;
   dareState: string;
   currentRevision: number;
@@ -165,6 +167,7 @@ function inspection(row: VisibleDareRow): DareV2Inspection {
   return DareV2InspectionSchema.parse({
     ...listItem(row),
     channelId: row.channelId,
+    originConversationId: row.originConversationId,
     canonicalScoutQl: visibleDareScoutQlV2({
       state,
       plan,

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/links.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, test } from "vitest";
+import { dareV2DraftComponents } from "#src/betting/dare-components-v2.ts";
 import { resetConfigurationForTests } from "#src/configuration.ts";
 import {
   getDocsUrl,
   getExploreConversationUrl,
 } from "#src/discord/commands/links.ts";
+import { exploreActionRow } from "#src/discord/scout/messages.ts";
 import { buildDiscordInstallUrl } from "#src/lib/discord/install-url.ts";
 import { PermissionFlagsBits, PermissionsBitField } from "discord.js";
 
@@ -31,8 +33,36 @@ describe("stage-aware Discord links", () => {
 
     expect(getDocsUrl()).toBe("https://beta.scout-for-lol.com/docs/");
     expect(getExploreConversationUrl("conversation-id")).toBe(
-      "https://beta.scout-for-lol.com/app/explore/conversation-id/",
+      "https://beta.scout-for-lol.com/app/explore/conversation-id",
     );
+  });
+
+  test("keeps Scout and Bryan Bucks conversation buttons slashless", () => {
+    Bun.env["WEB_APP_ORIGIN"] = "https://beta.scout-for-lol.com/";
+    resetConfigurationForTests();
+    const conversationId = "10000000-0000-4000-8000-000000000001";
+    const expected = `https://beta.scout-for-lol.com/app/explore/${conversationId}`;
+
+    const scoutButton = JSON.stringify(
+      exploreActionRow({
+        conversationId,
+        assistantMessageId: "10000000-0000-4000-8000-000000000002",
+        posted: false,
+      }),
+    );
+    const dareButtons = JSON.stringify(
+      dareV2DraftComponents({
+        intentId: "10000000-0000-4000-8000-000000000003",
+        dareId: 7,
+        revision: 2,
+        conversationId,
+      }),
+    );
+
+    expect(scoutButton).toContain(`"url":"${expected}"`);
+    expect(dareButtons).toContain(`"url":"${expected}"`);
+    expect(scoutButton).not.toContain(`"url":"${expected}/"`);
+    expect(dareButtons).not.toContain(`"url":"${expected}/"`);
   });
 
   test("keeps applications.commands in the install URL", () => {

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/links.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/links.ts
@@ -16,5 +16,5 @@ export function getDocsUrl(): string {
 }
 
 export function getExploreConversationUrl(conversationId: string): string {
-  return `${getOrigin()}/app/explore/${conversationId}/`;
+  return `${getOrigin()}/app/explore/${conversationId}`;
 }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.test.ts
@@ -8,6 +8,7 @@ import {
 } from "vitest";
 import {
   DiscordAccountIdSchema,
+  DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   type DiscordAccountId,
   type DiscordGuildId,
@@ -40,6 +41,7 @@ const guildId = DiscordGuildIdSchema.parse("100000000000000061");
 const otherGuildId = DiscordGuildIdSchema.parse("100000000000000062");
 const actor = DiscordAccountIdSchema.parse("300000000000000061");
 const rival = bucksTestDiscordId(7);
+const DARE_CHANNEL_ID = DiscordChannelIdSchema.parse("200000000000000061");
 const MATCH_ID = "NA1_5000009101";
 
 function caller() {
@@ -47,6 +49,8 @@ function caller() {
 }
 
 async function clearAll(): Promise<void> {
+  await db.bucksDareV2ConfirmationIntent.deleteMany();
+  await db.bucksDareV2.deleteMany();
   await db.bucksLedgerEntry.deleteMany();
   await db.bucksOpenPosition.deleteMany();
   await db.bucksWeeklyParlayBet.deleteMany();
@@ -251,6 +255,8 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   resetFlagOverrides("betting_enabled");
+  resetFlagOverrides("dare_v2");
+  resetFlagOverrides("scoutql_relational_enabled");
   resetFlagOverrides("weekly_parlays_enabled");
   addFlagOverride("betting_enabled", true, { server: guildId });
   trpc.setMembership([{ guildId, asAdmin: false }]);
@@ -259,6 +265,8 @@ beforeEach(async () => {
 
 afterAll(async () => {
   resetFlagOverrides("betting_enabled");
+  resetFlagOverrides("dare_v2");
+  resetFlagOverrides("scoutql_relational_enabled");
   resetFlagOverrides("weekly_parlays_enabled");
   await shutdownFeatureFlags();
   await db.$disconnect();
@@ -280,8 +288,46 @@ describe("bucks.status", () => {
     const status = await caller().bucks.status();
     expect(status).toEqual({
       state: "available",
-      guilds: [{ id: guildId, name: "test-guild" }],
+      guilds: [{ id: guildId, name: "test-guild", daresAvailable: false }],
     });
+  });
+
+  test("shows Dares when the v2 and relational flags are enabled", async () => {
+    addFlagOverride("dare_v2", true, { server: guildId });
+    addFlagOverride("scoutql_relational_enabled", true, { server: guildId });
+
+    const status = await caller().bucks.status();
+    expect(status).toMatchObject({
+      guilds: [{ id: guildId, daresAvailable: true }],
+    });
+  });
+
+  test("keeps Dares available to the owner of an existing private draft", async () => {
+    await db.bucksDareV2.create({
+      data: {
+        serverId: guildId,
+        channelId: DARE_CHANNEL_ID,
+        challengerDiscordId: actor,
+        openingStake: 20,
+      },
+    });
+
+    const status = await caller().bucks.status();
+    expect(status).toMatchObject({ guilds: [{ daresAvailable: true }] });
+  });
+
+  test("does not expose another member's private draft", async () => {
+    await db.bucksDareV2.create({
+      data: {
+        serverId: guildId,
+        channelId: DARE_CHANNEL_ID,
+        challengerDiscordId: rival,
+        openingStake: 20,
+      },
+    });
+
+    const status = await caller().bucks.status();
+    expect(status).toMatchObject({ guilds: [{ daresAvailable: false }] });
   });
 
   test("answers no_shared_guild when the member shares no enabled guild", async () => {
@@ -301,6 +347,18 @@ describe("bucks.status", () => {
 });
 
 describe("bucks reads", () => {
+  test("Dare management is scoped to an explicit shared guild", async () => {
+    await expect(
+      caller().bucks.dareList({ guildId, scope: "mine" }),
+    ).resolves.toEqual([]);
+    await expect(
+      caller().bucks.dareList({ guildId: otherGuildId, scope: "guild" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    await expect(
+      caller().bucks.dareInspect({ guildId, dareId: 999 }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
   test("wallet answers null before any Bucks interaction", async () => {
     const wallet = await caller().bucks.wallet({ guildId });
     expect(wallet).toEqual({ eligible: false, wallet: null });

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import {
   BucksParlaySideSchema,
@@ -6,6 +7,8 @@ import {
   DiscordAccountIdSchema,
   DiscordGuildIdSchema,
   RiotTeamIdSchema,
+  type DiscordAccountId,
+  type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { captureBucksMemberActivity } from "#src/analytics/bryan-bucks.ts";
 import type { BucksMemberActivityKind } from "#src/analytics/product-analytics.ts";
@@ -16,6 +19,10 @@ import {
 } from "#src/betting/accounts.ts";
 import { cancelBet } from "#src/betting/cancel-bet.ts";
 import { bettingAnchor } from "#src/betting/components.ts";
+import {
+  inspectVisibleDareV2,
+  listVisibleDaresV2,
+} from "#src/betting/dare-view-v2.ts";
 import { cancellationHouseCut } from "#src/betting/house-cut.ts";
 import { refreshBucksMessages } from "#src/betting/message-refresh.ts";
 import { ledgerKindLabel } from "#src/betting/navigation.ts";
@@ -36,13 +43,56 @@ import {
   assertBucksScope,
   resolveBucksScope,
 } from "#src/consumer/bucks-access.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
+import {
+  DareDraftEditorInputSchema,
+  DareDraftPreviewInputSchema,
+  previewDareDraftEditorV2,
+  reviseDareDraftEditorV2,
+  validateDareDraftEditorV2,
+} from "#src/explore/dare-editor-v2.ts";
 import { router, webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
 
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 const MatchInput = GuildInput.extend({
   matchId: z.string().min(1).max(64),
 });
+const DareListInput = GuildInput.extend({
+  scope: z.enum(["mine", "guild"]),
+  search: z.string().min(1).max(100).optional(),
+});
+const DareInspectInput = GuildInput.extend({
+  dareId: z.number().int().positive(),
+});
+const DareDraftInput = DareDraftEditorInputSchema.extend({
+  guildId: DiscordGuildIdSchema,
+});
+const DareDraftPreviewInput = DareDraftPreviewInputSchema.extend({
+  guildId: DiscordGuildIdSchema,
+});
+
+async function dareManagementAvailable(
+  guildId: DiscordGuildId,
+  viewerDiscordId: DiscordAccountId,
+): Promise<boolean> {
+  const [dareEnabled, relationalEnabled, existingDare] = await Promise.all([
+    isPolicyEnabled("dare_v2", { server: guildId }),
+    isPolicyEnabled("scoutql_relational_enabled", { server: guildId }),
+    prisma.bucksDareV2.findFirst({
+      where: {
+        serverId: guildId,
+        dareState: { not: "deleted" },
+        OR: [
+          { dareState: { not: "draft" } },
+          { challengerDiscordId: viewerDiscordId },
+        ],
+      },
+      select: { id: true },
+    }),
+  ]);
+  return (dareEnabled && relationalEnabled) || existingDare !== null;
+}
 
 /**
  * Best-effort member-activity analytics for a completed web mutation.
@@ -85,14 +135,88 @@ export const bucksRouter = router({
     if (scope.kind === "forbidden") {
       return { state: scope.reason } as const;
     }
+    const viewerDiscordId = DiscordAccountIdSchema.parse(ctx.user.discordId);
     return {
       state: "available",
-      guilds: scope.guilds.map((guild) => ({
-        id: guild.id,
-        name: guild.name,
-      })),
+      guilds: await Promise.all(
+        scope.guilds.map(async (guild) => ({
+          id: guild.id,
+          name: guild.name,
+          daresAvailable: await dareManagementAvailable(
+            DiscordGuildIdSchema.parse(guild.id),
+            viewerDiscordId,
+          ),
+        })),
+      ),
     } as const;
   }),
+
+  dareList: webProcedure.input(DareListInput).query(async ({ ctx, input }) => {
+    await assertBucksScope(ctx.user, input.guildId);
+    return await listVisibleDaresV2(
+      {
+        serverId: input.guildId,
+        viewerDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+        scope: input.scope,
+        ...(input.search === undefined ? {} : { search: input.search }),
+      },
+      prisma,
+    );
+  }),
+
+  dareInspect: webProcedure
+    .input(DareInspectInput)
+    .query(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const dare = await inspectVisibleDareV2(
+        {
+          dareId: input.dareId,
+          serverId: input.guildId,
+          viewerDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+        },
+        prisma,
+      );
+      if (dare === null) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Dare not found." });
+      }
+      return dare;
+    }),
+
+  dareValidateDraft: webProcedure
+    .input(DareDraftInput)
+    .query(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const { guildId, ...draft } = input;
+      return await validateDareDraftEditorV2(
+        draft,
+        DiscordAccountIdSchema.parse(ctx.user.discordId),
+        [guildId],
+      );
+    }),
+
+  darePreviewDraft: webProcedure
+    .input(DareDraftPreviewInput)
+    .query(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const { guildId, ...draft } = input;
+      return await previewDareDraftEditorV2(
+        draft,
+        DiscordAccountIdSchema.parse(ctx.user.discordId),
+        [guildId],
+      );
+    }),
+
+  dareReviseDraft: webMutationProcedure
+    .input(DareDraftInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const { guildId, ...draft } = input;
+      return await reviseDareDraftEditorV2(
+        draft,
+        DiscordAccountIdSchema.parse(ctx.user.discordId),
+        [guildId],
+      );
+    }),
 
   wallet: webProcedure.input(GuildInput).query(async ({ ctx, input }) => {
     await assertBucksScope(ctx.user, input.guildId);

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.test.ts
@@ -71,7 +71,6 @@ describe("explore router", () => {
 
     expect(await caller.explore.status()).toEqual({
       enabled: false,
-      daresEnabled: false,
       quota: [],
     });
     await expect(caller.explore.list()).rejects.toThrow(/not enabled/i);
@@ -83,7 +82,6 @@ describe("explore router", () => {
 
     const status = await caller.explore.status();
     expect(status.enabled).toBe(false);
-    expect(status.daresEnabled).toBe(false);
     await expect(caller.explore.list()).rejects.toThrow(/limited to a few/i);
   });
 
@@ -92,25 +90,8 @@ describe("explore router", () => {
 
     const status = await caller.explore.status();
     expect(status.enabled).toBe(true);
-    expect(status.daresEnabled).toBe(false);
     expect(status.quota.length).toBeGreaterThan(0);
     expect(await caller.explore.list()).toEqual([]);
-  });
-
-  test("exposes the Dare surface only for a relevant private draft", async () => {
-    await trpc.prisma.bucksDareV2.create({
-      data: {
-        serverId: ALLOWED_GUILD,
-        channelId: DARE_CHANNEL,
-        challengerDiscordId: OWNER,
-        openingStake: 20,
-      },
-    });
-
-    const ownerStatus = await trpc.authedCaller(OWNER).explore.status();
-    const strangerStatus = await trpc.authedCaller(STRANGER).explore.status();
-    expect(ownerStatus.daresEnabled).toBe(true);
-    expect(strangerStatus.daresEnabled).toBe(false);
   });
 
   test("reloads a confirmation intent's durable outcome for its actor", async () => {

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/explore.router.ts
@@ -12,14 +12,9 @@ import {
   ExploreRunOutcomeResultSchema,
   ExploreTurnRequestSchema,
 } from "@scout-for-lol/data";
-import {
-  inspectVisibleDareV2,
-  listVisibleDaresV2,
-} from "#src/betting/dare-view-v2.ts";
 import { consumeDareV2ConfirmationIntent } from "#src/betting/dare-intent-consume-v2.ts";
 import { tryEnsureDareV2Callout } from "#src/betting/dare-callout-v2.ts";
 import { DareV2IntentActionSchema } from "#src/betting/dare-intent-v2.ts";
-import { isPolicyEnabled } from "#src/configuration/flags.ts";
 import { prisma } from "#src/database/index.ts";
 import {
   assertExploreAccess,
@@ -45,13 +40,6 @@ import {
   shareExploreConversation,
 } from "#src/explore/store.ts";
 import { scoutExploreSharesTotal } from "#src/metrics/explore.ts";
-import {
-  DareDraftEditorInputSchema,
-  DareDraftPreviewInputSchema,
-  previewDareDraftEditorV2,
-  reviseDareDraftEditorV2,
-  validateDareDraftEditorV2,
-} from "#src/explore/dare-editor-v2.ts";
 import {
   protectedProcedure,
   router,
@@ -97,33 +85,6 @@ async function requireExploreUserAndGuilds(
   };
 }
 
-async function dareSurfaceEnabled(
-  userId: DiscordAccountId,
-  guildIds: string[],
-): Promise<boolean> {
-  const [enabledByGuild, existingDare] = await Promise.all([
-    Promise.all(
-      guildIds.map(async (guildId) => {
-        const serverId = DiscordGuildIdSchema.parse(guildId);
-        const [dareEnabled, relationalEnabled] = await Promise.all([
-          isPolicyEnabled("dare_v2", { server: serverId }),
-          isPolicyEnabled("scoutql_relational_enabled", { server: serverId }),
-        ]);
-        return dareEnabled && relationalEnabled;
-      }),
-    ),
-    prisma.bucksDareV2.findFirst({
-      where: {
-        serverId: { in: guildIds },
-        dareState: { not: "deleted" },
-        OR: [{ dareState: { not: "draft" } }, { challengerDiscordId: userId }],
-      },
-      select: { id: true },
-    }),
-  ]);
-  return enabledByGuild.some(Boolean) || existingDare !== null;
-}
-
 async function requireGuildDareIntent(intentId: string, guildIds: string[]) {
   const intent = await prisma.bucksDareV2ConfirmationIntent.findUnique({
     where: { id: intentId },
@@ -151,18 +112,17 @@ export const exploreRouter = router({
    */
   status: exploreProcedure.query(async ({ ctx }) => {
     if (!isExploreConfigured()) {
-      return { enabled: false, daresEnabled: false, quota: [] };
+      return { enabled: false, quota: [] };
     }
     try {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
+      const { userId } = await requireExploreUserAndGuilds(ctx.user);
       return {
         enabled: true,
-        daresEnabled: await dareSurfaceEnabled(userId, guildIds),
         quota: getExploreQuotaStatus({ userId }).quota,
       };
     } catch (error) {
       if (error instanceof TRPCError && error.code === "FORBIDDEN") {
-        return { enabled: false, daresEnabled: false, quota: [] };
+        return { enabled: false, quota: [] };
       }
       throw error;
     }
@@ -172,76 +132,6 @@ export const exploreRouter = router({
     const userId = await requireExploreUser(ctx.user);
     return await listExploreConversations(prisma, userId);
   }),
-
-  dareList: exploreProcedure
-    .input(
-      z.strictObject({
-        scope: z.enum(["mine", "guild"]),
-        search: z.string().min(1).max(100).optional(),
-      }),
-    )
-    .query(async ({ ctx, input }) => {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      const pages = await Promise.all(
-        guildIds.map(
-          async (guildId) =>
-            await listVisibleDaresV2(
-              {
-                serverId: DiscordGuildIdSchema.parse(guildId),
-                viewerDiscordId: userId,
-                scope: input.scope,
-                ...(input.search === undefined ? {} : { search: input.search }),
-              },
-              prisma,
-            ),
-        ),
-      );
-      return pages
-        .flat()
-        .toSorted((left, right) =>
-          right.updatedAt.localeCompare(left.updatedAt),
-        )
-        .slice(0, 100);
-    }),
-
-  dareInspect: exploreProcedure
-    .input(z.strictObject({ dareId: z.number().int().positive() }))
-    .query(async ({ ctx, input }) => {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      for (const guildId of guildIds) {
-        const dare = await inspectVisibleDareV2(
-          {
-            dareId: input.dareId,
-            serverId: DiscordGuildIdSchema.parse(guildId),
-            viewerDiscordId: userId,
-          },
-          prisma,
-        );
-        if (dare !== null) return dare;
-      }
-      throw new TRPCError({ code: "NOT_FOUND", message: "Dare not found." });
-    }),
-
-  dareValidateDraft: exploreProcedure
-    .input(DareDraftEditorInputSchema)
-    .query(async ({ ctx, input }) => {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      return await validateDareDraftEditorV2(input, userId, guildIds);
-    }),
-
-  darePreviewDraft: exploreProcedure
-    .input(DareDraftPreviewInputSchema)
-    .query(async ({ ctx, input }) => {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      return await previewDareDraftEditorV2(input, userId, guildIds);
-    }),
-
-  dareReviseDraft: webMutationProcedure
-    .input(DareDraftEditorInputSchema)
-    .mutation(async ({ ctx, input }) => {
-      const { userId, guildIds } = await requireExploreUserAndGuilds(ctx.user);
-      return await reviseDareDraftEditorV2(input, userId, guildIds);
-    }),
 
   dareIntentStatus: exploreProcedure
     .input(z.strictObject({ intentId: z.uuid() }))

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/bryan-bucks-commands.md
@@ -43,6 +43,11 @@ queues, game and time bounds, stake, and generated contract ScoutQL. Funding is
 never automatic: use **Confirm and fund**, **Revise in Explore**, or **Cancel
 draft** from that preview.
 
+Use the **Dares** tab in Bryan Bucks to search **My Dares** or the selected
+server's funded **Guild Dares**, inspect contract evidence and proof, and edit
+an unfunded draft. Explore remains the conversational creation and revision
+surface.
+
 ## Options
 
 ### `/bb transfer`

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/dashboard.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/reference/dashboard.md
@@ -15,28 +15,37 @@ A beta deployment of the same dashboard runs at
 
 ## Top level
 
-| Route                  | Contents                                          |
-| ---------------------- | ------------------------------------------------- |
-| `/app/`                | Server picker — the servers you can manage        |
-| `/app/welcome`         | Guided onboarding wizard                          |
-| `/app/installed`       | Landing page after adding Scout to a server       |
-| `/app/explore`         | Persistent Explore conversations and dare drawers |
-| `/app/g/<server id>/…` | The workspace for one server                      |
+| Route                  | Contents                                            |
+| ---------------------- | --------------------------------------------------- |
+| `/app/`                | Server picker — the servers you can manage          |
+| `/app/welcome`         | Guided onboarding wizard                            |
+| `/app/installed`       | Landing page after adding Scout to a server         |
+| `/app/explore`         | Persistent Explore conversations and Dare authoring |
+| `/app/bucks/dares`     | Dare discovery and management for Bryan Bucks       |
+| `/app/g/<server id>/…` | The workspace for one server                        |
 
 ## Explore
 
 Explore keeps private, branching conversations over Scout's recorded match
-corpus. When Dare v2 is enabled for one of your Bryan Bucks servers, the header
-also opens searchable **My Dares** and **Guild Dares** drawers.
+corpus. It is also the conversational Dare authoring surface: `/bb dare` starts
+a private Explore conversation, and transcript cards let the author clarify a
+contract and confirm its next action.
+
+## Bryan Bucks Dares
+
+The **Dares** tab under Bryan Bucks is the discovery and management surface for
+the currently selected server. It appears when Dare v2 is enabled or when the
+member has an existing Dare that must remain accessible.
 
 **My Dares** includes your private unfunded drafts and every visible funded
-contract. **Guild Dares** includes funded contracts in servers you currently
-share; it never exposes another member's draft. A dare card shows its stable ID,
-revision, lifecycle state, explicit same-game or cross-game meaning, targets,
-queue and time bounds, current pot, evidence progress, and reproducible proof
-after settlement.
+contract involving you. **Guild Dares** includes funded contracts in the
+selected server; it never exposes another member's draft. A Dare detail shows
+its stable ID, revision, lifecycle state, explicit same-game or cross-game
+meaning, targets, queue and time bounds, current pot, evidence progress, and
+reproducible proof after settlement.
 
-Draft owners can validate, historically preview, revise, or delete a draft.
+Draft owners can validate, historically preview, or revise a draft with the
+advanced editor, or return to Explore for conversational revision.
 The advanced editor exposes the typed contract plan and generated ScoutQL with
 diagnostics, semantic explanation, and a meaning diff before revision. Funding,
 acceptance, decline, contribution, and cancellation first create a revision-

--- a/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-explore-conversation.md
+++ b/packages/scout-for-lol/packages/docs-site/src/content/docs/tutorials/first-explore-conversation.md
@@ -70,6 +70,12 @@ private Explore conversation and an unfunded draft. Open **Revise in Explore**
 from Discord, then tell Scout what was wrong in ordinary language—for example,
 “the CS and duration conditions must happen in the same game.”
 
+To find the draft later, open Bryan Bucks, choose its server, and select the
+**Dares** tab. **My Dares** contains your private draft; **Guild Dares** contains
+the server's funded contracts. Open the draft there to inspect its evidence or
+use the advanced editor, then return to Explore for another conversational
+revision.
+
 Before replacing the draft, inspect the card's explicit scope, targets,
 participation relationship, queues, first-N or game cap, deadline, stake, plain
 meaning, and canonical ScoutQL. Historical preview uses only matches and


### PR DESCRIPTION
Why:
Dares were exposed as an Explore management drawer, while generated Explore links failed when their trailing slash was preserved.

What:
- Add the guild-scoped Bryan Bucks Dares route with list, search, detail, proof/evidence, and draft editing states.
- Move Dare management procedures behind the Bryan Bucks router and server-side guild authorization.
- Keep conversational authoring and confirmation flows in Explore.
- Generate slashless Explore conversation URLs for Scout and Bryan Bucks buttons.
- Update tests and Scout documentation.

Verification:
- Focused app lint, architecture, typecheck, production build, and Dares UI tests passed.
- Focused backend and docs build/typecheck/lint tasks passed.
- Discord link/command suites passed 19 tests.
- git diff --check passed.
- Authenticated beta browser acceptance was not run because local startup awaited workstation 1Password approval.

Rollout:
No database migration or Dare contract change is required. The feature remains governed by existing Dare and relational ScoutQL flags.