### PR TITLE
feat(scout-for-lol): expose Dare progress, controls, and notifications

### DIFF
--- a/packages/feature-flags/src/managed-flag-inventory.json
+++ b/packages/feature-flags/src/managed-flag-inventory.json
@@ -250,6 +250,30 @@
       "thresholdRollouts": []
     },
     {
+      "key": "dare_extended_contracts_enabled",
+      "owner": "scout",
+      "namespace": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable authoring extended Bryan Bucks Dare contracts.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
+      "key": "dare_notifications_enabled",
+      "owner": "scout",
+      "namespace": "scout",
+      "source": "scout-policy",
+      "purpose": "Enable Bryan Bucks Dare lifecycle and progress DMs.",
+      "type": "boolean",
+      "default": false,
+      "rollouts": [],
+      "rules": [],
+      "thresholdRollouts": []
+    },
+    {
       "key": "scoutql_relational_enabled",
       "owner": "scout",
       "namespace": "scout",

--- a/packages/scout-for-lol/packages/app/src/components/bucks-cards.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-cards.test.tsx
@@ -206,6 +206,8 @@ describe("BucksNotificationPreferencesForm", () => {
         preferences={{
           ownBetSettlementDms: true,
           betsOnPlayerSettlementDms: false,
+          dareLifecycleDms: true,
+          dareProgressDms: false,
         }}
         pending={false}
         error={null}
@@ -215,6 +217,8 @@ describe("BucksNotificationPreferencesForm", () => {
     expect(html).toContain("<form");
     expect(html).toContain('name="ownBetSettlementDms"');
     expect(html).toContain('name="betsOnPlayerSettlementDms"');
+    expect(html).toContain('name="dareLifecycleDms"');
+    expect(html).toContain('name="dareProgressDms"');
     expect(html).toContain("DM me when my own bets settle");
     expect(html).toContain("DM me when bets on my games settle");
   });

--- a/packages/scout-for-lol/packages/app/src/components/bucks-dare-actions.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-dare-actions.tsx
@@ -1,7 +1,13 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@scout-for-lol/design-system/components/button";
-import { Input } from "@scout-for-lol/design-system/components/input";
+import {
+  focusFirstInvalid,
+  handleFormSubmit,
+  submitThenChangeValidation,
+  useScoutForm,
+} from "#src/components/semantic-form.tsx";
+import { BucksContributionFormSchema } from "#src/lib/bucks-forms.ts";
 import { useTRPC } from "#src/lib/trpc.ts";
 
 type PreparedAction = {
@@ -13,6 +19,13 @@ type PreparedAction = {
   irreversible: boolean;
 };
 
+function contributionPayload(amount: number | undefined) {
+  if (amount === undefined) {
+    throw new Error("A contribution action requires an amount.");
+  }
+  return { action: "contribute" as const, amount };
+}
+
 export function BucksDareActions(props: {
   guildId: string;
   dareId: number;
@@ -21,12 +34,24 @@ export function BucksDareActions(props: {
 }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const [contribution, setContribution] = useState("10");
   const [prepared, setPrepared] = useState<PreparedAction | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const prepare = useMutation(trpc.bucks.darePrepareAction.mutationOptions());
   const confirm = useMutation(trpc.bucks.dareConfirmAction.mutationOptions());
   const deleteDraft = useMutation(trpc.bucks.dareDeleteDraft.mutationOptions());
+  const contributionFormElement = useRef<HTMLFormElement>(null);
+  const contributionForm = useScoutForm({
+    defaultValues: { contributionAmount: "10" },
+    validationLogic: submitThenChangeValidation,
+    validators: { onDynamic: BucksContributionFormSchema },
+    onSubmit: ({ value }) => {
+      const parsed = BucksContributionFormSchema.parse(value);
+      prepareAction("contribute", parsed.contributionAmount);
+    },
+    onSubmitInvalid: () => {
+      focusFirstInvalid(contributionFormElement.current);
+    },
+  });
 
   if (props.availableActions.length === 0) return null;
 
@@ -42,11 +67,10 @@ export function BucksDareActions(props: {
     });
   }
 
-  function prepareAction(action: string): void {
-    const amount = Number.parseInt(contribution, 10);
+  function prepareAction(action: string, contributionAmount?: number): void {
     const payload =
       action === "contribute"
-        ? { action: "contribute" as const, amount }
+        ? contributionPayload(contributionAmount)
         : action === "fund"
           ? ({ action: "fund" } as const)
           : action === "accept"
@@ -109,27 +133,41 @@ export function BucksDareActions(props: {
       <div className="flex flex-wrap items-center gap-2">
         {props.availableActions.map((action) =>
           action === "contribute" ? (
-            <div key={action} className="flex items-center gap-2">
-              <Input
-                aria-label="Contribution amount"
-                inputMode="numeric"
-                className="w-24"
-                value={contribution}
-                onChange={(event) => {
-                  setContribution(event.target.value);
-                }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                disabled={prepare.isPending || !/^\d+$/.test(contribution)}
-                onClick={() => {
-                  prepareAction(action);
+            <contributionForm.AppForm key={action}>
+              <form
+                ref={contributionFormElement}
+                className="flex items-end gap-2"
+                onSubmit={(event) => {
+                  handleFormSubmit(event, () =>
+                    contributionForm.handleSubmit(),
+                  );
                 }}
               >
-                Contribute BB
-              </Button>
-            </div>
+                <fieldset
+                  disabled={prepare.isPending}
+                  className="flex items-end gap-2"
+                >
+                  <contributionForm.AppField name="contributionAmount">
+                    {(field) => (
+                      <field.TextField
+                        id={`dare-${props.dareId.toString()}-contribution`}
+                        label="Contribution (BB)"
+                        type="number"
+                        inputMode="numeric"
+                        min={1}
+                        step={1}
+                        required
+                        autoComplete="off"
+                        fieldClassName="w-28"
+                      />
+                    )}
+                  </contributionForm.AppField>
+                  <Button type="submit" variant="outline">
+                    Contribute BB
+                  </Button>
+                </fieldset>
+              </form>
+            </contributionForm.AppForm>
           ) : (
             <Button
               key={action}

--- a/packages/scout-for-lol/packages/app/src/components/bucks-dare-actions.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-dare-actions.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import { Input } from "@scout-for-lol/design-system/components/input";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+type PreparedAction = {
+  intentId: string;
+  expiresAt: Date;
+  action: string;
+  amount: string | null;
+  targets: string[];
+  irreversible: boolean;
+};
+
+export function BucksDareActions(props: {
+  guildId: string;
+  dareId: number;
+  revision: number;
+  availableActions: string[];
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [contribution, setContribution] = useState("10");
+  const [prepared, setPrepared] = useState<PreparedAction | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const prepare = useMutation(trpc.bucks.darePrepareAction.mutationOptions());
+  const confirm = useMutation(trpc.bucks.dareConfirmAction.mutationOptions());
+  const deleteDraft = useMutation(trpc.bucks.dareDeleteDraft.mutationOptions());
+
+  if (props.availableActions.length === 0) return null;
+
+  function invalidateDares(): void {
+    void queryClient.invalidateQueries({
+      queryKey: trpc.bucks.dareList.pathKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: trpc.bucks.dareInspect.pathKey(),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: trpc.bucks.dareEvidence.pathKey(),
+    });
+  }
+
+  function prepareAction(action: string): void {
+    const amount = Number.parseInt(contribution, 10);
+    const payload =
+      action === "contribute"
+        ? { action: "contribute" as const, amount }
+        : action === "fund"
+          ? ({ action: "fund" } as const)
+          : action === "accept"
+            ? ({ action: "accept" } as const)
+            : action === "decline"
+              ? ({ action: "decline" } as const)
+              : ({ action: "cancel" } as const);
+    prepare.mutate(
+      {
+        guildId: props.guildId,
+        dareId: props.dareId,
+        expectedRevision: props.revision,
+        payload,
+        idempotencyKey: globalThis.crypto.randomUUID(),
+      },
+      {
+        onSuccess: (outcome) => {
+          if (outcome.kind !== "intent_created") {
+            setMessage(outcome.kind.replaceAll("_", " "));
+            return;
+          }
+          setPrepared({
+            intentId: outcome.intentId,
+            expiresAt: new Date(outcome.expiresAt),
+            action: outcome.confirmation.action,
+            amount: outcome.confirmation.amount,
+            targets: outcome.confirmation.targets,
+            irreversible: outcome.confirmation.irreversible,
+          });
+          setMessage(null);
+        },
+      },
+    );
+  }
+
+  function deleteCurrentDraft(): void {
+    deleteDraft.mutate(
+      {
+        guildId: props.guildId,
+        dareId: props.dareId,
+        expectedRevision: props.revision,
+      },
+      {
+        onSuccess: (outcome) => {
+          setMessage(outcome.kind.replaceAll("_", " "));
+          invalidateDares();
+        },
+      },
+    );
+  }
+
+  return (
+    <section className="space-y-3 rounded-lg border border-scout-border p-4">
+      <div>
+        <h2 className="text-sm font-medium">Available actions</h2>
+        <p className="text-xs text-scout-subtle">
+          Financial and binding actions require a short-lived confirmation.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {props.availableActions.map((action) =>
+          action === "contribute" ? (
+            <div key={action} className="flex items-center gap-2">
+              <Input
+                aria-label="Contribution amount"
+                inputMode="numeric"
+                className="w-24"
+                value={contribution}
+                onChange={(event) => {
+                  setContribution(event.target.value);
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={prepare.isPending || !/^\d+$/.test(contribution)}
+                onClick={() => {
+                  prepareAction(action);
+                }}
+              >
+                Contribute BB
+              </Button>
+            </div>
+          ) : (
+            <Button
+              key={action}
+              type="button"
+              variant={
+                action === "decline" || action === "cancel"
+                  ? "outline"
+                  : "default"
+              }
+              disabled={prepare.isPending || deleteDraft.isPending}
+              onClick={() => {
+                if (action === "delete_draft") deleteCurrentDraft();
+                else prepareAction(action);
+              }}
+            >
+              {action.replaceAll("_", " ")}
+            </Button>
+          ),
+        )}
+      </div>
+      {prepared !== null && (
+        <div className="space-y-2 rounded-md bg-scout-primary/5 p-3 text-sm">
+          <p>
+            Confirm <strong>{prepared.action}</strong> for{" "}
+            {prepared.targets.join(", ")}
+            {prepared.amount === null ? "" : ` (${prepared.amount})`}.
+          </p>
+          <p className="text-xs text-scout-subtle">
+            {prepared.irreversible
+              ? "This commits a binding or financial change. "
+              : ""}
+            Expires {prepared.expiresAt.toLocaleTimeString()}.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={confirm.isPending}
+              onClick={() => {
+                confirm.mutate(
+                  { guildId: props.guildId, intentId: prepared.intentId },
+                  {
+                    onSuccess: (outcome) => {
+                      setMessage(outcome.kind.replaceAll("_", " "));
+                      setPrepared(null);
+                      invalidateDares();
+                    },
+                  },
+                );
+              }}
+            >
+              {confirm.isPending ? "Confirming…" : "Confirm"}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setPrepared(null);
+              }}
+            >
+              Keep unchanged
+            </Button>
+          </div>
+        </div>
+      )}
+      {message !== null && <p className="text-sm capitalize">{message}</p>}
+      {(prepare.error ?? confirm.error ?? deleteDraft.error) !== null && (
+        <p className="text-sm text-scout-danger">
+          {(prepare.error ?? confirm.error ?? deleteDraft.error)?.message}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/bucks-dare-progress.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-dare-progress.tsx
@@ -1,0 +1,193 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type { DarePollHealth, DareProgress } from "@scout-for-lol/data";
+import { Button } from "@scout-for-lol/design-system/components/button";
+import { ErrorState } from "@scout-for-lol/design-system/domain/states";
+import { useTRPC } from "#src/lib/trpc.ts";
+
+export function DareProgressPanel(props: { progress: DareProgress }) {
+  return (
+    <section className="space-y-3 rounded-lg border border-scout-border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-medium">Progress</h2>
+          <p className="text-sm text-scout-subtle">{props.progress.summary}</p>
+        </div>
+        <span className="text-xs text-scout-subtle">
+          {props.progress.matchedGames.toString()} matched /{" "}
+          {props.progress.eligibleGames.toString()} eligible
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {props.progress.conditions.map((condition) => (
+          <li
+            key={condition.key}
+            className="rounded-md bg-scout-surface px-3 py-2 text-sm"
+          >
+            <div className="flex flex-wrap justify-between gap-2">
+              <span>{condition.label}</span>
+              <span className="font-mono text-xs">
+                {String(condition.current)} / {String(condition.target)}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-scout-subtle">
+              {condition.matchedGames.toString()} matched of{" "}
+              {condition.eligibleGames.toString()} eligible
+              {condition.unknownGames > 0
+                ? ` · ${condition.unknownGames.toString()} incomplete`
+                : ""}
+            </p>
+          </li>
+        ))}
+      </ul>
+      {props.progress.coverageGaps.length > 0 && (
+        <p className="text-xs text-scout-warning">
+          {props.progress.coverageGaps.length.toString()} match
+          {props.progress.coverageGaps.length === 1 ? " has" : "es have"}{" "}
+          incomplete evidence and will not be treated as a failed condition.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function formatOptionalDate(value: string | null): string {
+  return value === null ? "not available" : new Date(value).toLocaleString();
+}
+
+export function DareProcessingHealthPanel(props: { health: DarePollHealth }) {
+  return (
+    <section className="space-y-2 rounded-lg border border-scout-border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-sm font-medium">Processing health</h2>
+        <span className="rounded-full border border-scout-border px-2 py-0.5 text-xs">
+          {props.health.status}
+        </span>
+      </div>
+      <p className="text-xs text-scout-subtle">
+        Last successful processing:{" "}
+        {formatOptionalDate(props.health.lastSuccessfulProcessingAt)}
+        {" · "}Evidence watermark:{" "}
+        {formatOptionalDate(props.health.evidenceWatermarkAt)}
+      </p>
+      {props.health.incompleteReasons.map((reason) => (
+        <p key={reason} className="text-xs text-scout-warning">
+          {reason}
+        </p>
+      ))}
+    </section>
+  );
+}
+
+export function DareEvidencePanel(props: {
+  guildId: string;
+  dareId: number;
+  enabled: boolean;
+}) {
+  const trpc = useTRPC();
+  const query = useInfiniteQuery(
+    trpc.bucks.dareEvidence.infiniteQueryOptions(
+      { guildId: props.guildId, dareId: props.dareId, limit: 10 },
+      {
+        enabled: props.enabled,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+    ),
+  );
+  if (!props.enabled) return null;
+  if (query.isError) {
+    return (
+      <ErrorState
+        message={query.error.message}
+        onRetry={() => {
+          void query.refetch();
+        }}
+      />
+    );
+  }
+  const items = query.data?.pages.flatMap((page) => page.items) ?? [];
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-sm font-medium">Evaluated matches</h2>
+        <p className="text-xs text-scout-subtle">
+          Chronological evidence used by the frozen evaluator.
+        </p>
+      </div>
+      <ol className="space-y-2">
+        {items.map((item) => (
+          <li key={item.matchId}>
+            <details className="rounded-lg border border-scout-border p-3">
+              <summary className="cursor-pointer text-sm">
+                <span className="font-medium">{item.matchId}</span>
+                <span className="ml-2 text-xs text-scout-subtle">
+                  {item.queue} · {new Date(item.gameEndAt).toLocaleString()} ·{" "}
+                  {item.coverageState.replaceAll("_", " ")}
+                </span>
+              </summary>
+              <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                <EvidenceJson
+                  label="Candidate sets and results"
+                  value={{
+                    candidates: item.candidateMembership,
+                    results: item.setResults,
+                    actualValues: item.actualValues,
+                  }}
+                />
+                <EvidenceJson
+                  label="Progress before and after"
+                  value={{
+                    before: item.progressBefore,
+                    after: item.progressAfter,
+                  }}
+                />
+                <EvidenceJson
+                  label="Coverage and sources"
+                  value={{
+                    coverage: item.coverageState,
+                    targets: item.targetDependencies,
+                    sources: item.sourceReferences,
+                  }}
+                />
+                <EvidenceJson
+                  label="Evaluation trace"
+                  value={item.evaluationTrace}
+                />
+              </div>
+              <details className="mt-3">
+                <summary className="cursor-pointer text-xs text-scout-subtle">
+                  Raw evidence JSON
+                </summary>
+                <pre className="mt-2 max-h-96 overflow-auto rounded-md bg-scout-surface p-3 text-xs whitespace-pre-wrap">
+                  {JSON.stringify(item.raw, null, 2)}
+                </pre>
+              </details>
+            </details>
+          </li>
+        ))}
+      </ol>
+      {query.hasNextPage && (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={query.isFetchingNextPage}
+          onClick={() => {
+            void query.fetchNextPage();
+          }}
+        >
+          {query.isFetchingNextPage ? "Loading…" : "Load more evidence"}
+        </Button>
+      )}
+    </section>
+  );
+}
+
+function EvidenceJson(props: { label: string; value: unknown }) {
+  return (
+    <div className="min-w-0">
+      <h3 className="text-xs font-medium">{props.label}</h3>
+      <pre className="mt-1 max-h-64 overflow-auto rounded-md bg-scout-surface p-2 text-xs whitespace-pre-wrap">
+        {JSON.stringify(props.value, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/components/bucks-notification-preferences-form.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/bucks-notification-preferences-form.tsx
@@ -11,6 +11,8 @@ import {
 export type BucksNotificationPreferencesView = {
   ownBetSettlementDms: boolean;
   betsOnPlayerSettlementDms: boolean;
+  dareLifecycleDms: boolean;
+  dareProgressDms: boolean;
 };
 
 /**
@@ -31,10 +33,26 @@ export function BucksNotificationPreferencesForm(props: {
       props.onSubmit(value);
     },
   });
-  const { ownBetSettlementDms, betsOnPlayerSettlementDms } = props.preferences;
+  const {
+    ownBetSettlementDms,
+    betsOnPlayerSettlementDms,
+    dareLifecycleDms,
+    dareProgressDms,
+  } = props.preferences;
   useEffect(() => {
-    form.reset({ ownBetSettlementDms, betsOnPlayerSettlementDms });
-  }, [form, ownBetSettlementDms, betsOnPlayerSettlementDms]);
+    form.reset({
+      ownBetSettlementDms,
+      betsOnPlayerSettlementDms,
+      dareLifecycleDms,
+      dareProgressDms,
+    });
+  }, [
+    form,
+    ownBetSettlementDms,
+    betsOnPlayerSettlementDms,
+    dareLifecycleDms,
+    dareProgressDms,
+  ]);
 
   return (
     <form
@@ -57,6 +75,36 @@ export function BucksNotificationPreferencesForm(props: {
                 }}
               />
               DM me when my own bets settle
+            </label>
+          )}
+        </form.Field>
+        <form.Field name="dareLifecycleDms">
+          {(field) => (
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                name={field.name}
+                checked={field.state.value}
+                onChange={(event) => {
+                  field.handleChange(event.target.checked);
+                }}
+              />
+              DM me about Dares being funded, accepted, settled, or cancelled
+            </label>
+          )}
+        </form.Field>
+        <form.Field name="dareProgressDms">
+          {(field) => (
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                name={field.name}
+                checked={field.state.value}
+                onChange={(event) => {
+                  field.handleChange(event.target.checked);
+                }}
+              />
+              DM me when a Dare makes material progress
             </label>
           )}
         </form.Field>

--- a/packages/scout-for-lol/packages/app/src/components/filter-select.tsx
+++ b/packages/scout-for-lol/packages/app/src/components/filter-select.tsx
@@ -1,0 +1,28 @@
+export function FilterSelect<const Value extends string>(props: {
+  label: string;
+  value: Value;
+  options: readonly Value[];
+  onChange: (value: Value) => void;
+}) {
+  return (
+    <label className="space-y-1 text-xs text-scout-subtle">
+      <span>{props.label}</span>
+      <select
+        className="h-9 w-full rounded-md border border-scout-border bg-scout-surface px-2 text-sm text-scout-text"
+        value={props.value}
+        onChange={(event) => {
+          const parsed = props.options.find(
+            (option) => option === event.target.value,
+          );
+          if (parsed !== undefined) props.onChange(parsed);
+        }}
+      >
+        {props.options.map((option) => (
+          <option key={option} value={option}>
+            {option.replaceAll("_", " ")}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/packages/scout-for-lol/packages/app/src/lib/bucks-forms.test.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/bucks-forms.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { bucksStakeFormSchema } from "./bucks-forms.ts";
+import {
+  BucksContributionFormSchema,
+  bucksStakeFormSchema,
+} from "./bucks-forms.ts";
 
 describe("bucks stake form schema", () => {
   const schema = bucksStakeFormSchema(25);
@@ -32,5 +35,19 @@ describe("bucks stake form schema", () => {
 
   test("rejects a missing side", () => {
     expect(schema.safeParse({ side: "", stake: "5" }).success).toBe(false);
+  });
+});
+
+describe("BucksContributionFormSchema", () => {
+  test("accepts only positive whole BB amounts", () => {
+    expect(
+      BucksContributionFormSchema.parse({ contributionAmount: "10" }),
+    ).toEqual({ contributionAmount: 10 });
+    expect(() =>
+      BucksContributionFormSchema.parse({ contributionAmount: "1.5" }),
+    ).toThrow();
+    expect(() =>
+      BucksContributionFormSchema.parse({ contributionAmount: "0" }),
+    ).toThrow();
   });
 });

--- a/packages/scout-for-lol/packages/app/src/lib/bucks-forms.ts
+++ b/packages/scout-for-lol/packages/app/src/lib/bucks-forms.ts
@@ -37,4 +37,22 @@ export function bucksStakeFormSchema(balance: number) {
 
 export type BucksStakeFormValues = { side: string; stake: string };
 
+export const BucksContributionFormSchema = z.object({
+  contributionAmount: z
+    .string()
+    .trim()
+    .min(1, "Enter a contribution")
+    .transform((value, context) => {
+      const parsed = Number(value);
+      if (!Number.isSafeInteger(parsed) || parsed < 1) {
+        context.addIssue({
+          code: "custom",
+          message: "Contribution must be a whole number of at least 1 BB",
+        });
+        return z.NEVER;
+      }
+      return parsed;
+    }),
+});
+
 export const BUCKS_QUICK_STAKES = [1, 5] as const;

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-dares.test.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-dares.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
+import { DareProgressSchema } from "@scout-for-lol/data";
 import {
   DareDetail,
   DareList,
@@ -8,6 +9,43 @@ import {
 } from "#src/routes/bucks-dares.tsx";
 
 const noAction = vi.fn();
+const progress = DareProgressSchema.parse({
+  value: false,
+  final: false,
+  finalityReason: "in_progress",
+  matchedGames: 2,
+  eligibleGames: 3,
+  evidenceGames: 3,
+  conditions: [
+    {
+      key: "0",
+      kind: "matching_games",
+      label: "wins: gte 3 matching games",
+      targetKeys: ["virmel"],
+      gameSet: "wins",
+      operator: "gte",
+      current: 2,
+      target: 3,
+      remaining: 1,
+      matchedGames: 2,
+      eligibleGames: 3,
+      unknownGames: 0,
+      value: false,
+    },
+  ],
+  targets: [
+    {
+      targetKey: "virmel",
+      conditionKeys: ["0"],
+      matchedGames: 2,
+      eligibleGames: 3,
+      value: false,
+    },
+  ],
+  coverageGaps: [],
+  latestMaterialChange: null,
+  summary: "1 remaining for wins: gte 3 matching games.",
+});
 
 describe("parseBucksDareId", () => {
   test("selects the list when the optional route segment is absent", () => {
@@ -77,6 +115,8 @@ describe("DareList", () => {
             potTotal: 40,
             evidenceGames: 2,
             updatedAt: "2026-09-01T00:00:00.000Z",
+            progress,
+            requiresViewerAction: true,
           },
         ]}
         onRetry={noAction}
@@ -120,6 +160,19 @@ describe("DareDetail", () => {
             finalValue: true,
             proof: { eligibleGames: 3 },
             voidReason: null,
+            progress: { ...progress, value: true, final: true },
+            viewerRoles: ["challenger"],
+            availableActions: [],
+            requiresViewerAction: false,
+            processingHealth: {
+              status: "healthy",
+              pollStartedAt: "2026-09-01T00:00:00.000Z",
+              pollCompletedAt: "2026-09-01T00:00:30.000Z",
+              evidenceWatermarkAt: "2026-09-01T00:00:00.000Z",
+              lastSuccessfulProcessingAt: "2026-09-01T00:00:30.000Z",
+              failureReason: null,
+              incompleteReasons: [],
+            },
           }}
         />
       </MemoryRouter>,

--- a/packages/scout-for-lol/packages/app/src/routes/bucks-dares.tsx
+++ b/packages/scout-for-lol/packages/app/src/routes/bucks-dares.tsx
@@ -1,10 +1,21 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { Link, useNavigate, useParams } from "react-router";
 import { z } from "zod";
-import type { DareDeadlineSpecV2 } from "@scout-for-lol/data";
+import type {
+  DareDeadlineSpecV2,
+  DarePollHealth,
+  DareProgress,
+} from "@scout-for-lol/data";
 import { BucksDareEditor } from "#src/components/bucks-dare-editor.tsx";
+import { BucksDareActions } from "#src/components/bucks-dare-actions.tsx";
+import { FilterSelect } from "#src/components/filter-select.tsx";
+import {
+  DareEvidencePanel,
+  DareProcessingHealthPanel,
+  DareProgressPanel,
+} from "#src/components/bucks-dare-progress.tsx";
 import { ScoutQlCode } from "#src/components/scoutql-code.tsx";
 import { Button } from "@scout-for-lol/design-system/components/button";
 import { Input } from "@scout-for-lol/design-system/components/input";
@@ -64,16 +75,42 @@ export function BucksDares() {
 function DareListPage(props: { guildId: string; guildName: string }) {
   const trpc = useTRPC();
   const navigate = useNavigate();
-  const [scope, setScope] = useState<"mine" | "guild">("mine");
+  const [scope, setScope] = useState<"mine" | "guild" | "needs_action">("mine");
   const [search, setSearch] = useState("");
-  const trimmedSearch = search.trim();
-  const list = useQuery(
-    trpc.bucks.dareList.queryOptions({
-      guildId: props.guildId,
-      scope,
-      ...(trimmedSearch.length === 0 ? {} : { search: trimmedSearch }),
-    }),
+  const [stateFilter, setStateFilter] = useState<
+    | "all"
+    | "draft"
+    | "pending_accept"
+    | "active"
+    | "achieved"
+    | "unachieved"
+    | "declined"
+    | "expired"
+    | "voided"
+    | "cancelled"
+  >("all");
+  const [role, setRole] = useState<
+    "all" | "challenger" | "target" | "contributor" | "involved"
+  >("all");
+  const [sort, setSort] = useState<"needs_action" | "deadline" | "updated">(
+    "updated",
   );
+  const trimmedSearch = search.trim();
+  const list = useInfiniteQuery(
+    trpc.bucks.dareList.infiniteQueryOptions(
+      {
+        guildId: props.guildId,
+        scope,
+        sort,
+        limit: 25,
+        ...(trimmedSearch.length === 0 ? {} : { search: trimmedSearch }),
+        ...(stateFilter === "all" ? {} : { states: [stateFilter] }),
+        ...(role === "all" ? {} : { role }),
+      },
+      { getNextPageParam: (lastPage) => lastPage.nextCursor },
+    ),
+  );
+  const dares = list.data?.pages.flatMap((page) => page.items) ?? [];
 
   return (
     <div className="space-y-6">
@@ -94,11 +131,19 @@ function DareListPage(props: { guildId: string; guildName: string }) {
         <Tabs
           value={scope}
           onValueChange={(next) => {
-            if (next === "mine" || next === "guild") setScope(next);
+            if (
+              next === "mine" ||
+              next === "guild" ||
+              next === "needs_action"
+            ) {
+              setScope(next);
+              if (next === "needs_action") setSort("needs_action");
+            }
           }}
         >
           <TabsList>
             <TabsTrigger value="mine">My Dares</TabsTrigger>
+            <TabsTrigger value="needs_action">Needs action</TabsTrigger>
             <TabsTrigger value="guild">Guild Dares</TabsTrigger>
           </TabsList>
         </Tabs>
@@ -116,10 +161,48 @@ function DareListPage(props: { guildId: string; guildName: string }) {
         </div>
       </div>
 
+      <div className="grid gap-3 sm:grid-cols-3">
+        <FilterSelect
+          label="State"
+          value={stateFilter}
+          options={[
+            "all",
+            "draft",
+            "pending_accept",
+            "active",
+            "achieved",
+            "unachieved",
+            "declined",
+            "expired",
+            "voided",
+            "cancelled",
+          ]}
+          onChange={(value) => {
+            setStateFilter(value);
+          }}
+        />
+        <FilterSelect
+          label="Role"
+          value={role}
+          options={["all", "involved", "challenger", "target", "contributor"]}
+          onChange={(value) => {
+            setRole(value);
+          }}
+        />
+        <FilterSelect
+          label="Sort"
+          value={sort}
+          options={["updated", "needs_action", "deadline"]}
+          onChange={(value) => {
+            setSort(value);
+          }}
+        />
+      </div>
+
       <DareList
         loading={list.isPending}
         error={list.error}
-        dares={list.data ?? []}
+        dares={dares}
         onRetry={() => {
           void list.refetch();
         }}
@@ -127,6 +210,18 @@ function DareListPage(props: { guildId: string; guildName: string }) {
           void navigate(`/bucks/dares/${dareId.toString()}`);
         }}
       />
+      {list.hasNextPage && (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={list.isFetchingNextPage}
+          onClick={() => {
+            void list.fetchNextPage();
+          }}
+        >
+          {list.isFetchingNextPage ? "Loading…" : "Load more dares"}
+        </Button>
+      )}
     </div>
   );
 }
@@ -142,6 +237,8 @@ export function DareList(props: {
     potTotal: number;
     evidenceGames: number;
     updatedAt: string;
+    progress: DareProgress;
+    requiresViewerAction: boolean;
   }[];
   onRetry: () => void;
   onSelect: (dareId: number) => void;
@@ -180,6 +277,14 @@ export function DareList(props: {
               {dare.targetAliases.join(", ")} · {dare.potTotal.toString()} BB ·{" "}
               {dare.evidenceGames.toString()} evidence games
             </p>
+            <div className="flex items-center justify-between gap-2 text-xs">
+              <span className="text-scout-subtle">{dare.progress.summary}</span>
+              {dare.requiresViewerAction && (
+                <span className="rounded-full bg-scout-warning/15 px-2 py-0.5 text-scout-warning">
+                  Needs action
+                </span>
+              )}
+            </div>
           </button>
         </li>
       ))}
@@ -190,10 +295,20 @@ export function DareList(props: {
 function DareDetailPage(props: { guildId: string; dareId: number }) {
   const trpc = useTRPC();
   const detail = useQuery(
-    trpc.bucks.dareInspect.queryOptions({
-      guildId: props.guildId,
-      dareId: props.dareId,
-    }),
+    trpc.bucks.dareInspect.queryOptions(
+      {
+        guildId: props.guildId,
+        dareId: props.dareId,
+      },
+      {
+        refetchInterval: (query) => {
+          const state = query.state.data?.state;
+          return state === undefined || isNonterminalDareState(state)
+            ? 30_000
+            : false;
+        },
+      },
+    ),
   );
   if (detail.isPending) return <LoadingState label="Loading dare…" />;
   if (detail.isError) {
@@ -206,7 +321,26 @@ function DareDetailPage(props: { guildId: string; dareId: number }) {
       />
     );
   }
-  return <DareDetail guildId={props.guildId} dare={detail.data} />;
+  return (
+    <>
+      <DareDetail guildId={props.guildId} dare={detail.data} />
+      <div className="mt-5">
+        <BucksDareActions
+          guildId={props.guildId}
+          dareId={detail.data.id}
+          revision={detail.data.fundedRevision ?? detail.data.currentRevision}
+          availableActions={detail.data.availableActions}
+        />
+      </div>
+      <div className="mt-5">
+        <DareEvidencePanel
+          guildId={props.guildId}
+          dareId={detail.data.id}
+          enabled={detail.data.evidenceGames > 0}
+        />
+      </div>
+    </>
+  );
 }
 
 export function DareDetail(props: {
@@ -234,6 +368,11 @@ export function DareDetail(props: {
     finalValue: boolean | null;
     proof: unknown;
     voidReason: string | null;
+    progress: DareProgress;
+    viewerRoles: string[];
+    availableActions: string[];
+    requiresViewerAction: boolean;
+    processingHealth: DarePollHealth;
   };
 }) {
   const revision = props.dare.fundedRevision ?? props.dare.currentRevision;
@@ -266,6 +405,8 @@ export function DareDetail(props: {
         />
       )}
       <p className="whitespace-pre-wrap text-sm">{props.dare.plainLanguage}</p>
+      <DareProgressPanel progress={props.dare.progress} />
+      <DareProcessingHealthPanel health={props.dare.processingHealth} />
       <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
         <Fact label="Revision" value={revision.toString()} />
         <Fact
@@ -320,6 +461,10 @@ export function DareDetail(props: {
       )}
     </div>
   );
+}
+
+function isNonterminalDareState(state: string): boolean {
+  return state === "draft" || state === "pending_accept" || state === "active";
 }
 
 function Fact(props: { label: string; value: string }) {

--- a/packages/scout-for-lol/packages/backend/prisma/migrations/20260903000000_dare_notifications/migration.sql
+++ b/packages/scout-for-lol/packages/backend/prisma/migrations/20260903000000_dare_notifications/migration.sql
@@ -1,0 +1,48 @@
+ALTER TABLE "BucksNotificationPreference"
+ADD COLUMN "dareLifecycleDms" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "dareProgressDms" BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE "BotState"
+ADD COLUMN "pollStartedAt" TIMESTAMP(3),
+ADD COLUMN "pollCompletedAt" TIMESTAMP(3),
+ADD COLUMN "evidenceWatermarkAt" TIMESTAMP(3),
+ADD COLUMN "pollEvidenceComplete" BOOLEAN,
+ADD COLUMN "pollFailureReason" TEXT,
+ADD COLUMN "pollStatus" TEXT NOT NULL DEFAULT 'never';
+
+CREATE TABLE "BucksDareNotificationEvent" (
+  "id" TEXT NOT NULL,
+  "dareId" INTEGER NOT NULL,
+  "revision" INTEGER NOT NULL,
+  "category" TEXT NOT NULL,
+  "kind" TEXT NOT NULL,
+  "actorDiscordId" TEXT,
+  "matchId" TEXT,
+  "payload" TEXT NOT NULL,
+  "deduplicationKey" TEXT NOT NULL,
+  "occurredAt" TIMESTAMP(3) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "BucksDareNotificationEvent_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "BucksDareNotificationEvent_dareId_fkey" FOREIGN KEY ("dareId") REFERENCES "BucksDareV2"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "BucksDareNotificationDelivery" (
+  "id" SERIAL NOT NULL,
+  "eventId" TEXT NOT NULL,
+  "discordId" TEXT NOT NULL,
+  "deliveryState" TEXT NOT NULL DEFAULT 'pending',
+  "attemptCount" INTEGER NOT NULL DEFAULT 0,
+  "nextAttemptAt" TIMESTAMP(3),
+  "lastAttemptAt" TIMESTAMP(3),
+  "lastError" TEXT,
+  "sentAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "BucksDareNotificationDelivery_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "BucksDareNotificationDelivery_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "BucksDareNotificationEvent"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "BucksDareNotificationEvent_deduplicationKey_key" ON "BucksDareNotificationEvent"("deduplicationKey");
+CREATE INDEX "BucksDareNotificationEvent_dareId_occurredAt_idx" ON "BucksDareNotificationEvent"("dareId", "occurredAt");
+CREATE UNIQUE INDEX "BucksDareNotificationDelivery_eventId_discordId_key" ON "BucksDareNotificationDelivery"("eventId", "discordId");
+CREATE INDEX "BucksDareNotificationDelivery_deliveryState_nextAttemptAt_createdAt_idx" ON "BucksDareNotificationDelivery"("deliveryState", "nextAttemptAt", "createdAt");

--- a/packages/scout-for-lol/packages/backend/prisma/schema.prisma
+++ b/packages/scout-for-lol/packages/backend/prisma/schema.prisma
@@ -701,6 +701,12 @@ model OutreachConversion {
 model BotState {
   id                   Int       @id @default(1)
   lastSuccessfulPollAt DateTime?
+  pollStartedAt        DateTime?
+  pollCompletedAt      DateTime?
+  evidenceWatermarkAt  DateTime?
+  pollEvidenceComplete Boolean?
+  pollFailureReason    String?
+  pollStatus           String    @default("never")
   updatedAt            DateTime  @updatedAt
 }
 
@@ -851,6 +857,8 @@ model BucksNotificationPreference {
   discordId                 String
   ownBetSettlementDms       Boolean   @default(true)
   betsOnPlayerSettlementDms Boolean   @default(true)
+  dareLifecycleDms          Boolean   @default(true)
+  dareProgressDms           Boolean   @default(true)
   settlementDmHintShownAt   DateTime?
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt
@@ -1497,11 +1505,12 @@ model BucksDareV2 {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  revisions     BucksDareV2Revision[]
-  targets       BucksDareV2Target[]
-  contributions BucksDareV2Contribution[]
-  evidence      BucksDareV2Evidence[]
-  intents       BucksDareV2ConfirmationIntent[]
+  revisions          BucksDareV2Revision[]
+  targets            BucksDareV2Target[]
+  contributions      BucksDareV2Contribution[]
+  evidence           BucksDareV2Evidence[]
+  intents            BucksDareV2ConfirmationIntent[]
+  notificationEvents BucksDareNotificationEvent[]
 
   @@index([challengerDiscordId, dareState, updatedAt])
   @@index([serverId, dareState, updatedAt])
@@ -1610,6 +1619,46 @@ model BucksDareV2ConfirmationIntent {
   createdAt      DateTime    @default(now())
 
   @@index([dareId, expiresAt])
+}
+
+// Transactional outbox for Dare lifecycle and material-progress DMs. An event
+// freezes the recipients at occurrence time; delivery checks each recipient's
+// current preference so suppression remains an operator-controlled decision.
+model BucksDareNotificationEvent {
+  id               String      @id @default(uuid())
+  dareId           Int
+  dare             BucksDareV2 @relation(fields: [dareId], references: [id], onDelete: Cascade)
+  revision         Int
+  category         String
+  kind             String
+  actorDiscordId   String?
+  matchId          String?
+  payload          String
+  deduplicationKey String      @unique
+  occurredAt       DateTime
+  createdAt        DateTime    @default(now())
+
+  deliveries BucksDareNotificationDelivery[]
+
+  @@index([dareId, occurredAt])
+}
+
+model BucksDareNotificationDelivery {
+  id            Int                        @id @default(autoincrement())
+  eventId       String
+  event         BucksDareNotificationEvent @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  discordId     String
+  deliveryState String                     @default("pending")
+  attemptCount  Int                        @default(0)
+  nextAttemptAt DateTime?
+  lastAttemptAt DateTime?
+  lastError     String?
+  sentAt        DateTime?
+  createdAt     DateTime                   @default(now())
+  updatedAt     DateTime                   @updatedAt
+
+  @@unique([eventId, discordId])
+  @@index([deliveryState, nextAttemptAt, createdAt])
 }
 
 // Durable marker for Bucks EARNINGS on a (match, guild).

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.test.ts
@@ -18,6 +18,7 @@ function content(input: {
     revision: 1,
     plainLanguage: "Virmel wins a game with at least 8 CS per minute.",
     evidenceCount: 0,
+    progressSummary: "Waiting for more eligible match evidence.",
     state: "pending_accept",
     targets: [{ alias: "Virmel", acceptedAt: null, declinedAt: null }],
     acceptDeadline: ACCEPT_DEADLINE,
@@ -38,6 +39,9 @@ describe("dareV2CalloutContent", () => {
     expect(rendered).toContain("<@100> put **10 BB** on Virmel.");
     expect(rendered).toContain("Pot: **10 BB**");
     expect(rendered).toContain("**Pile-ons:**\nNone yet.");
+    expect(rendered).toContain(
+      "**Progress** · Waiting for more eligible match evidence. (0 evidence games)",
+    );
   });
 
   test("shows a later contributor separately from the opening stake", () => {

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-content-v2.ts
@@ -91,6 +91,7 @@ export type DareV2CalloutInput = {
   revision: number;
   plainLanguage: string;
   evidenceCount: number;
+  progressSummary: string;
   state: BucksDareV2State;
   targets: readonly DareV2CalloutTarget[];
   acceptDeadline: Date | null;
@@ -160,7 +161,7 @@ export function renderDareV2Callout(input: DareV2CalloutInput): {
       `**Contract · revision ${input.revision.toString()}**`,
       input.plainLanguage,
       "",
-      `**Progress** · ${formatInteger(input.evidenceCount)} evidence games`,
+      `**Progress** · ${input.progressSummary} (${formatInteger(input.evidenceCount)} evidence games)`,
       `**Status** · ${statusText(input)}`,
     ],
     pileOns,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-callout-v2.ts
@@ -3,6 +3,7 @@ import type { MessageCreateOptions, MessageEditOptions } from "discord.js";
 import {
   BucksDareV2StateSchema,
   BucksMessageRefSchema,
+  DareCompiledPlanV2Schema,
   DiscordChannelIdSchema,
   DiscordGuildIdSchema,
   type BucksDareV2State,
@@ -11,6 +12,8 @@ import {
 } from "@scout-for-lol/data";
 import { dareV2CalloutComponents } from "#src/betting/dare-components-v2.ts";
 import { renderDareV2Callout } from "#src/betting/dare-callout-content-v2.ts";
+import { deriveDareProgressV2 } from "#src/betting/dare-progress-v2.ts";
+import { storedDareV2Evidence } from "#src/betting/dare-settle-evidence-v2.ts";
 import { observeBucksDelivery } from "#src/betting/delivery-observability.ts";
 import { runSerialized } from "#src/betting/refresh-queue.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
@@ -96,6 +99,9 @@ export async function loadDareV2CalloutState(
         orderBy: { id: "asc" },
         select: { discordId: true, amount: true },
       },
+      evidence: {
+        orderBy: [{ gameEndAt: "asc" }, { matchId: "asc" }],
+      },
       _count: { select: { evidence: true } },
     },
   });
@@ -110,6 +116,13 @@ export async function loadDareV2CalloutState(
     );
   }
   const state = BucksDareV2StateSchema.parse(dare.dareState);
+  const progress = deriveDareProgressV2({
+    plan: DareCompiledPlanV2Schema.parse(JSON.parse(revision.compiledPlan)),
+    evidence: dare.evidence.map((row) => storedDareV2Evidence(row)),
+    targetKeys: dare.targets.map((target) => target.targetKey),
+    final: !["draft", "pending_accept", "active"].includes(state),
+    finalityReason: state,
+  });
   const rendered = renderDareV2Callout({
     id: dare.id,
     challengerDiscordId: dare.challengerDiscordId,
@@ -120,6 +133,7 @@ export async function loadDareV2CalloutState(
     revision: revisionNumber,
     plainLanguage: revision.plainLanguage,
     evidenceCount: dare._count.evidence,
+    progressSummary: progress.summary,
     state,
     targets: dare.targets,
     acceptDeadline: dare.acceptDeadline,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-contribute-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-contribute-v2.ts
@@ -8,6 +8,7 @@ import {
 import { pendingDareV2CalloutRefresh } from "#src/betting/dare-callout-refresh-state-v2.ts";
 import { stakeDareV2ContributionInTransaction } from "#src/betting/dare-ledger-v2.ts";
 import type { Db } from "#src/database/index.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
 
 const OPEN_DARE_STATES: ReadonlySet<BucksDareV2State> = new Set(
   OPEN_BUCKS_DARE_V2_STATES,
@@ -98,6 +99,16 @@ export async function contributeToDareV2InTransaction(
     bucksAccountId: input.bucksAccountId,
     discordId: input.actorDiscordId,
     amount: input.amount,
+  });
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: dare.id,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: "contributed",
+    actorDiscordId: input.actorDiscordId,
+    summary: `A ${input.amount.toString()} Bryan Bucks contribution raised the pot to ${dare.potTotal.toString()}.`,
+    deduplicationKey: `dare:${dare.id.toString()}:revision:${input.revision.toString()}:contribution:${input.actorDiscordId}:${input.now.toISOString()}`,
+    occurredAt: input.now,
   });
   return {
     kind: "contributed",

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-draft-v2.ts
@@ -175,6 +175,7 @@ export function prepareDareDraftV2(
     revision: BUCKS_INT32_MAX,
     plainLanguage,
     evidenceCount: BUCKS_INT32_MAX,
+    progressSummary: "Waiting for more eligible match evidence.",
     state: "pending_accept",
     targets: targets.map((target) => ({
       alias: target.alias,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-v2.ts
@@ -2,18 +2,26 @@ import { z } from "zod";
 
 export type DareTruthValue = boolean | null;
 
-export const DareMatchEvidenceV2Schema = z.strictObject({
-  matchId: z.string().min(1),
-  gameStartAt: z.iso.datetime(),
-  gameEndAt: z.iso.datetime(),
-  queue: z.string().min(1),
-  candidateSets: z.record(z.string(), z.boolean()),
-  setResults: z.record(z.string(), z.boolean().nullable()),
-  setValues: z.record(z.string(), z.record(z.string(), z.number().nullable())),
+export const DareEvidenceDiagnosticsV2Schema = z.strictObject({
   coverageState: z.enum(["complete", "missing", "not_required"]),
   targetDependencies: z.record(z.string(), z.array(z.string().min(1))),
   sourceReferences: z.array(z.string().min(1)),
   evaluationTrace: z.array(z.string()),
 });
+
+export const DareMatchEvidenceV2Schema = z
+  .strictObject({
+    matchId: z.string().min(1),
+    gameStartAt: z.iso.datetime(),
+    gameEndAt: z.iso.datetime(),
+    queue: z.string().min(1),
+    candidateSets: z.record(z.string(), z.boolean()),
+    setResults: z.record(z.string(), z.boolean().nullable()),
+    setValues: z.record(
+      z.string(),
+      z.record(z.string(), z.number().nullable()),
+    ),
+  })
+  .extend(DareEvidenceDiagnosticsV2Schema.shape);
 
 export type DareMatchEvidenceV2 = z.infer<typeof DareMatchEvidenceV2Schema>;

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
@@ -1,0 +1,156 @@
+import {
+  BucksDareV2StateSchema,
+  DareCompiledPlanV2Schema,
+  DareProgressSchema,
+  DareTargetBindingV2Schema,
+  type DiscordAccountId,
+  type DiscordGuildId,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+import { deriveDareProgressV2 } from "#src/betting/dare-progress-v2.ts";
+import { storedDareV2Evidence } from "#src/betting/dare-settle-evidence-v2.ts";
+import type { ExtendedPrismaClient } from "#src/database/index.ts";
+
+export const DareEvidenceInspectionSchema = z.strictObject({
+  matchId: z.string().min(1),
+  gameStartAt: z.iso.datetime(),
+  gameEndAt: z.iso.datetime(),
+  queue: z.string().min(1),
+  candidateMembership: z.record(z.string(), z.boolean()),
+  actualValues: z.record(
+    z.string(),
+    z.record(z.string(), z.number().nullable()),
+  ),
+  setResults: z.record(z.string(), z.boolean().nullable()),
+  coverageState: z.enum(["complete", "missing", "not_required"]),
+  targetDependencies: z.record(z.string(), z.array(z.string().min(1))),
+  sourceReferences: z.array(z.string().min(1)),
+  evaluationTrace: z.array(z.string()),
+  planVersion: z.string().min(1),
+  progressBefore: DareProgressSchema,
+  progressAfter: DareProgressSchema,
+  raw: z.json(),
+});
+
+export const DareEvidencePageSchema = z.strictObject({
+  items: z.array(DareEvidenceInspectionSchema),
+  nextCursor: z.string().min(1).nullable(),
+});
+export type DareEvidencePage = z.infer<typeof DareEvidencePageSchema>;
+
+const DEFAULT_PAGE_SIZE = 10;
+
+function cursorFor(row: { gameEndAt: string; matchId: string }): string {
+  return `${row.gameEndAt}|${row.matchId}`;
+}
+
+function visible(
+  state: z.infer<typeof BucksDareV2StateSchema>,
+  challengerDiscordId: string,
+  viewerDiscordId: DiscordAccountId,
+): boolean {
+  return (
+    (state !== "draft" && state !== "deleted") ||
+    challengerDiscordId === viewerDiscordId
+  );
+}
+
+export async function listDareEvidenceV2(
+  input: {
+    dareId: number;
+    serverId: DiscordGuildId;
+    viewerDiscordId: DiscordAccountId;
+    cursor?: string | undefined;
+    limit?: number | undefined;
+  },
+  prisma: ExtendedPrismaClient,
+): Promise<DareEvidencePage | null> {
+  const dare = await prisma.bucksDareV2.findFirst({
+    where: { id: input.dareId, serverId: input.serverId },
+    select: {
+      challengerDiscordId: true,
+      dareState: true,
+      currentRevision: true,
+      fundedRevision: true,
+      targets: { select: { targetKey: true } },
+      revisions: {
+        select: { revision: true, compiledPlan: true, targetsJson: true },
+      },
+      evidence: {
+        orderBy: [{ gameEndAt: "asc" }, { matchId: "asc" }],
+      },
+    },
+  });
+  if (dare === null) return null;
+  const state = BucksDareV2StateSchema.parse(dare.dareState);
+  if (!visible(state, dare.challengerDiscordId, input.viewerDiscordId)) {
+    return null;
+  }
+  const revisionNumber = dare.fundedRevision ?? dare.currentRevision;
+  const revision = dare.revisions.find(
+    (candidate) => candidate.revision === revisionNumber,
+  );
+  if (revision === undefined) {
+    throw new Error(
+      `Dare v2 ${input.dareId.toString()} is missing revision ${revisionNumber.toString()}.`,
+    );
+  }
+  const plan = DareCompiledPlanV2Schema.parse(
+    JSON.parse(revision.compiledPlan),
+  );
+  const targetKeys =
+    dare.targets.length === 0
+      ? DareTargetBindingV2Schema.array()
+          .parse(JSON.parse(revision.targetsJson))
+          .map((target) => target.key)
+      : dare.targets.map((target) => target.targetKey);
+  const evidence = dare.evidence.map((row) => storedDareV2Evidence(row));
+  const rows = evidence.map((row, index) => {
+    const common = {
+      plan,
+      targetKeys,
+      final: false,
+      finalityReason: "evidence_snapshot",
+    };
+    return DareEvidenceInspectionSchema.parse({
+      matchId: row.matchId,
+      gameStartAt: row.gameStartAt,
+      gameEndAt: row.gameEndAt,
+      queue: row.queue,
+      candidateMembership: row.candidateSets,
+      actualValues: row.setValues,
+      setResults: row.setResults,
+      coverageState: row.coverageState,
+      targetDependencies: row.targetDependencies,
+      sourceReferences: row.sourceReferences,
+      evaluationTrace: row.evaluationTrace,
+      planVersion: dare.evidence[index]?.planVersion,
+      progressBefore: deriveDareProgressV2({
+        ...common,
+        evidence: evidence.slice(0, index),
+      }),
+      progressAfter: deriveDareProgressV2({
+        ...common,
+        evidence: evidence.slice(0, index + 1),
+      }),
+      raw: row,
+    });
+  });
+  const start =
+    input.cursor === undefined
+      ? 0
+      : rows.findIndex((row) => cursorFor(row) === input.cursor) + 1;
+  if (start === 0 && input.cursor !== undefined) {
+    throw new Error("Dare evidence cursor does not belong to this Dare.");
+  }
+  const limit = input.limit ?? DEFAULT_PAGE_SIZE;
+  const page = rows.slice(start, start + limit);
+  const last = page.at(-1);
+  return DareEvidencePageSchema.parse({
+    items: page,
+    nextCursor:
+      last !== undefined && start + page.length < rows.length
+        ? cursorFor(last)
+        : null,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-evidence-view-v2.ts
@@ -7,30 +7,29 @@ import {
   type DiscordGuildId,
 } from "@scout-for-lol/data";
 import { z } from "zod";
+import { DareEvidenceDiagnosticsV2Schema } from "#src/betting/dare-evidence-v2.ts";
 import { deriveDareProgressV2 } from "#src/betting/dare-progress-v2.ts";
 import { storedDareV2Evidence } from "#src/betting/dare-settle-evidence-v2.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 
-export const DareEvidenceInspectionSchema = z.strictObject({
-  matchId: z.string().min(1),
-  gameStartAt: z.iso.datetime(),
-  gameEndAt: z.iso.datetime(),
-  queue: z.string().min(1),
-  candidateMembership: z.record(z.string(), z.boolean()),
-  actualValues: z.record(
-    z.string(),
-    z.record(z.string(), z.number().nullable()),
-  ),
-  setResults: z.record(z.string(), z.boolean().nullable()),
-  coverageState: z.enum(["complete", "missing", "not_required"]),
-  targetDependencies: z.record(z.string(), z.array(z.string().min(1))),
-  sourceReferences: z.array(z.string().min(1)),
-  evaluationTrace: z.array(z.string()),
-  planVersion: z.string().min(1),
-  progressBefore: DareProgressSchema,
-  progressAfter: DareProgressSchema,
-  raw: z.json(),
-});
+export const DareEvidenceInspectionSchema = z
+  .strictObject({
+    matchId: z.string().min(1),
+    gameStartAt: z.iso.datetime(),
+    gameEndAt: z.iso.datetime(),
+    queue: z.string().min(1),
+    candidateMembership: z.record(z.string(), z.boolean()),
+    actualValues: z.record(
+      z.string(),
+      z.record(z.string(), z.number().nullable()),
+    ),
+    setResults: z.record(z.string(), z.boolean().nullable()),
+    planVersion: z.string().min(1),
+    progressBefore: DareProgressSchema,
+    progressAfter: DareProgressSchema,
+    raw: z.json(),
+  })
+  .extend(DareEvidenceDiagnosticsV2Schema.shape);
 
 export const DareEvidencePageSchema = z.strictObject({
   items: z.array(DareEvidenceInspectionSchema),

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-fund-consent-v2.ts
@@ -20,6 +20,7 @@ import {
   parseDareV2Targets,
 } from "#src/betting/dare-v2-common.ts";
 import type { Db } from "#src/database/index.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
 
 function contractCompilerVersion(revision: {
   compilerVersion: string;
@@ -128,6 +129,16 @@ export async function fundDareV2InTransaction(
     discordId: input.actorDiscordId,
     amount: revision.openingStake,
   });
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: dare.id,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: "funded",
+    actorDiscordId: input.actorDiscordId,
+    summary: `Funded for ${revision.openingStake.toString()} Bryan Bucks and awaiting target acceptance.`,
+    deduplicationKey: `dare:${dare.id.toString()}:revision:${input.revision.toString()}:funded`,
+    occurredAt: input.now,
+  });
   return {
     kind: "funded",
     dareId: dare.id,
@@ -185,6 +196,16 @@ export async function acceptDareV2InTransaction(
     where: { dareId: input.dareId },
   });
   if (unaccepted > 0) {
+    await enqueueDareNotificationInTransaction(tx, {
+      dareId: input.dareId,
+      revision: input.revision,
+      category: "lifecycle",
+      kind: "accepted",
+      actorDiscordId: input.actorDiscordId,
+      summary: `${(targetCount - unaccepted).toString()} of ${targetCount.toString()} targets have accepted.`,
+      deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:accepted:${input.actorDiscordId}`,
+      occurredAt: input.now,
+    });
     return {
       kind: "accepted",
       activated: false,
@@ -233,6 +254,16 @@ export async function acceptDareV2InTransaction(
       resolution: "expired",
       withCut: false,
     });
+    await enqueueDareNotificationInTransaction(tx, {
+      dareId: input.dareId,
+      revision: input.revision,
+      category: "lifecycle",
+      kind: "expired",
+      actorDiscordId: input.actorDiscordId,
+      summary: `The acceptance window expired; ${facts.potTotal.toString()} Bryan Bucks were fully refunded.`,
+      deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:expired`,
+      occurredAt: input.now,
+    });
     return { kind: "accept_window_expired", dareState: "expired" } as const;
   }
   const contract = DareContractV2Schema.parse({
@@ -266,6 +297,26 @@ export async function acceptDareV2InTransaction(
       `Dare v2 ${input.dareId.toString()} lost its activation claim.`,
     );
   }
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: input.dareId,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: "accepted",
+    actorDiscordId: input.actorDiscordId,
+    summary: `All ${targetCount.toString()} targets accepted.`,
+    deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:accepted:${input.actorDiscordId}`,
+    occurredAt: input.now,
+  });
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: input.dareId,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: "activated",
+    actorDiscordId: input.actorDiscordId,
+    summary: `The Dare is active until ${deadlineAt.toISOString()}.`,
+    deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:activated`,
+    occurredAt: input.now,
+  });
   return {
     kind: "accepted",
     activated: true,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification-delivery.ts
@@ -1,0 +1,271 @@
+import type { Client } from "discord.js";
+import { z } from "zod";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import {
+  DareNotificationCategorySchema,
+  DareNotificationKindSchema,
+} from "#src/betting/dare-notification-outbox.ts";
+import { getBucksNotificationPreferences } from "#src/betting/notification-preferences.ts";
+import { isPolicyEnabled } from "#src/configuration/flags.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { client } from "#src/discord/client.ts";
+import { sendDM, type DmStatus } from "#src/discord/utils/dm.ts";
+import { createLogger } from "#src/logger.ts";
+
+const logger = createLogger("dare-notification-delivery");
+const MAX_ATTEMPTS = 5;
+const CLAIM_TIMEOUT_MS = 10 * 60 * 1000;
+const BASE_RETRY_MS = 60 * 1000;
+
+const DareNotificationPayloadSchema = z.object({
+  serverId: DiscordGuildIdSchema,
+  summary: z.string().min(1),
+});
+
+const DareNotificationEventSchema = z.object({
+  category: DareNotificationCategorySchema,
+  kind: DareNotificationKindSchema,
+  payload: z.string().transform((value, context) => {
+    try {
+      return DareNotificationPayloadSchema.parse(JSON.parse(value));
+    } catch (error) {
+      context.addIssue({
+        code: "custom",
+        message: error instanceof Error ? error.message : "Invalid payload",
+      });
+      return z.NEVER;
+    }
+  }),
+});
+
+type DeliveryRow = {
+  id: number;
+  discordId: string;
+  attemptCount: number;
+  event: {
+    category: string;
+    kind: string;
+    payload: string;
+  };
+};
+
+export type DareNotificationDeliveryDependencies = {
+  client: Client;
+  isPolicyEnabled: typeof isPolicyEnabled;
+  getPreferences: typeof getBucksNotificationPreferences;
+  sendDm: typeof sendDM;
+};
+
+const defaultDependencies: DareNotificationDeliveryDependencies = {
+  client,
+  isPolicyEnabled,
+  getPreferences: getBucksNotificationPreferences,
+  sendDm: sendDM,
+};
+
+function retryAt(attemptCount: number, now: Date): Date {
+  const exponent = Math.max(0, attemptCount - 1);
+  return new Date(now.getTime() + BASE_RETRY_MS * 2 ** exponent);
+}
+
+function renderMessage(input: {
+  dareId: number;
+  kind: z.infer<typeof DareNotificationKindSchema>;
+  summary: string;
+}): string {
+  const label = input.kind.replaceAll("_", " ");
+  return `**Dare #${input.dareId.toString()} — ${label}**\n${input.summary}`;
+}
+
+async function finalizeDelivery(
+  db: ExtendedPrismaClient,
+  input: {
+    id: number;
+    status: string;
+    attemptCount: number;
+    now: Date;
+    error?: string | undefined;
+  },
+): Promise<void> {
+  await db.bucksDareNotificationDelivery.update({
+    where: { id: input.id },
+    data: {
+      deliveryState: input.status,
+      attemptCount: input.attemptCount,
+      lastAttemptAt: input.now,
+      lastError: input.error ?? null,
+      nextAttemptAt:
+        input.status === "retry"
+          ? retryAt(input.attemptCount, input.now)
+          : null,
+      sentAt: input.status === "sent" ? input.now : null,
+    },
+  });
+}
+
+async function claimDelivery(
+  db: ExtendedPrismaClient,
+  row: DeliveryRow,
+  now: Date,
+): Promise<boolean> {
+  const staleBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
+  const claimed = await db.bucksDareNotificationDelivery.updateMany({
+    where: {
+      id: row.id,
+      OR: [
+        { deliveryState: "pending" },
+        { deliveryState: "retry", nextAttemptAt: { lte: now } },
+        {
+          deliveryState: "delivering",
+          lastAttemptAt: { lte: staleBefore },
+        },
+      ],
+    },
+    data: { deliveryState: "delivering", lastAttemptAt: now },
+  });
+  return claimed.count === 1;
+}
+
+async function recordSendOutcome(
+  db: ExtendedPrismaClient,
+  row: DeliveryRow,
+  status: DmStatus,
+  now: Date,
+): Promise<void> {
+  const attemptCount = row.attemptCount + 1;
+  if (status === "sent") {
+    await finalizeDelivery(db, {
+      id: row.id,
+      status: "sent",
+      attemptCount,
+      now,
+    });
+    return;
+  }
+  if (status === "dm_disabled" || status === "budget_exhausted") {
+    await finalizeDelivery(db, {
+      id: row.id,
+      status: "permanent_failure",
+      attemptCount,
+      now,
+      error: status,
+    });
+    return;
+  }
+  await finalizeDelivery(db, {
+    id: row.id,
+    status: attemptCount >= MAX_ATTEMPTS ? "exhausted" : "retry",
+    attemptCount,
+    now,
+    error: status,
+  });
+}
+
+async function deliverOne(
+  row: DeliveryRow & { event: DeliveryRow["event"] & { dareId: number } },
+  db: ExtendedPrismaClient,
+  dependencies: DareNotificationDeliveryDependencies,
+  now: Date,
+): Promise<void> {
+  if (!(await claimDelivery(db, row, now))) return;
+
+  const parsed = DareNotificationEventSchema.safeParse(row.event);
+  if (!parsed.success) {
+    await finalizeDelivery(db, {
+      id: row.id,
+      status: "permanent_failure",
+      attemptCount: row.attemptCount + 1,
+      now,
+      error: parsed.error.message,
+    });
+    return;
+  }
+  const { category, kind, payload } = parsed.data;
+  const enabled = await dependencies.isPolicyEnabled(
+    "dare_notifications_enabled",
+    { server: payload.serverId },
+  );
+  if (!enabled) {
+    await finalizeDelivery(db, {
+      id: row.id,
+      status: "suppressed",
+      attemptCount: row.attemptCount,
+      now,
+      error: "feature_disabled",
+    });
+    return;
+  }
+  const discordId = DiscordAccountIdSchema.parse(row.discordId);
+  const preferences = await dependencies.getPreferences(
+    { serverId: payload.serverId, discordId },
+    db,
+  );
+  const preferenceEnabled =
+    category === "lifecycle"
+      ? preferences.dareLifecycleDms
+      : preferences.dareProgressDms;
+  if (!preferenceEnabled) {
+    await finalizeDelivery(db, {
+      id: row.id,
+      status: "suppressed",
+      attemptCount: row.attemptCount,
+      now,
+      error: "recipient_preference",
+    });
+    return;
+  }
+  const status = await dependencies.sendDm({
+    client: dependencies.client,
+    userId: discordId,
+    guildId: payload.serverId,
+    kind: "dare_notification",
+    message: renderMessage({
+      dareId: row.event.dareId,
+      kind,
+      summary: payload.summary,
+    }),
+    suppressMentions: true,
+    prisma: db,
+  });
+  await recordSendOutcome(db, row, status, now);
+}
+
+export async function deliverPendingDareNotifications(
+  prismaClient: ExtendedPrismaClient = prisma,
+  dependencies: DareNotificationDeliveryDependencies = defaultDependencies,
+  now = new Date(),
+): Promise<void> {
+  const staleBefore = new Date(now.getTime() - CLAIM_TIMEOUT_MS);
+  const rows = await prismaClient.bucksDareNotificationDelivery.findMany({
+    where: {
+      OR: [
+        { deliveryState: "pending" },
+        { deliveryState: "retry", nextAttemptAt: { lte: now } },
+        {
+          deliveryState: "delivering",
+          lastAttemptAt: { lte: staleBefore },
+        },
+      ],
+    },
+    include: {
+      event: {
+        select: { dareId: true, category: true, kind: true, payload: true },
+      },
+    },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    take: 100,
+  });
+  const outcomes = await Promise.allSettled(
+    rows.map(async (row) => {
+      await deliverOne(row, prismaClient, dependencies, now);
+    }),
+  );
+  for (const outcome of outcomes) {
+    if (outcome.status === "rejected") {
+      logger.error("Dare notification delivery failed:", outcome.reason);
+    }
+  }
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification-delivery.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification-delivery.ts
@@ -263,9 +263,17 @@ export async function deliverPendingDareNotifications(
       await deliverOne(row, prismaClient, dependencies, now);
     }),
   );
+  const failures: unknown[] = [];
   for (const outcome of outcomes) {
     if (outcome.status === "rejected") {
       logger.error("Dare notification delivery failed:", outcome.reason);
+      failures.push(outcome.reason);
     }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `${failures.length.toString()} Dare notification delivery operation(s) failed.`,
+    );
   }
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification-outbox.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification-outbox.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import { DiscordAccountIdSchema } from "@scout-for-lol/data";
+import type { Db } from "#src/database/index.ts";
+
+export const DareNotificationCategorySchema = z.enum(["lifecycle", "progress"]);
+export const DareNotificationKindSchema = z.enum([
+  "funded",
+  "accepted",
+  "declined",
+  "contributed",
+  "activated",
+  "cancelled",
+  "expired",
+  "voided",
+  "achieved",
+  "failed",
+  "advanced",
+  "regressed",
+  "race_leader_changed",
+  "new_best",
+  "rank_changed",
+  "sequence_changed",
+  "streak_changed",
+]);
+
+export type DareNotificationEventInput = {
+  dareId: number;
+  revision: number;
+  category: z.infer<typeof DareNotificationCategorySchema>;
+  kind: z.infer<typeof DareNotificationKindSchema>;
+  actorDiscordId?: string | undefined;
+  matchId?: string | undefined;
+  summary: string;
+  deduplicationKey: string;
+  occurredAt: Date;
+};
+
+export async function enqueueDareNotificationInTransaction(
+  tx: Db,
+  input: DareNotificationEventInput,
+): Promise<void> {
+  const eventInput = {
+    ...input,
+    category: DareNotificationCategorySchema.parse(input.category),
+    kind: DareNotificationKindSchema.parse(input.kind),
+  };
+  const dare = await tx.bucksDareV2.findUniqueOrThrow({
+    where: { id: input.dareId },
+    select: {
+      serverId: true,
+      challengerDiscordId: true,
+      targets: { select: { discordId: true } },
+      contributions: { select: { discordId: true } },
+    },
+  });
+  const recipientIds = [
+    ...new Set([
+      dare.challengerDiscordId,
+      ...dare.targets.map((target) => target.discordId),
+      ...dare.contributions.map((contribution) => contribution.discordId),
+    ]),
+  ].map((discordId) => DiscordAccountIdSchema.parse(discordId));
+  await tx.bucksDareNotificationEvent.createMany({
+    data: [
+      {
+        id: globalThis.crypto.randomUUID(),
+        dareId: eventInput.dareId,
+        revision: eventInput.revision,
+        category: eventInput.category,
+        kind: eventInput.kind,
+        ...(eventInput.actorDiscordId === undefined
+          ? {}
+          : { actorDiscordId: eventInput.actorDiscordId }),
+        ...(eventInput.matchId === undefined
+          ? {}
+          : { matchId: eventInput.matchId }),
+        payload: JSON.stringify({
+          serverId: dare.serverId,
+          summary: eventInput.summary,
+        }),
+        deduplicationKey: eventInput.deduplicationKey,
+        occurredAt: eventInput.occurredAt,
+      },
+    ],
+    skipDuplicates: true,
+  });
+  const event = await tx.bucksDareNotificationEvent.findUniqueOrThrow({
+    where: { deduplicationKey: eventInput.deduplicationKey },
+    select: { id: true },
+  });
+  await tx.bucksDareNotificationDelivery.createMany({
+    data: recipientIds.map((discordId) => ({
+      eventId: event.id,
+      discordId,
+    })),
+    skipDuplicates: true,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification-production.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification-production.ts
@@ -1,0 +1,86 @@
+import type { DareContractV2 } from "@scout-for-lol/data";
+import type { DareMatchEvidenceV2 } from "#src/betting/dare-evidence-v2.ts";
+import type { DareFinalityV2 } from "#src/betting/dare-proof-v2.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
+import { deriveDareProgressV2 } from "#src/betting/dare-progress-v2.ts";
+import type { Db } from "#src/database/index.ts";
+
+type TerminalResolution = "achieved" | "unachieved" | "voided";
+
+function terminalKind(resolution: TerminalResolution) {
+  if (resolution === "achieved") return "achieved" as const;
+  if (resolution === "voided") return "voided" as const;
+  return "failed" as const;
+}
+
+function terminalSummary(
+  resolution: TerminalResolution,
+  potTotal: number,
+): string {
+  if (resolution === "achieved") {
+    return `Dare achieved; the ${potTotal.toString()} Bryan Bucks pot was paid out.`;
+  }
+  if (resolution === "voided") {
+    return `Dare voided because required evidence was incomplete; the ${potTotal.toString()} Bryan Bucks pot was refunded.`;
+  }
+  return "The Dare ended without being achieved.";
+}
+
+export async function enqueueTerminalDareNotification(
+  tx: Db,
+  input: {
+    dareId: number;
+    revision: number;
+    potTotal: number;
+    resolution: TerminalResolution;
+    matchId?: string | undefined;
+    now: Date;
+  },
+): Promise<void> {
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: input.dareId,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: terminalKind(input.resolution),
+    ...(input.matchId === undefined ? {} : { matchId: input.matchId }),
+    summary: terminalSummary(input.resolution, input.potTotal),
+    deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:terminal:${input.resolution}`,
+    occurredAt: input.now,
+  });
+}
+
+export async function enqueueMaterialDareProgressNotification(
+  tx: Db,
+  input: {
+    dareId: number;
+    contract: DareContractV2;
+    evidence: readonly DareMatchEvidenceV2[];
+    matchId: string;
+    finality: DareFinalityV2;
+    now: Date;
+  },
+): Promise<void> {
+  const progress = deriveDareProgressV2({
+    plan: input.contract.compiledPlan,
+    evidence: input.evidence,
+    targetKeys: input.contract.targets.map((target) => target.key),
+    final: false,
+    finalityReason: input.finality.reason,
+  });
+  if (
+    progress.latestMaterialChange?.matchId !== input.matchId ||
+    progress.latestMaterialChange.kind === "coverage"
+  ) {
+    return;
+  }
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: input.dareId,
+    revision: input.contract.revision,
+    category: "progress",
+    kind: "advanced",
+    matchId: input.matchId,
+    summary: progress.summary,
+    deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.contract.revision.toString()}:progress:${input.matchId}`,
+    occurredAt: input.now,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification-production.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification-production.ts
@@ -69,15 +69,19 @@ export async function enqueueMaterialDareProgressNotification(
   });
   if (
     progress.latestMaterialChange?.matchId !== input.matchId ||
-    progress.latestMaterialChange.kind === "coverage"
+    !["advance", "regression"].includes(progress.latestMaterialChange.kind)
   ) {
     return;
   }
+  const kind =
+    progress.latestMaterialChange.kind === "regression"
+      ? "regressed"
+      : "advanced";
   await enqueueDareNotificationInTransaction(tx, {
     dareId: input.dareId,
     revision: input.contract.revision,
     category: "progress",
-    kind: "advanced",
+    kind,
     matchId: input.matchId,
     summary: progress.summary,
     deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.contract.revision.toString()}:progress:${input.matchId}`,

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification.integration.test.ts
@@ -157,4 +157,29 @@ describe("Dare notification outbox", () => {
       }),
     ).resolves.toBe(2);
   });
+
+  test("isolates recipients but propagates unexpected delivery failures", async () => {
+    const dareId = await seedDare();
+    await enqueue(dareId);
+    const getPreferences = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("preference store unavailable"))
+      .mockImplementation(getBucksNotificationPreferences);
+    const sendDm = vi.fn(async () => "sent" as const);
+
+    await expect(
+      deliverPendingDareNotifications(
+        db,
+        {
+          client,
+          isPolicyEnabled: async () => true,
+          getPreferences,
+          sendDm,
+        },
+        NOW,
+      ),
+    ).rejects.toThrow("1 Dare notification delivery operation(s) failed.");
+    expect(getPreferences).toHaveBeenCalledTimes(2);
+    expect(sendDm).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-notification.integration.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-notification.integration.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  DiscordChannelIdSchema,
+  DiscordGuildIdSchema,
+  PlayerIdSchema,
+} from "@scout-for-lol/data";
+import { deliverPendingDareNotifications } from "#src/betting/dare-notification-delivery.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
+import {
+  getBucksNotificationPreferences,
+  updateBucksNotificationPreferences,
+} from "#src/betting/notification-preferences.ts";
+import { client } from "#src/discord/client.ts";
+import { createTestDatabase } from "#src/testing/test-database.ts";
+import { bucksTestDiscordId } from "#src/testing/bucks-fixtures.ts";
+
+const { prisma: db } = createTestDatabase("dare-notification-outbox");
+const SERVER = DiscordGuildIdSchema.parse("1337623164146155593");
+const CHALLENGER = bucksTestDiscordId(61);
+const TARGET = bucksTestDiscordId(62);
+const NOW = new Date("2026-09-03T00:00:00.000Z");
+
+async function seedDare(): Promise<number> {
+  const dare = await db.bucksDareV2.create({
+    data: {
+      serverId: SERVER,
+      channelId: DiscordChannelIdSchema.parse("1337623164146155594"),
+      challengerDiscordId: CHALLENGER,
+      openingStake: 10,
+    },
+  });
+  await db.bucksDareV2Target.createMany({
+    data: [
+      {
+        dareId: dare.id,
+        targetKey: "challenger-too",
+        discordId: CHALLENGER,
+        playerId: PlayerIdSchema.parse(1),
+        alias: "challenger",
+        accounts: "[]",
+      },
+      {
+        dareId: dare.id,
+        targetKey: "target",
+        discordId: TARGET,
+        playerId: PlayerIdSchema.parse(2),
+        alias: "target",
+        accounts: "[]",
+      },
+    ],
+  });
+  return dare.id;
+}
+
+async function enqueue(dareId: number): Promise<void> {
+  await db.$transaction(async (tx) => {
+    await enqueueDareNotificationInTransaction(tx, {
+      dareId,
+      revision: 1,
+      category: "progress",
+      kind: "advanced",
+      matchId: "NA1_NOTIFICATION",
+      summary: "One win remains.",
+      deduplicationKey: `test:${dareId.toString()}:advance`,
+      occurredAt: NOW,
+    });
+  });
+}
+
+beforeEach(async () => {
+  await db.bucksDareNotificationDelivery.deleteMany();
+  await db.bucksDareNotificationEvent.deleteMany();
+  await db.bucksNotificationPreference.deleteMany();
+  await db.bucksDareV2Target.deleteMany();
+  await db.bucksDareV2.deleteMany();
+});
+
+afterAll(async () => {
+  await db.$disconnect();
+});
+
+describe("Dare notification outbox", () => {
+  test("freezes and deduplicates involved recipients transactionally", async () => {
+    const dareId = await seedDare();
+    await enqueue(dareId);
+    await enqueue(dareId);
+
+    const event = await db.bucksDareNotificationEvent.findMany({
+      include: { deliveries: { orderBy: { discordId: "asc" } } },
+    });
+    expect(event).toHaveLength(1);
+    expect(event[0]?.deliveries.map((row) => row.discordId)).toEqual(
+      [CHALLENGER, TARGET].toSorted(),
+    );
+  });
+
+  test("checks the current preference and records suppression", async () => {
+    const dareId = await seedDare();
+    await enqueue(dareId);
+    await updateBucksNotificationPreferences(
+      {
+        serverId: SERVER,
+        discordId: TARGET,
+        updates: { dareProgressDms: false },
+      },
+      db,
+    );
+    const sendDm = vi.fn(async () => "sent" as const);
+    await deliverPendingDareNotifications(
+      db,
+      {
+        client,
+        isPolicyEnabled: async () => true,
+        getPreferences: getBucksNotificationPreferences,
+        sendDm,
+      },
+      NOW,
+    );
+
+    const rows = await db.bucksDareNotificationDelivery.findMany({
+      orderBy: { discordId: "asc" },
+    });
+    expect(rows.map((row) => [row.discordId, row.deliveryState])).toEqual([
+      [CHALLENGER, "sent"],
+      [TARGET, "suppressed"],
+    ]);
+    expect(sendDm).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaves transient failures retryable without affecting recipients", async () => {
+    const dareId = await seedDare();
+    await enqueue(dareId);
+    const sendDm = vi
+      .fn()
+      .mockResolvedValueOnce("failed")
+      .mockResolvedValue("sent");
+    const dependencies = {
+      client,
+      isPolicyEnabled: async () => true,
+      getPreferences: getBucksNotificationPreferences,
+      sendDm,
+    };
+    await deliverPendingDareNotifications(db, dependencies, NOW);
+    const retry = await db.bucksDareNotificationDelivery.findFirstOrThrow({
+      where: { deliveryState: "retry" },
+    });
+    expect(retry.nextAttemptAt).toEqual(new Date(NOW.getTime() + 60 * 1000));
+
+    await deliverPendingDareNotifications(
+      db,
+      dependencies,
+      new Date(NOW.getTime() + 60 * 1000),
+    );
+    await expect(
+      db.bucksDareNotificationDelivery.count({
+        where: { deliveryState: "sent" },
+      }),
+    ).resolves.toBe(2);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-poll-health.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-poll-health.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { darePollHealth } from "#src/betting/dare-poll-health.ts";
+
+const NOW = new Date("2026-09-03T00:05:00.000Z");
+
+describe("Dare poll health", () => {
+  test("marks a started but unfinished poll as delayed", () => {
+    expect(
+      darePollHealth(
+        {
+          lastSuccessfulPollAt: null,
+          pollStartedAt: new Date("2026-09-03T00:04:30.000Z"),
+          pollCompletedAt: null,
+          evidenceWatermarkAt: null,
+          pollEvidenceComplete: null,
+          pollFailureReason: null,
+          pollStatus: "running",
+        },
+        NOW,
+      ),
+    ).toMatchObject({ status: "delayed" });
+  });
+
+  test("marks a healthy poll older than two cadences as stale", () => {
+    expect(
+      darePollHealth(
+        {
+          lastSuccessfulPollAt: new Date("2026-09-03T00:02:00.000Z"),
+          pollStartedAt: new Date("2026-09-03T00:01:30.000Z"),
+          pollCompletedAt: new Date("2026-09-03T00:02:00.000Z"),
+          evidenceWatermarkAt: new Date("2026-09-03T00:01:30.000Z"),
+          pollEvidenceComplete: true,
+          pollFailureReason: null,
+          pollStatus: "healthy",
+        },
+        NOW,
+      ),
+    ).toMatchObject({ status: "stale" });
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-poll-health.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-poll-health.ts
@@ -1,0 +1,69 @@
+import { DarePollHealthSchema, type DarePollHealth } from "@scout-for-lol/data";
+import { z } from "zod";
+
+const POLL_STALE_AFTER_MS = 2 * 60 * 1000;
+const StoredPollStatusSchema = z.enum([
+  "never",
+  "running",
+  "healthy",
+  "incomplete",
+  "failed",
+]);
+
+type PollHealthRow = {
+  lastSuccessfulPollAt: Date | null;
+  pollStartedAt: Date | null;
+  pollCompletedAt: Date | null;
+  evidenceWatermarkAt: Date | null;
+  pollEvidenceComplete: boolean | null;
+  pollFailureReason: string | null;
+  pollStatus: string;
+};
+
+function iso(value: Date | null): string | null {
+  return value?.toISOString() ?? null;
+}
+
+export function darePollHealth(
+  row: PollHealthRow | null,
+  now = new Date(),
+): DarePollHealth {
+  if (row === null) {
+    return DarePollHealthSchema.parse({
+      status: "never",
+      pollStartedAt: null,
+      pollCompletedAt: null,
+      evidenceWatermarkAt: null,
+      lastSuccessfulProcessingAt: null,
+      failureReason: null,
+      incompleteReasons: ["No post-match poll has completed yet."],
+    });
+  }
+  const storedStatus = StoredPollStatusSchema.parse(row.pollStatus);
+  const unfinished =
+    row.pollStartedAt !== null &&
+    (row.pollCompletedAt === null || row.pollCompletedAt < row.pollStartedAt);
+  const stale =
+    storedStatus === "healthy" &&
+    row.pollCompletedAt !== null &&
+    now.getTime() - row.pollCompletedAt.getTime() > POLL_STALE_AFTER_MS;
+  const status = unfinished ? "delayed" : stale ? "stale" : storedStatus;
+  const incompleteReasons = [
+    ...(unfinished ? ["A post-match poll started but has not completed."] : []),
+    ...(stale
+      ? ["The latest completed poll is more than two cadences old."]
+      : []),
+    ...(row.pollEvidenceComplete === false
+      ? [row.pollFailureReason ?? "Required match evidence is incomplete."]
+      : []),
+  ];
+  return DarePollHealthSchema.parse({
+    status: status === "running" ? "delayed" : status,
+    pollStartedAt: iso(row.pollStartedAt),
+    pollCompletedAt: iso(row.pollCompletedAt),
+    evidenceWatermarkAt: iso(row.evidenceWatermarkAt),
+    lastSuccessfulProcessingAt: iso(row.lastSuccessfulPollAt),
+    failureReason: row.pollFailureReason,
+    incompleteReasons,
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.test.ts
@@ -162,3 +162,134 @@ describe("Dare progress v2", () => {
     expect(progress.matchedGames).toBe(1);
   });
 });
+
+describe("Dare progress v2 Boolean and change semantics", () => {
+  test("summarizes the Boolean result instead of an unsatisfied OR leaf", () => {
+    const plan = DareCompiledPlanV2Schema.parse({
+      ...PLAN,
+      result: {
+        kind: "or",
+        operands: [
+          {
+            kind: "matching_games",
+            gameSet: "wins",
+            operator: "gte",
+            threshold: 1,
+          },
+          {
+            kind: "matching_games",
+            gameSet: "wins",
+            operator: "gte",
+            threshold: 2,
+          },
+        ],
+      },
+    });
+    const progress = deriveDareProgressV2({
+      plan,
+      evidence: [
+        evidence({
+          matchId: "one-win",
+          gameEndAt: "2026-01-01T00:00:00.000Z",
+          result: true,
+        }),
+      ],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "reversible",
+    });
+
+    expect(progress.value).toBe(true);
+    expect(progress.summary).toBe(
+      "All current conditions are satisfied; awaiting finality.",
+    );
+  });
+
+  test("explains a false NOT expression without reversing its leaf meaning", () => {
+    const plan = DareCompiledPlanV2Schema.parse({
+      ...PLAN,
+      result: {
+        kind: "not",
+        operand: {
+          kind: "matching_games",
+          gameSet: "wins",
+          operator: "gte",
+          threshold: 1,
+        },
+      },
+    });
+    const progress = deriveDareProgressV2({
+      plan,
+      evidence: [
+        evidence({
+          matchId: "excluded-win",
+          gameEndAt: "2026-01-01T00:00:00.000Z",
+          result: true,
+        }),
+      ],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "reversible",
+    });
+
+    expect(progress.value).toBe(false);
+    expect(progress.summary).toBe(
+      "The excluded condition is currently satisfied; it must become false.",
+    );
+  });
+
+  test("labels increasing remaining work as a regression", () => {
+    const plan = DareCompiledPlanV2Schema.parse({
+      ...PLAN,
+      result: {
+        kind: "matching_games",
+        gameSet: "wins",
+        operator: "lte",
+        threshold: 1,
+      },
+    });
+    const progress = deriveDareProgressV2({
+      plan,
+      evidence: [
+        evidence({
+          matchId: "first-win",
+          gameEndAt: "2026-01-01T00:00:00.000Z",
+          result: true,
+        }),
+        evidence({
+          matchId: "second-win",
+          gameEndAt: "2026-01-02T00:00:00.000Z",
+          result: true,
+        }),
+      ],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "reversible",
+    });
+
+    expect(progress.latestMaterialChange).toMatchObject({
+      matchId: "second-win",
+      kind: "regression",
+      summary: "Progress regressed after match second-win.",
+    });
+  });
+
+  test("does not treat an ordinary eligible miss as material progress", () => {
+    const progress = deriveDareProgressV2({
+      plan: PLAN,
+      evidence: [
+        evidence({
+          matchId: "ordinary-miss",
+          gameEndAt: "2026-01-01T00:00:00.000Z",
+          result: false,
+        }),
+      ],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "reversible",
+    });
+
+    expect(progress.eligibleGames).toBe(1);
+    expect(progress.latestMaterialChange).toBeNull();
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.test.ts
@@ -1,0 +1,164 @@
+import { DareCompiledPlanV2Schema } from "@scout-for-lol/data";
+import { describe, expect, test } from "vitest";
+import { DareMatchEvidenceV2Schema } from "#src/betting/dare-evidence-v2.ts";
+import { deriveDareProgressV2 } from "#src/betting/dare-progress-v2.ts";
+
+const PLAN = DareCompiledPlanV2Schema.parse({
+  version: 2,
+  gameSets: [
+    {
+      name: "wins",
+      targetKeys: ["target"],
+      relationship: "same_match",
+      queues: ["solo"],
+      predicate: {
+        kind: "comparison",
+        value: { kind: "participant", target: "target", field: "win" },
+        operator: "eq",
+        threshold: true,
+      },
+      projections: [],
+      orderBy: "game_end_at_asc_match_id_asc",
+      limit: 3,
+    },
+  ],
+  result: {
+    kind: "matching_games",
+    gameSet: "wins",
+    operator: "gte",
+    threshold: 2,
+  },
+  maxEligibleGames: 3,
+});
+
+function evidence(input: {
+  matchId: string;
+  gameEndAt: string;
+  result: boolean | null;
+  coverage?: "complete" | "missing";
+}) {
+  return DareMatchEvidenceV2Schema.parse({
+    matchId: input.matchId,
+    gameStartAt: new Date(
+      new Date(input.gameEndAt).getTime() - 20 * 60 * 1000,
+    ).toISOString(),
+    gameEndAt: input.gameEndAt,
+    queue: "solo",
+    candidateSets: { wins: true },
+    setResults: { wins: input.result },
+    setValues: { wins: {} },
+    coverageState: input.coverage ?? "complete",
+    targetDependencies: { wins: ["target"] },
+    sourceReferences: ["match_participants"],
+    evaluationTrace: [`wins=${String(input.result)}`],
+  });
+}
+
+describe("Dare progress v2", () => {
+  test("derives chronological progress without mutating stored counters", () => {
+    const progress = deriveDareProgressV2({
+      plan: PLAN,
+      evidence: [
+        evidence({
+          matchId: "later",
+          gameEndAt: "2026-01-03T00:00:00.000Z",
+          result: true,
+        }),
+        evidence({
+          matchId: "first",
+          gameEndAt: "2026-01-01T00:00:00.000Z",
+          result: false,
+        }),
+        evidence({
+          matchId: "second",
+          gameEndAt: "2026-01-02T00:00:00.000Z",
+          result: true,
+        }),
+      ],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "reversible",
+    });
+
+    expect(progress).toMatchObject({
+      value: true,
+      matchedGames: 2,
+      eligibleGames: 3,
+      evidenceGames: 3,
+      summary: "All current conditions are satisfied; awaiting finality.",
+      targets: [
+        {
+          targetKey: "target",
+          matchedGames: 2,
+          eligibleGames: 3,
+          value: true,
+        },
+      ],
+    });
+    expect(progress.conditions[0]).toMatchObject({
+      current: 2,
+      target: 2,
+      remaining: 0,
+      value: true,
+    });
+    expect(progress.latestMaterialChange).toMatchObject({
+      matchId: "later",
+      kind: "advance",
+    });
+  });
+
+  test("keeps incomplete coverage unknown and visible", () => {
+    const progress = deriveDareProgressV2({
+      plan: PLAN,
+      evidence: [
+        evidence({
+          matchId: "known",
+          gameEndAt: "2025-12-31T00:00:00.000Z",
+          result: true,
+        }),
+        evidence({
+          matchId: "missing",
+          gameEndAt: "2026-01-01T00:00:00.000Z",
+          result: null,
+          coverage: "missing",
+        }),
+      ],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "reversible",
+    });
+
+    expect(progress.value).toBeNull();
+    expect(progress.conditions[0]).toMatchObject({
+      current: 1,
+      unknownGames: 1,
+      value: null,
+    });
+    expect(progress.coverageGaps).toEqual([
+      expect.objectContaining({ matchId: "missing" }),
+    ]);
+    expect(progress.latestMaterialChange).toMatchObject({
+      matchId: "missing",
+      kind: "coverage",
+    });
+  });
+
+  test("bounds duplicate and excess evidence by the immutable plan", () => {
+    const repeated = evidence({
+      matchId: "same",
+      gameEndAt: "2026-01-01T00:00:00.000Z",
+      result: true,
+    });
+    const progress = deriveDareProgressV2({
+      plan: PLAN,
+      evidence: [repeated, repeated, repeated, repeated],
+      targetKeys: ["target"],
+      final: false,
+      finalityReason: "game_cap",
+    });
+
+    expect(progress.evidenceGames).toBe(1);
+    expect(progress.eligibleGames).toBe(1);
+    expect(progress.matchedGames).toBe(1);
+  });
+});

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.ts
@@ -1,0 +1,343 @@
+import {
+  DareProgressSchema,
+  type DareCompiledPlanV2,
+  type DareGameSetV2,
+  type DareProgress,
+  type DareProgressCondition,
+  type DareResultExpressionV2,
+} from "@scout-for-lol/data";
+import type {
+  DareMatchEvidenceV2,
+  DareTruthValue,
+} from "#src/betting/dare-evidence-v2.ts";
+import { evaluateDareEvidenceV2 } from "#src/betting/dare-evaluator-v2.ts";
+
+type ProgressContext = {
+  plan: DareCompiledPlanV2;
+  evidence: readonly DareMatchEvidenceV2[];
+  gameSets: ReadonlyMap<string, DareGameSetV2>;
+};
+
+function orderedEvidence(
+  plan: DareCompiledPlanV2,
+  evidence: readonly DareMatchEvidenceV2[],
+): DareMatchEvidenceV2[] {
+  const unique = new Map<string, DareMatchEvidenceV2>();
+  for (const row of evidence) {
+    const existing = unique.get(row.matchId);
+    if (
+      existing !== undefined &&
+      JSON.stringify(existing) !== JSON.stringify(row)
+    ) {
+      throw new Error(
+        `Dare progress received conflicting evidence for ${row.matchId}.`,
+      );
+    }
+    unique.set(row.matchId, row);
+  }
+  return [...unique.values()]
+    .toSorted((left, right) => {
+      const time = left.gameEndAt.localeCompare(right.gameEndAt);
+      return time === 0 ? left.matchId.localeCompare(right.matchId) : time;
+    })
+    .slice(0, plan.maxEligibleGames);
+}
+
+function scopedRows(
+  context: ProgressContext,
+  gameSet: DareGameSetV2,
+): DareMatchEvidenceV2[] {
+  return context.evidence
+    .filter((row) => row.candidateSets[gameSet.name] === true)
+    .slice(0, gameSet.limit);
+}
+
+function remainingForComparison(
+  operator: string,
+  current: number,
+  target: number,
+): number {
+  if (operator === "gte") return Math.max(target - current, 0);
+  if (operator === "gt") return Math.max(target + 1 - current, 0);
+  if (operator === "lte") return Math.max(current - target, 0);
+  if (operator === "lt") return Math.max(current - target + 1, 0);
+  return Math.abs(target - current);
+}
+
+function aggregateValue(
+  functionName: "sum" | "average" | "minimum" | "maximum",
+  values: readonly number[],
+): number | null {
+  if (values.length === 0) return null;
+  if (functionName === "sum") {
+    return values.reduce((total, value) => total + value, 0);
+  }
+  if (functionName === "average") {
+    return values.reduce((total, value) => total + value, 0) / values.length;
+  }
+  return functionName === "minimum" ? Math.min(...values) : Math.max(...values);
+}
+
+function leafCondition(
+  context: ProgressContext,
+  expression: Extract<
+    DareResultExpressionV2,
+    { kind: "matching_games" | "aggregate" }
+  >,
+  key: string,
+): DareProgressCondition {
+  const gameSet = context.gameSets.get(expression.gameSet);
+  if (gameSet === undefined) {
+    throw new Error(
+      `Dare progress references unknown game set ${expression.gameSet}.`,
+    );
+  }
+  const rows = scopedRows(context, gameSet);
+  const matchedRows = rows.filter(
+    (row) => row.setResults[gameSet.name] === true,
+  );
+  const unknownGames = rows.filter(
+    (row) => row.setResults[gameSet.name] === null,
+  ).length;
+  const value = evaluateDareEvidenceV2({
+    plan: { ...context.plan, result: expression },
+    evidence: context.evidence,
+  });
+  if (expression.kind === "matching_games") {
+    const current = matchedRows.length;
+    return {
+      key,
+      kind: expression.kind,
+      label: `${gameSet.name}: ${expression.operator} ${expression.threshold.toString()} matching games`,
+      targetKeys: [...gameSet.targetKeys],
+      gameSet: gameSet.name,
+      operator: expression.operator,
+      current,
+      target: expression.threshold,
+      remaining: remainingForComparison(
+        expression.operator,
+        current,
+        expression.threshold,
+      ),
+      matchedGames: current,
+      eligibleGames: rows.length,
+      unknownGames,
+      value,
+    };
+  }
+  const projected = matchedRows.map(
+    (row) => row.setValues[gameSet.name]?.[expression.projection] ?? null,
+  );
+  const knownValues = projected.filter((candidate) => candidate !== null);
+  const current = aggregateValue(expression.function, knownValues);
+  return {
+    key,
+    kind: expression.kind,
+    label: `${expression.function} ${expression.projection}: ${expression.operator} ${expression.threshold.toString()}`,
+    targetKeys: [...gameSet.targetKeys],
+    gameSet: gameSet.name,
+    operator: expression.operator,
+    current,
+    target: expression.threshold,
+    remaining:
+      current === null
+        ? null
+        : remainingForComparison(
+            expression.operator,
+            current,
+            expression.threshold,
+          ),
+    matchedGames: matchedRows.length,
+    eligibleGames: rows.length,
+    unknownGames:
+      unknownGames + projected.filter((candidate) => candidate === null).length,
+    value,
+  };
+}
+
+function collectConditions(
+  context: ProgressContext,
+  expression: DareResultExpressionV2,
+  path: readonly number[],
+): DareProgressCondition[] {
+  if (expression.kind === "matching_games" || expression.kind === "aggregate") {
+    return [leafCondition(context, expression, path.join("."))];
+  }
+  if (expression.kind === "not") {
+    return collectConditions(context, expression.operand, [...path, 0]);
+  }
+  return expression.operands.flatMap((operand, index) =>
+    collectConditions(context, operand, [...path, index]),
+  );
+}
+
+function combinedTruth(values: readonly DareTruthValue[]): DareTruthValue {
+  if (values.includes(false)) return false;
+  return values.every((value) => value === true) ? true : null;
+}
+
+function progressSignature(
+  conditions: readonly DareProgressCondition[],
+): string {
+  return JSON.stringify(
+    conditions.map((condition) => ({
+      key: condition.key,
+      current: condition.current,
+      value: condition.value,
+      eligibleGames: condition.eligibleGames,
+      unknownGames: condition.unknownGames,
+    })),
+  );
+}
+
+function latestMaterialChange(
+  plan: DareCompiledPlanV2,
+  evidence: readonly DareMatchEvidenceV2[],
+) {
+  let previous = progressSignature(progressConditions(plan, []));
+  let latest: DareProgress["latestMaterialChange"] = null;
+  for (const [index, row] of evidence.entries()) {
+    const conditions = progressConditions(plan, evidence.slice(0, index + 1));
+    const signature = progressSignature(conditions);
+    if (signature === previous) continue;
+    const coverage = row.coverageState === "missing";
+    latest = {
+      kind: coverage ? "coverage" : "advance",
+      matchId: row.matchId,
+      occurredAt: row.gameEndAt,
+      summary: coverage
+        ? `Match ${row.matchId} has incomplete evidence.`
+        : `Progress changed after match ${row.matchId}.`,
+      conditionKeys: conditions
+        .filter((condition, conditionIndex) => {
+          const before = progressConditions(plan, evidence.slice(0, index))[
+            conditionIndex
+          ];
+          return (
+            before === undefined ||
+            progressSignature([before]) !== progressSignature([condition])
+          );
+        })
+        .map((condition) => condition.key),
+    };
+    previous = signature;
+  }
+  return latest;
+}
+
+function progressConditions(
+  plan: DareCompiledPlanV2,
+  evidence: readonly DareMatchEvidenceV2[],
+): DareProgressCondition[] {
+  const ordered = orderedEvidence(plan, evidence);
+  return collectConditions(
+    {
+      plan,
+      evidence: ordered,
+      gameSets: new Map(
+        plan.gameSets.map((gameSet) => [gameSet.name, gameSet]),
+      ),
+    },
+    plan.result,
+    [0],
+  );
+}
+
+function progressSummary(
+  value: DareTruthValue,
+  final: boolean,
+  conditions: readonly DareProgressCondition[],
+): string {
+  if (final) return value === true ? "Dare achieved." : "Dare not achieved.";
+  const next = conditions.find(
+    (condition) => condition.value !== true && condition.remaining !== null,
+  );
+  if (next === undefined) {
+    return value === true
+      ? "All current conditions are satisfied; awaiting finality."
+      : "Waiting for more eligible match evidence.";
+  }
+  const remaining = next.remaining;
+  if (remaining === null) {
+    throw new Error("A selected Dare progress condition has no remainder.");
+  }
+  return remaining === 0
+    ? `${next.label} is currently satisfied.`
+    : `${remaining.toString()} remaining for ${next.label}.`;
+}
+
+export function deriveDareProgressV2(input: {
+  plan: DareCompiledPlanV2;
+  evidence: readonly DareMatchEvidenceV2[];
+  targetKeys: readonly string[];
+  final: boolean;
+  finalityReason: string;
+}): DareProgress {
+  const evidence = orderedEvidence(input.plan, input.evidence);
+  const conditions = progressConditions(input.plan, evidence);
+  const value = evaluateDareEvidenceV2({ plan: input.plan, evidence });
+  const eligibleMatchIds = new Set(
+    evidence
+      .filter((row) => Object.values(row.candidateSets).includes(true))
+      .map((row) => row.matchId),
+  );
+  const matchedMatchIds = new Set(
+    evidence
+      .filter((row) => Object.values(row.setResults).includes(true))
+      .map((row) => row.matchId),
+  );
+  return DareProgressSchema.parse({
+    value,
+    final: input.final,
+    finalityReason: input.finalityReason,
+    matchedGames: matchedMatchIds.size,
+    eligibleGames: eligibleMatchIds.size,
+    evidenceGames: evidence.length,
+    conditions,
+    targets: input.targetKeys.map((targetKey) => {
+      const targetConditions = conditions.filter((condition) =>
+        condition.targetKeys.includes(targetKey),
+      );
+      return {
+        targetKey,
+        conditionKeys: targetConditions.map((condition) => condition.key),
+        matchedGames: new Set(
+          targetConditions.flatMap((condition) =>
+            evidence
+              .filter(
+                (row) =>
+                  condition.gameSet !== null &&
+                  row.setResults[condition.gameSet] === true,
+              )
+              .map((row) => row.matchId),
+          ),
+        ).size,
+        eligibleGames: new Set(
+          targetConditions.flatMap((condition) =>
+            evidence
+              .filter(
+                (row) =>
+                  condition.gameSet !== null &&
+                  row.candidateSets[condition.gameSet] === true,
+              )
+              .map((row) => row.matchId),
+          ),
+        ).size,
+        value: combinedTruth(
+          targetConditions.map((condition) => condition.value),
+        ),
+      };
+    }),
+    coverageGaps: evidence
+      .filter((row) => row.coverageState === "missing")
+      .map((row) => ({
+        matchId: row.matchId,
+        gameEndAt: row.gameEndAt,
+        sourceReferences: row.sourceReferences,
+        targetKeys: [...new Set(Object.values(row.targetDependencies).flat())],
+        reason: "Required match evidence is incomplete.",
+      })),
+    latestMaterialChange: latestMaterialChange(input.plan, evidence),
+    summary: progressSummary(value, input.final, conditions),
+  });
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-progress-v2.ts
@@ -184,43 +184,107 @@ function progressSignature(
       key: condition.key,
       current: condition.current,
       value: condition.value,
-      eligibleGames: condition.eligibleGames,
       unknownGames: condition.unknownGames,
     })),
   );
+}
+
+function changedConditionKeys(
+  before: readonly DareProgressCondition[],
+  after: readonly DareProgressCondition[],
+): string[] {
+  return after
+    .filter((condition, index) => {
+      const previous = before[index];
+      return (
+        previous === undefined ||
+        progressSignature([previous]) !== progressSignature([condition])
+      );
+    })
+    .map((condition) => condition.key);
+}
+
+function conditionRegressed(
+  previous: DareProgressCondition | undefined,
+  current: DareProgressCondition,
+): boolean {
+  if (previous === undefined) return false;
+  if (previous.value === true && current.value === false) return true;
+  return (
+    previous.remaining !== null &&
+    current.remaining !== null &&
+    current.remaining > previous.remaining
+  );
+}
+
+function conditionAdvanced(
+  previous: DareProgressCondition | undefined,
+  current: DareProgressCondition,
+): boolean {
+  if (previous === undefined) return false;
+  if (previous.value === false && current.value === true) return true;
+  return (
+    previous.remaining !== null &&
+    current.remaining !== null &&
+    current.remaining < previous.remaining
+  );
+}
+
+function progressChangeKind(
+  beforeValue: DareTruthValue,
+  afterValue: DareTruthValue,
+  before: readonly DareProgressCondition[],
+  after: readonly DareProgressCondition[],
+): "advance" | "regression" | "evidence" {
+  if (beforeValue === true && afterValue === false) return "regression";
+  if (beforeValue === false && afterValue === true) return "advance";
+  const regressed = after.some((condition, index) =>
+    conditionRegressed(before[index], condition),
+  );
+  const advanced = after.some((condition, index) =>
+    conditionAdvanced(before[index], condition),
+  );
+  if (regressed && !advanced) return "regression";
+  return advanced ? "advance" : "evidence";
 }
 
 function latestMaterialChange(
   plan: DareCompiledPlanV2,
   evidence: readonly DareMatchEvidenceV2[],
 ) {
-  let previous = progressSignature(progressConditions(plan, []));
+  let previousConditions = progressConditions(plan, []);
+  let previous = progressSignature(previousConditions);
+  let previousValue = evaluateDareEvidenceV2({ plan, evidence: [] });
   let latest: DareProgress["latestMaterialChange"] = null;
   for (const [index, row] of evidence.entries()) {
-    const conditions = progressConditions(plan, evidence.slice(0, index + 1));
+    const currentEvidence = evidence.slice(0, index + 1);
+    const conditions = progressConditions(plan, currentEvidence);
     const signature = progressSignature(conditions);
     if (signature === previous) continue;
     const coverage = row.coverageState === "missing";
+    const value = evaluateDareEvidenceV2({ plan, evidence: currentEvidence });
+    const kind = coverage
+      ? "coverage"
+      : progressChangeKind(
+          previousValue,
+          value,
+          previousConditions,
+          conditions,
+        );
     latest = {
-      kind: coverage ? "coverage" : "advance",
+      kind,
       matchId: row.matchId,
       occurredAt: row.gameEndAt,
       summary: coverage
         ? `Match ${row.matchId} has incomplete evidence.`
-        : `Progress changed after match ${row.matchId}.`,
-      conditionKeys: conditions
-        .filter((condition, conditionIndex) => {
-          const before = progressConditions(plan, evidence.slice(0, index))[
-            conditionIndex
-          ];
-          return (
-            before === undefined ||
-            progressSignature([before]) !== progressSignature([condition])
-          );
-        })
-        .map((condition) => condition.key),
+        : kind === "regression"
+          ? `Progress regressed after match ${row.matchId}.`
+          : `Progress changed after match ${row.matchId}.`,
+      conditionKeys: changedConditionKeys(previousConditions, conditions),
     };
     previous = signature;
+    previousConditions = conditions;
+    previousValue = value;
   }
   return latest;
 }
@@ -243,27 +307,56 @@ function progressConditions(
   );
 }
 
+type ProgressSummaryContext = {
+  plan: DareCompiledPlanV2;
+  evidence: readonly DareMatchEvidenceV2[];
+  conditions: ReadonlyMap<string, DareProgressCondition>;
+};
+
+function falseExpressionSummary(
+  context: ProgressSummaryContext,
+  expression: DareResultExpressionV2,
+  path: readonly number[],
+): string {
+  if (expression.kind === "not") {
+    return "The excluded condition is currently satisfied; it must become false.";
+  }
+  if (expression.kind === "or") {
+    return "At least one alternative must still be satisfied.";
+  }
+  if (expression.kind === "and") {
+    const index = expression.operands.findIndex(
+      (operand) =>
+        evaluateDareEvidenceV2({
+          plan: { ...context.plan, result: operand },
+          evidence: context.evidence,
+        }) !== true,
+    );
+    const selected = expression.operands[index];
+    return selected === undefined
+      ? "Waiting for more eligible match evidence."
+      : falseExpressionSummary(context, selected, [...path, index]);
+  }
+  const condition = context.conditions.get(path.join("."));
+  if (condition?.remaining === undefined || condition.remaining === null) {
+    return "Waiting for more eligible match evidence.";
+  }
+  return condition.remaining === 0
+    ? `${condition.label} is currently satisfied.`
+    : `${condition.remaining.toString()} remaining for ${condition.label}.`;
+}
+
 function progressSummary(
+  context: ProgressSummaryContext,
   value: DareTruthValue,
   final: boolean,
-  conditions: readonly DareProgressCondition[],
 ): string {
   if (final) return value === true ? "Dare achieved." : "Dare not achieved.";
-  const next = conditions.find(
-    (condition) => condition.value !== true && condition.remaining !== null,
-  );
-  if (next === undefined) {
-    return value === true
-      ? "All current conditions are satisfied; awaiting finality."
-      : "Waiting for more eligible match evidence.";
+  if (value === true) {
+    return "All current conditions are satisfied; awaiting finality.";
   }
-  const remaining = next.remaining;
-  if (remaining === null) {
-    throw new Error("A selected Dare progress condition has no remainder.");
-  }
-  return remaining === 0
-    ? `${next.label} is currently satisfied.`
-    : `${remaining.toString()} remaining for ${next.label}.`;
+  if (value === null) return "Waiting for more eligible match evidence.";
+  return falseExpressionSummary(context, context.plan.result, [0]);
 }
 
 export function deriveDareProgressV2(input: {
@@ -338,6 +431,16 @@ export function deriveDareProgressV2(input: {
         reason: "Required match evidence is incomplete.",
       })),
     latestMaterialChange: latestMaterialChange(input.plan, evidence),
-    summary: progressSummary(value, input.final, conditions),
+    summary: progressSummary(
+      {
+        plan: input.plan,
+        evidence,
+        conditions: new Map(
+          conditions.map((condition) => [condition.key, condition]),
+        ),
+      },
+      value,
+      input.final,
+    ),
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-refund-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-refund-v2.ts
@@ -6,6 +6,7 @@ import {
 } from "#src/betting/dare-ledger-v2.ts";
 import { currentDareV2State } from "#src/betting/dare-v2-common.ts";
 import type { Db } from "#src/database/index.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
 
 async function freshFacts(tx: Db, dareId: number) {
   const dare = await tx.bucksDareV2.findUniqueOrThrow({
@@ -83,6 +84,16 @@ export async function declineDareV2InTransaction(
     resolution: "declined",
     withCut: false,
   });
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: input.dareId,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: "declined",
+    actorDiscordId: input.actorDiscordId,
+    summary: `A target declined; the ${facts.potTotal.toString()} Bryan Bucks pot was fully refunded.`,
+    deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:declined`,
+    occurredAt: input.now,
+  });
   return { kind: "declined", potTotal: facts.potTotal, refunds } as const;
 }
 
@@ -119,6 +130,16 @@ export async function cancelDareV2InTransaction(
     facts,
     resolution: "cancelled",
     withCut: false,
+  });
+  await enqueueDareNotificationInTransaction(tx, {
+    dareId: input.dareId,
+    revision: input.revision,
+    category: "lifecycle",
+    kind: "cancelled",
+    actorDiscordId: input.actorDiscordId,
+    summary: `The Dare was cancelled before activation; ${facts.potTotal.toString()} Bryan Bucks were fully refunded.`,
+    deduplicationKey: `dare:${input.dareId.toString()}:revision:${input.revision.toString()}:cancelled`,
+    occurredAt: input.now,
   });
   return { kind: "cancelled", potTotal: facts.potTotal, refunds } as const;
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-match-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-match-v2.ts
@@ -1,0 +1,33 @@
+import {
+  resolveQueueTypeFromGame,
+  type DareContractV2,
+  type RawMatch,
+} from "@scout-for-lol/data";
+import { isRemakeMatch } from "#src/betting/outcome.ts";
+
+export function matchTouchesDareContractV2(
+  matchData: RawMatch,
+  contract: DareContractV2,
+): boolean {
+  const puuids = new Set(
+    matchData.info.participants.map((participant) => participant.puuid),
+  );
+  return contract.targets.some((target) =>
+    target.accounts.some((account) => puuids.has(account.puuid)),
+  );
+}
+
+export function dareV2MatchSettlementContext(matchData: RawMatch) {
+  if (isRemakeMatch(matchData)) return null;
+  const queue = resolveQueueTypeFromGame(
+    matchData.info.queueId,
+    matchData.info.gameMode,
+    matchData.info.gameType,
+  );
+  if (queue === undefined) return null;
+  return {
+    queue,
+    gameStartAt: new Date(matchData.info.gameStartTimestamp),
+    gameEndAt: new Date(matchData.info.gameEndTimestamp),
+  };
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-settle-v2.ts
@@ -1,11 +1,9 @@
 import {
   DareCompiledPlanV2Schema,
-  resolveQueueTypeFromGame,
   type DareContractV2,
   type RawMatch,
 } from "@scout-for-lol/data";
 import type { Prisma } from "#generated/prisma/client/index.js";
-import { isRemakeMatch } from "#src/betting/outcome.ts";
 import { pendingDareV2CalloutRefresh } from "#src/betting/dare-callout-refresh-state-v2.ts";
 import type { DareTimelineEvidenceV2 } from "#src/betting/dare-evaluator-v2.ts";
 import { dareEvaluatorImplementationV2 } from "#src/betting/dare-evaluator-registry-v2.ts";
@@ -41,6 +39,14 @@ import {
   readableDareV2Contract,
 } from "#src/betting/dare-v2-common.ts";
 import { voidDareV2WithFullRefund } from "#src/betting/dare-void-v2.ts";
+import {
+  enqueueMaterialDareProgressNotification,
+  enqueueTerminalDareNotification,
+} from "#src/betting/dare-notification-production.ts";
+import {
+  dareV2MatchSettlementContext,
+  matchTouchesDareContractV2,
+} from "#src/betting/dare-settle-match-v2.ts";
 import {
   prisma,
   type Db,
@@ -147,6 +153,14 @@ async function resolveFinalDareV2(
       ...(value === null ? { voidReason: "missing_evidence" } : {}),
     });
   }
+  await enqueueTerminalDareNotification(tx, {
+    dareId: input.dare.id,
+    revision: input.contract.revision,
+    potTotal: input.dare.potTotal,
+    resolution,
+    ...(input.matchId === undefined ? {} : { matchId: input.matchId }),
+    now: input.now,
+  });
   return resolution;
 }
 
@@ -213,6 +227,16 @@ async function captureOneDareV2(
         now: input.now,
       })
     : "captured";
+  if (resolution === "captured") {
+    await enqueueMaterialDareProgressNotification(tx, {
+      dareId: input.dare.id,
+      contract: input.contract,
+      evidence,
+      matchId: input.matchEvidence.matchId,
+      finality,
+      now: input.now,
+    });
+  }
   return {
     contractVersion: 2,
     dareId: input.dare.id,
@@ -224,18 +248,6 @@ async function captureOneDareV2(
     finality,
     proof,
   };
-}
-
-function matchTouchesContract(
-  matchData: RawMatch,
-  contract: DareContractV2,
-): boolean {
-  const puuids = new Set(
-    matchData.info.participants.map((participant) => participant.puuid),
-  );
-  return contract.targets.some((target) =>
-    target.accounts.some((account) => puuids.has(account.puuid)),
-  );
 }
 
 async function inspectStoredContract(
@@ -271,21 +283,6 @@ async function inspectStoredContract(
   };
 }
 
-function matchSettlementContext(matchData: RawMatch) {
-  if (isRemakeMatch(matchData)) return null;
-  const queue = resolveQueueTypeFromGame(
-    matchData.info.queueId,
-    matchData.info.gameMode,
-    matchData.info.gameType,
-  );
-  if (queue === undefined) return null;
-  return {
-    queue,
-    gameStartAt: new Date(matchData.info.gameStartTimestamp),
-    gameEndAt: new Date(matchData.info.gameEndTimestamp),
-  };
-}
-
 export async function settleDaresV2ForMatch(
   matchData: RawMatch,
   prismaClient: ExtendedPrismaClient = prisma,
@@ -295,7 +292,7 @@ export async function settleDaresV2ForMatch(
   } = {},
 ): Promise<DareV2SettlementSummary[]> {
   const now = options.now ?? new Date();
-  const context = matchSettlementContext(matchData);
+  const context = dareV2MatchSettlementContext(matchData);
   if (context === null) return [];
   const rows = await prismaClient.bucksDareV2.findMany({
     where: {
@@ -331,7 +328,7 @@ export async function settleDaresV2ForMatch(
     }
   }
   const relevant = contracts.filter(({ contract }) =>
-    matchTouchesContract(matchData, contract),
+    matchTouchesDareContractV2(matchData, contract),
   );
   if (relevant.length === 0) {
     if (inspected.firstFailure !== null) {
@@ -412,7 +409,7 @@ export async function dareV2MatchNeedsTimeline(
   matchData: RawMatch,
   prismaClient: ExtendedPrismaClient = prisma,
 ): Promise<boolean> {
-  const context = matchSettlementContext(matchData);
+  const context = dareV2MatchSettlementContext(matchData);
   if (context === null) return false;
   const rows = await prismaClient.bucksDareV2.findMany({
     where: {
@@ -427,7 +424,7 @@ export async function dareV2MatchNeedsTimeline(
     const contract = readableDareV2Contract(row.contractJson);
     return (
       contract !== null &&
-      matchTouchesContract(matchData, contract) &&
+      matchTouchesDareContractV2(matchData, contract) &&
       darePlanNeedsTimeline(contract.compiledPlan)
     );
   });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-sweep-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-sweep-v2.ts
@@ -15,6 +15,7 @@ import { collectDareV2Batch } from "#src/betting/dare-settle-batch-v2.ts";
 import { voidDareV2WithFullRefund } from "#src/betting/dare-void-v2.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { createLogger } from "#src/logger.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
 
 const logger = createLogger("betting-dare-sweep-v2");
 
@@ -69,6 +70,15 @@ async function expireOne(
       facts,
       resolution: "expired",
       withCut: false,
+    });
+    await enqueueDareNotificationInTransaction(tx, {
+      dareId: dare.id,
+      revision: dare.fundedRevision ?? dare.currentRevision,
+      category: "lifecycle",
+      kind: "expired",
+      summary: `The acceptance window expired; ${dare.potTotal.toString()} Bryan Bucks were fully refunded.`,
+      deduplicationKey: `dare:${dare.id.toString()}:revision:${(dare.fundedRevision ?? dare.currentRevision).toString()}:expired`,
+      occurredAt: now,
     });
     return true;
   });

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-index-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-index-v2.ts
@@ -1,0 +1,226 @@
+import {
+  BucksDareV2StateSchema,
+  DareTargetBindingV2Schema,
+  type BucksDareV2State,
+  type DiscordAccountId,
+} from "@scout-for-lol/data";
+
+export type VisibleDareIndexRow = {
+  id: number;
+  dareState: string;
+  currentRevision: number;
+  fundedRevision: number | null;
+  challengerDiscordId: string;
+  acceptDeadline: Date | null;
+  deadlineAt: Date | null;
+  updatedAt: Date;
+  revisions: {
+    revision: number;
+    originalText: string;
+    targetsJson: string;
+  }[];
+  targets: {
+    discordId: string;
+    alias: string;
+    acceptedAt: Date | null;
+    declinedAt: Date | null;
+  }[];
+  contributions: { discordId: string }[];
+};
+
+export type VisibleDareIndexItem = {
+  id: number;
+  state: BucksDareV2State;
+  targetAliases: string[];
+  viewerRoles: ("member" | "challenger" | "target" | "contributor")[];
+  requiresViewerAction: boolean;
+  acceptDeadline: string | null;
+  deadlineAt: string | null;
+  updatedAt: string;
+};
+
+export const visibleDareIndexSelectionV2 = {
+  id: true,
+  dareState: true,
+  currentRevision: true,
+  fundedRevision: true,
+  challengerDiscordId: true,
+  acceptDeadline: true,
+  deadlineAt: true,
+  updatedAt: true,
+  revisions: {
+    select: {
+      revision: true,
+      originalText: true,
+      targetsJson: true,
+    },
+  },
+  targets: {
+    select: {
+      discordId: true,
+      alias: true,
+      acceptedAt: true,
+      declinedAt: true,
+    },
+  },
+  contributions: { select: { discordId: true } },
+};
+
+export function dareViewerFactsV2(
+  row: Pick<
+    VisibleDareIndexRow,
+    "dareState" | "challengerDiscordId" | "targets" | "contributions"
+  >,
+  viewerDiscordId: DiscordAccountId,
+) {
+  const state = BucksDareV2StateSchema.parse(row.dareState);
+  const challenger = row.challengerDiscordId === viewerDiscordId;
+  const target = row.targets.find(
+    (candidate) => candidate.discordId === viewerDiscordId,
+  );
+  const contributor = row.contributions.some(
+    (candidate) => candidate.discordId === viewerDiscordId,
+  );
+  const roles = [
+    "member" as const,
+    ...(challenger ? (["challenger"] as const) : []),
+    ...(target === undefined ? [] : (["target"] as const)),
+    ...(contributor ? (["contributor"] as const) : []),
+  ];
+  const awaitingTarget =
+    state === "pending_accept" &&
+    target?.acceptedAt === null &&
+    target.declinedAt === null;
+  const actions = [
+    ...(state === "draft" && challenger
+      ? (["fund", "delete_draft"] as const)
+      : []),
+    ...(awaitingTarget ? (["accept", "decline"] as const) : []),
+    ...(state === "pending_accept" && challenger ? (["cancel"] as const) : []),
+    ...(target === undefined &&
+    (state === "pending_accept" || state === "active")
+      ? (["contribute"] as const)
+      : []),
+  ];
+  return {
+    roles,
+    actions,
+    requiresViewerAction: (state === "draft" && challenger) || awaitingTarget,
+  };
+}
+
+function indexRevision(row: VisibleDareIndexRow) {
+  const revisionNumber = row.fundedRevision ?? row.currentRevision;
+  const revision = row.revisions.find(
+    (candidate) => candidate.revision === revisionNumber,
+  );
+  if (revision === undefined) {
+    throw new Error(
+      `Dare v2 ${row.id.toString()} is missing revision ${revisionNumber.toString()}.`,
+    );
+  }
+  return revision;
+}
+
+function indexedVisibleDare(
+  row: VisibleDareIndexRow,
+  viewerDiscordId: DiscordAccountId,
+): VisibleDareIndexItem {
+  const revision = indexRevision(row);
+  const draftTargets = DareTargetBindingV2Schema.array().parse(
+    JSON.parse(revision.targetsJson),
+  );
+  const viewer = dareViewerFactsV2(row, viewerDiscordId);
+  return {
+    id: row.id,
+    state: BucksDareV2StateSchema.parse(row.dareState),
+    targetAliases:
+      row.targets.length === 0
+        ? draftTargets.map((target) => target.alias)
+        : row.targets.map((target) => target.alias),
+    viewerRoles: viewer.roles,
+    requiresViewerAction: viewer.requiresViewerAction,
+    acceptDeadline: row.acceptDeadline?.toISOString() ?? null,
+    deadlineAt: row.deadlineAt?.toISOString() ?? null,
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function matchesSearch(
+  row: VisibleDareIndexRow,
+  item: VisibleDareIndexItem,
+  search: string | undefined,
+): boolean {
+  if (search === undefined || search.length === 0) return true;
+  const normalizedSearch = search.toLocaleLowerCase();
+  return (
+    indexRevision(row)
+      .originalText.toLocaleLowerCase()
+      .includes(normalizedSearch) ||
+    item.targetAliases.some((alias) =>
+      alias.toLocaleLowerCase().includes(normalizedSearch),
+    )
+  );
+}
+
+function hasViewerRole(
+  item: VisibleDareIndexItem,
+  role: "challenger" | "target" | "contributor" | "involved" | undefined,
+): boolean {
+  if (role === undefined) return true;
+  if (role === "involved") {
+    return item.viewerRoles.some((candidate) => candidate !== "member");
+  }
+  return item.viewerRoles.includes(role);
+}
+
+function sortVisibleDares(
+  items: VisibleDareIndexItem[],
+  sort: "needs_action" | "deadline" | "updated",
+): VisibleDareIndexItem[] {
+  return items.toSorted((left, right) => {
+    if (sort === "needs_action") {
+      const action =
+        Number(right.requiresViewerAction) - Number(left.requiresViewerAction);
+      if (action !== 0) return action;
+    }
+    if (sort === "deadline") {
+      const leftDeadline = left.deadlineAt ?? left.acceptDeadline;
+      const rightDeadline = right.deadlineAt ?? right.acceptDeadline;
+      if (leftDeadline !== rightDeadline) {
+        if (leftDeadline === null) return 1;
+        if (rightDeadline === null) return -1;
+        return leftDeadline.localeCompare(rightDeadline);
+      }
+    }
+    const updated = right.updatedAt.localeCompare(left.updatedAt);
+    return updated === 0 ? right.id - left.id : updated;
+  });
+}
+
+export function indexVisibleDaresV2(input: {
+  rows: VisibleDareIndexRow[];
+  viewerDiscordId: DiscordAccountId;
+  search?: string | undefined;
+  states?: BucksDareV2State[] | undefined;
+  role?: "challenger" | "target" | "contributor" | "involved" | undefined;
+  needsAction: boolean;
+  sort: "needs_action" | "deadline" | "updated";
+}): VisibleDareIndexItem[] {
+  return sortVisibleDares(
+    input.rows
+      .map((row) => ({
+        row,
+        item: indexedVisibleDare(row, input.viewerDiscordId),
+      }))
+      .filter(
+        ({ row, item }) =>
+          matchesSearch(row, item, input.search) &&
+          (input.states === undefined || input.states.includes(item.state)) &&
+          hasViewerRole(item, input.role) &&
+          (!input.needsAction || item.requiresViewerAction),
+      )
+      .map(({ item }) => item),
+    input.sort,
+  );
+}

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-model-v2.ts
@@ -1,0 +1,86 @@
+import {
+  BucksDareV2StateSchema,
+  DareCompiledPlanV2Schema,
+  DareDeadlineSpecV2Schema,
+  DarePollHealthSchema,
+  DareProgressSchema,
+  DareTargetBindingV2Schema,
+} from "@scout-for-lol/data";
+import { z } from "zod";
+
+const StoredTargetSchema = DareTargetBindingV2Schema.omit({
+  accounts: true,
+}).extend({
+  acceptedAt: z.iso.datetime().nullable(),
+  declinedAt: z.iso.datetime().nullable(),
+  payout: z.number().int().nullable(),
+  fee: z.number().int().nullable(),
+});
+
+export const DareViewerRoleSchema = z.enum([
+  "member",
+  "challenger",
+  "target",
+  "contributor",
+]);
+export const DareAvailableActionSchema = z.enum([
+  "fund",
+  "accept",
+  "decline",
+  "contribute",
+  "cancel",
+  "delete_draft",
+]);
+
+export const DareV2ListItemSchema = z.strictObject({
+  id: z.number().int().positive(),
+  serverId: z.string().min(1),
+  state: BucksDareV2StateSchema,
+  currentRevision: z.number().int().positive(),
+  fundedRevision: z.number().int().positive().nullable(),
+  challengerDiscordId: z.string().min(1),
+  targetAliases: z.array(z.string().min(1)),
+  plainLanguage: z.string().min(1),
+  openingStake: z.number().int().positive(),
+  potTotal: z.number().int().nonnegative(),
+  evidenceGames: z.number().int().nonnegative(),
+  progress: DareProgressSchema,
+  viewerRoles: z.array(DareViewerRoleSchema),
+  availableActions: z.array(DareAvailableActionSchema),
+  requiresViewerAction: z.boolean(),
+  proposalExpiresAt: z.iso.datetime().nullable(),
+  acceptDeadline: z.iso.datetime().nullable(),
+  activatedAt: z.iso.datetime().nullable(),
+  deadlineAt: z.iso.datetime().nullable(),
+  settledAt: z.iso.datetime().nullable(),
+  finalValue: z.boolean().nullable(),
+  updatedAt: z.iso.datetime(),
+});
+export type DareV2ListItem = z.infer<typeof DareV2ListItemSchema>;
+
+export const DareV2ListPageSchema = z.strictObject({
+  items: z.array(DareV2ListItemSchema),
+  nextCursor: z.string().min(1).nullable(),
+});
+export type DareV2ListPage = z.infer<typeof DareV2ListPageSchema>;
+
+export const DareV2InspectionSchema = DareV2ListItemSchema.extend({
+  channelId: z.string().min(1),
+  originConversationId: z.string().min(1).nullable(),
+  canonicalScoutQl: z.string().min(1),
+  plan: DareCompiledPlanV2Schema,
+  semanticProofPlan: z.string().min(1),
+  originalText: z.string().min(1),
+  deadlineSpec: DareDeadlineSpecV2Schema,
+  compilerVersion: z.string().min(1),
+  scoutQlPlanHash: z
+    .string()
+    .regex(/^[a-f\d]{64}$/)
+    .nullable(),
+  evaluatorVersion: z.string().min(1),
+  targets: z.array(StoredTargetSchema),
+  proof: z.json().nullable(),
+  voidReason: z.string().nullable(),
+  processingHealth: DarePollHealthSchema,
+});
+export type DareV2Inspection = z.infer<typeof DareV2InspectionSchema>;

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -7,60 +7,20 @@ import {
   type DiscordAccountId,
   type DiscordGuildId,
 } from "@scout-for-lol/data";
-import { z } from "zod";
+import type { z } from "zod";
 import { formatDareScoutQlV2 } from "#src/betting/dare-contract-compiler-v2.ts";
+import { deriveDareProgressV2 } from "#src/betting/dare-progress-v2.ts";
+import { storedDareV2Evidence } from "#src/betting/dare-settle-evidence-v2.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
-
-const StoredTargetSchema = DareTargetBindingV2Schema.omit({
-  accounts: true,
-}).extend({
-  acceptedAt: z.iso.datetime().nullable(),
-  declinedAt: z.iso.datetime().nullable(),
-  payout: z.number().int().nullable(),
-  fee: z.number().int().nullable(),
-});
-
-export const DareV2ListItemSchema = z.strictObject({
-  id: z.number().int().positive(),
-  serverId: z.string().min(1),
-  state: BucksDareV2StateSchema,
-  currentRevision: z.number().int().positive(),
-  fundedRevision: z.number().int().positive().nullable(),
-  challengerDiscordId: z.string().min(1),
-  targetAliases: z.array(z.string().min(1)),
-  plainLanguage: z.string().min(1),
-  openingStake: z.number().int().positive(),
-  potTotal: z.number().int().nonnegative(),
-  evidenceGames: z.number().int().nonnegative(),
-  proposalExpiresAt: z.iso.datetime().nullable(),
-  acceptDeadline: z.iso.datetime().nullable(),
-  activatedAt: z.iso.datetime().nullable(),
-  deadlineAt: z.iso.datetime().nullable(),
-  settledAt: z.iso.datetime().nullable(),
-  finalValue: z.boolean().nullable(),
-  updatedAt: z.iso.datetime(),
-});
-export type DareV2ListItem = z.infer<typeof DareV2ListItemSchema>;
-
-export const DareV2InspectionSchema = DareV2ListItemSchema.extend({
-  channelId: z.string().min(1),
-  originConversationId: z.string().min(1).nullable(),
-  canonicalScoutQl: z.string().min(1),
-  plan: DareCompiledPlanV2Schema,
-  semanticProofPlan: z.string().min(1),
-  originalText: z.string().min(1),
-  deadlineSpec: DareDeadlineSpecV2Schema,
-  compilerVersion: z.string().min(1),
-  scoutQlPlanHash: z
-    .string()
-    .regex(/^[a-f\d]{64}$/)
-    .nullable(),
-  evaluatorVersion: z.string().min(1),
-  targets: z.array(StoredTargetSchema),
-  proof: z.json().nullable(),
-  voidReason: z.string().nullable(),
-});
-export type DareV2Inspection = z.infer<typeof DareV2InspectionSchema>;
+import { darePollHealth } from "#src/betting/dare-poll-health.ts";
+import {
+  DareV2InspectionSchema,
+  DareV2ListItemSchema,
+  DareV2ListPageSchema,
+  type DareV2Inspection,
+  type DareV2ListItem,
+  type DareV2ListPage,
+} from "#src/betting/dare-view-model-v2.ts";
 
 type VisibleDareRow = {
   id: number;
@@ -106,6 +66,19 @@ type VisibleDareRow = {
     fee: number | null;
   }[];
   _count: { evidence: number };
+  evidence: {
+    matchId: string;
+    gameStartAt: Date;
+    gameEndAt: Date;
+    queueType: string;
+    candidateMembership: string;
+    evaluationOutput: string;
+    coverageState: string;
+    targetDependencies: string;
+    sourceReferences: string;
+    evaluationTrace: string;
+  }[];
+  contributions: { discordId: string }[];
 };
 
 function iso(value: Date | null): string | null {
@@ -125,15 +98,65 @@ function activeRevision(row: VisibleDareRow) {
   return revision;
 }
 
-function listItem(row: VisibleDareRow): DareV2ListItem {
+function terminalState(state: BucksDareV2State): boolean {
+  return !["draft", "pending_accept", "active"].includes(state);
+}
+
+function viewerFacts(row: VisibleDareRow, viewerDiscordId: DiscordAccountId) {
+  const state = BucksDareV2StateSchema.parse(row.dareState);
+  const challenger = row.challengerDiscordId === viewerDiscordId;
+  const target = row.targets.find(
+    (candidate) => candidate.discordId === viewerDiscordId,
+  );
+  const contributor = row.contributions.some(
+    (candidate) => candidate.discordId === viewerDiscordId,
+  );
+  const roles = [
+    "member" as const,
+    ...(challenger ? (["challenger"] as const) : []),
+    ...(target === undefined ? [] : (["target"] as const)),
+    ...(contributor ? (["contributor"] as const) : []),
+  ];
+  const awaitingTarget =
+    state === "pending_accept" &&
+    target?.acceptedAt === null &&
+    target.declinedAt === null;
+  const actions = [
+    ...(state === "draft" && challenger
+      ? (["fund", "delete_draft"] as const)
+      : []),
+    ...(awaitingTarget ? (["accept", "decline"] as const) : []),
+    ...(state === "pending_accept" && challenger ? (["cancel"] as const) : []),
+    ...(target === undefined &&
+    (state === "pending_accept" || state === "active")
+      ? (["contribute"] as const)
+      : []),
+  ];
+  return {
+    roles,
+    actions,
+    requiresViewerAction: (state === "draft" && challenger) || awaitingTarget,
+  };
+}
+
+function listItem(
+  row: VisibleDareRow,
+  viewerDiscordId: DiscordAccountId,
+): DareV2ListItem {
   const revision = activeRevision(row);
+  const state = BucksDareV2StateSchema.parse(row.dareState);
   const draftTargets = DareTargetBindingV2Schema.array().parse(
     JSON.parse(revision.targetsJson),
   );
+  const targetKeys =
+    row.targets.length === 0
+      ? draftTargets.map((target) => target.key)
+      : row.targets.map((target) => target.targetKey);
+  const viewer = viewerFacts(row, viewerDiscordId);
   return DareV2ListItemSchema.parse({
     id: row.id,
     serverId: row.serverId,
-    state: BucksDareV2StateSchema.parse(row.dareState),
+    state,
     currentRevision: row.currentRevision,
     fundedRevision: row.fundedRevision,
     challengerDiscordId: row.challengerDiscordId,
@@ -145,6 +168,16 @@ function listItem(row: VisibleDareRow): DareV2ListItem {
     openingStake: row.openingStake,
     potTotal: row.potTotal,
     evidenceGames: row._count.evidence,
+    progress: deriveDareProgressV2({
+      plan: DareCompiledPlanV2Schema.parse(JSON.parse(revision.compiledPlan)),
+      evidence: row.evidence.map((evidence) => storedDareV2Evidence(evidence)),
+      targetKeys,
+      final: terminalState(state),
+      finalityReason: terminalState(state) ? state : "in_progress",
+    }),
+    viewerRoles: viewer.roles,
+    availableActions: viewer.actions,
+    requiresViewerAction: viewer.requiresViewerAction,
     proposalExpiresAt: iso(row.proposalExpiresAt),
     acceptDeadline: iso(row.acceptDeadline),
     activatedAt: iso(row.activatedAt),
@@ -155,7 +188,11 @@ function listItem(row: VisibleDareRow): DareV2ListItem {
   });
 }
 
-function inspection(row: VisibleDareRow): DareV2Inspection {
+function inspection(
+  row: VisibleDareRow,
+  viewerDiscordId: DiscordAccountId,
+  processingHealth: ReturnType<typeof darePollHealth>,
+): DareV2Inspection {
   const revision = activeRevision(row);
   const state = BucksDareV2StateSchema.parse(row.dareState);
   const plan = DareCompiledPlanV2Schema.parse(
@@ -165,7 +202,7 @@ function inspection(row: VisibleDareRow): DareV2Inspection {
     JSON.parse(revision.targetsJson),
   );
   return DareV2InspectionSchema.parse({
-    ...listItem(row),
+    ...listItem(row, viewerDiscordId),
     channelId: row.channelId,
     originConversationId: row.originConversationId,
     canonicalScoutQl: visibleDareScoutQlV2({
@@ -206,6 +243,7 @@ function inspection(row: VisibleDareRow): DareV2Inspection {
           })),
     proof: row.proofJson === null ? null : JSON.parse(row.proofJson),
     voidReason: row.voidReason,
+    processingHealth,
   });
 }
 
@@ -222,10 +260,14 @@ export function visibleDareScoutQlV2(input: {
 const includeVisibleDare = {
   revisions: { orderBy: { revision: "asc" as const } },
   targets: { orderBy: { id: "asc" as const } },
+  contributions: { select: { discordId: true } },
+  evidence: {
+    orderBy: [{ gameEndAt: "asc" as const }, { matchId: "asc" as const }],
+  },
   _count: { select: { evidence: true } },
 };
 
-const VISIBLE_DARE_PAGE_SIZE = 100;
+const VISIBLE_DARE_PAGE_SIZE = 25;
 
 function matchesVisibleDareSearch(
   row: VisibleDareRow,
@@ -246,15 +288,114 @@ function matchesVisibleDareSearch(
 function matchingVisibleDareItems(
   rows: VisibleDareRow[],
   search: string | undefined,
+  viewerDiscordId: DiscordAccountId,
 ): DareV2ListItem[] {
   return rows
-    .map((row) => ({ row, item: listItem(row) }))
+    .map((row) => ({ row, item: listItem(row, viewerDiscordId) }))
     .filter(({ row, item }) => matchesVisibleDareSearch(row, item, search))
     .map(({ item }) => item);
 }
 
+function sortVisibleDareItems(
+  items: DareV2ListItem[],
+  sort: "needs_action" | "deadline" | "updated",
+): DareV2ListItem[] {
+  return items.toSorted((left, right) => {
+    if (sort === "needs_action") {
+      const action =
+        Number(right.requiresViewerAction) - Number(left.requiresViewerAction);
+      if (action !== 0) return action;
+    }
+    if (sort === "deadline") {
+      const leftDeadline = left.deadlineAt ?? left.acceptDeadline;
+      const rightDeadline = right.deadlineAt ?? right.acceptDeadline;
+      if (leftDeadline !== rightDeadline) {
+        if (leftDeadline === null) return 1;
+        if (rightDeadline === null) return -1;
+        return leftDeadline.localeCompare(rightDeadline);
+      }
+    }
+    const updated = right.updatedAt.localeCompare(left.updatedAt);
+    return updated === 0 ? right.id - left.id : updated;
+  });
+}
+
+function hasViewerRole(
+  item: DareV2ListItem,
+  role: "challenger" | "target" | "contributor" | "involved" | undefined,
+): boolean {
+  if (role === undefined) return true;
+  if (role === "involved") {
+    return item.viewerRoles.some((candidate) => candidate !== "member");
+  }
+  return item.viewerRoles.includes(role);
+}
+
 function visibleState(state: BucksDareV2State): boolean {
   return state !== "draft" && state !== "deleted";
+}
+
+export async function listVisibleDarePageV2(
+  input: {
+    serverId: DiscordGuildId;
+    viewerDiscordId: DiscordAccountId;
+    scope: "mine" | "guild" | "needs_action";
+    search?: string | undefined;
+    states?: BucksDareV2State[] | undefined;
+    role?: "challenger" | "target" | "contributor" | "involved" | undefined;
+    sort?: "needs_action" | "deadline" | "updated" | undefined;
+    cursor?: string | undefined;
+    limit?: number | undefined;
+  },
+  prisma: ExtendedPrismaClient,
+): Promise<DareV2ListPage> {
+  const search = input.search?.trim();
+  const rows = await prisma.bucksDareV2.findMany({
+    where: {
+      serverId: input.serverId,
+      AND: [
+        input.scope === "guild"
+          ? { dareState: { notIn: ["draft", "deleted"] } }
+          : {
+              dareState: { not: "deleted" },
+              OR: [
+                { challengerDiscordId: input.viewerDiscordId },
+                { targets: { some: { discordId: input.viewerDiscordId } } },
+                {
+                  contributions: {
+                    some: { discordId: input.viewerDiscordId },
+                  },
+                },
+              ],
+            },
+      ],
+    },
+    include: includeVisibleDare,
+  });
+  const matches = sortVisibleDareItems(
+    matchingVisibleDareItems(rows, search, input.viewerDiscordId).filter(
+      (item) =>
+        (input.states === undefined || input.states.includes(item.state)) &&
+        hasViewerRole(item, input.role) &&
+        (input.scope !== "needs_action" || item.requiresViewerAction),
+    ),
+    input.sort ?? (input.scope === "needs_action" ? "needs_action" : "updated"),
+  );
+  const cursorIndex =
+    input.cursor === undefined
+      ? -1
+      : matches.findIndex((item) => item.id.toString() === input.cursor);
+  const start = cursorIndex + 1;
+  const limit = input.limit ?? VISIBLE_DARE_PAGE_SIZE;
+  const items = matches.slice(start, start + limit);
+  const last = items.at(-1);
+  return DareV2ListPageSchema.parse({
+    items,
+    nextCursor:
+      last !== undefined && start + items.length < matches.length
+        ? last.id.toString()
+        : null,
+  });
 }
 
 export async function listVisibleDaresV2(
@@ -266,46 +407,8 @@ export async function listVisibleDaresV2(
   },
   prisma: ExtendedPrismaClient,
 ): Promise<DareV2ListItem[]> {
-  const search = input.search?.trim();
-  const matches: DareV2ListItem[] = [];
-  let cursorId: number | undefined;
-  while (matches.length < VISIBLE_DARE_PAGE_SIZE) {
-    const rows = await prisma.bucksDareV2.findMany({
-      where: {
-        serverId: input.serverId,
-        AND: [
-          input.scope === "guild"
-            ? { dareState: { notIn: ["draft", "deleted"] } }
-            : {
-                dareState: { not: "deleted" },
-                OR: [
-                  { challengerDiscordId: input.viewerDiscordId },
-                  { targets: { some: { discordId: input.viewerDiscordId } } },
-                  {
-                    contributions: {
-                      some: { discordId: input.viewerDiscordId },
-                    },
-                  },
-                ],
-              },
-        ],
-      },
-      include: includeVisibleDare,
-      orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
-      take: VISIBLE_DARE_PAGE_SIZE,
-      ...(cursorId === undefined ? {} : { cursor: { id: cursorId }, skip: 1 }),
-    });
-    matches.push(...matchingVisibleDareItems(rows, search));
-    if (matches.length >= VISIBLE_DARE_PAGE_SIZE) {
-      return matches.slice(0, VISIBLE_DARE_PAGE_SIZE);
-    }
-    const lastRow = rows.at(-1);
-    if (lastRow === undefined || rows.length < VISIBLE_DARE_PAGE_SIZE) {
-      return matches;
-    }
-    cursorId = lastRow.id;
-  }
-  return matches;
+  const page = await listVisibleDarePageV2({ ...input, limit: 100 }, prisma);
+  return page.items;
 }
 
 export async function inspectVisibleDareV2(
@@ -316,10 +419,13 @@ export async function inspectVisibleDareV2(
   },
   prisma: ExtendedPrismaClient,
 ): Promise<DareV2Inspection | null> {
-  const row = await prisma.bucksDareV2.findFirst({
-    where: { id: input.dareId, serverId: input.serverId },
-    include: includeVisibleDare,
-  });
+  const [row, botState] = await Promise.all([
+    prisma.bucksDareV2.findFirst({
+      where: { id: input.dareId, serverId: input.serverId },
+      include: includeVisibleDare,
+    }),
+    prisma.botState.findUnique({ where: { id: 1 } }),
+  ]);
   if (row === null) return null;
   const state = BucksDareV2StateSchema.parse(row.dareState);
   if (
@@ -328,5 +434,5 @@ export async function inspectVisibleDareV2(
   ) {
     return null;
   }
-  return inspection(row);
+  return inspection(row, input.viewerDiscordId, darePollHealth(botState));
 }

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-view-v2.ts
@@ -14,6 +14,11 @@ import { storedDareV2Evidence } from "#src/betting/dare-settle-evidence-v2.ts";
 import type { ExtendedPrismaClient } from "#src/database/index.ts";
 import { darePollHealth } from "#src/betting/dare-poll-health.ts";
 import {
+  dareViewerFactsV2,
+  indexVisibleDaresV2,
+  visibleDareIndexSelectionV2,
+} from "#src/betting/dare-view-index-v2.ts";
+import {
   DareV2InspectionSchema,
   DareV2ListItemSchema,
   DareV2ListPageSchema,
@@ -102,43 +107,6 @@ function terminalState(state: BucksDareV2State): boolean {
   return !["draft", "pending_accept", "active"].includes(state);
 }
 
-function viewerFacts(row: VisibleDareRow, viewerDiscordId: DiscordAccountId) {
-  const state = BucksDareV2StateSchema.parse(row.dareState);
-  const challenger = row.challengerDiscordId === viewerDiscordId;
-  const target = row.targets.find(
-    (candidate) => candidate.discordId === viewerDiscordId,
-  );
-  const contributor = row.contributions.some(
-    (candidate) => candidate.discordId === viewerDiscordId,
-  );
-  const roles = [
-    "member" as const,
-    ...(challenger ? (["challenger"] as const) : []),
-    ...(target === undefined ? [] : (["target"] as const)),
-    ...(contributor ? (["contributor"] as const) : []),
-  ];
-  const awaitingTarget =
-    state === "pending_accept" &&
-    target?.acceptedAt === null &&
-    target.declinedAt === null;
-  const actions = [
-    ...(state === "draft" && challenger
-      ? (["fund", "delete_draft"] as const)
-      : []),
-    ...(awaitingTarget ? (["accept", "decline"] as const) : []),
-    ...(state === "pending_accept" && challenger ? (["cancel"] as const) : []),
-    ...(target === undefined &&
-    (state === "pending_accept" || state === "active")
-      ? (["contribute"] as const)
-      : []),
-  ];
-  return {
-    roles,
-    actions,
-    requiresViewerAction: (state === "draft" && challenger) || awaitingTarget,
-  };
-}
-
 function listItem(
   row: VisibleDareRow,
   viewerDiscordId: DiscordAccountId,
@@ -152,7 +120,7 @@ function listItem(
     row.targets.length === 0
       ? draftTargets.map((target) => target.key)
       : row.targets.map((target) => target.targetKey);
-  const viewer = viewerFacts(row, viewerDiscordId);
+  const viewer = dareViewerFactsV2(row, viewerDiscordId);
   return DareV2ListItemSchema.parse({
     id: row.id,
     serverId: row.serverId,
@@ -269,68 +237,6 @@ const includeVisibleDare = {
 
 const VISIBLE_DARE_PAGE_SIZE = 25;
 
-function matchesVisibleDareSearch(
-  row: VisibleDareRow,
-  item: DareV2ListItem,
-  search: string | undefined,
-): boolean {
-  if (search === undefined || search.length === 0) return true;
-  const normalizedSearch = search.toLocaleLowerCase();
-  const revision = activeRevision(row);
-  return (
-    revision.originalText.toLocaleLowerCase().includes(normalizedSearch) ||
-    item.targetAliases.some((alias) =>
-      alias.toLocaleLowerCase().includes(normalizedSearch),
-    )
-  );
-}
-
-function matchingVisibleDareItems(
-  rows: VisibleDareRow[],
-  search: string | undefined,
-  viewerDiscordId: DiscordAccountId,
-): DareV2ListItem[] {
-  return rows
-    .map((row) => ({ row, item: listItem(row, viewerDiscordId) }))
-    .filter(({ row, item }) => matchesVisibleDareSearch(row, item, search))
-    .map(({ item }) => item);
-}
-
-function sortVisibleDareItems(
-  items: DareV2ListItem[],
-  sort: "needs_action" | "deadline" | "updated",
-): DareV2ListItem[] {
-  return items.toSorted((left, right) => {
-    if (sort === "needs_action") {
-      const action =
-        Number(right.requiresViewerAction) - Number(left.requiresViewerAction);
-      if (action !== 0) return action;
-    }
-    if (sort === "deadline") {
-      const leftDeadline = left.deadlineAt ?? left.acceptDeadline;
-      const rightDeadline = right.deadlineAt ?? right.acceptDeadline;
-      if (leftDeadline !== rightDeadline) {
-        if (leftDeadline === null) return 1;
-        if (rightDeadline === null) return -1;
-        return leftDeadline.localeCompare(rightDeadline);
-      }
-    }
-    const updated = right.updatedAt.localeCompare(left.updatedAt);
-    return updated === 0 ? right.id - left.id : updated;
-  });
-}
-
-function hasViewerRole(
-  item: DareV2ListItem,
-  role: "challenger" | "target" | "contributor" | "involved" | undefined,
-): boolean {
-  if (role === undefined) return true;
-  if (role === "involved") {
-    return item.viewerRoles.some((candidate) => candidate !== "member");
-  }
-  return item.viewerRoles.includes(role);
-}
-
 function visibleState(state: BucksDareV2State): boolean {
   return state !== "draft" && state !== "deleted";
 }
@@ -370,25 +276,41 @@ export async function listVisibleDarePageV2(
             },
       ],
     },
-    include: includeVisibleDare,
+    select: visibleDareIndexSelectionV2,
   });
-  const matches = sortVisibleDareItems(
-    matchingVisibleDareItems(rows, search, input.viewerDiscordId).filter(
-      (item) =>
-        (input.states === undefined || input.states.includes(item.state)) &&
-        hasViewerRole(item, input.role) &&
-        (input.scope !== "needs_action" || item.requiresViewerAction),
-    ),
-    input.sort ?? (input.scope === "needs_action" ? "needs_action" : "updated"),
-  );
+  const matches = indexVisibleDaresV2({
+    rows,
+    viewerDiscordId: input.viewerDiscordId,
+    search,
+    states: input.states,
+    role: input.role,
+    needsAction: input.scope === "needs_action",
+    sort:
+      input.sort ??
+      (input.scope === "needs_action" ? "needs_action" : "updated"),
+  });
   const cursorIndex =
     input.cursor === undefined
       ? -1
       : matches.findIndex((item) => item.id.toString() === input.cursor);
   const start = cursorIndex + 1;
   const limit = input.limit ?? VISIBLE_DARE_PAGE_SIZE;
-  const items = matches.slice(start, start + limit);
-  const last = items.at(-1);
+  const pageIndex = matches.slice(start, start + limit);
+  const pageRows = await prisma.bucksDareV2.findMany({
+    where: { id: { in: pageIndex.map((item) => item.id) } },
+    include: includeVisibleDare,
+  });
+  const pageRowsById = new Map(pageRows.map((row) => [row.id, row]));
+  const items = pageIndex.map((item) => {
+    const row = pageRowsById.get(item.id);
+    if (row === undefined) {
+      throw new Error(
+        `Dare v2 ${item.id.toString()} disappeared while paging.`,
+      );
+    }
+    return listItem(row, input.viewerDiscordId);
+  });
+  const last = pageIndex.at(-1);
   return DareV2ListPageSchema.parse({
     items,
     nextCursor:

--- a/packages/scout-for-lol/packages/backend/src/betting/dare-void-v2.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/dare-void-v2.ts
@@ -5,6 +5,7 @@ import {
   refundDareV2ContributionsInTransaction,
 } from "#src/betting/dare-ledger-v2.ts";
 import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { enqueueDareNotificationInTransaction } from "#src/betting/dare-notification-outbox.ts";
 
 export type RefundableDareV2Row = Prisma.BucksDareV2GetPayload<{
   include: { targets: true };
@@ -54,6 +55,15 @@ export async function voidDareV2WithFullRefund(
       resolution: "voided",
       withCut: false,
       voidReason: reason,
+    });
+    await enqueueDareNotificationInTransaction(tx, {
+      dareId: dare.id,
+      revision: dare.fundedRevision ?? dare.currentRevision,
+      category: "lifecycle",
+      kind: "voided",
+      summary: `The Dare was voided (${reason.replaceAll("_", " ")}); ${dare.potTotal.toString()} Bryan Bucks were fully refunded.`,
+      deduplicationKey: `dare:${dare.id.toString()}:revision:${(dare.fundedRevision ?? dare.currentRevision).toString()}:voided`,
+      occurredAt: now,
     });
     return true;
   });

--- a/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.test.ts
@@ -33,6 +33,8 @@ describe("Bryan Bucks notification preferences", () => {
     ).resolves.toEqual({
       ownBetSettlementDms: true,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: null,
     });
   });
@@ -65,6 +67,8 @@ describe("Bryan Bucks notification preferences", () => {
     ).resolves.toEqual({
       ownBetSettlementDms: false,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: null,
     });
 
@@ -80,6 +84,8 @@ describe("Bryan Bucks notification preferences", () => {
     ).resolves.toEqual({
       ownBetSettlementDms: false,
       betsOnPlayerSettlementDms: false,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: null,
     });
   });
@@ -90,16 +96,20 @@ describe("Bryan Bucks notification preferences", () => {
         {
           ownBetSettlementDms: true,
           betsOnPlayerSettlementDms: false,
+          dareLifecycleDms: true,
+          dareProgressDms: true,
           settlementDmHintShownAt: null,
         },
         {},
       ),
-    ).toContain("Use `your_bets` or `bets_on_you`");
+    ).toContain("Choose any notification option");
     expect(
       formatBucksNotificationPreferences(
         {
           ownBetSettlementDms: false,
           betsOnPlayerSettlementDms: true,
+          dareLifecycleDms: true,
+          dareProgressDms: true,
           settlementDmHintShownAt: null,
         },
         { ownBetSettlementDms: false },
@@ -121,6 +131,8 @@ describe("Bryan Bucks notification preferences", () => {
       getNotificationPreferences: async () => ({
         ownBetSettlementDms: values.get("your_bets") ?? true,
         betsOnPlayerSettlementDms: values.get("bets_on_you") ?? true,
+        dareLifecycleDms: true,
+        dareProgressDms: true,
         settlementDmHintShownAt: null,
       }),
       updateNotificationPreferences: async ({ updates }) => {
@@ -133,6 +145,8 @@ describe("Bryan Bucks notification preferences", () => {
         return {
           ownBetSettlementDms: values.get("your_bets") ?? true,
           betsOnPlayerSettlementDms: values.get("bets_on_you") ?? true,
+          dareLifecycleDms: true,
+          dareProgressDms: true,
           settlementDmHintShownAt: null,
         };
       },

--- a/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/notification-preferences.ts
@@ -9,17 +9,23 @@ import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 export type BucksNotificationPreferences = {
   ownBetSettlementDms: boolean;
   betsOnPlayerSettlementDms: boolean;
+  dareLifecycleDms: boolean;
+  dareProgressDms: boolean;
   settlementDmHintShownAt: Date | null;
 };
 
 export type BucksNotificationPreferenceUpdates = {
   ownBetSettlementDms?: boolean;
   betsOnPlayerSettlementDms?: boolean;
+  dareLifecycleDms?: boolean;
+  dareProgressDms?: boolean;
 };
 
 const DEFAULT_PREFERENCES: BucksNotificationPreferences = {
   ownBetSettlementDms: true,
   betsOnPlayerSettlementDms: true,
+  dareLifecycleDms: true,
+  dareProgressDms: true,
   settlementDmHintShownAt: null,
 };
 
@@ -39,6 +45,8 @@ function preferencesFromRow(
   row: {
     ownBetSettlementDms: boolean;
     betsOnPlayerSettlementDms: boolean;
+    dareLifecycleDms: boolean;
+    dareProgressDms: boolean;
     settlementDmHintShownAt: Date | null;
   } | null,
 ): BucksNotificationPreferences {
@@ -47,6 +55,8 @@ function preferencesFromRow(
     : {
         ownBetSettlementDms: row.ownBetSettlementDms,
         betsOnPlayerSettlementDms: row.betsOnPlayerSettlementDms,
+        dareLifecycleDms: row.dareLifecycleDms,
+        dareProgressDms: row.dareProgressDms,
         settlementDmHintShownAt: row.settlementDmHintShownAt,
       };
 }
@@ -62,6 +72,8 @@ export async function getBucksNotificationPreferences(
     select: {
       ownBetSettlementDms: true,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: true,
     },
   });
@@ -83,6 +95,8 @@ export async function getBucksNotificationPreferencesForUsers(
       discordId: true,
       ownBetSettlementDms: true,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: true,
     },
   });
@@ -101,7 +115,9 @@ export async function updateBucksNotificationPreferences(
   const discordId = DiscordAccountIdSchema.parse(input.discordId);
   if (
     input.updates.ownBetSettlementDms === undefined &&
-    input.updates.betsOnPlayerSettlementDms === undefined
+    input.updates.betsOnPlayerSettlementDms === undefined &&
+    input.updates.dareLifecycleDms === undefined &&
+    input.updates.dareProgressDms === undefined
   ) {
     return await getBucksNotificationPreferences(
       { serverId, discordId },
@@ -117,6 +133,8 @@ export async function updateBucksNotificationPreferences(
       ownBetSettlementDms: input.updates.ownBetSettlementDms ?? true,
       betsOnPlayerSettlementDms:
         input.updates.betsOnPlayerSettlementDms ?? true,
+      dareLifecycleDms: input.updates.dareLifecycleDms ?? true,
+      dareProgressDms: input.updates.dareProgressDms ?? true,
     },
     update: {
       ...(input.updates.ownBetSettlementDms === undefined
@@ -127,10 +145,18 @@ export async function updateBucksNotificationPreferences(
         : {
             betsOnPlayerSettlementDms: input.updates.betsOnPlayerSettlementDms,
           }),
+      ...(input.updates.dareLifecycleDms === undefined
+        ? {}
+        : { dareLifecycleDms: input.updates.dareLifecycleDms }),
+      ...(input.updates.dareProgressDms === undefined
+        ? {}
+        : { dareProgressDms: input.updates.dareProgressDms }),
     },
     select: {
       ownBetSettlementDms: true,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: true,
     },
   });
@@ -150,6 +176,8 @@ export async function markBucksSettlementDmHintShown(
       discordId,
       ownBetSettlementDms: true,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
       settlementDmHintShownAt: new Date(),
     },
     update: { settlementDmHintShownAt: new Date() },

--- a/packages/scout-for-lol/packages/backend/src/betting/postmatch-hook.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/postmatch-hook.ts
@@ -31,6 +31,7 @@ import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
 import { isFeatureHardDisabled } from "#src/configuration/flags.ts";
 import { captureWeeklyParlayContributions } from "#src/betting/weekly-parlay-contribution.ts";
 import { createLogger } from "#src/logger.ts";
+import { deliverPendingDareNotifications } from "#src/betting/dare-notification-delivery.ts";
 
 const logger = createLogger("betting-postmatch-hook");
 
@@ -160,6 +161,7 @@ export async function settleAndAwardBucks(
     ...defaultDareV2CalloutDependencies,
     prismaClient,
   });
+  await deliverPendingDareNotifications(prismaClient);
   let dareSettlements: DareSettlementSummary[];
   try {
     dareSettlements = await settleDaresForMatch(matchData, prismaClient);

--- a/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/betting/settlement-dm.test.ts
@@ -403,6 +403,8 @@ describe("Bryan Bucks settlement DM notification hint", () => {
             {
               ownBetSettlementDms: true,
               betsOnPlayerSettlementDms: true,
+              dareLifecycleDms: true,
+              dareProgressDms: true,
               settlementDmHintShownAt: hintShownAt,
             },
           ],
@@ -450,6 +452,8 @@ describe("Bryan Bucks settlement DM notification hint", () => {
             {
               ownBetSettlementDms: true,
               betsOnPlayerSettlementDms: true,
+              dareLifecycleDms: true,
+              dareProgressDms: true,
               settlementDmHintShownAt: null,
             },
           ],
@@ -487,6 +491,8 @@ describe("Bryan Bucks settlement DM notification hint", () => {
               {
                 ownBetSettlementDms: true,
                 betsOnPlayerSettlementDms: true,
+                dareLifecycleDms: true,
+                dareProgressDms: true,
                 settlementDmHintShownAt: new Date(0),
               },
             ],

--- a/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
+++ b/packages/scout-for-lol/packages/backend/src/configuration/flags.ts
@@ -145,6 +145,8 @@ export type FlagName =
   | "betting_enabled"
   | "bucks_dares_enabled"
   | "dare_v2"
+  | "dare_extended_contracts_enabled"
+  | "dare_notifications_enabled"
   | "bucks_transfers_enabled"
   | "weekly_parlays_enabled"
   | "betting_player_bet_outcome_dm_enabled"
@@ -174,6 +176,8 @@ const PRODUCTION_HARD_DISABLED_FLAGS: ReadonlySet<FlagName> = new Set<FlagName>(
     "betting_enabled",
     "bucks_dares_enabled",
     "dare_v2",
+    "dare_extended_contracts_enabled",
+    "dare_notifications_enabled",
     "bucks_transfers_enabled",
     "weekly_parlays_enabled",
     "betting_player_bet_outcome_dm_enabled",
@@ -269,6 +273,14 @@ const FLAG_REGISTRY: Record<FlagName, FlagConfig> = {
   dare_v2: {
     default: false,
     overrides: [{ value: true, attributes: { server: MY_SERVER } }],
+  },
+  dare_extended_contracts_enabled: {
+    default: false,
+    overrides: [],
+  },
+  dare_notifications_enabled: {
+    default: false,
+    overrides: [],
   },
   // Relational/timeline ScoutQL access is an independently ramped capability
   // because it exposes a wider query surface than Dare v2 creation itself.

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-definition.ts
@@ -66,7 +66,7 @@ export const bbCommand = new SlashCommandBuilder()
   .addSubcommand((sub) =>
     sub
       .setName("notifications")
-      .setDescription("Choose which Bryan Bucks settlement DMs you receive")
+      .setDescription("Choose which Bryan Bucks DMs you receive")
       .addStringOption((option) =>
         option
           .setName("your_bets")
@@ -80,6 +80,24 @@ export const bbCommand = new SlashCommandBuilder()
         option
           .setName("bets_on_you")
           .setDescription("DMs about bets other users placed on you")
+          .addChoices(
+            { name: "On", value: "on" },
+            { name: "Off", value: "off" },
+          ),
+      )
+      .addStringOption((option) =>
+        option
+          .setName("dare_lifecycle")
+          .setDescription("DMs when a Dare changes lifecycle state")
+          .addChoices(
+            { name: "On", value: "on" },
+            { name: "Off", value: "off" },
+          ),
+      )
+      .addStringOption((option) =>
+        option
+          .setName("dare_progress")
+          .setDescription("DMs when a Dare makes material progress")
           .addChoices(
             { name: "On", value: "on" },
             { name: "Off", value: "off" },

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/bb-notifications.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/bb-notifications.ts
@@ -34,6 +34,12 @@ export function formatBucksNotificationPreferences(
     updates.betsOnPlayerSettlementDms === undefined
       ? undefined
       : `bets on you ${updates.betsOnPlayerSettlementDms ? "on" : "off"}`,
+    updates.dareLifecycleDms === undefined
+      ? undefined
+      : `Dare lifecycle ${updates.dareLifecycleDms ? "on" : "off"}`,
+    updates.dareProgressDms === undefined
+      ? undefined
+      : `Dare progress ${updates.dareProgressDms ? "on" : "off"}`,
   ].filter((value) => value !== undefined);
   return [
     "🔔 **Bryan Bucks notifications**",
@@ -42,8 +48,10 @@ export function formatBucksNotificationPreferences(
       "Bets other users placed on me",
       preferences.betsOnPlayerSettlementDms,
     ),
+    notificationStatusLine("Dare lifecycle", preferences.dareLifecycleDms),
+    notificationStatusLine("Dare progress", preferences.dareProgressDms),
     changed.length === 0
-      ? "Use `your_bets` or `bets_on_you` with `on` or `off` to change these settings."
+      ? "Choose any notification option with `on` or `off` to change these settings."
       : `Updated: ${changed.join(", ")}.`,
   ].join("\n");
 }
@@ -60,14 +68,25 @@ export async function replyBbNotifications(
   const betsOnPlayerSettlementDms = notificationToggle(
     interaction.options.getString("bets_on_you"),
   );
+  const dareLifecycleDms = notificationToggle(
+    interaction.options.getString("dare_lifecycle"),
+  );
+  const dareProgressDms = notificationToggle(
+    interaction.options.getString("dare_progress"),
+  );
   const updates: BucksNotificationPreferenceUpdates = {
     ...(ownBetSettlementDms === undefined ? {} : { ownBetSettlementDms }),
     ...(betsOnPlayerSettlementDms === undefined
       ? {}
       : { betsOnPlayerSettlementDms }),
+    ...(dareLifecycleDms === undefined ? {} : { dareLifecycleDms }),
+    ...(dareProgressDms === undefined ? {} : { dareProgressDms }),
   };
   const preferences =
-    ownBetSettlementDms === undefined && betsOnPlayerSettlementDms === undefined
+    ownBetSettlementDms === undefined &&
+    betsOnPlayerSettlementDms === undefined &&
+    dareLifecycleDms === undefined &&
+    dareProgressDms === undefined
       ? await (
           dependencies.getNotificationPreferences ??
           getBucksNotificationPreferences

--- a/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/commands/definitions.test.ts
@@ -147,7 +147,7 @@ describe("registered Discord commands", () => {
     expect(notifications).toEqual(
       expect.objectContaining({
         name: "notifications",
-        description: "Choose which Bryan Bucks settlement DMs you receive",
+        description: "Choose which Bryan Bucks DMs you receive",
       }),
     );
     expect(notifications.options).toEqual([
@@ -161,6 +161,22 @@ describe("registered Discord commands", () => {
       }),
       expect.objectContaining({
         name: "bets_on_you",
+        required: false,
+        choices: [
+          { name: "On", value: "on" },
+          { name: "Off", value: "off" },
+        ],
+      }),
+      expect.objectContaining({
+        name: "dare_lifecycle",
+        required: false,
+        choices: [
+          { name: "On", value: "on" },
+          { name: "Off", value: "off" },
+        ],
+      }),
+      expect.objectContaining({
+        name: "dare_progress",
         required: false,
         choices: [
           { name: "On", value: "on" },

--- a/packages/scout-for-lol/packages/backend/src/discord/utils/dm.ts
+++ b/packages/scout-for-lol/packages/backend/src/discord/utils/dm.ts
@@ -54,6 +54,7 @@ export const DmKindSchema = z.enum([
   "data_validation",
   "betting_settlement_receipt",
   "betting_player_bet_outcome",
+  "dare_notification",
 ]);
 export type DmKind = z.infer<typeof DmKindSchema>;
 
@@ -104,6 +105,7 @@ const CORE_DM_KINDS: ReadonlySet<string> = new Set([
   "data_validation",
   "betting_settlement_receipt",
   "betting_player_bet_outcome",
+  "dare_notification",
 ]);
 
 export type SendDmOptions = {

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/dare-v2-recovery.test.ts
@@ -11,9 +11,12 @@ const mocks = vi.hoisted(() => ({
   closeExpiredBettingWindows: vi.fn(async () => []),
   closeExpiredParlayWindows: vi.fn(async () => []),
   deliverDareSummaries: vi.fn(() => Promise.resolve()),
+  deliverPendingDareNotifications: vi.fn(() => Promise.resolve()),
   expireDareAcceptWindows: vi.fn(async () => []),
   expireDareV2AcceptWindows: vi.fn(async () => [17]),
   getPostmatchMessageIds: vi.fn(async () => new Map<string, string>()),
+  markPostMatchPollCompleted: vi.fn(() => Promise.resolve()),
+  markPostMatchPollFailed: vi.fn(() => Promise.resolve()),
   refreshClosedBucksMessages: vi.fn(() => Promise.resolve()),
   refreshClosedParlayMessages: vi.fn(() => Promise.resolve()),
   refreshPendingDareV2Callouts: vi.fn(() => Promise.resolve([])),
@@ -40,6 +43,13 @@ vi.mock("#src/betting/dare-sweep.ts", () => ({
 }));
 vi.mock("#src/betting/dare-delivery.ts", () => ({
   deliverDareSummaries: mocks.deliverDareSummaries,
+}));
+vi.mock("#src/betting/dare-notification-delivery.ts", () => ({
+  deliverPendingDareNotifications: mocks.deliverPendingDareNotifications,
+}));
+vi.mock("#src/league/tasks/recovery/app-state.ts", () => ({
+  markPostMatchPollCompleted: mocks.markPostMatchPollCompleted,
+  markPostMatchPollFailed: mocks.markPostMatchPollFailed,
 }));
 vi.mock("#src/betting/dare-sweep-v2.ts", () => ({
   expireDareV2AcceptWindows: mocks.expireDareV2AcceptWindows,
@@ -78,6 +88,7 @@ vi.mock("#src/league/tasks/prematch/active-game-queries.ts", () => ({
 }));
 vi.mock("#src/configuration/flags.ts", () => ({
   isFeatureHardDisabled: () => true,
+  isPolicyEnabled: () => Promise.resolve(false),
 }));
 vi.mock("#src/logger.ts", () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn() }),
@@ -107,6 +118,9 @@ describe("Dare v2 recovery", () => {
     expect(mocks.checkMatchHistory).toHaveBeenCalledOnce();
     expect(mocks.settleEndedDareV2Windows).toHaveBeenCalledOnce();
     expect(mocks.refreshPendingDareV2Callouts).toHaveBeenCalledOnce();
+    expect(mocks.deliverPendingDareNotifications).toHaveBeenCalledOnce();
+    expect(mocks.markPostMatchPollCompleted).toHaveBeenCalledOnce();
+    expect(mocks.markPostMatchPollFailed).not.toHaveBeenCalled();
     expect(mocks.retryPendingBucksEarnings).not.toHaveBeenCalled();
     expect(mocks.settleEndedDareWindows).not.toHaveBeenCalled();
     expect(mocks.voidStaleBettingPools).not.toHaveBeenCalled();

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/index.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/index.ts
@@ -15,6 +15,11 @@ import { MatchIdSchema } from "@scout-for-lol/data/index.ts";
 import { runMaintenanceSteps } from "#src/league/tasks/maintenance-steps.ts";
 import { createLogger } from "#src/logger.ts";
 import { isFeatureHardDisabled } from "#src/configuration/flags.ts";
+import { deliverPendingDareNotifications } from "#src/betting/dare-notification-delivery.ts";
+import {
+  markPostMatchPollCompleted,
+  markPostMatchPollFailed,
+} from "#src/league/tasks/recovery/app-state.ts";
 
 const logger = createLogger("tasks-postmatch");
 
@@ -119,6 +124,12 @@ export async function runPostMatchMaintenance(options?: {
         }
       },
     },
+    {
+      name: "dare notification delivery",
+      run: async () => {
+        await deliverPendingDareNotifications();
+      },
+    },
   ];
   if (!bettingHardDisabled) {
     steps.push(
@@ -155,7 +166,17 @@ export async function runPostMatchMaintenance(options?: {
   }
   // Isolated per step, then re-thrown: a persistently failing recovery path
   // cannot starve the remaining clocks while money stays escrowed.
-  await runMaintenanceSteps("post-match maintenance", steps);
+  try {
+    await runMaintenanceSteps("post-match maintenance", steps);
+    await markPostMatchPollCompleted({
+      completedAt: new Date(),
+      evidenceComplete: settleDareV2Deadlines,
+      evidenceWatermark: options?.dareEvidenceWatermark,
+    });
+  } catch (error) {
+    await markPostMatchPollFailed(error, new Date());
+    throw error;
+  }
   return { dareSummaries };
 }
 

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/postmatch/match-history-polling.ts
@@ -22,7 +22,11 @@ import {
 import type { settleAndAwardBucks } from "#src/betting/postmatch-hook.ts";
 import { settleBucksWithDareTimelineV2 } from "#src/betting/dare-postmatch-timeline-v2.ts";
 import { matchHistoryPollingSkipsTotal } from "#src/metrics/index.ts";
-import { setLastSuccessfulPollAt } from "#src/league/tasks/recovery/app-state.ts";
+import {
+  markPostMatchPollCompleted,
+  markPostMatchPollFailed,
+  markPostMatchPollStarted,
+} from "#src/league/tasks/recovery/app-state.ts";
 import { recordMatchForReportStore } from "#src/report-store/live-ingest.ts";
 import { getPostmatchMessageIdsForMatchIdOrEmpty } from "#src/league/tasks/prematch/active-game-queries.ts";
 import { getPuuidsBlockedFromLivePolling } from "#src/league/initial-history/live-polling.ts";
@@ -399,6 +403,7 @@ export async function discoverPostMatchIntents(): Promise<{
   isPollingInProgress = true;
   pollingStartTime = Date.now();
   try {
+    await markPostMatchPollStarted(new Date(pollingStartTime));
     const discovery = await collectMatchDiscovery();
     if (!discovery.complete) {
       logger.warn(
@@ -406,12 +411,14 @@ export async function discoverPostMatchIntents(): Promise<{
       );
       return { matches: [], evidenceComplete: false };
     }
-    await setLastSuccessfulPollAt(new Date());
     return {
       matches: discovery.intents,
       evidenceComplete: true,
       evidenceWatermark: discovery.evidenceWatermark.toISOString(),
     };
+  } catch (error) {
+    await markPostMatchPollFailed(error, new Date());
+    throw error;
   } finally {
     isPollingInProgress = false;
     pollingStartTime = undefined;
@@ -437,11 +444,17 @@ export async function checkMatchHistory(): Promise<{
   const startTime = Date.now();
 
   try {
+    await markPostMatchPollStarted(new Date(pollingStartTime));
     const discovery = await collectMatchDiscovery();
     if (!discovery.complete) {
       logger.warn(
         "Match discovery evidence is incomplete; leaving ingestion cursors unchanged",
       );
+      await markPostMatchPollCompleted({
+        completedAt: new Date(),
+        evidenceComplete: false,
+        evidenceWatermark: discovery.evidenceWatermark,
+      });
       return { evidenceComplete: false };
     }
     if (discovery.intents.length === 0) {
@@ -450,7 +463,11 @@ export async function checkMatchHistory(): Promise<{
       logger.info(
         `⏱️  Match history check completed in ${totalTime.toString()}ms`,
       );
-      await setLastSuccessfulPollAt(new Date());
+      await markPostMatchPollCompleted({
+        completedAt: new Date(),
+        evidenceComplete: true,
+        evidenceWatermark: discovery.evidenceWatermark,
+      });
       return {
         evidenceComplete: true,
         evidenceWatermark: discovery.evidenceWatermark,
@@ -491,13 +508,18 @@ export async function checkMatchHistory(): Promise<{
       `📊 Processed ${processedMatchIds.size.toString()} unique match(es)`,
     );
 
-    await setLastSuccessfulPollAt(new Date());
+    await markPostMatchPollCompleted({
+      completedAt: new Date(),
+      evidenceComplete: true,
+      evidenceWatermark: discovery.evidenceWatermark,
+    });
     return {
       evidenceComplete: true,
       evidenceWatermark: discovery.evidenceWatermark,
     };
   } catch (error) {
     logger.error("❌ Error in match history check:", error);
+    await markPostMatchPollFailed(error, new Date());
     throw error;
   } finally {
     isPollingInProgress = false;

--- a/packages/scout-for-lol/packages/backend/src/league/tasks/recovery/app-state.ts
+++ b/packages/scout-for-lol/packages/backend/src/league/tasks/recovery/app-state.ts
@@ -1,4 +1,5 @@
-import { prisma } from "#src/database/index.ts";
+import { prisma, type ExtendedPrismaClient } from "#src/database/index.ts";
+import { getErrorMessage } from "#src/utils/errors.ts";
 
 const BOT_STATE_ID = 1;
 
@@ -14,5 +15,87 @@ export async function setLastSuccessfulPollAt(date: Date): Promise<void> {
     where: { id: BOT_STATE_ID },
     update: { lastSuccessfulPollAt: date },
     create: { id: BOT_STATE_ID, lastSuccessfulPollAt: date },
+  });
+}
+
+export async function markPostMatchPollStarted(
+  startedAt: Date,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  await prismaClient.botState.upsert({
+    where: { id: BOT_STATE_ID },
+    update: {
+      pollStartedAt: startedAt,
+      pollCompletedAt: null,
+      pollEvidenceComplete: null,
+      pollFailureReason: null,
+      pollStatus: "running",
+    },
+    create: {
+      id: BOT_STATE_ID,
+      pollStartedAt: startedAt,
+      pollStatus: "running",
+    },
+  });
+}
+
+export async function markPostMatchPollCompleted(
+  input: {
+    completedAt: Date;
+    evidenceComplete: boolean;
+    evidenceWatermark?: Date | undefined;
+  },
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  await prismaClient.botState.upsert({
+    where: { id: BOT_STATE_ID },
+    update: {
+      ...(input.evidenceComplete
+        ? { lastSuccessfulPollAt: input.completedAt }
+        : {}),
+      pollCompletedAt: input.completedAt,
+      pollEvidenceComplete: input.evidenceComplete,
+      evidenceWatermarkAt: input.evidenceWatermark ?? null,
+      pollFailureReason: input.evidenceComplete
+        ? null
+        : "Match discovery evidence was incomplete.",
+      pollStatus: input.evidenceComplete ? "healthy" : "incomplete",
+    },
+    create: {
+      id: BOT_STATE_ID,
+      ...(input.evidenceComplete
+        ? { lastSuccessfulPollAt: input.completedAt }
+        : {}),
+      pollCompletedAt: input.completedAt,
+      pollEvidenceComplete: input.evidenceComplete,
+      evidenceWatermarkAt: input.evidenceWatermark ?? null,
+      pollFailureReason: input.evidenceComplete
+        ? null
+        : "Match discovery evidence was incomplete.",
+      pollStatus: input.evidenceComplete ? "healthy" : "incomplete",
+    },
+  });
+}
+
+export async function markPostMatchPollFailed(
+  error: unknown,
+  failedAt: Date,
+  prismaClient: ExtendedPrismaClient = prisma,
+): Promise<void> {
+  await prismaClient.botState.upsert({
+    where: { id: BOT_STATE_ID },
+    update: {
+      pollCompletedAt: failedAt,
+      pollEvidenceComplete: false,
+      pollFailureReason: getErrorMessage(error),
+      pollStatus: "failed",
+    },
+    create: {
+      id: BOT_STATE_ID,
+      pollCompletedAt: failedAt,
+      pollEvidenceComplete: false,
+      pollFailureReason: getErrorMessage(error),
+      pollStatus: "failed",
+    },
   });
 }

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-dare-action-procedures.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import { tryEnsureDareV2Callout } from "#src/betting/dare-callout-v2.ts";
+import { deleteDareDraftV2 } from "#src/betting/dare-draft-v2.ts";
+import { listDareEvidenceV2 } from "#src/betting/dare-evidence-view-v2.ts";
+import { consumeDareV2ConfirmationIntent } from "#src/betting/dare-intent-consume-v2.ts";
+import {
+  createDareV2ConfirmationIntent,
+  DareV2IntentPayloadSchema,
+} from "#src/betting/dare-intent-v2.ts";
+import { assertBucksScope } from "#src/consumer/bucks-access.ts";
+import { prisma } from "#src/database/index.ts";
+import { webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
+
+const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
+const DareInput = GuildInput.extend({ dareId: z.number().int().positive() });
+const DareEvidenceInput = DareInput.extend({
+  cursor: z.string().min(1).optional(),
+  limit: z.number().int().min(1).max(25).optional(),
+});
+const DarePrepareActionInput = DareInput.extend({
+  expectedRevision: z.number().int().positive(),
+  payload: DareV2IntentPayloadSchema,
+  idempotencyKey: z.uuid(),
+});
+const DareConfirmActionInput = GuildInput.extend({ intentId: z.uuid() });
+const DareDeleteDraftInput = DareInput.extend({
+  expectedRevision: z.number().int().positive(),
+});
+
+export const bucksDareActionProcedures = {
+  dareEvidence: webProcedure
+    .input(DareEvidenceInput)
+    .query(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const page = await listDareEvidenceV2(
+        {
+          dareId: input.dareId,
+          serverId: input.guildId,
+          viewerDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+          ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
+          ...(input.limit === undefined ? {} : { limit: input.limit }),
+        },
+        prisma,
+      );
+      if (page === null) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Dare not found." });
+      }
+      return page;
+    }),
+
+  darePrepareAction: webMutationProcedure
+    .input(DarePrepareActionInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const outcome = await createDareV2ConfirmationIntent({
+        dareId: input.dareId,
+        serverId: input.guildId,
+        actorDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+        expectedRevision: input.expectedRevision,
+        payload: input.payload,
+        idempotencyKey: input.idempotencyKey,
+      });
+      if (outcome.kind !== "intent_created") return outcome;
+      const dare = await prisma.bucksDareV2.findUniqueOrThrow({
+        where: { id: input.dareId },
+        select: {
+          openingStake: true,
+          potTotal: true,
+          targets: { orderBy: { id: "asc" }, select: { alias: true } },
+        },
+      });
+      const amount =
+        input.payload.action === "contribute"
+          ? `${input.payload.amount.toString()} BB to a ${dare.potTotal.toString()} BB pot`
+          : input.payload.action === "fund"
+            ? `${dare.openingStake.toString()} BB`
+            : null;
+      return {
+        ...outcome,
+        confirmation: {
+          action: input.payload.action,
+          amount,
+          targets: dare.targets.map((target) => target.alias),
+          irreversible: ["fund", "accept", "contribute"].includes(
+            input.payload.action,
+          ),
+        },
+      };
+    }),
+
+  dareConfirmAction: webMutationProcedure
+    .input(DareConfirmActionInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const intent = await prisma.bucksDareV2ConfirmationIntent.findUnique({
+        where: { id: input.intentId },
+        select: { dareId: true },
+      });
+      const outcome = await consumeDareV2ConfirmationIntent({
+        intentId: input.intentId,
+        serverId: input.guildId,
+        actorDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+      });
+      const failed = [
+        "not_found",
+        "forbidden",
+        "intent_expired",
+        "feature_disabled",
+        "insufficient",
+      ].includes(outcome.kind);
+      const callout =
+        intent === null || failed
+          ? null
+          : await tryEnsureDareV2Callout(intent.dareId);
+      return { ...outcome, callout };
+    }),
+
+  dareDeleteDraft: webMutationProcedure
+    .input(DareDeleteDraftInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      return await deleteDareDraftV2({
+        dareId: input.dareId,
+        serverId: input.guildId,
+        challengerDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+        expectedRevision: input.expectedRevision,
+      });
+    }),
+};

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-notification-procedures.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks-notification-procedures.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import {
+  DiscordAccountIdSchema,
+  DiscordGuildIdSchema,
+} from "@scout-for-lol/data";
+import {
+  getBucksNotificationPreferences,
+  updateBucksNotificationPreferences,
+} from "#src/betting/notification-preferences.ts";
+import { assertBucksScope } from "#src/consumer/bucks-access.ts";
+import { webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
+
+const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
+
+function publicPreferences(preferences: {
+  ownBetSettlementDms: boolean;
+  betsOnPlayerSettlementDms: boolean;
+  dareLifecycleDms: boolean;
+  dareProgressDms: boolean;
+}) {
+  return {
+    ownBetSettlementDms: preferences.ownBetSettlementDms,
+    betsOnPlayerSettlementDms: preferences.betsOnPlayerSettlementDms,
+    dareLifecycleDms: preferences.dareLifecycleDms,
+    dareProgressDms: preferences.dareProgressDms,
+  };
+}
+
+export const bucksNotificationProcedures = {
+  notificationPreferences: webProcedure
+    .input(GuildInput)
+    .query(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const preferences = await getBucksNotificationPreferences({
+        serverId: input.guildId,
+        discordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+      });
+      return publicPreferences(preferences);
+    }),
+
+  setNotificationPreferences: webMutationProcedure
+    .input(
+      GuildInput.extend({
+        ownBetSettlementDms: z.boolean().optional(),
+        betsOnPlayerSettlementDms: z.boolean().optional(),
+        dareLifecycleDms: z.boolean().optional(),
+        dareProgressDms: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertBucksScope(ctx.user, input.guildId);
+      const preferences = await updateBucksNotificationPreferences({
+        serverId: input.guildId,
+        discordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
+        updates: {
+          ...(input.ownBetSettlementDms === undefined
+            ? {}
+            : { ownBetSettlementDms: input.ownBetSettlementDms }),
+          ...(input.betsOnPlayerSettlementDms === undefined
+            ? {}
+            : {
+                betsOnPlayerSettlementDms: input.betsOnPlayerSettlementDms,
+              }),
+          ...(input.dareLifecycleDms === undefined
+            ? {}
+            : { dareLifecycleDms: input.dareLifecycleDms }),
+          ...(input.dareProgressDms === undefined
+            ? {}
+            : { dareProgressDms: input.dareProgressDms }),
+        },
+      });
+      return publicPreferences(preferences);
+    }),
+};

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.test.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.test.ts
@@ -350,7 +350,7 @@ describe("bucks reads", () => {
   test("Dare management is scoped to an explicit shared guild", async () => {
     await expect(
       caller().bucks.dareList({ guildId, scope: "mine" }),
-    ).resolves.toEqual([]);
+    ).resolves.toEqual({ items: [], nextCursor: null });
     await expect(
       caller().bucks.dareList({ guildId: otherGuildId, scope: "guild" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
@@ -523,6 +523,8 @@ describe("bucks reads", () => {
     expect(defaults).toEqual({
       ownBetSettlementDms: true,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
     });
     const updated = await caller().bucks.setNotificationPreferences({
       guildId,
@@ -531,6 +533,8 @@ describe("bucks reads", () => {
     expect(updated).toEqual({
       ownBetSettlementDms: false,
       betsOnPlayerSettlementDms: true,
+      dareLifecycleDms: true,
+      dareProgressDms: true,
     });
     const reread = await caller().bucks.notificationPreferences({ guildId });
     expect(reread).toEqual(updated);

--- a/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.ts
+++ b/packages/scout-for-lol/packages/backend/src/trpc/router/bucks.router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import {
   BucksParlaySideSchema,
+  BucksDareV2StateSchema,
   BucksPoolRosterSchema,
   BucksStakeSchema,
   DiscordAccountIdSchema,
@@ -21,15 +22,11 @@ import { cancelBet } from "#src/betting/cancel-bet.ts";
 import { bettingAnchor } from "#src/betting/components.ts";
 import {
   inspectVisibleDareV2,
-  listVisibleDaresV2,
+  listVisibleDarePageV2,
 } from "#src/betting/dare-view-v2.ts";
 import { cancellationHouseCut } from "#src/betting/house-cut.ts";
 import { refreshBucksMessages } from "#src/betting/message-refresh.ts";
 import { ledgerKindLabel } from "#src/betting/navigation.ts";
-import {
-  getBucksNotificationPreferences,
-  updateBucksNotificationPreferences,
-} from "#src/betting/notification-preferences.ts";
 import { getOpenMarketsView } from "#src/betting/open-market-view.ts";
 import { placeBet } from "#src/betting/place-bet.ts";
 import { placeParlayBet } from "#src/betting/parlay-place-bet.ts";
@@ -53,14 +50,21 @@ import {
   validateDareDraftEditorV2,
 } from "#src/explore/dare-editor-v2.ts";
 import { router, webMutationProcedure, webProcedure } from "#src/trpc/trpc.ts";
+import { bucksDareActionProcedures } from "#src/trpc/router/bucks-dare-action-procedures.ts";
+import { bucksNotificationProcedures } from "#src/trpc/router/bucks-notification-procedures.ts";
 
 const GuildInput = z.object({ guildId: DiscordGuildIdSchema });
 const MatchInput = GuildInput.extend({
   matchId: z.string().min(1).max(64),
 });
 const DareListInput = GuildInput.extend({
-  scope: z.enum(["mine", "guild"]),
+  scope: z.enum(["mine", "guild", "needs_action"]),
   search: z.string().min(1).max(100).optional(),
+  states: z.array(BucksDareV2StateSchema).max(9).optional(),
+  role: z.enum(["challenger", "target", "contributor", "involved"]).optional(),
+  sort: z.enum(["needs_action", "deadline", "updated"]).optional(),
+  cursor: z.string().min(1).optional(),
+  limit: z.number().int().min(1).max(50).optional(),
 });
 const DareInspectInput = GuildInput.extend({
   dareId: z.number().int().positive(),
@@ -116,19 +120,7 @@ async function captureWebActivity(
   });
 }
 
-/**
- * The Bryan Bucks web surface.
- *
- * Every read model and mutation delegates to the existing `src/betting/`
- * domain functions — the guarded-conditional-write transactions, post-commit
- * metrics, and ledger chokepoint all live there and are shared verbatim with
- * the Discord surface. Mutations additionally enqueue the same serialized
- * Discord market-message refresh the `/bb` handlers use, so the channel copy
- * never goes stale because a Buck moved from a browser.
- *
- * Every procedure except `status` takes an explicit `guildId` validated
- * against the caller's resolved scope; none of them trusts the client.
- */
+/** Bryan Bucks web reads and domain-backed mutations, scoped by guild. */
 export const bucksRouter = router({
   status: webProcedure.query(async ({ ctx }) => {
     const scope = await resolveBucksScope(ctx.user);
@@ -153,12 +145,17 @@ export const bucksRouter = router({
 
   dareList: webProcedure.input(DareListInput).query(async ({ ctx, input }) => {
     await assertBucksScope(ctx.user, input.guildId);
-    return await listVisibleDaresV2(
+    return await listVisibleDarePageV2(
       {
         serverId: input.guildId,
         viewerDiscordId: DiscordAccountIdSchema.parse(ctx.user.discordId),
         scope: input.scope,
         ...(input.search === undefined ? {} : { search: input.search }),
+        ...(input.states === undefined ? {} : { states: input.states }),
+        ...(input.role === undefined ? {} : { role: input.role }),
+        ...(input.sort === undefined ? {} : { sort: input.sort }),
+        ...(input.cursor === undefined ? {} : { cursor: input.cursor }),
+        ...(input.limit === undefined ? {} : { limit: input.limit }),
       },
       prisma,
     );
@@ -181,6 +178,9 @@ export const bucksRouter = router({
       }
       return dare;
     }),
+
+  ...bucksDareActionProcedures,
+  ...bucksNotificationProcedures,
 
   dareValidateDraft: webProcedure
     .input(DareDraftInput)
@@ -303,51 +303,6 @@ export const bucksRouter = router({
       entries: snapshot.entries,
     } as const;
   }),
-
-  notificationPreferences: webProcedure
-    .input(GuildInput)
-    .query(async ({ ctx, input }) => {
-      await assertBucksScope(ctx.user, input.guildId);
-      const discordId = DiscordAccountIdSchema.parse(ctx.user.discordId);
-      const preferences = await getBucksNotificationPreferences({
-        serverId: input.guildId,
-        discordId,
-      });
-      return {
-        ownBetSettlementDms: preferences.ownBetSettlementDms,
-        betsOnPlayerSettlementDms: preferences.betsOnPlayerSettlementDms,
-      };
-    }),
-
-  setNotificationPreferences: webMutationProcedure
-    .input(
-      GuildInput.extend({
-        ownBetSettlementDms: z.boolean().optional(),
-        betsOnPlayerSettlementDms: z.boolean().optional(),
-      }),
-    )
-    .mutation(async ({ ctx, input }) => {
-      await assertBucksScope(ctx.user, input.guildId);
-      const discordId = DiscordAccountIdSchema.parse(ctx.user.discordId);
-      const preferences = await updateBucksNotificationPreferences({
-        serverId: input.guildId,
-        discordId,
-        updates: {
-          ...(input.ownBetSettlementDms === undefined
-            ? {}
-            : { ownBetSettlementDms: input.ownBetSettlementDms }),
-          ...(input.betsOnPlayerSettlementDms === undefined
-            ? {}
-            : {
-                betsOnPlayerSettlementDms: input.betsOnPlayerSettlementDms,
-              }),
-        },
-      });
-      return {
-        ownBetSettlementDms: preferences.ownBetSettlementDms,
-        betsOnPlayerSettlementDms: preferences.betsOnPlayerSettlementDms,
-      };
-    }),
 
   placeOutcomeBet: webMutationProcedure
     .input(

--- a/packages/scout-for-lol/packages/data/src/model/dare-progress.ts
+++ b/packages/scout-for-lol/packages/data/src/model/dare-progress.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const DareProgressValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+export const DareProgressConditionSchema = z.strictObject({
+  key: z.string().min(1),
+  kind: z.string().min(1),
+  label: z.string().min(1),
+  targetKeys: z.array(z.string().min(1)),
+  gameSet: z.string().min(1).nullable(),
+  operator: z.string().min(1).nullable(),
+  current: DareProgressValueSchema,
+  target: DareProgressValueSchema,
+  remaining: z.number().nonnegative().nullable(),
+  matchedGames: z.number().int().nonnegative(),
+  eligibleGames: z.number().int().nonnegative(),
+  unknownGames: z.number().int().nonnegative(),
+  value: z.boolean().nullable(),
+});
+export type DareProgressCondition = z.infer<typeof DareProgressConditionSchema>;
+
+export const DareTargetProgressSchema = z.strictObject({
+  targetKey: z.string().min(1),
+  conditionKeys: z.array(z.string().min(1)),
+  matchedGames: z.number().int().nonnegative(),
+  eligibleGames: z.number().int().nonnegative(),
+  value: z.boolean().nullable(),
+});
+
+export const DareCoverageGapSchema = z.strictObject({
+  matchId: z.string().min(1),
+  gameEndAt: z.iso.datetime(),
+  sourceReferences: z.array(z.string().min(1)),
+  targetKeys: z.array(z.string().min(1)),
+  reason: z.string().min(1),
+});
+
+export const DareProgressChangeSchema = z.strictObject({
+  kind: z.enum(["advance", "regression", "coverage", "evidence"]),
+  matchId: z.string().min(1),
+  occurredAt: z.iso.datetime(),
+  summary: z.string().min(1),
+  conditionKeys: z.array(z.string().min(1)),
+});
+
+export const DareProgressSchema = z.strictObject({
+  value: z.boolean().nullable(),
+  final: z.boolean(),
+  finalityReason: z.string().min(1),
+  matchedGames: z.number().int().nonnegative(),
+  eligibleGames: z.number().int().nonnegative(),
+  evidenceGames: z.number().int().nonnegative(),
+  conditions: z.array(DareProgressConditionSchema),
+  targets: z.array(DareTargetProgressSchema),
+  coverageGaps: z.array(DareCoverageGapSchema),
+  latestMaterialChange: DareProgressChangeSchema.nullable(),
+  summary: z.string().min(1),
+});
+export type DareProgress = z.infer<typeof DareProgressSchema>;
+
+export const DarePollHealthSchema = z.strictObject({
+  status: z.enum([
+    "never",
+    "healthy",
+    "incomplete",
+    "failed",
+    "delayed",
+    "stale",
+  ]),
+  pollStartedAt: z.iso.datetime().nullable(),
+  pollCompletedAt: z.iso.datetime().nullable(),
+  evidenceWatermarkAt: z.iso.datetime().nullable(),
+  lastSuccessfulProcessingAt: z.iso.datetime().nullable(),
+  failureReason: z.string().nullable(),
+  incompleteReasons: z.array(z.string().min(1)),
+});
+export type DarePollHealth = z.infer<typeof DarePollHealthSchema>;

--- a/packages/scout-for-lol/packages/data/src/model/index.ts
+++ b/packages/scout-for-lol/packages/data/src/model/index.ts
@@ -5,6 +5,7 @@ export * from "./competition-format.ts";
 export * from "./discord.ts";
 export * from "./division.ts";
 export * from "./dare-contract-v2.ts";
+export * from "./dare-progress.ts";
 export * from "./dare-paraphrase-corpus.ts";
 export * from "./lake-columns.ts";
 export * from "./lane.ts";


### PR DESCRIPTION
Why
Bryan Bucks Dares currently hide most match-by-match progress and operational state, and their management and notification controls are split across surfaces.

What
- Add a version-independent progress and poll-health read model with compatibility for existing evaluator evidence.
- Add searchable, paginated, role-aware discovery plus Needs action and detailed evidence inspection.
- Add revision-bound web confirmation intents for funded Dare actions.
- Add durable lifecycle/progress notification events, per-recipient delivery state, recovery, and web/Discord preferences.
- Add rollout flags defaulted off and update Bryan Bucks reference documentation.

Verification
- Focused data, backend, and app typechecks, tests, and lint
- PostgreSQL Dare, intent, notification, and view integration suites
- Scout docs and wiki lint/build
- bunx lefthook run pre-commit
- Live beta and production checks were not run

Stack
Foundation, experience, and notification foundation for the evaluator-3 semantics PR above this one.