### PR TITLE
fix(scout-for-lol): show accurate Dare funding and pile-ons

### DIFF
--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { dareV2CalloutContent } from "#src/betting/dare-callout-content-v2.ts";
+
+const ACCEPT_DEADLINE = new Date("2026-09-02T12:00:00.000Z");
+
+function content(input: {
+  openingStake: number;
+  potTotal: number;
+  contributions: readonly { discordId: string; amount: number }[];
+}) {
+  return dareV2CalloutContent({
+    id: 1,
+    challengerDiscordId: "100",
+    openingStake: input.openingStake,
+    potTotal: input.potTotal,
+    contributions: input.contributions,
+    targetAliases: ["Virmel"],
+    revision: 1,
+    plainLanguage: "Virmel wins a game with at least 8 CS per minute.",
+    evidenceCount: 0,
+    state: "pending_accept",
+    targets: [{ alias: "Virmel", acceptedAt: null, declinedAt: null }],
+    acceptDeadline: ACCEPT_DEADLINE,
+    deadlineAt: null,
+    finalValue: null,
+    voidReason: null,
+  });
+}
+
+describe("dareV2CalloutContent", () => {
+  test("shows no pile-ons when only the opening contribution exists", () => {
+    const rendered = content({
+      openingStake: 10,
+      potTotal: 10,
+      contributions: [{ discordId: "100", amount: 10 }],
+    });
+
+    expect(rendered).toContain("<@100> put **10 BB** on Virmel.");
+    expect(rendered).toContain("Pot: **10 BB**");
+    expect(rendered).toContain("**Pile-ons:**\nNone yet.");
+  });
+
+  test("shows a later contributor separately from the opening stake", () => {
+    const rendered = content({
+      openingStake: 10,
+      potTotal: 15,
+      contributions: [
+        { discordId: "100", amount: 10 },
+        { discordId: "200", amount: 5 },
+      ],
+    });
+
+    expect(rendered).toContain("<@100> put **10 BB** on Virmel.");
+    expect(rendered).toContain("Pot: **15 BB**");
+    expect(rendered).toContain("<@200> — **5 BB**");
+    expect(rendered).not.toContain("<@100> — **10 BB**");
+  });
+
+  test("aggregates repeated contributions in first-contribution order", () => {
+    const rendered = content({
+      openingStake: 10,
+      potTotal: 25,
+      contributions: [
+        { discordId: "100", amount: 10 },
+        { discordId: "200", amount: 5 },
+        { discordId: "300", amount: 2 },
+        { discordId: "200", amount: 5 },
+      ],
+    });
+
+    expect(rendered).toContain("<@200> — **10 BB**");
+    expect(rendered).toContain("<@300> — **2 BB**");
+    expect(rendered.indexOf("<@200> — **10 BB**")).toBeLessThan(
+      rendered.indexOf("<@300> — **2 BB**"),
+    );
+    expect(rendered).not.toContain("<@200> — **5 BB**");
+  });
+
+  test("keeps the opening stake separate from the current pot", () => {
+    const rendered = content({
+      openingStake: 10,
+      potTotal: 20,
+      contributions: [
+        { discordId: "100", amount: 10 },
+        { discordId: "200", amount: 10 },
+      ],
+    });
+
+    expect(rendered).toContain("put **10 BB**");
+    expect(rendered).toContain("Pot: **20 BB**");
+  });
+
+  test("summarizes deterministic overflow contributors", () => {
+    const rendered = content({
+      openingStake: 10,
+      potTotal: 211,
+      contributions: [
+        { discordId: "100", amount: 10 },
+        ...Array.from({ length: 200 }, (_, index) => ({
+          discordId: (index + 200).toString(),
+          amount: 1,
+        })),
+      ],
+    });
+
+    expect(rendered.length).toBeLessThanOrEqual(2000);
+    expect(rendered).toContain("…and");
+    expect(rendered).toContain("more contributor(s).");
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.ts
@@ -1,10 +1,75 @@
-import type { BucksDareV2State } from "@scout-for-lol/data";
+import { formatInteger, type BucksDareV2State } from "@scout-for-lol/data";
+import { DARE_CALLOUT_MAX_LENGTH } from "#src/betting/dare-copy.ts";
 
 type DareV2CalloutTarget = {
   alias: string;
   acceptedAt: Date | null;
   declinedAt: Date | null;
 };
+
+export type DareV2CalloutContribution = {
+  discordId: string;
+  amount: number;
+};
+
+function pileOnContributions(
+  contributions: readonly DareV2CalloutContribution[],
+): DareV2CalloutContribution[] {
+  const totals = new Map<string, number>();
+  const order: string[] = [];
+  for (const contribution of contributions.slice(1)) {
+    const current = totals.get(contribution.discordId);
+    if (current === undefined) order.push(contribution.discordId);
+    totals.set(contribution.discordId, (current ?? 0) + contribution.amount);
+  }
+  return order.map((discordId) => {
+    const amount = totals.get(discordId);
+    if (amount === undefined) {
+      throw new Error(`Missing pile-on total for ${discordId}.`);
+    }
+    return { discordId, amount };
+  });
+}
+
+function renderPileOnLines(
+  contributions: readonly DareV2CalloutContribution[],
+  visibleCount: number,
+): string[] {
+  const visible = contributions.slice(0, visibleCount);
+  const hidden = contributions.length - visible.length;
+  return [
+    "**Pile-ons:**",
+    ...(visible.length === 0
+      ? ["None yet."]
+      : visible.map(
+          (contribution) =>
+            `<@${contribution.discordId}> — **${formatInteger(contribution.amount)} BB**`,
+        )),
+    ...(hidden === 0
+      ? []
+      : [`…and ${formatInteger(hidden)} more contributor(s).`]),
+  ];
+}
+
+function renderWithinDiscordLimit(input: {
+  baseLines: readonly string[];
+  pileOns: readonly DareV2CalloutContribution[];
+}): string {
+  for (
+    let visibleCount = input.pileOns.length;
+    visibleCount >= 0;
+    visibleCount--
+  ) {
+    const content = [
+      ...input.baseLines,
+      ...renderPileOnLines(input.pileOns, visibleCount),
+    ].join("\n");
+    if (content.length <= DARE_CALLOUT_MAX_LENGTH) return content;
+  }
+  throw new Error(
+    `Dare v2 callout exceeds Discord's ${DARE_CALLOUT_MAX_LENGTH.toString()}-character limit.`,
+  );
+}
 
 function statusText(input: {
   state: BucksDareV2State;
@@ -55,7 +120,9 @@ function statusText(input: {
 export function dareV2CalloutContent(input: {
   id: number;
   challengerDiscordId: string;
+  openingStake: number;
   potTotal: number;
+  contributions: readonly DareV2CalloutContribution[];
   targetAliases: readonly string[];
   revision: number;
   plainLanguage: string;
@@ -67,14 +134,18 @@ export function dareV2CalloutContent(input: {
   finalValue: boolean | null;
   voidReason: string | null;
 }): string {
-  return [
-    `🎯 **Scout Dare #${input.id.toString()}**`,
-    `<@${input.challengerDiscordId}> put **${input.potTotal.toString()} BB** on ${input.targetAliases.join(", ")}.`,
-    "",
-    `**Contract · revision ${input.revision.toString()}**`,
-    input.plainLanguage,
-    "",
-    `**Progress** · ${input.evidenceCount.toString()} evidence games`,
-    `**Status** · ${statusText(input)}`,
-  ].join("\n");
+  return renderWithinDiscordLimit({
+    baseLines: [
+      `🎯 **Scout Dare #${input.id.toString()}**`,
+      `<@${input.challengerDiscordId}> put **${formatInteger(input.openingStake)} BB** on ${input.targetAliases.join(", ")}.`,
+      `Pot: **${formatInteger(input.potTotal)} BB**`,
+      "",
+      `**Contract · revision ${input.revision.toString()}**`,
+      input.plainLanguage,
+      "",
+      `**Progress** · ${formatInteger(input.evidenceCount)} evidence games`,
+      `**Status** · ${statusText(input)}`,
+    ],
+    pileOns: pileOnContributions(input.contributions),
+  });
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.ts
@@ -54,7 +54,15 @@ function renderPileOnLines(
 function renderWithinDiscordLimit(input: {
   baseLines: readonly string[];
   pileOns: readonly DareV2CalloutContribution[];
-}): string {
+  enforceDiscordLimit: boolean;
+}): { content: string; visibleCount: number } {
+  const fullContent = [
+    ...input.baseLines,
+    ...renderPileOnLines(input.pileOns, input.pileOns.length),
+  ].join("\n");
+  if (!input.enforceDiscordLimit) {
+    return { content: fullContent, visibleCount: input.pileOns.length };
+  }
   for (
     let visibleCount = input.pileOns.length;
     visibleCount >= 0;
@@ -64,12 +72,33 @@ function renderWithinDiscordLimit(input: {
       ...input.baseLines,
       ...renderPileOnLines(input.pileOns, visibleCount),
     ].join("\n");
-    if (content.length <= DARE_CALLOUT_MAX_LENGTH) return content;
+    if (content.length <= DARE_CALLOUT_MAX_LENGTH) {
+      return { content, visibleCount };
+    }
   }
   throw new Error(
     `Dare v2 callout exceeds Discord's ${DARE_CALLOUT_MAX_LENGTH.toString()}-character limit.`,
   );
 }
+
+export type DareV2CalloutInput = {
+  id: number;
+  challengerDiscordId: string;
+  openingStake: number;
+  potTotal: number;
+  contributions: readonly DareV2CalloutContribution[];
+  targetAliases: readonly string[];
+  revision: number;
+  plainLanguage: string;
+  evidenceCount: number;
+  state: BucksDareV2State;
+  targets: readonly DareV2CalloutTarget[];
+  acceptDeadline: Date | null;
+  deadlineAt: Date | null;
+  finalValue: boolean | null;
+  voidReason: string | null;
+  enforceDiscordLimit?: boolean;
+};
 
 function statusText(input: {
   state: BucksDareV2State;
@@ -117,24 +146,12 @@ function statusText(input: {
   return input.finalValue === null ? input.state : String(input.finalValue);
 }
 
-export function dareV2CalloutContent(input: {
-  id: number;
-  challengerDiscordId: string;
-  openingStake: number;
-  potTotal: number;
-  contributions: readonly DareV2CalloutContribution[];
-  targetAliases: readonly string[];
-  revision: number;
-  plainLanguage: string;
-  evidenceCount: number;
-  state: BucksDareV2State;
-  targets: readonly DareV2CalloutTarget[];
-  acceptDeadline: Date | null;
-  deadlineAt: Date | null;
-  finalValue: boolean | null;
-  voidReason: string | null;
-}): string {
-  return renderWithinDiscordLimit({
+export function renderDareV2Callout(input: DareV2CalloutInput): {
+  content: string;
+  contributorDiscordIds: string[];
+} {
+  const pileOns = pileOnContributions(input.contributions);
+  const rendered = renderWithinDiscordLimit({
     baseLines: [
       `🎯 **Scout Dare #${input.id.toString()}**`,
       `<@${input.challengerDiscordId}> put **${formatInteger(input.openingStake)} BB** on ${input.targetAliases.join(", ")}.`,
@@ -146,6 +163,17 @@ export function dareV2CalloutContent(input: {
       `**Progress** · ${formatInteger(input.evidenceCount)} evidence games`,
       `**Status** · ${statusText(input)}`,
     ],
-    pileOns: pileOnContributions(input.contributions),
+    pileOns,
+    enforceDiscordLimit: input.enforceDiscordLimit ?? true,
   });
+  return {
+    content: rendered.content,
+    contributorDiscordIds: pileOns
+      .slice(0, rendered.visibleCount)
+      .map((contribution) => contribution.discordId),
+  };
+}
+
+export function dareV2CalloutContent(input: DareV2CalloutInput): string {
+  return renderDareV2Callout(input).content;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
@@ -10,7 +10,7 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { dareV2CalloutComponents } from "#src/betting/dare-components-v2.ts";
-import { dareV2CalloutContent } from "#src/betting/dare-callout-content-v2.ts";
+import { renderDareV2Callout } from "#src/betting/dare-callout-content-v2.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -20,6 +20,7 @@ import { createLogger } from "#src/logger.ts";
 
 const logger = createLogger("betting-dare-callout-v2");
 const CALLOUT_CLAIM_STALE_MS = 10 * 60 * 1000;
+const MAX_ALLOWED_MENTION_USERS = 100;
 
 export type DareV2MessageSender = (
   options: MessageCreateOptions,
@@ -69,6 +70,19 @@ export type DareV2CalloutState = {
   content: string;
 };
 
+function allowedMentionUsers(
+  state: DareV2CalloutState,
+  includeTargets: boolean,
+): string[] {
+  return [
+    ...new Set([
+      state.challengerDiscordId,
+      ...state.contributorDiscordIds,
+      ...(includeTargets ? state.targetDiscordIds : []),
+    ]),
+  ].slice(0, MAX_ALLOWED_MENTION_USERS);
+}
+
 export async function loadDareV2CalloutState(
   dareId: number,
   prismaClient: ExtendedPrismaClient = prisma,
@@ -96,11 +110,23 @@ export async function loadDareV2CalloutState(
     );
   }
   const state = BucksDareV2StateSchema.parse(dare.dareState);
-  const contributorDiscordIds = [
-    ...new Set(
-      dare.contributions.slice(1).map((contribution) => contribution.discordId),
-    ),
-  ];
+  const rendered = renderDareV2Callout({
+    id: dare.id,
+    challengerDiscordId: dare.challengerDiscordId,
+    openingStake: dare.openingStake,
+    potTotal: dare.potTotal,
+    contributions: dare.contributions,
+    targetAliases: dare.targets.map((target) => target.alias),
+    revision: revisionNumber,
+    plainLanguage: revision.plainLanguage,
+    evidenceCount: dare._count.evidence,
+    state,
+    targets: dare.targets,
+    acceptDeadline: dare.acceptDeadline,
+    deadlineAt: dare.deadlineAt,
+    finalValue: dare.finalValue,
+    voidReason: dare.voidReason,
+  });
   return {
     id: dare.id,
     serverId: dare.serverId,
@@ -111,24 +137,8 @@ export async function loadDareV2CalloutState(
     revision: revisionNumber,
     challengerDiscordId: dare.challengerDiscordId,
     targetDiscordIds: dare.targets.map((target) => target.discordId),
-    contributorDiscordIds,
-    content: dareV2CalloutContent({
-      id: dare.id,
-      challengerDiscordId: dare.challengerDiscordId,
-      openingStake: dare.openingStake,
-      potTotal: dare.potTotal,
-      contributions: dare.contributions,
-      targetAliases: dare.targets.map((target) => target.alias),
-      revision: revisionNumber,
-      plainLanguage: revision.plainLanguage,
-      evidenceCount: dare._count.evidence,
-      state,
-      targets: dare.targets,
-      acceptDeadline: dare.acceptDeadline,
-      deadlineAt: dare.deadlineAt,
-      finalValue: dare.finalValue,
-      voidReason: dare.voidReason,
-    }),
+    contributorDiscordIds: rendered.contributorDiscordIds,
+    content: rendered.content,
   };
 }
 
@@ -241,13 +251,7 @@ export async function postDareV2Callout(
                 }),
                 allowedMentions: {
                   parse: [],
-                  users: [
-                    ...new Set([
-                      state.challengerDiscordId,
-                      ...state.targetDiscordIds,
-                      ...state.contributorDiscordIds,
-                    ]),
-                  ],
+                  users: allowedMentionUsers(state, true),
                 },
               },
               DiscordChannelIdSchema.parse(state.channelId),
@@ -307,12 +311,7 @@ export async function refreshDareV2Callout(
               }),
               allowedMentions: {
                 parse: [],
-                users: [
-                  ...new Set([
-                    state.challengerDiscordId,
-                    ...state.contributorDiscordIds,
-                  ]),
-                ],
+                users: allowedMentionUsers(state, false),
               },
             },
           });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
@@ -65,6 +65,7 @@ export type DareV2CalloutState = {
   revision: number;
   challengerDiscordId: string;
   targetDiscordIds: string[];
+  contributorDiscordIds: string[];
   content: string;
 };
 
@@ -77,6 +78,10 @@ export async function loadDareV2CalloutState(
     include: {
       revisions: { orderBy: { revision: "asc" } },
       targets: { orderBy: { id: "asc" } },
+      contributions: {
+        orderBy: { id: "asc" },
+        select: { discordId: true, amount: true },
+      },
       _count: { select: { evidence: true } },
     },
   });
@@ -91,6 +96,11 @@ export async function loadDareV2CalloutState(
     );
   }
   const state = BucksDareV2StateSchema.parse(dare.dareState);
+  const contributorDiscordIds = [
+    ...new Set(
+      dare.contributions.slice(1).map((contribution) => contribution.discordId),
+    ),
+  ];
   return {
     id: dare.id,
     serverId: dare.serverId,
@@ -101,10 +111,13 @@ export async function loadDareV2CalloutState(
     revision: revisionNumber,
     challengerDiscordId: dare.challengerDiscordId,
     targetDiscordIds: dare.targets.map((target) => target.discordId),
+    contributorDiscordIds,
     content: dareV2CalloutContent({
       id: dare.id,
       challengerDiscordId: dare.challengerDiscordId,
+      openingStake: dare.openingStake,
       potTotal: dare.potTotal,
+      contributions: dare.contributions,
       targetAliases: dare.targets.map((target) => target.alias),
       revision: revisionNumber,
       plainLanguage: revision.plainLanguage,
@@ -228,7 +241,13 @@ export async function postDareV2Callout(
                 }),
                 allowedMentions: {
                   parse: [],
-                  users: [state.challengerDiscordId, ...state.targetDiscordIds],
+                  users: [
+                    ...new Set([
+                      state.challengerDiscordId,
+                      ...state.targetDiscordIds,
+                      ...state.contributorDiscordIds,
+                    ]),
+                  ],
                 },
               },
               DiscordChannelIdSchema.parse(state.channelId),
@@ -286,7 +305,15 @@ export async function refreshDareV2Callout(
                 dareId: state.id,
                 revision: state.revision,
               }),
-              allowedMentions: { parse: [] },
+              allowedMentions: {
+                parse: [],
+                users: [
+                  ...new Set([
+                    state.challengerDiscordId,
+                    ...state.contributorDiscordIds,
+                  ]),
+                ],
+              },
             },
           });
         },

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
@@ -165,7 +165,9 @@ export function prepareDareDraftV2(
   const calloutPreview = dareV2CalloutContent({
     id: BUCKS_INT32_MAX,
     challengerDiscordId: "9".repeat(20),
+    openingStake: BUCKS_INT32_MAX,
     potTotal: BUCKS_INT32_MAX,
+    contributions: [],
     targetAliases: targets.map((target) => target.alias),
     revision: BUCKS_INT32_MAX,
     plainLanguage,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
@@ -167,7 +167,10 @@ export function prepareDareDraftV2(
     challengerDiscordId: "9".repeat(20),
     openingStake: BUCKS_INT32_MAX,
     potTotal: BUCKS_INT32_MAX,
-    contributions: [],
+    contributions: [
+      { discordId: "9".repeat(20), amount: BUCKS_INT32_MAX },
+      { discordId: "8".repeat(20), amount: BUCKS_INT32_MAX },
+    ],
     targetAliases: targets.map((target) => target.alias),
     revision: BUCKS_INT32_MAX,
     plainLanguage,
@@ -182,6 +185,7 @@ export function prepareDareDraftV2(
     deadlineAt: null,
     finalValue: null,
     voidReason: null,
+    enforceDiscordLimit: false,
   });
   if (calloutPreview.length > DARE_CALLOUT_MAX_LENGTH) {
     issues.push(

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-v2.integration.test.ts
@@ -303,6 +303,30 @@ async function consume(intentId: string, actor: DiscordAccountId) {
   );
 }
 
+async function makeContribution(
+  dareId: number,
+  actor: DiscordAccountId,
+  amount: number,
+  key: string,
+): Promise<void> {
+  const result = await createDareV2ConfirmationIntent(
+    {
+      dareId,
+      serverId: SERVER,
+      actorDiscordId: actor,
+      expectedRevision: 1,
+      payload: { action: "contribute", amount },
+      idempotencyKey: key,
+    },
+    deps,
+    T0,
+  );
+  if (result.kind !== "intent_created") {
+    throw new Error("Expected contribution intent.");
+  }
+  await consume(result.intentId, actor);
+}
+
 async function expectChallengerBalance(balance: number): Promise<void> {
   const wallet = await db.bucksAccount.findUniqueOrThrow({
     where: {
@@ -1394,6 +1418,61 @@ describe("Dare v2 callout delivery", () => {
       messageRef: JSON.stringify({
         channelId: CHANNEL,
         messageId: "retried-callout-message",
+      }),
+    });
+  });
+});
+
+describe("Dare v2 callout contributor delivery", () => {
+  test("renders pile-ons and allows contributor mentions on post and refresh", async () => {
+    const dareId = await makeDraft({ openingStake: 10 });
+    const fundIntent = await intent({
+      dareId,
+      actor: CHALLENGER,
+      action: "fund",
+      key: "fund-callout-contributor",
+    });
+    await consume(fundIntent, CHALLENGER);
+    await makeContribution(dareId, CONTRIBUTOR, 5, "contributor-callout-first");
+
+    const sendMessage = vi.fn(() =>
+      Promise.resolve({
+        channelId: CHANNEL,
+        id: "contributor-callout-message",
+      }),
+    );
+    const editMessage = vi.fn(() => Promise.resolve());
+    const dependencies = { prismaClient: db, sendMessage, editMessage };
+
+    await postDareV2Callout(dareId, dependencies);
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(`<@${CONTRIBUTOR}> — **5 BB**`),
+        allowedMentions: expect.objectContaining({
+          users: expect.arrayContaining([CONTRIBUTOR]),
+        }),
+      }),
+      CHANNEL,
+      SERVER,
+    );
+
+    await makeContribution(
+      dareId,
+      CONTRIBUTOR,
+      5,
+      "contributor-callout-second",
+    );
+    await refreshDareV2Callout(dareId, dependencies);
+
+    expect(editMessage).toHaveBeenCalledWith({
+      channelId: CHANNEL,
+      messageId: "contributor-callout-message",
+      options: expect.objectContaining({
+        content: expect.stringContaining(`<@${CONTRIBUTOR}> — **10 BB**`),
+        allowedMentions: {
+          parse: [],
+          users: expect.arrayContaining([CONTRIBUTOR]),
+        },
       }),
     });
   });


### PR DESCRIPTION
## Why

Dare v2 callouts displayed the current pot as the challenger's opening stake, obscuring who funded later contributions.

## What

- Render the opening stake separately from the current pot.
- Aggregate and display later pile-on contributors in contribution order.
- Allow contributor mentions on initial callouts and refreshes, with bounded overflow summaries.
- Add renderer and delivery coverage.

## Verification

- Focused Dare v2 Vitest suites passed.
- Backend typecheck passed.
- Backend lint passed with 0 errors.
- Live beta data was inspected read-only; no live mutation was performed.