### PR TITLE
feat(llm-observability): monitor complimentary OpenAI inference

### DIFF
--- a/.jscpd-baseline.json
+++ b/.jscpd-baseline.json
@@ -780,10 +780,6 @@
       "clones": 2,
       "tokens": 146
     },
-    "packages/homelab/src/cdk8s/src/temporal-backup-worker.test.ts|packages/homelab/src/cdk8s/src/temporal-workflow-boundary.test.ts": {
-      "clones": 1,
-      "tokens": 73
-    },
     "packages/homelab/src/helm-types/src/cli.test.ts|packages/homelab/src/helm-types/src/cli.test.ts": {
       "clones": 3,
       "tokens": 222
@@ -1791,6 +1787,10 @@
     "packages/temporal/src/workflows/glitter-corpus.test.ts|packages/temporal/src/workflows/glitter-corpus.test.ts": {
       "clones": 1,
       "tokens": 78
+    },
+    "packages/temporal/src/workflows/test-support.ts|packages/temporal/src/workflows/test-support.ts": {
+      "clones": 1,
+      "tokens": 76
     },
     "packages/toolkit/src/commands/history/history.ts|packages/toolkit/src/commands/history/history.ts": {
       "clones": 1,

--- a/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
+++ b/packages/docs/wiki/src/content/docs/explanation/llm-stack.md
@@ -72,6 +72,26 @@ question, waiting on the correlated OpenRouter Broadcast record to settle it;
 until then the spend ceilings take the per-series maximum of `actual` and
 `upstream`, because an alert should err toward firing.
 
+For OpenAI BYOK traffic, none of those three gateway figures proves what OpenAI
+charged. Complimentary input/output sharing creates a fourth case: OpenRouter's
+`actual` cost is zero, `upstream` is an estimate of ordinary provider cost, and
+OpenAI may still charge zero because the request used its `incentivized-tier`.
+The evidence therefore has a strict order:
+
+1. `openrouter_metadata.is_byok` proves which credential path one request used.
+2. OpenAI's organization Usage API proves which `service_tier` received its
+   tokens after the provider's ingestion delay.
+3. OpenAI's organization Costs API is the billing authority for money charged.
+4. OpenRouter actual, upstream, and catalog cost remain routing and estimation
+   diagnostics, not proof of an OpenAI payment.
+
+The `temporal-billing-worker` reconciles the OpenRouter OpenAI project hourly,
+with a 15-minute ingestion cutoff. It is a single-purpose Activity Worker: it
+has one organization admin key, Temporal and telemetry access, HTTPS egress,
+and Alertmanager access, but no Flipt reachability or Kubernetes service-account
+token. The privileged admin key remains organization-wide at OpenAI despite
+that runtime isolation.
+
 ## Attribution
 
 Spans carry who a call was made on behalf of, as a `(kind, id)` pair over
@@ -112,7 +132,10 @@ would need its own store, which is deliberately not built until a chargeback or
 quota requirement justifies it.
 
 Structured-output attempts, router attempts, and missing router metadata have
-separate counters. Existing `ai_provider_errors_total` and
+separate counters. BYOK status is a bounded per-request counter; official
+current-day OpenAI tokens, cost, and reconciliation freshness are gauges.
+Project IDs, generation IDs, user IDs, prompts, and responses never become
+labels. Existing `ai_provider_errors_total` and
 `ai_provider_issue_active` series remain queryable across the cutover.
 
 ## Deployment acceptance

--- a/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
+++ b/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
@@ -22,6 +22,10 @@ Take the per-series maximum of `actual` and `upstream`, not `actual` alone: a BY
 route bills nothing through OpenRouter and reads as `$0` under an actual-only query
 while still costing real money upstream.
 
+For OpenAI complimentary-token traffic, this is intentionally conservative and
+does not answer what was paid. Use the official reconciliation below before
+treating `upstream` as an OpenAI charge.
+
 The inner `sum` must stay inside the `max`. These series carry `pod`, so a deploy
 inside the window leaves two counter series per workload, and taking the maximum
 first would keep only the longer-lived pod's spend.
@@ -73,6 +77,49 @@ Workloads with no requester declare `system` on purpose — scheduled betting ru
 and match reviews are not made on behalf of a person who asked. Those are
 attributed, just not to a human. A span with _no_ subject attributes at all is an
 unwrapped call site.
+
+## Verify Scout's complimentary OpenAI inference
+
+First confirm that successful Scout reviews used the configured provider key:
+
+```bash
+toolkit prom query 'sum by (model, upstream_provider, byok) (increase(llm_openrouter_byok_requests_total{service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?"}[1h]))'
+```
+
+`byok="true"` is necessary but not sufficient. Trigger the
+`openai-complimentary-usage-hourly` Temporal schedule after waiting at least 15
+minutes from the request, then query the official provider reconciliation:
+
+```bash
+toolkit prom query 'sum by (model, service_tier, type) (openai_project_usage_tokens)'
+toolkit prom query 'max(openai_project_cost_usd)'
+toolkit prom query 'time() - max(openai_usage_reconciliation_last_success_timestamp_seconds)'
+```
+
+The request is confirmed complimentary only when its tokens appear under
+`incentivized-tier` and official current-day Costs remain zero. A request that
+crosses OpenAI's daily allowance can be billed in full, so any `default`-tier
+tokens are actionable even when BYOK is still healthy.
+
+The alerts divide failures by evidence layer:
+
+- `ScoutOpenAiNotByok` means OpenRouter reported shared capacity for a
+  successful Scout review.
+- `LlmOpenRouterMetadataMissing` means the request-level credential evidence is
+  absent.
+- `OpenAiComplimentaryPaidTokens` means the official Usage API reported
+  `default`-tier tokens.
+- `OpenAiOpenRouterProjectCost` means official current-day Costs reached one
+  cent.
+- `OpenAiComplimentaryMonitorStale` means no complete reconciliation succeeded
+  for two hours after the billing worker started.
+
+To rotate the monitor credential, create a new organization admin key named
+`openai-usage-monitor`, replace only the `OPENAI_ADMIN_KEY` field in the
+dedicated 1Password item, restart `temporal-billing-worker`, and run the
+schedule once. Delete the prior OpenAI admin key only after Usage, Costs,
+metrics, and both Alertmanager resolutions succeed. Never move this key into
+the shared Temporal item: OpenAI admin keys are organization-wide credentials.
 
 ## Related
 

--- a/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
+++ b/packages/homelab/src/cdk8s/grafana/ai-provider-dashboard-llm.ts
@@ -260,6 +260,83 @@ export function addLlmPanels(
 
   builder.withPanel(createSubjectTokenPanel());
   builder.withPanel(createSubjectCallPanel());
+
+  builder.withRow(
+    new dashboard.RowBuilder("OpenAI Complimentary Inference").gridPos({
+      x: 0,
+      y: 100,
+      w: 24,
+      h: 1,
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "OpenRouter BYOK Request Rate",
+      description:
+        "Successful OpenRouter language requests by provider-reported BYOK state. Scout reviews should remain byok=true.",
+      targets: [
+        {
+          query:
+            "sum by (service, workload, model, upstream_provider, byok) (rate(llm_openrouter_byok_requests_total[5m])) or on() vector(0)",
+          legend:
+            "{{service}} {{workload}} {{model}} {{upstream_provider}} byok={{byok}}",
+        },
+      ],
+      gridPos: { x: 0, y: 101, w: 12, h: 8 },
+      unit: "reqps",
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Official OpenAI Tokens by Service Tier",
+      description:
+        "Current UTC-day tokens from OpenAI's organization Usage API after the ingestion cutoff.",
+      targets: [
+        {
+          query:
+            "sum by (model, service_tier, type) (openai_project_usage_tokens) or on() vector(0)",
+          legend: "{{model}} {{service_tier}} {{type}}",
+        },
+      ],
+      gridPos: { x: 12, y: 101, w: 12, h: 8 },
+      unit: "short",
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "Official OpenAI Project Cost",
+      description:
+        "Current UTC-day cost from OpenAI's organization Costs API; this is the billing authority.",
+      targets: [
+        {
+          query: "max(openai_project_cost_usd) or on() vector(0)",
+          legend: "official cost",
+        },
+      ],
+      gridPos: { x: 0, y: 109, w: 12, h: 8 },
+      unit: "currencyUSD",
+    }),
+  );
+
+  builder.withPanel(
+    createTimeseriesPanel({
+      title: "OpenAI Reconciliation Freshness",
+      description:
+        "Seconds since the last complete Usage, Costs, metrics, and Alertmanager reconciliation.",
+      targets: [
+        {
+          query:
+            "time() - max(openai_usage_reconciliation_last_success_timestamp_seconds)",
+          legend: "last success age",
+        },
+      ],
+      gridPos: { x: 12, y: 109, w: 12, h: 8 },
+      unit: "s",
+    }),
+  );
 }
 
 /**

--- a/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
+++ b/packages/homelab/src/cdk8s/onepassword-vault-snapshot.json
@@ -1,6 +1,6 @@
 {
   "vaultId": "v64ocnykdqju4ui6j6pua56xw4",
-  "generatedAt": "2026-08-31T01:34:48.092Z",
+  "generatedAt": "2026-09-02T06:35:42.423Z",
   "items": [
     {
       "ref": "037fea718ca7342d83da3f0210b7ce00483490e5d5f32a55aed15a0fce678707",
@@ -55,6 +55,18 @@
       "blankFields": [
         "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
         "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
+      ]
+    },
+    {
+      "ref": "10ff8888c7194e1d9de443f894f6ab1f937a958e626c7a8644d072344b402e5a",
+      "title": "d0a4596e18161b7f790bd84923545beca59e68ca5839ffe47d764890fc64e42b",
+      "fields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa",
+        "7cf055fbf7ce9eabf54b9bcb0a91de284fff423927afc35b371d29225220b548",
+        "f3f6918a76ed1ef35bd826ad1bb8b0001b78da92175ccdaa476047d190cbe00d"
+      ],
+      "blankFields": [
+        "4b3a0f7ec9c74329647dd6577bdd7a9ac0361fd4c724b3de12a55e9161f9e9aa"
       ]
     },
     {

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -16,7 +16,10 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
   expect(serialized).toContain("ScoutOpenAiNotByok");
   expect(serialized).toContain("OpenAiComplimentaryMonitorStale");
   expect(serialized).toContain("llm_openrouter_byok_requests_total");
-  expect(serialized).toContain(String.raw`byok=~"false|unknown"`);
+  const scoutByokAlert = groups
+    .flatMap(({ rules: groupRules }) => groupRules)
+    .find((rule) => rule?.alert === "ScoutOpenAiNotByok");
+  expect(scoutByokAlert?.expr?.value).toContain('byok=~"false|unknown"');
   expect(serialized).toContain(
     "openai_usage_reconciliation_last_success_timestamp_seconds",
   );

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -16,6 +16,7 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
   expect(serialized).toContain("ScoutOpenAiNotByok");
   expect(serialized).toContain("OpenAiComplimentaryMonitorStale");
   expect(serialized).toContain("llm_openrouter_byok_requests_total");
+  expect(serialized).toContain('byok=~\\"false|unknown\\"');
   expect(serialized).toContain(
     "openai_usage_reconciliation_last_success_timestamp_seconds",
   );

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -16,7 +16,7 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
   expect(serialized).toContain("ScoutOpenAiNotByok");
   expect(serialized).toContain("OpenAiComplimentaryMonitorStale");
   expect(serialized).toContain("llm_openrouter_byok_requests_total");
-  expect(serialized).toContain('byok=~\\"false|unknown\\"');
+  expect(serialized).toContain(String.raw`byok=~"false|unknown"`);
   expect(serialized).toContain(
     "openai_usage_reconciliation_last_success_timestamp_seconds",
   );

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -13,6 +13,12 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
   expect(serialized).toContain("llm:requests:rate5m");
   expect(serialized).toContain("llm:request_duration:p95_5m");
   expect(serialized).toContain("LlmOpenRouterMetadataMissing");
+  expect(serialized).toContain("ScoutOpenAiNotByok");
+  expect(serialized).toContain("OpenAiComplimentaryMonitorStale");
+  expect(serialized).toContain("llm_openrouter_byok_requests_total");
+  expect(serialized).toContain(
+    "openai_usage_reconciliation_last_success_timestamp_seconds",
+  );
   expect(serialized).toContain("LlmStructuredOutputExhausted");
   expect(serialized).toContain("birmel_admission_classifier_total");
   expect(serialized).toContain("birmel_memory_extraction_total");

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -112,6 +112,33 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
       interval: "30s",
       rules: [
         {
+          alert: "ScoutOpenAiNotByok",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            'sum(increase(llm_openrouter_byok_requests_total{service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?",byok="false"}[15m])) > 0',
+          ),
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            summary: "Scout review reached OpenAI without BYOK",
+            description: escapePrometheusTemplate(
+              "At least one successful Scout review used OpenRouter shared capacity instead of the configured OpenAI key. Check the OpenRouter BYOK key state and shared-capacity fallback setting before relying on complimentary OpenAI tokens.",
+            ),
+          },
+        },
+        {
+          alert: "OpenAiComplimentaryMonitorStale",
+          expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
+            '(time() - max(temporal_worker_app_process_start_time_seconds{namespace="temporal",pod=~"temporal-billing-worker-.*"})) > 7200 and ((time() - max(openai_usage_reconciliation_last_success_timestamp_seconds{namespace="temporal"})) > 7200 or absent(openai_usage_reconciliation_last_success_timestamp_seconds{namespace="temporal"}))',
+          ),
+          for: "5m",
+          labels: { severity: "warning", category: "llm" },
+          annotations: {
+            summary: "OpenAI complimentary-token reconciliation is stale",
+            description: escapePrometheusTemplate(
+              "The isolated billing worker has been running for more than two hours without a successful OpenAI Usage and Costs reconciliation. Check its Temporal poller, admin key, OpenAI project scope, and API errors.",
+            ),
+          },
+        },
+        {
           alert: "LlmOpenRouterMetadataMissing",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
             "sum(increase(llm_openrouter_metadata_missing_total[15m])) > 0",

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -114,13 +114,13 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "ScoutOpenAiNotByok",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'sum(increase(llm_openrouter_byok_requests_total{service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?",byok="false"}[15m])) > 0',
+            'sum(increase(llm_openrouter_byok_requests_total{service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?",byok=~"false|unknown"}[15m])) > 0',
           ),
           labels: { severity: "warning", category: "llm" },
           annotations: {
             summary: "Scout review reached OpenAI without BYOK",
             description: escapePrometheusTemplate(
-              "At least one successful Scout review used OpenRouter shared capacity instead of the configured OpenAI key. Check the OpenRouter BYOK key state and shared-capacity fallback setting before relying on complimentary OpenAI tokens.",
+              "At least one successful Scout review used OpenRouter shared capacity or lacked BYOK metadata. Check the OpenRouter key state and shared-capacity fallback before relying on complimentary OpenAI tokens.",
             ),
           },
         },

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/temporal-worker-health.ts
@@ -174,6 +174,14 @@ export const TEMPORAL_DOMAIN_QUEUES: readonly TemporalDomainQueueDefinition[] =
       servedNamespaces: ["prod"],
     },
     {
+      queue: "billing",
+      metricsNamespace: "temporal",
+      deploymentPattern: "temporal-temporal-billing-worker",
+      servicePattern: ".*temporal-billing-worker.*metrics.*",
+      activityPoller: true,
+      servedNamespaces: ["prod"],
+    },
+    {
       queue: "maintenance",
       metricsNamespace: "buildkite",
       deploymentPattern: "temporal-maintenance-worker",

--- a/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
@@ -119,6 +119,7 @@ export function createTemporalOperationsWorkers(
       TEMPORAL_NAMESPACE: EnvValue.fromValue("prod"),
       TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
       TEMPORAL_WORKER_ROLE: EnvValue.fromValue("billing"),
+      FEATURE_FLAGS_MODE: EnvValue.fromValue("disabled"),
       ENVIRONMENT: EnvValue.fromValue("production"),
       TELEMETRY_ENABLED: EnvValue.fromValue("true"),
       OTLP_ENDPOINT: EnvValue.fromValue(

--- a/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/operations-workers.ts
@@ -60,6 +60,7 @@ export type TemporalOperationsWorkerProps = {
   freshRssManifestVolume: Volume;
   freshRssCredentialVolume: Volume;
   backupSecret: ISecret;
+  billingSecret: ISecret;
 };
 
 export function createTemporalOperationsWorkers(
@@ -102,6 +103,40 @@ export function createTemporalOperationsWorkers(
         readOnly: true,
       },
     ],
+  });
+
+  const billingDeployment = createTemporalDomainWorker(chart, {
+    name: "temporal-billing-worker",
+    component: "billing-worker",
+    featureFlagsEnabled: false,
+    automountServiceAccountToken: false,
+    cpuRequest: Cpu.millis(100),
+    cpuLimit: Cpu.millis(500),
+    memoryRequest: Size.mebibytes(256),
+    memoryLimit: Size.mebibytes(512),
+    envVariables: {
+      TEMPORAL_ADDRESS: EnvValue.fromValue(`${props.serverServiceName}:7233`),
+      TEMPORAL_NAMESPACE: EnvValue.fromValue("prod"),
+      TEMPORAL_METRICS_ADDRESS: EnvValue.fromValue("0.0.0.0:9464"),
+      TEMPORAL_WORKER_ROLE: EnvValue.fromValue("billing"),
+      ENVIRONMENT: EnvValue.fromValue("production"),
+      TELEMETRY_ENABLED: EnvValue.fromValue("true"),
+      OTLP_ENDPOINT: EnvValue.fromValue(
+        "http://tempo.tempo.svc.cluster.local:4318",
+      ),
+      TELEMETRY_SERVICE_NAME: EnvValue.fromValue("temporal-billing-worker"),
+      OPENAI_ADMIN_KEY: EnvValue.fromSecretValue({
+        secret: props.billingSecret,
+        key: "OPENAI_ADMIN_KEY",
+      }),
+      OPENAI_OPENROUTER_PROJECT_ID: EnvValue.fromSecretValue({
+        secret: props.billingSecret,
+        key: "OPENAI_OPENROUTER_PROJECT_ID",
+      }),
+      ALERTMANAGER_URL: EnvValue.fromValue(
+        "http://prometheus-kube-prometheus-alertmanager.prometheus:9093",
+      ),
+    },
   });
 
   const repoDeployment = createTemporalDomainWorker(chart, {
@@ -244,5 +279,6 @@ export function createTemporalOperationsWorkers(
     repoDeployment,
     scoutDeployment,
     backupDeployment,
+    billingDeployment,
   };
 }

--- a/packages/homelab/src/cdk8s/src/resources/temporal/runtime-env.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/runtime-env.ts
@@ -1,7 +1,14 @@
 import { EnvValue, type ISecret } from "cdk8s-plus-31";
 
 export type TemporalRuntimeRole =
-  "backup" | "control" | "home" | "reports" | "infra" | "repo" | "scout";
+  | "backup"
+  | "billing"
+  | "control"
+  | "home"
+  | "reports"
+  | "infra"
+  | "repo"
+  | "scout";
 
 export function temporalRuntimeEnv(
   serverServiceName: string,

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker-network-policies.ts
@@ -138,6 +138,7 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
     "glitter-corpus-worker",
     "glitter-context-worker",
     "backup-worker",
+    "billing-worker",
   ]) {
     new KubeNetworkPolicy(chart, `${component}-network-policy`, {
       metadata: { name: `temporal-${component}-netpol` },
@@ -173,6 +174,17 @@ export function createTemporalWorkerNetworkPolicies(chart: Chart): void {
           ],
           ports: [{ port: IntOrString.fromNumber(8333), protocol: "TCP" }],
         },
+      ],
+    },
+  });
+
+  new KubeNetworkPolicy(chart, "temporal-billing-alertmanager-netpol", {
+    metadata: { name: "temporal-billing-alertmanager-netpol" },
+    spec: {
+      podSelector: { matchLabels: { component: "billing-worker" } },
+      policyTypes: ["Egress"],
+      egress: [
+        { ports: [{ port: IntOrString.fromNumber(9093), protocol: "TCP" }] },
       ],
     },
   });

--- a/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
+++ b/packages/homelab/src/cdk8s/src/resources/temporal/worker.ts
@@ -99,6 +99,19 @@ export function createTemporalWorkerDeployment(
     "temporal-seaweedfs-backup-secret",
     backupCredentialItem.name,
   );
+  const openAiUsageMonitorItem = new OnePasswordItem(
+    chart,
+    "temporal-openai-usage-monitor-1p",
+    {
+      metadata: { name: "temporal-openai-usage-monitor" },
+      spec: { itemPath: vaultItemPath("openai-usage-monitor") },
+    },
+  );
+  const openAiUsageMonitorSecret = Secret.fromSecretName(
+    chart,
+    "temporal-openai-usage-monitor-secret",
+    openAiUsageMonitorItem.name,
+  );
   const freshRssManifest = new ConfigMap(chart, "temporal-freshrss-manifest", {
     metadata: { name: "temporal-freshrss-manifest" },
     data: { "desired.json": FRESHRSS_DESIRED_JSON },
@@ -259,18 +272,24 @@ export function createTemporalWorkerDeployment(
       defaultMode: 0o400,
     },
   );
-  const { infraDeployment, repoDeployment, scoutDeployment, backupDeployment } =
-    createTemporalOperationsWorkers(chart, {
-      serverServiceName: props.serverServiceName,
-      secret,
-      scoutWeeklyParlaySecret,
-      infraServiceAccount,
-      homelabAuditEnvironment: homelabAuditEnv(secret),
-      talosConfigVolume,
-      freshRssManifestVolume,
-      freshRssCredentialVolume,
-      backupSecret,
-    });
+  const {
+    infraDeployment,
+    repoDeployment,
+    scoutDeployment,
+    backupDeployment,
+    billingDeployment,
+  } = createTemporalOperationsWorkers(chart, {
+    serverServiceName: props.serverServiceName,
+    secret,
+    scoutWeeklyParlaySecret,
+    infraServiceAccount,
+    homelabAuditEnvironment: homelabAuditEnv(secret),
+    talosConfigVolume,
+    freshRssManifestVolume,
+    freshRssCredentialVolume,
+    backupSecret,
+    billingSecret: openAiUsageMonitorSecret,
+  });
 
   return {
     agentDeployment,
@@ -283,6 +302,7 @@ export function createTemporalWorkerDeployment(
     repoDeployment,
     scoutDeployment,
     backupDeployment,
+    billingDeployment,
     glitterCorpusDeployment: corpusDeployment,
     glitterContextDeployment: contextDeployment,
   };

--- a/packages/homelab/src/cdk8s/src/temporal-backup-worker.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-backup-worker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import {
   findTemporalResource,
+  findTemporalWorkerContainer,
   synthesizeTemporalResources,
 } from "./temporal-test-resources.ts";
 
@@ -12,43 +13,10 @@ function resources() {
 describe("Temporal SeaweedFS backup boundary", () => {
   test("uses one dedicated secret and no Kubernetes token", () => {
     const synthesized = resources();
-    const deployment = findTemporalResource(
+    const { pod, container } = findTemporalWorkerContainer(
       synthesized,
-      "Deployment",
       "temporal-temporal-backup-worker",
     );
-    const pod = z
-      .object({
-        template: z.object({
-          metadata: z.object({ labels: z.record(z.string(), z.string()) }),
-          spec: z.object({
-            automountServiceAccountToken: z.literal(false),
-            containers: z.array(
-              z.object({
-                env: z.array(
-                  z.object({
-                    name: z.string(),
-                    value: z.string().optional(),
-                    valueFrom: z
-                      .object({
-                        secretKeyRef: z.object({
-                          key: z.string(),
-                          name: z.string(),
-                        }),
-                      })
-                      .optional(),
-                  }),
-                ),
-              }),
-            ),
-          }),
-        }),
-      })
-      .parse(deployment.spec).template;
-    const container = pod.spec.containers[0];
-    if (container === undefined) {
-      throw new Error("Temporal backup container is missing");
-    }
     expect(pod.metadata.labels).toMatchObject({
       app: "temporal-worker",
       component: "backup-worker",

--- a/packages/homelab/src/cdk8s/src/temporal-billing-worker.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-billing-worker.test.ts
@@ -21,6 +21,7 @@ describe("Temporal OpenAI billing boundary", () => {
     expect(container.env.map((entry) => entry.name).sort()).toEqual([
       "ALERTMANAGER_URL",
       "ENVIRONMENT",
+      "FEATURE_FLAGS_MODE",
       "OPENAI_ADMIN_KEY",
       "OPENAI_OPENROUTER_PROJECT_ID",
       "OTLP_ENDPOINT",

--- a/packages/homelab/src/cdk8s/src/temporal-billing-worker.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-billing-worker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { z } from "zod";
 import {
   findTemporalResource,
+  findTemporalWorkerContainer,
   synthesizeTemporalResources,
 } from "./temporal-test-resources.ts";
 
@@ -12,42 +13,10 @@ function resources() {
 describe("Temporal OpenAI billing boundary", () => {
   test("projects the dedicated admin credential only into the billing worker", () => {
     const synthesized = resources();
-    const deployment = findTemporalResource(
+    const { pod, container } = findTemporalWorkerContainer(
       synthesized,
-      "Deployment",
       "temporal-temporal-billing-worker",
     );
-    const pod = z
-      .object({
-        template: z.object({
-          metadata: z.object({ labels: z.record(z.string(), z.string()) }),
-          spec: z.object({
-            automountServiceAccountToken: z.literal(false),
-            containers: z.array(
-              z.object({
-                env: z.array(
-                  z.object({
-                    name: z.string(),
-                    value: z.string().optional(),
-                    valueFrom: z
-                      .object({
-                        secretKeyRef: z.object({
-                          key: z.string(),
-                          name: z.string(),
-                        }),
-                      })
-                      .optional(),
-                  }),
-                ),
-              }),
-            ),
-          }),
-        }),
-      })
-      .parse(deployment.spec).template;
-    const container = pod.spec.containers[0];
-    if (container === undefined)
-      throw new Error("Billing container is missing");
     expect(pod.metadata.labels["component"]).toBe("billing-worker");
     expect(container.env.map((entry) => entry.name).sort()).toEqual([
       "ALERTMANAGER_URL",
@@ -73,7 +42,12 @@ describe("Temporal OpenAI billing boundary", () => {
       },
     });
     expect(
-      JSON.stringify(synthesized.filter((resource) => resource !== deployment)),
+      JSON.stringify(
+        synthesized.filter(
+          (resource) =>
+            resource.metadata.name !== "temporal-temporal-billing-worker",
+        ),
+      ),
     ).not.toContain("OPENAI_ADMIN_KEY");
 
     const item = findTemporalResource(

--- a/packages/homelab/src/cdk8s/src/temporal-billing-worker.test.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-billing-worker.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import {
+  findTemporalResource,
+  synthesizeTemporalResources,
+} from "./temporal-test-resources.ts";
+
+function resources() {
+  return synthesizeTemporalResources(".test-synth-temporal-billing-worker");
+}
+
+describe("Temporal OpenAI billing boundary", () => {
+  test("projects the dedicated admin credential only into the billing worker", () => {
+    const synthesized = resources();
+    const deployment = findTemporalResource(
+      synthesized,
+      "Deployment",
+      "temporal-temporal-billing-worker",
+    );
+    const pod = z
+      .object({
+        template: z.object({
+          metadata: z.object({ labels: z.record(z.string(), z.string()) }),
+          spec: z.object({
+            automountServiceAccountToken: z.literal(false),
+            containers: z.array(
+              z.object({
+                env: z.array(
+                  z.object({
+                    name: z.string(),
+                    value: z.string().optional(),
+                    valueFrom: z
+                      .object({
+                        secretKeyRef: z.object({
+                          key: z.string(),
+                          name: z.string(),
+                        }),
+                      })
+                      .optional(),
+                  }),
+                ),
+              }),
+            ),
+          }),
+        }),
+      })
+      .parse(deployment.spec).template;
+    const container = pod.spec.containers[0];
+    if (container === undefined)
+      throw new Error("Billing container is missing");
+    expect(pod.metadata.labels["component"]).toBe("billing-worker");
+    expect(container.env.map((entry) => entry.name).sort()).toEqual([
+      "ALERTMANAGER_URL",
+      "ENVIRONMENT",
+      "OPENAI_ADMIN_KEY",
+      "OPENAI_OPENROUTER_PROJECT_ID",
+      "OTLP_ENDPOINT",
+      "TELEMETRY_ENABLED",
+      "TELEMETRY_SERVICE_NAME",
+      "TEMPORAL_ADDRESS",
+      "TEMPORAL_METRICS_ADDRESS",
+      "TEMPORAL_NAMESPACE",
+      "TEMPORAL_WORKER_ROLE",
+      "TZ",
+    ]);
+    expect(container.env).toContainEqual({
+      name: "OPENAI_ADMIN_KEY",
+      valueFrom: {
+        secretKeyRef: {
+          key: "OPENAI_ADMIN_KEY",
+          name: "temporal-openai-usage-monitor",
+        },
+      },
+    });
+    expect(
+      JSON.stringify(synthesized.filter((resource) => resource !== deployment)),
+    ).not.toContain("OPENAI_ADMIN_KEY");
+
+    const item = findTemporalResource(
+      synthesized,
+      "OnePasswordItem",
+      "temporal-openai-usage-monitor",
+    );
+    expect(
+      z.object({ itemPath: z.string() }).parse(item.spec).itemPath,
+    ).toMatch(/\/items\/openai-usage-monitor$/u);
+  });
+
+  test("allows only metrics, DNS, Temporal, tracing, HTTPS, and Alertmanager", () => {
+    const synthesized = resources();
+    const base = findTemporalResource(
+      synthesized,
+      "NetworkPolicy",
+      "temporal-billing-worker-netpol",
+    );
+    const baseJson = JSON.stringify(base.spec);
+    for (const port of [53, 443, 4318, 7233, 9464, 9465]) {
+      expect(baseJson).toContain(String(port));
+    }
+    const alertmanager = findTemporalResource(
+      synthesized,
+      "NetworkPolicy",
+      "temporal-billing-alertmanager-netpol",
+    );
+    expect(JSON.stringify(alertmanager.spec)).toContain("9093");
+    const flipt = findTemporalResource(
+      synthesized,
+      "NetworkPolicy",
+      "temporal-workers-flipt-egress",
+    );
+    expect(JSON.stringify(flipt.spec)).not.toContain("billing-worker");
+  });
+});

--- a/packages/homelab/src/cdk8s/src/temporal-test-resources.ts
+++ b/packages/homelab/src/cdk8s/src/temporal-test-resources.ts
@@ -2,6 +2,7 @@ import { App } from "cdk8s";
 import { parseAllDocuments } from "yaml";
 import { z } from "zod";
 import { createTemporalChart } from "./cdk8s-charts/temporal.ts";
+import { ContainerEnvSchema } from "./testing/container-env-schema.ts";
 
 const TemporalResourceSchema = z
   .object({
@@ -13,6 +14,21 @@ const TemporalResourceSchema = z
   .loose();
 
 export type TemporalResource = z.infer<typeof TemporalResourceSchema>;
+
+const TemporalWorkerPodSchema = z.object({
+  metadata: z.object({ labels: z.record(z.string(), z.string()) }),
+  spec: z.object({
+    automountServiceAccountToken: z.literal(false),
+    containers: z.array(z.object({ env: ContainerEnvSchema })),
+  }),
+});
+const TemporalWorkerDeploymentSchema = z.object({
+  template: TemporalWorkerPodSchema,
+});
+
+export type TemporalWorkerContainer = z.infer<
+  typeof TemporalWorkerPodSchema
+>["spec"]["containers"][number];
 
 export function synthesizeTemporalResources(
   outdir: string,
@@ -37,4 +53,20 @@ export function findTemporalResource(
     throw new Error(`Missing ${kind}/${name}`);
   }
   return resource;
+}
+
+export function findTemporalWorkerContainer(
+  synthesized: readonly TemporalResource[],
+  name: string,
+): {
+  pod: z.infer<typeof TemporalWorkerPodSchema>;
+  container: TemporalWorkerContainer;
+} {
+  const deployment = findTemporalResource(synthesized, "Deployment", name);
+  const pod = TemporalWorkerDeploymentSchema.parse(deployment.spec).template;
+  const container = pod.spec.containers[0];
+  if (container === undefined) {
+    throw new Error(`Missing container in ${name}`);
+  }
+  return { pod, container };
 }

--- a/packages/homelab/src/cdk8s/src/testing/container-env-schema.ts
+++ b/packages/homelab/src/cdk8s/src/testing/container-env-schema.ts
@@ -7,5 +7,13 @@ import { z } from "zod";
  * re-declare the identical nested Zod object (jscpd flags that duplication).
  */
 export const ContainerEnvSchema = z.array(
-  z.object({ name: z.string(), value: z.string().optional() }),
+  z.object({
+    name: z.string(),
+    value: z.string().optional(),
+    valueFrom: z
+      .object({
+        secretKeyRef: z.object({ key: z.string(), name: z.string() }),
+      })
+      .optional(),
+  }),
 );

--- a/packages/llm-runtime/eslint-suppressions.json
+++ b/packages/llm-runtime/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/metrics.ts": {
-    "sonarjs/cognitive-complexity": {
-      "count": 1
-    }
-  },
   "src/validated-object.ts": {
     "sonarjs/cognitive-complexity": {
       "count": 1

--- a/packages/llm-runtime/src/logging.ts
+++ b/packages/llm-runtime/src/logging.ts
@@ -50,6 +50,7 @@ export function logOpenRouterResponse(input: {
     model: metadata.requestedModel,
     resolvedModel: metadata.resolvedModel,
     upstreamProvider: metadata.upstreamProvider,
+    isByok: metadata.isByok,
     generationId: metadata.generationId,
     route: metadata.route,
     region: metadata.region,

--- a/packages/llm-runtime/src/metadata.ts
+++ b/packages/llm-runtime/src/metadata.ts
@@ -26,6 +26,7 @@ const RouterMetadataSchema = z
     region: z.string().nullable().optional(),
     attempt: z.number().int().nonnegative().optional(),
     attempts: z.array(RouterAttemptSchema).optional(),
+    is_byok: z.boolean().optional(),
   })
   .loose();
 
@@ -184,6 +185,7 @@ function routingFields(input: {
   OpenRouterCallMetadata,
   | "requestedModel"
   | "upstreamProvider"
+  | "isByok"
   | "route"
   | "region"
   | "fallbackAttempts"
@@ -198,6 +200,7 @@ function routingFields(input: {
       nonEmpty(input.provider?.provider) ??
       nonEmpty(input.responseProvider) ??
       nonEmpty(attempts.at(-1)?.provider),
+    isByok: input.router?.is_byok,
     route: nonEmpty(input.router?.strategy),
     region: nonEmpty(input.router?.region ?? undefined),
     fallbackAttempts: Math.max(

--- a/packages/llm-runtime/src/metrics.ts
+++ b/packages/llm-runtime/src/metrics.ts
@@ -23,6 +23,9 @@ type RuntimeMetrics = CommonLlmMetrics & {
     "service" | "workload" | "model" | "upstream_provider" | "outcome"
   >;
   metadataMissing: Counter<"service" | "workload" | "model">;
+  byokRequests: Counter<
+    "service" | "workload" | "model" | "upstream_provider" | "byok"
+  >;
   structuredAttempts: Counter<"service" | "workload" | "model" | "outcome">;
 };
 
@@ -30,6 +33,54 @@ const metricsByRegister = new WeakMap<Registry, RuntimeMetrics>();
 
 function stableModelId(modelId: string): string {
   return modelIdForOpenRouterRoute(modelId) ?? modelId;
+}
+
+function recordByokResponse(
+  metrics: RuntimeMetrics,
+  input: {
+    readonly service: string;
+    readonly workload: string;
+    readonly model: string;
+    readonly upstreamProvider: string | undefined;
+    readonly isByok: boolean | undefined;
+  },
+): void {
+  metrics.byokRequests.inc({
+    service: input.service,
+    workload: input.workload,
+    model: input.model,
+    upstream_provider: input.upstreamProvider ?? "unknown",
+    byok: input.isByok === undefined ? "unknown" : String(input.isByok),
+  });
+}
+
+function recordLanguageRouterMetadata(
+  metrics: RuntimeMetrics,
+  input: {
+    readonly successful: boolean;
+    readonly endpoint: "language" | "embedding" | "image" | "unknown";
+    readonly service: string;
+    readonly workload: string;
+    readonly model: string;
+    readonly metadata: ReturnType<typeof parseOpenRouterMetadata>;
+  },
+): void {
+  if (!input.successful || input.endpoint !== "language") return;
+  if (!input.metadata.routerMetadataPresent) {
+    metrics.metadataMissing.inc({
+      service: input.service,
+      workload: input.workload,
+      model: input.model,
+    });
+    return;
+  }
+  recordByokResponse(metrics, {
+    service: input.service,
+    workload: input.workload,
+    model: input.model,
+    upstreamProvider: input.metadata.upstreamProvider,
+    isByok: input.metadata.isByok,
+  });
 }
 
 export function recordRouterResponse(
@@ -56,17 +107,14 @@ export function recordRouterResponse(
     input.responseStatus < 400;
   // OpenRouter currently emits router metadata only on completion routes, not
   // embeddings or images. Do not turn unsupported endpoints into false alerts.
-  if (
-    successful &&
-    input.endpoint === "language" &&
-    !metadata.routerMetadataPresent
-  ) {
-    metrics.metadataMissing.inc({
-      service: input.service,
-      workload: input.workload,
-      model,
-    });
-  }
+  recordLanguageRouterMetadata(metrics, {
+    successful,
+    endpoint: input.endpoint,
+    service: input.service,
+    workload: input.workload,
+    model,
+    metadata,
+  });
   for (const attempt of metadata.attempts) {
     metrics.routerAttempts.inc({
       service: input.service,
@@ -150,6 +198,12 @@ export function runtimeMetrics(
       name: "llm_openrouter_metadata_missing_total",
       help: "Successful OpenRouter calls without router metadata.",
       labelNames: ["service", "workload", "model"],
+      registers: [register],
+    }),
+    byokRequests: new Counter({
+      name: "llm_openrouter_byok_requests_total",
+      help: "Successful OpenRouter language calls by BYOK status.",
+      labelNames: ["service", "workload", "model", "upstream_provider", "byok"],
       registers: [register],
     }),
     structuredAttempts: new Counter({

--- a/packages/llm-runtime/src/types.ts
+++ b/packages/llm-runtime/src/types.ts
@@ -16,6 +16,7 @@ export type OpenRouterRuntimeLogRecord = {
   model: string;
   resolvedModel?: string | undefined;
   upstreamProvider?: string | undefined;
+  isByok?: boolean | undefined;
   generationId?: string | undefined;
   route?: string | undefined;
   region?: string | undefined;
@@ -116,6 +117,7 @@ export type OpenRouterCallMetadata = {
   requestedModel: string;
   resolvedModel?: string | undefined;
   upstreamProvider?: string | undefined;
+  isByok?: boolean | undefined;
   route?: string | undefined;
   region?: string | undefined;
   fallbackAttempts: number;

--- a/packages/llm-runtime/test/attributed-fetch.test.ts
+++ b/packages/llm-runtime/test/attributed-fetch.test.ts
@@ -12,6 +12,7 @@ const ObservationSchema = z.object({
   responseBody: z.object({
     openrouter_metadata: z.object({
       requested: z.string(),
+      is_byok: z.boolean().optional(),
       attempts: z.array(z.object({ provider: z.string() }).loose()),
     }),
   }),
@@ -56,6 +57,7 @@ test("captures router metadata from a JSON response without consuming it", async
     id: "generation-json",
     openrouter_metadata: {
       requested: "openai/gpt-5.6-luna",
+      is_byok: true,
       attempts: [
         {
           provider: "Provider A",
@@ -91,7 +93,7 @@ test("captures router metadata from the final additive SSE chunk", async () => {
   const observations: AttributedResponseObservation[] = [];
   const sse = [
     'data: {"id":"generation-sse","choices":[{"delta":{"content":"ok"}}]}',
-    'data: {"id":"generation-sse","openrouter_metadata":{"requested":"openai/gpt-5.6-luna","attempts":[{"provider":"Provider B","model":"openai/gpt-5.6-luna","status":200}],"future":{"accepted":true}}}',
+    'data: {"id":"generation-sse","openrouter_metadata":{"requested":"openai/gpt-5.6-luna","is_byok":true,"attempts":[{"provider":"Provider B","model":"openai/gpt-5.6-luna","status":200}],"future":{"accepted":true}}}',
     "data: [DONE]",
     "",
   ].join("\n\n");
@@ -118,6 +120,7 @@ test("captures router metadata from the final additive SSE chunk", async () => {
   expect(
     observation.responseBody.openrouter_metadata.attempts[0]?.provider,
   ).toBe("Provider B");
+  expect(observation.responseBody.openrouter_metadata.is_byok).toBe(true);
 });
 
 test("keeps the final SSE metadata event without buffering the whole stream", async () => {
@@ -209,6 +212,7 @@ test("records stable model ids, upstream attempts, and missing metadata", async 
     endpoint: "language",
     responseBody: {
       openrouter_metadata: {
+        is_byok: false,
         attempts: [
           {
             provider: "Provider A",
@@ -243,6 +247,9 @@ test("records stable model ids, upstream attempts, and missing metadata", async 
     'upstream_provider="Provider B",outcome="success"',
   );
   expect(exposition).toContain('workload="missing-metadata"');
+  expect(exposition).toContain(
+    'llm_openrouter_byok_requests_total{service="test-service",workload="test-workload",model="gpt-5.6-luna",upstream_provider="Provider B",byok="false"} 1',
+  );
 });
 
 test("does not double-count language calls the AI SDK telemetry already recorded", async () => {

--- a/packages/llm-runtime/test/provider-contract.test.ts
+++ b/packages/llm-runtime/test/provider-contract.test.ts
@@ -39,7 +39,7 @@ describe("AI SDK 7 and OpenRouter provider contracts", () => {
     let body: unknown;
     const sse = [
       'data: {"id":"gen-stream","model":"openai/gpt-5.6-luna","provider":"Provider A","choices":[{"index":0,"delta":{"role":"assistant","content":"hel"},"finish_reason":null}]}',
-      'data: {"id":"gen-stream","model":"openai/gpt-5.6-luna","provider":"Provider A","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5,"cost":0.00005,"cost_details":{"upstream_inference_cost":0.00004}},"openrouter_metadata":{"requested":"openai/gpt-5.6-luna","attempt":1,"attempts":[{"provider":"Provider A","model":"openai/gpt-5.6-luna","status":200}]}}',
+      'data: {"id":"gen-stream","model":"openai/gpt-5.6-luna","provider":"Provider A","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5,"cost":0.00005,"cost_details":{"upstream_inference_cost":0.00004}},"openrouter_metadata":{"requested":"openai/gpt-5.6-luna","is_byok":true,"attempt":1,"attempts":[{"provider":"Provider A","model":"openai/gpt-5.6-luna","status":200}]}}',
       "data: [DONE]",
       "",
     ].join("\n\n");

--- a/packages/llm-runtime/test/runtime.test.ts
+++ b/packages/llm-runtime/test/runtime.test.ts
@@ -58,6 +58,7 @@ function openRouterResponse(
     },
     openrouter_metadata: {
       requested: "openai/gpt-5.6-luna",
+      is_byok: true,
       strategy: "direct",
       region: "iad",
       attempt: 2,
@@ -206,6 +207,7 @@ describe("catalog-aware runtime", () => {
       model: "gpt-5.6-luna",
       resolvedModel: "openai/gpt-5.6-luna",
       upstreamProvider: "Provider B",
+      isByok: true,
       generationId: "gen-test",
       fallbackAttempts: 1,
       inputTokens: 12,
@@ -253,6 +255,7 @@ describe("OpenRouter metadata", () => {
         model: "openai/gpt-5.6-luna",
         openrouter_metadata: {
           requested: "openai/gpt-5.6-luna",
+          is_byok: true,
           strategy: "direct",
           region: "iad",
           attempt: 2,
@@ -274,10 +277,26 @@ describe("OpenRouter metadata", () => {
     });
     expect(metadata.fallbackAttempts).toBe(1);
     expect(metadata.upstreamProvider).toBe("Provider B");
+    expect(metadata.isByok).toBe(true);
     expect(metadata.region).toBe("iad");
     expect(metadata.actualCostUsd).toBe(0.0001);
     expect(metadata.upstreamCostUsd).toBe(0.00008);
     expect(metadata.routerMetadataPresent).toBe(true);
+  });
+
+  test("preserves false and absent BYOK metadata", () => {
+    expect(
+      parseOpenRouterMetadata({
+        requestedModel: "gpt-5.6-luna",
+        responseBody: { openrouter_metadata: { is_byok: false } },
+      }).isByok,
+    ).toBe(false);
+    expect(
+      parseOpenRouterMetadata({
+        requestedModel: "gpt-5.6-luna",
+        responseBody: { openrouter_metadata: {} },
+      }).isByok,
+    ).toBeUndefined();
   });
 
   test("uses raw OpenRouter token details when AI SDK usage is unavailable", () => {

--- a/packages/temporal/AGENTS.md
+++ b/packages/temporal/AGENTS.md
@@ -16,7 +16,7 @@ files sequentially: each file owns a native time-skipping server and authentic
 Node worker threads, and concurrent environments exhaust the bounded CI agent.
 `bun run test` runs both phases through the stable package interface.
 
-Production uses the same Bun image in twelve single-replica Kubernetes
+Production uses the same Bun image in thirteen single-replica Kubernetes
 Deployments selected by `TEMPORAL_WORKER_ROLE`. `control` owns schedule
 reconciliation and public HTTP/event surfaces without a task queue. The
 credentialless `workflows` role runs as stable and candidate Deployments on
@@ -30,6 +30,9 @@ After rollback and candidate-history drain, rerun `rollback` with no active ramp
 to copy stable back to candidate before the next CI image release may advance
 it; review and commit both the catalog and pin-state changes through the normal
 PR flow.
+The isolated `billing` role polls only the `billing` Activity queue and owns the
+OpenAI organization Usage/Costs credential; it has no Flipt access or service
+account token.
 Domain roles are Activity-only and own their registries in the typed contract
 in `src/worker-config.ts`. The explicit local `all` role preserves the
 single-process development behavior. Keep new queue ownership and capabilities in that contract so a

--- a/packages/temporal/src/activities/index.ts
+++ b/packages/temporal/src/activities/index.ts
@@ -45,6 +45,7 @@ import { scoutWeeklyParlayActivities } from "./scout-weekly-parlay.ts";
 import { scoutBryanBucksActivities } from "./scout-bryan-bucks.ts";
 import { fliptFlagInventoryActivities } from "./flipt-flag-inventory.ts";
 import { seaweedFsBackupActivities } from "./seaweedfs-backup.ts";
+import { openAiComplimentaryUsageActivities } from "./openai-complimentary-usage.ts";
 
 export const homeActivities = {
   ...haActivities,
@@ -120,4 +121,8 @@ export const maintenanceWorkerActivities = {
 };
 export const backupWorkerActivities = {
   ...seaweedFsBackupActivities,
+};
+
+export const billingActivities = {
+  ...openAiComplimentaryUsageActivities,
 };

--- a/packages/temporal/src/activities/openai-complimentary-usage.ts
+++ b/packages/temporal/src/activities/openai-complimentary-usage.ts
@@ -1,0 +1,52 @@
+import { createAlertmanagerPoster } from "#lib/alertmanager.ts";
+import {
+  openAiProjectCostUsd,
+  openAiProjectUsageTokens,
+  openAiUsageReconciliationLastSuccessTimestampSeconds,
+} from "#observability/metrics.ts";
+import { buildOpenAiComplimentaryAlerts } from "#shared/openai-complimentary-alerts.ts";
+import {
+  fetchOpenAiComplimentaryUsage,
+  type OpenAiComplimentaryUsageResult,
+} from "#shared/openai-complimentary-usage.ts";
+
+function requiredEnvironment(name: string): string {
+  const value = Bun.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} is required for OpenAI usage reconciliation`);
+  }
+  return value;
+}
+
+export type OpenAiComplimentaryUsageActivities =
+  typeof openAiComplimentaryUsageActivities;
+
+export const openAiComplimentaryUsageActivities = {
+  async reconcileOpenAiComplimentaryUsage(): Promise<OpenAiComplimentaryUsageResult> {
+    const now = new Date();
+    const result = await fetchOpenAiComplimentaryUsage({
+      adminKey: requiredEnvironment("OPENAI_ADMIN_KEY"),
+      projectId: requiredEnvironment("OPENAI_OPENROUTER_PROJECT_ID"),
+      now,
+    });
+    openAiProjectUsageTokens.reset();
+    for (const row of result.tokenRows) {
+      openAiProjectUsageTokens.set(
+        {
+          model: row.model,
+          service_tier: row.serviceTier,
+          type: row.type,
+        },
+        row.tokens,
+      );
+    }
+    openAiProjectCostUsd.set(result.costUsd);
+    await createAlertmanagerPoster(requiredEnvironment("ALERTMANAGER_URL"))(
+      buildOpenAiComplimentaryAlerts(result, now),
+    );
+    openAiUsageReconciliationLastSuccessTimestampSeconds.set(
+      Math.floor(now.getTime() / 1000),
+    );
+    return result;
+  },
+};

--- a/packages/temporal/src/activities/openai-complimentary-usage.ts
+++ b/packages/temporal/src/activities/openai-complimentary-usage.ts
@@ -1,4 +1,5 @@
 import { createAlertmanagerPoster } from "#lib/alertmanager.ts";
+import { Context } from "@temporalio/activity";
 import {
   openAiProjectCostUsd,
   openAiProjectUsageTokens,
@@ -28,6 +29,7 @@ export const openAiComplimentaryUsageActivities = {
       adminKey: requiredEnvironment("OPENAI_ADMIN_KEY"),
       projectId: requiredEnvironment("OPENAI_OPENROUTER_PROJECT_ID"),
       now,
+      cancellationSignal: Context.current().cancellationSignal,
     });
     openAiProjectUsageTokens.reset();
     for (const row of result.tokenRows) {

--- a/packages/temporal/src/observability/metrics.ts
+++ b/packages/temporal/src/observability/metrics.ts
@@ -19,6 +19,25 @@ export const register = new Registry();
 register.setDefaultLabels({ component: "temporal-worker" });
 collectDefaultMetrics({ register, prefix: "temporal_worker_app_" });
 
+export const openAiProjectUsageTokens = new Gauge({
+  name: "openai_project_usage_tokens",
+  help: "Official OpenAI current-day project usage by model, service tier, and token type",
+  labelNames: ["model", "service_tier", "type"] as const,
+  registers: [register],
+});
+
+export const openAiProjectCostUsd = new Gauge({
+  name: "openai_project_cost_usd",
+  help: "Official OpenAI current-day cost for the monitored OpenRouter project",
+  registers: [register],
+});
+
+export const openAiUsageReconciliationLastSuccessTimestampSeconds = new Gauge({
+  name: "openai_usage_reconciliation_last_success_timestamp_seconds",
+  help: "Unix timestamp of the last successful official OpenAI usage and cost reconciliation",
+  registers: [register],
+});
+
 // ---------------------------------------------------------------------------
 // GitHub webhook metrics (merge-conflict check + PR-closed build cancel). The
 // webhook server is the ingress for those two features; the PR review /

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -290,6 +290,17 @@ test("Flipt inventory drift starts on the shared Workflow queue", () => {
   });
 });
 
+test("OpenAI complimentary usage reconciles hourly on the shared Workflow queue", () => {
+  expect(findScheduleById("openai-complimentary-usage-hourly")).toMatchObject({
+    workflowType: "runOpenAiComplimentaryUsageReconciliation",
+    args: [],
+    timing: { kind: "cron", expression: "17 * * * *", timezone: "UTC" },
+    taskQueue: TASK_QUEUES.WORKFLOWS,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "10 minutes",
+  });
+});
+
 test("protobuf watch timeout covers collection and both delivery paths", () => {
   const timeout = findScheduleById(
     "protobufjs-v8-watch-weekly",
@@ -366,6 +377,7 @@ const WORKFLOWS_WITHOUT_LONG_SLEEPS = new Set([
   "fetchSkillCappedManifest",
   "runFreshRssSyncWorkflow",
   "runFliptFlagInventory",
+  "runOpenAiComplimentaryUsageReconciliation",
   // These workflows await one direct maintenance activity; the activity
   // timeout and retry policy are the relevant execution budget.
   "runBunCacheGcWorkflow",

--- a/packages/temporal/src/schedules/schedule-definitions-early.ts
+++ b/packages/temporal/src/schedules/schedule-definitions-early.ts
@@ -4,6 +4,20 @@ import { schedulesInNamespace } from "./schedule-types.ts";
 
 export const EARLY_SCHEDULES = schedulesInNamespace("prod", [
   {
+    id: "openai-complimentary-usage-hourly",
+    workflowType: "runOpenAiComplimentaryUsageReconciliation",
+    args: [],
+    timing: {
+      kind: "cron",
+      expression: "17 * * * *",
+      timezone: "UTC",
+    },
+    taskQueue: TASK_QUEUES.WORKFLOWS,
+    overlap: ScheduleOverlapPolicy.SKIP,
+    workflowExecutionTimeout: "10 minutes",
+    memo: "Hourly official OpenAI complimentary-token usage and cost reconciliation",
+  },
+  {
     id: "report-freshness-monitor",
     workflowType: "monitorReportFreshness",
     args: [],

--- a/packages/temporal/src/shared/execution-metadata.ts
+++ b/packages/temporal/src/shared/execution-metadata.ts
@@ -52,6 +52,7 @@ export function executionDomainForTaskQueue(
     case TASK_QUEUES.MAINTENANCE:
       return "maintenance";
     case TASK_QUEUES.BACKUP:
+    case TASK_QUEUES.BILLING:
       return "platform";
     case TASK_QUEUES.WORKFLOWS:
       return "platform";
@@ -97,6 +98,7 @@ const WORKFLOW_TYPE_DOMAINS: Readonly<Record<string, ExecutionDomain>> = {
   fetchSkillCappedManifest: "repo",
   runFreshRssSyncWorkflow: "repo",
   runFliptFlagInventory: "repo",
+  runOpenAiComplimentaryUsageReconciliation: "platform",
   generateDependencySummary: "repo",
   runProtobufWatch: "repo",
   runPokeemeraldDataRefresh: "repo",

--- a/packages/temporal/src/shared/openai-complimentary-alerts.ts
+++ b/packages/temporal/src/shared/openai-complimentary-alerts.ts
@@ -1,0 +1,61 @@
+import type { AlertmanagerAlert } from "#lib/alertmanager.ts";
+import type { OpenAiComplimentaryUsageResult } from "./openai-complimentary-usage.ts";
+
+const ALERT_TTL_MS = 3 * 60 * 60 * 1000;
+
+function alert(input: {
+  readonly alertname: string;
+  readonly firing: boolean;
+  readonly summary: string;
+  readonly description: string;
+  readonly now: Date;
+}): AlertmanagerAlert {
+  return {
+    labels: {
+      alertname: input.alertname,
+      severity: "warning",
+      component: "openai-billing",
+    },
+    annotations: {
+      summary: input.summary,
+      description: input.description,
+      message: input.description,
+    },
+    startsAt: input.now.toISOString(),
+    endsAt: new Date(
+      input.now.getTime() + (input.firing ? ALERT_TTL_MS : 0),
+    ).toISOString(),
+  };
+}
+
+export function buildOpenAiComplimentaryAlerts(
+  result: OpenAiComplimentaryUsageResult,
+  now: Date,
+): AlertmanagerAlert[] {
+  const paidTokens = result.defaultTierTokens > 0;
+  const charged = result.costUsd >= 0.01;
+  return [
+    alert({
+      alertname: "OpenAiComplimentaryPaidTokens",
+      firing: paidTokens,
+      summary: paidTokens
+        ? "OpenAI project used default-tier tokens"
+        : "OpenAI project has no default-tier tokens",
+      description: paidTokens
+        ? `${String(result.defaultTierTokens)} current-day tokens were reported as default tier. A request that crosses the daily complimentary allowance is billed in full; otherwise verify OpenAI sharing eligibility and OpenRouter BYOK routing.`
+        : "All current-day OpenAI project tokens are outside the paid default tier.",
+      now,
+    }),
+    alert({
+      alertname: "OpenAiOpenRouterProjectCost",
+      firing: charged,
+      summary: charged
+        ? "Official OpenAI project cost reached the warning threshold"
+        : "Official OpenAI project cost remains below the warning threshold",
+      description: charged
+        ? `OpenAI reports $${result.costUsd.toFixed(6)} for the monitored project today. Reconcile service-tier usage before relying on OpenRouter's estimated upstream cost.`
+        : `OpenAI reports $${result.costUsd.toFixed(6)} for the monitored project today.`,
+      now,
+    }),
+  ];
+}

--- a/packages/temporal/src/shared/openai-complimentary-usage.test.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+import { buildOpenAiComplimentaryAlerts } from "./openai-complimentary-alerts.ts";
+import {
+  fetchOpenAiComplimentaryUsage,
+  type OpenAiUsageFetch,
+} from "./openai-complimentary-usage.ts";
+
+function page(results: readonly unknown[], input?: { next?: string }) {
+  return {
+    object: "page",
+    data: [{ start_time: 1, end_time: 2, results }],
+    has_more: input?.next !== undefined,
+    next_page: input?.next ?? null,
+  };
+}
+
+function requestUrl(request: Parameters<OpenAiUsageFetch>[0]): URL {
+  if (typeof request === "string") return new URL(request);
+  if (request instanceof URL) return request;
+  return new URL(request.url);
+}
+
+const malformedPaginationFetcher: OpenAiUsageFetch = () =>
+  Promise.resolve(
+    Response.json({ ...page([]), has_more: true, next_page: null }),
+  );
+
+describe("OpenAI complimentary usage", () => {
+  test("paginates, applies the ingestion cutoff, and aggregates tiers and cost", async () => {
+    const urls: URL[] = [];
+    const fetcher: OpenAiUsageFetch = (request) => {
+      const url = requestUrl(request);
+      urls.push(url);
+      if (url.pathname.endsWith("/usage/completions")) {
+        const second = url.searchParams.get("page") === "completion-next";
+        return Promise.resolve(
+          Response.json(
+            page(
+              [
+                {
+                  input_tokens: second ? 7 : 100,
+                  output_tokens: second ? 3 : 20,
+                  model: "gpt-5.4-mini",
+                  service_tier: second ? "default" : "incentivized-tier",
+                },
+              ],
+              second ? undefined : { next: "completion-next" },
+            ),
+          ),
+        );
+      }
+      return Promise.resolve(
+        Response.json(
+          page([
+            {
+              amount: { value: 0.0125, currency: "usd" },
+              project_id: "project-openrouter",
+            },
+          ]),
+        ),
+      );
+    };
+
+    const result = await fetchOpenAiComplimentaryUsage({
+      adminKey: "test-admin-key",
+      projectId: "project-openrouter",
+      now: new Date("2026-09-01T08:17:00.000Z"),
+      fetcher,
+    });
+
+    expect(result.windowStart).toBe("2026-09-01T00:00:00.000Z");
+    expect(result.windowEnd).toBe("2026-09-01T08:02:00.000Z");
+    expect(result.defaultTierTokens).toBe(10);
+    expect(result.costUsd).toBe(0.0125);
+    expect(result.tokenRows).toEqual(
+      expect.arrayContaining([
+        {
+          model: "gpt-5.4-mini",
+          serviceTier: "incentivized-tier",
+          type: "input",
+          tokens: 100,
+        },
+        {
+          model: "gpt-5.4-mini",
+          serviceTier: "default",
+          type: "output",
+          tokens: 3,
+        },
+      ]),
+    );
+    expect(urls).toHaveLength(3);
+    for (const url of urls) {
+      expect(url.searchParams.get("end_time")).toBe("1788249720");
+      expect(url.searchParams.get("project_ids")).toBe("project-openrouter");
+    }
+  });
+
+  test("fails closed on malformed pagination", async () => {
+    await expect(
+      fetchOpenAiComplimentaryUsage({
+        adminKey: "test-admin-key",
+        projectId: "project-openrouter",
+        now: new Date("2026-09-01T08:17:00.000Z"),
+        fetcher: malformedPaginationFetcher,
+      }),
+    ).rejects.toThrow("has_more without a next_page");
+  });
+
+  test("fires and resolves stable paid-tier and cost alerts", () => {
+    const now = new Date("2026-09-01T08:17:00.000Z");
+    const base = {
+      windowStart: "2026-09-01T00:00:00.000Z",
+      windowEnd: "2026-09-01T08:02:00.000Z",
+      observedAt: now.toISOString(),
+      tokenRows: [],
+    };
+    const firing = buildOpenAiComplimentaryAlerts(
+      { ...base, defaultTierTokens: 1, costUsd: 0.01 },
+      now,
+    );
+    const resolved = buildOpenAiComplimentaryAlerts(
+      { ...base, defaultTierTokens: 0, costUsd: 0 },
+      now,
+    );
+    expect(firing.map((entry) => entry.labels["alertname"])).toEqual([
+      "OpenAiComplimentaryPaidTokens",
+      "OpenAiOpenRouterProjectCost",
+    ]);
+    expect(firing.every((entry) => entry.endsAt > entry.startsAt)).toBe(true);
+    expect(resolved.every((entry) => entry.endsAt === entry.startsAt)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/temporal/src/shared/openai-complimentary-usage.test.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.test.ts
@@ -28,9 +28,12 @@ const malformedPaginationFetcher: OpenAiUsageFetch = () =>
 describe("OpenAI complimentary usage", () => {
   test("paginates, applies the ingestion cutoff, and aggregates tiers and cost", async () => {
     const urls: URL[] = [];
-    const fetcher: OpenAiUsageFetch = (request) => {
+    const signals: (AbortSignal | null | undefined)[] = [];
+    const cancellationController = new AbortController();
+    const fetcher: OpenAiUsageFetch = (request, init) => {
       const url = requestUrl(request);
       urls.push(url);
+      signals.push(init?.signal);
       if (url.pathname.endsWith("/usage/completions")) {
         const second = url.searchParams.get("page") === "completion-next";
         return Promise.resolve(
@@ -66,6 +69,7 @@ describe("OpenAI complimentary usage", () => {
       projectId: "project-openrouter",
       now: new Date("2026-09-01T08:17:00.000Z"),
       fetcher,
+      cancellationSignal: cancellationController.signal,
     });
 
     expect(result.windowStart).toBe("2026-09-01T00:00:00.000Z");
@@ -89,6 +93,8 @@ describe("OpenAI complimentary usage", () => {
       ]),
     );
     expect(urls).toHaveLength(3);
+    expect(signals).toHaveLength(3);
+    expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
     for (const url of urls) {
       expect(url.searchParams.get("end_time")).toBe("1788249720");
       expect(url.searchParams.get("project_ids")).toBe("project-openrouter");

--- a/packages/temporal/src/shared/openai-complimentary-usage.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.ts
@@ -119,7 +119,7 @@ async function fetchPagedResults<RESULT extends z.ZodType>(input: {
   readonly cancellationSignal: AbortSignal | undefined;
 }): Promise<z.infer<RESULT>[]> {
   const results: z.infer<RESULT>[] = [];
-  const pageSchema = usagePageSchema(input.schema);
+  const PageSchema = usagePageSchema(input.schema);
   let cursor: string | undefined;
   do {
     const url = new URL(`https://api.openai.com/v1/organization/${input.path}`);
@@ -132,7 +132,7 @@ async function fetchPagedResults<RESULT extends z.ZodType>(input: {
     }
     url.searchParams.set("limit", String(input.limit));
     if (cursor !== undefined) url.searchParams.set("page", cursor);
-    const page = pageSchema.parse(
+    const page = PageSchema.parse(
       await fetchPage({
         url,
         adminKey: input.adminKey,

--- a/packages/temporal/src/shared/openai-complimentary-usage.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.ts
@@ -35,9 +35,6 @@ function usagePageSchema<RESULT extends z.ZodType>(result: RESULT) {
     .loose();
 }
 
-const CompletionPageSchema = usagePageSchema(CompletionResultSchema);
-const CostPageSchema = usagePageSchema(CostResultSchema);
-
 export type OpenAiUsageTokenRow = {
   readonly model: string;
   readonly serviceTier: string;
@@ -108,62 +105,34 @@ async function fetchPage(input: {
   return await response.json();
 }
 
-async function fetchCompletions(input: {
+async function fetchPagedResults<RESULT extends z.ZodType>(input: {
+  readonly path: string;
+  readonly bucketWidth: string;
+  readonly limit: number;
+  readonly groupBy: readonly string[];
+  readonly schema: RESULT;
   readonly startTime: number;
   readonly endTime: number;
   readonly adminKey: string;
   readonly projectId: string;
   readonly fetcher: OpenAiUsageFetch;
   readonly cancellationSignal: AbortSignal | undefined;
-}): Promise<z.infer<typeof CompletionResultSchema>[]> {
-  const results: z.infer<typeof CompletionResultSchema>[] = [];
+}): Promise<z.infer<RESULT>[]> {
+  const results: z.infer<RESULT>[] = [];
+  const pageSchema = usagePageSchema(input.schema);
   let cursor: string | undefined;
   do {
-    const url = new URL(
-      "https://api.openai.com/v1/organization/usage/completions",
-    );
+    const url = new URL(`https://api.openai.com/v1/organization/${input.path}`);
     url.searchParams.set("start_time", String(input.startTime));
     url.searchParams.set("end_time", String(input.endTime));
-    url.searchParams.set("bucket_width", "1h");
+    url.searchParams.set("bucket_width", input.bucketWidth);
     url.searchParams.append("project_ids", input.projectId);
-    url.searchParams.append("group_by", "model");
-    url.searchParams.append("group_by", "service_tier");
-    url.searchParams.set("limit", "24");
+    for (const groupBy of input.groupBy) {
+      url.searchParams.append("group_by", groupBy);
+    }
+    url.searchParams.set("limit", String(input.limit));
     if (cursor !== undefined) url.searchParams.set("page", cursor);
-    const page = CompletionPageSchema.parse(
-      await fetchPage({
-        url,
-        adminKey: input.adminKey,
-        fetcher: input.fetcher,
-        cancellationSignal: input.cancellationSignal,
-      }),
-    );
-    for (const bucket of page.data) results.push(...bucket.results);
-    cursor = pageCursor(page);
-  } while (cursor !== undefined);
-  return results;
-}
-
-async function fetchCosts(input: {
-  readonly startTime: number;
-  readonly endTime: number;
-  readonly adminKey: string;
-  readonly projectId: string;
-  readonly fetcher: OpenAiUsageFetch;
-  readonly cancellationSignal: AbortSignal | undefined;
-}): Promise<z.infer<typeof CostResultSchema>[]> {
-  const results: z.infer<typeof CostResultSchema>[] = [];
-  let cursor: string | undefined;
-  do {
-    const url = new URL("https://api.openai.com/v1/organization/costs");
-    url.searchParams.set("start_time", String(input.startTime));
-    url.searchParams.set("end_time", String(input.endTime));
-    url.searchParams.set("bucket_width", "1d");
-    url.searchParams.append("project_ids", input.projectId);
-    url.searchParams.append("group_by", "project_id");
-    url.searchParams.set("limit", "31");
-    if (cursor !== undefined) url.searchParams.set("page", cursor);
-    const page = CostPageSchema.parse(
+    const page = pageSchema.parse(
       await fetchPage({
         url,
         adminKey: input.adminKey,
@@ -215,8 +184,22 @@ export async function fetchOpenAiComplimentaryUsage(
     cancellationSignal: input.cancellationSignal,
   };
   const [completions, costs] = await Promise.all([
-    fetchCompletions(common),
-    fetchCosts(common),
+    fetchPagedResults({
+      ...common,
+      path: "usage/completions",
+      bucketWidth: "1h",
+      limit: 24,
+      groupBy: ["model", "service_tier"],
+      schema: CompletionResultSchema,
+    }),
+    fetchPagedResults({
+      ...common,
+      path: "costs",
+      bucketWidth: "1d",
+      limit: 31,
+      groupBy: ["project_id"],
+      schema: CostResultSchema,
+    }),
   ]);
   const tokenRows = aggregateTokenRows(completions);
   return {

--- a/packages/temporal/src/shared/openai-complimentary-usage.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.ts
@@ -89,7 +89,7 @@ async function fetchPage(input: {
   readonly url: URL;
   readonly adminKey: string;
   readonly fetcher: OpenAiUsageFetch;
-  readonly cancellationSignal?: AbortSignal;
+  readonly cancellationSignal: AbortSignal | undefined;
 }): Promise<unknown> {
   const timeoutSignal = AbortSignal.timeout(30_000);
   const signal =
@@ -114,7 +114,7 @@ async function fetchCompletions(input: {
   readonly adminKey: string;
   readonly projectId: string;
   readonly fetcher: OpenAiUsageFetch;
-  readonly cancellationSignal?: AbortSignal;
+  readonly cancellationSignal: AbortSignal | undefined;
 }): Promise<z.infer<typeof CompletionResultSchema>[]> {
   const results: z.infer<typeof CompletionResultSchema>[] = [];
   let cursor: string | undefined;
@@ -150,7 +150,7 @@ async function fetchCosts(input: {
   readonly adminKey: string;
   readonly projectId: string;
   readonly fetcher: OpenAiUsageFetch;
-  readonly cancellationSignal?: AbortSignal;
+  readonly cancellationSignal: AbortSignal | undefined;
 }): Promise<z.infer<typeof CostResultSchema>[]> {
   const results: z.infer<typeof CostResultSchema>[] = [];
   let cursor: string | undefined;

--- a/packages/temporal/src/shared/openai-complimentary-usage.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.ts
@@ -1,0 +1,219 @@
+import { z } from "zod";
+
+const CompletionResultSchema = z
+  .object({
+    input_tokens: z.number().int().nonnegative(),
+    output_tokens: z.number().int().nonnegative(),
+    model: z.string().min(1),
+    service_tier: z.string().min(1),
+  })
+  .loose();
+
+const CostResultSchema = z
+  .object({
+    amount: z.object({ value: z.number().nonnegative(), currency: z.string() }),
+    project_id: z.string().min(1),
+  })
+  .loose();
+
+function usagePageSchema<RESULT extends z.ZodType>(result: RESULT) {
+  return z
+    .object({
+      object: z.literal("page"),
+      data: z.array(
+        z
+          .object({
+            start_time: z.number().int().nonnegative(),
+            end_time: z.number().int().nonnegative(),
+            results: z.array(result),
+          })
+          .loose(),
+      ),
+      has_more: z.boolean(),
+      next_page: z.string().min(1).nullable(),
+    })
+    .loose();
+}
+
+const CompletionPageSchema = usagePageSchema(CompletionResultSchema);
+const CostPageSchema = usagePageSchema(CostResultSchema);
+
+export type OpenAiUsageTokenRow = {
+  readonly model: string;
+  readonly serviceTier: string;
+  readonly type: "input" | "output";
+  readonly tokens: number;
+};
+
+export type OpenAiComplimentaryUsageResult = {
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly observedAt: string;
+  readonly tokenRows: readonly OpenAiUsageTokenRow[];
+  readonly defaultTierTokens: number;
+  readonly costUsd: number;
+};
+
+export type OpenAiUsageClientInput = {
+  readonly adminKey: string;
+  readonly projectId: string;
+  readonly now: Date;
+  readonly fetcher?: OpenAiUsageFetch;
+};
+
+export type OpenAiUsageFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => Promise<Response>;
+
+function utcMidnightSeconds(date: Date): number {
+  return Math.floor(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()) /
+      1000,
+  );
+}
+
+function pageCursor(page: {
+  readonly has_more: boolean;
+  readonly next_page: string | null;
+}): string | undefined {
+  if (!page.has_more) return undefined;
+  if (page.next_page === null) {
+    throw new Error("OpenAI returned has_more without a next_page cursor");
+  }
+  return page.next_page;
+}
+
+async function fetchPage(input: {
+  readonly url: URL;
+  readonly adminKey: string;
+  readonly fetcher: OpenAiUsageFetch;
+}): Promise<unknown> {
+  const response = await input.fetcher(input.url, {
+    headers: { authorization: `Bearer ${input.adminKey}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `OpenAI organization API request failed: ${String(response.status)} ${await response.text()}`,
+    );
+  }
+  return await response.json();
+}
+
+async function fetchCompletions(input: {
+  readonly startTime: number;
+  readonly endTime: number;
+  readonly adminKey: string;
+  readonly projectId: string;
+  readonly fetcher: OpenAiUsageFetch;
+}): Promise<z.infer<typeof CompletionResultSchema>[]> {
+  const results: z.infer<typeof CompletionResultSchema>[] = [];
+  let cursor: string | undefined;
+  do {
+    const url = new URL(
+      "https://api.openai.com/v1/organization/usage/completions",
+    );
+    url.searchParams.set("start_time", String(input.startTime));
+    url.searchParams.set("end_time", String(input.endTime));
+    url.searchParams.set("bucket_width", "1h");
+    url.searchParams.append("project_ids", input.projectId);
+    url.searchParams.append("group_by", "model");
+    url.searchParams.append("group_by", "service_tier");
+    url.searchParams.set("limit", "24");
+    if (cursor !== undefined) url.searchParams.set("page", cursor);
+    const page = CompletionPageSchema.parse(
+      await fetchPage({
+        url,
+        adminKey: input.adminKey,
+        fetcher: input.fetcher,
+      }),
+    );
+    for (const bucket of page.data) results.push(...bucket.results);
+    cursor = pageCursor(page);
+  } while (cursor !== undefined);
+  return results;
+}
+
+async function fetchCosts(input: {
+  readonly startTime: number;
+  readonly endTime: number;
+  readonly adminKey: string;
+  readonly projectId: string;
+  readonly fetcher: OpenAiUsageFetch;
+}): Promise<z.infer<typeof CostResultSchema>[]> {
+  const results: z.infer<typeof CostResultSchema>[] = [];
+  let cursor: string | undefined;
+  do {
+    const url = new URL("https://api.openai.com/v1/organization/costs");
+    url.searchParams.set("start_time", String(input.startTime));
+    url.searchParams.set("end_time", String(input.endTime));
+    url.searchParams.set("bucket_width", "1d");
+    url.searchParams.append("project_ids", input.projectId);
+    url.searchParams.append("group_by", "project_id");
+    url.searchParams.set("limit", "31");
+    if (cursor !== undefined) url.searchParams.set("page", cursor);
+    const page = CostPageSchema.parse(
+      await fetchPage({
+        url,
+        adminKey: input.adminKey,
+        fetcher: input.fetcher,
+      }),
+    );
+    for (const bucket of page.data) results.push(...bucket.results);
+    cursor = pageCursor(page);
+  } while (cursor !== undefined);
+  return results;
+}
+
+function aggregateTokenRows(
+  results: readonly z.infer<typeof CompletionResultSchema>[],
+): OpenAiUsageTokenRow[] {
+  const totals = new Map<string, OpenAiUsageTokenRow>();
+  for (const result of results) {
+    for (const [type, tokens] of [
+      ["input", result.input_tokens],
+      ["output", result.output_tokens],
+    ] as const) {
+      const key = `${result.model}\u{0}${result.service_tier}\u{0}${type}`;
+      const previous = totals.get(key);
+      totals.set(key, {
+        model: result.model,
+        serviceTier: result.service_tier,
+        type,
+        tokens: (previous?.tokens ?? 0) + tokens,
+      });
+    }
+  }
+  return [...totals.values()];
+}
+
+export async function fetchOpenAiComplimentaryUsage(
+  input: OpenAiUsageClientInput,
+): Promise<OpenAiComplimentaryUsageResult> {
+  const fetcher = input.fetcher ?? fetch;
+  const endTime = Math.floor((input.now.getTime() - 15 * 60 * 1000) / 1000);
+  const cutoff = new Date(endTime * 1000);
+  const startTime = utcMidnightSeconds(cutoff);
+  const common = {
+    startTime,
+    endTime,
+    adminKey: input.adminKey,
+    projectId: input.projectId,
+    fetcher,
+  };
+  const [completions, costs] = await Promise.all([
+    fetchCompletions(common),
+    fetchCosts(common),
+  ]);
+  const tokenRows = aggregateTokenRows(completions);
+  return {
+    windowStart: new Date(startTime * 1000).toISOString(),
+    windowEnd: new Date(endTime * 1000).toISOString(),
+    observedAt: input.now.toISOString(),
+    tokenRows,
+    defaultTierTokens: tokenRows
+      .filter((row) => row.serviceTier === "default")
+      .reduce((total, row) => total + row.tokens, 0),
+    costUsd: costs.reduce((total, row) => total + row.amount.value, 0),
+  };
+}

--- a/packages/temporal/src/shared/openai-complimentary-usage.ts
+++ b/packages/temporal/src/shared/openai-complimentary-usage.ts
@@ -58,6 +58,7 @@ export type OpenAiUsageClientInput = {
   readonly adminKey: string;
   readonly projectId: string;
   readonly now: Date;
+  readonly cancellationSignal?: AbortSignal;
   readonly fetcher?: OpenAiUsageFetch;
 };
 
@@ -88,9 +89,16 @@ async function fetchPage(input: {
   readonly url: URL;
   readonly adminKey: string;
   readonly fetcher: OpenAiUsageFetch;
+  readonly cancellationSignal?: AbortSignal;
 }): Promise<unknown> {
+  const timeoutSignal = AbortSignal.timeout(30_000);
+  const signal =
+    input.cancellationSignal === undefined
+      ? timeoutSignal
+      : AbortSignal.any([input.cancellationSignal, timeoutSignal]);
   const response = await input.fetcher(input.url, {
     headers: { authorization: `Bearer ${input.adminKey}` },
+    signal,
   });
   if (!response.ok) {
     throw new Error(
@@ -106,6 +114,7 @@ async function fetchCompletions(input: {
   readonly adminKey: string;
   readonly projectId: string;
   readonly fetcher: OpenAiUsageFetch;
+  readonly cancellationSignal?: AbortSignal;
 }): Promise<z.infer<typeof CompletionResultSchema>[]> {
   const results: z.infer<typeof CompletionResultSchema>[] = [];
   let cursor: string | undefined;
@@ -126,6 +135,7 @@ async function fetchCompletions(input: {
         url,
         adminKey: input.adminKey,
         fetcher: input.fetcher,
+        cancellationSignal: input.cancellationSignal,
       }),
     );
     for (const bucket of page.data) results.push(...bucket.results);
@@ -140,6 +150,7 @@ async function fetchCosts(input: {
   readonly adminKey: string;
   readonly projectId: string;
   readonly fetcher: OpenAiUsageFetch;
+  readonly cancellationSignal?: AbortSignal;
 }): Promise<z.infer<typeof CostResultSchema>[]> {
   const results: z.infer<typeof CostResultSchema>[] = [];
   let cursor: string | undefined;
@@ -157,6 +168,7 @@ async function fetchCosts(input: {
         url,
         adminKey: input.adminKey,
         fetcher: input.fetcher,
+        cancellationSignal: input.cancellationSignal,
       }),
     );
     for (const bucket of page.data) results.push(...bucket.results);
@@ -200,6 +212,7 @@ export async function fetchOpenAiComplimentaryUsage(
     adminKey: input.adminKey,
     projectId: input.projectId,
     fetcher,
+    cancellationSignal: input.cancellationSignal,
   };
   const [completions, costs] = await Promise.all([
     fetchCompletions(common),

--- a/packages/temporal/src/shared/task-queues.ts
+++ b/packages/temporal/src/shared/task-queues.ts
@@ -17,6 +17,8 @@ export const TASK_QUEUES = {
   MAINTENANCE: "maintenance",
   /** Serial object-level SeaweedFS backup and retention work. */
   BACKUP: "backup",
+  /** Official provider usage and cost reconciliation with isolated credentials. */
+  BILLING: "billing",
   /** Scout beta activity worker, co-located with its database and Discord bot. */
   SCOUT_BETA: "scout-beta",
   /** Scout production activity worker, co-located with its database and Discord bot. */
@@ -48,6 +50,7 @@ export const TaskQueueSchema = z.enum([
   TASK_QUEUES.REPO_AUTOMATION,
   TASK_QUEUES.SCOUT,
   TASK_QUEUES.MAINTENANCE,
+  TASK_QUEUES.BILLING,
   TASK_QUEUES.SCOUT_BETA,
   TASK_QUEUES.SCOUT_PROD,
   TASK_QUEUES.AGENT_TASK,

--- a/packages/temporal/src/shared/worker-role.test.ts
+++ b/packages/temporal/src/shared/worker-role.test.ts
@@ -15,6 +15,7 @@ describe("Temporal worker role", () => {
     "all",
     "agent",
     "backup",
+    "billing",
     "control",
     "glitter",
     "glitter-context",

--- a/packages/temporal/src/shared/worker-role.ts
+++ b/packages/temporal/src/shared/worker-role.ts
@@ -4,6 +4,7 @@ export const WorkerRoleSchema = z.enum([
   "all",
   "agent",
   "backup",
+  "billing",
   "control",
   "glitter",
   "glitter-context",

--- a/packages/temporal/src/worker-config.test.ts
+++ b/packages/temporal/src/worker-config.test.ts
@@ -119,6 +119,7 @@ describe("Temporal worker role contracts", () => {
     const serialRoles: Exclude<QueueWorkerRole, "workflows">[] = [
       "agent",
       "backup",
+      "billing",
       "glitter-context",
       "glitter-corpus",
       "infra",

--- a/packages/temporal/src/worker-config.ts
+++ b/packages/temporal/src/worker-config.ts
@@ -9,6 +9,7 @@ import {
   scoutActivities,
   maintenanceWorkerActivities,
   backupWorkerActivities,
+  billingActivities,
 } from "./activities/index.ts";
 import { TASK_QUEUES, type TaskQueue } from "./shared/task-queues.ts";
 import type { WorkerRole } from "./shared/worker-role.ts";
@@ -16,6 +17,7 @@ import type { WorkerRole } from "./shared/worker-role.ts";
 export type QueueWorkerRole =
   | "agent"
   | "backup"
+  | "billing"
   | "glitter-context"
   | "glitter-corpus"
   | "home"
@@ -45,6 +47,13 @@ export type QueueWorkerDefinition =
   ActivityWorkerDefinition | WorkflowWorkerDefinition;
 
 const ACTIVITY_WORKER_DEFINITIONS: readonly ActivityWorkerDefinition[] = [
+  {
+    kind: "activity",
+    role: "billing",
+    taskQueue: TASK_QUEUES.BILLING,
+    activities: billingActivities,
+    maxConcurrentActivityTaskExecutions: 1,
+  },
   {
     kind: "activity",
     role: "backup",

--- a/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
+++ b/packages/temporal/src/workflows/flipt-flag-inventory.test.ts
@@ -1,32 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 import { runFliptFlagInventory } from "./flipt-flag-inventory.ts";
-import { Worker, type WorkerOptions } from "@temporalio/worker";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
-
-async function runFliptTest<T>(
-  environment: TestWorkflowEnvironment,
-  activities: NonNullable<WorkerOptions["activities"]>,
-  execute: () => Promise<T>,
-): Promise<T> {
-  const workflowWorker = await Worker.create({
-    connection: environment.nativeConnection,
-    taskQueue: TASK_QUEUES.WORKFLOWS,
-    workflowsPath: new URL("index.ts", import.meta.url).pathname,
-  });
-  const activityWorker = await Worker.create({
-    connection: environment.nativeConnection,
-    taskQueue: TASK_QUEUES.REPO_AUTOMATION,
-    activities,
-  });
-  const activityRun = activityWorker.run();
-  try {
-    return await workflowWorker.runUntil(execute());
-  } finally {
-    activityWorker.shutdown();
-    await activityRun;
-  }
-}
+import { runWorkflowWithActivityWorker } from "./test-support.ts";
 
 describe("runFliptFlagInventory", () => {
   test("routes the check to the repo automation queue", async () => {
@@ -56,7 +32,12 @@ describe("runFliptFlagInventory", () => {
         workflowId: `test-flipt-flag-inventory-${crypto.randomUUID()}`,
       });
     try {
-      await runFliptTest(environment, activities, execution);
+      await runWorkflowWithActivityWorker(environment, {
+        activityTaskQueue: TASK_QUEUES.REPO_AUTOMATION,
+        workflowPath: new URL("index.ts", import.meta.url).pathname,
+        activities,
+        execute: execution,
+      });
       expect(observed).toHaveLength(1);
     } finally {
       await environment.teardown();
@@ -79,7 +60,12 @@ describe("runFliptFlagInventory", () => {
       });
     try {
       await expect(
-        runFliptTest(environment, activities, execution),
+        runWorkflowWithActivityWorker(environment, {
+          activityTaskQueue: TASK_QUEUES.REPO_AUTOMATION,
+          workflowPath: new URL("index.ts", import.meta.url).pathname,
+          activities,
+          execute: execution,
+        }),
       ).rejects.toThrow("Workflow execution failed");
     } finally {
       await environment.teardown();

--- a/packages/temporal/src/workflows/index.ts
+++ b/packages/temporal/src/workflows/index.ts
@@ -129,6 +129,8 @@ import {
   runSeaweedFsBackupWorkflow as _runSeaweedFsBackupWorkflow,
 } from "./seaweedfs-backup.ts";
 import type { BackupCadence } from "@shepherdjerred/seaweedfs-backup/schemas";
+import { runOpenAiComplimentaryUsageReconciliation as _runOpenAiComplimentaryUsageReconciliation } from "./openai-complimentary-usage.ts";
+import type { OpenAiComplimentaryUsageResult } from "#shared/openai-complimentary-usage.ts";
 
 export function workerDeploymentCanaryWorkflow(
   input: WorkerDeploymentCanaryInput,
@@ -423,4 +425,8 @@ export async function runSeaweedFsBackupRetentionAndGcWorkflow(): Promise<{
   candidateObjects: number;
 }> {
   return _runSeaweedFsBackupRetentionAndGcWorkflow();
+}
+
+export async function runOpenAiComplimentaryUsageReconciliation(): Promise<OpenAiComplimentaryUsageResult> {
+  return _runOpenAiComplimentaryUsageReconciliation();
 }

--- a/packages/temporal/src/workflows/openai-complimentary-usage.test.ts
+++ b/packages/temporal/src/workflows/openai-complimentary-usage.test.ts
@@ -1,32 +1,8 @@
-import { Worker, type WorkerOptions } from "@temporalio/worker";
-import { TestWorkflowEnvironment } from "@temporalio/testing";
 import { describe, expect, test } from "vitest";
 import { TASK_QUEUES } from "#shared/task-queues.ts";
 import { runOpenAiComplimentaryUsageReconciliation } from "./openai-complimentary-usage.ts";
-
-async function runTest<T>(
-  environment: TestWorkflowEnvironment,
-  activities: NonNullable<WorkerOptions["activities"]>,
-  execute: () => Promise<T>,
-): Promise<T> {
-  const workflowWorker = await Worker.create({
-    connection: environment.nativeConnection,
-    taskQueue: TASK_QUEUES.WORKFLOWS,
-    workflowsPath: new URL("index.ts", import.meta.url).pathname,
-  });
-  const activityWorker = await Worker.create({
-    connection: environment.nativeConnection,
-    taskQueue: TASK_QUEUES.BILLING,
-    activities,
-  });
-  const activityRun = activityWorker.run();
-  try {
-    return await workflowWorker.runUntil(execute());
-  } finally {
-    activityWorker.shutdown();
-    await activityRun;
-  }
-}
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { runWorkflowWithActivityWorker } from "./test-support.ts";
 
 describe("OpenAI complimentary reconciliation workflow", () => {
   test("routes to billing and returns the reconciliation", async () => {
@@ -41,10 +17,13 @@ describe("OpenAI complimentary reconciliation workflow", () => {
     };
     try {
       await expect(
-        runTest(
-          environment,
-          { reconcileOpenAiComplimentaryUsage: () => Promise.resolve(result) },
-          () =>
+        runWorkflowWithActivityWorker(environment, {
+          activityTaskQueue: TASK_QUEUES.BILLING,
+          workflowPath: new URL("index.ts", import.meta.url).pathname,
+          activities: {
+            reconcileOpenAiComplimentaryUsage: () => Promise.resolve(result),
+          },
+          execute: () =>
             environment.client.workflow.execute(
               runOpenAiComplimentaryUsageReconciliation,
               {
@@ -53,7 +32,7 @@ describe("OpenAI complimentary reconciliation workflow", () => {
                 workflowId: `test-openai-usage-${crypto.randomUUID()}`,
               },
             ),
-        ),
+        }),
       ).resolves.toEqual(result);
     } finally {
       await environment.teardown();
@@ -65,15 +44,16 @@ describe("OpenAI complimentary reconciliation workflow", () => {
     let attempts = 0;
     try {
       await expect(
-        runTest(
-          environment,
-          {
+        runWorkflowWithActivityWorker(environment, {
+          activityTaskQueue: TASK_QUEUES.BILLING,
+          workflowPath: new URL("index.ts", import.meta.url).pathname,
+          activities: {
             reconcileOpenAiComplimentaryUsage: () => {
               attempts += 1;
               throw new Error("OpenAI unavailable");
             },
           },
-          () =>
+          execute: () =>
             environment.client.workflow.execute(
               runOpenAiComplimentaryUsageReconciliation,
               {
@@ -82,7 +62,7 @@ describe("OpenAI complimentary reconciliation workflow", () => {
                 workflowId: `test-openai-usage-failure-${crypto.randomUUID()}`,
               },
             ),
-        ),
+        }),
       ).rejects.toThrow("Workflow execution failed");
       expect(attempts).toBe(3);
     } finally {

--- a/packages/temporal/src/workflows/openai-complimentary-usage.test.ts
+++ b/packages/temporal/src/workflows/openai-complimentary-usage.test.ts
@@ -1,0 +1,92 @@
+import { Worker, type WorkerOptions } from "@temporalio/worker";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { describe, expect, test } from "vitest";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+import { runOpenAiComplimentaryUsageReconciliation } from "./openai-complimentary-usage.ts";
+
+async function runTest<T>(
+  environment: TestWorkflowEnvironment,
+  activities: NonNullable<WorkerOptions["activities"]>,
+  execute: () => Promise<T>,
+): Promise<T> {
+  const workflowWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: TASK_QUEUES.WORKFLOWS,
+    workflowsPath: new URL("index.ts", import.meta.url).pathname,
+  });
+  const activityWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: TASK_QUEUES.BILLING,
+    activities,
+  });
+  const activityRun = activityWorker.run();
+  try {
+    return await workflowWorker.runUntil(execute());
+  } finally {
+    activityWorker.shutdown();
+    await activityRun;
+  }
+}
+
+describe("OpenAI complimentary reconciliation workflow", () => {
+  test("routes to billing and returns the reconciliation", async () => {
+    const environment = await TestWorkflowEnvironment.createTimeSkipping();
+    const result = {
+      windowStart: "2026-09-01T00:00:00.000Z",
+      windowEnd: "2026-09-01T08:02:00.000Z",
+      observedAt: "2026-09-01T08:17:00.000Z",
+      tokenRows: [],
+      defaultTierTokens: 0,
+      costUsd: 0,
+    };
+    try {
+      await expect(
+        runTest(
+          environment,
+          { reconcileOpenAiComplimentaryUsage: () => Promise.resolve(result) },
+          () =>
+            environment.client.workflow.execute(
+              runOpenAiComplimentaryUsageReconciliation,
+              {
+                args: [],
+                taskQueue: TASK_QUEUES.WORKFLOWS,
+                workflowId: `test-openai-usage-${crypto.randomUUID()}`,
+              },
+            ),
+        ),
+      ).resolves.toEqual(result);
+    } finally {
+      await environment.teardown();
+    }
+  }, 60_000);
+
+  test("propagates failure after three bounded attempts", async () => {
+    const environment = await TestWorkflowEnvironment.createTimeSkipping();
+    let attempts = 0;
+    try {
+      await expect(
+        runTest(
+          environment,
+          {
+            reconcileOpenAiComplimentaryUsage: () => {
+              attempts += 1;
+              throw new Error("OpenAI unavailable");
+            },
+          },
+          () =>
+            environment.client.workflow.execute(
+              runOpenAiComplimentaryUsageReconciliation,
+              {
+                args: [],
+                taskQueue: TASK_QUEUES.WORKFLOWS,
+                workflowId: `test-openai-usage-failure-${crypto.randomUUID()}`,
+              },
+            ),
+        ),
+      ).rejects.toThrow("Workflow execution failed");
+      expect(attempts).toBe(3);
+    } finally {
+      await environment.teardown();
+    }
+  }, 60_000);
+});

--- a/packages/temporal/src/workflows/openai-complimentary-usage.ts
+++ b/packages/temporal/src/workflows/openai-complimentary-usage.ts
@@ -1,0 +1,20 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type { OpenAiComplimentaryUsageActivities } from "#activities/openai-complimentary-usage.ts";
+import type { OpenAiComplimentaryUsageResult } from "#shared/openai-complimentary-usage.ts";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
+
+const { reconcileOpenAiComplimentaryUsage } =
+  proxyActivities<OpenAiComplimentaryUsageActivities>({
+    taskQueue: TASK_QUEUES.BILLING,
+    startToCloseTimeout: "2 minutes",
+    retry: {
+      maximumAttempts: 3,
+      initialInterval: "30 seconds",
+      backoffCoefficient: 2,
+      maximumInterval: "2 minutes",
+    },
+  });
+
+export async function runOpenAiComplimentaryUsageReconciliation(): Promise<OpenAiComplimentaryUsageResult> {
+  return await reconcileOpenAiComplimentaryUsage();
+}

--- a/packages/temporal/src/workflows/test-support.ts
+++ b/packages/temporal/src/workflows/test-support.ts
@@ -1,5 +1,6 @@
-import { Worker } from "@temporalio/worker";
+import { Worker, type WorkerOptions } from "@temporalio/worker";
 import type { TestWorkflowEnvironment } from "@temporalio/testing";
+import { TASK_QUEUES } from "#shared/task-queues.ts";
 
 export function createReportCapture(reportRunId: string): {
   reports: unknown[];
@@ -15,6 +16,52 @@ export function createReportCapture(reportRunId: string): {
     return { accepted: true, duplicate: false, reportRunId };
   };
   return { reports, deliverActivityReport };
+}
+
+export async function runWorkflowWithActivityWorker<T>(
+  environment: TestWorkflowEnvironment,
+  options: {
+    activityTaskQueue: string;
+    workflowPath: string;
+    activities: NonNullable<WorkerOptions["activities"]>;
+    execute: () => Promise<T>;
+  },
+): Promise<T> {
+  const workflowWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: TASK_QUEUES.WORKFLOWS,
+    workflowsPath: options.workflowPath,
+  });
+  const activityWorker = await Worker.create({
+    connection: environment.nativeConnection,
+    taskQueue: options.activityTaskQueue,
+    activities: options.activities,
+  });
+  const activityRun = activityWorker.run();
+  try {
+    const workflowResult = options.execute();
+    const workflowState: {
+      outcome: "pending" | "fulfilled" | "rejected";
+    } = { outcome: "pending" };
+    const observedWorkflowResult = (async () => {
+      try {
+        const value = await workflowResult;
+        workflowState.outcome = "fulfilled";
+        return value;
+      } catch (error: unknown) {
+        workflowState.outcome = "rejected";
+        throw error;
+      }
+    })();
+    try {
+      return await workflowWorker.runUntil(observedWorkflowResult);
+    } catch {
+      return await observedWorkflowResult;
+    }
+  } finally {
+    activityWorker.shutdown();
+    await activityRun;
+  }
 }
 
 export async function runWithReportWorker(

--- a/scripts/check-ai-architecture.test.ts
+++ b/scripts/check-ai-architecture.test.ts
@@ -137,4 +137,25 @@ describe("AI architecture guard", () => {
       "direct-provider-endpoint",
     ]);
   });
+
+  test("allows only the official OpenAI billing reconciliation endpoint", () => {
+    expect(
+      findAiArchitectureViolations([
+        {
+          path: "packages/temporal/src/shared/openai-complimentary-usage.ts",
+          contents:
+            'const usage = "https://api.openai.com/v1/organization/usage/completions";\nconst costs = "https://api.openai.com/v1/organization/costs";',
+        },
+      ]),
+    ).toEqual([]);
+    expect(
+      findAiArchitectureViolations([
+        {
+          path: "packages/temporal/src/shared/openai-usage.ts",
+          contents:
+            'const usage = "https://api.openai.com/v1/organization/usage/completions";',
+        },
+      ]).map(({ rule }) => rule),
+    ).toEqual(["direct-provider-endpoint"]);
+  });
 });

--- a/scripts/check-ai-architecture.ts
+++ b/scripts/check-ai-architecture.ts
@@ -127,6 +127,10 @@ const STREAMBOT_VOICE_TTS_PATHS = new Set([
 ]);
 const SUBSCRIPTION_QUOTA_ENDPOINTS =
   "packages/macos-ai-subscription-tracker/Sources/QuotaBarCore/ProviderEndpoints.swift";
+// The billing monitor uses OpenAI's official organization Usage and Costs APIs
+// as the payment authority; this is not an inference path.
+const OPENAI_BILLING_RECONCILIATION_PATH =
+  "packages/temporal/src/shared/openai-complimentary-usage.ts";
 const NATIVE_SDK_CONTRACT_TEST = "scripts/release-agent-sdk-contract.test.ts";
 
 function isTestOrFixture(filePath: string): boolean {
@@ -167,7 +171,8 @@ function isAllowedViolation(rule: ArchitectureRule, filePath: string): boolean {
   if (rule.id === "direct-provider-endpoint") {
     return (
       filePath === WHISPER_TRANSCRIPTION_ADAPTER ||
-      filePath === SUBSCRIPTION_QUOTA_ENDPOINTS
+      filePath === SUBSCRIPTION_QUOTA_ENDPOINTS ||
+      filePath === OPENAI_BILLING_RECONCILIATION_PATH
     );
   }
 


### PR DESCRIPTION
Why:
Scout needs independent proof that OpenAI requests are using the configured OpenRouter BYOK path and that the official OpenAI billing record remains complimentary. OpenRouter estimates cannot establish payment status.

What:
- Record and expose OpenRouter is_byok metadata for successful language requests.
- Add Scout BYOK and missing-metadata alerts plus an hourly official OpenAI Usage/Costs reconciliation.
- Add an isolated single-replica Temporal billing worker with a dedicated admin-key projection, bounded retries, gauges, Alertmanager fire/resolve alerts, and Grafana panels.
- Add fixture/authentic-Node workflow coverage and operator documentation.

Verification:
- bunx turbo run lint typecheck --filter=@shepherdjerred/llm-runtime --filter=@shepherdjerred/temporal --filter=@homelab/cdk8s --filter=@shepherdjerred/docs-wiki
- llm-runtime: 36 tests; Temporal: 1,099 Bun tests and 71 authentic-Node workflow tests; homelab: 42 focused synth/rule/dashboard tests; wiki: 67-page build
- git diff --check and staged pre-commit safety checks pass
- Live deployment acceptance is pending creation of the dedicated openai-usage-monitor 1Password item; the 1Password Desktop approval currently blocks that external credential action.