### PR TITLE
feat(trmnl-dashboard): manage all dashboard archives with trmnlp

### DIFF
--- a/packages/trmnl-dashboard/README.md
+++ b/packages/trmnl-dashboard/README.md
@@ -59,11 +59,12 @@ bun run smoke         # boots the trmnl-dashboard:dev image and asserts a clean 
 
 ## Private plugins as code
 
-The two existing private plugins are complete
+The three existing private plugins are complete
 [`trmnlp`](https://github.com/usetrmnl/trmnlp/blob/main/README.md) projects:
 
 - `trmnl/home-assistant` — plugin ID `303046`
 - `trmnl/homelab` — plugin ID `303047`
+- `trmnl/pets` — plugin ID `464652`
 
 Their IDs are immutable deployment targets. Do not run `trmnlp init` or push a
 project without its committed ID: that would create a new remote plugin and
@@ -73,7 +74,7 @@ The repository pins both the `trmnlp` image and TRMNL framework version. Local
 and CI rendering uses deterministic synthetic JSON from `trmnl/fixtures`; it
 does not call the production dashboard or need its polling key.
 
-From the repository root, validate all four layouts for both plugins:
+From the repository root, validate all four layouts for all three plugins:
 
 ```bash
 docker run --rm --entrypoint sh \
@@ -88,13 +89,13 @@ Preview one plugin at `http://localhost:4567`:
 docker run --rm --entrypoint sh -p 4567:4567 \
   -v "$(pwd):/workspace" -w /workspace \
   trmnl/trmnlp:v0.11.0@sha256:4ac6d7f35ff30665b6c3b2634c2ba830488b2ee38783acc2ce953b652cb1c973 \
-  packages/trmnl-dashboard/scripts/trmnlp-ci.sh serve home-assistant
+  packages/trmnl-dashboard/scripts/trmnlp-ci.sh serve pets
 ```
 
 Buildkite runs the same validation without secrets on pull requests. On main,
-the path-selected `trmnl` lane validates both projects before publishing either
-one, then pushes plugin `303046` followed by `303047`. The publisher uses the
-dedicated account-level `TRMNL_API_KEY` from
+the path-selected `trmnl` lane validates all three projects before publishing
+any of them, then pushes plugin `303046`, `303047`, and `464652` in that order.
+The publisher uses the dedicated account-level `TRMNL_API_KEY` from
 `buildkite-trmnl-credentials`; this is intentionally separate from the
 dashboard service's polling key.
 
@@ -104,12 +105,17 @@ through the environment and pull each existing ID explicitly:
 ```bash
 trmnlp pull --id 303046 --dir packages/trmnl-dashboard/trmnl/home-assistant
 trmnlp pull --id 303047 --dir packages/trmnl-dashboard/trmnl/homelab
+trmnlp pull --id 464652 --dir packages/trmnl-dashboard/trmnl/pets
 ```
 
-Review every resulting diff before committing. Hosted custom-field values are
-instance state and must not be copied into Git. The `api_key` field is a
-password whose value remains stored only in TRMNL; `settings.yml` commits only
-the field definition and encoded header template.
+Review every resulting diff before committing. A pull replaces the local
+archive files, so repository review remains the boundary for accepting remote
+markup or settings changes. Hosted custom-field values are instance state and
+must not be copied into Git. The `api_key` field is a password whose value
+remains stored only in TRMNL; preserving that keyname lets publication retain
+the existing hosted value. `settings.yml` commits only the field definition and
+encoded header template, while `.trmnlp.yml` contains synthetic local preview
+values and is never uploaded.
 
 Playlist membership and ordering, schedules, mashups, and device settings
 remain managed in the TRMNL UI because the hosted API does not expose their

--- a/packages/trmnl-dashboard/scripts/trmnlp-ci.sh
+++ b/packages/trmnl-dashboard/scripts/trmnlp-ci.sh
@@ -17,6 +17,7 @@ check_plugin_ids() {
     expected = {
       "home-assistant" => 303046,
       "homelab" => 303047,
+      "pets" => 464652,
     }
     settings = expected.to_h do |slug, _expected_id|
       path = File.join(ARGV.fetch(0), slug, "src", "settings.yml")
@@ -73,9 +74,15 @@ start_fixture_server() {
   while [ "$attempt" -lt 30 ]; do
     if ruby -rsocket -e '
       begin
-        socket = TCPSocket.new("127.0.0.1", 4568)
-        socket.write "GET /home-assistant.json HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-        exit(socket.read.start_with?("HTTP/1.1 200") ? 0 : 1)
+        paths = %w[home-assistant.json homelab.json pets.json]
+        ready = paths.all? do |path|
+          socket = TCPSocket.new("127.0.0.1", 4568)
+          socket.write "GET /#{path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+          response = socket.read
+          socket.close
+          response.start_with?("HTTP/1.1 200")
+        end
+        exit(ready ? 0 : 1)
       rescue SystemCallError
         exit 1
       end
@@ -138,6 +145,7 @@ validate_all() {
   start_fixture_server
   validate_project "$trmnl_root/home-assistant"
   validate_project "$trmnl_root/homelab"
+  validate_project "$trmnl_root/pets"
 }
 
 self_test() {
@@ -146,6 +154,7 @@ self_test() {
   cp -R "$trmnl_root/fixtures" "$self_test_dir/trmnl/fixtures"
   cp -R "$trmnl_root/home-assistant" "$self_test_dir/trmnl/home-assistant"
   cp -R "$trmnl_root/homelab" "$self_test_dir/trmnl/homelab"
+  cp -R "$trmnl_root/pets" "$self_test_dir/trmnl/pets"
 
   ruby -ryaml -e '
     path = ARGV.fetch(0)
@@ -240,6 +249,23 @@ SCRIPT
     echo "the Selenium timeout did not trigger exactly one retry" >&2
     exit 1
   fi
+
+  : >"$publish_log"
+  TRMNL_ROOT="$self_test_dir/trmnl" \
+    TRMNLP_COMMAND="$fake_trmnlp" \
+    TRMNLP_TEST_LOG="$publish_log" \
+    TRMNL_API_KEY=self-test \
+    "$0" publish
+  expected_publish_log="$self_test_dir/expected-push.log"
+  printf '%s\n' \
+    "$self_test_dir/trmnl/home-assistant" \
+    "$self_test_dir/trmnl/homelab" \
+    "$self_test_dir/trmnl/pets" >"$expected_publish_log"
+  if ! cmp -s "$expected_publish_log" "$publish_log"; then
+    echo "plugins were not published exactly once in deterministic order" >&2
+    diff -u "$expected_publish_log" "$publish_log"
+    exit 1
+  fi
 }
 
 check_plugin_ids
@@ -261,16 +287,18 @@ case "$mode" in
     validate_all
     "$trmnlp_command" push --force --dir "$trmnl_root/home-assistant"
     "$trmnlp_command" push --force --dir "$trmnl_root/homelab"
+    "$trmnlp_command" push --force --dir "$trmnl_root/pets"
     git -C "$repo_root" diff --exit-code -- \
       packages/trmnl-dashboard/trmnl/home-assistant \
-      packages/trmnl-dashboard/trmnl/homelab
+      packages/trmnl-dashboard/trmnl/homelab \
+      packages/trmnl-dashboard/trmnl/pets
     ;;
   serve)
     case "$plugin_slug" in
-      home-assistant | homelab)
+      home-assistant | homelab | pets)
         ;;
       *)
-        echo "serve requires home-assistant or homelab" >&2
+        echo "serve requires home-assistant, homelab, or pets" >&2
         exit 1
         ;;
     esac
@@ -278,7 +306,7 @@ case "$mode" in
     "$trmnlp_command" serve --bind 0.0.0.0 --dir "$trmnl_root/$plugin_slug"
     ;;
   *)
-    echo "usage: $0 {check-ids|self-test|validate|publish|serve <home-assistant|homelab>}" >&2
+    echo "usage: $0 {check-ids|self-test|validate|publish|serve <home-assistant|homelab|pets>}" >&2
     exit 1
     ;;
 esac

--- a/packages/trmnl-dashboard/src/__tests__/pets-template.test.ts
+++ b/packages/trmnl-dashboard/src/__tests__/pets-template.test.ts
@@ -2,29 +2,78 @@ import { describe, expect, it } from "vitest";
 import { Liquid } from "liquidjs";
 import type { PetCarePayload, PetProblem } from "../types.ts";
 
-const templatePath = new URL("../../trmnl/pets.liquid", import.meta.url)
+const templateDirectory = new URL("../../trmnl/pets/src/", import.meta.url)
   .pathname;
 const liquid = new Liquid({ strictVariables: true, strictFilters: true });
+const layouts = [
+  "full",
+  "half_horizontal",
+  "half_vertical",
+  "quadrant",
+] as const;
+const statuses = ["ok", "warning", "error"] as const;
 
-describe("pets.liquid", () => {
-  it.each([
-    ["healthy", fixture("ok")],
-    ["warning", fixture("warning")],
-    ["critical", fixture("error")],
-  ])("renders the %s fixture", async (_name, payload) => {
-    const template = await Bun.file(templatePath).text();
-    const html = await liquid.parseAndRender(template, payload);
+describe("Pets TRMNL layouts", () => {
+  it.each(
+    statuses.flatMap((status) => layouts.map((layout) => ({ layout, status }))),
+  )("renders $layout with a $status payload", async ({ layout, status }) => {
+    const shared = await Bun.file(`${templateDirectory}shared.liquid`).text();
+    const template = await Bun.file(
+      `${templateDirectory}${layout}.liquid`,
+    ).text();
+    const payload = fixture(status);
+    const html = await liquid.parseAndRender(`${shared}\n${template}`, payload);
 
     expect(html).toContain("Pet Care");
-    expect(html).toContain("Globe litter");
-    expect(html).toContain("Hopper");
-    expect(html).toContain("Roborock Fleet");
-    expect(html).toContain("Litter cycles");
-    if (payload.status === "ok") {
-      expect(html).not.toContain("ACTIVE PROBLEMS");
-    } else {
-      expect(html).toContain("ACTIVE PROBLEMS");
+    expect(html).toContain(status.toUpperCase());
+
+    switch (layout) {
+      case "full": {
+        expect(html).toContain("Globe litter");
+        expect(html).toContain("Hopper");
+        expect(html).toContain("Roborock Fleet");
+        expect(html).toContain("Litter cycles");
+        break;
+      }
+      case "half_horizontal": {
+        expect(html).toContain("Pet devices");
+        expect(html).toContain("Vacuum fleet");
+        expect(html).toContain("Litter cycles");
+        break;
+      }
+      case "half_vertical": {
+        expect(html).toContain("Fountain water");
+        expect(html).toContain("Litter / waste");
+        expect(html).toContain("Vacuum fleet");
+        break;
+      }
+      case "quadrant": {
+        expect(html).toContain("Highest priority");
+        expect(html).toContain("Water");
+        expect(html).toContain("Litter");
+        break;
+      }
     }
+
+    if (payload.status !== "ok") {
+      expect(html).toContain(payload.problems[0]?.summary);
+    }
+  });
+
+  it("does not report all clear when diagnostics are incomplete", async () => {
+    const shared = await Bun.file(`${templateDirectory}shared.liquid`).text();
+    const template = await Bun.file(
+      `${templateDirectory}quadrant.liquid`,
+    ).text();
+    const payload = fixture("ok");
+    payload.status = "unknown";
+    payload.summary = "Pet diagnostics incomplete";
+    payload.errors = ["Alertmanager alerts: request failed"];
+
+    const html = await liquid.parseAndRender(`${shared}\n${template}`, payload);
+
+    expect(html).toContain("UNKNOWN · diagnostics incomplete");
+    expect(html).not.toContain("All clear");
   });
 });
 

--- a/packages/trmnl-dashboard/trmnl/fixtures/pets.json
+++ b/packages/trmnl-dashboard/trmnl/fixtures/pets.json
@@ -1,0 +1,126 @@
+{
+  "screen": "pets",
+  "generated_at": "2026-09-02T15:30:00.000Z",
+  "generated_time": "8:30 AM",
+  "status": "warning",
+  "summary": "2 active pet-care problems",
+  "problems": [
+    {
+      "severity": "critical",
+      "alert": "LitterRobotWasteCritical",
+      "summary": "Storage LR5 waste drawer critical"
+    },
+    {
+      "severity": "warning",
+      "alert": "RoborockConsumableDue",
+      "summary": "2nd Floor dock strainer due"
+    }
+  ],
+  "fountain": {
+    "status": "warning",
+    "water_percent": 28,
+    "water_ounces": 24,
+    "cleaning_days": 2,
+    "filter_days": 4,
+    "dispensing": true,
+    "dispensing_mode": "Flowing Water (Constant)",
+    "wifi": true,
+    "drinking_ounces_today": 4.1,
+    "drinking_visits_today": 9
+  },
+  "feeders": [
+    {
+      "id": "living-room",
+      "label": "Living Room",
+      "status": "ok",
+      "food_low": false,
+      "dispenser_problem": false,
+      "battery_problem": false,
+      "wifi": true,
+      "desiccant_days": 9,
+      "last_feed_at": "2026-09-02T14:00:10Z",
+      "feedings_today": 2,
+      "food_grams_today": 20
+    },
+    {
+      "id": "guest-room",
+      "label": "Guest Room",
+      "status": "warning",
+      "food_low": true,
+      "dispenser_problem": false,
+      "battery_problem": false,
+      "wifi": true,
+      "desiccant_days": 3,
+      "last_feed_at": "2026-09-02T14:01:20Z",
+      "feedings_today": 2,
+      "food_grams_today": 20
+    }
+  ],
+  "litter_robot": {
+    "status": "error",
+    "name": "Storage",
+    "online": true,
+    "ready": true,
+    "litter_percent": 72.5,
+    "waste_percent": 84,
+    "hopper_status": "Ready",
+    "hopper_level_raw": 1,
+    "hopper_installed": true,
+    "hopper_enabled": true,
+    "last_seen_at": "2026-09-02T15:21:53Z",
+    "filter_due_at": "2026-09-26T03:00:32Z",
+    "cycles_today": 2
+  },
+  "vacuums": [
+    {
+      "id": "1st-floor",
+      "label": "1st Floor",
+      "status": "ok",
+      "state": "docked",
+      "battery_percent": 100,
+      "last_clean_at": "2026-09-01T22:29:17Z",
+      "consumable_hours": 40,
+      "clean_water_empty": false,
+      "dirty_water_full": false,
+      "cleaning_fluid_low": false,
+      "water_shortage": false,
+      "dust_bag": null
+    },
+    {
+      "id": "2nd-floor",
+      "label": "2nd Floor",
+      "status": "warning",
+      "state": "docked",
+      "battery_percent": 87,
+      "last_clean_at": "2026-09-01T23:12:44Z",
+      "consumable_hours": 0,
+      "clean_water_empty": false,
+      "dirty_water_full": false,
+      "cleaning_fluid_low": true,
+      "water_shortage": false,
+      "dust_bag": null
+    },
+    {
+      "id": "3rd-floor",
+      "label": "3rd Floor",
+      "status": "ok",
+      "state": "charging",
+      "battery_percent": 64,
+      "last_clean_at": "2026-09-01T20:05:30Z",
+      "consumable_hours": 18,
+      "clean_water_empty": false,
+      "dirty_water_full": false,
+      "cleaning_fluid_low": false,
+      "water_shortage": false,
+      "dust_bag": null
+    }
+  ],
+  "activity": {
+    "drinking_ounces": 4.1,
+    "drinking_visits": 9,
+    "feedings": 4,
+    "food_grams": 40,
+    "litter_cycles": 2
+  },
+  "errors": []
+}

--- a/packages/trmnl-dashboard/trmnl/pets/.trmnlp.yml
+++ b/packages/trmnl-dashboard/trmnl/pets/.trmnlp.yml
@@ -1,0 +1,11 @@
+---
+watch:
+  - .trmnlp.yml
+  - src
+custom_fields:
+  api_key: preview-only
+time_zone: America/Los_Angeles
+variables:
+  trmnl:
+    plugin_settings:
+      polling_url: http://127.0.0.1:4568/pets.json

--- a/packages/trmnl-dashboard/trmnl/pets/src/full.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets/src/full.liquid
@@ -84,7 +84,4 @@
   </div>
 </div>
 
-<div class="title_bar">
-  <span class="title">Pet Care</span>
-  <span class="instance">{{ status | upcase }} · {{ generated_time }}</span>
-</div>
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/pets/src/half_horizontal.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets/src/half_horizontal.liquid
@@ -1,0 +1,35 @@
+<div class="layout layout--col gap--small">
+  <div class="grid grid--cols-4 gap--small">
+    <div class="item"><div class="content"><span class="title">Problems</span><span class="value value--small">{{ problems.size }}</span></div></div>
+    <div class="item"><div class="content"><span class="title">Water</span><span class="value value--small">{{ fountain.water_percent | default: "n/a" }}%</span></div></div>
+    <div class="item"><div class="content"><span class="title">Food</span><span class="value value--small">{{ activity.food_grams | default: "n/a" }}g</span></div></div>
+    <div class="item"><div class="content"><span class="title">Litter cycles</span><span class="value value--small">{{ activity.litter_cycles | default: "n/a" }}</span></div></div>
+  </div>
+
+  <div class="grid grid--cols-2 gap--medium">
+    <div>
+      <span class="label label--underline">Pet devices</span>
+      <table class="table table--condensed">
+        <tbody>
+          <tr><td>Fountain</td><td class="text--right">{{ fountain.status | upcase }} · {{ fountain.cleaning_days | default: "n/a" }}d clean</td></tr>
+          {% for feeder in feeders %}<tr><td>{{ feeder.label }} feeder</td><td class="text--right">{{ feeder.status | upcase }} · {{ feeder.food_grams_today | default: "n/a" }}g</td></tr>{% endfor %}
+          {% if litter_robot %}<tr><td>{{ litter_robot.name }} LR5</td><td class="text--right">{{ litter_robot.status | upcase }} · {{ litter_robot.waste_percent }}% waste</td></tr>{% endif %}
+        </tbody>
+      </table>
+    </div>
+
+    <div>
+      <span class="label label--underline">Vacuum fleet</span>
+      <table class="table table--condensed">
+        <tbody>
+          {% for vacuum in vacuums %}
+            <tr><td>{{ vacuum.label }}</td><td class="text--right">{{ vacuum.status | upcase }} · {{ vacuum.battery_percent | default: "n/a" }}%</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% for problem in problems limit: 1 %}<div class="label">{{ problem.severity | upcase }} · {{ problem.summary }}</div>{% endfor %}
+    </div>
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/pets/src/half_vertical.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets/src/half_vertical.liquid
@@ -1,0 +1,28 @@
+<div class="layout layout--col gap--small">
+  <div class="item">
+    <div class="meta"></div>
+    <div class="content"><span class="title">{{ status | upcase }}</span><span class="value value--small">{{ summary }}</span></div>
+  </div>
+
+  {% if problems.size > 0 %}
+    <div>
+      <span class="label label--underline">Problems</span>
+      {% for problem in problems limit: 2 %}<div>{{ problem.severity | upcase }} · {{ problem.summary }}</div>{% endfor %}
+    </div>
+  {% endif %}
+
+  <table class="table table--condensed">
+    <tbody>
+      <tr><td>Fountain water</td><td class="text--right">{{ fountain.water_percent | default: "n/a" }}% · {{ fountain.status | upcase }}</td></tr>
+      <tr><td>Feeders / food</td><td class="text--right">{{ feeders.size }} · {{ activity.food_grams | default: "n/a" }}g</td></tr>
+      {% if litter_robot %}<tr><td>Litter / waste</td><td class="text--right">{{ litter_robot.litter_percent }}% / {{ litter_robot.waste_percent }}%</td></tr>{% else %}<tr><td>LR5 diagnostics</td><td class="text--right">Unavailable</td></tr>{% endif %}
+    </tbody>
+  </table>
+
+  <div>
+    <span class="label label--underline">Vacuum fleet</span>
+    {% for vacuum in vacuums %}<div class="flex flex--row flex--between"><span>{{ vacuum.label }}</span><span>{{ vacuum.status | upcase }} · {{ vacuum.battery_percent | default: "n/a" }}%</span></div>{% endfor %}
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/pets/src/quadrant.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets/src/quadrant.liquid
@@ -1,0 +1,25 @@
+<div class="layout layout--col gap--small">
+  <div class="item">
+    <div class="meta"></div>
+    <div class="content"><span class="title">{{ status | upcase }}</span><span class="value value--small">{{ summary }}</span></div>
+  </div>
+
+  <div class="grid grid--cols-3 gap--small">
+    <div class="item"><div class="content"><span class="title">Problems</span><span class="value">{{ problems.size }}</span></div></div>
+    <div class="item"><div class="content"><span class="title">Water</span><span class="value">{{ fountain.water_percent | default: "n/a" }}%</span></div></div>
+    <div class="item"><div class="content"><span class="title">Litter</span><span class="value">{% if litter_robot %}{{ litter_robot.litter_percent }}%{% else %}n/a{% endif %}</span></div></div>
+  </div>
+
+  <div>
+    <span class="label label--underline">Highest priority</span>
+    {% if problems.size > 0 %}
+      {% for problem in problems limit: 1 %}<div>{{ problem.severity | upcase }} · {{ problem.summary }}</div>{% endfor %}
+    {% elsif status == "ok" %}
+      <div>All clear</div>
+    {% else %}
+      <div>{{ status | upcase }} · diagnostics incomplete</div>
+    {% endif %}
+  </div>
+</div>
+
+{{ dashboard_title_bar }}

--- a/packages/trmnl-dashboard/trmnl/pets/src/settings.yml
+++ b/packages/trmnl-dashboard/trmnl/pets/src/settings.yml
@@ -1,0 +1,40 @@
+---
+strategy: polling
+no_screen_padding: 'no'
+dark_mode: 'no'
+static_data: ''
+polling_verb: get
+framework_version: 3.1.1
+serverless_language: ''
+polling_url: https://trmnl.sjer.red/api/pets
+polling_headers: x-api-key={{ api_key | url_encode }}
+polling_body: ''
+id: 464652
+oauth_enabled: 'false'
+oauth_pkce_enabled: 'no'
+oauth_authorize_url: ''
+oauth_token_url: ''
+oauth_scopes: ''
+oauth_scope_separator: ''
+oauth_refresh_url: ''
+oauth_auth_params: ''
+oauth_token_headers: ''
+oauth_token_site: ''
+oauth_token_params: ''
+oauth_token_request_auth_method: ''
+oauth_body_format: ''
+oauth_token_response_metadata: ''
+oauth_authorization_method: ''
+oauth_refresh_params: ''
+oauth_token_field_name: ''
+oauth_expiry_field_name: ''
+oauth_expiry_strategy: ''
+oauth_fixed_expiry_ms: ''
+custom_fields:
+- keyname: api_key
+  field_type: password
+  name: API Key
+  description: Dashboard polling key stored only in TRMNL.
+name: Pets Dashboard
+description: Pet-care status and daily activity.
+refresh_interval: 15

--- a/packages/trmnl-dashboard/trmnl/pets/src/shared.liquid
+++ b/packages/trmnl-dashboard/trmnl/pets/src/shared.liquid
@@ -1,0 +1,7 @@
+{% assign dashboard_status = status | upcase %}
+{% capture dashboard_title_bar %}
+  <div class="title_bar">
+    <span class="title">Pet Care</span>
+    <span class="instance">{{ dashboard_status }} · {{ generated_time }}</span>
+  </div>
+{% endcapture %}


### PR DESCRIPTION
Why

Pets plugin 464652 was the only TRMNL dashboard archive still managed manually. That left its hosted settings and layouts outside the same validation and publication boundary used by Home and Homelab.

What

- add a fixed-ID Pets trmnlp project with the existing polling contract, synthetic warning preview data, shared markup, and full, horizontal-half, vertical-half, and quadrant layouts
- validate all three fixed plugin IDs and all twelve layouts before publishing Home, Homelab, then Pets
- extend the harness self-test for missing and duplicate IDs, fail-before-publish behavior, deterministic three-plugin ordering, and bounded screenshot retry
- strictly render every Pets layout against healthy, warning, and error payloads and document what archive sync does and does not own

Verification

- `packages/trmnl-dashboard/scripts/trmnlp-ci.sh self-test`
- pinned `trmnl/trmnlp:v0.11.0` validation produced all twelve HTML and PNG artifacts
- `bunx turbo run test typecheck lint --filter=@shepherdjerred/trmnl-dashboard`
- `shellcheck packages/trmnl-dashboard/scripts/trmnlp-ci.sh`
- `bunx lefthook run pre-commit`
- visually inspected all twelve generated PNGs
- confirmed unauthenticated `GET https://trmnl.sjer.red/api/pets` remains HTTP 401

Rollout

This PR does not mutate hosted TRMNL state. After merge, the exact-main `trmnl-publish` lane must publish all three archives before the Pets health reset, physical-device verification, and authenticated endpoint checks can be completed. Hosted custom-field values, playlists, schedules, mashups, and device settings remain outside archive sync.

Visual proof

The four rendered Pets layouts will be attached in a PR comment after draft creation.