### PR TITLE
fix(homelab): expand Temporal PostgreSQL volume to 128Gi

### DIFF
--- a/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
+++ b/packages/homelab/src/cdk8s/src/resources/postgres/temporal-db.ts
@@ -95,19 +95,21 @@ export function createTemporalPostgreSQLDatabase(chart: Chart) {
         },
       },
       volume: {
-        // 32Gi for a ~2.5Gi database, because `zfs-ssd` provisions volumes with
+        // 128Gi for a ~2.5Gi database, because `zfs-ssd` provisions volumes with
         // ZFS `quotaType: quota`, which counts snapshots against the same quota
         // as live data. Velero retention (12 6hourly + 7 daily + 4 weekly +
         // 3 monthly) holds ~26 snapshots, and this WAL-heavy cluster diverges
         // ~500-700Mi of blocks per snapshot, so snapshots steady-state around
-        // 15Gi -- 6x the live dataset. At 16Gi that left 0B writable on
+        // 15Gi -- 6x the live dataset. The quota had again reduced the live
+        // filesystem to 3.9GiB and halted Temporal, so retain ample space for
+        // snapshot divergence and recovery WAL.
         // 2026-08-27: Postgres could not create postmaster.pid ("Disk quota
         // exceeded"), crash recovery looped, and the Temporal frontend never
         // bound :7233, crashlooping every Temporal worker and Scout beta.
         // quotaType is immutable per-volume and StorageClass parameters are
         // immutable, so sizing around snapshot overhead is the available fix
         // without recreating the volume on a refquota class.
-        size: "32Gi",
+        size: "128Gi",
         storageClass: "zfs-ssd",
       },
       users: {


### PR DESCRIPTION
Why:
Temporal PostgreSQL exhausted its effective ZFS dataset quota, causing Temporal workflow-start timeouts and a Scout beta Explore outage.

What:
Declare a 128Gi Temporal PostgreSQL volume, four times the prior 32Gi declaration. The live claim has already been expanded and PostgreSQL restarted to complete the urgent recovery.

Verification:
- bun run --cwd packages/homelab/src/cdk8s typecheck
- bun run --cwd packages/homelab/src/cdk8s build
- Live: verified PVC capacity, mounted filesystem free space, PostgreSQL query, Temporal recovery, Scout beta endpoint, and recovery of the two pending Explore turns.