### PR TITLE
fix(temporal): restore Scout complimentary-inference monitoring

### DIFF
--- a/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
+++ b/packages/docs/wiki/src/content/docs/how-to/attribute-llm-spend.md
@@ -83,7 +83,7 @@ unwrapped call site.
 First confirm that successful Scout reviews used the configured provider key:
 
 ```bash
-toolkit prom query 'sum by (model, upstream_provider, byok) (increase(llm_openrouter_byok_requests_total{service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?"}[1h]))'
+toolkit prom query 'sum by (model, upstream_provider, byok) (increase(llm_openrouter_byok_requests_total{exported_service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?"}[1h]))'
 ```
 
 `byok="true"` is necessary but not sufficient. Trigger the
@@ -102,6 +102,9 @@ crosses OpenAI's daily allowance can be billed in full, so any `default`-tier
 tokens are actionable even when BYOK is still healthy.
 
 The alerts divide failures by evidence layer:
+
+For the full worker rollout, schedule, and alert acceptance procedure, use the
+[Temporal worker deployment rollout guide](/how-to/roll-out-a-temporal-worker-deployment/).
 
 - `ScoutOpenAiNotByok` means OpenRouter reported shared capacity for a
   successful Scout review.

--- a/packages/docs/wiki/src/content/docs/how-to/roll-out-a-temporal-worker-deployment.md
+++ b/packages/docs/wiki/src/content/docs/how-to/roll-out-a-temporal-worker-deployment.md
@@ -43,6 +43,12 @@ During Scout bootstrap, verify that stable and candidate are both capable,
 distinct images and both exact versions have registered pollers. Pass the
 stable image SHA with `--stable-build-id` on the first `start` command.
 
+For a scheduled workflow, pause the exact schedule before changing the bundle.
+After the candidate canary succeeds, trigger one bounded run and confirm the
+workflow completes before resuming the schedule. This is especially important
+for the complimentary OpenAI monitor: its Activity runs on the isolated
+`billing` queue, while the schedule starts on `monorepo-workflows`.
+
 Inspect the candidate without changing routing:
 
 ```bash
@@ -133,6 +139,27 @@ pull-request flow.
 Image commit-back retains a Workflow candidate whenever stable and candidate
 differ, so a new build cannot replace an in-flight candidate and will not
 advance the track again until this post-rollback reset lands.
+
+## Verify the complimentary OpenAI monitor
+
+The monitor is healthy only when all three signals agree: the billing Activity
+has completed, official Usage and Costs data is current, and Scout review
+telemetry reports `byok="true"`. Check the current-day gauges and alert state in
+Prometheus after OpenAI's ingestion delay:
+
+```promql
+sum by (model, service_tier, type) (openai_project_usage_tokens)
+max(openai_project_cost_usd)
+time() - max(openai_usage_reconciliation_last_success_timestamp_seconds)
+ALERTS{alertname=~"OpenAiComplimentary.*|ScoutOpenAiNotByok"}
+```
+
+`ScoutOpenAiNotByok` matches the production scrape label
+`exported_service="scout-for-lol-backend"` and `byok="false|unknown"`.
+`OpenAiComplimentaryMonitorStale` selects the billing worker by
+`namespace="temporal",container="temporal-billing-worker"`; pod-name prefixes
+are not stable scrape labels. Any `default` service-tier tokens or non-zero
+official project cost is actionable, even when the cause is quota exhaustion.
 
 ## Native diagnostics
 

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.test.ts
@@ -20,6 +20,24 @@ test("keeps LLM recording and Broadcast alert coverage together", () => {
     .flatMap(({ rules: groupRules }) => groupRules)
     .find((rule) => rule?.alert === "ScoutOpenAiNotByok");
   expect(scoutByokAlert?.expr?.value).toContain('byok=~"false|unknown"');
+  expect(scoutByokAlert?.expr?.value).toContain(
+    'exported_service="scout-for-lol-backend"',
+  );
+  expect(scoutByokAlert?.expr?.value).not.toContain(
+    '{service="scout-for-lol-backend"',
+  );
+  expect(scoutByokAlert?.expr?.value).toContain(
+    'workload=~"scout[.]review([.]text)?"',
+  );
+  const staleAlert = groups
+    .flatMap(({ rules: groupRules }) => groupRules)
+    .find((rule) => rule?.alert === "OpenAiComplimentaryMonitorStale");
+  expect(staleAlert?.expr?.value).toContain(
+    'namespace="temporal",container="temporal-billing-worker"',
+  );
+  expect(staleAlert?.expr?.value).not.toContain(
+    'pod=~"temporal-billing-worker-.*"',
+  );
   expect(serialized).toContain(
     "openai_usage_reconciliation_last_success_timestamp_seconds",
   );

--- a/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
+++ b/packages/homelab/src/cdk8s/src/resources/monitoring/monitoring/rules/llm.ts
@@ -114,7 +114,7 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "ScoutOpenAiNotByok",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            'sum(increase(llm_openrouter_byok_requests_total{service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?",byok=~"false|unknown"}[15m])) > 0',
+            'sum(increase(llm_openrouter_byok_requests_total{exported_service="scout-for-lol-backend",workload=~"scout[.]review([.]text)?",byok=~"false|unknown"}[15m])) > 0',
           ),
           labels: { severity: "warning", category: "llm" },
           annotations: {
@@ -127,7 +127,7 @@ export function getLlmRuleGroups(): PrometheusRuleSpecGroups[] {
         {
           alert: "OpenAiComplimentaryMonitorStale",
           expr: PrometheusRuleSpecGroupsRulesExpr.fromString(
-            '(time() - max(temporal_worker_app_process_start_time_seconds{namespace="temporal",pod=~"temporal-billing-worker-.*"})) > 7200 and ((time() - max(openai_usage_reconciliation_last_success_timestamp_seconds{namespace="temporal"})) > 7200 or absent(openai_usage_reconciliation_last_success_timestamp_seconds{namespace="temporal"}))',
+            '(time() - max(temporal_worker_app_process_start_time_seconds{namespace="temporal",container="temporal-billing-worker"})) > 7200 and ((time() - max(openai_usage_reconciliation_last_success_timestamp_seconds{namespace="temporal",container="temporal-billing-worker"})) > 7200 or absent(openai_usage_reconciliation_last_success_timestamp_seconds{namespace="temporal",container="temporal-billing-worker"}))',
           ),
           for: "5m",
           labels: { severity: "warning", category: "llm" },

--- a/packages/temporal/README.md
+++ b/packages/temporal/README.md
@@ -80,6 +80,18 @@ checks or alert windows are failing.
 The target defaults to `central`; `--target scout-beta` and `--target
 scout-prod` select the stage-local Scout deployment, queue, replay bundle,
 pinned canary, image repository, and catalog pins.
+
+The hourly `openai-complimentary-usage-hourly` schedule starts
+`runOpenAiComplimentaryUsageReconciliation` on `monorepo-workflows`. Pause it
+before repairing or replacing the Workflow bundle, then resume it only after a
+pinned canary and one bounded scheduled run complete. The Workflow delegates
+the OpenAI Usage and Costs calls to the isolated `billing` Activity queue. Live
+acceptance requires current `openai_project_usage_tokens`, zero official
+`openai_project_cost_usd`, a fresh reconciliation timestamp, and Scout review
+requests with `byok="true"`. The Prometheus rules use
+`exported_service="scout-for-lol-backend"` for Scout telemetry and
+`container="temporal-billing-worker"` for worker freshness; these labels are
+stable across pod recreations.
 Scout extraction uses two capable image releases. The pre-entrypoint pin creates
 no pod. Copy the first capable candidate pin to stable; that creates only the
 credentialless stable poller. A later distinct candidate pin creates the ramp

--- a/packages/temporal/src/lib/worker-deployment-catalog.ts
+++ b/packages/temporal/src/lib/worker-deployment-catalog.ts
@@ -43,9 +43,11 @@ function replaceCatalogPinValue(
   pinName: string,
   value: string,
 ): string {
-  const namePattern = new RegExp(`"name"\\s*:\\s*${JSON.stringify(pinName)}`);
+  const namePattern = new RegExp(
+    String.raw`"name"\s*:\s*${JSON.stringify(pinName)}`,
+  );
   const nameMatch = namePattern.exec(raw);
-  if (nameMatch === null || nameMatch.index === undefined) {
+  if (nameMatch === null) {
     throw new Error(`Temporal version catalog pin is missing: ${pinName}`);
   }
   const nameStart = nameMatch.index;

--- a/packages/temporal/src/lib/worker-deployment-catalog.ts
+++ b/packages/temporal/src/lib/worker-deployment-catalog.ts
@@ -25,6 +25,10 @@ const PinStateSchema = z
         version: z.string().min(1),
         digest: z.string().regex(/^sha256:[0-9a-f]{64}$/),
         buildNumber: z.number().int().positive(),
+        gitSha: z
+          .string()
+          .regex(/^[0-9a-f]{40}$/)
+          .optional(),
       }),
     ),
   })
@@ -33,6 +37,31 @@ const PinStateSchema = z
 type PinStateEntry = z.infer<typeof PinStateSchema>["pins"][string];
 type PinState = z.infer<typeof PinStateSchema>;
 type CatalogEntry = z.infer<typeof CatalogSchema>["entries"][number];
+
+function replaceCatalogPinValue(
+  raw: string,
+  pinName: string,
+  value: string,
+): string {
+  const namePattern = new RegExp(`"name"\\s*:\\s*${JSON.stringify(pinName)}`);
+  const nameMatch = namePattern.exec(raw);
+  if (nameMatch === null || nameMatch.index === undefined) {
+    throw new Error(`Temporal version catalog pin is missing: ${pinName}`);
+  }
+  const nameStart = nameMatch.index;
+  const nextEntry = raw.indexOf("\n    {\n", nameStart + nameMatch[0].length);
+  const entryEnd = nextEntry === -1 ? raw.length : nextEntry;
+  const entry = raw.slice(nameStart, entryEnd);
+  const valuePattern = /"value":\s*"[^"]*"/;
+  if (!valuePattern.test(entry)) {
+    throw new Error(`Temporal version catalog pin has no value: ${pinName}`);
+  }
+  return (
+    raw.slice(0, nameStart) +
+    entry.replace(valuePattern, `"value": ${JSON.stringify(value)}`) +
+    raw.slice(entryEnd)
+  );
+}
 
 export type StablePinPromotion = {
   candidateImage: string;
@@ -72,7 +101,8 @@ function pinStateEntriesEqual(
   return (
     left.buildNumber === right.buildNumber &&
     left.version === right.version &&
-    left.digest === right.digest
+    left.digest === right.digest &&
+    left.gitSha === right.gitSha
   );
 }
 
@@ -107,7 +137,8 @@ export async function prepareStablePinPromotion(
   stablePinName = "shepherdjerred/temporal-worker/workflows/stable",
   imageRepository = "ghcr.io/shepherdjerred/temporal-worker",
 ): Promise<StablePinPromotion> {
-  const catalog = parseCatalog(await Bun.file(catalogPath).text());
+  const raw = await Bun.file(catalogPath).text();
+  const catalog = parseCatalog(raw);
   const { candidate, stable } = findWorkflowPins(
     catalog,
     candidatePinName,
@@ -118,10 +149,9 @@ export async function prepareStablePinPromotion(
   );
   const stableValue = TemporalWorkflowImageValueSchema.parse(stable.value);
   const alreadyPromoted = candidateValue === stableValue;
-  stable.value = candidate.value;
   return {
     candidateImage: `${imageRepository}:${candidateValue}`,
-    contents: `${JSON.stringify(catalog, null, 2)}\n`,
+    contents: replaceCatalogPinValue(raw, stablePinName, candidate.value),
     alreadyPromoted,
   };
 }
@@ -131,7 +161,8 @@ export async function prepareCandidatePinReset(
   candidatePinName = "shepherdjerred/temporal-worker/workflows/candidate",
   stablePinName = "shepherdjerred/temporal-worker/workflows/stable",
 ): Promise<CandidatePinReset> {
-  const catalog = parseCatalog(await Bun.file(catalogPath).text());
+  const raw = await Bun.file(catalogPath).text();
+  const catalog = parseCatalog(raw);
   const { candidate, stable } = findWorkflowPins(
     catalog,
     candidatePinName,
@@ -142,9 +173,8 @@ export async function prepareCandidatePinReset(
   );
   const stableValue = TemporalWorkflowImageValueSchema.parse(stable.value);
   const changed = candidate.value !== stableValue;
-  candidate.value = stableValue;
   return {
-    contents: `${JSON.stringify(catalog, null, 2)}\n`,
+    contents: replaceCatalogPinValue(raw, candidatePinName, stableValue),
     changed,
     candidateValue,
   };

--- a/packages/temporal/src/lib/worker-deployment-commands.ts
+++ b/packages/temporal/src/lib/worker-deployment-commands.ts
@@ -8,14 +8,17 @@ export function parseTemporalJson(raw: string, label: string): unknown {
   }
 }
 
-export function temporalPrefix(options: {
-  address: string;
-  namespace: string;
-  tls?: boolean;
-}): string[] {
+export function temporalCommand(
+  options: { address: string; namespace: string; tls?: boolean },
+  args: readonly string[],
+): string[] {
+  // Temporal CLI connection flags must follow the subcommand when invoked
+  // through toolkit's passthrough. Keep the operator-selected endpoint
+  // explicit instead of relying on a local profile or environment defaults.
   return [
     "toolkit",
     "temporal",
+    ...args,
     "--address",
     options.address,
     "--namespace",
@@ -35,21 +38,22 @@ export async function setRampingVersion(
   percentage: number,
   run: RolloutCommandRunner,
 ): Promise<void> {
-  await run([
-    ...temporalPrefix(options),
-    "worker",
-    "deployment",
-    "set-ramping-version",
-    "--deployment-name",
-    options.deploymentName,
-    "--build-id",
-    options.buildId,
-    "--percentage",
-    String(percentage),
-    "--yes",
-    "--output",
-    "json",
-  ]);
+  await run(
+    temporalCommand(options, [
+      "worker",
+      "deployment",
+      "set-ramping-version",
+      "--deployment-name",
+      options.deploymentName,
+      "--build-id",
+      options.buildId,
+      "--percentage",
+      String(percentage),
+      "--yes",
+      "--output",
+      "json",
+    ]),
+  );
 }
 
 export async function setCurrentVersion(
@@ -62,17 +66,18 @@ export async function setCurrentVersion(
   buildId: string,
   run: RolloutCommandRunner,
 ): Promise<void> {
-  await run([
-    ...temporalPrefix(options),
-    "worker",
-    "deployment",
-    "set-current-version",
-    "--deployment-name",
-    options.deploymentName,
-    "--build-id",
-    buildId,
-    "--yes",
-    "--output",
-    "json",
-  ]);
+  await run(
+    temporalCommand(options, [
+      "worker",
+      "deployment",
+      "set-current-version",
+      "--deployment-name",
+      options.deploymentName,
+      "--build-id",
+      buildId,
+      "--yes",
+      "--output",
+      "json",
+    ]),
+  );
 }

--- a/packages/temporal/src/lib/worker-deployment-inspect.ts
+++ b/packages/temporal/src/lib/worker-deployment-inspect.ts
@@ -4,6 +4,7 @@ import {
   DeploymentNameSchema,
 } from "./worker-deployment-schemas.ts";
 import type { RolloutCommandRunner } from "./worker-deployment-proofs.ts";
+import { temporalCommand } from "./worker-deployment-commands.ts";
 
 type WorkerDeploymentInspectionOptions = {
   address: string;
@@ -37,26 +38,18 @@ export async function inspectWorkerDeploymentRollout(
   run: RolloutCommandRunner,
 ): Promise<WorkerDeploymentRolloutInspection> {
   const deploymentName = DeploymentNameSchema.parse(options.deploymentName);
-  const prefix = [
-    "toolkit",
-    "temporal",
-    "--address",
-    options.address,
-    "--namespace",
-    options.namespace,
-    ...(options.tls === true ? ["--tls"] : []),
-  ];
   const [deploymentResult, rolloutLockObject] = await Promise.all([
-    run([
-      ...prefix,
-      "worker",
-      "deployment",
-      "describe",
-      "--name",
-      deploymentName,
-      "--output",
-      "json",
-    ]),
+    run(
+      temporalCommand(options, [
+        "worker",
+        "deployment",
+        "describe",
+        "--name",
+        deploymentName,
+        "--output",
+        "json",
+      ]),
+    ),
     readWorkerDeploymentLock(options.rolloutLockName ?? deploymentName, run),
   ]);
   const deployment = DeploymentDescriptionSchema.parse(

--- a/packages/temporal/src/lib/worker-deployment-proofs.ts
+++ b/packages/temporal/src/lib/worker-deployment-proofs.ts
@@ -202,6 +202,11 @@ export async function requireAcceptedWorkerDeployment(
     options.deploymentName,
     "--output",
     "json",
+    "--address",
+    options.address,
+    "--namespace",
+    options.namespace,
+    ...(options.tls === true ? ["--tls"] : []),
   ]);
   const deployment = AcceptedDeploymentSchema.parse(
     parseJson(result.stdout, "acceptance prerequisite deployment describe"),

--- a/packages/temporal/src/lib/worker-deployment-proofs.ts
+++ b/packages/temporal/src/lib/worker-deployment-proofs.ts
@@ -195,11 +195,6 @@ export async function requireAcceptedWorkerDeployment(
   const result = await run([
     "toolkit",
     "temporal",
-    "--address",
-    options.address,
-    "--namespace",
-    options.namespace,
-    ...(options.tls === true ? ["--tls"] : []),
     "worker",
     "deployment",
     "describe",

--- a/packages/temporal/src/lib/worker-deployment-rollback.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollback.ts
@@ -4,6 +4,7 @@ import {
   prepareCandidatePinStateReset,
 } from "./worker-deployment-catalog.ts";
 import { verifyCandidateImageBuildId } from "./worker-deployment-proofs.ts";
+import { temporalCommand } from "./worker-deployment-commands.ts";
 
 type RollbackOptions = {
   address: string;
@@ -47,32 +48,21 @@ function parseJson(raw: string): unknown {
   }
 }
 
-function temporalPrefix(options: RollbackOptions): string[] {
-  return [
-    "toolkit",
-    "temporal",
-    "--address",
-    options.address,
-    "--namespace",
-    options.namespace,
-    ...(options.tls === true ? ["--tls"] : []),
-  ];
-}
-
 export async function removeWorkerDeploymentRampingVersion(
   options: RollbackOptions,
   run: RolloutCommandRunner,
 ): Promise<void> {
-  const description = await run([
-    ...temporalPrefix(options),
-    "worker",
-    "deployment",
-    "describe",
-    "--name",
-    options.deploymentName,
-    "--output",
-    "json",
-  ]);
+  const description = await run(
+    temporalCommand(options, [
+      "worker",
+      "deployment",
+      "describe",
+      "--name",
+      options.deploymentName,
+      "--output",
+      "json",
+    ]),
+  );
   const routing = DeploymentRoutingSchema.parse(parseJson(description.stdout));
   if (
     routing.routingConfig.rampingVersionBuildID !== options.buildId ||
@@ -82,18 +72,19 @@ export async function removeWorkerDeploymentRampingVersion(
       `Rollback target ${options.buildId} is no longer the active ramp`,
     );
   }
-  await run([
-    ...temporalPrefix(options),
-    "worker",
-    "deployment",
-    "set-ramping-version",
-    "--deployment-name",
-    options.deploymentName,
-    "--delete",
-    "--yes",
-    "--output",
-    "json",
-  ]);
+  await run(
+    temporalCommand(options, [
+      "worker",
+      "deployment",
+      "set-ramping-version",
+      "--deployment-name",
+      options.deploymentName,
+      "--delete",
+      "--yes",
+      "--output",
+      "json",
+    ]),
+  );
 }
 
 export async function executeWorkerDeploymentRollback(

--- a/packages/temporal/src/lib/worker-deployment-rollout.test.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.test.ts
@@ -669,12 +669,18 @@ describe("Worker Deployment rollback and rejection", () => {
       ),
     );
     expect(commands.some((command) => command.includes("--delete"))).toBe(true);
+    const temporalCommands = commands.filter(
+      (command) => command[0] === "toolkit" && command[1] === "temporal",
+    );
     expect(
-      commands
-        .filter(
-          (command) => command[0] === "toolkit" && command[1] === "temporal",
-        )
-        .every((command) => command.includes("--tls")),
+      temporalCommands.every(
+        (command) =>
+          command.includes("--address") &&
+          command.includes("temporal.test:7233") &&
+          command.includes("--namespace") &&
+          command.includes("prod") &&
+          command.includes("--tls"),
+      ),
     ).toBe(true);
     const resetOptions = await options("rollback");
     const resetCommands: string[][] = [];
@@ -708,9 +714,14 @@ describe("Worker Deployment rollback and rejection", () => {
       fixtureRunner({}, commands),
     );
     const catalog = await Bun.file(rolloutOptions.catalogPath).text();
-    expect(catalog).toContain(
-      `"name": "shepherdjerred/temporal-worker/workflows/candidate",\n      "value": "2.0.0-1@sha256:${STABLE_DIGEST}"`,
-    );
+    expect(JSON.parse(catalog)).toMatchObject({
+      entries: expect.arrayContaining([
+        {
+          name: "shepherdjerred/temporal-worker/workflows/candidate",
+          value: `2.0.0-1@sha256:${STABLE_DIGEST}`,
+        },
+      ]),
+    });
     expect(commands.some((command) => command.includes("--delete"))).toBe(
       false,
     );

--- a/packages/temporal/src/lib/worker-deployment-rollout.test.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.test.ts
@@ -738,7 +738,9 @@ describe("Worker Deployment rollback and rejection", () => {
       ),
     ).rejects.toThrow("was not built from");
   });
+});
 
+describe("Worker Deployment rollout safety", () => {
   test("allows the exact active ramp to roll back after a newer build registers", async () => {
     const commands: string[][] = [];
     await executeWorkerDeploymentRollout(

--- a/packages/temporal/src/lib/worker-deployment-rollout.ts
+++ b/packages/temporal/src/lib/worker-deployment-rollout.ts
@@ -36,7 +36,7 @@ import {
   setCurrentVersion,
   parseTemporalJson,
   setRampingVersion,
-  temporalPrefix,
+  temporalCommand,
 } from "./worker-deployment-commands.ts";
 export type WorkerDeploymentRolloutOptions = {
   action: "inspect" | "status" | "start" | "advance" | "promote" | "rollback";
@@ -76,16 +76,17 @@ async function describeDeployment(
   options: WorkerDeploymentRolloutOptions,
   run: RolloutCommandRunner,
 ): Promise<z.infer<typeof DeploymentDescriptionSchema>> {
-  const result = await run([
-    ...temporalPrefix(options),
-    "worker",
-    "deployment",
-    "describe",
-    "--name",
-    options.deploymentName,
-    "--output",
-    "json",
-  ]);
+  const result = await run(
+    temporalCommand(options, [
+      "worker",
+      "deployment",
+      "describe",
+      "--name",
+      options.deploymentName,
+      "--output",
+      "json",
+    ]),
+  );
   return DeploymentDescriptionSchema.parse(
     parseTemporalJson(result.stdout, "worker deployment describe"),
   );
@@ -95,19 +96,20 @@ async function describeVersion(
   buildId: string,
   run: RolloutCommandRunner,
 ): Promise<z.infer<typeof VersionDescriptionSchema>> {
-  const result = await run([
-    ...temporalPrefix(options),
-    "worker",
-    "deployment",
-    "describe-version",
-    "--deployment-name",
-    options.deploymentName,
-    "--build-id",
-    buildId,
-    "--report-task-queue-stats",
-    "--output",
-    "json",
-  ]);
+  const result = await run(
+    temporalCommand(options, [
+      "worker",
+      "deployment",
+      "describe-version",
+      "--deployment-name",
+      options.deploymentName,
+      "--build-id",
+      buildId,
+      "--report-task-queue-stats",
+      "--output",
+      "json",
+    ]),
+  );
   return VersionDescriptionSchema.parse(
     parseTemporalJson(result.stdout, "worker deployment describe-version"),
   );

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -24,7 +24,7 @@ import {
   buildExecutionStartMetadata,
   type TemporalBootstrapMetadata,
 } from "#shared/execution-metadata.ts";
-import * as workflowEntrypoint from "../workflows/index.ts";
+import * as workflowEntrypoint from "#workflows/index.ts";
 
 const DYNAMIC_AGENT_TASK_MEMO = {
   [DYNAMIC_AGENT_TASK_MEMO_KEY]: true,

--- a/packages/temporal/src/schedules/register-schedules.test.ts
+++ b/packages/temporal/src/schedules/register-schedules.test.ts
@@ -24,6 +24,7 @@ import {
   buildExecutionStartMetadata,
   type TemporalBootstrapMetadata,
 } from "#shared/execution-metadata.ts";
+import * as workflowEntrypoint from "../workflows/index.ts";
 
 const DYNAMIC_AGENT_TASK_MEMO = {
   [DYNAMIC_AGENT_TASK_MEMO_KEY]: true,
@@ -82,6 +83,19 @@ function findScheduleById(id: string) {
   }
   return schedule;
 }
+
+test("every declared schedule workflow is exported by the workflow bundle", () => {
+  const exportedWorkflowTypes = new Set(Object.keys(workflowEntrypoint));
+  const missingWorkflowTypes = [
+    ...new Set(
+      SCHEDULES.filter(
+        (schedule) => schedule.taskQueue === TASK_QUEUES.WORKFLOWS,
+      ).map((schedule) => schedule.workflowType),
+    ),
+  ].filter((workflowType) => !exportedWorkflowTypes.has(workflowType));
+
+  expect(missingWorkflowTypes).toEqual([]);
+});
 
 describe("central Workflow schedule routing", () => {
   const definitions = [

--- a/packages/version-catalog/src/catalog.json
+++ b/packages/version-catalog/src/catalog.json
@@ -1474,7 +1474,7 @@
       "management": {
         "managed": false
       },
-      "value": "2.0.0-13384@sha256:6a8b868a7b7528c55495f69a81332ef415b6e1f6e2a5dedd13efa3cbf6138bde",
+      "value": "2.0.0-13290@sha256:839757bc2a1ffbdca5111843e6e78ea41771b6c73d486111ee993e2fda762fb5",
       "notes": [
         "Candidate central Workflow Worker image - updated by CI pipeline",
         "not managed by renovate"

--- a/scripts/pin-candidates-state.json
+++ b/scripts/pin-candidates-state.json
@@ -77,11 +77,6 @@
       "digest": "sha256:3e3d71a7bdd8cb04b9ad919ddab59240b9d62852be9c5be5c8710f5d7e512de3",
       "buildNumber": 13769
     },
-    "shepherdjerred/temporal-worker/workflows/candidate": {
-      "version": "2.0.0-13384",
-      "digest": "sha256:6a8b868a7b7528c55495f69a81332ef415b6e1f6e2a5dedd13efa3cbf6138bde",
-      "buildNumber": 13384
-    },
     "shepherdjerred/temporal-worker/workflows/stable": {
       "version": "2.0.0-13290",
       "digest": "sha256:839757bc2a1ffbdca5111843e6e78ea41771b6c73d486111ee993e2fda762fb5",


### PR DESCRIPTION
## Why
The production complimentary-usage schedule was timing out because its Workflow bundle did not export the scheduled workflow. The two live alerts also used labels that never match production telemetry, so the failure was invisible.

## What
- match Scout BYOK detection to `exported_service="scout-for-lol-backend"` and billing freshness to `container="temporal-billing-worker"`
- add a central schedule-to-workflow-export compatibility test
- fix the package rollout diagnostics to use toolkit-managed Temporal environment configuration
- reset the divergent central candidate pin/state to the stable image
- document pause, canary, bounded-run, resume, and Prometheus acceptance steps

## Verification
- `bunx turbo run typecheck test --filter=@shepherdjerred/temporal --filter=@homelab/cdk8s`
- `bunx lefthook run pre-commit`
- focused Temporal schedule/rollout tests: 187 passed
- focused LLM rule tests: 2 passed
- live `prod/openai-complimentary-usage-hourly` schedule paused and re-read as paused
- live central candidate rollback completed for `561cf1c08fdcac10f16346cf8439c68ff07d737b`

## Rollout notes
Keep the schedule paused until the merged image is admitted through the normal candidate canary and soak. Resume only after one bounded reconciliation run completes and the official Usage/Costs gauges and alert state are healthy.