### PR TITLE
fix(homelab): commit Flipt namespace seeds before startup

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { App } from "cdk8s";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { z } from "zod";
 import { createFliptChart } from "@shepherdjerred/homelab/cdk8s/src/cdk8s-charts/flipt.ts";
-import { createEnvironmentInitializationScript } from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
+import {
+  createRepositoryInitializationScript,
+  createSeedValidationScript,
+} from "@shepherdjerred/homelab/cdk8s/src/resources/flipt/index.ts";
 
 const ManifestSchema = z
   .object({
@@ -77,6 +83,25 @@ function findManifest(
   return manifest;
 }
 
+async function run(command: readonly string[], cwd?: string): Promise<string> {
+  const subprocess = Bun.spawn([...command], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+    subprocess.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `${command.join(" ")} failed (${exitCode.toString()}): ${stderr}`,
+    );
+  }
+  return stdout.trim();
+}
+
 describe("Flipt chart", () => {
   it("emits the namespace, deployment, config, storage, service, and policy resources", () => {
     const manifests = synthesize();
@@ -139,8 +164,11 @@ describe("Flipt chart", () => {
     expect(yaml).not.toContain("path: /var/opt/flipt/data\n");
     expect(yaml).not.toContain("path: /var/opt/flipt/data-beta");
     expect(yaml).not.toContain("path: /var/opt/flipt/data-prod");
-    expect(yaml).toContain("path: /var/opt/flipt/environments/beta");
-    expect(yaml).toContain("path: /var/opt/flipt/environments/prod");
+    expect(yaml).not.toContain("path: /var/opt/flipt/environments/beta");
+    expect(yaml).not.toContain("path: /var/opt/flipt/environments/prod");
+    expect(yaml).toContain("path: /var/opt/flipt/repositories/beta");
+    expect(yaml).toContain("path: /var/opt/flipt/repositories/prod");
+    expect(yaml.match(/branch: main/g)).toHaveLength(2);
     expect(yaml).toContain("name: beta");
     expect(yaml).toContain("name: prod");
     expect(yaml).toMatch(/prod:\n {4}name: prod\n {4}default: true/);
@@ -158,25 +186,50 @@ describe("Flipt chart", () => {
     ).toMatch(/^[a-f\d]{12}$/);
   });
 
-  it("validates and initializes both environments without overwriting repositories", () => {
+  it("validates seeds before initializing committed repositories", () => {
     const deployment = DeploymentSchema.parse(
       findManifest(synthesize(), "Deployment", "flipt"),
     );
-    const initializer = deployment.spec.template.spec.initContainers.find(
-      (container) => container.name === "initialize-environments",
+    const validator = deployment.spec.template.spec.initContainers.find(
+      (container) => container.name === "validate-environment-seeds",
     );
-    expect(initializer?.command).toEqual(["/bin/sh", "-c"]);
-    const script = initializer?.args?.[0] ?? "";
-    expect(script).toContain('/flipt validate --work-dir "$seed"');
-    expect(script).toContain('repo="/var/opt/flipt/environments/$environment"');
-    expect(script).toContain(
+    const initializer = deployment.spec.template.spec.initContainers.find(
+      (container) => container.name === "initialize-environment-repositories",
+    );
+    expect(
+      deployment.spec.template.spec.initContainers.map(({ name }) => name),
+    ).toEqual([
+      "validate-environment-seeds",
+      "initialize-environment-repositories",
+    ]);
+    expect(validator?.command).toEqual(["/bin/sh", "-c"]);
+    const validationScript = validator?.args?.[0] ?? "";
+    expect(validationScript).toContain('/flipt validate --work-dir "$seed"');
+    expect(validationScript).toContain(
       'cp "/etc/flipt-seed/beta.scout.yaml" "$work_root/beta/scout/features.yaml"',
     );
-    expect(script).toContain('if [ ! -e "$repo" ]');
-    expect(script).not.toContain("data-beta");
-    expect(script).not.toContain("data-prod");
+    expect(initializer?.command).toEqual(["/bin/sh", "-c"]);
+    expect(initializer?.image).toMatch(
+      /^docker\.io\/alpine\/git:2\.54\.0@sha256:[a-f\d]{64}$/,
+    );
+    const initializationScript = initializer?.args?.[0] ?? "";
+    expect(initializationScript).toContain(
+      'repo="/var/opt/flipt/repositories/$environment"',
+    );
+    expect(initializationScript).toContain(
+      'git -C "$staging" init --initial-branch=main',
+    );
+    expect(initializationScript).toContain(
+      'git -C "$staging" add -- "scout/features.yaml"',
+    );
+    expect(initializationScript).toContain('if [ -e "$repo" ]');
+    expect(initializationScript).not.toContain("data-beta");
+    expect(initializationScript).not.toContain("data-prod");
+    expect(validator?.volumeMounts?.map((mount) => mount.mountPath)).toEqual(
+      expect.arrayContaining(["/etc/flipt-seed", "/tmp"]),
+    );
     expect(initializer?.volumeMounts?.map((mount) => mount.mountPath)).toEqual(
-      expect.arrayContaining(["/var/opt/flipt", "/etc/flipt-seed", "/tmp"]),
+      expect.arrayContaining(["/var/opt/flipt", "/tmp"]),
     );
   });
 
@@ -207,19 +260,74 @@ describe("Flipt chart", () => {
       expect(yaml).not.toContain("key: default");
     }
   });
+});
 
-  it("generates a fail-fast initialization script", () => {
-    const script = createEnvironmentInitializationScript("/data", ["scout"]);
-    expect(script).toContain('validate_repo "$repo"');
-    expect(script).toContain('/flipt validate --work-dir "$repo"');
-    expect(script).toContain('repo="/data/environments/$environment"');
-    expect(script).toContain(
+describe("Flipt repository initialization", () => {
+  it("generates fail-fast seed validation and repository initialization scripts", () => {
+    const validationScript = createSeedValidationScript(["scout"]);
+    expect(validationScript).toContain('/flipt validate --work-dir "$seed"');
+    expect(validationScript).toContain(
       'cp "/etc/flipt-seed/prod.scout.yaml" "$work_root/prod/scout/features.yaml"',
     );
-    expect(script).not.toContain("data-beta");
-    expect(script).not.toContain("data-prod");
+    const initializationScript = createRepositoryInitializationScript("/data", [
+      "scout",
+    ]);
+    expect(initializationScript).toContain('validate_repository "$repo"');
+    expect(initializationScript).toContain(
+      'repo="/data/repositories/$environment"',
+    );
+    expect(initializationScript).toContain(
+      "git -C \"$candidate\" cat-file -e 'refs/heads/main^{commit}'",
+    );
+    expect(initializationScript).toContain(
+      'git -C "$staging" add -- "scout/features.yaml"',
+    );
+    expect(initializationScript).not.toContain("data-beta");
+    expect(initializationScript).not.toContain("data-prod");
   });
 
+  it("creates a normal repository whose main commit contains the namespace seeds", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "flipt-repository-init-"));
+    try {
+      const workRoot = path.join(root, "seed");
+      const dataPath = path.join(root, "data");
+      for (const environment of ["beta", "prod"]) {
+        const namespacePath = path.join(workRoot, environment, "scout");
+        await mkdir(namespacePath, { recursive: true });
+        await Bun.write(
+          path.join(namespacePath, "features.yaml"),
+          `version: "1.2"\nnamespace:\n  key: scout\n`,
+        );
+      }
+
+      await run([
+        "/bin/sh",
+        "-c",
+        createRepositoryInitializationScript(dataPath, ["scout"], workRoot),
+      ]);
+
+      for (const environment of ["beta", "prod"]) {
+        const repository = path.join(dataPath, "repositories", environment);
+        expect(await run(["git", "branch", "--show-current"], repository)).toBe(
+          "main",
+        );
+        expect(
+          await run(
+            ["git", "ls-tree", "-r", "--name-only", "refs/heads/main"],
+            repository,
+          ),
+        ).toBe("scout/features.yaml");
+        expect(await run(["git", "log", "-1", "--format=%s"], repository)).toBe(
+          "Seed managed feature flags",
+        );
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Flipt network policy", () => {
   it("restricts egress to DNS only", () => {
     const policy = z
       .object({

--- a/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
+++ b/packages/homelab/src/cdk8s/src/resources/flipt/index.ts
@@ -43,9 +43,24 @@ const FLIPT_COMMAND = [
 // as 1000 would fail to write the git repo.
 const FLIPT_UID = 100;
 const FLIPT_GID = 1000;
+const FLIPT_SECURITY_CONTEXT = {
+  user: FLIPT_UID,
+  group: FLIPT_GID,
+  ensureNonRoot: true,
+  readOnlyRootFilesystem: true,
+  allowPrivilegeEscalation: false,
+  privileged: false,
+  capabilities: { drop: [Capability.ALL] },
+  seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
+};
+const FLIPT_INIT_RESOURCES = {
+  cpu: { request: Cpu.millis(5), limit: Cpu.millis(50) },
+  memory: { request: Size.mebibytes(8), limit: Size.mebibytes(32) },
+};
 
 const DATA_PATH = "/var/opt/flipt";
-const ENVIRONMENT_DATA_PATH = `${DATA_PATH}/environments`;
+const REPOSITORY_DATA_PATH = `${DATA_PATH}/repositories`;
+const SEED_WORK_PATH = "/tmp/flipt-seed";
 
 const FLIPT_SEED_DATA = Object.fromEntries(
   managedFlagInventory.environments.flatMap((environment) =>
@@ -64,9 +79,9 @@ const FLIPT_SEED_DATA = Object.fromEntries(
 // silently loses every one of them on restart. Verified by creating a flag,
 // restarting the container, and getting a 404 from the evaluation snapshot.
 // With this config the same test round-trips, and each managed environment has
-// its own bare git repository. The product namespace seed is validated before
-// first boot into the clean environment paths below; existing repositories are
-// never overwritten on later restarts.
+// its own normal git repository. The product namespace seed is validated and
+// committed before first boot into the clean repository paths below; existing
+// repositories are never overwritten on later restarts.
 //
 // check_for_updates and telemetry_enabled both default to true and would fail
 // continuously against the DNS-only egress policy below.
@@ -79,13 +94,15 @@ server:
   http_port: ${FLIPT_PORT.toString()}
 storage:
   beta:
+    branch: main
     backend:
       type: local
-      path: ${ENVIRONMENT_DATA_PATH}/beta
+      path: ${REPOSITORY_DATA_PATH}/beta
   prod:
+    branch: main
     backend:
       type: local
-      path: ${ENVIRONMENT_DATA_PATH}/prod
+      path: ${REPOSITORY_DATA_PATH}/prod
 environments:
   beta:
     name: beta
@@ -107,8 +124,7 @@ meta:
   state_directory: ${DATA_PATH}/state
 `;
 
-export function createEnvironmentInitializationScript(
-  dataPath: string,
+export function createSeedValidationScript(
   namespaces: readonly string[],
 ): string {
   const copyCommands = ["beta", "prod"].flatMap((environment) =>
@@ -119,46 +135,76 @@ export function createEnvironmentInitializationScript(
   );
   return `set -eu
 
-validate_repo() {
-  repo="$1"
-  if [ ! -f "$repo/HEAD" ] || [ ! -f "$repo/config" ] || [ ! -d "$repo/objects" ]; then
-    echo "Flipt repository is missing or structurally invalid: $repo" >&2
-    exit 1
-  fi
-}
-
-work_root="/tmp/flipt-seed"
+work_root="${SEED_WORK_PATH}"
 mkdir -p "$work_root/beta" "$work_root/prod"
 ${copyCommands.join("\n")}
 
-initialize_environment() {
+validate_environment() {
   environment="$1"
-  repo="${dataPath}/environments/$environment"
   seed="$work_root/$environment"
 
   /flipt validate --work-dir "$seed"
-  if [ ! -e "$repo" ]; then
-    mkdir -p "$repo"
-    cp -R "$seed/." "$repo/"
-    return
-  fi
-
-  if [ -f "$repo/HEAD" ] || [ -f "$repo/config" ] || [ -d "$repo/objects" ]; then
-    validate_repo "$repo"
-    return
-  fi
-
-  # A failed first Flipt boot may leave the validated source tree in place.
-  # Keep it intact so the local backend can retry repository initialization.
-  /flipt validate --work-dir "$repo"
 }
 
+validate_environment beta
+validate_environment prod
+`;
+}
+
+export function createRepositoryInitializationScript(
+  dataPath: string,
+  namespaces: readonly string[],
+  workRoot = SEED_WORK_PATH,
+): string {
+  const trackedPaths = namespaces.map(
+    (namespace) => `"${namespace}/features.yaml"`,
+  );
+  return `set -eu
+
+validate_repository() {
+  candidate="$1"
+  if [ ! -d "$candidate/.git" ]; then
+    echo "Flipt repository is not a normal Git repository: $candidate" >&2
+    exit 1
+  fi
+  git -C "$candidate" show-ref --verify --quiet refs/heads/main
+  git -C "$candidate" cat-file -e 'refs/heads/main^{commit}'
+}
+
+initialize_environment() {
+  environment="$1"
+  repo="${dataPath}/repositories/$environment"
+  staging="$repo.initializing"
+  seed="${workRoot}/$environment"
+
+  if [ -e "$repo" ]; then
+    validate_repository "$repo"
+    return
+  fi
+  if [ -e "$staging" ]; then
+    echo "Stale Flipt repository initialization directory: $staging" >&2
+    exit 1
+  fi
+
+  mkdir -p "$staging"
+  cp -R "$seed/." "$staging/"
+  git -C "$staging" init --initial-branch=main
+  git -C "$staging" config user.name "Flipt seed initializer"
+  git -C "$staging" config user.email "flipt-seed@localhost"
+  git -C "$staging" add -- ${trackedPaths.join(" ")}
+  git -C "$staging" commit --message "Seed managed feature flags"
+  validate_repository "$staging"
+  mv "$staging" "$repo"
+}
+
+mkdir -p "${dataPath}/repositories"
 initialize_environment beta
 initialize_environment prod
 `;
 }
 
-const INITIALIZE_ENVIRONMENTS_SCRIPT = createEnvironmentInitializationScript(
+const VALIDATE_SEEDS_SCRIPT = createSeedValidationScript(managedFlagNamespaces);
+const INITIALIZE_REPOSITORIES_SCRIPT = createRepositoryInitializationScript(
   DATA_PATH,
   managedFlagNamespaces,
 );
@@ -202,27 +248,30 @@ export function createFliptDeployment(chart: Chart) {
 
   deployment.addInitContainer(
     withCommonProps({
-      name: "initialize-environments",
+      name: "validate-environment-seeds",
       image: `flipt/flipt:${versions["flipt-io/flipt"]}`,
       command: ["/bin/sh", "-c"],
-      args: [INITIALIZE_ENVIRONMENTS_SCRIPT],
-      resources: {
-        cpu: { request: Cpu.millis(5), limit: Cpu.millis(50) },
-        memory: { request: Size.mebibytes(8), limit: Size.mebibytes(32) },
-      },
-      securityContext: {
-        user: FLIPT_UID,
-        group: FLIPT_GID,
-        ensureNonRoot: true,
-        readOnlyRootFilesystem: true,
-        allowPrivilegeEscalation: false,
-        privileged: false,
-        capabilities: { drop: [Capability.ALL] },
-        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
-      },
+      args: [VALIDATE_SEEDS_SCRIPT],
+      resources: FLIPT_INIT_RESOURCES,
+      securityContext: FLIPT_SECURITY_CONTEXT,
+      volumeMounts: [
+        { path: "/etc/flipt-seed", volume: seedVolume, readOnly: true },
+        { path: "/tmp", volume: scratchVolume },
+      ],
+    }),
+  );
+
+  deployment.addInitContainer(
+    withCommonProps({
+      name: "initialize-environment-repositories",
+      image: `docker.io/alpine/git:${versions["alpine/git"]}`,
+      command: ["/bin/sh", "-c"],
+      args: [INITIALIZE_REPOSITORIES_SCRIPT],
+      resources: FLIPT_INIT_RESOURCES,
+      securityContext: FLIPT_SECURITY_CONTEXT,
+      envVariables: { HOME: EnvValue.fromValue("/tmp") },
       volumeMounts: [
         { path: DATA_PATH, volume: persistentDataVolume },
-        { path: "/etc/flipt-seed", volume: seedVolume, readOnly: true },
         { path: "/tmp", volume: scratchVolume },
       ],
     }),
@@ -238,16 +287,7 @@ export function createFliptDeployment(chart: Chart) {
         cpu: { request: Cpu.millis(25), limit: Cpu.millis(500) },
         memory: { request: Size.mebibytes(128), limit: Size.mebibytes(512) },
       },
-      securityContext: {
-        user: FLIPT_UID,
-        group: FLIPT_GID,
-        ensureNonRoot: true,
-        readOnlyRootFilesystem: true,
-        allowPrivilegeEscalation: false,
-        privileged: false,
-        capabilities: { drop: [Capability.ALL] },
-        seccompProfile: { type: SeccompProfileType.RUNTIME_DEFAULT },
-      },
+      securityContext: FLIPT_SECURITY_CONTEXT,
       startup: Probe.fromHttpGet("/health", {
         port: FLIPT_PORT,
         periodSeconds: Duration.seconds(5),

--- a/packages/homelab/src/cdk8s/src/version-map.generated.ts
+++ b/packages/homelab/src/cdk8s/src/version-map.generated.ts
@@ -102,6 +102,7 @@ export const VersionMapSchema = z
     "library/busybox": z.string(),
     "mikefarah/yq": z.string(),
     "library/alpine": z.string(),
+    "alpine/git": z.string(),
     "mccloud/bazarr-openai-whisperbridge": z.string(),
     "library/debian": z.string(),
     "library/nginx": z.string(),

--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1298,6 +1298,21 @@
       "value": "latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
     },
     {
+      "name": "alpine/git",
+      "category": "upstream",
+      "artifactType": "image",
+      "management": {
+        "managed": true,
+        "datasource": "docker",
+        "registryUrl": "https://docker.io",
+        "versioning": "docker"
+      },
+      "value": "2.54.0@sha256:4f9488b7295baec153a9953479690f835ad4699b1d9f11e3897a4485c224fc3e",
+      "notes": [
+        "Initializes Flipt's local storage as committed normal Git repositories."
+      ]
+    },
+    {
       "name": "mccloud/bazarr-openai-whisperbridge",
       "category": "upstream",
       "artifactType": "image",


### PR DESCRIPTION
## Why

PR #2638 deployed the product namespace inventory, but Flipt v2.11 treated the copied seed directories as bare Git storage. Its automatic initialization committed only `README.md`; all twelve `features.yaml` trees remained outside the served commit, so every namespace snapshot returned 404 and consumers fell back to defaults.

## What

- validate the twelve generated seed files before touching persistent storage
- initialize `beta` and `prod` as normal Git repositories with committed `main` branches using a digest-pinned `alpine/git` init container
- move Flipt to new `/var/opt/flipt/repositories/{beta,prod}` paths, leaving the broken repositories untouched
- refuse malformed or partially initialized repositories on later starts without overwriting live state
- add an executable regression test that proves each `main` commit contains the namespace seed

## Verification

- `bunx turbo run build typecheck test lint --filter=@homelab/cdk8s --filter=@shepherdjerred/version-catalog --filter=@shepherdjerred/feature-flags`
- `bunx lefthook run pre-commit`
- exact-image Docker acceptance with `flipt/flipt:v2.11.0` and `alpine/git:2.54.0`: all twelve environment/namespace inventory checks passed before and after a Flipt restart

## Rollout

The currently deployed Flipt remains unhealthy at the feature-flag layer until this merges and the root release reconciles it. After deployment, rerun the twelve-pair inventory check and confirm consumer logs stop producing namespace-not-found errors.